### PR TITLE
Complex cosh cos accuracy refinement

### DIFF
--- a/libcudacxx/include/cuda/std/__complex/hyperbolic_functions.h
+++ b/libcudacxx/include/cuda/std/__complex/hyperbolic_functions.h
@@ -181,27 +181,153 @@ _CCCL_API inline complex<__half> sinh(const complex<__half>& __x) noexcept
 // cosh
 
 template <class _Tp>
-[[nodiscard]] _CCCL_API inline complex<_Tp> cosh(const complex<_Tp>& __x)
+[[nodiscard]] _CCCL_API inline complex<_Tp> cosh(const complex<_Tp>& __x) noexcept
 {
-  if (::cuda::std::isinf(__x.real()) && !::cuda::std::isfinite(__x.imag()))
+  // Need to distinguish +-0.0, use signbit rather than >
+  const bool __x_neg = ::cuda::std::signbit(__x.real());
+
+  const _Tp __imag_x = __x_neg ? -__x.imag() : __x.imag();
+  _Tp __real_x_abs   = ::cuda::std::fabs(__x.real());
+
+  // Special cases that don't fall through the rest of the algo:
+  if (::cuda::std::isnan(__real_x_abs) || !(::cuda::std::isfinite(__imag_x)))
   {
-    return complex<_Tp>(::cuda::std::abs(__x.real()), numeric_limits<_Tp>::quiet_NaN());
+    if (!(::cuda::std::isfinite(__imag_x)) && (__real_x_abs == numeric_limits<_Tp>::infinity()))
+    {
+      return complex<_Tp>{numeric_limits<_Tp>::infinity(), numeric_limits<_Tp>::quiet_NaN()};
+    }
+
+    if (!(::cuda::std::isfinite(__imag_x)) && (__real_x_abs == _Tp{0}))
+    {
+      // Real part sign is unspecified
+      return complex<_Tp>{numeric_limits<_Tp>::quiet_NaN(), _Tp{0}};
+    }
+
+    if (::cuda::std::isnan(__real_x_abs) && (__imag_x == _Tp{0}))
+    {
+      // Real part sign is unspecified
+      return complex<_Tp>{numeric_limits<_Tp>::quiet_NaN(), _Tp{0}};
+    }
   }
-  if (__x.real() == _Tp(0) && !::cuda::std::isfinite(__x.imag()))
+
+  const auto [__sin, __cos] = ::cuda::sincos(__imag_x);
+
+  // Using ans = {cosh(re) * cos(im), sinh(re) * sin(im)}
+  // results in intermediate overflows where eg sinh(re) overflows, but sinh(re) * sin(im) does not.
+  // We scale our inputs to avoid this.
+
+  // Rather than examining exponents, we save computation by pre-selecting 2
+  // separate intervals that cover our problematic overflow interval.
+  // Use sinh(x) ~= cosh(x) ~= exp(x)/2 for large x.
+  // Need two intervals to ensure the reduced values do not break the sinh(x) ~= cosh(x) ~= exp(x)/2 estimate.
+
+  // We need eg sinh(x) * sin(y) to not have intermediate overflow. We find bounds where the final result will overflow
+  // no matter the (non-zero) value of y.
+  // sin(y) can attain the smallest denormal value, we calculate the largest value of x where sinh(x) * sin(y) is still
+  // finite.
+  // This is attained at asinh(x) * MIN_DENORMAL_FLOAT = MAX_FLOAT.
+  // aka x ~= (MAX_FLOAT_EXPONENT - MIN_DENORMAL_FLOAT_EXPONENT + 1) * log(2)
+  // aka x ~= (1024 + 1074 + 1) * log(2) in double for example.
+  // ~= 1454.916... for double
+  // ~= 192.695.... for float
+
+  // we also find where sinh(x) ~=cosh(x) ~= exp(x)/2 overflows normally..
+  // This is at exp(x)/2 = MAX_FLOAT,
+  // aka x ~= (MAX_FLOAT_EXPONENT + 1) * log(2)
+  // This is:
+  // ~= (1024 + 1) * log(2) ~= 710.475... for double
+  // ~= (128  + 1) * log(2) ~= 89.416...  for float
+
+  constexpr int32_t __mant_nbits = __fp_mant_nbits_v<__fp_format_of_v<_Tp>>;
+  constexpr int32_t __exp_max    = __fp_exp_max_v<__fp_format_of_v<_Tp>>;
+
+  // Massage these values a little to cover the edges.
+  // These values are small enough we can cast to int and back as a poor mans constexpr floor.
+  // (we want __ans_always_overflow_bound to be slightly larger than the real value, we add 1)
+  constexpr _Tp __ln2 = __numbers<_Tp>::__ln2();
+
+  constexpr _Tp __sinh_cosh_overflow_bound = _Tp{int(_Tp{__exp_max + 2} * __ln2)};
+  constexpr _Tp __ans_always_overflow_bound =
+    _Tp{int(_Tp{(__exp_max + 1) + (__exp_max + __mant_nbits - 1)} * __ln2) + 1};
+
+  // We split the above interval into two. Get the midpoint:
+  constexpr _Tp __overflow_interval_midpoint = (__sinh_cosh_overflow_bound + __ans_always_overflow_bound) * _Tp{0.5};
+
+  // Our values look like this for double/float:
+  // double:
+  // __sinh_cosh_overflow_bound: 710.000000
+  // __ans_always_overflow_bound: 1455.000000
+  // __overflow_interval_midpoint: 1082.500000
+  // float:
+  // __sinh_cosh_overflow_bound: 89.000000
+  // __ans_always_overflow_bound: 193.000000
+  // __overflow_interval_midpoint: 141.000000
+
+  _Tp __in_scale  = _Tp{0};
+  _Tp __out_scale = _Tp{1};
+
+  if (__real_x_abs >= __sinh_cosh_overflow_bound)
   {
-    return complex<_Tp>(numeric_limits<_Tp>::quiet_NaN(), __x.real());
+    // Here sinh and cosh will overflow, but the final result may not.
+    // Get scale factors for the first half of the interval:
+    __in_scale = __overflow_interval_midpoint - __sinh_cosh_overflow_bound;
+
+    // Here what we really want is an accurate constexpr exp(__in_scale * 0.5).
+    // Calling exp loses too much accuracy (as well as relying on it being evaluated at compile time).
+    // Set the value manually for now:
+    // __out_scale = ::cuda::std::exp(__in_scale * _Tp{0.5});
+    __out_scale = is_same_v<_Tp, double> ? static_cast<_Tp>(7.715201168634011507e80) : static_cast<_Tp>(1.95729609e11f);
+
+    // Other half of the interval:
+    if (__real_x_abs > __overflow_interval_midpoint)
+    {
+      __in_scale = __ans_always_overflow_bound - __sinh_cosh_overflow_bound;
+
+      // Same as above, set the value manually for the moment:
+      // __out_scale = ::cuda::std::exp(__in_scale * _Tp{0.5});
+      __out_scale =
+        is_same_v<_Tp, double> ? static_cast<_Tp>(5.952432907249161686e161) : static_cast<_Tp>(3.831008e22f);
+    }
+
+    if (__real_x_abs > __ans_always_overflow_bound)
+    {
+      // Here the final answer will overflow, with one exception.
+      // If (imag == 0.0), we would end up later multiplying inf * 0.0 to get NaN,
+      // while the correct answer is 0.0.
+      // This seems be be the best place to correct this for (as opposed to an early return).
+      // We clamp the value to a value that still always overflows the final answer, while the intermediate
+      // calculation with our scaling will not. (real == inf) has already been purged.
+      __real_x_abs = __ans_always_overflow_bound;
+    }
   }
-  if (__x.real() == _Tp(0) && __x.imag() == _Tp(0))
-  {
-    return complex<_Tp>(_Tp(1), __x.imag());
-  }
-  if (__x.imag() == _Tp(0) && !::cuda::std::isfinite(__x.real()))
-  {
-    return complex<_Tp>(::cuda::std::abs(__x.real()), __x.imag());
-  }
-  const auto [__im_sin, __im_cos] = ::cuda::sincos(__x.imag());
-  return complex<_Tp>(::cuda::std::cosh(__x.real()) * __im_cos, ::cuda::std::sinh(__x.real()) * __im_sin);
+
+  const _Tp __cosh_re_scaled = ::cuda::std::cosh(__real_x_abs - __in_scale);
+  const _Tp __sinh_re_scaled = ::cuda::std::sinh(__real_x_abs - __in_scale);
+
+  // Order of multiplication matters for under/overflow:
+  const _Tp __ans_re = (__cosh_re_scaled * (__cos * __out_scale)) * __out_scale;
+  const _Tp __ans_im = (__sinh_re_scaled * (__sin * __out_scale)) * __out_scale;
+
+  const complex __ans_abs{__ans_re, __ans_im};
+  return __ans_abs;
 }
