### PR TITLE
[cub]: Always use `select_policy` to invoke the policy selector

### DIFF
--- a/c/parallel/src/histogram.cu
+++ b/c/parallel/src/histogram.cu
@@ -299,7 +299,7 @@ struct __align__({1}) storage_t {{
 using device_histogram_policy = {3};
 using namespace cub;
 using namespace cub::detail::histogram;
-static_assert(device_histogram_policy()(detail::current_tuning_arch()) == {4}, "Host generated and JIT compiled policy mismatch");
+static_assert(detail::current_policy<device_histogram_policy>() == {4}, "Host generated and JIT compiled policy mismatch");
 )XXX",
     d_samples.value_type.size, // 0
     d_samples.value_type.alignment, // 1

--- a/c/parallel/src/merge_sort.cu
+++ b/c/parallel/src/merge_sort.cu
@@ -261,7 +261,7 @@ struct __align__({3}) items_storage_t {{
 using device_merge_sort_policy = {9};
 using namespace cub;
 using namespace cub::detail::merge_sort;
-static_assert(device_merge_sort_policy()(detail::current_tuning_arch()) == {10}, "Host generated and JIT compiled policy mismatch");
+static_assert(detail::current_policy<device_merge_sort_policy>() == {10}, "Host generated and JIT compiled policy mismatch");
 )XXX",
     input_keys_it.value_type.size, // 0
     input_keys_it.value_type.alignment, // 1

--- a/c/parallel/src/radix_sort.cu
+++ b/c/parallel/src/radix_sort.cu
@@ -259,7 +259,7 @@ using namespace cub::detail;
 using namespace cub::detail::radix_sort;
 using cub::detail::delay_constructor_policy;
 using cub::detail::delay_constructor_kind;
-static_assert(device_radix_sort_policy()(current_tuning_arch()) == {6}, "Host generated and JIT compiled policy mismatch");
+static_assert(detail::current_policy<device_radix_sort_policy>() == {6}, "Host generated and JIT compiled policy mismatch");
 )XXX",
     input_keys_it.value_type.size, // 0
     input_keys_it.value_type.alignment, // 1

--- a/c/parallel/src/reduce.cu
+++ b/c/parallel/src/reduce.cu
@@ -251,7 +251,7 @@ struct __align__({2}) storage_t {{
 using device_reduce_policy = {6};
 using namespace cub;
 using namespace cub::detail::reduce;
-static_assert(device_reduce_policy()(detail::current_tuning_arch()) == {7}, "Host generated and JIT compiled policy mismatch");
+static_assert(detail::current_policy<device_reduce_policy>() == {7}, "Host generated and JIT compiled policy mismatch");
 )XXX",
     jit_template_header_contents, // 0
     input_it.value_type.size, // 1

--- a/c/parallel/src/scan.cu
+++ b/c/parallel/src/scan.cu
@@ -361,7 +361,7 @@ using namespace cub;
 using namespace cub::detail::scan;
 using cub::detail::delay_constructor_policy;
 using cub::detail::delay_constructor_kind;
-static_assert(device_scan_policy()(detail::current_tuning_arch()) == {6}, "Host generated and JIT compiled policy mismatch");
+static_assert(detail::current_policy<device_scan_policy>() == {6}, "Host generated and JIT compiled policy mismatch");
 )XXX",
     input_it.value_type.size, // 0
     input_it.value_type.alignment, // 1

--- a/c/parallel/src/segmented_reduce.cu
+++ b/c/parallel/src/segmented_reduce.cu
@@ -189,9 +189,7 @@ using device_segmented_reduce_policy = {8};
 using namespace cub;
 using namespace cub::detail::reduce;
 using namespace cub::detail::segmented_reduce;
-static_assert(
-  device_segmented_reduce_policy()(detail::current_tuning_arch()) == {9},
-  "Host generated and JIT compiled policy mismatch");
+static_assert(detail::current_policy<device_segmented_reduce_policy>() == {9}, "Host generated and JIT compiled policy mismatch");
 )XXX",
     jit_template_header_contents, // 0
     input_it.value_type.size, // 1

--- a/c/parallel/src/segmented_sort.cu
+++ b/c/parallel/src/segmented_sort.cu
@@ -535,10 +535,10 @@ using namespace cub::detail;
 using namespace cub::detail::segmented_sort;
 using namespace cub::detail::three_way_partition;
 static_assert(
-  device_segmented_sort_policy_selector()(current_tuning_arch()) == {12},
+  detail::current_policy<device_segmented_sort_policy_selector>() == {12},
   "Host generated and JIT compiled policy mismatch");
 static_assert(
-  device_three_way_partition_policy_selector()(current_tuning_arch()) == {14},
+  detail::current_policy<device_three_way_partition_policy_selector>() == {14},
   "Host generated and JIT compiled three-way partition policy mismatch");
 )XXX",
     jit_template_header_contents, // 0

--- a/c/parallel/src/three_way_partition.cu
+++ b/c/parallel/src/three_way_partition.cu
@@ -196,7 +196,7 @@ using namespace cub;
 using namespace cub::detail;
 using namespace cub::detail::three_way_partition;
 static_assert(
-  device_three_way_partition_policy_selector()(current_tuning_arch()) == {11},
+  detail::current_policy<device_three_way_partition_policy_selector>() == {11},
   "Host generated and JIT compiled policy mismatch");
 )XXX",
     jit_template_header_contents, // 0

