### PR TITLE
[Tile] Avoid calling builtin device functions in tile mode

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_accessor/shared_mem_accessor.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_accessor/shared_mem_accessor.runfail.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: Calling a __device__ function in tile code
+
 #include <cuda/mdspan>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/array_func/memset.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/array_func/memset.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: Calling a __device__ function in tile code
+
 // void* memset(void* s, int c, size_t n);
 
 #include <cuda/std/cassert>


### PR DESCRIPTION
The compiler does not support all builtins yet
