### PR TITLE
Replace `detail::merge_sort::dispatch` by CUB's public API

### DIFF
--- a/cub/benchmarks/bench/merge_sort/keys.cu
+++ b/cub/benchmarks/bench/merge_sort/keys.cu
@@ -15,8 +15,6 @@
 #  define TUNE_THREADS_PER_BLOCK (1 << TUNE_THREADS_PER_BLOCK_POW2)
 #endif // TUNE_BASE
 
-using value_t = cub::NullType;
-
 #if !TUNE_BASE
 template <typename KeyT>
 struct policy_selector
@@ -37,8 +35,6 @@ template <typename T, typename OffsetT>
 void keys(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 {
   using key_t        = T;
-  using value_t      = cub::NullType;
-  using offset_t     = cub::detail::choose_offset_t<OffsetT>;
   using compare_op_t = less_t;
 
   // Retrieve axis parameters
@@ -56,43 +52,18 @@ void keys(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   state.add_global_memory_reads<T>(elements, "Size");
   state.add_global_memory_writes<T>(elements);
 
-  // Allocate temporary storage:
-  std::size_t temp_size{};
-  cub::detail::merge_sort::dispatch(
-    nullptr,
-    temp_size,
-    d_buffer_1,
-    static_cast<value_t*>(nullptr),
-    d_buffer_2,
-    static_cast<value_t*>(nullptr),
-    static_cast<offset_t>(elements),
-    compare_op_t{},
-    nullptr /* stream */
-#if !TUNE_BASE
-    ,
-    policy_selector<key_t>{}
-#endif // !TUNE_BASE
-  );
-
-  thrust::device_vector<nvbench::uint8_t> temp(temp_size, thrust::no_init);
-  auto* temp_storage = thrust::raw_pointer_cast(temp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::merge_sort::dispatch(
-      temp_storage,
-      temp_size,
-      d_buffer_1,
-      static_cast<value_t*>(nullptr),
-      d_buffer_2,
-      static_cast<value_t*>(nullptr),
-      static_cast<offset_t>(elements),
-      compare_op_t{},
-      launch.get_stream()
+    auto env = cub_bench_env(
+      alloc,
+      launch
 #if !TUNE_BASE
-        ,
-      policy_selector<key_t>{}
+      ,
+      cuda::execution::__tune(policy_selector<key_t>{})
 #endif // !TUNE_BASE
     );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceMergeSort::SortKeysCopy, "SortKeysCopy failed", d_buffer_1, d_buffer_2, elements, compare_op_t{}, env);
   });
 }
 

--- a/cub/benchmarks/bench/merge_sort/keys.cu
+++ b/cub/benchmarks/bench/merge_sort/keys.cu
@@ -63,7 +63,13 @@ void keys(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 #endif // !TUNE_BASE
     );
     _CCCL_TRY_CUDA_API(
-      cub::DeviceMergeSort::SortKeysCopy, "SortKeysCopy failed", d_buffer_1, d_buffer_2, elements, compare_op_t{}, env);
+      cub::DeviceMergeSort::SortKeysCopy,
+      "SortKeysCopy failed",
+      d_buffer_1,
+      d_buffer_2,
+      static_cast<OffsetT>(elements),
+      compare_op_t{},
+      env);
   });
 }
 

--- a/cub/benchmarks/bench/merge_sort/pairs.cu
+++ b/cub/benchmarks/bench/merge_sort/pairs.cu
@@ -76,7 +76,7 @@ void pairs(nvbench::state& state, nvbench::type_list<KeyT, ValueT, OffsetT>)
       d_values_buffer_1,
       d_keys_buffer_2,
       d_values_buffer_2,
-      elements,
+      static_cast<OffsetT>(elements),
       compare_op_t{},
       env);
   });

