### PR TITLE
Implement parallel `cuda::std::sort`

### DIFF
--- a/cub/cub/device/device_radix_sort.cuh
+++ b/cub/cub/device/device_radix_sort.cuh
@@ -24,13 +24,37 @@
 
 #include <cuda/__execution/require.h>
 #include <cuda/std/__execution/env.h>
+#include <cuda/std/__functional/operations.h>
+#include <cuda/std/__memory/pointer_traits.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/integral_constant.h>
+#include <cuda/std/__type_traits/is_arithmetic.h>
 #include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_one_of.h>
 #include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
+
+#ifndef _CCCL_DOXYGEN_INVOKED // Do not document
+template <class _InputIterator, class _BinaryPredicate, class _ValueType = ::cuda::std::iter_value_t<_InputIterator>>
+inline constexpr bool __can_use_radix_sort =
+  (::cuda::std::is_arithmetic_v<_ValueType>
+#  if _CCCL_HAS_NVFP16() && !defined(__CUDA_NO_HALF_OPERATORS__) && !defined(__CUDA_NO_HALF_CONVERSIONS__)
+   || ::cuda::std::is_same_v<_ValueType, __half>
+#  endif // _CCCL_HAS_NVFP16() && !defined(__CUDA_NO_HALF_OPERATORS__) && !defined(__CUDA_NO_HALF_CONVERSIONS__)
+#  if _CCCL_HAS_NVBF16() && !defined(__CUDA_NO_BFLOAT16_CONVERSIONS__) && !defined(__CUDA_NO_BFLOAT16_OPERATORS__)
+   || ::cuda::std::is_same_v<_ValueType, __nv_bfloat16>
+#  endif // _CCCL_HAS_NVBF16() && !defined(__CUDA_NO_BFLOAT16_CONVERSIONS__) &&
+         // !defined(__CUDA_NO_BFLOAT16_OPERATORS__)
+   )
+  && ::cuda::std::__is_one_of_v<::cuda::std::remove_cvref_t<_BinaryPredicate>,
+                                ::cuda::std::less<>,
+                                ::cuda::std::less<_ValueType>,
+                                ::cuda::std::greater<>,
+                                ::cuda::std::greater<_ValueType>>;
+#endif // !_CCCL_DOXYGEN_INVOKED
 
 //! @rst
 //! DeviceRadixSort provides device-wide, parallel operations for

--- a/libcudacxx/benchmarks/bench/sort/basic.cu
+++ b/libcudacxx/benchmarks/bench/sort/basic.cu
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+#include <thrust/sort.h>
+
+#include <cuda/memory_pool>
+#include <cuda/std/execution>
+#include <cuda/stream>
+
+#include "nvbench_helper.cuh"
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements         = static_cast<std::size_t>(state.get_int64("Elements"));
+  const bit_entropy entropy   = str_to_entropy(state.get_string("Entropy"));
+  thrust::device_vector<T> in = generate(elements, entropy);
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<T>(elements);
+
+  caching_allocator_t alloc{};
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               cuda::std::sort(cuda_policy(alloc, launch), in.begin(), in.end());
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
+  .add_string_axis("Entropy", {"1.000", "0.201"});
+
+struct fake_less
+{
+  template <class T, class U>
+  [[nodiscard]] _CCCL_API constexpr bool operator()(const T& t, const U& u) const
+  {
+    // complex is not less than comparable, so just compare the first element
+    if constexpr (cuda::std::__is_cpp17_less_than_comparable_v<T, U>)
+    {
+      return t < u;
+    }
+    else
+    {
+      return cuda::std::get<0>(t) < cuda::std::get<0>(u);
+    }
+  }
+};
+
+template <typename T>
+static void with_predicate(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements         = static_cast<std::size_t>(state.get_int64("Elements"));
+  const bit_entropy entropy   = str_to_entropy(state.get_string("Entropy"));
+  thrust::device_vector<T> in = generate(elements, entropy);
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<T>(elements);
+
+  caching_allocator_t alloc{};
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               cuda::std::sort(cuda_policy(alloc, launch), in.begin(), in.end(), fake_less{});
+             });
+}
+
+NVBENCH_BENCH_TYPES(with_predicate, NVBENCH_TYPE_AXES(all_types))
+  .set_name("with_predicate")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
+  .add_string_axis("Entropy", {"1.000", "0.201"});

