### PR TITLE
Add default member initializers to BuildInformation

### DIFF
--- a/c/parallel/test/algorithm_execution.h
+++ b/c/parallel/test/algorithm_execution.h
@@ -25,12 +25,12 @@ inline constexpr bool check_ldl_stl_in_sass = false;
 template <int device_id_ = 0>
 class BuildInformation
 {
-  int cc_major;
-  int cc_minor;
-  const char* cub_path;
-  const char* thrust_path;
-  const char* libcudacxx_path;
-  const char* ctk_path;
+  int cc_major{};
+  int cc_minor{};
+  const char* cub_path{};
+  const char* thrust_path{};
+  const char* libcudacxx_path{};
+  const char* ctk_path{};
 
   BuildInformation() = default;
   BuildInformation(int major, int minor, const char* cub, const char* thrust, const char* libcudacxx, const char* ctk)


### PR DESCRIPTION
## Description

In `c/parallel/test/algorithm_execution.h`, `BuildInformation` has a defaulted default constructor (`BuildInformation() = default`) that leaves all 6 members uninitialized — including 4 raw pointers (`cub_path`, `thrust_path`, `libcudacxx_path`, `ctk_path`).

Adding `{}` default member initializers ensures zero-initialization when the default constructor is used.

This is test-only code, so production behavior is unaffected.

### Change

```diff
-  int cc_major;
-  int cc_minor;
-  const char* cub_path;
-  const char* thrust_path;
-  const char* libcudacxx_path;
-  const char* ctk_path;
+  int cc_major{};
+  int cc_minor{};
+  const char* cub_path{};
+  const char* thrust_path{};
+  const char* libcudacxx_path{};
+  const char* ctk_path{};
```

Found via cppcheck 2.17.1 (uninitMemberVarPrivate).

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)