### PR TITLE
[docs] Hide cub::DeviceReduce::__arg_min_env and fix ArgMin @overload

### DIFF
--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -1087,9 +1087,10 @@ public:
   //! @rst
   //! .. versionadded:: 2.2.0
   //!    First appears in CUDA Toolkit 12.3.
+  //! @endrst
+  //!
   //! @overload
   //! @note Uses ``cuda::std::less`` as comparison operator
-  //! @endrst
   template <typename InputIteratorT, typename ExtremumOutIteratorT, typename IndexOutIteratorT>
   CUB_RUNTIME_FUNCTION static cudaError_t ArgMin(
     void* d_temp_storage,
@@ -1104,6 +1105,7 @@ public:
       d_temp_storage, temp_storage_bytes, d_in, d_min_out, d_index_out, num_items, ::cuda::std::less{}, stream);
   }
 
+private:
   template <typename InputIteratorT,
             typename ExtremumOutIteratorT,
             typename IndexOutIteratorT,
@@ -1185,6 +1187,7 @@ public:
     return deallocate_error;
   }
 
+public:
   //! @rst
   //! Finds the first device-wide minimum using the less-than (``<``) operator and also returns the index of that item.
   //!


### PR DESCRIPTION
internal helper `__arg_min_env` was by mistake exposed to the docs.

fixes `ArgMin` docs along the way