### PR TITLE
Improve diagnostics of Thrust's `temporary_allocator`

### DIFF
--- a/thrust/thrust/detail/allocator/temporary_allocator.h
+++ b/thrust/thrust/detail/allocator/temporary_allocator.h
@@ -27,8 +27,7 @@
 
 #include <nv/target>
 
-#include <exception>
-#include <iostream>
+#include <cstdio>
 
 #if _CCCL_CUDA_COMPILATION() && _CCCL_DEVICE_COMPILATION()
 #  include <thrust/system/cuda/detail/terminate.h>
@@ -101,7 +100,9 @@ public:
     _CCCL_CATCH (std::exception & e)
     {
       // if we have some context about the thrown exception, log it
-      std::cerr << "Exception thrown in thrust::detail::temporary_allocator::deallocate: " << e.what() << '\n';
+      NV_IF_TARGET(NV_IS_HOST, {
+        ::fprintf(stderr, "Exception thrown in thrust::detail::temporary_allocator::deallocate: %s\n", e.what());
+      })
       _CCCL_ASSERT(false, "Exception thrown in thrust::detail::temporary_allocator::deallocate");
 #if _CCCL_CUDA_COMPILATION()
       NV_IF_TARGET(NV_IS_HOST, cudaGetLastError();)

--- a/thrust/thrust/detail/allocator/temporary_allocator.h
+++ b/thrust/thrust/detail/allocator/temporary_allocator.h
@@ -27,6 +27,9 @@
 
 #include <nv/target>
 
+#include <exception>
+#include <iostream>
+
 #if _CCCL_CUDA_COMPILATION() && _CCCL_DEVICE_COMPILATION()
 #  include <thrust/system/cuda/detail/terminate.h>
 #endif // _CCCL_CUDA_COMPILATION() && _CCCL_DEVICE_COMPILATION()
@@ -91,13 +94,22 @@ public:
     {
       thrust::return_temporary_buffer(system(), p, n);
     }
+    // Swallow all exceptions to maintain noexcept contract per C++ allocator requirements.
+    // Deallocate must be noexcept to be safe in destructors and during exception unwinding.
+    // Clear CUDA error state and leak the memory rather than propagating exception.
+    // Memory is leaked, but this matches standard allocator behavior when deallocation fails.
+    _CCCL_CATCH (std::exception & e)
+    {
+      // if we have some context about the thrown exception, log it
+      std::cerr << "Exception thrown in thrust::detail::temporary_allocator::deallocate: " << e.what() << '\n';
+      _CCCL_ASSERT(false, "Exception thrown in thrust::detail::temporary_allocator::deallocate");
+#if _CCCL_CUDA_COMPILATION()
+      NV_IF_TARGET(NV_IS_HOST, cudaGetLastError();)
+#endif // _CCCL_CUDA_COMPILATION()
+    }
     _CCCL_CATCH_ALL
     {
-      _CCCL_ASSERT(false, "Exception thrown in deallocate");
-      // Swallow all exceptions to maintain noexcept contract per C++ allocator requirements.
-      // Deallocate must be noexcept to be safe in destructors and during exception unwinding.
-      // Clear CUDA error state and leak the memory rather than propagating exception.
-      // Memory is leaked, but this matches standard allocator behavior when deallocation fails.
+      _CCCL_ASSERT(false, "Exception thrown in thrust::detail::temporary_allocator::deallocate");
 #if _CCCL_CUDA_COMPILATION()
       NV_IF_TARGET(NV_IS_HOST, cudaGetLastError();)
 #endif // _CCCL_CUDA_COMPILATION()


### PR DESCRIPTION
I initially had a hard time debugging #8644 because `thrust::detail::temporary_allocator` would swallow the error message by CUDA. This PR tries to make such errors visible.