### PR TITLE
Add SegmentedScan env overloads (separate overloads)

### DIFF
--- a/cub/cub/device/device_segmented_scan.cuh
+++ b/cub/cub/device/device_segmented_scan.cuh
@@ -475,6 +475,131 @@ struct DeviceSegmentedScan
   }
 
   //! @rst
+  //! Computes a device-wide segmented exclusive prefix sum with separate input and output offsets.
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! - Results are not deterministic for computation of prefix sum on floating-point types
+  //!   and may vary from run to run.
+  //! - Can use a specific stream or cuda memory resource through the ``env`` parameter.
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates an exclusive segmented prefix sum with separate input
+  //! and output offsets using a stream environment.
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_scan_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin exclusive-segmented-sum-separate-env
+  //!     :end-before: example-end exclusive-segmented-sum-separate-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading segmented scan inputs @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Random-access output iterator type for writing segmented scan outputs @iterator
+  //!
+  //! @tparam BeginOffsetIteratorInputT
+  //!   **[inferred]** Random-access input iterator type for reading segment beginning offsets in the input data
+  //!   sequence @iterator
+  //!
+  //! @tparam EndOffsetIteratorInputT
+  //!   **[inferred]** Random-access input iterator type for reading segment ending offsets in the input data sequence
+  //!   @iterator
+  //!
+  //! @tparam BeginOffsetIteratorOutputT
+  //!   **[inferred]** Random-access input iterator type for reading segment beginning offsets in the output sequence
+  //!   @iterator
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Execution environment type. Default is ``cuda::std::execution::env<>``.
+  //!
+  //! @param[in] d_in
+  //!   Random-access iterator to the input sequence of data items
+  //!
+  //! @param[out] d_out
+  //!   Random-access iterator to the output sequence of data items
+  //!
+  //! @param[in] d_in_begin_offsets
+  //!   Random-access input iterator to the sequence of beginning offsets in the input data of length ``num_segments``
+  //!
+  //! @param[in] d_in_end_offsets
+  //!   Random-access input iterator to the sequence of ending offsets in the input data of length ``num_segments``
+  //!
+  //! @param[in] d_out_begin_offsets
+  //!   Random-access input iterator to the sequence of beginning offsets in the output data of length ``num_segments``
+  //!
+  //! @param[in] num_segments
+  //!   The number of segments that comprise the segmented prefix scan data.
+  //!
+  //! @param[in] env
+  //!   @rst
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  //!   @endrst
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename BeginOffsetIteratorInputT,
+            typename EndOffsetIteratorInputT,
+            typename BeginOffsetIteratorOutputT,
+            typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
+#ifdef _CCCL_DOXYGEN_INVOKED
+            void
+#else
+            ::cuda::std::execution::env<>
+#endif
+            >
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t ExclusiveSegmentedSum(
+    InputIteratorT d_in,
+    OutputIteratorT d_out,
+    BeginOffsetIteratorInputT d_in_begin_offsets,
+    EndOffsetIteratorInputT d_in_end_offsets,
+    BeginOffsetIteratorOutputT d_out_begin_offsets,
+    ::cuda::std::int64_t num_segments,
+    EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSegmentedScan::ExclusiveSegmentedSum");
+
+    using offset_t =
+      detail::common_iterator_value_t<BeginOffsetIteratorInputT, EndOffsetIteratorInputT, BeginOffsetIteratorOutputT>;
+    static_assert(::cuda::std::is_integral_v<offset_t>, "Offset iterator value type should be integral.");
+
+    using scan_op_t = ::cuda::std::plus<>;
+    scan_op_t scan_op{};
+
+    using init_value_t = cub::detail::it_value_t<InputIteratorT>;
+    init_value_t init_value{};
+
+    return detail::dispatch_with_env(
+      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+        return cub::detail::segmented_scan::dispatch_segmented_scan<
+          InputIteratorT,
+          OutputIteratorT,
+          BeginOffsetIteratorInputT,
+          EndOffsetIteratorInputT,
+          BeginOffsetIteratorOutputT,
+          scan_op_t,
+          detail::InputValue<init_value_t>>::
+          dispatch(
+            d_temp_storage,
+            temp_storage_bytes,
+            d_in,
+            d_out,
+            num_segments,
+            d_in_begin_offsets,
+            d_in_end_offsets,
+            d_out_begin_offsets,
+            scan_op,
+            detail::InputValue<init_value_t>(init_value),
+            stream);
+      });
+  }
+
+  //! @rst
   //! Computes a device-wide segmented exclusive prefix scan using the specified
   //! binary associative ``scan_op`` functor. The ``init_value`` value is applied as
   //! the initial value, and is assigned to the first element in each output segment.
@@ -890,6 +1015,145 @@ struct DeviceSegmentedScan
   }
 
   //! @rst
