### PR TITLE
Allow public tuning of `cub::DeviceTransform`

### DIFF
--- a/cub/benchmarks/bench/transform/common.h
+++ b/cub/benchmarks/bench/transform/common.h
@@ -29,14 +29,13 @@
 #if !TUNE_BASE
 struct policy_selector
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability cc) const
-    -> cub::detail::transform::transform_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability cc) const -> cub::TransformPolicy
   {
     const int min_bytes_in_flight = cub::detail::transform::cc_to_min_bytes_in_flight(cc) + TUNE_BIF_BIAS;
 #  if TUNE_ALGORITHM == 0 || TUNE_ALGORITHM == 1
     // setup prefetch, since it's either used directly or the fallback to vectorized
-    auto algorithm                = cub::detail::transform::Algorithm::prefetch;
-    auto pref_policy              = cub::detail::transform::prefetch_policy{};
+    auto algorithm                = cub::TransformAlgorithm::prefetch;
+    auto pref_policy              = cub::TransformPrefetchPolicy{};
     pref_policy.threads_per_block = TUNE_THREADS;
     pref_policy.unroll_factor     = TUNE_UNROLL_FACTOR;
 #    ifdef TUNE_PREFETCH_MULT
@@ -47,27 +46,25 @@ struct policy_selector
 #    endif // TUNE_ITEMS_PER_THREAD_NO_INPUT
 
     // setup vectorized if requested
-    auto vec_policy = cub::detail::transform::vectorized_policy{};
+    auto vec_policy = cub::TransformVectorizedPolicy{};
 #    if TUNE_ALGORITHM == 1
-    algorithm                    = cub::detail::transform::Algorithm::vectorized;
+    algorithm                    = cub::TransformAlgorithm::vectorized;
     vec_policy.threads_per_block = TUNE_THREADS;
     vec_policy.vec_size          = (1 << TUNE_VEC_SIZE_POW2);
     vec_policy.items_per_thread  = vec_policy.vec_size * TUNE_UNROLL_FACTOR;
 #    endif
     return {min_bytes_in_flight, algorithm, pref_policy, vec_policy, {}};
 #  elif TUNE_ALGORITHM == 2
-    constexpr auto algorithm   = cub::detail::transform::Algorithm::memcpy_async;
-    auto policy                = cub::detail::transform::async_copy_policy{};
-    policy.threads_per_block   = TUNE_THREADS;
-    policy.bulk_copy_alignment = cub::detail::transform::ldgsts_size_and_align;
-    policy.unroll_factor       = TUNE_UNROLL_FACTOR;
+    constexpr auto algorithm = cub::TransformAlgorithm::ldgsts;
+    auto policy              = cub::TransformAsyncCopyPolicy{};
+    policy.threads_per_block     = TUNE_THREADS;
+    policy.unroll_factor     = TUNE_UNROLL_FACTOR;
     return {min_bytes_in_flight, algorithm, {}, {}, policy};
 #  elif TUNE_ALGORITHM == 3
-    constexpr auto algorithm   = cub::detail::transform::Algorithm::ublkcp;
-    auto policy                = cub::detail::transform::async_copy_policy{};
-    policy.threads_per_block   = TUNE_THREADS;
-    policy.bulk_copy_alignment = cub::detail::transform::bulk_copy_alignment(cc);
-    policy.unroll_factor       = TUNE_UNROLL_FACTOR;
+    constexpr auto algorithm = cub::TransformAlgorithm::ublkcp;
+    auto policy              = cub::TransformAsyncCopyPolicy{};
+    policy.threads_per_block     = TUNE_THREADS;
+    policy.unroll_factor     = TUNE_UNROLL_FACTOR;
     return {min_bytes_in_flight, algorithm, {}, {}, policy};
 #  else // TUNE_ALGORITHM
 #    error Policy hub does not yet implement the specified value for algorithm

--- a/cub/benchmarks/bench/transform/common.h
+++ b/cub/benchmarks/bench/transform/common.h
@@ -57,13 +57,13 @@ struct policy_selector
 #  elif TUNE_ALGORITHM == 2
     constexpr auto algorithm = cub::TransformAlgorithm::ldgsts;
     auto policy              = cub::TransformAsyncCopyPolicy{};
-    policy.threads_per_block     = TUNE_THREADS;
+    policy.threads_per_block = TUNE_THREADS;
     policy.unroll_factor     = TUNE_UNROLL_FACTOR;
     return {min_bytes_in_flight, algorithm, {}, {}, policy};
 #  elif TUNE_ALGORITHM == 3
     constexpr auto algorithm = cub::TransformAlgorithm::ublkcp;
     auto policy              = cub::TransformAsyncCopyPolicy{};
-    policy.threads_per_block     = TUNE_THREADS;
+    policy.threads_per_block = TUNE_THREADS;
     policy.unroll_factor     = TUNE_UNROLL_FACTOR;
     return {min_bytes_in_flight, algorithm, {}, {}, policy};
 #  else // TUNE_ALGORITHM

--- a/cub/cub/detail/cc_dispatch.cuh
+++ b/cub/cub/detail/cc_dispatch.cuh
@@ -112,9 +112,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_to_cc_list(
   // This causes f to be only instantiated for each distinct policy, since the same policy for different arches results
   // in the same integral_constant type passed to f
   using policy_t = decltype(policy_selector(::cuda::compute_capability{}));
-  (...,
-   (device_cc == all_ccs[Is] ? (e = f(policy_constant<policy_t, policy_selector(all_ccs[Is])>{}))
-                             : cudaSuccess));
+  (..., (device_cc == all_ccs[Is] ? (e = f(policy_constant<policy_t, policy_selector(all_ccs[Is])>{})) : cudaSuccess));
 #  else // if _CCCL_STD_VER >= 2020
   // In C++17, we have to collapse architectures with the same policies ourselves, so we instantiate call_for_cc once
   // per policy on the lowest CC which produces the same policy

--- a/cub/cub/detail/cc_dispatch.cuh
+++ b/cub/cub/detail/cc_dispatch.cuh
@@ -84,7 +84,7 @@ struct lowest_cc_resolver<::cuda::std::integer_sequence<int, CudaCcs...>, Policy
 
 // GCC below 12 ICEs in some cases when creating an integral_constant holding a policy
 #  if _CCCL_STD_VER >= 2020 && _CCCL_COMPILER(GCC, <, 12)
-template <auto P>
+template <typename Tp, Tp P>
 struct policy_constant
 {
   _CCCL_API constexpr auto operator()() const noexcept
@@ -93,8 +93,8 @@ struct policy_constant
   }
 };
 #  else // _CCCL_STD_VER >= 2020 && _CCCL_COMPILER(GCC, <, 12)
-template <auto P>
-using policy_constant = ::cuda::std::integral_constant<decltype(P), P>;
+template <typename Tp, Tp P> // using <auto P> will miscompile on GCC 12
+using policy_constant = ::cuda::std::integral_constant<Tp, P>;
 #  endif // _CCCL_STD_VER >= 2020 && _CCCL_COMPILER(GCC, <, 12)
 
 template <typename PolicySelector, typename FunctorT, size_t... Is>
@@ -111,8 +111,9 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_to_cc_list(
   // In C++20, we just create an integral_constant holding the policy, because policies are structural types in C++20.
   // This causes f to be only instantiated for each distinct policy, since the same policy for different arches results
   // in the same integral_constant type passed to f
+  using policy_t = decltype(policy_selector(::cuda::compute_capability{}));
   (...,
-   (device_cc == all_ccs[Is] ? (e = f(policy_constant<policy_selector(all_ccs[Is])>{}))
+   (device_cc == all_ccs[Is] ? (e = f(policy_constant<policy_t, policy_selector(all_ccs[Is])>{}))
                              : cudaSuccess));
 #  else // if _CCCL_STD_VER >= 2020
   // In C++17, we have to collapse architectures with the same policies ourselves, so we instantiate call_for_cc once

--- a/cub/cub/detail/cc_dispatch.cuh
+++ b/cub/cub/detail/cc_dispatch.cuh
@@ -82,6 +82,21 @@ struct lowest_cc_resolver<::cuda::std::integer_sequence<int, CudaCcs...>, Policy
 };
 #  endif // if _CCCL_STD_VER < 2020
 
+// GCC below 12 ICEs in some cases when creating an integral_constant holding a policy
+#  if _CCCL_STD_VER >= 2020 && _CCCL_COMPILER(GCC, <, 12)
+template <auto P>
+struct policy_constant
+{
+  _CCCL_API constexpr auto operator()() const noexcept
+  {
+    return P;
+  }
+};
+#  else // _CCCL_STD_VER >= 2020 && _CCCL_COMPILER(GCC, <, 12)
+template <auto P>
+using policy_constant = ::cuda::std::integral_constant<decltype(P), P>;
+#  endif // _CCCL_STD_VER >= 2020 && _CCCL_COMPILER(GCC, <, 12)
+
 template <typename PolicySelector, typename FunctorT, size_t... Is>
 CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_to_cc_list(
   PolicySelector policy_selector, ::cuda::compute_capability device_cc, FunctorT&& f, ::cuda::std::index_sequence<Is...>)
@@ -96,9 +111,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_to_cc_list(
   // In C++20, we just create an integral_constant holding the policy, because policies are structural types in C++20.
   // This causes f to be only instantiated for each distinct policy, since the same policy for different arches results
   // in the same integral_constant type passed to f
-  using policy_t = decltype(policy_selector(::cuda::compute_capability{}));
   (...,
-   (device_cc == all_ccs[Is] ? (e = f(::cuda::std::integral_constant<policy_t, policy_selector(all_ccs[Is])>{}))
+   (device_cc == all_ccs[Is] ? (e = f(policy_constant<policy_selector(all_ccs[Is])>{}))
                              : cudaSuccess));
 #  else // if _CCCL_STD_VER >= 2020
   // In C++17, we have to collapse architectures with the same policies ourselves, so we instantiate call_for_cc once

--- a/cub/cub/device/device_transform.cuh
+++ b/cub/cub/device/device_transform.cuh
@@ -53,6 +53,24 @@ struct proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::__return_constant<
 CUB_NAMESPACE_BEGIN
 //! DeviceTransform provides device-wide, parallel operations for transforming elements tuple-wise from multiple input
 //! sequences into an output sequence.
+//!
+//! @par Tuning
+//! @rst
+//! All algorithms in DeviceTransform that accept an environment can be tuned by passing a custom :ref:`policy selector
+//! <cub-policy-selectors>` that returns a @ref TransformPolicy, as shown in the example below:
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_transform_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin transform-policy-selector
+//!      :end-before: example-end transform-policy-selector
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_transform_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin transform-tuning
+//!      :end-before: example-end transform-tuning
+//! @endrst
 struct DeviceTransform
 {
   template <detail::transform::requires_stable_address StableAddress = detail::transform::requires_stable_address::no,
@@ -89,8 +107,8 @@ struct DeviceTransform
                                                     ::cuda::std::tuple<RandomAccessIteratorsIn...>,
                                                     RandomAccessIteratorOut>;
 
-    using policy_selector = ::cuda::std::execution::
-      __query_result_or_t<tuning_env, detail::transform::transform_policy, default_policy_selector>;
+    using policy_selector =
+      ::cuda::std::execution::__query_result_or_t<tuning_env, TransformPolicy, default_policy_selector>;
 
 #if _CCCL_HAS_CONCEPTS()
     static_assert(detail::transform::transform_policy_selector<policy_selector>);

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -200,8 +200,8 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto configure_as
   -> cuda_expected<
     ::cuda::std::tuple<decltype(launcher_factory(0, 0, 0, nullptr)), decltype(kernel_source.TransformKernel()), int>>
 {
-  CUB_DETAIL_CONSTEXPR_ISH const transform_policy policy = policy_getter();
-  CUB_DETAIL_CONSTEXPR_ISH int threads_per_block         = policy.async_copy.threads_per_block;
+  CUB_DETAIL_CONSTEXPR_ISH const TransformPolicy policy = policy_getter();
+  CUB_DETAIL_CONSTEXPR_ISH int threads_per_block            = policy.async_copy.threads_per_block;
 
   _CCCL_ASSERT(threads_per_block % alignment == 0, "threads_per_block needs to be a multiple of the copy alignment");
   // ^ then tile_size is a multiple of it
@@ -347,9 +347,11 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_prefetch_or_vectorized
   KernelLauncherFactory launcher_factory,
   ::cuda::compute_capability cc)
 {
-  CUB_DETAIL_CONSTEXPR_ISH const transform_policy policy = policy_getter();
+  CUB_DETAIL_CONSTEXPR_ISH const TransformPolicy policy = policy_getter();
   CUB_DETAIL_CONSTEXPR_ISH const int threads_per_block =
-    policy.algorithm == Algorithm::vectorized ? policy.vectorized.threads_per_block : policy.prefetch.threads_per_block;
+    policy.algorithm == TransformAlgorithm::vectorized
+      ? policy.vectorized.threads_per_block
+      : policy.prefetch.threads_per_block;
 
   auto determine_config = [&]() -> cuda_expected<prefetch_config> {
     int max_occupancy = 0;
@@ -378,7 +380,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_prefetch_or_vectorized
   ::cuda::std::optional<int> ipt;
 
   // the policy already handles the compile-time checks if we can vectorize. Do the remaining alignment check here
-  if CUB_DETAIL_CONSTEXPR_ISH (Algorithm::vectorized == policy.algorithm)
+  if CUB_DETAIL_CONSTEXPR_ISH (TransformAlgorithm::vectorized == policy.algorithm)
   {
     const int vs  = policy.vectorized.vec_size;
     can_vectorize = kernel_source.CanVectorize(vs, out, ::cuda::std::get<Is>(in)...);
@@ -392,7 +394,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_prefetch_or_vectorized
   {
     // otherwise, set up the prefetch kernel
     auto prefetch_policy = policy.prefetch;
-    if (policy.algorithm != Algorithm::prefetch)
+    if (policy.algorithm != TransformAlgorithm::prefetch)
     {
       // if tuning selected the vectorized path we compiled the kernel for it, so we need to use the same block size
       prefetch_policy.threads_per_block = policy.vectorized.threads_per_block;
@@ -466,7 +468,7 @@ struct invoke_for_cc<::cuda::std::tuple<RandomAccessIteratorsIn...>,
   template <typename PolicyGetter>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t operator()(PolicyGetter policy_getter) const
   {
-    CUB_DETAIL_CONSTEXPR_ISH transform_policy active_policy = policy_getter();
+    CUB_DETAIL_CONSTEXPR_ISH TransformPolicy active_policy = policy_getter();
     const auto seq = ::cuda::std::index_sequence_for<RandomAccessIteratorsIn...>{};
 
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
@@ -480,7 +482,7 @@ struct invoke_for_cc<::cuda::std::tuple<RandomAccessIteratorsIn...>,
                  }))
 #endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
 
-    if CUB_DETAIL_CONSTEXPR_ISH (Algorithm::ublkcp == active_policy.algorithm)
+    if CUB_DETAIL_CONSTEXPR_ISH (TransformAlgorithm::ublkcp == active_policy.algorithm)
     {
       return invoke_async_algorithm(
         ::cuda::std::move(in),
@@ -500,7 +502,7 @@ struct invoke_for_cc<::cuda::std::tuple<RandomAccessIteratorsIn...>,
         launcher_factory,
         cc);
     }
-    else if CUB_DETAIL_CONSTEXPR_ISH (Algorithm::memcpy_async == active_policy.algorithm)
+    else if CUB_DETAIL_CONSTEXPR_ISH (TransformAlgorithm::ldgsts == active_policy.algorithm)
     {
       return invoke_async_algorithm(
         ::cuda::std::move(in),

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -201,7 +201,7 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto configure_as
     ::cuda::std::tuple<decltype(launcher_factory(0, 0, 0, nullptr)), decltype(kernel_source.TransformKernel()), int>>
 {
   CUB_DETAIL_CONSTEXPR_ISH const TransformPolicy policy = policy_getter();
-  CUB_DETAIL_CONSTEXPR_ISH int threads_per_block            = policy.async_copy.threads_per_block;
+  CUB_DETAIL_CONSTEXPR_ISH int threads_per_block        = policy.async_copy.threads_per_block;
 
   _CCCL_ASSERT(threads_per_block % alignment == 0, "threads_per_block needs to be a multiple of the copy alignment");
   // ^ then tile_size is a multiple of it

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -96,6 +96,8 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void prefetch_tile(It begin, int items)
 template <int UnrollFactor, typename F>
 _CCCL_DEVICE _CCCL_FORCEINLINE void unrolled_for(int count, F&& body)
 {
+  static_assert(UnrollFactor >= 0,
+                "unroll_factor must be zero (ignore unroll hint) or positive (unroll with the given factor)");
   if constexpr (UnrollFactor > 0)
   {
     _CCCL_PRAGMA_UNROLL(UnrollFactor)
@@ -218,20 +220,16 @@ _CCCL_HOST_DEVICE _CCCL_CONSTEVAL auto load_store_type()
   }
 }
 
-// FIXME(bgruber): nvcc 12.0 - 13.1 crash with `error: Internal Compiler Error (codegen): "unexpected error in codegen
-// for function: found previous definition of same function!"` when we pass a const& as template parameter (and the
-// function template body contains a lambda). As a workaround, we pass the parts of the policy by value.
-// TODO(bgruber): In C++20, we should just pass transform_policy by value.
-template < // const transform_policy& Policy,
-  int threads_per_block,
-  int items_per_thread,
-  int vec_size,
-  int PrefetchByteStride,
-  int PrefetchUnrollFactor,
-  typename Offset,
-  typename F,
-  typename RandomAccessIteratorOut,
-  typename... RandomAccessIteratorsIn>
+// TODO(bgruber): In C++20, we should just pass TransformPolicy by value.
+template <int threads_per_block,
+          int items_per_thread,
+          int vec_size,
+          int PrefetchByteStride,
+          int PrefetchUnrollFactor,
+          typename Offset,
+          typename F,
+          typename RandomAccessIteratorOut,
+          typename... RandomAccessIteratorsIn>
 _CCCL_DEVICE void transform_kernel_vectorized(
   Offset num_items,
   int num_elem_per_thread_prefetch,
@@ -568,19 +566,15 @@ _CCCL_DEVICE auto copy_and_return_smem_dst_fallback(
   return reinterpret_cast<T*>(dst);
 }
 
-// FIXME(bgruber): nvcc 12.0 - 13.1 crash with `error: Internal Compiler Error (codegen): "unexpected error in codegen
-// for function: found previous definition of same function!"` when we pass a const& as template parameter (and the
-// function template body contains a lambda). As a workaround, we pass the parts of the policy by value.
-// TODO(bgruber): In C++20, we should just pass transform_policy by value.
+// TODO(bgruber): In C++20, we should just pass TransformPolicy by value.
 // note: there is no PDL in this kernel since PDL is not supported below Hopper and this kernel is intended for Ampere
-template < // const transform_policy& Policy,
-  int threads_per_block,
-  int UnrollFactor,
-  typename Offset,
-  typename Predicate,
-  typename F,
-  typename RandomAccessIteratorOut,
-  typename... InTs>
+template <int threads_per_block,
+          int UnrollFactor,
+          typename Offset,
+          typename Predicate,
+          typename F,
+          typename RandomAccessIteratorOut,
+          typename... InTs>
 _CCCL_DEVICE void transform_kernel_ldgsts(
   Offset num_items,
   int num_elem_per_thread,
@@ -712,27 +706,18 @@ _CCCL_DEVICE void bulk_copy_maybe_unaligned(
     dst_ptr[bytes_to_copy - tail_bytes + threadIdx.x] = tail_byte;
   }
 }
-// FIXME(bgruber): nvcc 12.0 - 13.1 error with `function "void
-// cub::_V_300300_SM_750_800_900_1000_1200::detail::transform::transform_kernel_ublkcp< ::policy, int,
-// ::cuda::always_true,
-// ::cuda::std::__4::logical_and<int> , bool *, int, int > (T2, int, T3, T4, T5,
-// ::cub::_V_300300_SM_750_800_900_1000_1200::detail::transform::aligned_base_ptr<T6> ...)::[lambda(T1) (instance
-// 3)]::operator ()< ::cuda::std::__4::integral_constant<bool, (bool)1> >  const" has already been defined` when we pass
-// a const& as template parameter (and the function template body contains a lambda). As a workaround, we pass the parts
-// of the policy by value.
-// TODO(bgruber): In C++20, we should just pass transform_policy by value.
+
+// TODO(bgruber): In C++20, we should just pass TransformPolicy by value.
 // Note: we tried implementing work stealing, aka. cluster launch control, aka. UGETNEXTWORKID, (see PR:
 // https://github.com/NVIDIA/cccl/pull/5099) and the slowdowns on some benchmarks outweighed the benefits on B200. So we
 // didn't merge the changes. The problem was mostly a 25% increase in integer instructions, as shown by ncu.
-template < // const transform_policy& Policy,
-  int threads_per_block,
-  int bulk_copy_alignment,
-  int UnrollFactor,
-  typename Offset,
-  typename Predicate,
-  typename F,
-  typename RandomAccessIteratorOut,
-  typename... InTs>
+template <int threads_per_block,
+          int UnrollFactor,
+          typename Offset,
+          typename Predicate,
+          typename F,
+          typename RandomAccessIteratorOut,
+          typename... InTs>
 _CCCL_DEVICE void transform_kernel_ublkcp(
   Offset num_items,
   int num_elem_per_thread,
@@ -742,7 +727,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
   aligned_base_ptr<InTs>... aligned_ptrs)
 {
   // constexpr int threads_per_block       = Policy.async_copy.threads_per_block;
-  // constexpr int bulk_copy_alignment = Policy.async_copy.bulk_copy_alignment;
+  constexpr int bulk_copy_alignment = transform::bulk_copy_alignment(current_tuning_cc());
 
   // add padding after a tile in shared memory to make space for the next tile's head padding, and retain alignment
   constexpr int max_alignment = ::cuda::std::max({int{alignof(InTs)}...});
@@ -993,12 +978,12 @@ _CCCL_EXEC_CHECK_DISABLE
 template <typename PolicySelector>
 [[nodiscard]] _CCCL_HOST_DEVICE_API _CCCL_CONSTEVAL int get_threads_per_block_helper() noexcept
 {
-  constexpr transform_policy policy = current_policy<PolicySelector>();
-  if constexpr (policy.algorithm == Algorithm::prefetch)
+  constexpr TransformPolicy policy = current_policy<PolicySelector>();
+  if constexpr (policy.algorithm == TransformAlgorithm::prefetch)
   {
     return policy.prefetch.threads_per_block;
   }
-  else if constexpr (policy.algorithm == Algorithm::vectorized)
+  else if constexpr (policy.algorithm == TransformAlgorithm::vectorized)
   {
     return policy.vectorized.threads_per_block;
   }
@@ -1036,9 +1021,9 @@ __launch_bounds__(get_threads_per_block<PolicySelector>) _CCCL_KERNEL_ATTRIBUTES
 {
   _CCCL_ASSERT(blockDim.y == 1 && blockDim.z == 1, "transform_kernel only supports 1D blocks");
 
-  static constexpr transform_policy policy = current_policy<PolicySelector>();
+  static constexpr TransformPolicy policy = current_policy<PolicySelector>();
 
-  if constexpr (policy.algorithm == Algorithm::prefetch)
+  if constexpr (policy.algorithm == TransformAlgorithm::prefetch)
   {
     transform_kernel_prefetch<policy.prefetch.threads_per_block,
                               policy.prefetch.prefetch_byte_stride,
@@ -1050,7 +1035,7 @@ __launch_bounds__(get_threads_per_block<PolicySelector>) _CCCL_KERNEL_ATTRIBUTES
       ::cuda::std::move(out),
       ::cuda::std::move(ins.iterator)...);
   }
-  else if constexpr (policy.algorithm == Algorithm::vectorized)
+  else if constexpr (policy.algorithm == TransformAlgorithm::vectorized)
   {
     static_assert(::cuda::std::is_same_v<Predicate, ::cuda::always_true>,
                   "Cannot vectorize transform with a predicate");
@@ -1067,7 +1052,7 @@ __launch_bounds__(get_threads_per_block<PolicySelector>) _CCCL_KERNEL_ATTRIBUTES
       ::cuda::std::move(out),
       ::cuda::std::move(ins.iterator)...);
   }
-  else if constexpr (policy.algorithm == Algorithm::memcpy_async)
+  else if constexpr (policy.algorithm == TransformAlgorithm::ldgsts)
   {
     NV_IF_TARGET(
       NV_PROVIDES_SM_80,
@@ -1079,13 +1064,11 @@ __launch_bounds__(get_threads_per_block<PolicySelector>) _CCCL_KERNEL_ATTRIBUTES
          ::cuda::std::move(out),
          ::cuda::std::move(ins.aligned_ptr)...);));
   }
-  else if constexpr (policy.algorithm == Algorithm::ublkcp)
+  else if constexpr (policy.algorithm == TransformAlgorithm::ublkcp)
   {
     NV_IF_TARGET(
       NV_PROVIDES_SM_90,
-      (transform_kernel_ublkcp</*policy*/ policy.async_copy.threads_per_block,
-                               policy.async_copy.bulk_copy_alignment,
-                               policy.async_copy.unroll_factor>(
+      (transform_kernel_ublkcp</*policy*/ policy.async_copy.threads_per_block, policy.async_copy.unroll_factor>(
          num_items,
          num_elem_per_thread,
          ::cuda::std::move(pred),

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -502,21 +502,5 @@ struct policy_selector_from_types<RequiresStableAddress,
     return policies(cc);
   }
 };
-
-struct always_true_predicate
-{
-  template <typename... Ts>
-  _CCCL_HOST_DEVICE constexpr bool operator()(Ts&&...) const
-  {
-    return true;
-  }
-};
 } // namespace detail::transform
 CUB_NAMESPACE_END
-
-namespace cuda
-{
-template <>
-struct proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::transform::always_true_predicate> : ::cuda::std::true_type
-{};
-} // namespace cuda

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -30,51 +30,56 @@
 #include <cuda/std/tuple>
 
 CUB_NAMESPACE_BEGIN
-namespace detail::transform
-{
-enum class Algorithm
+
+//! Backend algorithms for @ref DeviceTransform.
+enum class TransformAlgorithm
 {
   // We previously had a fallback algorithm that would use cub::DeviceFor. Benchmarks showed that the prefetch algorithm
   // is always superior to that fallback, so it was removed.
-  prefetch,
-  vectorized,
-  memcpy_async,
-  ublkcp
+  prefetch, //!< Uses a transform kernel that relies on prefetching the memory of all contiguous iterators.
+  vectorized, //!< Uses a transform kernel that uses load and store vectorization.
+  ldgsts, //!< Uses a transform kernel that relies on cp.async/LDGSTS to stage data into shared memory.
+  ublkcp //!< Uses a transform kernel that relies on cp.async.bulk/UBLKCP to stage data into shared memory.
 };
 
 #if _CCCL_HOSTED()
-inline ::std::ostream& operator<<(::std::ostream& os, const Algorithm& algorithm)
+inline ::std::ostream& operator<<(::std::ostream& os, const TransformAlgorithm& algorithm)
 {
   switch (algorithm)
   {
-    case Algorithm::prefetch:
-      return os << "Algorithm::prefetch";
-    case Algorithm::vectorized:
-      return os << "Algorithm::vectorized";
-    case Algorithm::memcpy_async:
-      return os << "Algorithm::memcpy_async";
-    case Algorithm::ublkcp:
-      return os << "Algorithm::ublkcp";
+    case TransformAlgorithm::prefetch:
+      return os << "TransformAlgorithm::prefetch";
+    case TransformAlgorithm::vectorized:
+      return os << "TransformAlgorithm::vectorized";
+    case TransformAlgorithm::ldgsts:
+      return os << "TransformAlgorithm::ldgsts";
+    case TransformAlgorithm::ublkcp:
+      return os << "TransformAlgorithm::ublkcp";
     default:
-      return os << "Algorithm::<unknown>";
+      return os << "TransformAlgorithm::<unknown>";
   }
 }
 #endif // _CCCL_HOSTED()
 
-struct prefetch_policy
+//! The prefetch sub-policy for @ref TransformPolicy.
+struct TransformPrefetchPolicy
 {
-  int threads_per_block;
+  int threads_per_block; //!< Number of threads in a CUDA block
   // items per tile are determined at runtime. these (inclusive) bounds allow overriding that value via a tuning policy
-  int items_per_thread_no_input = 2; // when there are no input iterators, the kernel is just filling
-  int min_items_per_thread      = 1;
-  int max_items_per_thread      = 32;
-  int prefetch_byte_stride      = 128; // somewhat of a cache line size
+  int items_per_thread_no_input = 2; //!< When there are no iterators as inputs, the kernel is just filling. This is the
+                                     //!< number of items written per thread in this case.
+  int min_items_per_thread = 1; //!< Minimum number of items per thread (inclusive)
+  int max_items_per_thread = 32; //!< Maximum number of items per thread (inclusive)
+  int prefetch_byte_stride = 128; //!< The stride in bytes to issue prefetch requests to memory. Corresponds somewhat to
+                                  //!< the size of a cache line.
   // ahendriksen: various unrolling yields less <1% gains at much higher compile-time cost, so prevent unrolling
   // bgruber: but A6000 and H100 show small gains without pragma, so omitting pragma
-  int unroll_factor = -1; // -1 means we leave it to the compiler
+  // TODO(bgruber): settle how the unroll factor works and provide a common documentation block.
+  int unroll_factor = 0; //!< The unroll factor for the transformation loop in the kernel. The value 0 retains the
+                         //!< compiler's default unrolling (specifying no unroll pragma), 1 means no unrolling.
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const prefetch_policy& lhs, const prefetch_policy& rhs)
+  operator==(const TransformPrefetchPolicy& lhs, const TransformPrefetchPolicy& rhs)
   {
     return lhs.threads_per_block == rhs.threads_per_block
         && lhs.items_per_thread_no_input == rhs.items_per_thread_no_input
@@ -83,16 +88,16 @@ struct prefetch_policy
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const prefetch_policy& lhs, const prefetch_policy& rhs)
+  operator!=(const TransformPrefetchPolicy& lhs, const TransformPrefetchPolicy& rhs)
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const prefetch_policy& policy)
+  friend ::std::ostream& operator<<(::std::ostream& os, const TransformPrefetchPolicy& policy)
   {
     return os
-        << "prefetch_policy { .threads_per_block = " << policy.threads_per_block << ", .items_per_thread_no_input = "
+        << "TransformPrefetchPolicy { .threads_per_block = " << policy.threads_per_block << ", .items_per_thread_no_input = "
         << policy.items_per_thread_no_input << ", .min_items_per_thread = " << policy.min_items_per_thread
         << ", .max_items_per_thread = " << policy.max_items_per_thread << ", .prefetch_byte_stride = "
         << policy.prefetch_byte_stride << ", .unroll_factor = " << policy.unroll_factor << " }";
@@ -100,104 +105,111 @@ struct prefetch_policy
 #endif // _CCCL_HOSTED()
 };
 
-struct vectorized_policy
+//! The vectorized sub-policy for @ref TransformPolicy.
+struct TransformVectorizedPolicy
 {
-  int threads_per_block;
-  int items_per_thread;
-  int vec_size;
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int items_per_thread; //!< Number of items processed per thread. Must be a multiple of vec_size.
+  int vec_size; //!< Number of elements loaded/stored per vectorized access. Must evenly divide items_per_thread.
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const vectorized_policy& lhs, const vectorized_policy& rhs)
+  operator==(const TransformVectorizedPolicy& lhs, const TransformVectorizedPolicy& rhs)
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
         && lhs.vec_size == rhs.vec_size;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const vectorized_policy& lhs, const vectorized_policy& rhs)
+  operator!=(const TransformVectorizedPolicy& lhs, const TransformVectorizedPolicy& rhs)
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const vectorized_policy& policy)
+  friend ::std::ostream& operator<<(::std::ostream& os, const TransformVectorizedPolicy& policy)
   {
-    return os << "vectorized_policy { .threads_per_block = " << policy.threads_per_block
+    return os << "TransformVectorizedPolicy { .threads_per_block = " << policy.threads_per_block
               << ", .items_per_thread = " << policy.items_per_thread << ", .vec_size = " << policy.vec_size << " }";
   }
 #endif // _CCCL_HOSTED()
 };
 
-struct async_copy_policy
+//! The async copy sub-policy for @ref TransformPolicy.
+struct TransformAsyncCopyPolicy
 {
-  int threads_per_block;
-  int bulk_copy_alignment; // TODO(bgruber): this should probably be removed from the tuning policy
+  int threads_per_block; //!< Number of threads in a CUDA block
   // items per tile are determined at runtime. these (inclusive) bounds allow overriding that value via a tuning policy
-  int min_items_per_thread = 1;
-  int max_items_per_thread = 32;
+  int min_items_per_thread = 1; //!< Minimum number of items per thread (inclusive)
+  int max_items_per_thread = 32; //!< Maximum number of items per thread (inclusive)
   // Unroll 1 tends to improve performance, especially for smaller data types (confirmed by benchmark)
-  int unroll_factor = 1;
+  int unroll_factor = 1; //!< The unroll factor for the transformation loop in the kernel. The value 0 retains the
+                         //!< compiler's default unrolling (specifying no unroll pragma), 1 means no unrolling.
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const async_copy_policy& lhs, const async_copy_policy& rhs)
+  operator==(const TransformAsyncCopyPolicy& lhs, const TransformAsyncCopyPolicy& rhs)
   {
-    return lhs.threads_per_block == rhs.threads_per_block && lhs.bulk_copy_alignment == rhs.bulk_copy_alignment
-        && lhs.min_items_per_thread == rhs.min_items_per_thread && lhs.max_items_per_thread == rhs.max_items_per_thread
-        && lhs.unroll_factor == rhs.unroll_factor;
+    return lhs.threads_per_block == rhs.threads_per_block && lhs.min_items_per_thread == rhs.min_items_per_thread
+        && lhs.max_items_per_thread == rhs.max_items_per_thread && lhs.unroll_factor == rhs.unroll_factor;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const async_copy_policy& lhs, const async_copy_policy& rhs)
+  operator!=(const TransformAsyncCopyPolicy& lhs, const TransformAsyncCopyPolicy& rhs)
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const async_copy_policy& policy)
+  friend ::std::ostream& operator<<(::std::ostream& os, const TransformAsyncCopyPolicy& policy)
   {
-    return os
-        << "async_copy_policy { .threads_per_block = " << policy.threads_per_block << ", .bulk_copy_alignment = "
-        << policy.bulk_copy_alignment << ", .min_items_per_thread = " << policy.min_items_per_thread
-        << ", .max_items_per_thread = " << policy.max_items_per_thread << ", .unroll_factor = " << policy.unroll_factor
-        << " }";
+    return os << "TransformAsyncCopyPolicy { .threads_per_block = " << policy.threads_per_block << ", .min_items_per_thread = "
+              << policy.min_items_per_thread << ", .max_items_per_thread = " << policy.max_items_per_thread
+              << ", .unroll_factor = " << policy.unroll_factor << " }";
   }
 #endif // _CCCL_HOSTED()
 };
 
-struct transform_policy
+//! The tuning policy for all algorithms in @ref DeviceTransform.
+struct TransformPolicy
 {
-  int min_bytes_in_flight;
-  Algorithm algorithm;
-  prefetch_policy prefetch;
-  vectorized_policy vectorized;
-  async_copy_policy async_copy;
+  int min_bytes_in_flight; //!< Minimum number of bytes in flight per SM to reach by scaling the items per thread. Has
+                           //!< no effect if algorithm is @p vectorized.
+  TransformAlgorithm algorithm; //!< The transform algorithm to use by the kernel
+  TransformPrefetchPolicy prefetch; //!< Sub-policy for the prefetch algorithm. Only used when @p algorithm is @p
+                                    //!< prefetch or when @p algorithm is @p vectorized and the input pointers are not
+                                    //!< sufficiently aligned.
+  TransformVectorizedPolicy vectorized; //!< Sub-policy for the vectorized algorithm. Only used when @p algorithm is @p
+                                        //!< vectorized.
+  TransformAsyncCopyPolicy async_copy; //!< Sub-policy for the async copy algorithms. Only used when @p algorithm is @p
+                                       //!< ldgsts or @p ublkcp.
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const transform_policy& lhs, const transform_policy& rhs)
+  operator==(const TransformPolicy& lhs, const TransformPolicy& rhs)
   {
     return lhs.min_bytes_in_flight == rhs.min_bytes_in_flight && lhs.algorithm == rhs.algorithm
         && lhs.prefetch == rhs.prefetch && lhs.vectorized == rhs.vectorized && lhs.async_copy == rhs.async_copy;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const transform_policy& lhs, const transform_policy& rhs)
+  operator!=(const TransformPolicy& lhs, const TransformPolicy& rhs)
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const transform_policy& policy)
+  friend ::std::ostream& operator<<(::std::ostream& os, const TransformPolicy& policy)
   {
-    return os << "transform_policy { .min_bytes_in_flight = " << policy.min_bytes_in_flight
+    return os << "TransformPolicy { .min_bytes_in_flight = " << policy.min_bytes_in_flight
               << ", .algorithm = " << policy.algorithm << ", .prefetch = " << policy.prefetch
               << ", .vectorized = " << policy.vectorized << ", .async_copy = " << policy.async_copy << " }";
   }
 #endif // _CCCL_HOSTED()
 };
 
+namespace detail::transform
+{
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>
-concept transform_policy_selector = policy_selector<T, transform_policy>;
+concept transform_policy_selector = policy_selector<T, TransformPolicy>;
 #endif // _CCCL_HAS_CONCEPTS()
 
 template <typename... Its>
@@ -282,18 +294,18 @@ tuned_vectorized_policy(::cuda::compute_capability cc, int store_size, bool fill
     // TODO(bgruber): re-enable this later! It's disabled to avoid SASS changes in PR #6914
     // if (cc >= ::cuda::compute_capability{12, 0})
     // {
-    //   return vectorized_policy{256, 8, 4};
+    //   return TransformVectorizedPolicy{256, 8, 4};
     // }
     // manually tuned fill on B200, same as H200
     if (cc >= ::cuda::compute_capability{9, 0})
     {
-      return vectorized_policy{
+      return TransformVectorizedPolicy{
         store_size > 4 ? 128 : 256, 16, ::cuda::std::max(8 / store_size, 1) /* 64-bit instructions */};
     }
     // manually tuned fill on A100
     if (cc >= ::cuda::compute_capability{8, 0})
     {
-      return vectorized_policy{256, 8, ::cuda::std::max(8 / store_size, 1) /* 64-bit instructions */};
+      return TransformVectorizedPolicy{256, 8, ::cuda::std::max(8 / store_size, 1) /* 64-bit instructions */};
     }
   }
   else
@@ -301,12 +313,12 @@ tuned_vectorized_policy(::cuda::compute_capability cc, int store_size, bool fill
     // manually tuned triad on A100
     if (cc == ::cuda::compute_capability{8, 0})
     {
-      return vectorized_policy{128, 16, 4};
+      return TransformVectorizedPolicy{128, 16, 4};
     }
   }
 
   // defaults from fill on RTX 5090, but can be changed
-  return vectorized_policy{256, 8, 4};
+  return TransformVectorizedPolicy{256, 8, 4};
 }
 
 template <int InputCount>
@@ -317,7 +329,7 @@ struct policy_selector
   ::cuda::std::array<iterator_info, InputCount> inputs;
   iterator_info output;
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> transform_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> TransformPolicy
   {
     const bool no_input_streams = InputCount == 0;
 
@@ -343,10 +355,10 @@ struct policy_selector
       const int async_block_size = (cc < ::cuda::compute_capability{10, 0}) ? 256 : 128;
       const int alignment        = bulk_copy_alignment(cc);
 
-      const auto prefetch = prefetch_policy{256};
+      const auto prefetch = TransformPrefetchPolicy{256};
       const auto vectorized =
         tuned_vectorized_policy(cc, ::cuda::std::max(1, output.value_type_size), no_input_streams);
-      const auto async = async_copy_policy{async_block_size, alignment};
+      const auto async = TransformAsyncCopyPolicy{async_block_size};
 
       // We cannot use the architecture-specific amount of SMEM here instead of max_smem_per_block, because this is not
       // forward compatible. If a user compiled for sm_xxx and we assume the available SMEM for that architecture, but
@@ -384,12 +396,12 @@ struct policy_selector
                                        || no_input_streams || !can_memcpy_all_inputs || vector_kernel_is_faster;
 
       const auto algorithm =
-        fallback_to_prefetch ? Algorithm::prefetch
+        fallback_to_prefetch ? TransformAlgorithm::prefetch
         : fallback_to_vectorized
-          ? (all_value_types_have_power_of_two_size ? Algorithm::vectorized : Algorithm::prefetch)
-          : Algorithm::ublkcp;
+          ? (all_value_types_have_power_of_two_size ? TransformAlgorithm::vectorized : TransformAlgorithm::prefetch)
+          : TransformAlgorithm::ublkcp;
 
-      return transform_policy{
+      return TransformPolicy{
         min_bytes_in_flight,
         algorithm,
         prefetch,
@@ -400,10 +412,10 @@ struct policy_selector
     else if (cc >= ::cuda::compute_capability{8, 0})
     {
       const int threads_per_block = 256;
-      const auto prefetch         = prefetch_policy{threads_per_block};
+      const auto prefetch         = TransformPrefetchPolicy{threads_per_block};
       const auto vectorized =
         tuned_vectorized_policy(cc, ::cuda::std::max(1, output.value_type_size), no_input_streams);
-      const auto async = async_copy_policy{threads_per_block, ldgsts_size_and_align};
+      const auto async = TransformAsyncCopyPolicy{threads_per_block};
 
       // We cannot use the architecture-specific amount of SMEM here instead of max_smem_per_block, because this is not
       // forward compatible. If a user compiled for sm_xxx and we assume the available SMEM for that architecture, but
@@ -423,12 +435,12 @@ struct policy_selector
         exhaust_smem || no_input_streams || !can_memcpy_all_inputs || use_vector_kernel_on_ampere;
 
       const auto algorithm =
-        fallback_to_prefetch ? Algorithm::prefetch
+        fallback_to_prefetch ? TransformAlgorithm::prefetch
         : fallback_to_vectorized
-          ? (all_value_types_have_power_of_two_size ? Algorithm::vectorized : Algorithm::prefetch)
-          : Algorithm::memcpy_async;
+          ? (all_value_types_have_power_of_two_size ? TransformAlgorithm::vectorized : TransformAlgorithm::prefetch)
+          : TransformAlgorithm::ldgsts;
 
-      return transform_policy{
+      return TransformPolicy{
         min_bytes_in_flight,
         algorithm,
         prefetch,
@@ -438,13 +450,15 @@ struct policy_selector
     }
 
     // fallback
-    return transform_policy{
+    return TransformPolicy{
       min_bytes_in_flight,
-      (fallback_to_prefetch || !all_value_types_have_power_of_two_size) ? Algorithm::prefetch : Algorithm::vectorized,
-      prefetch_policy{256},
+      (fallback_to_prefetch || !all_value_types_have_power_of_two_size)
+        ? TransformAlgorithm::prefetch
+        : TransformAlgorithm::vectorized,
+      TransformPrefetchPolicy{256},
       tuned_vectorized_policy(
         ::cuda::compute_capability{6, 0}, ::cuda::std::max(1, output.value_type_size), no_input_streams),
-      async_copy_policy{}, // never used
+      TransformAsyncCopyPolicy{}, // never used
     };
   }
 };
@@ -477,7 +491,7 @@ struct policy_selector_from_types<RequiresStableAddress,
                 "could pass an output iterator by accident, but it could also be a transform_iterator with a "
                 "__device__ callable and a deduced return type (which is void in host code).");
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> transform_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> TransformPolicy
   {
     constexpr auto policies = policy_selector<sizeof...(RandomAccessIteratorsIn)>{
       RequiresStableAddress,
@@ -487,6 +501,21 @@ struct policy_selector_from_types<RequiresStableAddress,
     return policies(cc);
   }
 };
-} // namespace detail::transform
 
+struct always_true_predicate
+{
+  template <typename... Ts>
+  _CCCL_HOST_DEVICE constexpr bool operator()(Ts&&...) const
+  {
+    return true;
+  }
+};
+} // namespace detail::transform
 CUB_NAMESPACE_END
+
+namespace cuda
+{
+template <>
+struct proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::transform::always_true_predicate> : ::cuda::std::true_type
+{};
+} // namespace cuda

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -74,9 +74,9 @@ struct TransformPrefetchPolicy
                                   //!< the size of a cache line.
   // ahendriksen: various unrolling yields less <1% gains at much higher compile-time cost, so prevent unrolling
   // bgruber: but A6000 and H100 show small gains without pragma, so omitting pragma
-  // TODO(bgruber): settle how the unroll factor works and provide a common documentation block.
-  int unroll_factor = 0; //!< The unroll factor for the transformation loop in the kernel. The value 0 retains the
-                         //!< compiler's default unrolling (specifying no unroll pragma), 1 means no unrolling.
+  int unroll_factor = 0; //!< For any value >1, the unroll factor for the transformation loop in the kernel. The value 0
+                         //!< retains the compiler's default unrolling by specifying no unroll pragma. 1 prevents no
+                         //!< unrolling.
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const TransformPrefetchPolicy& lhs, const TransformPrefetchPolicy& rhs)

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -219,7 +219,7 @@ _CCCL_HOST_DEVICE constexpr auto loaded_bytes_per_iteration() -> int
   return (int{sizeof(it_value_t<Its>)} + ... + 0);
 }
 
-constexpr int ldgsts_size_and_align = 16;
+inline constexpr int ldgsts_size_and_align = 16;
 
 template <int InputCount>
 _CCCL_HOST_DEVICE constexpr auto memcpy_async_dyn_smem_for_tile_size(

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -75,11 +75,11 @@ struct TransformPrefetchPolicy
   // ahendriksen: various unrolling yields less <1% gains at much higher compile-time cost, so prevent unrolling
   // bgruber: but A6000 and H100 show small gains without pragma, so omitting pragma
   int unroll_factor = 0; //!< For any value >1, the unroll factor for the transformation loop in the kernel. The value 0
-                         //!< retains the compiler's default unrolling by specifying no unroll pragma. 1 prevents no
+                         //!< retains the compiler's default unrolling by specifying no unroll pragma. 1 prevents
                          //!< unrolling.
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const TransformPrefetchPolicy& lhs, const TransformPrefetchPolicy& rhs)
+  operator==(const TransformPrefetchPolicy& lhs, const TransformPrefetchPolicy& rhs) noexcept
   {
     return lhs.threads_per_block == rhs.threads_per_block
         && lhs.items_per_thread_no_input == rhs.items_per_thread_no_input
@@ -88,7 +88,7 @@ struct TransformPrefetchPolicy
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const TransformPrefetchPolicy& lhs, const TransformPrefetchPolicy& rhs)
+  operator!=(const TransformPrefetchPolicy& lhs, const TransformPrefetchPolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }
@@ -114,14 +114,14 @@ struct TransformVectorizedPolicy
   int vec_size; //!< Number of elements loaded/stored per vectorized access. Must evenly divide items_per_thread.
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const TransformVectorizedPolicy& lhs, const TransformVectorizedPolicy& rhs)
+  operator==(const TransformVectorizedPolicy& lhs, const TransformVectorizedPolicy& rhs) noexcept
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
         && lhs.vec_size == rhs.vec_size;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const TransformVectorizedPolicy& lhs, const TransformVectorizedPolicy& rhs)
+  operator!=(const TransformVectorizedPolicy& lhs, const TransformVectorizedPolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }
@@ -147,14 +147,14 @@ struct TransformAsyncCopyPolicy
                          //!< compiler's default unrolling (specifying no unroll pragma), 1 means no unrolling.
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const TransformAsyncCopyPolicy& lhs, const TransformAsyncCopyPolicy& rhs)
+  operator==(const TransformAsyncCopyPolicy& lhs, const TransformAsyncCopyPolicy& rhs) noexcept
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.min_items_per_thread == rhs.min_items_per_thread
         && lhs.max_items_per_thread == rhs.max_items_per_thread && lhs.unroll_factor == rhs.unroll_factor;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const TransformAsyncCopyPolicy& lhs, const TransformAsyncCopyPolicy& rhs)
+  operator!=(const TransformAsyncCopyPolicy& lhs, const TransformAsyncCopyPolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }
@@ -184,14 +184,14 @@ struct TransformPolicy
                                        //!< ldgsts or @p ublkcp.
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const TransformPolicy& lhs, const TransformPolicy& rhs)
+  operator==(const TransformPolicy& lhs, const TransformPolicy& rhs) noexcept
   {
     return lhs.min_bytes_in_flight == rhs.min_bytes_in_flight && lhs.algorithm == rhs.algorithm
         && lhs.prefetch == rhs.prefetch && lhs.vectorized == rhs.vectorized && lhs.async_copy == rhs.async_copy;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const TransformPolicy& lhs, const TransformPolicy& rhs)
+  operator!=(const TransformPolicy& lhs, const TransformPolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -97,10 +97,11 @@ struct TransformPrefetchPolicy
   friend ::std::ostream& operator<<(::std::ostream& os, const TransformPrefetchPolicy& policy)
   {
     return os
-        << "TransformPrefetchPolicy { .threads_per_block = " << policy.threads_per_block << ", .items_per_thread_no_input = "
-        << policy.items_per_thread_no_input << ", .min_items_per_thread = " << policy.min_items_per_thread
-        << ", .max_items_per_thread = " << policy.max_items_per_thread << ", .prefetch_byte_stride = "
-        << policy.prefetch_byte_stride << ", .unroll_factor = " << policy.unroll_factor << " }";
+        << "TransformPrefetchPolicy { .threads_per_block = " << policy.threads_per_block
+        << ", .items_per_thread_no_input = " << policy.items_per_thread_no_input << ", .min_items_per_thread = "
+        << policy.min_items_per_thread << ", .max_items_per_thread = " << policy.max_items_per_thread
+        << ", .prefetch_byte_stride = " << policy.prefetch_byte_stride << ", .unroll_factor = " << policy.unroll_factor
+        << " }";
   }
 #endif // _CCCL_HOSTED()
 };
@@ -161,9 +162,9 @@ struct TransformAsyncCopyPolicy
 #if _CCCL_HOSTED()
   friend ::std::ostream& operator<<(::std::ostream& os, const TransformAsyncCopyPolicy& policy)
   {
-    return os << "TransformAsyncCopyPolicy { .threads_per_block = " << policy.threads_per_block << ", .min_items_per_thread = "
-              << policy.min_items_per_thread << ", .max_items_per_thread = " << policy.max_items_per_thread
-              << ", .unroll_factor = " << policy.unroll_factor << " }";
+    return os << "TransformAsyncCopyPolicy { .threads_per_block = " << policy.threads_per_block
+              << ", .min_items_per_thread = " << policy.min_items_per_thread << ", .max_items_per_thread = "
+              << policy.max_items_per_thread << ", .unroll_factor = " << policy.unroll_factor << " }";
   }
 #endif // _CCCL_HOSTED()
 };

--- a/cub/test/catch2_test_device_transform_env.cu
+++ b/cub/test/catch2_test_device_transform_env.cu
@@ -248,8 +248,7 @@ C2H_TEST("DeviceTransform::TransformStableArgumentAddresses custom stream", "[de
 // use a policy selector that prescribes to run with exactly 8 threads per block and 3 items per thread
 struct my_policy_selector
 {
-  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const
-    -> cub::TransformPolicy
+  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::TransformPolicy
   {
     constexpr int min_bytes_in_flight = 64 * 1024;
     constexpr auto algorithm          = cub::TransformAlgorithm::prefetch;

--- a/cub/test/catch2_test_device_transform_env.cu
+++ b/cub/test/catch2_test_device_transform_env.cu
@@ -314,15 +314,15 @@ C2H_TEST("TransformPolicy", "[transform][device]")
     .algorithm           = cub::TransformAlgorithm::prefetch,
     .prefetch =
       cub::TransformPrefetchPolicy{
-        .block_threads             = 256,
+        .threads_per_block         = 256,
         .items_per_thread_no_input = 2,
         .min_items_per_thread      = 1,
         .max_items_per_thread      = 32,
         .prefetch_byte_stride      = 128,
         .unroll_factor             = 0},
-    .vectorized = cub::TransformVectorizedPolicy{.block_threads = 256, .items_per_thread = 8, .vec_size = 4},
+    .vectorized = cub::TransformVectorizedPolicy{.threads_per_block = 256, .items_per_thread = 8, .vec_size = 4},
     .async_copy = cub::TransformAsyncCopyPolicy{
-      .block_threads = 256, .min_items_per_thread = 1, .max_items_per_thread = 32, .unroll_factor = 1}};
+      .threads_per_block = 256, .min_items_per_thread = 1, .max_items_per_thread = 32, .unroll_factor = 1}};
 #  else // _CCCL_STD_VER >= 2020
   constexpr auto p2 = p1;
 #  endif // _CCCL_STD_VER >= 2020

--- a/cub/test/catch2_test_device_transform_env.cu
+++ b/cub/test/catch2_test_device_transform_env.cu
@@ -249,11 +249,11 @@ C2H_TEST("DeviceTransform::TransformStableArgumentAddresses custom stream", "[de
 struct my_policy_selector
 {
   _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::transform::transform_policy
+    -> cub::TransformPolicy
   {
     constexpr int min_bytes_in_flight = 64 * 1024;
-    constexpr auto algorithm          = cub::detail::transform::Algorithm::prefetch;
-    constexpr auto policy             = cub::detail::transform::prefetch_policy{8, 3, 3, 3};
+    constexpr auto algorithm          = cub::TransformAlgorithm::prefetch;
+    constexpr auto policy             = cub::TransformPrefetchPolicy{8, 3, 3, 3};
     return {min_bytes_in_flight, algorithm, policy, {}, {}};
   }
 };
@@ -292,3 +292,43 @@ C2H_TEST("DeviceTransform::Transform can be tuned with custom stream", "[reduce]
   c2h::device_vector<unsigned> expected{0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7};
   REQUIRE(result == expected);
 }
+
+#if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
+C2H_TEST("TransformPolicy", "[transform][device]")
+{
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::TransformPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::TransformPolicy>);
+
+  // aggregate init
+  constexpr auto p1 = cub::TransformPolicy{
+    64 * 1024,
+    cub::TransformAlgorithm::prefetch,
+    cub::TransformPrefetchPolicy{256, 2, 1, 32, 128, 0},
+    cub::TransformVectorizedPolicy{256, 8, 4},
+    cub::TransformAsyncCopyPolicy{256, 1, 32, 1}};
+
+#  if _CCCL_STD_VER >= 2020
+  // designated init
+  constexpr auto p2 = cub::TransformPolicy{
+    .min_bytes_in_flight = 64 * 1024,
+    .algorithm           = cub::TransformAlgorithm::prefetch,
+    .prefetch =
+      cub::TransformPrefetchPolicy{
+        .block_threads             = 256,
+        .items_per_thread_no_input = 2,
+        .min_items_per_thread      = 1,
+        .max_items_per_thread      = 32,
+        .prefetch_byte_stride      = 128,
+        .unroll_factor             = 0},
+    .vectorized = cub::TransformVectorizedPolicy{.block_threads = 256, .items_per_thread = 8, .vec_size = 4},
+    .async_copy = cub::TransformAsyncCopyPolicy{
+      .block_threads = 256, .min_items_per_thread = 1, .max_items_per_thread = 32, .unroll_factor = 1}};
+#  else // _CCCL_STD_VER >= 2020
+  constexpr auto p2 = p1;
+#  endif // _CCCL_STD_VER >= 2020
+
+  // comparison
+  STATIC_REQUIRE(p1 == p2);
+  STATIC_REQUIRE_FALSE(p1 != p2);
+}
+#endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_transform_env_api.cu
+++ b/cub/test/catch2_test_device_transform_env_api.cu
@@ -28,7 +28,7 @@ struct MyTransformPolicySelector
   {
     return {.min_bytes_in_flight = 64 * 1024,
             .algorithm           = cub::TransformAlgorithm::prefetch,
-            .prefetch            = {.block_threads = 256},
+            .prefetch            = {.threads_per_block = 256},
             .vectorized          = {},
             .async_copy          = {}};
   }

--- a/cub/test/catch2_test_device_transform_env_api.cu
+++ b/cub/test/catch2_test_device_transform_env_api.cu
@@ -22,7 +22,7 @@ _CCCL_DIAG_SUPPRESS_CLANG("-Wgnu-designator")
 #  endif // _CCCL_COMPILER(CLANG)
 
 // example-begin transform-policy-selector
-struct MyTransformPolicySelector
+struct TransformPolicySelector
 {
   __host__ __device__ constexpr auto operator()(cuda::compute_capability /*cc*/) const -> cub::TransformPolicy
   {
@@ -48,7 +48,7 @@ C2H_TEST("cub::DeviceTransform::Transform env-based API with tuning", "[transfor
     d_output.data(),
     d_input.size(),
     cuda::std::negate{},
-    cuda::execution::tune(MyTransformPolicySelector{}));
+    cuda::execution::tune(TransformPolicySelector{}));
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceTransform::Transform failed with status: " << error << '\n';

--- a/cub/test/catch2_test_device_transform_env_api.cu
+++ b/cub/test/catch2_test_device_transform_env_api.cu
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "insert_nested_NVTX_range_guard.h"
+
+#include <cub/device/device_transform.cuh>
+
+#include <thrust/device_vector.h>
+
+#include <cuda/__execution/tune.h>
+
+#include <iostream>
+
+#include <c2h/catch2_test_helper.h>
+
+#if _CCCL_STD_VER >= 2020
+
+// example-begin transform-policy-selector
+struct MyTransformPolicySelector
+{
+  __host__ __device__ constexpr auto operator()(cuda::compute_capability /*cc*/) const -> cub::TransformPolicy
+  {
+    return {.min_bytes_in_flight = 64 * 1024,
+            .algorithm           = cub::TransformAlgorithm::prefetch,
+            .prefetch            = {.block_threads = 256},
+            .vectorized          = {},
+            .async_copy          = {}};
+  }
+};
+// example-end transform-policy-selector
+
+C2H_TEST("cub::DeviceTransform::Transform env-based API with tuning", "[transform][env]")
+{
+  // example-begin transform-tuning
+  auto d_input  = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7};
+  auto d_output = thrust::device_vector<int>(7);
+
+  const auto error = cub::DeviceTransform::Transform(
+    d_input.data(),
+    d_output.data(),
+    d_input.size(),
+    cuda::std::negate{},
+    cuda::execution::tune(MyTransformPolicySelector{}));
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceTransform::Transform failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected{-1, -2, -3, -4, -5, -6, -7};
+  // example-end transform-tuning
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_output == expected);
+}
+
+#endif // _CCCL_STD_VER >= 2020