--- a/libcudacxx/include/cuda/std/__memory/pointer_traits.h
+++ b/libcudacxx/include/cuda/std/__memory/pointer_traits.h
@@ -233,6 +233,13 @@ _CCCL_API constexpr auto to_address(const _Pointer& __p) noexcept -> decltype(::
   return ::cuda::std::__to_address(__p);
 }
 
+template <class _Iter, class = void>
+inline constexpr bool __can_to_address = false;
+
+template <class _Iter>
+inline constexpr bool
+  __can_to_address<_Iter, void_t<decltype(::cuda::std::to_address(::cuda::std::declval<_Iter&>()))>> = true;
+
 _CCCL_END_NAMESPACE_CUDA_STD
 
 #include <cuda/std/__cccl/epilogue.h>

--- a/libcudacxx/include/cuda/std/__pstl/cuda/adjacent_difference.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/adjacent_difference.h
@@ -26,6 +26,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/copy_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/copy_if.h
@@ -26,6 +26,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/copy_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/copy_n.h
@@ -26,6 +26,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/exclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/exclusive_scan.h
@@ -26,6 +26,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/find_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/find_if.h
@@ -26,6 +26,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/for_each_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/for_each_n.h
@@ -26,6 +26,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/generate_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/generate_n.h
@@ -26,6 +26,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/inclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/inclusive_scan.h
@@ -26,6 +26,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/merge.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/merge.h
@@ -26,6 +26,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/partition.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/partition.h
@@ -26,6 +26,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/partition_copy.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/partition_copy.h
@@ -26,6 +26,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
@@ -26,6 +26,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/rotate.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/rotate.h
@@ -26,6 +26,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/rotate_copy.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/rotate_copy.h
@@ -26,6 +26,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/shift_left.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/shift_left.h
@@ -26,6 +26,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/shift_right.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/shift_right.h
@@ -26,6 +26,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/sort.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/sort.h
@@ -1,0 +1,214 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_CUDA_SORT_H
+#define _CUDA_STD___PSTL_CUDA_SORT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_HAS_BACKEND_CUDA()
+
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
+_CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
+
+#  include <cub/device/device_merge_sort.cuh>
+#  include <cub/device/device_radix_sort.cuh>
+#  include <cub/device/device_transform.cuh>
+
+_CCCL_DIAG_POP
+
+#  include <cuda/__cmath/round_up.h>
+#  include <cuda/__execution/policy.h>
+#  include <cuda/__functional/always_true_false.h>
+#  include <cuda/__functional/call_or.h>
+#  include <cuda/__stream/get_stream.h>
+#  include <cuda/__stream/stream_ref.h>
+#  include <cuda/std/__algorithm/sort.h>
+#  include <cuda/std/__exception/cuda_error.h>
+#  include <cuda/std/__exception/exception_macros.h>
+#  include <cuda/std/__execution/env.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__functional/operations.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__pstl/cuda/temporary_storage.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/is_one_of.h>
+#  include <cuda/std/__type_traits/remove_cvref.h>
+#  include <cuda/std/__utility/move.h>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+template <>
+struct __pstl_dispatch<__pstl_algorithm::__sort, __execution_backend::__cuda>
+{
+  template <class _Tp>
+  using _DeviceRadixSort =
+    cudaError_t (*)(void*, size_t&, CUB_NS_QUALIFIER::DoubleBuffer<_Tp>&, size_t, int, int, cudaStream_t);
+
+  template <class _Tp, class _BinaryPredicate>
+  [[nodiscard]] static _CCCL_CONSTEVAL _DeviceRadixSort<_Tp> __select_radix_impl() noexcept
+  {
+    if constexpr (__is_one_of_v<remove_cvref_t<_BinaryPredicate>, less<>, less<_Tp>>)
+    {
+      return CUB_NS_QUALIFIER::DeviceRadixSort::SortKeys;
+    }
+    else
+    {
+      return CUB_NS_QUALIFIER::DeviceRadixSort::SortKeysDescending;
+    }
+  }
+
+  template <class _Policy, class _Tp, class _BinaryPredicate>
+  _CCCL_HOST_API static void __radix_sort_impl(const _Policy& __policy, _Tp* __first, _Tp* __last, _BinaryPredicate)
+  {
+    const auto __count = static_cast<size_t>(::cuda::std::distance(__first, __last));
+    auto __stream      = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+
+    CUB_NS_QUALIFIER::DoubleBuffer<_Tp> __buffer{__first, nullptr};
+
+    constexpr _DeviceRadixSort<_Tp> __device_radix_sort = __select_radix_impl<_Tp, _BinaryPredicate>();
+
+    // Determine temporary device storage requirements for device_sort
+    size_t __num_bytes = 0;
+    _CCCL_TRY_CUDA_API(
+      __device_radix_sort,
+      "__pstl_cuda_sort: determination of device storage for cub::DeviceRadixSort::SortKeys failed",
+      static_cast<void*>(nullptr),
+      __num_bytes,
+      __buffer,
+      __count,
+      0,
+      static_cast<int>(sizeof(_Tp) * CHAR_BIT),
+      __stream.get());
+
+    {
+      __temporary_storage<_Tp> __storage{__policy, __num_bytes, ::cuda::round_up(__count, 128)};
+      __buffer.d_buffers[1] = __storage.template __get_raw_ptr<0>();
+
+      // Run the kernel
+      _CCCL_TRY_CUDA_API(
+        __device_radix_sort,
+        "__pstl_cuda_sort: kernel launch of cub::DeviceRadixSort::SortKeys failed",
+        __storage.__get_temp_storage(),
+        __num_bytes,
+        __buffer,
+        __count,
+        0,
+        static_cast<int>(sizeof(_Tp) * CHAR_BIT),
+        __stream.get());
+
+      // Need to copy the memory back
+      if (__buffer.selector != 0)
+      {
+        _CCCL_TRY_CUDA_API(
+          CUB_NS_QUALIFIER::DeviceTransform::TransformIf,
+          "__pstl_cuda_sort: kernel launch of cub::DeviceTransform::TransformIf failed",
+          tuple{__storage.template __get_raw_ptr<0>()},
+          __first,
+          __count,
+          ::cuda::always_true{},
+          identity{},
+          __stream.get());
+      }
+    }
+
+    __stream.sync();
+  }
+
+  template <class _Policy, class _InputIterator, class _BinaryPredicate>
+  _CCCL_HOST_API static void
+  __merge_sort_impl(const _Policy& __policy, _InputIterator __first, _InputIterator __last, _BinaryPredicate __pred)
+  {
+    const auto __count = ::cuda::std::distance(__first, __last);
+    auto __stream      = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+
+    // Run the kernel
+    _CCCL_TRY_CUDA_API(
+      CUB_NS_QUALIFIER::DeviceMergeSort::SortKeys,
+      "__pstl_cuda_sort: kernel launch of cub::DeviceMergeSort::SortKeys failed",
+      ::cuda::std::move(__first),
+      __count,
+      ::cuda::std::move(__pred),
+      __policy);
+
+    __stream.sync();
+  }
+
+  _CCCL_TEMPLATE(class _Policy, class _InputIterator, class _BinaryPredicate)
+  _CCCL_REQUIRES(__has_forward_traversal<_InputIterator>)
+  _CCCL_HOST_API void operator()(
+    [[maybe_unused]] const _Policy& __policy,
+    _InputIterator __first,
+    _InputIterator __last,
+    _BinaryPredicate __pred) const
+  {
+    if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>)
+    {
+      try
+      {
+        if constexpr (CUB_NS_QUALIFIER::__can_use_radix_sort<_InputIterator, _BinaryPredicate> //
+                      && __can_to_address<_InputIterator>)
+        {
+          __radix_sort_impl(
+            __policy, ::cuda::std::to_address(__first), ::cuda::std::to_address(__last), ::cuda::std::move(__pred));
+        }
+        else
+        {
+          __merge_sort_impl(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
+        }
+      }
+      catch (const ::cuda::cuda_error& __err)
+      {
+        if (__err.status() == cudaErrorMemoryAllocation)
+        {
+          _CCCL_THROW(::std::bad_alloc);
+        }
+        else
+        {
+          throw __err;
+        }
+      }
+    }
+    else
+    {
+      static_assert(__always_false_v<_Policy>, "CUDA backend of cuda::std::sort requires random access iterators");
+      // TODO(miscco) Implement a GPU friendly serial sort
+      // ::cuda::std::sort(::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
+    }
+  }
+};
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD_EXECUTION
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CCCL_HAS_BACKEND_CUDA()
+
+#endif // _CUDA_STD___PSTL_CUDA_SORT_H