+  //! Computes a device-wide segmented exclusive prefix scan with separate input and output offsets
+  //! using the specified binary associative ``scan_op`` functor. The ``init_value`` value is applied as
+  //! the initial value, and is assigned to the first element in each output segment.
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! - Supports non-commutative scan operators.
+  //! - Results are not deterministic for pseudo-associative operators (e.g.,
+  //!   addition of floating-point types). Results for pseudo-associative
+  //!   operators may vary from run to run.
+  //! - Can use a specific stream or cuda memory resource through the ``env`` parameter.
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates an exclusive segmented prefix scan with separate input
+  //! and output offsets and a user-supplied initial value using a stream environment.
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_scan_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin exclusive-segmented-scan-separate-env
+  //!     :end-before: example-end exclusive-segmented-scan-separate-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading segmented scan inputs @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Random-access output iterator type for writing segmented scan outputs @iterator
+  //!
+  //! @tparam BeginOffsetIteratorInputT
+  //!   **[inferred]** Random-access input iterator type for reading segment beginning offsets in the input data
+  //!   sequence @iterator
+  //!
+  //! @tparam EndOffsetIteratorInputT
+  //!   **[inferred]** Random-access input iterator type for reading segment ending offsets in the input data sequence
+  //!   @iterator
+  //!
+  //! @tparam BeginOffsetIteratorOutputT
+  //!   **[inferred]** Random-access input iterator type for reading segment beginning offsets in the output sequence
+  //!   @iterator
+  //!
+  //! @tparam ScanOpT
+  //!   **[inferred]** Binary associative scan functor type having member `T operator()(const T &a, const T &b)`
+  //!
+  //! @tparam InitValueT
+  //!   **[inferred]** Type of the ``init_value``
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Execution environment type. Default is ``cuda::std::execution::env<>``.
+  //!
+  //! @param[in] d_in
+  //!   Random-access iterator to the input sequence of data items
+  //!
+  //! @param[out] d_out
+  //!   Random-access iterator to the output sequence of data items
+  //!
+  //! @param[in] d_in_begin_offsets
+  //!   Random-access input iterator to the sequence of beginning offsets in the input data of length ``num_segments``
+  //!
+  //! @param[in] d_in_end_offsets
+  //!   Random-access input iterator to the sequence of ending offsets in the input data of length ``num_segments``
+  //!
+  //! @param[in] d_out_begin_offsets
+  //!   Random-access input iterator to the sequence of beginning offsets in the output data of length ``num_segments``
+  //!
+  //! @param[in] num_segments
+  //!   The number of segments that comprise the segmented prefix scan data.
+  //!
+  //! @param[in] scan_op
+  //!   Binary associative scan functor
+  //!
+  //! @param[in] init_value
+  //!   Initial value to seed the exclusive scan for each segment in the output sequence
+  //!
+  //! @param[in] env
+  //!   @rst
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  //!   @endrst
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename BeginOffsetIteratorInputT,
+            typename EndOffsetIteratorInputT,
+            typename BeginOffsetIteratorOutputT,
+            typename ScanOpT,
+            typename InitValueT,
+            typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
+#ifdef _CCCL_DOXYGEN_INVOKED
+            void
+#else
+            ::cuda::std::execution::env<>
+#endif
+            >
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t ExclusiveSegmentedScan(
+    InputIteratorT d_in,
+    OutputIteratorT d_out,
+    BeginOffsetIteratorInputT d_in_begin_offsets,
+    EndOffsetIteratorInputT d_in_end_offsets,
+    BeginOffsetIteratorOutputT d_out_begin_offsets,
+    ::cuda::std::int64_t num_segments,
+    ScanOpT scan_op,
+    InitValueT init_value,
+    EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSegmentedScan::ExclusiveSegmentedScan");
+
+    using offset_t =
+      detail::common_iterator_value_t<BeginOffsetIteratorInputT, EndOffsetIteratorInputT, BeginOffsetIteratorOutputT>;
+    static_assert(::cuda::std::is_integral_v<offset_t>, "Offset iterator value type should be integral.");
+
+    return detail::dispatch_with_env(
+      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+        return cub::detail::segmented_scan::dispatch_segmented_scan<
+          InputIteratorT,
+          OutputIteratorT,
+          BeginOffsetIteratorInputT,
+          EndOffsetIteratorInputT,
+          BeginOffsetIteratorOutputT,
+          ScanOpT,
+          detail::InputValue<InitValueT>>::
+          dispatch(
+            d_temp_storage,
+            temp_storage_bytes,
+            d_in,
+            d_out,
+            num_segments,
+            d_in_begin_offsets,
+            d_in_end_offsets,
+            d_out_begin_offsets,
+            scan_op,
+            detail::InputValue<InitValueT>(init_value),
+            stream);
+      });
+  }
+
+  //! @rst
   //! Computes a device-wide segmented inclusive prefix sum.
   //!
   //! - Results are not deterministic for computation of prefix sum on floating-point types
@@ -1264,6 +1528,126 @@ struct DeviceSegmentedScan
                           scan_op,
                           NullType(),
                           stream);
+  }
+
+  //! @rst
+  //! Computes a device-wide segmented inclusive prefix sum with separate input and output offsets.
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! - Results are not deterministic for computation of prefix sum on floating-point types
+  //!   and may vary from run to run.
+  //! - Can use a specific stream or cuda memory resource through the ``env`` parameter.
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates an inclusive segmented prefix sum with separate input
+  //! and output offsets using a stream environment.
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_scan_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin inclusive-segmented-sum-separate-env
+  //!     :end-before: example-end inclusive-segmented-sum-separate-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading segmented scan inputs @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Random-access output iterator type for writing segmented scan outputs @iterator
+  //!
+  //! @tparam BeginOffsetIteratorInputT
+  //!   **[inferred]** Random-access input iterator type for reading segment beginning offsets in the input data
+  //!   sequence @iterator
+  //!
+  //! @tparam EndOffsetIteratorInputT
+  //!   **[inferred]** Random-access input iterator type for reading segment ending offsets in the input data sequence
+  //!   @iterator
+  //!
+  //! @tparam BeginOffsetIteratorOutputT
+  //!   **[inferred]** Random-access input iterator type for reading segment beginning offsets in the output sequence
+  //!   @iterator
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Execution environment type. Default is ``cuda::std::execution::env<>``.
+  //!
+  //! @param[in] d_in
+  //!   Random-access iterator to the input sequence of data items
+  //!
+  //! @param[out] d_out
+  //!   Random-access iterator to the output sequence of data items
+  //!
+  //! @param[in] d_in_begin_offsets
+  //!   Random-access input iterator to the sequence of beginning offsets in the input data of length ``num_segments``
+  //!
+  //! @param[in] d_in_end_offsets
+  //!   Random-access input iterator to the sequence of ending offsets in the input data of length ``num_segments``
+  //!
+  //! @param[in] d_out_begin_offsets
+  //!   Random-access input iterator to the sequence of beginning offsets in the output data of length ``num_segments``
+  //!
+  //! @param[in] num_segments
+  //!   The number of segments that comprise the segmented prefix scan data.
+  //!
+  //! @param[in] env
+  //!   @rst
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  //!   @endrst
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename BeginOffsetIteratorInputT,
+            typename EndOffsetIteratorInputT,
+            typename BeginOffsetIteratorOutputT,
+            typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
+#ifdef _CCCL_DOXYGEN_INVOKED
+            void
+#else
+            ::cuda::std::execution::env<>
+#endif
+            >
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t InclusiveSegmentedSum(
+    InputIteratorT d_in,
+    OutputIteratorT d_out,
+    BeginOffsetIteratorInputT d_in_begin_offsets,
+    EndOffsetIteratorInputT d_in_end_offsets,
+    BeginOffsetIteratorOutputT d_out_begin_offsets,
+    ::cuda::std::int64_t num_segments,
+    EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSegmentedScan::InclusiveSegmentedSum");
+
+    using offset_t =
+      detail::common_iterator_value_t<BeginOffsetIteratorInputT, EndOffsetIteratorInputT, BeginOffsetIteratorOutputT>;
+    static_assert(::cuda::std::is_integral_v<offset_t>, "Offset iterator value type should be integral.");
+
+    using scan_op_t = ::cuda::std::plus<>;
+    scan_op_t scan_op{};
+
+    return detail::dispatch_with_env(
+      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+        return cub::detail::segmented_scan::dispatch_segmented_scan<
+          InputIteratorT,
+          OutputIteratorT,
+          BeginOffsetIteratorInputT,
+          EndOffsetIteratorInputT,
+          BeginOffsetIteratorOutputT,
+          scan_op_t,
+          NullType>::dispatch(d_temp_storage,
+                              temp_storage_bytes,
+                              d_in,
+                              d_out,
+                              num_segments,
+                              d_in_begin_offsets,
+                              d_in_end_offsets,
+                              d_out_begin_offsets,
+                              scan_op,
+                              NullType(),
+                              stream);
+      });
   }
 
   //! @rst
