### PR TITLE
Fix pointer_traits specializations to use alias template for rebind

### DIFF
--- a/thrust/testing/device_ptr.cu
+++ b/thrust/testing/device_ptr.cu
@@ -253,3 +253,30 @@ void TestToAddress()
   ASSERT_EQUAL(last - first, 3);
 }
 DECLARE_VECTOR_UNITTEST(TestToAddress);
+
+// Verify that cuda::std::pointer_traits<device_ptr<T>>::rebind produces the
+// correct pointer type, not a nested struct. This is required for
+// cuda::std::allocator_traits to correctly compute void_pointer when an
+// allocator uses device_ptr as its pointer type (e.g. rmm::mr::thrust_allocator).
+// See GitHub issue #8485.
+struct device_char_allocator
+{
+  using value_type = char;
+  using pointer    = thrust::device_ptr<char>;
+  pointer allocate(std::size_t n);
+  void deallocate(pointer p, std::size_t);
+};
+
+// pointer_traits::rebind should produce a pointer type, not a rebind struct.
+static_assert(
+  cuda::std::is_same_v<cuda::std::pointer_traits<thrust::device_ptr<char>>::rebind<void>, thrust::device_ptr<void>>,
+  "pointer_traits<device_ptr<char>>::rebind<void> should be device_ptr<void>");
+static_assert(
+  cuda::std::is_same_v<cuda::std::pointer_traits<thrust::device_ptr<int>>::rebind<float>, thrust::device_ptr<float>>,
+  "pointer_traits<device_ptr<int>>::rebind<float> should be device_ptr<float>");
+
+// allocator_traits::void_pointer must resolve to device_ptr<void> for allocators
+// whose pointer type is device_ptr<T>.
+static_assert(
+  cuda::std::is_same_v<cuda::std::allocator_traits<device_char_allocator>::void_pointer, thrust::device_ptr<void>>,
+  "allocator_traits::void_pointer should be device_ptr<void> for device_ptr-based allocators");

--- a/thrust/thrust/detail/pointer.h
+++ b/thrust/thrust/detail/pointer.h
@@ -405,10 +405,7 @@ struct pointer_traits<Pointer, void_t<typename Pointer::raw_pointer>>
   using difference_type = ptrdiff_t;
 
   template <typename U>
-  struct rebind
-  {
-    using other = typename THRUST_NS_QUALIFIER::detail::rebind_pointer<pointer, U>::type;
-  };
+  using rebind = typename THRUST_NS_QUALIFIER::detail::rebind_pointer<pointer, U>::type;
 
   // Backwards compatibility with thrust::detail::pointer_traits
   using raw_pointer = typename pointer::raw_pointer;

--- a/thrust/thrust/device_ptr.h
+++ b/thrust/thrust/device_ptr.h
@@ -237,10 +237,7 @@ struct pointer_traits<THRUST_NS_QUALIFIER::device_ptr<T>>
   using difference_type = ptrdiff_t;
 
   template <typename U>
-  struct rebind
-  {
-    using other = typename THRUST_NS_QUALIFIER::detail::rebind_pointer<pointer, U>::type;
-  };
+  using rebind = typename THRUST_NS_QUALIFIER::detail::rebind_pointer<pointer, U>::type;
 
   // Backwards compatibility with thrust::detail::pointer_traits
   using raw_pointer = typename pointer::raw_pointer;

--- a/thrust/thrust/iterator/detail/normal_iterator.h
+++ b/thrust/thrust/iterator/detail/normal_iterator.h
@@ -70,10 +70,7 @@ struct pointer_traits<THRUST_NS_QUALIFIER::detail::normal_iterator<Pointer>>
   using difference_type = ptrdiff_t;
 
   template <typename U>
-  struct rebind
-  {
-    using other = typename THRUST_NS_QUALIFIER::detail::rebind_pointer<pointer, U>::type;
-  };
+  using rebind = typename THRUST_NS_QUALIFIER::detail::rebind_pointer<pointer, U>::type;
 
   [[nodiscard]] _CCCL_API inline static pointer pointer_to(Pointer& r) noexcept(noexcept(::cuda::std::addressof(r)))
   {


### PR DESCRIPTION
## Description

closes #8485

PR #7439 introduced `cuda::std::pointer_traits` specializations for `thrust::device_ptr<T>`, `thrust::pointer<...>`, and `thrust::detail::normal_iterator<...>`. All three defined `rebind` as a nested struct:

```cpp
template <typename U>
struct rebind {
  using other = typename thrust::detail::rebind_pointer<pointer, U>::type;
};
```

However, `cuda::std::allocator_traits` computes `void_pointer` as `pointer_traits<Ptr>::template rebind<void>`, which expects `rebind` to be an alias template (as in the primary `__pointer_traits_impl`). With the struct form, `rebind<void>` resolves to the struct type itself instead of `device_ptr<void>`, breaking any allocator whose pointer type is a thrust device pointer.

This broke all RAPIDS third-party builds (cugraph, cudf, cuvs) in [nightly CI](https://github.com/NVIDIA/cccl/actions/runs/24491505141), since RMM's `thrust_allocator<char>` uses `device_ptr<char>` as its pointer type.

The fix changes all three specializations to use an alias template:

```cpp
template <typename U>
using rebind = typename THRUST_NS_QUALIFIER::detail::rebind_pointer<pointer, U>::type;
```

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.