### PR TITLE
Ensure that algorithms can be run with host / device only iterators

### DIFF
--- a/libcudacxx/include/cuda/std/__numeric/accumulate.h
+++ b/libcudacxx/include/cuda/std/__numeric/accumulate.h
@@ -28,6 +28,7 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp accumulate(_InputIterator __first, _InputIterator __last, _Tp __init)
 {
@@ -38,6 +39,7 @@ template <class _InputIterator, class _Tp>
   return __init;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _Tp, class _BinaryOperation>
 [[nodiscard]] _CCCL_API constexpr _Tp
 accumulate(_InputIterator __first, _InputIterator __last, _Tp __init, _BinaryOperation __binary_op)

--- a/libcudacxx/include/cuda/std/__numeric/adjacent_difference.h
+++ b/libcudacxx/include/cuda/std/__numeric/adjacent_difference.h
@@ -29,6 +29,7 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _OutputIterator>
 _CCCL_API constexpr _OutputIterator
 adjacent_difference(_InputIterator __first, _InputIterator __last, _OutputIterator __result)
@@ -47,6 +48,7 @@ adjacent_difference(_InputIterator __first, _InputIterator __last, _OutputIterat
   return __result;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _OutputIterator, class _BinaryOperation>
 _CCCL_API constexpr _OutputIterator adjacent_difference(
   _InputIterator __first, _InputIterator __last, _OutputIterator __result, _BinaryOperation __binary_op)

--- a/libcudacxx/include/cuda/std/__numeric/exclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__numeric/exclusive_scan.h
@@ -29,6 +29,7 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _OutputIterator, class _Tp, class _BinaryOp>
 _CCCL_API constexpr _OutputIterator
 exclusive_scan(_InputIterator __first, _InputIterator __last, _OutputIterator __result, _Tp __init, _BinaryOp __b)

--- a/libcudacxx/include/cuda/std/__numeric/gcd_lcm.h
+++ b/libcudacxx/include/cuda/std/__numeric/gcd_lcm.h
@@ -35,14 +35,14 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Tp>
-constexpr _CCCL_API inline _Tp __gcd(_Tp __m, _Tp __n)
+[[nodiscard]] _CCCL_API constexpr _Tp __gcd(_Tp __m, _Tp __n)
 {
   static_assert((!is_signed_v<_Tp>) );
   return __n == 0 ? __m : ::cuda::std::__gcd<_Tp>(__n, __m % __n);
 }
 
 template <class _Tp, class _Up>
-constexpr _CCCL_API inline common_type_t<_Tp, _Up> gcd(_Tp __m, _Up __n)
+[[nodiscard]] _CCCL_API constexpr common_type_t<_Tp, _Up> gcd(_Tp __m, _Up __n)
 {
   static_assert((is_integral_v<_Tp> && is_integral_v<_Up>), "Arguments to gcd must be integer types");
   static_assert((!is_same_v<remove_cv_t<_Tp>, bool>), "First argument to gcd cannot be bool");
@@ -53,7 +53,7 @@ constexpr _CCCL_API inline common_type_t<_Tp, _Up> gcd(_Tp __m, _Up __n)
 }
 
 template <class _Tp, class _Up>
-constexpr _CCCL_API inline common_type_t<_Tp, _Up> lcm(_Tp __m, _Up __n)
+[[nodiscard]] _CCCL_API constexpr common_type_t<_Tp, _Up> lcm(_Tp __m, _Up __n)
 {
   static_assert((is_integral_v<_Tp> && is_integral_v<_Up>), "Arguments to lcm must be integer types");
   static_assert((!is_same_v<remove_cv_t<_Tp>, bool>), "First argument to lcm cannot be bool");

--- a/libcudacxx/include/cuda/std/__numeric/inclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__numeric/inclusive_scan.h
@@ -30,6 +30,7 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _OutputIterator, class _Tp, class _BinaryOp>
 _CCCL_API constexpr _OutputIterator
 inclusive_scan(_InputIterator __first, _InputIterator __last, _OutputIterator __result, _BinaryOp __b, _Tp __init)
@@ -42,6 +43,7 @@ inclusive_scan(_InputIterator __first, _InputIterator __last, _OutputIterator __
   return __result;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _OutputIterator, class _BinaryOp>
 _CCCL_API constexpr _OutputIterator
 inclusive_scan(_InputIterator __first, _InputIterator __last, _OutputIterator __result, _BinaryOp __b)

--- a/libcudacxx/include/cuda/std/__numeric/inner_product.h
+++ b/libcudacxx/include/cuda/std/__numeric/inner_product.h
@@ -28,6 +28,7 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator1, class _InputIterator2, class _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp
 inner_product(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _Tp __init)
@@ -39,6 +40,7 @@ inner_product(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2
   return __init;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator1, class _InputIterator2, class _Tp, class _BinaryOperation1, class _BinaryOperation2>
 [[nodiscard]] _CCCL_API constexpr _Tp inner_product(
   _InputIterator1 __first1,

--- a/libcudacxx/include/cuda/std/__numeric/iota.h
+++ b/libcudacxx/include/cuda/std/__numeric/iota.h
@@ -26,6 +26,7 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Tp>
 _CCCL_API constexpr void iota(_ForwardIterator __first, _ForwardIterator __last, _Tp __value_)
 {

--- a/libcudacxx/include/cuda/std/__numeric/midpoint.h
+++ b/libcudacxx/include/cuda/std/__numeric/midpoint.h
@@ -56,16 +56,11 @@ midpoint(_Tp __a, _Tp __b) noexcept
   }
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, enable_if_t<is_object_v<_Tp> && !is_void_v<_Tp> && (sizeof(_Tp) > 0), int> = 0>
 [[nodiscard]] _CCCL_API constexpr _Tp* midpoint(_Tp* __a, _Tp* __b) noexcept
 {
   return __a + ::cuda::std::midpoint(ptrdiff_t(0), __b - __a);
-}
-
-template <typename _Tp>
-[[nodiscard]] _CCCL_API constexpr int __sign(_Tp __val)
-{
-  return (_Tp(0) < __val) - (__val < _Tp(0));
 }
 
 template <typename _Fp>

--- a/libcudacxx/include/cuda/std/__numeric/partial_sum.h
+++ b/libcudacxx/include/cuda/std/__numeric/partial_sum.h
@@ -29,6 +29,7 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _OutputIterator>
 _CCCL_API constexpr _OutputIterator partial_sum(_InputIterator __first, _InputIterator __last, _OutputIterator __result)
 {
@@ -45,6 +46,7 @@ _CCCL_API constexpr _OutputIterator partial_sum(_InputIterator __first, _InputIt
   return __result;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _OutputIterator, class _BinaryOperation>
 _CCCL_API constexpr _OutputIterator
 partial_sum(_InputIterator __first, _InputIterator __last, _OutputIterator __result, _BinaryOperation __binary_op)

--- a/libcudacxx/include/cuda/std/__numeric/transform_exclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__numeric/transform_exclusive_scan.h
@@ -26,6 +26,7 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _OutputIterator, class _Tp, class _BinaryOp, class _UnaryOp>
 _CCCL_API constexpr _OutputIterator transform_exclusive_scan(
   _InputIterator __first, _InputIterator __last, _OutputIterator __result, _Tp __init, _BinaryOp __b, _UnaryOp __u)

--- a/libcudacxx/include/cuda/std/__numeric/transform_inclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__numeric/transform_inclusive_scan.h
@@ -28,6 +28,7 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _OutputIterator, class _Tp, class _BinaryOp, class _UnaryOp>
 _CCCL_API constexpr _OutputIterator transform_inclusive_scan(
   _InputIterator __first, _InputIterator __last, _OutputIterator __result, _BinaryOp __b, _UnaryOp __u, _Tp __init)
@@ -41,6 +42,7 @@ _CCCL_API constexpr _OutputIterator transform_inclusive_scan(
   return __result;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _OutputIterator, class _BinaryOp, class _UnaryOp>
 _CCCL_API constexpr _OutputIterator transform_inclusive_scan(
   _InputIterator __first, _InputIterator __last, _OutputIterator __result, _BinaryOp __b, _UnaryOp __u)

--- a/libcudacxx/include/cuda/std/__numeric/transform_reduce.h
+++ b/libcudacxx/include/cuda/std/__numeric/transform_reduce.h
@@ -30,6 +30,7 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _Tp, class _BinaryOp, class _UnaryOp>
 [[nodiscard]] _CCCL_API constexpr _Tp
 transform_reduce(_InputIterator __first, _InputIterator __last, _Tp __init, _BinaryOp __b, _UnaryOp __u)
@@ -57,6 +58,7 @@ template <class _InputIterator1, class _InputIterator2, class _Tp, class _Binary
   return __init;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator1, class _InputIterator2, class _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp
 transform_reduce(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _Tp __init)

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_backward.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_backward.pass.cpp
@@ -171,6 +171,13 @@ TEST_CONSTEXPR_CXX20 TEST_FUNC bool test()
   test<const NonTrivialCopy*, NonTrivialCopy*>();
   test<const NonTrivialDestructor*, NonTrivialDestructor*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_if.pass.cpp
@@ -112,6 +112,13 @@ constexpr TEST_FUNC bool test()
   test<const int*, random_access_iterator<int*>>();
   test<const int*, int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_n.pass.cpp
@@ -96,6 +96,13 @@ TEST_CONSTEXPR_CXX20 TEST_FUNC bool test()
   test<const int*, random_access_iterator<int*>>();
   test<const int*, int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_rand.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_rand.pass.cpp
@@ -27,6 +27,13 @@ TEST_CONSTEXPR_CXX20 TEST_FUNC bool test()
   test<random_access_iterator<const int*>, random_access_iterator<int*>>();
   test<random_access_iterator<const int*>, int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.fill/fill.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.fill/fill.pass.cpp
@@ -55,6 +55,13 @@ TEST_FUNC constexpr bool test()
   test_int<random_access_iterator<int*>>();
   test_int<int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test_int<host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test_int<device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.fill/fill_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.fill/fill_n.pass.cpp
@@ -167,6 +167,13 @@ TEST_FUNC constexpr bool test()
   test5();
   test6();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test_int<host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test_int<device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.generate/generate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.generate/generate.pass.cpp
@@ -53,6 +53,13 @@ constexpr TEST_FUNC bool test()
   test<random_access_iterator<int*>>();
   test<int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.generate/generate_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.generate/generate_n.pass.cpp
@@ -69,6 +69,13 @@ constexpr TEST_FUNC bool test()
   test<random_access_iterator<int*>>();
   test<int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.move/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.move/move.pass.cpp
@@ -210,6 +210,13 @@ TEST_FUNC constexpr bool test()
   test<NonTrivialMove*, NonTrivialMove*>();
   test<NonTrivialDestructor*, NonTrivialDestructor*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<int*, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<int*, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
 #if defined(_LIBCUDACXX_HAS_MEMORY)
   test1<cpp17_input_iterator<cuda::std::unique_ptr<int>*>, cpp17_output_iterator<cuda::std::unique_ptr<int>*>>();
   test1<cpp17_input_iterator<cuda::std::unique_ptr<int>*>, cpp17_input_iterator<cuda::std::unique_ptr<int>*>>();

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.move/move_backward.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.move/move_backward.pass.cpp
@@ -195,6 +195,13 @@ TEST_FUNC constexpr bool test()
   test<NonTrivialMove*, NonTrivialMove*>();
   test<NonTrivialDestructor*, NonTrivialDestructor*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<int*, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<int*, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
 #if defined(_LIBCUDACXX_HAS_MEMORY)
   test1<bidirectional_iterator<cuda::std::unique_ptr<int>*>, bidirectional_iterator<cuda::std::unique_ptr<int>*>>();
   test1<bidirectional_iterator<cuda::std::unique_ptr<int>*>, random_access_iterator<cuda::std::unique_ptr<int>*>>();

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.end/find_end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.end/find_end.pass.cpp
@@ -56,6 +56,13 @@ int main(int, char**)
   test<random_access_iterator<const int*>, bidirectional_iterator<const int*>>();
   test<random_access_iterator<const int*>, random_access_iterator<const int*>>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>, host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>, device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   static_assert(test<forward_iterator<const int*>, forward_iterator<const int*>>());
   static_assert(test<forward_iterator<const int*>, bidirectional_iterator<const int*>>());
   static_assert(test<forward_iterator<const int*>, random_access_iterator<const int*>>());

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.end/find_end_pred.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.end/find_end_pred.pass.cpp
@@ -103,6 +103,13 @@ int main(int, char**)
   test<random_access_iterator<const int*>, bidirectional_iterator<const int*>>();
   test<random_access_iterator<const int*>, random_access_iterator<const int*>>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>, host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>, device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   static_assert(test<forward_iterator<const int*>, forward_iterator<const int*>>());
   static_assert(test<forward_iterator<const int*>, bidirectional_iterator<const int*>>());
   static_assert(test<forward_iterator<const int*>, random_access_iterator<const int*>>());

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search.pass.cpp
@@ -127,6 +127,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>, bidirectional_iterator<const int*>>();
   test<random_access_iterator<const int*>, random_access_iterator<const int*>>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>, host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>, device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   adl_test<forward_iterator<User::S*>>();
   adl_test<random_access_iterator<User::S*>>();
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search_n.pass.cpp
@@ -78,6 +78,13 @@ TEST_FUNC constexpr bool test()
   test<bidirectional_iterator<const int*>>();
   test<random_access_iterator<const int*>>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search_n_pred.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search_n_pred.pass.cpp
@@ -190,6 +190,13 @@ TEST_FUNC constexpr bool test()
   test<bidirectional_iterator<const int*>>();
   test<random_access_iterator<const int*>>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   // test bug reported in https://reviews.llvm.org/D124079?#3661721
   {
     A a[]       = {A(1, 2), A(2, 3), A(2, 4)};

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search_pred.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search_pred.pass.cpp
@@ -137,6 +137,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>, bidirectional_iterator<const int*>>();
   test<random_access_iterator<const int*>, random_access_iterator<const int*>>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>, host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>, device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -49,6 +49,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>>();
   test<const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/binary.search/binary_search_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/binary.search/binary_search_comp.pass.cpp
@@ -49,6 +49,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>>();
   test<const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range.pass.cpp
@@ -8,6 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// CONSTEXPR_STEPS: 15000000
+
 // <algorithm>
 
 // template<ForwardIterator Iter, class T>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range.pass.cpp
@@ -73,6 +73,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>>();
   test<const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range_comp.pass.cpp
@@ -72,6 +72,13 @@ TEST_FUNC constexpr bool test()
   test<bidirectional_iterator<const int*>>();
   test<random_access_iterator<const int*>>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range_comp.pass.cpp
@@ -8,6 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// CONSTEXPR_STEPS: 15000000
+
 // <algorithm>
 
 // template<ForwardIterator Iter, class T, CopyConstructible Compare>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -63,6 +63,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>>();
   test<const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/lower.bound/lower_bound_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/lower.bound/lower_bound_comp.pass.cpp
@@ -64,6 +64,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>>();
   test<const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -63,6 +63,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>>();
   test<const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/upper.bound/upper_bound_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/upper.bound/upper_bound_comp.pass.cpp
@@ -64,6 +64,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>>();
   test<const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/make.heap/make_heap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/make.heap/make_heap.pass.cpp
@@ -59,6 +59,13 @@ TEST_FUNC constexpr bool test()
   test<MoveOnly, random_access_iterator<MoveOnly*>>();
   test<MoveOnly, MoveOnly*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<int, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<int, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/make.heap/make_heap_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/make.heap/make_heap_comp.pass.cpp
@@ -60,6 +60,13 @@ TEST_FUNC constexpr bool test()
   test<MoveOnly, random_access_iterator<MoveOnly*>>();
   test<MoveOnly, MoveOnly*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<int, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<int, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/pop.heap/pop_heap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/pop.heap/pop_heap.pass.cpp
@@ -61,6 +61,13 @@ TEST_FUNC constexpr bool test()
   test<MoveOnly, random_access_iterator<MoveOnly*>>();
   test<MoveOnly, MoveOnly*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<int, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<int, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/pop.heap/pop_heap_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/pop.heap/pop_heap_comp.pass.cpp
@@ -61,6 +61,13 @@ TEST_FUNC constexpr bool test()
   test<MoveOnly, random_access_iterator<MoveOnly*>>();
   test<MoveOnly, MoveOnly*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<int, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<int, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/push.heap/push_heap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/push.heap/push_heap.pass.cpp
@@ -58,6 +58,13 @@ TEST_FUNC constexpr bool test()
   test<MoveOnly, random_access_iterator<MoveOnly*>>();
   test<MoveOnly, MoveOnly*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<int, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<int, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/push.heap/push_heap_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/push.heap/push_heap_comp.pass.cpp
@@ -58,6 +58,13 @@ TEST_FUNC constexpr bool test()
   test<MoveOnly, random_access_iterator<MoveOnly*>>();
   test<MoveOnly, MoveOnly*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<int, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<int, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/sort_heap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/sort_heap.pass.cpp
@@ -55,6 +55,13 @@ TEST_FUNC constexpr bool test()
   test<MoveOnly, random_access_iterator<MoveOnly*>>();
   test<MoveOnly, MoveOnly*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<int, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<int, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/sort_heap_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/sort_heap_comp.pass.cpp
@@ -56,6 +56,13 @@ TEST_FUNC constexpr bool test()
   test<MoveOnly, random_access_iterator<MoveOnly*>>();
   test<MoveOnly, MoveOnly*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<int, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<int, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.lex.comparison/lexicographical_compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.lex.comparison/lexicographical_compare.pass.cpp
@@ -66,6 +66,13 @@ TEST_FUNC constexpr bool test()
   test<const int*, random_access_iterator<const int*>>();
   test<const int*, const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>, host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>, device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.lex.comparison/lexicographical_compare_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.lex.comparison/lexicographical_compare_comp.pass.cpp
@@ -70,6 +70,13 @@ TEST_FUNC constexpr bool test()
   test<const int*, random_access_iterator<const int*>>();
   test<const int*, const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>, host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>, device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/inplace_merge.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/inplace_merge.pass.cpp
@@ -151,6 +151,13 @@ int main(int, char**)
   test<random_access_iterator<S*>>(reinterpret_cast<S*>(arr), randomness);
   test<S*>(reinterpret_cast<S*>(arr), randomness);
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<int*>>(arr, randomness);))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<int*>>(arr, randomness);))
+#endif // TEST_CUDA_COMPILATION()
+
 #if defined(_LIBCUDACXX_HAS_VECTOR)
 #  if !defined(TEST_HAS_NO_EXCEPTIONS)
   {

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/inplace_merge_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/inplace_merge_comp.pass.cpp
@@ -190,6 +190,13 @@ int main(int, char**)
   test<random_access_iterator<S*>>(reinterpret_cast<S*>(arr), randomness);
   test<S*>(reinterpret_cast<S*>(arr), randomness);
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<int*>>(arr, randomness);))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<int*>>(arr, randomness);))
+#endif // TEST_CUDA_COMPILATION()
+
 #if defined(_LIBCUDACXX_HAS_VECTOR)
   test_PR31166();
 #endif // _LIBCUDACXX_HAS_VECTOR

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/merge.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/merge.pass.cpp
@@ -81,6 +81,13 @@ TEST_FUNC constexpr void test1()
   test2<T, bidirectional_iterator<const T*>>();
   test2<T, random_access_iterator<const T*>>();
   test2<T, const T*>();
+
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test2<T, host_only_iterator<const T*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test2<T, device_only_iterator<const T*>>();))
+#endif // TEST_CUDA_COMPILATION()
 }
 
 TEST_FUNC constexpr bool test()

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/merge_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/merge_comp.pass.cpp
@@ -84,6 +84,13 @@ TEST_FUNC constexpr void test1()
   test2<T, bidirectional_iterator<const T*>>();
   test2<T, random_access_iterator<const T*>>();
   test2<T, const T*>();
