### PR TITLE
Fix DeviceTransform byte-offset overflow when num_items*sizeof(T) > 4Gb

### DIFF
--- a/cub/cub/device/device_transform.cuh
+++ b/cub/cub/device/device_transform.cuh
@@ -97,11 +97,16 @@ struct DeviceTransform
 
     // Even when num_items fits in offset_t, the byte product (num_items * sizeof(T)) used for
     // pointer arithmetic inside the kernel may overflow 32-bit math. Promote to int64_t in that case.
+    // Only the input iterators are considered: the kernel's buggy expression
+    // `aligned_ptr.ptr + offset * unsigned{sizeof(T)}` (in transform_kernel_ublkcp) is on the input
+    // bulk-copy side; output writes use the output iterator's own arithmetic. Including the output
+    // iterator's value_type would also break compilation for write-only output iterators whose
+    // value_type is `void` (e.g. transform_output_iterator, tabulate_output_iterator).
     // todo(giannis): consider moving this to a helper function under choose_offset.cuh ?
-    if constexpr (sizeof(offset_t) < sizeof(::cuda::std::int64_t))
+    if constexpr (sizeof(offset_t) < sizeof(::cuda::std::int64_t) && sizeof...(RandomAccessIteratorsIn) > 0)
     {
-      constexpr ::cuda::std::size_t max_value_size = ::cuda::std::max(
-        {sizeof(detail::it_value_t<RandomAccessIteratorsIn>)..., sizeof(detail::it_value_t<RandomAccessIteratorOut>)});
+      constexpr ::cuda::std::size_t max_value_size =
+        ::cuda::std::max({sizeof(detail::it_value_t<RandomAccessIteratorsIn>)...});
       if (static_cast<::cuda::std::uint64_t>(num_items) * max_value_size > 0xFFFFFFFFull)
       {
         return detail::transform::dispatch<StableAddress>(

--- a/cub/cub/device/device_transform.cuh
+++ b/cub/cub/device/device_transform.cuh
@@ -16,16 +16,13 @@
 #include <cub/detail/choose_offset.cuh>
 #include <cub/device/dispatch/dispatch_transform.cuh>
 #include <cub/util_namespace.cuh>
-#include <cub/util_type.cuh>
 
 #include <cuda/__execution/tune.h>
 #include <cuda/__functional/address_stability.h>
 #include <cuda/__functional/call_or.h>
 #include <cuda/__iterator/zip_iterator.h>
 #include <cuda/__stream/get_stream.h>
-#include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__execution/env.h>
-#include <cuda/std/cstdint>
 #include <cuda/std/tuple>
 
 CUB_NAMESPACE_BEGIN
@@ -94,31 +91,6 @@ struct DeviceTransform
 #if _CCCL_HAS_CONCEPTS()
     static_assert(detail::transform::transform_policy_selector<policy_selector>);
 #endif // _CCCL_HAS_CONCEPTS()
-
-    // Even when num_items fits in offset_t, the byte product (num_items * sizeof(T)) used for
-    // pointer arithmetic inside the kernel may overflow 32-bit math. Promote to int64_t in that case.
-    // Only the input iterators are considered: the kernel's buggy expression
-    // `aligned_ptr.ptr + offset * unsigned{sizeof(T)}` (in transform_kernel_ublkcp) is on the input
-    // bulk-copy side; output writes use the output iterator's own arithmetic. Including the output
-    // iterator's value_type would also break compilation for write-only output iterators whose
-    // value_type is `void` (e.g. transform_output_iterator, tabulate_output_iterator).
-    // todo(giannis): consider moving this to a helper function under choose_offset.cuh ?
-    if constexpr (sizeof(offset_t) < sizeof(::cuda::std::int64_t) && sizeof...(RandomAccessIteratorsIn) > 0)
-    {
-      constexpr ::cuda::std::size_t max_value_size =
-        ::cuda::std::max({sizeof(detail::it_value_t<RandomAccessIteratorsIn>)...});
-      if (static_cast<::cuda::std::uint64_t>(num_items) * max_value_size > 0xFFFFFFFFull)
-      {
-        return detail::transform::dispatch<StableAddress>(
-          ::cuda::std::move(inputs),
-          ::cuda::std::move(output),
-          static_cast<::cuda::std::int64_t>(num_items),
-          ::cuda::std::move(predicate),
-          ::cuda::std::move(transform_op),
-          stream,
-          policy_selector{});
-      }
-    }
 
     return detail::transform::dispatch<StableAddress>(
       ::cuda::std::move(inputs),

--- a/cub/cub/device/device_transform.cuh
+++ b/cub/cub/device/device_transform.cuh
@@ -16,13 +16,16 @@
 #include <cub/detail/choose_offset.cuh>
 #include <cub/device/dispatch/dispatch_transform.cuh>
 #include <cub/util_namespace.cuh>
+#include <cub/util_type.cuh>
 
 #include <cuda/__execution/tune.h>
 #include <cuda/__functional/address_stability.h>
 #include <cuda/__functional/call_or.h>
 #include <cuda/__iterator/zip_iterator.h>
 #include <cuda/__stream/get_stream.h>
+#include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__execution/env.h>
+#include <cuda/std/cstdint>
 #include <cuda/std/tuple>
 
 CUB_NAMESPACE_BEGIN
@@ -91,6 +94,26 @@ struct DeviceTransform
 #if _CCCL_HAS_CONCEPTS()
     static_assert(detail::transform::transform_policy_selector<policy_selector>);
 #endif // _CCCL_HAS_CONCEPTS()
+
+    // Even when num_items fits in offset_t, the byte product (num_items * sizeof(T)) used for
+    // pointer arithmetic inside the kernel may overflow 32-bit math. Promote to int64_t in that case.
+    // todo(giannis): consider moving this to a helper function under choose_offset.cuh ?
+    if constexpr (sizeof(offset_t) < sizeof(::cuda::std::int64_t))
+    {
+      constexpr ::cuda::std::size_t max_value_size = ::cuda::std::max(
+        {sizeof(detail::it_value_t<RandomAccessIteratorsIn>)..., sizeof(detail::it_value_t<RandomAccessIteratorOut>)});
+      if (static_cast<::cuda::std::uint64_t>(num_items) * max_value_size > 0xFFFFFFFFull)
+      {
+        return detail::transform::dispatch<StableAddress>(
+          ::cuda::std::move(inputs),
+          ::cuda::std::move(output),
+          static_cast<::cuda::std::int64_t>(num_items),
+          ::cuda::std::move(predicate),
+          ::cuda::std::move(transform_op),
+          stream,
+          policy_selector{});
+      }
+    }
 
     return detail::transform::dispatch<StableAddress>(
       ::cuda::std::move(inputs),

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -556,7 +556,7 @@ _CCCL_DEVICE auto copy_and_return_smem_dst_fallback(
   const int head_padding = alignof(T) < ldgsts_size_and_align ? aligned_ptr.head_padding : 0;
 
   const char* src = aligned_ptr.ptr + offset * sizeof(T) + head_padding;
-  char* dst = smem + smem_offset + head_padding;
+  char* dst       = smem + smem_offset + head_padding;
   _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(src), "");
   _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(dst), "");
   const int bytes_to_copy = int{sizeof(T)} * valid_items;
@@ -878,7 +878,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       const int head_padding = alignof(T) < bulk_copy_alignment ? aligned_ptr.head_padding : 0;
 
       const char* src = aligned_ptr.ptr + offset * sizeof(T) + head_padding;
-      char* dst = smem + head_padding;
+      char* dst       = smem + head_padding;
       _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(src), "");
       _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(dst), "");
       const int bytes_to_copy = int{sizeof(T)} * valid_items;

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -514,7 +514,7 @@ copy_and_return_smem_dst(AlignedPtr aligned_ptr, int& smem_offset, Offset offset
   {
     smem_offset = ::cuda::round_up(smem_offset, int{alignof(T)});
   }
-  const char* const src = aligned_ptr.ptr + offset * unsigned{sizeof(T)}; // compute expression in U32 if Offset==I32
+  const char* const src = aligned_ptr.ptr + offset * sizeof(T);
   char* const dst       = smem + smem_offset;
   _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<ldgsts_size_and_align>(src), "");
   _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<ldgsts_size_and_align>(dst), "");
@@ -555,8 +555,7 @@ _CCCL_DEVICE auto copy_and_return_smem_dst_fallback(
   _CCCL_ASSERT(alignof(T) < ldgsts_size_and_align || aligned_ptr.head_padding == 0, "");
   const int head_padding = alignof(T) < ldgsts_size_and_align ? aligned_ptr.head_padding : 0;
 
-  const char* src = aligned_ptr.ptr + offset * unsigned{sizeof(T)} + head_padding; // compute expression in U32 if
-                                                                                   // Offset==I32
+  const char* src = aligned_ptr.ptr + offset * sizeof(T) + head_padding;
   char* dst = smem + smem_offset + head_padding;
   _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(src), "");
   _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(dst), "");
