### PR TITLE
[Tile] Avoid uses of `threadIdx` and related CUDA builtins

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/functional/proclaim_return_type.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/proclaim_return_type.pass.cpp
@@ -8,8 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: gcc-4
-
 #include <cuda/functional>
 #include <cuda/std/cassert>
 #include <cuda/std/type_traits>
@@ -20,10 +18,16 @@
 template <typename ReturnT>
 TEST_FUNC void test_lambda_return_type()
 {
-  // Ensure type can be queried from cuda::std::invoke_result_t
+// Ensure type can be queried from cuda::std::invoke_result_t
+#  if _CCCL_TILE_COMPILATION()
+  auto d_lm = [] _CCCL_TILE() -> ReturnT {
+    return ReturnT{};
+  };
+#  else // ^^^ _CCCL_TILE_COMPILATION() ^^^ / vvv !_CCCL_TILE_COMPILATION() vvv
   auto d_lm = [] TEST_DEVICE_FUNC() -> ReturnT {
     return ReturnT{};
   };
+#  endif // !_CCCL_TILE_COMPILATION()
   auto hd_lm = [] TEST_FUNC() -> ReturnT {
     return ReturnT{};
   };

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/block_level/hierarchy_queries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/block_level/hierarchy_queries.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 #include "hierarchy_queries.h"
 
 #include <cuda/hierarchy>

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/block_level/hierarchy_query_signatures.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/block_level/hierarchy_query_signatures.compile.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 #include <cuda/hierarchy>
 #include <cuda/std/cstddef>
 #include <cuda/std/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/block_level/native_hierarchy_queries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/block_level/native_hierarchy_queries.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 #include <cuda/hierarchy>
 #include <cuda/std/cassert>
 #include <cuda/std/cstddef>

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/block_level/native_hierarchy_query_signatures.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/block_level/native_hierarchy_query_signatures.compile.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 #include <cuda/hierarchy>
 #include <cuda/std/cstddef>
 #include <cuda/std/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/cluster_level/hierarchy_queries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/cluster_level/hierarchy_queries.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 #include "hierarchy_queries.h"
 
 #include <cuda/hierarchy>

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/cluster_level/hierarchy_query_signatures.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/cluster_level/hierarchy_query_signatures.compile.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 #include <cuda/hierarchy>
 #include <cuda/std/cstddef>
 #include <cuda/std/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/cluster_level/native_hierarchy_queries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/cluster_level/native_hierarchy_queries.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 #include <cuda/hierarchy>
 #include <cuda/std/cassert>
 #include <cuda/std/cstddef>

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/cluster_level/native_hierarchy_query_signatures.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/cluster_level/native_hierarchy_query_signatures.compile.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 #include <cuda/hierarchy>
 #include <cuda/std/mdspan>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/hierarchy_objects.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/hierarchy_objects.compile.pass.cpp
@@ -10,6 +10,8 @@
 #include <cuda/hierarchy>
 #include <cuda/std/type_traits>
 
+#include "test_macros.h"
+
 static_assert(cuda::std::is_same_v<cuda::thread_level, cuda::std::remove_const_t<decltype(cuda::gpu_thread)>>);
 static_assert(cuda::std::is_same_v<cuda::warp_level, cuda::std::remove_const_t<decltype(cuda::warp)>>);
 static_assert(cuda::std::is_same_v<cuda::block_level, cuda::std::remove_const_t<decltype(cuda::block)>>);

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/hierarchy_queries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/hierarchy_queries.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 #include "hierarchy_queries.h"
 
 #include <cuda/hierarchy>

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/hierarchy_query_signatures.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/hierarchy_query_signatures.compile.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 #include <cuda/hierarchy>
 #include <cuda/std/cstddef>
 #include <cuda/std/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/native_hierarchy_queries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/native_hierarchy_queries.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 #include <cuda/hierarchy>
 #include <cuda/std/cassert>
 #include <cuda/std/cstddef>

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/native_hierarchy_query_signatures.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/native_hierarchy_query_signatures.compile.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 #include <cuda/hierarchy>
 #include <cuda/std/cstddef>
 #include <cuda/std/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/warp_level/hierarchy_queries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/warp_level/hierarchy_queries.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 #include "hierarchy_queries.h"
 
 #include <cuda/hierarchy>

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/warp_level/hierarchy_query_signatures.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/warp_level/hierarchy_query_signatures.compile.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 #include <cuda/hierarchy>
 #include <cuda/std/cstddef>
 #include <cuda/std/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/warp_level/native_hierarchy_queries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/warp_level/native_hierarchy_queries.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 #include <cuda/hierarchy>
 #include <cuda/std/cassert>
 #include <cuda/std/cstddef>

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/warp_level/native_hierarchy_query_signatures.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/warp_level/native_hierarchy_query_signatures.compile.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 #include <cuda/hierarchy>
 #include <cuda/std/cstddef>
 #include <cuda/std/mdspan>


### PR DESCRIPTION
In tile mode we cannot access any of threadIdx or gridDim or ...

We also cannot use compiler builtins such as `__isGlobal` because those are recognized as device functions
