### PR TITLE
Add `DeviceAdjacentDifference::Subtract[Left|Right]` overloads with two iterators

### DIFF
--- a/cub/benchmarks/bench/adjacent_difference/subtract_left.cu
+++ b/cub/benchmarks/bench/adjacent_difference/subtract_left.cu
@@ -33,7 +33,7 @@ void left(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 
   const auto elements         = static_cast<std::size_t>(state.get_int64("Elements{io}"));
   thrust::device_vector<T> in = generate(elements);
-  thrust::device_vector<T> out(elements);
+  thrust::device_vector<T> out(elements, thrust::no_init);
 
   input_it_t d_in   = thrust::raw_pointer_cast(in.data());
   output_it_t d_out = thrust::raw_pointer_cast(out.data());
@@ -42,41 +42,24 @@ void left(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  std::size_t temp_storage_bytes{};
-
-  cub::detail::adjacent_difference::
-    dispatch<cub::MayAlias::No, cub::ReadOption::Left, input_it_t, output_it_t, offset_t, difference_op_t>(
-      nullptr,
-      temp_storage_bytes,
+  caching_allocator_t alloc;
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
+    auto env = cub_bench_env(
+      alloc,
+      launch
+#if !TUNE_BASE
+      ,
+      cuda::execution::__tune(policy_selector_t{})
+#endif // !TUNE_BASE
+    );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceAdjacentDifference::SubtractLeftCopy,
+      "SubtractLeftCopy failed",
       d_in,
       d_out,
       static_cast<offset_t>(elements),
       difference_op_t{},
-      nullptr
-#if !TUNE_BASE
-      ,
-      policy_selector_t{}
-#endif // TUNE_BASE
-    );
-
-  thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes, thrust::no_init);
-  std::uint8_t* d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
-
-  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::adjacent_difference::
-      dispatch<cub::MayAlias::No, cub::ReadOption::Left, input_it_t, output_it_t, offset_t, difference_op_t>(
-        d_temp_storage,
-        temp_storage_bytes,
-        d_in,
-        d_out,
-        static_cast<offset_t>(elements),
-        difference_op_t{},
-        launch.get_stream()
-#if !TUNE_BASE
-          ,
-        policy_selector_t{}
-#endif // TUNE_BASE
-      );
+      env);
   });
 }
 

--- a/cub/cub/device/device_adjacent_difference.cuh
+++ b/cub/cub/device/device_adjacent_difference.cuh
@@ -635,12 +635,20 @@ struct DeviceAdjacentDifference
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceAdjacentDifference::SubtractLeftCopy");
 
-    using OffsetT = detail::choose_offset_t<NumItemsT>;
+    using OffsetT                 = detail::choose_offset_t<NumItemsT>;
+    using default_policy_selector = detail::adjacent_difference::policy_selector_from_types<InputIteratorT, false>;
 
-    return detail::dispatch_with_env(
-      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, auto stream) {
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return detail::adjacent_difference::dispatch<MayAlias::No, ReadOption::Left>(
-          d_temp_storage, temp_storage_bytes, d_input, d_output, static_cast<OffsetT>(num_items), difference_op, stream);
+          d_temp_storage,
+          temp_storage_bytes,
+          d_input,
+          d_output,
+          static_cast<OffsetT>(num_items),
+          difference_op,
+          stream,
+          policy_selector);
       });
   }
 
@@ -713,11 +721,20 @@ struct DeviceAdjacentDifference
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceAdjacentDifference::SubtractLeft");
 
     using OffsetT = detail::choose_offset_t<NumItemsT>;
+    using default_policy_selector =
+      detail::adjacent_difference::policy_selector_from_types<RandomAccessIteratorT, true>;
 
-    return detail::dispatch_with_env(
-      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, auto stream) {
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return detail::adjacent_difference::dispatch<MayAlias::Yes, ReadOption::Left>(
-          d_temp_storage, temp_storage_bytes, d_input, d_input, static_cast<OffsetT>(num_items), difference_op, stream);
+          d_temp_storage,
+          temp_storage_bytes,
+          d_input,
+          d_input,
+          static_cast<OffsetT>(num_items),
+          difference_op,
+          stream,
+          policy_selector);
       });
   }
 
@@ -800,12 +817,20 @@ struct DeviceAdjacentDifference
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceAdjacentDifference::SubtractRightCopy");
 
-    using OffsetT = detail::choose_offset_t<NumItemsT>;
+    using OffsetT                 = detail::choose_offset_t<NumItemsT>;
+    using default_policy_selector = detail::adjacent_difference::policy_selector_from_types<InputIteratorT, false>;
 
-    return detail::dispatch_with_env(
-      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, auto stream) {
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return detail::adjacent_difference::dispatch<MayAlias::No, ReadOption::Right>(
-          d_temp_storage, temp_storage_bytes, d_input, d_output, static_cast<OffsetT>(num_items), difference_op, stream);
+          d_temp_storage,
+          temp_storage_bytes,
+          d_input,
+          d_output,
+          static_cast<OffsetT>(num_items),
+          difference_op,
+          stream,
+          policy_selector);
       });
   }
 
@@ -878,11 +903,20 @@ struct DeviceAdjacentDifference
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceAdjacentDifference::SubtractRight");
 
     using OffsetT = detail::choose_offset_t<NumItemsT>;
+    using default_policy_selector =
+      detail::adjacent_difference::policy_selector_from_types<RandomAccessIteratorT, true>;
 
-    return detail::dispatch_with_env(
-      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, auto stream) {
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return detail::adjacent_difference::dispatch<MayAlias::Yes, ReadOption::Right>(
-          d_temp_storage, temp_storage_bytes, d_input, d_input, static_cast<OffsetT>(num_items), difference_op, stream);
+          d_temp_storage,
+          temp_storage_bytes,
+          d_input,
+          d_input,
+          static_cast<OffsetT>(num_items),
+          difference_op,
+          stream,
+          policy_selector);
       });
   }
 };

--- a/cub/cub/device/device_adjacent_difference.cuh
+++ b/cub/cub/device/device_adjacent_difference.cuh
@@ -220,6 +220,71 @@ struct DeviceAdjacentDifference
   //! @rst
   //! Subtracts the left element of each adjacent pair of elements residing within device-accessible memory.
   //!
