### PR TITLE
(Cosmetic) Complex math functions consistency.

### DIFF
--- a/libcudacxx/include/cuda/std/__complex/arg.h
+++ b/libcudacxx/include/cuda/std/__complex/arg.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/libcudacxx/include/cuda/std/__complex/arg.h
+++ b/libcudacxx/include/cuda/std/__complex/arg.h
@@ -55,19 +55,19 @@ template <class _Tp>
 }
 #endif // _CCCL_HAS_LONG_DOUBLE()
 
-#if _LIBCUDACXX_HAS_NVBF16()
-[[nodiscard]] _CCCL_API inline __nv_bfloat16 arg(__nv_bfloat16 __re)
-{
-  return ::cuda::std::atan2(::__int2bfloat16_rn(0), __re);
-}
-#endif // _LIBCUDACXX_HAS_NVBF16()
-
 #if _LIBCUDACXX_HAS_NVFP16()
 [[nodiscard]] _CCCL_API inline __half arg(__half __re)
 {
   return ::cuda::std::atan2(::__int2half_rn(0), __re);
 }
 #endif // _LIBCUDACXX_HAS_NVFP16()
+
+#if _LIBCUDACXX_HAS_NVBF16()
+[[nodiscard]] _CCCL_API inline __nv_bfloat16 arg(__nv_bfloat16 __re)
+{
+  return ::cuda::std::atan2(::__int2bfloat16_rn(0), __re);
+}
+#endif // _LIBCUDACXX_HAS_NVBF16()
 
 _CCCL_TEMPLATE(class _Tp)
 _CCCL_REQUIRES(is_integral_v<_Tp>)

--- a/libcudacxx/include/cuda/std/__complex/exponential_functions.h
+++ b/libcudacxx/include/cuda/std/__complex/exponential_functions.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/libcudacxx/include/cuda/std/__complex/exponential_functions.h
+++ b/libcudacxx/include/cuda/std/__complex/exponential_functions.h
@@ -29,8 +29,8 @@
 #include <cuda/std/__cmath/trigonometric_functions.h>
 #include <cuda/std/__complex/complex.h>
 #include <cuda/std/__complex/logarithms.h>
-#include <cuda/std/__complex/nvfp16.h>
 #include <cuda/std/__complex/nvbf16.h>
+#include <cuda/std/__complex/nvfp16.h>
 #include <cuda/std/__complex/vector_support.h>
 #include <cuda/std/__type_traits/common_type.h>
 #include <cuda/std/limits>

--- a/libcudacxx/include/cuda/std/__complex/exponential_functions.h
+++ b/libcudacxx/include/cuda/std/__complex/exponential_functions.h
@@ -29,8 +29,8 @@
 #include <cuda/std/__cmath/trigonometric_functions.h>
 #include <cuda/std/__complex/complex.h>
 #include <cuda/std/__complex/logarithms.h>
-#include <cuda/std/__complex/nvbf16.h>
 #include <cuda/std/__complex/nvfp16.h>
+#include <cuda/std/__complex/nvbf16.h>
 #include <cuda/std/__complex/vector_support.h>
 #include <cuda/std/__type_traits/common_type.h>
 #include <cuda/std/limits>
@@ -312,14 +312,6 @@ _CCCL_API inline complex<double> exp<double>(const complex<double>& __x)
   return complex<double>(__ans_r, __ans_i);
 }
 
-#if _LIBCUDACXX_HAS_NVBF16()
-template <>
-_CCCL_API inline complex<__nv_bfloat16> exp(const complex<__nv_bfloat16>& __x)
-{
-  return complex<__nv_bfloat16>{::cuda::std::exp(complex<float>{__x})};
-}
-#endif // _LIBCUDACXX_HAS_NVBF16()
-
 #if _LIBCUDACXX_HAS_NVFP16()
 template <>
 _CCCL_API inline complex<__half> exp(const complex<__half>& __x)
@@ -327,6 +319,14 @@ _CCCL_API inline complex<__half> exp(const complex<__half>& __x)
   return complex<__half>{::cuda::std::exp(complex<float>{__x})};
 }
 #endif // _LIBCUDACXX_HAS_NVFP16()