@@ -1643,6 +2027,134 @@ struct DeviceSegmentedScan
                           scan_op,
                           NullType(),
                           stream);
+  }
+
+  //! @rst
+  //! Computes a device-wide segmented inclusive prefix scan with separate input and output offsets
+  //! using the specified binary associative ``scan_op`` functor.
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! - Supports non-commutative scan operators.
+  //! - Results are not deterministic for pseudo-associative operators (e.g.,
+  //!   addition of floating-point types). Results for pseudo-associative
+  //!   operators may vary from run to run.
+  //! - Can use a specific stream or cuda memory resource through the ``env`` parameter.
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates an inclusive segmented prefix scan with separate input
+  //! and output offsets and a user-supplied scan operator using a stream environment.
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_scan_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin inclusive-segmented-scan-separate-env
+  //!     :end-before: example-end inclusive-segmented-scan-separate-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading segmented scan inputs @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Random-access output iterator type for writing segmented scan outputs @iterator
+  //!
+  //! @tparam BeginOffsetIteratorInputT
+  //!   **[inferred]** Random-access input iterator type for reading segment beginning offsets in the input data
+  //!   sequence @iterator
+  //!
+  //! @tparam EndOffsetIteratorInputT
+  //!   **[inferred]** Random-access input iterator type for reading segment ending offsets in the input data sequence
+  //!   @iterator
+  //!
+  //! @tparam BeginOffsetIteratorOutputT
+  //!   **[inferred]** Random-access input iterator type for reading segment beginning offsets in the output sequence
+  //!   @iterator
+  //!
+  //! @tparam ScanOpT
+  //!   **[inferred]** Binary associative scan functor type having member `T operator()(const T &a, const T &b)`
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Execution environment type. Default is ``cuda::std::execution::env<>``.
+  //!
+  //! @param[in] d_in
+  //!   Random-access iterator to the input sequence of data items
+  //!
+  //! @param[out] d_out
+  //!   Random-access iterator to the output sequence of data items
+  //!
+  //! @param[in] d_in_begin_offsets
+  //!   Random-access input iterator to the sequence of beginning offsets in the input data of length ``num_segments``
+  //!
+  //! @param[in] d_in_end_offsets
+  //!   Random-access input iterator to the sequence of ending offsets in the input data of length ``num_segments``
+  //!
+  //! @param[in] d_out_begin_offsets
+  //!   Random-access input iterator to the sequence of beginning offsets in the output data of length ``num_segments``
+  //!
+  //! @param[in] num_segments
+  //!   The number of segments that comprise the segmented prefix scan data.
+  //!
+  //! @param[in] scan_op
+  //!   Binary associative scan functor
+  //!
+  //! @param[in] env
+  //!   @rst
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  //!   @endrst
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename BeginOffsetIteratorInputT,
+            typename EndOffsetIteratorInputT,
+            typename BeginOffsetIteratorOutputT,
+            typename ScanOpT,
+            typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
+#ifdef _CCCL_DOXYGEN_INVOKED
+            void
+#else
+            ::cuda::std::execution::env<>
+#endif
+            >
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t InclusiveSegmentedScan(
+    InputIteratorT d_in,
+    OutputIteratorT d_out,
+    BeginOffsetIteratorInputT d_in_begin_offsets,
+    EndOffsetIteratorInputT d_in_end_offsets,
+    BeginOffsetIteratorOutputT d_out_begin_offsets,
+    ::cuda::std::int64_t num_segments,
+    ScanOpT scan_op,
+    EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSegmentedScan::InclusiveSegmentedScan");
+
+    using offset_t =
+      detail::common_iterator_value_t<BeginOffsetIteratorInputT, EndOffsetIteratorInputT, BeginOffsetIteratorOutputT>;
+    static_assert(::cuda::std::is_integral_v<offset_t>, "Offset iterator value type should be integral.");
+
+    return detail::dispatch_with_env(
+      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+        return cub::detail::segmented_scan::dispatch_segmented_scan<
+          InputIteratorT,
+          OutputIteratorT,
+          BeginOffsetIteratorInputT,
+          EndOffsetIteratorInputT,
+          BeginOffsetIteratorOutputT,
+          ScanOpT,
+          NullType>::dispatch(d_temp_storage,
+                              temp_storage_bytes,
+                              d_in,
+                              d_out,
+                              num_segments,
+                              d_in_begin_offsets,
+                              d_in_end_offsets,
+                              d_out_begin_offsets,
+                              scan_op,
+                              NullType(),
+                              stream);
+      });
   }
 
   //! @rst
@@ -2059,6 +2571,149 @@ struct DeviceSegmentedScan
                                      scan_op,
                                      detail::InputValue<InitValueT>(init_value),
                                      stream);
