### PR TITLE
Disable use of extended arithmetic types in tile mode

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/extended_data_types.h
+++ b/libcudacxx/include/cuda/std/__cccl/extended_data_types.h
@@ -40,6 +40,8 @@
 #if _CCCL_TILE_COMPILATION() // TODO(miscco): Fix access to extended floating point types
 #  define CCCL_DISABLE_FP16_SUPPORT
 #  define CCCL_DISABLE_BF16_SUPPORT
+#  define CCCL_DISABLE_INT128_SUPPORT
+#  define CCCL_DISABLE_FLOAT128_SUPPORT
 #endif // _CCCL_TILE_COMPILATION()
 
 #if !defined(CCCL_DISABLE_INT128_SUPPORT) && _CCCL_OS(LINUX) \
@@ -113,7 +115,8 @@ struct __nv_fp4x4_e2m1;
  * __float128
  **********************************************************************************************************************/
 
-#if !defined(CCCL_DISABLE_FLOAT128_SUPPORT) && _CCCL_HAS_INT128() && _CCCL_OS(LINUX) && !_CCCL_ARCH(ARM64)
+#if !defined(CCCL_DISABLE_FLOAT128_SUPPORT) && _CCCL_HAS_INT128() && _CCCL_OS(LINUX) && !_CCCL_ARCH(ARM64) \
+  && !_CCCL_TILE_COMPILATION()
 // Detect host compiler support
 #  if (defined(__CUDACC_RTC_FLOAT128__) || defined(__SIZEOF_FLOAT128__) || defined(__FLOAT128__))
 #    if _CCCL_DEVICE_COMPILATION()

--- a/libcudacxx/include/cuda/std/__cccl/extended_data_types.h
+++ b/libcudacxx/include/cuda/std/__cccl/extended_data_types.h
@@ -37,6 +37,11 @@
 #define _CCCL_HAS_NVBF16()   0
 #define _CCCL_HAS_FLOAT128() 0
 
+#if _CCCL_TILE_COMPILATION() // TODO(miscco): Fix access to extended floating point types
+#  define CCCL_DISABLE_FP16_SUPPORT
+#  define CCCL_DISABLE_BF16_SUPPORT
+#endif // _CCCL_TILE_COMPILATION()
+
 #if !defined(CCCL_DISABLE_INT128_SUPPORT) && _CCCL_OS(LINUX) \
   && ((_CCCL_COMPILER(NVRTC) && defined(__CUDACC_RTC_INT128__)) || defined(__SIZEOF_INT128__))
 #  undef _CCCL_HAS_INT128

--- a/libcudacxx/test/libcudacxx/cuda/float/bfloat_cos_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/bfloat_cos_comparison.pass.cpp
@@ -9,6 +9,9 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
+// XFAIL: enable-tile
+// tile does not support access to members of `__half` or `__nv_bfloat16`
+
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"

--- a/libcudacxx/test/libcudacxx/cuda/float/bfloat_exp_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/bfloat_exp_comparison.pass.cpp
@@ -9,6 +9,9 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
+// XFAIL: enable-tile
+// tile does not support access to members of `__half` or `__nv_bfloat16`
+
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"

--- a/libcudacxx/test/libcudacxx/cuda/float/bfloat_log_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/bfloat_log_comparison.pass.cpp
@@ -9,6 +9,9 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
+// XFAIL: enable-tile
+// tile does not support access to members of `__half` or `__nv_bfloat16`
+
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"

--- a/libcudacxx/test/libcudacxx/cuda/float/bfloat_sin_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/bfloat_sin_comparison.pass.cpp
@@ -9,6 +9,9 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
+// XFAIL: enable-tile
+// tile does not support access to members of `__half` or `__nv_bfloat16`
+
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"

--- a/libcudacxx/test/libcudacxx/cuda/float/bfloat_sqrt_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/bfloat_sqrt_comparison.pass.cpp
@@ -9,6 +9,9 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
+// XFAIL: enable-tile
+// tile does not support access to members of `__half` or `__nv_bfloat16`
+
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"

--- a/libcudacxx/test/libcudacxx/cuda/float/half_cos_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/half_cos_comparison.pass.cpp
@@ -9,6 +9,9 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
+// XFAIL: enable-tile
+// tile does not support access to members of `__half` or `__nv_bfloat16`
+
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"

