### PR TITLE
Allows moving the token returned from `BlockLoadToShared`. 

### DIFF
--- a/cub/cub/block/block_load_to_shared.cuh
+++ b/cub/cub/block/block_load_to_shared.cuh
@@ -241,6 +241,10 @@ private:
     token_impl(const token_impl&)            = delete;
     token_impl& operator=(const token_impl&) = delete;
     // NOLINTEND(modernize-use-equals-delete)
+
+  public:
+    token_impl(token_impl&&)            = default;
+    token_impl& operator=(token_impl&&) = default;
   };
 
 public:

--- a/cub/cub/block/block_load_to_shared.cuh
+++ b/cub/cub/block/block_load_to_shared.cuh
@@ -237,12 +237,12 @@ private:
     _CCCL_DEVICE_API _CCCL_FORCEINLINE token_impl() {} // NOLINT(modernize-use-equals-default) ctor must have a body to
                                                        // avoid token_impl{} to compile
 
+  public:
     // NOLINTBEGIN(modernize-use-equals-delete)
     token_impl(const token_impl&)            = delete;
     token_impl& operator=(const token_impl&) = delete;
     // NOLINTEND(modernize-use-equals-delete)
 
-  public:
     token_impl(token_impl&&)            = default;
     token_impl& operator=(token_impl&&) = default;
   };


### PR DESCRIPTION
## Description

Allows moving the token returned from `BlockLoadToShared`. 

Thanks to @pauleonix, who originally ran into and made the proposal.