### PR TITLE
[libcu++] Replace `cuda::__bad_any_cast` with `std::bad_any_cast`

### DIFF
--- a/libcudacxx/include/cuda/__memory_resource/any_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/any_resource.h
@@ -1078,7 +1078,7 @@ template <class _Tp, class... _Properties>
 //!   destination resource type template argument).
 //! @param __src The source resource to cast from.
 //! @return A new type-erased resource wrapper with the destination properties.
-//! @throws __bad_any_cast if the runtime type does not support the destination
+//! @throws std::bad_any_cast if the runtime type does not support the destination
 //!   interface.
 template <class... _DstProperties, class... _SrcProperties>
 [[nodiscard]] _CCCL_HOST_API auto dynamic_resource_cast(any_resource<_SrcProperties...>&& __src)

--- a/libcudacxx/include/cuda/__utility/__basic_any/basic_any_fwd.h
+++ b/libcudacxx/include/cuda/__utility/__basic_any/basic_any_fwd.h
@@ -105,8 +105,6 @@ constexpr size_t __default_small_object_align = alignof(::cuda::std::max_align_t
 
 using __make_type_list _CCCL_NODEBUG_ALIAS = ::cuda::std::__type_quote<::cuda::std::__type_list>;
 
-[[noreturn]] _CCCL_API void __throw_bad_any_cast();
-
 enum class __vtable_kind : uint8_t
 {
   __normal,

--- a/libcudacxx/include/cuda/__utility/__basic_any/basic_any_ref.h
+++ b/libcudacxx/include/cuda/__utility/__basic_any/basic_any_ref.h
@@ -29,6 +29,8 @@
 #include <cuda/__utility/__basic_any/rtti.h>
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__concepts/same_as.h>
+#include <cuda/std/__exception/exception_macros.h>
+#include <cuda/std/__host_stdlib/any>
 #include <cuda/std/__type_traits/is_const.h>
 #include <cuda/std/__type_traits/maybe_const.h>
 #include <cuda/std/__type_traits/remove_const.h>
@@ -210,7 +212,7 @@ private:
     using __src_interface_t _CCCL_NODEBUG_ALIAS = typename ::cuda::std::remove_reference_t<_SrcCvAny>::interface_type;
     if (!__from.has_value())
     {
-      __throw_bad_any_cast();
+      _CCCL_THROW(::std::bad_any_cast);
     }
     auto __to_vptr = __vptr_cast<__src_interface_t, interface_type>(__from.__get_vptr());
     __set_ref(__to_vptr, __from.__get_optr());

--- a/libcudacxx/include/cuda/__utility/__basic_any/dynamic_any_cast.h
+++ b/libcudacxx/include/cuda/__utility/__basic_any/dynamic_any_cast.h
@@ -35,7 +35,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 //! \brief Casts one __basic_any reference type to another __basic_any type using
 //! runtime information to determine the validity of the conversion.
 //!
-//! \throws __bad_any_cast when \c __src cannot be dynamically cast to a
+//! \throws std::bad_any_cast when \c __src cannot be dynamically cast to a
 //! \c __basic_any<_DstInterface>.
 _CCCL_TEMPLATE(class _DstInterface, class _SrcInterface)
 _CCCL_REQUIRES(__any_castable_to<__basic_any<_SrcInterface>, __basic_any<_DstInterface>>)

--- a/libcudacxx/include/cuda/__utility/__basic_any/rtti.h
+++ b/libcudacxx/include/cuda/__utility/__basic_any/rtti.h
@@ -26,14 +26,12 @@
 #include <cuda/__utility/__basic_any/virtual_ptrs.h>
 #include <cuda/__utility/immovable.h>
 #include <cuda/std/__cccl/unreachable.h>
+#include <cuda/std/__exception/exception_macros.h>
 #include <cuda/std/__exception/terminate.h>
+#include <cuda/std/__host_stdlib/any>
 #include <cuda/std/__utility/typeid.h>
 
 #include <nv/target>
-
-#if _CCCL_HOSTED()
-#  include <typeinfo> // IWYU pragma: keep (for std::bad_cast)
-#endif // _CCCL_HOSTED()
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -44,34 +42,6 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 //!
 struct __iunknown : __basic_interface<::cuda::std::__type_always<__iunknown>::__call>
 {};
-
-#if _CCCL_HAS_EXCEPTIONS()
-//!
-//! __bad_any_cast
-//!
-struct __bad_any_cast : ::std::bad_cast
-{
-  __bad_any_cast() noexcept                                         = default;
-  __bad_any_cast(__bad_any_cast const&) noexcept                    = default;
-  ~__bad_any_cast() noexcept override                               = default;
-  auto operator=(__bad_any_cast const&) noexcept -> __bad_any_cast& = default;
-
-  auto what() const noexcept -> char const* override
-  {
-    return "cannot cast value to target type";
-  }
-};
-
-[[noreturn]] _CCCL_API inline void __throw_bad_any_cast()
-{
-  NV_IF_ELSE_TARGET(NV_IS_HOST, (throw __bad_any_cast();), (::cuda::std::terminate();))
-}
-#else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
-[[noreturn]] _CCCL_API inline void __throw_bad_any_cast()
-{
-  ::cuda::std::terminate();
-}
-#endif // !_CCCL_HAS_EXCEPTIONS()
 
 struct __rtti_base : __immovable
 {
@@ -264,7 +234,7 @@ template <class _SrcInterface, class _DstInterface>
     auto __dst_vptr = __try_vptr_cast<_SrcInterface, _DstInterface>(__src_vptr);
     if (!__dst_vptr && __src_vptr)
     {
-      __throw_bad_any_cast();
+      _CCCL_THROW(::std::bad_any_cast);
     }
     return __dst_vptr;
   }

--- a/libcudacxx/include/cuda/std/__host_stdlib/any
+++ b/libcudacxx/include/cuda/std/__host_stdlib/any
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___HOST_STDLIB_ANY
+#define _CUDA_STD___HOST_STDLIB_ANY
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_HOSTED()
+#  include <any>
+#endif // _CCCL_HOSTED()
+
+#endif // _CUDA_STD___HOST_STDLIB_ANY

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/any_resource/resource_cast.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/any_resource/resource_cast.cu
@@ -182,14 +182,14 @@ TEST_CASE("dynamic_resource_cast any_resource narrowing", "[container][resource]
   {
     cuda::mr::any_resource<cuda::mr::host_accessible> src{stored};
     CHECK_THROWS_AS(cuda::mr::dynamic_resource_cast<cuda::mr::device_accessible>(::cuda::std::move(src)),
-                    cuda::__bad_any_cast);
+                    std::bad_any_cast);
   }
 
   SECTION("cast to undeclared property throws")
   {
     // extra_property is supported by big_resource but not in the wrapper's interface
     cuda::mr::any_resource<cuda::mr::host_accessible> src{stored};
-    CHECK_THROWS_AS(cuda::mr::dynamic_resource_cast<extra_property>(::cuda::std::move(src)), cuda::__bad_any_cast);
+    CHECK_THROWS_AS(cuda::mr::dynamic_resource_cast<extra_property>(::cuda::std::move(src)), std::bad_any_cast);
   }
 #  endif // _CCCL_HAS_EXCEPTIONS()
 }
@@ -231,7 +231,7 @@ TEST_CASE("dynamic_resource_cast any_synchronous_resource", "[container][resourc
   {
     cuda::mr::any_synchronous_resource<cuda::mr::host_accessible> src{stored};
     CHECK_THROWS_AS(cuda::mr::dynamic_resource_cast<cuda::mr::device_accessible>(::cuda::std::move(src)),
-                    cuda::__bad_any_cast);
+                    std::bad_any_cast);
   }
 #  endif // _CCCL_HAS_EXCEPTIONS()
 }
