### PR TITLE
Make group queries more generic

### DIFF
--- a/cudax/include/cuda/experimental/__hierarchy/groups.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/groups.cuh
@@ -57,10 +57,11 @@ class thread_group
   _Synchronizer __synchronizer_;
 
 public:
-  using unit_type      = thread_level;
-  using level_type     = _Level;
-  using mapping_type   = _Mapping;
-  using hierarchy_type = _Hierarchy;
+  using unit_type             = thread_level;
+  using level_type            = _Level;
+  using mapping_type          = _Mapping;
+  using __mapping_result_type = _MappingResult;
+  using hierarchy_type        = _Hierarchy;
 
   // todo(dabayer): Do we want default behaviour like this, or do we want some kind of cuda::auto_sync_mechanism{} tag?
   _CCCL_TEMPLATE(class _HierarchyLike)
@@ -96,6 +97,12 @@ public:
   [[nodiscard]] _CCCL_DEVICE_API const _Mapping& mapping() const noexcept
   {
     return __mapping_;
+  }
+
+  // todo(dabayer): Do we want to expose mapping result getter?
+  [[nodiscard]] _CCCL_DEVICE_API _MappingResult __mapping_result() const noexcept
+  {
+    return __mapping_result_;
   }
 
   // todo(dabayer): Do we want to expose .arrive() and .wait()? Do we want to implement .sync() using them? Do we want

--- a/cudax/include/cuda/experimental/__hierarchy/queries.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/queries.cuh
@@ -1,0 +1,117 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_EXPERIMENTAL___HIERARCHY_QUERIES_CUH
+#define _CUDA_EXPERIMENTAL___HIERARCHY_QUERIES_CUH
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__hierarchy/queries/count.h>
+#include <cuda/__hierarchy/queries/rank.h>
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__fwd/span.h>
+#include <cuda/std/__type_traits/is_same.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+#if !defined(_CCCL_DOXYGEN_INVOKED)
+
+namespace cuda::experimental
+{
+template <class _Unit, class _Group>
+[[nodiscard]] _CCCL_DEVICE_API constexpr ::cuda::std::size_t __static_count_query_group() noexcept
+{
+  using _GroupUnit          = typename _Group::unit_type;
+  using _GroupMappingResult = typename _Group::__mapping_result_type;
+
+  constexpr auto __group_unit_count = _GroupMappingResult::static_count();
+
+  if constexpr (::cuda::std::is_same_v<_Unit, _GroupUnit>)
+  {
+    return __group_unit_count;
+  }
+  else
+  {
+    using _UnitExts = decltype(_Unit::extents(_GroupUnit{}, ::cuda::std::declval<typename _Group::hierarchy_type>()));
+
+    if constexpr (_UnitExts::rank_dynamic() == 0 && __group_unit_count != ::cuda::std::dynamic_extent)
+    {
+      auto __ret = __group_unit_count;
+      for (::cuda::std::size_t __i = 0; __i < _UnitExts::rank(); ++__i)
+      {
+        __ret *= _UnitExts::static_extent(__i);
+      }
+      return __ret;
+    }
+    else
+    {
+      return ::cuda::std::dynamic_extent;
+    }
+  }
+}
+
+template <class _Tp, class _Unit, class _Group>
+[[nodiscard]] _CCCL_DEVICE_API constexpr _Tp __count_query_group(const _Group& __group) noexcept
+{
+  using _GroupUnit = typename _Group::unit_type;
+
+  // todo(dabayer): This optimization segfaults the compiler.
+  // constexpr auto __static_count = ::cuda::experimental::__static_count_query_group<_Unit, _Group>();
+  // if constexpr (__static_count != ::cuda::std::dynamic_extent)
+  // {
+  //   return static_cast<_Tp>(__static_count);
+  // }
+  // else
+  {
+    const auto __group_unit_count = static_cast<_Tp>(__group.__mapping_result().count());
+    if constexpr (::cuda::std::is_same_v<_Unit, _GroupUnit>)
+    {
+      return __group_unit_count;
+    }
+    else
+    {
+      const auto __unit_count = __count_query<_Unit, _GroupUnit>::template __call<_Tp>(__group.hierarchy());
+      return static_cast<_Tp>(__unit_count * __group_unit_count);
+    }
+  }
+}
+
+template <class _Tp, class _Unit, class _Group>
+[[nodiscard]] _CCCL_DEVICE_API _Tp __rank_query_group(const _Group& __group) noexcept
+{
+  using _GroupUnit = typename _Group::unit_type;
+
+  const auto __group_unit_rank = static_cast<_Tp>(__group.__mapping_result().rank());
+  if constexpr (::cuda::std::is_same_v<_Unit, _GroupUnit>)
+  {
+    return __group_unit_rank;
+  }
+  else
+  {
+    const auto __unit_rank        = __rank_query<_Unit, _GroupUnit>::template __call<_Tp>(__group.hierarchy());
+    const auto __group_unit_count = ::cuda::experimental::__count_query_group<_Tp, _Unit>(__group);
+    return static_cast<_Tp>(__group_unit_rank * __group_unit_count + __unit_rank);
+  }
+}
+} // namespace cuda::experimental
+
+#endif // !_CCCL_DOXYGEN_INVOKED
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_EXPERIMENTAL___HIERARCHY_QUERIES_CUH

