### PR TITLE
Avoid unnecessary contiguous iterator checks

### DIFF
--- a/cub/cub/device/device_for.cuh
+++ b/cub/cub/device/device_for.cuh
@@ -122,16 +122,19 @@ struct DeviceFor
       (AllowCopy
        /*|| detail::for_each::can_regain_copy_freedom<detail::it_value_t<RandomAccessIteratorT>, OpT>::value*/);
 
-    if constexpr (allow_vectorization && THRUST_NS_QUALIFIER::is_contiguous_iterator_v<RandomAccessIteratorT>)
+    if constexpr (allow_vectorization)
     {
-      auto* unwrapped_first = THRUST_NS_QUALIFIER::unwrap_contiguous_iterator(first);
-      using wrapped_op_t    = __op_wrapper_vectorized_t<NumItemsT, OpT, detail::it_value_t<RandomAccessIteratorT>>;
+      if constexpr (THRUST_NS_QUALIFIER::is_contiguous_iterator_v<RandomAccessIteratorT>)
+      {
+        auto* unwrapped_first = THRUST_NS_QUALIFIER::unwrap_contiguous_iterator(first);
+        using wrapped_op_t    = __op_wrapper_vectorized_t<NumItemsT, OpT, detail::it_value_t<RandomAccessIteratorT>>;
 
-      if (::cuda::std::is_sufficiently_aligned<alignof(typename wrapped_op_t::vector_t)>(unwrapped_first))
-      { // Vectorize loads
-        const NumItemsT num_vec_items = ::cuda::ceil_div(num_items, wrapped_op_t::vec_size);
-        return __bulk(
-          num_vec_items, wrapped_op_t{unwrapped_first, op, num_items / wrapped_op_t::vec_size, num_items}, env);
+        if (::cuda::std::is_sufficiently_aligned<alignof(typename wrapped_op_t::vector_t)>(unwrapped_first))
+        { // Vectorize loads
+          const NumItemsT num_vec_items = ::cuda::ceil_div(num_items, wrapped_op_t::vec_size);
+          return __bulk(
+            num_vec_items, wrapped_op_t{unwrapped_first, op, num_items / wrapped_op_t::vec_size, num_items}, env);
+        }
       }
     }
 

--- a/cub/test/catch2_test_device_for_api.cu
+++ b/cub/test/catch2_test_device_for_api.cu
@@ -8,6 +8,9 @@
 #include <thrust/count.h>
 #include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/device_vector.h>
+#include <thrust/iterator/zip_iterator.h>
+
+#include <cuda/iterator>
 
 #include <c2h/catch2_test_helper.h>
 
@@ -47,6 +50,26 @@ struct odd_count_t
   }
 };
 // example-end bulk-odd-count-t
