### PR TITLE
Provide simplified cuda device atomics

### DIFF
--- a/cub/cub/agent/agent_find.cuh
+++ b/cub/cub/agent/agent_find.cuh
@@ -12,10 +12,8 @@
 #include <thrust/detail/raw_reference_cast.h>
 #include <thrust/type_traits/is_trivially_relocatable.h>
 
+#include <cuda/__atomic/cuda_atomic_relaxed.h>
 #include <cuda/__memory/is_aligned.h>
-#if !_CCCL_HAS_NV_ATOMIC_BUILTINS()
-#  include <cuda/atomic>
-#endif // !_CCCL_HAS_NV_ATOMIC_BUILTINS()
 #include <cuda/std/__type_traits/integral_constant.h>
 
 CUB_NAMESPACE_BEGIN
@@ -162,13 +160,8 @@ struct agent_t
       // Only one thread reads atomically and propagates it to other threads of the block through shared memory
       if (threadIdx.x == 0)
       {
-#if _CCCL_HAS_NV_ATOMIC_BUILTINS()
-        // __nv_atomic_load is a compiler build-in and compiles a lot faster
-        __nv_atomic_load(found_pos_ptr, &temp_storage.global_result, __NV_ATOMIC_RELAXED, __NV_THREAD_SCOPE_DEVICE);
-#else // ^^^ _CCCL_HAS_NV_ATOMIC_BUILTINS() ^^^ / vvv !_CCCL_HAS_NV_ATOMIC_BUILTINS() vvv
-        temp_storage.global_result = ::cuda::atomic_ref<OffsetT, ::cuda::std::thread_scope_device>{*found_pos_ptr}.load(
-          ::cuda::std::memory_order_relaxed);
-#endif // !_CCCL_HAS_NV_ATOMIC_BUILTINS()
+        ::cuda::__cccl_cuda_atomic_load_relaxed<::cuda::std::thread_scope_device>(
+          found_pos_ptr, temp_storage.global_result);
       }
       __syncthreads();
 

--- a/cub/cub/block/specializations/block_reduce_warp_reductions.cuh
+++ b/cub/cub/block/specializations/block_reduce_warp_reductions.cuh
@@ -24,9 +24,9 @@
 #include <cub/util_ptx.cuh>
 #include <cub/warp/warp_reduce.cuh>
 
+#include <cuda/__atomic/cuda_atomic_relaxed.h>
 #include <cuda/__cmath/ceil_div.h>
 #include <cuda/__ptx/instructions/get_sreg.h>
-#include <cuda/atomic>
 #include <cuda/std/__algorithm/min.h>
 
 CUB_NAMESPACE_BEGIN
@@ -121,14 +121,8 @@ struct BlockReduceWarpReductions
     // Warp 0 already contributed its aggregate above since its also linear_tid == 0
     if (lane_id == 0 && warp_id != 0)
     {
-      // TODO: replace this with other atomic operations when specified
-      NV_IF_ELSE_TARGET(
-        NV_PROVIDES_SM_60,
-        ({
-          ::cuda::atomic_ref<T, ::cuda::thread_scope_block> atomic_target(temp_storage.warp_aggregates[0]);
-          atomic_target.fetch_add(warp_aggregate, ::cuda::memory_order_relaxed);
-        }),
-        (atomicAdd(&temp_storage.warp_aggregates[0], warp_aggregate);));
+      ::cuda::__cccl_cuda_atomic_fetch_add_relaxed<::cuda::std::thread_scope_block>(
+        temp_storage.warp_aggregates, warp_aggregate);
     }
 
     __syncthreads();

--- a/cub/cub/detail/warpspeed/constant_assert.cuh
+++ b/cub/cub/detail/warpspeed/constant_assert.cuh
@@ -48,5 +48,5 @@
     } while (0)
 #else
 // Host or !_WARPSPEED_FORCE_ASSERT_AT_COMPILE_TIME
-#  define _WS_CONSTANT_ASSERT(expr, msg) (assert((expr) && (msg)))
+#  define _WS_CONSTANT_ASSERT(expr, msg) _CCCL_ASSERT((expr), msg)
 #endif