+
+// We have performance issues with extended floating point types
+#if _LIBCUDACXX_HAS_NVFP16()
+template <>
+_CCCL_API inline complex<__half> cosh(const complex<__half>& __x) noexcept
+{
+  return complex<__half>{::cuda::std::cosh(complex<float>{__x})};
+}
+#endif // _LIBCUDACXX_HAS_NVFP16()
+
+#if _LIBCUDACXX_HAS_NVBF16()
+template <>
+_CCCL_API inline complex<__nv_bfloat16> cosh(const complex<__nv_bfloat16>& __x) noexcept
+{
+  return complex<__nv_bfloat16>{::cuda::std::cosh(complex<float>{__x})};
+}
+#endif // _LIBCUDACXX_HAS_NVBF16()
 
 // tanh
 

--- a/libcudacxx/include/cuda/std/__complex/hyperbolic_functions.h
+++ b/libcudacxx/include/cuda/std/__complex/hyperbolic_functions.h
@@ -308,8 +308,7 @@ template <class _Tp>
   const _Tp __ans_re = (__cosh_re_scaled * (__cos * __out_scale)) * __out_scale;
   const _Tp __ans_im = (__sinh_re_scaled * (__sin * __out_scale)) * __out_scale;
 
-  const complex __ans_abs{__ans_re, __ans_im};
-  return __ans_abs;
+  return complex<_Tp>{__ans_re, __ans_im};
 }
 
 // We have performance issues with extended floating point types

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/cosh.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/cosh.pass.cpp
@@ -73,7 +73,18 @@ TEST_FUNC void test_edges()
       assert(cuda::std::isinf(r.real()));
       assert(!cuda::std::signbit(r.real()));
       assert(r.imag() == T(0));
