### PR TITLE
fix env cub::FindIf docs predicate duplicate

### DIFF
--- a/cub/cub/device/device_find.cuh
+++ b/cub/cub/device/device_find.cuh
@@ -372,8 +372,8 @@ struct DeviceFind
   //! .. literalinclude:: ../../../cub/test/catch2_test_device_find_env_api.cu
   //!     :language: c++
   //!     :dedent:
-  //!     :start-after: example-begin find-if-env-predicate
-  //!     :end-before: example-end find-if-env-predicate
+  //!     :start-after: example-begin find-if-predicate
+  //!     :end-before: example-end find-if-predicate
   //!
   //! .. literalinclude:: ../../../cub/test/catch2_test_device_find_env_api.cu
   //!     :language: c++

--- a/cub/test/catch2_test_device_find_env_api.cu
+++ b/cub/test/catch2_test_device_find_env_api.cu
@@ -14,7 +14,7 @@
 
 #include <c2h/catch2_test_helper.h>
 
-// example-begin find-if-env-predicate
+// example-begin find-if-predicate
 struct is_greater_than_t
 {
   int threshold;
@@ -23,7 +23,7 @@ struct is_greater_than_t
     return value > threshold;
   }
 };
-// example-end find-if-env-predicate
+// example-end find-if-predicate
 
 C2H_TEST("cub::DeviceFind::FindIf accepts env with stream", "[find][env]")
 {


### PR DESCRIPTION
env `cub::FindIf` docs example snippet show predicate twice instead of showing:

predicate
env-find-if snippet

see [link](https://nvidia.github.io/cccl/unstable/cub/api/structcub_1_1DeviceFind.html#_CPPv4I00000EN3cub10DeviceFind6FindIfE11cudaError_t14InputIteratorT15OutputIteratorT7ScanOpT9NumItemsT4EnvT)

i think this happens because the two snippets were sharing a common sub-string `find-if-env*`

@gevtushenko  thanks for the find

this should fix it