### PR TITLE
[libcu++] Add first, last and subspan to buffer

### DIFF
--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -477,6 +477,69 @@ public:
     return __buf_.data();
   }
 
+  //! @brief Returns a span over the first \p __count elements.
+  //! @param __count Number of elements in the returned span.
+  //! @pre `__count <= size()`
+  [[nodiscard]] _CCCL_HOST_API ::cuda::std::span<_Tp> first(size_type __count) noexcept
+  {
+    _CCCL_ASSERT(__count <= size(), "cuda::buffer::first(count): count out of range");
+    return {data(), __count};
+  }
+
+  //! @overload
+  [[nodiscard]] _CCCL_HOST_API ::cuda::std::span<const _Tp> first(size_type __count) const noexcept
+  {
+    _CCCL_ASSERT(__count <= size(), "cuda::buffer::first(count): count out of range");
+    return {data(), __count};
+  }
+
+  //! @brief Returns a span over the last \p __count elements.
+  //! @param __count Number of elements in the returned span.
+  //! @pre `__count <= size()`
+  [[nodiscard]] _CCCL_HOST_API ::cuda::std::span<_Tp> last(size_type __count) noexcept
+  {
+    _CCCL_ASSERT(__count <= size(), "cuda::buffer::last(count): count out of range");
+    return {data() + size() - __count, __count};
+  }
+
+  //! @overload
+  [[nodiscard]] _CCCL_HOST_API ::cuda::std::span<const _Tp> last(size_type __count) const noexcept
+  {
+    _CCCL_ASSERT(__count <= size(), "cuda::buffer::last(count): count out of range");
+    return {data() + size() - __count, __count};
+  }
+
+  //! @brief Returns a span over a subset of the buffer.
+  //! @param __offset Index of the first element in the returned span.
+  //! @param __count Number of elements. Defaults to `dynamic_extent`, meaning
+  //!   all elements from \p __offset to the end.
+  //! @pre `__offset <= size()`
+  //! @pre `__count <= size() - __offset || __count == dynamic_extent`
+  [[nodiscard]] _CCCL_HOST_API ::cuda::std::span<_Tp>
+  subspan(size_type __offset, size_type __count = ::cuda::std::dynamic_extent) noexcept
+  {
+    _CCCL_ASSERT(__offset <= size(), "cuda::buffer::subspan(offset, count): offset out of range");
+    if (__count == ::cuda::std::dynamic_extent)
+    {
+      return {data() + __offset, size() - __offset};
+    }
+    _CCCL_ASSERT(__count <= size() - __offset, "cuda::buffer::subspan(offset, count): count out of range");
+    return {data() + __offset, __count};
+  }
+
+  //! @overload
+  [[nodiscard]] _CCCL_HOST_API ::cuda::std::span<const _Tp>
+  subspan(size_type __offset, size_type __count = ::cuda::std::dynamic_extent) const noexcept
+  {
+    _CCCL_ASSERT(__offset <= size(), "cuda::buffer::subspan(offset, count): offset out of range");
+    if (__count == ::cuda::std::dynamic_extent)
+    {
+      return {data() + __offset, size() - __offset};
+    }
+    _CCCL_ASSERT(__count <= size() - __offset, "cuda::buffer::subspan(offset, count): count out of range");
+    return {data() + __offset, __count};
+  }
+
 #  ifndef _CCCL_DOXYGEN_INVOKED
   //! @brief Returns a pointer to the first element of the buffer. If the buffer
   //! is empty, the returned pointer will be null.

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/access.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/access.cu
@@ -80,6 +80,81 @@ C2H_CCCLRT_TEST("cuda::buffer access and stream", "[container][buffer]", test_ty
     }
   }
 
+  SECTION("cuda::buffer::first")
+  {
+    Buffer buf{stream, resource, {T(1), T(2), T(3), T(4)}};
+    buf.stream().sync();
+
+    auto span = buf.first(2);
+    static_assert(cuda::std::is_same_v<decltype(span), cuda::std::span<T>>);
+    CCCLRT_CHECK(span.size() == 2);
+    CCCLRT_CHECK(span.data() == buf.data());
+
+    auto const_span = cuda::std::as_const(buf).first(2);
+    static_assert(cuda::std::is_same_v<decltype(const_span), cuda::std::span<const T>>);
+    CCCLRT_CHECK(const_span.size() == 2);
+    CCCLRT_CHECK(const_span.data() == buf.data());
+
+    // first(0) is valid
+    auto empty_span = buf.first(0);
+    CCCLRT_CHECK(empty_span.size() == 0);
+
+    // first(size()) returns the whole buffer
+    auto full_span = buf.first(buf.size());
+    CCCLRT_CHECK(full_span.size() == buf.size());
+  }
+
+  SECTION("cuda::buffer::last")
+  {
+    Buffer buf{stream, resource, {T(1), T(2), T(3), T(4)}};
+    buf.stream().sync();
+
+    auto span = buf.last(2);
+    static_assert(cuda::std::is_same_v<decltype(span), cuda::std::span<T>>);
+    CCCLRT_CHECK(span.size() == 2);
+    CCCLRT_CHECK(span.data() == buf.data() + 2);
+
+    auto const_span = cuda::std::as_const(buf).last(2);
+    static_assert(cuda::std::is_same_v<decltype(const_span), cuda::std::span<const T>>);
+    CCCLRT_CHECK(const_span.size() == 2);
+    CCCLRT_CHECK(const_span.data() == buf.data() + 2);
+
+    // last(0) is valid
+    auto empty_span = buf.last(0);
+    CCCLRT_CHECK(empty_span.size() == 0);
+  }
+
+  SECTION("cuda::buffer::subspan")
+  {
+    Buffer buf{stream, resource, {T(1), T(2), T(3), T(4)}};
+    buf.stream().sync();
+
+    // subspan with offset and count
+    auto span = buf.subspan(1, 2);
+    static_assert(cuda::std::is_same_v<decltype(span), cuda::std::span<T>>);
+    CCCLRT_CHECK(span.size() == 2);
+    CCCLRT_CHECK(span.data() == buf.data() + 1);
+
+    auto const_span = cuda::std::as_const(buf).subspan(1, 2);
+    static_assert(cuda::std::is_same_v<decltype(const_span), cuda::std::span<const T>>);
+    CCCLRT_CHECK(const_span.size() == 2);
+    CCCLRT_CHECK(const_span.data() == buf.data() + 1);
+
+    // subspan with offset only (to end)
+    auto tail = buf.subspan(2);
+    CCCLRT_CHECK(tail.size() == 2);
+    CCCLRT_CHECK(tail.data() == buf.data() + 2);
+
+    // subspan(0) returns the whole buffer
+    auto full = buf.subspan(0);
+    CCCLRT_CHECK(full.size() == buf.size());
+    CCCLRT_CHECK(full.data() == buf.data());
+
+    // subspan(size()) returns empty
+    auto empty = buf.subspan(buf.size());
+    CCCLRT_CHECK(empty.size() == 0);
+  }
+
   SECTION("cuda::buffer::memory_resource")
   {
     static_assert(noexcept(cuda::std::declval<const Buffer&>().memory_resource()));


### PR DESCRIPTION
Working on an example I realized it would be nice to create those subspans directly from a buffer without a need to crate a span first.

I could see `first` and `last` to be a bit vague and maybe `subspan` without the others would be sufficient, but I decided to add all 3