### PR TITLE
[CUB] Delegate large segments to Multi-CTA Implementation in `DeviceSegmentedTopK`

### DIFF
--- a/cub/cub/agent/agent_batched_topk.cuh
+++ b/cub/cub/agent/agent_batched_topk.cuh
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #pragma once

--- a/cub/cub/agent/agent_batched_topk.cuh
+++ b/cub/cub/agent/agent_batched_topk.cuh
@@ -23,11 +23,26 @@
 #include <cub/util_type.cuh>
 
 #include <cuda/__cmath/ceil_div.h>
+#include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
 
 namespace detail::batched_topk
 {
+// Atomic counters used by the small-segment kernel to (a) enqueue large segments into the large-segment work queue
+// and (b) elect the last block to run the epilogue scan over the queued tile counts. `alignas(128)` isolates each
+// counter on its own cache line for performance.
+struct alignas(128) batched_topk_counters
+{
+  // Number of segments enqueued in the large-segment work queue. Atomically incremented (by 1) by the first thread
+  // of each block that decides its segment is large.
+  unsigned long long large_segments_count;
+
+  // Block retirement counter. Each block atomically increments by 1 when it has finished processing its segment, and
+  // the block that observes `gridDim.x - 1` runs the epilogue on the queued large segments tile counts.
+  alignas(128) unsigned retirement_count;
+};
+
 template <typename PolicyGetter, // TODO(bgruber): pass worker_policy as NTTP in C++20
           typename KeyInputItItT,
           typename KeyOutputItItT,
@@ -54,13 +69,12 @@ struct agent_batched_topk_worker_per_segment
 
   static constexpr worker_policy active_policy = PolicyGetter{}();
 
-  static constexpr int block_threads             = active_policy.block_threads;
-  static constexpr int items_per_thread          = active_policy.items_per_thread;
-  static constexpr int tile_size                 = block_threads * items_per_thread;
-  static constexpr int epilogue_items_per_thread = active_policy.epilogue_items_per_thread;
-  static constexpr int epilogue_tile_size        = block_threads * epilogue_items_per_thread;
-  // TODO (elstehle): This is just a placeholder for now, we will need to specialize this for the large segment agent.
-  static constexpr int large_segment_agent_tile_size = tile_size;
+  static constexpr int block_threads                 = active_policy.block_threads;
+  static constexpr int items_per_thread              = active_policy.items_per_thread;
+  static constexpr int tile_size                     = block_threads * items_per_thread;
+  static constexpr int epilogue_items_per_thread     = active_policy.epilogue.items_per_thread;
+  static constexpr int epilogue_tile_size            = block_threads * epilogue_items_per_thread;
+  static constexpr int large_segment_agent_tile_size = active_policy.epilogue.multi_worker_tile_size;
 
   static constexpr bool only_small_segments = params::static_max_value_v<SegmentSizeParameterT> <= tile_size;
 
@@ -81,10 +95,10 @@ struct agent_batched_topk_worker_per_segment
   using block_store_vals_t = BlockStore<value_t, block_threads, items_per_thread, active_policy.store_algorithm>;
 
   using block_load_epilogue_t =
-    BlockLoad<segment_size_val_t, block_threads, epilogue_items_per_thread, active_policy.epilogue_load_algorithm>;
-  using block_scan_epilogue_t = BlockScan<int, block_threads, active_policy.epilogue_scan_algorithm>;
+    BlockLoad<segment_size_val_t, block_threads, epilogue_items_per_thread, active_policy.epilogue.load_algorithm>;
+  using block_scan_epilogue_t = BlockScan<int, block_threads, active_policy.epilogue.scan_algorithm>;
   using block_store_epilogue_t =
-    BlockStore<segment_size_val_t, block_threads, epilogue_items_per_thread, active_policy.epilogue_store_algorithm>;
+    BlockStore<segment_size_val_t, block_threads, epilogue_items_per_thread, active_policy.epilogue.store_algorithm>;
 
   // -------------------------------------------------------------------------
   // Shared Memory Storage
@@ -118,9 +132,7 @@ struct agent_batched_topk_worker_per_segment
   KParameterT k_param;
   SelectDirectionParameterT select_directions;
   NumSegmentsParameterT num_segments;
-  num_segments_val_t* d_large_segments_counter;
-  // Currently we use int for segment_id = blockIdx.x, so int has be enough.
-  ::cuda::std::uint32_t* d_retirement_counter;
+  batched_topk_counters* d_counters;
   num_segments_val_t* d_large_segments_ids;
   // Assuming the large segment agent will also use int for tile_id = blockIdx.x.
   ::cuda::std::int64_t* d_large_segments_tile_offsets;
@@ -137,8 +149,7 @@ struct agent_batched_topk_worker_per_segment
     KParameterT k_param,
     SelectDirectionParameterT select_directions,
     NumSegmentsParameterT num_segments,
-    num_segments_val_t* d_large_segments_counter,
-    ::cuda::std::uint32_t* d_retirement_counter,
+    batched_topk_counters* d_counters,
     num_segments_val_t* d_large_segments_ids,
     ::cuda::std::int64_t* d_large_segments_tile_offsets)
       : temp_storage(temp_storage.Alias())
@@ -150,8 +161,7 @@ struct agent_batched_topk_worker_per_segment
       , k_param(k_param)
       , select_directions(select_directions)
       , num_segments(num_segments)
-      , d_large_segments_counter(d_large_segments_counter)
-      , d_retirement_counter(d_retirement_counter)
+      , d_counters(d_counters)
       , d_large_segments_ids(d_large_segments_ids)
       , d_large_segments_tile_offsets(d_large_segments_tile_offsets)
   {}
@@ -179,10 +189,10 @@ struct agent_batched_topk_worker_per_segment
       if (threadIdx.x == 0u)
       {
         // Add to large segment queue
-        const auto large_segment_queue_idx            = atomicAdd(d_large_segments_counter, num_segments_val_t{1});
+        const auto large_segment_queue_idx            = atomicAdd(&d_counters->large_segments_count, 1ull);
         d_large_segments_ids[large_segment_queue_idx] = static_cast<num_segments_val_t>(segment_id);
         d_large_segments_tile_offsets[large_segment_queue_idx] =
-          static_cast<::cuda::std::int64_t>(::cuda::std::ceil_div(segment_size, large_segment_agent_tile_size));
+          static_cast<::cuda::std::int64_t>(::cuda::ceil_div(segment_size, large_segment_agent_tile_size));
       }
     }
     else
@@ -301,7 +311,7 @@ struct agent_batched_topk_worker_per_segment
       if (threadIdx.x == 0u)
       {
         __threadfence();
-        const auto retirement_count = atomicAdd(d_retirement_counter, 1u);
+        const auto retirement_count = atomicAdd(&d_counters->retirement_count, 1u);
         is_last_block               = retirement_count == (gridDim.x - 1u);
       }
       // This sync also makes sure that the shared memory can be reused.
@@ -310,7 +320,7 @@ struct agent_batched_topk_worker_per_segment
       {
         return;
       }
-      const auto num_large_segments = *d_large_segments_counter;
+      const auto num_large_segments = d_counters->large_segments_count;
       // For tracking the running total across tiles (loop iterations).
       const auto prefix_callback_op =
         [running_total = segment_size_val_t{0}](segment_size_val_t block_aggregate) mutable {

--- a/cub/cub/agent/agent_batched_topk.cuh
+++ b/cub/cub/agent/agent_batched_topk.cuh
@@ -22,6 +22,8 @@
 #include <cub/device/dispatch/tuning/tuning_batched_topk.cuh>
 #include <cub/util_type.cuh>
 
+#include <cuda/__cmath/ceil_div.h>
+
 CUB_NAMESPACE_BEGIN
 
 namespace detail::batched_topk
@@ -58,6 +60,11 @@ struct agent_batched_topk_worker_per_segment
   static constexpr int tile_size        = block_threads * items_per_thread;
   static constexpr int epilogue_items_per_thread = active_policy.epilogue_items_per_thread;
   static constexpr int epilogue_tile_size        = block_threads * epilogue_items_per_thread;
+  // TODO (elstehle): This is just a placeholder for now, we will need to specialize this for the large segment agent.
+  static constexpr int large_segment_agent_tile_size = tile_size;
+
+  static constexpr bool any_small_segments  = params::static_min_value_v<SegmentSizeParameterT> <= tile_size;
+  static constexpr bool only_small_segments = params::static_max_value_v<SegmentSizeParameterT> <= tile_size;
 
   // Check if we are dealing with keys-only or key-value pairs
   static constexpr bool is_keys_only = ::cuda::std::is_same_v<value_t, cub::NullType>;
@@ -113,16 +120,12 @@ struct agent_batched_topk_worker_per_segment
   KParameterT k_param;
   SelectDirectionParameterT select_directions;
   NumSegmentsParameterT num_segments;
-  // Currently we use int for segment_id, so int has be enough for these atomic counters.
-  int* d_retirement_count;
-  int* d_large_segment_queue;
-  key_it_t* d_key_large_segments_it;
-  key_it_t* d_key_large_segments_out_it;
-  value_it_t* d_value_large_segments_it;
-  value_it_t* d_value_large_segments_out_it;
-  [[maybe_unused]] segment_size_val_t* d_large_segments_sizes;
-  [[maybe_unused]] k_val_t* d_large_segments_k;
-  [[maybe_unused]] select_direction_val_t* d_large_segments_select_directions;
+  // Currently we use int for segment_id = blockIdx.x, so int has be enough for all three.
+  int* d_large_segments_counter;
+  int* d_retirement_counter;
+  int* d_large_segments_ids;
+  // Assuming the large segment agent will also use int for tile_id = blockIdx.x.
+  int* d_large_segments_tile_offsets;
   // -------------------------------------------------------------------------
   // Constructor
   // -------------------------------------------------------------------------
@@ -136,15 +139,10 @@ struct agent_batched_topk_worker_per_segment
     KParameterT k_param,
     SelectDirectionParameterT select_directions,
     NumSegmentsParameterT num_segments,
-    int* d_retirement_count,
-    int* d_large_segment_queue,
-    key_it_t* d_key_large_segments_it,
-    key_it_t* d_key_large_segments_out_it,
-    value_it_t* d_value_large_segments_it,
-    value_it_t* d_value_large_segments_out_it,
-    segment_size_val_t* d_large_segments_sizes,
-    k_val_t* d_large_segments_k,
-    select_direction_val_t* d_large_segments_select_directions)
+    int* d_large_segments_counter,
+    int* d_retirement_counter,
+    int* d_large_segments_ids,
+    int* d_large_segments_tile_offsets)
       : temp_storage(temp_storage.Alias())
       , d_key_segments_it(d_key_segments_it)
       , d_key_segments_out_it(d_key_segments_out_it)
@@ -154,15 +152,10 @@ struct agent_batched_topk_worker_per_segment
       , k_param(k_param)
       , select_directions(select_directions)
       , num_segments(num_segments)
-      , d_retirement_count(d_retirement_count)
-      , d_large_segment_queue(d_large_segment_queue)
-      , d_key_large_segments_it(d_key_large_segments_it)
-      , d_key_large_segments_out_it(d_key_large_segments_out_it)
-      , d_value_large_segments_it(d_value_large_segments_it)
-      , d_value_large_segments_out_it(d_value_large_segments_out_it)
-      , d_large_segments_sizes(d_large_segments_sizes)
-      , d_large_segments_k(d_large_segments_k)
-      , d_large_segments_select_directions(d_large_segments_select_directions)
+      , d_large_segments_counter(d_large_segments_counter)
+      , d_retirement_counter(d_retirement_counter)
+      , d_large_segments_ids(d_large_segments_ids)
+      , d_large_segments_tile_offsets(d_large_segments_tile_offsets)
   {}
 
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void Process()
@@ -182,37 +175,19 @@ struct agent_batched_topk_worker_per_segment
 
     // Resolve Segment Parameters
     const auto segment_size = segment_sizes.get_param(segment_id);
