### PR TITLE
[Tile] Disable tests that take the address of a function in tile mode

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/execution/execution_policy/get_memory_resource.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/execution/execution_policy/get_memory_resource.pass.cpp
@@ -8,6 +8,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/functional>

--- a/libcudacxx/test/libcudacxx/cuda/execution/execution_policy/get_stream.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/execution/execution_policy/get_stream.pass.cpp
@@ -8,6 +8,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/functional>

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/allocate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/allocate.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/construction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/construction.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/conversion.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/equality.fail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/equality.fail.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/equality.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/equality.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/inheritance.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/inheritance.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/properties.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/concepts/async_resource.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/concepts/async_resource.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/concepts/async_resource_with.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/concepts/async_resource_with.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/concepts/resource.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/concepts/resource.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/concepts/resource_with.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/concepts/resource_with.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/get_memory_resource/get_memory_resource.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/get_memory_resource/get_memory_resource.pass.cpp
@@ -8,6 +8,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/__functional/call_or.h>

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/get_property/forward_property.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/get_property/forward_property.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 // cuda::forward_property

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/get_property/get_property.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/get_property/get_property.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/get_property/has_property.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/get_property/has_property.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/properties/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/properties/properties.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/allocate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/allocate.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/construction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/construction.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/conversion.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/equality.fail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/equality.fail.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/equality.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/equality.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/inheritance.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/inheritance.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/properties.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/cuda/utility/basic_any.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utility/basic_any.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 #include <cuda/__utility/basic_any.h>
 #include <cuda/__utility/immovable.h>
 #include <cuda/std/__utility/as_const.h>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/remove_copy_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/remove_copy_if.pass.cpp
@@ -21,10 +21,13 @@
 #include "test_iterators.h"
 #include "test_macros.h"
 
-TEST_FUNC constexpr bool equalToTwo(const int v) noexcept
+struct equalToTwo
 {
-  return v == 2;
-}
+  TEST_FUNC constexpr bool operator()(const int v) const noexcept
+  {
+    return v == 2;
+  }
+};
 
 template <class InIter, class OutIter>
 constexpr TEST_FUNC void test()
@@ -33,7 +36,7 @@ constexpr TEST_FUNC void test()
   int ia[N]                     = {0, 1, 2, 3, 4, 2, 3, 4, 2};
   constexpr int expected[N - 3] = {0, 1, 3, 4, 3, 4};
   int ib[N]                     = {0};
-  OutIter r                     = cuda::std::remove_copy_if(InIter(ia), InIter(ia + N), OutIter(ib), equalToTwo);
+  OutIter r                     = cuda::std::remove_copy_if(InIter(ia), InIter(ia + N), OutIter(ib), equalToTwo{});
   assert(base(r) == ib + N - 3);
   for (int i = 0; i < N - 3; ++i)
   {

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/replace_copy_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/replace_copy_if.pass.cpp
@@ -22,10 +22,13 @@
 #include "test_iterators.h"
 #include "test_macros.h"
 
-constexpr TEST_FUNC bool equalToTwo(const int v) noexcept
+struct equalToTwo
 {
-  return v == 2;
-}
+  TEST_FUNC constexpr bool operator()(const int v) const noexcept
+  {
+    return v == 2;
+  }
+};
 
 template <class InIter, class OutIter>
 constexpr TEST_FUNC void test()
@@ -34,7 +37,7 @@ constexpr TEST_FUNC void test()
   constexpr int ia[N]       = {0, 1, 2, 3, 4};
   int ib[N + 1]             = {0};
   constexpr int expected[N] = {0, 1, 5, 3, 4};
-  OutIter r                 = cuda::std::replace_copy_if(InIter(ia), InIter(ia + N), OutIter(ib), equalToTwo, 5);
+  OutIter r                 = cuda::std::replace_copy_if(InIter(ia), InIter(ia + N), OutIter(ib), equalToTwo{}, 5);
   assert(base(r) == ib + N);
   for (int i = 0; i < N; ++i)
   {

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/replace_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/replace_if.pass.cpp
@@ -21,10 +21,13 @@
 #include "test_iterators.h"
 #include "test_macros.h"
 
-constexpr TEST_FUNC bool equalToTwo(const int v) noexcept
+struct equalToTwo
 {
-  return v == 2;
-}
+  TEST_FUNC constexpr bool operator()(const int v) const noexcept
+  {
+    return v == 2;
+  }
+};
 
 template <class Iter>
 constexpr TEST_FUNC void test()
@@ -32,7 +35,7 @@ constexpr TEST_FUNC void test()
   constexpr int N           = 5;
   int ia[N]                 = {0, 1, 2, 3, 4};
   constexpr int expected[N] = {0, 1, 5, 3, 4};
