### PR TITLE
Add warpspeed_scan tunings for SM120

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -927,6 +927,40 @@ struct policy_selector
   {
     if (arch >= ::cuda::arch_id::sm_120)
     {
+      // tunings from cub/benchmarks/bench/scan/exclusive/sum.warpspeed.cu
+      if (operation_t == op_kind_t::plus && accum_is_primitive_or_trivially_copy_constructible)
+      {
+        switch (input_value_size)
+        {
+          case 1:
+            // wrps_2.lbi_6.ipt_104 ()  1.092963  0.999648  1.103642   1.2
+            return scan_warpspeed_policy{2, 6, 104 - 1};
+          case 2:
+            // wrps_2.lbi_2.ipt_112 ()  1.223837  1.013303  1.244702  1.566667
+            return scan_warpspeed_policy{2, 2, 112 - 1};
+          case 4:
+            if (input_type == type_t::float32)
+            {
+              // wrps_1.lbi_2.ipt_104 ()  1.105203  1.002890  1.128118   1.4
+              return scan_warpspeed_policy{1, 2, 104 - 1};
+            }
+            //  wrps_1.lbi_2.ipt_80 ()  1.101183  1.004120  1.124414   1.4
+            return scan_warpspeed_policy{1, 2, 80 - 1};
+          case 8:
+            if (input_type == type_t::float64)
+            {
+              // wrps_1.lbi_4.ipt_40 ()  1.100034  0.961905  1.122249  1.333333
+              return scan_warpspeed_policy{1, 4, 40 - 1};
+            }
+            // wrps_1.lbi_6.ipt_56 ()  1.163872  1.002935  1.188899  1.466667
+            return scan_warpspeed_policy{1, 6, 56 - 1};
+          case 16:
+            // wrps_1.lbi_6.ipt_56 ()  1.139563  1.006005  1.161235  1.333333
+            return scan_warpspeed_policy{1, 6, 56 - 1};
+          default:
+            break;
+        }
+      }
       return get_sm120_fallback_warpspeed_policy();
     }
     if (arch >= ::cuda::arch_id::sm_100)


### PR DESCRIPTION
initial results look no good and not on par with the DB scores

```bash
['build_main/base.json', 'build_sm120/sm120.json']
# base

## [0] NVIDIA RTX PRO 6000 Blackwell Workstation Edition

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I64      |      2^16      |   6.144 us |       0.00% |   6.144 us |       0.00% |    0.000 us |   0.00% |   ????   |
|   I8    |      I64      |      2^20      |   8.191 us |       0.05% |   8.192 us |       0.00% |    0.001 us |   0.01% |   SLOW   |
|   I8    |      I64      |      2^24      |  23.710 us |       4.27% |  24.707 us |       2.03% |    0.997 us |   4.21% |   SLOW   |
|   I8    |      I64      |      2^28      | 364.706 us |       0.77% | 368.215 us |       0.99% |    3.509 us |   0.96% |   SLOW   |
|   I8    |      I64      |      2^32      |   5.846 ms |       4.40% |   5.854 ms |       5.15% |    8.198 us |   0.14% |   SAME   |
|   I16   |      I64      |      2^16      |   6.671 us |      13.41% |   6.200 us |       5.51% |   -0.471 us |  -7.06% |   FAST   |
|   I16   |      I64      |      2^20      |   9.092 us |      11.18% |   8.218 us |       2.76% |   -0.874 us |  -9.61% |   FAST   |
|   I16   |      I64      |      2^24      |  42.969 us |       1.86% |  42.220 us |       2.43% |   -0.750 us |  -1.74% |   SAME   |
|   I16   |      I64      |      2^28      | 728.485 us |       0.35% | 725.810 us |       0.45% |   -2.675 us |  -0.37% |   FAST   |
|   I16   |      I64      |      2^32      |  11.781 ms |       2.56% |  11.742 ms |       2.58% |  -38.306 us |  -0.33% |   SAME   |
|   I32   |      I64      |      2^16      |   6.419 us |      10.83% |   6.144 us |       0.00% |   -0.275 us |  -4.28% |   ????   |
|   I32   |      I64      |      2^20      |  10.239 us |       0.14% |  10.239 us |       0.14% |   -0.000 us |  -0.00% |   SAME   |
|   I32   |      I64      |      2^24      |  89.639 us |       1.51% |  92.558 us |       2.48% |    2.919 us |   3.26% |   SLOW   |
|   I32   |      I64      |      2^28      |   1.461 ms |       0.35% |   1.448 ms |       0.37% |  -13.399 us |  -0.92% |   FAST   |
|   I32   |      I64      |      2^32      |  23.480 ms |       1.83% |  23.407 ms |       1.55% |  -73.786 us |  -0.31% |   SAME   |
|   I64   |      I64      |      2^16      |   8.192 us |       0.00% |   7.076 us |      14.38% |   -1.116 us | -13.62% |   FAST   |
|   I64   |      I64      |      2^20      |  14.759 us |      10.90% |  13.908 us |       5.99% |   -0.851 us |  -5.77% |   SAME   |
|   I64   |      I64      |      2^24      | 180.832 us |       0.79% | 184.231 us |       1.26% |    3.399 us |   1.88% |   SLOW   |
|   I64   |      I64      |      2^28      |   2.928 ms |       0.24% |   2.906 ms |       0.26% |  -21.401 us |  -0.73% |   FAST   |
|   I64   |      I64      |      2^32      |  46.828 ms |       0.04% |  46.776 ms |       0.08% |  -51.675 us |  -0.11% |   FAST   |
|  I128   |      I64      |      2^16      |   8.192 us |       0.00% |   8.322 us |       6.33% |    0.130 us |   1.58% |   SLOW   |
|  I128   |      I64      |      2^20      |  30.930 us |       2.10% |  32.025 us |       3.28% |    1.095 us |   3.54% |   SLOW   |
|  I128   |      I64      |      2^24      | 372.893 us |      10.35% | 364.951 us |       0.64% |   -7.941 us |  -2.13% |   FAST   |
|  I128   |      I64      |      2^28      |   5.814 ms |       0.17% |   5.797 ms |       0.21% |  -16.776 us |  -0.29% |   FAST   |
|   F32   |      I64      |      2^16      |   6.867 us |      14.18% |   6.204 us |       5.87% |   -0.663 us |  -9.66% |   FAST   |
|   F32   |      I64      |      2^20      |  10.387 us |       5.14% |  10.336 us |       4.02% |   -0.051 us |  -0.49% |   SAME   |
|   F32   |      I64      |      2^24      |  88.876 us |       6.50% | 106.578 us |      23.40% |   17.702 us |  19.92% |   SLOW   |
|   F32   |      I64      |      2^28      |   1.460 ms |       0.34% |   1.448 ms |       0.38% |  -12.236 us |  -0.84% |   FAST   |
|   F32   |      I64      |      2^32      |  23.489 ms |       1.52% |  23.412 ms |       1.49% |  -77.283 us |  -0.33% |   SAME   |
|   F64   |      I64      |      2^16      |  10.159 us |       4.09% |   8.739 us |      10.40% |   -1.419 us | -13.97% |   FAST   |
|   F64   |      I64      |      2^20      |  17.058 us |       5.66% |  20.479 us |       0.06% |    3.421 us |  20.05% |   SLOW   |
|   F64   |      I64      |      2^24      | 183.092 us |       0.79% | 196.800 us |       1.51% |   13.708 us |   7.49% |   SLOW   |
|   F64   |      I64      |      2^28      |   2.927 ms |       0.20% |   2.922 ms |       0.40% |   -4.847 us |  -0.17% |   SAME   |
|   F64   |      I64      |      2^32      |  46.819 ms |       0.04% |  46.301 ms |       0.18% | -518.879 us |  -1.11% |   FAST   |
|   C32   |      I64      |      2^16      |   7.588 us |      12.31% |   6.627 us |      13.17% |   -0.960 us | -12.66% |   FAST   |
|   C32   |      I64      |      2^20      |  14.970 us |       8.68% |  16.387 us |       2.75% |    1.417 us |   9.46% |   SLOW   |
|   C32   |      I64      |      2^24      | 182.094 us |       0.79% | 184.436 us |       1.23% |    2.342 us |   1.29% |   SLOW   |
|   C32   |      I64      |      2^28      |   2.929 ms |       0.22% |   2.908 ms |       0.31% |  -20.851 us |  -0.71% |   FAST   |
|   C32   |      I64      |      2^32      |  46.914 ms |       0.04% |  46.784 ms |       0.04% | -130.362 us |  -0.28% |   FAST   |
```

