### PR TITLE
Add env overloads for DeviceFind::FindIf, LowerBound, UpperBound

### DIFF
--- a/cub/cub/device/device_find.cuh
+++ b/cub/cub/device/device_find.cuh
@@ -15,6 +15,7 @@
 
 #include <cub/detail/binary_search_helpers.cuh>
 #include <cub/detail/choose_offset.cuh>
+#include <cub/detail/env_dispatch.cuh>
 #include <cub/device/device_for.cuh>
 #include <cub/device/dispatch/dispatch_find.cuh>
 #include <cub/thread/thread_operators.cuh>
@@ -333,6 +334,315 @@ struct DeviceFind
       detail::find::make_comp_wrapper<detail::find::upper_bound>(
         d_range, static_cast<RangeOffsetT>(range_num_items), comp),
       stream);
+  }
+  //! @rst
+  //! Finds the first element in the input sequence that satisfies the given predicate.
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! This is an environment-based API that allows customization of:
+  //!
+  //! - Stream: Query via ``cuda::get_stream``
+  //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
+  //!
+  //! - The search terminates at the first element where the predicate evaluates to true.
+  //! - The index of the found element is written to ``d_out``.
+  //! - If no element satisfies the predicate, ``num_items`` is written to ``d_out``.
+  //! - The range ``[d_out, d_out + 1)`` shall not overlap ``[d_in, d_in + num_items)`` in any way.
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates the finding of the first element that satisfies the predicate.
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_find_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin find-if-env-predicate
+  //!     :end-before: example-end find-if-env-predicate
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_find_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin find-if-env
+  //!     :end-before: example-end find-if-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input items @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Random-access output iterator type for writing the result index @iterator
+  //!
+  //! @tparam ScanOpT
+  //!   **[inferred]** Unary predicate functor type having member `bool operator()(const T &a)`
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** An integral type representing the number of input elements
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., ``cuda::std::execution::env<...>``)
+  //!
+  //! @param[in] d_in
+  //!   Random-access iterator to the input sequence of data items
+  //!
+  //! @param[out] d_out
+  //!   Random-access iterator to the output location for the index of the found element
+  //!
+  //! @param[in] scan_op
+  //!   Unary predicate functor for determining whether an element satisfies the search condition
+  //!
+  //! @param[in] num_items
+  //!   Total number of input items (i.e., the length of `d_in`)
+  //!
+  //! @param[in] env
+  //!   @rst
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  //!   @endrst
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename ScanOpT,
+            typename NumItemsT,
+            typename EnvT = ::cuda::std::execution::env<>>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
+  FindIf(InputIteratorT d_in, OutputIteratorT d_out, ScanOpT scan_op, NumItemsT num_items, EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceFind::FindIf");
+
+    using OffsetT = detail::choose_offset_t<NumItemsT>;
+
+    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
+      return detail::find::dispatch(storage, bytes, d_in, d_out, static_cast<OffsetT>(num_items), scan_op, stream);
+    });
+  }
+
+  //! @rst
+  //! For each ``value`` in ``[d_values, d_values + values_num_items)``, performs a binary search in the range
+  //! ``[d_range, d_range + range_num_items)``, using ``comp`` as the comparator to find the iterator to the element
+  //! of said range which **is not** ordered **before** ``value``.
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! This is an environment-based API that allows customization of:
+  //!
+  //! - Stream: Query via ``cuda::get_stream``
+  //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
+  //!
+  //! - The range ``[d_range, d_range + range_num_items)`` must be sorted consistently with ``comp``.
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates the lower bound search.
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_find_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin lower-bound-env
+  //!     :end-before: example-end lower-bound-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam RangeIteratorT
+  //!   is a model of [Random Access Iterator], whose value type forms a [Relation] with the value type of
+  //!   ``ValuesIteratorT`` using ``CompareOpT`` as the predicate.
+  //!
+  //! @tparam RangeNumItemsT
+  //!   is an integral type representing the number of elements in the range to be searched.
+  //!
+  //! @tparam ValuesIteratorT
+  //!   is a model of [Random Access Iterator], whose value type forms a [Relation] with the value type of
+  //!   ``RangeIteratorT`` using ``CompareOpT`` as the predicate.
+  //!
+  //! @tparam ValuesNumItemsT
+  //!   is a model of integral type representing the number of elements in the range of values to be searched for.
+  //!
+  //! @tparam OutputIteratorT
+  //!   is a model of [Random Access Iterator], whose value type is assignable from ``RangeIteratorT``'s difference
+  //!   type.
+  //!
+  //! @tparam CompareOpT
+  //!   is a model of [Strict Weak Ordering], which forms a [Relation] with the value types of ``RangeIteratorT``
+  //!   and ``ValuesIteratorT``.
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., ``cuda::std::execution::env<...>``)
+  //!
+  //! @param[in] d_range
+  //!   Iterator to the beginning of the ordered range to be searched.
+  //!
+  //! @param[in] range_num_items
+  //!   Number of elements in the ordered range to be searched.
+  //!
+  //! @param[in] d_values
+  //!   Iterator to the beginning of the range of values to be searched for.
+  //!
+  //! @param[in] values_num_items
+  //!   Number of elements in the range of values to be searched for.
+  //!
+  //! @param[out] d_output
+  //!   Iterator to the beginning of the output range.
+  //!
+  //! @param[in] comp
+  //!   Comparison function object which returns true if its first argument is ordered before the second in the
+  //!   [Strict Weak Ordering] of the range to be searched.
+  //!
+  //! @param[in] env
+  //!   @rst
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  //!   @endrst
+  //!
+  //! [Random Access Iterator]: https://en.cppreference.com/w/cpp/iterator/random_access_iterator
+  //! [Strict Weak Ordering]: https://en.cppreference.com/w/cpp/concepts/strict_weak_order
+  //! [Relation]: https://en.cppreference.com/w/cpp/concepts/relation
+  template <typename RangeIteratorT,
+            typename RangeNumItemsT,
+            typename ValuesIteratorT,
+            typename ValuesNumItemsT,
+            typename OutputIteratorT,
+            typename CompareOpT,
+            typename EnvT = ::cuda::std::execution::env<>>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t LowerBound(
+    RangeIteratorT d_range,
+    RangeNumItemsT range_num_items,
+    ValuesIteratorT d_values,
+    ValuesNumItemsT values_num_items,
+    OutputIteratorT d_output,
+    CompareOpT comp,
+    EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceFind::LowerBound");
+
+    using RangeOffsetT  = detail::choose_offset_t<RangeNumItemsT>;
+    using ValuesOffsetT = detail::choose_offset_t<ValuesNumItemsT>;
+
+    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
+      return DeviceFor::__for_each_n_no_nvtx(
+        storage,
+        bytes,
+        ::cuda::make_zip_iterator(d_values, d_output),
+        static_cast<ValuesOffsetT>(values_num_items),
+        detail::find::make_comp_wrapper<detail::find::lower_bound>(
+          d_range, static_cast<RangeOffsetT>(range_num_items), comp),
+        stream);
+    });
+  }
+
+  //! @rst
+  //! For each ``value`` in ``[d_values, d_values + values_num_items)``, performs a binary search in the range
+  //! ``[d_range, d_range + range_num_items)``,
+  //! using ``comp`` as the comparator to find the iterator to the element of said range which **is** ordered
+  //! **after** ``value``.
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! This is an environment-based API that allows customization of:
+  //!
+  //! - Stream: Query via ``cuda::get_stream``
+  //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
+  //!
+  //! - The range ``[d_range, d_range + range_num_items)`` must be sorted consistently with ``comp``.
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates the upper bound search.
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_find_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin upper-bound-env
+  //!     :end-before: example-end upper-bound-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam RangeIteratorT
+  //!   is a model of [Random Access Iterator], whose value type forms a [Relation] with the value type of
+  //!   ``ValuesIteratorT`` using ``CompareOpT`` as the predicate.
+  //!
+  //! @tparam RangeNumItemsT
+  //!   is an integral type representing the number of elements in the range to be searched.
+  //!
+  //! @tparam ValuesIteratorT
+  //!   is a model of [Random Access Iterator], whose value type forms a [Relation] with the value type of
+  //!   ``RangeIteratorT`` using ``CompareOpT`` as the predicate.
+  //!
+  //! @tparam ValuesNumItemsT
+  //!   is a model of integral type representing the number of elements in the range of values to be searched for.
+  //!
+  //! @tparam OutputIteratorT
+  //!   is a model of [Random Access Iterator], whose value type is assignable from ``RangeIteratorT``'s difference
+  //!   type.
+  //!
+  //! @tparam CompareOpT
+  //!   is a model of [Strict Weak Ordering], which forms a [Relation] with the value types of ``RangeIteratorT``
+  //!   and ``ValuesIteratorT``.
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., ``cuda::std::execution::env<...>``)
+  //!
+  //! @param[in] d_range
+  //!   Iterator to the beginning of the ordered range to be searched.
+  //!
+  //! @param[in] range_num_items
+  //!   Number of elements in the ordered range to be searched.
+  //!
+  //! @param[in] d_values
+  //!   Iterator to the beginning of the range of values to be searched for.
+  //!
+  //! @param[in] values_num_items
+  //!   Number of elements in the range of values to be searched for.
+  //!
+  //! @param[out] d_output
+  //!   Iterator to the beginning of the output range.
+  //!
+  //! @param[in] comp
+  //!   Comparison function object which returns true if its first argument is ordered before the second in the
+  //!   [Strict Weak Ordering] of the range to be searched.
+  //!
+  //! @param[in] env
+  //!   @rst
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  //!   @endrst
+  //!
+  //! [Random Access Iterator]: https://en.cppreference.com/w/cpp/iterator/random_access_iterator
+  //! [Strict Weak Ordering]: https://en.cppreference.com/w/cpp/concepts/strict_weak_order
+  //! [Relation]: https://en.cppreference.com/w/cpp/concepts/relation
+  template <typename RangeIteratorT,
+            typename RangeNumItemsT,
+            typename ValuesIteratorT,
+            typename ValuesNumItemsT,
+            typename OutputIteratorT,
+            typename CompareOpT,
+            typename EnvT = ::cuda::std::execution::env<>>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t UpperBound(
+    RangeIteratorT d_range,
+    RangeNumItemsT range_num_items,
+    ValuesIteratorT d_values,
+    ValuesNumItemsT values_num_items,
+    OutputIteratorT d_output,
+    CompareOpT comp,
+    EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceFind::UpperBound");
+
+    using RangeOffsetT  = detail::choose_offset_t<RangeNumItemsT>;
+    using ValuesOffsetT = detail::choose_offset_t<ValuesNumItemsT>;
+
+    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
+      return DeviceFor::__for_each_n_no_nvtx(
+        storage,
+        bytes,
+        ::cuda::make_zip_iterator(d_values, d_output),
+        static_cast<ValuesOffsetT>(values_num_items),
+        detail::find::make_comp_wrapper<detail::find::upper_bound>(
+          d_range, static_cast<RangeOffsetT>(range_num_items), comp),
+        stream);
+    });
   }
 };
 

