### PR TITLE
Implement parallel `cuda::std::is_heap_until` / `is_heap`

### DIFF
--- a/libcudacxx/benchmarks/bench/is_heap/basic.cu
+++ b/libcudacxx/benchmarks/bench/is_heap/basic.cu
@@ -34,7 +34,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
 {
   const auto elements        = static_cast<std::size_t>(state.get_int64("Elements"));
   const auto violation_frac  = state.get_float64("ViolationAt");
-  const auto violation_point = ::cuda::std::clamp<std::size_t>(elements * violation_frac, 0ull, elements - 1);
+  const auto violation_point = cuda::std::clamp<std::size_t>(elements * violation_frac, 0ull, elements - 1);
 
   thrust::device_vector<T> dinput(elements, thrust::no_init);
   prepare_input(dinput, violation_point);
@@ -60,7 +60,7 @@ static void with_predicate(nvbench::state& state, nvbench::type_list<T>)
 {
   const auto elements        = static_cast<std::size_t>(state.get_int64("Elements"));
   const auto violation_frac  = state.get_float64("ViolationAt");
-  const auto violation_point = ::cuda::std::clamp<std::size_t>(elements * violation_frac, 0ull, elements - 1);
+  const auto violation_point = cuda::std::clamp<std::size_t>(elements * violation_frac, 0ull, elements - 1);
 
   thrust::device_vector<T> dinput(elements, thrust::no_init);
   prepare_input(dinput, violation_point);

--- a/libcudacxx/benchmarks/bench/is_heap/basic.cu
+++ b/libcudacxx/benchmarks/bench/is_heap/basic.cu
@@ -46,7 +46,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
 
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch) {
-               do_not_optimize(cuda::std::is_heap_until(cuda_policy(alloc, launch), dinput.begin(), dinput.end()));
+               do_not_optimize(cuda::std::is_heap(cuda_policy(alloc, launch), dinput.begin(), dinput.end()));
              });
 }
 
@@ -70,11 +70,11 @@ static void with_predicate(nvbench::state& state, nvbench::type_list<T>)
 
   caching_allocator_t alloc{};
 
-  state.exec(
-    nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-      do_not_optimize(
-        cuda::std::is_heap_until(cuda_policy(alloc, launch), dinput.begin(), dinput.end(), cuda::std::less<>{}));
-    });
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               do_not_optimize(
+                 cuda::std::is_heap(cuda_policy(alloc, launch), dinput.begin(), dinput.end(), cuda::std::less<>{}));
+             });
 }
 
 NVBENCH_BENCH_TYPES(with_predicate, NVBENCH_TYPE_AXES(fundamental_types))

