### PR TITLE
Use environment based CUB APIs when possible in PSTL

### DIFF
--- a/libcudacxx/include/cuda/std/__pstl/cuda/adjacent_difference.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/adjacent_difference.h
@@ -82,7 +82,7 @@ struct __pstl_dispatch<__pstl_algorithm::__adjacent_difference, __execution_back
       nullptr);
 
     // Allocate memory for result
-    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
     {
       __temporary_storage<> __storage{__policy, __num_bytes};
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/adjacent_difference.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/adjacent_difference.h
@@ -66,40 +66,22 @@ struct __pstl_dispatch<__pstl_algorithm::__adjacent_difference, __execution_back
     _BinaryOp __binary_op)
   {
     auto __count = ::cuda::std::distance(__first, __last);
-    auto __ret   = __result + __count;
 
-    // Determine temporary device storage requirements for device_merge
-    size_t __num_bytes = 0;
+    // We pass the policy as an environment to DeviceAdjacentDifference
     _CCCL_TRY_CUDA_API(
       CUB_NS_QUALIFIER::DeviceAdjacentDifference::SubtractLeftCopy,
-      "__pstl_cuda_merge: determination of device storage for cub::DeviceAdjacentDifference::SubtractLeftCopy failed",
-      static_cast<void*>(nullptr),
-      __num_bytes,
-      __first,
+      "__pstl_cuda_merge: kernel launch of cub::DeviceAdjacentDifference::SubtractLeftCopy failed",
+      ::cuda::std::move(__first),
       __result,
       __count,
-      __binary_op,
-      nullptr);
+      ::cuda::std::move(__binary_op),
+      __policy);
 
-    // Allocate memory for result
+    // Get the stream for synchronization after the algorithm is run
     auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
-    {
-      __temporary_storage<> __storage{__policy, __num_bytes};
+    __stream.sync();
 
-      // Run the kernel, the standard requires that the input and output range do not overlap
-      _CCCL_TRY_CUDA_API(
-        CUB_NS_QUALIFIER::DeviceAdjacentDifference::SubtractLeftCopy,
-        "__pstl_cuda_merge: kernel launch of cub::DeviceAdjacentDifference::SubtractLeftCopy failed",
-        __storage.__get_temp_storage(),
-        __num_bytes,
-        ::cuda::std::move(__first),
-        ::cuda::std::move(__result),
-        __count,
-        ::cuda::std::move(__binary_op),
-        __stream.get());
-    }
-
-    return __ret;
+    return __result + __count;
   }
 
   _CCCL_TEMPLATE(class _Policy, class _InputIterator, class _OutputIterator, class _BinaryOp)

--- a/libcudacxx/include/cuda/std/__pstl/cuda/copy_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/copy_if.h
@@ -71,7 +71,7 @@ struct __pstl_dispatch<__pstl_algorithm::__copy_if, __execution_backend::__cuda>
     using _OffsetType = iter_difference_t<_InputIterator>;
     _OffsetType __ret;
 
-    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
 
     // Determine temporary device storage requirements
     void* __temp_storage = nullptr;

--- a/libcudacxx/include/cuda/std/__pstl/cuda/copy_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/copy_n.h
@@ -70,8 +70,7 @@ struct __pstl_dispatch<__pstl_algorithm::__copy_n, __execution_backend::__cuda>
   [[nodiscard]] _CCCL_HOST_API static _OutputIterator __par_impl(
     const _Policy& __policy, _InputIterator __first, _Size __count, _OutputIterator __result, _UnaryPred __pred)
   {
-    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
-
+    // We pass the policy as an environment to DeviceTransform
     _CCCL_TRY_CUDA_API(
       CUB_NS_QUALIFIER::DeviceTransform::TransformIf,
       "__pstl_cuda_copy_n: kernel launch of device_transform failed",
@@ -80,9 +79,12 @@ struct __pstl_dispatch<__pstl_algorithm::__copy_n, __execution_backend::__cuda>
       __count,
       ::cuda::std::move(__pred),
       identity{},
-      __stream.get());
+      __policy);
 
+    // Get the stream for synchronization after the algorithm is run
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
     __stream.sync();
