### PR TITLE
[libcu++] Fix `reference_converts_from_temporary` test for `gcc-15`

### DIFF
--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/reference_converts_from_temporary.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/reference_converts_from_temporary.pass.cpp
@@ -22,13 +22,21 @@ struct SimpleClass
 };
 struct ConvertsToRvalue
 {
-  constexpr operator int();
-  explicit constexpr operator int&&();
+  TEST_FUNC constexpr operator int()
+  {
+    return 0;
+  }
+
+  TEST_FUNC explicit constexpr operator int&&();
 };
 struct ConvertsToConstReference
 {
-  constexpr operator int();
-  explicit constexpr operator int&();
+  TEST_FUNC constexpr operator int()
+  {
+    return 0;
+  }
+
+  TEST_FUNC explicit constexpr operator int&();
 };
 
 // not references


### PR DESCRIPTION
`gcc-15` complains about the `operator int` being used bot undefined.