@@ -811,7 +810,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       // turning this lambda into a function does not change SASS
       auto bulk_copy_tile = [&](auto aligned_ptr) {
         using T         = typename decltype(aligned_ptr)::value_type;
-        const char* src = aligned_ptr.ptr + offset * unsigned{sizeof(T)}; // compute expression in U32 if Offset==I32
+        const char* src = aligned_ptr.ptr + offset * sizeof(T);
         char* dst       = smem;
         _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<bulk_copy_alignment>(src), "");
         _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<bulk_copy_alignment>(dst), "");
@@ -878,8 +877,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       _CCCL_ASSERT(alignof(T) < bulk_copy_alignment || aligned_ptr.head_padding == 0, "");
       const int head_padding = alignof(T) < bulk_copy_alignment ? aligned_ptr.head_padding : 0;
 
-      const char* src = aligned_ptr.ptr + offset * unsigned{sizeof(T)} + head_padding; // compute expression in U32 if
-                                                                                       // Offset==I32
+      const char* src = aligned_ptr.ptr + offset * sizeof(T) + head_padding;
       char* dst = smem + head_padding;
       _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(src), "");
       _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(dst), "");

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -113,8 +113,7 @@ struct times_seven
 // Exercises the 32-bit byte-offset overflow regime in transform_kernel_ublkcp (NVIDIA/cccl#8800).
 // num_items = 2^30 +/- a few thread blocks: combined with sizeof(type) = 4, byte product
 // straddles 4 GiB (negative delta -> just under, positive -> just over). Both deltas fit in I32
