### PR TITLE
[libcu++] Add arch_traits for sm_5x

### DIFF
--- a/libcudacxx/include/cuda/__device/arch_traits.h
+++ b/libcudacxx/include/cuda/__device/arch_traits.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -201,6 +201,46 @@ struct arch_traits_t
 //! @brief Gets the architecture traits for the given architecture id \c _Id.
 template <arch_id _Id>
 [[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits() noexcept;
+
+template <>
+[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_50>() noexcept
+{
+  auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_50);
+  __traits.max_resident_grids                   = 32;
+  __traits.max_shared_memory_per_multiprocessor = 64 * 1024;
+  __traits.max_blocks_per_multiprocessor        = 32;
+  __traits.max_threads_per_multiprocessor       = 2048;
+  __traits.max_warps_per_multiprocessor         = __traits.max_threads_per_multiprocessor / __traits.warp_size;
+  __traits.max_shared_memory_per_block_optin    = 48 * 1024;
+  return __traits;
+};
+
+template <>
+[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_52>() noexcept
+{
+  auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_52);
+  __traits.max_resident_grids                   = 32;
+  __traits.max_shared_memory_per_multiprocessor = 96 * 1024;
+  __traits.max_blocks_per_multiprocessor        = 32;
+  __traits.max_threads_per_multiprocessor       = 2048;
+  __traits.max_warps_per_multiprocessor         = __traits.max_threads_per_multiprocessor / __traits.warp_size;
+  __traits.max_shared_memory_per_block_optin    = 48 * 1024;
+  return __traits;
+};
+
+template <>
+[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_53>() noexcept
+{
+  auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_53);
+  __traits.max_resident_grids                   = 32;
+  __traits.max_shared_memory_per_multiprocessor = 64 * 1024;
+  __traits.max_blocks_per_multiprocessor        = 32;
+  __traits.max_threads_per_multiprocessor       = 2048;
+  __traits.max_warps_per_multiprocessor         = __traits.max_threads_per_multiprocessor / __traits.warp_size;
+  __traits.max_shared_memory_per_block_optin    = 48 * 1024;
+  __traits.max_registers_per_block              = 32 * 1024;
+  return __traits;
+};
 
 template <>
 [[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_60>() noexcept

--- a/libcudacxx/include/cuda/std/__cccl/execution_space.h
+++ b/libcudacxx/include/cuda/std/__cccl/execution_space.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -72,7 +72,7 @@
 #endif // ^^^ !_CCCL_CUDA_COMPILER(NVHPC) ^^^
 
 //! @brief List of all known PTX architectures supported by this CCCL version.
-#define _CCCL_KNOWN_CUDA_ARCH_LIST 60, 61, 62, 70, 75, 80, 86, 87, 88, 89, 90, 100, 103, 110, 120, 121
+#define _CCCL_KNOWN_CUDA_ARCH_LIST 50, 52, 53, 60, 61, 62, 70, 75, 80, 86, 87, 88, 89, 90, 100, 103, 110, 120, 121
 
 //! @brief List of all known architecture specific architectures supported by this CCCL version.
 #define _CCCL_KNOWN_CUDA_ARCH_SPECIFIC_LIST 90, 100, 103, 110, 120, 121

--- a/libcudacxx/include/cuda/std/__cccl/preprocessor.h
+++ b/libcudacxx/include/cuda/std/__cccl/preprocessor.h
@@ -121,6 +121,15 @@ CCCL_IGNORE_MSVC_TRADITIONAL_PREPROCESSOR_WARNING to suppress this warning.
 #define _CCCL_PP_FOR_EACH_16(_Mp, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16)               \
   _Mp(_1) _Mp(_2) _Mp(_3) _Mp(_4) _Mp(_5) _Mp(_6) _Mp(_7) _Mp(_8) _Mp(_9) _Mp(_10) _Mp(_11) _Mp(_12) _Mp(_13) _Mp(_14) \
     _Mp(_15) _Mp(_16)
+#define _CCCL_PP_FOR_EACH_17(_Mp, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17)        \
+  _Mp(_1) _Mp(_2) _Mp(_3) _Mp(_4) _Mp(_5) _Mp(_6) _Mp(_7) _Mp(_8) _Mp(_9) _Mp(_10) _Mp(_11) _Mp(_12) _Mp(_13) _Mp(_14) \
+    _Mp(_15) _Mp(_16) _Mp(_17)
+#define _CCCL_PP_FOR_EACH_18(_Mp, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18)   \
+  _Mp(_1) _Mp(_2) _Mp(_3) _Mp(_4) _Mp(_5) _Mp(_6) _Mp(_7) _Mp(_8) _Mp(_9) _Mp(_10) _Mp(_11) _Mp(_12) _Mp(_13) _Mp(_14) \
+    _Mp(_15) _Mp(_16) _Mp(_17) _Mp(_18)
+#define _CCCL_PP_FOR_EACH_19(_Mp, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19) \
+  _Mp(_1) _Mp(_2) _Mp(_3) _Mp(_4) _Mp(_5) _Mp(_6) _Mp(_7) _Mp(_8) _Mp(_9) _Mp(_10) _Mp(_11) _Mp(_12) _Mp(_13) _Mp(_14)   \
+    _Mp(_15) _Mp(_16) _Mp(_17) _Mp(_18) _Mp(_19)
 
 #define _CCCL_PP_PROBE_EMPTY_PROBE__CCCL_PP_PROBE_EMPTY _CCCL_PP_PROBE(~)
 

--- a/libcudacxx/include/cuda/std/__cccl/preprocessor.h
+++ b/libcudacxx/include/cuda/std/__cccl/preprocessor.h
@@ -121,14 +121,14 @@ CCCL_IGNORE_MSVC_TRADITIONAL_PREPROCESSOR_WARNING to suppress this warning.
 #define _CCCL_PP_FOR_EACH_16(_Mp, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16)               \
   _Mp(_1) _Mp(_2) _Mp(_3) _Mp(_4) _Mp(_5) _Mp(_6) _Mp(_7) _Mp(_8) _Mp(_9) _Mp(_10) _Mp(_11) _Mp(_12) _Mp(_13) _Mp(_14) \
     _Mp(_15) _Mp(_16)
-#define _CCCL_PP_FOR_EACH_17(_Mp, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17)        \
+#define _CCCL_PP_FOR_EACH_17(_Mp, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17)          \
   _Mp(_1) _Mp(_2) _Mp(_3) _Mp(_4) _Mp(_5) _Mp(_6) _Mp(_7) _Mp(_8) _Mp(_9) _Mp(_10) _Mp(_11) _Mp(_12) _Mp(_13) _Mp(_14) \
     _Mp(_15) _Mp(_16) _Mp(_17)
-#define _CCCL_PP_FOR_EACH_18(_Mp, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18)   \
+#define _CCCL_PP_FOR_EACH_18(_Mp, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18)     \
   _Mp(_1) _Mp(_2) _Mp(_3) _Mp(_4) _Mp(_5) _Mp(_6) _Mp(_7) _Mp(_8) _Mp(_9) _Mp(_10) _Mp(_11) _Mp(_12) _Mp(_13) _Mp(_14) \
     _Mp(_15) _Mp(_16) _Mp(_17) _Mp(_18)
 #define _CCCL_PP_FOR_EACH_19(_Mp, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19) \
-  _Mp(_1) _Mp(_2) _Mp(_3) _Mp(_4) _Mp(_5) _Mp(_6) _Mp(_7) _Mp(_8) _Mp(_9) _Mp(_10) _Mp(_11) _Mp(_12) _Mp(_13) _Mp(_14)   \
+  _Mp(_1) _Mp(_2) _Mp(_3) _Mp(_4) _Mp(_5) _Mp(_6) _Mp(_7) _Mp(_8) _Mp(_9) _Mp(_10) _Mp(_11) _Mp(_12) _Mp(_13) _Mp(_14)  \
     _Mp(_15) _Mp(_16) _Mp(_17) _Mp(_18) _Mp(_19)
 
 #define _CCCL_PP_PROBE_EMPTY_PROBE__CCCL_PP_PROBE_EMPTY _CCCL_PP_PROBE(~)

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/all_arch_ids.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/all_arch_ids.pass.cpp
@@ -25,6 +25,9 @@ TEST_FUNC constexpr bool test()
   const auto all_arch_ids = cuda::__all_arch_ids();
 
   cuda::std::size_t i = 0;
+  assert(all_arch_ids[i++] == cuda::arch_id::sm_50);
+  assert(all_arch_ids[i++] == cuda::arch_id::sm_52);
+  assert(all_arch_ids[i++] == cuda::arch_id::sm_53);
   assert(all_arch_ids[i++] == cuda::arch_id::sm_60);
   assert(all_arch_ids[i++] == cuda::arch_id::sm_61);
   assert(all_arch_ids[i++] == cuda::arch_id::sm_62);


### PR DESCRIPTION
We still support 12.X CTK and it supports sm_5x. We should add traits for those architectures until we drop 12.X support