### PR TITLE
[Tile] Disable tests that rely on `__builtin_unreachable`

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/default_accessor/accessor.restrict.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/default_accessor/accessor.restrict.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 #include <cuda/mdspan>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_accessor/device_accessor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_accessor/device_accessor.pass.cpp
@@ -6,6 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_accessor/device_accessor.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_accessor/device_accessor.runfail.cpp
@@ -6,6 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/assign.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // constexpr mdspan& operator=(const mdspan& rhs) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/conversion.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // template<class OtherElementType, class OtherExtents,

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.copy.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // constexpr mdspan(const mdspan&) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.move.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // constexpr mdspan(mdspan&&) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/deduction.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/mdspan>
 
 //  template<class CArray>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/move.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // constexpr mdspan& operator=(mdspan&&) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/assign.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // constexpr mdspan& operator=(const mdspan& rhs) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/conversion.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // template<class OtherElementType, class OtherExtents,

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.copy.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // constexpr mdspan(const mdspan&) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.move.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // constexpr mdspan(mdspan&&) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/deduction.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/mdspan>
 
 //  template<class CArray>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/index_operator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/index_operator.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // UNSUPPORTED: nvrtc

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/move.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // constexpr mdspan& operator=(mdspan&&) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride/no_unique_address.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride/no_unique_address.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/comparison.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/mdspan>
 
 // template<class OtherMapping>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/contant_offset.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/contant_offset.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/mdspan>
 
 // Test layout_stride_relaxed::mapping with integral_constant as _OffsetType:

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/conversion.layout_stride.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/conversion.layout_stride.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/mdspan>
 
 // Test conversion operator from layout_stride_relaxed::mapping to layout_stride::mapping:

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/ctor.default.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/mdspan>
 
 // Test default construction:

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/ctor.extents_strides.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/ctor.extents_strides.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/mdspan>
 
 // constexpr mapping(const extents_type& e, const strides_type& s, offset_type offset = 0) noexcept;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/ctor.strided_mapping.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/ctor.strided_mapping.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/mdspan>
 
 // Converting constructor from strided layout mappings:

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/index_operator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/index_operator.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/mdspan>
 
 // Test index operator:

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/negative_stride_unsigned_index.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/negative_stride_unsigned_index.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 //
+// XFAIL: enable-tile && !c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/__mdspan/layout_stride_relaxed.h>
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/offset.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/offset.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/mdspan>
 
 // Test offset functionality specific to layout_stride_relaxed:

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/properties.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/mdspan>
 
 // Test properties of layout_stride_relaxed::mapping:

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/required_span_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/required_span_size.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/mdspan>
 
 // constexpr index_type required_span_size() const noexcept;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/stride.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/stride.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/mdspan>
 
 // constexpr index_type stride(rank_type i) const noexcept;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_accessor/managed_accessor.1.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_accessor/managed_accessor.1.runfail.cpp
@@ -6,6 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_accessor/managed_accessor.2.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_accessor/managed_accessor.2.runfail.cpp
@@ -6,6 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_accessor/managed_accessor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_accessor/managed_accessor.pass.cpp
@@ -6,6 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/assign.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // constexpr mdspan& operator=(const mdspan& rhs) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/conversion.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // template<class OtherElementType, class OtherExtents,

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.copy.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // constexpr mdspan(const mdspan&) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.move.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // constexpr mdspan(mdspan&&) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/deduction.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/mdspan>
 
 //  template<class CArray>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/move.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // constexpr mdspan& operator=(mdspan&&) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/mdspan_to_dlpack/mdspan_to_dlpack.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/mdspan_to_dlpack/mdspan_to_dlpack.pass.cpp
@@ -6,6 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/mdspan_to_dlpack/mdspan_to_dlpack.wrapper.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/mdspan_to_dlpack/mdspan_to_dlpack.wrapper.pass.cpp
@@ -6,6 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/deduction.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/mdspan>
 
 //  template<class CArray>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_accessor/shared_mem_accessor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_accessor/shared_mem_accessor.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 #include <cuda/mdspan>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/deduction.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/mdspan>
 
 //  template<class CArray>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/index_operator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/index_operator.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // UNSUPPORTED: nvrtc

