### PR TITLE
Replace `detail::rle::encode|non_trivial_runs` by the public API 

### DIFF
--- a/cub/benchmarks/bench/run_length_encode/encode.cu
+++ b/cub/benchmarks/bench/run_length_encode/encode.cu
@@ -3,8 +3,6 @@
 
 #include <cub/device/device_run_length_encode.cuh>
 
-#include <cuda/iterator>
-
 #include <look_back_helper.cuh>
 #include <nvbench_helper.cuh>
 
@@ -34,78 +32,58 @@ struct bench_encode_policy_selector
 };
 #endif // !TUNE_BASE
 
+//! @tparam RunLengthT Offset type large enough to represent the longest run in the sequence
 template <class T, class OffsetT, class RunLengthT>
 static void rle(nvbench::state& state, nvbench::type_list<T, OffsetT, RunLengthT>)
 {
-  // Offset type large enough to represent any offset into the input sequence
+  // Offset type large enough to represent any offset into the input sequence and the total number of runs
   using offset_t = cub::detail::choose_signed_offset_t<OffsetT>;
-  // Offset type large enough to represent the longest run in the sequence
-  using run_length_t = RunLengthT;
-  // Offset type large enough to represent the total number of runs in the sequence
-  using num_runs_t = offset_t;
-
-  using run_length_input_it_t = cuda::constant_iterator<run_length_t, offset_t>;
-  using equality_op_t         = cuda::std::equal_to<>;
-  using reduction_op_t        = cuda::std::plus<>;
-  using accum_t               = run_length_t;
 
   const auto elements                    = static_cast<std::size_t>(state.get_int64("Elements{io}"));
   constexpr std::size_t min_segment_size = 1;
   const std::size_t max_segment_size     = static_cast<std::size_t>(state.get_int64("MaxSegSize"));
 
-  thrust::device_vector<num_runs_t> num_runs_out(1);
-  thrust::device_vector<run_length_t> out_vals(elements);
+  thrust::device_vector<offset_t> num_runs_out(1);
+  thrust::device_vector<RunLengthT> out_counts(elements);
   thrust::device_vector<T> out_keys(elements);
   thrust::device_vector<T> in_keys = generate.uniform.key_segments(elements, min_segment_size, max_segment_size);
 
-  const T* d_in_keys  = thrust::raw_pointer_cast(in_keys.data());
-  T* d_out_keys       = thrust::raw_pointer_cast(out_keys.data());
-  auto d_out_vals     = thrust::raw_pointer_cast(out_vals.data());
-  auto d_num_runs_out = thrust::raw_pointer_cast(num_runs_out.data());
-  run_length_input_it_t d_in_vals(run_length_t{1});
+  const T* d_in_keys       = thrust::raw_pointer_cast(in_keys.data());
+  T* d_out_keys            = thrust::raw_pointer_cast(out_keys.data());
+  RunLengthT* d_out_counts = thrust::raw_pointer_cast(out_counts.data());
+  offset_t* d_num_runs_out = thrust::raw_pointer_cast(num_runs_out.data());
 
-  std::uint8_t* d_temp_storage{};
-  std::size_t temp_storage_bytes{};
-  const offset_t num_items = static_cast<offset_t>(elements);
-
-  auto dispatch_on_stream = [&](cudaStream_t stream) {
-    return cub::detail::reduce_by_key::dispatch_streaming</* OverrideAccumT */ accum_t>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_in_keys,
-      d_out_keys,
-      d_in_vals,
-      d_out_vals,
-      d_num_runs_out,
-      equality_op_t{},
-      reduction_op_t{},
-      num_items,
-      stream,
-#if TUNE_BASE
-      cub::detail::rle::encode::policy_selector_from_types<accum_t, T> {}
-#else // TUNE_BASE
-      bench_encode_policy_selector{}
-#endif // TUNE_BASE
-    );
-  };
-
-  dispatch_on_stream(cudaStream_t{nullptr});
-
-  thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
-  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
-
-  dispatch_on_stream(cudaStream_t{nullptr});
+  // Run once to get num_runs for memory accounting
+  (void) cub::DeviceRunLengthEncode::Encode(
+    d_in_keys, d_out_keys, d_out_counts, d_num_runs_out, static_cast<OffsetT>(elements));
   cudaDeviceSynchronize();
