### PR TITLE
Remove hardcoded c++17 dialect for benchmarks

### DIFF
--- a/cub/benchmarks/CMakeLists.txt
+++ b/cub/benchmarks/CMakeLists.txt
@@ -87,7 +87,6 @@ function(add_bench target_name bench_name bench_src)
   cccl_add_executable(
     ${bench_target}
     NO_METATARGETS
-    DIALECT 17
     SOURCES "${bench_src}"
   )
   target_link_libraries(

--- a/cub/benchmarks/CMakeLists.txt
+++ b/cub/benchmarks/CMakeLists.txt
@@ -84,11 +84,7 @@ function(add_bench target_name bench_name bench_src)
   set(bench_target ${bench_name})
   set(${target_name} ${bench_target} PARENT_SCOPE)
 
-  cccl_add_executable(
-    ${bench_target}
-    NO_METATARGETS
-    SOURCES "${bench_src}"
-  )
+  cccl_add_executable(${bench_target} NO_METATARGETS SOURCES "${bench_src}")
   target_link_libraries(
     ${bench_target}
     PRIVATE #

--- a/cudax/benchmarks/CMakeLists.txt
+++ b/cudax/benchmarks/CMakeLists.txt
@@ -27,11 +27,7 @@ function(add_bench target_name bench_name bench_src)
   set(bench_target ${bench_name})
   set(${target_name} ${bench_target} PARENT_SCOPE)
 
-  cccl_add_executable(
-    ${bench_target}
-    NO_METATARGETS
-    SOURCES "${bench_src}"
-  )
+  cccl_add_executable(${bench_target} NO_METATARGETS SOURCES "${bench_src}")
   target_link_libraries(
     ${bench_target}
     PRIVATE #

--- a/cudax/benchmarks/CMakeLists.txt
+++ b/cudax/benchmarks/CMakeLists.txt
@@ -30,7 +30,6 @@ function(add_bench target_name bench_name bench_src)
   cccl_add_executable(
     ${bench_target}
     NO_METATARGETS
-    DIALECT 17
     SOURCES "${bench_src}"
   )
   target_link_libraries(

--- a/libcudacxx/benchmarks/CMakeLists.txt
+++ b/libcudacxx/benchmarks/CMakeLists.txt
@@ -57,7 +57,6 @@ function(add_bench target_name bench_name bench_src)
   cccl_add_executable(
     ${bench_target}
     NO_METATARGETS
-    DIALECT 17
     SOURCES "${bench_src}"
   )
   target_link_libraries(

--- a/libcudacxx/benchmarks/CMakeLists.txt
+++ b/libcudacxx/benchmarks/CMakeLists.txt
@@ -54,11 +54,7 @@ function(add_bench target_name bench_name bench_src)
   set(bench_target ${bench_name})
   set(${target_name} ${bench_target} PARENT_SCOPE)
 
-  cccl_add_executable(
-    ${bench_target}
-    NO_METATARGETS
-    SOURCES "${bench_src}"
-  )
+  cccl_add_executable(${bench_target} NO_METATARGETS SOURCES "${bench_src}")
   target_link_libraries(
     ${bench_target}
     PRIVATE libcudacxx::libcudacxx cccl.nvbench_helper nvbench::main

--- a/nvbench_helper/CMakeLists.txt
+++ b/nvbench_helper/CMakeLists.txt
@@ -12,7 +12,7 @@ cccl_get_nvbench()
 cccl_get_thrust()
 
 add_library(cccl.nvbench_helper OBJECT nvbench_helper/nvbench_helper.cu)
-cccl_configure_target(cccl.nvbench_helper DIALECT 17)
+cccl_configure_target(cccl.nvbench_helper)
 target_link_libraries(
   cccl.nvbench_helper
   PUBLIC
@@ -59,7 +59,6 @@ if (nvbench_helper_ENABLE_TESTING)
       ${nvbench_helper_test_target}
       ADD_CTEST
       NO_METATARGETS
-      DIALECT 17
       SOURCES
         test/gen_seed.cu
         test/gen_range.cu

--- a/thrust/benchmarks/CMakeLists.txt
+++ b/thrust/benchmarks/CMakeLists.txt
@@ -27,11 +27,7 @@ function(add_bench target_name bench_name bench_src)
   set(bench_target ${bench_name})
   set(${target_name} ${bench_target} PARENT_SCOPE)
 
-  cccl_add_executable(
-    ${bench_target}
-    NO_METATARGETS
-    SOURCES "${bench_src}"
-  )
+  cccl_add_executable(${bench_target} NO_METATARGETS SOURCES "${bench_src}")
   target_link_libraries(
     ${bench_target}
     PRIVATE #

--- a/thrust/benchmarks/CMakeLists.txt
+++ b/thrust/benchmarks/CMakeLists.txt
@@ -30,7 +30,6 @@ function(add_bench target_name bench_name bench_src)
   cccl_add_executable(
     ${bench_target}
     NO_METATARGETS
-    DIALECT 17
     SOURCES "${bench_src}"
   )
   target_link_libraries(
@@ -76,7 +75,7 @@ function(add_bench_dir bench_dir)
 
       string(APPEND bench_name ".base")
       add_bench(base_bench_target ${bench_name} "${real_bench_src}")
-      cccl_configure_target(${bench_name} DIALECT 17)
+      cccl_configure_target(${bench_name})
       target_link_libraries(${bench_name} PRIVATE ${thrust_target})
 
       if ("CUDA" STREQUAL "${config_device}")


### PR DESCRIPTION
This changes benchmark-related CMake targets to use the user-configured `CMAKE_CXX_STANDARD` / `CMAKE_CUDA_STANDARD` instead of hardcoding `DIALECT 17`.

Before this change, several benchmark paths always forced c++17 even when the build was configured for C++20. Tests already inherit the configured dialect, so this makes benchmarks consistent with the rest of the repo.
