### PR TITLE
[libcu++][cub] Replace exception keywords with our exception macros

### DIFF
--- a/cub/cub/detail/temporary_storage.cuh
+++ b/cub/cub/detail/temporary_storage.cuh
@@ -31,6 +31,7 @@
 
 #include <cuda/__stream/stream_ref.h>
 #include <cuda/std/__algorithm/max.h>
+#include <cuda/std/__exception/exception_macros.h>
 #include <cuda/std/cstddef>
 
 CUB_NAMESPACE_BEGIN
@@ -350,28 +351,30 @@ template <typename MRT>
 CUB_RUNTIME_FUNCTION cudaError_t
 allocate(::cuda::stream_ref stream, void*& d_temp_storage, size_t temp_storage_bytes, MRT& mr)
 {
-  NV_IF_ELSE_TARGET(
-    NV_IS_HOST,
-    (
-      try { d_temp_storage = mr.allocate(stream, temp_storage_bytes, alignof(::cuda::std::max_align_t)); } catch (...) {
-        return cudaErrorMemoryAllocation;
-      }),
-    (d_temp_storage = mr.allocate(stream, temp_storage_bytes, alignof(::cuda::std::max_align_t));));
-  return cudaSuccess;
+  _CCCL_TRY
+  {
+    d_temp_storage = mr.allocate(stream, temp_storage_bytes, alignof(::cuda::std::max_align_t));
+    return cudaSuccess;
+  }
+  _CCCL_CATCH_ALL
+  {
+    return cudaErrorMemoryAllocation;
+  }
 }
 
 template <typename MRT>
 CUB_RUNTIME_FUNCTION cudaError_t
 deallocate(::cuda::stream_ref stream, void* d_temp_storage, size_t temp_storage_bytes, MRT& mr)
 {
-  NV_IF_ELSE_TARGET(
-    NV_IS_HOST,
-    (
-      try {
-        mr.deallocate(stream, d_temp_storage, temp_storage_bytes, alignof(::cuda::std::max_align_t));
-      } catch (...) { return cudaErrorMemoryAllocation; }),
-    (mr.deallocate(stream, d_temp_storage, temp_storage_bytes, alignof(::cuda::std::max_align_t));));
-  return cudaSuccess;
+  _CCCL_TRY
+  {
+    mr.deallocate(stream, d_temp_storage, temp_storage_bytes, alignof(::cuda::std::max_align_t));
+    return cudaSuccess;
+  }
+  _CCCL_CATCH_ALL
+  {
+    return cudaErrorMemoryAllocation;
+  }
 }
 } // namespace detail::temporary_storage
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/adjacent_difference.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/adjacent_difference.h
@@ -113,7 +113,7 @@ struct __pstl_dispatch<__pstl_algorithm::__adjacent_difference, __execution_back
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/adjacent_difference.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/adjacent_difference.h
@@ -96,7 +96,7 @@ struct __pstl_dispatch<__pstl_algorithm::__adjacent_difference, __execution_back
     if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>
                   && ::cuda::std::__has_random_access_traversal<_OutputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl(
           __policy,
@@ -105,7 +105,7 @@ struct __pstl_dispatch<__pstl_algorithm::__adjacent_difference, __execution_back
           ::cuda::std::move(__result),
           ::cuda::std::move(__binary_op));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -116,6 +116,7 @@ struct __pstl_dispatch<__pstl_algorithm::__adjacent_difference, __execution_back
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/copy_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/copy_if.h
@@ -130,12 +130,12 @@ struct __pstl_dispatch<__pstl_algorithm::__copy_if, __execution_backend::__cuda>
   {
     if constexpr (::cuda::std::__has_random_access_traversal<_OutputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl(
           __policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__result), ::cuda::std::move(__pred));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == ::cudaErrorMemoryAllocation)
         {
@@ -146,6 +146,7 @@ struct __pstl_dispatch<__pstl_algorithm::__copy_if, __execution_backend::__cuda>
           throw;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/copy_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/copy_n.h
@@ -103,12 +103,12 @@ struct __pstl_dispatch<__pstl_algorithm::__copy_n, __execution_backend::__cuda>
     if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>
                   && ::cuda::std::__has_random_access_traversal<_OutputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl(
           __policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__result), ::cuda::std::move(__pred));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -119,6 +119,7 @@ struct __pstl_dispatch<__pstl_algorithm::__copy_n, __execution_backend::__cuda>
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/copy_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/copy_n.h
@@ -116,7 +116,7 @@ struct __pstl_dispatch<__pstl_algorithm::__copy_n, __execution_backend::__cuda>
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/exclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/exclusive_scan.h
@@ -118,7 +118,7 @@ struct __pstl_dispatch<__pstl_algorithm::__exclusive_scan, __execution_backend::
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/exclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/exclusive_scan.h
@@ -99,7 +99,7 @@ struct __pstl_dispatch<__pstl_algorithm::__exclusive_scan, __execution_backend::
     if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>
                   && ::cuda::std::__has_random_access_traversal<_OutputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         const auto __count = ::cuda::std::distance(__first, __last);
         return __par_impl(
@@ -110,7 +110,7 @@ struct __pstl_dispatch<__pstl_algorithm::__exclusive_scan, __execution_backend::
           ::cuda::std::move(__binary_op),
           __init);
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -121,6 +121,7 @@ struct __pstl_dispatch<__pstl_algorithm::__exclusive_scan, __execution_backend::
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/find_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/find_if.h
@@ -123,11 +123,11 @@ struct __pstl_dispatch<__pstl_algorithm::__find_if, __execution_backend::__cuda>
   {
     if constexpr (::cuda::std::__has_random_access_traversal<_Iter>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -138,6 +138,7 @@ struct __pstl_dispatch<__pstl_algorithm::__find_if, __execution_backend::__cuda>
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/find_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/find_if.h
@@ -135,7 +135,7 @@ struct __pstl_dispatch<__pstl_algorithm::__find_if, __execution_backend::__cuda>
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/for_each_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/for_each_n.h
@@ -102,7 +102,7 @@ struct __pstl_dispatch<__pstl_algorithm::__for_each_n, __execution_backend::__cu
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/for_each_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/for_each_n.h
@@ -90,11 +90,11 @@ struct __pstl_dispatch<__pstl_algorithm::__for_each_n, __execution_backend::__cu
   {
     if constexpr (::cuda::std::__has_random_access_traversal<_Iter>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl(__policy, ::cuda::std::move(__first), __orig_n, ::cuda::std::move(__func));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == ::cudaErrorMemoryAllocation)
         {
@@ -105,6 +105,7 @@ struct __pstl_dispatch<__pstl_algorithm::__for_each_n, __execution_backend::__cu
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/generate_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/generate_n.h
@@ -89,11 +89,11 @@ struct __pstl_dispatch<__pstl_algorithm::__generate_n, __execution_backend::__cu
   {
     if constexpr (::cuda::std::__has_random_access_traversal<_OutputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl(__policy, ::cuda::std::move(__result), __count, ::cuda::std::move(__func));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -104,6 +104,7 @@ struct __pstl_dispatch<__pstl_algorithm::__generate_n, __execution_backend::__cu
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/generate_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/generate_n.h
@@ -101,7 +101,7 @@ struct __pstl_dispatch<__pstl_algorithm::__generate_n, __execution_backend::__cu
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/inclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/inclusive_scan.h
@@ -125,7 +125,7 @@ struct __pstl_dispatch<__pstl_algorithm::__inclusive_scan, __execution_backend::
     if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>
                   && ::cuda::std::__has_random_access_traversal<_OutputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         const auto __count = ::cuda::std::distance(__first, __last);
         return __par_impl(
@@ -136,7 +136,7 @@ struct __pstl_dispatch<__pstl_algorithm::__inclusive_scan, __execution_backend::
           ::cuda::std::move(__binary_op),
           __init);
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -147,6 +147,7 @@ struct __pstl_dispatch<__pstl_algorithm::__inclusive_scan, __execution_backend::
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {
@@ -173,13 +174,13 @@ struct __pstl_dispatch<__pstl_algorithm::__inclusive_scan, __execution_backend::
     if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>
                   && ::cuda::std::__has_random_access_traversal<_OutputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         const auto __count = ::cuda::std::distance(__first, __last);
         return __par_impl(
           __policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__result), ::cuda::std::move(__binary_op));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -190,6 +191,7 @@ struct __pstl_dispatch<__pstl_algorithm::__inclusive_scan, __execution_backend::
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/inclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/inclusive_scan.h
@@ -144,7 +144,7 @@ struct __pstl_dispatch<__pstl_algorithm::__inclusive_scan, __execution_backend::
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }
@@ -187,7 +187,7 @@ struct __pstl_dispatch<__pstl_algorithm::__inclusive_scan, __execution_backend::
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/max_element.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/max_element.h
@@ -121,11 +121,11 @@ struct __pstl_dispatch<__pstl_algorithm::__max_element, __execution_backend::__c
   {
     if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -136,6 +136,7 @@ struct __pstl_dispatch<__pstl_algorithm::__max_element, __execution_backend::__c
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/max_element.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/max_element.h
@@ -133,7 +133,7 @@ struct __pstl_dispatch<__pstl_algorithm::__max_element, __execution_backend::__c
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/merge.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/merge.h
@@ -109,7 +109,7 @@ struct __pstl_dispatch<__pstl_algorithm::__merge, __execution_backend::__cuda>
                   && ::cuda::std::__has_random_access_traversal<_InputIterator2>
                   && ::cuda::std::__has_random_access_traversal<_OutputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl(
           __policy,
@@ -120,7 +120,7 @@ struct __pstl_dispatch<__pstl_algorithm::__merge, __execution_backend::__cuda>
           ::cuda::std::move(__result),
           ::cuda::std::move(__comp));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -131,6 +131,7 @@ struct __pstl_dispatch<__pstl_algorithm::__merge, __execution_backend::__cuda>
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/merge.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/merge.h
@@ -128,7 +128,7 @@ struct __pstl_dispatch<__pstl_algorithm::__merge, __execution_backend::__cuda>
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/min_element.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/min_element.h
@@ -133,7 +133,7 @@ struct __pstl_dispatch<__pstl_algorithm::__min_element, __execution_backend::__c
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/min_element.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/min_element.h
@@ -121,11 +121,11 @@ struct __pstl_dispatch<__pstl_algorithm::__min_element, __execution_backend::__c
   {
     if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -136,6 +136,7 @@ struct __pstl_dispatch<__pstl_algorithm::__min_element, __execution_backend::__c
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/partition.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/partition.h
@@ -146,7 +146,7 @@ struct __pstl_dispatch<__pstl_algorithm::__partition, __execution_backend::__cud
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/partition.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/partition.h
@@ -134,11 +134,11 @@ struct __pstl_dispatch<__pstl_algorithm::__partition, __execution_backend::__cud
   {
     if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -149,6 +149,7 @@ struct __pstl_dispatch<__pstl_algorithm::__partition, __execution_backend::__cud
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/partition_copy.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/partition_copy.h
@@ -158,7 +158,7 @@ struct __pstl_dispatch<__pstl_algorithm::__partition_copy, __execution_backend::
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/partition_copy.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/partition_copy.h
@@ -140,7 +140,7 @@ struct __pstl_dispatch<__pstl_algorithm::__partition_copy, __execution_backend::
                   && ::cuda::std::__has_random_access_traversal<_OutputIterator1>
                   && ::cuda::std::__has_random_access_traversal<_OutputIterator2>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl(
           __policy,
@@ -150,7 +150,7 @@ struct __pstl_dispatch<__pstl_algorithm::__partition_copy, __execution_backend::
           ::cuda::std::move(__result_false),
           ::cuda::std::move(__pred));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -161,6 +161,7 @@ struct __pstl_dispatch<__pstl_algorithm::__partition_copy, __execution_backend::
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
@@ -144,7 +144,7 @@ struct __pstl_dispatch<__pstl_algorithm::__reduce, __execution_backend::__cuda>
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
@@ -131,12 +131,12 @@ struct __pstl_dispatch<__pstl_algorithm::__reduce, __execution_backend::__cuda>
   {
     if constexpr (::cuda::std::__has_random_access_traversal<_Iter>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl(
           __policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__init), ::cuda::std::move(__func));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -147,6 +147,7 @@ struct __pstl_dispatch<__pstl_algorithm::__reduce, __execution_backend::__cuda>
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/remove_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/remove_if.h
@@ -122,11 +122,11 @@ struct __pstl_dispatch<__pstl_algorithm::__remove_if, __execution_backend::__cud
   {
     if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl(__policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__pred));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == ::cudaErrorMemoryAllocation)
         {
@@ -137,6 +137,7 @@ struct __pstl_dispatch<__pstl_algorithm::__remove_if, __execution_backend::__cud
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/remove_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/remove_if.h
@@ -134,7 +134,7 @@ struct __pstl_dispatch<__pstl_algorithm::__remove_if, __execution_backend::__cud
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/rotate.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/rotate.h
@@ -146,11 +146,11 @@ struct __pstl_dispatch<__pstl_algorithm::__rotate, __execution_backend::__cuda>
   {
     if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl(__policy, ::cuda::std::move(__first), ::cuda::std::move(__middle), ::cuda::std::move(__last));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -161,6 +161,7 @@ struct __pstl_dispatch<__pstl_algorithm::__rotate, __execution_backend::__cuda>
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/rotate.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/rotate.h
@@ -158,7 +158,7 @@ struct __pstl_dispatch<__pstl_algorithm::__rotate, __execution_backend::__cuda>
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/rotate_copy.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/rotate_copy.h
@@ -156,7 +156,7 @@ struct __pstl_dispatch<__pstl_algorithm::__rotate_copy, __execution_backend::__c
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/rotate_copy.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/rotate_copy.h
@@ -139,7 +139,7 @@ struct __pstl_dispatch<__pstl_algorithm::__rotate_copy, __execution_backend::__c
     if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>
                   && ::cuda::std::__has_random_access_traversal<_OutputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl(
           __policy,
@@ -148,7 +148,7 @@ struct __pstl_dispatch<__pstl_algorithm::__rotate_copy, __execution_backend::__c
           ::cuda::std::move(__last),
           ::cuda::std::move(__result));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -159,6 +159,7 @@ struct __pstl_dispatch<__pstl_algorithm::__rotate_copy, __execution_backend::__c
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/shift_left.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/shift_left.h
@@ -140,7 +140,7 @@ struct __pstl_dispatch<__pstl_algorithm::__shift_left, __execution_backend::__cu
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/shift_left.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/shift_left.h
@@ -128,11 +128,11 @@ struct __pstl_dispatch<__pstl_algorithm::__shift_left, __execution_backend::__cu
   {
     if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), __num_shifted);
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -143,6 +143,7 @@ struct __pstl_dispatch<__pstl_algorithm::__shift_left, __execution_backend::__cu
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/shift_right.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/shift_right.h
@@ -168,7 +168,7 @@ struct __pstl_dispatch<__pstl_algorithm::__shift_right, __execution_backend::__c
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/shift_right.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/shift_right.h
@@ -156,11 +156,11 @@ struct __pstl_dispatch<__pstl_algorithm::__shift_right, __execution_backend::__c
   {
     if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), __num_shifted);
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -171,6 +171,7 @@ struct __pstl_dispatch<__pstl_algorithm::__shift_right, __execution_backend::__c
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/stable_partition.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/stable_partition.h
@@ -150,7 +150,7 @@ struct __pstl_dispatch<__pstl_algorithm::__stable_partition, __execution_backend
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/stable_partition.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/stable_partition.h
@@ -138,11 +138,11 @@ struct __pstl_dispatch<__pstl_algorithm::__stable_partition, __execution_backend
   {
     if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -153,6 +153,7 @@ struct __pstl_dispatch<__pstl_algorithm::__stable_partition, __execution_backend
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/transform.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/transform.h
@@ -107,7 +107,7 @@ struct __pstl_dispatch<__pstl_algorithm::__transform, __execution_backend::__cud
     if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>
                   && ::cuda::std::__has_random_access_traversal<_OutputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         const auto __count = ::cuda::std::distance(__first, __last);
         return __par_impl(
@@ -118,7 +118,7 @@ struct __pstl_dispatch<__pstl_algorithm::__transform, __execution_backend::__cud
           ::cuda::std::move(__func),
           ::cuda::std::move(__pred));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -129,6 +129,7 @@ struct __pstl_dispatch<__pstl_algorithm::__transform, __execution_backend::__cud
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {
@@ -160,7 +161,7 @@ struct __pstl_dispatch<__pstl_algorithm::__transform, __execution_backend::__cud
                   && ::cuda::std::__has_random_access_traversal<_InputIterator2>
                   && ::cuda::std::__has_random_access_traversal<_OutputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         const auto __count = ::cuda::std::distance(__first1, __last1);
         return __par_impl(
@@ -171,7 +172,7 @@ struct __pstl_dispatch<__pstl_algorithm::__transform, __execution_backend::__cud
           ::cuda::std::move(__func),
           ::cuda::std::move(__pred));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -182,6 +183,7 @@ struct __pstl_dispatch<__pstl_algorithm::__transform, __execution_backend::__cud
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/transform.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/transform.h
@@ -126,7 +126,7 @@ struct __pstl_dispatch<__pstl_algorithm::__transform, __execution_backend::__cud
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }
@@ -179,7 +179,7 @@ struct __pstl_dispatch<__pstl_algorithm::__transform, __execution_backend::__cud
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/transform_reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/transform_reduce.h
@@ -156,7 +156,7 @@ struct __pstl_dispatch<__pstl_algorithm::__transform_reduce, __execution_backend
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/transform_reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/transform_reduce.h
@@ -138,7 +138,7 @@ struct __pstl_dispatch<__pstl_algorithm::__transform_reduce, __execution_backend
   {
     if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl(
           __policy,
@@ -148,7 +148,7 @@ struct __pstl_dispatch<__pstl_algorithm::__transform_reduce, __execution_backend
           ::cuda::std::move(__reduction_op),
           ::cuda::std::move(__transform_op));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == ::cudaErrorMemoryAllocation)
         {
@@ -159,6 +159,7 @@ struct __pstl_dispatch<__pstl_algorithm::__transform_reduce, __execution_backend
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/unique.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/unique.h
@@ -160,7 +160,7 @@ struct __pstl_dispatch<__pstl_algorithm::__unique, __execution_backend::__cuda>
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }
@@ -201,7 +201,7 @@ struct __pstl_dispatch<__pstl_algorithm::__unique, __execution_backend::__cuda>
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
     }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/unique.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/unique.h
@@ -147,12 +147,12 @@ struct __pstl_dispatch<__pstl_algorithm::__unique, __execution_backend::__cuda>
   {
     if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl<CUB_NS_QUALIFIER::SelectImpl::SelectPotentiallyInPlace>(
           __policy, __first, ::cuda::std::move(__last), __first, ::cuda::std::move(__pred));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == ::cudaErrorMemoryAllocation)
         {
@@ -163,6 +163,7 @@ struct __pstl_dispatch<__pstl_algorithm::__unique, __execution_backend::__cuda>
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {
@@ -184,7 +185,7 @@ struct __pstl_dispatch<__pstl_algorithm::__unique, __execution_backend::__cuda>
     if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>
                   && ::cuda::std::__has_random_access_traversal<_OutputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         return __par_impl<CUB_NS_QUALIFIER::SelectImpl::Select>(
           __policy,
@@ -193,7 +194,7 @@ struct __pstl_dispatch<__pstl_algorithm::__unique, __execution_backend::__cuda>
           ::cuda::std::move(__result),
           ::cuda::std::move(__pred));
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == ::cudaErrorMemoryAllocation)
         {
@@ -204,6 +205,7 @@ struct __pstl_dispatch<__pstl_algorithm::__unique, __execution_backend::__cuda>
           _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {


### PR DESCRIPTION
We don't want to use plain `throw`, because it's a hard error when exceptions are disabled. Some of those slipped in parallel algorithms implementation, so I've fixed those.

Edit: I've extended the scope of the PR, I've also found some `try` and `catch` uses.