### PR TITLE
Replace `detail::for_each::dispatch` by CUB's public API

### DIFF
--- a/cub/benchmarks/bench/for_each/base.cu
+++ b/cub/benchmarks/bench/for_each/base.cu
@@ -41,14 +41,10 @@ void for_each(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 
   op_t<T> op{d_out};
 
-  std::size_t temp_size{};
-  cub::DeviceFor::ForEachN(nullptr, temp_size, d_in, elements, op);
-
-  thrust::device_vector<nvbench::uint8_t> temp(temp_size);
-  auto* temp_storage = thrust::raw_pointer_cast(temp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::DeviceFor::ForEachN(temp_storage, temp_size, d_in, elements, op, launch.get_stream());
+    auto env = cub_bench_env(alloc, launch);
+    _CCCL_TRY_CUDA_API(cub::DeviceFor::ForEachN, "ForEachN failed", d_in, elements, op, env);
   });
 }
 

--- a/cub/benchmarks/bench/for_each/copy.cu
+++ b/cub/benchmarks/bench/for_each/copy.cu
@@ -38,14 +38,10 @@ void for_each(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 
   op_t<T> op{d_out};
 
-  std::size_t temp_size{};
-  cub::DeviceFor::ForEachCopyN(nullptr, temp_size, d_in, elements, op);
-
-  thrust::device_vector<nvbench::uint8_t> temp(temp_size);
-  auto* temp_storage = thrust::raw_pointer_cast(temp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::DeviceFor::ForEachCopyN(temp_storage, temp_size, d_in, elements, op, launch.get_stream());
+    auto env = cub_bench_env(alloc, launch);
+    _CCCL_TRY_CUDA_API(cub::DeviceFor::ForEachCopyN, "ForEachCopyN failed", d_in, elements, op, env);
   });
 }
 

--- a/cub/benchmarks/bench/for_each/extents.cu
+++ b/cub/benchmarks/bench/for_each/extents.cu
@@ -52,7 +52,7 @@ void for_each_in_extents(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   op_t<T, OffsetT> op{temp_in, temp_out};
 
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::DeviceFor::ForEachInExtents(ext, op, launch.get_stream());
+    _CCCL_TRY_CUDA_API(cub::DeviceFor::ForEachInExtents, "ForEachInExtents failed", ext, op, launch.get_stream());
   });
 }
 

--- a/cub/cub/device/device_find.cuh
+++ b/cub/cub/device/device_find.cuh
@@ -17,6 +17,7 @@
 #include <cub/detail/choose_offset.cuh>
 #include <cub/detail/env_dispatch.cuh>
 #include <cub/device/device_for.cuh>
+#include <cub/device/device_transform.cuh>
 #include <cub/device/dispatch/dispatch_find.cuh>
 #include <cub/thread/thread_operators.cuh>
 

--- a/cub/cub/device/device_find.cuh
+++ b/cub/cub/device/device_find.cuh
@@ -17,7 +17,6 @@
 #include <cub/detail/choose_offset.cuh>
 #include <cub/detail/env_dispatch.cuh>
 #include <cub/device/device_for.cuh>
-#include <cub/device/device_transform.cuh>
 #include <cub/device/dispatch/dispatch_find.cuh>
 #include <cub/thread/thread_operators.cuh>
 