+
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test2<T, host_only_iterator<const T*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test2<T, device_only_iterator<const T*>>();))
+#endif // TEST_CUDA_COMPILATION()
 }
 
 TEST_FUNC constexpr bool test()

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/max_element.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/max_element.pass.cpp
@@ -50,6 +50,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>>(input_data);
   test<const int*>(input_data);
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>(input_data);))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>(input_data);))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/max_element_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/max_element_comp.pass.cpp
@@ -70,6 +70,13 @@ TEST_FUNC constexpr bool test()
   test<const int*>(input_data);
   test_eq();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>(input_data);))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>(input_data);))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/min_element.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/min_element.pass.cpp
@@ -50,6 +50,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>>(input_data);
   test<const int*>(input_data);
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>(input_data);))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>(input_data);))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/min_element_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/min_element_comp.pass.cpp
@@ -70,6 +70,13 @@ TEST_FUNC constexpr bool test()
   test<const int*>(input_data);
   test_eq();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>(input_data);))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>(input_data);))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/minmax_element.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/minmax_element.pass.cpp
@@ -72,6 +72,13 @@ TEST_FUNC constexpr bool test()
   test<const int*>(input_data);
   test_eq();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>(input_data);))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>(input_data);))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/minmax_element_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/minmax_element_comp.pass.cpp
