### PR TITLE
feat(thrust): mark complex<> members constexpr where safe

### DIFF
--- a/thrust/testing/catch2_test_complex.cu
+++ b/thrust/testing/catch2_test_complex.cu
@@ -689,3 +689,170 @@ TEMPLATE_LIST_TEST_CASE("ComplexExplicitConstruction", "[complex]", FloatingPoin
   const thrust::complex<T> input(42.0, 1337.0);
   [[maybe_unused]] const user_complex result = thrust::exp(input);
 }
+
+// Compile-time tests for thrust::complex (issue #485). These exercise the
+// constexpr-marked constructors, accessors, arithmetic operators and equality
+// operators of thrust::complex<T> via static_assert. They are independent of
+// the runtime test cases above and run at compile time only.
+namespace
+{
+template <typename T>
+constexpr bool test_complex_constexpr_construction()
+{
+  using C = thrust::complex<T>;
+
+  // Default construction zero-initializes.
+  static_assert(C().real() == T(0), "default ctor real");
+  static_assert(C().imag() == T(0), "default ctor imag");
+
+  // Construct from real only.
+  static_assert(C(T(2)).real() == T(2), "ctor(real)");
+  static_assert(C(T(2)).imag() == T(0), "ctor(real) imag is zero");
+
+  // Construct from real and imag.
+  static_assert(C(T(1), T(2)).real() == T(1), "ctor(real, imag) real");
+  static_assert(C(T(1), T(2)).imag() == T(2), "ctor(real, imag) imag");
+
+  // Copy and converting copy.
+  static_assert(C(C(T(3), T(4))).real() == T(3), "copy ctor real");
+  static_assert(C(C(T(3), T(4))).imag() == T(4), "copy ctor imag");
+  return true;
+}
+
+template <typename T>
+constexpr bool test_complex_constexpr_arithmetic()
+{
+  using C = thrust::complex<T>;
+
+  // Binary +, -, * with two complex operands.
+  static_assert((C(T(1), T(2)) + C(T(3), T(4))).real() == T(4), "operator+ real");
+  static_assert((C(T(1), T(2)) + C(T(3), T(4))).imag() == T(6), "operator+ imag");
+  static_assert((C(T(5), T(6)) - C(T(1), T(2))).real() == T(4), "operator- real");
+  static_assert((C(T(5), T(6)) - C(T(1), T(2))).imag() == T(4), "operator- imag");
+  // (1+2i)(3+4i) = (1*3 - 2*4) + (1*4 + 2*3)i = -5 + 10i
+  static_assert((C(T(1), T(2)) * C(T(3), T(4))).real() == T(-5), "operator* real");
+  static_assert((C(T(1), T(2)) * C(T(3), T(4))).imag() == T(10), "operator* imag");
+
+  // Mixed scalar/complex operands.
+  static_assert((C(T(1), T(2)) + T(1)).real() == T(2), "operator+ scalar rhs");
+  static_assert((T(1) + C(T(1), T(2))).real() == T(2), "operator+ scalar lhs");
+  static_assert((C(T(2), T(4)) * T(2)).real() == T(4), "operator* scalar rhs");
+  static_assert((T(2) * C(T(2), T(4))).imag() == T(8), "operator* scalar lhs");
+  static_assert((C(T(4), T(8)) / T(2)).real() == T(2), "operator/ scalar rhs");
+  static_assert((C(T(4), T(8)) / T(2)).imag() == T(4), "operator/ scalar rhs imag");
+
+  // Complex / complex (the hardest one to keep constexpr-friendly).
+  static_assert((C(T(1), T(0)) / C(T(1), T(0))).real() == T(1), "complex/complex");
+
+  // Unary + and -.
+  static_assert((+C(T(1), T(2))).real() == T(1), "unary plus real");
+  static_assert((+C(T(1), T(2))).imag() == T(2), "unary plus imag");
+  static_assert((-C(T(1), T(2))).real() == T(-1), "unary minus real");
+  static_assert((-C(T(1), T(2))).imag() == T(-2), "unary minus imag");
+
+  // conj is constexpr.
+  static_assert(thrust::conj(C(T(1), T(2))).real() == T(1), "conj real");
+  static_assert(thrust::conj(C(T(1), T(2))).imag() == T(-2), "conj imag");
+
+  return true;
+}
+
+template <typename T>
+constexpr bool test_complex_constexpr_equality()
+{
+  using C = thrust::complex<T>;
+
+  static_assert(C(T(1), T(2)) == C(T(1), T(2)), "operator== same");
+  static_assert(C(T(1), T(2)) != C(T(3), T(4)), "operator!= different");
+  static_assert(C(T(5), T(0)) == T(5), "operator== complex/scalar");
+  static_assert(T(5) == C(T(5), T(0)), "operator== scalar/complex");
+  static_assert(C(T(5), T(1)) != T(5), "operator!= complex/scalar (imag != 0)");
+  static_assert(T(5) != C(T(6), T(0)), "operator!= scalar/complex");
+
+  return true;
+}
+
+template <typename T>
+constexpr bool test_complex_constexpr_compound_assignment()
+{
+  using C = thrust::complex<T>;
+
+  // The compound assignment operators mutate state; exercise them inside
+  // a constexpr function so we can verify the final value via static_assert.
+  C v(T(1), T(2));
+  v += C(T(3), T(4));
+  if (v.real() != T(4) || v.imag() != T(6))
+  {
+    return false;
+  }
+
+  v -= C(T(3), T(4));
+  if (v.real() != T(1) || v.imag() != T(2))
+  {
+    return false;
+  }
+
+  v *= C(T(3), T(4));
+  // (1+2i)(3+4i) = -5 + 10i
+  if (v.real() != T(-5) || v.imag() != T(10))
+  {
+    return false;
+  }
+
+  // Scalar compound assignments.
+  C s(T(2), T(4));
+  s += T(1);
+  if (s.real() != T(3) || s.imag() != T(4))
+  {
+    return false;
+  }
+  s *= T(2);
+  if (s.real() != T(6) || s.imag() != T(8))
+  {
+    return false;
+  }
+  s /= T(2);
+  if (s.real() != T(3) || s.imag() != T(4))
+  {
+    return false;
+  }
+
+  return true;
+}
+
+template <typename T>
+constexpr bool test_complex_constexpr_setters()
+{
+  using C = thrust::complex<T>;
+  C v;
+  v.real(T(5));
+  v.imag(T(7));
+  return v.real() == T(5) && v.imag() == T(7);
+}
+
+// Force evaluation of the static_asserts inside the helpers above, for both
+// float and double, at compile time.
+static_assert(test_complex_constexpr_construction<float>(), "");
+static_assert(test_complex_constexpr_construction<double>(), "");
+static_assert(test_complex_constexpr_arithmetic<float>(), "");
+static_assert(test_complex_constexpr_arithmetic<double>(), "");
+static_assert(test_complex_constexpr_equality<float>(), "");
+static_assert(test_complex_constexpr_equality<double>(), "");
+static_assert(test_complex_constexpr_compound_assignment<float>(), "");
+static_assert(test_complex_constexpr_compound_assignment<double>(), "");
+static_assert(test_complex_constexpr_setters<float>(), "");
+static_assert(test_complex_constexpr_setters<double>(), "");
+} // anonymous namespace
+
+TEMPLATE_LIST_TEST_CASE("ComplexConstexpr", "[complex]", FloatingPointTypes)
+{
+  // The actual checks are static_asserts at namespace scope above; this
+  // runtime case exists so the test binary records that the constexpr
+  // checks were exercised for each floating point type.
+  using T = TestType;
+  STATIC_REQUIRE(test_complex_constexpr_construction<T>());
+  STATIC_REQUIRE(test_complex_constexpr_arithmetic<T>());
+  STATIC_REQUIRE(test_complex_constexpr_equality<T>());
+  STATIC_REQUIRE(test_complex_constexpr_compound_assignment<T>());
+  STATIC_REQUIRE(test_complex_constexpr_setters<T>());
+}

