### PR TITLE
[Tile] Disable tests that rely on math compiler builtins

### DIFF
--- a/libcudacxx/include/cuda/std/__cmath/isfinite.h
+++ b/libcudacxx/include/cuda/std/__cmath/isfinite.h
@@ -37,14 +37,20 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 #  define _CCCL_BUILTIN_ISFINITE(...) __builtin_isfinite(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(isfinite)
 
+#if _CCCL_TILE_COMPILATION() // nvbug6077402: error: "call to non-tile function not supported!"
+#  undef _CCCL_BUILTIN_ISFINITE
+#endif // _CCCL_TILE_COMPILATION()
+
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr bool __isfinite_impl(_Tp __x) noexcept
 {
   static_assert(is_floating_point_v<_Tp>, "Only standard floating-point types are supported");
+#if !_CCCL_TILE_COMPILATION() // nvbug6077402: error: "call to non-tile function not supported!"
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     return ::isfinite(__x);
   }
+#endif // !_CCCL_TILE_COMPILATION()
   return !::cuda::std::isnan(__x) && !::cuda::std::isinf(__x);
 }
 
@@ -53,10 +59,12 @@ template <class _Tp>
 #if defined(_CCCL_BUILTIN_ISFINITE)
   return _CCCL_BUILTIN_ISFINITE(__x);
 #else // ^^^ _CCCL_BUILTIN_ISFINITE ^^^ / vvv !_CCCL_BUILTIN_ISFINITE vvv
+#  if !_CCCL_TILE_COMPILATION() // nvbug6077402: error: "call to non-tile function not supported!"
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     return ::isfinite(__x);
   }
+#  endif // !_CCCL_TILE_COMPILATION()
 #  if _CCCL_HAS_CONSTEXPR_BIT_CAST()
   return (::cuda::std::__fp_get_storage(__x) & __fp_exp_mask_of_v<float>) != __fp_exp_mask_of_v<float>;
 #  else // ^^^ _CCCL_HAS_CONSTEXPR_BIT_CAST() ^^^ / vvv !_CCCL_HAS_CONSTEXPR_BIT_CAST() vvv
@@ -70,10 +78,12 @@ template <class _Tp>
 #if defined(_CCCL_BUILTIN_ISFINITE)
   return _CCCL_BUILTIN_ISFINITE(__x);
 #else // ^^^ _CCCL_BUILTIN_ISFINITE ^^^ / vvv !_CCCL_BUILTIN_ISFINITE vvv
+#  if !_CCCL_TILE_COMPILATION() // nvbug6077402: error: "call to non-tile function not supported!"
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     return ::isfinite(__x);
   }
+#  endif // !_CCCL_TILE_COMPILATION()
 #  if _CCCL_HAS_CONSTEXPR_BIT_CAST()
   return (::cuda::std::__fp_get_storage(__x) & __fp_exp_mask_of_v<double>) != __fp_exp_mask_of_v<double>;
 #  else // ^^^ _CCCL_HAS_CONSTEXPR_BIT_CAST() ^^^ / vvv !_CCCL_HAS_CONSTEXPR_BIT_CAST() vvv

--- a/libcudacxx/include/cuda/std/__cmath/isinf.h
+++ b/libcudacxx/include/cuda/std/__cmath/isinf.h
@@ -37,14 +37,20 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 #  define _CCCL_BUILTIN_ISINF(...) __builtin_isinf(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(isinf)
 
+#if _CCCL_TILE_COMPILATION() // nvbug6077402: error: "call to non-tile function not supported!"
+#  undef _CCCL_BUILTIN_ISINF
+#endif // _CCCL_TILE_COMPILATION()
+
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr bool __isinf_impl(_Tp __x) noexcept
 {
   static_assert(is_floating_point_v<_Tp>, "Only standard floating-point types are supported");
+#if !_CCCL_TILE_COMPILATION() // nvbug6077402: error: "call to non-tile function not supported!"
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     return ::isinf(__x);
   }
+#endif // !_CCCL_TILE_COMPILATION()
   if (::cuda::std::isnan(__x))
   {
     return false;
@@ -64,10 +70,12 @@ template <class _Tp>
   }
   return _CCCL_BUILTIN_ISINF(__x) && !_CCCL_BUILTIN_ISNAN(__x);
 #elif _CCCL_HAS_CONSTEXPR_BIT_CAST()
+#  if !_CCCL_TILE_COMPILATION() // nvbug6077402: error: "call to non-tile function not supported!"
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     return ::isinf(__x);
   }
+#  endif // !_CCCL_TILE_COMPILATION()
   return (::cuda::std::__fp_get_storage(__x) & __fp_exp_mant_mask_of_v<float>) == __fp_exp_mask_of_v<float>;
 #else // ^^^ _CCCL_HAS_CONSTEXPR_BIT_CAST() ^^^ / vvv !_CCCL_HAS_CONSTEXPR_BIT_CAST() vvv
   return ::cuda::std::__isinf_impl(__x);
@@ -86,10 +94,12 @@ template <class _Tp>
   }
   return _CCCL_BUILTIN_ISINF(__x) && !_CCCL_BUILTIN_ISNAN(__x);
 #elif _CCCL_HAS_CONSTEXPR_BIT_CAST()
+#  if !_CCCL_TILE_COMPILATION() // nvbug6077402: error: "call to non-tile function not supported!"
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     return ::isinf(__x);
   }