--- a/cub/benchmarks/bench/merge_sort/pairs.cu
+++ b/cub/benchmarks/bench/merge_sort/pairs.cu
@@ -36,7 +36,6 @@ void pairs(nvbench::state& state, nvbench::type_list<KeyT, ValueT, OffsetT>)
 {
   using key_t        = KeyT;
   using value_t      = ValueT;
-  using offset_t     = cub::detail::choose_offset_t<OffsetT>;
   using compare_op_t = less_t;
 
   // Retrieve axis parameters
@@ -60,43 +59,26 @@ void pairs(nvbench::state& state, nvbench::type_list<KeyT, ValueT, OffsetT>)
   state.add_global_memory_writes<KeyT>(elements);
   state.add_global_memory_writes<ValueT>(elements);
 
-  // Allocate temporary storage:
-  std::size_t temp_size{};
-  cub::detail::merge_sort::dispatch(
-    nullptr,
-    temp_size,
-    d_keys_buffer_1,
-    d_values_buffer_1,
-    d_keys_buffer_2,
-    d_values_buffer_2,
-    static_cast<offset_t>(elements),
-    compare_op_t{},
-    nullptr /* stream */
-#if !TUNE_BASE
-    ,
-    policy_selector<key_t>{}
-#endif // !TUNE_BASE
-  );
-
-  thrust::device_vector<nvbench::uint8_t> temp(temp_size, thrust::no_init);
-  auto* temp_storage = thrust::raw_pointer_cast(temp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::merge_sort::dispatch(
-      temp_storage,
-      temp_size,
+    auto env = cub_bench_env(
+      alloc,
+      launch
+#if !TUNE_BASE
+      ,
+      cuda::execution::__tune(policy_selector<key_t>{})
+#endif // !TUNE_BASE
+    );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceMergeSort::SortPairsCopy,
+      "SortPairsCopy failed",
       d_keys_buffer_1,
       d_values_buffer_1,
       d_keys_buffer_2,
       d_values_buffer_2,
-      static_cast<offset_t>(elements),
+      elements,
       compare_op_t{},
-      launch.get_stream()
-#if !TUNE_BASE
-        ,
-      policy_selector<key_t>{}
-#endif // !TUNE_BASE
-    );
+      env);
   });
 }
 

--- a/cub/cub/device/device_merge_sort.cuh
+++ b/cub/cub/device/device_merge_sort.cuh
@@ -299,12 +299,23 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
+    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
 