--- a/cub/cub/detail/warpspeed/look_ahead.cuh
+++ b/cub/cub/detail/warpspeed/look_ahead.cuh
@@ -19,16 +19,13 @@
 #include <cub/warp/specializations/warp_reduce_shfl.cuh>
 #include <cub/warp/warp_reduce.cuh>
 
+#include <cuda/__atomic/cuda_atomic_relaxed.h>
 #include <cuda/__cmath/pow2.h>
 #include <cuda/__functional/operator_properties.h>
 #include <cuda/__memory/is_aligned.h>
 #include <cuda/__ptx/instructions/get_sreg.h>
 #include <cuda/std/__bit/popcount.h>
 #include <cuda/std/__type_traits/underlying_type.h>
-
-#if !_CCCL_HAS_NV_ATOMIC_BUILTINS()
-#  include <cuda/atomic>
-#endif // !_CCCL_HAS_NV_ATOMIC_BUILTINS()
 
 #include <nv/target>
 
@@ -79,13 +76,7 @@ storeTileAggregate(tile_state_t<AccumT>* ptrTileStates, scan_state scanState, Ac
   {
     static_assert(::cuda::is_power_of_two(sizeof(tile_state_t<AccumT>)));
     tile_state_t<AccumT> tmp{scanState, sum};
-
-#  if _CCCL_HAS_NV_ATOMIC_BUILTINS()
-    __nv_atomic_store(ptrTileStates + index, &tmp, __NV_ATOMIC_RELAXED, __NV_THREAD_SCOPE_DEVICE);
-#  else // ^^^ _CCCL_HAS_NV_ATOMIC_BUILTINS() ^^^ / vvv !_CCCL_HAS_NV_ATOMIC_BUILTINS() vvv
-    ::cuda::atomic_ref<tile_state_t<AccumT>, ::cuda::std::thread_scope_device>{ptrTileStates[index]}.store(
-      tmp, ::cuda::std::memory_order_relaxed);
-#  endif // !_CCCL_HAS_NV_ATOMIC_BUILTINS()
+    ::cuda::__cccl_cuda_atomic_store_relaxed<::cuda::std::thread_scope_device>(ptrTileStates + index, tmp);
   }
   else
   {
@@ -106,12 +97,7 @@ _CCCL_DEVICE_API tile_state_t<AccumT> loadTileAggregate(tile_state_t<AccumT>* pt
                 && ::cuda::std::is_trivially_copyable_v<tile_state_t<AccumT>>)
   {
     static_assert(::cuda::is_power_of_two(sizeof(tile_state_t<AccumT>)));
-#  if _CCCL_HAS_NV_ATOMIC_BUILTINS()
-    __nv_atomic_load(ptrTileStates + index, &res, __NV_ATOMIC_RELAXED, __NV_THREAD_SCOPE_DEVICE);
-#  else // ^^^ _CCCL_HAS_NV_ATOMIC_BUILTINS() ^^^ / vvv !_CCCL_HAS_NV_ATOMIC_BUILTINS() vvv
-    res = ::cuda::atomic_ref<tile_state_t<AccumT>, ::cuda::std::thread_scope_device>{ptrTileStates[index]}.load(
-      ::cuda::std::memory_order_relaxed);
-#  endif // !_CCCL_HAS_NV_ATOMIC_BUILTINS()
+    ::cuda::__cccl_cuda_atomic_load_relaxed<::cuda::std::thread_scope_device>(ptrTileStates + index, res);
   }
   else
   {

--- a/cub/cub/device/dispatch/kernels/kernel_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_reduce.cuh
@@ -18,8 +18,8 @@
 #include <cub/grid/grid_even_share.cuh>
 #include <cub/util_arch.cuh>
 
+#include <cuda/__atomic/cuda_atomic_relaxed.h>
 #include <cuda/__device/arch_id.h>
-#include <cuda/atomic>
 
 CUB_NAMESPACE_BEGIN
 
@@ -341,14 +341,8 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(int(
   // only thread 0 has valid value in block aggregate
   if (threadIdx.x == 0)
   {
-    // TODO: replace this with other atomic operations when specified
-    NV_IF_ELSE_TARGET(NV_PROVIDES_SM_60,
-                      ({
-                        ::cuda::atomic_ref<AccumT, ::cuda::thread_scope_device> atomic_target(d_out[0]);
-                        atomic_target.fetch_add(blockIdx.x == 0 ? reduction_op(init, block_aggregate) : block_aggregate,
-                                                ::cuda::memory_order_relaxed);
-                      }),
-                      (atomicAdd(&d_out[0], blockIdx.x == 0 ? reduction_op(init, block_aggregate) : block_aggregate);));
+    ::cuda::__cccl_cuda_atomic_fetch_add_relaxed<::cuda::std::thread_scope_device>(
+      d_out, blockIdx.x == 0 ? reduction_op(init, block_aggregate) : block_aggregate);
   }
 }
 } // namespace detail::reduce

--- a/libcudacxx/include/cuda/__atomic/cuda_atomic_relaxed.h
+++ b/libcudacxx/include/cuda/__atomic/cuda_atomic_relaxed.h
@@ -1,0 +1,130 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the CUDA C++ Standard Library,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___ATOMIC_CUDA_ATOMIC_RELAXED_H
+#define _CUDA___ATOMIC_CUDA_ATOMIC_RELAXED_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__atomic/functions/cuda_ptx_derived.h>
+#include <cuda/std/__atomic/order.h>
+#include <cuda/std/__atomic/scopes.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+#if _CCCL_CUDA_COMPILATION()
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+template <::cuda::thread_scope _Scope>
+[[nodiscard]] _CCCL_API constexpr auto __cccl_select_scope()
+{
+  if constexpr (_Scope == ::cuda::thread_scope_system)
+  {
+    return ::cuda::std::__thread_scope_system_tag{};
+  }
+  else if constexpr (_Scope == ::cuda::thread_scope_device)
+  {
+    return ::cuda::std::__thread_scope_device_tag{};
+  }
+  else if constexpr (_Scope == ::cuda::thread_scope_block)
+  {
+    return ::cuda::std::__thread_scope_block_tag{};
+  }
+  else if constexpr (_Scope == ::cuda::thread_scope_thread)
+  {
+    return ::cuda::std::__thread_scope_block_tag{};
+  }
+  else
+  {
+    static_assert(::cuda::std::__always_false_v<::cuda::std::integral_constant<::cuda::thread_scope, _Scope>>,
+                  "Invalid thread scope");
+    _CCCL_UNREACHABLE();
+  }
+}
+
+//! Loads `*__ptr` atomically into `__dst` using `__nv_atomic_load` when available, otherwise uses ptx helper
+template <::cuda::thread_scope _Scope, typename _Tp>
+_CCCL_DEVICE_API void __cccl_cuda_atomic_load_relaxed(const _Tp* __ptr, _Tp& __dst)
+{
+  using __proxy_t              = typename ::cuda::std::__atomic_cuda_deduce_bitwise<_Tp>::__type;
+  using __proxy_tag            = typename ::cuda::std::__atomic_cuda_deduce_bitwise<_Tp>::__tag;
+  const __proxy_t* __ptr_proxy = reinterpret_cast<const __proxy_t*>(__ptr);
+  __proxy_t* __dst_proxy       = reinterpret_cast<__proxy_t*>(&__dst);
+  if (::cuda::std::__cuda_load_weak_if_local(__ptr_proxy, __dst_proxy, sizeof(__proxy_t)))
+  {
+    return;
+  }
+
+  auto __scope = __cccl_select_scope<_Scope>();
+  ::cuda::std::__cuda_atomic_bind_load<__proxy_t, __proxy_tag, decltype(__scope), ::cuda::std::__atomic_cuda_mmio_disable>
+    __bound_load{__ptr_proxy, __dst_proxy};
+  ::cuda::std::__cuda_atomic_load_memory_order_dispatch(__bound_load, ::cuda::memory_order_relaxed, __scope);
+}
+
+//! Loads `*__ptr` atomically into `__dst` using `__nv_atomic_load` when available, otherwise uses ptx helper
+template <::cuda::thread_scope _Scope, typename _Tp>
+_CCCL_DEVICE_API void __cccl_cuda_atomic_store_relaxed(_Tp* __ptr, _Tp __val)
+{
+  using __proxy_t        = typename ::cuda::std::__atomic_cuda_deduce_bitwise<_Tp>::__type;
+  using __proxy_tag      = typename ::cuda::std::__atomic_cuda_deduce_bitwise<_Tp>::__tag;
+  __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(__ptr);
+  __proxy_t* __val_proxy = reinterpret_cast<__proxy_t*>(&__val);
+  if (::cuda::std::__cuda_store_weak_if_local(__ptr_proxy, __val_proxy, sizeof(__proxy_t)))
+  {
+    return;
+  }
+
+  auto __scope = __cccl_select_scope<_Scope>();
+  ::cuda::std::__cuda_atomic_bind_store<__proxy_t, __proxy_tag, decltype(__scope), ::cuda::std::__atomic_cuda_mmio_disable>
+    __bound_store{__ptr_proxy, __val_proxy};
+  ::cuda::std::__cuda_atomic_store_memory_order_dispatch(__bound_store, ::cuda::memory_order_relaxed, __scope);
+}
+
+//! Adds `__val` to `*__ptr` and returns the previous value. Uses `__nv_atomic_fetch_add` when available, PTX otherwise
+template <::cuda::thread_scope _Scope, typename _Tp, typename _Up>
+_CCCL_DEVICE_API _Tp __cccl_cuda_atomic_fetch_add_relaxed(_Tp* __ptr, _Up __op)
+{
+  constexpr auto __skip_v = ::cuda::std::__atomic_ptr_skip_t<_Tp>::__skip;
+  __op                    = __op * __skip_v;
+  using __proxy_t         = typename ::cuda::std::__atomic_cuda_deduce_arithmetic<_Tp>::__type;
+  using __proxy_tag       = typename ::cuda::std::__atomic_cuda_deduce_arithmetic<_Tp>::__tag;
+  _Tp __dst{};
+  __proxy_t* __ptr_proxy = reinterpret_cast<__proxy_t*>(__ptr);
+  __proxy_t* __dst_proxy = reinterpret_cast<__proxy_t*>(&__dst);
+  __proxy_t* __op_proxy  = reinterpret_cast<__proxy_t*>(&__op);
+  if (::cuda::std::__cuda_fetch_add_weak_if_local(__ptr_proxy, *__op_proxy, __dst_proxy))
+  {
+    return __dst;
+  }
+
+  auto __scope = __cccl_select_scope<_Scope>();
+  ::cuda::std::__cuda_atomic_bind_fetch_add<__proxy_t, __proxy_tag, decltype(__scope)> __bound_add{
+    __ptr_proxy, __dst_proxy, __op_proxy};
+  ::cuda::std::__cuda_atomic_fetch_memory_order_dispatch(__bound_add, ::cuda::memory_order_relaxed, __scope);
+  return __dst;
+}
+
+_CCCL_END_NAMESPACE_CUDA
+
+#endif // _CCCL_CUDA_COMPILATION()
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___ATOMIC_CUDA_ATOMIC_RELAXED_H

--- a/libcudacxx/test/libcudacxx/libcxx/atomics/cuda_relaxed/atomic_fetch_add.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/atomics/cuda_relaxed/atomic_fetch_add.pass.cpp
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
+// <cuda/std/atomic>
+
+// template <class Integral>
+//     Integral
+//     atomic_fetch_add(volatile atomic<Integral>* obj, Integral op);
+//
+// template <class Integral>
+//     Integral
+//     atomic_fetch_add(atomic<Integral>* obj, Integral op);
+//
+// template <class T>
+//     T*
+//     atomic_fetch_add(volatile atomic<T*>* obj, ptrdiff_t op);
+//
+// template <class T>
+//     T*
+//     atomic_fetch_add(atomic<T*>* obj, ptrdiff_t op);
+
+#include <cuda/__atomic/cuda_atomic_relaxed.h>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+#include "cuda_space_selector.h"
+#include "test_macros.h"
+
+template <class T, template <typename, typename> class Selector, cuda::thread_scope _Scope>
+struct TestFn
+{
+  TEST_DEVICE_FUNC void operator()() const
+  {
+    {
+      Selector<T, constructor_initializer> sel;
+      T& t = *sel.construct(1);
+      assert(::cuda::__cccl_cuda_atomic_fetch_add_relaxed<_Scope>(&t, T(2)) == T(1));
+      assert(t == T(3));
+    }
+  }
+};
+
+template <template <typename, typename> class Selector, cuda::thread_scope Scope>
+TEST_DEVICE_FUNC void test()
+{
+  TestFn<char, Selector, Scope>()();
+  TestFn<signed char, Selector, Scope>()();
+  TestFn<unsigned char, Selector, Scope>()();
+  TestFn<short, Selector, Scope>()();
+  TestFn<unsigned short, Selector, Scope>()();
+  TestFn<int, Selector, Scope>()();
+  TestFn<unsigned int, Selector, Scope>()();
+  TestFn<long, Selector, Scope>()();
+  TestFn<unsigned long, Selector, Scope>()();
+  TestFn<long long, Selector, Scope>()();
+  TestFn<unsigned long long, Selector, Scope>()();
+  TestFn<wchar_t, Selector, Scope>();
+  TestFn<char16_t, Selector, Scope>()();
+  TestFn<char32_t, Selector, Scope>()();
+  TestFn<int8_t, Selector, Scope>()();
+  TestFn<uint8_t, Selector, Scope>()();
+  TestFn<int16_t, Selector, Scope>()();
+  TestFn<uint16_t, Selector, Scope>()();
+  TestFn<int32_t, Selector, Scope>()();
+  TestFn<uint32_t, Selector, Scope>()();
+  TestFn<int64_t, Selector, Scope>()();
+  TestFn<uint64_t, Selector, Scope>()();
+  TestFn<float, Selector, Scope>()();
+  TestFn<double, Selector, Scope>()();
+}
+
+template <template <typename, typename> class Selector>
+TEST_DEVICE_FUNC void test()
+{
+  test<Selector, ::cuda::thread_scope_system>();
+  test<Selector, ::cuda::thread_scope_device>();
+  test<Selector, ::cuda::thread_scope_block>();
+  test<Selector, ::cuda::thread_scope_thread>();
+}
+
+int main(int, char**)
+{
+  NV_IF_TARGET(NV_IS_DEVICE, ({
+                 test<local_memory_selector>();
+                 test<shared_memory_selector>();
+                 test<global_memory_selector>();
+               }))
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/atomics/cuda_relaxed/atomic_load.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/atomics/cuda_relaxed/atomic_load.pass.cpp
@@ -1,0 +1,94 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
+// UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
+// UNSUPPORTED: windows && pre-sm-70
+//  ... assertion fails line 35
+
+// <cuda/std/atomic>
+
+// template <class T>
+//     T
+//     atomic_load(const volatile atomic<T>* obj);
+//
+// template <class T>
+//     T
+//     atomic_load(const atomic<T>* obj);
+
+#include <cuda/__atomic/cuda_atomic_relaxed.h>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+#include "cuda_space_selector.h"
+#include "test_macros.h"
+
+template <class T, template <typename, typename> class Selector, cuda::thread_scope _Scope>
+struct TestFn
+{
+  TEST_DEVICE_FUNC void operator()() const
+  {
+    Selector<T, constructor_initializer> sel;
+    T& t = *sel.construct(1337);
+    T t1;
+    __syncthreads();
+    ::cuda::__cccl_cuda_atomic_load_relaxed<_Scope>(&t, t1);
+    assert(t1 == T(1337));
+  }
+};
+
+template <template <typename, typename> class Selector, cuda::thread_scope Scope>
+TEST_DEVICE_FUNC void test()
+{
+  TestFn<char, Selector, Scope>()();
+  TestFn<signed char, Selector, Scope>()();
+  TestFn<unsigned char, Selector, Scope>()();
+  TestFn<short, Selector, Scope>()();
+  TestFn<unsigned short, Selector, Scope>()();
+  TestFn<int, Selector, Scope>()();
+  TestFn<unsigned int, Selector, Scope>()();
+  TestFn<long, Selector, Scope>()();
+  TestFn<unsigned long, Selector, Scope>()();
+  TestFn<long long, Selector, Scope>()();
+  TestFn<unsigned long long, Selector, Scope>()();
+  TestFn<wchar_t, Selector, Scope>();
+  TestFn<char16_t, Selector, Scope>()();
+  TestFn<char32_t, Selector, Scope>()();
+  TestFn<int8_t, Selector, Scope>()();
+  TestFn<uint8_t, Selector, Scope>()();
+  TestFn<int16_t, Selector, Scope>()();
+  TestFn<uint16_t, Selector, Scope>()();
+  TestFn<int32_t, Selector, Scope>()();
+  TestFn<uint32_t, Selector, Scope>()();
+  TestFn<int64_t, Selector, Scope>()();
+  TestFn<uint64_t, Selector, Scope>()();
+  TestFn<float, Selector, Scope>()();
+  TestFn<double, Selector, Scope>()();
+}
+
+template <template <typename, typename> class Selector>
+_CCCL_DEVICE void test()
+{
+  test<Selector, ::cuda::thread_scope_system>();
+  test<Selector, ::cuda::thread_scope_device>();
+  test<Selector, ::cuda::thread_scope_block>();
+  test<Selector, ::cuda::thread_scope_thread>();
+}
+
+int main(int, char**)
+{
+  NV_IF_TARGET(NV_IS_DEVICE, ({
+                 test<local_memory_selector>();
+                 test<shared_memory_selector>();
+                 test<global_memory_selector>();
+               }))
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/atomics/cuda_relaxed/atomic_store.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/atomics/cuda_relaxed/atomic_store.pass.cpp
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
+// UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
+// UNSUPPORTED: windows && pre-sm-70
+
+// <cuda/std/atomic>
+
+// template <class T>
+//     void
+//     atomic_store(volatile atomic<T>* obj, T desr);
+//
+// template <class T>
+//     void
+//     atomic_store(atomic<T>* obj, T desr);
+
+#include <cuda/__atomic/cuda_atomic_relaxed.h>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+#include "cuda_space_selector.h"
+#include "test_macros.h"
+
+template <class T, template <typename, typename> class Selector, cuda::thread_scope _Scope>
+struct TestFn
+{
+  TEST_DEVICE_FUNC void operator()() const
+  {
+    Selector<T, constructor_initializer> sel;
+    T& t = *sel.construct(1);
+    ::cuda::__cccl_cuda_atomic_store_relaxed<_Scope>(&t, T(2));
+    assert(t == T(2));
+  }
+};
+
+template <template <typename, typename> class Selector, cuda::thread_scope Scope>
+TEST_DEVICE_FUNC void test()
+{
+  TestFn<char, Selector, Scope>()();
+  TestFn<signed char, Selector, Scope>()();
+  TestFn<unsigned char, Selector, Scope>()();
+  TestFn<short, Selector, Scope>()();
+  TestFn<unsigned short, Selector, Scope>()();
+  TestFn<int, Selector, Scope>()();
+  TestFn<unsigned int, Selector, Scope>()();
+  TestFn<long, Selector, Scope>()();
+  TestFn<unsigned long, Selector, Scope>()();
+  TestFn<long long, Selector, Scope>()();
+  TestFn<unsigned long long, Selector, Scope>()();
+  TestFn<wchar_t, Selector, Scope>();
+  TestFn<char16_t, Selector, Scope>()();
+  TestFn<char32_t, Selector, Scope>()();
+  TestFn<int8_t, Selector, Scope>()();
+  TestFn<uint8_t, Selector, Scope>()();
+  TestFn<int16_t, Selector, Scope>()();
+  TestFn<uint16_t, Selector, Scope>()();
+  TestFn<int32_t, Selector, Scope>()();
+  TestFn<uint32_t, Selector, Scope>()();
+  TestFn<int64_t, Selector, Scope>()();
+  TestFn<uint64_t, Selector, Scope>()();
+  TestFn<float, Selector, Scope>()();
+  TestFn<double, Selector, Scope>()();
+}
+
+template <template <typename, typename> class Selector>
+TEST_DEVICE_FUNC void test()
+{
+  test<Selector, ::cuda::thread_scope_system>();
+  test<Selector, ::cuda::thread_scope_device>();
+  test<Selector, ::cuda::thread_scope_block>();
+  test<Selector, ::cuda::thread_scope_thread>();
+}
+
+int main(int, char**)
+{
+  NV_IF_TARGET(NV_IS_DEVICE, ({
+                 test<local_memory_selector>();
+                 test<shared_memory_selector>();
+                 test<global_memory_selector>();
+               }))
+
+  return 0;
+}


### PR DESCRIPTION
We use need atomic stores loads and adds in CUB

However, using a full <atomic> is a bit of an overkill for that.

This introduces a simplified function that should do the same trick without pulling in all of atomic 