--- a/cub/cub/device/device_for.cuh
+++ b/cub/cub/device/device_for.cuh
@@ -642,7 +642,7 @@ public:
       temp_storage_bytes = 1;
       return cudaSuccess;
     }
-    return ForEachNNoNVTX(first, num_items, op, stream);
+    return __for_each_n_no_nvtx(first, num_items, op, stream);
   }
   //! @endcond
 

--- a/cub/cub/device/device_for.cuh
+++ b/cub/cub/device/device_for.cuh
@@ -642,7 +642,7 @@ public:
       temp_storage_bytes = 1;
       return cudaSuccess;
     }
-    return __for_each_n_no_nvtx(first, num_items, op, stream);
+    return ForEachNNoNVTX(first, num_items, op, stream);
   }
   //! @endcond
 

--- a/cub/test/catch2_test_device_find_env.cu
+++ b/cub/test/catch2_test_device_find_env.cu
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Should precede any includes
+struct stream_registry_factory_t;
+#define CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY stream_registry_factory_t
+
+#include "insert_nested_NVTX_range_guard.h"
+
+#include <cub/device/device_find.cuh>
+
+#include <thrust/device_vector.h>
+
+#include <cuda/iterator>
+
+#include "catch2_test_env_launch_helper.h"
+
+DECLARE_LAUNCH_WRAPPER(cub::DeviceFind::FindIf, device_find_if);
+
+// %PARAM% TEST_LAUNCH lid 0:1:2
+
+#include <c2h/catch2_test_helper.h>
+
+namespace stdexec = cuda::std::execution;
+
+struct is_greater_than_t
+{
+  int threshold;
+  __host__ __device__ bool operator()(int value) const
+  {
+    return value > threshold;
+  }
+};
+
+#if TEST_LAUNCH == 0
+
+TEST_CASE("Device FindIf works with default environment", "[find][device]")
+{
+  constexpr int num_items = 8;
+  auto d_in               = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6, 7};
+  auto d_out              = c2h::device_vector<int>(1);
+  is_greater_than_t predicate{4};
+
+  auto error = cub::DeviceFind::FindIf(d_in.begin(), d_out.begin(), predicate, num_items);
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_out[0] == 5);
+}
+
+TEST_CASE("Device FindIf no match returns num_items with default environment", "[find][device]")
+{
+  constexpr int num_items = 5;
+  auto d_in               = c2h::device_vector<int>{0, 1, 2, 3, 4};
+  auto d_out              = c2h::device_vector<int>(1);
+  is_greater_than_t predicate{100};
+
+  auto error = cub::DeviceFind::FindIf(d_in.begin(), d_out.begin(), predicate, num_items);
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_out[0] == num_items);
+}
+
+TEST_CASE("Device LowerBound works with default environment", "[find][device]")
+{
+  auto d_range  = c2h::device_vector<int>{0, 2, 4, 6, 8};
+  auto d_values = c2h::device_vector<int>{1, 3, 5, 7};
+  auto d_output = c2h::device_vector<int>(4);
+
+  auto error = cub::DeviceFind::LowerBound(
+    d_range.begin(),
+    static_cast<int>(d_range.size()),
+    d_values.begin(),
+    static_cast<int>(d_values.size()),
+    d_output.begin(),
+    cuda::std::less{});
+  REQUIRE(error == cudaSuccess);
+
+  c2h::device_vector<int> expected = {1, 2, 3, 4};
+  REQUIRE(d_output == expected);
+}
+
+TEST_CASE("Device UpperBound works with default environment", "[find][device]")
+{
+  auto d_range  = c2h::device_vector<int>{0, 2, 4, 6, 8};
+  auto d_values = c2h::device_vector<int>{1, 3, 5, 7};
+  auto d_output = c2h::device_vector<int>(4);
+
+  auto error = cub::DeviceFind::UpperBound(
+    d_range.begin(),
+    static_cast<int>(d_range.size()),
+    d_values.begin(),
+    static_cast<int>(d_values.size()),
+    d_output.begin(),
+    cuda::std::less{});
+  REQUIRE(error == cudaSuccess);
+
+  c2h::device_vector<int> expected = {1, 2, 3, 4};
+  REQUIRE(d_output == expected);
+}
+
+#endif
+
+C2H_TEST("Device FindIf uses environment", "[find][device]")
+{
+  constexpr int num_items = 8;
+  auto d_in               = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6, 7};
+  auto d_out              = c2h::device_vector<int>(1);
+  is_greater_than_t predicate{4};
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceFind::FindIf(nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), predicate, num_items));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_find_if(d_in.begin(), d_out.begin(), predicate, num_items, env);
+
+  REQUIRE(d_out[0] == 5);
+}
+
+C2H_TEST("Device FindIf no match uses environment", "[find][device]")
+{
+  constexpr int num_items = 5;
+  auto d_in               = c2h::device_vector<int>{0, 1, 2, 3, 4};
+  auto d_out              = c2h::device_vector<int>(1);
+  is_greater_than_t predicate{100};
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceFind::FindIf(nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), predicate, num_items));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_find_if(d_in.begin(), d_out.begin(), predicate, num_items, env);
+
+  REQUIRE(d_out[0] == num_items);
+}

