### PR TITLE
Fix attribute ordering issue with GCC

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk.pass.cpp
@@ -26,7 +26,7 @@ using barrier = cuda::barrier<cuda::thread_scope_block>;
 namespace cde = cuda::device::experimental;
 
 static constexpr int buf_len = 1024;
-TEST_GLOBAL_VARIABLE alignas(128) int gmem_buffer[buf_len];
+alignas(128) TEST_GLOBAL_VARIABLE int gmem_buffer[buf_len];
 
 TEST_DEVICE_FUNC void test()
 {

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_1d.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_1d.pass.cpp
@@ -35,16 +35,16 @@
 // cuda::std::array cannot be shared between host and device as some of its
 // member functions take a const reference, which is unsupported by nvcc.
 constexpr cuda::std::array<uint64_t, 1> GMEM_DIMS{256};
-_CCCL_DEVICE constexpr cuda::std::array<uint64_t, 1> GMEM_DIMS_DEV{256};
+TEST_FUNC constexpr cuda::std::array<uint64_t, 1> GMEM_DIMS_DEV{256};
 constexpr cuda::std::array<uint32_t, 1> SMEM_DIMS{32};
-_CCCL_DEVICE constexpr cuda::std::array<uint32_t, 1> SMEM_DIMS_DEV{32};
+TEST_FUNC constexpr cuda::std::array<uint32_t, 1> SMEM_DIMS_DEV{32};
 
-_CCCL_DEVICE constexpr cuda::std::array<uint32_t, 1> TEST_SMEM_COORDS[] = {{0}, {4}, {8}};
+TEST_FUNC constexpr cuda::std::array<uint32_t, 1> TEST_SMEM_COORDS[] = {{0}, {4}, {8}};
 
 constexpr size_t gmem_len = tensor_len(GMEM_DIMS);
 constexpr size_t smem_len = tensor_len(SMEM_DIMS);
 
-_CCCL_DEVICE int gmem_tensor[gmem_len];
+TEST_GLOBAL_VARIABLE int gmem_tensor[gmem_len];
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/cuda/memcpy_async/memcpy_async_tx.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memcpy_async/memcpy_async_tx.pass.cpp
@@ -29,7 +29,7 @@ TEST_NV_DIAG_SUPPRESS(static_var_with_dynamic_init)
 static_assert(false, "Insufficient CUDA Compute Capability: cuda::device::memcpy_async_tx is not available.");
 #endif // __CUDA_MINIMUM_ARCH__
 
-TEST_GLOBAL_VARIABLE alignas(16) int gmem_x[2048];
+alignas(16) TEST_GLOBAL_VARIABLE int gmem_x[2048];
 
 int main(int, char**)
 {


### PR DESCRIPTION
Looks like GCC gets confused when ordering `alignas` with other attributes sometimes, resulting in 

```
cp_async_bulk.pass.cpp(29): error: attribute does not apply to any entity
    static alignas(128) int gmem_buffer[buf_len];
```

Fix this by moving the `alignas` to the front