### PR TITLE
[HostJit] Do include nvtx header for HostJit

### DIFF
--- a/cub/cub/config.cuh
+++ b/cub/cub/config.cuh
@@ -24,6 +24,6 @@
 #include <cub/util_macro.cuh> // IWYU pragma: export
 #include <cub/util_namespace.cuh> // IWYU pragma: export
 
-#if _CCCL_HOSTED()
+#if !_CCCL_COMPILER(NVRTC)
 #  include <cuda/__nvtx/nvtx.h>
-#endif // _CCCL_HOSTED()
+#endif // !_CCCL_COMPILER(NVRTC)


### PR DESCRIPTION
We need the definitions of the respective macros for it to work.

We do not have any of the nvtx headers in the include path, so its fine to use the macros because they will just be empty
