### PR TITLE
Use the new tuning API internally for `detail::scan_by_key::dispatch`

### DIFF
--- a/cub/benchmarks/bench/scan/exclusive/by_key.cu
+++ b/cub/benchmarks/bench/scan/exclusive/by_key.cu
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2011-2026, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: BSD-3
 
-#include <cub/detail/choose_offset.cuh>
 #include <cub/device/device_scan.cuh>
 
 #include <look_back_helper.cuh>
@@ -35,14 +34,9 @@ struct bench_scan_by_key_policy_selector
 template <typename KeyT, typename ValueT, typename OffsetT>
 static void scan(nvbench::state& state, nvbench::type_list<KeyT, ValueT, OffsetT>)
 {
-  using init_value_t    = ValueT;
-  using op_t            = ::cuda::std::plus<>;
-  using accum_t         = ::cuda::std::__accumulator_t<op_t, ValueT, init_value_t>;
-  using key_input_it_t  = const KeyT*;
-  using val_input_it_t  = const ValueT*;
-  using val_output_it_t = ValueT*;
-  using equality_op_t   = ::cuda::std::equal_to<>;
-  using offset_t        = cub::detail::choose_offset_t<OffsetT>;
+  using init_value_t  = ValueT;
+  using op_t          = ::cuda::std::plus<>;
+  using equality_op_t = ::cuda::std::equal_to<>;
 
   const auto elements = static_cast<std::size_t>(state.get_int64("Elements{io}"));
 
@@ -50,45 +44,36 @@ static void scan(nvbench::state& state, nvbench::type_list<KeyT, ValueT, OffsetT
   thrust::device_vector<ValueT> out_vals(elements);
   thrust::device_vector<KeyT> keys = generate.uniform.key_segments(elements, 0, 5200);
 
-  const KeyT* d_keys       = thrust::raw_pointer_cast(keys.data());
-  const ValueT* d_in_vals  = thrust::raw_pointer_cast(in_vals.data());
-  ValueT* d_out_vals       = thrust::raw_pointer_cast(out_vals.data());
-  const offset_t num_items = static_cast<offset_t>(elements);
+  const KeyT* d_keys      = thrust::raw_pointer_cast(keys.data());
+  const ValueT* d_in_vals = thrust::raw_pointer_cast(in_vals.data());
+  ValueT* d_out_vals      = thrust::raw_pointer_cast(out_vals.data());
 
   state.add_element_count(elements);
   state.add_global_memory_reads<KeyT>(elements);
   state.add_global_memory_reads<ValueT>(elements);
   state.add_global_memory_writes<ValueT>(elements);
 
-  size_t tmp_size{};
-  nvbench::uint8_t* d_tmp = nullptr;
-  auto dispatch_on_stream = [&](cudaStream_t stream) {
-    return cub::detail::scan_by_key::
-      dispatch<key_input_it_t, val_input_it_t, val_output_it_t, equality_op_t, op_t, init_value_t, offset_t, accum_t>(
-        d_tmp,
-        tmp_size,
-        d_keys,
-        d_in_vals,
-        d_out_vals,
-        equality_op_t{},
-        op_t{},
-        init_value_t{},
-        num_items,
-        stream
-#if !TUNE_BASE
-        ,
-        bench_scan_by_key_policy_selector{}
-#endif
-      );
-  };
-
-  dispatch_on_stream(nullptr /* stream */);
-
-  thrust::device_vector<nvbench::uint8_t> tmp(tmp_size, thrust::no_init);
-  d_tmp = thrust::raw_pointer_cast(tmp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    dispatch_on_stream(launch.get_stream());
+    auto env = cub_bench_env(
+      alloc,
+      launch
+#if !TUNE_BASE
+      ,
+      cuda::execution::tune(bench_scan_by_key_policy_selector{})
+#endif // !TUNE_BASE
+    );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceScan::ExclusiveScanByKey,
+      "ExclusiveScanByKey failed",
+      d_keys,
+      d_in_vals,
+      d_out_vals,
+      op_t{},
+      init_value_t{},
+      static_cast<OffsetT>(elements),
+      equality_op_t{},
+      env);
   });
 }
 

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -204,15 +204,8 @@ struct DeviceScan
     using policy_selector_t = ::cuda::std::execution::
       __query_result_or_t<TuningEnvT, detail::scan_by_key::scan_by_key_policy, default_policy_selector_t>;
 