--- a/cub/cub/device/device_for.cuh
+++ b/cub/cub/device/device_for.cuh
@@ -44,6 +44,8 @@ struct DeviceFor
   template <class OffsetT, class OpT, class RandomAccessIteratorT>
   struct __op_wrapper_t
   {
+    static_assert(::cuda::std::is_integral_v<OffsetT>);
+
     RandomAccessIteratorT input;
     OpT op;
 
@@ -62,6 +64,8 @@ struct DeviceFor
   template <class OffsetT, class OpT, class T>
   struct __op_wrapper_vectorized_t
   {
+    static_assert(::cuda::std::is_integral_v<OffsetT>);
+
     const T* input; // Raw pointer to the input data
     OpT op; // User-provided operator
     OffsetT partially_filled_vector_id; // Index of the vector that doesn't have all elements

--- a/cub/cub/device/device_for.cuh
+++ b/cub/cub/device/device_for.cuh
@@ -21,6 +21,7 @@
 #include <thrust/type_traits/unwrap_contiguous_iterator.h>
 
 #include <cuda/__cmath/ceil_div.h>
+#include <cuda/__execution/tune.h>
 #include <cuda/__functional/call_or.h>
 #include <cuda/__stream/get_stream.h>
 #include <cuda/std/__concepts/concept_macros.h>
@@ -37,102 +38,121 @@
 
 CUB_NAMESPACE_BEGIN
 
-namespace detail::for_each
-{
-/**
- * `op_wrapper_t` turns bulk into a for-each operation by wrapping the user-provided unary operator.
- */
-template <class OffsetT, class OpT, class RandomAccessIteratorT>
-struct op_wrapper_t
-{
-  RandomAccessIteratorT input;
-  OpT op;
-
-  _CCCL_DEVICE _CCCL_FORCEINLINE void operator()(OffsetT i)
-  {
-    // Dereferencing `thrust::device_vector<T>` iterators returns a `thrust::device_reference<T>`
-    // instead of `T`. Since user-provided operator expects `T` as an argument, we need to unwrap.
-    (void) op(THRUST_NS_QUALIFIER::raw_reference_cast(*(input + i)));
-  }
-};
-
-/**
- * `op_wrapper_vectorized_t` turns bulk into a for-each-copy operation.
- * `op_wrapper_vectorized_t` is similar to `op_wrapper_t` but does not provide any guarantees about
- * address of the input parameter. `OpT` might be given a copy of the value or an actual reference
- * to the input iterator value (depending on the alignment of input iterator)
- */
-template <class OffsetT, class OpT, class T>
-struct op_wrapper_vectorized_t
-{
-  const T* input; // Raw pointer to the input data
-  OpT op; // User-provided operator
-  OffsetT partially_filled_vector_id; // Index of the vector that doesn't have all elements
-  OffsetT num_items; // Total number of non-vectorized items
-
-  // TODO Can be extracted into tuning
-  constexpr static int vec_size = 4;
-
-  // Type of the vector that is used to load the input data
-  using vector_t = typename CubVector<T, vec_size>::Type;
-
-  _CCCL_DEVICE _CCCL_FORCEINLINE void operator()(OffsetT i)
-  {
-    // Surrounding `Bulk` call doesn't invoke this operator on invalid indices, so we don't need to
-    // check for out-of-bounds access here.
-    if (i != partially_filled_vector_id)
-    { // Case of fully filled vector
-      const vector_t vec = *reinterpret_cast<const vector_t*>(input + vec_size * i);
-
-      _CCCL_PRAGMA_UNROLL_FULL()
-      for (int j = 0; j < vec_size; j++)
-      {
-        (void) op(*(reinterpret_cast<const T*>(&vec) + j));
-      }
-    }
-    else
-    { // Case of partially filled vector
-      for (OffsetT j = i * vec_size; j < num_items; j++)
-      {
-        (void) op(input[j]);
-      }
-    }
-  }
-};
-} // namespace detail::for_each
-
 struct DeviceFor
 {
 private:
-  template <bool UseVectorization, class RandomAccessOrContiguousIteratorT, class OffsetT, class OpT>
-  CUB_RUNTIME_FUNCTION static cudaError_t
-  for_each_n(RandomAccessOrContiguousIteratorT first, OffsetT num_items, OpT op, cudaStream_t stream)
+  //! `op_wrapper_t` turns bulk into a for-each operation by wrapping the user-provided unary operator.
+  template <class OffsetT, class OpT, class RandomAccessIteratorT>
+  struct op_wrapper_t
   {
-    if constexpr (UseVectorization)
+    RandomAccessIteratorT input;
+    OpT op;
+
+    _CCCL_DEVICE _CCCL_FORCEINLINE void operator()(OffsetT i)
+    {
+      // Dereferencing `thrust::device_vector<T>` iterators returns a `thrust::device_reference<T>`
+      // instead of `T`. Since user-provided operator expects `T` as an argument, we need to unwrap.
+      (void) op(THRUST_NS_QUALIFIER::raw_reference_cast(*(input + i)));
+    }
+  };
+
+  //!  `op_wrapper_vectorized_t` turns bulk into a for-each-copy operation.
+  //!  `op_wrapper_vectorized_t` is similar to `op_wrapper_t` but does not provide any guarantees about
+  //!  address of the input parameter. `OpT` might be given a copy of the value or an actual reference
+  //!  to the input iterator value (depending on the alignment of input iterator)
+  template <class OffsetT, class OpT, class T>
+  struct op_wrapper_vectorized_t
+  {
+    const T* input; // Raw pointer to the input data
+    OpT op; // User-provided operator
+    OffsetT partially_filled_vector_id; // Index of the vector that doesn't have all elements
+    OffsetT num_items; // Total number of non-vectorized items
+
+    // TODO Can be extracted into tuning
+    constexpr static int vec_size = 4;
+
+    // Type of the vector that is used to load the input data
+    using vector_t = typename CubVector<T, vec_size>::Type;
+
+    _CCCL_DEVICE _CCCL_FORCEINLINE void operator()(OffsetT i)
+    {
+      // Surrounding `Bulk` call doesn't invoke this operator on invalid indices, so we don't need to
+      // check for out-of-bounds access here.
+      if (i != partially_filled_vector_id)
+      { // Case of fully filled vector
+        const vector_t vec = *reinterpret_cast<const vector_t*>(input + vec_size * i);
+
+        _CCCL_PRAGMA_UNROLL_FULL()
+        for (int j = 0; j < vec_size; j++)
+        {
+          (void) op(*(reinterpret_cast<const T*>(&vec) + j));
+        }
+      }
+      else
+      { // Case of partially filled vector
+        for (OffsetT j = i * vec_size; j < num_items; j++)
+        {
+          (void) op(input[j]);
+        }
+      }
+    }
+  };
+
+  template <class OffsetT, class OpT, class EnvT>
+  CUB_RUNTIME_FUNCTION static cudaError_t __bulk(OffsetT num_items, OpT op, EnvT env = {})
+  {
+    auto stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, env);
+    [[maybe_unused]] const auto tuning_env =
+      ::cuda::__call_or(::cuda::execution::__get_tuning, ::cuda::std::execution::env<>{}, env);
+    using default_policy_selector = detail::for_each::policy_selector;
+    using policy_selector         = ::cuda::std::execution::
+      __query_result_or_t<decltype(tuning_env), detail::for_each::for_policy, default_policy_selector>;
+    return detail::for_each::dispatch(num_items, op, stream.get(), policy_selector{});
+  }
+
+  template <bool AllowCopy = false, class RandomAccessIteratorT, class NumItemsT, class OpT, class EnvT>
+  CUB_RUNTIME_FUNCTION static cudaError_t
+  __for_each_n(RandomAccessIteratorT first, NumItemsT num_items, OpT op, EnvT env)
+  {
+    // We tried to detect if we can still use vectorization from the non-Copy CUB APIs, but it's disabled for now:
+    constexpr bool allow_vectorization =
+      (AllowCopy
+       /*|| detail::for_each::can_regain_copy_freedom<detail::it_value_t<RandomAccessIteratorT>, OpT>::value*/);
+
+    if constexpr (allow_vectorization && THRUST_NS_QUALIFIER::is_contiguous_iterator_v<RandomAccessIteratorT>)
     {
       auto* unwrapped_first = THRUST_NS_QUALIFIER::unwrap_contiguous_iterator(first);
-      using wrapped_op_t =
-        detail::for_each::op_wrapper_vectorized_t<OffsetT, OpT, detail::it_value_t<RandomAccessOrContiguousIteratorT>>;
+      using wrapped_op_t    = op_wrapper_vectorized_t<NumItemsT, OpT, detail::it_value_t<RandomAccessIteratorT>>;
 
       if (::cuda::std::is_sufficiently_aligned<alignof(typename wrapped_op_t::vector_t)>(unwrapped_first))
       { // Vectorize loads
-        const OffsetT num_vec_items = ::cuda::ceil_div(num_items, wrapped_op_t::vec_size);
-
-        return detail::for_each::dispatch<OffsetT, wrapped_op_t>(
+        const NumItemsT num_vec_items = ::cuda::ceil_div(num_items, wrapped_op_t::vec_size);
+        return __bulk(
           num_vec_items,
           wrapped_op_t{
             unwrapped_first, op, num_items % wrapped_op_t::vec_size ? num_vec_items - 1 : num_vec_items, num_items},
-          stream);
+          env);
       }
+    }
 
-      // Fallback to non-vectorized version
-      return for_each_n<false>(first, num_items, op, stream);
-    }
-    else
+    return __bulk(num_items, op_wrapper_t<NumItemsT, OpT, RandomAccessIteratorT>{first, op}, env);
+  }
+
+  template <class RandomAccessIteratorT, class NumItemsT, class OpT>
+  CUB_RUNTIME_FUNCTION static cudaError_t __for_each_n(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    RandomAccessIteratorT first,
+    NumItemsT num_items,
+    OpT op,
+    cudaStream_t stream = {})
+  {
+    if (d_temp_storage == nullptr)
     {
-      using wrapped_op_t = detail::for_each::op_wrapper_t<OffsetT, OpT, RandomAccessOrContiguousIteratorT>;
-      return detail::for_each::dispatch<OffsetT, wrapped_op_t>(num_items, wrapped_op_t{first, op}, stream);
+      temp_storage_bytes = 1;
+      return cudaSuccess;
     }
+    return __for_each_n(first, num_items, op, stream);
   }
 
 public:
@@ -596,8 +616,7 @@ public:
     {
       return cudaSuccess;
     }
-    auto stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, env);
-    return detail::for_each::dispatch</* OffsetT */ ShapeT, OpT>(shape, op, stream.get());
+    return __bulk(shape, op, env);
   }
 
   // we need this so the previous overload is not ambiguous with the next one