--- a/cub/test/catch2_test_device_find_env.cu
+++ b/cub/test/catch2_test_device_find_env.cu
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // Should precede any includes

--- a/cub/test/catch2_test_device_find_env.cu
+++ b/cub/test/catch2_test_device_find_env.cu
@@ -16,6 +16,8 @@ struct stream_registry_factory_t;
 #include "catch2_test_env_launch_helper.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceFind::FindIf, device_find_if);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceFind::LowerBound, device_lower_bound);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceFind::UpperBound, device_upper_bound);
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -117,21 +119,70 @@ C2H_TEST("Device FindIf uses environment", "[find][device]")
   REQUIRE(d_out[0] == 5);
 }
 
-C2H_TEST("Device FindIf no match uses environment", "[find][device]")
+C2H_TEST("Device LowerBound uses environment", "[find][device]")
 {
-  constexpr int num_items = 5;
-  auto d_in               = c2h::device_vector<int>{0, 1, 2, 3, 4};
-  auto d_out              = c2h::device_vector<int>(1);
-  is_greater_than_t predicate{100};
+  auto d_range  = c2h::device_vector<int>{0, 2, 4, 6, 8};
+  auto d_values = c2h::device_vector<int>{1, 3, 5, 7};
+  auto d_output = c2h::device_vector<int>(4);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
     cudaSuccess
-    == cub::DeviceFind::FindIf(nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), predicate, num_items));
+    == cub::DeviceFind::LowerBound(
+      nullptr,
+      expected_bytes_allocated,
+      d_range.begin(),
+      static_cast<int>(d_range.size()),
+      d_values.begin(),
+      static_cast<int>(d_values.size()),
+      d_output.begin(),
+      cuda::std::less{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
-  device_find_if(d_in.begin(), d_out.begin(), predicate, num_items, env);
+  device_lower_bound(
+    d_range.begin(),
+    static_cast<int>(d_range.size()),
+    d_values.begin(),
+    static_cast<int>(d_values.size()),
+    d_output.begin(),
+    cuda::std::less{},
+    env);
 
-  REQUIRE(d_out[0] == num_items);
+  c2h::device_vector<int> expected = {1, 2, 3, 4};
+  REQUIRE(d_output == expected);
+}
+
+C2H_TEST("Device UpperBound uses environment", "[find][device]")
+{
+  auto d_range  = c2h::device_vector<int>{0, 2, 4, 6, 8};
+  auto d_values = c2h::device_vector<int>{1, 3, 5, 7};
+  auto d_output = c2h::device_vector<int>(4);
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceFind::UpperBound(
+      nullptr,
+      expected_bytes_allocated,
+      d_range.begin(),
+      static_cast<int>(d_range.size()),
+      d_values.begin(),
+      static_cast<int>(d_values.size()),
+      d_output.begin(),
+      cuda::std::less{}));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_upper_bound(
+    d_range.begin(),
+    static_cast<int>(d_range.size()),
+    d_values.begin(),
+    static_cast<int>(d_values.size()),
+    d_output.begin(),
+    cuda::std::less{},
+    env);
+
+  c2h::device_vector<int> expected = {1, 2, 3, 4};
+  REQUIRE(d_output == expected);
 }

