### PR TITLE
[Tile] Disable tests that use bitfields

### DIFF
--- a/libcudacxx/include/cuda/__bit/bitfield.h
+++ b/libcudacxx/include/cuda/__bit/bitfield.h
@@ -32,10 +32,11 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
-#if __cccl_ptx_isa >= 200
+#if !_CCCL_TILE_COMPILATION() // error: asm statement is unsupported in tile code
+#  if __cccl_ptx_isa >= 200
 
-[[nodiscard]] _CCCL_DEVICE_API inline uint32_t
-__bfi(uint32_t __dest, uint32_t __source, int __start, int __width) noexcept
+[[nodiscard]]
+_CCCL_DEVICE_API inline uint32_t __bfi(uint32_t __dest, uint32_t __source, int __start, int __width) noexcept
 {
   asm("bfi.b32 %0, %1, %2, %3, %4;" : "=r"(__dest) : "r"(__source), "r"(__dest), "r"(__start), "r"(__width));
   return __dest;
@@ -62,20 +63,22 @@ __bfi(uint64_t __dest, uint64_t __source, int __start, int __width) noexcept
   return __ret;
 }
 
-#endif // __cccl_ptx_isa >= 200
+#  endif // __cccl_ptx_isa >= 200
+#endif // !_CCCL_TILE_COMPILATION()
 
 template <typename _Tp>
-[[nodiscard]] _CCCL_API constexpr _Tp
-bitfield_insert(const _Tp __dest, const _Tp __source, int __start, int __width) noexcept
+[[nodiscard]]
+_CCCL_API constexpr _Tp bitfield_insert(const _Tp __dest, const _Tp __source, int __start, int __width) noexcept
 {
   static_assert(::cuda::std::__cccl_is_cv_unsigned_integer_v<_Tp>, "bitfield_insert() requires unsigned integer types");
   [[maybe_unused]] constexpr auto __digits = ::cuda::std::numeric_limits<_Tp>::digits;
   _CCCL_ASSERT(__width >= 0 && __width <= __digits, "width out of range");
   _CCCL_ASSERT(__start >= 0 && __start <= __digits, "start position out of range");
   _CCCL_ASSERT(__start + __width <= __digits, "start position + width out of range");
-  if constexpr (sizeof(_Tp) <= sizeof(uint64_t))
+#if !_CCCL_TILE_COMPILATION() // error: asm statement is unsupported in tile code
+  _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
-    _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+    if constexpr (sizeof(_Tp) <= sizeof(uint64_t))
     {
       // clang-format off
       NV_DISPATCH_TARGET( // all SM < 70
@@ -86,6 +89,7 @@ bitfield_insert(const _Tp __dest, const _Tp __source, int __start, int __width) 
       // clang-format on
     }
   }
+#endif // !_CCCL_TILE_COMPILATION()
   auto __mask = ::cuda::bitmask<_Tp>(__start, __width);
   return (::cuda::__shl(__source, __start) & __mask) | (__dest & ~__mask);
 }
@@ -99,9 +103,10 @@ template <typename _Tp>
   _CCCL_ASSERT(__width >= 0 && __width <= __digits, "width out of range");
   _CCCL_ASSERT(__start >= 0 && __start <= __digits, "start position out of range");
   _CCCL_ASSERT(__start + __width <= __digits, "start position + width out of range");
-  if constexpr (sizeof(_Tp) <= sizeof(uint32_t))
+#if !_CCCL_TILE_COMPILATION() // error: asm statement is unsupported in tile code
+  _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
-    _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+    if constexpr (sizeof(_Tp) <= sizeof(uint32_t))
     {
       // clang-format off
       NV_DISPATCH_TARGET( // all SM < 70
@@ -111,6 +116,7 @@ template <typename _Tp>
       // clang-format on
     }
   }
+#endif // !_CCCL_TILE_COMPILATION()
   return ::cuda::__shr(__value, __start) & ::cuda::bitmask<_Tp>(0, __width);
 }
 

--- a/libcudacxx/test/libcudacxx/libcxx/text/format/format.arguments/format.arg/arg_t.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/text/format/format.arguments/format.arg/arg_t.compile.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // cuda::std::__fmt_arg_t

--- a/libcudacxx/test/libcudacxx/libcxx/text/format/format.arguments/format.arg/determine_arg_t.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/text/format/format.arguments/format.arg/determine_arg_t.compile.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // cuda::std::__fmt_determine_arg_t