@@ -609,42 +628,6 @@ public:
   {
     return Bulk(shape, op, ::cuda::stream_ref{stream});
   }
-
-private:
-  // Internal version without NVTX range
-  template <class RandomAccessIteratorT, class NumItemsT, class OpT>
-  CUB_RUNTIME_FUNCTION static cudaError_t
-  __for_each_n_no_nvtx(RandomAccessIteratorT first, NumItemsT num_items, OpT op, cudaStream_t stream = {})
-  {
-    using offset_t = NumItemsT;
-    // Disable auto-vectorization for now:
-    // constexpr bool use_vectorization =
-    //   detail::for_each::can_regain_copy_freedom<detail::it_value_t<RandomAccessIteratorT>, OpT>::value
-    //   && THRUST_NS_QUALIFIER::is_contiguous_iterator_v<RandomAccessIteratorT>;
-    constexpr bool use_vectorization = false;
-    return for_each_n<use_vectorization, RandomAccessIteratorT, offset_t, OpT>(first, num_items, op, stream);
-  }
-
-public:
-  //! @cond
-  //! Internal helper without NVTX range, for use by other device algorithms to avoid nested NVTX ranges.
-  template <class RandomAccessIteratorT, class NumItemsT, class OpT>
-  CUB_RUNTIME_FUNCTION static cudaError_t __for_each_n_no_nvtx(
-    void* d_temp_storage,
-    size_t& temp_storage_bytes,
-    RandomAccessIteratorT first,
-    NumItemsT num_items,
-    OpT op,
-    cudaStream_t stream = {})
-  {
-    if (d_temp_storage == nullptr)
-    {
-      temp_storage_bytes = 1;
-      return cudaSuccess;
-    }
-    return __for_each_n_no_nvtx(first, num_items, op, stream);
-  }
-  //! @endcond
 
   //! @rst
   //! Overview
@@ -732,8 +715,7 @@ public:
   ForEachN(RandomAccessIteratorT first, NumItemsT num_items, OpT op, EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceFor::ForEachN");
-    auto stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, env);
-    return __for_each_n_no_nvtx(first, num_items, op, stream.get());
+    return __for_each_n(first, num_items, op, env);
   }
 
   // We keep this overload around to support types that are convertible to `cudaStream_t` but not copyable