-    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::merge_sort::dispatch(
-        storage, bytes, d_keys, d_items, d_keys, d_items, static_cast<ChooseOffsetT>(num_items), compare_op, stream);
-    });
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::merge_sort::dispatch(
+          storage,
+          bytes,
+          d_keys,
+          d_items,
+          d_keys,
+          d_items,
+          static_cast<ChooseOffsetT>(num_items),
+          compare_op,
+          stream,
+          policy_selector);
+      });
   }
 
   /**
@@ -542,20 +553,23 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
+    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
 
-    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::merge_sort::dispatch(
-        storage,
-        bytes,
-        d_input_keys,
-        d_input_items,
-        d_output_keys,
-        d_output_items,
-        static_cast<ChooseOffsetT>(num_items),
-        compare_op,
-        stream);
-    });
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::merge_sort::dispatch(
+          storage,
+          bytes,
+          d_input_keys,
+          d_input_items,
+          d_output_keys,
+          d_output_items,
+          static_cast<ChooseOffsetT>(num_items),
+          compare_op,
+          stream,
+          policy_selector);
+      });
   }
 
 private:
@@ -740,20 +754,23 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
+    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
 
-    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::merge_sort::dispatch(
-        storage,
-        bytes,
-        d_keys,
-        static_cast<NullType*>(nullptr),
-        d_keys,
-        static_cast<NullType*>(nullptr),
-        static_cast<ChooseOffsetT>(num_items),
-        compare_op,
-        stream);
-    });
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::merge_sort::dispatch(
+          storage,
+          bytes,
+          d_keys,
+          static_cast<NullType*>(nullptr),
+          d_keys,
+          static_cast<NullType*>(nullptr),
+          static_cast<ChooseOffsetT>(num_items),
+          compare_op,
+          stream,
+          policy_selector);
+      });
   }
 
 private:
@@ -967,20 +984,23 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
+    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
 
-    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::merge_sort::dispatch(
-        storage,
-        bytes,
-        d_input_keys,
-        static_cast<NullType*>(nullptr),
-        d_output_keys,
-        static_cast<NullType*>(nullptr),
-        static_cast<ChooseOffsetT>(num_items),
-        compare_op,
-        stream);
-    });
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::merge_sort::dispatch(
+          storage,
+          bytes,
+          d_input_keys,
+          static_cast<NullType*>(nullptr),
+          d_output_keys,
+          static_cast<NullType*>(nullptr),
+          static_cast<ChooseOffsetT>(num_items),
+          compare_op,
+          stream,
+          policy_selector);
+      });
   }
 
   /**
@@ -1161,12 +1181,23 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
+    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
 
-    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::merge_sort::dispatch(
-        storage, bytes, d_keys, d_items, d_keys, d_items, static_cast<ChooseOffsetT>(num_items), compare_op, stream);
-    });
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::merge_sort::dispatch(
+          storage,
+          bytes,
+          d_keys,
+          d_items,
+          d_keys,
+          d_items,
+          static_cast<ChooseOffsetT>(num_items),
+          compare_op,
+          stream,
+          policy_selector);
+      });
   }
 
   /**
@@ -1328,20 +1359,23 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
+    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
 
-    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::merge_sort::dispatch(
-        storage,
-        bytes,
-        d_keys,
-        static_cast<NullType*>(nullptr),
-        d_keys,
-        static_cast<NullType*>(nullptr),
-        static_cast<ChooseOffsetT>(num_items),
-        compare_op,
-        stream);
-    });
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::merge_sort::dispatch(
+          storage,
+          bytes,
+          d_keys,
+          static_cast<NullType*>(nullptr),
+          d_keys,
+          static_cast<NullType*>(nullptr),
+          static_cast<ChooseOffsetT>(num_items),
+          compare_op,
+          stream,
+          policy_selector);
+      });
   }
 
   /**
@@ -1528,20 +1562,23 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
+    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
 
-    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::merge_sort::dispatch(
-        storage,
-        bytes,
-        d_input_keys,
-        static_cast<NullType*>(nullptr),
-        d_output_keys,
-        static_cast<NullType*>(nullptr),
-        static_cast<ChooseOffsetT>(num_items),
-        compare_op,
-        stream);
-    });
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::merge_sort::dispatch(
+          storage,
+          bytes,
+          d_input_keys,
+          static_cast<NullType*>(nullptr),
+          d_output_keys,
+          static_cast<NullType*>(nullptr),
+          static_cast<ChooseOffsetT>(num_items),
+          compare_op,
+          stream,
+          policy_selector);
+      });
   }
 };
 

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -9,8 +9,10 @@ struct stream_registry_factory_t;
 
 #include <cub/device/device_merge_sort.cuh>
 
+#include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/device_vector.h>
 
+#include <cuda/__execution/tune.h>
 #include <cuda/devices>
 #include <cuda/stream>
 
@@ -29,6 +31,44 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceMergeSort::StableSortKeysCopy, device_merge_st
 #include <c2h/catch2_test_helper.h>
 
 namespace stdexec = cuda::std::execution;
+
+template <int BlockThreads>
+struct merge_sort_tuning
+{
+  _CCCL_API constexpr auto operator()(cuda::arch_id /*arch*/) const -> cub::detail::merge_sort::merge_sort_policy
+  {
+    return {BlockThreads, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_STORE_DIRECT};
+  }
+};
+
+struct unrelated_policy
+{};
+
+struct unrelated_tuning
+{
+  // should never be called
+  auto operator()(cuda::arch_id /*arch*/) const -> unrelated_policy
+  {
+    throw 1337;
+  }
+};
+
+struct block_size_compare_t
+{
+  unsigned int* block_size;
+
+  __device__ bool operator()(int lhs, int rhs) const
+  {
+    if (threadIdx.x == 0)
+    {
+      // use an atomic operation to write the block dim in case multiple blocks are launched
+      atomicMin(block_size, blockDim.x);
+    }
+    return lhs < rhs;
+  }
+};
+
+using block_sizes = c2h::type_list<cuda::std::integral_constant<int, 64>, cuda::std::integral_constant<int, 128>>;
 
 #if TEST_LAUNCH == 0
 
