### PR TITLE
Replace `detail::scan::dispatch` by CUB's public API

### DIFF
--- a/cub/benchmarks/bench/scan/applications/P1/log-cdf-from-log-pdfs.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/log-cdf-from-log-pdfs.cu
@@ -101,13 +101,11 @@ static void inclusive_scan(nvbench::state& state, nvbench::type_list<FloatingPoi
 {
   static_assert(cuda::std::is_floating_point_v<FloatingPointT>);
 
-  using wrapped_init_t = cub::NullType;
-  using value_t        = FloatingPointT;
-  using input_t        = const value_t*;
-  using output_t       = value_t*;
-  using offset_t       = cub::detail::choose_offset_t<OffsetT>;
-  using op_t           = impl::log_add_plus;
-  using accum_t        = value_t;
+  using value_t  = FloatingPointT;
+  using input_t  = const value_t*;
+  using output_t = value_t*;
+  using op_t     = impl::log_add_plus;
+  using accum_t  = value_t;
 
   const auto elements = static_cast<std::size_t>(state.get_int64("Elements{io}"));
   auto mu             = static_cast<value_t>(state.get_float64("Mu{io}"));
@@ -135,40 +133,24 @@ static void inclusive_scan(nvbench::state& state, nvbench::type_list<FloatingPoi
   state.add_global_memory_reads<value_t>(elements, "Size");
   state.add_global_memory_writes<value_t>(elements);
 
-  size_t tmp_size;
-  cub::detail::scan::dispatch_with_accum<accum_t>(
-    nullptr,
-    tmp_size,
-    d_input,
-    d_output,
-    op_t{},
-    wrapped_init_t{},
-    input.size(),
-    bench_stream
-#if !TUNE_BASE
-    ,
-    policy_selector<accum_t>{}
-#endif // !TUNE_BASE
-  );
-
-  thrust::device_vector<nvbench::uint8_t> tmp(tmp_size, thrust::no_init);
-  nvbench::uint8_t* d_tmp = thrust::raw_pointer_cast(tmp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::scan::dispatch_with_accum<accum_t>(
-      d_tmp,
-      tmp_size,
+    auto env = cub_bench_env(
+      alloc,
+      launch
+#if !TUNE_BASE
+      ,
+      cuda::execution::__tune(policy_selector<accum_t>{})
+#endif // !TUNE_BASE
+    );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceScan::InclusiveScan,
+      "InclusiveScan failed",
       d_input,
       d_output,
       op_t{},
-      wrapped_init_t{},
-      input.size(),
-      launch.get_stream()
-#if !TUNE_BASE
-        ,
-      policy_selector<accum_t>{}
-#endif // !TUNE_BASE
-    );
+      static_cast<OffsetT>(input.size()),
+      env);
   });
 
   // for validation, use

--- a/cub/benchmarks/bench/scan/applications/P1/log-cdf-from-log-pdfs.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/log-cdf-from-log-pdfs.cu
@@ -101,11 +101,11 @@ static void inclusive_scan(nvbench::state& state, nvbench::type_list<FloatingPoi
 {
   static_assert(cuda::std::is_floating_point_v<FloatingPointT>);
 
-  using value_t  = FloatingPointT;
-  using input_t  = const value_t*;
-  using output_t = value_t*;
-  using op_t     = impl::log_add_plus;
-  using accum_t  = value_t;
+  using value_t                  = FloatingPointT;
+  using input_t                  = const value_t*;
+  using output_t                 = value_t*;
+  using op_t                     = impl::log_add_plus;
+  [[maybe_unused]] using accum_t = value_t;
 
   const auto elements = static_cast<std::size_t>(state.get_int64("Elements{io}"));
   auto mu             = static_cast<value_t>(state.get_float64("Mu{io}"));

--- a/cub/benchmarks/bench/scan/applications/P1/log-cdf-from-log-pdfs.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/log-cdf-from-log-pdfs.cu
@@ -140,7 +140,7 @@ static void inclusive_scan(nvbench::state& state, nvbench::type_list<FloatingPoi
       launch
 #if !TUNE_BASE
       ,
-      cuda::execution::__tune(policy_selector<accum_t>{})
+      cuda::execution::tune(policy_selector<accum_t>{})
 #endif // !TUNE_BASE
     );
     _CCCL_TRY_CUDA_API(

--- a/cub/benchmarks/bench/scan/applications/P1/log-cdf-from-log-pdfs.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/log-cdf-from-log-pdfs.cu
@@ -105,7 +105,7 @@ static void inclusive_scan(nvbench::state& state, nvbench::type_list<FloatingPoi
   using input_t                  = const value_t*;
   using output_t                 = value_t*;
   using op_t                     = impl::log_add_plus;
-  [[maybe_unused]] using accum_t = value_t;
+  using accum_t [[maybe_unused]] = value_t;
 
   const auto elements = static_cast<std::size_t>(state.get_int64("Elements{io}"));
   auto mu             = static_cast<value_t>(state.get_float64("Mu{io}"));

--- a/cub/benchmarks/bench/scan/applications/P1/non-commutative-bicyclic-monoid.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/non-commutative-bicyclic-monoid.cu
@@ -90,7 +90,7 @@ static void inclusive_scan(nvbench::state& state, nvbench::type_list<T, OffsetT>
   static_assert(cuda::std::is_integral_v<T> && cuda::std::is_unsigned_v<T>, "Unsigned integral type should be used");
   using pair_t                   = cuda::std::pair<T, T>;
   using op_t                     = impl::bicyclic_monoid_op<T>;
-  [[maybe_unused]] using accum_t = pair_t;
+  using accum_t [[maybe_unused]] = pair_t;
 
   const auto elements = static_cast<std::size_t>(state.get_int64("Elements{io}"));
 

--- a/cub/benchmarks/bench/scan/applications/P1/non-commutative-bicyclic-monoid.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/non-commutative-bicyclic-monoid.cu
@@ -123,7 +123,7 @@ static void inclusive_scan(nvbench::state& state, nvbench::type_list<T, OffsetT>
       launch
 #if !TUNE_BASE
       ,
-      cuda::execution::__tune(policy_selector<accum_t>{})
+      cuda::execution::tune(policy_selector<accum_t>{})
 #endif // !TUNE_BASE
     );
     _CCCL_TRY_CUDA_API(

--- a/cub/benchmarks/bench/scan/applications/P1/non-commutative-bicyclic-monoid.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/non-commutative-bicyclic-monoid.cu
@@ -88,9 +88,9 @@ template <typename T, typename OffsetT>
 static void inclusive_scan(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 {
   static_assert(cuda::std::is_integral_v<T> && cuda::std::is_unsigned_v<T>, "Unsigned integral type should be used");
-  using pair_t  = cuda::std::pair<T, T>;
-  using op_t    = impl::bicyclic_monoid_op<T>;
-  using accum_t = pair_t;
+  using pair_t                   = cuda::std::pair<T, T>;
+  using op_t                     = impl::bicyclic_monoid_op<T>;
+  [[maybe_unused]] using accum_t = pair_t;
 
   const auto elements = static_cast<std::size_t>(state.get_int64("Elements{io}"));
 

--- a/cub/benchmarks/bench/scan/applications/P1/non-commutative-bicyclic-monoid.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/non-commutative-bicyclic-monoid.cu
@@ -88,13 +88,9 @@ template <typename T, typename OffsetT>
 static void inclusive_scan(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 {
   static_assert(cuda::std::is_integral_v<T> && cuda::std::is_unsigned_v<T>, "Unsigned integral type should be used");
-  using wrapped_init_t = cub::NullType;
-  using pair_t         = cuda::std::pair<T, T>;
-  using op_t           = impl::bicyclic_monoid_op<T>;
-  using accum_t        = pair_t;
-  using input_it_t     = const pair_t*;
-  using output_it_t    = pair_t*;
-  using offset_t       = cub::detail::choose_offset_t<OffsetT>;
+  using pair_t  = cuda::std::pair<T, T>;
+  using op_t    = impl::bicyclic_monoid_op<T>;
+  using accum_t = pair_t;
 
   const auto elements = static_cast<std::size_t>(state.get_int64("Elements{io}"));
 
@@ -120,42 +116,24 @@ static void inclusive_scan(nvbench::state& state, nvbench::type_list<T, OffsetT>
   state.add_global_memory_reads<pair_t>(elements, "Size");
   state.add_global_memory_writes<pair_t>(elements);
 
-  cudaStream_t bench_stream = state.get_cuda_stream();
-
-  size_t tmp_size;
-  cub::detail::scan::dispatch_with_accum<accum_t>(
-    nullptr,
-    tmp_size,
-    d_input,
-    d_output,
-    op_t{},
-    wrapped_init_t{},
-    input.size(),
-    bench_stream
-#if !TUNE_BASE
-    ,
-    policy_selector<accum_t>{}
-#endif // !TUNE_BASE
-  );
-
-  thrust::device_vector<nvbench::uint8_t> tmp(tmp_size, thrust::no_init);
-  nvbench::uint8_t* d_tmp = thrust::raw_pointer_cast(tmp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::scan::dispatch_with_accum<accum_t>(
-      d_tmp,
-      tmp_size,
+    auto env = cub_bench_env(
+      alloc,
+      launch
+#if !TUNE_BASE
+      ,
+      cuda::execution::__tune(policy_selector<accum_t>{})
+#endif // !TUNE_BASE
+    );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceScan::InclusiveScan,
+      "InclusiveScan failed",
       d_input,
       d_output,
       op_t{},
-      wrapped_init_t{},
-      input.size(),
-      launch.get_stream()
-#if !TUNE_BASE
-        ,
-      policy_selector<accum_t>{}
-#endif // !TUNE_BASE
-    );
+      static_cast<OffsetT>(input.size()),
+      env);
   });
 }
 

--- a/cub/benchmarks/bench/scan/applications/P1/rabin-karp-second-fingerprinting.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/rabin-karp-second-fingerprinting.cu
@@ -315,7 +315,7 @@ static void inclusive_scan(nvbench::state& state, nvbench::type_list<BitsetT, Of
       launch
 #if !TUNE_BASE
       ,
-      cuda::execution::__tune(policy_selector<accum_t>{})
+      cuda::execution::tune(policy_selector<accum_t>{})
 #endif // !TUNE_BASE
     );
     _CCCL_TRY_CUDA_API(

--- a/cub/benchmarks/bench/scan/applications/P1/rabin-karp-second-fingerprinting.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/rabin-karp-second-fingerprinting.cu
@@ -280,15 +280,13 @@ template <typename InputT, typename OutputT>
 template <typename BitsetT, typename OffsetT>
 static void inclusive_scan(nvbench::state& state, nvbench::type_list<BitsetT, OffsetT>)
 {
-  using wrapped_init_t = cub::NullType;
-  using op_t           = impl::RabinKarpOp;
-  using input_t        = BitsetT;
-  using raw_it_t       = const input_t*;
-  using input_it_t     = cuda::transform_iterator<impl::ChunkToMat<input_t>, raw_it_t>;
-  using accum_t        = impl::MatT;
-  using output_ptr_t   = impl::MatT*;
-  using output_it_t    = impl::write_at_specific_index_or_discard<OffsetT, output_ptr_t>;
-  using offset_t       = cub::detail::choose_offset_t<OffsetT>;
+  using op_t         = impl::RabinKarpOp;
+  using input_t      = BitsetT;
+  using raw_it_t     = const input_t*;
+  using input_it_t   = cuda::transform_iterator<impl::ChunkToMat<input_t>, raw_it_t>;
+  using accum_t      = impl::MatT;
+  using output_ptr_t = impl::MatT*;
+  using output_it_t  = impl::write_at_specific_index_or_discard<OffsetT, output_ptr_t>;
 
   using ZpT = impl::ZpT;
 
@@ -310,42 +308,24 @@ static void inclusive_scan(nvbench::state& state, nvbench::type_list<BitsetT, Of
   state.add_global_memory_reads<input_t>(elements, "Sequence Size");
   state.add_global_memory_writes<accum_t>(1, "Hash Size");
 
-  cudaStream_t bench_stream = state.get_cuda_stream().get_stream();
-
-  size_t tmp_size;
-  cub::detail::scan::dispatch_with_accum<accum_t>(
-    nullptr,
-    tmp_size,
-    inp_it,
-    out_it,
-    op_t{p},
-    wrapped_init_t{},
-    input.size(),
-    bench_stream
-#if !TUNE_BASE
-    ,
-    policy_selector<accum_t>{}
-#endif // !TUNE_BASE
-  );
-
-  thrust::device_vector<nvbench::uint8_t> tmp(tmp_size, thrust::no_init);
-  nvbench::uint8_t* d_tmp = thrust::raw_pointer_cast(tmp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::scan::dispatch_with_accum<accum_t>(
-      d_tmp,
-      tmp_size,
-      inp_it,
-      out_it, // iterator that only writes the last element of inclusive prefix scan sequence,
-      op_t{p},
-      wrapped_init_t{},
-      input.size(),
-      launch.get_stream()
+    auto env = cub_bench_env(
+      alloc,
+      launch
 #if !TUNE_BASE
-        ,
-      policy_selector<accum_t>{}
+      ,
+      cuda::execution::__tune(policy_selector<accum_t>{})
 #endif // !TUNE_BASE
     );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceScan::InclusiveScan,
+      "InclusiveScan failed",
+      inp_it,
+      out_it, // iterator that only writes the last element of inclusive prefix scan sequence
+      op_t{p},
+      static_cast<OffsetT>(input.size()),
+      env);
   });
 
   // for validation uncomment these two lines

--- a/cub/benchmarks/bench/scan/applications/P1/running-min-max.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/running-min-max.cu
@@ -192,7 +192,7 @@ void benchmark_impl(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   using value_t                  = T;
   using pair_t                   = impl::min_max_t<value_t>;
   using op_t                     = impl::scan_op;
-  [[maybe_unused]] using accum_t = pair_t;
+  using accum_t [[maybe_unused]] = pair_t;
   using input_raw_t              = const value_t*;
   using input_it_t               = cuda::transform_iterator<impl::embed_op<value_t>, input_raw_t>;
   using output_it_t              = pair_t*;

--- a/cub/benchmarks/bench/scan/applications/P1/running-min-max.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/running-min-max.cu
@@ -189,13 +189,13 @@ void validate(const thrust::device_vector<ValueT>& input,
 template <typename T, typename OffsetT>
 void benchmark_impl(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 {
-  using value_t     = T;
-  using pair_t      = impl::min_max_t<value_t>;
-  using op_t        = impl::scan_op;
-  using accum_t     = pair_t;
-  using input_raw_t = const value_t*;
-  using input_it_t  = cuda::transform_iterator<impl::embed_op<value_t>, input_raw_t>;
-  using output_it_t = pair_t*;
+  using value_t                  = T;
+  using pair_t                   = impl::min_max_t<value_t>;
+  using op_t                     = impl::scan_op;
+  [[maybe_unused]] using accum_t = pair_t;
+  using input_raw_t              = const value_t*;
+  using input_it_t               = cuda::transform_iterator<impl::embed_op<value_t>, input_raw_t>;
+  using output_it_t              = pair_t*;
 
   const auto elements = static_cast<std::size_t>(state.get_int64("Elements{io}"));
 

--- a/cub/benchmarks/bench/scan/applications/P1/running-min-max.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/running-min-max.cu
@@ -189,15 +189,13 @@ void validate(const thrust::device_vector<ValueT>& input,
 template <typename T, typename OffsetT>
 void benchmark_impl(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 {
-  using wrapped_init_t = cub::NullType;
-  using value_t        = T;
-  using pair_t         = impl::min_max_t<value_t>;
-  using op_t           = impl::scan_op;
-  using accum_t        = pair_t;
-  using input_raw_t    = const value_t*;
-  using input_it_t     = cuda::transform_iterator<impl::embed_op<value_t>, input_raw_t>;
-  using output_it_t    = pair_t*;
-  using offset_t       = cub::detail::choose_offset_t<OffsetT>;
+  using value_t     = T;
+  using pair_t      = impl::min_max_t<value_t>;
+  using op_t        = impl::scan_op;
+  using accum_t     = pair_t;
+  using input_raw_t = const value_t*;
+  using input_it_t  = cuda::transform_iterator<impl::embed_op<value_t>, input_raw_t>;
+  using output_it_t = pair_t*;
 
   const auto elements = static_cast<std::size_t>(state.get_int64("Elements{io}"));
 
@@ -213,46 +211,28 @@ void benchmark_impl(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   state.add_global_memory_reads<value_t>(elements, "Size");
   state.add_global_memory_writes<pair_t>(elements);
 
-  cudaStream_t bench_stream = state.get_cuda_stream().get_stream();
-
-  size_t tmp_size;
-  cub::detail::scan::dispatch_with_accum<accum_t>(
-    nullptr,
-    tmp_size,
-    inp_it,
-    d_output,
-    op_t{},
-    wrapped_init_t{},
-    input.size(),
-    bench_stream
-#if !TUNE_BASE
-    ,
-    policy_selector<accum_t>{}
-#endif // !TUNE_BASE
-  );
-
-  thrust::device_vector<nvbench::uint8_t> tmp(tmp_size, thrust::no_init);
-  nvbench::uint8_t* d_tmp = thrust::raw_pointer_cast(tmp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::scan::dispatch_with_accum<accum_t>(
-      d_tmp,
-      tmp_size,
+    auto env = cub_bench_env(
+      alloc,
+      launch
+#if !TUNE_BASE
+      ,
+      cuda::execution::__tune(policy_selector<accum_t>{})
+#endif // !TUNE_BASE
+    );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceScan::InclusiveScan,
+      "InclusiveScan failed",
       inp_it,
       d_output,
       op_t{},
-      wrapped_init_t{},
-      input.size(),
-      launch.get_stream()
-#if !TUNE_BASE
-        ,
-      policy_selector<accum_t>{}
-#endif // !TUNE_BASE
-    );
+      static_cast<OffsetT>(input.size()),
+      env);
   });
 
   // for verification use
-  // impl::validate(input, output, bench_stream);
+  // impl::validate(input, output, state.get_cuda_stream().get_stream());
 }
 
 #ifdef TUNE_T

--- a/cub/benchmarks/bench/scan/applications/P1/running-min-max.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/running-min-max.cu
@@ -218,7 +218,7 @@ void benchmark_impl(nvbench::state& state, nvbench::type_list<T, OffsetT>)
       launch
 #if !TUNE_BASE
       ,
-      cuda::execution::__tune(policy_selector<accum_t>{})
+      cuda::execution::tune(policy_selector<accum_t>{})
 #endif // !TUNE_BASE
     );
     _CCCL_TRY_CUDA_API(

--- a/cub/benchmarks/bench/scan/applications/P1/scan-over-unitriangular-group.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/scan-over-unitriangular-group.cu
@@ -104,7 +104,7 @@ void benchmark_impl(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   using value_t                  = T;
   using tuple_t                  = impl::triplet_t<value_t>;
   using op_t                     = impl::unitriangular_dim3_op;
-  [[maybe_unused]] using accum_t = tuple_t;
+  using accum_t [[maybe_unused]] = tuple_t;
 
   const auto elements       = static_cast<std::size_t>(state.get_int64("Elements{io}"));
   cudaStream_t bench_stream = state.get_cuda_stream().get_stream();

--- a/cub/benchmarks/bench/scan/applications/P1/scan-over-unitriangular-group.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/scan-over-unitriangular-group.cu
@@ -101,14 +101,10 @@ bool validation(const thrust::device_vector<TupleT>& input,
 template <typename T, typename OffsetT>
 void benchmark_impl(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 {
-  using wrapped_init_t = cub::NullType;
-  using value_t        = T;
-  using tuple_t        = impl::triplet_t<value_t>;
-  using op_t           = impl::unitriangular_dim3_op;
-  using accum_t        = tuple_t;
-  using input_it_t     = const tuple_t*;
-  using output_it_t    = tuple_t*;
-  using offset_t       = cub::detail::choose_offset_t<OffsetT>;
+  using value_t = T;
+  using tuple_t = impl::triplet_t<value_t>;
+  using op_t    = impl::unitriangular_dim3_op;
+  using accum_t = tuple_t;
 
   const auto elements       = static_cast<std::size_t>(state.get_int64("Elements{io}"));
   cudaStream_t bench_stream = state.get_cuda_stream().get_stream();
@@ -133,40 +129,24 @@ void benchmark_impl(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   auto d_input  = thrust::raw_pointer_cast(input.data());
   auto d_output = thrust::raw_pointer_cast(output.data());
 
-  size_t tmp_size;
-  cub::detail::scan::dispatch_with_accum<accum_t>(
-    nullptr,
-    tmp_size,
-    d_input,
-    d_output,
-    op_t{},
-    wrapped_init_t{},
-    input.size(),
-    bench_stream
-#if !TUNE_BASE
-    ,
-    policy_selector<accum_t>{}
-#endif // !TUNE_BASE
-  );
-
-  thrust::device_vector<nvbench::uint8_t> tmp(tmp_size, thrust::no_init);
-  nvbench::uint8_t* d_tmp = thrust::raw_pointer_cast(tmp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::scan::dispatch_with_accum<accum_t>(
-      d_tmp,
-      tmp_size,
+    auto env = cub_bench_env(
+      alloc,
+      launch
+#if !TUNE_BASE
+      ,
+      cuda::execution::__tune(policy_selector<accum_t>{})
+#endif // !TUNE_BASE
+    );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceScan::InclusiveScan,
+      "InclusiveScan failed",
       d_input,
       d_output,
       op_t{},
-      wrapped_init_t{},
-      input.size(),
-      launch.get_stream()
-#if !TUNE_BASE
-        ,
-      policy_selector<accum_t>{}
-#endif // !TUNE_BASE
-    );
+      static_cast<OffsetT>(input.size()),
+      env);
   });
 
   // for validation use (recommended for integral types and smallish input sizes)

--- a/cub/benchmarks/bench/scan/applications/P1/scan-over-unitriangular-group.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/scan-over-unitriangular-group.cu
@@ -136,7 +136,7 @@ void benchmark_impl(nvbench::state& state, nvbench::type_list<T, OffsetT>)
       launch
 #if !TUNE_BASE
       ,
-      cuda::execution::__tune(policy_selector<accum_t>{})
+      cuda::execution::tune(policy_selector<accum_t>{})
 #endif // !TUNE_BASE
     );
     _CCCL_TRY_CUDA_API(

--- a/cub/benchmarks/bench/scan/applications/P1/scan-over-unitriangular-group.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/scan-over-unitriangular-group.cu
@@ -101,10 +101,10 @@ bool validation(const thrust::device_vector<TupleT>& input,
 template <typename T, typename OffsetT>
 void benchmark_impl(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 {
-  using value_t = T;
-  using tuple_t = impl::triplet_t<value_t>;
-  using op_t    = impl::unitriangular_dim3_op;
-  using accum_t = tuple_t;
+  using value_t                  = T;
+  using tuple_t                  = impl::triplet_t<value_t>;
+  using op_t                     = impl::unitriangular_dim3_op;
+  [[maybe_unused]] using accum_t = tuple_t;
 
   const auto elements       = static_cast<std::size_t>(state.get_int64("Elements{io}"));
   cudaStream_t bench_stream = state.get_cuda_stream().get_stream();

--- a/cub/benchmarks/bench/scan/exclusive/base.cuh
+++ b/cub/benchmarks/bench/scan/exclusive/base.cuh
@@ -15,12 +15,9 @@ template <typename T, typename OffsetT>
 static void basic(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 try
 {
-  using init_t         = T;
-  using wrapped_init_t = cub::detail::InputValue<init_t>;
-  using accum_t        = ::cuda::std::__accumulator_t<op_t, init_t, T>;
-  using input_it_t     = const T*;
-  using output_it_t    = T*;
-  using offset_t       = cub::detail::choose_offset_t<OffsetT>;
+  using init_t   = T;
+  using accum_t  = ::cuda::std::__accumulator_t<op_t, init_t, T>;
+  using offset_t = cub::detail::choose_offset_t<OffsetT>;
 #if USES_WARPSPEED()
   static_assert(sizeof(offset_t) == sizeof(size_t)); // warpspeed scan uses size_t internally
 #endif // USES_WARPSPEED()
@@ -42,38 +39,27 @@ try
   state.add_global_memory_reads<T>(elements, "Size");
   state.add_global_memory_writes<T>(elements);
 
-  size_t tmp_size;
-  cub::detail::scan::dispatch_with_accum<accum_t>(
-    nullptr,
-    tmp_size,
-    d_input,
-    d_output,
-    op_t{},
-    wrapped_init_t{T{}},
-    static_cast<offset_t>(input.size()),
-    nullptr /* stream */
-#if !TUNE_BASE
-    ,
-    policy_selector<accum_t>{}
-#endif // !TUNE_BASE
-  );
-
-  thrust::device_vector<nvbench::uint8_t> tmp(tmp_size, thrust::no_init);
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::scan::dispatch_with_accum<accum_t>(
-      thrust::raw_pointer_cast(tmp.data()),
-      tmp_size,
+    auto env = cub_bench_env(
+      alloc,
+      launch
+#if !TUNE_BASE
+      ,
+      cuda::execution::__tune(policy_selector<accum_t>{})
+#endif // !TUNE_BASE
+    );
+    // FIXME(bgruber): using cuda::std::plus<> as op_t is a breaking change, since we previously overrode the
+    // accumulator type to be T.
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceScan::ExclusiveScan,
+      "ExclusiveScan failed",
       d_input,
       d_output,
       op_t{},
-      wrapped_init_t{T{}},
+      init_t{},
       static_cast<offset_t>(input.size()),
-      launch.get_stream()
-#if !TUNE_BASE
-        ,
-      policy_selector<accum_t>{}
-#endif // !TUNE_BASE
-    );
+      env);
   });
 }
 catch (const std::bad_alloc&)

--- a/cub/benchmarks/bench/scan/exclusive/base.cuh
+++ b/cub/benchmarks/bench/scan/exclusive/base.cuh
@@ -15,9 +15,9 @@ template <typename T, typename OffsetT>
 static void basic(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 try
 {
-  using init_t   = T;
-  using accum_t  = ::cuda::std::__accumulator_t<op_t, init_t, T>;
-  using offset_t = cub::detail::choose_offset_t<OffsetT>;
+  using init_t                   = T;
+  [[maybe_unused]] using accum_t = ::cuda::std::__accumulator_t<op_t, init_t, T>;
+  using offset_t                 = cub::detail::choose_offset_t<OffsetT>;
 #if USES_WARPSPEED()
   static_assert(sizeof(offset_t) == sizeof(size_t)); // warpspeed scan uses size_t internally
 #endif // USES_WARPSPEED()

--- a/cub/benchmarks/bench/scan/exclusive/base.cuh
+++ b/cub/benchmarks/bench/scan/exclusive/base.cuh
@@ -49,8 +49,6 @@ try
       cuda::execution::__tune(policy_selector<accum_t>{})
 #endif // !TUNE_BASE
     );
-    // FIXME(bgruber): using cuda::std::plus<> as op_t is a breaking change, since we previously overrode the
-    // accumulator type to be T.
     _CCCL_TRY_CUDA_API(
       cub::DeviceScan::ExclusiveScan,
       "ExclusiveScan failed",

--- a/cub/benchmarks/bench/scan/exclusive/base.cuh
+++ b/cub/benchmarks/bench/scan/exclusive/base.cuh
@@ -16,7 +16,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 try
 {
   using init_t                   = T;
-  [[maybe_unused]] using accum_t = ::cuda::std::__accumulator_t<op_t, init_t, T>;
+  using accum_t [[maybe_unused]] = ::cuda::std::__accumulator_t<op_t, init_t, T>;
   using offset_t                 = cub::detail::choose_offset_t<OffsetT>;
 #if USES_WARPSPEED()
   static_assert(sizeof(offset_t) == sizeof(size_t)); // warpspeed scan uses size_t internally

--- a/cub/benchmarks/bench/scan/exclusive/base.cuh
+++ b/cub/benchmarks/bench/scan/exclusive/base.cuh
@@ -46,7 +46,7 @@ try
       launch
 #if !TUNE_BASE
       ,
-      cuda::execution::__tune(policy_selector<accum_t>{})
+      cuda::execution::tune(policy_selector<accum_t>{})
 #endif // !TUNE_BASE
     );
     _CCCL_TRY_CUDA_API(

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -95,7 +95,7 @@ struct DeviceScan
             typename InitValueT,
             typename NumItemsT,
             typename Determinism>
-  CUB_RUNTIME_FUNCTION static cudaError_t scan_impl_determinism(
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t scan_impl_determinism(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     InputIteratorT d_in,

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -103,12 +103,10 @@ struct DeviceScan
     ScanOpT scan_op,
     InitValueT init,
     NumItemsT num_items,
-    Determinism determinism,
+    Determinism /*determinism*/,
     cudaStream_t stream,
     PolicySelectorT policy_selector)
   {
-    (void) determinism;
-
     // Unsigned integer type for global offsets
     using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::scan::dispatch<EnforceInclusive>(

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -87,14 +87,14 @@ CUB_NAMESPACE_BEGIN
 struct DeviceScan
 {
   //! @cond
-  template <typename TuningEnvT,
+  template <ForceInclusive EnforceInclusive = ForceInclusive::No,
+            typename PolicySelectorT,
             typename InputIteratorT,
             typename OutputIteratorT,
             typename ScanOpT,
             typename InitValueT,
             typename NumItemsT,
-            ::cuda::execution::determinism::__determinism_t Determinism,
-            ForceInclusive EnforceInclusive = ForceInclusive::No>
+            typename Determinism>
   CUB_RUNTIME_FUNCTION static cudaError_t scan_impl_determinism(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -103,25 +103,14 @@ struct DeviceScan
     ScanOpT scan_op,
     InitValueT init,
     NumItemsT num_items,
-    ::cuda::execution::determinism::__determinism_holder_t<Determinism>,
-    cudaStream_t stream)
+    Determinism determinism,
+    cudaStream_t stream,
+    PolicySelectorT policy_selector)
   {
+    (void) determinism;
+
     // Unsigned integer type for global offsets
     using offset_t = detail::choose_offset_t<NumItemsT>;
-
-    using accum_t =
-      ::cuda::std::__accumulator_t<ScanOpT,
-                                   cub::detail::it_value_t<InputIteratorT>,
-                                   ::cuda::std::_If<::cuda::std::is_same_v<InitValueT, NullType>,
-                                                    cub::detail::it_value_t<InputIteratorT>,
-                                                    typename InitValueT::value_type>>;
-
-    using default_policy_selector_t =
-      detail::scan::policy_selector_from_types<InputIteratorT, OutputIteratorT, accum_t, offset_t, ScanOpT>;
-
-    using policy_selector_t =
-      ::cuda::std::execution::__query_result_or_t<TuningEnvT, detail::scan::scan_policy, default_policy_selector_t>;
-
     return detail::scan::dispatch<EnforceInclusive>(
       d_temp_storage,
       temp_storage_bytes,
@@ -131,7 +120,7 @@ struct DeviceScan
       init,
       static_cast<offset_t>(num_items),
       stream,
-      policy_selector_t{});
+      policy_selector);
   }
 
   template <ForceInclusive EnforceInclusive = ForceInclusive::No,
@@ -161,6 +150,9 @@ struct DeviceScan
                                    ::cuda::std::_If<::cuda::std::is_same_v<InitValueT, NullType>,
                                                     cub::detail::it_value_t<InputIteratorT>,
                                                     typename InitValueT::value_type>>;
+    using offset_t = detail::choose_offset_t<NumItemsT>;
+    using default_policy_selector_t =
+      detail::scan::policy_selector_from_types<InputIteratorT, OutputIteratorT, accum_t, offset_t, ScanOpT>;
 
     constexpr bool is_determinism_required =
       !::cuda::std::is_same_v<requested_determinism_t, ::cuda::execution::determinism::not_guaranteed_t>;
@@ -171,18 +163,11 @@ struct DeviceScan
     static_assert(!is_determinism_required || is_safe_integral_op,
                   "run_to_run or gpu_to_gpu is only supported for integral types with known operators");
 
-    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      using tuning_t = decltype(tuning);
-      return scan_impl_determinism<
-        tuning_t,
-        InputIteratorT,
-        OutputIteratorT,
-        ScanOpT,
-        InitValueT,
-        NumItemsT,
-        ::cuda::execution::determinism::__determinism_t(requested_determinism_t::value),
-        EnforceInclusive>(storage, bytes, d_in, d_out, scan_op, init, num_items, requested_determinism_t{}, stream);
-    });
+    return detail::dispatch_with_env_and_tuning<default_policy_selector_t>(
+      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return scan_impl_determinism<EnforceInclusive>(
+          storage, bytes, d_in, d_out, scan_op, init, num_items, requested_determinism_t{}, stream, policy_selector);
+      });
   }
 
   template <typename TuningEnvT,

--- a/cub/test/catch2_test_device_scan_env.cu
+++ b/cub/test/catch2_test_device_scan_env.cu
@@ -36,11 +36,12 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceScan::InclusiveScanInit, device_scan_inclusive
 
 namespace stdexec = cuda::std::execution;
 
+using block_size_check_t = block_size_extracting_op<cuda::std::plus<>>;
+
 // Launcher helper always passes an environment.
 // We need a test of simple use to check if default environment works.
 // ifdef it out not to spend time compiling and running it twice.
 #if TEST_LAUNCH == 0
-using block_size_check_t = block_size_extracting_op<cuda::std::plus<>>;
 
 TEST_CASE("Device scan exclusive scan works with default environment", "[scan][device]")
 {

--- a/cub/test/catch2_test_device_scan_env.cu
+++ b/cub/test/catch2_test_device_scan_env.cu
@@ -105,6 +105,26 @@ TEST_CASE("Device scan exclusive sum works with default environment", "[sum][dev
   REQUIRE(d_out[1] == value_t{} + d_in[0]);
 }
 
+TEST_CASE("Device scan inclusive-scan-init works with default environment", "[scan][device]")
+{
+  using num_items_t = int;
+  using value_t     = int;
+
+  num_items_t num_items = 3;
+  auto d_in             = cuda::constant_iterator(value_t{1});
+  auto d_out            = c2h::device_vector<value_t>(num_items);
+
+  value_t init{10};
+
+  REQUIRE(cudaSuccess == cub::DeviceScan::InclusiveScanInit(d_in, d_out.begin(), cuda::std::plus{}, init, num_items));
+
+  REQUIRE(thrust::equal(d_out.begin(), d_out.end(), thrust::make_counting_iterator(init + 1)));
+}
+
+#endif // TEST_LAUNCH == 0
+
+#if TEST_LAUNCH != 1
+
 template <int ThreadsPerBlock>
 struct scan_tuning
 {
@@ -134,7 +154,8 @@ struct unrelated_tuning
   }
 };
 
-using block_sizes = c2h::type_list<cuda::std::integral_constant<int, 32>, cuda::std::integral_constant<int, 64>>;
+using block_sizes =
+  c2h::type_list<cuda::std::integral_constant<unsigned int, 32>, cuda::std::integral_constant<unsigned int, 64>>;
 
 C2H_TEST("Device scan exclusive-scan can be tuned", "[scan][device]", block_sizes)
 {
@@ -239,22 +260,6 @@ C2H_TEST("Device scan inclusive-scan can be tuned", "[scan][device]", block_size
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
-TEST_CASE("Device scan inclusive-scan-init works with default environment", "[scan][device]")
-{
-  using num_items_t = int;
-  using value_t     = int;
-
-  num_items_t num_items = 3;
-  auto d_in             = cuda::constant_iterator(value_t{1});
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-
-  value_t init{10};
-
-  REQUIRE(cudaSuccess == cub::DeviceScan::InclusiveScanInit(d_in, d_out.begin(), cuda::std::plus{}, init, num_items));
-
-  REQUIRE(thrust::equal(d_out.begin(), d_out.end(), thrust::make_counting_iterator(init + 1)));
-}
-
 C2H_TEST("Device scan inclusive-scan-init can be tuned", "[scan][device]", block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
@@ -336,7 +341,7 @@ TEST_CASE("Device scan exclusive scan with FutureValue in-place works with defau
   REQUIRE(d_data == expected);
 }
 
-#endif
+#endif // TEST_LAUCH != 1
 
 C2H_TEST("Device scan exclusive-scan uses environment", "[scan][device]")
 {

--- a/cub/test/catch2_test_device_scan_env.cu
+++ b/cub/test/catch2_test_device_scan_env.cu
@@ -57,7 +57,7 @@ TEST_CASE("Device scan exclusive scan works with default environment", "[scan][d
 
   cuda::compute_capability cc;
   REQUIRE(cudaSuccess == cub::detail::ptx_compute_cap(cc));
-  const auto target_block_size = selector_t{}(cc).lookback.threads_per_block;
+  const unsigned int target_block_size = selector_t{}(cc).lookback.threads_per_block;
 
   c2h::device_vector<unsigned int> d_block_size(1);
   block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
@@ -228,7 +228,7 @@ TEST_CASE("Device scan inclusive-scan works with default environment", "[scan][d
 
   cuda::compute_capability cc;
   REQUIRE(cudaSuccess == cub::detail::ptx_compute_cap(cc));
-  const auto target_block_size = selector_t{}(cc).lookback.threads_per_block;
+  const unsigned int target_block_size = selector_t{}(cc).lookback.threads_per_block;
 
   c2h::device_vector<unsigned int> d_block_size(1);
   block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};

--- a/cub/test/catch2_test_device_scan_env.cu
+++ b/cub/test/catch2_test_device_scan_env.cu
@@ -342,7 +342,7 @@ TEST_CASE("Device scan exclusive scan with FutureValue in-place works with defau
   REQUIRE(d_data == expected);
 }
 
-#endif // TEST_LAUCH != 1
+#endif // TEST_LAUNCH != 1
 
 C2H_TEST("Device scan exclusive-scan uses environment", "[scan][device]")
 {

--- a/docs/cub/developer/device_scope.rst
+++ b/docs/cub/developer/device_scope.rst
@@ -139,9 +139,9 @@ A more precise description is given later.
         a.Process();
       }
 
-      template <int BlockThreads, ...>
+      template <int ThreadsPerBlock, ...>
       struct AgentPolicy { // legacy
-        static constexpr threads_per_block = BlockThreads;
+        static constexpr threads_per_block = ThreadsPerBlock;
         ...
       };
 

--- a/thrust/thrust/system/cuda/detail/scan.h
+++ b/thrust/thrust/system/cuda/detail/scan.h
@@ -40,6 +40,7 @@ template <typename Derived, typename InputIt, typename Size, typename OutputIt, 
 _CCCL_HOST_DEVICE OutputIt inclusive_scan_n_impl(
   thrust::cuda_cub::execution_policy<Derived>& policy, InputIt first, Size num_items, OutputIt result, ScanOp scan_op)
 {
+  using AccumT        = thrust::detail::it_value_t<InputIt>;
   cudaStream_t stream = thrust::cuda_cub::stream(policy);
   cudaError_t status;
 
@@ -51,15 +52,35 @@ _CCCL_HOST_DEVICE OutputIt inclusive_scan_n_impl(
 
   // Determine temporary storage requirements:
   size_t tmp_size = 0;
-  status          = cub::DeviceScan::InclusiveScan(nullptr, tmp_size, first, result, scan_op, num_items, stream);
-  thrust::cuda_cub::throw_on_error(status, "after determining tmp storage requirements for inclusive_scan");
+  {
+    // TODO(bgruber): we should call cub::DeviceScan::InclusiveScan directly in CCCL 4.0, which is a breaking change.
+    // See https://github.com/NVIDIA/cccl/issues/3993 for details.
+    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
+      status,
+      cub::detail::scan::dispatch_with_accum<AccumT>,
+      num_items,
+      (nullptr, tmp_size, first, result, scan_op, cub::NullType{}, num_items_fixed, stream));
+    thrust::cuda_cub::throw_on_error(
+      status,
+      "after determining tmp storage "
+      "requirements for inclusive_scan");
+  }
 
   // Run scan:
-  thrust::detail::temporary_array<std::uint8_t, Derived> tmp{policy, tmp_size};
-  status = cub::DeviceScan::InclusiveScan(tmp.data().get(), tmp_size, first, result, scan_op, num_items, stream);
-  thrust::cuda_cub::throw_on_error(status, "after dispatching inclusive_scan kernel");
-  thrust::cuda_cub::throw_on_error(
-    thrust::cuda_cub::synchronize_optional(policy), "inclusive_scan failed to synchronize");
+  {
+    // Allocate temporary storage:
+    thrust::detail::temporary_array<std::uint8_t, Derived> tmp{policy, tmp_size};
+    // TODO(bgruber): we should call cub::DeviceScan::InclusiveScan directly in CCCL 4.0, which is a breaking change.
+    // See https://github.com/NVIDIA/cccl/issues/3993 for details.
+    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
+      status,
+      cub::detail::scan::dispatch_with_accum<AccumT>,
+      num_items,
+      (tmp.data().get(), tmp_size, first, result, scan_op, cub::NullType{}, num_items_fixed, stream));
+    thrust::cuda_cub::throw_on_error(status, "after dispatching inclusive_scan kernel");
+    thrust::cuda_cub::throw_on_error(
+      thrust::cuda_cub::synchronize_optional(policy), "inclusive_scan failed to synchronize");
+  }
 
   return result + num_items;
 }
@@ -74,6 +95,9 @@ _CCCL_HOST_DEVICE OutputIt inclusive_scan_n_impl(
   InitValueT init,
   ScanOp scan_op)
 {
+  using InputValueT   = cub::detail::InputValue<InitValueT>;
+  using ValueT        = cub::detail::it_value_t<InputIt>;
+  using AccumT        = ::cuda::std::__accumulator_t<ScanOp, ValueT, InitValueT>;
   cudaStream_t stream = thrust::cuda_cub::stream(policy);
   cudaError_t status;
 
@@ -85,16 +109,35 @@ _CCCL_HOST_DEVICE OutputIt inclusive_scan_n_impl(
 
   // Determine temporary storage requirements:
   size_t tmp_size = 0;
-  status = cub::DeviceScan::InclusiveScanInit(nullptr, tmp_size, first, result, scan_op, init, num_items, stream);
-  thrust::cuda_cub::throw_on_error(status, "after determining tmp storage requirements for inclusive_scan");
+  {
+    // TODO(bgruber): we should call cub::DeviceScan::InclusiveScanInit directly in CCCL 4.0, which is a breaking
+    // change. See https://github.com/NVIDIA/cccl/issues/3993 for details.
+    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
+      status,
+      (cub::detail::scan::dispatch_with_accum<AccumT, cub::ForceInclusive::Yes>),
+      num_items,
+      (nullptr, tmp_size, first, result, scan_op, InputValueT(init), num_items_fixed, stream));
+    thrust::cuda_cub::throw_on_error(
+      status,
+      "after determining tmp storage "
+      "requirements for inclusive_scan");
+  }
 
   // Run scan:
-  thrust::detail::temporary_array<std::uint8_t, Derived> tmp{policy, tmp_size};
-  status =
-    cub::DeviceScan::InclusiveScanInit(tmp.data().get(), tmp_size, first, result, scan_op, init, num_items, stream);
-  thrust::cuda_cub::throw_on_error(status, "after dispatching inclusive_scan kernel");
-  thrust::cuda_cub::throw_on_error(
-    thrust::cuda_cub::synchronize_optional(policy), "inclusive_scan failed to synchronize");
+  {
+    // Allocate temporary storage:
+    thrust::detail::temporary_array<std::uint8_t, Derived> tmp{policy, tmp_size};
+    // TODO(bgruber): we should call cub::DeviceScan::InclusiveScanInit directly in CCCL 4.0, which is a breaking
+    // change. See https://github.com/NVIDIA/cccl/issues/3993 for details.
+    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
+      status,
+      (cub::detail::scan::dispatch_with_accum<AccumT, cub::ForceInclusive::Yes>),
+      num_items,
+      (tmp.data().get(), tmp_size, first, result, scan_op, InputValueT(init), num_items_fixed, stream));
+    thrust::cuda_cub::throw_on_error(status, "after dispatching inclusive_scan kernel");
+    thrust::cuda_cub::throw_on_error(
+      thrust::cuda_cub::synchronize_optional(policy), "inclusive_scan failed to synchronize");
+  }
 
   return result + num_items;
 }
@@ -109,6 +152,7 @@ _CCCL_HOST_DEVICE OutputIt exclusive_scan_n_impl(
   InitValueT init,
   ScanOp scan_op)
 {
+  using InputValueT   = cub::detail::InputValue<InitValueT>;
   cudaStream_t stream = thrust::cuda_cub::stream(policy);
   cudaError_t status;
 
@@ -120,15 +164,35 @@ _CCCL_HOST_DEVICE OutputIt exclusive_scan_n_impl(
 
   // Determine temporary storage requirements:
   size_t tmp_size = 0;
-  status          = cub::DeviceScan::ExclusiveScan(nullptr, tmp_size, first, result, scan_op, init, num_items, stream);
-  thrust::cuda_cub::throw_on_error(status, "after determining tmp storage requirements for exclusive_scan");
+  {
+    // TODO(bgruber): we should call cub::DeviceScan::ExclusiveScan directly in CCCL 4.0, which is a breaking change.
+    // See https://github.com/NVIDIA/cccl/issues/3993 for details.
+    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
+      status,
+      cub::detail::scan::dispatch_with_accum<InitValueT>,
+      num_items,
+      (nullptr, tmp_size, first, result, scan_op, InputValueT(init), num_items_fixed, stream));
+    thrust::cuda_cub::throw_on_error(
+      status,
+      "after determining tmp storage "
+      "requirements for exclusive_scan");
+  }
 
   // Run scan:
-  thrust::detail::temporary_array<std::uint8_t, Derived> tmp{policy, tmp_size};
-  status = cub::DeviceScan::ExclusiveScan(tmp.data().get(), tmp_size, first, result, scan_op, init, num_items, stream);
-  thrust::cuda_cub::throw_on_error(status, "after dispatching exclusive_scan kernel");
-  thrust::cuda_cub::throw_on_error(
-    thrust::cuda_cub::synchronize_optional(policy), "exclusive_scan failed to synchronize");
+  {
+    // Allocate temporary storage:
+    thrust::detail::temporary_array<std::uint8_t, Derived> tmp{policy, tmp_size};
+    // TODO(bgruber): we should call cub::DeviceScan::ExclusiveScan directly in CCCL 4.0, which is a breaking change.
+    // See https://github.com/NVIDIA/cccl/issues/3993 for details.
+    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
+      status,
+      cub::detail::scan::dispatch_with_accum<InitValueT>,
+      num_items,
+      (tmp.data().get(), tmp_size, first, result, scan_op, InputValueT(init), num_items_fixed, stream));
+    thrust::cuda_cub::throw_on_error(status, "after dispatching exclusive_scan kernel");
+    thrust::cuda_cub::throw_on_error(
+      thrust::cuda_cub::synchronize_optional(policy), "exclusive_scan failed to synchronize");
+  }
 
   return result + num_items;
 }

--- a/thrust/thrust/system/cuda/detail/scan.h
+++ b/thrust/thrust/system/cuda/detail/scan.h
@@ -40,7 +40,6 @@ template <typename Derived, typename InputIt, typename Size, typename OutputIt, 
 _CCCL_HOST_DEVICE OutputIt inclusive_scan_n_impl(
   thrust::cuda_cub::execution_policy<Derived>& policy, InputIt first, Size num_items, OutputIt result, ScanOp scan_op)
 {
-  using AccumT        = thrust::detail::it_value_t<InputIt>;
   cudaStream_t stream = thrust::cuda_cub::stream(policy);
   cudaError_t status;
 
@@ -52,31 +51,15 @@ _CCCL_HOST_DEVICE OutputIt inclusive_scan_n_impl(
 
   // Determine temporary storage requirements:
   size_t tmp_size = 0;
-  {
-    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
-      status,
-      cub::detail::scan::dispatch_with_accum<AccumT>,
-      num_items,
-      (nullptr, tmp_size, first, result, scan_op, cub::NullType{}, num_items_fixed, stream));
-    thrust::cuda_cub::throw_on_error(
-      status,
-      "after determining tmp storage "
-      "requirements for inclusive_scan");
-  }
+  status          = cub::DeviceScan::InclusiveScan(nullptr, tmp_size, first, result, scan_op, num_items, stream);
+  thrust::cuda_cub::throw_on_error(status, "after determining tmp storage requirements for inclusive_scan");
 
   // Run scan:
-  {
-    // Allocate temporary storage:
-    thrust::detail::temporary_array<std::uint8_t, Derived> tmp{policy, tmp_size};
-    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
-      status,
-      cub::detail::scan::dispatch_with_accum<AccumT>,
-      num_items,
-      (tmp.data().get(), tmp_size, first, result, scan_op, cub::NullType{}, num_items_fixed, stream));
-    thrust::cuda_cub::throw_on_error(status, "after dispatching inclusive_scan kernel");
-    thrust::cuda_cub::throw_on_error(
-      thrust::cuda_cub::synchronize_optional(policy), "inclusive_scan failed to synchronize");
-  }
+  thrust::detail::temporary_array<std::uint8_t, Derived> tmp{policy, tmp_size};
+  status = cub::DeviceScan::InclusiveScan(tmp.data().get(), tmp_size, first, result, scan_op, num_items, stream);
+  thrust::cuda_cub::throw_on_error(status, "after dispatching inclusive_scan kernel");
+  thrust::cuda_cub::throw_on_error(
+    thrust::cuda_cub::synchronize_optional(policy), "inclusive_scan failed to synchronize");
 
   return result + num_items;
 }
@@ -91,9 +74,6 @@ _CCCL_HOST_DEVICE OutputIt inclusive_scan_n_impl(
   InitValueT init,
   ScanOp scan_op)
 {
-  using InputValueT   = cub::detail::InputValue<InitValueT>;
-  using ValueT        = cub::detail::it_value_t<InputIt>;
-  using AccumT        = ::cuda::std::__accumulator_t<ScanOp, ValueT, InitValueT>;
   cudaStream_t stream = thrust::cuda_cub::stream(policy);
   cudaError_t status;
 
@@ -105,31 +85,16 @@ _CCCL_HOST_DEVICE OutputIt inclusive_scan_n_impl(
 
   // Determine temporary storage requirements:
   size_t tmp_size = 0;
-  {
-    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
-      status,
-      (cub::detail::scan::dispatch_with_accum<AccumT, cub::ForceInclusive::Yes>),
-      num_items,
-      (nullptr, tmp_size, first, result, scan_op, InputValueT(init), num_items_fixed, stream));
-    thrust::cuda_cub::throw_on_error(
-      status,
-      "after determining tmp storage "
-      "requirements for inclusive_scan");
-  }
+  status = cub::DeviceScan::InclusiveScanInit(nullptr, tmp_size, first, result, scan_op, init, num_items, stream);
+  thrust::cuda_cub::throw_on_error(status, "after determining tmp storage requirements for inclusive_scan");
 
   // Run scan:
-  {
-    // Allocate temporary storage:
-    thrust::detail::temporary_array<std::uint8_t, Derived> tmp{policy, tmp_size};
-    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
-      status,
-      (cub::detail::scan::dispatch_with_accum<AccumT, cub::ForceInclusive::Yes>),
-      num_items,
-      (tmp.data().get(), tmp_size, first, result, scan_op, InputValueT(init), num_items_fixed, stream));
-    thrust::cuda_cub::throw_on_error(status, "after dispatching inclusive_scan kernel");
-    thrust::cuda_cub::throw_on_error(
-      thrust::cuda_cub::synchronize_optional(policy), "inclusive_scan failed to synchronize");
-  }
+  thrust::detail::temporary_array<std::uint8_t, Derived> tmp{policy, tmp_size};
+  status =
+    cub::DeviceScan::InclusiveScanInit(tmp.data().get(), tmp_size, first, result, scan_op, init, num_items, stream);
+  thrust::cuda_cub::throw_on_error(status, "after dispatching inclusive_scan kernel");
+  thrust::cuda_cub::throw_on_error(
+    thrust::cuda_cub::synchronize_optional(policy), "inclusive_scan failed to synchronize");
 
   return result + num_items;
 }
@@ -144,7 +109,6 @@ _CCCL_HOST_DEVICE OutputIt exclusive_scan_n_impl(
   InitValueT init,
   ScanOp scan_op)
 {
-  using InputValueT   = cub::detail::InputValue<InitValueT>;
   cudaStream_t stream = thrust::cuda_cub::stream(policy);
   cudaError_t status;
 
@@ -156,31 +120,15 @@ _CCCL_HOST_DEVICE OutputIt exclusive_scan_n_impl(
 
   // Determine temporary storage requirements:
   size_t tmp_size = 0;
-  {
-    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
-      status,
-      cub::detail::scan::dispatch_with_accum<InitValueT>,
-      num_items,
-      (nullptr, tmp_size, first, result, scan_op, InputValueT(init), num_items_fixed, stream));
-    thrust::cuda_cub::throw_on_error(
-      status,
-      "after determining tmp storage "
-      "requirements for exclusive_scan");
-  }
+  status          = cub::DeviceScan::ExclusiveScan(nullptr, tmp_size, first, result, scan_op, init, num_items, stream);
+  thrust::cuda_cub::throw_on_error(status, "after determining tmp storage requirements for exclusive_scan");
 
   // Run scan:
-  {
-    // Allocate temporary storage:
-    thrust::detail::temporary_array<std::uint8_t, Derived> tmp{policy, tmp_size};
-    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
-      status,
-      cub::detail::scan::dispatch_with_accum<InitValueT>,
-      num_items,
-      (tmp.data().get(), tmp_size, first, result, scan_op, InputValueT(init), num_items_fixed, stream));
-    thrust::cuda_cub::throw_on_error(status, "after dispatching exclusive_scan kernel");
-    thrust::cuda_cub::throw_on_error(
-      thrust::cuda_cub::synchronize_optional(policy), "exclusive_scan failed to synchronize");
-  }
+  thrust::detail::temporary_array<std::uint8_t, Derived> tmp{policy, tmp_size};
+  status = cub::DeviceScan::ExclusiveScan(tmp.data().get(), tmp_size, first, result, scan_op, init, num_items, stream);
+  thrust::cuda_cub::throw_on_error(status, "after dispatching exclusive_scan kernel");
+  thrust::cuda_cub::throw_on_error(
+    thrust::cuda_cub::synchronize_optional(policy), "exclusive_scan failed to synchronize");
 
   return result + num_items;
 }


### PR DESCRIPTION
- [x] Merge before: #8473
- [x] Postponed:  #6576
- [x] No SASS changes for `cub.bench.exclusive.sum.baes` for SM`75,80,90,100,120`

Fixes: #8373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified device scan benchmarks with modernized internal API patterns.
  * Device scan dispatch refactored to support flexible runtime policy selection for improved tuning capabilities.
  * Expanded test coverage for inclusive and exclusive scan initialization operations.

* **Chores**
  * Added implementation notes marking areas for future optimization work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->