--- a/libcudacxx/benchmarks/bench/is_heap_until/basic.cu
+++ b/libcudacxx/benchmarks/bench/is_heap_until/basic.cu
@@ -34,7 +34,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
 {
   const auto elements        = static_cast<std::size_t>(state.get_int64("Elements"));
   const auto violation_frac  = state.get_float64("ViolationAt");
-  const auto violation_point = ::cuda::std::clamp<std::size_t>(elements * violation_frac, 0ull, elements - 1);
+  const auto violation_point = cuda::std::clamp<std::size_t>(elements * violation_frac, 0ull, elements - 1);
 
   thrust::device_vector<T> dinput(elements, thrust::no_init);
   prepare_input(dinput, violation_point);
@@ -60,7 +60,7 @@ static void with_predicate(nvbench::state& state, nvbench::type_list<T>)
 {
   const auto elements        = static_cast<std::size_t>(state.get_int64("Elements"));
   const auto violation_frac  = state.get_float64("ViolationAt");
-  const auto violation_point = ::cuda::std::clamp<std::size_t>(elements * violation_frac, 0ull, elements - 1);
+  const auto violation_point = cuda::std::clamp<std::size_t>(elements * violation_frac, 0ull, elements - 1);
 
   thrust::device_vector<T> dinput(elements, thrust::no_init);
   prepare_input(dinput, violation_point);

--- a/libcudacxx/benchmarks/bench/is_heap_until/basic.cu
+++ b/libcudacxx/benchmarks/bench/is_heap_until/basic.cu
@@ -1,0 +1,83 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+#include <thrust/fill.h>
+
+#include <cuda/functional>
+#include <cuda/std/execution>
+#include <cuda/stream>
+
+#include "nvbench_helper.cuh"
+
+// All-zero is a valid heap; setting one element to 1 forces a violation at
+// that child index since its parent is still 0.
+template <typename T>
+static void prepare_input(thrust::device_vector<T>& d, std::size_t violation_point)
+{
+  thrust::fill(d.begin(), d.end(), T{0});
+  if (violation_point >= 1 && violation_point < d.size())
+  {
+    d[violation_point] = T{1};
+  }
+}
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements        = static_cast<std::size_t>(state.get_int64("Elements"));
+  const auto violation_frac  = state.get_float64("ViolationAt");
+  const auto violation_point = ::cuda::std::clamp<std::size_t>(elements * violation_frac, 0ull, elements - 1);
+
+  thrust::device_vector<T> dinput(elements, thrust::no_init);
+  prepare_input(dinput, violation_point);
+
+  state.add_global_memory_reads<T>(2 * elements);
+  state.add_global_memory_writes<size_t>(1);
+
+  caching_allocator_t alloc{};
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               do_not_optimize(cuda::std::is_heap_until(cuda_policy(alloc, launch), dinput.begin(), dinput.end()));
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
+  .add_float64_axis("ViolationAt", std::vector{1.0, 0.5, 0.01});
+
+template <typename T>
+static void with_predicate(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements        = static_cast<std::size_t>(state.get_int64("Elements"));
+  const auto violation_frac  = state.get_float64("ViolationAt");
+  const auto violation_point = ::cuda::std::clamp<std::size_t>(elements * violation_frac, 0ull, elements - 1);
+
+  thrust::device_vector<T> dinput(elements, thrust::no_init);
+  prepare_input(dinput, violation_point);
+
+  state.add_global_memory_reads<T>(2 * elements);
+  state.add_global_memory_writes<size_t>(1);
+
+  caching_allocator_t alloc{};
+
+  state.exec(
+    nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+      do_not_optimize(
+        cuda::std::is_heap_until(cuda_policy(alloc, launch), dinput.begin(), dinput.end(), cuda::std::less<>{}));
+    });
+}
+
+NVBENCH_BENCH_TYPES(with_predicate, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("with_predicate")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
+  .add_float64_axis("ViolationAt", std::vector{1.0, 0.5, 0.01});

--- a/libcudacxx/include/cuda/std/__pstl/is_heap.h
+++ b/libcudacxx/include/cuda/std/__pstl/is_heap.h
@@ -24,7 +24,6 @@
 #if !_CCCL_COMPILER(NVRTC)
 
 #  include <cuda/__iterator/counting_iterator.h>
-#  include <cuda/__iterator/transform_iterator.h>
 #  include <cuda/__iterator/zip_function.h>
 #  include <cuda/__iterator/zip_iterator.h>
 #  include <cuda/__nvtx/nvtx.h>
@@ -36,7 +35,7 @@
 #  include <cuda/std/__iterator/distance.h>
 #  include <cuda/std/__iterator/iterator_traits.h>
 #  include <cuda/std/__pstl/dispatch.h>
-#  include <cuda/std/__pstl/is_heap_until.h> // for __is_heap_parent_at_fn
+#  include <cuda/std/__pstl/is_heap_until.h>
 #  include <cuda/std/__type_traits/always_false.h>
 #  include <cuda/std/__type_traits/is_execution_policy.h>
 #  include <cuda/std/__utility/move.h>
@@ -76,14 +75,15 @@ _CCCL_REQUIRES(__has_random_access_traversal<_RandomAccessIterator> _CCCL_AND is
       return true;
     }
 
-    auto __parent_at = ::cuda::transform_iterator{
-      ::cuda::counting_iterator{__diff_t(0)}, __is_heap_parent_at_fn<_RandomAccessIterator>{__first}};
-
-    auto __result = __dispatch(
+    // Find the first heap-property violation in the index range [1, n).
+    // The result's dereferenced value is the violating child index, or n
+    // if the range is a heap. `::cuda::std::get<1>(__result.__iterators())`
+    // returns __last in the latter case.
+    const auto __result = __dispatch(
       __policy,
-      ::cuda::zip_iterator{__parent_at, __first + 1},
-      ::cuda::zip_iterator{__parent_at + (__n - 1), __last},
-      ::cuda::zip_function{::cuda::std::move(__comp)});
+      ::cuda::zip_iterator{::cuda::counting_iterator{__diff_t(1)}, __first + 1},
+      ::cuda::zip_iterator{::cuda::counting_iterator{__n}, __last},
+      ::cuda::zip_function{__is_heap_until_fn<_RandomAccessIterator, _Compare>{__first, ::cuda::std::move(__comp)}});
     return ::cuda::std::get<1>(__result.__iterators()) == __last;
   }
   else

--- a/libcudacxx/include/cuda/std/__pstl/is_heap.h
+++ b/libcudacxx/include/cuda/std/__pstl/is_heap.h
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_IS_HEAP_H
+#define _CUDA_STD___PSTL_IS_HEAP_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/std/__algorithm/is_heap.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__functional/operations.h>
+#  include <cuda/std/__iterator/concepts.h>
+#  include <cuda/std/__pstl/is_heap_until.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__utility/move.h>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_TEMPLATE(class _Policy, class _RandomAccessIterator, class _Compare = less<>)
+_CCCL_REQUIRES(__has_random_access_traversal<_RandomAccessIterator> _CCCL_AND is_execution_policy_v<_Policy>)
+[[nodiscard]] _CCCL_HOST_API bool
+is_heap(const _Policy& __policy, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp = {})
+{
+  return ::cuda::std::is_heap_until(__policy, __first, __last, ::cuda::std::move(__comp)) == __last;
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___PSTL_IS_HEAP_H

--- a/libcudacxx/include/cuda/std/__pstl/is_heap.h
+++ b/libcudacxx/include/cuda/std/__pstl/is_heap.h
@@ -23,13 +23,27 @@
 
 #if !_CCCL_COMPILER(NVRTC)
 
+#  include <cuda/__iterator/counting_iterator.h>
+#  include <cuda/__iterator/transform_iterator.h>
+#  include <cuda/__iterator/zip_function.h>
+#  include <cuda/__iterator/zip_iterator.h>
+#  include <cuda/__nvtx/nvtx.h>
 #  include <cuda/std/__algorithm/is_heap.h>
 #  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
 #  include <cuda/std/__functional/operations.h>
 #  include <cuda/std/__iterator/concepts.h>
-#  include <cuda/std/__pstl/is_heap_until.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__pstl/is_heap_until.h> // for __is_heap_parent_at_fn
+#  include <cuda/std/__type_traits/always_false.h>
 #  include <cuda/std/__type_traits/is_execution_policy.h>
 #  include <cuda/std/__utility/move.h>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/find_if.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
 
 #  include <cuda/std/__cccl/prologue.h>
 
@@ -39,10 +53,44 @@ _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
 _CCCL_TEMPLATE(class _Policy, class _RandomAccessIterator, class _Compare = less<>)
 _CCCL_REQUIRES(__has_random_access_traversal<_RandomAccessIterator> _CCCL_AND is_execution_policy_v<_Policy>)
-[[nodiscard]] _CCCL_HOST_API bool
-is_heap(const _Policy& __policy, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp = {})
+[[nodiscard]] _CCCL_HOST_API bool is_heap(
+  [[maybe_unused]] const _Policy& __policy,
+  _RandomAccessIterator __first,
+  _RandomAccessIterator __last,
+  _Compare __comp = {})
 {
-  return ::cuda::std::is_heap_until(__policy, __first, __last, ::cuda::std::move(__comp)) == __last;
+  static_assert(indirect_binary_predicate<_Compare, _RandomAccessIterator, _RandomAccessIterator>,
+                "cuda::std::is_heap: Compare must satisfy "
+                "indirect_binary_predicate<Compare, RandomAccessIterator, RandomAccessIterator>");
+
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__find_if, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cuda::std::is_heap");
+
+    using __diff_t = iter_difference_t<_RandomAccessIterator>;
+    const auto __n = ::cuda::std::distance(__first, __last);
+    if (__n < __diff_t(2))
+    {
+      return true;
+    }
+
+    auto __parent_at = ::cuda::transform_iterator{
+      ::cuda::counting_iterator{__diff_t(0)}, __is_heap_parent_at_fn<_RandomAccessIterator>{__first}};
+
+    auto __result = __dispatch(
+      __policy,
+      ::cuda::zip_iterator{__parent_at, __first + 1},
+      ::cuda::zip_iterator{__parent_at + (__n - 1), __last},
+      ::cuda::zip_function{::cuda::std::move(__comp)});
+    return ::cuda::std::get<1>(__result.__iterators()) == __last;
+  }
+  else
+  {
+    static_assert(__always_false_v<_Policy>, "Parallel cuda::std::is_heap requires at least one selected backend");
+    return ::cuda::std::is_heap(::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__comp));
+  }
 }
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT

--- a/libcudacxx/include/cuda/std/__pstl/is_heap_until.h
+++ b/libcudacxx/include/cuda/std/__pstl/is_heap_until.h
@@ -1,0 +1,117 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_IS_HEAP_UNTIL_H
+#define _CUDA_STD___PSTL_IS_HEAP_UNTIL_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/__iterator/counting_iterator.h>
+#  include <cuda/__nvtx/nvtx.h>
+#  include <cuda/std/__algorithm/is_heap_until.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__functional/operations.h>
+#  include <cuda/std/__iterator/concepts.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__utility/move.h>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/find_if.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+// Returns true at the first child index `i` (1 <= i < n) where the parent-child
+// max-heap invariant is broken, i.e. comp(base[(i-1)/2], base[i]) holds.
+template <class _RandomAccessIterator, class _Compare>
+struct __is_heap_until_fn
+{
+  _RandomAccessIterator __base_;
+  _Compare __comp_;
+
+  template <class _Diff>
+  [[nodiscard]] _CCCL_DEVICE_API constexpr bool operator()(const _Diff& __i) const
+  {
+    return __comp_(__base_[(__i - _Diff(1)) / _Diff(2)], __base_[__i]);
+  }
+};
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_TEMPLATE(class _Policy, class _RandomAccessIterator, class _Compare = less<>)
+_CCCL_REQUIRES(__has_random_access_traversal<_RandomAccessIterator> _CCCL_AND is_execution_policy_v<_Policy>)
+[[nodiscard]] _CCCL_HOST_API _RandomAccessIterator is_heap_until(
+  [[maybe_unused]] const _Policy& __policy,
+  _RandomAccessIterator __first,
+  _RandomAccessIterator __last,
+  _Compare __comp = {})
+{
+  static_assert(indirect_binary_predicate<_Compare, _RandomAccessIterator, _RandomAccessIterator>,
+                "cuda::std::is_heap_until: Compare must satisfy "
+                "indirect_binary_predicate<Compare, RandomAccessIterator, RandomAccessIterator>");
+
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__find_if, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cuda::std::is_heap_until");
+
+    using __diff_t = iter_difference_t<_RandomAccessIterator>;
+    const auto __n = ::cuda::std::distance(__first, __last);
+    if (__n < __diff_t(2))
+    {
+      return __last;
+    }
+
+    // Find the first heap-property violation in the index range [1, n).
+    // The result's dereferenced value is the violating child index, or n
+    // if the range is a heap. `__first + *__it` returns __last in the
+    // latter case.
+    const auto __it = __dispatch(
+      __policy,
+      ::cuda::counting_iterator{__diff_t(1)},
+      ::cuda::counting_iterator{__n},
+      __is_heap_until_fn<_RandomAccessIterator, _Compare>{__first, ::cuda::std::move(__comp)});
+    return __first + (*__it);
+  }
+  else
+  {
+    static_assert(__always_false_v<_Policy>,
+                  "Parallel cuda::std::is_heap_until requires at least one selected backend");
+    return ::cuda::std::is_heap_until(::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__comp));
+  }
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___PSTL_IS_HEAP_UNTIL_H

