### PR TITLE
Replace `detail::segmented_reduce::dispatch` by the public API

### DIFF
--- a/cub/benchmarks/bench/segmented_reduce/base.cuh
+++ b/cub/benchmarks/bench/segmented_reduce/base.cuh
@@ -79,7 +79,7 @@ void fixed_size_segmented_reduce(nvbench::state& state, nvbench::type_list<T>)
     {
       _CCCL_TRY_CUDA_API(
         cub::DeviceSegmentedReduce::ArgMin,
-        "ArgMin failed",
+        "Segmented ArgMin failed",
         d_in,
         d_out,
         static_cast<::cuda::std::int64_t>(num_segments),

--- a/cub/benchmarks/bench/segmented_reduce/base.cuh
+++ b/cub/benchmarks/bench/segmented_reduce/base.cuh
@@ -90,7 +90,7 @@ void fixed_size_segmented_reduce(nvbench::state& state, nvbench::type_list<T>)
     {
       _CCCL_TRY_CUDA_API(
         cub::DeviceSegmentedReduce::Reduce,
-        "Reduce failed",
+        "Segmented reduce failed",
         d_in,
         d_out,
         static_cast<::cuda::std::int64_t>(num_segments),

--- a/cub/benchmarks/bench/segmented_reduce/base.cuh
+++ b/cub/benchmarks/bench/segmented_reduce/base.cuh
@@ -1,9 +1,9 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: BSD-3
 
 #pragma once
 
-#include <cub/device/dispatch/dispatch_segmented_reduce.cuh>
+#include <cub/device/device_segmented_reduce.cuh>
 
 #include <cuda/std/type_traits>
 
@@ -44,11 +44,9 @@ void fixed_size_segmented_reduce(nvbench::state& state, nvbench::type_list<T>)
 {
   static constexpr bool is_argmin = std::is_same_v<op_t, cub::detail::arg_min>;
 
-  using input_it_t  = const T*;
-  using output_t    = cuda::std::conditional_t<is_argmin, cuda::std::pair<int, T>, T>;
-  using output_it_t = output_t*;
-  using accum_t     = output_t;
-  using init_t      = cuda::std::conditional_t<is_argmin, cub::detail::reduce::empty_problem_init_t<accum_t>, T>;
+  using output_t = cuda::std::conditional_t<is_argmin, cuda::std::pair<int, T>, T>;
+  using accum_t  = output_t;
+  using init_t   = cuda::std::conditional_t<is_argmin, cub::detail::reduce::empty_problem_init_t<accum_t>, T>;
 
   // Retrieve axis parameters
   const size_t num_elements = static_cast<size_t>(state.get_int64("Elements{io}"));
@@ -59,67 +57,48 @@ void fixed_size_segmented_reduce(nvbench::state& state, nvbench::type_list<T>)
   thrust::device_vector<T> in = generate(elements);
   thrust::device_vector<output_t> out(num_segments);
 
-  input_it_t d_in   = thrust::raw_pointer_cast(in.data());
-  output_it_t d_out = thrust::raw_pointer_cast(out.data());
+  const T* d_in   = thrust::raw_pointer_cast(in.data());
+  output_t* d_out = thrust::raw_pointer_cast(out.data());
 
   // Enable throughput calculations and add "Size" column to results.
   state.add_element_count(elements);
   state.add_global_memory_reads<T>(elements, "Size");
   state.add_global_memory_writes<output_t>(num_segments);
 
-  [[maybe_unused]] auto d_indexed_in = thrust::make_transform_iterator(
-    thrust::counting_iterator<::cuda::std::int64_t>{0},
-    cub::detail::segmented_reduce::generate_idx_value<input_it_t, T>(d_in, segment_size));
-  using arg_index_input_iterator_t = decltype(d_indexed_in);
-
-  auto select_in = [&] {
+  caching_allocator_t alloc;
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
+    auto env = cub_bench_env(
+      alloc,
+      launch
+#if !TUNE_BASE
+      ,
+      cuda::execution::tune(policy_selector<accum_t>{})
+#endif
+    );
     if constexpr (is_argmin)
     {
-      return d_indexed_in;
+      _CCCL_TRY_CUDA_API(
+        cub::DeviceSegmentedReduce::ArgMin,
+        "ArgMin failed",
+        d_in,
+        d_out,
+        static_cast<::cuda::std::int64_t>(num_segments),
+        static_cast<int>(segment_size),
+        env);
     }
     else
     {
-      return d_in;
+      _CCCL_TRY_CUDA_API(
+        cub::DeviceSegmentedReduce::Reduce,
+        "Reduce failed",
+        d_in,
+        d_out,
+        static_cast<::cuda::std::int64_t>(num_segments),
+        static_cast<int>(segment_size),
+        op_t{},
+        init_t{},
+        env);
     }
-  };
-
-  // Allocate temporary storage:
-  std::size_t temp_size;
-  cub::detail::segmented_reduce::dispatch_fixed_size<accum_t>(
-    nullptr,
-    temp_size,
-    select_in(),
-    d_out,
-    static_cast<::cuda::std::int64_t>(num_segments),
-    static_cast<int>(segment_size),
-    op_t{},
-    init_t{},
-    nullptr /* stream */
-#if !TUNE_BASE
-    ,
-    policy_selector<accum_t>{}
-#endif
-  );
-
-  thrust::device_vector<nvbench::uint8_t> temp(temp_size);
-  auto* temp_storage = thrust::raw_pointer_cast(temp.data());
-
-  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::segmented_reduce::dispatch_fixed_size<accum_t>(
-      temp_storage,
-      temp_size,
-      select_in(),
-      d_out,
-      static_cast<::cuda::std::int64_t>(num_segments),
-      static_cast<int>(segment_size),
-      op_t{},
-      init_t{},
-      launch.get_stream()
-#if !TUNE_BASE
-        ,
-      policy_selector<accum_t>{}
-#endif
-    );
   });
 }
 

--- a/cub/benchmarks/bench/segmented_reduce/variable_base.cuh
+++ b/cub/benchmarks/bench/segmented_reduce/variable_base.cuh
@@ -95,6 +95,8 @@ void variable_segmented_reduce(nvbench::state& state, nvbench::type_list<T, Offs
   std::size_t temp_size{};
   using override_offset_t = cuda::std::conditional_t<(is_argmin || is_argmax), int, cub::detail::use_default>;
 
+  // TODO(bgruber): rewrite this to use the public CUB API directly. But in order to do this, we need to expose the
+  // guaranteed_max_seg_size at the public API
   cub::detail::segmented_reduce::dispatch<accum_t, override_offset_t>(
     nullptr,
     temp_size,

--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -74,7 +74,7 @@ struct DeviceSegmentedReduce
 {
 private:
   template <typename ReductionOpT,
-            typename TuningEnvT = ::cuda::std::execution::env,
+            typename TuningEnvT = ::cuda::std::execution::env<>,
             typename InputIteratorT,
             typename OutputIteratorT>
   CUB_RUNTIME_FUNCTION static cudaError_t fixed_size_arg_dispatch(

--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -514,6 +514,34 @@ public:
       d_in, d_out, num_segments, d_begin_offsets, d_end_offsets, reduction_op, initial_value, env);
   }
 
+  template <typename InputIteratorT, typename OutputIteratorT, typename ReductionOpT, typename T>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t __reduce(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    InputIteratorT d_in,
+    OutputIteratorT d_out,
+    ::cuda::std::int64_t num_segments,
+    int segment_size,
+    ReductionOpT reduction_op,
+    T initial_value,
+    cudaStream_t stream = nullptr)
+  {
+    // `offset_t` a.k.a `SegmentSizeT` is fixed to `int` type now, but later can be changed to accept
+    // integral constant or larger integral types
+    using offset_t = int;
+
+    return detail::segmented_reduce::dispatch_fixed_size(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_in,
+      d_out,
+      num_segments,
+      static_cast<offset_t>(segment_size),
+      reduction_op,
+      initial_value,
+      stream);
+  }
+
   //! @rst
   //! Computes a device-wide segmented reduction using the specified
   //! binary ``reduction_op`` functor and a fixed segment size.
@@ -591,21 +619,8 @@ public:
     cudaStream_t stream = nullptr)
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::Reduce");
-
-    // `offset_t` a.k.a `SegmentSizeT` is fixed to `int` type now, but later can be changed to accept
-    // integral constant or larger integral types
-    using offset_t = int;
-
-    return detail::segmented_reduce::dispatch_fixed_size(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_in,
-      d_out,
-      num_segments,
-      static_cast<offset_t>(segment_size),
-      reduction_op,
-      initial_value,
-      stream);
+    return __reduce(
+      d_temp_storage, temp_storage_bytes, d_in, d_out, num_segments, segment_size, reduction_op, initial_value, stream);
   }
 
   //! @rst
@@ -991,22 +1006,9 @@ public:
       cudaStream_t stream = nullptr)
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::Sum");
-    using output_t = detail::non_void_value_t<OutputIteratorT, detail::it_value_t<InputIteratorT>>;
-
-    // `offset_t` a.k.a `SegmentSizeT` is fixed to `int` type now, but later can be changed to accept
-    // integral constant or larger integral types
-    using offset_t = int;
-
-    return detail::segmented_reduce::dispatch_fixed_size(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_in,
-      d_out,
-      num_segments,
-      static_cast<offset_t>(segment_size),
-      ::cuda::std::plus{},
-      output_t{},
-      stream);
+    using init_t = detail::non_void_value_t<OutputIteratorT, detail::it_value_t<InputIteratorT>>;
+    return __reduce(
+      d_temp_storage, temp_storage_bytes, d_in, d_out, num_segments, segment_size, ::cuda::std::plus{}, init_t{}, stream);
   }
 
   //! @rst
