### PR TITLE
[HostJit] Add basic implementations of string functions

### DIFF
--- a/c/parallel/src/hostjit/include/hostjit/cuda_minimal/stubs/string.h
+++ b/c/parallel/src/hostjit/include/hostjit/cuda_minimal/stubs/string.h
@@ -1,15 +1,68 @@
 #ifndef _HOSTJIT_STRING_H
 #define _HOSTJIT_STRING_H
+
 #include <stddef.h>
 #ifdef __cplusplus
 extern "C" {
-#endif
+inline void* memcpy(void* __s1, const void* __s2, size_t __n)
+{
+  return __builtin_memcpy(__s1, __s2, __n);
+}
+inline void* memmove(void* __s1, const void* __s2, size_t __n)
+{
+  return __builtin_memmove(__s1, __s2, __n);
+}
+inline int memcmp(const void* __s1, const void* __s2, size_t __n)
+{
+  return __builtin_memcmp(__s1, __s2, __n);
+}
+inline char* strchr(char* __s, int __c)
+{
+  return __builtin_strchr(__s, __c);
+}
+inline char* strpbrk(char* __s1, const char* __s2)
+{
+  return __builtin_strpbrk(__s1, __s2);
+}
+inline char* strrchr(char* __s, int __c)
+{
+  return __builtin_strrchr(__s, __c);
+}
+inline void* memchr(void* __s, int __c, size_t __n)
+{
+  return __builtin_memchr(__s, __c, __n);
+}
+inline char* strstr(char* __s1, const char* __s2)
+{
+  return __builtin_strstr(__s1, __s2);
+}
+inline char* strcpy(char* __s1, const char* __s2)
+{
+  return __builtin_strcpy(__s1, __s2);
+}
+inline char* strncpy(char* __s1, const char* __s2, size_t __n)
+{
+  return __builtin_strncpy(__s1, __s2, __n);
+}
+inline int strcmp(const char* __s1, const char* __s2)
+{
+  return __builtin_strcmp(__s1, __s2);
+}
+inline int strncmp(const char* __s1, const char* __s2, size_t __n)
+{
+  return __builtin_strncmp(__s1, __s2, __n);
+}
+inline size_t strlen(const char* __s)
+{
+  return __builtin_strlen(__s);
+}
+}
+#else // ^^^ __cplusplus ^^^ / vvv !__cplusplus vvv
 void* memcpy(void*, const void*, size_t);
 void* memset(void*, int, size_t);
 int memcmp(const void*, const void*, size_t);
 void* memmove(void*, const void*, size_t);
 size_t strlen(const char*);
-#ifdef __cplusplus
-}
-#endif
-#endif
+#endif // !__cplusplus
+
+#endif //_HOSTJIT_STRING_H

--- a/docs/cccl/development/macro.rst
+++ b/docs/cccl/development/macro.rst
@@ -496,3 +496,58 @@ Usage example:
     _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
     // code ..
     _CCCL_DIAG_POP
+
+----
+
+Freestanding support
+--------------------------
+
+We - partially - support building CCCL headers in freestanding mode, for example JIT compilation with NVRTC.
+
++-----------------------------+----------------------------------------------------+
+| ``_CCCL_HOSTED()``          | "Normal" compilation mode with host STL support    |
++-----------------------------+----------------------------------------------------+
+| ``_CCCL_FREESTANDING()``    | Freestanding compilation mode, no host STL support |
++-----------------------------+----------------------------------------------------+
+| ``_CCCL_HOSTJIT()``         | Freestanding compilation mode, with host compiler  |
++-----------------------------+----------------------------------------------------+
+
+Usage example:
+
+.. code-block:: c++
+
+    #if _CCCL_HOSTED()
+    #  include <iostream> // Host STL header not available in freestanding
+    #endif // _CCCL_HOSTED()
+
+    // code ..
+
+Similarly we also provide macros to detect which host standard library is available
+
++-----------------------------------+----------------------------------------------------+
+| ``_CCCL_HAS_HOST_STD_LIB()``      | Whether a known host standard library is available |
++-----------------------------------+----------------------------------------------------+
+| ``_CCCL_HOST_STD_LIB(LIBSTDCXX)`` | libstdc++ is available as host standard library    |
++-----------------------------------+----------------------------------------------------+
+| ``_CCCL_HOST_STD_LIB(LIBCXX)``    | libc++ is available as host standard library       |
++-----------------------------------+----------------------------------------------------+
+| ``_CCCL_HOST_STD_LIB(STL)``       | MSVC STL is available as host standard library     |
++-----------------------------------+----------------------------------------------------+
+
+Usage example:
+
+.. code-block:: c++
+
+    #if _CCCL_HAS_HOST_STD_LIB()
+    _CCCL_BEGIN_NAMESPACE_STD
+
+    #  if _CCCL_HOST_STD_LIB(STL)
+    template <class _Tp, size_t _Size>
+    class array;
+    #  else // ^^^ _CCCL_HOST_STD_LIB(STL) ^^^ / vvv !_CCCL_HOST_STD_LIB(STL) vvv
+    template <class _Tp, size_t _Size>
+    struct array;
+    #  endif // !_CCCL_HOST_STD_LIB(STL)
+
+    _CCCL_END_NAMESPACE_STD
+    #endif // _CCCL_HAS_HOST_STD_LIB()

