### PR TITLE
[Tile] Disable tests that rely on a return statements inside loops

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/properties.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <mdspan>
 
 // template<class ElementType, class Extents, class LayoutPolicy = layout_right,

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/properties.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <mdspan>
 
 // template<class ElementType, class Extents, class LayoutPolicy = layout_right,

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/properties.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <mdspan>
 
 // template<class ElementType, class Extents, class LayoutPolicy = layout_right,

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/properties.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <mdspan>
 
 // template<class ElementType, class Extents, class LayoutPolicy = layout_right,

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/properties.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <mdspan>
 
 // template<class ElementType, class Extents, class LayoutPolicy = layout_right,

--- a/libcudacxx/test/libcudacxx/libcxx/literals/int128.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/literals/int128.pass.cpp
@@ -1,3 +1,13 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
 #include <cuda/std/cassert>
 
 #include "literal.h"

--- a/libcudacxx/test/libcudacxx/libcxx/literals/uint128.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/literals/uint128.pass.cpp
@@ -1,3 +1,13 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
 #include <cuda/std/cassert>
 
 #include "literal.h"

--- a/libcudacxx/test/libcudacxx/std/concepts/concepts.lang/concept.swappable/swappable.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/concepts/concepts.lang/concept.swappable/swappable.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // template<class T>
 // concept swappable = // see below
 

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/properties.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <mdspan>
 
 // template<class ElementType, class Extents, class LayoutPolicy = layout_right,

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/layout_left.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/layout_left.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <mdspan>
 
 // constexpr mdspan& operator=(const mdspan& rhs) = default;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/layout_right.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/layout_right.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <mdspan>
 
 // constexpr mdspan& operator=(const mdspan& rhs) = default;

--- a/libcudacxx/test/libcudacxx/std/language.support/support.srcloc/general.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.srcloc/general.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // The way we currently compile nvrtc is not working with that test
 // UNSUPPORTED: nvrtc && !c++20
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.take.while/adaptor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.take.while/adaptor.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // cuda::std::views::take_while
 
 // #include <cuda/std/algorithm>

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.take.while/general.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.take.while/general.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // Some basic examples of how take_while_view might be used in the wild. This is a general
 // collection of sample algorithms and functions that try to mock general usage of
 // this view.

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.transform/general.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.transform/general.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // Some basic examples of how transform_view might be used in the wild. This is a general
 // collection of sample algorithms and functions that try to mock general usage of
 // this view.


### PR DESCRIPTION
We have a lot of tests that use an conditional return inside a loop. That is currently not supported.

Mark those tests as XFAIL so that we know when it works again
