### PR TITLE
Improve `iterator_traits` implementation

### DIFF
--- a/libcudacxx/include/cuda/std/__fwd/iterator.h
+++ b/libcudacxx/include/cuda/std/__fwd/iterator.h
@@ -28,13 +28,8 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 template <class _Container>
 class _CCCL_TYPE_VISIBILITY_DEFAULT __back_insert_iterator;
 
-#if _CCCL_HAS_CONCEPTS()
-template <class>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
-#else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS()
 template <class, class = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
-#endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 
 _LIBCUDACXX_BEGIN_HIDDEN_FRIEND_NAMESPACE
 

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -79,47 +79,27 @@ struct __cccl_std_contiguous_iterator_tag_exists : __cccl_type_is_defined<struct
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-#if _CCCL_HAS_CONCEPTS()
-
 template <class _Tp>
 using __with_reference = _Tp&;
 
 template <class _Tp>
-concept __can_reference = requires { typename __with_reference<_Tp>; };
-
-template <class _Tp>
-concept __dereferenceable = requires(_Tp& __t) {
-  { *__t } -> __can_reference; // not required to be equality-preserving
-};
-
-// [iterator.traits]
-template <__dereferenceable _Tp>
-using iter_reference_t = decltype(*declval<_Tp&>());
-
-#else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ // vvv _CCCL_HAS_CONCEPTS() vvv
-
-template <class _Tp>
-using __with_reference = _Tp&;
-
-template <class _Tp>
-_CCCL_CONCEPT_FRAGMENT(__can_reference_, requires()(typename(__with_reference<_Tp>)));
-
-template <class _Tp>
-_CCCL_CONCEPT __can_reference = _CCCL_FRAGMENT(__can_reference_, _Tp);
+_CCCL_CONCEPT __can_reference = _CCCL_REQUIRES_EXPR((_Tp))(typename(__with_reference<_Tp>));
 
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wvoid-ptr-dereference")
+
 template <class _Tp>
-_CCCL_CONCEPT_FRAGMENT(__dereferenceable_, requires(_Tp& __t)(requires(__can_reference<decltype(*__t)>)));
+_CCCL_CONCEPT __dereferenceable = _CCCL_REQUIRES_EXPR((_Tp), _Tp& __t)(requires(__can_reference<decltype(*__t)>));
+
 _CCCL_DIAG_POP
 
-template <class _Tp>
-_CCCL_CONCEPT __dereferenceable = _CCCL_FRAGMENT(__dereferenceable_, _Tp);
-
 // [iterator.traits]
+#if _CCCL_HAS_CONCEPTS()
+template <__dereferenceable _Tp>
+using iter_reference_t = decltype(*::cuda::std::declval<_Tp&>());
+#else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ // vvv _CCCL_HAS_CONCEPTS() vvv
 template <class _Tp>
-using iter_reference_t = enable_if_t<__dereferenceable<_Tp>, decltype(*declval<_Tp&>())>;
-
+using iter_reference_t = enable_if_t<__dereferenceable<_Tp>, decltype(*::cuda::std::declval<_Tp&>())>;
 #endif // _CCCL_HAS_CONCEPTS()
 
 #if _CCCL_COMPILER(NVRTC)
@@ -223,7 +203,8 @@ _CCCL_API inline auto __iter_concept_fn(_Iter, __priority_tag<0>)
                  random_access_iterator_tag>;
 
 template <class _Iter>
-using __iter_concept_t = decltype(::cuda::std::__iter_concept_fn<_Iter>(declval<_Iter>(), __priority_tag<3>{}));
+using __iter_concept_t =
+  decltype(::cuda::std::__iter_concept_fn<_Iter>(::cuda::std::declval<_Iter>(), __priority_tag<3>{}));
 
 template <class _Iter, class = void>
 struct __iter_concept_cache
