### PR TITLE
[Tile] Disable tests that rely on indirect calls in tile mode

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/launch/extended_lambda.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/launch/extended_lambda.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: indirect call is unsupported in tile code
+
 // ADDITIONAL_COMPILE_FLAGS: --extended-lambda
 // UNSUPPORTED: nvrtc
 

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.primitives/iterator.operations/next.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.primitives/iterator.operations/next.pass.cpp
@@ -23,11 +23,13 @@
 template <class It>
 TEST_FUNC constexpr void check_next_n(It it, typename cuda::std::iterator_traits<It>::difference_type n, It result)
 {
+#if !_CCCL_TILE_COMPILATION() // error: indirect call is unsupported in tile code
   static_assert(cuda::std::is_same<decltype(cuda::std::next(it, n)), It>::value);
   assert(cuda::std::next(it, n) == result);
 
   It (*next_ptr)(It, typename cuda::std::iterator_traits<It>::difference_type) = cuda::std::next;
   assert(next_ptr(it, n) == result);
+#endif // !_CCCL_TILE_COMPILATION()
 }
 
 template <class It>

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.primitives/iterator.operations/prev.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.primitives/iterator.operations/prev.pass.cpp
@@ -21,11 +21,13 @@
 template <class It>
 TEST_FUNC constexpr void check_prev_n(It it, typename cuda::std::iterator_traits<It>::difference_type n, It result)
 {
+#if !_CCCL_TILE_COMPILATION() // error: indirect call is unsupported in tile code
   static_assert(cuda::std::is_same<decltype(cuda::std::prev(it, n)), It>::value);
   assert(cuda::std::prev(it, n) == result);
 
   It (*prev_ptr)(It, typename cuda::std::iterator_traits<It>::difference_type) = cuda::std::prev;
   assert(prev_ptr(it, n) == result);
+#endif // !_CCCL_TILE_COMPILATION()
 }
 
 template <class It>

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_of_pointer_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_of_pointer_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: indirect call is unsupported in tile code
+
 // <cuda/std/string_view>
 
 // constexpr size_type find_first_of(const charT* s, size_type pos = 0) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_of_pointer_size_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_of_pointer_size_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: indirect call is unsupported in tile code
+
 // <cuda/std/string_view>
 
 // constexpr size_type find_first_of(const charT* s, size_type pos, size_type n) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_of_string_view_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_of_string_view_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: indirect call is unsupported in tile code
+
 // <cuda/std/string_view>
 
 // size_type find_first_of(const basic_string_view& str, size_type pos = 0) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/rfind_pointer_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/rfind_pointer_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: indirect call is unsupported in tile code
+
 // <cuda/std/string_view>
 
 // constexpr size_type rfind(const charT* s, size_type pos = npos) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/rfind_pointer_size_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/rfind_pointer_size_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: indirect call is unsupported in tile code
+
 // <cuda/std/string_view>
 
 // constexpr size_type rfind(const charT* s, size_type pos, size_type n) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/rfind_string_view_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/rfind_string_view_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: indirect call is unsupported in tile code
+
 // <cuda/std/string_view>
 
 // constexpr size_type rfind(basic_string_view s, size_type pos = npos) const noexcept;


### PR DESCRIPTION
Indirect calls are not supported in tile mode. We should investigate whether we can replace occurences by using classical types with call operators
