### PR TITLE
[Tile] Disable tests that rely on `__builtin_countlz`

### DIFF
--- a/libcudacxx/include/cuda/std/__bit/countl.h
+++ b/libcudacxx/include/cuda/std/__bit/countl.h
@@ -130,12 +130,14 @@ template <typename _Tp>
 [[nodiscard]] _CCCL_API constexpr int __cccl_countl_zero_impl(_Tp __v) noexcept
 {
   static_assert(is_same_v<_Tp, uint32_t> || is_same_v<_Tp, uint64_t>);
+#  if !_CCCL_TILE_COMPILATION() // nvbug6084444: error: "call to non-tile function not supported!"
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     NV_IF_ELSE_TARGET(NV_IS_HOST,
                       (return ::cuda::std::__cccl_countl_zero_impl_host(__v);),
                       (return ::cuda::std::__cccl_countl_zero_impl_device(__v);));
   }
+#  endif // !_CCCL_TILE_COMPILATION()
   return ::cuda::std::__cccl_countl_zero_impl_constexpr(__v);
 }
 

--- a/libcudacxx/include/cuda/std/__bit/countr.h
+++ b/libcudacxx/include/cuda/std/__bit/countr.h
@@ -142,12 +142,14 @@ template <typename _Tp>
 [[nodiscard]] _CCCL_API constexpr int __cccl_countr_zero_impl(_Tp __v) noexcept
 {
   static_assert(is_same_v<_Tp, uint32_t> || is_same_v<_Tp, uint64_t>);
+#  if !_CCCL_TILE_COMPILATION() // nvbug6084444: error: "call to non-tile function not supported!"
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     NV_IF_ELSE_TARGET(NV_IS_HOST,
                       (return ::cuda::std::__cccl_countr_zero_impl_host(__v);),
                       (return ::cuda::std::__cccl_countr_zero_impl_device(__v);));
   }
+#  endif // !_CCCL_TILE_COMPILATION()
   return ::cuda::std::__cccl_countr_zero_impl_constexpr(__v);
 }
 

--- a/libcudacxx/test/libcudacxx/libcxx/macros/extended_data_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/macros/extended_data_types.pass.cpp
@@ -6,6 +6,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 #include <cuda/std/__cccl/extended_data_types.h>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.count/countl_one.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.count/countl_one.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6084444: error: "call to non-tile function not supported!"
+
 // template <class T>
 //   constexpr int countl_one(T x) noexcept;
 

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.count/countl_zero.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.count/countl_zero.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6084444: error: "call to non-tile function not supported!"
+
 // template <class T>
 //   constexpr int countl_zero(T x) noexcept;
 


### PR DESCRIPTION
The builtin is currently not supported and we cannot rely on them during runtime.