@@ -826,10 +808,9 @@ public:
   ForEach(RandomAccessIteratorT first, RandomAccessIteratorT last, OpT op, EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceFor::ForEach");
-    auto stream          = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, env);
     using offset_t       = detail::it_difference_t<RandomAccessIteratorT>;
     const auto num_items = static_cast<offset_t>(::cuda::std::distance(first, last));
-    return __for_each_n_no_nvtx(first, num_items, op, stream.get());
+    return __for_each_n(first, num_items, op, env);
   }
 
   // We keep this overload around to support types that are convertible to `cudaStream_t` but not copyable
@@ -840,18 +821,6 @@ public:
     return ForEach(first, last, op, ::cuda::stream_ref{stream});
   }
 
-private:
-  // Internal version without NVTX range
-  template <class RandomAccessIteratorT, class NumItemsT, class OpT>
-  CUB_RUNTIME_FUNCTION static cudaError_t
-  ForEachCopyNNoNVTX(RandomAccessIteratorT first, NumItemsT num_items, OpT op, cudaStream_t stream = {})
-  {
-    using offset_t                   = NumItemsT;
-    constexpr bool use_vectorization = THRUST_NS_QUALIFIER::is_contiguous_iterator_v<RandomAccessIteratorT>;
-    return for_each_n<use_vectorization, RandomAccessIteratorT, offset_t, OpT>(first, num_items, op, stream);
-  }
-
-public:
   //! @rst
   //! Overview
   //! +++++++++++++++++++++++++++++++++++++++++++++
@@ -941,8 +910,7 @@ public:
   ForEachCopyN(RandomAccessIteratorT first, NumItemsT num_items, OpT op, EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceFor::ForEachCopyN");
-    auto stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, env);
-    return ForEachCopyNNoNVTX(first, num_items, op, stream.get());
+    return __for_each_n<true>(first, num_items, op, env);
   }
 
   // We keep this overload around to support types that are convertible to `cudaStream_t` but not copyable
@@ -1038,10 +1006,9 @@ public:
   ForEachCopy(RandomAccessIteratorT first, RandomAccessIteratorT last, OpT op, EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceFor::ForEachCopy");
-    auto stream          = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, env);
     using offset_t       = detail::it_difference_t<RandomAccessIteratorT>;
     const auto num_items = static_cast<offset_t>(::cuda::std::distance(first, last));
-    return ForEachCopyNNoNVTX(first, num_items, op, stream.get());
+    return __for_each_n<true>(first, num_items, op, env);
   }
 
   // We keep this overload around to support types that are convertible to `cudaStream_t` but not copyable
@@ -1347,8 +1314,7 @@ public:
     {
       return cudaSuccess;
     }
-    auto stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, env);
-    return detail::for_each::dispatch<ShapeT>(shape, op_wrapper, stream.get());
+    return __bulk(shape, op_wrapper, env);
   }
 
 #ifndef _CCCL_DOXYGEN_INVOKED

--- a/cub/cub/device/device_for.cuh
+++ b/cub/cub/device/device_for.cuh
@@ -131,10 +131,7 @@ struct DeviceFor
       { // Vectorize loads
         const NumItemsT num_vec_items = ::cuda::ceil_div(num_items, wrapped_op_t::vec_size);
         return __bulk(
-          num_vec_items,
-          wrapped_op_t{
-            unwrapped_first, op, num_items % wrapped_op_t::vec_size ? num_vec_items - 1 : num_vec_items, num_items},
-          env);
+          num_vec_items, wrapped_op_t{unwrapped_first, op, num_items / wrapped_op_t::vec_size, num_items}, env);
       }
     }
 

--- a/cub/cub/device/device_for.cuh
+++ b/cub/cub/device/device_for.cuh
@@ -81,7 +81,14 @@ struct DeviceFor
     {
       // Surrounding `Bulk` call doesn't invoke this operator on invalid indices, so we don't need to
       // check for out-of-bounds access here.
-      if (i != partially_filled_vector_id)
+      if (i == partially_filled_vector_id)
+      { // Case of partially filled vector
+        for (OffsetT j = i * vec_size; j < num_items; j++)
+        {
+          (void) op(input[j]);
+        }
+      }
+      else
       { // Case of fully filled vector
         const vector_t vec = *reinterpret_cast<const vector_t*>(input + vec_size * i);
 
@@ -91,18 +98,11 @@ struct DeviceFor
           (void) op(*(reinterpret_cast<const T*>(&vec) + j));
         }
       }
-      else
-      { // Case of partially filled vector
-        for (OffsetT j = i * vec_size; j < num_items; j++)
-        {
-          (void) op(input[j]);
-        }
-      }
     }
   };
 
   template <class OffsetT, class OpT, class EnvT>
-  CUB_RUNTIME_FUNCTION static cudaError_t __bulk(OffsetT num_items, OpT op, EnvT env = {})
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t __bulk(OffsetT num_items, OpT op, EnvT env = {})
   {
     auto stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, env);
     [[maybe_unused]] const auto tuning_env =
@@ -114,7 +114,7 @@ struct DeviceFor
   }
 
   template <bool AllowCopy = false, class RandomAccessIteratorT, class NumItemsT, class OpT, class EnvT>
-  CUB_RUNTIME_FUNCTION static cudaError_t
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t
   __for_each_n(RandomAccessIteratorT first, NumItemsT num_items, OpT op, EnvT env)
   {
     // We tried to detect if we can still use vectorization from the non-Copy CUB APIs, but it's disabled for now:
@@ -139,7 +139,7 @@ struct DeviceFor
   }
 
   template <class RandomAccessIteratorT, class NumItemsT, class OpT>