--- a/thrust/thrust/complex.h
+++ b/thrust/thrust/complex.h
@@ -81,7 +81,7 @@ public:
    *     .. versionadded:: 2.2.0
    *  \endverbatim
    */
-  _CCCL_HOST_DEVICE complex(const T& re);
+  _CCCL_HOST_DEVICE constexpr complex(const T& re);
 
   /*! Construct a complex number from its real and imaginary parts.
    *
@@ -92,7 +92,7 @@ public:
    *     .. versionadded:: 2.2.0
    *  \endverbatim
    */
-  _CCCL_HOST_DEVICE complex(const T& re, const T& im);
+  _CCCL_HOST_DEVICE constexpr complex(const T& re, const T& im);
 
   /*! Default construct a complex number.
    */
@@ -117,7 +117,7 @@ public:
    *  \endverbatim
    */
   template <typename U>
-  _CCCL_HOST_DEVICE complex(const complex<U>& z);
+  _CCCL_HOST_DEVICE constexpr complex(const complex<U>& z);
 
 #if _CCCL_HOSTED()
   /*! This converting copy constructor copies from a <tt>std::complex</tt> with
@@ -157,7 +157,7 @@ public:
    *     .. versionadded:: 2.2.0
    *  \endverbatim
    */
-  _CCCL_HOST_DEVICE complex& operator=(const T& re);
+  _CCCL_HOST_DEVICE constexpr complex& operator=(const T& re);
 
   /*! Assign `z.real()` and `z.imag()` to the real and imaginary parts of this
    *  \p complex respectively.
@@ -178,7 +178,7 @@ public:
    *  \endverbatim
    */
   template <typename U>
