### PR TITLE
Make accidentally exposed function private

### DIFF
--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -1100,6 +1100,7 @@ public:
       d_temp_storage, temp_storage_bytes, d_in, d_min_out, d_index_out, num_items, ::cuda::std::less{}, stream);
   }
 
+private:
   template <typename InputIteratorT,
             typename ExtremumOutIteratorT,
             typename IndexOutIteratorT,
@@ -1181,6 +1182,7 @@ public:
     return deallocate_error;
   }
 
+public:
   //! @rst
   //! Finds the first device-wide minimum using the less-than (``<``) operator and also returns the index of that item.
   //!


### PR DESCRIPTION
The function (`__arg_min_env()`) is showing up in the `cub::DeviceReduce` docs. This PR makes it private.