@@ -74,6 +74,13 @@ TEST_FUNC constexpr bool test()
   test<const int*>(input_data);
   test_eq();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>(input_data);))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>(input_data);))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/ranges.min.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/ranges.min.pass.cpp
@@ -223,6 +223,13 @@ TEST_FUNC constexpr void test_range()
     test_range_types<bidirectional_iterator<int*>>();
     test_range_types<random_access_iterator<int*>>();
     test_range_types<contiguous_iterator<int*>>();
+
+#if !TEST_COMPILER(NVRTC)
+    NV_IF_TARGET(NV_IS_HOST, (test_range_types<host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+    NV_IF_TARGET(NV_IS_DEVICE, (test_range_types<device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
   }
 
   int a[] = {7, 6, 9, 3, 5, 1, 2, 4};

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/ranges.min_element.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/ranges.min_element.pass.cpp
@@ -231,6 +231,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>>();
   test<const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   int a[] = {7, 6, 5, 3, 4, 2, 1, 8};
   test_iterators(a, a + 8);
   int a2[] = {7, 6, 5, 3, 4, 2, 1, 8};

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.nth.element/nth_element.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.nth.element/nth_element.pass.cpp
@@ -78,6 +78,13 @@ TEST_FUNC constexpr bool test()
   test<MoveOnly, random_access_iterator<MoveOnly*>>();
   test<MoveOnly, MoveOnly*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<int, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<int, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.nth.element/nth_element_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.nth.element/nth_element_comp.pass.cpp
@@ -79,6 +79,13 @@ TEST_FUNC constexpr bool test()
   test<MoveOnly, random_access_iterator<MoveOnly*>>();
   test<MoveOnly, MoveOnly*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<int, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<int, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/next_permutation.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/next_permutation.pass.cpp
@@ -69,6 +69,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<int*>>();
   test<int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/next_permutation_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/next_permutation_comp.pass.cpp
@@ -71,6 +71,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<int*>>();
   test<int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/prev_permutation.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/prev_permutation.pass.cpp
@@ -69,6 +69,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<int*>>();
   test<int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/prev_permutation_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/prev_permutation_comp.pass.cpp
@@ -71,6 +71,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<int*>>();
   test<int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/includes/includes.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/includes/includes.pass.cpp
@@ -83,6 +83,13 @@ TEST_FUNC constexpr bool test()
   test<const int*, random_access_iterator<const int*>>();
   test<const int*, const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>, host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>, device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/includes/includes_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/includes/includes_comp.pass.cpp
@@ -84,6 +84,13 @@ TEST_FUNC constexpr bool test()
   test<const int*, random_access_iterator<const int*>>();
   test<const int*, const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>, host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>, device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.difference/set_difference.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.difference/set_difference.pass.cpp
@@ -81,6 +81,13 @@ TEST_FUNC constexpr void test1()
   test2<T, bidirectional_iterator<const T*>>();
   test2<T, random_access_iterator<const T*>>();
   test2<T, const T*>();
+
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test2<T, host_only_iterator<const T*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test2<T, device_only_iterator<const T*>>();))
+#endif // TEST_CUDA_COMPILATION()
 }
 
 TEST_FUNC constexpr bool test()

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.difference/set_difference_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.difference/set_difference_comp.pass.cpp
@@ -84,6 +84,13 @@ TEST_FUNC constexpr void test1()
   test2<T, bidirectional_iterator<const T*>>();
   test2<T, random_access_iterator<const T*>>();
   test2<T, const T*>();