--- a/libcudacxx/include/cuda/std/__pstl/is_heap_until.h
+++ b/libcudacxx/include/cuda/std/__pstl/is_heap_until.h
@@ -24,6 +24,9 @@
 #if !_CCCL_COMPILER(NVRTC)
 
 #  include <cuda/__iterator/counting_iterator.h>
+#  include <cuda/__iterator/transform_iterator.h>
+#  include <cuda/__iterator/zip_function.h>
+#  include <cuda/__iterator/zip_iterator.h>
 #  include <cuda/__nvtx/nvtx.h>
 #  include <cuda/std/__algorithm/is_heap_until.h>
 #  include <cuda/std/__concepts/concept_macros.h>
@@ -45,18 +48,19 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-// Returns true at the first child index `i` (1 <= i < n) where the parent-child
-// max-heap invariant is broken, i.e. comp(base[(i-1)/2], base[i]) holds.
-template <class _RandomAccessIterator, class _Compare>
-struct __is_heap_until_fn
+// Maps a child-relative index k (0 <= k < n - 1) to the value of its parent
+// in the heap, i.e. base[(k + 1 - 1) / 2] == base[k / 2]. Used as the unary
+// functor of a transform_iterator to expose parent loads to the find_if
+// dispatch alongside the (sequential) child loads.
+template <class _RandomAccessIterator>
+struct __is_heap_parent_at_fn
 {
   _RandomAccessIterator __base_;
-  _Compare __comp_;
 
   template <class _Diff>
-  [[nodiscard]] _CCCL_DEVICE_API constexpr bool operator()(const _Diff& __i) const
+  [[nodiscard]] _CCCL_DEVICE_API constexpr iter_reference_t<_RandomAccessIterator> operator()(const _Diff& __k) const
   {
-    return __comp_(__base_[(__i - _Diff(1)) / _Diff(2)], __base_[__i]);
+    return __base_[__k / _Diff(2)];
   }
 };
 
@@ -87,16 +91,18 @@ _CCCL_REQUIRES(__has_random_access_traversal<_RandomAccessIterator> _CCCL_AND is
       return __last;
     }
 
-    // Find the first heap-property violation in the index range [1, n).
-    // The result's dereferenced value is the violating child index, or n
-    // if the range is a heap. `__first + *__it` returns __last in the
-    // latter case.
-    const auto __it = __dispatch(
+    // Pair each child (at indices [1, n)) with its parent value, exposing both
+    // loads to the find_if dispatch. comp(parent, child) holds at the first
+    // heap-property violation.
+    auto __parent_at = ::cuda::transform_iterator{
+      ::cuda::counting_iterator{__diff_t(0)}, __is_heap_parent_at_fn<_RandomAccessIterator>{__first}};
+
+    auto __result = __dispatch(
       __policy,
-      ::cuda::counting_iterator{__diff_t(1)},
-      ::cuda::counting_iterator{__n},
-      __is_heap_until_fn<_RandomAccessIterator, _Compare>{__first, ::cuda::std::move(__comp)});
-    return __first + (*__it);
+      ::cuda::zip_iterator{__parent_at, __first + 1},
+      ::cuda::zip_iterator{__parent_at + (__n - 1), __last},
+      ::cuda::zip_function{::cuda::std::move(__comp)});
+    return ::cuda::std::get<1>(__result.__iterators());
   }
   else
   {

--- a/libcudacxx/include/cuda/std/__pstl/is_heap_until.h
+++ b/libcudacxx/include/cuda/std/__pstl/is_heap_until.h
@@ -24,7 +24,6 @@
 #if !_CCCL_COMPILER(NVRTC)
 
 #  include <cuda/__iterator/counting_iterator.h>
-#  include <cuda/__iterator/transform_iterator.h>
 #  include <cuda/__iterator/zip_function.h>
 #  include <cuda/__iterator/zip_iterator.h>
 #  include <cuda/__nvtx/nvtx.h>
@@ -48,23 +47,23 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-// Maps a child-relative index k (0 <= k < n - 1) to the value of its parent
-// in the heap, i.e. base[(k + 1 - 1) / 2] == base[k / 2]. Used as the unary
-// functor of a transform_iterator to expose parent loads to the find_if
-// dispatch alongside the (sequential) child loads.
-template <class _RandomAccessIterator>
-struct __is_heap_parent_at_fn
+// Returns true at the first child index `i` (1 <= i < n) where the parent-child
+// max-heap invariant is broken, i.e. comp(base[(i-1)/2], base[i]) holds.
+template <class _RandomAccessIterator, class _Compare>
+struct __is_heap_until_fn
 {
   _RandomAccessIterator __base_;
+  _Compare __comp_;
 
-  _CCCL_HOST_DEVICE explicit __is_heap_parent_at_fn(_RandomAccessIterator __base)
+  _CCCL_HOST_DEVICE explicit __is_heap_parent_at_fn(_RandomAccessIterator __base, _Compare __comp)
       : __base_(::cuda::std::move(__base))
+      , __comp_(::cuda::std::move(__comp))
   {}
 
-  template <class _Diff>
-  [[nodiscard]] _CCCL_DEVICE_API constexpr iter_reference_t<_RandomAccessIterator> operator()(const _Diff& __k) const
+  template <class _Diff, class _Tp>
+  [[nodiscard]] _CCCL_DEVICE_API constexpr bool operator()(const _Diff& __i, const _Tp& __current) const
   {
-    return __base_[__k / _Diff(2)];
+    return __comp_(__base_[(__i - _Diff(1)) / _Diff(2)], __current);
   }
 };
 
@@ -95,17 +94,15 @@ _CCCL_REQUIRES(__has_random_access_traversal<_RandomAccessIterator> _CCCL_AND is
       return __last;
     }
 
-    // Pair each child (at indices [1, n)) with its parent value, exposing both
-    // loads to the find_if dispatch. comp(parent, child) holds at the first
-    // heap-property violation.
-    auto __parent_at = ::cuda::transform_iterator{
-      ::cuda::counting_iterator{__diff_t(0)}, __is_heap_parent_at_fn<_RandomAccessIterator>{__first}};
-
-    auto __result = __dispatch(
+    // Find the first heap-property violation in the index range [1, n).
+    // The result's dereferenced value is the violating child index, or n
+    // if the range is a heap. `::cuda::std::get<1>(__result.__iterators())`
+    // returns __last in the latter case.
+    const auto __result = __dispatch(
       __policy,
-      ::cuda::zip_iterator{__parent_at, __first + 1},
-      ::cuda::zip_iterator{__parent_at + (__n - 1), __last},
-      ::cuda::zip_function{::cuda::std::move(__comp)});
+      ::cuda::zip_iterator{::cuda::counting_iterator{__diff_t(1)}, __first + 1},
+      ::cuda::zip_iterator{::cuda::counting_iterator{__n}, __last},
+      ::cuda::zip_function{__is_heap_until_fn<_RandomAccessIterator, _Compare>{__first, ::cuda::std::move(__comp)}});
     return ::cuda::std::get<1>(__result.__iterators());
   }
   else

