### PR TITLE
Remove MSVC warning 4848 because its unused

### DIFF
--- a/cudax/include/cuda/experimental/__execution/prologue.cuh
+++ b/cudax/include/cuda/experimental/__execution/prologue.cuh
@@ -23,7 +23,6 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_GCC("-Wsubobject-linkage")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-value")
-_CCCL_DIAG_SUPPRESS_MSVC(4848) // [[no_unique_address]] prior to C++20 as a vendor extension
 _CCCL_DIAG_SUPPRESS_MSVC(4714) // function 'foo' marked as __forceinline not inlined
 
 _CCCL_DIAG_SUPPRESS_GCC("-Wmissing-braces")

--- a/libcudacxx/codegen/generate_prologue_epilogue.py
+++ b/libcudacxx/codegen/generate_prologue_epilogue.py
@@ -151,7 +151,8 @@ _CCCL_NV_DIAG_PUSH()
 // warning C4668: 'meow' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'
 // warning C4800: 'boo': forcing value to bool 'true' or 'false' (performance warning)
 // warning C4996: 'meow': was declared deprecated
-_CCCL_DIAG_SUPPRESS_MSVC(4100 4127 4180 4197 4296 4324 4455 4503 4522 4668 4800 4996)
+// warning C4848: support for [[foo]] in C++XX and earlier is a vendor extension (e.g. no_unique_address)
+_CCCL_DIAG_SUPPRESS_MSVC(4100 4127 4180 4197 4296 4324 4455 4503 4522 4668 4800 4996 4848)
 
 // disable warnings about using C++23 features in C++20 (needed for if consteval)
 #if _CCCL_HAS_IF_CONSTEVAL_IN_CXX20()

--- a/libcudacxx/codegen/generate_prologue_epilogue.py
+++ b/libcudacxx/codegen/generate_prologue_epilogue.py
@@ -151,8 +151,7 @@ _CCCL_NV_DIAG_PUSH()
 // warning C4668: 'meow' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'
 // warning C4800: 'boo': forcing value to bool 'true' or 'false' (performance warning)
 // warning C4996: 'meow': was declared deprecated
-// warning C4848: support for [[foo]] in C++XX and earlier is a vendor extension (e.g. no_unique_address)
-_CCCL_DIAG_SUPPRESS_MSVC(4100 4127 4180 4197 4296 4324 4455 4503 4522 4668 4800 4996 4848)
+_CCCL_DIAG_SUPPRESS_MSVC(4100 4127 4180 4197 4296 4324 4455 4503 4522 4668 4800 4996)
 
 // disable warnings about using C++23 features in C++20 (needed for if consteval)
 #if _CCCL_HAS_IF_CONSTEVAL_IN_CXX20()

--- a/libcudacxx/include/cuda/std/__expected/expected_base.h
+++ b/libcudacxx/include/cuda/std/__expected/expected_base.h
@@ -55,10 +55,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-// MSVC complains about [[no_unique_address]] prior to C++20 as a vendor extension
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_MSVC(4848)
-
 struct __expected_construct_from_invoke_tag
 {
   _CCCL_HIDE_FROM_ABI explicit __expected_construct_from_invoke_tag() = default;
@@ -425,8 +421,6 @@ struct __expected_destruct<_Tp, _Err, true, true>
   {}
 };
 
-_CCCL_DIAG_POP
-
 template <class _Tp, class _Err>
 struct __expected_storage : __expected_destruct<_Tp, _Err>
 {
@@ -751,9 +745,6 @@ struct __expected_move_assign<_Tp, _Err, __smf_availability::__deleted> : __expe
 };
 
 // expected<void, E> base classtemplate <class _Tp, class _Err>
-// MSVC complains about [[no_unique_address]] prior to C++20 as a vendor extension
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_MSVC(4848)
 
 template <class _Err>
 struct __expected_destruct<void, _Err, false, false>
@@ -900,8 +891,6 @@ struct __expected_destruct<void, _Err, false, true>
       : __has_val_(__has_val)
   {}
 };