-    return detail::scan_by_key::dispatch<
-      KeysInputIteratorT,
-      ValuesInputIteratorT,
-      ValuesOutputIteratorT,
-      EqualityOpT,
-      ScanOpT,
-      InitValueT,
-      offset_t,
-      accum_t>(
+    // we would not need to override the accumulator type, but we must ensure it's the same as for the policy here
+    return detail::scan_by_key::dispatch</* OverrideAccumT = */ accum_t>(
       d_temp_storage,
       temp_storage_bytes,
       d_keys_in,

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -2975,30 +2975,9 @@ struct DeviceScan
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceScan::ExclusiveSumByKey");
 
     using init_t = cub::detail::it_value_t<ValuesInputIteratorT>;
-    init_t init_value{};
-
     return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      using offset_t = detail::choose_offset_t<NumItemsT>;
       using tuning_t = decltype(tuning);
-      using accum_t =
-        ::cuda::std::__accumulator_t<::cuda::std::plus<>, cub::detail::it_value_t<ValuesInputIteratorT>, init_t>;
-      using default_policy_selector_t =
-        detail::scan_by_key::policy_selector_from_types<detail::it_value_t<KeysInputIteratorT>,
-                                                        accum_t,
-                                                        cub::detail::it_value_t<ValuesInputIteratorT>,
-                                                        ::cuda::std::plus<>>;
-      using policy_selector_t = ::cuda::std::execution::
-        __query_result_or_t<tuning_t, detail::scan_by_key::scan_by_key_policy, default_policy_selector_t>;
-
-      return detail::scan_by_key::dispatch<
-        KeysInputIteratorT,
-        ValuesInputIteratorT,
-        ValuesOutputIteratorT,
-        EqualityOpT,
-        ::cuda::std::plus<>,
-        init_t,
-        offset_t,
-        accum_t>(
+      return scan_by_key_impl<tuning_t>(
         storage,
         bytes,
         d_keys_in,
@@ -3006,10 +2985,9 @@ struct DeviceScan
         d_values_out,
         equality_op,
         ::cuda::std::plus<>{},
-        init_value,
-        static_cast<offset_t>(num_items),
-        stream,
-        policy_selector_t{});
+        init_t{},
+        num_items,
+        stream);
     });
   }
 

--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -687,6 +687,7 @@ struct DispatchScanByKey
 namespace detail::scan_by_key
 {
 template <
+  typename OverrideAccumT = use_default,
   typename KeysInputIteratorT,
   typename ValuesInputIteratorT,
   typename ValuesOutputIteratorT,
@@ -694,11 +695,14 @@ template <
   typename ScanOpT,
   typename InitValueT,
   typename OffsetT,
-  typename AccumT = ::cuda::std::__accumulator_t<
-    ScanOpT,
-    cub::detail::it_value_t<ValuesInputIteratorT>,
-    ::cuda::std::
-      _If<::cuda::std::is_same_v<InitValueT, NullType>, cub::detail::it_value_t<ValuesInputIteratorT>, InitValueT>>,
+  typename AccumT = ::cuda::std::conditional_t<
+    !::cuda::std::is_same_v<OverrideAccumT, use_default>,
+    OverrideAccumT,
+    ::cuda::std::__accumulator_t<
+      ScanOpT,
+      cub::detail::it_value_t<ValuesInputIteratorT>,
+      ::cuda::std::
+        _If<::cuda::std::is_same_v<InitValueT, NullType>, cub::detail::it_value_t<ValuesInputIteratorT>, InitValueT>>>,
   typename PolicySelector = policy_selector_from_types<cub::detail::it_value_t<KeysInputIteratorT>,
                                                        AccumT,
                                                        cub::detail::it_value_t<ValuesInputIteratorT>,

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -1061,6 +1061,8 @@ struct policy_selector
   int accum_size;
   bool value_is_primitive;
   bool value_is_trivially_copyable;
+  bool accum_is_primitive;
+  bool accum_is_trivially_copyable;
   type_t key_type;
   type_t value_type;
   type_t accum_type;
@@ -1070,8 +1072,7 @@ struct policy_selector
     -> scan_by_key_policy
   {
     const bool value_is_primitive_or_trivially_copyable = value_is_primitive || value_is_trivially_copyable;
-    const bool primitive_accum =
-      accum_type != type_t::other && accum_type != type_t::int128 && accum_type != type_t::uint128;
+    const bool accum_is_primitive_or_trivially_copyable = accum_is_primitive || accum_is_trivially_copyable;
     const bool primitive_value = value_is_primitive && value_type != type_t::int128 && value_type != type_t::uint128;
     const bool primitive_op    = operation_t != op_kind_t::other;
     const int max_input_bytes  = (::cuda::std::max) (key_size, accum_size);
@@ -1511,7 +1512,7 @@ struct policy_selector
         }
 #endif
 
-        if (key_size == 16 && primitive_accum)
+        if (key_size == 16 && accum_is_primitive)
         {
           switch (value_size)
           {
@@ -1589,7 +1590,8 @@ struct policy_selector
               LOAD_CA,
               BLOCK_STORE_WARP_TRANSPOSE,
               BLOCK_SCAN_WARP_SCANS,
-              default_reduce_by_key_delay_constructor_policy(sizeof(int), accum_size, true, primitive_accum)};
+              default_reduce_by_key_delay_constructor_policy(
+                sizeof(int), accum_size, true, accum_is_primitive_or_trivially_copyable)};
     }
 
     if (cc >= ::cuda::compute_capability{8, 0})