+
     return __result + __count;
   }
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/copy_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/copy_n.h
@@ -70,7 +70,7 @@ struct __pstl_dispatch<__pstl_algorithm::__copy_n, __execution_backend::__cuda>
   [[nodiscard]] _CCCL_HOST_API static _OutputIterator __par_impl(
     const _Policy& __policy, _InputIterator __first, _Size __count, _OutputIterator __result, _UnaryPred __pred)
   {
-    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
 
     _CCCL_TRY_CUDA_API(
       CUB_NS_QUALIFIER::DeviceTransform::TransformIf,

--- a/libcudacxx/include/cuda/std/__pstl/cuda/exclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/exclusive_scan.h
@@ -85,7 +85,7 @@ struct __pstl_dispatch<__pstl_algorithm::__exclusive_scan, __execution_backend::
       __count);
 
     // Allocate memory for result
-    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
 
     {
       __temporary_storage<> __storage{__policy, __num_bytes};

--- a/libcudacxx/include/cuda/std/__pstl/cuda/exclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/exclusive_scan.h
@@ -69,43 +69,22 @@ struct __pstl_dispatch<__pstl_algorithm::__exclusive_scan, __execution_backend::
     _BinaryOp __binary_op,
     _Tp __init)
   {
-    _OutputIterator __ret = __result + iter_difference_t<_OutputIterator>(__count);
-
-    // Determine temporary device storage requirements for reduce
-    size_t __num_bytes = 0;
+    // We pass the policy as an environment to DeviceScan
     _CCCL_TRY_CUDA_API(
       CUB_NS_QUALIFIER::DeviceScan::ExclusiveScan,
-      "__pstl_cuda_exclusive_scan: determination of device storage for cub::DeviceScan::ExclusiveScan failed",
-      static_cast<void*>(nullptr),
-      __num_bytes,
-      __first,
+      "__pstl_cuda_exclusive_scan: kernel launch of cub::DeviceScan::ExclusiveScan failed",
+      ::cuda::std::move(__first),
       __result,
-      __binary_op,
+      ::cuda::std::move(__binary_op),
       __init,
-      __count);
+      __count,
+      __policy);
 
-    // Allocate memory for result
+    // Get the stream for synchronization after the algorithm is run
     auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
-
-    {
-      __temporary_storage<> __storage{__policy, __num_bytes};
-
-      // Run the scan
-      _CCCL_TRY_CUDA_API(
-        CUB_NS_QUALIFIER::DeviceScan::ExclusiveScan,
-        "__pstl_cuda_exclusive_scan: kernel launch of cub::DeviceScan::ExclusiveScan failed",
-        __storage.__get_temp_storage(),
-        __num_bytes,
-        ::cuda::std::move(__first),
-        ::cuda::std::move(__result),
-        ::cuda::std::move(__binary_op),
-        __init,
-        __count,
-        __stream.get());
-    }
-
     __stream.sync();
-    return __ret;
+
+    return __result + iter_difference_t<_OutputIterator>(__count);
   }
 
   template <class _Policy, class _InputIterator, class _OutputIterator, class _Tp, class _BinaryOp>

--- a/libcudacxx/include/cuda/std/__pstl/cuda/find_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/find_if.h
@@ -84,7 +84,7 @@ struct __pstl_dispatch<__pstl_algorithm::__find_if, __execution_backend::__cuda>
       __num_items);
 
     // Allocate memory for result