+#  endif // !_CCCL_TILE_COMPILATION()
   return (::cuda::std::__fp_get_storage(__x) & __fp_exp_mant_mask_of_v<double>) == __fp_exp_mask_of_v<double>;
 #else // ^^^ _CCCL_HAS_CONSTEXPR_BIT_CAST() ^^^ / vvv !_CCCL_HAS_CONSTEXPR_BIT_CAST() vvv
   return ::cuda::std::__isinf_impl(__x);

--- a/libcudacxx/include/cuda/std/__cmath/isnan.h
+++ b/libcudacxx/include/cuda/std/__cmath/isnan.h
@@ -35,14 +35,20 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 #  define _CCCL_BUILTIN_ISNAN(...) __builtin_isnan(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(isnan)
 
+#if _CCCL_TILE_COMPILATION() // nvbug6077402: error: "call to non-tile function not supported!"
+#  undef _CCCL_BUILTIN_ISNAN
+#endif // _CCCL_TILE_COMPILATION()
+
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr bool __isnan_impl(_Tp __x) noexcept
 {
   static_assert(is_floating_point_v<_Tp>, "Only standard floating-point types are supported");
+#if !_CCCL_TILE_COMPILATION() // nvbug6077402: error: "call to non-tile function not supported!"
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     return ::isnan(__x);
   }
+#endif // !_CCCL_TILE_COMPILATION()
   return __x != __x;
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/cmath/sincos.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/cmath/sincos.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/cmath>
 
 #include <cuda/cmath>

--- a/libcudacxx/test/libcudacxx/cuda/functional/absorbing_element.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/absorbing_element.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 #include <cuda/functional>
 #include <cuda/std/cassert>
 #include <cuda/std/limits>

--- a/libcudacxx/test/libcudacxx/cuda/functional/identity_element.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/identity_element.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 #include <cuda/functional>
 #include <cuda/std/cassert>
 #include <cuda/std/cmath>

--- a/libcudacxx/test/libcudacxx/cuda/functional/maximum.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/maximum.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 #include <cuda/functional>
 #include <cuda/std/cassert>
 #include <cuda/type_traits>

--- a/libcudacxx/test/libcudacxx/cuda/functional/minimum.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/minimum.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 #include <cuda/functional>
 #include <cuda/std/cassert>
 #include <cuda/type_traits>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/error_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/error_functions.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/exponential_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/exponential_functions.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fdim.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fdim.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cmath>
 
 #include <cuda/std/__floating_point/fp.h>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fma.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fma.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_abs.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_abs.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // clang-format off
 #include <disable_nvfp_conversions_and_operators.h>
 // clang-format on

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_min_max.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_min_max.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cmath>
 
 #include <cuda/std/__floating_point/fp.h>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/gamma.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/gamma.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/hyperbolic_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/hyperbolic_functions.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/hypot.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/hypot.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/inverse_hyperbolic_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/inverse_hyperbolic_functions.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/inverse_trigonometric_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/inverse_trigonometric_functions.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/logarithms.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/logarithms.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/modulo.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/modulo.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/remainder.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/remainder.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/roots.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/roots.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/rounding.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/rounding.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/trigonometric_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/trigonometric_functions.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cmath>
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/cmplx.over/arg.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/cmplx.over/arg.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<Arithmetic T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/cmplx.over/conj.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/cmplx.over/conj.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>      complex<T>           conj(const complex<T>&);

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/cmplx.over/imag.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/cmplx.over/imag.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<Arithmetic T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/cmplx.over/norm.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/cmplx.over/norm.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<Arithmetic T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/cmplx.over/pow.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/cmplx.over/pow.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<Arithmetic T, Arithmetic U>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/cmplx.over/proj.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/cmplx.over/proj.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>    complex<T>           proj(const complex<T>&);

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/cmplx.over/real.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/cmplx.over/real.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<Arithmetic T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.member.ops/divide_equal_complex.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.member.ops/divide_equal_complex.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // complex& operator/=(const complex& rhs);

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.ops/complex_divide_complex.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.ops/complex_divide_complex.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.ops/complex_times_complex.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.ops/complex_times_complex.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.ops/scalar_divide_complex.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.ops/scalar_divide_complex.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/acos.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/acos.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/acosh.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/acosh.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/asin.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/asin.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/asinh.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/asinh.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/atan.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/atan.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/atanh.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/atanh.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/cos.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/cos.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/cosh.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/cosh.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/exp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/exp.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/log.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/log.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/log10.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/log10.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/pow_complex_complex.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/pow_complex_complex.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/pow_complex_scalar.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/pow_complex_scalar.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/pow_scalar_complex.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/pow_scalar_complex.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/sin.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/sin.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/sinh.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/sinh.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/sqrt.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/sqrt.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/tan.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/tan.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/tanh.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/tanh.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.value.ops/abs.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.value.ops/abs.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.value.ops/arg.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.value.ops/arg.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.value.ops/norm.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.value.ops/norm.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.value.ops/polar.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.value.ops/polar.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <cuda/std/complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.value.ops/proj.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.value.ops/proj.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <complex>
 
 // template<class T>

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/numeric.ops.midpoint/midpoint.float.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/numeric.ops.midpoint/midpoint.float.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077402: error: "call to non-tile function not supported!"
+
 // <numeric>
 
 // template <class _Float>


### PR DESCRIPTION
The ccompiler currently does not support a lot of the `__builtin_` builtins, so we have to wait until it does.

See nvbug6077402
