### PR TITLE
[cuda.compute]: API cleanup before 1.0

### DIFF
--- a/cub/cub/device/device_merge_sort.cuh
+++ b/cub/cub/device/device_merge_sort.cuh
@@ -103,7 +103,7 @@ private:
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyIteratorT d_keys,
-    ValueIteratorT d_items,
+    ValueIteratorT d_values,
     OffsetT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
@@ -114,9 +114,9 @@ private:
       d_temp_storage,
       temp_storage_bytes,
       d_keys,
-      d_items,
+      d_values,
       d_keys,
-      d_items,
+      d_values,
       static_cast<ChooseOffsetT>(num_items),
       compare_op,
       stream);
@@ -197,7 +197,7 @@ public:
    * @param[in,out] d_keys
    *   Pointer to the input sequence of unsorted input keys
    *
-   * @param[in,out] d_items
+   * @param[in,out] d_values
    *   Pointer to the input sequence of unsorted input values
    *
    * @param[in] num_items
@@ -225,13 +225,13 @@ public:
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyIteratorT d_keys,
-    ValueIteratorT d_items,
+    ValueIteratorT d_values,
     OffsetT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, GetName());
-    return SortPairsNoNVTX(d_temp_storage, temp_storage_bytes, d_keys, d_items, num_items, compare_op, stream);
+    return SortPairsNoNVTX(d_temp_storage, temp_storage_bytes, d_keys, d_values, num_items, compare_op, stream);
   }
 
   //! @rst
@@ -276,7 +276,7 @@ public:
   //! @param[in,out] d_keys
   //!   Keys to sort
   //!
-  //! @param[in,out] d_items
+  //! @param[in,out] d_values
   //!   Values corresponding to keys
   //!
   //! @param[in] num_items
@@ -295,7 +295,7 @@ public:
             typename CompareOpT,
             typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
-  SortPairs(KeyIteratorT d_keys, ValueIteratorT d_items, OffsetT num_items, CompareOpT compare_op, EnvT env = {})
+  SortPairs(KeyIteratorT d_keys, ValueIteratorT d_values, OffsetT num_items, CompareOpT compare_op, EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
@@ -308,9 +308,9 @@ public:
           storage,
           bytes,
           d_keys,
-          d_items,
+          d_values,
           d_keys,
-          d_items,
+          d_values,
           static_cast<ChooseOffsetT>(num_items),
           compare_op,
           stream,
@@ -326,7 +326,7 @@ public:
    *   that `i` and `j` are equivalent: neither one is less than the
    *   other. It is not guaranteed that the relative order of these
    *   two elements will be preserved by sort.
-   * - Input arrays `d_input_keys` and `d_input_items` are not modified.
+   * - Input arrays `d_input_keys` and `d_input_values` are not modified.
    * - Note that the behavior is undefined if the input and output ranges
    *   overlap in any way.
    *
@@ -405,13 +405,13 @@ public:
    * @param[in] d_input_keys
    *   Pointer to the input sequence of unsorted input keys
    *
-   * @param[in] d_input_items
+   * @param[in] d_input_values
    *   Pointer to the input sequence of unsorted input values
    *
    * @param[out] d_output_keys
    *   Pointer to the output sequence of sorted input keys
    *
-   * @param[out] d_output_items
+   * @param[out] d_output_values
    *   Pointer to the output sequence of sorted input values
    *
    * @param[in] num_items
@@ -444,9 +444,9 @@ public:
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyInputIteratorT d_input_keys,
-    ValueInputIteratorT d_input_items,
+    ValueInputIteratorT d_input_values,
     KeyIteratorT d_output_keys,
-    ValueIteratorT d_output_items,
+    ValueIteratorT d_output_values,
     OffsetT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
@@ -458,9 +458,9 @@ public:
       d_temp_storage,
       temp_storage_bytes,
       d_input_keys,
-      d_input_items,
+      d_input_values,
       d_output_keys,
-      d_output_items,
+      d_output_values,
       static_cast<ChooseOffsetT>(num_items),
       compare_op,
       stream);
@@ -478,7 +478,7 @@ public:
   //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
   //!
   //! - SortPairsCopy is not guaranteed to be stable.
-  //! - Input arrays ``d_input_keys`` and ``d_input_items`` are not modified.
+  //! - Input arrays ``d_input_keys`` and ``d_input_values`` are not modified.
   //! - The behavior is undefined if the input and output ranges overlap in any way.
   //!
   //! Snippet
@@ -516,13 +516,13 @@ public:
   //! @param[in] d_input_keys
   //!   Pointer to the input sequence of unsorted input keys
   //!
-  //! @param[in] d_input_items
+  //! @param[in] d_input_values
   //!   Pointer to the input sequence of unsorted input values
   //!
   //! @param[out] d_output_keys
   //!   Pointer to the output sequence of sorted input keys
   //!
-  //! @param[out] d_output_items
+  //! @param[out] d_output_values
   //!   Pointer to the output sequence of sorted input values
   //!
   //! @param[in] num_items
@@ -544,9 +544,9 @@ public:
             typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t SortPairsCopy(
     KeyInputIteratorT d_input_keys,
-    ValueInputIteratorT d_input_items,
+    ValueInputIteratorT d_input_values,
     KeyIteratorT d_output_keys,
-    ValueIteratorT d_output_items,
+    ValueIteratorT d_output_values,
     OffsetT num_items,
     CompareOpT compare_op,
     EnvT env = {})
@@ -562,9 +562,9 @@ public:
           storage,
           bytes,
           d_input_keys,
-          d_input_items,
+          d_input_values,
           d_output_keys,
-          d_output_items,
+          d_output_values,
           static_cast<ChooseOffsetT>(num_items),
           compare_op,
           stream,
@@ -1077,7 +1077,7 @@ public:
    * @param[in,out] d_keys
    *   Pointer to the input sequence of unsorted input keys
    *
-   * @param[in,out] d_items
+   * @param[in,out] d_values
    *   Pointer to the input sequence of unsorted input values
    *
    * @param[in] num_items
@@ -1105,7 +1105,7 @@ public:
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyIteratorT d_keys,
-    ValueIteratorT d_items,
+    ValueIteratorT d_values,
     OffsetT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
@@ -1113,7 +1113,7 @@ public:
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, GetName());
 
     return SortPairsNoNVTX<KeyIteratorT, ValueIteratorT, OffsetT, CompareOpT>(
-      d_temp_storage, temp_storage_bytes, d_keys, d_items, num_items, compare_op, stream);
+      d_temp_storage, temp_storage_bytes, d_keys, d_values, num_items, compare_op, stream);
   }
 
   //! @rst
@@ -1158,7 +1158,7 @@ public:
   //! @param[in,out] d_keys
   //!   Keys to sort
   //!
-  //! @param[in,out] d_items
+  //! @param[in,out] d_values
   //!   Values corresponding to keys
   //!
   //! @param[in] num_items
@@ -1177,7 +1177,7 @@ public:
             typename CompareOpT,
             typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
