### PR TITLE
Add missing env Select::UniqueByKey overload and tests

### DIFF
--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -360,7 +360,13 @@ public:
     typename OutputIteratorT,
     typename NumSelectedIteratorT,
     typename NumItemsT,
-    typename EnvT                 = ::cuda::std::execution::env<>,
+    typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
+#ifdef _CCCL_DOXYGEN_INVOKED
+    void
+#else
+    ::cuda::std::execution::env<>
+#endif
+    ,
     ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<InputIteratorT, void*>
                                && !::cuda::std::is_same_v<FlagIterator, size_t&>,
                              int> = 0>
@@ -458,7 +464,13 @@ public:
             typename FlagIterator,
             typename NumSelectedIteratorT,
             typename NumItemsT,
-            typename EnvT                 = ::cuda::std::execution::env<>,
+            typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
+#ifdef _CCCL_DOXYGEN_INVOKED
+            void
+#else
+            ::cuda::std::execution::env<>
+#endif
+            ,
             ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<IteratorT, void*>
                                        && !::cuda::std::is_same_v<FlagIterator, size_t&>,
                                      int> = 0>
@@ -559,7 +571,13 @@ public:
     typename NumSelectedIteratorT,
     typename SelectOp,
     typename NumItemsT,
-    typename EnvT                 = ::cuda::std::execution::env<>,
+    typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
+#ifdef _CCCL_DOXYGEN_INVOKED
+    void
+#else
+    ::cuda::std::execution::env<>
+#endif
+    ,
     ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<InputIteratorT, void*>,
                              int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
