### PR TITLE
[Tile] Disable tests that rely on dynamic allocation

### DIFF
--- a/libcudacxx/include/cuda/std/__cstdlib/malloc.h
+++ b/libcudacxx/include/cuda/std/__cstdlib/malloc.h
@@ -42,6 +42,10 @@ using ::malloc;
 [[nodiscard]] _CCCL_DEVICE_API inline void* __calloc_device(size_t __n, size_t __size) noexcept
 {
   void* __ptr{};
+
+#  if _CCCL_TILE_COMPILATION() // dynamic allocations are not supported in tile mode
+  _CCCL_VERIFY(false, "dynamimc allocation is not supported in tile programs");
+#  else // ^^^ _CCCL_TILE_COMPILATION() ^^^ / vvv !_CCCL_TILE_COMPILATION() vvv
   // check for overflow through a hypothetical larger integer
   // TODO (miscco): use `mul_overflow` once implemented
   if (::cuda::mul_hi(__n, __size) == 0)
@@ -53,6 +57,7 @@ using ::malloc;
       ::cuda::std::memset(__ptr, 0, __nbytes);
     }
   }
+#  endif // !_CCCL_TILE_COMPILATION()
 
   return __ptr;
 }

--- a/libcudacxx/test/libcudacxx/cuda/cmath/fast_modulo_division.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/cmath/fast_modulo_division.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 #include <cuda/cmath>
 #include <cuda/std/chrono>
 #include <cuda/std/cstdint>

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/ctor.value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/ctor.value.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // constexpr explicit shuffle_iterator(Bijection, index_type = 0);
 // template<class RGN> constexpr explicit shuffle_iterator(index_type, RNG, index_type = 0);
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/make_shuffle_iterator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/make_shuffle_iterator.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // constexpr explicit shuffle_iterator(Bijection, index_type = 0);
 // template<class RGN> constexpr explicit shuffle_iterator(index_type, RNG, index_type = 0);
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/uniformity.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/uniformity.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // Test uniformity of shuffle_iterator permutation distribution
 // This test checks that different seeds produce a reasonably uniform
 // distribution across all possible permutations.

--- a/libcudacxx/test/libcudacxx/cuda/random/feistel_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/random/feistel_size.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 #include <cuda/__random/feistel_bijection.h>
 #include <cuda/std/cassert>
 #include <cuda/std/random>

--- a/libcudacxx/test/libcudacxx/cuda/random/pcg64.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/random/pcg64.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <random>
 
 #include <cuda/__random/pcg_engine.h>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.random.sample/sample.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.random.sample/sample.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // <algorithm>
 
 // template <class PopulationIterator, class SampleIterator, class Distance,

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.random.sample/sample.stable.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.random.sample/sample.stable.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // <algorithm>
 
 // template <class PopulationIterator, class SampleIterator, class Distance,

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.random.shuffle/random_shuffle_urng.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.random.shuffle/random_shuffle_urng.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // <algorithm>
 
 // template<class RandomAccessIterator, class UniformRandomNumberGenerator>

--- a/libcudacxx/test/libcudacxx/std/language.support/cstdlib/aligned_alloc.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/cstdlib/aligned_alloc.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // Disable CCCL assertions in this test to test the erroneous behavior
 #undef CCCL_ENABLE_ASSERTIONS
 

--- a/libcudacxx/test/libcudacxx/std/language.support/cstdlib/calloc.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/cstdlib/calloc.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>
 #include <cuda/std/cstdlib>

--- a/libcudacxx/test/libcudacxx/std/random/distribution/bernoulli.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/bernoulli.pass.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
 

--- a/libcudacxx/test/libcudacxx/std/random/distribution/binomial.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/binomial.pass.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
 

--- a/libcudacxx/test/libcudacxx/std/random/distribution/cauchy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/cauchy.pass.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
 

--- a/libcudacxx/test/libcudacxx/std/random/distribution/chi_squared.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/chi_squared.pass.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
 

--- a/libcudacxx/test/libcudacxx/std/random/distribution/exponential.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/exponential.pass.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
 

--- a/libcudacxx/test/libcudacxx/std/random/distribution/extreme_value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/extreme_value.pass.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
 

--- a/libcudacxx/test/libcudacxx/std/random/distribution/fisher_f.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/fisher_f.pass.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
 

--- a/libcudacxx/test/libcudacxx/std/random/distribution/gamma.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/gamma.pass.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
 

--- a/libcudacxx/test/libcudacxx/std/random/distribution/geometric.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/geometric.pass.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
 

--- a/libcudacxx/test/libcudacxx/std/random/distribution/lognormal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/lognormal.pass.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
 

--- a/libcudacxx/test/libcudacxx/std/random/distribution/negative_binomial.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/negative_binomial.pass.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
 

--- a/libcudacxx/test/libcudacxx/std/random/distribution/normal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/normal.pass.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
 

--- a/libcudacxx/test/libcudacxx/std/random/distribution/poisson.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/poisson.pass.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
 