+
+#if _LIBCUDACXX_HAS_NVBF16()
+template <>
+_CCCL_API inline complex<__nv_bfloat16> exp(const complex<__nv_bfloat16>& __x)
+{
+  return complex<__nv_bfloat16>{::cuda::std::exp(complex<float>{__x})};
+}
+#endif // _LIBCUDACXX_HAS_NVBF16()
 
 // pow
 

--- a/libcudacxx/include/cuda/std/__complex/hyperbolic_functions.h
+++ b/libcudacxx/include/cuda/std/__complex/hyperbolic_functions.h
@@ -162,14 +162,6 @@ template <class _Tp>
 }
 
 // We have performance issues with extended floating point types
-#if _LIBCUDACXX_HAS_NVBF16()
-template <>
-_CCCL_API inline complex<__nv_bfloat16> sinh(const complex<__nv_bfloat16>& __x) noexcept
-{
-  return complex<__nv_bfloat16>{::cuda::std::sinh(complex<float>{__x})};
-}
-#endif // _LIBCUDACXX_HAS_NVBF16()
-
 #if _LIBCUDACXX_HAS_NVFP16()
 template <>
 _CCCL_API inline complex<__half> sinh(const complex<__half>& __x) noexcept
@@ -177,6 +169,14 @@ _CCCL_API inline complex<__half> sinh(const complex<__half>& __x) noexcept
   return complex<__half>{::cuda::std::sinh(complex<float>{__x})};
 }
 #endif // _LIBCUDACXX_HAS_NVFP16()
+
+#if _LIBCUDACXX_HAS_NVBF16()
+template <>
+_CCCL_API inline complex<__nv_bfloat16> sinh(const complex<__nv_bfloat16>& __x) noexcept
+{
+  return complex<__nv_bfloat16>{::cuda::std::sinh(complex<float>{__x})};
+}
+#endif // _LIBCUDACXX_HAS_NVBF16()
 
 // cosh
 

--- a/libcudacxx/include/cuda/std/__complex/inverse_hyperbolic_functions.h
+++ b/libcudacxx/include/cuda/std/__complex/inverse_hyperbolic_functions.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/libcudacxx/include/cuda/std/__complex/inverse_hyperbolic_functions.h
+++ b/libcudacxx/include/cuda/std/__complex/inverse_hyperbolic_functions.h
@@ -29,8 +29,8 @@
 #include <cuda/std/__complex/complex.h>
 #include <cuda/std/__complex/exponential_functions.h>
 #include <cuda/std/__complex/logarithms.h>
-#include <cuda/std/__complex/nvbf16.h>
 #include <cuda/std/__complex/nvfp16.h>
+#include <cuda/std/__complex/nvbf16.h>
 #include <cuda/std/__complex/roots.h>
 #include <cuda/std/limits>
 #include <cuda/std/numbers>
@@ -380,14 +380,6 @@ template <class _Tp>
 }
 
 // We have performance issues with some trigonometric functions with extended floating point types
-#if _LIBCUDACXX_HAS_NVBF16()
-template <>
-_CCCL_API inline complex<__nv_bfloat16> asinh(const complex<__nv_bfloat16>& __x) noexcept
-{
-  return complex<__nv_bfloat16>{::cuda::std::asinh(complex<float>{__x})};
-}
-#endif // _LIBCUDACXX_HAS_NVBF16()
-
 #if _LIBCUDACXX_HAS_NVFP16()
 template <>
 _CCCL_API inline complex<__half> asinh(const complex<__half>& __x) noexcept
@@ -395,6 +387,14 @@ _CCCL_API inline complex<__half> asinh(const complex<__half>& __x) noexcept
   return complex<__half>{::cuda::std::asinh(complex<float>{__x})};
 }
 #endif // _LIBCUDACXX_HAS_NVFP16()
+
+#if _LIBCUDACXX_HAS_NVBF16()
+template <>
+_CCCL_API inline complex<__nv_bfloat16> asinh(const complex<__nv_bfloat16>& __x) noexcept
+{
+  return complex<__nv_bfloat16>{::cuda::std::asinh(complex<float>{__x})};
+}
+#endif // _LIBCUDACXX_HAS_NVBF16()
 
 // acosh
 