--- a/libcudacxx/include/cuda/std/__pstl/is_heap_until.h
+++ b/libcudacxx/include/cuda/std/__pstl/is_heap_until.h
@@ -55,7 +55,7 @@ struct __is_heap_until_fn
   _RandomAccessIterator __base_;
   _Compare __comp_;
 
-  _CCCL_HOST_DEVICE explicit __is_heap_until_fn(_RandomAccessIterator __base, _Compare __comp)
+  _CCCL_API explicit constexpr __is_heap_until_fn(_RandomAccessIterator __base, _Compare __comp)
       : __base_(::cuda::std::move(__base))
       , __comp_(::cuda::std::move(__comp))
   {}

--- a/libcudacxx/include/cuda/std/__pstl/is_heap_until.h
+++ b/libcudacxx/include/cuda/std/__pstl/is_heap_until.h
@@ -57,6 +57,10 @@ struct __is_heap_parent_at_fn
 {
   _RandomAccessIterator __base_;
 
+  _CCCL_HOST_DEVICE explicit __is_heap_parent_at_fn(_RandomAccessIterator __base)
+      : __base_(::cuda::std::move(__base))
+  {}
+
   template <class _Diff>
   [[nodiscard]] _CCCL_DEVICE_API constexpr iter_reference_t<_RandomAccessIterator> operator()(const _Diff& __k) const
   {

--- a/libcudacxx/include/cuda/std/__pstl/is_heap_until.h
+++ b/libcudacxx/include/cuda/std/__pstl/is_heap_until.h
@@ -55,7 +55,7 @@ struct __is_heap_until_fn
   _RandomAccessIterator __base_;
   _Compare __comp_;
 
-  _CCCL_HOST_DEVICE explicit __is_heap_parent_at_fn(_RandomAccessIterator __base, _Compare __comp)
+  _CCCL_HOST_DEVICE explicit __is_heap_until_fn(_RandomAccessIterator __base, _Compare __comp)
       : __base_(::cuda::std::move(__base))
       , __comp_(::cuda::std::move(__comp))
   {}

--- a/libcudacxx/include/cuda/std/execution
+++ b/libcudacxx/include/cuda/std/execution
@@ -49,6 +49,8 @@
 #  include <cuda/std/__pstl/generate.h>
 #  include <cuda/std/__pstl/generate_n.h>
 #  include <cuda/std/__pstl/inclusive_scan.h>
+#  include <cuda/std/__pstl/is_heap.h>
+#  include <cuda/std/__pstl/is_heap_until.h>
 #  include <cuda/std/__pstl/is_partitioned.h>
 #  include <cuda/std/__pstl/is_sorted.h>
 #  include <cuda/std/__pstl/is_sorted_until.h>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap.cu
@@ -38,8 +38,14 @@ void test_is_heap(const Policy& policy, c2h::device_vector<T>& input)
     CHECK(res);
   }
 
+  { // size-1 should not access anything; using a host pointer would segfault on device
+    T host_value{};
+    const auto res = cuda::std::is_heap(policy, &host_value, &host_value + 1);
+    CHECK(res);
+  }
+
   // Strictly decreasing range is a valid max-heap.
-  thrust::sequence(input.begin(), input.end(), static_cast<T>(size), static_cast<T>(-1));
+  thrust::sequence(input.begin(), input.end(), size, -1);
   { // valid max-heap, contiguous range
     const auto res = cuda::std::is_heap(policy, input.begin(), input.end());
     CHECK(res);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap.cu
@@ -1,0 +1,102 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template<class ExecutionPolicy, RandomAccessIterator Iter>
+// bool is_heap(ExecutionPolicy&& policy, Iter first, Iter last);
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/std/iterator>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "test_pstl.h"
+
+inline constexpr int size = 1000;
+
+template <class Policy, class T>
+void test_is_heap(const Policy& policy, c2h::device_vector<T>& input)
+{
+  { // empty should not access anything
+    const auto res = cuda::std::is_heap(policy, static_cast<T*>(nullptr), static_cast<T*>(nullptr));
+    CHECK(res);
+  }
+
+  // Strictly decreasing range is a valid max-heap.
+  thrust::sequence(input.begin(), input.end(), static_cast<T>(size), static_cast<T>(-1));
+  { // valid max-heap, contiguous range
+    const auto res = cuda::std::is_heap(policy, input.begin(), input.end());
+    CHECK(res);
+  }
+
+  T* raw_pointer = thrust::raw_pointer_cast(input.data());
+  { // valid max-heap, random access range
+    const auto res =
+      cuda::std::is_heap(policy, random_access_iterator{raw_pointer}, random_access_iterator{raw_pointer + size});
+    CHECK(res);
+  }
+
+  // Break the max-heap property at child index 42 (parent index 20).
+  input[42] = static_cast<T>(size + 1);
+  { // broken max-heap, contiguous range
+    const auto res = cuda::std::is_heap(policy, input.begin(), input.end());
+    CHECK(!res);
+  }
+
+  { // broken max-heap, random access range
+    const auto res =
+      cuda::std::is_heap(policy, random_access_iterator{raw_pointer}, random_access_iterator{raw_pointer + size});
+    CHECK(!res);
+  }
+}
+
+C2H_TEST("cuda::std::is_heap(iter, iter)", "[parallel algorithm]", all_types)
+{
+  using T = typename c2h::get<0, TestType>;
+  c2h::device_vector<T> input(size, thrust::no_init);
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_is_heap(policy, input);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_is_heap(policy, input);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource);
+    test_is_heap(policy, input);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy =
+      cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);
+    test_is_heap(policy, input);
+  }
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap_comp.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap_comp.cu
@@ -39,8 +39,14 @@ void test_is_heap(const Policy& policy, c2h::device_vector<T>& input)
     CHECK(res);
   }
 