--- a/cub/test/catch2_test_device_find_env_api.cu
+++ b/cub/test/catch2_test_device_find_env_api.cu
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "insert_nested_NVTX_range_guard.h"

--- a/cub/test/catch2_test_device_find_env_api.cu
+++ b/cub/test/catch2_test_device_find_env_api.cu
@@ -50,23 +50,6 @@ C2H_TEST("cub::DeviceFind::FindIf accepts env with stream", "[find][env]")
   REQUIRE(d_out[0] == expected);
 }
 
-C2H_TEST("cub::DeviceFind::FindIf no match returns num_items", "[find][env]")
-{
-  constexpr int num_items         = 5;
-  thrust::device_vector<int> d_in = {0, 1, 2, 3, 4};
-  thrust::device_vector<int> d_out(1);
-  is_greater_than_t predicate{100};
-
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
-
-  auto error = cub::DeviceFind::FindIf(d_in.begin(), d_out.begin(), predicate, num_items, stream_ref);
-  stream.sync();
-
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(d_out[0] == num_items);
-}
-
 C2H_TEST("cub::DeviceFind::LowerBound accepts env with stream", "[find][env]")
 {
   // example-begin lower-bound-env

--- a/cub/test/catch2_test_device_find_env_api.cu
+++ b/cub/test/catch2_test_device_find_env_api.cu
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "insert_nested_NVTX_range_guard.h"
+
+#include <cub/device/device_find.cuh>
+
+#include <thrust/device_vector.h>
+
+#include <cuda/devices>
+#include <cuda/stream>
+
+#include <iostream>
+
+#include <c2h/catch2_test_helper.h>
+
+// example-begin find-if-env-predicate
+struct is_greater_than_t
+{
+  int threshold;
+  __host__ __device__ bool operator()(int value) const
+  {
+    return value > threshold;
+  }
+};
+// example-end find-if-env-predicate
+
+C2H_TEST("cub::DeviceFind::FindIf accepts env with stream", "[find][env]")
+{
+  // example-begin find-if-env
+  constexpr int num_items         = 8;
+  thrust::device_vector<int> d_in = {0, 1, 2, 3, 4, 5, 6, 7};
+  thrust::device_vector<int> d_out(1);
+  is_greater_than_t predicate{4};
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceFind::FindIf(d_in.begin(), d_out.begin(), predicate, num_items, stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceFind::FindIf failed with status: " << error << '\n';
+  }
+
+  int expected = 5;
+  // example-end find-if-env
+  stream.sync();
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_out[0] == expected);
+}
+
+C2H_TEST("cub::DeviceFind::FindIf no match returns num_items", "[find][env]")
+{
+  constexpr int num_items         = 5;
+  thrust::device_vector<int> d_in = {0, 1, 2, 3, 4};
+  thrust::device_vector<int> d_out(1);
+  is_greater_than_t predicate{100};
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceFind::FindIf(d_in.begin(), d_out.begin(), predicate, num_items, stream_ref);
+  stream.sync();
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_out[0] == num_items);
+}
+
+C2H_TEST("cub::DeviceFind::LowerBound accepts env with stream", "[find][env]")
+{
+  // example-begin lower-bound-env
+  thrust::device_vector<int> d_range  = {0, 2, 4, 6, 8};
+  thrust::device_vector<int> d_values = {1, 3, 5, 7};
+  thrust::device_vector<int> d_output(4);
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceFind::LowerBound(
+    d_range.begin(),
+    static_cast<int>(d_range.size()),
+    d_values.begin(),
+    static_cast<int>(d_values.size()),
+    d_output.begin(),
+    cuda::std::less{},
+    stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceFind::LowerBound failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected = {1, 2, 3, 4};
+  // example-end lower-bound-env
+  stream.sync();
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_output == expected);
+}
+
+C2H_TEST("cub::DeviceFind::UpperBound accepts env with stream", "[find][env]")
+{
+  // example-begin upper-bound-env
+  thrust::device_vector<int> d_range  = {0, 2, 4, 6, 8};
+  thrust::device_vector<int> d_values = {1, 3, 5, 7};
+  thrust::device_vector<int> d_output(4);
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceFind::UpperBound(
+    d_range.begin(),
+    static_cast<int>(d_range.size()),
+    d_values.begin(),
+    static_cast<int>(d_values.size()),
+    d_output.begin(),
+    cuda::std::less{},
+    stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceFind::UpperBound failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected = {1, 2, 3, 4};
+  // example-end upper-bound-env
+  stream.sync();
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_output == expected);
+}


### PR DESCRIPTION
closes #8431

`cub::Find*` algorithms were added after I opened the EPIC for env algorithms so they slipped the list. This adds their env counterparts