@@ -1831,7 +1833,7 @@ struct policy_selector
         }
 #endif
 
-        if (key_size == 16 && primitive_accum)
+        if (key_size == 16 && accum_is_primitive)
         {
           switch (value_size)
           {
@@ -1909,7 +1911,8 @@ struct policy_selector
               LOAD_CA,
               BLOCK_STORE_WARP_TRANSPOSE,
               BLOCK_SCAN_WARP_SCANS,
-              default_reduce_by_key_delay_constructor_policy(sizeof(int), accum_size, true, primitive_accum)};
+              default_reduce_by_key_delay_constructor_policy(
+                sizeof(int), accum_size, true, accum_is_primitive_or_trivially_copyable)};
     }
 
     return {128,
@@ -1918,7 +1921,8 @@ struct policy_selector
             LOAD_CA,
             BLOCK_STORE_WARP_TRANSPOSE,
             BLOCK_SCAN_WARP_SCANS,
-            default_reduce_by_key_delay_constructor_policy(sizeof(int), accum_size, true, primitive_accum)};
+            default_reduce_by_key_delay_constructor_policy(
+              sizeof(int), accum_size, true, accum_is_primitive_or_trivially_copyable)};
   }
 };
 
@@ -1934,6 +1938,8 @@ struct policy_selector_from_types
       static_cast<int>(sizeof(AccumT)),
       is_primitive<ValueT>::value,
       ::cuda::is_trivially_copyable_v<ValueT>,
+      is_primitive<AccumT>::value,
+      ::cuda::std::is_trivially_copyable_v<AccumT>,
       classify_type<KeyT>,
       classify_type<ValueT>,
       classify_type<AccumT>,

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -1078,15 +1078,23 @@ struct policy_selector
     const int max_input_bytes  = (::cuda::std::max) (key_size, accum_size);
     const int combined_input_bytes = key_size + accum_size;
 
-    const auto default_items =
-      max_input_bytes <= 8
-        ? 9
-        : Nominal4BItemsToItemsCombined(/* nominal_4b_items_per_thread */ 9, combined_input_bytes);
-
-    const auto policy500_items =
-      max_input_bytes <= 8
-        ? 6
-        : Nominal4BItemsToItemsCombined(/* nominal_4b_items_per_thread */ 6, combined_input_bytes);
+    auto default_policy =
+      [&](CacheLoadModifier load_modifier,
+          int delay_ctor_key_size,
+          bool delay_ctor_key_is_primitive_or_trivially_copyable) -> scan_by_key_policy {
+      const auto items_per_thread =
+        max_input_bytes <= 8
+          ? 9
+          : Nominal4BItemsToItemsCombined(/* nominal_4b_items_per_thread */ 9, combined_input_bytes);
+      return {256,
+              items_per_thread,
+              BLOCK_LOAD_WARP_TRANSPOSE,
+              load_modifier,
+              BLOCK_STORE_WARP_TRANSPOSE,
+              BLOCK_SCAN_WARP_SCANS,
+              default_reduce_by_key_delay_constructor_policy(
+                delay_ctor_key_size, sizeof(int), delay_ctor_key_is_primitive_or_trivially_copyable, true)};
+    };
 
     if (cc >= ::cuda::compute_capability{10, 0})
     {
@@ -1572,26 +1580,12 @@ struct policy_selector
 #endif
       }
 
-      return {256,
-              default_items,
-              BLOCK_LOAD_WARP_TRANSPOSE,
-              LOAD_DEFAULT,
-              BLOCK_STORE_WARP_TRANSPOSE,
-              BLOCK_SCAN_WARP_SCANS,
-              default_reduce_by_key_delay_constructor_policy(
-                sizeof(int), value_size, true, value_is_primitive_or_trivially_copyable)};
+      return default_policy(LOAD_DEFAULT, value_size, value_is_primitive_or_trivially_copyable);
     }
 
-    if (cc >= ::cuda::compute_capability{8, 6}) // && cc < ::cuda::compute_capability{9, 0}
+    if (cc >= ::cuda::compute_capability{8, 6})
     {
-      return {256,
-              default_items,
-              BLOCK_LOAD_WARP_TRANSPOSE,
-              LOAD_CA,
-              BLOCK_STORE_WARP_TRANSPOSE,
-              BLOCK_SCAN_WARP_SCANS,
-              default_reduce_by_key_delay_constructor_policy(
-                sizeof(int), accum_size, true, accum_is_primitive_or_trivially_copyable)};
+      return default_policy(LOAD_CA, accum_size, accum_is_primitive_or_trivially_copyable);
     }
 
     if (cc >= ::cuda::compute_capability{8, 0})
@@ -1893,36 +1887,27 @@ struct policy_selector
 #endif
       }
 
