### PR TITLE
[Tile] Avoid using `asm` optimizations for saturating arithmetics in tile mode

### DIFF
--- a/libcudacxx/include/cuda/__bit/bitmask.h
+++ b/libcudacxx/include/cuda/__bit/bitmask.h
@@ -37,6 +37,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 template <typename _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp __shl(const _Tp __value, int __shift) noexcept
 {
+#if !_CCCL_TILE_COMPILATION() // error: asm statement is unsupported in tile code
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     if constexpr (sizeof(_Tp) <= sizeof(uint64_t))
@@ -46,12 +47,14 @@ template <typename _Tp>
                           return ::cuda::ptx::shl(static_cast<_Up>(__value), __shift);))
     }
   }
+#endif // !_CCCL_TILE_COMPILATION()
   return (__shift >= ::cuda::std::numeric_limits<_Tp>::digits) ? _Tp{0} : __value << __shift;
 }
 
 template <typename _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp __shr(const _Tp __value, int __shift) noexcept
 {
+#if !_CCCL_TILE_COMPILATION() // error: asm statement is unsupported in tile code
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     if constexpr (sizeof(_Tp) <= sizeof(uint64_t))
@@ -61,6 +64,7 @@ template <typename _Tp>
                           return ::cuda::ptx::shr(static_cast<_Up>(__value), __shift);))
     }
   }
+#endif // !_CCCL_TILE_COMPILATION()
   return (__shift >= ::cuda::std::numeric_limits<_Tp>::digits) ? _Tp{0} : __value >> __shift;
 }
 
@@ -72,6 +76,7 @@ template <typename _Tp = uint32_t>
   _CCCL_ASSERT(__width >= 0 && __width <= __digits, "width out of range");
   _CCCL_ASSERT(__start >= 0 && __start <= __digits, "start position out of range");
   _CCCL_ASSERT(__start + __width <= __digits, "start position + width out of range");
+#if !_CCCL_TILE_COMPILATION() // error: asm statement is unsupported in tile code
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     if constexpr (sizeof(_Tp) <= sizeof(uint32_t))
@@ -79,6 +84,7 @@ template <typename _Tp = uint32_t>
       NV_IF_TARGET(NV_PROVIDES_SM_70, (return ::cuda::ptx::bmsk_clamp(__start, __width);))
     }
   }
+#endif // !_CCCL_TILE_COMPILATION()
   return ::cuda::__shl(static_cast<_Tp>(::cuda::__shl(_Tp{1}, __width) - 1), __start);
 }
 

--- a/libcudacxx/include/cuda/__launch/configuration.h
+++ b/libcudacxx/include/cuda/__launch/configuration.h
@@ -270,10 +270,12 @@ public:
   {
     if constexpr (::cuda::std::is_unbounded_array_v<_Tp>)
     {
+#  if !_CCCL_TILE_COMPILATION() // error: asm statement is unsupported in tile code
       _CCCL_IF_NOT_CONSTEVAL_DEFAULT
       {
         NV_IF_TARGET(NV_IS_DEVICE, (return ::cuda::ptx::get_sreg_dynamic_smem_size();))
       }
+#  endif // !_CCCL_TILE_COMPILATION()
       return __base_type::__n_ * sizeof(value_type);
     }
     else

--- a/libcudacxx/include/cuda/__numeric/add_overflow.h
+++ b/libcudacxx/include/cuda/__numeric/add_overflow.h
@@ -227,12 +227,14 @@ template <class _Tp>
 template <typename _Tp>
 [[nodiscard]] _CCCL_API constexpr overflow_result<_Tp> __add_overflow_uniform_type(_Tp __lhs, _Tp __rhs) noexcept
 {
+#if !_CCCL_TILE_COMPILATION() // error: asm statement is unsupported in tile code
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     NV_IF_TARGET(NV_IS_DEVICE,
                  (return ::cuda::__add_overflow_device(__lhs, __rhs);),
                  (return ::cuda::__add_overflow_host(__lhs, __rhs);))
   }
+#endif // !_CCCL_TILE_COMPILATION()
   return ::cuda::__add_overflow_generic_impl(__lhs, __rhs);
 }
 

--- a/libcudacxx/include/cuda/__numeric/sub_overflow.h
+++ b/libcudacxx/include/cuda/__numeric/sub_overflow.h
@@ -244,12 +244,14 @@ template <class _Tp>
 template <typename _Tp>
 [[nodiscard]] _CCCL_API constexpr overflow_result<_Tp> __sub_overflow_uniform_type(_Tp __lhs, _Tp __rhs) noexcept
 {
+#if !_CCCL_TILE_COMPILATION() // error: asm statement is unsupported in tile code
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     NV_IF_TARGET(NV_IS_DEVICE,
                  (return ::cuda::__sub_overflow_device(__lhs, __rhs);),
                  (return ::cuda::__sub_overflow_host(__lhs, __rhs);))
   }
+#endif // !_CCCL_TILE_COMPILATION()
   return ::cuda::__sub_overflow_generic_impl(__lhs, __rhs);
 }
 