--- a/libcudacxx/test/libcudacxx/cuda/utilities/variant/device_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/variant/device_only_types.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 #include <cuda/std/cassert>
 #include <cuda/std/variant>
 

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/array/at.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/array/at.pass.cpp
@@ -103,6 +103,7 @@ void test_exceptions()
     }
   }
 
+#  if !_CCCL_TILE_COMPILATION() // error: Internal Compiler Error: "call to unknown tile builtin function!"
   {
     cuda::std::array<int, 0> array = {};
 
@@ -120,6 +121,7 @@ void test_exceptions()
       assert(false);
     }
   }
+#  endif // !_CCCL_TILE_COMPILATION()
 }
 #endif // TEST_HAS_EXCEPTIONS()
 

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/array/at_const.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/array/at_const.pass.cpp
@@ -99,6 +99,7 @@ void test_exceptions()
     }
   }
 
+#  if !_CCCL_TILE_COMPILATION() // error: Internal Compiler Error: "call to unknown tile builtin function!"
   {
     cuda::std::array<int, 0> array = {};
 
@@ -116,6 +117,7 @@ void test_exceptions()
       assert(false);
     }
   }
+#  endif // !_CCCL_TILE_COMPILATION()
 }
 #endif // TEST_HAS_EXCEPTIONS()
 

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/assign.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // constexpr mdspan& operator=(const mdspan& rhs) = default;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/conversion.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // template<class OtherElementType, class OtherExtents,

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.copy.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // constexpr mdspan(const mdspan&) = default;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.move.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // constexpr mdspan(mdspan&&) = default;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/deduction.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 //  template<class CArray>

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/move.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <mdspan>
 
 // constexpr mdspan& operator=(mdspan&&) = default;

--- a/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugated.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugated.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 #include <cuda/std/cassert>
 #include <cuda/std/complex>
 #include <cuda/std/linalg>

--- a/libcudacxx/test/libcudacxx/std/linalg/accessors/scaled.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/accessors/scaled.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 #include <cuda/std/cassert>
 #include <cuda/std/linalg>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/std/linalg/layouts/transposed.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/layouts/transposed.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 #include <cuda/std/cassert>
 #include <cuda/std/cstddef>
 #include <cuda/std/linalg>

--- a/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int16.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int16.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 #include <cuda/std/array>
 #include <cuda/std/charconv>
 #include <cuda/std/cstddef>

--- a/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int32.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int32.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 #include <cuda/std/array>
 #include <cuda/std/charconv>
 #include <cuda/std/cstddef>

--- a/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int64.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int64.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 #include <cuda/std/array>
 #include <cuda/std/charconv>
 #include <cuda/std/cstddef>

--- a/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int8.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int8.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 #include <cuda/std/array>
 #include <cuda/std/charconv>
 #include <cuda/std/cstddef>

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.unreachable/unreachable.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.unreachable/unreachable.runfail.cpp
@@ -8,6 +8,9 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: msvc
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 #include <cuda/std/utility>
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.relops/relops.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.relops/relops.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/std/variant>
 
 // template <class ...Types>

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.assign/copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.assign/copy.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;
@@ -450,7 +453,7 @@ TEST_FUNC void test_copy_assignment_same_index()
     assert(&vref == &v1);
     assert(v1.index() == 1);
     assert(cuda::std::get<1>(v1).value == 42);
-#if !TEST_COMPILER(MSVC)
+#if !TEST_COMPILER(MSVC) && !_CCCL_TILE_COMPILATION()
     assert(CopyAssign::copy_construct() == 0);
     assert(CopyAssign::move_construct() == 0);
     // FIXME(mdominiak): try to narrow down what in the compiler makes it emit an invalid PTX call instruction without
