### PR TITLE
[cudax] Extend mapping result properties

### DIFF
--- a/cudax/include/cuda/experimental/__hierarchy/concepts.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/concepts.cuh
@@ -49,12 +49,14 @@ _CCCL_CONCEPT group = _CCCL_REQUIRES_EXPR((_Group), _Group&& __g, const _Group&&
 template <class _Tp>
 _CCCL_CONCEPT __group_mapping_result = _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __v)(
   requires(::cuda::std::is_copy_constructible_v<_Tp>),
-  _Same_as(::cuda::std::size_t) __v.static_group_count(),
+  _Same_as(::cuda::std::size_t) _Tp::static_group_count(),
   _Same_as(unsigned) __v.group_count(),
   _Same_as(unsigned) __v.group_rank(),
-  _Same_as(::cuda::std::size_t) __v.static_count(),
+  _Same_as(::cuda::std::size_t) _Tp::static_count(),
   _Same_as(unsigned) __v.count(),
-  _Same_as(unsigned) __v.rank());
+  _Same_as(unsigned) __v.rank(),
+  _Same_as(bool) _Tp::is_always_exhaustive(),
+  _Same_as(bool) _Tp::is_always_contiguous());
 
 template <class _Synchronizer, class _MappingResult>
 _CCCL_CONCEPT __has_sync_aligned = _CCCL_REQUIRES_EXPR(

--- a/cudax/include/cuda/experimental/__hierarchy/fwd.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/fwd.cuh
@@ -73,7 +73,7 @@ class cluster_group;
 
 // mappings
 
-template <::cuda::std::size_t _Np>
+template <::cuda::std::size_t _Np = ::cuda::std::dynamic_extent, bool _IsExhaustive = true>
 class group_by;
 
 // synchronizers

--- a/cudax/include/cuda/experimental/__hierarchy/groups.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/groups.cuh
@@ -63,6 +63,7 @@ public:
   using __mapping_result_type = _MappingResult;
   using hierarchy_type        = _Hierarchy;
 
+  // todo(dabayer): Remove _Level and _HierarchyLike parameters and take a base group instead.
   // todo(dabayer): Do we want default behaviour like this, or do we want some kind of cuda::auto_sync_mechanism{} tag?
   _CCCL_TEMPLATE(class _HierarchyLike)
   _CCCL_REQUIRES(::cuda::std::is_same_v<_Hierarchy, __hierarchy_type_of<_HierarchyLike>>)
@@ -72,7 +73,9 @@ public:
       , __mapping_{__mapping}
       , __mapping_result_{__mapping_.map(thread_level{}, _Level{}, ::cuda::__unpack_hierarchy_if_needed(__hier_like))}
       , __synchronizer_{__mapping_result_}
-  {}
+  {
+    ::cuda::experimental::__check_mapping_result(__mapping_result_);
+  }
 
   _CCCL_TEMPLATE(class _Synchronizer2 = _Synchronizer, class _MappingResult2 = _MappingResult, class _HierarchyLike)
   _CCCL_REQUIRES(__is_barrier_synchronizer<_Synchronizer2>
@@ -86,7 +89,9 @@ public:
       , __mapping_{__mapping}
       , __mapping_result_{__mapping_.map(thread_level{}, _Level{}, ::cuda::__unpack_hierarchy_if_needed(__hier_like))}
       , __synchronizer_{__mapping_result_, __barriers}
-  {}
+  {
+    ::cuda::experimental::__check_mapping_result(__mapping_result_);
+  }
 
   [[nodiscard]] _CCCL_DEVICE_API const _Hierarchy& hierarchy() const noexcept
   {

--- a/cudax/include/cuda/experimental/__hierarchy/mappings.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/mappings.cuh
@@ -36,13 +36,20 @@
 
 namespace cuda::experimental
 {
+struct non_exhaustive_t
+{
+  _CCCL_HIDE_FROM_ABI explicit non_exhaustive_t() = default;
+};
+
+_CCCL_DEVICE constexpr non_exhaustive_t non_exhaustive;
+
 // Requirements on mappings:
 // - must be copyable
 // - must implement `map(_Unit, _Level, _Hierarchy)` method that returns an object that satisfies the
 //   `__group_mapping_result` concept
 
 // todo(dabayer): do we want to add stride parameter?
-template <::cuda::std::size_t _Np = ::cuda::std::dynamic_extent>
+template <::cuda::std::size_t _Np, bool _IsExhaustive>
 class group_by
 {
   static_assert(_Np != 0, "_Np must not be zero");
@@ -56,6 +63,11 @@ public:
     unsigned __group_rank_;
     unsigned __rank_;
 
+    [[nodiscard]] _CCCL_DEVICE_API static constexpr __mapping_result __invalid(unsigned __group_count) noexcept
+    {
+      return {__group_count, 0xffff'ffffu, 0xffff'ffffu};
+    }
+
     [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_group_count() noexcept
     {
       return _NGroups;
@@ -68,6 +80,10 @@ public:
 
     [[nodiscard]] _CCCL_DEVICE_API unsigned group_rank() const noexcept
     {
+      if constexpr (!_IsExhaustive)
+      {
+        _CCCL_ASSERT(is_valid(), "getting group rank of thread that is not part of the group is UB");
+      }
       return __group_rank_;
     }
 
@@ -78,46 +94,110 @@ public:
 
     [[nodiscard]] _CCCL_DEVICE_API unsigned count() const noexcept
     {
+      if constexpr (!_IsExhaustive)
+      {
+        _CCCL_ASSERT(is_valid(), "getting count of thread that is not part of the group is UB");
+      }
       return static_cast<unsigned>(_Np);
     }
 
     [[nodiscard]] _CCCL_DEVICE_API unsigned rank() const noexcept
     {
+      if constexpr (!_IsExhaustive)
+      {
+        _CCCL_ASSERT(is_valid(), "getting rank of thread that is not part of the group is UB");
+      }
       return __rank_;
     }
 
-    // todo(dabayer): add method that determines whether the unit is part of the group or not.
+    [[nodiscard]] _CCCL_DEVICE_API bool is_valid() const noexcept
+    {
+      if constexpr (_IsExhaustive)
+      {
+        return true;
+      }
+      else
+      {
+        return __rank_ != 0xffff'ffffu;
+      }
+    }
+
+    [[nodiscard]] _CCCL_DEVICE_API static constexpr bool is_always_exhaustive() noexcept
+    {
+      return _IsExhaustive;
+    }
+
+    [[nodiscard]] _CCCL_DEVICE_API static constexpr bool is_always_contiguous() noexcept
+    {
+      return true;
+    }
   };
 
   _CCCL_HIDE_FROM_ABI explicit group_by() = default;
 
-  [[nodiscard]] _CCCL_API constexpr unsigned n() const noexcept
+  _CCCL_TEMPLATE(bool _IsExhaustive2 = _IsExhaustive)
+  _CCCL_REQUIRES((!_IsExhaustive))
+  _CCCL_DEVICE_API constexpr group_by(non_exhaustive_t) noexcept {}
+
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_count() noexcept
+  {
+    return _Np;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr bool is_always_exhaustive() noexcept
+  {
+    return _IsExhaustive;
+  }
+
+  [[nodiscard]] _CCCL_API constexpr unsigned count() const noexcept
   {
     return static_cast<unsigned>(_Np);
   }
 
   template <class _Unit, class _Level, class _Hierarchy>
-  [[nodiscard]] _CCCL_DEVICE_API auto map(const _Unit& __unit, const _Level&, _Hierarchy __hier) noexcept
+  [[nodiscard]] _CCCL_DEVICE_API auto map(const _Unit& __unit, const _Level&, _Hierarchy __hier) const noexcept
   {
-    constexpr auto __nunits_in_level = _Unit::static_count(_Level{}, __hier);
+    constexpr auto __static_nunits = _Unit::static_count(_Level{}, __hier);
     constexpr auto __static_ngroups =
-      (__nunits_in_level != ::cuda::std::dynamic_extent) ? __nunits_in_level / _Np : ::cuda::std::dynamic_extent;
+      (__static_nunits != ::cuda::std::dynamic_extent) ? __static_nunits / _Np : ::cuda::std::dynamic_extent;
+
+    const auto __nunits    = _Unit::template count_as<unsigned>(_Level{}, __hier);
+    const auto __unit_rank = _Unit::template rank_as<unsigned>(_Level{}, __hier);
 
     __mapping_result<__static_ngroups> __ret{};
-    __ret.__group_count_ = _Unit::template count_as<unsigned>(_Level{}, __hier) / n();
-    __ret.__group_rank_  = _Unit::template rank_as<unsigned>(_Level{}, __hier) / n();
-    __ret.__rank_        = _Unit::template rank_as<unsigned>(_Level{}, __hier) % n();
+    __ret.__group_count_ = __nunits / count();
+    __ret.__group_rank_  = __unit_rank / count();
+    __ret.__rank_        = __unit_rank % count();
+
+    // If the mapping is exhaustive, check the preconditions, otherwise return invalid mapping for the remainder.
+    if constexpr (_IsExhaustive)
+    {
+      if constexpr (__static_nunits != ::cuda::std::dynamic_extent)
+      {
+        static_assert(__static_nunits % _Np == 0, "group_by mapping _IsExhaustive precondition violation");
+      }
+      else
+      {
+        _CCCL_ASSERT(__nunits % count() == 0, "group_by mapping _IsExhaustive precondition violation");
+      }
+    }
+    else if (__nunits % count() != 0)
+    {
+      if (__ret.__group_rank_ >= __ret.__group_count_)
+      {
+        return __mapping_result<__static_ngroups>::__invalid(__ret.__group_count_);
+      }
+    }
     return __ret;
   }
 };
 
-template <>
-class group_by<::cuda::std::dynamic_extent>
+template <bool _IsExhaustive>
+class group_by<::cuda::std::dynamic_extent, _IsExhaustive>
 {
   unsigned __n_;
 
 public:
-  template <::cuda::std::size_t _NGroups>
   struct __mapping_result
   {
     unsigned __group_count_;
@@ -125,9 +205,14 @@ public:
     unsigned __count_;
     unsigned __rank_;
 
+    [[nodiscard]] _CCCL_DEVICE_API static constexpr __mapping_result __invalid(unsigned __group_count) noexcept
+    {
+      return {__group_count, 0xffff'ffffu, 0xffff'ffffu, 0xffff'ffffu};
+    }
+
     [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_group_count() noexcept
     {
-      return _NGroups;
+      return ::cuda::std::dynamic_extent;
     }
 
     [[nodiscard]] _CCCL_DEVICE_API unsigned group_count() const noexcept
@@ -137,6 +222,10 @@ public:
 
     [[nodiscard]] _CCCL_DEVICE_API unsigned group_rank() const noexcept
     {
+      if constexpr (!_IsExhaustive)
+      {
+        _CCCL_ASSERT(is_valid(), "getting group rank of thread that is not part of the group is UB");
+      }
       return __group_rank_;
     }
 
@@ -147,12 +236,42 @@ public:
 
     [[nodiscard]] _CCCL_DEVICE_API unsigned count() const noexcept
     {
+      if constexpr (!_IsExhaustive)
+      {
+        _CCCL_ASSERT(is_valid(), "getting group rank of thread that is not part of the group is UB");
+      }
       return __count_;
     }
 
     [[nodiscard]] _CCCL_DEVICE_API unsigned rank() const noexcept
     {
+      if constexpr (!_IsExhaustive)
+      {
+        _CCCL_ASSERT(is_valid(), "getting rank of thread that is not part of the group is UB");
+      }
       return __rank_;
+    }
+
+    [[nodiscard]] _CCCL_DEVICE_API bool is_valid() const noexcept
+    {
+      if constexpr (_IsExhaustive)
+      {
+        return true;
+      }
+      else
+      {
+        return __rank_ != 0xffff'ffffu;
+      }
+    }
+
+    [[nodiscard]] _CCCL_DEVICE_API static constexpr bool is_always_exhaustive() noexcept
+    {
+      return _IsExhaustive;
+    }
+
+    [[nodiscard]] _CCCL_DEVICE_API static constexpr bool is_always_contiguous() noexcept
+    {
+      return true;
     }
   };
 
@@ -162,28 +281,80 @@ public:
     _CCCL_ASSERT(__n_ > 0, "__n cannot be 0");
   }
 
-  [[nodiscard]] _CCCL_API constexpr unsigned n() const noexcept
+  _CCCL_TEMPLATE(bool _IsExhaustive2 = _IsExhaustive)
+  _CCCL_REQUIRES((!_IsExhaustive2))
+  _CCCL_DEVICE_API explicit constexpr group_by(unsigned __n, non_exhaustive_t) noexcept
+      : __n_{__n}
+  {
+    _CCCL_ASSERT(__n_ > 0, "__n cannot be 0");
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_count() noexcept
+  {
+    return ::cuda::std::dynamic_extent;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr bool is_always_exhaustive() noexcept
+  {
+    return _IsExhaustive;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr unsigned count() const noexcept
   {
     return __n_;
   }
 
   template <class _Unit, class _Level, class _Hierarchy>
-  [[nodiscard]] _CCCL_DEVICE_API auto map(const _Unit& __unit, const _Level& __level, const _Hierarchy& __hier) noexcept
+  [[nodiscard]] _CCCL_DEVICE_API auto
+  map(const _Unit& __unit, const _Level& __level, const _Hierarchy& __hier) const noexcept
   {
-    __mapping_result<::cuda::std::dynamic_extent> __ret{};
-    __ret.__group_count_ = __unit.template count_as<unsigned>(__level, __hier) / n();
-    __ret.__group_rank_  = __unit.template rank_as<unsigned>(__level, __hier) / n();
-    __ret.__count_       = n();
-    __ret.__rank_        = __unit.template rank_as<unsigned>(__level, __hier) % n();
+    const auto __nunits    = __unit.template count_as<unsigned>(__level, __hier);
+    const auto __unit_rank = __unit.template rank_as<unsigned>(__level, __hier);
+
+    __mapping_result __ret{};
+    __ret.__group_count_ = __nunits / __n_;
+    __ret.__group_rank_  = __unit_rank / __n_;
+    __ret.__count_       = __n_;
+    __ret.__rank_        = __unit_rank % __n_;
+
+    // If the mapping is exhaustive, check the preconditions, otherwise remove the last partial group.
+    if constexpr (_IsExhaustive)
+    {
+      _CCCL_ASSERT(__nunits % __n_ == 0, "group_by mapping _IsExhaustive precondition violation");
+    }
+    else if (__nunits % __n_ != 0)
+    {
+      if (__ret.__group_rank_ >= __ret.__group_count_)
+      {
+        return __mapping_result::__invalid(__ret.__group_count_);
+      }
+    }
     return __ret;
   }
 };
 
-_CCCL_HOST_DEVICE group_by(unsigned) -> group_by<::cuda::std::dynamic_extent>;
+_CCCL_DEVICE group_by(unsigned) -> group_by<::cuda::std::dynamic_extent>;
+
+_CCCL_DEVICE group_by(unsigned, non_exhaustive_t) -> group_by<::cuda::std::dynamic_extent, false>;
 
 template <class _Mapping, class _Unit, class _Level, class _Hierarchy>
 using __group_mapping_result_t =
   decltype(::cuda::std::declval<_Mapping>().map(_Unit{}, _Level{}, ::cuda::std::declval<_Hierarchy>()));
+
+template <class _MappingResult>
+_CCCL_DEVICE_API void __check_mapping_result(const _MappingResult& __mapping_result) noexcept
+{
+  // Don't check the mapping result if it's not valid. We can skip this check if mapping result is always exhaustive.
+  if constexpr (!_MappingResult::is_always_exhaustive())
+  {
+    if (!__mapping_result.is_valid())
+    {
+      return;
+    }
+  }
+  _CCCL_ASSERT(__mapping_result.group_rank() < __mapping_result.group_count(), "invalid group rank");
+  _CCCL_ASSERT(__mapping_result.rank() < __mapping_result.count(), "invalid rank");
+}
 } // namespace cuda::experimental
 
 #endif // !_CCCL_DOXYGEN_INVOKED

--- a/cudax/include/cuda/experimental/__hierarchy/queries.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/queries.cuh
@@ -108,6 +108,12 @@ template <class _Tp, class _Unit, class _Group>
     return static_cast<_Tp>(__group_unit_rank * __group_unit_count + __unit_rank);
   }
 }
+
+template <class _Unit, class _Group>
+[[nodiscard]] _CCCL_DEVICE_API bool __is_part_of_group(const _Group& __group) noexcept
+{
+  return __group.__mapping_result().is_valid();
+}
 } // namespace cuda::experimental
 
 #endif // !_CCCL_DOXYGEN_INVOKED

--- a/cudax/include/cuda/experimental/__hierarchy/synchronizers.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/synchronizers.cuh
@@ -80,8 +80,16 @@ public:
   }
 
   template <class _MappingResult>
-  _CCCL_DEVICE_API void __sync(const _MappingResult&) noexcept
+  _CCCL_DEVICE_API void __sync(const _MappingResult& __mapping_result) noexcept
   {
+    if constexpr (!_MappingResult::is_always_exhaustive())
+    {
+      if (!__mapping_result.is_valid())
+      {
+        return;
+      }
+    }
+
     ::__syncwarp(__lane_mask_);
   }
 };
@@ -153,6 +161,14 @@ public:
   template <class _MappingResult>
   _CCCL_DEVICE_API void __sync(const _MappingResult& __mapping_result) noexcept
   {
+    if constexpr (!_MappingResult::is_always_exhaustive())
+    {
+      if (!__mapping_result.is_valid())
+      {
+        return;
+      }
+    }
+
     __barriers_[__mapping_result.group_rank()].arrive_and_wait();
   }
 };

--- a/cudax/include/cuda/experimental/__hierarchy/this_group.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/this_group.cuh
@@ -110,6 +110,21 @@ struct __this_mapping_result
     return 0;
   }
 
+  [[nodiscard]] _CCCL_DEVICE_API bool is_valid() const noexcept
+  {
+    return true;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr bool is_always_exhaustive() noexcept
+  {
+    return true;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr bool is_always_contiguous() noexcept
+  {
+    return true;
+  }
+
   // todo(dabayer): add method that determines whether the unit is part of the group or not.
 };
 

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -129,6 +129,7 @@ cudax_add_catch2_test(test_target algorithm
 
 cudax_add_catch2_test(test_target hierarchy_groups
     hierarchy/group.cu
+    hierarchy/mapping/group_by.cu
 )
 target_compile_definitions(${test_target} PUBLIC _CUDAX_HIERARCHY)
 

--- a/cudax/test/hierarchy/group.cu
+++ b/cudax/test/hierarchy/group.cu
@@ -419,7 +419,7 @@ __device__ void test_queries(const cudax::thread_group<Level, cudax::group_by<N>
   // reference. Can we find a solution that works without copying the group?
   // static_assert(cuda::gpu_thread.static_count(group) == N);
 
-  const auto count_ref = group.mapping().n();
+  const auto count_ref = group.mapping().count();
   const auto rank_ref  = cuda::gpu_thread.rank(Level{}, group.hierarchy()) % count_ref;
 
   CUDAX_REQUIRE(cuda::gpu_thread.count(group) == count_ref);

--- a/cudax/test/hierarchy/mapping/group_by.cu
+++ b/cudax/test/hierarchy/mapping/group_by.cu
@@ -1,0 +1,349 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/devices>
+#include <cuda/hierarchy>
+#include <cuda/launch>
+#include <cuda/std/cstddef>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+#include <cuda/stream>
+
+#include <cuda/experimental/hierarchy.cuh>
+
+#include "testing.cuh"
+
+template <cuda::std::size_t N, class Config>
+__device__ void test_group_by(Config config)
+{
+  // Test static N.
+  {
+    using Mapping = cudax::group_by<N>;
+    static_assert(cuda::std::is_same_v<Mapping, cudax::group_by<N, true>>);
+
+    // Test default constructor.
+    {
+      static_assert(cuda::std::is_trivially_default_constructible_v<Mapping>);
+      static_assert(cuda::std::is_empty_v<Mapping>);
+
+      cudax::group_by<N> mapping;
+      CUDAX_CHECK(mapping.count() == static_cast<unsigned>(N));
+    }
+
+    // Test the mapping is not constructible from unsigned.
+    static_assert(!cuda::std::is_constructible_v<Mapping, unsigned>);
+
+    // Test the mapping is not constructible from non_exhaustive_t.
+    static_assert(!cuda::std::is_constructible_v<Mapping, cudax::non_exhaustive_t>);
+
+    // Test the mapping is not constructible from unsigned and non_exhaustive_t.
+    static_assert(!cuda::std::is_constructible_v<Mapping, unsigned, cudax::non_exhaustive_t>);
+
+    // Test static_count().
+    static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_count())>);
+    static_assert(noexcept(Mapping::static_count()));
+    static_assert(Mapping::static_count() == N);
+
+    // Test is_always_exhaustive().
+    static_assert(cuda::std::is_same_v<bool, decltype(Mapping::is_always_exhaustive())>);
+    static_assert(noexcept(Mapping::is_always_exhaustive()));
+    static_assert(Mapping::is_always_exhaustive());
+
+    // Test count().
+    {
+      static_assert(cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().count())>);
+      static_assert(noexcept(cuda::std::declval<const Mapping>().count()));
+
+      const Mapping mapping;
+      CUDAX_CHECK(mapping.count() == static_cast<unsigned>(N));
+    }
+
+    // Test map(...).
+    {
+      static_assert(cudax::__group_mapping_result<decltype(cuda::std::declval<const Mapping>().map(
+                      cuda::gpu_thread, cuda::warp, config.hierarchy()))>);
+      static_assert(
+        noexcept(cuda::std::declval<const Mapping>().map(cuda::gpu_thread, cuda::warp, config.hierarchy())));
+
+      const Mapping mapping;
+      auto result  = mapping.map(cuda::gpu_thread, cuda::warp, config.hierarchy());
+      using Result = decltype(result);
+
+      static_assert(Result::static_group_count() == 32 / N);
+      CUDAX_CHECK(result.group_count() == cuda::gpu_thread.count(cuda::warp) / N);
+      CUDAX_CHECK(result.group_rank() == cuda::gpu_thread.rank(cuda::warp) / N);
+
+      static_assert(Result::static_count() == N);
+      CUDAX_CHECK(result.count() == N);
+      CUDAX_CHECK(result.rank() == cuda::gpu_thread.rank(cuda::warp) % N);
+
+      CUDAX_CHECK(result.is_valid());
+      static_assert(Result::is_always_exhaustive());
+      static_assert(Result::is_always_contiguous());
+    }
+  }
+
+  // Test dynamic N.
+  {
+    using Mapping = cudax::group_by<>;
+    static_assert(cuda::std::is_same_v<Mapping, cudax::group_by<cuda::std::dynamic_extent, true>>);
+
+    // Test default constructor.
+    static_assert(!cuda::std::is_default_constructible_v<Mapping>);
+    static_assert(!cuda::std::is_empty_v<Mapping>);
+
+    // Test the mapping is constructible from unsigned.
+    {
+      static_assert(cuda::std::is_nothrow_constructible_v<Mapping, unsigned>);
+
+      cudax::group_by mapping{N};
+      static_assert(cuda::std::is_same_v<Mapping, decltype(mapping)>);
+      CUDAX_CHECK(mapping.count() == static_cast<unsigned>(N));
+    }
+
+    // Test the mapping is not constructible from non_exhaustive_t.
+    static_assert(!cuda::std::is_constructible_v<Mapping, cudax::non_exhaustive_t>);
+
+    // Test the mapping is not constructible from unsigned and non_exhaustive_t.
+    static_assert(!cuda::std::is_constructible_v<Mapping, unsigned, cudax::non_exhaustive_t>);
+
+    // Test static_count().
+    static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_count())>);
+    static_assert(noexcept(Mapping::static_count()));
+    static_assert(Mapping::static_count() == cuda::std::dynamic_extent);
+
+    // Test is_always_exhaustive().
+    static_assert(cuda::std::is_same_v<bool, decltype(Mapping::is_always_exhaustive())>);
+    static_assert(noexcept(Mapping::is_always_exhaustive()));
+    static_assert(Mapping::is_always_exhaustive());
+
+    // Test count().
+    {
+      static_assert(cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().count())>);
+      static_assert(noexcept(cuda::std::declval<const Mapping>().count()));
+
+      const Mapping mapping{N};
+      CUDAX_CHECK(mapping.count() == static_cast<unsigned>(N));
+    }
+
+    // Test map(...).
+    {
+      static_assert(cudax::__group_mapping_result<decltype(cuda::std::declval<const Mapping>().map(
+                      cuda::gpu_thread, cuda::warp, config.hierarchy()))>);
+      static_assert(
+        noexcept(cuda::std::declval<const Mapping>().map(cuda::gpu_thread, cuda::warp, config.hierarchy())));
+
+      const Mapping mapping{N};
+      auto result  = mapping.map(cuda::gpu_thread, cuda::warp, config.hierarchy());
+      using Result = decltype(result);
+
+      static_assert(Result::static_group_count() == cuda::std::dynamic_extent);
+      CUDAX_CHECK(result.group_count() == cuda::gpu_thread.count(cuda::warp) / N);
+      CUDAX_CHECK(result.group_rank() == cuda::gpu_thread.rank(cuda::warp) / N);
+
+      static_assert(Result::static_count() == cuda::std::dynamic_extent);
+      CUDAX_CHECK(result.count() == N);
+      CUDAX_CHECK(result.rank() == cuda::gpu_thread.rank(cuda::warp) % N);
+
+      CUDAX_CHECK(result.is_valid());
+      static_assert(Result::is_always_exhaustive());
+      static_assert(Result::is_always_contiguous());
+    }
+  }
+}
+
+template <cuda::std::size_t N, class Config>
+__device__ void test_group_by_non_exhaustive(Config config)
+{
+  // Test static N.
+  {
+    using Mapping = cudax::group_by<N, false>;
+
+    // Test default constructor.
+    static_assert(cuda::std::is_trivially_default_constructible_v<Mapping>);
+    static_assert(cuda::std::is_empty_v<Mapping>);
+
+    // Test the mapping is not constructible from unsigned.
+    static_assert(!cuda::std::is_constructible_v<Mapping, unsigned>);
+
+    // Test the mapping is not constructible from non_exhaustive_t.
+    {
+      static_assert(cuda::std::is_nothrow_constructible_v<Mapping, cudax::non_exhaustive_t>);
+
+      Mapping mapping{cudax::non_exhaustive};
+      static_assert(cuda::std::is_same_v<decltype(mapping), Mapping>);
+      CUDAX_CHECK(mapping.count() == static_cast<unsigned>(N));
+    }
+
+    // Test the mapping is not constructible from unsigned and non_exhaustive_t.
+    static_assert(!cuda::std::is_constructible_v<Mapping, unsigned, cudax::non_exhaustive_t>);
+
+    // Test static_count().
+    static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_count())>);
+    static_assert(noexcept(Mapping::static_count()));
+    static_assert(Mapping::static_count() == N);
+
+    // Test is_always_exhaustive().
+    static_assert(cuda::std::is_same_v<bool, decltype(Mapping::is_always_exhaustive())>);
+    static_assert(noexcept(Mapping::is_always_exhaustive()));
+    static_assert(!Mapping::is_always_exhaustive());
+
+    // Test count().
+    {
+      static_assert(cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().count())>);
+      static_assert(noexcept(cuda::std::declval<const Mapping>().count()));
+
+      const Mapping mapping{cudax::non_exhaustive};
+      CUDAX_CHECK(mapping.count() == static_cast<unsigned>(N));
+    }
+
+    // Test map(...).
+    {
+      static_assert(cudax::__group_mapping_result<decltype(cuda::std::declval<const Mapping>().map(
+                      cuda::gpu_thread, cuda::warp, config.hierarchy()))>);
+      static_assert(
+        noexcept(cuda::std::declval<const Mapping>().map(cuda::gpu_thread, cuda::warp, config.hierarchy())));
+
+      const Mapping mapping{cudax::non_exhaustive};
+      auto result  = mapping.map(cuda::gpu_thread, cuda::warp, config.hierarchy());
+      using Result = decltype(result);
+
+      static_assert(Result::static_group_count() == 32 / N);
+      static_assert(Result::static_count() == N);
+      static_assert(!Result::is_always_exhaustive());
+      static_assert(Result::is_always_contiguous());
+
+      const auto is_valid_ref = (cuda::gpu_thread.count(cuda::warp) / N) * N < cuda::gpu_thread.rank(cuda::warp);
+      CUDAX_CHECK(result.is_valid() == is_valid_ref);
+
+      if (is_valid_ref)
+      {
+        CUDAX_CHECK(result.group_count() == cuda::gpu_thread.count(cuda::warp) / N);
+        CUDAX_CHECK(result.group_rank() == cuda::gpu_thread.rank(cuda::warp) / N);
+
+        CUDAX_CHECK(result.count() == N);
+        CUDAX_CHECK(result.rank() == cuda::gpu_thread.rank(cuda::warp) % N);
+      }
+    }
+  }
+
+  // Test dynamic N.
+  {
+    using Mapping = cudax::group_by<cuda::std::dynamic_extent, false>;
+
+    // Test default constructor.
+    static_assert(!cuda::std::is_default_constructible_v<Mapping>);
+    static_assert(!cuda::std::is_empty_v<Mapping>);
+
+    // Test the mapping is constructible from unsigned.
+    {
+      static_assert(cuda::std::is_nothrow_constructible_v<Mapping, unsigned>);
+
+      Mapping mapping{N};
+      static_assert(cuda::std::is_same_v<Mapping, decltype(mapping)>);
+      CUDAX_CHECK(mapping.count() == static_cast<unsigned>(N));
+    }
+
+    // Test the mapping is not constructible from non_exhaustive_t.
+    static_assert(!cuda::std::is_constructible_v<Mapping, cudax::non_exhaustive_t>);
+
+    // Test the mapping is not constructible from unsigned and non_exhaustive_t.
+    {
+      static_assert(cuda::std::is_nothrow_constructible_v<Mapping, unsigned, cudax::non_exhaustive_t>);
+
+      cudax::group_by mapping{static_cast<unsigned>(N), cudax::non_exhaustive};
+      static_assert(cuda::std::is_same_v<decltype(mapping), Mapping>);
+      CUDAX_CHECK(mapping.count() == static_cast<unsigned>(N));
+    }
+
+    // Test static_count().
+    static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_count())>);
+    static_assert(noexcept(Mapping::static_count()));
+    static_assert(Mapping::static_count() == cuda::std::dynamic_extent);
+
+    // Test count().
+    {
+      static_assert(cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().count())>);
+      static_assert(noexcept(cuda::std::declval<const Mapping>().count()));
+
+      const Mapping mapping{N, cudax::non_exhaustive};
+      CUDAX_CHECK(mapping.count() == static_cast<unsigned>(N));
+    }
+
+    // Test map(...).
+    {
+      static_assert(cudax::__group_mapping_result<decltype(cuda::std::declval<const Mapping>().map(
+                      cuda::gpu_thread, cuda::warp, config.hierarchy()))>);
+      static_assert(
+        noexcept(cuda::std::declval<const Mapping>().map(cuda::gpu_thread, cuda::warp, config.hierarchy())));
+
+      const Mapping mapping{N, cudax::non_exhaustive};
+      auto result  = mapping.map(cuda::gpu_thread, cuda::warp, config.hierarchy());
+      using Result = decltype(result);
+
+      static_assert(Result::static_group_count() == cuda::std::dynamic_extent);
+      static_assert(Result::static_count() == cuda::std::dynamic_extent);
+      static_assert(!Result::is_always_exhaustive());
+      static_assert(Result::is_always_contiguous());
+
+      const auto is_valid_ref = (cuda::gpu_thread.count(cuda::warp) / N) * N < cuda::gpu_thread.rank(cuda::warp);
+      CUDAX_CHECK(result.is_valid() == is_valid_ref);
+
+      if (is_valid_ref)
+      {
+        CUDAX_CHECK(result.group_count() == cuda::gpu_thread.count(cuda::warp) / N);
+        CUDAX_CHECK(result.group_rank() == cuda::gpu_thread.rank(cuda::warp) / N);
+
+        CUDAX_CHECK(result.count() == N);
+        CUDAX_CHECK(result.rank() == cuda::gpu_thread.rank(cuda::warp) % N);
+      }
+    }
+  }
+}
+
+struct TestKernel
+{
+  template <class Config>
+  __device__ void operator()(const Config& config)
+  {
+    test_group_by<1>(config);
+    test_group_by<2>(config);
+    test_group_by<4>(config);
+    test_group_by<16>(config);
+    test_group_by<32>(config);
+
+    test_group_by_non_exhaustive<1>(config);
+    test_group_by_non_exhaustive<2>(config);
+    test_group_by_non_exhaustive<3>(config);
+    test_group_by_non_exhaustive<4>(config);
+    test_group_by_non_exhaustive<14>(config);
+    test_group_by_non_exhaustive<16>(config);
+    test_group_by_non_exhaustive<30>(config);
+    test_group_by_non_exhaustive<32>(config);
+  }
+};
+
+C2H_TEST("Hierarchy groups", "[hierarchy]")
+{
+  const auto device = cuda::devices[0];
+
+  const cuda::stream stream{device};
+
+  {
+    const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims<8, 4>());
+    cuda::launch(stream, config, TestKernel{});
+  }
+  {
+    const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims(dim3{8, 4}));
+    cuda::launch(stream, config, TestKernel{});
+  }
+
+  stream.sync();
+}