@@ -433,4 +473,115 @@ TEST_CASE("DeviceMergeSort::StableSortKeysCopy uses custom stream", "[merge_sort
 
   c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(d_keys_out == expected_keys);
+}
+
+C2H_TEST("DeviceMergeSort::SortPairs can be tuned", "[merge_sort][device]", block_sizes)
+{
+  constexpr int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<int> d_keys{4, 1, 3, 2};
+  c2h::device_vector<int> d_values{0, 1, 2, 3};
+  c2h::device_vector<int> d_block_size(1);
+  auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{}, unrelated_tuning{});
+
+  REQUIRE(cudaSuccess
+          == cub::DeviceMergeSort::SortPairs(
+            d_keys.data().get(), d_values.data().get(), static_cast<int>(d_keys.size()), compare_op, env));
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceMergeSort::SortPairsCopy can be tuned", "[merge_sort][device]", block_sizes)
+{
+  constexpr int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<int> d_keys_in{4, 1, 3, 2};
+  c2h::device_vector<int> d_values_in{0, 1, 2, 3};
+  c2h::device_vector<int> d_keys_out(4);
+  c2h::device_vector<int> d_values_out(4);
+  c2h::device_vector<int> d_block_size(1);
+  auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{}, unrelated_tuning{});
+
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceMergeSort::SortPairsCopy(
+      d_keys_in.data().get(),
+      d_values_in.data().get(),
+      d_keys_out.data().get(),
+      d_values_out.data().get(),
+      static_cast<int>(d_keys_in.size()),
+      compare_op,
+      env));
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceMergeSort::SortKeys can be tuned", "[merge_sort][device]", block_sizes)
+{
+  constexpr int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<int> d_keys{4, 1, 3, 2};
+  c2h::device_vector<int> d_block_size(1);
+  auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{}, unrelated_tuning{});
+
+  REQUIRE(cudaSuccess
+          == cub::DeviceMergeSort::SortKeys(d_keys.data().get(), static_cast<int>(d_keys.size()), compare_op, env));
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceMergeSort::SortKeysCopy can be tuned", "[merge_sort][device]", block_sizes)
+{
+  constexpr int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<int> d_keys_in{4, 1, 3, 2};
+  c2h::device_vector<int> d_keys_out(4);
+  c2h::device_vector<int> d_block_size(1);
+  auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{}, unrelated_tuning{});
+
+  REQUIRE(cudaSuccess
+          == cub::DeviceMergeSort::SortKeysCopy(
+            d_keys_in.data().get(), d_keys_out.data().get(), static_cast<int>(d_keys_in.size()), compare_op, env));
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceMergeSort::StableSortPairs can be tuned", "[merge_sort][device]", block_sizes)
+{
+  constexpr int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<int> d_keys{4, 1, 3, 2};
+  c2h::device_vector<int> d_values{0, 1, 2, 3};
+  c2h::device_vector<int> d_block_size(1);
+  auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{}, unrelated_tuning{});
+
+  REQUIRE(cudaSuccess
+          == cub::DeviceMergeSort::StableSortPairs(
+            d_keys.data().get(), d_values.data().get(), static_cast<int>(d_keys.size()), compare_op, env));
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceMergeSort::StableSortKeys can be tuned", "[merge_sort][device]", block_sizes)
+{
+  constexpr int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<int> d_keys{4, 1, 3, 2};
+  c2h::device_vector<int> d_block_size(1);
+  auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{}, unrelated_tuning{});
+
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceMergeSort::StableSortKeys(d_keys.data().get(), static_cast<int>(d_keys.size()), compare_op, env));
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceMergeSort::StableSortKeysCopy can be tuned", "[merge_sort][device]", block_sizes)
+{
+  constexpr int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<int> d_keys_in{4, 1, 3, 2};
+  c2h::device_vector<int> d_keys_out(4);
+  c2h::device_vector<int> d_block_size(1);
+  auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{}, unrelated_tuning{});
+
+  REQUIRE(cudaSuccess
+          == cub::DeviceMergeSort::StableSortKeysCopy(
+            d_keys_in.data().get(), d_keys_out.data().get(), static_cast<int>(d_keys_in.size()), compare_op, env));
+  REQUIRE(d_block_size[0] == target_block_size);
 }

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -479,6 +479,8 @@ C2H_TEST("DeviceMergeSort::SortPairs can be tuned", "[merge_sort][device]", bloc
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
+#if TEST_LAUNCH != 1
+
 C2H_TEST("DeviceMergeSort::SortPairsCopy can be tuned", "[merge_sort][device]", block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
@@ -490,16 +492,14 @@ C2H_TEST("DeviceMergeSort::SortPairsCopy can be tuned", "[merge_sort][device]", 
   auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
   auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{});
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMergeSort::SortPairsCopy(
-      d_keys_in.data().get(),
-      d_values_in.data().get(),
-      d_keys_out.data().get(),
-      d_values_out.data().get(),
-      static_cast<int>(d_keys_in.size()),
-      compare_op,
-      env));
+  device_merge_sort_pairs_copy(
+    d_keys_in.data().get(),
+    d_values_in.data().get(),
+    d_keys_out.data().get(),
+    d_values_out.data().get(),
+    static_cast<int>(d_keys_in.size()),
+    compare_op,
+    env);
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
@@ -511,8 +511,7 @@ C2H_TEST("DeviceMergeSort::SortKeys can be tuned", "[merge_sort][device]", block
   auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
   auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{});
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceMergeSort::SortKeys(d_keys.data().get(), static_cast<int>(d_keys.size()), compare_op, env));
+  device_merge_sort_keys(d_keys.data().get(), static_cast<int>(d_keys.size()), compare_op, env);
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
@@ -525,9 +524,8 @@ C2H_TEST("DeviceMergeSort::SortKeysCopy can be tuned", "[merge_sort][device]", b
   auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
   auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{});
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceMergeSort::SortKeysCopy(
-            d_keys_in.data().get(), d_keys_out.data().get(), static_cast<int>(d_keys_in.size()), compare_op, env));
+  device_merge_sort_keys_copy(
+    d_keys_in.data().get(), d_keys_out.data().get(), static_cast<int>(d_keys_in.size()), compare_op, env);
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
@@ -540,9 +538,8 @@ C2H_TEST("DeviceMergeSort::StableSortPairs can be tuned", "[merge_sort][device]"
   auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
   auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{});
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceMergeSort::StableSortPairs(
-            d_keys.data().get(), d_values.data().get(), static_cast<int>(d_keys.size()), compare_op, env));
+  device_merge_stable_sort_pairs(
+    d_keys.data().get(), d_values.data().get(), static_cast<int>(d_keys.size()), compare_op, env);
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
@@ -554,9 +551,7 @@ C2H_TEST("DeviceMergeSort::StableSortKeys can be tuned", "[merge_sort][device]",
   auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
   auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{});
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMergeSort::StableSortKeys(d_keys.data().get(), static_cast<int>(d_keys.size()), compare_op, env));
+  device_merge_stable_sort_keys(d_keys.data().get(), static_cast<int>(d_keys.size()), compare_op, env);
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
@@ -569,8 +564,9 @@ C2H_TEST("DeviceMergeSort::StableSortKeysCopy can be tuned", "[merge_sort][devic
   auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
   auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{});
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceMergeSort::StableSortKeysCopy(
-            d_keys_in.data().get(), d_keys_out.data().get(), static_cast<int>(d_keys_in.size()), compare_op, env));
+  device_merge_stable_sort_keys_copy(
+    d_keys_in.data().get(), d_keys_out.data().get(), static_cast<int>(d_keys_in.size()), compare_op, env);
   REQUIRE(d_block_size[0] == target_block_size);
 }