-      return {256,
-              default_items,
-              BLOCK_LOAD_WARP_TRANSPOSE,
-              LOAD_DEFAULT,
-              BLOCK_STORE_WARP_TRANSPOSE,
-              BLOCK_SCAN_WARP_SCANS,
-              default_reduce_by_key_delay_constructor_policy(
-                sizeof(int), value_size, true, value_is_primitive_or_trivially_copyable)};
+      return default_policy(LOAD_DEFAULT, value_size, value_is_primitive_or_trivially_copyable);
     }
 
-    if (cc >= ::cuda::compute_capability{6, 0})
+    if (cc >= ::cuda::compute_capability{5, 2})
     {
-      return {256,
-              default_items,
-              BLOCK_LOAD_WARP_TRANSPOSE,
-              LOAD_CA,
-              BLOCK_STORE_WARP_TRANSPOSE,
-              BLOCK_SCAN_WARP_SCANS,
-              default_reduce_by_key_delay_constructor_policy(
-                sizeof(int), accum_size, true, accum_is_primitive_or_trivially_copyable)};
+      return default_policy(LOAD_CA, accum_size, accum_is_primitive_or_trivially_copyable);
     }
 
+    // SM50
+    const auto items_per_thread =
+      max_input_bytes <= 8
+        ? 6
+        : Nominal4BItemsToItemsCombined(/* nominal_4b_items_per_thread */ 6, combined_input_bytes);
     return {128,
-            policy500_items,
+            items_per_thread,
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_CA,
             BLOCK_STORE_WARP_TRANSPOSE,
             BLOCK_SCAN_WARP_SCANS,
             default_reduce_by_key_delay_constructor_policy(
-              sizeof(int), accum_size, true, accum_is_primitive_or_trivially_copyable)};
+              accum_size, sizeof(int), accum_is_primitive_or_trivially_copyable, true)};
   }
 };
 

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -1924,7 +1924,7 @@ struct policy_selector_from_types
       is_primitive<ValueT>::value,
       ::cuda::is_trivially_copyable_v<ValueT>,
       is_primitive<AccumT>::value,
-      ::cuda::std::is_trivially_copyable_v<AccumT>,
+      ::cuda::is_trivially_copyable_v<AccumT>,
       classify_type<KeyT>,
       classify_type<ValueT>,
       classify_type<AccumT>,

