### PR TITLE
[thrust] Fix pointer_traits::rebind to use alias template (fixes allocator_traits::void_pointer)

### DIFF
--- a/thrust/testing/device_ptr.cu
+++ b/thrust/testing/device_ptr.cu
@@ -2,6 +2,8 @@
 #include <thrust/device_vector.h>
 
 #include <cuda/std/iterator>
+#include <cuda/std/memory>
+#include <cuda/std/type_traits>
 
 #include <iterator>
 
@@ -253,3 +255,29 @@ void TestToAddress()
   ASSERT_EQUAL(last - first, 3);
 }
 DECLARE_VECTOR_UNITTEST(TestToAddress);
+
+// Verify that pointer_traits<device_ptr<T>>::rebind<U> is an alias template,
+// not a struct, so that allocator_traits::void_pointer is computed correctly.
+// Regression test for https://github.com/NVIDIA/cccl/issues/8485
+struct TestPointerTraitsRebind
+{
+  using pointer    = thrust::device_ptr<char>;
+  using value_type = char;
+  using traits     = cuda::std::pointer_traits<pointer>;
+  // rebind<U> must yield device_ptr<U> directly (alias template form)
+  static_assert(cuda::std::is_same_v<traits::rebind<void>, thrust::device_ptr<void>>);
+  static_assert(cuda::std::is_same_v<traits::rebind<int>, thrust::device_ptr<int>>);
+};
+
+// Verify that allocator_traits::void_pointer resolves correctly
+// when the allocator's pointer is thrust::device_ptr<T>
+struct DeviceCharAllocator
+{
+  using value_type = char;
+  using pointer    = thrust::device_ptr<char>;
+  pointer allocate(::std::size_t n);
+  void deallocate(pointer p, ::std::size_t);
+};
+static_assert(
+  cuda::std::is_same_v<cuda::std::allocator_traits<DeviceCharAllocator>::void_pointer, thrust::device_ptr<void>>,
+  "void_pointer should be device_ptr<void>");

--- a/thrust/thrust/detail/pointer.h
+++ b/thrust/thrust/detail/pointer.h
@@ -405,10 +405,7 @@ struct pointer_traits<Pointer, void_t<typename Pointer::raw_pointer>>
   using difference_type = ptrdiff_t;
 
   template <typename U>
-  struct rebind
-  {
-    using other = typename THRUST_NS_QUALIFIER::detail::rebind_pointer<pointer, U>::type;
-  };
+  using rebind = typename THRUST_NS_QUALIFIER::detail::rebind_pointer<pointer, U>::type;
 
   // Backwards compatibility with thrust::detail::pointer_traits
   using raw_pointer = typename pointer::raw_pointer;

--- a/thrust/thrust/device_ptr.h
+++ b/thrust/thrust/device_ptr.h
@@ -237,10 +237,7 @@ struct pointer_traits<THRUST_NS_QUALIFIER::device_ptr<T>>
   using difference_type = ptrdiff_t;
 
   template <typename U>
-  struct rebind
-  {
-    using other = typename THRUST_NS_QUALIFIER::detail::rebind_pointer<pointer, U>::type;
-  };
+  using rebind = typename THRUST_NS_QUALIFIER::detail::rebind_pointer<pointer, U>::type;
 
   // Backwards compatibility with thrust::detail::pointer_traits
   using raw_pointer = typename pointer::raw_pointer;

--- a/thrust/thrust/iterator/detail/normal_iterator.h
+++ b/thrust/thrust/iterator/detail/normal_iterator.h
@@ -70,10 +70,7 @@ struct pointer_traits<THRUST_NS_QUALIFIER::detail::normal_iterator<Pointer>>
   using difference_type = ptrdiff_t;
 
   template <typename U>
-  struct rebind
-  {
-    using other = typename THRUST_NS_QUALIFIER::detail::rebind_pointer<pointer, U>::type;
-  };
+  using rebind = typename THRUST_NS_QUALIFIER::detail::rebind_pointer<pointer, U>::type;
 
   [[nodiscard]] _CCCL_API inline static pointer pointer_to(Pointer& r) noexcept(noexcept(::cuda::std::addressof(r)))
   {


### PR DESCRIPTION
## What

Fix `cuda::std::pointer_traits` specializations for thrust smart pointers (`device_ptr<T>`, generic thrust `Pointer`, and `normal_iterator<Pointer>`) to use an **alias template** form for `rebind` instead of a nested struct.

**Before (broken):**
```cpp
template <typename U>
struct rebind {
  using other = typename THRUST_NS_QUALIFIER::detail::rebind_pointer<pointer, U>::type;
};
```

**After (fixed):**
```cpp
template <typename U>
using rebind = typename THRUST_NS_QUALIFIER::detail::rebind_pointer<pointer, U>::type;
```

## Why

PR #7439 introduced explicit `cuda::std::pointer_traits` specializations for thrust smart pointers. Those specializations defined `rebind` as a nested struct (C++03 allocator convention) rather than an alias template (C++11 pointer_traits convention).

`cuda::std::allocator_traits` computes `void_pointer` and `const_pointer` via:
```cpp
using type = typename pointer_traits<_Ptr>::template rebind<void>;
```
This expects `rebind<U>` to yield the type directly (alias template form). With the struct form, `rebind<void>` resolves to the struct type itself — not `device_ptr<void>` — causing a type mismatch:

```
error: no suitable user-defined conversion from
  "thrust::device_ptr<char>"
  to "cuda::std::pointer_traits<thrust::device_ptr<char>, void>::rebind<void>" exists
```

This breaks any allocator whose `pointer` type is a thrust smart pointer, most notably RMM's `thrust_allocator<char>` which is used pervasively across RAPIDS. All three RAPIDS third-party nightly CI jobs were failing due to this regression.

## How

Change all three `cuda::std::pointer_traits` specializations in thrust headers:
- `thrust/thrust/device_ptr.h` — specialization for `thrust::device_ptr<T>`
- `thrust/thrust/detail/pointer.h` — generic specialization for any `Pointer` with `raw_pointer`
- `thrust/thrust/iterator/detail/normal_iterator.h` — specialization for `normal_iterator<Pointer>`

The internal `thrust::detail::pointer_traits` (from `thrust/detail/type_traits/pointer_traits.h`) continues to use the `struct rebind { using other = ...; }` form since it is used internally with `::other` syntax — this is not affected.

## Test

Added compile-time static assertions in `thrust/testing/device_ptr.cu`:
```cpp
static_assert(is_same_v<pointer_traits<device_ptr<char>>::rebind<void>, device_ptr<void>>);
static_assert(is_same_v<allocator_traits<DeviceCharAllocator>::void_pointer, device_ptr<void>>);
```

Verified: static_assert tests compile with MSVC 19.50 / CUDA 12.9 / RTX 5070 (sm_89)

Fixes #8485