-  StableSortPairs(KeyIteratorT d_keys, ValueIteratorT d_items, OffsetT num_items, CompareOpT compare_op, EnvT env = {})
+  StableSortPairs(KeyIteratorT d_keys, ValueIteratorT d_values, OffsetT num_items, CompareOpT compare_op, EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
@@ -1190,9 +1190,9 @@ public:
           storage,
           bytes,
           d_keys,
-          d_items,
+          d_values,
           d_keys,
-          d_items,
+          d_values,
           static_cast<ChooseOffsetT>(num_items),
           compare_op,
           stream,

--- a/docs/python/compute/developer_overview.rst
+++ b/docs/python/compute/developer_overview.rst
@@ -423,7 +423,7 @@ as an example:
 #. In the first stage, ``cuda.compute.make_reduce_into(...)`` constructs
    a reusable reduction object:
 
-   ``reducer = cuda.compute.make_reduce_into(d_in, d_out, op, h_init)``
+   ``reducer = cuda.compute.make_reduce_into(d_in=d_in, d_out=d_out, op=op, h_init=h_init)``
 
    Here ``op`` is a Python function that must be made available to the
    CUDA kernel. As in the simplified prototype above, this stage
@@ -437,7 +437,7 @@ as an example:
 #. In the second stage, that reduction object is used to query the
    amount of temporary storage required by the algorithm:
 
-   ``temp_storage_size = reducer(None, d_input, d_output, op, num_items, h_init)``
+   ``temp_storage_size = reducer(temp_storage=None, d_in=d_input, d_out=d_output, num_items=num_items, op=op, h_init=h_init)``
 
    This returns the size of the temporary storage buffer, which must be
    allocated in device-accessible memory. No kernels are launched at
@@ -446,7 +446,7 @@ as an example:
 #. In the third stage, the algorithm is executed using the allocated
    temporary storage:
 
-   ``reducer(temp_storage, d_input, d_output, op, num_items, h_init)``
+   ``reducer(temp_storage=temp_storage, d_in=d_input, d_out=d_output, num_items=num_items, op=op, h_init=h_init)``
 
    At this point, the kernels stored in the reduction object are
    launched and the reduction is performed.

--- a/docs/python/compute/index.rst
+++ b/docs/python/compute/index.rst
@@ -87,7 +87,7 @@ returns a reusable reduction object that lets you manage memory explicitly.
 
    # create a reducer object:
    reducer = cuda.compute.make_reduce_into(d_in=d_in, d_out=d_out, op=op, h_init=h_init)
-   # get the temporary storage size by passing None as the first argument:
+   # get the temporary storage size by passing None for the temp_storage argument:
    temp_storage_bytes = reducer(temp_storage=None, d_in=d_in, d_out=d_out, num_items=num_items, op=op, h_init=h_init)
    # allocate the temporary storage as any array-like object
    # (e.g., CuPy array, Torch tensor):

--- a/docs/python/compute/index.rst
+++ b/docs/python/compute/index.rst
@@ -35,6 +35,18 @@ Typical usage of an algorithm looks like this:
 API conventions
 +++++++++++++++
 
+* **Keyword-only parameters** — All algorithm parameters (except the internal
+  ``temp_storage`` argument of the object-based API) are **keyword-only**.
+  They must always be passed by name, not by position:
+
+  .. code-block:: python
+
+     # correct
+     cuda.compute.reduce_into(d_in=d_input, d_out=d_output, num_items=n, op=OpKind.PLUS, h_init=h_init)
+
+     # incorrect — positional arguments are not accepted
+     cuda.compute.reduce_into(d_input, d_output, n, OpKind.PLUS, h_init)  # TypeError
+
 * **Naming** — The ``d_`` prefix denotes *device* memory (e.g., CuPy arrays, PyTorch tensors);
   ``h_`` denotes *host* memory (NumPy arrays). Some scalar values must be passed as
   host arrays.
@@ -75,14 +87,14 @@ returns a reusable reduction object that lets you manage memory explicitly.
    :caption: Controlling temporary memory.
 
    # create a reducer object:
-   reducer = cuda.compute.make_reduce_into(d_in, d_out, op, h_init)
+   reducer = cuda.compute.make_reduce_into(d_in=d_in, d_out=d_out, op=op, h_init=h_init)
    # get the temporary storage size by passing None as the first argument:
-   temp_storage_bytes = reducer(None, d_in, d_out, op, num_items, h_init)
+   temp_storage_bytes = reducer(None, d_in=d_in, d_out=d_out, num_items=num_items, op=op, h_init=h_init)
    # allocate the temporary storage as any array-like object
    # (e.g., CuPy array, Torch tensor):
    temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
    # perform the reduction, passing the temporary storage as the first argument:
-   reducer(temp_storage, d_in, d_out, op, num_items, h_init)
+   reducer(temp_storage, d_in=d_in, d_out=d_out, num_items=num_items, op=op, h_init=h_init)
 
 The object-based API splits the algorithm invocation into three phases,
 

--- a/docs/python/compute/index.rst
+++ b/docs/python/compute/index.rst
@@ -35,8 +35,7 @@ Typical usage of an algorithm looks like this:
 API conventions
 +++++++++++++++
 
-* **Keyword-only parameters** — All algorithm parameters (except the internal
-  ``temp_storage`` argument of the object-based API) are **keyword-only**.
+* **Keyword-only parameters** — All algorithm parameters are **keyword-only**.
   They must always be passed by name, not by position:
 
   .. code-block:: python
@@ -89,12 +88,12 @@ returns a reusable reduction object that lets you manage memory explicitly.
    # create a reducer object:
    reducer = cuda.compute.make_reduce_into(d_in=d_in, d_out=d_out, op=op, h_init=h_init)
    # get the temporary storage size by passing None as the first argument:
-   temp_storage_bytes = reducer(None, d_in=d_in, d_out=d_out, num_items=num_items, op=op, h_init=h_init)
+   temp_storage_bytes = reducer(temp_storage=None, d_in=d_in, d_out=d_out, num_items=num_items, op=op, h_init=h_init)
    # allocate the temporary storage as any array-like object
    # (e.g., CuPy array, Torch tensor):
    temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
-   # perform the reduction, passing the temporary storage as the first argument:
-   reducer(temp_storage, d_in=d_in, d_out=d_out, num_items=num_items, op=op, h_init=h_init)
+   # perform the reduction:
+   reducer(temp_storage=temp_storage, d_in=d_in, d_out=d_out, num_items=num_items, op=op, h_init=h_init)
 
 The object-based API splits the algorithm invocation into three phases,
 

--- a/python/cuda_cccl/benchmarks/compute/histogram/even.py
+++ b/python/cuda_cccl/benchmarks/compute/histogram/even.py
@@ -81,22 +81,22 @@ def bench_histogram_even(state: bench.State):
     h_upper_level = np.array([upper_level], dtype=dtype)
 
     histogrammer = make_histogram_even(
-        d_samples,
-        d_histogram,
-        h_num_output_levels,
-        h_lower_level,
-        h_upper_level,
-        num_elements,
+        d_samples=d_samples,
+        d_histogram=d_histogram,
+        h_num_output_levels=h_num_output_levels,
+        h_lower_level=h_lower_level,
+        h_upper_level=h_upper_level,
+        num_samples=num_elements,
     )
 
     temp_storage_bytes = histogrammer(
-        None,
-        d_samples,
-        d_histogram,
-        h_num_output_levels,
-        h_lower_level,
-        h_upper_level,
-        num_elements,
+        temp_storage=None,
+        d_samples=d_samples,
+        d_histogram=d_histogram,
+        h_num_output_levels=h_num_output_levels,
+        h_lower_level=h_lower_level,
+        h_upper_level=h_upper_level,
+        num_samples=num_elements,
     )
     with alloc_stream:
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
@@ -107,14 +107,14 @@ def bench_histogram_even(state: bench.State):
 
     def launcher(launch: bench.Launch):
         histogrammer(
-            temp_storage,
-            d_samples,
-            d_histogram,
-            h_num_output_levels,
-            h_lower_level,
-            h_upper_level,
-            num_elements,
-            launch.get_stream(),
+            temp_storage=temp_storage,
+            d_samples=d_samples,
+            d_histogram=d_histogram,
+            h_num_output_levels=h_num_output_levels,
+            h_lower_level=h_lower_level,
+            h_upper_level=h_upper_level,
+            num_samples=num_elements,
+            stream=launch.get_stream(),
         )
 
     state.exec(launcher, batched=False)

--- a/python/cuda_cccl/benchmarks/compute/merge_sort/keys.py
+++ b/python/cuda_cccl/benchmarks/compute/merge_sort/keys.py
@@ -46,16 +46,22 @@ def bench_merge_sort_keys(state: bench.State):
 
     alloc_stream.synchronize()
 
-    sorter = make_merge_sort(d_in_keys, None, d_out_keys, None, OpKind.LESS)
+    sorter = make_merge_sort(
+        d_in_keys=d_in_keys,
+        d_in_values=None,
+        d_out_keys=d_out_keys,
+        d_out_values=None,
+        op=OpKind.LESS,
+    )
 
     temp_storage_bytes = sorter(
         None,
-        d_in_keys,
-        None,
-        d_out_keys,
-        None,
-        OpKind.LESS,
-        num_elements,
+        d_in_keys=d_in_keys,
+        d_in_values=None,
+        d_out_keys=d_out_keys,
+        d_out_values=None,
+        op=OpKind.LESS,
+        num_items=num_elements,
     )
     with alloc_stream:
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
@@ -67,13 +73,13 @@ def bench_merge_sort_keys(state: bench.State):
     def launcher(launch: bench.Launch):
         sorter(
             temp_storage,
-            d_in_keys,
-            None,
-            d_out_keys,
-            None,
-            OpKind.LESS,
-            num_elements,
-            launch.get_stream(),
+            d_in_keys=d_in_keys,
+            d_in_values=None,
+            d_out_keys=d_out_keys,
+            d_out_values=None,
+            op=OpKind.LESS,
+            num_items=num_elements,
+            stream=launch.get_stream(),
         )
 
     state.exec(launcher, batched=False)

--- a/python/cuda_cccl/benchmarks/compute/merge_sort/keys.py
+++ b/python/cuda_cccl/benchmarks/compute/merge_sort/keys.py
@@ -55,7 +55,7 @@ def bench_merge_sort_keys(state: bench.State):
     )
 
     temp_storage_bytes = sorter(
-        None,
+        temp_storage=None,
         d_in_keys=d_in_keys,
         d_in_values=None,
         d_out_keys=d_out_keys,
@@ -72,7 +72,7 @@ def bench_merge_sort_keys(state: bench.State):
 
     def launcher(launch: bench.Launch):
         sorter(
-            temp_storage,
+            temp_storage=temp_storage,
             d_in_keys=d_in_keys,
             d_in_values=None,
             d_out_keys=d_out_keys,

--- a/python/cuda_cccl/benchmarks/compute/merge_sort/pairs.py
+++ b/python/cuda_cccl/benchmarks/compute/merge_sort/pairs.py
@@ -68,7 +68,7 @@ def bench_merge_sort_pairs(state: bench.State):
     )
 
     temp_storage_bytes = sorter(
-        None,
+        temp_storage=None,
         d_in_keys=d_in_keys,
         d_in_values=d_in_values,
         d_out_keys=d_out_keys,
@@ -87,7 +87,7 @@ def bench_merge_sort_pairs(state: bench.State):
 
     def launcher(launch: bench.Launch):
         sorter(
-            temp_storage,
+            temp_storage=temp_storage,
             d_in_keys=d_in_keys,
             d_in_values=d_in_values,
             d_out_keys=d_out_keys,

--- a/python/cuda_cccl/benchmarks/compute/merge_sort/pairs.py
+++ b/python/cuda_cccl/benchmarks/compute/merge_sort/pairs.py
@@ -60,17 +60,21 @@ def bench_merge_sort_pairs(state: bench.State):
     alloc_stream.synchronize()
 
     sorter = make_merge_sort(
-        d_in_keys, d_in_values, d_out_keys, d_out_values, OpKind.LESS
+        d_in_keys=d_in_keys,
+        d_in_values=d_in_values,
+        d_out_keys=d_out_keys,
+        d_out_values=d_out_values,
+        op=OpKind.LESS,
     )
 
     temp_storage_bytes = sorter(
         None,
-        d_in_keys,
-        d_in_values,
-        d_out_keys,
-        d_out_values,
-        OpKind.LESS,
-        num_elements,
+        d_in_keys=d_in_keys,
+        d_in_values=d_in_values,
+        d_out_keys=d_out_keys,
+        d_out_values=d_out_values,
+        op=OpKind.LESS,
+        num_items=num_elements,
     )
     with alloc_stream:
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
@@ -84,13 +88,13 @@ def bench_merge_sort_pairs(state: bench.State):
     def launcher(launch: bench.Launch):
         sorter(
             temp_storage,
-            d_in_keys,
-            d_in_values,
-            d_out_keys,
-            d_out_values,
-            OpKind.LESS,
-            num_elements,
-            launch.get_stream(),
+            d_in_keys=d_in_keys,
+            d_in_values=d_in_values,
+            d_out_keys=d_out_keys,
+            d_out_values=d_out_values,
+            op=OpKind.LESS,
+            num_items=num_elements,
+            stream=launch.get_stream(),
         )
 
     state.exec(launcher, batched=False)

--- a/python/cuda_cccl/benchmarks/compute/partition/three_way.py
+++ b/python/cuda_cccl/benchmarks/compute/partition/three_way.py
@@ -80,25 +80,25 @@ def bench_three_way_partition(state: bench.State):
         return x < right_thresh
 
     partitioner = make_three_way_partition(
-        d_in,
-        d_first_part_out,
-        d_second_part_out,
-        d_unselected_out,
-        d_num_selected_out,
-        select_first_part,
-        select_second_part,
+        d_in=d_in,
+        d_first_part_out=d_first_part_out,
+        d_second_part_out=d_second_part_out,
+        d_unselected_out=d_unselected_out,
+        d_num_selected_out=d_num_selected_out,
+        select_first_part_op=select_first_part,
+        select_second_part_op=select_second_part,
     )
 
     temp_storage_bytes = partitioner(
-        None,
-        d_in,
-        d_first_part_out,
-        d_second_part_out,
-        d_unselected_out,
-        d_num_selected_out,
-        select_first_part,
-        select_second_part,
-        num_elements,
+        temp_storage=None,
+        d_in=d_in,
+        d_first_part_out=d_first_part_out,
+        d_second_part_out=d_second_part_out,
+        d_unselected_out=d_unselected_out,
+        d_num_selected_out=d_num_selected_out,
+        select_first_part_op=select_first_part,
+        select_second_part_op=select_second_part,
+        num_items=num_elements,
     )
     with alloc_stream:
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
@@ -111,16 +111,16 @@ def bench_three_way_partition(state: bench.State):
 
     def launcher(launch: bench.Launch):
         partitioner(
-            temp_storage,
-            d_in,
-            d_first_part_out,
-            d_second_part_out,
-            d_unselected_out,
-            d_num_selected_out,
-            select_first_part,
-            select_second_part,
-            num_elements,
-            launch.get_stream(),
+            temp_storage=temp_storage,
+            d_in=d_in,
+            d_first_part_out=d_first_part_out,
+            d_second_part_out=d_second_part_out,
+            d_unselected_out=d_unselected_out,
+            d_num_selected_out=d_num_selected_out,
+            select_first_part_op=select_first_part,
+            select_second_part_op=select_second_part,
+            num_items=num_elements,
+            stream=launch.get_stream(),
         )
 
     state.exec(launcher, batched=False)

--- a/python/cuda_cccl/benchmarks/compute/radix_sort/keys.py
+++ b/python/cuda_cccl/benchmarks/compute/radix_sort/keys.py
@@ -48,15 +48,21 @@ def bench_radix_sort_keys(state: bench.State):
 
     alloc_stream.synchronize()
 
-    sorter = make_radix_sort(d_in_keys, d_out_keys, None, None, SortOrder.ASCENDING)
+    sorter = make_radix_sort(
+        d_in_keys=d_in_keys,
+        d_out_keys=d_out_keys,
+        d_in_values=None,
+        d_out_values=None,
+        order=SortOrder.ASCENDING,
+    )
 
     temp_storage_bytes = sorter(
         None,
-        d_in_keys,
-        d_out_keys,
-        None,
-        None,
-        num_elements,
+        d_in_keys=d_in_keys,
+        d_out_keys=d_out_keys,
+        d_in_values=None,
+        d_out_values=None,
+        num_items=num_elements,
     )
     with alloc_stream:
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
@@ -68,12 +74,12 @@ def bench_radix_sort_keys(state: bench.State):
     def launcher(launch: bench.Launch):
         sorter(
             temp_storage,
-            d_in_keys,
-            d_out_keys,
-            None,
-            None,
-            num_elements,
-            launch.get_stream(),
+            d_in_keys=d_in_keys,
+            d_out_keys=d_out_keys,
+            d_in_values=None,
+            d_out_values=None,
+            num_items=num_elements,
+            stream=launch.get_stream(),
         )
 
     state.exec(launcher, batched=False)

--- a/python/cuda_cccl/benchmarks/compute/radix_sort/keys.py
+++ b/python/cuda_cccl/benchmarks/compute/radix_sort/keys.py
@@ -57,7 +57,7 @@ def bench_radix_sort_keys(state: bench.State):
     )
 
     temp_storage_bytes = sorter(
-        None,
+        temp_storage=None,
         d_in_keys=d_in_keys,
         d_out_keys=d_out_keys,
         d_in_values=None,
@@ -73,7 +73,7 @@ def bench_radix_sort_keys(state: bench.State):
 
     def launcher(launch: bench.Launch):
         sorter(
-            temp_storage,
+            temp_storage=temp_storage,
             d_in_keys=d_in_keys,
             d_out_keys=d_out_keys,
             d_in_values=None,

--- a/python/cuda_cccl/benchmarks/compute/radix_sort/pairs.py
+++ b/python/cuda_cccl/benchmarks/compute/radix_sort/pairs.py
@@ -66,7 +66,7 @@ def bench_radix_sort_pairs(state: bench.State):
     )
 
     temp_storage_bytes = sorter(
-        None,
+        temp_storage=None,
         d_in_keys=d_in_keys,
         d_out_keys=d_out_keys,
         d_in_values=d_in_values,
@@ -84,7 +84,7 @@ def bench_radix_sort_pairs(state: bench.State):
 
     def launcher(launch: bench.Launch):
         sorter(
-            temp_storage,
+            temp_storage=temp_storage,
             d_in_keys=d_in_keys,
             d_out_keys=d_out_keys,
             d_in_values=d_in_values,

--- a/python/cuda_cccl/benchmarks/compute/radix_sort/pairs.py
+++ b/python/cuda_cccl/benchmarks/compute/radix_sort/pairs.py
@@ -58,16 +58,20 @@ def bench_radix_sort_pairs(state: bench.State):
     alloc_stream.synchronize()
 
     sorter = make_radix_sort(
-        d_in_keys, d_out_keys, d_in_values, d_out_values, SortOrder.ASCENDING
+        d_in_keys=d_in_keys,
+        d_out_keys=d_out_keys,
+        d_in_values=d_in_values,
+        d_out_values=d_out_values,
+        order=SortOrder.ASCENDING,
     )
 
     temp_storage_bytes = sorter(
         None,
-        d_in_keys,
-        d_out_keys,
-        d_in_values,
-        d_out_values,
-        num_elements,
+        d_in_keys=d_in_keys,
+        d_out_keys=d_out_keys,
+        d_in_values=d_in_values,
+        d_out_values=d_out_values,
+        num_items=num_elements,
     )
     with alloc_stream:
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
@@ -81,12 +85,12 @@ def bench_radix_sort_pairs(state: bench.State):
     def launcher(launch: bench.Launch):
         sorter(
             temp_storage,
-            d_in_keys,
-            d_out_keys,
-            d_in_values,
-            d_out_values,
-            num_elements,
-            launch.get_stream(),
+            d_in_keys=d_in_keys,
+            d_out_keys=d_out_keys,
+            d_in_values=d_in_values,
+            d_out_values=d_out_values,
+            num_items=num_elements,
+            stream=launch.get_stream(),
         )
 
     state.exec(launcher, batched=False)

--- a/python/cuda_cccl/benchmarks/compute/reduce/custom.py
+++ b/python/cuda_cccl/benchmarks/compute/reduce/custom.py
@@ -46,7 +46,12 @@ def bench_reduce_custom(state: bench.State):
     reducer = make_reduce_into(d_in=d_in, d_out=d_out, op=max_op, h_init=h_init)
 
     temp_storage_bytes = reducer(
-        None, d_in=d_in, d_out=d_out, num_items=num_items, op=max_op, h_init=h_init
+        temp_storage=None,
+        d_in=d_in,
+        d_out=d_out,
+        num_items=num_items,
+        op=max_op,
+        h_init=h_init,
     )
     with alloc_stream:
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
@@ -57,7 +62,7 @@ def bench_reduce_custom(state: bench.State):
 
     def launcher(launch: bench.Launch):
         reducer(
-            temp_storage,
+            temp_storage=temp_storage,
             d_in=d_in,
             d_out=d_out,
             num_items=num_items,

--- a/python/cuda_cccl/benchmarks/compute/reduce/custom.py
+++ b/python/cuda_cccl/benchmarks/compute/reduce/custom.py
@@ -43,9 +43,11 @@ def bench_reduce_custom(state: bench.State):
 
     h_init = np.zeros(1, dtype=dtype)
 
-    reducer = make_reduce_into(d_in, d_out, max_op, h_init)
+    reducer = make_reduce_into(d_in=d_in, d_out=d_out, op=max_op, h_init=h_init)
 
-    temp_storage_bytes = reducer(None, d_in, d_out, max_op, num_items, h_init)
+    temp_storage_bytes = reducer(
+        None, d_in=d_in, d_out=d_out, num_items=num_items, op=max_op, h_init=h_init
+    )
     with alloc_stream:
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
 
@@ -55,7 +57,13 @@ def bench_reduce_custom(state: bench.State):
 
     def launcher(launch: bench.Launch):
         reducer(
-            temp_storage, d_in, d_out, max_op, num_items, h_init, launch.get_stream()
+            temp_storage,
+            d_in=d_in,
+            d_out=d_out,
+            num_items=num_items,
+            op=max_op,
+            h_init=h_init,
+            stream=launch.get_stream(),
         )
 
     state.exec(launcher, batched=False)

--- a/python/cuda_cccl/benchmarks/compute/reduce/min.py
+++ b/python/cuda_cccl/benchmarks/compute/reduce/min.py
@@ -44,9 +44,16 @@ def bench_reduce_min(state: bench.State):
         init_val = np.finfo(dtype).max
     h_init = np.array([init_val], dtype=dtype)
 
-    reducer = make_reduce_into(d_in, d_out, OpKind.MINIMUM, h_init)
+    reducer = make_reduce_into(d_in=d_in, d_out=d_out, op=OpKind.MINIMUM, h_init=h_init)
 
-    temp_storage_bytes = reducer(None, d_in, d_out, OpKind.MINIMUM, num_items, h_init)
+    temp_storage_bytes = reducer(
+        None,
+        d_in=d_in,
+        d_out=d_out,
+        num_items=num_items,
+        op=OpKind.MINIMUM,
+        h_init=h_init,
+    )
     with alloc_stream:
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
 
@@ -57,12 +64,12 @@ def bench_reduce_min(state: bench.State):
     def launcher(launch: bench.Launch):
         reducer(
             temp_storage,
-            d_in,
-            d_out,
-            OpKind.MINIMUM,
-            num_items,
-            h_init,
-            launch.get_stream(),
+            d_in=d_in,
+            d_out=d_out,
+            num_items=num_items,
+            op=OpKind.MINIMUM,
+            h_init=h_init,
+            stream=launch.get_stream(),
         )
 
     state.exec(launcher, batched=False)

--- a/python/cuda_cccl/benchmarks/compute/reduce/min.py
+++ b/python/cuda_cccl/benchmarks/compute/reduce/min.py
@@ -47,7 +47,7 @@ def bench_reduce_min(state: bench.State):
     reducer = make_reduce_into(d_in=d_in, d_out=d_out, op=OpKind.MINIMUM, h_init=h_init)
 
     temp_storage_bytes = reducer(
-        None,
+        temp_storage=None,
         d_in=d_in,
         d_out=d_out,
         num_items=num_items,
@@ -63,7 +63,7 @@ def bench_reduce_min(state: bench.State):
 
     def launcher(launch: bench.Launch):
         reducer(
-            temp_storage,
+            temp_storage=temp_storage,
             d_in=d_in,
             d_out=d_out,
             num_items=num_items,

--- a/python/cuda_cccl/benchmarks/compute/reduce/nondeterministic.py
+++ b/python/cuda_cccl/benchmarks/compute/reduce/nondeterministic.py
@@ -43,14 +43,16 @@ def bench_reduce_nondeterministic(state: bench.State):
     h_init = np.zeros(1, dtype=dtype)
 
     reducer = make_reduce_into(
-        d_in,
-        d_out,
-        OpKind.PLUS,
-        h_init,
+        d_in=d_in,
+        d_out=d_out,
+        op=OpKind.PLUS,
+        h_init=h_init,
         determinism=Determinism.NOT_GUARANTEED,
     )
 
-    temp_storage_bytes = reducer(None, d_in, d_out, OpKind.PLUS, num_items, h_init)
+    temp_storage_bytes = reducer(
+        None, d_in=d_in, d_out=d_out, num_items=num_items, op=OpKind.PLUS, h_init=h_init
+    )
     with alloc_stream:
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
 
@@ -61,12 +63,12 @@ def bench_reduce_nondeterministic(state: bench.State):
     def launcher(launch: bench.Launch):
         reducer(
             temp_storage,
-            d_in,
-            d_out,
-            OpKind.PLUS,
-            num_items,
-            h_init,
-            launch.get_stream(),
+            d_in=d_in,
+            d_out=d_out,
+            num_items=num_items,
+            op=OpKind.PLUS,
+            h_init=h_init,
+            stream=launch.get_stream(),
         )
 
     state.exec(launcher, batched=False)

--- a/python/cuda_cccl/benchmarks/compute/reduce/nondeterministic.py
+++ b/python/cuda_cccl/benchmarks/compute/reduce/nondeterministic.py
@@ -51,7 +51,12 @@ def bench_reduce_nondeterministic(state: bench.State):
     )
 
     temp_storage_bytes = reducer(
-        None, d_in=d_in, d_out=d_out, num_items=num_items, op=OpKind.PLUS, h_init=h_init
+        temp_storage=None,
+        d_in=d_in,
+        d_out=d_out,
+        num_items=num_items,
+        op=OpKind.PLUS,
+        h_init=h_init,
     )
     with alloc_stream:
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
@@ -62,7 +67,7 @@ def bench_reduce_nondeterministic(state: bench.State):
 
     def launcher(launch: bench.Launch):
         reducer(
-            temp_storage,
+            temp_storage=temp_storage,
             d_in=d_in,
             d_out=d_out,
             num_items=num_items,

--- a/python/cuda_cccl/benchmarks/compute/reduce/sum.py
+++ b/python/cuda_cccl/benchmarks/compute/reduce/sum.py
@@ -42,7 +42,12 @@ def bench_reduce_sum(state: bench.State):
     reducer = make_reduce_into(d_in=d_in, d_out=d_out, op=OpKind.PLUS, h_init=h_init)
 
     temp_storage_bytes = reducer(
-        None, d_in=d_in, d_out=d_out, num_items=num_items, op=OpKind.PLUS, h_init=h_init
+        temp_storage=None,
+        d_in=d_in,
+        d_out=d_out,
+        num_items=num_items,
+        op=OpKind.PLUS,
+        h_init=h_init,
     )
     with alloc_stream:
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
@@ -53,7 +58,7 @@ def bench_reduce_sum(state: bench.State):
 
     def launcher(launch: bench.Launch):
         reducer(
-            temp_storage,
+            temp_storage=temp_storage,
             d_in=d_in,
             d_out=d_out,
             num_items=num_items,

--- a/python/cuda_cccl/benchmarks/compute/reduce/sum.py
+++ b/python/cuda_cccl/benchmarks/compute/reduce/sum.py
@@ -39,9 +39,11 @@ def bench_reduce_sum(state: bench.State):
     # Initial value for reduction
     h_init = np.zeros(1, dtype=dtype)
 
-    reducer = make_reduce_into(d_in, d_out, OpKind.PLUS, h_init)
+    reducer = make_reduce_into(d_in=d_in, d_out=d_out, op=OpKind.PLUS, h_init=h_init)
 
-    temp_storage_bytes = reducer(None, d_in, d_out, OpKind.PLUS, num_items, h_init)
+    temp_storage_bytes = reducer(
+        None, d_in=d_in, d_out=d_out, num_items=num_items, op=OpKind.PLUS, h_init=h_init
+    )
     with alloc_stream:
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
 
@@ -52,12 +54,12 @@ def bench_reduce_sum(state: bench.State):
     def launcher(launch: bench.Launch):
         reducer(
             temp_storage,
-            d_in,
-            d_out,
-            OpKind.PLUS,
-            num_items,
-            h_init,
-            launch.get_stream(),
+            d_in=d_in,
+            d_out=d_out,
+            num_items=num_items,
+            op=OpKind.PLUS,
+            h_init=h_init,
+            stream=launch.get_stream(),
         )
 
     state.exec(launcher, batched=False)

--- a/python/cuda_cccl/benchmarks/compute/scan/exclusive/custom.py
+++ b/python/cuda_cccl/benchmarks/compute/scan/exclusive/custom.py
@@ -47,7 +47,12 @@ def bench_scan_exclusive_custom(state: bench.State):
     scanner = make_exclusive_scan(d_in=d_in, d_out=d_out, op=max_op, init_value=h_init)
 
     temp_storage_bytes = scanner(
-        None, d_in=d_in, d_out=d_out, op=max_op, init_value=h_init, num_items=num_items
+        temp_storage=None,
+        d_in=d_in,
+        d_out=d_out,
+        op=max_op,
+        init_value=h_init,
+        num_items=num_items,
     )
     with alloc_stream:
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
@@ -58,7 +63,7 @@ def bench_scan_exclusive_custom(state: bench.State):
 
     def launcher(launch: bench.Launch):
         scanner(
-            temp_storage,
+            temp_storage=temp_storage,
             d_in=d_in,
             d_out=d_out,
             op=max_op,

--- a/python/cuda_cccl/benchmarks/compute/scan/exclusive/custom.py
+++ b/python/cuda_cccl/benchmarks/compute/scan/exclusive/custom.py
@@ -44,9 +44,11 @@ def bench_scan_exclusive_custom(state: bench.State):
 
     h_init = np.zeros(1, dtype=dtype)
 
-    scanner = make_exclusive_scan(d_in, d_out, max_op, h_init)
+    scanner = make_exclusive_scan(d_in=d_in, d_out=d_out, op=max_op, init_value=h_init)
 
-    temp_storage_bytes = scanner(None, d_in, d_out, max_op, num_items, h_init)
+    temp_storage_bytes = scanner(
+        None, d_in=d_in, d_out=d_out, op=max_op, init_value=h_init, num_items=num_items
+    )
     with alloc_stream:
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
 
@@ -56,7 +58,13 @@ def bench_scan_exclusive_custom(state: bench.State):
 
     def launcher(launch: bench.Launch):
         scanner(
-            temp_storage, d_in, d_out, max_op, num_items, h_init, launch.get_stream()
+            temp_storage,
+            d_in=d_in,
+            d_out=d_out,
+            op=max_op,
+            init_value=h_init,
+            num_items=num_items,
+            stream=launch.get_stream(),
         )
 
     state.exec(launcher, batched=False)

--- a/python/cuda_cccl/benchmarks/compute/scan/exclusive/sum.py
+++ b/python/cuda_cccl/benchmarks/compute/scan/exclusive/sum.py
@@ -41,9 +41,18 @@ def bench_scan_exclusive_sum(state: bench.State):
     # Initial value for scan (identity for addition)
     h_init = np.zeros(1, dtype=dtype)
 
-    scanner = make_exclusive_scan(d_in, d_out, OpKind.PLUS, h_init)
+    scanner = make_exclusive_scan(
+        d_in=d_in, d_out=d_out, op=OpKind.PLUS, init_value=h_init
+    )
 
-    temp_storage_bytes = scanner(None, d_in, d_out, OpKind.PLUS, num_items, h_init)
+    temp_storage_bytes = scanner(
+        None,
+        d_in=d_in,
+        d_out=d_out,
+        op=OpKind.PLUS,
+        init_value=h_init,
+        num_items=num_items,
+    )
     with alloc_stream:
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
 
@@ -54,12 +63,12 @@ def bench_scan_exclusive_sum(state: bench.State):
     def launcher(launch: bench.Launch):
         scanner(
             temp_storage,
-            d_in,
-            d_out,
-            OpKind.PLUS,
-            num_items,
-            h_init,
-            launch.get_stream(),
+            d_in=d_in,
+            d_out=d_out,
+            op=OpKind.PLUS,
+            init_value=h_init,
+            num_items=num_items,
+            stream=launch.get_stream(),
         )
 
     state.exec(launcher, batched=False)

--- a/python/cuda_cccl/benchmarks/compute/scan/exclusive/sum.py
+++ b/python/cuda_cccl/benchmarks/compute/scan/exclusive/sum.py
@@ -46,7 +46,7 @@ def bench_scan_exclusive_sum(state: bench.State):
     )
 
     temp_storage_bytes = scanner(
-        None,
+        temp_storage=None,
         d_in=d_in,
         d_out=d_out,
         op=OpKind.PLUS,
@@ -62,7 +62,7 @@ def bench_scan_exclusive_sum(state: bench.State):
 
     def launcher(launch: bench.Launch):
         scanner(
-            temp_storage,
+            temp_storage=temp_storage,
             d_in=d_in,
             d_out=d_out,
             op=OpKind.PLUS,

--- a/python/cuda_cccl/benchmarks/compute/segmented_reduce/variable_sum.py
+++ b/python/cuda_cccl/benchmarks/compute/segmented_reduce/variable_sum.py
@@ -44,23 +44,23 @@ def run_segmented_reduce(
     guaranteed_max_seg_size,
 ):
     reducer = make_segmented_reduce(
-        d_in,
-        d_out,
-        start_offsets,
-        end_offsets,
-        OpKind.PLUS,
-        h_init,
+        d_in=d_in,
+        d_out=d_out,
+        start_offsets_in=start_offsets,
+        end_offsets_in=end_offsets,
+        op=OpKind.PLUS,
+        h_init=h_init,
     )
 
     temp_storage_bytes = reducer(
         None,
-        d_in,
-        d_out,
-        OpKind.PLUS,
-        num_segments,
-        start_offsets,
-        end_offsets,
-        h_init,
+        d_in=d_in,
+        d_out=d_out,
+        num_segments=num_segments,
+        start_offsets_in=start_offsets,
+        end_offsets_in=end_offsets,
+        op=OpKind.PLUS,
+        h_init=h_init,
         max_segment_size=guaranteed_max_seg_size,
     )
     alloc_stream = as_cupy_stream(state.get_stream())
@@ -70,15 +70,15 @@ def run_segmented_reduce(
     def launcher(launch: bench.Launch):
         reducer(
             temp_storage,
-            d_in,
-            d_out,
-            OpKind.PLUS,
-            num_segments,
-            start_offsets,
-            end_offsets,
-            h_init,
-            guaranteed_max_seg_size,
-            launch.get_stream(),
+            d_in=d_in,
+            d_out=d_out,
+            num_segments=num_segments,
+            start_offsets_in=start_offsets,
+            end_offsets_in=end_offsets,
+            op=OpKind.PLUS,
+            h_init=h_init,
+            max_segment_size=guaranteed_max_seg_size,
+            stream=launch.get_stream(),
         )
 
     state.exec(launcher, batched=False, sync=True)

--- a/python/cuda_cccl/benchmarks/compute/segmented_reduce/variable_sum.py
+++ b/python/cuda_cccl/benchmarks/compute/segmented_reduce/variable_sum.py
@@ -53,7 +53,7 @@ def run_segmented_reduce(
     )
 
     temp_storage_bytes = reducer(
-        None,
+        temp_storage=None,
         d_in=d_in,
         d_out=d_out,
         num_segments=num_segments,
@@ -69,7 +69,7 @@ def run_segmented_reduce(
 
     def launcher(launch: bench.Launch):
         reducer(
-            temp_storage,
+            temp_storage=temp_storage,
             d_in=d_in,
             d_out=d_out,
             num_segments=num_segments,

--- a/python/cuda_cccl/benchmarks/compute/segmented_sort/keys.py
+++ b/python/cuda_cccl/benchmarks/compute/segmented_sort/keys.py
@@ -46,25 +46,25 @@ def run_segmented_sort(
     num_segments,
 ):
     sorter = make_segmented_sort(
-        d_in_keys,
-        d_out_keys,
-        None,
-        None,
-        start_offsets,
-        end_offsets,
-        SortOrder.ASCENDING,
+        d_in_keys=d_in_keys,
+        d_out_keys=d_out_keys,
+        d_in_values=None,
+        d_out_values=None,
+        start_offsets_in=start_offsets,
+        end_offsets_in=end_offsets,
+        order=SortOrder.ASCENDING,
     )
 
     temp_storage_bytes = sorter(
         None,
-        d_in_keys,
-        d_out_keys,
-        None,
-        None,
-        num_items,
-        num_segments,
-        start_offsets,
-        end_offsets,
+        d_in_keys=d_in_keys,
+        d_out_keys=d_out_keys,
+        d_in_values=None,
+        d_out_values=None,
+        num_items=num_items,
+        num_segments=num_segments,
+        start_offsets_in=start_offsets,
+        end_offsets_in=end_offsets,
     )
     alloc_stream = as_cupy_stream(state.get_stream())
     with alloc_stream:
@@ -73,15 +73,15 @@ def run_segmented_sort(
     def launcher(launch: bench.Launch):
         sorter(
             temp_storage,
-            d_in_keys,
-            d_out_keys,
-            None,
-            None,
-            num_items,
-            num_segments,
-            start_offsets,
-            end_offsets,
-            launch.get_stream(),
+            d_in_keys=d_in_keys,
+            d_out_keys=d_out_keys,
+            d_in_values=None,
+            d_out_values=None,
+            num_items=num_items,
+            num_segments=num_segments,
+            start_offsets_in=start_offsets,
+            end_offsets_in=end_offsets,
+            stream=launch.get_stream(),
         )
 
     state.exec(launcher, batched=False, sync=True)

--- a/python/cuda_cccl/benchmarks/compute/segmented_sort/keys.py
+++ b/python/cuda_cccl/benchmarks/compute/segmented_sort/keys.py
@@ -56,7 +56,7 @@ def run_segmented_sort(
     )
 
     temp_storage_bytes = sorter(
-        None,
+        temp_storage=None,
         d_in_keys=d_in_keys,
         d_out_keys=d_out_keys,
         d_in_values=None,
@@ -72,7 +72,7 @@ def run_segmented_sort(
 
     def launcher(launch: bench.Launch):
         sorter(
-            temp_storage,
+            temp_storage=temp_storage,
             d_in_keys=d_in_keys,
             d_out_keys=d_out_keys,
             d_in_values=None,

--- a/python/cuda_cccl/benchmarks/compute/select/if.py
+++ b/python/cuda_cccl/benchmarks/compute/select/if.py
@@ -70,15 +70,20 @@ def bench_select_if(state: bench.State):
     def less_than_threshold(x):
         return x < thresh_val
 
-    selector = make_select(d_in, d_out, d_num_selected, less_than_threshold)
+    selector = make_select(
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=less_than_threshold,
+    )
 
     temp_storage_bytes = selector(
-        None,
-        d_in,
-        d_out,
-        d_num_selected,
-        less_than_threshold,
-        num_elements,
+        temp_storage=None,
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=less_than_threshold,
+        num_items=num_elements,
     )
     with alloc_stream:
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
@@ -90,13 +95,13 @@ def bench_select_if(state: bench.State):
 
     def launcher(launch: bench.Launch):
         selector(
-            temp_storage,
-            d_in,
-            d_out,
-            d_num_selected,
-            less_than_threshold,
-            num_elements,
-            launch.get_stream(),
+            temp_storage=temp_storage,
+            d_in=d_in,
+            d_out=d_out,
+            d_num_selected_out=d_num_selected,
+            cond=less_than_threshold,
+            num_items=num_elements,
+            stream=launch.get_stream(),
         )
 
     state.exec(launcher, batched=False)

--- a/python/cuda_cccl/benchmarks/compute/select/unique_by_key.py
+++ b/python/cuda_cccl/benchmarks/compute/select/unique_by_key.py
@@ -64,23 +64,23 @@ def bench_unique_by_key(state: bench.State):
     alloc_stream.synchronize()
 
     uniquer = make_unique_by_key(
-        d_in_keys,
-        d_in_values,
-        d_out_keys,
-        d_out_values,
-        d_num_selected,
-        OpKind.EQUAL_TO,
+        d_in_keys=d_in_keys,
+        d_in_items=d_in_values,
+        d_out_keys=d_out_keys,
+        d_out_items=d_out_values,
+        d_out_num_selected=d_num_selected,
+        op=OpKind.EQUAL_TO,
     )
 
     temp_storage_bytes = uniquer(
-        None,
-        d_in_keys,
-        d_in_values,
-        d_out_keys,
-        d_out_values,
-        d_num_selected,
-        OpKind.EQUAL_TO,
-        num_elements,
+        temp_storage=None,
+        d_in_keys=d_in_keys,
+        d_in_items=d_in_values,
+        d_out_keys=d_out_keys,
+        d_out_items=d_out_values,
+        d_out_num_selected=d_num_selected,
+        op=OpKind.EQUAL_TO,
+        num_items=num_elements,
     )
     with alloc_stream:
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
@@ -88,15 +88,15 @@ def bench_unique_by_key(state: bench.State):
     # Run once before timing to materialize the number of selected runs,
     # matching the C++ metric accounting flow.
     uniquer(
-        temp_storage,
-        d_in_keys,
-        d_in_values,
-        d_out_keys,
-        d_out_values,
-        d_num_selected,
-        OpKind.EQUAL_TO,
-        num_elements,
-        alloc_stream,
+        temp_storage=temp_storage,
+        d_in_keys=d_in_keys,
+        d_in_items=d_in_values,
+        d_out_keys=d_out_keys,
+        d_out_items=d_out_values,
+        d_out_num_selected=d_num_selected,
+        op=OpKind.EQUAL_TO,
+        num_items=num_elements,
+        stream=alloc_stream,
     )
     alloc_stream.synchronize()
     num_runs = int(d_num_selected.get()[0])
@@ -110,15 +110,15 @@ def bench_unique_by_key(state: bench.State):
 
     def launcher(launch: bench.Launch):
         uniquer(
-            temp_storage,
-            d_in_keys,
-            d_in_values,
-            d_out_keys,
-            d_out_values,
-            d_num_selected,
-            OpKind.EQUAL_TO,
-            num_elements,
-            launch.get_stream(),
+            temp_storage=temp_storage,
+            d_in_keys=d_in_keys,
+            d_in_items=d_in_values,
+            d_out_keys=d_out_keys,
+            d_out_items=d_out_values,
+            d_out_num_selected=d_num_selected,
+            op=OpKind.EQUAL_TO,
+            num_items=num_elements,
+            stream=launch.get_stream(),
         )
 
     state.exec(launcher, batched=False)

--- a/python/cuda_cccl/benchmarks/compute/transform/babelstream.py
+++ b/python/cuda_cccl/benchmarks/compute/transform/babelstream.py
@@ -65,14 +65,16 @@ def bench_mul(state: bench.State):
     def mul_op(ci):
         return ci * scalar
 
-    transform = cuda.compute.make_unary_transform(c, b, mul_op)
+    transform = cuda.compute.make_unary_transform(d_in=c, d_out=b, op=mul_op)
 
     state.add_element_count(num_items)
     state.add_global_memory_reads(num_items * c.dtype.itemsize)
     state.add_global_memory_writes(num_items * b.dtype.itemsize)
 
     def launcher(launch: bench.Launch):
-        transform(c, b, mul_op, num_items, launch.get_stream())
+        transform(
+            d_in=c, d_out=b, op=mul_op, num_items=num_items, stream=launch.get_stream()
+        )
 
     state.exec(launcher, batched=False)
 
@@ -101,14 +103,21 @@ def bench_add(state: bench.State):
     def add_op(ai, bi):
         return ai + bi
 
-    transform = cuda.compute.make_binary_transform(a, b, c, add_op)
+    transform = cuda.compute.make_binary_transform(d_in1=a, d_in2=b, d_out=c, op=add_op)
 
     state.add_element_count(num_items)
     state.add_global_memory_reads(2 * num_items * a.dtype.itemsize)
     state.add_global_memory_writes(num_items * c.dtype.itemsize)
 
     def launcher(launch: bench.Launch):
-        transform(a, b, c, add_op, num_items, launch.get_stream())
+        transform(
+            d_in1=a,
+            d_in2=b,
+            d_out=c,
+            op=add_op,
+            num_items=num_items,
+            stream=launch.get_stream(),
+        )
 
     state.exec(launcher, batched=False)
 
@@ -139,14 +148,23 @@ def bench_triad(state: bench.State):
     def triad_op(bi, ci):
         return bi + scalar * ci
 
-    transform = cuda.compute.make_binary_transform(b, c, a, triad_op)
+    transform = cuda.compute.make_binary_transform(
+        d_in1=b, d_in2=c, d_out=a, op=triad_op
+    )
 
     state.add_element_count(num_items)
     state.add_global_memory_reads(2 * num_items * a.dtype.itemsize)
     state.add_global_memory_writes(num_items * a.dtype.itemsize)
 
     def launcher(launch: bench.Launch):
-        transform(b, c, a, triad_op, num_items, launch.get_stream())
+        transform(
+            d_in1=b,
+            d_in2=c,
+            d_out=a,
+            op=triad_op,
+            num_items=num_items,
+            stream=launch.get_stream(),
+        )
 
     state.exec(launcher, batched=False)
 
@@ -180,7 +198,7 @@ def bench_nstream(state: bench.State):
     def nstream_op(abc):
         return abc[0] + abc[1] + scalar * abc[2]
 
-    transform = cuda.compute.make_unary_transform(zip_in, a, nstream_op)
+    transform = cuda.compute.make_unary_transform(d_in=zip_in, d_out=a, op=nstream_op)
 
     state.add_element_count(num_items)
     state.add_global_memory_reads(3 * num_items * a.dtype.itemsize)
@@ -189,7 +207,13 @@ def bench_nstream(state: bench.State):
     def launcher(launch: bench.Launch):
         # Update ZipIterator state for each iteration
         zip_in_iter = ZipIterator(a, b, c)
-        transform(zip_in_iter, a, nstream_op, num_items, launch.get_stream())
+        transform(
+            d_in=zip_in_iter,
+            d_out=a,
+            op=nstream_op,
+            num_items=num_items,
+            stream=launch.get_stream(),
+        )
 
     state.exec(launcher, batched=False)
 

--- a/python/cuda_cccl/benchmarks/compute/transform/complex_cmp.py
+++ b/python/cuda_cccl/benchmarks/compute/transform/complex_cmp.py
@@ -77,7 +77,9 @@ def bench_compare_complex(state: bench.State):
         return
 
     num_items = num_elements - 1
-    transformer = make_binary_transform(d_in[:-1], d_in[1:], d_out, less_complex)
+    transformer = make_binary_transform(
+        d_in1=d_in[:-1], d_in2=d_in[1:], d_out=d_out, op=less_complex
+    )
 
     state.add_element_count(num_elements)
     state.add_global_memory_reads(num_elements * d_in.dtype.itemsize)
@@ -85,12 +87,12 @@ def bench_compare_complex(state: bench.State):
 
     def launcher(launch: bench.Launch):
         transformer(
-            d_in[:-1],
-            d_in[1:],
-            d_out,
-            less_complex,
-            num_items,
-            launch.get_stream(),
+            d_in1=d_in[:-1],
+            d_in2=d_in[1:],
+            d_out=d_out,
+            op=less_complex,
+            num_items=num_items,
+            stream=launch.get_stream(),
         )
 
     state.exec(launcher, batched=False)

--- a/python/cuda_cccl/benchmarks/compute/transform/fib.py
+++ b/python/cuda_cccl/benchmarks/compute/transform/fib.py
@@ -69,14 +69,20 @@ def bench_transform_fib(state: bench.State):
         state.skip("Skipping: out of memory.")
         return
 
-    transformer = make_unary_transform(d_in, d_out, fib_op)
+    transformer = make_unary_transform(d_in=d_in, d_out=d_out, op=fib_op)
 
     state.add_element_count(num_elements)
     state.add_global_memory_reads(num_elements * d_in.dtype.itemsize)
     state.add_global_memory_writes(num_elements * d_out.dtype.itemsize)
 
     def launcher(launch: bench.Launch):
-        transformer(d_in, d_out, fib_op, num_elements, launch.get_stream())
+        transformer(
+            d_in=d_in,
+            d_out=d_out,
+            op=fib_op,
+            num_items=num_elements,
+            stream=launch.get_stream(),
+        )
 
     state.exec(launcher, batched=False)
 

--- a/python/cuda_cccl/benchmarks/compute/transform/fill.py
+++ b/python/cuda_cccl/benchmarks/compute/transform/fill.py
@@ -42,14 +42,22 @@ def bench_fill(state: bench.State):
     # Python equivalent of C++ return_constant<T>{42}
     constant_it = ConstantIterator(dtype(42))
 
-    transform = cuda.compute.make_unary_transform(constant_it, d_out, OpKind.IDENTITY)
+    transform = cuda.compute.make_unary_transform(
+        d_in=constant_it, d_out=d_out, op=OpKind.IDENTITY
+    )
 
     state.add_element_count(num_items)
     state.add_global_memory_reads(0)
     state.add_global_memory_writes(num_items * d_out.dtype.itemsize)
 
     def launcher(launch: bench.Launch):
-        transform(constant_it, d_out, OpKind.IDENTITY, num_items, launch.get_stream())
+        transform(
+            d_in=constant_it,
+            d_out=d_out,
+            op=OpKind.IDENTITY,
+            num_items=num_items,
+            stream=launch.get_stream(),
+        )
 
     state.exec(launcher, batched=False)
 

--- a/python/cuda_cccl/benchmarks/compute/transform/grayscale.py
+++ b/python/cuda_cccl/benchmarks/compute/transform/grayscale.py
@@ -63,14 +63,20 @@ def bench_transform_grayscale(state: bench.State):
         state.skip("Skipping: out of memory.")
         return
 
-    transformer = make_unary_transform(d_pixels, d_out, to_grayscale)
+    transformer = make_unary_transform(d_in=d_pixels, d_out=d_out, op=to_grayscale)
 
     state.add_element_count(num_elements)
     state.add_global_memory_reads(num_elements * d_pixels.dtype.itemsize)
     state.add_global_memory_writes(num_elements * d_out.dtype.itemsize)
 
     def launcher(launch: bench.Launch):
-        transformer(d_pixels, d_out, to_grayscale, num_elements, launch.get_stream())
+        transformer(
+            d_in=d_pixels,
+            d_out=d_out,
+            op=to_grayscale,
+            num_items=num_elements,
+            stream=launch.get_stream(),
+        )
 
     state.exec(launcher, batched=False)
 

--- a/python/cuda_cccl/benchmarks/compute/transform/heavy.py
+++ b/python/cuda_cccl/benchmarks/compute/transform/heavy.py
@@ -116,14 +116,16 @@ def bench_heavy(state: bench.State):
         return
 
     op = _HEAVY_OPS[n_regs]
-    transform = cuda.compute.make_unary_transform(d_in, d_out, op)
+    transform = cuda.compute.make_unary_transform(d_in=d_in, d_out=d_out, op=op)
 
     state.add_element_count(size)
     state.add_global_memory_reads(size * d_in.dtype.itemsize)
     state.add_global_memory_writes(size * d_out.dtype.itemsize)
 
     def launcher(launch: bench.Launch):
-        transform(d_in, d_out, op, size, launch.get_stream())
+        transform(
+            d_in=d_in, d_out=d_out, op=op, num_items=size, stream=launch.get_stream()
+        )
 
     state.exec(launcher, batched=False)
 

--- a/python/cuda_cccl/benchmarks/compute/transform_reduce/sum.py
+++ b/python/cuda_cccl/benchmarks/compute/transform_reduce/sum.py
@@ -49,7 +49,7 @@ def bench_transform_reduce_sum(state: bench.State):
     )
 
     temp_storage_bytes = reducer(
-        None,
+        temp_storage=None,
         d_in=transform_it,
         d_out=d_out,
         num_items=num_items,
@@ -65,7 +65,7 @@ def bench_transform_reduce_sum(state: bench.State):
 
     def launcher(launch: bench.Launch):
         reducer(
-            temp_storage,
+            temp_storage=temp_storage,
             d_in=transform_it,
             d_out=d_out,
             num_items=num_items,

--- a/python/cuda_cccl/benchmarks/compute/transform_reduce/sum.py
+++ b/python/cuda_cccl/benchmarks/compute/transform_reduce/sum.py
@@ -44,10 +44,17 @@ def bench_transform_reduce_sum(state: bench.State):
     transform_it = TransformIterator(d_in, square_op)
     h_init = np.zeros(1, dtype=dtype)
 
-    reducer = make_reduce_into(transform_it, d_out, OpKind.PLUS, h_init)
+    reducer = make_reduce_into(
+        d_in=transform_it, d_out=d_out, op=OpKind.PLUS, h_init=h_init
+    )
 
     temp_storage_bytes = reducer(
-        None, transform_it, d_out, OpKind.PLUS, num_items, h_init
+        None,
+        d_in=transform_it,
+        d_out=d_out,
+        num_items=num_items,
+        op=OpKind.PLUS,
+        h_init=h_init,
     )
     with alloc_stream:
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
@@ -57,7 +64,15 @@ def bench_transform_reduce_sum(state: bench.State):
     state.add_global_memory_writes(1 * d_out.dtype.itemsize)
 
     def launcher(launch: bench.Launch):
-        reducer(temp_storage, transform_it, d_out, OpKind.PLUS, num_items, h_init)
+        reducer(
+            temp_storage,
+            d_in=transform_it,
+            d_out=d_out,
+            num_items=num_items,
+            op=OpKind.PLUS,
+            h_init=h_init,
+            stream=launch.get_stream(),
+        )
 
     state.exec(launcher, batched=False)
 

--- a/python/cuda_cccl/cuda/compute/algorithms/_binary_search.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_binary_search.py
@@ -82,12 +82,13 @@ class _BinarySearch:
 
     def __call__(
         self,
+        *,
         d_data,
+        num_items: int,
         d_values,
+        num_values: int,
         d_out,
         comp: Operator | None,
-        num_items: int,
-        num_values: int,
         stream=None,
     ):
         set_cccl_iterator_state(self.d_data_cccl, d_data)
@@ -127,6 +128,7 @@ def _make_binary_search(
 
 
 def make_lower_bound(
+    *,
     d_data: DeviceArrayLike,
     d_values: DeviceArrayLike | IteratorT,
     d_out: DeviceArrayLike,
@@ -165,6 +167,7 @@ def make_lower_bound(
 
 
 def make_upper_bound(
+    *,
     d_data: DeviceArrayLike,
     d_values: DeviceArrayLike | IteratorT,
     d_out: DeviceArrayLike,
@@ -203,11 +206,12 @@ def make_upper_bound(
 
 
 def lower_bound(
+    *,
     d_data: DeviceArrayLike,
-    d_values: DeviceArrayLike | IteratorT,
-    d_out: DeviceArrayLike,
     num_items: int,
+    d_values: DeviceArrayLike | IteratorT,
     num_values: int,
+    d_out: DeviceArrayLike,
     comp: Operator | None = None,
     stream=None,
 ):
@@ -222,23 +226,34 @@ def lower_bound(
 
     Args:
         d_data: Device array containing the sorted input range.
-        d_values: Device array or iterator containing the search values.
-        d_out: Device array to store the index results.
         num_items: Number of items in ``d_data``.
+        d_values: Device array or iterator containing the search values.
         num_values: Number of items in ``d_values``.
+        d_out: Device array to store the index results.
         comp: Optional comparison operator (default: ``OpKind.LESS``).
         stream: CUDA stream for the operation (optional).
     """
-    searcher = make_lower_bound(d_data, d_values, d_out, comp)
-    searcher(d_data, d_values, d_out, comp, num_items, num_values, stream)
+    searcher = make_lower_bound(
+        d_data=d_data, d_values=d_values, d_out=d_out, comp=comp
+    )
+    searcher(
+        d_data=d_data,
+        num_items=num_items,
+        d_values=d_values,
+        num_values=num_values,
+        d_out=d_out,
+        comp=comp,
+        stream=stream,
+    )
 
 
 def upper_bound(
+    *,
     d_data: DeviceArrayLike,
-    d_values: DeviceArrayLike | IteratorT,
-    d_out: DeviceArrayLike,
     num_items: int,
+    d_values: DeviceArrayLike | IteratorT,
     num_values: int,
+    d_out: DeviceArrayLike,
     comp: Operator | None = None,
     stream=None,
 ):
@@ -253,12 +268,22 @@ def upper_bound(
 
     Args:
         d_data: Device array containing the sorted input range.
-        d_values: Device array or iterator containing the search values.
-        d_out: Device array to store the index results.
         num_items: Number of items in ``d_data``.
+        d_values: Device array or iterator containing the search values.
         num_values: Number of items in ``d_values``.
+        d_out: Device array to store the index results.
         comp: Optional comparison operator (default: ``OpKind.LESS``).
         stream: CUDA stream for the operation (optional).
     """
-    searcher = make_upper_bound(d_data, d_values, d_out, comp)
-    searcher(d_data, d_values, d_out, comp, num_items, num_values, stream)
+    searcher = make_upper_bound(
+        d_data=d_data, d_values=d_values, d_out=d_out, comp=comp
+    )
+    searcher(
+        d_data=d_data,
+        num_items=num_items,
+        d_values=d_values,
+        num_values=num_values,
+        d_out=d_out,
+        comp=comp,
+        stream=stream,
+    )

--- a/python/cuda_cccl/cuda/compute/algorithms/_histogram.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_histogram.py
@@ -66,6 +66,7 @@ class _Histogram:
 
     def __call__(
         self,
+        *,
         temp_storage,
         d_samples: DeviceArrayLike | IteratorT,
         d_histogram: DeviceArrayLike,
@@ -140,6 +141,7 @@ def _make_histogram_even_impl(
 
 
 def make_histogram_even(
+    *,
     d_samples: DeviceArrayLike | IteratorT,
     d_histogram: DeviceArrayLike,
     h_num_output_levels: np.ndarray,
@@ -192,6 +194,7 @@ def make_histogram_even(
 
 
 def histogram_even(
+    *,
     d_samples: DeviceArrayLike | IteratorT,
     d_histogram: DeviceArrayLike,
     num_output_levels: int,
@@ -231,31 +234,31 @@ def histogram_even(
     h_upper_level = np.array([upper_level], dtype=type(upper_level))
 
     histogram = make_histogram_even(
-        d_samples,
-        d_histogram,
-        h_num_output_levels,
-        h_lower_level,
-        h_upper_level,
-        num_samples,
+        d_samples=d_samples,
+        d_histogram=d_histogram,
+        h_num_output_levels=h_num_output_levels,
+        h_lower_level=h_lower_level,
+        h_upper_level=h_upper_level,
+        num_samples=num_samples,
     )
     temp_storage_bytes = histogram(
-        None,
-        d_samples,
-        d_histogram,
-        h_num_output_levels,
-        h_lower_level,
-        h_upper_level,
-        num_samples,
-        stream,
+        temp_storage=None,
+        d_samples=d_samples,
+        d_histogram=d_histogram,
+        h_num_output_levels=h_num_output_levels,
+        h_lower_level=h_lower_level,
+        h_upper_level=h_upper_level,
+        num_samples=num_samples,
+        stream=stream,
     )
     temp_storage = TempStorageBuffer(temp_storage_bytes, stream)
     histogram(
-        temp_storage,
-        d_samples,
-        d_histogram,
-        h_num_output_levels,
-        h_lower_level,
-        h_upper_level,
-        num_samples,
-        stream,
+        temp_storage=temp_storage,
+        d_samples=d_samples,
+        d_histogram=d_histogram,
+        h_num_output_levels=h_num_output_levels,
+        h_lower_level=h_lower_level,
+        h_upper_level=h_upper_level,
+        num_samples=num_samples,
+        stream=stream,
     )

--- a/python/cuda_cccl/cuda/compute/algorithms/_reduce.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_reduce.py
@@ -71,8 +71,8 @@ class _Reduce:
 
     def __call__(
         self,
-        temp_storage,
         *,
+        temp_storage,
         d_in,
         d_out,
         num_items: int,
@@ -185,7 +185,7 @@ def reduce_into(
     """
     reducer = make_reduce_into(d_in=d_in, d_out=d_out, op=op, h_init=h_init, **kwargs)
     tmp_storage_bytes = reducer(
-        None,
+        temp_storage=None,
         d_in=d_in,
         d_out=d_out,
         num_items=num_items,
@@ -195,7 +195,7 @@ def reduce_into(
     )
     tmp_storage = TempStorageBuffer(tmp_storage_bytes, stream)
     reducer(
-        tmp_storage,
+        temp_storage=tmp_storage,
         d_in=d_in,
         d_out=d_out,
         num_items=num_items,

--- a/python/cuda_cccl/cuda/compute/algorithms/_reduce.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_reduce.py
@@ -72,10 +72,11 @@ class _Reduce:
     def __call__(
         self,
         temp_storage,
+        *,
         d_in,
         d_out,
-        op: Callable | OpAdapter,
         num_items: int,
+        op: Callable | OpAdapter,
         h_init: np.ndarray | GpuStruct,
         stream=None,
     ):
@@ -112,6 +113,7 @@ class _Reduce:
 
 @cache_with_registered_key_functions
 def make_reduce_into(
+    *,
     d_in: DeviceArrayLike | IteratorT,
     d_out: DeviceArrayLike | IteratorT,
     op: Operator,
@@ -150,10 +152,11 @@ def make_reduce_into(
 
 
 def reduce_into(
+    *,
     d_in: DeviceArrayLike | IteratorT,
     d_out: DeviceArrayLike | IteratorT,
-    op: Operator,
     num_items: int,
+    op: Operator,
     h_init: np.ndarray | GpuStruct,
     stream=None,
     **kwargs,
@@ -173,14 +176,30 @@ def reduce_into(
     Args:
         d_in: Device array or iterator containing the input sequence of data items
         d_out: Device array to store the result of the reduction
+        num_items: Number of items to reduce
         op: Binary operator to apply.
             The signature is ``(T, T) -> T``, where ``T`` is
             the data type of the initial value ``h_init``.
-        num_items: Number of items to reduce
         h_init: Initial value for the reduction
         stream: CUDA stream for the operation (optional)
     """
-    reducer = make_reduce_into(d_in, d_out, op, h_init, **kwargs)
-    tmp_storage_bytes = reducer(None, d_in, d_out, op, num_items, h_init, stream)
+    reducer = make_reduce_into(d_in=d_in, d_out=d_out, op=op, h_init=h_init, **kwargs)
+    tmp_storage_bytes = reducer(
+        None,
+        d_in=d_in,
+        d_out=d_out,
+        num_items=num_items,
+        op=op,
+        h_init=h_init,
+        stream=stream,
+    )
     tmp_storage = TempStorageBuffer(tmp_storage_bytes, stream)
-    reducer(tmp_storage, d_in, d_out, op, num_items, h_init, stream)
+    reducer(
+        tmp_storage,
+        d_in=d_in,
+        d_out=d_out,
+        num_items=num_items,
+        op=op,
+        h_init=h_init,
+        stream=stream,
+    )

--- a/python/cuda_cccl/cuda/compute/algorithms/_scan.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_scan.py
@@ -117,11 +117,12 @@ class _Scan:
     def __call__(
         self,
         temp_storage,
+        *,
         d_in,
         d_out,
         op: Callable | OpAdapter,
-        num_items: int,
         init_value: np.ndarray | DeviceArrayLike | GpuStruct | None,
+        num_items: int,
         stream=None,
     ):
         set_cccl_iterator_state(self.d_in_cccl, d_in)
@@ -173,10 +174,11 @@ class _Scan:
 # TODO Accept stream
 @cache_with_registered_key_functions
 def make_exclusive_scan(
+    *,
     d_in: DeviceArrayLike | IteratorT,
     d_out: DeviceArrayLike | IteratorT,
     op: Operator,
-    init_value: np.ndarray | DeviceArrayLike | GpuStruct | None,
+    init_value: np.ndarray | DeviceArrayLike | GpuStruct,
 ):
     """Computes a device-wide scan using the specified binary ``op`` and initial value ``init``.
 
@@ -194,7 +196,7 @@ def make_exclusive_scan(
         op: Binary scan operator.
             The signature is ``(T, T) -> T``, where ``T`` is the data type of
             the initial value ``init_value``.
-        init_value: Numpy array, device array, or GPU struct storing initial value of the scan, or None for no initial value
+        init_value: Numpy array, device array, or GPU struct storing initial value of the scan
 
     Returns:
         A callable object that can be used to perform the scan
@@ -204,10 +206,11 @@ def make_exclusive_scan(
 
 
 def exclusive_scan(
+    *,
     d_in: DeviceArrayLike | IteratorT,
     d_out: DeviceArrayLike | IteratorT,
     op: Operator,
-    init_value: np.ndarray | DeviceArrayLike | GpuStruct | None,
+    init_value: np.ndarray | DeviceArrayLike | GpuStruct,
     num_items: int,
     stream=None,
 ):
@@ -234,20 +237,37 @@ def exclusive_scan(
         num_items: Number of items to scan
         stream: CUDA stream for the operation (optional)
     """
-    scanner = make_exclusive_scan(d_in, d_out, op, init_value)
-    tmp_storage_bytes = scanner(None, d_in, d_out, op, num_items, init_value, stream)
+    scanner = make_exclusive_scan(d_in=d_in, d_out=d_out, op=op, init_value=init_value)
+    tmp_storage_bytes = scanner(
+        None,
+        d_in=d_in,
+        d_out=d_out,
+        op=op,
+        init_value=init_value,
+        num_items=num_items,
+        stream=stream,
+    )
     tmp_storage = TempStorageBuffer(tmp_storage_bytes, stream)
-    scanner(tmp_storage, d_in, d_out, op, num_items, init_value, stream)
+    scanner(
+        tmp_storage,
+        d_in=d_in,
+        d_out=d_out,
+        op=op,
+        init_value=init_value,
+        num_items=num_items,
+        stream=stream,
+    )
 
 
 # TODO Figure out `sum` without operator and initial value
 # TODO Accept stream
 @cache_with_registered_key_functions
 def make_inclusive_scan(
+    *,
     d_in: DeviceArrayLike | IteratorT,
     d_out: DeviceArrayLike | IteratorT,
     op: Operator,
-    init_value: np.ndarray | DeviceArrayLike | GpuStruct | None,
+    init_value: np.ndarray | DeviceArrayLike | GpuStruct | None = None,
 ):
     """Computes a device-wide scan using the specified binary ``op`` and initial value ``init``.
 
@@ -275,10 +295,11 @@ def make_inclusive_scan(
 
 
 def inclusive_scan(
+    *,
     d_in: DeviceArrayLike | IteratorT,
     d_out: DeviceArrayLike | IteratorT,
     op: Operator,
-    init_value: np.ndarray | DeviceArrayLike | GpuStruct | None,
+    init_value: np.ndarray | DeviceArrayLike | GpuStruct | None = None,
     num_items: int,
     stream=None,
 ):
@@ -305,7 +326,23 @@ def inclusive_scan(
         num_items: Number of items to scan
         stream: CUDA stream for the operation (optional)
     """
-    scanner = make_inclusive_scan(d_in, d_out, op, init_value)
-    tmp_storage_bytes = scanner(None, d_in, d_out, op, num_items, init_value, stream)
+    scanner = make_inclusive_scan(d_in=d_in, d_out=d_out, op=op, init_value=init_value)
+    tmp_storage_bytes = scanner(
+        None,
+        d_in=d_in,
+        d_out=d_out,
+        op=op,
+        init_value=init_value,
+        num_items=num_items,
+        stream=stream,
+    )
     tmp_storage = TempStorageBuffer(tmp_storage_bytes, stream)
-    scanner(tmp_storage, d_in, d_out, op, num_items, init_value, stream)
+    scanner(
+        tmp_storage,
+        d_in=d_in,
+        d_out=d_out,
+        op=op,
+        init_value=init_value,
+        num_items=num_items,
+        stream=stream,
+    )

--- a/python/cuda_cccl/cuda/compute/algorithms/_scan.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_scan.py
@@ -116,8 +116,8 @@ class _Scan:
 
     def __call__(
         self,
-        temp_storage,
         *,
+        temp_storage,
         d_in,
         d_out,
         op: Callable | OpAdapter,
@@ -239,7 +239,7 @@ def exclusive_scan(
     """
     scanner = make_exclusive_scan(d_in=d_in, d_out=d_out, op=op, init_value=init_value)
     tmp_storage_bytes = scanner(
-        None,
+        temp_storage=None,
         d_in=d_in,
         d_out=d_out,
         op=op,
@@ -249,7 +249,7 @@ def exclusive_scan(
     )
     tmp_storage = TempStorageBuffer(tmp_storage_bytes, stream)
     scanner(
-        tmp_storage,
+        temp_storage=tmp_storage,
         d_in=d_in,
         d_out=d_out,
         op=op,
@@ -328,7 +328,7 @@ def inclusive_scan(
     """
     scanner = make_inclusive_scan(d_in=d_in, d_out=d_out, op=op, init_value=init_value)
     tmp_storage_bytes = scanner(
-        None,
+        temp_storage=None,
         d_in=d_in,
         d_out=d_out,
         op=op,
@@ -338,7 +338,7 @@ def inclusive_scan(
     )
     tmp_storage = TempStorageBuffer(tmp_storage_bytes, stream)
     scanner(
-        tmp_storage,
+        temp_storage=tmp_storage,
         d_in=d_in,
         d_out=d_out,
         op=op,

--- a/python/cuda_cccl/cuda/compute/algorithms/_segmented_reduce.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_segmented_reduce.py
@@ -70,8 +70,8 @@ class _SegmentedReduce:
 
     def __call__(
         self,
-        temp_storage,
         *,
+        temp_storage,
         d_in,
         d_out,
         num_segments: int,
@@ -213,7 +213,7 @@ def segmented_reduce(
         h_init=h_init,
     )
     tmp_storage_bytes = reducer(
-        None,
+        temp_storage=None,
         d_in=d_in,
         d_out=d_out,
         num_segments=num_segments,
@@ -226,7 +226,7 @@ def segmented_reduce(
     )
     tmp_storage = TempStorageBuffer(tmp_storage_bytes, stream)
     reducer(
-        tmp_storage,
+        temp_storage=tmp_storage,
         d_in=d_in,
         d_out=d_out,
         num_segments=num_segments,

--- a/python/cuda_cccl/cuda/compute/algorithms/_segmented_reduce.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_segmented_reduce.py
@@ -71,12 +71,13 @@ class _SegmentedReduce:
     def __call__(
         self,
         temp_storage,
+        *,
         d_in,
         d_out,
-        op: Callable | OpAdapter,
         num_segments: int,
         start_offsets_in,
         end_offsets_in,
+        op: Callable | OpAdapter,
         h_init,
         max_segment_size: int | None = None,
         stream=None,
@@ -126,6 +127,7 @@ class _SegmentedReduce:
 
 @cache_with_registered_key_functions
 def make_segmented_reduce(
+    *,
     d_in: DeviceArrayLike | IteratorT,
     d_out: DeviceArrayLike | IteratorT,
     start_offsets_in: DeviceArrayLike | IteratorT,
@@ -163,13 +165,14 @@ def make_segmented_reduce(
 
 
 def segmented_reduce(
+    *,
     d_in: DeviceArrayLike | IteratorT,
     d_out: DeviceArrayLike | IteratorT,
+    num_segments: int,
     start_offsets_in: DeviceArrayLike | IteratorT,
     end_offsets_in: DeviceArrayLike | IteratorT,
     op: Operator,
     h_init: np.ndarray | GpuStruct,
-    num_segments: int,
     max_segment_size: int | None = None,
     stream=None,
 ):
@@ -189,43 +192,48 @@ def segmented_reduce(
     Args:
         d_in: Device array or iterator containing the input sequence of data items
         d_out: Device array to store the result of the reduction for each segment
+        num_segments: Number of segments to reduce
         start_offsets_in: Device array or iterator containing the sequence of beginning offsets
         end_offsets_in: Device array or iterator containing the sequence of ending offsets
         op: Binary operator to apply.
             The signature is ``(T, T) -> T``, where ``T`` is
             the data type of the initial value ``h_init``.
         h_init: Initial value for the reduction
-        num_segments: Number of segments to reduce
         max_segment_size: The number of elements in the largest segment (optional)
             If provided, this information is used to dispatch to the
             optimal kernel for best performance.
         stream: CUDA stream for the operation (optional)
     """
     reducer = make_segmented_reduce(
-        d_in, d_out, start_offsets_in, end_offsets_in, op, h_init
+        d_in=d_in,
+        d_out=d_out,
+        start_offsets_in=start_offsets_in,
+        end_offsets_in=end_offsets_in,
+        op=op,
+        h_init=h_init,
     )
     tmp_storage_bytes = reducer(
         None,
-        d_in,
-        d_out,
-        op,
-        num_segments,
-        start_offsets_in,
-        end_offsets_in,
-        h_init,
-        max_segment_size,
-        stream,
+        d_in=d_in,
+        d_out=d_out,
+        num_segments=num_segments,
+        start_offsets_in=start_offsets_in,
+        end_offsets_in=end_offsets_in,
+        op=op,
+        h_init=h_init,
+        max_segment_size=max_segment_size,
+        stream=stream,
     )
     tmp_storage = TempStorageBuffer(tmp_storage_bytes, stream)
     reducer(
         tmp_storage,
-        d_in,
-        d_out,
-        op,
-        num_segments,
-        start_offsets_in,
-        end_offsets_in,
-        h_init,
-        max_segment_size,
-        stream,
+        d_in=d_in,
+        d_out=d_out,
+        num_segments=num_segments,
+        start_offsets_in=start_offsets_in,
+        end_offsets_in=end_offsets_in,
+        op=op,
+        h_init=h_init,
+        max_segment_size=max_segment_size,
+        stream=stream,
     )

--- a/python/cuda_cccl/cuda/compute/algorithms/_select.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_select.py
@@ -58,6 +58,7 @@ class _Select:
 
     def __call__(
         self,
+        *,
         temp_storage,
         d_in,
         d_out,
@@ -67,21 +68,22 @@ class _Select:
         stream=None,
     ):
         return self.partitioner(
-            temp_storage,
-            d_in,
-            d_out,
-            self.discard_second,
-            self.discard_unselected,
-            d_num_selected_out,
-            make_op_adapter(cond),
-            self.false_op,
-            num_items,
-            stream,
+            temp_storage=temp_storage,
+            d_in=d_in,
+            d_first_part_out=d_out,
+            d_second_part_out=self.discard_second,
+            d_unselected_out=self.discard_unselected,
+            d_num_selected_out=d_num_selected_out,
+            select_first_part_op=make_op_adapter(cond),
+            select_second_part_op=self.false_op,
+            num_items=num_items,
+            stream=stream,
         )
 
 
 @cache_with_registered_key_functions
 def make_select(
+    *,
     d_in: DeviceArrayLike | IteratorT,
     d_out: DeviceArrayLike | IteratorT,
     d_num_selected_out: DeviceArrayLike,
@@ -120,6 +122,7 @@ def make_select(
 
 
 def select(
+    *,
     d_in: DeviceArrayLike | IteratorT,
     d_out: DeviceArrayLike | IteratorT,
     d_num_selected_out: DeviceArrayLike,
@@ -166,24 +169,26 @@ def select(
     """
     # Create adapter to support stateful ops
     cond_adapter = make_op_adapter(cond)
-    selector = make_select(d_in, d_out, d_num_selected_out, cond_adapter)
+    selector = make_select(
+        d_in=d_in, d_out=d_out, d_num_selected_out=d_num_selected_out, cond=cond_adapter
+    )
 
     tmp_storage_bytes = selector(
-        None,
-        d_in,
-        d_out,
-        d_num_selected_out,
-        cond_adapter,
-        num_items,
-        stream,
+        temp_storage=None,
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected_out,
+        cond=cond_adapter,
+        num_items=num_items,
+        stream=stream,
     )
     tmp_storage = TempStorageBuffer(tmp_storage_bytes, stream)
     selector(
-        tmp_storage,
-        d_in,
-        d_out,
-        d_num_selected_out,
-        cond_adapter,
-        num_items,
-        stream,
+        temp_storage=tmp_storage,
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected_out,
+        cond=cond_adapter,
+        num_items=num_items,
+        stream=stream,
     )

--- a/python/cuda_cccl/cuda/compute/algorithms/_select.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_select.py
@@ -47,13 +47,13 @@ class _Select:
 
         # Use three_way_partition internally
         self.partitioner = make_three_way_partition(
-            d_in,
-            d_out,  # first_part_out - this is where selected items go
-            self.discard_second,  # second_part_out - discarded
-            self.discard_unselected,  # unselected_out - discarded
-            d_num_selected_out,
-            cond,  # select_first_part_op - user's select condition
-            self.false_op,  # select_second_part_op - always false
+            d_in=d_in,
+            d_first_part_out=d_out,
+            d_second_part_out=self.discard_second,
+            d_unselected_out=self.discard_unselected,
+            d_num_selected_out=d_num_selected_out,
+            select_first_part_op=cond,
+            select_second_part_op=self.false_op,
         )
 
     def __call__(

--- a/python/cuda_cccl/cuda/compute/algorithms/_sort/_merge_sort.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_sort/_merge_sort.py
@@ -63,8 +63,8 @@ class _MergeSort:
 
     def __call__(
         self,
-        temp_storage,
         *,
+        temp_storage,
         d_in_keys: DeviceArrayLike | IteratorT,
         d_in_values: DeviceArrayLike | IteratorT | None,
         d_out_keys: DeviceArrayLike,
@@ -198,7 +198,7 @@ def merge_sort(
         op=op,
     )
     tmp_storage_bytes = sorter(
-        None,
+        temp_storage=None,
         d_in_keys=d_in_keys,
         d_in_values=d_in_values,
         d_out_keys=d_out_keys,
@@ -209,7 +209,7 @@ def merge_sort(
     )
     tmp_storage = TempStorageBuffer(tmp_storage_bytes, stream)
     sorter(
-        tmp_storage,
+        temp_storage=tmp_storage,
         d_in_keys=d_in_keys,
         d_in_values=d_in_values,
         d_out_keys=d_out_keys,

--- a/python/cuda_cccl/cuda/compute/algorithms/_sort/_merge_sort.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_sort/_merge_sort.py
@@ -22,9 +22,9 @@ from ...typing import DeviceArrayLike, IteratorT, Operator
 class _MergeSort:
     __slots__ = [
         "d_in_keys_cccl",
-        "d_in_items_cccl",
+        "d_in_values_cccl",
         "d_out_keys_cccl",
-        "d_out_items_cccl",
+        "d_out_values_cccl",
         "op_adapter",
         "op_cccl",
         "build_result",
@@ -33,19 +33,19 @@ class _MergeSort:
     def __init__(
         self,
         d_in_keys: DeviceArrayLike | IteratorT,
-        d_in_items: DeviceArrayLike | IteratorT | None,
+        d_in_values: DeviceArrayLike | IteratorT | None,
         d_out_keys: DeviceArrayLike,
-        d_out_items: DeviceArrayLike | None,
+        d_out_values: DeviceArrayLike | None,
         op: OpAdapter,
     ):
-        present_in_values = d_in_items is not None
-        present_out_values = d_out_items is not None
+        present_in_values = d_in_values is not None
+        present_out_values = d_out_values is not None
         assert present_in_values == present_out_values
 
         self.d_in_keys_cccl = cccl.to_cccl_input_iter(d_in_keys)
-        self.d_in_items_cccl = cccl.to_cccl_input_iter(d_in_items)
+        self.d_in_values_cccl = cccl.to_cccl_input_iter(d_in_values)
         self.d_out_keys_cccl = cccl.to_cccl_output_iter(d_out_keys)
-        self.d_out_items_cccl = cccl.to_cccl_output_iter(d_out_items)
+        self.d_out_values_cccl = cccl.to_cccl_output_iter(d_out_values)
         self.op_adapter = op
 
         # Compile the op - merge_sort expects int8 return (comparison)
@@ -55,33 +55,34 @@ class _MergeSort:
         self.build_result = call_build(
             _bindings.DeviceMergeSortBuildResult,
             self.d_in_keys_cccl,
-            self.d_in_items_cccl,
+            self.d_in_values_cccl,
             self.d_out_keys_cccl,
-            self.d_out_items_cccl,
+            self.d_out_values_cccl,
             self.op_cccl,
         )
 
     def __call__(
         self,
         temp_storage,
+        *,
         d_in_keys: DeviceArrayLike | IteratorT,
-        d_in_items: DeviceArrayLike | IteratorT | None,
+        d_in_values: DeviceArrayLike | IteratorT | None,
         d_out_keys: DeviceArrayLike,
-        d_out_items: DeviceArrayLike | None,
-        op: Operator,
+        d_out_values: DeviceArrayLike | None,
         num_items: int,
+        op: Operator,
         stream=None,
     ):
-        present_in_values = d_in_items is not None
-        present_out_values = d_out_items is not None
+        present_in_values = d_in_values is not None
+        present_out_values = d_out_values is not None
         assert present_in_values == present_out_values
 
         set_cccl_iterator_state(self.d_in_keys_cccl, d_in_keys)
         if present_in_values:
-            set_cccl_iterator_state(self.d_in_items_cccl, d_in_items)
+            set_cccl_iterator_state(self.d_in_values_cccl, d_in_values)
         set_cccl_iterator_state(self.d_out_keys_cccl, d_out_keys)
         if present_out_values:
-            set_cccl_iterator_state(self.d_out_items_cccl, d_out_items)
+            set_cccl_iterator_state(self.d_out_values_cccl, d_out_values)
 
         op_adapter = make_op_adapter(op)
         self.op_cccl.state = op_adapter.get_state()
@@ -100,9 +101,9 @@ class _MergeSort:
             d_temp_storage,
             temp_storage_bytes,
             self.d_in_keys_cccl,
-            self.d_in_items_cccl,
+            self.d_in_values_cccl,
             self.d_out_keys_cccl,
-            self.d_out_items_cccl,
+            self.d_out_values_cccl,
             num_items,
             self.op_cccl,
             stream_handle,
@@ -113,10 +114,11 @@ class _MergeSort:
 
 @cache_with_registered_key_functions
 def make_merge_sort(
+    *,
     d_in_keys: DeviceArrayLike | IteratorT,
-    d_in_items: DeviceArrayLike | IteratorT | None,
+    d_in_values: DeviceArrayLike | IteratorT | None = None,
     d_out_keys: DeviceArrayLike,
-    d_out_items: DeviceArrayLike | None,
+    d_out_values: DeviceArrayLike | None = None,
     op: Operator,
 ):
     """Implements a device-wide merge sort using ``d_in_keys`` and the comparison operator ``op``.
@@ -131,9 +133,9 @@ def make_merge_sort(
 
     Args:
         d_in_keys: Device array or iterator containing the input keys to be sorted
-        d_in_items: Optional device array or iterator that contains each key's corresponding item
+        d_in_values: Optional device array or iterator that contains each key's corresponding value
         d_out_keys: Device array to store the sorted keys
-        d_out_items: Device array to store the sorted items
+        d_out_values: Device array to store the sorted values
         op: The comparison operator for sorting. The signature is  ``(T, T) -> int8``, where ``T`` is the input data type. See notes below.
 
     Returns:
@@ -147,16 +149,17 @@ def make_merge_sort(
       follow the required semantics can lead to incorrect results, silent memory corruption, or crashes.
     """
     op_adapter = make_op_adapter(op)
-    return _MergeSort(d_in_keys, d_in_items, d_out_keys, d_out_items, op_adapter)
+    return _MergeSort(d_in_keys, d_in_values, d_out_keys, d_out_values, op_adapter)
 
 
 def merge_sort(
+    *,
     d_in_keys: DeviceArrayLike | IteratorT,
-    d_in_items: DeviceArrayLike | IteratorT | None,
+    d_in_values: DeviceArrayLike | IteratorT | None = None,
     d_out_keys: DeviceArrayLike,
-    d_out_items: DeviceArrayLike | None,
-    op: Operator,
+    d_out_values: DeviceArrayLike | None = None,
     num_items: int,
+    op: Operator,
     stream=None,
 ):
     """
@@ -165,7 +168,7 @@ def merge_sort(
     This function automatically handles temporary storage allocation and execution.
 
     Example:
-        Below, ``merge_sort`` is used to sort a sequence of keys inplace. It also rearranges the items according to the keys' order.
+        Below, ``merge_sort`` is used to sort a sequence of keys inplace. It also rearranges the values according to the keys' order.
 
         .. literalinclude:: ../../python/cuda_cccl/tests/compute/examples/sort/merge_sort_basic.py
             :language: python
@@ -173,11 +176,11 @@ def merge_sort(
 
     Args:
         d_in_keys: Device array or iterator containing the input sequence of keys
-        d_in_items: Device array or iterator containing the input sequence of items (optional)
+        d_in_values: Device array or iterator containing the input sequence of values (optional)
         d_out_keys: Device array to store the sorted keys
-        d_out_items: Device array to store the sorted items (optional)
-        op: The comparison operator for sorting. The signature is  ``(T, T) -> int8``, where ``T`` is the input data type. See notes below.
+        d_out_values: Device array to store the sorted values (optional)
         num_items: Number of items to sort
+        op: The comparison operator for sorting. The signature is  ``(T, T) -> int8``, where ``T`` is the input data type. See notes below.
         stream: CUDA stream for the operation (optional)
 
     .. important::
@@ -187,18 +190,31 @@ def merge_sort(
       ``lambda lhs, rhs: rhs >= lhs`` does not, because it is reflexive: ``r(x, x) == True``. Providing a comparator that does not
       follow the required semantics can lead to incorrect results, silent memory corruption, or crashes.
     """
-    sorter = make_merge_sort(d_in_keys, d_in_items, d_out_keys, d_out_items, op)
+    sorter = make_merge_sort(
+        d_in_keys=d_in_keys,
+        d_in_values=d_in_values,
+        d_out_keys=d_out_keys,
+        d_out_values=d_out_values,
+        op=op,
+    )
     tmp_storage_bytes = sorter(
-        None, d_in_keys, d_in_items, d_out_keys, d_out_items, op, num_items, stream
+        None,
+        d_in_keys=d_in_keys,
+        d_in_values=d_in_values,
+        d_out_keys=d_out_keys,
+        d_out_values=d_out_values,
+        num_items=num_items,
+        op=op,
+        stream=stream,
     )
     tmp_storage = TempStorageBuffer(tmp_storage_bytes, stream)
     sorter(
         tmp_storage,
-        d_in_keys,
-        d_in_items,
-        d_out_keys,
-        d_out_items,
-        op,
-        num_items,
-        stream,
+        d_in_keys=d_in_keys,
+        d_in_values=d_in_values,
+        d_out_keys=d_out_keys,
+        d_out_values=d_out_values,
+        num_items=num_items,
+        op=op,
+        stream=stream,
     )

--- a/python/cuda_cccl/cuda/compute/algorithms/_sort/_radix_sort.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_sort/_radix_sort.py
@@ -70,6 +70,7 @@ class _RadixSort:
     def __call__(
         self,
         temp_storage,
+        *,
         d_in_keys: DeviceArrayLike | DoubleBuffer,
         d_out_keys: DeviceArrayLike | None,
         d_in_values: DeviceArrayLike | DoubleBuffer | None,
@@ -139,6 +140,7 @@ class _RadixSort:
 
 @cache_with_registered_key_functions
 def make_radix_sort(
+    *,
     d_in_keys: DeviceArrayLike | DoubleBuffer,
     d_out_keys: DeviceArrayLike | None,
     d_in_values: DeviceArrayLike | DoubleBuffer | None,
@@ -169,12 +171,13 @@ def make_radix_sort(
 
 
 def radix_sort(
+    *,
     d_in_keys: DeviceArrayLike | DoubleBuffer,
     d_out_keys: DeviceArrayLike | None,
-    d_in_values: DeviceArrayLike | DoubleBuffer | None,
-    d_out_values: DeviceArrayLike | None,
-    order: SortOrder,
+    d_in_values: DeviceArrayLike | DoubleBuffer | None = None,
+    d_out_values: DeviceArrayLike | None = None,
     num_items: int,
+    order: SortOrder,
     begin_bit: int | None = None,
     end_bit: int | None = None,
     stream=None,
@@ -204,33 +207,39 @@ def radix_sort(
         d_out_keys: Device array to store the sorted keys (optional)
         d_in_values: Device array or DoubleBuffer containing the input sequence of values (optional)
         d_out_values: Device array to store the sorted values (optional)
-        order: Sort order (ascending or descending)
         num_items: Number of items to sort
+        order: Sort order (ascending or descending)
         begin_bit: Beginning bit position for comparison (optional)
         end_bit: Ending bit position for comparison (optional)
         stream: CUDA stream for the operation (optional)
     """
-    sorter = make_radix_sort(d_in_keys, d_out_keys, d_in_values, d_out_values, order)
+    sorter = make_radix_sort(
+        d_in_keys=d_in_keys,
+        d_out_keys=d_out_keys,
+        d_in_values=d_in_values,
+        d_out_values=d_out_values,
+        order=order,
+    )
     tmp_storage_bytes = sorter(
         None,
-        d_in_keys,
-        d_out_keys,
-        d_in_values,
-        d_out_values,
-        num_items,
-        begin_bit,
-        end_bit,
-        stream,
+        d_in_keys=d_in_keys,
+        d_out_keys=d_out_keys,
+        d_in_values=d_in_values,
+        d_out_values=d_out_values,
+        num_items=num_items,
+        begin_bit=begin_bit,
+        end_bit=end_bit,
+        stream=stream,
     )
     tmp_storage = TempStorageBuffer(tmp_storage_bytes, stream)
     sorter(
         tmp_storage,
-        d_in_keys,
-        d_out_keys,
-        d_in_values,
-        d_out_values,
-        num_items,
-        begin_bit,
-        end_bit,
-        stream,
+        d_in_keys=d_in_keys,
+        d_out_keys=d_out_keys,
+        d_in_values=d_in_values,
+        d_out_values=d_out_values,
+        num_items=num_items,
+        begin_bit=begin_bit,
+        end_bit=end_bit,
+        stream=stream,
     )

--- a/python/cuda_cccl/cuda/compute/algorithms/_sort/_radix_sort.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_sort/_radix_sort.py
@@ -69,8 +69,8 @@ class _RadixSort:
 
     def __call__(
         self,
-        temp_storage,
         *,
+        temp_storage,
         d_in_keys: DeviceArrayLike | DoubleBuffer,
         d_out_keys: DeviceArrayLike | None,
         d_in_values: DeviceArrayLike | DoubleBuffer | None,
@@ -221,7 +221,7 @@ def radix_sort(
         order=order,
     )
     tmp_storage_bytes = sorter(
-        None,
+        temp_storage=None,
         d_in_keys=d_in_keys,
         d_out_keys=d_out_keys,
         d_in_values=d_in_values,
@@ -233,7 +233,7 @@ def radix_sort(
     )
     tmp_storage = TempStorageBuffer(tmp_storage_bytes, stream)
     sorter(
-        tmp_storage,
+        temp_storage=tmp_storage,
         d_in_keys=d_in_keys,
         d_out_keys=d_out_keys,
         d_in_values=d_in_values,

--- a/python/cuda_cccl/cuda/compute/algorithms/_sort/_segmented_sort.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_sort/_segmented_sort.py
@@ -66,6 +66,7 @@ class _SegmentedSort:
     def __call__(
         self,
         temp_storage,
+        *,
         d_in_keys,
         d_out_keys,
         d_in_values,
@@ -134,10 +135,11 @@ class _SegmentedSort:
 
 @cache_with_registered_key_functions
 def make_segmented_sort(
+    *,
     d_in_keys: DeviceArrayLike | DoubleBuffer,
-    d_out_keys: DeviceArrayLike | None,
-    d_in_values: DeviceArrayLike | DoubleBuffer | None,
-    d_out_values: DeviceArrayLike | None,
+    d_out_keys: DeviceArrayLike | None = None,
+    d_in_values: DeviceArrayLike | DoubleBuffer | None = None,
+    d_out_values: DeviceArrayLike | None = None,
     start_offsets_in: DeviceArrayLike,
     end_offsets_in: DeviceArrayLike,
     order: SortOrder,
@@ -176,10 +178,11 @@ def make_segmented_sort(
 
 
 def segmented_sort(
+    *,
     d_in_keys: DeviceArrayLike | DoubleBuffer,
-    d_out_keys: DeviceArrayLike | None,
-    d_in_values: DeviceArrayLike | DoubleBuffer | None,
-    d_out_values: DeviceArrayLike | None,
+    d_out_keys: DeviceArrayLike | None = None,
+    d_in_values: DeviceArrayLike | DoubleBuffer | None = None,
+    d_out_values: DeviceArrayLike | None = None,
     num_items: int,
     num_segments: int,
     start_offsets_in: DeviceArrayLike,
@@ -219,36 +222,36 @@ def segmented_sort(
         stream: CUDA stream for the operation (optional)
     """
     sorter = make_segmented_sort(
-        d_in_keys,
-        d_out_keys,
-        d_in_values,
-        d_out_values,
-        start_offsets_in,
-        end_offsets_in,
-        order,
+        d_in_keys=d_in_keys,
+        d_out_keys=d_out_keys,
+        d_in_values=d_in_values,
+        d_out_values=d_out_values,
+        start_offsets_in=start_offsets_in,
+        end_offsets_in=end_offsets_in,
+        order=order,
     )
     tmp_storage_bytes = sorter(
         None,
-        d_in_keys,
-        d_out_keys,
-        d_in_values,
-        d_out_values,
-        num_items,
-        num_segments,
-        start_offsets_in,
-        end_offsets_in,
-        stream,
+        d_in_keys=d_in_keys,
+        d_out_keys=d_out_keys,
+        d_in_values=d_in_values,
+        d_out_values=d_out_values,
+        num_items=num_items,
+        num_segments=num_segments,
+        start_offsets_in=start_offsets_in,
+        end_offsets_in=end_offsets_in,
+        stream=stream,
     )
     tmp_storage = TempStorageBuffer(tmp_storage_bytes, stream)
     sorter(
         tmp_storage,
-        d_in_keys,
-        d_out_keys,
-        d_in_values,
-        d_out_values,
-        num_items,
-        num_segments,
-        start_offsets_in,
-        end_offsets_in,
-        stream,
+        d_in_keys=d_in_keys,
+        d_out_keys=d_out_keys,
+        d_in_values=d_in_values,
+        d_out_values=d_out_values,
+        num_items=num_items,
+        num_segments=num_segments,
+        start_offsets_in=start_offsets_in,
+        end_offsets_in=end_offsets_in,
+        stream=stream,
     )

--- a/python/cuda_cccl/cuda/compute/algorithms/_sort/_segmented_sort.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_sort/_segmented_sort.py
@@ -65,8 +65,8 @@ class _SegmentedSort:
 
     def __call__(
         self,
-        temp_storage,
         *,
+        temp_storage,
         d_in_keys,
         d_out_keys,
         d_in_values,
@@ -231,7 +231,7 @@ def segmented_sort(
         order=order,
     )
     tmp_storage_bytes = sorter(
-        None,
+        temp_storage=None,
         d_in_keys=d_in_keys,
         d_out_keys=d_out_keys,
         d_in_values=d_in_values,
@@ -244,7 +244,7 @@ def segmented_sort(
     )
     tmp_storage = TempStorageBuffer(tmp_storage_bytes, stream)
     sorter(
-        tmp_storage,
+        temp_storage=tmp_storage,
         d_in_keys=d_in_keys,
         d_out_keys=d_out_keys,
         d_in_values=d_in_values,

--- a/python/cuda_cccl/cuda/compute/algorithms/_three_way_partition.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_three_way_partition.py
@@ -67,6 +67,7 @@ class _ThreeWayPartition:
 
     def __call__(
         self,
+        *,
         temp_storage,
         d_in,
         d_first_part_out,
@@ -116,6 +117,7 @@ class _ThreeWayPartition:
 
 @cache_with_registered_key_functions
 def make_three_way_partition(
+    *,
     d_in: DeviceArrayLike | IteratorT,
     d_first_part_out: DeviceArrayLike | IteratorT,
     d_second_part_out: DeviceArrayLike | IteratorT,
@@ -167,6 +169,7 @@ def make_three_way_partition(
 
 
 def three_way_partition(
+    *,
     d_in: DeviceArrayLike | IteratorT,
     d_first_part_out: DeviceArrayLike | IteratorT,
     d_second_part_out: DeviceArrayLike | IteratorT,
@@ -212,36 +215,36 @@ def three_way_partition(
     second_op_adapter = make_op_adapter(select_second_part_op)
 
     partitioner = make_three_way_partition(
-        d_in,
-        d_first_part_out,
-        d_second_part_out,
-        d_unselected_out,
-        d_num_selected_out,
-        first_op_adapter,
-        second_op_adapter,
+        d_in=d_in,
+        d_first_part_out=d_first_part_out,
+        d_second_part_out=d_second_part_out,
+        d_unselected_out=d_unselected_out,
+        d_num_selected_out=d_num_selected_out,
+        select_first_part_op=first_op_adapter,
+        select_second_part_op=second_op_adapter,
     )
     tmp_storage_bytes = partitioner(
-        None,
-        d_in,
-        d_first_part_out,
-        d_second_part_out,
-        d_unselected_out,
-        d_num_selected_out,
-        first_op_adapter,
-        second_op_adapter,
-        num_items,
-        stream,
+        temp_storage=None,
+        d_in=d_in,
+        d_first_part_out=d_first_part_out,
+        d_second_part_out=d_second_part_out,
+        d_unselected_out=d_unselected_out,
+        d_num_selected_out=d_num_selected_out,
+        select_first_part_op=first_op_adapter,
+        select_second_part_op=second_op_adapter,
+        num_items=num_items,
+        stream=stream,
     )
     tmp_storage = TempStorageBuffer(tmp_storage_bytes, stream)
     partitioner(
-        tmp_storage,
-        d_in,
-        d_first_part_out,
-        d_second_part_out,
-        d_unselected_out,
-        d_num_selected_out,
-        first_op_adapter,
-        second_op_adapter,
-        num_items,
-        stream,
+        temp_storage=tmp_storage,
+        d_in=d_in,
+        d_first_part_out=d_first_part_out,
+        d_second_part_out=d_second_part_out,
+        d_unselected_out=d_unselected_out,
+        d_num_selected_out=d_num_selected_out,
+        select_first_part_op=first_op_adapter,
+        select_second_part_op=second_op_adapter,
+        num_items=num_items,
+        stream=stream,
     )

--- a/python/cuda_cccl/cuda/compute/algorithms/_transform.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_transform.py
@@ -42,6 +42,7 @@ class _UnaryTransform:
 
     def __call__(
         self,
+        *,
         d_in,
         d_out,
         op: Callable | OpAdapter,
@@ -101,6 +102,7 @@ class _BinaryTransform:
 
     def __call__(
         self,
+        *,
         d_in1,
         d_in2,
         d_out,
@@ -129,6 +131,7 @@ class _BinaryTransform:
 
 @cache_with_registered_key_functions
 def make_unary_transform(
+    *,
     d_in: DeviceArrayLike | IteratorT,
     d_out: DeviceArrayLike | IteratorT,
     op: Operator,
@@ -162,6 +165,7 @@ def make_unary_transform(
 
 @cache_with_registered_key_functions
 def make_binary_transform(
+    *,
     d_in1: DeviceArrayLike | IteratorT,
     d_in2: DeviceArrayLike | IteratorT,
     d_out: DeviceArrayLike | IteratorT,
@@ -196,6 +200,7 @@ def make_binary_transform(
 
 
 def unary_transform(
+    *,
     d_in: DeviceArrayLike | IteratorT,
     d_out: DeviceArrayLike | IteratorT,
     op: Operator,
@@ -236,11 +241,14 @@ def unary_transform(
         stream: CUDA stream to use for the operation.
     """
     op_adapter = make_op_adapter(op)
-    transformer = make_unary_transform(d_in, d_out, op_adapter)
-    transformer(d_in, d_out, op_adapter, num_items, stream)
+    transformer = make_unary_transform(d_in=d_in, d_out=d_out, op=op_adapter)
+    transformer(
+        d_in=d_in, d_out=d_out, op=op_adapter, num_items=num_items, stream=stream
+    )
 
 
 def binary_transform(
+    *,
     d_in1: DeviceArrayLike | IteratorT,
     d_in2: DeviceArrayLike | IteratorT,
     d_out: DeviceArrayLike | IteratorT,
@@ -280,5 +288,14 @@ def binary_transform(
         stream: CUDA stream to use for the operation.
     """
     op_adapter = make_op_adapter(op)
-    transformer = make_binary_transform(d_in1, d_in2, d_out, op_adapter)
-    transformer(d_in1, d_in2, d_out, op_adapter, num_items, stream)
+    transformer = make_binary_transform(
+        d_in1=d_in1, d_in2=d_in2, d_out=d_out, op=op_adapter
+    )
+    transformer(
+        d_in1=d_in1,
+        d_in2=d_in2,
+        d_out=d_out,
+        op=op_adapter,
+        num_items=num_items,
+        stream=stream,
+    )

--- a/python/cuda_cccl/cuda/compute/algorithms/_unique_by_key.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_unique_by_key.py
@@ -61,6 +61,7 @@ class _UniqueByKey:
 
     def __call__(
         self,
+        *,
         temp_storage,
         d_in_keys: DeviceArrayLike | IteratorT,
         d_in_items: DeviceArrayLike | IteratorT,
@@ -108,6 +109,7 @@ class _UniqueByKey:
 
 @cache_with_registered_key_functions
 def make_unique_by_key(
+    *,
     d_in_keys: DeviceArrayLike | IteratorT,
     d_in_items: DeviceArrayLike | IteratorT,
     d_out_keys: DeviceArrayLike | IteratorT,
@@ -143,6 +145,7 @@ def make_unique_by_key(
 
 
 def unique_by_key(
+    *,
     d_in_keys: DeviceArrayLike | IteratorT,
     d_in_items: DeviceArrayLike | IteratorT,
     d_out_keys: DeviceArrayLike | IteratorT,
@@ -176,28 +179,33 @@ def unique_by_key(
         stream: CUDA stream for the operation (optional)
     """
     uniquer = make_unique_by_key(
-        d_in_keys, d_in_items, d_out_keys, d_out_items, d_out_num_selected, op
+        d_in_keys=d_in_keys,
+        d_in_items=d_in_items,
+        d_out_keys=d_out_keys,
+        d_out_items=d_out_items,
+        d_out_num_selected=d_out_num_selected,
+        op=op,
     )
     tmp_storage_bytes = uniquer(
-        None,
-        d_in_keys,
-        d_in_items,
-        d_out_keys,
-        d_out_items,
-        d_out_num_selected,
-        op,
-        num_items,
-        stream,
+        temp_storage=None,
+        d_in_keys=d_in_keys,
+        d_in_items=d_in_items,
+        d_out_keys=d_out_keys,
+        d_out_items=d_out_items,
+        d_out_num_selected=d_out_num_selected,
+        op=op,
+        num_items=num_items,
+        stream=stream,
     )
     tmp_storage = TempStorageBuffer(tmp_storage_bytes, stream)
     uniquer(
-        tmp_storage,
-        d_in_keys,
-        d_in_items,
-        d_out_keys,
-        d_out_items,
-        d_out_num_selected,
-        op,
-        num_items,
-        stream,
+        temp_storage=tmp_storage,
+        d_in_keys=d_in_keys,
+        d_in_items=d_in_items,
+        d_out_keys=d_out_keys,
+        d_out_items=d_out_items,
+        d_out_num_selected=d_out_num_selected,
+        op=op,
+        num_items=num_items,
+        stream=stream,
     )

--- a/python/cuda_cccl/tests/compute/examples/binary_search/lower_bound_basic.py
+++ b/python/cuda_cccl/tests/compute/examples/binary_search/lower_bound_basic.py
@@ -14,7 +14,13 @@ d_data = cp.asarray(h_data)
 d_values = cp.asarray(h_values)
 d_out = cp.empty(len(h_values), dtype=np.uintp)
 
-cuda.compute.lower_bound(d_data, d_values, d_out, len(d_data), len(d_values))
+cuda.compute.lower_bound(
+    d_data=d_data,
+    num_items=len(d_data),
+    d_values=d_values,
+    num_values=len(d_values),
+    d_out=d_out,
+)
 
 expected = np.searchsorted(h_data, h_values, side="left").astype(np.uintp)
 got = cp.asnumpy(d_out)

--- a/python/cuda_cccl/tests/compute/examples/binary_search/lower_bound_object.py
+++ b/python/cuda_cccl/tests/compute/examples/binary_search/lower_bound_object.py
@@ -14,8 +14,15 @@ d_data = cp.asarray(h_data)
 d_values = cp.asarray(h_values)
 d_out = cp.empty(len(h_values), dtype=np.uintp)
 
-searcher = cuda.compute.make_lower_bound(d_data, d_values, d_out)
-searcher(d_data, d_values, d_out, None, len(d_data), len(d_values))
+searcher = cuda.compute.make_lower_bound(d_data=d_data, d_values=d_values, d_out=d_out)
+searcher(
+    d_data=d_data,
+    num_items=len(d_data),
+    d_values=d_values,
+    num_values=len(d_values),
+    d_out=d_out,
+    comp=None,
+)
 
 expected = np.searchsorted(h_data, h_values, side="left").astype(np.uintp)
 got = cp.asnumpy(d_out)

--- a/python/cuda_cccl/tests/compute/examples/binary_search/upper_bound_basic.py
+++ b/python/cuda_cccl/tests/compute/examples/binary_search/upper_bound_basic.py
@@ -14,7 +14,13 @@ d_data = cp.asarray(h_data)
 d_values = cp.asarray(h_values)
 d_out = cp.empty(len(h_values), dtype=np.uintp)
 
-cuda.compute.upper_bound(d_data, d_values, d_out, len(d_data), len(d_values))
+cuda.compute.upper_bound(
+    d_data=d_data,
+    num_items=len(d_data),
+    d_values=d_values,
+    num_values=len(d_values),
+    d_out=d_out,
+)
 
 expected = np.searchsorted(h_data, h_values, side="right").astype(np.uintp)
 got = cp.asnumpy(d_out)

--- a/python/cuda_cccl/tests/compute/examples/binary_search/upper_bound_object.py
+++ b/python/cuda_cccl/tests/compute/examples/binary_search/upper_bound_object.py
@@ -14,8 +14,15 @@ d_data = cp.asarray(h_data)
 d_values = cp.asarray(h_values)
 d_out = cp.empty(len(h_values), dtype=np.uintp)
 
-searcher = cuda.compute.make_upper_bound(d_data, d_values, d_out)
-searcher(d_data, d_values, d_out, None, len(d_data), len(d_values))
+searcher = cuda.compute.make_upper_bound(d_data=d_data, d_values=d_values, d_out=d_out)
+searcher(
+    d_data=d_data,
+    num_items=len(d_data),
+    d_values=d_values,
+    num_values=len(d_values),
+    d_out=d_out,
+    comp=None,
+)
 
 expected = np.searchsorted(h_data, h_values, side="right").astype(np.uintp)
 got = cp.asnumpy(d_out)

--- a/python/cuda_cccl/tests/compute/examples/histogram/histogram_even_basic.py
+++ b/python/cuda_cccl/tests/compute/examples/histogram/histogram_even_basic.py
@@ -25,12 +25,12 @@ upper_level = np.float32(12)
 
 # Perform the histogram even.
 cuda.compute.histogram_even(
-    d_samples,
-    d_histogram,
-    num_levels,
-    lower_level,
-    upper_level,
-    num_samples,
+    d_samples=d_samples,
+    d_histogram=d_histogram,
+    num_output_levels=num_levels,
+    lower_level=lower_level,
+    upper_level=upper_level,
+    num_samples=num_samples,
 )
 
 # Verify the result.

--- a/python/cuda_cccl/tests/compute/examples/histogram/histogram_object.py
+++ b/python/cuda_cccl/tests/compute/examples/histogram/histogram_object.py
@@ -30,23 +30,23 @@ d_histogram = cp.zeros(num_levels - 1, dtype="int32")
 
 # Create the histogram object.
 histogrammer = cuda.compute.make_histogram_even(
-    d_samples,
-    d_histogram,
-    h_num_output_levels,
-    h_lower_level,
-    h_upper_level,
-    len(h_samples),
+    d_samples=d_samples,
+    d_histogram=d_histogram,
+    h_num_output_levels=h_num_output_levels,
+    h_lower_level=h_lower_level,
+    h_upper_level=h_upper_level,
+    num_samples=len(h_samples),
 )
 
 # Get the temporary storage size.
 temp_storage_size = histogrammer(
-    None,
-    d_samples,
-    d_histogram,
-    h_num_output_levels,
-    h_lower_level,
-    h_upper_level,
-    len(h_samples),
+    temp_storage=None,
+    d_samples=d_samples,
+    d_histogram=d_histogram,
+    h_num_output_levels=h_num_output_levels,
+    h_lower_level=h_lower_level,
+    h_upper_level=h_upper_level,
+    num_samples=len(h_samples),
 )
 
 # Allocate the temporary storage.
@@ -54,13 +54,13 @@ d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
 
 # Perform the histogram.
 histogrammer(
-    d_temp_storage,
-    d_samples,
-    d_histogram,
-    h_num_output_levels,
-    h_lower_level,
-    h_upper_level,
-    len(h_samples),
+    temp_storage=d_temp_storage,
+    d_samples=d_samples,
+    d_histogram=d_histogram,
+    h_num_output_levels=h_num_output_levels,
+    h_lower_level=h_lower_level,
+    h_upper_level=h_upper_level,
+    num_samples=len(h_samples),
 )
 
 # Verify the result.

--- a/python/cuda_cccl/tests/compute/examples/iterator/cache_modified_iterator_basic.py
+++ b/python/cuda_cccl/tests/compute/examples/iterator/cache_modified_iterator_basic.py
@@ -30,7 +30,9 @@ h_init = np.array([0], dtype=np.int32)
 d_output = cp.empty(1, dtype=np.int32)
 
 # Perform the reduction.
-cuda.compute.reduce_into(cache_it, d_output, OpKind.PLUS, len(d_input), h_init)
+cuda.compute.reduce_into(
+    d_in=cache_it, d_out=d_output, num_items=len(d_input), op=OpKind.PLUS, h_init=h_init
+)
 
 # Verify the result.
 expected_output = sum(h_input)  # 1 + 2 + 3 + 4 + 5 = 15

--- a/python/cuda_cccl/tests/compute/examples/iterator/constant_iterator_basic.py
+++ b/python/cuda_cccl/tests/compute/examples/iterator/constant_iterator_basic.py
@@ -30,7 +30,9 @@ h_init = np.array([0], dtype=np.int32)
 d_output = cp.empty(1, dtype=np.int32)
 
 # Perform the reduction.
-cuda.compute.reduce_into(constant_it, d_output, OpKind.PLUS, num_items, h_init)
+cuda.compute.reduce_into(
+    d_in=constant_it, d_out=d_output, num_items=num_items, op=OpKind.PLUS, h_init=h_init
+)
 
 # Verify the result.
 expected_output = constant_value * num_items

--- a/python/cuda_cccl/tests/compute/examples/iterator/counting_iterator_basic.py
+++ b/python/cuda_cccl/tests/compute/examples/iterator/counting_iterator_basic.py
@@ -32,7 +32,9 @@ h_init = np.array([0], dtype=np.int32)
 d_output = cp.empty(1, dtype=np.int32)
 
 # Perform the reduction.
-cuda.compute.reduce_into(first_it, d_output, OpKind.PLUS, num_items, h_init)
+cuda.compute.reduce_into(
+    d_in=first_it, d_out=d_output, num_items=num_items, op=OpKind.PLUS, h_init=h_init
+)
 
 # Verify the result.
 expected_output = functools.reduce(

--- a/python/cuda_cccl/tests/compute/examples/iterator/discard_iterator_basic.py
+++ b/python/cuda_cccl/tests/compute/examples/iterator/discard_iterator_basic.py
@@ -28,13 +28,13 @@ d_out_values = DiscardIterator()
 
 # Perform the unique by key operation.
 cuda.compute.unique_by_key(
-    d_in_keys,
-    d_in_values,
-    d_out_keys,
-    d_out_values,
-    d_out_num_selected,
-    OpKind.EQUAL_TO,
-    d_in_keys.size,
+    d_in_keys=d_in_keys,
+    d_in_items=d_in_values,
+    d_out_keys=d_out_keys,
+    d_out_items=d_out_values,
+    d_out_num_selected=d_out_num_selected,
+    op=OpKind.EQUAL_TO,
+    num_items=d_in_keys.size,
 )
 
 # Verify the result.

--- a/python/cuda_cccl/tests/compute/examples/iterator/permutation_iterator_basic.py
+++ b/python/cuda_cccl/tests/compute/examples/iterator/permutation_iterator_basic.py
@@ -27,7 +27,9 @@ d_output = cp.empty(1, dtype=np.int32)
 
 # Perform the reduction on the permuted values.
 num_items = len(d_indices)
-cuda.compute.reduce_into(perm_it, d_output, OpKind.PLUS, num_items, h_init)
+cuda.compute.reduce_into(
+    d_in=perm_it, d_out=d_output, num_items=num_items, op=OpKind.PLUS, h_init=h_init
+)
 
 # Verify the result:
 expected_output = d_values[d_indices].sum()

--- a/python/cuda_cccl/tests/compute/examples/iterator/permutation_iterator_composed.py
+++ b/python/cuda_cccl/tests/compute/examples/iterator/permutation_iterator_composed.py
@@ -42,7 +42,9 @@ d_output = cp.empty(1, dtype=np.int32)
 
 # Perform the reduction on the composed iterator
 num_items = len(d_indices)
-cuda.compute.reduce_into(perm_it, d_output, OpKind.PLUS, num_items, h_init)
+cuda.compute.reduce_into(
+    d_in=perm_it, d_out=d_output, num_items=num_items, op=OpKind.PLUS, h_init=h_init
+)
 
 # Verify the result: 9 + 1 + 25 + 4 = 39
 expected_output = 9 + 1 + 25 + 4

--- a/python/cuda_cccl/tests/compute/examples/iterator/permutation_iterator_output.py
+++ b/python/cuda_cccl/tests/compute/examples/iterator/permutation_iterator_output.py
@@ -34,7 +34,9 @@ perm_it = PermutationIterator(d_values, d_indices)
 
 # Perform the transform, scattering squared values to permuted locations.
 num_items = len(d_indices)
-cuda.compute.unary_transform(input_it, perm_it, square_op, num_items)
+cuda.compute.unary_transform(
+    d_in=input_it, d_out=perm_it, op=square_op, num_items=num_items
+)
 
 # Verify the result: values[9]=0, values[3]=1, values[7]=4, values[1]=9, values[5]=16
 # Other positions should remain 0

--- a/python/cuda_cccl/tests/compute/examples/iterator/reverse_input_iterator.py
+++ b/python/cuda_cccl/tests/compute/examples/iterator/reverse_input_iterator.py
@@ -28,7 +28,13 @@ d_output = cp.empty(len(d_input), dtype=np.int32)
 h_init = np.array(0, dtype=np.int32)
 
 # Perform the reduction.
-cuda.compute.inclusive_scan(reverse_it, d_output, OpKind.PLUS, h_init, len(d_input))
+cuda.compute.inclusive_scan(
+    d_in=reverse_it,
+    d_out=d_output,
+    op=OpKind.PLUS,
+    init_value=h_init,
+    num_items=len(d_input),
+)
 
 # Verify the result.
 expected_output = np.array([5, 9, 12, 14, 15], dtype=np.int32)

--- a/python/cuda_cccl/tests/compute/examples/iterator/reverse_output_iterator.py
+++ b/python/cuda_cccl/tests/compute/examples/iterator/reverse_output_iterator.py
@@ -28,7 +28,13 @@ h_init = np.array(0, dtype=np.int32)
 reverse_out_it = ReverseIterator(d_output)
 
 # Perform the reduction.
-cuda.compute.inclusive_scan(d_input, reverse_out_it, OpKind.PLUS, h_init, len(d_input))
+cuda.compute.inclusive_scan(
+    d_in=d_input,
+    d_out=reverse_out_it,
+    op=OpKind.PLUS,
+    init_value=h_init,
+    num_items=len(d_input),
+)
 
 # Verify the result.
 expected_output = np.array([15, 10, 6, 3, 1], dtype=np.int32)

--- a/python/cuda_cccl/tests/compute/examples/iterator/shuffle_iterator_basic.py
+++ b/python/cuda_cccl/tests/compute/examples/iterator/shuffle_iterator_basic.py
@@ -25,7 +25,9 @@ shuffle_it = ShuffleIterator(num_items, seed=42)
 perm_it = PermutationIterator(d_input, shuffle_it)
 
 # Use unary_transform to write values into d_output
-cuda.compute.unary_transform(perm_it, d_output, lambda x: x, num_items)
+cuda.compute.unary_transform(
+    d_in=perm_it, d_out=d_output, op=lambda x: x, num_items=num_items
+)
 
 # Verify it is a valid permutation of the input data:
 cp.testing.assert_array_equal(cp.sort(d_output), d_input)

--- a/python/cuda_cccl/tests/compute/examples/iterator/transform_iterator_basic.py
+++ b/python/cuda_cccl/tests/compute/examples/iterator/transform_iterator_basic.py
@@ -26,7 +26,9 @@ h_init = np.array([0], dtype=np.int32)  # Initial value for the reduction
 it_input = TransformIterator(d_input, lambda a: a**2)
 
 # Use `reduce_into` to compute the sum of the squares of the input.
-reduce_into(it_input, d_output, OpKind.PLUS, len(d_input), h_init)
+reduce_into(
+    d_in=it_input, d_out=d_output, num_items=len(d_input), op=OpKind.PLUS, h_init=h_init
+)
 
 # Verify the result.
 expected_output = cp.sum(d_input**2).get()

--- a/python/cuda_cccl/tests/compute/examples/iterator/transform_iterator_lambda.py
+++ b/python/cuda_cccl/tests/compute/examples/iterator/transform_iterator_lambda.py
@@ -35,7 +35,13 @@ h_init = np.array([0], dtype=np.int32)
 d_output = cp.empty(1, dtype=np.int32)
 
 # Perform the reduction: sum of squares from 1 to 10.
-cuda.compute.reduce_into(transform_it, d_output, OpKind.PLUS, num_items, h_init)
+cuda.compute.reduce_into(
+    d_in=transform_it,
+    d_out=d_output,
+    num_items=num_items,
+    op=OpKind.PLUS,
+    h_init=h_init,
+)
 
 # Verify the result: 1^2 + 2^2 + ... + 10^2 = 385
 expected_output = sum(x * x for x in range(first_item, first_item + num_items))

--- a/python/cuda_cccl/tests/compute/examples/iterator/transform_output_iterator.py
+++ b/python/cuda_cccl/tests/compute/examples/iterator/transform_output_iterator.py
@@ -34,11 +34,11 @@ d_out_it = TransformOutputIterator(d_output, sqrt)
 
 # Apply a sum reduction into the transform output iterator
 cuda.compute.reduce_into(
-    d_input,
-    d_out_it,
-    OpKind.PLUS,
-    len(d_input),
-    np.asarray([0], dtype=np.float32),
+    d_in=d_input,
+    d_out=d_out_it,
+    num_items=len(d_input),
+    op=OpKind.PLUS,
+    h_init=np.asarray([0], dtype=np.float32),
 )
 
 assert cp.allclose(d_output, cp.sqrt(cp.sum(d_input)), atol=1e-6)

--- a/python/cuda_cccl/tests/compute/examples/iterator/zip_iterator_counting.py
+++ b/python/cuda_cccl/tests/compute/examples/iterator/zip_iterator_counting.py
@@ -41,7 +41,9 @@ h_init = np.asarray([(-1, -1)], dtype=dtype)
 d_output = cp.empty(1, dtype=dtype)
 
 # Perform the reduction.
-cuda.compute.reduce_into(zip_it, d_output, max_by_value, num_items, h_init)
+cuda.compute.reduce_into(
+    d_in=zip_it, d_out=d_output, num_items=num_items, op=max_by_value, h_init=h_init
+)
 
 result = d_output.get()[0]
 expected_index = 4

--- a/python/cuda_cccl/tests/compute/examples/iterator/zip_iterator_elementwise.py
+++ b/python/cuda_cccl/tests/compute/examples/iterator/zip_iterator_elementwise.py
@@ -33,7 +33,9 @@ def sum_paired_values(pair):
 
 
 # Perform the unary transform.
-cuda.compute.unary_transform(zip_it, d_output, sum_paired_values, num_items)
+cuda.compute.unary_transform(
+    d_in=zip_it, d_out=d_output, op=sum_paired_values, num_items=num_items
+)
 
 # Calculate the expected results.
 expected = d_input1.get() + d_input2.get()

--- a/python/cuda_cccl/tests/compute/examples/iterator/zip_iterator_reduction.py
+++ b/python/cuda_cccl/tests/compute/examples/iterator/zip_iterator_reduction.py
@@ -43,7 +43,9 @@ h_init = Pair(0, 0.0)
 d_output = cp.empty(1, dtype=Pair.dtype)
 
 # Perform the reduction.
-cuda.compute.reduce_into(zip_it, d_output, sum_pairs, len(d_input1), h_init)
+cuda.compute.reduce_into(
+    d_in=zip_it, d_out=d_output, num_items=len(d_input1), op=sum_pairs, h_init=h_init
+)
 
 # Calculate the expected results.
 expected_first = sum(d_input1.get())

--- a/python/cuda_cccl/tests/compute/examples/partition/three_way_partition_basic.py
+++ b/python/cuda_cccl/tests/compute/examples/partition/three_way_partition_basic.py
@@ -32,14 +32,14 @@ def greater_than_equal_op(x):
 
 # Perform the three_way_partition.
 cuda.compute.three_way_partition(
-    d_input,
-    d_first_part,
-    d_second_part,
-    d_unselected,
-    d_num_selected,
-    less_than_op,
-    greater_than_equal_op,
-    len(h_input),
+    d_in=d_input,
+    d_first_part_out=d_first_part,
+    d_second_part_out=d_second_part,
+    d_unselected_out=d_unselected,
+    d_num_selected_out=d_num_selected,
+    select_first_part_op=less_than_op,
+    select_second_part_op=greater_than_equal_op,
+    num_items=len(h_input),
 )
 
 # Verify the result.

--- a/python/cuda_cccl/tests/compute/examples/partition/three_way_partition_object.py
+++ b/python/cuda_cccl/tests/compute/examples/partition/three_way_partition_object.py
@@ -32,40 +32,40 @@ def greater_than_equal_op(x):
 
 # Create the three_way_partition object.
 partitioner = cuda.compute.make_three_way_partition(
-    d_input,
-    d_first_part,
-    d_second_part,
-    d_unselected,
-    d_num_selected,
-    less_than_op,
-    greater_than_equal_op,
+    d_in=d_input,
+    d_first_part_out=d_first_part,
+    d_second_part_out=d_second_part,
+    d_unselected_out=d_unselected,
+    d_num_selected_out=d_num_selected,
+    select_first_part_op=less_than_op,
+    select_second_part_op=greater_than_equal_op,
 )
 
 # Get the temporary storage size.
 temp_storage_size = partitioner(
-    None,
-    d_input,
-    d_first_part,
-    d_second_part,
-    d_unselected,
-    d_num_selected,
-    less_than_op,
-    greater_than_equal_op,
-    len(h_input),
+    temp_storage=None,
+    d_in=d_input,
+    d_first_part_out=d_first_part,
+    d_second_part_out=d_second_part,
+    d_unselected_out=d_unselected,
+    d_num_selected_out=d_num_selected,
+    select_first_part_op=less_than_op,
+    select_second_part_op=greater_than_equal_op,
+    num_items=len(h_input),
 )
 d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
 
 # Perform the three_way_partition.
 partitioner(
-    d_temp_storage,
-    d_input,
-    d_first_part,
-    d_second_part,
-    d_unselected,
-    d_num_selected,
-    less_than_op,
-    greater_than_equal_op,
-    len(h_input),
+    temp_storage=d_temp_storage,
+    d_in=d_input,
+    d_first_part_out=d_first_part,
+    d_second_part_out=d_second_part,
+    d_unselected_out=d_unselected,
+    d_num_selected_out=d_num_selected,
+    select_first_part_op=less_than_op,
+    select_second_part_op=greater_than_equal_op,
+    num_items=len(h_input),
 )
 
 # Verify the result.

--- a/python/cuda_cccl/tests/compute/examples/raw_op/cpp_stateful.py
+++ b/python/cuda_cccl/tests/compute/examples/raw_op/cpp_stateful.py
@@ -93,7 +93,13 @@ d_output = cp.empty(num_items, dtype=np.int32)
 d_num_selected = cp.empty(1, dtype=np.int32)
 
 # Run select with the stateful operator
-cuda.compute.select(d_input, d_output, d_num_selected, select_op, num_items)
+cuda.compute.select(
+    d_in=d_input,
+    d_out=d_output,
+    d_num_selected_out=d_num_selected,
+    cond=select_op,
+    num_items=num_items,
+)
 
 # Get results
 num_selected = d_num_selected.get()[0]

--- a/python/cuda_cccl/tests/compute/examples/raw_op/cpp_stateless.py
+++ b/python/cuda_cccl/tests/compute/examples/raw_op/cpp_stateless.py
@@ -58,7 +58,9 @@ d_output = cp.empty(1, dtype=np.int32)
 h_init = np.array(1, dtype=np.int32)
 
 # Use the custom operator with reduce_into
-cuda.compute.reduce_into(d_input, d_output, multiply_op, len(d_input), h_init)
+cuda.compute.reduce_into(
+    d_in=d_input, d_out=d_output, num_items=len(d_input), op=multiply_op, h_init=h_init
+)
 
 # Verify the result
 result = d_output.get()[0]

--- a/python/cuda_cccl/tests/compute/examples/reduction/min_reduction.py
+++ b/python/cuda_cccl/tests/compute/examples/reduction/min_reduction.py
@@ -25,7 +25,9 @@ d_input = cp.array([8, 6, 7, 5, 3, 0, 9], dtype=dtype)
 d_output = cp.empty(1, dtype=dtype)
 
 # Perform the reduction.
-cuda.compute.reduce_into(d_input, d_output, min_op, len(d_input), h_init)
+cuda.compute.reduce_into(
+    d_in=d_input, d_out=d_output, num_items=len(d_input), op=min_op, h_init=h_init
+)
 
 # Verify the result.
 expected_output = 0

--- a/python/cuda_cccl/tests/compute/examples/reduction/minmax_reduction.py
+++ b/python/cuda_cccl/tests/compute/examples/reduction/minmax_reduction.py
@@ -48,7 +48,9 @@ d_out = cp.empty(tuple(), dtype=MinMax.dtype)
 h_init = MinMax(np.inf, -np.inf)
 
 # Perform the reduction.
-cuda.compute.reduce_into(tr_it, d_out, minmax_op, nelems, h_init)
+cuda.compute.reduce_into(
+    d_in=tr_it, d_out=d_out, num_items=nelems, op=minmax_op, h_init=h_init
+)
 
 # Verify the result.
 actual = d_out.get()

--- a/python/cuda_cccl/tests/compute/examples/reduction/reduce_object.py
+++ b/python/cuda_cccl/tests/compute/examples/reduction/reduce_object.py
@@ -24,17 +24,33 @@ d_input = cp.asarray(h_input)
 d_output = cp.empty(1, dtype=dtype)
 
 # Create a reducer object.
-reducer = cuda.compute.make_reduce_into(d_input, d_output, OpKind.PLUS, h_init)
+reducer = cuda.compute.make_reduce_into(
+    d_in=d_input, d_out=d_output, op=OpKind.PLUS, h_init=h_init
+)
 
 # Get the temporary storage size.
-temp_storage_size = reducer(None, d_input, d_output, OpKind.PLUS, len(h_input), h_init)
+temp_storage_size = reducer(
+    None,
+    d_in=d_input,
+    d_out=d_output,
+    num_items=len(h_input),
+    op=OpKind.PLUS,
+    h_init=h_init,
+)
 
 # Allocate temporary storage using any user-defined allocator.
 # The result must be an object exposing `__cuda_array_interface__`.
 d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
 
 # Perform the reduction.
-reducer(d_temp_storage, d_input, d_output, OpKind.PLUS, len(h_input), h_init)
+reducer(
+    d_temp_storage,
+    d_in=d_input,
+    d_out=d_output,
+    num_items=len(h_input),
+    op=OpKind.PLUS,
+    h_init=h_init,
+)
 
 expected_result = np.sum(h_input) + init_value
 actual_result = d_output.get()[0]

--- a/python/cuda_cccl/tests/compute/examples/reduction/reduce_object.py
+++ b/python/cuda_cccl/tests/compute/examples/reduction/reduce_object.py
@@ -30,7 +30,7 @@ reducer = cuda.compute.make_reduce_into(
 
 # Get the temporary storage size.
 temp_storage_size = reducer(
-    None,
+    temp_storage=None,
     d_in=d_input,
     d_out=d_output,
     num_items=len(h_input),
@@ -44,7 +44,7 @@ d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
 
 # Perform the reduction.
 reducer(
-    d_temp_storage,
+    temp_storage=d_temp_storage,
     d_in=d_input,
     d_out=d_output,
     num_items=len(h_input),

--- a/python/cuda_cccl/tests/compute/examples/reduction/sum_custom_reduction.py
+++ b/python/cuda_cccl/tests/compute/examples/reduction/sum_custom_reduction.py
@@ -26,7 +26,9 @@ def add_op(a, b):
 
 
 # Perform the reduction.
-cuda.compute.reduce_into(d_input, d_output, add_op, len(d_input), h_init)
+cuda.compute.reduce_into(
+    d_in=d_input, d_out=d_output, num_items=len(d_input), op=add_op, h_init=h_init
+)
 
 # Verify the result.
 expected_output = 6

--- a/python/cuda_cccl/tests/compute/examples/reduction/sum_reduction.py
+++ b/python/cuda_cccl/tests/compute/examples/reduction/sum_reduction.py
@@ -20,7 +20,9 @@ d_input = cp.array([1, 2, 3, 4, 5], dtype=dtype)
 d_output = cp.empty(1, dtype=dtype)
 
 # Perform the reduction.
-cuda.compute.reduce_into(d_input, d_output, OpKind.PLUS, len(d_input), h_init)
+cuda.compute.reduce_into(
+    d_in=d_input, d_out=d_output, num_items=len(d_input), op=OpKind.PLUS, h_init=h_init
+)
 
 # Verify the result.
 expected_output = 15

--- a/python/cuda_cccl/tests/compute/examples/reduction/sum_reduction_lambda.py
+++ b/python/cuda_cccl/tests/compute/examples/reduction/sum_reduction_lambda.py
@@ -23,7 +23,13 @@ d_input = cp.array([1, 2, 3, 4, 5], dtype=dtype)
 d_output = cp.empty(1, dtype=dtype)
 
 # Perform the reduction using a lambda function.
-cuda.compute.reduce_into(d_input, d_output, lambda a, b: a + b, len(d_input), h_init)
+cuda.compute.reduce_into(
+    d_in=d_input,
+    d_out=d_output,
+    num_items=len(d_input),
+    op=lambda a, b: a + b,
+    h_init=h_init,
+)
 
 # Verify the result.
 expected_output = 15

--- a/python/cuda_cccl/tests/compute/examples/scan/ema_example.py
+++ b/python/cuda_cccl/tests/compute/examples/scan/ema_example.py
@@ -77,7 +77,9 @@ def combine_op(v: ValueScale, t: cp.int64) -> cp.float64:
     return (1 - alpha) * v.value * alpha ** (t + v.scale)
 
 
-cuda.compute.binary_transform(d_cumsum, it_seq, d_ema, combine_op, u.size)
+cuda.compute.binary_transform(
+    d_in1=d_cumsum, d_in2=it_seq, d_out=d_ema, op=combine_op, num_items=u.size
+)
 
 d_ema += (alpha ** cp.arange(1, u.size + 1)) * u[0]
 

--- a/python/cuda_cccl/tests/compute/examples/scan/ema_example.py
+++ b/python/cuda_cccl/tests/compute/examples/scan/ema_example.py
@@ -65,7 +65,9 @@ d_inp = ZipIterator(u, negative_exponents_it)
 d_cumsum = cp.empty(u.shape, dtype=ValueScale.dtype)
 h_init = ValueScale(0.0, 0)
 
-cuda.compute.inclusive_scan(d_inp, d_cumsum, add_op, h_init, u.size)
+cuda.compute.inclusive_scan(
+    d_in=d_inp, d_out=d_cumsum, op=add_op, init_value=h_init, num_items=u.size
+)
 
 it_seq = CountingIterator(cp.int64(0))
 d_ema = cp.empty_like(u)

--- a/python/cuda_cccl/tests/compute/examples/scan/exclusive_scan_max.py
+++ b/python/cuda_cccl/tests/compute/examples/scan/exclusive_scan_max.py
@@ -25,7 +25,9 @@ d_input = cp.array([-5, 0, 2, -3, 2, 4, 0, -1, 2, 8], dtype="int32")
 d_output = cp.empty_like(d_input, dtype="int32")
 
 # Perform the exclusive scan.
-cuda.compute.exclusive_scan(d_input, d_output, max_op, h_init, d_input.size)
+cuda.compute.exclusive_scan(
+    d_in=d_input, d_out=d_output, op=max_op, init_value=h_init, num_items=d_input.size
+)
 
 # Verify the result.
 expected = np.asarray([1, 1, 1, 2, 2, 2, 4, 4, 4, 4])

--- a/python/cuda_cccl/tests/compute/examples/scan/exclusive_scan_object.py
+++ b/python/cuda_cccl/tests/compute/examples/scan/exclusive_scan_object.py
@@ -23,12 +23,28 @@ d_input = cp.asarray(h_input)
 d_output = cp.empty(len(h_input), dtype=dtype)
 
 # Create the scanner object and allocate temporary storage.
-scanner = cuda.compute.make_exclusive_scan(d_input, d_output, OpKind.PLUS, h_init)
-temp_storage_size = scanner(None, d_input, d_output, OpKind.PLUS, len(h_input), h_init)
+scanner = cuda.compute.make_exclusive_scan(
+    d_in=d_input, d_out=d_output, op=OpKind.PLUS, init_value=h_init
+)
+temp_storage_size = scanner(
+    None,
+    d_in=d_input,
+    d_out=d_output,
+    op=OpKind.PLUS,
+    num_items=len(h_input),
+    init_value=h_init,
+)
 d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
 
 # Perform the exclusive scan.
-scanner(d_temp_storage, d_input, d_output, OpKind.PLUS, len(h_input), h_init)
+scanner(
+    d_temp_storage,
+    d_in=d_input,
+    d_out=d_output,
+    op=OpKind.PLUS,
+    num_items=len(h_input),
+    init_value=h_init,
+)
 
 # Verify the result.
 expected_result = np.array([0, 1, 3, 6], dtype=dtype)

--- a/python/cuda_cccl/tests/compute/examples/scan/exclusive_scan_object.py
+++ b/python/cuda_cccl/tests/compute/examples/scan/exclusive_scan_object.py
@@ -27,7 +27,7 @@ scanner = cuda.compute.make_exclusive_scan(
     d_in=d_input, d_out=d_output, op=OpKind.PLUS, init_value=h_init
 )
 temp_storage_size = scanner(
-    None,
+    temp_storage=None,
     d_in=d_input,
     d_out=d_output,
     op=OpKind.PLUS,
@@ -38,7 +38,7 @@ d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
 
 # Perform the exclusive scan.
 scanner(
-    d_temp_storage,
+    temp_storage=d_temp_storage,
     d_in=d_input,
     d_out=d_output,
     op=OpKind.PLUS,

--- a/python/cuda_cccl/tests/compute/examples/scan/inclusive_scan_custom.py
+++ b/python/cuda_cccl/tests/compute/examples/scan/inclusive_scan_custom.py
@@ -25,7 +25,9 @@ def add_op(a, b):
 
 
 # Perform the inclusive scan.
-cuda.compute.inclusive_scan(d_input, d_output, add_op, h_init, d_input.size)
+cuda.compute.inclusive_scan(
+    d_in=d_input, d_out=d_output, op=add_op, init_value=h_init, num_items=d_input.size
+)
 
 # Verify the result.
 expected = np.asarray([0, 2, 2, 6, 6])

--- a/python/cuda_cccl/tests/compute/examples/scan/inclusive_scan_object.py
+++ b/python/cuda_cccl/tests/compute/examples/scan/inclusive_scan_object.py
@@ -27,7 +27,7 @@ scanner = cuda.compute.make_inclusive_scan(
     d_in=d_input, d_out=d_output, op=OpKind.PLUS, init_value=h_init
 )
 temp_storage_size = scanner(
-    None,
+    temp_storage=None,
     d_in=d_input,
     d_out=d_output,
     op=OpKind.PLUS,
@@ -38,7 +38,7 @@ d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
 
 # Perform the inclusive scan.
 scanner(
-    d_temp_storage,
+    temp_storage=d_temp_storage,
     d_in=d_input,
     d_out=d_output,
     op=OpKind.PLUS,

--- a/python/cuda_cccl/tests/compute/examples/scan/inclusive_scan_object.py
+++ b/python/cuda_cccl/tests/compute/examples/scan/inclusive_scan_object.py
@@ -23,12 +23,28 @@ d_input = cp.asarray(h_input)
 d_output = cp.empty(len(h_input), dtype=dtype)
 
 # Create the scanner object and allocate temporary storage.
-scanner = cuda.compute.make_inclusive_scan(d_input, d_output, OpKind.PLUS, h_init)
-temp_storage_size = scanner(None, d_input, d_output, OpKind.PLUS, len(h_input), h_init)
+scanner = cuda.compute.make_inclusive_scan(
+    d_in=d_input, d_out=d_output, op=OpKind.PLUS, init_value=h_init
+)
+temp_storage_size = scanner(
+    None,
+    d_in=d_input,
+    d_out=d_output,
+    op=OpKind.PLUS,
+    num_items=len(h_input),
+    init_value=h_init,
+)
 d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
 
 # Perform the inclusive scan.
-scanner(d_temp_storage, d_input, d_output, OpKind.PLUS, len(h_input), h_init)
+scanner(
+    d_temp_storage,
+    d_in=d_input,
+    d_out=d_output,
+    op=OpKind.PLUS,
+    num_items=len(h_input),
+    init_value=h_init,
+)
 
 # Verify the result.
 expected_result = np.array([1, 3, 6, 10], dtype=dtype)

--- a/python/cuda_cccl/tests/compute/examples/scan/logcdf_example.py
+++ b/python/cuda_cccl/tests/compute/examples/scan/logcdf_example.py
@@ -51,10 +51,14 @@ h_init = np.array(-np.inf, dtype=np.float64)
 logcdf2 = cp.empty_like(logpdf)
 
 # Perform the first inclusive scan (log-add-exp).
-cuda.compute.inclusive_scan(logpdf, logcdf, logaddexp, h_init, logpdf.size)
+cuda.compute.inclusive_scan(
+    d_in=logpdf, d_out=logcdf, op=logaddexp, init_value=h_init, num_items=logpdf.size
+)
 
 # Perform the second inclusive scan (maximum).
-cuda.compute.inclusive_scan(logcdf, logcdf2, maximum, h_init, logpdf.size)
+cuda.compute.inclusive_scan(
+    d_in=logcdf, d_out=logcdf2, op=maximum, init_value=h_init, num_items=logpdf.size
+)
 
 # Verify the results and compute quantiles.
 assert cp.all(logcdf2[:-1] <= logcdf2[1:])

--- a/python/cuda_cccl/tests/compute/examples/scan/running_average.py
+++ b/python/cuda_cccl/tests/compute/examples/scan/running_average.py
@@ -41,7 +41,9 @@ it_output = TransformOutputIterator(d_output, write_op)
 
 h_init = SumAndCount(0.0, 0)
 
-cuda.compute.inclusive_scan(it_input, it_output, add_op, h_init, len(d_input))
+cuda.compute.inclusive_scan(
+    d_in=it_input, d_out=it_output, op=add_op, init_value=h_init, num_items=len(d_input)
+)
 
 expected = np.array([1.0, 1.5, 2.0, 2.5, 3.0], dtype=np.float32)
 np.testing.assert_allclose(d_output.get(), expected)

--- a/python/cuda_cccl/tests/compute/examples/scan/segmented_sum.py
+++ b/python/cuda_cccl/tests/compute/examples/scan/segmented_sum.py
@@ -54,7 +54,9 @@ d_output = cp.empty(data.shape, dtype=ValueFlag.dtype)
 h_init = ValueFlag(0, 0)
 
 # Perform the segmented scan.
-cuda.compute.inclusive_scan(zip_it, d_output, schwartz_sum, h_init, data.size)
+cuda.compute.inclusive_scan(
+    d_in=zip_it, d_out=d_output, op=schwartz_sum, init_value=h_init, num_items=data.size
+)
 
 # Verify the result.
 expected_prefix = np.asarray([1, 2, 1, 2, 3, 1, 1, 2], dtype=np.int64)

--- a/python/cuda_cccl/tests/compute/examples/segmented/segmented_reduce_basic.py
+++ b/python/cuda_cccl/tests/compute/examples/segmented/segmented_reduce_basic.py
@@ -43,7 +43,13 @@ d_output = cp.empty(n_segments, dtype=dtype)
 
 # Perform the segmented reduce.
 cuda.compute.segmented_reduce(
-    d_input, d_output, start_o, end_o, min_op, h_init, n_segments
+    d_in=d_input,
+    d_out=d_output,
+    num_segments=n_segments,
+    start_offsets_in=start_o,
+    end_offsets_in=end_o,
+    op=min_op,
+    h_init=h_init,
 )
 
 # Verify the result.

--- a/python/cuda_cccl/tests/compute/examples/segmented/segmented_reduce_object.py
+++ b/python/cuda_cccl/tests/compute/examples/segmented/segmented_reduce_object.py
@@ -37,7 +37,7 @@ reducer = cuda.compute.make_segmented_reduce(
 
 # Get the temporary storage size.
 temp_storage_size = reducer(
-    None,
+    temp_storage=None,
     d_in=d_input,
     d_out=d_output,
     num_segments=2,
@@ -52,7 +52,7 @@ d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
 
 # Perform the segmented reduce.
 reducer(
-    d_temp_storage,
+    temp_storage=d_temp_storage,
     d_in=d_input,
     d_out=d_output,
     num_segments=2,

--- a/python/cuda_cccl/tests/compute/examples/segmented/segmented_reduce_object.py
+++ b/python/cuda_cccl/tests/compute/examples/segmented/segmented_reduce_object.py
@@ -27,12 +27,24 @@ end_offsets = cp.array([3, 6], dtype=np.int64)
 
 # Create the segmented reduce object.
 reducer = cuda.compute.make_segmented_reduce(
-    d_input, d_output, start_offsets, end_offsets, OpKind.PLUS, h_init
+    d_in=d_input,
+    d_out=d_output,
+    start_offsets_in=start_offsets,
+    end_offsets_in=end_offsets,
+    op=OpKind.PLUS,
+    h_init=h_init,
 )
 
 # Get the temporary storage size.
 temp_storage_size = reducer(
-    None, d_input, d_output, OpKind.PLUS, 2, start_offsets, end_offsets, h_init
+    None,
+    d_in=d_input,
+    d_out=d_output,
+    num_segments=2,
+    start_offsets_in=start_offsets,
+    end_offsets_in=end_offsets,
+    op=OpKind.PLUS,
+    h_init=h_init,
 )
 
 # Allocate the temporary storage.
@@ -41,13 +53,13 @@ d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
 # Perform the segmented reduce.
 reducer(
     d_temp_storage,
-    d_input,
-    d_output,
-    OpKind.PLUS,
-    2,
-    start_offsets,
-    end_offsets,
-    h_init,
+    d_in=d_input,
+    d_out=d_output,
+    num_segments=2,
+    start_offsets_in=start_offsets,
+    end_offsets_in=end_offsets,
+    op=OpKind.PLUS,
+    h_init=h_init,
 )
 
 # Verify the result.

--- a/python/cuda_cccl/tests/compute/examples/select/select_basic.py
+++ b/python/cuda_cccl/tests/compute/examples/select/select_basic.py
@@ -20,7 +20,13 @@ def is_even(x):
 
 
 # Execute select
-select(d_in, d_out, d_num_selected, is_even, len(d_in))
+select(
+    d_in=d_in,
+    d_out=d_out,
+    d_num_selected_out=d_num_selected,
+    cond=is_even,
+    num_items=len(d_in),
+)
 
 # Get results
 num_selected = int(d_num_selected[0])

--- a/python/cuda_cccl/tests/compute/examples/select/select_object.py
+++ b/python/cuda_cccl/tests/compute/examples/select/select_object.py
@@ -20,16 +20,33 @@ def greater_than_5(x):
 
 
 # Create select object (can be reused)
-selector = make_select(d_in, d_out, d_num_selected, greater_than_5)
+selector = make_select(
+    d_in=d_in,
+    d_out=d_out,
+    d_num_selected_out=d_num_selected,
+    cond=greater_than_5,
+)
 
 # Get required temp storage
 temp_storage_bytes = selector(
-    None, d_in, d_out, d_num_selected, greater_than_5, len(d_in)
+    temp_storage=None,
+    d_in=d_in,
+    d_out=d_out,
+    d_num_selected_out=d_num_selected,
+    cond=greater_than_5,
+    num_items=len(d_in),
 )
 d_temp_storage = cp.empty(temp_storage_bytes, dtype=cp.uint8)
 
 # Execute select
-selector(d_temp_storage, d_in, d_out, d_num_selected, greater_than_5, len(d_in))
+selector(
+    temp_storage=d_temp_storage,
+    d_in=d_in,
+    d_out=d_out,
+    d_num_selected_out=d_num_selected,
+    cond=greater_than_5,
+    num_items=len(d_in),
+)
 
 # Get results
 num_selected = int(d_num_selected[0])
@@ -42,7 +59,14 @@ d_in2 = cp.array([10, 20, 3, 15, 2, 8, 30], dtype=cp.int32)
 d_out2 = cp.empty_like(d_in2)
 d_num_selected2 = cp.zeros(2, dtype=cp.uint64)
 
-selector(d_temp_storage, d_in2, d_out2, d_num_selected2, greater_than_5, len(d_in2))
+selector(
+    temp_storage=d_temp_storage,
+    d_in=d_in2,
+    d_out=d_out2,
+    d_num_selected_out=d_num_selected2,
+    cond=greater_than_5,
+    num_items=len(d_in2),
+)
 
 num_selected2 = int(d_num_selected2[0])
 result2 = d_out2[:num_selected2].get()

--- a/python/cuda_cccl/tests/compute/examples/select/select_with_iterator.py
+++ b/python/cuda_cccl/tests/compute/examples/select/select_with_iterator.py
@@ -28,7 +28,13 @@ def greater_than_20(x):
     return x > 20
 
 
-select(squared_iter, d_out, d_num_selected, greater_than_20, len(d_in))
+select(
+    d_in=squared_iter,
+    d_out=d_out,
+    d_num_selected_out=d_num_selected,
+    cond=greater_than_20,
+    num_items=len(d_in),
+)
 
 # Get results
 num_selected = int(d_num_selected[0])

--- a/python/cuda_cccl/tests/compute/examples/select/select_with_side_effect.py
+++ b/python/cuda_cccl/tests/compute/examples/select/select_with_side_effect.py
@@ -28,7 +28,13 @@ def count_rejects(x):
 
 
 # Execute select - selects even numbers, counts rejections
-select(d_in, d_out, d_num_selected, count_rejects, len(d_in))
+select(
+    d_in=d_in,
+    d_out=d_out,
+    d_num_selected_out=d_num_selected,
+    cond=count_rejects,
+    num_items=len(d_in),
+)
 
 # Get results
 num_selected = int(d_num_selected.get()[0])

--- a/python/cuda_cccl/tests/compute/examples/sort/merge_sort_basic.py
+++ b/python/cuda_cccl/tests/compute/examples/sort/merge_sort_basic.py
@@ -26,12 +26,12 @@ d_in_values = cp.asarray(h_in_values)
 
 # Perform the merge sort.
 cuda.compute.merge_sort(
-    d_in_keys,
-    d_in_values,
-    d_in_keys,
-    d_in_values,
-    OpKind.LESS,
-    d_in_keys.size,
+    d_in_keys=d_in_keys,
+    d_in_values=d_in_values,
+    d_out_keys=d_in_keys,
+    d_out_values=d_in_values,
+    op=OpKind.LESS,
+    num_items=d_in_keys.size,
 )
 
 # Verify the result.

--- a/python/cuda_cccl/tests/compute/examples/sort/merge_sort_object.py
+++ b/python/cuda_cccl/tests/compute/examples/sort/merge_sort_object.py
@@ -35,7 +35,7 @@ sorter = cuda.compute.make_merge_sort(
 
 # Get the temporary storage size.
 temp_storage_size = sorter(
-    None,
+    temp_storage=None,
     d_in_keys=d_input_keys,
     d_in_values=d_input_values,
     d_out_keys=d_output_keys,
@@ -49,7 +49,7 @@ d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
 
 # Perform the merge sort.
 sorter(
-    d_temp_storage,
+    temp_storage=d_temp_storage,
     d_in_keys=d_input_keys,
     d_in_values=d_input_values,
     d_out_keys=d_output_keys,

--- a/python/cuda_cccl/tests/compute/examples/sort/merge_sort_object.py
+++ b/python/cuda_cccl/tests/compute/examples/sort/merge_sort_object.py
@@ -26,22 +26,22 @@ d_output_values = cp.empty_like(d_input_values)
 
 # Create the merge sort object.
 sorter = cuda.compute.make_merge_sort(
-    d_input_keys,
-    d_input_values,
-    d_output_keys,
-    d_output_values,
-    OpKind.LESS,
+    d_in_keys=d_input_keys,
+    d_in_values=d_input_values,
+    d_out_keys=d_output_keys,
+    d_out_values=d_output_values,
+    op=OpKind.LESS,
 )
 
 # Get the temporary storage size.
 temp_storage_size = sorter(
     None,
-    d_input_keys,
-    d_input_values,
-    d_output_keys,
-    d_output_values,
-    OpKind.LESS,
-    len(h_input_keys),
+    d_in_keys=d_input_keys,
+    d_in_values=d_input_values,
+    d_out_keys=d_output_keys,
+    d_out_values=d_output_values,
+    op=OpKind.LESS,
+    num_items=len(h_input_keys),
 )
 
 # Allocate the temporary storage.
@@ -50,12 +50,12 @@ d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
 # Perform the merge sort.
 sorter(
     d_temp_storage,
-    d_input_keys,
-    d_input_values,
-    d_output_keys,
-    d_output_values,
-    OpKind.LESS,
-    len(h_input_keys),
+    d_in_keys=d_input_keys,
+    d_in_values=d_input_values,
+    d_out_keys=d_output_keys,
+    d_out_values=d_output_values,
+    op=OpKind.LESS,
+    num_items=len(h_input_keys),
 )
 
 # Verify the result.

--- a/python/cuda_cccl/tests/compute/examples/sort/radix_sort_basic.py
+++ b/python/cuda_cccl/tests/compute/examples/sort/radix_sort_basic.py
@@ -30,12 +30,12 @@ d_out_values = cp.empty_like(d_in_values)
 
 # Perform the radix sort.
 cuda.compute.radix_sort(
-    d_in_keys,
-    d_out_keys,
-    d_in_values,
-    d_out_values,
-    SortOrder.ASCENDING,
-    d_in_keys.size,
+    d_in_keys=d_in_keys,
+    d_out_keys=d_out_keys,
+    d_in_values=d_in_values,
+    d_out_values=d_out_values,
+    order=SortOrder.ASCENDING,
+    num_items=d_in_keys.size,
 )
 
 # Verify the result.

--- a/python/cuda_cccl/tests/compute/examples/sort/radix_sort_buffer.py
+++ b/python/cuda_cccl/tests/compute/examples/sort/radix_sort_buffer.py
@@ -34,12 +34,12 @@ values_double_buffer = DoubleBuffer(d_in_values, d_out_values)
 
 # Perform the radix sort.
 cuda.compute.radix_sort(
-    keys_double_buffer,
-    None,
-    values_double_buffer,
-    None,
-    SortOrder.ASCENDING,
-    d_in_keys.size,
+    d_in_keys=keys_double_buffer,
+    d_out_keys=None,
+    d_in_values=values_double_buffer,
+    d_out_values=None,
+    order=SortOrder.ASCENDING,
+    num_items=d_in_keys.size,
 )
 
 # Verify the result.

--- a/python/cuda_cccl/tests/compute/examples/sort/radix_sort_object.py
+++ b/python/cuda_cccl/tests/compute/examples/sort/radix_sort_object.py
@@ -26,32 +26,32 @@ d_output_values = cp.empty_like(d_input_values)
 
 # Create the radix sort object.
 sorter = cuda.compute.make_radix_sort(
-    d_input_keys,
-    d_output_keys,
-    d_input_values,
-    d_output_values,
-    SortOrder.ASCENDING,
+    d_in_keys=d_input_keys,
+    d_out_keys=d_output_keys,
+    d_in_values=d_input_values,
+    d_out_values=d_output_values,
+    order=SortOrder.ASCENDING,
 )
 
 # Get the temporary storage size.
 temp_storage_size = sorter(
     None,
-    d_input_keys,
-    d_output_keys,
-    d_input_values,
-    d_output_values,
-    len(h_input_keys),
+    d_in_keys=d_input_keys,
+    d_out_keys=d_output_keys,
+    d_in_values=d_input_values,
+    d_out_values=d_output_values,
+    num_items=len(h_input_keys),
 )
 d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
 
 # Perform the radix sort.
 sorter(
     d_temp_storage,
-    d_input_keys,
-    d_output_keys,
-    d_input_values,
-    d_output_values,
-    len(h_input_keys),
+    d_in_keys=d_input_keys,
+    d_out_keys=d_output_keys,
+    d_in_values=d_input_values,
+    d_out_values=d_output_values,
+    num_items=len(h_input_keys),
 )
 
 # Verify the result.

--- a/python/cuda_cccl/tests/compute/examples/sort/radix_sort_object.py
+++ b/python/cuda_cccl/tests/compute/examples/sort/radix_sort_object.py
@@ -35,7 +35,7 @@ sorter = cuda.compute.make_radix_sort(
 
 # Get the temporary storage size.
 temp_storage_size = sorter(
-    None,
+    temp_storage=None,
     d_in_keys=d_input_keys,
     d_out_keys=d_output_keys,
     d_in_values=d_input_values,
@@ -46,7 +46,7 @@ d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
 
 # Perform the radix sort.
 sorter(
-    d_temp_storage,
+    temp_storage=d_temp_storage,
     d_in_keys=d_input_keys,
     d_out_keys=d_output_keys,
     d_in_values=d_input_values,

--- a/python/cuda_cccl/tests/compute/examples/sort/segmented_sort_basic.py
+++ b/python/cuda_cccl/tests/compute/examples/sort/segmented_sort_basic.py
@@ -27,15 +27,15 @@ d_out_vals = cp.empty_like(d_in_vals)
 
 # Perform the segmented sort (ascending within each segment).
 cuda.compute.segmented_sort(
-    d_in_keys,
-    d_out_keys,
-    d_in_vals,
-    d_out_vals,
-    d_in_keys.size,
-    start_offsets.size,
-    cp.asarray(start_offsets),
-    cp.asarray(end_offsets),
-    cuda.compute.SortOrder.ASCENDING,
+    d_in_keys=d_in_keys,
+    d_out_keys=d_out_keys,
+    d_in_values=d_in_vals,
+    d_out_values=d_out_vals,
+    num_items=d_in_keys.size,
+    num_segments=start_offsets.size,
+    start_offsets_in=cp.asarray(start_offsets),
+    end_offsets_in=cp.asarray(end_offsets),
+    order=cuda.compute.SortOrder.ASCENDING,
 )
 
 # Verify the result.

--- a/python/cuda_cccl/tests/compute/examples/sort/segmented_sort_buffer.py
+++ b/python/cuda_cccl/tests/compute/examples/sort/segmented_sort_buffer.py
@@ -31,15 +31,15 @@ vals_db = cuda.compute.DoubleBuffer(d_in_vals, d_tmp_vals)
 
 # Perform the segmented sort (descending within each segment).
 cuda.compute.segmented_sort(
-    keys_db,
-    None,
-    vals_db,
-    None,
-    d_in_keys.size,
-    start_offsets.size,
-    cp.asarray(start_offsets),
-    cp.asarray(end_offsets),
-    cuda.compute.SortOrder.DESCENDING,
+    d_in_keys=keys_db,
+    d_out_keys=None,
+    d_in_values=vals_db,
+    d_out_values=None,
+    num_items=d_in_keys.size,
+    num_segments=start_offsets.size,
+    start_offsets_in=cp.asarray(start_offsets),
+    end_offsets_in=cp.asarray(end_offsets),
+    order=cuda.compute.SortOrder.DESCENDING,
 )
 
 # Verify the result.

--- a/python/cuda_cccl/tests/compute/examples/sort/segmented_sort_object.py
+++ b/python/cuda_cccl/tests/compute/examples/sort/segmented_sort_object.py
@@ -37,7 +37,7 @@ sorter = cuda.compute.make_segmented_sort(
 
 # Get the temporary storage size.
 temp_storage_size = sorter(
-    None,
+    temp_storage=None,
     d_in_keys=d_input_keys,
     d_out_keys=d_output_keys,
     d_in_values=d_input_vals,
@@ -51,7 +51,7 @@ d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
 
 # Perform the segmented sort.
 sorter(
-    d_temp_storage,
+    temp_storage=d_temp_storage,
     d_in_keys=d_input_keys,
     d_out_keys=d_output_keys,
     d_in_values=d_input_vals,

--- a/python/cuda_cccl/tests/compute/examples/sort/segmented_sort_object.py
+++ b/python/cuda_cccl/tests/compute/examples/sort/segmented_sort_object.py
@@ -26,40 +26,40 @@ d_output_vals = cp.empty_like(d_input_vals)
 
 # Create the segmented sort object.
 sorter = cuda.compute.make_segmented_sort(
-    d_input_keys,
-    d_output_keys,
-    d_input_vals,
-    d_output_vals,
-    cp.asarray(start_offsets),
-    cp.asarray(end_offsets),
-    cuda.compute.SortOrder.ASCENDING,
+    d_in_keys=d_input_keys,
+    d_out_keys=d_output_keys,
+    d_in_values=d_input_vals,
+    d_out_values=d_output_vals,
+    start_offsets_in=cp.asarray(start_offsets),
+    end_offsets_in=cp.asarray(end_offsets),
+    order=cuda.compute.SortOrder.ASCENDING,
 )
 
 # Get the temporary storage size.
 temp_storage_size = sorter(
     None,
-    d_input_keys,
-    d_output_keys,
-    d_input_vals,
-    d_output_vals,
-    h_input_keys.size,
-    start_offsets.size,
-    cp.asarray(start_offsets),
-    cp.asarray(end_offsets),
+    d_in_keys=d_input_keys,
+    d_out_keys=d_output_keys,
+    d_in_values=d_input_vals,
+    d_out_values=d_output_vals,
+    num_items=h_input_keys.size,
+    num_segments=start_offsets.size,
+    start_offsets_in=cp.asarray(start_offsets),
+    end_offsets_in=cp.asarray(end_offsets),
 )
 d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
 
 # Perform the segmented sort.
 sorter(
     d_temp_storage,
-    d_input_keys,
-    d_output_keys,
-    d_input_vals,
-    d_output_vals,
-    h_input_keys.size,
-    start_offsets.size,
-    cp.asarray(start_offsets),
-    cp.asarray(end_offsets),
+    d_in_keys=d_input_keys,
+    d_out_keys=d_output_keys,
+    d_in_values=d_input_vals,
+    d_out_values=d_output_vals,
+    num_items=h_input_keys.size,
+    num_segments=start_offsets.size,
+    start_offsets_in=cp.asarray(start_offsets),
+    end_offsets_in=cp.asarray(end_offsets),
 )
 
 # Verify the result.

--- a/python/cuda_cccl/tests/compute/examples/struct/nested_struct_reduction.py
+++ b/python/cuda_cccl/tests/compute/examples/struct/nested_struct_reduction.py
@@ -57,7 +57,9 @@ d_output = cp.empty(1, dtype=Particle.dtype)
 h_init = Particle(0, Point(0, 0))
 
 # Perform the reduction
-cuda.compute.reduce_into(d_input, d_output, sum_particles, num_items, h_init)
+cuda.compute.reduce_into(
+    d_in=d_input, d_out=d_output, num_items=num_items, op=sum_particles, h_init=h_init
+)
 
 # Verify the result
 result = d_output.get()[0]

--- a/python/cuda_cccl/tests/compute/examples/struct/nested_struct_tuple_construction.py
+++ b/python/cuda_cccl/tests/compute/examples/struct/nested_struct_tuple_construction.py
@@ -62,7 +62,9 @@ d_output = cp.empty(1, dtype=DataPoint.dtype)
 h_init = DataPoint(0, Stats(0, 0.0))
 
 # Perform the reduction
-cuda.compute.reduce_into(d_input, d_output, sum_with_tuples, num_items, h_init)
+cuda.compute.reduce_into(
+    d_in=d_input, d_out=d_output, num_items=num_items, op=sum_with_tuples, h_init=h_init
+)
 
 # Verify the result
 result = d_output.get()[0]

--- a/python/cuda_cccl/tests/compute/examples/struct/nested_struct_zip_iterator.py
+++ b/python/cuda_cccl/tests/compute/examples/struct/nested_struct_zip_iterator.py
@@ -72,7 +72,9 @@ d_output = cp.empty(1, dtype=Pixel.dtype)
 h_init = Pixel(Point(0, 0), Color(0, 0, 0))
 
 # Perform the reduction on the zipped data
-cuda.compute.reduce_into(zip_it, d_output, sum_pixels, num_items, h_init)
+cuda.compute.reduce_into(
+    d_in=zip_it, d_out=d_output, num_items=num_items, op=sum_pixels, h_init=h_init
+)
 
 # Verify the result
 result = d_output.get()[0]

--- a/python/cuda_cccl/tests/compute/examples/struct/struct_reduction.py
+++ b/python/cuda_cccl/tests/compute/examples/struct/struct_reduction.py
@@ -36,7 +36,9 @@ d_out = cp.empty(1, Pixel.dtype)
 h_init = Pixel(0, 0, 0)
 
 # Perform the reduction.
-cuda.compute.reduce_into(d_rgb, d_out, max_g_value, d_rgb.size, h_init)
+cuda.compute.reduce_into(
+    d_in=d_rgb, d_out=d_out, num_items=d_rgb.size, op=max_g_value, h_init=h_init
+)
 
 # Calculate the expected result.
 h_rgb = d_rgb.get()

--- a/python/cuda_cccl/tests/compute/examples/struct/struct_transform.py
+++ b/python/cuda_cccl/tests/compute/examples/struct/struct_transform.py
@@ -47,7 +47,9 @@ d_in2.set(h_in2)
 
 d_out = cp.empty_like(d_in1)
 
-cuda.compute.binary_transform(d_in1, d_in2, d_out, add_points, num_items)
+cuda.compute.binary_transform(
+    d_in1=d_in1, d_in2=d_in2, d_out=d_out, op=add_points, num_items=num_items
+)
 
 result = d_out.get()
 

--- a/python/cuda_cccl/tests/compute/examples/transform/binary_transform_basic.py
+++ b/python/cuda_cccl/tests/compute/examples/transform/binary_transform_basic.py
@@ -23,7 +23,9 @@ d_in2 = cp.asarray(input2_data)
 d_out = cp.empty_like(d_in1)
 
 # Perform the binary transform.
-cuda.compute.binary_transform(d_in1, d_in2, d_out, OpKind.PLUS, len(d_in1))
+cuda.compute.binary_transform(
+    d_in1=d_in1, d_in2=d_in2, d_out=d_out, op=OpKind.PLUS, num_items=len(d_in1)
+)
 
 # Verify the result.
 result = d_out.get()

--- a/python/cuda_cccl/tests/compute/examples/transform/binary_transform_object.py
+++ b/python/cuda_cccl/tests/compute/examples/transform/binary_transform_object.py
@@ -25,11 +25,17 @@ d_output = cp.empty_like(d_input1)
 
 # Create the binary transform object.
 transformer = cuda.compute.make_binary_transform(
-    d_input1, d_input2, d_output, OpKind.PLUS
+    d_in1=d_input1, d_in2=d_input2, d_out=d_output, op=OpKind.PLUS
 )
 
 # Perform the binary transform.
-transformer(d_input1, d_input2, d_output, OpKind.PLUS, len(h_input1))
+transformer(
+    d_in1=d_input1,
+    d_in2=d_input2,
+    d_out=d_output,
+    op=OpKind.PLUS,
+    num_items=len(h_input1),
+)
 
 # Verify the result.
 expected_result = np.array([11, 22, 33, 44], dtype=dtype)

--- a/python/cuda_cccl/tests/compute/examples/transform/unary_transform_basic.py
+++ b/python/cuda_cccl/tests/compute/examples/transform/unary_transform_basic.py
@@ -24,7 +24,7 @@ def op(a):
 
 
 # Perform the unary transform.
-cuda.compute.unary_transform(d_in, d_out, op, len(d_in))
+cuda.compute.unary_transform(d_in=d_in, d_out=d_out, op=op, num_items=len(d_in))
 
 # Verify the result.
 result = d_out.get()

--- a/python/cuda_cccl/tests/compute/examples/transform/unary_transform_object.py
+++ b/python/cuda_cccl/tests/compute/examples/transform/unary_transform_object.py
@@ -25,10 +25,12 @@ def add_one_op(a):
 
 
 # Create the unary transform object.
-transformer = cuda.compute.make_unary_transform(d_input, d_output, add_one_op)
+transformer = cuda.compute.make_unary_transform(
+    d_in=d_input, d_out=d_output, op=add_one_op
+)
 
 # Perform the unary transform.
-transformer(d_input, d_output, add_one_op, len(h_input))
+transformer(d_in=d_input, d_out=d_output, op=add_one_op, num_items=len(h_input))
 
 # Verify the result.
 expected_result = np.array([2, 3, 4, 5], dtype=dtype)

--- a/python/cuda_cccl/tests/compute/examples/unique/unique_by_key_basic.py
+++ b/python/cuda_cccl/tests/compute/examples/unique/unique_by_key_basic.py
@@ -28,13 +28,13 @@ d_out_num_selected = cp.empty(1, np.int32)
 
 # Perform the unique by key operation.
 cuda.compute.unique_by_key(
-    d_in_keys,
-    d_in_values,
-    d_out_keys,
-    d_out_values,
-    d_out_num_selected,
-    OpKind.EQUAL_TO,
-    d_in_keys.size,
+    d_in_keys=d_in_keys,
+    d_in_items=d_in_values,
+    d_out_keys=d_out_keys,
+    d_out_items=d_out_values,
+    d_out_num_selected=d_out_num_selected,
+    op=OpKind.EQUAL_TO,
+    num_items=d_in_keys.size,
 )
 
 # Verify the result.

--- a/python/cuda_cccl/tests/compute/examples/unique/unique_by_key_object.py
+++ b/python/cuda_cccl/tests/compute/examples/unique/unique_by_key_object.py
@@ -27,24 +27,24 @@ d_num_selected = cp.empty(1, dtype=np.int32)
 
 # Create the unique by key object.
 uniquer = cuda.compute.make_unique_by_key(
-    d_input_keys,
-    d_input_values,
-    d_output_keys,
-    d_output_values,
-    d_num_selected,
-    OpKind.EQUAL_TO,
+    d_in_keys=d_input_keys,
+    d_in_items=d_input_values,
+    d_out_keys=d_output_keys,
+    d_out_items=d_output_values,
+    d_out_num_selected=d_num_selected,
+    op=OpKind.EQUAL_TO,
 )
 
 # Get the temporary storage size.
 temp_storage_size = uniquer(
-    None,
-    d_input_keys,
-    d_input_values,
-    d_output_keys,
-    d_output_values,
-    d_num_selected,
-    OpKind.EQUAL_TO,
-    len(h_input_keys),
+    temp_storage=None,
+    d_in_keys=d_input_keys,
+    d_in_items=d_input_values,
+    d_out_keys=d_output_keys,
+    d_out_items=d_output_values,
+    d_out_num_selected=d_num_selected,
+    op=OpKind.EQUAL_TO,
+    num_items=len(h_input_keys),
 )
 
 # Allocate the temporary storage.
@@ -52,14 +52,14 @@ d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
 
 # Perform the unique by key operation.
 uniquer(
-    d_temp_storage,
-    d_input_keys,
-    d_input_values,
-    d_output_keys,
-    d_output_values,
-    d_num_selected,
-    OpKind.EQUAL_TO,
-    len(h_input_keys),
+    temp_storage=d_temp_storage,
+    d_in_keys=d_input_keys,
+    d_in_items=d_input_values,
+    d_out_keys=d_output_keys,
+    d_out_items=d_output_values,
+    d_out_num_selected=d_num_selected,
+    op=OpKind.EQUAL_TO,
+    num_items=len(h_input_keys),
 )
 
 # Verify the result.

--- a/python/cuda_cccl/tests/compute/test_binary_search.py
+++ b/python/cuda_cccl/tests/compute/test_binary_search.py
@@ -51,7 +51,13 @@ def test_lower_bound_basic(dtype, num_items, num_values):
     d_values = cp.asarray(h_values)
     d_out = cp.empty(num_values, dtype=np.uintp)
 
-    cuda.compute.lower_bound(d_data, d_values, d_out, num_items, num_values)
+    cuda.compute.lower_bound(
+        d_data=d_data,
+        num_items=num_items,
+        d_values=d_values,
+        num_values=num_values,
+        d_out=d_out,
+    )
 
     expected = np.searchsorted(h_data, h_values, side="left").astype(np.uintp)
     got = cp.asnumpy(d_out)
@@ -70,7 +76,13 @@ def test_upper_bound_basic(dtype, num_items, num_values):
     d_values = cp.asarray(h_values)
     d_out = cp.empty(num_values, dtype=np.uintp)
 
-    cuda.compute.upper_bound(d_data, d_values, d_out, num_items, num_values)
+    cuda.compute.upper_bound(
+        d_data=d_data,
+        num_items=num_items,
+        d_values=d_values,
+        num_values=num_values,
+        d_out=d_out,
+    )
 
     expected = np.searchsorted(h_data, h_values, side="right").astype(np.uintp)
     got = cp.asnumpy(d_out)
@@ -96,12 +108,24 @@ def test_binary_search_with_duplicates(dtype):
     d_values = cp.asarray(h_values)
     d_out = cp.empty(len(h_values), dtype=np.uintp)
 
-    cuda.compute.lower_bound(d_data, d_values, d_out, len(h_data), len(h_values))
+    cuda.compute.lower_bound(
+        d_data=d_data,
+        num_items=len(h_data),
+        d_values=d_values,
+        num_values=len(h_values),
+        d_out=d_out,
+    )
     expected = np.searchsorted(h_data, h_values, side="left").astype(np.uintp)
     got = cp.asnumpy(d_out)
     assert np.array_equal(got, expected)
 
-    cuda.compute.upper_bound(d_data, d_values, d_out, len(h_data), len(h_values))
+    cuda.compute.upper_bound(
+        d_data=d_data,
+        num_items=len(h_data),
+        d_values=d_values,
+        num_values=len(h_values),
+        d_out=d_out,
+    )
     expected = np.searchsorted(h_data, h_values, side="right").astype(np.uintp)
     got = cp.asnumpy(d_out)
     assert np.array_equal(got, expected)
@@ -114,7 +138,13 @@ def test_binary_search_requires_unsigned_output():
     d_out = cp.empty(len(d_values), dtype=np.int32)  # signed, should fail
 
     with pytest.raises(TypeError, match="unsigned integer"):
-        cuda.compute.lower_bound(d_data, d_values, d_out, len(d_data), len(d_values))
+        cuda.compute.lower_bound(
+            d_data=d_data,
+            num_items=len(d_data),
+            d_values=d_values,
+            num_values=len(d_values),
+            d_out=d_out,
+        )
 
 
 def test_binary_search_requires_pointer_sized_output():
@@ -126,4 +156,10 @@ def test_binary_search_requires_pointer_sized_output():
     )  # unsigned but not pointer-sized (on 64-bit)
 
     with pytest.raises(ValueError, match="pointer-sized"):
-        cuda.compute.lower_bound(d_data, d_values, d_out, len(d_data), len(d_values))
+        cuda.compute.lower_bound(
+            d_data=d_data,
+            num_items=len(d_data),
+            d_values=d_values,
+            num_values=len(d_values),
+            d_out=d_out,
+        )

--- a/python/cuda_cccl/tests/compute/test_deferred_annotations.py
+++ b/python/cuda_cccl/tests/compute/test_deferred_annotations.py
@@ -30,7 +30,13 @@ def test_transform_iterator_future_annotations():
     h_init = np.array([0], dtype=np.int32)
 
     transform_it = TransformIterator(d_in, add_one)
-    reduce_into(transform_it, d_out, OpKind.PLUS, d_in.size, h_init)
+    reduce_into(
+        d_in=transform_it,
+        d_out=d_out,
+        num_items=d_in.size,
+        op=OpKind.PLUS,
+        h_init=h_init,
+    )
 
     expected = int(cp.sum(d_in + 1).get())
     assert int(d_out.get()[0]) == expected

--- a/python/cuda_cccl/tests/compute/test_histogram.py
+++ b/python/cuda_cccl/tests/compute/test_histogram.py
@@ -109,12 +109,12 @@ def test_device_histogram_basic_use(dtype, num_samples):
     d_histogram = cp.zeros(num_levels - 1, dtype=np.int32)
 
     cuda.compute.histogram_even(
-        d_samples,
-        d_histogram,
-        num_levels,
-        lower_level,
-        upper_level,
-        num_samples,
+        d_samples=d_samples,
+        d_histogram=d_histogram,
+        num_output_levels=num_levels,
+        lower_level=lower_level,
+        upper_level=upper_level,
+        num_samples=num_samples,
     )
 
     h_expected = compute_reference_histogram(
@@ -143,12 +143,12 @@ def test_device_histogram_sample_iterator():
     upper_level = np.int32(adjusted_total_samples)
 
     cuda.compute.histogram_even(
-        counting_it,
-        d_histogram,
-        num_levels,
-        lower_level,
-        upper_level,
-        adjusted_total_samples,
+        d_samples=counting_it,
+        d_histogram=d_histogram,
+        num_output_levels=num_levels,
+        lower_level=lower_level,
+        upper_level=upper_level,
+        num_samples=adjusted_total_samples,
     )
 
     # Each bin should have exactly samples_per_bin elements
@@ -169,7 +169,12 @@ def test_device_histogram_single_sample():
     d_histogram = cp.zeros(num_levels - 1, dtype=np.int32)
 
     cuda.compute.histogram_even(
-        d_samples, d_histogram, num_levels, lower_level, upper_level, 1
+        d_samples=d_samples,
+        d_histogram=d_histogram,
+        num_output_levels=num_levels,
+        lower_level=lower_level,
+        upper_level=upper_level,
+        num_samples=1,
     )
 
     # Sample 5.0 should go into bin 2 (bins: [0,2.5), [2.5,5), [5,7.5), [7.5,10))
@@ -190,12 +195,12 @@ def test_device_histogram_out_of_range():
     d_histogram = cp.zeros(num_levels - 1, dtype=np.int32)
 
     cuda.compute.histogram_even(
-        d_samples,
-        d_histogram,
-        num_levels,
-        lower_level,
-        upper_level,
-        len(h_samples),
+        d_samples=d_samples,
+        d_histogram=d_histogram,
+        num_output_levels=num_levels,
+        lower_level=lower_level,
+        upper_level=upper_level,
+        num_samples=len(h_samples),
     )
 
     # Only 0.5 (bin 0) and 5.5 (bin 1) should be counted
@@ -223,12 +228,12 @@ def test_device_histogram_with_stream(cuda_stream):
         d_histogram = cp.zeros(num_levels - 1, dtype=np.int32)
 
     cuda.compute.histogram_even(
-        d_samples,
-        d_histogram,
-        num_levels,
-        lower_level,
-        upper_level,
-        len(h_samples),
+        d_samples=d_samples,
+        d_histogram=d_histogram,
+        num_output_levels=num_levels,
+        lower_level=lower_level,
+        upper_level=upper_level,
+        num_samples=len(h_samples),
         stream=cuda_stream,
     )
 
@@ -254,12 +259,12 @@ def test_device_histogram_with_constant_iterator():
     d_histogram = cp.zeros(num_levels - 1, dtype=np.int32)
 
     cuda.compute.histogram_even(
-        constant_it,
-        d_histogram,
-        num_levels,
-        lower_level,
-        upper_level,
-        num_samples,
+        d_samples=constant_it,
+        d_histogram=d_histogram,
+        num_output_levels=num_levels,
+        lower_level=lower_level,
+        upper_level=upper_level,
+        num_samples=num_samples,
     )
 
     h_result = cp.asnumpy(d_histogram)
@@ -286,12 +291,12 @@ def test_histogram_even():
 
     # Run histogram with automatic temp storage allocation
     cuda.compute.histogram_even(
-        d_samples,
-        d_histogram,
-        num_levels,
-        lower_level,
-        upper_level,
-        num_samples,
+        d_samples=d_samples,
+        d_histogram=d_histogram,
+        num_output_levels=num_levels,
+        lower_level=lower_level,
+        upper_level=upper_level,
+        num_samples=num_samples,
     )
 
     # Check the result is correct
@@ -328,31 +333,31 @@ def test_histogram_cache_bug_crosses_256_bin_threshold():
     d_histogram[:num_bins_1] = 0
 
     hist = cuda.compute.make_histogram_even(
-        d_samples,
-        d_histogram[:num_bins_1],
-        h_num_output_levels,
-        h_lower_level,
-        h_upper_level,
-        num_samples,
+        d_samples=d_samples,
+        d_histogram=d_histogram[:num_bins_1],
+        h_num_output_levels=h_num_output_levels,
+        h_lower_level=h_lower_level,
+        h_upper_level=h_upper_level,
+        num_samples=num_samples,
     )
     temp_bytes = hist(
-        None,
-        d_samples,
-        d_histogram[:num_bins_1],
-        h_num_output_levels,
-        h_lower_level,
-        h_upper_level,
-        num_samples,
+        temp_storage=None,
+        d_samples=d_samples,
+        d_histogram=d_histogram[:num_bins_1],
+        h_num_output_levels=h_num_output_levels,
+        h_lower_level=h_lower_level,
+        h_upper_level=h_upper_level,
+        num_samples=num_samples,
     )
     temp_storage = cp.empty(temp_bytes, dtype=np.uint8)
     hist(
-        temp_storage,
-        d_samples,
-        d_histogram[:num_bins_1],
-        h_num_output_levels,
-        h_lower_level,
-        h_upper_level,
-        num_samples,
+        temp_storage=temp_storage,
+        d_samples=d_samples,
+        d_histogram=d_histogram[:num_bins_1],
+        h_num_output_levels=h_num_output_levels,
+        h_lower_level=h_lower_level,
+        h_upper_level=h_upper_level,
+        num_samples=num_samples,
     )
     cp.cuda.Device().synchronize()
     assert int(d_histogram[:num_bins_1].sum()) == num_samples
@@ -366,32 +371,32 @@ def test_histogram_cache_bug_crosses_256_bin_threshold():
     d_histogram[:num_bins_2] = 0
 
     hist2 = cuda.compute.make_histogram_even(
-        d_samples,
-        d_histogram[:num_bins_2],
-        h_num_output_levels,
-        h_lower_level,
-        h_upper_level,
-        num_samples,
+        d_samples=d_samples,
+        d_histogram=d_histogram[:num_bins_2],
+        h_num_output_levels=h_num_output_levels,
+        h_lower_level=h_lower_level,
+        h_upper_level=h_upper_level,
+        num_samples=num_samples,
     )
 
     temp_bytes2 = hist2(
-        None,
-        d_samples,
-        d_histogram[:num_bins_2],
-        h_num_output_levels,
-        h_lower_level,
-        h_upper_level,
-        num_samples,
+        temp_storage=None,
+        d_samples=d_samples,
+        d_histogram=d_histogram[:num_bins_2],
+        h_num_output_levels=h_num_output_levels,
+        h_lower_level=h_lower_level,
+        h_upper_level=h_upper_level,
+        num_samples=num_samples,
     )
     temp_storage2 = cp.empty(temp_bytes2, dtype=np.uint8)
     hist2(
-        temp_storage2,
-        d_samples,
-        d_histogram[:num_bins_2],
-        h_num_output_levels,
-        h_lower_level,
-        h_upper_level,
-        num_samples,
+        temp_storage=temp_storage2,
+        d_samples=d_samples,
+        d_histogram=d_histogram[:num_bins_2],
+        h_num_output_levels=h_num_output_levels,
+        h_lower_level=h_lower_level,
+        h_upper_level=h_upper_level,
+        num_samples=num_samples,
     )
     cp.cuda.Device().synchronize()
     assert int(d_histogram[:num_bins_2].sum()) == num_samples

--- a/python/cuda_cccl/tests/compute/test_iterators.py
+++ b/python/cuda_cccl/tests/compute/test_iterators.py
@@ -208,7 +208,13 @@ def test_transform_iterator_with_lambda():
     d_output = cp.empty(1, dtype=np.int32)
 
     # Perform reduction on the transformed iterator
-    cuda.compute.reduce_into(transform_it, d_output, OpKind.PLUS, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=transform_it,
+        d_out=d_output,
+        num_items=num_items,
+        op=OpKind.PLUS,
+        h_init=h_init,
+    )
 
     # Expected: sum of (10*2, 11*2, ..., 109*2) = 2 * sum(10..109)
     expected = 2 * sum(range(first_item, first_item + num_items))
@@ -238,7 +244,13 @@ def test_transform_iterator_with_zip_iterator():
     h_init = np.array([0], dtype=np.int32)
     d_output = cp.empty(1, dtype=np.int32)
 
-    cuda.compute.reduce_into(transform_it, d_output, OpKind.PLUS, len(d_a), h_init)
+    cuda.compute.reduce_into(
+        d_in=transform_it,
+        d_out=d_output,
+        num_items=len(d_a),
+        op=OpKind.PLUS,
+        h_init=h_init,
+    )
 
     result = d_output.get()[0]
     expected = (d_a + d_b).sum().get()

--- a/python/cuda_cccl/tests/compute/test_merge_sort.py
+++ b/python/cuda_cccl/tests/compute/test_merge_sort.py
@@ -365,7 +365,7 @@ def test_merge_sort_large_temp_storage_not_negative():
     )
 
     temp_storage_bytes = sorter(
-        None,
+        temp_storage=None,
         d_in_keys=d_in_keys,
         d_in_values=None,
         d_out_keys=d_out_keys,

--- a/python/cuda_cccl/tests/compute/test_merge_sort.py
+++ b/python/cuda_cccl/tests/compute/test_merge_sort.py
@@ -56,9 +56,14 @@ def type_to_problem_sizes(dtype) -> List[int]:
 def merge_sort_device(
     d_in_keys, d_in_items, d_out_keys, d_out_items, op, num_items, stream=None
 ):
-    # Use the new single-phase API with automatic temp storage allocation
     cuda.compute.merge_sort(
-        d_in_keys, d_in_items, d_out_keys, d_out_items, op, num_items, stream=stream
+        d_in_keys=d_in_keys,
+        d_in_values=d_in_items,
+        d_out_keys=d_out_keys,
+        d_out_values=d_out_items,
+        num_items=num_items,
+        op=op,
+        stream=stream,
     )
 
 
@@ -309,7 +314,12 @@ def test_merge_sort_well_known_less():
     d_out_keys = cp.empty_like(d_in_keys)
 
     cuda.compute.merge_sort(
-        d_in_keys, None, d_out_keys, None, OpKind.LESS, len(d_in_keys)
+        d_in_keys=d_in_keys,
+        d_in_values=None,
+        d_out_keys=d_out_keys,
+        d_out_values=None,
+        num_items=len(d_in_keys),
+        op=OpKind.LESS,
     )
 
     expected = np.array([1, 2, 3, 5, 8, 9])
@@ -323,7 +333,12 @@ def test_merge_sort_well_known_greater():
     d_out_keys = cp.empty_like(d_in_keys)
 
     cuda.compute.merge_sort(
-        d_in_keys, None, d_out_keys, None, OpKind.GREATER, len(d_in_keys)
+        d_in_keys=d_in_keys,
+        d_in_values=None,
+        d_out_keys=d_out_keys,
+        d_out_values=None,
+        num_items=len(d_in_keys),
+        op=OpKind.GREATER,
     )
 
     expected = np.array([9, 8, 5, 3, 2, 1])
@@ -343,18 +358,18 @@ def test_merge_sort_large_temp_storage_not_negative():
 
     sorter = cuda.compute.make_merge_sort(
         d_in_keys=d_in_keys,
-        d_in_items=None,
+        d_in_values=None,
         d_out_keys=d_out_keys,
-        d_out_items=None,
+        d_out_values=None,
         op=OpKind.LESS,
     )
 
     temp_storage_bytes = sorter(
-        temp_storage=None,
+        None,
         d_in_keys=d_in_keys,
-        d_in_items=None,
+        d_in_values=None,
         d_out_keys=d_out_keys,
-        d_out_items=None,
+        d_out_values=None,
         op=OpKind.LESS,
         num_items=num_items,
     )
@@ -371,12 +386,12 @@ def test_merge_sort_with_values_well_known():
     d_out_values = cp.empty_like(d_in_values)
 
     cuda.compute.merge_sort(
-        d_in_keys,
-        d_in_values,
-        d_out_keys,
-        d_out_values,
-        OpKind.LESS,
-        len(d_in_keys),
+        d_in_keys=d_in_keys,
+        d_in_values=d_in_values,
+        d_out_keys=d_out_keys,
+        d_out_values=d_out_values,
+        num_items=len(d_in_keys),
+        op=OpKind.LESS,
     )
 
     expected_keys = np.array([1, 2, 3, 4])

--- a/python/cuda_cccl/tests/compute/test_nested_struct.py
+++ b/python/cuda_cccl/tests/compute/test_nested_struct.py
@@ -35,7 +35,9 @@ def test_reduce_nested_struct_direct():
 
     h_init = Outer(0, Inner(0, 0.0))
 
-    cuda.compute.reduce_into(d_input, d_output, sum_nested, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input, d_out=d_output, num_items=num_items, op=sum_nested, h_init=h_init
+    )
 
     result = d_output.view(np.uint8).get().view(Outer.dtype)[0]
 
@@ -79,7 +81,9 @@ def test_nested_struct_inline():
 
     h_init = Outer(0, Inner(0, 0.0))
 
-    cuda.compute.reduce_into(d_input, d_output, sum_nested, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input, d_out=d_output, num_items=num_items, op=sum_nested, h_init=h_init
+    )
 
     result = d_output.view(np.uint8).get().view(Outer.dtype)[0]
 
@@ -126,7 +130,9 @@ def test_nested_struct_in_zip_iterator():
     d_output = cp.empty(1, dtype=Pixel.dtype)
     h_init = Pixel(Point(0, 0), Color(0, 0, 0))
 
-    cuda.compute.reduce_into(zip_it, d_output, sum_pixels, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=zip_it, d_out=d_output, num_items=num_items, op=sum_pixels, h_init=h_init
+    )
 
     result = d_output.get()[0]
 
@@ -229,7 +235,9 @@ def test_dict_init_with_reduction():
     # Use dictionary initialization for the init value
     h_init = Outer({"x": 0, "inner": {"a": 0, "b": 0.0}})
 
-    cuda.compute.reduce_into(d_input, d_output, sum_nested, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input, d_out=d_output, num_items=num_items, op=sum_nested, h_init=h_init
+    )
 
     result = d_output.view(np.uint8).get().view(Outer.dtype)[0]
 
@@ -270,7 +278,11 @@ def test_nested_struct_tuple_construction():
     h_init = Outer(0, Inner(0, 0.0))
 
     cuda.compute.reduce_into(
-        d_input, d_output, sum_nested_with_tuples, num_items, h_init
+        d_in=d_input,
+        d_out=d_output,
+        num_items=num_items,
+        op=sum_nested_with_tuples,
+        h_init=h_init,
     )
 
     result = d_output.view(np.uint8).get().view(Outer.dtype)[0]
@@ -318,7 +330,13 @@ def test_deeply_nested_tuple_construction():
 
     h_init = Level3(0, Level2(0.0, Level1(0)))
 
-    cuda.compute.reduce_into(d_input, d_output, sum_deeply_nested, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input,
+        d_out=d_output,
+        num_items=num_items,
+        op=sum_deeply_nested,
+        h_init=h_init,
+    )
 
     result = d_output.view(np.uint8).get().view(Level3.dtype)[0]
 
@@ -365,7 +383,9 @@ def test_mixed_tuple_and_direct_construction():
 
     h_init = Outer(0, Inner1(0, 0), Inner2(0.0, 0.0))
 
-    cuda.compute.reduce_into(d_input, d_output, sum_mixed, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input, d_out=d_output, num_items=num_items, op=sum_mixed, h_init=h_init
+    )
 
     result = d_output.view(np.uint8).get().view(Outer.dtype)[0]
 
@@ -419,7 +439,11 @@ def test_tuple_construction_in_zip_iterator():
     h_init = Pixel(Point(0, 0), Color(0, 0, 0))
 
     cuda.compute.reduce_into(
-        zip_it, d_output, sum_pixels_with_tuples, num_items, h_init
+        d_in=zip_it,
+        d_out=d_output,
+        num_items=num_items,
+        op=sum_pixels_with_tuples,
+        h_init=h_init,
     )
 
     result = d_output.get()[0]
@@ -464,7 +488,13 @@ def test_all_tuple_construction():
 
     h_init = Outer(Inner1(0), Inner2(0.0))
 
-    cuda.compute.reduce_into(d_input, d_output, sum_all_tuples, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input,
+        d_out=d_output,
+        num_items=num_items,
+        op=sum_all_tuples,
+        h_init=h_init,
+    )
 
     result = d_output.view(np.uint8).get().view(Outer.dtype)[0]
 

--- a/python/cuda_cccl/tests/compute/test_no_numba.py
+++ b/python/cuda_cccl/tests/compute/test_no_numba.py
@@ -42,7 +42,13 @@ def test_binary_transform_op_kind():
     d_input2 = cp.array(h_input2)
     d_output = cp.empty(num_items, dtype=np.int32)
 
-    cuda.compute.binary_transform(d_input1, d_input2, d_output, OpKind.PLUS, num_items)
+    cuda.compute.binary_transform(
+        d_in1=d_input1,
+        d_in2=d_input2,
+        d_out=d_output,
+        op=OpKind.PLUS,
+        num_items=num_items,
+    )
 
     result = d_output.get()
     expected = h_input1 + h_input2

--- a/python/cuda_cccl/tests/compute/test_no_numba.py
+++ b/python/cuda_cccl/tests/compute/test_no_numba.py
@@ -25,7 +25,9 @@ def test_reduce_op_kind():
     d_output = cp.empty(1, dtype=np.int32)
 
     h_init = np.array(0, dtype=np.int32)
-    cuda.compute.reduce_into(d_input, d_output, OpKind.PLUS, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input, d_out=d_output, num_items=num_items, op=OpKind.PLUS, h_init=h_init
+    )
 
     result = d_output.get()[0]
     expected = np.sum(h_input)
@@ -60,15 +62,15 @@ def test_segmented_sort_op_kind():
     num_segments = len(h_offsets) - 1
 
     cuda.compute.segmented_sort(
-        d_keys_in,
-        d_keys_out,
-        None,
-        None,
-        num_items,
-        num_segments,
-        d_offsets[:-1],
-        d_offsets[1:],
-        cuda.compute.SortOrder.ASCENDING,
+        d_in_keys=d_keys_in,
+        d_out_keys=d_keys_out,
+        d_in_values=None,
+        d_out_values=None,
+        num_items=num_items,
+        num_segments=num_segments,
+        start_offsets_in=d_offsets[:-1],
+        end_offsets_in=d_offsets[1:],
+        order=cuda.compute.SortOrder.ASCENDING,
     )
 
     result = d_keys_out.get()

--- a/python/cuda_cccl/tests/compute/test_permutation_iterator.py
+++ b/python/cuda_cccl/tests/compute/test_permutation_iterator.py
@@ -149,7 +149,9 @@ def test_unary_transform_of_permutation_iterator():
         return a + 1
 
     d_out = cp.empty_like(values, shape=(len(indices),))
-    cuda.compute.unary_transform(perm_it, d_out, op, len(indices))
+    cuda.compute.unary_transform(
+        d_in=perm_it, d_out=d_out, op=op, num_items=len(indices)
+    )
 
     expected = values[indices] + 1
     assert cp.all(d_out == expected)

--- a/python/cuda_cccl/tests/compute/test_permutation_iterator.py
+++ b/python/cuda_cccl/tests/compute/test_permutation_iterator.py
@@ -45,7 +45,11 @@ def test_permutation_iterator_with_array_values():
     h_init = np.array([0], dtype="int32")
     d_output = cp.empty(1, dtype="int32")
     cuda.compute.reduce_into(
-        perm_it, d_output, cuda.compute.OpKind.PLUS, len(indices), h_init
+        d_in=perm_it,
+        d_out=d_output,
+        num_items=len(indices),
+        op=cuda.compute.OpKind.PLUS,
+        h_init=h_init,
     )
     assert d_output[0] == values[indices].sum()
 
@@ -59,7 +63,11 @@ def test_permutation_iterator_with_iterator_values():
     d_output = cp.empty(1, dtype="int32")
 
     cuda.compute.reduce_into(
-        perm_it, d_output, cuda.compute.OpKind.PLUS, len(indices), h_init
+        d_in=perm_it,
+        d_out=d_output,
+        num_items=len(indices),
+        op=cuda.compute.OpKind.PLUS,
+        h_init=h_init,
     )
 
     expected = cp.arange(10, 20)[indices].sum()
@@ -84,7 +92,13 @@ def test_permutation_iterator_of_zip_iterator():
     h_init = Pair(0, 0)
     d_output = cp.empty(1, dtype=Pair.dtype)
 
-    cuda.compute.reduce_into(perm_it, d_output, sum_both_fields, len(indices), h_init)
+    cuda.compute.reduce_into(
+        d_in=perm_it,
+        d_out=d_output,
+        num_items=len(indices),
+        op=sum_both_fields,
+        h_init=h_init,
+    )
 
     result = d_output.get()[0]
     assert result["value_0"] == d_values1[indices].sum()
@@ -113,7 +127,13 @@ def test_zip_iterator_of_permutation_iterators():
     d_output = cp.empty(1, dtype=Pair.dtype)
 
     num_items = len(indices1)
-    cuda.compute.reduce_into(zip_it, d_output, sum_both_fields, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=zip_it,
+        d_out=d_output,
+        num_items=num_items,
+        op=sum_both_fields,
+        h_init=h_init,
+    )
 
     result = d_output.get()[0]
     assert result["value_0"] == d_values1[indices1].sum()
@@ -210,11 +230,11 @@ def test_permutation_iterator_advance():
 
     remaining_items = len(indices) - offset
     cuda.compute.reduce_into(
-        advanced_perm_it,
-        d_output,
-        cuda.compute.OpKind.PLUS,
-        remaining_items,
-        h_init,
+        d_in=advanced_perm_it,
+        d_out=d_output,
+        num_items=remaining_items,
+        op=cuda.compute.OpKind.PLUS,
+        h_init=h_init,
     )
 
     # Expected: values[indices[2:]] = values[[4, 1, 3, 5]] = [50, 20, 40, 60]

--- a/python/cuda_cccl/tests/compute/test_radix_sort.py
+++ b/python/cuda_cccl/tests/compute/test_radix_sort.py
@@ -71,15 +71,15 @@ def radix_sort_device(
 ):
     # Use the new single-phase API with automatic temp storage allocation
     cuda.compute.radix_sort(
-        d_in_keys,
-        d_out_keys,
-        d_in_values,
-        d_out_values,
-        order,
-        num_items,
-        begin_bit,
-        end_bit,
-        stream,
+        d_in_keys=d_in_keys,
+        d_out_keys=d_out_keys,
+        d_in_values=d_in_values,
+        d_out_values=d_out_values,
+        num_items=num_items,
+        order=order,
+        begin_bit=begin_bit,
+        end_bit=end_bit,
+        stream=stream,
     )
 
 
@@ -438,12 +438,12 @@ def test_radix_sort_large_num_items(dtype, monkeypatch):
     d_out_keys = cp.empty(num_items, dtype=dtype)
 
     cuda.compute.radix_sort(
-        d_in_keys,
-        d_out_keys,
-        None,
-        None,
-        SortOrder.ASCENDING,
-        num_items,
+        d_in_keys=d_in_keys,
+        d_out_keys=d_out_keys,
+        d_in_values=None,
+        d_out_values=None,
+        num_items=num_items,
+        order=SortOrder.ASCENDING,
     )
 
     h_out_keys = d_out_keys.get()
@@ -498,12 +498,12 @@ def test_radix_sort(monkeypatch):
 
     # Call single-phase API directly with num_items parameter
     cuda.compute.radix_sort(
-        d_in_keys,
-        d_out_keys,
-        d_in_values,
-        d_out_values,
-        SortOrder.ASCENDING,
-        d_in_keys.size,
+        d_in_keys=d_in_keys,
+        d_out_keys=d_out_keys,
+        d_in_values=d_in_values,
+        d_out_values=d_out_values,
+        num_items=d_in_keys.size,
+        order=SortOrder.ASCENDING,
     )
 
     # Check the result is correct
@@ -550,12 +550,12 @@ def test_radix_sort_double_buffer(monkeypatch):
 
     # Call single-phase API directly with num_items parameter
     cuda.compute.radix_sort(
-        keys_double_buffer,
-        None,
-        values_double_buffer,
-        None,
-        SortOrder.ASCENDING,
-        d_in_keys.size,
+        d_in_keys=keys_double_buffer,
+        d_out_keys=None,
+        d_in_values=values_double_buffer,
+        d_out_values=None,
+        num_items=d_in_keys.size,
+        order=SortOrder.ASCENDING,
     )
 
     # Check the result is correct

--- a/python/cuda_cccl/tests/compute/test_raw_op.py
+++ b/python/cuda_cccl/tests/compute/test_raw_op.py
@@ -501,7 +501,13 @@ def test_cpp_stateful_op_select_with_counter():
     d_num_selected = cp.empty(1, dtype=np.int32)
 
     # Run select
-    cuda.compute.select(d_input, d_output, d_num_selected, op, num_items)
+    cuda.compute.select(
+        d_in=d_input,
+        d_out=d_output,
+        d_num_selected_out=d_num_selected,
+        cond=op,
+        num_items=num_items,
+    )
 
     # Get results
     num_selected = d_num_selected.get()[0]

--- a/python/cuda_cccl/tests/compute/test_raw_op.py
+++ b/python/cuda_cccl/tests/compute/test_raw_op.py
@@ -117,7 +117,9 @@ def test_cpp_op_basic_add():
 
     # Use the custom op with reduce_into
     h_init = np.array(0, dtype=np.int32)
-    cuda.compute.reduce_into(d_input, d_output, op, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input, d_out=d_output, num_items=num_items, op=op, h_init=h_init
+    )
 
     # Verify result
     result = d_output.get()[0]
@@ -148,7 +150,9 @@ def test_cpp_op_max():
 
     # Use the custom op with reduce_into
     h_init = np.array(-np.inf, dtype=np.float32)
-    cuda.compute.reduce_into(d_input, d_output, op, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input, d_out=d_output, num_items=num_items, op=op, h_init=h_init
+    )
 
     # Verify result
     result = d_output.get()[0]
@@ -174,7 +178,9 @@ def test_cpp_op_multiply():
 
     # Use the custom op with reduce_into
     h_init = np.array(1, dtype=np.int32)
-    cuda.compute.reduce_into(d_input, d_output, op, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input, d_out=d_output, num_items=num_items, op=op, h_init=h_init
+    )
 
     # Verify result
     result = d_output.get()[0]
@@ -203,7 +209,9 @@ def test_cpp_op_complex_logic():
 
     # Use the custom op with reduce_into
     h_init = np.array(0, dtype=np.int32)
-    cuda.compute.reduce_into(d_input, d_output, op, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input, d_out=d_output, num_items=num_items, op=op, h_init=h_init
+    )
 
     # Expected: 1 | 2 | 4 | 8 | 16 = 31 (all bits set)
     result = d_output.get()[0]
@@ -229,7 +237,9 @@ def test_cpp_op_different_types():
 
     # Use the custom op with reduce_into
     h_init = np.array(0.0, dtype=np.float64)
-    cuda.compute.reduce_into(d_input, d_output, op, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input, d_out=d_output, num_items=num_items, op=op, h_init=h_init
+    )
 
     # Verify result
     result = d_output.get()[0]
@@ -256,7 +266,9 @@ def test_cpp_op_name_extraction():
 
     # Use the custom op with reduce_into
     h_init = np.array(0, dtype=np.int32)
-    cuda.compute.reduce_into(d_input, d_output, op, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input, d_out=d_output, num_items=num_items, op=op, h_init=h_init
+    )
 
     # Verify result
     result = d_output.get()[0]
@@ -284,7 +296,9 @@ def test_cpp_op_min():
 
     # Use the custom op with reduce_into
     h_init = np.array(np.iinfo(np.int32).max, dtype=np.int32)
-    cuda.compute.reduce_into(d_input, d_output, op, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input, d_out=d_output, num_items=num_items, op=op, h_init=h_init
+    )
 
     # Verify result
     result = d_output.get()[0]
@@ -337,7 +351,9 @@ def test_cpp_op_with_struct():
     h_init = Point(0, 0)
 
     # Use the custom op with reduce_into
-    cuda.compute.reduce_into(d_input, d_output, op, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input, d_out=d_output, num_items=num_items, op=op, h_init=h_init
+    )
 
     # Verify result
     result = d_output.view(np.uint8).get().view(Point.dtype)[0]
@@ -374,7 +390,13 @@ def test_cpp_op_with_transform_iterator():
     h_init = np.array(0, dtype=np.int32)
 
     # Sum the doubled values using built-in PLUS operator
-    cuda.compute.reduce_into(transform_iter, d_output, OpKind.PLUS, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=transform_iter,
+        d_out=d_output,
+        num_items=num_items,
+        op=OpKind.PLUS,
+        h_init=h_init,
+    )
 
     # Verify result: sum of (0*2, 1*2, 2*2, ..., 9*2) = 2 * sum(0..9) = 2 * 45 = 90
     result = d_output.get()[0]
@@ -415,7 +437,9 @@ def test_cpp_stateful_op_reduce_with_constant():
 
     # Use the stateful op with reduce_into
     h_init = np.array(0, dtype=np.int32)
-    cuda.compute.reduce_into(d_input, d_output, op, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input, d_out=d_output, num_items=num_items, op=op, h_init=h_init
+    )
 
     # Get result
     result = d_output.get()[0]

--- a/python/cuda_cccl/tests/compute/test_reduce.py
+++ b/python/cuda_cccl/tests/compute/test_reduce.py
@@ -656,7 +656,7 @@ def test_reduce_invalid_stream():
         TypeError, match="does not implement the '__cuda_stream__' protocol"
     ):
         _ = reduce_into(
-            None,
+            temp_storage=None,
             d_in=d_in,
             d_out=d_out,
             op=add_op,
@@ -669,7 +669,7 @@ def test_reduce_invalid_stream():
         TypeError, match="could not obtain __cuda_stream__ protocol version and handle"
     ):
         _ = reduce_into(
-            None,
+            temp_storage=None,
             d_in=d_in,
             d_out=d_out,
             op=add_op,
@@ -680,7 +680,7 @@ def test_reduce_invalid_stream():
 
     with pytest.raises(TypeError, match="invalid stream handle"):
         _ = reduce_into(
-            None,
+            temp_storage=None,
             d_in=d_in,
             d_out=d_out,
             op=add_op,

--- a/python/cuda_cccl/tests/compute/test_reduce.py
+++ b/python/cuda_cccl/tests/compute/test_reduce.py
@@ -77,7 +77,9 @@ def test_device_reduce(dtype, num_items, op):
     h_input = random_int(num_items, dtype)
     d_input = numba.cuda.to_device(h_input)
 
-    cuda.compute.reduce_into(d_input, d_output, op, d_input.size, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input, d_out=d_output, num_items=d_input.size, op=op, h_init=h_init
+    )
     h_output = d_output.copy_to_host()
     assert h_output[0] == pytest.approx(
         sum(h_input) + init_value, rel=0.08 if dtype == np.float16 else 0
@@ -98,7 +100,11 @@ def test_device_reduce_with_lambda():
 
     # Use a lambda function directly as the reducer
     cuda.compute.reduce_into(
-        d_input, d_output, lambda a, b: a + b, d_input.size, h_init
+        d_in=d_input,
+        d_out=d_output,
+        num_items=d_input.size,
+        op=lambda a, b: a + b,
+        h_init=h_init,
     )
     h_output = d_output.copy_to_host()
     assert h_output[0] == sum(h_input) + init_value
@@ -117,7 +123,13 @@ def test_device_reduce_with_lambda_variable():
     d_input = numba.cuda.to_device(h_input)
 
     # Use a lambda function assigned to a variable as the reducer
-    cuda.compute.reduce_into(d_input, d_output, add_op_lambda, d_input.size, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input,
+        d_out=d_output,
+        num_items=d_input.size,
+        op=add_op_lambda,
+        h_init=h_init,
+    )
     h_output = d_output.copy_to_host()
     assert h_output[0] == sum(h_input) + init_value
 
@@ -131,7 +143,9 @@ def test_complex_device_reduce():
         h_input = real_imag[0] + 1j * real_imag[1]
         d_input = numba.cuda.to_device(h_input)
         assert d_input.size == num_items
-        cuda.compute.reduce_into(d_input, d_output, add_op, num_items, h_init)
+        cuda.compute.reduce_into(
+            d_in=d_input, d_out=d_output, num_items=num_items, op=add_op, h_init=h_init
+        )
 
         result = d_output.copy_to_host()[0]
         expected = np.sum(h_input, initial=h_init[0])
@@ -155,7 +169,9 @@ def _test_device_sum_with_iterator(
 
     h_init = np.array([start_sum_with], dtype_out)
 
-    cuda.compute.reduce_into(d_input, d_output, add_op, len(l_varr), h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input, d_out=d_output, num_items=len(l_varr), op=add_op, h_init=h_init
+    )
 
     h_output = d_output.copy_to_host()
     assert h_output[0] == expected_result
@@ -321,93 +337,93 @@ def test_reducer_caching():
 
     # inputs are device arrays
     reducer_1 = cuda.compute.make_reduce_into(
-        cp.zeros(3, dtype="int64"),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=cp.zeros(3, dtype="int64"),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     reducer_2 = cuda.compute.make_reduce_into(
-        cp.zeros(3, dtype="int64"),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=cp.zeros(3, dtype="int64"),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     assert reducer_1 is reducer_2
 
     # inputs are device arrays of different dtype:
     reducer_1 = cuda.compute.make_reduce_into(
-        cp.zeros(3, dtype="int64"),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=cp.zeros(3, dtype="int64"),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     reducer_2 = cuda.compute.make_reduce_into(
-        cp.zeros(3, dtype="int32"),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=cp.zeros(3, dtype="int32"),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     assert reducer_1 is not reducer_2
 
     # outputs are of different dtype:
     reducer_1 = cuda.compute.make_reduce_into(
-        cp.zeros(3, dtype="int64"),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=cp.zeros(3, dtype="int64"),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     reducer_2 = cuda.compute.make_reduce_into(
-        cp.zeros(3, dtype="int64"),
-        cp.zeros(1, dtype="int32"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=cp.zeros(3, dtype="int64"),
+        d_out=cp.zeros(1, dtype="int32"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     assert reducer_1 is not reducer_2
 
     # inputs are of same dtype but different size
     # (should still use cached reducer):
     reducer_1 = cuda.compute.make_reduce_into(
-        cp.zeros(3, dtype="int64"),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=cp.zeros(3, dtype="int64"),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     reducer_2 = cuda.compute.make_reduce_into(
-        cp.zeros(5, dtype="int64"),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=cp.zeros(5, dtype="int64"),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     assert reducer_1 is reducer_2
 
     # inputs are counting iterators of the
     # same value type:
     reducer_1 = cuda.compute.make_reduce_into(
-        CountingIterator(np.int32(0)),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=CountingIterator(np.int32(0)),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     reducer_2 = cuda.compute.make_reduce_into(
-        CountingIterator(np.int32(0)),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=CountingIterator(np.int32(0)),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     assert reducer_1 is reducer_2
 
     # inputs are counting iterators of different value type:
     reducer_1 = cuda.compute.make_reduce_into(
-        CountingIterator(np.int32(0)),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=CountingIterator(np.int32(0)),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     reducer_2 = cuda.compute.make_reduce_into(
-        CountingIterator(np.int64(0)),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=CountingIterator(np.int64(0)),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     assert reducer_1 is not reducer_2
 
@@ -422,63 +438,63 @@ def test_reducer_caching():
 
     # inputs are TransformIterators
     reducer_1 = cuda.compute.make_reduce_into(
-        TransformIterator(CountingIterator(np.int32(0)), op1),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=TransformIterator(CountingIterator(np.int32(0)), op1),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     reducer_2 = cuda.compute.make_reduce_into(
-        TransformIterator(CountingIterator(np.int32(0)), op1),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=TransformIterator(CountingIterator(np.int32(0)), op1),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     assert reducer_1 is reducer_2
 
     # inputs are TransformIterators with different
     # op:
     reducer_1 = cuda.compute.make_reduce_into(
-        TransformIterator(CountingIterator(np.int32(0)), op1),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=TransformIterator(CountingIterator(np.int32(0)), op1),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     reducer_2 = cuda.compute.make_reduce_into(
-        TransformIterator(CountingIterator(np.int32(0)), op2),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=TransformIterator(CountingIterator(np.int32(0)), op2),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     assert reducer_1 is not reducer_2
 
     # inputs are TransformIterators with same op
     # but different name:
     reducer_1 = cuda.compute.make_reduce_into(
-        TransformIterator(CountingIterator(np.int32(0)), op1),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=TransformIterator(CountingIterator(np.int32(0)), op1),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     reducer_2 = cuda.compute.make_reduce_into(
-        TransformIterator(CountingIterator(np.int32(0)), op3),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=TransformIterator(CountingIterator(np.int32(0)), op3),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
 
     # inputs are CountingIterators of same kind
     # but different state:
     reducer_1 = cuda.compute.make_reduce_into(
-        CountingIterator(np.int32(0)),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=CountingIterator(np.int32(0)),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     reducer_2 = cuda.compute.make_reduce_into(
-        CountingIterator(np.int32(1)),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=CountingIterator(np.int32(1)),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
 
     assert reducer_1 is reducer_2
@@ -488,47 +504,47 @@ def test_reducer_caching():
     ary1 = cp.asarray([0, 1, 2], dtype="int64")
     ary2 = cp.asarray([0, 1], dtype="int64")
     reducer_1 = cuda.compute.make_reduce_into(
-        TransformIterator(ary1, op1),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=TransformIterator(ary1, op1),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     reducer_2 = cuda.compute.make_reduce_into(
-        TransformIterator(ary2, op1),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=TransformIterator(ary2, op1),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     assert reducer_1 is reducer_2
 
     # inputs are TransformIterators of same kind
     # but different state:
     reducer_1 = cuda.compute.make_reduce_into(
-        TransformIterator(CountingIterator(np.int32(0)), op1),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=TransformIterator(CountingIterator(np.int32(0)), op1),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     reducer_2 = cuda.compute.make_reduce_into(
-        TransformIterator(CountingIterator(np.int32(1)), op1),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=TransformIterator(CountingIterator(np.int32(1)), op1),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     assert reducer_1 is reducer_2
 
     # inputs are TransformIterators with different kind:
     reducer_1 = cuda.compute.make_reduce_into(
-        TransformIterator(CountingIterator(np.int32(0)), op1),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=TransformIterator(CountingIterator(np.int32(0)), op1),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     reducer_2 = cuda.compute.make_reduce_into(
-        TransformIterator(CountingIterator(np.int64(0)), op1),
-        cp.zeros(1, dtype="int64"),
-        sum_op,
-        np.zeros(1, dtype="int64"),
+        d_in=TransformIterator(CountingIterator(np.int64(0)), op1),
+        d_out=cp.zeros(1, dtype="int64"),
+        op=sum_op,
+        h_init=np.zeros(1, dtype="int64"),
     )
     assert reducer_1 is not reducer_2
 
@@ -553,7 +569,9 @@ def test_reduce_2d_array(array_2d):
     d_out = cp.empty(1, dtype=array_2d.dtype)
     h_init = np.asarray([0], dtype=array_2d.dtype)
     d_in = array_2d
-    cuda.compute.reduce_into(d_in, d_out, binary_op, d_in.size, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_in, d_out=d_out, num_items=d_in.size, op=binary_op, h_init=h_init
+    )
     np.testing.assert_allclose(d_in.sum().get(), d_out.get())
 
 
@@ -567,11 +585,15 @@ def test_reduce_non_contiguous():
 
     d_in = cp.zeros((size, 2))[:, 0]
     with pytest.raises(ValueError, match="Non-contiguous arrays are not supported."):
-        _ = cuda.compute.make_reduce_into(d_in, d_out, binary_op, h_init)
+        _ = cuda.compute.make_reduce_into(
+            d_in=d_in, d_out=d_out, op=binary_op, h_init=h_init
+        )
 
     d_in = cp.zeros(size)[::2]
     with pytest.raises(ValueError, match="Non-contiguous arrays are not supported."):
-        _ = cuda.compute.make_reduce_into(d_in, d_out, binary_op, h_init)
+        _ = cuda.compute.make_reduce_into(
+            d_in=d_in, d_out=d_out, op=binary_op, h_init=h_init
+        )
 
 
 def test_reduce_with_stream(cuda_stream):
@@ -586,7 +608,14 @@ def test_reduce_with_stream(cuda_stream):
         d_in = cp.asarray(h_in)
         d_out = cp.empty(1, dtype=np.int32)
 
-    cuda.compute.reduce_into(d_in, d_out, add_op, d_in.size, h_init, stream=cuda_stream)
+    cuda.compute.reduce_into(
+        d_in=d_in,
+        d_out=d_out,
+        num_items=d_in.size,
+        op=add_op,
+        h_init=h_init,
+        stream=cuda_stream,
+    )
     with cp_stream:
         cp.testing.assert_allclose(d_in.sum().get(), d_out.get())
 
@@ -619,7 +648,9 @@ def test_reduce_invalid_stream():
     d_out = cp.empty(1)
     h_init = np.empty(1)
     d_in = cp.empty(1)
-    reduce_into = cuda.compute.make_reduce_into(d_in, d_out, add_op, h_init)
+    reduce_into = cuda.compute.make_reduce_into(
+        d_in=d_in, d_out=d_out, op=add_op, h_init=h_init
+    )
 
     with pytest.raises(
         TypeError, match="does not implement the '__cuda_stream__' protocol"
@@ -665,7 +696,13 @@ def test_device_reduce_well_known_plus():
     d_input = cp.array([1, 2, 3, 4, 5], dtype=dtype)
     d_output = cp.empty(1, dtype=dtype)
 
-    cuda.compute.reduce_into(d_input, d_output, OpKind.PLUS, len(d_input), h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input,
+        d_out=d_output,
+        num_items=len(d_input),
+        op=OpKind.PLUS,
+        h_init=h_init,
+    )
 
     expected_output = 15
     assert (d_output == expected_output).all()
@@ -677,7 +714,13 @@ def test_device_reduce_well_known_minimum():
     d_input = cp.array([8, 6, 7, 5, 3, 0, 9], dtype=dtype)
     d_output = cp.empty(1, dtype=dtype)
 
-    cuda.compute.reduce_into(d_input, d_output, OpKind.MINIMUM, len(d_input), h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input,
+        d_out=d_output,
+        num_items=len(d_input),
+        op=OpKind.MINIMUM,
+        h_init=h_init,
+    )
 
     expected_output = 0
     assert (d_output == expected_output).all()
@@ -689,7 +732,13 @@ def test_device_reduce_well_known_maximum():
     d_input = cp.array([8, 6, 7, 5, 3, 0, 9], dtype=dtype)
     d_output = cp.empty(1, dtype=dtype)
 
-    cuda.compute.reduce_into(d_input, d_output, OpKind.MAXIMUM, len(d_input), h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input,
+        d_out=d_output,
+        num_items=len(d_input),
+        op=OpKind.MAXIMUM,
+        h_init=h_init,
+    )
 
     expected_output = 9
     assert (d_output == expected_output).all()
@@ -707,7 +756,9 @@ def test_cache_modified_input_iterator():
     h_init = np.array([0], dtype=np.int32)
     d_output = cp.empty(1, dtype=np.int32)
 
-    cuda.compute.reduce_into(iterator, d_output, add_op, len(values), h_init)
+    cuda.compute.reduce_into(
+        d_in=iterator, d_out=d_output, num_items=len(values), op=add_op, h_init=h_init
+    )
 
     expected_output = functools.reduce(lambda a, b: a + b, values)
     assert (d_output == expected_output).all()
@@ -724,7 +775,9 @@ def test_constant_iterator():
     h_init = np.array([0], dtype=np.int32)
     d_output = cp.empty(1, dtype=np.int32)
 
-    cuda.compute.reduce_into(constant_it, d_output, add_op, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=constant_it, d_out=d_output, num_items=num_items, op=add_op, h_init=h_init
+    )
 
     expected_output = functools.reduce(lambda a, b: a + b, [value] * num_items)
     assert (d_output == expected_output).all()
@@ -741,7 +794,9 @@ def test_counting_iterator():
     h_init = np.array([0], dtype=np.int32)  # Initial value for the reduction
     d_output = cp.empty(1, dtype=np.int32)  # Storage for output
 
-    cuda.compute.reduce_into(first_it, d_output, add_op, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=first_it, d_out=d_output, num_items=num_items, op=add_op, h_init=h_init
+    )
 
     expected_output = functools.reduce(
         lambda a, b: a + b, range(first_item, first_item + num_items)
@@ -763,7 +818,9 @@ def test_transform_iterator():
     h_init = np.array([0], dtype=np.int32)
     d_output = cp.empty(1, dtype=np.int32)
 
-    cuda.compute.reduce_into(transform_it, d_output, add_op, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=transform_it, d_out=d_output, num_items=num_items, op=add_op, h_init=h_init
+    )
 
     expected_output = functools.reduce(
         lambda a, b: a + b, [a**2 for a in range(first_item, first_item + num_items)]
@@ -786,7 +843,9 @@ def test_reduce_struct_type():
 
     h_init = Pixel(0, 0, 0)
 
-    cuda.compute.reduce_into(d_rgb, d_out, max_g_value, d_rgb.size, h_init)
+    cuda.compute.reduce_into(
+        d_in=d_rgb, d_out=d_out, num_items=d_rgb.size, op=max_g_value, h_init=h_init
+    )
 
     h_rgb = d_rgb.get()
     expected = h_rgb[h_rgb.view("int32")[:, 1].argmax()]
@@ -826,7 +885,9 @@ def test_reduce_struct_type_minmax():
     h_init = MinMax(np.inf, -np.inf)
 
     # run the reduction algorithm
-    cuda.compute.reduce_into(tr_it, d_out, minmax_op, nelems, h_init)
+    cuda.compute.reduce_into(
+        d_in=tr_it, d_out=d_out, num_items=nelems, op=minmax_op, h_init=h_init
+    )
 
     # display values computed on the device
     actual = d_out.get()
@@ -851,7 +912,13 @@ def test_reduce_transform_output_iterator(floating_array):
 
     d_out_it = TransformOutputIterator(d_output, sqrt)
 
-    cuda.compute.reduce_into(d_input, d_out_it, OpKind.PLUS, len(d_input), h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input,
+        d_out=d_out_it,
+        num_items=len(d_input),
+        op=OpKind.PLUS,
+        h_init=h_init,
+    )
 
     expected = cp.sqrt(cp.sum(d_input))
     np.testing.assert_allclose(d_output.get(), expected.get(), atol=1e-6)
@@ -865,11 +932,11 @@ def test_reduce_with_not_guaranteed_determinism(floating_array):
     d_output = cp.empty(1, dtype=dtype)
 
     cuda.compute.reduce_into(
-        d_input,
-        d_output,
-        OpKind.PLUS,
-        len(d_input),
-        h_init,
+        d_in=d_input,
+        d_out=d_output,
+        num_items=len(d_input),
+        op=OpKind.PLUS,
+        h_init=h_init,
         determinism=Determinism.NOT_GUARANTEED,
     )
 
@@ -880,7 +947,13 @@ def test_reduce_bool():
     d_output = cp.empty_like(d_input, shape=(1,))
 
     # Perform the reduction.
-    cuda.compute.reduce_into(d_input, d_output, OpKind.MAXIMUM, len(d_input), h_init)
+    cuda.compute.reduce_into(
+        d_in=d_input,
+        d_out=d_output,
+        num_items=len(d_input),
+        op=OpKind.MAXIMUM,
+        h_init=h_init,
+    )
 
     expected = True
     assert d_output.get()[0] == expected

--- a/python/cuda_cccl/tests/compute/test_scan.py
+++ b/python/cuda_cccl/tests/compute/test_scan.py
@@ -37,8 +37,14 @@ def scan_device(d_input, d_output, num_items, op, h_init, force_inclusive, strea
     scan_algorithm = (
         cuda.compute.inclusive_scan if force_inclusive else cuda.compute.exclusive_scan
     )
-    # Call single-phase API directly with all parameters including num_items
-    scan_algorithm(d_input, d_output, op, h_init, num_items, stream)
+    scan_algorithm(
+        d_in=d_input,
+        d_out=d_output,
+        op=op,
+        init_value=h_init,
+        num_items=num_items,
+        stream=stream,
+    )
 
 
 @pytest.mark.parametrize(
@@ -214,7 +220,13 @@ def test_exclusive_scan_well_known_plus():
     d_input = cp.array([1, 2, 3, 4, 5], dtype=dtype)
     d_output = cp.empty_like(d_input, dtype=dtype)
 
-    cuda.compute.exclusive_scan(d_input, d_output, OpKind.PLUS, h_init, d_input.size)
+    cuda.compute.exclusive_scan(
+        d_in=d_input,
+        d_out=d_output,
+        op=OpKind.PLUS,
+        init_value=h_init,
+        num_items=d_input.size,
+    )
 
     expected = np.array([0, 1, 3, 6, 10])
     np.testing.assert_equal(d_output.get(), expected)
@@ -238,7 +250,13 @@ def test_inclusive_scan_well_known_plus(monkeypatch):
     d_input = cp.array([1, 2, 3, 4, 5], dtype=dtype)
     d_output = cp.empty_like(d_input, dtype=dtype)
 
-    cuda.compute.inclusive_scan(d_input, d_output, OpKind.PLUS, h_init, d_input.size)
+    cuda.compute.inclusive_scan(
+        d_in=d_input,
+        d_out=d_output,
+        op=OpKind.PLUS,
+        init_value=h_init,
+        num_items=d_input.size,
+    )
 
     expected = np.array([1, 3, 6, 10, 15])
     np.testing.assert_equal(d_output.get(), expected)
@@ -253,7 +271,13 @@ def test_exclusive_scan_well_known_maximum():
     d_input = cp.array([-5, 0, 2, -3, 2, 4, 0, -1, 2, 8], dtype=dtype)
     d_output = cp.empty_like(d_input, dtype=dtype)
 
-    cuda.compute.exclusive_scan(d_input, d_output, OpKind.MAXIMUM, h_init, d_input.size)
+    cuda.compute.exclusive_scan(
+        d_in=d_input,
+        d_out=d_output,
+        op=OpKind.MAXIMUM,
+        init_value=h_init,
+        num_items=d_input.size,
+    )
 
     expected = np.array([1, 1, 1, 2, 2, 2, 4, 4, 4, 4])
     np.testing.assert_equal(d_output.get(), expected)
@@ -273,7 +297,13 @@ def test_scan_transform_output_iterator(floating_array):
 
     d_out_it = TransformOutputIterator(d_output, square)
 
-    cuda.compute.inclusive_scan(d_input, d_out_it, OpKind.PLUS, h_init, d_input.size)
+    cuda.compute.inclusive_scan(
+        d_in=d_input,
+        d_out=d_out_it,
+        op=OpKind.PLUS,
+        init_value=h_init,
+        num_items=d_input.size,
+    )
 
     expected = cp.cumsum(d_input) ** 2
     # Use more lenient tolerance for float32 due to precision differences
@@ -291,7 +321,13 @@ def test_exclusive_scan_max():
     d_input = cp.array([-5, 0, 2, -3, 2, 4, 0, -1, 2, 8], dtype="int32")
     d_output = cp.empty_like(d_input, dtype="int32")
 
-    cuda.compute.exclusive_scan(d_input, d_output, max_op, h_init, d_input.size)
+    cuda.compute.exclusive_scan(
+        d_in=d_input,
+        d_out=d_output,
+        op=max_op,
+        init_value=h_init,
+        num_items=d_input.size,
+    )
 
     expected = np.asarray([1, 1, 1, 2, 2, 2, 4, 4, 4, 4])
     np.testing.assert_equal(d_output.get(), expected)
@@ -305,7 +341,13 @@ def test_inclusive_scan_add():
     d_input = cp.array([-5, 0, 2, -3, 2, 4, 0, -1, 2, 8], dtype="int32")
     d_output = cp.empty_like(d_input, dtype="int32")
 
-    cuda.compute.inclusive_scan(d_input, d_output, add_op, h_init, d_input.size)
+    cuda.compute.inclusive_scan(
+        d_in=d_input,
+        d_out=d_output,
+        op=add_op,
+        init_value=h_init,
+        num_items=d_input.size,
+    )
 
     expected = np.asarray([-5, -5, -3, -6, -4, 0, 0, -1, 1, 9])
     np.testing.assert_equal(d_output.get(), expected)
@@ -332,7 +374,13 @@ def test_reverse_input_iterator(monkeypatch):
     d_output = cp.empty_like(d_input, dtype="int32")
     reverse_it = ReverseIterator(d_input)
 
-    cuda.compute.inclusive_scan(reverse_it, d_output, add_op, h_init, len(d_input))
+    cuda.compute.inclusive_scan(
+        d_in=reverse_it,
+        d_out=d_output,
+        op=add_op,
+        init_value=h_init,
+        num_items=len(d_input),
+    )
 
     # Check the result is correct
     expected = np.asarray([8, 10, 9, 9, 13, 15, 12, 14, 14, 9])
@@ -349,7 +397,13 @@ def test_reverse_output_iterator():
     d_output = cp.empty_like(d_input, dtype="int32")
     reverse_it = ReverseIterator(d_output)
 
-    cuda.compute.inclusive_scan(d_input, reverse_it, add_op, h_init, len(d_input))
+    cuda.compute.inclusive_scan(
+        d_in=d_input,
+        d_out=reverse_it,
+        op=add_op,
+        init_value=h_init,
+        num_items=len(d_input),
+    )
 
     expected = np.asarray([9, 1, -1, 0, 0, -4, -6, -3, -5, -5])
     np.testing.assert_equal(d_output.get(), expected)
@@ -428,7 +482,11 @@ def test_inclusive_scan_with_lambda():
 
     # Use a lambda function directly as the scan operator
     cuda.compute.inclusive_scan(
-        d_input, d_output, lambda a, b: a + b, h_init, len(d_input)
+        d_in=d_input,
+        d_out=d_output,
+        op=lambda a, b: a + b,
+        init_value=h_init,
+        num_items=len(d_input),
     )
 
     expected = np.array([1, 3, 6, 10, 15], dtype=np.int32)

--- a/python/cuda_cccl/tests/compute/test_segmented_reduce.py
+++ b/python/cuda_cccl/tests/compute/test_segmented_reduce.py
@@ -62,7 +62,13 @@ def test_segmented_reduce(input_array, offset_dtype, monkeypatch):
 
     # Call single-phase API directly with num_segments parameter
     cuda.compute.segmented_reduce(
-        d_in, d_out, start_offsets, end_offsets, reduce_op, h_init, n_segments
+        d_in=d_in,
+        d_out=d_out,
+        num_segments=n_segments,
+        start_offsets_in=start_offsets,
+        end_offsets_in=end_offsets,
+        op=reduce_op,
+        h_init=h_init,
     )
 
     d_expected = cp.empty_like(d_out)
@@ -108,7 +114,13 @@ def test_segmented_reduce_struct_type(monkeypatch):
 
     # Call single-phase API directly with n_segments parameter
     cuda.compute.segmented_reduce(
-        d_rgb, d_out, start_offsets, end_offsets, max_g_value, h_init, n_segments
+        d_in=d_rgb,
+        d_out=d_out,
+        num_segments=n_segments,
+        start_offsets_in=start_offsets,
+        end_offsets_in=end_offsets,
+        op=max_g_value,
+        h_init=h_init,
     )
 
     h_rgb = np.reshape(d_rgb.get(), (n_segments, -1))
@@ -172,7 +184,13 @@ def test_large_num_segments_uniform_segment_sizes_nonuniform_input(monkeypatch):
         match="Segmented sort does not currently support more than 2\\^31-1 segments\\.",
     ):
         cuda.compute.segmented_reduce(
-            input_it, res, start_offsets, end_offsets, my_add, h_init, num_segments
+            d_in=input_it,
+            d_out=res,
+            num_segments=num_segments,
+            start_offsets_in=start_offsets,
+            end_offsets_in=end_offsets,
+            op=my_add,
+            h_init=h_init,
         )
 
 
@@ -236,7 +254,13 @@ def test_large_num_segments_nonuniform_segment_sizes_uniform_input(monkeypatch):
         match="Segmented sort does not currently support more than 2\\^31-1 segments\\.",
     ):
         cuda.compute.segmented_reduce(
-            input_it, res, start_offsets, end_offsets, _plus, h_init, num_segments
+            d_in=input_it,
+            d_out=res,
+            num_segments=num_segments,
+            start_offsets_in=start_offsets,
+            end_offsets_in=end_offsets,
+            op=_plus,
+            h_init=h_init,
         )
 
 
@@ -257,7 +281,13 @@ def test_segmented_reduce_well_known_plus(monkeypatch):
     d_output = cp.empty(3, dtype=dtype)
 
     cuda.compute.segmented_reduce(
-        d_input, d_output, d_starts, d_ends, OpKind.PLUS, h_init, 3
+        d_in=d_input,
+        d_out=d_output,
+        num_segments=3,
+        start_offsets_in=d_starts,
+        end_offsets_in=d_ends,
+        op=OpKind.PLUS,
+        h_init=h_init,
     )
 
     expected = np.array([6, 9, 30])
@@ -281,7 +311,13 @@ def test_segmented_reduce_well_known_maximum(monkeypatch):
     d_output = cp.empty(3, dtype=dtype)
 
     cuda.compute.segmented_reduce(
-        d_input, d_output, d_starts, d_ends, OpKind.MAXIMUM, h_init, 3
+        d_in=d_input,
+        d_out=d_output,
+        num_segments=3,
+        start_offsets_in=d_starts,
+        end_offsets_in=d_ends,
+        op=OpKind.MAXIMUM,
+        h_init=h_init,
     )
 
     expected = np.array([9, 4, 8])  # max of each segment
@@ -304,7 +340,13 @@ def test_segmented_reduce_bool_maximum(monkeypatch):
     d_output = cp.empty(3, dtype=np.bool_)
 
     cuda.compute.segmented_reduce(
-        d_input, d_output, d_starts, d_ends, OpKind.MAXIMUM, h_init, 3
+        d_in=d_input,
+        d_out=d_output,
+        num_segments=3,
+        start_offsets_in=d_starts,
+        end_offsets_in=d_ends,
+        op=OpKind.MAXIMUM,
+        h_init=h_init,
     )
 
     expected = np.array([True, False, True], dtype=np.bool_)
@@ -337,7 +379,13 @@ def test_segmented_reduce_transform_output_iterator(floating_array, monkeypatch)
     d_out_it = TransformOutputIterator(d_output, sqrt)
 
     cuda.compute.segmented_reduce(
-        d_input, d_out_it, start_offsets, end_offsets, OpKind.PLUS, h_init, 2
+        d_in=d_input,
+        d_out=d_out_it,
+        num_segments=2,
+        start_offsets_in=start_offsets,
+        end_offsets_in=end_offsets,
+        op=OpKind.PLUS,
+        h_init=h_init,
     )
 
     expected = cp.sqrt(
@@ -383,7 +431,13 @@ def test_device_segmented_reduce_for_rowwise_sum(monkeypatch):
     d_output = cp.empty(n_rows, dtype=d_input.dtype)
 
     cuda.compute.segmented_reduce(
-        d_input, d_output, start_offsets, end_offsets, add_op, h_init, n_rows
+        d_in=d_input,
+        d_out=d_output,
+        num_segments=n_rows,
+        start_offsets_in=start_offsets,
+        end_offsets_in=end_offsets,
+        op=add_op,
+        h_init=h_init,
     )
 
     expected = cp.sum(mat, axis=-1)
@@ -409,7 +463,13 @@ def test_segmented_reduce_with_lambda(monkeypatch):
 
     # Use a lambda function directly as the reducer
     cuda.compute.segmented_reduce(
-        d_input, d_output, d_starts, d_ends, lambda a, b: a + b, h_init, 3
+        d_in=d_input,
+        d_out=d_output,
+        num_segments=3,
+        start_offsets_in=d_starts,
+        end_offsets_in=d_ends,
+        op=lambda a, b: a + b,
+        h_init=h_init,
     )
 
     expected = np.array([6, 9, 30])  # sum of each segment
@@ -453,13 +513,13 @@ def test_segmented_reduce_max_segment_size(max_seg_size, monkeypatch):
     d_ends = offsets[1:]
 
     cuda.compute.segmented_reduce(
-        d_input,
-        d_output,
-        d_starts,
-        d_ends,
-        OpKind.PLUS,
-        h_init,
-        num_segments,
+        d_in=d_input,
+        d_out=d_output,
+        num_segments=num_segments,
+        start_offsets_in=d_starts,
+        end_offsets_in=d_ends,
+        op=OpKind.PLUS,
+        h_init=h_init,
         max_segment_size=max_seg_size,
     )
 

--- a/python/cuda_cccl/tests/compute/test_segmented_sort.py
+++ b/python/cuda_cccl/tests/compute/test_segmented_sort.py
@@ -122,15 +122,15 @@ def test_segmented_sort_keys(dtype, num_segments, segment_size, monkeypatch):
     d_out_keys = numba.cuda.to_device(np.empty_like(h_in_keys))
 
     cuda.compute.segmented_sort(
-        d_in_keys,
-        d_out_keys,
-        None,
-        None,
-        num_items,
-        num_segments,
-        cp.asarray(start_offsets),
-        cp.asarray(end_offsets),
-        order,
+        d_in_keys=d_in_keys,
+        d_out_keys=d_out_keys,
+        d_in_values=None,
+        d_out_values=None,
+        num_items=num_items,
+        num_segments=num_segments,
+        start_offsets_in=cp.asarray(start_offsets),
+        end_offsets_in=cp.asarray(end_offsets),
+        order=order,
     )
 
     h_out_keys = d_out_keys.copy_to_host()
@@ -159,15 +159,15 @@ def test_segmented_sort_pairs(dtype, num_segments, segment_size):
     d_out_vals = numba.cuda.to_device(np.empty_like(h_in_vals))
 
     cuda.compute.segmented_sort(
-        d_in_keys,
-        d_out_keys,
-        d_in_vals,
-        d_out_vals,
-        num_items,
-        num_segments,
-        cp.asarray(start_offsets),
-        cp.asarray(end_offsets),
-        order,
+        d_in_keys=d_in_keys,
+        d_out_keys=d_out_keys,
+        d_in_values=d_in_vals,
+        d_out_values=d_out_vals,
+        num_items=num_items,
+        num_segments=num_segments,
+        start_offsets_in=cp.asarray(start_offsets),
+        end_offsets_in=cp.asarray(end_offsets),
+        order=order,
     )
 
     h_out_keys = d_out_keys.copy_to_host()
@@ -194,15 +194,15 @@ def test_segmented_sort_keys_double_buffer(dtype, num_segments, segment_size):
     keys_db = cuda.compute.DoubleBuffer(d_in_keys, d_tmp_keys)
 
     cuda.compute.segmented_sort(
-        keys_db,
-        None,
-        None,
-        None,
-        num_items,
-        num_segments,
-        cp.asarray(start_offsets),
-        cp.asarray(end_offsets),
-        order,
+        d_in_keys=keys_db,
+        d_out_keys=None,
+        d_in_values=None,
+        d_out_values=None,
+        num_items=num_items,
+        num_segments=num_segments,
+        start_offsets_in=cp.asarray(start_offsets),
+        end_offsets_in=cp.asarray(end_offsets),
+        order=order,
     )
 
     h_out_keys = keys_db.current().copy_to_host()
@@ -233,15 +233,15 @@ def test_segmented_sort_pairs_double_buffer(dtype, num_segments, segment_size):
     vals_db = cuda.compute.DoubleBuffer(d_in_vals, d_tmp_vals)
 
     cuda.compute.segmented_sort(
-        keys_db,
-        None,
-        vals_db,
-        None,
-        num_items,
-        num_segments,
-        cp.asarray(start_offsets),
-        cp.asarray(end_offsets),
-        order,
+        d_in_keys=keys_db,
+        d_out_keys=None,
+        d_in_values=vals_db,
+        d_out_values=None,
+        num_items=num_items,
+        num_segments=num_segments,
+        start_offsets_in=cp.asarray(start_offsets),
+        end_offsets_in=cp.asarray(end_offsets),
+        order=order,
     )
 
     h_out_keys = keys_db.current().copy_to_host()
@@ -303,15 +303,15 @@ def test_segmented_sort_variable_segment_sizes(num_segments):
     d_out_vals = numba.cuda.to_device(np.empty_like(h_in_vals))
 
     cuda.compute.segmented_sort(
-        d_in_keys,
-        d_out_keys,
-        d_in_vals,
-        d_out_vals,
-        num_items,
-        num_segments,
-        cp.asarray(start_offsets),
-        cp.asarray(end_offsets),
-        order,
+        d_in_keys=d_in_keys,
+        d_out_keys=d_out_keys,
+        d_in_values=d_in_vals,
+        d_out_values=d_out_vals,
+        num_items=num_items,
+        num_segments=num_segments,
+        start_offsets_in=cp.asarray(start_offsets),
+        end_offsets_in=cp.asarray(end_offsets),
+        order=order,
     )
 
     h_out_keys = d_out_keys.copy_to_host()

--- a/python/cuda_cccl/tests/compute/test_select.py
+++ b/python/cuda_cccl/tests/compute/test_select.py
@@ -72,11 +72,11 @@ def test_select_basic(dtype, num_items):
     d_num_selected = cp.empty(2, dtype=np.uint64)
 
     cuda.compute.select(
-        d_in,
-        d_out,
-        d_num_selected,
-        even_op,
-        num_items,
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=even_op,
+        num_items=num_items,
     )
 
     num_selected = int(d_num_selected[0].get())
@@ -100,11 +100,11 @@ def test_select_greater_than(dtype, num_items):
     d_num_selected = cp.empty(2, dtype=np.uint64)
 
     cuda.compute.select(
-        d_in,
-        d_out,
-        d_num_selected,
-        greater_than_42,
-        num_items,
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=greater_than_42,
+        num_items=num_items,
     )
 
     num_selected = int(d_num_selected[0].get())
@@ -129,11 +129,11 @@ def test_select_all_pass(dtype):
     d_num_selected = cp.empty(2, dtype=np.uint64)
 
     cuda.compute.select(
-        d_in,
-        d_out,
-        d_num_selected,
-        always_true,
-        num_items,
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=always_true,
+        num_items=num_items,
     )
 
     num_selected = int(d_num_selected[0].get())
@@ -156,11 +156,11 @@ def test_select_none_pass(monkeypatch, dtype):
     d_num_selected = cp.empty(2, dtype=np.int32)
 
     cuda.compute.select(
-        d_in,
-        d_out,
-        d_num_selected,
-        always_false,
-        num_items,
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=always_false,
+        num_items=num_items,
     )
 
     num_selected = int(d_num_selected[0].get())
@@ -181,11 +181,11 @@ def test_select_empty():
     d_num_selected = cp.empty(2, dtype=np.uint64)
 
     cuda.compute.select(
-        d_in,
-        d_out,
-        d_num_selected,
-        even_op,
-        num_items,
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=even_op,
+        num_items=num_items,
     )
 
     num_selected = int(d_num_selected[0].get())
@@ -207,11 +207,11 @@ def test_select_with_iterator(dtype):
     d_num_selected = cp.empty(2, dtype=np.uint64)
 
     cuda.compute.select(
-        d_in_iter,
-        d_out,
-        d_num_selected,
-        less_than_50,
-        num_items,
+        d_in=d_in_iter,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=less_than_50,
+        num_items=num_items,
     )
 
     num_selected = int(d_num_selected[0].get())
@@ -245,12 +245,12 @@ def test_select_object_api(dtype):
 
     # Get temp storage size
     temp_storage_bytes = selector(
-        None,
-        d_in,
-        d_out,
-        d_num_selected,
-        divisible_by_3,
-        num_items,
+        temp_storage=None,
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=divisible_by_3,
+        num_items=num_items,
     )
 
     # Allocate temp storage
@@ -258,12 +258,12 @@ def test_select_object_api(dtype):
 
     # Execute select
     selector(
-        d_temp_storage,
-        d_in,
-        d_out,
-        d_num_selected,
-        divisible_by_3,
-        num_items,
+        temp_storage=d_temp_storage,
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=divisible_by_3,
+        num_items=num_items,
     )
 
     num_selected = int(d_num_selected[0].get())
@@ -298,10 +298,22 @@ def test_select_reuse_object(dtype):
 
     # First execution
     temp_storage_bytes = selector(
-        None, d_in1, d_out, d_num_selected, positive_op, num_items
+        temp_storage=None,
+        d_in=d_in1,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=positive_op,
+        num_items=num_items,
     )
     d_temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
-    selector(d_temp_storage, d_in1, d_out, d_num_selected, positive_op, num_items)
+    selector(
+        temp_storage=d_temp_storage,
+        d_in=d_in1,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=positive_op,
+        num_items=num_items,
+    )
 
     num_selected1 = int(d_num_selected[0].get())
     got1 = d_out.get()[:num_selected1]
@@ -314,7 +326,14 @@ def test_select_reuse_object(dtype):
     h_in2 = random_array(num_items, dtype, max_value=100) - 50
     d_in2 = cp.asarray(h_in2)
 
-    selector(d_temp_storage, d_in2, d_out, d_num_selected, positive_op, num_items)
+    selector(
+        temp_storage=d_temp_storage,
+        d_in=d_in2,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=positive_op,
+        num_items=num_items,
+    )
 
     num_selected2 = int(d_num_selected[0].get())
     got2 = d_out.get()[:num_selected2]
@@ -350,11 +369,11 @@ def test_select_with_struct(dtype):
     d_num_selected = cp.empty(2, dtype=np.uint64)
 
     cuda.compute.select(
-        d_in,
-        d_out,
-        d_num_selected,
-        in_first_quadrant,
-        num_items,
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=in_first_quadrant,
+        num_items=num_items,
     )
 
     num_selected = int(d_num_selected[0].get())
@@ -401,11 +420,11 @@ def test_select_with_zip_iterator(monkeypatch):
     d_num_selected = cp.empty(1, dtype=np.int32)
 
     cuda.compute.select(
-        zip_in,
-        zip_out,
-        d_num_selected,
-        condition,
-        num_items,
+        d_in=zip_in,
+        d_out=zip_out,
+        d_num_selected_out=d_num_selected,
+        cond=condition,
+        num_items=num_items,
     )
 
     num_selected = int(d_num_selected[0].get())
@@ -443,11 +462,11 @@ def test_select_stateful_threshold():
     d_num_selected = cp.empty(2, dtype=np.uint64)
 
     cuda.compute.select(
-        d_in,
-        d_out,
-        d_num_selected,
-        threshold_select,
-        num_items,
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=threshold_select,
+        num_items=num_items,
     )
 
     # Check selected output
@@ -490,11 +509,11 @@ def test_select_stateful_atomic():
     d_num_selected = cp.empty(2, dtype=np.uint64)
 
     cuda.compute.select(
-        d_in,
-        d_out,
-        d_num_selected,
-        count_rejects,
-        num_items,
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=count_rejects,
+        num_items=num_items,
     )
 
     # Check selected output
@@ -539,7 +558,13 @@ def test_select_with_side_effect_counting_rejects():
             numba_cuda.atomic.add(reject_count, 0, 1)
             return False
 
-    cuda.compute.select(d_in, d_out, d_num_selected, count_rejects, len(d_in))
+    cuda.compute.select(
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=count_rejects,
+        num_items=len(d_in),
+    )
 
     num_selected = int(d_num_selected.get()[0])
     num_rejected = int(reject_count.get()[0])
@@ -558,7 +583,13 @@ def test_select_with_lambda():
     d_num_selected = cp.empty(2, dtype=np.uint64)
 
     # Use a lambda function directly as the predicate
-    cuda.compute.select(d_in, d_out, d_num_selected, lambda x: x % 2 == 0, num_items)
+    cuda.compute.select(
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=lambda x: x % 2 == 0,
+        num_items=num_items,
+    )
 
     num_selected = int(d_num_selected.get()[0])
     expected_selected = [x for x in h_in if x % 2 == 0]
@@ -582,7 +613,13 @@ def test_select_stateful_state_updates():
     def select_gt_5(x):
         return x > threshold_5[0]
 
-    cuda.compute.select(d_in, d_out, d_count, select_gt_5, num_items)
+    cuda.compute.select(
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_count,
+        cond=select_gt_5,
+        num_items=num_items,
+    )
     count1 = int(d_count[0].get())
     assert count1 == 14
     expected_1 = list(range(6, 20))
@@ -593,7 +630,13 @@ def test_select_stateful_state_updates():
         return x > threshold_15[0]
 
     d_count.fill(0)
-    cuda.compute.select(d_in, d_out, d_count, select_gt_15, num_items)
+    cuda.compute.select(
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_count,
+        cond=select_gt_15,
+        num_items=num_items,
+    )
     count2 = int(d_count[0].get())
     assert count2 == 4
     expected_2 = list(range(16, 20))
@@ -601,7 +644,13 @@ def test_select_stateful_state_updates():
 
     # Call 3: Back to first threshold (test cache reuse with updated state)
     d_count.fill(0)
-    cuda.compute.select(d_in, d_out, d_count, select_gt_5, num_items)
+    cuda.compute.select(
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_count,
+        cond=select_gt_5,
+        num_items=num_items,
+    )
     count3 = int(d_count[0].get())
     assert count3 == 14
     np.testing.assert_array_equal(d_out.get()[:count3], expected_1)
@@ -634,13 +683,25 @@ def test_select_stateful_same_bytecode_different_state():
     select_15 = make_selector(threshold_15)
 
     # Call 1: threshold > 5
-    cuda.compute.select(d_in, d_out, d_count, select_5, num_items)
+    cuda.compute.select(
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_count,
+        cond=select_5,
+        num_items=num_items,
+    )
     count1 = int(d_count[0].get())
     assert count1 == 14
 
     # Call 2: threshold > 15 (different state, same bytecode)
     d_count.fill(0)
-    cuda.compute.select(d_in, d_out, d_count, select_15, num_items)
+    cuda.compute.select(
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_count,
+        cond=select_15,
+        num_items=num_items,
+    )
     count2 = int(d_count[0].get())
     assert count2 == 4  # If this fails, cache collision bug is present
 
@@ -669,7 +730,13 @@ def test_stateful_caching_same_dtype_different_values():
     def select_gt_30(x):
         return x > threshold_30[0]
 
-    cuda.compute.select(d_in, d_out, d_count, select_gt_30, num_items)
+    cuda.compute.select(
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_count,
+        cond=select_gt_30,
+        num_items=num_items,
+    )
     count_30 = int(d_count[0].get())
 
     # Test with threshold_70
@@ -678,7 +745,13 @@ def test_stateful_caching_same_dtype_different_values():
 
     d_out.fill(0)
     d_count.fill(0)
-    cuda.compute.select(d_in, d_out, d_count, select_gt_70, num_items)
+    cuda.compute.select(
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_count,
+        cond=select_gt_70,
+        num_items=num_items,
+    )
     count_70 = int(d_count[0].get())
 
     # Verify correct results (not cache collision)

--- a/python/cuda_cccl/tests/compute/test_select.py
+++ b/python/cuda_cccl/tests/compute/test_select.py
@@ -237,10 +237,10 @@ def test_select_object_api(dtype):
 
     # Create select object
     selector = cuda.compute.make_select(
-        d_in,
-        d_out,
-        d_num_selected,
-        divisible_by_3,
+        d_in=d_in,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=divisible_by_3,
     )
 
     # Get temp storage size
@@ -290,10 +290,10 @@ def test_select_reuse_object(dtype):
     h_in1 = random_array(num_items, dtype, max_value=100) - 50
     d_in1 = cp.asarray(h_in1)
     selector = cuda.compute.make_select(
-        d_in1,
-        d_out,
-        d_num_selected,
-        positive_op,
+        d_in=d_in1,
+        d_out=d_out,
+        d_num_selected_out=d_num_selected,
+        cond=positive_op,
     )
 
     # First execution

--- a/python/cuda_cccl/tests/compute/test_shuffle_iterator.py
+++ b/python/cuda_cccl/tests/compute/test_shuffle_iterator.py
@@ -20,7 +20,9 @@ def test_shuffle_iterator_bijectivity():
     shuffle_it = ShuffleIterator(num_items, seed)
 
     d_output = cp.empty(num_items, dtype=np.int64)
-    cuda.compute.unary_transform(shuffle_it, d_output, lambda x: x, num_items)
+    cuda.compute.unary_transform(
+        d_in=shuffle_it, d_out=d_output, op=lambda x: x, num_items=num_items
+    )
 
     result = d_output.get()
 
@@ -38,8 +40,12 @@ def test_shuffle_iterator_determinism():
     d_output1 = cp.empty(num_items, dtype=np.int64)
     d_output2 = cp.empty(num_items, dtype=np.int64)
 
-    cuda.compute.unary_transform(shuffle_it1, d_output1, lambda x: x, num_items)
-    cuda.compute.unary_transform(shuffle_it2, d_output2, lambda x: x, num_items)
+    cuda.compute.unary_transform(
+        d_in=shuffle_it1, d_out=d_output1, op=lambda x: x, num_items=num_items
+    )
+    cuda.compute.unary_transform(
+        d_in=shuffle_it2, d_out=d_output2, op=lambda x: x, num_items=num_items
+    )
 
     cp.testing.assert_array_equal(d_output1, d_output2)
 
@@ -51,7 +57,9 @@ def test_shuffle_iterator_various_sizes(num_items):
     shuffle_it = ShuffleIterator(num_items, seed)
 
     d_output = cp.empty(num_items, dtype=np.int64)
-    cuda.compute.unary_transform(shuffle_it, d_output, lambda x: x, num_items)
+    cuda.compute.unary_transform(
+        d_in=shuffle_it, d_out=d_output, op=lambda x: x, num_items=num_items
+    )
 
     result = d_output.get()
 
@@ -69,7 +77,9 @@ def test_shuffle_iterator_with_permutation_iterator():
     perm_it = PermutationIterator(d_values, shuffle_it)
 
     d_output = cp.empty(num_items, dtype=np.int32)
-    cuda.compute.unary_transform(perm_it, d_output, lambda x: x, num_items)
+    cuda.compute.unary_transform(
+        d_in=perm_it, d_out=d_output, op=lambda x: x, num_items=num_items
+    )
 
     result = d_output.get()
 

--- a/python/cuda_cccl/tests/compute/test_three_way_partition.py
+++ b/python/cuda_cccl/tests/compute/test_three_way_partition.py
@@ -91,14 +91,14 @@ def test_three_way_partition_basic(dtype, num_items, monkeypatch):
     d_unselected = cp.empty_like(d_in)
     d_num_selected = cp.empty(2, dtype=np.int32)
     cuda.compute.three_way_partition(
-        d_in,
-        d_first,
-        d_second,
-        d_unselected,
-        d_num_selected,
-        less_than_op,
-        greater_equal_op,
-        num_items,
+        d_in=d_in,
+        d_first_part_out=d_first,
+        d_second_part_out=d_second,
+        d_unselected_out=d_unselected,
+        d_num_selected_out=d_num_selected,
+        select_first_part_op=less_than_op,
+        select_second_part_op=greater_equal_op,
+        num_items=num_items,
     )
 
     num_selected = d_num_selected.get()
@@ -133,14 +133,14 @@ def test_three_way_partition_empty():
         return x >= 42
 
     cuda.compute.three_way_partition(
-        d_in,
-        d_first,
-        d_second,
-        d_unselected,
-        d_num_selected,
-        less_than_op,
-        greater_equal_op,
-        0,
+        d_in=d_in,
+        d_first_part_out=d_first,
+        d_second_part_out=d_second,
+        d_unselected_out=d_unselected,
+        d_num_selected_out=d_num_selected,
+        select_first_part_op=less_than_op,
+        select_second_part_op=greater_equal_op,
+        num_items=0,
     )
 
     np.testing.assert_array_equal(d_num_selected.get(), np.array([0, 0]))
@@ -170,14 +170,14 @@ def test_three_way_partition_with_iterators():
     d_num_selected = cp.empty(2, dtype=np.uint32)
 
     cuda.compute.three_way_partition(
-        in_it,
-        d_first,
-        d_second,
-        d_unselected,
-        d_num_selected,
-        less_than_op,
-        greater_equal_op,
-        num_items,
+        d_in=in_it,
+        d_first_part_out=d_first,
+        d_second_part_out=d_second,
+        d_unselected_out=d_unselected,
+        d_num_selected_out=d_num_selected,
+        select_first_part_op=less_than_op,
+        select_second_part_op=greater_equal_op,
+        num_items=num_items,
     )
 
     num_selected = d_num_selected.get()
@@ -232,14 +232,14 @@ def test_three_way_partition_struct_type():
     d_num_selected = cp.empty(2, dtype=np.uint64)
 
     cuda.compute.three_way_partition(
-        d_in,
-        d_first,
-        d_second,
-        d_unselected,
-        d_num_selected,
-        less_than_op,
-        greater_equal_op,
-        num_items,
+        d_in=d_in,
+        d_first_part_out=d_first,
+        d_second_part_out=d_second,
+        d_unselected_out=d_unselected,
+        d_num_selected_out=d_num_selected,
+        select_first_part_op=less_than_op,
+        select_second_part_op=greater_equal_op,
+        num_items=num_items,
     )
 
     num_selected = d_num_selected.get()
@@ -278,14 +278,14 @@ def test_three_way_partition_with_stream(cuda_stream):
         d_num_selected = cp.empty(2, dtype=np.int64)
 
     cuda.compute.three_way_partition(
-        d_in,
-        d_first,
-        d_second,
-        d_unselected,
-        d_num_selected,
-        less_than_op,
-        greater_equal_op,
-        num_items,
+        d_in=d_in,
+        d_first_part_out=d_first,
+        d_second_part_out=d_second,
+        d_unselected_out=d_unselected,
+        d_num_selected_out=d_num_selected,
+        select_first_part_op=less_than_op,
+        select_second_part_op=greater_equal_op,
+        num_items=num_items,
         stream=cuda_stream,
     )
 
@@ -320,14 +320,14 @@ def test_three_way_partition_no_selection():
     d_num_selected = cp.empty(2, dtype=np.int64)
 
     cuda.compute.three_way_partition(
-        d_in,
-        d_first,
-        d_second,
-        d_unselected,
-        d_num_selected,
-        less_than_op,
-        greater_equal_op,
-        num_items,
+        d_in=d_in,
+        d_first_part_out=d_first,
+        d_second_part_out=d_second,
+        d_unselected_out=d_unselected,
+        d_num_selected_out=d_num_selected,
+        select_first_part_op=less_than_op,
+        select_second_part_op=greater_equal_op,
+        num_items=num_items,
     )
 
     num_selected = d_num_selected.get()
@@ -357,14 +357,14 @@ def test_three_way_partition_same_predicate():
     d_num_selected = cp.empty(2, dtype=np.int64)
 
     cuda.compute.three_way_partition(
-        d_in,
-        d_first,
-        d_second,
-        d_unselected,
-        d_num_selected,
-        always_true,
-        always_true,
-        num_items,
+        d_in=d_in,
+        d_first_part_out=d_first,
+        d_second_part_out=d_second,
+        d_unselected_out=d_unselected,
+        d_num_selected_out=d_num_selected,
+        select_first_part_op=always_true,
+        select_second_part_op=always_true,
+        num_items=num_items,
     )
 
     num_selected = d_num_selected.get()
@@ -390,14 +390,14 @@ def test_three_way_partition_all_selected_first():
     d_num_selected = cp.empty(2, dtype=np.int64)
 
     cuda.compute.three_way_partition(
-        d_in,
-        d_first,
-        d_second,
-        d_unselected,
-        d_num_selected,
-        less_than_op,
-        greater_equal_op,
-        num_items,
+        d_in=d_in,
+        d_first_part_out=d_first,
+        d_second_part_out=d_second,
+        d_unselected_out=d_unselected,
+        d_num_selected_out=d_num_selected,
+        select_first_part_op=less_than_op,
+        select_second_part_op=greater_equal_op,
+        num_items=num_items,
     )
 
     num_selected = d_num_selected.get()

--- a/python/cuda_cccl/tests/compute/test_transform.py
+++ b/python/cuda_cccl/tests/compute/test_transform.py
@@ -19,7 +19,9 @@ def unary_transform_host(h_input: np.ndarray, op):
 
 
 def unary_transform_device(d_input, d_output, num_items, op, stream=None):
-    cuda.compute.unary_transform(d_input, d_output, op, num_items, stream=stream)
+    cuda.compute.unary_transform(
+        d_in=d_input, d_out=d_output, op=op, num_items=num_items, stream=stream
+    )
 
 
 def binary_transform_host(h_input1: np.ndarray, h_input2: np.ndarray, op):
@@ -28,7 +30,12 @@ def binary_transform_host(h_input1: np.ndarray, h_input2: np.ndarray, op):
 
 def binary_transform_device(d_input1, d_input2, d_output, num_items, op, stream=None):
     cuda.compute.binary_transform(
-        d_input1, d_input2, d_output, op, num_items, stream=stream
+        d_in1=d_input1,
+        d_in2=d_input2,
+        d_out=d_output,
+        op=op,
+        num_items=num_items,
+        stream=stream,
     )
 
 
@@ -96,7 +103,7 @@ def test_unary_transform_struct_type():
 
     d_out = cp.empty_like(d_in)
 
-    cuda.compute.unary_transform(d_in, d_out, op, len(d_in))
+    cuda.compute.unary_transform(d_in=d_in, d_out=d_out, op=op, num_items=len(d_in))
 
     got = d_out.get()
 
@@ -143,7 +150,9 @@ def test_binary_transform_struct_type():
 
     d_out = cp.empty_like(d_in1)
 
-    cuda.compute.binary_transform(d_in1, d_in2, d_out, op, len(d_in1))
+    cuda.compute.binary_transform(
+        d_in1=d_in1, d_in2=d_in2, d_out=d_out, op=op, num_items=len(d_in1)
+    )
 
     got = d_out.get()
 
@@ -264,7 +273,9 @@ def test_unary_transform_well_known_negate():
     d_output = cp.empty_like(d_input, dtype=dtype)
 
     # Run unary transform with well-known NEGATE operation
-    cuda.compute.unary_transform(d_input, d_output, OpKind.NEGATE, len(d_input))
+    cuda.compute.unary_transform(
+        d_in=d_input, d_out=d_output, op=OpKind.NEGATE, num_items=len(d_input)
+    )
 
     # Check the result is correct
     expected = np.array([-1, 2, -3, 4, -5])
@@ -278,7 +289,9 @@ def test_unary_transform_well_known_identity():
     d_output = cp.empty_like(d_input, dtype=dtype)
 
     # Run unary transform with well-known IDENTITY operation
-    cuda.compute.unary_transform(d_input, d_output, OpKind.IDENTITY, len(d_input))
+    cuda.compute.unary_transform(
+        d_in=d_input, d_out=d_output, op=OpKind.IDENTITY, num_items=len(d_input)
+    )
 
     # Check the result is correct
     expected = np.array([1, 2, 3, 4, 5])
@@ -294,7 +307,11 @@ def test_binary_transform_well_known_plus(dtype):
 
     # Run binary transform with well-known PLUS operation
     cuda.compute.binary_transform(
-        d_input1, d_input2, d_output, OpKind.PLUS, len(d_input1)
+        d_in1=d_input1,
+        d_in2=d_input2,
+        d_out=d_output,
+        op=OpKind.PLUS,
+        num_items=len(d_input1),
     )
 
     # Check the result is correct
@@ -311,7 +328,11 @@ def test_binary_transform_well_known_multiplies():
 
     # Run binary transform with well-known MULTIPLIES operation
     cuda.compute.binary_transform(
-        d_input1, d_input2, d_output, OpKind.MULTIPLIES, len(d_input1)
+        d_in1=d_input1,
+        d_in2=d_input2,
+        d_out=d_output,
+        op=OpKind.MULTIPLIES,
+        num_items=len(d_input1),
     )
 
     # Check the result is correct
@@ -339,7 +360,9 @@ def test_unary_transform_struct_type_with_annotations():
 
     d_out = cp.empty_like(d_in)
 
-    cuda.compute.unary_transform(d_in, d_out, scale_op, num_items)
+    cuda.compute.unary_transform(
+        d_in=d_in, d_out=d_out, op=scale_op, num_items=num_items
+    )
 
     result = d_out.get()
 
@@ -374,7 +397,9 @@ def test_binary_transform_struct_type_with_annotations():
 
     d_out = cp.empty_like(d_in1)
 
-    cuda.compute.binary_transform(d_in1, d_in2, d_out, add_vectors, num_items)
+    cuda.compute.binary_transform(
+        d_in1=d_in1, d_in2=d_in2, d_out=d_out, op=add_vectors, num_items=num_items
+    )
 
     result = d_out.get()
 
@@ -397,7 +422,9 @@ def test_unary_transform_stateful_counting():
             numba_cuda.atomic.add(even_count, 0, 1)
         return x * 2
 
-    cuda.compute.unary_transform(d_in, d_out, count_evens, len(d_in))
+    cuda.compute.unary_transform(
+        d_in=d_in, d_out=d_out, op=count_evens, num_items=len(d_in)
+    )
 
     expected_output = cp.arange(100, dtype=np.int32) * 2
     np.testing.assert_array_equal(d_out.get(), expected_output.get())
@@ -420,7 +447,9 @@ def test_unary_transform_stateful_state_updates():
     def add_threshold_10(x):
         return x + threshold_10[0]
 
-    cuda.compute.unary_transform(d_in, d_out, add_threshold_10, num_items)
+    cuda.compute.unary_transform(
+        d_in=d_in, d_out=d_out, op=add_threshold_10, num_items=num_items
+    )
     result_1 = d_out.get()
     expected_1 = d_in.get() + 10
     np.testing.assert_array_equal(result_1, expected_1)
@@ -430,14 +459,18 @@ def test_unary_transform_stateful_state_updates():
         return x + threshold_15[0]
 
     d_out.fill(0)
-    cuda.compute.unary_transform(d_in, d_out, add_threshold_15, num_items)
+    cuda.compute.unary_transform(
+        d_in=d_in, d_out=d_out, op=add_threshold_15, num_items=num_items
+    )
     result_2 = d_out.get()
     expected_2 = d_in.get() + 15
     np.testing.assert_array_equal(result_2, expected_2)
 
     # Call 3: Back to first threshold (test cache reuse with updated state)
     d_out.fill(0)
-    cuda.compute.unary_transform(d_in, d_out, add_threshold_10, num_items)
+    cuda.compute.unary_transform(
+        d_in=d_in, d_out=d_out, op=add_threshold_10, num_items=num_items
+    )
     result_3 = d_out.get()
     expected_3 = d_in.get() + 10
     np.testing.assert_array_equal(result_3, expected_3)
@@ -456,7 +489,9 @@ def test_unary_transform_stateful_multiple_arrays():
     def transform_with_multiple_state(x):
         return (x + offset[0]) * multiplier[0]
 
-    cuda.compute.unary_transform(d_in, d_out, transform_with_multiple_state, num_items)
+    cuda.compute.unary_transform(
+        d_in=d_in, d_out=d_out, op=transform_with_multiple_state, num_items=num_items
+    )
     result = d_out.get()
     expected = (d_in.get() + 5) * 2
     np.testing.assert_array_equal(result, expected)
@@ -469,7 +504,9 @@ def test_unary_transform_stateful_multiple_arrays():
         return (x + offset[0]) * multiplier[0]
 
     d_out.fill(0)
-    cuda.compute.unary_transform(d_in, d_out, transform_with_updated_state, num_items)
+    cuda.compute.unary_transform(
+        d_in=d_in, d_out=d_out, op=transform_with_updated_state, num_items=num_items
+    )
     result = d_out.get()
     expected = (d_in.get() + 10) * 3
     np.testing.assert_array_equal(result, expected)
@@ -494,14 +531,19 @@ def test_unary_transform_stateful_closure_factory():
     d_out = cp.empty_like(d_in)
 
     # First call with offset 10
-    cuda.compute.unary_transform(d_in, d_out, make_adder(cp.array([10])), len(d_in))
+    cuda.compute.unary_transform(
+        d_in=d_in, d_out=d_out, op=make_adder(cp.array([10])), num_items=len(d_in)
+    )
     np.testing.assert_array_equal(d_out.get(), np.array([10, 11, 12]))
 
     # Multiple calls with different offsets to test state re-detection
     for i in range(5):
         offset = i * 10
         cuda.compute.unary_transform(
-            d_in, d_out, make_adder(cp.array([offset])), len(d_in)
+            d_in=d_in,
+            d_out=d_out,
+            op=make_adder(cp.array([offset])),
+            num_items=len(d_in),
         )
         expected = np.array([offset, offset + 1, offset + 2])
         np.testing.assert_array_equal(
@@ -517,7 +559,9 @@ def test_unary_transform_with_lambda():
     d_out = cp.empty_like(d_in)
 
     # Use a lambda function directly
-    cuda.compute.unary_transform(d_in, d_out, lambda x: x * 2, len(d_in))
+    cuda.compute.unary_transform(
+        d_in=d_in, d_out=d_out, op=lambda x: x * 2, num_items=len(d_in)
+    )
 
     expected = np.array([2, 4, 6, 8, 10], dtype=np.int32)
     np.testing.assert_array_equal(d_out.get(), expected)
@@ -530,7 +574,13 @@ def test_binary_transform_with_lambda():
     d_out = cp.empty_like(d_in1)
 
     # Use a lambda function directly
-    cuda.compute.binary_transform(d_in1, d_in2, d_out, lambda a, b: a + b, len(d_in1))
+    cuda.compute.binary_transform(
+        d_in1=d_in1,
+        d_in2=d_in2,
+        d_out=d_out,
+        op=lambda a, b: a + b,
+        num_items=len(d_in1),
+    )
 
     expected = np.array([11, 22, 33, 44, 55], dtype=np.int32)
     np.testing.assert_array_equal(d_out.get(), expected)
@@ -542,7 +592,11 @@ def test_binary_transform_bool_equal_to():
     d_output = cp.empty_like(d_input1)
 
     cuda.compute.binary_transform(
-        d_input1, d_input2, d_output, OpKind.EQUAL_TO, len(d_input1)
+        d_in1=d_input1,
+        d_in2=d_input2,
+        d_out=d_output,
+        op=OpKind.EQUAL_TO,
+        num_items=len(d_input1),
     )
 
     expected = np.array([True, False, False, True], dtype=np.bool_)
@@ -566,10 +620,10 @@ def test_stateful_transform_same_bytecode_different_sizes():
     op1 = make_op(cp.empty(1))  # len(arr) == 1
     op2 = make_op(cp.empty(2))  # len(arr) == 2
 
-    cuda.compute.unary_transform(d_in, d_out, op1, len(d_in))
+    cuda.compute.unary_transform(d_in=d_in, d_out=d_out, op=op1, num_items=len(d_in))
     np.testing.assert_array_equal(np.asarray([False, True, True]), d_out.get())
 
-    cuda.compute.unary_transform(d_in, d_out, op2, len(d_in))
+    cuda.compute.unary_transform(d_in=d_in, d_out=d_out, op=op2, num_items=len(d_in))
     np.testing.assert_array_equal(np.asarray([False, False, True]), d_out.get())
 
 
@@ -591,7 +645,9 @@ def test_transform_caching_with_global_np_ufunc():
 
     d_out = cp.empty_like(d_in)
 
-    cuda.compute.unary_transform(d_in, d_out, make_op(), len(d_in))
+    cuda.compute.unary_transform(
+        d_in=d_in, d_out=d_out, op=make_op(), num_items=len(d_in)
+    )
     cp.testing.assert_allclose(d_out, cp.sin(d_in))
 
     def make_op():
@@ -602,7 +658,9 @@ def test_transform_caching_with_global_np_ufunc():
 
         return op
 
-    cuda.compute.unary_transform(d_in, d_out, make_op(), len(d_in))
+    cuda.compute.unary_transform(
+        d_in=d_in, d_out=d_out, op=make_op(), num_items=len(d_in)
+    )
     cp.testing.assert_allclose(d_out, cp.cos(d_in))
 
     d_in = cp.asarray([1.0, 2.0, 3.0])

--- a/python/cuda_cccl/tests/compute/test_unique_by_key.py
+++ b/python/cuda_cccl/tests/compute/test_unique_by_key.py
@@ -66,14 +66,14 @@ def unique_by_key_device(
 ):
     # Call single-phase API directly with all parameters including num_items
     cuda.compute.unique_by_key(
-        d_in_keys,
-        d_in_items,
-        d_out_keys,
-        d_out_items,
-        d_out_num_selected,
-        op,
-        num_items,
-        stream,
+        d_in_keys=d_in_keys,
+        d_in_items=d_in_items,
+        d_out_keys=d_out_keys,
+        d_out_items=d_out_items,
+        d_out_num_selected=d_out_num_selected,
+        op=op,
+        num_items=num_items,
+        stream=stream,
     )
 
 
@@ -441,13 +441,13 @@ def test_unique_by_key_well_known_equal_to(monkeypatch):
 
     # Run unique by key with well-known EQUAL_TO operation
     cuda.compute.unique_by_key(
-        d_in_keys,
-        d_in_values,
-        d_out_keys,
-        d_out_values,
-        d_num_selected,
-        OpKind.EQUAL_TO,
-        len(d_in_keys),
+        d_in_keys=d_in_keys,
+        d_in_items=d_in_values,
+        d_out_keys=d_out_keys,
+        d_out_items=d_out_values,
+        d_out_num_selected=d_num_selected,
+        op=OpKind.EQUAL_TO,
+        num_items=len(d_in_keys),
     )
 
     # Check the result is correct

--- a/python/cuda_cccl/tests/compute/test_zip_iterator.py
+++ b/python/cuda_cccl/tests/compute/test_zip_iterator.py
@@ -199,7 +199,11 @@ def test_zip_iterator_with_transform(num_items):
     d_output = cp.empty(num_items, dtype=TransformedPair.dtype)
 
     cuda.compute.binary_transform(
-        zip_it1, zip_it2, d_output, binary_transform, num_items
+        d_in1=zip_it1,
+        d_in2=zip_it2,
+        d_out=d_output,
+        op=binary_transform,
+        num_items=num_items,
     )
 
     result = d_output.get()

--- a/python/cuda_cccl/tests/compute/test_zip_iterator.py
+++ b/python/cuda_cccl/tests/compute/test_zip_iterator.py
@@ -32,7 +32,9 @@ def test_zip_iterator_basic(num_items):
     d_output = cp.empty(1, dtype=Pair.dtype)
     h_init = Pair(0, 0.0)
 
-    cuda.compute.reduce_into(zip_it, d_output, sum_pairs, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=zip_it, d_out=d_output, num_items=num_items, op=sum_pairs, h_init=h_init
+    )
 
     expected_first = d_input1.sum().get()
     expected_second = d_input2.sum().get()
@@ -60,7 +62,9 @@ def test_zip_iterator_with_counting_iterator(num_items):
 
     d_output = cp.empty(1, dtype=dtype)
 
-    cuda.compute.reduce_into(zip_it, d_output, max_by_value, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=zip_it, d_out=d_output, num_items=num_items, op=max_by_value, h_init=h_init
+    )
 
     result = d_output.get()[0]
 
@@ -96,7 +100,9 @@ def test_zip_iterator_with_counting_iterator_and_transform(num_items):
     result = d_output.get()[0]
     h_init = IndexValuePair(-1, -1)
 
-    cuda.compute.reduce_into(zip_it, d_output, max_by_value, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=zip_it, d_out=d_output, num_items=num_items, op=max_by_value, h_init=h_init
+    )
 
     result = d_output.get()[0]
 
@@ -129,7 +135,9 @@ def test_zip_iterator_n_iterators(num_items):
     d_output = cp.empty(1, dtype=Triple.dtype)
     h_init = Triple(0, 0.0, 0)
 
-    cuda.compute.reduce_into(zip_it, d_output, sum_triples, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=zip_it, d_out=d_output, num_items=num_items, op=sum_triples, h_init=h_init
+    )
 
     result = d_output.get()[0]
 
@@ -160,7 +168,9 @@ def test_zip_iterator_single_iterator(num_items):
     d_output = cp.empty(1, dtype=Single.dtype)
     h_init = Single(0)
 
-    cuda.compute.reduce_into(zip_it, d_output, sum_singles, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=zip_it, d_out=d_output, num_items=num_items, op=sum_singles, h_init=h_init
+    )
 
     result = d_output.get()[0]
 
@@ -225,7 +235,13 @@ def test_zip_iterator_with_scan(num_items):
     d_output = cp.empty(num_items, dtype=Pair.dtype)
     h_init = Pair(cp.iinfo(np.int64).max, cp.iinfo(np.int64).max)
 
-    cuda.compute.inclusive_scan(zip_it, d_output, min_pairs, h_init, num_items)
+    cuda.compute.inclusive_scan(
+        d_in=zip_it,
+        d_out=d_output,
+        op=min_pairs,
+        init_value=h_init,
+        num_items=num_items,
+    )
 
     result = d_output.get()
 
@@ -265,7 +281,13 @@ def test_output_zip_iterator_with_scan(monkeypatch, num_items):
     def add_pairs(p1, p2):
         return p1[0] + p2[0], p1[1] + p2[1]
 
-    cuda.compute.inclusive_scan(zip_it, zip_out_it, add_pairs, None, num_items)
+    cuda.compute.inclusive_scan(
+        d_in=zip_it,
+        d_out=zip_out_it,
+        op=add_pairs,
+        init_value=None,
+        num_items=num_items,
+    )
 
     in1 = d_in1.get()
     in2 = d_in2.get()
@@ -318,7 +340,13 @@ def test_nested_zip_iterators():
     d_output = cp.empty(1, dtype=OuterTriple.dtype)
     h_init = OuterTriple(InnerPair(0, 0), 0.0)
 
-    cuda.compute.reduce_into(outer_zip, d_output, sum_nested_zips, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=outer_zip,
+        d_out=d_output,
+        num_items=num_items,
+        op=sum_nested_zips,
+        h_init=h_init,
+    )
 
     result = d_output.get()[0]
 
@@ -364,7 +392,13 @@ def test_deeply_nested_zip_iterators():
     d_output = cp.empty(1, dtype=OuterPair.dtype)
     h_init = OuterPair(InnerPair(0, 0.0), 0)
 
-    cuda.compute.reduce_into(outer_zip, d_output, sum_nested_zips, num_items, h_init)
+    cuda.compute.reduce_into(
+        d_in=outer_zip,
+        d_out=d_output,
+        num_items=num_items,
+        op=sum_nested_zips,
+        h_init=h_init,
+    )
 
     result = d_output.get()[0]
 
@@ -425,7 +459,13 @@ def test_nested_output_zip_iterator_with_scan(monkeypatch, num_items, dtype_map)
         result2 = (v1[1].x + v2[1].x, v1[1].y + v2[1].y)
         return Vec2(result1[0], result1[1]), Vec2(result2[0], result2[1])
 
-    cuda.compute.inclusive_scan(zip_it, zip_out_it, add_vec2_pairs, None, num_items)
+    cuda.compute.inclusive_scan(
+        d_in=zip_it,
+        d_out=zip_out_it,
+        op=add_vec2_pairs,
+        init_value=None,
+        num_items=num_items,
+    )
 
     in1 = d_in1.get()
     in2 = d_in2.get()
@@ -621,7 +661,11 @@ def test_zip_iterator_advance():
 
     remaining_items = num_items - offset
     cuda.compute.reduce_into(
-        advanced_zip_it, d_output, sum_pairs, remaining_items, h_init
+        d_in=advanced_zip_it,
+        d_out=d_output,
+        num_items=remaining_items,
+        op=sum_pairs,
+        h_init=h_init,
     )
 
     result = d_output.get()[0]
@@ -668,7 +712,11 @@ def test_nested_zip_iterator_advance():
 
     remaining_items = num_items - offset
     cuda.compute.reduce_into(
-        advanced_outer_zip, d_output, sum_nested_zips, remaining_items, h_init
+        d_in=advanced_outer_zip,
+        d_out=d_output,
+        num_items=remaining_items,
+        op=sum_nested_zips,
+        h_init=h_init,
     )
 
     result = d_output.get()[0]


### PR DESCRIPTION
## Description

- All `cuda.compute` algorithm parameters are now **keyword-only** — positional calls raise `TypeError`
- Parameter order aligned with CUB's C++ API (e.g. `num_items` before `op` in `reduce_into` and `merge_sort`)
- `merge_sort` parameter rename: `d_in_items`/`d_out_items` → `d_in_values`/`d_out_values`
- CUB header `device_merge_sort.cuh`: matching rename of `d_items`/`d_input_items`/`d_output_items` → `d_values`/`d_input_values`/`d_output_values`
- Docs updated: keyword-only convention documented in API conventions section

## Changed files

### Algorithm implementations (7)
| File | Change |
|---|---|
| `_reduce.py` | Keyword-only; `num_items` before `op` |
| `_segmented_reduce.py` | Keyword-only; `num_segments` before offsets; `op`/`h_init` after offsets |
| `_scan.py` | Keyword-only; removed `\| None` from `exclusive_scan`'s `init_value` annotation |
| `_binary_search.py` | Keyword-only; reordered to `d_data, num_items, d_values, num_values, d_out` |
| `_sort/_radix_sort.py` | Keyword-only; `num_items` before `order` |
| `_sort/_merge_sort.py` | Keyword-only; `d_in_items`/`d_out_items` → `d_in_values`/`d_out_values`; `num_items` before `op` |
| `_sort/_segmented_sort.py` | Keyword-only |

### CUB C++ (1)
- `cub/device/device_merge_sort.cuh`: rename `d_items` → `d_values` throughout

### Tests / examples / benchmarks (72)
All call sites updated to keyword-only form with corrected parameter order.

### Docs (1)
- `docs/python/compute/index.rst`: added keyword-only convention to API conventions section; updated object-based API code example

## Migration

```python
# Before
cuda.compute.reduce_into(d_in, d_out, op, num_items, h_init)
cuda.compute.merge_sort(d_in_keys, d_in_items, d_out_keys, d_out_items, op, num_items)
cuda.compute.lower_bound(d_data, d_values, d_out, num_items, num_values)

# After
cuda.compute.reduce_into(d_in=d_in, d_out=d_out, num_items=num_items, op=op, h_init=h_init)
cuda.compute.merge_sort(d_in_keys=d_in_keys, d_in_values=d_in_values, d_out_keys=d_out_keys, d_out_values=d_out_values, num_items=num_items, op=op)
cuda.compute.lower_bound(d_data=d_data, num_items=num_items, d_values=d_values, num_values=num_values, d_out=d_out)
```


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
