### PR TITLE
[cudax] Move groups to groups header

### DIFF
--- a/cudax/include/cuda/experimental/__group/concepts.cuh
+++ b/cudax/include/cuda/experimental/__group/concepts.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_EXPERIMENTAL___HIERARCHY_CONCEPTS_CUH
-#define _CUDA_EXPERIMENTAL___HIERARCHY_CONCEPTS_CUH
+#ifndef _CUDA_EXPERIMENTAL___GROUP_CONCEPTS_CUH
+#define _CUDA_EXPERIMENTAL___GROUP_CONCEPTS_CUH
 
 #include <cuda/std/detail/__config>
 
@@ -68,4 +68,4 @@ _CCCL_CONCEPT __has_sync_aligned = _CCCL_REQUIRES_EXPR(
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDA_EXPERIMENTAL___HIERARCHY_CONCEPTS_CUH
+#endif // _CUDA_EXPERIMENTAL___GROUP_CONCEPTS_CUH

--- a/cudax/include/cuda/experimental/__group/fwd.cuh
+++ b/cudax/include/cuda/experimental/__group/fwd.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_EXPERIMENTAL___HIERARCHY_FWD_CUH
-#define _CUDA_EXPERIMENTAL___HIERARCHY_FWD_CUH
+#ifndef _CUDA_EXPERIMENTAL___GROUP_FWD_CUH
+#define _CUDA_EXPERIMENTAL___GROUP_FWD_CUH
 
 #include <cuda/std/detail/__config>
 
@@ -108,4 +108,4 @@ inline constexpr bool __is_barrier_synchronizer<__barrier_synchronizer<_Unit, _L
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDA_EXPERIMENTAL___HIERARCHY_FWD_CUH
+#endif // _CUDA_EXPERIMENTAL___GROUP_FWD_CUH

--- a/cudax/include/cuda/experimental/__group/group.cuh
+++ b/cudax/include/cuda/experimental/__group/group.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_EXPERIMENTAL___HIERARCHY_GROUPS_CUH
-#define _CUDA_EXPERIMENTAL___HIERARCHY_GROUPS_CUH
+#ifndef _CUDA_EXPERIMENTAL___GROUP_GROUP_CUH
+#define _CUDA_EXPERIMENTAL___GROUP_GROUP_CUH
 
 #include <cuda/std/detail/__config>
 
@@ -32,11 +32,11 @@
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/span>
 
-#include <cuda/experimental/__hierarchy/concepts.cuh>
-#include <cuda/experimental/__hierarchy/fwd.cuh>
-#include <cuda/experimental/__hierarchy/mappings.cuh>
-#include <cuda/experimental/__hierarchy/synchronizers.cuh>
-#include <cuda/experimental/__hierarchy/this_group.cuh>
+#include <cuda/experimental/__group/concepts.cuh>
+#include <cuda/experimental/__group/fwd.cuh>
+#include <cuda/experimental/__group/mapping/group_by.cuh>
+#include <cuda/experimental/__group/synchronizers.cuh>
+#include <cuda/experimental/__group/this_group.cuh>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -154,4 +154,4 @@ _CCCL_HOST_DEVICE thread_group(const _Level&, const group_by<_Np>&, const _Hiera
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDA_EXPERIMENTAL___HIERARCHY_GROUPS_CUH
+#endif // _CUDA_EXPERIMENTAL___GROUP_GROUP_CUH

--- a/cudax/include/cuda/experimental/__group/implicit_hierarchy.cuh
+++ b/cudax/include/cuda/experimental/__group/implicit_hierarchy.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_EXPERIMENTAL___HIERARCHY_IMPLICIT_HIERARCHY_CUH
-#define _CUDA_EXPERIMENTAL___HIERARCHY_IMPLICIT_HIERARCHY_CUH
+#ifndef _CUDA_EXPERIMENTAL___GROUP_IMPLICIT_HIERARCHY_CUH
+#define _CUDA_EXPERIMENTAL___GROUP_IMPLICIT_HIERARCHY_CUH
 
 #include <cuda/std/detail/__config>
 
@@ -23,7 +23,7 @@
 
 #include <cuda/hierarchy>
 
-#include <cuda/experimental/__hierarchy/fwd.cuh>
+#include <cuda/experimental/__group/fwd.cuh>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -45,4 +45,4 @@ namespace cuda::experimental
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDA_EXPERIMENTAL___HIERARCHY_IMPLICIT_HIERARCHY_CUH
+#endif // _CUDA_EXPERIMENTAL___GROUP_IMPLICIT_HIERARCHY_CUH

--- a/cudax/include/cuda/experimental/__group/mapping/group_by.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/group_by.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_EXPERIMENTAL___HIERARCHY_MAPPINGS_CUH
-#define _CUDA_EXPERIMENTAL___HIERARCHY_MAPPINGS_CUH
+#ifndef _CUDA_EXPERIMENTAL___GROUP_MAPPING_GROUP_BY_CUH
+#define _CUDA_EXPERIMENTAL___GROUP_MAPPING_GROUP_BY_CUH
 
 #include <cuda/std/detail/__config>
 
@@ -26,7 +26,7 @@
 #include <cuda/std/__fwd/span.h>
 #include <cuda/std/__utility/cmp.h>
 
-#include <cuda/experimental/__hierarchy/fwd.cuh>
+#include <cuda/experimental/__group/fwd.cuh>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -361,4 +361,4 @@ _CCCL_DEVICE_API void __check_mapping_result(const _MappingResult& __mapping_res
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDA_EXPERIMENTAL___HIERARCHY_MAPPINGS_CUH
+#endif // _CUDA_EXPERIMENTAL___GROUP_MAPPING_GROUP_BY_CUH

--- a/cudax/include/cuda/experimental/__group/queries.cuh
+++ b/cudax/include/cuda/experimental/__group/queries.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_EXPERIMENTAL___HIERARCHY_QUERIES_CUH
-#define _CUDA_EXPERIMENTAL___HIERARCHY_QUERIES_CUH
+#ifndef _CUDA_EXPERIMENTAL___GROUP_QUERIES_CUH
+#define _CUDA_EXPERIMENTAL___GROUP_QUERIES_CUH
 
 #include <cuda/std/detail/__config>
 
@@ -120,4 +120,4 @@ template <class _Unit, class _Group>
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDA_EXPERIMENTAL___HIERARCHY_QUERIES_CUH
+#endif // _CUDA_EXPERIMENTAL___GROUP_QUERIES_CUH

--- a/cudax/include/cuda/experimental/__group/synchronizers.cuh
+++ b/cudax/include/cuda/experimental/__group/synchronizers.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_EXPERIMENTAL___HIERARCHY_SYNCHRONIZERS_CUH
-#define _CUDA_EXPERIMENTAL___HIERARCHY_SYNCHRONIZERS_CUH
+#ifndef _CUDA_EXPERIMENTAL___GROUP_SYNCHRONIZERS_CUH
+#define _CUDA_EXPERIMENTAL___GROUP_SYNCHRONIZERS_CUH
 
 #include <cuda/std/detail/__config>
 
@@ -32,8 +32,8 @@
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/span>
 
-#include <cuda/experimental/__hierarchy/concepts.cuh>
-#include <cuda/experimental/__hierarchy/fwd.cuh>
+#include <cuda/experimental/__group/concepts.cuh>
+#include <cuda/experimental/__group/fwd.cuh>
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/cudax/include/cuda/experimental/__group/this_group.cuh
+++ b/cudax/include/cuda/experimental/__group/this_group.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_EXPERIMENTAL___THIS_GROUP_CUH
-#define _CUDA_EXPERIMENTAL___THIS_GROUP_CUH
+#ifndef _CUDA_EXPERIMENTAL___GROUP_THIS_GROUP_CUH
+#define _CUDA_EXPERIMENTAL___GROUP_THIS_GROUP_CUH
 
 #include <cuda/std/detail/__config>
 
@@ -27,8 +27,8 @@
 #include <cuda/std/__type_traits/is_integer.h>
 #include <cuda/std/__type_traits/is_same.h>
 
-#include <cuda/experimental/__hierarchy/fwd.cuh>
-#include <cuda/experimental/__hierarchy/implicit_hierarchy.cuh>
+#include <cuda/experimental/__group/fwd.cuh>
+#include <cuda/experimental/__group/implicit_hierarchy.cuh>
 
 #if _CCCL_HAS_COOPERATIVE_GROUPS()
 #  include <cooperative_groups.h>
@@ -548,4 +548,4 @@ _CCCL_HOST_DEVICE this_grid(const ::cooperative_groups::grid_group&) -> this_gri
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDA_EXPERIMENTAL___THIS_GROUP_CUH
+#endif // _CUDA_EXPERIMENTAL___GROUP_THIS_GROUP_CUH

--- a/cudax/include/cuda/experimental/group.cuh
+++ b/cudax/include/cuda/experimental/group.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_EXPERIMENTAL_HIERARCHY
-#define _CUDA_EXPERIMENTAL_HIERARCHY
+#ifndef _CUDA_EXPERIMENTAL_GROUP
+#define _CUDA_EXPERIMENTAL_GROUP
 
 #include <cuda/std/detail/__config>
 
@@ -21,13 +21,13 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/experimental/__hierarchy/concepts.cuh>
-#include <cuda/experimental/__hierarchy/fwd.cuh>
-#include <cuda/experimental/__hierarchy/groups.cuh>
-#include <cuda/experimental/__hierarchy/implicit_hierarchy.cuh>
-#include <cuda/experimental/__hierarchy/mappings.cuh>
-#include <cuda/experimental/__hierarchy/queries.cuh>
-#include <cuda/experimental/__hierarchy/synchronizers.cuh>
-#include <cuda/experimental/__hierarchy/this_group.cuh>
+#include <cuda/experimental/__group/concepts.cuh>
+#include <cuda/experimental/__group/fwd.cuh>
+#include <cuda/experimental/__group/group.cuh>
+#include <cuda/experimental/__group/implicit_hierarchy.cuh>
+#include <cuda/experimental/__group/mapping/group_by.cuh>
+#include <cuda/experimental/__group/queries.cuh>
+#include <cuda/experimental/__group/synchronizers.cuh>
+#include <cuda/experimental/__group/this_group.cuh>
 
-#endif // _CUDA_EXPERIMENTAL_HIERARCHY
+#endif // _CUDA_EXPERIMENTAL_GROUP

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -127,11 +127,11 @@ cudax_add_catch2_test(test_target algorithm
     algorithm/copy.cu
 )
 
-cudax_add_catch2_test(test_target hierarchy_groups
-    hierarchy/group.cu
-    hierarchy/mapping/group_by.cu
+cudax_add_catch2_test(test_target group
+    group/group.cu
+    group/mapping/group_by.cu
 )
-target_compile_definitions(${test_target} PUBLIC _CUDAX_HIERARCHY)
+target_compile_definitions(${test_target} PUBLIC _CUDAX_GROUP)
 
 if (cudax_ENABLE_CUFILE)
   cudax_add_catch2_test(test_target cufile.driver_attributes

--- a/cudax/test/group/group.cu
+++ b/cudax/test/group/group.cu
@@ -21,7 +21,7 @@
 #include <cuda/std/utility>
 #include <cuda/stream>
 
-#include <cuda/experimental/hierarchy.cuh>
+#include <cuda/experimental/group.cuh>
 
 #include <cooperative_groups.h>
 

--- a/cudax/test/group/mapping/group_by.cu
+++ b/cudax/test/group/mapping/group_by.cu
@@ -16,7 +16,7 @@
 #include <cuda/std/utility>
 #include <cuda/stream>
 
-#include <cuda/experimental/hierarchy.cuh>
+#include <cuda/experimental/group.cuh>
 
 #include "testing.cuh"
 

--- a/docs/cudax/Doxyfile
+++ b/docs/cudax/Doxyfile
@@ -15,7 +15,7 @@ INPUT                  = ../../cudax/include/cuda/experimental/__copy_bytes \
                          ../../cudax/include/cuda/experimental/__device \
                          ../../cudax/include/cuda/experimental/graph.cuh \
                          ../../cudax/include/cuda/experimental/__graph \
-                         ../../cudax/include/cuda/experimental/__hierarchy \
+                         ../../cudax/include/cuda/experimental/__group \
                          ../../cudax/include/cuda/experimental/__launch \
                          ../../cudax/include/cuda/experimental/__places \
                          ../../cudax/include/cuda/experimental/__places/exec \

--- a/libcudacxx/include/cuda/__hierarchy/hierarchy_level_base.h
+++ b/libcudacxx/include/cuda/__hierarchy/hierarchy_level_base.h
@@ -35,11 +35,11 @@
 #  include <cuda/std/__mdspan/extents.h>
 #  include <cuda/std/__type_traits/is_integer.h>
 
-#  if defined(_CUDAX_HIERARCHY)
-#    include <cuda/experimental/__hierarchy/concepts.cuh>
-#    include <cuda/experimental/__hierarchy/fwd.cuh>
-#    include <cuda/experimental/__hierarchy/queries.cuh>
-#  endif // _CUDAX_HIERARCHY
+#  if defined(_CUDAX_GROUP)
+#    include <cuda/experimental/__group/concepts.cuh>
+#    include <cuda/experimental/__group/fwd.cuh>
+#    include <cuda/experimental/__group/queries.cuh>
+#  endif // _CUDAX_GROUP
 
 #  include <cuda/std/__cccl/prologue.h>
 
@@ -170,7 +170,7 @@ struct hierarchy_level_base
   }
 #  endif // _CCCL_CUDA_COMPILATION()
 
-#  if defined(_CUDAX_HIERARCHY)
+#  if defined(_CUDAX_GROUP)
 #    if _CCCL_CUDA_COMPILATION()
 
   _CCCL_TEMPLATE(class _Group)
@@ -223,7 +223,7 @@ struct hierarchy_level_base
     return ::cuda::experimental::__is_part_of_group<_Level>(__group);
   }
 #    endif // _CCCL_CUDA_COMPILATION()
-#  endif // _CUDAX_HIERARCHY
+#  endif // _CUDAX_GROUP
 
 private:
   template <class>

--- a/libcudacxx/include/cuda/__hierarchy/native_hierarchy_level_base.h
+++ b/libcudacxx/include/cuda/__hierarchy/native_hierarchy_level_base.h
@@ -73,10 +73,10 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __native_hierarchy_level_base : hierarchy_leve
   using __base_type::rank;
   using __base_type::rank_as;
 
-#    if defined(_CUDAX_HIERARCHY)
+#    if defined(_CUDAX_GROUP)
   using __base_type::is_part_of;
   using __base_type::is_root_rank;
-#    endif // _CUDAX_HIERARCHY
+#    endif // _CUDAX_GROUP
 
   _CCCL_TEMPLATE(class _InLevel)
   _CCCL_REQUIRES(__is_native_hierarchy_level_v<_InLevel>)


### PR DESCRIPTION
I think groups deserve their own header since they introduce a lot of code, so I'd like to put them in `<cuda/experimental/group.h>` and `<cuda/group>` in the future.

This PR is a follow-up to #8500.