### PR TITLE
Rename `agent_warp_reduce_policy` to `warp_reduce_policy`

### DIFF
--- a/cub/cub/device/dispatch/kernels/kernel_segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_segmented_reduce.cuh
@@ -138,7 +138,7 @@ __launch_bounds__(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).large_red
   using AgentReduceT = reduce::AgentReduce<large_agent_policy_t, InputIteratorT, OffsetT, ReductionOpT, AccumT>;
 
   // Medium segment agent (one warp per segment)
-  static constexpr agent_warp_reduce_policy med_pol = full_policy.medium_reduce;
+  static constexpr warp_reduce_policy med_pol = full_policy.medium_reduce;
   using medium_agent_policy_t =
     AgentWarpReducePolicy<med_pol.block_threads,
                           med_pol.warp_threads,
@@ -150,7 +150,7 @@ __launch_bounds__(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).large_red
     reduce::AgentWarpReduce<medium_agent_policy_t, InputIteratorT, OffsetT, ReductionOpT, AccumT>;
 
   // Small segment agent (one thread per segment)
-  static constexpr agent_warp_reduce_policy small_pol = full_policy.small_reduce;
+  static constexpr warp_reduce_policy small_pol = full_policy.small_reduce;
   using small_agent_policy_t =
     AgentWarpReducePolicy<small_pol.block_threads,
                           small_pol.warp_threads,

--- a/cub/cub/device/dispatch/tuning/tuning_segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_segmented_reduce.cuh
@@ -23,7 +23,7 @@ CUB_NAMESPACE_BEGIN
 namespace detail::segmented_reduce
 {
 // for small/medium segments
-struct agent_warp_reduce_policy
+struct warp_reduce_policy
 {
   int block_threads;
   int warp_threads;
@@ -41,26 +41,24 @@ struct agent_warp_reduce_policy
     return block_threads / warp_threads;
   }
 
-  [[nodiscard]] _CCCL_API constexpr friend bool
-  operator==(const agent_warp_reduce_policy& lhs, const agent_warp_reduce_policy& rhs)
+  [[nodiscard]] _CCCL_API constexpr friend bool operator==(const warp_reduce_policy& lhs, const warp_reduce_policy& rhs)
   {
     return lhs.block_threads == rhs.block_threads && lhs.warp_threads == rhs.warp_threads
         && lhs.items_per_thread == rhs.items_per_thread && lhs.vector_load_length == rhs.vector_load_length
         && lhs.load_modifier == rhs.load_modifier;
   }
 
-  [[nodiscard]] _CCCL_API constexpr friend bool
-  operator!=(const agent_warp_reduce_policy& lhs, const agent_warp_reduce_policy& rhs)
+  [[nodiscard]] _CCCL_API constexpr friend bool operator!=(const warp_reduce_policy& lhs, const warp_reduce_policy& rhs)
   {
     return !(lhs == rhs);
   }
 
 #if !_CCCL_COMPILER(NVRTC)
-  friend ::std::ostream& operator<<(::std::ostream& os, const agent_warp_reduce_policy& p)
+  friend ::std::ostream& operator<<(::std::ostream& os, const warp_reduce_policy& p)
   {
-    return os << "agent_warp_reduce_policy { .block_threads = " << p.block_threads
-              << ", .warp_threads = " << p.warp_threads << ", .items_per_thread = " << p.items_per_thread
-              << ", .vector_load_length = " << p.vector_load_length << ", .load_modifier = " << p.load_modifier << " }";
+    return os << "warp_reduce_policy { .block_threads = " << p.block_threads << ", .warp_threads = " << p.warp_threads
+              << ", .items_per_thread = " << p.items_per_thread << ", .vector_load_length = " << p.vector_load_length
+              << ", .load_modifier = " << p.load_modifier << " }";
   }
 #endif // !_CCCL_COMPILER(NVRTC)
 };
@@ -68,8 +66,8 @@ struct agent_warp_reduce_policy
 struct segmented_reduce_policy
 {
   reduce::agent_reduce_policy large_reduce;
-  agent_warp_reduce_policy small_reduce;
-  agent_warp_reduce_policy medium_reduce;
+  warp_reduce_policy small_reduce;
+  warp_reduce_policy medium_reduce;
 
   _CCCL_API constexpr friend bool operator==(const segmented_reduce_policy& lhs, const segmented_reduce_policy& rhs)
   {
@@ -112,9 +110,9 @@ struct policy_selector
 
     return segmented_reduce_policy{
       rp,
-      agent_warp_reduce_policy{
+      warp_reduce_policy{
         rp.block_threads, small_threads_per_warp, rp.items_per_thread, rp.vector_load_length, rp.load_modifier},
-      agent_warp_reduce_policy{
+      warp_reduce_policy{
         rp.block_threads, medium_threads_per_warp, rp.items_per_thread, rp.vector_load_length, rp.load_modifier}};
   }
 };


### PR DESCRIPTION
Makes the policy more in line with others. We shouldn't have the term "agent" in any of the new policies.