### PR TITLE
Add `__lazy_call_or`

### DIFF
--- a/libcudacxx/include/cuda/__functional/lazy_call_or.h
+++ b/libcudacxx/include/cuda/__functional/lazy_call_or.h
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___FUNCTIONAL_LAZY_CALL_OR_H
+#define _CUDA___FUNCTIONAL_LAZY_CALL_OR_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__tuple_dir/ignore.h>
+#include <cuda/std/__type_traits/is_callable.h>
+#include <cuda/std/__utility/forward.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+_CCCL_BEGIN_NAMESPACE_CPO(__lazy_call_or_ns)
+//! @brief `__lazy_call_or` is like `__call_or` except that the fallback value is computed
+//! lazily.
+//!
+//! The fallback value must be a functor that takes no arguments and returns a single
+//! value. The type of the returned fallback value need not be the same as the type of the
+//! computed value.
+struct __fn
+{
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _Fn, class _FallbackCallable, class... _Args)
+  _CCCL_REQUIRES(::cuda::std::__is_callable_v<_Fn, _Args...>)
+  _CCCL_API constexpr auto operator()(_Fn __fn, _FallbackCallable&&, _Args&&... __args) const
+    noexcept(::cuda::std::__is_nothrow_callable_v<_Fn, _Args...>) -> ::cuda::std::__call_result_t<_Fn, _Args...>
+  {
+    return __fn(::cuda::std::forward<_Args>(__args)...);
+  }
+
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _FallbackCallable, class... _Args>
+  _CCCL_API constexpr auto operator()(::cuda::std::__ignore_t, _FallbackCallable&& __fallback, _Args&&...) const
+    noexcept(::cuda::std::__is_nothrow_callable_v<_FallbackCallable>) -> ::cuda::std::__call_result_t<_FallbackCallable>
+  {
+    return ::cuda::std::forward<_FallbackCallable>(__fallback)();
+  }
+};
+_CCCL_END_NAMESPACE_CPO
+
+inline namespace __cpo
+{
+_CCCL_GLOBAL_CONSTANT auto __lazy_call_or = __lazy_call_or_ns::__fn{};
+} // namespace __cpo
+
+template <class _Fn, class _FallbackCallable, class... _Args>
+using __lazy_call_result_or_t _CCCL_NODEBUG_ALIAS =
+  ::cuda::std::__call_result_t<__lazy_call_or_ns::__fn, _Fn, _FallbackCallable, _Args...>;
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___FUNCTIONAL_LAZY_CALL_OR_H

