### PR TITLE
cub, c.parallel: rewire binary search to transform w/ small linear search.

### DIFF
--- a/c/parallel/include/cccl/c/binary_search.h
+++ b/c/parallel/include/cccl/c/binary_search.h
@@ -19,17 +19,16 @@
 #include <stdint.h>
 
 #include <cccl/c/extern_c.h>
+#include <cccl/c/transform.h>
 #include <cccl/c/types.h>
 
 CCCL_C_EXTERN_C_BEGIN
 
 typedef struct cccl_device_binary_search_build_result_t
 {
-  int cc;
-  void* cubin;
-  size_t cubin_size;
-  CUlibrary library;
-  CUkernel kernel;
+  cccl_device_transform_build_result_t transform;
+  size_t op_state_size;
+  size_t op_state_alignment;
 } cccl_device_binary_search_build_result_t;
 
 CCCL_C_API CUresult cccl_device_binary_search_build(

--- a/c/parallel/include/cccl/c/binary_search.h
+++ b/c/parallel/include/cccl/c/binary_search.h
@@ -26,6 +26,8 @@ CCCL_C_EXTERN_C_BEGIN
 
 typedef struct cccl_device_binary_search_build_result_t
 {
+  void* cubin;
+  size_t cubin_size;
   cccl_device_transform_build_result_t transform;
   size_t op_state_size;
   size_t op_state_alignment;

--- a/c/parallel/include/cccl/c/binary_search.h
+++ b/c/parallel/include/cccl/c/binary_search.h
@@ -26,8 +26,6 @@ CCCL_C_EXTERN_C_BEGIN
 
 typedef struct cccl_device_binary_search_build_result_t
 {
-  void* cubin;
-  size_t cubin_size;
   cccl_device_transform_build_result_t transform;
   size_t op_state_size;
   size_t op_state_alignment;

--- a/c/parallel/src/binary_search.cu
+++ b/c/parallel/src/binary_search.cu
@@ -9,74 +9,109 @@
 //===----------------------------------------------------------------------===//
 
 #include <cub/detail/choose_offset.cuh>
-#include <cub/grid/grid_even_share.cuh>
-#include <cub/util_device.cuh>
 
+#include <algorithm>
+#include <cstring>
 #include <format>
+#include <memory>
+#include <string>
 #include <type_traits>
 #include <vector>
 
 #include <cccl/c/binary_search.h>
+#include <cccl/c/transform.h>
 #include <cccl/c/types.h>
-#include <for/for_op_helper.h>
 #include <jit_templates/templates/input_iterator.h>
 #include <jit_templates/templates/operation.h>
-#include <jit_templates/templates/output_iterator.h>
-#include <nvrtc/command_list.h>
-#include <nvrtc/ltoir_list_appender.h>
-#include <util/build_utils.h>
 #include <util/context.h>
 #include <util/errors.h>
-#include <util/indirect_arg.h>
 #include <util/types.h>
-
-struct op_wrapper;
-struct device_reduce_policy;
 
 using OffsetT = unsigned long long;
 static_assert(std::is_same_v<cub::detail::choose_offset_t<OffsetT>, OffsetT>, "OffsetT must be size_t");
 
-static cudaError_t Invoke(
-  indirect_arg_t d_in,
-  size_t num_items,
-  indirect_arg_t d_values,
-  size_t num_values,
-  indirect_arg_t d_out,
+namespace binary_search
+{
+struct op_state_header_t
+{
+  void* data;
+  OffsetT num_data;
+};
+
+struct op_state_t
+{
+  std::unique_ptr<char[]> storage;
+
+  void* get()
+  {
+    return storage.get();
+  }
+};
+
+static size_t align_up(size_t offset, size_t alignment)
+{
+  const size_t remainder = offset % alignment;
+  return remainder == 0 ? offset : offset + alignment - remainder;
+}
+
+static size_t comparator_state_offset(cccl_op_t op)
+{
+  return op.type == CCCL_STATEFUL ? align_up(sizeof(op_state_header_t), op.alignment) : sizeof(op_state_header_t);
+}
+
+static size_t op_state_alignment(cccl_op_t op)
+{
+  return op.type == CCCL_STATEFUL ? std::max(alignof(op_state_header_t), op.alignment) : alignof(op_state_header_t);
+}
+
+static size_t op_state_size(cccl_op_t op)
+{
+  const size_t unaligned_size =
+    op.type == CCCL_STATEFUL ? comparator_state_offset(op) + op.size : sizeof(op_state_header_t);
+  return align_up(unaligned_size, op_state_alignment(op));
+}
+
+static op_state_t make_op_state(cccl_iterator_t data, OffsetT num_data, cccl_op_t op)
+{
+  op_state_t result{std::make_unique<char[]>(op_state_size(op))};
+  char* raw = static_cast<char*>(result.get());
+
+  auto* header     = reinterpret_cast<op_state_header_t*>(raw);
+  header->data     = data.state;
+  header->num_data = num_data;
+
+  if (op.type == CCCL_STATEFUL)
+  {
+    std::memcpy(raw + comparator_state_offset(op), op.state, op.size);
+  }
+
+  return result;
+}
+} // namespace binary_search
+
+static CUresult Invoke(
+  cccl_iterator_t d_in,
+  uint64_t num_items,
+  cccl_iterator_t d_values,
+  uint64_t num_values,
+  cccl_iterator_t d_out,
   cccl_op_t op,
-  int /*cc*/,
-  CUfunction kernel,
+  cccl_device_binary_search_build_result_t build,
   CUstream stream)
 {
-  cudaError error = cudaSuccess;
+  auto state = binary_search::make_op_state(d_in, static_cast<OffsetT>(num_items), op);
 
-  if (num_values == 0)
-  {
-    return error;
-  }
+  cccl_op_t transform_op = op;
+  transform_op.type      = CCCL_STATEFUL;
+  transform_op.state     = state.get();
+  transform_op.size      = build.op_state_size;
+  transform_op.alignment = build.op_state_alignment;
 
-  void* args[] = {&d_in, &num_items, &d_values, &num_values, &d_out, &op};
-
-  const unsigned int thread_count = 256;
-  const size_t items_per_block    = 512;
-  const size_t block_sz           = cuda::ceil_div(num_values, items_per_block);
-
-  if (block_sz > std::numeric_limits<unsigned int>::max())
-  {
-    return cudaErrorInvalidValue;
-  }
-  const unsigned int block_count = static_cast<unsigned int>(block_sz);
-
-  check(cuLaunchKernel(kernel, block_count, 1, 1, thread_count, 1, 1, 0, stream, args, 0));
-
-  // Check for failure to launch
-  error = CubDebug(cudaPeekAtLastError());
-
-  return error;
+  return cccl_device_unary_transform(build.transform, d_values, d_out, num_values, transform_op, stream);
 }
 
 struct binary_search_data_iterator_tag;
 struct binary_search_values_iterator_tag;
-struct binary_search_output_iterator_tag;
 struct binary_search_op_tag;
 
 CUresult cccl_device_binary_search_build_ex(
@@ -100,16 +135,8 @@ try
     throw std::runtime_error(std::string("Iterators are unsupported in for_each currently"));
   }
 
-  const char* name = "test";
-
-  const int cc = cc_major * 10 + cc_minor;
-
   auto [d_data_it_name, d_data_it_src] =
     get_specialization<binary_search_data_iterator_tag>(template_id<input_iterator_traits>(), d_data);
-  auto [d_values_it_name, d_values_it_src] =
-    get_specialization<binary_search_values_iterator_tag>(template_id<input_iterator_traits>(), d_values);
-  auto [d_out_it_name, d_out_it_src] = get_specialization<binary_search_output_iterator_tag>(
-    template_id<output_iterator_traits>(), d_out, d_out.value_type);
   auto [op_name, op_src] =
     get_specialization<binary_search_op_tag>(template_id<binary_user_predicate_traits>(), op, d_data.value_type);
 
@@ -124,129 +151,112 @@ try
     throw std::runtime_error(std::format("Invalid binary search mode ({})", static_cast<int>(mode)));
   }();
 
-  const std::string src = std::format(
+  const bool user_defined_comparator = op.type == CCCL_STATEFUL || op.type == CCCL_STATELESS;
+  const bool comparator_stateful     = op.type == CCCL_STATEFUL;
+  const auto comparator_offset       = binary_search::comparator_state_offset(op);
+  const std::string output_t         = cccl_type_enum_to_name(d_out.value_type.type);
+  const std::string comparator_src =
+    user_defined_comparator && op.code_type == CCCL_OP_CPP_SOURCE && op.code != nullptr && op.code_size != 0
+      ? std::string{op.code, op.code_size}
+      : std::string{};
+  const size_t storage_size = std::max({d_data.value_type.size, d_values.value_type.size, d_out.value_type.size});
+  const size_t storage_alignment =
+    std::max({d_data.value_type.alignment, d_values.value_type.alignment, d_out.value_type.alignment});
+
+  const std::string transform_op_src = std::format(
     R"XXX(
-#include <cub/agent/agent_for.cuh>
 #include <cub/detail/binary_search_helpers.cuh>
-#include <cuda/__iterator/zip_iterator.h>
+#include <cuda/std/__cstring/memcpy.h>
 
-{11}
+{8}
 
-struct __align__({10}) storage_t {{
-  char data[{9}];
+struct __align__({7}) storage_t {{
+  char data[{6}];
 }};
+
+{12}
 
 {0}
 {2}
-{4}
-{6}
-
-using policy_dim_t = cub::detail::for_each::policy_t<256, 2>;
 using OffsetT = cuda::std::size_t;
 
-struct device_for_policy
+struct binary_search_op_state
 {{
-  struct ActivePolicy
-  {{
-    using for_policy_t = policy_dim_t;
-  }};
+  {1} data;
+  OffsetT num_data;
 }};
 
-_CCCL_KERNEL_ATTRIBUTES
-__launch_bounds__(device_for_policy::ActivePolicy::for_policy_t::block_threads)
-void binary_search_kernel({1} d_data, OffsetT num_data, {3} d_values, OffsetT num_values, {5} d_out, {7} op)
+extern "C" __device__ void binary_search_transform_op(void* state, const void* value, void* result)
 {{
-  auto input_it     = cuda::make_zip_iterator(d_values, d_out);
-  auto comp_wrapper = cub::detail::find::make_comp_wrapper<{8}>(d_data, num_data, op);
-  auto agent_op     = [&comp_wrapper, &input_it](OffsetT index) {{
-    comp_wrapper(input_it[index]);
-  }};
+  auto* header     = static_cast<binary_search_op_state*>(state);
+  const auto& item = *static_cast<const {3}*>(value);
 
-  using active_policy_t = device_for_policy::ActivePolicy::for_policy_t;
-  using agent_t         = cub::detail::for_each::agent_block_striped_t<active_policy_t, OffsetT, decltype(agent_op)>;
-
-  constexpr auto block_threads  = active_policy_t::block_threads;
-  constexpr auto items_per_tile = active_policy_t::items_per_thread * block_threads;
-
-  const auto tile_base     = static_cast<OffsetT>(blockIdx.x) * items_per_tile;
-  const auto num_remaining = num_values - tile_base;
-  const auto items_in_tile = static_cast<OffsetT>(num_remaining < items_per_tile ? num_remaining : items_per_tile);
-
-  if (items_in_tile == items_per_tile)
+  {4} comparator{{}};
+  if constexpr ({9})
   {{
-    agent_t{{tile_base, agent_op}}.template consume_tile<true>(items_per_tile, block_threads);
+    ::cuda::std::memcpy(&comparator, static_cast<char*>(state) + {10}, sizeof(comparator));
   }}
-  else
-  {{
-    agent_t{{tile_base, agent_op}}.template consume_tile<false>(items_in_tile, block_threads);
-  }}
+
+  const auto search_op =
+    cub::detail::find::make_binary_search_transform_op<{11}>(header->data, header->num_data, comparator);
+  *static_cast<{5}*>(result) =
+    static_cast<{5}>(search_op(item));
 }}
 )XXX",
     d_data_it_src,
     d_data_it_name,
-    d_values_it_src,
-    d_values_it_name,
-    d_out_it_src,
-    d_out_it_name,
     op_src,
+    cccl_type_enum_to_name(d_values.value_type.type),
     op_name,
+    output_t,
+    storage_size,
+    storage_alignment,
+    jit_template_header_contents,
+    comparator_stateful ? "true" : "false",
+    comparator_offset,
     mode_t,
-    d_out.value_type.size,
-    d_out.value_type.alignment,
-    jit_template_header_contents);
+    comparator_src);
 
-  const std::string arch = std::format("-arch=sm_{0}{1}", cc_major, cc_minor);
+  cccl_op_t transform_op = op;
+  transform_op.type      = CCCL_STATEFUL;
+  transform_op.name      = "binary_search_transform_op";
+  transform_op.code      = transform_op_src.c_str();
+  transform_op.code_size = transform_op_src.size();
+  transform_op.code_type = CCCL_OP_CPP_SOURCE;
+  transform_op.size      = binary_search::op_state_size(op);
+  transform_op.alignment = binary_search::op_state_alignment(op);
 
-  std::vector<const char*> args = {
-    arch.c_str(),
+  std::vector<const char*> extra_ltoirs;
+  std::vector<size_t> extra_ltoir_sizes;
+  if (user_defined_comparator && op.code_type == CCCL_OP_LTOIR && op.code_size != 0)
+  {
+    extra_ltoirs.push_back(op.code);
+    extra_ltoir_sizes.push_back(op.code_size);
+  }
+  for (size_t i = 0; user_defined_comparator && i < op.num_extra_ltoirs; ++i)
+  {
+    extra_ltoirs.push_back(op.extra_ltoirs[i]);
+    extra_ltoir_sizes.push_back(op.extra_ltoir_sizes[i]);
+  }
+  transform_op.extra_ltoirs      = extra_ltoirs.data();
+  transform_op.extra_ltoir_sizes = extra_ltoir_sizes.data();
+  transform_op.num_extra_ltoirs  = extra_ltoirs.size();
+
+  check(cccl_device_unary_transform_build_ex(
+    &build_ptr->transform,
+    d_values,
+    d_out,
+    transform_op,
+    cc_major,
+    cc_minor,
     cub_path,
     thrust_path,
     libcudacxx_path,
     ctk_path,
-    "-std=c++20",
-    "-rdc=true",
-    "-dlto",
-    "-DCUB_DISABLE_CDP"};
+    config));
 
-  cccl::detail::extend_args_with_build_config(args, config);
-
-  constexpr size_t num_lto_args   = 2;
-  const char* lopts[num_lto_args] = {"-lto", arch.c_str()};
-
-  std::string lowered_name;
-
-  // Collect all LTO-IRs to be linked
-  nvrtc_linkable_list linkable_list;
-  nvrtc_linkable_list_appender appender{linkable_list};
-
-  appender.append_operation(op);
-
-  // Add iterator definitions if present
-  for (const auto& it_type : {d_data, d_values, d_out})
-  {
-    if (cccl_iterator_kind_t::CCCL_ITERATOR == it_type.type)
-    {
-      appender.append_operation(it_type.advance);
-      appender.append_operation(it_type.dereference);
-    }
-  }
-
-  nvrtc_link_result result =
-    begin_linking_nvrtc_program(num_lto_args, lopts)
-      ->add_program(nvrtc_translation_unit{src, name})
-      ->add_expression({"binary_search_kernel"})
-      ->compile_program({args.data(), args.size()})
-      ->get_name({"binary_search_kernel", lowered_name})
-      ->link_program()
-      ->add_link_list(linkable_list)
-      ->finalize_program();
-
-  cuLibraryLoadData(&build_ptr->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
-  check(cuLibraryGetKernel(&build_ptr->kernel, build_ptr->library, lowered_name.c_str()));
-
-  build_ptr->cc         = cc;
-  build_ptr->cubin      = (void*) result.data.release();
-  build_ptr->cubin_size = result.size;
+  build_ptr->op_state_size      = transform_op.size;
+  build_ptr->op_state_alignment = transform_op.alignment;
 
   return CUDA_SUCCESS;
 }
@@ -271,9 +281,7 @@ CUresult cccl_device_binary_search(
   try
   {
     pushed = try_push_context();
-    auto exec_status =
-      Invoke(d_data, num_items, d_values, num_values, d_out, op, build.cc, (CUfunction) build.kernel, stream);
-    error = static_cast<CUresult>(exec_status);
+    error  = Invoke(d_data, num_items, d_values, num_values, d_out, op, build, stream);
   }
   catch (...)
   {
@@ -327,10 +335,7 @@ try
     return CUDA_ERROR_INVALID_VALUE;
   }
 
-  std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(build_ptr->cubin));
-  check(cuLibraryUnload(build_ptr->library));
-
-  return CUDA_SUCCESS;
+  return cccl_device_transform_cleanup(&build_ptr->transform);
 }
 catch (...)
 {

--- a/c/parallel/src/binary_search.cu
+++ b/c/parallel/src/binary_search.cu
@@ -255,6 +255,8 @@ extern "C" __device__ void binary_search_transform_op(void* state, const void* v
     ctk_path,
     config));
 
+  build_ptr->cubin              = build_ptr->transform.cubin;
+  build_ptr->cubin_size         = build_ptr->transform.cubin_size;
   build_ptr->op_state_size      = transform_op.size;
   build_ptr->op_state_alignment = transform_op.alignment;
 

--- a/c/parallel/src/binary_search.cu
+++ b/c/parallel/src/binary_search.cu
@@ -23,6 +23,8 @@
 #include <cccl/c/types.h>
 #include <jit_templates/templates/input_iterator.h>
 #include <jit_templates/templates/operation.h>
+#include <nvrtc/command_list.h>
+#include <util/build_utils.h>
 #include <util/context.h>
 #include <util/errors.h>
 #include <util/types.h>
@@ -151,10 +153,11 @@ try
     throw std::runtime_error(std::format("Invalid binary search mode ({})", static_cast<int>(mode)));
   }();
 
-  const bool comparator_stateful = op.type == CCCL_STATEFUL;
-  const auto comparator_offset   = binary_search::comparator_state_offset(op);
-  const std::string output_t     = cccl_type_enum_to_name(d_out.value_type.type);
-  const size_t storage_size      = std::max({d_data.value_type.size, d_values.value_type.size, d_out.value_type.size});
+  const bool user_defined_comparator = op.type == CCCL_STATEFUL || op.type == CCCL_STATELESS;
+  const bool comparator_stateful     = op.type == CCCL_STATEFUL;
+  const auto comparator_offset       = binary_search::comparator_state_offset(op);
+  const std::string output_t         = cccl_type_enum_to_name(d_out.value_type.type);
+  const size_t storage_size = std::max({d_data.value_type.size, d_values.value_type.size, d_out.value_type.size});
   const size_t storage_alignment =
     std::max({d_data.value_type.alignment, d_values.value_type.alignment, d_out.value_type.alignment});
 
@@ -219,12 +222,42 @@ extern "C" __device__ void binary_search_transform_op(void* state, const void* v
 
   std::vector<const char*> extra_ltoirs;
   std::vector<size_t> extra_ltoir_sizes;
-  if ((op.type == CCCL_STATEFUL || op.type == CCCL_STATELESS) && op.code_type == CCCL_OP_LTOIR && op.code_size != 0)
+  std::unique_ptr<char[]> comparator_ltoir;
+
+  const std::string arch        = std::format("-arch=sm_{0}{1}", cc_major, cc_minor);
+  std::vector<const char*> args = {
+    arch.c_str(),
+    cub_path,
+    thrust_path,
+    libcudacxx_path,
+    ctk_path,
+    "-rdc=true",
+    "-dlto",
+    "-default-device",
+    "-DCUB_DISABLE_CDP",
+    "-std=c++20"};
+  cccl::detail::extend_args_with_build_config(args, config);
+
+  constexpr size_t num_lto_args   = 2;
+  const char* lopts[num_lto_args] = {"-lto", arch.c_str()};
+
+  if (user_defined_comparator && op.code_type == CCCL_OP_CPP_SOURCE && op.code_size != 0)
+  {
+    auto [lto_size, lto_buf] =
+      begin_linking_nvrtc_program(num_lto_args, lopts)
+        ->add_program(nvrtc_translation_unit{op.code, op.name})
+        ->compile_program({args.data(), args.size()})
+        ->get_program_ltoir();
+    comparator_ltoir = std::move(lto_buf);
+    extra_ltoirs.push_back(comparator_ltoir.get());
+    extra_ltoir_sizes.push_back(lto_size);
+  }
+  else if (user_defined_comparator && op.code_type == CCCL_OP_LTOIR && op.code_size != 0)
   {
     extra_ltoirs.push_back(op.code);
     extra_ltoir_sizes.push_back(op.code_size);
   }
-  for (size_t i = 0; (op.type == CCCL_STATEFUL || op.type == CCCL_STATELESS) && i < op.num_extra_ltoirs; ++i)
+  for (size_t i = 0; user_defined_comparator && i < op.num_extra_ltoirs; ++i)
   {
     extra_ltoirs.push_back(op.extra_ltoirs[i]);
     extra_ltoir_sizes.push_back(op.extra_ltoir_sizes[i]);

--- a/c/parallel/src/binary_search.cu
+++ b/c/parallel/src/binary_search.cu
@@ -137,8 +137,8 @@ try
 
   auto [d_data_it_name, d_data_it_src] =
     get_specialization<binary_search_data_iterator_tag>(template_id<input_iterator_traits>(), d_data);
-  auto [op_name, op_src] =
-    get_specialization<binary_search_op_tag>(template_id<binary_user_predicate_traits>(), op, d_data.value_type);
+  auto [op_name, op_src] = get_specialization<binary_search_op_tag>(
+    template_id<binary_user_predicate_traits>(), op, d_data.value_type, d_data.value_type);
 
   const std::string mode_t = [&] {
     switch (mode)
@@ -151,15 +151,10 @@ try
     throw std::runtime_error(std::format("Invalid binary search mode ({})", static_cast<int>(mode)));
   }();
 
-  const bool user_defined_comparator = op.type == CCCL_STATEFUL || op.type == CCCL_STATELESS;
-  const bool comparator_stateful     = op.type == CCCL_STATEFUL;
-  const auto comparator_offset       = binary_search::comparator_state_offset(op);
-  const std::string output_t         = cccl_type_enum_to_name(d_out.value_type.type);
-  const std::string comparator_src =
-    user_defined_comparator && op.code_type == CCCL_OP_CPP_SOURCE && op.code != nullptr && op.code_size != 0
-      ? std::string{op.code, op.code_size}
-      : std::string{};
-  const size_t storage_size = std::max({d_data.value_type.size, d_values.value_type.size, d_out.value_type.size});
+  const bool comparator_stateful = op.type == CCCL_STATEFUL;
+  const auto comparator_offset   = binary_search::comparator_state_offset(op);
+  const std::string output_t     = cccl_type_enum_to_name(d_out.value_type.type);
+  const size_t storage_size      = std::max({d_data.value_type.size, d_values.value_type.size, d_out.value_type.size});
   const size_t storage_alignment =
     std::max({d_data.value_type.alignment, d_values.value_type.alignment, d_out.value_type.alignment});
 
@@ -169,12 +164,9 @@ try
 #include <cuda/std/__cstring/memcpy.h>
 
 {8}
-
 struct __align__({7}) storage_t {{
   char data[{6}];
 }};
-
-{12}
 
 {0}
 {2}
@@ -214,8 +206,7 @@ extern "C" __device__ void binary_search_transform_op(void* state, const void* v
     jit_template_header_contents,
     comparator_stateful ? "true" : "false",
     comparator_offset,
-    mode_t,
-    comparator_src);
+    mode_t);
 
   cccl_op_t transform_op = op;
   transform_op.type      = CCCL_STATEFUL;
@@ -228,12 +219,12 @@ extern "C" __device__ void binary_search_transform_op(void* state, const void* v
 
   std::vector<const char*> extra_ltoirs;
   std::vector<size_t> extra_ltoir_sizes;
-  if (user_defined_comparator && op.code_type == CCCL_OP_LTOIR && op.code_size != 0)
+  if ((op.type == CCCL_STATEFUL || op.type == CCCL_STATELESS) && op.code_type == CCCL_OP_LTOIR && op.code_size != 0)
   {
     extra_ltoirs.push_back(op.code);
     extra_ltoir_sizes.push_back(op.code_size);
   }
-  for (size_t i = 0; user_defined_comparator && i < op.num_extra_ltoirs; ++i)
+  for (size_t i = 0; (op.type == CCCL_STATEFUL || op.type == CCCL_STATELESS) && i < op.num_extra_ltoirs; ++i)
   {
     extra_ltoirs.push_back(op.extra_ltoirs[i]);
     extra_ltoir_sizes.push_back(op.extra_ltoir_sizes[i]);
@@ -255,8 +246,6 @@ extern "C" __device__ void binary_search_transform_op(void* state, const void* v
     ctk_path,
     config));
 
-  build_ptr->cubin              = build_ptr->transform.cubin;
-  build_ptr->cubin_size         = build_ptr->transform.cubin_size;
   build_ptr->op_state_size      = transform_op.size;
   build_ptr->op_state_alignment = transform_op.alignment;
 

--- a/c/parallel/src/jit_templates/mappings/operation.h
+++ b/c/parallel/src/jit_templates/mappings/operation.h
@@ -18,40 +18,62 @@
 #  include <cccl/c/types.h>
 #endif
 
+template <auto Operation = nullptr>
 struct cccl_op_t_mapping
 {
-  bool is_stateless   = false;
-  int size            = 1;
-  int alignment       = 1;
-  void (*operation)() = nullptr;
+  bool is_stateless               = false;
+  int size                        = 1;
+  int alignment                   = 1;
+  static constexpr auto operation = Operation;
 };
 
 #ifndef _CCCL_C_PARALLEL_JIT_TEMPLATES_PREPROCESS
 template <>
 struct parameter_mapping<cccl_op_t>
 {
-  static const constexpr auto archetype = cccl_op_t_mapping{};
+  static const constexpr auto archetype = cccl_op_t_mapping<>{};
 
   template <typename Traits, typename ArgT>
   static std::string map(template_id<Traits>, ArgT arg)
   {
     const auto& value = arg_traits<cuda::std::decay_t<ArgT>>::unwrap(arg);
     return std::format(
-      "cccl_op_t_mapping{{.is_stateless = {}, .size = {}, .alignment = {}, .operation = {}}}",
+      "cccl_op_t_mapping<{}>{{.is_stateless = {}, .size = {}, .alignment = {}}}",
+      value.name,
       value.type != cccl_op_kind_t::CCCL_STATEFUL,
       value.size,
-      value.alignment,
-      value.name);
+      value.alignment);
   }
 
   template <typename Traits, typename ArgT>
   static std::string aux(template_id<Traits>, ArgT arg)
   {
     const auto& value = arg_traits<cuda::std::decay_t<ArgT>>::unwrap(arg);
-    return std::format(R"(
-        extern "C" __device__ void {}();
+
+    std::string args;
+    if (value.type == cccl_op_kind_t::CCCL_STATEFUL)
+    {
+      args += "void*";
+      if constexpr (Traits::arity > 0)
+      {
+        args += ", ";
+      }
+    }
+
+    for (int i = 0; i < Traits::arity; ++i)
+    {
+      args += "const void*";
+      args += ", ";
+    }
+
+    args += "void*";
+
+    return std::format(
+      R"(
+        extern "C" __device__ void {}({});
         )",
-                       value.name);
+      value.name,
+      args);
   }
 };
 #endif

--- a/c/parallel/src/jit_templates/templates/operation.h
+++ b/c/parallel/src/jit_templates/templates/operation.h
@@ -28,20 +28,15 @@ using cccl_mapping_to_type = decltype(RetT)::Type;
 template <typename Tag, cccl_op_t_mapping Operation, cccl_type_info_mapping RetT, cccl_type_info_mapping... ArgTs>
 struct stateless_user_operation
 {
-  // Note: The user provided C f  unction (Operation.operation) must match the signature:
+  // Note: The user provided C function must match the signature:
   // void (void* arg1, ..., void* argN, void* result_ptr)
   __device__ cccl_mapping_to_type<RetT> operator()(cccl_mapping_to_type<ArgTs>... args) const
   {
-    using TargetCFuncPtr = void (*)(const decltype(args, void())*..., void*);
-
-    // Cast the stored operation pointer (assumed to be void* or compatible)
-    auto c_func_ptr = reinterpret_cast<TargetCFuncPtr>(Operation.operation);
-
     // Prepare storage for the result
     typename decltype(RetT)::Type result;
 
     // Call the C function, casting argument addresses to void*
-    c_func_ptr((const_cast<void*>(static_cast<const void*>(&args)))..., &result);
+    decltype(Operation)::operation((const_cast<void*>(static_cast<const void*>(&args)))..., &result);
 
     return result;
   }
@@ -59,18 +54,13 @@ struct stateful_user_operation
   user_operation_state<Operation.size, Operation.alignment> state;
   __device__ cccl_mapping_to_type<RetT> operator()(cccl_mapping_to_type<ArgTs>... args)
   {
-    // Note: The user provided C function (Operation.operation) must match the signature:
+    // Note: The user provided C function must match the signature:
     // void (void* state, void* arg1, ..., void* argN, void* result_ptr)
-    using TargetCFuncPtr = void (*)(void*, const decltype(args, void())*..., void*);
-
-    // Cast the stored operation pointer (assumed to be void* or compatible)
-    auto c_func_ptr = reinterpret_cast<TargetCFuncPtr>(Operation.operation);
-
     // Prepare storage for the result
     typename decltype(RetT)::Type result;
 
     // Call the C function, passing state address, casting argument addresses to void*, and result pointer
-    c_func_ptr(&state, (const_cast<void*>(static_cast<const void*>(&args)))..., &result);
+    decltype(Operation)::operation(&state, (const_cast<void*>(static_cast<const void*>(&args)))..., &result);
 
     return result;
   }
@@ -354,18 +344,54 @@ __device__ {1} operator{2}(const {3} & lhs, const {3} & rhs)
 #endif
 };
 
+struct unary_user_operation_traits
+{
+  static const constexpr auto name = "unary_user_operation_traits::type";
+  // Input operand count for generated C ABI declarations.
+  static constexpr int arity = 1;
+
+  template <typename Tag, cccl_op_t_mapping Operation, cccl_type_info_mapping RetT, cccl_type_info_mapping ValueT>
+  using type = user_operation_traits::type<Tag, Operation, RetT, ValueT>;
+
+#ifndef _CCCL_C_PARALLEL_JIT_TEMPLATES_PREPROCESS
+  template <typename Tag, typename RetArg, typename ValueArg>
+  static cuda::std::optional<specialization> special(cccl_op_t operation, RetArg ret, ValueArg value)
+  {
+    return user_operation_traits::special<Tag>(operation, ret, value);
+  }
+#endif
+};
+
+struct unary_user_predicate_traits
+{
+  static const constexpr auto name = "unary_user_predicate_traits::type";
+  static constexpr int arity       = 1;
+
+  template <typename Tag, cccl_op_t_mapping Operation, cccl_type_info_mapping ValueT>
+  using type = user_operation_traits::type<Tag, Operation, cccl_type_info_mapping<bool>{}, ValueT>;
+
+#ifndef _CCCL_C_PARALLEL_JIT_TEMPLATES_PREPROCESS
+  template <typename Tag, typename ValueArg>
+  static cuda::std::optional<specialization> special(cccl_op_t operation, ValueArg value)
+  {
+    return user_operation_traits::special<Tag>(
+      operation, cccl_type_info{sizeof(bool), alignof(bool), CCCL_BOOLEAN}, value);
+  }
+#endif
+};
+
 struct binary_user_operation_traits
 {
   static const constexpr auto name = "binary_user_operation_traits::type";
-  template <typename Tag, cccl_op_t_mapping Operation, cccl_type_info_mapping ValueT>
-  using type = user_operation_traits::type<Tag, Operation, ValueT, ValueT, ValueT>;
+  static constexpr int arity       = 2;
+  template <typename Tag, cccl_op_t_mapping Operation, cccl_type_info_mapping RetT, cccl_type_info_mapping... ArgTs>
+  using type = user_operation_traits::type<Tag, Operation, RetT, ArgTs...>;
 
 #ifndef _CCCL_C_PARALLEL_JIT_TEMPLATES_PREPROCESS
-  template <typename Tag, typename Arg>
-  static cuda::std::optional<specialization> special(cccl_op_t operation, Arg arg)
+  template <typename Tag, typename RetArg, typename LhsArg, typename RhsArg>
+  static cuda::std::optional<specialization> special(cccl_op_t operation, RetArg ret, LhsArg lhs, RhsArg rhs)
   {
-    auto wrapped = arg_traits<cuda::std::decay_t<Arg>>::wrap(arg);
-    return user_operation_traits::special<Tag>(operation, wrapped, wrapped, wrapped);
+    return user_operation_traits::special<Tag>(operation, ret, lhs, rhs);
   }
 #endif
 };
@@ -373,15 +399,16 @@ struct binary_user_operation_traits
 struct binary_user_predicate_traits
 {
   static const constexpr auto name = "binary_user_predicate_traits::type";
-  template <typename Tag, cccl_op_t_mapping Operation, cccl_type_info_mapping ValueT>
-  using type = user_operation_traits::type<Tag, Operation, cccl_type_info_mapping<bool>{}, ValueT, ValueT>;
+  static constexpr int arity       = 2;
+  template <typename Tag, cccl_op_t_mapping Operation, cccl_type_info_mapping ValueT, cccl_type_info_mapping... OtherArgTs>
+  using type = user_operation_traits::type<Tag, Operation, cccl_type_info_mapping<bool>{}, ValueT, OtherArgTs...>;
 
 #ifndef _CCCL_C_PARALLEL_JIT_TEMPLATES_PREPROCESS
-  template <typename Tag, typename Arg>
-  static cuda::std::optional<specialization> special(cccl_op_t operation, Arg arg)
+  template <typename Tag, typename LhsArg, typename RhsArg>
+  static cuda::std::optional<specialization> special(cccl_op_t operation, LhsArg lhs, RhsArg rhs)
   {
-    auto wrapped = arg_traits<cuda::std::decay_t<Arg>>::wrap(arg);
-    return user_operation_traits::special<Tag>(operation, wrapped, wrapped, wrapped);
+    return user_operation_traits::special<Tag>(
+      operation, cccl_type_info{sizeof(bool), alignof(bool), CCCL_BOOLEAN}, lhs, rhs);
   }
 #endif
 };

--- a/c/parallel/src/reduce.cu
+++ b/c/parallel/src/reduce.cu
@@ -215,8 +215,8 @@ try
   const auto [output_iterator_name, output_iterator_src] =
     get_specialization<reduce_iterator_tag>(template_id<output_iterator_traits>(), output_it, accum_t);
 
-  const auto [op_name, op_src] =
-    get_specialization<reduction_operation_tag>(template_id<binary_user_operation_traits>(), op, accum_t);
+  const auto [op_name, op_src] = get_specialization<reduction_operation_tag>(
+    template_id<binary_user_operation_traits>(), op, accum_t, accum_t, accum_t);
 
   const auto offset_t = cccl_type_enum_to_name(cccl_type_enum::CCCL_UINT64);
 

--- a/c/parallel/src/segmented_reduce.cu
+++ b/c/parallel/src/segmented_reduce.cu
@@ -148,8 +148,8 @@ try
   const auto [end_offset_iterator_name, end_offset_iterator_src] =
     get_specialization<segmented_reduce_end_offset_iterator_tag>(template_id<input_iterator_traits>(), end_offset_it);
 
-  const auto [op_name, op_src] =
-    get_specialization<segmented_reduce_operation_tag>(template_id<binary_user_operation_traits>(), op, accum_t);
+  const auto [op_name, op_src] = get_specialization<segmented_reduce_operation_tag>(
+    template_id<binary_user_operation_traits>(), op, accum_t, accum_t, accum_t);
 
   // OffsetT is checked to match have 64-bit size
   const auto offset_t = cccl_type_enum_to_name(cccl_type_enum::CCCL_UINT64);

--- a/c/parallel/src/segmented_sort.cu
+++ b/c/parallel/src/segmented_sort.cu
@@ -471,10 +471,10 @@ try
     cccl_type_enum::CCCL_UINT32};
 
   const auto [large_selector_name, large_selector_src] = get_specialization<segmented_sort_large_selector_tag>(
-    template_id<user_operation_traits>(), large_selector_op, selector_result_t, selector_input_t);
+    template_id<unary_user_operation_traits>(), large_selector_op, selector_result_t, selector_input_t);
 
   const auto [small_selector_name, small_selector_src] = get_specialization<segmented_sort_small_selector_tag>(
-    template_id<user_operation_traits>(), small_selector_op, selector_result_t, selector_input_t);
+    template_id<unary_user_operation_traits>(), small_selector_op, selector_result_t, selector_input_t);
 
   const auto policy_sel = cub::detail::segmented_sort::policy_selector{
     static_cast<int>(keys_in_it.value_type.size),

--- a/c/parallel/src/three_way_partition.cu
+++ b/c/parallel/src/three_way_partition.cu
@@ -155,10 +155,10 @@ try
 
   const auto [select_first_part_op_name, select_first_part_op_src] =
     get_specialization<three_way_partition_select_first_part_operation_tag>(
-      template_id<user_operation_traits>(), select_first_part_op, selector_result_t, d_in.value_type);
+      template_id<unary_user_operation_traits>(), select_first_part_op, selector_result_t, d_in.value_type);
   const auto [select_second_part_op_name, select_second_part_op_src] =
     get_specialization<three_way_partition_select_second_part_operation_tag>(
-      template_id<user_operation_traits>(), select_second_part_op, selector_result_t, d_in.value_type);
+      template_id<unary_user_operation_traits>(), select_second_part_op, selector_result_t, d_in.value_type);
 
   const auto offset_t = cccl_type_enum_to_name(cccl_type_enum::CCCL_INT64);
 