-  const num_runs_t num_runs = num_runs_out[0];
+  const offset_t num_runs = num_runs_out[0];
 
   state.add_element_count(elements);
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(num_runs);
-  state.add_global_memory_writes<run_length_t>(num_runs);
-  state.add_global_memory_writes<num_runs_t>(1);
+  state.add_global_memory_writes<RunLengthT>(num_runs);
+  state.add_global_memory_writes<offset_t>(1);
 
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    dispatch_on_stream(launch.get_stream());
+    auto env = cub_bench_env(
+      alloc,
+      launch
+#if !TUNE_BASE
+      ,
+      cuda::execution::__tune(bench_encode_policy_selector{})
+#endif // !TUNE_BASE
+    );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceRunLengthEncode::Encode,
+      "Encode failed",
+      d_in_keys,
+      d_out_keys,
+      d_out_counts,
+      d_num_runs_out,
+      static_cast<OffsetT>(elements),
+      env);
   });
 }
 

--- a/cub/benchmarks/bench/run_length_encode/encode.cu
+++ b/cub/benchmarks/bench/run_length_encode/encode.cu
@@ -72,7 +72,7 @@ static void rle(nvbench::state& state, nvbench::type_list<T, OffsetT, RunLengthT
       launch
 #if !TUNE_BASE
       ,
-      cuda::execution::__tune(bench_encode_policy_selector{})
+      cuda::execution::tune(bench_encode_policy_selector{})
 #endif // !TUNE_BASE
     );
     _CCCL_TRY_CUDA_API(

--- a/cub/benchmarks/bench/run_length_encode/non_trivial_runs.cu
+++ b/cub/benchmarks/bench/run_length_encode/non_trivial_runs.cu
@@ -37,16 +37,7 @@ struct bench_rle_policy_selector
 template <class T, class OffsetT, class RunLengthT>
 static void rle(nvbench::state& state, nvbench::type_list<T, OffsetT, RunLengthT>)
 {
-  // Offset type large enough to represent any offset into the input sequence
   using offset_t = cub::detail::choose_signed_offset_t<OffsetT>;
-  // Offset type large enough to represent the longest run in the sequence
-  using run_length_t = RunLengthT;
-
-  using keys_input_it_t            = const T*;
-  using offset_output_it_t         = offset_t*;
-  using length_output_it_t         = run_length_t*;
-  using num_runs_output_iterator_t = offset_t*;
-  using equality_op_t              = ::cuda::std::equal_to<>;
 
   const auto elements                    = static_cast<std::size_t>(state.get_int64("Elements{io}"));
   constexpr std::size_t min_segment_size = 1;
@@ -54,43 +45,32 @@ static void rle(nvbench::state& state, nvbench::type_list<T, OffsetT, RunLengthT
 
   thrust::device_vector<offset_t> num_runs_out(1);
   thrust::device_vector<offset_t> out_offsets(elements);
-  thrust::device_vector<run_length_t> out_lengths(elements);
+  thrust::device_vector<RunLengthT> out_lengths(elements);
   thrust::device_vector<T> in_keys = generate.uniform.key_segments(elements, min_segment_size, max_segment_size);
 
-  const T* d_in_keys          = thrust::raw_pointer_cast(in_keys.data());
-  offset_t* d_out_offsets     = thrust::raw_pointer_cast(out_offsets.data());
-  run_length_t* d_out_lengths = thrust::raw_pointer_cast(out_lengths.data());
-  offset_t* d_num_runs_out    = thrust::raw_pointer_cast(num_runs_out.data());
+  const T* d_in_keys        = thrust::raw_pointer_cast(in_keys.data());
+  offset_t* d_out_offsets   = thrust::raw_pointer_cast(out_offsets.data());
+  RunLengthT* d_out_lengths = thrust::raw_pointer_cast(out_lengths.data());
+  offset_t* d_num_runs_out  = thrust::raw_pointer_cast(num_runs_out.data());
 
-  std::uint8_t* d_temp_storage{};
-  std::size_t temp_storage_bytes{};
-  const offset_t num_items = static_cast<offset_t>(elements);
-
-  auto dispatch_on_stream = [&](cudaStream_t stream) {
-    cub::detail::rle::dispatch(
-      d_temp_storage,
-      temp_storage_bytes,
+  {
+    // Run once to get num_runs for memory accounting
+    auto memory_env = cuda::std::execution::env{
+#if !TUNE_BASE
+      cuda::execution::tune(bench_rle_policy_selector{})
+#endif // !TUNE_BASE
+    };
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceRunLengthEncode::NonTrivialRuns,
+      "NonTrivialRuns failed",
       d_in_keys,
       d_out_offsets,
       d_out_lengths,
       d_num_runs_out,
-      equality_op_t{},
-      num_items,
-      stream
-#if !TUNE_BASE
-      ,
-      bench_rle_policy_selector{}
-#endif
-    );
-  };
-
-  dispatch_on_stream(cudaStream_t{nullptr});
-
-  thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
-  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
-
-  dispatch_on_stream(cudaStream_t{nullptr});
-  cudaDeviceSynchronize();
+      static_cast<OffsetT>(elements),
+      memory_env);
+    cudaDeviceSynchronize();
+  }
   const OffsetT num_runs = num_runs_out[0];
 
   state.add_element_count(elements);
@@ -99,8 +79,25 @@ static void rle(nvbench::state& state, nvbench::type_list<T, OffsetT, RunLengthT
   state.add_global_memory_writes<OffsetT>(num_runs);
   state.add_global_memory_writes<OffsetT>(1);
 
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    dispatch_on_stream(launch.get_stream().get_stream());
+    auto env = cub_bench_env(
+      alloc,
+      launch
+#if !TUNE_BASE
+      ,
+      cuda::execution::tune(bench_rle_policy_selector{})
+#endif // !TUNE_BASE
+    );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceRunLengthEncode::NonTrivialRuns,
+      "NonTrivialRuns failed",
+      d_in_keys,
+      d_out_offsets,
+      d_out_lengths,
+      d_num_runs_out,
+      static_cast<OffsetT>(elements),
+      env);
   });
 }
 