-    if (params::static_min_value_v<SegmentSizeParameterT> > tile_size
-        || (params::static_max_value_v<SegmentSizeParameterT> > tile_size && segment_size > tile_size))
+    if (!any_small_segments || (!only_small_segments && segment_size > tile_size))
     {
       // Enqueue large segment
       if (threadIdx.x == 0u)
       {
         // Add to large segment queue
-        const int large_segment_queue_index = atomicAdd(d_large_segment_queue, 1);
-        // TODO (pauleonix): Should we write out the segment_id instead of all these parameters?
-        if constexpr (params::is_per_segment_param_v<SegmentSizeParameterT>)
-        {
-          d_large_segments_sizes[large_segment_queue_index] = segment_size;
-        }
-        if constexpr (params::is_per_segment_param_v<KParameterT>)
-        {
-          d_large_segments_k[large_segment_queue_index] = k_param.get_param(segment_id);
-        }
-        if constexpr (params::is_per_segment_param_v<SelectDirectionParameterT>)
-        {
-          d_large_segments_select_directions[large_segment_queue_index] = select_directions.get_param(segment_id);
-        }
-        d_key_large_segments_it[large_segment_queue_index]     = d_key_segments_it[segment_id];
-        d_key_large_segments_out_it[large_segment_queue_index] = d_key_segments_out_it[segment_id];
-        if constexpr (!is_keys_only)
-        {
-          d_value_large_segments_it[large_segment_queue_index]     = d_value_segments_it[segment_id];
-          d_value_large_segments_out_it[large_segment_queue_index] = d_value_segments_out_it[segment_id];
-        }
+        const auto large_segment_queue_idx            = atomicAdd(d_large_segments_counter, 1);
+        d_large_segments_ids[large_segment_queue_idx] = segment_id;
+        d_large_segments_tile_offsets[large_segment_queue_idx] =
+          ::cuda::narrow<int>(::cuda::std::ceil_div(segment_size, large_segment_agent_tile_size));
       }
     }
-    else if constexpr (params::static_min_value_v<SegmentSizeParameterT> <= tile_size)
+    else if constexpr (any_small_segments)
     {
       // Process small segment
       const auto k         = (::cuda::std::min) (k_param.get_param(segment_id),
@@ -319,42 +294,52 @@ struct agent_batched_topk_worker_per_segment
       }
     }
 
-    bool is_last_block = false;
-    if (threadIdx.x == 0u)
+    // Epilogue: Scan queued large segment sizes (in tiles not elements) for load balancing search in the large segment
+    // agent
+    if constexpr (!only_small_segments)
     {
-      __threadfence();
-      const int retirement_count = atomicAdd(d_retirement_count, 1);
-      is_last_block              = retirement_count == static_cast<int>(gridDim.x) - 1;
-    }
-    // This sync also makes sure that the shared memory can be reused.
-    is_last_block = static_cast<bool>(__syncthreads_or(static_cast<int>(is_last_block)));
-    if (!is_last_block)
-    {
-      return;
-    }
-
-    // Epilogue: Scan large segment sizes for load balancing search in the next kernel launch
-    const auto num_large_segments = *d_large_segment_queue;
-    const auto prefix_callback_op =
-      [running_total = segment_size_val_t{0}](segment_size_val_t block_aggregate) mutable {
-        auto old_running_total = running_total;
-        running_total += block_aggregate;
-        return old_running_total;
-      };
-    _CCCL_PRAGMA_NOUNROLL()
-    for (int large_segment_offset = 0; large_segment_offset < num_large_segments;
-         large_segment_offset += epilogue_tile_size)
-    {
-      segment_size_val_t segment_sizes[epilogue_items_per_thread];
-      block_load_epilogue_t(temp_storage.load_epilogue)
-        .Load(
-          d_large_segments_sizes + large_segment_offset, segment_sizes, num_large_segments - large_segment_offset, 0);
-      __syncthreads();
-      block_scan_epilogue_t(temp_storage.scan_epilogue).ExclusiveSum(segment_sizes, segment_sizes, prefix_callback_op);
-      __syncthreads();
-      block_store_epilogue_t(temp_storage.store_epilogue)
-        .Store(d_large_segments_sizes + large_segment_offset, segment_sizes, num_large_segments - large_segment_offset);
-      __syncthreads();
+      // Determine last block trying to retire.
+      bool is_last_block = false;
+      if (threadIdx.x == 0u)
+      {
+        __threadfence();
+        const auto retirement_count = atomicAdd(d_retirement_counter, 1);
+        is_last_block               = retirement_count == static_cast<int>(gridDim.x) - 1;
+      }
+      // This sync also makes sure that the shared memory can be reused.
+      is_last_block = static_cast<bool>(__syncthreads_or(static_cast<int>(is_last_block)));
+      if (!is_last_block)
+      {
+        return;
+      }
+      const auto num_large_segments = *d_large_segments_counter;
+      // For tracking the running total across tiles (loop iterations).
+      const auto prefix_callback_op =
+        [running_total = segment_size_val_t{0}](segment_size_val_t block_aggregate) mutable {
+          auto old_running_total = running_total;
+          running_total += block_aggregate;
+          return old_running_total;
+        };
+      _CCCL_PRAGMA_NOUNROLL()
+      for (int large_segment_offset = 0; large_segment_offset < num_large_segments;
+           large_segment_offset += epilogue_tile_size)
+      {
+        segment_size_val_t segment_tile_offsets[epilogue_items_per_thread];
+        block_load_epilogue_t(temp_storage.load_epilogue)
+          .Load(d_large_segments_tile_offsets + large_segment_offset,
+                segment_tile_offsets,
+                num_large_segments - large_segment_offset,
+                0);
+        __syncthreads();
+        block_scan_epilogue_t(temp_storage.scan_epilogue)
+          .ExclusiveSum(segment_tile_offsets, segment_tile_offsets, prefix_callback_op);
+        __syncthreads();
+        block_store_epilogue_t(temp_storage.store_epilogue)
+          .Store(d_large_segments_tile_offsets + large_segment_offset,
+                 segment_tile_offsets,
+                 num_large_segments - large_segment_offset);
+        __syncthreads();
+      }
     }
   }
 };

--- a/cub/cub/agent/agent_batched_topk.cuh
+++ b/cub/cub/agent/agent_batched_topk.cuh
@@ -17,13 +17,13 @@
 #include <cub/block/block_scan.cuh>
 #include <cub/block/block_store.cuh>
 #include <cub/block/block_topk.cuh>
+#include <cub/detail/choose_offset.cuh>
 #include <cub/detail/segmented_params.cuh>
 #include <cub/device/dispatch/dispatch_common.cuh>
 #include <cub/device/dispatch/tuning/tuning_batched_topk.cuh>
 #include <cub/util_type.cuh>
 
 #include <cuda/__cmath/ceil_div.h>
-#include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
 
@@ -32,11 +32,13 @@ namespace detail::batched_topk
 // Atomic counters used by the small-segment kernel to (a) enqueue large segments into the large-segment work queue
 // and (b) elect the last block to run the epilogue scan over the queued tile counts. `alignas(128)` isolates each
 // counter on its own cache line for performance.
+template <class NumTilesT>
 struct batched_topk_counters
 {
+  using tile_count_t = detail::choose_offset_t<NumTilesT>;
   // Number of segments enqueued in the large-segment work queue. Atomically incremented (by 1) by the first thread
   // of each block that decides its segment is large.
-  alignas(128) unsigned long long large_segments_count;
+  alignas(128) tile_count_t large_segments_count;
 
   // Block retirement counter. Each block atomically increments by 1 when it has finished processing its segment, and
   // the block that observes `gridDim.x - 1` runs the epilogue on the queued large segments tile counts.
@@ -51,7 +53,8 @@ template <typename PolicyGetter, // TODO(bgruber): pass worker_policy as NTTP in
           typename SegmentSizeParameterT,
           typename KParameterT,
           typename SelectDirectionParameterT,
-          typename NumSegmentsParameterT>
+          typename NumSegmentsParameterT,
+          typename LargeSegmentTileOffsetT>
 struct agent_batched_topk_worker_per_segment
 {
   // -------------------------------------------------------------------------
@@ -66,6 +69,7 @@ struct agent_batched_topk_worker_per_segment
 
   using segment_size_val_t = typename SegmentSizeParameterT::value_type;
   using num_segments_val_t = typename NumSegmentsParameterT::value_type;
+  using counters_t         = batched_topk_counters<num_segments_val_t>;
 
   static constexpr auto policy                 = PolicyGetter{}();
   static constexpr worker_policy active_policy = policy.worker_per_segment_policy;
@@ -84,6 +88,7 @@ struct agent_batched_topk_worker_per_segment
   static constexpr int multi_worker_per_segment_tile_size =
     multi_worker_per_segment_policy.block_threads * multi_worker_per_segment_policy.items_per_thread;
 
+  // Check if there could be large segments present
   static constexpr bool only_small_segments = params::static_max_value_v<SegmentSizeParameterT> <= tile_size;
 
   // Check if we are dealing with keys-only or key-value pairs
@@ -140,10 +145,9 @@ struct agent_batched_topk_worker_per_segment
   KParameterT k_param;
   SelectDirectionParameterT select_directions;
   NumSegmentsParameterT num_segments;
-  batched_topk_counters* d_counters;
+  counters_t* d_counters;
   num_segments_val_t* d_large_segments_ids;
-  // Assuming the large segment agent will also use int for tile_id = blockIdx.x.
-  ::cuda::std::int64_t* d_large_segments_tile_offsets;
+  LargeSegmentTileOffsetT* d_large_segments_tile_offsets;
   // -------------------------------------------------------------------------
   // Constructor
   // -------------------------------------------------------------------------
@@ -157,9 +161,9 @@ struct agent_batched_topk_worker_per_segment
     KParameterT k_param,
     SelectDirectionParameterT select_directions,
     NumSegmentsParameterT num_segments,
-    batched_topk_counters* d_counters,
+    counters_t* d_counters,
     num_segments_val_t* d_large_segments_ids,
-    ::cuda::std::int64_t* d_large_segments_tile_offsets)
+    LargeSegmentTileOffsetT* d_large_segments_tile_offsets)
       : temp_storage(temp_storage.Alias())
       , d_key_segments_it(d_key_segments_it)
       , d_key_segments_out_it(d_key_segments_out_it)
@@ -200,7 +204,7 @@ struct agent_batched_topk_worker_per_segment
         const auto large_segment_queue_idx            = atomicAdd(&d_counters->large_segments_count, 1ull);
         d_large_segments_ids[large_segment_queue_idx] = static_cast<num_segments_val_t>(segment_id);
         d_large_segments_tile_offsets[large_segment_queue_idx] =
-          static_cast<::cuda::std::int64_t>(::cuda::ceil_div(segment_size, multi_worker_per_segment_tile_size));
+          static_cast<LargeSegmentTileOffsetT>(::cuda::ceil_div(segment_size, multi_worker_per_segment_tile_size));
       }
     }
     else

--- a/cub/cub/agent/agent_batched_topk.cuh
+++ b/cub/cub/agent/agent_batched_topk.cuh
@@ -67,14 +67,22 @@ struct agent_batched_topk_worker_per_segment
   using segment_size_val_t = typename SegmentSizeParameterT::value_type;
   using num_segments_val_t = typename NumSegmentsParameterT::value_type;
 
-  static constexpr worker_policy active_policy = PolicyGetter{}();
+  static constexpr auto policy                 = PolicyGetter{}();
+  static constexpr worker_policy active_policy = policy.worker_per_segment_policy;
 
-  static constexpr int block_threads                 = active_policy.block_threads;
-  static constexpr int items_per_thread              = active_policy.items_per_thread;
-  static constexpr int tile_size                     = block_threads * items_per_thread;
-  static constexpr int epilogue_items_per_thread     = active_policy.epilogue.items_per_thread;
-  static constexpr int epilogue_tile_size            = block_threads * epilogue_items_per_thread;
-  static constexpr int large_segment_agent_tile_size = active_policy.epilogue.multi_worker_tile_size;
+  // For block-topk (and keys/values load/store):
+  static constexpr int block_threads    = active_policy.block_threads;
+  static constexpr int items_per_thread = active_policy.items_per_thread;
+  static constexpr int tile_size        = block_threads * items_per_thread;
+
+  // For block-scan (and offsets load/store):
+  static constexpr int epilogue_items_per_thread = active_policy.epilogue.items_per_thread;
+  static constexpr int epilogue_tile_size        = block_threads * epilogue_items_per_thread;
+
+  // Number used for preprocessing segment-size data, not for tuning => should not affect performance of this agent.
+  static constexpr multi_worker_policy multi_worker_per_segment_policy = policy.multi_worker_per_segment_policy;
+  static constexpr int multi_worker_per_segment_tile_size =
+    multi_worker_per_segment_policy.block_threads * multi_worker_per_segment_policy.items_per_thread;
 
   static constexpr bool only_small_segments = params::static_max_value_v<SegmentSizeParameterT> <= tile_size;
 
