### PR TITLE
Use the new tuning API internally for `detail::topk::dispatch`

### DIFF
--- a/cub/benchmarks/bench/topk/keys.cu
+++ b/cub/benchmarks/bench/topk/keys.cu
@@ -1,8 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <cub/detail/choose_offset.cuh>
 #include <cub/device/device_topk.cuh>
+
+#include <cuda/__execution/determinism.h>
+#include <cuda/__execution/output_ordering.h>
+#include <cuda/__execution/require.h>
+#include <cuda/__execution/tune.h>
 
 #include <nvbench_helper.cuh>
 
@@ -11,7 +15,7 @@
 // %RANGE% TUNE_BLOCK_LOAD_ALGORITHM ld 0:2:1
 
 #if !TUNE_BASE
-template <class KeyInT, class OffsetT>
+template <class KeyInT>
 struct policy_selector_t
 {
   [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
@@ -40,12 +44,6 @@ struct policy_selector_t
 template <typename KeyT, typename OffsetT, typename OutOffsetT>
 void topk_keys(nvbench::state& state, nvbench::type_list<KeyT, OffsetT, OutOffsetT>)
 {
-  using offset_t = cub::detail::choose_offset_t<OffsetT>;
-  using out_offset_t =
-    cuda::std::conditional_t<sizeof(offset_t) < sizeof(cub::detail::choose_offset_t<OutOffsetT>),
-                             offset_t,
-                             cub::detail::choose_offset_t<OutOffsetT>>;
-
   // Retrieve axis parameters
   const auto elements          = static_cast<size_t>(state.get_int64("Elements{io}"));
   const auto selected_elements = static_cast<size_t>(state.get_int64("SelectedElements"));
@@ -69,45 +67,39 @@ void topk_keys(nvbench::state& state, nvbench::type_list<KeyT, OffsetT, OutOffse
   state.add_global_memory_reads<KeyT>(elements, "InputKeys");
   state.add_global_memory_writes<KeyT>(selected_elements, "OutputKeys");
 
-  // allocate temporary storage
-  size_t temp_size;
-  cub::detail::topk::dispatch<cub::detail::topk::select::max>(
+  // TODO(bgruber): call cub::DeviceTopK::MaxKeys with a the caching_allocator_t once we have an env-overload without
+  // temporary storage
+  auto env = cuda::std::execution::env{
+    cuda::execution::require(cuda::execution::determinism::not_guaranteed, cuda::execution::output_ordering::unsorted)
+#if !TUNE_BASE
+      ,
+    cuda::execution::tune(policy_selector_t<KeyT>{})
+#endif // !TUNE_BASE
+  };
+
+  // Allocate temporary storage
+  size_t temp_size{};
+  cub::DeviceTopK::MaxKeys(
     nullptr,
     temp_size,
     d_keys_in,
     d_keys_out,
-    static_cast<const cub::NullType*>(nullptr),
-    static_cast<cub::NullType*>(nullptr),
-    static_cast<offset_t>(elements),
-    static_cast<out_offset_t>(selected_elements),
-    cub::detail::identity_decomposer_t{},
-    nullptr
-#if !TUNE_BASE
-    ,
-    policy_selector_t<KeyT, OffsetT>{}
-#endif // !TUNE_BASE
-  );
+    static_cast<OffsetT>(elements),
+    static_cast<OutOffsetT>(selected_elements),
+    env);
   thrust::device_vector<nvbench::uint8_t> temp(temp_size, thrust::no_init);
   auto* temp_storage = thrust::raw_pointer_cast(temp.data());
 
-  // run the algorithm
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::topk::dispatch<cub::detail::topk::select::max>(
+    auto env_with_stream = cuda::std::execution::env{cuda::stream_ref{launch.get_stream().get_stream()}, env};
+    cub::DeviceTopK::MaxKeys(
       temp_storage,
       temp_size,
       d_keys_in,
       d_keys_out,
-      static_cast<const cub::NullType*>(nullptr),
-      static_cast<cub::NullType*>(nullptr),
-      static_cast<offset_t>(elements),
-      static_cast<out_offset_t>(selected_elements),
-      cub::detail::identity_decomposer_t{},
-      launch.get_stream()
-#if !TUNE_BASE
-        ,
-      policy_selector_t<KeyT, OffsetT>{}
-#endif // !TUNE_BASE
-    );
+      static_cast<OffsetT>(elements),
+      static_cast<OutOffsetT>(selected_elements),
+      env_with_stream);
   });
 }
 

--- a/cub/benchmarks/bench/topk/pairs.cu
+++ b/cub/benchmarks/bench/topk/pairs.cu
@@ -1,8 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <cub/detail/choose_offset.cuh>
 #include <cub/device/device_topk.cuh>
+
+#include <cuda/__execution/determinism.h>
+#include <cuda/__execution/output_ordering.h>
+#include <cuda/__execution/require.h>
+#include <cuda/__execution/tune.h>
 
 #include <nvbench_helper.cuh>
 
@@ -11,7 +15,7 @@
 // %RANGE% TUNE_BLOCK_LOAD_ALGORITHM ld 0:2:1
 
 #if !TUNE_BASE
-template <class KeyInT, class OffsetT>
+template <class KeyInT>
 struct policy_selector_t
 {
   [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
@@ -40,11 +44,6 @@ struct policy_selector_t
 template <typename KeyT, typename ValueT, typename OffsetT, typename OutOffsetT>
 void topk_pairs(nvbench::state& state, nvbench::type_list<KeyT, ValueT, OffsetT, OutOffsetT>)
 {
-  using offset_t = cub::detail::choose_offset_t<OffsetT>;
-  using out_offset_t =
-    cuda::std::conditional_t<sizeof(offset_t) < sizeof(cub::detail::choose_offset_t<OutOffsetT>),
-                             offset_t,
-                             cub::detail::choose_offset_t<OutOffsetT>>;
   // Retrieve axis parameters
   const auto elements          = static_cast<size_t>(state.get_int64("Elements{io}"));
   const auto selected_elements = static_cast<size_t>(state.get_int64("SelectedElements"));
@@ -75,45 +74,41 @@ void topk_pairs(nvbench::state& state, nvbench::type_list<KeyT, ValueT, OffsetT,
   state.add_global_memory_writes<KeyT>(selected_elements, "OutputKeys");
   state.add_global_memory_writes<ValueT>(selected_elements, "OutputVales");
 
-  // allocate temporary storage
-  size_t temp_size;
-  cub::detail::topk::dispatch<cub::detail::topk::select::max>(
+  auto env = cuda::std::execution::env{
+    cuda::execution::require(cuda::execution::determinism::not_guaranteed, cuda::execution::output_ordering::unsorted)
+#if !TUNE_BASE
+      ,
+    cuda::execution::tune(policy_selector_t<KeyT>{})
+#endif // !TUNE_BASE
+  };
+
+  // Allocate temporary storage
+  size_t temp_size{};
+  cub::DeviceTopK::MaxPairs(
     nullptr,
     temp_size,
     d_keys_in,
     d_keys_out,
     d_values_in,
     d_values_out,
-    static_cast<offset_t>(elements),
-    static_cast<out_offset_t>(selected_elements),
-    cub::detail::identity_decomposer_t{},
-    nullptr
-#if !TUNE_BASE
-    ,
-    policy_selector_t<KeyT, OffsetT>{}
-#endif // !TUNE_BASE
-  );
+    static_cast<OffsetT>(elements),
+    static_cast<OutOffsetT>(selected_elements),
+    env);
   thrust::device_vector<nvbench::uint8_t> temp(temp_size, thrust::no_init);
   auto* temp_storage = thrust::raw_pointer_cast(temp.data());
 
-  // run the algorithm
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::topk::dispatch<cub::detail::topk::select::max>(
+    auto env_with_stream = cuda::std::execution::env{cuda::stream_ref{launch.get_stream().get_stream()}, env};
+    cub::DeviceTopK::MaxPairs(
       temp_storage,
       temp_size,
       d_keys_in,
       d_keys_out,
       d_values_in,
       d_values_out,
-      static_cast<offset_t>(elements),
-      static_cast<out_offset_t>(selected_elements),
-      cub::detail::identity_decomposer_t{},
-      launch.get_stream()
-#if !TUNE_BASE
-        ,
-      policy_selector_t<KeyT, OffsetT>{}
-#endif // !TUNE_BASE
-    );
+      static_cast<OffsetT>(elements),
+      static_cast<OutOffsetT>(selected_elements),
+      env_with_stream);
   });
 }
 

--- a/cub/cub/device/device_topk.cuh
+++ b/cub/cub/device/device_topk.cuh
@@ -23,6 +23,7 @@
 #include <cuda/__execution/determinism.h>
 #include <cuda/__execution/output_ordering.h>
 #include <cuda/__execution/require.h>
+#include <cuda/__execution/tune.h>
 #include <cuda/__functional/call_or.h>
 #include <cuda/__stream/get_stream.h>
 #include <cuda/std/__execution/env.h>
@@ -85,6 +86,13 @@ CUB_RUNTIME_FUNCTION static cudaError_t dispatch_topk(
   // Query relevant properties from the environment
   auto stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, env);
 
+  // Extract policy selector from environment tuning
+  using default_policy_selector_t = topk::policy_selector_from_types<it_value_t<KeyInputIteratorT>>;
+  using tuning_env_t =
+    ::cuda::__call_result_or_t<::cuda::execution::__get_tuning_t, ::cuda::std::execution::env<>, EnvT>;
+  using policy_selector_t =
+    ::cuda::std::execution::__query_result_or_t<tuning_env_t, topk::topk_policy, default_policy_selector_t>;
+
   return topk::dispatch<SelectDirection>(
     d_temp_storage,
     temp_storage_bytes,
@@ -95,7 +103,8 @@ CUB_RUNTIME_FUNCTION static cudaError_t dispatch_topk(
     static_cast<offset_t>(num_items),
     static_cast<out_offset_t>(k),
     decomposer,
-    stream.get());
+    stream.get(),
+    policy_selector_t{});
 }
 
 template <topk::select SelectDirection,

--- a/cub/test/catch2_test_device_topk_env.cu
+++ b/cub/test/catch2_test_device_topk_env.cu
@@ -22,7 +22,7 @@ struct stream_registry_factory_t;
 
 #include "catch2_test_env_launch_helper.h"
 
-// %PARAM% TEST_LAUNCH lid 0:1:2
+// %PARAM% TEST_LAUNCH lid 0:2
 
 #include <c2h/catch2_test_helper.h>
 

--- a/cub/test/catch2_test_device_topk_env.cu
+++ b/cub/test/catch2_test_device_topk_env.cu
@@ -54,7 +54,7 @@ using block_sizes =
 C2H_TEST("DeviceTopK::MaxKeys can be tuned", "[topk][device]", block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
-  c2h::device_vector<unsigned int> d_block_size(1, 0);
+  c2h::device_vector<unsigned int> d_block_size{0};
 
   block_size_extracting_constant_iterator input(42, thrust::raw_pointer_cast(d_block_size.data()));
   c2h::device_vector<int> d_keys_out(3);
@@ -62,19 +62,28 @@ C2H_TEST("DeviceTopK::MaxKeys can be tuned", "[topk][device]", block_sizes)
   auto env = stdexec::env{topk_requirements(), cuda::execution::tune(topk_tuning<target_block_size>{})};
 
   size_t temp_size{};
-  REQUIRE(cudaSuccess == cub::DeviceTopK::MaxKeys(nullptr, temp_size, input, d_keys_out.begin(), 1024, 3, env));
-
-  c2h::device_vector<char> temp(temp_size);
   REQUIRE(cudaSuccess
           == cub::DeviceTopK::MaxKeys(
-            thrust::raw_pointer_cast(temp.data()), temp_size, input, d_keys_out.begin(), 1024, 3, env));
+            nullptr, temp_size, input, d_keys_out.begin(), /* elements */ 1024, d_keys_out.size(), env));
+
+  c2h::device_vector<char> temp(temp_size);
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceTopK::MaxKeys(
+      thrust::raw_pointer_cast(temp.data()),
+      temp_size,
+      input,
+      d_keys_out.begin(),
+      /* elements */ 1024,
+      d_keys_out.size(),
+      env));
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
 C2H_TEST("DeviceTopK::MinKeys can be tuned", "[topk][device]", block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
-  c2h::device_vector<unsigned int> d_block_size(1, 0);
+  c2h::device_vector<unsigned int> d_block_size{0};
 
   block_size_extracting_constant_iterator input(42, thrust::raw_pointer_cast(d_block_size.data()));
   c2h::device_vector<int> d_keys_out(3);
@@ -82,19 +91,28 @@ C2H_TEST("DeviceTopK::MinKeys can be tuned", "[topk][device]", block_sizes)
   auto env = stdexec::env{topk_requirements(), cuda::execution::tune(topk_tuning<target_block_size>{})};
 
   size_t temp_size{};
-  REQUIRE(cudaSuccess == cub::DeviceTopK::MinKeys(nullptr, temp_size, input, d_keys_out.begin(), 1024, 3, env));
-
-  c2h::device_vector<char> temp(temp_size);
   REQUIRE(cudaSuccess
           == cub::DeviceTopK::MinKeys(
-            thrust::raw_pointer_cast(temp.data()), temp_size, input, d_keys_out.begin(), 1024, 3, env));
+            nullptr, temp_size, input, d_keys_out.begin(), /* elements */ 1024, d_keys_out.size(), env));
+
+  c2h::device_vector<char> temp(temp_size);
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceTopK::MinKeys(
+      thrust::raw_pointer_cast(temp.data()),
+      temp_size,
+      input,
+      d_keys_out.begin(),
+      /* elements */ 1024,
+      d_keys_out.size(),
+      env));
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
 C2H_TEST("DeviceTopK::MaxPairs can be tuned", "[topk][device]", block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
-  c2h::device_vector<unsigned int> d_block_size(1, 0);
+  c2h::device_vector<unsigned int> d_block_size{0};
 
   block_size_extracting_constant_iterator input(42, thrust::raw_pointer_cast(d_block_size.data()));
   auto values_in = cuda::make_counting_iterator<int>(0);
@@ -127,7 +145,7 @@ C2H_TEST("DeviceTopK::MaxPairs can be tuned", "[topk][device]", block_sizes)
 C2H_TEST("DeviceTopK::MinPairs can be tuned", "[topk][device]", block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
-  c2h::device_vector<unsigned int> d_block_size(1, 0);
+  c2h::device_vector<unsigned int> d_block_size{0};
 
   block_size_extracting_constant_iterator input(42, thrust::raw_pointer_cast(d_block_size.data()));
   auto values_in = cuda::make_counting_iterator<int>(0);
@@ -137,9 +155,18 @@ C2H_TEST("DeviceTopK::MinPairs can be tuned", "[topk][device]", block_sizes)
   auto env = stdexec::env{topk_requirements(), cuda::execution::tune(topk_tuning<target_block_size>{})};
 
   size_t temp_size{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceTopK::MinPairs(
-            nullptr, temp_size, input, d_keys_out.begin(), values_in, d_values_out.begin(), 1024, 3, env));
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceTopK::MinPairs(
+      nullptr,
+      temp_size,
+      input,
+      d_keys_out.begin(),
+      values_in,
+      d_values_out.begin(),
+      /* elements */ 1024,
+      d_keys_out.size(),
+      env));
 
   c2h::device_vector<char> temp(temp_size);
   REQUIRE(

--- a/cub/test/catch2_test_device_topk_env.cu
+++ b/cub/test/catch2_test_device_topk_env.cu
@@ -37,12 +37,12 @@ auto topk_requirements()
     cuda::execution::determinism::not_guaranteed, cuda::execution::output_ordering::unsorted);
 }
 
