### PR TITLE
Fix bug in reduce bench base.cuh only shown during tuning

### DIFF
--- a/cub/benchmarks/bench/reduce/base.cuh
+++ b/cub/benchmarks/bench/reduce/base.cuh
@@ -13,12 +13,13 @@
 #if !TUNE_BASE
 struct policy_selector
 {
-  _CCCL_API constexpr auto operator()(cuda::arch_id) const -> ::cub::reduce_policy
+  _CCCL_API constexpr auto operator()(cuda::arch_id) const -> ::cub::detail::reduce::reduce_policy
   {
-    const auto [items, threads] = cub::detail::scale_mem_bound(TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD);
-    const auto policy           = cub::agent_reduce_policy{
+    const auto [items, threads] =
+      cub::detail::scale_mem_bound(TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, int{sizeof(TUNE_T)});
+    const auto policy = cub::detail::reduce::agent_reduce_policy{
       threads, items, 1 << TUNE_ITEMS_PER_VEC_LOAD_POW2, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_DEFAULT};
-    return {policy, policy, policy, policy};
+    return {policy, policy, policy};
   }
 };
 #endif // !TUNE_BASE


### PR DESCRIPTION
While tuning `reduce` in sm120 I ran across this bug:

```bash
ggonidelis@alon-ts1-iec-09:~/cccl$  cmake --build build/build_0 --target cub.bench.reduce.sum.variant 2
>&1 | tail -80                                                                                                                                          
[  0%] Built target nvbench.main                                                                                                                        
[ 33%] Generate git revision file for nvbench_git_revision                                                                                              
[ 33%] Built target nvbench_git_revision_compute_git_info                                                                                               
[ 33%] Built target fmt                                                                                                                                 
[ 66%] Built target nvbench                                                                                                                             
[100%] Built target cccl.nvbench_helper                                                                                                                 
[100%] Building CUDA object cub/benchmarks/CMakeFiles/cub.bench.reduce.sum.variant.dir/bench/reduce/sum.cu.o                                            
/home/scratch.ggonidelis_sw/alon-ts1-iec-09/cccl/cub/benchmarks/bench/reduce/base.cuh(16): error: namespace "cub" has no member "reduce_policy"         
             constexpr auto operator()(cuda::arch_id) const -> ::cub::reduce_policy                                                                     
                                                                      ^                                                                                 
                                                                                                                                                        
/home/scratch.ggonidelis_sw/alon-ts1-iec-09/cccl/cub/benchmarks/bench/reduce/base.cuh(18): error: too few arguments in function call                    
      const auto [items, threads] = cub::detail::scale_mem_bound(704, 21);                                                                              
                                                                        ^                                                                               
                                                                                                                                                        
/home/scratch.ggonidelis_sw/alon-ts1-iec-09/cccl/cub/benchmarks/bench/reduce/base.cuh(19): error: namespace "cub" has no member "agent_reduce_policy"   
      const auto policy = cub::agent_reduce_policy{                                                                                                     
                               ^                                                                                                                        
                                                                                                                                                        
/home/scratch.ggonidelis_sw/alon-ts1-iec-09/cccl/cub/benchmarks/bench/reduce/base.cuh(19): error: expected a ";"                                        
      const auto policy = cub::agent_reduce_policy{                                                                                                     
                                                  ^                                                                                                     
                                                                                                                                                        
/home/scratch.ggonidelis_sw/alon-ts1-iec-09/cccl/cub/benchmarks/bench/reduce/base.cuh(21): error: too many initializer values                           
      return {policy, policy, policy, policy};                                                                                                          
                      ^                                                                                                                                 
                                                                                                                                                        
5 errors detected in the compilation of "/home/scratch.ggonidelis_sw/alon-ts1-iec-09/cccl/cub/benchmarks/bench/reduce/sum.cu".  
```

@bernhardmgruber  for viz