+  }
+
+  //! @rst
+  //! Computes a device-wide segmented inclusive prefix scan with separate input and output offsets
+  //! using the specified binary associative ``scan_op`` functor. The result of applying the ``scan_op``
+  //! binary operator to ``init_value`` value and the first value in each input segment is assigned to
+  //! the first value of the corresponding output segment.
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! - Supports non-commutative scan operators.
+  //! - Results are not deterministic for pseudo-associative operators (e.g.,
+  //!   addition of floating-point types). Results for pseudo-associative
+  //!   operators may vary from run to run.
+  //! - Can use a specific stream or cuda memory resource through the ``env`` parameter.
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates an inclusive segmented prefix scan with separate input
+  //! and output offsets and a user-supplied initial value using a stream environment.
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_scan_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin inclusive-segmented-scan-init-separate-env
+  //!     :end-before: example-end inclusive-segmented-scan-init-separate-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading segmented scan inputs @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Random-access output iterator type for writing segmented scan outputs @iterator
+  //!
+  //! @tparam BeginOffsetIteratorInputT
+  //!   **[inferred]** Random-access input iterator type for reading segment beginning offsets in the input data
+  //!   sequence @iterator
+  //!
+  //! @tparam EndOffsetIteratorInputT
+  //!   **[inferred]** Random-access input iterator type for reading segment ending offsets in the input data sequence
+  //!   @iterator
+  //!
+  //! @tparam BeginOffsetIteratorOutputT
+  //!   **[inferred]** Random-access input iterator type for reading segment beginning offsets in the output sequence
+  //!   @iterator
+  //!
+  //! @tparam ScanOpT
+  //!   **[inferred]** Binary associative scan functor type having member `T operator()(const T &a, const T &b)`
+  //!
+  //! @tparam InitValueT
+  //!   **[inferred]** Type of the ``init_value``
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Execution environment type. Default is ``cuda::std::execution::env<>``.
+  //!
+  //! @param[in] d_in
+  //!   Random-access iterator to the input sequence of data items
+  //!
+  //! @param[out] d_out
+  //!   Random-access iterator to the output sequence of data items
+  //!
+  //! @param[in] d_in_begin_offsets
+  //!   Random-access input iterator to the sequence of beginning offsets in the input data of length ``num_segments``
+  //!
+  //! @param[in] d_in_end_offsets
+  //!   Random-access input iterator to the sequence of ending offsets in the input data of length ``num_segments``
+  //!
+  //! @param[in] d_out_begin_offsets
+  //!   Random-access input iterator to the sequence of beginning offsets in the output data of length ``num_segments``
+  //!
+  //! @param[in] num_segments
+  //!   The number of segments that comprise the segmented prefix scan data.
+  //!
+  //! @param[in] scan_op
+  //!   Binary associative scan functor
+  //!
+  //! @param[in] init_value
+  //!   Initial value to seed the inclusive scan for each segment
+  //!
+  //! @param[in] env
+  //!   @rst
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  //!   @endrst
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename BeginOffsetIteratorInputT,
+            typename EndOffsetIteratorInputT,
+            typename BeginOffsetIteratorOutputT,
+            typename ScanOpT,
+            typename InitValueT,
+            typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
+#ifdef _CCCL_DOXYGEN_INVOKED
+            void
+#else
+            ::cuda::std::execution::env<>
+#endif
+            >
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t InclusiveSegmentedScanInit(
+    InputIteratorT d_in,
+    OutputIteratorT d_out,
+    BeginOffsetIteratorInputT d_in_begin_offsets,
+    EndOffsetIteratorInputT d_in_end_offsets,
+    BeginOffsetIteratorOutputT d_out_begin_offsets,
+    ::cuda::std::int64_t num_segments,
+    ScanOpT scan_op,
+    InitValueT init_value,
+    EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit");
+
+    using offset_t =
+      detail::common_iterator_value_t<BeginOffsetIteratorInputT, EndOffsetIteratorInputT, BeginOffsetIteratorOutputT>;
+    static_assert(::cuda::std::is_integral_v<offset_t>, "Offset iterator value type should be integral.");
+    static_assert(!::cuda::std::is_same_v<InitValueT, NullType>);
+
+    using accum_t = ::cuda::std::__accumulator_t<ScanOpT, cub::detail::it_value_t<InputIteratorT>, InitValueT>;
+
+    return detail::dispatch_with_env(
+      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+        return cub::detail::segmented_scan::dispatch_segmented_scan<
+          InputIteratorT,
+          OutputIteratorT,
+          BeginOffsetIteratorInputT,
+          EndOffsetIteratorInputT,
+          BeginOffsetIteratorOutputT,
+          ScanOpT,
+          detail::InputValue<InitValueT>,
+          accum_t,
+          ForceInclusive::Yes>::dispatch(d_temp_storage,
+                                         temp_storage_bytes,
+                                         d_in,
+                                         d_out,
+                                         num_segments,
+                                         d_in_begin_offsets,
+                                         d_in_end_offsets,
+                                         d_out_begin_offsets,
+                                         scan_op,
+                                         detail::InputValue<InitValueT>(init_value),
+                                         stream);
+      });
   }
 };
 

--- a/cub/test/catch2_test_device_segmented_scan_env.cu
+++ b/cub/test/catch2_test_device_segmented_scan_env.cu
@@ -29,6 +29,10 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedScan::InclusiveSegmentedScanInit, dev
 
 namespace stdexec = cuda::std::execution;
 
+// Test data (separate input/output offsets):
+// Input data: {1,2,3,4,5,6,7,8}  - 3 segments of sizes 3, 2, 3 at input offsets {0,3,5,8}
+// Output layout: 10 slots with padding at positions 3 and 6; output begin offsets {0,4,7}
+
 #if TEST_LAUNCH == 0
 
 TEST_CASE("Device segmented exclusive sum works with default environment", "[segmented_scan][device]")
@@ -108,6 +112,104 @@ TEST_CASE("Device segmented inclusive scan init works with default environment",
             d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, ::cuda::std::plus<>{}, 100));
 
   thrust::device_vector<int> expected{108, 114, 121, 126, 103, 103, 112, 101, 103};
+  REQUIRE(d_out == expected);
+}
+
+TEST_CASE("Device segmented exclusive sum with separate offsets works with default environment",
+          "[segmented_scan][device]")
+{
+  ::cuda::std::int64_t num_segments = 3;
+  thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
+  thrust::device_vector<int> d_out_offsets{0, 4, 7};
+  auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
+  auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
+  thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<int> d_out(10);
+
+  REQUIRE(cudaSuccess
+          == cub::DeviceSegmentedScan::ExclusiveSegmentedSum(
+            d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments));
+
+  thrust::device_vector<int> expected{0, 1, 3, 0, 0, 4, 0, 0, 6, 13};
+  REQUIRE(d_out == expected);
+}
+
+TEST_CASE("Device segmented exclusive scan with separate offsets works with default environment",
+          "[segmented_scan][device]")
+{
+  ::cuda::std::int64_t num_segments = 3;
+  thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
+  thrust::device_vector<int> d_out_offsets{0, 4, 7};
+  auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
+  auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
+  thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<int> d_out(10);
+
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
+      d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}, 100));
+
+  thrust::device_vector<int> expected{100, 101, 103, 0, 100, 104, 0, 100, 106, 113};
+  REQUIRE(d_out == expected);
+}
+
+TEST_CASE("Device segmented inclusive sum with separate offsets works with default environment",
+          "[segmented_scan][device]")
+{
+  ::cuda::std::int64_t num_segments = 3;
+  thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
+  thrust::device_vector<int> d_out_offsets{0, 4, 7};
+  auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
+  auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
+  thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<int> d_out(10);
+
+  REQUIRE(cudaSuccess
+          == cub::DeviceSegmentedScan::InclusiveSegmentedSum(
+            d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments));
+
+  thrust::device_vector<int> expected{1, 3, 6, 0, 4, 9, 0, 6, 13, 21};
+  REQUIRE(d_out == expected);
+}
+
+TEST_CASE("Device segmented inclusive scan with separate offsets works with default environment",
+          "[segmented_scan][device]")
+{
+  ::cuda::std::int64_t num_segments = 3;
+  thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
+  thrust::device_vector<int> d_out_offsets{0, 4, 7};
+  auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
+  auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
+  thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<int> d_out(10);
+
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSegmentedScan::InclusiveSegmentedScan(
+      d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}));
+
+  thrust::device_vector<int> expected{1, 3, 6, 0, 4, 9, 0, 6, 13, 21};
+  REQUIRE(d_out == expected);
+}
+
+TEST_CASE("Device segmented inclusive scan init with separate offsets works with default environment",
+          "[segmented_scan][device]")
+{
+  ::cuda::std::int64_t num_segments = 3;
+  thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
+  thrust::device_vector<int> d_out_offsets{0, 4, 7};
+  auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
+  auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
+  thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<int> d_out(10);
+
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
+      d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}, 100));
+
+  thrust::device_vector<int> expected{101, 103, 106, 0, 104, 109, 0, 106, 113, 121};
   REQUIRE(d_out == expected);
 }
 