+  { // size-1 should not access anything; using a host pointer would segfault on device
+    T host_value{};
+    const auto res = cuda::std::is_heap(policy, &host_value, &host_value + 1, cuda::std::greater<>{});
+    CHECK(res);
+  }
+
   // Strictly increasing range is a valid min-heap under greater<>.
-  thrust::sequence(input.begin(), input.end(), static_cast<T>(0));
+  thrust::sequence(input.begin(), input.end(), 0);
   { // valid min-heap, contiguous range
     const auto res = cuda::std::is_heap(policy, input.begin(), input.end(), cuda::std::greater<>{});
     CHECK(res);

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap_comp.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap_comp.cu
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template<class ExecutionPolicy, RandomAccessIterator Iter, BinaryPredicate>
+// bool is_heap(ExecutionPolicy&& policy, Iter first, Iter last, BinaryPredicate pred);
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/std/iterator>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "test_pstl.h"
+
+inline constexpr int size = 1000;
+
+template <class Policy, class T>
+void test_is_heap(const Policy& policy, c2h::device_vector<T>& input)
+{
+  { // empty should not access anything
+    const auto res =
+      cuda::std::is_heap(policy, static_cast<T*>(nullptr), static_cast<T*>(nullptr), cuda::std::greater<>{});
+    CHECK(res);
+  }
+
+  // Strictly increasing range is a valid min-heap under greater<>.
+  thrust::sequence(input.begin(), input.end(), static_cast<T>(0));
+  { // valid min-heap, contiguous range
+    const auto res = cuda::std::is_heap(policy, input.begin(), input.end(), cuda::std::greater<>{});
+    CHECK(res);
+  }
+
+  T* raw_pointer = thrust::raw_pointer_cast(input.data());
+  { // valid min-heap, random access range
+    const auto res = cuda::std::is_heap(
+      policy, random_access_iterator{raw_pointer}, random_access_iterator{raw_pointer + size}, cuda::std::greater<>{});
+    CHECK(res);
+  }
+
+  // Break the min-heap property at child index 42.
+  input[42] = static_cast<T>(0);
+  { // broken min-heap, contiguous range
+    const auto res = cuda::std::is_heap(policy, input.begin(), input.end(), cuda::std::greater<>{});
+    CHECK(!res);
+  }
+
+  { // broken min-heap, random access range
+    const auto res = cuda::std::is_heap(
+      policy, random_access_iterator{raw_pointer}, random_access_iterator{raw_pointer + size}, cuda::std::greater<>{});
+    CHECK(!res);
+  }
+}
+
+C2H_TEST("cuda::std::is_heap(iter, iter, comp)", "[parallel algorithm]", all_types)
+{
+  using T = typename c2h::get<0, TestType>;
+  c2h::device_vector<T> input(size, thrust::no_init);
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_is_heap(policy, input);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_is_heap(policy, input);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource);
+    test_is_heap(policy, input);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy =
+      cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);
+    test_is_heap(policy, input);
+  }
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap_until.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap_until.cu
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template<class ExecutionPolicy, RandomAccessIterator Iter>
+// Iter is_heap_until(ExecutionPolicy&& policy, Iter first, Iter last);
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/std/iterator>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "test_pstl.h"
+
+inline constexpr int size = 1000;
+
+template <class Policy, class T>
+void test_is_heap_until(const Policy& policy, c2h::device_vector<T>& input)
+{
+  { // empty should not access anything
+    const auto res = cuda::std::is_heap_until(policy, static_cast<T*>(nullptr), static_cast<T*>(nullptr));
+    CHECK(res == nullptr);
+  }
+
+  // Strictly decreasing range is a valid max-heap (parent always > child)
+  thrust::sequence(input.begin(), input.end(), static_cast<T>(size), static_cast<T>(-1));
+  { // valid max-heap, contiguous range
+    const auto res = cuda::std::is_heap_until(policy, input.begin(), input.end());
+    CHECK(res == input.end());
+  }
+
+  T* raw_pointer = thrust::raw_pointer_cast(input.data());
+  { // valid max-heap, random access range
+    const auto res =
+      cuda::std::is_heap_until(policy, random_access_iterator{raw_pointer}, random_access_iterator{raw_pointer + size});
+    CHECK(res == random_access_iterator{raw_pointer + size});
+  }
+
+  // Inject a value at child index 42 that exceeds its parent at index (42-1)/2 = 20.
+  // Parent value is size - 20 = 980; child value size + 1 = 1001 violates the
+  // max-heap property -> is_heap_until must return iterator at index 42.
+  input[42] = static_cast<T>(size + 1);
+  { // broken max-heap, contiguous range
+    const auto res = cuda::std::is_heap_until(policy, input.begin(), input.end());
+    CHECK(res == cuda::std::next(input.begin(), 42));
+    CHECK(cuda::std::is_heap(policy, input.begin(), res));
+  }
+
+  { // broken max-heap, random access range
+    const auto res =
+      cuda::std::is_heap_until(policy, random_access_iterator{raw_pointer}, random_access_iterator{raw_pointer + size});
+    CHECK(res == random_access_iterator{raw_pointer + 42});
+    CHECK(cuda::std::is_heap(policy, random_access_iterator{raw_pointer}, res));
+  }
+}
+
+C2H_TEST("cuda::std::is_heap_until(iter, iter)", "[parallel algorithm]", all_types)
+{
+  using T = typename c2h::get<0, TestType>;
+  c2h::device_vector<T> input(size, thrust::no_init);
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_is_heap_until(policy, input);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_is_heap_until(policy, input);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource);
+    test_is_heap_until(policy, input);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy =
+      cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);
+    test_is_heap_until(policy, input);
+  }
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap_until.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap_until.cu
@@ -38,8 +38,14 @@ void test_is_heap_until(const Policy& policy, c2h::device_vector<T>& input)
     CHECK(res == nullptr);
   }
 