--- a/libcudacxx/include/cuda/std/__pstl/cuda/stable_partition.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/stable_partition.h
@@ -26,6 +26,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/transform.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/transform.h
@@ -26,6 +26,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/transform_reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/transform_reduce.h
@@ -26,6 +26,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 

--- a/libcudacxx/include/cuda/std/__pstl/dispatch.h
+++ b/libcudacxx/include/cuda/std/__pstl/dispatch.h
@@ -52,6 +52,7 @@ enum class __pstl_algorithm
   __shift_left,
   __shift_right,
   __stable_partition,
+  __sort,
   __transform,
   __transform_reduce,
   __unique,

--- a/libcudacxx/include/cuda/std/__pstl/sort.h
+++ b/libcudacxx/include/cuda/std/__pstl/sort.h
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_SORT_H
+#define _CUDA_STD___PSTL_SORT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/__nvtx/nvtx.h>
+#  include <cuda/std/__algorithm/sort.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__functional/operations.h>
+#  include <cuda/std/__iterator/concepts.h>
+#  include <cuda/std/__iterator/incrementable_traits.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/integral_constant.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__utility/move.h>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/sort.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_TEMPLATE(class _Policy, class _InputIterator, class _BinaryPredicate = less<>)
+_CCCL_REQUIRES(__has_forward_traversal<_InputIterator> _CCCL_AND is_execution_policy_v<_Policy>)
+_CCCL_HOST_API void sort(
+  [[maybe_unused]] const _Policy& __policy, _InputIterator __first, _InputIterator __last, _BinaryPredicate __pred = {})
+{
+  static_assert(indirect_binary_predicate<_BinaryPredicate, _InputIterator, _InputIterator>,
+                "cuda::std::sort: BinaryPredicate must satisfy indirect_binary_predicate<InputIterator, "
+                "InputIterator>");
+
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__sort, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cuda::std::sort");
+
+    if (__first == __last)
+    {
+      return;
+    }
+
+    __dispatch(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
+  }
+  else
+  {
+    static_assert(__always_false_v<_Policy>, "Parallel cuda::std::sort requires at least one selected backend");
+    ::cuda::std::sort(::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
+  }
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___PSTL_SORT_H

--- a/libcudacxx/include/cuda/std/execution
+++ b/libcudacxx/include/cuda/std/execution
@@ -76,6 +76,7 @@
 #  include <cuda/std/__pstl/rotate_copy.h>
 #  include <cuda/std/__pstl/shift_left.h>
 #  include <cuda/std/__pstl/shift_right.h>
+#  include <cuda/std/__pstl/sort.h>
 #  include <cuda/std/__pstl/stable_partition.h>
 #  include <cuda/std/__pstl/swap_ranges.h>
 #  include <cuda/std/__pstl/transform.h>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/sort/pstl_sort.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/sort/pstl_sort.cu
@@ -1,0 +1,99 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template<RandomAccessIterator Iter>
+// void sort(Iter first, Iter last);
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "test_pstl.h"
+
+inline constexpr int size = 1000;
+
+template <class Policy, class T>
+void test_sort(const Policy& policy, c2h::device_vector<T>& input, c2h::device_vector<int>& data)
+{
+  { // empty should not access anything
+    cuda::std::sort(policy, static_cast<T*>(nullptr), static_cast<T*>(nullptr));
+  }
+
+  cuda::std::transform(policy, data.begin(), data.end(), input.begin(), cast_to<T>{});
+  { // unsorted contiguous range
+    cuda::std::sort(policy, input.begin(), input.end());
+    CHECK(cuda::std::is_sorted(policy, input.begin(), input.end()));
+  }
+
+  { // sorted contiguous range
+    cuda::std::sort(policy, input.begin(), input.end());
+    CHECK(cuda::std::is_sorted(policy, input.begin(), input.end()));
+  }
+
+  cuda::std::transform(policy, data.begin(), data.end(), input.begin(), cast_to<T>{});
+  T* raw_pointer = thrust::raw_pointer_cast(input.data());
+  { // unsorted random access range
+    cuda::std::sort(policy, random_access_iterator{raw_pointer}, random_access_iterator{raw_pointer + size});
+    CHECK(cuda::std::is_sorted(policy, input.begin(), input.end()));
+  }
+
+  { // sorted random access range
+    cuda::std::sort(policy, random_access_iterator{raw_pointer}, random_access_iterator{raw_pointer + size});
+    CHECK(cuda::std::is_sorted(policy, input.begin(), input.end()));
+  }
+}
+
+C2H_TEST("cuda::std::sort(iter, iter)", "[parallel algorithm]", all_types)
+{
+  using T = typename c2h::get<0, TestType>;
+  c2h::device_vector<int> data(size, thrust::no_init);
+  c2h::gen(C2H_SEED(10), data);
+  c2h::device_vector<T> input(size);
+  cuda::std::transform(cuda::execution::gpu, data.begin(), data.end(), input.begin(), cast_to<T>{});
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_sort(policy, input, data);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_sort(policy, input, data);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource);
+    test_sort(policy, input, data);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy =
+      cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);
+    test_sort(policy, input, data);
+  }
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/sort/pstl_sort_comp.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/sort/pstl_sort_comp.cu
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template<RandomAccessIterator Iter, class BinaryPredicate>
+// void sort(Iter first, Iter last, BinaryPredicate pred);
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "test_pstl.h"
+
+inline constexpr int size = 1000;
+
+template <class Policy, class T>
+void test_sort(const Policy& policy, c2h::device_vector<T>& input, c2h::device_vector<int>& data)
+{
+  { // empty should not access anything
+    cuda::std::sort(policy, static_cast<T*>(nullptr), static_cast<T*>(nullptr));
+  }
+
+  cuda::std::transform(policy, data.begin(), data.end(), input.begin(), cast_to<T>{});
+  { // unsorted contiguous range
+    cuda::std::sort(policy, input.begin(), input.end(), cuda::std::greater<T>{});
+    CHECK(cuda::std::is_sorted(policy, input.begin(), input.end(), cuda::std::greater<T>{}));
+  }
+
+  { // sorted contiguous range
+    cuda::std::sort(policy, input.begin(), input.end(), cuda::std::greater<T>{});
+    CHECK(cuda::std::is_sorted(policy, input.begin(), input.end(), cuda::std::greater<T>{}));
+  }
+
+  cuda::std::transform(policy, data.begin(), data.end(), input.begin(), cast_to<T>{});
+  T* raw_pointer = thrust::raw_pointer_cast(input.data());
+  { // unsorted random access range
+    cuda::std::sort(
+      policy, random_access_iterator{raw_pointer}, random_access_iterator{raw_pointer + size}, cuda::std::greater<T>{});
+    CHECK(cuda::std::is_sorted(policy, input.begin(), input.end(), cuda::std::greater<T>{}));
+  }
+
+  { // sorted random access range
+    cuda::std::sort(
+      policy, random_access_iterator{raw_pointer}, random_access_iterator{raw_pointer + size}, cuda::std::greater<T>{});
+    CHECK(cuda::std::is_sorted(policy, input.begin(), input.end(), cuda::std::greater<T>{}));
+  }
+}
+
+C2H_TEST("cuda::std::sort(iter, iter)", "[parallel algorithm]", all_types)
+{
+  using T = typename c2h::get<0, TestType>;
+  c2h::device_vector<int> data(size, thrust::no_init);
+  c2h::gen(C2H_SEED(10), data);
+  c2h::device_vector<T> input(size);
+  cuda::std::transform(cuda::execution::gpu, data.begin(), data.end(), input.begin(), cast_to<T>{});
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_sort(policy, input, data);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_sort(policy, input, data);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource);
+    test_sort(policy, input, data);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy =
+      cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);
+    test_sort(policy, input, data);
+  }
+}

