### PR TITLE
 Implement C++26 P4037R1: signed char / unsigned char in <random>

### DIFF
--- a/libcudacxx/include/cuda/std/__random/is_valid.h
+++ b/libcudacxx/include/cuda/std/__random/is_valid.h
@@ -25,27 +25,46 @@
 #include <cuda/std/__type_traits/is_integer.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/is_unsigned.h>
+#include <cuda/std/__type_traits/is_unsigned_integer.h>
 #include <cuda/std/__utility/declval.h>
 
 #include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-// [rand.req.genl]/1.4:
-// The effect of instantiating a template that has a template type parameter
-// named RealType is undefined unless the corresponding template argument is
-// cv-unqualified and is one of float, double, or long double.
+// [rand.req.genl]/1.5 (C++26, per P4037R1):
+// A template argument corresponding to a template parameter named RealType
+// must be a (cv-unqualified) standard floating-point type or a member of an
+// implementation-defined subset of extended floating-point types; otherwise
+// the program is ill-formed.
 
 template <class _Type>
 inline constexpr bool __cccl_random_is_valid_realtype = __cccl_is_floating_point_v<_Type>;
 
-// [rand.req.genl]/1.5:
-// The effect of instantiating a template that has a template type parameter
-// named IntType is undefined unless the corresponding template argument is
-// cv-unqualified and is one of short, int, long, long long, unsigned short,
-// unsigned int, unsigned long, or unsigned long long.
+// [rand.req.genl]/1.6 (C++26, per P4037R1):
+// A template argument corresponding to a template parameter named IntType
+// must be a (cv-unqualified) standard signed or unsigned integer type, an
+// extended integer type whose width is in [width(char), width(long long)],
+// or a member of an implementation-defined subset of integer types; otherwise
+// the program is ill-formed.
+//
+// Note: This includes signed char and unsigned char but excludes plain char,
+// bool, and char8_t/char16_t/char32_t/wchar_t (see P4037R1 section 4.2).
 template <class _Type>
 inline constexpr bool __cccl_random_is_valid_inttype = __cccl_is_integer_v<_Type>;
+
+// [rand.req.genl]/1.7 (C++26, per P4037R1):
+// A template argument corresponding to a template parameter named UIntType
+// must be a (cv-unqualified) standard or extended unsigned integer type whose
+// width is in [width(short), width(long long)], or a member of an
+// implementation-defined subset of unsigned integer types; otherwise the
+// program is ill-formed.
+//
+// Per P4037R1 section 4.5, unsigned char is supported unilaterally as part of
+// the implementation-defined subset so that small engines like
+// linear_congruential_engine<unsigned char, ...> are usable.
+template <class _Type>
+inline constexpr bool __cccl_random_is_valid_uinttype = __cccl_is_unsigned_integer_v<_Type>;
 
 // [rand.req.urng]/3:
 // A class G meets the uniform random bit generator requirements if G models

--- a/libcudacxx/include/cuda/std/__random/linear_congruential_engine.h
+++ b/libcudacxx/include/cuda/std/__random/linear_congruential_engine.h
@@ -3,7 +3,7 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -34,81 +34,81 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-template <uint64_t __A,
-          uint64_t __C,
-          uint64_t __M,
+template <uint64_t _Ap,
+          uint64_t _Cp,
           uint64_t _Mp,