-  cuda::std::replace_if(Iter(ia), Iter(ia + N), equalToTwo, 5);
+  cuda::std::replace_if(Iter(ia), Iter(ia + N), equalToTwo{}, 5);
 
   for (int i = 0; i < N; ++i)
   {

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.transform/unary_transform.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.transform/unary_transform.pass.cpp
@@ -20,10 +20,13 @@
 #include "test_iterators.h"
 #include "test_macros.h"
 
-constexpr TEST_FUNC int plusOne(const int v) noexcept
+struct plusOne
 {
-  return v + 1;
-}
+  TEST_FUNC constexpr int operator()(const int v) const noexcept
+  {
+    return v + 1;
+  }
+};
 
 template <class InIter, class OutIter>
 constexpr TEST_FUNC void test()
@@ -34,7 +37,7 @@ constexpr TEST_FUNC void test()
     constexpr int expected[N] = {2, 4, 7, 8};
     int ib[N + 1]             = {0, 0, 0, 0, 0};
 
-    OutIter r = cuda::std::transform(InIter(ia), InIter(ia + N), OutIter(ib), plusOne);
+    OutIter r = cuda::std::transform(InIter(ia), InIter(ia + N), OutIter(ib), plusOne{});
     assert(base(r) == ib + N);
     for (int i = 0; i < N; ++i)
     {

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.clamp/clamp.comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.clamp/clamp.comp.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+
 // <algorithm>
 
 // template<class T, class Compare>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/merge.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/merge.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+
 // <algorithm>
 
 // template<InputIterator InIter1, InputIterator InIter2, typename OutIter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/merge_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/merge_comp.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+
 // <algorithm>
 
 // template<InputIterator InIter1, InputIterator InIter2, typename OutIter,

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.difference/set_difference.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.difference/set_difference.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+
 // <algorithm>
 
 // template<InputIterator InIter1, InputIterator InIter2, typename OutIter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.difference/set_difference_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.difference/set_difference_comp.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+
 // <algorithm>
 
 // template<InputIterator InIter1, InputIterator InIter2, typename OutIter,

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.intersection/set_intersection.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.intersection/set_intersection.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+
 // <algorithm>
 
 // template<InputIterator InIter1, InputIterator InIter2, typename OutIter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.intersection/set_intersection_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.intersection/set_intersection_comp.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+
 // <algorithm>
 
 // template<InputIterator InIter1, InputIterator InIter2, typename OutIter,

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.symmetric.difference/set_symmetric_difference.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.symmetric.difference/set_symmetric_difference.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+
 // <algorithm>
 
 // template<InputIterator InIter1, InputIterator InIter2, typename OutIter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.symmetric.difference/set_symmetric_difference_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.symmetric.difference/set_symmetric_difference_comp.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+
 // <algorithm>
 
 // template<InputIterator InIter1, InputIterator InIter2, typename OutIter,

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.union/set_union.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.union/set_union.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+
 // <algorithm>
 
 // template<InputIterator InIter1, InputIterator InIter2, typename OutIter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.union/set_union_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.union/set_union_comp.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+
 // <algorithm>
 
 // template<InputIterator InIter1, InputIterator InIter2, typename OutIter,

--- a/libcudacxx/test/libcudacxx/std/utilities/expol/environments.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expol/environments.pass.cpp
@@ -9,6 +9,10 @@
 
 // UNSUPPORTED: nvrtc
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 #include <cuda/std/execution>
 #include <cuda/std/type_traits>
 #include <cuda/stream>

--- a/libcudacxx/test/libcudacxx/std/utilities/expol/is_execution_policy.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expol/is_execution_policy.compile.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // template<class T> struct is_execution_policy;
 // template<class T> constexpr bool is_execution_policy_v = is_execution_policy<T>::value;
 

--- a/libcudacxx/test/libcudacxx/std/utilities/expol/policies.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expol/policies.compile.pass.cpp
@@ -19,6 +19,10 @@
 
 // UNSUPPORTED: libcpp-has-no-incomplete-pstl
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 #include <cuda/std/execution>
 #include <cuda/std/type_traits>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.invoke/invoke.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.invoke/invoke.pass.cpp
@@ -116,6 +116,7 @@ TEST_FUNC int& foo(NonCopyable&&)
   return data;
 }
 
+#if !_CCCL_TILE_COMPILATION() // error: taking address or reference of a function is unsupported in tile mode!
 template <class Signature, class Expect, class Functor>
 TEST_FUNC void test_b12(Functor&& f)
 {
@@ -158,6 +159,7 @@ TEST_FUNC void test_b34(Functor&& f)
   DeducedReturnType ret = cuda::std::invoke(func_ptr, cuda::std::forward<Functor>(f));
   assert(ret == 42);
 }
+#endif // !_CCCL_TILE_COMPILATION()
 
 template <class Expect, class Functor>
 TEST_FUNC void test_b5(Functor&& f)
