### PR TITLE
[HostJit] Include `<new>` for device compilations

### DIFF
--- a/libcudacxx/include/cuda/std/__host_stdlib/new
+++ b/libcudacxx/include/cuda/std/__host_stdlib/new
@@ -21,8 +21,9 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HOSTED()
+// HostJiT also needs <new>
+#if !_CCCL_COMPILER(NVRTC)
 #  include <new>
-#endif // _CCCL_HOSTED()
+#endif // !_CCCL_COMPILER(NVRTC)
 
 #endif // _CUDA_STD___HOST_STDLIB_NEW


### PR DESCRIPTION
We need the definition of `operator new` to be available for HostJit