-  _CCCL_HOST_DEVICE complex& operator=(const complex<U>& z);
+  _CCCL_HOST_DEVICE constexpr complex& operator=(const complex<U>& z);
 
 #if _CCCL_HOSTED()
   /*! Assign `z.real()` and `z.imag()` to the real and imaginary parts of this
@@ -221,7 +221,7 @@ public:
    *  \endverbatim
    */
   template <typename U>
-  _CCCL_HOST_DEVICE complex<T>& operator+=(const complex<U>& z);
+  _CCCL_HOST_DEVICE constexpr complex<T>& operator+=(const complex<U>& z);
 
   /*! Subtracts a \p complex from this \p complex and assigns the result to
    *  this \p complex.
@@ -235,7 +235,7 @@ public:
    *  \endverbatim
    */
   template <typename U>
-  _CCCL_HOST_DEVICE complex<T>& operator-=(const complex<U>& z);
+  _CCCL_HOST_DEVICE constexpr complex<T>& operator-=(const complex<U>& z);
 
   /*! Multiplies this \p complex by another \p complex and assigns the result
    *  to this \p complex.
@@ -249,7 +249,7 @@ public:
    *  \endverbatim
    */
   template <typename U>
-  _CCCL_HOST_DEVICE complex<T>& operator*=(const complex<U>& z);
+  _CCCL_HOST_DEVICE constexpr complex<T>& operator*=(const complex<U>& z);
 
   /*! Divides this \p complex by another \p complex and assigns the result to
    *  this \p complex.
@@ -263,7 +263,7 @@ public:
    *  \endverbatim
    */
   template <typename U>
-  _CCCL_HOST_DEVICE complex<T>& operator/=(const complex<U>& z);
+  _CCCL_HOST_DEVICE constexpr complex<T>& operator/=(const complex<U>& z);
 
   /*! Adds a scalar to this \p complex and assigns the result to this
    *  \p complex.
@@ -277,7 +277,7 @@ public:
    *  \endverbatim
    */
   template <typename U>
-  _CCCL_HOST_DEVICE complex<T>& operator+=(const U& z);
+  _CCCL_HOST_DEVICE constexpr complex<T>& operator+=(const U& z);
 
   /*! Subtracts a scalar from this \p complex and assigns the result to
    *  this \p complex.
@@ -291,7 +291,7 @@ public:
    *  \endverbatim
    */
   template <typename U>
