### PR TITLE
[Tile] Avoid virtual functions

### DIFF
--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp
@@ -156,6 +156,7 @@ int main(int, char**)
   types::for_each(types::as_pointers<types::cv_qualified_versions<char>>(),
                   TestIter2<char, types::as_pointers<types::cv_qualified_versions<char>>>());
 
+#if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
   {
     Derived d;
     Derived* a[] = {&d, nullptr};
@@ -164,6 +165,7 @@ int main(int, char**)
     assert(cuda::std::equal(a, a + 2, b));
     assert(cuda::std::equal(a, a + 2, b, b + 2));
   }
+#endif // !_CCCL_TILE_COMPILATION()
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.not_fn/not_fn.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.not_fn/not_fn.pass.cpp
@@ -701,7 +701,8 @@ TEST_FUNC void call_operator_noexcept_test()
   }
 }
 
-#if !TEST_CUDA_COMPILER(CLANG) // https://github.com/llvm/llvm-project/issues/67533
+#if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
+#  if !TEST_CUDA_COMPILER(CLANG) // https://github.com/llvm/llvm-project/issues/67533
 TEST_FUNC void test_lwg2767()
 {
   // See https://cplusplus.github.io/LWG/lwg-defects.html#2767
@@ -727,7 +728,8 @@ TEST_FUNC void test_lwg2767()
     assert(b);
   }
 }
-#endif // TEST_CUDA_COMPILER(CLANG)
+#  endif // TEST_CUDA_COMPILER(CLANG)
+#endif // !_CCCL_TILE_COMPILATION
 
 int main(int, char**)
 {
@@ -740,9 +742,11 @@ int main(int, char**)
   call_operator_sfinae_test(); // somewhat of an extension
   // call_operator_forwarding_test();
   call_operator_noexcept_test();
-#if !TEST_CUDA_COMPILER(CLANG)
+#if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
+#  if !TEST_CUDA_COMPILER(CLANG)
   test_lwg2767();
-#endif // TEST_CUDA_COMPILER(CLANG)
+#  endif // TEST_CUDA_COMPILER(CLANG)
+#endif // !_CCCL_TILE_COMPILATION()
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_destructible.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_destructible.pass.cpp
@@ -46,10 +46,12 @@ TEST_FUNC void test_is_not_destructible()
 class Empty
 {};
 
+#if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
 class NotEmpty
 {
   TEST_FUNC virtual ~NotEmpty();
 };
+#endif // !_CCCL_TILE_COMPILATION()
 
 union Union
 {};
@@ -66,6 +68,7 @@ struct A
 
 using Function = void();
 
+#if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
 struct PublicAbstract
 {
 public:
@@ -81,6 +84,7 @@ struct PrivateAbstract
 private:
   TEST_FUNC virtual void foo() = 0;
 };
+#endif // !_CCCL_TILE_COMPILATION()
 
 struct PublicDestructor
 {
@@ -98,6 +102,7 @@ private:
   TEST_FUNC ~PrivateDestructor() {}
 };
 
+#if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
 struct VirtualPublicDestructor
 {
 public:
@@ -129,6 +134,7 @@ struct PurePrivateDestructor
 private:
   TEST_FUNC virtual ~PurePrivateDestructor() = 0;
 };
+#endif // !_CCCL_TILE_COMPILATION()
 
 struct DeletedPublicDestructor
 {
@@ -146,6 +152,7 @@ private:
   TEST_FUNC ~DeletedPrivateDestructor() = delete;
 };
 
+#if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
 struct DeletedVirtualPublicDestructor
 {
 public:
@@ -161,6 +168,7 @@ struct DeletedVirtualPrivateDestructor
 private:
   TEST_FUNC virtual ~DeletedVirtualPrivateDestructor() = delete;
 };
+#endif // !_CCCL_TILE_COMPILATION()
 
 int main(int, char**)
 {
@@ -175,12 +183,14 @@ int main(int, char**)
   test_is_destructible<char[3]>();
   test_is_destructible<bit_zero>();
   test_is_destructible<int[3]>();
+  test_is_destructible<PublicDestructor>();
+#if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
   test_is_destructible<ProtectedAbstract>();
   test_is_destructible<PublicAbstract>();
   test_is_destructible<PrivateAbstract>();
-  test_is_destructible<PublicDestructor>();
   test_is_destructible<VirtualPublicDestructor>();
   test_is_destructible<PurePublicDestructor>();
+#endif // !_CCCL_TILE_COMPILATION()
 
   test_is_not_destructible<int[]>();
   test_is_not_destructible<void>();
@@ -189,21 +199,26 @@ int main(int, char**)
   // Test access controlled destructors
   test_is_not_destructible<ProtectedDestructor>();
   test_is_not_destructible<PrivateDestructor>();
+#if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
   test_is_not_destructible<VirtualProtectedDestructor>();
   test_is_not_destructible<VirtualPrivateDestructor>();
   test_is_not_destructible<PureProtectedDestructor>();
   test_is_not_destructible<PurePrivateDestructor>();
+#endif // !_CCCL_TILE_COMPILATION()
 
   // Test deleted constructors
   test_is_not_destructible<DeletedPublicDestructor>();
   test_is_not_destructible<DeletedProtectedDestructor>();
   test_is_not_destructible<DeletedPrivateDestructor>();
+
+#if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
   // test_is_not_destructible<DeletedVirtualPublicDestructor>(); // previously failed due to clang bug #20268
   test_is_not_destructible<DeletedVirtualProtectedDestructor>();
   test_is_not_destructible<DeletedVirtualPrivateDestructor>();
 
   // Test private destructors
   test_is_not_destructible<NotEmpty>();
+#endif // !_CCCL_TILE_COMPILATION()
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_nothrow_destructible.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_nothrow_destructible.pass.cpp
@@ -59,6 +59,7 @@ private:
   TEST_FUNC ~PrivateDestructor() {}
 };
 
+#if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
 struct VirtualPublicDestructor
 {
 public:
@@ -90,6 +91,7 @@ struct PurePrivateDestructor
 private:
   TEST_FUNC virtual ~PurePrivateDestructor() = 0;
 };
+#endif // !_CCCL_TILE_COMPILATION()
 
 class Empty
 {};
@@ -102,10 +104,12 @@ struct bit_zero
   int : 0;
 };
 