@@ -247,525 +228,263 @@ _CCCL_CONCEPT __has_member_pointer = _CCCL_REQUIRES_EXPR((_Tp))(typename(typenam
 template <class _Tp>
 _CCCL_CONCEPT __has_member_iterator_category = _CCCL_REQUIRES_EXPR((_Tp))(typename(typename _Tp::iterator_category));
 
-#if _CCCL_HAS_CONCEPTS()
-
 // The `cpp17-*-iterator` exposition-only concepts have very similar names to the `Cpp17*Iterator` named requirements
 // from `[iterator.cpp17]`. To avoid confusion between the two, the exposition-only concepts have been banished to
 // a "detail" namespace indicating they have a niche use-case.
 namespace __iterator_traits_detail
 {
-template <class _Ip>
-concept __cpp17_iterator = requires(_Ip __i) {
-  { *__i } -> __can_reference;
-  { ++__i } -> same_as<_Ip&>;
-  { *__i++ } -> __can_reference;
-} && copyable<_Ip>;
+// [iterator.traits#concept:cpp17-iterator]
+template <class _Iter>
+_CCCL_CONCEPT __cpp17_iterator = _CCCL_REQUIRES_EXPR((_Iter), _Iter __i)(
+  requires(copyable<_Iter>),
+  requires(__can_reference<decltype(*__i)>),
+  requires(same_as<decltype(++__i), _Iter&>),
+  requires(__can_reference<decltype(*__i++)>));
 
-template <class _Ip>
-concept __cpp17_input_iterator = __cpp17_iterator<_Ip> && equality_comparable<_Ip> && requires(_Ip __i) {
-  typename incrementable_traits<_Ip>::difference_type;
-  typename indirectly_readable_traits<_Ip>::value_type;
-  typename common_reference_t<iter_reference_t<_Ip>&&, typename indirectly_readable_traits<_Ip>::value_type&>;
-  typename common_reference_t<decltype(*__i++)&&, typename indirectly_readable_traits<_Ip>::value_type&>;
-  requires signed_integral<typename incrementable_traits<_Ip>::difference_type>;
-};
+// [iterator.traits#concept:cpp17-input-iterator]
+template <class _Iter>
+_CCCL_CONCEPT __cpp17_input_iterator = _CCCL_REQUIRES_EXPR((_Iter), _Iter __i)(
+  requires(__cpp17_iterator<_Iter>),
+  requires(equality_comparable<_Iter>),
+  typename(typename incrementable_traits<_Iter>::difference_type),
+  typename(typename indirectly_readable_traits<_Iter>::value_type),
+  typename(common_reference_t<iter_reference_t<_Iter>&&, typename indirectly_readable_traits<_Iter>::value_type&>),
+  typename(common_reference_t<decltype(*__i++)&&, typename indirectly_readable_traits<_Iter>::value_type&>),
+  requires(signed_integral<typename incrementable_traits<_Iter>::difference_type>));
 
-template <class _Ip>
-concept __cpp17_forward_iterator =
-  __cpp17_input_iterator<_Ip> && constructible_from<_Ip> && is_lvalue_reference_v<iter_reference_t<_Ip>>
-  && same_as<remove_cvref_t<iter_reference_t<_Ip>>, typename indirectly_readable_traits<_Ip>::value_type>
-  && requires(_Ip __i) {
-       { __i++ } -> convertible_to<_Ip const&>;
-       { *__i++ } -> same_as<iter_reference_t<_Ip>>;
-     };
+// [iterator.traits#concept:cpp17-forward-iterator]
+template <class _Iter>
+_CCCL_CONCEPT __cpp17_forward_iterator = _CCCL_REQUIRES_EXPR((_Iter), _Iter __i)(
+  requires(__cpp17_input_iterator<_Iter>),
+  requires(constructible_from<_Iter>),
+  requires(is_lvalue_reference_v<iter_reference_t<_Iter>>),
+  requires(same_as<remove_cvref_t<iter_reference_t<_Iter>>, typename indirectly_readable_traits<_Iter>::value_type>),
+  requires(convertible_to<decltype(__i++), _Iter const&>),
+  requires(same_as<decltype(*__i++), iter_reference_t<_Iter>>));
 
-template <class _Ip>
-concept __cpp17_bidirectional_iterator = __cpp17_forward_iterator<_Ip> && requires(_Ip __i) {
-  { --__i } -> same_as<_Ip&>;
-  { __i-- } -> convertible_to<_Ip const&>;
-  { *__i-- } -> same_as<iter_reference_t<_Ip>>;
-};
+// [iterator.traits#concept:cpp17-bidirectional-iterator]
+template <class _Iter>
+_CCCL_CONCEPT __cpp17_bidirectional_iterator = _CCCL_REQUIRES_EXPR((_Iter), _Iter __i)(
+  requires(__cpp17_forward_iterator<_Iter>),
+  requires(same_as<decltype(--__i), _Iter&>),
+  requires(convertible_to<decltype(__i--), _Iter const&>),
+  requires(same_as<decltype(*__i--), iter_reference_t<_Iter>>));
 
-template <class _Ip>
-concept __cpp17_random_access_iterator =
-  __cpp17_bidirectional_iterator<_Ip> && totally_ordered<_Ip>
-  && requires(_Ip __i, typename incrementable_traits<_Ip>::difference_type __n) {
-       { __i += __n } -> same_as<_Ip&>;
-       { __i -= __n } -> same_as<_Ip&>;
-       { __i + __n } -> same_as<_Ip>;
-       { __n + __i } -> same_as<_Ip>;
-       { __i - __n } -> same_as<_Ip>;
-       { __i - __i } -> same_as<decltype(__n)>; // NOLINT(misc-redundant-expression) ; This is llvm.org/PR54114
-       { __i[__n] } -> convertible_to<iter_reference_t<_Ip>>;
-     };
-} // namespace __iterator_traits_detail
-
-// We need to consider if a user has specialized std::iterator_traits
-template <class _Ip>
-concept __specialized_from_std = !__is_primary_std_template<remove_cvref_t<_Ip>>::value;
-
-template <class _Ip>
-concept __specifies_members = !__specialized_from_std<_Ip> && requires {
-  typename _Ip::value_type;
-  typename _Ip::difference_type;
-  requires __has_member_reference<_Ip>;
-  requires __has_member_iterator_category<_Ip>;
-};
-
-template <class>
-struct __iterator_traits_member_pointer_or_void
-{
-  using type = void;
-};
-
-template <__has_member_pointer _Tp>
-struct __iterator_traits_member_pointer_or_void<_Tp>
-{
-  using type = typename _Tp::pointer;
-};
-
-template <class _Tp>
-concept __cpp17_iterator_missing_members =
-  !__specialized_from_std<_Tp> && !__specifies_members<_Tp> && __iterator_traits_detail::__cpp17_iterator<_Tp>;
-
-template <class _Tp>
-concept __cpp17_input_iterator_missing_members =
-  __cpp17_iterator_missing_members<_Tp> && __iterator_traits_detail::__cpp17_input_iterator<_Tp>;
-
-// Otherwise, `pointer` names `void`.
-template <class>
-struct __iterator_traits_member_pointer_or_arrow_or_void
-{
-  using type = void;
-};
-
-// [iterator.traits]/3.2.1
-// If the qualified-id `I::pointer` is valid and denotes a type, `pointer` names that type.
-template <__has_member_pointer _Ip>
-struct __iterator_traits_member_pointer_or_arrow_or_void<_Ip>
-{
-  using type = typename _Ip::pointer;
-};
-
-// Otherwise, if `decltype(declval<I&>().operator->())` is well-formed, then `pointer` names that
-// type.
-template <class _Ip>
-  requires requires(_Ip& __i) { __i.operator->(); } && (!__has_member_pointer<_Ip>)
-struct __iterator_traits_member_pointer_or_arrow_or_void<_Ip>
-{
-  using type = decltype(declval<_Ip&>().operator->());
-};
-
-// Otherwise, `reference` names `iter-reference-t<I>`.
-template <class _Ip>
-struct __iterator_traits_member_reference
-{
-  using type = iter_reference_t<_Ip>;
-};
-
-// [iterator.traits]/3.2.2
-// If the qualified-id `I::reference` is valid and denotes a type, `reference` names that type.
-template <__has_member_reference _Ip>
-struct __iterator_traits_member_reference<_Ip>
-{
-  using type = typename _Ip::reference;
-};
-
-// [iterator.traits]/3.2.3.4
-// input_iterator_tag
-template <class _Ip>
-struct __deduce_iterator_category
-{
-  using type = input_iterator_tag;
-};
-
-// [iterator.traits]/3.2.3.1
-// `random_access_iterator_tag` if `I` satisfies `cpp17-random-access-iterator`, or otherwise
-template <__iterator_traits_detail::__cpp17_random_access_iterator _Ip>
-struct __deduce_iterator_category<_Ip>
-{
-  using type = random_access_iterator_tag;
-};
-
-// [iterator.traits]/3.2.3.2
-// `bidirectional_iterator_tag` if `I` satisfies `cpp17-bidirectional-iterator`, or otherwise
-template <__iterator_traits_detail::__cpp17_bidirectional_iterator _Ip>
-  requires(!__iterator_traits_detail::__cpp17_random_access_iterator<_Ip>) // nvbug 3885350
-struct __deduce_iterator_category<_Ip>
-{
-  using type = bidirectional_iterator_tag;
-};
-
-// [iterator.traits]/3.2.3.3
-// `forward_iterator_tag` if `I` satisfies `cpp17-forward-iterator`, or otherwise
-template <__iterator_traits_detail::__cpp17_forward_iterator _Ip>
-  requires(!__iterator_traits_detail::__cpp17_bidirectional_iterator<_Ip>) // nvbug 3885350
-struct __deduce_iterator_category<_Ip>
-{
-  using type = forward_iterator_tag;
-};
-
-template <class _Ip>
-struct __iterator_traits_iterator_category : __deduce_iterator_category<_Ip>
-{};
-
-// [iterator.traits]/3.2.3
-// If the qualified-id `I::iterator-category` is valid and denotes a type, `iterator-category` names
-// that type.
-template <__has_member_iterator_category _Ip>
-struct __iterator_traits_iterator_category<_Ip>
-{
-  using type = typename _Ip::iterator_category;
-};
-
-// otherwise, it names void.
-template <class>
-struct __iterator_traits_difference_type
-{
-  using type = void;
-};
-
-// If the qualified-id `incrementable_traits<I>::difference_type` is valid and denotes a type, then
-// `difference_type` names that type;
-template <class _Ip>
-  requires requires { typename incrementable_traits<_Ip>::difference_type; }
-struct __iterator_traits_difference_type<_Ip>
-{
-  using type = typename incrementable_traits<_Ip>::difference_type;
-};
-
-// [iterator.traits]/3.4
-// Otherwise, `iterator_traits<I>` has no members by any of the above names.
-template <class>
-struct __iterator_traits
-{};
-
-#  if !_CCCL_COMPILER(NVRTC)
-// We need to properly accept specializations of `std::iterator_traits`
-template <__specialized_from_std _Ip>
-struct __iterator_traits<_Ip> : public ::std::iterator_traits<_Ip>
-{};
-#  endif // !_CCCL_COMPILER(NVRTC)
-
-// [iterator.traits]/3.1
-// If `I` has valid ([temp.deduct]) member types `difference-type`, `value-type`, `reference`, and
-// `iterator-category`, then `iterator-traits<I>` has the following publicly accessible members:
-template <__specifies_members _Ip>
-struct __iterator_traits<_Ip>
-{
-  using iterator_category = typename _Ip::iterator_category;
-  using value_type        = typename _Ip::value_type;
-  using difference_type   = typename _Ip::difference_type;
-  using pointer           = typename __iterator_traits_member_pointer_or_void<_Ip>::type;
-  using reference         = typename _Ip::reference;
-};
-
-// [iterator.traits]/3.2
-// Otherwise, if `I` satisfies the exposition-only concept `cpp17-input-iterator`,
-// `iterator-traits<I>` has the following publicly accessible members:
-template <__cpp17_input_iterator_missing_members _Ip>
-struct __iterator_traits<_Ip>
-{
-  using iterator_category = typename __iterator_traits_iterator_category<_Ip>::type;
-  using value_type        = typename indirectly_readable_traits<_Ip>::value_type;
-  using difference_type   = typename incrementable_traits<_Ip>::difference_type;
-  using pointer           = typename __iterator_traits_member_pointer_or_arrow_or_void<_Ip>::type;
-  using reference         = typename __iterator_traits_member_reference<_Ip>::type;
-};
-
-// Otherwise, if `I` satisfies the exposition-only concept `cpp17-iterator`, then
-// `iterator_traits<I>` has the following publicly accessible members:
-template <__cpp17_iterator_missing_members _Ip>
-  requires(!__cpp17_input_iterator_missing_members<_Ip>) // nvbug 3885350
-struct __iterator_traits<_Ip>
-{
-  using iterator_category = output_iterator_tag;
-  using value_type        = void;
-  using difference_type   = typename __iterator_traits_difference_type<_Ip>::type;
-  using pointer           = void;
-  using reference         = void;
-};
-
-template <class _Ip>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits : __iterator_traits<_Ip>
-{
-  using __cccl_primary_template = iterator_traits;
-};
-
-#else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
-
-// The `cpp17-*-iterator` exposition-only concepts have very similar names to the `Cpp17*Iterator` named requirements
-// from `[iterator.cpp17]`. To avoid confusion between the two, the exposition-only concepts have been banished to
-// a "detail" namespace indicating they have a niche use-case.
-namespace __iterator_traits_detail
-{
-template <class _Ip>
-_CCCL_CONCEPT_FRAGMENT(
-  __cpp17_iterator_,
-  requires(_Ip __i)(requires(__can_reference<decltype(*__i)>),
-                    requires(same_as<_Ip&, decltype(++__i)>),
-                    requires(__can_reference<decltype(*__i++)>),
-                    requires(copyable<_Ip>)));
-
-template <class _Ip>
-_CCCL_CONCEPT __cpp17_iterator = _CCCL_FRAGMENT(__cpp17_iterator_, _Ip);
-
-template <class _Ip>
-_CCCL_CONCEPT_FRAGMENT(
-  __cpp17_input_iterator_,
-  requires(_Ip __i)(
-    typename(common_reference_t<iter_reference_t<_Ip>&&, typename indirectly_readable_traits<_Ip>::value_type&>),
-    typename(common_reference_t<decltype(*__i++)&&, typename indirectly_readable_traits<_Ip>::value_type&>),
-    requires(__cpp17_iterator<_Ip>),
-    requires(equality_comparable<_Ip>),
-    requires(__has_member_difference_type<incrementable_traits<_Ip>>),
-    requires(__has_member_value_type<indirectly_readable_traits<_Ip>>),
-    requires(signed_integral<typename incrementable_traits<_Ip>::difference_type>)));
-
-template <class _Ip>
-_CCCL_CONCEPT __cpp17_input_iterator = _CCCL_FRAGMENT(__cpp17_input_iterator_, _Ip);
-
-template <class _Ip>
-_CCCL_CONCEPT_FRAGMENT(
-  __cpp17_forward_iterator_,
-  requires(_Ip __i)(
-    requires(__cpp17_input_iterator<_Ip>),
-    requires(convertible_to<decltype(__i++), _Ip const&>),
-    requires(same_as<iter_reference_t<_Ip>, decltype(*__i++)>),
-    requires(constructible_from<_Ip>),
-    requires(is_lvalue_reference_v<iter_reference_t<_Ip>>),
-    requires(same_as<remove_cvref_t<iter_reference_t<_Ip>>, typename indirectly_readable_traits<_Ip>::value_type>)));
-
-template <class _Ip>
-_CCCL_CONCEPT __cpp17_forward_iterator = _CCCL_FRAGMENT(__cpp17_forward_iterator_, _Ip);
-
-template <class _Ip>
-_CCCL_CONCEPT_FRAGMENT(
-  __cpp17_bidirectional_iterator_,
-  requires(_Ip __i)(requires(__cpp17_forward_iterator<_Ip>),
-                    requires(same_as<_Ip&, decltype(--__i)>),
-                    requires(convertible_to<decltype(__i--), _Ip const&>),
-                    requires(same_as<iter_reference_t<_Ip>, decltype(*__i--)>)));
-
-template <class _Ip>
-_CCCL_CONCEPT __cpp17_bidirectional_iterator = _CCCL_FRAGMENT(__cpp17_bidirectional_iterator_, _Ip);
-
-template <class _Ip>
-_CCCL_CONCEPT_FRAGMENT(
-  __cpp17_random_access_iterator_,
-  requires(_Ip __i, typename incrementable_traits<_Ip>::difference_type __n)(
-    requires(same_as<_Ip&, decltype(__i += __n)>),
-    requires(same_as<_Ip&, decltype(__i -= __n)>),
-    requires(same_as<_Ip, decltype(__i + __n)>),
-    requires(same_as<_Ip, decltype(__n + __i)>),
-    requires(same_as<_Ip, decltype(__i - __n)>),
+// [iterator.traits#concept:cpp17-random-access-iterator]
+// Needs to be its own concept, because we need `typename incrementable_traits<_Iter>::difference_type` to be valid
+template <class _Iter>
+_CCCL_CONCEPT __cpp17_random_access_iterator_operations =
+  _CCCL_REQUIRES_EXPR((_Iter), _Iter __i, typename incrementable_traits<_Iter>::difference_type __n)(
+    requires(same_as<_Iter&, decltype(__i += __n)>),
+    requires(same_as<_Iter&, decltype(__i -= __n)>),
+    requires(same_as<_Iter, decltype(__i + __n)>),
+    requires(same_as<_Iter, decltype(__n + __i)>),
+    requires(same_as<_Iter, decltype(__i - __n)>),
     requires(same_as<decltype(__n), decltype(__i - __i)>),
-    requires(convertible_to<decltype(__i[__n]), iter_reference_t<_Ip>>)));
+    requires(convertible_to<decltype(__i[__n]), iter_reference_t<_Iter>>));
 
-template <class _Ip>
-_CCCL_CONCEPT __cpp17_random_access_iterator =
-  __cpp17_bidirectional_iterator<_Ip> && totally_ordered<_Ip> && _CCCL_FRAGMENT(__cpp17_random_access_iterator_, _Ip);
+template <class _Iter>
+_CCCL_CONCEPT __cpp17_random_access_iterator = _CCCL_REQUIRES_EXPR((_Iter))(
+  requires(__cpp17_bidirectional_iterator<_Iter>),
+  requires(totally_ordered<_Iter>),
+  requires(__cpp17_random_access_iterator_operations<_Iter>));
 } // namespace __iterator_traits_detail
 
-// We need to consider if a user has specialized std::iterator_traits
-template <class _Ip>
-inline constexpr bool __specialized_from_std = !__is_primary_std_template<remove_cvref_t<_Ip>>::value;
+// [iterator.traits]#3.1
+// If the qualified-id I​::​pointer is valid and denotes a type, then ​pointer names that type;
+template <class _Iter>
+_CCCL_API auto __iterator_traits_deduce_member_pointer_or_void(int) -> typename _Iter::pointer;
+// Otherwise, it names void.
+template <class _Iter>
+_CCCL_API auto __iterator_traits_deduce_member_pointer_or_void(...) -> void;
 
-template <class _Ip>
-_CCCL_CONCEPT __specifies_members =
-  !__specialized_from_std<_Ip> && __has_member_value_type<_Ip> && __has_member_difference_type<_Ip>
-  && __has_member_reference<_Ip> && __has_member_iterator_category<_Ip>;
+template <class _Iter>
+using __iterator_traits_member_pointer_or_void =
+  decltype(::cuda::std::__iterator_traits_deduce_member_pointer_or_void<_Iter>(0));
 
-template <class, class = void>
-struct __iterator_traits_member_pointer_or_void
-{
-  using type = void;
-};
+// [iterator.traits]#3.2
+// [iterator.traits]#3.2.1
+// If the qualified-id I​::​pointer is valid and denotes a type, then pointer names that type.
+template <class _Iter>
+_CCCL_API auto __iterator_traits_deduce_member_pointer_or_arrow_or_void(int, __priority_tag<1>) ->
+  typename _Iter::pointer;
 
-template <class _Tp>
-struct __iterator_traits_member_pointer_or_void<_Tp, enable_if_t<__has_member_pointer<_Tp>>>
-{
-  using type = typename _Tp::pointer;
-};
+// Otherwise, if decltype(​declval<I&>().operator->()) is well-formed, then pointer names that type.
+template <class _Iter>
+_CCCL_API auto __iterator_traits_deduce_member_pointer_or_arrow_or_void(int, __priority_tag<0>)
+  -> decltype(::cuda::std::declval<_Iter&>().operator->());
 
-template <class _Tp>
-_CCCL_CONCEPT __cpp17_iterator_missing_members =
-  !__specialized_from_std<_Tp> && !__specifies_members<_Tp> && __iterator_traits_detail::__cpp17_iterator<_Tp>;
+// Otherwise, pointer names void.
+template <class _Iter>
+_CCCL_API auto __iterator_traits_deduce_member_pointer_or_arrow_or_void(...) -> void;
 
-template <class _Tp>
-_CCCL_CONCEPT __cpp17_input_iterator_missing_members =
-  __cpp17_iterator_missing_members<_Tp> && __iterator_traits_detail::__cpp17_input_iterator<_Tp>;
+template <class _Iter>
+using __iterator_traits_member_pointer_or_arrow_or_void =
+  decltype(::cuda::std::__iterator_traits_deduce_member_pointer_or_arrow_or_void<_Iter>(0, __priority_tag<1>{}));
 
-// Otherwise, `pointer` names `void`.
-template <class, class = void>
-struct __iterator_traits_member_pointer_or_arrow_or_void
-{
-  using type = void;
-};
-
-// [iterator.traits]/3.2.1
-// If the qualified-id `I::pointer` is valid and denotes a type, `pointer` names that type.
-template <class _Ip>
-struct __iterator_traits_member_pointer_or_arrow_or_void<_Ip, enable_if_t<__has_member_pointer<_Ip>>>
-{
-  using type = typename _Ip::pointer;
-};
-
-template <class _Ip, class = void>
-inline constexpr bool __has_operator_arrow = false;
-
-template <class _Ip>
-inline constexpr bool __has_operator_arrow<_Ip, decltype((void) ::cuda::std::declval<_Ip&>().operator->())> = true;
-
-// Otherwise, if `decltype(declval<I&>().operator->())` is well-formed, then `pointer` names that
-// type.
-template <class _Ip>
-struct __iterator_traits_member_pointer_or_arrow_or_void<
-  _Ip,
-  enable_if_t<__has_operator_arrow<_Ip> && !__has_member_pointer<_Ip>>>
-{
-  using type = decltype(declval<_Ip&>().operator->());
-};
-
-// Otherwise, `reference` names `iter-reference-t<I>`.
-template <class _Ip, class = void>
-struct __iterator_traits_member_reference
-{
-  using type = iter_reference_t<_Ip>;
-};
-
-// [iterator.traits]/3.2.2
+// [iterator.traits]#3.2.2
 // If the qualified-id `I::reference` is valid and denotes a type, `reference` names that type.
-template <class _Ip>
-struct __iterator_traits_member_reference<_Ip, enable_if_t<__has_member_reference<_Ip>>>
+template <class _Iter>
+_CCCL_API auto __iterator_traits_deduce_member_reference(int) -> typename _Iter::reference;
+// Otherwise, `reference` names `iter-reference-t<I>`.
+template <class _Iter>
+_CCCL_API auto __iterator_traits_deduce_member_reference(...) -> iter_reference_t<_Iter>;
+
+template <class _Iter>
+using __iterator_traits_member_reference = decltype(::cuda::std::__iterator_traits_deduce_member_reference<_Iter>(0));
+
+// [iterator.traits]#3.2.3
+template <class _Iter>
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __iterator_traits_deduce_iterator_category() noexcept
 {
-  using type = typename _Ip::reference;
-};
+  if constexpr (__has_member_iterator_category<_Iter>)
+  { // If the qualified-id `I::iterator-category` is valid and denotes a type, `iterator-category` names that type.
+    return typename _Iter::iterator_category{};
+  }
+  else if constexpr (__iterator_traits_detail::__cpp17_random_access_iterator<_Iter>)
+  { // Otherwise `random_access_iterator_tag` if `I` satisfies `cpp17-random-access-iterator`,
+    return random_access_iterator_tag{};
+  }
+  else if constexpr (__iterator_traits_detail::__cpp17_bidirectional_iterator<_Iter>)
+  { // or otherwise `bidirectional_iterator_tag` if `I` satisfies `cpp17-bidirectional-iterator`,
+    return bidirectional_iterator_tag{};
+  }
+  else if constexpr (__iterator_traits_detail::__cpp17_forward_iterator<_Iter>)
+  { // or otherwise `forward_iterator_tag` if `I` satisfies `cpp17-forward-iterator`,
+    return forward_iterator_tag{};
+  }
+  else
+  { // or otherwise input_iterator_tag
+    return input_iterator_tag{};
+  }
+}
 
-// [iterator.traits]/3.2.3.4
-// input_iterator_tag
-template <class _Ip, class = void>
-struct __deduce_iterator_category
-{
-  using type = input_iterator_tag;
-};
+template <class _Iter>
+using __iterator_traits_iterator_category = decltype(::cuda::std::__iterator_traits_deduce_iterator_category<_Iter>());
 
-// [iterator.traits]/3.2.3.1
-// `random_access_iterator_tag` if `I` satisfies `cpp17-random-access-iterator`, or otherwise
-template <class _Ip>
-struct __deduce_iterator_category<_Ip, enable_if_t<__iterator_traits_detail::__cpp17_random_access_iterator<_Ip>>>
-{
-  using type = random_access_iterator_tag;
-};
-
-// [iterator.traits]/3.2.3.2
-// `bidirectional_iterator_tag` if `I` satisfies `cpp17-bidirectional-iterator`, or otherwise
-template <class _Ip>
-struct __deduce_iterator_category<_Ip,
-                                  enable_if_t<!__iterator_traits_detail::__cpp17_random_access_iterator<_Ip>
-                                              && __iterator_traits_detail::__cpp17_bidirectional_iterator<_Ip>>>
-{
-  using type = bidirectional_iterator_tag;
-};
-
-// [iterator.traits]/3.2.3.3
-// `forward_iterator_tag` if `I` satisfies `cpp17-forward-iterator`, or otherwise
-template <class _Ip>
-struct __deduce_iterator_category<_Ip,
-                                  enable_if_t<!__iterator_traits_detail::__cpp17_bidirectional_iterator<_Ip>
-                                              && __iterator_traits_detail::__cpp17_forward_iterator<_Ip>>>
-{
-  using type = forward_iterator_tag;
-};
-
-template <class _Ip, class = void>
-struct __iterator_traits_iterator_category : __deduce_iterator_category<_Ip>
-{};
-
-// [iterator.traits]/3.2.3
-// If the qualified-id `I::iterator-category` is valid and denotes a type, `iterator-category` names
-// that type.
-template <class _Ip>
-struct __iterator_traits_iterator_category<_Ip, enable_if_t<__has_member_iterator_category<_Ip>>>
-{
-  using type = typename _Ip::iterator_category;
-};
-
-// otherwise, it names void.
-template <class, class = void>
-struct __iterator_traits_difference_type
-{
-  using type = void;
-};
-
+// [iterator.traits]#3.3
 // If the qualified-id `incrementable_traits<I>::difference_type` is valid and denotes a type, then
 // `difference_type` names that type;
-template <class _Ip>
-struct __iterator_traits_difference_type<_Ip, void_t<typename incrementable_traits<_Ip>::difference_type>>
+template <class _Iter>
+_CCCL_API auto __iterator_traits_deduce_member_difference(int) -> typename incrementable_traits<_Iter>::difference_type;
+// Otherwise, it names void.
+template <class _Iter>
+_CCCL_API auto __iterator_traits_deduce_member_difference(...) -> void;
+
+template <class _Iter>
+using __iterator_traits_difference_type = decltype(::cuda::std::__iterator_traits_deduce_member_difference<_Iter>(0));
+
+enum class __iterator_traits_selection
 {
-  using type = typename incrementable_traits<_Ip>::difference_type;
+  __specialized_from_std,
+  __specifies_members,
+  __cpp17_input_iterator,
+  __cpp17_iterator,
+  __no_members,
 };
 
-// [iterator.traits]/3.4
-// Otherwise, `iterator_traits<I>` has no members by any of the above names.
-template <class, class = void>
-struct __iterator_traits
-{};
+// We need to consider if a user has specialized std::iterator_traits
+template <class _Iter>
+_CCCL_CONCEPT __specialized_from_std = !__is_primary_std_template<remove_cvref_t<_Iter>>::value;
 
-#  if !_CCCL_COMPILER(NVRTC)
-template <class _Ip>
-struct __iterator_traits<_Ip, enable_if_t<__specialized_from_std<_Ip>>> : public ::std::iterator_traits<_Ip>
-{};
-#  endif // !_CCCL_COMPILER(NVRTC)
+// If I has valid member types difference_type, value_type, reference, and iterator_category,
+template <class _Iter>
+_CCCL_CONCEPT __specifies_members = _CCCL_REQUIRES_EXPR((_Iter))(
+  typename(typename _Iter::value_type),
+  typename(typename _Iter::difference_type),
+  typename(typename _Iter::reference),
+  typename(typename _Iter::iterator_category));
 
-// [iterator.traits]/3.1
-// If `I` has valid ([temp.deduct]) member types `difference-type`, `value-type`, `reference`, and
+// [iterator.traits]#3.2.3
+template <class _Iter>
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __iterator_traits_selection __select_iterator_traits_specialization() noexcept
+{
+  if constexpr (__specialized_from_std<_Iter>)
+  { // We need to consider if a user has specialized std::iterator_traits
+    return __iterator_traits_selection::__specialized_from_std;
+  }
+  if constexpr (__specifies_members<_Iter>)
+  { // If I has valid member types difference_type, value_type, reference, and iterator_category,
+    return __iterator_traits_selection::__specifies_members;
+  }
+  else if constexpr (__iterator_traits_detail::__cpp17_input_iterator<_Iter>)
+  { // Otherwise, if I satisfies the exposition-only concept cpp17-input-iterator,
+    return __iterator_traits_selection::__cpp17_input_iterator;
+  }
+  else if constexpr (__iterator_traits_detail::__cpp17_iterator<_Iter>)
+  { // Otherwise, if I satisfies the exposition-only concept cpp17-iterator,
+    return __iterator_traits_selection::__cpp17_iterator;
+  }
+  else
+  { // Otherwise, iterator_traits<I> has no members by any of the above names.
+    return __iterator_traits_selection::__no_members;
+  }
+}
+
+// [iterator.traits]#3
+template <class _Iter, __iterator_traits_selection = ::cuda::std::__select_iterator_traits_specialization<_Iter>()>
+struct __iterator_traits;
+
+#if !_CCCL_COMPILER(NVRTC)
+// We need to properly accept specializations of `std::iterator_traits`
+template <class _Iter>
+struct __iterator_traits<_Iter, __iterator_traits_selection::__specialized_from_std>
+    : public ::std::iterator_traits<_Iter>
+{};
+#endif // !_CCCL_COMPILER(NVRTC)
+
+// [iterator.traits]#3.1
+// If `I` has valid member types `difference-type`, `value-type`, `reference`, and
 // `iterator-category`, then `iterator-traits<I>` has the following publicly accessible members:
-template <class _Ip>
-struct __iterator_traits<_Ip, enable_if_t<__specifies_members<_Ip>>>
+template <class _Iter>
+struct __iterator_traits<_Iter, __iterator_traits_selection::__specifies_members>
 {
-  using iterator_category = typename _Ip::iterator_category;
-  using value_type        = typename _Ip::value_type;
-  using difference_type   = typename _Ip::difference_type;
-  using pointer           = typename __iterator_traits_member_pointer_or_void<_Ip>::type;
-  using reference         = typename _Ip::reference;
+  using iterator_category = typename _Iter::iterator_category;
+  using value_type        = typename _Iter::value_type;
+  using difference_type   = typename _Iter::difference_type;
+  using pointer           = __iterator_traits_member_pointer_or_void<_Iter>;
+  using reference         = typename _Iter::reference;
 };
 
-// [iterator.traits]/3.2
+// [iterator.traits]#3.2
 // Otherwise, if `I` satisfies the exposition-only concept `cpp17-input-iterator`,
 // `iterator-traits<I>` has the following publicly accessible members:
-template <class _Ip>
-struct __iterator_traits<_Ip, enable_if_t<!__specifies_members<_Ip> && __cpp17_input_iterator_missing_members<_Ip>>>
+template <class _Iter>
+struct __iterator_traits<_Iter, __iterator_traits_selection::__cpp17_input_iterator>
 {
-  using iterator_category = typename __iterator_traits_iterator_category<_Ip>::type;
-  using value_type        = typename indirectly_readable_traits<_Ip>::value_type;
-  using difference_type   = typename incrementable_traits<_Ip>::difference_type;
-  using pointer           = typename __iterator_traits_member_pointer_or_arrow_or_void<_Ip>::type;
-  using reference         = typename __iterator_traits_member_reference<_Ip>::type;
+  using iterator_category = __iterator_traits_iterator_category<_Iter>;
+  using value_type        = typename indirectly_readable_traits<_Iter>::value_type;
+  using difference_type   = typename incrementable_traits<_Iter>::difference_type;
+  using pointer           = __iterator_traits_member_pointer_or_arrow_or_void<_Iter>;
+  using reference         = __iterator_traits_member_reference<_Iter>;
 };
 
+// [iterator.traits]#3.3
 // Otherwise, if `I` satisfies the exposition-only concept `cpp17-iterator`, then
 // `iterator_traits<I>` has the following publicly accessible members:
-template <class _Ip>
-struct __iterator_traits<_Ip,
-                         enable_if_t<!__specifies_members<_Ip> && !__cpp17_input_iterator_missing_members<_Ip>
-                                     && __cpp17_iterator_missing_members<_Ip>>>
+template <class _Iter>
+struct __iterator_traits<_Iter, __iterator_traits_selection::__cpp17_iterator>
 {
   using iterator_category = output_iterator_tag;
   using value_type        = void;
-  using difference_type   = typename __iterator_traits_difference_type<_Ip>::type;
+  using difference_type   = __iterator_traits_difference_type<_Iter>;
   using pointer           = void;
   using reference         = void;
 };
 
-template <class _Ip, class>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits : __iterator_traits<_Ip>
+// [iterator.traits]#3.4
+// Otherwise, `iterator_traits<I>` has no members by any of the above names.
+template <class _Iter>
+struct __iterator_traits<_Iter, __iterator_traits_selection::__no_members>
+{};
+
+template <class _Iter, class>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits : __iterator_traits<_Iter>
 {
   using __cccl_primary_template = iterator_traits;
 };
 
-#endif // _CCCL_HAS_CONCEPTS()
-
+// [iterator.traits]#5
 template <class _Tp>
 #if _CCCL_HAS_CONCEPTS()
   requires is_object_v<_Tp>
@@ -775,7 +494,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits<_Tp*>
   using difference_type   = ptrdiff_t;
   using value_type        = remove_cv_t<_Tp>;
   using pointer           = _Tp*;
-  using reference         = typename add_lvalue_reference<_Tp>::type;
+  using reference         = add_lvalue_reference_t<_Tp>;
   using iterator_category = random_access_iterator_tag;
   using iterator_concept  = contiguous_iterator_tag;
 };

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -237,9 +237,9 @@ namespace __iterator_traits_detail
 template <class _Iter>
 _CCCL_CONCEPT __cpp17_iterator = _CCCL_REQUIRES_EXPR((_Iter), _Iter __i)(
   requires(copyable<_Iter>),
-  requires(__can_reference<decltype(*__i)>),
-  requires(same_as<decltype(++__i), _Iter&>),
-  requires(__can_reference<decltype(*__i++)>));
+  _Satisfies(__can_reference)(*__i),
+  _Same_as(_Iter&)(++__i),
+  _Satisfies(__can_reference)(*__i++));
 
 // [iterator.traits#concept:cpp17-input-iterator]
 template <class _Iter>
