### PR TITLE
Add B200 tuning for warpspeed_scan 

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -943,6 +943,11 @@ struct policy_selector
             // wrps_4.lbi_2.ipt_96 ()  1.082511  0.929516  1.091523  1.264033
             return scan_warpspeed_policy{4, 2, 96 - 1};
           case 4:
+            if (input_type == type_t::float32)
+            {
+              // wrps_4.lbi_3.ipt_88 ()  1.047200  1.002119  1.042654  1.081102
+              return scan_warpspeed_policy{4, 3, 88 - 1};
+            }
             // wrps_4.lbi_3.ipt_80 ()  1.019078  0.999708  1.017346  1.052592
             return scan_warpspeed_policy{4, 3, 80 - 1};
           case 8:

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -940,8 +940,14 @@ struct policy_selector
             // wrps_3.lbi_4.ipt_96 ()  1.454824  1.247212  1.450590  1.560418
             return scan_warpspeed_policy{3, 4, 96 - 1};
           case 2:
-            // wrps_6.lbi_2.ipt_96 ()  1.167633  1.167633  1.167633  1.167633
-            return scan_warpspeed_policy{6, 2, 96 - 1};
+            // wrps_4.lbi_2.ipt_96 ()  1.082511  0.929516  1.091523  1.264033
+            return scan_warpspeed_policy{4, 2, 96 - 1};
+          case 4:
+            // wrps_4.lbi_3.ipt_80 ()  1.019078  0.999708  1.017346  1.052592
+            return scan_warpspeed_policy{4, 3, 80 - 1};
+          case 8:
+            // wrps_2.lbi_5.ipt_88 ()  1.085781   1.0  1.079245  1.103545
+            return scan_warpspeed_policy{2, 5, 88 - 1};
 
             // TODO(bgruber): tune for more data types
           default:

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -940,7 +940,7 @@ struct policy_selector
             // wrps_3.lbi_4.ipt_96 ()  1.454824  1.247212  1.450590  1.560418
             return scan_warpspeed_policy{3, 4, 96 - 1};
           case 2:
-	    // clang-format off
+            // clang-format off
 // TODO(bgruber): we found this tuning but it regresses large problems, we should revisit this
 //            // wrps_4.lbi_2.ipt_96 ()  1.082511  0.929516  1.091523  1.264033
 //            return scan_warpspeed_policy{4, 2, 96 - 1};
@@ -950,8 +950,8 @@ struct policy_selector
 //|   I16   |      I64      |      2^28      | 224.318 us |       0.37% | 233.381 us |       0.46% |     9.063 us |   4.04% |   SLOW   |
 //|   I16   |      I64      |      2^32      |   3.238 ms |       0.53% |   3.429 ms |       0.53% |   191.299 us |   5.91% |   SLOW   |
             // clang-format on
