### PR TITLE
Add env overload for DeviceSelect::Unique with custom `EquialityOpT`

### DIFF
--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -1553,7 +1553,8 @@ public:
     typename NumSelectedIteratorT,
     typename NumItemsT,
     typename EnvT                 = ::cuda::std::execution::env<>,
-    ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<InputIteratorT, void*>,
+    ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<InputIteratorT, void*>
+                               && !::cuda::std::indirect_binary_predicate<EnvT, InputIteratorT, InputIteratorT>,
                              int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
   Unique(InputIteratorT d_in,
@@ -1659,7 +1660,8 @@ public:
     typename NumItemsT,
     typename EqualityOpT,
     typename EnvT                 = ::cuda::std::execution::env<>,
-    ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<InputIteratorT, void*>,
+    ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<InputIteratorT, void*>
+                               && ::cuda::std::indirect_binary_predicate<EqualityOpT, InputIteratorT, InputIteratorT>,
                              int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Unique(
     InputIteratorT d_in,

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -1661,13 +1661,13 @@ public:
     typename EnvT                 = ::cuda::std::execution::env<>,
     ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<InputIteratorT, void*>,
                              int> = 0>
-  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
-  Unique(InputIteratorT d_in,
-         OutputIteratorT d_out,
-         NumSelectedIteratorT d_num_selected_out,
-         NumItemsT num_items,
-         EqualityOpT equality_op,
-         EnvT env = {})
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Unique(
+    InputIteratorT d_in,
+    OutputIteratorT d_out,
+    NumSelectedIteratorT d_num_selected_out,
+    NumItemsT num_items,
+    EqualityOpT equality_op,
+    EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSelect::Unique");
 

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -1583,6 +1583,113 @@ public:
   }
 
   //! @rst
+  //! Given an input sequence ``d_in`` having runs of consecutive equal-valued keys,
+  //! only the first key from each run is selectively copied to ``d_out``.
+  //! The total number of items selected is written to ``d_num_selected_out``.
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! This is an environment-based API that allows customization of:
+  //!
+  //! - Stream: Query via ``cuda::get_stream``
+  //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
+  //!
+  //! - The user-provided equality operator, ``equality_op``, is used to determine whether keys are equivalent.
+  //! - Copies of the selected items are compacted into ``d_out`` and maintain their original relative ordering.
+  //! - | The range ``[d_out, d_out + *d_num_selected_out)`` shall not overlap
+  //!   | ``[d_in, d_in + num_items)`` nor ``d_num_selected_out`` in any way.
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates the compaction of items selected from an ``int`` device vector
+  //! using a custom equality operator:
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_select_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin select-unique-eqop-env
+  //!     :end-before: example-end select-unique-eqop-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input items @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Random-access output iterator type for writing selected items @iterator
+  //!
+  //! @tparam NumSelectedIteratorT
+  //!   **[inferred]** Output iterator type for recording the number of items selected @iterator
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
+  //! @tparam EqualityOpT
+  //!   **[inferred]** Type of equality_op
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., ``cuda::std::execution::env<...>``)
+  //!
+  //! @param[in] d_in
+  //!   Pointer to the input sequence of data items
+  //!
+  //! @param[out] d_out
+  //!   Pointer to the output sequence of selected data items
+  //!
+  //! @param[out] d_num_selected_out
+  //!   Pointer to the output total number of items selected
+  //!   (i.e., length of `d_out`)
+  //!
+  //! @param[in] num_items
+  //!   Total number of input items (i.e., length of `d_in`)
+  //!
+  //! @param[in] equality_op
+  //!   Binary equality operator
+  //!
+  //! @param[in] env
+  //!   @rst
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  //!   @endrst
+  template <
+    typename InputIteratorT,
+    typename OutputIteratorT,
+    typename NumSelectedIteratorT,
+    typename NumItemsT,
+    typename EqualityOpT,
+    typename EnvT                 = ::cuda::std::execution::env<>,
+    ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<InputIteratorT, void*>,
+                             int> = 0>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
+  Unique(InputIteratorT d_in,
+         OutputIteratorT d_out,
+         NumSelectedIteratorT d_num_selected_out,
+         NumItemsT num_items,
+         EqualityOpT equality_op,
+         EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSelect::Unique");
+
+    using offset_t = ::cuda::std::int64_t;
+
+    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
+      using tuning_t = decltype(tuning);
+      return select_impl<tuning_t, SelectImpl::Select>(
+        storage,
+        bytes,
+        d_in,
+        static_cast<NullType*>(nullptr),
+        d_out,
+        d_num_selected_out,
+        static_cast<offset_t>(num_items),
+        NullType{},
+        equality_op,
+        stream);
+    });
+  }
+
+  //! @rst
   //! Given an input sequence ``d_keys_in`` and ``d_values_in`` with runs of key-value pairs with consecutive
   //! equal-valued keys, only the first key and its value from each run is selectively copied
   //! to ``d_keys_out`` and ``d_values_out``.