+
+#endif // TEST_LAUNCH != 1

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -41,35 +41,6 @@ struct merge_sort_tuning
   }
 };
 
-struct unrelated_policy
-{};
-
-struct unrelated_tuning
-{
-  // should never be called
-  auto operator()(cuda::arch_id /*arch*/) const -> unrelated_policy
-  {
-    throw 1337;
-  }
-};
-
-struct block_size_compare_t
-{
-  unsigned int* block_size;
-
-  __device__ bool operator()(int lhs, int rhs) const
-  {
-    if (threadIdx.x == 0)
-    {
-      // use an atomic operation to write the block dim in case multiple blocks are launched
-      atomicMin(block_size, blockDim.x);
-    }
-    return lhs < rhs;
-  }
-};
-
-using block_sizes = c2h::type_list<cuda::std::integral_constant<int, 64>, cuda::std::integral_constant<int, 128>>;
-
 #if TEST_LAUNCH == 0
 
 TEST_CASE("DeviceMergeSort::SortPairs works with default environment", "[merge_sort][device]")
@@ -475,14 +446,32 @@ TEST_CASE("DeviceMergeSort::StableSortKeysCopy uses custom stream", "[merge_sort
   REQUIRE(d_keys_out == expected_keys);
 }
 
+struct block_size_compare_t
+{
+  unsigned int* block_size;
+
+  __device__ bool operator()(int lhs, int rhs) const
+  {
+    if (threadIdx.x == 0)
+    {
+      // use an atomic operation to write the block dim in case multiple blocks are launched
+      atomicMin(block_size, blockDim.x);
+    }
+    return lhs < rhs;
+  }
+};
+
+using block_sizes =
+  c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
+
 C2H_TEST("DeviceMergeSort::SortPairs can be tuned", "[merge_sort][device]", block_sizes)
 {
-  constexpr int target_block_size = c2h::get<0, TestType>::value;
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_keys{4, 1, 3, 2};
   c2h::device_vector<int> d_values{0, 1, 2, 3};
-  c2h::device_vector<int> d_block_size(1);
+  c2h::device_vector<unsigned int> d_block_size(1);
   auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
-  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{}, unrelated_tuning{});
+  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{});
 
   REQUIRE(cudaSuccess
           == cub::DeviceMergeSort::SortPairs(
@@ -492,14 +481,14 @@ C2H_TEST("DeviceMergeSort::SortPairs can be tuned", "[merge_sort][device]", bloc
 
 C2H_TEST("DeviceMergeSort::SortPairsCopy can be tuned", "[merge_sort][device]", block_sizes)
 {
-  constexpr int target_block_size = c2h::get<0, TestType>::value;
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_keys_in{4, 1, 3, 2};
   c2h::device_vector<int> d_values_in{0, 1, 2, 3};
   c2h::device_vector<int> d_keys_out(4);
   c2h::device_vector<int> d_values_out(4);
-  c2h::device_vector<int> d_block_size(1);
+  c2h::device_vector<unsigned int> d_block_size(1);
   auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
-  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{}, unrelated_tuning{});
+  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{});
 
   REQUIRE(
     cudaSuccess
@@ -516,11 +505,11 @@ C2H_TEST("DeviceMergeSort::SortPairsCopy can be tuned", "[merge_sort][device]", 
 
 C2H_TEST("DeviceMergeSort::SortKeys can be tuned", "[merge_sort][device]", block_sizes)
 {
-  constexpr int target_block_size = c2h::get<0, TestType>::value;
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_keys{4, 1, 3, 2};
-  c2h::device_vector<int> d_block_size(1);
+  c2h::device_vector<unsigned int> d_block_size(1);
   auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
-  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{}, unrelated_tuning{});
+  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{});
 
   REQUIRE(cudaSuccess
           == cub::DeviceMergeSort::SortKeys(d_keys.data().get(), static_cast<int>(d_keys.size()), compare_op, env));
@@ -529,12 +518,12 @@ C2H_TEST("DeviceMergeSort::SortKeys can be tuned", "[merge_sort][device]", block
 
 C2H_TEST("DeviceMergeSort::SortKeysCopy can be tuned", "[merge_sort][device]", block_sizes)
 {
-  constexpr int target_block_size = c2h::get<0, TestType>::value;
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_keys_in{4, 1, 3, 2};
   c2h::device_vector<int> d_keys_out(4);
-  c2h::device_vector<int> d_block_size(1);
+  c2h::device_vector<unsigned int> d_block_size(1);
   auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
-  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{}, unrelated_tuning{});
+  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{});
 
   REQUIRE(cudaSuccess
           == cub::DeviceMergeSort::SortKeysCopy(
@@ -544,12 +533,12 @@ C2H_TEST("DeviceMergeSort::SortKeysCopy can be tuned", "[merge_sort][device]", b
 
 C2H_TEST("DeviceMergeSort::StableSortPairs can be tuned", "[merge_sort][device]", block_sizes)
 {
-  constexpr int target_block_size = c2h::get<0, TestType>::value;
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_keys{4, 1, 3, 2};
   c2h::device_vector<int> d_values{0, 1, 2, 3};
-  c2h::device_vector<int> d_block_size(1);
+  c2h::device_vector<unsigned int> d_block_size(1);
   auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
-  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{}, unrelated_tuning{});
+  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{});
 
   REQUIRE(cudaSuccess
           == cub::DeviceMergeSort::StableSortPairs(
@@ -559,11 +548,11 @@ C2H_TEST("DeviceMergeSort::StableSortPairs can be tuned", "[merge_sort][device]"
 
 C2H_TEST("DeviceMergeSort::StableSortKeys can be tuned", "[merge_sort][device]", block_sizes)
 {
-  constexpr int target_block_size = c2h::get<0, TestType>::value;
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_keys{4, 1, 3, 2};
-  c2h::device_vector<int> d_block_size(1);
+  c2h::device_vector<unsigned int> d_block_size(1);
   auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
-  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{}, unrelated_tuning{});
+  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{});
 
   REQUIRE(
     cudaSuccess
@@ -573,12 +562,12 @@ C2H_TEST("DeviceMergeSort::StableSortKeys can be tuned", "[merge_sort][device]",
 
 C2H_TEST("DeviceMergeSort::StableSortKeysCopy can be tuned", "[merge_sort][device]", block_sizes)
 {
-  constexpr int target_block_size = c2h::get<0, TestType>::value;
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_keys_in{4, 1, 3, 2};
   c2h::device_vector<int> d_keys_out(4);
-  c2h::device_vector<int> d_block_size(1);
+  c2h::device_vector<unsigned int> d_block_size(1);
   auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
-  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{}, unrelated_tuning{});
+  auto env        = cuda::execution::__tune(merge_sort_tuning<target_block_size>{});
 
   REQUIRE(cudaSuccess
           == cub::DeviceMergeSort::StableSortKeysCopy(

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -455,7 +455,7 @@ struct block_size_compare_t
     if (threadIdx.x == 0)
     {
       // use an atomic operation to write the block dim in case multiple blocks are launched
-      atomicMin(block_size, blockDim.x);
+      atomicMax(block_size, blockDim.x);
     }
     return lhs < rhs;
   }

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -127,11 +127,12 @@ struct unrelated_tuning
   }
 };
 
-using block_sizes = c2h::type_list<cuda::std::integral_constant<int, 32>, cuda::std::integral_constant<int, 64>>;
+using block_sizes =
+  c2h::type_list<cuda::std::integral_constant<unsigned int, 32>, cuda::std::integral_constant<unsigned int, 64>>;
 
 C2H_TEST("Device reduce can be tuned", "[reduce][device]", block_sizes)
 {
-  constexpr int target_block_size = c2h::get<0, TestType>::value;
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
   block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
 
@@ -149,7 +150,7 @@ C2H_TEST("Device reduce can be tuned", "[reduce][device]", block_sizes)
 
 C2H_TEST("Device sum can be tuned", "[reduce][device]", block_sizes)
 {
-  constexpr int target_block_size = c2h::get<0, TestType>::value;
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
   auto num_items = 1;
   auto d_in      = cuda::constant_iterator(1);

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -41,13 +41,13 @@ namespace stdexec = cuda::std::execution;
 #if TEST_LAUNCH == 0
 struct block_size_check_t
 {
-  int* ptr;
+  unsigned int* ptr;
 
   __device__ int operator()(int a, int b)
   {
     if (threadIdx.x == 0)
     {
-      *ptr = blockDim.x;
+      atomicMin(ptr, blockDim.x);
     }
     return a + b;
   }
@@ -65,12 +65,12 @@ TEST_CASE("Device reduce works with default environment", "[reduce][device]")
   cuda::arch_id arch_id{};
   REQUIRE(cudaSuccess == cub::detail::ptx_arch_id(arch_id, current_device));
 
-  int target_block_size =
+  unsigned int target_block_size =
     cub::detail::reduce::policy_selector_from_types<value_t, offset_t, block_size_check_t>{}(arch_id)
       .single_tile.block_threads;
 
   num_items_t num_items = 1;
-  c2h::device_vector<int> d_block_size(1);
+  c2h::device_vector<unsigned int> d_block_size(1);
   block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
   auto d_in  = cuda::constant_iterator(value_t{1});
   auto d_out = thrust::device_vector<value_t>(1);
@@ -131,7 +131,7 @@ using block_sizes = c2h::type_list<cuda::std::integral_constant<int, 32>, cuda::
 C2H_TEST("Device reduce can be tuned", "[reduce][device]", block_sizes)
 {
   constexpr int target_block_size = c2h::get<0, TestType>::value;
-  c2h::device_vector<int> d_block_size(1);
+  c2h::device_vector<unsigned int> d_block_size(1);
   block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
 
   auto num_items = 1;

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -47,7 +47,8 @@ struct block_size_check_t
   {
     if (threadIdx.x == 0)
     {
-      atomicMin(ptr, blockDim.x);
+      // use an atomic operation to write the block dim in case multiple blocks are launched
+      atomicMax(ptr, blockDim.x);
     }
     return a + b;
   }

--- a/cub/test/catch2_test_env_launch_helper.h
+++ b/cub/test/catch2_test_env_launch_helper.h
@@ -512,8 +512,11 @@ void launch(ActionT action, Args... args)
     REQUIRE(cudaSuccess == cudaStreamDestroy(stream));
   }
 
-  size_t expected_bytes_allocated = fixed_env.query(get_expected_allocation_size_t{});
-  REQUIRE(expected_bytes_allocated == bytes_allocated);
+  if constexpr (cuda::std::execution::__queryable_with<env_t, get_expected_allocation_size_t>)
+  {
+    const size_t expected_bytes_allocated = fixed_env.query(get_expected_allocation_size_t{});
+    REQUIRE(expected_bytes_allocated == bytes_allocated);
+  }
 }
 
 #elif TEST_LAUNCH == 1
@@ -550,7 +553,11 @@ void launch(ActionT action, Args... args)
   tpl_t tuple(args...);
   env_t env = cuda::std::get<env_idx>(tuple);
 
-  size_t expected_bytes_allocated = env.query(get_expected_allocation_size_t{});
+  static_assert(cuda::std::execution::__queryable_with<env_t, get_expected_allocation_size_t>,
+                "Unit tests using env launch wrappers (declared with DECLARE_LAUNCH_WRAPPER) must pass "
+                "expected_allocation_size as property in their env");
+
+  const size_t expected_bytes_allocated = env.query(get_expected_allocation_size_t{});
 
   c2h::device_vector<cudaError_t> d_error(1, cudaErrorInvalidValue);
   c2h::device_vector<std::size_t> d_temp_storage(expected_bytes_allocated);
@@ -659,8 +666,11 @@ void launch(ActionT action, Args... args)
     REQUIRE(cudaSuccess == cudaStreamDestroy(stream));
   }
 
-  size_t expected_bytes_allocated = fixed_env.query(get_expected_allocation_size_t{});
-  REQUIRE(expected_bytes_allocated == bytes_allocated);
+  if constexpr (cuda::std::execution::__queryable_with<env_t, get_expected_allocation_size_t>)
+  {
+    const size_t expected_bytes_allocated = fixed_env.query(get_expected_allocation_size_t{});
+    REQUIRE(expected_bytes_allocated == bytes_allocated);
+  }
 }
 
 #endif // TEST_LAUNCH == 0

--- a/thrust/thrust/system/cuda/detail/sort.h
+++ b/thrust/thrust/system/cuda/detail/sort.h
@@ -57,20 +57,13 @@ THRUST_RUNTIME_FUNCTION cudaError_t doit_step(
   cudaStream_t stream,
   thrust::detail::integral_constant<bool, false> /* sort_keys */)
 {
-  using ItemsInputIt = cub::NullType*;
-  ItemsInputIt items = nullptr;
-
   cudaError_t status = cudaSuccess;
 
-  using dispatch32_t = cub::DispatchMergeSort<KeysIt, ItemsInputIt, KeysIt, ItemsInputIt, std::uint32_t, CompareOp>;
-  using dispatch64_t = cub::DispatchMergeSort<KeysIt, ItemsInputIt, KeysIt, ItemsInputIt, std::uint64_t, CompareOp>;
-
-  THRUST_UNSIGNED_INDEX_TYPE_DISPATCH2(
+  THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
     status,
-    dispatch32_t::Dispatch,
-    dispatch64_t::Dispatch,
+    cub::DeviceMergeSort::SortKeys,
     keys_count,
-    (d_temp_storage, temp_storage_bytes, keys, items, keys, items, keys_count_fixed, compare_op, stream));
+    (d_temp_storage, temp_storage_bytes, keys, keys_count_fixed, compare_op, stream));
 
   return status;
 }
@@ -88,15 +81,11 @@ THRUST_RUNTIME_FUNCTION cudaError_t doit_step(
 {
   cudaError_t status = cudaSuccess;
 
-  using dispatch32_t = cub::DispatchMergeSort<KeysIt, ItemsIt, KeysIt, ItemsIt, std::uint32_t, CompareOp>;
-  using dispatch64_t = cub::DispatchMergeSort<KeysIt, ItemsIt, KeysIt, ItemsIt, std::uint64_t, CompareOp>;
-
-  THRUST_UNSIGNED_INDEX_TYPE_DISPATCH2(
+  THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
     status,
-    dispatch32_t::Dispatch,
-    dispatch64_t::Dispatch,
+    cub::DeviceMergeSort::SortPairs,
     keys_count,
-    (d_temp_storage, temp_storage_bytes, keys, items, keys, items, keys_count_fixed, compare_op, stream));
+    (d_temp_storage, temp_storage_bytes, keys, items, keys_count_fixed, compare_op, stream));
 
   return status;
 }


### PR DESCRIPTION
Fixes: #8376

- [x] Merge before: #8381
- [x] No SASS changes in `thrust.test.sort` on SM120
- [x] No SASS changes in `cub.bench.merge_sort.pairs.base` on SM120