+#if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
 class Abstract
 {
   TEST_FUNC virtual void foo() = 0;
 };
+#endif // !_CCCL_TILE_COMPILATION()
 
 int main(int, char**)
 {
@@ -122,20 +126,24 @@ int main(int, char**)
 
   // requires noexcept. These are all destructible.
   test_is_nothrow_destructible<PublicDestructor>();
+#if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
   test_is_nothrow_destructible<VirtualPublicDestructor>();
   test_is_nothrow_destructible<PurePublicDestructor>();
-  test_is_nothrow_destructible<bit_zero>();
   test_is_nothrow_destructible<Abstract>();
+#endif // !_CCCL_TILE_COMPILATION()
+  test_is_nothrow_destructible<bit_zero>();
   test_is_nothrow_destructible<Empty>();
   test_is_nothrow_destructible<Union>();
 
   // requires access control
   test_is_not_nothrow_destructible<ProtectedDestructor>();
   test_is_not_nothrow_destructible<PrivateDestructor>();
+#if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
   test_is_not_nothrow_destructible<VirtualProtectedDestructor>();
   test_is_not_nothrow_destructible<VirtualPrivateDestructor>();
   test_is_not_nothrow_destructible<PureProtectedDestructor>();
   test_is_not_nothrow_destructible<PurePrivateDestructor>();
+#endif // !_CCCL_TILE_COMPILATION()
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_trivially_destructible.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_trivially_destructible.pass.cpp
@@ -59,6 +59,7 @@ private:
   TEST_FUNC ~PrivateDestructor() {}
 };
 
+#if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
 struct VirtualPublicDestructor
 {
 public:
@@ -90,6 +91,7 @@ struct PurePrivateDestructor
 private:
   TEST_FUNC virtual ~PurePrivateDestructor() = 0;
 };
+#endif // !_CCCL_TILE_COMPILATION()
 
 class Empty
 {};
@@ -102,6 +104,7 @@ struct bit_zero
   int : 0;
 };
 
+#if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
 class Abstract
 {
   TEST_FUNC virtual void foo() = 0;
@@ -111,6 +114,7 @@ class AbstractDestructor
 {
   TEST_FUNC virtual ~AbstractDestructor() = 0;
 };
+#endif // !_CCCL_TILE_COMPILATION()
 
 struct A
 {
@@ -122,10 +126,12 @@ int main(int, char**)
   test_is_not_trivially_destructible<void>();
   test_is_not_trivially_destructible<A>();
   test_is_not_trivially_destructible<char[]>();
+#if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
   test_is_not_trivially_destructible<VirtualPublicDestructor>();
   test_is_not_trivially_destructible<PurePublicDestructor>();
 
   test_is_trivially_destructible<Abstract>();
+#endif // !_CCCL_TILE_COMPILATION()
   test_is_trivially_destructible<Union>();
   test_is_trivially_destructible<Empty>();
   test_is_trivially_destructible<int&>();
@@ -139,10 +145,12 @@ int main(int, char**)
   // requires access control sfinae
   test_is_not_trivially_destructible<ProtectedDestructor>();
   test_is_not_trivially_destructible<PrivateDestructor>();
+#if !_CCCL_TILE_COMPILATION() // error: virtual function is unsupported in tile code
   test_is_not_trivially_destructible<VirtualProtectedDestructor>();
   test_is_not_trivially_destructible<VirtualPrivateDestructor>();
   test_is_not_trivially_destructible<PureProtectedDestructor>();
   test_is_not_trivially_destructible<PurePrivateDestructor>();
+#endif // !_CCCL_TILE_COMPILATION()
 
 #if !_CCCL_IS_IDENTIFIER(_Atomic)
   test_is_trivially_destructible<_Atomic int>();

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.cons/string_view_ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.cons/string_view_ctor.pass.cpp
@@ -179,19 +179,23 @@ TEST_FUNC constexpr void test_string_ctor()
   }
 }
 
