### PR TITLE
[Tile] Disable tests that trigger an internal compiler error when validating tile MLIR

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/default_accessor/accessor.restrict.functional.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/default_accessor/accessor.restrict.functional.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 #include <cuda/mdspan>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/swap.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <mdspan>
 //
 // friend constexpr void swap(mdspan& x, mdspan& y) noexcept;

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/cast.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/cast.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // clang-format off
 #include <disable_nvfp_conversions_and_operators.h>
 // clang-format on

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/overflow_handler/no_sat.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/overflow_handler/no_sat.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // ADDITIONAL_COMPILE_OPTIONS_HOST: -fext-numeric-literals
 // ADDITIONAL_COMPILE_DEFINITIONS: CCCL_GCC_HAS_EXTENDED_NUMERIC_LITERALS
 

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/overflow_handler/sat_finite.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/overflow_handler/sat_finite.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // ADDITIONAL_COMPILE_OPTIONS_HOST: -fext-numeric-literals
 // ADDITIONAL_COMPILE_DEFINITIONS: CCCL_GCC_HAS_EXTENDED_NUMERIC_LITERALS
 

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/storage.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/storage.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // clang-format off
 #include <disable_nvfp_conversions_and_operators.h>
 // clang-format on

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memchr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memchr.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 #include <cuda/std/__string/constexpr_c_functions.h>
 #include <cuda/std/type_traits>
 

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memmove.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memmove.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 #include <cuda/std/__string/constexpr_c_functions.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strchr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strchr.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 #include <cuda/std/__string/constexpr_c_functions.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_bidir.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_bidir.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <algorithm>
 
 // template<InputIterator InIter, OutputIterator<auto, InIter::reference> OutIter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_cpp17.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_cpp17.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <algorithm>
 
 // template<InputIterator InIter, OutputIterator<auto, InIter::reference> OutIter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_fwd.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_fwd.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <algorithm>
 
 // template<InputIterator InIter, OutputIterator<auto, InIter::reference> OutIter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_n.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <algorithm>
 
 // template<InputIterator InIter, OutputIterator<auto, InIter::reference> OutIter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_ptr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_ptr.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <algorithm>
 
 // template<InputIterator InIter, OutputIterator<auto, InIter::reference> OutIter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_rand.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_rand.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <algorithm>
 
 // template<InputIterator InIter, OutputIterator<auto, InIter::reference> OutIter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.all_of/all_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.all_of/all_of.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <algorithm>
 
 // template <class InputIterator, class Predicate>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.any_of/any_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.any_of/any_of.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <algorithm>
 
 // template <class InputIterator, class Predicate>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <algorithm>
 
 // template<InputIterator Iter1, InputIterator Iter2>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.none_of/none_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.none_of/none_of.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <algorithm>
 
 // template <class InputIterator, class Predicate>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/make.heap/make_heap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/make.heap/make_heap.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <algorithm>
 
 // template<RandomAccessIterator Iter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/make.heap/make_heap_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/make.heap/make_heap_comp.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <algorithm>
 
 // template<RandomAccessIterator Iter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/sort_heap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/sort_heap.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <algorithm>
 
 // template<RandomAccessIterator Iter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/sort_heap_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/sort_heap_comp.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <algorithm>
 
 // template<RandomAccessIterator Iter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/next_permutation.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/next_permutation.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <algorithm>
 
 // template<BidirectionalIterator Iter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/next_permutation_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/next_permutation_comp.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <algorithm>
 
 // template<BidirectionalIterator Iter, StrictWeakOrder<auto, Iter::value_type> Compare>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/prev_permutation.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/prev_permutation.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <algorithm>
 
 // template<BidirectionalIterator Iter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/prev_permutation_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/prev_permutation_comp.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <algorithm>
 
 // template<BidirectionalIterator Iter, StrictWeakOrder<auto, Iter::value_type> Compare>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.union/set_union_move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.union/set_union_move.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <algorithm>
 
 // template<InputIterator InIter1, InputIterator InIter2, typename OutIter,

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // CONSTEXPR_STEPS: 15000000
 
 // <algorithm>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort_comp.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // CONSTEXPR_STEPS: 15000000
 
 // <algorithm>

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan.extents.dims/compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan.extents.dims/compare.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 #include <cuda/std/cassert>
 #include <cuda/std/mdspan>
 

--- a/libcudacxx/test/libcudacxx/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/insert.iter.op_assign/lv_value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/insert.iter.op_assign/lv_value.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/iterator>
 
 // insert_iterator

--- a/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugate_transposed.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugate_transposed.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 #include <cuda/std/cassert>
 #include <cuda/std/complex>
 #include <cuda/std/linalg>

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bit.cast/bit_cast.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bit.cast/bit_cast.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6077498: ICE when validating tile MLIR
+
 // <cuda/std/bit>
 //
 // template<class To, class From>

--- a/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/array_func/memchr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/array_func/memchr.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 #include <cuda/std/cstring>
 #include <cuda/std/type_traits>
 

--- a/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/array_func/memcmp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/array_func/memcmp.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // int memcmp(const void* lhs, const void* rhs, size_t count);
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/array_func/memmove.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/array_func/memmove.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // void* memmove(void* dst, const void* src, size_t count);
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/string_exam/strchr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/string_exam/strchr.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 #include <cuda/std/cassert>
 #include <cuda/std/cstddef>
 #include <cuda/std/cstring>

