### PR TITLE
[libcu++] Add total_global_memory device attribute

### DIFF
--- a/libcudacxx/include/cuda/__device/attributes.h
+++ b/libcudacxx/include/cuda/__device/attributes.h
@@ -759,6 +759,18 @@ using host_memory_pools_supported_t = __dev_attr<::cudaDevAttrHostMemoryPoolsSup
 static constexpr host_memory_pools_supported_t host_memory_pools_supported{};
 #  endif // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^
 
+// Total global memory available on the device in bytes
+struct total_global_memory_t
+{
+  using type = ::cuda::std::size_t;
+
+  [[nodiscard]] _CCCL_HOST_API type operator()(device_ref __dev) const
+  {
+    return ::cuda::__driver::__deviceTotalMem(__dev.get());
+  }
+};
+static constexpr total_global_memory_t total_global_memory{};
+
 // Combines major and minor compute capability in a 100 * major + 10 * minor format, allows to query full compute
 // capability in a single query
 struct compute_capability_t

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -253,6 +253,15 @@ _CCCL_HOST_API inline void __deviceGetName(char* __name_out, int __len, int __or
   ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to query the name of a device", __name_out, __len, __dev);
 }
 
+[[nodiscard]] _CCCL_HOST_API inline ::cuda::std::size_t __deviceTotalMem(int __ordinal)
+{
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDeviceTotalMem);
+  ::std::size_t __result;
+  ::CUdevice __dev = __deviceGet(__ordinal);
+  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to query total memory of a device", &__result, __dev);
+  return static_cast<::cuda::std::size_t>(__result);
+}
+
 // Primary context management
 
 [[nodiscard]] _CCCL_HOST_API inline ::CUcontext __primaryCtxRetain(::CUdevice __dev)

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/device_smoke.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/device_smoke.c2h.cu
@@ -289,6 +289,13 @@ C2H_CCCLRT_TEST("Smoke", "[device]")
       int compute_cap_minor                = device_ref(0).attribute(attributes::compute_capability_minor);
       CCCLRT_REQUIRE(compute_cap.get() == 10 * compute_cap_major + compute_cap_minor);
     }
+
+    SECTION("Total global memory")
+    {
+      auto total_mem = device_ref(0).attribute(attributes::total_global_memory);
+      STATIC_REQUIRE(::cuda::std::is_same_v<decltype(total_mem), cuda::std::size_t>);
+      CCCLRT_REQUIRE(total_mem > 0);
+    }
   }
   SECTION("Name")
   {


### PR DESCRIPTION
Working on https://github.com/NVIDIA/cccl/pull/8541 I encountered a need for this simple wrapper over `cuDeviceTotalMem`