### PR TITLE
[Tile] Disable tests that rely on a return statements inside loops

### DIFF
--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants/denorm_min.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants/denorm_min.pass.cpp
@@ -6,7 +6,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
-//===----------------------------------------------------------------------===//
 
 // ADDITIONAL_COMPILE_OPTIONS_HOST: -fext-numeric-literals
 // ADDITIONAL_COMPILE_DEFINITIONS: CCCL_GCC_HAS_EXTENDED_NUMERIC_LITERALS


### PR DESCRIPTION
We have a lot of tests that use an conditional return inside a loop. That is currently not supported.

Mark those tests as XFAIL so that we know when it works again