-      assert(cuda::std::signbit(r.imag()) == cuda::std::signbit(testcases[i].imag()));
+      // From:
+      // cosh(conj(z)) == conj(cosh(z)),
+      // cosh(z) == cosh(-z),
+      // cosh(+inf, +0) = (+inf, +0)
+
+      // We need:
+      // cosh(+inf, +0) == (+inf, +0)
+      // cosh(-inf, -0) == (+inf, +0)
+      // cosh(+inf, -0) == (+inf, -0)
+      // cosh(-inf, +0) == (+inf, -0)
+      assert(cuda::std::signbit(r.imag())
+             == (cuda::std::signbit(testcases[i].imag()) ^ cuda::std::signbit(testcases[i].real())));
     }
     else if (cuda::std::isinf(testcases[i].real()) && cuda::std::isfinite(testcases[i].imag()))
     {

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/cosh.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/cosh.pass.cpp
@@ -46,7 +46,19 @@ TEST_FUNC void test_edges()
     {
       assert(r.real() == T(1));
       assert(r.imag() == T(0));
-      assert(cuda::std::signbit(r.imag()) == cuda::std::signbit(testcases[i].imag()));
+
+      // From:
+      // cosh(conj(z)) == conj(cosh(z)),
+      // cosh(z) == cosh(-z),
+      // cosh(+0, +0) = (+0, +0)
+
+      // We need:
+      // cosh(+0, +0) == (+1, +0)
+      // cosh(-0, -0) == (+1, +0)
+      // cosh(+0, -0) == (+1, -0)
+      // cosh(-0, +0) == (+1, -0)
+      assert(cuda::std::signbit(r.imag())
+             == (cuda::std::signbit(testcases[i].imag()) ^ cuda::std::signbit(testcases[i].real())));
     }
     else if (testcases[i].real() == T(0) && cuda::std::isinf(testcases[i].imag()))
     {


### PR DESCRIPTION
## Update the complex cosh (and thus cos) function to avoid overflow issues.

Much like the previous `sinh/sin` functions, the current complex `cosh` function has situations where it will overflow intermediately, resulting in Inf or NaN return values when the result should be finite. This version addresses this.

## Perf
Again very similar to the `sin/sinh` functions recently updated. Unfortunately the original implementation is a bit too simplistic to be able to match perf on, so we take a loss here. (Though not as pronounced as in the `sin/sinh` case).
It might be possible to match it by completely deconstructing/rewriting the real `sin/cos/sinh/cosh` functions, but this would be a large body of work.
(Side note, this is still faster the the version from December [before the suggested `sincos` got implemeted](https://github.com/NVIDIA/cccl/pull/6742), users not actively using TOT should not see a slowdown.)
Using the math-teams standard math_bench test we have the following:

**Operations/SM/cycle:**
`ccosh():`
| H100 |  old | new | new/old |
| --- | --- | --- | --- |
| fp64 | 0.4097 | 0.4009 | 0.98 | 
| fp32 | 1.4746 | 1.3883 | 0.94 |

## Correctness
For the new version, an intensive bracket and bisect search, along with testing special hard values, gives:

```
GPU fp64:
Max ulp real error (5.063,0) @ (-712.9399454,10.95352174)	(0xc0864785021cce18,0x4025e8340088d0d4)
	Ours = (-8.88215792e+307,inf)    Ref = (-8.88215792e+307,inf)
	Ours = (0xffdf9f1cb5cd2f04,0x7ff0000000000000)               Ref = (0xffdf9f1cb5cd2eff,0x7ff0000000000000)

Max ulp imag error (0.7954,3.867) @ (-710.0987223,10.16924)	(0xc08630ca2ee83588,0x402456a69ff75ebf)
	Ours = (-9.067370004e+307,8.353815508e+307)    Ref = (-9.067370004e+307,8.353815508e+307)
	Ours = (0xffe023f4d14cad05,0x7fddbd9605bb7f17)               Ref = (0xffe023f4d14cad04,0x7fddbd9605bb7f13)
```

```
GPU fp32:
Max ulp real error (5.518,0) @ (89.7105484,-1.929940224)	(0x42b36bcd,0xbff70848)
	Ours = (-1.605675616e+38,-inf)    Ref = (-1.605676225e+38,-inf)
	Ours = (0xfef19860,0xff800000)               Ref = (0xfef19866,0xff800000)

Max ulp imag error (0,4.933) @ (-89.52375793,3.479028282e+37)	(0xc2b30c2a,0x7dd162eb)
	Ours = (inf,8.346621257e+37)    Ref = (inf,8.346623792e+37)
	Ours = (0x7f800000,0x7e7b2c08)               Ref = (0x7f800000,0x7e7b2c0d)
```

```
CPU fp64:
Max ulp real error (4.671,1.12) @ (710.175924,-3.2518977e+218)	(0x408631684ad2a400,0xed4d7a9387552000)
	Ours = (8.784274928e+307,1.001092743e+308)    Ref = (8.784274928e+307,1.001092743e+308)
	Ours = (0x7fdf45e70d289c45,0x7fe1d1ee4b509b09)               Ref = (0x7fdf45e70d289c40,0x7fe1d1ee4b509b08)

Max ulp imag error (0,4.609) @ (710.8546255,-1.612955025e+77)	(0x408636d645df9800,0xcff649a04ea2f800)
	Ours = (inf,1.739046162e+308)    Ref = (inf,1.739046162e+308)
	Ours = (0x7ff0000000000000,0x7feef4bfa482fdcf)               Ref = (0x7ff0000000000000,0x7feef4bfa482fdca)
```

```
CPU fp32:
Max ulp real error (4.188,0) @ (90.36499023,1.959307909)	(0x42b4bae0,0x3ffaca9a)
	Ours = (-3.329733572e+38,inf)    Ref = (-3.329734384e+38,inf)
	Ours = (0xff7a8056,0x7f800000)               Ref = (0xff7a805a,0x7f800000)

Max ulp imag error (0,5.265) @ (-140.9147339,1.018322593e-29)	(0xc30cea2c,0xf4e8a55)
	Ours = (inf,-8.041676387e+31)    Ref = (inf,-8.041678805e+31)
	Ours = (0x7f800000,0xf47dc025)               Ref = (0x7f800000,0xf47dc02a)
```