### PR TITLE
Document public CUB tuning API

### DIFF
--- a/docs/cub/index.rst
+++ b/docs/cub/index.rst
@@ -10,6 +10,7 @@ CUB
    Overview <self>
    test_overview
    benchmarking
+   policy_selectors
    tuning
    developer_overview
    releases

--- a/docs/cub/policy_selectors.rst
+++ b/docs/cub/policy_selectors.rst
@@ -13,7 +13,7 @@ e.g. :code:`cub::ReducePolicy`, which must be returned by a policy selector pass
 CUB provides default policy selectors providing tunings for known architectures and workloads,
 which are not publicly accessible to users, but used internally by CUB to select tunings.
 Users can override CUB's policy selector for a given algorithm
-by passing a custom policy selector through the algorithm's environment parameter,
+by passing a custom policy selector through the algorithm's environment parameter.
 
 For a description of how policy selectors are used internally in CUB's dispatch layer and kernels
 see the corresponding :ref:`developer documentation <cub-developer-guide-device-scope>`.
@@ -55,9 +55,9 @@ taking a ``cuda::arch_id`` and returning the algorithm's policy struct:
       }
     };
 
-The policy selector must be stateless (:coda:`std::is_empty_v<T>` must be :coda:`true`),
+The policy selector must be stateless (:code:`std::is_empty_v<T>` must be :code:`true`),
 since only its type will be passed to a kernel and it will be default-constructed in device code.
-It can be a class template, but then only a full specialization can be passed to cub,
+It can be a class template, but then only a full specialization can be passed to CUB,
 e.g., :code:`my_reduce_tuning<float>`.
 The implementation can use branches and helper functions arbitrarily,
 as long as they can be evaluated at compile-time.
@@ -73,7 +73,7 @@ and each algorithm will pick the one with the matching policy struct.
 This is useful if the same environment is reused across several algorithm calls.
 
 The policy structs themselves aim to be simple aggregates without special member functions (constructors, assignment operators, etc.),
