### PR TITLE
[Tile] Disable tests that rely on `__builtin_launder`

### DIFF
--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/access.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/access.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+
 #include <cuda/std/algorithm>
 #include <cuda/std/array>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/capacity.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/capacity.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+
 #include <cuda/std/algorithm>
 #include <cuda/std/array>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/comparison.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+
 #include <cuda/std/cassert>
 #include <cuda/std/initializer_list>
 #include <cuda/std/inplace_vector>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/emplace.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/emplace.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+
 #include <cuda/std/algorithm>
 #include <cuda/std/array>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/insert.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/insert.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+
 #include <cuda/std/algorithm>
 #include <cuda/std/array>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/iterators.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/iterators.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+
 #include <cuda/std/algorithm>
 #include <cuda/std/array>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/resize.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/resize.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+
 #include <cuda/std/algorithm>
 #include <cuda/std/array>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/swap.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+
 #include <cuda/std/algorithm>
 #include <cuda/std/array>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/back.insert.iter.op_assign/lv_value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/back.insert.iter.op_assign/lv_value.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+
 // <cuda/std/iterator>
 
 // back_insert_iterator

--- a/libcudacxx/test/libcudacxx/std/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/back.insert.iter.op_assign/rv_value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/back.insert.iter.op_assign/rv_value.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+
 // <cuda/std/iterator>
 
 // back_insert_iterator

--- a/libcudacxx/test/libcudacxx/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/insert.iter.op_assign/rv_value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/insert.iter.op_assign/rv_value.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077640: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+
 // <cuda/std/iterator>
 
 // insert_iterator


### PR DESCRIPTION
The builtin is currently not supported in tile mode.

However, we have some features such as `inplace_vector` and also the buffer types that rely on it.

Mark those tests as XFAIL so that we know when the builtin has been implemented
