### PR TITLE
Fix `filter_view` initialization issues

### DIFF
--- a/libcudacxx/include/cuda/std/__ranges/filter_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/filter_view.h
@@ -85,15 +85,15 @@ template <class _View,
 #endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 class filter_view : public view_interface<filter_view<_View, _Pred>>
 {
-  _CCCL_NO_UNIQUE_ADDRESS _View __base_;
-  _CCCL_NO_UNIQUE_ADDRESS __movable_box<_Pred> __pred_;
+  _View __base_;
+  __movable_box<_Pred> __pred_;
 
   // We cache the result of begin() to allow providing an amortized O(1) begin() whenever
   // the underlying range is at least a forward_range.
   static constexpr bool __use_cache = forward_range<_View>;
   using _cache_type _CCCL_NODEBUG =
     conditional_t<__use_cache, __non_propagating_cache<iterator_t<_View>>, __empty_cache>;
-  _CCCL_NO_UNIQUE_ADDRESS _cache_type __cached_begin_;
+  _cache_type __cached_begin_;
 
 public:
   // __iterator and __sentinel should be private, but several compilers (clang-14, gcc-12,
@@ -104,8 +104,8 @@ public:
   class __iterator : public __filter_iterator_category<_View>
   {
   public:
-    _CCCL_NO_UNIQUE_ADDRESS iterator_t<_View> __current_;
-    _CCCL_NO_UNIQUE_ADDRESS filter_view* __parent_ = nullptr;
+    iterator_t<_View> __current_;
+    filter_view* __parent_ = nullptr;
 
     using iterator_concept =
       conditional_t<bidirectional_range<_View>,

--- a/libcudacxx/include/cuda/std/__ranges/filter_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/filter_view.h
@@ -85,7 +85,7 @@ template <class _View,
 #endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 class filter_view : public view_interface<filter_view<_View, _Pred>>
 {
-  _CCCL_NO_UNIQUE_ADDRESS _View __base_{};
+  _CCCL_NO_UNIQUE_ADDRESS _View __base_;
   _CCCL_NO_UNIQUE_ADDRESS __movable_box<_Pred> __pred_;
 
   // We cache the result of begin() to allow providing an amortized O(1) begin() whenever
@@ -93,7 +93,7 @@ class filter_view : public view_interface<filter_view<_View, _Pred>>
   static constexpr bool __use_cache = forward_range<_View>;
   using _cache_type _CCCL_NODEBUG =
     conditional_t<__use_cache, __non_propagating_cache<iterator_t<_View>>, __empty_cache>;
-  _CCCL_NO_UNIQUE_ADDRESS _cache_type __cached_begin_{};
+  _CCCL_NO_UNIQUE_ADDRESS _cache_type __cached_begin_;
 
 public:
   // __iterator and __sentinel should be private, but several compilers (clang-14, gcc-12,
@@ -104,7 +104,7 @@ public:
   class __iterator : public __filter_iterator_category<_View>
   {
   public:
-    _CCCL_NO_UNIQUE_ADDRESS iterator_t<_View> __current_{};
+    _CCCL_NO_UNIQUE_ADDRESS iterator_t<_View> __current_;
     _CCCL_NO_UNIQUE_ADDRESS filter_view* __parent_ = nullptr;
 
     using iterator_concept =
@@ -118,15 +118,11 @@ public:
     using value_type      = range_value_t<_View>;
     using difference_type = range_difference_t<_View>;
 
-#if _CCCL_HAS_CONCEPTS()
-    _CCCL_HIDE_FROM_ABI __iterator() noexcept(is_nothrow_default_constructible_v<iterator_t<_View>>)
-      requires default_initializable<iterator_t<_View>>
-    = default;
-#else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
     _CCCL_TEMPLATE(class _View2 = _View)
     _CCCL_REQUIRES(default_initializable<iterator_t<_View2>>)
-    _CCCL_API constexpr __iterator() noexcept(is_nothrow_default_constructible_v<iterator_t<_View2>>) {}
-#endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
+    _CCCL_API constexpr __iterator() noexcept(is_nothrow_default_constructible_v<iterator_t<_View2>>)
+        : __current_()
+    {}
 
     _CCCL_API constexpr __iterator(filter_view& __parent, iterator_t<_View> __current) noexcept(
       is_nothrow_move_constructible_v<iterator_t<_View>>)
@@ -286,22 +282,18 @@ public:
     {
       return !(__x == __y);
     }
-#endif
+#endif // _CCCL_STD_VER <= 2017
   };
 
-#if _CCCL_HAS_CONCEPTS()
-  _CCCL_HIDE_FROM_ABI constexpr filter_view() noexcept(
-    is_nothrow_default_constructible_v<_View> && is_nothrow_default_constructible_v<_Pred>)
-    requires default_initializable<_View> && default_initializable<_Pred>
-  = default;
-#else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
   _CCCL_TEMPLATE(class _View2 = _View, class _Pred2 = _Pred)
   _CCCL_REQUIRES(default_initializable<_View2> _CCCL_AND default_initializable<_Pred2>)
   _CCCL_API constexpr filter_view() noexcept(is_nothrow_default_constructible_v<_View2>
                                              && is_nothrow_default_constructible_v<_Pred2>)
       : view_interface<filter_view<_View, _Pred>>{}
+      , __base_()
+      , __pred_()
+      , __cached_begin_()
   {}
-#endif // !_CCCL_HAS_CONCEPTS()
 
   _CCCL_API constexpr explicit filter_view(_View __base, _Pred __pred) noexcept(
     is_nothrow_move_constructible_v<_View>

--- a/libcudacxx/include/cuda/std/__ranges/movable_box.h
+++ b/libcudacxx/include/cuda/std/__ranges/movable_box.h
@@ -399,7 +399,7 @@ struct __movable_box<_Tp, true> : __movable_box_base<_Tp>
       : __base(in_place, ::cuda::std::forward<_Args>(__args)...)
   {}
 
-  _CCCL_HIDE_FROM_ABI constexpr __movable_box() = default;
+  _CCCL_HIDE_FROM_ABI constexpr __movable_box() noexcept(is_nothrow_default_constructible_v<_Tp>) = default;
 };
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/adaptor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/adaptor.pass.cpp
@@ -40,17 +40,6 @@ struct Range : cuda::std::ranges::view_base
   using Iterator = forward_iterator<int*>;
   using Sentinel = sentinel_wrapper<Iterator>;
 
-  // (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-  // default constructors that don't exist because it evaluates the class initializers before
-  // considering the default constructors requirements clause.
-#if (TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12) || TEST_COMPILER(MSVC, <, 19, 44)) \
-  && (TEST_STD_VER == 2020)
-  TEST_FUNC constexpr explicit Range()
-      : Range{nullptr, nullptr}
-  {}
-#endif // (TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12)
-       // || TEST_COMPILER(MSVC, <, 19, 44)) && (TEST_STD_VER == 2020)
-
   TEST_FUNC constexpr explicit Range(int* b, int* e)
       : begin_(b)
       , end_(e)
@@ -155,14 +144,6 @@ TEST_FUNC constexpr bool test()
     [[maybe_unused]] auto partial = cuda::std::views::filter(X{});
   }
 
-  // nvcc 12.0 commits harakiri by way of
-  //
-  // libcudacxx/include/cuda/std/__ranges/filter_view.h(85): error: Internal Compiler Error
-  // (codegen): "internal error during structure layout!"
-  //
-  // You can fix the ICE by making the predicates constexpr, but then the static_assert()s fail
-  // (but also only for nvcc 12.0).
-#if !TEST_CUDA_COMPILER(NVCC) || TEST_CUDA_COMPILER(NVCC, >=, 12, 1)
   {
     // Test `adaptor | views::filter(pred)`
     Range const range(buff, buff + 8);
@@ -195,7 +176,6 @@ TEST_FUNC constexpr bool test()
       compareViews(result, {0, 6});
     }
   }
-#endif // !TEST_CUDA_COMPILER(NVCC) || TEST_CUDA_COMPILER(NVCC, >=, 12, 1)
 
   // Test SFINAE friendliness
   {

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/base.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/base.pass.cpp
@@ -19,16 +19,9 @@
 
 struct Range : cuda::std::ranges::view_base
 {
-  // (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-  // default constructors that don't exist because it evaluates the class initializers before
-  // considering the default constructors requirements clause.
-#if (TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12) || TEST_COMPILER(MSVC, <, 19, 44)) \
-  && (TEST_STD_VER == 2020)
-  TEST_FUNC constexpr explicit Range()
+  TEST_FUNC constexpr Range()
       : Range{nullptr, nullptr}
   {}
-#endif // (TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12)
-       // || TEST_COMPILER(MSVC, <, 19, 44)) && (TEST_STD_VER == 2020)
 
   TEST_FUNC constexpr explicit Range(int* b, int* e)
       : begin_(b)

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/begin.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/begin.pass.cpp
@@ -7,13 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-// default constructors that don't exist because it evaluates the class initializers before
-// considering the default constructors requirements clause. It's not possible to selectively
-// disable them in this file like the others, so we just disable the compiler entirely.
-
-// UNSUPPORTED: (clang-14 || gcc-12 || msvc-19.39) && c++20
-
 // constexpr iterator begin();
 
 #include <cuda/std/cassert>
@@ -27,17 +20,6 @@ struct Range : cuda::std::ranges::view_base
 {
   using Iterator = forward_iterator<int*>;
   using Sentinel = sentinel_wrapper<Iterator>;
-
-  // (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-  // default constructors that don't exist because it evaluates the class initializers before
-  // considering the default constructors requirements clause.
-#if (TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12) || TEST_COMPILER(MSVC, <, 19, 44)) \
-  && (TEST_STD_VER == 2020)
-  TEST_FUNC constexpr explicit Range()
-      : Range{nullptr, nullptr}
-  {}
-#endif // (TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12)
-       // || TEST_COMPILER(MSVC, <, 19, 44)) && (TEST_STD_VER == 2020)
 
   TEST_FUNC constexpr explicit Range(int* b, int* e)
       : begin_(b)
@@ -64,16 +46,9 @@ struct InputRange : cuda::std::ranges::view_base
   using Iterator = cpp17_input_iterator<int*>;
   using Sentinel = sentinel_wrapper<Iterator>;
 
-  // (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-  // default constructors that don't exist because it evaluates the class initializers before
-  // considering the default constructors requirements clause.
-#if (TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12) || TEST_COMPILER(MSVC, <, 19, 44)) \
-  && (TEST_STD_VER == 2020)
   TEST_FUNC constexpr explicit InputRange()
       : InputRange{nullptr, nullptr}
   {}
-#endif // (TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12)
-       // || TEST_COMPILER(MSVC, <, 19, 44)) && (TEST_STD_VER == 2020)
 
   TEST_FUNC constexpr explicit InputRange(int* b, int* e)
       : begin_(b)

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/ctad.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/ctad.pass.cpp
@@ -51,11 +51,6 @@ TEST_FUNC constexpr bool test()
     static_assert(cuda::std::is_same_v<decltype(view), cuda::std::ranges::filter_view<View, Pred>>);
   }
 
-  // (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-  // default constructors that don't exist because it evaluates the class initializers before
-  // considering the default constructors requirements clause.
-#if !((TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12) || TEST_COMPILER(MSVC, <, 19, 44)) \
-      && (TEST_STD_VER == 2020))
   {
     // Test with a range that isn't a view, to make sure we properly use views::all_t in the
     // implementation.
@@ -66,8 +61,6 @@ TEST_FUNC constexpr bool test()
     static_assert(
       cuda::std::is_same_v<decltype(view), cuda::std::ranges::filter_view<cuda::std::ranges::ref_view<Range>, Pred>>);
   }
-#endif // !((TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12)
-       //     || TEST_COMPILER(MSVC, <, 19, 44)) && (TEST_STD_VER == 2020))
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/ctor.default.pass.cpp
@@ -20,7 +20,7 @@ _CCCL_GLOBAL_CONSTANT int buff[] = {1, 2, 3, 4, 5, 6, 7, 8};
 
 struct DefaultConstructibleView : cuda::std::ranges::view_base
 {
-  TEST_FUNC constexpr DefaultConstructibleView()
+  TEST_FUNC constexpr DefaultConstructibleView() noexcept(false)
       : begin_(buff)
       , end_(buff + 8)
   {}
@@ -94,17 +94,6 @@ struct NoexceptPredicate
 
 TEST_FUNC constexpr bool test()
 {
-  // The following program is so powerful that cicc 12.9 simply crashes with
-  //
-  // Segmentation fault (core dumped)
-  // # --error 0x8b --
-  //
-  // The cause of this is the View constructor, so nothing we can do except disable this.
-  //
-  // (gcc-12 || msvc-19.39) claims that View is not default constructible. It is unclear how
-  // they arrive at this conclusion.
-#if !_CCCL_CUDACC_EQUAL(12, 9) \
-  && !((TEST_COMPILER(GCC, ==, 12) || TEST_COMPILER(MSVC, <, 19, 44)) && (TEST_STD_VER == 2020))
   {
     using View = cuda::std::ranges::filter_view<DefaultConstructibleView, DefaultConstructiblePredicate>;
 
@@ -129,23 +118,17 @@ TEST_FUNC constexpr bool test()
     assert(*it++ == 8);
     assert(it == end);
   }
-#endif // !_CCCL_CUDACC_EQUAL(12, 9)
-       // && !((TEST_COMPILER(GCC, ==, 12) || TEST_COMPILER(MSVC, <, 19, 44))
-       //      && (TEST_STD_VER == 2020))
 
   // Check cases where the default constructor isn't provided
   {
     static_assert(!cuda::std::is_default_constructible_v<
                   cuda::std::ranges::filter_view<DefaultConstructibleView, NoDefaultPredicate>>);
-    // (clang-14 || gcc-12 || msvc-19.39) tries to actually instantiate the default ctors
-#if !((TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12) || TEST_COMPILER(MSVC, <, 19, 44)) \
-      && (TEST_STD_VER == 2020))
+
     static_assert(!cuda::std::is_default_constructible_v<
                   cuda::std::ranges::filter_view<NoDefaultView, DefaultConstructiblePredicate>>);
     static_assert(
       !cuda::std::is_default_constructible_v<cuda::std::ranges::filter_view<NoDefaultView, NoDefaultPredicate>>);
-#endif // !((TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12)
-       //     || TEST_COMPILER(MSVC, <, 19, 44)) && (TEST_STD_VER == 2020))
+    //     || TEST_COMPILER(MSVC, <, 19, 44)) && (TEST_STD_VER == 2020))
   }
 
   // Check noexcept-ness

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/ctor.default.pass.cpp
@@ -20,7 +20,7 @@ _CCCL_GLOBAL_CONSTANT int buff[] = {1, 2, 3, 4, 5, 6, 7, 8};
 
 struct DefaultConstructibleView : cuda::std::ranges::view_base
 {
-  TEST_FUNC constexpr DefaultConstructibleView() noexcept(false)
+  TEST_FUNC constexpr DefaultConstructibleView()
       : begin_(buff)
       , end_(buff + 8)
   {}
@@ -137,9 +137,9 @@ TEST_FUNC constexpr bool test()
       using View = cuda::std::ranges::filter_view<DefaultConstructibleView, DefaultConstructiblePredicate>;
       // GCC 7 simply gives the wrong answer here. No amount of cajoling, pleading, or
       // massaging the code ever got it to pass this static_assert()
-#if !TEST_COMPILER(GCC) || TEST_COMPILER(GCC, >=, 8, 0)
+#if !TEST_COMPILER(GCC)
       static_assert(!cuda::std::is_nothrow_default_constructible_v<View>);
-#endif // !TEST_COMPILER(GCC) || TEST_COMPILER(GCC, >=, 8, 0)
+#endif // !TEST_COMPILER(GCC)
     }
     {
       using View = cuda::std::ranges::filter_view<NoexceptView, NoexceptPredicate>;

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/ctor.view_pred.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/ctor.view_pred.pass.cpp
@@ -19,17 +19,6 @@
 
 struct Range : cuda::std::ranges::view_base
 {
-  // (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-  // default constructors that don't exist because it evaluates the class initializers before
-  // considering the default constructors requirements clause.
-#if (TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12) || TEST_COMPILER(MSVC, <, 19, 44)) \
-  && (TEST_STD_VER == 2020)
-  TEST_FUNC constexpr explicit Range()
-      : Range{nullptr, nullptr}
-  {}
-#endif // (TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12)
-       // || TEST_COMPILER(MSVC, <, 19, 44)) && (TEST_STD_VER == 2020)
-
   TEST_FUNC constexpr explicit Range(int* b, int* e)
       : begin_(b)
       , end_(e)
@@ -69,17 +58,6 @@ struct TrackingRange
     : TrackInitialization
     , cuda::std::ranges::view_base
 {
-  // (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-  // default constructors that don't exist because it evaluates the class initializers before
-  // considering the default constructors requirements clause.
-#if (TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12) || TEST_COMPILER(MSVC, <, 19, 44)) \
-  && (TEST_STD_VER == 2020)
-  TEST_FUNC constexpr explicit TrackingRange()
-      : TrackInitialization{nullptr, nullptr}
-  {}
-#endif // (TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12)
-       // || TEST_COMPILER(MSVC, <, 19, 44)) && (TEST_STD_VER == 2020)
-
   using TrackInitialization::TrackInitialization;
   [[nodiscard]] TEST_FUNC int* begin() const
   {

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/end.pass.cpp
@@ -22,17 +22,6 @@ struct Range : cuda::std::ranges::view_base
   using Iterator = forward_iterator<int*>;
   using Sentinel = sentinel_wrapper<Iterator>;
 
-  // (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-  // default constructors that don't exist because it evaluates the class initializers before
-  // considering the default constructors requirements clause.
-#if (TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12) || TEST_COMPILER(MSVC, <, 19, 44)) \
-  && (TEST_STD_VER == 2020)
-  TEST_FUNC constexpr explicit Range()
-      : Range{nullptr, nullptr}
-  {}
-#endif // (TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12)
-       // || TEST_COMPILER(MSVC, <, 19, 44)) && (TEST_STD_VER == 2020)
-
   TEST_FUNC constexpr explicit Range(int* b, int* e)
       : begin_(b)
       , end_(e)
@@ -54,17 +43,6 @@ private:
 struct CommonRange : cuda::std::ranges::view_base
 {
   using Iterator = forward_iterator<int*>;
-
-  // (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-  // default constructors that don't exist because it evaluates the class initializers before
-  // considering the default constructors requirements clause.
-#if (TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12) || TEST_COMPILER(MSVC, <, 19, 44)) \
-  && (TEST_STD_VER == 2020)
-  TEST_FUNC constexpr explicit CommonRange()
-      : CommonRange{nullptr, nullptr}
-  {}
-#endif // (TEST_COMPILER(CLANG, ==, 14) || TEST_COMPILER(GCC, ==, 12)
-       // || TEST_COMPILER(MSVC, <, 19, 44)) && (TEST_STD_VER == 2020)
 
   TEST_FUNC constexpr explicit CommonRange(int* b, int* e)
       : begin_(b)

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/arrow.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/arrow.pass.cpp
@@ -7,13 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-// default constructors that don't exist because it evaluates the class initializers before
-// considering the default constructors requirements clause. It's not possible to selectively
-// disable them in this file like the others, so we just disable the compiler entirely.
-
-// UNSUPPORTED: (clang-14 || gcc-12 || msvc-19.39) && c++20
-
 // constexpr iterator_t<V> operator->() const
 //    requires has-arrow<iterator_t<V>> && copyable<iterator_t<V>>
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/base.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/base.pass.cpp
@@ -7,13 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-// default constructors that don't exist because it evaluates the class initializers before
-// considering the default constructors requirements clause. It's not possible to selectively
-// disable them in this file like the others, so we just disable the compiler entirely.
-
-// UNSUPPORTED: (clang-14 || gcc-12 || msvc-19.39) && c++20
-
 // constexpr iterator_t<V> const& base() const& noexcept;
 // constexpr iterator_t<V> base() &&;
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/compare.pass.cpp
@@ -7,13 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-// default constructors that don't exist because it evaluates the class initializers before
-// considering the default constructors requirements clause. It's not possible to selectively
-// disable them in this file like the others, so we just disable the compiler entirely.
-
-// UNSUPPORTED: (clang-14 || gcc-12 || msvc-19.39) && c++20
-
 // friend constexpr bool operator==(iterator const&, iterator const&)
 //  requires equality_comparable<iterator_t<V>>
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/ctor.default.pass.cpp
@@ -7,13 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-// default constructors that don't exist because it evaluates the class initializers before
-// considering the default constructors requirements clause. It's not possible to selectively
-// disable them in this file like the others, so we just disable the compiler entirely.
-
-// UNSUPPORTED: (clang-14 || gcc-12 || msvc-19.39) && c++20
-
 // cuda::std::ranges::filter_view<V>::<iterator>() requires default_initializable<iterator_t<V>> = default;
 
 #include <cuda/std/cassert>
@@ -24,7 +17,7 @@
 #include "test_iterators.h"
 #include "test_macros.h"
 
-template <class Iterator, bool IsNoexcept>
+template <class Iterator>
 TEST_FUNC constexpr void test_default_constructible()
 {
   // Make sure the iterator is default constructible when the underlying iterator is.
@@ -37,7 +30,8 @@ TEST_FUNC constexpr void test_default_constructible()
   // GCC 7 simply gives the wrong answer here. No amount of cajoling, pleading, or
   // massaging the code ever got it to pass this static_assert()
 #if !_CCCL_COMPILER(GCC) || _CCCL_COMPILER(GCC, >=, 8, 0)
-  static_assert(cuda::std::is_nothrow_default_constructible_v<FilterIterator> == IsNoexcept);
+  static_assert(cuda::std::is_nothrow_default_constructible_v<FilterIterator>
+                == cuda::std::is_nothrow_default_constructible_v<Iterator>);
 #endif
 }
 
@@ -55,11 +49,11 @@ TEST_FUNC constexpr bool tests()
 {
   test_not_default_constructible<cpp17_input_iterator<int*>>();
   test_not_default_constructible<cpp20_input_iterator<int*>>();
-  test_default_constructible<forward_iterator<int*>, /* noexcept */ false>();
-  test_default_constructible<bidirectional_iterator<int*>, /* noexcept */ false>();
-  test_default_constructible<random_access_iterator<int*>, /* noexcept */ false>();
-  test_default_constructible<contiguous_iterator<int*>, /* noexcept */ false>();
-  test_default_constructible<int*, /* noexcept */ true>();
+  test_default_constructible<forward_iterator<int*>>();
+  test_default_constructible<bidirectional_iterator<int*>>();
+  test_default_constructible<random_access_iterator<int*>>();
+  test_default_constructible<contiguous_iterator<int*>>();
+  test_default_constructible<int*>();
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/ctor.parent_iter.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/ctor.parent_iter.pass.cpp
@@ -7,13 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-// default constructors that don't exist because it evaluates the class initializers before
-// considering the default constructors requirements clause. It's not possible to selectively
-// disable them in this file like the others, so we just disable the compiler entirely.
-
-// UNSUPPORTED: (clang-14 || gcc-12 || msvc-19.39) && c++20
-
 // constexpr cuda::std::ranges::filter_view::<iterator>(filter_view&, iterator_t<V>);
 
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/decrement.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/decrement.pass.cpp
@@ -7,13 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-// default constructors that don't exist because it evaluates the class initializers before
-// considering the default constructors requirements clause. It's not possible to selectively
-// disable them in this file like the others, so we just disable the compiler entirely.
-
-// UNSUPPORTED: (clang-14 || gcc-12 || msvc-19.39) && c++20
-
 // constexpr iterator& operator--() requires bidirectional_range<V>;
 // constexpr iterator operator--(int) requires bidirectional_range<V>;
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/deref.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/deref.pass.cpp
@@ -7,13 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-// default constructors that don't exist because it evaluates the class initializers before
-// considering the default constructors requirements clause. It's not possible to selectively
-// disable them in this file like the others, so we just disable the compiler entirely.
-
-// UNSUPPORTED: (clang-14 || gcc-12 || msvc-19.39) && c++20
-
 // constexpr range_reference_t<V> operator*() const;
 
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/increment.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/increment.pass.cpp
@@ -7,13 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-// default constructors that don't exist because it evaluates the class initializers before
-// considering the default constructors requirements clause. It's not possible to selectively
-// disable them in this file like the others, so we just disable the compiler entirely.
-
-// UNSUPPORTED: (clang-14 || gcc-12 || msvc-19.39) && c++20
-
 // constexpr iterator& operator++();
 // constexpr void operator++(int);
 // constexpr iterator operator++(int) requires forward_range<V>;

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/iter_move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/iter_move.pass.cpp
@@ -7,13 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-// default constructors that don't exist because it evaluates the class initializers before
-// considering the default constructors requirements clause. It's not possible to selectively
-// disable them in this file like the others, so we just disable the compiler entirely.
-
-// UNSUPPORTED: (clang-14 || gcc-12 || msvc-19.39) && c++20
-
 // friend constexpr range_rvalue_reference_t<V> iter_move(iterator const& i)
 //  noexcept(noexcept(ranges::iter_move(i.current_)));
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/iter_swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/iter_swap.pass.cpp
@@ -7,13 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-// default constructors that don't exist because it evaluates the class initializers before
-// considering the default constructors requirements clause. It's not possible to selectively
-// disable them in this file like the others, so we just disable the compiler entirely.
-
-// UNSUPPORTED: (clang-14 || gcc-12 || msvc-19.39) && c++20
-
 // friend constexpr void iter_swap(iterator const& x, iterator const& y)
 //  noexcept(noexcept(ranges::iter_swap(x.current_, y.current_)))
 //  requires(indirectly_swappable<iterator_t<V>>);

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/types.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/types.compile.pass.cpp
@@ -7,13 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-// default constructors that don't exist because it evaluates the class initializers before
-// considering the default constructors requirements clause. It's not possible to selectively
-// disable them in this file like the others, so we just disable the compiler entirely.
-
-// UNSUPPORTED: (clang-14 || gcc-12 || msvc-19.39) && c++20
-
 // cuda::std::filter_view::<iterator>::difference_type
 // cuda::std::filter_view::<iterator>::value_type
 // cuda::std::filter_view::<iterator>::iterator_category

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/base.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/base.pass.cpp
@@ -7,13 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-// default constructors that don't exist because it evaluates the class initializers before
-// considering the default constructors requirements clause. It's not possible to selectively
-// disable them in this file like the others, so we just disable the compiler entirely.
-
-// UNSUPPORTED: (clang-14 || gcc-12 || msvc-19.39) && c++20
-
 // constexpr sentinel_t<V> base() const;
 
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/compare.pass.cpp
@@ -7,13 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-// default constructors that don't exist because it evaluates the class initializers before
-// considering the default constructors requirements clause. It's not possible to selectively
-// disable them in this file like the others, so we just disable the compiler entirely.
-
-// UNSUPPORTED: (clang-14 || gcc-12 || msvc-19.39) && c++20
-
 // friend constexpr bool operator==(iterator const&, sentinel const&);
 
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/ctor.default.pass.cpp
@@ -7,13 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-// default constructors that don't exist because it evaluates the class initializers before
-// considering the default constructors requirements clause. It's not possible to selectively
-// disable them in this file like the others, so we just disable the compiler entirely.
-
-// UNSUPPORTED: (clang-14 || gcc-12 || msvc-19.39) && c++20
-
 // filter_view<V>::<sentinel>() = default;
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/ctor.parent.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/ctor.parent.pass.cpp
@@ -7,13 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// (clang-14 || gcc-12 || msvc-19.39) in C++20 tries to erroneously instantiate a bunch of
-// default constructors that don't exist because it evaluates the class initializers before
-// considering the default constructors requirements clause. It's not possible to selectively
-// disable them in this file like the others, so we just disable the compiler entirely.
-
-// UNSUPPORTED: (clang-14 || gcc-12 || msvc-19.39) && c++20
-
 // constexpr explicit sentinel(filter_view&);
 
 #include <cuda/std/array>


### PR DESCRIPTION
Currently we used member initializer with `filter_view`

However, that breaks some compilers in C++20, so just use the plain default constructor if possible