--- a/c/parallel/src/transform.cu
+++ b/c/parallel/src/transform.cu
@@ -219,8 +219,8 @@ try
       template_id<output_iterator_traits>(),
       tagged_arg<output_storage_t, cccl_iterator_t>{output_it},
       tagged_arg<output_storage_t, cccl_type_info>{output_it.value_type});
-  const auto [op_name, op_src] = get_specialization<unary_transform_operation_tag, user_operation_traits>(
-    template_id<user_operation_traits>(),
+  const auto [op_name, op_src] = get_specialization<unary_transform_operation_tag, unary_user_operation_traits>(
+    template_id<unary_user_operation_traits>(),
     op,
     tagged_arg<output_storage_t, cccl_type_info>{output_it.value_type},
     tagged_arg<input_storage_t, cccl_type_info>{input_it.value_type});
@@ -411,8 +411,8 @@ try
       template_id<output_iterator_traits>(),
       tagged_arg<output_storage_t, cccl_iterator_t>{output_it},
       tagged_arg<output_storage_t, cccl_type_info>{output_it.value_type});
-  const auto [op_name, op_src] = get_specialization<binary_transform_operation_tag, user_operation_traits>(
-    template_id<user_operation_traits>(),
+  const auto [op_name, op_src] = get_specialization<binary_transform_operation_tag, binary_user_operation_traits>(
+    template_id<binary_user_operation_traits>(),
     op,
     tagged_arg<output_storage_t, cccl_type_info>{output_it.value_type},
     tagged_arg<input1_storage_t, cccl_type_info>{input1_it.value_type},

--- a/cub/cub/detail/binary_search_helpers.cuh
+++ b/cub/cub/detail/binary_search_helpers.cuh
@@ -23,6 +23,8 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail::find
 {
+constexpr ::cuda::std::ptrdiff_t linear_lower_bound_threshold = 8;
+
 template <typename RangeIteratorT, typename RangeNumItemsT, typename CompareOpT, typename Mode>
 struct comp_wrapper_t
 {
@@ -48,6 +50,19 @@ _CCCL_HOST_DEVICE auto make_comp_wrapper(RangeIteratorT first, RangeNumItemsT nu
 
 struct lower_bound
 {
+  template <typename RangeIteratorT, typename DifferenceT, typename T, typename CompareOpT>
+  _CCCL_DEVICE _CCCL_FORCEINLINE static DifferenceT
+  Linear(RangeIteratorT first, DifferenceT num_items, const T& value, CompareOpT comp)
+  {
+    DifferenceT retval = 0;
+    for (DifferenceT i = 0; i < num_items; ++i)
+    {
+      retval += static_cast<DifferenceT>(comp(first[i], value));
+    }
+
+    return retval;
+  }
+
   template <typename RangeIteratorT, typename T, typename CompareOpT>
   _CCCL_DEVICE _CCCL_FORCEINLINE static ::cuda::std::ptrdiff_t
   Invoke(RangeIteratorT first, RangeIteratorT last, const T& value, CompareOpT comp)
@@ -58,6 +73,19 @@ struct lower_bound
 
 struct upper_bound
 {
+  template <typename RangeIteratorT, typename DifferenceT, typename T, typename CompareOpT>
+  _CCCL_DEVICE _CCCL_FORCEINLINE static DifferenceT
+  Linear(RangeIteratorT first, DifferenceT num_items, const T& value, CompareOpT comp)
+  {
+    DifferenceT retval = 0;
+    for (DifferenceT i = 0; i < num_items; ++i)
+    {
+      retval += static_cast<DifferenceT>(!comp(value, first[i]));
+    }
+
+    return retval;
+  }
+
   template <typename RangeIteratorT, typename T, typename CompareOpT>
   _CCCL_DEVICE _CCCL_FORCEINLINE static ::cuda::std::ptrdiff_t
   Invoke(RangeIteratorT first, RangeIteratorT last, const T& value, CompareOpT comp)
@@ -65,6 +93,34 @@ struct upper_bound
     return ::cuda::std::upper_bound(first, last, value, comp) - first;
   }
 };
+
+template <typename RangeIteratorT, typename RangeNumItemsT, typename CompareOpT, typename Mode>
+struct binary_search_transform_op_t
+{
+  RangeIteratorT first;
+  RangeNumItemsT num_items;
+  CompareOpT op;
+
+  template <typename Value>
+  _CCCL_DEVICE _CCCL_FORCEINLINE ::cuda::std::ptrdiff_t operator()(const Value& value) const
+  {
+    using DifferenceT = ::cuda::std::iter_difference_t<RangeIteratorT>;
+    const auto count  = static_cast<DifferenceT>(num_items);
+
+    if (num_items <= static_cast<RangeNumItemsT>(linear_lower_bound_threshold))
+    {
+      return Mode::Linear(first, count, value, op);
+    }
+
+    return Mode::Invoke(first, first + count, value, op);
+  }
+};
+
+template <typename Mode, typename RangeIteratorT, typename RangeNumItemsT, typename CompareOpT>
+_CCCL_HOST_DEVICE auto make_binary_search_transform_op(RangeIteratorT first, RangeNumItemsT num_items, CompareOpT comp)
+{
+  return binary_search_transform_op_t<RangeIteratorT, RangeNumItemsT, CompareOpT, Mode>{first, num_items, comp};
+}
 } // namespace detail::find
 
 CUB_NAMESPACE_END

--- a/cub/cub/device/device_find.cuh
+++ b/cub/cub/device/device_find.cuh
@@ -17,6 +17,7 @@
 #include <cub/detail/choose_offset.cuh>
 #include <cub/detail/env_dispatch.cuh>
 #include <cub/device/device_for.cuh>
+#include <cub/device/device_transform.cuh>
 #include <cub/device/dispatch/dispatch_find.cuh>
 #include <cub/thread/thread_operators.cuh>
 
@@ -212,14 +213,20 @@ struct DeviceFind
     using RangeOffsetT  = detail::choose_offset_t<RangeNumItemsT>;
     using ValuesOffsetT = detail::choose_offset_t<ValuesNumItemsT>;
 
-    return DeviceFor::__for_each_n_no_nvtx(
-      d_temp_storage,
-      temp_storage_bytes,
-      ::cuda::make_zip_iterator(d_values, d_output),
+    if (d_temp_storage == nullptr)
+    {
+      temp_storage_bytes = 1;
+      return cudaSuccess;
+    }
+
+    return DeviceTransform::__transform_internal(
+      ::cuda::std::make_tuple(d_values),
+      d_output,
       static_cast<ValuesOffsetT>(values_num_items),
-      detail::find::make_comp_wrapper<detail::find::lower_bound>(
+      detail::transform::always_true_predicate{},
+      detail::find::make_binary_search_transform_op<detail::find::lower_bound>(
         d_range, static_cast<RangeOffsetT>(range_num_items), comp),
-      stream);
+      ::cuda::stream_ref{stream});
   }
 
   //! @rst
@@ -520,14 +527,20 @@ struct DeviceFind
     using ValuesOffsetT = detail::choose_offset_t<ValuesNumItemsT>;
 
     return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return DeviceFor::__for_each_n_no_nvtx(
-        storage,
-        bytes,
-        ::cuda::make_zip_iterator(d_values, d_output),
+      if (storage == nullptr)
+      {
+        bytes = 1;
+        return cudaSuccess;
+      }
+
+      return DeviceTransform::__transform_internal(
+        ::cuda::std::make_tuple(d_values),
+        d_output,
         static_cast<ValuesOffsetT>(values_num_items),
-        detail::find::make_comp_wrapper<detail::find::lower_bound>(
+        detail::transform::always_true_predicate{},
+        detail::find::make_binary_search_transform_op<detail::find::lower_bound>(
           d_range, static_cast<RangeOffsetT>(range_num_items), comp),
-        stream);
+        ::cuda::stream_ref{stream});
     });
   }
 

--- a/cub/cub/device/device_find.cuh
+++ b/cub/cub/device/device_find.cuh
@@ -333,14 +333,20 @@ struct DeviceFind
     using RangeOffsetT  = detail::choose_offset_t<RangeNumItemsT>;
     using ValuesOffsetT = detail::choose_offset_t<ValuesNumItemsT>;
 
-    return DeviceFor::__for_each_n_no_nvtx(
-      d_temp_storage,
-      temp_storage_bytes,
-      ::cuda::make_zip_iterator(d_values, d_output),
+    if (d_temp_storage == nullptr)
+    {
+      temp_storage_bytes = 1;
+      return cudaSuccess;
+    }
+
+    return DeviceTransform::__transform_internal(
+      ::cuda::std::make_tuple(d_values),
+      d_output,
       static_cast<ValuesOffsetT>(values_num_items),
-      detail::find::make_comp_wrapper<detail::find::upper_bound>(
+      detail::transform::always_true_predicate{},
+      detail::find::make_binary_search_transform_op<detail::find::upper_bound>(
         d_range, static_cast<RangeOffsetT>(range_num_items), comp),
-      stream);
+      ::cuda::stream_ref{stream});
   }
   //! @rst
   //! Finds the first element in the input sequence that satisfies the given predicate.
@@ -647,14 +653,20 @@ struct DeviceFind
     using ValuesOffsetT = detail::choose_offset_t<ValuesNumItemsT>;
 
     return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return DeviceFor::__for_each_n_no_nvtx(
-        storage,
-        bytes,
-        ::cuda::make_zip_iterator(d_values, d_output),
+      if (storage == nullptr)
+      {
+        bytes = 1;
+        return cudaSuccess;
+      }
+
+      return DeviceTransform::__transform_internal(
+        ::cuda::std::make_tuple(d_values),
+        d_output,
         static_cast<ValuesOffsetT>(values_num_items),
-        detail::find::make_comp_wrapper<detail::find::upper_bound>(
+        detail::transform::always_true_predicate{},
+        detail::find::make_binary_search_transform_op<detail::find::upper_bound>(
           d_range, static_cast<RangeOffsetT>(range_num_items), comp),
-        stream);
+        ::cuda::stream_ref{stream});
     });
   }
 };