-  _CCCL_HOST_DEVICE complex<T>& operator-=(const U& z);
+  _CCCL_HOST_DEVICE constexpr complex<T>& operator-=(const U& z);
 
   /*! Multiplies this \p complex by a scalar and assigns the result
    *  to this \p complex.
@@ -305,7 +305,7 @@ public:
    *  \endverbatim
    */
   template <typename U>
-  _CCCL_HOST_DEVICE complex<T>& operator*=(const U& z);
+  _CCCL_HOST_DEVICE constexpr complex<T>& operator*=(const U& z);
 
   /*! Divides this \p complex by a scalar and assigns the result to
    *  this \p complex.
@@ -319,7 +319,7 @@ public:
    *  \endverbatim
    */
   template <typename U>
-  _CCCL_HOST_DEVICE complex<T>& operator/=(const U& z);
+  _CCCL_HOST_DEVICE constexpr complex<T>& operator/=(const U& z);
 
   /* --- Getter functions ---
    * The volatile ones are there to help for example
@@ -358,7 +358,7 @@ public:
    *     .. versionadded:: 2.2.0
    *  \endverbatim
    */
-  _CCCL_HOST_DEVICE T real() const
+  _CCCL_HOST_DEVICE constexpr T real() const
   {
     return data.x;
   }
@@ -369,7 +369,7 @@ public:
    *     .. versionadded:: 2.2.0
    *  \endverbatim
    */
-  _CCCL_HOST_DEVICE T imag() const
+  _CCCL_HOST_DEVICE constexpr T imag() const
   {
     return data.y;
   }
@@ -413,7 +413,7 @@ public:
    *     .. versionadded:: 2.2.0
    *  \endverbatim
    */
-  _CCCL_HOST_DEVICE void real(T re)
+  _CCCL_HOST_DEVICE constexpr void real(T re)
   {
     data.x = re;
   }
@@ -426,7 +426,7 @@ public:
    *     .. versionadded:: 2.2.0
    *  \endverbatim
    */
-  _CCCL_HOST_DEVICE void imag(T im)
+  _CCCL_HOST_DEVICE constexpr void imag(T im)
   {
     data.y = im;
   }
@@ -449,8 +449,11 @@ public:
 private:
   struct alignas(sizeof(T) * 2) storage
   {
-    T x;
-    T y;
+    // Default-initialize so the implicitly defaulted complex<T> default
+    // constructor is constexpr (data members must have a constant
+    // initializer for the default constructor to be a constant expression).
+    T x{};
+    T y{};
   };
   storage data;
 };
@@ -499,7 +502,7 @@ _CCCL_HOST_DEVICE T norm(const complex<T>& z);
  *  \endverbatim
  */
 template <typename T>