+  //! Overview
+  //! ++++++++++++++++++++++++++
+  //!
+  //! - Calculates the differences of adjacent elements in ``d_input``.
+  //!   That is, ``*d_input`` is assigned to ``*d_output``, and, for each iterator ``i`` in the
+  //!   range ``[d_input + 1, d_input + num_items)``, the result of
+  //!   ``difference_op(*i, *(i - 1))`` is assigned to ``*(d_output + (i - d_input))``.
+  //! - The input and output ranges are allowed to overlap.
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input elements @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Random-access output iterator type for writing output elements @iterator
+  //!
+  //! @tparam DifferenceOpT
+  //!   Its `result_type` is convertible to a type in `OutputIteratorT`'s set of `value_types`.
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
+  //! @param[in] d_temp_storage
+  //!   Device-accessible allocation of temporary storage. When `nullptr`, the
+  //!   required allocation size is written to `temp_storage_bytes` and no work is done.
+  //!
+  //! @param[in,out] temp_storage_bytes
+  //!   Reference to size in bytes of `d_temp_storage` allocation
+  //!
+  //! @param[in] d_input
+  //!   Beginning of the input sequence
+  //!
+  //! @param[out] d_output
+  //!   Beginning of the output sequence
+  //!
+  //! @param[in] num_items
+  //!   Number of items in the input sequence
+  //!
+  //! @param[in] difference_op
+  //!   The binary function used to compute differences
+  //!
+  //! @param[in] stream
+  //!   @rst
+  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`
+  //!   @endrst
+  template <typename InputIteratorT, typename OutputIteratorT, typename DifferenceOpT, typename NumItemsT>
+  static CUB_RUNTIME_FUNCTION cudaError_t SubtractLeft(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    InputIteratorT d_input,
+    OutputIteratorT d_output,
+    NumItemsT num_items,
+    DifferenceOpT difference_op,
+    cudaStream_t stream = nullptr)
+  {
+    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceAdjacentDifference::SubtractLeft");
+    using OffsetT = detail::choose_offset_t<NumItemsT>;
+    return detail::adjacent_difference::dispatch<MayAlias::Yes, ReadOption::Left>(
+      d_temp_storage, temp_storage_bytes, d_input, d_output, static_cast<OffsetT>(num_items), difference_op, stream);
+  }
+
+  //! @rst
+  //! Subtracts the left element of each adjacent pair of elements residing within device-accessible memory.
+  //!
   //! .. versionadded:: 2.2.0
   //!    First appears in CUDA Toolkit 12.3.
   //!
@@ -461,6 +526,73 @@ struct DeviceAdjacentDifference
   //! @rst
   //! Subtracts the right element of each adjacent pair of elements residing within device-accessible memory.
   //!
+  //! Overview
+  //! ++++++++++++++++++++++++++
+  //!
+  //! - Calculates the right differences of adjacent elements in ``d_input``.
+  //!   That is, ``*(d_input + num_items - 1)`` is assigned to
+  //!   ``*(d_output + num_items - 1)``, and, for each iterator ``i`` in the range
+  //!   ``[d_input, d_input + num_items - 1)``, the result of
+  //!   ``difference_op(*i, *(i + 1))`` is assigned to
+  //!   ``*(d_output + (i - d_input))``.
+  //! - The input and output ranges are allowed to overlap.
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input elements @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Random-access output iterator type for writing output elements @iterator
+  //!
+  //! @tparam DifferenceOpT
+  //!   Its `result_type` is convertible to a type in `OutputIteratorT`'s set of `value_types`.
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
+  //! @param[in] d_temp_storage
+  //!   Device-accessible allocation of temporary storage. When `nullptr`, the
+  //!   required allocation size is written to `temp_storage_bytes` and no work is done.
+  //!
+  //! @param[in,out] temp_storage_bytes
+  //!   Reference to size in bytes of `d_temp_storage` allocation
+  //!
+  //! @param[in] d_input
+  //!   Beginning of the input sequence
+  //!
+  //! @param[out] d_output
+  //!   Beginning of the output sequence
+  //!
+  //! @param[in] num_items
+  //!   Number of items in the input sequence
+  //!
+  //! @param[in] difference_op
+  //!   The binary function used to compute differences
+  //!
+  //! @param[in] stream
+  //!   @rst
+  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   @endrst
+  template <typename InputIteratorT, typename OutputIteratorT, typename DifferenceOpT, typename NumItemsT>
+  static CUB_RUNTIME_FUNCTION cudaError_t SubtractRight(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    InputIteratorT d_input,
+    OutputIteratorT d_output,
+    NumItemsT num_items,
+    DifferenceOpT difference_op,
+    cudaStream_t stream = nullptr)
+  {
+    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceAdjacentDifference::SubtractRight");
+    using OffsetT = detail::choose_offset_t<NumItemsT>;
+    return detail::adjacent_difference::dispatch<MayAlias::Yes, ReadOption::Right>(
+      d_temp_storage, temp_storage_bytes, d_input, d_output, static_cast<OffsetT>(num_items), difference_op, stream);
+  }
+
+  //! @rst
+  //! Subtracts the right element of each adjacent pair of elements residing within device-accessible memory.
+  //!
   //! .. versionadded:: 2.2.0
   //!    First appears in CUDA Toolkit 12.3.
   //!
@@ -653,6 +785,98 @@ struct DeviceAdjacentDifference
   }
 
   //! @rst
+  //! Subtracts the left element of each adjacent pair of elements residing within device-accessible memory.
+  //!
+  //! This is an environment-based API that allows customization of:
+  //!
+  //! - Stream: Query via ``cuda::get_stream``
+  //!
+  //! Overview
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! - Calculates the differences of adjacent elements in ``d_input``.
+  //!   That is, ``*d_input`` is assigned to ``*d_output``, and, for each iterator ``i`` in the
+  //!   range ``[d_input + 1, d_input + num_items)``, the result of
+  //!   ``difference_op(*i, *(i - 1))`` is assigned to ``*(d_output + (i - d_input))``.
+  //! - The input and output ranges are allowed to overlap.
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates how to use ``SubtractLeft`` with potentially aliasing
+  //! input and output ranges and a custom stream via an environment.
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_adjacent_difference_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin subtract-left-two-iter-env-stream
+  //!     :end-before: example-end subtract-left-two-iter-env-stream
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input elements @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Random-access output iterator type for writing output elements @iterator
+  //!
+  //! @tparam DifferenceOpT
+  //!   **[inferred]** Binary function object type used to compute differences
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Execution environment type. Default is ``cuda::std::execution::env<>``.
+  //!   Supports customization of stream via ``cuda::get_stream``.
+  //!
+  //! @param[in] d_input
+  //!   Beginning of the input sequence
+  //!
+  //! @param[out] d_output
+  //!   Beginning of the output sequence
+  //!
+  //! @param[in] num_items
+  //!   Number of items in the input sequence
+  //!
+  //! @param[in] difference_op
+  //!   The binary function used to compute differences
+  //!
+  //! @param[in] env
+  //!   @rst
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  //!   @endrst
+  template <
+    typename InputIteratorT,
+    typename OutputIteratorT,
+    typename DifferenceOpT,
+    typename NumItemsT,
+    typename EnvT                 = ::cuda::std::execution::env<>,
+    ::cuda::std::enable_if_t<!::cuda::std::is_same_v<InputIteratorT, void*> && ::cuda::std::is_integral_v<NumItemsT>,
+                             int> = 0>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t SubtractLeft(
+    InputIteratorT d_input, OutputIteratorT d_output, NumItemsT num_items, DifferenceOpT difference_op, EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceAdjacentDifference::SubtractLeft");
+
+    using OffsetT                 = detail::choose_offset_t<NumItemsT>;
+    using default_policy_selector = detail::adjacent_difference::policy_selector_from_types<InputIteratorT, true>;
+
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+        return detail::adjacent_difference::dispatch<MayAlias::Yes, ReadOption::Left>(
+          d_temp_storage,
+          temp_storage_bytes,
+          d_input,
+          d_output,
+          static_cast<OffsetT>(num_items),
+          difference_op,
+          stream,
+          policy_selector);
+      });
+  }
+
+  //! @rst
   //! Subtracts the left element of each adjacent pair of elements in-place.
   //!
   //! .. versionadded:: 3.4.0
@@ -714,7 +938,9 @@ struct DeviceAdjacentDifference
             typename DifferenceOpT,
             typename NumItemsT,
             typename EnvT = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<!::cuda::std::is_same_v<RandomAccessIteratorT, void*>, int> = 0>
+            ::cuda::std::enable_if_t<
+              !::cuda::std::is_same_v<RandomAccessIteratorT, void*> && ::cuda::std::is_integral_v<NumItemsT>,
+              int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t
   SubtractLeft(RandomAccessIteratorT d_input, NumItemsT num_items, DifferenceOpT difference_op, EnvT env = {})
   {
@@ -835,6 +1061,100 @@ struct DeviceAdjacentDifference
   }
 
   //! @rst
+  //! Subtracts the right element of each adjacent pair of elements residing within device-accessible memory.
+  //!
+  //! This is an environment-based API that allows customization of:
+  //!
+  //! - Stream: Query via ``cuda::get_stream``
+  //!
+  //! Overview
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! - Calculates the right differences of adjacent elements in ``d_input``.
+  //!   That is, ``*(d_input + num_items - 1)`` is assigned to
+  //!   ``*(d_output + num_items - 1)``, and, for each iterator ``i`` in the range
+  //!   ``[d_input, d_input + num_items - 1)``, the result of
+  //!   ``difference_op(*i, *(i + 1))`` is assigned to
+  //!   ``*(d_output + (i - d_input))``.
+  //! - The input and output ranges are allowed to overlap.
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates how to use ``SubtractRight`` with potentially aliasing
+  //! input and output ranges and a custom stream via an environment.
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_adjacent_difference_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin subtract-right-two-iter-env-stream
+  //!     :end-before: example-end subtract-right-two-iter-env-stream
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input elements @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Random-access output iterator type for writing output elements @iterator
+  //!
+  //! @tparam DifferenceOpT
+  //!   **[inferred]** Binary function object type used to compute differences
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Execution environment type. Default is ``cuda::std::execution::env<>``.
+  //!   Supports customization of stream via ``cuda::get_stream``.
+  //!
+  //! @param[in] d_input
+  //!   Beginning of the input sequence
+  //!
+  //! @param[out] d_output
+  //!   Beginning of the output sequence
+  //!
+  //! @param[in] num_items
+  //!   Number of items in the input sequence
+  //!
+  //! @param[in] difference_op
+  //!   The binary function used to compute differences
+  //!
+  //! @param[in] env
+  //!   @rst
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  //!   @endrst
+  template <
+    typename InputIteratorT,
+    typename OutputIteratorT,
+    typename DifferenceOpT,
+    typename NumItemsT,
+    typename EnvT                 = ::cuda::std::execution::env<>,
+    ::cuda::std::enable_if_t<!::cuda::std::is_same_v<InputIteratorT, void*> && ::cuda::std::is_integral_v<NumItemsT>,
+                             int> = 0>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t SubtractRight(
+    InputIteratorT d_input, OutputIteratorT d_output, NumItemsT num_items, DifferenceOpT difference_op, EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceAdjacentDifference::SubtractRight");
+
+    using OffsetT                 = detail::choose_offset_t<NumItemsT>;
+    using default_policy_selector = detail::adjacent_difference::policy_selector_from_types<InputIteratorT, true>;
+
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+        return detail::adjacent_difference::dispatch<MayAlias::Yes, ReadOption::Right>(
+          d_temp_storage,
+          temp_storage_bytes,
+          d_input,
+          d_output,
+          static_cast<OffsetT>(num_items),
+          difference_op,
+          stream,
+          policy_selector);
+      });
+  }
+
+  //! @rst
   //! Subtracts the right element of each adjacent pair of elements in-place.
   //!
   //! .. versionadded:: 3.4.0
@@ -896,7 +1216,9 @@ struct DeviceAdjacentDifference
             typename DifferenceOpT,
             typename NumItemsT,
             typename EnvT = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<!::cuda::std::is_same_v<RandomAccessIteratorT, void*>, int> = 0>
+            ::cuda::std::enable_if_t<
+              !::cuda::std::is_same_v<RandomAccessIteratorT, void*> && ::cuda::std::is_integral_v<NumItemsT>,
+              int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t
   SubtractRight(RandomAccessIteratorT d_input, NumItemsT num_items, DifferenceOpT difference_op, EnvT env = {})
   {

--- a/cub/test/catch2_test_device_adjacent_difference_env.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_env.cu
@@ -187,13 +187,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy can be tuned", "[adjacent_d
 
   block_size_extracting_minus_t op{thrust::raw_pointer_cast(d_block_size.data())};
 
-  size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceAdjacentDifference::SubtractLeftCopy(
-            nullptr, expected_bytes_allocated, input.begin(), output.begin(), input.size(), op));
-
-  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated),
-                          cuda::execution::__tune(adj_diff_tuning<target_block_size>{})};
+  auto env = cuda::execution::__tune(adj_diff_tuning<target_block_size>{});
 
   device_adjacent_difference_subtract_left_copy(input.begin(), output.begin(), input.size(), op, env);
 
@@ -210,13 +204,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeft can be tuned", "[adjacent_diffe
 
   block_size_extracting_minus_t op{thrust::raw_pointer_cast(d_block_size.data())};
 
-  size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceAdjacentDifference::SubtractLeft(nullptr, expected_bytes_allocated, data.begin(), data.size(), op));
-
-  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated),
-                          cuda::execution::__tune(adj_diff_tuning<target_block_size>{})};
+  auto env = cuda::execution::__tune(adj_diff_tuning<target_block_size>{});
 
   device_adjacent_difference_subtract_left(data.begin(), data.size(), op, env);
 
@@ -234,13 +222,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy can be tuned", "[adjacent_
 
   block_size_extracting_minus_t op{thrust::raw_pointer_cast(d_block_size.data())};
 
-  size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceAdjacentDifference::SubtractRightCopy(
-            nullptr, expected_bytes_allocated, input.begin(), output.begin(), input.size(), op));
-
-  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated),
-                          cuda::execution::__tune(adj_diff_tuning<target_block_size>{})};
+  auto env = cuda::execution::__tune(adj_diff_tuning<target_block_size>{});
 
   device_adjacent_difference_subtract_right_copy(input.begin(), output.begin(), input.size(), op, env);
 
@@ -257,13 +239,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRight can be tuned", "[adjacent_diff
 
   block_size_extracting_minus_t op{thrust::raw_pointer_cast(d_block_size.data())};
 
-  size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceAdjacentDifference::SubtractRight(nullptr, expected_bytes_allocated, data.begin(), data.size(), op));
-
-  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated),
-                          cuda::execution::__tune(adj_diff_tuning<target_block_size>{})};
+  auto env = cuda::execution::__tune(adj_diff_tuning<target_block_size>{});
 
   device_adjacent_difference_subtract_right(data.begin(), data.size(), op, env);
 

--- a/cub/test/catch2_test_device_adjacent_difference_env.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_env.cu
@@ -157,7 +157,7 @@ struct block_size_extracting_minus_t
 
   __device__ int operator()(int lhs, int rhs) const
   {
-    if (threadIdx.x == 0)
+    if (threadIdx.x == 1) // thread 0 does not always call this operator
     {
       atomicMax(d_block_size, blockDim.x);
     }
@@ -183,10 +183,8 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy can be tuned", "[adjacent_d
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto input                               = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
   auto output                              = c2h::device_vector<int>(8);
-  auto d_block_size                        = c2h::device_vector<unsigned int>(1, 0);
-
-  block_size_extracting_minus_t op{thrust::raw_pointer_cast(d_block_size.data())};
-
+  auto d_block_size                        = c2h::device_vector<unsigned int>{0};
+  auto op  = block_size_extracting_minus_t{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::__tune(adj_diff_tuning<target_block_size>{});
 
   device_adjacent_difference_subtract_left_copy(input.begin(), output.begin(), input.size(), op, env);
@@ -200,10 +198,8 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeft can be tuned", "[adjacent_diffe
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto data                                = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
-  auto d_block_size                        = c2h::device_vector<unsigned int>(1, 0);
-
-  block_size_extracting_minus_t op{thrust::raw_pointer_cast(d_block_size.data())};
-
+  auto d_block_size                        = c2h::device_vector<unsigned int>{0};
+  auto op  = block_size_extracting_minus_t{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::__tune(adj_diff_tuning<target_block_size>{});
 
   device_adjacent_difference_subtract_left(data.begin(), data.size(), op, env);
@@ -218,10 +214,8 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy can be tuned", "[adjacent_
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto input                               = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
   auto output                              = c2h::device_vector<int>(8);
-  auto d_block_size                        = c2h::device_vector<unsigned int>(1, 0);
-
-  block_size_extracting_minus_t op{thrust::raw_pointer_cast(d_block_size.data())};
-
+  auto d_block_size                        = c2h::device_vector<unsigned int>{0};
+  auto op  = block_size_extracting_minus_t{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::__tune(adj_diff_tuning<target_block_size>{});
 
   device_adjacent_difference_subtract_right_copy(input.begin(), output.begin(), input.size(), op, env);
@@ -235,10 +229,8 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRight can be tuned", "[adjacent_diff
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   auto data                                = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
-  auto d_block_size                        = c2h::device_vector<unsigned int>(1, 0);
-
-  block_size_extracting_minus_t op{thrust::raw_pointer_cast(d_block_size.data())};
-
+  auto d_block_size                        = c2h::device_vector<unsigned int>{0};
+  auto op  = block_size_extracting_minus_t{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::__tune(adj_diff_tuning<target_block_size>{});
 
   device_adjacent_difference_subtract_right(data.begin(), data.size(), op, env);

--- a/cub/test/catch2_test_device_adjacent_difference_env.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_env.cu
@@ -9,7 +9,10 @@ struct stream_registry_factory_t;
 
 #include <cub/device/device_adjacent_difference.cuh>
 
+#include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/device_vector.h>
+
+#include <cuda/__execution/tune.h>
 
 #include "catch2_test_env_launch_helper.h"
 
@@ -145,3 +148,128 @@ C2H_TEST("Device adjacent difference subtract right uses environment", "[adjacen
   c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
   REQUIRE(data == expected);
 }
+
+#if TEST_LAUNCH != 1
+
+struct block_size_extracting_minus_t
+{
+  unsigned int* d_block_size;
+
+  __device__ int operator()(int lhs, int rhs) const
+  {
+    if (threadIdx.x == 0)
+    {
+      atomicMax(d_block_size, blockDim.x);
+    }
+    return lhs - rhs;
+  }
+};
+
+template <int BlockThreads>
+struct adj_diff_tuning
+{
+  _CCCL_API constexpr auto operator()(cuda::arch_id /*arch*/) const
+    -> cub::detail::adjacent_difference::adjacent_difference_policy
+  {
+    return {BlockThreads, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_STORE_DIRECT};
+  }
+};
+
+using block_sizes =
+  c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
+
+C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy can be tuned", "[adjacent_difference][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  auto input                               = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
+  auto output                              = c2h::device_vector<int>(8);
+  auto d_block_size                        = c2h::device_vector<unsigned int>(1, 0);
+
+  block_size_extracting_minus_t op{thrust::raw_pointer_cast(d_block_size.data())};
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(cudaSuccess
+          == cub::DeviceAdjacentDifference::SubtractLeftCopy(
+            nullptr, expected_bytes_allocated, input.begin(), output.begin(), input.size(), op));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated),
+                          cuda::execution::__tune(adj_diff_tuning<target_block_size>{})};
+
+  device_adjacent_difference_subtract_left_copy(input.begin(), output.begin(), input.size(), op, env);
+
+  c2h::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
+  REQUIRE(output == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceAdjacentDifference::SubtractLeft can be tuned", "[adjacent_difference][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  auto data                                = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
+  auto d_block_size                        = c2h::device_vector<unsigned int>(1, 0);
+
+  block_size_extracting_minus_t op{thrust::raw_pointer_cast(d_block_size.data())};
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceAdjacentDifference::SubtractLeft(nullptr, expected_bytes_allocated, data.begin(), data.size(), op));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated),
+                          cuda::execution::__tune(adj_diff_tuning<target_block_size>{})};
+
+  device_adjacent_difference_subtract_left(data.begin(), data.size(), op, env);
+
+  c2h::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
+  REQUIRE(data == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy can be tuned", "[adjacent_difference][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  auto input                               = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
+  auto output                              = c2h::device_vector<int>(8);
+  auto d_block_size                        = c2h::device_vector<unsigned int>(1, 0);
+
+  block_size_extracting_minus_t op{thrust::raw_pointer_cast(d_block_size.data())};
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(cudaSuccess
+          == cub::DeviceAdjacentDifference::SubtractRightCopy(
+            nullptr, expected_bytes_allocated, input.begin(), output.begin(), input.size(), op));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated),
+                          cuda::execution::__tune(adj_diff_tuning<target_block_size>{})};
+
+  device_adjacent_difference_subtract_right_copy(input.begin(), output.begin(), input.size(), op, env);
+
+  c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
+  REQUIRE(output == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceAdjacentDifference::SubtractRight can be tuned", "[adjacent_difference][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  auto data                                = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
+  auto d_block_size                        = c2h::device_vector<unsigned int>(1, 0);
+
+  block_size_extracting_minus_t op{thrust::raw_pointer_cast(d_block_size.data())};
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceAdjacentDifference::SubtractRight(nullptr, expected_bytes_allocated, data.begin(), data.size(), op));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated),
+                          cuda::execution::__tune(adj_diff_tuning<target_block_size>{})};
+
+  device_adjacent_difference_subtract_right(data.begin(), data.size(), op, env);
+
+  c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
+  REQUIRE(data == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+#endif // TEST_LAUNCH != 1

--- a/cub/test/catch2_test_device_adjacent_difference_env.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_env.cu
@@ -77,6 +77,34 @@ TEST_CASE("Device adjacent difference subtract right works with default environm
   REQUIRE(data == expected);
 }
 
+TEST_CASE("Device adjacent difference subtract left with two iterators works with default environment",
+          "[adjacent_difference][device]")
+{
+  auto input  = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
+  auto output = c2h::device_vector<int>(8);
+
+  REQUIRE(cudaSuccess
+          == cub::DeviceAdjacentDifference::SubtractLeft(
+            input.begin(), output.begin(), static_cast<int>(input.size()), cuda::std::minus{}));
+
+  c2h::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
+  REQUIRE(output == expected);
+}
+
+TEST_CASE("Device adjacent difference subtract right with two iterators works with default environment",
+          "[adjacent_difference][device]")
+{
+  auto input  = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
+  auto output = c2h::device_vector<int>(8);
+
+  REQUIRE(cudaSuccess
+          == cub::DeviceAdjacentDifference::SubtractRight(
+            input.begin(), output.begin(), static_cast<int>(input.size()), cuda::std::minus{}));
+
+  c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
+  REQUIRE(output == expected);
+}
+
 #endif
 
 C2H_TEST("Device adjacent difference subtract left copy uses environment", "[adjacent_difference][device]")
@@ -147,6 +175,58 @@ C2H_TEST("Device adjacent difference subtract right uses environment", "[adjacen
 
   c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
   REQUIRE(data == expected);
+}
+
+C2H_TEST("Device adjacent difference subtract left with two iterators uses environment",
+         "[adjacent_difference][device]")
+{
+  auto input  = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
+  auto output = c2h::device_vector<int>(8);
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceAdjacentDifference::SubtractLeft(
+      nullptr,
+      expected_bytes_allocated,
+      input.begin(),
+      output.begin(),
+      static_cast<int>(input.size()),
+      cuda::std::minus{}));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_adjacent_difference_subtract_left(
+    input.begin(), output.begin(), static_cast<int>(input.size()), cuda::std::minus{}, env);
+
+  c2h::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
+  REQUIRE(output == expected);
+}
+
+C2H_TEST("Device adjacent difference subtract right with two iterators uses environment",
+         "[adjacent_difference][device]")
+{
+  auto input  = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
+  auto output = c2h::device_vector<int>(8);
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceAdjacentDifference::SubtractRight(
+      nullptr,
+      expected_bytes_allocated,
+      input.begin(),
+      output.begin(),
+      static_cast<int>(input.size()),
+      cuda::std::minus{}));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_adjacent_difference_subtract_right(
+    input.begin(), output.begin(), static_cast<int>(input.size()), cuda::std::minus{}, env);
+
+  c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
+  REQUIRE(output == expected);
 }
 
 #if TEST_LAUNCH != 1
@@ -237,6 +317,42 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRight can be tuned", "[adjacent_diff
 
   c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
   REQUIRE(data == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceAdjacentDifference::SubtractLeft with two iterators can be tuned",
+         "[adjacent_difference][device]",
+         block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  auto input                               = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
+  auto output                              = c2h::device_vector<int>(8);
+  auto d_block_size                        = c2h::device_vector<unsigned int>{0};
+  auto op  = block_size_extracting_minus_t{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env = cuda::execution::__tune(adj_diff_tuning<target_block_size>{});
+
+  device_adjacent_difference_subtract_left(input.begin(), output.begin(), static_cast<int>(input.size()), op, env);
+
+  c2h::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
+  REQUIRE(output == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceAdjacentDifference::SubtractRight with two iterators can be tuned",
+         "[adjacent_difference][device]",
+         block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  auto input                               = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
+  auto output                              = c2h::device_vector<int>(8);
+  auto d_block_size                        = c2h::device_vector<unsigned int>{0};
+  auto op  = block_size_extracting_minus_t{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env = cuda::execution::__tune(adj_diff_tuning<target_block_size>{});
+
+  device_adjacent_difference_subtract_right(input.begin(), output.begin(), static_cast<int>(input.size()), op, env);
+
+  c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
+  REQUIRE(output == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
 

--- a/cub/test/catch2_test_device_adjacent_difference_env_api.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_env_api.cu
@@ -59,6 +59,29 @@ C2H_TEST("cub::DeviceAdjacentDifference::SubtractLeft accepts stream", "[adjacen
   REQUIRE(data == expected);
 }
 
+C2H_TEST("cub::DeviceAdjacentDifference::SubtractLeft with two iterators accepts stream", "[adjacent_difference][env]")
+{
+  // example-begin subtract-left-two-iter-env-stream
+  auto input  = thrust::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
+  auto output = thrust::device_vector<int>(8);
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceAdjacentDifference::SubtractLeft(
+    input.begin(), output.begin(), static_cast<int>(input.size()), cuda::std::minus{}, stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceAdjacentDifference::SubtractLeft failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
+  // example-end subtract-left-two-iter-env-stream
+  stream.sync();
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(output == expected);
+}
+
 C2H_TEST("cub::DeviceAdjacentDifference::SubtractRightCopy accepts stream", "[adjacent_difference][env]")
 {
   // example-begin subtract-right-copy-env-stream
@@ -103,4 +126,27 @@ C2H_TEST("cub::DeviceAdjacentDifference::SubtractRight accepts stream", "[adjace
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(data == expected);
+}
+
+C2H_TEST("cub::DeviceAdjacentDifference::SubtractRight with two iterators accepts stream", "[adjacent_difference][env]")
+{
+  // example-begin subtract-right-two-iter-env-stream
+  auto input  = thrust::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
+  auto output = thrust::device_vector<int>(8);
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceAdjacentDifference::SubtractRight(
+    input.begin(), output.begin(), static_cast<int>(input.size()), cuda::std::minus{}, stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceAdjacentDifference::SubtractRight  failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
+  // example-end subtract-right-two-iter-env-stream
+  stream.sync();
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(output == expected);
 }

--- a/cub/test/catch2_test_device_adjacent_difference_substract_left.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_substract_left.cu
@@ -39,6 +39,19 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeft can run with empty input", "[de
   adjacent_difference_subtract_left(in.begin(), num_items, cuda::std::minus<>{});
 }
 
+C2H_TEST("DeviceAdjacentDifference::SubtractLeft with two iterators can run with empty input",
+         "[device][adjacent_difference]",
+         types)
+{
+  using type = typename c2h::get<0, TestType>;
+
+  constexpr int num_items = 0;
+  c2h::device_vector<type> in(num_items);
+  c2h::device_vector<type> out(num_items);
+
+  adjacent_difference_subtract_left(in.begin(), out.begin(), num_items, cuda::std::minus<>{});
+}
+
 C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy can run with empty input", "[device][adjacent_difference]", types)
 {
   using type = typename c2h::get<0, TestType>;
@@ -64,6 +77,22 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy does not change the input",
   REQUIRE(reference == in);
 }
 
+C2H_TEST("DeviceAdjacentDifference::SubtractLeft with two iterators does not change the input",
+         "[device][adjacent_difference]",
+         types)
+{
+  using type = typename c2h::get<0, TestType>;
+
+  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
+  c2h::device_vector<type> in(num_items);
+  c2h::gen(C2H_SEED(2), in);
+
+  c2h::device_vector<type> reference = in;
+  adjacent_difference_subtract_left(in.begin(), cuda::discard_iterator(), num_items, cuda::std::minus<>{});
+
+  REQUIRE(reference == in);
+}
+
 C2H_TEST("DeviceAdjacentDifference::SubtractLeft works with iterators", "[device][adjacent_difference]", types)
 {
   using type = typename c2h::get<0, TestType>;
@@ -79,6 +108,26 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeft works with iterators", "[device
   adjacent_difference_subtract_left(in.begin(), num_items, cuda::std::minus<>{});
 
   REQUIRE(reference == in);
+}
+
+C2H_TEST("DeviceAdjacentDifference::SubtractLeft with two iterators works with iterators",
+         "[device][adjacent_difference]",
+         types)
+{
+  using type = typename c2h::get<0, TestType>;
+
+  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
+  c2h::device_vector<type> in(num_items);
+  c2h::device_vector<type> out(num_items);
+  c2h::gen(C2H_SEED(2), in);
+
+  c2h::host_vector<type> h_in = in;
+  c2h::host_vector<type> reference(num_items);
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), std::minus<type>{});
+
+  adjacent_difference_subtract_left(in.begin(), out.begin(), num_items, cuda::std::minus<>{});
+
+  REQUIRE(reference == out);
 }
 
 C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with iterators", "[device][adjacent_difference]", types)
@@ -114,6 +163,27 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeft works with pointers", "[device]
   adjacent_difference_subtract_left(thrust::raw_pointer_cast(in.data()), num_items, cuda::std::minus<>{});
 
   REQUIRE(reference == in);
+}
+
+C2H_TEST("DeviceAdjacentDifference::SubtractLeft with two iterators works with pointers",
+         "[device][adjacent_difference]",
+         types)
+{
+  using type = typename c2h::get<0, TestType>;
+
+  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
+  c2h::device_vector<type> in(num_items);
+  c2h::device_vector<type> out(num_items);
+  c2h::gen(C2H_SEED(2), in);
+
+  c2h::host_vector<type> h_in = in;
+  c2h::host_vector<type> reference(num_items);
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), std::minus<type>{});
+
+  adjacent_difference_subtract_left(
+    thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), num_items, cuda::std::minus<>{});
+
+  REQUIRE(reference == out);
 }
 
 C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with pointers", "[device][adjacent_difference]", types)

--- a/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
@@ -340,3 +340,75 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy uses right number of invoc
 
   REQUIRE(counts.front() == static_cast<unsigned long long>(num_items - 1));
 }
+
+C2H_TEST("DeviceAdjacentDifference::SubtractRight may-alias can run with empty input",
+         "[device][adjacent_difference]",
+         types)
+{
+  using type = typename c2h::get<0, TestType>;
+
+  constexpr int num_items = 0;
+  c2h::device_vector<type> in(num_items);
+  c2h::device_vector<type> out(num_items);
+
+  adjacent_difference_subtract_right(in.begin(), out.begin(), num_items, cuda::std::minus<>{});
+}
+
+C2H_TEST("DeviceAdjacentDifference::SubtractRight may-alias works with iterators",
+         "[device][adjacent_difference]",
+         types)
+{
+  using type = typename c2h::get<0, TestType>;
+
+  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
+  c2h::device_vector<type> in(num_items);
+  c2h::device_vector<type> out(num_items);
+  c2h::gen(C2H_SEED(2), in);
+
+  c2h::host_vector<type> h_in = in;
+  c2h::host_vector<type> reference(num_items);
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), ref_diff<type>{});
+  std::rotate(reference.begin(), reference.begin() + 1, reference.end());
+  reference.back() = h_in.back();
+
+  adjacent_difference_subtract_right(in.begin(), out.begin(), num_items, cuda::std::minus<>{});
+
+  REQUIRE(reference == out);
+}
+
+C2H_TEST("DeviceAdjacentDifference::SubtractRight may-alias works with pointers", "[device][adjacent_difference]", types)
+{
+  using type = typename c2h::get<0, TestType>;
+
+  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
+  c2h::device_vector<type> in(num_items);
+  c2h::device_vector<type> out(num_items);
+  c2h::gen(C2H_SEED(2), in);
+
+  c2h::host_vector<type> h_in = in;
+  c2h::host_vector<type> reference(num_items);
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), ref_diff<type>{});
+  std::rotate(reference.begin(), reference.begin() + 1, reference.end());
+  reference.back() = h_in.back();
+
+  adjacent_difference_subtract_right(
+    thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), num_items, cuda::std::minus<>{});
+
+  REQUIRE(reference == out);
+}
+
+C2H_TEST("DeviceAdjacentDifference::SubtractRight may-alias does not change the input",
+         "[device][adjacent_difference]",
+         types)
+{
+  using type = typename c2h::get<0, TestType>;
+
+  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
+  c2h::device_vector<type> in(num_items);
+  c2h::gen(C2H_SEED(2), in);
+
+  c2h::device_vector<type> reference = in;
+  adjacent_difference_subtract_right(in.begin(), cuda::discard_iterator(), num_items, cuda::std::minus<>{});
+
+  REQUIRE(reference == in);
+}

--- a/thrust/thrust/system/cuda/detail/adjacent_difference.h
+++ b/thrust/thrust/system/cuda/detail/adjacent_difference.h
@@ -30,6 +30,7 @@
 #  include <thrust/type_traits/is_contiguous_iterator.h>
 #  include <thrust/type_traits/unwrap_contiguous_iterator.h>
 
+#  include <cuda/__memory/check_address.h>
 #  include <cuda/std/__functional/operations.h>
 #  include <cuda/std/__iterator/distance.h>
 #  include <cuda/std/__type_traits/is_pointer.h>
@@ -50,7 +51,7 @@ namespace cuda_cub
 {
 namespace __adjacent_difference
 {
-template <bool Comparable, class InputIt, class OutputIt, class BinaryOp>
+template <class InputIt, class OutputIt, class BinaryOp>
 cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
@@ -65,14 +66,18 @@ cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
     return cudaSuccess;
   }
 
-  if constexpr (Comparable)
+  using InputValueT                    = thrust::detail::it_value_t<InputIt>;
+  using OutputValueT                   = thrust::detail::it_value_t<OutputIt>;
+  constexpr bool can_compare_iterators = ::cuda::std::is_pointer_v<InputIt> && ::cuda::std::is_pointer_v<OutputIt>
+                                      && std::is_same_v<InputValueT, OutputValueT>;
+
+  if constexpr (can_compare_iterators)
   {
     cudaError_t status;
-    // The documentation states that pointers might be equal but can't alias in
-    // any other way. That is, the distance should be equal to zero or exceed
-    // `num_items`. In the latter case, we use an optimized version.
+    // cub::DeviceAdjacentDifference only allows in-place (first and result iterator equal) or non-overlapping use cases
     if (first == result)
     {
+      // in-place
       THRUST_INDEX_TYPE_DISPATCH(
         status,
         cub::DeviceAdjacentDifference::SubtractLeft,
@@ -81,6 +86,7 @@ cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
     }
     else
     {
+      _CCCL_ASSERT(!::cuda::__are_ptrs_overlapping(first, result, num_items), "Ranges must not overlap");
       THRUST_INDEX_TYPE_DISPATCH(
         status,
         cub::DeviceAdjacentDifference::SubtractLeftCopy,
@@ -91,10 +97,12 @@ cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
   }
   else
   {
+    // when we cannot compare the iterators, we have to assume they could alias
+    // TODO(bgruber): expose a cub::DeviceAdjacentDifference::SubtractLeft with two different iterators
     cudaError_t status;
     THRUST_INDEX_TYPE_DISPATCH(
       status,
-      cub::DeviceAdjacentDifference::SubtractLeft,
+      (cub::detail::adjacent_difference::dispatch<cub::MayAlias::Yes, cub::ReadOption::Left>),
       num_items,
       (d_temp_storage, temp_storage_bytes, first, result, num_items_fixed, binary_op, stream));
     return status;
@@ -109,27 +117,16 @@ adjacent_difference(execution_policy<Derived>& policy, InputIt first, InputIt la
   std::size_t storage_size = 0;
   cudaStream_t stream      = cuda_cub::stream(policy);
 
-  using UnwrapInputIt  = thrust::try_unwrap_contiguous_iterator_t<InputIt>;
-  using UnwrapOutputIt = thrust::try_unwrap_contiguous_iterator_t<OutputIt>;
-
-  using InputValueT  = thrust::detail::it_value_t<UnwrapInputIt>;
-  using OutputValueT = thrust::detail::it_value_t<UnwrapOutputIt>;
-
-  constexpr bool can_compare_iterators =
-    ::cuda::std::is_pointer_v<UnwrapInputIt> && ::cuda::std::is_pointer_v<UnwrapOutputIt>
-    && std::is_same_v<InputValueT, OutputValueT>;
-
   auto first_unwrap  = thrust::try_unwrap_contiguous_iterator(first);
   auto result_unwrap = thrust::try_unwrap_contiguous_iterator(result);
 
-  cudaError_t status =
-    doit_step<can_compare_iterators>(nullptr, storage_size, first_unwrap, result_unwrap, binary_op, num_items, stream);
+  cudaError_t status = doit_step(nullptr, storage_size, first_unwrap, result_unwrap, binary_op, num_items, stream);
   cuda_cub::throw_on_error(status, "adjacent_difference failed on 1st step");
 
   // Allocate temporary storage.
   thrust::detail::temporary_array<std::uint8_t, Derived> tmp(policy, storage_size);
 
-  status = doit_step<can_compare_iterators>(
+  status = doit_step(
     static_cast<void*>(tmp.data().get()), storage_size, first_unwrap, result_unwrap, binary_op, num_items, stream);
   cuda_cub::throw_on_error(status, "adjacent_difference failed on 2nd step");
 

--- a/thrust/thrust/system/cuda/detail/adjacent_difference.h
+++ b/thrust/thrust/system/cuda/detail/adjacent_difference.h
@@ -50,7 +50,7 @@ namespace cuda_cub
 {
 namespace __adjacent_difference
 {
-template <cub::MayAlias AliasOpt, class InputIt, class OutputIt, class BinaryOp>
+template <bool Comparable, class InputIt, class OutputIt, class BinaryOp>
 cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
@@ -65,49 +65,40 @@ cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
     return cudaSuccess;
   }
 
-  cudaError_t status;
-  THRUST_INDEX_TYPE_DISPATCH(
-    status,
-    (cub::detail::adjacent_difference::dispatch<AliasOpt, cub::ReadOption::Left>),
-    num_items,
-    (d_temp_storage, temp_storage_bytes, first, result, num_items_fixed, binary_op, stream));
-  return status;
-}
-
-template <class InputIt, class OutputIt, class BinaryOp>
-cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
-  void* d_temp_storage,
-  size_t& temp_storage_bytes,
-  InputIt first,
-  OutputIt result,
-  BinaryOp binary_op,
-  std::size_t num_items,
-  cudaStream_t stream,
-  thrust::detail::integral_constant<bool, false> /* comparable */)
-{
-  return doit_step<cub::MayAlias::Yes>(d_temp_storage, temp_storage_bytes, first, result, binary_op, num_items, stream);
-}
-
-template <class InputIt, class OutputIt, class BinaryOp>
-cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
-  void* d_temp_storage,
-  size_t& temp_storage_bytes,
-  InputIt first,
-  OutputIt result,
-  BinaryOp binary_op,
-  std::size_t num_items,
-  cudaStream_t stream,
-  thrust::detail::integral_constant<bool, true> /* comparable */)
-{
-  // The documentation states that pointers might be equal but can't alias in
-  // any other way. That is, the distance should be equal to zero or exceed
-  // `num_items`. In the latter case, we use an optimized version.
-  if (first != result)
+  if constexpr (Comparable)
   {
-    return doit_step<cub::MayAlias::No>(d_temp_storage, temp_storage_bytes, first, result, binary_op, num_items, stream);
+    cudaError_t status;
+    // The documentation states that pointers might be equal but can't alias in
+    // any other way. That is, the distance should be equal to zero or exceed
+    // `num_items`. In the latter case, we use an optimized version.
+    if (first == result)
+    {
+      THRUST_INDEX_TYPE_DISPATCH(
+        status,
+        cub::DeviceAdjacentDifference::SubtractLeft,
+        num_items,
+        (d_temp_storage, temp_storage_bytes, first, num_items_fixed, binary_op, stream));
+    }
+    else
+    {
+      THRUST_INDEX_TYPE_DISPATCH(
+        status,
+        cub::DeviceAdjacentDifference::SubtractLeftCopy,
+        num_items,
+        (d_temp_storage, temp_storage_bytes, first, result, num_items_fixed, binary_op, stream));
+    }
+    return status;
   }
-
-  return doit_step<cub::MayAlias::Yes>(d_temp_storage, temp_storage_bytes, first, result, binary_op, num_items, stream);
+  else
+  {
+    cudaError_t status;
+    THRUST_INDEX_TYPE_DISPATCH(
+      status,
+      cub::DeviceAdjacentDifference::SubtractLeftCopy,
+      num_items,
+      (d_temp_storage, temp_storage_bytes, first, result, num_items_fixed, binary_op, stream));
+    return status;
+  }
 }
 
 template <typename Derived, typename InputIt, typename OutputIt, typename BinaryOp>
@@ -131,24 +122,15 @@ adjacent_difference(execution_policy<Derived>& policy, InputIt first, InputIt la
   auto first_unwrap  = thrust::try_unwrap_contiguous_iterator(first);
   auto result_unwrap = thrust::try_unwrap_contiguous_iterator(result);
 
-  thrust::detail::integral_constant<bool, can_compare_iterators> comparable;
-
   cudaError_t status =
-    doit_step(nullptr, storage_size, first_unwrap, result_unwrap, binary_op, num_items, stream, comparable);
+    doit_step<can_compare_iterators>(nullptr, storage_size, first_unwrap, result_unwrap, binary_op, num_items, stream);
   cuda_cub::throw_on_error(status, "adjacent_difference failed on 1st step");
 
   // Allocate temporary storage.
   thrust::detail::temporary_array<std::uint8_t, Derived> tmp(policy, storage_size);
 
-  status = doit_step(
-    static_cast<void*>(tmp.data().get()),
-    storage_size,
-    first_unwrap,
-    result_unwrap,
-    binary_op,
-    num_items,
-    stream,
-    comparable);
+  status = doit_step<can_compare_iterators>(
+    static_cast<void*>(tmp.data().get()), storage_size, first_unwrap, result_unwrap, binary_op, num_items, stream);
   cuda_cub::throw_on_error(status, "adjacent_difference failed on 2nd step");
 
   status = cuda_cub::synchronize_optional(policy);

--- a/thrust/thrust/system/cuda/detail/adjacent_difference.h
+++ b/thrust/thrust/system/cuda/detail/adjacent_difference.h
@@ -94,7 +94,7 @@ cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
     cudaError_t status;
     THRUST_INDEX_TYPE_DISPATCH(
       status,
-      cub::DeviceAdjacentDifference::SubtractLeftCopy,
+      cub::DeviceAdjacentDifference::SubtractLeft,
       num_items,
       (d_temp_storage, temp_storage_bytes, first, result, num_items_fixed, binary_op, stream));
     return status;

--- a/thrust/thrust/system/cuda/detail/adjacent_difference.h
+++ b/thrust/thrust/system/cuda/detail/adjacent_difference.h
@@ -77,7 +77,7 @@ cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
         status,
         cub::DeviceAdjacentDifference::SubtractLeft,
         num_items,
-        (d_temp_storage, temp_storage_bytes, first, num_items_fixed, binary_op, stream));
+        (d_temp_storage, temp_storage_bytes, result, num_items_fixed, binary_op, stream));
     }
     else
     {


### PR DESCRIPTION
While working on #8492, I realized that Thrust uses a version of `cub::DeviceAdjacentDifference` that is not exposed in the public API: an overlapping version that uses dedicated input and output iterators. We only have an overload taking a single iterator (in-place) and another one taking two iterators but requiring the input and output range to not overlap.

I am still not entirely sure whether we want those overloads and if Thrust's logic is fully correct. Thrust's API mentions:
```c++
 *  \remark Note that \p result is permitted to be the same iterator as \p first. This is
 *          useful for computing differences "in place".
 ```
but it does not mention that the input/output ranges are not allowed to overlap in any other way. The parallel overloads in the PSTL do not allow that. So Thrust seems to support more use cases here.

This PR adds the corresponding CUB overloads for Thrust use case, so we can migrate it away from using the dispatch layer.