+
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test2<T, host_only_iterator<const T*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test2<T, device_only_iterator<const T*>>();))
+#endif // TEST_CUDA_COMPILATION()
 }
 
 TEST_FUNC constexpr bool test()

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.intersection/set_intersection.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.intersection/set_intersection.pass.cpp
@@ -81,6 +81,13 @@ TEST_FUNC constexpr void test1()
   test2<T, bidirectional_iterator<const T*>>();
   test2<T, random_access_iterator<const T*>>();
   test2<T, const T*>();
+
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test2<T, host_only_iterator<const T*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test2<T, device_only_iterator<const T*>>();))
+#endif // TEST_CUDA_COMPILATION()
 }
 
 TEST_FUNC constexpr bool test()

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.intersection/set_intersection_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.intersection/set_intersection_comp.pass.cpp
@@ -84,6 +84,13 @@ TEST_FUNC constexpr void test1()
   test2<T, bidirectional_iterator<const T*>>();
   test2<T, random_access_iterator<const T*>>();
   test2<T, const T*>();
+
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test2<T, host_only_iterator<const T*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test2<T, device_only_iterator<const T*>>();))
+#endif // TEST_CUDA_COMPILATION()
 }
 
 TEST_FUNC constexpr bool test()

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.symmetric.difference/set_symmetric_difference.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.symmetric.difference/set_symmetric_difference.pass.cpp
@@ -81,6 +81,13 @@ TEST_FUNC constexpr void test1()
   test2<T, bidirectional_iterator<const T*>>();
   test2<T, random_access_iterator<const T*>>();
   test2<T, const T*>();