+
+struct assign_zip_value_t
+{
+  template <class Tuple>
+  __device__ void operator()(Tuple tuple) const
+  {
+    cuda::std::get<1>(tuple) = cuda::std::get<0>(tuple);
+  }
+};
+
+template <class OutputIt>
+struct tabulate_output_op
+{
+  OutputIt output;
+
+  __device__ void operator()(int idx, int value) const
+  {
+    output[idx] = value;
+  }
+};
 
 C2H_TEST("Device bulk works with temporary storage", "[bulk][device]")
 {
@@ -142,6 +165,23 @@ C2H_TEST("Device for each n works without temporary storage", "[for_each][device
   // example-end for-each-n-wo-temp-storage
 
   REQUIRE(vec == expected);
+}
+
+C2H_TEST("Device for each n works with a tabulate output iterator in a zip iterator", "[for_each][device]")
+{
+  c2h::device_vector<int> input = {1, 2, 3, 4};
+  c2h::device_vector<int> output(input.size());
+
+  auto output_it = cuda::tabulate_output_iterator{tabulate_output_op{output.begin()}};
+  auto zipped_it = thrust::make_zip_iterator(input.begin(), output_it);
+
+  auto result = cub::DeviceFor::ForEachN(zipped_it, input.size(), assign_zip_value_t{});
+  if (result != cudaSuccess)
+  {
+    std::cerr << "ForEachN operation failed with error code: " << result << '\n';
+  }
+
+  REQUIRE(output == input);
 }
 
 C2H_TEST("Device for each works with temporary storage", "[for_each][device]")

--- a/cub/test/catch2_test_device_for_api.cu
+++ b/cub/test/catch2_test_device_for_api.cu
@@ -172,7 +172,7 @@ C2H_TEST("Device for each n works with a tabulate output iterator in a zip itera
   c2h::device_vector<int> input = {1, 2, 3, 4};
   c2h::device_vector<int> output(input.size());
 
-  auto output_it = cuda::tabulate_output_iterator{tabulate_output_op{output.begin()}};
+  auto output_it = cuda::tabulate_output_iterator{tabulate_output_op<decltype(output.begin())>{output.begin()}};
   auto zipped_it = thrust::make_zip_iterator(input.begin(), output_it);
 
   auto result = cub::DeviceFor::ForEachN(zipped_it, input.size(), assign_zip_value_t{});

--- a/thrust/testing/catch2_test_binary_search.cu
+++ b/thrust/testing/catch2_test_binary_search.cu
@@ -3,6 +3,7 @@
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 
+#include <cuda/iterator>
 #include <cuda/std/cstdint>
 
 #include "catch2_test_helper.h"
@@ -64,6 +65,31 @@ TEST_CASE("ScalarLowerBoundDispatchImplicit", "[binary_search]")
   thrust::lower_bound(thrust::retag<my_tag>(vec.begin()), thrust::retag<my_tag>(vec.end()), 0);
 
   CHECK(13 == vec.front());
+}
+
+template <class OutputIt>
+struct tabulate_lower_bound_output_op
+{
+  OutputIt output;
+
+  _CCCL_DEVICE void operator()(int idx, int value) const
+  {
+    output[idx] = value;
+  }
+};
+
+TEST_CASE("VectorLowerBoundWithTabulateOutputIterator", "[binary_search]")
+{
+  thrust::device_vector<int> haystack = {0, 2, 4, 6};
+  thrust::device_vector<int> needles  = {1, 3, 5, 7};
+  thrust::device_vector<int> output(needles.size());
+
+  auto output_it = cuda::tabulate_output_iterator{tabulate_lower_bound_output_op{output.begin()}};
+
+  thrust::lower_bound(haystack.begin(), haystack.end(), needles.begin(), needles.end(), output_it);
+
+  thrust::device_vector<int> expected = {1, 2, 3, 4};
+  CHECK(output == expected);
 }
 
 TEMPLATE_LIST_TEST_CASE("ScalarUpperBoundSimple", "[binary_search]", vector_list)

--- a/thrust/testing/catch2_test_binary_search.cu
+++ b/thrust/testing/catch2_test_binary_search.cu
@@ -84,7 +84,8 @@ TEST_CASE("VectorLowerBoundWithTabulateOutputIterator", "[binary_search]")
   thrust::device_vector<int> needles  = {1, 3, 5, 7};
   thrust::device_vector<int> output(needles.size());
 
-  auto output_it = cuda::tabulate_output_iterator{tabulate_lower_bound_output_op{output.begin()}};
+  auto output_it =
+    cuda::tabulate_output_iterator{tabulate_lower_bound_output_op<decltype(output.begin())>{output.begin()}};
 
   thrust::lower_bound(haystack.begin(), haystack.end(), needles.begin(), needles.end(), output_it);
 

--- a/thrust/testing/catch2_test_binary_search.cu
+++ b/thrust/testing/catch2_test_binary_search.cu
@@ -67,7 +67,6 @@ TEST_CASE("ScalarLowerBoundDispatchImplicit", "[binary_search]")
   CHECK(13 == vec.front());
 }
 