-
-_CCCL_DIAG_POP
 
 template <class _Err>
 struct __expected_storage<void, _Err> : __expected_destruct<void, _Err>

--- a/libcudacxx/include/cuda/std/__ranges/reverse_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/reverse_view.h
@@ -44,10 +44,6 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
-// MSVC complains about [[msvc::no_unique_address]] prior to C++20 as a vendor extension
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_MSVC(4848)
-
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
 #if _CCCL_HAS_CONCEPTS()
@@ -251,8 +247,6 @@ inline namespace __cpo
 _CCCL_GLOBAL_CONSTANT auto reverse = __reverse::__fn{};
 } // namespace __cpo
 _CCCL_END_NAMESPACE_CUDA_STD_VIEWS
-
-_CCCL_DIAG_POP
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/std/__ranges/subrange.h
+++ b/libcudacxx/include/cuda/std/__ranges/subrange.h
@@ -53,10 +53,6 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
-// MSVC complains about [[msvc::no_unique_address]] prior to C++20 as a vendor extension
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_MSVC(4848)
-
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
 #if _CCCL_HAS_CONCEPTS()
@@ -502,8 +498,6 @@ struct tuple_element<1, const ::cuda::std::ranges::subrange<_Ip, _Sp, _Kp>>
 };
 
 _CCCL_END_NAMESPACE_CUDA_STD
-
-_CCCL_DIAG_POP
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/std/__ranges/take_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/take_view.h
@@ -55,10 +55,6 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
-// MSVC complains about [[msvc::no_unique_address]] prior to C++20 as a vendor extension
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_MSVC(4848)
-
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
 #if _CCCL_HAS_CONCEPTS()
@@ -464,8 +460,6 @@ _CCCL_GLOBAL_CONSTANT auto take = __take::__fn{};
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_VIEWS
-
-_CCCL_DIAG_POP
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/std/__ranges/take_while_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/take_while_view.h
@@ -44,10 +44,6 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
-// MSVC complains about [[msvc::no_unique_address]] prior to C++20 as a vendor extension
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_MSVC(4848)
-
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
 template <class _View, class _Pred>
@@ -251,8 +247,6 @@ inline namespace __cpo
 _CCCL_GLOBAL_CONSTANT auto take_while = __take_while::__fn{};
 } // namespace __cpo
 _CCCL_END_NAMESPACE_CUDA_STD_VIEWS
-
-_CCCL_DIAG_POP
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/std/__ranges/transform_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/transform_view.h
@@ -53,10 +53,6 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
-// MSVC complains about [[msvc::no_unique_address]] prior to C++20 as a vendor extension
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_MSVC(4848)
-
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
 template <class _Fn, class _View>
@@ -514,8 +510,6 @@ inline namespace __cpo
 _CCCL_GLOBAL_CONSTANT auto transform = __transform::__fn{};
 } // namespace __cpo
 _CCCL_END_NAMESPACE_CUDA_STD_VIEWS
-
-_CCCL_DIAG_POP
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/std/ranges
+++ b/libcudacxx/include/cuda/std/ranges
@@ -21,10 +21,6 @@
 #  pragma system_header
 #endif // no system header
 
-// MSVC complains about [[msvc::no_unique_address]] prior to C++20 as a vendor extension
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_MSVC(4848)
-
 #include <cuda/std/__ranges/access.h>
 #include <cuda/std/__ranges/all.h>
 #include <cuda/std/__ranges/concepts.h>
@@ -66,7 +62,5 @@ _CCCL_DIAG_SUPPRESS_MSVC(4848)
 // [tuple.helper]
 #include <cuda/std/__tuple_dir/tuple_element.h>
 #include <cuda/std/__tuple_dir/tuple_size.h>
-
-_CCCL_DIAG_POP
 
 #endif //_CUDA_STD_RANGES


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

MSVC error 4848 is silenced often enough that it warrants being silenced globally. For each such macro, we already ensure that it is only enabled when we are sure the compiler supports it properly.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