-_CCCL_HOST_DEVICE complex<T> conj(const complex<T>& z);
+_CCCL_HOST_DEVICE constexpr complex<T> conj(const complex<T>& z);
 
 /*! Returns a \p complex with the specified magnitude and phase.
  *
@@ -542,7 +545,8 @@ _CCCL_HOST_DEVICE complex<T> proj(const T& z);
  *  \endverbatim
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator+(const complex<T0>& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>>
+operator+(const complex<T0>& x, const complex<T1>& y);
 
 /*! Adds a scalar to a \p complex number.
  *
@@ -557,7 +561,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator+(const co
  *  \endverbatim
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator+(const complex<T0>& x, const T1& y);
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>> operator+(const complex<T0>& x, const T1& y);
 
 /*! Adds a \p complex number to a scalar.
  *
@@ -572,7 +576,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator+(const co
  *  \endverbatim
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator+(const T0& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>> operator+(const T0& x, const complex<T1>& y);
 
 /*! Subtracts two \p complex numbers.
  *
@@ -587,7 +591,8 @@ _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator+(const T0
  *  \endverbatim
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator-(const complex<T0>& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>>
+operator-(const complex<T0>& x, const complex<T1>& y);
 
 /*! Subtracts a scalar from a \p complex number.
  *
@@ -602,7 +607,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator-(const co
  *  \endverbatim
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator-(const complex<T0>& x, const T1& y);
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>> operator-(const complex<T0>& x, const T1& y);
 
 /*! Subtracts a \p complex number from a scalar.
  *
@@ -617,7 +622,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator-(const co
  *  \endverbatim
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator-(const T0& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>> operator-(const T0& x, const complex<T1>& y);
 
 /*! Multiplies two \p complex numbers.
  *
@@ -632,7 +637,8 @@ _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator-(const T0
  *  \endverbatim
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const complex<T0>& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>>
+operator*(const complex<T0>& x, const complex<T1>& y);
 
 /*! Multiplies a \p complex number by a scalar.
  *
@@ -644,7 +650,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const co
  *  \endverbatim
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const complex<T0>& x, const T1& y);
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>> operator*(const complex<T0>& x, const T1& y);
 
 /*! Multiplies a scalar by a \p complex number.
  *
@@ -659,7 +665,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const co
  *  \endverbatim
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const T0& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>> operator*(const T0& x, const complex<T1>& y);
 
 /*! Divides two \p complex numbers.
  *
@@ -674,7 +680,8 @@ _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const T0
  *  \endverbatim
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const complex<T0>& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>>
+operator/(const complex<T0>& x, const complex<T1>& y);
 
 /*! Divides a \p complex number by a scalar.
  *
@@ -689,7 +696,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const co
  *  \endverbatim
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const complex<T0>& x, const T1& y);
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>> operator/(const complex<T0>& x, const T1& y);
 
 /*! Divides a scalar by a \p complex number.
  *
@@ -704,7 +711,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const co
  *  \endverbatim
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const T0& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>> operator/(const T0& x, const complex<T1>& y);
 
 /* --- Unary Arithmetic operators --- */
 
@@ -717,7 +724,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const T0
  *  \endverbatim
  */
 template <typename T>
-_CCCL_HOST_DEVICE complex<T> operator+(const complex<T>& y);
+_CCCL_HOST_DEVICE constexpr complex<T> operator+(const complex<T>& y);
 
 /*! Unary minus, returns the additive inverse (negation) of its \p complex
  * argument.
@@ -729,7 +736,7 @@ _CCCL_HOST_DEVICE complex<T> operator+(const complex<T>& y);
  *  \endverbatim
  */
 template <typename T>
-_CCCL_HOST_DEVICE complex<T> operator-(const complex<T>& y);
+_CCCL_HOST_DEVICE constexpr complex<T> operator-(const complex<T>& y);
 
 /* --- Exponential Functions --- */
 
