### PR TITLE
Add a static assert rejecting too large input types.

### DIFF
--- a/libcudacxx/include/cuda/std/__atomic/types/reference.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/reference.h
@@ -38,6 +38,7 @@ struct __atomic_ref_storage
 #if !_CCCL_COMPILER(GCC) || _CCCL_COMPILER(GCC, >=, 5)
   static_assert(is_trivially_copyable_v<_Tp>, "std::atomic_ref<Tp> requires that 'Tp' be a trivially copyable type");
 #endif
+  static_assert(sizeof(__underlying_t) <= 16, "cuda::std::atomic_ref<Tp> only supports sizeof(Tp)<=16");
 
   _Tp* __a_value;
 

--- a/libcudacxx/include/cuda/std/__atomic/types/reference.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/reference.h
@@ -38,7 +38,7 @@ struct __atomic_ref_storage
 #if !_CCCL_COMPILER(GCC) || _CCCL_COMPILER(GCC, >=, 5)
   static_assert(is_trivially_copyable_v<_Tp>, "std::atomic_ref<Tp> requires that 'Tp' be a trivially copyable type");
 #endif
-  static_assert(sizeof(__underlying_t) <= 16, "cuda::std::atomic_ref<Tp> only supports sizeof(Tp)<=16");
+  static_assert(sizeof(__underlying_t) <= 16, "cuda::std::atomic_ref<Tp> only supports sizeof(Tp) <= 16");
 
   _Tp* __a_value;
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/supported_sizes.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/supported_sizes.fail.cpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
+// UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
+// UNSUPPORTED: windows && pre-sm-70
+
+// <cuda/std/atomic>
+
+#include <cuda/atomic>
+#include <cuda/std/atomic>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct TooLarge
+{
+  int32_t v[6];
+};
+
+template <typename T>
+TEST_FUNC void check_supported_type(T v)
+{
+  cuda::std::atomic<T> atom(v);
+  cuda::std::atomic_ref<T> ref(v);
+}
+
+int main(int, char**)
+{
+  check_supported_type(TooLarge{});
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/supported_sizes.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/supported_sizes.pass.cpp
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
+// UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
+// UNSUPPORTED: windows && pre-sm-70
+
+// <cuda/std/atomic>
+
+#include <cuda/atomic>
+#include <cuda/std/atomic>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+template <typename T>
+TEST_FUNC void check_supported_type(T v)
+{
+  cuda::std::atomic<T> atom(v);
+  cuda::std::atomic_ref<T> ref(v);
+}
+
+int main(int, char**)
+{
+  check_supported_type(static_cast<char>(0));
+  check_supported_type(static_cast<signed char>(0));
+  check_supported_type(static_cast<unsigned char>(0));
+  check_supported_type(static_cast<short>(0));
+  check_supported_type(static_cast<unsigned short>(0));
+  check_supported_type(static_cast<int>(0));
+  check_supported_type(static_cast<unsigned int>(0));
+  check_supported_type(static_cast<long>(0));
+  check_supported_type(static_cast<unsigned long>(0));
+  check_supported_type(static_cast<long long>(0));
+  check_supported_type(static_cast<unsigned long long>(0));
+  check_supported_type(static_cast<wchar_t>(0));
+  check_supported_type(static_cast<char16_t>(0));
+  check_supported_type(static_cast<char32_t>(0));
+  check_supported_type(static_cast<uintptr_t>(0));
+  check_supported_type(static_cast<uint8_t>(0));
+  check_supported_type(static_cast<int16_t>(0));
+  check_supported_type(static_cast<uint16_t>(0));
+  check_supported_type(static_cast<int32_t>(0));
+  check_supported_type(static_cast<uint32_t>(0));
+  check_supported_type(static_cast<int64_t>(0));
+  check_supported_type(static_cast<uint64_t>(0));
+#if __cccl_ptx_isa >= 840
+  check_supported_type(static_cast<__int128_t>(0));
+  check_supported_type(static_cast<__uint128_t>(0));
+#endif
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/supported_sizes.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/supported_sizes.pass.cpp
@@ -51,9 +51,11 @@ int main(int, char**)
   check_supported_type(static_cast<uint32_t>(0));
   check_supported_type(static_cast<int64_t>(0));
   check_supported_type(static_cast<uint64_t>(0));
+#if _CCCL_HAS_INT128()
   NV_IF_TARGET(NV_IS_DEVICE,
                // Perform check only on device
                (check_supported_type(static_cast<__int128_t>(0)); check_supported_type(static_cast<__uint128_t>(0));))
+#endif // _CCCL_HAS_INT128()
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/supported_sizes.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/supported_sizes.pass.cpp
@@ -51,10 +51,9 @@ int main(int, char**)
   check_supported_type(static_cast<uint32_t>(0));
   check_supported_type(static_cast<int64_t>(0));
   check_supported_type(static_cast<uint64_t>(0));
-#if __cccl_ptx_isa >= 840
-  check_supported_type(static_cast<__int128_t>(0));
-  check_supported_type(static_cast<__uint128_t>(0));
-#endif
+  NV_IF_TARGET(NV_IS_DEVICE,
+               // Perform check only on device
+               (check_supported_type(static_cast<__int128_t>(0)); check_supported_type(static_cast<__uint128_t>(0));))
 
   return 0;
 }


### PR DESCRIPTION
## Description

Fixes a documentation drift issue with `atomic_ref`.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
