### PR TITLE
Fix `<cuda/barrier>` `clang-tidy` warnings

### DIFF
--- a/libcudacxx/include/cuda/__barrier/barrier_block_scope.h
+++ b/libcudacxx/include/cuda/__barrier/barrier_block_scope.h
@@ -241,7 +241,7 @@ private:
   {
     if (::cuda::device::is_object_from(__barrier, ::cuda::device::address_space::shared))
     {
-      bool __ready = 0;
+      bool __ready = false;
       ::cuda::std::chrono::high_resolution_clock::time_point const __start =
         ::cuda::std::chrono::high_resolution_clock::now();
       ::cuda::std::chrono::nanoseconds __elapsed(0);
@@ -371,7 +371,7 @@ private:
         ::cuda::std::__barrier_poll_tester_parity<barrier>(this, __phase_parity), __nanosec);
     }
 
-    bool __ready = 0;
+    bool __ready = false;
     ::cuda::std::chrono::high_resolution_clock::time_point const __start =
       ::cuda::std::chrono::high_resolution_clock::now();
     do

--- a/libcudacxx/include/cuda/barrier
+++ b/libcudacxx/include/cuda/barrier
@@ -46,7 +46,7 @@
 // We need to forward-declare both CUtensorMap_st (the struct) and CUtensorMap
 // (the typedef):
 struct CUtensorMap_st;
-typedef struct CUtensorMap_st CUtensorMap;
+typedef struct CUtensorMap_st CUtensorMap; // NOLINT(modernize-use-using)
 
 #include <cuda/std/__cccl/prologue.h>
 


### PR DESCRIPTION
I've came across some `clang-tidy` warnings when including and instantiating types from `<cuda/barrier>`. Not sure why the `typedef` warning hasn't appeared earlier.