-  CUB_RUNTIME_FUNCTION static cudaError_t __for_each_n(
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t __for_each_n(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     RandomAccessIteratorT first,

--- a/cub/cub/device/device_for.cuh
+++ b/cub/cub/device/device_for.cuh
@@ -40,10 +40,9 @@ CUB_NAMESPACE_BEGIN
 
 struct DeviceFor
 {
-private:
-  //! `op_wrapper_t` turns bulk into a for-each operation by wrapping the user-provided unary operator.
+  //! `__op_wrapper_t` turns bulk into a for-each operation by wrapping the user-provided unary operator.
   template <class OffsetT, class OpT, class RandomAccessIteratorT>
-  struct op_wrapper_t
+  struct __op_wrapper_t
   {
     RandomAccessIteratorT input;
     OpT op;
@@ -56,12 +55,12 @@ private:
     }
   };
 
-  //!  `op_wrapper_vectorized_t` turns bulk into a for-each-copy operation.
-  //!  `op_wrapper_vectorized_t` is similar to `op_wrapper_t` but does not provide any guarantees about
+  //!  `__op_wrapper_vectorized_t` turns bulk into a for-each-copy operation.
+  //!  `__op_wrapper_vectorized_t` is similar to `op_wrapper_t` but does not provide any guarantees about
   //!  address of the input parameter. `OpT` might be given a copy of the value or an actual reference
   //!  to the input iterator value (depending on the alignment of input iterator)
   template <class OffsetT, class OpT, class T>
-  struct op_wrapper_vectorized_t
+  struct __op_wrapper_vectorized_t
   {
     const T* input; // Raw pointer to the input data
     OpT op; // User-provided operator
@@ -122,7 +121,7 @@ private:
     if constexpr (allow_vectorization && THRUST_NS_QUALIFIER::is_contiguous_iterator_v<RandomAccessIteratorT>)
     {
       auto* unwrapped_first = THRUST_NS_QUALIFIER::unwrap_contiguous_iterator(first);
-      using wrapped_op_t    = op_wrapper_vectorized_t<NumItemsT, OpT, detail::it_value_t<RandomAccessIteratorT>>;
+      using wrapped_op_t    = __op_wrapper_vectorized_t<NumItemsT, OpT, detail::it_value_t<RandomAccessIteratorT>>;
 
       if (::cuda::std::is_sufficiently_aligned<alignof(typename wrapped_op_t::vector_t)>(unwrapped_first))
       { // Vectorize loads
@@ -135,7 +134,7 @@ private:
       }
     }
 
-    return __bulk(num_items, op_wrapper_t<NumItemsT, OpT, RandomAccessIteratorT>{first, op}, env);
+    return __bulk(num_items, __op_wrapper_t<NumItemsT, OpT, RandomAccessIteratorT>{first, op}, env);
   }
 
   template <class RandomAccessIteratorT, class NumItemsT, class OpT>

--- a/cub/test/catch2_test_device_for_env.cu
+++ b/cub/test/catch2_test_device_for_env.cu
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// Should precede any includes
+struct stream_registry_factory_t;
+#define CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY stream_registry_factory_t
+
 #include "insert_nested_NVTX_range_guard.h"
 
 #include <cub/device/device_for.cuh>
@@ -8,6 +12,17 @@
 #include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/device_vector.h>
 
+#include "catch2_test_env_launch_helper.h"
+
+DECLARE_LAUNCH_WRAPPER(cub::DeviceFor::Bulk, device_for_bulk);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceFor::ForEachN, device_for_each_n);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceFor::ForEach, device_for_each);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceFor::ForEachCopyN, device_for_each_copy_n);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceFor::ForEachCopy, device_for_each_copy);
+
+// %PARAM% TEST_LAUNCH lid 0:1:2
+
+#include <cuda/__execution/tune.h>
 #include <cuda/devices>
 #include <cuda/stream>
 
@@ -44,9 +59,49 @@ struct odd_count_op
   }
 };
 
+template <int BlockThreads>
+struct for_each_tuning
+{
+  _CCCL_API constexpr auto operator()(cuda::arch_id /*arch*/) const -> cub::detail::for_each::for_policy
+  {
+    return {BlockThreads, 2};
+  }
+};
+
+struct block_size_extracting_idx_op
+{
+  unsigned int* block_size;
+
+  __device__ void operator()(int) const
+  {
+    if (threadIdx.x == 0)
+    {
+      atomicMax(block_size, blockDim.x);
+    }
+  }
+};
+
+struct block_size_extracting_ref_op
+{
+  unsigned int* block_size;
+
+  __device__ void operator()(int&) const
+  {
+    if (threadIdx.x == 0)
+    {
+      atomicMax(block_size, blockDim.x);
+    }
+  }
+};
+
+using block_sizes =
+  c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
+
 // -----------------------------------------------------------------------
-// Bulk
+// Existing env tests (only run once)
 // -----------------------------------------------------------------------
+
+#if TEST_LAUNCH == 0
 
 C2H_TEST("DeviceFor::Bulk env uses custom stream", "[for][env]")
 {
@@ -64,10 +119,6 @@ C2H_TEST("DeviceFor::Bulk env uses custom stream", "[for][env]")
   REQUIRE(vec == expected);
 }
 
-// -----------------------------------------------------------------------
-// ForEachN
-// -----------------------------------------------------------------------
-
 C2H_TEST("DeviceFor::ForEachN env uses custom stream", "[for][env]")
 {
   auto vec = c2h::device_vector<int>{1, 2, 3, 4};
@@ -84,10 +135,6 @@ C2H_TEST("DeviceFor::ForEachN env uses custom stream", "[for][env]")
   REQUIRE(vec == expected);
 }
 