-    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
 
     {
       __temporary_storage<_OffsetType> __storage{__policy, __num_bytes, 1};

--- a/libcudacxx/include/cuda/std/__pstl/cuda/for_each_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/for_each_n.h
@@ -68,7 +68,7 @@ struct __pstl_dispatch<__pstl_algorithm::__for_each_n, __execution_backend::__cu
   {
     const auto __count = ::cuda::std::__convert_to_integral(__orig_n);
 
-    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
 
     _CCCL_TRY_CUDA_API(
       CUB_NS_QUALIFIER::DeviceFor::ForEachN,

--- a/libcudacxx/include/cuda/std/__pstl/cuda/for_each_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/for_each_n.h
@@ -45,6 +45,7 @@ _CCCL_DIAG_POP
 #  include <cuda/std/__execution/env.h>
 #  include <cuda/std/__execution/policy.h>
 #  include <cuda/std/__host_stdlib/new>
+#  include <cuda/std/__iterator/incrementable_traits.h>
 #  include <cuda/std/__iterator/iterator_traits.h>
 #  include <cuda/std/__pstl/dispatch.h>
 #  include <cuda/std/__type_traits/always_false.h>
@@ -68,18 +69,20 @@ struct __pstl_dispatch<__pstl_algorithm::__for_each_n, __execution_backend::__cu
   {
     const auto __count = ::cuda::std::__convert_to_integral(__orig_n);
 
-    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
-
+    // We pass the policy as an environment to DeviceFor
     _CCCL_TRY_CUDA_API(
       CUB_NS_QUALIFIER::DeviceFor::ForEachN,
       "__pstl_dispatch: kernel launch failed",
       __first,
       __count,
       ::cuda::std::move(__func),
-      __stream.get());
+      __policy);
 
+    // Get the stream for synchronization after the algorithm is run
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
     __stream.sync();
-    return __first + __count;
+
+    return __first + static_cast<iter_difference_t<_Iter>>(__count);
   }
 
   template <class _Policy, class _Iter, class _Size, class _Fn>

--- a/libcudacxx/include/cuda/std/__pstl/cuda/generate_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/generate_n.h
@@ -66,20 +66,20 @@ struct __pstl_dispatch<__pstl_algorithm::__generate_n, __execution_backend::__cu
   [[nodiscard]] _CCCL_HOST_API static _OutputIterator
   __par_impl(const _Policy& __policy, _OutputIterator __result, const int64_t __count, _UnaryOp __func)
   {
-    auto __stream    = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
-    const auto __ret = __result + __count;
-
-    // We pass the policy as an environment to device_transform
+    // We pass the policy as an environment to DeviceTransform
     _CCCL_TRY_CUDA_API(
       CUB_NS_QUALIFIER::DeviceTransform::Generate,
       "__pstl_cuda_generate: call to cub device_transform::Generate failed",
-      ::cuda::std::move(__result),
+      __result,
       __count,
       ::cuda::std::move(__func),
-      __stream);
+      __policy);
 
+    // Get the stream for synchronization after the algorithm is run
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
     __stream.sync();
-    return __ret;
+
+    return __result + __count;
   }
 
   _CCCL_TEMPLATE(class _Policy, class _OutputIterator, class _Size, class _UnaryOp)

--- a/libcudacxx/include/cuda/std/__pstl/cuda/generate_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/generate_n.h
@@ -66,7 +66,7 @@ struct __pstl_dispatch<__pstl_algorithm::__generate_n, __execution_backend::__cu
   [[nodiscard]] _CCCL_HOST_API static _OutputIterator
   __par_impl(const _Policy& __policy, _OutputIterator __result, const int64_t __count, _UnaryOp __func)
   {
-    auto __stream    = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __stream    = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
     const auto __ret = __result + __count;
 
     // We pass the policy as an environment to device_transform

--- a/libcudacxx/include/cuda/std/__pstl/cuda/inclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/inclusive_scan.h
@@ -69,43 +69,22 @@ struct __pstl_dispatch<__pstl_algorithm::__inclusive_scan, __execution_backend::
     _BinaryOp __binary_op,
     _Tp __init)
   {
-    _OutputIterator __ret = __result + iter_difference_t<_OutputIterator>(__count);
-
-    // Determine temporary device storage requirements for reduce
-    size_t __num_bytes = 0;
+    // We pass the policy as an environment to DeviceScan
     _CCCL_TRY_CUDA_API(
       CUB_NS_QUALIFIER::DeviceScan::InclusiveScanInit,
-      "__pstl_cuda_inclusive_scan: determination of device storage for cub::DeviceScan::InclusiveScanInit failed",
-      static_cast<void*>(nullptr),
-      __num_bytes,
-      __first,
+      "__pstl_cuda_exclusive_scan: kernel launch of cub::DeviceScan::InclusiveScanInit failed",
+      ::cuda::std::move(__first),
       __result,
-      __binary_op,
+      ::cuda::std::move(__binary_op),
       __init,
-      __count);
+      __count,
+      __policy);
 
-    // Allocate memory for result
+    // Get the stream for synchronization after the algorithm is run
     auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
-
-    {
-      __temporary_storage<> __storage{__policy, __num_bytes};
-
-      // Run the scan
-      _CCCL_TRY_CUDA_API(
-        CUB_NS_QUALIFIER::DeviceScan::InclusiveScanInit,
-        "__pstl_cuda_exclusive_scan: kernel launch of cub::DeviceScan::InclusiveScanInit failed",
-        __storage.__get_temp_storage(),
-        __num_bytes,
-        ::cuda::std::move(__first),
-        ::cuda::std::move(__result),
-        ::cuda::std::move(__binary_op),
-        __init,
-        __count,
-        __stream.get());
-    }
-
     __stream.sync();
-    return __ret;
+
+    return __result + iter_difference_t<_OutputIterator>(__count);
   }
 
   template <class _Policy, class _InputIterator, class _OutputIterator, class _BinaryOp>