@@ -1029,7 +1036,7 @@ _CCCL_HOST ::std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<Ch
  *  \endverbatim
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE bool operator==(const complex<T0>& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE constexpr bool operator==(const complex<T0>& x, const complex<T1>& y);
 
 #if _CCCL_HOSTED()
 /*! Returns true if two \p complex numbers are equal and false otherwise.
@@ -1068,7 +1075,7 @@ _CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator==(const ::std::complex<T0>& x
  *  \endverbatim
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE bool operator==(const T0& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE constexpr bool operator==(const T0& x, const complex<T1>& y);
 
 /*! Returns true if the imaginary part of the \p complex number is zero and
  *  the real part is equal to the scalar. Returns false otherwise.
@@ -1081,7 +1088,7 @@ _CCCL_HOST_DEVICE bool operator==(const T0& x, const complex<T1>& y);
  *  \endverbatim
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE bool operator==(const complex<T0>& x, const T1& y);
+_CCCL_HOST_DEVICE constexpr bool operator==(const complex<T0>& x, const T1& y);
 
 /*! Returns true if two \p complex numbers are different and false otherwise.
  *
@@ -1093,7 +1100,7 @@ _CCCL_HOST_DEVICE bool operator==(const complex<T0>& x, const T1& y);
  *  \endverbatim
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE bool operator!=(const complex<T0>& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE constexpr bool operator!=(const complex<T0>& x, const complex<T1>& y);
 
 #if _CCCL_HOSTED()
 /*! Returns true if two \p complex numbers are different and false otherwise.
@@ -1132,7 +1139,7 @@ _CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator!=(const ::std::complex<T0>& x
  *  \endverbatim
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE bool operator!=(const T0& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE constexpr bool operator!=(const T0& x, const complex<T1>& y);
 
 /*! Returns true if the imaginary part of the \p complex number is not zero or
  *  the real part is different from the scalar. Returns false otherwise.
@@ -1145,7 +1152,7 @@ _CCCL_HOST_DEVICE bool operator!=(const T0& x, const complex<T1>& y);
  *  \endverbatim
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE bool operator!=(const complex<T0>& x, const T1& y);
+_CCCL_HOST_DEVICE constexpr bool operator!=(const complex<T0>& x, const T1& y);
 
 /*!
  * \} end group complex_numbers

--- a/thrust/thrust/detail/complex/arithmetic.h
+++ b/thrust/thrust/detail/complex/arithmetic.h
@@ -20,70 +20,74 @@ THRUST_NAMESPACE_BEGIN
 /* --- Binary Arithmetic Operators --- */
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator+(const complex<T0>& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>>
+operator+(const complex<T0>& x, const complex<T1>& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x.real() + y.real(), x.imag() + y.imag());
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator+(const complex<T0>& x, const T1& y)
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>> operator+(const complex<T0>& x, const T1& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x.real() + y, x.imag());
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator+(const T0& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>> operator+(const T0& x, const complex<T1>& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x + y.real(), y.imag());
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator-(const complex<T0>& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>>
+operator-(const complex<T0>& x, const complex<T1>& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x.real() - y.real(), x.imag() - y.imag());
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator-(const complex<T0>& x, const T1& y)
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>> operator-(const complex<T0>& x, const T1& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x.real() - y, x.imag());
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator-(const T0& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>> operator-(const T0& x, const complex<T1>& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x - y.real(), -y.imag());
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const complex<T0>& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>>
+operator*(const complex<T0>& x, const complex<T1>& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x.real() * y.real() - x.imag() * y.imag(), x.real() * y.imag() + x.imag() * y.real());
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const complex<T0>& x, const T1& y)
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>> operator*(const complex<T0>& x, const T1& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x.real() * y, x.imag() * y);
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const T0& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>> operator*(const T0& x, const complex<T1>& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x * y.real(), x * y.imag());
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const complex<T0>& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>>
+operator/(const complex<T0>& x, const complex<T1>& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
   T s     = ::cuda::std::abs(y.real()) + ::cuda::std::abs(y.imag());
@@ -104,14 +108,14 @@ _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const co
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const complex<T0>& x, const T1& y)
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>> operator/(const complex<T0>& x, const T1& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x.real() / y, x.imag() / y);
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const T0& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE constexpr complex<::cuda::std::common_type_t<T0, T1>> operator/(const T0& x, const complex<T1>& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x) / y;
@@ -120,13 +124,13 @@ _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const T0
 /* --- Unary Arithmetic Operators --- */
 
 template <typename T>
-_CCCL_HOST_DEVICE complex<T> operator+(const complex<T>& y)
+_CCCL_HOST_DEVICE constexpr complex<T> operator+(const complex<T>& y)
 {
   return y;
 }
 
 template <typename T>
-_CCCL_HOST_DEVICE complex<T> operator-(const complex<T>& y)
+_CCCL_HOST_DEVICE constexpr complex<T> operator-(const complex<T>& y)
 {
   return y * -T(1);
 }
@@ -147,7 +151,7 @@ _CCCL_HOST_DEVICE T arg(const complex<T>& z)
 }
 
 template <typename T>
-_CCCL_HOST_DEVICE complex<T> conj(const complex<T>& z)
+_CCCL_HOST_DEVICE constexpr complex<T> conj(const complex<T>& z)
 {
   return complex<T>(z.real(), -z.imag());
 }

--- a/thrust/thrust/detail/complex/complex.inl
+++ b/thrust/thrust/detail/complex/complex.inl
@@ -14,14 +14,14 @@ THRUST_NAMESPACE_BEGIN
 /* --- Constructors --- */
 
 template <typename T>
-_CCCL_HOST_DEVICE complex<T>::complex(const T& re)
+_CCCL_HOST_DEVICE constexpr complex<T>::complex(const T& re)
     // Initialize the storage in the member initializer list using C++ unicorn
     // initialization. This allows `complex<T const>` to work.
     : data{re, T()}
 {}
 
 template <typename T>
-_CCCL_HOST_DEVICE complex<T>::complex(const T& re, const T& im)
+_CCCL_HOST_DEVICE constexpr complex<T>::complex(const T& re, const T& im)
     // Initialize the storage in the member initializer list using C++ unicorn
     // initialization. This allows `complex<T const>` to work.
     : data{re, im}
@@ -29,7 +29,7 @@ _CCCL_HOST_DEVICE complex<T>::complex(const T& re, const T& im)
 
 template <typename T>
 template <typename U>
-_CCCL_HOST_DEVICE complex<T>::complex(const complex<U>& z)
+_CCCL_HOST_DEVICE constexpr complex<T>::complex(const complex<U>& z)
     // Initialize the storage in the member initializer list using C++ unicorn
     // initialization. This allows `complex<T const>` to work.
     // We do a functional-style cast here to suppress conversion warnings.
@@ -57,7 +57,7 @@ _CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex<T>::complex(const ::std::complex<U>
 /* --- Assignment Operators --- */
 
 template <typename T>
-_CCCL_HOST_DEVICE complex<T>& complex<T>::operator=(const T& re)
+_CCCL_HOST_DEVICE constexpr complex<T>& complex<T>::operator=(const T& re)
 {
   real(re);
   imag(T());
@@ -66,7 +66,7 @@ _CCCL_HOST_DEVICE complex<T>& complex<T>::operator=(const T& re)
 
 template <typename T>
 template <typename U>
-_CCCL_HOST_DEVICE complex<T>& complex<T>::operator=(const complex<U>& z)
+_CCCL_HOST_DEVICE constexpr complex<T>& complex<T>::operator=(const complex<U>& z)
 {
   real(T(z.real()));
   imag(T(z.imag()));
@@ -96,7 +96,7 @@ _CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex<T>& complex<T>::operator=(const ::s
 
 template <typename T>
 template <typename U>
-_CCCL_HOST_DEVICE complex<T>& complex<T>::operator+=(const complex<U>& z)
+_CCCL_HOST_DEVICE constexpr complex<T>& complex<T>::operator+=(const complex<U>& z)
 {
   *this = *this + z;
   return *this;
@@ -104,7 +104,7 @@ _CCCL_HOST_DEVICE complex<T>& complex<T>::operator+=(const complex<U>& z)
 
 template <typename T>
 template <typename U>
-_CCCL_HOST_DEVICE complex<T>& complex<T>::operator-=(const complex<U>& z)
+_CCCL_HOST_DEVICE constexpr complex<T>& complex<T>::operator-=(const complex<U>& z)
 {
   *this = *this - z;
   return *this;
@@ -112,7 +112,7 @@ _CCCL_HOST_DEVICE complex<T>& complex<T>::operator-=(const complex<U>& z)
 
 template <typename T>
 template <typename U>
-_CCCL_HOST_DEVICE complex<T>& complex<T>::operator*=(const complex<U>& z)
+_CCCL_HOST_DEVICE constexpr complex<T>& complex<T>::operator*=(const complex<U>& z)
 {
   *this = *this * z;
   return *this;
@@ -120,7 +120,7 @@ _CCCL_HOST_DEVICE complex<T>& complex<T>::operator*=(const complex<U>& z)
 
 template <typename T>
 template <typename U>
-_CCCL_HOST_DEVICE complex<T>& complex<T>::operator/=(const complex<U>& z)
+_CCCL_HOST_DEVICE constexpr complex<T>& complex<T>::operator/=(const complex<U>& z)
 {
   *this = *this / z;
   return *this;
@@ -128,7 +128,7 @@ _CCCL_HOST_DEVICE complex<T>& complex<T>::operator/=(const complex<U>& z)
 
 template <typename T>
 template <typename U>
-_CCCL_HOST_DEVICE complex<T>& complex<T>::operator+=(const U& z)
+_CCCL_HOST_DEVICE constexpr complex<T>& complex<T>::operator+=(const U& z)
 {
   *this = *this + z;
   return *this;
@@ -136,7 +136,7 @@ _CCCL_HOST_DEVICE complex<T>& complex<T>::operator+=(const U& z)
 
 template <typename T>
 template <typename U>
-_CCCL_HOST_DEVICE complex<T>& complex<T>::operator-=(const U& z)
+_CCCL_HOST_DEVICE constexpr complex<T>& complex<T>::operator-=(const U& z)
 {
   *this = *this - z;
   return *this;
@@ -144,7 +144,7 @@ _CCCL_HOST_DEVICE complex<T>& complex<T>::operator-=(const U& z)
 
 template <typename T>
 template <typename U>
-_CCCL_HOST_DEVICE complex<T>& complex<T>::operator*=(const U& z)
+_CCCL_HOST_DEVICE constexpr complex<T>& complex<T>::operator*=(const U& z)
 {
   *this = *this * z;
   return *this;
@@ -152,7 +152,7 @@ _CCCL_HOST_DEVICE complex<T>& complex<T>::operator*=(const U& z)
 
 template <typename T>
 template <typename U>
-_CCCL_HOST_DEVICE complex<T>& complex<T>::operator/=(const U& z)
+_CCCL_HOST_DEVICE constexpr complex<T>& complex<T>::operator/=(const U& z)
 {
   *this = *this / z;
   return *this;
@@ -161,7 +161,7 @@ _CCCL_HOST_DEVICE complex<T>& complex<T>::operator/=(const U& z)
 /* --- Equality Operators --- */
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE bool operator==(const complex<T0>& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE constexpr bool operator==(const complex<T0>& x, const complex<T1>& y)
 {
   return x.real() == y.real() && x.imag() == y.imag();
 }
@@ -181,19 +181,19 @@ _CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator==(const ::std::complex<T0>& x
 #endif // _CCCL_HOSTED()
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE bool operator==(const T0& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE constexpr bool operator==(const T0& x, const complex<T1>& y)
 {
   return x == y.real() && y.imag() == T1();
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE bool operator==(const complex<T0>& x, const T1& y)
+_CCCL_HOST_DEVICE constexpr bool operator==(const complex<T0>& x, const T1& y)
 {
   return x.real() == y && x.imag() == T1();
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE bool operator!=(const complex<T0>& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE constexpr bool operator!=(const complex<T0>& x, const complex<T1>& y)
 {
   return !(x == y);
 }
@@ -213,13 +213,13 @@ _CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator!=(const ::std::complex<T0>& x
 #endif // _CCCL_HOSTED()
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE bool operator!=(const T0& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE constexpr bool operator!=(const T0& x, const complex<T1>& y)
 {
   return !(x == y);
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE bool operator!=(const complex<T0>& x, const T1& y)
+_CCCL_HOST_DEVICE constexpr bool operator!=(const complex<T0>& x, const T1& y)
 {
   return !(x == y);
 }


### PR DESCRIPTION
## Summary
Closes #485. Marks `thrust::complex` constructors, accessors, arithmetic and equality operators `constexpr` where the bodies are constexpr-correct (skipping `abs/arg/norm/polar` which pull in non-constexpr math). Storage now uses default-member-initializers so the defaulted `complex<T>` ctor is itself a constant expression.

## Test plan
- Added `static_assert` battery in `thrust/testing/catch2_test_complex.cu` covering construction, arithmetic, equality, compound assignment, and setters for both `float` and `double`.
- Verified host-only compile with Apple clang 17 (C++17/20/23) and g++ (C++17). CUDA build was NOT verified locally; reviewers should confirm via CI on `nvcc`/`nvhpc`.

## Concerns / open questions
1. Maintainer @miscco indicated in 2024 a preference for routing users to `cuda::std::complex` over investing in `thrust::complex`. Confirming this work is still wanted before going beyond draft.
2. `thrust::complex<T> v;` (default-init) previously left storage uninitialized; the new default-member-initializers zero it. Aligns with `cuda::std::complex` but is a subtle behavior change worth a reviewer note.