+#if !_CCCL_TILE_COMPILATION() // virtual functions are unsupported in tile code
 struct Nonsense
 {
   TEST_FUNC virtual ~Nonsense() {}
 };
+#endif // !_CCCL_TILE_COMPILATION()
 
 TEST_FUNC constexpr void test_for_non_eager_instantiation()
 {
+#if !_CCCL_TILE_COMPILATION() // virtual functions are unsupported in tile code
   // Ensure we don't accidentally instantiate `cuda::std::basic_string_view<Nonsense>`
   // since it may not be well formed and can cause an error in the
   // non-immediate context.
   static_assert(!cuda::std::is_constructible<cuda::std::bitset<3>, Nonsense*>::value);
   static_assert(
     !cuda::std::is_constructible<cuda::std::bitset<3>, Nonsense*, cuda::std::size_t, Nonsense&, Nonsense&>::value, "");
+#endif // !_CCCL_TILE_COMPILATION()
 }
 
 TEST_FUNC constexpr bool test()

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.assign/convert_move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.assign/convert_move.pass.cpp
@@ -20,6 +20,7 @@
 
 #include "test_macros.h"
 
+#if !_CCCL_TILE_COMPILATION() // virtual functions are unsupported in tile code
 struct B
 {
   int id_;
@@ -37,6 +38,7 @@ struct D : B
       : B(i)
   {}
 };
+#endif // !_CCCL_TILE_COMPILATION()
 
 struct E
 {
@@ -66,6 +68,7 @@ int main(int, char**)
     assert(cuda::std::get<0>(t1) == 2);
     assert(cuda::std::get<1>(t1) == int('a'));
   }
+#if !_CCCL_TILE_COMPILATION() // virtual functions are unsupported in tile code
   {
     using T0 = cuda::std::tuple<long, char, D>;
     using T1 = cuda::std::tuple<long long, int, B>;
@@ -99,6 +102,7 @@ int main(int, char**)
     assert(cuda::std::get<1>(t1) == int('a'));
     assert(cuda::std::get<2>(t1)->id_ == 3);
   }