@@ -246,5 +348,186 @@ C2H_TEST("Device segmented inclusive scan init uses environment", "[segmented_sc
     d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, ::cuda::std::plus<>{}, 100, env);
 
   thrust::device_vector<int> expected{108, 114, 121, 126, 103, 103, 112, 101, 103};
+  REQUIRE(d_out == expected);
+}
+
+C2H_TEST("Device segmented exclusive sum with separate offsets uses environment", "[segmented_scan][device]")
+{
+  ::cuda::std::int64_t num_segments = 3;
+  thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
+  thrust::device_vector<int> d_out_offsets{0, 4, 7};
+  auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
+  auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
+  thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<int> d_out(10);
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSegmentedScan::ExclusiveSegmentedSum(
+      nullptr,
+      expected_bytes_allocated,
+      d_in.begin(),
+      d_out.begin(),
+      d_in_off_it,
+      d_in_off_it + 1,
+      d_out_off_it,
+      num_segments));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_segmented_exclusive_sum(
+    d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, env);
+
+  thrust::device_vector<int> expected{0, 1, 3, 0, 0, 4, 0, 0, 6, 13};
+  REQUIRE(d_out == expected);
+}
+
+C2H_TEST("Device segmented exclusive scan with separate offsets uses environment", "[segmented_scan][device]")
+{
+  ::cuda::std::int64_t num_segments = 3;
+  thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
+  thrust::device_vector<int> d_out_offsets{0, 4, 7};
+  auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
+  auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
+  thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<int> d_out(10);
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
+      nullptr,
+      expected_bytes_allocated,
+      d_in.begin(),
+      d_out.begin(),
+      d_in_off_it,
+      d_in_off_it + 1,
+      d_out_off_it,
+      num_segments,
+      ::cuda::std::plus<>{},
+      100));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_segmented_exclusive_scan(
+    d_in.begin(),
+    d_out.begin(),
+    d_in_off_it,
+    d_in_off_it + 1,
+    d_out_off_it,
+    num_segments,
+    ::cuda::std::plus<>{},
+    100,
+    env);
+
+  thrust::device_vector<int> expected{100, 101, 103, 0, 100, 104, 0, 100, 106, 113};
+  REQUIRE(d_out == expected);
+}
+
+C2H_TEST("Device segmented inclusive sum with separate offsets uses environment", "[segmented_scan][device]")
+{
+  ::cuda::std::int64_t num_segments = 3;
+  thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
+  thrust::device_vector<int> d_out_offsets{0, 4, 7};
+  auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
+  auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
+  thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<int> d_out(10);
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSegmentedScan::InclusiveSegmentedSum(
+      nullptr,
+      expected_bytes_allocated,
+      d_in.begin(),
+      d_out.begin(),
+      d_in_off_it,
+      d_in_off_it + 1,
+      d_out_off_it,
+      num_segments));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_segmented_inclusive_sum(
+    d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, env);
+
+  thrust::device_vector<int> expected{1, 3, 6, 0, 4, 9, 0, 6, 13, 21};
+  REQUIRE(d_out == expected);
+}
+
+C2H_TEST("Device segmented inclusive scan with separate offsets uses environment", "[segmented_scan][device]")
+{
+  ::cuda::std::int64_t num_segments = 3;
+  thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
+  thrust::device_vector<int> d_out_offsets{0, 4, 7};
+  auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
+  auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
+  thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<int> d_out(10);
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSegmentedScan::InclusiveSegmentedScan(
+      nullptr,
+      expected_bytes_allocated,
+      d_in.begin(),
+      d_out.begin(),
+      d_in_off_it,
+      d_in_off_it + 1,
+      d_out_off_it,
+      num_segments,
+      ::cuda::std::plus<>{}));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_segmented_inclusive_scan(
+    d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}, env);
+
+  thrust::device_vector<int> expected{1, 3, 6, 0, 4, 9, 0, 6, 13, 21};
+  REQUIRE(d_out == expected);
+}
+
+C2H_TEST("Device segmented inclusive scan init with separate offsets uses environment", "[segmented_scan][device]")
+{
+  ::cuda::std::int64_t num_segments = 3;
+  thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
+  thrust::device_vector<int> d_out_offsets{0, 4, 7};
+  auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
+  auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
+  thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<int> d_out(10);
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
+      nullptr,
+      expected_bytes_allocated,
+      d_in.begin(),
+      d_out.begin(),
+      d_in_off_it,
+      d_in_off_it + 1,
+      d_out_off_it,
+      num_segments,
+      ::cuda::std::plus<>{},
+      100));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_segmented_inclusive_scan_init(
+    d_in.begin(),
+    d_out.begin(),
+    d_in_off_it,
+    d_in_off_it + 1,
+    d_out_off_it,
+    num_segments,
+    ::cuda::std::plus<>{},
+    100,
+    env);
+
+  thrust::device_vector<int> expected{101, 103, 106, 0, 104, 109, 0, 106, 113, 121};
   REQUIRE(d_out == expected);
 }

--- a/cub/test/catch2_test_device_segmented_scan_env.cu
+++ b/cub/test/catch2_test_device_segmented_scan_env.cu
@@ -118,98 +118,105 @@ TEST_CASE("Device segmented inclusive scan init works with default environment",
 TEST_CASE("Device segmented exclusive sum with separate offsets works with default environment",
           "[segmented_scan][device]")
 {
+  const auto sentinel             = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
   auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
   auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::device_vector<int> d_out(10);
+  thrust::device_vector<int> d_out(10, sentinel);
 
   REQUIRE(cudaSuccess
           == cub::DeviceSegmentedScan::ExclusiveSegmentedSum(
             d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments));
 
-  thrust::device_vector<int> expected{0, 1, 3, 0, 0, 4, 0, 0, 6, 13};
+  thrust::device_vector<int> expected{0, 1, 3, sentinel, 0, 4, sentinel, 0, 6, 13};
   REQUIRE(d_out == expected);
 }
 
 TEST_CASE("Device segmented exclusive scan with separate offsets works with default environment",
           "[segmented_scan][device]")
 {
+  const auto sentinel             = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
   auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
   auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::device_vector<int> d_out(10);
+  thrust::device_vector<int> d_out(10, sentinel);
 
   REQUIRE(
     cudaSuccess
     == cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
       d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}, 100));
 