+
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test2<T, host_only_iterator<const T*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test2<T, device_only_iterator<const T*>>();))
+#endif // TEST_CUDA_COMPILATION()
 }
 
 TEST_FUNC constexpr bool test()

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.symmetric.difference/set_symmetric_difference_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.symmetric.difference/set_symmetric_difference_comp.pass.cpp
@@ -84,6 +84,13 @@ TEST_FUNC constexpr void test1()
   test2<T, bidirectional_iterator<const T*>>();
   test2<T, random_access_iterator<const T*>>();
   test2<T, const T*>();
+
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test2<T, host_only_iterator<const T*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test2<T, device_only_iterator<const T*>>();))
+#endif // TEST_CUDA_COMPILATION()
 }
 
 TEST_FUNC constexpr bool test()

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.union/set_union.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.union/set_union.pass.cpp
@@ -81,6 +81,13 @@ TEST_FUNC constexpr void test1()
   test2<T, bidirectional_iterator<const T*>>();
   test2<T, random_access_iterator<const T*>>();
   test2<T, const T*>();
+
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test2<T, host_only_iterator<const T*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test2<T, device_only_iterator<const T*>>();))
+#endif // TEST_CUDA_COMPILATION()
 }
 
 TEST_FUNC constexpr bool test()

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.union/set_union_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.union/set_union_comp.pass.cpp
@@ -84,6 +84,13 @@ TEST_FUNC constexpr void test1()
   test2<T, bidirectional_iterator<const T*>>();
   test2<T, random_access_iterator<const T*>>();
   test2<T, const T*>();
+
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test2<T, host_only_iterator<const T*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test2<T, device_only_iterator<const T*>>();))
+#endif // TEST_CUDA_COMPILATION()
 }
 
 TEST_FUNC constexpr bool test()

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted.pass.cpp
@@ -182,6 +182,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>>();
   test<const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted_comp.pass.cpp
@@ -183,6 +183,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>>();
   test<const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted_until.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted_until.pass.cpp
@@ -182,6 +182,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>>();
   test<const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted_until_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted_until_comp.pass.cpp
@@ -183,6 +183,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>>();
   test<const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort.copy/partial_sort_copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort.copy/partial_sort_copy.pass.cpp
@@ -93,6 +93,13 @@ TEST_FUNC constexpr bool test()
     test<MoveOnly, int*, MoveOnly*>();
   }
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<int, host_only_iterator<int*>, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<int, device_only_iterator<int*>, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort.copy/partial_sort_copy_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort.copy/partial_sort_copy_comp.pass.cpp
@@ -8,6 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// CONSTEXPR_STEPS: 15000000
+
 // <algorithm>
 
 // template<InputIterator InIter, RandomAccessIterator RAIter, class Compare>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort.copy/partial_sort_copy_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort.copy/partial_sort_copy_comp.pass.cpp