@@ -649,13 +667,19 @@ public:
   //!
   //! @param[in] env
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
-  template <typename IteratorT,
-            typename NumSelectedIteratorT,
-            typename SelectOp,
-            typename NumItemsT,
-            typename EnvT                 = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<IteratorT, void*>,
-                                     int> = 0>
+  template <
+    typename IteratorT,
+    typename NumSelectedIteratorT,
+    typename SelectOp,
+    typename NumItemsT,
+    typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
+#ifdef _CCCL_DOXYGEN_INVOKED
+    void
+#else
+    ::cuda::std::execution::env<>
+#endif
+    ,
+    ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<IteratorT, void*>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
   If(IteratorT d_data, NumSelectedIteratorT d_num_selected_out, NumItemsT num_items, SelectOp select_op, EnvT env = {})
   {
@@ -1344,7 +1368,13 @@ public:
     typename NumSelectedIteratorT,
     typename SelectOp,
     typename NumItemsT,
-    typename EnvT                 = ::cuda::std::execution::env<>,
+    typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
+#ifdef _CCCL_DOXYGEN_INVOKED
+    void
+#else
+    ::cuda::std::execution::env<>
+#endif
+    ,
     ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<InputIteratorT, void*>,
                              int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t FlaggedIf(
@@ -1451,7 +1481,13 @@ public:
     typename NumSelectedIteratorT,
     typename SelectOp,
     typename NumItemsT,
-    typename EnvT = ::cuda::std::execution::env<>,
+    typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
+#ifdef _CCCL_DOXYGEN_INVOKED
+    void
+#else
+    ::cuda::std::execution::env<>
+#endif
+    ,
     ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<IteratorT, void*>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t FlaggedIf(
     IteratorT d_data,
@@ -1549,7 +1585,13 @@ public:
     typename OutputIteratorT,
     typename NumSelectedIteratorT,
     typename NumItemsT,
-    typename EnvT                 = ::cuda::std::execution::env<>,
+    typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
+#ifdef _CCCL_DOXYGEN_INVOKED
+    void
+#else
+    ::cuda::std::execution::env<>
+#endif
+    ,
     ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<InputIteratorT, void*>
                                && !::cuda::std::indirect_binary_predicate<EnvT, InputIteratorT, InputIteratorT>,
                              int> = 0>
@@ -1656,7 +1698,13 @@ public:
     typename NumSelectedIteratorT,
     typename NumItemsT,
     typename EqualityOpT,
-    typename EnvT                 = ::cuda::std::execution::env<>,
+    typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
+#ifdef _CCCL_DOXYGEN_INVOKED
+    void
+#else
+    ::cuda::std::execution::env<>
+#endif
+    ,
     ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<InputIteratorT, void*>
                                && ::cuda::std::indirect_binary_predicate<EqualityOpT, InputIteratorT, InputIteratorT>,
                              int> = 0>
@@ -1778,7 +1826,13 @@ public:
     typename NumSelectedIteratorT,
     typename NumItemsT,
     typename EqualityOpT,
-    typename EnvT                 = ::cuda::std::execution::env<>,
+    typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
+#ifdef _CCCL_DOXYGEN_INVOKED
+    void
+#else
+    ::cuda::std::execution::env<>
+#endif
+    ,
     ::cuda::std::enable_if_t<::cuda::std::indirect_binary_predicate<EqualityOpT, KeyInputIteratorT, KeyInputIteratorT>,
                              int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t UniqueByKey(
@@ -1894,7 +1948,13 @@ public:
     typename ValueOutputIteratorT,
     typename NumSelectedIteratorT,
     typename NumItemsT,
-    typename EnvT = ::cuda::std::execution::env<>,
+    typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
+#ifdef _CCCL_DOXYGEN_INVOKED
+    void
+#else
+    ::cuda::std::execution::env<>
+#endif
+    ,
     ::cuda::std::enable_if_t<!::cuda::std::indirect_binary_predicate<EnvT, KeyInputIteratorT, KeyInputIteratorT>, int> =
       0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t UniqueByKey(

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -1777,10 +1777,9 @@ public:
     typename ValueOutputIteratorT,
     typename NumSelectedIteratorT,
     typename NumItemsT,
-    typename EqualityOpT          = ::cuda::std::equal_to<>,
+    typename EqualityOpT,
     typename EnvT                 = ::cuda::std::execution::env<>,
-    ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<KeyInputIteratorT, void*>
-                               && !::cuda::std::is_convertible_v<EqualityOpT, cudaStream_t>,
+    ::cuda::std::enable_if_t<::cuda::std::indirect_binary_predicate<EqualityOpT, KeyInputIteratorT, KeyInputIteratorT>,
                              int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t UniqueByKey(
     KeyInputIteratorT d_keys_in,
@@ -1789,8 +1788,8 @@ public:
     ValueOutputIteratorT d_values_out,
     NumSelectedIteratorT d_num_selected_out,
     NumItemsT num_items,
-    EqualityOpT equality_op = {},
-    EnvT env                = {})
+    EqualityOpT equality_op,
+    EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSelect::UniqueByKey");
 
@@ -1807,6 +1806,121 @@ public:
         d_values_out,
         d_num_selected_out,
         equality_op,
+        static_cast<offset_t>(num_items),
+        stream);
+    });
+  }
+
+  //! @rst
+  //! Given an input sequence ``d_keys_in`` and ``d_values_in`` with runs of key-value pairs with consecutive
+  //! equal-valued keys, only the first key and its value from each run is selectively copied
+  //! to ``d_keys_out`` and ``d_values_out``.
+  //! The total number of items selected is written to ``d_num_selected_out``.
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! This is an environment-based API that allows customization of:
+  //!
+  //! - Stream: Query via ``cuda::get_stream``
+  //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
+  //!
+  //! - The ``==`` equality operator is used to determine whether keys are equivalent.
+  //! - Copies of the selected items are compacted into ``d_keys_out`` and ``d_values_out`` and maintain
+  //!   their original relative ordering.
+  //! - In-place operations are not supported. There must be no overlap between
+  //!   any of the provided ranges.
+  //!
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates the compaction of items selected from an ``int`` device vector
+  //! using environment-based API and default key equality:
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_select_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin select-uniquebykey-default-eq-env
+  //!     :end-before: example-end select-uniquebykey-default-eq-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam KeyInputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input keys @iterator
+  //!
+  //! @tparam ValueInputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input values @iterator
+  //!
+  //! @tparam KeyOutputIteratorT
+  //!   **[inferred]** Random-access output iterator type for writing selected keys @iterator
+  //!
+  //! @tparam ValueOutputIteratorT
+  //!   **[inferred]** Random-access output iterator type for writing selected values @iterator
+  //!
+  //! @tparam NumSelectedIteratorT
+  //!   **[inferred]** Output iterator type for recording the number of items selected @iterator
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., `cuda::std::execution::env<...>`)
+  //!
+  //! @param[in] d_keys_in
+  //!   Pointer to the input sequence of keys
+  //!
+  //! @param[in] d_values_in
+  //!   Pointer to the input sequence of values
+  //!
+  //! @param[out] d_keys_out
+  //!   Pointer to the output sequence of selected keys
+  //!
+  //! @param[out] d_values_out
+  //!   Pointer to the output sequence of selected values
+  //!
+  //! @param[out] d_num_selected_out
+  //!   Pointer to the total number of items selected (i.e., length of `d_keys_out` or `d_values_out`)
+  //!
+  //! @param[in] num_items
+  //!   Total number of input items (i.e., length of `d_keys_in` or `d_values_in`)
+  //!
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  template <
+    typename KeyInputIteratorT,
+    typename ValueInputIteratorT,
+    typename KeyOutputIteratorT,
+    typename ValueOutputIteratorT,
+    typename NumSelectedIteratorT,
+    typename NumItemsT,
+    typename EnvT = ::cuda::std::execution::env<>,
+    ::cuda::std::enable_if_t<!::cuda::std::indirect_binary_predicate<EnvT, KeyInputIteratorT, KeyInputIteratorT>, int> =
+      0>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t UniqueByKey(
+    KeyInputIteratorT d_keys_in,
+    ValueInputIteratorT d_values_in,
+    KeyOutputIteratorT d_keys_out,
+    ValueOutputIteratorT d_values_out,
+    NumSelectedIteratorT d_num_selected_out,
+    NumItemsT num_items,
+    EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSelect::UniqueByKey");
+
+    using offset_t = detail::choose_offset_t<NumItemsT>;
+
+    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
+      using tuning_t = decltype(tuning);
+      return unique_by_key_impl<tuning_t>(
+        storage,
+        bytes,
+        d_keys_in,
+        d_values_in,
+        d_keys_out,
+        d_values_out,
+        d_num_selected_out,
+        ::cuda::std::equal_to<>{},
         static_cast<offset_t>(num_items),
         stream);
     });

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -1818,23 +1818,24 @@ public:
   //!
   //! @param[in] env
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
-  template <
-    typename KeyInputIteratorT,
-    typename ValueInputIteratorT,
-    typename KeyOutputIteratorT,
-    typename ValueOutputIteratorT,
-    typename NumSelectedIteratorT,
-    typename NumItemsT,
-    typename EqualityOpT,
-    typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
+  template <typename KeyInputIteratorT,
+            typename ValueInputIteratorT,
+            typename KeyOutputIteratorT,
+            typename ValueOutputIteratorT,
+            typename NumSelectedIteratorT,
+            typename NumItemsT,
+            typename EqualityOpT,
+            typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
 #ifdef _CCCL_DOXYGEN_INVOKED