--- a/libcudacxx/test/libcudacxx/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/find.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/find.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 #include <cuda/std/__string_>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/find.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/find.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 #include <cuda/std/__string_>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/find.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/find.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 #include <cuda/std/__string_>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char8_t/find.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char8_t/find.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 #include <cuda/std/__string_>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/common_type_specialization.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/common_type_specialization.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // During the review D130295 it was noticed libc++'s implementation uses
 // cuda::std::common_type. When users specialize this template for their own types the
 // comparisons would fail. This tests with a specialized cuda::std::common_type.

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/equal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/equal.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // template<class charT, class traits>

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/greater.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/greater.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // template<class charT, class traits>

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/greater_equal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/greater_equal.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // template<class charT, class traits>

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/less.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/less.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // template<class charT, class traits>

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/less_equal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/less_equal.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // template<class charT, class traits>

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/not_equal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/not_equal.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // template<class charT, class traits>

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.cons/from_range.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.cons/from_range.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 //  template <class Range>

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_char_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_char_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr size_type find(charT c, size_type pos = 0) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_not_of_char_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_not_of_char_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr size_type find_first_not_of(charT c, size_type pos = 0) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_not_of_pointer_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_not_of_pointer_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr size_type find_first_not_of(const charT* s, size_type pos = 0) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_not_of_pointer_size_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_not_of_pointer_size_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr size_type find_first_not_of(const charT* s, size_type pos, size_type n) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_not_of_string_view_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_not_of_string_view_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // size_type find_first_not_of(const basic_string& str, size_type pos = 0) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_of_char_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_of_char_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr size_type find_first_of(charT c, size_type pos = 0) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_not_of_char_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_not_of_char_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr size_type find_last_not_of(charT c, size_type pos = 0) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_not_of_pointer_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_not_of_pointer_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr size_type find_last_not_of(const charT* s, size_type pos = npos) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_not_of_pointer_size_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_not_of_pointer_size_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr size_type find_last_not_of(const charT* s, size_type pos, size_type n) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_not_of_string_view_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_not_of_string_view_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // size_type find_last_not_of(const basic_string& str, size_type pos = npos) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_of_char_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_of_char_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr size_type find_last_of(charT c, size_type pos = 0) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_of_pointer_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_of_pointer_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr size_type find_last_of(const charT* s, size_type pos = npos) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_of_pointer_size_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_of_pointer_size_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr size_type find_last_of(const charT* s, size_type pos, size_type n) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_of_string_view_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_of_string_view_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // size_type find_last_of(const basic_string& str, size_type pos = npos) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_pointer_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_pointer_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr size_type find(const charT* s, size_type pos = 0) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_pointer_size_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_pointer_size_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr size_type find(const charT* s, size_type pos, size_type n) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_string_view_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_string_view_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr size_type find(basic_string_view s, size_type pos = 0) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/rfind_char_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/rfind_char_size.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr size_type rfind(charT c, size_type pos = npos) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.literals/literal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.literals/literal.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr string_view operator""sv(const char* str, size_t len) noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.ops/compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.ops/compare.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr int compare(basic_string_view str) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.ops/contains.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.ops/contains.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr bool contains(basic_string_view x) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.ops/ends_with.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.ops/ends_with.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr bool ends_with(basic_string_view x) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.ops/starts_with.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.ops/starts_with.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/string_view>
 
 // constexpr bool starts_with(basic_string_view x) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.assign/assign_value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.assign/assign_value.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/optional>
 
 // template <class U> optional<T>& operator=(U&& v);

--- a/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.assign/emplace_initializer_list.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.assign/emplace_initializer_list.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/optional>
 
 // template <class U, class... Args>

--- a/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.ctor/initializer_list.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.ctor/initializer_list.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // <cuda/std/optional>
 
 // template <class U, class... Args>

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/left_shift.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/left_shift.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // The CI "Apple back-deployment with assertions enabled" needs a higher value
 // CONSTEXPR_STEPS: 12712420
 

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/left_shift_eq.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/left_shift_eq.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // bitset<N>& operator<<=(size_t pos); // constexpr since C++23
 
 #include <cuda/std/bitset>

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/op_eq_eq.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/op_eq_eq.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile && !c++17
+// nvbug6076227: ICE when validating tile MLIR
+
 // test:
 
 // bool operator==(const bitset<N>& rhs) const; // constexpr since C++23

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/right_shift.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/right_shift.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // bitset<N> operator>>(size_t pos) const; // constexpr since C++23
 
 #include <cuda/std/bitset>

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/right_shift_eq.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/right_shift_eq.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // CONSTEXPR_STEPS: 15000000
 
 // bitset<N>& operator<<=(size_t pos); // constexpr since C++23

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.operators/op_and.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.operators/op_and.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // bitset<N> operator&(const bitset<N>& lhs, const bitset<N>& rhs); // constexpr since C++23
 
 #include <cuda/std/bitset>

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.operators/op_not.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.operators/op_not.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // bitset<N> operator^(const bitset<N>& lhs, const bitset<N>& rhs); // constexpr since C++23
 
 #include <cuda/std/bitset>

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.operators/op_or.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.operators/op_or.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 // bitset<N> operator|(const bitset<N>& lhs, const bitset<N>& rhs); // constexpr since C++23
 
 #include <cuda/std/bitset>


### PR DESCRIPTION
We have a lot of tests that currently crash the compiler during validation. This is a compund commit to investigate those tests.

See nvbug6076227