--- a/libcudacxx/include/cuda/std/__cccl/compiler.h
+++ b/libcudacxx/include/cuda/std/__cccl/compiler.h
@@ -222,4 +222,17 @@
 #  define _CCCL_WARNING(_MSG) _CCCL_PRAGMA(GCC warning _MSG)
 #endif // !_CCCL_COMPILER(MSVC)
 
+// Freestanding environment detection
+// NVRTC is treated as freestanding since it has no access to the host standard library
+#if defined(_CCCL_ENABLE_FREESTANDING) || _CCCL_COMPILER(NVRTC)
+#  define _CCCL_FREESTANDING() 1
+#  define _CCCL_HOSTED()       0
+#  define _CCCL_HOSTJIT()      (!_CCCL_COMPILER(NVRTC))
+#  define _CCCL_NO_TYPEID
+#else // ^^^ _CCCL_ENABLE_FREESTANDING ||  _CCCL_COMPILER(NVRTC) ^^^ / vvv Hosted environment vvv
+#  define _CCCL_FREESTANDING() 0
+#  define _CCCL_HOSTED()       1
+#  define _CCCL_HOSTJIT()      0
+#endif // Hosted environment
+
 #endif // __CCCL_COMPILER_H

--- a/libcudacxx/include/cuda/std/__cccl/host_std_lib.h
+++ b/libcudacxx/include/cuda/std/__cccl/host_std_lib.h
@@ -34,17 +34,6 @@
 #  include <ciso646>
 #endif // ^^^ __has_include(<ciso646>) ^^^
 
-// Freestanding environment detection
-// NVRTC is treated as freestanding since it has no access to the host standard library
-#if defined(_CCCL_ENABLE_FREESTANDING) || _CCCL_COMPILER(NVRTC)
-#  define _CCCL_FREESTANDING() 1
-#  define _CCCL_NO_TYPEID
-#else
-#  define _CCCL_FREESTANDING() 0
-#endif
-
-#define _CCCL_HOSTED() (!_CCCL_FREESTANDING())
-
 #define _CCCL_HOST_STD_LIB_MAKE_VERSION(_MAJOR, _MINOR) ((_MAJOR) * 100 + (_MINOR))
 #define _CCCL_HOST_STD_LIB(...)                         _CCCL_VERSION_COMPARE(_CCCL_HOST_STD_LIB_, _CCCL_HOST_STD_LIB_##__VA_ARGS__)
 

--- a/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
+++ b/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
@@ -28,7 +28,9 @@
 
 #if _CCCL_HOSTED()
 #  include <cstring>
-#endif // _CCCL_HOSTED()
+#elif _CCCL_HOSTJIT()
+#  include <string.h>
+#endif // _CCCL_HOSTJIT()
 
 #include <cuda/std/__cccl/prologue.h>
 


### PR DESCRIPTION
We need implementations of e.g `strcpy` for CCCL.

Those are defined in the host string.h We can use the compiler builtins for them just fine. This reduces code changes needed in libcu++ considerably and is also simply correct.

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
