### PR TITLE
[thrust] Fix is_partitioned with non-const predicates

### DIFF
--- a/thrust/testing/cuda/is_partitioned.cu
+++ b/thrust/testing/cuda/is_partitioned.cu
@@ -2,15 +2,9 @@
 #include <thrust/functional.h>
 #include <thrust/partition.h>
 
-#include <unittest/unittest.h>
+#include <cuda/std/utility>
 
-#ifdef THRUST_TEST_DEVICE_SIDE
-template <typename ExecutionPolicy, typename Iterator, typename Predicate, typename Iterator2>
-__global__ void
-is_partitioned_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Predicate pred, Iterator2 result)
-{
-  *result = thrust::is_partitioned(exec, first, last, pred);
-}
+#include <unittest/unittest.h>
 
 template <typename T>
 struct is_even
@@ -20,6 +14,14 @@ struct is_even
     return ((int) x % 2) == 0;
   }
 };
+
+#ifdef THRUST_TEST_DEVICE_SIDE
+template <typename ExecutionPolicy, typename Iterator, typename Predicate, typename Iterator2>
+__global__ void
+is_partitioned_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Predicate pred, Iterator2 result)
+{
+  *result = thrust::is_partitioned(exec, first, last, pred);
+}
 
 template <typename ExecutionPolicy>
 void TestIsPartitionedDevice(ExecutionPolicy exec)
@@ -110,3 +112,38 @@ void TestIsPartitionedCudaStreams()
   cudaStreamDestroy(s);
 }
 DECLARE_UNITTEST(TestIsPartitionedCudaStreams);
+
+// Wraps a callable with a non-const operator() so the predicate becomes
+// non-const-callable. is_partitioned must accept such predicates;
+// do not add const to operator() — that would defeat the test.
+template <typename F>
+struct NonConstAdapter
+{
+  F f;
+
+  NonConstAdapter(const F& func)
+      : f(func)
+  {}
+
+  template <typename... Args>
+  _CCCL_HOST_DEVICE auto operator()(Args&&... args) -> decltype(f(cuda::std::forward<Args>(args)...))
+  {
+    return f(cuda::std::forward<Args>(args)...);
+  }
+};
+
+void TestIsPartitionedWithNonConstPredicate()
+{
+  thrust::device_vector<int> partitioned   = {0, 2, 4, 1, 3, 5};
+  thrust::device_vector<int> unpartitioned = {0, 1, 2, 3};
+
+  using Adapter = NonConstAdapter<is_even<int>>;
+
+  ASSERT_EQUAL_QUIET(
+    true, thrust::is_partitioned(thrust::cuda::par, partitioned.begin(), partitioned.end(), Adapter{is_even<int>{}}));
+
+  ASSERT_EQUAL_QUIET(
+    false,
+    thrust::is_partitioned(thrust::cuda::par, unpartitioned.begin(), unpartitioned.end(), Adapter{is_even<int>{}}));
+}
+DECLARE_UNITTEST(TestIsPartitionedWithNonConstPredicate);

--- a/thrust/testing/cuda/is_partitioned.cu
+++ b/thrust/testing/cuda/is_partitioned.cu
@@ -2,9 +2,15 @@
 #include <thrust/functional.h>
 #include <thrust/partition.h>
 
-#include <cuda/std/utility>
-
 #include <unittest/unittest.h>
+
+#ifdef THRUST_TEST_DEVICE_SIDE
+template <typename ExecutionPolicy, typename Iterator, typename Predicate, typename Iterator2>
+__global__ void
+is_partitioned_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Predicate pred, Iterator2 result)
+{
+  *result = thrust::is_partitioned(exec, first, last, pred);
+}
 
 template <typename T>
 struct is_even
@@ -14,14 +20,6 @@ struct is_even
     return ((int) x % 2) == 0;
   }
 };
-
-#ifdef THRUST_TEST_DEVICE_SIDE
-template <typename ExecutionPolicy, typename Iterator, typename Predicate, typename Iterator2>
-__global__ void
-is_partitioned_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Predicate pred, Iterator2 result)
-{
-  *result = thrust::is_partitioned(exec, first, last, pred);
-}
 
 template <typename ExecutionPolicy>
 void TestIsPartitionedDevice(ExecutionPolicy exec)
@@ -113,22 +111,12 @@ void TestIsPartitionedCudaStreams()
 }
 DECLARE_UNITTEST(TestIsPartitionedCudaStreams);
 