-  thrust::device_vector<int> expected{100, 101, 103, 0, 100, 104, 0, 100, 106, 113};
+  thrust::device_vector<int> expected{
+    100, 101, 103, sentinel, 100, 104, sentinel, 100, 106, 113};
   REQUIRE(d_out == expected);
 }
 
 TEST_CASE("Device segmented inclusive sum with separate offsets works with default environment",
           "[segmented_scan][device]")
 {
+  const auto sentinel             = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
   auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
   auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::device_vector<int> d_out(10);
+  thrust::device_vector<int> d_out(10, sentinel);
 
   REQUIRE(cudaSuccess
           == cub::DeviceSegmentedScan::InclusiveSegmentedSum(
             d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments));
 
-  thrust::device_vector<int> expected{1, 3, 6, 0, 4, 9, 0, 6, 13, 21};
+  thrust::device_vector<int> expected{1, 3, 6, sentinel, 4, 9, sentinel, 6, 13, 21};
   REQUIRE(d_out == expected);
 }
 
 TEST_CASE("Device segmented inclusive scan with separate offsets works with default environment",
           "[segmented_scan][device]")
 {
+  const auto sentinel             = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
   auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
   auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::device_vector<int> d_out(10);
+  thrust::device_vector<int> d_out(10, sentinel);
 
   REQUIRE(
     cudaSuccess
     == cub::DeviceSegmentedScan::InclusiveSegmentedScan(
       d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}));
 
-  thrust::device_vector<int> expected{1, 3, 6, 0, 4, 9, 0, 6, 13, 21};
+  thrust::device_vector<int> expected{1, 3, 6, sentinel, 4, 9, sentinel, 6, 13, 21};
   REQUIRE(d_out == expected);
 }
 
 TEST_CASE("Device segmented inclusive scan init with separate offsets works with default environment",
           "[segmented_scan][device]")
 {
+  const auto sentinel             = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
   auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
   auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::device_vector<int> d_out(10);
+  thrust::device_vector<int> d_out(10, sentinel);
 
   REQUIRE(
     cudaSuccess
     == cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
       d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}, 100));
 
-  thrust::device_vector<int> expected{101, 103, 106, 0, 104, 109, 0, 106, 113, 121};
+  thrust::device_vector<int> expected{
+    101, 103, 106, sentinel, 104, 109, sentinel, 106, 113, 121};
   REQUIRE(d_out == expected);
 }
 