@@ -260,27 +260,27 @@ _CCCL_CONCEPT __cpp17_forward_iterator = _CCCL_REQUIRES_EXPR((_Iter), _Iter __i)
   requires(is_lvalue_reference_v<iter_reference_t<_Iter>>),
   requires(same_as<remove_cvref_t<iter_reference_t<_Iter>>, typename indirectly_readable_traits<_Iter>::value_type>),
   requires(convertible_to<decltype(__i++), _Iter const&>),
-  requires(same_as<decltype(*__i++), iter_reference_t<_Iter>>));
+  _Same_as(iter_reference_t<_Iter>)(*__i++));
 
 // [iterator.traits#concept:cpp17-bidirectional-iterator]
 template <class _Iter>
 _CCCL_CONCEPT __cpp17_bidirectional_iterator = _CCCL_REQUIRES_EXPR((_Iter), _Iter __i)(
   requires(__cpp17_forward_iterator<_Iter>),
-  requires(same_as<decltype(--__i), _Iter&>),
+  _Same_as(_Iter&)(--__i),
   requires(convertible_to<decltype(__i--), _Iter const&>),
-  requires(same_as<decltype(*__i--), iter_reference_t<_Iter>>));
+  _Same_as(iter_reference_t<_Iter>)(*__i--));
 
 // [iterator.traits#concept:cpp17-random-access-iterator]
 // Needs to be its own concept, because we need `typename incrementable_traits<_Iter>::difference_type` to be valid
 template <class _Iter>
 _CCCL_CONCEPT __cpp17_random_access_iterator_operations =
   _CCCL_REQUIRES_EXPR((_Iter), _Iter __i, typename incrementable_traits<_Iter>::difference_type __n)(
-    requires(same_as<_Iter&, decltype(__i += __n)>),
-    requires(same_as<_Iter&, decltype(__i -= __n)>),
-    requires(same_as<_Iter, decltype(__i + __n)>),
-    requires(same_as<_Iter, decltype(__n + __i)>),
-    requires(same_as<_Iter, decltype(__i - __n)>),
-    requires(same_as<decltype(__n), decltype(__i - __i)>),
+    _Same_as(_Iter&)(__i += __n),
+    _Same_as(_Iter&)(__i -= __n),
+    _Same_as(_Iter)(__i + __n),
+    _Same_as(_Iter)(__n + __i),
+    _Same_as(_Iter)(__i - __n),
+    _Same_as(decltype(__n))(__i - __i),
     requires(convertible_to<decltype(__i[__n]), iter_reference_t<_Iter>>));
 
 template <class _Iter>

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.primitives/iterator.traits/cxx20_iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.primitives/iterator.traits/cxx20_iterator_traits.compile.pass.cpp
@@ -179,6 +179,77 @@ static_assert(cuda::std::same_as<LegacyInputTraits::reference, LegacyInput::refe
 static_assert(cuda::std::same_as<LegacyInputTraits::pointer, void>);
 static_assert(!has_iterator_concept_v<LegacyInputTraits>);
 
+struct LegacyInputArrow
+{
+  struct iterator_category
+  {};
+  struct value_type
+  {};
+  struct reference
+  {
+    TEST_FUNC operator value_type() const;
+  };
+
+  TEST_FUNC friend bool operator==(LegacyInputArrow, LegacyInputArrow);
+#if TEST_STD_VER < 2020
+  TEST_FUNC friend bool operator!=(LegacyInputArrow, LegacyInputArrow);
+#endif
+  // Otherwise, if decltype(​declval<I&>().operator->()) is well-formed, then pointer names that type.
+  TEST_FUNC int* operator->();
+  TEST_FUNC reference operator*() const;
+  TEST_FUNC LegacyInputArrow& operator++();
+  TEST_FUNC LegacyInputArrow operator++(int);
+};
+template <>
+struct cuda::std::incrementable_traits<LegacyInputArrow>
+{
+  using difference_type = short;
+};
+using LegacyInputArrowTraits = cuda::std::iterator_traits<LegacyInputArrow>;
+static_assert(cuda::std::same_as<LegacyInputArrowTraits::iterator_category, LegacyInputArrow::iterator_category>);
+static_assert(cuda::std::same_as<LegacyInputArrowTraits::value_type, LegacyInputArrow::value_type>);
+static_assert(cuda::std::same_as<LegacyInputArrowTraits::difference_type, short>);
+static_assert(cuda::std::same_as<LegacyInputArrowTraits::reference, LegacyInputArrow::reference>);
+static_assert(cuda::std::same_as<LegacyInputArrowTraits::pointer, int*>);
+static_assert(!has_iterator_concept_v<LegacyInputArrowTraits>);
+
+struct LegacyInputPointer
+{
+  struct iterator_category
+  {};
+  struct value_type
+  {};
+  struct reference
+  {
+    TEST_FUNC operator value_type() const;
+  };
+  // If the qualified-id I​::​pointer is valid and denotes a type, then pointer names that type.
+  struct pointer
+  {};
+
+  TEST_FUNC friend bool operator==(LegacyInputPointer, LegacyInputPointer);
+#if TEST_STD_VER < 2020
+  TEST_FUNC friend bool operator!=(LegacyInputPointer, LegacyInputPointer);
+#endif
+  // Otherwise, if decltype(​declval<I&>().operator->()) is well-formed, then pointer names that type.
+  TEST_FUNC int* operator->();
+  TEST_FUNC reference operator*() const;
+  TEST_FUNC LegacyInputPointer& operator++();
+  TEST_FUNC LegacyInputPointer operator++(int);
+};
+template <>
+struct cuda::std::incrementable_traits<LegacyInputPointer>
+{
+  using difference_type = short;
+};
+using LegacyInputPointerTraits = cuda::std::iterator_traits<LegacyInputPointer>;
+static_assert(cuda::std::same_as<LegacyInputPointerTraits::iterator_category, LegacyInputPointer::iterator_category>);
+static_assert(cuda::std::same_as<LegacyInputPointerTraits::value_type, LegacyInputPointer::value_type>);
+static_assert(cuda::std::same_as<LegacyInputPointerTraits::difference_type, short>);
+static_assert(cuda::std::same_as<LegacyInputPointerTraits::reference, LegacyInputPointer::reference>);
+static_assert(cuda::std::same_as<LegacyInputPointerTraits::pointer, LegacyInputPointer::pointer>);
+static_assert(!has_iterator_concept_v<LegacyInputPointerTraits>);
+
 struct LegacyInputNoValueType
 {
   struct not_value_type

--- a/thrust/examples/stream_compaction.cu
+++ b/thrust/examples/stream_compaction.cu
@@ -21,7 +21,7 @@ struct is_odd
 template <typename Iterator>
 void print_range(const std::string& name, Iterator first, Iterator last)
 {
-  using T = typename std::iterator_traits<Iterator>::value_type;
+  using T = cuda::std::iter_value_t<Iterator>;
 
   std::cout << name << ": ";
   thrust::copy(first, last, std::ostream_iterator<T>(std::cout, " "));

--- a/thrust/examples/stream_compaction.cu
+++ b/thrust/examples/stream_compaction.cu
@@ -4,8 +4,9 @@
 #include <thrust/remove.h>
 #include <thrust/sequence.h>
 
+#include <cuda/std/iterator>
+
 #include <iostream>
-#include <iterator>
 #include <string>
 
 // this functor returns true if the argument is odd, and false otherwise

--- a/thrust/examples/summary_statistics.cu
+++ b/thrust/examples/summary_statistics.cu
@@ -121,7 +121,7 @@ struct summary_stats_binary_op
 template <typename Iterator>
 void print_range(const std::string& name, Iterator first, Iterator last)
 {
-  using T = typename std::iterator_traits<Iterator>::value_type;
+  using T = cuda::std::iter_value_t<Iterator>;
 
   std::cout << name << ": ";
   thrust::copy(first, last, std::ostream_iterator<T>(std::cout, " "));

--- a/thrust/examples/summary_statistics.cu
+++ b/thrust/examples/summary_statistics.cu
@@ -4,6 +4,8 @@
 #include <thrust/host_vector.h>
 #include <thrust/transform_reduce.h>
 
+#include <cuda/std/iterator>
+
 #include <cmath>
 #include <iostream>
 #include <limits>

--- a/thrust/examples/transform_iterator.cu
+++ b/thrust/examples/transform_iterator.cu
@@ -48,7 +48,7 @@ struct simple_negate
 template <typename Iterator>
 void print_range(const std::string& name, Iterator first, Iterator last)
 {
-  using T = typename std::iterator_traits<Iterator>::value_type;
+  using T = cuda::std::iter_value_t<Iterator>;
 
   std::cout << name << ": ";
   thrust::copy(first, last, std::ostream_iterator<T>(std::cout, " "));

--- a/thrust/examples/transform_iterator.cu
+++ b/thrust/examples/transform_iterator.cu
@@ -4,8 +4,9 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/reduce.h>
 
+#include <cuda/std/iterator>
+
 #include <iostream>
-#include <iterator>
 #include <string>
 
 // this functor clamps a value to the range [lo, hi]

--- a/thrust/thrust/advance.h
+++ b/thrust/thrust/advance.h
@@ -31,7 +31,7 @@ advance(InputIterator& i, Distance n)
 //! deprecated [since 3.1]
 template <typename InputIterator>
 CCCL_DEPRECATED_BECAUSE("Use ::cuda::std::next instead") _CCCL_API constexpr InputIterator
-next(InputIterator i, typename ::cuda::std::iterator_traits<InputIterator>::difference_type n = 1)
+next(InputIterator i, ::cuda::std::iter_difference_t<InputIterator> n = 1)
 {
   return ::cuda::std::next(i, n);
 }
@@ -39,7 +39,7 @@ next(InputIterator i, typename ::cuda::std::iterator_traits<InputIterator>::diff
 //! deprecated [since 3.1]
 template <typename InputIterator>
 CCCL_DEPRECATED_BECAUSE("Use ::cuda::std::prev instead") _CCCL_API constexpr InputIterator
-prev(InputIterator i, typename ::cuda::std::iterator_traits<InputIterator>::difference_type n = 1)
+prev(InputIterator i, ::cuda::std::iter_difference_t<InputIterator> n = 1)
 {
   return ::cuda::std::prev(i, n);
 }

--- a/thrust/thrust/detail/pointer.h
+++ b/thrust/thrust/detail/pointer.h
@@ -25,6 +25,7 @@
 #include <thrust/iterator/iterator_traversal_tags.h>
 
 #include <cuda/std/__host_stdlib/ostream>
+#include <cuda/std/__iterator/iterator_traits.h>
 #include <cuda/std/__memory/addressof.h>
 #include <cuda/std/__memory/pointer_traits.h>
 #include <cuda/std/__type_traits/enable_if.h>

--- a/thrust/thrust/distance.h
+++ b/thrust/thrust/distance.h
@@ -22,7 +22,7 @@ THRUST_NAMESPACE_BEGIN
 
 template <class InputIter>
 [[nodiscard]] CCCL_DEPRECATED_BECAUSE("Use cuda::std::distance instead")
-_CCCL_API constexpr typename ::cuda::std::iterator_traits<InputIter>::difference_type
+_CCCL_API constexpr ::cuda::std::iter_difference_t<InputIter>
 distance(InputIter first, InputIter last)
 {
   return ::cuda::std::distance(first, last);

--- a/thrust/thrust/iterator/iterator_traits.h
+++ b/thrust/thrust/iterator/iterator_traits.h
@@ -76,12 +76,8 @@ struct lazy_trait
 //! at compile-time. You can specialize cuda::std::iterator_traits for your own iterator types if needed.
 //! deprecated [Since 3.0]
 template <typename T>
-using iterator_traits CCCL_DEPRECATED_BECAUSE("Use cuda::std::iterator_traits instead") =
-// FIXME(bgruber): switching to ::cuda::std::iterator_traits<T> breaks some tests, e.g. cub.test.device_merge_sort.lid_1
-#if _CCCL_COMPILER(NVRTC)
-  ::cuda
-#endif // _CCCL_COMPILER(NVRTC)
-  ::std::iterator_traits<T>;
+using iterator_traits
+  CCCL_DEPRECATED_BECAUSE("Use cuda::std::iterator_traits instead") = ::cuda::std::iterator_traits<T>;
 
 _CCCL_SUPPRESS_DEPRECATED_PUSH
 

--- a/thrust/thrust/iterator/offset_iterator.h
+++ b/thrust/thrust/iterator/offset_iterator.h
@@ -80,7 +80,7 @@ THRUST_NAMESPACE_BEGIN
 //!
 //! In the above example, the offset is loaded from a device vector, transformed by a \p transform_iterator, and then
 //! applied to the underlying iterator, when the \p offset_iterator is accessed.
-template <typename Iterator, typename Offset = typename ::cuda::std::iterator_traits<Iterator>::difference_type>
+template <typename Iterator, typename Offset = ::cuda::std::iter_difference_t<Iterator>>
 class offset_iterator : public iterator_adaptor<offset_iterator<Iterator, Offset>, Iterator>
 {
   //! \cond

--- a/thrust/thrust/iterator/zip_iterator.h
+++ b/thrust/thrust/iterator/zip_iterator.h
@@ -343,7 +343,7 @@ THRUST_NAMESPACE_END
 // The reason is that libcu++ backported the C++20 range iterator machinery to C++17, but C++17 has slightly different
 // language rules, especially regarding `void`. We deemed to it too hard to work around the issues.
 #if _CCCL_STD_VER < 2020
-_CCCL_BEGIN_NAMESPACE_CUDA_STD
+_CCCL_BEGIN_NAMESPACE_STD
 template <typename IteratorTuple>
 struct iterator_traits<THRUST_NS_QUALIFIER::zip_iterator<IteratorTuple>>
 {
@@ -354,5 +354,5 @@ struct iterator_traits<THRUST_NS_QUALIFIER::zip_iterator<IteratorTuple>>
   using iterator_category = typename It::iterator_category;
   using difference_type   = typename It::difference_type;
 };
-_CCCL_END_NAMESPACE_CUDA_STD
+_CCCL_END_NAMESPACE_STD
 #endif // _CCCL_STD_VER < 2020

--- a/thrust/thrust/iterator/zip_iterator.h
+++ b/thrust/thrust/iterator/zip_iterator.h
@@ -338,21 +338,3 @@ inline _CCCL_HOST_DEVICE zip_iterator<::cuda::std::tuple<Iterators...>> make_zip
 //! \} // end iterators
 
 THRUST_NAMESPACE_END
-
-// libcu++ iterator traits fail for complex zip_iterators in C++17, see e.g.: https://godbolt.org/z/7jb4qG3bb
-// The reason is that libcu++ backported the C++20 range iterator machinery to C++17, but C++17 has slightly different
-// language rules, especially regarding `void`. We deemed to it too hard to work around the issues.
-#if _CCCL_STD_VER < 2020
-_CCCL_BEGIN_NAMESPACE_STD
-template <typename IteratorTuple>
-struct iterator_traits<THRUST_NS_QUALIFIER::zip_iterator<IteratorTuple>>
-{
-  using It                = THRUST_NS_QUALIFIER::zip_iterator<IteratorTuple>;
-  using value_type        = typename It::value_type;
-  using reference         = typename It::reference;
-  using pointer           = void;
-  using iterator_category = typename It::iterator_category;
-  using difference_type   = typename It::difference_type;
-};
-_CCCL_END_NAMESPACE_STD
-#endif // _CCCL_STD_VER < 2020


### PR DESCRIPTION
Our `iterator_traits` implementation has been a thorn in my side forever. It was completely split between a concepts and C++17 implementation which led to a ton of code duplication.

Even worse, it also led to a bug in the C++17 implementation, where we relied on C++20 concept subsumption.

This made it so that we could not use `cuda::std::iterator_traits` for thrust iterators.

Wih that fixed, we can now always use `cuda::std::iterator_traits` for thrust
