### PR TITLE
Workaround `subrange.h`  nvcc+clang bug

### DIFF
--- a/libcudacxx/include/cuda/std/__fwd/subrange.h
+++ b/libcudacxx/include/cuda/std/__fwd/subrange.h
@@ -32,18 +32,24 @@ enum class _CCCL_TYPE_VISIBILITY_DEFAULT subrange_kind : bool
   sized
 };
 
+// nvcc+clang bug: ternary expression mixed with <> in a default template argument
+// "mismatched delimiters in default argument expression"
+template <class _Iter, class _Sent>
+inline constexpr subrange_kind __default_subrange_kind =
+  sized_sentinel_for<_Sent, _Iter> ? subrange_kind::sized : subrange_kind::unsized;
+
 #if _CCCL_HAS_CONCEPTS()
 template <input_or_output_iterator _Iter,
           sentinel_for<_Iter> _Sent = _Iter,
-          subrange_kind _Kind       = sized_sentinel_for<_Sent, _Iter> ? subrange_kind::sized : subrange_kind::unsized>
+          subrange_kind _Kind       = __default_subrange_kind<_Iter, _Sent>>
   requires(_Kind == subrange_kind::sized || !sized_sentinel_for<_Sent, _Iter>)
 class _CCCL_TYPE_VISIBILITY_DEFAULT subrange;
 #else // ^^^ C++20 ^^^ / vvv C++17 vvv
 template <class _Iter,
-          class _Sent         = _Iter,
-          subrange_kind _Kind = sized_sentinel_for<_Sent, _Iter> ? subrange_kind::sized : subrange_kind::unsized,
-          enable_if_t<input_or_output_iterator<_Iter>, int>                                      = 0,
-          enable_if_t<sentinel_for<_Sent, _Iter>, int>                                           = 0,
+          class _Sent                                       = _Iter,
+          subrange_kind _Kind                               = __default_subrange_kind<_Iter, _Sent>,
+          enable_if_t<input_or_output_iterator<_Iter>, int> = 0,
+          enable_if_t<sentinel_for<_Sent, _Iter>, int>      = 0,
           enable_if_t<(_Kind == subrange_kind::sized || !sized_sentinel_for<_Sent, _Iter>), int> = 0>
 class _CCCL_TYPE_VISIBILITY_DEFAULT subrange;
 #endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^


### PR DESCRIPTION
## Description

Refactor default template argument for subrange class to resolve nvcc+clang bug.