@@ -192,7 +200,7 @@ struct agent_batched_topk_worker_per_segment
         const auto large_segment_queue_idx            = atomicAdd(&d_counters->large_segments_count, 1ull);
         d_large_segments_ids[large_segment_queue_idx] = static_cast<num_segments_val_t>(segment_id);
         d_large_segments_tile_offsets[large_segment_queue_idx] =
-          static_cast<::cuda::std::int64_t>(::cuda::ceil_div(segment_size, large_segment_agent_tile_size));
+          static_cast<::cuda::std::int64_t>(::cuda::ceil_div(segment_size, multi_worker_per_segment_tile_size));
       }
     }
     else

--- a/cub/cub/agent/agent_batched_topk.cuh
+++ b/cub/cub/agent/agent_batched_topk.cuh
@@ -32,16 +32,21 @@ namespace detail::batched_topk
 // Atomic counters used by the small-segment kernel to (a) enqueue large segments into the large-segment work queue
 // and (b) elect the last block to run the epilogue scan over the queued tile counts. `alignas(128)` isolates each
 // counter on its own cache line for performance.
-template <class NumTilesT>
+template <class NumSegmentsT>
 struct batched_topk_counters
 {
-  using tile_count_t = detail::choose_offset_t<NumTilesT>;
+  // Force unsigned integer type for segment count.
+  using segment_count_t = detail::choose_offset_t<NumSegmentsT>;
   // Number of segments enqueued in the large-segment work queue. Atomically incremented (by 1) by the first thread
   // of each block that decides its segment is large.
-  alignas(128) tile_count_t large_segments_count;
+  alignas(128) segment_count_t large_segments_count;
 
   // Block retirement counter. Each block atomically increments by 1 when it has finished processing its segment, and
   // the block that observes `gridDim.x - 1` runs the epilogue on the queued large segments tile counts.
+  // Assumption: Future support for more than 2^31 - 1 segments will use multiple launches of a slightly modified
+  // small-segment kernel instead of additional grid dimensions. Therefore each grid will handle a maximum of 2^31 - 1
+  // segments per launch. The counter would not even have to be reset to 0 after each launch if we cleverly make use of
+  // its modulo arithmetic.
   alignas(128) unsigned retirement_count;
 };
 
@@ -334,6 +339,8 @@ struct agent_batched_topk_worker_per_segment
       }
       const auto num_large_segments = d_counters->large_segments_count;
       // For tracking the running total across tiles (loop iterations).
+      // Caution: The functor is only invoked by the first warp in the block, and the value returned by lane 0 in that
+      // warp is used as the initial value.
       const auto prefix_callback_op =
         [running_total = segment_size_val_t{0}](segment_size_val_t block_aggregate) mutable {
           auto old_running_total = running_total;

--- a/cub/cub/agent/agent_batched_topk.cuh
+++ b/cub/cub/agent/agent_batched_topk.cuh
@@ -47,11 +47,17 @@ struct agent_batched_topk_worker_per_segment
   using key_t   = it_value_t<key_it_t>;
   using value_t = it_value_t<value_it_t>;
 
+  using segment_size_val_t     = typename SegmentSizeParameterT::value_type;
+  using k_val_t                = typename KParameterT::value_type;
+  using select_direction_val_t = typename SelectDirectionParameterT::value_type;
+
   static constexpr worker_policy active_policy = PolicyGetter{}();
 
   static constexpr int block_threads    = active_policy.block_threads;
   static constexpr int items_per_thread = active_policy.items_per_thread;
   static constexpr int tile_size        = block_threads * items_per_thread;
+  static constexpr int epilogue_items_per_thread = active_policy.epilogue_items_per_thread;
+  static constexpr int epilogue_tile_size        = block_threads * epilogue_items_per_thread;
 
   // Check if we are dealing with keys-only or key-value pairs
   static constexpr bool is_keys_only = ::cuda::std::is_same_v<value_t, cub::NullType>;
@@ -69,6 +75,12 @@ struct agent_batched_topk_worker_per_segment
   using block_store_keys_t = BlockStore<key_t, block_threads, items_per_thread, active_policy.store_algorithm>;
   using block_store_vals_t = BlockStore<value_t, block_threads, items_per_thread, active_policy.store_algorithm>;
 
+  using block_load_epilogue_t =
+    BlockLoad<segment_size_val_t, block_threads, epilogue_items_per_thread, active_policy.epilogue_load_algorithm>;
+  using block_scan_epilogue_t = BlockScan<int, block_threads, active_policy.epilogue_scan_algorithm>;
+  using block_store_epilogue_t =
+    BlockStore<segment_size_val_t, block_threads, epilogue_items_per_thread, active_policy.epilogue_store_algorithm>;
+
   // -------------------------------------------------------------------------
   // Shared Memory Storage
   // -------------------------------------------------------------------------
@@ -81,6 +93,9 @@ struct agent_batched_topk_worker_per_segment
       typename block_topk_t::TempStorage topk;
       typename block_store_keys_t::TempStorage store_keys;
       typename block_store_vals_t::TempStorage store_vals;
+      typename block_load_epilogue_t::TempStorage load_epilogue;
+      typename block_scan_epilogue_t::TempStorage scan_epilogue;
+      typename block_store_epilogue_t::TempStorage store_epilogue;
     };
   };
 
@@ -98,7 +113,16 @@ struct agent_batched_topk_worker_per_segment
   KParameterT k_param;
   SelectDirectionParameterT select_directions;
   NumSegmentsParameterT num_segments;
-
+  // Currently we use int for segment_id, so int has be enough for these atomic counters.
+  int* d_retirement_count;
+  int* d_large_segment_queue;
+  key_it_t* d_key_large_segments_it;
+  key_it_t* d_key_large_segments_out_it;
+  value_it_t* d_value_large_segments_it;
+  value_it_t* d_value_large_segments_out_it;
+  [[maybe_unused]] segment_size_val_t* d_large_segments_sizes;
+  [[maybe_unused]] k_val_t* d_large_segments_k;
+  [[maybe_unused]] select_direction_val_t* d_large_segments_select_directions;
   // -------------------------------------------------------------------------
   // Constructor
   // -------------------------------------------------------------------------
@@ -111,7 +135,16 @@ struct agent_batched_topk_worker_per_segment
     SegmentSizeParameterT segment_sizes,
     KParameterT k_param,
     SelectDirectionParameterT select_directions,
-    NumSegmentsParameterT num_segments)
+    NumSegmentsParameterT num_segments,
+    int* d_retirement_count,
+    int* d_large_segment_queue,
+    key_it_t* d_key_large_segments_it,
+    key_it_t* d_key_large_segments_out_it,
+    value_it_t* d_value_large_segments_it,
+    value_it_t* d_value_large_segments_out_it,
+    segment_size_val_t* d_large_segments_sizes,
+    k_val_t* d_large_segments_k,
+    select_direction_val_t* d_large_segments_select_directions)
       : temp_storage(temp_storage.Alias())
       , d_key_segments_it(d_key_segments_it)
       , d_key_segments_out_it(d_key_segments_out_it)
@@ -121,6 +154,15 @@ struct agent_batched_topk_worker_per_segment
       , k_param(k_param)
       , select_directions(select_directions)
       , num_segments(num_segments)
+      , d_retirement_count(d_retirement_count)
+      , d_large_segment_queue(d_large_segment_queue)
+      , d_key_large_segments_it(d_key_large_segments_it)
+      , d_key_large_segments_out_it(d_key_large_segments_out_it)
+      , d_value_large_segments_it(d_value_large_segments_it)
+      , d_value_large_segments_out_it(d_value_large_segments_out_it)
+      , d_large_segments_sizes(d_large_segments_sizes)
+      , d_large_segments_k(d_large_segments_k)
+      , d_large_segments_select_directions(d_large_segments_select_directions)
   {}
 
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void Process()
@@ -140,107 +182,179 @@ struct agent_batched_topk_worker_per_segment
 
     // Resolve Segment Parameters
     const auto segment_size = segment_sizes.get_param(segment_id);
-    const auto k            = (::cuda::std::min) (k_param.get_param(segment_id),
-                                       static_cast<decltype(k_param.get_param(segment_id))>(segment_size));
-    const auto direction    = select_directions.get_param(segment_id);
-
-    // Determine padding key based on direction
-    const key_t padding_key =
-      (direction == detail::topk::select::max)
-        ? ::cuda::std::numeric_limits<key_t>::lowest()
-        : ::cuda::std::numeric_limits<key_t>::max();
-
-    // Dereference iterator-of-iterators to get the segment specific iterator
-    auto block_keys_in = d_key_segments_it[segment_id];
-
-    // Load Keys
-    key_t thread_keys[items_per_thread];
-    if constexpr (is_full_tile)
+    if (params::static_min_value_v<SegmentSizeParameterT> > tile_size
+        || (params::static_max_value_v<SegmentSizeParameterT> > tile_size && segment_size > tile_size))
     {
-      // No padding needed
-      block_load_keys_t(temp_storage.load_keys).Load(block_keys_in, thread_keys);
+      // Enqueue large segment
+      if (threadIdx.x == 0u)
+      {
+        // Add to large segment queue
+        const int large_segment_queue_index = atomicAdd(d_large_segment_queue, 1);
+        // TODO (pauleonix): Should we write out the segment_id instead of all these parameters?
+        if constexpr (params::is_per_segment_param_v<SegmentSizeParameterT>)
+        {
+          d_large_segments_sizes[large_segment_queue_index] = segment_size;
+        }
+        if constexpr (params::is_per_segment_param_v<KParameterT>)
+        {
+          d_large_segments_k[large_segment_queue_index] = k_param.get_param(segment_id);
+        }
+        if constexpr (params::is_per_segment_param_v<SelectDirectionParameterT>)
+        {
+          d_large_segments_select_directions[large_segment_queue_index] = select_directions.get_param(segment_id);
+        }
+        d_key_large_segments_it[large_segment_queue_index]     = d_key_segments_it[segment_id];
+        d_key_large_segments_out_it[large_segment_queue_index] = d_key_segments_out_it[segment_id];
+        if constexpr (!is_keys_only)
+        {
+          d_value_large_segments_it[large_segment_queue_index]     = d_value_segments_it[segment_id];
+          d_value_large_segments_out_it[large_segment_queue_index] = d_value_segments_out_it[segment_id];
+        }
+      }
     }
-    else
+    else if constexpr (params::static_min_value_v<SegmentSizeParameterT> <= tile_size)
     {
-      // Potentially partial final load with padding
-      // TODO (elstehle): explore whether a runtime check for segment_size == tile_size improves performance
-      block_load_keys_t(temp_storage.load_keys).Load(block_keys_in, thread_keys, segment_size);
-    }
+      // Process small segment
+      const auto k         = (::cuda::std::min) (k_param.get_param(segment_id),
+                                         static_cast<decltype(k_param.get_param(segment_id))>(segment_size));
+      const auto direction = select_directions.get_param(segment_id);
 
-    // Load Values (if applicable)
-    [[maybe_unused]] value_t thread_values[items_per_thread];
+      // Determine padding key based on direction
+      const key_t padding_key =
+        (direction == detail::topk::select::max)
+          ? ::cuda::std::numeric_limits<key_t>::lowest()
+          : ::cuda::std::numeric_limits<key_t>::max();
 
