### PR TITLE
[Tile] Disable host only tests

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_accessor/host_accessor.1.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_accessor/host_accessor.1.runfail.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_accessor/host_accessor.2.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_accessor/host_accessor.2.runfail.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+
 #include <cuda/mdspan>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_accessor/host_accessor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_accessor/host_accessor.pass.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/utilities/expected/expected.void/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/expected/expected.void/host_only_types.pass.cpp
@@ -7,6 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/utilities/expected/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/expected/host_only_types.pass.cpp
@@ -7,6 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/utilities/optional/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/optional/host_only_types.pass.cpp
@@ -7,6 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/utilities/tuple/forward_as_tuple_interop.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/tuple/forward_as_tuple_interop.pass.cpp
@@ -7,7 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+
 // UNSUPPORTED: nvrtc
+
 #include <cuda/std/cassert>
 #include <cuda/std/tuple>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/cuda/utilities/tuple/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/tuple/host_only_types.pass.cpp
@@ -7,6 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/utilities/tuple/vector_types_get.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/tuple/vector_types_get.pass.cpp
@@ -7,6 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+
 #include <cuda/std/__floating_point/fp.h>
 #include <cuda/std/cassert>
 #include <cuda/std/limits>

--- a/libcudacxx/test/libcudacxx/cuda/utilities/unexpected/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/unexpected/host_only_types.pass.cpp
@@ -7,6 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/utilities/utility/pair/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/utility/pair/host_only_types.pass.cpp
@@ -7,6 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/utilities/utility/pair/interop/pair.assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/utility/pair/interop/pair.assign.pass.cpp
@@ -7,6 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/utilities/utility/pair/interop/pair.cons.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/utility/pair/interop/pair.cons.pass.cpp
@@ -7,7 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+
 // UNSUPPORTED: nvrtc
+
 #include <cuda/std/cassert>
 #include <cuda/std/utility>
 

--- a/libcudacxx/test/libcudacxx/cuda/utilities/utility/pair/interop/pair.conv.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/utility/pair/interop/pair.conv.pass.cpp
@@ -7,7 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
 // UNSUPPORTED: nvrtc
+
 #include <cuda/std/cassert>
 #include <cuda/std/utility>
 

--- a/libcudacxx/test/libcudacxx/cuda/utilities/variant/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/variant/host_only_types.pass.cpp
@@ -7,6 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/std/cassert>


### PR DESCRIPTION
There is no reason to run those tests in tile mode and it corrently errors out. So mark those tests as UNSUPPORTED
