### PR TITLE
Swap the `load_modifier` and `store_algorithm` in `sub_warp_merge_sort_policy`

### DIFF
--- a/cub/benchmarks/bench/segmented_sort/keys.cu
+++ b/cub/benchmarks/bench/segmented_sort/keys.cu
@@ -56,20 +56,20 @@ struct device_seg_sort_policy_selector
         tune_sw_threads,
         TUNE_S_ITEMS,
         (TUNE_S_TRANSPOSE == 0) ? cub::WarpLoadAlgorithm::WARP_LOAD_DIRECT : cub::WarpLoadAlgorithm::WARP_LOAD_TRANSPOSE,
-        cub::WARP_STORE_DIRECT,
         (TUNE_S_LOAD == 0)   ? cub::LOAD_DEFAULT
         : (TUNE_S_LOAD == 1) ? cub::LOAD_LDG
                              : cub::LOAD_CA,
+        cub::WARP_STORE_DIRECT,
       },
       sub_warp_merge_sort_policy{
         TUNE_THREADS,
         tune_mw_threads,
         TUNE_M_ITEMS,
         (TUNE_M_TRANSPOSE == 0) ? cub::WarpLoadAlgorithm::WARP_LOAD_DIRECT : cub::WarpLoadAlgorithm::WARP_LOAD_TRANSPOSE,
-        cub::WARP_STORE_DIRECT,
         (TUNE_M_LOAD == 0)   ? cub::LOAD_DEFAULT
         : (TUNE_M_LOAD == 1) ? cub::LOAD_LDG
                              : cub::LOAD_CA,
+        cub::WARP_STORE_DIRECT,
       },
       TUNE_PARTITIONING_THRESHOLD,
     };

--- a/cub/cub/device/dispatch/dispatch_segmented_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_segmented_sort.cuh
@@ -321,15 +321,15 @@ struct policy_selector_from_hub
         sp::WARP_THREADS,
         sp::ITEMS_PER_THREAD,
         sp::LOAD_ALGORITHM,
-        sp::STORE_ALGORITHM,
-        sp::LOAD_MODIFIER},
+        sp::LOAD_MODIFIER,
+        sp::STORE_ALGORITHM},
       sub_warp_merge_sort_policy{
         mp::BLOCK_THREADS,
         mp::WARP_THREADS,
         mp::ITEMS_PER_THREAD,
         mp::LOAD_ALGORITHM,
-        mp::STORE_ALGORITHM,
-        mp::LOAD_MODIFIER},
+        mp::LOAD_MODIFIER,
+        mp::STORE_ALGORITHM},
       ap::PARTITIONING_THRESHOLD};
   }
 };

--- a/cub/cub/device/dispatch/tuning/tuning_segmented_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_segmented_sort.cuh
@@ -74,8 +74,8 @@ struct sub_warp_merge_sort_policy
   int warp_threads;
   int items_per_thread;
   WarpLoadAlgorithm load_algorithm;
-  WarpStoreAlgorithm store_algorithm;
   CacheLoadModifier load_modifier;
+  WarpStoreAlgorithm store_algorithm;
 
   [[nodiscard]] _CCCL_API constexpr int segments_per_block() const
   {
@@ -92,7 +92,7 @@ struct sub_warp_merge_sort_policy
   {
     return lhs.block_threads == rhs.block_threads && lhs.warp_threads == rhs.warp_threads
         && lhs.items_per_thread == rhs.items_per_thread && lhs.load_algorithm == rhs.load_algorithm
-        && lhs.store_algorithm == rhs.store_algorithm && lhs.load_modifier == rhs.load_modifier;
+        && lhs.load_modifier == rhs.load_modifier && lhs.store_algorithm == rhs.store_algorithm;
   }
 
   [[nodiscard]] _CCCL_API constexpr friend bool
@@ -107,7 +107,7 @@ struct sub_warp_merge_sort_policy
     return os
         << "sub_warp_merge_sort_policy { .block_threads = " << p.block_threads << ", .warp_threads = " << p.warp_threads
         << ", .items_per_thread = " << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm
-        << ", .store_algorithm = " << p.store_algorithm << ", .load_modifier = " << p.load_modifier << " }";
+        << ", .load_modifier = " << p.load_modifier << ", .store_algorithm = " << p.store_algorithm << " }";
   }
 #endif // !_CCCL_COMPILER(NVRTC)
 };
