### PR TITLE
[CUB] Add benchmarks for `WarpReduceBatched`

### DIFF
--- a/cub/benchmarks/bench/reduce/warp_reduce_batched_base.cuh
+++ b/cub/benchmarks/bench/reduce/warp_reduce_batched_base.cuh
@@ -1,0 +1,241 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#include <cub/warp/warp_reduce.cuh>
+#include <cub/warp/warp_reduce_batched.cuh>
+
+#include <cuda/cmath>
+
+#include <cuda_runtime_api.h>
+#include <device_side_benchmark.cuh>
+#include <nvbench_helper.cuh>
+
+/**
+ * @brief Benchmark operator for batched warp reduction
+ *
+ * Performs Batches reductions of LogicalWarpThreads elements each using WarpReduceBatched
+ */
+template <int LogicalWarpThreads>
+struct benchmark_batched_op_t
+{
+  template <typename T, cuda::std::size_t Batches>
+  __device__ __forceinline__ cuda::std::array<T, Batches> operator()(cuda::std::array<T, Batches> thread_data) const
+  {
+    using WarpReduceBatched           = cub::WarpReduceBatched<T, Batches, LogicalWarpThreads>;
+    using TempStorage                 = typename WarpReduceBatched::TempStorage;
+    constexpr auto max_out_per_thread = cuda::ceil_div(Batches, LogicalWarpThreads);
+    cuda::std::array<T, max_out_per_thread> outputs;
+    __shared__ TempStorage temp_storage;
+
+    WarpReduceBatched{temp_storage}.ReduceToStriped(thread_data, outputs, op_t{});
+
+#pragma unroll
+    for (int i = 0; i < max_out_per_thread; ++i)
+    {
+      thread_data[i] = outputs[i];
+    }
+    return thread_data;
+  }
+};
+
+/**
+ * @brief Benchmark operator for sequential warp reductions (baseline)
+ *
+ * Performs Batches sequential calls to WarpReduce
+ */
+template <int LogicalWarpThreads>
+struct benchmark_sequential_op_t
+{
+  template <typename T, cuda::std::size_t Batches>
+  __device__ __forceinline__ cuda::std::array<T, Batches> operator()(cuda::std::array<T, Batches> thread_data) const
+  {
+    using WarpReduce  = cub::WarpReduce<T, LogicalWarpThreads>;
+    using TempStorage = typename WarpReduce::TempStorage;
+    __shared__ TempStorage temp_storage;
+
+    WarpReduce warp_reduce{temp_storage};
+
+// Sequentially reduce Batches arrays
+#pragma unroll
+    for (int i = 0; i < Batches; ++i)
+    {
+      // This is somewhat of an unfair comparison since all results are returned by lane 0
+      // while they are distributed among threads for WarpReduceBatched.
+      thread_data[i] = warp_reduce.Reduce(thread_data[i], op_t{});
+    }
+    return thread_data;
+  }
+};
+
+enum class launch_bounds_mode_t
+{
+  partial,
+  full,
+};
+
+launch_bounds_mode_t parse_launch_bounds_mode(nvbench::state& state)
+{
+  const auto& launch_bounds_mode = state.get_string("LaunchBoundsMode");
+  if (launch_bounds_mode == "partial")
+  {
+    return launch_bounds_mode_t::partial;
+  }
+  else if (launch_bounds_mode == "full")
+  {
+    return launch_bounds_mode_t::full;
+  }
+  else
+  {
+    throw std::invalid_argument("Invalid launch bounds mode: " + launch_bounds_mode);
+  }
+}
+
+using batches_list              = nvbench::enum_type_list<8, 15, 16, 32, 64>;
+using logical_warp_threads_list = nvbench::enum_type_list<8, 16, 32>;
+
+/**
+ * @brief Run batched warp reduction benchmark
+ */
+template <typename T, nvbench::int32_t Batches, nvbench::int32_t LogicalWarpThreads>
+void warp_reduce_batched(nvbench::state& state,
+                         nvbench::type_list<T, nvbench::enum_type<Batches>, nvbench::enum_type<LogicalWarpThreads>>)
+{
+  constexpr int block_size                = 256;
+  constexpr int grid_size                 = (1 << 28) / block_size;
+  constexpr int max_sm_warps              = 48; // For consumer GPUs, datacenter allows 64, but same amount of registers
+  constexpr int full_bounds_max_sm_blocks = (max_sm_warps * 32) / block_size;
+  constexpr int unroll_factor = cuda::ceil_div(64, cuda::next_power_of_two(Batches)); // Balance compile time and
+                                                                                      // performance
+  const auto launch_bounds_mode = parse_launch_bounds_mode(state);
+  const auto& kernel =
+    launch_bounds_mode == launch_bounds_mode_t::full
+      ? benchmark_kernel_full_bounds<block_size,
+                                     full_bounds_max_sm_blocks,
+                                     unroll_factor,
+                                     benchmark_batched_op_t<LogicalWarpThreads>,
+                                     cuda::std::array<T, Batches>>
+      : benchmark_kernel<block_size,
+                         unroll_factor,
+                         benchmark_batched_op_t<LogicalWarpThreads>,
+                         cuda::std::array<T, Batches>>;
+
+  auto wspro_stages = 0;
+  for (int stride_inter_reduce = 2; stride_inter_reduce <= LogicalWarpThreads; stride_inter_reduce *= 2)
+  {
+    wspro_stages += cuda::ceil_div(Batches, stride_inter_reduce);
+  }
+  state.add_summary("Stages").set_int64("value", wspro_stages);
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launcher) {
+    kernel<<<grid_size, block_size, 0, launcher.get_stream()>>>(benchmark_batched_op_t<LogicalWarpThreads>{});
+  });
+}
+
+NVBENCH_BENCH_TYPES(warp_reduce_batched, NVBENCH_TYPE_AXES(value_types, batches_list, logical_warp_threads_list))
+  .set_name("base")
+  .set_type_axes_names({"T{ct}", "Batches", "LogicalWarpThreads"})
+  .add_string_axis("LaunchBoundsMode", {"partial", "full"});
+
+/**
+ * @brief Run sequential warp reduction benchmark (baseline)
+ */
+template <typename T, nvbench::int32_t Batches, nvbench::int32_t LogicalWarpThreads>
+void warp_reduce_sequential(nvbench::state& state,
+                            nvbench::type_list<T, nvbench::enum_type<Batches>, nvbench::enum_type<LogicalWarpThreads>>)
+{
+  constexpr int block_size                = 256;
+  constexpr int grid_size                 = (1 << 28) / block_size;
+  constexpr int max_sm_warps              = 48; // For consumer GPUs, datacenter allows 64, but same amount of registers
+  constexpr int full_bounds_max_sm_blocks = (max_sm_warps * 32) / block_size;
+  constexpr int unroll_factor = cuda::ceil_div(64, cuda::next_power_of_two(Batches)); // Balance compile time and
+                                                                                      // performance
+  const auto launch_bounds_mode = parse_launch_bounds_mode(state);
+  const auto& kernel =
+    launch_bounds_mode == launch_bounds_mode_t::full
+      ? benchmark_kernel_full_bounds<block_size,
+                                     full_bounds_max_sm_blocks,
+                                     unroll_factor,
+                                     benchmark_sequential_op_t<LogicalWarpThreads>,
+                                     cuda::std::array<T, Batches>>
+      : benchmark_kernel<block_size,
+                         unroll_factor,
+                         benchmark_sequential_op_t<LogicalWarpThreads>,
+                         cuda::std::array<T, Batches>>;
+
+  const auto sequential_stages = Batches * cuda::ilog2(LogicalWarpThreads);
+  state.add_summary("Stages").set_int64("value", sequential_stages);
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launcher) {
+    kernel<<<grid_size, block_size, 0, launcher.get_stream()>>>(benchmark_sequential_op_t<LogicalWarpThreads>{});
+  });
+}
+
+NVBENCH_BENCH_TYPES(warp_reduce_sequential, NVBENCH_TYPE_AXES(value_types, batches_list, logical_warp_threads_list))
+  .set_name("sequential")
+  .set_type_axes_names({"T{ct}", "Batches", "LogicalWarpThreads"})
+  .add_string_axis("LaunchBoundsMode", {"partial", "full"});
+
+/**
+ * @brief Run batched warp reduction latency benchmark
+ */
+template <typename T, nvbench::int32_t Batches, nvbench::int32_t LogicalWarpThreads>
+void warp_reduce_batched_latency(
+  nvbench::state& state, nvbench::type_list<T, nvbench::enum_type<Batches>, nvbench::enum_type<LogicalWarpThreads>>)
+{
+  constexpr int block_size    = 32;
+  constexpr int grid_size     = 1;
+  constexpr int unroll_factor = cuda::ceil_div(128, cuda::next_power_of_two(Batches)); // Balance compile time and
+                                                                                       // performance
+  const auto& kernel =
+    benchmark_kernel<block_size, unroll_factor, benchmark_batched_op_t<LogicalWarpThreads>, cuda::std::array<T, Batches>>;
+
+  auto wspro_stages = 0;
+  for (int stride_inter_reduce = 2; stride_inter_reduce <= LogicalWarpThreads; stride_inter_reduce *= 2)
+  {
+    wspro_stages += cuda::ceil_div(Batches, stride_inter_reduce);
+  }
+  state.add_summary("Stages").set_int64("value", wspro_stages);
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launcher) {
+    kernel<<<grid_size, block_size, 0, launcher.get_stream()>>>(benchmark_batched_op_t<LogicalWarpThreads>{});
+  });
+}
+
+NVBENCH_BENCH_TYPES(warp_reduce_batched_latency,
+                    NVBENCH_TYPE_AXES(value_types, batches_list, logical_warp_threads_list))
+  .set_name("base-latency")
+  .set_type_axes_names({"T{ct}", "Batches", "LogicalWarpThreads"});
+
+/**
+ * @brief Run sequential warp reduction latency benchmark (baseline)
+ */
+template <typename T, nvbench::int32_t Batches, nvbench::int32_t LogicalWarpThreads>
+void warp_reduce_sequential_latency(
+  nvbench::state& state, nvbench::type_list<T, nvbench::enum_type<Batches>, nvbench::enum_type<LogicalWarpThreads>>)
+{
+  constexpr int block_size    = 32;
+  constexpr int grid_size     = 1;
+  constexpr int unroll_factor = cuda::ceil_div(128, cuda::next_power_of_two(Batches)); // Balance compile time and
+                                                                                       // performance
+  const auto& kernel =
+    benchmark_kernel<block_size,
+                     unroll_factor,
+                     benchmark_sequential_op_t<LogicalWarpThreads>,
+                     cuda::std::array<T, Batches>>;
+
+  const auto sequential_stages = Batches * cuda::ilog2(LogicalWarpThreads);
+  state.add_summary("Stages").set_int64("value", sequential_stages);
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launcher) {
+    kernel<<<grid_size, block_size, 0, launcher.get_stream()>>>(benchmark_sequential_op_t<LogicalWarpThreads>{});
+  });
+}
+
+NVBENCH_BENCH_TYPES(warp_reduce_sequential_latency,
+                    NVBENCH_TYPE_AXES(value_types, batches_list, logical_warp_threads_list))
+  .set_name("sequential-latency")
+  .set_type_axes_names({"T{ct}", "Batches", "LogicalWarpThreads"});

