### PR TITLE
[cccl.c] Add APIs for AoT compilation

### DIFF
--- a/c/parallel/include/cccl/c/binary_search.h
+++ b/c/parallel/include/cccl/c/binary_search.h
@@ -90,5 +90,13 @@ CCCL_C_API CUresult cccl_device_binary_search(
 
 CCCL_C_API CUresult cccl_device_binary_search_cleanup(cccl_device_binary_search_build_result_t* bld_ptr);
 
+// Serialize a compiled build result to a file.
+CCCL_C_API CUresult
+cccl_device_binary_search_save_file(const cccl_device_binary_search_build_result_t* build, const char* path);
+
+// Load a serialized build result from a file, then call cccl_device_binary_search_load().
+CCCL_C_API CUresult
+cccl_device_binary_search_load_file(cccl_device_binary_search_build_result_t* build, const char* path);
+
 CCCL_C_EXTERN_C_END
 // NOLINTEND(modernize-use-using)

--- a/c/parallel/include/cccl/c/binary_search.h
+++ b/c/parallel/include/cccl/c/binary_search.h
@@ -61,6 +61,25 @@ CCCL_C_API CUresult cccl_device_binary_search_build_ex(
   const char* ctk_path,
   cccl_build_config* config);
 
+// Compile-only step: populates cubin and lowered name; does NOT load into device.
+CCCL_C_API CUresult cccl_device_binary_search_compile(
+  cccl_device_binary_search_build_result_t* build,
+  cccl_binary_search_mode_t mode,
+  cccl_iterator_t d_data,
+  cccl_iterator_t d_values,
+  cccl_iterator_t d_out,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
+// Load step: calls cuLibraryLoadData + cuLibraryGetKernel.
+CCCL_C_API CUresult cccl_device_binary_search_load(cccl_device_binary_search_build_result_t* build);
+
 CCCL_C_API CUresult cccl_device_binary_search(
   cccl_device_binary_search_build_result_t build,
   cccl_iterator_t d_data,

--- a/c/parallel/include/cccl/c/binary_search.h
+++ b/c/parallel/include/cccl/c/binary_search.h
@@ -61,7 +61,6 @@ CCCL_C_API CUresult cccl_device_binary_search_build_ex(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Compile-only step: populates cubin and lowered name; does NOT load into device.
 CCCL_C_API CUresult cccl_device_binary_search_compile(
   cccl_device_binary_search_build_result_t* build,
   cccl_binary_search_mode_t mode,
@@ -77,7 +76,6 @@ CCCL_C_API CUresult cccl_device_binary_search_compile(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Load step: calls cuLibraryLoadData + cuLibraryGetKernel.
 CCCL_C_API CUresult cccl_device_binary_search_load(cccl_device_binary_search_build_result_t* build);
 
 CCCL_C_API CUresult cccl_device_binary_search(

--- a/c/parallel/include/cccl/c/for.h
+++ b/c/parallel/include/cccl/c/for.h
@@ -30,6 +30,7 @@ typedef struct cccl_device_for_build_result_t
   size_t cubin_size;
   CUlibrary library;
   CUkernel static_kernel;
+  char* static_kernel_lowered_name;
 } cccl_device_for_build_result_t;
 
 CCCL_C_API CUresult cccl_device_for_build(
@@ -55,6 +56,20 @@ CCCL_C_API CUresult cccl_device_for_build_ex(
   const char* libcudacxx_path,
   const char* ctk_path,
   cccl_build_config* config);
+
+CCCL_C_API CUresult cccl_device_for_compile(
+  cccl_device_for_build_result_t* build,
+  cccl_iterator_t d_data,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
+CCCL_C_API CUresult cccl_device_for_load(cccl_device_for_build_result_t* build);
 
 CCCL_C_API CUresult cccl_device_for(
   cccl_device_for_build_result_t build, cccl_iterator_t d_data, uint64_t num_items, cccl_op_t op, CUstream stream);

--- a/c/parallel/include/cccl/c/for.h
+++ b/c/parallel/include/cccl/c/for.h
@@ -76,5 +76,11 @@ CCCL_C_API CUresult cccl_device_for(
 
 CCCL_C_API CUresult cccl_device_for_cleanup(cccl_device_for_build_result_t* bld_ptr);
 
+// Serialize a compiled build result to a file.
+CCCL_C_API CUresult cccl_device_for_save_file(const cccl_device_for_build_result_t* build, const char* path);
+
+// Load a serialized build result from a file, then call cccl_device_for_load().
+CCCL_C_API CUresult cccl_device_for_load_file(cccl_device_for_build_result_t* build, const char* path);
+
 CCCL_C_EXTERN_C_END
 // NOLINTEND(modernize-use-using)

--- a/c/parallel/include/cccl/c/histogram.h
+++ b/c/parallel/include/cccl/c/histogram.h
@@ -38,6 +38,10 @@ typedef struct cccl_device_histogram_build_result_t
   CUkernel init_kernel;
   CUkernel sweep_kernel;
   void* runtime_policy;
+  size_t runtime_policy_size;
+  // Lowered (mangled) kernel names, heap-allocated, freed by cccl_device_histogram_cleanup():
+  char* init_kernel_lowered_name;
+  char* sweep_kernel_lowered_name;
 } cccl_device_histogram_build_result_t;
 
 CCCL_C_API CUresult cccl_device_histogram_build(
@@ -77,6 +81,29 @@ CCCL_C_API CUresult cccl_device_histogram_build_ex(
   const char* libcudacxx_path,
   const char* ctk_path,
   cccl_build_config* config);
+
+// Compile-only step: populates cubin, lowered names, and policy; does NOT load into device.
+CCCL_C_API CUresult cccl_device_histogram_compile(
+  cccl_device_histogram_build_result_t* build,
+  int num_channels,
+  int num_active_channels,
+  cccl_iterator_t d_samples,
+  int num_output_levels_val,
+  cccl_iterator_t d_output_histograms,
+  cccl_value_t lower_level,
+  int64_t num_rows,
+  int64_t row_stride_samples,
+  bool is_evenly_segmented,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
+// Load step: calls cuLibraryLoadData + cuLibraryGetKernel for init and sweep kernels.
+CCCL_C_API CUresult cccl_device_histogram_load(cccl_device_histogram_build_result_t* build);
 
 CCCL_C_API CUresult cccl_device_histogram_even(
   cccl_device_histogram_build_result_t build,

--- a/c/parallel/include/cccl/c/histogram.h
+++ b/c/parallel/include/cccl/c/histogram.h
@@ -119,5 +119,11 @@ CCCL_C_API CUresult cccl_device_histogram_even(
 
 CCCL_C_API CUresult cccl_device_histogram_cleanup(cccl_device_histogram_build_result_t* bld_ptr);
 
+// Serialize a compiled build result to a file.
+CCCL_C_API CUresult cccl_device_histogram_save_file(const cccl_device_histogram_build_result_t* build, const char* path);
+
+// Load a serialized build result from a file, then call cccl_device_histogram_load().
+CCCL_C_API CUresult cccl_device_histogram_load_file(cccl_device_histogram_build_result_t* build, const char* path);
+
 CCCL_C_EXTERN_C_END
 // NOLINTEND(modernize-use-using)

--- a/c/parallel/include/cccl/c/histogram.h
+++ b/c/parallel/include/cccl/c/histogram.h
@@ -82,7 +82,6 @@ CCCL_C_API CUresult cccl_device_histogram_build_ex(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Compile-only step: populates cubin, lowered names, and policy; does NOT load into device.
 CCCL_C_API CUresult cccl_device_histogram_compile(
   cccl_device_histogram_build_result_t* build,
   int num_channels,
@@ -102,7 +101,6 @@ CCCL_C_API CUresult cccl_device_histogram_compile(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Load step: calls cuLibraryLoadData + cuLibraryGetKernel for init and sweep kernels.
 CCCL_C_API CUresult cccl_device_histogram_load(cccl_device_histogram_build_result_t* build);
 
 CCCL_C_API CUresult cccl_device_histogram_even(

--- a/c/parallel/include/cccl/c/merge_sort.h
+++ b/c/parallel/include/cccl/c/merge_sort.h
@@ -35,6 +35,11 @@ typedef struct cccl_device_merge_sort_build_result_t
   CUkernel partition_kernel;
   CUkernel merge_kernel;
   void* runtime_policy;
+  size_t runtime_policy_size;
+  // Lowered (mangled) kernel names, heap-allocated, freed by cccl_device_merge_sort_cleanup():
+  char* block_sort_kernel_lowered_name;
+  char* partition_kernel_lowered_name;
+  char* merge_kernel_lowered_name;
 } cccl_device_merge_sort_build_result_t;
 
 CCCL_C_API CUresult cccl_device_merge_sort_build(
@@ -66,6 +71,25 @@ CCCL_C_API CUresult cccl_device_merge_sort_build_ex(
   const char* libcudacxx_path,
   const char* ctk_path,
   cccl_build_config* config);
+
+// Compile-only step: populates cubin, lowered names, and policy; does NOT load into device.
+CCCL_C_API CUresult cccl_device_merge_sort_compile(
+  cccl_device_merge_sort_build_result_t* build,
+  cccl_iterator_t d_in_keys,
+  cccl_iterator_t d_in_items,
+  cccl_iterator_t d_out_keys,
+  cccl_iterator_t d_out_items,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
+// Load step: calls cuLibraryLoadData + cuLibraryGetKernel for all kernels.
+CCCL_C_API CUresult cccl_device_merge_sort_load(cccl_device_merge_sort_build_result_t* build);
 
 CCCL_C_API CUresult cccl_device_merge_sort(
   cccl_device_merge_sort_build_result_t build,

--- a/c/parallel/include/cccl/c/merge_sort.h
+++ b/c/parallel/include/cccl/c/merge_sort.h
@@ -103,5 +103,12 @@ CCCL_C_API CUresult cccl_device_merge_sort(
 
 CCCL_C_API CUresult cccl_device_merge_sort_cleanup(cccl_device_merge_sort_build_result_t* bld_ptr);
 
+// Serialize a compiled build result to a file.
+CCCL_C_API CUresult
+cccl_device_merge_sort_save_file(const cccl_device_merge_sort_build_result_t* build, const char* path);
+
+// Load a serialized build result from a file, then call cccl_device_merge_sort_load().
+CCCL_C_API CUresult cccl_device_merge_sort_load_file(cccl_device_merge_sort_build_result_t* build, const char* path);
+
 CCCL_C_EXTERN_C_END
 // NOLINTEND(modernize-use-using)

--- a/c/parallel/include/cccl/c/merge_sort.h
+++ b/c/parallel/include/cccl/c/merge_sort.h
@@ -72,7 +72,6 @@ CCCL_C_API CUresult cccl_device_merge_sort_build_ex(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Compile-only step: populates cubin, lowered names, and policy; does NOT load into device.
 CCCL_C_API CUresult cccl_device_merge_sort_compile(
   cccl_device_merge_sort_build_result_t* build,
   cccl_iterator_t d_in_keys,
@@ -88,7 +87,6 @@ CCCL_C_API CUresult cccl_device_merge_sort_compile(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Load step: calls cuLibraryLoadData + cuLibraryGetKernel for all kernels.
 CCCL_C_API CUresult cccl_device_merge_sort_load(cccl_device_merge_sort_build_result_t* build);
 
 CCCL_C_API CUresult cccl_device_merge_sort(

--- a/c/parallel/include/cccl/c/radix_sort.h
+++ b/c/parallel/include/cccl/c/radix_sort.h
@@ -43,6 +43,17 @@ typedef struct cccl_device_radix_sort_build_result_t
   CUkernel onesweep_kernel;
   cccl_sort_order_t order;
   void* runtime_policy;
+  size_t runtime_policy_size;
+  // Lowered (mangled) kernel names, heap-allocated, freed by cccl_device_radix_sort_cleanup():
+  char* single_tile_kernel_lowered_name;
+  char* upsweep_kernel_lowered_name;
+  char* alt_upsweep_kernel_lowered_name;
+  char* scan_bins_kernel_lowered_name;
+  char* downsweep_kernel_lowered_name;
+  char* alt_downsweep_kernel_lowered_name;
+  char* histogram_kernel_lowered_name;
+  char* exclusive_sum_kernel_lowered_name;
+  char* onesweep_kernel_lowered_name;
 } cccl_device_radix_sort_build_result_t;
 
 CCCL_C_API CUresult cccl_device_radix_sort_build(
@@ -74,6 +85,25 @@ CCCL_C_API CUresult cccl_device_radix_sort_build_ex(
   const char* libcudacxx_path,
   const char* ctk_path,
   cccl_build_config* config);
+
+// Compile-only step: populates cubin, lowered names, and policy; does NOT load into device.
+CCCL_C_API CUresult cccl_device_radix_sort_compile(
+  cccl_device_radix_sort_build_result_t* build,
+  cccl_sort_order_t sort_order,
+  cccl_iterator_t input_keys_it,
+  cccl_iterator_t input_values_it,
+  cccl_op_t decomposer,
+  const char* decomposer_return_type,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
+// Load step: calls cuLibraryLoadData + cuLibraryGetKernel for all 9 kernels.
+CCCL_C_API CUresult cccl_device_radix_sort_load(cccl_device_radix_sort_build_result_t* build);
 
 CCCL_C_API CUresult cccl_device_radix_sort(
   cccl_device_radix_sort_build_result_t build,

--- a/c/parallel/include/cccl/c/radix_sort.h
+++ b/c/parallel/include/cccl/c/radix_sort.h
@@ -86,7 +86,6 @@ CCCL_C_API CUresult cccl_device_radix_sort_build_ex(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Compile-only step: populates cubin, lowered names, and policy; does NOT load into device.
 CCCL_C_API CUresult cccl_device_radix_sort_compile(
   cccl_device_radix_sort_build_result_t* build,
   cccl_sort_order_t sort_order,
@@ -102,7 +101,6 @@ CCCL_C_API CUresult cccl_device_radix_sort_compile(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Load step: calls cuLibraryLoadData + cuLibraryGetKernel for all 9 kernels.
 CCCL_C_API CUresult cccl_device_radix_sort_load(cccl_device_radix_sort_build_result_t* build);
 
 CCCL_C_API CUresult cccl_device_radix_sort(

--- a/c/parallel/include/cccl/c/radix_sort.h
+++ b/c/parallel/include/cccl/c/radix_sort.h
@@ -121,5 +121,12 @@ CCCL_C_API CUresult cccl_device_radix_sort(
 
 CCCL_C_API CUresult cccl_device_radix_sort_cleanup(cccl_device_radix_sort_build_result_t* bld_ptr);
 
+// Serialize a compiled build result to a file.
+CCCL_C_API CUresult
+cccl_device_radix_sort_save_file(const cccl_device_radix_sort_build_result_t* build, const char* path);
+
+// Load a serialized build result from a file, then call cccl_device_radix_sort_load().
+CCCL_C_API CUresult cccl_device_radix_sort_load_file(cccl_device_radix_sort_build_result_t* build, const char* path);
+
 CCCL_C_EXTERN_C_END
 // NOLINTEND(modernize-use-using)

--- a/c/parallel/include/cccl/c/reduce.h
+++ b/c/parallel/include/cccl/c/reduce.h
@@ -116,5 +116,11 @@ CCCL_C_API CUresult cccl_device_reduce_nondeterministic(
 
 CCCL_C_API CUresult cccl_device_reduce_cleanup(cccl_device_reduce_build_result_t* bld_ptr);
 
+// Serialize a compiled build result to a file.
+CCCL_C_API CUresult cccl_device_reduce_save_file(const cccl_device_reduce_build_result_t* build, const char* path);
+
+// Load a serialized build result from a file, then call cccl_device_reduce_load().
+CCCL_C_API CUresult cccl_device_reduce_load_file(cccl_device_reduce_build_result_t* build, const char* path);
+
 CCCL_C_EXTERN_C_END
 // NOLINTEND(modernize-use-using)

--- a/c/parallel/include/cccl/c/reduce.h
+++ b/c/parallel/include/cccl/c/reduce.h
@@ -75,7 +75,6 @@ CCCL_C_API CUresult cccl_device_reduce_build_ex(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Compile-only step: populates cubin, lowered names, and policy fields; does NOT load into device.
 CCCL_C_API CUresult cccl_device_reduce_compile(
   cccl_device_reduce_build_result_t* build,
   cccl_iterator_t d_in,
@@ -91,7 +90,6 @@ CCCL_C_API CUresult cccl_device_reduce_compile(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Load step: calls cuLibraryLoadData + cuLibraryGetKernel for all kernels.
 CCCL_C_API CUresult cccl_device_reduce_load(cccl_device_reduce_build_result_t* build);
 
 CCCL_C_API CUresult cccl_device_reduce(

--- a/c/parallel/include/cccl/c/reduce.h
+++ b/c/parallel/include/cccl/c/reduce.h
@@ -36,6 +36,12 @@ typedef struct cccl_device_reduce_build_result_t
   CUkernel nondeterministic_atomic_kernel;
   cccl_determinism_t determinism;
   void* runtime_policy;
+  size_t runtime_policy_size;
+  // Lowered (mangled) kernel names, heap-allocated, freed by cccl_device_reduce_cleanup():
+  char* single_tile_kernel_lowered_name;
+  char* single_tile_second_kernel_lowered_name;
+  char* reduction_kernel_lowered_name;
+  char* nondeterministic_kernel_lowered_name;
 } cccl_device_reduce_build_result_t;
 
 // TODO return a union of nvtx/cuda/nvrtc errors or a string?
@@ -68,6 +74,25 @@ CCCL_C_API CUresult cccl_device_reduce_build_ex(
   const char* libcudacxx_path,
   const char* ctk_path,
   cccl_build_config* config);
+
+// Compile-only step: populates cubin, lowered names, and policy fields; does NOT load into device.
+CCCL_C_API CUresult cccl_device_reduce_compile(
+  cccl_device_reduce_build_result_t* build,
+  cccl_iterator_t d_in,
+  cccl_iterator_t d_out,
+  cccl_op_t op,
+  cccl_value_t init,
+  cccl_determinism_t determinism,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
+// Load step: calls cuLibraryLoadData + cuLibraryGetKernel for all kernels.
+CCCL_C_API CUresult cccl_device_reduce_load(cccl_device_reduce_build_result_t* build);
 
 CCCL_C_API CUresult cccl_device_reduce(
   cccl_device_reduce_build_result_t build,

--- a/c/parallel/include/cccl/c/scan.h
+++ b/c/parallel/include/cccl/c/scan.h
@@ -152,5 +152,11 @@ CCCL_C_API CUresult cccl_device_inclusive_scan_no_init(
 
 CCCL_C_API CUresult cccl_device_scan_cleanup(cccl_device_scan_build_result_t* bld_ptr);
 
+// Serialize a compiled build result to a file.
+CCCL_C_API CUresult cccl_device_scan_save_file(const cccl_device_scan_build_result_t* build, const char* path);
+
+// Load a serialized build result from a file, then call cccl_device_scan_load().
+CCCL_C_API CUresult cccl_device_scan_load_file(cccl_device_scan_build_result_t* build, const char* path);
+
 CCCL_C_EXTERN_C_END
 // NOLINTEND(modernize-use-using)

--- a/c/parallel/include/cccl/c/scan.h
+++ b/c/parallel/include/cccl/c/scan.h
@@ -40,6 +40,10 @@ typedef struct cccl_device_scan_build_result_t
   size_t description_bytes_per_tile;
   size_t payload_bytes_per_tile;
   void* runtime_policy;
+  size_t runtime_policy_size;
+  // Lowered (mangled) kernel names, heap-allocated, freed by cccl_device_scan_cleanup():
+  char* init_kernel_lowered_name;
+  char* scan_kernel_lowered_name;
 } cccl_device_scan_build_result_t;
 
 CCCL_C_API CUresult cccl_device_scan_build(
@@ -73,6 +77,26 @@ CCCL_C_API CUresult cccl_device_scan_build_ex(
   const char* libcudacxx_path,
   const char* ctk_path,
   cccl_build_config* config);
+
+// Compile-only step: populates cubin, lowered names, and policy fields; does NOT load into device.
+CCCL_C_API CUresult cccl_device_scan_compile(
+  cccl_device_scan_build_result_t* build_ptr,
+  cccl_iterator_t d_in,
+  cccl_iterator_t d_out,
+  cccl_op_t op,
+  cccl_type_info init,
+  bool force_inclusive,
+  cccl_init_kind_t init_kind,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
+// Load step: calls cuLibraryLoadData + cuLibraryGetKernel for all kernels.
+CCCL_C_API CUresult cccl_device_scan_load(cccl_device_scan_build_result_t* build_ptr);
 
 CCCL_C_API CUresult cccl_device_exclusive_scan(
   cccl_device_scan_build_result_t build,

--- a/c/parallel/include/cccl/c/scan.h
+++ b/c/parallel/include/cccl/c/scan.h
@@ -78,7 +78,6 @@ CCCL_C_API CUresult cccl_device_scan_build_ex(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Compile-only step: populates cubin, lowered names, and policy fields; does NOT load into device.
 CCCL_C_API CUresult cccl_device_scan_compile(
   cccl_device_scan_build_result_t* build_ptr,
   cccl_iterator_t d_in,
@@ -95,7 +94,6 @@ CCCL_C_API CUresult cccl_device_scan_compile(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Load step: calls cuLibraryLoadData + cuLibraryGetKernel for all kernels.
 CCCL_C_API CUresult cccl_device_scan_load(cccl_device_scan_build_result_t* build_ptr);
 
 CCCL_C_API CUresult cccl_device_exclusive_scan(

--- a/c/parallel/include/cccl/c/segmented_reduce.h
+++ b/c/parallel/include/cccl/c/segmented_reduce.h
@@ -70,7 +70,6 @@ CCCL_C_API CUresult cccl_device_segmented_reduce_build_ex(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Compile-only step: populates cubin, lowered name, and policy; does NOT load into device.
 CCCL_C_API CUresult cccl_device_segmented_reduce_compile(
   cccl_device_segmented_reduce_build_result_t* build,
   cccl_iterator_t d_in,
@@ -87,7 +86,6 @@ CCCL_C_API CUresult cccl_device_segmented_reduce_compile(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Load step: calls cuLibraryLoadData + cuLibraryGetKernel.
 CCCL_C_API CUresult cccl_device_segmented_reduce_load(cccl_device_segmented_reduce_build_result_t* build);
 
 CCCL_C_API CUresult cccl_device_segmented_reduce(

--- a/c/parallel/include/cccl/c/segmented_reduce.h
+++ b/c/parallel/include/cccl/c/segmented_reduce.h
@@ -32,6 +32,9 @@ typedef struct cccl_device_segmented_reduce_build_result_t
   uint64_t accumulator_size;
   CUkernel segmented_reduce_kernel;
   void* runtime_policy;
+  size_t runtime_policy_size;
+  // Lowered (mangled) kernel name, heap-allocated, freed by cccl_device_segmented_reduce_cleanup():
+  char* segmented_reduce_kernel_lowered_name;
 } cccl_device_segmented_reduce_build_result_t;
 
 // TODO return a union of nvtx/cuda/nvrtc errors or a string?
@@ -66,6 +69,26 @@ CCCL_C_API CUresult cccl_device_segmented_reduce_build_ex(
   const char* libcudacxx_path,
   const char* ctk_path,
   cccl_build_config* config);
+
+// Compile-only step: populates cubin, lowered name, and policy; does NOT load into device.
+CCCL_C_API CUresult cccl_device_segmented_reduce_compile(
+  cccl_device_segmented_reduce_build_result_t* build,
+  cccl_iterator_t d_in,
+  cccl_iterator_t d_out,
+  cccl_iterator_t begin_offset_in,
+  cccl_iterator_t end_offset_in,
+  cccl_op_t op,
+  cccl_value_t init,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
+// Load step: calls cuLibraryLoadData + cuLibraryGetKernel.
+CCCL_C_API CUresult cccl_device_segmented_reduce_load(cccl_device_segmented_reduce_build_result_t* build);
 
 CCCL_C_API CUresult cccl_device_segmented_reduce(
   cccl_device_segmented_reduce_build_result_t build,

--- a/c/parallel/include/cccl/c/segmented_reduce.h
+++ b/c/parallel/include/cccl/c/segmented_reduce.h
@@ -104,5 +104,13 @@ CCCL_C_API CUresult cccl_device_segmented_reduce(
 
 CCCL_C_API CUresult cccl_device_segmented_reduce_cleanup(cccl_device_segmented_reduce_build_result_t* bld_ptr);
 
+// Serialize a compiled build result to a file.
+CCCL_C_API CUresult
+cccl_device_segmented_reduce_save_file(const cccl_device_segmented_reduce_build_result_t* build, const char* path);
+
+// Load a serialized build result from a file, then call cccl_device_segmented_reduce_load().
+CCCL_C_API CUresult
+cccl_device_segmented_reduce_load_file(cccl_device_segmented_reduce_build_result_t* build, const char* path);
+
 CCCL_C_EXTERN_C_END
 // NOLINTEND(modernize-use-using)

--- a/c/parallel/include/cccl/c/segmented_sort.h
+++ b/c/parallel/include/cccl/c/segmented_sort.h
@@ -40,8 +40,16 @@ typedef struct cccl_device_segmented_sort_build_result_t
   CUkernel three_way_partition_init_kernel;
   CUkernel three_way_partition_kernel;
   void* runtime_policy;
+  size_t runtime_policy_size;
   void* partition_runtime_policy;
+  size_t partition_runtime_policy_size;
   cccl_sort_order_t order;
+  // Lowered (mangled) kernel names, heap-allocated, freed by cccl_device_segmented_sort_cleanup():
+  char* segmented_sort_fallback_kernel_lowered_name;
+  char* segmented_sort_kernel_small_lowered_name;
+  char* segmented_sort_kernel_large_lowered_name;
+  char* three_way_partition_init_kernel_lowered_name;
+  char* three_way_partition_kernel_lowered_name;
 } cccl_device_segmented_sort_build_result_t;
 
 // TODO return a union of nvtx/cuda/nvrtc errors or a string?
@@ -74,6 +82,25 @@ CCCL_C_API CUresult cccl_device_segmented_sort_build_ex(
   const char* libcudacxx_path,
   const char* ctk_path,
   cccl_build_config* config);
+
+// Compile-only step: populates cubin, lowered names, and policy; does NOT load into device.
+CCCL_C_API CUresult cccl_device_segmented_sort_compile(
+  cccl_device_segmented_sort_build_result_t* build,
+  cccl_sort_order_t sort_order,
+  cccl_iterator_t d_keys_in,
+  cccl_iterator_t d_values_in,
+  cccl_iterator_t begin_offset_in,
+  cccl_iterator_t end_offset_in,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
+// Load step: calls cuLibraryLoadData + cuLibraryGetKernel for all 5 kernels.
+CCCL_C_API CUresult cccl_device_segmented_sort_load(cccl_device_segmented_sort_build_result_t* build);
 
 CCCL_C_API CUresult cccl_device_segmented_sort(
   cccl_device_segmented_sort_build_result_t build,

--- a/c/parallel/include/cccl/c/segmented_sort.h
+++ b/c/parallel/include/cccl/c/segmented_sort.h
@@ -118,5 +118,13 @@ CCCL_C_API CUresult cccl_device_segmented_sort(
 
 CCCL_C_API CUresult cccl_device_segmented_sort_cleanup(cccl_device_segmented_sort_build_result_t* bld_ptr);
 
+// Serialize a compiled build result to a file.
+CCCL_C_API CUresult
+cccl_device_segmented_sort_save_file(const cccl_device_segmented_sort_build_result_t* build, const char* path);
+
+// Load a serialized build result from a file, then call cccl_device_segmented_sort_load().
+CCCL_C_API CUresult
+cccl_device_segmented_sort_load_file(cccl_device_segmented_sort_build_result_t* build, const char* path);
+
 CCCL_C_EXTERN_C_END
 // NOLINTEND(modernize-use-using)

--- a/c/parallel/include/cccl/c/segmented_sort.h
+++ b/c/parallel/include/cccl/c/segmented_sort.h
@@ -83,7 +83,6 @@ CCCL_C_API CUresult cccl_device_segmented_sort_build_ex(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Compile-only step: populates cubin, lowered names, and policy; does NOT load into device.
 CCCL_C_API CUresult cccl_device_segmented_sort_compile(
   cccl_device_segmented_sort_build_result_t* build,
   cccl_sort_order_t sort_order,
@@ -99,7 +98,6 @@ CCCL_C_API CUresult cccl_device_segmented_sort_compile(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Load step: calls cuLibraryLoadData + cuLibraryGetKernel for all 5 kernels.
 CCCL_C_API CUresult cccl_device_segmented_sort_load(cccl_device_segmented_sort_build_result_t* build);
 
 CCCL_C_API CUresult cccl_device_segmented_sort(

--- a/c/parallel/include/cccl/c/three_way_partition.h
+++ b/c/parallel/include/cccl/c/three_way_partition.h
@@ -32,6 +32,10 @@ typedef struct cccl_device_three_way_partition_build_result_t
   CUkernel three_way_partition_init_kernel;
   CUkernel three_way_partition_kernel;
   void* runtime_policy;
+  size_t runtime_policy_size;
+  // Lowered (mangled) kernel names, heap-allocated, freed by cccl_device_three_way_partition_cleanup():
+  char* three_way_partition_init_kernel_lowered_name;
+  char* three_way_partition_kernel_lowered_name;
 } cccl_device_three_way_partition_build_result_t;
 
 // TODO return a union of nvtx/cuda/nvrtc errors or a string?
@@ -68,6 +72,27 @@ CCCL_C_API CUresult cccl_device_three_way_partition_build_ex(
   const char* libcudacxx_path,
   const char* ctk_path,
   cccl_build_config* config);
+
+// Compile-only step: populates cubin, lowered names, and policy; does NOT load into device.
+CCCL_C_API CUresult cccl_device_three_way_partition_compile(
+  cccl_device_three_way_partition_build_result_t* build,
+  cccl_iterator_t d_in,
+  cccl_iterator_t d_first_part_out,
+  cccl_iterator_t d_second_part_out,
+  cccl_iterator_t d_unselected_out,
+  cccl_iterator_t d_num_selected_out,
+  cccl_op_t select_first_part_op,
+  cccl_op_t select_second_part_op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
+// Load step: calls cuLibraryLoadData + cuLibraryGetKernel for init and partition kernels.
+CCCL_C_API CUresult cccl_device_three_way_partition_load(cccl_device_three_way_partition_build_result_t* build);
 
 CCCL_C_API CUresult cccl_device_three_way_partition(
   cccl_device_three_way_partition_build_result_t build,

--- a/c/parallel/include/cccl/c/three_way_partition.h
+++ b/c/parallel/include/cccl/c/three_way_partition.h
@@ -73,7 +73,6 @@ CCCL_C_API CUresult cccl_device_three_way_partition_build_ex(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Compile-only step: populates cubin, lowered names, and policy; does NOT load into device.
 CCCL_C_API CUresult cccl_device_three_way_partition_compile(
   cccl_device_three_way_partition_build_result_t* build,
   cccl_iterator_t d_in,
@@ -91,7 +90,6 @@ CCCL_C_API CUresult cccl_device_three_way_partition_compile(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Load step: calls cuLibraryLoadData + cuLibraryGetKernel for init and partition kernels.
 CCCL_C_API CUresult cccl_device_three_way_partition_load(cccl_device_three_way_partition_build_result_t* build);
 
 CCCL_C_API CUresult cccl_device_three_way_partition(

--- a/c/parallel/include/cccl/c/three_way_partition.h
+++ b/c/parallel/include/cccl/c/three_way_partition.h
@@ -108,5 +108,13 @@ CCCL_C_API CUresult cccl_device_three_way_partition(
 
 CCCL_C_API CUresult cccl_device_three_way_partition_cleanup(cccl_device_three_way_partition_build_result_t* bld_ptr);
 
+// Serialize a compiled build result to a file.
+CCCL_C_API CUresult cccl_device_three_way_partition_save_file(
+  const cccl_device_three_way_partition_build_result_t* build, const char* path);
+
+// Load a serialized build result from a file, then call cccl_device_three_way_partition_load().
+CCCL_C_API CUresult
+cccl_device_three_way_partition_load_file(cccl_device_three_way_partition_build_result_t* build, const char* path);
+
 CCCL_C_EXTERN_C_END
 // NOLINTEND(modernize-use-using)

--- a/c/parallel/include/cccl/c/transform.h
+++ b/c/parallel/include/cccl/c/transform.h
@@ -139,5 +139,11 @@ CCCL_C_API CUresult cccl_device_binary_transform(
 
 CCCL_C_API CUresult cccl_device_transform_cleanup(cccl_device_transform_build_result_t* bld_ptr);
 
+// Serialize a compiled build result to a file.
+CCCL_C_API CUresult cccl_device_transform_save_file(const cccl_device_transform_build_result_t* build, const char* path);
+
+// Load a serialized build result from a file, then call cccl_device_transform_load().
+CCCL_C_API CUresult cccl_device_transform_load_file(cccl_device_transform_build_result_t* build, const char* path);
+
 CCCL_C_EXTERN_C_END
 // NOLINTEND(modernize-use-using)

--- a/c/parallel/include/cccl/c/transform.h
+++ b/c/parallel/include/cccl/c/transform.h
@@ -31,7 +31,10 @@ typedef struct cccl_device_transform_build_result_t
   CUkernel transform_kernel;
   int loaded_bytes_per_iteration;
   void* runtime_policy;
+  size_t runtime_policy_size;
   void* cache;
+  // Lowered (mangled) kernel name, heap-allocated, freed by cccl_device_transform_cleanup():
+  char* transform_kernel_lowered_name;
 } cccl_device_transform_build_result_t;
 
 CCCL_C_API CUresult cccl_device_unary_transform_build(
@@ -60,6 +63,23 @@ CCCL_C_API CUresult cccl_device_unary_transform_build_ex(
   const char* ctk_path,
   cccl_build_config* config);
 
+// Compile-only step for unary transform: populates cubin, lowered name, and policy; does NOT load into device.
+CCCL_C_API CUresult cccl_device_unary_transform_compile(
+  cccl_device_transform_build_result_t* build_ptr,
+  cccl_iterator_t d_in,
+  cccl_iterator_t d_out,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
+// Load step (shared for unary and binary): calls cuLibraryLoadData + cuLibraryGetKernel.
+CCCL_C_API CUresult cccl_device_transform_load(cccl_device_transform_build_result_t* build_ptr);
+
 CCCL_C_API CUresult cccl_device_unary_transform(
   cccl_device_transform_build_result_t build,
   cccl_iterator_t d_in,
@@ -83,6 +103,21 @@ CCCL_C_API CUresult cccl_device_binary_transform_build(
 
 // Extended version with build configuration
 CCCL_C_API CUresult cccl_device_binary_transform_build_ex(
+  cccl_device_transform_build_result_t* build_ptr,
+  cccl_iterator_t d_in1,
+  cccl_iterator_t d_in2,
+  cccl_iterator_t d_out,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
+// Compile-only step for binary transform: populates cubin, lowered name, and policy; does NOT load into device.
+CCCL_C_API CUresult cccl_device_binary_transform_compile(
   cccl_device_transform_build_result_t* build_ptr,
   cccl_iterator_t d_in1,
   cccl_iterator_t d_in2,

--- a/c/parallel/include/cccl/c/transform.h
+++ b/c/parallel/include/cccl/c/transform.h
@@ -63,7 +63,6 @@ CCCL_C_API CUresult cccl_device_unary_transform_build_ex(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Compile-only step for unary transform: populates cubin, lowered name, and policy; does NOT load into device.
 CCCL_C_API CUresult cccl_device_unary_transform_compile(
   cccl_device_transform_build_result_t* build_ptr,
   cccl_iterator_t d_in,
@@ -77,7 +76,6 @@ CCCL_C_API CUresult cccl_device_unary_transform_compile(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Load step (shared for unary and binary): calls cuLibraryLoadData + cuLibraryGetKernel.
 CCCL_C_API CUresult cccl_device_transform_load(cccl_device_transform_build_result_t* build_ptr);
 
 CCCL_C_API CUresult cccl_device_unary_transform(
@@ -116,7 +114,6 @@ CCCL_C_API CUresult cccl_device_binary_transform_build_ex(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Compile-only step for binary transform: populates cubin, lowered name, and policy; does NOT load into device.
 CCCL_C_API CUresult cccl_device_binary_transform_compile(
   cccl_device_transform_build_result_t* build_ptr,
   cccl_iterator_t d_in1,

--- a/c/parallel/include/cccl/c/types.h
+++ b/c/parallel/include/cccl/c/types.h
@@ -175,5 +175,12 @@ typedef enum cccl_binary_search_mode_t
   CCCL_BINARY_SEARCH_UPPER_BOUND = 1,
 } cccl_binary_search_mode_t;
 
+typedef enum cccl_ltoir_input_type
+{
+  CCCL_LTOIR_INPUT_LTOIR  = 0, // Raw LTO-IR blob
+  CCCL_LTOIR_INPUT_OBJECT = 1, // Relocatable object (nvcc -dc -dlto output)
+  CCCL_LTOIR_INPUT_FATBIN = 2, // Fatbin container
+} cccl_ltoir_input_type;
+
 CCCL_C_EXTERN_C_END
 // NOLINTEND(modernize-use-using)

--- a/c/parallel/include/cccl/c/unique_by_key.h
+++ b/c/parallel/include/cccl/c/unique_by_key.h
@@ -105,5 +105,13 @@ CCCL_C_API CUresult cccl_device_unique_by_key(
 
 CCCL_C_API CUresult cccl_device_unique_by_key_cleanup(cccl_device_unique_by_key_build_result_t* bld_ptr);
 
+// Serialize a compiled build result to a file.
+CCCL_C_API CUresult
+cccl_device_unique_by_key_save_file(const cccl_device_unique_by_key_build_result_t* build, const char* path);
+
+// Load a serialized build result from a file, then call cccl_device_unique_by_key_load().
+CCCL_C_API CUresult
+cccl_device_unique_by_key_load_file(cccl_device_unique_by_key_build_result_t* build, const char* path);
+
 CCCL_C_EXTERN_C_END
 // NOLINTEND(modernize-use-using)

--- a/c/parallel/include/cccl/c/unique_by_key.h
+++ b/c/parallel/include/cccl/c/unique_by_key.h
@@ -34,6 +34,10 @@ typedef struct cccl_device_unique_by_key_build_result_t
   size_t description_bytes_per_tile;
   size_t payload_bytes_per_tile;
   void* runtime_policy;
+  size_t runtime_policy_size;
+  // Lowered (mangled) kernel names, heap-allocated, freed by cccl_device_unique_by_key_cleanup():
+  char* compact_init_kernel_lowered_name;
+  char* sweep_kernel_lowered_name;
 } cccl_device_unique_by_key_build_result_t;
 
 CCCL_C_API CUresult cccl_device_unique_by_key_build(
@@ -67,6 +71,26 @@ CCCL_C_API CUresult cccl_device_unique_by_key_build_ex(
   const char* libcudacxx_path,
   const char* ctk_path,
   cccl_build_config* config);
+
+// Compile-only step: populates cubin, lowered names, and policy; does NOT load into device.
+CCCL_C_API CUresult cccl_device_unique_by_key_compile(
+  cccl_device_unique_by_key_build_result_t* build,
+  cccl_iterator_t d_keys_in,
+  cccl_iterator_t d_values_in,
+  cccl_iterator_t d_keys_out,
+  cccl_iterator_t d_values_out,
+  cccl_iterator_t d_num_selected_out,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
+// Load step: calls cuLibraryLoadData + cuLibraryGetKernel for compact_init and sweep kernels.
+CCCL_C_API CUresult cccl_device_unique_by_key_load(cccl_device_unique_by_key_build_result_t* build);
 
 CCCL_C_API CUresult cccl_device_unique_by_key(
   cccl_device_unique_by_key_build_result_t build,

--- a/c/parallel/include/cccl/c/unique_by_key.h
+++ b/c/parallel/include/cccl/c/unique_by_key.h
@@ -72,7 +72,6 @@ CCCL_C_API CUresult cccl_device_unique_by_key_build_ex(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Compile-only step: populates cubin, lowered names, and policy; does NOT load into device.
 CCCL_C_API CUresult cccl_device_unique_by_key_compile(
   cccl_device_unique_by_key_build_result_t* build,
   cccl_iterator_t d_keys_in,
@@ -89,7 +88,6 @@ CCCL_C_API CUresult cccl_device_unique_by_key_compile(
   const char* ctk_path,
   cccl_build_config* config);
 
-// Load step: calls cuLibraryLoadData + cuLibraryGetKernel for compact_init and sweep kernels.
 CCCL_C_API CUresult cccl_device_unique_by_key_load(cccl_device_unique_by_key_build_result_t* build);
 
 CCCL_C_API CUresult cccl_device_unique_by_key(

--- a/c/parallel/src/binary_search.cu
+++ b/c/parallel/src/binary_search.cu
@@ -116,7 +116,7 @@ struct binary_search_data_iterator_tag;
 struct binary_search_values_iterator_tag;
 struct binary_search_op_tag;
 
-CUresult cccl_device_binary_search_build_ex(
+CUresult cccl_device_binary_search_compile(
   cccl_device_binary_search_build_result_t* build_ptr,
   cccl_binary_search_mode_t mode,
   cccl_iterator_t d_data,
@@ -266,7 +266,7 @@ extern "C" __device__ void binary_search_transform_op(void* state, const void* v
   transform_op.extra_ltoir_sizes = extra_ltoir_sizes.data();
   transform_op.num_extra_ltoirs  = extra_ltoirs.size();
 
-  check(cccl_device_unary_transform_build_ex(
+  check(cccl_device_unary_transform_compile(
     &build_ptr->transform,
     d_values,
     d_out,
@@ -287,6 +287,51 @@ extern "C" __device__ void binary_search_transform_op(void* state, const void* v
 catch (...)
 {
   return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_binary_search_load(cccl_device_binary_search_build_result_t* build_ptr)
+{
+  if (build_ptr == nullptr)
+  {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  return cccl_device_transform_load(&build_ptr->transform);
+}
+
+CUresult cccl_device_binary_search_build_ex(
+  cccl_device_binary_search_build_result_t* build_ptr,
+  cccl_binary_search_mode_t mode,
+  cccl_iterator_t d_data,
+  cccl_iterator_t d_values,
+  cccl_iterator_t d_out,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config)
+{
+  CUresult r = cccl_device_binary_search_compile(
+    build_ptr,
+    mode,
+    d_data,
+    d_values,
+    d_out,
+    op,
+    cc_major,
+    cc_minor,
+    cub_path,
+    thrust_path,
+    libcudacxx_path,
+    ctk_path,
+    config);
+  if (r != CUDA_SUCCESS)
+  {
+    return r;
+  }
+  return cccl_device_binary_search_load(build_ptr);
 }
 
 CUresult cccl_device_binary_search(

--- a/c/parallel/src/binary_search.cu
+++ b/c/parallel/src/binary_search.cu
@@ -18,6 +18,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "util/aot.h"
 #include <cccl/c/binary_search.h>
 #include <cccl/c/transform.h>
 #include <cccl/c/types.h>
@@ -405,6 +406,55 @@ try
   }
 
   return cccl_device_transform_cleanup(&build_ptr->transform);
+}
+catch (...)
+{
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_binary_search_save_file(const cccl_device_binary_search_build_result_t* build, const char* path)
+try
+{
+  if (build->cubin == nullptr)
+  {
+    printf("\nERROR in cccl_device_binary_search_save_file(): build has no cubin\n");
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  AotWriter w(path);
+  w.write_header(CclbTag::binary_search);
+  w.write_i32(build->cc);
+  w.write_blob(build->cubin, build->cubin_size);
+  w.write_u32(1);
+  w.write_string(build->kernel_lowered_name);
+  return CUDA_SUCCESS;
+}
+catch (...)
+{
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_binary_search_load_file(cccl_device_binary_search_build_result_t* build, const char* path)
+try
+{
+  AotReader r(path);
+  CclbTag tag = r.read_tag();
+  if (tag != CclbTag::binary_search)
+  {
+    printf("\nERROR in cccl_device_binary_search_load_file(): unexpected tag %u\n", static_cast<uint32_t>(tag));
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  build->cc         = r.read_i32();
+  build->cubin      = r.read_blob(&build->cubin_size);
+  uint32_t nkernels = r.read_u32();
+  if (nkernels != 1)
+  {
+    printf("\nERROR in cccl_device_binary_search_load_file(): expected 1 kernel, got %u\n", nkernels);
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  build->kernel_lowered_name = r.read_string_heap();
+  build->library             = nullptr;
+  build->kernel              = nullptr;
+  return cccl_device_binary_search_load(build);
 }
 catch (...)
 {

--- a/c/parallel/src/for.cu
+++ b/c/parallel/src/for.cu
@@ -77,7 +77,7 @@ static std::string get_device_for_kernel_name()
     "cub::detail::for_each::static_kernel<device_for_policy_selector, {0}, {1}>", offset_t, function_op_t);
 }
 
-CUresult cccl_device_for_build_ex(
+CUresult cccl_device_for_compile(
   cccl_device_for_build_result_t* build_ptr,
   cccl_iterator_t d_data,
   cccl_op_t op,
@@ -114,14 +114,11 @@ try
 
   std::string lowered_name;
 
-  // Collect all LTO-IRs to be linked
   nvrtc_linkable_list linkable_list;
   nvrtc_linkable_list_appender appender{linkable_list};
 
-  // Add operation if it's LTO-IR (C++ source not yet supported in for)
   appender.append_operation(op);
 
-  // Add iterator definitions if present
   if (cccl_iterator_kind_t::CCCL_ITERATOR == d_data.type)
   {
     appender.append_operation(d_data.advance);
@@ -138,18 +135,53 @@ try
       ->add_link_list(linkable_list)
       ->finalize_program();
 
-  cuLibraryLoadData(&build_ptr->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
-  check(cuLibraryGetKernel(&build_ptr->static_kernel, build_ptr->library, lowered_name.c_str()));
-
-  build_ptr->cc         = cc;
-  build_ptr->cubin      = (void*) result.data.release();
-  build_ptr->cubin_size = result.size;
+  build_ptr->cc                         = cc;
+  build_ptr->cubin                      = (void*) result.data.release();
+  build_ptr->cubin_size                 = result.size;
+  build_ptr->static_kernel_lowered_name = duplicate_c_string(lowered_name);
 
   return CUDA_SUCCESS;
 }
 catch (...)
 {
   return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_for_load(cccl_device_for_build_result_t* build_ptr)
+try
+{
+  if (build_ptr == nullptr || build_ptr->cubin == nullptr || build_ptr->cubin_size == 0)
+  {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  check(cuLibraryLoadData(&build_ptr->library, build_ptr->cubin, nullptr, nullptr, 0, nullptr, nullptr, 0));
+  check(cuLibraryGetKernel(&build_ptr->static_kernel, build_ptr->library, build_ptr->static_kernel_lowered_name));
+  return CUDA_SUCCESS;
+}
+catch (...)
+{
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_for_build_ex(
+  cccl_device_for_build_result_t* build_ptr,
+  cccl_iterator_t d_data,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config)
+{
+  CUresult r = cccl_device_for_compile(
+    build_ptr, d_data, op, cc_major, cc_minor, cub_path, thrust_path, libcudacxx_path, ctk_path, config);
+  if (r != CUDA_SUCCESS)
+  {
+    return r;
+  }
+  return cccl_device_for_load(build_ptr);
 }
 
 CUresult cccl_device_for(
@@ -202,7 +234,11 @@ try
   }
 
   std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(build_ptr->cubin));
-  check(cuLibraryUnload(build_ptr->library));
+  std::unique_ptr<char[]> kernel_name(build_ptr->static_kernel_lowered_name);
+  if (build_ptr->library != nullptr)
+  {
+    check(cuLibraryUnload(build_ptr->library));
+  }
 
   return CUDA_SUCCESS;
 }

--- a/c/parallel/src/for.cu
+++ b/c/parallel/src/for.cu
@@ -21,6 +21,7 @@
 #include <for/for_op_helper.h>
 #include <nvrtc/command_list.h>
 #include <nvrtc/ltoir_list_appender.h>
+#include <util/aot.h>
 #include <util/build_utils.h>
 #include <util/context.h>
 #include <util/errors.h>
@@ -241,6 +242,55 @@ try
   }
 
   return CUDA_SUCCESS;
+}
+catch (...)
+{
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_for_save_file(const cccl_device_for_build_result_t* build, const char* path)
+try
+{
+  AotWriter w(path);
+  if (build->cubin == nullptr)
+  {
+    printf("\nERROR: cccl_device_for_save_file: build result has no cubin (was cccl_device_for_compile called?)\n");
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  w.write_header(CclbTag::for_each);
+  w.write_i32(build->cc);
+  w.write_blob(build->cubin, build->cubin_size);
+  w.write_u32(1);
+  w.write_string(build->static_kernel_lowered_name);
+  return CUDA_SUCCESS;
+}
+catch (...)
+{
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_for_load_file(cccl_device_for_build_result_t* build, const char* path)
+try
+{
+  AotReader r(path);
+  CclbTag tag = r.read_tag();
+  if (tag != CclbTag::for_each)
+  {
+    printf("\nERROR: cccl_device_for_load_file: file tag mismatch\n");
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  build->cc         = r.read_i32();
+  build->cubin      = r.read_blob(&build->cubin_size);
+  uint32_t nkernels = r.read_u32();
+  if (nkernels != 1)
+  {
+    printf("\nERROR: cccl_device_for_load_file: expected 1 kernel, got %u\n", nkernels);
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  build->static_kernel_lowered_name = r.read_string_heap();
+  build->library                    = nullptr;
+  build->static_kernel              = nullptr;
+  return cccl_device_for_load(build);
 }
 catch (...)
 {

--- a/c/parallel/src/histogram.cu
+++ b/c/parallel/src/histogram.cu
@@ -388,8 +388,8 @@ static_assert(device_histogram_policy()(detail::current_tuning_arch()) == {4}, "
                                    // it later.
   build_ptr->runtime_policy            = new cub::detail::histogram::policy_selector{policy_sel};
   build_ptr->runtime_policy_size       = sizeof(cub::detail::histogram::policy_selector);
-  build_ptr->init_kernel_lowered_name  = strdup(init_kernel_lowered_name.c_str());
-  build_ptr->sweep_kernel_lowered_name = strdup(sweep_kernel_lowered_name.c_str());
+  build_ptr->init_kernel_lowered_name  = duplicate_c_string(init_kernel_lowered_name);
+  build_ptr->sweep_kernel_lowered_name = duplicate_c_string(sweep_kernel_lowered_name);
 
   return CUDA_SUCCESS;
 }
@@ -641,8 +641,8 @@ try
   std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(build_ptr->cubin));
   std::unique_ptr<cub::detail::histogram::policy_selector> policy(
     static_cast<cub::detail::histogram::policy_selector*>(build_ptr->runtime_policy));
-  std::free(build_ptr->init_kernel_lowered_name);
-  std::free(build_ptr->sweep_kernel_lowered_name);
+  std::unique_ptr<char[]> init_name(build_ptr->init_kernel_lowered_name);
+  std::unique_ptr<char[]> sweep_name(build_ptr->sweep_kernel_lowered_name);
   if (build_ptr->library != nullptr)
   {
     check(cuLibraryUnload(build_ptr->library));

--- a/c/parallel/src/histogram.cu
+++ b/c/parallel/src/histogram.cu
@@ -19,6 +19,7 @@
 #include "cccl/c/types.h"
 #include "kernels/iterators.h"
 #include "util/context.h"
+#include "util/errors.h"
 #include "util/indirect_arg.h"
 #include "util/types.h"
 #include <cccl/c/histogram.h>
@@ -222,7 +223,7 @@ bool check_histogram_overflow(
 }
 } // namespace histogram
 
-CUresult cccl_device_histogram_build_ex(
+CUresult cccl_device_histogram_compile(
   cccl_device_histogram_build_result_t* build_ptr,
   int num_channels,
   int num_active_channels,
@@ -376,10 +377,6 @@ static_assert(device_histogram_policy()(detail::current_tuning_arch()) == {4}, "
       ->add_link_list(linkable_list)
       ->finalize_program();
 
-  cuLibraryLoadData(&build_ptr->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
-  check(cuLibraryGetKernel(&build_ptr->init_kernel, build_ptr->library, init_kernel_lowered_name.c_str()));
-  check(cuLibraryGetKernel(&build_ptr->sweep_kernel, build_ptr->library, sweep_kernel_lowered_name.c_str()));
-
   build_ptr->cc                  = cc;
   build_ptr->cubin               = (void*) result.data.release();
   build_ptr->cubin_size          = result.size;
@@ -389,16 +386,87 @@ static_assert(device_histogram_policy()(detail::current_tuning_arch()) == {4}, "
   build_ptr->num_active_channels = num_active_channels;
   build_ptr->may_overflow = false; // This is set in cccl_device_histogram_even_impl so that kernel source can access
                                    // it later.
-  build_ptr->runtime_policy = new cub::detail::histogram::policy_selector{policy_sel};
+  build_ptr->runtime_policy            = new cub::detail::histogram::policy_selector{policy_sel};
+  build_ptr->runtime_policy_size       = sizeof(cub::detail::histogram::policy_selector);
+  build_ptr->init_kernel_lowered_name  = strdup(init_kernel_lowered_name.c_str());
+  build_ptr->sweep_kernel_lowered_name = strdup(sweep_kernel_lowered_name.c_str());
 
   return CUDA_SUCCESS;
 }
 catch (const std::exception& exc)
 {
   fflush(stderr);
-  printf("\nEXCEPTION in cccl_device_histogram_build(): %s\n", exc.what());
+  printf("\nEXCEPTION in cccl_device_histogram_compile(): %s\n", exc.what());
   fflush(stdout);
   return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_histogram_load(cccl_device_histogram_build_result_t* build_ptr)
+try
+{
+  if (build_ptr == nullptr || build_ptr->cubin == nullptr || build_ptr->cubin_size == 0)
+  {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  CUresult status = cuLibraryLoadData(&build_ptr->library, build_ptr->cubin, nullptr, nullptr, 0, nullptr, nullptr, 0);
+  if (status != CUDA_SUCCESS)
+  {
+    return status;
+  }
+  check(cuLibraryGetKernel(&build_ptr->init_kernel, build_ptr->library, build_ptr->init_kernel_lowered_name));
+  check(cuLibraryGetKernel(&build_ptr->sweep_kernel, build_ptr->library, build_ptr->sweep_kernel_lowered_name));
+  return CUDA_SUCCESS;
+}
+catch (const std::exception& exc)
+{
+  fflush(stderr);
+  printf("\nEXCEPTION in cccl_device_histogram_load(): %s\n", exc.what());
+  fflush(stdout);
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_histogram_build_ex(
+  cccl_device_histogram_build_result_t* build_ptr,
+  int num_channels,
+  int num_active_channels,
+  cccl_iterator_t d_samples,
+  int num_output_levels_val,
+  cccl_iterator_t d_output_histograms,
+  cccl_value_t lower_level,
+  int64_t num_rows,
+  int64_t row_stride_samples,
+  bool is_evenly_segmented,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config)
+{
+  CUresult r = cccl_device_histogram_compile(
+    build_ptr,
+    num_channels,
+    num_active_channels,
+    d_samples,
+    num_output_levels_val,
+    d_output_histograms,
+    lower_level,
+    num_rows,
+    row_stride_samples,
+    is_evenly_segmented,
+    cc_major,
+    cc_minor,
+    cub_path,
+    thrust_path,
+    libcudacxx_path,
+    ctk_path,
+    config);
+  if (r != CUDA_SUCCESS)
+  {
+    return r;
+  }
+  return cccl_device_histogram_load(build_ptr);
 }
 
 template <typename is_byte_sample>
@@ -573,7 +641,12 @@ try
   std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(build_ptr->cubin));
   std::unique_ptr<cub::detail::histogram::policy_selector> policy(
     static_cast<cub::detail::histogram::policy_selector*>(build_ptr->runtime_policy));
-  check(cuLibraryUnload(build_ptr->library));
+  std::free(build_ptr->init_kernel_lowered_name);
+  std::free(build_ptr->sweep_kernel_lowered_name);
+  if (build_ptr->library != nullptr)
+  {
+    check(cuLibraryUnload(build_ptr->library));
+  }
 
   return CUDA_SUCCESS;
 }

--- a/c/parallel/src/histogram.cu
+++ b/c/parallel/src/histogram.cu
@@ -18,6 +18,7 @@
 
 #include "cccl/c/types.h"
 #include "kernels/iterators.h"
+#include "util/aot.h"
 #include "util/context.h"
 #include "util/errors.h"
 #include "util/indirect_arg.h"
@@ -422,6 +423,70 @@ catch (const std::exception& exc)
   fflush(stderr);
   printf("\nEXCEPTION in cccl_device_histogram_load(): %s\n", exc.what());
   fflush(stdout);
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_histogram_save_file(const cccl_device_histogram_build_result_t* build, const char* path)
+try
+{
+  AotWriter w(path);
+  w.write_header(CclbTag::histogram);
+  w.write_i32(build->cc);
+  w.write_blob(build->cubin, build->cubin_size);
+  w.write_blob(build->runtime_policy, build->runtime_policy_size);
+  w.write_u32(2);
+  w.write_string(build->init_kernel_lowered_name);
+  w.write_string(build->sweep_kernel_lowered_name);
+  w.write_type_info(build->counter_type);
+  w.write_type_info(build->level_type);
+  w.write_type_info(build->sample_type);
+  w.write_i32(build->num_active_channels);
+  w.write_bool(build->may_overflow);
+  return CUDA_SUCCESS;
+}
+catch (...)
+{
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_histogram_load_file(cccl_device_histogram_build_result_t* build, const char* path)
+try
+{
+  AotReader r(path);
+  CclbTag tag = r.read_tag();
+  if (tag != CclbTag::histogram)
+  {
+    printf("\nERROR in cccl_device_histogram_load_file(): unexpected tag %u\n", static_cast<uint32_t>(tag));
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  *build    = {};
+  build->cc = r.read_i32();
+  {
+    uint64_t sz       = 0;
+    void* tmp_cb      = r.read_blob(&sz);
+    build->cubin_size = sz;
+    char* nb          = new char[static_cast<size_t>(sz)];
+    std::memcpy(nb, tmp_cb, static_cast<size_t>(sz));
+    std::free(tmp_cb);
+    build->cubin = nb;
+  }
+  {
+    uint64_t pol_sz            = 0;
+    build->runtime_policy      = r.read_blob(&pol_sz);
+    build->runtime_policy_size = static_cast<size_t>(pol_sz);
+  }
+  (void) r.read_u32(); // nkernels
+  build->init_kernel_lowered_name  = r.read_string_heap();
+  build->sweep_kernel_lowered_name = r.read_string_heap();
+  build->counter_type              = r.read_type_info();
+  build->level_type                = r.read_type_info();
+  build->sample_type               = r.read_type_info();
+  build->num_active_channels       = r.read_i32();
+  build->may_overflow              = r.read_bool();
+  return cccl_device_histogram_load(build);
+}
+catch (...)
+{
   return CUDA_ERROR_UNKNOWN;
 }
 

--- a/c/parallel/src/merge_sort.cu
+++ b/c/parallel/src/merge_sort.cu
@@ -13,7 +13,6 @@
 #include <cub/device/device_merge_sort.cuh>
 #include <cub/device/dispatch/tuning/tuning_merge_sort.cuh>
 
-#include <cstring> // strdup, free
 #include <format>
 #include <sstream>
 #include <vector>
@@ -341,9 +340,9 @@ static_assert(device_merge_sort_policy()(detail::current_tuning_arch()) == {10},
   build_ptr->item_type                      = input_items_it.value_type;
   build_ptr->runtime_policy                 = new cub::detail::merge_sort::policy_selector{policy_sel};
   build_ptr->runtime_policy_size            = sizeof(cub::detail::merge_sort::policy_selector);
-  build_ptr->block_sort_kernel_lowered_name = strdup(block_sort_kernel_lowered_name.c_str());
-  build_ptr->partition_kernel_lowered_name  = strdup(partition_kernel_lowered_name.c_str());
-  build_ptr->merge_kernel_lowered_name      = strdup(merge_kernel_lowered_name.c_str());
+  build_ptr->block_sort_kernel_lowered_name = duplicate_c_string(block_sort_kernel_lowered_name);
+  build_ptr->partition_kernel_lowered_name  = duplicate_c_string(partition_kernel_lowered_name);
+  build_ptr->merge_kernel_lowered_name      = duplicate_c_string(merge_kernel_lowered_name);
 
   return CUDA_SUCCESS;
 }
@@ -526,12 +525,12 @@ try
     check(cuLibraryUnload(build_ptr->library));
   }
 
-  free(build_ptr->block_sort_kernel_lowered_name);
-  free(build_ptr->partition_kernel_lowered_name);
-  free(build_ptr->merge_kernel_lowered_name);
-  build_ptr->block_sort_kernel_lowered_name = nullptr;
-  build_ptr->partition_kernel_lowered_name  = nullptr;
-  build_ptr->merge_kernel_lowered_name      = nullptr;
+  for (char* p : {build_ptr->block_sort_kernel_lowered_name,
+                  build_ptr->partition_kernel_lowered_name,
+                  build_ptr->merge_kernel_lowered_name})
+  {
+    delete[] p;
+  }
 
   return CUDA_SUCCESS;
 }

--- a/c/parallel/src/merge_sort.cu
+++ b/c/parallel/src/merge_sort.cu
@@ -13,6 +13,7 @@
 #include <cub/device/device_merge_sort.cuh>
 #include <cub/device/dispatch/tuning/tuning_merge_sort.cuh>
 
+#include <cstring> // strdup, free
 #include <format>
 #include <sstream>
 #include <vector>
@@ -20,6 +21,7 @@
 #include "kernels/iterators.h"
 #include "kernels/operators.h"
 #include "util/context.h"
+#include "util/errors.h"
 #include "util/indirect_arg.h"
 #include "util/tuning.h"
 #include "util/types.h"
@@ -183,7 +185,7 @@ struct merge_sort_kernel_source
 };
 } // namespace merge_sort
 
-CUresult cccl_device_merge_sort_build_ex(
+CUresult cccl_device_merge_sort_compile(
   cccl_device_merge_sort_build_result_t* build_ptr,
   cccl_iterator_t input_keys_it,
   cccl_iterator_t input_items_it,
@@ -332,27 +334,85 @@ static_assert(device_merge_sort_policy()(detail::current_tuning_arch()) == {10},
       ->add_link_list(linkable_list)
       ->finalize_program();
 
-  cuLibraryLoadData(&build_ptr->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
-  check(cuLibraryGetKernel(&build_ptr->block_sort_kernel, build_ptr->library, block_sort_kernel_lowered_name.c_str()));
-  check(cuLibraryGetKernel(&build_ptr->partition_kernel, build_ptr->library, partition_kernel_lowered_name.c_str()));
-  check(cuLibraryGetKernel(&build_ptr->merge_kernel, build_ptr->library, merge_kernel_lowered_name.c_str()));
-
-  build_ptr->cc             = cc;
-  build_ptr->cubin          = (void*) result.data.release();
-  build_ptr->cubin_size     = result.size;
-  build_ptr->key_type       = input_keys_it.value_type;
-  build_ptr->item_type      = input_items_it.value_type;
-  build_ptr->runtime_policy = new cub::detail::merge_sort::policy_selector{policy_sel};
+  build_ptr->cc                             = cc;
+  build_ptr->cubin                          = (void*) result.data.release();
+  build_ptr->cubin_size                     = result.size;
+  build_ptr->key_type                       = input_keys_it.value_type;
+  build_ptr->item_type                      = input_items_it.value_type;
+  build_ptr->runtime_policy                 = new cub::detail::merge_sort::policy_selector{policy_sel};
+  build_ptr->runtime_policy_size            = sizeof(cub::detail::merge_sort::policy_selector);
+  build_ptr->block_sort_kernel_lowered_name = strdup(block_sort_kernel_lowered_name.c_str());
+  build_ptr->partition_kernel_lowered_name  = strdup(partition_kernel_lowered_name.c_str());
+  build_ptr->merge_kernel_lowered_name      = strdup(merge_kernel_lowered_name.c_str());
 
   return CUDA_SUCCESS;
 }
 catch (const std::exception& exc)
 {
   fflush(stderr);
-  printf("\nEXCEPTION in cccl_device_merge_sort_build(): %s\n", exc.what());
+  printf("\nEXCEPTION in cccl_device_merge_sort_compile(): %s\n", exc.what());
   fflush(stdout);
 
   return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_merge_sort_load(cccl_device_merge_sort_build_result_t* build_ptr)
+try
+{
+  if (build_ptr == nullptr || build_ptr->cubin == nullptr || build_ptr->cubin_size == 0)
+  {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  check(cuLibraryLoadData(&build_ptr->library, build_ptr->cubin, nullptr, nullptr, 0, nullptr, nullptr, 0));
+  check(
+    cuLibraryGetKernel(&build_ptr->block_sort_kernel, build_ptr->library, build_ptr->block_sort_kernel_lowered_name));
+  check(cuLibraryGetKernel(&build_ptr->partition_kernel, build_ptr->library, build_ptr->partition_kernel_lowered_name));
+  check(cuLibraryGetKernel(&build_ptr->merge_kernel, build_ptr->library, build_ptr->merge_kernel_lowered_name));
+  return CUDA_SUCCESS;
+}
+catch (const std::exception& exc)
+{
+  fflush(stderr);
+  printf("\nEXCEPTION in cccl_device_merge_sort_load(): %s\n", exc.what());
+  fflush(stdout);
+
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_merge_sort_build_ex(
+  cccl_device_merge_sort_build_result_t* build_ptr,
+  cccl_iterator_t input_keys_it,
+  cccl_iterator_t input_items_it,
+  cccl_iterator_t output_keys_it,
+  cccl_iterator_t output_items_it,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config)
+{
+  CUresult r = cccl_device_merge_sort_compile(
+    build_ptr,
+    input_keys_it,
+    input_items_it,
+    output_keys_it,
+    output_items_it,
+    op,
+    cc_major,
+    cc_minor,
+    cub_path,
+    thrust_path,
+    libcudacxx_path,
+    ctk_path,
+    config);
+  if (r != CUDA_SUCCESS)
+  {
+    return r;
+  }
+  return cccl_device_merge_sort_load(build_ptr);
 }
 
 CUresult cccl_device_merge_sort(
@@ -461,7 +521,17 @@ try
   std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(build_ptr->cubin));
   std::unique_ptr<cub::detail::merge_sort::policy_selector> policy(
     static_cast<cub::detail::merge_sort::policy_selector*>(build_ptr->runtime_policy));
-  check(cuLibraryUnload(build_ptr->library));
+  if (build_ptr->library != nullptr)
+  {
+    check(cuLibraryUnload(build_ptr->library));
+  }
+
+  free(build_ptr->block_sort_kernel_lowered_name);
+  free(build_ptr->partition_kernel_lowered_name);
+  free(build_ptr->merge_kernel_lowered_name);
+  build_ptr->block_sort_kernel_lowered_name = nullptr;
+  build_ptr->partition_kernel_lowered_name  = nullptr;
+  build_ptr->merge_kernel_lowered_name      = nullptr;
 
   return CUDA_SUCCESS;
 }

--- a/c/parallel/src/merge_sort.cu
+++ b/c/parallel/src/merge_sort.cu
@@ -19,6 +19,7 @@
 
 #include "kernels/iterators.h"
 #include "kernels/operators.h"
+#include "util/aot.h"
 #include "util/context.h"
 #include "util/errors.h"
 #include "util/indirect_arg.h"
@@ -375,6 +376,75 @@ catch (const std::exception& exc)
   printf("\nEXCEPTION in cccl_device_merge_sort_load(): %s\n", exc.what());
   fflush(stdout);
 
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_merge_sort_save_file(const cccl_device_merge_sort_build_result_t* build, const char* path)
+try
+{
+  if (build->cubin == nullptr)
+  {
+    printf("\nERROR in cccl_device_merge_sort_save_file(): build has no cubin\n");
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  AotWriter w(path);
+  w.write_header(CclbTag::merge_sort);
+  w.write_i32(build->cc);
+  w.write_blob(build->cubin, build->cubin_size);
+  w.write_blob(build->runtime_policy, build->runtime_policy_size);
+  w.write_u32(3);
+  w.write_string(build->block_sort_kernel_lowered_name);
+  w.write_string(build->partition_kernel_lowered_name);
+  w.write_string(build->merge_kernel_lowered_name);
+  w.write_type_info(build->key_type);
+  w.write_type_info(build->item_type);
+  return CUDA_SUCCESS;
+}
+catch (...)
+{
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_merge_sort_load_file(cccl_device_merge_sort_build_result_t* build, const char* path)
+try
+{
+  AotReader r(path);
+  CclbTag tag = r.read_tag();
+
+  if (tag != CclbTag::merge_sort)
+  {
+    printf("\nERROR in cccl_device_merge_sort_load_file(): unexpected tag %u\n", static_cast<uint32_t>(tag));
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  *build    = {};
+  build->cc = r.read_i32();
+
+  {
+    uint64_t sz       = 0;
+    void* tmp_cb      = r.read_blob(&sz);
+    build->cubin_size = sz;
+    char* nb          = new char[static_cast<size_t>(sz)];
+    std::memcpy(nb, tmp_cb, static_cast<size_t>(sz));
+    std::free(tmp_cb);
+    build->cubin = nb;
+  }
+
+  {
+    uint64_t pol_sz            = 0;
+    build->runtime_policy      = r.read_blob(&pol_sz);
+    build->runtime_policy_size = static_cast<size_t>(pol_sz);
+  }
+  (void) r.read_u32(); // nkernels
+  build->block_sort_kernel_lowered_name = r.read_string_heap();
+  build->partition_kernel_lowered_name  = r.read_string_heap();
+  build->merge_kernel_lowered_name      = r.read_string_heap();
+  build->key_type                       = r.read_type_info();
+  build->item_type                      = r.read_type_info();
+  return cccl_device_merge_sort_load(build);
+}
+catch (...)
+{
   return CUDA_ERROR_UNKNOWN;
 }
 

--- a/c/parallel/src/radix_sort.cu
+++ b/c/parallel/src/radix_sort.cu
@@ -19,6 +19,7 @@
 #include "cub/util_type.cuh"
 #include "kernels/operators.h"
 #include "util/context.h"
+#include "util/errors.h"
 #include "util/indirect_arg.h"
 #include "util/types.h"
 #include <cccl/c/radix_sort.h>
@@ -193,7 +194,7 @@ struct radix_sort_kernel_source
 };
 } // namespace radix_sort
 
-CUresult cccl_device_radix_sort_build_ex(
+CUresult cccl_device_radix_sort_compile(
   cccl_device_radix_sort_build_result_t* build_ptr,
   cccl_sort_order_t sort_order,
   cccl_iterator_t input_keys_it,
@@ -351,38 +352,101 @@ static_assert(device_radix_sort_policy()(current_tuning_arch()) == {6}, "Host ge
       ->add_link_list(linkable_list)
       ->finalize_program();
 
-  cuLibraryLoadData(&build_ptr->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
-  check(
-    cuLibraryGetKernel(&build_ptr->single_tile_kernel, build_ptr->library, single_tile_kernel_lowered_name.c_str()));
-  check(cuLibraryGetKernel(&build_ptr->upsweep_kernel, build_ptr->library, upsweep_kernel_lowered_name.c_str()));
-  check(
-    cuLibraryGetKernel(&build_ptr->alt_upsweep_kernel, build_ptr->library, alt_upsweep_kernel_lowered_name.c_str()));
-  check(cuLibraryGetKernel(&build_ptr->scan_bins_kernel, build_ptr->library, scan_bins_kernel_lowered_name.c_str()));
-  check(cuLibraryGetKernel(&build_ptr->downsweep_kernel, build_ptr->library, downsweep_kernel_lowered_name.c_str()));
-  check(cuLibraryGetKernel(
-    &build_ptr->alt_downsweep_kernel, build_ptr->library, alt_downsweep_kernel_lowered_name.c_str()));
-  check(cuLibraryGetKernel(&build_ptr->histogram_kernel, build_ptr->library, histogram_kernel_lowered_name.c_str()));
-  check(cuLibraryGetKernel(
-    &build_ptr->exclusive_sum_kernel, build_ptr->library, exclusive_sum_kernel_lowered_name.c_str()));
-  check(cuLibraryGetKernel(&build_ptr->onesweep_kernel, build_ptr->library, onesweep_kernel_lowered_name.c_str()));
-
-  build_ptr->cc             = cc_major * 10 + cc_minor;
-  build_ptr->cubin          = (void*) result.data.release();
-  build_ptr->cubin_size     = result.size;
-  build_ptr->key_type       = input_keys_it.value_type;
-  build_ptr->value_type     = input_values_it.value_type;
-  build_ptr->order          = sort_order;
-  build_ptr->runtime_policy = new cub::detail::radix_sort::policy_selector{policy_sel};
+  build_ptr->cc                                = cc_major * 10 + cc_minor;
+  build_ptr->cubin                             = (void*) result.data.release();
+  build_ptr->cubin_size                        = result.size;
+  build_ptr->key_type                          = input_keys_it.value_type;
+  build_ptr->value_type                        = input_values_it.value_type;
+  build_ptr->order                             = sort_order;
+  build_ptr->runtime_policy                    = new cub::detail::radix_sort::policy_selector{policy_sel};
+  build_ptr->runtime_policy_size               = sizeof(cub::detail::radix_sort::policy_selector);
+  build_ptr->single_tile_kernel_lowered_name   = strdup(single_tile_kernel_lowered_name.c_str());
+  build_ptr->upsweep_kernel_lowered_name       = strdup(upsweep_kernel_lowered_name.c_str());
+  build_ptr->alt_upsweep_kernel_lowered_name   = strdup(alt_upsweep_kernel_lowered_name.c_str());
+  build_ptr->scan_bins_kernel_lowered_name     = strdup(scan_bins_kernel_lowered_name.c_str());
+  build_ptr->downsweep_kernel_lowered_name     = strdup(downsweep_kernel_lowered_name.c_str());
+  build_ptr->alt_downsweep_kernel_lowered_name = strdup(alt_downsweep_kernel_lowered_name.c_str());
+  build_ptr->histogram_kernel_lowered_name     = strdup(histogram_kernel_lowered_name.c_str());
+  build_ptr->exclusive_sum_kernel_lowered_name = strdup(exclusive_sum_kernel_lowered_name.c_str());
+  build_ptr->onesweep_kernel_lowered_name      = strdup(onesweep_kernel_lowered_name.c_str());
 
   return CUDA_SUCCESS;
 }
 catch (const std::exception& exc)
 {
   fflush(stderr);
-  printf("\nEXCEPTION in cccl_device_radix_sort_build(): %s\n", exc.what());
+  printf("\nEXCEPTION in cccl_device_radix_sort_compile(): %s\n", exc.what());
   fflush(stdout);
 
   return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_radix_sort_load(cccl_device_radix_sort_build_result_t* build_ptr)
+try
+{
+  if (build_ptr == nullptr || build_ptr->cubin == nullptr || build_ptr->cubin_size == 0)
+  {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  check(cuLibraryLoadData(&build_ptr->library, build_ptr->cubin, nullptr, nullptr, 0, nullptr, nullptr, 0));
+  check(
+    cuLibraryGetKernel(&build_ptr->single_tile_kernel, build_ptr->library, build_ptr->single_tile_kernel_lowered_name));
+  check(cuLibraryGetKernel(&build_ptr->upsweep_kernel, build_ptr->library, build_ptr->upsweep_kernel_lowered_name));
+  check(
+    cuLibraryGetKernel(&build_ptr->alt_upsweep_kernel, build_ptr->library, build_ptr->alt_upsweep_kernel_lowered_name));
+  check(cuLibraryGetKernel(&build_ptr->scan_bins_kernel, build_ptr->library, build_ptr->scan_bins_kernel_lowered_name));
+  check(cuLibraryGetKernel(&build_ptr->downsweep_kernel, build_ptr->library, build_ptr->downsweep_kernel_lowered_name));
+  check(cuLibraryGetKernel(
+    &build_ptr->alt_downsweep_kernel, build_ptr->library, build_ptr->alt_downsweep_kernel_lowered_name));
+  check(cuLibraryGetKernel(&build_ptr->histogram_kernel, build_ptr->library, build_ptr->histogram_kernel_lowered_name));
+  check(cuLibraryGetKernel(
+    &build_ptr->exclusive_sum_kernel, build_ptr->library, build_ptr->exclusive_sum_kernel_lowered_name));
+  check(cuLibraryGetKernel(&build_ptr->onesweep_kernel, build_ptr->library, build_ptr->onesweep_kernel_lowered_name));
+  return CUDA_SUCCESS;
+}
+catch (const std::exception& exc)
+{
+  fflush(stderr);
+  printf("\nEXCEPTION in cccl_device_radix_sort_load(): %s\n", exc.what());
+  fflush(stdout);
+
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_radix_sort_build_ex(
+  cccl_device_radix_sort_build_result_t* build_ptr,
+  cccl_sort_order_t sort_order,
+  cccl_iterator_t input_keys_it,
+  cccl_iterator_t input_values_it,
+  cccl_op_t decomposer,
+  const char* decomposer_return_type,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config)
+{
+  CUresult r = cccl_device_radix_sort_compile(
+    build_ptr,
+    sort_order,
+    input_keys_it,
+    input_values_it,
+    decomposer,
+    decomposer_return_type,
+    cc_major,
+    cc_minor,
+    cub_path,
+    thrust_path,
+    libcudacxx_path,
+    ctk_path,
+    config);
+  if (r != CUDA_SUCCESS)
+  {
+    return r;
+  }
+  return cccl_device_radix_sort_load(build_ptr);
 }
 
 template <cub::SortOrder Order>
@@ -544,7 +608,19 @@ try
   using namespace cub::detail::radix_sort;
   std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(build_ptr->cubin));
   std::unique_ptr<policy_selector> policy(static_cast<policy_selector*>(build_ptr->runtime_policy));
-  check(cuLibraryUnload(build_ptr->library));
+  std::free(build_ptr->single_tile_kernel_lowered_name);
+  std::free(build_ptr->upsweep_kernel_lowered_name);
+  std::free(build_ptr->alt_upsweep_kernel_lowered_name);
+  std::free(build_ptr->scan_bins_kernel_lowered_name);
+  std::free(build_ptr->downsweep_kernel_lowered_name);
+  std::free(build_ptr->alt_downsweep_kernel_lowered_name);
+  std::free(build_ptr->histogram_kernel_lowered_name);
+  std::free(build_ptr->exclusive_sum_kernel_lowered_name);
+  std::free(build_ptr->onesweep_kernel_lowered_name);
+  if (build_ptr->library != nullptr)
+  {
+    check(cuLibraryUnload(build_ptr->library));
+  }
 
   return CUDA_SUCCESS;
 }

--- a/c/parallel/src/radix_sort.cu
+++ b/c/parallel/src/radix_sort.cu
@@ -360,15 +360,15 @@ static_assert(device_radix_sort_policy()(current_tuning_arch()) == {6}, "Host ge
   build_ptr->order                             = sort_order;
   build_ptr->runtime_policy                    = new cub::detail::radix_sort::policy_selector{policy_sel};
   build_ptr->runtime_policy_size               = sizeof(cub::detail::radix_sort::policy_selector);
-  build_ptr->single_tile_kernel_lowered_name   = strdup(single_tile_kernel_lowered_name.c_str());
-  build_ptr->upsweep_kernel_lowered_name       = strdup(upsweep_kernel_lowered_name.c_str());
-  build_ptr->alt_upsweep_kernel_lowered_name   = strdup(alt_upsweep_kernel_lowered_name.c_str());
-  build_ptr->scan_bins_kernel_lowered_name     = strdup(scan_bins_kernel_lowered_name.c_str());
-  build_ptr->downsweep_kernel_lowered_name     = strdup(downsweep_kernel_lowered_name.c_str());
-  build_ptr->alt_downsweep_kernel_lowered_name = strdup(alt_downsweep_kernel_lowered_name.c_str());
-  build_ptr->histogram_kernel_lowered_name     = strdup(histogram_kernel_lowered_name.c_str());
-  build_ptr->exclusive_sum_kernel_lowered_name = strdup(exclusive_sum_kernel_lowered_name.c_str());
-  build_ptr->onesweep_kernel_lowered_name      = strdup(onesweep_kernel_lowered_name.c_str());
+  build_ptr->single_tile_kernel_lowered_name   = duplicate_c_string(single_tile_kernel_lowered_name);
+  build_ptr->upsweep_kernel_lowered_name       = duplicate_c_string(upsweep_kernel_lowered_name);
+  build_ptr->alt_upsweep_kernel_lowered_name   = duplicate_c_string(alt_upsweep_kernel_lowered_name);
+  build_ptr->scan_bins_kernel_lowered_name     = duplicate_c_string(scan_bins_kernel_lowered_name);
+  build_ptr->downsweep_kernel_lowered_name     = duplicate_c_string(downsweep_kernel_lowered_name);
+  build_ptr->alt_downsweep_kernel_lowered_name = duplicate_c_string(alt_downsweep_kernel_lowered_name);
+  build_ptr->histogram_kernel_lowered_name     = duplicate_c_string(histogram_kernel_lowered_name);
+  build_ptr->exclusive_sum_kernel_lowered_name = duplicate_c_string(exclusive_sum_kernel_lowered_name);
+  build_ptr->onesweep_kernel_lowered_name      = duplicate_c_string(onesweep_kernel_lowered_name);
 
   return CUDA_SUCCESS;
 }
@@ -608,15 +608,19 @@ try
   using namespace cub::detail::radix_sort;
   std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(build_ptr->cubin));
   std::unique_ptr<policy_selector> policy(static_cast<policy_selector*>(build_ptr->runtime_policy));
-  std::free(build_ptr->single_tile_kernel_lowered_name);
-  std::free(build_ptr->upsweep_kernel_lowered_name);
-  std::free(build_ptr->alt_upsweep_kernel_lowered_name);
-  std::free(build_ptr->scan_bins_kernel_lowered_name);
-  std::free(build_ptr->downsweep_kernel_lowered_name);
-  std::free(build_ptr->alt_downsweep_kernel_lowered_name);
-  std::free(build_ptr->histogram_kernel_lowered_name);
-  std::free(build_ptr->exclusive_sum_kernel_lowered_name);
-  std::free(build_ptr->onesweep_kernel_lowered_name);
+  for (char* p :
+       {build_ptr->single_tile_kernel_lowered_name,
+        build_ptr->upsweep_kernel_lowered_name,
+        build_ptr->alt_upsweep_kernel_lowered_name,
+        build_ptr->scan_bins_kernel_lowered_name,
+        build_ptr->downsweep_kernel_lowered_name,
+        build_ptr->alt_downsweep_kernel_lowered_name,
+        build_ptr->histogram_kernel_lowered_name,
+        build_ptr->exclusive_sum_kernel_lowered_name,
+        build_ptr->onesweep_kernel_lowered_name})
+  {
+    delete[] p;
+  }
   if (build_ptr->library != nullptr)
   {
     check(cuLibraryUnload(build_ptr->library));

--- a/c/parallel/src/radix_sort.cu
+++ b/c/parallel/src/radix_sort.cu
@@ -18,6 +18,7 @@
 #include "cccl/c/types.h"
 #include "cub/util_type.cuh"
 #include "kernels/operators.h"
+#include "util/aot.h"
 #include "util/context.h"
 #include "util/errors.h"
 #include "util/indirect_arg.h"
@@ -410,6 +411,89 @@ catch (const std::exception& exc)
   printf("\nEXCEPTION in cccl_device_radix_sort_load(): %s\n", exc.what());
   fflush(stdout);
 
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_radix_sort_save_file(const cccl_device_radix_sort_build_result_t* build, const char* path)
+try
+{
+  if (build->cubin == nullptr)
+  {
+    printf("\nERROR in cccl_device_radix_sort_save_file(): build has no cubin\n");
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  AotWriter w(path);
+  w.write_header(CclbTag::radix_sort);
+  w.write_i32(build->cc);
+  w.write_blob(build->cubin, build->cubin_size);
+  w.write_blob(build->runtime_policy, build->runtime_policy_size);
+  w.write_u32(9);
+  w.write_string(build->single_tile_kernel_lowered_name);
+  w.write_string(build->upsweep_kernel_lowered_name);
+  w.write_string(build->alt_upsweep_kernel_lowered_name);
+  w.write_string(build->scan_bins_kernel_lowered_name);
+  w.write_string(build->downsweep_kernel_lowered_name);
+  w.write_string(build->alt_downsweep_kernel_lowered_name);
+  w.write_string(build->histogram_kernel_lowered_name);
+  w.write_string(build->exclusive_sum_kernel_lowered_name);
+  w.write_string(build->onesweep_kernel_lowered_name);
+  w.write_type_info(build->key_type);
+  w.write_type_info(build->value_type);
+  w.write_i32(static_cast<int32_t>(build->order));
+  return CUDA_SUCCESS;
+}
+catch (...)
+{
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_radix_sort_load_file(cccl_device_radix_sort_build_result_t* build, const char* path)
+try
+{
+  AotReader r(path);
+  CclbTag tag = r.read_tag();
+
+  if (tag != CclbTag::radix_sort)
+  {
+    printf("\nERROR in cccl_device_radix_sort_load_file(): unexpected tag %u\n", static_cast<uint32_t>(tag));
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  *build    = {};
+  build->cc = r.read_i32();
+
+  {
+    uint64_t sz       = 0;
+    void* tmp_cb      = r.read_blob(&sz);
+    build->cubin_size = sz;
+    char* nb          = new char[static_cast<size_t>(sz)];
+    std::memcpy(nb, tmp_cb, static_cast<size_t>(sz));
+    std::free(tmp_cb);
+    build->cubin = nb;
+  }
+
+  {
+    uint64_t pol_sz            = 0;
+    build->runtime_policy      = r.read_blob(&pol_sz);
+    build->runtime_policy_size = static_cast<size_t>(pol_sz);
+  }
+  (void) r.read_u32(); // nkernels
+  build->single_tile_kernel_lowered_name   = r.read_string_heap();
+  build->upsweep_kernel_lowered_name       = r.read_string_heap();
+  build->alt_upsweep_kernel_lowered_name   = r.read_string_heap();
+  build->scan_bins_kernel_lowered_name     = r.read_string_heap();
+  build->downsweep_kernel_lowered_name     = r.read_string_heap();
+  build->alt_downsweep_kernel_lowered_name = r.read_string_heap();
+  build->histogram_kernel_lowered_name     = r.read_string_heap();
+  build->exclusive_sum_kernel_lowered_name = r.read_string_heap();
+  build->onesweep_kernel_lowered_name      = r.read_string_heap();
+  build->key_type                          = r.read_type_info();
+  build->value_type                        = r.read_type_info();
+  build->order                             = static_cast<cccl_sort_order_t>(r.read_i32());
+  return cccl_device_radix_sort_load(build);
+}
+catch (...)
+{
   return CUDA_ERROR_UNKNOWN;
 }
 

--- a/c/parallel/src/reduce.cu
+++ b/c/parallel/src/reduce.cu
@@ -18,10 +18,8 @@
 #include <cuda/std/functional> // ::cuda::std::identity
 #include <cuda/std/variant>
 
-#include <cstring> // strdup, free, memcpy
 #include <format>
 #include <memory>
-#include <new> // std::nothrow
 #include <vector>
 
 #include "jit_templates/templates/input_iterator.h"
@@ -340,11 +338,11 @@ static_assert(device_reduce_policy()(detail::current_tuning_arch()) == {7}, "Hos
   build->determinism                            = determinism;
   build->runtime_policy                         = new cub::detail::reduce::policy_selector{policy_sel};
   build->runtime_policy_size                    = sizeof(cub::detail::reduce::policy_selector);
-  build->single_tile_kernel_lowered_name        = strdup(single_tile_kernel_lowered_name.c_str());
-  build->single_tile_second_kernel_lowered_name = strdup(single_tile_second_kernel_lowered_name.c_str());
-  build->reduction_kernel_lowered_name          = strdup(reduction_kernel_lowered_name.c_str());
+  build->single_tile_kernel_lowered_name        = duplicate_c_string(single_tile_kernel_lowered_name);
+  build->single_tile_second_kernel_lowered_name = duplicate_c_string(single_tile_second_kernel_lowered_name);
+  build->reduction_kernel_lowered_name          = duplicate_c_string(reduction_kernel_lowered_name);
   build->nondeterministic_kernel_lowered_name =
-    build_nondeterministic ? strdup(nondeterministic_kernel_lowered_name.c_str()) : nullptr;
+    build_nondeterministic ? duplicate_c_string(nondeterministic_kernel_lowered_name) : nullptr;
 
   return CUDA_SUCCESS;
 }
@@ -554,14 +552,13 @@ try
     check(cuLibraryUnload(build_ptr->library));
   }
 
-  free(build_ptr->single_tile_kernel_lowered_name);
-  free(build_ptr->single_tile_second_kernel_lowered_name);
-  free(build_ptr->reduction_kernel_lowered_name);
-  free(build_ptr->nondeterministic_kernel_lowered_name);
-  build_ptr->single_tile_kernel_lowered_name        = nullptr;
-  build_ptr->single_tile_second_kernel_lowered_name = nullptr;
-  build_ptr->reduction_kernel_lowered_name          = nullptr;
-  build_ptr->nondeterministic_kernel_lowered_name   = nullptr;
+  for (char* p : {build_ptr->single_tile_kernel_lowered_name,
+                  build_ptr->single_tile_second_kernel_lowered_name,
+                  build_ptr->reduction_kernel_lowered_name,
+                  build_ptr->nondeterministic_kernel_lowered_name})
+  {
+    delete[] p;
+  }
 
   return CUDA_SUCCESS;
 }

--- a/c/parallel/src/reduce.cu
+++ b/c/parallel/src/reduce.cu
@@ -18,8 +18,10 @@
 #include <cuda/std/functional> // ::cuda::std::identity
 #include <cuda/std/variant>
 
+#include <cstring> // strdup, free, memcpy
 #include <format>
 #include <memory>
+#include <new> // std::nothrow
 #include <vector>
 
 #include "jit_templates/templates/input_iterator.h"
@@ -172,7 +174,7 @@ struct reduce_kernel_source
 struct reduce_iterator_tag;
 struct reduction_operation_tag;
 
-CUresult cccl_device_reduce_build_ex(
+CUresult cccl_device_reduce_compile(
   cccl_device_reduce_build_result_t* build,
   cccl_iterator_t input_it,
   cccl_iterator_t output_it,
@@ -191,7 +193,7 @@ try
   if (determinism == CCCL_NOT_GUARANTEED && (op.type != CCCL_PLUS || output_it.type != CCCL_POINTER))
   {
     fflush(stderr);
-    printf("\nERROR in cccl_device_reduce_build(): non-deterministic reduce with non-plus operator or non-pointer "
+    printf("\nERROR in cccl_device_reduce_compile(): non-deterministic reduce with non-plus operator or non-pointer "
            "output iterator is not supported\n");
     fflush(stdout);
     return CUDA_ERROR_INVALID_VALUE;
@@ -200,7 +202,7 @@ try
   if (determinism == CCCL_GPU_TO_GPU)
   {
     fflush(stderr);
-    printf("\nERROR in cccl_device_reduce_build(): gpu-to-gpu determinism is not supported\n");
+    printf("\nERROR in cccl_device_reduce_compile(): gpu-to-gpu determinism is not supported\n");
     fflush(stdout);
     return CUDA_ERROR_INVALID_VALUE;
   }
@@ -331,33 +333,92 @@ static_assert(device_reduce_policy()(detail::current_tuning_arch()) == {7}, "Hos
       ->add_link_list(linkable_list)
       ->finalize_program();
 
-  cuLibraryLoadData(&build->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
-  check(cuLibraryGetKernel(&build->single_tile_kernel, build->library, single_tile_kernel_lowered_name.c_str()));
-  check(cuLibraryGetKernel(
-    &build->single_tile_second_kernel, build->library, single_tile_second_kernel_lowered_name.c_str()));
-  check(cuLibraryGetKernel(&build->reduction_kernel, build->library, reduction_kernel_lowered_name.c_str()));
-  if (build_nondeterministic)
-  {
-    check(cuLibraryGetKernel(
-      &build->nondeterministic_atomic_kernel, build->library, nondeterministic_kernel_lowered_name.c_str()));
-  }
-
-  build->cc               = cc_major * 10 + cc_minor;
-  build->cubin            = (void*) result.data.release();
-  build->cubin_size       = result.size;
-  build->accumulator_size = accum_t.size;
-  build->determinism      = determinism;
-  build->runtime_policy   = new cub::detail::reduce::policy_selector{policy_sel};
+  build->cc                                     = cc_major * 10 + cc_minor;
+  build->cubin                                  = (void*) result.data.release();
+  build->cubin_size                             = result.size;
+  build->accumulator_size                       = accum_t.size;
+  build->determinism                            = determinism;
+  build->runtime_policy                         = new cub::detail::reduce::policy_selector{policy_sel};
+  build->runtime_policy_size                    = sizeof(cub::detail::reduce::policy_selector);
+  build->single_tile_kernel_lowered_name        = strdup(single_tile_kernel_lowered_name.c_str());
+  build->single_tile_second_kernel_lowered_name = strdup(single_tile_second_kernel_lowered_name.c_str());
+  build->reduction_kernel_lowered_name          = strdup(reduction_kernel_lowered_name.c_str());
+  build->nondeterministic_kernel_lowered_name =
+    build_nondeterministic ? strdup(nondeterministic_kernel_lowered_name.c_str()) : nullptr;
 
   return CUDA_SUCCESS;
 }
 catch (const std::exception& exc)
 {
   fflush(stderr);
-  printf("\nEXCEPTION in cccl_device_reduce_build(): %s\n", exc.what());
+  printf("\nEXCEPTION in cccl_device_reduce_compile(): %s\n", exc.what());
   fflush(stdout);
 
   return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_reduce_load(cccl_device_reduce_build_result_t* build)
+try
+{
+  if (build == nullptr || build->cubin == nullptr || build->cubin_size == 0)
+  {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  check(cuLibraryLoadData(&build->library, build->cubin, nullptr, nullptr, 0, nullptr, nullptr, 0));
+  check(cuLibraryGetKernel(&build->single_tile_kernel, build->library, build->single_tile_kernel_lowered_name));
+  check(cuLibraryGetKernel(
+    &build->single_tile_second_kernel, build->library, build->single_tile_second_kernel_lowered_name));
+  check(cuLibraryGetKernel(&build->reduction_kernel, build->library, build->reduction_kernel_lowered_name));
+  if (build->nondeterministic_kernel_lowered_name != nullptr)
+  {
+    check(cuLibraryGetKernel(
+      &build->nondeterministic_atomic_kernel, build->library, build->nondeterministic_kernel_lowered_name));
+  }
+  return CUDA_SUCCESS;
+}
+catch (const std::exception& exc)
+{
+  fflush(stderr);
+  printf("\nEXCEPTION in cccl_device_reduce_load(): %s\n", exc.what());
+  fflush(stdout);
+
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_reduce_build_ex(
+  cccl_device_reduce_build_result_t* build,
+  cccl_iterator_t input_it,
+  cccl_iterator_t output_it,
+  cccl_op_t op,
+  cccl_value_t init,
+  cccl_determinism_t determinism,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config)
+{
+  CUresult r = cccl_device_reduce_compile(
+    build,
+    input_it,
+    output_it,
+    op,
+    init,
+    determinism,
+    cc_major,
+    cc_minor,
+    cub_path,
+    thrust_path,
+    libcudacxx_path,
+    ctk_path,
+    config);
+  if (r != CUDA_SUCCESS)
+  {
+    return r;
+  }
+  return cccl_device_reduce_load(build);
 }
 
 // c.parallel provides two separate reduce functions, one for each determinism
@@ -488,7 +549,19 @@ try
   using namespace cub::detail::reduce;
   std::unique_ptr<char[]> cubin(static_cast<char*>(build_ptr->cubin));
   std::unique_ptr<policy_selector> policy(static_cast<policy_selector*>(build_ptr->runtime_policy));
-  check(cuLibraryUnload(build_ptr->library));
+  if (build_ptr->library != nullptr)
+  {
+    check(cuLibraryUnload(build_ptr->library));
+  }
+
+  free(build_ptr->single_tile_kernel_lowered_name);
+  free(build_ptr->single_tile_second_kernel_lowered_name);
+  free(build_ptr->reduction_kernel_lowered_name);
+  free(build_ptr->nondeterministic_kernel_lowered_name);
+  build_ptr->single_tile_kernel_lowered_name        = nullptr;
+  build_ptr->single_tile_second_kernel_lowered_name = nullptr;
+  build_ptr->reduction_kernel_lowered_name          = nullptr;
+  build_ptr->nondeterministic_kernel_lowered_name   = nullptr;
 
   return CUDA_SUCCESS;
 }

--- a/c/parallel/src/reduce.cu
+++ b/c/parallel/src/reduce.cu
@@ -26,6 +26,7 @@
 #include "jit_templates/templates/operation.h"
 #include "jit_templates/templates/output_iterator.h"
 #include "jit_templates/traits.h"
+#include "util/aot.h"
 #include "util/context.h"
 #include "util/errors.h"
 #include "util/indirect_arg.h"
@@ -380,6 +381,77 @@ catch (const std::exception& exc)
   printf("\nEXCEPTION in cccl_device_reduce_load(): %s\n", exc.what());
   fflush(stdout);
 
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_reduce_save_file(const cccl_device_reduce_build_result_t* build, const char* path)
+try
+{
+  AotWriter w(path);
+  if (build->cubin == nullptr)
+  {
+    printf("\nERROR in cccl_device_reduce_save_file(): build has no cubin\n");
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  w.write_header(CclbTag::reduce);
+  w.write_i32(build->cc);
+  w.write_blob(build->cubin, build->cubin_size);
+  w.write_blob(build->runtime_policy, build->runtime_policy_size);
+  w.write_u32(4);
+  w.write_string(build->single_tile_kernel_lowered_name);
+  w.write_string(build->single_tile_second_kernel_lowered_name);
+  w.write_string(build->reduction_kernel_lowered_name);
+  w.write_string(build->nondeterministic_kernel_lowered_name);
+  w.write_u64(build->accumulator_size);
+  w.write_i32(static_cast<int32_t>(build->determinism));
+  return CUDA_SUCCESS;
+}
+catch (...)
+{
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_reduce_load_file(cccl_device_reduce_build_result_t* build, const char* path)
+try
+{
+  AotReader r(path);
+  CclbTag tag = r.read_tag();
+
+  *build    = {};
+  build->cc = r.read_i32();
+
+  if (tag != CclbTag::reduce)
+  {
+    printf("\nERROR in cccl_device_reduce_load_file(): unexpected tag %u\n", static_cast<uint32_t>(tag));
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  {
+    uint64_t sz       = 0;
+    void* tmp_cb      = r.read_blob(&sz);
+    build->cubin_size = sz;
+    char* nb          = new char[static_cast<size_t>(sz)];
+    std::memcpy(nb, tmp_cb, static_cast<size_t>(sz));
+    std::free(tmp_cb);
+    build->cubin = nb;
+  }
+
+  {
+    uint64_t pol_sz            = 0;
+    build->runtime_policy      = r.read_blob(&pol_sz);
+    build->runtime_policy_size = static_cast<size_t>(pol_sz);
+  }
+  (void) r.read_u32(); // nkernels
+  build->single_tile_kernel_lowered_name        = r.read_string_heap();
+  build->single_tile_second_kernel_lowered_name = r.read_string_heap();
+  build->reduction_kernel_lowered_name          = r.read_string_heap();
+  build->nondeterministic_kernel_lowered_name   = r.read_string_heap();
+  build->accumulator_size                       = r.read_u64();
+  build->determinism                            = static_cast<cccl_determinism_t>(r.read_i32());
+  return cccl_device_reduce_load(build);
+}
+catch (...)
+{
   return CUDA_ERROR_UNKNOWN;
 }
 

--- a/c/parallel/src/scan.cu
+++ b/c/parallel/src/scan.cu
@@ -27,6 +27,7 @@
 
 #include <nvrtc.h>
 
+#include "util/aot.h"
 #include <cccl/c/scan.h>
 #include <kernels/iterators.h>
 #include <kernels/operators.h>
@@ -607,6 +608,83 @@ CUresult cccl_device_inclusive_scan_no_init(
   assert(build.init_kind == cccl_init_kind_t::CCCL_NO_INIT);
   return cccl_device_scan<cub::ForceInclusive::Yes, cub::NullType>(
     build, d_temp_storage, temp_storage_bytes, d_in, d_out, num_items, op, cub::NullType{}, stream);
+}
+
+CUresult cccl_device_scan_save_file(const cccl_device_scan_build_result_t* build, const char* path)
+try
+{
+  AotWriter w(path);
+  if (build->cubin == nullptr)
+  {
+    printf("\nERROR in cccl_device_scan_save_file(): build has no cubin\n");
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  w.write_header(CclbTag::scan);
+  w.write_i32(build->cc);
+  w.write_blob(build->cubin, build->cubin_size);
+  w.write_blob(build->runtime_policy, build->runtime_policy_size);
+  w.write_u32(2);
+  w.write_string(build->init_kernel_lowered_name);
+  w.write_string(build->scan_kernel_lowered_name);
+  w.write_type_info(build->input_type);
+  w.write_type_info(build->output_type);
+  w.write_type_info(build->accumulator_type);
+  w.write_bool(build->force_inclusive);
+  w.write_i32(static_cast<int32_t>(build->init_kind));
+  w.write_u64(static_cast<uint64_t>(build->description_bytes_per_tile));
+  w.write_u64(static_cast<uint64_t>(build->payload_bytes_per_tile));
+  return CUDA_SUCCESS;
+}
+catch (...)
+{
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_scan_load_file(cccl_device_scan_build_result_t* build, const char* path)
+try
+{
+  AotReader r(path);
+  CclbTag tag = r.read_tag();
+
+  *build    = {};
+  build->cc = r.read_i32();
+
+  if (tag != CclbTag::scan)
+  {
+    printf("\nERROR in cccl_device_scan_load_file(): unexpected tag %u\n", static_cast<uint32_t>(tag));
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  {
+    uint64_t sz       = 0;
+    void* tmp_cb      = r.read_blob(&sz);
+    build->cubin_size = sz;
+    char* nb          = new char[static_cast<size_t>(sz)];
+    std::memcpy(nb, tmp_cb, static_cast<size_t>(sz));
+    std::free(tmp_cb);
+    build->cubin = nb;
+  }
+
+  {
+    uint64_t pol_sz            = 0;
+    build->runtime_policy      = r.read_blob(&pol_sz);
+    build->runtime_policy_size = static_cast<size_t>(pol_sz);
+  }
+  (void) r.read_u32(); // nkernels
+  build->init_kernel_lowered_name   = r.read_string_heap();
+  build->scan_kernel_lowered_name   = r.read_string_heap();
+  build->input_type                 = r.read_type_info();
+  build->output_type                = r.read_type_info();
+  build->accumulator_type           = r.read_type_info();
+  build->force_inclusive            = r.read_bool();
+  build->init_kind                  = static_cast<cccl_init_kind_t>(r.read_i32());
+  build->description_bytes_per_tile = static_cast<size_t>(r.read_u64());
+  build->payload_bytes_per_tile     = static_cast<size_t>(r.read_u64());
+  return cccl_device_scan_load(build);
+}
+catch (...)
+{
+  return CUDA_ERROR_UNKNOWN;
 }
 
 CUresult cccl_device_scan_build_ex(

--- a/c/parallel/src/scan.cu
+++ b/c/parallel/src/scan.cu
@@ -238,7 +238,7 @@ struct scan_kernel_source
 };
 } // namespace scan
 
-CUresult cccl_device_scan_build_ex(
+CUresult cccl_device_scan_compile(
   cccl_device_scan_build_result_t* build_ptr,
   cccl_iterator_t input_it,
   cccl_iterator_t output_it,
@@ -421,10 +421,6 @@ static_assert(device_scan_policy()(detail::current_tuning_arch()) == {6}, "Host 
       ->add_link_list(linkable_list)
       ->finalize_program();
 
-  cuLibraryLoadData(&build_ptr->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
-  check(cuLibraryGetKernel(&build_ptr->init_kernel, build_ptr->library, init_kernel_lowered_name.c_str()));
-  check(cuLibraryGetKernel(&build_ptr->scan_kernel, build_ptr->library, scan_kernel_lowered_name.c_str()));
-
   auto [description_bytes_per_tile,
         payload_bytes_per_tile] = get_tile_state_bytes_per_tile(accum_t, accum_cpp, args.data(), args.size(), arch);
 
@@ -439,13 +435,41 @@ static_assert(device_scan_policy()(detail::current_tuning_arch()) == {6}, "Host 
   build_ptr->description_bytes_per_tile = description_bytes_per_tile;
   build_ptr->payload_bytes_per_tile     = payload_bytes_per_tile;
   build_ptr->runtime_policy             = new cub::detail::scan::policy_selector{policy_sel};
+  build_ptr->runtime_policy_size        = sizeof(cub::detail::scan::policy_selector);
+  build_ptr->init_kernel_lowered_name   = strdup(init_kernel_lowered_name.c_str());
+  build_ptr->scan_kernel_lowered_name   = strdup(scan_kernel_lowered_name.c_str());
 
   return CUDA_SUCCESS;
 }
 catch (const std::exception& exc)
 {
   fflush(stderr);
-  printf("\nEXCEPTION in cccl_device_scan_build(): %s\n", exc.what());
+  printf("\nEXCEPTION in cccl_device_scan_compile(): %s\n", exc.what());
+  fflush(stdout);
+
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_scan_load(cccl_device_scan_build_result_t* build_ptr)
+try
+{
+  if (build_ptr == nullptr || build_ptr->cubin == nullptr || build_ptr->cubin_size == 0)
+  {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  CUresult status = cuLibraryLoadData(&build_ptr->library, build_ptr->cubin, nullptr, nullptr, 0, nullptr, nullptr, 0);
+  if (status != CUDA_SUCCESS)
+  {
+    return status;
+  }
+  check(cuLibraryGetKernel(&build_ptr->init_kernel, build_ptr->library, build_ptr->init_kernel_lowered_name));
+  check(cuLibraryGetKernel(&build_ptr->scan_kernel, build_ptr->library, build_ptr->scan_kernel_lowered_name));
+  return CUDA_SUCCESS;
+}
+catch (const std::exception& exc)
+{
+  fflush(stderr);
+  printf("\nEXCEPTION in cccl_device_scan_load(): %s\n", exc.what());
   fflush(stdout);
 
   return CUDA_ERROR_UNKNOWN;
@@ -585,6 +609,44 @@ CUresult cccl_device_inclusive_scan_no_init(
     build, d_temp_storage, temp_storage_bytes, d_in, d_out, num_items, op, cub::NullType{}, stream);
 }
 
+CUresult cccl_device_scan_build_ex(
+  cccl_device_scan_build_result_t* build_ptr,
+  cccl_iterator_t d_in,
+  cccl_iterator_t d_out,
+  cccl_op_t op,
+  cccl_type_info init,
+  bool force_inclusive,
+  cccl_init_kind_t init_kind,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config)
+{
+  CUresult r = cccl_device_scan_compile(
+    build_ptr,
+    d_in,
+    d_out,
+    op,
+    init,
+    force_inclusive,
+    init_kind,
+    cc_major,
+    cc_minor,
+    cub_path,
+    thrust_path,
+    libcudacxx_path,
+    ctk_path,
+    config);
+  if (r != CUDA_SUCCESS)
+  {
+    return r;
+  }
+  return cccl_device_scan_load(build_ptr);
+}
+
 CUresult cccl_device_scan_build(
   cccl_device_scan_build_result_t* build_ptr,
   cccl_iterator_t d_in,
@@ -627,7 +689,12 @@ try
   std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(build_ptr->cubin));
   std::unique_ptr<cub::detail::scan::policy_selector> policy(
     static_cast<cub::detail::scan::policy_selector*>(build_ptr->runtime_policy));
-  check(cuLibraryUnload(build_ptr->library));
+  std::free(build_ptr->init_kernel_lowered_name);
+  std::free(build_ptr->scan_kernel_lowered_name);
+  if (build_ptr->library != nullptr)
+  {
+    check(cuLibraryUnload(build_ptr->library));
+  }
 
   return CUDA_SUCCESS;
 }

--- a/c/parallel/src/scan.cu
+++ b/c/parallel/src/scan.cu
@@ -436,8 +436,8 @@ static_assert(device_scan_policy()(detail::current_tuning_arch()) == {6}, "Host 
   build_ptr->payload_bytes_per_tile     = payload_bytes_per_tile;
   build_ptr->runtime_policy             = new cub::detail::scan::policy_selector{policy_sel};
   build_ptr->runtime_policy_size        = sizeof(cub::detail::scan::policy_selector);
-  build_ptr->init_kernel_lowered_name   = strdup(init_kernel_lowered_name.c_str());
-  build_ptr->scan_kernel_lowered_name   = strdup(scan_kernel_lowered_name.c_str());
+  build_ptr->init_kernel_lowered_name   = duplicate_c_string(init_kernel_lowered_name);
+  build_ptr->scan_kernel_lowered_name   = duplicate_c_string(scan_kernel_lowered_name);
 
   return CUDA_SUCCESS;
 }
@@ -689,8 +689,8 @@ try
   std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(build_ptr->cubin));
   std::unique_ptr<cub::detail::scan::policy_selector> policy(
     static_cast<cub::detail::scan::policy_selector*>(build_ptr->runtime_policy));
-  std::free(build_ptr->init_kernel_lowered_name);
-  std::free(build_ptr->scan_kernel_lowered_name);
+  std::unique_ptr<char[]> init_name(build_ptr->init_kernel_lowered_name);
+  std::unique_ptr<char[]> scan_name(build_ptr->scan_kernel_lowered_name);
   if (build_ptr->library != nullptr)
   {
     check(cuLibraryUnload(build_ptr->library));

--- a/c/parallel/src/segmented_reduce.cu
+++ b/c/parallel/src/segmented_reduce.cu
@@ -26,6 +26,7 @@
 #include "jit_templates/templates/operation.h"
 #include "jit_templates/templates/output_iterator.h"
 #include "jit_templates/traits.h"
+#include "util/aot.h"
 #include <cccl/c/segmented_reduce.h>
 #include <cccl/c/types.h> // cccl_type_info
 #include <nvrtc/command_list.h>
@@ -298,6 +299,72 @@ catch (const std::exception& exc)
   printf("\nEXCEPTION in cccl_device_segmented_reduce_load(): %s\n", exc.what());
   fflush(stdout);
 
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult
+cccl_device_segmented_reduce_save_file(const cccl_device_segmented_reduce_build_result_t* build, const char* path)
+try
+{
+  AotWriter w(path);
+  if (build->cubin == nullptr)
+  {
+    printf("\nERROR in cccl_device_segmented_reduce_save_file(): build has no cubin\n");
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  w.write_header(CclbTag::segmented_reduce);
+  w.write_i32(build->cc);
+  w.write_blob(build->cubin, build->cubin_size);
+  w.write_blob(build->runtime_policy, build->runtime_policy_size);
+  w.write_u32(1);
+  w.write_string(build->segmented_reduce_kernel_lowered_name);
+  w.write_u64(build->accumulator_size);
+  return CUDA_SUCCESS;
+}
+catch (const std::exception& exc)
+{
+  printf("\nEXCEPTION in cccl_device_segmented_reduce_save_file(): %s\n", exc.what());
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_segmented_reduce_load_file(cccl_device_segmented_reduce_build_result_t* build, const char* path)
+try
+{
+  AotReader r(path);
+  CclbTag tag = r.read_tag();
+
+  *build    = {};
+  build->cc = r.read_i32();
+
+  if (tag != CclbTag::segmented_reduce)
+  {
+    printf("\nERROR in cccl_device_segmented_reduce_load_file(): unexpected tag %u\n", static_cast<uint32_t>(tag));
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  {
+    uint64_t sz       = 0;
+    void* tmp_cb      = r.read_blob(&sz);
+    build->cubin_size = sz;
+    char* nb          = new char[static_cast<size_t>(sz)];
+    std::memcpy(nb, tmp_cb, static_cast<size_t>(sz));
+    std::free(tmp_cb);
+    build->cubin = nb;
+  }
+
+  {
+    uint64_t pol_sz            = 0;
+    build->runtime_policy      = r.read_blob(&pol_sz);
+    build->runtime_policy_size = static_cast<size_t>(pol_sz);
+  }
+  (void) r.read_u32(); // nkernels
+  build->segmented_reduce_kernel_lowered_name = r.read_string_heap();
+  build->accumulator_size                     = r.read_u64();
+  return cccl_device_segmented_reduce_load(build);
+}
+catch (const std::exception& exc)
+{
+  printf("\nEXCEPTION in cccl_device_segmented_reduce_load_file(): %s\n", exc.what());
   return CUDA_ERROR_UNKNOWN;
 }
 

--- a/c/parallel/src/segmented_reduce.cu
+++ b/c/parallel/src/segmented_reduce.cu
@@ -267,7 +267,7 @@ static_assert(
   build_ptr->accumulator_size                     = accum_t.size;
   build_ptr->runtime_policy                       = new cub::detail::segmented_reduce::policy_selector{policy_sel};
   build_ptr->runtime_policy_size                  = sizeof(cub::detail::segmented_reduce::policy_selector);
-  build_ptr->segmented_reduce_kernel_lowered_name = strdup(segmented_reduce_kernel_lowered_name.c_str());
+  build_ptr->segmented_reduce_kernel_lowered_name = duplicate_c_string(segmented_reduce_kernel_lowered_name);
 
   return CUDA_SUCCESS;
 }
@@ -437,11 +437,10 @@ try
     return CUDA_ERROR_INVALID_VALUE;
   }
 
-  // allocation behind cubin is owned by unique_ptr with delete[] deleter now
   std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(build_ptr->cubin));
   std::unique_ptr<cub::detail::segmented_reduce::policy_selector> policy(
     static_cast<cub::detail::segmented_reduce::policy_selector*>(build_ptr->runtime_policy));
-  std::free(build_ptr->segmented_reduce_kernel_lowered_name);
+  std::unique_ptr<char[]> kernel_name(build_ptr->segmented_reduce_kernel_lowered_name);
   if (build_ptr->library != nullptr)
   {
     check(cuLibraryUnload(build_ptr->library));

--- a/c/parallel/src/segmented_reduce.cu
+++ b/c/parallel/src/segmented_reduce.cu
@@ -112,7 +112,7 @@ struct segmented_reduce_start_offset_iterator_tag;
 struct segmented_reduce_end_offset_iterator_tag;
 struct segmented_reduce_operation_tag;
 
-CUresult cccl_device_segmented_reduce_build_ex(
+CUresult cccl_device_segmented_reduce_compile(
   cccl_device_segmented_reduce_build_result_t* build_ptr,
   cccl_iterator_t input_it,
   cccl_iterator_t output_it,
@@ -261,26 +261,82 @@ static_assert(
       ->add_link_list(linkable_list)
       ->finalize_program();
 
-  // populate build struct members
-  cuLibraryLoadData(&build_ptr->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
-  check(cuLibraryGetKernel(
-    &build_ptr->segmented_reduce_kernel, build_ptr->library, segmented_reduce_kernel_lowered_name.c_str()));
-
-  build_ptr->cc               = cc_major * 10 + cc_minor;
-  build_ptr->cubin            = (void*) result.data.release();
-  build_ptr->cubin_size       = result.size;
-  build_ptr->accumulator_size = accum_t.size;
-  build_ptr->runtime_policy   = new cub::detail::segmented_reduce::policy_selector{policy_sel};
+  build_ptr->cc                                   = cc_major * 10 + cc_minor;
+  build_ptr->cubin                                = (void*) result.data.release();
+  build_ptr->cubin_size                           = result.size;
+  build_ptr->accumulator_size                     = accum_t.size;
+  build_ptr->runtime_policy                       = new cub::detail::segmented_reduce::policy_selector{policy_sel};
+  build_ptr->runtime_policy_size                  = sizeof(cub::detail::segmented_reduce::policy_selector);
+  build_ptr->segmented_reduce_kernel_lowered_name = strdup(segmented_reduce_kernel_lowered_name.c_str());
 
   return CUDA_SUCCESS;
 }
 catch (const std::exception& exc)
 {
   fflush(stderr);
-  printf("\nEXCEPTION in cccl_device_segmented_reduce_build(): %s\n", exc.what());
+  printf("\nEXCEPTION in cccl_device_segmented_reduce_compile(): %s\n", exc.what());
   fflush(stdout);
 
   return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_segmented_reduce_load(cccl_device_segmented_reduce_build_result_t* build_ptr)
+try
+{
+  if (build_ptr == nullptr || build_ptr->cubin == nullptr || build_ptr->cubin_size == 0)
+  {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  check(cuLibraryLoadData(&build_ptr->library, build_ptr->cubin, nullptr, nullptr, 0, nullptr, nullptr, 0));
+  check(cuLibraryGetKernel(
+    &build_ptr->segmented_reduce_kernel, build_ptr->library, build_ptr->segmented_reduce_kernel_lowered_name));
+  return CUDA_SUCCESS;
+}
+catch (const std::exception& exc)
+{
+  fflush(stderr);
+  printf("\nEXCEPTION in cccl_device_segmented_reduce_load(): %s\n", exc.what());
+  fflush(stdout);
+
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_segmented_reduce_build_ex(
+  cccl_device_segmented_reduce_build_result_t* build_ptr,
+  cccl_iterator_t input_it,
+  cccl_iterator_t output_it,
+  cccl_iterator_t start_offset_it,
+  cccl_iterator_t end_offset_it,
+  cccl_op_t op,
+  cccl_value_t init,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config)
+{
+  CUresult r = cccl_device_segmented_reduce_compile(
+    build_ptr,
+    input_it,
+    output_it,
+    start_offset_it,
+    end_offset_it,
+    op,
+    init,
+    cc_major,
+    cc_minor,
+    cub_path,
+    thrust_path,
+    libcudacxx_path,
+    ctk_path,
+    config);
+  if (r != CUDA_SUCCESS)
+  {
+    return r;
+  }
+  return cccl_device_segmented_reduce_load(build_ptr);
 }
 
 CUresult cccl_device_segmented_reduce(
@@ -385,7 +441,11 @@ try
   std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(build_ptr->cubin));
   std::unique_ptr<cub::detail::segmented_reduce::policy_selector> policy(
     static_cast<cub::detail::segmented_reduce::policy_selector*>(build_ptr->runtime_policy));
-  check(cuLibraryUnload(build_ptr->library));
+  std::free(build_ptr->segmented_reduce_kernel_lowered_name);
+  if (build_ptr->library != nullptr)
+  {
+    check(cuLibraryUnload(build_ptr->library));
+  }
 
   return CUDA_SUCCESS;
 }

--- a/c/parallel/src/segmented_sort.cu
+++ b/c/parallel/src/segmented_sort.cu
@@ -220,7 +220,6 @@ extern "C" __device__ void {0}(void* state_ptr, const void* arg_ptr, void* resul
       ->add_program(nvrtc_translation_unit{code.c_str(), selector_op_name})
       ->compile_program({compile_args, num_compile_args})
       ->get_program_ltoir();
-  // Use malloc so cleanup can consistently use std::free regardless of build vs deserialized path
   char* code_copy = static_cast<char*>(std::malloc(lto_size));
   std::memcpy(code_copy, lto_buf.get(), lto_size);
   selector_op.code      = code_copy;
@@ -646,14 +645,15 @@ static_assert(
   build_ptr->runtime_policy             = new cub::detail::segmented_sort::policy_selector{policy_sel};
   build_ptr->runtime_policy_size        = sizeof(cub::detail::segmented_sort::policy_selector);
   build_ptr->partition_runtime_policy   = new cub::detail::three_way_partition::policy_selector{partition_policy_sel};
-  build_ptr->partition_runtime_policy_size               = sizeof(cub::detail::three_way_partition::policy_selector);
-  build_ptr->order                                       = sort_order;
-  build_ptr->segmented_sort_fallback_kernel_lowered_name = strdup(segmented_sort_fallback_kernel_lowered_name.c_str());
-  build_ptr->segmented_sort_kernel_small_lowered_name    = strdup(segmented_sort_kernel_small_lowered_name.c_str());
-  build_ptr->segmented_sort_kernel_large_lowered_name    = strdup(segmented_sort_kernel_large_lowered_name.c_str());
+  build_ptr->partition_runtime_policy_size = sizeof(cub::detail::three_way_partition::policy_selector);
+  build_ptr->order                         = sort_order;
+  build_ptr->segmented_sort_fallback_kernel_lowered_name =
+    duplicate_c_string(segmented_sort_fallback_kernel_lowered_name);
+  build_ptr->segmented_sort_kernel_small_lowered_name = duplicate_c_string(segmented_sort_kernel_small_lowered_name);
+  build_ptr->segmented_sort_kernel_large_lowered_name = duplicate_c_string(segmented_sort_kernel_large_lowered_name);
   build_ptr->three_way_partition_init_kernel_lowered_name =
-    strdup(three_way_partition_init_kernel_lowered_name.c_str());
-  build_ptr->three_way_partition_kernel_lowered_name = strdup(three_way_partition_kernel_lowered_name.c_str());
+    duplicate_c_string(three_way_partition_init_kernel_lowered_name);
+  build_ptr->three_way_partition_kernel_lowered_name = duplicate_c_string(three_way_partition_kernel_lowered_name);
 
   return CUDA_SUCCESS;
 }
@@ -896,7 +896,6 @@ try
     return CUDA_ERROR_INVALID_VALUE;
   }
 
-  // allocation behind cubin is owned by unique_ptr with delete[] deleter now
   std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(build_ptr->cubin));
 
   // Clean up the selector op states and code buffers (malloc-allocated, so use std::free)
@@ -910,11 +909,15 @@ try
     static_cast<cub::detail::segmented_sort::policy_selector*>(build_ptr->runtime_policy));
   std::unique_ptr<cub::detail::three_way_partition::policy_selector> prtp(
     static_cast<cub::detail::three_way_partition::policy_selector*>(build_ptr->partition_runtime_policy));
-  std::free(build_ptr->segmented_sort_fallback_kernel_lowered_name);
-  std::free(build_ptr->segmented_sort_kernel_small_lowered_name);
-  std::free(build_ptr->segmented_sort_kernel_large_lowered_name);
-  std::free(build_ptr->three_way_partition_init_kernel_lowered_name);
-  std::free(build_ptr->three_way_partition_kernel_lowered_name);
+  for (char* p :
+       {build_ptr->segmented_sort_fallback_kernel_lowered_name,
+        build_ptr->segmented_sort_kernel_small_lowered_name,
+        build_ptr->segmented_sort_kernel_large_lowered_name,
+        build_ptr->three_way_partition_init_kernel_lowered_name,
+        build_ptr->three_way_partition_kernel_lowered_name})
+  {
+    delete[] p;
+  }
   if (build_ptr->library != nullptr)
   {
     check(cuLibraryUnload(build_ptr->library));

--- a/c/parallel/src/segmented_sort.cu
+++ b/c/parallel/src/segmented_sort.cu
@@ -25,6 +25,7 @@
 #include "jit_templates/templates/operation.h"
 #include "jit_templates/templates/output_iterator.h"
 #include "jit_templates/traits.h"
+#include "util/aot.h"
 #include "util/context.h"
 #include "util/errors.h"
 #include "util/indirect_arg.h"
@@ -696,6 +697,102 @@ catch (const std::exception& exc)
   printf("\nEXCEPTION in cccl_device_segmented_sort_load(): %s\n", exc.what());
   fflush(stdout);
 
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_segmented_sort_save_file(const cccl_device_segmented_sort_build_result_t* build, const char* path)
+try
+{
+  AotWriter w(path);
+  w.write_header(CclbTag::segmented_sort);
+  w.write_i32(build->cc);
+  w.write_blob(build->cubin, build->cubin_size);
+  w.write_blob(build->runtime_policy, build->runtime_policy_size);
+  w.write_blob(build->partition_runtime_policy, build->partition_runtime_policy_size);
+  w.write_u32(5);
+  w.write_string(build->segmented_sort_fallback_kernel_lowered_name);
+  w.write_string(build->segmented_sort_kernel_small_lowered_name);
+  w.write_string(build->segmented_sort_kernel_large_lowered_name);
+  w.write_string(build->three_way_partition_init_kernel_lowered_name);
+  w.write_string(build->three_way_partition_kernel_lowered_name);
+  // Selector ops: save type/size/alignment only (state and code are not serialized)
+  w.write_i32(static_cast<int32_t>(build->large_segments_selector_op.type));
+  w.write_u64(static_cast<uint64_t>(build->large_segments_selector_op.size));
+  w.write_u64(static_cast<uint64_t>(build->large_segments_selector_op.alignment));
+  w.write_i32(static_cast<int32_t>(build->small_segments_selector_op.type));
+  w.write_u64(static_cast<uint64_t>(build->small_segments_selector_op.size));
+  w.write_u64(static_cast<uint64_t>(build->small_segments_selector_op.alignment));
+  w.write_type_info(build->key_type);
+  w.write_type_info(build->offset_type);
+  w.write_i32(static_cast<int32_t>(build->order));
+  return CUDA_SUCCESS;
+}
+catch (...)
+{
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_segmented_sort_load_file(cccl_device_segmented_sort_build_result_t* build, const char* path)
+try
+{
+  AotReader r(path);
+  CclbTag tag = r.read_tag();
+  if (tag != CclbTag::segmented_sort)
+  {
+    printf("\nERROR in cccl_device_segmented_sort_load_file(): unexpected tag %u\n", static_cast<uint32_t>(tag));
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  *build    = {};
+  build->cc = r.read_i32();
+  {
+    uint64_t sz       = 0;
+    void* tmp_cb      = r.read_blob(&sz);
+    build->cubin_size = sz;
+    char* nb          = new char[static_cast<size_t>(sz)];
+    std::memcpy(nb, tmp_cb, static_cast<size_t>(sz));
+    std::free(tmp_cb);
+    build->cubin = nb;
+  }
+  {
+    uint64_t pol_sz            = 0;
+    build->runtime_policy      = r.read_blob(&pol_sz);
+    build->runtime_policy_size = static_cast<size_t>(pol_sz);
+  }
+  {
+    uint64_t pol_sz                      = 0;
+    build->partition_runtime_policy      = r.read_blob(&pol_sz);
+    build->partition_runtime_policy_size = static_cast<size_t>(pol_sz);
+  }
+  (void) r.read_u32(); // nkernels
+  build->segmented_sort_fallback_kernel_lowered_name  = r.read_string_heap();
+  build->segmented_sort_kernel_small_lowered_name     = r.read_string_heap();
+  build->segmented_sort_kernel_large_lowered_name     = r.read_string_heap();
+  build->three_way_partition_init_kernel_lowered_name = r.read_string_heap();
+  build->three_way_partition_kernel_lowered_name      = r.read_string_heap();
+  // Reconstruct selector ops with zeroed state (no code/state round-trip)
+  build->large_segments_selector_op           = {};
+  build->large_segments_selector_op.type      = static_cast<cccl_op_kind_t>(r.read_i32());
+  build->large_segments_selector_op.size      = static_cast<size_t>(r.read_u64());
+  build->large_segments_selector_op.alignment = static_cast<size_t>(r.read_u64());
+  if (build->large_segments_selector_op.size > 0)
+  {
+    build->large_segments_selector_op.state = std::calloc(1, build->large_segments_selector_op.size);
+  }
+  build->small_segments_selector_op           = {};
+  build->small_segments_selector_op.type      = static_cast<cccl_op_kind_t>(r.read_i32());
+  build->small_segments_selector_op.size      = static_cast<size_t>(r.read_u64());
+  build->small_segments_selector_op.alignment = static_cast<size_t>(r.read_u64());
+  if (build->small_segments_selector_op.size > 0)
+  {
+    build->small_segments_selector_op.state = std::calloc(1, build->small_segments_selector_op.size);
+  }
+  build->key_type    = r.read_type_info();
+  build->offset_type = r.read_type_info();
+  build->order       = static_cast<cccl_sort_order_t>(r.read_i32());
+  return cccl_device_segmented_sort_load(build);
+}
+catch (...)
+{
   return CUDA_ERROR_UNKNOWN;
 }
 

--- a/c/parallel/src/segmented_sort.cu
+++ b/c/parallel/src/segmented_sort.cu
@@ -220,15 +220,19 @@ extern "C" __device__ void {0}(void* state_ptr, const void* arg_ptr, void* resul
       ->add_program(nvrtc_translation_unit{code.c_str(), selector_op_name})
       ->compile_program({compile_args, num_compile_args})
       ->get_program_ltoir();
-  selector_op.code      = lto_buf.release();
+  // Use malloc so cleanup can consistently use std::free regardless of build vs deserialized path
+  char* code_copy = static_cast<char*>(std::malloc(lto_size));
+  std::memcpy(code_copy, lto_buf.get(), lto_size);
+  selector_op.code      = code_copy;
   selector_op.code_size = lto_size;
   selector_op.code_type = CCCL_OP_LTOIR;
   selector_op.size      = sizeof(selector_state_t);
   selector_op.alignment = alignof(selector_state_t);
-  selector_op.state     = selector_op_state.get();
 
   selector_op_state->initialize(offset, begin_offset_iterator, end_offset_iterator);
-  selector_op_state.release();
+  auto* state_copy = static_cast<selector_state_t*>(std::malloc(sizeof(selector_state_t)));
+  std::memcpy(state_copy, selector_op_state.get(), sizeof(selector_state_t));
+  selector_op.state = state_copy;
 
   return selector_op;
 }
@@ -357,7 +361,7 @@ struct segmented_sort_end_offset_iterator_tag;
 struct segmented_sort_large_selector_tag;
 struct segmented_sort_small_selector_tag;
 
-CUresult cccl_device_segmented_sort_build_ex(
+CUresult cccl_device_segmented_sort_compile(
   cccl_device_segmented_sort_build_result_t* build_ptr,
   cccl_sort_order_t sort_order,
   cccl_iterator_t keys_in_it,
@@ -632,20 +636,6 @@ static_assert(
       ->finalize_program();
 
   // populate build struct members
-  cuLibraryLoadData(&build_ptr->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
-  check(cuLibraryGetKernel(&build_ptr->segmented_sort_fallback_kernel,
-                           build_ptr->library,
-                           segmented_sort_fallback_kernel_lowered_name.c_str()));
-  check(cuLibraryGetKernel(
-    &build_ptr->segmented_sort_kernel_small, build_ptr->library, segmented_sort_kernel_small_lowered_name.c_str()));
-  check(cuLibraryGetKernel(
-    &build_ptr->segmented_sort_kernel_large, build_ptr->library, segmented_sort_kernel_large_lowered_name.c_str()));
-  check(cuLibraryGetKernel(&build_ptr->three_way_partition_init_kernel,
-                           build_ptr->library,
-                           three_way_partition_init_kernel_lowered_name.c_str()));
-  check(cuLibraryGetKernel(
-    &build_ptr->three_way_partition_kernel, build_ptr->library, three_way_partition_kernel_lowered_name.c_str()));
-
   build_ptr->cc                         = cc_major * 10 + cc_minor;
   build_ptr->large_segments_selector_op = large_selector_op;
   build_ptr->small_segments_selector_op = small_selector_op;
@@ -654,18 +644,95 @@ static_assert(
   build_ptr->key_type                   = keys_in_it.value_type;
   build_ptr->offset_type                = cccl_type_info{sizeof(OffsetT), alignof(OffsetT), cccl_type_enum::CCCL_INT64};
   build_ptr->runtime_policy             = new cub::detail::segmented_sort::policy_selector{policy_sel};
+  build_ptr->runtime_policy_size        = sizeof(cub::detail::segmented_sort::policy_selector);
   build_ptr->partition_runtime_policy   = new cub::detail::three_way_partition::policy_selector{partition_policy_sel};
-  build_ptr->order                      = sort_order;
+  build_ptr->partition_runtime_policy_size               = sizeof(cub::detail::three_way_partition::policy_selector);
+  build_ptr->order                                       = sort_order;
+  build_ptr->segmented_sort_fallback_kernel_lowered_name = strdup(segmented_sort_fallback_kernel_lowered_name.c_str());
+  build_ptr->segmented_sort_kernel_small_lowered_name    = strdup(segmented_sort_kernel_small_lowered_name.c_str());
+  build_ptr->segmented_sort_kernel_large_lowered_name    = strdup(segmented_sort_kernel_large_lowered_name.c_str());
+  build_ptr->three_way_partition_init_kernel_lowered_name =
+    strdup(three_way_partition_init_kernel_lowered_name.c_str());
+  build_ptr->three_way_partition_kernel_lowered_name = strdup(three_way_partition_kernel_lowered_name.c_str());
 
   return CUDA_SUCCESS;
 }
 catch (const std::exception& exc)
 {
   fflush(stderr);
-  printf("\nEXCEPTION in cccl_device_segmented_sort_build(): %s\n", exc.what());
+  printf("\nEXCEPTION in cccl_device_segmented_sort_compile(): %s\n", exc.what());
   fflush(stdout);
 
   return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_segmented_sort_load(cccl_device_segmented_sort_build_result_t* build)
+try
+{
+  if (build == nullptr || build->cubin == nullptr || build->cubin_size == 0)
+  {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  CUresult status = cuLibraryLoadData(&build->library, build->cubin, nullptr, nullptr, 0, nullptr, nullptr, 0);
+  if (status != CUDA_SUCCESS)
+  {
+    return status;
+  }
+  check(cuLibraryGetKernel(
+    &build->segmented_sort_fallback_kernel, build->library, build->segmented_sort_fallback_kernel_lowered_name));
+  check(cuLibraryGetKernel(
+    &build->segmented_sort_kernel_small, build->library, build->segmented_sort_kernel_small_lowered_name));
+  check(cuLibraryGetKernel(
+    &build->segmented_sort_kernel_large, build->library, build->segmented_sort_kernel_large_lowered_name));
+  check(cuLibraryGetKernel(
+    &build->three_way_partition_init_kernel, build->library, build->three_way_partition_init_kernel_lowered_name));
+  check(cuLibraryGetKernel(
+    &build->three_way_partition_kernel, build->library, build->three_way_partition_kernel_lowered_name));
+  return CUDA_SUCCESS;
+}
+catch (const std::exception& exc)
+{
+  fflush(stderr);
+  printf("\nEXCEPTION in cccl_device_segmented_sort_load(): %s\n", exc.what());
+  fflush(stdout);
+
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_segmented_sort_build_ex(
+  cccl_device_segmented_sort_build_result_t* build_ptr,
+  cccl_sort_order_t sort_order,
+  cccl_iterator_t keys_in_it,
+  cccl_iterator_t values_in_it,
+  cccl_iterator_t start_offset_it,
+  cccl_iterator_t end_offset_it,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config)
+{
+  CUresult result = cccl_device_segmented_sort_compile(
+    build_ptr,
+    sort_order,
+    keys_in_it,
+    values_in_it,
+    start_offset_it,
+    end_offset_it,
+    cc_major,
+    cc_minor,
+    cub_path,
+    thrust_path,
+    libcudacxx_path,
+    ctk_path,
+    config);
+  if (result != CUDA_SUCCESS)
+  {
+    return result;
+  }
+  return cccl_device_segmented_sort_load(build_ptr);
 }
 
 CUresult cccl_device_segmented_sort_build(
@@ -832,22 +899,26 @@ try
   // allocation behind cubin is owned by unique_ptr with delete[] deleter now
   std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(build_ptr->cubin));
 
-  // Clean up the selector op states
-  std::unique_ptr<segmented_sort::selector_state_t> large_state(
-    static_cast<segmented_sort::selector_state_t*>(build_ptr->large_segments_selector_op.state));
-  std::unique_ptr<segmented_sort::selector_state_t> small_state(
-    static_cast<segmented_sort::selector_state_t*>(build_ptr->small_segments_selector_op.state));
-
-  // Clean up the selector op code buffers
-  std::unique_ptr<char[]> large_code(const_cast<char*>(build_ptr->large_segments_selector_op.code));
-  std::unique_ptr<char[]> small_code(const_cast<char*>(build_ptr->small_segments_selector_op.code));
+  // Clean up the selector op states and code buffers (malloc-allocated, so use std::free)
+  std::free(build_ptr->large_segments_selector_op.state);
+  std::free(build_ptr->small_segments_selector_op.state);
+  std::free(const_cast<char*>(build_ptr->large_segments_selector_op.code));
+  std::free(const_cast<char*>(build_ptr->small_segments_selector_op.code));
 
   // Clean up the runtime policies
   std::unique_ptr<cub::detail::segmented_sort::policy_selector> rtp(
     static_cast<cub::detail::segmented_sort::policy_selector*>(build_ptr->runtime_policy));
   std::unique_ptr<cub::detail::three_way_partition::policy_selector> prtp(
     static_cast<cub::detail::three_way_partition::policy_selector*>(build_ptr->partition_runtime_policy));
-  check(cuLibraryUnload(build_ptr->library));
+  std::free(build_ptr->segmented_sort_fallback_kernel_lowered_name);
+  std::free(build_ptr->segmented_sort_kernel_small_lowered_name);
+  std::free(build_ptr->segmented_sort_kernel_large_lowered_name);
+  std::free(build_ptr->three_way_partition_init_kernel_lowered_name);
+  std::free(build_ptr->three_way_partition_kernel_lowered_name);
+  if (build_ptr->library != nullptr)
+  {
+    check(cuLibraryUnload(build_ptr->library));
+  }
 
   return CUDA_SUCCESS;
 }

--- a/c/parallel/src/three_way_partition.cu
+++ b/c/parallel/src/three_way_partition.cu
@@ -279,8 +279,8 @@ static_assert(
   build_ptr->runtime_policy      = new cub::detail::three_way_partition::policy_selector{policy_sel};
   build_ptr->runtime_policy_size = sizeof(cub::detail::three_way_partition::policy_selector);
   build_ptr->three_way_partition_init_kernel_lowered_name =
-    strdup(three_way_partition_init_kernel_lowered_name.c_str());
-  build_ptr->three_way_partition_kernel_lowered_name = strdup(three_way_partition_kernel_lowered_name.c_str());
+    duplicate_c_string(three_way_partition_init_kernel_lowered_name);
+  build_ptr->three_way_partition_kernel_lowered_name = duplicate_c_string(three_way_partition_kernel_lowered_name);
 
   return CUDA_SUCCESS;
 }
@@ -435,8 +435,8 @@ try
   std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(bld_ptr->cubin));
   std::unique_ptr<cub::detail::three_way_partition::policy_selector> policy(
     static_cast<cub::detail::three_way_partition::policy_selector*>(bld_ptr->runtime_policy));
-  std::free(bld_ptr->three_way_partition_init_kernel_lowered_name);
-  std::free(bld_ptr->three_way_partition_kernel_lowered_name);
+  std::unique_ptr<char[]> init_name(bld_ptr->three_way_partition_init_kernel_lowered_name);
+  std::unique_ptr<char[]> kernel_name(bld_ptr->three_way_partition_kernel_lowered_name);
   if (bld_ptr->library != nullptr)
   {
     check(cuLibraryUnload(bld_ptr->library));

--- a/c/parallel/src/three_way_partition.cu
+++ b/c/parallel/src/three_way_partition.cu
@@ -114,7 +114,7 @@ struct three_way_partition_num_selected_output_iterator_tag;
 struct three_way_partition_select_first_part_operation_tag;
 struct three_way_partition_select_second_part_operation_tag;
 
-CUresult cccl_device_three_way_partition_build_ex(
+CUresult cccl_device_three_way_partition_compile(
   cccl_device_three_way_partition_build_result_t* build_ptr,
   cccl_iterator_t d_in,
   cccl_iterator_t d_first_part_out,
@@ -273,27 +273,87 @@ static_assert(
       ->add_link_list(linkable_list)
       ->finalize_program();
 
-  cuLibraryLoadData(&build_ptr->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
-  check(cuLibraryGetKernel(&build_ptr->three_way_partition_init_kernel,
-                           build_ptr->library,
-                           three_way_partition_init_kernel_lowered_name.c_str()));
-  check(cuLibraryGetKernel(
-    &build_ptr->three_way_partition_kernel, build_ptr->library, three_way_partition_kernel_lowered_name.c_str()));
-
-  build_ptr->cc             = cc;
-  build_ptr->cubin          = (void*) result.data.release();
-  build_ptr->cubin_size     = result.size;
-  build_ptr->runtime_policy = new cub::detail::three_way_partition::policy_selector{policy_sel};
+  build_ptr->cc                  = cc;
+  build_ptr->cubin               = (void*) result.data.release();
+  build_ptr->cubin_size          = result.size;
+  build_ptr->runtime_policy      = new cub::detail::three_way_partition::policy_selector{policy_sel};
+  build_ptr->runtime_policy_size = sizeof(cub::detail::three_way_partition::policy_selector);
+  build_ptr->three_way_partition_init_kernel_lowered_name =
+    strdup(three_way_partition_init_kernel_lowered_name.c_str());
+  build_ptr->three_way_partition_kernel_lowered_name = strdup(three_way_partition_kernel_lowered_name.c_str());
 
   return CUDA_SUCCESS;
 }
 catch (const std::exception& exc)
 {
   fflush(stderr);
-  printf("\nEXCEPTION in cccl_device_three_way_partition_build(): %s\n", exc.what());
+  printf("\nEXCEPTION in cccl_device_three_way_partition_compile(): %s\n", exc.what());
   fflush(stdout);
 
   return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_three_way_partition_load(cccl_device_three_way_partition_build_result_t* build)
+try
+{
+  if (build == nullptr || build->cubin == nullptr || build->cubin_size == 0)
+  {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  check(cuLibraryLoadData(&build->library, build->cubin, nullptr, nullptr, 0, nullptr, nullptr, 0));
+  check(cuLibraryGetKernel(
+    &build->three_way_partition_init_kernel, build->library, build->three_way_partition_init_kernel_lowered_name));
+  check(cuLibraryGetKernel(
+    &build->three_way_partition_kernel, build->library, build->three_way_partition_kernel_lowered_name));
+  return CUDA_SUCCESS;
+}
+catch (const std::exception& exc)
+{
+  fflush(stderr);
+  printf("\nEXCEPTION in cccl_device_three_way_partition_load(): %s\n", exc.what());
+  fflush(stdout);
+
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_three_way_partition_build_ex(
+  cccl_device_three_way_partition_build_result_t* build_ptr,
+  cccl_iterator_t d_in,
+  cccl_iterator_t d_first_part_out,
+  cccl_iterator_t d_second_part_out,
+  cccl_iterator_t d_unselected_out,
+  cccl_iterator_t d_num_selected_out,
+  cccl_op_t select_first_part_op,
+  cccl_op_t select_second_part_op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config)
+{
+  CUresult result = cccl_device_three_way_partition_compile(
+    build_ptr,
+    d_in,
+    d_first_part_out,
+    d_second_part_out,
+    d_unselected_out,
+    d_num_selected_out,
+    select_first_part_op,
+    select_second_part_op,
+    cc_major,
+    cc_minor,
+    cub_path,
+    thrust_path,
+    libcudacxx_path,
+    ctk_path,
+    config);
+  if (result != CUDA_SUCCESS)
+  {
+    return result;
+  }
+  return cccl_device_three_way_partition_load(build_ptr);
 }
 
 CUresult cccl_device_three_way_partition(
@@ -375,7 +435,12 @@ try
   std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(bld_ptr->cubin));
   std::unique_ptr<cub::detail::three_way_partition::policy_selector> policy(
     static_cast<cub::detail::three_way_partition::policy_selector*>(bld_ptr->runtime_policy));
-  check(cuLibraryUnload(bld_ptr->library));
+  std::free(bld_ptr->three_way_partition_init_kernel_lowered_name);
+  std::free(bld_ptr->three_way_partition_kernel_lowered_name);
+  if (bld_ptr->library != nullptr)
+  {
+    check(cuLibraryUnload(bld_ptr->library));
+  }
 
   return CUDA_SUCCESS;
 }

--- a/c/parallel/src/three_way_partition.cu
+++ b/c/parallel/src/three_way_partition.cu
@@ -25,6 +25,7 @@
 #include "jit_templates/templates/operation.h"
 #include "jit_templates/templates/output_iterator.h"
 #include "jit_templates/traits.h"
+#include "util/aot.h"
 #include "util/context.h"
 #include "util/errors.h"
 #include "util/indirect_arg.h"
@@ -313,6 +314,64 @@ catch (const std::exception& exc)
   printf("\nEXCEPTION in cccl_device_three_way_partition_load(): %s\n", exc.what());
   fflush(stdout);
 
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult
+cccl_device_three_way_partition_save_file(const cccl_device_three_way_partition_build_result_t* build, const char* path)
+try
+{
+  AotWriter w(path);
+  w.write_header(CclbTag::three_way_partition);
+  w.write_i32(build->cc);
+  w.write_blob(build->cubin, build->cubin_size);
+  w.write_blob(build->runtime_policy, build->runtime_policy_size);
+  w.write_u32(2);
+  w.write_string(build->three_way_partition_init_kernel_lowered_name);
+  w.write_string(build->three_way_partition_kernel_lowered_name);
+  return CUDA_SUCCESS;
+}
+catch (const std::exception& exc)
+{
+  printf("\nEXCEPTION in cccl_device_three_way_partition_save_file(): %s\n", exc.what());
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult
+cccl_device_three_way_partition_load_file(cccl_device_three_way_partition_build_result_t* build, const char* path)
+try
+{
+  AotReader r(path);
+  CclbTag tag = r.read_tag();
+  if (tag != CclbTag::three_way_partition)
+  {
+    printf("\nERROR in cccl_device_three_way_partition_load_file(): unexpected tag %u\n", static_cast<uint32_t>(tag));
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  *build    = {};
+  build->cc = r.read_i32();
+  {
+    uint64_t sz       = 0;
+    void* tmp_cb      = r.read_blob(&sz);
+    build->cubin_size = sz;
+    char* nb          = new char[static_cast<size_t>(sz)];
+    std::memcpy(nb, tmp_cb, static_cast<size_t>(sz));
+    std::free(tmp_cb);
+    build->cubin = nb;
+  }
+  {
+    uint64_t pol_sz            = 0;
+    build->runtime_policy      = r.read_blob(&pol_sz);
+    build->runtime_policy_size = static_cast<size_t>(pol_sz);
+  }
+  (void) r.read_u32(); // nkernels
+  build->three_way_partition_init_kernel_lowered_name = r.read_string_heap();
+  build->three_way_partition_kernel_lowered_name      = r.read_string_heap();
+  return cccl_device_three_way_partition_load(build);
+}
+catch (const std::exception& exc)
+{
+  printf("\nEXCEPTION in cccl_device_three_way_partition_load_file(): %s\n", exc.what());
   return CUDA_ERROR_UNKNOWN;
 }
 

--- a/c/parallel/src/transform.cu
+++ b/c/parallel/src/transform.cu
@@ -330,9 +330,8 @@ static_assert(device_transform_policy()(detail::current_tuning_arch()) == {9}, "
   build_ptr->cubin                         = (void*) result.data.release();
   build_ptr->cubin_size                    = result.size;
   build_ptr->cache                         = new transform::cache();
-  build_ptr->transform_kernel_lowered_name = strdup(kernel_lowered_name.c_str());
+  build_ptr->transform_kernel_lowered_name = duplicate_c_string(kernel_lowered_name);
 
-  // avoid new and delete which requires the allocated and freed types to match
   build_ptr->runtime_policy      = std::malloc(sizeof(policy_sel));
   build_ptr->runtime_policy_size = sizeof(policy_sel);
   std::memcpy(build_ptr->runtime_policy, &policy_sel, sizeof(policy_sel));
@@ -570,9 +569,8 @@ static_assert(device_transform_policy()(detail::current_tuning_arch()) == {12}, 
   build_ptr->cubin                         = (void*) result.data.release();
   build_ptr->cubin_size                    = result.size;
   build_ptr->cache                         = new transform::cache();
-  build_ptr->transform_kernel_lowered_name = strdup(kernel_lowered_name.c_str());
+  build_ptr->transform_kernel_lowered_name = duplicate_c_string(kernel_lowered_name);
 
-  // avoid new and delete which requires the allocated and freed types to match
   build_ptr->runtime_policy      = std::malloc(sizeof(policy_sel));
   build_ptr->runtime_policy_size = sizeof(policy_sel);
   std::memcpy(build_ptr->runtime_policy, &policy_sel, sizeof(policy_sel));
@@ -710,7 +708,7 @@ try
   using namespace cub::detail::transform;
   std::unique_ptr<char[]> cubin(static_cast<char*>(build_ptr->cubin));
   std::free(build_ptr->runtime_policy);
-  std::free(build_ptr->transform_kernel_lowered_name);
+  std::unique_ptr<char[]> kernel_name(build_ptr->transform_kernel_lowered_name);
   std::unique_ptr<transform::cache> cache(static_cast<transform::cache*>(build_ptr->cache));
   if (build_ptr->library != nullptr)
   {

--- a/c/parallel/src/transform.cu
+++ b/c/parallel/src/transform.cu
@@ -120,6 +120,10 @@ struct transform_kernel_source
   CacheAsyncConfiguration(const ActionT& action)
   {
     auto cache = reinterpret_cast<transform::cache*>(build.cache);
+    if (cache == nullptr)
+    {
+      return action();
+    }
     if (!cache->async_config.has_value())
     {
       cache->async_config = action();
@@ -132,6 +136,10 @@ struct transform_kernel_source
   CachePrefetchConfiguration(const ActionT& action)
   {
     auto cache = reinterpret_cast<transform::cache*>(build.cache);
+    if (cache == nullptr)
+    {
+      return action();
+    }
     if (!cache->prefetch_config.has_value())
     {
       cache->prefetch_config = action();
@@ -195,7 +203,7 @@ auto make_iterator_info(cccl_iterator_t it) -> cub::detail::iterator_info
 }
 } // namespace transform
 
-CUresult cccl_device_unary_transform_build_ex(
+CUresult cccl_device_unary_transform_compile(
   cccl_device_transform_build_result_t* build_ptr,
   cccl_iterator_t input_it,
   cccl_iterator_t output_it,
@@ -317,18 +325,16 @@ static_assert(device_transform_policy()(detail::current_tuning_arch()) == {9}, "
       ->add_link_list(linkable_list)
       ->finalize_program();
 
-  cuLibraryLoadData(&build_ptr->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
-  check(cuLibraryGetKernel(&build_ptr->transform_kernel, build_ptr->library, kernel_lowered_name.c_str()));
-
-  build_ptr->loaded_bytes_per_iteration = static_cast<int>(input_it.value_type.size);
-  build_ptr->cc                         = cc_major * 10 + cc_minor;
-  build_ptr->cubin                      = (void*) result.data.release();
-  build_ptr->cubin_size                 = result.size;
-  build_ptr->cache                      = new transform::cache();
+  build_ptr->loaded_bytes_per_iteration    = static_cast<int>(input_it.value_type.size);
+  build_ptr->cc                            = cc_major * 10 + cc_minor;
+  build_ptr->cubin                         = (void*) result.data.release();
+  build_ptr->cubin_size                    = result.size;
+  build_ptr->cache                         = new transform::cache();
+  build_ptr->transform_kernel_lowered_name = strdup(kernel_lowered_name.c_str());
 
   // avoid new and delete which requires the allocated and freed types to match
-  static_assert(std::is_trivially_copyable_v<decltype(policy_sel)>);
-  build_ptr->runtime_policy = std::malloc(sizeof(policy_sel));
+  build_ptr->runtime_policy      = std::malloc(sizeof(policy_sel));
+  build_ptr->runtime_policy_size = sizeof(policy_sel);
   std::memcpy(build_ptr->runtime_policy, &policy_sel, sizeof(policy_sel));
 
   return CUDA_SUCCESS;
@@ -336,9 +342,50 @@ static_assert(device_transform_policy()(detail::current_tuning_arch()) == {9}, "
 catch (const std::exception& exc)
 {
   fflush(stderr);
-  printf("\nEXCEPTION in cccl_device_unary_transform_build(): %s\n", exc.what());
+  printf("\nEXCEPTION in cccl_device_unary_transform_compile(): %s\n", exc.what());
   fflush(stdout);
   return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_transform_load(cccl_device_transform_build_result_t* build_ptr)
+try
+{
+  if (build_ptr == nullptr || build_ptr->cubin == nullptr || build_ptr->cubin_size == 0)
+  {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  check(cuLibraryLoadData(&build_ptr->library, build_ptr->cubin, nullptr, nullptr, 0, nullptr, nullptr, 0));
+  check(cuLibraryGetKernel(&build_ptr->transform_kernel, build_ptr->library, build_ptr->transform_kernel_lowered_name));
+  return CUDA_SUCCESS;
+}
+catch (const std::exception& exc)
+{
+  fflush(stderr);
+  printf("\nEXCEPTION in cccl_device_transform_load(): %s\n", exc.what());
+  fflush(stdout);
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_unary_transform_build_ex(
+  cccl_device_transform_build_result_t* build_ptr,
+  cccl_iterator_t input_it,
+  cccl_iterator_t output_it,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config)
+{
+  CUresult r = cccl_device_unary_transform_compile(
+    build_ptr, input_it, output_it, op, cc_major, cc_minor, cub_path, thrust_path, libcudacxx_path, ctk_path, config);
+  if (r != CUDA_SUCCESS)
+  {
+    return r;
+  }
+  return cccl_device_transform_load(build_ptr);
 }
 
 CUresult cccl_device_unary_transform(
@@ -383,7 +430,7 @@ CUresult cccl_device_unary_transform(
   return error;
 }
 
-CUresult cccl_device_binary_transform_build_ex(
+CUresult cccl_device_binary_transform_compile(
   cccl_device_transform_build_result_t* build_ptr,
   cccl_iterator_t input1_it,
   cccl_iterator_t input2_it,
@@ -518,18 +565,16 @@ static_assert(device_transform_policy()(detail::current_tuning_arch()) == {12}, 
       ->add_link_list(linkable_list)
       ->finalize_program();
 
-  cuLibraryLoadData(&build_ptr->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
-  check(cuLibraryGetKernel(&build_ptr->transform_kernel, build_ptr->library, kernel_lowered_name.c_str()));
-
-  build_ptr->loaded_bytes_per_iteration = static_cast<int>((input1_it.value_type.size + input2_it.value_type.size));
-  build_ptr->cc                         = cc_major * 10 + cc_minor;
-  build_ptr->cubin                      = (void*) result.data.release();
-  build_ptr->cubin_size                 = result.size;
-  build_ptr->cache                      = new transform::cache();
+  build_ptr->loaded_bytes_per_iteration    = static_cast<int>((input1_it.value_type.size + input2_it.value_type.size));
+  build_ptr->cc                            = cc_major * 10 + cc_minor;
+  build_ptr->cubin                         = (void*) result.data.release();
+  build_ptr->cubin_size                    = result.size;
+  build_ptr->cache                         = new transform::cache();
+  build_ptr->transform_kernel_lowered_name = strdup(kernel_lowered_name.c_str());
 
   // avoid new and delete which requires the allocated and freed types to match
-  static_assert(std::is_trivially_copyable_v<decltype(policy_sel)>);
-  build_ptr->runtime_policy = std::malloc(sizeof(policy_sel));
+  build_ptr->runtime_policy      = std::malloc(sizeof(policy_sel));
+  build_ptr->runtime_policy_size = sizeof(policy_sel);
   std::memcpy(build_ptr->runtime_policy, &policy_sel, sizeof(policy_sel));
 
   return CUDA_SUCCESS;
@@ -537,9 +582,43 @@ static_assert(device_transform_policy()(detail::current_tuning_arch()) == {12}, 
 catch (const std::exception& exc)
 {
   fflush(stderr);
-  printf("\nEXCEPTION in cccl_device_binary_transform_build(): %s\n", exc.what());
+  printf("\nEXCEPTION in cccl_device_binary_transform_compile(): %s\n", exc.what());
   fflush(stdout);
   return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_binary_transform_build_ex(
+  cccl_device_transform_build_result_t* build_ptr,
+  cccl_iterator_t input1_it,
+  cccl_iterator_t input2_it,
+  cccl_iterator_t output_it,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config)
+{
+  CUresult r = cccl_device_binary_transform_compile(
+    build_ptr,
+    input1_it,
+    input2_it,
+    output_it,
+    op,
+    cc_major,
+    cc_minor,
+    cub_path,
+    thrust_path,
+    libcudacxx_path,
+    ctk_path,
+    config);
+  if (r != CUDA_SUCCESS)
+  {
+    return r;
+  }
+  return cccl_device_transform_load(build_ptr);
 }
 
 CUresult cccl_device_binary_transform(
@@ -631,8 +710,12 @@ try
   using namespace cub::detail::transform;
   std::unique_ptr<char[]> cubin(static_cast<char*>(build_ptr->cubin));
   std::free(build_ptr->runtime_policy);
+  std::free(build_ptr->transform_kernel_lowered_name);
   std::unique_ptr<transform::cache> cache(static_cast<transform::cache*>(build_ptr->cache));
-  check(cuLibraryUnload(build_ptr->library));
+  if (build_ptr->library != nullptr)
+  {
+    check(cuLibraryUnload(build_ptr->library));
+  }
 
   return CUDA_SUCCESS;
 }

--- a/c/parallel/src/transform.cu
+++ b/c/parallel/src/transform.cu
@@ -31,6 +31,7 @@
 #include "jit_templates/templates/operation.h"
 #include "jit_templates/templates/output_iterator.h"
 #include "jit_templates/traits.h"
+#include "util/aot.h"
 #include <cccl/c/transform.h>
 #include <cccl/c/types.h> // cccl_type_info
 #include <nvrtc/command_list.h>
@@ -695,6 +696,73 @@ CUresult cccl_device_binary_transform_build(
 {
   return cccl_device_binary_transform_build_ex(
     build_ptr, d_in1, d_in2, d_out, op, cc_major, cc_minor, cub_path, thrust_path, libcudacxx_path, ctk_path, nullptr);
+}
+
+CUresult cccl_device_transform_save_file(const cccl_device_transform_build_result_t* build, const char* path)
+try
+{
+  AotWriter w(path);
+  if (build->cubin == nullptr)
+  {
+    printf("\nERROR in cccl_device_transform_save_file(): build has no cubin\n");
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  w.write_header(CclbTag::transform);
+  w.write_i32(build->cc);
+  w.write_blob(build->cubin, build->cubin_size);
+  w.write_blob(build->runtime_policy, build->runtime_policy_size);
+  w.write_u32(1);
+  w.write_string(build->transform_kernel_lowered_name);
+  w.write_i32(build->loaded_bytes_per_iteration);
+  // cache is NOT serialized
+  return CUDA_SUCCESS;
+}
+catch (const std::exception& exc)
+{
+  printf("\nEXCEPTION in cccl_device_transform_save_file(): %s\n", exc.what());
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_transform_load_file(cccl_device_transform_build_result_t* build, const char* path)
+try
+{
+  AotReader r(path);
+  CclbTag tag = r.read_tag();
+
+  *build    = {};
+  build->cc = r.read_i32();
+
+  if (tag != CclbTag::transform)
+  {
+    printf("\nERROR in cccl_device_transform_load_file(): unexpected tag %u\n", static_cast<uint32_t>(tag));
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  {
+    uint64_t sz       = 0;
+    void* tmp_cb      = r.read_blob(&sz);
+    build->cubin_size = sz;
+    char* nb          = new char[static_cast<size_t>(sz)];
+    std::memcpy(nb, tmp_cb, static_cast<size_t>(sz));
+    std::free(tmp_cb);
+    build->cubin = nb;
+  }
+
+  {
+    uint64_t pol_sz            = 0;
+    build->runtime_policy      = r.read_blob(&pol_sz);
+    build->runtime_policy_size = static_cast<size_t>(pol_sz);
+  }
+  (void) r.read_u32(); // nkernels
+  build->transform_kernel_lowered_name = r.read_string_heap();
+  build->loaded_bytes_per_iteration    = r.read_i32();
+  build->cache                         = nullptr; // not serialized
+  return cccl_device_transform_load(build);
+}
+catch (const std::exception& exc)
+{
+  printf("\nEXCEPTION in cccl_device_transform_load_file(): %s\n", exc.what());
+  return CUDA_ERROR_UNKNOWN;
 }
 
 CUresult cccl_device_transform_cleanup(cccl_device_transform_build_result_t* build_ptr)

--- a/c/parallel/src/unique_by_key.cu
+++ b/c/parallel/src/unique_by_key.cu
@@ -17,6 +17,7 @@
 #include <sstream>
 #include <vector>
 
+#include "util/aot.h"
 #include <cccl/c/unique_by_key.h>
 #include <kernels/iterators.h>
 #include <kernels/operators.h>
@@ -401,6 +402,73 @@ catch (const std::exception& exc)
   printf("\nEXCEPTION in cccl_device_unique_by_key_load(): %s\n", exc.what());
   fflush(stdout);
 
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_unique_by_key_save_file(const cccl_device_unique_by_key_build_result_t* build, const char* path)
+try
+{
+  if (build->cubin == nullptr)
+  {
+    printf("\nERROR in cccl_device_unique_by_key_save_file(): build has no cubin\n");
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  AotWriter w(path);
+  w.write_header(CclbTag::unique_by_key);
+  w.write_i32(build->cc);
+  w.write_blob(build->cubin, build->cubin_size);
+  w.write_blob(build->runtime_policy, build->runtime_policy_size);
+  w.write_u32(2);
+  w.write_string(build->compact_init_kernel_lowered_name);
+  w.write_string(build->sweep_kernel_lowered_name);
+  w.write_u64(static_cast<uint64_t>(build->description_bytes_per_tile));
+  w.write_u64(static_cast<uint64_t>(build->payload_bytes_per_tile));
+  return CUDA_SUCCESS;
+}
+catch (...)
+{
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_unique_by_key_load_file(cccl_device_unique_by_key_build_result_t* build, const char* path)
+try
+{
+  AotReader r(path);
+  CclbTag tag = r.read_tag();
+
+  if (tag != CclbTag::unique_by_key)
+  {
+    printf("\nERROR in cccl_device_unique_by_key_load_file(): unexpected tag %u\n", static_cast<uint32_t>(tag));
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  *build    = {};
+  build->cc = r.read_i32();
+
+  {
+    uint64_t sz       = 0;
+    void* tmp_cb      = r.read_blob(&sz);
+    build->cubin_size = sz;
+    char* nb          = new char[static_cast<size_t>(sz)];
+    std::memcpy(nb, tmp_cb, static_cast<size_t>(sz));
+    std::free(tmp_cb);
+    build->cubin = nb;
+  }
+
+  {
+    uint64_t pol_sz            = 0;
+    build->runtime_policy      = r.read_blob(&pol_sz);
+    build->runtime_policy_size = static_cast<size_t>(pol_sz);
+  }
+  (void) r.read_u32(); // nkernels
+  build->compact_init_kernel_lowered_name = r.read_string_heap();
+  build->sweep_kernel_lowered_name        = r.read_string_heap();
+  build->description_bytes_per_tile       = static_cast<size_t>(r.read_u64());
+  build->payload_bytes_per_tile           = static_cast<size_t>(r.read_u64());
+  return cccl_device_unique_by_key_load(build);
+}
+catch (...)
+{
   return CUDA_ERROR_UNKNOWN;
 }
 

--- a/c/parallel/src/unique_by_key.cu
+++ b/c/parallel/src/unique_by_key.cu
@@ -365,8 +365,8 @@ static_assert(
   build_ptr->payload_bytes_per_tile           = payload_bytes_per_tile;
   build_ptr->runtime_policy                   = new cub::detail::unique_by_key::policy_selector{policy_sel};
   build_ptr->runtime_policy_size              = sizeof(cub::detail::unique_by_key::policy_selector);
-  build_ptr->compact_init_kernel_lowered_name = strdup(compact_init_kernel_lowered_name.c_str());
-  build_ptr->sweep_kernel_lowered_name        = strdup(sweep_kernel_lowered_name.c_str());
+  build_ptr->compact_init_kernel_lowered_name = duplicate_c_string(compact_init_kernel_lowered_name);
+  build_ptr->sweep_kernel_lowered_name        = duplicate_c_string(sweep_kernel_lowered_name);
 
   return CUDA_SUCCESS;
 }
@@ -544,8 +544,8 @@ try
   std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(build_ptr->cubin));
   std::unique_ptr<cub::detail::unique_by_key::policy_selector> policy(
     static_cast<cub::detail::unique_by_key::policy_selector*>(build_ptr->runtime_policy));
-  std::free(build_ptr->compact_init_kernel_lowered_name);
-  std::free(build_ptr->sweep_kernel_lowered_name);
+  std::unique_ptr<char[]> init_name(build_ptr->compact_init_kernel_lowered_name);
+  std::unique_ptr<char[]> sweep_name(build_ptr->sweep_kernel_lowered_name);
   if (build_ptr->library != nullptr)
   {
     check(cuLibraryUnload(build_ptr->library));

--- a/c/parallel/src/unique_by_key.cu
+++ b/c/parallel/src/unique_by_key.cu
@@ -153,7 +153,7 @@ struct unique_by_key_kernel_source
 };
 } // namespace unique_by_key
 
-CUresult cccl_device_unique_by_key_build_ex(
+CUresult cccl_device_unique_by_key_compile(
   cccl_device_unique_by_key_build_result_t* build_ptr,
   cccl_iterator_t input_keys_it,
   cccl_iterator_t input_values_it,
@@ -355,30 +355,91 @@ static_assert(
       ->add_link_list(linkable_list)
       ->finalize_program();
 
-  cuLibraryLoadData(&build_ptr->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
-  check(
-    cuLibraryGetKernel(&build_ptr->compact_init_kernel, build_ptr->library, compact_init_kernel_lowered_name.c_str()));
-  check(cuLibraryGetKernel(&build_ptr->sweep_kernel, build_ptr->library, sweep_kernel_lowered_name.c_str()));
-
   auto [description_bytes_per_tile,
         payload_bytes_per_tile] = get_tile_state_bytes_per_tile(offset_t, offset_cpp, args.data(), args.size(), arch);
 
-  build_ptr->cc                         = cc;
-  build_ptr->cubin                      = (void*) result.data.release();
-  build_ptr->cubin_size                 = result.size;
-  build_ptr->description_bytes_per_tile = description_bytes_per_tile;
-  build_ptr->payload_bytes_per_tile     = payload_bytes_per_tile;
-  build_ptr->runtime_policy             = new cub::detail::unique_by_key::policy_selector{policy_sel};
+  build_ptr->cc                               = cc;
+  build_ptr->cubin                            = (void*) result.data.release();
+  build_ptr->cubin_size                       = result.size;
+  build_ptr->description_bytes_per_tile       = description_bytes_per_tile;
+  build_ptr->payload_bytes_per_tile           = payload_bytes_per_tile;
+  build_ptr->runtime_policy                   = new cub::detail::unique_by_key::policy_selector{policy_sel};
+  build_ptr->runtime_policy_size              = sizeof(cub::detail::unique_by_key::policy_selector);
+  build_ptr->compact_init_kernel_lowered_name = strdup(compact_init_kernel_lowered_name.c_str());
+  build_ptr->sweep_kernel_lowered_name        = strdup(sweep_kernel_lowered_name.c_str());
 
   return CUDA_SUCCESS;
 }
 catch (const std::exception& exc)
 {
   fflush(stderr);
-  printf("\nEXCEPTION in cccl_device_unique_by_key_build(): %s\n", exc.what());
+  printf("\nEXCEPTION in cccl_device_unique_by_key_compile(): %s\n", exc.what());
   fflush(stdout);
 
   return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_unique_by_key_load(cccl_device_unique_by_key_build_result_t* build)
+try
+{
+  if (build == nullptr || build->cubin == nullptr || build->cubin_size == 0)
+  {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  CUresult status = cuLibraryLoadData(&build->library, build->cubin, nullptr, nullptr, 0, nullptr, nullptr, 0);
+  if (status != CUDA_SUCCESS)
+  {
+    return status;
+  }
+  check(cuLibraryGetKernel(&build->compact_init_kernel, build->library, build->compact_init_kernel_lowered_name));
+  check(cuLibraryGetKernel(&build->sweep_kernel, build->library, build->sweep_kernel_lowered_name));
+  return CUDA_SUCCESS;
+}
+catch (const std::exception& exc)
+{
+  fflush(stderr);
+  printf("\nEXCEPTION in cccl_device_unique_by_key_load(): %s\n", exc.what());
+  fflush(stdout);
+
+  return CUDA_ERROR_UNKNOWN;
+}
+
+CUresult cccl_device_unique_by_key_build_ex(
+  cccl_device_unique_by_key_build_result_t* build_ptr,
+  cccl_iterator_t input_keys_it,
+  cccl_iterator_t input_values_it,
+  cccl_iterator_t output_keys_it,
+  cccl_iterator_t output_values_it,
+  cccl_iterator_t output_num_selected_it,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config)
+{
+  CUresult result = cccl_device_unique_by_key_compile(
+    build_ptr,
+    input_keys_it,
+    input_values_it,
+    output_keys_it,
+    output_values_it,
+    output_num_selected_it,
+    op,
+    cc_major,
+    cc_minor,
+    cub_path,
+    thrust_path,
+    libcudacxx_path,
+    ctk_path,
+    config);
+  if (result != CUDA_SUCCESS)
+  {
+    return result;
+  }
+  return cccl_device_unique_by_key_load(build_ptr);
 }
 
 CUresult cccl_device_unique_by_key(
@@ -483,7 +544,12 @@ try
   std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(build_ptr->cubin));
   std::unique_ptr<cub::detail::unique_by_key::policy_selector> policy(
     static_cast<cub::detail::unique_by_key::policy_selector*>(build_ptr->runtime_policy));
-  check(cuLibraryUnload(build_ptr->library));
+  std::free(build_ptr->compact_init_kernel_lowered_name);
+  std::free(build_ptr->sweep_kernel_lowered_name);
+  if (build_ptr->library != nullptr)
+  {
+    check(cuLibraryUnload(build_ptr->library));
+  }
 
   return CUDA_SUCCESS;
 }

--- a/c/parallel/src/util/aot.cpp
+++ b/c/parallel/src/util/aot.cpp
@@ -1,0 +1,246 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include "aot.h"
+
+#include <cstring>
+#include <string>
+
+// ---------------------------------------------------------------------------
+// AotWriter
+// ---------------------------------------------------------------------------
+
+AotWriter::AotWriter(const char* path)
+{
+  fp_ = std::fopen(path, "wb");
+  if (!fp_)
+  {
+    throw std::runtime_error(std::string("AotWriter: cannot open file for writing: ") + path);
+  }
+}
+
+AotWriter::~AotWriter()
+{
+  if (fp_)
+  {
+    std::fclose(fp_);
+    fp_ = nullptr;
+  }
+}
+
+void AotWriter::write_raw(const void* data, size_t size)
+{
+  if (size == 0)
+  {
+    return;
+  }
+  size_t written = std::fwrite(data, 1, size, fp_);
+  if (written != size)
+  {
+    throw std::runtime_error("AotWriter: short write");
+  }
+}
+
+void AotWriter::write_header(CclbTag tag)
+{
+  // magic: 4 bytes
+  write_raw("CCLB", 4);
+  // version: uint32_t = 1
+  uint32_t version = 1;
+  write_raw(&version, sizeof(version));
+  // tag: uint32_t enum value
+  uint32_t tag_val = static_cast<uint32_t>(tag);
+  write_raw(&tag_val, sizeof(tag_val));
+}
+
+void AotWriter::write_i32(int32_t v)
+{
+  write_raw(&v, sizeof(v));
+}
+
+void AotWriter::write_u32(uint32_t v)
+{
+  write_raw(&v, sizeof(v));
+}
+
+void AotWriter::write_u64(uint64_t v)
+{
+  write_raw(&v, sizeof(v));
+}
+
+void AotWriter::write_bool(bool v)
+{
+  uint8_t b = v ? 1 : 0;
+  write_raw(&b, sizeof(b));
+}
+
+void AotWriter::write_blob(const void* data, uint64_t size)
+{
+  write_u64(size);
+  if (size > 0 && data != nullptr)
+  {
+    write_raw(data, static_cast<size_t>(size));
+  }
+}
+
+void AotWriter::write_string(const char* s)
+{
+  uint16_t len = (s != nullptr) ? static_cast<uint16_t>(std::strlen(s)) : 0;
+  write_raw(&len, sizeof(len));
+  if (len > 0)
+  {
+    write_raw(s, len);
+  }
+}
+
+void AotWriter::write_type_info(cccl_type_info ti)
+{
+  uint64_t sz  = static_cast<uint64_t>(ti.size);
+  uint64_t aln = static_cast<uint64_t>(ti.alignment);
+  int32_t tp   = static_cast<int32_t>(ti.type);
+  write_raw(&sz, sizeof(sz));
+  write_raw(&aln, sizeof(aln));
+  write_raw(&tp, sizeof(tp));
+}
+
+// ---------------------------------------------------------------------------
+// AotReader
+// ---------------------------------------------------------------------------
+
+AotReader::AotReader(const char* path)
+{
+  fp_ = std::fopen(path, "rb");
+  if (!fp_)
+  {
+    throw std::runtime_error(std::string("AotReader: cannot open file for reading: ") + path);
+  }
+  // Validate magic
+  char magic[4];
+  read_raw(magic, 4);
+  if (std::memcmp(magic, "CCLB", 4) != 0)
+  {
+    std::fclose(fp_);
+    fp_ = nullptr;
+    throw std::runtime_error("AotReader: bad magic (not a CCLB file)");
+  }
+  // Validate version
+  uint32_t version = 0;
+  read_raw(&version, sizeof(version));
+  if (version != 1)
+  {
+    std::fclose(fp_);
+    fp_ = nullptr;
+    throw std::runtime_error(std::string("AotReader: unsupported version: ") + std::to_string(version));
+  }
+}
+
+AotReader::~AotReader()
+{
+  if (fp_)
+  {
+    std::fclose(fp_);
+    fp_ = nullptr;
+  }
+}
+
+void AotReader::read_raw(void* buf, size_t size)
+{
+  if (size == 0)
+  {
+    return;
+  }
+  size_t got = std::fread(buf, 1, size, fp_);
+  if (got != size)
+  {
+    throw std::runtime_error("AotReader: short read (truncated file?)");
+  }
+}
+
+CclbTag AotReader::read_tag()
+{
+  uint32_t val = 0;
+  read_raw(&val, sizeof(val));
+  return static_cast<CclbTag>(val);
+}
+
+int32_t AotReader::read_i32()
+{
+  int32_t v = 0;
+  read_raw(&v, sizeof(v));
+  return v;
+}
+
+uint32_t AotReader::read_u32()
+{
+  uint32_t v = 0;
+  read_raw(&v, sizeof(v));
+  return v;
+}
+
+uint64_t AotReader::read_u64()
+{
+  uint64_t v = 0;
+  read_raw(&v, sizeof(v));
+  return v;
+}
+
+bool AotReader::read_bool()
+{
+  uint8_t b = 0;
+  read_raw(&b, sizeof(b));
+  return b != 0;
+}
+
+void* AotReader::read_blob(uint64_t* size_out)
+{
+  uint64_t sz = read_u64();
+  *size_out   = sz;
+  if (sz == 0)
+  {
+    return nullptr;
+  }
+  void* buf = std::malloc(static_cast<size_t>(sz));
+  if (!buf)
+  {
+    throw std::runtime_error("AotReader: malloc failed for blob");
+  }
+  read_raw(buf, static_cast<size_t>(sz));
+  return buf;
+}
+
+char* AotReader::read_string_heap()
+{
+  uint16_t len = 0;
+  read_raw(&len, sizeof(len));
+  if (len == 0)
+  {
+    return nullptr;
+  }
+  char* buf = static_cast<char*>(std::malloc(static_cast<size_t>(len) + 1));
+  if (!buf)
+  {
+    throw std::runtime_error("AotReader: malloc failed for string");
+  }
+  read_raw(buf, len);
+  buf[len] = '\0';
+  return buf;
+}
+
+cccl_type_info AotReader::read_type_info()
+{
+  uint64_t sz  = read_u64();
+  uint64_t aln = read_u64();
+  int32_t tp   = read_i32();
+  cccl_type_info ti;
+  ti.size      = static_cast<size_t>(sz);
+  ti.alignment = static_cast<size_t>(aln);
+  ti.type      = static_cast<cccl_type_enum>(tp);
+  return ti;
+}

--- a/c/parallel/src/util/aot.h
+++ b/c/parallel/src/util/aot.h
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+
+#ifndef CCCL_C_EXPERIMENTAL
+#  define CCCL_C_EXPERIMENTAL
+#endif
+#include <cccl/c/types.h>
+
+enum class CclbTag : uint32_t
+{
+  reduce              = 0,
+  segmented_reduce    = 1,
+  binary_search       = 2,
+  scan                = 3,
+  unique_by_key       = 4,
+  merge_sort          = 5,
+  transform           = 6,
+  radix_sort          = 7,
+  histogram           = 8,
+  segmented_sort      = 9,
+  three_way_partition = 10,
+  for_each            = 11,
+};
+
+// Writer: opens file, writes fields in sequence, closes on destruction.
+struct AotWriter
+{
+  FILE* fp_;
+  explicit AotWriter(const char* path);
+  ~AotWriter();
+
+  void write_header(CclbTag tag); // magic + version + tag
+  void write_i32(int32_t v);
+  void write_u32(uint32_t v);
+  void write_u64(uint64_t v);
+  void write_bool(bool v);
+  void write_blob(const void* data, uint64_t size); // writes u64 size then bytes
+  void write_string(const char* s); // writes u16 length + chars (null ptr → length 0)
+  void write_type_info(cccl_type_info ti); // u64 size, u64 alignment, i32 type
+
+private:
+  void write_raw(const void* data, size_t size);
+};
+
+// Reader: opens file, validates magic+version, reads fields in sequence.
+struct AotReader
+{
+  FILE* fp_;
+  explicit AotReader(const char* path); // throws std::runtime_error if bad magic/version
+  ~AotReader();
+
+  CclbTag read_tag();
+  int32_t read_i32();
+  uint32_t read_u32();
+  uint64_t read_u64();
+  bool read_bool();
+  // Reads a size-prefixed blob. Returns malloc'd pointer + size.
+  // Caller must free() the returned pointer.
+  void* read_blob(uint64_t* size_out);
+  // Reads a length-prefixed string. Returns malloc'd null-terminated string.
+  // Returns nullptr if stored length was 0.
+  char* read_string_heap();
+  cccl_type_info read_type_info();
+
+private:
+  void read_raw(void* buf, size_t size);
+};

--- a/c/parallel/src/util/types.h
+++ b/c/parallel/src/util/types.h
@@ -14,7 +14,10 @@
 
 #include <cuda/std/cstdint>
 
+#include <cstring>
+#include <memory>
 #include <string>
+#include <string_view>
 
 #include "errors.h"
 #include <cccl/c/types.h>
@@ -141,6 +144,14 @@ inline constexpr cub::detail::type_t cccl_type_enum_to_cub_type(cccl_type_enum t
     default:
       return cub::detail::type_t::other;
   }
+}
+
+inline char* duplicate_c_string(std::string_view s)
+{
+  auto p = std::make_unique<char[]>(s.size() + 1);
+  std::memcpy(p.get(), s.data(), s.size());
+  p[s.size()] = '\0';
+  return p.release();
 }
 
 inline constexpr cub::detail::op_kind_t cccl_op_kind_to_cub_op(cccl_op_kind_t type)

--- a/c/parallel/test/CMakeLists.txt
+++ b/c/parallel/test/CMakeLists.txt
@@ -32,6 +32,7 @@ function(cccl_c_parallel_add_test target_name_var source)
 
   # Get the first CUDA include directory only
   list(GET CUDAToolkit_INCLUDE_DIRS 0 CUDA_FIRST_INCLUDE_DIR)
+
   target_compile_definitions(
     ${target_name}
     PRIVATE

--- a/c/parallel/test/test_binary_search.cpp
+++ b/c/parallel/test/test_binary_search.cpp
@@ -276,7 +276,7 @@ C2H_TEST("BinarySearch compile/load round-trip", "[binary_search][aot]")
   pointer_t<T> data_ptr(data);
   pointer_t<T> values_ptr(values);
   pointer_t<std::ptrdiff_t> output_ptr(n_values);
-  CUstream null_stream = 0;
+  CUstream null_stream = nullptr;
 
   REQUIRE(CUDA_SUCCESS
           == cccl_device_binary_search(build, data_ptr, n_items, values_ptr, n_values, output_ptr, op, null_stream));

--- a/c/parallel/test/test_binary_search.cpp
+++ b/c/parallel/test/test_binary_search.cpp
@@ -189,3 +189,104 @@ C2H_TEST("DeviceFind::UpperBound works", "[find][device][binary-search]", integr
   using value_type = c2h::get<0, TestType>;
   test_vectorized<BinarySearch_IntegralTypes_UpperBound_Fixture_Tag, value_type>(upper_bound{}, std_upper_bound);
 }
+
+C2H_TEST("BinarySearch build result has AoT metadata populated", "[binary_search][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  cccl_op_t op = make_well_known_binary_operation();
+  pointer_t<T> data(1);
+  pointer_t<T> values(1);
+  pointer_t<T> out(1);
+
+  BuildResultT build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_binary_search_build(
+      &build,
+      CCCL_BINARY_SEARCH_LOWER_BOUND,
+      data,
+      values,
+      out,
+      op,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path()));
+
+  CHECK(build.cc == build_info.get_cc_major() * 10 + build_info.get_cc_minor());
+  CHECK(build.cubin != nullptr);
+  CHECK(build.cubin_size > 0);
+  REQUIRE(build.kernel_lowered_name != nullptr);
+  CHECK(build.kernel_lowered_name[0] != '\0');
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_binary_search_cleanup(&build));
+}
+
+C2H_TEST("BinarySearch compile/load round-trip", "[binary_search][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  operation_t op = make_operation("op", get_merge_sort_op(get_type_info<T>().type));
+  pointer_t<T> dummy_data(1);
+  pointer_t<T> dummy_values(1);
+  pointer_t<std::ptrdiff_t> dummy_out(1);
+
+  BuildResultT build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_binary_search_compile(
+      &build,
+      CCCL_BINARY_SEARCH_LOWER_BOUND,
+      dummy_data,
+      dummy_values,
+      dummy_out,
+      op,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path(),
+      nullptr));
+
+  REQUIRE(build.cubin != nullptr);
+  REQUIRE(build.cubin_size > 0);
+  REQUIRE(build.kernel_lowered_name != nullptr);
+  CHECK(build.library == nullptr);
+  CHECK(build.kernel == nullptr);
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_binary_search_load(&build));
+  REQUIRE(build.library != nullptr);
+  CHECK(build.kernel != nullptr);
+
+  constexpr std::size_t n_items  = 16;
+  constexpr std::size_t n_values = 4;
+  std::vector<T> data            = generate<T>(n_items);
+  std::sort(data.begin(), data.end());
+  const std::vector<T> values = generate<T>(n_values);
+  pointer_t<T> data_ptr(data);
+  pointer_t<T> values_ptr(values);
+  pointer_t<std::ptrdiff_t> output_ptr(n_values);
+  CUstream null_stream = 0;
+
+  REQUIRE(CUDA_SUCCESS
+          == cccl_device_binary_search(build, data_ptr, n_items, values_ptr, n_values, output_ptr, op, null_stream));
+
+  std::vector<std::ptrdiff_t> expected(n_values);
+  for (std::size_t i = 0; i < n_values; ++i)
+  {
+    expected[i] = std::lower_bound(data.begin(), data.end(), values[i]) - data.begin();
+  }
+  REQUIRE(expected == std::vector<std::ptrdiff_t>(output_ptr));
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_binary_search_cleanup(&build));
+}

--- a/c/parallel/test/test_histogram.cpp
+++ b/c/parallel/test/test_histogram.cpp
@@ -497,7 +497,7 @@ C2H_TEST("Histogram compile/load round-trip", "[histogram][device][aot]")
   pointer_t<T> histogram_ptr(2); // 2 bins
   value_t<T> upper_level_val{T{4}};
   value_t<int> num_levels_val{3}; // 3 level boundaries → 2 bins
-  CUstream null_stream      = 0;
+  CUstream null_stream      = nullptr;
   size_t temp_storage_bytes = 0;
 
   REQUIRE(

--- a/c/parallel/test/test_histogram.cpp
+++ b/c/parallel/test/test_histogram.cpp
@@ -14,6 +14,7 @@
 
 #include <cuda_runtime.h>
 
+#include "algorithm_execution.h"
 #include "test_util.h"
 #include <cccl/c/histogram.h>
 
@@ -397,4 +398,143 @@ C2H_TEST("DeviceHistogram::HistogramEven sample iterator", "[histogram][device]"
   {
     CHECK(h_histogram[c] == std::vector<counter_t>(d_single_histogram_ptr));
   }
+}
+
+C2H_TEST("Histogram build result has AoT metadata populated", "[histogram][device][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  pointer_t<T> samples(1);
+  pointer_t<T> histograms(1);
+  value_t<T> lower_level{T{0}};
+
+  cccl_device_histogram_build_result_t build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_histogram_build(
+      &build,
+      /*num_channels=*/1,
+      /*num_active_channels=*/1,
+      samples,
+      /*num_output_levels_val=*/3,
+      histograms,
+      lower_level,
+      /*num_rows=*/1,
+      /*row_stride_samples=*/1,
+      /*is_evenly_segmented=*/true,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path()));
+
+  CHECK(build.cc == build_info.get_cc_major() * 10 + build_info.get_cc_minor());
+  CHECK(build.cubin != nullptr);
+  CHECK(build.cubin_size > 0);
+  CHECK(build.runtime_policy != nullptr);
+  CHECK(build.runtime_policy_size > 0);
+  REQUIRE(build.init_kernel_lowered_name != nullptr);
+  CHECK(build.init_kernel_lowered_name[0] != '\0');
+  REQUIRE(build.sweep_kernel_lowered_name != nullptr);
+  CHECK(build.sweep_kernel_lowered_name[0] != '\0');
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_histogram_cleanup(&build));
+}
+
+C2H_TEST("Histogram compile/load round-trip", "[histogram][device][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  pointer_t<T> dummy_samples(1);
+  pointer_t<T> dummy_histograms(1);
+  value_t<T> lower_level_val{T{0}};
+
+  cccl_device_histogram_build_result_t build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_histogram_compile(
+      &build,
+      /*num_channels=*/1,
+      /*num_active_channels=*/1,
+      dummy_samples,
+      /*num_output_levels_val=*/3,
+      dummy_histograms,
+      lower_level_val,
+      /*num_rows=*/1,
+      /*row_stride_samples=*/1,
+      /*is_evenly_segmented=*/true,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path(),
+      nullptr));
+
+  REQUIRE(build.cubin != nullptr);
+  REQUIRE(build.cubin_size > 0);
+  REQUIRE(build.init_kernel_lowered_name != nullptr);
+  REQUIRE(build.sweep_kernel_lowered_name != nullptr);
+  CHECK(build.library == nullptr);
+  CHECK(build.init_kernel == nullptr);
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_histogram_load(&build));
+  REQUIRE(build.library != nullptr);
+  CHECK(build.init_kernel != nullptr);
+  CHECK(build.sweep_kernel != nullptr);
+
+  // 16 samples uniformly in [0, 4), 2 bins: [0,2) and [2,4)
+  constexpr std::size_t n_samples = 16;
+  const std::vector<T> samples    = {0, 0, 1, 1, 2, 2, 3, 3, 0, 1, 2, 3, 0, 1, 2, 3};
+  pointer_t<T> samples_ptr(samples);
+  pointer_t<T> histogram_ptr(2); // 2 bins
+  value_t<T> upper_level_val{T{4}};
+  value_t<int> num_levels_val{3}; // 3 level boundaries → 2 bins
+  CUstream null_stream      = 0;
+  size_t temp_storage_bytes = 0;
+
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_histogram_even(
+      build,
+      nullptr,
+      &temp_storage_bytes,
+      samples_ptr,
+      histogram_ptr,
+      num_levels_val,
+      lower_level_val,
+      upper_level_val,
+      /*num_row_pixels=*/static_cast<int64_t>(n_samples),
+      /*num_rows=*/1,
+      /*row_stride_samples=*/static_cast<int64_t>(n_samples),
+      null_stream));
+  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_histogram_even(
+      build,
+      temp_storage.ptr,
+      &temp_storage_bytes,
+      samples_ptr,
+      histogram_ptr,
+      num_levels_val,
+      lower_level_val,
+      upper_level_val,
+      /*num_row_pixels=*/static_cast<int64_t>(n_samples),
+      /*num_rows=*/1,
+      /*row_stride_samples=*/static_cast<int64_t>(n_samples),
+      null_stream));
+
+  // samples {0,0,1,1,0,1,0,1} in bin 0 (8 samples) and {2,2,3,3,2,3,2,3} in bin 1 (8 samples)
+  REQUIRE(histogram_ptr[0] == 8);
+  REQUIRE(histogram_ptr[1] == 8);
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_histogram_cleanup(&build));
 }

--- a/c/parallel/test/test_merge_sort.cpp
+++ b/c/parallel/test/test_merge_sort.cpp
@@ -706,3 +706,117 @@ extern "C" __device__ bool op(large_key_pair lhs, large_key_pair rhs) {
       ctk_path));
 }
  */
+
+C2H_TEST("MergeSort build result has AoT metadata populated", "[merge_sort][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  cccl_op_t op = make_well_known_binary_operation();
+  pointer_t<T> keys_in(1);
+  pointer_t<T> items_in(1);
+  pointer_t<T> keys_out(1);
+  pointer_t<T> items_out(1);
+
+  BuildResultT build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_merge_sort_build(
+      &build,
+      keys_in,
+      items_in,
+      keys_out,
+      items_out,
+      op,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path()));
+
+  CHECK(build.cc == build_info.get_cc_major() * 10 + build_info.get_cc_minor());
+  CHECK(build.cubin != nullptr);
+  CHECK(build.cubin_size > 0);
+  CHECK(build.runtime_policy != nullptr);
+  CHECK(build.runtime_policy_size > 0);
+  REQUIRE(build.block_sort_kernel_lowered_name != nullptr);
+  CHECK(build.block_sort_kernel_lowered_name[0] != '\0');
+  REQUIRE(build.partition_kernel_lowered_name != nullptr);
+  CHECK(build.partition_kernel_lowered_name[0] != '\0');
+  REQUIRE(build.merge_kernel_lowered_name != nullptr);
+  CHECK(build.merge_kernel_lowered_name[0] != '\0');
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_merge_sort_cleanup(&build));
+}
+
+C2H_TEST("MergeSort compile/load round-trip", "[merge_sort][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  cccl_op_t op = make_well_known_less_binary_predicate();
+  pointer_t<T> dummy_keys_in(1);
+  pointer_t<T> dummy_items_in(1);
+  pointer_t<T> dummy_keys_out(1);
+  pointer_t<T> dummy_items_out(1);
+
+  BuildResultT build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_merge_sort_compile(
+      &build,
+      dummy_keys_in,
+      dummy_items_in,
+      dummy_keys_out,
+      dummy_items_out,
+      op,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path(),
+      nullptr));
+
+  REQUIRE(build.cubin != nullptr);
+  REQUIRE(build.cubin_size > 0);
+  REQUIRE(build.block_sort_kernel_lowered_name != nullptr);
+  REQUIRE(build.partition_kernel_lowered_name != nullptr);
+  REQUIRE(build.merge_kernel_lowered_name != nullptr);
+  CHECK(build.library == nullptr);
+  CHECK(build.block_sort_kernel == nullptr);
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_merge_sort_load(&build));
+  REQUIRE(build.library != nullptr);
+  CHECK(build.block_sort_kernel != nullptr);
+  CHECK(build.partition_kernel != nullptr);
+  CHECK(build.merge_kernel != nullptr);
+
+  constexpr std::size_t n    = 16;
+  const std::vector<T> input = generate<T>(n);
+  pointer_t<T> keys_in(input);
+  pointer_t<T> items_in(input);
+  pointer_t<T> keys_out(n);
+  pointer_t<T> items_out(n);
+  CUstream null_stream      = 0;
+  size_t temp_storage_bytes = 0;
+
+  REQUIRE(CUDA_SUCCESS
+          == cccl_device_merge_sort(
+            build, nullptr, &temp_storage_bytes, keys_in, items_in, keys_out, items_out, n, op, null_stream));
+  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  REQUIRE(CUDA_SUCCESS
+          == cccl_device_merge_sort(
+            build, temp_storage.ptr, &temp_storage_bytes, keys_in, items_in, keys_out, items_out, n, op, null_stream));
+
+  std::vector<T> expected(input);
+  std::sort(expected.begin(), expected.end());
+  REQUIRE(expected == std::vector<T>(keys_out));
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_merge_sort_cleanup(&build));
+}

--- a/c/parallel/test/test_merge_sort.cpp
+++ b/c/parallel/test/test_merge_sort.cpp
@@ -803,7 +803,7 @@ C2H_TEST("MergeSort compile/load round-trip", "[merge_sort][aot]")
   pointer_t<T> items_in(input);
   pointer_t<T> keys_out(n);
   pointer_t<T> items_out(n);
-  CUstream null_stream      = 0;
+  CUstream null_stream      = nullptr;
   size_t temp_storage_bytes = 0;
 
   REQUIRE(CUDA_SUCCESS

--- a/c/parallel/test/test_radix_sort.cpp
+++ b/c/parallel/test/test_radix_sort.cpp
@@ -420,7 +420,7 @@ C2H_TEST("RadixSort compile/load round-trip", "[radix_sort][aot]")
   pointer_t<T> keys_out(n);
   pointer_t<T> values_in(n);
   pointer_t<T> values_out(n);
-  CUstream null_stream      = 0;
+  CUstream null_stream      = nullptr;
   size_t temp_storage_bytes = 0;
   int selector              = -1;
 

--- a/c/parallel/test/test_radix_sort.cpp
+++ b/c/parallel/test/test_radix_sort.cpp
@@ -327,3 +327,143 @@ C2H_TEST("DeviceRadixSort::SortPairs works", "[radix_sort]", test_params_tuple)
   REQUIRE(expected_keys == std::vector<KeyT>(output_keys));
   REQUIRE(expected_items == std::vector<ItemT>(output_items));
 }
+
+C2H_TEST("RadixSort build result has AoT metadata populated", "[radix_sort][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  pointer_t<T> keys_in(1);
+  pointer_t<T> values_in(1);
+  static constexpr cccl_op_t decomposer_no_op{};
+
+  BuildResultT build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_radix_sort_build(
+      &build,
+      CCCL_ASCENDING,
+      keys_in,
+      values_in,
+      decomposer_no_op,
+      "",
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path()));
+
+  CHECK(build.cc == build_info.get_cc_major() * 10 + build_info.get_cc_minor());
+  CHECK(build.cubin != nullptr);
+  CHECK(build.cubin_size > 0);
+  CHECK(build.runtime_policy != nullptr);
+  CHECK(build.runtime_policy_size > 0);
+  REQUIRE(build.single_tile_kernel_lowered_name != nullptr);
+  CHECK(build.single_tile_kernel_lowered_name[0] != '\0');
+  REQUIRE(build.upsweep_kernel_lowered_name != nullptr);
+  CHECK(build.upsweep_kernel_lowered_name[0] != '\0');
+  REQUIRE(build.downsweep_kernel_lowered_name != nullptr);
+  CHECK(build.downsweep_kernel_lowered_name[0] != '\0');
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_radix_sort_cleanup(&build));
+}
+
+C2H_TEST("RadixSort compile/load round-trip", "[radix_sort][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  pointer_t<T> dummy_keys_in(1);
+  pointer_t<T> dummy_values_in(1);
+  static constexpr cccl_op_t decomposer_no_op{};
+
+  BuildResultT build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_radix_sort_compile(
+      &build,
+      CCCL_ASCENDING,
+      dummy_keys_in,
+      dummy_values_in,
+      decomposer_no_op,
+      "",
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path(),
+      nullptr));
+
+  REQUIRE(build.cubin != nullptr);
+  REQUIRE(build.cubin_size > 0);
+  REQUIRE(build.single_tile_kernel_lowered_name != nullptr);
+  REQUIRE(build.upsweep_kernel_lowered_name != nullptr);
+  REQUIRE(build.downsweep_kernel_lowered_name != nullptr);
+  CHECK(build.library == nullptr);
+  CHECK(build.single_tile_kernel == nullptr);
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_radix_sort_load(&build));
+  REQUIRE(build.library != nullptr);
+  CHECK(build.single_tile_kernel != nullptr);
+  CHECK(build.upsweep_kernel != nullptr);
+  CHECK(build.downsweep_kernel != nullptr);
+
+  constexpr std::size_t n    = 16;
+  const std::vector<T> input = generate<T>(n);
+  pointer_t<T> keys_in(input);
+  pointer_t<T> keys_out(n);
+  pointer_t<T> values_in(n);
+  pointer_t<T> values_out(n);
+  CUstream null_stream      = 0;
+  size_t temp_storage_bytes = 0;
+  int selector              = -1;
+
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_radix_sort(
+      build,
+      nullptr,
+      &temp_storage_bytes,
+      keys_in,
+      keys_out,
+      values_in,
+      values_out,
+      decomposer_no_op,
+      n,
+      /*begin_bit=*/0,
+      /*end_bit=*/sizeof(T) * 8,
+      /*is_overwrite_okay=*/false,
+      &selector,
+      null_stream));
+  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_radix_sort(
+      build,
+      temp_storage.ptr,
+      &temp_storage_bytes,
+      keys_in,
+      keys_out,
+      values_in,
+      values_out,
+      decomposer_no_op,
+      n,
+      /*begin_bit=*/0,
+      /*end_bit=*/sizeof(T) * 8,
+      /*is_overwrite_okay=*/false,
+      &selector,
+      null_stream));
+
+  std::vector<T> expected(input);
+  std::sort(expected.begin(), expected.end());
+  // is_overwrite_okay=false → result is always in keys_out (selector not used for routing)
+  REQUIRE(expected == std::vector<T>(keys_out));
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_radix_sort_cleanup(&build));
+}

--- a/c/parallel/test/test_reduce.cpp
+++ b/c/parallel/test/test_reduce.cpp
@@ -703,7 +703,7 @@ C2H_TEST("Reduce compile/load round-trip", "[reduce][aot]")
   const std::vector<T> input = generate<T>(n);
   pointer_t<T> input_ptr(input);
   pointer_t<T> output_ptr(1);
-  CUstream null_stream      = 0;
+  CUstream null_stream      = nullptr;
   size_t temp_storage_bytes = 0;
 
   REQUIRE(CUDA_SUCCESS

--- a/c/parallel/test/test_reduce.cpp
+++ b/c/parallel/test/test_reduce.cpp
@@ -10,9 +10,13 @@
 
 #include <cstdint>
 #include <iostream> // std::cerr
+#include <memory>
+#include <numeric>
 #include <optional> // std::optional
 #include <string>
+#include <vector>
 
+#include <cuda.h>
 #include <cuda_runtime.h>
 
 #include "algorithm_execution.h"
@@ -576,6 +580,58 @@ C2H_TEST("Reduce works with C++ source operations using _ex build", "[reduce]")
   REQUIRE(CUDA_SUCCESS == cccl_device_reduce_cleanup(&build));
 }
 
+C2H_TEST("Reduce build result has AoT metadata populated", "[reduce][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  operation_t op             = make_operation("op", get_reduce_op(get_type_info<T>().type));
+  const std::vector<T> input = generate<T>(16);
+  pointer_t<T> input_ptr(input);
+  pointer_t<T> output_ptr(1);
+  value_t<T> init{T{0}};
+
+  BuildResultT build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_reduce_build(
+      &build,
+      input_ptr,
+      output_ptr,
+      op,
+      init,
+      CCCL_RUN_TO_RUN,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path()));
+
+  // cc field is packed as cc_major * 10 + cc_minor
+  CHECK(build.cc == build_info.get_cc_major() * 10 + build_info.get_cc_minor());
+
+  CHECK(build.cubin != nullptr);
+  CHECK(build.cubin_size > 0);
+
+  CHECK(build.runtime_policy != nullptr);
+  CHECK(build.runtime_policy_size > 0);
+
+  REQUIRE(build.single_tile_kernel_lowered_name != nullptr);
+  CHECK(build.single_tile_kernel_lowered_name[0] != '\0');
+  REQUIRE(build.single_tile_second_kernel_lowered_name != nullptr);
+  CHECK(build.single_tile_second_kernel_lowered_name[0] != '\0');
+  REQUIRE(build.reduction_kernel_lowered_name != nullptr);
+  CHECK(build.reduction_kernel_lowered_name[0] != '\0');
+
+  // nondeterministic name is null for CCCL_RUN_TO_RUN builds
+  CHECK(build.nondeterministic_kernel_lowered_name == nullptr);
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_reduce_cleanup(&build));
+}
+
 struct Reduce_Nondeterministic_Plus_Fixture_Tag;
 C2H_TEST("Reduce works with not_guaranteed determinism and plus", "[reduce][nondeterministic]")
 {
@@ -596,4 +652,71 @@ C2H_TEST("Reduce works with not_guaranteed determinism and plus", "[reduce][nond
   const T output   = output_ptr[0];
   const T expected = std::accumulate(input.begin(), input.end(), init.value);
   REQUIRE(output == expected);
+}
+
+C2H_TEST("Reduce compile/load round-trip", "[reduce][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  cccl_op_t op = make_well_known_binary_operation(); // plus
+  pointer_t<T> dummy_in(1);
+  pointer_t<T> dummy_out(1);
+  value_t<T> init{T{0}};
+
+  BuildResultT build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_reduce_compile(
+      &build,
+      dummy_in,
+      dummy_out,
+      op,
+      init,
+      CCCL_RUN_TO_RUN,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path(),
+      nullptr));
+
+  REQUIRE(build.cubin != nullptr);
+  REQUIRE(build.cubin_size > 0);
+  REQUIRE(build.single_tile_kernel_lowered_name != nullptr);
+  REQUIRE(build.single_tile_second_kernel_lowered_name != nullptr);
+  REQUIRE(build.reduction_kernel_lowered_name != nullptr);
+  CHECK(build.library == nullptr);
+  CHECK(build.single_tile_kernel == nullptr);
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_reduce_load(&build));
+
+  REQUIRE(build.library != nullptr);
+  CHECK(build.single_tile_kernel != nullptr);
+  CHECK(build.single_tile_second_kernel != nullptr);
+  CHECK(build.reduction_kernel != nullptr);
+
+  constexpr std::size_t n    = 16;
+  const std::vector<T> input = generate<T>(n);
+  pointer_t<T> input_ptr(input);
+  pointer_t<T> output_ptr(1);
+  CUstream null_stream      = 0;
+  size_t temp_storage_bytes = 0;
+
+  REQUIRE(CUDA_SUCCESS
+          == cccl_device_reduce(build, nullptr, &temp_storage_bytes, input_ptr, output_ptr, n, op, init, null_stream));
+
+  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  REQUIRE(CUDA_SUCCESS
+          == cccl_device_reduce(
+            build, temp_storage.ptr, &temp_storage_bytes, input_ptr, output_ptr, n, op, init, null_stream));
+
+  const T result   = output_ptr[0];
+  const T expected = std::accumulate(input.begin(), input.end(), T{0});
+  REQUIRE(result == expected);
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_reduce_cleanup(&build));
 }

--- a/c/parallel/test/test_scan.cpp
+++ b/c/parallel/test/test_scan.cpp
@@ -813,3 +813,111 @@ C2H_TEST("Scan works with no init value", "[scan]")
     REQUIRE(expected == std::vector<T>(output_ptr));
   }
 }
+
+C2H_TEST("Scan build result has AoT metadata populated", "[scan][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  cccl_op_t op = make_well_known_binary_operation();
+  pointer_t<T> in(1);
+  pointer_t<T> out(1);
+  value_t<T> init{T{0}};
+
+  BuildResultT build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_scan_build(
+      &build,
+      in,
+      out,
+      op,
+      static_cast<cccl_value_t>(init).type,
+      /*force_inclusive=*/false,
+      CCCL_VALUE_INIT,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path()));
+
+  CHECK(build.cc == build_info.get_cc_major() * 10 + build_info.get_cc_minor());
+  CHECK(build.cubin != nullptr);
+  CHECK(build.cubin_size > 0);
+  CHECK(build.runtime_policy != nullptr);
+  CHECK(build.runtime_policy_size > 0);
+  REQUIRE(build.init_kernel_lowered_name != nullptr);
+  CHECK(build.init_kernel_lowered_name[0] != '\0');
+  REQUIRE(build.scan_kernel_lowered_name != nullptr);
+  CHECK(build.scan_kernel_lowered_name[0] != '\0');
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_scan_cleanup(&build));
+}
+
+C2H_TEST("Scan compile/load round-trip", "[scan][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  cccl_op_t op = make_well_known_binary_operation();
+  pointer_t<T> dummy_in(1);
+  pointer_t<T> dummy_out(1);
+  value_t<T> init{T{0}};
+
+  BuildResultT build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_scan_compile(
+      &build,
+      dummy_in,
+      dummy_out,
+      op,
+      static_cast<cccl_value_t>(init).type,
+      /*force_inclusive=*/false,
+      CCCL_VALUE_INIT,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path(),
+      nullptr));
+
+  REQUIRE(build.cubin != nullptr);
+  REQUIRE(build.cubin_size > 0);
+  REQUIRE(build.init_kernel_lowered_name != nullptr);
+  REQUIRE(build.scan_kernel_lowered_name != nullptr);
+  CHECK(build.library == nullptr);
+  CHECK(build.init_kernel == nullptr);
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_scan_load(&build));
+  REQUIRE(build.library != nullptr);
+  CHECK(build.init_kernel != nullptr);
+  CHECK(build.scan_kernel != nullptr);
+
+  constexpr std::size_t n    = 16;
+  const std::vector<T> input = generate<T>(n);
+  pointer_t<T> input_ptr(input);
+  pointer_t<T> output_ptr(n);
+  CUstream null_stream      = 0;
+  size_t temp_storage_bytes = 0;
+
+  REQUIRE(CUDA_SUCCESS
+          == cccl_device_exclusive_scan(
+            build, nullptr, &temp_storage_bytes, input_ptr, output_ptr, n, op, init, null_stream));
+  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  REQUIRE(CUDA_SUCCESS
+          == cccl_device_exclusive_scan(
+            build, temp_storage.ptr, &temp_storage_bytes, input_ptr, output_ptr, n, op, init, null_stream));
+
+  std::vector<T> expected(n);
+  std::exclusive_scan(input.begin(), input.end(), expected.begin(), T{0});
+  REQUIRE(expected == std::vector<T>(output_ptr));
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_scan_cleanup(&build));
+}

--- a/c/parallel/test/test_scan.cpp
+++ b/c/parallel/test/test_scan.cpp
@@ -904,7 +904,7 @@ C2H_TEST("Scan compile/load round-trip", "[scan][aot]")
   const std::vector<T> input = generate<T>(n);
   pointer_t<T> input_ptr(input);
   pointer_t<T> output_ptr(n);
-  CUstream null_stream      = 0;
+  CUstream null_stream      = nullptr;
   size_t temp_storage_bytes = 0;
 
   REQUIRE(CUDA_SUCCESS

--- a/c/parallel/test/test_segmented_reduce.cpp
+++ b/c/parallel/test/test_segmented_reduce.cpp
@@ -1177,3 +1177,141 @@ C2H_TEST_LIST("segmented_reduce respects guaranteed_max_segment_size for large s
 
   run_guaranteed_max_seg_size_test<segment_size, TestType>(n_rows, segment_size, build_cache, test_key);
 }
+
+C2H_TEST("SegmentedReduce build result has AoT metadata populated", "[segmented_reduce][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  cccl_op_t op = make_well_known_binary_operation();
+  pointer_t<T> in(1);
+  pointer_t<T> out(1);
+  pointer_t<T> begin_offsets(1);
+  pointer_t<T> end_offsets(1);
+  value_t<T> init{T{0}};
+
+  cccl_device_segmented_reduce_build_result_t build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_segmented_reduce_build(
+      &build,
+      in,
+      out,
+      begin_offsets,
+      end_offsets,
+      op,
+      init,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path()));
+
+  CHECK(build.cc == build_info.get_cc_major() * 10 + build_info.get_cc_minor());
+  CHECK(build.cubin != nullptr);
+  CHECK(build.cubin_size > 0);
+  CHECK(build.runtime_policy != nullptr);
+  CHECK(build.runtime_policy_size > 0);
+  REQUIRE(build.segmented_reduce_kernel_lowered_name != nullptr);
+  CHECK(build.segmented_reduce_kernel_lowered_name[0] != '\0');
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_segmented_reduce_cleanup(&build));
+}
+
+C2H_TEST("SegmentedReduce compile/load round-trip", "[segmented_reduce][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  cccl_op_t op = make_well_known_binary_operation();
+  pointer_t<T> dummy_in(1);
+  pointer_t<T> dummy_out(1);
+  pointer_t<T> dummy_begin_offsets(1);
+  pointer_t<T> dummy_end_offsets(1);
+  value_t<T> init{T{0}};
+
+  cccl_device_segmented_reduce_build_result_t build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_segmented_reduce_compile(
+      &build,
+      dummy_in,
+      dummy_out,
+      dummy_begin_offsets,
+      dummy_end_offsets,
+      op,
+      init,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path(),
+      nullptr));
+
+  REQUIRE(build.cubin != nullptr);
+  REQUIRE(build.cubin_size > 0);
+  REQUIRE(build.segmented_reduce_kernel_lowered_name != nullptr);
+  CHECK(build.library == nullptr);
+  CHECK(build.segmented_reduce_kernel == nullptr);
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_segmented_reduce_load(&build));
+  REQUIRE(build.library != nullptr);
+  CHECK(build.segmented_reduce_kernel != nullptr);
+
+  constexpr std::size_t n          = 16;
+  constexpr std::size_t n_segments = 2;
+  const std::vector<T> input       = generate<T>(n);
+  pointer_t<T> input_ptr(input);
+  pointer_t<T> output_ptr(n_segments);
+  const std::vector<int> begin_offsets_host = {0, static_cast<int>(n / 2)};
+  const std::vector<int> end_offsets_host   = {static_cast<int>(n / 2), static_cast<int>(n)};
+  pointer_t<int> begin_offsets_ptr(begin_offsets_host);
+  pointer_t<int> end_offsets_ptr(end_offsets_host);
+  CUstream null_stream      = 0;
+  size_t temp_storage_bytes = 0;
+
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_segmented_reduce(
+      build,
+      nullptr,
+      &temp_storage_bytes,
+      input_ptr,
+      output_ptr,
+      n_segments,
+      begin_offsets_ptr,
+      end_offsets_ptr,
+      op,
+      init,
+      /*max_segment_size=*/0,
+      null_stream));
+  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_segmented_reduce(
+      build,
+      temp_storage.ptr,
+      &temp_storage_bytes,
+      input_ptr,
+      output_ptr,
+      n_segments,
+      begin_offsets_ptr,
+      end_offsets_ptr,
+      op,
+      init,
+      /*max_segment_size=*/0,
+      null_stream));
+
+  const T expected0 = std::accumulate(input.begin(), input.begin() + n / 2, T{0});
+  const T expected1 = std::accumulate(input.begin() + n / 2, input.end(), T{0});
+  REQUIRE(output_ptr[0] == expected0);
+  REQUIRE(output_ptr[1] == expected1);
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_segmented_reduce_cleanup(&build));
+}

--- a/c/parallel/test/test_segmented_reduce.cpp
+++ b/c/parallel/test/test_segmented_reduce.cpp
@@ -1273,7 +1273,7 @@ C2H_TEST("SegmentedReduce compile/load round-trip", "[segmented_reduce][aot]")
   const std::vector<int> end_offsets_host   = {static_cast<int>(n / 2), static_cast<int>(n)};
   pointer_t<int> begin_offsets_ptr(begin_offsets_host);
   pointer_t<int> end_offsets_ptr(end_offsets_host);
-  CUstream null_stream      = 0;
+  CUstream null_stream      = nullptr;
   size_t temp_storage_bytes = 0;
 
   REQUIRE(

--- a/c/parallel/test/test_segmented_sort.cpp
+++ b/c/parallel/test/test_segmented_sort.cpp
@@ -829,7 +829,7 @@ C2H_TEST("SegmentedSort compile/load round-trip", "[segmented_sort][aot]")
   const std::vector<Off> end_offsets_host   = {static_cast<Off>(n / 2), static_cast<Off>(n)};
   pointer_t<Off> begin_offsets_ptr(begin_offsets_host);
   pointer_t<Off> end_offsets_ptr(end_offsets_host);
-  CUstream null_stream      = 0;
+  CUstream null_stream      = nullptr;
   size_t temp_storage_bytes = 0;
   int selector              = -1;
 

--- a/c/parallel/test/test_segmented_sort.cpp
+++ b/c/parallel/test/test_segmented_sort.cpp
@@ -723,3 +723,157 @@ C2H_TEST("SegmentedSort works with variable segment sizes", "[segmented_sort][va
   REQUIRE(expected_keys == std::vector<key_t>(output_keys));
   REQUIRE(expected_values == std::vector<item_t>(output_vals));
 }
+
+C2H_TEST("SegmentedSort build result has AoT metadata populated", "[segmented_sort][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  pointer_t<T> keys_in(1);
+  pointer_t<T> values_in(1);
+  pointer_t<T> begin_offsets(1);
+  pointer_t<T> end_offsets(1);
+
+  BuildResultT build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_segmented_sort_build(
+      &build,
+      CCCL_ASCENDING,
+      keys_in,
+      values_in,
+      begin_offsets,
+      end_offsets,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path()));
+
+  CHECK(build.cc == build_info.get_cc_major() * 10 + build_info.get_cc_minor());
+  CHECK(build.cubin != nullptr);
+  CHECK(build.cubin_size > 0);
+  CHECK(build.runtime_policy != nullptr);
+  CHECK(build.runtime_policy_size > 0);
+  CHECK(build.partition_runtime_policy != nullptr);
+  CHECK(build.partition_runtime_policy_size > 0);
+  REQUIRE(build.segmented_sort_fallback_kernel_lowered_name != nullptr);
+  CHECK(build.segmented_sort_fallback_kernel_lowered_name[0] != '\0');
+  REQUIRE(build.segmented_sort_kernel_small_lowered_name != nullptr);
+  CHECK(build.segmented_sort_kernel_small_lowered_name[0] != '\0');
+  REQUIRE(build.three_way_partition_init_kernel_lowered_name != nullptr);
+  CHECK(build.three_way_partition_init_kernel_lowered_name[0] != '\0');
+  REQUIRE(build.three_way_partition_kernel_lowered_name != nullptr);
+  CHECK(build.three_way_partition_kernel_lowered_name[0] != '\0');
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_segmented_sort_cleanup(&build));
+}
+
+C2H_TEST("SegmentedSort compile/load round-trip", "[segmented_sort][aot]")
+{
+  using T   = int32_t;
+  using Off = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  pointer_t<T> dummy_keys_in(1);
+  pointer_t<T> dummy_values_in(1);
+  pointer_t<Off> dummy_begin_offsets(1);
+  pointer_t<Off> dummy_end_offsets(1);
+
+  BuildResultT build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_segmented_sort_compile(
+      &build,
+      CCCL_ASCENDING,
+      dummy_keys_in,
+      dummy_values_in,
+      dummy_begin_offsets,
+      dummy_end_offsets,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path(),
+      nullptr));
+
+  REQUIRE(build.cubin != nullptr);
+  REQUIRE(build.cubin_size > 0);
+  REQUIRE(build.segmented_sort_fallback_kernel_lowered_name != nullptr);
+  REQUIRE(build.segmented_sort_kernel_small_lowered_name != nullptr);
+  REQUIRE(build.three_way_partition_init_kernel_lowered_name != nullptr);
+  CHECK(build.library == nullptr);
+  CHECK(build.segmented_sort_fallback_kernel == nullptr);
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_segmented_sort_load(&build));
+  REQUIRE(build.library != nullptr);
+  CHECK(build.segmented_sort_fallback_kernel != nullptr);
+  CHECK(build.segmented_sort_kernel_small != nullptr);
+  CHECK(build.three_way_partition_init_kernel != nullptr);
+  CHECK(build.three_way_partition_kernel != nullptr);
+
+  constexpr std::size_t n          = 8;
+  constexpr std::size_t n_segments = 2;
+  const std::vector<T> input       = generate<T>(n);
+  pointer_t<T> keys_in(input);
+  pointer_t<T> keys_out(n);
+  pointer_t<T> values_in(n); // items not checked — just keys
+  pointer_t<T> values_out(n);
+  const std::vector<Off> begin_offsets_host = {0, static_cast<Off>(n / 2)};
+  const std::vector<Off> end_offsets_host   = {static_cast<Off>(n / 2), static_cast<Off>(n)};
+  pointer_t<Off> begin_offsets_ptr(begin_offsets_host);
+  pointer_t<Off> end_offsets_ptr(end_offsets_host);
+  CUstream null_stream      = 0;
+  size_t temp_storage_bytes = 0;
+  int selector              = -1;
+
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_segmented_sort(
+      build,
+      nullptr,
+      &temp_storage_bytes,
+      keys_in,
+      keys_out,
+      values_in,
+      values_out,
+      n,
+      n_segments,
+      begin_offsets_ptr,
+      end_offsets_ptr,
+      /*is_overwrite_okay=*/false,
+      &selector,
+      null_stream));
+  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_segmented_sort(
+      build,
+      temp_storage.ptr,
+      &temp_storage_bytes,
+      keys_in,
+      keys_out,
+      values_in,
+      values_out,
+      n,
+      n_segments,
+      begin_offsets_ptr,
+      end_offsets_ptr,
+      /*is_overwrite_okay=*/false,
+      &selector,
+      null_stream));
+
+  auto& output_keys = (selector == 0) ? keys_in : keys_out;
+  std::vector<T> result(output_keys);
+  // Each segment should be sorted ascending
+  CHECK(std::is_sorted(result.begin(), result.begin() + n / 2));
+  CHECK(std::is_sorted(result.begin() + n / 2, result.end()));
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_segmented_sort_cleanup(&build));
+}

--- a/c/parallel/test/test_three_way_partition.cpp
+++ b/c/parallel/test/test_three_way_partition.cpp
@@ -632,7 +632,7 @@ C2H_TEST("ThreeWayPartition compile/load round-trip", "[three_way_partition][aot
   pointer_t<T> second_out(n);
   pointer_t<T> unselected_out(n);
   pointer_t<int> num_selected_out(2);
-  CUstream null_stream      = 0;
+  CUstream null_stream      = nullptr;
   size_t temp_storage_bytes = 0;
 
   REQUIRE(

--- a/c/parallel/test/test_three_way_partition.cpp
+++ b/c/parallel/test/test_three_way_partition.cpp
@@ -525,3 +525,155 @@ C2H_TEST("ThreeWayPartition works with iterators", "[three_way_partition]")
   REQUIRE(static_cast<std::size_t>(num_selected[1]) == std_result.num_items_in_second_part);
   REQUIRE(num_items - static_cast<std::size_t>(num_selected[0] + num_selected[1]) == std_result.num_unselected_items);
 }
+
+C2H_TEST("ThreeWayPartition build result has AoT metadata populated", "[three_way_partition][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  auto [first_src, second_src] = get_three_way_partition_ops(get_type_info<T>().type, 21);
+  operation_t first_op         = make_operation("less_op", first_src);
+  operation_t second_op        = make_operation("greater_op", second_src);
+
+  pointer_t<T> in(1);
+  pointer_t<T> first_out(1);
+  pointer_t<T> second_out(1);
+  pointer_t<T> unselected_out(1);
+  pointer_t<T> num_selected_out(1);
+
+  BuildResultT build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_three_way_partition_build(
+      &build,
+      in,
+      first_out,
+      second_out,
+      unselected_out,
+      num_selected_out,
+      first_op,
+      second_op,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path()));
+
+  CHECK(build.cc == build_info.get_cc_major() * 10 + build_info.get_cc_minor());
+  CHECK(build.cubin != nullptr);
+  CHECK(build.cubin_size > 0);
+  CHECK(build.runtime_policy != nullptr);
+  CHECK(build.runtime_policy_size > 0);
+  REQUIRE(build.three_way_partition_init_kernel_lowered_name != nullptr);
+  CHECK(build.three_way_partition_init_kernel_lowered_name[0] != '\0');
+  REQUIRE(build.three_way_partition_kernel_lowered_name != nullptr);
+  CHECK(build.three_way_partition_kernel_lowered_name[0] != '\0');
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_three_way_partition_cleanup(&build));
+}
+
+C2H_TEST("ThreeWayPartition compile/load round-trip", "[three_way_partition][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+  constexpr T split_value = 21;
+
+  auto [first_src, second_src] = get_three_way_partition_ops(get_type_info<T>().type, split_value);
+  operation_t first_op         = make_operation("less_op", first_src);
+  operation_t second_op        = make_operation("greater_op", second_src);
+
+  pointer_t<T> dummy_in(1);
+  pointer_t<T> dummy_first_out(1);
+  pointer_t<T> dummy_second_out(1);
+  pointer_t<T> dummy_unselected_out(1);
+  pointer_t<T> dummy_num_selected_out(1);
+
+  BuildResultT build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_three_way_partition_compile(
+      &build,
+      dummy_in,
+      dummy_first_out,
+      dummy_second_out,
+      dummy_unselected_out,
+      dummy_num_selected_out,
+      first_op,
+      second_op,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path(),
+      nullptr));
+
+  REQUIRE(build.cubin != nullptr);
+  REQUIRE(build.cubin_size > 0);
+  REQUIRE(build.three_way_partition_init_kernel_lowered_name != nullptr);
+  REQUIRE(build.three_way_partition_kernel_lowered_name != nullptr);
+  CHECK(build.library == nullptr);
+  CHECK(build.three_way_partition_init_kernel == nullptr);
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_three_way_partition_load(&build));
+  REQUIRE(build.library != nullptr);
+  CHECK(build.three_way_partition_init_kernel != nullptr);
+  CHECK(build.three_way_partition_kernel != nullptr);
+
+  constexpr std::size_t n    = 16;
+  const std::vector<T> input = generate<T>(n);
+  pointer_t<T> input_ptr(input);
+  pointer_t<T> first_out(n);
+  pointer_t<T> second_out(n);
+  pointer_t<T> unselected_out(n);
+  pointer_t<int> num_selected_out(2);
+  CUstream null_stream      = 0;
+  size_t temp_storage_bytes = 0;
+
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_three_way_partition(
+      build,
+      nullptr,
+      &temp_storage_bytes,
+      input_ptr,
+      first_out,
+      second_out,
+      unselected_out,
+      num_selected_out,
+      first_op,
+      second_op,
+      n,
+      null_stream));
+  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_three_way_partition(
+      build,
+      temp_storage.ptr,
+      &temp_storage_bytes,
+      input_ptr,
+      first_out,
+      second_out,
+      unselected_out,
+      num_selected_out,
+      first_op,
+      second_op,
+      n,
+      null_stream));
+
+  const int n_first      = num_selected_out[0];
+  const int n_second     = num_selected_out[1];
+  const int n_unselected = static_cast<int>(n) - n_first - n_second;
+  CHECK(n_first >= 0);
+  CHECK(n_second >= 0);
+  CHECK(n_unselected >= 0);
+  CHECK(n_first + n_second + n_unselected == static_cast<int>(n));
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_three_way_partition_cleanup(&build));
+}

--- a/c/parallel/test/test_transform.cpp
+++ b/c/parallel/test/test_transform.cpp
@@ -822,3 +822,94 @@ extern "C" __device__ void op(void* state_ptr, void* x_ptr, void* out_ptr) {
     REQUIRE(counter[0] == static_cast<int>(num_items));
   }
 }
+
+C2H_TEST("Transform build result has AoT metadata populated", "[transform][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  cccl_op_t op = make_well_known_unary_operation();
+  pointer_t<T> in(1);
+  pointer_t<T> out(1);
+
+  BuildResultT build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_unary_transform_build(
+      &build,
+      in,
+      out,
+      op,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path()));
+
+  CHECK(build.cc == build_info.get_cc_major() * 10 + build_info.get_cc_minor());
+  CHECK(build.cubin != nullptr);
+  CHECK(build.cubin_size > 0);
+  CHECK(build.runtime_policy != nullptr);
+  CHECK(build.runtime_policy_size > 0);
+  REQUIRE(build.transform_kernel_lowered_name != nullptr);
+  CHECK(build.transform_kernel_lowered_name[0] != '\0');
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_transform_cleanup(&build));
+}
+
+C2H_TEST("Transform compile/load round-trip", "[transform][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  cccl_op_t op = make_well_known_unary_operation();
+  pointer_t<T> dummy_in(1);
+  pointer_t<T> dummy_out(1);
+
+  BuildResultT build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_unary_transform_compile(
+      &build,
+      dummy_in,
+      dummy_out,
+      op,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path(),
+      nullptr));
+
+  REQUIRE(build.cubin != nullptr);
+  REQUIRE(build.cubin_size > 0);
+  REQUIRE(build.transform_kernel_lowered_name != nullptr);
+  CHECK(build.library == nullptr);
+  CHECK(build.transform_kernel == nullptr);
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_transform_load(&build));
+  REQUIRE(build.library != nullptr);
+  CHECK(build.transform_kernel != nullptr);
+
+  constexpr std::size_t n    = 16;
+  const std::vector<T> input = generate<T>(n);
+  pointer_t<T> input_ptr(input);
+  pointer_t<T> output_ptr(n);
+  CUstream null_stream = 0;
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_unary_transform(build, input_ptr, output_ptr, n, op, null_stream));
+
+  std::vector<T> expected(input);
+  std::transform(expected.begin(), expected.end(), expected.begin(), [](T x) {
+    return -x;
+  });
+  REQUIRE(expected == std::vector<T>(output_ptr));
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_transform_cleanup(&build));
+}

--- a/c/parallel/test/test_transform.cpp
+++ b/c/parallel/test/test_transform.cpp
@@ -901,7 +901,7 @@ C2H_TEST("Transform compile/load round-trip", "[transform][aot]")
   const std::vector<T> input = generate<T>(n);
   pointer_t<T> input_ptr(input);
   pointer_t<T> output_ptr(n);
-  CUstream null_stream = 0;
+  CUstream null_stream = nullptr;
 
   REQUIRE(CUDA_SUCCESS == cccl_device_unary_transform(build, input_ptr, output_ptr, n, op, null_stream));
 

--- a/c/parallel/test/test_unique_by_key.cpp
+++ b/c/parallel/test/test_unique_by_key.cpp
@@ -1048,7 +1048,7 @@ C2H_TEST("UniqueByKey compile/load round-trip", "[unique_by_key][aot]")
   pointer_t<T> keys_out(n);
   pointer_t<T> values_out(n);
   pointer_t<uint64_t> num_selected_out(1);
-  CUstream null_stream      = 0;
+  CUstream null_stream      = nullptr;
   size_t temp_storage_bytes = 0;
 
   REQUIRE(

--- a/c/parallel/test/test_unique_by_key.cpp
+++ b/c/parallel/test/test_unique_by_key.cpp
@@ -943,3 +943,145 @@ C2H_TEST("UniqueByKey works with C++ source operations using custom headers", "[
   // Cleanup
   REQUIRE(CUDA_SUCCESS == cccl_device_unique_by_key_cleanup(&build));
 }
+
+C2H_TEST("UniqueByKey build result has AoT metadata populated", "[unique_by_key][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  cccl_op_t op = make_well_known_binary_operation();
+  pointer_t<T> keys_in(1);
+  pointer_t<T> values_in(1);
+  pointer_t<T> keys_out(1);
+  pointer_t<T> values_out(1);
+  pointer_t<uint64_t> num_selected_out(1);
+
+  BuildResultT build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_unique_by_key_build(
+      &build,
+      keys_in,
+      values_in,
+      keys_out,
+      values_out,
+      num_selected_out,
+      op,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path()));
+
+  CHECK(build.cc == build_info.get_cc_major() * 10 + build_info.get_cc_minor());
+  CHECK(build.cubin != nullptr);
+  CHECK(build.cubin_size > 0);
+  CHECK(build.runtime_policy != nullptr);
+  CHECK(build.runtime_policy_size > 0);
+  REQUIRE(build.compact_init_kernel_lowered_name != nullptr);
+  CHECK(build.compact_init_kernel_lowered_name[0] != '\0');
+  REQUIRE(build.sweep_kernel_lowered_name != nullptr);
+  CHECK(build.sweep_kernel_lowered_name[0] != '\0');
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_unique_by_key_cleanup(&build));
+}
+
+C2H_TEST("UniqueByKey compile/load round-trip", "[unique_by_key][aot]")
+{
+  using T = int32_t;
+
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  cccl_op_t op = make_well_known_unique_binary_predicate();
+  pointer_t<T> dummy_keys_in(1);
+  pointer_t<T> dummy_values_in(1);
+  pointer_t<T> dummy_keys_out(1);
+  pointer_t<T> dummy_values_out(1);
+  pointer_t<uint64_t> dummy_num_selected_out(1);
+
+  BuildResultT build{};
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_unique_by_key_compile(
+      &build,
+      dummy_keys_in,
+      dummy_values_in,
+      dummy_keys_out,
+      dummy_values_out,
+      dummy_num_selected_out,
+      op,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path(),
+      nullptr));
+
+  REQUIRE(build.cubin != nullptr);
+  REQUIRE(build.cubin_size > 0);
+  REQUIRE(build.compact_init_kernel_lowered_name != nullptr);
+  REQUIRE(build.sweep_kernel_lowered_name != nullptr);
+  CHECK(build.library == nullptr);
+  CHECK(build.compact_init_kernel == nullptr);
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_unique_by_key_load(&build));
+  REQUIRE(build.library != nullptr);
+  CHECK(build.compact_init_kernel != nullptr);
+  CHECK(build.sweep_kernel != nullptr);
+
+  constexpr std::size_t n = 16;
+  // Input with consecutive duplicate keys: 0,0,1,1,2,2,...,7,7 → 8 unique keys
+  std::vector<T> input_keys(n);
+  std::vector<T> input_values(n);
+  for (std::size_t i = 0; i < n; ++i)
+  {
+    input_keys[i]   = static_cast<T>(i / 2);
+    input_values[i] = static_cast<T>(i);
+  }
+  pointer_t<T> keys_in(input_keys);
+  pointer_t<T> values_in(input_values);
+  pointer_t<T> keys_out(n);
+  pointer_t<T> values_out(n);
+  pointer_t<uint64_t> num_selected_out(1);
+  CUstream null_stream      = 0;
+  size_t temp_storage_bytes = 0;
+
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_unique_by_key(
+      build,
+      nullptr,
+      &temp_storage_bytes,
+      keys_in,
+      values_in,
+      keys_out,
+      values_out,
+      num_selected_out,
+      op,
+      n,
+      null_stream));
+  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_unique_by_key(
+      build,
+      temp_storage.ptr,
+      &temp_storage_bytes,
+      keys_in,
+      values_in,
+      keys_out,
+      values_out,
+      num_selected_out,
+      op,
+      n,
+      null_stream));
+
+  REQUIRE(num_selected_out[0] == 8); // 8 unique keys
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_unique_by_key_cleanup(&build));
+}


### PR DESCRIPTION
## Description

Depends on https://github.com/NVIDIA/cccl/pull/8484.

First-time execution:

```
$ ./build/cccl-c-parallel/bin/cccl.c.parallel.test.bench_aot
Randomness seeded to: 556061959

--- AoT vs JIT first-execution latency  (SM 89, N=1048576) ---
  algorithm                   JIT (compile+load+run)  AoT (load+run)      speedup
  ------------------------------------------------------------------------------
  reduce (int32)              JIT:  1015.7 ms   AoT:   1.988 ms   speedup:    511x
  scan (int32, excl.)         JIT:  1286.1 ms   AoT:   3.309 ms   speedup:    389x
  merge_sort (int32, keys)    JIT:   891.4 ms   AoT:   1.944 ms   speedup:    459x
  radix_sort (int32, keys)    JIT:  2265.9 ms   AoT:   5.656 ms   speedup:    401x
  ------------------------------------------------------------------------------
```

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