@@ -194,8 +194,8 @@ struct policy_selector
         __make_scaled_segmented_radix_sort_policy(
           256, 23, BLOCK_LOAD_TRANSPOSE, LOAD_DEFAULT, RADIX_RANK_MEMOIZE, BLOCK_SCAN_WARP_SCANS, radix_bits),
         sub_warp_merge_sort_policy{
-          256, large_items ? 8 : 2, small_itp, WARP_LOAD_TRANSPOSE, WARP_STORE_DIRECT, LOAD_LDG},
-        sub_warp_merge_sort_policy{256, 16, medium_itp, WARP_LOAD_TRANSPOSE, WARP_STORE_DIRECT, LOAD_LDG},
+          256, large_items ? 8 : 2, small_itp, WARP_LOAD_TRANSPOSE, LOAD_LDG, WARP_STORE_DIRECT},
+        sub_warp_merge_sort_policy{256, 16, medium_itp, WARP_LOAD_TRANSPOSE, LOAD_LDG, WARP_STORE_DIRECT},
         500};
     }
 
@@ -208,8 +208,8 @@ struct policy_selector
         __make_scaled_segmented_radix_sort_policy(
           256, 23, BLOCK_LOAD_TRANSPOSE, LOAD_DEFAULT, RADIX_RANK_MEMOIZE, BLOCK_SCAN_WARP_SCANS, radix_bits),
         sub_warp_merge_sort_policy{
-          256, keys_only ? 4 : 2, small_itp, WARP_LOAD_TRANSPOSE, WARP_STORE_DIRECT, LOAD_DEFAULT},
-        sub_warp_merge_sort_policy{256, 32, medium_itp, WARP_LOAD_TRANSPOSE, WARP_STORE_DIRECT, LOAD_DEFAULT},
+          256, keys_only ? 4 : 2, small_itp, WARP_LOAD_TRANSPOSE, LOAD_DEFAULT, WARP_STORE_DIRECT},
+        sub_warp_merge_sort_policy{256, 32, medium_itp, WARP_LOAD_TRANSPOSE, LOAD_DEFAULT, WARP_STORE_DIRECT},
         500};
     }
 
@@ -221,8 +221,8 @@ struct policy_selector
       return segmented_sort_policy{
         __make_scaled_segmented_radix_sort_policy(
           256, 19, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, RADIX_RANK_MEMOIZE, BLOCK_SCAN_WARP_SCANS, radix_bits),
-        sub_warp_merge_sort_policy{256, keys_only ? 4 : 8, small_itp, WARP_LOAD_DIRECT, WARP_STORE_DIRECT, LOAD_DEFAULT},
-        sub_warp_merge_sort_policy{256, 32, medium_itp, WARP_LOAD_DIRECT, WARP_STORE_DIRECT, LOAD_DEFAULT},
+        sub_warp_merge_sort_policy{256, keys_only ? 4 : 8, small_itp, WARP_LOAD_DIRECT, LOAD_DEFAULT, WARP_STORE_DIRECT},
+        sub_warp_merge_sort_policy{256, 32, medium_itp, WARP_LOAD_DIRECT, LOAD_DEFAULT, WARP_STORE_DIRECT},
         500};
     }
 