@@ -459,7 +462,7 @@ TEST_FUNC void test_copy_assignment_same_index()
     // interactions of many weird things these tests are doing.
     asm volatile("" ::: "memory");
     assert(CopyAssign::copy_assign() == 1);
-#endif // !TEST_COMPILER(MSVC)
+#endif // !TEST_COMPILER(MSVC) && !_CCCL_TILE_COMPILATION()
   }
 #if TEST_HAS_EXCEPTIONS()
 #  if defined(_LIBCUDACXX_HAS_STRING)
@@ -572,7 +575,7 @@ TEST_FUNC void test_copy_assignment_different_index()
     assert(&vref == &v1);
     assert(v1.index() == 1);
     assert(cuda::std::get<1>(v1).value == 42);
-#if !TEST_COMPILER(MSVC)
+#if !TEST_COMPILER(MSVC) && !_CCCL_TILE_COMPILATION()
     assert(CopyAssign::alive() == 2);
     assert(CopyAssign::copy_construct() == 1);
     assert(CopyAssign::move_construct() == 1);
@@ -582,7 +585,7 @@ TEST_FUNC void test_copy_assignment_different_index()
     // interactions of many weird things these tests are doing.
     asm volatile("" ::: "memory");
     assert(CopyAssign::copy_assign() == 0);
-#endif // !TEST_COMPILER(MSVC)
+#endif // !TEST_COMPILER(MSVC) && !_CCCL_TILE_COMPILATION()
   }
 #if TEST_HAS_EXCEPTIONS()
 #  if defined(_LIBCUDACXX_HAS_STRING)

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.assign/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.assign/move.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.ctor/copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.ctor/copy.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.ctor/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.ctor/move.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.dtor/dtor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.dtor/dtor.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.mod/emplace_index_args.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.mod/emplace_index_args.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.mod/emplace_index_init_list_args.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.mod/emplace_index_init_list_args.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.mod/emplace_type_args.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.mod/emplace_type_args.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.mod/emplace_type_init_list_args.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.mod/emplace_type_init_list_args.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.status/index.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.status/index.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.status/valueless_by_exception.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.status/valueless_by_exception.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.swap/swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.swap/swap.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_argument_forwarding.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_argument_forwarding.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/std/variant>
 // template <class Visitor, class... Variants>
 // constexpr see below visit(Visitor&& vis, Variants&&... vars);

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_call_operator_forwarding_multiple.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_call_operator_forwarding_multiple.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/std/variant>
 // template <class Visitor, class... Variants>
 // constexpr see below visit(Visitor&& vis, Variants&&... vars);

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_call_operator_forwarding_single.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_call_operator_forwarding_single.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/std/variant>
 // template <class Visitor, class... Variants>
 // constexpr see below visit(Visitor&& vis, Variants&&... vars);

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_caller_nonconst.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_caller_nonconst.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/std/variant>
 // template <class Visitor, class... Variants>
 // constexpr see below visit(Visitor&& vis, Variants&&... vars);

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_derived.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_derived.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/std/variant>
 // template <class Visitor, class... Variants>
 // constexpr see below visit(Visitor&& vis, Variants&&... vars);

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_exceptions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_exceptions.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // <cuda/std/variant>
 // template <class Visitor, class... Variants>
 // constexpr see below visit(Visitor&& vis, Variants&&... vars);

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_argument_forwarding.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_argument_forwarding.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 // UNSUPPORTED: gcc-6

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_call_operator_forwarding_multiple.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_call_operator_forwarding_multiple.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 // UNSUPPORTED: gcc-6

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_call_operator_forwarding_single.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_call_operator_forwarding_single.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 // UNSUPPORTED: gcc-6

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_caller_nonconst.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_caller_nonconst.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_sfinae.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_sfinae.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 


### PR DESCRIPTION
The builtin is currently not supported in tile mode. However, we heavily rely on it for some of our variadic types such as `mdspan` and `variant`

Mark those tests as XFAIL for now, so that we know when the builtin is supported.