--- a/libcudacxx/include/cuda/__hierarchy/hierarchy_level_base.h
+++ b/libcudacxx/include/cuda/__hierarchy/hierarchy_level_base.h
@@ -219,7 +219,8 @@ struct hierarchy_level_base
   _CCCL_REQUIRES(::cuda::experimental::group<_Group>)
   [[nodiscard]] _CCCL_API static constexpr bool is_part_of(const _Group& __group) noexcept
   {
-    return true;
+    // todo: static_assert that the _Level <= _Group::unit_type
+    return ::cuda::experimental::__is_part_of_group<_Level>(__group);
   }
 #    endif // _CCCL_CUDA_COMPILATION()
 #  endif // _CUDAX_HIERARCHY


### PR DESCRIPTION
This PR extends mapping result's properties by specifying:
- `MappingResult::is_always_exhaustive()`: a compile-time constant specifying whether a the mapping can produce threads that are not part of the group object (optional participation).
- `MappingResult::is_always_contiguous()`: a compile-time constant specifying whether the mapping produces a contiguous range of units (for example puts in a group threads `0` and `1`, but not `0` and `2`).

There properties are later used to optimize the group. queries/operations. I've made `cudax::group_by` templated on whether it may result in a non-exhaustive group by passing the `cudax::non_exhaustive` tag to the constructor. That way both static/dynamic versions of `cudax::group_by` can cut-off all excess threads that don't create a full group. The exhaustive version `assert`s on not creating a partial group.

I've written a proper test for `cudax::group_by`, too.

In next PR, I'd like to make the constructor take a base group instead of hierarchy + level parameters.