--- a/cub/test/catch2_test_device_select_common.cuh
+++ b/cub/test/catch2_test_device_select_common.cuh
@@ -44,6 +44,15 @@ struct multiply_n
   }
 };
 
+template <typename T>
+struct eq_mod3_t
+{
+  __host__ __device__ bool operator()(const T& a, const T& b) const
+  {
+    return (a % 3) == (b % 3);
+  }
+};
+
 template <typename T, typename TargetT>
 struct modx_and_add_divy
 {

--- a/cub/test/catch2_test_device_select_env.cu
+++ b/cub/test/catch2_test_device_select_env.cu
@@ -201,13 +201,10 @@ TEST_CASE("Device select unique with custom equality_op works with default envir
   auto d_out            = c2h::device_vector<value_t>(num_items);
   auto d_num_selected   = c2h::device_vector<int>(1);
 
-  auto eq_mod3 = [] __host__ __device__(value_t a, value_t b) {
-    return (a % 3) == (b % 3);
-  };
+  eq_mod3_t<value_t> eq_mod3{};
 
   REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::Unique(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, eq_mod3));
+    cudaSuccess == cub::DeviceSelect::Unique(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, eq_mod3));
 
   c2h::device_vector<value_t> expected_output{0, 1, 2};
   c2h::device_vector<int> expected_num_selected{3};
@@ -497,9 +494,7 @@ C2H_TEST("Device select unique with custom equality_op uses environment", "[sele
   auto d_out            = c2h::device_vector<value_t>(num_items);
   auto d_num_selected   = c2h::device_vector<int>(1);
 
-  auto eq_mod3 = [] __host__ __device__(value_t a, value_t b) {
-    return (a % 3) == (b % 3);
-  };
+  eq_mod3_t<value_t> eq_mod3{};
 
   size_t expected_bytes_allocated{};
   REQUIRE(

--- a/cub/test/catch2_test_device_select_env.cu
+++ b/cub/test/catch2_test_device_select_env.cu
@@ -191,6 +191,32 @@ TEST_CASE("Device select unique works with default environment", "[select][devic
   REQUIRE(d_out == expected_output);
 }
 
+TEST_CASE("Device select unique with custom equality_op works with default environment", "[select][device]")
+{
+  using value_t     = int;
+  using num_items_t = int;
+
+  num_items_t num_items = 8;
+  auto d_in             = c2h::device_vector<value_t>{0, 3, 6, 1, 4, 7, 2, 5};
+  auto d_out            = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected   = c2h::device_vector<int>(1);
+
+  auto eq_mod3 = [] __host__ __device__(value_t a, value_t b) {
+    return (a % 3) == (b % 3);
+  };
+
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSelect::Unique(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, eq_mod3));
+
+  c2h::device_vector<value_t> expected_output{0, 1, 2};
+  c2h::device_vector<int> expected_num_selected{3};
+
+  REQUIRE(d_num_selected == expected_num_selected);
+  d_out.resize(d_num_selected[0]);
+  REQUIRE(d_out == expected_output);
+}
+
 TEST_CASE("Device select unique_by_key works with default environment", "[select][device]")
 {
   using value_t     = int;
@@ -455,6 +481,38 @@ C2H_TEST("Device select unique uses environment", "[select][device]")
 
   c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 5};
   c2h::device_vector<int> expected_num_selected{5};
+
+  REQUIRE(d_num_selected == expected_num_selected);
+  d_out.resize(d_num_selected[0]);
+  REQUIRE(d_out == expected_output);
+}
+
+C2H_TEST("Device select unique with custom equality_op uses environment", "[select][device]")
+{
+  using value_t     = int;
+  using num_items_t = int;
+
+  num_items_t num_items = 8;
+  auto d_in             = c2h::device_vector<value_t>{0, 3, 6, 1, 4, 7, 2, 5};
+  auto d_out            = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected   = c2h::device_vector<int>(1);
+
+  auto eq_mod3 = [] __host__ __device__(value_t a, value_t b) {
+    return (a % 3) == (b % 3);
+  };
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSelect::Unique(
+      nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, eq_mod3));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_select_unique(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, eq_mod3, env);
+
+  c2h::device_vector<value_t> expected_output{0, 1, 2};
+  c2h::device_vector<int> expected_num_selected{3};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_out.resize(d_num_selected[0]);