@@ -669,14 +669,6 @@ template <class _Tp>
 }
 
 // We have performance issues with some trigonometric functions with extended floating point types
-#if _LIBCUDACXX_HAS_NVBF16()
-template <>
-_CCCL_API inline complex<__nv_bfloat16> acosh(const complex<__nv_bfloat16>& __x)
-{
-  return complex<__nv_bfloat16>{::cuda::std::acosh(complex<float>{__x})};
-}
-#endif // _LIBCUDACXX_HAS_NVBF16()
-
 #if _LIBCUDACXX_HAS_NVFP16()
 template <>
 _CCCL_API inline complex<__half> acosh(const complex<__half>& __x)
@@ -684,6 +676,14 @@ _CCCL_API inline complex<__half> acosh(const complex<__half>& __x)
   return complex<__half>{::cuda::std::acosh(complex<float>{__x})};
 }
 #endif // _LIBCUDACXX_HAS_NVFP16()
+
+#if _LIBCUDACXX_HAS_NVBF16()
+template <>
+_CCCL_API inline complex<__nv_bfloat16> acosh(const complex<__nv_bfloat16>& __x)
+{
+  return complex<__nv_bfloat16>{::cuda::std::acosh(complex<float>{__x})};
+}
+#endif // _LIBCUDACXX_HAS_NVBF16()
 
 // atanh
 
@@ -798,14 +798,6 @@ template <class _Tp>
 }
 
 // We have performance issues with some trigonometric functions with extended floating point types
-#if _LIBCUDACXX_HAS_NVBF16()
-template <>
-_CCCL_API inline complex<__nv_bfloat16> atanh(const complex<__nv_bfloat16>& __x)
-{
-  return complex<__nv_bfloat16>{::cuda::std::atanh(complex<float>{__x})};
-}
-#endif // _LIBCUDACXX_HAS_NVBF16()
-
 #if _LIBCUDACXX_HAS_NVFP16()
 template <>
 _CCCL_API inline complex<__half> atanh(const complex<__half>& __x)
@@ -813,6 +805,14 @@ _CCCL_API inline complex<__half> atanh(const complex<__half>& __x)
   return complex<__half>{::cuda::std::atanh(complex<float>{__x})};
 }
 #endif // _LIBCUDACXX_HAS_NVFP16()
+
+#if _LIBCUDACXX_HAS_NVBF16()
+template <>
+_CCCL_API inline complex<__nv_bfloat16> atanh(const complex<__nv_bfloat16>& __x)
+{
+  return complex<__nv_bfloat16>{::cuda::std::atanh(complex<float>{__x})};
+}
+#endif // _LIBCUDACXX_HAS_NVBF16()
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__complex/inverse_hyperbolic_functions.h
+++ b/libcudacxx/include/cuda/std/__complex/inverse_hyperbolic_functions.h
@@ -29,8 +29,8 @@
 #include <cuda/std/__complex/complex.h>
 #include <cuda/std/__complex/exponential_functions.h>
 #include <cuda/std/__complex/logarithms.h>
-#include <cuda/std/__complex/nvfp16.h>
 #include <cuda/std/__complex/nvbf16.h>
+#include <cuda/std/__complex/nvfp16.h>
 #include <cuda/std/__complex/roots.h>
 #include <cuda/std/limits>
 #include <cuda/std/numbers>

--- a/libcudacxx/include/cuda/std/__complex/inverse_trigonometric_functions.h
+++ b/libcudacxx/include/cuda/std/__complex/inverse_trigonometric_functions.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/libcudacxx/include/cuda/std/__complex/inverse_trigonometric_functions.h
+++ b/libcudacxx/include/cuda/std/__complex/inverse_trigonometric_functions.h
@@ -29,8 +29,8 @@
 #include <cuda/std/__complex/exponential_functions.h>
 #include <cuda/std/__complex/inverse_hyperbolic_functions.h>
 #include <cuda/std/__complex/logarithms.h>
-#include <cuda/std/__complex/nvfp16.h>
 #include <cuda/std/__complex/nvbf16.h>
+#include <cuda/std/__complex/nvfp16.h>
 #include <cuda/std/__complex/roots.h>
 #include <cuda/std/limits>
 #include <cuda/std/numbers>