-    void
+            void
 #else
-    ::cuda::std::execution::env<>
+            ::cuda::std::execution::env<>
 #endif
-    ,
-    ::cuda::std::enable_if_t<::cuda::std::indirect_binary_predicate<EqualityOpT, KeyInputIteratorT, KeyInputIteratorT>,
-                             int> = 0>
+            ,
+            ::cuda::std::enable_if_t<
+              ::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<KeyInputIteratorT, void*>
+                && ::cuda::std::indirect_binary_predicate<EqualityOpT, KeyInputIteratorT, KeyInputIteratorT>,
+              int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t UniqueByKey(
     KeyInputIteratorT d_keys_in,
     ValueInputIteratorT d_values_in,
@@ -1955,8 +1956,9 @@ public:
     ::cuda::std::execution::env<>
 #endif
     ,
-    ::cuda::std::enable_if_t<!::cuda::std::indirect_binary_predicate<EnvT, KeyInputIteratorT, KeyInputIteratorT>, int> =
-      0>
+    ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<KeyInputIteratorT, void*>
+                               && !::cuda::std::indirect_binary_predicate<EnvT, KeyInputIteratorT, KeyInputIteratorT>,
+                             int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t UniqueByKey(
     KeyInputIteratorT d_keys_in,
     ValueInputIteratorT d_values_in,

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -1968,24 +1968,8 @@ public:
     NumItemsT num_items,
     EnvT env = {})
   {
-    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSelect::UniqueByKey");
-
-    using offset_t = detail::choose_offset_t<NumItemsT>;
-
-    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      using tuning_t = decltype(tuning);
-      return unique_by_key_impl<tuning_t>(
-        storage,
-        bytes,
-        d_keys_in,
-        d_values_in,
-        d_keys_out,
-        d_values_out,
-        d_num_selected_out,
-        ::cuda::std::equal_to<>{},
-        static_cast<offset_t>(num_items),
-        stream);
-    });
+    return UniqueByKey(
+      d_keys_in, d_values_in, d_keys_out, d_values_out, d_num_selected_out, num_items, ::cuda::std::equal_to<>{}, env);
   }
 
   //! @rst