--- a/libcudacxx/test/libcudacxx/std/random/distribution/student_t.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/student_t.pass.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
 

--- a/libcudacxx/test/libcudacxx/std/random/distribution/uniform_int.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/uniform_int.pass.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
 

--- a/libcudacxx/test/libcudacxx/std/random/distribution/uniform_real.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/uniform_real.pass.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
 

--- a/libcudacxx/test/libcudacxx/std/random/distribution/weibull.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/weibull.pass.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
 //
 // REQUIRES: long_tests
 

--- a/libcudacxx/test/libcudacxx/std/random/engine/lcg.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/engine/lcg.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 #include <cuda/std/random>
 
 #include "random_utilities/test_engine.h"

--- a/libcudacxx/test/libcudacxx/std/random/engine/philox.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/engine/philox.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 #include <cuda/std/random>
 
 #include "random_utilities/test_engine.h"

--- a/libcudacxx/test/libcudacxx/std/random/generate_canonical/generate_canonical.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/generate_canonical/generate_canonical.pass.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
 //
 
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/random/seed_seq/assign.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/seed_seq/assign.compile.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 #include <cuda/std/cassert>
 #include <cuda/std/random>
 

--- a/libcudacxx/test/libcudacxx/std/random/seed_seq/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/seed_seq/ctor.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 #include <cuda/std/cassert>
 #include <cuda/std/random>
 

--- a/libcudacxx/test/libcudacxx/std/random/seed_seq/generate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/seed_seq/generate.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 #include <cuda/std/random>
 #if !_CCCL_COMPILER(NVRTC)
 #  include <cstdint>

--- a/libcudacxx/test/libcudacxx/std/random/seed_seq/param.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/seed_seq/param.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 #include <cuda/std/cassert>
 #include <cuda/std/random>
 

--- a/libcudacxx/test/libcudacxx/std/random/seed_seq/size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/seed_seq/size.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 #include <cuda/std/cassert>
 #include <cuda/std/random>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/allocator.traits/allocator.traits.members/destroy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/allocator.traits/allocator.traits.members/destroy.pass.cpp