@@ -99,6 +99,13 @@ TEST_FUNC constexpr bool test()
     test<MoveOnly, int*, MoveOnly*>();
   }
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<int, host_only_iterator<int*>, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<int, device_only_iterator<int*>, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort.pass.cpp
@@ -65,6 +65,13 @@ TEST_FUNC constexpr bool test()
   test<MoveOnly, random_access_iterator<MoveOnly*>>();
   test<MoveOnly, MoveOnly*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<int, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<int, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort.pass.cpp
@@ -8,6 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// CONSTEXPR_STEPS: 15000000
+
 // <algorithm>
 
 // template<RandomAccessIterator Iter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort_comp.pass.cpp
@@ -67,6 +67,13 @@ TEST_FUNC constexpr bool test()
   test<MoveOnly, random_access_iterator<MoveOnly*>>();
   test<MoveOnly, MoveOnly*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<int, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<int, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort_comp.pass.cpp
@@ -8,6 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// CONSTEXPR_STEPS: 15000000
+
 // <algorithm>
 
 // template<RandomAccessIterator Iter, StrictWeakOrder<auto, Iter::value_type> Compare>

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/accumulate/accumulate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/accumulate/accumulate.pass.cpp
@@ -50,6 +50,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>>();
   test<const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/accumulate/accumulate_op.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/accumulate/accumulate_op.pass.cpp
@@ -97,6 +97,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>>();
   test<const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   test_use_move();
 
 #ifdef _LIBCUDACXX_HAS_STRING

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/adjacent.difference/adjacent_difference.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/adjacent.difference/adjacent_difference.pass.cpp
@@ -121,6 +121,13 @@ TEST_FUNC constexpr bool test()
   test<const int*, random_access_iterator<int*>>();
   test<const int*, int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   X x[3] = {X(1), X(2), X(3)};
   Y y[3] = {Y(1), Y(2), Y(3)};
   cuda::std::adjacent_difference(x, x + 3, y);

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/adjacent.difference/adjacent_difference_op.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/adjacent.difference/adjacent_difference_op.pass.cpp
@@ -182,6 +182,13 @@ TEST_FUNC constexpr bool test()
   test<const int*, random_access_iterator<int*>>();
   test<const int*, int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   X x[3] = {X(1), X(2), X(3)};
   Y y[3] = {Y(1), Y(2), Y(3)};
   cuda::std::adjacent_difference(x, x + 3, y, cuda::std::minus<X>());

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/exclusive.scan/exclusive_scan.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/exclusive.scan/exclusive_scan.pass.cpp
@@ -109,6 +109,13 @@ TEST_FUNC constexpr bool test()
   test<const int*>();
   test<int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/exclusive.scan/exclusive_scan_init_op.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/exclusive.scan/exclusive_scan_init_op.pass.cpp
@@ -72,6 +72,13 @@ TEST_FUNC constexpr bool test()
   test<const int*>();
   test<int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   //  Make sure that the calculations are done using the init typedef
   {
     cuda::std::array<unsigned char, 10> v{};

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/inclusive_scan.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/inclusive_scan.pass.cpp
@@ -119,6 +119,13 @@ TEST_FUNC constexpr bool test()
   test<const int*>();
   test<int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/inclusive_scan_op.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/inclusive_scan_op.pass.cpp
@@ -123,6 +123,13 @@ TEST_FUNC constexpr bool test()
   test<const int*>();
   test<int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/inclusive_scan_op_init.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/inclusive_scan_op_init.pass.cpp
@@ -140,6 +140,13 @@ TEST_FUNC constexpr bool test()
   test<const int*>();
   test<int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inner.product/inner_product.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inner.product/inner_product.pass.cpp
@@ -79,6 +79,13 @@ TEST_FUNC constexpr bool test()
   test<const int*, random_access_iterator<const int*>>();
   test<const int*, const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inner.product/inner_product_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inner.product/inner_product_comp.pass.cpp
@@ -143,6 +143,13 @@ TEST_FUNC constexpr bool test()
   test<const int*, random_access_iterator<const int*>>();
   test<const int*, const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   test_use_move();
 
 #ifdef _LIBCUDACXX_HAS_STRING

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/numeric.iota/iota.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/numeric.iota/iota.pass.cpp
@@ -38,6 +38,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<int*>>();
   test<int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, test<host_only_iterator<int*>>();)
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, test<device_only_iterator<int*>>();)
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/partial.sum/partial_sum.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/partial.sum/partial_sum.pass.cpp
@@ -70,6 +70,13 @@ TEST_FUNC constexpr bool test()
   test<const int*, random_access_iterator<int*>>();
   test<const int*, int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/partial.sum/partial_sum_op.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/partial.sum/partial_sum_op.pass.cpp
@@ -132,6 +132,13 @@ TEST_FUNC constexpr bool test()
   test<const int*, random_access_iterator<int*>>();
   test<const int*, int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   test_use_move();
 
 #ifdef _LIBCUDACXX_HAS_STRING

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/reduce/reduce.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/reduce/reduce.pass.cpp
@@ -61,6 +61,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>>();
   test<const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/reduce/reduce_init.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/reduce/reduce_init.pass.cpp
@@ -64,6 +64,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>>();
   test<const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/reduce/reduce_init_op.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/reduce/reduce_init_op.pass.cpp