-template <unsigned int BlockThreads>
+template <unsigned int ThreadsPerBlock>
 struct topk_tuning
 {
   _CCCL_API constexpr auto operator()(cuda::arch_id /*arch*/) const -> cub::detail::topk::topk_policy
   {
-    return {BlockThreads, 1, 8, cub::BLOCK_LOAD_DIRECT, cub::BLOCK_SCAN_WARP_SCANS};
+    return {ThreadsPerBlock, 1, 8, cub::BLOCK_LOAD_DIRECT, cub::BLOCK_SCAN_WARP_SCANS};
   }
 };
 

--- a/cub/test/catch2_test_device_topk_env.cu
+++ b/cub/test/catch2_test_device_topk_env.cu
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Should precede any includes
+struct stream_registry_factory_t;
+#define CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY stream_registry_factory_t
+
+#include "insert_nested_NVTX_range_guard.h"
+
+#include <cub/device/device_topk.cuh>
+
+#include <thrust/detail/raw_pointer_cast.h>
+#include <thrust/device_vector.h>
+#include <thrust/sort.h>
+
+#include <cuda/__execution/determinism.h>
+#include <cuda/__execution/output_ordering.h>
+#include <cuda/__execution/require.h>
+#include <cuda/__execution/tune.h>
+#include <cuda/iterator>
+#include <cuda/std/functional>
+
+#include "catch2_test_env_launch_helper.h"
+
+// %PARAM% TEST_LAUNCH lid 0:1:2
+
+#include <c2h/catch2_test_helper.h>
+
+// TODO(bgruber): the tests below should be refactored to call an env-overload that uses a memory resource to allocate
+// temporary storage
+
+namespace stdexec = cuda::std::execution;
+
+auto topk_requirements()
+{
+  return cuda::execution::require(
+    cuda::execution::determinism::not_guaranteed, cuda::execution::output_ordering::unsorted);
+}
+
+template <unsigned int BlockThreads>
+struct topk_tuning
+{
+  _CCCL_API constexpr auto operator()(cuda::arch_id /*arch*/) const -> cub::detail::topk::topk_policy
+  {
+    return {BlockThreads, 1, 8, cub::BLOCK_LOAD_DIRECT, cub::BLOCK_SCAN_WARP_SCANS};
+  }
+};
+
+using block_sizes =
+  c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
+
+#if TEST_LAUNCH != 1
+
+C2H_TEST("DeviceTopK::MaxKeys can be tuned", "[topk][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<unsigned int> d_block_size(1, 0);
+
+  block_size_extracting_constant_iterator input(42, thrust::raw_pointer_cast(d_block_size.data()));
+  c2h::device_vector<int> d_keys_out(3);
+
+  auto env = stdexec::env{topk_requirements(), cuda::execution::tune(topk_tuning<target_block_size>{})};
+
+  size_t temp_size{};
+  REQUIRE(cudaSuccess == cub::DeviceTopK::MaxKeys(nullptr, temp_size, input, d_keys_out.begin(), 1024, 3, env));
+
+  c2h::device_vector<char> temp(temp_size);
+  REQUIRE(cudaSuccess
+          == cub::DeviceTopK::MaxKeys(
+            thrust::raw_pointer_cast(temp.data()), temp_size, input, d_keys_out.begin(), 1024, 3, env));
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceTopK::MinKeys can be tuned", "[topk][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<unsigned int> d_block_size(1, 0);
+
+  block_size_extracting_constant_iterator input(42, thrust::raw_pointer_cast(d_block_size.data()));
+  c2h::device_vector<int> d_keys_out(3);
+
+  auto env = stdexec::env{topk_requirements(), cuda::execution::tune(topk_tuning<target_block_size>{})};
+
+  size_t temp_size{};
+  REQUIRE(cudaSuccess == cub::DeviceTopK::MinKeys(nullptr, temp_size, input, d_keys_out.begin(), 1024, 3, env));
+
+  c2h::device_vector<char> temp(temp_size);
+  REQUIRE(cudaSuccess
+          == cub::DeviceTopK::MinKeys(
+            thrust::raw_pointer_cast(temp.data()), temp_size, input, d_keys_out.begin(), 1024, 3, env));
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceTopK::MaxPairs can be tuned", "[topk][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<unsigned int> d_block_size(1, 0);
+
+  block_size_extracting_constant_iterator input(42, thrust::raw_pointer_cast(d_block_size.data()));
+  auto values_in = cuda::make_counting_iterator<int>(0);
+  c2h::device_vector<int> d_keys_out(3);
+  c2h::device_vector<int> d_values_out(3);
+
+  auto env = stdexec::env{topk_requirements(), cuda::execution::tune(topk_tuning<target_block_size>{})};
+
+  size_t temp_size{};
+  REQUIRE(cudaSuccess
+          == cub::DeviceTopK::MaxPairs(
+            nullptr, temp_size, input, d_keys_out.begin(), values_in, d_values_out.begin(), 1024, 3, env));
+
+  c2h::device_vector<char> temp(temp_size);
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceTopK::MaxPairs(
+      thrust::raw_pointer_cast(temp.data()),
+      temp_size,
+      input,
+      d_keys_out.begin(),
+      values_in,
+      d_values_out.begin(),
+      1024,
+      3,
+      env));
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceTopK::MinPairs can be tuned", "[topk][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<unsigned int> d_block_size(1, 0);
+
+  block_size_extracting_constant_iterator input(42, thrust::raw_pointer_cast(d_block_size.data()));
+  auto values_in = cuda::make_counting_iterator<int>(0);
+  c2h::device_vector<int> d_keys_out(3);
+  c2h::device_vector<int> d_values_out(3);
+
+  auto env = stdexec::env{topk_requirements(), cuda::execution::tune(topk_tuning<target_block_size>{})};
+
+  size_t temp_size{};
+  REQUIRE(cudaSuccess
+          == cub::DeviceTopK::MinPairs(
+            nullptr, temp_size, input, d_keys_out.begin(), values_in, d_values_out.begin(), 1024, 3, env));
+
+  c2h::device_vector<char> temp(temp_size);
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceTopK::MinPairs(
+      thrust::raw_pointer_cast(temp.data()),
+      temp_size,
+      input,
+      d_keys_out.begin(),
+      values_in,
+      d_values_out.begin(),
+      1024,
+      3,
+      env));
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+#endif // TEST_LAUNCH != 1

--- a/cub/test/catch2_test_device_topk_env.cu
+++ b/cub/test/catch2_test_device_topk_env.cu
@@ -40,7 +40,7 @@ auto topk_requirements()
 template <unsigned int ThreadsPerBlock>
 struct topk_tuning
 {
-  _CCCL_API constexpr auto operator()(cuda::arch_id /*arch*/) const -> cub::detail::topk::topk_policy
+  _CCCL_API constexpr auto operator()(cuda::compute_capability /*cc*/) const -> cub::detail::topk::topk_policy
   {
     return {ThreadsPerBlock, 1, 8, cub::BLOCK_LOAD_DIRECT, cub::BLOCK_SCAN_WARP_SCANS};
   }

--- a/cub/test/catch2_test_device_topk_env.cu
+++ b/cub/test/catch2_test_device_topk_env.cu
@@ -66,7 +66,7 @@ C2H_TEST("DeviceTopK::MaxKeys can be tuned", "[topk][device]", block_sizes)
           == cub::DeviceTopK::MaxKeys(
             nullptr, temp_size, input, d_keys_out.begin(), /* elements */ 1024, d_keys_out.size(), env));
 
-  c2h::device_vector<char> temp(temp_size);
+  c2h::device_vector<char> temp(temp_size, thrust::no_init);
   REQUIRE(
     cudaSuccess
     == cub::DeviceTopK::MaxKeys(
@@ -95,7 +95,7 @@ C2H_TEST("DeviceTopK::MinKeys can be tuned", "[topk][device]", block_sizes)
           == cub::DeviceTopK::MinKeys(
             nullptr, temp_size, input, d_keys_out.begin(), /* elements */ 1024, d_keys_out.size(), env));
 
-  c2h::device_vector<char> temp(temp_size);
+  c2h::device_vector<char> temp(temp_size, thrust::no_init);
   REQUIRE(
     cudaSuccess
     == cub::DeviceTopK::MinKeys(
@@ -126,7 +126,7 @@ C2H_TEST("DeviceTopK::MaxPairs can be tuned", "[topk][device]", block_sizes)
           == cub::DeviceTopK::MaxPairs(
             nullptr, temp_size, input, d_keys_out.begin(), values_in, d_values_out.begin(), 1024, 3, env));
 
-  c2h::device_vector<char> temp(temp_size);
+  c2h::device_vector<char> temp(temp_size, thrust::no_init);
   REQUIRE(
     cudaSuccess
     == cub::DeviceTopK::MaxPairs(
@@ -168,7 +168,7 @@ C2H_TEST("DeviceTopK::MinPairs can be tuned", "[topk][device]", block_sizes)
       d_keys_out.size(),
       env));
 
-  c2h::device_vector<char> temp(temp_size);
+  c2h::device_vector<char> temp(temp_size, thrust::no_init);
   REQUIRE(
     cudaSuccess
     == cub::DeviceTopK::MinPairs(


### PR DESCRIPTION
- [x] No SASS changes for `cub.bench.topk.pairs.base` on SM`80;90`

Fixes: #7961