--- a/libcudacxx/include/cuda/std/__complex/inverse_trigonometric_functions.h
+++ b/libcudacxx/include/cuda/std/__complex/inverse_trigonometric_functions.h
@@ -29,8 +29,8 @@
 #include <cuda/std/__complex/exponential_functions.h>
 #include <cuda/std/__complex/inverse_hyperbolic_functions.h>
 #include <cuda/std/__complex/logarithms.h>
-#include <cuda/std/__complex/nvbf16.h>
 #include <cuda/std/__complex/nvfp16.h>
+#include <cuda/std/__complex/nvbf16.h>
 #include <cuda/std/__complex/roots.h>
 #include <cuda/std/limits>
 #include <cuda/std/numbers>
@@ -99,14 +99,6 @@ template <class _Tp>
 }
 
 // We have performance issues with some trigonometric functions with extended floating point types
-#if _LIBCUDACXX_HAS_NVBF16()
-template <>
-_CCCL_API inline complex<__nv_bfloat16> acos(const complex<__nv_bfloat16>& __x)
-{
-  return complex<__nv_bfloat16>{::cuda::std::acos(complex<float>{__x})};
-}
-#endif // _LIBCUDACXX_HAS_NVBF16()
-
 #if _LIBCUDACXX_HAS_NVFP16()
 template <>
 _CCCL_API inline complex<__half> acos(const complex<__half>& __x)
@@ -114,6 +106,14 @@ _CCCL_API inline complex<__half> acos(const complex<__half>& __x)
   return complex<__half>{::cuda::std::acos(complex<float>{__x})};
 }
 #endif // _LIBCUDACXX_HAS_NVFP16()
+
+#if _LIBCUDACXX_HAS_NVBF16()
+template <>
+_CCCL_API inline complex<__nv_bfloat16> acos(const complex<__nv_bfloat16>& __x)
+{
+  return complex<__nv_bfloat16>{::cuda::std::acos(complex<float>{__x})};
+}
+#endif // _LIBCUDACXX_HAS_NVBF16()
 
 // atan
 

--- a/libcudacxx/include/cuda/std/__complex/logarithms.h
+++ b/libcudacxx/include/cuda/std/__complex/logarithms.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/libcudacxx/include/cuda/std/__complex/logarithms.h
+++ b/libcudacxx/include/cuda/std/__complex/logarithms.h
@@ -24,8 +24,8 @@
 #include <cuda/std/__complex/arg.h>
 #include <cuda/std/__complex/complex.h>
 #include <cuda/std/__complex/math.h>
-#include <cuda/std/__complex/nvbf16.h>
 #include <cuda/std/__complex/nvfp16.h>
+#include <cuda/std/__complex/nvbf16.h>
 #include <cuda/std/__floating_point/fp.h>
 #include <cuda/std/__type_traits/make_unsigned.h>
 #include <cuda/std/numbers>
@@ -251,16 +251,6 @@ template <class _Tp>
   return complex<_Tp>(__abs_rescaled, ::cuda::std::atan2(__x.imag(), __x.real()));
 }
 
-#if _LIBCUDACXX_HAS_NVBF16()
-template <>
-// The general template for log when generated for __nv_bfloat16 is both worse for
-// accuracy and slower than the fp32 version.
-_CCCL_API inline complex<__nv_bfloat16> log(const complex<__nv_bfloat16>& __x)
-{
-  return complex<__nv_bfloat16>{::cuda::std::log(complex<float>{__x})};
-}
-#endif // _LIBCUDACXX_HAS_NVBF16()
-
 #if _LIBCUDACXX_HAS_NVFP16()
 template <>
 // The general template for log when generated for __half is both worse for
@@ -271,6 +261,16 @@ _CCCL_API inline complex<__half> log(const complex<__half>& __x)
 }
 #endif // _LIBCUDACXX_HAS_NVFP16()
 
+#if _LIBCUDACXX_HAS_NVBF16()
+template <>
+// The general template for log when generated for __nv_bfloat16 is both worse for
+// accuracy and slower than the fp32 version.
+_CCCL_API inline complex<__nv_bfloat16> log(const complex<__nv_bfloat16>& __x)
+{
+  return complex<__nv_bfloat16>{::cuda::std::log(complex<float>{__x})};
+}
+#endif // _LIBCUDACXX_HAS_NVBF16()
+
 // log10
 
 template <class _Tp>