--- a/cub/test/catch2_test_device_select_env_api.cu
+++ b/cub/test/catch2_test_device_select_env_api.cu
@@ -216,15 +216,13 @@ C2H_TEST("cub::DeviceSelect::Unique with custom equality_op accepts env with str
   auto output       = thrust::device_vector<int>(8);
   auto num_selected = thrust::device_vector<int>(1);
 
-  auto eq_mod3 = [] __host__ __device__(int a, int b) {
-    return (a % 3) == (b % 3);
-  };
+  eq_mod3_t<int> eq_mod3{};
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
 
-  auto error = cub::DeviceSelect::Unique(
-    input.begin(), output.begin(), num_selected.begin(), input.size(), eq_mod3, stream_ref);
+  auto error =
+    cub::DeviceSelect::Unique(input.begin(), output.begin(), num_selected.begin(), input.size(), eq_mod3, stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceSelect::Unique with custom equality_op failed with status: " << error << '\n';

--- a/cub/test/catch2_test_device_select_env_api.cu
+++ b/cub/test/catch2_test_device_select_env_api.cu
@@ -208,6 +208,41 @@ C2H_TEST("cub::DeviceSelect::Unique accepts env with stream", "[select][env]")
   REQUIRE(num_selected == expected_num_selected);
 }
 
+C2H_TEST("cub::DeviceSelect::Unique with custom equality_op accepts env with stream", "[select][env]")
+{
+  // example-begin select-unique-eqop-env
+  // Unique by modulo 3 — consecutive elements are "equal" if they have the same remainder mod 3
+  auto input        = thrust::device_vector<int>{0, 3, 6, 1, 4, 7, 2, 5};
+  auto output       = thrust::device_vector<int>(8);
+  auto num_selected = thrust::device_vector<int>(1);
+
+  auto eq_mod3 = [] __host__ __device__(int a, int b) {
+    return (a % 3) == (b % 3);
+  };
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceSelect::Unique(
+    input.begin(), output.begin(), num_selected.begin(), input.size(), eq_mod3, stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceSelect::Unique with custom equality_op failed with status: " << error << '\n';
+  }
+
+  // 0,3,6 all == mod 3 (consecutive), keep first (0); 1,4,7 all == mod 3 (consecutive), keep first (1);
+  // 2,5 == mod 3 (consecutive), keep first (2)
+  thrust::device_vector<int> expected_output{0, 1, 2};
+  thrust::device_vector<int> expected_num_selected{3};
+  // example-end select-unique-eqop-env
+  stream.sync();
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(num_selected == expected_num_selected);
+  output.resize(num_selected[0]);
+  REQUIRE(output == expected_output);
+}
+
 C2H_TEST("cub::DeviceSelect::UniqueByKey accepts env with stream", "[select][env]")
 {
   // example-begin select-uniquebykey-env

--- a/cub/test/catch2_test_device_select_env_api.cu
+++ b/cub/test/catch2_test_device_select_env_api.cu
@@ -211,7 +211,7 @@ C2H_TEST("cub::DeviceSelect::Unique accepts env with stream", "[select][env]")
 C2H_TEST("cub::DeviceSelect::Unique with custom equality_op accepts env with stream", "[select][env]")
 {
   // example-begin select-unique-eqop-env
-  // Unique by modulo 3 — consecutive elements are "equal" if they have the same remainder mod 3
+  // Unique modulo 3 — consecutive elements are "equal" if they have the same remainder mod 3
   auto input        = thrust::device_vector<int>{0, 3, 6, 1, 4, 7, 2, 5};
   auto output       = thrust::device_vector<int>(8);
   auto num_selected = thrust::device_vector<int>(1);


### PR DESCRIPTION
slipped while #5335 

Adds `DeviceSelect::Unique` that accepts op. The previous `Unique` that was added didn't accept any operators