@@ -1383,21 +1385,15 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::Min");
     using input_t = detail::it_value_t<InputIteratorT>;
-
-    // `offset_t` a.k.a `SegmentSizeT` is fixed to `int` type now, but later can be changed to accept
-    // integral constant or larger integral types
-    using offset_t = int;
-
     static_assert(::cuda::std::numeric_limits<input_t>::is_specialized,
                   "numeric_limits must be specialized for the input value type");
-
-    return detail::segmented_reduce::dispatch_fixed_size(
+    return __reduce(
       d_temp_storage,
       temp_storage_bytes,
       d_in,
       d_out,
       num_segments,
-      static_cast<offset_t>(segment_size),
+      segment_size,
       ::cuda::minimum<>{},
       ::cuda::std::numeric_limits<input_t>::max(),
       stream);
@@ -2190,21 +2186,15 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::Max");
     using input_t = detail::it_value_t<InputIteratorT>;
-
-    // `offset_t` a.k.a `SegmentSizeT` is fixed to `int` type now, but later can be changed to accept
-    // integral constant or larger integral types
-    using offset_t = int;
-
     static_assert(::cuda::std::numeric_limits<input_t>::is_specialized,
                   "numeric_limits must be specialized for the input value type");
-
-    return detail::segmented_reduce::dispatch_fixed_size(
+    return __reduce(
       d_temp_storage,
       temp_storage_bytes,
       d_in,
       d_out,
       num_segments,
-      static_cast<offset_t>(segment_size),
+      segment_size,
       ::cuda::maximum<>{},
       ::cuda::std::numeric_limits<input_t>::lowest(),
       stream);

--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -73,7 +73,10 @@ CUB_NAMESPACE_BEGIN
 struct DeviceSegmentedReduce
 {
 private:
-  template <typename ReductionOpT, typename InputIteratorT, typename OutputIteratorT>
+  template <typename ReductionOpT,
+            typename TuningEnvT = ::cuda::std::execution::env,
+            typename InputIteratorT,
+            typename OutputIteratorT>
   CUB_RUNTIME_FUNCTION static cudaError_t fixed_size_arg_dispatch(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -108,6 +111,11 @@ private:
       is_min ? ::cuda::std::numeric_limits<input_value_t>::max() : ::cuda::std::numeric_limits<input_value_t>::lowest();
     init_t initial_value{accum_t(1, sentinel)};
 
+    using default_policy_selector_t =
+      detail::segmented_reduce::policy_selector_from_types<accum_t, offset_t, ReductionOpT>;
+    using policy_selector_t = ::cuda::std::execution::
+      __query_result_or_t<TuningEnvT, detail::segmented_reduce::segmented_reduce_policy, default_policy_selector_t>;
+
     return detail::segmented_reduce::dispatch_fixed_size<accum_t>(
       d_temp_storage,
       temp_storage_bytes,
@@ -117,7 +125,8 @@ private:
       static_cast<offset_t>(segment_size),
       ReductionOpT(),
       initial_value,
-      stream);
+      stream,
+      policy_selector_t{});
   }
 
   template <typename ReductionOpT, typename InputIteratorT, typename OutputIteratorT, typename EnvT>
@@ -136,7 +145,7 @@ private:
 
     return detail::dispatch_with_env(
       env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
-        return fixed_size_arg_dispatch<ReductionOpT>(
+        return fixed_size_arg_dispatch<ReductionOpT, decltype(tuning)>(
           d_temp_storage, temp_storage_bytes, d_in, d_out, num_segments, segment_size, stream);
       });
   }

--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -77,7 +77,7 @@ private:
             typename TuningEnvT = ::cuda::std::execution::env<>,
             typename InputIteratorT,
             typename OutputIteratorT>
-  CUB_RUNTIME_FUNCTION static cudaError_t fixed_size_arg_dispatch(
+  CUB_RUNTIME_FUNCTION static cudaError_t fixed_size_arg_impl(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     InputIteratorT d_in,
@@ -130,7 +130,7 @@ private:
   }
 
   template <typename ReductionOpT, typename InputIteratorT, typename OutputIteratorT, typename EnvT>
-  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t fixed_size_arg_dispatch_env(
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t fixed_size_arg_impl_env(
     InputIteratorT d_in, OutputIteratorT d_out, ::cuda::std::int64_t num_segments, int segment_size, EnvT env)
   {
     using requirements_t = ::cuda::std::execution::
@@ -145,7 +145,7 @@ private:
 
     return detail::dispatch_with_env(
       env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
-        return fixed_size_arg_dispatch<ReductionOpT, decltype(tuning)>(
+        return fixed_size_arg_impl<ReductionOpT, decltype(tuning)>(
           d_temp_storage, temp_storage_bytes, d_in, d_out, num_segments, segment_size, stream);
       });
   }
@@ -159,7 +159,7 @@ private:
             typename ReductionOpT,
             typename InitT,
             typename EnvT>
-  CUB_RUNTIME_FUNCTION static cudaError_t segmented_reduce_impl(
+  CUB_RUNTIME_FUNCTION static cudaError_t variable_size_env_impl(
     InputIteratorT d_in,
     OutputIteratorT d_out,
     ::cuda::std::int64_t num_segments,
@@ -209,6 +209,34 @@ private:
     _CCCL_UNREACHABLE();
   }
 
+  template <typename InputIteratorT, typename OutputIteratorT, typename ReductionOpT, typename T>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t fixed_size_impl(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    InputIteratorT d_in,
+    OutputIteratorT d_out,
+    ::cuda::std::int64_t num_segments,
+    int segment_size,
+    ReductionOpT reduction_op,
+    T initial_value,
+    cudaStream_t stream = nullptr)
+  {
+    // `offset_t` a.k.a `SegmentSizeT` is fixed to `int` type now, but later can be changed to accept
+    // integral constant or larger integral types
+    using offset_t = int;
+
+    return detail::segmented_reduce::dispatch_fixed_size(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_in,
+      d_out,
+      num_segments,
+      static_cast<offset_t>(segment_size),
+      reduction_op,
+      initial_value,
+      stream);
+  }
+
   template <typename AccumT,
             typename OffsetT,
             typename InputIteratorT,
@@ -216,7 +244,7 @@ private:
             typename ReductionOpT,
             typename InitT,
             typename EnvT>
-  CUB_RUNTIME_FUNCTION static cudaError_t fixed_size_segmented_reduce_impl(
+  CUB_RUNTIME_FUNCTION static cudaError_t fixed_size_env_impl(
     InputIteratorT d_in,
     OutputIteratorT d_out,
     ::cuda::std::int64_t num_segments,
@@ -510,36 +538,8 @@ public:
     using OffsetT = detail::common_iterator_value_t<BeginOffsetIteratorT, EndOffsetIteratorT>;
     using AccumT  = ::cuda::std::__accumulator_t<ReductionOpT, cub::detail::it_value_t<InputIteratorT>, T>;
 
-    return segmented_reduce_impl<AccumT, OffsetT>(
+    return variable_size_env_impl<AccumT, OffsetT>(
       d_in, d_out, num_segments, d_begin_offsets, d_end_offsets, reduction_op, initial_value, env);
-  }
-
-  template <typename InputIteratorT, typename OutputIteratorT, typename ReductionOpT, typename T>
-  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t __reduce(
-    void* d_temp_storage,
-    size_t& temp_storage_bytes,
-    InputIteratorT d_in,
-    OutputIteratorT d_out,
-    ::cuda::std::int64_t num_segments,
-    int segment_size,
-    ReductionOpT reduction_op,
-    T initial_value,
-    cudaStream_t stream = nullptr)
-  {
-    // `offset_t` a.k.a `SegmentSizeT` is fixed to `int` type now, but later can be changed to accept
-    // integral constant or larger integral types
-    using offset_t = int;
-
-    return detail::segmented_reduce::dispatch_fixed_size(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_in,
-      d_out,
-      num_segments,
-      static_cast<offset_t>(segment_size),
-      reduction_op,
-      initial_value,
-      stream);
   }
 
   //! @rst
@@ -619,7 +619,7 @@ public:
     cudaStream_t stream = nullptr)
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::Reduce");
-    return __reduce(
+    return fixed_size_impl(
       d_temp_storage, temp_storage_bytes, d_in, d_out, num_segments, segment_size, reduction_op, initial_value, stream);
   }
 
@@ -718,7 +718,7 @@ public:
     using offset_t = int;
     using accum_t  = ::cuda::std::__accumulator_t<ReductionOpT, cub::detail::it_value_t<InputIteratorT>, T>;
 
-    return fixed_size_segmented_reduce_impl<accum_t>(
+    return fixed_size_env_impl<accum_t>(
       d_in, d_out, num_segments, static_cast<offset_t>(segment_size), reduction_op, initial_value, env);
   }
 
@@ -938,7 +938,7 @@ public:
     using op_t    = ::cuda::std::plus<>;
     using AccumT  = ::cuda::std::__accumulator_t<op_t, cub::detail::it_value_t<InputIteratorT>, init_t>;
 
-    return segmented_reduce_impl<AccumT, OffsetT>(
+    return variable_size_env_impl<AccumT, OffsetT>(
       d_in, d_out, num_segments, d_begin_offsets, d_end_offsets, op_t{}, init_t{}, env);
   }
 
@@ -1007,7 +1007,7 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::Sum");
     using init_t = detail::non_void_value_t<OutputIteratorT, detail::it_value_t<InputIteratorT>>;
-    return __reduce(
+    return fixed_size_impl(
       d_temp_storage, temp_storage_bytes, d_in, d_out, num_segments, segment_size, ::cuda::std::plus{}, init_t{}, stream);
   }
 
@@ -1082,7 +1082,7 @@ public:
     using op_t     = ::cuda::std::plus<>;
     using accum_t  = ::cuda::std::__accumulator_t<op_t, cub::detail::it_value_t<InputIteratorT>, output_t>;
 
-    return fixed_size_segmented_reduce_impl<accum_t>(
+    return fixed_size_env_impl<accum_t>(
       d_in, d_out, num_segments, static_cast<offset_t>(segment_size), op_t{}, output_t{}, env);
   }
 
@@ -1313,7 +1313,7 @@ public:
     static_assert(::cuda::std::numeric_limits<init_t>::is_specialized,
                   "numeric_limits must be specialized for the input value type");
 
-    return segmented_reduce_impl<AccumT, OffsetT>(
+    return variable_size_env_impl<AccumT, OffsetT>(
       d_in, d_out, num_segments, d_begin_offsets, d_end_offsets, op_t{}, ::cuda::std::numeric_limits<init_t>::max(), env);
   }
 
@@ -1387,7 +1387,7 @@ public:
     using input_t = detail::it_value_t<InputIteratorT>;
     static_assert(::cuda::std::numeric_limits<input_t>::is_specialized,
                   "numeric_limits must be specialized for the input value type");
-    return __reduce(
+    return fixed_size_impl(
       d_temp_storage,
       temp_storage_bytes,
       d_in,
@@ -1473,7 +1473,7 @@ public:
     using op_t     = ::cuda::minimum<>;
     using accum_t  = ::cuda::std::__accumulator_t<op_t, cub::detail::it_value_t<InputIteratorT>, input_t>;
 
-    return fixed_size_segmented_reduce_impl<accum_t>(
+    return fixed_size_env_impl<accum_t>(
       d_in,
       d_out,
       num_segments,
@@ -1754,7 +1754,7 @@ public:
 
     InitT initial_value{OverrideAccumT(1, ::cuda::std::numeric_limits<InputValueT>::max())};
 
-    return segmented_reduce_impl<OverrideAccumT, OverrideOffsetT>(
+    return variable_size_env_impl<OverrideAccumT, OverrideOffsetT>(
       d_indexed_in, d_out, num_segments, d_begin_offsets, d_end_offsets, cub::ArgMin{}, initial_value, env);
   }
 
@@ -1826,7 +1826,7 @@ public:
     cudaStream_t stream = nullptr)
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::ArgMin");
-    return fixed_size_arg_dispatch<cub::detail::arg_min>(
+    return fixed_size_arg_impl<cub::detail::arg_min>(
       d_temp_storage, temp_storage_bytes, d_in, d_out, num_segments, segment_size, stream);
   }
 
@@ -1889,7 +1889,7 @@ public:
   ArgMin(InputIteratorT d_in, OutputIteratorT d_out, ::cuda::std::int64_t num_segments, int segment_size, EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSegmentedReduce::ArgMin");
-    return fixed_size_arg_dispatch_env<cub::detail::arg_min>(d_in, d_out, num_segments, segment_size, env);
+    return fixed_size_arg_impl_env<cub::detail::arg_min>(d_in, d_out, num_segments, segment_size, env);
   }
 
   //! @rst
@@ -2113,7 +2113,7 @@ public:
     static_assert(::cuda::std::numeric_limits<init_t>::is_specialized,
                   "numeric_limits must be specialized for the input value type");
 
-    return segmented_reduce_impl<AccumT, OffsetT>(
+    return variable_size_env_impl<AccumT, OffsetT>(
       d_in,
       d_out,
       num_segments,
@@ -2188,7 +2188,7 @@ public:
     using input_t = detail::it_value_t<InputIteratorT>;
     static_assert(::cuda::std::numeric_limits<input_t>::is_specialized,
                   "numeric_limits must be specialized for the input value type");
-    return __reduce(
+    return fixed_size_impl(
       d_temp_storage,
       temp_storage_bytes,
       d_in,
@@ -2272,7 +2272,7 @@ public:
     using offset_t = int;
     using op_t     = ::cuda::maximum<>;
     using accum_t  = ::cuda::std::__accumulator_t<op_t, cub::detail::it_value_t<InputIteratorT>, input_t>;
-    return fixed_size_segmented_reduce_impl<accum_t>(
+    return fixed_size_env_impl<accum_t>(
       d_in,
       d_out,
       num_segments,
@@ -2556,7 +2556,7 @@ public:
 
     InitT initial_value{OverrideAccumT(1, ::cuda::std::numeric_limits<InputValueT>::lowest())};
 
-    return segmented_reduce_impl<OverrideAccumT, OverrideOffsetT>(
+    return variable_size_env_impl<OverrideAccumT, OverrideOffsetT>(
       d_indexed_in, d_out, num_segments, d_begin_offsets, d_end_offsets, cub::ArgMax{}, initial_value, env);
   }
 
@@ -2631,7 +2631,7 @@ public:
     cudaStream_t stream = nullptr)
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::ArgMax");
-    return fixed_size_arg_dispatch<detail::arg_max>(
+    return fixed_size_arg_impl<detail::arg_max>(
       d_temp_storage, temp_storage_bytes, d_in, d_out, num_segments, segment_size, stream);
   }
 
@@ -2694,7 +2694,7 @@ public:
   ArgMax(InputIteratorT d_in, OutputIteratorT d_out, ::cuda::std::int64_t num_segments, int segment_size, EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSegmentedReduce::ArgMax");
-    return fixed_size_arg_dispatch_env<cub::detail::arg_max>(d_in, d_out, num_segments, segment_size, env);
+    return fixed_size_arg_impl_env<cub::detail::arg_max>(d_in, d_out, num_segments, segment_size, env);
   }
 };
 

--- a/cub/cub/device/dispatch/dispatch_segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_segmented_reduce.cuh
@@ -684,29 +684,25 @@ struct DeviceFixedSizeSegmentedReduceKernelSource
   }
 };
 
-template <
-  typename OverrideAccumT = use_default,
-  typename InputIteratorT,
-  typename OutputIteratorT,
-  typename OffsetT,
-  typename ReductionOpT,
-  typename InitT = non_void_value_t<OutputIteratorT, it_value_t<InputIteratorT>>,
-  typename AccumT =
-    decltype(select_segmented_accum_t<InputIteratorT, InitT, ReductionOpT>(static_cast<OverrideAccumT*>(nullptr))),
-  typename PolicySelector = policy_selector_from_hub<detail::segmented_reduce::policy_hub<AccumT, OffsetT, ReductionOpT>,
-                                                     AccumT,
-                                                     OffsetT,
-                                                     ReductionOpT>,
-  typename KernelSource = DeviceFixedSizeSegmentedReduceKernelSource<
-    PolicySelector,
-    InputIteratorT,
-    OutputIteratorT,
-    OffsetT,
-    ReductionOpT,
-    InitT,
-    AccumT>,
-  typename KernelLauncherFactory                                       = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY,
-  ::cuda::std::enable_if_t<::cuda::std::is_arithmetic_v<OffsetT>, int> = 0>
+template <typename OverrideAccumT = use_default,
+          typename InputIteratorT,
+          typename OutputIteratorT,
+          typename OffsetT,
+          typename ReductionOpT,
+          typename InitT  = non_void_value_t<OutputIteratorT, it_value_t<InputIteratorT>>,
+          typename AccumT = decltype(select_segmented_accum_t<InputIteratorT, InitT, ReductionOpT>(
+            static_cast<OverrideAccumT*>(nullptr))),
+          typename PolicySelector,
+          typename KernelSource = DeviceFixedSizeSegmentedReduceKernelSource<
+            PolicySelector,
+            InputIteratorT,
+            OutputIteratorT,
+            OffsetT,
+            ReductionOpT,
+            InitT,
+            AccumT>,
+          typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY,
+          ::cuda::std::enable_if_t<::cuda::std::is_arithmetic_v<OffsetT>, int> = 0>
 #if _CCCL_HAS_CONCEPTS()
   requires segmented_reduce_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
@@ -720,7 +716,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch_fixed_size(
   ReductionOpT reduction_op,
   InitT init,
   cudaStream_t stream,
-  PolicySelector policy_selector         = {},
+  PolicySelector policy_selector,
   KernelSource kernel_source             = {},
   KernelLauncherFactory launcher_factory = {})
 {

--- a/cub/cub/device/dispatch/dispatch_segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_segmented_reduce.cuh
@@ -689,18 +689,18 @@ template <typename OverrideAccumT = use_default,
           typename OutputIteratorT,
           typename OffsetT,
           typename ReductionOpT,
-          typename InitT  = non_void_value_t<OutputIteratorT, it_value_t<InputIteratorT>>,
-          typename AccumT = decltype(select_segmented_accum_t<InputIteratorT, InitT, ReductionOpT>(
+          typename InitT          = non_void_value_t<OutputIteratorT, it_value_t<InputIteratorT>>,
+          typename AccumT         = decltype(select_segmented_accum_t<InputIteratorT, InitT, ReductionOpT>(
             static_cast<OverrideAccumT*>(nullptr))),
-          typename PolicySelector,
-          typename KernelSource = DeviceFixedSizeSegmentedReduceKernelSource<
-            PolicySelector,
-            InputIteratorT,
-            OutputIteratorT,
-            OffsetT,
-            ReductionOpT,
-            InitT,
-            AccumT>,
+          typename PolicySelector = policy_selector_from_types<AccumT, OffsetT, ReductionOpT>,
+          typename KernelSource   = DeviceFixedSizeSegmentedReduceKernelSource<
+              PolicySelector,
+              InputIteratorT,
+              OutputIteratorT,
+              OffsetT,
+              ReductionOpT,
+              InitT,
+              AccumT>,
           typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY,
           ::cuda::std::enable_if_t<::cuda::std::is_arithmetic_v<OffsetT>, int> = 0>
 #if _CCCL_HAS_CONCEPTS()
@@ -716,7 +716,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch_fixed_size(
   ReductionOpT reduction_op,
   InitT init,
   cudaStream_t stream,
-  PolicySelector policy_selector,
+  PolicySelector policy_selector         = {},
   KernelSource kernel_source             = {},
   KernelLauncherFactory launcher_factory = {})
 {

--- a/cub/test/catch2_test_device_segmented_reduce_env.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_env.cu
@@ -363,47 +363,273 @@ C2H_TEST("Device segmented argmax uses environment", "[segmented_reduce][device]
 }
 
 template <int BlockThreads>
-struct reduce_tuning
+struct segmented_reduce_tuning
 {
-  _CCCL_API constexpr auto operator()(::cuda::arch_id) const -> cub::detail::reduce::reduce_policy
+  _CCCL_API constexpr auto operator()(::cuda::arch_id) const -> cub::detail::segmented_reduce::segmented_reduce_policy
   {
     auto rp = cub::detail::reduce::agent_reduce_policy{
       BlockThreads, 1, 1, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_DEFAULT};
-    return {rp, rp, rp};
+    return {rp,
+            cub::detail::segmented_reduce::warp_reduce_policy{BlockThreads, 1, 1, 1, cub::LOAD_DEFAULT},
+            cub::detail::segmented_reduce::warp_reduce_policy{BlockThreads, 32, 1, 1, cub::LOAD_DEFAULT}};
   }
 };
 
-struct unrelated_policy
-{};
+using block_sizes = c2h::type_list<cuda::std::integral_constant<int, 64>, cuda::std::integral_constant<int, 128>>;
 
-struct unrelated_tuning
+#if TEST_LAUNCH != 1
+
+C2H_TEST("DeviceSegmentedReduce::Reduce can be tuned", "[segmented_reduce][device]", block_sizes)
 {
-  // should never be called
-  auto operator()(cuda::arch_id /*arch*/) const -> unrelated_policy
-  {
-    throw 1337;
-  }
-};
-
-using block_sizes = c2h::type_list<cuda::std::integral_constant<int, 32>, cuda::std::integral_constant<int, 64>>;
-
-C2H_TEST("Device segmented sum can be tuned", "[segmented_reduce][device]", block_sizes)
-{
-  constexpr int target_block_size = c2h::get<0, TestType>::value;
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
   int num_segments                     = 3;
-  thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
+  thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
-  thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
+  thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<int> d_out(3);
+  thrust::device_vector<unsigned int> d_block_size(1);
+
+  block_size_extracting_op<::cuda::std::plus<>> reduce_op{thrust::raw_pointer_cast(d_block_size.data())};
 
   // We are expecting that `unrelated_tuning` is ignored
-  auto env = cuda::execution::tune(reduce_tuning<target_block_size>{}, unrelated_tuning{});
+  auto env = cuda::execution::tune(segmented_reduce_tuning<target_block_size>{});
 
-  auto error =
-    cub::DeviceSegmentedReduce::Sum(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
-  thrust::device_vector<int> expected{21, 0, 17};
+  device_segmented_reduce(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, reduce_op, 0, env);
 
+  thrust::device_vector<int> expected{26, 12, 3};
   REQUIRE(d_out == expected);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_block_size[0] == target_block_size);
 }
+
+C2H_TEST("Fixed-size DeviceSegmentedReduce::Reduce can be tuned", "[segmented_reduce][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+
+  int num_segments = 2;
+  int segment_size = 3;
+  thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
+  thrust::device_vector<int> d_out(2);
+  thrust::device_vector<unsigned int> d_block_size(1);
+
+  block_size_extracting_op<::cuda::std::plus<>> reduce_op{thrust::raw_pointer_cast(d_block_size.data())};
+
+  auto env = cuda::execution::tune(segmented_reduce_tuning<target_block_size>{});
+
+  device_segmented_reduce(d_in.begin(), d_out.begin(), num_segments, segment_size, reduce_op, 0, env);
+
+  thrust::device_vector<int> expected{21, 8};
+  REQUIRE(d_out == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceSegmentedReduce::Sum can be tuned", "[segmented_reduce][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+
+  int num_segments                     = 3;
+  thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
+  auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
+  thrust::device_vector<int> d_out(3);
+  thrust::device_vector<unsigned int> d_block_size(1);
+
+  // use block_size_recording_iterator to embed blockDim info in the input type and query after
+  // since Sum can not take a custom reduction_op
+  auto d_in = block_size_extracting_constant_iterator(1, thrust::raw_pointer_cast(d_block_size.data()));
+
+  auto env = cuda::execution::tune(segmented_reduce_tuning<target_block_size>{});
+
+  device_segmented_reduce_sum(d_in, d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
+
+  thrust::device_vector<int> expected{4, 3, 2};
+  REQUIRE(d_out == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("Fixed-size DeviceSegmentedReduce::Sum can be tuned", "[segmented_reduce][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+
+  int num_segments = 2;
+  int segment_size = 3;
+  thrust::device_vector<int> d_out(2);
+  thrust::device_vector<unsigned int> d_block_size(1);
+
+  // use block_size_recording_iterator to embed blockDim info in the input type and query after
+  // since Sum can not take a custom reduction_op
+  auto d_in = block_size_extracting_constant_iterator(1, thrust::raw_pointer_cast(d_block_size.data()));
+
+  auto env = cuda::execution::tune(segmented_reduce_tuning<target_block_size>{});
+
+  device_segmented_reduce_sum(d_in, d_out.begin(), num_segments, segment_size, env);
+
+  thrust::device_vector<int> expected{3, 3};
+  REQUIRE(d_out == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceSegmentedReduce::Min can be tuned", "[segmented_reduce][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+
+  int num_segments                     = 3;
+  thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
+  auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
+  thrust::device_vector<int> d_out(3);
+  thrust::device_vector<unsigned int> d_block_size(1);
+
+  auto d_in = block_size_extracting_constant_iterator(1, thrust::raw_pointer_cast(d_block_size.data()));
+  auto env  = cuda::execution::tune(segmented_reduce_tuning<target_block_size>{});
+
+  device_segmented_reduce_min(d_in, d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
+
+  thrust::device_vector<int> expected{1, 1, 1};
+  REQUIRE(d_out == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("Fixed-size DeviceSegmentedReduce::Min can be tuned", "[segmented_reduce][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+
+  int num_segments = 2;
+  int segment_size = 3;
+  thrust::device_vector<int> d_out(2);
+  thrust::device_vector<unsigned int> d_block_size(1);
+
+  auto d_in = block_size_extracting_constant_iterator(1, thrust::raw_pointer_cast(d_block_size.data()));
+  auto env  = cuda::execution::tune(segmented_reduce_tuning<target_block_size>{});
+
+  device_segmented_reduce_min(d_in, d_out.begin(), num_segments, segment_size, env);
+
+  thrust::device_vector<int> expected{1, 1};
+  REQUIRE(d_out == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceSegmentedReduce::Max can be tuned", "[segmented_reduce][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+
+  int num_segments                     = 3;
+  thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
+  auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
+  thrust::device_vector<int> d_out(3);
+  thrust::device_vector<unsigned int> d_block_size(1);
+
+  auto d_in = block_size_extracting_constant_iterator(1, thrust::raw_pointer_cast(d_block_size.data()));
+  auto env  = cuda::execution::tune(segmented_reduce_tuning<target_block_size>{});
+
+  device_segmented_reduce_max(d_in, d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
+
+  thrust::device_vector<int> expected{1, 1, 1};
+  REQUIRE(d_out == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("Fixed-size DeviceSegmentedReduce::Max can be tuned", "[segmented_reduce][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+
+  int num_segments = 2;
+  int segment_size = 3;
+  thrust::device_vector<int> d_out(2);
+  thrust::device_vector<unsigned int> d_block_size(1);
+
+  auto d_in = block_size_extracting_constant_iterator(1, thrust::raw_pointer_cast(d_block_size.data()));
+  auto env  = cuda::execution::tune(segmented_reduce_tuning<target_block_size>{});
+
+  device_segmented_reduce_max(d_in, d_out.begin(), num_segments, segment_size, env);
+
+  thrust::device_vector<int> expected{1, 1};
+  REQUIRE(d_out == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceSegmentedReduce::ArgMin can be tuned", "[segmented_reduce][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+
+  int num_segments                     = 3;
+  thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
+  auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
+  thrust::device_vector<cub::KeyValuePair<int, int>> d_out(3);
+  thrust::device_vector<unsigned int> d_block_size(1);
+
+  auto d_in = block_size_extracting_constant_iterator(1, thrust::raw_pointer_cast(d_block_size.data()));
+  auto env  = cuda::execution::tune(segmented_reduce_tuning<target_block_size>{});
+
+  device_segmented_reduce_argmin(d_in, d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
+
+  thrust::host_vector<cub::KeyValuePair<int, int>> h_out(d_out);
+  for (int i = 0; i < num_segments; i++)
+  {
+    REQUIRE(h_out[i].key == 0);
+    REQUIRE(h_out[i].value == 1);
+  }
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("Fixed-size DeviceSegmentedReduce::ArgMin can be tuned", "[segmented_reduce][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+
+  int num_segments = 2;
+  int segment_size = 3;
+  thrust::device_vector<cuda::std::pair<int, int>> d_out(2);
+  thrust::device_vector<unsigned int> d_block_size(1);
+
+  auto d_in = block_size_extracting_constant_iterator(1, thrust::raw_pointer_cast(d_block_size.data()));
+  auto env  = cuda::execution::tune(segmented_reduce_tuning<target_block_size>{});
+
+  device_segmented_reduce_argmin(d_in, d_out.begin(), num_segments, segment_size, env);
+
+  thrust::device_vector<cuda::std::pair<int, int>> expected{{0, 1}, {0, 1}};
+  REQUIRE(d_out == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceSegmentedReduce::ArgMax can be tuned", "[segmented_reduce][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+
+  int num_segments                     = 3;
+  thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
+  auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
+  thrust::device_vector<cub::KeyValuePair<int, int>> d_out(3);
+  thrust::device_vector<unsigned int> d_block_size(1);
+
+  auto d_in = block_size_extracting_constant_iterator(1, thrust::raw_pointer_cast(d_block_size.data()));
+  auto env  = cuda::execution::tune(segmented_reduce_tuning<target_block_size>{});
+
+  device_segmented_reduce_argmax(d_in, d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
+
+  thrust::host_vector<cub::KeyValuePair<int, int>> h_out(d_out);
+  for (int i = 0; i < num_segments; i++)
+  {
+    REQUIRE(h_out[i].key == 0);
+    REQUIRE(h_out[i].value == 1);
+  }
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("Fixed-size DeviceSegmentedReduce::ArgMax can be tuned", "[segmented_reduce][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+
+  int num_segments = 2;
+  int segment_size = 3;
+  thrust::device_vector<cuda::std::pair<int, int>> d_out(2);
+  thrust::device_vector<unsigned int> d_block_size(1);
+
+  auto d_in = block_size_extracting_constant_iterator(1, thrust::raw_pointer_cast(d_block_size.data()));
+  auto env  = cuda::execution::tune(segmented_reduce_tuning<target_block_size>{});
+
+  device_segmented_reduce_argmax(d_in, d_out.begin(), num_segments, segment_size, env);
+
+  thrust::device_vector<cuda::std::pair<int, int>> expected{{0, 1}, {0, 1}};
+  REQUIRE(d_out == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+#endif // TEST_LAUNCH != 1


### PR DESCRIPTION
- [x] Merge before: #8693
- [x] Merge before: #8694
- [x] No SASS changes for `cub.bench.segmented_reduce.sum.base` on SM`75;100`

Fixes: #7950