### PR TITLE
[cudax] Make `barrier_synchronizer` work with any level

### DIFF
--- a/cudax/include/cuda/experimental/__group/synchronizer/barrier_synchronizer.cuh
+++ b/cudax/include/cuda/experimental/__group/synchronizer/barrier_synchronizer.cuh
@@ -47,9 +47,37 @@ inline constexpr bool
 template <class _Span>
 using _SpanElementType = typename _Span::element_type;
 
+template <class _Level>
+[[nodiscard]] _CCCL_DEVICE_API _CCCL_CONSTEVAL thread_scope __minimum_required_scope_for() noexcept
+{
+  if constexpr (::cuda::std::is_same_v<_Level, thread_level>)
+  {
+    return thread_scope_thread;
+  }
+  else if constexpr (::cuda::std::is_same_v<_Level, warp_level> || ::cuda::std::is_same_v<_Level, block_level>)
+  {
+    return thread_scope_block;
+  }
+  else if constexpr (::cuda::std::is_same_v<_Level, cluster_level> || ::cuda::std::is_same_v<_Level, grid_level>)
+  {
+    return thread_scope_device;
+  }
+  else
+  {
+    return thread_scope_system;
+  }
+}
+
+template <class _Tp>
+inline constexpr thread_scope __barrier_scope_v = thread_scope_system;
+template <thread_scope _Sco, class _ComplFn>
+inline constexpr thread_scope __barrier_scope_v<barrier<_Sco, _ComplFn>> = _Sco;
+
 template <class _Barrier, ::cuda::std::size_t _Np>
 class barrier_synchronizer
 {
+  static_assert(__is_cuda_barrier_v<_Barrier>, "_Barrier must be cv-unqualified cuda::barrier type");
+
   ::cuda::std::span<_Barrier, _Np> __barriers_;
 
 public:
@@ -88,8 +116,11 @@ public:
     const _Mapping& __mapping,
     const _MappingResult& __mapping_result) const noexcept
   {
-    static_assert(::cuda::std::is_same_v<typename _ParentGroup::level_type, block_level>,
-                  "only block_level is currently supported");
+    using _Level = typename _ParentGroup::level_type;
+
+    // todo(dabayer): Relax this condition if all units in the group are within a level that is smaller than _Level.
+    static_assert(__barrier_scope_v<_Barrier> <= ::cuda::experimental::__minimum_required_scope_for<_Level>(),
+                  "_Barrier's thread scope is insufficient for group synchronization in _Level");
 
     if constexpr (_MappingResult::static_group_count() != ::cuda::std::dynamic_extent
                   && _Np != ::cuda::std::dynamic_extent)
@@ -101,17 +132,7 @@ public:
       _CCCL_ASSERT(__mapping_result.group_count() <= __barriers_.size(), "invalid number of barriers passed");
     }
 
-    // todo(dabayer): Enable this and fix initialization for threads with optional participation.
-    static_assert(_MappingResult::is_always_exhaustive());
-    // if constexpr (!_MappingResult::is_always_exhaustive())
-    // {
-    //   if (!__mapping_result.is_valid())
-    //   {
-    //     return;
-    //   }
-    // }
-
-    if (__mapping_result.rank() == 0)
+    if (__mapping_result.is_valid() && __mapping_result.rank() == 0)
     {
       init(&__barriers_[__mapping_result.group_rank()], static_cast<::cuda::std::ptrdiff_t>(__mapping_result.count()));
     }

--- a/cudax/test/common/group_testing.cuh
+++ b/cudax/test/common/group_testing.cuh
@@ -21,7 +21,7 @@
 
 namespace
 {
-template <class T>
+template <class T, cuda::std::size_t Id>
 __device__ T global_barriers_storage;
 
 //! @brief Returns reference to an array of N cuda::barrier objects with suitable thread scope for level allocated in
@@ -41,7 +41,7 @@ __device__ auto& get_barriers(const Level& level) noexcept
   }
   else
   {
-    return reinterpret_cast<Barrier(&)[N]>(global_barriers_storage<BarriersStorage>);
+    return reinterpret_cast<Barrier(&)[N]>(global_barriers_storage<BarriersStorage, Id>);
   }
 }
 } // namespace