@@ -65,6 +65,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>>();
   test<const int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   //  Make sure the math is done using the correct type
   {
     auto v       = {1, 2, 3, 4, 5, 6, 7, 8};

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.exclusive.scan/transform_exclusive_scan_init_bop_uop.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.exclusive.scan/transform_exclusive_scan_init_bop_uop.pass.cpp
@@ -173,6 +173,13 @@ TEST_FUNC constexpr bool test()
   test<const int*>();
   test<int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.inclusive.scan/transform_inclusive_scan_bop_uop.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.inclusive.scan/transform_inclusive_scan_bop_uop.pass.cpp
@@ -139,6 +139,13 @@ TEST_FUNC constexpr bool test()
   test<const int*>();
   test<int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.inclusive.scan/transform_inclusive_scan_bop_uop_init.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.inclusive.scan/transform_inclusive_scan_bop_uop_init.pass.cpp
@@ -174,6 +174,13 @@ TEST_FUNC constexpr bool test()
   test<const int*>();
   test<int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/transform_reduce_iter_iter_init_bop_uop.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/transform_reduce_iter_iter_init_bop_uop.pass.cpp
@@ -127,6 +127,13 @@ TEST_FUNC constexpr bool test()
   test<const int*>();
   test<int*>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   //  Make sure the math is done using the correct type
   {
     auto v       = {1, 2, 3, 4, 5, 6};

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/transform_reduce_iter_iter_iter_init.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/transform_reduce_iter_iter_iter_init.pass.cpp
@@ -94,6 +94,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>, bidirectional_iterator<const unsigned int*>>();
   test<random_access_iterator<const int*>, random_access_iterator<const unsigned int*>>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<const unsigned int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<const unsigned int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   //  just plain pointers (const vs. non-const, too)
   test<const int*, const unsigned int*>();
   test<const int*, unsigned int*>();

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/transform_reduce_iter_iter_iter_init_op_op.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/transform_reduce_iter_iter_iter_init_op_op.pass.cpp
@@ -111,6 +111,13 @@ TEST_FUNC constexpr bool test()
   test<random_access_iterator<const int*>, bidirectional_iterator<const unsigned int*>>();
   test<random_access_iterator<const int*>, random_access_iterator<const unsigned int*>>();
 
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<host_only_iterator<const int*>, host_only_iterator<const unsigned int*>>();))
+#endif // !TEST_COMPILER(NVRTC)
+#if TEST_CUDA_COMPILATION()
+  NV_IF_TARGET(NV_IS_DEVICE, (test<device_only_iterator<const int*>, device_only_iterator<const unsigned int*>>();))
+#endif // TEST_CUDA_COMPILATION()
+
   //  just plain pointers (const vs. non-const, too)
   test<const int*, const unsigned int*>();
   test<const int*, unsigned int*>();

--- a/libcudacxx/test/support/test_iterators.h
+++ b/libcudacxx/test/support/test_iterators.h
@@ -2154,4 +2154,262 @@ public:
 };
 static_assert(cuda::std::random_access_iterator<advance_only_iterator>);
 
