### PR TITLE
Fix invalid C++ syntax: remove leading :: after struct in proclaims_copyable_arguments specializations

### DIFF
--- a/cub/cub/device/device_transform.cuh
+++ b/cub/cub/device/device_transform.cuh
@@ -42,9 +42,11 @@ struct __return_constant
 } // namespace detail
 CUB_NAMESPACE_END
 
+namespace cuda {
 template <typename T>
-struct cuda::proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::__return_constant<T>> : ::cuda::std::true_type
+struct proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::__return_constant<T>> : ::cuda::std::true_type
 {};
+} // namespace cuda
 
 CUB_NAMESPACE_BEGIN
 //! DeviceTransform provides device-wide, parallel operations for transforming elements tuple-wise from multiple input

--- a/cub/cub/device/device_transform.cuh
+++ b/cub/cub/device/device_transform.cuh
@@ -43,7 +43,7 @@ struct __return_constant
 CUB_NAMESPACE_END
 
 template <typename T>
-struct ::cuda::proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::__return_constant<T>> : ::cuda::std::true_type
+struct cuda::proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::__return_constant<T>> : ::cuda::std::true_type
 {};
 
 CUB_NAMESPACE_BEGIN

--- a/cub/cub/device/device_transform.cuh
+++ b/cub/cub/device/device_transform.cuh
@@ -42,7 +42,8 @@ struct __return_constant
 } // namespace detail
 CUB_NAMESPACE_END
 
-namespace cuda {
+namespace cuda
+{
 template <typename T>
 struct proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::__return_constant<T>> : ::cuda::std::true_type
 {};

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -42,10 +42,10 @@ struct always_true_predicate
 } // namespace detail::transform
 CUB_NAMESPACE_END
 
-namespace cuda {
+namespace cuda
+{
 template <>
-struct proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::transform::always_true_predicate>
-    : ::cuda::std::true_type
+struct proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::transform::always_true_predicate> : ::cuda::std::true_type
 {};
 } // namespace cuda
 

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -43,7 +43,7 @@ struct always_true_predicate
 CUB_NAMESPACE_END
 
 template <>
-struct ::cuda::proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::transform::always_true_predicate>
+struct cuda::proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::transform::always_true_predicate>
     : ::cuda::std::true_type
 {};
 

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -42,10 +42,12 @@ struct always_true_predicate
 } // namespace detail::transform
 CUB_NAMESPACE_END
 
+namespace cuda {
 template <>
-struct cuda::proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::transform::always_true_predicate>
+struct proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::transform::always_true_predicate>
     : ::cuda::std::true_type
 {};
+} // namespace cuda
 
 CUB_NAMESPACE_BEGIN
 namespace detail::transform


### PR DESCRIPTION
## Description

Using `struct ::cuda::proclaims_copyable_arguments<...>` (global qualification after the struct keyword) is rejected by GCC up to 15.2:

    error: global qualification of class name is invalid before ‘:’ token

Other compilers such as Clang accept this. When compiling through nvcc, cudafe++ rewrites the code into valid forms before passing to the host compiler, so this was never caught in CI. However, downstream projects that include CCCL headers directly in C++ translation units compiled by GCC hit build failures.

Refs: microsoft/onnxruntime#28023

Small reproducer: https://godbolt.org/z/ssjavqveT

Fixes: #8833

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
