### PR TITLE
[Tile] Disable use of `__brev` device compiler builtins

### DIFF
--- a/libcudacxx/include/cuda/__bit/bit_reverse.h
+++ b/libcudacxx/include/cuda/__bit/bit_reverse.h
@@ -180,10 +180,12 @@ template <typename _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp bit_reverse(_Tp __value) noexcept
 {
   static_assert(::cuda::std::__cccl_is_cv_unsigned_integer_v<_Tp>, "bit_reverse() requires unsigned integer types");
+#if !_CCCL_TILE_COMPILATION() // nvbug6085411: error: "call to non-tile function not supported!"
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     NV_IF_TARGET(NV_IS_DEVICE, (return ::cuda::__bit_reverse_device(__value);))
   }
+#endif // !_CCCL_TILE_COMPILATION()
 #if defined(_CCCL_BUILTIN_BITREVERSE32)
   return ::cuda::__bit_reverse_builtin(__value);
 #else


### PR DESCRIPTION
Those are not available in tile code

See nvbug6085411