--- a/cudax/include/cuda/experimental/__hierarchy/this_group.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/this_group.cuh
@@ -78,6 +78,41 @@ _CCCL_DEVICE_API void __cluster_sync() noexcept
 }
 #  endif // _CCCL_CUDA_COMPILATION()
 
+struct __this_mapping_result
+{
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_group_count() noexcept
+  {
+    return 1;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API unsigned group_count() const noexcept
+  {
+    return 1;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API unsigned group_rank() const noexcept
+  {
+    return 0;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_count() noexcept
+  {
+    return 1;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API unsigned count() const noexcept
+  {
+    return 1;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API unsigned rank() const noexcept
+  {
+    return 0;
+  }
+
+  // todo(dabayer): add method that determines whether the unit is part of the group or not.
+};
+
 // todo: use __hier_ in queries
 template <class _Level, class _Hierarchy>
 class __this_group_base
@@ -86,6 +121,8 @@ class __this_group_base
   static_assert(__is_hierarchy_v<_Hierarchy>);
 
 protected:
+  using __mapping_result_type = __this_mapping_result;
+
   _Hierarchy __hier_;
 
 public:
@@ -138,8 +175,10 @@ class this_thread : __this_group_base<thread_level, _Hierarchy>
   using __base_type = __this_group_base<thread_level, _Hierarchy>;
 
 public:
-  using unit_type      = thread_level;
-  using level_type     = thread_level;
+  using unit_type    = thread_level;
+  using level_type   = thread_level;
+  using mapping_type = void;
+  using typename __base_type::__mapping_result_type;
   using hierarchy_type = _Hierarchy;
 
   using __base_type::__base_type;
@@ -159,7 +198,12 @@ public:
 
   _CCCL_DEVICE_API void sync_aligned() noexcept {}
 
-  [[nodiscard]] _CCCL_DEVICE_API const _Hierarchy& hierarchy() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API constexpr __mapping_result_type __mapping_result() const noexcept
+  {
+    return {};
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr const _Hierarchy& hierarchy() const noexcept
   {
     return __base_type::__hier_;
   }
@@ -183,8 +227,10 @@ class this_warp : __this_group_base<warp_level, _Hierarchy>
   using __base_type = __this_group_base<warp_level, _Hierarchy>;
 
 public:
-  using unit_type      = warp_level;
-  using level_type     = warp_level;
+  using unit_type    = warp_level;
+  using level_type   = warp_level;
+  using mapping_type = void;
+  using typename __base_type::__mapping_result_type;
   using hierarchy_type = _Hierarchy;
 
   using __base_type::__base_type;
@@ -210,7 +256,12 @@ public:
     ::__syncwarp();
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API const _Hierarchy& hierarchy() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API constexpr __mapping_result_type __mapping_result() const noexcept
+  {
+    return {};
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr const _Hierarchy& hierarchy() const noexcept
   {
     return __base_type::__hier_;
   }
@@ -235,8 +286,10 @@ class this_block : __this_group_base<block_level, _Hierarchy>
   using __base_type = __this_group_base<block_level, _Hierarchy>;
 
 public:
-  using unit_type      = block_level;
-  using level_type     = block_level;
+  using unit_type    = block_level;
+  using level_type   = block_level;
+  using mapping_type = void;
+  using typename __base_type::__mapping_result_type;
   using hierarchy_type = _Hierarchy;
 
   using __base_type::__base_type;
@@ -261,7 +314,12 @@ public:
     ::cuda::experimental::__block_sync<true>();
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API const _Hierarchy& hierarchy() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API constexpr __mapping_result_type __mapping_result() const noexcept
+  {
+    return {};
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr const _Hierarchy& hierarchy() const noexcept
   {
     return __base_type::__hier_;
   }
@@ -284,8 +342,10 @@ class this_cluster : __this_group_base<cluster_level, _Hierarchy>
   using __base_type = __this_group_base<cluster_level, _Hierarchy>;
 
 public:
-  using unit_type      = cluster_level;
-  using level_type     = cluster_level;
+  using unit_type    = cluster_level;
+  using level_type   = cluster_level;
+  using mapping_type = void;
+  using typename __base_type::__mapping_result_type;
   using hierarchy_type = _Hierarchy;
 
   using __base_type::__base_type;
@@ -324,7 +384,12 @@ public:
     }
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API const _Hierarchy& hierarchy() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API constexpr __mapping_result_type __mapping_result() const noexcept
+  {
+    return {};
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr const _Hierarchy& hierarchy() const noexcept
   {
     return __base_type::__hier_;
   }
@@ -418,8 +483,10 @@ class this_grid : __this_group_base<grid_level, _Hierarchy>
 #  endif // _CCCL_CUDA_COMPILATION()
 
 public:
-  using unit_type      = grid_level;
-  using level_type     = grid_level;
+  using unit_type    = grid_level;
+  using level_type   = grid_level;
+  using mapping_type = void;
+  using typename __base_type::__mapping_result_type;
   using hierarchy_type = _Hierarchy;
 
   using __base_type::__base_type;
@@ -439,7 +506,12 @@ public:
     __sync_impl<true>();
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API const _Hierarchy& hierarchy() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API constexpr __mapping_result_type __mapping_result() const noexcept
+  {
+    return {};
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr const _Hierarchy& hierarchy() const noexcept
   {
     return __base_type::__hier_;
   }

--- a/cudax/include/cuda/experimental/hierarchy.cuh
+++ b/cudax/include/cuda/experimental/hierarchy.cuh
@@ -26,6 +26,7 @@
 #include <cuda/experimental/__hierarchy/groups.cuh>
 #include <cuda/experimental/__hierarchy/implicit_hierarchy.cuh>
 #include <cuda/experimental/__hierarchy/mappings.cuh>
+#include <cuda/experimental/__hierarchy/queries.cuh>
 #include <cuda/experimental/__hierarchy/synchronizers.cuh>
 #include <cuda/experimental/__hierarchy/this_group.cuh>
 

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -129,6 +129,7 @@ cudax_add_catch2_test(test_target algorithm
 cudax_add_catch2_test(test_target hierarchy_groups
     hierarchy/group.cu
 )
+target_compile_definitions(${test_target} PUBLIC _CUDAX_HIERARCHY)
 
 if (cudax_ENABLE_CUFILE)
   cudax_add_catch2_test(test_target cufile.driver_attributes

--- a/cudax/test/hierarchy/group.cu
+++ b/cudax/test/hierarchy/group.cu
@@ -8,8 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define _CUDAX_HIERARCHY
-
 #include <cub/block/block_reduce.cuh>
 #include <cub/thread/thread_reduce.cuh>
 #include <cub/warp/warp_reduce.cuh>
@@ -193,8 +191,12 @@ __device__ void test_cooperative_algorithm(Group& group)
 }
 
 template <class Hierarchy>
-__device__ void test_queries(cudax::this_thread<Hierarchy>& group)
+__device__ void test_this_queries(const cudax::this_thread<Hierarchy>& group)
 {
+  // todo(dabayer): These queries end up in `error: expression must have a constant value`, when group is taken by
+  // reference. Can we find a solution that works without copying the group?
+  // static_assert(cuda::gpu_thread.static_count(group) == 1);
+
   CUDAX_REQUIRE(cuda::gpu_thread.count(group) == 1);
   CUDAX_REQUIRE(group.count(cuda::warp) == cuda::gpu_thread.count(cuda::warp));
   CUDAX_REQUIRE(group.count(cuda::block) == cuda::gpu_thread.count(cuda::block));
@@ -213,8 +215,13 @@ __device__ void test_queries(cudax::this_thread<Hierarchy>& group)
 }
 
 template <class Hierarchy>
-__device__ void test_queries(cudax::this_warp<Hierarchy>& group)
+__device__ void test_this_queries(const cudax::this_warp<Hierarchy>& group)
 {
+  // todo(dabayer): These queries end up in `error: expression must have a constant value`, when group is taken by
+  // reference. Can we find a solution that works without copying the group?
+  // static_assert(cuda::gpu_thread.static_count(group) == cuda::gpu_thread.static_count(cuda::warp,
+  // group.hierarchy())); static_assert(cuda::warp.static_count(group) == 1);
+
   CUDAX_REQUIRE(cuda::gpu_thread.count(group) == cuda::gpu_thread.count(cuda::warp));
   CUDAX_REQUIRE(cuda::warp.count(group) == 1);
   CUDAX_REQUIRE(group.count(cuda::block) == cuda::warp.count(cuda::block));
@@ -235,8 +242,14 @@ __device__ void test_queries(cudax::this_warp<Hierarchy>& group)
 }
 
 template <class Hierarchy>
-__device__ void test_queries(cudax::this_block<Hierarchy>& group)
+__device__ void test_this_queries(const cudax::this_block<Hierarchy>& group)
 {
+  // todo(dabayer): These queries end up in `error: expression must have a constant value`, when group is taken by
+  // reference. Can we find a solution that works without copying the group?
+  // static_assert(cuda::gpu_thread.static_count(group) == cuda::gpu_thread.static_count(cuda::block,
+  // group.hierarchy())); static_assert(cuda::warp.static_count(group) == cuda::warp.static_count(cuda::block,
+  // group.hierarchy())); static_assert(cuda::block.static_count(group) == 1);
+
   CUDAX_REQUIRE(cuda::gpu_thread.count(group) == cuda::gpu_thread.count(cuda::block));
   CUDAX_REQUIRE(cuda::warp.count(group) == cuda::warp.count(cuda::block));
   CUDAX_REQUIRE(cuda::block.count(group) == 1);
@@ -259,8 +272,15 @@ __device__ void test_queries(cudax::this_block<Hierarchy>& group)
 }
 
 template <class Hierarchy>
-__device__ void test_queries(cudax::this_cluster<Hierarchy>& group)
+__device__ void test_this_queries(const cudax::this_cluster<Hierarchy>& group)
 {
+  // todo(dabayer): These queries end up in `error: expression must have a constant value`, when group is taken by
+  // reference. Can we find a solution that works without copying the group?
+  // static_assert(cuda::gpu_thread.static_count(group) == cuda::gpu_thread.static_count(cuda::cluster,
+  // group.hierarchy())); static_assert(cuda::warp.static_count(group) == cuda::warp.static_count(cuda::cluster,
+  // group.hierarchy())); static_assert(cuda::block.static_count(group) == cuda::block.static_count(cuda::cluster,
+  // group.hierarchy())); static_assert(cuda::cluster.static_count(group) == 1);
+
   CUDAX_REQUIRE(cuda::gpu_thread.count(group) == cuda::gpu_thread.count(cuda::cluster));
   CUDAX_REQUIRE(cuda::warp.count(group) == cuda::warp.count(cuda::cluster));
   CUDAX_REQUIRE(cuda::block.count(group) == cuda::block.count(cuda::cluster));
@@ -285,8 +305,16 @@ __device__ void test_queries(cudax::this_cluster<Hierarchy>& group)
 }
 
 template <class Hierarchy>
-__device__ void test_queries(cudax::this_grid<Hierarchy>& group)
+__device__ void test_this_queries(const cudax::this_grid<Hierarchy>& group)
 {
+  // todo(dabayer): These queries end up in `error: expression must have a constant value`, when group is taken by
+  // reference. Can we find a solution that works without copying the group?
+  // static_assert(cuda::gpu_thread.static_count(group) == cuda::gpu_thread.static_count(cuda::grid,
+  // group.hierarchy())); static_assert(cuda::warp.static_count(group) == cuda::warp.static_count(cuda::grid,
+  // group.hierarchy())); static_assert(cuda::block.static_count(group) == cuda::block.static_count(cuda::grid,
+  // group.hierarchy())); static_assert(cuda::cluster.static_count(group) == cuda::cluster.static_count(cuda::grid,
+  // group.hierarchy())); static_assert(cuda::grid.static_count(group) == 1);
+
   CUDAX_REQUIRE(cuda::gpu_thread.count(group) == cuda::gpu_thread.count(cuda::grid));
   CUDAX_REQUIRE(cuda::warp.count(group) == cuda::warp.count(cuda::grid));
   CUDAX_REQUIRE(cuda::block.count(group) == cuda::block.count(cuda::grid));
@@ -360,7 +388,7 @@ __device__ void test_this_group(const Config& config)
     test_common_properties<Level, Level>(implicit_hierarchy, group);
     // todo: implement cooperative algorithm that supports dynamic extents
     // test_cooperative_algorithm(group);
-    test_queries(group);
+    test_this_queries(group);
   }
 
   // Test construction from kernel_config.
@@ -377,11 +405,27 @@ __device__ void test_this_group(const Config& config)
     {
       test_cooperative_algorithm(group);
     }
-    test_queries(group);
+    test_this_queries(group);
   }
 
   // Test construction from CG equivalents
   test_cg_interop<Level>(implicit_hierarchy);
+}
+
+template <class Level, cuda::std::size_t N, class Hierarchy, class Sync>
+__device__ void test_queries(const cudax::thread_group<Level, cudax::group_by<N>, Hierarchy, Sync>& group)
+{
+  // todo(dabayer): These queries end up in `error: expression must have a constant value`, when group is taken by
+  // reference. Can we find a solution that works without copying the group?
+  // static_assert(cuda::gpu_thread.static_count(group) == N);
+
+  const auto count_ref = group.mapping().n();
+  const auto rank_ref  = cuda::gpu_thread.rank(Level{}, group.hierarchy()) % count_ref;
+
+  CUDAX_REQUIRE(cuda::gpu_thread.count(group) == count_ref);
+  CUDAX_REQUIRE(cuda::gpu_thread.rank(group) == rank_ref);
+  CUDAX_REQUIRE(cuda::gpu_thread.is_root_rank(group) == (rank_ref == 0));
+  CUDAX_REQUIRE(cuda::gpu_thread.is_part_of(group));
 }
 
 template <class Unit, template <class...> class GroupTempl, class Level, class Config, cuda::std::size_t N>
@@ -398,6 +442,7 @@ __device__ void test_group_by_group(const Config& config)
         decltype(group)>);
 
     test_common_properties<Unit, Level>(config.hierarchy(), group);
+    test_queries<Level>(group);
   }
 
   if constexpr (cuda::std::is_same_v<Level, cuda::block_level>)
@@ -428,13 +473,15 @@ __device__ void test_group_by_group(const Config& config)
   // Test dynamically specified group size
   // if constexpr (cuda::std::is_same_v<Level, cuda::warp_level>)
   // {
-  //   GroupTempl group{Level{}, cudax::group_by{static_cast<unsigned>(N)}, config};
+  //   using Mapping = cudax::group_by<cuda::std::dynamic_extent>;
+
+  //   GroupTempl group{Level{}, Mapping{static_cast<unsigned>(N)}, config};
   //   static_assert(
-  //     cuda::std::is_same_v<GroupTempl<Level, typename Config::hierarchy_type,
-  //     cudax::group_by<cuda::std::dynamic_extent>>,
-  //                          decltype(group)>);
+  //     cuda::std::is_same_v<GroupTempl<Level, Mapping, typename Config::hierarchy_type,
+  //     cudax::__syncwarp_synchronizer<Unit, Level, Mapping>>, decltype(group)>);
 
   //   test_common_properties<Unit, Level>(config.hierarchy(), group);
+  //   test_queries<Level>(group);
   // }
 }
 
@@ -468,7 +515,7 @@ struct TestKernel
     test_this_group<cuda::grid_level, cudax::this_grid>(config);
 
     // todo: allow this once hierarchy is queryable for missing levels
-    // test_group_by_group<cuda::thread_level, cudax::thread_group, cuda::warp_level>(config);
+    test_group_by_group<cuda::thread_level, cudax::thread_group, cuda::warp_level>(config);
     test_group_by_group<cuda::thread_level, cudax::thread_group, cuda::block_level>(config);
     if constexpr (Hierarchy::has_level(cuda::cluster))
     {

--- a/libcudacxx/include/cuda/__hierarchy/hierarchy_level_base.h
+++ b/libcudacxx/include/cuda/__hierarchy/hierarchy_level_base.h
@@ -36,7 +36,9 @@
 #  include <cuda/std/__type_traits/is_integer.h>
 
 #  if defined(_CUDAX_HIERARCHY)
+#    include <cuda/experimental/__hierarchy/concepts.cuh>
 #    include <cuda/experimental/__hierarchy/fwd.cuh>
+#    include <cuda/experimental/__hierarchy/queries.cuh>
 #  endif // _CUDAX_HIERARCHY
 
 #  include <cuda/std/__cccl/prologue.h>
@@ -169,76 +171,52 @@ struct hierarchy_level_base
 #  endif // _CCCL_CUDA_COMPILATION()
 
 #  if defined(_CUDAX_HIERARCHY)
+#    if _CCCL_CUDA_COMPILATION()
+
+  _CCCL_TEMPLATE(class _Group)
+  _CCCL_REQUIRES(::cuda::experimental::group<_Group>)
+  [[nodiscard]] _CCCL_API static constexpr ::cuda::std::size_t static_count(const _Group&) noexcept
+  {
+    return ::cuda::experimental::__static_count_query_group<_Level, _Group>();
+  }
+
+  _CCCL_TEMPLATE(class _Group)
+  _CCCL_REQUIRES(::cuda::experimental::group<_Group>)
+  [[nodiscard]] _CCCL_API static constexpr auto count(const _Group& __group) noexcept
+  {
+    return count_as<__default_1d_query_type<typename _Group::unit_type>>(__group);
+  }
+
+  _CCCL_TEMPLATE(class _Group)
+  _CCCL_REQUIRES(::cuda::experimental::group<_Group>)
+  [[nodiscard]] _CCCL_API static auto rank(const _Group& __group) noexcept
+  {
+    return rank_as<__default_1d_query_type<typename _Group::unit_type>>(__group);
+  }
+
   _CCCL_TEMPLATE(class _Tp, class _Group)
-  _CCCL_REQUIRES(
-    ::cuda::std::__cccl_is_integer_v<_Tp> _CCCL_AND ::cuda::experimental::__is_this_hierarchy_group_v<_Group>)
+  _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp> _CCCL_AND ::cuda::experimental::group<_Group>)
   [[nodiscard]] _CCCL_API static constexpr _Tp count_as(const _Group& __group) noexcept
   {
-    if constexpr (::cuda::std::is_same_v<_Level, typename _Group::level_type>)
-    {
-      return _Tp{1};
-    }
-    else
-    {
-      return _Level::template count_as<_Tp>(typename _Group::level_type{}, __group.hierarchy());
-    }
+    return ::cuda::experimental::__count_query_group<_Tp, _Level>(__group);
   }
 
-  _CCCL_TEMPLATE(class _Group)
-  _CCCL_REQUIRES(::cuda::experimental::__is_this_hierarchy_group_v<_Group>)
-  [[nodiscard]] _CCCL_API static constexpr ::cuda::std::size_t count(const _Group& __group) noexcept
-  {
-    if constexpr (::cuda::std::is_same_v<_Level, typename _Group::level_type>)
-    {
-      return 1;
-    }
-    else
-    {
-      return _Level::count(typename _Group::level_type{}, __group.hierarchy());
-    }
-  }
-
-#    if _CCCL_CUDA_COMPILATION()
   _CCCL_TEMPLATE(class _Tp, class _Group)
-  _CCCL_REQUIRES(
-    ::cuda::std::__cccl_is_integer_v<_Tp> _CCCL_AND ::cuda::experimental::__is_this_hierarchy_group_v<_Group>)
-  [[nodiscard]] _CCCL_API static constexpr _Tp rank_as(const _Group& __group) noexcept
+  _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp> _CCCL_AND ::cuda::experimental::group<_Group>)
+  [[nodiscard]] _CCCL_API static _Tp rank_as(const _Group& __group) noexcept
   {
-    if constexpr (::cuda::std::is_same_v<_Level, typename _Group::level_type>)
-    {
-      return _Tp{0};
-    }
-    else
-    {
-      // todo: Pass __group.hierarchy() to the query.
-      return _Level::template rank_as<_Tp>(typename _Group::level_type{} /*, __group.hierarchy()*/);
-    }
+    return ::cuda::experimental::__rank_query_group<_Tp, _Level>(__group);
   }
 
   _CCCL_TEMPLATE(class _Group)
-  _CCCL_REQUIRES(::cuda::experimental::__is_this_hierarchy_group_v<_Group>)
-  [[nodiscard]] _CCCL_API static constexpr ::cuda::std::size_t rank(const _Group& __group) noexcept
-  {
-    if constexpr (::cuda::std::is_same_v<_Level, typename _Group::level_type>)
-    {
-      return 0;
-    }
-    else
-    {
-      // todo: Pass __group.hierarchy() to the query.
-      return _Level::rank(typename _Group::level_type{} /*, __group.hierarchy()*/);
-    }
-  }
-
-  _CCCL_TEMPLATE(class _Group)
-  _CCCL_REQUIRES(::cuda::experimental::__is_this_hierarchy_group_v<_Group>)
-  [[nodiscard]] _CCCL_API static constexpr bool is_root_rank(const _Group& __group) noexcept
+  _CCCL_REQUIRES(::cuda::experimental::group<_Group>)
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr bool is_root_rank(const _Group& __group) noexcept
   {
     return _Level::rank(__group) == 0;
   }
 
   _CCCL_TEMPLATE(class _Group)
-  _CCCL_REQUIRES(::cuda::experimental::__is_this_hierarchy_group_v<_Group>)
+  _CCCL_REQUIRES(::cuda::experimental::group<_Group>)
   [[nodiscard]] _CCCL_API static constexpr bool is_part_of(const _Group& __group) noexcept
   {
     return true;


### PR DESCRIPTION
This PR extents `unit.query(group)` queries and makes them more generic, so they don't work with _this_ groups exclusively, but with any group independent on the group's mapping.

I will make another PR that implements query base for groups that will allow `group.query(level)` queries.