### PR TITLE
Revert I8 tunings for warpspeed scan

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -937,18 +937,21 @@ struct policy_selector
         switch (input_value_size)
         {
           case 1:
+            // wrps_4.lbi_8.ipt_160 ()  1.264254  1.264254  1.264254  1.264254
+            return scan_warpspeed_policy{4, 8, 160 - 1};
+            // TODO(gonidelis): we found this tuning but it regressed:
             // wrps_3.lbi_4.ipt_96 ()  1.454824  1.247212  1.450590  1.560418
-            return scan_warpspeed_policy{3, 4, 96 - 1};
+            // return scan_warpspeed_policy{3, 4, 96 - 1};
           case 2:
+            // TODO(gonidelis): we found this tuning but it regresses large problems, we should revisit this
+            // // wrps_4.lbi_2.ipt_96 ()  1.082511  0.929516  1.091523  1.264033
+            // return scan_warpspeed_policy{4, 2, 96 - 1};
             // clang-format off
-// TODO(bgruber): we found this tuning but it regresses large problems, we should revisit this
-//            // wrps_4.lbi_2.ipt_96 ()  1.082511  0.929516  1.091523  1.264033
-//            return scan_warpspeed_policy{4, 2, 96 - 1};
-//|   I16   |      I64      |      2^16      |  17.304 us |       1.07% |  15.244 us |       0.77% |    -2.060 us | -11.91% |   FAST   |
-//|   I16   |      I64      |      2^20      |  19.466 us |       1.21% |  17.266 us |       2.93% |    -2.200 us | -11.30% |   FAST   |
-//|   I16   |      I64      |      2^24      |  39.565 us |       2.46% |  35.835 us |       4.25% |    -3.730 us |  -9.43% |   FAST   |
-//|   I16   |      I64      |      2^28      | 224.318 us |       0.37% | 233.381 us |       0.46% |     9.063 us |   4.04% |   SLOW   |
-//|   I16   |      I64      |      2^32      |   3.238 ms |       0.53% |   3.429 ms |       0.53% |   191.299 us |   5.91% |   SLOW   |
+            //|   I16   |      I64      |      2^16      |  17.304 us |       1.07% |  15.244 us |       0.77% |    -2.060 us | -11.91% |   FAST   |
+            //|   I16   |      I64      |      2^20      |  19.466 us |       1.21% |  17.266 us |       2.93% |    -2.200 us | -11.30% |   FAST   |
+            //|   I16   |      I64      |      2^24      |  39.565 us |       2.46% |  35.835 us |       4.25% |    -3.730 us |  -9.43% |   FAST   |
+            //|   I16   |      I64      |      2^28      | 224.318 us |       0.37% | 233.381 us |       0.46% |     9.063 us |   4.04% |   SLOW   |
+            //|   I16   |      I64      |      2^32      |   3.238 ms |       0.53% |   3.429 ms |       0.53% |   191.299 us |   5.91% |   SLOW   |
             // clang-format on
             // wrps_6.lbi_2.ipt_96 ()  1.167633  1.167633  1.167633  1.167633
             return scan_warpspeed_policy{6, 2, 96 - 1};


### PR DESCRIPTION
Introduced in #8611.

Change caused by this PR:

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I64      |      2^16      |   9.312 us |       6.27% |  11.180 us |       0.94% |    1.868 us |  20.06% |  🔴 SLOW  |
|   I8    |      I64      |      2^20      |  12.742 us |       7.78% |  13.393 us |       4.28% |    0.651 us |   5.11% |  🔴 SLOW  |
|   I8    |      I64      |      2^24      |  29.897 us |       3.85% |  26.068 us |       2.99% |   -3.829 us | -12.81% |  🟢 FAST  |
|   I8    |      I64      |      2^28      | 228.980 us |       0.49% | 214.950 us |       0.60% |  -14.030 us |  -6.13% |  🟢 FAST  |
|   I8    |      I64      |      2^32      |   3.451 ms |       0.04% |   3.237 ms |       0.24% | -213.883 us |  -6.20% |  🟢 FAST  |

Fixes: #8688 