@@ -279,14 +279,6 @@ template <class _Tp>
   return ::cuda::std::log(__x) * __numbers<_Tp>::__log10e();
 }
 
-#if _LIBCUDACXX_HAS_NVBF16()
-template <>
-_CCCL_API inline complex<__nv_bfloat16> log10(const complex<__nv_bfloat16>& __x)
-{
-  return complex<__nv_bfloat16>{::cuda::std::log10(complex<float>{__x})};
-}
-#endif // _LIBCUDACXX_HAS_NVBF16()
-
 #if _LIBCUDACXX_HAS_NVFP16()
 template <>
 _CCCL_API inline complex<__half> log10(const complex<__half>& __x)
@@ -294,6 +286,14 @@ _CCCL_API inline complex<__half> log10(const complex<__half>& __x)
   return complex<__half>{::cuda::std::log10(complex<float>{__x})};
 }
 #endif // _LIBCUDACXX_HAS_NVFP16()
+
+#if _LIBCUDACXX_HAS_NVBF16()
+template <>
+_CCCL_API inline complex<__nv_bfloat16> log10(const complex<__nv_bfloat16>& __x)
+{
+  return complex<__nv_bfloat16>{::cuda::std::log10(complex<float>{__x})};
+}
+#endif // _LIBCUDACXX_HAS_NVBF16()
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__complex/logarithms.h
+++ b/libcudacxx/include/cuda/std/__complex/logarithms.h
@@ -24,8 +24,8 @@
 #include <cuda/std/__complex/arg.h>
 #include <cuda/std/__complex/complex.h>
 #include <cuda/std/__complex/math.h>
-#include <cuda/std/__complex/nvfp16.h>
 #include <cuda/std/__complex/nvbf16.h>
+#include <cuda/std/__complex/nvfp16.h>
 #include <cuda/std/__floating_point/fp.h>
 #include <cuda/std/__type_traits/make_unsigned.h>
 #include <cuda/std/numbers>

--- a/libcudacxx/include/cuda/std/__complex/roots.h
+++ b/libcudacxx/include/cuda/std/__complex/roots.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/libcudacxx/include/cuda/std/__complex/roots.h
+++ b/libcudacxx/include/cuda/std/__complex/roots.h
@@ -194,14 +194,6 @@ template <class _Tp>
   return complex<_Tp>{__ans_re, ::cuda::std::copysign(__ans_im, __im)};
 }
 
-#if _LIBCUDACXX_HAS_NVBF16()
-template <>
-_CCCL_API inline complex<__nv_bfloat16> sqrt(const complex<__nv_bfloat16>& __x) noexcept
-{
-  return complex<__nv_bfloat16>{::cuda::std::sqrt(complex<float>{__x})};
-}
-#endif // _LIBCUDACXX_HAS_NVBF16()
-
 #if _LIBCUDACXX_HAS_NVFP16()
 template <>
 _CCCL_API inline complex<__half> sqrt(const complex<__half>& __x) noexcept
@@ -209,6 +201,14 @@ _CCCL_API inline complex<__half> sqrt(const complex<__half>& __x) noexcept
   return complex<__half>{::cuda::std::sqrt(complex<float>{__x})};
 }
 #endif // _LIBCUDACXX_HAS_NVFP16()
+
+#if _LIBCUDACXX_HAS_NVBF16()
+template <>
+_CCCL_API inline complex<__nv_bfloat16> sqrt(const complex<__nv_bfloat16>& __x) noexcept
+{
+  return complex<__nv_bfloat16>{::cuda::std::sqrt(complex<float>{__x})};
+}
+#endif // _LIBCUDACXX_HAS_NVBF16()
 
 _CCCL_END_NAMESPACE_CUDA_STD
 


### PR DESCRIPTION
Small cosmetic changes for consistency.
https://github.com/NVIDIA/cccl/issues/8774

Changed the order of fp16 and bf16 so fp16 is always first.
Updated copyright year.
  (Done with Claude)

Feel free to add any cosmetic changes you would like to see to this request. Preferably ones that need no accuracy re-testing.