--- a/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/parsed_spec_abi.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/parsed_spec_abi.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // cuda::std::__fmt_parsed_spec

--- a/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/spec_chrono_abi.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/spec_chrono_abi.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // cuda::std::__fmt_spec_chrono

--- a/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/spec_fields_abi.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/spec_fields_abi.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // cuda::std::__fmt_spec_fields

--- a/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/spec_parser_abi.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/spec_parser_abi.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // cuda::std::__fmt_spec_parser

--- a/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/spec_std_abi.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/spec_std_abi.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // cuda::std::__fmt_spec_std

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg.store/make_format_args.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg.store/make_format_args.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // template<class Context = format_context, class... Args>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg.store/make_wformat_args.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg.store/make_wformat_args.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // template<class... Args>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/ctor.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // basic_format_arg() noexcept;

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/operator_bool.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/operator_bool.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // explicit operator bool() const noexcept

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/visit_format_arg.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/visit_format_arg.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // template<class Visitor, class Context>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/ctad.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/ctad.compile.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // template<class Context, class... Args>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/ctor.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // template<class... Args>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/get.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/get.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // basic_format_arg<Context> get(size_t i) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/types.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/types.compile.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // Namespace std typedefs:

--- a/libcudacxx/test/libcudacxx/std/text/format/format.error/format.error.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.error/format.error.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // UNSUPPORTED: nvrtc
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/advance_to.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/advance_to.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // void advance_to(iterator it);

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/arg.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/arg.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // basic_format_arg<basic_format_context> arg(size_t id) const;

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/ctor.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // The Standard does not specify a constructor

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/out.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/out.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // iterator out();

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.bool.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.bool.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // [format.formatter.spec]:

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.c_string.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.c_string.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // C++23 the formatter is a debug-enabled specialization.

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.char.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.char.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // C++23 the formatter is a debug-enabled specialization.

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.char_array.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.char_array.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // C++23 the formatter is a debug-enabled specialization.

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.handle.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.handle.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // A user defined formatter using

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.pointer.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.pointer.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // [format.formatter.spec]:

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.signed_integral.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.signed_integral.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // [format.formatter.spec]:

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.string.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.string.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // C++23 the formatter is a debug-enabled specialization.

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.unsigned_integral.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.unsigned_integral.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // [format.formatter.spec]:

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/advance_to.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/advance_to.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // constexpr void advance_to(const_iterator it);

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/begin.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/begin.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // constexpr begin() const noexcept;

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/check_arg_id.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/check_arg_id.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // constexpr void check_arg_id(size_t id);

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/ctor.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // constexpr explicit

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/end.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // constexpr end() const noexcept;

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/next_arg_id.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/next_arg_id.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // constexpr size_t next_arg_id();

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/types.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/types.compile.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // Class typedefs:

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.general/ignore.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.general/ignore.pass.cpp
@@ -38,6 +38,7 @@ TEST_FUNC constexpr bool test()
     static_assert(noexcept(res = (cuda::std::ignore = 42)));
     assert(&res == &cuda::std::ignore);
   }
+#if !_CCCL_TILE_COMPILATION() // bit field read/write is unsupported in tile code
   { // Test bit-field binding.
     struct S
     {
@@ -47,6 +48,7 @@ TEST_FUNC constexpr bool test()
     auto& res = (cuda::std::ignore = s.bf);
     assert(&res == &cuda::std::ignore);
   }
+#endif // !_CCCL_TILE_COMPILATION()
   { // Test that cuda::std::ignore provides constexpr copy/move constructors
     auto copy  = cuda::std::ignore;
     auto moved = cuda::std::move(copy);

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.underlying/to_underlying.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.underlying/to_underlying.pass.cpp
@@ -18,7 +18,8 @@
 
 #include "test_macros.h"
 
-#if TEST_COMPILER(GCC, <, 10)
+// error: bit field read/write is unsupported in tile code
+#if TEST_COMPILER(GCC, <, 10) || _CCCL_TILE_COMPILATION()
 #  define OMIT_BITFIELD_ENUMS 1
 #endif // TEST_COMPILER(GCC, <, 10)
 


### PR DESCRIPTION
Tile programs currently do not support bitfields. Those are used inside of formatters and some few tests

This also ensures that the `bitfield` header does not throw up during tile compilation due to the use of ptx 