### PR TITLE
[cudax] Implement `composite_mapping` for groups

### DIFF
--- a/cudax/include/cuda/experimental/__group/fwd.cuh
+++ b/cudax/include/cuda/experimental/__group/fwd.cuh
@@ -97,6 +97,13 @@ inline constexpr bool __is_this_group_v<this_cluster<_Hierarchy>> = true;
 template <class _Hierarchy>
 inline constexpr bool __is_this_group_v<this_grid<_Hierarchy>> = true;
 
+template <class _Tp>
+inline constexpr bool __is_group_mapping_v = false;
+template <::cuda::std::size_t _Count, bool _IsExhaustive>
+inline constexpr bool __is_group_mapping_v<group_by<_Count, _IsExhaustive>> = true;
+template <class _Data, bool _IsExhaustive>
+inline constexpr bool __is_group_mapping_v<group_as<_Data, _IsExhaustive>> = true;
+
 // tags
 
 struct non_exhaustive_t;

--- a/cudax/include/cuda/experimental/__group/mapping/composite_mapping.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/composite_mapping.cuh
@@ -1,0 +1,140 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_EXPERIMENTAL___GROUP_MAPPING_COMPOSITE_MAPPING_CUH
+#define _CUDA_EXPERIMENTAL___GROUP_MAPPING_COMPOSITE_MAPPING_CUH
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__type_traits/fold.h>
+#include <cuda/std/__type_traits/is_nothrow_copy_constructible.h>
+#include <cuda/std/tuple>
+
+#include <cuda/experimental/__group/fwd.cuh>
+#include <cuda/experimental/__group/queries.cuh>
+#include <cuda/experimental/__group/traits.cuh>
+
+#include <cuda/std/__cccl/prologue.h>
+
+#if !defined(_CCCL_DOXYGEN_INVOKED)
+
+// todo(dabayer): do we want to always use uint32_t for all counts/ranks?
+
+namespace cuda::experimental
+{
+template <class... _Mappings>
+class composite_mapping
+{
+  ::cuda::std::tuple<_Mappings...> __mappings_;
+
+  template <::cuda::std::size_t _Ip = 0, class _ParentGroup, class _PrevMappingResult>
+  [[nodiscard]] _CCCL_DEVICE_API auto
+  __map_impl(const _ParentGroup& __parent, const _PrevMappingResult& __prev_mapping_result) const noexcept
+  {
+    const auto __result = ::cuda::std::get<_Ip>(__mappings_).map(__parent, __prev_mapping_result);
+    if constexpr (_Ip + 1 < sizeof...(_Mappings))
+    {
+      return __map_impl<_Ip + 1>(__parent, __result);
+    }
+    else
+    {
+      return __result;
+    }
+  }
+
+public:
+  _CCCL_DEVICE_API constexpr composite_mapping(const _Mappings&... __mappings) noexcept(
+    ::cuda::std::__fold_and_v<::cuda::std::is_nothrow_copy_constructible_v<_Mappings>...>)
+      : __mappings_{__mappings...}
+  {}
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr const ::cuda::std::tuple<_Mappings...>& get() const noexcept
+  {
+    return __mappings_;
+  }
+
+  template <class _ParentGroup, class _PrevMappingResult>
+  [[nodiscard]] _CCCL_DEVICE_API auto
+  map(const _ParentGroup& __parent, const _PrevMappingResult& __prev_mapping_result) const noexcept
+  {
+    return __map_impl(__parent, __prev_mapping_result);
+  }
+};
+
+template <class... _Mappings>
+_CCCL_DEVICE composite_mapping(const _Mappings&...) -> composite_mapping<_Mappings...>;
+
+_CCCL_TEMPLATE(class _Lhs, class _Rhs)
+_CCCL_REQUIRES(__is_group_mapping_v<_Lhs> _CCCL_AND __is_group_mapping_v<_Rhs>)
+[[nodiscard]] _CCCL_DEVICE_API constexpr composite_mapping<_Lhs, _Rhs>
+operator|(const _Lhs& __lhs, const _Rhs& __rhs) noexcept(
+  ::cuda::std::is_nothrow_constructible_v<composite_mapping<_Lhs, _Rhs>, const _Lhs&, const _Rhs&>)
+{
+  return {__lhs, __rhs};
+}
+
+_CCCL_TEMPLATE(class... _LhsMappings, class _Rhs)
+_CCCL_REQUIRES(__is_group_mapping_v<_Rhs>)
+[[nodiscard]] _CCCL_DEVICE_API constexpr composite_mapping<_LhsMappings..., _Rhs>
+operator|(const composite_mapping<_LhsMappings...>& __lhs, const _Rhs& __rhs) noexcept(
+  ::cuda::std::is_nothrow_constructible_v<composite_mapping<_LhsMappings..., _Rhs>, const _LhsMappings&..., const _Rhs&>)
+{
+  return ::cuda::std::apply(
+    [&](const auto&... __lhs_mappings) {
+      return composite_mapping{__lhs_mappings..., __rhs};
+    },
+    __lhs.get());
+}
+
+_CCCL_TEMPLATE(class _Lhs, class... _RhsMappings)
+_CCCL_REQUIRES(__is_group_mapping_v<_Lhs>)
+[[nodiscard]] _CCCL_DEVICE_API constexpr composite_mapping<_Lhs, _RhsMappings...>
+operator|(const _Lhs& __lhs, const composite_mapping<_RhsMappings...>& __rhs) noexcept(
+  ::cuda::std::is_nothrow_constructible_v<composite_mapping<_Lhs, _RhsMappings...>, const _Lhs&, const _RhsMappings&...>)
+{
+  return ::cuda::std::apply(
+    [&](const auto&... __rhs_mappings) {
+      return composite_mapping{__lhs, __rhs_mappings...};
+    },
+    __rhs.get());
+}
+
+template <class... _LhsMappings, class... _RhsMappings>
+[[nodiscard]] _CCCL_DEVICE_API constexpr composite_mapping<_LhsMappings..., _RhsMappings...>
+operator|(const composite_mapping<_LhsMappings...>& __lhs, const composite_mapping<_RhsMappings...>& __rhs) noexcept(
+  ::cuda::std::is_nothrow_constructible_v<composite_mapping<_LhsMappings..., _RhsMappings...>,
+                                          const _LhsMappings&...,
+                                          const _RhsMappings&...>)
+{
+  return ::cuda::std::apply(
+    [&](const auto&... __lhs_mappings) {
+      return ::cuda::std::apply(
+        [&](const auto&... __rhs_mappings) {
+          return composite_mapping{__lhs_mappings..., __rhs_mappings...};
+        },
+        __rhs.get());
+    },
+    __lhs.get());
+}
+} // namespace cuda::experimental
+
+#endif // !_CCCL_DOXYGEN_INVOKED
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_EXPERIMENTAL___GROUP_MAPPING_COMPOSITE_MAPPING_CUH

