### PR TITLE
Prefer the term warpspeed over lookahead

### DIFF
--- a/c/parallel/src/scan.cu
+++ b/c/parallel/src/scan.cu
@@ -232,7 +232,7 @@ struct scan_kernel_source
   {
     // we can ignore passing a wrong AccumT, since we only store a pointer, and the kernel will have the right type
     cub::detail::scan::tile_state_kernel_arg_t<scan_tile_state, char> arg;
-    ::cuda::std::__construct_at(&arg.lookahead, static_cast<cub::detail::warpspeed::tile_state_t<char>*>(ts));
+    ::cuda::std::__construct_at(&arg.warpspeed, static_cast<cub::detail::warpspeed::tile_state_t<char>*>(ts));
     return arg;
   }
 };

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -141,7 +141,7 @@ struct DeviceScanKernelSource
   CUB_RUNTIME_FUNCTION static constexpr auto look_ahead_make_tile_state_kernel_arg(void* ts)
   {
     tile_state_kernel_arg_t<ScanTileStateT, AccumT> arg;
-    ::cuda::std::__construct_at(&arg.lookahead, static_cast<warpspeed::tile_state_t<AccumT>*>(ts));
+    ::cuda::std::__construct_at(&arg.warpspeed, static_cast<warpspeed::tile_state_t<AccumT>*>(ts));
     return arg;
   }
 };
@@ -499,7 +499,7 @@ struct DispatchScan
   }
 
   template <typename PolicyGetter>
-  CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t __invoke_lookahead_algorithm(PolicyGetter policy_getter)
+  CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t __invoke_warpspeed_algorithm(PolicyGetter policy_getter)
   {
 #if __cccl_ptx_isa >= 860
     if (num_items == 0)
@@ -808,7 +808,7 @@ struct DispatchScan
   {
     if CUB_DETAIL_CONSTEXPR_ISH (policy_getter().algorithm == detail::scan::scan_algorithm::warpspeed)
     {
-      return __invoke_lookahead_algorithm(policy_getter);
+      return __invoke_warpspeed_algorithm(policy_getter);
     }
     else
     {

--- a/cub/cub/device/dispatch/kernels/kernel_scan.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan.cuh
@@ -31,7 +31,7 @@ namespace detail::scan
 template <typename ScanTileState, typename AccumT>
 union tile_state_kernel_arg_t
 {
-  warpspeed::tile_state_t<AccumT>* lookahead;
+  warpspeed::tile_state_t<AccumT>* warpspeed;
   ScanTileState lookback;
 
   // ScanTileState<AccumT> is not trivially [default|copy]-constructible, so because of
@@ -68,7 +68,7 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(128) void DeviceScanInitKernel(
   constexpr scan_policy policy = PolicySelectorT{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
   if constexpr (policy.algorithm == scan_algorithm::warpspeed)
   {
-    device_scan_init_lookahead_body(tile_state.lookahead, num_tiles);
+    device_scan_init_warpspeed_body(tile_state.warpspeed, num_tiles);
   }
   else
 #endif // _CCCL_CUDACC_AT_LEAST(12, 8)
@@ -205,8 +205,8 @@ __launch_bounds__(device_scan_launch_bounds<PolicySelector>, 1) _CCCL_KERNEL_ATT
     NV_IF_TARGET(
       NV_PROVIDES_SM_100, ({
         auto scan_params = scanKernelParams<it_value_t<InputIteratorT>, it_value_t<OutputIteratorT>, AccumT>{
-          d_in, d_out, tile_state.lookahead, num_items, num_stages};
-        device_scan_lookahead_body<PolicySelector, ForceInclusive, RealInitValueT>(scan_params, scan_op, init_value);
+          d_in, d_out, tile_state.warpspeed, num_items, num_stages};
+        device_scan_warpspeed_body<PolicySelector, ForceInclusive, RealInitValueT>(scan_params, scan_op, init_value);
       }));
 #else
     static_assert(sizeof(d_in) == 0,

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -794,7 +794,7 @@ template <typename PolicySelector,
           typename AccumT,
           typename ScanOpT,
           typename InitValueT>
-_CCCL_DEVICE_API _CCCL_FORCEINLINE void device_scan_lookahead_body(
+_CCCL_DEVICE_API _CCCL_FORCEINLINE void device_scan_warpspeed_body(
   const scanKernelParams<InputT, OutputT, AccumT> params, ScanOpT scan_op, const InitValueT& init_value)
 {
 #if __cccl_ptx_isa >= 860
@@ -830,7 +830,7 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void device_scan_lookahead_body(
 
 template <typename AccumT>
 _CCCL_DEVICE_API _CCCL_FORCEINLINE void
-device_scan_init_lookahead_body(warpspeed::tile_state_t<AccumT>* tile_states, const int num_temp_states)
+device_scan_init_warpspeed_body(warpspeed::tile_state_t<AccumT>* tile_states, const int num_temp_states)
 {
   const int tile_id = blockDim.x * blockIdx.x + threadIdx.x;
   if (tile_id >= num_temp_states)

--- a/cub/test/catch2_test_device_scan.cu
+++ b/cub/test/catch2_test_device_scan.cu
@@ -84,8 +84,8 @@ C2H_TEST("Device scan works with all device interfaces", "[scan][device]", full_
     10,
     1337,
     3000,
-    1 * 31 * 128, // tile size for int64s for lookahead
-    10'000, // a handful of tiles for lookahead
+    1 * 31 * 128, // tile size for int64s for warpspeed scan
+    10'000, // a handful of tiles for warpspeed scan
     take(3, random(min_items, max_items)),
     values({
       min_items,


### PR DESCRIPTION
The term "lookahead" stems from the warp-specialized nature of the scan implementation that allows the lookahead warp to outrun the reduction and scan warps and thus already start looking ahead from future tile indices. While this is interesting trivia, the great leap of the new scan implementation comes from warp specialization, which is powered by the warpspeed library. We already use that term widely, so let's replace the remaining occurrences of lookahead.