--- a/libcudacxx/include/cuda/std/__pstl/cuda/inclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/inclusive_scan.h
@@ -85,7 +85,7 @@ struct __pstl_dispatch<__pstl_algorithm::__inclusive_scan, __execution_backend::
       __count);
 
     // Allocate memory for result
-    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
 
     {
       __temporary_storage<> __storage{__policy, __num_bytes};
@@ -131,7 +131,7 @@ struct __pstl_dispatch<__pstl_algorithm::__inclusive_scan, __execution_backend::
       __count);
 
     // Allocate memory for result
-    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
 
     {
       __temporary_storage<> __storage{__policy, __num_bytes};

--- a/libcudacxx/include/cuda/std/__pstl/cuda/merge.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/merge.h
@@ -75,40 +75,21 @@ struct __pstl_dispatch<__pstl_algorithm::__merge, __execution_backend::__cuda>
     auto __ret                                  = __result + static_cast<iter_difference_t<_OutputIterator>>(__count1)
                + static_cast<iter_difference_t<_OutputIterator>>(__count2);
 
-    // Determine temporary device storage requirements for device_merge
-    size_t __num_bytes = 0;
+    // We pass the policy as an environment to DeviceMerge
     _CCCL_TRY_CUDA_API(
       CUB_NS_QUALIFIER::DeviceMerge::MergeKeys,
-      "__pstl_cuda_merge: determination of device storage for cub::DeviceMerge::MergeKeys failed",
-      static_cast<void*>(nullptr),
-      __num_bytes,
-      __first1,
+      "__pstl_cuda_merge: kernel launch of cub::DeviceMerge::MergeKeys failed",
+      ::cuda::std::move(__first1),
       __count1,
-      __first2,
+      ::cuda::std::move(__first2),
       __count2,
-      __result,
-      __comp);
+      ::cuda::std::move(__result),
+      ::cuda::std::move(__comp),
+      __policy);
 
-    // Allocate memory for result
+    // Get the stream for synchronization after the algorithm is run
     auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
-
-    {
-      __temporary_storage<> __storage{__policy, __num_bytes};
-
-      // Run the kernel
-      _CCCL_TRY_CUDA_API(
-        CUB_NS_QUALIFIER::DeviceMerge::MergeKeys,
-        "__pstl_cuda_merge: kernel launch of cub::DeviceMerge::MergeKeys failed",
-        __storage.__get_temp_storage(),
-        __num_bytes,
-        ::cuda::std::move(__first1),
-        __count1,
-        ::cuda::std::move(__first2),
-        __count2,
-        ::cuda::std::move(__result),
-        ::cuda::std::move(__comp),
-        __stream.get());
-    }
+    __stream.sync();
 
     return __ret;
   }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/merge.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/merge.h
@@ -90,7 +90,7 @@ struct __pstl_dispatch<__pstl_algorithm::__merge, __execution_backend::__cuda>
       __comp);
 
     // Allocate memory for result
-    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
 
     {
       __temporary_storage<> __storage{__policy, __num_bytes};

--- a/libcudacxx/include/cuda/std/__pstl/cuda/partition.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/partition.h
@@ -97,7 +97,7 @@ struct __pstl_dispatch<__pstl_algorithm::__partition, __execution_backend::__cud
         __count,
         CUB_NS_QUALIFIER::detail::transform::always_true_predicate{},
         identity{},
-        __stream.get());
+        __policy);
 
       // Run the kernel, the standard requires that the input and output range do not overlap
       _CCCL_TRY_CUDA_API(

--- a/libcudacxx/include/cuda/std/__pstl/cuda/partition.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/partition.h
@@ -84,7 +84,7 @@ struct __pstl_dispatch<__pstl_algorithm::__partition, __execution_backend::__cud
       nullptr);
 
     // Allocate memory for result
-    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
     {
       __temporary_storage<_OffsetType, value_type> __storage{__policy, __num_bytes, 1, __count};
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/partition_copy.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/partition_copy.h
@@ -90,7 +90,7 @@ struct __pstl_dispatch<__pstl_algorithm::__partition_copy, __execution_backend::
       nullptr);
 
     // Allocate memory for result