--- a/cub/test/catch2_test_device_transform_env_api.cu
+++ b/cub/test/catch2_test_device_transform_env_api.cu
@@ -29,8 +29,8 @@ struct TransformPolicySelector
     return {.min_bytes_in_flight = 64 * 1024,
             .algorithm           = cub::TransformAlgorithm::prefetch,
             .prefetch            = {.threads_per_block = 256},
-            .vectorized          = {},
-            .async_copy          = {}};
+            .vectorized          = {}, // unused because algorithm is prefetch
+            .async_copy          = {}}; // unused because algorithm is prefetch
   }
 };
 // example-end transform-policy-selector

--- a/cub/test/catch2_test_device_transform_env_api.cu
+++ b/cub/test/catch2_test_device_transform_env_api.cu
@@ -15,6 +15,12 @@
 
 #if _CCCL_STD_VER >= 2020
 
+// nvcc turns the `.member = value,` C++ syntax into GNU's `member: value,` when clang (14 - 21) is used
+_CCCL_DIAG_PUSH
+#  if _CCCL_COMPILER(CLANG)
+_CCCL_DIAG_SUPPRESS_CLANG("-Wgnu-designator")
+#  endif // _CCCL_COMPILER(CLANG)
+
 // example-begin transform-policy-selector
 struct MyTransformPolicySelector
 {
@@ -28,6 +34,8 @@ struct MyTransformPolicySelector
   }
 };
 // example-end transform-policy-selector