+#endif // !_CCCL_TILE_COMPILATION()
 
   {
     // Test that tuple evaluates correctly applies an lvalue reference

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.assign/move_pair.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.assign/move_pair.pass.cpp
@@ -20,24 +20,6 @@
 #include "MoveOnly.h"
 #include "test_macros.h"
 
-struct B
-{
-  int id_;
-
-  TEST_FUNC explicit B(int i = 0)
-      : id_(i)
-  {}
-
-  TEST_FUNC virtual ~B() {}
-};
-
-struct D : B
-{
-  TEST_FUNC explicit D(int i)
-      : B(i)
-  {}
-};
-
 int main(int, char**)
 {
   {

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_convert_move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_convert_move.pass.cpp
@@ -22,6 +22,7 @@
 #include "allocators.h"
 #include "test_macros.h"
 
+#if !_CCCL_TILE_COMPILATION() // virtual functions are unsupported in tile code
 struct B
 {
   int id_;
@@ -39,6 +40,7 @@ struct D : B
       : B(i)
   {}
 };
+#endif // !_CCCL_TILE_COMPILATION()
 
 struct Explicit
 {
@@ -68,6 +70,7 @@ int main(int, char**)
     assert(cuda::std::get<0>(t1) == 2);
   }
 
+#if !_CCCL_TILE_COMPILATION() // virtual functions are unsupported in tile code
   {
     using T0 = cuda::std::tuple<cuda::std::unique_ptr<D>>;
     using T1 = cuda::std::tuple<cuda::std::unique_ptr<B>>;
@@ -98,6 +101,7 @@ int main(int, char**)
     assert(cuda::std::get<1>(t1) == 2);
     assert(cuda::std::get<2>(t1)->id_ == 3);
   }
+#endif // !_CCCL_TILE_COMPILATION()
   {
     cuda::std::tuple<int> t1(42);
     cuda::std::tuple<Explicit> t2{cuda::std::allocator_arg, cuda::std::allocator<void>{}, cuda::std::move(t1)};

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_move_pair.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_move_pair.pass.cpp
@@ -13,6 +13,9 @@
 // template <class Alloc, class U1, class U2>
 //   tuple(allocator_arg_t, const Alloc& a, pair<U1, U2>&&);
 
+// UNSUPPORTED: enable-tile
+// In tile mode virtual functions are unsupported
+
 #include <cuda/std/__memory_>
 #include <cuda/std/cassert>
 #include <cuda/std/tuple>

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_move.pass.cpp
@@ -35,6 +35,7 @@ struct Implicit
   {}
 };
 
+#if !_CCCL_TILE_COMPILATION() // virtual functions are unsupported in tile code
 struct B
 {
   int id_;
@@ -52,6 +53,7 @@ struct D : B
       : B(i)
   {}
 };
+#endif // !_CCCL_TILE_COMPILATION()
 
 struct BonkersBananas
 {
@@ -86,6 +88,8 @@ int main(int, char**)
     assert(cuda::std::get<0>(t1) == 2);
     assert(cuda::std::get<1>(t1) == int('a'));
   }
+
+#if !_CCCL_TILE_COMPILATION() // virtual functions are unsupported in tile code
   {
     using T0 = cuda::std::tuple<long, char, D>;
     using T1 = cuda::std::tuple<long long, int, B>;
@@ -116,6 +120,7 @@ int main(int, char**)
     assert(cuda::std::get<1>(t1) == int('a'));
     assert(cuda::std::get<2>(t1)->id_ == 3);
   }
+#endif // !_CCCL_TILE_COMPILATION()
 
   {
     cuda::std::tuple<int> t1(42);

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/dtor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/dtor.pass.cpp
@@ -22,10 +22,12 @@
 
 #include "test_macros.h"
 
+#if !_CCCL_TILE_COMPILATION() // virtual function is unsupported in tile code
 struct not_trivially_destructible
 {
   TEST_FUNC virtual ~not_trivially_destructible() {}
 };
+#endif // !_CCCL_TILE_COMPILATION()
 
 int main(int, char**)
 {
@@ -40,7 +42,10 @@ int main(int, char**)
       cuda::std::tuple<int, not_trivially_destructible> >::value, "");
   */
   // non-string check
+
+#if !_CCCL_TILE_COMPILATION() // virtual function is unsupported in tile code
   static_assert(!cuda::std::is_trivially_destructible<cuda::std::tuple<not_trivially_destructible>>::value);
   static_assert(!cuda::std::is_trivially_destructible<cuda::std::tuple<int, not_trivially_destructible>>::value);
+#endif // !_CCCL_TILE_COMPILATION()
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/move_pair.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/move_pair.pass.cpp
@@ -12,6 +12,9 @@
 
 // template <class U1, class U2> tuple(pair<U1, U2>&& u);
 
+// UNSUPPORTED: enable-tile
+// In tile mode virtual functions are unsupported
+
 #include <cuda/std/__memory_>
 #include <cuda/std/cassert>
 #include <cuda/std/tuple>

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/pairs/pairs.pair/assign_rv_pair_U_V.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/pairs/pairs.pair/assign_rv_pair_U_V.pass.cpp
@@ -22,6 +22,7 @@
 #include "archetypes.h"
 #include "test_macros.h"
 
+#if !_CCCL_TILE_COMPILATION() // virtual functions are unsupported in tile code
 struct Base
 {
   TEST_FUNC virtual ~Base() {}
@@ -29,6 +30,7 @@ struct Base
 
 struct Derived : public Base
 {};
+#endif // !_CCCL_TILE_COMPILATION()
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/pairs/pairs.pair/rv_pair_U_V.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/pairs/pairs.pair/rv_pair_U_V.pass.cpp
@@ -39,6 +39,7 @@ TEST_FUNC void test_pair_rv()
   static_assert(test_convertible<P2, UP2>() == CanConvert);
 }
 
+#if !_CCCL_TILE_COMPILATION() // virtual functions are unsupported in tile code
 struct Base
 {
   TEST_FUNC virtual ~Base() {}
@@ -46,6 +47,7 @@ struct Base
 
 struct Derived : public Base
 {};
+#endif // !_CCCL_TILE_COMPILATION()
 
 template <class T, class U>
 struct DPair : public cuda::std::pair<T, U>


### PR DESCRIPTION
Virtual functions are not supported in tile mode, so disable all tests for them