@@ -254,7 +254,7 @@ TEST_CASE("dynamic_resource_cast resource_ref", "[container][resource]")
   SECTION("invalid cast throws")
   {
     cuda::mr::resource_ref<cuda::mr::host_accessible> ref{stored};
-    CHECK_THROWS_AS(cuda::mr::dynamic_resource_cast<cuda::mr::device_accessible>(&ref), cuda::__bad_any_cast);
+    CHECK_THROWS_AS(cuda::mr::dynamic_resource_cast<cuda::mr::device_accessible>(&ref), std::bad_any_cast);
   }
 #  endif // _CCCL_HAS_EXCEPTIONS()
 }
@@ -277,7 +277,7 @@ TEST_CASE("dynamic_resource_cast synchronous_resource_ref", "[container][resourc
   SECTION("invalid cast throws")
   {
     cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible> ref{stored};
-    CHECK_THROWS_AS(cuda::mr::dynamic_resource_cast<cuda::mr::device_accessible>(&ref), cuda::__bad_any_cast);
+    CHECK_THROWS_AS(cuda::mr::dynamic_resource_cast<cuda::mr::device_accessible>(&ref), std::bad_any_cast);
   }
 #  endif // _CCCL_HAS_EXCEPTIONS()
 }

--- a/libcudacxx/test/libcudacxx/cuda/utility/basic_any.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utility/basic_any.pass.cpp
@@ -707,7 +707,7 @@ _CCCL_HOST void test_iset_dynamic_cast()
     (void) bad;
     assert(false && "should have thrown");
   }
-  catch (cuda::__bad_any_cast const&)
+  catch (std::bad_any_cast const&)
   {
     // expected
   }
@@ -720,7 +720,7 @@ _CCCL_HOST void test_iset_dynamic_cast()
     (void) bad;
     assert(false && "should have thrown");
   }
-  catch (cuda::__bad_any_cast const&)
+  catch (std::bad_any_cast const&)
   {
     // expected
   }


### PR DESCRIPTION
All of the host standard libraries come with `<any>` header, thus we should just throw `std::bad_any_cast` instead of the internal `cuda::__bad_any_cast`.