-	    // wrps_6.lbi_2.ipt_96 ()  1.167633  1.167633  1.167633  1.167633
-	    return scan_warpspeed_policy{6, 2, 96 - 1};
+            // wrps_6.lbi_2.ipt_96 ()  1.167633  1.167633  1.167633  1.167633
+            return scan_warpspeed_policy{6, 2, 96 - 1};
           case 4:
             if (input_type == type_t::float32)
             {

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -927,18 +927,6 @@ struct policy_selector
   {
     if (arch >= ::cuda::arch_id::sm_120)
     {
-      // tunings from cub.bench.scan.exclusive.sum.warpspeed[T{ct}=I128, OffsetT{ct}=I64] on B200
-      if (operation_t == op_kind_t::plus && accum_is_primitive_or_trivially_copy_constructible)
-      {
-        switch (input_value_size)
-        {
-          case 16:
-            // wrps_5.lbi_8.ipt_16 (b200-077_i128/3.db)  1.159883  1.000000  1.143709  1.275821
-            return scan_warpspeed_policy{5, 8, 16 - 1};
-          default:
-            break;
-        }
-      }
       return get_sm120_fallback_warpspeed_policy();
     }
     if (arch >= ::cuda::arch_id::sm_100)

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -939,9 +939,9 @@ struct policy_selector
           case 1:
             // wrps_3.lbi_4.ipt_96 ()  1.454824  1.247212  1.450590  1.560418
             return scan_warpspeed_policy{3, 4, 96 - 1};
-            // clang-format off
+          case 2:
+	    // clang-format off
 // TODO(bgruber): we found this tuning but it regresses large problems, we should revisit this
-//         case 2:
 //            // wrps_4.lbi_2.ipt_96 ()  1.082511  0.929516  1.091523  1.264033
 //            return scan_warpspeed_policy{4, 2, 96 - 1};
 //|   I16   |      I64      |      2^16      |  17.304 us |       1.07% |  15.244 us |       0.77% |    -2.060 us | -11.91% |   FAST   |

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -937,8 +937,8 @@ struct policy_selector
         switch (input_value_size)
         {
           case 1:
-            // wrps_4.lbi_8.ipt_160 ()  1.264254  1.264254  1.264254  1.264254
-            return scan_warpspeed_policy{4, 8, 160 - 1};
+            // wrps_3.lbi_4.ipt_96 ()  1.454824  1.247212  1.450590  1.560418
+            return scan_warpspeed_policy{3, 4, 96 - 1};
           case 2:
             // wrps_6.lbi_2.ipt_96 ()  1.167633  1.167633  1.167633  1.167633
             return scan_warpspeed_policy{6, 2, 96 - 1};

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -951,9 +951,17 @@ struct policy_selector
           case 1:
             // wrps_3.lbi_4.ipt_96 ()  1.454824  1.247212  1.450590  1.560418
             return scan_warpspeed_policy{3, 4, 96 - 1};
-          case 2:
-            // wrps_4.lbi_2.ipt_96 ()  1.082511  0.929516  1.091523  1.264033
-            return scan_warpspeed_policy{4, 2, 96 - 1};
+            // clang-format off
+// TODO(bgruber): we found this tuning but it regresses large problems, we should revisit this
+//         case 2:
+//            // wrps_4.lbi_2.ipt_96 ()  1.082511  0.929516  1.091523  1.264033
+//            return scan_warpspeed_policy{4, 2, 96 - 1};
+//|   I16   |      I64      |      2^16      |  17.304 us |       1.07% |  15.244 us |       0.77% |    -2.060 us | -11.91% |   FAST   |
+//|   I16   |      I64      |      2^20      |  19.466 us |       1.21% |  17.266 us |       2.93% |    -2.200 us | -11.30% |   FAST   |
+//|   I16   |      I64      |      2^24      |  39.565 us |       2.46% |  35.835 us |       4.25% |    -3.730 us |  -9.43% |   FAST   |
+//|   I16   |      I64      |      2^28      | 224.318 us |       0.37% | 233.381 us |       0.46% |     9.063 us |   4.04% |   SLOW   |
+//|   I16   |      I64      |      2^32      |   3.238 ms |       0.53% |   3.429 ms |       0.53% |   191.299 us |   5.91% |   SLOW   |
+            // clang-format on
           case 4:
             if (input_type == type_t::float32)
             {

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -950,6 +950,7 @@ struct policy_selector
 //|   I16   |      I64      |      2^28      | 224.318 us |       0.37% | 233.381 us |       0.46% |     9.063 us |   4.04% |   SLOW   |
 //|   I16   |      I64      |      2^32      |   3.238 ms |       0.53% |   3.429 ms |       0.53% |   191.299 us |   5.91% |   SLOW   |
             // clang-format on
+	    return scan_warpspeed_policy{6, 2, 96 - 1};
           case 4:
             if (input_type == type_t::float32)
             {

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -927,6 +927,18 @@ struct policy_selector
   {
     if (arch >= ::cuda::arch_id::sm_120)
     {
+      // tunings from cub.bench.scan.exclusive.sum.warpspeed[T{ct}=I128, OffsetT{ct}=I64] on B200
+      if (operation_t == op_kind_t::plus && accum_is_primitive_or_trivially_copy_constructible)
+      {
+        switch (input_value_size)
+        {
+          case 16:
+            // wrps_5.lbi_8.ipt_16 (b200-077_i128/3.db)  1.159883  1.000000  1.143709  1.275821
+            return scan_warpspeed_policy{5, 8, 16 - 1};
+          default:
+            break;
+        }
+      }
       return get_sm120_fallback_warpspeed_policy();
     }
     if (arch >= ::cuda::arch_id::sm_100)
@@ -953,7 +965,9 @@ struct policy_selector
           case 8:
             // wrps_2.lbi_5.ipt_88 ()  1.085781   1.0  1.079245  1.103545
             return scan_warpspeed_policy{2, 5, 88 - 1};
-
+          case 16:
+            // wrps_5.lbi_8.ipt_16 ()  1.159883  1.000000  1.143709  1.275821
+            return scan_warpspeed_policy{5, 8, 16 - 1};
             // TODO(bgruber): tune for more data types
           default:
             break;

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -950,6 +950,7 @@ struct policy_selector
 //|   I16   |      I64      |      2^28      | 224.318 us |       0.37% | 233.381 us |       0.46% |     9.063 us |   4.04% |   SLOW   |
 //|   I16   |      I64      |      2^32      |   3.238 ms |       0.53% |   3.429 ms |       0.53% |   191.299 us |   5.91% |   SLOW   |
             // clang-format on
+	    // wrps_6.lbi_2.ipt_96 ()  1.167633  1.167633  1.167633  1.167633
 	    return scan_warpspeed_policy{6, 2, 96 - 1};
           case 4:
             if (input_type == type_t::float32)


### PR DESCRIPTION
Adds b200 tunings for warpspeed scan.

Verification results for `i8` (will post for the other CTs as soon as I get my hands on a functioning B200 - last one I fetched had a bogus driver ended up wasting my time)

DO NOT MERGE BEFORE VERIFIED WITH A B200 BENCH DIFF


**important**:  @bernhardmgruber  given that i32 doesn't gain much but f32 does should i constrain `case 2` with an embeded ` if (input_type == type_t::float32 && accum_type == type_t::float32)` or sth?


<img width="3586" height="2106" alt="image" src="https://github.com/user-attachments/assets/d578881a-f392-4d57-a250-876957d24051" />

Fixes: #8348