-    if constexpr (!is_keys_only)
-    {
-      __syncthreads();
-      auto block_vals_in = d_value_segments_it[segment_id];
+      // Dereference iterator-of-iterators to get the segment specific iterator
+      auto block_keys_in = d_key_segments_it[segment_id];
 
+      // Load Keys
+      key_t thread_keys[items_per_thread];
       if constexpr (is_full_tile)
       {
         // No padding needed
-        block_load_vals_t(temp_storage.load_vals).Load(block_vals_in, thread_values);
+        block_load_keys_t(temp_storage.load_keys).Load(block_keys_in, thread_keys);
       }
       else
       {
         // Potentially partial final load with padding
         // TODO (elstehle): explore whether a runtime check for segment_size == tile_size improves performance
-        block_load_vals_t(temp_storage.load_vals).Load(block_vals_in, thread_values, segment_size);
+        block_load_keys_t(temp_storage.load_keys).Load(block_keys_in, thread_keys, segment_size);
+      }
+
+      // Load Values (if applicable)
+      [[maybe_unused]] value_t thread_values[items_per_thread];
+
+      if constexpr (!is_keys_only)
+      {
+        __syncthreads();
+        auto block_vals_in = d_value_segments_it[segment_id];
+
+        if constexpr (is_full_tile)
+        {
+          // No padding needed
+          block_load_vals_t(temp_storage.load_vals).Load(block_vals_in, thread_values);
+        }
+        else
+        {
+          // Potentially partial final load with padding
+          // TODO (elstehle): explore whether a runtime check for segment_size == tile_size improves performance
+          block_load_vals_t(temp_storage.load_vals).Load(block_vals_in, thread_values, segment_size);
+        }
+      }
+
+      __syncthreads();
+
+      // Perform Block Top-K
+      if constexpr (is_keys_only)
+      {
+        const bool is_successful_dispatch = cub::detail::params::dispatch_discrete(
+          select_directions, segment_id, [this, &thread_keys, k, segment_size](auto direction_tag) {
+            if constexpr (decltype(direction_tag)::value == detail::topk::select::max)
+            {
+              block_topk_t(temp_storage.topk).template max_keys<is_full_tile>(thread_keys, k, segment_size);
+            }
+            else
+            {
+              block_topk_t(temp_storage.topk).template min_keys<is_full_tile>(thread_keys, k, segment_size);
+            }
+          });
+        _CCCL_ASSERT(is_successful_dispatch, "Error: Unsupported select direction");
+      }
+      else
+      {
+        // Pass both keys and values
+        const bool is_successful_dispatch = cub::detail::params::dispatch_discrete(
+          select_directions, segment_id, [this, &thread_keys, &thread_values, k, segment_size](auto direction_tag) {
+            if constexpr (decltype(direction_tag)::value == detail::topk::select::max)
+            {
+              block_topk_t(temp_storage.topk)
+                .template max_pairs<is_full_tile>(thread_keys, thread_values, k, segment_size);
+            }
+            else
+            {
+              block_topk_t(temp_storage.topk)
+                .template min_pairs<is_full_tile>(thread_keys, thread_values, k, segment_size);
+            }
+          });
+        _CCCL_ASSERT(is_successful_dispatch, "Error: Unsupported select direction");
+      }
+
+      __syncthreads();
+
+      auto block_keys_out = d_key_segments_out_it[segment_id];
+
+      block_store_keys_t(temp_storage.store_keys)
+        .Store(block_keys_out,
+               thread_keys,
+               k // Only store K items
+        );
+
+      if constexpr (!is_keys_only)
+      {
+        __syncthreads();
+        auto block_vals_out = d_value_segments_out_it[segment_id];
+
+        block_store_vals_t(temp_storage.store_vals).Store(block_vals_out, thread_values, k);
       }
     }
 
-    __syncthreads();
-
-    // Perform Block Top-K
-    if constexpr (is_keys_only)
+    bool is_last_block = false;
+    if (threadIdx.x == 0u)
     {
-      const bool is_successful_dispatch = cub::detail::params::dispatch_discrete(
-        select_directions, segment_id, [this, &thread_keys, k, segment_size](auto direction_tag) {
-          if constexpr (decltype(direction_tag)::value == detail::topk::select::max)
-          {
-            block_topk_t(temp_storage.topk).template max_keys<is_full_tile>(thread_keys, k, segment_size);
-          }
-          else
-          {
-            block_topk_t(temp_storage.topk).template min_keys<is_full_tile>(thread_keys, k, segment_size);
-          }
-        });
-      _CCCL_ASSERT(is_successful_dispatch, "Error: Unsupported select direction");
+      __threadfence();
+      const int retirement_count = atomicAdd(d_retirement_count, 1);
+      is_last_block              = retirement_count == static_cast<int>(gridDim.x) - 1;
     }
-    else
+    // This sync also makes sure that the shared memory can be reused.
+    is_last_block = static_cast<bool>(__syncthreads_or(static_cast<int>(is_last_block)));
+    if (!is_last_block)
     {
-      // Pass both keys and values
-      const bool is_successful_dispatch = cub::detail::params::dispatch_discrete(
-        select_directions, segment_id, [this, &thread_keys, &thread_values, k, segment_size](auto direction_tag) {
-          if constexpr (decltype(direction_tag)::value == detail::topk::select::max)
-          {
-            block_topk_t(temp_storage.topk)
-              .template max_pairs<is_full_tile>(thread_keys, thread_values, k, segment_size);
-          }
-          else
-          {
-            block_topk_t(temp_storage.topk)
-              .template min_pairs<is_full_tile>(thread_keys, thread_values, k, segment_size);
-          }
-        });
-      _CCCL_ASSERT(is_successful_dispatch, "Error: Unsupported select direction");
+      return;
     }
 
-    __syncthreads();
-
-    auto block_keys_out = d_key_segments_out_it[segment_id];
-
-    block_store_keys_t(temp_storage.store_keys)
-      .Store(block_keys_out,
-             thread_keys,
-             k // Only store K items
-      );
-
-    if constexpr (!is_keys_only)
+    // Epilogue: Scan large segment sizes for load balancing search in the next kernel launch
+    const auto num_large_segments = *d_large_segment_queue;
+    const auto prefix_callback_op =
+      [running_total = segment_size_val_t{0}](segment_size_val_t block_aggregate) mutable {
+        auto old_running_total = running_total;
+        running_total += block_aggregate;
+        return old_running_total;
+      };
+    _CCCL_PRAGMA_NOUNROLL()
+    for (int large_segment_offset = 0; large_segment_offset < num_large_segments;
+         large_segment_offset += epilogue_tile_size)
     {
+      segment_size_val_t segment_sizes[epilogue_items_per_thread];
+      block_load_epilogue_t(temp_storage.load_epilogue)
+        .Load(
+          d_large_segments_sizes + large_segment_offset, segment_sizes, num_large_segments - large_segment_offset, 0);
       __syncthreads();
-      auto block_vals_out = d_value_segments_out_it[segment_id];
-
-      block_store_vals_t(temp_storage.store_vals).Store(block_vals_out, thread_values, k);
+      block_scan_epilogue_t(temp_storage.scan_epilogue).ExclusiveSum(segment_sizes, segment_sizes, prefix_callback_op);
+      __syncthreads();
+      block_store_epilogue_t(temp_storage.store_epilogue)
+        .Store(d_large_segments_sizes + large_segment_offset, segment_sizes, num_large_segments - large_segment_offset);
+      __syncthreads();
     }
   }
 };

--- a/cub/cub/agent/agent_batched_topk.cuh
+++ b/cub/cub/agent/agent_batched_topk.cuh
@@ -49,21 +49,19 @@ struct agent_batched_topk_worker_per_segment
   using key_t   = it_value_t<key_it_t>;
   using value_t = it_value_t<value_it_t>;
 
-  using segment_size_val_t     = typename SegmentSizeParameterT::value_type;
-  using k_val_t                = typename KParameterT::value_type;
-  using select_direction_val_t = typename SelectDirectionParameterT::value_type;
+  using segment_size_val_t = typename SegmentSizeParameterT::value_type;
+  using num_segments_val_t = typename NumSegmentsParameterT::value_type;
 
   static constexpr worker_policy active_policy = PolicyGetter{}();
 
-  static constexpr int block_threads    = active_policy.block_threads;
-  static constexpr int items_per_thread = active_policy.items_per_thread;
-  static constexpr int tile_size        = block_threads * items_per_thread;
+  static constexpr int block_threads             = active_policy.block_threads;
+  static constexpr int items_per_thread          = active_policy.items_per_thread;
+  static constexpr int tile_size                 = block_threads * items_per_thread;
   static constexpr int epilogue_items_per_thread = active_policy.epilogue_items_per_thread;
   static constexpr int epilogue_tile_size        = block_threads * epilogue_items_per_thread;
   // TODO (elstehle): This is just a placeholder for now, we will need to specialize this for the large segment agent.
   static constexpr int large_segment_agent_tile_size = tile_size;
 
-  static constexpr bool any_small_segments  = params::static_min_value_v<SegmentSizeParameterT> <= tile_size;
   static constexpr bool only_small_segments = params::static_max_value_v<SegmentSizeParameterT> <= tile_size;
 
   // Check if we are dealing with keys-only or key-value pairs
@@ -120,12 +118,12 @@ struct agent_batched_topk_worker_per_segment
   KParameterT k_param;
   SelectDirectionParameterT select_directions;
   NumSegmentsParameterT num_segments;
-  // Currently we use int for segment_id = blockIdx.x, so int has be enough for all three.
-  int* d_large_segments_counter;
-  int* d_retirement_counter;
-  int* d_large_segments_ids;
+  num_segments_val_t* d_large_segments_counter;
+  // Currently we use int for segment_id = blockIdx.x, so int has be enough.
+  ::cuda::std::uint32_t* d_retirement_counter;
+  num_segments_val_t* d_large_segments_ids;
   // Assuming the large segment agent will also use int for tile_id = blockIdx.x.
-  int* d_large_segments_tile_offsets;
+  ::cuda::std::int64_t* d_large_segments_tile_offsets;
   // -------------------------------------------------------------------------
   // Constructor
   // -------------------------------------------------------------------------
@@ -139,10 +137,10 @@ struct agent_batched_topk_worker_per_segment
     KParameterT k_param,
     SelectDirectionParameterT select_directions,
     NumSegmentsParameterT num_segments,
-    int* d_large_segments_counter,
-    int* d_retirement_counter,
-    int* d_large_segments_ids,
-    int* d_large_segments_tile_offsets)
+    num_segments_val_t* d_large_segments_counter,
+    ::cuda::std::uint32_t* d_retirement_counter,
+    num_segments_val_t* d_large_segments_ids,
+    ::cuda::std::int64_t* d_large_segments_tile_offsets)
       : temp_storage(temp_storage.Alias())
       , d_key_segments_it(d_key_segments_it)
       , d_key_segments_out_it(d_key_segments_out_it)
@@ -175,19 +173,19 @@ struct agent_batched_topk_worker_per_segment
 
     // Resolve Segment Parameters
     const auto segment_size = segment_sizes.get_param(segment_id);
-    if (!any_small_segments || (!only_small_segments && segment_size > tile_size))
+    if (!only_small_segments && segment_size > tile_size)
     {
       // Enqueue large segment
       if (threadIdx.x == 0u)
       {
         // Add to large segment queue
-        const auto large_segment_queue_idx            = atomicAdd(d_large_segments_counter, 1);
-        d_large_segments_ids[large_segment_queue_idx] = segment_id;
+        const auto large_segment_queue_idx            = atomicAdd(d_large_segments_counter, num_segments_val_t{1});
+        d_large_segments_ids[large_segment_queue_idx] = static_cast<num_segments_val_t>(segment_id);
         d_large_segments_tile_offsets[large_segment_queue_idx] =
-          ::cuda::narrow<int>(::cuda::std::ceil_div(segment_size, large_segment_agent_tile_size));
+          static_cast<::cuda::std::int64_t>(::cuda::std::ceil_div(segment_size, large_segment_agent_tile_size));
       }
     }