--- a/libcudacxx/include/cuda/std/__bit/integral.h
+++ b/libcudacxx/include/cuda/std/__bit/integral.h
@@ -41,6 +41,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 template <class _Tp>
 _CCCL_API constexpr uint32_t __bit_log2(_Tp __t) noexcept
 {
+#if !_CCCL_TILE_COMPILATION() // error: asm statement is unsupported in tile code
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     if constexpr (sizeof(_Tp) <= 8)
@@ -55,6 +56,7 @@ _CCCL_API constexpr uint32_t __bit_log2(_Tp __t) noexcept
                     return __high == ~uint32_t{0} ? ::cuda::ptx::bfind(static_cast<uint64_t>(__t)) : __high + 64;))
     }
   }
+#endif // !_CCCL_TILE_COMPILATION()
   return numeric_limits<_Tp>::digits - 1 - ::cuda::std::countl_zero(__t);
 }
 
@@ -76,9 +78,10 @@ _CCCL_REQUIRES(::cuda::std::__cccl_is_unsigned_integer_v<_Tp>)
   _CCCL_ASSERT(__t <= numeric_limits<_Tp>::max() / 2, "bit_ceil overflow");
   // if __t == 0, __t - 1 == 0xFFFFFFFF, bit_width(0xFFFFFFFF) returns 32
   auto __width = ::cuda::std::bit_width(static_cast<_Up>(__t) - 1);
-  if constexpr (sizeof(_Tp) <= 8)
+#if !_CCCL_TILE_COMPILATION() // error: asm statement is unsupported in tile code
+  _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
-    _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+    if constexpr (sizeof(_Tp) <= 8)
     {
       // CUDA right shift (ptx::shr) returns 0 if the right operand is larger than the number of bits of the type
       // The result is computed as max(1, bit_width(__t - 1)) because it is more efficient than the ternary operator
@@ -89,6 +92,7 @@ _CCCL_REQUIRES(::cuda::std::__cccl_is_unsigned_integer_v<_Tp>)
                     return __ret;))
     }
   }
+#endif // !_CCCL_TILE_COMPILATION()
   auto __ret = static_cast<_Tp>(__t <= 1 ? _Up{1} : _Up{1} << __width);
   _CCCL_ASSUME(__ret >= __t);
   return __ret;
@@ -101,9 +105,10 @@ _CCCL_REQUIRES(::cuda::std::__cccl_is_unsigned_integer_v<_Tp>)
   using _Up   = _If<sizeof(_Tp) <= 4, uint32_t, _Tp>;
   auto __log2 = ::cuda::std::__bit_log2(static_cast<_Up>(__t));
   // __bit_log2 returns 0xFFFFFFFF if __t == 0
-  if constexpr (sizeof(_Tp) <= 8)
+#if !_CCCL_TILE_COMPILATION() // error: asm statement is unsupported in tile code
+  _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
-    _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+    if constexpr (sizeof(_Tp) <= 8)
     {
       // CUDA left shift (ptx::shl) returns 0 if the right operand is larger than the number of bits of the type
       // -> the result is 0 if __t == 0
@@ -113,6 +118,7 @@ _CCCL_REQUIRES(::cuda::std::__cccl_is_unsigned_integer_v<_Tp>)
                     return __ret;))
     }
   }
+#endif // !_CCCL_TILE_COMPILATION()
   auto __ret = static_cast<_Tp>(__t == 0 ? _Up{0} : _Up{1} << __log2);
   _CCCL_ASSUME(__ret >= __t / 2 && __ret <= __t);
   return __ret;

--- a/libcudacxx/include/cuda/std/__numeric/saturating_add.h
+++ b/libcudacxx/include/cuda/std/__numeric/saturating_add.h
@@ -204,12 +204,14 @@ _CCCL_TEMPLATE(class _Tp)
 _CCCL_REQUIRES(__cccl_is_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr _Tp saturating_add(_Tp __x, _Tp __y) noexcept
 {
+#if !_CCCL_TILE_COMPILATION() // error: asm statement is unsupported in tile code
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     NV_IF_ELSE_TARGET(NV_IS_HOST,
                       (return ::cuda::std::__saturating_add_impl_host(__x, __y);),
                       (return ::cuda::std::__saturating_add_impl_device(__x, __y);))
   }
+#endif // !_CCCL_TILE_COMPILATION()
   return ::cuda::saturating_add_overflow(__x, __y).value;
 }
 

--- a/libcudacxx/include/cuda/std/__numeric/saturating_sub.h
+++ b/libcudacxx/include/cuda/std/__numeric/saturating_sub.h
@@ -175,12 +175,14 @@ _CCCL_TEMPLATE(class _Tp)
 _CCCL_REQUIRES(__cccl_is_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr _Tp saturating_sub(_Tp __x, _Tp __y) noexcept
 {
+#if !_CCCL_TILE_COMPILATION() // error: asm statement is unsupported in tile code
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
     NV_IF_ELSE_TARGET(NV_IS_HOST,
                       (return ::cuda::std::__saturating_sub_impl_host(__x, __y);),
                       (return ::cuda::std::__saturating_sub_impl_device(__x, __y);))
   }
+#endif // !_CCCL_TILE_COMPILATION()
   return ::cuda::saturating_sub_overflow(__x, __y).value;
 }
 


### PR DESCRIPTION
We rely on ptx or asm statements for improved runtime performance. 

Disable those optimizations in tile mode