-// and I64 offset types. The earlier version of this test (PR #5176) used unsigned short, which
-// kept the byte product under 4 GiB even at I32 num_items max and missed the bug.
+// and I64 offset types.
 C2H_TEST("DeviceTransform::Transform works with large input",
          "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
          offset_types)

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -14,7 +14,6 @@
 #include <cuda/iterator>
 #include <cuda/std/__functional/identity.h>
 
-#include <numeric>
 #include <sstream>
 
 #include "catch2_large_problem_helper.cuh"
@@ -111,17 +110,22 @@ struct times_seven
   }
 };
 
-C2H_TEST("DeviceTransform::Transform with large input",
+// Exercises the 32-bit byte-offset overflow regime in transform_kernel_ublkcp (NVIDIA/cccl#8800).
+// num_items = 2^30 +/- a few thread blocks: combined with sizeof(type) = 4, byte product
+// straddles 4 GiB (negative delta -> just under, positive -> just over). Both deltas fit in I32
+// and I64 offset types. The earlier version of this test (PR #5176) used unsigned short, which
+// kept the byte product under 4 GiB even at I32 num_items max and missed the bug.
+C2H_TEST("DeviceTransform::Transform works with large input",
          "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
          offset_types)
 try
 {
-  using type     = unsigned short;
+  using type     = std::uint32_t;
   using offset_t = c2h::get<0, TestType>;
 
-  // make size a few thread blocks below/beyond 4GiB. need to make sure I32 num_items stays below 2^31
-  constexpr offset_t num_items = static_cast<offset_t>((1ll << 31) + (sizeof(offset_t) == 4 ? -123456 : 123456));
-  REQUIRE(num_items > 0);
+  const auto delta         = GENERATE(-123456, 123456);
+  const offset_t num_items = static_cast<offset_t>((offset_t{1} << 30) + delta);
+  CAPTURE(c2h::type_name<offset_t>(), num_items);
 
   c2h::device_vector<type> input(static_cast<size_t>(num_items), thrust::no_init);
   c2h::gen(C2H_SEED(1), input);
@@ -133,41 +137,6 @@ try
   c2h::host_vector<type> input_h = input;
   c2h::host_vector<type> reference_h(static_cast<size_t>(num_items), thrust::no_init);
   std::transform(input_h.begin(), input_h.end(), reference_h.begin(), times_seven{});
-  REQUIRE((reference_h == result));
-}
-catch (const std::bad_alloc&)
-{
-  // allocation failure is not a test failure, so we can run tests on smaller GPUs
-}
-
-// Regression for byte-offset overflow (NVIDIA/cccl#8800). With int32 Offset and
-// num_items * sizeof(T) > 2^32, transform_kernel_ublkcp's byte-offset multiply wrapped in 32-bit
-// math, corrupting tail outputs. The "large input" test above uses unsigned short (2 bytes), which
-// keeps the byte product under 4 GiB even at int32 num_items max — so it does not cover this regime.
-// This test does, with a 4-byte type pushed past 2^30 elements.
-C2H_TEST("DeviceTransform::Transform byte-product exceeds 4 GiB",
-         "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
-         offset_types)
-try
-{
-  using type     = std::uint32_t;
-  using offset_t = c2h::get<0, TestType>;
-
-  // Just past 2^30 elements: num_items * sizeof(type) > 2^32 bytes, but num_items fits in int32.
-  constexpr offset_t num_items = static_cast<offset_t>((offset_t{1} << 30) + 13'229'464);
-  REQUIRE(static_cast<std::uint64_t>(num_items) * sizeof(type) > 0xFFFFFFFFull);
-
-  c2h::device_vector<type> input(static_cast<size_t>(num_items), thrust::no_init);
-  thrust::sequence(input.begin(), input.end(), type{1000});
-
-  c2h::device_vector<type> result(static_cast<size_t>(num_items), thrust::no_init);
-  transform_many(cuda::std::make_tuple(input.begin()), result.begin(), num_items, cuda::std::identity{});
-
-  // Match the verification pattern of the "large input" test above: build the host reference and
-  // compare. Allocates ~4.35 GiB on host, same scale as the existing test, so likely runs wherever
-  // that one does.
-  c2h::host_vector<type> reference_h(static_cast<size_t>(num_items), thrust::no_init);
-  std::iota(reference_h.begin(), reference_h.end(), type{1000});
   REQUIRE((reference_h == result));
 }
 catch (const std::bad_alloc&)

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -14,6 +14,7 @@
 #include <cuda/iterator>
 #include <cuda/std/__functional/identity.h>
 
+#include <numeric>
 #include <sstream>
 
 #include "catch2_large_problem_helper.cuh"
@@ -132,6 +133,41 @@ try
   c2h::host_vector<type> input_h = input;
   c2h::host_vector<type> reference_h(static_cast<size_t>(num_items), thrust::no_init);
   std::transform(input_h.begin(), input_h.end(), reference_h.begin(), times_seven{});
+  REQUIRE((reference_h == result));
+}
+catch (const std::bad_alloc&)
+{
+  // allocation failure is not a test failure, so we can run tests on smaller GPUs
+}
+
+// Regression for byte-offset overflow (NVIDIA/cccl#8800). With int32 Offset and
+// num_items * sizeof(T) > 2^32, transform_kernel_ublkcp's byte-offset multiply wrapped in 32-bit
+// math, corrupting tail outputs. The "large input" test above uses unsigned short (2 bytes), which
+// keeps the byte product under 4 GiB even at int32 num_items max — so it does not cover this regime.
+// This test does, with a 4-byte type pushed past 2^30 elements.
+C2H_TEST("DeviceTransform::Transform byte-product exceeds 4 GiB",
+         "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         offset_types)
+try
+{
+  using type     = std::uint32_t;
+  using offset_t = c2h::get<0, TestType>;
+
+  // Just past 2^30 elements: num_items * sizeof(type) > 2^32 bytes, but num_items fits in int32.
+  constexpr offset_t num_items = static_cast<offset_t>((offset_t{1} << 30) + 13'229'464);
+  REQUIRE(static_cast<std::uint64_t>(num_items) * sizeof(type) > 0xFFFFFFFFull);
+
+  c2h::device_vector<type> input(static_cast<size_t>(num_items), thrust::no_init);
+  thrust::sequence(input.begin(), input.end(), type{1000});
+
+  c2h::device_vector<type> result(static_cast<size_t>(num_items), thrust::no_init);
+  transform_many(cuda::std::make_tuple(input.begin()), result.begin(), num_items, cuda::std::identity{});
+
+  // Match the verification pattern of the "large input" test above: build the host reference and
+  // compare. Allocates ~4.35 GiB on host, same scale as the existing test, so likely runs wherever
+  // that one does.
+  c2h::host_vector<type> reference_h(static_cast<size_t>(num_items), thrust::no_init);
+  std::iota(reference_h.begin(), reference_h.end(), type{1000});
   REQUIRE((reference_h == result));
 }
 catch (const std::bad_alloc&)


### PR DESCRIPTION
fixes https://github.com/NVIDIA/cccl/issues/8800

~_adding more context and tests in a bit - don't merge_~ my full research path in the comments


When we addd TMA in `__transform_internal`, when the dispatcher picks `int32` OffsetT and the byte product exceeds `UINT_MAX`, `transform_kernel_ublkcp`'s deliberate `U32` multiply (`offset * unsigned{sizeof(T)}`) wraps and reads from wrong tile addresses, corrupting tail outputs.   