@@ -177,6 +179,7 @@ TEST_FUNC void test_b5(Functor&& f)
   assert(ret == 42);
 }
 
+#if !_CCCL_TILE_COMPILATION() // error: taking address or reference of a function is unsupported in tile mode!
 TEST_FUNC void bullet_one_two_tests()
 {
   {
@@ -310,18 +313,23 @@ TEST_FUNC void bullet_three_four_tests()
     test_b34<int const volatile&>(static_cast<Fn const volatile*>(cl));
   }
 }
+#endif // !_CCCL_TILE_COMPILATION()
 
 TEST_FUNC void bullet_five_tests()
 {
+#if !_CCCL_TILE_COMPILATION() //  error: taking address or reference of a function is unsupported in tile mode!
   using FooType = int&(NonCopyable&&);
   {
     FooType& fn = foo;
     test_b5<int&>(fn);
   }
+#endif // !_CCCL_TILE_COMPILATION()
+#if !_CCCL_TILE_COMPILATION() // error: function-to-pointer decay is unsupported in tile code
   {
     FooType* fn = foo;
     test_b5<int&>(fn);
   }
+#endif // !_CCCL_TILE_COMPILATION()
   {
     using Fn = TestClass;
     Fn cl(42);
@@ -389,8 +397,10 @@ TEST_FUNC void noexcept_test()
 
 int main(int, char**)
 {
+#if !_CCCL_TILE_COMPILATION() // error: taking address or reference of a function is unsupported in tile mode!
   bullet_one_two_tests();
   bullet_three_four_tests();
+#endif // !_CCCL_TILE_COMPILATION()
   bullet_five_tests();
   noexcept_test();
 

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.memfn/member_function.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.memfn/member_function.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // <cuda/std/functional>
 
 // template<Returnable R, class T, CopyConstructible... Args>

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.memfn/member_function_const.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.memfn/member_function_const.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // <cuda/std/functional>
 
 // template<Returnable R, class T, CopyConstructible... Args>

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.memfn/member_function_const_volatile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.memfn/member_function_const_volatile.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // <cuda/std/functional>
 
 // template<Returnable R, class T, CopyConstructible... Args>

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.memfn/member_function_volatile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.memfn/member_function_volatile.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // <cuda/std/functional>
 
 // template<Returnable R, class T, CopyConstructible... Args>

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.not_fn/not_fn.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.not_fn/not_fn.pass.cpp
@@ -448,10 +448,12 @@ TEST_FUNC void return_type_tests()
 // other callable types here.
 TEST_FUNC void other_callable_types_test()
 {
+#if !_CCCL_TILE_COMPILATION() // error: function-to-pointer decay is unsupported in tile code
   { // test with function pointer
     auto ret = cuda::std::not_fn(returns_true);
     assert(ret() == false);
   }
+#endif // !_CCCL_TILE_COMPILATION()
   { // test with lambda
     auto returns_value = [](bool value) {
       return value;
@@ -460,6 +462,7 @@ TEST_FUNC void other_callable_types_test()
     assert(ret(true) == false);
     assert(ret(false) == true);
   }
+#if !_CCCL_TILE_COMPILATION() // error: taking address or reference of a function is unsupported in tile mode!"
   { // test with pointer to member function
     MemFunCallable mt(true);
     const MemFunCallable mf(false);
@@ -478,6 +481,7 @@ TEST_FUNC void other_callable_types_test()
     assert(ret(&mt) == false);
     assert(ret(&mf) == true);
   }
+#endif // !_CCCL_TILE_COMPILATION()
   { // test with pointer to member data
     MemFunCallable mt(true);
     const MemFunCallable mf(false);
@@ -521,11 +525,13 @@ void throws_in_constructor_test()
 
 TEST_FUNC void call_operator_sfinae_test()
 {
+#if !_CCCL_TILE_COMPILATION() // error: function-to-pointer decay is unsupported in tile code
   { // wrong number of arguments
     using T = decltype(cuda::std::not_fn(returns_true));
     static_assert(cuda::std::is_invocable<T>::value); // callable only with no args
     static_assert(!cuda::std::is_invocable<T, bool>::value);
   }
+#endif // !_CCCL_TILE_COMPILATION()
   { // violates const correctness (member function pointer)
     using T = decltype(cuda::std::not_fn(&MemFunCallable::return_value_nc));
     static_assert(cuda::std::is_invocable<T, MemFunCallable&>::value);

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.access/conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.access/conversion.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // <functional>
 
 // reference_wrapper

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.assign/copy_assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.assign/copy_assign.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // <functional>
 
 // reference_wrapper

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.const/copy_ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.const/copy_ctor.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // <functional>
 
 // reference_wrapper

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.const/type_ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.const/type_ctor.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // <functional>
 
 // reference_wrapper

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.helpers/ref_2.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.helpers/ref_2.pass.cpp
@@ -60,6 +60,7 @@ int main(int, char**)
   test();
   static_assert(test());
 
+#if !_CCCL_TILE_COMPILATION() // error: function-to-pointer decay is unsupported in tile code
   {
     unary_counting_predicate<bool (*)(int), int> cp(is5);
     assert(!cp(6));
@@ -69,6 +70,7 @@ int main(int, char**)
     assert(call_pred(cuda::std::ref(cp)));
     assert(cp.count() == 2);
   }
+#endif // !_CCCL_TILE_COMPILATION()
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.invoke/invoke_int_0.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.invoke/invoke_int_0.pass.cpp
@@ -24,8 +24,6 @@
 
 // 0 args, return int
 
-TEST_GLOBAL_VARIABLE int count = 0;
-
 TEST_FUNC int f_int_0()
 {
   return 3;
@@ -41,17 +39,21 @@ struct A_int_0
 
 TEST_FUNC void test_int_0()
 {
+#if !_CCCL_TILE_COMPILATION() // error: taking address or reference of a function is unsupported in tile mode!
   // function
   {
     cuda::std::reference_wrapper<int()> r1(f_int_0);
     assert(r1() == 3);
   }
+#endif // !_CCCL_TILE_COMPILATION()
+#if !_CCCL_TILE_COMPILATION() // error: function-to-pointer decay is unsupported in tile code
   // function pointer
   {
     int (*fp)() = f_int_0;
     cuda::std::reference_wrapper<int (*)()> r1(fp);
     assert(r1() == 3);
   }
+#endif // !_CCCL_TILE_COMPILATION()
   // functor
   {
     A_int_0 a0;
@@ -59,21 +61,6 @@ TEST_FUNC void test_int_0()
     assert(r1() == 4);
   }
 }
-
-// 1 arg, return void
-
-TEST_FUNC void f_void_1(int i)
-{
-  count += i;
-}
-
-struct A_void_1
-{
-  TEST_FUNC void operator()(int i)
-  {
-    count += i;
-  }
-};
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.invoke/robust_against_adl.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.invoke/robust_against_adl.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // <functional>
 
 // #include <cuda/std/functional>

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_nothrow_invocable.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_nothrow_invocable.pass.cpp
@@ -62,6 +62,7 @@ TEST_FUNC constexpr bool throws_invocable_r()
 
 TEST_FUNC void test_noexcept_function_pointers()
 {
+#if !_CCCL_TILE_COMPILATION() // error: taking address of a function is unsupported in tile code
   struct Dummy
   {
     TEST_FUNC void foo() noexcept {}
@@ -72,6 +73,7 @@ TEST_FUNC void test_noexcept_function_pointers()
   // pointers.
   static_assert(cuda::std::is_nothrow_invocable<decltype(&Dummy::foo), Dummy&>::value);
   static_assert(cuda::std::is_nothrow_invocable<decltype(&Dummy::bar)>::value);
+#endif // !_CCCL_TILE_COMPILATION()
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_scoped_enum.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_scoped_enum.pass.cpp
@@ -136,12 +136,15 @@ int main(int, char**)
   test_negative<void (TestMembers::*)()>();
 
   test_negative<decltype(func1)>();
-  test_negative<decltype(&func1)>();
   test_negative<decltype(func2)>();
-  test_negative<decltype(&func2)>();
   test_negative<decltype(TestMembers::static_method)>();
+
+#if !_CCCL_TILE_COMPILATION() // error: taking address of a function is unsupported in tile code
+  test_negative<decltype(&func1)>();
+  test_negative<decltype(&func2)>();
   test_negative<decltype(&TestMembers::static_method)>();
   test_negative<decltype(&TestMembers::method)>();
+#endif // !_CCCL_TILE_COMPILATION()
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.apply/apply.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.apply/apply.pass.cpp
@@ -7,7 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: nvrtc
-// UNSUPPORTED: gcc-6
+
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
 
 // <cuda/std/tuple>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.apply/apply_extended_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.apply/apply_extended_types.pass.cpp
@@ -6,7 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: gcc-6
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
 
 // <cuda/std/tuple>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.apply/apply_large_arity.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.apply/apply_large_arity.pass.cpp
@@ -6,9 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: gcc-6
 // UNSUPPORTED: windows
-// We run out of heap space with windows
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
 
 // <cuda/std/tuple>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/typeid/typeid.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/typeid/typeid.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // <cuda/std/utility>
 
 // _CCCL_TYPEID(<type>)


### PR DESCRIPTION
In tile mode it is currently unsupported to take the address of a function.

This marks most tests that rely on it as UNSUPPORTED and tries to work around the situations where it is easy to disable There are few tests we want to keep as XFAIL because we hope to work around some of the issues