--- a/cudax/test/common/group_testing.cuh
+++ b/cudax/test/common/group_testing.cuh
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef COMMON_GROUP_CUH
+#define COMMON_GROUP_CUH
+
+#include <cuda/barrier>
+#include <cuda/std/cstddef>
+#include <cuda/std/type_traits>
+
+#include <cuda/experimental/group.cuh>
+
+#include "testing.cuh"
+
+namespace
+{
+template <class T>
+__device__ T global_barriers_storage;
+
+//! @brief Returns reference to an array of N cuda::barrier objects with suitable thread scope for level allocated in
+//!        suitable address space (shared or device memory). Id parameter can be used to create unique object.
+template <cuda::std::size_t N, cuda::std::size_t Id = 0, class Level>
+__device__ auto& get_barriers(const Level& level) noexcept
+{
+  constexpr auto scope = cudax::__minimum_required_scope_for<Level>();
+
+  using Barrier         = cuda::barrier<scope>;
+  using BarriersStorage = cuda::std::aligned_storage_t<N * sizeof(Barrier), alignof(Barrier)>;
+
+  if constexpr (scope >= cuda::thread_scope_block)
+  {
+    __shared__ BarriersStorage shared_barriers_storage;
+    return reinterpret_cast<Barrier(&)[N]>(shared_barriers_storage);
+  }
+  else
+  {
+    return reinterpret_cast<Barrier(&)[N]>(global_barriers_storage<BarriersStorage>);
+  }
+}
+} // namespace
+
+#endif // COMMON_GROUP_CUH

--- a/cudax/test/group/cooperative_algorithm.cu
+++ b/cudax/test/group/cooperative_algorithm.cu
@@ -25,7 +25,7 @@
 
 #include <cooperative_groups.h>
 