-          bool _MightOverflow = (__A != 0 && __M != 0 && __M - 1 > (_Mp - __C) / __A),
-          bool _OverflowOk    = ((__M | (__M - 1)) > __M), // m = 2^n
-          bool _SchrageOk     = (__A != 0 && __M != 0 && __M % __A <= __M / __A)> // r <= q
+          uint64_t _MpMax,
+          bool _MightOverflow = (_Ap != 0 && _Mp != 0 && _Mp - 1 > (_MpMax - _Cp) / _Ap),
+          bool _OverflowOk    = ((_Mp | (_Mp - 1)) > _Mp), // m = 2^n
+          bool _SchrageOk     = (_Ap != 0 && _Mp != 0 && _Mp % _Ap <= _Mp / _Ap)> // r <= q
 struct __lce_alg_picker
 {
-  static_assert(__A != 0 || __M != 0 || !_MightOverflow || _OverflowOk || _SchrageOk,
+  static_assert(_Ap != 0 || _Mp != 0 || !_MightOverflow || _OverflowOk || _SchrageOk,
                 "The current values of a, c, and m cannot generate a number "
                 "within bounds of linear_congruential_engine.");
 
   static constexpr const bool __use_schrage = _MightOverflow && !_OverflowOk && _SchrageOk;
 };
 
-template <uint64_t __A,
-          uint64_t __C,
-          uint64_t __M,
+template <uint64_t _Ap,
+          uint64_t _Cp,
           uint64_t _Mp,
-          bool _UseSchrage = __lce_alg_picker<__A, __C, __M, _Mp>::__use_schrage>
+          uint64_t _MpMax,
+          bool _UseSchrage = __lce_alg_picker<_Ap, _Cp, _Mp, _MpMax>::__use_schrage>
 struct __lce_ta;
 
 // 64
 
-template <uint64_t __A, uint64_t __C, uint64_t __M>
-struct __lce_ta<__A, __C, __M, ~uint64_t{0}, true>
+template <uint64_t _Ap, uint64_t _Cp, uint64_t _Mp>
+struct __lce_ta<_Ap, _Cp, _Mp, ~uint64_t{0}, true>
 {
   using result_type = uint64_t;
   [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
   {
     // Schrage's algorithm
-    constexpr result_type __q = __M / __A;
-    constexpr result_type __r = __M % __A;
-    const result_type __t0    = __A * (__x % __q);
+    constexpr result_type __q = _Mp / _Ap;
+    constexpr result_type __r = _Mp % _Ap;
+    const result_type __t0    = _Ap * (__x % __q);
     const result_type __t1    = __r * (__x / __q);
-    __x                       = __t0 + (__t0 < __t1) * __M - __t1;
-    __x += __C - (__x >= __M - __C) * __M;
+    __x                       = __t0 + (__t0 < __t1) * _Mp - __t1;
+    __x += _Cp - (__x >= _Mp - _Cp) * _Mp;
     return __x;
   }
 };
 
-template <uint64_t __A, uint64_t __M>
-struct __lce_ta<__A, 0, __M, ~uint64_t{0}, true>
+template <uint64_t _Ap, uint64_t _Mp>
+struct __lce_ta<_Ap, 0, _Mp, ~uint64_t{0}, true>
 {
   using result_type = uint64_t;
   [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
   {
     // Schrage's algorithm
-    constexpr result_type __q = __M / __A;
-    constexpr result_type __r = __M % __A;
-    const result_type __t0    = __A * (__x % __q);
+    constexpr result_type __q = _Mp / _Ap;
+    constexpr result_type __r = _Mp % _Ap;
+    const result_type __t0    = _Ap * (__x % __q);
     const result_type __t1    = __r * (__x / __q);
-    __x                       = __t0 + (__t0 < __t1) * __M - __t1;
+    __x                       = __t0 + (__t0 < __t1) * _Mp - __t1;
     return __x;
   }
 };
 
-template <uint64_t __A, uint64_t __C, uint64_t __M>
-struct __lce_ta<__A, __C, __M, ~uint64_t{0}, false>
+template <uint64_t _Ap, uint64_t _Cp, uint64_t _Mp>
+struct __lce_ta<_Ap, _Cp, _Mp, ~uint64_t{0}, false>
 {
   using result_type = uint64_t;
   [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
   {
-    return (__A * __x + __C) % __M;
+    return (_Ap * __x + _Cp) % _Mp;
   }
 };
 
-template <uint64_t __A, uint64_t __C>
-struct __lce_ta<__A, __C, 0, ~uint64_t{0}, false>
+template <uint64_t _Ap, uint64_t _Cp>
+struct __lce_ta<_Ap, _Cp, 0, ~uint64_t{0}, false>
 {
   using result_type = uint64_t;
   [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
   {
-    return __A * __x + __C;
+    return _Ap * __x + _Cp;
   }
 };
 
@@ -120,16 +120,16 @@ struct __lce_ta<_Ap, _Cp, _Mp, ~uint32_t{0}, true>
   using result_type = uint32_t;
   [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
   {
-    constexpr auto __A = static_cast<result_type>(_Ap);
-    constexpr auto __C = static_cast<result_type>(_Cp);
-    constexpr auto __M = static_cast<result_type>(_Mp);
+    constexpr auto __a = static_cast<result_type>(_Ap);
+    constexpr auto __c = static_cast<result_type>(_Cp);
+    constexpr auto __m = static_cast<result_type>(_Mp);
     // Schrage's algorithm
-    constexpr result_type __q = __M / __A;
-    constexpr result_type __r = __M % __A;
-    const result_type __t0    = __A * (__x % __q);
+    constexpr result_type __q = __m / __a;
+    constexpr result_type __r = __m % __a;
+    const result_type __t0    = __a * (__x % __q);
     const result_type __t1    = __r * (__x / __q);
-    __x                       = __t0 + (__t0 < __t1) * __M - __t1;
-    __x += __C - (__x >= __M - __C) * __M;
+    __x                       = __t0 + (__t0 < __t1) * __m - __t1;
+    __x += __c - (__x >= __m - __c) * __m;
     return __x;
   }
 };
@@ -140,14 +140,14 @@ struct __lce_ta<_Ap, 0, _Mp, ~uint32_t{0}, true>
   using result_type = uint32_t;
   [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
   {
-    constexpr result_type __A = static_cast<result_type>(_Ap);
-    constexpr result_type __M = static_cast<result_type>(_Mp);
+    constexpr result_type __a = static_cast<result_type>(_Ap);
+    constexpr result_type __m = static_cast<result_type>(_Mp);
     // Schrage's algorithm
-    constexpr result_type __q = __M / __A;
-    constexpr result_type __r = __M % __A;
-    const result_type __t0    = __A * (__x % __q);
+    constexpr result_type __q = __m / __a;
+    constexpr result_type __r = __m % __a;
+    const result_type __t0    = __a * (__x % __q);
     const result_type __t1    = __r * (__x / __q);
-    __x                       = __t0 + (__t0 < __t1) * __M - __t1;
+    __x                       = __t0 + (__t0 < __t1) * __m - __t1;
     return __x;
   }
 };
@@ -158,10 +158,10 @@ struct __lce_ta<_Ap, _Cp, _Mp, ~uint32_t{0}, false>
   using result_type = uint32_t;
   [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
   {
-    constexpr result_type __A = static_cast<result_type>(_Ap);
-    constexpr result_type __C = static_cast<result_type>(_Cp);
-    constexpr result_type __M = static_cast<result_type>(_Mp);
-    return (__A * __x + __C) % __M;
+    constexpr result_type __a = static_cast<result_type>(_Ap);
+    constexpr result_type __c = static_cast<result_type>(_Cp);
+    constexpr result_type __m = static_cast<result_type>(_Mp);
+    return (__a * __x + __c) % __m;
   }
 };
 
@@ -171,32 +171,33 @@ struct __lce_ta<_Ap, _Cp, 0, ~uint32_t{0}, false>
   using result_type = uint32_t;
   [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
   {
-    constexpr result_type __A = static_cast<result_type>(_Ap);
-    constexpr result_type __C = static_cast<result_type>(_Cp);
-    return __A * __x + __C;
+    constexpr result_type __a = static_cast<result_type>(_Ap);
+    constexpr result_type __c = static_cast<result_type>(_Cp);
+    return __a * __x + __c;
   }
 };
 
 // 16
 
-template <uint64_t __A, uint64_t __C, uint64_t __M, bool __b>
-struct __lce_ta<__A, __C, __M, static_cast<uint16_t>(~0), __b>
+template <uint64_t _Ap, uint64_t _Cp, uint64_t _Mp, bool _UseSchrage>
+struct __lce_ta<_Ap, _Cp, _Mp, static_cast<uint16_t>(~0), _UseSchrage>
 {
   using result_type = uint16_t;
   [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
   {
-    return static_cast<result_type>(__lce_ta<__A, __C, __M, ~uint32_t{0}>::next(__x));
+    return static_cast<result_type>(__lce_ta<_Ap, _Cp, _Mp, ~uint32_t{0}>::next(__x));
   }
 };
 
 // 8
-template <uint64_t __A, uint64_t __C, uint64_t __M, bool __b>
-struct __lce_ta<__A, __C, __M, static_cast<uint8_t>(~0), __b>
+
+template <uint64_t _Ap, uint64_t _Cp, uint64_t _Mp, bool _UseSchrage>
+struct __lce_ta<_Ap, _Cp, _Mp, static_cast<uint8_t>(~0), _UseSchrage>
 {
   using result_type = uint8_t;
   [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
   {
-    return static_cast<result_type>(__lce_ta<__A, __C, __M, ~uint32_t{0}>::next(__x));
+    return static_cast<result_type>(__lce_ta<_Ap, _Cp, _Mp, ~uint32_t{0}>::next(__x));
   }
 };
 

--- a/libcudacxx/include/cuda/std/__random/linear_congruential_engine.h
+++ b/libcudacxx/include/cuda/std/__random/linear_congruential_engine.h
@@ -24,9 +24,9 @@
 #include <cuda/std/__host_stdlib/istream>
 #include <cuda/std/__host_stdlib/ostream>
 #include <cuda/std/__random/is_seed_sequence.h>
+#include <cuda/std/__random/is_valid.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/integral_constant.h>
-#include <cuda/std/__type_traits/is_unsigned.h>
 #include <cuda/std/climits>
 #include <cuda/std/cstdint>
 
@@ -189,6 +189,17 @@ struct __lce_ta<__A, __C, __M, static_cast<uint16_t>(~0), __b>
   }
 };
 
+// 8
+template <uint64_t __A, uint64_t __C, uint64_t __M, bool __b>
+struct __lce_ta<__A, __C, __M, static_cast<uint8_t>(~0), __b>
+{
+  using result_type = uint8_t;
+  [[nodiscard]] _CCCL_API static constexpr result_type next(result_type __x) noexcept
+  {
+    return static_cast<result_type>(__lce_ta<__A, __C, __M, ~uint32_t{0}>::next(__x));
+  }
+};
+
 template <class _UIntType, _UIntType __A, _UIntType __C, _UIntType __M>
 class _CCCL_TYPE_VISIBILITY_DEFAULT linear_congruential_engine;
 
@@ -206,7 +217,8 @@ private:
 
   static_assert(__M == 0 || __A < __M, "linear_congruential_engine invalid parameters");
   static_assert(__M == 0 || __C < __M, "linear_congruential_engine invalid parameters");
-  static_assert(is_unsigned_v<_UIntType>, "_UIntType must be uint32_t type");
+  static_assert(__cccl_random_is_valid_uinttype<_UIntType>,
+                "linear_congruential_engine: UIntType must be a supported unsigned integer type");
 
 public:
   static constexpr const result_type _Min = __C == 0u ? 1u : 0u;

--- a/libcudacxx/include/cuda/std/__random/philox_engine.h
+++ b/libcudacxx/include/cuda/std/__random/philox_engine.h
@@ -26,6 +26,7 @@
 #include <cuda/std/__host_stdlib/istream>
 #include <cuda/std/__host_stdlib/ostream>
 #include <cuda/std/__random/is_seed_sequence.h>
+#include <cuda/std/__random/is_valid.h>
 #include <cuda/std/__type_traits/make_nbit_int.h>
 #include <cuda/std/__utility/pair.h>
 #include <cuda/std/array>
@@ -86,7 +87,8 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 template <typename _UIntType, size_t _WordSize, size_t _WordCount, size_t _NumRounds, _UIntType... _Constants>
 class philox_engine
 {
-  static_assert(__cccl_is_unsigned_integer_v<_UIntType>, "philox_engine: _UIntType must be an unsigned integer type");
+  static_assert(__cccl_random_is_valid_uinttype<_UIntType>,
+                "philox_engine: UIntType must be a supported unsigned integer type");
   static_assert(_WordCount == 2 || _WordCount == 4, "N argument must be either 2 or 4");
   static_assert(sizeof...(_Constants) == _WordCount, "consts array must be of length N");
   static_assert(_NumRounds > 0, "rounds must be a strictly positive number");

--- a/libcudacxx/test/libcudacxx/std/random/distribution/uniform_int.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/distribution/uniform_int.pass.cpp
@@ -63,10 +63,25 @@ TEST_FUNC void test()
   test_distribution<D, false, G, test_constexpr>(params, uniform_int_cdf<T>{});
 }
 
+// P4037R1: made signed char / unsigned char valid IntType template arguments.
+
+TEST_FUNC void test_p4037r1_small_types()
+{
+  using D_s = cuda::std::uniform_int_distribution<signed char>;
+  using D_u = cuda::std::uniform_int_distribution<unsigned char>;
+  static_assert(cuda::std::is_same_v<D_s::result_type, signed char>);
+  static_assert(cuda::std::is_same_v<D_u::result_type, unsigned char>);
+  static_assert(D_s().min() == 0);
+  static_assert(D_s().max() == cuda::std::numeric_limits<signed char>::max());
+  static_assert(D_u().min() == 0);
+  static_assert(D_u().max() == cuda::std::numeric_limits<unsigned char>::max());
+}
+
 int main(int, char**)
 {
   test<int>();
   test<long>();
   test<short>();
+  test_p4037r1_small_types();
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/random/engine/lcg.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/engine/lcg.pass.cpp
@@ -21,8 +21,21 @@ TEST_FUNC void test()
   test_engine<cuda::std::minstd_rand, 399268537ull>();
 }
 
+// P4037R1: linear_congruential_engine must accept the unsigned char UIntType
+TEST_FUNC void test_p4037r1_small_uinttype()
+{
+  using E = cuda::std::linear_congruential_engine<unsigned char, 5u, 1u, 13u>;
+  static_assert(cuda::std::is_same_v<E::result_type, unsigned char>);
+  static_assert(E::min() == 0u);
+  static_assert(E::max() == 12u);
+  static_assert(E::multiplier == 5u);
+  static_assert(E::increment == 1u);
+  static_assert(E::modulus == 13u);
+}
+
 int main(int, char**)
 {
   test();
+  test_p4037r1_small_uinttype();
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/random/small_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/small_types.pass.cpp
@@ -1,0 +1,126 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
+// <random>
+//
+// Verify that distributions and engines accept signed char / unsigned char as
+// template arguments (C++26, P4037R1) and produce correct values at runtime.
+
+#include <cuda/std/cassert>
+#include <cuda/std/limits>
+#include <cuda/std/random>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+// Compile-only smoke check: every IntType distribution instantiates cleanly
+// with signed char and unsigned char (P4037R1). Pure type-level checks, so we
+// do not require the default constructor to be constexpr (binomial/poisson
+// default ctors perform FP math that is not constexpr pre-C++23).
+
+template <template <class> class Dist, class IntType>
+struct smoke_int_distribution
+{
+  using D = Dist<IntType>;
+  using P = typename D::param_type;
+  static_assert(cuda::std::is_same_v<typename D::result_type, IntType>);
+  static_assert(cuda::std::is_same_v<typename P::distribution_type, D>);
+};
+
+template struct smoke_int_distribution<cuda::std::uniform_int_distribution, signed char>;
+template struct smoke_int_distribution<cuda::std::uniform_int_distribution, unsigned char>;
+template struct smoke_int_distribution<cuda::std::binomial_distribution, signed char>;
+template struct smoke_int_distribution<cuda::std::binomial_distribution, unsigned char>;
+template struct smoke_int_distribution<cuda::std::geometric_distribution, signed char>;
+template struct smoke_int_distribution<cuda::std::geometric_distribution, unsigned char>;
+template struct smoke_int_distribution<cuda::std::negative_binomial_distribution, signed char>;
+template struct smoke_int_distribution<cuda::std::negative_binomial_distribution, unsigned char>;
+template struct smoke_int_distribution<cuda::std::poisson_distribution, signed char>;
+template struct smoke_int_distribution<cuda::std::poisson_distribution, unsigned char>;
+
+// End-to-end instantiation: distributions and engines compile and run for
+// signed char / unsigned char.
+
+template <class IntType>
+TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_uniform_int_small_type()
+{
+  using D = cuda::std::uniform_int_distribution<IntType>;
+  using P = typename D::param_type;
+  using G = cuda::std::philox4x64;
+
+  // Construct over the full domain of the small type.
+  const IntType lo = cuda::std::numeric_limits<IntType>::min();
+  const IntType hi = cuda::std::numeric_limits<IntType>::max();
+  D d(lo, hi);
+  assert(d.a() == lo);
+  assert(d.b() == hi);
+  assert(d.min() == lo);
+  assert(d.max() == hi);
+
+  G g(42);
+  for (int i = 0; i < 32; ++i)
+  {
+    const IntType v = d(g);
+    assert(static_cast<int>(v) >= static_cast<int>(lo));
+    assert(static_cast<int>(v) <= static_cast<int>(hi));
+  }
+
+  // Sub-range also works.
+  D d2(P(IntType{0}, IntType{10}));
+  for (int i = 0; i < 32; ++i)
+  {
+    const IntType v = d2(g);
+    assert(static_cast<int>(v) >= 0);
+    assert(static_cast<int>(v) <= 10);
+  }
+  return true;
+}
+
+TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_small_lce()
+{
+  // A trivially small linear_congruential_engine with an 8-bit result_type.
+  // Parameters chosen so 0 <= c < m and 0 <= a < m, and _Min (=0) < _Max (=12).
+  using Engine = cuda::std::linear_congruential_engine<unsigned char, 5u, 1u, 13u>;
+  static_assert(cuda::std::is_same_v<Engine::result_type, unsigned char>);
+  static_assert(Engine::min() == 0u);
+  static_assert(Engine::max() == 12u);
+
+  // From seed 1: x -> (5x + 1) mod 13 produces the cycle 6, 5, 0, 1, 6, 5, 0, 1, ...
+  Engine e(1);
+  assert(e() == 6u);
+  assert(e() == 5u);
+  assert(e() == 0u);
+  assert(e() == 1u);
+
+  // All generated values stay in [min(), max()].
+  for (int i = 0; i < 32; ++i)
+  {
+    const unsigned char v = e();
+    assert(v <= Engine::max());
+  }
+  return true;
+}
+
+int main(int, char**)
+{
+  test_uniform_int_small_type<signed char>();
+  test_uniform_int_small_type<unsigned char>();
+  test_small_lce();
+
+#if TEST_STD_VER >= 2020
+  static_assert(test_uniform_int_small_type<signed char>());
+  static_assert(test_uniform_int_small_type<unsigned char>());
+  static_assert(test_small_lce());
+#endif // TEST_STD_VER >= 2020
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/random/small_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/small_types.pass.cpp
@@ -58,8 +58,8 @@ TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_uniform_int_small_type()
   using G = cuda::std::philox4x64;
 
   // Construct over the full domain of the small type.
-  const IntType lo = cuda::std::numeric_limits<IntType>::min();
-  const IntType hi = cuda::std::numeric_limits<IntType>::max();
+  IntType lo = cuda::std::numeric_limits<IntType>::min();
+  IntType hi = cuda::std::numeric_limits<IntType>::max();
   D d(lo, hi);
   assert(d.a() == lo);
   assert(d.b() == hi);
@@ -69,7 +69,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_uniform_int_small_type()
   G g(42);
   for (int i = 0; i < 32; ++i)
   {
-    const IntType v = d(g);
+    IntType v = d(g);
     assert(static_cast<int>(v) >= static_cast<int>(lo));
     assert(static_cast<int>(v) <= static_cast<int>(hi));
   }
@@ -78,7 +78,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_uniform_int_small_type()
   D d2(P(IntType{0}, IntType{10}));
   for (int i = 0; i < 32; ++i)
   {
-    const IntType v = d2(g);
+    IntType v = d2(g);
     assert(static_cast<int>(v) >= 0);
     assert(static_cast<int>(v) <= 10);
   }
@@ -104,7 +104,7 @@ TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_small_lce()
   // All generated values stay in [min(), max()].
   for (int i = 0; i < 32; ++i)
   {
-    const unsigned char v = e();
+    unsigned char v = e();
     assert(v <= Engine::max());
   }
   return true;

--- a/libcudacxx/test/libcudacxx/std/random/valid_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/valid_types.pass.cpp
@@ -198,7 +198,7 @@ int main(int, char**)
   static_assert(test_uniform_int_small_type<signed char>());
   static_assert(test_uniform_int_small_type<unsigned char>());
   static_assert(test_small_lce());
-#endif
+#endif // TEST_STD_VER >= 2020
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/random/valid_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/valid_types.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: dynamic memory allocation is unsupported in tile code
-
 // <random>
 //
 // Verify [rand.req.genl]/1.6 and /1.7 (C++26, P4037R1) for the set of integer
@@ -19,8 +16,6 @@
 // - char / bool / char8_t / char16_t / char32_t / wchar_t must be rejected.
 // - __int128_t / __uint128_t are part of CCCL's implementation-defined subset.
 
-#include <cuda/std/cassert>
-#include <cuda/std/limits>
 #include <cuda/std/random>
 #include <cuda/std/type_traits>
 
@@ -96,109 +91,7 @@ static_assert(!cuda::std::__cccl_random_is_valid_uinttype<wchar_t>);
 static_assert(!cuda::std::__cccl_random_is_valid_uinttype<char8_t>);
 #endif // _CCCL_HAS_CHAR8_T()
 
-// -----------------------------------------------------------------------------
-// Compile-only smoke check: every IntType distribution instantiates cleanly
-// with signed char and unsigned char (P4037R1). Pure type-level checks, so we
-// do not require the default constructor to be constexpr (binomial/poisson
-// default ctors perform FP math that is not constexpr pre-C++23).
-// -----------------------------------------------------------------------------
-
-template <template <class> class Dist, class IntType>
-struct smoke_int_distribution
-{
-  using D = Dist<IntType>;
-  using P = typename D::param_type;
-  static_assert(cuda::std::is_same_v<typename D::result_type, IntType>);
-  static_assert(cuda::std::is_same_v<typename P::distribution_type, D>);
-};
-
-template struct smoke_int_distribution<cuda::std::uniform_int_distribution, signed char>;
-template struct smoke_int_distribution<cuda::std::uniform_int_distribution, unsigned char>;
-template struct smoke_int_distribution<cuda::std::binomial_distribution, signed char>;
-template struct smoke_int_distribution<cuda::std::binomial_distribution, unsigned char>;
-template struct smoke_int_distribution<cuda::std::geometric_distribution, signed char>;
-template struct smoke_int_distribution<cuda::std::geometric_distribution, unsigned char>;
-template struct smoke_int_distribution<cuda::std::negative_binomial_distribution, signed char>;
-template struct smoke_int_distribution<cuda::std::negative_binomial_distribution, unsigned char>;
-template struct smoke_int_distribution<cuda::std::poisson_distribution, signed char>;
-template struct smoke_int_distribution<cuda::std::poisson_distribution, unsigned char>;
-
-// -----------------------------------------------------------------------------
-// End-to-end instantiation: distributions and engines compile and run for
-// signed char / unsigned char.
-// -----------------------------------------------------------------------------
-
-template <class IntType>
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_uniform_int_small_type()
-{
-  using D = cuda::std::uniform_int_distribution<IntType>;
-  using P = typename D::param_type;
-  using G = cuda::std::philox4x64;
-
-  // Construct over the full domain of the small type.
-  const IntType lo = cuda::std::numeric_limits<IntType>::min();
-  const IntType hi = cuda::std::numeric_limits<IntType>::max();
-  D d(lo, hi);
-  assert(d.a() == lo);
-  assert(d.b() == hi);
-  assert(d.min() == lo);
-  assert(d.max() == hi);
-
-  G g(42);
-  for (int i = 0; i < 32; ++i)
-  {
-    const IntType v = d(g);
-    assert(static_cast<int>(v) >= static_cast<int>(lo));
-    assert(static_cast<int>(v) <= static_cast<int>(hi));
-  }
-
-  // Sub-range also works.
-  D d2(P(IntType{0}, IntType{10}));
-  for (int i = 0; i < 32; ++i)
-  {
-    const IntType v = d2(g);
-    assert(static_cast<int>(v) >= 0);
-    assert(static_cast<int>(v) <= 10);
-  }
-  return true;
-}
-
-TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_small_lce()
-{
-  // A trivially small linear_congruential_engine with an 8-bit result_type.
-  // Parameters chosen so 0 <= c < m and 0 <= a < m, and _Min (=0) < _Max (=12).
-  using Engine = cuda::std::linear_congruential_engine<unsigned char, 5u, 1u, 13u>;
-  static_assert(cuda::std::is_same_v<Engine::result_type, unsigned char>);
-  static_assert(Engine::min() == 0u);
-  static_assert(Engine::max() == 12u);
-
-  // From seed 1: x -> (5x + 1) mod 13 produces the cycle 6, 5, 0, 1, 6, 5, 0, 1, ...
-  Engine e(1);
-  assert(e() == 6u);
-  assert(e() == 5u);
-  assert(e() == 0u);
-  assert(e() == 1u);
-
-  // All generated values stay in [min(), max()].
-  for (int i = 0; i < 32; ++i)
-  {
-    const unsigned char v = e();
-    assert(v <= Engine::max());
-  }
-  return true;
-}
-
 int main(int, char**)
 {
-  test_uniform_int_small_type<signed char>();
-  test_uniform_int_small_type<unsigned char>();
-  test_small_lce();
-
-#if TEST_STD_VER >= 2020
-  static_assert(test_uniform_int_small_type<signed char>());
-  static_assert(test_uniform_int_small_type<unsigned char>());
-  static_assert(test_small_lce());
-#endif // TEST_STD_VER >= 2020
-
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/random/valid_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/valid_types.pass.cpp
@@ -1,0 +1,204 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
+// <random>
+//
+// Verify [rand.req.genl]/1.6 and /1.7 (C++26, P4037R1) for the set of integer
+// types accepted as IntType (for distributions) and UIntType (for engines).
+//
+// - signed char / unsigned char must be accepted (P4037R1).
+// - char / bool / char8_t / char16_t / char32_t / wchar_t must be rejected.
+// - __int128_t / __uint128_t are part of CCCL's implementation-defined subset.
+
+#include <cuda/std/cassert>
+#include <cuda/std/limits>
+#include <cuda/std/random>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+// -----------------------------------------------------------------------------
+// IntType trait (__cccl_random_is_valid_inttype)
+// -----------------------------------------------------------------------------
+
+// Accepted: standard signed/unsigned integer types (including signed/unsigned char).
+static_assert(cuda::std::__cccl_random_is_valid_inttype<signed char>);
+static_assert(cuda::std::__cccl_random_is_valid_inttype<unsigned char>);
+static_assert(cuda::std::__cccl_random_is_valid_inttype<short>);
+static_assert(cuda::std::__cccl_random_is_valid_inttype<unsigned short>);
+static_assert(cuda::std::__cccl_random_is_valid_inttype<int>);
+static_assert(cuda::std::__cccl_random_is_valid_inttype<unsigned int>);
+static_assert(cuda::std::__cccl_random_is_valid_inttype<long>);
+static_assert(cuda::std::__cccl_random_is_valid_inttype<unsigned long>);
+static_assert(cuda::std::__cccl_random_is_valid_inttype<long long>);
+static_assert(cuda::std::__cccl_random_is_valid_inttype<unsigned long long>);
+
+#if _CCCL_HAS_INT128()
+// CCCL implementation defined extended integer types.
+static_assert(cuda::std::__cccl_random_is_valid_inttype<__int128_t>);
+static_assert(cuda::std::__cccl_random_is_valid_inttype<__uint128_t>);
+#endif // _CCCL_HAS_INT128()
+
+// Rejected: non-integer types and character/boolean types
+static_assert(!cuda::std::__cccl_random_is_valid_inttype<bool>);
+static_assert(!cuda::std::__cccl_random_is_valid_inttype<char>);
+static_assert(!cuda::std::__cccl_random_is_valid_inttype<char16_t>);
+static_assert(!cuda::std::__cccl_random_is_valid_inttype<char32_t>);
+static_assert(!cuda::std::__cccl_random_is_valid_inttype<wchar_t>);
+#if _CCCL_HAS_CHAR8_T()
+static_assert(!cuda::std::__cccl_random_is_valid_inttype<char8_t>);
+#endif // _CCCL_HAS_CHAR8_T()
+static_assert(!cuda::std::__cccl_random_is_valid_inttype<float>);
+static_assert(!cuda::std::__cccl_random_is_valid_inttype<double>);
+static_assert(!cuda::std::__cccl_random_is_valid_inttype<void*>);
+
+// -----------------------------------------------------------------------------
+// UIntType trait (__cccl_random_is_valid_uinttype)
+// -----------------------------------------------------------------------------
+
+// Accepted: standard unsigned integer types
+static_assert(cuda::std::__cccl_random_is_valid_uinttype<unsigned char>);
+static_assert(cuda::std::__cccl_random_is_valid_uinttype<unsigned short>);
+static_assert(cuda::std::__cccl_random_is_valid_uinttype<unsigned int>);
+static_assert(cuda::std::__cccl_random_is_valid_uinttype<unsigned long>);
+static_assert(cuda::std::__cccl_random_is_valid_uinttype<unsigned long long>);
+
+#if _CCCL_HAS_INT128()
+// CCCL implementation-defined extended unsigned integer type.
+static_assert(cuda::std::__cccl_random_is_valid_uinttype<__uint128_t>);
+// Signed 128-bit must be rejected (UIntType requires unsigned).
+static_assert(!cuda::std::__cccl_random_is_valid_uinttype<__int128_t>);
+#endif // _CCCL_HAS_INT128()
+
+// Rejected: signed integer types (UIntType requires unsigned).
+static_assert(!cuda::std::__cccl_random_is_valid_uinttype<signed char>);
+static_assert(!cuda::std::__cccl_random_is_valid_uinttype<short>);
+static_assert(!cuda::std::__cccl_random_is_valid_uinttype<int>);
+static_assert(!cuda::std::__cccl_random_is_valid_uinttype<long>);
+static_assert(!cuda::std::__cccl_random_is_valid_uinttype<long long>);
+
+// Rejected: bool and character types.
+static_assert(!cuda::std::__cccl_random_is_valid_uinttype<bool>);
+static_assert(!cuda::std::__cccl_random_is_valid_uinttype<char>);
+static_assert(!cuda::std::__cccl_random_is_valid_uinttype<char16_t>);
+static_assert(!cuda::std::__cccl_random_is_valid_uinttype<char32_t>);
+static_assert(!cuda::std::__cccl_random_is_valid_uinttype<wchar_t>);
+#if _CCCL_HAS_CHAR8_T()
+static_assert(!cuda::std::__cccl_random_is_valid_uinttype<char8_t>);
+#endif // _CCCL_HAS_CHAR8_T()
+
+// -----------------------------------------------------------------------------
+// Compile-only smoke check: every IntType distribution instantiates cleanly
+// with signed char and unsigned char (P4037R1). Pure type-level checks, so we
+// do not require the default constructor to be constexpr (binomial/poisson
+// default ctors perform FP math that is not constexpr pre-C++23).
+// -----------------------------------------------------------------------------
+
+template <template <class> class Dist, class IntType>
+struct smoke_int_distribution
+{
+  using D = Dist<IntType>;
+  using P = typename D::param_type;
+  static_assert(cuda::std::is_same_v<typename D::result_type, IntType>);
+  static_assert(cuda::std::is_same_v<typename P::distribution_type, D>);
+};
+
+template struct smoke_int_distribution<cuda::std::uniform_int_distribution, signed char>;
+template struct smoke_int_distribution<cuda::std::uniform_int_distribution, unsigned char>;
+template struct smoke_int_distribution<cuda::std::binomial_distribution, signed char>;
+template struct smoke_int_distribution<cuda::std::binomial_distribution, unsigned char>;
+template struct smoke_int_distribution<cuda::std::geometric_distribution, signed char>;
+template struct smoke_int_distribution<cuda::std::geometric_distribution, unsigned char>;
+template struct smoke_int_distribution<cuda::std::negative_binomial_distribution, signed char>;
+template struct smoke_int_distribution<cuda::std::negative_binomial_distribution, unsigned char>;
+template struct smoke_int_distribution<cuda::std::poisson_distribution, signed char>;
+template struct smoke_int_distribution<cuda::std::poisson_distribution, unsigned char>;
+
+// -----------------------------------------------------------------------------
+// End-to-end instantiation: distributions and engines compile and run for
+// signed char / unsigned char.
+// -----------------------------------------------------------------------------
+
+template <class IntType>
+TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_uniform_int_small_type()
+{
+  using D = cuda::std::uniform_int_distribution<IntType>;
+  using P = typename D::param_type;
+  using G = cuda::std::philox4x64;
+
+  // Construct over the full domain of the small type.
+  const IntType lo = cuda::std::numeric_limits<IntType>::min();
+  const IntType hi = cuda::std::numeric_limits<IntType>::max();
+  D d(lo, hi);
+  assert(d.a() == lo);
+  assert(d.b() == hi);
+  assert(d.min() == lo);
+  assert(d.max() == hi);
+
+  G g(42);
+  for (int i = 0; i < 32; ++i)
+  {
+    const IntType v = d(g);
+    assert(static_cast<int>(v) >= static_cast<int>(lo));
+    assert(static_cast<int>(v) <= static_cast<int>(hi));
+  }
+
+  // Sub-range also works.
+  D d2(P(IntType{0}, IntType{10}));
+  for (int i = 0; i < 32; ++i)
+  {
+    const IntType v = d2(g);
+    assert(static_cast<int>(v) >= 0);
+    assert(static_cast<int>(v) <= 10);
+  }
+  return true;
+}
+
+TEST_FUNC TEST_CONSTEXPR_CXX20 bool test_small_lce()
+{
+  // A trivially small linear_congruential_engine with an 8-bit result_type.
+  // Parameters chosen so 0 <= c < m and 0 <= a < m, and _Min (=0) < _Max (=12).
+  using Engine = cuda::std::linear_congruential_engine<unsigned char, 5u, 1u, 13u>;
+  static_assert(cuda::std::is_same_v<Engine::result_type, unsigned char>);
+  static_assert(Engine::min() == 0u);
+  static_assert(Engine::max() == 12u);
+
+  // From seed 1: x -> (5x + 1) mod 13 produces the cycle 6, 5, 0, 1, 6, 5, 0, 1, ...
+  Engine e(1);
+  assert(e() == 6u);
+  assert(e() == 5u);
+  assert(e() == 0u);
+  assert(e() == 1u);
+
+  // All generated values stay in [min(), max()].
+  for (int i = 0; i < 32; ++i)
+  {
+    const unsigned char v = e();
+    assert(v <= Engine::max());
+  }
+  return true;
+}
+
+int main(int, char**)
+{
+  test_uniform_int_small_type<signed char>();
+  test_uniform_int_small_type<unsigned char>();
+  test_small_lce();
+
+#if TEST_STD_VER >= 2020
+  static_assert(test_uniform_int_small_type<signed char>());
+  static_assert(test_uniform_int_small_type<unsigned char>());
+  static_assert(test_small_lce());
+#endif
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/random/valid_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/valid_types.pass.cpp
@@ -3,7 +3,7 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
Generating random bytes and using 8-bit types in <random> instead of a standards defect hidden behind “UB.”

- includes normal standard integer types, which now explicitly cover `signed char` and `unsigned char`
- cover unsigned integer types in a width range (with `unsigned char` supported for engines)

closes #8243 