--- a/cub/cub/device/device_run_length_encode.cuh
+++ b/cub/cub/device/device_run_length_encode.cuh
@@ -22,10 +22,10 @@
 
 #include <cub/detail/choose_offset.cuh>
 #include <cub/detail/env_dispatch.cuh>
-#include <cub/device/dispatch/dispatch_reduce_by_key.cuh>
 #include <cub/device/dispatch/dispatch_rle.cuh>
 #include <cub/device/dispatch/dispatch_streaming_reduce_by_key.cuh>
 #include <cub/device/dispatch/tuning/tuning_rle_encode.cuh>
+#include <cub/device/dispatch/tuning/tuning_rle_non_trivial_runs.cuh>
 
 #include <cuda/__iterator/constant_iterator.h>
 #include <cuda/std/__execution/env.h>
@@ -302,23 +302,24 @@ struct DeviceRunLengthEncode
     using lengths_input_iterator_t = ::cuda::constant_iterator<length_t, offset_t>;
     using accum_t                  = ::cuda::std::__accumulator_t<reduction_op, length_t, length_t>;
     using key_t = cub::detail::non_void_value_t<UniqueOutputIteratorT, cub::detail::it_value_t<InputIteratorT>>;
-    using policy_selector_t = detail::rle::encode::policy_selector_from_types<accum_t, key_t>;
+    using default_policy_selector = detail::rle::encode::policy_selector_from_types<accum_t, key_t>;
 
-    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::reduce_by_key::dispatch_streaming<accum_t>(
-        storage,
-        bytes,
-        d_in,
-        d_unique_out,
-        lengths_input_iterator_t(length_t{1}),
-        d_counts_out,
-        d_num_runs_out,
-        equality_op{},
-        reduction_op{},
-        static_cast<offset_t>(num_items),
-        stream,
-        policy_selector_t{});
-    });
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::reduce_by_key::dispatch_streaming<accum_t>(
+          storage,
+          bytes,
+          d_in,
+          d_unique_out,
+          lengths_input_iterator_t(length_t{1}),
+          d_counts_out,
+          d_num_runs_out,
+          equality_op{},
+          reduction_op{},
+          static_cast<offset_t>(num_items),
+          stream,
+          policy_selector);
+      });
   }
 
   //! @rst
@@ -541,21 +542,26 @@ struct DeviceRunLengthEncode
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceRunLengthEncode::NonTrivialRuns");
 
-    using global_offset_t = detail::choose_signed_offset_t<NumItemsT>;
-    using equality_op     = ::cuda::std::equal_to<>;
+    using global_offset_t         = detail::choose_signed_offset_t<NumItemsT>;
+    using equality_op             = ::cuda::std::equal_to<>;
+    using length_t                = detail::non_void_value_t<LengthsOutputIteratorT, global_offset_t>;
+    using key_t                   = detail::it_value_t<InputIteratorT>;
+    using default_policy_selector = detail::rle::non_trivial_runs::policy_selector_from_types<length_t, key_t>;
 
