### PR TITLE
[Tile] Disable tests that rely on `__builtin_popcount`

### DIFF
--- a/libcudacxx/include/cuda/std/__bit/popcount.h
+++ b/libcudacxx/include/cuda/std/__bit/popcount.h
@@ -125,12 +125,14 @@ template <typename _Tp>
 {
   static_assert(is_same_v<_Tp, uint32_t> || is_same_v<_Tp, uint64_t>);
 
+#  if !_CCCL_TILE_COMPILATION() // nvbug6081171: error: "call to non-tile function not supported!"
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     NV_IF_ELSE_TARGET(NV_IS_HOST,
                       (return ::cuda::std::__cccl_popcount_impl_host(__v);),
                       (return ::cuda::std::__cccl_popcount_impl_device(__v);))
   }
+#  endif // !_CCCL_TILE_COMPILATION()
   return ::cuda::std::__cccl_popcount_impl_constexpr(__v);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/dlpack_to_mdspan/dlpack_to_mdspan.exceptions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/dlpack_to_mdspan/dlpack_to_mdspan.exceptions.pass.cpp
@@ -6,6 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// nvbug6081171: error: "call to non-tile function not supported!"
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/dlpack_to_mdspan/dlpack_to_mdspan.layout_stride_relaxed.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/dlpack_to_mdspan/dlpack_to_mdspan.layout_stride_relaxed.pass.cpp
@@ -6,6 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// nvbug6081171: error: "call to non-tile function not supported!"
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/dlpack_to_mdspan/dlpack_to_mdspan.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/dlpack_to_mdspan/dlpack_to_mdspan.pass.cpp
@@ -6,6 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// nvbug6081171: error: "call to non-tile function not supported!"
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.count/popcount.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.count/popcount.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6081171: error: "call to non-tile function not supported!"
+
 // template <class T>
 //   constexpr int popcount(T x) noexcept;
 


### PR DESCRIPTION
It is currently not supported in tile mode.

See nvbug6081171