--- a/thrust/testing/cuda/sort.cu
+++ b/thrust/testing/cuda/sort.cu
@@ -131,15 +131,35 @@ DECLARE_UNITTEST(TestComparisonSortCudaStreams);
 template <typename T>
 struct TestRadixSortDispatch
 {
-  static_assert(thrust::cuda_cub::__smart_sort::can_use_primitive_sort<T, ::cuda::std::less<T>>::value);
-  static_assert(thrust::cuda_cub::__smart_sort::can_use_primitive_sort<T, ::cuda::std::greater<T>>::value);
-  static_assert(thrust::cuda_cub::__smart_sort::can_use_primitive_sort<T, ::cuda::std::less<T>>::value);
-  static_assert(thrust::cuda_cub::__smart_sort::can_use_primitive_sort<T, ::cuda::std::greater<T>>::value);
+  static_assert(cub::__can_use_radix_sort<T*, ::cuda::std::less<T>>);
+  static_assert(cub::__can_use_radix_sort<T*, ::cuda::std::greater<T>>);
+  static_assert(cub::__can_use_radix_sort<T*, ::cuda::std::less<T>>);
+  static_assert(cub::__can_use_radix_sort<T*, ::cuda::std::greater<T>>);
 
-  static_assert(thrust::cuda_cub::__smart_sort::can_use_primitive_sort<T, ::cuda::std::less<>>::value);
-  static_assert(thrust::cuda_cub::__smart_sort::can_use_primitive_sort<T, ::cuda::std::greater<>>::value);
-  static_assert(thrust::cuda_cub::__smart_sort::can_use_primitive_sort<T, ::cuda::std::less<>>::value);
-  static_assert(thrust::cuda_cub::__smart_sort::can_use_primitive_sort<T, ::cuda::std::greater<>>::value);
+  static_assert(cub::__can_use_radix_sort<T*, ::cuda::std::less<>>);
+  static_assert(cub::__can_use_radix_sort<T*, ::cuda::std::greater<>>);
+  static_assert(cub::__can_use_radix_sort<T*, ::cuda::std::less<>>);
+  static_assert(cub::__can_use_radix_sort<T*, ::cuda::std::greater<>>);
+
+  static_assert(cub::__can_use_radix_sort<const T*, ::cuda::std::less<T>>);
+  static_assert(cub::__can_use_radix_sort<const T*, ::cuda::std::greater<T>>);
+  static_assert(cub::__can_use_radix_sort<const T*, ::cuda::std::less<T>>);
+  static_assert(cub::__can_use_radix_sort<const T*, ::cuda::std::greater<T>>);
+
+  static_assert(cub::__can_use_radix_sort<const T*, ::cuda::std::less<>>);
+  static_assert(cub::__can_use_radix_sort<const T*, ::cuda::std::greater<>>);
+  static_assert(cub::__can_use_radix_sort<const T*, ::cuda::std::less<>>);
+  static_assert(cub::__can_use_radix_sort<const T*, ::cuda::std::greater<>>);
+
+  static_assert(cub::__can_use_radix_sort<T*, const ::cuda::std::less<T>>);
+  static_assert(cub::__can_use_radix_sort<T*, const ::cuda::std::greater<T>>);
+  static_assert(cub::__can_use_radix_sort<T*, const ::cuda::std::less<T>>);
+  static_assert(cub::__can_use_radix_sort<T*, const ::cuda::std::greater<T>>);
+
+  static_assert(cub::__can_use_radix_sort<T*, const ::cuda::std::less<>>);
+  static_assert(cub::__can_use_radix_sort<T*, const ::cuda::std::greater<>>);
+  static_assert(cub::__can_use_radix_sort<T*, const ::cuda::std::less<>>);
+  static_assert(cub::__can_use_radix_sort<T*, const ::cuda::std::greater<>>);
 
   void operator()() const {}
 };