+  { // size-1 should not access anything; using a host pointer would segfault on device
+    T host_value{};
+    const auto res = cuda::std::is_heap_until(policy, &host_value, &host_value + 1);
+    CHECK(res == &host_value + 1);
+  }
+
   // Strictly decreasing range is a valid max-heap (parent always > child)
-  thrust::sequence(input.begin(), input.end(), static_cast<T>(size), static_cast<T>(-1));
+  thrust::sequence(input.begin(), input.end(), size, -1);
   { // valid max-heap, contiguous range
     const auto res = cuda::std::is_heap_until(policy, input.begin(), input.end());
     CHECK(res == input.end());

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap_until_comp.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap_until_comp.cu
@@ -1,0 +1,108 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template<class ExecutionPolicy, RandomAccessIterator Iter, BinaryPredicate>
+// Iter is_heap_until(ExecutionPolicy&& policy, Iter first, Iter last, BinaryPredicate pred);
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/std/iterator>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "test_pstl.h"
+
+inline constexpr int size = 1000;
+
+template <class Policy, class T>
+void test_is_heap_until(const Policy& policy, c2h::device_vector<T>& input)
+{
+  { // empty should not access anything
+    const auto res =
+      cuda::std::is_heap_until(policy, static_cast<T*>(nullptr), static_cast<T*>(nullptr), cuda::std::greater<>{});
+    CHECK(res == nullptr);
+  }
+
+  // Strictly increasing range is a valid min-heap under greater<>
+  // (parent always smaller than child).
+  thrust::sequence(input.begin(), input.end(), static_cast<T>(0));
+  { // valid min-heap, contiguous range
+    const auto res = cuda::std::is_heap_until(policy, input.begin(), input.end(), cuda::std::greater<>{});
+    CHECK(res == input.end());
+  }
+
+  T* raw_pointer = thrust::raw_pointer_cast(input.data());
+  { // valid min-heap, random access range
+    const auto res = cuda::std::is_heap_until(
+      policy, random_access_iterator{raw_pointer}, random_access_iterator{raw_pointer + size}, cuda::std::greater<>{});
+    CHECK(res == random_access_iterator{raw_pointer + size});
+  }
+
+  // Inject a value at child index 42 smaller than its parent at index 20.
+  // Parent value = 20, child value = 0 violates the min-heap property
+  // (greater<>(20, 0) == true) -> is_heap_until must return iterator at i=42.
+  input[42] = static_cast<T>(0);
+  { // broken min-heap, contiguous range
+    const auto res = cuda::std::is_heap_until(policy, input.begin(), input.end(), cuda::std::greater<>{});
+    CHECK(res == cuda::std::next(input.begin(), 42));
+    CHECK(cuda::std::is_heap(policy, input.begin(), res, cuda::std::greater<>{}));
+  }
+
+  { // broken min-heap, random access range
+    const auto res = cuda::std::is_heap_until(
+      policy, random_access_iterator{raw_pointer}, random_access_iterator{raw_pointer + size}, cuda::std::greater<>{});
+    CHECK(res == random_access_iterator{raw_pointer + 42});
+    CHECK(cuda::std::is_heap(policy, random_access_iterator{raw_pointer}, res, cuda::std::greater<>{}));
+  }
+}
+
+C2H_TEST("cuda::std::is_heap_until(iter, iter, comp)", "[parallel algorithm]", all_types)
+{
+  using T = typename c2h::get<0, TestType>;
+  c2h::device_vector<T> input(size, thrust::no_init);
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_is_heap_until(policy, input);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_is_heap_until(policy, input);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource);
+    test_is_heap_until(policy, input);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy =
+      cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);
+    test_is_heap_until(policy, input);
+  }
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap_until_comp.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl_is_heap_until_comp.cu
@@ -39,9 +39,15 @@ void test_is_heap_until(const Policy& policy, c2h::device_vector<T>& input)
     CHECK(res == nullptr);
   }
 
