### PR TITLE
[Tile] Disable tests that trigger internal compiler error during codegen for `intptr_t`

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/index_operator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/index_operator.pass.cpp
@@ -158,7 +158,9 @@ int main(int, char**)
   test();
   static_assert(test());
 
+#if !_CCCL_TILE_COMPILATION() // nvbug6081143: Error: Internal Compiler Error (tile codegen): "unhandled type!"
   // The large test iterates over ~10k loop indices.
   test_large();
+#endif // !_CCCL_TILE_COMPILATION()
   return 0;
 }


### PR DESCRIPTION
The compiler breaks during codegen for an unhandled type. Looks like intptr_t is not supported yet

See nvbug6081143