--- a/cub/test/catch2_test_env_launch_helper.h
+++ b/cub/test/catch2_test_env_launch_helper.h
@@ -75,9 +75,9 @@ static CUB_RUNTIME_FUNCTION stream_registry_factory_state_t* get_stream_registry
 
 struct kernel_launcher_t : thrust::cuda_cub::detail::triple_chevron
 {
-  template <class... Args>
-  CUB_RUNTIME_FUNCTION kernel_launcher_t(Args... args)
-      : thrust::cuda_cub::detail::triple_chevron(args...)
+  CUB_RUNTIME_FUNCTION kernel_launcher_t(
+    dim3 grid, dim3 block, size_t shared_mem = 0, cudaStream_t stream = nullptr, bool dependent_launch = false)
+      : thrust::cuda_cub::detail::triple_chevron(grid, block, shared_mem, stream, dependent_launch)
   {}
 
   template <class K, class... Args>

--- a/python/cuda_cccl/cuda/compute/_bindings_impl.pyx
+++ b/python/cuda_cccl/cuda/compute/_bindings_impl.pyx
@@ -2253,11 +2253,9 @@ cdef class DeviceHistogramBuildResult:
 # -------------------
 cdef extern from "cccl/c/binary_search.h":
     cdef struct cccl_device_binary_search_build_result_t 'cccl_device_binary_search_build_result_t':
-        int cc
-        void* cubin
-        size_t cubin_size
-        CUlibrary library
-        CUkernel kernel
+        cccl_device_transform_build_result_t transform
+        size_t op_state_size
+        size_t op_state_alignment
 
     cdef CUresult cccl_device_binary_search_build(
         cccl_device_binary_search_build_result_t*,
@@ -2364,8 +2362,8 @@ cdef class DeviceBinarySearchBuildResult:
 
     def _get_cubin(self):
         return PyBytes_FromStringAndSize(
-            <const char*>self.build_data.cubin,
-            self.build_data.cubin_size
+            <const char*>self.build_data.transform.cubin,
+            self.build_data.transform.cubin_size
         )
 
 


### PR DESCRIPTION
## Description

`{Lower,Upper}Bound` in CUB now run through `Transform`, not `ForEach`. c.parallel now reuses the transform logic to build its binary_search algorithm - I wasn't sure if that was feasible, but apparently the "C++ source" operator support + extra ltoir options actually are enough for this, well, simplification.

Resolves #8221.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