@@ -353,13 +360,14 @@ C2H_TEST("Device segmented inclusive scan init uses environment", "[segmented_sc
 
 C2H_TEST("Device segmented exclusive sum with separate offsets uses environment", "[segmented_scan][device]")
 {
+  const auto sentinel             = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
   auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
   auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::device_vector<int> d_out(10);
+  thrust::device_vector<int> d_out(10, sentinel);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -379,19 +387,20 @@ C2H_TEST("Device segmented exclusive sum with separate offsets uses environment"
   device_segmented_exclusive_sum(
     d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, env);
 
-  thrust::device_vector<int> expected{0, 1, 3, 0, 0, 4, 0, 0, 6, 13};
+  thrust::device_vector<int> expected{0, 1, 3, sentinel, 0, 4, sentinel, 0, 6, 13};
   REQUIRE(d_out == expected);
 }
 
 C2H_TEST("Device segmented exclusive scan with separate offsets uses environment", "[segmented_scan][device]")
 {
+  const auto sentinel             = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
   auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
   auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::device_vector<int> d_out(10);
+  thrust::device_vector<int> d_out(10, sentinel);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -421,19 +430,21 @@ C2H_TEST("Device segmented exclusive scan with separate offsets uses environment
     100,
     env);
 
-  thrust::device_vector<int> expected{100, 101, 103, 0, 100, 104, 0, 100, 106, 113};
+  thrust::device_vector<int> expected{
+    100, 101, 103, sentinel, 100, 104, sentinel, 100, 106, 113};
   REQUIRE(d_out == expected);
 }
 
 C2H_TEST("Device segmented inclusive sum with separate offsets uses environment", "[segmented_scan][device]")
 {
+  const auto sentinel             = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
   auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
   auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::device_vector<int> d_out(10);
+  thrust::device_vector<int> d_out(10, sentinel);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -453,19 +464,20 @@ C2H_TEST("Device segmented inclusive sum with separate offsets uses environment"
   device_segmented_inclusive_sum(
     d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, env);
 
-  thrust::device_vector<int> expected{1, 3, 6, 0, 4, 9, 0, 6, 13, 21};
+  thrust::device_vector<int> expected{1, 3, 6, sentinel, 4, 9, sentinel, 6, 13, 21};
   REQUIRE(d_out == expected);
 }
 
 C2H_TEST("Device segmented inclusive scan with separate offsets uses environment", "[segmented_scan][device]")
 {
+  const auto sentinel             = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
   auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
   auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::device_vector<int> d_out(10);
+  thrust::device_vector<int> d_out(10, sentinel);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -486,19 +498,20 @@ C2H_TEST("Device segmented inclusive scan with separate offsets uses environment
   device_segmented_inclusive_scan(
     d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}, env);
 
-  thrust::device_vector<int> expected{1, 3, 6, 0, 4, 9, 0, 6, 13, 21};
+  thrust::device_vector<int> expected{1, 3, 6, sentinel, 4, 9, sentinel, 6, 13, 21};
   REQUIRE(d_out == expected);
 }
 
 C2H_TEST("Device segmented inclusive scan init with separate offsets uses environment", "[segmented_scan][device]")
 {
+  const auto sentinel             = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
   auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
   auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::device_vector<int> d_out(10);
+  thrust::device_vector<int> d_out(10, sentinel);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -528,6 +541,7 @@ C2H_TEST("Device segmented inclusive scan init with separate offsets uses enviro
     100,
     env);
 
-  thrust::device_vector<int> expected{101, 103, 106, 0, 104, 109, 0, 106, 113, 121};
+  thrust::device_vector<int> expected{
+    101, 103, 106, sentinel, 104, 109, sentinel, 106, 113, 121};
   REQUIRE(d_out == expected);
 }

--- a/cub/test/catch2_test_device_segmented_scan_env.cu
+++ b/cub/test/catch2_test_device_segmented_scan_env.cu
@@ -118,7 +118,7 @@ TEST_CASE("Device segmented inclusive scan init works with default environment",
 TEST_CASE("Device segmented exclusive sum with separate offsets works with default environment",
           "[segmented_scan][device]")
 {
-  const auto sentinel             = -1;
+  const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
@@ -138,7 +138,7 @@ TEST_CASE("Device segmented exclusive sum with separate offsets works with defau
 TEST_CASE("Device segmented exclusive scan with separate offsets works with default environment",
           "[segmented_scan][device]")
 {
-  const auto sentinel             = -1;
+  const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
@@ -152,15 +152,14 @@ TEST_CASE("Device segmented exclusive scan with separate offsets works with defa
     == cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
       d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}, 100));
 
-  thrust::device_vector<int> expected{
-    100, 101, 103, sentinel, 100, 104, sentinel, 100, 106, 113};
+  thrust::device_vector<int> expected{100, 101, 103, sentinel, 100, 104, sentinel, 100, 106, 113};
   REQUIRE(d_out == expected);
 }
 
 TEST_CASE("Device segmented inclusive sum with separate offsets works with default environment",
           "[segmented_scan][device]")
 {
-  const auto sentinel             = -1;
+  const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
@@ -180,7 +179,7 @@ TEST_CASE("Device segmented inclusive sum with separate offsets works with defau
 TEST_CASE("Device segmented inclusive scan with separate offsets works with default environment",
           "[segmented_scan][device]")
 {
-  const auto sentinel             = -1;
+  const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
@@ -201,7 +200,7 @@ TEST_CASE("Device segmented inclusive scan with separate offsets works with defa
 TEST_CASE("Device segmented inclusive scan init with separate offsets works with default environment",
           "[segmented_scan][device]")
 {
-  const auto sentinel             = -1;
+  const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
@@ -215,8 +214,7 @@ TEST_CASE("Device segmented inclusive scan init with separate offsets works with
     == cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
       d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}, 100));
 
-  thrust::device_vector<int> expected{
-    101, 103, 106, sentinel, 104, 109, sentinel, 106, 113, 121};
+  thrust::device_vector<int> expected{101, 103, 106, sentinel, 104, 109, sentinel, 106, 113, 121};
   REQUIRE(d_out == expected);
 }
 
@@ -360,7 +358,7 @@ C2H_TEST("Device segmented inclusive scan init uses environment", "[segmented_sc
 
 C2H_TEST("Device segmented exclusive sum with separate offsets uses environment", "[segmented_scan][device]")
 {
-  const auto sentinel             = -1;
+  const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
@@ -393,7 +391,7 @@ C2H_TEST("Device segmented exclusive sum with separate offsets uses environment"
 
 C2H_TEST("Device segmented exclusive scan with separate offsets uses environment", "[segmented_scan][device]")
 {
-  const auto sentinel             = -1;
+  const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
@@ -430,14 +428,13 @@ C2H_TEST("Device segmented exclusive scan with separate offsets uses environment
     100,
     env);
 
-  thrust::device_vector<int> expected{
-    100, 101, 103, sentinel, 100, 104, sentinel, 100, 106, 113};
+  thrust::device_vector<int> expected{100, 101, 103, sentinel, 100, 104, sentinel, 100, 106, 113};
   REQUIRE(d_out == expected);
 }
 
 C2H_TEST("Device segmented inclusive sum with separate offsets uses environment", "[segmented_scan][device]")
 {
-  const auto sentinel             = -1;
+  const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
@@ -470,7 +467,7 @@ C2H_TEST("Device segmented inclusive sum with separate offsets uses environment"
 
 C2H_TEST("Device segmented inclusive scan with separate offsets uses environment", "[segmented_scan][device]")
 {
-  const auto sentinel             = -1;
+  const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
@@ -504,7 +501,7 @@ C2H_TEST("Device segmented inclusive scan with separate offsets uses environment
 
 C2H_TEST("Device segmented inclusive scan init with separate offsets uses environment", "[segmented_scan][device]")
 {
-  const auto sentinel             = -1;
+  const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
@@ -541,7 +538,6 @@ C2H_TEST("Device segmented inclusive scan init with separate offsets uses enviro
     100,
     env);
 
-  thrust::device_vector<int> expected{
-    101, 103, 106, sentinel, 104, 109, sentinel, 106, 113, 121};
+  thrust::device_vector<int> expected{101, 103, 106, sentinel, 104, 109, sentinel, 106, 113, 121};
   REQUIRE(d_out == expected);
 }

--- a/cub/test/catch2_test_device_segmented_scan_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_scan_env_api.cu
@@ -152,7 +152,7 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit accepts stream", 
 C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum (separate offsets) accepts stream", "[segmented_scan][env]")
 {
   // example-begin exclusive-segmented-sum-separate-env
-  const auto sentinel             = -1;
+  const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
@@ -182,7 +182,7 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum (separate offsets) acc
 C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan (separate offsets) accepts stream", "[segmented_scan][env]")
 {
   // example-begin exclusive-segmented-scan-separate-env
-  const auto sentinel             = -1;
+  const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
@@ -209,8 +209,7 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan (separate offsets) ac
     std::cerr << "cub::DeviceSegmentedScan::ExclusiveSegmentedScan failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{
-    100, 101, 103, sentinel, 100, 104, sentinel, 100, 106, 113};
+  thrust::device_vector<int> expected{100, 101, 103, sentinel, 100, 104, sentinel, 100, 106, 113};
   // example-end exclusive-segmented-scan-separate-env
   stream.sync();
 
@@ -221,7 +220,7 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan (separate offsets) ac
 C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum (separate offsets) accepts stream", "[segmented_scan][env]")
 {
   // example-begin inclusive-segmented-sum-separate-env
-  const auto sentinel             = -1;
+  const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
@@ -251,7 +250,7 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum (separate offsets) acc
 C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan (separate offsets) accepts stream", "[segmented_scan][env]")
 {
   // example-begin inclusive-segmented-scan-separate-env
-  const auto sentinel             = -1;
+  const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
@@ -289,7 +288,7 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit (separate offsets
          "[segmented_scan][env]")
 {
   // example-begin inclusive-segmented-scan-init-separate-env
-  const auto sentinel             = -1;
+  const auto sentinel               = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
@@ -316,8 +315,7 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit (separate offsets
     std::cerr << "cub::DeviceSegmentedScan::InclusiveSegmentedScanInit failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{
-    101, 103, 106, sentinel, 104, 109, sentinel, 106, 113, 121};
+  thrust::device_vector<int> expected{101, 103, 106, sentinel, 104, 109, sentinel, 106, 113, 121};
   // example-end inclusive-segmented-scan-init-separate-env
   stream.sync();
 

--- a/cub/test/catch2_test_device_segmented_scan_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_scan_env_api.cu
@@ -152,13 +152,14 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit accepts stream", 
 C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum (separate offsets) accepts stream", "[segmented_scan][env]")
 {
   // example-begin exclusive-segmented-sum-separate-env
+  const auto sentinel             = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
   auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
   auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::device_vector<int> d_out(10);
+  thrust::device_vector<int> d_out(10, sentinel);
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
@@ -170,7 +171,7 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum (separate offsets) acc
     std::cerr << "cub::DeviceSegmentedScan::ExclusiveSegmentedSum failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{0, 1, 3, 0, 0, 4, 0, 0, 6, 13};
+  thrust::device_vector<int> expected{0, 1, 3, sentinel, 0, 4, sentinel, 0, 6, 13};
   // example-end exclusive-segmented-sum-separate-env
   stream.sync();
 
@@ -181,13 +182,14 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum (separate offsets) acc
 C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan (separate offsets) accepts stream", "[segmented_scan][env]")
 {
   // example-begin exclusive-segmented-scan-separate-env
+  const auto sentinel             = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
   auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
   auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::device_vector<int> d_out(10);
+  thrust::device_vector<int> d_out(10, sentinel);
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
@@ -207,7 +209,8 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan (separate offsets) ac
     std::cerr << "cub::DeviceSegmentedScan::ExclusiveSegmentedScan failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{100, 101, 103, 0, 100, 104, 0, 100, 106, 113};
+  thrust::device_vector<int> expected{
+    100, 101, 103, sentinel, 100, 104, sentinel, 100, 106, 113};
   // example-end exclusive-segmented-scan-separate-env
   stream.sync();
 
@@ -218,13 +221,14 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan (separate offsets) ac
 C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum (separate offsets) accepts stream", "[segmented_scan][env]")
 {
   // example-begin inclusive-segmented-sum-separate-env
+  const auto sentinel             = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
   auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
   auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::device_vector<int> d_out(10);
+  thrust::device_vector<int> d_out(10, sentinel);
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
@@ -236,7 +240,7 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum (separate offsets) acc
     std::cerr << "cub::DeviceSegmentedScan::InclusiveSegmentedSum failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{1, 3, 6, 0, 4, 9, 0, 6, 13, 21};
+  thrust::device_vector<int> expected{1, 3, 6, sentinel, 4, 9, sentinel, 6, 13, 21};
   // example-end inclusive-segmented-sum-separate-env
   stream.sync();
 
@@ -247,13 +251,14 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum (separate offsets) acc
 C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan (separate offsets) accepts stream", "[segmented_scan][env]")
 {
   // example-begin inclusive-segmented-scan-separate-env
+  const auto sentinel             = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
   auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
   auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::device_vector<int> d_out(10);
+  thrust::device_vector<int> d_out(10, sentinel);
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
@@ -272,7 +277,7 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan (separate offsets) ac
     std::cerr << "cub::DeviceSegmentedScan::InclusiveSegmentedScan failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{1, 3, 6, 0, 4, 9, 0, 6, 13, 21};
+  thrust::device_vector<int> expected{1, 3, 6, sentinel, 4, 9, sentinel, 6, 13, 21};
   // example-end inclusive-segmented-scan-separate-env
   stream.sync();
 
@@ -284,13 +289,14 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit (separate offsets
          "[segmented_scan][env]")
 {
   // example-begin inclusive-segmented-scan-init-separate-env
+  const auto sentinel             = -1;
   ::cuda::std::int64_t num_segments = 3;
   thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
   auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
   auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::device_vector<int> d_out(10);
+  thrust::device_vector<int> d_out(10, sentinel);
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
@@ -310,7 +316,8 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit (separate offsets
     std::cerr << "cub::DeviceSegmentedScan::InclusiveSegmentedScanInit failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{101, 103, 106, 0, 104, 109, 0, 106, 113, 121};
+  thrust::device_vector<int> expected{
+    101, 103, 106, sentinel, 104, 109, sentinel, 106, 113, 121};
   // example-end inclusive-segmented-scan-init-separate-env
   stream.sync();
 

--- a/cub/test/catch2_test_device_segmented_scan_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_scan_env_api.cu
@@ -148,3 +148,172 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit accepts stream", 
   REQUIRE(error == cudaSuccess);
   REQUIRE(d_out == expected);
 }
+
+C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum (separate offsets) accepts stream", "[segmented_scan][env]")
+{
+  // example-begin exclusive-segmented-sum-separate-env
+  ::cuda::std::int64_t num_segments = 3;
+  thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
+  thrust::device_vector<int> d_out_offsets{0, 4, 7};
+  auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
+  auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
+  thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<int> d_out(10);
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceSegmentedScan::ExclusiveSegmentedSum(
+    d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceSegmentedScan::ExclusiveSegmentedSum failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected{0, 1, 3, 0, 0, 4, 0, 0, 6, 13};
+  // example-end exclusive-segmented-sum-separate-env
+  stream.sync();
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_out == expected);
+}
+
+C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan (separate offsets) accepts stream", "[segmented_scan][env]")
+{
+  // example-begin exclusive-segmented-scan-separate-env
+  ::cuda::std::int64_t num_segments = 3;
+  thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
+  thrust::device_vector<int> d_out_offsets{0, 4, 7};
+  auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
+  auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
+  thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<int> d_out(10);
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
+    d_in.begin(),
+    d_out.begin(),
+    d_in_off_it,
+    d_in_off_it + 1,
+    d_out_off_it,
+    num_segments,
+    ::cuda::std::plus<>{},
+    100,
+    stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceSegmentedScan::ExclusiveSegmentedScan failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected{100, 101, 103, 0, 100, 104, 0, 100, 106, 113};
+  // example-end exclusive-segmented-scan-separate-env
+  stream.sync();
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_out == expected);
+}
+
+C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum (separate offsets) accepts stream", "[segmented_scan][env]")
+{
+  // example-begin inclusive-segmented-sum-separate-env
+  ::cuda::std::int64_t num_segments = 3;
+  thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
+  thrust::device_vector<int> d_out_offsets{0, 4, 7};
+  auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
+  auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
+  thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<int> d_out(10);
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceSegmentedScan::InclusiveSegmentedSum(
+    d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceSegmentedScan::InclusiveSegmentedSum failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected{1, 3, 6, 0, 4, 9, 0, 6, 13, 21};
+  // example-end inclusive-segmented-sum-separate-env
+  stream.sync();
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_out == expected);
+}
+
+C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan (separate offsets) accepts stream", "[segmented_scan][env]")
+{
+  // example-begin inclusive-segmented-scan-separate-env
+  ::cuda::std::int64_t num_segments = 3;
+  thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
+  thrust::device_vector<int> d_out_offsets{0, 4, 7};
+  auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
+  auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
+  thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<int> d_out(10);
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceSegmentedScan::InclusiveSegmentedScan(
+    d_in.begin(),
+    d_out.begin(),
+    d_in_off_it,
+    d_in_off_it + 1,
+    d_out_off_it,
+    num_segments,
+    ::cuda::std::plus<>{},
+    stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceSegmentedScan::InclusiveSegmentedScan failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected{1, 3, 6, 0, 4, 9, 0, 6, 13, 21};
+  // example-end inclusive-segmented-scan-separate-env
+  stream.sync();
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_out == expected);
+}
+
+C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit (separate offsets) accepts stream",
+         "[segmented_scan][env]")
+{
+  // example-begin inclusive-segmented-scan-init-separate-env
+  ::cuda::std::int64_t num_segments = 3;
+  thrust::device_vector<int> d_in_offsets{0, 3, 5, 8};
+  thrust::device_vector<int> d_out_offsets{0, 4, 7};
+  auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
+  auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
+  thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<int> d_out(10);
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
+    d_in.begin(),
+    d_out.begin(),
+    d_in_off_it,
+    d_in_off_it + 1,
+    d_out_off_it,
+    num_segments,
+    ::cuda::std::plus<>{},
+    100,
+    stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceSegmentedScan::InclusiveSegmentedScanInit failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected{101, 103, 106, 0, 104, 109, 0, 106, 113, 121};
+  // example-end inclusive-segmented-scan-init-separate-env
+  stream.sync();
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_out == expected);
+}


### PR DESCRIPTION
fixes second half of #8433 