### PR TITLE
[Tile] Do not check TypeID in variant tests

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/index_operator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/index_operator.pass.cpp
@@ -143,7 +143,7 @@ TEST_FUNC constexpr void iterate(MDS mds, Args... args)
   }
 }
 
-_CCCL_DEVICE __managed__ cuda::std::array<int, 1024> iteration_data{};
+__managed__ cuda::std::array<int, 1024> iteration_data{};
 
 template <class Mapping>
 TEST_FUNC constexpr void test_iteration(Mapping m)

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/index_operator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/index_operator.pass.cpp
@@ -143,7 +143,7 @@ TEST_FUNC constexpr void iterate(MDS mds, Args... args)
   }
 }
 
-__managed__ cuda::std::array<int, 1024> iteration_data{};
+_CCCL_DEVICE __managed__ cuda::std::array<int, 1024> iteration_data{};
 
 template <class Mapping>
 TEST_FUNC constexpr void test_iteration(Mapping m)

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_accessor/shared_mem_accessor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_accessor/shared_mem_accessor.pass.cpp
@@ -20,7 +20,9 @@ TEST_DEVICE_FUNC void basic_mdspan_access_test()
   __shared__ int smem[4];
   [[maybe_unused]] cuda::shared_memory_mdspan<int, ext_t> md{smem, ext_t{}};
   unused(md[0]);
+#if !_CCCL_TILE_COMPILATION()
   asm volatile("" : : "l"((size_t) smem) : "memory");
+#endif // !_CCCL_TILE_COMPILATION()
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.apply/make_from_tuple.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.apply/make_from_tuple.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: nvrtc
 // UNSUPPORTED: gcc-6
 
+// UNSUPPORTED: enable-tile
+// TypeID is unsupported un tile mode
+
 // <cuda/std/tuple>
 
 // template <class T, class Tuple> constexpr T make_from_tuple(Tuple&&);

--- a/libcudacxx/test/support/variant_test_helpers.h
+++ b/libcudacxx/test/support/variant_test_helpers.h
@@ -171,19 +171,25 @@ struct ForwardingCallObject
   template <class... Args>
   TEST_FUNC static void set_call(CallType type)
   {
+#if !_CCCL_TILE_COMPILATION() // Pointer types are not supported in tile mode
     assert(last_call_type() == CT_None);
     assert(last_call_args() == nullptr);
     last_call_type() = type;
     last_call_args() = cuda::std::addressof(makeArgumentID<Args...>());
+#endif // !_CCCL_TILE_COMPILATION()
   }
 
   template <class... Args>
   TEST_FUNC static bool check_call(CallType type)
   {
+#if _CCCL_TILE_COMPILATION() // Pointer types are not supported in tile mode
+    return true;
+#else // ^^^ _CCCL_TILE_COMPILATION() ^^^ / vvv !_CCCL_TILE_COMPILATION() vvv
     bool result      = last_call_type() == type && last_call_args() && *last_call_args() == makeArgumentID<Args...>();
     last_call_type() = CT_None;
     last_call_args() = nullptr;
     return result;
+#endif // !_CCCL_TILE_COMPILATION()
   }
 
   // To check explicit return type for visit<R>
@@ -192,8 +198,10 @@ struct ForwardingCallObject
     return 0;
   }
 
+#if !_CCCL_TILE_COMPILATION() // Pointer types are not supported in tile mode
   STATIC_MEMBER_VAR(last_call_type, CallType)
   STATIC_MEMBER_VAR(last_call_args, const TypeID*)
+#endif // !_CCCL_TILE_COMPILATION()
 };
 
 struct ReturnFirst


### PR DESCRIPTION
In tile returning a reference to `const TypeID*` is not possible