--- a/c/parallel/src/transform.cu
+++ b/c/parallel/src/transform.cu
@@ -255,7 +255,7 @@ struct __align__({4}) output_storage_t {{
 using device_transform_policy = {8};
 using namespace cub;
 using namespace cub::detail::transform;
-static_assert(device_transform_policy()(detail::current_tuning_arch()) == {9}, "Host generated and JIT compiled policy mismatch");
+static_assert(detail::current_policy<device_transform_policy>() == {9}, "Host generated and JIT compiled policy mismatch");
 )XXX",
     jit_template_header_contents, // 0
     input_it.value_type.size, // 1
@@ -454,7 +454,7 @@ struct __align__({6}) output_storage_t {{
 using device_transform_policy = {11};
 using namespace cub;
 using namespace cub::detail::transform;
-static_assert(device_transform_policy()(detail::current_tuning_arch()) == {12}, "Host generated and JIT compiled policy mismatch");
+static_assert(detail::current_policy<device_transform_policy>() == {12}, "Host generated and JIT compiled policy mismatch");
 )XXX",
     jit_template_header_contents, // 0
     input1_it.value_type.size, // 1

--- a/c/parallel/src/unique_by_key.cu
+++ b/c/parallel/src/unique_by_key.cu
@@ -259,7 +259,7 @@ using namespace cub;
 using namespace cub::detail::unique_by_key;
 using cub::detail::delay_constructor_policy;
 using cub::detail::delay_constructor_kind;
-static_assert(device_unique_by_key_policy()(detail::current_tuning_arch()) == {13}, "Host generated and JIT compiled policy mismatch");
+static_assert(detail::current_policy<device_unique_by_key_policy>() == {13}, "Host generated and JIT compiled policy mismatch");
 static_assert(
   cub::detail::unique_by_key::unique_by_key_vsmem_helper_t<
     cub::detail::policy_getter<device_unique_by_key_policy, detail::current_tuning_arch()>,

--- a/cub/cub/detail/arch_dispatch.cuh
+++ b/cub/cub/detail/arch_dispatch.cuh
@@ -13,6 +13,8 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cub/util_arch.cuh>
+
 #include <cuda/__device/arch_id.h>
 #include <cuda/std/__type_traits/is_empty.h>
 #include <cuda/std/__utility/forward.h>
@@ -29,7 +31,7 @@ struct policy_getter : PolicySelector
 {
   _CCCL_API _CCCL_FORCEINLINE constexpr auto operator()() const
   {
-    return PolicySelector::operator()(ArchId);
+    return select_policy<PolicySelector>(ArchId);
   }
 };
 
@@ -39,18 +41,19 @@ struct device_policy_getter : PolicySelector
 {
   _CCCL_DEVICE_API _CCCL_FORCEINLINE constexpr auto operator()() const
   {
-    return PolicySelector::operator()(ArchId);
+    return select_policy<PolicySelector>(ArchId);
   }
 };
 
 #if !defined(CUB_DEFINE_RUNTIME_POLICIES) && !_CCCL_COMPILER(NVRTC)
 #  if _CCCL_STD_VER < 2020
 template <typename PolicySelector, size_t N>
-_CCCL_API constexpr auto find_lowest_arch_with_same_policy(
-  PolicySelector policy_selector, size_t i, const ::cuda::std::array<::cuda::arch_id, N>& all_arches) -> ::cuda::arch_id
+_CCCL_API constexpr auto
+find_lowest_arch_with_same_policy(PolicySelector, size_t i, const ::cuda::std::array<::cuda::arch_id, N>& all_arches)
+  -> ::cuda::arch_id
 {
-  const auto policy = policy_selector(all_arches[i]);
-  while (i > 0 && policy_selector(all_arches[i - 1]) == policy)
+  const auto policy = select_policy<PolicySelector>(all_arches[i]);
+  while (i > 0 && select_policy<PolicySelector>(all_arches[i - 1]) == policy)
   {
     --i;
   }
@@ -66,13 +69,13 @@ struct lowest_arch_resolver<ArchMult, ::cuda::std::integer_sequence<int, CudaArc
 {
   static_assert(sizeof...(CudaArches) == sizeof...(Is));
 
-  using policy_t = decltype(PolicySelector{}(::cuda::arch_id{}));
+  using policy_t = decltype(select_policy<PolicySelector>(::cuda::arch_id{}));
 
   static constexpr ::cuda::arch_id all_arches[sizeof...(Is)] = {::cuda::arch_id{(CudaArches * ArchMult) / 10}...};
 
   // GCC 7 has issues reusing the constexpr array of tuning policies in find_lowest below (it loses the constexpr-ness)
 #    if _CCCL_COMPILER(GCC, >=, 8)
-  static constexpr policy_t all_policies[sizeof...(Is)] = {PolicySelector{}(all_arches[Is])...};
+  static constexpr policy_t all_policies[sizeof...(Is)] = {select_policy<PolicySelector>(all_arches[Is])...};
 #    endif // _CCCL_COMPILER(GCC, <, 8)
 
   _CCCL_API static constexpr auto find_lowest(size_t i) -> ::cuda::arch_id
@@ -81,8 +84,8 @@ struct lowest_arch_resolver<ArchMult, ::cuda::std::integer_sequence<int, CudaArc
     const auto& policy = all_policies[i];
     while (i > 0 && policy == all_policies[i - 1])
 #    else // _CCCL_COMPILER(GCC, >=, 8)
-    const auto& policy = PolicySelector{}(all_arches[i]);
-    while (i > 0 && policy == PolicySelector{}(all_arches[i - 1]))
+    const auto& policy = select_policy<PolicySelector>(all_arches[i]);
+    while (i > 0 && policy == select_policy<PolicySelector>(all_arches[i - 1]))
 #    endif // _CCCL_COMPILER(GCC, >=, 8)
     {
       --i;
@@ -96,7 +99,10 @@ struct lowest_arch_resolver<ArchMult, ::cuda::std::integer_sequence<int, CudaArc
 
 template <int ArchMult, int... CudaArches, typename PolicySelector, typename FunctorT, size_t... Is>
 CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_to_arch_list(
-  PolicySelector policy_selector, ::cuda::arch_id device_arch, FunctorT&& f, ::cuda::std::index_sequence<Is...>)
+  [[maybe_unused]] PolicySelector policy_selector,
+  ::cuda::arch_id device_arch,
+  FunctorT&& f,
+  ::cuda::std::index_sequence<Is...>)
 {
   _CCCL_ASSERT(((device_arch == ::cuda::arch_id{(CudaArches * ArchMult) / 10}) || ...),
                "device_arch must appear in the list of architectures compiled for");
@@ -106,11 +112,12 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_to_arch_list(
   // In C++20, we just create an integral_constant holding the policy, because policies are structural types in C++20.
   // This causes f to be only instantiated for each distinct policy, since the same policy for different arches results
   // in the same integral_constant type passed to f
-  using policy_t = decltype(policy_selector(::cuda::arch_id{}));
+  using policy_t = decltype(select_policy<PolicySelector>(::cuda::arch_id{}));
   (...,
    (device_arch == ::cuda::arch_id{(CudaArches * ArchMult) / 10}
-      ? (e = f(
-           ::cuda::std::integral_constant<policy_t, policy_selector(::cuda::arch_id{(CudaArches * ArchMult) / 10})>{}))
+      ? (e = f(::cuda::std::integral_constant<
+               policy_t,
+               select_policy<PolicySelector>(::cuda::arch_id{(CudaArches * ArchMult) / 10})>{}))
       : cudaSuccess));
 #  else // if _CCCL_STD_VER >= 2020
   // In C++17, we have to collapse architectures with the same policies ourselves, so we instantiate call_for_arch once
@@ -169,10 +176,10 @@ dispatch_arch(PolicySelector policy_selector, ::cuda::arch_id device_arch, F&& f
 // if we are compiling CCCL.C with runtime policies, we cannot query the policy hub at compile time
 _CCCL_EXEC_CHECK_DISABLE
 template <typename PolicySelector, typename F>
-_CCCL_API _CCCL_FORCEINLINE cudaError_t dispatch_arch(PolicySelector policy_selector, ::cuda::arch_id device_arch, F&& f)
+_CCCL_API _CCCL_FORCEINLINE cudaError_t dispatch_arch(PolicySelector, ::cuda::arch_id device_arch, F&& f)
 {
   return f([&] {
-    return policy_selector(device_arch);
+    return select_policy<PolicySelector>(device_arch);
   });
 }
 #endif // !defined(CUB_DEFINE_RUNTIME_POLICIES) && !_CCCL_COMPILER(NVRTC)

--- a/cub/cub/detail/env_dispatch.cuh
+++ b/cub/cub/detail/env_dispatch.cuh
@@ -14,6 +14,7 @@
 
 #include <cub/detail/device_memory_resource.cuh>
 #include <cub/detail/temporary_storage.cuh>
+#include <cub/util_arch.cuh>
 
 #include <cuda/__execution/tune.h>
 #include <cuda/__functional/call_or.h>
@@ -80,7 +81,7 @@ CUB_RUNTIME_FUNCTION static cudaError_t dispatch_with_env_and_tuning(EnvT env, A
 {
   return detail::dispatch_with_env(
     env, [&]([[maybe_unused]] auto tuning_env, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
-      using policy_t = decltype(DefaultPolicySelector{}(::cuda::arch_id{}));
+      using policy_t = decltype(select_policy<DefaultPolicySelector>(::cuda::arch_id{}));
       using policy_selector =
         ::cuda::std::execution::__query_result_or_t<decltype(tuning_env), policy_t, DefaultPolicySelector>;
       return algorithm_callable(policy_selector{}, d_temp_storage, temp_storage_bytes, stream);

--- a/cub/cub/detail/launcher/cuda_driver.cuh
+++ b/cub/cub/detail/launcher/cuda_driver.cuh
@@ -90,7 +90,7 @@ struct CudaDriverLauncherFactory
 
   ::cudaError_t PtxArchId(::cuda::arch_id& arch_id) const
   {
-    arch_id = ::cuda::to_arch_id(::cuda::compute_capability(cc));
+    arch_id = ::cuda::__to_arch_id_unchecked(::cuda::compute_capability(cc));
     return ::cudaSuccess;
   }
 

--- a/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
+++ b/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
@@ -333,7 +333,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   OffsetT num_items,
   DifferenceOpT difference_op,
   cudaStream_t stream,
-  PolicySelector policy_selector         = {},
+  PolicySelector                         = {},
   KernelLauncherFactory launcher_factory = {})
 {
   using InputT = detail::it_value_t<InputIteratorT>;
@@ -344,7 +344,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
     return error;
   }
 
-  const adjacent_difference_policy active_policy = policy_selector(arch_id);
+  const adjacent_difference_policy active_policy = select_policy<PolicySelector>(arch_id);
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(
     NV_IS_HOST, ({

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -303,7 +303,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   BufferSizeIteratorT buffer_sizes,
   ::cuda::std::int64_t num_buffers,
   cudaStream_t stream,
-  PolicySelectorT policy_selector = {})
+  PolicySelectorT = {})
 {
   using per_invocation_buffer_offset_t = detail::batch_memcpy::per_invocation_buffer_offset_t;
   using BufferSizeT                    = cub::detail::it_value_t<BufferSizeIteratorT>;
@@ -315,7 +315,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   {
     return error;
   }
-  const batch_memcpy_policy active_policy = policy_selector(arch_id);
+  const batch_memcpy_policy active_policy = select_policy<PolicySelectorT>(arch_id);
 
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(NV_IS_HOST, ({

--- a/cub/cub/device/dispatch/dispatch_find.cuh
+++ b/cub/cub/device/dispatch/dispatch_find.cuh
@@ -95,7 +95,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   OffsetT num_items,
   PredicateT predicate,
   cudaStream_t stream,
-  PolicySelector policy_selector = {})
+  PolicySelector = {})
 {
   using output_t = it_value_t<OutputIteratorT>;
 
@@ -112,7 +112,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
     return error;
   }
 
-  const find_policy active_policy = policy_selector(arch_id);
+  const find_policy active_policy = select_policy<PolicySelector>(arch_id);
 
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(NV_IS_HOST, ({

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -27,6 +27,7 @@
 #include <cub/device/dispatch/tuning/tuning_histogram.cuh>
 #include <cub/grid/grid_queue.cuh>
 #include <cub/thread/thread_search.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_debug.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_math.cuh>
@@ -188,7 +189,7 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto dispatch(
   OffsetT num_rows,
   OffsetT row_stride_samples,
   cudaStream_t stream,
-  PolicySelector policy_selector         = {},
+  PolicySelector                         = {},
   KernelSource kernel_source             = {},
   KernelLauncherFactory launcher_factory = {})
 {
@@ -198,7 +199,7 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto dispatch(
     return error;
   }
 
-  const histogram_policy active_policy = policy_selector(arch_id);
+  const histogram_policy active_policy = select_policy<PolicySelector>(arch_id);
 
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(NV_IS_HOST, ({

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -23,6 +23,7 @@
 #include <cub/detail/arch_dispatch.cuh>
 #include <cub/device/dispatch/kernels/kernel_radix_sort.cuh>
 #include <cub/device/dispatch/tuning/tuning_radix_sort.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_debug.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_type.cuh>
@@ -1211,7 +1212,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(NV_IS_HOST, ({
                  std::stringstream ss;
-                 ss << policy_selector(arch_id);
+                 ss << select_policy<PolicySelector>(arch_id);
                  _CubLog("Dispatching DeviceReduce to arch %d with tuning: %s\n", (int) arch_id, ss.str().c_str());
                }))
 #endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -26,6 +26,7 @@
 #include <cub/device/dispatch/kernels/kernel_reduce.cuh>
 #include <cub/device/dispatch/tuning/tuning_reduce.cuh>
 #include <cub/grid/grid_even_share.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_debug.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_temporary_storage.cuh>
@@ -767,7 +768,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   InitT init,
   cudaStream_t stream,
   TransformOpT transform_op              = {},
-  PolicySelector policy_selector         = {},
+  PolicySelector                         = {},
   KernelSource kernel_source             = {},
   KernelLauncherFactory launcher_factory = {})
 {
@@ -778,7 +779,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
     return error;
   }
 
-  const reduce_policy active_policy = policy_selector(arch_id);
+  const reduce_policy active_policy = select_policy<PolicySelector>(arch_id);
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(NV_IS_HOST, ({
                  std::stringstream ss;

--- a/cub/cub/device/dispatch/dispatch_reduce_deterministic.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_deterministic.cuh
@@ -22,6 +22,7 @@
 #include <cub/device/dispatch/dispatch_reduce.cuh>
 #include <cub/device/dispatch/kernels/kernel_reduce_deterministic.cuh>
 #include <cub/device/dispatch/tuning/tuning_reduce_deterministic.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_debug.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_temporary_storage.cuh>
@@ -335,7 +336,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   InitT init                             = {},
   cudaStream_t stream                    = {},
   TransformOpT transform_op              = {},
-  PolicySelector policy_selector         = {},
+  PolicySelector                         = {},
   KernelLauncherFactory launcher_factory = {})
 {
   // Get arch ID
@@ -345,7 +346,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
     return error;
   }
 
-  const rfa_policy active_policy = policy_selector(arch_id);
+  const rfa_policy active_policy = select_policy<PolicySelector>(arch_id);
   const auto tile_items =
     static_cast<OffsetT>(active_policy.single_tile.block_threads * active_policy.single_tile.items_per_thread);
 

--- a/cub/cub/device/dispatch/dispatch_reduce_nondeterministic.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_nondeterministic.cuh
@@ -25,6 +25,7 @@
 #include <cub/grid/grid_even_share.cuh>
 #include <cub/thread/thread_operators.cuh>
 #include <cub/thread/thread_store.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_debug.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_temporary_storage.cuh>
@@ -172,7 +173,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch_nondeterministic(
   InitT init,
   cudaStream_t stream,
   TransformOpT transform_op              = {},
-  PolicySelector policy_selector         = {},
+  PolicySelector                         = {},
   KernelSource kernel_source             = {},
   KernelLauncherFactory launcher_factory = {})
 {
@@ -183,7 +184,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch_nondeterministic(
     return error;
   }
 
-  const reduce_policy active_policy = policy_selector(arch_id);
+  const reduce_policy active_policy = select_policy<PolicySelector>(arch_id);
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(
     NV_IS_HOST, ({

--- a/cub/cub/device/dispatch/dispatch_rle.cuh
+++ b/cub/cub/device/dispatch/dispatch_rle.cuh
@@ -661,7 +661,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch(
   EqualityOpT equality_op,
   OffsetT num_items,
   cudaStream_t stream,
-  PolicySelector policy_selector = {})
+  PolicySelector = {})
 {
   using local_offset_t  = ::cuda::std::int32_t;
   using global_offset_t = OffsetT;
@@ -678,7 +678,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch(
     return error;
   }
 
-  const non_trivial_runs::rle_non_trivial_runs_policy active_policy = policy_selector(arch_id);
+  const non_trivial_runs::rle_non_trivial_runs_policy active_policy = select_policy<PolicySelector>(arch_id);
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(
     NV_IS_HOST, ({

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -31,6 +31,7 @@
 #include <cub/device/dispatch/kernels/kernel_scan.cuh>
 #include <cub/device/dispatch/tuning/tuning_scan.cuh>
 #include <cub/thread/thread_operators.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_debug.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_math.cuh>
@@ -964,7 +965,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(NV_IS_HOST, ({
                  std::stringstream ss;
-                 ss << policy_selector(arch_id);
+                 ss << select_policy<PolicySelector>(arch_id);
                  _CubLog("Dispatching DeviceScan to arch %d with tuning: %s\n", (int) arch_id, ss.str().c_str());
                }))
 #endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)

--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -645,14 +645,14 @@ struct DispatchScanByKey
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
     NV_IF_TARGET(NV_IS_HOST, ({
                    ::std::stringstream ss;
-                   ss << policy_selector(arch_id);
+                   ss << cub::detail::select_policy<PolicySelectorT>(arch_id);
                    _CubLog("Dispatching DeviceScanByKey to arch %d with tuning: %s\n",
                            static_cast<int>(arch_id),
                            ss.str().c_str());
                  }))
 #endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
 
-    const detail::scan_by_key::scan_by_key_policy active_policy = policy_selector(arch_id);
+    const detail::scan_by_key::scan_by_key_policy active_policy = cub::detail::select_policy<PolicySelectorT>(arch_id);
 
     return DispatchScanByKey<KeysInputIteratorT,
                              ValuesInputIteratorT,
@@ -724,7 +724,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   InitValueT init_value,
   OffsetT num_items,
   cudaStream_t stream,
-  PolicySelector policy_selector         = {},
+  PolicySelector                         = {},
   KernelSource kernel_source             = {},
   KernelLauncherFactory launcher_factory = {}) -> cudaError_t
 {
@@ -741,7 +741,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   NV_IF_TARGET(
     NV_IS_HOST, ({
       ::std::stringstream ss;
-      ss << policy_selector(arch_id);
+      ss << select_policy<PolicySelector>(arch_id);
       _CubLog("Dispatching DeviceScanByKey to arch %d with tuning: %s\n", static_cast<int>(arch_id), ss.str().c_str());
     }))
 #endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
@@ -751,7 +751,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
     using MaxPolicy = void;
   };
 
-  const detail::scan_by_key::scan_by_key_policy active_policy = policy_selector(arch_id);
+  const detail::scan_by_key::scan_by_key_policy active_policy = select_policy<PolicySelector>(arch_id);
 
   return DispatchScanByKey<KeysInputIteratorT,
                            ValuesInputIteratorT,

--- a/cub/cub/device/dispatch/dispatch_segmented_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_segmented_radix_sort.cuh
@@ -22,6 +22,7 @@
 
 #include <cub/device/dispatch/kernels/kernel_segmented_radix_sort.cuh>
 #include <cub/device/dispatch/tuning/tuning_radix_sort.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_debug.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_math.cuh>
@@ -890,7 +891,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   bool is_overwrite_okay,
   cudaStream_t stream,
   DecomposerT decomposer                 = {},
-  PolicySelector policy_selector         = {},
+  PolicySelector                         = {},
   KernelSource kernel_source             = {},
   KernelLauncherFactory launcher_factory = {})
 {
@@ -909,7 +910,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
     return error;
   }
 
-  const radix_sort_policy active_policy = policy_selector(arch_id);
+  const radix_sort_policy active_policy = select_policy<PolicySelector>(arch_id);
 
   return invoke_passes_segmented_radix_sort(
     d_temp_storage,

--- a/cub/cub/device/dispatch/dispatch_segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_segmented_reduce.cuh
@@ -19,6 +19,7 @@
 #include <cub/device/dispatch/dispatch_common.cuh>
 #include <cub/device/dispatch/kernels/kernel_segmented_reduce.cuh>
 #include <cub/device/dispatch/tuning/tuning_segmented_reduce.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_debug.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_temporary_storage.cuh>
@@ -97,13 +98,15 @@ private:
 public:
   [[nodiscard]] _CCCL_API constexpr auto operator()(::cuda::arch_id arch_id) const -> segmented_reduce_policy
   {
-    NV_IF_ELSE_TARGET(
-      NV_IS_HOST,
-      (const int ptx_version = static_cast<int>(arch_id) * 10; segmented_reduce_policy policy{};
-       extract_policy_dispatch_t dispatch{policy};
-       PolicyHub::MaxPolicy::Invoke(ptx_version, dispatch);
-       return policy;),
-      (return convert_policy<typename PolicyHub::MaxPolicy::ActivePolicy>();));
+    NV_IF_ELSE_TARGET(NV_IS_HOST,
+                      ({
+                        const int ptx_version = static_cast<int>(arch_id) * 10;
+                        segmented_reduce_policy policy{};
+                        extract_policy_dispatch_t dispatch{policy};
+                        PolicyHub::MaxPolicy::Invoke(ptx_version, dispatch);
+                        return policy;
+                      }),
+                      (return convert_policy<typename PolicyHub::MaxPolicy::ActivePolicy>();));
   }
 };
 } // namespace detail::segmented_reduce
@@ -520,7 +523,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   InitT init,
   size_t max_segment_size,
   cudaStream_t stream,
-  PolicySelector policy_selector         = {},
+  PolicySelector                         = {},
   KernelSource kernel_source             = {},
   KernelLauncherFactory launcher_factory = {})
 {
@@ -536,7 +539,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
     return error;
   }
 
-  const segmented_reduce_policy active_policy = policy_selector(arch_id);
+  const segmented_reduce_policy active_policy = select_policy<PolicySelector>(arch_id);
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(
     NV_IS_HOST, ({
@@ -720,7 +723,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch_fixed_size(
   ReductionOpT reduction_op,
   InitT init,
   cudaStream_t stream,
-  PolicySelector policy_selector         = {},
+  PolicySelector                         = {},
   KernelSource kernel_source             = {},
   KernelLauncherFactory launcher_factory = {})
 {
@@ -740,7 +743,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch_fixed_size(
     return error;
   }
 
-  const segmented_reduce_policy active_policy = policy_selector(arch_id);
+  const segmented_reduce_policy active_policy = select_policy<PolicySelector>(arch_id);
 #if !_CCCL_COMPILER(NVRTC) && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(
     NV_IS_HOST,

--- a/cub/cub/device/dispatch/dispatch_segmented_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_segmented_scan.cuh
@@ -22,6 +22,7 @@
 #include <cub/device/dispatch/dispatch_common.cuh>
 #include <cub/device/dispatch/kernels/kernel_segmented_scan.cuh>
 #include <cub/device/dispatch/tuning/tuning_segmented_scan.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_debug.cuh>
 #include <cub/util_device.cuh>
 
@@ -125,7 +126,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   int num_segments_per_worker,
   worker worker_choice,
   cudaStream_t stream,
-  PolicySelector policy_selector         = {},
+  PolicySelector                         = {},
   KernelSource kernel_source             = {},
   KernelLauncherFactory launcher_factory = {})
 {
@@ -143,7 +144,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
     return error;
   }
 
-  const segmented_scan_policy active_policy = policy_selector(arch_id);
+  const segmented_scan_policy active_policy = select_policy<PolicySelector>(arch_id);
 
 #if !_CCCL_COMPILER(NVRTC) && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(

--- a/cub/cub/device/dispatch/dispatch_select_if.cuh
+++ b/cub/cub/device/dispatch/dispatch_select_if.cuh
@@ -1111,7 +1111,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   NV_IF_TARGET(
     NV_IS_HOST, ({
       ::std::stringstream ss;
-      ss << PolicySelector{}(arch_id);
+      ss << select_policy<PolicySelector>(arch_id);
       _CubLog("Dispatching DeviceSelectIf to arch %d with tuning: %s\n", static_cast<int>(arch_id), ss.str().c_str());
     }))
 #endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)

--- a/cub/cub/device/dispatch/dispatch_streaming_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_streaming_reduce_by_key.cuh
@@ -17,6 +17,7 @@
 #include <cub/device/dispatch/dispatch_common.cuh>
 #include <cub/device/dispatch/dispatch_reduce_by_key.cuh>
 #include <cub/device/dispatch/tuning/tuning_reduce_by_key.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_type.cuh>
 
@@ -65,7 +66,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming(
   ReductionOpT reduction_op,
   OffsetT num_items,
   cudaStream_t stream,
-  PolicySelector policy_selector = {})
+  PolicySelector = {})
 {
   ::cuda::arch_id arch_id{};
   if (const auto error = CubDebug(ptx_arch_id(arch_id)))
@@ -73,7 +74,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming(
     return error;
   }
 
-  const reduce_by_key_policy policy = policy_selector(arch_id);
+  const reduce_by_key_policy policy = select_policy<PolicySelector>(arch_id);
 
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(NV_IS_HOST, ({

--- a/cub/cub/device/dispatch/dispatch_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/dispatch_three_way_partition.cuh
@@ -17,6 +17,7 @@
 #include <cub/device/dispatch/dispatch_scan.cuh>
 #include <cub/device/dispatch/kernels/kernel_three_way_partition.cuh>
 #include <cub/device/dispatch/tuning/tuning_three_way_partition.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_math.cuh>
 
@@ -463,7 +464,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   SelectSecondPartOp select_second_part_op,
   OffsetT num_items,
   cudaStream_t stream,
-  PolicySelector policy_selector         = {},
+  PolicySelector                         = {},
   KernelSource kernel_source             = {},
   KernelLauncherFactory launcher_factory = {})
 {
@@ -473,7 +474,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
     return error;
   }
 
-  const three_way_partition_policy active_policy = policy_selector(arch_id);
+  const three_way_partition_policy active_policy = select_policy<PolicySelector>(arch_id);
 
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(

--- a/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
@@ -23,6 +23,7 @@
 #include <cub/device/dispatch/kernels/kernel_scan.cuh>
 #include <cub/device/dispatch/kernels/kernel_unique_by_key.cuh>
 #include <cub/device/dispatch/tuning/tuning_unique_by_key.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_math.cuh>
 #include <cub/util_vsmem.cuh>
@@ -511,7 +512,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(NV_IS_HOST, ({
                  ::std::stringstream ss;
-                 ss << policy_selector(arch_id);
+                 ss << select_policy<PolicySelector>(arch_id);
                  _CubLog("Dispatching DeviceSelect::UniqueByKey to arch %d with tuning: %s\n",
                          static_cast<int>(arch_id),
                          ss.str().c_str());

--- a/cub/cub/util_arch.cuh
+++ b/cub/cub/util_arch.cuh
@@ -180,7 +180,7 @@ struct NoScaling
 
 // Gets the current tuning architecture. Compared to CUB_PTX_ARCH, it can result in arch-specific architecture id. When
 // compiling with nvc++, it always results in ordinary arch id for __NVCOMPILER_CUDA_ARCH__.
-[[nodiscard]] _CCCL_API constexpr ::cuda::arch_id current_tuning_arch() noexcept
+[[nodiscard]] _CCCL_DEVICE_API constexpr ::cuda::arch_id current_tuning_arch() noexcept
 {
 #  if _CCCL_CUDA_COMPILER(NVHPC)
   return ::cuda::__to_arch_id_unchecked(::cuda::compute_capability{__NVCOMPILER_CUDA_ARCH__ / 10});
@@ -205,7 +205,7 @@ template <class PolicySelector>
 
 // Selects the tuning policy for the current_tuning_arch() architecture.
 template <class PolicySelector>
-[[nodiscard]] _CCCL_API constexpr auto current_policy()
+[[nodiscard]] _CCCL_DEVICE_API constexpr auto current_policy()
 {
   return select_policy<PolicySelector>(current_tuning_arch());
 }

--- a/cub/cub/util_arch.cuh
+++ b/cub/cub/util_arch.cuh
@@ -183,9 +183,9 @@ struct NoScaling
 [[nodiscard]] _CCCL_API constexpr ::cuda::arch_id current_tuning_arch() noexcept
 {
 #  if _CCCL_CUDA_COMPILER(NVHPC)
-  return ::cuda::to_arch_id(::cuda::compute_capability(__NVCOMPILER_CUDA_ARCH__ / 10));
+  return ::cuda::__to_arch_id_unchecked(::cuda::compute_capability{__NVCOMPILER_CUDA_ARCH__ / 10});
 #  elif _CCCL_DEVICE_COMPILATION()
-  return ::cuda::device::current_arch_id();
+  return ::cuda::device::__current_arch_id_unchecked();
 #  else // _CCCL_HOST_COMPILATION()
   return ::cuda::arch_id{};
 #  endif
@@ -196,18 +196,11 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class PolicySelector>
 [[nodiscard]] _CCCL_API constexpr auto select_policy(::cuda::arch_id arch_id)
 {
-  // todo(dabayer): enable this once current policies are rewritten to work with cuda::compute_capability
-  // if constexpr (::cuda::std::is_invocable_v<PolicySelector, ::cuda::arch_id>)
-  // {
-  //   return PolicySelector{}(arch_id);
-  // }
-  // else
-  // {
-  //   return PolicySelector{}(::cuda::compute_capability{arch_id});
-  // }
-  //
-  // Just convert arch-specific architectures to ordinary archs for now.
-  return PolicySelector{}(::cuda::arch_id{::cuda::compute_capability{arch_id}.get()});
+  // Currently, the tuning selectors should not care about specific architectures, so we convert the arch_id to the
+  // non-specific value.
+
+  // todo(dabayer): Invoke the selector with compute capability.
+  return PolicySelector{}(::cuda::__to_arch_id_unchecked(::cuda::compute_capability{arch_id}));
 }
 
 // Selects the tuning policy for the current_tuning_arch() architecture.

--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -362,7 +362,7 @@ CUB_RUNTIME_FUNCTION cudaError_t ptx_arch_id(::cuda::arch_id& arch_id)
   {
     return error;
   }
-  arch_id = ::cuda::to_arch_id(::cuda::compute_capability(ptx_version / 10));
+  arch_id = ::cuda::__to_arch_id_unchecked(::cuda::compute_capability(ptx_version / 10));
   return cudaSuccess;
 }
 
@@ -375,7 +375,7 @@ _CCCL_HOST_API cudaError_t ptx_arch_id(::cuda::arch_id& arch_id, int device)
   {
     return error;
   }
-  arch_id = ::cuda::to_arch_id(::cuda::compute_capability(ptx_version / 10));
+  arch_id = ::cuda::__to_arch_id_unchecked(::cuda::compute_capability(ptx_version / 10));
   return cudaSuccess;
 }
 } // namespace detail

--- a/cub/test/catch2_test_device_merge.cu
+++ b/cub/test/catch2_test_device_merge.cu
@@ -109,7 +109,8 @@ C2H_TEST("DeviceMerge::MergeKeys almost tile-sized input sizes", "[merge][device
   cuda::arch_id arch_id{};
   REQUIRE(cub::detail::ptx_arch_id(arch_id) == cudaSuccess);
   const offset_t items_per_tile =
-    cub::detail::merge::policy_selector_from_types<key_t, cub::NullType, offset_t>{}(arch_id).items_per_thread;
+    cub::detail::select_policy<cub::detail::merge::policy_selector_from_types<key_t, cub::NullType, offset_t>>(arch_id)
+      .items_per_thread;
 
   test_keys<key_t>(items_per_tile - 1, 1);
   test_keys<key_t>(items_per_tile, 1);

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -54,7 +54,8 @@ TEST_CASE("Device reduce works with default environment", "[reduce][device]")
   REQUIRE(cudaSuccess == cub::detail::ptx_arch_id(arch_id, current_device));
 
   unsigned int target_block_size =
-    cub::detail::reduce::policy_selector_from_types<value_t, offset_t, block_size_check_t>{}(arch_id)
+    cub::detail::select_policy<cub::detail::reduce::policy_selector_from_types<value_t, offset_t, block_size_check_t>>(
+      arch_id)
       .single_tile.block_threads;
 
   num_items_t num_items = 1;

--- a/cub/test/catch2_test_device_scan_by_key_env.cu
+++ b/cub/test/catch2_test_device_scan_by_key_env.cu
@@ -59,7 +59,8 @@ TEST_CASE("Device scan exclusive-scan-by-key works with default environment", "[
   REQUIRE(cudaSuccess == cudaGetDeviceProperties(&device_props, current_device));
 
   const auto target_block_size =
-    selector_t{}(cuda::to_arch_id(cuda::compute_capability{device_props.major, device_props.minor})).block_threads;
+    cub::detail::select_policy<selector_t>(cuda::compute_capability{device_props.major, device_props.minor})
+      .block_threads;
 
   num_items_t num_items = 1;
   auto d_keys           = thrust::device_vector<key_t>{0};
@@ -106,7 +107,8 @@ TEST_CASE("Device scan inclusive-scan-by-key works with default environment", "[
   REQUIRE(cudaSuccess == cudaGetDeviceProperties(&device_props, current_device));
 
   const auto target_block_size =
-    selector_t{}(cuda::to_arch_id(cuda::compute_capability{device_props.major, device_props.minor})).block_threads;
+    cub::detail::select_policy<selector_t>(cuda::compute_capability{device_props.major, device_props.minor})
+      .block_threads;
 
   num_items_t num_items = 1;
   auto d_keys           = thrust::device_vector<key_t>{0};

--- a/cub/test/catch2_test_device_scan_by_key_env.cu
+++ b/cub/test/catch2_test_device_scan_by_key_env.cu
@@ -8,6 +8,7 @@ struct stream_registry_factory_t;
 #include "insert_nested_NVTX_range_guard.h"
 
 #include <cub/device/device_scan.cuh>
+#include <cub/util_device.cuh>
 
 #include <thrust/device_vector.h>
 
@@ -52,15 +53,10 @@ TEST_CASE("Device scan exclusive-scan-by-key works with default environment", "[
 
   using selector_t = cub::detail::scan_by_key::policy_selector_from_types<key_t, accum_t, value_t, block_size_check_t>;
 
-  int current_device{};
-  REQUIRE(cudaSuccess == cudaGetDevice(&current_device));
+  cuda::arch_id ptx_arch_id{};
+  REQUIRE(cudaSuccess == cub::detail::ptx_arch_id(ptx_arch_id));
 
-  cudaDeviceProp device_props{};
-  REQUIRE(cudaSuccess == cudaGetDeviceProperties(&device_props, current_device));
-
-  const auto target_block_size =
-    cub::detail::select_policy<selector_t>(cuda::compute_capability{device_props.major, device_props.minor})
-      .block_threads;
+  const auto target_block_size = cub::detail::select_policy<selector_t>(ptx_arch_id).block_threads;
 
   num_items_t num_items = 1;
   auto d_keys           = thrust::device_vector<key_t>{0};
@@ -100,15 +96,10 @@ TEST_CASE("Device scan inclusive-scan-by-key works with default environment", "[
 
   using selector_t = cub::detail::scan_by_key::policy_selector_from_types<key_t, accum_t, value_t, block_size_check_t>;
 
-  int current_device{};
-  REQUIRE(cudaSuccess == cudaGetDevice(&current_device));
+  cuda::arch_id ptx_arch_id{};
+  REQUIRE(cudaSuccess == cub::detail::ptx_arch_id(ptx_arch_id));
 
-  cudaDeviceProp device_props{};
-  REQUIRE(cudaSuccess == cudaGetDeviceProperties(&device_props, current_device));
-
-  const auto target_block_size =
-    cub::detail::select_policy<selector_t>(cuda::compute_capability{device_props.major, device_props.minor})
-      .block_threads;
+  const auto target_block_size = cub::detail::select_policy<selector_t>(ptx_arch_id).block_threads;
 
   num_items_t num_items = 1;
   auto d_keys           = thrust::device_vector<key_t>{0};

--- a/cub/test/catch2_test_device_scan_env.cu
+++ b/cub/test/catch2_test_device_scan_env.cu
@@ -57,7 +57,7 @@ TEST_CASE("Device scan exclusive scan works with default environment", "[scan][d
 
   cuda::arch_id arch_id;
   REQUIRE(cudaSuccess == cub::detail::ptx_arch_id(arch_id));
-  const auto target_block_size = selector_t{}(arch_id).lookback.block_threads;
+  const auto target_block_size = cub::detail::select_policy<selector_t>(arch_id).lookback.block_threads;
 
   c2h::device_vector<unsigned int> d_block_size(1);
   block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
@@ -207,7 +207,7 @@ TEST_CASE("Device scan inclusive-scan works with default environment", "[scan][d
 
   cuda::arch_id arch_id;
   REQUIRE(cudaSuccess == cub::detail::ptx_arch_id(arch_id));
-  const auto target_block_size = selector_t{}(arch_id).lookback.block_threads;
+  const auto target_block_size = cub::detail::select_policy<selector_t>(arch_id).lookback.block_threads;
 
   c2h::device_vector<unsigned int> d_block_size(1);
   block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};

--- a/cub/test/catch2_test_device_segmented_reduce_max_seg_size.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_max_seg_size.cu
@@ -33,7 +33,9 @@ C2H_TEST("Device segmented reduce works with dynamic max segment sizes",
 
   cuda::arch_id arch_id{};
   REQUIRE(cudaSuccess == cub::detail::ptx_arch_id(arch_id));
-  auto full_policy = cub::detail::segmented_reduce::policy_selector_from_types<accum_t, offset_t, op_t>{}(arch_id);
+  auto full_policy =
+    cub::detail::select_policy<cub::detail::segmented_reduce::policy_selector_from_types<accum_t, offset_t, op_t>>(
+      arch_id);
 
   const int small_segment_size  = full_policy.small_reduce.items_per_tile();
   const int medium_segment_size = full_policy.medium_reduce.items_per_tile();

--- a/cub/test/catch2_test_device_select_env.cu
+++ b/cub/test/catch2_test_device_select_env.cu
@@ -301,7 +301,7 @@ TEST_CASE("Device select unique_by_key default tuning chooses target block size"
   cuda::arch_id arch_id{};
   REQUIRE(cudaSuccess == cub::detail::ptx_arch_id(arch_id, current_device));
 
-  const auto target_block_size = selector_t{}(arch_id).block_threads;
+  const auto target_block_size = cub::detail::select_policy<selector_t>(arch_id).block_threads;
 
   num_items_t num_items = 1;
   auto d_keys_in        = c2h::device_vector<key_t>{0};

--- a/libcudacxx/include/cuda/__device/arch_id.h
+++ b/libcudacxx/include/cuda/__device/arch_id.h
@@ -88,6 +88,11 @@ enum class arch_id : int
   }
 }
 
+[[nodiscard]] _CCCL_API constexpr arch_id __to_arch_id_unchecked(compute_capability __cc) noexcept
+{
+  return static_cast<arch_id>(__cc.get());
+}
+
 //! @brief Converts the compute capability to the architecture id.
 //!
 //! @param __cc The compute capability. Must have a corresponding architecture id.
@@ -96,7 +101,12 @@ enum class arch_id : int
 [[nodiscard]] _CCCL_API constexpr arch_id to_arch_id(compute_capability __cc) noexcept
 {
   _CCCL_ASSERT(::cuda::__has_known_arch(__cc), "this compute capability cannot be converted to arch id");
-  return static_cast<arch_id>(__cc.get());
+  return ::cuda::__to_arch_id_unchecked(__cc);
+}
+
+[[nodiscard]] _CCCL_API constexpr arch_id __to_arch_specific_id_unchecked(compute_capability __cc) noexcept
+{
+  return static_cast<arch_id>(__cc.get() * __arch_specific_id_multiplier);
 }
 
 //! @brief Converts the compute capability to the architecture specific id.
@@ -108,7 +118,7 @@ enum class arch_id : int
 {
   _CCCL_ASSERT(::cuda::__has_known_specific_arch(__cc),
                "this compute capability cannot be converted to arch specific id");
-  return static_cast<arch_id>(__cc.get() * __arch_specific_id_multiplier);
+  return ::cuda::__to_arch_specific_id_unchecked(__cc);
 }
 
 _CCCL_END_NAMESPACE_CUDA
@@ -151,6 +161,22 @@ _CCCL_END_NAMESPACE_STD
 
 _CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
 
+[[nodiscard]] _CCCL_DEVICE_API inline _CCCL_TARGET_CONSTEXPR ::cuda::arch_id __current_arch_id_unchecked() noexcept
+{
+#  if _CCCL_CUDA_COMPILER(NVHPC)
+  return ::cuda::__to_arch_id_unchecked(::cuda::device::current_compute_capability());
+#  elif _CCCL_DEVICE_COMPILATION()
+  constexpr auto __cc = ::cuda::device::current_compute_capability();
+#    if defined(__CUDA_ARCH_SPECIFIC__)
+  return ::cuda::__to_arch_specific_id_unchecked(__cc);
+#    else // ^^^ __CUDA_ARCH_SPECIFIC__ ^^^ / vvv !__CUDA_ARCH_SPECIFIC__ vvv
+  return ::cuda::__to_arch_id_unchecked(__cc);
+#    endif // ^^^ !__CUDA_ARCH_SPECIFIC__ ^^^
+#  else
+  return {};
+#  endif // ^^^ single-pass cuda compiler ^^^
+}
+
 //! @brief This function should cause a link error. If it happens, you are trying to compile the code for an unsupported
 //!        architecture (too new/old).
 _CCCL_DEVICE_API ::cuda::arch_id __unknown_cuda_architecture();
@@ -184,7 +210,7 @@ template <class _Dummy = void>
   constexpr auto __is_known_cc = ::cuda::std::__always_false_v<_Dummy> || ::cuda::__has_known_arch(__cc);
   static_assert(__is_known_cc, "unknown CUDA architecture");
   return ::cuda::to_arch_id(__cc);
-#    endif // ^^^ __CUDA_ARCH_SPECIFIC__ ^^^
+#    endif // ^^^ !__CUDA_ARCH_SPECIFIC__ ^^^
 #  else
   return {};
 #  endif // ^^^ single-pass cuda compiler ^^^


### PR DESCRIPTION
This PR rewrites all `policy_selector{}(arch_id)` invocations to use `cub::detail::select_policy<PolicySelector>(arch_id)` instead. This is necessary to allow us to change the tuning selector invocation mechanism.