### PR TITLE
Value-initialize iterator in make_iterator to avoid uninitialized state

### DIFF
--- a/c/parallel/test/test_util.h
+++ b/c/parallel/test/test_util.h
@@ -916,7 +916,7 @@ struct name_source_t
 template <class ValueT, class StateT>
 iterator_t<ValueT, StateT> make_iterator(name_source_t state, operation_t advance, operation_t dereference)
 {
-  iterator_t<ValueT, StateT> it;
+  iterator_t<ValueT, StateT> it{};
   it.state_name                = state.name;
   const std::string& state_src = std::string{state.def_src};
   it.advance                   = make_operation(advance.name, state_src + advance.code);


### PR DESCRIPTION
## Description

In `c/parallel/test/test_util.h`, `make_iterator()` constructs an `iterator_t<ValueT, StateT>` but never assigns `it.state`. The `operator cccl_iterator_t()` conversion operator then takes `&state`, passing a pointer to uninitialized memory to the C API.

Adding `{}` value-initializes all members, including `state`, so the pointer passed downstream is deterministic.

This is test-only code, so production behavior is unaffected.

### Change

```diff
-  iterator_t<ValueT, StateT> it;
+  iterator_t<ValueT, StateT> it{};
```

Found via cppcheck 2.17.1 (uninitvar).

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)