### PR TITLE
[Tile] Try to use `assert` instead of `__trap` for tile mode

### DIFF
--- a/libcudacxx/include/cuda/std/__exception/terminate.h
+++ b/libcudacxx/include/cuda/std/__exception/terminate.h
@@ -22,6 +22,10 @@
 #  pragma system_header
 #endif // no system header
 
+#if _CCCL_TILE_COMPILATION()
+#  include <cassert>
+#endif // !_CCCL_TILE_COMPILATION()
+
 #if !_CCCL_COMPILER(NVRTC)
 #  include <stdlib.h>
 #endif // !_CCCL_COMPILER(NVRTC)
@@ -35,8 +39,12 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_NOVERSION // purposefully not using versioning na
 
 [[noreturn]] _CCCL_API inline void __cccl_terminate() noexcept
 {
+#if _CCCL_TILE_COMPILATION()
+  NV_IF_ELSE_TARGET(NV_IS_HOST, (::exit(-1);), (assert(false);))
+#else // ^^^ _CCCL_TILE_COMPILATION() ^^^ / vvv !_CCCL_TILE_COMPILATION()
   NV_IF_ELSE_TARGET(NV_IS_HOST, (::exit(-1);), (::__trap();))
   _CCCL_UNREACHABLE();
+#endif // !_CCCL_TILE_COMPILATION()
 }
 
 #if 0 // Expose once atomic is universally available

--- a/libcudacxx/include/cuda/std/__exception/terminate.h
+++ b/libcudacxx/include/cuda/std/__exception/terminate.h
@@ -23,7 +23,7 @@
 #endif // no system header
 
 #if _CCCL_TILE_COMPILATION()
-#  include <cassert>
+#  include <cuda/std/cassert>
 #endif // !_CCCL_TILE_COMPILATION()
 
 #if !_CCCL_COMPILER(NVRTC)


### PR DESCRIPTION
Trap is currently not available in tile mode.

See nvbug6072716