--- a/cub/test/catch2_test_device_scan_by_key_env.cu
+++ b/cub/test/catch2_test_device_scan_by_key_env.cu
@@ -131,7 +131,7 @@ TEST_CASE("Device scan inclusive-scan-by-key works with default environment", "[
 template <int BlockThreads>
 struct scan_by_key_tuning
 {
-  _CCCL_API constexpr auto operator()(cuda::arch_id /*arch*/) const -> cub::detail::scan_by_key::scan_by_key_policy
+  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::detail::scan_by_key::scan_by_key_policy
   {
     return {BlockThreads,
             1,

--- a/cub/test/catch2_test_device_scan_by_key_env.cu
+++ b/cub/test/catch2_test_device_scan_by_key_env.cu
@@ -9,9 +9,11 @@ struct stream_registry_factory_t;
 
 #include <cub/device/device_scan.cuh>
 
+#include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/device_vector.h>
 
 #include <cuda/__device/compute_capability.h>
+#include <cuda/__execution/tune.h>
 #include <cuda/__iterator/constant_iterator.h>
 
 #include "catch2_test_env_launch_helper.h"
@@ -123,6 +125,104 @@ TEST_CASE("Device scan inclusive-scan-by-key works with default environment", "[
 }
 
 #endif
+
+#if TEST_LAUNCH != 1
+
+template <int BlockThreads>
+struct scan_by_key_tuning
+{
+  _CCCL_API constexpr auto operator()(cuda::arch_id /*arch*/) const -> cub::detail::scan_by_key::scan_by_key_policy
+  {
+    return {BlockThreads,
+            1,
+            cub::BLOCK_LOAD_DIRECT,
+            cub::LOAD_DEFAULT,
+            cub::BLOCK_STORE_DIRECT,
+            cub::BLOCK_SCAN_WARP_SCANS,
+            {}};
+  }
+};
+
+using block_sizes =
+  c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
+using block_size_extracting_scan_op_t  = block_size_extracting_op<cuda::std::plus<>>;
+using block_size_extracting_equality_t = block_size_extracting_op<cuda::std::equal_to<>>;
+
+C2H_TEST("DeviceScan::ExclusiveSumByKey can be tuned", "[scan][by_key][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<int> d_keys{0, 0, 1, 1, 1, 2, 2};
+  c2h::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
+  c2h::device_vector<int> d_out(7);
+  c2h::device_vector<unsigned int> d_block_size(1);
+
+  auto equality_op = block_size_extracting_equality_t{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env         = cuda::execution::tune(scan_by_key_tuning<target_block_size>{});
+
+  device_scan_exclusive_sum_by_key(d_keys.begin(), d_in.begin(), d_out.begin(), 7, equality_op, env);
+
+  c2h::device_vector<int> expected{0, 8, 0, 7, 12, 0, 0};
+  REQUIRE(d_out == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceScan::ExclusiveScanByKey can be tuned", "[scan][by_key][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<int> d_keys{0, 0, 1, 1, 1, 2, 2};
+  c2h::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
+  c2h::device_vector<int> d_out(7);
+  c2h::device_vector<unsigned int> d_block_size(1);
+
+  auto scan_op = block_size_extracting_scan_op_t{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env     = cuda::execution::tune(scan_by_key_tuning<target_block_size>{});
+
+  device_scan_exclusive_scan_by_key(
+    d_keys.begin(), d_in.begin(), d_out.begin(), scan_op, 0, 7, cuda::std::equal_to<>{}, env);
+
+  c2h::device_vector<int> expected{0, 8, 0, 7, 12, 0, 0};
+  REQUIRE(d_out == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceScan::InclusiveSumByKey can be tuned", "[scan][by_key][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<int> d_keys{0, 0, 1, 1, 1, 2, 2};
+  c2h::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
+  c2h::device_vector<int> d_out(7);
+  c2h::device_vector<unsigned int> d_block_size(1);
+
+  auto equality_op = block_size_extracting_equality_t{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env         = cuda::execution::tune(scan_by_key_tuning<target_block_size>{});
+
+  device_scan_inclusive_sum_by_key(d_keys.begin(), d_in.begin(), d_out.begin(), 7, equality_op, env);
+
+  c2h::device_vector<int> expected{8, 14, 7, 12, 15, 0, 9};
+  REQUIRE(d_out == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceScan::InclusiveScanByKey can be tuned", "[scan][by_key][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<int> d_keys{0, 0, 1, 1, 1, 2, 2};
+  c2h::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
+  c2h::device_vector<int> d_out(7);
+  c2h::device_vector<unsigned int> d_block_size(1);
+
+  auto scan_op = block_size_extracting_scan_op_t{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env     = cuda::execution::tune(scan_by_key_tuning<target_block_size>{});
+
+  device_scan_inclusive_scan_by_key(
+    d_keys.begin(), d_in.begin(), d_out.begin(), scan_op, 7, cuda::std::equal_to<>{}, env);
+
+  c2h::device_vector<int> expected{8, 14, 7, 12, 15, 0, 9};
+  REQUIRE(d_out == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+#endif // TEST_LAUNCH != 1
 
 C2H_TEST("Device scan exclusive-sum-by-key uses environment", "[scan][by_key][device]")
 {

--- a/cub/test/catch2_test_env_launch_helper.h
+++ b/cub/test/catch2_test_env_launch_helper.h
@@ -528,10 +528,7 @@ struct block_size_extracting_op
   template <typename... Ts>
   __device__ auto operator()(Ts&&... args) const -> decltype(InnerOp{}(::cuda::std::forward<Ts>(args)...))
   {
-    if (threadIdx.x == 0)
-    {
-      atomicMax(ptr, blockDim.x);
-    }
+    atomicMax(ptr, blockDim.x); // not every thread may reach this, so avoid guarding the atomic by threadIdx
     return InnerOp{}(::cuda::std::forward<Ts>(args)...);
   }
 };
@@ -557,19 +554,13 @@ struct block_size_extracting_constant_iterator
 
   __device__ reference operator[](difference_type) const
   {
-    if (threadIdx.x == 0)
-    {
-      atomicMax(block_size_ptr, blockDim.x);
-    }
+    atomicMax(block_size_ptr, blockDim.x); // not every thread may reach this, so avoid guarding the atomic by threadIdx
     return value;
   }
 
   __device__ reference operator*() const
   {
-    if (threadIdx.x == 0)
-    {
-      atomicMax(block_size_ptr, blockDim.x);
-    }
+    atomicMax(block_size_ptr, blockDim.x); // not every thread may reach this, so avoid guarding the atomic by threadIdx
     return value;
   }
 

--- a/thrust/thrust/system/cuda/detail/scan_by_key.h
+++ b/thrust/thrust/system/cuda/detail/scan_by_key.h
@@ -60,6 +60,9 @@ _CCCL_HOST_DEVICE ValuesOutIt inclusive_scan_by_key_n(
     return result;
   }
 
+  // FIXME(bgruber): We must override CUB's accumulator type for backward compatibility until CCCL 4.0. Then we should
+  // switch to calling the CUB public API, which uses __accumulator_t. See also:
+  // https://github.com/NVIDIA/cccl/issues/3993
   using accum_t = thrust::detail::it_value_t<ValuesInIt>;
 
   // Convert to raw pointers if possible:

--- a/thrust/thrust/system/cuda/detail/scan_by_key.h
+++ b/thrust/thrust/system/cuda/detail/scan_by_key.h
@@ -60,6 +60,8 @@ _CCCL_HOST_DEVICE ValuesOutIt inclusive_scan_by_key_n(
     return result;
   }
 
+  using accum_t = thrust::detail::it_value_t<ValuesInIt>;
+
   // Convert to raw pointers if possible:
   auto keys_unwrap   = thrust::try_unwrap_contiguous_iterator(keys);
   auto values_unwrap = thrust::try_unwrap_contiguous_iterator(values);
@@ -72,9 +74,18 @@ _CCCL_HOST_DEVICE ValuesOutIt inclusive_scan_by_key_n(
   std::size_t tmp_size = 0;
   THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
     status,
-    cub::DeviceScan::InclusiveScanByKey,
+    cub::detail::scan_by_key::dispatch</* OverrideAccumT = */ accum_t>,
     num_items,
-    (nullptr, tmp_size, keys_unwrap, values_unwrap, result_unwrap, scan_op, num_items_fixed, equality_op, stream));
+    (nullptr,
+     tmp_size,
+     keys_unwrap,
+     values_unwrap,
+     result_unwrap,
+     equality_op,
+     scan_op,
+     cub::NullType{},
+     num_items_fixed,
+     stream));
   thrust::cuda_cub::throw_on_error(
     status,
     "after determining tmp storage "
@@ -87,16 +98,17 @@ _CCCL_HOST_DEVICE ValuesOutIt inclusive_scan_by_key_n(
 
     THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
       status,
-      cub::DeviceScan::InclusiveScanByKey,
+      cub::detail::scan_by_key::dispatch</* OverrideAccumT = */ accum_t>,
       num_items,
       (tmp.data().get(),
        tmp_size,
        keys_unwrap,
        values_unwrap,
        result_unwrap,
-       scan_op,
-       num_items_fixed,
        equality_op,
+       scan_op,
+       cub::NullType{},
+       num_items_fixed,
        stream));
 
     thrust::cuda_cub::throw_on_error(status, "after dispatching inclusive_scan_by_key kernel");
@@ -144,17 +156,17 @@ _CCCL_HOST_DEVICE ValuesOutIt exclusive_scan_by_key_n(
   std::size_t tmp_size = 0;
   THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
     status,
-    cub::DeviceScan::ExclusiveScanByKey,
+    cub::detail::scan_by_key::dispatch</* OverrideAccumT = */ InitValueT>,
     num_items,
     (nullptr,
      tmp_size,
      keys_unwrap,
      values_unwrap,
      result_unwrap,
+     equality_op,
      scan_op,
      init_value,
      num_items_fixed,
-     equality_op,
      stream));
   thrust::cuda_cub::throw_on_error(
     status,
@@ -168,17 +180,17 @@ _CCCL_HOST_DEVICE ValuesOutIt exclusive_scan_by_key_n(
 
     THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
       status,
-      cub::DeviceScan::ExclusiveScanByKey,
+      cub::detail::scan_by_key::dispatch</* OverrideAccumT = */ InitValueT>,
       num_items,
       (tmp.data().get(),
        tmp_size,
        keys_unwrap,
        values_unwrap,
        result_unwrap,
+       equality_op,
        scan_op,
        init_value,
        num_items_fixed,
-       equality_op,
        stream));
 
     thrust::cuda_cub::throw_on_error(status, "after dispatching exclusive_scan_by_key kernel");

--- a/thrust/thrust/system/cuda/detail/scan_by_key.h
+++ b/thrust/thrust/system/cuda/detail/scan_by_key.h
@@ -87,7 +87,7 @@ _CCCL_HOST_DEVICE ValuesOutIt inclusive_scan_by_key_n(
     EqualityOpT,
     ScanOpT,
     cub::NullType,
-    std::uint64_t,
+    cub::detail::choose_offset_t<std::uint64_t>,
     AccumT>;
 
   cudaStream_t stream = thrust::cuda_cub::stream(policy);
@@ -196,7 +196,7 @@ _CCCL_HOST_DEVICE ValuesOutIt exclusive_scan_by_key_n(
     EqualityOpT,
     ScanOpT,
     InitValueT,
-    std::uint64_t,
+    cub::detail::choose_offset_t<std::uint64_t>,
     InitValueT>;
 
   cudaStream_t stream = thrust::cuda_cub::stream(policy);

--- a/thrust/thrust/system/cuda/detail/scan_by_key.h
+++ b/thrust/thrust/system/cuda/detail/scan_by_key.h
@@ -17,8 +17,7 @@
 
 #  include <thrust/system/cuda/config.h>
 
-#  include <cub/device/dispatch/dispatch_scan_by_key.cuh>
-#  include <cub/util_type.cuh>
+#  include <cub/device/device_scan.cuh>
 
 #  include <thrust/detail/temporary_array.h>
 #  include <thrust/functional.h>
@@ -62,80 +61,42 @@ _CCCL_HOST_DEVICE ValuesOutIt inclusive_scan_by_key_n(
   }
 
   // Convert to raw pointers if possible:
-  using KeysInUnwrapIt    = thrust::try_unwrap_contiguous_iterator_t<KeysInIt>;
-  using ValuesInUnwrapIt  = thrust::try_unwrap_contiguous_iterator_t<ValuesInIt>;
-  using ValuesOutUnwrapIt = thrust::try_unwrap_contiguous_iterator_t<ValuesOutIt>;
-  using AccumT            = thrust::detail::it_value_t<ValuesInUnwrapIt>;
-
   auto keys_unwrap   = thrust::try_unwrap_contiguous_iterator(keys);
   auto values_unwrap = thrust::try_unwrap_contiguous_iterator(values);
   auto result_unwrap = thrust::try_unwrap_contiguous_iterator(result);
-
-  using Dispatch32 = cub::DispatchScanByKey<
-    KeysInUnwrapIt,
-    ValuesInUnwrapIt,
-    ValuesOutUnwrapIt,
-    EqualityOpT,
-    ScanOpT,
-    cub::NullType,
-    std::uint32_t,
-    AccumT>;
-  using Dispatch64 = cub::DispatchScanByKey<
-    KeysInUnwrapIt,
-    ValuesInUnwrapIt,
-    ValuesOutUnwrapIt,
-    EqualityOpT,
-    ScanOpT,
-    cub::NullType,
-    cub::detail::choose_offset_t<std::uint64_t>,
-    AccumT>;
 
   cudaStream_t stream = thrust::cuda_cub::stream(policy);
   cudaError_t status{};
 
   // Determine temporary storage requirements:
   std::size_t tmp_size = 0;
-  {
-    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH2(
-      status,
-      Dispatch32::Dispatch,
-      Dispatch64::Dispatch,
-      num_items,
-      (nullptr,
-       tmp_size,
-       keys_unwrap,
-       values_unwrap,
-       result_unwrap,
-       equality_op,
-       scan_op,
-       cub::NullType{},
-       num_items_fixed,
-       stream));
-    thrust::cuda_cub::throw_on_error(
-      status,
-      "after determining tmp storage "
-      "requirements for inclusive_scan_by_key");
-  }
+  THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
+    status,
+    cub::DeviceScan::InclusiveScanByKey,
+    num_items,
+    (nullptr, tmp_size, keys_unwrap, values_unwrap, result_unwrap, scan_op, num_items_fixed, equality_op, stream));
+  thrust::cuda_cub::throw_on_error(
+    status,
+    "after determining tmp storage "
+    "requirements for inclusive_scan_by_key");
 
   // Run scan:
   {
     // Allocate temporary storage:
     thrust::detail::temporary_array<std::uint8_t, Derived> tmp{policy, tmp_size};
 
-    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH2(
+    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
       status,
-      Dispatch32::Dispatch,
-      Dispatch64::Dispatch,
+      cub::DeviceScan::InclusiveScanByKey,
       num_items,
       (tmp.data().get(),
        tmp_size,
        keys_unwrap,
        values_unwrap,
        result_unwrap,
-       equality_op,
        scan_op,
-       cub::NullType{},
        num_items_fixed,
+       equality_op,
        stream));
 
     thrust::cuda_cub::throw_on_error(status, "after dispatching inclusive_scan_by_key kernel");
@@ -172,79 +133,52 @@ _CCCL_HOST_DEVICE ValuesOutIt exclusive_scan_by_key_n(
   }
 
   // Convert to raw pointers if possible:
-  using KeysInUnwrapIt    = thrust::try_unwrap_contiguous_iterator_t<KeysInIt>;
-  using ValuesInUnwrapIt  = thrust::try_unwrap_contiguous_iterator_t<ValuesInIt>;
-  using ValuesOutUnwrapIt = thrust::try_unwrap_contiguous_iterator_t<ValuesOutIt>;
-
   auto keys_unwrap   = thrust::try_unwrap_contiguous_iterator(keys);
   auto values_unwrap = thrust::try_unwrap_contiguous_iterator(values);
   auto result_unwrap = thrust::try_unwrap_contiguous_iterator(result);
-
-  using Dispatch32 = cub::DispatchScanByKey<
-    KeysInUnwrapIt,
-    ValuesInUnwrapIt,
-    ValuesOutUnwrapIt,
-    EqualityOpT,
-    ScanOpT,
-    InitValueT,
-    std::uint32_t,
-    InitValueT>;
-  using Dispatch64 = cub::DispatchScanByKey<
-    KeysInUnwrapIt,
-    ValuesInUnwrapIt,
-    ValuesOutUnwrapIt,
-    EqualityOpT,
-    ScanOpT,
-    InitValueT,
-    cub::detail::choose_offset_t<std::uint64_t>,
-    InitValueT>;
 
   cudaStream_t stream = thrust::cuda_cub::stream(policy);
   cudaError_t status{};
 
   // Determine temporary storage requirements:
   std::size_t tmp_size = 0;
-  {
-    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH2(
-      status,
-      Dispatch32::Dispatch,
-      Dispatch64::Dispatch,
-      num_items,
-      (nullptr,
-       tmp_size,
-       keys_unwrap,
-       values_unwrap,
-       result_unwrap,
-       equality_op,
-       scan_op,
-       init_value,
-       num_items_fixed,
-       stream));
-    thrust::cuda_cub::throw_on_error(
-      status,
-      "after determining tmp storage "
-      "requirements for exclusive_scan_by_key");
-  }
+  THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
+    status,
+    cub::DeviceScan::ExclusiveScanByKey,
+    num_items,
+    (nullptr,
+     tmp_size,
+     keys_unwrap,
+     values_unwrap,
+     result_unwrap,
+     scan_op,
+     init_value,
+     num_items_fixed,
+     equality_op,
+     stream));
+  thrust::cuda_cub::throw_on_error(
+    status,
+    "after determining tmp storage "
+    "requirements for exclusive_scan_by_key");
 
   // Run scan:
   {
     // Allocate temporary storage:
     thrust::detail::temporary_array<std::uint8_t, Derived> tmp{policy, tmp_size};
 
-    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH2(
+    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
       status,
-      Dispatch32::Dispatch,
-      Dispatch64::Dispatch,
+      cub::DeviceScan::ExclusiveScanByKey,
       num_items,
       (tmp.data().get(),
        tmp_size,
        keys_unwrap,
        values_unwrap,
        result_unwrap,
-       equality_op,
        scan_op,
        init_value,
        num_items_fixed,
+       equality_op,
        stream));
 
     thrust::cuda_cub::throw_on_error(status, "after dispatching exclusive_scan_by_key kernel");

--- a/thrust/thrust/system/cuda/detail/scan_by_key.h
+++ b/thrust/thrust/system/cuda/detail/scan_by_key.h
@@ -72,24 +72,26 @@ _CCCL_HOST_DEVICE ValuesOutIt inclusive_scan_by_key_n(
 
   // Determine temporary storage requirements:
   std::size_t tmp_size = 0;
-  THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
-    status,
-    cub::detail::scan_by_key::dispatch</* OverrideAccumT = */ accum_t>,
-    num_items,
-    (nullptr,
-     tmp_size,
-     keys_unwrap,
-     values_unwrap,
-     result_unwrap,
-     equality_op,
-     scan_op,
-     cub::NullType{},
-     num_items_fixed,
-     stream));
-  thrust::cuda_cub::throw_on_error(
-    status,
-    "after determining tmp storage "
-    "requirements for inclusive_scan_by_key");
+  {
+    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
+      status,
+      cub::detail::scan_by_key::dispatch</* OverrideAccumT = */ accum_t>,
+      num_items,
+      (nullptr,
+       tmp_size,
+       keys_unwrap,
+       values_unwrap,
+       result_unwrap,
+       equality_op,
+       scan_op,
+       cub::NullType{},
+       num_items_fixed,
+       stream));
+    thrust::cuda_cub::throw_on_error(
+      status,
+      "after determining tmp storage "
+      "requirements for inclusive_scan_by_key");
+  }
 
   // Run scan:
   {
@@ -154,24 +156,26 @@ _CCCL_HOST_DEVICE ValuesOutIt exclusive_scan_by_key_n(
 
   // Determine temporary storage requirements:
   std::size_t tmp_size = 0;
-  THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
-    status,
-    cub::detail::scan_by_key::dispatch</* OverrideAccumT = */ InitValueT>,
-    num_items,
-    (nullptr,
-     tmp_size,
-     keys_unwrap,
-     values_unwrap,
-     result_unwrap,
-     equality_op,
-     scan_op,
-     init_value,
-     num_items_fixed,
-     stream));
-  thrust::cuda_cub::throw_on_error(
-    status,
-    "after determining tmp storage "
-    "requirements for exclusive_scan_by_key");
+  {
+    THRUST_UNSIGNED_INDEX_TYPE_DISPATCH(
+      status,
+      cub::detail::scan_by_key::dispatch</* OverrideAccumT = */ InitValueT>,
+      num_items,
+      (nullptr,
+       tmp_size,
+       keys_unwrap,
+       values_unwrap,
+       result_unwrap,
+       equality_op,
+       scan_op,
+       init_value,
+       num_items_fixed,
+       stream));
+    thrust::cuda_cub::throw_on_error(
+      status,
+      "after determining tmp storage "
+      "requirements for exclusive_scan_by_key");
+  }
 
   // Run scan:
   {


### PR DESCRIPTION
- [x] No SASS changes for `cub.bench.scan.exclusive.by_key.base` on SM`100;90;86;80;75`
- [x] No SASS changes for `thrust.test.scan_by_key` on SM`100;90;86;80;75`

Fixes: #8436 
