### PR TITLE
Allow public tuning of `cub::DeviceMergeSort` 

### DIFF
--- a/cub/benchmarks/bench/merge_sort/keys.cu
+++ b/cub/benchmarks/bench/merge_sort/keys.cu
@@ -19,8 +19,7 @@
 template <typename KeyT>
 struct policy_selector
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> cub::MergeSortPolicy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::MergeSortPolicy
   {
     return cub::MergeSortPolicy{
       TUNE_THREADS_PER_BLOCK,

--- a/cub/benchmarks/bench/merge_sort/keys.cu
+++ b/cub/benchmarks/bench/merge_sort/keys.cu
@@ -20,9 +20,9 @@ template <typename KeyT>
 struct policy_selector
 {
   [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::merge_sort::merge_sort_policy
+    -> cub::MergeSortPolicy
   {
-    return cub::detail::merge_sort::merge_sort_policy{
+    return cub::MergeSortPolicy{
       TUNE_THREADS_PER_BLOCK,
       cub::Nominal4BItemsToItems<KeyT>(TUNE_ITEMS_PER_THREAD),
       (TUNE_TRANSPOSE == 0 ? cub::BLOCK_LOAD_DIRECT : cub::BLOCK_LOAD_WARP_TRANSPOSE),

--- a/cub/benchmarks/bench/merge_sort/pairs.cu
+++ b/cub/benchmarks/bench/merge_sort/pairs.cu
@@ -19,8 +19,7 @@
 template <typename KeyT>
 struct policy_selector
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> cub::MergeSortPolicy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::MergeSortPolicy
   {
     return cub::MergeSortPolicy{
       TUNE_THREADS_PER_BLOCK,

--- a/cub/benchmarks/bench/merge_sort/pairs.cu
+++ b/cub/benchmarks/bench/merge_sort/pairs.cu
@@ -20,9 +20,9 @@ template <typename KeyT>
 struct policy_selector
 {
   [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::merge_sort::merge_sort_policy
+    -> cub::MergeSortPolicy
   {
-    return cub::detail::merge_sort::merge_sort_policy{
+    return cub::MergeSortPolicy{
       TUNE_THREADS_PER_BLOCK,
       cub::Nominal4BItemsToItems<KeyT>(TUNE_ITEMS_PER_THREAD),
       (TUNE_TRANSPOSE == 0 ? cub::BLOCK_LOAD_DIRECT : cub::BLOCK_LOAD_WARP_TRANSPOSE),

--- a/cub/cub/agent/agent_merge_sort.cuh
+++ b/cub/cub/agent/agent_merge_sort.cuh
@@ -43,10 +43,10 @@ struct AgentBlockSort
 
   static constexpr bool KEYS_ONLY = ::cuda::std::is_same_v<ValueT, NullType>;
 
-  static constexpr merge_sort_policy policy = PolicyGetter{}();
-  static constexpr int BLOCK_THREADS        = policy.threads_per_block;
-  static constexpr int ITEMS_PER_THREAD     = policy.items_per_thread;
-  static constexpr int ITEMS_PER_TILE       = policy.items_per_tile();
+  static constexpr MergeSortPolicy policy = PolicyGetter{}();
+  static constexpr int BLOCK_THREADS      = policy.threads_per_block;
+  static constexpr int ITEMS_PER_THREAD   = policy.items_per_thread;
+  static constexpr int ITEMS_PER_TILE     = policy.items_per_tile();
 
   using BlockMergeSortT = BlockMergeSort<KeyT, BLOCK_THREADS, ITEMS_PER_THREAD, ValueT>;
 
@@ -378,10 +378,10 @@ struct AgentMerge
 
   static constexpr bool KEYS_ONLY = ::cuda::std::is_same_v<ValueT, NullType>;
 
-  static constexpr merge_sort_policy policy = PolicyGetter{}();
-  static constexpr int BLOCK_THREADS        = policy.threads_per_block;
-  static constexpr int ITEMS_PER_THREAD     = policy.items_per_thread;
-  static constexpr int ITEMS_PER_TILE       = policy.items_per_tile();
+  static constexpr MergeSortPolicy policy = PolicyGetter{}();
+  static constexpr int BLOCK_THREADS      = policy.threads_per_block;
+  static constexpr int ITEMS_PER_THREAD   = policy.items_per_thread;
+  static constexpr int ITEMS_PER_TILE     = policy.items_per_tile();
 
   using KeysLoadPingIt  = try_make_cache_modified_iterator_t<policy.load_modifier, KeyIteratorT>;
   using ItemsLoadPingIt = try_make_cache_modified_iterator_t<policy.load_modifier, ValueIteratorT>;

--- a/cub/cub/agent/agent_merge_sort.cuh
+++ b/cub/cub/agent/agent_merge_sort.cuh
@@ -46,7 +46,7 @@ struct AgentBlockSort
   static constexpr MergeSortPolicy policy = PolicyGetter{}();
   static constexpr int BLOCK_THREADS      = policy.threads_per_block;
   static constexpr int ITEMS_PER_THREAD   = policy.items_per_thread;
-  static constexpr int ITEMS_PER_TILE     = policy.items_per_tile();
+  static constexpr int ITEMS_PER_TILE     = BLOCK_THREADS * ITEMS_PER_THREAD;
 
   using BlockMergeSortT = BlockMergeSort<KeyT, BLOCK_THREADS, ITEMS_PER_THREAD, ValueT>;
 
@@ -381,7 +381,7 @@ struct AgentMerge
   static constexpr MergeSortPolicy policy = PolicyGetter{}();
   static constexpr int BLOCK_THREADS      = policy.threads_per_block;
   static constexpr int ITEMS_PER_THREAD   = policy.items_per_thread;
-  static constexpr int ITEMS_PER_TILE     = policy.items_per_tile();
+  static constexpr int ITEMS_PER_TILE     = BLOCK_THREADS * ITEMS_PER_THREAD;
 
   using KeysLoadPingIt  = try_make_cache_modified_iterator_t<policy.load_modifier, KeyIteratorT>;
   using ItemsLoadPingIt = try_make_cache_modified_iterator_t<policy.load_modifier, ValueIteratorT>;
@@ -412,8 +412,8 @@ struct AgentMerge
     typename BlockStoreKeysPong::TempStorage store_keys_pong;
     typename BlockStoreItemsPong::TempStorage store_items_pong;
 
-    KeyT keys_shared[policy.items_per_tile() + 1];
-    ValueT items_shared[policy.items_per_tile() + 1];
+    KeyT keys_shared[ITEMS_PER_TILE + 1];
+    ValueT items_shared[ITEMS_PER_TILE + 1];
   };
 
   /// Alias wrapper allowing storage to be unioned

--- a/cub/cub/device/device_merge_sort.cuh
+++ b/cub/cub/device/device_merge_sort.cuh
@@ -87,12 +87,10 @@ CUB_NAMESPACE_BEGIN
  * @endcode
  *
  * @par Tuning
- * @par
- * All algorithms in DeviceMergeSort that accept an environment can be tuned by passing a custom policy selector (TODO:
- * link to common tuning page) that returns a @ref MergeSortPolicy, as shown in the example below:
- * @par
- *
  * @rst
+ * All algorithms in DeviceMergeSort that accept an environment can be tuned by passing a custom :ref:`policy selector
+ * <cub-policy-selectors>` that returns a @ref MergeSortPolicy, as shown in the example below:
+ *
  *  .. literalinclude:: ../../../cub/test/catch2_test_device_merge_sort_env_api.cu
  *      :language: c++
  *      :dedent:
@@ -105,7 +103,6 @@ CUB_NAMESPACE_BEGIN
  *      :start-after: example-begin sort-pairs-tuning
  *      :end-before: example-end sort-pairs-tuning
  * @endrst
- *
  *
  * [LessThan Comparable]: https://en.cppreference.com/w/cpp/named_req/LessThanComparable
  */

--- a/cub/cub/device/device_merge_sort.cuh
+++ b/cub/cub/device/device_merge_sort.cuh
@@ -86,6 +86,27 @@ CUB_NAMESPACE_BEGIN
  *   CustomLess());
  * @endcode
  *
+ * @par Tuning
+ * @par
+ * All algorithms in DeviceMergeSort that accept an environment can be tuned by passing a custom policy selector (TODO:
+ * link to common tuning page) that returns a @ref MergeSortPolicy, as shown in the example below:
+ * @par
+ *
+ * @rst
+ *  .. literalinclude:: ../../../cub/test/catch2_test_device_merge_sort_env_api.cu
+ *      :language: c++
+ *      :dedent:
+ *      :start-after: example-begin sort-pairs-policy-selector
+ *      :end-before: example-end sort-pairs-policy-selector
+ *
+ *  .. literalinclude:: ../../../cub/test/catch2_test_device_merge_sort_env_api.cu
+ *      :language: c++
+ *      :dedent:
+ *      :start-after: example-begin sort-pairs-tuning
+ *      :end-before: example-end sort-pairs-tuning
+ * @endrst
+ *
+ *
  * [LessThan Comparable]: https://en.cppreference.com/w/cpp/named_req/LessThanComparable
  */
 struct DeviceMergeSort

--- a/cub/cub/device/dispatch/dispatch_merge_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge_sort.cuh
@@ -521,7 +521,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
                  }))
 #endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
 
-    const auto tile_size = active_policy.items_per_tile();
+    const auto tile_size = active_policy.block_threads * active_policy.items_per_thread;
     const auto num_tiles = ::cuda::ceil_div(num_items, tile_size);
 
     const auto merge_partitions_size         = static_cast<size_t>(1 + num_tiles) * sizeof(OffsetT);

--- a/cub/cub/device/dispatch/dispatch_merge_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge_sort.cuh
@@ -216,6 +216,9 @@ public:
       CompareOpT,
       KeyT,
       ValueT>::policy;
+    static_assert(1 <= policy.threads_per_block && policy.threads_per_block <= 1024,
+                  "Number of threads per block need to be inside [1;1024]");
+    static_assert(1 <= policy.items_per_thread, "Number of items per thread needs to be at least 1");
     constexpr auto tile_size = policy.threads_per_block * policy.items_per_thread;
     const auto num_tiles     = ::cuda::ceil_div(num_items, tile_size);
 
@@ -511,6 +514,9 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
                  }))
 #endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
 
+    _CCCL_ASSERT(1 <= policy.threads_per_block && policy.threads_per_block <= 1024,
+                 "Number of threads per block need to be inside [1;1024]");
+    _CCCL_ASSERT(1 <= policy.items_per_thread, "Number of items per thread needs to be at least 1");
     const auto tile_size = active_policy.threads_per_block * active_policy.items_per_thread;
     const auto num_tiles = ::cuda::ceil_div(num_items, tile_size);
 

--- a/cub/cub/device/dispatch/dispatch_merge_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge_sort.cuh
@@ -514,9 +514,9 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
                  }))
 #endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
 
-    _CCCL_ASSERT(1 <= policy.threads_per_block && policy.threads_per_block <= 1024,
+    _CCCL_ASSERT(1 <= active_policy.threads_per_block && active_policy.threads_per_block <= 1024,
                  "Number of threads per block need to be inside [1;1024]");
-    _CCCL_ASSERT(1 <= policy.items_per_thread, "Number of items per thread needs to be at least 1");
+    _CCCL_ASSERT(1 <= active_policy.items_per_thread, "Number of items per thread needs to be at least 1");
     const auto tile_size = active_policy.threads_per_block * active_policy.items_per_thread;
     const auto num_tiles = ::cuda::ceil_div(num_items, tile_size);
 

--- a/cub/cub/device/dispatch/dispatch_merge_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge_sort.cuh
@@ -185,7 +185,7 @@ private:
   template <typename ActivePolicyT>
   struct policy_getter
   {
-    _CCCL_HOST_DEVICE_API constexpr auto operator()() -> detail::merge_sort::merge_sort_policy
+    _CCCL_HOST_DEVICE_API constexpr auto operator()() -> MergeSortPolicy
     {
       using mp = typename ActivePolicyT::MergeSortPolicy;
       return {mp::BLOCK_THREADS, mp::ITEMS_PER_THREAD, mp::LOAD_ALGORITHM, mp::LOAD_MODIFIER, mp::STORE_ALGORITHM};
@@ -495,7 +495,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
 
   return detail::dispatch_compute_cap(policy_selector, cc, [&](auto policy_getter) -> cudaError_t {
 #ifdef CUB_DEFINE_RUNTIME_POLICIES
-    const merge_sort_policy active_policy = policy_getter();
+    const MergeSortPolicy active_policy = policy_getter();
 #else // CUB_DEFINE_RUNTIME_POLICIES
     using vsmem_adapted_agents = merge_sort_vsmem_helper_t<
       decltype(policy_getter),
@@ -507,7 +507,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
       CompareOpT,
       KeyT,
       ValueT>;
-  constexpr merge_sort_policy active_policy = vsmem_adapted_agents::policy;
+  constexpr MergeSortPolicy active_policy = vsmem_adapted_agents::policy;
 #endif // CUB_DEFINE_RUNTIME_POLICIES
 
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)

--- a/cub/cub/device/dispatch/dispatch_merge_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge_sort.cuh
@@ -111,7 +111,7 @@ template <typename KeyInputIteratorT,
           typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY,
           typename KeyT                  = cub::detail::it_value_t<KeyIteratorT>,
           typename ValueT                = cub::detail::it_value_t<ValueIteratorT>>
-struct DispatchMergeSort
+struct CCCL_DEPRECATED_BECAUSE("Please use DeviceMergeSort") DispatchMergeSort
 {
   /// Whether or not there are values to be trucked along with keys
   static constexpr bool KEYS_ONLY = ::cuda::std::is_same_v<ValueT, NullType>;

--- a/cub/cub/device/dispatch/dispatch_merge_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge_sort.cuh
@@ -216,7 +216,7 @@ public:
       CompareOpT,
       KeyT,
       ValueT>::policy;
-    constexpr auto tile_size = policy.block_threads * policy.items_per_thread;
+    constexpr auto tile_size = policy.threads_per_block * policy.items_per_thread;
     const auto num_tiles     = ::cuda::ceil_div(num_items, tile_size);
 
     const auto merge_partitions_size         = static_cast<size_t>(1 + num_tiles) * sizeof(OffsetT);
@@ -511,7 +511,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
                  }))
 #endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
 
-    const auto tile_size = active_policy.block_threads * active_policy.items_per_thread;
+    const auto tile_size = active_policy.threads_per_block * active_policy.items_per_thread;
     const auto num_tiles = ::cuda::ceil_div(num_items, tile_size);
 
     const auto merge_partitions_size         = static_cast<size_t>(1 + num_tiles) * sizeof(OffsetT);

--- a/cub/cub/device/dispatch/dispatch_merge_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge_sort.cuh
@@ -195,7 +195,7 @@ private:
 public:
   // Invocation
   template <typename ActivePolicyT>
-  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t Invoke([[maybe_unused]] ActivePolicyT policy = {})
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t Invoke([[maybe_unused]] ActivePolicyT = {})
   {
     if (num_items == 0)
     {
@@ -206,18 +206,18 @@ public:
       return cudaSuccess;
     }
 
-    constexpr auto tile_size =
-      detail::merge_sort::merge_sort_vsmem_helper_t<
-        policy_getter<ActivePolicyT>,
-        KeyInputIteratorT,
-        ValueInputIteratorT,
-        KeyIteratorT,
-        ValueIteratorT,
-        OffsetT,
-        CompareOpT,
-        KeyT,
-        ValueT>::policy.items_per_tile();
-    const auto num_tiles = ::cuda::ceil_div(num_items, tile_size);
+    static constexpr auto policy = detail::merge_sort::merge_sort_vsmem_helper_t<
+      policy_getter<ActivePolicyT>,
+      KeyInputIteratorT,
+      ValueInputIteratorT,
+      KeyIteratorT,
+      ValueIteratorT,
+      OffsetT,
+      CompareOpT,
+      KeyT,
+      ValueT>::policy;
+    constexpr auto tile_size = policy.block_threads * policy.items_per_thread;
+    const auto num_tiles     = ::cuda::ceil_div(num_items, tile_size);
 
     const auto merge_partitions_size         = static_cast<size_t>(1 + num_tiles) * sizeof(OffsetT);
     const auto temporary_keys_storage_size   = static_cast<size_t>(num_items * kernel_source.KeySize());
@@ -279,17 +279,7 @@ public:
     auto keys_buffer      = static_cast<KeyT*>(allocations[1]);
     auto items_buffer     = static_cast<ValueT*>(allocations[2]);
 
-    const int threads_per_block =
-      detail::merge_sort::merge_sort_vsmem_helper_t<
-        policy_getter<ActivePolicyT>,
-        KeyInputIteratorT,
-        ValueInputIteratorT,
-        KeyIteratorT,
-        ValueIteratorT,
-        OffsetT,
-        CompareOpT,
-        KeyT,
-        ValueT>::policy.threads_per_block;
+    const int threads_per_block = policy.threads_per_block;
 
     // Invoke DeviceMergeSortBlockSortKernel
     launcher_factory(

--- a/cub/cub/device/dispatch/kernels/kernel_merge_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_merge_sort.cuh
@@ -75,7 +75,7 @@ class merge_sort_vsmem_helper_impl
     (max_default_size > max_smem_per_block) && (max_fallback_size <= max_smem_per_block);
 
 public:
-  static constexpr merge_sort_policy policy = uses_fallback_policy ? FallbackPolicyGetter{}() : DefaultPolicyGetter{}();
+  static constexpr MergeSortPolicy policy = uses_fallback_policy ? FallbackPolicyGetter{}() : DefaultPolicyGetter{}();
   using block_sort_agent_t =
     ::cuda::std::_If<uses_fallback_policy, fallback_block_sort_agent_t, default_block_sort_agent_t>;
   using merge_agent_t = ::cuda::std::_If<uses_fallback_policy, fallback_merge_agent_t, default_merge_agent_t>;
@@ -166,9 +166,9 @@ __launch_bounds__(
     KeyT,
     ValueT>;
 
-  static constexpr merge_sort_policy active_policy = vsmem_adapted_agents::policy;
-  using agent_block_sort_t                         = typename vsmem_adapted_agents::block_sort_agent_t;
-  using vsmem_helper_t                             = vsmem_helper_impl<agent_block_sort_t>;
+  static constexpr MergeSortPolicy active_policy = vsmem_adapted_agents::policy;
+  using agent_block_sort_t                       = typename vsmem_adapted_agents::block_sort_agent_t;
+  using vsmem_helper_t                           = vsmem_helper_impl<agent_block_sort_t>;
 
   // Static shared memory allocation
   __shared__ typename vsmem_helper_t::static_temp_storage_t static_temp_storage;
@@ -267,9 +267,9 @@ __launch_bounds__(
     KeyT,
     ValueT>;
 
-  static constexpr merge_sort_policy active_policy = vsmem_adapted_agents::policy;
-  using agent_merge_t                              = typename vsmem_adapted_agents::merge_agent_t;
-  using vsmem_helper_t                             = vsmem_helper_impl<agent_merge_t>;
+  static constexpr MergeSortPolicy active_policy = vsmem_adapted_agents::policy;
+  using agent_merge_t                            = typename vsmem_adapted_agents::merge_agent_t;
+  using vsmem_helper_t                           = vsmem_helper_impl<agent_merge_t>;
 
   // Static shared memory allocation
   __shared__ typename vsmem_helper_t::static_temp_storage_t static_temp_storage;

--- a/cub/cub/device/dispatch/kernels/kernel_merge_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_merge_sort.cuh
@@ -30,7 +30,7 @@ struct fallback_policy_getter
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HOST_DEVICE_API _CCCL_FORCEINLINE constexpr auto operator()() const
   {
-    merge_sort_policy policy = DefaultPolicyGetter{}();
+    MergeSortPolicy policy   = DefaultPolicyGetter{}();
     policy.threads_per_block = 64;
     policy.items_per_thread  = 1;
     return policy;

--- a/cub/cub/device/dispatch/tuning/tuning_merge_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_merge_sort.cuh
@@ -41,6 +41,41 @@ struct AgentMergeSortPolicy
   static constexpr cub::BlockStoreAlgorithm STORE_ALGORITHM = StoreAlgorithm;
 };
 
+struct MergeSortPolicy
+{
+  int threads_per_block;
+  int items_per_thread;
+  BlockLoadAlgorithm load_algorithm;
+  CacheLoadModifier load_modifier;
+  BlockStoreAlgorithm store_algorithm;
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr int items_per_tile() const
+  {
+    return threads_per_block * items_per_thread;
+  }
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const MergeSortPolicy& lhs, const MergeSortPolicy& rhs)
+  {
+    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
+        && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
+        && lhs.store_algorithm == rhs.store_algorithm;
+  }
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool operator!=(const MergeSortPolicy& lhs, const MergeSortPolicy& rhs)
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const MergeSortPolicy& p)
+  {
+    return os << "MergeSortPolicy { .threads_per_block = " << p.threads_per_block
+              << ", .items_per_thread = " << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm
+              << ", .load_modifier = " << p.load_modifier << ", .store_algorithm = " << p.store_algorithm << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
 namespace detail::merge_sort
 {
 // TODO(bgruber): drop in CCCL 4.0 when we remove all public CUB dispatchers
@@ -87,56 +122,19 @@ struct policy_hub
   using MaxPolicy = Policy600;
 };
 
-struct merge_sort_policy
-{
-  int threads_per_block;
-  int items_per_thread;
-  BlockLoadAlgorithm load_algorithm;
-  CacheLoadModifier load_modifier;
-  BlockStoreAlgorithm store_algorithm;
-
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr int items_per_tile() const
-  {
-    return threads_per_block * items_per_thread;
-  }
-
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const merge_sort_policy& lhs, const merge_sort_policy& rhs)
-  {
-    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
-        && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
-        && lhs.store_algorithm == rhs.store_algorithm;
-  }
-
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const merge_sort_policy& lhs, const merge_sort_policy& rhs)
-  {
-    return !(lhs == rhs);
-  }
-
-#if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const merge_sort_policy& p)
-  {
-    return os << "merge_sort_policy { .threads_per_block = " << p.threads_per_block
-              << ", .items_per_thread = " << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm
-              << ", .load_modifier = " << p.load_modifier << ", .store_algorithm = " << p.store_algorithm << " }";
-  }
-#endif // _CCCL_HOSTED()
-};
-
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>
-concept merge_sort_policy_selector = policy_selector<T, merge_sort_policy>;
+concept merge_sort_policy_selector = policy_selector<T, MergeSortPolicy>;
 #endif // _CCCL_HAS_CONCEPTS()
 
 struct policy_selector
 {
   int key_size;
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const -> merge_sort_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const -> MergeSortPolicy
   {
     // from SM60
-    return merge_sort_policy{
+    return MergeSortPolicy{
       256,
       detail::nominal_4B_items_to_items(17, key_size),
       BLOCK_LOAD_WARP_TRANSPOSE,
@@ -153,7 +151,7 @@ template <typename KeyIteratorT>
 struct policy_selector_from_types
 {
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
-    -> merge_sort_policy
+    -> MergeSortPolicy
   {
     return policy_selector{int{sizeof(it_value_t<KeyIteratorT>)}}(cc);
   }
@@ -164,11 +162,11 @@ template <typename PolicyHub>
 struct policy_selector_from_hub
 {
   // this is only called in device code, so we can ignore the cc parameter
-  _CCCL_DEVICE_API constexpr auto operator()(::cuda::compute_capability /*cc*/) const -> merge_sort_policy
+  _CCCL_DEVICE_API constexpr auto operator()(::cuda::compute_capability /*cc*/) const -> MergeSortPolicy
   {
     using ap = typename PolicyHub::MaxPolicy::ActivePolicy;
     using mp = typename ap::MergeSortPolicy;
-    return merge_sort_policy{
+    return MergeSortPolicy{
       mp::BLOCK_THREADS, mp::ITEMS_PER_THREAD, mp::LOAD_ALGORITHM, mp::LOAD_MODIFIER, mp::STORE_ALGORITHM};
   }
 };

--- a/cub/cub/device/dispatch/tuning/tuning_merge_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_merge_sort.cuh
@@ -50,14 +50,16 @@ struct MergeSortPolicy
   CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
   BlockStoreAlgorithm store_algorithm; //!< The @ref BlockStoreAlgorithm used for storing items to global memory
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const MergeSortPolicy& lhs, const MergeSortPolicy& rhs)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const MergeSortPolicy& lhs, const MergeSortPolicy& rhs)
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
         && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
         && lhs.store_algorithm == rhs.store_algorithm;
   }
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool operator!=(const MergeSortPolicy& lhs, const MergeSortPolicy& rhs)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const MergeSortPolicy& lhs, const MergeSortPolicy& rhs)
   {
     return !(lhs == rhs);
   }
@@ -146,8 +148,7 @@ static_assert(merge_sort_policy_selector<policy_selector>);
 template <typename KeyIteratorT>
 struct policy_selector_from_types
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
-    -> MergeSortPolicy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> MergeSortPolicy
   {
     return policy_selector{int{sizeof(it_value_t<KeyIteratorT>)}}(cc);
   }

--- a/cub/cub/device/dispatch/tuning/tuning_merge_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_merge_sort.cuh
@@ -41,18 +41,14 @@ struct AgentMergeSortPolicy
   static constexpr cub::BlockStoreAlgorithm STORE_ALGORITHM = StoreAlgorithm;
 };
 
+//! The tuning policy for all algorithms in @ref DeviceMergeSort.
 struct MergeSortPolicy
 {
-  int threads_per_block;
-  int items_per_thread;
-  BlockLoadAlgorithm load_algorithm;
-  CacheLoadModifier load_modifier;
-  BlockStoreAlgorithm store_algorithm;
-
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr int items_per_tile() const
-  {
-    return threads_per_block * items_per_thread;
-  }
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int items_per_thread; //!< Number of items processed per thread
+  BlockLoadAlgorithm load_algorithm; //!< The @ref BlockLoadAlgorithm used for loading items from global memory
+  CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
+  BlockStoreAlgorithm store_algorithm; //!< The @ref BlockStoreAlgorithm used for storing items to global memory
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const MergeSortPolicy& lhs, const MergeSortPolicy& rhs)
   {

--- a/cub/test/catch2_test_device_merge_sort_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_merge_sort_custom_policy_hub.cu
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// TODO(bgruber): drop this test with CCCL 4.0 when we drop the merge sort dispatcher
+
+// disable deprecation warnings for DispatchMergeSort
+#define CCCL_IGNORE_DEPRECATED_API
+
 #include "insert_nested_NVTX_range_guard.h"
 
 #include <cub/device/device_merge_sort.cuh>
@@ -13,8 +18,6 @@
 #include <c2h/catch2_test_helper.h>
 
 using namespace cub;
-
-// TODO(bgruber): drop this test with CCCL 4.0 when we drop the merge sort dispatcher after publishing the tuning API
 
 template <typename KeyIteratorT>
 struct my_policy_hub

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -35,8 +35,7 @@ namespace stdexec = cuda::std::execution;
 template <int ThreadsPerBlock>
 struct merge_sort_tuning
 {
-  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const
-    -> cub::MergeSortPolicy
+  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::MergeSortPolicy
   {
     return {ThreadsPerBlock, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_STORE_DIRECT};
   }

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -558,3 +558,29 @@ C2H_TEST("DeviceMergeSort::StableSortKeysCopy can be tuned", "[merge_sort][devic
 }
 
 #endif // TEST_LAUNCH != 1
+
+C2H_TEST("MergeSortPolicy", "[merge_sort][device]")
+{
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::MergeSortPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::MergeSortPolicy>);
+
+  // aggregate init
+  constexpr auto p1 = cub::MergeSortPolicy{
+    256,
+    11,
+    cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+    cub::CacheLoadModifier::LOAD_DEFAULT,
+    cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT};
+
+  // designated init
+  constexpr auto p2 = cub::MergeSortPolicy{
+    .block_threads    = 256,
+    .items_per_thread = 11,
+    .load_algorithm   = cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+    .load_modifier    = cub::CacheLoadModifier::LOAD_DEFAULT,
+    .store_algorithm  = cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT};
+
+  // comparison
+  STATIC_REQUIRE(p1 == p2);
+  STATIC_REQUIRE_FALSE(p1 != p2);
+}

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -36,7 +36,7 @@ template <int ThreadsPerBlock>
 struct merge_sort_tuning
 {
   _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::merge_sort::merge_sort_policy
+    -> cub::MergeSortPolicy
   {
     return {ThreadsPerBlock, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_STORE_DIRECT};
   }

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -559,6 +559,7 @@ C2H_TEST("DeviceMergeSort::StableSortKeysCopy can be tuned", "[merge_sort][devic
 
 #endif // TEST_LAUNCH != 1
 
+#if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
 C2H_TEST("MergeSortPolicy", "[merge_sort][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::MergeSortPolicy>);
@@ -572,7 +573,7 @@ C2H_TEST("MergeSortPolicy", "[merge_sort][device]")
     cub::CacheLoadModifier::LOAD_DEFAULT,
     cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT};
 
-#if _CCCL_STD_VER >= 2020
+#  if _CCCL_STD_VER >= 2020
   // designated init
   constexpr auto p2 = cub::MergeSortPolicy{
     .block_threads    = 256,
@@ -580,11 +581,12 @@ C2H_TEST("MergeSortPolicy", "[merge_sort][device]")
     .load_algorithm   = cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
     .load_modifier    = cub::CacheLoadModifier::LOAD_DEFAULT,
     .store_algorithm  = cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT};
-#else // _CCCL_STD_VER >= 2020
+#  else // _CCCL_STD_VER >= 2020
   constexpr auto p2 = p1;
-#endif // _CCCL_STD_VER >= 2020
+#  endif // _CCCL_STD_VER >= 2020
 
   // comparison
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 }
+#endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -572,6 +572,7 @@ C2H_TEST("MergeSortPolicy", "[merge_sort][device]")
     cub::CacheLoadModifier::LOAD_DEFAULT,
     cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT};
 
+#if _CCCL_STD_VER >= 2020
   // designated init
   constexpr auto p2 = cub::MergeSortPolicy{
     .block_threads    = 256,
@@ -579,6 +580,9 @@ C2H_TEST("MergeSortPolicy", "[merge_sort][device]")
     .load_algorithm   = cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
     .load_modifier    = cub::CacheLoadModifier::LOAD_DEFAULT,
     .store_algorithm  = cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT};
+#else // _CCCL_STD_VER >= 2020
+  constexpr auto p2 = p1;
+#endif // _CCCL_STD_VER >= 2020
 
   // comparison
   STATIC_REQUIRE(p1 == p2);

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -576,11 +576,11 @@ C2H_TEST("MergeSortPolicy", "[merge_sort][device]")
 #  if _CCCL_STD_VER >= 2020
   // designated init
   constexpr auto p2 = cub::MergeSortPolicy{
-    .block_threads    = 256,
-    .items_per_thread = 11,
-    .load_algorithm   = cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
-    .load_modifier    = cub::CacheLoadModifier::LOAD_DEFAULT,
-    .store_algorithm  = cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT};
+    .threads_per_block = 256,
+    .items_per_thread  = 11,
+    .load_algorithm    = cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+    .load_modifier     = cub::CacheLoadModifier::LOAD_DEFAULT,
+    .store_algorithm   = cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT};
 #  else // _CCCL_STD_VER >= 2020
   constexpr auto p2 = p1;
 #  endif // _CCCL_STD_VER >= 2020

--- a/cub/test/catch2_test_device_merge_sort_env_api.cu
+++ b/cub/test/catch2_test_device_merge_sort_env_api.cu
@@ -7,6 +7,7 @@
 
 #include <thrust/device_vector.h>
 
+#include <cuda/__execution/tune.h>
 #include <cuda/devices>
 #include <cuda/stream>
 
@@ -200,6 +201,46 @@ C2H_TEST("cub::DeviceMergeSort::SortPairs env-based API with greater comparator"
 
   thrust::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
   thrust::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_keys == expected_keys);
+  REQUIRE(d_values == expected_values);
+}
+
+// example-begin sort-pairs-policy-selector
+struct MergeSortPolicySelector
+{
+  __host__ __device__ constexpr auto operator()(cuda::arch_id arch) const -> cub::MergeSortPolicy
+  {
+    return {.block_threads    = 256,
+            .items_per_thread = arch > cuda::arch_id::sm_90 ? 17 : 14,
+            .load_algorithm   = cub::BLOCK_LOAD_DIRECT,
+            .load_modifier    = cub::LOAD_DEFAULT,
+            .store_algorithm  = cub::BLOCK_STORE_DIRECT};
+  }
+};
+// example-end sort-pairs-policy-selector
+
+C2H_TEST("cub::DeviceMergeSort::SortPairs env-based API", "[merge_sort][env]")
+{
+  // example-begin sort-pairs-tuning
+  auto d_keys   = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
+  auto d_values = thrust::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
+
+  const auto error = cub::DeviceMergeSort::SortPairs(
+    d_keys.data(),
+    d_values.data(),
+    d_keys.size(),
+    cuda::std::less{},
+    cuda::execution::tune(MergeSortPolicySelector{})); // TODO(bgruber): make cuda::execution::__tune public
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceMergeSort::SortPairs failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  thrust::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
+  // example-end sort-pairs-tuning
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(d_keys == expected_keys);

--- a/cub/test/catch2_test_device_merge_sort_env_api.cu
+++ b/cub/test/catch2_test_device_merge_sort_env_api.cu
@@ -207,6 +207,8 @@ C2H_TEST("cub::DeviceMergeSort::SortPairs env-based API with greater comparator"
   REQUIRE(d_values == expected_values);
 }
 
+#if _CCCL_STD_VER >= 2020
+
 // example-begin sort-pairs-policy-selector
 struct MergeSortPolicySelector
 {
@@ -246,3 +248,5 @@ C2H_TEST("cub::DeviceMergeSort::SortPairs env-based API", "[merge_sort][env]")
   REQUIRE(d_keys == expected_keys);
   REQUIRE(d_values == expected_values);
 }
+
+#endif // _CCCL_STD_VER >= 2020

--- a/cub/test/catch2_test_device_merge_sort_env_api.cu
+++ b/cub/test/catch2_test_device_merge_sort_env_api.cu
@@ -232,7 +232,7 @@ C2H_TEST("cub::DeviceMergeSort::SortPairs env-based API", "[merge_sort][env]")
     d_values.data(),
     d_keys.size(),
     cuda::std::less{},
-    cuda::execution::tune(MergeSortPolicySelector{})); // TODO(bgruber): make cuda::execution::__tune public
+    cuda::execution::tune(MergeSortPolicySelector{}));
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceMergeSort::SortPairs failed with status: " << error << '\n';

--- a/cub/test/catch2_test_device_merge_sort_env_api.cu
+++ b/cub/test/catch2_test_device_merge_sort_env_api.cu
@@ -212,10 +212,10 @@ C2H_TEST("cub::DeviceMergeSort::SortPairs env-based API with greater comparator"
 // example-begin sort-pairs-policy-selector
 struct MergeSortPolicySelector
 {
-  __host__ __device__ constexpr auto operator()(cuda::arch_id arch) const -> cub::MergeSortPolicy
+  __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::MergeSortPolicy
   {
     return {.block_threads    = 256,
-            .items_per_thread = arch > cuda::arch_id::sm_90 ? 17 : 14,
+            .items_per_thread = cc > cuda::compute_capability{9, 0} ? 17 : 14,
             .load_algorithm   = cub::BLOCK_LOAD_DIRECT,
             .load_modifier    = cub::LOAD_DEFAULT,
             .store_algorithm  = cub::BLOCK_STORE_DIRECT};

--- a/cub/test/catch2_test_device_merge_sort_env_api.cu
+++ b/cub/test/catch2_test_device_merge_sort_env_api.cu
@@ -230,11 +230,7 @@ C2H_TEST("cub::DeviceMergeSort::SortPairs env-based API", "[merge_sort][env]")
   auto d_values = thrust::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
 
   const auto error = cub::DeviceMergeSort::SortPairs(
-    d_keys.data(),
-    d_values.data(),
-    d_keys.size(),
-    cuda::std::less{},
-    cuda::execution::tune(MergeSortPolicySelector{}));
+    d_keys.data(), d_values.data(), d_keys.size(), cuda::std::less{}, cuda::execution::tune(MergeSortPolicySelector{}));
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceMergeSort::SortPairs failed with status: " << error << '\n';

--- a/cub/test/catch2_test_device_merge_sort_env_api.cu
+++ b/cub/test/catch2_test_device_merge_sort_env_api.cu
@@ -214,11 +214,11 @@ struct MergeSortPolicySelector
 {
   __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::MergeSortPolicy
   {
-    return {.block_threads    = 256,
-            .items_per_thread = cc > cuda::compute_capability{9, 0} ? 17 : 14,
-            .load_algorithm   = cub::BLOCK_LOAD_DIRECT,
-            .load_modifier    = cub::LOAD_DEFAULT,
-            .store_algorithm  = cub::BLOCK_STORE_DIRECT};
+    return {.threads_per_block = 256,
+            .items_per_thread  = cc > cuda::compute_capability{9, 0} ? 17 : 14,
+            .load_algorithm    = cub::BLOCK_LOAD_DIRECT,
+            .load_modifier     = cub::LOAD_DEFAULT,
+            .store_algorithm   = cub::BLOCK_STORE_DIRECT};
   }
 };
 // example-end sort-pairs-policy-selector

--- a/cub/test/catch2_test_device_merge_sort_env_api.cu
+++ b/cub/test/catch2_test_device_merge_sort_env_api.cu
@@ -223,7 +223,7 @@ struct MergeSortPolicySelector
 };
 // example-end sort-pairs-policy-selector
 
-C2H_TEST("cub::DeviceMergeSort::SortPairs env-based API", "[merge_sort][env]")
+C2H_TEST("cub::DeviceMergeSort::SortPairs env-based API with tuning", "[merge_sort][env]")
 {
   // example-begin sort-pairs-tuning
   auto d_keys   = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};


### PR DESCRIPTION
Preceding work:

- [x] Ideally, merge before: #8623
- [x] Merge before: #8652
- [x] Merge first: #8835
- [x] Merge first: #8836
- [x] #7671 is sufficiently approved to proceed with this PR. The remaining discussion can continue here.

Fixes: #8574

## New public entities for `cub::DeviceMergeSort`

| Entity | Data Members |
|--------|--------------|
| `cub::MergeSortPolicy` | `threads_per_block`, `items_per_thread`, `load_algorithm`, `load_modifier`, `store_algorithm` |