--- a/cub/benchmarks/bench/reduce/warp_reduce_batched_base.cuh
+++ b/cub/benchmarks/bench/reduce/warp_reduce_batched_base.cuh
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #pragma once
@@ -14,11 +14,6 @@
 #include <device_side_benchmark.cuh>
 #include <nvbench_helper.cuh>
 
-/**
- * @brief Benchmark operator for batched warp reduction
- *
- * Performs Batches reductions of LogicalWarpThreads elements each using WarpReduceBatched
- */
 template <int LogicalWarpThreads>
 struct benchmark_batched_op_t
 {
@@ -42,11 +37,6 @@ struct benchmark_batched_op_t
   }
 };
 
-/**
- * @brief Benchmark operator for sequential warp reductions (baseline)
- *
- * Performs Batches sequential calls to WarpReduce
- */
 template <int LogicalWarpThreads>
 struct benchmark_sequential_op_t
 {
@@ -97,9 +87,6 @@ launch_bounds_mode_t parse_launch_bounds_mode(nvbench::state& state)
 using batches_list              = nvbench::enum_type_list<8, 15, 16, 32, 64>;
 using logical_warp_threads_list = nvbench::enum_type_list<8, 16, 32>;
 
-/**
- * @brief Run batched warp reduction benchmark
- */
 template <typename T, nvbench::int32_t Batches, nvbench::int32_t LogicalWarpThreads>
 void warp_reduce_batched(nvbench::state& state,
                          nvbench::type_list<T, nvbench::enum_type<Batches>, nvbench::enum_type<LogicalWarpThreads>>)
@@ -140,9 +127,6 @@ NVBENCH_BENCH_TYPES(warp_reduce_batched, NVBENCH_TYPE_AXES(value_types, batches_
   .set_type_axes_names({"T{ct}", "Batches", "LogicalWarpThreads"})
   .add_string_axis("LaunchBoundsMode", {"partial", "full"});
 
-/**
- * @brief Run sequential warp reduction benchmark (baseline)
- */
 template <typename T, nvbench::int32_t Batches, nvbench::int32_t LogicalWarpThreads>
 void warp_reduce_sequential(nvbench::state& state,
                             nvbench::type_list<T, nvbench::enum_type<Batches>, nvbench::enum_type<LogicalWarpThreads>>)
@@ -179,9 +163,6 @@ NVBENCH_BENCH_TYPES(warp_reduce_sequential, NVBENCH_TYPE_AXES(value_types, batch
   .set_type_axes_names({"T{ct}", "Batches", "LogicalWarpThreads"})
   .add_string_axis("LaunchBoundsMode", {"partial", "full"});
 
-/**
- * @brief Run batched warp reduction latency benchmark
- */
 template <typename T, nvbench::int32_t Batches, nvbench::int32_t LogicalWarpThreads>
 void warp_reduce_batched_latency(
   nvbench::state& state, nvbench::type_list<T, nvbench::enum_type<Batches>, nvbench::enum_type<LogicalWarpThreads>>)
@@ -210,9 +191,6 @@ NVBENCH_BENCH_TYPES(warp_reduce_batched_latency,
   .set_name("base-latency")
   .set_type_axes_names({"T{ct}", "Batches", "LogicalWarpThreads"});
 
-/**
- * @brief Run sequential warp reduction latency benchmark (baseline)
- */
 template <typename T, nvbench::int32_t Batches, nvbench::int32_t LogicalWarpThreads>
 void warp_reduce_sequential_latency(
   nvbench::state& state, nvbench::type_list<T, nvbench::enum_type<Batches>, nvbench::enum_type<LogicalWarpThreads>>)

--- a/cub/benchmarks/bench/reduce/warp_reduce_batched_sum.cu
+++ b/cub/benchmarks/bench/reduce/warp_reduce_batched_sum.cu
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <nvbench_helper.cuh>
+
+using value_types = nvbench::type_list<int32_t, int64_t, float, double>;
+
+using op_t = ::cuda::std::plus<>;
+
+#include "warp_reduce_batched_base.cuh"

--- a/cub/benchmarks/bench/reduce/warp_reduce_batched_sum.cu
+++ b/cub/benchmarks/bench/reduce/warp_reduce_batched_sum.cu
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <nvbench_helper.cuh>

--- a/cub/cub/warp/specializations/warp_reduce_batched_wspro.cuh
+++ b/cub/cub/warp/specializations/warp_reduce_batched_wspro.cuh
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 //! @file
-//! cub::WarpReduceBatchedWspro provides WSPRO-based batched parallel reduction of items partitioned across a CUDA
+//! cub::warp_reduce_batched_wspro provides WSPRO-based batched parallel reduction of items partitioned across a CUDA
 //! thread warp.
 
 #pragma once
@@ -17,9 +17,11 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cub/util_arch.cuh>
 #include <cub/util_ptx.cuh>
 #include <cub/util_type.cuh>
-// For REDUX helper
+// Next two for REDUX helpers
+#include <cub/thread/thread_operators.cuh>
 #include <cub/warp/specializations/warp_reduce_shfl.cuh>
 
 #include <cuda/__cmath/ceil_div.h>
@@ -27,8 +29,8 @@
 #include <cuda/__ptx/instructions/get_sreg.h>
 #include <cuda/__utility/static_for.h>
 #include <cuda/__warp/warp_shuffle.h>
-#include <cuda/std/__functional/operations.h>
 #include <cuda/std/array>
+#include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
 
@@ -120,7 +122,7 @@ struct warp_reduce_batched_wspro
       _CCCL_PRAGMA_UNROLL_FULL()
       for (int i = 0; i < Batches; ++i)
       {
-        auto result         = reduce_op_sync(inputs[i], reduce_mask, reduction_op);
+        auto result         = cub::detail::reduce_op_sync(inputs[i], reduce_mask, reduction_op);
         const auto out_lane = ToBlocked ? i / max_out_per_thread : i % LogicalWarpThreads;
         const auto out_idx  = ToBlocked ? i % max_out_per_thread : i / LogicalWarpThreads;
         if (logical_lane_id == out_lane)

--- a/cub/cub/warp/warp_reduce_batched.cuh
+++ b/cub/cub/warp/warp_reduce_batched.cuh
@@ -26,7 +26,8 @@
 #include <cuda/__cmath/ceil_div.h>
 #include <cuda/__cmath/pow2.h>
 #include <cuda/std/__functional/operations.h>
-#include <cuda/std/__iterator/iterator_traits.h>
+#include <cuda/std/__iterator/readable_traits.h>
+#include <cuda/std/__type_traits/is_same.h>
 
 CUB_NAMESPACE_BEGIN
 
@@ -38,19 +39,20 @@ CUB_NAMESPACE_BEGIN
 //! ++++++++
 //!
 //! - A `reduction <http://en.wikipedia.org/wiki/Reduce_(higher-order_function)>`__ (or *fold*) uses a binary combining
-//!   operator to compute a single aggregate from a list of input elements.
-//! - Supports "logical" warps smaller than the physical warp size (e.g., logical warps of 8 threads)
+//!   operator to compute a single aggregate from a list of input elements. Parallel reductions are in general only
+//!   deterministic when the reduction operator is both commutative and associative.
+//! - Supports "logical" warps smaller than the physical warp size (e.g., logical warps of 8 threads).
 //! - This primitive performs batched reductions taking one item per batch per thread.
-//! - Results are distributed among the threads (given more batches than logical warp threads, either in a striped or
-//! blocked manner).
+//! - Results are distributed among the threads. When there are more batches than logical warp threads, results can be
+//!   distributed among threads in either striped or blocked manner.
 //! - The number of batches must be non-negative. Compile-time and register pressure increase with the number of
-//! batches.
+//!   batches.
 //!
 //! Performance Characteristics
 //! +++++++++++++++++++++++++++
 //!
-//! - Uses special instructions when applicable (e.g., warp ``SHFL`` instructions)
-//! - Uses synchronization-free communication between warp lanes when applicable
+//! - Uses special instructions when applicable (e.g., warp ``SHFL`` instructions).
+//! - Uses synchronization-free communication between warp lanes when applicable.
 //! - Should generally give much better performance than sequential ``WarpReduce`` calls independent of blocked or
 //! striped output arrangements.
 //! - Achieves peak efficiency when the number of batches is a multiple of the number of logical warp threads.
@@ -58,9 +60,9 @@ CUB_NAMESPACE_BEGIN
 //! performance than ``SyncPhysicalWarp = false``.
 //!   Note that it can cause a deadlock if not all non-exited logical warps from the same physical warp participate in
 //!   the reduction (due to branches).
-//! - Uneven number of batches are less efficient than the next higher even ones.
+//! - Any uneven number of batches is less efficient than the next higher even number.
 //! - For more batches than logical warp threads, the striped output can be slightly more performant than blocked output
-//! depending on the number of batches and the number of logical warp threads.
+//!   depending on the number of batches and the number of logical warp threads.
 //! - Blocked output should generally give much better performance than converting striped output to blocked using e.g.
 //! ``WarpExchange::StripedToBlocked()``.
 //! - For types of less than 4 bytes future optimization might let blocked output outperform striped output.
@@ -87,9 +89,9 @@ CUB_NAMESPACE_BEGIN
 //!   The number of batches to reduce. Also corresponds to the size of the range of inputs for each thread.
 //!
 //! @tparam LogicalWarpThreads
-//!   <b>[optional]</b> The number of threads per "logical" warp (may be less than the number of
+//!   **[optional]** The number of threads per "logical" warp (may be less than the number of
 //!   hardware warp threads but has to be a power of two).  Default is the warp size of the targeted CUDA
-//!   compute-capability (e.g., 32 threads for SM20).
+//!   compute-capability (e.g., 32 threads for SM80).
 //!
 template <typename T, int Batches, int LogicalWarpThreads = detail::warp_threads, bool SyncPhysicalWarp = false>
 class WarpReduceBatched

--- a/cub/test/warp/catch2_test_warp_reduce_batched_api.cu
+++ b/cub/test/warp/catch2_test_warp_reduce_batched_api.cu
@@ -326,11 +326,11 @@ __global__ __launch_bounds__(8) void WarpReduceBatchedSumToBlockedApiKernel(int*
   }
 }
 
-C2H_TEST("WarpReduceBatched::SumToStriped documentation kernel", "[warp][reduce][batched]")
+C2H_TEST("WarpReduceBatched::SumToBlocked documentation kernel", "[warp][reduce][batched]")
 {
   c2h::device_vector<int> d_out(20);
 
-  WarpReduceBatchedSumToStripedApiKernel<<<1, 8>>>(thrust::raw_pointer_cast(d_out.data()));
+  WarpReduceBatchedSumToBlockedApiKernel<<<1, 8>>>(thrust::raw_pointer_cast(d_out.data()));
   REQUIRE(cudaSuccess == cudaPeekAtLastError());
   REQUIRE(cudaSuccess == cudaDeviceSynchronize());
 

--- a/nvbench_helper/nvbench_helper/device_side_benchmark.cuh
+++ b/nvbench_helper/nvbench_helper/device_side_benchmark.cuh
@@ -21,23 +21,37 @@ __device__ __forceinline__ static T generate_random_data()
   return ret;
 }
 
-__device__ static int device_var[16];
+__device__ static int device_var[128];
 
 template <typename T>
 __device__ __forceinline__ static void sink(T value)
 {
+  static_assert(sizeof(T) <= sizeof(device_var), "value type too large to fit in device_var");
   if (cuda::ptx::get_sreg_smid() == static_cast<uint32_t>(-1))
   {
     *reinterpret_cast<T*>(device_var) = value;
   }
 }
 
-template <int BlockThreads, int UnrollFactor, typename ActionT, typename T>
-__launch_bounds__(BlockThreads) __global__ static void benchmark_kernel(_CCCL_GRID_CONSTANT const ActionT action)
+template <int UnrollFactor, typename T, typename ActionT>
+__device__ __forceinline__ static void benchmark_kernel_body(const ActionT& action)
 {
   auto data = generate_random_data<T>();
   cuda::static_for<UnrollFactor>([&]([[maybe_unused]] auto _) {
     data = action(data);
   });
   sink(data);
+}
+
+template <int BlockThreads, int UnrollFactor, typename ActionT, typename T>
+__launch_bounds__(BlockThreads) __global__ static void benchmark_kernel(_CCCL_GRID_CONSTANT const ActionT action)
+{
+  benchmark_kernel_body<UnrollFactor, T>(action);
+}
+
+template <int BlockThreads, int SmBlocks, int UnrollFactor, typename ActionT, typename T>
+__launch_bounds__(BlockThreads, SmBlocks) __global__
+  static void benchmark_kernel_full_bounds(_CCCL_GRID_CONSTANT const ActionT action)
+{
+  benchmark_kernel_body<UnrollFactor, T>(action);
 }


### PR DESCRIPTION
## Description

Split off from #7692 

I was unhappy with the `WarpReduce` benchmark as its workload depends on what occupancy the compiler deems best (which can change and therefore makes regression testing impossible). Therefore I implemented the benchmarks with static workloads. I also added a benchmark with full launch bounds for full occupancy/maximum register pressure and a latency benchmark using a single warp.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #8511 

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines]().
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
