### PR TITLE
`ceil_div`: Disable NVHPC path when `cuda::std::is_constant_evaluated()` is not available

### DIFF
--- a/libcudacxx/include/cuda/__cmath/ceil_div.h
+++ b/libcudacxx/include/cuda/__cmath/ceil_div.h
@@ -60,7 +60,7 @@ _CCCL_REQUIRES(::cuda::std::is_integral_v<_Tp> _CCCL_AND ::cuda::std::is_integra
   }
   else
   {
-    _CCCL_IF_CONSTEVAL
+    _CCCL_IF_CONSTEVAL_DEFAULT
     {
       const auto __res = __a1 / __b1;
       return static_cast<_Common>(__res + (__res * __b1 != __a1));


### PR DESCRIPTION
# Description

GCC 8.x doesn't provide `cuda::std::is_constant_evaluated()` builtin. When `cuda::std::ceil_div` is used with nvc++/gcc-8, the code enables `NV_IF_ELSE_TARGET` which cannot be used in a constant evaluation context. 
This PR replaces `_CCCL_IF_CONSTEVAL` with `_CCCL_IF_CONSTEVAL_DEFAULT` to prevent the problem.

Closes #8741