--- a/thrust/testing/cuda/sort.cu
+++ b/thrust/testing/cuda/sort.cu
@@ -161,6 +161,16 @@ struct TestRadixSortDispatch
   static_assert(cub::__can_use_radix_sort<T*, const ::cuda::std::less<>>);
   static_assert(cub::__can_use_radix_sort<T*, const ::cuda::std::greater<>>);
 
+  static_assert(cub::__can_use_radix_sort<cuda::std::reverse_iterator<T*>, ::cuda::std::less<T>>);
+  static_assert(cub::__can_use_radix_sort<cuda::std::reverse_iterator<T*>, ::cuda::std::greater<T>>);
+  static_assert(cub::__can_use_radix_sort<cuda::std::reverse_iterator<T*>, ::cuda::std::less<T>>);
+  static_assert(cub::__can_use_radix_sort<cuda::std::reverse_iterator<T*>, ::cuda::std::greater<T>>);
+
+  static_assert(cub::__can_use_radix_sort<cuda::std::reverse_iterator<T*>, ::cuda::std::less<>>);
+  static_assert(cub::__can_use_radix_sort<cuda::std::reverse_iterator<T*>, ::cuda::std::greater<>>);
+  static_assert(cub::__can_use_radix_sort<cuda::std::reverse_iterator<T*>, ::cuda::std::less<>>);
+  static_assert(cub::__can_use_radix_sort<cuda::std::reverse_iterator<T*>, ::cuda::std::greater<>>);
+
   void operator()() const {}
 };
 SimpleUnitTest<TestRadixSortDispatch,