--- a/libcudacxx/test/libcudacxx/cuda/functional/lazy_call_or.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/lazy_call_or.pass.cpp
@@ -1,0 +1,158 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/__functional/lazy_call_or.h>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+struct plus_one
+{
+  TEST_FUNC constexpr int operator()(int value) const noexcept
+  {
+    return value + 1;
+  }
+};
+
+struct throwing_plus_one
+{
+  TEST_FUNC constexpr int operator()(int value) const noexcept(false)
+  {
+    return value + 1;
+  }
+};
+
+struct fallback_long
+{
+  TEST_FUNC constexpr long operator()() const noexcept
+  {
+    return 13L;
+  }
+};
+
+struct throwing_fallback
+{
+  TEST_FUNC constexpr long operator()() const noexcept(false)
+  {
+    return 13L;
+  }
+};
+
+struct fallback_value_category
+{
+  TEST_FUNC constexpr int operator()() & noexcept
+  {
+    return 41;
+  }
+
+  TEST_FUNC constexpr int operator()() && noexcept
+  {
+    return 42;
+  }
+};
+
+struct counting_fallback
+{
+  int* calls_;
+
+  TEST_FUNC constexpr int operator()() const noexcept
+  {
+    ++*calls_;
+    return 13;
+  }
+};
+
+struct arg
+{
+  int value_;
+};
+
+struct value_category_fn
+{
+  TEST_FUNC constexpr int operator()(arg& value) const noexcept
+  {
+    return value.value_;
+  }
+
+  TEST_FUNC constexpr int operator()(arg&& value) const noexcept
+  {
+    return value.value_ + 1;
+  }
+};
+
+TEST_FUNC constexpr void test_call_result()
+{
+  static_assert(cuda::std::is_same_v<decltype(cuda::__lazy_call_or(plus_one{}, fallback_long{}, 41)), int>);
+  static_assert(cuda::std::is_same_v<decltype(cuda::__lazy_call_or(cuda::std::ignore, fallback_long{}, 41)), long>);
+
+  static_assert(cuda::std::is_same_v<cuda::__lazy_call_result_or_t<plus_one, fallback_long, int>, int>);
+  static_assert(cuda::std::is_same_v<cuda::__lazy_call_result_or_t<cuda::std::__ignore_t, fallback_long, int>, long>);
+}
+
+TEST_FUNC constexpr void test_noexcept()
+{
+  static_assert(noexcept(cuda::__lazy_call_or(plus_one{}, throwing_fallback{}, 41)));
+  static_assert(noexcept(cuda::__lazy_call_or(cuda::std::ignore, fallback_long{}, 41)));
+  // MSVC 19.39 and GCC 9 and lower compute the wrong answer for these
+#if (TEST_COMPILER(MSVC, <=, 19, 39) || TEST_COMPILER(GCC, <=, 9)) && (TEST_STD_VER <= 2017)
+#  define WRONG_ANSWER
+#endif // (msvc-19.39- || gcc-9-) && cpp17
+
+#ifndef WRONG_ANSWER
+  static_assert(!noexcept(cuda::__lazy_call_or(throwing_plus_one{}, fallback_long{}, 41)));
+  static_assert(!noexcept(cuda::__lazy_call_or(cuda::std::ignore, throwing_fallback{}, 41)));
+#endif // !WRONG_ANSWER
+}
+
+TEST_FUNC constexpr void test_constexpr()
+{
+  static_assert(cuda::__lazy_call_or(plus_one{}, fallback_long{}, 41) == 42);
+  static_assert(cuda::__lazy_call_or(cuda::std::ignore, fallback_long{}, 41) == 13L);
+  // lvalue arg forwarding
+  {
+    fallback_value_category fallback{};
+    static_assert(cuda::__lazy_call_or(cuda::std::ignore, fallback, 0) == 41);
+    arg value{41};
+    // must be assert() because value is not constexpr
+    assert(cuda::__lazy_call_or(value_category_fn{}, fallback_long{}, value) == 41);
+    assert(cuda::__lazy_call_or(value_category_fn{}, fallback_long{}, ::cuda::std::move(value)) == 42);
+  }
+  static_assert(cuda::__lazy_call_or(value_category_fn{}, fallback_long{}, arg{41}) == 42);
+  static_assert(cuda::__lazy_call_or(cuda::std::ignore, fallback_value_category{}, 0) == 42);
+}
+
+TEST_FUNC constexpr void test_lazy_evaluation()
+{
+  int fallback_calls = 0;
+  counting_fallback fallback{&fallback_calls};
+
+  static_assert(cuda::__lazy_call_or(plus_one{}, fallback, 41) == 42);
+  assert(fallback_calls == 0);
+
+  assert(cuda::__lazy_call_or(cuda::std::ignore, fallback, 41) == 13);
+  assert(fallback_calls == 1);
+}
+
+TEST_FUNC constexpr bool test()
+{
+  test_call_result();
+  test_noexcept();
+  test_constexpr();
+  test_lazy_evaluation();
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/functional/lazy_call_or.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/lazy_call_or.pass.cpp
@@ -101,15 +101,12 @@ TEST_FUNC constexpr void test_noexcept()
 {
   static_assert(noexcept(cuda::__lazy_call_or(plus_one{}, throwing_fallback{}, 41)));
   static_assert(noexcept(cuda::__lazy_call_or(cuda::std::ignore, fallback_long{}, 41)));
-  // MSVC 19.39 and GCC 9 and lower compute the wrong answer for these
-#if (TEST_COMPILER(MSVC, <=, 19, 39) || TEST_COMPILER(GCC, <=, 9)) && (TEST_STD_VER <= 2017)
-#  define WRONG_ANSWER
-#endif // (msvc-19.39- || gcc-9-) && cpp17
 
-#ifndef WRONG_ANSWER
+  // MSVC 19.39 and GCC 9 and lower compute the wrong answer for these
+#if !((TEST_COMPILER(MSVC, <=, 19, 39) || TEST_COMPILER(GCC, <=, 9)) && (TEST_STD_VER <= 2017))
   static_assert(!noexcept(cuda::__lazy_call_or(throwing_plus_one{}, fallback_long{}, 41)));
   static_assert(!noexcept(cuda::__lazy_call_or(cuda::std::ignore, throwing_fallback{}, 41)));
-#endif // !WRONG_ANSWER
+#endif // !((msvc-19.39- || gcc-9-) && cpp17)
 }
 
 TEST_FUNC constexpr void test_constexpr()


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

Add `cuda::__lazy_call_or`, which acts like `cuda::__call_or` except that the default value is lazily computed.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conditional callable invocation utility with lazy fallback evaluation support, enabling deferred callable selection based on runtime conditions.

* **Tests**
  * Added comprehensive test suite validating the new utility's behavior, including noexcept correctness, constexpr compatibility, and lazy evaluation semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->