-// Wraps a callable with a non-const operator() so the predicate becomes
-// non-const-callable. is_partitioned must accept such predicates;
-// do not add const to operator() — that would defeat the test.
-template <typename F>
-struct NonConstAdapter
+template <typename T>
+struct is_even_non_const
 {
-  F f;
-
-  NonConstAdapter(const F& func)
-      : f(func)
-  {}
-
-  template <typename... Args>
-  _CCCL_HOST_DEVICE auto operator()(Args&&... args) -> decltype(f(cuda::std::forward<Args>(args)...))
+  _CCCL_HOST_DEVICE bool operator()(T x) // no const
   {
-    return f(cuda::std::forward<Args>(args)...);
+    return ((int) x % 2) == 0;
   }
 };
 
@@ -137,13 +125,11 @@ void TestIsPartitionedWithNonConstPredicate()
   thrust::device_vector<int> partitioned   = {0, 2, 4, 1, 3, 5};
   thrust::device_vector<int> unpartitioned = {0, 1, 2, 3};
 
-  using Adapter = NonConstAdapter<is_even<int>>;
-
   ASSERT_EQUAL_QUIET(
-    true, thrust::is_partitioned(thrust::cuda::par, partitioned.begin(), partitioned.end(), Adapter{is_even<int>{}}));
+    true, thrust::is_partitioned(thrust::cuda::par, partitioned.begin(), partitioned.end(), is_even_non_const<int>{}));
 
   ASSERT_EQUAL_QUIET(
     false,
-    thrust::is_partitioned(thrust::cuda::par, unpartitioned.begin(), unpartitioned.end(), Adapter{is_even<int>{}}));
+    thrust::is_partitioned(thrust::cuda::par, unpartitioned.begin(), unpartitioned.end(), is_even_non_const<int>{}));
 }
 DECLARE_UNITTEST(TestIsPartitionedWithNonConstPredicate);

--- a/thrust/thrust/system/cuda/detail/partition.h
+++ b/thrust/thrust/system/cuda/detail/partition.h
@@ -377,8 +377,10 @@ struct __is_partitioned_fn
 {
   Predicate pred_;
 
+  // Not const-qualified: a const operator() would propagate const onto pred_
+  // and reject predicates whose own operator() is non-const (Thrust permits these).
   template <class Tuple>
-  [[nodiscard]] _CCCL_HOST_DEVICE bool operator()(const Tuple& tuple) const
+  [[nodiscard]] _CCCL_HOST_DEVICE bool operator()(const Tuple& tuple)
   {
     const bool lhs = pred_(thrust::raw_reference_cast(::cuda::std::get<0>(tuple)));
     const bool rhs = pred_(thrust::raw_reference_cast(::cuda::std::get<1>(tuple)));


### PR DESCRIPTION
## What

`thrust::is_partitioned` on the CUDA backend rejects predicates whose `operator()` is not const-qualified.

The compile error reported in #8714:

```
.../partition.h(383): error: no instance of function template "MyPred::operator()" matches
  the argument list and object (the object has type qualifiers that prevent a match)
  const bool lhs = pred_(thrust::raw_reference_cast(::cuda::std::get<0>(tuple)));
                   ^
```

## Why

The single-pass implementation merged in #8427 introduced an internal wrapper `__is_partitioned_fn` whose `operator()` is const-qualified. Inside a const member function, the `pred_` data member is treated as `const Predicate`, so any user predicate whose own `operator()` is non-const cannot be invoked.

Thrust does not require predicates to be const-callable (`thrust/testing/cuda/unique.cu` already exercises this for `unique`). The two-pass implementation prior to #8427 forwarded the predicate directly to `find_if`/`find_if_not` without an intermediate wrapper, so non-const predicates worked.

Closes #8714.

## How

- **Fix**: drop the trailing `const` on `__is_partitioned_fn::operator()`. The wrapper is constructed locally and consumed only by `cuda_cub::find_if`, which takes the predicate by value and stores it in a non-const `agent_t::predicate` member. No call site requires the wrapper itself to be const-callable.

- **Comment**: a short note above the operator explains why the `const` is intentionally absent, to discourage it from being added back during a future cleanup.

- **Test**: `TestIsPartitionedWithNonConstPredicate` in `thrust/testing/cuda/is_partitioned.cu`, using the same `NonConstAdapter` pattern already established at `thrust/testing/cuda/unique.cu:455`. Two assertions exercise both branches of the wrapper's `!lhs && rhs` logic (partitioned and not-partitioned inputs). The pre-existing `is_even<T>` predicate template is hoisted out of `#ifdef THRUST_TEST_DEVICE_SIDE` so the new test can reuse it.

## Test

Built locally with the `thrust-cpp17` preset (CUDA 13.0, gcc14, sm_80):

```
ninja thrust.cpp.cuda.test.cuda.is_partitioned thrust.cpp.cuda.test.is_partitioned
```

All three resulting executables compile clean (`cdp_0`, `cdp_1`, generic), zero warnings.

Reverting just the fix and rebuilding confirms the new regression test fails to compile with the exact error reported in #8714, so it serves as a true regression guard.