-thus supporting C++20 designated initializers (i.e., the syntax :code:`{ .block_threads = 512, ... }`.
+thus supporting C++20 designated initializers (i.e., the syntax :code:`{ .block_threads = 512, ... }`).
 They may occasionally contain member functions that compute derived values from the contained tuning values.
 They support comparison for (in-)equality and serialization using :code:`operator<<`.
 All policy structs are public types and will try to evolve in a non-breaking way,
@@ -104,7 +104,7 @@ Multiple tunings for different algorithms can be combined in a single environmen
     cub::DeviceScan::ExclusiveSum(d_in, d_out, num_items, env);
 
 An environment can carry further properties like a stream or a memory resource.
-Policy selectors can simply by added to those:
+Policy selectors can simply be added to those:
 
 .. code:: c++
 

--- a/docs/cub/policy_selectors.rst
+++ b/docs/cub/policy_selectors.rst
@@ -74,9 +74,9 @@ Multiple policy selectors returning different policy structs can be passed as pa
 and each algorithm will pick the one with the matching policy struct.
 This is useful if the same environment is reused across several algorithm calls.
 
-The policy structs themselves are simple aggregates without special member functions (no constructors, assignment operators, etc.).
+The policy structs themselves are simple semiregular aggregates.
 They support C++20 designated initializers (i.e., the syntax :code:`{ .block_threads = 512, ... }`),
-support comparison for (in-)equality and serialization using :code:`operator<<`.
+comparison for (in-)equality, and serialization using :code:`operator<<`.
 They may occasionally contain member functions that compute derived values from the contained tuning values.
 All policy structs are public types and will evolve in a non-breaking way, at least during minor releases,
 by only adding new data members at the end of the struct.

--- a/docs/cub/policy_selectors.rst
+++ b/docs/cub/policy_selectors.rst
@@ -1,0 +1,126 @@
+.. _cub-policy-selectors:
+
+CUB Tuning Policy Selectors
+================================================================================
+
+Policy selectors are the mechanism by which CUB's device algorithms and kernels select
+tuning parameters for a given GPU architecture and workload.
+A policy selector is a stateless callable that maps a :code:`cuda::arch_id` to a policy struct
+containing the tuning values for that architecture.
+Each set of CUB algorithms using a common underlying implementation defines a common policy struct,
+e.g. :code:`cub::ReducePolicy`, which must be returned by a policy selector passed to those algorithms.
+
+CUB provides default policy selectors providing tunings for known architectures and workloads,
+which are not publicly accessible to users, but used internally by CUB to select tunings.
+Users can override CUB's policy selector for a given algorithm
+by passing a custom policy selector through the algorithm's environment parameter,
+
+For a description of how policy selectors are used internally in CUB's dispatch layer and kernels
+see the corresponding :ref:`developer documentation <cub-developer-guide-device-scope>`.
+
+Defining a policy selector
+--------------------------------------------------------------------------------
+
+A policy selector is any type with a :code:`__host__`,  :code:`__device__`, and :code:`constexpr` call operator
+taking a ``cuda::arch_id`` and returning the algorithm's policy struct:
+
+..
+    TODO(bgruber): we have to update this example again after the reduce tuning API has been actually released
+
+.. code:: c++
+
+    template <typename T>
+    struct my_reduce_tuning {
+      __host__ __device__ constexpr auto operator()(cuda::arch_id arch) const -> cub::ReducePolicy {
+        // tuning for Hopper and later
+        if (arch >= cuda::arch_id::sm_90) {
+          const auto policy = cub::detail::agent_reduce_policy{
+            .block_threads = 512,
+            .items_per_thread = 64 / sizeof(T), // 8 double, 16 float, 32 half_t, ...
+            .vector_load_length = 2,
+            .block_algorithm = cub::BLOCK_REDUCE_WARP_REDUCTIONS,
+            .load_modifier = cub::LOAD_DEFAULT
+          };
+          return {policy, policy, policy, policy};
+        }
+        // fallback for older architectures
+        const auto policy = cub::detail::agent_reduce_policy{
+          .block_threads = 256,
+          .items_per_thread = 12,
+          .vector_load_length = 1,
+          .block_algorithm = cub::BLOCK_REDUCE_WARP_REDUCTIONS,
+          .load_modifier = cub::LOAD_DEFAULT
+        };
+        return {policy, policy, policy, policy};
+      }
+    };
+
+The policy selector must be stateless (:coda:`std::is_empty_v<T>` must be :coda:`true`),
+since only its type will be passed to a kernel and it will be default-constructed in device code.
+It can be a class template, but then only a full specialization can be passed to cub,
+e.g., :code:`my_reduce_tuning<float>`.
+The implementation can use branches and helper functions arbitrarily,
+as long as they can be evaluated at compile-time.
+The returned tuning policy can, and probably should, contain different values for different CUDA architectures or workloads.
+
+Each CUB algorithm with an environment parameter searches the environment for a policy selector returning a matching policy struct.
+If one is found, the policy selector will be used to determine the tuning values for host-side dispatch and kernel compilation.
+Each CUB algorithm documents the policy struct to which it responds.
+If CUB does not find a matching policy selector in the environment, it falls back to its internal default policy selector.
+
+Multiple policy selectors returning different policy structs can be passed as part of the same environment,
+and each algorithm will pick the one with the matching policy struct.
+This is useful if the same environment is reused across several algorithm calls.
+
+The policy structs themselves aim to be simple aggregates without special member functions (constructors, assignment operators, etc.),
+thus supporting C++20 designated initializers (i.e., the syntax :code:`{ .block_threads = 512, ... }`.
+They may occasionally contain member functions that compute derived values from the contained tuning values.
+They support comparison for (in-)equality and serialization using :code:`operator<<`.
+All policy structs are public types and will try to evolve in a non-breaking way,
+by only adding new data members at the end of the struct.
+
+
+Passing a policy selector to CUB
+--------------------------------------------------------------------------------
+
+Custom policy selectors are passed to CUB algorithms via the environment argument.
+They first need to be wrapped by passing them to :code:`cuda::execution::tune(...)`:
+
+.. code:: c++
+
+    cub::DeviceReduce::Reduce(
+      d_in, d_out, num_items, op, init,
+      cuda::execution::tune(my_reduce_tuning<int>{}));
+
+Multiple tunings for different algorithms can be combined in a single environment:
+
+.. code:: c++
+
+    auto env = cuda::execution::tune(
+      my_reduce_tuning<int>{},
+      my_scan_tuning{}
+    );
+    cub::DeviceReduce::Reduce(d_in, d_out, num_items, op, init, env);
+    cub::DeviceScan::ExclusiveSum(d_in, d_out, num_items, env);
+
+An environment can carry further properties like a stream or a memory resource.
+Policy selectors can simply by added to those:
+
+.. code:: c++
+
+    auto env = cuda::std::execution::env{
+      stream_ref,
+      resource,
+      cuda::execution::tune(my_reduce_tuning{})
+    };
+    cub::DeviceReduce::Reduce(d_in, d_out, num_items, op, init, env);
+
+    // alternatively, if we want to extend an env `other_env`
+    auto env = cuda::std::execution::env{
+      other_env,
+      cuda::execution::tune(my_reduce_tuning{})
+    };
+    cub::DeviceReduce::Reduce(d_in, d_out, num_items, op, init, env);
+
+CUB's benchmarks also make heavy use of policy selectors for tuning.
+For more details on authoring benchmarks and their policy selectors, see :ref:`cub-tuning`.

--- a/docs/cub/policy_selectors.rst
+++ b/docs/cub/policy_selectors.rst
@@ -4,13 +4,13 @@ CUB Tuning Policy Selectors
 ================================================================================
 
 Policy selectors are the mechanism by which CUB's device algorithms and kernels select
-tuning parameters for a given GPU architecture and workload.
-A policy selector is a stateless callable that maps a :code:`cuda::arch_id` to a policy struct
-containing the tuning values for that architecture.
+tuning parameters for a given workload and GPU compute capability.
+A policy selector is a stateless callable that maps a :code:`cuda::compute_capability` to a policy struct
+containing the tuning values for that compute capability.
 Each set of CUB algorithms using a common underlying implementation defines a common policy struct,
 e.g. :code:`cub::ReducePolicy`, which must be returned by a policy selector passed to those algorithms.
 
-CUB employs internal default policy selectors providing tunings for known architectures and workloads,
+CUB employs internal default policy selectors providing tunings for known compute capabilities and workloads,
 which are not publicly accessible to users.
 Users can override CUB's policy selector for a given algorithm
 by passing a custom policy selector through the algorithm's environment parameter.
@@ -22,7 +22,7 @@ Defining a policy selector
 --------------------------------------------------------------------------------
 
 A policy selector is any type with a :code:`__host__`,  :code:`__device__`, :code:`constexpr`, and :code:`const` call operator
-taking a ``cuda::arch_id`` and returning the algorithm's policy struct:
+taking a ``cuda::compute_capability`` and returning the algorithm's policy struct:
 
 ..
     TODO(bgruber): we have to update this example again after the reduce tuning API has been actually released
@@ -31,9 +31,9 @@ taking a ``cuda::arch_id`` and returning the algorithm's policy struct:
 
     template <typename T>
     struct my_reduce_tuning {
-      __host__ __device__ constexpr auto operator()(cuda::arch_id arch) const -> cub::ReducePolicy {
+      __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::ReducePolicy {
         // tuning for Hopper and later
-        if (arch >= cuda::arch_id::sm_90) {
+        if (cc >= cuda::compute_capability(9, 0)) {
           const auto policy = cub::detail::agent_reduce_policy{
             .block_threads = 512,
             .items_per_thread = 64 / sizeof(T), // 8 double, 16 float, 32 half_t, ...
@@ -43,7 +43,7 @@ taking a ``cuda::arch_id`` and returning the algorithm's policy struct:
           };
           return {policy, policy, policy, policy};
         }
-        // fallback for older architectures
+        // fallback for older GPUs
         const auto policy = cub::detail::agent_reduce_policy{
           .block_threads = 256,
           .items_per_thread = 12,
@@ -63,7 +63,7 @@ It can be a class template, but then only a full specialization can be passed to
 e.g., :code:`my_reduce_tuning<float>`.
 The implementation can use branches and helper functions arbitrarily,
 as long as they can be evaluated at compile-time.
-The returned tuning policy can, and probably should, contain different values for different CUDA architectures or workloads.
+The returned tuning policy can, and probably should, contain different values for different compute capabilities or workloads.
 
 Each CUB algorithm with an environment parameter searches the environment for a policy selector returning a matching policy struct.
 If one is found, the policy selector will be used to determine the tuning values for host-side dispatch and kernel compilation.

--- a/docs/cub/policy_selectors.rst
+++ b/docs/cub/policy_selectors.rst
@@ -55,8 +55,10 @@ taking a ``cuda::arch_id`` and returning the algorithm's policy struct:
       }
     };
 
-The policy selector must be stateless (:code:`std::is_empty_v<T>` must be :code:`true`),
-since only its type will be passed to a kernel and it will be default-constructed in device code.
+The policy selector must be stateless (:code:`std::is_empty_v<T>` must be :code:`true`)
+since only its type will be passed to a kernel.
+Policy selectors are also freely constructed and copied where needed,
+so they must also be default constructible and copyable (:code:`std::semiregular<T>` must be :code:`true`).
 It can be a class template, but then only a full specialization can be passed to CUB,
 e.g., :code:`my_reduce_tuning<float>`.
 The implementation can use branches and helper functions arbitrarily,

--- a/docs/cub/policy_selectors.rst
+++ b/docs/cub/policy_selectors.rst
@@ -10,8 +10,8 @@ containing the tuning values for that architecture.
 Each set of CUB algorithms using a common underlying implementation defines a common policy struct,
 e.g. :code:`cub::ReducePolicy`, which must be returned by a policy selector passed to those algorithms.
 
-CUB provides default policy selectors providing tunings for known architectures and workloads,
-which are not publicly accessible to users, but used internally by CUB to select tunings.
+CUB employs internal default policy selectors providing tunings for known architectures and workloads,
+which are not publicly accessible to users.
 Users can override CUB's policy selector for a given algorithm
 by passing a custom policy selector through the algorithm's environment parameter.
 
@@ -21,7 +21,7 @@ see the corresponding :ref:`developer documentation <cub-developer-guide-device-
 Defining a policy selector
 --------------------------------------------------------------------------------
 
-A policy selector is any type with a :code:`__host__`,  :code:`__device__`, and :code:`constexpr` call operator
+A policy selector is any type with a :code:`__host__`,  :code:`__device__`, :code:`constexpr`, and :code:`const` call operator
 taking a ``cuda::arch_id`` and returning the algorithm's policy struct:
 
 ..
@@ -72,11 +72,11 @@ Multiple policy selectors returning different policy structs can be passed as pa
 and each algorithm will pick the one with the matching policy struct.
 This is useful if the same environment is reused across several algorithm calls.
 
-The policy structs themselves aim to be simple aggregates without special member functions (constructors, assignment operators, etc.),
-thus supporting C++20 designated initializers (i.e., the syntax :code:`{ .block_threads = 512, ... }`).
+The policy structs themselves are simple aggregates without special member functions (no constructors, assignment operators, etc.).
+They support C++20 designated initializers (i.e., the syntax :code:`{ .block_threads = 512, ... }`),
+support comparison for (in-)equality and serialization using :code:`operator<<`.
 They may occasionally contain member functions that compute derived values from the contained tuning values.
-They support comparison for (in-)equality and serialization using :code:`operator<<`.
-All policy structs are public types and will try to evolve in a non-breaking way,
+All policy structs are public types and will evolve in a non-breaking way, at least during minor releases,
 by only adding new data members at the end of the struct.
 
 
@@ -111,7 +111,8 @@ Policy selectors can simply be added to those:
     auto env = cuda::std::execution::env{
       stream_ref,
       resource,
-      cuda::execution::tune(my_reduce_tuning{})
+      cuda::execution::tune(
+        my_reduce_tuning<int>{}, my_reduce_tuning{})
     };
     cub::DeviceReduce::Reduce(d_in, d_out, num_items, op, init, env);
 

--- a/docs/cub/tuning.rst
+++ b/docs/cub/tuning.rst
@@ -114,51 +114,56 @@ a :code:`nvbench::type_list`. For more details on the benchmark signature, take 
   void algname(nvbench::state &state, nvbench::type_list<T, OffsetT>)
   {...}
 
-.. @giannis: not sure if Policy Hub should be part of "Authoring Benchmarks" since it's attached to the Dispatch Layer. Policy Hub
-.. is not supposed to be used only when we run benchmarks, but in general when a primitive is invoked with specific compile time params.
+Before proceeding further with the benchmark authoring
+it is imperative to understand policy selectors and how they provide tuning values.
 
-Before proceeding further with the benchmark authoring it is imperative to understand the Policy Hub mechanism.
++++++++++++++++
+Policy Selector
++++++++++++++++
 
-++++++++++
-Policy Hub
-++++++++++
+The tuning value of all CUB device algorithms can be customized
+by providing a custom policy selector to the environment argument of a CUB API call.
+See :ref:`cub-policy-selectors` for a full explanation.
 
-Tuning relies on CUB's device algorithms to expose a dispatch layer which can be parameterized by a Policy Hub. The Policy Hub is an intermediate
-class that enables tuning. In other words it translates the SM architecture, the input types etc. which accepts at instantiation as input,
-into the parameter values that are optimal for when executing the specific compile time workload.
+The tuning infrastructure will use the :code:`TUNE_BASE` macro to distinguish between compiling the base version (i.e. baseline) of a benchmark
+and compiling a variant for a given set of tuning parameters.
+When base is used, no custom policy selector is specified, so CUB's default tunings are used.
+If :code:`TUNE_BASE` is not defined, we define a custom policy selector
+that specifies the values for the current variant (i.e. the current set of tuning parameters),
+which are derived from the parameter macros defined in the :code:`%RANGE%` comments, which define the search space.
+This custom policy selector is passed to :code:`cuda::execution::tune`,
+and the returned values is included in the environment passed to the CUB API.
 
-CUB usually provides a default policy hub, but when tuning we want to overwrite it, so we have to specialize the dispatch layer.
-**The tuning infrastructure will use the** :code:`TUNE_BASE` **macro to distinguish between compiling the base version (i.e. baseline) of a benchmark
-and compiling a variant for a given set of tuning parameters.**
-When base is used, no policy is specified, so that the default policy CUB provides is used.
-If :code:`TUNE_BASE` is not defined, we specify a custom policy
-using the parameter macros defined in the :code:`%RANGE%` comments which define the search space.
-
-The following code is included in the benchmark for the policy hub to be enabled and the parameters to have effect in execution:
+The following code is included in the benchmark for the policy selector to be enabled
+and the parameters to have effect in execution:
 
 ..
-    The following code is repeated further down as well. Please keep in sync!
-    TODO(bgruber): replace this example with the new tuning API design
+    TODO(bgruber): we have to update this example again after the reduce tuning API has been actually released
 
 .. code:: c++
 
-  #if TUNE_BASE
-    using dispatch_t = cub::DispatchReduce<T, OffsetT>; // uses default policy hub
-  #else
-    template <typename AccumT, typename OffsetT>
-    struct policy_hub_t {
-      struct MaxPolicy : cub::ChainedPolicy<300, policy_t, policy_t> {
-        static constexpr int threads_per_block  = TUNE_THREADS_PER_BLOCK;
-        static constexpr int items_per_thread   = TUNE_ITEMS_PER_THREAD;
-        ...
+  #if !TUNE_BASE
+  template <typename T>
+  struct policy_selector {
+    _CCCL_API constexpr auto operator()(cuda::arch_id /*arch*/) const -> cub::ReducePolicy {
+      const auto [items, threads] = cub::detail::scale_mem_bound(
+                                     TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, sizeof(T));
+      const auto policy = cub::detail::agent_reduce_policy{
+        .block_threads = threads,
+        .items_per_thread = items,
+        .vector_load_length = 1 << TUNE_ITEMS_PER_VEC_LOAD_POW2,
+        .block_algorithm = cub::BLOCK_REDUCE_WARP_REDUCTIONS,
+        .load_modifier = cub::LOAD_DEFAULT
       };
-    };
-
-    using dispatch_t = cub::DispatchReduce<T, OffsetT, policy_hub_t<accum_t, offset_t>>;
+      return {policy, policy, policy, policy};
+    }
+  };
   #endif
 
-The custom policy hub used for tuning should only expose a single :code:`MaxPolicy` for CUB to use.
-It must contain all parameters required for the full definition of the search space.
+The custom policy selector returns a fixed policy regardless of the CUDA architecture,
+since tuning is usually done on a specific GPU architecture and compiling only for that architecture.
+The policy selectors uses all tuning parameters from the search space to form the policy used by CUB.
+
 
 +++++++++
 Main Body
@@ -187,41 +192,26 @@ For this, you can optionally provide information on the memory reads and writes 
     state.add_global_memory_reads<T>(elements, "Size");
     state.add_global_memory_writes<T>(1);
 
-Most CUB algorithms need to be called twice:
-
-1. once to query the amount of temporary storage needed,
-2. once to run the actual algorithm.
-
-We perform the first call now and allocate temporary storage:
-
-.. code:: c++
-
-    std::size_t temp_size;
-    dispatch_t::Dispatch(nullptr,
-                         temp_size,
-                         d_in,
-                         d_out,
-                         static_cast<offset_t>(elements),
-                         0 /* stream */);
-
-    thrust::device_vector<char> temp(temp_size);
-    auto *temp_storage = thrust::raw_pointer_cast(temp.data());
-
-Finally, we can execute the timed region of the benchmark,
-which contains the second call to a CUB algorithm and performs the actual work we want to benchmark:
+Finally, the actual benchmark region then calls the public CUB API with an appropriate environment.
+Temporary storage allocation is handled automatically by a caching allocator provided through the environment.
+The CUDA stream is provided by the :code:`nvbench::launch` parameter of the benchmark lambda.
+When tuning (:code:`TUNE_BASE` is not defined),
+an instance of the custom policy selector is wrapped by :code:`cuda::execution::tune` and passed to the environment as well.
 
 .. code:: c++
 
+    caching_allocator_t alloc;
     state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch,
                [&](nvbench::launch &launch) {
-      dispatch_t::Dispatch(temp_storage,
-                           temp_size,
-                           d_in,
-                           d_out,
-                           static_cast<offset_t>(elements),
-                           launch.get_stream());
+      auto env = cub_bench_env(
+        alloc,
+        launch
+  #if !TUNE_BASE
+        , cuda::execution::tune(policy_selector<T>{})
+  #endif // !TUNE_BASE
+      );
+      cub::DeviceReduce::Reduce(d_in, d_out, elements, op_t{}, init, env);
     });
-  }
 
 This concludes defining the benchmark function.
 Now we need to tell NVBench about it.
@@ -526,7 +516,7 @@ For all these reasons, comparing the distribution of samples is the only reliabl
 whether a tuning provides a consistent speedup for all runtime workloads.
 
 
-Creating tuning policies
+Creating and extending tuning policies
 --------------------------------------------------------------------------------
 
 Once a suitable tuning result has been selected, we have to translate it into C++ code that will be picked up by CUB.
@@ -554,68 +544,65 @@ was thus compiled with ``-DTUNE_ITEMS_PER_THREAD=19 -DTUNE_THREADS_PER_BLOCK=512
 The meaning of these values is specific to the benchmark definition,
 and we have to check the benchmark’s source code for how they are applied.
 Equally named tuning parameters may not translate to different benchmarks (please double check).
-These tuning parameters are then typically used to create a policy hub,
-which is passed to the algorithm’s dispatcher, as :ref:`sketched above <cub-tuning-authoring-benchmarks>`,
-and repeated here:
+
+As a user of CUB,
+such a new set of tuning parameters (i.e. a variant) is then typically used to define a policy selector,
+which is passed to the public CUB API through the environment,
+as :ref:`sketched above <cub-tuning-authoring-benchmarks>`:
 
 .. code:: c++
-
-  #if !TUNE_BASE
-    template <typename AccumT, typename OffsetT>
-    struct policy_hub_t {
-      struct MaxPolicy : cub::ChainedPolicy<300, policy_t, policy_t> {
-        static constexpr int threads_per_block  = TUNE_THREADS_PER_BLOCK;
-        static constexpr int items_per_thread   = TUNE_ITEMS_PER_THREAD;
-        using AlgorithmPolicy = AgentAlgorithmPolicy<threads_per_block, items_per_thread, ...>;
+  struct policy_selector {
+    _CCCL_API constexpr auto operator()(cuda::arch_id /*arch*/) const -> cub::AlgorithmPolicy {
+      return {
+        .block_threads = 512,
+        .items_per_thread = 19,
+        ...
       };
-  #endif
+    }
+  };
 
-.. @giannis: sentences below are loaded simplify/expand them
+The default tunings defined inside CUB’s source use the same infrastructure
+but should only be changed and extended by the CCCL maintainers.
+All default tunings are found in the :code:`cub/device/detail/tuning/tuning_*.cuh` headers, organized by algorithm.
+CUB's policy selectors are highly parameterized on type information and traits of the input arguments to CUB algorithms
+(like accumulator type, offset size, and operation kind),
+which they turn into a policy for a given architecture.
 
-The tunings defined in CUB's source are similar.
-However, they take predefined tuning values based on the template arguments of a CUB algorithm
-to build an agent policy for the policy hub.
 The way tuning values are selected is different for each CUB algorithm and requires studying the corresponding code.
-The general principles of the policy hub and tunings are documented in the :ref:`CUB device layer documentation <cub-developer-policies>`.
-There is typically a tuning class template specialization per variant or group of variants and per PTX version.
+The general principles of policy selectors and tunings are documented :ref:`here <cub-policy-selectors>`.
 For example, signed and unsigned integers of the same size are often represented by the same tuning.
 In general, variants for which the algorithmic behavior is expected to be the same
 (same arithmetic intensity, no special instructions for one of the data types, same amount of bytes to load/store, etc.)
 are covered by the same tuning.
 
-When new tuning values have been found and an existing tuning specialization exists for this variant,
-the tuning values can simply be updated in the corresponding CUB tuning header.
+When a better variant has been found and CUB already has a tuning for this variant,
+the tuning parameter values can simply be updated in the corresponding CUB tuning header.
 This is usually the case when a CUB algorithm has been reengineered and shows different performance characteristics,
 or more tuning parameters are exposed (e.g., a new load algorithm is available).
-For example, this existing radix sort tuning may exist:
+For example, an existing tuning selection function may contain code like:
 
 .. code:: c++
 
-    template <typename ValueT, size_t KeySize, size_t ValueSize, size_t OffsetSize>
-    struct sm100_small_key_tuning : sm90_small_key_tuning<KeySize, ValueSize, OffsetSize> {};
-    ...
-    template <typename ValueT>
-    struct sm100_small_key_tuning<ValueT, 1, 0, 8> {
-      static constexpr int threads = 256; // better value from tuning analysis: 512
-      static constexpr int items = 14;    // better value from tuning analysis: 19
-    };
+    constexpr auto get_sm90_tuning(type_t accum_t, op_kind_t op, int offset_size, int accum_size) {
+      if (op == op_kind_t::plus && offset_size == 4 && accum_size == 4)
+        return { .block_threads = 256, .items_per_thread = 14 }; // tuning variant proposes: 512 and 19
+      ...
+    }
 
-The template specialization applies when sorting 1-byte keys without values 8-byte offsets.
-However, the concrete value type is disregarded.
-Since we have found that 512 threads per block and 19 items per thread is better, we can update the values in place.
+Since we have found that 512 threads per block and 19 items per thread are better, we can update the value in place.
 
 A different case is when we tune beyond what's currently supported by CUB's existing tunings.
-This may be because we tune for a new hardware architecture,
-in which case a new tuning class template and specializations should be added.
+This may be because we tune for a new CUDA architecture,
+in which case a new branch based on the :code:`cuda::arch_id` passed to the :code:`policy_selector::operator()`
+should be introduced, handling this architecture.
 Or we tune for new key, value or offset types, etc.,
-in which case the existing policy hub and tuning class templates may need to be extended.
+in which case the existing tuning functions may need additional branches.
 There is no general rule on how this extension is done, though.
+The implementation may be different for each CUB algorithm.
 
-In the seldom case, that no tuning better than the existing one (baseline) has been found,
-it must be ensured that either the old tuning values are replicated in the new tuning specialization,
-or the new tuning specialization defers to the old one,
-or the tuning selection mechanism falls back accordingly.
-There is no general rule on how this is implemented.
+In the seldom case, that no variant outperforms the baseline,
+it must be ensured that any newly added logic correctly falls back to the old tuning values.
+There is again no general rule on how this is implemented.
 
 
 Verification

--- a/docs/cub/tuning.rst
+++ b/docs/cub/tuning.rst
@@ -145,7 +145,7 @@ and the parameters to have effect in execution:
   #if !TUNE_BASE
   template <typename T>
   struct policy_selector {
-    _CCCL_API constexpr auto operator()(cuda::arch_id /*arch*/) const -> cub::ReducePolicy {
+    _CCCL_API constexpr auto operator()(cuda::compute_capability /*cc*/) const -> cub::ReducePolicy {
       const auto [items, threads] = cub::detail::scale_mem_bound(
                                      TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, sizeof(T));
       const auto policy = cub::detail::agent_reduce_policy{
@@ -160,8 +160,8 @@ and the parameters to have effect in execution:
   };
   #endif
 
-The custom policy selector returns a fixed policy regardless of the CUDA architecture,
-since tuning is usually done on a specific GPU architecture and compiling only for that architecture.
+The custom policy selector returns a fixed policy regardless of the compute capability,
+since tuning is usually done on a specific GPU and compiling only for that GPU's compute capability.
 The policy selector uses all tuning parameters from the search space to form the policy used by CUB.
 
 
@@ -552,7 +552,7 @@ as :ref:`sketched above <cub-tuning-authoring-benchmarks>`:
 .. code:: c++
 
   struct policy_selector {
-    _CCCL_API constexpr auto operator()(cuda::arch_id /*arch*/) const -> cub::AlgorithmPolicy {
+    _CCCL_API constexpr auto operator()(cuda::compute_capability /*cc*/) const -> cub::AlgorithmPolicy {
       return {
         .block_threads = 512,
         .items_per_thread = 19,
@@ -566,7 +566,7 @@ but should only be changed and extended by the CCCL maintainers.
 All default tunings are found in the :code:`cub/device/detail/tuning/tuning_*.cuh` headers, organized by algorithm.
 CUB's policy selectors are highly parameterized on type information and traits of the input arguments to CUB algorithms
 (like accumulator type, offset size, and operation kind),
-which they turn into a policy for a given architecture.
+which they turn into a policy for a given compute capability.
 
 The way tuning values are selected is different for each CUB algorithm and requires studying the corresponding code.
 The general principles of policy selectors and tunings are documented :ref:`here <cub-policy-selectors>`.
@@ -592,9 +592,9 @@ For example, an existing tuning selection function may contain code like:
 Since we have found that 512 threads per block and 19 items per thread are better, we can update the value in place.
 
 A different case is when we tune beyond what's currently supported by CUB's existing tunings.
-This may be because we tune for a new CUDA architecture,
-in which case a new branch based on the :code:`cuda::arch_id` passed to the :code:`policy_selector::operator()`
-should be introduced, handling this architecture.
+This may be because we tune for a new GPU architecture,
+in which case a new branch based on the :code:`cuda::compute_capability` passed to the :code:`policy_selector::operator()`
+should be introduced, handling this new GPU's compute capability.
 Or we tune for new key, value or offset types, etc.,
 in which case the existing tuning functions may need additional branches.
 There is no general rule on how this extension is done, though.
@@ -612,8 +612,8 @@ Once we have selected tunings and implemented them in CUB, we need to verify the
 This process consists of two steps.
 
 Firstly, we need to ensure that adding new tunings and policies did not break existing tunings.
-This is most relevant when tunings for new PTX versions have been added.
-To verify this, compile the corresponding benchmarks for the previous architecture
+This is most relevant when tunings for new compute capabilities have been added.
+To verify this, compile the corresponding benchmarks for the previous compute capabilities
 (excluding the new tunings) before and after modifying any tunings,
 and compare the generated SASS :code:(`cuobjdump -sass`).
 It should not have changed.

--- a/docs/cub/tuning.rst
+++ b/docs/cub/tuning.rst
@@ -545,8 +545,7 @@ The meaning of these values is specific to the benchmark definition,
 and we have to check the benchmark’s source code for how they are applied.
 Equally named tuning parameters may not translate to different benchmarks (please double check).
 
-As a user of CUB,
-such a new set of tuning parameters (i.e. a variant) is then typically used to define a policy selector,
+As a user of CUB, such a new set of tuning parameters (i.e. a variant) can then be used to define a policy selector,
 which is passed to the public CUB API through the environment,
 as :ref:`sketched above <cub-tuning-authoring-benchmarks>`:
 

--- a/docs/cub/tuning.rst
+++ b/docs/cub/tuning.rst
@@ -132,7 +132,7 @@ If :code:`TUNE_BASE` is not defined, we define a custom policy selector
 that specifies the values for the current variant (i.e. the current set of tuning parameters),
 which are derived from the parameter macros defined in the :code:`%RANGE%` comments, which define the search space.
 This custom policy selector is passed to :code:`cuda::execution::tune`,
-and the returned values is included in the environment passed to the CUB API.
+and the returned value is included in the environment passed to the CUB API.
 
 The following code is included in the benchmark for the policy selector to be enabled
 and the parameters to have effect in execution:
@@ -162,7 +162,7 @@ and the parameters to have effect in execution:
 
 The custom policy selector returns a fixed policy regardless of the CUDA architecture,
 since tuning is usually done on a specific GPU architecture and compiling only for that architecture.
-The policy selectors uses all tuning parameters from the search space to form the policy used by CUB.
+The policy selector uses all tuning parameters from the search space to form the policy used by CUB.
 
 
 +++++++++
@@ -551,6 +551,7 @@ which is passed to the public CUB API through the environment,
 as :ref:`sketched above <cub-tuning-authoring-benchmarks>`:
 
 .. code:: c++
+
   struct policy_selector {
     _CCCL_API constexpr auto operator()(cuda::arch_id /*arch*/) const -> cub::AlgorithmPolicy {
       return {


### PR DESCRIPTION
I let claude rewrite the documentation and did a lot of manual editing on top. Here is a summary by claude claude:

  - Updated `docs/cub/developer/device_scope.rst` to document the new dispatch architecture: `policy_selector` + `dispatch_arch` replacing `ChainedPolicy`/`MaxPolicy`/`PolicyHub`                                   
  - Created `docs/cub/policy_selectors.rst` explaining how users define and pass custom policy selectors via `cuda::execution::tune`                                                                                 
  - Updated `docs/cub/tuning.rst` so benchmarks call the public CUB API with an environment instead of instantiating dispatch structs with custom policy hubs                                                        
                                                                                                                                                                                                                     
  This follows the roll-out of the new tuning API across ~20 CUB dispatchers (#7165). The old docs described `ChainedPolicy` linked lists, the `MaxPolicy` kernel trick, and template-specialization-based tunings.  
  The new architecture uses stateless `constexpr` callables returning plain aggregate policy structs, `dispatch_arch` for runtime-to-compile-time arch dispatch, and kernels querying                                
  `PolicySelector{}(arch_id{CUB_PTX_ARCH / 10})` directly

After some design reconsideration, I changed all uses of the term architecture by compute capability.

<details>
  <summary>Prompts:</summary>
  
Please look at the github issue https://github.com/NVIDIA/cccl/issues/7165.
It has many sub issues attached that are named something like "Implement the new tuning API for".
I paste the list here as well: 

Implement the new tuning API for DispatchAdjacentDifference #7522
bernhardmgruber
Implement the new tuning API for detail::for_each::dispatch_t #7525
bernhardmgruber
Implement the new tuning API for DeviceRleDispatch #7532
bernhardmgruber
Implement the new tuning API for detail::merge::dispatch_t #7638
bernhardmgruber
Implement the new tuning API for detail::reduce::dispatch_streaming_arg_reduce_t #7645
bernhardmgruber
Implement the new tuning API for DispatchReduceByKey #7531
bernhardmgruber
Implement the new tuning API for detail::find::dispatch_t #7812
bernhardmgruber
Implement the new tuning API for DispatchSegmentedRadixSort #7642
bernhardmgruber
Implement the new tuning API for DispatchStreamingReduceByKey #7533
bernhardmgruber
Implement the new tuning API for DispatchTopK #7648
bernhardmgruber
Implement the new tuning API for DispatchSegmentedSort #7643
bernhardmgruber
Implement the new tuning API for DispatchThreeWayPartitionIf #7646
bernhardmgruber
Implement the new tuning API for DeviceScan #7521
griwes
Implement the new tuning API for DispatchMergeSort #7639
bernhardmgruber
Implement the new tuning API for DispatchBatchMemcpy #7636
bernhardmgruber
Implement the new tuning API for DispatchHistogram #7637
bernhardmgruber
Implement the new tuning API for DispatchSelectIf #7644
bernhardmgruber
Implement the new tuning API for DispatchScanByKey #7640
griwes
Implement the new tuning API for DispatchUniqueByKey #7647
griwes
Implement the new tuning API for detail::batched_topk::dispatch_batched_topk #8479
bernhardmgruber
Implement the new tuning API for DispatchFixedSizeSegmentedReduce #7641
srinivasyadav18
Implement the new tuning API for detail::segmented_scan::dispatch_segmented_scan #8424
oleksandr-pavlyk

Go to each of the linked issues and find the linked pull request. if it's merged, get the git SHA of the commit that resulted from the merge. Please print the list of commit SHAs.

Now, please look at the documentation page docs/cub/developer/device_scope.rst. It documents how the CUB device level API looks like, and how it calls through the dispatch layer to a kernel. It also documents how tuning policies work, etc. This documentation is mostly obsolete based on all the pull requests above. Please look at the changes of all the git SHAs above and try to understand how the new dispatch logic works. Then please update the device_scope.rst documentation page to reflect the new architecture of CUB.

Before all the changes, I drafted a document describing the new API (a design document). I placed a copy for you into ./new_api.md. Please read that document as well. It should help you understand the changes to the documentation.

Please also update docs/cub/tuning.rst, the section titled Policy Hub. It should discuss policy selectors instead. Instead of showing how to instantiate the Dispatch struct, show how to pass a policy selector to the public CUB API. An example can be found in this PR: https://github.com/NVIDIA/cccl/pull/8495. Just show calling the public API like `cub::DeviceScan::InclusiveScan(..., /* env = */ cuda::execution::tune(policy_selector{}));`. Please also update the sections titled Main Body to call the public API instead. Also the section titled Creating tuning policies.

Please move the section "Policy Selector" to a new page between the TOC entries "CUB Benchmarks" and "CUB Tunings". Add a link to that page where the section was.

I have reworded some things. See the last two commits. I have not touched the device_scope.rst changes yet. They go to a different PR. Please check what is added by the last two commits only and suggest improvements and reword where necessary.

Just apply the changes, I can look at the diff
  
</details>

I also let claude rewrite the developer documentation, but that will come as a separate PR.

- [x] Merge before: #8728 

Fixes: #8593