-    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
     {
       __temporary_storage<_OffsetType> __storage{__policy, __num_bytes, 1};
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
@@ -92,7 +92,7 @@ struct __pstl_dispatch<__pstl_algorithm::__reduce, __execution_backend::__cuda>
       __init);
 
     // Allocate memory for result
-    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
 
     {
       __temporary_storage<_Tp> __storage{__policy, __num_bytes, 1};

--- a/libcudacxx/include/cuda/std/__pstl/cuda/remove_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/remove_if.h
@@ -66,7 +66,7 @@ struct __pstl_dispatch<__pstl_algorithm::__remove_if, __execution_backend::__cud
     using _OffsetType = iter_difference_t<_InputIterator>;
     _OffsetType __ret;
 
-    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
 
     // Determine temporary device storage requirements
     void* __temp_storage = nullptr;

--- a/libcudacxx/include/cuda/std/__pstl/cuda/rotate.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/rotate.h
@@ -116,7 +116,7 @@ struct __pstl_dispatch<__pstl_algorithm::__rotate, __execution_backend::__cuda>
         __count,
         CUB_NS_QUALIFIER::detail::transform::always_true_predicate{},
         identity{},
-        __stream.get());
+        __policy);
 
       // Run the kernel, we use the flagged kernel because we know the exact ordering we want
       _CCCL_TRY_CUDA_API(

--- a/libcudacxx/include/cuda/std/__pstl/cuda/rotate.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/rotate.h
@@ -101,7 +101,7 @@ struct __pstl_dispatch<__pstl_algorithm::__rotate, __execution_backend::__cuda>
       __count,
       nullptr);
 
-    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
 
     {
       // Allocate memory for result

--- a/libcudacxx/include/cuda/std/__pstl/cuda/rotate_copy.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/rotate_copy.h
@@ -103,7 +103,7 @@ struct __pstl_dispatch<__pstl_algorithm::__rotate_copy, __execution_backend::__c
       __count,
       nullptr);
 
-    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
 
     {
       // Allocate memory for result

--- a/libcudacxx/include/cuda/std/__pstl/cuda/transform.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/transform.h
@@ -71,22 +71,22 @@ struct __pstl_dispatch<__pstl_algorithm::__transform, __execution_backend::__cud
     _UnaryOp __func,
     _Predicate __pred)
   {
-    auto __stream    = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
-    const auto __ret = __result + __count;
-
-    // We pass the policy as an environment to device_transform
+    // We pass the policy as an environment to DeviceTransform
     _CCCL_TRY_CUDA_API(
       CUB_NS_QUALIFIER::DeviceTransform::TransformIf,
       "cuda::std::transform: failed inside CUDA backend",
       ::cuda::std::move(__first),
-      ::cuda::std::move(__result),
+      __result,
       __count,
       ::cuda::std::move(__pred),
       ::cuda::std::move(__func),
-      __stream.get());
+      __policy);
 
+    // Get the stream for synchronization after the algorithm is run
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
     __stream.sync();
-    return __ret;
+
+    return __result + __count;
   }
 
   _CCCL_TEMPLATE(class _Policy,

--- a/libcudacxx/include/cuda/std/__pstl/cuda/transform.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/transform.h
@@ -71,7 +71,7 @@ struct __pstl_dispatch<__pstl_algorithm::__transform, __execution_backend::__cud
     _UnaryOp __func,
     _Predicate __pred)
   {
-    auto __stream    = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __stream    = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
     const auto __ret = __result + __count;
 
     // We pass the policy as an environment to device_transform

--- a/libcudacxx/include/cuda/std/__pstl/cuda/transform_reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/transform_reduce.h
@@ -92,7 +92,7 @@ struct __pstl_dispatch<__pstl_algorithm::__transform_reduce, __execution_backend
       __init);
 
     // Allocate memory for result
-    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
 
     {
       __temporary_storage<_Tp> __storage{__policy, __num_bytes, 1};

--- a/libcudacxx/include/cuda/std/__pstl/cuda/unique.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/unique.h
@@ -104,7 +104,7 @@ struct __pstl_dispatch<__pstl_algorithm::__unique, __execution_backend::__cuda>
       __count,
       nullptr);
 
-    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
 
     { // Create temporary storage for the return value as well as a copy of the input sequence as Unique is not inplace
       __temporary_storage<_OffsetType> __storage{__policy, __num_bytes, 1};


### PR DESCRIPTION
Some of our PSTL algorithms can use the new environment based CUB APIs

This gives us the advantage that the user can pass tunings / guarantees along with the execution policy.