-    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::rle::dispatch(
-        storage,
-        bytes,
-        d_in,
-        d_offsets_out,
-        d_lengths_out,
-        d_num_runs_out,
-        equality_op{},
-        static_cast<global_offset_t>(num_items),
-        stream);
-    });
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::rle::dispatch(
+          storage,
+          bytes,
+          d_in,
+          d_offsets_out,
+          d_lengths_out,
+          d_num_runs_out,
+          equality_op{},
+          static_cast<global_offset_t>(num_items),
+          stream,
+          policy_selector);
+      });
   }
 };
 

--- a/cub/test/catch2_test_device_run_length_encode_env.cu
+++ b/cub/test/catch2_test_device_run_length_encode_env.cu
@@ -9,8 +9,10 @@ struct stream_registry_factory_t;
 
 #include <cub/device/device_run_length_encode.cuh>
 
+#include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/device_vector.h>
 
+#include <cuda/__execution/tune.h>
 #include <cuda/devices>
 #include <cuda/iterator>
 #include <cuda/stream>
@@ -25,6 +27,28 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceRunLengthEncode::NonTrivialRuns, non_trivial_r
 #include <c2h/catch2_test_helper.h>
 
 namespace stdexec = cuda::std::execution;
+
+template <int BlockThreads>
+struct rle_encode_tuning
+{
+  _CCCL_API constexpr auto operator()(cuda::arch_id /*arch*/) const -> cub::detail::reduce_by_key::reduce_by_key_policy
+  {
+    return {BlockThreads, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_SCAN_WARP_SCANS, {}};
+  }
+};
+
+template <int BlockThreads>
+struct rle_non_trivial_runs_tuning
+{
+  _CCCL_API constexpr auto operator()(cuda::arch_id /*arch*/) const
+    -> cub::detail::rle::non_trivial_runs::rle_non_trivial_runs_policy
+  {
+    return {BlockThreads, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, false, cub::BLOCK_SCAN_WARP_SCANS, {}};
+  }
+};
+
+using block_sizes =
+  c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
 
 #if TEST_LAUNCH == 0
 
@@ -229,3 +253,51 @@ TEST_CASE("DeviceRunLengthEncode::NonTrivialRuns uses custom stream", "[run_leng
   REQUIRE(d_offsets_out == expected_offsets);
   REQUIRE(d_lengths_out == expected_lengths);
 }
+
+#if TEST_LAUNCH != 1
+
+C2H_TEST("DeviceRunLengthEncode::Encode can be tuned", "[run_length_encode][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  constexpr int num_items                  = 256;
+
+  auto d_block_size = c2h::device_vector<unsigned int>(1, 0);
+  block_size_extracting_constant_iterator d_in(42, thrust::raw_pointer_cast(d_block_size.data()));
+
+  auto d_unique_out   = c2h::device_vector<int>(1);
+  auto d_counts_out   = c2h::device_vector<int>(1);
+  auto d_num_runs_out = c2h::device_vector<int>(1);
+
+  auto env = cuda::execution::tune(rle_encode_tuning<target_block_size>{});
+
+  run_length_encode_env(d_in, d_unique_out.begin(), d_counts_out.begin(), d_num_runs_out.begin(), num_items, env);
+
+  REQUIRE(d_num_runs_out[0] == 1);
+  REQUIRE(d_unique_out[0] == 42);
+  REQUIRE(d_counts_out[0] == num_items);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns can be tuned", "[run_length_encode][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  constexpr int num_items                  = 256;
+
+  auto d_block_size = c2h::device_vector<unsigned int>(1, 0);
+  block_size_extracting_constant_iterator d_in(42, thrust::raw_pointer_cast(d_block_size.data()));
+
+  auto d_offsets_out  = c2h::device_vector<int>(1);
+  auto d_lengths_out  = c2h::device_vector<int>(1);
+  auto d_num_runs_out = c2h::device_vector<int>(1);
+
+  auto env = cuda::execution::tune(rle_non_trivial_runs_tuning<target_block_size>{});
+
+  non_trivial_runs_env(d_in, d_offsets_out.begin(), d_lengths_out.begin(), d_num_runs_out.begin(), num_items, env);
+
+  REQUIRE(d_num_runs_out[0] == 1);
+  REQUIRE(d_offsets_out[0] == 0);
+  REQUIRE(d_lengths_out[0] == num_items);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+#endif // TEST_LAUNCH != 1


### PR DESCRIPTION
And extract tunings at the public API.

- [x] Merge before: #8694
- [x] No SASS changes for `cub.bench.run_length_encode.encode.base` for SM`75;80;86;90;100`
- [x] No SASS changes for `cub.bench.run_length_encode.non_trivial_runs.base` for SM`75;80;86;90;100`

Fixes: #7954
Fixes: #7959