+  { // size-1 should not access anything; using a host pointer would segfault on device
+    T host_value{};
+    const auto res = cuda::std::is_heap_until(policy, &host_value, &host_value + 1, cuda::std::greater<>{});
+    CHECK(res == &host_value + 1);
+  }
+
   // Strictly increasing range is a valid min-heap under greater<>
   // (parent always smaller than child).
-  thrust::sequence(input.begin(), input.end(), static_cast<T>(0));
+  thrust::sequence(input.begin(), input.end(), 0);
   { // valid min-heap, contiguous range
     const auto res = cuda::std::is_heap_until(policy, input.begin(), input.end(), cuda::std::greater<>{});
     CHECK(res == input.end());


### PR DESCRIPTION
## Description

closes #7761

This implements the heap-checking algorithms for the cuda backend.

* `std::is_heap_until` see https://en.cppreference.com/w/cpp/algorithm/is_heap_until
* `std::is_heap`       see https://en.cppreference.com/w/cpp/algorithm/is_heap

The implementation reuses the existing `__find_if` PSTL dispatch over a
`cuda::counting_iterator` paired with an index-aware predicate that
evaluates `comp(base[(i - 1) / 2], base[i])`. No new dispatch machinery
is required: `is_heap_until` is "find first heap-property violation",
which maps directly onto find_if.

`is_heap` is implemented in terms of `is_heap_until == last`, so the two
stay in lock-step semantically.

Tests follow the `pstl_is_sorted_*` shape and exercise empty range,
valid heap, and broken heap (with violation injected at child index 42
whose parent is index 20), over `all_types`
(uint16/int32/uint64/int128/float/double/half/bfloat16), with raw
pointer and `random_access_iterator` inputs, default `less<>` and custom
`greater<>` (min-heap) comparator, across the four standard sections
(default stream / provided stream / memory_resource / both).

Benchmark mirrors `is_partitioned/basic.cu`, parameterised on element
count and violation position.

## Test results

Local run on RTX 5070 + CUDA 12.9 + MSVC 19.50 (sm_89, Release):

\`\`\`
libcudacxx.test.std.algorithms.alg.sorting.alg.heap.operations.is.heap.pstl_is_heap
  All tests passed (160 assertions in 8 test cases)
libcudacxx.test.std.algorithms.alg.sorting.alg.heap.operations.is.heap.pstl_is_heap_comp
  All tests passed (160 assertions in 8 test cases)
libcudacxx.test.std.algorithms.alg.sorting.alg.heap.operations.is.heap.pstl_is_heap_until
  All tests passed (224 assertions in 8 test cases)
libcudacxx.test.std.algorithms.alg.sorting.alg.heap.operations.is.heap.pstl_is_heap_until_comp
  All tests passed (224 assertions in 8 test cases)
\`\`\`

Total: **768 assertions across 32 test cases, 0 failures**.

The benchmark target (\`libcudacxx.bench.is_heap_until.basic.base\`)
also builds and runs end-to-end (NVBench output verified on a small
config).

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.