@@ -233,8 +233,8 @@ struct policy_selector
       return segmented_sort_policy{
         __make_scaled_segmented_radix_sort_policy(
           256, 16, BLOCK_LOAD_TRANSPOSE, LOAD_DEFAULT, RADIX_RANK_MEMOIZE, BLOCK_SCAN_RAKING_MEMOIZE, radix_bits),
-        sub_warp_merge_sort_policy{256, 4, small_medium_itp, WARP_LOAD_DIRECT, WARP_STORE_DIRECT, LOAD_DEFAULT},
-        sub_warp_merge_sort_policy{256, 32, small_medium_itp, WARP_LOAD_DIRECT, WARP_STORE_DIRECT, LOAD_DEFAULT},
+        sub_warp_merge_sort_policy{256, 4, small_medium_itp, WARP_LOAD_DIRECT, LOAD_DEFAULT, WARP_STORE_DIRECT},
+        sub_warp_merge_sort_policy{256, 32, small_medium_itp, WARP_LOAD_DIRECT, LOAD_DEFAULT, WARP_STORE_DIRECT},
         500};
     }
 
@@ -245,8 +245,8 @@ struct policy_selector
       return segmented_sort_policy{
         __make_scaled_segmented_radix_sort_policy(
           256, 19, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, RADIX_RANK_MEMOIZE, BLOCK_SCAN_WARP_SCANS, radix_bits),
-        sub_warp_merge_sort_policy{256, 4, small_medium_itp, WARP_LOAD_DIRECT, WARP_STORE_DIRECT, LOAD_DEFAULT},
-        sub_warp_merge_sort_policy{256, 32, small_medium_itp, WARP_LOAD_DIRECT, WARP_STORE_DIRECT, LOAD_DEFAULT},
+        sub_warp_merge_sort_policy{256, 4, small_medium_itp, WARP_LOAD_DIRECT, LOAD_DEFAULT, WARP_STORE_DIRECT},
+        sub_warp_merge_sort_policy{256, 32, small_medium_itp, WARP_LOAD_DIRECT, LOAD_DEFAULT, WARP_STORE_DIRECT},
         500};
     }
 
@@ -257,8 +257,8 @@ struct policy_selector
       return segmented_sort_policy{
         __make_scaled_segmented_radix_sort_policy(
           256, 19, BLOCK_LOAD_TRANSPOSE, LOAD_DEFAULT, RADIX_RANK_MATCH, BLOCK_SCAN_WARP_SCANS, radix_bits),
-        sub_warp_merge_sort_policy{256, 4, small_medium_itp, WARP_LOAD_DIRECT, WARP_STORE_DIRECT, LOAD_DEFAULT},
-        sub_warp_merge_sort_policy{256, 32, small_medium_itp, WARP_LOAD_DIRECT, WARP_STORE_DIRECT, LOAD_DEFAULT},
+        sub_warp_merge_sort_policy{256, 4, small_medium_itp, WARP_LOAD_DIRECT, LOAD_DEFAULT, WARP_STORE_DIRECT},
+        sub_warp_merge_sort_policy{256, 32, small_medium_itp, WARP_LOAD_DIRECT, LOAD_DEFAULT, WARP_STORE_DIRECT},
         500};
     }
 
@@ -268,8 +268,8 @@ struct policy_selector
     return segmented_sort_policy{
       __make_scaled_segmented_radix_sort_policy(
         256, 16, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, RADIX_RANK_MEMOIZE, BLOCK_SCAN_RAKING_MEMOIZE, radix_bits),
-      sub_warp_merge_sort_policy{256, 4, small_medium_itp, WARP_LOAD_DIRECT, WARP_STORE_DIRECT, LOAD_DEFAULT},
-      sub_warp_merge_sort_policy{256, 32, small_medium_itp, WARP_LOAD_DIRECT, WARP_STORE_DIRECT, LOAD_DEFAULT},
+      sub_warp_merge_sort_policy{256, 4, small_medium_itp, WARP_LOAD_DIRECT, LOAD_DEFAULT, WARP_STORE_DIRECT},
+      sub_warp_merge_sort_policy{256, 32, small_medium_itp, WARP_LOAD_DIRECT, LOAD_DEFAULT, WARP_STORE_DIRECT},
       300};
   }
 };


### PR DESCRIPTION
Makes the policy more in line with others

- [x] No SASS changes for `cub.bench.segmented_sort.keys.base` on SM`75;80;86`