-// -----------------------------------------------------------------------
-// ForEach
-// -----------------------------------------------------------------------
-
 C2H_TEST("DeviceFor::ForEach env uses custom stream", "[for][env]")
 {
   auto vec = c2h::device_vector<int>{1, 2, 3, 4};
@@ -103,10 +150,6 @@ C2H_TEST("DeviceFor::ForEach env uses custom stream", "[for][env]")
   c2h::device_vector<int> expected{1, 4, 9, 16};
   REQUIRE(vec == expected);
 }
-
-// -----------------------------------------------------------------------
-// ForEachCopyN
-// -----------------------------------------------------------------------
 
 C2H_TEST("DeviceFor::ForEachCopyN env uses custom stream", "[for][env]")
 {
@@ -125,10 +168,6 @@ C2H_TEST("DeviceFor::ForEachCopyN env uses custom stream", "[for][env]")
   REQUIRE(count == expected_count);
 }
 
-// -----------------------------------------------------------------------
-// ForEachCopy
-// -----------------------------------------------------------------------
-
 C2H_TEST("DeviceFor::ForEachCopy env uses custom stream", "[for][env]")
 {
   auto vec   = c2h::device_vector<int>{1, 2, 3, 4};
@@ -145,3 +184,68 @@ C2H_TEST("DeviceFor::ForEachCopy env uses custom stream", "[for][env]")
   c2h::device_vector<int> expected_count{2};
   REQUIRE(count == expected_count);
 }