@@ -7,7 +7,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // <memory>
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
 
 // template <class Alloc>
 // struct allocator_traits

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/pointer_type.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/pointer_type.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move.pass.cpp
@@ -11,6 +11,9 @@
 // Self assignment post-conditions are tested.
 // ADDITIONAL_COMPILE_OPTIONS_HOST: -Wno-self-move
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: nvrtc
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.runtime.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.runtime.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.single.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.single.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/null.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/null.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/nullptr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/nullptr.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/deduct.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/deduct.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/default.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move_convert.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move_convert.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: nvrtc
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move_convert.runtime.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move_convert.runtime.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move_convert.single.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move_convert.single.pass.cpp
@@ -7,6 +7,9 @@
 
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/null.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/null.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/nullptr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/nullptr.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/pointer.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/pointer.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/pointer_deleter.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/pointer_deleter.fail.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/pointer_deleter.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/pointer_deleter.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.dtor/null.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.dtor/null.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/release.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/release.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset.runtime.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset.runtime.fail.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset.single.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset.single.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset_self.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset_self.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/swap.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/dereference.single.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/dereference.single.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/dereference.verify.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/dereference.verify.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/explicit_bool.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/explicit_bool.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/get.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/get.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/get_deleter.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/get_deleter.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/op_arrow.single.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/op_arrow.single.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/op_arrow.verify.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/op_arrow.verify.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/op_subscript.runtime.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/op_subscript.runtime.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/op_subscript.single.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/op_subscript.single.fail.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique.array.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique.array.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 #include <cuda/std/__memory_>
 #if defined(_LIBCUDACXX_HAS_STRING)
 #  include <cuda/std/string>

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique.single.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique.single.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 #include <cuda/std/__memory_>
 #if defined(_LIBCUDACXX_HAS_STRING)
 #  include <cuda/std/string>

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique.sizezero.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique.sizezero.pass.cpp
@@ -12,6 +12,9 @@
 // UNSUPPORTED: nvrtc
 // UNSUPPORTED: nvhpc
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // Test the fix for https://llvm.org/PR54100
 
 #include <cuda/std/__memory_>

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique_for_overwrite.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique_for_overwrite.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // template<class T>
 //   constexpr unique_ptr<T> make_unique_for_overwrite(); // T is not array
 //

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt/convert_ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt/convert_ctor.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // default_delete

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt/default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt/default.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // default_delete

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt/incomplete.compile.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt/incomplete.compile.fail.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // <memory>
 
 // default_delete

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt/void.compile.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt/void.compile.fail.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // <memory>
 
 // default_delete

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt1/convert_ctor.compile.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt1/convert_ctor.compile.fail.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // <memory>
 
 // default_delete

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt1/convert_ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt1/convert_ctor.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // <memory>
 
 // default_delete[]

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt1/default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt1/default.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // UNSUPPORTED: true

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt1/incomplete.compile.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt1/incomplete.compile.fail.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // <memory>
 
 // default_delete

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.special/cmp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.special/cmp.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.special/cmp_nullptr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.special/cmp_nullptr.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.special/swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.special/swap.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <memory>
 
 // unique_ptr

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/specialized.algorithms/specialized.addressof/addressof.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/specialized.algorithms/specialized.addressof/addressof.pass.cpp
@@ -36,6 +36,7 @@ struct nothing
 
 int main(int, char**)
 {
+#if !_CCCL_TILE_COMPILATION() // error: dynamic memory allocation is unsupported in tile code
   {
     int i;
     double d;
@@ -47,6 +48,7 @@ int main(int, char**)
     assert(cuda::std::addressof(*ctp) == tp);
     delete tp;
   }
+#endif // !_CCCL_TILE_COMPILATION()
   {
     union
     {

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/temporary.buffer/overaligned.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/temporary.buffer/overaligned.pass.cpp
@@ -20,6 +20,9 @@
 //   void
 //   return_temporary_buffer(T* p);
 
+// XFAIL: enable-tile
+// In tile mode dynamic memory allocation is unsupported
+
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>
 #include <cuda/std/memory>

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/temporary.buffer/temporary_buffer.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/temporary.buffer/temporary_buffer.pass.cpp
@@ -22,6 +22,9 @@
 
 // UNSUPPORTED: nvrtc
 
+// XFAIL: enable-tile
+// In tile mode dynamic memory allocation is unsupported
+
 #include <cuda/std/cassert>
 #include <cuda/std/memory>
 #include <cuda/std/utility>

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.general/tuple.smartptr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.general/tuple.smartptr.pass.cpp
@@ -10,6 +10,9 @@
 //  Tuples of smart pointers; based on bug #18350
 //  auto_ptr doesn't have a copy constructor that takes a const &, but tuple does.
 
+// XFAIL: enable-tile
+// In tile mode dynamic memory allocation is unsupported
+
 #include <cuda/std/__memory_>
 #include <cuda/std/tuple>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.elem/get_rv.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.elem/get_rv.pass.cpp
@@ -24,12 +24,14 @@
 
 int main(int, char**)
 {
+#if !_CCCL_TILE_COMPILATION() // dynamic memory allocation with non-placement ::operator new is unsupported in tile code
   {
     using T = cuda::std::tuple<cuda::std::unique_ptr<int>>;
     T t(cuda::std::unique_ptr<int>(new int(3)));
     cuda::std::unique_ptr<int> p = cuda::std::get<0>(cuda::std::move(t));
     assert(*p == 3);
   }
+#endif // !_CCCL_TILE_COMPILATION()
 
   {
     cuda::std::tuple<MoveOnly> t(3);

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.elem/tuple.by.type.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.elem/tuple.by.type.pass.cpp
@@ -52,6 +52,7 @@ int main(int, char**)
     assert(i2 == 2);
   }
 
+#if !_CCCL_TILE_COMPILATION() // dynamic memory allocation with non-placement ::operator new is unsupported in tile code
   {
     using upint = cuda::std::unique_ptr<int>;
     cuda::std::tuple<upint> t(upint(new int(4)));
@@ -67,6 +68,7 @@ int main(int, char**)
     assert(*p == 4);
     assert(cuda::std::get<upint>(t) != nullptr);
   }
+#endif // !_CCCL_TILE_COMPILATION()
 
   {
     int x = 42;

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.swap/swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.swap/swap.pass.cpp
@@ -164,6 +164,7 @@ int main(int, char**)
     assert(i == 2);
     assert(j == 1);
   }
+#if !_CCCL_TILE_COMPILATION() // dynamic memory allocation with non-placement ::operator new is unsupported in tile code
   {
     cuda::std::unique_ptr<int> i(new int(1));
     cuda::std::unique_ptr<int> j(new int(2));
@@ -171,6 +172,7 @@ int main(int, char**)
     assert(*i == 2);
     assert(*j == 1);
   }
+#endif // !_CCCL_TILE_COMPILATION()
   {
     // test that the swap
     static_assert(can_swap<CopyOnly&>());

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.swap/swap_array.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.swap/swap_array.pass.cpp
@@ -104,6 +104,7 @@ int main(int, char**)
     assert(j[1] == 2);
     assert(j[2] == 3);
   }
+#if !_CCCL_TILE_COMPILATION() // dynamic memory allocation with non-placement ::operator new is unsupported in tile code
   {
     cuda::std::unique_ptr<int> i[3];
     for (int k = 0; k < 3; ++k)
@@ -123,6 +124,7 @@ int main(int, char**)
     assert(*j[1] == 2);
     assert(*j[2] == 3);
   }
+#endif // !_CCCL_TILE_COMPILATION()
   {
     using CA = CopyOnly[42];
     using MA = NoexceptMoveOnly[42];


### PR DESCRIPTION
In tile mode the compiler takes care of all memory handling, so dynamic memory allocation is currently not supported