--- a/thrust/thrust/system/cuda/detail/sort.h
+++ b/thrust/thrust/system/cuda/detail/sort.h
@@ -271,45 +271,26 @@ THRUST_RUNTIME_FUNCTION void radix_sort(execution_policy<Derived>& policy, Key* 
 
 namespace __smart_sort
 {
-template <class Key, class CompareOp>
-using can_use_primitive_sort = ::cuda::std::integral_constant<
-  bool,
-  (::cuda::std::is_arithmetic_v<Key>
-#  if _CCCL_HAS_NVFP16() && !defined(__CUDA_NO_HALF_OPERATORS__) && !defined(__CUDA_NO_HALF_CONVERSIONS__)
-   || ::cuda::std::is_same_v<Key, __half>
-#  endif // _CCCL_HAS_NVFP16() && !defined(__CUDA_NO_HALF_OPERATORS__) && !defined(__CUDA_NO_HALF_CONVERSIONS__)
-#  if _CCCL_HAS_NVBF16() && !defined(__CUDA_NO_BFLOAT16_CONVERSIONS__) && !defined(__CUDA_NO_BFLOAT16_OPERATORS__)
-   || ::cuda::std::is_same_v<Key, __nv_bfloat16>
-#  endif // _CCCL_HAS_NVBF16() && !defined(__CUDA_NO_BFLOAT16_CONVERSIONS__) &&
-         // !defined(__CUDA_NO_BFLOAT16_OPERATORS__)
-   )
-    && (::cuda::std::is_same_v<CompareOp, ::cuda::std::less<Key>>
-        || ::cuda::std::is_same_v<CompareOp, ::cuda::std::less<void>>
-        || ::cuda::std::is_same_v<CompareOp, ::cuda::std::greater<Key>>
-        || ::cuda::std::is_same_v<CompareOp, ::cuda::std::greater<void>>)>;
-
-template <
-  class SORT_ITEMS,
-  class STABLE,
-  class Policy,
-  class KeysIt,
-  class ItemsIt,
-  class CompareOp,
-  ::cuda::std::enable_if_t<!can_use_primitive_sort<thrust::detail::it_value_t<KeysIt>, CompareOp>::value, int> = 0>
+template <class SORT_ITEMS,
+          class STABLE,
+          class Policy,
+          class KeysIt,
+          class ItemsIt,
+          class CompareOp,
+          ::cuda::std::enable_if_t<!CUB_NS_QUALIFIER::__can_use_radix_sort<KeysIt, CompareOp>, int> = 0>
 THRUST_RUNTIME_FUNCTION void
 smart_sort(Policy& policy, KeysIt keys_first, KeysIt keys_last, ItemsIt items_first, CompareOp compare_op)
 {
   __merge_sort::merge_sort<SORT_ITEMS, STABLE>(policy, keys_first, keys_last, items_first, compare_op);
 }
 
-template <
-  class SORT_ITEMS,
-  class /*STABLE*/,
-  class Policy,
-  class KeysIt,
-  class ItemsIt,
-  class CompareOp,
-  ::cuda::std::enable_if_t<can_use_primitive_sort<thrust::detail::it_value_t<KeysIt>, CompareOp>::value, int> = 0>
+template <class SORT_ITEMS,
+          class /*STABLE*/,
+          class Policy,
+          class KeysIt,
+          class ItemsIt,
+          class CompareOp,
+          ::cuda::std::enable_if_t<CUB_NS_QUALIFIER::__can_use_radix_sort<KeysIt, CompareOp>, int> = 0>
 THRUST_RUNTIME_FUNCTION void smart_sort(
   execution_policy<Policy>& policy,
   KeysIt keys_first,


### PR DESCRIPTION
This implements the sort algorithm for the cuda backend.

* std::sort see https://en.cppreference.com/w/cpp/algorithm/sort.html

It provides tests and benchmarks similar to Thrust and some boilerplate for libcu++

The functionality is publicly available yet and implemented in a private internal header

Fixes #7376