--- a/libcudacxx/test/libcudacxx/cuda/float/half_exp_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/half_exp_comparison.pass.cpp
@@ -9,6 +9,9 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
+// XFAIL: enable-tile
+// tile does not support access to members of `__half` or `__nv_bfloat16`
+
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"

--- a/libcudacxx/test/libcudacxx/cuda/float/half_log_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/half_log_comparison.pass.cpp
@@ -9,6 +9,9 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
+// XFAIL: enable-tile
+// tile does not support access to members of `__half` or `__nv_bfloat16`
+
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"

--- a/libcudacxx/test/libcudacxx/cuda/float/half_sin_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/half_sin_comparison.pass.cpp
@@ -9,6 +9,9 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
+// XFAIL: enable-tile
+// tile does not support access to members of `__half` or `__nv_bfloat16`
+
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"

--- a/libcudacxx/test/libcudacxx/cuda/float/half_sqrt_comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/float/half_sqrt_comparison.pass.cpp
@@ -9,6 +9,9 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: nvrtc, nvcc-11, nvcc-12.0, nvcc-12.1
 
+// XFAIL: enable-tile
+// tile does not support access to members of `__half` or `__nv_bfloat16`
+
 #include <cuda/std/cmath>
 
 #include "host_device_comparison.h"

--- a/libcudacxx/test/libcudacxx/cuda/utilities/tuple/vector_types_get.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/tuple/vector_types_get.pass.cpp
@@ -77,11 +77,20 @@ TEST_FUNC constexpr BaseType get_expected()
 template <class T>
 TEST_FUNC constexpr bool test_eq(const T& lhs, const T& rhs)
 {
-  if constexpr (cuda::std::is_same_v<T, __half> || cuda::std::is_same_v<T, __nv_bfloat16>)
+#if _CCCL_HAS_NVFP16()
+  if constexpr (cuda::std::is_same_v<T, __half>)
   {
     return cuda::std::__fp_get_storage(lhs) == cuda::std::__fp_get_storage(rhs);
   }
   else
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
+    if constexpr (cuda::std::is_same_v<T, __nv_bfloat16>)
+  {
+    return cuda::std::__fp_get_storage(lhs) == cuda::std::__fp_get_storage(rhs);
+  }
+  else
+#endif // _CCCL_HAS_NVBF16()
   {
     return lhs == rhs;
   }

--- a/libcudacxx/test/libcudacxx/cuda/utilities/tuple/vector_types_structured_bindings.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/tuple/vector_types_structured_bindings.pass.cpp
@@ -79,11 +79,20 @@ TEST_FUNC constexpr BaseType get_expected()
 template <class T>
 TEST_FUNC constexpr bool test_eq(const T& lhs, const T& rhs)
 {
-  if constexpr (cuda::std::is_same_v<T, __half> || cuda::std::is_same_v<T, __nv_bfloat16>)
+#if _CCCL_HAS_NVFP16()
+  if constexpr (cuda::std::is_same_v<T, __half>)
   {
     return cuda::std::__fp_get_storage(lhs) == cuda::std::__fp_get_storage(rhs);
   }
   else
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
+    if constexpr (cuda::std::is_same_v<T, __nv_bfloat16>)
+  {
+    return cuda::std::__fp_get_storage(lhs) == cuda::std::__fp_get_storage(rhs);
+  }
+  else
+#endif // _CCCL_HAS_NVBF16()
   {
     return lhs == rhs;
   }

--- a/libcudacxx/test/libcudacxx/libcxx/macros/extended_data_types.bf16.fail.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/macros/extended_data_types.bf16.fail.cpp
@@ -6,6 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// tile does not support access to members of `__half` or `__nv_bfloat16`
+
 #include <cuda/std/__cccl/extended_data_types.h>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/libcxx/macros/extended_data_types.fp16.fail.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/macros/extended_data_types.fp16.fail.cpp
@@ -6,6 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// tile does not support access to members of `__half` or `__nv_bfloat16`
+
 #include <cuda/std/__cccl/extended_data_types.h>
 
 #include "test_macros.h"


### PR DESCRIPTION
NVCC currently does not support extended arithmetic types in tile mode.

Its slightly different for `__half` and `__nv_bfloat16` which are treated as compiler builtins, but that also means we cannot access their internals, which breaks a lot of internal machinery