### PR TITLE
[Tile] Disable tests that rely on `asm` statements

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/annotated_ptr/access_property.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/annotated_ptr/access_property.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "test_macros.h"
 #include "utils.h"
 

--- a/libcudacxx/test/libcudacxx/cuda/annotated_ptr/access_property_constexpr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/annotated_ptr/access_property_constexpr.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc
 
 // error: expression must have a constant value annotated_ptr.h: note #2701-D: attempt to access run-time storage

--- a/libcudacxx/test/libcudacxx/cuda/annotated_ptr/annotated_ptr.createpolicy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/annotated_ptr/annotated_ptr.createpolicy.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc
 // UNSUPPORTED: pre-sm-80
 

--- a/libcudacxx/test/libcudacxx/cuda/annotated_ptr/annotated_ptr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/annotated_ptr/annotated_ptr.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "utils.h"
 
 static_assert(sizeof(cuda::annotated_ptr<int, cuda::access_property::global>) == sizeof(uintptr_t),

--- a/libcudacxx/test/libcudacxx/cuda/annotated_ptr/annotated_ptr_bench.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/annotated_ptr/annotated_ptr_bench.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "test_macros.h"
 #include "utils.h"
 

--- a/libcudacxx/test/libcudacxx/cuda/annotated_ptr/annotated_ptr_constexpr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/annotated_ptr/annotated_ptr_constexpr.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc
 
 // error: expression must have a constant value annotated_ptr.h: note #2701-D: attempt to access run-time storage

--- a/libcudacxx/test/libcudacxx/cuda/annotated_ptr/annotated_ptr_constructors.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/annotated_ptr/annotated_ptr_constructors.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "utils.h"
 
 template <typename T, typename P>

--- a/libcudacxx/test/libcudacxx/cuda/annotated_ptr/annotated_ptr_shmem.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/annotated_ptr/annotated_ptr_shmem.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "test_macros.h"
 #include "utils.h"
 

--- a/libcudacxx/test/libcudacxx/cuda/annotated_ptr/apply_access_property.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/annotated_ptr/apply_access_property.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "utils.h"
 
 constexpr size_t array_size = 128;

--- a/libcudacxx/test/libcudacxx/cuda/annotated_ptr/associate_access_property.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/annotated_ptr/associate_access_property.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "utils.h"
 #define ARR_SZ 128
 

--- a/libcudacxx/test/libcudacxx/cuda/annotated_ptr/memcpy_async.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/annotated_ptr/memcpy_async.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: pre-sm-70
 
 #include <cooperative_groups.h>

--- a/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_fetch_half.fail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_fetch_half.fail.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 // UNSUPPORTED: nvcc-11, nvcc-12

--- a/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_fetch_max.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_fetch_max.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 //
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_fetch_min.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_fetch_min.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 //
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/cuda/atomics/atomic.local.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/atomics/atomic.local.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: windows && pre-sm-70
 
 #include <cuda/atomic>

--- a/libcudacxx/test/libcudacxx/cuda/atomics/atomic.uninitialized.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/atomics/atomic.uninitialized.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 //
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 // UNSUPPORTED: nvrtc

--- a/libcudacxx/test/libcudacxx/cuda/atomics/atomic_16b_host_constructible.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/atomics/atomic_16b_host_constructible.pass.cpp
@@ -8,6 +8,9 @@
 //
 // UNSUPPORTED: windows
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/atomic>
 
 #include <cuda/atomic>

--- a/libcudacxx/test/libcudacxx/cuda/atomics/atomic_16b_host_no_override.fail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/atomics/atomic_16b_host_no_override.fail.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
 // UNSUPPORTED: nvrtc
 
 // <cuda/atomic>

--- a/libcudacxx/test/libcudacxx/cuda/atomics/atomic_16b_ld_st.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/atomics/atomic_16b_ld_st.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: pre-sm-70
 // UNSUPPORTED: windows
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/atomic>
 
 #include <cuda/atomic>

--- a/libcudacxx/test/libcudacxx/cuda/atomics/atomic_ref_small.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/atomics/atomic_ref_small.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/cuda/atomics/bad_atomic_alignment.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/atomics/bad_atomic_alignment.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 //
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/cuda/barrier/arrive_tx_cluster.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/arrive_tx_cluster.runfail.cpp
@@ -13,6 +13,9 @@
 
 // UNSUPPORTED: no_execute
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/barrier>
 
 #include <cuda/barrier>

--- a/libcudacxx/test/libcudacxx/cuda/barrier/arrive_tx_cta.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/arrive_tx_cta.pass.cpp
@@ -11,6 +11,9 @@
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-90
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/barrier>
 
 #include "arrive_tx.h"

--- a/libcudacxx/test/libcudacxx/cuda/barrier/arrive_tx_device.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/arrive_tx_device.runfail.cpp
@@ -13,6 +13,9 @@
 
 // UNSUPPORTED: no_execute
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/barrier>
 
 #include <cuda/barrier>

--- a/libcudacxx/test/libcudacxx/cuda/barrier/arrive_tx_feature_test.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/arrive_tx_feature_test.pass.cpp
@@ -11,6 +11,9 @@
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-90
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/barrier>
 
 #include <cuda/barrier>

--- a/libcudacxx/test/libcudacxx/cuda/barrier/arrive_tx_thread.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/arrive_tx_thread.pass.cpp
@@ -11,6 +11,9 @@
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-90
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/barrier>
 
 #include "arrive_tx.h"

--- a/libcudacxx/test/libcudacxx/cuda/barrier/arrive_tx_warp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/arrive_tx_warp.pass.cpp
@@ -11,6 +11,9 @@
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-90
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/barrier>
 
 #include "arrive_tx.h"

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk.pass.cpp
@@ -12,6 +12,9 @@
 // UNSUPPORTED: pre-sm-90
 // ADDITIONAL_COMPILE_DEFINITIONS: CCCL_IGNORE_DEPRECATED_API
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/barrier>
 
 #include <cuda/barrier>

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_feature_test.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_feature_test.pass.cpp
@@ -11,6 +11,9 @@
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-90
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/barrier>
 
 #include <cuda/barrier>

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_ptx_compiles.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_ptx_compiles.pass.cpp
@@ -12,6 +12,9 @@
 // UNSUPPORTED: pre-sm-90
 // ADDITIONAL_COMPILE_DEFINITIONS: CCCL_IGNORE_DEPRECATED_API
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/barrier>
 
 #include <cuda/barrier>

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor.pass.cpp
@@ -15,6 +15,9 @@
 // UNSUPPORTED: nvrtc
 // NVRTC_SKIP_KERNEL_RUN // This will have effect once PR 433 is merged (line above should be removed.)
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/barrier>
 
 #include <cuda/barrier>

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_1d.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_1d.pass.cpp
@@ -17,6 +17,9 @@
 // XFAIL: clang && !nvcc
 // NVRTC_SKIP_KERNEL_RUN // This will have effect once PR 433 is merged (line above should be removed.)
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/barrier>
 
 #include <cuda/barrier>

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_2d.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_2d.pass.cpp
@@ -17,6 +17,9 @@
 // XFAIL: clang && !nvcc
 // NVRTC_SKIP_KERNEL_RUN // This will have effect once PR 433 is merged (line above should be removed.)
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/barrier>
 
 #include <cuda/barrier>

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_3d.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_3d.pass.cpp
@@ -17,6 +17,9 @@
 // XFAIL: clang && !nvcc
 // NVRTC_SKIP_KERNEL_RUN // This will have effect once PR 433 is merged (line above should be removed.)
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/barrier>
 
 #include <cuda/barrier>

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_4d.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_4d.pass.cpp
@@ -17,6 +17,9 @@
 // XFAIL: clang && !nvcc
 // NVRTC_SKIP_KERNEL_RUN // This will have effect once PR 433 is merged (line above should be removed.)
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/barrier>
 
 #include <cuda/barrier>

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_5d.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_5d.pass.cpp
@@ -17,6 +17,9 @@
 // XFAIL: clang && !nvcc
 // NVRTC_SKIP_KERNEL_RUN // This will have effect once PR 433 is merged (line above should be removed.)
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/barrier>
 
 #include <cuda/barrier>

--- a/libcudacxx/test/libcudacxx/cuda/barrier/expect_tx_cta.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/expect_tx_cta.pass.cpp
@@ -11,6 +11,9 @@
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-90
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/barrier>
 
 #include "arrive_tx.h"

--- a/libcudacxx/test/libcudacxx/cuda/barrier/expect_tx_device.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/expect_tx_device.runfail.cpp
@@ -11,6 +11,9 @@
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-90
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: no_execute
 
 // <cuda/barrier>

--- a/libcudacxx/test/libcudacxx/cuda/barrier/expect_tx_thread.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/expect_tx_thread.pass.cpp
@@ -11,6 +11,9 @@
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-90
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/barrier>
 
 #include "arrive_tx.h"

--- a/libcudacxx/test/libcudacxx/cuda/barrier/expect_tx_warp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/expect_tx_warp.pass.cpp
@@ -11,6 +11,9 @@
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-90
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/barrier>
 
 #include "arrive_tx.h"

--- a/libcudacxx/test/libcudacxx/cuda/barrier/init.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/init.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/barrier>
 
 #include "cuda_space_selector.h"

--- a/libcudacxx/test/libcudacxx/cuda/barrier/native_handle.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/native_handle.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-80
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/barrier>
 
 #include "cuda_space_selector.h"

--- a/libcudacxx/test/libcudacxx/cuda/memcpy_async/group_memcpy_async_16b.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memcpy_async/group_memcpy_async_16b.pass.cpp
@@ -8,6 +8,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 // UNSUPPORTED: pre-sm-70
 
 #include "group_memcpy_async.h"

--- a/libcudacxx/test/libcudacxx/cuda/memcpy_async/group_memcpy_async_32b.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memcpy_async/group_memcpy_async_32b.pass.cpp
@@ -8,6 +8,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 // UNSUPPORTED: pre-sm-70
 
 #include "group_memcpy_async.h"

--- a/libcudacxx/test/libcudacxx/cuda/memcpy_async/group_memcpy_async_64b.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memcpy_async/group_memcpy_async_64b.pass.cpp
@@ -8,6 +8,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 // UNSUPPORTED: pre-sm-70
 
 #include "group_memcpy_async.h"

--- a/libcudacxx/test/libcudacxx/cuda/memcpy_async/memcpy_async_16.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memcpy_async/memcpy_async_16.pass.cpp
@@ -8,6 +8,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 // UNSUPPORTED: pre-sm-70
 
 #include "memcpy_async.h"

--- a/libcudacxx/test/libcudacxx/cuda/memcpy_async/memcpy_async_32.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memcpy_async/memcpy_async_32.pass.cpp
@@ -8,6 +8,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 // UNSUPPORTED: pre-sm-70
 
 // clang-cuda < 20 errors out with "fatal error: error in backend: Cannot cast between two non-generic address spaces"

--- a/libcudacxx/test/libcudacxx/cuda/memcpy_async/memcpy_async_64.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memcpy_async/memcpy_async_64.pass.cpp
@@ -8,6 +8,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 // UNSUPPORTED: pre-sm-70
 
 // clang-cuda < 20 errors out with "fatal error: error in backend: Cannot cast between two non-generic address spaces"

--- a/libcudacxx/test/libcudacxx/cuda/memcpy_async/memcpy_async_8.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memcpy_async/memcpy_async_8.pass.cpp
@@ -8,6 +8,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 // UNSUPPORTED: pre-sm-70
 
 #include "memcpy_async.h"

--- a/libcudacxx/test/libcudacxx/cuda/memcpy_async/memcpy_async_block.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memcpy_async/memcpy_async_block.pass.cpp
@@ -8,6 +8,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 // UNSUPPORTED: pre-sm-70
 
 // clang-cuda < 20 errors out with "fatal error: error in backend: Cannot cast between two non-generic address spaces"

--- a/libcudacxx/test/libcudacxx/cuda/memcpy_async/memcpy_async_large.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memcpy_async/memcpy_async_large.pass.cpp
@@ -8,6 +8,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 // UNSUPPORTED: pre-sm-70
 
 #include "memcpy_async.h"

--- a/libcudacxx/test/libcudacxx/cuda/memcpy_async/memcpy_async_tx.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memcpy_async/memcpy_async_tx.pass.cpp
@@ -7,7 +7,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-90
 

--- a/libcudacxx/test/libcudacxx/cuda/memcpy_async/preconditions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memcpy_async/preconditions.pass.cpp
@@ -10,6 +10,10 @@
 
 #define _LIBCUDACXX_MEMCPY_ASYNC_PRE_TESTING
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 #include <cuda/__memcpy_async/check_preconditions.h>
 #include <cuda/std/cstddef>
 

--- a/libcudacxx/test/libcudacxx/cuda/memory/address_space.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/address_space.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/memory>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/cuda/memory/align_down.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/align_down.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/memory>
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>

--- a/libcudacxx/test/libcudacxx/cuda/memory/align_down.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/align_down.runfail.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/memory>
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>

--- a/libcudacxx/test/libcudacxx/cuda/memory/align_up.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/align_up.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/memory>
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>

--- a/libcudacxx/test/libcudacxx/cuda/memory/align_up.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/align_up.runfail.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/memory>
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>

--- a/libcudacxx/test/libcudacxx/cuda/memory/aligned_size_t.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/aligned_size_t.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/cuda/memory/check_address.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/check_address.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/memory>
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>

--- a/libcudacxx/test/libcudacxx/cuda/memory/discard_memory.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/discard_memory.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/memory>
 #include <cuda/std/cassert>
 #include <cuda/std/cstddef>

--- a/libcudacxx/test/libcudacxx/cuda/memory/get_device_address.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/get_device_address.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/memory>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/cuda/memory/is_aligned.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/is_aligned.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/memory>
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>

--- a/libcudacxx/test/libcudacxx/cuda/memory/is_pointer_accessible.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/is_pointer_accessible.pass.cpp
@@ -6,6 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/__runtime/ensure_current_context.h>

--- a/libcudacxx/test/libcudacxx/cuda/memory/is_valid_alignment.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/is_valid_alignment.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/memory>
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>

--- a/libcudacxx/test/libcudacxx/cuda/memory/ptr_alignment.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/ptr_alignment.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/memory>
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>

--- a/libcudacxx/test/libcudacxx/cuda/memory/ptr_in_range.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/ptr_in_range.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/memory>
 #include <cuda/std/cassert>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/cuda/memory/ptr_rebind.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/ptr_rebind.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/memory>
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>

--- a/libcudacxx/test/libcudacxx/cuda/memory/ranges_overlap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/ranges_overlap.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/iterator>
 #include <cuda/memory>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_arrive_on.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_arrive_on.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // Remove after bump to version 4
 #include <cuda/barrier>
 

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_divergent_threads.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_divergent_threads.pass.cpp
@@ -11,6 +11,9 @@
 // UNSUPPORTED: pre-sm-70
 // UNSUPPORTED: nvrtc
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/pipeline>
 #include <cuda/std/type_traits>
 

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_group_concept_thread_scope_block.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_group_concept_thread_scope_block.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "pipeline_group_concept.h"
 
 int main(int argc, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_group_concept_thread_scope_device.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_group_concept_thread_scope_device.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "pipeline_group_concept.h"
 
 int main(int argc, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_group_concept_thread_scope_system.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_group_concept_thread_scope_system.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "pipeline_group_concept.h"
 
 int main(int argc, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_producer_consumer.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_producer_consumer.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/pipeline>
 
 #include <cooperative_groups.h>

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_block_16.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_block_16.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "pipeline_memcpy_async_thread_scope_generic.h"
 
 int main(int argc, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_block_32.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_block_32.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // clang-cuda < 20 errors out with "fatal error: error in backend: Cannot cast between two non-generic address spaces"
 // XFAIL: clang-14 && !nvcc
 // XFAIL: clang-15 && !nvcc

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_block_64.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_block_64.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // clang-cuda < 20 errors out with "fatal error: error in backend: Cannot cast between two non-generic address spaces"
 // XFAIL: clang-14 && !nvcc
 // XFAIL: clang-15 && !nvcc

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_block_8.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_block_8.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "pipeline_memcpy_async_thread_scope_generic.h"
 
 int main(int argc, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_block_large_type.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_block_large_type.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "pipeline_memcpy_async_thread_scope_generic.h"
 
 int main(int argc, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_device_16.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_device_16.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "pipeline_memcpy_async_thread_scope_generic.h"
 
 int main(int argc, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_device_32.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_device_32.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // clang-cuda < 20 errors out with "fatal error: error in backend: Cannot cast between two non-generic address spaces"
 // XFAIL: clang-14 && !nvcc
 // XFAIL: clang-15 && !nvcc

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_device_64.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_device_64.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // clang-cuda < 20 errors out with "fatal error: error in backend: Cannot cast between two non-generic address spaces"
 // XFAIL: clang-14 && !nvcc
 // XFAIL: clang-15 && !nvcc

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_device_8.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_device_8.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "pipeline_memcpy_async_thread_scope_generic.h"
 
 int main(int argc, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_device_large_type.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_device_large_type.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "pipeline_memcpy_async_thread_scope_generic.h"
 
 int main(int argc, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_system_16.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_system_16.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "pipeline_memcpy_async_thread_scope_generic.h"
 
 int main(int argc, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_system_32.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_system_32.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // clang-cuda < 20 errors out with "fatal error: error in backend: Cannot cast between two non-generic address spaces"
 // XFAIL: clang-14 && !nvcc
 // XFAIL: clang-15 && !nvcc

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_system_64.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_system_64.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // clang-cuda < 20 errors out with "fatal error: error in backend: Cannot cast between two non-generic address spaces"
 // XFAIL: clang-14 && !nvcc
 // XFAIL: clang-15 && !nvcc

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_system_8.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_system_8.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "pipeline_memcpy_async_thread_scope_generic.h"
 
 int main(int argc, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_system_large_type.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_system_large_type.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "pipeline_memcpy_async_thread_scope_generic.h"
 
 int main(int argc, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_thread_16.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_thread_16.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "pipeline_memcpy_async_thread_scope_thread.h"
 
 int main(int argc, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_thread_32.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_thread_32.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // clang-cuda < 20 errors out with "fatal error: error in backend: Cannot cast between two non-generic address spaces"
 // XFAIL: clang-14 && !nvcc
 // XFAIL: clang-15 && !nvcc

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_thread_8.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_thread_8.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "pipeline_memcpy_async_thread_scope_thread.h"
 
 int main(int argc, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_thread_large_type.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_thread_scope_thread_large_type.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include "pipeline_memcpy_async_thread_scope_thread.h"
 
 int main(int argc, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.barrier.cluster.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.barrier.cluster.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.bfind.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.bfind.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.bmsk.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.bmsk.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.clusterlaunchcontrol.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.clusterlaunchcontrol.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.bulk.commit_group.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.bulk.commit_group.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.bulk.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.bulk.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.bulk.multicast.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.bulk.multicast.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.bulk.tensor.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.bulk.tensor.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.bulk.tensor.multicast.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.bulk.tensor.multicast.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.bulk.wait_group.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.bulk.wait_group.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.mbarrier.arrive.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.async.mbarrier.arrive.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.reduce.async.bulk.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.reduce.async.bulk.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.reduce.async.bulk.tensor.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.reduce.async.bulk.tensor.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.elect.sync.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.elect.sync.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.exit.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.exit.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.fence.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.fence.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.get_sreg.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.get_sreg.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: clang && !nvcc
 

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.getctarank.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.getctarank.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.ld.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.ld.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier.arrive.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier.arrive.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier.expect_tx.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier.expect_tx.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier.init.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier.init.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier.wait.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier.wait.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier_inval.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mbarrier_inval.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.multimem.ld_reduce.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.multimem.ld_reduce.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.multimem.red.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.multimem.red.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.multimem.st.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.multimem.st.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.prmt.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.prmt.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.red.async.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.red.async.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.setmaxnreg.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.setmaxnreg.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.shfl.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.shfl.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: clang && !nvcc
 

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.shl.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.shl.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.shr.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.shr.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.st.async.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.st.async.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.st.bulk.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.st.bulk.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.st.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.st.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.alloc.cta_group_1.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.alloc.cta_group_1.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.alloc.cta_group_2.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.alloc.cta_group_2.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.commit.cta_group_1.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.commit.cta_group_1.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.commit.cta_group_2.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.commit.cta_group_2.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.cp.cta_group_1.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.cp.cta_group_1.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.cp.cta_group_2.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.cp.cta_group_2.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.fence.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.fence.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.ld.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.ld.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.mma.cta_group_1.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.mma.cta_group_1.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.mma.cta_group_2.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.mma.cta_group_2.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.mma.ws.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.mma.ws.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.shift.cta_group_1.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.shift.cta_group_1.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.shift.cta_group_2.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.shift.cta_group_2.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.st.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.st.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.wait.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tcgen05.wait.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tensormap.cp_fenceproxy.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tensormap.cp_fenceproxy.compile.pass.cpp
@@ -7,6 +7,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tensormap.replace.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.tensormap.replace.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.trap.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.trap.compile.pass.cpp
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
 // UNSUPPORTED: libcpp-has-no-threads
 
 // <cuda/ptx>

--- a/libcudacxx/test/libcudacxx/cuda/stream_ref/get_stream.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/stream_ref/get_stream.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc
 
 #include <cuda/__functional/call_or.h>

--- a/libcudacxx/test/libcudacxx/cuda/warp/lane_mask.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/warp/lane_mask.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>
 #include <cuda/std/limits>

--- a/libcudacxx/test/libcudacxx/cuda/warp/warp_match.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/warp/warp_match.pass.cpp
@@ -8,6 +8,9 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: pre-sm-70
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/std/array>
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>

--- a/libcudacxx/test/libcudacxx/cuda/warp/warp_shuffle.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/warp/warp_shuffle.pass.cpp
@@ -6,6 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/std/array>
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>

--- a/libcudacxx/test/libcudacxx/cuda/work_stealing/for_each_canceled/for_each_canceled.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/work_stealing/for_each_canceled/for_each_canceled.pass.cpp
@@ -10,6 +10,9 @@
 
 // UNSUPPORTED: nvrtc
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // ADDITIONAL_COMPILE_DEFINITIONS: CCCL_IGNORE_DEPRECATED_API
 
 #include <cuda/std/cmath>

--- a/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_cuda_float.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_cuda_float.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_cuda_generic.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_cuda_generic.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_cuda_signed.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_cuda_signed.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_cuda_unsigned.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_cuda_unsigned.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_std_float.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_std_float.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_std_generic.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_std_generic.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_std_signed.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_std_signed.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_std_unsigned.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_std_unsigned.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/heterogeneous/atomic/flag.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/atomic/flag.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/heterogeneous/atomic/reference_cuda.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/atomic/reference_cuda.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/heterogeneous/atomic/reference_std.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/atomic/reference_std.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/heterogeneous/barrier.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/barrier.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc, pre-sm-70
 // UNSUPPORTED: clang && (!nvcc)
 

--- a/libcudacxx/test/libcudacxx/heterogeneous/latch.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/latch.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc, pre-sm-70
 
 // uncomment for a really verbose output detailing what test steps are being launched

--- a/libcudacxx/test/libcudacxx/heterogeneous/semaphore.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/semaphore.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc, pre-sm-70
 
 // uncomment for a really verbose output detailing what test steps are being launched

--- a/libcudacxx/test/libcudacxx/libcxx/atomics/atomics.flag/init_bool.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/atomics/atomics.flag/init_bool.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/libcxx/atomics/atomics.order/memory_order.underlying_type.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/atomics/atomics.order/memory_order.underlying_type.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/libcxx/atomics/version.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/atomics/version.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.fences/atomic_signal_fence.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.fences/atomic_signal_fence.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.fences/atomic_thread_fence.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.fences/atomic_thread_fence.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.flag/atomic_flag_clear.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.flag/atomic_flag_clear.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.flag/atomic_flag_clear_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.flag/atomic_flag_clear_explicit.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.flag/atomic_flag_test_and_set.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.flag/atomic_flag_test_and_set.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.flag/atomic_flag_test_and_set_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.flag/atomic_flag_test_and_set_explicit.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.flag/atomic_flag_wait.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.flag/atomic_flag_wait.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.flag/clear.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.flag/clear.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.flag/default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.flag/default.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.flag/init.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.flag/init.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 // XFAIL: c++98, c++03

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.flag/test_and_set.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.flag/test_and_set.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.general/replace_failure_order.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.general/replace_failure_order.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.lockfree/isalwayslockfree.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.lockfree/isalwayslockfree.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, c++98, c++03, c++11, c++14, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.lockfree/lockfree.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.lockfree/lockfree.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.order/kill_dependency.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.order/kill_dependency.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.order/memory_order.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.order/memory_order.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.order/memory_order_new.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.order/memory_order_new.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 // UNSUPPORTED: c++17

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/address.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/address.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 //  ... test case crashes clang.

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/address_ref.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/address_ref.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 //  ... test case crashes clang.

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/address_ref_constness.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/address_ref_constness.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 //  ... test case crashes clang.

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/atomic_copyable.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/atomic_copyable.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/bool.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/bool.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/cstdint_typedefs.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/cstdint_typedefs.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/enum_class.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/enum_class.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/floating_point.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/floating_point.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/floating_point_ref.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/floating_point_ref.pass.cpp
@@ -6,7 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-//
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/floating_point_ref_constness.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/floating_point_ref_constness.pass.cpp
@@ -6,7 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-//
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/1b_integral_cuda.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/1b_integral_cuda.pass.cpp
@@ -6,7 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/1b_integral_std.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/1b_integral_std.pass.cpp
@@ -6,7 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/2b_integral_cuda.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/2b_integral_cuda.pass.cpp
@@ -6,7 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/2b_integral_std.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/2b_integral_std.pass.cpp
@@ -6,7 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/4b_integral_cuda.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/4b_integral_cuda.pass.cpp
@@ -6,7 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/4b_integral_std.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/4b_integral_std.pass.cpp
@@ -6,7 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/8b_integral_cuda.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/8b_integral_cuda.pass.cpp
@@ -6,7 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/8b_integral_std.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/8b_integral_std.pass.cpp
@@ -6,7 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/integral_ref.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/integral_ref.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/integral_ref_constness.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/integral_ref_constness.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral_typedefs.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral_typedefs.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/non_arithmetic.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/non_arithmetic.fail.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/non_trivial.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/non_trivial.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/trivially_copyable.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/trivially_copyable.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_compare_exchange_strong.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_compare_exchange_strong.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 //  ... assertion fails line 34

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_compare_exchange_strong_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_compare_exchange_strong_explicit.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 //  ... assertion fails line 38

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_compare_exchange_weak.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_compare_exchange_weak.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 //  ... assertion fails line 34

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_compare_exchange_weak_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_compare_exchange_weak_explicit.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 //  ... assertion fails line 38

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_exchange.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_exchange.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 //  ... fails assertion line 31

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_exchange_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_exchange_explicit.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 //  ... assertion fails line 32

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 //  ... test crashes clang

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add_explicit.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 //  ... test crashes clang

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_and.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_and.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_and_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_and_explicit.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_or.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_or.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_or_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_or_explicit.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 //  ... test crashes clang

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub_explicit.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 //  ... test crashes clang

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_xor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_xor.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_xor_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_xor_explicit.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_init.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_init.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 //  ... assertion fails line 36

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_is_lock_free.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_is_lock_free.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_load.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_load.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 //  ... assertion fails line 35

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_load_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_load_explicit.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 //  ... assertion fails line 31

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_store.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_store.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_store_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_store_explicit.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_var_init.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_var_init.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 // XFAIL: c++98, c++03

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/ctor.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.wait/atomic_ref_member_wait.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.wait/atomic_ref_member_wait.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.wait/atomic_wait.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.wait/atomic_wait.pass.cpp
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/execution/exec.env/env.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/execution/exec.env/env.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/std/execution>
 
 // all other includes follow after <cuda/std/execution>

--- a/libcudacxx/test/libcudacxx/std/execution/exec.get.env/get.env.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/execution/exec.get.env/get.env.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/std/execution>
 
 // all other includes follow after <cuda/std/execution>

--- a/libcudacxx/test/libcudacxx/std/execution/exec.prop/prop.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/execution/exec.prop/prop.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/std/execution>
 
 // all other includes follow after <cuda/std/execution>

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bit.endian/endian.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bit.endian/endian.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // enum class endian;
 // <cuda/std/bit>
 

--- a/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/array_func/memcpy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/array_func/memcpy.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // void* memcpy(void* dst, const void* src, size_t count);
 
 #include <cuda/atomic>

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/arrive.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/arrive.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/arrive_and_drop.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/arrive_and_drop.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/arrive_and_wait.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/arrive_and_wait.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/completion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/completion.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 // XFAIL: msvc-19.36 && c++20

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/max.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/max.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/try_wait_for.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/try_wait_for.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-80
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/try_wait_parity_for.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/try_wait_parity_for.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-80
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/try_wait_parity_until.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/try_wait_parity_until.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-80
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/try_wait_until.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/try_wait_until.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-80
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/version.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/version.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.latch/arrive_and_wait.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.latch/arrive_and_wait.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.latch/count_down.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.latch/count_down.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.latch/max.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.latch/max.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.latch/try_wait.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.latch/try_wait.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.latch/version.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.latch/version.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/acquire.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/acquire.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/max.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/max.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/release.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/release.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/timed.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/timed.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/try_acquire.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/try_acquire.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/version.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/version.pass.cpp
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
+
+// XFAIL: enable-tile
+// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/time/ctime/ctime.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/time/ctime/ctime.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/std/cassert>
 #include <cuda/std/ctime>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/ptr.align/align.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/ptr.align/align.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // #include <memory>
 
 // void* align(size_t alignment, size_t size, void*& ptr, size_t& space);

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.hires/now.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.hires/now.pass.cpp
@@ -12,6 +12,9 @@
 
 // static time_point now();
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/std/cassert>
 #include <cuda/std/chrono>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/from_time_t.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/from_time_t.pass.cpp
@@ -12,6 +12,9 @@
 
 // static time_point from_time_t(time_t t);
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/std/chrono>
 #include <cuda/std/ctime>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/now.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/now.pass.cpp
@@ -12,6 +12,9 @@
 
 // static time_point now();
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/std/cassert>
 #include <cuda/std/chrono>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/to_time_t.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/to_time_t.pass.cpp
@@ -12,6 +12,9 @@
 
 // time_t to_time_t(const time_point& t);
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 #include <cuda/std/chrono>
 #include <cuda/std/ctime>
 


### PR DESCRIPTION
In tile mode using direct `asm` statements is not supported.

There are some low hanging fruits like `discard_memory` which is used frequently. But in general I have just blanket marked those tests as UNSUPPORTED.

I kept the atomics tests as XFAIL so that we can see when they work again
