### PR TITLE
Disable failing deduction test case

### DIFF
--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp
@@ -145,8 +145,8 @@ __host__ __device__ void test_primary_template()
 #if !TEST_CUDA_COMPILER(NVCC, >, 13, 2) // nvbug6075893: NVCC fails to properly deduce prvalue input
   { // Testing (8)
     using Tup = cuda::std::tuple<void*, unsigned, char>;
-    cuda::std::tuple t1(Tup{nullptr, 42, 'a'});
-    static_assert(cuda::std::same_as<decltype(t1), Tup>);
+    cuda::std::tuple t1(Tup(nullptr, 42, 'a'));
+    static_assert(cuda::std::is_same_v<decltype(t1), Tup>);
     unused(t1);
   }
 #endif // !TEST_CUDA_COMPILER(NVCC, >, 13, 2)

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp
@@ -142,12 +142,14 @@ __host__ __device__ void test_primary_template()
     static_assert(cuda::std::is_same_v<decltype(t1), Tup>);
     unused(t1);
   }
+#if !TEST_CUDA_COMPILER(NVCC, >, 13, 2) // nvbug6075893: NVCC fails to properly deduce prvalue input
   { // Testing (8)
     using Tup = cuda::std::tuple<void*, unsigned, char>;
-    cuda::std::tuple t1(Tup(nullptr, 42, 'a'));
-    static_assert(cuda::std::is_same_v<decltype(t1), Tup>);
+    cuda::std::tuple t1(Tup{nullptr, 42, 'a'});
+    static_assert(cuda::std::same_as<decltype(t1), Tup>);
     unused(t1);
   }
+#endif // !TEST_CUDA_COMPILER(NVCC, >, 13, 2)
   // cuda::std::allocator not supported
   /*
   { // Testing (9)


### PR DESCRIPTION
There has been a latent codegen bug in NVCC that was exposed by a recent compiler upgrade. Disasble the test for now until the compiler bug is fixed.

See nvbug6075893