--- a/cudax/include/cuda/experimental/group.cuh
+++ b/cudax/include/cuda/experimental/group.cuh
@@ -25,6 +25,7 @@
 #include <cuda/experimental/__group/fwd.cuh>
 #include <cuda/experimental/__group/group.cuh>
 #include <cuda/experimental/__group/implicit_hierarchy.cuh>
+#include <cuda/experimental/__group/mapping/composite_mapping.cuh>
 #include <cuda/experimental/__group/mapping/group_as.cuh>
 #include <cuda/experimental/__group/mapping/group_by.cuh>
 #include <cuda/experimental/__group/queries.cuh>

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -129,6 +129,11 @@ cudax_add_catch2_test(test_target algorithm
     algorithm/copy.cu
 )
 
+cudax_add_catch2_test(test_target group.mapping.composite_mapping
+    group/mapping/composite_mapping.cu
+)
+target_compile_definitions(${test_target} PUBLIC _CUDAX_GROUP)
+
 cudax_add_catch2_test(test_target group.mapping.group_as
     group/mapping/group_as.cu
 )

--- a/cudax/test/group/mapping/composite_mapping.cu
+++ b/cudax/test/group/mapping/composite_mapping.cu
@@ -1,0 +1,191 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/devices>
+#include <cuda/hierarchy>
+#include <cuda/launch>
+#include <cuda/std/cstddef>
+#include <cuda/std/numeric>
+#include <cuda/std/tuple>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+#include <cuda/stream>
+
+#include <cuda/experimental/group.cuh>
+
+#include "group_testing.cuh"
+
+namespace
+{
+template <class Mapping1, class Mapping2, class Config>
+__device__ void test_composite_mapping(const Mapping1& mapping1, const Mapping2& mapping2, Config config)
+{
+  using Mapping = cudax::composite_mapping<Mapping1, Mapping2>;
+
+  // Test construction from 2 mappings.
+  {
+    cudax::composite_mapping mapping{mapping1, mapping2};
+    static_assert(cuda::std::is_same_v<decltype(mapping), Mapping>);
+    static_assert(cuda::std::is_nothrow_constructible_v<Mapping, Mapping1, Mapping2>
+                  == (cuda::std::is_nothrow_copy_constructible_v<Mapping1>
+                      && cuda::std::is_nothrow_copy_constructible_v<Mapping2>) );
+  }
+
+  // Test get().
+  {
+    const cudax::composite_mapping mapping{mapping1, mapping2};
+    static_assert(cuda::std::is_same_v<decltype(mapping.get()), const cuda::std::tuple<Mapping1, Mapping2>&>);
+    static_assert(noexcept(mapping.get()));
+
+    const auto& mapping1_ref = cuda::std::get<0>(mapping.get());
+    CUDAX_CHECK(mapping1_ref.count() == 4);
+
+    const auto& mapping2_ref = cuda::std::get<1>(mapping.get());
+    CUDAX_CHECK(mapping2_ref.count(0) == 1);
+    CUDAX_CHECK(mapping2_ref.count(1) == 3);
+  }
+
+  // Test map(...).
+  {
+    const cudax::this_warp parent_group{config};
+    const ThreadsInWarpMappingResult prev_mapping_result;
+    const cudax::composite_mapping mapping{mapping1, mapping2};
+
+    static_assert(cudax::__group_mapping_result<decltype(mapping.map(parent_group, prev_mapping_result))>);
+
+    auto result  = mapping.map(parent_group, prev_mapping_result);
+    using Result = decltype(result);
+
+    const auto rank_in_warp = cuda::gpu_thread.rank_as<unsigned>(parent_group);
+
+    if constexpr (Mapping1::static_count() != cuda::std::dynamic_extent
+                  && Mapping2::static_group_count() != cuda::std::dynamic_extent)
+    {
+      static_assert(Result::static_group_count() == 16);
+    }
+    else
+    {
+      static_assert(Result::static_group_count() == cuda::std::dynamic_extent);
+    }
+    CUDAX_CHECK(result.group_count() == 16);
+    CUDAX_CHECK(result.group_rank() == (rank_in_warp / 4 * 2 + (rank_in_warp % 4 > 0)));
+
+    static_assert(Result::static_count() == cuda::std::dynamic_extent);
+    CUDAX_CHECK(result.count() == ((rank_in_warp % 4 > 0) ? 3 : 1));
+    CUDAX_CHECK(result.rank() == ((rank_in_warp % 4 > 0) ? (rank_in_warp % 4 - 1) : 0));
+
+    CUDAX_CHECK(result.is_valid());
+    static_assert(Result::is_always_exhaustive());
+    static_assert(Result::is_always_contiguous());
+  }
+
+  // Test operator|.
+  {
+    auto mapping = mapping1 | mapping2;
+
+    static_assert(cuda::std::is_same_v<Mapping, decltype(mapping)>);
+    static_assert(noexcept(mapping1 | mapping2));
+
+    const auto& mapping1_ref = cuda::std::get<0>(mapping.get());
+    CUDAX_CHECK(mapping1_ref.count() == 4);
+
+    const auto& mapping2_ref = cuda::std::get<1>(mapping.get());
+    CUDAX_CHECK(mapping2_ref.count(0) == 1);
+    CUDAX_CHECK(mapping2_ref.count(1) == 3);
+  }
+  {
+    auto mapping = cudax::composite_mapping{mapping1} | mapping2;
+
+    static_assert(cuda::std::is_same_v<Mapping, decltype(mapping)>);
+    static_assert(noexcept(cudax::composite_mapping{mapping1} | mapping2));
+
+    const auto& mapping1_ref = cuda::std::get<0>(mapping.get());
+    CUDAX_CHECK(mapping1_ref.count() == 4);
+
+    const auto& mapping2_ref = cuda::std::get<1>(mapping.get());
+    CUDAX_CHECK(mapping2_ref.count(0) == 1);
+    CUDAX_CHECK(mapping2_ref.count(1) == 3);
+  }
+  {
+    auto mapping = mapping1 | cudax::composite_mapping{mapping2};
+
+    static_assert(cuda::std::is_same_v<Mapping, decltype(mapping)>);
+    static_assert(noexcept(mapping1 | cudax::composite_mapping{mapping2}));
+
+    const auto& mapping1_ref = cuda::std::get<0>(mapping.get());
+    CUDAX_CHECK(mapping1_ref.count() == 4);
+
+    const auto& mapping2_ref = cuda::std::get<1>(mapping.get());
+    CUDAX_CHECK(mapping2_ref.count(0) == 1);
+    CUDAX_CHECK(mapping2_ref.count(1) == 3);
+  }
+  {
+    auto mapping = cudax::composite_mapping{mapping1} | cudax::composite_mapping{mapping2};
+
+    static_assert(cuda::std::is_same_v<Mapping, decltype(mapping)>);
+    static_assert(noexcept(cudax::composite_mapping{mapping1} | cudax::composite_mapping{mapping2}));
+
+    const auto& mapping1_ref = cuda::std::get<0>(mapping.get());
+    CUDAX_CHECK(mapping1_ref.count() == 4);
+
+    const auto& mapping2_ref = cuda::std::get<1>(mapping.get());
+    CUDAX_CHECK(mapping2_ref.count(0) == 1);
+    CUDAX_CHECK(mapping2_ref.count(1) == 3);
+  }
+}
+
+struct TestKernel
+{
+  template <class Config>
+  __device__ void operator()(const Config& config)
+  {
+    {
+      const cudax::group_by<4> mapping1{};
+      const cudax::group_as mapping2{cuda::std::integer_sequence<cuda::std::size_t, 1, 3>{}};
+      test_composite_mapping(mapping1, mapping2, config);
+    }
+    {
+      const cudax::group_by mapping1{4};
+      const cudax::group_as mapping2{cuda::std::integer_sequence<cuda::std::size_t, 1, 3>{}};
+      test_composite_mapping(mapping1, mapping2, config);
+    }
+    {
+      const cudax::group_by<4> mapping1{};
+      constexpr unsigned counts2[]{1, 3};
+      const cudax::group_as mapping2{counts2};
+      test_composite_mapping(mapping1, mapping2, config);
+    }
+    {
+      const cudax::group_by mapping1{4};
+      constexpr unsigned counts2[]{1, 3};
+      const cudax::group_as mapping2{counts2};
+      test_composite_mapping(mapping1, mapping2, config);
+    }
+  }
+};
+} // namespace
+
+C2H_TEST("Composite mapping", "[group]")
+{
+  const auto device = cuda::devices[0];
+
+  const cuda::stream stream{device};
+
+  {
+    const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims<8, 4>());
+    cuda::launch(stream, config, TestKernel{});
+  }
+  {
+    const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims(dim3{8, 4}));
+    cuda::launch(stream, config, TestKernel{});
+  }
+
+  stream.sync();
+}


### PR DESCRIPTION
This PR implements `cudax::composite_mapping` that allows to combine multiple mappings into one. This can allow the user to skip creating intermediate groups and allows much more flexibility. Users are not expected to create the `composite_mapping` instance directly, but rather by using the pipe operator `|`. For example:
```cpp
cudax::group g{cuda::gpu_thread, cuda::this_warp{config}, cudax::group_by<4>{} | cudax::group_as<1, 3>{}, cudax::lane_synchronizer{});
```
Splits warp into `16` groups of counts `1` or `3`.

Depends on #8755