-    else if constexpr (any_small_segments)
+    else
     {
       // Process small segment
       const auto k         = (::cuda::std::min) (k_param.get_param(segment_id),
@@ -303,8 +301,8 @@ struct agent_batched_topk_worker_per_segment
       if (threadIdx.x == 0u)
       {
         __threadfence();
-        const auto retirement_count = atomicAdd(d_retirement_counter, 1);
-        is_last_block               = retirement_count == static_cast<int>(gridDim.x) - 1;
+        const auto retirement_count = atomicAdd(d_retirement_counter, 1u);
+        is_last_block               = retirement_count == (gridDim.x - 1u);
       }
       // This sync also makes sure that the shared memory can be reused.
       is_last_block = static_cast<bool>(__syncthreads_or(static_cast<int>(is_last_block)));

--- a/cub/cub/agent/agent_batched_topk.cuh
+++ b/cub/cub/agent/agent_batched_topk.cuh
@@ -32,11 +32,11 @@ namespace detail::batched_topk
 // Atomic counters used by the small-segment kernel to (a) enqueue large segments into the large-segment work queue
 // and (b) elect the last block to run the epilogue scan over the queued tile counts. `alignas(128)` isolates each
 // counter on its own cache line for performance.
-struct alignas(128) batched_topk_counters
+struct batched_topk_counters
 {
   // Number of segments enqueued in the large-segment work queue. Atomically incremented (by 1) by the first thread
   // of each block that decides its segment is large.
-  unsigned long long large_segments_count;
+  alignas(128) unsigned long long large_segments_count;
 
   // Block retirement counter. Each block atomically increments by 1 when it has finished processing its segment, and
   // the block that observes `gridDim.x - 1` runs the epilogue on the queued large segments tile counts.

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved. SPDX-License-Identifier:
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved. SPDX-License-Identifier:
 // Apache-2.0 WITH LLVM-exception
 
 //! @file

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -106,6 +106,13 @@ template <::cuda::std::int64_t MinNumSegments = 1,
           ::cuda::std::int64_t MaxNumSegments = ::cuda::std::numeric_limits<::cuda::std::int64_t>::max()>
 using num_segments_uniform = params::uniform_param<::cuda::std::int64_t, MinNumSegments, MaxNumSegments>;
 
+// Number of segments via iterator
+template <typename NumSegmentsItT,
+          ::cuda::std::int64_t MinNumSegments = 1,
+          ::cuda::std::int64_t MaxNumSegments = ::cuda::std::numeric_limits<::cuda::std::int64_t>::max()>
+using num_segments_indirect =
+  params::per_segment_param<NumSegmentsItT, ::cuda::std::int64_t, MinNumSegments, MaxNumSegments>;
+
 // ------------ TOTAL NUMBER OF ITEMS PARAMETER TYPES ------------
 
 // Number of items guarantee

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -106,35 +106,29 @@ template <::cuda::std::int64_t MinNumSegments = 1,
           ::cuda::std::int64_t MaxNumSegments = ::cuda::std::numeric_limits<::cuda::std::int64_t>::max()>
 using num_segments_uniform = params::uniform_param<::cuda::std::int64_t, MinNumSegments, MaxNumSegments>;
 
-// Number of segments via iterator
-template <typename NumSegmentsItT,
-          ::cuda::std::int64_t MinNumSegments = 1,
-          ::cuda::std::int64_t MaxNumSegments = ::cuda::std::numeric_limits<::cuda::std::int64_t>::max()>
-using num_segments_per_segment =
-  params::per_segment_param<NumSegmentsItT, ::cuda::std::int64_t, MinNumSegments, MaxNumSegments>;
-
 // ------------ TOTAL NUMBER OF ITEMS PARAMETER TYPES ------------
 
 // Number of items guarantee
-template <::cuda::std::int64_t MinNumItemsT = 1,
-          ::cuda::std::int64_t MaxNumItems  = ::cuda::std::numeric_limits<::cuda::std::int64_t>::max()>
+template <::cuda::std::int64_t MinNumItems = 1,
+          ::cuda::std::int64_t MaxNumItems = ::cuda::std::numeric_limits<::cuda::std::int64_t>::max()>
 struct total_num_items_guarantee
 {
-  static constexpr ::cuda::std::int64_t static_min_num_items = MinNumItemsT;
-  static constexpr ::cuda::std::int64_t static_max_num_items = MaxNumItems;
+  using value_type                                 = ::cuda::std::int64_t;
+  static constexpr value_type static_min_num_items = MinNumItems;
+  static constexpr value_type static_max_num_items = MaxNumItems;
 
-  ::cuda::std::int64_t min_num_items = MinNumItemsT;
-  ::cuda::std::int64_t max_num_items = MaxNumItems;
+  value_type min_num_items = MinNumItems;
+  value_type max_num_items = MaxNumItems;
 
   // Create default ctor, 1 param ctor taking min, 2 param ctor taking min/max
   total_num_items_guarantee() = default;
 
-  _CCCL_HOST_DEVICE total_num_items_guarantee(::cuda::std::int64_t num_items)
+  _CCCL_HOST_DEVICE total_num_items_guarantee(value_type num_items)
       : min_num_items(num_items)
       , max_num_items(num_items)
   {}
 
-  _CCCL_HOST_DEVICE total_num_items_guarantee(::cuda::std::int64_t min_items, ::cuda::std::int64_t max_items)
+  _CCCL_HOST_DEVICE total_num_items_guarantee(value_type min_items, value_type max_items)
       : min_num_items(min_items)
       , max_num_items(max_items)
   {}

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -214,7 +214,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
 {
   // Helper that determines (a) whether there's any one-worker-per-segment policy supporting the range of segment
   // sizes and k, and (b) if so, which set of one-worker-per-segment policies to use
-  constexpr worker_policy selected = find_smallest_covering_policy<
+  constexpr auto policy = find_smallest_covering_policy<
     PolicySelector,
     SegmentSizeParameterT,
     KeyInputItItT,
@@ -225,13 +225,15 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
     KParameterT,
     SelectDirectionParameterT,
     NumSegmentsParameterT>::policy;
-  static constexpr int worker_per_segment_tile_size = selected.block_threads * selected.items_per_thread;
+  constexpr worker_policy worker_per_segment_policy             = policy.worker_per_segment_policy;
+  constexpr multi_worker_policy multi_worker_per_segment_policy = policy.multi_worker_per_segment_policy;
+
+  static constexpr int worker_per_segment_tile_size =
+    worker_per_segment_policy.block_threads * worker_per_segment_policy.items_per_thread;
   static constexpr bool any_small_segments =
     params::static_min_value_v<SegmentSizeParameterT> <= worker_per_segment_tile_size;
   static constexpr bool only_small_segments =
     params::static_max_value_v<SegmentSizeParameterT> <= worker_per_segment_tile_size;
-
-  static constexpr auto large_segment_agent_tile_size = selected.epilogue.multi_worker_tile_size;
 
   // Allocation layout:
   //   only_small_segments: [0] dummy.
@@ -243,7 +245,9 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   using num_segments_val_t                        = typename NumSegmentsParameterT::value_type;
   using segment_size_scan_offset_t                = detail::choose_offset_t<num_segments_val_t>;
   using segment_size_scan_input_op_t              = segment_size_to_tile_count_op<SegmentSizeParameterT>;
-  const segment_size_scan_input_op_t segment_size_scan_input_op{segment_sizes, large_segment_agent_tile_size};
+  static constexpr auto multi_worker_per_segment_tile_size =
+    multi_worker_per_segment_policy.block_threads * multi_worker_per_segment_policy.items_per_thread;
+  const segment_size_scan_input_op_t segment_size_scan_input_op{segment_sizes, multi_worker_per_segment_tile_size};
   // Transform iterator over [0, num_segments) producing the tile-count for each segment.
   [[maybe_unused]] const auto segment_size_scan_input_it = ::cuda::transform_iterator(
     ::cuda::counting_iterator<num_segments_val_t>{num_segments_val_t{0}}, segment_size_scan_input_op);
@@ -294,10 +298,6 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   static_assert(!params::is_per_segment_param_v<NumSegmentsParameterT>,
                 "Only uniform segment sizes are currently supported.");
 
-  // TODO (elstehle): support larger number of segments through multiple kernel launches
-  const int grid_dim      = static_cast<int>(num_segments.get_param(0));
-  constexpr int block_dim = selected.block_threads;
-
   if constexpr (any_small_segments)
   {
     if constexpr (!only_small_segments)
@@ -309,7 +309,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
         return error;
       }
     }
-
+    const int grid_dim      = static_cast<int>(num_segments.get_param(0));
+    constexpr int block_dim = worker_per_segment_policy.block_threads;
     if (const auto error = CubDebug(
           THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(grid_dim, block_dim, 0, stream)
             .doit(device_segmented_topk_kernel<PolicySelector,
@@ -358,7 +359,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
 
   if constexpr (!only_small_segments)
   {
-    // TODO (elstehle): Implement the large segment agent.
+    // TODO (elstehle): support larger number of segments through multiple kernel launches
     // Depending on any_small_segments, we need to either:
     // - Indirectly get the large segment parameters via the queued large segment IDs
     // - Directly take the segment parameters since all segments are large

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -198,10 +198,32 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
     KParameterT,
     SelectDirectionParameterT,
     NumSegmentsParameterT>::policy;
+  static constexpr int worker_per_segment_tile_size = selected.block_threads * selected.items_per_thread;
+  static constexpr bool any_small_segments =
+    params::static_min_value_v<SegmentSizeParameterT> <= worker_per_segment_tile_size;
+  static constexpr bool only_small_segments =
+    params::static_max_value_v<SegmentSizeParameterT> <= worker_per_segment_tile_size;
+  constexpr int allocations_array_size            = !only_small_segments ? 4 : 1;
+  size_t allocation_sizes[allocations_array_size] = {1};
+  if constexpr (!only_small_segments)
+  {
+    const auto num_segments_val = num_segments.get_param(0);
+    allocation_sizes[0]         = sizeof(typename NumSegmentsParameterT::value_type);
+    allocation_sizes[1]         = sizeof(::cuda::std::uint32_t);
+    allocation_sizes[2]         = num_segments_val * sizeof(typename NumSegmentsParameterT::value_type);
+    allocation_sizes[3]         = num_segments_val * sizeof(::cuda::std::int64_t);
+  }
+
+  // Compute allocation pointers into the single storage blob (or compute the necessary size of the blob)
+  void* allocations[allocations_array_size] = {};
+  if (const auto error =
+        CubDebug(detail::alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))
+  {
+    return error;
+  }
 
   if (d_temp_storage == nullptr)
   {
-    temp_storage_bytes = 1;
     return cudaSuccess;
   }
 
@@ -214,29 +236,45 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   const int grid_dim      = static_cast<int>(num_segments.get_param(0));
   constexpr int block_dim = selected.block_threads;
 
-  if (const auto error = CubDebug(
-        THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(grid_dim, block_dim, 0, stream)
-          .doit(device_segmented_topk_kernel<PolicySelector,
-                                             KeyInputItItT,
-                                             KeyOutputItItT,
-                                             ValueInputItItT,
-                                             ValueOutputItItT,
-                                             SegmentSizeParameterT,
-                                             KParameterT,
-                                             SelectDirectionParameterT,
-                                             NumSegmentsParameterT>,
-                d_key_segments_it,
-                d_key_segments_out_it,
-                d_value_segments_it,
-                d_value_segments_out_it,
-                segment_sizes,
-                k,
-                select_directions,
-                num_segments)))
+  if constexpr (any_small_segments)
   {
-    return error;
+    if (const auto error = CubDebug(
+          THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(grid_dim, block_dim, 0, stream)
+            .doit(
+              device_segmented_topk_kernel<PolicySelector,
+                                           KeyInputItItT,
+                                           KeyOutputItItT,
+                                           ValueInputItItT,
+                                           ValueOutputItItT,
+                                           SegmentSizeParameterT,
+                                           KParameterT,
+                                           SelectDirectionParameterT,
+                                           NumSegmentsParameterT>,
+              d_key_segments_it,
+              d_key_segments_out_it,
+              d_value_segments_it,
+              d_value_segments_out_it,
+              segment_sizes,
+              k,
+              select_directions,
+              num_segments,
+              only_small_segments ? nullptr : static_cast<typename NumSegmentsParameterT::value_type*>(allocations[0]),
+              only_small_segments ? nullptr : static_cast<::cuda::std::uint32_t*>(allocations[1]),
+              only_small_segments ? nullptr : static_cast<typename NumSegmentsParameterT::value_type*>(allocations[2]),
+              only_small_segments ? nullptr : static_cast<::cuda::std::int64_t*>(allocations[3]))))
+    {
+      return error;
+    }
+  }
+  else
+  {
+    // TODO (pauleonix): Transform-Scan over all segments for tile offsets.
   }
 
+  if constexpr (!only_small_segments)
+  {
+    // TODO (pauleonix): Segmented sort as a placeholder for the large segment agent.
+  }
   return CubDebug(detail::DebugSyncStream(stream));
 }
 } // namespace detail::batched_topk

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -17,16 +17,23 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cub/detail/choose_offset.cuh>
 #include <cub/detail/segmented_params.cuh>
 #include <cub/device/dispatch/dispatch_common.cuh>
+#include <cub/device/dispatch/dispatch_scan.cuh>
 #include <cub/device/dispatch/kernels/kernel_batched_topk.cuh>
 #include <cub/device/dispatch/tuning/tuning_batched_topk.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_math.cuh>
 #include <cub/util_temporary_storage.cuh>
+#include <cub/util_type.cuh>
 
 #include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
 
+#include <cuda/__cmath/ceil_div.h>
+#include <cuda/__iterator/counting_iterator.h>
+#include <cuda/__iterator/transform_iterator.h>
+#include <cuda/std/__functional/operations.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/cstdint>
 #include <cuda/std/limits>
@@ -134,6 +141,26 @@ struct total_num_items_guarantee
 };
 
 // -----------------------------------------------------------------------------
+// Helper: turn a segment ID into the number of large-segment-agent tiles needed
+// to cover that segment. Wrapped in a transform_iterator, this produces the
+// per-segment tile counts that we exclusive-scan to obtain per-segment tile
+// offsets.
+// -----------------------------------------------------------------------------
+template <typename SegmentSizeParameterT>
+struct segment_size_to_tile_count_op
+{
+  SegmentSizeParameterT segment_sizes;
+  ::cuda::std::int32_t large_segment_agent_tile_size;
+
+  template <typename SegmentIndexT>
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE constexpr ::cuda::std::int64_t operator()(SegmentIndexT segment_id) const
+  {
+    return static_cast<::cuda::std::int64_t>(
+      ::cuda::ceil_div(segment_sizes.get_param(segment_id), large_segment_agent_tile_size));
+  }
+};
+
+// -----------------------------------------------------------------------------
 // Segmented Top-K Dispatch
 // -----------------------------------------------------------------------------
 
@@ -203,15 +230,50 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
     params::static_min_value_v<SegmentSizeParameterT> <= worker_per_segment_tile_size;
   static constexpr bool only_small_segments =
     params::static_max_value_v<SegmentSizeParameterT> <= worker_per_segment_tile_size;
-  constexpr int allocations_array_size            = !only_small_segments ? 4 : 1;
+
+  static constexpr auto large_segment_agent_tile_size = selected.epilogue.multi_worker_tile_size;
+
+  // Allocation layout:
+  //   only_small_segments: [0] dummy.
+  //   any_small_segments && !only_small_segments (mixed): [0] tile offsets, [1] counters struct,
+  //                                                       [2] large-segment ids.
+  //   !any_small_segments (large-only): [0] tile offsets, [1] segment-size transform-scan temp storage.
+  static constexpr int allocations_array_size     = only_small_segments ? 1 : (any_small_segments ? 3 : 2);
   size_t allocation_sizes[allocations_array_size] = {1};
+  using num_segments_val_t                        = typename NumSegmentsParameterT::value_type;
+  using segment_size_scan_offset_t                = detail::choose_offset_t<num_segments_val_t>;
+  using segment_size_scan_input_op_t              = segment_size_to_tile_count_op<SegmentSizeParameterT>;
+  const segment_size_scan_input_op_t segment_size_scan_input_op{segment_sizes, large_segment_agent_tile_size};
+  // Transform iterator over [0, num_segments) producing the tile-count for each segment.
+  [[maybe_unused]] const auto segment_size_scan_input_it = ::cuda::transform_iterator(
+    ::cuda::counting_iterator<num_segments_val_t>{num_segments_val_t{0}}, segment_size_scan_input_op);
+
   if constexpr (!only_small_segments)
   {
     const auto num_segments_val = num_segments.get_param(0);
-    allocation_sizes[0]         = sizeof(typename NumSegmentsParameterT::value_type);
-    allocation_sizes[1]         = sizeof(::cuda::std::uint32_t);
-    allocation_sizes[2]         = num_segments_val * sizeof(typename NumSegmentsParameterT::value_type);
-    allocation_sizes[3]         = num_segments_val * sizeof(::cuda::std::int64_t);
+    // For large segments size tile offsets.
+    allocation_sizes[0] = num_segments_val * sizeof(::cuda::std::int64_t);
+    if constexpr (any_small_segments)
+    {
+      allocation_sizes[1] = sizeof(batched_topk_counters);
+      allocation_sizes[2] = num_segments_val * sizeof(num_segments_val_t);
+    }
+    else
+    {
+      // Query the temporary storage requirement of the segment-size transform-scan.
+      if (const auto error = CubDebug(detail::scan::dispatch(
+            nullptr,
+            allocation_sizes[1],
+            segment_size_scan_input_it,
+            static_cast<::cuda::std::int64_t*>(nullptr),
+            ::cuda::std::plus<>{},
+            detail::InputValue<::cuda::std::int64_t>(::cuda::std::int64_t{0}),
+            static_cast<segment_size_scan_offset_t>(num_segments_val),
+            stream)))
+      {
+        return error;
+      }
+    }
   }
 
   // Compute allocation pointers into the single storage blob (or compute the necessary size of the blob)
@@ -238,42 +300,68 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
 
   if constexpr (any_small_segments)
   {
+    if constexpr (!only_small_segments)
+    {
+      // Zero-initialize the counters struct that holds the large-segment queue length and the block retirement
+      // counter; both are read by the agent's atomic operations and must start at 0.
+      if (const auto error = CubDebug(cudaMemsetAsync(allocations[1], 0, sizeof(batched_topk_counters), stream)))
+      {
+        return error;
+      }
+    }
+
     if (const auto error = CubDebug(
           THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(grid_dim, block_dim, 0, stream)
-            .doit(
-              device_segmented_topk_kernel<PolicySelector,
-                                           KeyInputItItT,
-                                           KeyOutputItItT,
-                                           ValueInputItItT,
-                                           ValueOutputItItT,
-                                           SegmentSizeParameterT,
-                                           KParameterT,
-                                           SelectDirectionParameterT,
-                                           NumSegmentsParameterT>,
-              d_key_segments_it,
-              d_key_segments_out_it,
-              d_value_segments_it,
-              d_value_segments_out_it,
-              segment_sizes,
-              k,
-              select_directions,
-              num_segments,
-              only_small_segments ? nullptr : static_cast<typename NumSegmentsParameterT::value_type*>(allocations[0]),
-              only_small_segments ? nullptr : static_cast<::cuda::std::uint32_t*>(allocations[1]),
-              only_small_segments ? nullptr : static_cast<typename NumSegmentsParameterT::value_type*>(allocations[2]),
-              only_small_segments ? nullptr : static_cast<::cuda::std::int64_t*>(allocations[3]))))
+            .doit(device_segmented_topk_kernel<PolicySelector,
+                                               KeyInputItItT,
+                                               KeyOutputItItT,
+                                               ValueInputItItT,
+                                               ValueOutputItItT,
+                                               SegmentSizeParameterT,
+                                               KParameterT,
+                                               SelectDirectionParameterT,
+                                               NumSegmentsParameterT>,
+                  d_key_segments_it,
+                  d_key_segments_out_it,
+                  d_value_segments_it,
+                  d_value_segments_out_it,
+                  segment_sizes,
+                  k,
+                  select_directions,
+                  num_segments,
+                  only_small_segments ? nullptr : static_cast<batched_topk_counters*>(allocations[1]),
+                  only_small_segments ? nullptr : static_cast<num_segments_val_t*>(allocations[2]),
+                  only_small_segments ? nullptr : static_cast<::cuda::std::int64_t*>(allocations[0]))))
     {
       return error;
     }
   }
   else
   {
-    // TODO (pauleonix): Transform-Scan over all segments for tile offsets.
+    // No small segments: the small-kernel epilogue (which would otherwise produce the per-segment tile offsets) does
+    // not run. Compute the per-segment tile offsets directly via a transform-scan over all segment sizes.
+    // The large segment agent will either consume these offsets directly (segment_id -> tile offset) or, when going
+    // through the large-segment queue, via a transform iterator over `d_large_segments_ids` (level of indirection).
+    if (const auto error = CubDebug(detail::scan::dispatch(
+          allocations[1],
+          allocation_sizes[1],
+          segment_size_scan_input_it,
+          static_cast<::cuda::std::int64_t*>(allocations[0]),
+          ::cuda::std::plus<>{},
+          detail::InputValue<::cuda::std::int64_t>(::cuda::std::int64_t{0}),
+          static_cast<segment_size_scan_offset_t>(num_segments.get_param(0)),
+          stream)))
+    {
+      return error;
+    }
   }
 
   if constexpr (!only_small_segments)
   {
-    // TODO (pauleonix): Segmented sort as a placeholder for the large segment agent.
+    // TODO (elstehle): Implement the large segment agent.
+    // Depending on any_small_segments, we need to either:
+    // - Indirectly get the large segment parameters via the queued large segment IDs
+    // - Directly take the segment parameters since all segments are large
   }
   return CubDebug(detail::DebugSyncStream(stream));
 }

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -140,16 +140,16 @@ struct total_num_items_guarantee
 // per-segment tile counts that we exclusive-scan to obtain per-segment tile
 // offsets.
 // -----------------------------------------------------------------------------
-template <typename SegmentSizeParameterT>
+template <class SegmentSizeParameterT, class TotalNumItemsValueType>
 struct segment_size_to_tile_count_op
 {
   SegmentSizeParameterT segment_sizes;
-  ::cuda::std::int32_t large_segment_agent_tile_size;
+  int large_segment_agent_tile_size;
 
   template <typename SegmentIndexT>
-  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE constexpr ::cuda::std::int64_t operator()(SegmentIndexT segment_id) const
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE constexpr TotalNumItemsValueType operator()(SegmentIndexT segment_id) const
   {
-    return static_cast<::cuda::std::int64_t>(
+    return static_cast<TotalNumItemsValueType>(
       ::cuda::ceil_div(segment_sizes.get_param(segment_id), large_segment_agent_tile_size));
   }
 };
@@ -206,6 +206,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   cudaStream_t stream                             = nullptr,
   [[maybe_unused]] PolicySelector policy_selector = {})
 {
+  using large_segment_tile_offset_t = typename TotalNumItemsGuaranteeT::value_type;
   // Helper that determines (a) whether there's any one-worker-per-segment policy supporting the range of segment
   // sizes and k, and (b) if so, which set of one-worker-per-segment policies to use
   constexpr auto policy = find_smallest_covering_policy<
@@ -218,7 +219,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
     SegmentSizeParameterT,
     KParameterT,
     SelectDirectionParameterT,
-    NumSegmentsParameterT>::policy;
+    NumSegmentsParameterT,
+    large_segment_tile_offset_t>::policy;
   constexpr worker_policy worker_per_segment_policy             = policy.worker_per_segment_policy;
   constexpr multi_worker_policy multi_worker_per_segment_policy = policy.multi_worker_per_segment_policy;
 
@@ -236,9 +238,12 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   //   !any_small_segments (large-only): [0] tile offsets, [1] segment-size transform-scan temp storage.
   static constexpr int allocations_array_size     = only_small_segments ? 1 : (any_small_segments ? 3 : 2);
   size_t allocation_sizes[allocations_array_size] = {1};
-  using num_segments_val_t                        = typename NumSegmentsParameterT::value_type;
-  using segment_size_scan_offset_t                = detail::choose_offset_t<num_segments_val_t>;
-  using segment_size_scan_input_op_t              = segment_size_to_tile_count_op<SegmentSizeParameterT>;
+
+  using num_segments_val_t         = typename NumSegmentsParameterT::value_type;
+  using counters_t                 = batched_topk_counters<num_segments_val_t>;
+  using segment_size_scan_offset_t = detail::choose_offset_t<num_segments_val_t>;
+  using segment_size_scan_input_op_t =
+    segment_size_to_tile_count_op<SegmentSizeParameterT, large_segment_tile_offset_t>;
   static constexpr auto multi_worker_per_segment_tile_size =
     multi_worker_per_segment_policy.block_threads * multi_worker_per_segment_policy.items_per_thread;
   const segment_size_scan_input_op_t segment_size_scan_input_op{segment_sizes, multi_worker_per_segment_tile_size};
@@ -249,11 +254,12 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   if constexpr (!only_small_segments)
   {
     const auto num_segments_val = num_segments.get_param(0);
-    // For large segments size tile offsets.
-    allocation_sizes[0] = num_segments_val * sizeof(::cuda::std::int64_t);
+    // Scan output
+    allocation_sizes[0] = num_segments_val * sizeof(large_segment_tile_offset_t);
     if constexpr (any_small_segments)
     {
-      allocation_sizes[1] = sizeof(batched_topk_counters);
+      allocation_sizes[1] = sizeof(counters_t);
+      // Large segment ids for indirectly accessing the large segment parameters
       allocation_sizes[2] = num_segments_val * sizeof(num_segments_val_t);
     }
     else
@@ -263,9 +269,9 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
             nullptr,
             allocation_sizes[1],
             segment_size_scan_input_it,
-            static_cast<::cuda::std::int64_t*>(nullptr),
+            static_cast<large_segment_tile_offset_t*>(nullptr),
             ::cuda::std::plus<>{},
-            detail::InputValue<::cuda::std::int64_t>(::cuda::std::int64_t{0}),
+            detail::InputValue<large_segment_tile_offset_t>(large_segment_tile_offset_t{0}),
             static_cast<segment_size_scan_offset_t>(num_segments_val),
             stream)))
       {
@@ -298,7 +304,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
     {
       // Zero-initialize the counters struct that holds the large-segment queue length and the block retirement
       // counter; both are read by the agent's atomic operations and must start at 0.
-      if (const auto error = CubDebug(cudaMemsetAsync(allocations[1], 0, sizeof(batched_topk_counters), stream)))
+      if (const auto error = CubDebug(cudaMemsetAsync(allocations[1], 0, sizeof(counters_t), stream)))
       {
         return error;
       }
@@ -307,26 +313,29 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
     constexpr int block_dim = worker_per_segment_policy.block_threads;
     if (const auto error = CubDebug(
           THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(grid_dim, block_dim, 0, stream)
-            .doit(device_segmented_topk_kernel<PolicySelector,
-                                               KeyInputItItT,
-                                               KeyOutputItItT,
-                                               ValueInputItItT,
-                                               ValueOutputItItT,
-                                               SegmentSizeParameterT,
-                                               KParameterT,
-                                               SelectDirectionParameterT,
-                                               NumSegmentsParameterT>,
-                  d_key_segments_it,
-                  d_key_segments_out_it,
-                  d_value_segments_it,
-                  d_value_segments_out_it,
-                  segment_sizes,
-                  k,
-                  select_directions,
-                  num_segments,
-                  only_small_segments ? nullptr : static_cast<batched_topk_counters*>(allocations[1]),
-                  only_small_segments ? nullptr : static_cast<num_segments_val_t*>(allocations[2]),
-                  only_small_segments ? nullptr : static_cast<::cuda::std::int64_t*>(allocations[0]))))
+            .doit(
+              device_segmented_topk_kernel<
+                PolicySelector,
+                KeyInputItItT,
+                KeyOutputItItT,
+                ValueInputItItT,
+                ValueOutputItItT,
+                SegmentSizeParameterT,
+                KParameterT,
+                SelectDirectionParameterT,
+                NumSegmentsParameterT,
+                large_segment_tile_offset_t>,
+              d_key_segments_it,
+              d_key_segments_out_it,
+              d_value_segments_it,
+              d_value_segments_out_it,
+              segment_sizes,
+              k,
+              select_directions,
+              num_segments,
+              only_small_segments ? nullptr : static_cast<counters_t*>(allocations[1]),
+              only_small_segments ? nullptr : static_cast<num_segments_val_t*>(allocations[2]),
+              only_small_segments ? nullptr : static_cast<large_segment_tile_offset_t*>(allocations[0]))))
     {
       return error;
     }
@@ -341,9 +350,9 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
           allocations[1],
           allocation_sizes[1],
           segment_size_scan_input_it,
-          static_cast<::cuda::std::int64_t*>(allocations[0]),
+          static_cast<large_segment_tile_offset_t*>(allocations[0]),
           ::cuda::std::plus<>{},
-          detail::InputValue<::cuda::std::int64_t>(::cuda::std::int64_t{0}),
+          detail::InputValue<large_segment_tile_offset_t>(large_segment_tile_offset_t{0}),
           static_cast<segment_size_scan_offset_t>(num_segments.get_param(0)),
           stream)))
     {

--- a/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 //! @file

--- a/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
@@ -106,7 +106,8 @@ template <typename PolicySelector,
           typename SegmentSizeParameterT,
           typename KParameterT,
           typename SelectDirectionParameterT,
-          typename NumSegmentsParameterT>
+          typename NumSegmentsParameterT,
+          typename LargeSegmentTileOffsetT>
 #if _CCCL_HAS_CONCEPTS()
   requires batched_topk_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
@@ -121,7 +122,8 @@ __launch_bounds__(int(
     SegmentSizeParameterT,
     KParameterT,
     SelectDirectionParameterT,
-    NumSegmentsParameterT>::policy.worker_per_segment_policy.block_threads)) __global__
+    NumSegmentsParameterT,
+    LargeSegmentTileOffsetT>::policy.worker_per_segment_policy.block_threads)) __global__
   void device_segmented_topk_kernel(
     KeyInputItItT d_key_segments_it,
     KeyOutputItItT d_key_segments_out_it,
@@ -131,9 +133,9 @@ __launch_bounds__(int(
     KParameterT k,
     SelectDirectionParameterT select_directions,
     NumSegmentsParameterT num_segments,
-    batched_topk_counters* d_counters,
+    batched_topk_counters<typename NumSegmentsParameterT::value_type>* d_counters,
     typename NumSegmentsParameterT::value_type* d_large_segments_ids,
-    ::cuda::std::int64_t* d_large_segments_tile_offsets)
+    LargeSegmentTileOffsetT* d_large_segments_tile_offsets)
 {
   using agent_t = typename find_smallest_covering_policy<
     PolicySelector,
@@ -145,7 +147,8 @@ __launch_bounds__(int(
     SegmentSizeParameterT,
     KParameterT,
     SelectDirectionParameterT,
-    NumSegmentsParameterT>::agent_t;
+    NumSegmentsParameterT,
+    LargeSegmentTileOffsetT>::agent_t;
 
   // Static Assertions (Constraints)
   static_assert(agent_t::tile_size >= params::static_max_value_v<SegmentSizeParameterT>,

--- a/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
@@ -34,6 +34,11 @@ template <typename PolicySelector, typename SegmentSizeParameterT, typename... A
 struct find_smallest_covering_policy
 {
 private:
+  struct policy_t
+  {
+    worker_policy worker_per_segment_policy;
+    multi_worker_policy multi_worker_per_segment_policy;
+  };
   static constexpr ::cuda::std::int64_t max_segment_size = params::static_max_value_v<SegmentSizeParameterT>;
   static constexpr batched_topk_policy active_policy     = current_policy<PolicySelector>();
 
@@ -53,7 +58,8 @@ private:
       {
         _CCCL_API constexpr auto operator()() const
         {
-          return active_policy.worker_per_segment_policies[Index];
+          return policy_t{active_policy.worker_per_segment_policies[Index],
+                          active_policy.multi_worker_per_segment_policy};
         }
       };
       using candidate_agent_t  = agent_batched_topk_worker_per_segment<policy_getter_17, AgentParamsT...>;
@@ -76,7 +82,8 @@ private:
 public:
   // TODO (elstehle): extend support for variable-size segments
   static_assert(selected_index >= 0, "No valid policy found for one-worker-per-segment approach");
-  static constexpr worker_policy policy = active_policy.worker_per_segment_policies[selected_index];
+  static constexpr policy_t policy = {
+    active_policy.worker_per_segment_policies[selected_index], active_policy.multi_worker_per_segment_policy};
 
   struct policy_getter_17 // TODO(bgruber): drop this in C++17 and pass policy directly
   {
@@ -114,7 +121,7 @@ __launch_bounds__(int(
     SegmentSizeParameterT,
     KParameterT,
     SelectDirectionParameterT,
-    NumSegmentsParameterT>::policy.block_threads)) __global__
+    NumSegmentsParameterT>::policy.worker_per_segment_policy.block_threads)) __global__
   void device_segmented_topk_kernel(
     KeyInputItItT d_key_segments_it,
     KeyOutputItItT d_key_segments_out_it,

--- a/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
@@ -123,7 +123,11 @@ __launch_bounds__(int(
     SegmentSizeParameterT segment_sizes,
     KParameterT k,
     SelectDirectionParameterT select_directions,
-    NumSegmentsParameterT num_segments)
+    NumSegmentsParameterT num_segments,
+    typename NumSegmentsParameterT::value_type* d_large_segments_counter,
+    ::cuda::std::uint32_t* d_retirement_counter,
+    typename NumSegmentsParameterT::value_type* d_large_segments_ids,
+    ::cuda::std::int64_t* d_large_segments_tile_offsets)
 {
   using agent_t = typename find_smallest_covering_policy<
     PolicySelector,
@@ -156,7 +160,11 @@ __launch_bounds__(int(
     segment_sizes,
     k,
     select_directions,
-    num_segments);
+    num_segments,
+    d_large_segments_counter,
+    d_retirement_counter,
+    d_large_segments_ids,
+    d_large_segments_tile_offsets);
 
   // Process segments
   agent.Process();

--- a/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
@@ -124,8 +124,7 @@ __launch_bounds__(int(
     KParameterT k,
     SelectDirectionParameterT select_directions,
     NumSegmentsParameterT num_segments,
-    typename NumSegmentsParameterT::value_type* d_large_segments_counter,
-    ::cuda::std::uint32_t* d_retirement_counter,
+    batched_topk_counters* d_counters,
     typename NumSegmentsParameterT::value_type* d_large_segments_ids,
     ::cuda::std::int64_t* d_large_segments_tile_offsets)
 {
@@ -161,8 +160,7 @@ __launch_bounds__(int(
     k,
     select_directions,
     num_segments,
-    d_large_segments_counter,
-    d_retirement_counter,
+    d_counters,
     d_large_segments_ids,
     d_large_segments_tile_offsets);
 

--- a/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #pragma once

--- a/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
@@ -30,6 +30,12 @@ struct worker_policy
   BlockLoadAlgorithm load_algorithm;
   BlockStoreAlgorithm store_algorithm;
 
+  int epilogue_items_per_thread;
+  // TODO(pauleonix): Do we want to reuse the same load and store algorithms for the epilogue?
+  BlockLoadAlgorithm epilogue_load_algorithm;
+  BlockScanAlgorithm epilogue_scan_algorithm;
+  BlockStoreAlgorithm epilogue_store_algorithm;
+
   _CCCL_API constexpr friend bool operator==(const worker_policy& lhs, const worker_policy& rhs)
   {
     return lhs.block_threads == rhs.block_threads && lhs.items_per_thread == rhs.items_per_thread
@@ -93,15 +99,17 @@ struct policy_selector
 {
   [[nodiscard]] _CCCL_API constexpr auto operator()(::cuda::arch_id /*arch*/) const -> batched_topk_policy
   {
-    constexpr auto load_alg  = BLOCK_LOAD_WARP_TRANSPOSE;
-    constexpr auto store_alg = BLOCK_STORE_WARP_TRANSPOSE;
+    constexpr auto load_alg                 = BLOCK_LOAD_WARP_TRANSPOSE;
+    constexpr auto store_alg                = BLOCK_STORE_WARP_TRANSPOSE;
+    constexpr auto epilogue_scan_alg        = BLOCK_SCAN_WARP_SCANS;
+    constexpr int epilogue_items_per_thread = 16;
     return batched_topk_policy{{{
-      worker_policy{256, 64, load_alg, store_alg},
-      worker_policy{256, 32, load_alg, store_alg},
-      worker_policy{256, 16, load_alg, store_alg},
-      worker_policy{256, 8, load_alg, store_alg},
-      worker_policy{256, 4, load_alg, store_alg},
-      worker_policy{128, 2, load_alg, store_alg},
+      worker_policy{256, 64, load_alg, store_alg, epilogue_items_per_thread, load_alg, epilogue_scan_alg, store_alg},
+      worker_policy{256, 32, load_alg, store_alg, epilogue_items_per_thread, load_alg, epilogue_scan_alg, store_alg},
+      worker_policy{256, 16, load_alg, store_alg, epilogue_items_per_thread, load_alg, epilogue_scan_alg, store_alg},
+      worker_policy{256, 8, load_alg, store_alg, epilogue_items_per_thread, load_alg, epilogue_scan_alg, store_alg},
+      worker_policy{256, 4, load_alg, store_alg, epilogue_items_per_thread, load_alg, epilogue_scan_alg, store_alg},
+      worker_policy{128, 2, load_alg, store_alg, epilogue_items_per_thread, load_alg, epilogue_scan_alg, store_alg},
     }}};
   }
 };

--- a/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
@@ -27,13 +27,29 @@ namespace detail::batched_topk
 struct epilogue_policy
 {
   int items_per_thread;
-  // TODO (elstehle): worker-agent needs to know tile size of multi-worker agent but it isn't a tuning parameter for the
-  // worker-agent. Depending on how the tuning for the multi-worker agent is implemented, the way this is passed to the
-  // worker-agent might need to be changed.
-  int multi_worker_tile_size;
   BlockLoadAlgorithm load_algorithm;
   BlockStoreAlgorithm store_algorithm;
   BlockScanAlgorithm scan_algorithm;
+
+  _CCCL_API constexpr friend bool operator==(const epilogue_policy& lhs, const epilogue_policy& rhs)
+  {
+    return lhs.items_per_thread == rhs.items_per_thread && lhs.load_algorithm == rhs.load_algorithm
+        && lhs.store_algorithm == rhs.store_algorithm && lhs.scan_algorithm == rhs.scan_algorithm;
+  }
+
+  _CCCL_API constexpr friend bool operator!=(const epilogue_policy& lhs, const epilogue_policy& rhs)
+  {
+    return !(lhs == rhs);
+  }
+
+#if !_CCCL_COMPILER(NVRTC)
+  friend ::std::ostream& operator<<(::std::ostream& os, const epilogue_policy& p)
+  {
+    return os
+        << "epilogue_policy { .items_per_thread = " << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm
+        << ", .store_algorithm = " << p.store_algorithm << ", .scan_algorithm = " << p.scan_algorithm << " }";
+  }
+#endif // !_CCCL_COMPILER(NVRTC)
 };
 
 struct worker_policy
@@ -48,7 +64,8 @@ struct worker_policy
   _CCCL_API constexpr friend bool operator==(const worker_policy& lhs, const worker_policy& rhs)
   {
     return lhs.block_threads == rhs.block_threads && lhs.items_per_thread == rhs.items_per_thread
-        && lhs.load_algorithm == rhs.load_algorithm && lhs.store_algorithm == rhs.store_algorithm;
+        && lhs.load_algorithm == rhs.load_algorithm && lhs.store_algorithm == rhs.store_algorithm
+        && lhs.epilogue == rhs.epilogue;
   }
 
   _CCCL_API constexpr friend bool operator!=(const worker_policy& lhs, const worker_policy& rhs)
@@ -59,9 +76,33 @@ struct worker_policy
 #if !_CCCL_COMPILER(NVRTC)
   friend ::std::ostream& operator<<(::std::ostream& os, const worker_policy& p)
   {
-    return os
-        << "worker_policy { .block_threads = " << p.block_threads << ", .items_per_thread = " << p.items_per_thread
-        << ", .load_algorithm = " << p.load_algorithm << ", .store_algorithm = " << p.store_algorithm << " }";
+    return os << "worker_policy { .block_threads = " << p.block_threads
+              << ", .items_per_thread = " << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm
+              << ", .store_algorithm = " << p.store_algorithm << ", .epilogue = " << p.epilogue << " }";
+  }
+#endif // !_CCCL_COMPILER(NVRTC)
+};
+
+struct multi_worker_policy
+{
+  int block_threads;
+  int items_per_thread;
+
+  _CCCL_API constexpr friend bool operator==(const multi_worker_policy& lhs, const multi_worker_policy& rhs)
+  {
+    return lhs.block_threads == rhs.block_threads && lhs.items_per_thread == rhs.items_per_thread;
+  }
+
+  _CCCL_API constexpr friend bool operator!=(const multi_worker_policy& lhs, const multi_worker_policy& rhs)
+  {
+    return !(lhs == rhs);
+  }
+
+#if !_CCCL_COMPILER(NVRTC)
+  friend ::std::ostream& operator<<(::std::ostream& os, const multi_worker_policy& p)
+  {
+    return os << "multi_worker_policy { .block_threads = " << p.block_threads
+              << ", .items_per_thread = " << p.items_per_thread << " }";
   }
 #endif // !_CCCL_COMPILER(NVRTC)
 };
@@ -71,10 +112,12 @@ struct batched_topk_policy
   // The list of per-segment agent policies is ordered by decreasing tile size. At compile time, the smallest policy
   // whose tile size still covers the upper bound of the segment size is selected.
   ::cuda::std::array<worker_policy, 6> worker_per_segment_policies;
+  multi_worker_policy multi_worker_per_segment_policy;
 
   _CCCL_API constexpr friend bool operator==(const batched_topk_policy& lhs, const batched_topk_policy& rhs)
   {
-    return lhs.worker_per_segment_policies == rhs.worker_per_segment_policies;
+    return lhs.worker_per_segment_policies == rhs.worker_per_segment_policies
+        && lhs.multi_worker_per_segment_policy == rhs.multi_worker_per_segment_policy;
   }
 
   _CCCL_API constexpr friend bool operator!=(const batched_topk_policy& lhs, const batched_topk_policy& rhs)
@@ -94,7 +137,7 @@ struct batched_topk_policy
       }
       os << p.worker_per_segment_policies[i];
     }
-    return os << " } }";
+    return os << " }, .multi_worker_per_segment_policy = " << p.multi_worker_per_segment_policy << " }";
   }
 #endif // !_CCCL_COMPILER(NVRTC)
 };
@@ -108,22 +151,20 @@ struct policy_selector
 {
   [[nodiscard]] _CCCL_API constexpr auto operator()(::cuda::arch_id /*arch*/) const -> batched_topk_policy
   {
-    constexpr auto load_alg                  = BLOCK_LOAD_WARP_TRANSPOSE;
-    constexpr auto store_alg                 = BLOCK_STORE_WARP_TRANSPOSE;
-    constexpr auto scan_alg                  = BLOCK_SCAN_WARP_SCANS;
-    constexpr auto epilogue_items_per_thread = 16;
-    constexpr auto multi_worker_tile_size    = 256 * 64;
-    constexpr auto epilogue =
-      epilogue_policy{epilogue_items_per_thread, multi_worker_tile_size, load_alg, store_alg, scan_alg};
-    // Only the first policy actually needs an epilogue policy.
-    return batched_topk_policy{{{
-      worker_policy{256, 64, load_alg, store_alg, epilogue},
-      worker_policy{256, 32, load_alg, store_alg, epilogue},
-      worker_policy{256, 16, load_alg, store_alg, epilogue},
-      worker_policy{256, 8, load_alg, store_alg, epilogue},
-      worker_policy{256, 4, load_alg, store_alg, epilogue},
-      worker_policy{128, 2, load_alg, store_alg, epilogue},
-    }}};
+    constexpr auto load_alg  = BLOCK_LOAD_WARP_TRANSPOSE;
+    constexpr auto store_alg = BLOCK_STORE_WARP_TRANSPOSE;
+    constexpr auto scan_alg  = BLOCK_SCAN_WARP_SCANS;
+    constexpr auto epilogue  = epilogue_policy{16, load_alg, store_alg, scan_alg};
+    return batched_topk_policy{
+      {{
+        worker_policy{256, 64, load_alg, store_alg, epilogue},
+        worker_policy{256, 32, load_alg, store_alg, epilogue},
+        worker_policy{256, 16, load_alg, store_alg, epilogue},
+        worker_policy{256, 8, load_alg, store_alg, epilogue},
+        worker_policy{256, 4, load_alg, store_alg, epilogue},
+        worker_policy{128, 2, load_alg, store_alg, epilogue},
+      }},
+      multi_worker_policy{256, 64}};
   }
 };
 

--- a/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
@@ -14,6 +14,7 @@
 #endif // no system header
 
 #include <cub/block/block_load.cuh>
+#include <cub/block/block_scan.cuh>
 #include <cub/block/block_store.cuh>
 
 #include <cuda/__device/arch_id.h>

--- a/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
@@ -23,6 +23,18 @@
 CUB_NAMESPACE_BEGIN
 namespace detail::batched_topk
 {
+struct epilogue_policy
+{
+  int items_per_thread;
+  // TODO (elstehle): worker-agent needs to know tile size of multi-worker agent but it isn't a tuning parameter for the
+  // worker-agent. Depending on how the tuning for the multi-worker agent is implemented, the way this is passed to the
+  // worker-agent might need to be changed.
+  int multi_worker_tile_size;
+  BlockLoadAlgorithm load_algorithm;
+  BlockScanAlgorithm scan_algorithm;
+  BlockStoreAlgorithm store_algorithm;
+};
+
 struct worker_policy
 {
   int block_threads;
@@ -30,11 +42,7 @@ struct worker_policy
   BlockLoadAlgorithm load_algorithm;
   BlockStoreAlgorithm store_algorithm;
 
-  int epilogue_items_per_thread;
-  // TODO(pauleonix): Do we want to reuse the same load and store algorithms for the epilogue?
-  BlockLoadAlgorithm epilogue_load_algorithm;
-  BlockScanAlgorithm epilogue_scan_algorithm;
-  BlockStoreAlgorithm epilogue_store_algorithm;
+  epilogue_policy epilogue;
 
   _CCCL_API constexpr friend bool operator==(const worker_policy& lhs, const worker_policy& rhs)
   {
@@ -99,17 +107,20 @@ struct policy_selector
 {
   [[nodiscard]] _CCCL_API constexpr auto operator()(::cuda::arch_id /*arch*/) const -> batched_topk_policy
   {
-    constexpr auto load_alg                 = BLOCK_LOAD_WARP_TRANSPOSE;
-    constexpr auto store_alg                = BLOCK_STORE_WARP_TRANSPOSE;
-    constexpr auto epilogue_scan_alg        = BLOCK_SCAN_WARP_SCANS;
-    constexpr int epilogue_items_per_thread = 16;
+    constexpr auto load_alg                  = BLOCK_LOAD_WARP_TRANSPOSE;
+    constexpr auto store_alg                 = BLOCK_STORE_WARP_TRANSPOSE;
+    constexpr auto scan_alg                  = BLOCK_SCAN_WARP_SCANS;
+    constexpr auto epilogue_items_per_thread = 16;
+    constexpr auto multi_worker_tile_size    = 256 * 64;
+    constexpr auto epilogue =
+      epilogue_policy{epilogue_items_per_thread, multi_worker_tile_size, load_alg, scan_alg, store_alg};
     return batched_topk_policy{{{
-      worker_policy{256, 64, load_alg, store_alg, epilogue_items_per_thread, load_alg, epilogue_scan_alg, store_alg},
-      worker_policy{256, 32, load_alg, store_alg, epilogue_items_per_thread, load_alg, epilogue_scan_alg, store_alg},
-      worker_policy{256, 16, load_alg, store_alg, epilogue_items_per_thread, load_alg, epilogue_scan_alg, store_alg},
-      worker_policy{256, 8, load_alg, store_alg, epilogue_items_per_thread, load_alg, epilogue_scan_alg, store_alg},
-      worker_policy{256, 4, load_alg, store_alg, epilogue_items_per_thread, load_alg, epilogue_scan_alg, store_alg},
-      worker_policy{128, 2, load_alg, store_alg, epilogue_items_per_thread, load_alg, epilogue_scan_alg, store_alg},
+      worker_policy{256, 64, load_alg, store_alg, epilogue},
+      worker_policy{256, 32, load_alg, store_alg, epilogue},
+      worker_policy{256, 16, load_alg, store_alg, epilogue},
+      worker_policy{256, 8, load_alg, store_alg, epilogue},
+      worker_policy{256, 4, load_alg, store_alg, epilogue},
+      worker_policy{128, 2, load_alg, store_alg, epilogue},
     }}};
   }
 };

--- a/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
@@ -32,8 +32,8 @@ struct epilogue_policy
   // worker-agent might need to be changed.
   int multi_worker_tile_size;
   BlockLoadAlgorithm load_algorithm;
-  BlockScanAlgorithm scan_algorithm;
   BlockStoreAlgorithm store_algorithm;
+  BlockScanAlgorithm scan_algorithm;
 };
 
 struct worker_policy
@@ -114,7 +114,8 @@ struct policy_selector
     constexpr auto epilogue_items_per_thread = 16;
     constexpr auto multi_worker_tile_size    = 256 * 64;
     constexpr auto epilogue =
-      epilogue_policy{epilogue_items_per_thread, multi_worker_tile_size, load_alg, scan_alg, store_alg};
+      epilogue_policy{epilogue_items_per_thread, multi_worker_tile_size, load_alg, store_alg, scan_alg};
+    // Only the first policy actually needs an epilogue policy.
     return batched_topk_policy{{{
       worker_policy{256, 64, load_alg, store_alg, epilogue},
       worker_policy{256, 32, load_alg, store_alg, epilogue},


### PR DESCRIPTION
## Description

This PR just handles the preparation for the multi-worker/large-segment agent/kernel that @elstehle is working on.

It implements a queue for the existing single-worker agent to queue tiles that are too large for it to handle and adds an epilogue that does a plus-scan on the segment sizes (in units of tiles of the multi-worker agent) from that queue. The resulting offsets from this fused scan will be used by the multi-worker agent for load-balancing-search.

In case we know that all items are too big for the single-worker agent, we avoid launching it and directly dispatch a SOL device scan for the load-balancing search offsets.

Due to the partial nature of this PR, the large segment handling (ids and offsets) can't really be tested yet.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #8364 

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
