### PR TITLE
[HostHit] Do not redefine arithmetic type aliases

### DIFF
--- a/libcudacxx/include/cuda/std/cstdint
+++ b/libcudacxx/include/cuda/std/cstdint
@@ -25,7 +25,7 @@
 
 #if _CCCL_HOSTED()
 #  include <cstdint>
-#else // ^^^ _CCCL_HOSTED() ^^^ / vvv _CCCL_FREESTANDING() vvv
+#elif _CCCL_COMPILER(NVRTC)
 #  include <cuda/std/climits>
 
 using int8_t   = signed char;
@@ -124,7 +124,7 @@ using uintmax_t = uint64_t;
 
 #  define INTMAX_C(X)  ((::intmax_t) (X))
 #  define UINTMAX_C(X) ((::uintmax_t) (X))
-#endif // ^^^ _CCCL_FREESTANDING()
+#endif // ^^^ _CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 


### PR DESCRIPTION
The definitions of e.g `int8_t` come from some of the fundamental includes.

Avoid redefinition errors.
