### PR TITLE
[HostJit] Add `_CCCL_HOSTJIT` macro

### DIFF
--- a/docs/cccl/development/macro.rst
+++ b/docs/cccl/development/macro.rst
@@ -496,3 +496,58 @@ Usage example:
     _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
     // code ..
     _CCCL_DIAG_POP
+
+----
+
+Freestanding support
+--------------------------
+
+We - partially - support building CCCL headers in freestanding mode, for example JIT compilation with NVRTC.
+
++-----------------------------+----------------------------------------------------+
+| ``_CCCL_HOSTED()``          | "Normal" compilation mode with host STL support    |
++-----------------------------+----------------------------------------------------+
+| ``_CCCL_FREESTANDING()``    | Freestanding compilation mode, no host STL support |
++-----------------------------+----------------------------------------------------+
+| ``_CCCL_HOSTJIT()``         | Freestanding compilation mode, with host compiler  |
++-----------------------------+----------------------------------------------------+
+
+Usage example:
+
+.. code-block:: c++
+
+    #if _CCCL_HOSTED()
+    #  include <iostream> // Host STL header not available in freestanding
+    #endif // _CCCL_HOSTED()
+
+    // code ..
+
+Similarly we also provide macros to detect which host standard library is available
+
++-----------------------------------+----------------------------------------------------+
+| ``_CCCL_HAS_HOST_STD_LIB()``      | Whether a known host standard library is available |
++-----------------------------------+----------------------------------------------------+
+| ``_CCCL_HOST_STD_LIB(LIBSTDCXX)`` | libstdc++ is available as host standard library    |
++-----------------------------------+----------------------------------------------------+
+| ``_CCCL_HOST_STD_LIB(LIBCXX)``    | libc++ is available as host standard library       |
++-----------------------------------+----------------------------------------------------+
+| ``_CCCL_HOST_STD_LIB(STL)``       | MSVC STL is available as host standard library     |
++-----------------------------------+----------------------------------------------------+
+
+Usage example:
+
+.. code-block:: c++
+
+    #if _CCCL_HAS_HOST_STD_LIB()
+    _CCCL_BEGIN_NAMESPACE_STD
+
+    #  if _CCCL_HOST_STD_LIB(STL)
+    template <class _Tp, size_t _Size>
+    class array;
+    #  else // ^^^ _CCCL_HOST_STD_LIB(STL) ^^^ / vvv !_CCCL_HOST_STD_LIB(STL) vvv
+    template <class _Tp, size_t _Size>
+    struct array;
+    #  endif // !_CCCL_HOST_STD_LIB(STL)
+
+    _CCCL_END_NAMESPACE_STD
+    #endif // _CCCL_HAS_HOST_STD_LIB()

--- a/libcudacxx/include/cuda/std/__cccl/compiler.h
+++ b/libcudacxx/include/cuda/std/__cccl/compiler.h
@@ -222,4 +222,17 @@
 #  define _CCCL_WARNING(_MSG) _CCCL_PRAGMA(GCC warning _MSG)
 #endif // !_CCCL_COMPILER(MSVC)
 
+// Freestanding environment detection
+// NVRTC is treated as freestanding since it has no access to the host standard library
+#if defined(_CCCL_ENABLE_FREESTANDING) || _CCCL_COMPILER(NVRTC)
+#  define _CCCL_FREESTANDING() 1
+#  define _CCCL_HOSTED()       0
+#  define _CCCL_HOSTJIT()      (!_CCCL_COMPILER(NVRTC))
+#  define _CCCL_NO_TYPEID
+#else // ^^^ _CCCL_ENABLE_FREESTANDING ||  _CCCL_COMPILER(NVRTC) ^^^ / vvv Hosted environment vvv
+#  define _CCCL_FREESTANDING() 0
+#  define _CCCL_HOSTED()       1
+#  define _CCCL_HOSTJIT()      0
+#endif // Hosted environment
+
 #endif // __CCCL_COMPILER_H

--- a/libcudacxx/include/cuda/std/__cccl/host_std_lib.h
+++ b/libcudacxx/include/cuda/std/__cccl/host_std_lib.h
@@ -34,17 +34,6 @@
 #  include <ciso646>
 #endif // ^^^ __has_include(<ciso646>) ^^^
 
-// Freestanding environment detection
-// NVRTC is treated as freestanding since it has no access to the host standard library
-#if defined(_CCCL_ENABLE_FREESTANDING) || _CCCL_COMPILER(NVRTC)
-#  define _CCCL_FREESTANDING() 1
-#  define _CCCL_NO_TYPEID
-#else
-#  define _CCCL_FREESTANDING() 0
-#endif
-
-#define _CCCL_HOSTED() (!_CCCL_FREESTANDING())
-
 #define _CCCL_HOST_STD_LIB_MAKE_VERSION(_MAJOR, _MINOR) ((_MAJOR) * 100 + (_MINOR))
 #define _CCCL_HOST_STD_LIB(...)                         _CCCL_VERSION_COMPARE(_CCCL_HOST_STD_LIB_, _CCCL_HOST_STD_LIB_##__VA_ARGS__)
 


### PR DESCRIPTION
We need to know when we are explicitly compiling for freestanding and not just for NVRTC

Also move the macro to the right place