+
+#endif // TEST_LAUNCH == 0
+
+#if TEST_LAUNCH != 1
+
+C2H_TEST("DeviceFor::Bulk can be tuned", "[for][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<unsigned int> d_block_size(1);
+  block_size_extracting_idx_op op{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env = cuda::execution::__tune(for_each_tuning<target_block_size>{});
+
+  device_for_bulk(4, op, env);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceFor::ForEachN can be tuned", "[for][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<int> d_data{1, 2, 3, 4};
+  c2h::device_vector<unsigned int> d_block_size(1);
+  block_size_extracting_ref_op op{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env = cuda::execution::__tune(for_each_tuning<target_block_size>{});
+
+  device_for_each_n(d_data.begin(), static_cast<int>(d_data.size()), op, env);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceFor::ForEach can be tuned", "[for][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<int> d_data{1, 2, 3, 4};
+  c2h::device_vector<unsigned int> d_block_size(1);
+  block_size_extracting_ref_op op{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env = cuda::execution::__tune(for_each_tuning<target_block_size>{});
+
+  device_for_each(d_data.begin(), d_data.end(), op, env);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceFor::ForEachCopyN can be tuned", "[for][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<int> d_data{1, 2, 3, 4};
+  c2h::device_vector<unsigned int> d_block_size(1);
+  block_size_extracting_idx_op op{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env = cuda::execution::__tune(for_each_tuning<target_block_size>{});
+
+  device_for_each_copy_n(d_data.begin(), static_cast<int>(d_data.size()), op, env);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceFor::ForEachCopy can be tuned", "[for][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<int> d_data{1, 2, 3, 4};
+  c2h::device_vector<unsigned int> d_block_size(1);
+  block_size_extracting_idx_op op{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env = cuda::execution::__tune(for_each_tuning<target_block_size>{});
+
+  device_for_each_copy(d_data.begin(), d_data.end(), op, env);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+#endif // TEST_LAUNCH != 1

--- a/cub/test/catch2_test_device_for_env.cu
+++ b/cub/test/catch2_test_device_for_env.cu
@@ -1,26 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// Should precede any includes
-struct stream_registry_factory_t;
-#define CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY stream_registry_factory_t
-
 #include "insert_nested_NVTX_range_guard.h"
 
 #include <cub/device/device_for.cuh>
 
 #include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/device_vector.h>
-
-#include "catch2_test_env_launch_helper.h"
-
-DECLARE_LAUNCH_WRAPPER(cub::DeviceFor::Bulk, device_for_bulk);
-DECLARE_LAUNCH_WRAPPER(cub::DeviceFor::ForEachN, device_for_each_n);
-DECLARE_LAUNCH_WRAPPER(cub::DeviceFor::ForEach, device_for_each);
-DECLARE_LAUNCH_WRAPPER(cub::DeviceFor::ForEachCopyN, device_for_each_copy_n);
-DECLARE_LAUNCH_WRAPPER(cub::DeviceFor::ForEachCopy, device_for_each_copy);
-
-// %PARAM% TEST_LAUNCH lid 0:1:2
 
 #include <cuda/__execution/tune.h>
 #include <cuda/devices>
@@ -59,6 +45,112 @@ struct odd_count_op
   }
 };
 
+// -----------------------------------------------------------------------
+// Bulk
+// -----------------------------------------------------------------------
+
+C2H_TEST("DeviceFor::Bulk env uses custom stream", "[for][env]")
+{
+  auto vec = c2h::device_vector<int>{1, 2, 3, 4};
+  square_idx_op op{thrust::raw_pointer_cast(vec.data())};
+
+  cuda::stream stream{cuda::devices[0]};
+  auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
+
+  auto error = cub::DeviceFor::Bulk(4, op, env);
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
+
+  c2h::device_vector<int> expected{1, 4, 9, 16};
+  REQUIRE(vec == expected);
+}
+
+// -----------------------------------------------------------------------
+// ForEachN
+// -----------------------------------------------------------------------
+
+C2H_TEST("DeviceFor::ForEachN env uses custom stream", "[for][env]")
+{
+  auto vec = c2h::device_vector<int>{1, 2, 3, 4};
+  square_ref_op op{};
+
+  cuda::stream stream{cuda::devices[0]};
+  auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
+
+  auto error = cub::DeviceFor::ForEachN(vec.begin(), static_cast<int>(vec.size()), op, env);
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
+
+  c2h::device_vector<int> expected{1, 4, 9, 16};
+  REQUIRE(vec == expected);
+}
+
+// -----------------------------------------------------------------------
+// ForEach
+// -----------------------------------------------------------------------
+
+C2H_TEST("DeviceFor::ForEach env uses custom stream", "[for][env]")
+{
+  auto vec = c2h::device_vector<int>{1, 2, 3, 4};
+  square_ref_op op{};
+
+  cuda::stream stream{cuda::devices[0]};
+  auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
+
+  auto error = cub::DeviceFor::ForEach(vec.begin(), vec.end(), op, env);
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
+
+  c2h::device_vector<int> expected{1, 4, 9, 16};
+  REQUIRE(vec == expected);
+}
+
+// -----------------------------------------------------------------------
+// ForEachCopyN
+// -----------------------------------------------------------------------
+
+C2H_TEST("DeviceFor::ForEachCopyN env uses custom stream", "[for][env]")
+{
+  auto vec   = c2h::device_vector<int>{1, 2, 3, 4};
+  auto count = c2h::device_vector<int>(1);
+  odd_count_op op{thrust::raw_pointer_cast(count.data())};
+
+  cuda::stream stream{cuda::devices[0]};
+  auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
+
+  auto error = cub::DeviceFor::ForEachCopyN(vec.begin(), static_cast<int>(vec.size()), op, env);
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
+
+  c2h::device_vector<int> expected_count{2};
+  REQUIRE(count == expected_count);
+}
+
+// -----------------------------------------------------------------------
+// ForEachCopy
+// -----------------------------------------------------------------------
+
+C2H_TEST("DeviceFor::ForEachCopy env uses custom stream", "[for][env]")
+{
+  auto vec   = c2h::device_vector<int>{1, 2, 3, 4};
+  auto count = c2h::device_vector<int>(1);
+  odd_count_op op{thrust::raw_pointer_cast(count.data())};
+
+  cuda::stream stream{cuda::devices[0]};
+  auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
+
+  auto error = cub::DeviceFor::ForEachCopy(vec.begin(), vec.end(), op, env);
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
+
+  c2h::device_vector<int> expected_count{2};
+  REQUIRE(count == expected_count);
+}
+
+// -----------------------------------------------------------------------
+// Tuning tests
+// -----------------------------------------------------------------------
+
 template <int BlockThreads>
 struct for_each_tuning
 {
@@ -68,7 +160,7 @@ struct for_each_tuning
   }
 };
 
-struct block_size_extracting_idx_op
+struct block_size_extracting_op
 {
   unsigned int* block_size;
 
@@ -97,106 +189,14 @@ struct block_size_extracting_ref_op
 using block_sizes =
   c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
 
-// -----------------------------------------------------------------------
-// Existing env tests (only run once)
-// -----------------------------------------------------------------------
-
-#if TEST_LAUNCH == 0
-
-C2H_TEST("DeviceFor::Bulk env uses custom stream", "[for][env]")
-{
-  auto vec = c2h::device_vector<int>{1, 2, 3, 4};
-  square_idx_op op{thrust::raw_pointer_cast(vec.data())};
-
-  cuda::stream stream{cuda::devices[0]};
-  auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
-
-  auto error = cub::DeviceFor::Bulk(4, op, env);
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
-
-  c2h::device_vector<int> expected{1, 4, 9, 16};
-  REQUIRE(vec == expected);
-}
-
-C2H_TEST("DeviceFor::ForEachN env uses custom stream", "[for][env]")
-{
-  auto vec = c2h::device_vector<int>{1, 2, 3, 4};
-  square_ref_op op{};
-
-  cuda::stream stream{cuda::devices[0]};
-  auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
-
-  auto error = cub::DeviceFor::ForEachN(vec.begin(), static_cast<int>(vec.size()), op, env);
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
-
-  c2h::device_vector<int> expected{1, 4, 9, 16};
-  REQUIRE(vec == expected);
-}
-
-C2H_TEST("DeviceFor::ForEach env uses custom stream", "[for][env]")
-{
-  auto vec = c2h::device_vector<int>{1, 2, 3, 4};
-  square_ref_op op{};
-
-  cuda::stream stream{cuda::devices[0]};
-  auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
-
-  auto error = cub::DeviceFor::ForEach(vec.begin(), vec.end(), op, env);
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
-
-  c2h::device_vector<int> expected{1, 4, 9, 16};
-  REQUIRE(vec == expected);
-}
-
-C2H_TEST("DeviceFor::ForEachCopyN env uses custom stream", "[for][env]")
-{
-  auto vec   = c2h::device_vector<int>{1, 2, 3, 4};
-  auto count = c2h::device_vector<int>(1);
-  odd_count_op op{thrust::raw_pointer_cast(count.data())};
-
-  cuda::stream stream{cuda::devices[0]};
-  auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
-
-  auto error = cub::DeviceFor::ForEachCopyN(vec.begin(), static_cast<int>(vec.size()), op, env);
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
-
-  c2h::device_vector<int> expected_count{2};
-  REQUIRE(count == expected_count);
-}
-
-C2H_TEST("DeviceFor::ForEachCopy env uses custom stream", "[for][env]")
-{
-  auto vec   = c2h::device_vector<int>{1, 2, 3, 4};
-  auto count = c2h::device_vector<int>(1);
-  odd_count_op op{thrust::raw_pointer_cast(count.data())};
-
-  cuda::stream stream{cuda::devices[0]};
-  auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
-
-  auto error = cub::DeviceFor::ForEachCopy(vec.begin(), vec.end(), op, env);
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
-
-  c2h::device_vector<int> expected_count{2};
-  REQUIRE(count == expected_count);
-}
-
-#endif // TEST_LAUNCH == 0
-
-#if TEST_LAUNCH != 1
-
 C2H_TEST("DeviceFor::Bulk can be tuned", "[for][device]", block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_extracting_idx_op op{thrust::raw_pointer_cast(d_block_size.data())};
+  block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::__tune(for_each_tuning<target_block_size>{});
 
-  device_for_bulk(4, op, env);
+  REQUIRE(cudaSuccess == cub::DeviceFor::Bulk(4, op, env));
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
@@ -208,7 +208,7 @@ C2H_TEST("DeviceFor::ForEachN can be tuned", "[for][device]", block_sizes)
   block_size_extracting_ref_op op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::__tune(for_each_tuning<target_block_size>{});
 
-  device_for_each_n(d_data.begin(), static_cast<int>(d_data.size()), op, env);
+  REQUIRE(cudaSuccess == cub::DeviceFor::ForEachN(d_data.begin(), static_cast<int>(d_data.size()), op, env));
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
@@ -220,7 +220,7 @@ C2H_TEST("DeviceFor::ForEach can be tuned", "[for][device]", block_sizes)
   block_size_extracting_ref_op op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::__tune(for_each_tuning<target_block_size>{});
 
-  device_for_each(d_data.begin(), d_data.end(), op, env);
+  REQUIRE(cudaSuccess == cub::DeviceFor::ForEach(d_data.begin(), d_data.end(), op, env));
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
@@ -229,10 +229,10 @@ C2H_TEST("DeviceFor::ForEachCopyN can be tuned", "[for][device]", block_sizes)
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_data{1, 2, 3, 4};
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_extracting_idx_op op{thrust::raw_pointer_cast(d_block_size.data())};
+  block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::__tune(for_each_tuning<target_block_size>{});
 
-  device_for_each_copy_n(d_data.begin(), static_cast<int>(d_data.size()), op, env);
+  REQUIRE(cudaSuccess == cub::DeviceFor::ForEachCopyN(d_data.begin(), static_cast<int>(d_data.size()), op, env));
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
@@ -241,11 +241,9 @@ C2H_TEST("DeviceFor::ForEachCopy can be tuned", "[for][device]", block_sizes)
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_data{1, 2, 3, 4};
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_extracting_idx_op op{thrust::raw_pointer_cast(d_block_size.data())};
+  block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::__tune(for_each_tuning<target_block_size>{});
 
-  device_for_each_copy(d_data.begin(), d_data.end(), op, env);
+  REQUIRE(cudaSuccess == cub::DeviceFor::ForEachCopy(d_data.begin(), d_data.end(), op, env));
   REQUIRE(d_block_size[0] == target_block_size);
 }
-
-#endif // TEST_LAUNCH != 1

--- a/cub/test/catch2_test_device_for_env.cu
+++ b/cub/test/catch2_test_device_for_env.cu
@@ -169,19 +169,6 @@ struct block_size_extracting_op
   }
 };
 
-struct block_size_extracting_ref_op
-{
-  unsigned int* block_size;
-
-  __device__ void operator()(int&) const
-  {
-    if (threadIdx.x == 0)
-    {
-      atomicMax(block_size, blockDim.x);
-    }
-  }
-};
-
 using block_sizes =
   c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
 
@@ -201,7 +188,7 @@ C2H_TEST("DeviceFor::ForEachN can be tuned", "[for][device]", block_sizes)
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_data{1, 2, 3, 4};
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_extracting_ref_op op{thrust::raw_pointer_cast(d_block_size.data())};
+  block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::__tune(for_each_tuning<target_block_size>{});
 
   REQUIRE(cudaSuccess == cub::DeviceFor::ForEachN(d_data.begin(), static_cast<int>(d_data.size()), op, env));
@@ -213,7 +200,7 @@ C2H_TEST("DeviceFor::ForEach can be tuned", "[for][device]", block_sizes)
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_data{1, 2, 3, 4};
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_extracting_ref_op op{thrust::raw_pointer_cast(d_block_size.data())};
+  block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::__tune(for_each_tuning<target_block_size>{});
 
   REQUIRE(cudaSuccess == cub::DeviceFor::ForEach(d_data.begin(), d_data.end(), op, env));

--- a/cub/test/catch2_test_device_for_env.cu
+++ b/cub/test/catch2_test_device_for_env.cu
@@ -147,10 +147,6 @@ C2H_TEST("DeviceFor::ForEachCopy env uses custom stream", "[for][env]")
   REQUIRE(count == expected_count);
 }
 
-// -----------------------------------------------------------------------
-// Tuning tests
-// -----------------------------------------------------------------------
-
 template <int BlockThreads>
 struct for_each_tuning
 {


### PR DESCRIPTION
- [x] No SASS changes in `cub.bench.for_each.base.base` for SM120
- [x] No SASS changes in `cub.bench.for_each.copy.base` for SM120
- [x] No SASS changes in `cub.bench.for_each.extents.base` for SM120

Fixes: #7953