-#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
 template <class OutputIt>
 struct tabulate_lower_bound_output_op
 {
@@ -93,7 +92,6 @@ TEST_CASE("VectorLowerBoundWithTabulateOutputIterator", "[binary_search]")
   thrust::device_vector<int> expected = {1, 2, 3, 4};
   CHECK(output == expected);
 }
-#endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
 
 TEMPLATE_LIST_TEST_CASE("ScalarUpperBoundSimple", "[binary_search]", vector_list)
 {

--- a/thrust/testing/catch2_test_binary_search.cu
+++ b/thrust/testing/catch2_test_binary_search.cu
@@ -67,6 +67,7 @@ TEST_CASE("ScalarLowerBoundDispatchImplicit", "[binary_search]")
   CHECK(13 == vec.front());
 }
 
+#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
 template <class OutputIt>
 struct tabulate_lower_bound_output_op
 {
@@ -92,6 +93,7 @@ TEST_CASE("VectorLowerBoundWithTabulateOutputIterator", "[binary_search]")
   thrust::device_vector<int> expected = {1, 2, 3, 4};
   CHECK(output == expected);
 }
+#endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
 
 TEMPLATE_LIST_TEST_CASE("ScalarUpperBoundSimple", "[binary_search]", vector_list)
 {

--- a/thrust/thrust/iterator/zip_iterator.h
+++ b/thrust/thrust/iterator/zip_iterator.h
@@ -26,6 +26,7 @@
 #endif // no system header
 
 #include <thrust/detail/type_traits.h>
+#include <thrust/iterator/detail/any_assign.h>
 #include <thrust/iterator/detail/minimum_system.h>
 #include <thrust/iterator/detail/tuple_of_iterator_references.h>
 #include <thrust/iterator/iterator_facade.h>
@@ -68,8 +69,12 @@ struct make_zip_iterator_base<::cuda::std::tuple<Its...>>
   // reference type is the type of the tuple obtained from the iterator's reference types.
   using reference = tuple_of_iterator_references<zip_iterator_reference_t<Its>...>;
 
+  template <class Iter>
+  using zip_iterator_value_t =
+    ::cuda::std::conditional_t<::cuda::std::is_same_v<it_value_t<Iter>, void>, any_assign, it_value_t<Iter>>;
+
   // Boost's Value type is the same as reference type. using value_type = reference;
-  using value_type = ::cuda::std::tuple<it_value_t<Its>...>;
+  using value_type = ::cuda::std::tuple<zip_iterator_value_t<Its>...>;
 
   // Difference type is the first iterator's difference type
   using difference_type = it_difference_t<::cuda::std::tuple_element_t<0, ::cuda::std::tuple<Its...>>>;


### PR DESCRIPTION
## Description

Closes #8779

This PR fixes a compilation failure introduced by #8565 when `cub::DeviceFor::ForEachN` is used with iterator types for which `thrust::is_contiguous_iterator_v` is not safe to instantiate. In particular, `thrust::lower_bound` can call into `DeviceFor` with a `thrust::zip_iterator` containing a `cuda::tabulate_output_iterator`; evaluating `is_contiguous_iterator_v` for that iterator attempts to form a tuple value type containing `void`.

The problematic condition combined both checks in one `if constexpr`:

```cpp
allow_vectorization &&
THRUST_NS_QUALIFIER::is_contiguous_iterator_v<RandomAccessIteratorT>
```

The fix nests the `if constexpr` blocks so the contiguous-iterator trait is only instantiated when vectorization is enabled.

Validation:

- `cmake --build /home/coder/cccl/build/opencode/cub-cpp20 --target cub.test.device.for_api.lid_0 -j36`
- `cmake --build /home/coder/cccl/build/opencode/thrust-cpp20 --target thrust.cpp.cuda.test.binary_search -j36`
- `/home/coder/cccl/build/opencode/cub-cpp20/bin/cub.test.device.for_api.lid_0 "*tabulate output iterator*"`
- `/home/coder/cccl/build/opencode/thrust-cpp20/bin/thrust.cpp.cuda.test.binary_search "VectorLowerBoundWithTabulateOutputIterator"`

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