+
+_CCCL_DIAG_POP
 
 C2H_TEST("cub::DeviceTransform::Transform env-based API with tuning", "[transform][env]")
 {

--- a/cub/test/catch2_test_device_transform_env_api.cu
+++ b/cub/test/catch2_test_device_transform_env_api.cu
@@ -41,7 +41,7 @@ C2H_TEST("cub::DeviceTransform::Transform env-based API with tuning", "[transfor
 {
   // example-begin transform-tuning
   auto d_input  = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7};
-  auto d_output = thrust::device_vector<int>(7);
+  auto d_output = thrust::device_vector<int>(7, thrust::no_init);
 
   const auto error = cub::DeviceTransform::Transform(
     d_input.data(),


### PR DESCRIPTION
- [x] rename memcpy_async to ldgsts
- [x] finish designing unroll_factor
- [x] remove bulk_copy_alignment from the tuning policy
- [x] Merge first: #8757
- [x] Merge first: #8728 
- [x] Merge first: #8835
- [x] Merge first: #8836
- [x] #7671 is sufficiently approved to proceed with this PR. The remaining discussion can continue here.
- [x] Bikeshedding
- [x] ~~Should we split the `TransformAsyncCopyPolicy` into two, one for `ldgsts` and one for `ublkcp`? Then they could evolve independently. I personally see little benefit, since we can extend `TransformAsyncCopyPolicy` for anything we need for bulk copy and ignore the filed for ldgsts. I am also certain that there will be no further development for the ldgsts kernel. Answer: Seems the reviewers were fine
- [x] Are we fine with `TransformAlgorithm::ldgsts` and `TransformAlgorithm::ublkcp`? It was suggested to pick names like `copy_async` or `bulk_copy`. Or include the term `tma`. I don't mind, but please make two consistent suggestions if you care. Answer: Seems the reviewers were fine

Fixes: #8585
Fixes: #5570

## New public entities for `cub::DeviceTransform`

| Entity | Enumerators / Data Members |
|--------|--------------|
| `cub::TransformAlgorithm` | `prefetch`, `vectorized`, `ldgsts`, `ublkcp` |
| `cub::TransformPrefetchPolicy` | `threads_per_block`, `items_per_thread_no_input`, `min_items_per_thread`, `max_items_per_thread`, `prefetch_byte_stride`, `unroll_factor` |
| `cub::TransformVectorizedPolicy` | `threads_per_block`, `items_per_thread`, `vec_size` |
| `cub::TransformAsyncCopyPolicy` | `threads_per_block`, `min_items_per_thread`, `max_items_per_thread`, `unroll_factor` |
| `cub::TransformPolicy` | `min_bytes_in_flight`, `algorithm` (`TransformAlgorithm`), `prefetch` (`TransformPrefetchPolicy`), `vectorized` (`TransformVectorizedPolicy`), `async_copy` (`TransformAsyncCopyPolicy`) |
