### PR TITLE
max_t::operator() should be declared const

### DIFF
--- a/nvbench_helper/nvbench_helper/nvbench_helper.cuh
+++ b/nvbench_helper/nvbench_helper/nvbench_helper.cuh
@@ -509,7 +509,7 @@ struct less_t
 struct max_t
 {
   template <typename DataType>
-  __host__ __device__ DataType operator()(const DataType& lhs, const DataType& rhs)
+  __host__ __device__ DataType operator()(const DataType& lhs, const DataType& rhs) const
   {
     less_t less{};
     return less(lhs, rhs) ? rhs : lhs;


### PR DESCRIPTION
The operator, defined in `"nvbench_helper.cuh"` and used in many benchmarks, does not have side effects. Qualifying the call operator as const allows max_t to be invoked from const methods of classes where max_t is stored as a member.

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