--- a/cub/test/catch2_test_device_select_env.cu
+++ b/cub/test/catch2_test_device_select_env.cu
@@ -260,6 +260,42 @@ TEST_CASE("Device select unique_by_key works with default environment", "[select
   REQUIRE(d_values_out == expected_values);
 }
 
+TEST_CASE("Device select unique_by_key works with default environment and explicit env", "[select][device]")
+{
+  using value_t     = int;
+  using num_items_t = int;
+
+  num_items_t num_items = 8;
+  auto d_keys_in        = c2h::device_vector<value_t>{0, 2, 2, 9, 5, 5, 5, 8};
+  auto d_values_in      = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto d_keys_out       = c2h::device_vector<value_t>(num_items);
+  auto d_values_out     = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected   = c2h::device_vector<int>(1);
+
+  auto env = stdexec::env{};
+
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSelect::UniqueByKey(
+      d_keys_in.begin(),
+      d_values_in.begin(),
+      d_keys_out.begin(),
+      d_values_out.begin(),
+      d_num_selected.begin(),
+      num_items,
+      env));
+
+  c2h::device_vector<value_t> expected_keys{0, 2, 9, 5, 8};
+  c2h::device_vector<value_t> expected_values{1, 2, 4, 5, 8};
+  c2h::device_vector<int> expected_num_selected{5};
+
+  REQUIRE(d_num_selected == expected_num_selected);
+  d_keys_out.resize(d_num_selected[0]);
+  d_values_out.resize(d_num_selected[0]);
+  REQUIRE(d_keys_out == expected_keys);
+  REQUIRE(d_values_out == expected_values);
+}
+
 TEST_CASE("Device select unique_by_key default tuning chooses target block size", "[select][device]")
 {
   using num_items_t = int;
@@ -604,6 +640,53 @@ C2H_TEST("Device select unique_by_key uses environment", "[select][device]")
     d_num_selected.begin(),
     num_items,
     ::cuda::std::equal_to<>{},
+    env);
+
+  c2h::device_vector<value_t> expected_keys{1, 2, 3, 4, 5};
+  c2h::device_vector<value_t> expected_values{10, 20, 30, 40, 50};
+  c2h::device_vector<int> expected_num_selected{5};
+
+  REQUIRE(d_num_selected == expected_num_selected);
+  d_keys_out.resize(d_num_selected[0]);
+  d_values_out.resize(d_num_selected[0]);
+  REQUIRE(d_keys_out == expected_keys);
+  REQUIRE(d_values_out == expected_values);
+}
+
+C2H_TEST("Device select unique_by_key uses environment without equality_op", "[select][device]")
+{
+  using value_t     = int;
+  using num_items_t = int;
+
+  num_items_t num_items = 10;
+  auto d_keys_in        = c2h::device_vector<value_t>{1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
+  auto d_values_in      = c2h::device_vector<value_t>{10, 11, 20, 21, 30, 31, 40, 41, 50, 51};
+  auto d_keys_out       = c2h::device_vector<value_t>(num_items);
+  auto d_values_out     = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected   = c2h::device_vector<int>(1);
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSelect::UniqueByKey(
+      nullptr,
+      expected_bytes_allocated,
+      d_keys_in.begin(),
+      d_values_in.begin(),
+      d_keys_out.begin(),
+      d_values_out.begin(),
+      d_num_selected.begin(),
+      num_items));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_select_unique_by_key(
+    d_keys_in.begin(),
+    d_values_in.begin(),
+    d_keys_out.begin(),
+    d_values_out.begin(),
+    d_num_selected.begin(),
+    num_items,
     env);
 
   c2h::device_vector<value_t> expected_keys{1, 2, 3, 4, 5};

--- a/cub/test/catch2_test_device_select_env_api.cu
+++ b/cub/test/catch2_test_device_select_env_api.cu
@@ -278,3 +278,63 @@ C2H_TEST("cub::DeviceSelect::UniqueByKey accepts env with stream", "[select][env
   REQUIRE(values_out == expected_values);
   REQUIRE(num_selected == expected_num_selected);
 }
+
+C2H_TEST("cub::DeviceSelect::UniqueByKey accepts env with stream without equality_op", "[select][env]")
+{
+  // example-begin select-uniquebykey-default-eq-env
+  // Same setup/expectations as the explicit equality_op test above, but relying on default equality.
+  auto keys_in      = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
+  auto values_in    = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto keys_out     = thrust::device_vector<int>(5);
+  auto values_out   = thrust::device_vector<int>(5);
+  auto num_selected = thrust::device_vector<int>(1);
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+  auto env = cuda::std::execution::env{stream_ref};
+
+  auto error = cub::DeviceSelect::UniqueByKey(
+    keys_in.begin(), values_in.begin(), keys_out.begin(), values_out.begin(), num_selected.begin(), keys_in.size(), env);
+
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceSelect::UniqueByKey without equality_op failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
+  thrust::device_vector<int> expected_values{1, 2, 4, 5, 8};
+  thrust::device_vector<int> expected_num_selected{5};
+  // example-end select-uniquebykey-default-eq-env
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(keys_out == expected_keys);
+  REQUIRE(values_out == expected_values);
+  REQUIRE(num_selected == expected_num_selected);
+}
+
+C2H_TEST("cub::DeviceSelect::UniqueByKey accepts default env without equality_op", "[select][env]")
+{
+  // Same expectations as other UniqueByKey tests, but call the 6-arg overload.
+  auto keys_in      = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
+  auto values_in    = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto keys_out     = thrust::device_vector<int>(5);
+  auto values_out   = thrust::device_vector<int>(5);
+  auto num_selected = thrust::device_vector<int>(1);
+
+  auto error = cub::DeviceSelect::UniqueByKey(
+    keys_in.begin(), values_in.begin(), keys_out.begin(), values_out.begin(), num_selected.begin(), keys_in.size());
+
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceSelect::UniqueByKey with default env failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
+  thrust::device_vector<int> expected_values{1, 2, 4, 5, 8};
+  thrust::device_vector<int> expected_num_selected{5};
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(keys_out == expected_keys);
+  REQUIRE(values_out == expected_values);
+  REQUIRE(num_selected == expected_num_selected);
+}


### PR DESCRIPTION
solving #8633 I found that there is a missing env overload, it's the one that has `EquialityOp` defaulted.

This solves ambiguity and adds the overload

**Ambiguities analysis beteween all UniqueByKey overloads (env and non-env) and how they separate:**

  1. 6 args (..., num_items)

  - only env-no-equality overload can match.

  2. 7 args (..., num_items, X)

  - env-with-equality matches iff X is an indirect_binary_predicate.
  - env-no-equality matches iff X is not.
  - mutually exclusive.

  3. 8 args **<--- most dangerous one**

  - overlap region is env-with-equality vs non-env-no-equality.
  - I tested the dangerous shape; compiler picks one (usually env if arg1 isn’t void* exactly), not ambiguous.

  4. 9 args

  - non-env-no-equality (with stream arg) vs non-env-with-equality (without stream arg).
  - disambiguated by `is_convertible_v<arg9, cudaStream_t>` gate.

  5. 10 args

  - only non-env-with-equality.