-#include "testing.cuh"
+#include "group_testing.cuh"
 
 namespace
 {

--- a/cudax/test/group/group.cu
+++ b/cudax/test/group/group.cu
@@ -18,7 +18,7 @@
 
 #include <cuda/experimental/group.cuh>
 
-#include "testing.cuh"
+#include "group_testing.cuh"
 
 namespace
 {
@@ -96,25 +96,17 @@ template <class T>
 __device__ T global_barrier_storage;
 
 template <cuda::std::size_t N, class Unit, class Level, class Config>
-__device__ void test_group_by_group(const Unit& unit, const Level& level, const Config& config)
+__device__ void test_group_by_group(Unit unit, Level level, Config config)
 {
-  constexpr cuda::std::size_t nbarriers = 128 / N;
-  constexpr auto use_global_barrier =
-    (cuda::std::is_same_v<Level, cuda::cluster_level> || cuda::std::is_same_v<Level, cuda::grid_level>);
-  constexpr auto barrier_scope = (use_global_barrier) ? cuda::thread_scope_device : cuda::thread_scope_block;
-
-  using Barrier         = cuda::barrier<barrier_scope>;
-  using BarriersStorage = cuda::std::aligned_storage_t<nbarriers * sizeof(Barrier), alignof(Barrier)>;
-  __shared__ BarriersStorage shared_barriers_storage;
-
-  auto& barriers = reinterpret_cast<Barrier(&)[nbarriers]>(
-    (use_global_barrier) ? global_barrier_storage<BarriersStorage> : shared_barriers_storage);
+  constexpr cuda::std::size_t nbarriers = unit.static_count(level, config) / N;
 
   auto parent_group = cudax::make_this_group(level, config);
-  cudax::barrier_synchronizer synchronizer{barriers};
 
   {
+    auto& barriers = get_barriers<nbarriers, 0>(level);
+
     cudax::group_by<N> mapping{};
+    cudax::barrier_synchronizer synchronizer{barriers};
     cudax::group group{unit, parent_group, mapping, synchronizer};
 
     static_assert(
@@ -124,7 +116,10 @@ __device__ void test_group_by_group(const Unit& unit, const Level& level, const 
     group.sync();
   }
   {
+    auto& barriers = get_barriers<nbarriers, 1>(level);
+
     cudax::group_by mapping{N};
+    cudax::barrier_synchronizer synchronizer{barriers};
     cudax::group group{unit, parent_group, mapping, synchronizer};
 
     static_assert(
@@ -156,10 +151,11 @@ struct TestKernel
   template <class Config>
   __device__ void operator()(const Config& config)
   {
+    // todo(dabayer): Investigate why enabling warp leads to launch failure and cluster deadlocks.
     // test_group_by_group(cuda::gpu_thread, cuda::warp, config);
     test_group_by_group(cuda::gpu_thread, cuda::block, config);
-    // test_group_by_group(cuda::gpu_thread, cuda::warp, config);
-    // test_group_by_group(cuda::gpu_thread, cuda::warp, config);
+    // test_group_by_group(cuda::gpu_thread, cuda::cluster, config);
+    test_group_by_group(cuda::gpu_thread, cuda::grid, config);
   }
 };
 } // namespace

--- a/cudax/test/group/make_this_group.cu
+++ b/cudax/test/group/make_this_group.cu
@@ -16,7 +16,7 @@
 
 #include <cuda/experimental/group.cuh>
 
-#include "testing.cuh"
+#include "group_testing.cuh"
 
 namespace
 {

--- a/cudax/test/group/mapping/group_by.cu
+++ b/cudax/test/group/mapping/group_by.cu
@@ -18,7 +18,7 @@
 
 #include <cuda/experimental/group.cuh>
 
-#include "testing.cuh"
+#include "group_testing.cuh"
 
 namespace
 {

--- a/cudax/test/group/synchronizer/barrier_synchronizer.cu
+++ b/cudax/test/group/synchronizer/barrier_synchronizer.cu
@@ -18,7 +18,7 @@
 
 #include <cuda/experimental/group.cuh>
 
-#include "testing.cuh"
+#include "group_testing.cuh"
 
 namespace
 {
@@ -27,13 +27,11 @@ __device__ void test_barrier_synchronizer(const Level& level, Config config)
 {
   constexpr cuda::std::size_t nbarriers = 8;
 
-  using Barrier         = cuda::barrier<cuda::thread_scope_block>;
-  using BarriersStorage = cuda::std::aligned_storage_t<8 * sizeof(Barrier), alignof(Barrier)>;
-  __shared__ BarriersStorage barriers_storage;
-  auto& barriers = reinterpret_cast<Barrier(&)[nbarriers]>(barriers_storage);
-
   // Test constructor from static span of barriers.
   {
+    auto& barriers = get_barriers<nbarriers, 0>(level);
+    using Barrier  = cuda::std::remove_all_extents_t<cuda::std::remove_reference_t<decltype(barriers)>>;
+
     cuda::std::span<Barrier, nbarriers> barriers_span{barriers, nbarriers};
     cudax::barrier_synchronizer synchronizer{barriers_span};
 
@@ -46,6 +44,9 @@ __device__ void test_barrier_synchronizer(const Level& level, Config config)
 
   // Test constructor from dynamic span of barriers.
   {
+    auto& barriers = get_barriers<nbarriers, 1>(level);
+    using Barrier  = cuda::std::remove_all_extents_t<cuda::std::remove_reference_t<decltype(barriers)>>;
+
     cuda::std::span<Barrier> barriers_span{barriers, nbarriers};
     cudax::barrier_synchronizer synchronizer{barriers_span};
 
@@ -59,6 +60,9 @@ __device__ void test_barrier_synchronizer(const Level& level, Config config)
 
   // Test constructor from array of barriers.
   {
+    auto& barriers = get_barriers<nbarriers, 2>(level);
+    using Barrier  = cuda::std::remove_all_extents_t<cuda::std::remove_reference_t<decltype(barriers)>>;
+
     cudax::barrier_synchronizer synchronizer{barriers};
 
     static_assert(cuda::std::is_same_v<cudax::barrier_synchronizer<Barrier, nbarriers>, decltype(synchronizer)>);
@@ -70,6 +74,9 @@ __device__ void test_barrier_synchronizer(const Level& level, Config config)
 
   // Test barriers().
   {
+    auto& barriers = get_barriers<nbarriers, 3>(level);
+    using Barrier  = cuda::std::remove_all_extents_t<cuda::std::remove_reference_t<decltype(barriers)>>;
+
     const cudax::barrier_synchronizer synchronizer{barriers};
 
     static_assert(cuda::std::is_same_v<cuda::std::span<Barrier, nbarriers>, decltype(synchronizer.barriers())>);
@@ -81,6 +88,9 @@ __device__ void test_barrier_synchronizer(const Level& level, Config config)
 
   // Test make_instance(...).
   {
+    auto& barriers = get_barriers<nbarriers, 4>(level);
+    using Barrier  = cuda::std::remove_all_extents_t<cuda::std::remove_reference_t<decltype(barriers)>>;
+
     const auto parent_group = cudax::make_this_group(level, config);
 
     const cudax::group_by mapping{4};
@@ -108,8 +118,10 @@ struct TestKernel
   template <class Config>
   __device__ void operator()(const Config& config)
   {
-    // todo(dabayer): Test other levels once supported.
+    test_barrier_synchronizer(cuda::warp, config);
     test_barrier_synchronizer(cuda::block, config);
+    test_barrier_synchronizer(cuda::cluster, config);
+    test_barrier_synchronizer(cuda::grid, config);
   }
 };
 } // namespace
@@ -121,11 +133,12 @@ C2H_TEST("Barrier synchronizer", "[group]")
   const cuda::stream stream{device};
 
   {
-    const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims<8, 4>());
+    const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims<8, 4>(), cuda::cooperative_launch{});
     cuda::launch(stream, config, TestKernel{});
   }
   {
-    const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims(dim3{8, 4}));
+    const auto config =
+      cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims(dim3{8, 4}), cuda::cooperative_launch{});
     cuda::launch(stream, config, TestKernel{});
   }
 

--- a/cudax/test/group/synchronizer/lane_synchronizer.cu
+++ b/cudax/test/group/synchronizer/lane_synchronizer.cu
@@ -17,7 +17,7 @@
 
 #include <cuda/experimental/group.cuh>
 
-#include "testing.cuh"
+#include "group_testing.cuh"
 
 namespace
 {

--- a/cudax/test/group/this_group.cu
+++ b/cudax/test/group/this_group.cu
@@ -20,7 +20,7 @@
 
 #include <cooperative_groups.h>
 
-#include "testing.cuh"
+#include "group_testing.cuh"
 
 namespace
 {

--- a/libcudacxx/include/cuda/__fwd/barrier.h
+++ b/libcudacxx/include/cuda/__fwd/barrier.h
@@ -31,6 +31,11 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 template <thread_scope _Sco, class _CompletionF = ::cuda::std::__empty_completion>
 class barrier;
 
+template <class _Tp>
+inline constexpr bool __is_cuda_barrier_v = false;
+template <thread_scope _Sco, class _ComplFn>
+inline constexpr bool __is_cuda_barrier_v<barrier<_Sco, _ComplFn>> = true;
+
 _CCCL_END_NAMESPACE_CUDA
 
 #include <cuda/std/__cccl/epilogue.h>


### PR DESCRIPTION
This PR extends `cudax::barrier_synchronizer` to support any level. I think we should consider adding `static constexpr thread_scope scope = _Sco` member to `cuda::barrier`.