+#if !TEST_COMPILER(NVRTC)
+template <class It>
+class host_only_iterator
+{
+  It it_;
+
+  template <class U>
+  friend class host_only_iterator;
+
+public:
+  using iterator_category = cuda::std::random_access_iterator_tag;
+  using value_type        = typename cuda::std::iterator_traits<It>::value_type;
+  using difference_type   = typename cuda::std::iterator_traits<It>::difference_type;
+  using pointer           = It;
+  using reference         = typename cuda::std::iterator_traits<It>::reference;
+
+  constexpr host_only_iterator()
+      : it_()
+  {}
+  constexpr explicit host_only_iterator(It it)
+      : it_(it)
+  {}
+
+  template <class U>
+  constexpr host_only_iterator(const host_only_iterator<U>& u)
+      : it_(u.it_)
+  {}
+
+  template <class U, class = typename cuda::std::enable_if<cuda::std::is_default_constructible<U>::value>::type>
+  constexpr host_only_iterator(host_only_iterator<U>&& u)
+      : it_(u.it_)
+  {
+    u.it_ = U();
+  }
+
+  constexpr reference operator*() const
+  {
+    return *it_;
+  }
+  constexpr reference operator[](difference_type n) const
+  {
+    return it_[n];
+  }
+
+  constexpr host_only_iterator& operator++()
+  {
+    ++it_;
+    return *this;
+  }
+  constexpr host_only_iterator& operator--()
+  {
+    --it_;
+    return *this;
+  }
+  constexpr host_only_iterator operator++(int)
+  {
+    return host_only_iterator(it_++);
+  }
+  constexpr host_only_iterator operator--(int)
+  {
+    return host_only_iterator(it_--);
+  }
+
+  constexpr host_only_iterator& operator+=(difference_type n)
+  {
+    it_ += n;
+    return *this;
+  }
+  constexpr host_only_iterator& operator-=(difference_type n)
+  {
+    it_ -= n;
+    return *this;
+  }
+  friend constexpr host_only_iterator operator+(host_only_iterator x, difference_type n)
+  {
+    x += n;
+    return x;
+  }
+  friend constexpr host_only_iterator operator+(difference_type n, host_only_iterator x)
+  {
+    x += n;
+    return x;
+  }
+  friend constexpr host_only_iterator operator-(host_only_iterator x, difference_type n)
+  {
+    x -= n;
+    return x;
+  }
+  friend constexpr difference_type operator-(host_only_iterator x, host_only_iterator y)
+  {
+    return x.it_ - y.it_;
+  }
+
+  friend constexpr bool operator==(const host_only_iterator& x, const host_only_iterator& y)
+  {
+    return x.it_ == y.it_;
+  }
+  friend constexpr bool operator!=(const host_only_iterator& x, const host_only_iterator& y)
+  {
+    return x.it_ != y.it_;
+  }
+  friend constexpr bool operator<(const host_only_iterator& x, const host_only_iterator& y)
+  {
+    return x.it_ < y.it_;
+  }
+  friend constexpr bool operator<=(const host_only_iterator& x, const host_only_iterator& y)
+  {
+    return x.it_ <= y.it_;
+  }
+  friend constexpr bool operator>(const host_only_iterator& x, const host_only_iterator& y)
+  {
+    return x.it_ > y.it_;
+  }
+  friend constexpr bool operator>=(const host_only_iterator& x, const host_only_iterator& y)
+  {
+    return x.it_ >= y.it_;
+  }
+
+  friend constexpr It base(const host_only_iterator& i)
+  {
+    return i.it_;
+  }
+
+  template <class T>
+  void operator,(T const&) = delete;
+};
+static_assert(cuda::std::random_access_iterator<host_only_iterator<int*>>);
+#endif // !TEST_COMPILER(NVRTC)
+
+#if TEST_CUDA_COMPILATION()
+template <class It>
+class device_only_iterator
+{
+  It it_;
+
+  template <class U>
+  friend class device_only_iterator;
+
+public:
+  using iterator_category = cuda::std::random_access_iterator_tag;
+  using value_type        = typename cuda::std::iterator_traits<It>::value_type;
+  using difference_type   = typename cuda::std::iterator_traits<It>::difference_type;
+  using pointer           = It;
+  using reference         = typename cuda::std::iterator_traits<It>::reference;
+
+  TEST_DEVICE_FUNC constexpr device_only_iterator()
+      : it_()
+  {}
+  TEST_DEVICE_FUNC constexpr explicit device_only_iterator(It it)
+      : it_(it)
+  {}
+
+  template <class U>
+  TEST_DEVICE_FUNC constexpr device_only_iterator(const device_only_iterator<U>& u)
+      : it_(u.it_)
+  {}
+
+  template <class U, class = typename cuda::std::enable_if<cuda::std::is_default_constructible<U>::value>::type>
+  TEST_DEVICE_FUNC constexpr device_only_iterator(device_only_iterator<U>&& u)
+      : it_(u.it_)
+  {
+    u.it_ = U();
+  }
+
+  TEST_DEVICE_FUNC constexpr reference operator*() const
+  {
+    return *it_;
+  }
+  TEST_DEVICE_FUNC constexpr reference operator[](difference_type n) const
+  {
+    return it_[n];
+  }
+
+  TEST_DEVICE_FUNC constexpr device_only_iterator& operator++()
+  {
+    ++it_;
+    return *this;
+  }
+  TEST_DEVICE_FUNC constexpr device_only_iterator& operator--()
+  {
+    --it_;
+    return *this;
+  }
+  TEST_DEVICE_FUNC constexpr device_only_iterator operator++(int)
+  {
+    return device_only_iterator(it_++);
+  }
+  TEST_DEVICE_FUNC constexpr device_only_iterator operator--(int)
+  {
+    return device_only_iterator(it_--);
+  }
+
+  TEST_DEVICE_FUNC constexpr device_only_iterator& operator+=(difference_type n)
+  {
+    it_ += n;
+    return *this;
+  }
+  TEST_DEVICE_FUNC constexpr device_only_iterator& operator-=(difference_type n)
+  {
+    it_ -= n;
+    return *this;
+  }
+  TEST_DEVICE_FUNC friend constexpr device_only_iterator operator+(device_only_iterator x, difference_type n)
+  {
+    x += n;
+    return x;
+  }
+  TEST_DEVICE_FUNC friend constexpr device_only_iterator operator+(difference_type n, device_only_iterator x)
+  {
+    x += n;
+    return x;
+  }
+  TEST_DEVICE_FUNC friend constexpr device_only_iterator operator-(device_only_iterator x, difference_type n)
+  {
+    x -= n;
+    return x;
+  }
+  TEST_DEVICE_FUNC friend constexpr difference_type operator-(device_only_iterator x, device_only_iterator y)
+  {
+    return x.it_ - y.it_;
+  }
+
+  TEST_DEVICE_FUNC friend constexpr bool operator==(const device_only_iterator& x, const device_only_iterator& y)
+  {
+    return x.it_ == y.it_;
+  }
+  TEST_DEVICE_FUNC friend constexpr bool operator!=(const device_only_iterator& x, const device_only_iterator& y)
+  {
+    return x.it_ != y.it_;
+  }
+  TEST_DEVICE_FUNC friend constexpr bool operator<(const device_only_iterator& x, const device_only_iterator& y)
+  {
+    return x.it_ < y.it_;
+  }
+  TEST_DEVICE_FUNC friend constexpr bool operator<=(const device_only_iterator& x, const device_only_iterator& y)
+  {
+    return x.it_ <= y.it_;
+  }
+  TEST_DEVICE_FUNC friend constexpr bool operator>(const device_only_iterator& x, const device_only_iterator& y)
+  {
+    return x.it_ > y.it_;
+  }
+  TEST_DEVICE_FUNC friend constexpr bool operator>=(const device_only_iterator& x, const device_only_iterator& y)
+  {
+    return x.it_ >= y.it_;
+  }
+
+  TEST_DEVICE_FUNC friend constexpr It base(const device_only_iterator& i)
+  {
+    return i.it_;
+  }
+
+  template <class T>
+  void operator,(T const&) = delete;
+};
+static_assert(cuda::std::random_access_iterator<device_only_iterator<int*>>);
+#endif // TEST_CUDA_COMPILATION()
+
 #endif // SUPPORT_TEST_ITERATORS_H

--- a/libcudacxx/test/support/test_macros.h
+++ b/libcudacxx/test/support/test_macros.h
@@ -16,6 +16,7 @@
 // Use the CCCL compiler detection
 #define TEST_COMPILER(...)      _CCCL_COMPILER(__VA_ARGS__)
 #define TEST_CUDA_COMPILER(...) _CCCL_CUDA_COMPILER(__VA_ARGS__)
+#define TEST_CUDA_COMPILATION() _CCCL_CUDA_COMPILATION()
 
 // Use the CCCL diagnostic suppression
 #define TEST_DIAG_SUPPRESS_CLANG(...) _CCCL_DIAG_SUPPRESS_CLANG(__VA_ARGS__)


### PR DESCRIPTION
We want to make sure that the algorithms in `<cuda/std/numeric>` and `<cuda/std/algorithm>` work with host / device only types

Note: Not all of our tests are as nicely structured as the one I changed. I will update those tests in a followup but this seems already like a nice improvement

Fixes #8469