### PR TITLE
Implement the new tuning API for `detail::batched_topk::dispatch_batched_topk`

### DIFF
--- a/cub/benchmarks/bench/segmented_topk/keys.cu
+++ b/cub/benchmarks/bench/segmented_topk/keys.cu
@@ -109,7 +109,7 @@ void fixed_seg_size_topk_keys(
     segment_sizes,
     k,
     select_directions,
-    num_segments_uniform_t{num_segments},
+    num_segments_uniform_t{static_cast<::cuda::std::int64_t>(num_segments)},
     total_num_items,
     nullptr
 #if !TUNE_BASE
@@ -133,7 +133,7 @@ void fixed_seg_size_topk_keys(
       segment_sizes,
       k,
       select_directions,
-      num_segments_uniform_t{num_segments},
+      num_segments_uniform_t{static_cast<::cuda::std::int64_t>(num_segments)},
       total_num_items,
       launch.get_stream()
 #if !TUNE_BASE

--- a/cub/benchmarks/bench/segmented_topk/keys.cu
+++ b/cub/benchmarks/bench/segmented_topk/keys.cu
@@ -12,33 +12,36 @@
 // %RANGE% TUNE_THREADS_PER_BLOCK tpb 128:1024:32
 // %RANGE% TUNE_BLOCK_LOAD_ALGORITHM ld 0:2:1
 
-#if TUNE_BLOCK_LOAD_ALGORITHM == 0
-#  define TUNE_LOAD_ALGORITHM cub::BLOCK_LOAD_DIRECT
-#elif TUNE_BLOCK_LOAD_ALGORITHM == 1
-#  define TUNE_LOAD_ALGORITHM cub::BLOCK_LOAD_WARP_TRANSPOSE
-#elif TUNE_BLOCK_LOAD_ALGORITHM == 2
-#  define TUNE_LOAD_ALGORITHM cub::BLOCK_LOAD_VECTORIZE
-#endif
-
 #if !TUNE_BASE
-template <class KeyInT, class OffsetT>
-struct policy_hub_t
+struct tuned_policy_selector
 {
-  struct policy_t : cub::ChainedPolicy<300, policy_t, policy_t>
+  [[nodiscard]] _CCCL_API constexpr auto operator()(::cuda::arch_id /*arch*/) const
+    -> cub::detail::batched_topk::batched_topk_policy
   {
-    static constexpr int items_per_thread = TUNE_ITEMS_PER_THREAD;
-
-    static constexpr int bits_per_pass = cub::detail::topk::calc_bits_per_pass<KeyInT>();
-
-    using topk_policy_t =
-      cub::detail::topk::AgentTopKPolicy<TUNE_THREADS_PER_BLOCK,
-                                         items_per_thread,
-                                         bits_per_pass,
-                                         TUNE_LOAD_ALGORITHM,
-                                         cub::BLOCK_SCAN_WARP_SCANS>;
-  };
-
-  using MaxPolicy = policy_t;
+    // Single-entry policy chain driven by the tuning knobs.
+    constexpr auto store_alg = cub::BLOCK_STORE_WARP_TRANSPOSE;
+#  if TUNE_BLOCK_LOAD_ALGORITHM == 0
+    constexpr auto load_alg = cub::BLOCK_LOAD_DIRECT;
+#  elif TUNE_BLOCK_LOAD_ALGORITHM == 1
+    constexpr auto load_alg = cub::BLOCK_LOAD_WARP_TRANSPOSE;
+#  elif TUNE_BLOCK_LOAD_ALGORITHM == 2
+    constexpr auto load_alg = cub::BLOCK_LOAD_VECTORIZE;
+#  endif
+    return cub::detail::batched_topk::batched_topk_policy{{{
+      cub::detail::batched_topk::agent_batched_topk_policy{
+        TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, load_alg, store_alg},
+      cub::detail::batched_topk::agent_batched_topk_policy{
+        TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, load_alg, store_alg},
+      cub::detail::batched_topk::agent_batched_topk_policy{
+        TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, load_alg, store_alg},
+      cub::detail::batched_topk::agent_batched_topk_policy{
+        TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, load_alg, store_alg},
+      cub::detail::batched_topk::agent_batched_topk_policy{
+        TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, load_alg, store_alg},
+      cub::detail::batched_topk::agent_batched_topk_policy{
+        TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, load_alg, store_alg},
+    }}};
+  }
 };
 #endif // !TUNE_BASE
 
@@ -50,10 +53,6 @@ void fixed_seg_size_topk_keys(
   // Range of guaranteed total number of items
   constexpr auto min_num_total_items = 1;
   constexpr auto max_num_total_items = ::cuda::std::numeric_limits<::cuda::std::int32_t>::max();
-
-  // Iterator types
-  using key_input_it_t  = cuda::strided_iterator<cuda::counting_iterator<KeyT*>>;
-  using key_output_it_t = cuda::strided_iterator<cuda::counting_iterator<KeyT*>>;
 
   // Static segment size
   using seg_size_t = cub::detail::batched_topk::segment_size_static<MaxSegmentSize>;
@@ -70,22 +69,6 @@ void fixed_seg_size_topk_keys(
   // Total number of items guarantee type
   using total_num_items_guarantee_t =
     cub::detail::batched_topk::total_num_items_guarantee<min_num_total_items, max_num_total_items>;
-
-  using dispatch_t = cub::detail::batched_topk::dispatch_batched_topk<
-    key_input_it_t,
-    key_output_it_t,
-    cub::NullType**,
-    cub::NullType**,
-    seg_size_t,
-    k_value_t,
-    select_direction_value_t,
-    num_segments_uniform_t,
-    total_num_items_guarantee_t
-#if !TUNE_BASE
-    ,
-    policy_hub_t<KeyT, cub::NullType, ::cuda::std::int32_t, MaxNumSelected>
-#endif // !TUNE_BASE
-    >;
 
   // Retrieve axis parameters
   const auto max_elements      = static_cast<size_t>(state.get_int64("Elements{io}"));
@@ -122,7 +105,7 @@ void fixed_seg_size_topk_keys(
 
   // allocate temporary storage
   size_t temp_size;
-  dispatch_t::dispatch(
+  cub::detail::batched_topk::dispatch(
     nullptr,
     temp_size,
     d_keys_in,
@@ -132,16 +115,21 @@ void fixed_seg_size_topk_keys(
     segment_sizes,
     k,
     select_directions,
-    num_segments,
+    num_segments_uniform_t{num_segments},
     total_num_items,
-    nullptr);
+    nullptr
+#if !TUNE_BASE
+    ,
+    tuned_policy_selector{}
+#endif // !TUNE_BASE
+  );
 
   thrust::device_vector<nvbench::uint8_t> temp(temp_size, thrust::no_init);
   auto* temp_storage = thrust::raw_pointer_cast(temp.data());
 
   // run the algorithm
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    dispatch_t::dispatch(
+    cub::detail::batched_topk::dispatch(
       temp_storage,
       temp_size,
       d_keys_in,
@@ -151,9 +139,14 @@ void fixed_seg_size_topk_keys(
       segment_sizes,
       k,
       select_directions,
-      num_segments,
+      num_segments_uniform_t{num_segments},
       total_num_items,
-      launch.get_stream());
+      launch.get_stream()
+#if !TUNE_BASE
+        ,
+      tuned_policy_selector{}
+#endif // !TUNE_BASE
+    );
   });
 }
 

--- a/cub/benchmarks/bench/segmented_topk/keys.cu
+++ b/cub/benchmarks/bench/segmented_topk/keys.cu
@@ -28,18 +28,12 @@ struct tuned_policy_selector
     constexpr auto load_alg = cub::BLOCK_LOAD_VECTORIZE;
 #  endif
     return cub::detail::batched_topk::batched_topk_policy{{{
-      cub::detail::batched_topk::agent_batched_topk_policy{
-        TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, load_alg, store_alg},
-      cub::detail::batched_topk::agent_batched_topk_policy{
-        TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, load_alg, store_alg},
-      cub::detail::batched_topk::agent_batched_topk_policy{
-        TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, load_alg, store_alg},
-      cub::detail::batched_topk::agent_batched_topk_policy{
-        TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, load_alg, store_alg},
-      cub::detail::batched_topk::agent_batched_topk_policy{
-        TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, load_alg, store_alg},
-      cub::detail::batched_topk::agent_batched_topk_policy{
-        TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, load_alg, store_alg},
+      cub::detail::batched_topk::worker_policy{TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, load_alg, store_alg},
+      cub::detail::batched_topk::worker_policy{TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, load_alg, store_alg},
+      cub::detail::batched_topk::worker_policy{TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, load_alg, store_alg},
+      cub::detail::batched_topk::worker_policy{TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, load_alg, store_alg},
+      cub::detail::batched_topk::worker_policy{TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, load_alg, store_alg},
+      cub::detail::batched_topk::worker_policy{TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, load_alg, store_alg},
     }}};
   }
 };

--- a/cub/cub/agent/agent_batched_topk.cuh
+++ b/cub/cub/agent/agent_batched_topk.cuh
@@ -19,26 +19,14 @@
 #include <cub/block/block_topk.cuh>
 #include <cub/detail/segmented_params.cuh>
 #include <cub/device/dispatch/dispatch_common.cuh>
+#include <cub/device/dispatch/tuning/tuning_batched_topk.cuh>
 #include <cub/util_type.cuh>
 
 CUB_NAMESPACE_BEGIN
 
 namespace detail::batched_topk
 {
-template <int BlockThreads, int ItemsPerThread, BlockLoadAlgorithm LoadAlgorithm, BlockStoreAlgorithm StoreAlgorithm>
-struct agent_batched_topk_worker_per_segment_policy
-{
-  /// Threads per thread block
-  static constexpr int block_threads = BlockThreads;
-
-  /// Items per thread (per tile of input)
-  static constexpr int items_per_thread = ItemsPerThread;
-
-  static constexpr BlockLoadAlgorithm load_algorithm   = LoadAlgorithm;
-  static constexpr BlockStoreAlgorithm store_algorithm = StoreAlgorithm;
-};
-
-template <typename ActivePolicyT,
+template <typename PolicyGetter, // TODO(bgruber): pass agent_batched_topk_policy as NTTP in C++20
           typename KeyInputItItT,
           typename KeyOutputItItT,
           typename ValueInputItItT,
@@ -59,8 +47,10 @@ struct agent_batched_topk_worker_per_segment
   using key_t   = it_value_t<key_it_t>;
   using value_t = it_value_t<value_it_t>;
 
-  static constexpr int block_threads    = ActivePolicyT::block_threads;
-  static constexpr int items_per_thread = ActivePolicyT::items_per_thread;
+  static constexpr agent_batched_topk_policy active_policy = PolicyGetter{}();
+
+  static constexpr int block_threads    = active_policy.block_threads;
+  static constexpr int items_per_thread = active_policy.items_per_thread;
   static constexpr int tile_size        = block_threads * items_per_thread;
 
   // Check if we are dealing with keys-only or key-value pairs
@@ -69,15 +59,15 @@ struct agent_batched_topk_worker_per_segment
   // -------------------------------------------------------------------------
   // Primitive Types
   // -------------------------------------------------------------------------
-  using block_load_keys_t = BlockLoad<key_t, block_threads, items_per_thread, ActivePolicyT::load_algorithm>;
-  using block_load_vals_t = BlockLoad<value_t, block_threads, items_per_thread, ActivePolicyT::load_algorithm>;
+  using block_load_keys_t = BlockLoad<key_t, block_threads, items_per_thread, active_policy.load_algorithm>;
+  using block_load_vals_t = BlockLoad<value_t, block_threads, items_per_thread, active_policy.load_algorithm>;
 
   using block_topk_t = block_topk<key_t, block_threads, items_per_thread, value_t>;
 
   // TODO (elstehle): Specialize for the case that we statically know k and we can skip passing num_valid_items to
   // Store()
-  using block_store_keys_t = BlockStore<key_t, block_threads, items_per_thread, ActivePolicyT::store_algorithm>;
-  using block_store_vals_t = BlockStore<value_t, block_threads, items_per_thread, ActivePolicyT::store_algorithm>;
+  using block_store_keys_t = BlockStore<key_t, block_threads, items_per_thread, active_policy.store_algorithm>;
+  using block_store_vals_t = BlockStore<value_t, block_threads, items_per_thread, active_policy.store_algorithm>;
 
   // -------------------------------------------------------------------------
   // Shared Memory Storage

--- a/cub/cub/agent/agent_batched_topk.cuh
+++ b/cub/cub/agent/agent_batched_topk.cuh
@@ -26,7 +26,7 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail::batched_topk
 {
-template <typename PolicyGetter, // TODO(bgruber): pass agent_batched_topk_policy as NTTP in C++20
+template <typename PolicyGetter, // TODO(bgruber): pass worker_policy as NTTP in C++20
           typename KeyInputItItT,
           typename KeyOutputItItT,
           typename ValueInputItItT,
@@ -47,7 +47,7 @@ struct agent_batched_topk_worker_per_segment
   using key_t   = it_value_t<key_it_t>;
   using value_t = it_value_t<value_it_t>;
 
-  static constexpr agent_batched_topk_policy active_policy = PolicyGetter{}();
+  static constexpr worker_policy active_policy = PolicyGetter{}();
 
   static constexpr int block_threads    = active_policy.block_threads;
   static constexpr int items_per_thread = active_policy.items_per_thread;

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -169,7 +169,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
 {
   // Currently, we only support segments that fit into shared memory
   // TODO (elstehle): extend support for variable-size segments
-  constexpr agent_batched_topk_policy selected = find_smallest_covering_policy<
+  constexpr worker_policy selected = find_smallest_covering_policy<
     PolicySelector,
     SegmentSizeParameterT,
     KeyInputItItT,

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -164,20 +164,22 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   SelectDirectionParameterT select_directions,
   NumSegmentsParameterT num_segments,
   [[maybe_unused]] TotalNumItemsGuaranteeT total_num_items_guarantee,
-  cudaStream_t stream            = nullptr,
-  PolicySelector policy_selector = {})
+  cudaStream_t stream                             = nullptr,
+  [[maybe_unused]] PolicySelector policy_selector = {})
 {
   // Currently, we only support segments that fit into shared memory
   // TODO (elstehle): extend support for variable-size segments
-  // The batched top-k tuning is arch-independent, so we evaluate the policy selector at compile time with a fixed
-  // placeholder arch to obtain block_threads statically for the kernel launch.
-  constexpr batched_topk_policy active_policy = policy_selector(::cuda::arch_id::sm_90);
-  constexpr int selected_index =
-    find_smallest_covering_policy_index(active_policy, params::static_max_value_v<SegmentSizeParameterT>);
-  static_assert(selected_index >= 0,
-                "Currently only small segments are supported, where each segment can be processed by a single thread "
-                "block.");
-  constexpr agent_batched_topk_policy selected = active_policy.worker_per_segment_policies[selected_index];
+  constexpr agent_batched_topk_policy selected = find_smallest_covering_policy<
+    PolicySelector,
+    SegmentSizeParameterT,
+    KeyInputItItT,
+    KeyOutputItItT,
+    ValueInputItItT,
+    ValueOutputItItT,
+    SegmentSizeParameterT,
+    KParameterT,
+    SelectDirectionParameterT,
+    NumSegmentsParameterT>::policy;
 
   if (d_temp_storage == nullptr)
   {

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -145,193 +145,80 @@ template <typename KeyInputItItT,
           typename SelectDirectionParameterT,
           typename NumSegmentsParameterT,
           typename TotalNumItemsGuaranteeT,
-          typename SelectedPolicy = policy_hub<it_value_t<it_value_t<KeyInputItItT>>,
-                                               it_value_t<it_value_t<ValueInputItItT>>,
-                                               ::cuda::std::int64_t,
-                                               params::static_max_value_v<KParameterT>>>
-struct dispatch_batched_topk
+          typename PolicySelector = policy_selector_from_types<it_value_t<it_value_t<KeyInputItItT>>,
+                                                               it_value_t<it_value_t<ValueInputItItT>>,
+                                                               ::cuda::std::int64_t,
+                                                               params::static_max_value_v<KParameterT>>>
+#if _CCCL_HAS_CONCEPTS()
+  requires batched_topk_policy_selector<PolicySelector>
+#endif // _CCCL_HAS_CONCEPTS()
+CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
+  void* d_temp_storage,
+  size_t& temp_storage_bytes,
+  KeyInputItItT d_key_segments_it,
+  KeyOutputItItT d_key_segments_out_it,
+  ValueInputItItT d_value_segments_it,
+  ValueOutputItItT d_value_segments_out_it,
+  SegmentSizeParameterT segment_sizes,
+  KParameterT k,
+  SelectDirectionParameterT select_directions,
+  NumSegmentsParameterT num_segments,
+  [[maybe_unused]] TotalNumItemsGuaranteeT total_num_items_guarantee,
+  cudaStream_t stream            = nullptr,
+  PolicySelector policy_selector = {})
 {
-  using offset_t = ::cuda::std::int64_t;
+  // Currently, we only support segments that fit into shared memory
+  // TODO (elstehle): extend support for variable-size segments
+  // The batched top-k tuning is arch-independent, so we evaluate the policy selector at compile time with a fixed
+  // placeholder arch to obtain block_threads statically for the kernel launch.
+  constexpr batched_topk_policy active_policy = policy_selector(::cuda::arch_id::sm_90);
+  constexpr int selected_index =
+    find_smallest_covering_policy_index(active_policy, params::static_max_value_v<SegmentSizeParameterT>);
+  static_assert(selected_index >= 0,
+                "Currently only small segments are supported, where each segment can be processed by a single thread "
+                "block.");
+  constexpr agent_batched_topk_policy selected = active_policy.worker_per_segment_policies[selected_index];
 
-  /// Device-accessible allocation of temporary storage.
-  /// When `nullptr`, the required allocation size is written to `temp_storage_bytes` and no work is done.
-  void* d_temp_storage;
-
-  /// Reference to size in bytes of `d_temp_storage` allocation
-  size_t& temp_storage_bytes;
-
-  /// d_key_segments_it[segment_index] -> iterator to the input sequence of key data for segment `segment_index`
-  KeyInputItItT d_key_segments_it;
-
-  /// d_key_segments_out_it[segment_index] -> iterator to the output sequence of key data for segment `segment_index`
-  KeyOutputItItT d_key_segments_out_it;
-
-  /// d_value_segments_it[segment_index] -> iterator to the input sequence of associated value items for segment
-  /// `segment_index`
-  ValueInputItItT d_value_segments_it;
-
-  /// d_value_segments_out_it[segment_index] -> iterator to the output sequence of associated value items for segment
-  /// `segment_index`
-  ValueOutputItItT d_value_segments_out_it;
-
-  /// Parameter providing segment sizes for each segment
-  SegmentSizeParameterT segment_sizes;
-
-  /// Parameter providing K for each segment
-  KParameterT k;
-
-  /// Parameter providing the selection direction for each segment
-  SelectDirectionParameterT select_directions;
-
-  /// Number of segments
-  NumSegmentsParameterT num_segments;
-
-  // Allows the user to provide a guarantee on the upper bound of the total number of items
-  TotalNumItemsGuaranteeT total_num_items_guarantee;
-
-  /// CUDA stream to launch kernels within. Default is stream<sub>0</sub>.
-  cudaStream_t stream;
-
-  int ptx_version;
-
-  // We pass ValueInputItItT itself as cub::NullType** when only keys are processed
-  static constexpr bool keys_only = ::cuda::std::is_same_v<ValueInputItItT, NullType**>;
-
-  template <typename ActiveWorkerPerSegmentPolicyTPolicyT>
-  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_one_worker_per_segment()
+  if (d_temp_storage == nullptr)
   {
-    using max_policy_t = typename SelectedPolicy::max_policy;
-
-    // Instantiate the kernel with the selected policy and check shared memory requirements
-    using topk_policy_t = ActiveWorkerPerSegmentPolicyTPolicyT;
-
-    constexpr int block_dim = topk_policy_t::block_threads;
-
-    if (d_temp_storage == nullptr)
-    {
-      temp_storage_bytes = 1;
-      return cudaSuccess;
-    }
-
-    // TODO (elstehle): support number of segments provided by device-accessible iterator
-    // Only uniform number of segments are supported (i.e., we  need to resolve the number of segments on the host)
-    static_assert(!params::is_per_segment_param_v<NumSegmentsParameterT>,
-                  "Only uniform segment sizes are currently supported.");
-
-    // TODO (elstehle): support larger number of segments through multiple kernel launches
-    int grid_dim = static_cast<int>(num_segments.get_param(0));
-
-    cudaError_t error = CubDebug(
-      THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(grid_dim, block_dim, 0, stream)
-        .doit(device_segmented_topk_kernel<max_policy_t,
-                                           KeyInputItItT,
-                                           KeyOutputItItT,
-                                           ValueInputItItT,
-                                           ValueOutputItItT,
-                                           SegmentSizeParameterT,
-                                           KParameterT,
-                                           SelectDirectionParameterT,
-                                           NumSegmentsParameterT>,
-              d_key_segments_it,
-              d_key_segments_out_it,
-              d_value_segments_it,
-              d_value_segments_out_it,
-              segment_sizes,
-              k,
-              select_directions,
-              num_segments));
-
-    // Check for failure to launch
-    if (cudaSuccess != error)
-    {
-      return error;
-    }
-
-    // Sync the stream if specified to flush runtime errors
-    error = CubDebug(detail::DebugSyncStream(stream));
-
-    // Check for failure to launch
-    if (cudaSuccess != error)
-    {
-      return error;
-    }
-
+    temp_storage_bytes = 1;
     return cudaSuccess;
   }
 
-  template <typename ActivePolicyT>
-  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t Invoke()
-  {
-    // Helper that determines (a) whether there's any one-worker-per-segment policy supporting the range of segment
-    // sizes and k, and (b) if so, which set of one-worker-per-segment policies to use
-    using find_smallest_covering_policy_t = find_smallest_covering_policy<
-      ActivePolicyT,
-      SegmentSizeParameterT,
-      agent_batched_topk_worker_per_segment,
-      KeyInputItItT,
-      KeyOutputItItT,
-      ValueInputItItT,
-      ValueOutputItItT,
-      SegmentSizeParameterT,
-      KParameterT,
-      SelectDirectionParameterT,
-      NumSegmentsParameterT>;
+  // TODO (elstehle): support number of segments provided by device-accessible iterator
+  // Only uniform number of segments are supported (i.e., we need to resolve the number of segments on the host)
+  static_assert(!params::is_per_segment_param_v<NumSegmentsParameterT>,
+                "Only uniform segment sizes are currently supported.");
 
-    // Currently, we only support segments that fit into shared memory
-    // TODO (elstehle): extend support for variable-size segments
-    static_assert(find_smallest_covering_policy_t::supports_one_worker_per_segment,
-                  "Currently only small segments are supported, where each segment can be processed by a single thread "
-                  "block.");
-    if constexpr (find_smallest_covering_policy_t::supports_one_worker_per_segment)
-    {
-      return invoke_one_worker_per_segment<typename find_smallest_covering_policy_t::worker_per_segment_policy_t>();
-    }
-    else
-    {
-      return cudaErrorNotSupported;
-    }
+  // TODO (elstehle): support larger number of segments through multiple kernel launches
+  const int grid_dim      = static_cast<int>(num_segments.get_param(0));
+  constexpr int block_dim = selected.block_threads;
+
+  if (const auto error = CubDebug(
+        THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(grid_dim, block_dim, 0, stream)
+          .doit(device_segmented_topk_kernel<PolicySelector,
+                                             KeyInputItItT,
+                                             KeyOutputItItT,
+                                             ValueInputItItT,
+                                             ValueOutputItItT,
+                                             SegmentSizeParameterT,
+                                             KParameterT,
+                                             SelectDirectionParameterT,
+                                             NumSegmentsParameterT>,
+                d_key_segments_it,
+                d_key_segments_out_it,
+                d_value_segments_it,
+                d_value_segments_out_it,
+                segment_sizes,
+                k,
+                select_directions,
+                num_segments)))
+  {
+    return error;
   }
 
-  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch(
-    void* d_temp_storage,
-    size_t& temp_storage_bytes,
-    KeyInputItItT d_key_segments_it,
-    KeyOutputItItT d_key_segments_out_it,
-    ValueInputItItT d_value_segments_it,
-    ValueOutputItItT d_value_segments_out_it,
-    SegmentSizeParameterT segment_sizes,
-    KParameterT k,
-    SelectDirectionParameterT select_directions,
-    NumSegmentsParameterT num_segments,
-    TotalNumItemsGuaranteeT total_num_items_guarantee,
-    cudaStream_t stream)
-  {
-    using max_policy_t = typename SelectedPolicy::max_policy;
-
-    int ptx_version = 0;
-    if (cudaError_t error = CubDebug(PtxVersion(ptx_version)))
-    {
-      return error;
-    }
-
-    dispatch_batched_topk dispatch{
-      d_temp_storage,
-      temp_storage_bytes,
-      d_key_segments_it,
-      d_key_segments_out_it,
-      d_value_segments_it,
-      d_value_segments_out_it,
-      segment_sizes,
-      k,
-      select_directions,
-      num_segments,
-      total_num_items_guarantee,
-      stream,
-      ptx_version};
-
-    return CubDebug(max_policy_t::Invoke(ptx_version, dispatch));
-  }
-};
+  return CubDebug(detail::DebugSyncStream(stream));
+}
 } // namespace detail::batched_topk
 
 CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -136,6 +136,24 @@ struct total_num_items_guarantee
 // -----------------------------------------------------------------------------
 // Segmented Top-K Dispatch
 // -----------------------------------------------------------------------------
+
+//! @param d_temp_storage Device-accessible allocation of temporary storage. When `nullptr`, the required allocation
+//!        size is written to `temp_storage_bytes` and no work is done.
+//! @param temp_storage_bytes Reference to size in bytes of `d_temp_storage` allocation
+//! @param d_key_segments_it d_key_segments_it[segment_index] -> iterator to the input sequence of key data for segment
+//!        `segment_index`
+//! @param d_key_segments_out_it d_key_segments_out_it[segment_index] -> iterator to the output sequence of key data for
+//!        segment `segment_index`
+//! @param d_value_segments_it d_value_segments_it[segment_index] -> iterator to the input sequence of associated value
+//!        items for segment `segment_index`. When cub::NullType**, only keys are provided.
+//! @param d_value_segments_out_it d_value_segments_out_it[segment_index] -> iterator to the output sequence of
+//!        associated value items for segment `segment_index`
+//! @param segment_sizes Parameter providing segment sizes for each segment
+//! @param k Parameter providing K for each segment
+//! @param select_directions Parameter providing the selection direction for each segment
+//! @param num_segments Number of segments
+//! @param total_num_items_guarantee Allows the user to provide a guarantee on the upper bound of the total number of
+//!        items
 template <typename KeyInputItItT,
           typename KeyOutputItItT,
           typename ValueInputItItT,
@@ -167,8 +185,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   cudaStream_t stream                             = nullptr,
   [[maybe_unused]] PolicySelector policy_selector = {})
 {
-  // Currently, we only support segments that fit into shared memory
-  // TODO (elstehle): extend support for variable-size segments
+  // Helper that determines (a) whether there's any one-worker-per-segment policy supporting the range of segment
+  // sizes and k, and (b) if so, which set of one-worker-per-segment policies to use
   constexpr worker_policy selected = find_smallest_covering_policy<
     PolicySelector,
     SegmentSizeParameterT,

--- a/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
@@ -74,6 +74,7 @@ private:
   static constexpr int selected_index = find_index<0>();
 
 public:
+  // TODO (elstehle): extend support for variable-size segments
   static_assert(selected_index >= 0, "No valid policy found for one-worker-per-segment approach");
   static constexpr worker_policy policy = active_policy.worker_per_segment_policies[selected_index];
 

--- a/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
@@ -29,6 +29,23 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail::batched_topk
 {
+// Finds the smallest policy whose tile size still covers the given max segment size. Returns -1 if none covers.
+[[nodiscard]] _CCCL_API constexpr int
+find_smallest_covering_policy_index(const batched_topk_policy& p, ::cuda::std::int64_t max_segment_size)
+{
+  int result = -1;
+  for (int i = 0; i < static_cast<int>(p.worker_per_segment_policies.size()); ++i)
+  {
+    const auto& wp                       = p.worker_per_segment_policies[i];
+    const ::cuda::std::int64_t tile_size = ::cuda::std::int64_t{wp.block_threads} * wp.items_per_thread;
+    if (tile_size >= max_segment_size)
+    {
+      result = i;
+    }
+  }
+  return result;
+}
+
 // Given a policy_selector and a segment-size parameter, resolves the agent type to be instantiated by the kernel.
 template <typename PolicySelector, typename SegmentSizeParameterT, typename... AgentParamsT>
 struct find_smallest_covering_policy

--- a/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved. SPDX-License-Identifier:
-// Apache-2.0 WITH LLVM-exception
-//!
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 //! @file
 //! Kernel entry point for device-wide batched top-k.
 
@@ -18,140 +18,45 @@
 
 #include <cub/agent/agent_batched_topk.cuh>
 #include <cub/detail/segmented_params.cuh>
+#include <cub/device/dispatch/tuning/tuning_batched_topk.cuh>
 #include <cub/util_arch.cuh>
 
-#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/__device/arch_id.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/cstdint>
-#include <cuda/std/tuple>
 
 CUB_NAMESPACE_BEGIN
 
 namespace detail::batched_topk
 {
-// -----------------------------------------------------------------------------
-// One-worker-per-segment policy selection
-// -----------------------------------------------------------------------------
-template <typename PoliciesT,
-          ::cuda::std::int64_t Index,
-          ::cuda::std::int64_t Count,
-          template <typename...> class WorkerPerSegmentAgentT,
-          typename... AgentParamsT>
-struct find_first_smem_fitting_policy_impl;
-
-// Base case: End of policy chain reached: If we reach Index == Count, it means we checked all with no match
-template <typename PoliciesT,
-          ::cuda::std::int64_t Count,
-          template <typename...> class WorkerPerSegmentAgentT,
-          typename... AgentParamsT>
-struct find_first_smem_fitting_policy_impl<PoliciesT, Count, Count, WorkerPerSegmentAgentT, AgentParamsT...>
-{
-  using policy_t                         = void;
-  static constexpr bool has_valid_policy = false;
-};
-
-// Policies are ordered by decreasing tile size. This finds the first (i.e., largest) policy whose agent
-// TempStorage fits within the static shared memory limit (max_smem_per_block, typically 48KB).
-// This is useful to figure out which segments (given a runtime segment size) can still be addressed with a
-// one-worker-per-segment approach.
-template <typename PoliciesT,
-          ::cuda::std::int64_t Index,
-          ::cuda::std::int64_t Count,
-          template <typename...> class WorkerPerSegmentAgentT,
-          typename... AgentParamsT>
-struct find_first_smem_fitting_policy_impl
-{
-  // Inspect the current policy
-  using current_policy_t = ::cuda::std::tuple_element_t<Index, PoliciesT>;
-
-  // Instantiate agent to check temporary storage size
-  using current_agent_t      = WorkerPerSegmentAgentT<current_policy_t, AgentParamsT...>;
-  static constexpr bool fits = (sizeof(typename current_agent_t::TempStorage) <= max_smem_per_block);
-
-  // The 'next' policy in the chain
-  using next_step =
-    find_first_smem_fitting_policy_impl<PoliciesT, Index + 1, Count, WorkerPerSegmentAgentT, AgentParamsT...>;
-
-  // Select result:
-  // If 'fits' is true, we stop here.
-  // If 'fits' is false, we take the result from 'next_step'.
-  using policy_t = ::cuda::std::conditional_t<fits, current_policy_t, typename next_step::policy_t>;
-
-  // Whether there's a valid policy that we can instantiate the agent with such that the agent's shared memory doesn't
-  // exceed the static shared memory limimt
-  static constexpr bool has_valid_policy = fits ? true : next_step::has_valid_policy;
-};
-
-// Policies are ordered by decreasing tile size. This finds the last (i.e., smallest) policy whose tile size
-// is still large enough to cover the user-provided upper bound on segment size (tile_size >= MaxSegmentSize).
-template <typename PoliciesT, ::cuda::std::int64_t Index, ::cuda::std::int64_t Count, int MaxSegmentSize>
-struct find_smallest_covering_policy_impl
-{
-  using current_policy_t = ::cuda::std::tuple_element_t<Index, PoliciesT>;
-
-  // Calculate the capacity of the current policy
-  static constexpr int tile_size = current_policy_t::block_threads * current_policy_t::items_per_thread;
-
-  // Does this policy still cover our segment?
-  static constexpr bool covers = (tile_size >= MaxSegmentSize);
-
-  // Peek at the next policy
-  using next_step = find_smallest_covering_policy_impl<PoliciesT, Index + 1, Count, MaxSegmentSize>;
-
-  // Selection Logic:
-  // If the current policy covers the segment, we check if the next one also still does.
-  // We want the last one that returns true for 'covers'.
-  using policy_t =
-    ::cuda::std::conditional_t<next_step::has_valid_policy,
-                               typename next_step::policy_t, // The next one is even tighter and still works
-                               ::cuda::std::conditional_t<covers, current_policy_t, void> // This is the tightest valid
-                                                                                          // one
-                               >;
-
-  static constexpr bool has_valid_policy = covers;
-};
-
-// Base case: end of tuple
-template <typename PoliciesT, ::cuda::std::int64_t Count, int MaxSegmentSize>
-struct find_smallest_covering_policy_impl<PoliciesT, Count, Count, MaxSegmentSize>
-{
-  using policy_t                         = void;
-  static constexpr bool has_valid_policy = false;
-};
-
-template <typename SegmentedTopKPolicy,
-          typename SegmentSizeParameterT,
-          template <typename...> class WorkerPerSegmentAgentT,
-          typename... AgentParamsT>
+// Given a policy_selector and a segment-size parameter, resolves the agent type to be instantiated by the kernel.
+template <typename PolicySelector, typename SegmentSizeParameterT, typename... AgentParamsT>
 struct find_smallest_covering_policy
 {
-  using worker_per_segment_policies     = typename SegmentedTopKPolicy::worker_per_segment_policies;
-  static constexpr int max_segment_size = params::static_max_value_v<SegmentSizeParameterT>;
+private:
+  static constexpr ::cuda::std::int64_t max_segment_size = params::static_max_value_v<SegmentSizeParameterT>;
+  static constexpr batched_topk_policy active_policy     = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr int selected_index = find_smallest_covering_policy_index(active_policy, max_segment_size);
 
-  // Finds the smallest policy whose tile size still covers the upper bound of the segment size.
-  // Since the policy list is ordered by decreasing tile size, this is the last policy where
-  // tile_size >= max_segment_size. A smaller tile means less shared memory, so a covering policy
-  // found here is guaranteed to also fit within the static shared memory limit.
-  using segment_optimized_impl =
-    find_smallest_covering_policy_impl<worker_per_segment_policies,
-                                       0,
-                                       ::cuda::std::tuple_size<worker_per_segment_policies>::value,
-                                       max_segment_size>;
-  static constexpr bool supports_one_worker_per_segment = segment_optimized_impl::has_valid_policy;
+public:
+  static constexpr bool supports_one_worker_per_segment = selected_index >= 0;
+  // Use a safe index to avoid out-of-bounds constexpr evaluation when no policy covers. The kernel body's static_assert
+  // rejects this case.
+  static constexpr agent_batched_topk_policy policy =
+    active_policy.worker_per_segment_policies[selected_index < 0 ? 0 : selected_index];
 
-  using worker_per_segment_policy_t =
-    ::cuda::std::conditional_t<supports_one_worker_per_segment, typename segment_optimized_impl::policy_t, void>;
-
-  using worker_per_segment_agent_t =
-    ::cuda::std::conditional_t<supports_one_worker_per_segment,
-                               WorkerPerSegmentAgentT<worker_per_segment_policy_t, AgentParamsT...>,
-                               void>;
+  using agent_t =
+    agent_batched_topk_worker_per_segment<agent_batched_topk_worker_per_segment_policy<policy.block_threads,
+                                                                                       policy.items_per_thread,
+                                                                                       policy.load_algorithm,
+                                                                                       policy.store_algorithm>,
+                                          AgentParamsT...>;
 };
 
 // -----------------------------------------------------------------------------
 // Global Kernel Entry Point
 // -----------------------------------------------------------------------------
-template <typename ChainedPolicyT,
+template <typename PolicySelector,
           typename KeyInputItItT,
           typename KeyOutputItItT,
           typename ValueInputItItT,
@@ -160,11 +65,13 @@ template <typename ChainedPolicyT,
           typename KParameterT,
           typename SelectDirectionParameterT,
           typename NumSegmentsParameterT>
+#if _CCCL_HAS_CONCEPTS()
+  requires batched_topk_policy_selector<PolicySelector>
+#endif // _CCCL_HAS_CONCEPTS()
 __launch_bounds__(int(
   find_smallest_covering_policy<
-    typename ChainedPolicyT::ActivePolicy,
+    PolicySelector,
     SegmentSizeParameterT,
-    agent_batched_topk_worker_per_segment,
     KeyInputItItT,
     KeyOutputItItT,
     ValueInputItItT,
@@ -172,7 +79,7 @@ __launch_bounds__(int(
     SegmentSizeParameterT,
     KParameterT,
     SelectDirectionParameterT,
-    NumSegmentsParameterT>::worker_per_segment_policy_t::block_threads)) __global__
+    NumSegmentsParameterT>::policy.block_threads)) __global__
   void device_segmented_topk_kernel(
     KeyInputItItT d_key_segments_it,
     KeyOutputItItT d_key_segments_out_it,
@@ -183,12 +90,9 @@ __launch_bounds__(int(
     SelectDirectionParameterT select_directions,
     NumSegmentsParameterT num_segments)
 {
-  using active_policy_t = typename ChainedPolicyT::ActivePolicy;
-
   using find_smallest_covering_policy_t = find_smallest_covering_policy<
-    active_policy_t,
+    PolicySelector,
     SegmentSizeParameterT,
-    agent_batched_topk_worker_per_segment,
     KeyInputItItT,
     KeyOutputItItT,
     ValueInputItItT,
@@ -197,9 +101,10 @@ __launch_bounds__(int(
     KParameterT,
     SelectDirectionParameterT,
     NumSegmentsParameterT>;
+  static_assert(find_smallest_covering_policy_t::supports_one_worker_per_segment,
+                "No valid policy found for one-worker-per-segment approach");
 
-  using agent_t = typename find_smallest_covering_policy_t::worker_per_segment_agent_t;
-  static_assert(!::cuda::std::is_same_v<agent_t, void>, "No valid policy found for one-worker-per-segment approach");
+  using agent_t = typename find_smallest_covering_policy_t::agent_t;
 
   // Static Assertions (Constraints)
   static_assert(agent_t::tile_size >= params::static_max_value_v<SegmentSizeParameterT>,

--- a/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
@@ -46,14 +46,14 @@ private:
     }
     else
     {
-      static constexpr agent_batched_topk_policy wp = active_policy.worker_per_segment_policies[I];
-      constexpr auto tile_size                      = ::cuda::std::int64_t{wp.block_threads} * wp.items_per_thread;
+      constexpr agent_batched_topk_policy wp = active_policy.worker_per_segment_policies[I];
+      constexpr auto tile_size               = ::cuda::std::int64_t{wp.block_threads} * wp.items_per_thread;
 
       struct policy_getter_17 // TODO(bgruber): drop this in C++17 and pass wp directly
       {
         _CCCL_API constexpr auto operator()() const
         {
-          return wp;
+          return active_policy.worker_per_segment_policies[I];
         }
       };
       using candidate_agent_t  = agent_batched_topk_worker_per_segment<policy_getter_17, AgentParamsT...>;

--- a/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
@@ -75,9 +75,6 @@ private:
 
 public:
   static_assert(selected_index >= 0, "No valid policy found for one-worker-per-segment approach");
-
-  // Use a safe index to avoid out-of-bounds constexpr evaluation when no policy covers. The kernel body's static_assert
-  // rejects this case.
   static constexpr worker_policy policy = active_policy.worker_per_segment_policies[selected_index];
 
   struct policy_getter_17 // TODO(bgruber): drop this in C++17 and pass policy directly

--- a/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
@@ -22,52 +22,72 @@
 #include <cub/util_arch.cuh>
 
 #include <cuda/__device/arch_id.h>
-#include <cuda/std/__type_traits/is_same.h>
-#include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
 
 namespace detail::batched_topk
 {
-// Finds the smallest policy whose tile size still covers the given max segment size. Returns -1 if none covers.
-[[nodiscard]] _CCCL_API constexpr int
-find_smallest_covering_policy_index(const batched_topk_policy& p, ::cuda::std::int64_t max_segment_size)
-{
-  int result = -1;
-  for (int i = 0; i < static_cast<int>(p.worker_per_segment_policies.size()); ++i)
-  {
-    const auto& wp                       = p.worker_per_segment_policies[i];
-    const ::cuda::std::int64_t tile_size = ::cuda::std::int64_t{wp.block_threads} * wp.items_per_thread;
-    if (tile_size >= max_segment_size)
-    {
-      result = i;
-    }
-  }
-  return result;
-}
-
 // Given a policy_selector and a segment-size parameter, resolves the agent type to be instantiated by the kernel.
+// Selects the smallest policy whose tile size still covers the upper bound on segment size AND whose instantiated
+// agent's shared memory usage fits within the static shared memory limit (max_smem_per_block).
 template <typename PolicySelector, typename SegmentSizeParameterT, typename... AgentParamsT>
 struct find_smallest_covering_policy
 {
 private:
   static constexpr ::cuda::std::int64_t max_segment_size = params::static_max_value_v<SegmentSizeParameterT>;
   static constexpr batched_topk_policy active_policy     = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
-  static constexpr int selected_index = find_smallest_covering_policy_index(active_policy, max_segment_size);
+
+  template <int I>
+  [[nodiscard]] static constexpr int find_index()
+  {
+    if constexpr (I >= active_policy.worker_per_segment_policies.size())
+    {
+      return -1;
+    }
+    else
+    {
+      static constexpr agent_batched_topk_policy wp = active_policy.worker_per_segment_policies[I];
+      constexpr auto tile_size                      = ::cuda::std::int64_t{wp.block_threads} * wp.items_per_thread;
+
+      struct policy_getter_17 // TODO(bgruber): drop this in C++17 and pass wp directly
+      {
+        _CCCL_API constexpr auto operator()() const
+        {
+          return wp;
+        }
+      };
+      using candidate_agent_t  = agent_batched_topk_worker_per_segment<policy_getter_17, AgentParamsT...>;
+      constexpr bool covers    = tile_size >= max_segment_size;
+      constexpr bool fits_smem = sizeof(typename candidate_agent_t::TempStorage) <= max_smem_per_block;
+      constexpr int next       = find_index<I + 1>();
+      if constexpr (covers && fits_smem)
+      {
+        return next >= 0 ? next : I;
+      }
+      else
+      {
+        return next;
+      }
+    }
+  }
+
+  static constexpr int selected_index = find_index<0>();
 
 public:
-  static constexpr bool supports_one_worker_per_segment = selected_index >= 0;
+  static_assert(selected_index >= 0, "No valid policy found for one-worker-per-segment approach");
+
   // Use a safe index to avoid out-of-bounds constexpr evaluation when no policy covers. The kernel body's static_assert
   // rejects this case.
-  static constexpr agent_batched_topk_policy policy =
-    active_policy.worker_per_segment_policies[selected_index < 0 ? 0 : selected_index];
+  static constexpr agent_batched_topk_policy policy = active_policy.worker_per_segment_policies[selected_index];
 
-  using agent_t =
-    agent_batched_topk_worker_per_segment<agent_batched_topk_worker_per_segment_policy<policy.block_threads,
-                                                                                       policy.items_per_thread,
-                                                                                       policy.load_algorithm,
-                                                                                       policy.store_algorithm>,
-                                          AgentParamsT...>;
+  struct policy_getter_17 // TODO(bgruber): drop this in C++17 and pass policy directly
+  {
+    _CCCL_API constexpr auto operator()() const
+    {
+      return policy;
+    }
+  };
+  using agent_t = agent_batched_topk_worker_per_segment<policy_getter_17, AgentParamsT...>;
 };
 
 // -----------------------------------------------------------------------------
@@ -107,7 +127,7 @@ __launch_bounds__(int(
     SelectDirectionParameterT select_directions,
     NumSegmentsParameterT num_segments)
 {
-  using find_smallest_covering_policy_t = find_smallest_covering_policy<
+  using agent_t = typename find_smallest_covering_policy<
     PolicySelector,
     SegmentSizeParameterT,
     KeyInputItItT,
@@ -117,11 +137,7 @@ __launch_bounds__(int(
     SegmentSizeParameterT,
     KParameterT,
     SelectDirectionParameterT,
-    NumSegmentsParameterT>;
-  static_assert(find_smallest_covering_policy_t::supports_one_worker_per_segment,
-                "No valid policy found for one-worker-per-segment approach");
-
-  using agent_t = typename find_smallest_covering_policy_t::agent_t;
+    NumSegmentsParameterT>::agent_t;
 
   // Static Assertions (Constraints)
   static_assert(agent_t::tile_size >= params::static_max_value_v<SegmentSizeParameterT>,

--- a/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
@@ -37,32 +37,32 @@ private:
   static constexpr ::cuda::std::int64_t max_segment_size = params::static_max_value_v<SegmentSizeParameterT>;
   static constexpr batched_topk_policy active_policy     = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
 
-  template <int I>
+  template <int Index>
   [[nodiscard]] static constexpr int find_index()
   {
-    if constexpr (I >= active_policy.worker_per_segment_policies.size())
+    if constexpr (Index >= active_policy.worker_per_segment_policies.size())
     {
       return -1;
     }
     else
     {
-      constexpr agent_batched_topk_policy wp = active_policy.worker_per_segment_policies[I];
+      constexpr agent_batched_topk_policy wp = active_policy.worker_per_segment_policies[Index];
       constexpr auto tile_size               = ::cuda::std::int64_t{wp.block_threads} * wp.items_per_thread;
 
       struct policy_getter_17 // TODO(bgruber): drop this in C++17 and pass wp directly
       {
         _CCCL_API constexpr auto operator()() const
         {
-          return active_policy.worker_per_segment_policies[I];
+          return active_policy.worker_per_segment_policies[Index];
         }
       };
       using candidate_agent_t  = agent_batched_topk_worker_per_segment<policy_getter_17, AgentParamsT...>;
       constexpr bool covers    = tile_size >= max_segment_size;
       constexpr bool fits_smem = sizeof(typename candidate_agent_t::TempStorage) <= max_smem_per_block;
-      constexpr int next       = find_index<I + 1>();
+      constexpr int next       = find_index<Index + 1>();
       if constexpr (covers && fits_smem)
       {
-        return next >= 0 ? next : I;
+        return next >= 0 ? next : Index;
       }
       else
       {

--- a/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
@@ -46,8 +46,8 @@ private:
     }
     else
     {
-      constexpr agent_batched_topk_policy wp = active_policy.worker_per_segment_policies[Index];
-      constexpr auto tile_size               = ::cuda::std::int64_t{wp.block_threads} * wp.items_per_thread;
+      constexpr worker_policy wp = active_policy.worker_per_segment_policies[Index];
+      constexpr auto tile_size   = ::cuda::std::int64_t{wp.block_threads} * wp.items_per_thread;
 
       struct policy_getter_17 // TODO(bgruber): drop this in C++17 and pass wp directly
       {
@@ -78,7 +78,7 @@ public:
 
   // Use a safe index to avoid out-of-bounds constexpr evaluation when no policy covers. The kernel body's static_assert
   // rejects this case.
-  static constexpr agent_batched_topk_policy policy = active_policy.worker_per_segment_policies[selected_index];
+  static constexpr worker_policy policy = active_policy.worker_per_segment_policies[selected_index];
 
   struct policy_getter_17 // TODO(bgruber): drop this in C++17 and pass policy directly
   {

--- a/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
@@ -13,6 +13,9 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cub/block/block_load.cuh>
+#include <cub/block/block_store.cuh>
+
 #include <cuda/__device/arch_id.h>
 #include <cuda/std/__host_stdlib/ostream>
 #include <cuda/std/array>

--- a/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
@@ -23,30 +23,30 @@
 CUB_NAMESPACE_BEGIN
 namespace detail::batched_topk
 {
-struct agent_batched_topk_policy
+struct worker_policy
 {
   int block_threads;
   int items_per_thread;
   BlockLoadAlgorithm load_algorithm;
   BlockStoreAlgorithm store_algorithm;
 
-  _CCCL_API constexpr friend bool operator==(const agent_batched_topk_policy& lhs, const agent_batched_topk_policy& rhs)
+  _CCCL_API constexpr friend bool operator==(const worker_policy& lhs, const worker_policy& rhs)
   {
     return lhs.block_threads == rhs.block_threads && lhs.items_per_thread == rhs.items_per_thread
         && lhs.load_algorithm == rhs.load_algorithm && lhs.store_algorithm == rhs.store_algorithm;
   }
 
-  _CCCL_API constexpr friend bool operator!=(const agent_batched_topk_policy& lhs, const agent_batched_topk_policy& rhs)
+  _CCCL_API constexpr friend bool operator!=(const worker_policy& lhs, const worker_policy& rhs)
   {
     return !(lhs == rhs);
   }
 
 #if !_CCCL_COMPILER(NVRTC)
-  friend ::std::ostream& operator<<(::std::ostream& os, const agent_batched_topk_policy& p)
+  friend ::std::ostream& operator<<(::std::ostream& os, const worker_policy& p)
   {
-    return os << "agent_batched_topk_policy { .block_threads = " << p.block_threads
-              << ", .items_per_thread = " << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm
-              << ", .store_algorithm = " << p.store_algorithm << " }";
+    return os
+        << "worker_policy { .block_threads = " << p.block_threads << ", .items_per_thread = " << p.items_per_thread
+        << ", .load_algorithm = " << p.load_algorithm << ", .store_algorithm = " << p.store_algorithm << " }";
   }
 #endif // !_CCCL_COMPILER(NVRTC)
 };
@@ -55,7 +55,7 @@ struct batched_topk_policy
 {
   // The list of per-segment agent policies is ordered by decreasing tile size. At compile time, the smallest policy
   // whose tile size still covers the upper bound of the segment size is selected.
-  ::cuda::std::array<agent_batched_topk_policy, 6> worker_per_segment_policies;
+  ::cuda::std::array<worker_policy, 6> worker_per_segment_policies;
 
   _CCCL_API constexpr friend bool operator==(const batched_topk_policy& lhs, const batched_topk_policy& rhs)
   {
@@ -96,12 +96,12 @@ struct policy_selector
     constexpr auto load_alg  = BLOCK_LOAD_WARP_TRANSPOSE;
     constexpr auto store_alg = BLOCK_STORE_WARP_TRANSPOSE;
     return batched_topk_policy{{{
-      agent_batched_topk_policy{256, 64, load_alg, store_alg},
-      agent_batched_topk_policy{256, 32, load_alg, store_alg},
-      agent_batched_topk_policy{256, 16, load_alg, store_alg},
-      agent_batched_topk_policy{256, 8, load_alg, store_alg},
-      agent_batched_topk_policy{256, 4, load_alg, store_alg},
-      agent_batched_topk_policy{128, 2, load_alg, store_alg},
+      worker_policy{256, 64, load_alg, store_alg},
+      worker_policy{256, 32, load_alg, store_alg},
+      worker_policy{256, 16, load_alg, store_alg},
+      worker_policy{256, 8, load_alg, store_alg},
+      worker_policy{256, 4, load_alg, store_alg},
+      worker_policy{128, 2, load_alg, store_alg},
     }}};
   }
 };

--- a/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
@@ -91,23 +91,6 @@ template <typename T>
 concept batched_topk_policy_selector = policy_selector<T, batched_topk_policy>;
 #endif // _CCCL_HAS_CONCEPTS()
 
-// Finds the smallest policy whose tile size still covers the given max segment size. Returns -1 if none covers.
-[[nodiscard]] _CCCL_API constexpr int
-find_smallest_covering_policy_index(const batched_topk_policy& p, ::cuda::std::int64_t max_segment_size)
-{
-  int result = -1;
-  for (int i = 0; i < static_cast<int>(p.worker_per_segment_policies.size()); ++i)
-  {
-    const auto& wp                       = p.worker_per_segment_policies[i];
-    const ::cuda::std::int64_t tile_size = ::cuda::std::int64_t{wp.block_threads} * wp.items_per_thread;
-    if (tile_size >= max_segment_size)
-    {
-      result = i;
-    }
-  }
-  return result;
-}
-
 struct policy_selector
 {
   [[nodiscard]] _CCCL_API constexpr auto operator()(::cuda::arch_id /*arch*/) const -> batched_topk_policy

--- a/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
@@ -13,9 +13,6 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cub/agent/agent_batched_topk.cuh>
-#include <cub/util_device.cuh>
-
 #include <cuda/__device/arch_id.h>
 #include <cuda/std/__host_stdlib/ostream>
 #include <cuda/std/array>

--- a/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
@@ -16,35 +16,127 @@
 #include <cub/agent/agent_batched_topk.cuh>
 #include <cub/util_device.cuh>
 
-#include <cuda/std/tuple>
+#include <cuda/__device/arch_id.h>
+#include <cuda/std/__host_stdlib/ostream>
+#include <cuda/std/array>
 
 CUB_NAMESPACE_BEGIN
 namespace detail::batched_topk
 {
-template <typename KeyT, typename ValueT, typename SegmentSizeT, ::cuda::std::int64_t MaxK>
-struct policy_hub
+struct agent_batched_topk_policy
 {
-  struct Policy900 : ChainedPolicy<900, Policy900, Policy900>
+  int block_threads;
+  int items_per_thread;
+  BlockLoadAlgorithm load_algorithm;
+  BlockStoreAlgorithm store_algorithm;
+
+  _CCCL_API constexpr friend bool operator==(const agent_batched_topk_policy& lhs, const agent_batched_topk_policy& rhs)
   {
-    static constexpr BlockLoadAlgorithm default_load_alg   = BLOCK_LOAD_WARP_TRANSPOSE;
-    static constexpr BlockStoreAlgorithm default_store_alg = BLOCK_STORE_WARP_TRANSPOSE;
+    return lhs.block_threads == rhs.block_threads && lhs.items_per_thread == rhs.items_per_thread
+        && lhs.load_algorithm == rhs.load_algorithm && lhs.store_algorithm == rhs.store_algorithm;
+  }
 
-    // The list below will be checked to determine if each policy can support the one-worker-per-segment approach
-    // within available shared memory limits. The first policy that fits SMEM is taken. Policies must be ordered by
-    // decreasing segment size.
-    // TODO (elstehle): Consider making this a static constexpr array of a simple struct and implementing
-    // find_smallest_covering_policy as a constexpr function.
-    using worker_per_segment_policies =
-      ::cuda::std::tuple<agent_batched_topk_worker_per_segment_policy<256, 64, default_load_alg, default_store_alg>,
-                         agent_batched_topk_worker_per_segment_policy<256, 32, default_load_alg, default_store_alg>,
-                         agent_batched_topk_worker_per_segment_policy<256, 16, default_load_alg, default_store_alg>,
-                         agent_batched_topk_worker_per_segment_policy<256, 8, default_load_alg, default_store_alg>,
-                         agent_batched_topk_worker_per_segment_policy<256, 4, default_load_alg, default_store_alg>,
-                         agent_batched_topk_worker_per_segment_policy<128, 2, default_load_alg, default_store_alg>>;
-  };
+  _CCCL_API constexpr friend bool operator!=(const agent_batched_topk_policy& lhs, const agent_batched_topk_policy& rhs)
+  {
+    return !(lhs == rhs);
+  }
 
-  using max_policy = Policy900;
+#if !_CCCL_COMPILER(NVRTC)
+  friend ::std::ostream& operator<<(::std::ostream& os, const agent_batched_topk_policy& p)
+  {
+    return os << "agent_batched_topk_policy { .block_threads = " << p.block_threads
+              << ", .items_per_thread = " << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm
+              << ", .store_algorithm = " << p.store_algorithm << " }";
+  }
+#endif // !_CCCL_COMPILER(NVRTC)
 };
+
+// The list of per-segment agent policies is ordered by decreasing tile size. At compile time, the smallest policy whose
+// tile size still covers the upper bound of the segment size is selected.
+inline constexpr int num_worker_per_segment_policies = 6;
+
+struct batched_topk_policy
+{
+  ::cuda::std::array<agent_batched_topk_policy, num_worker_per_segment_policies> worker_per_segment_policies;
+
+  _CCCL_API constexpr friend bool operator==(const batched_topk_policy& lhs, const batched_topk_policy& rhs)
+  {
+    return lhs.worker_per_segment_policies == rhs.worker_per_segment_policies;
+  }
+
+  _CCCL_API constexpr friend bool operator!=(const batched_topk_policy& lhs, const batched_topk_policy& rhs)
+  {
+    return !(lhs == rhs);
+  }
+
+#if !_CCCL_COMPILER(NVRTC)
+  friend ::std::ostream& operator<<(::std::ostream& os, const batched_topk_policy& p)
+  {
+    os << "batched_topk_policy { .worker_per_segment_policies = { ";
+    for (::cuda::std::size_t i = 0; i < p.worker_per_segment_policies.size(); ++i)
+    {
+      if (i != 0)
+      {
+        os << ", ";
+      }
+      os << p.worker_per_segment_policies[i];
+    }
+    return os << " } }";
+  }
+#endif // !_CCCL_COMPILER(NVRTC)
+};
+
+#if _CCCL_HAS_CONCEPTS()
+template <typename T>
+concept batched_topk_policy_selector = policy_selector<T, batched_topk_policy>;
+#endif // _CCCL_HAS_CONCEPTS()
+
+// Finds the smallest policy whose tile size still covers the given max segment size. Returns -1 if none covers.
+[[nodiscard]] _CCCL_API constexpr int
+find_smallest_covering_policy_index(const batched_topk_policy& p, ::cuda::std::int64_t max_segment_size)
+{
+  int result = -1;
+  for (int i = 0; i < static_cast<int>(p.worker_per_segment_policies.size()); ++i)
+  {
+    const auto& wp                       = p.worker_per_segment_policies[i];
+    const ::cuda::std::int64_t tile_size = ::cuda::std::int64_t{wp.block_threads} * wp.items_per_thread;
+    if (tile_size >= max_segment_size)
+    {
+      result = i;
+    }
+  }
+  return result;
+}
+
+struct policy_selector
+{
+  [[nodiscard]] _CCCL_API constexpr auto operator()(::cuda::arch_id /*arch*/) const -> batched_topk_policy
+  {
+    constexpr auto load_alg  = BLOCK_LOAD_WARP_TRANSPOSE;
+    constexpr auto store_alg = BLOCK_STORE_WARP_TRANSPOSE;
+    return batched_topk_policy{{{
+      agent_batched_topk_policy{256, 64, load_alg, store_alg},
+      agent_batched_topk_policy{256, 32, load_alg, store_alg},
+      agent_batched_topk_policy{256, 16, load_alg, store_alg},
+      agent_batched_topk_policy{256, 8, load_alg, store_alg},
+      agent_batched_topk_policy{256, 4, load_alg, store_alg},
+      agent_batched_topk_policy{128, 2, load_alg, store_alg},
+    }}};
+  }
+};
+
+template <typename KeyT, typename ValueT, typename SegmentSizeT, ::cuda::std::int64_t MaxK>
+struct policy_selector_from_types
+{
+  [[nodiscard]] _CCCL_API constexpr auto operator()(::cuda::arch_id arch) const -> batched_topk_policy
+  {
+    return policy_selector{}(arch);
+  }
+};
+
+#if _CCCL_HAS_CONCEPTS()
+static_assert(batched_topk_policy_selector<policy_selector>);
+#endif // _CCCL_HAS_CONCEPTS()
 } // namespace detail::batched_topk
 
 CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_batched_topk.cuh
@@ -51,13 +51,11 @@ struct agent_batched_topk_policy
 #endif // !_CCCL_COMPILER(NVRTC)
 };
 
-// The list of per-segment agent policies is ordered by decreasing tile size. At compile time, the smallest policy whose
-// tile size still covers the upper bound of the segment size is selected.
-inline constexpr int num_worker_per_segment_policies = 6;
-
 struct batched_topk_policy
 {
-  ::cuda::std::array<agent_batched_topk_policy, num_worker_per_segment_policies> worker_per_segment_policies;
+  // The list of per-segment agent policies is ordered by decreasing tile size. At compile time, the smallest policy
+  // whose tile size still covers the upper bound of the segment size is selected.
+  ::cuda::std::array<agent_batched_topk_policy, 6> worker_per_segment_policies;
 
   _CCCL_API constexpr friend bool operator==(const batched_topk_policy& lhs, const batched_topk_policy& rhs)
   {

--- a/cub/test/catch2_test_device_segmented_topk_keys.cu
+++ b/cub/test/catch2_test_device_segmented_topk_keys.cu
@@ -46,32 +46,20 @@ CUB_RUNTIME_FUNCTION static cudaError_t dispatch_batched_topk_keys(
   TotalNumItemsGuaranteeT total_num_items_guarantee,
   cudaStream_t stream = nullptr)
 {
-  using value_it_t = cub::NullType**;
-
   auto values_it = static_cast<cub::NullType**>(nullptr);
-  return cub::detail::batched_topk::dispatch_batched_topk<
-    KeyInputItItT,
-    KeyOutputItItT,
-    value_it_t,
-    value_it_t,
-    SegmentSizeParamT,
-    KParamT,
-    SelectDirectionParamT,
-    NumSegmentsParameterT,
-    TotalNumItemsGuaranteeT>::
-    dispatch(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_key_segments_it,
-      d_key_segments_out_it,
-      values_it,
-      values_it,
-      segment_sizes,
-      k,
-      select_directions,
-      num_segments,
-      total_num_items_guarantee,
-      stream);
+  return cub::detail::batched_topk::dispatch(
+    d_temp_storage,
+    temp_storage_bytes,
+    d_key_segments_it,
+    d_key_segments_out_it,
+    values_it,
+    values_it,
+    segment_sizes,
+    k,
+    select_directions,
+    num_segments,
+    total_num_items_guarantee,
+    stream);
 }
 
 // %PARAM% TEST_LAUNCH lid 0:1:2

--- a/cub/test/catch2_test_device_segmented_topk_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_topk_pairs.cu
@@ -47,56 +47,8 @@ struct flag_intra_segment_duplicates
 template <typename ItemItT, typename SegIdItT>
 flag_intra_segment_duplicates(ItemItT, SegIdItT) -> flag_intra_segment_duplicates<ItemItT, SegIdItT>;
 
-template <typename KeyInputItItT,
-          typename KeyOutputItItT,
-          typename ValueInputItItT,
-          typename ValueOutputItItT,
-          typename SegmentSizeParamT,
-          typename KParamT,
-          typename SelectDirectionParamT,
-          typename NumSegmentsParameterT,
-          typename TotalNumItemsGuaranteeT>
-CUB_RUNTIME_FUNCTION static cudaError_t dispatch_batched_topk_pairs(
-  void* d_temp_storage,
-  size_t& temp_storage_bytes,
-  KeyInputItItT d_key_segments_it,
-  KeyOutputItItT d_key_segments_out_it,
-  ValueInputItItT d_value_segments_it,
-  ValueOutputItItT d_value_segments_out_it,
-  SegmentSizeParamT segment_sizes,
-  KParamT k,
-  SelectDirectionParamT select_directions,
-  NumSegmentsParameterT num_segments,
-  TotalNumItemsGuaranteeT total_num_items_guarantee,
-  cudaStream_t stream = nullptr)
-{
-  return cub::detail::batched_topk::dispatch_batched_topk<
-    KeyInputItItT,
-    KeyOutputItItT,
-    ValueInputItItT,
-    ValueOutputItItT,
-    SegmentSizeParamT,
-    KParamT,
-    SelectDirectionParamT,
-    NumSegmentsParameterT,
-    TotalNumItemsGuaranteeT>::
-    dispatch(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_key_segments_it,
-      d_key_segments_out_it,
-      d_value_segments_it,
-      d_value_segments_out_it,
-      segment_sizes,
-      k,
-      select_directions,
-      num_segments,
-      total_num_items_guarantee,
-      stream);
-}
-
 // %PARAM% TEST_LAUNCH lid 0:1:2
-DECLARE_LAUNCH_WRAPPER(dispatch_batched_topk_pairs, batched_topk_pairs);
+DECLARE_LAUNCH_WRAPPER(cub::detail::batched_topk::dispatch, batched_topk_pairs);
 
 // Total segment size
 using max_segment_size_list = c2h::enum_type_list<cuda::std::size_t, 4 * 1024>;


### PR DESCRIPTION
- [x] No SASS changes for `cub.bench.segmented_topk.keys.base` for SM120

Fixes: #8479