### PR TITLE
[Tile] Disable tests that trigger internal compiler error about use of local static variable

### DIFF
--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/assign.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6080486 : error: Internal Compiler Error (tile codegen): "Static local variables not handled yet."
+
 #include <cuda/std/algorithm>
 #include <cuda/std/array>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/assignment.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/assignment.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6080486 : error: Internal Compiler Error (tile codegen): "Static local variables not handled yet."
+
 #include <cuda/std/algorithm>
 #include <cuda/std/cassert>
 #include <cuda/std/initializer_list>

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/constructor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/constructor.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6080486 : error: Internal Compiler Error (tile codegen): "Static local variables not handled yet."
+
 #include <cuda/std/__type_traits/is_nothrow_default_constructible.h>
 #include <cuda/std/algorithm>
 #include <cuda/std/array>


### PR DESCRIPTION
This is a really bogus error, that talks about a local static variable bubt points to a defaulted constructor.

Mark as XFAIL until the compiler team fixes it

See nvbug6080486
