### PR TITLE
Split off non-determin. reduce tuning

### DIFF
--- a/c/parallel/src/reduce.cu
+++ b/c/parallel/src/reduce.cu
@@ -368,11 +368,11 @@ static_assert(device_reduce_nd_policy()(detail::current_tuning_cc()) == {10},
   build->determinism      = determinism;
   if (build_nondeterministic)
   {
-    build->runtime_policy = new cub::detail::reduce::policy_selector{policy_sel};
+    build->runtime_policy = new cub::detail::reduce_nondeterministic::policy_selector{policy_sel_nd};
   }
   else
   {
-    build->runtime_policy = new cub::detail::reduce_nondeterministic::policy_selector{policy_sel_nd};
+    build->runtime_policy = new cub::detail::reduce::policy_selector{policy_sel};
   }
 
   return CUDA_SUCCESS;

--- a/c/parallel/src/reduce.cu
+++ b/c/parallel/src/reduce.cu
@@ -36,8 +36,8 @@
 #include <util/build_utils.h>
 
 struct device_reduce_policy;
-using TransformOpT = ::cuda::std::identity;
-using OffsetT      = unsigned long long;
+struct device_reduce_nd_policy;
+using OffsetT = unsigned long long;
 static_assert(std::is_same_v<cub::detail::choose_offset_t<OffsetT>, OffsetT>, "OffsetT must be size_t");
 
 namespace reduce
@@ -116,7 +116,7 @@ std::string get_device_reduce_nondeterministic_kernel_name(
   cccl_value_t init)
 {
   std::string chained_policy_t;
-  check(cccl_type_name_from_nvrtc<device_reduce_policy>(&chained_policy_t));
+  check(cccl_type_name_from_nvrtc<device_reduce_nd_policy>(&chained_policy_t));
 
   std::string offset_t;
   check(cccl_type_name_from_nvrtc<OffsetT>(&offset_t));
@@ -222,24 +222,30 @@ try
 
   const auto policy_sel = [&] {
     using namespace cub::detail;
-
     const auto accum_type  = cccl_type_enum_to_cub_type(accum_t.type);
     const auto operation_t = cccl_op_kind_to_cub_op(op.type);
-
-    const int offset_size = int{sizeof(OffsetT)};
+    const int offset_size  = int{sizeof(OffsetT)};
     return cub::detail::reduce::policy_selector{accum_type, operation_t, offset_size, static_cast<int>(accum_t.size)};
+  }();
+  const auto policy_sel_nd = [&] {
+    using namespace cub::detail;
+    const auto accum_type  = cccl_type_enum_to_cub_type(accum_t.type);
+    const auto operation_t = cccl_op_kind_to_cub_op(op.type);
+    const int offset_size  = int{sizeof(OffsetT)};
+    return reduce_nondeterministic::policy_selector{
+      accum_type, operation_t, offset_size, static_cast<int>(accum_t.size)};
   }();
 
   // TODO(bgruber): drop this if tuning policies become formattable
   std::stringstream policy_sel_str;
   policy_sel_str << policy_sel(cuda::compute_capability{cc_major, cc_minor});
-
-  auto policy_hub_expr =
-    std::format("cub::detail::reduce::policy_selector_from_types<{}, {}, {}>", accum_cpp, offset_t, op_name);
+  std::stringstream policy_sel_nd_str;
+  policy_sel_nd_str << policy_sel_nd(cuda::compute_capability{cc_major, cc_minor});
 
   std::string final_src = std::format(
     R"XXX(
 #include <cub/device/dispatch/tuning/tuning_reduce.cuh>
+#include <cub/device/dispatch/tuning/tuning_reduce_nondeterministic.cuh>
 #include <cub/device/dispatch/kernels/kernel_reduce.cuh>
 {0}
 struct __align__({2}) storage_t {{
@@ -248,10 +254,16 @@ struct __align__({2}) storage_t {{
 {3}
 {4}
 {5}
-using device_reduce_policy = {6};
+using device_reduce_policy = cub::detail::reduce::policy_selector_from_types<{6}, {7}, {8}>;
 using namespace cub;
 using namespace cub::detail::reduce;
-static_assert(device_reduce_policy()(detail::current_tuning_cc()) == {7}, "Host generated and JIT compiled policy mismatch");
+static_assert(device_reduce_policy()(detail::current_tuning_cc()) == {9},
+              "Host generated and JIT compiled reduce policy mismatch");
+using device_reduce_nd_policy = cub::detail::reduce_nondeterministic::policy_selector_from_types<{6}, {7}, {8}>;
+using namespace cub;
+using namespace cub::detail::reduce_nondeterministic;
+static_assert(device_reduce_nd_policy()(detail::current_tuning_cc()) == {10},
+              "Host generated and JIT compiled reduce nondeterministic policy mismatch");
 )XXX",
     jit_template_header_contents, // 0
     input_it.value_type.size, // 1
@@ -259,8 +271,11 @@ static_assert(device_reduce_policy()(detail::current_tuning_cc()) == {7}, "Host 
     input_iterator_src, // 3
     output_iterator_src, // 4
     op_src, // 5
-    policy_hub_expr, // 6
-    policy_sel_str.view()); // 7
+    accum_cpp, // 6
+    offset_t, // 7
+    op_name, // 8
+    policy_sel_str.view(), // 9
+    policy_sel_nd_str.view()); // 10
 
 #if false // CCCL_DEBUGGING_SWITCH
   fflush(stderr);
@@ -341,13 +356,24 @@ static_assert(device_reduce_policy()(detail::current_tuning_cc()) == {7}, "Host 
     check(cuLibraryGetKernel(
       &build->nondeterministic_atomic_kernel, build->library, nondeterministic_kernel_lowered_name.c_str()));
   }
+  else
+  {
+    build->nondeterministic_atomic_kernel = nullptr;
+  }
 
   build->cc               = cc_major * 10 + cc_minor;
   build->cubin            = (void*) result.data.release();
   build->cubin_size       = result.size;
   build->accumulator_size = accum_t.size;
   build->determinism      = determinism;
-  build->runtime_policy   = new cub::detail::reduce::policy_selector{policy_sel};
+  if (build_nondeterministic)
+  {
+    build->runtime_policy = new cub::detail::reduce::policy_selector{policy_sel};
+  }
+  else
+  {
+    build->runtime_policy = new cub::detail::reduce_nondeterministic::policy_selector{policy_sel_nd};
+  }
 
   return CUDA_SUCCESS;
 }
@@ -444,7 +470,7 @@ CUresult cccl_device_reduce_nondeterministic(
     CUdevice cu_device;
     check(cuCtxGetDevice(&cu_device));
 
-    auto exec_status = cub::detail::reduce::dispatch_nondeterministic<void>(
+    auto exec_status = cub::detail::reduce_nondeterministic::dispatch<void>(
       d_temp_storage,
       *temp_storage_bytes,
       indirect_arg_t{d_in}, // could be indirect_iterator_t, but CUB does not need to increment it
@@ -454,7 +480,7 @@ CUresult cccl_device_reduce_nondeterministic(
       indirect_arg_t{init},
       stream,
       ::cuda::std::identity{},
-      *static_cast<cub::detail::reduce::policy_selector*>(build.runtime_policy),
+      *static_cast<cub::detail::reduce_nondeterministic::policy_selector*>(build.runtime_policy),
       reduce::reduce_kernel_source{build},
       cub::detail::CudaDriverLauncherFactory{cu_device, build.cc});
 
@@ -485,9 +511,17 @@ try
     return CUDA_ERROR_INVALID_VALUE;
   }
 
-  using namespace cub::detail::reduce;
   std::unique_ptr<char[]> cubin(static_cast<char*>(build_ptr->cubin));
-  std::unique_ptr<policy_selector> policy(static_cast<policy_selector*>(build_ptr->runtime_policy));
+  std::unique_ptr<cub::detail::reduce::policy_selector> policy;
+  std::unique_ptr<cub::detail::reduce_nondeterministic::policy_selector> policy_nd;
+  if (build_ptr->determinism == CCCL_NOT_GUARANTEED)
+  {
+    policy_nd.reset(static_cast<cub::detail::reduce_nondeterministic::policy_selector*>(build_ptr->runtime_policy));
+  }
+  else
+  {
+    policy.reset(static_cast<cub::detail::reduce::policy_selector*>(build_ptr->runtime_policy));
+  }
   check(cuLibraryUnload(build_ptr->library));
 
   return CUDA_SUCCESS;

--- a/cub/benchmarks/bench/reduce/nondeterministic.cu
+++ b/cub/benchmarks/bench/reduce/nondeterministic.cu
@@ -17,17 +17,17 @@ template <typename AccumT>
 struct policy_selector
 {
   [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::reduce::reduce_policy
+    -> cub::detail::reduce_nondeterministic::reduce_nondeterministic_policy
   {
     const auto [items, threads] =
       cub::detail::scale_mem_bound(TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, int{sizeof(AccumT)});
-    const auto policy = cub::agent_reduce_policy{
+    const auto policy = cub::detail::reduce::agent_reduce_policy{
       threads,
       items,
       1 << TUNE_ITEMS_PER_VEC_LOAD_POW2,
       cub::BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
       cub::LOAD_DEFAULT};
-    return {{}, {}, {}, policy}; // Only reduce_nondeterministic is used
+    return {policy};
   }
 };
 #endif // !TUNE_BASE

--- a/cub/benchmarks/bench/reduce/nondeterministic.cu
+++ b/cub/benchmarks/bench/reduce/nondeterministic.cu
@@ -57,7 +57,7 @@ void nondeterministic_sum(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 
   // Allocate temporary storage:
   std::size_t temp_size;
-  cub::detail::reduce::dispatch_nondeterministic</* OverrideAccumT = */ T>(
+  cub::detail::reduce_nondeterministic::dispatch</* OverrideAccumT = */ T>(
     nullptr,
     temp_size,
     d_in,
@@ -77,7 +77,7 @@ void nondeterministic_sum(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   auto* temp_storage = thrust::raw_pointer_cast(temp.data());
 
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::reduce::dispatch_nondeterministic</* OverrideAccumT = */ T>(
+    cub::detail::reduce_nondeterministic::dispatch</* OverrideAccumT = */ T>(
       temp_storage,
       temp_size,
       d_in,

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -191,7 +191,9 @@ private:
     using default_policy_selector =
       detail::reduce_nondeterministic::policy_selector_from_types<accum_t, offset_t, ReductionOpT>;
     using policy_selector =
-      ::cuda::std::execution::__query_result_or_t<TuningEnvT, detail::reduce::reduce_policy, default_policy_selector>;
+      ::cuda::std::execution::__query_result_or_t<TuningEnvT,
+                                                  detail::reduce_nondeterministic::reduce_nondeterministic_policy,
+                                                  default_policy_selector>;
 
     return detail::reduce_nondeterministic::dispatch<accum_t>(
       d_temp_storage,

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -186,13 +186,14 @@ private:
     ::cuda::execution::determinism::not_guaranteed_t,
     cudaStream_t stream)
   {
-    using offset_t                = detail::choose_offset_t<NumItemsT>;
-    using accum_t                 = ::cuda::std::__accumulator_t<ReductionOpT, detail::it_value_t<InputIteratorT>, T>;
-    using default_policy_selector = detail::reduce::policy_selector_from_types<accum_t, offset_t, ReductionOpT>;
+    using offset_t = detail::choose_offset_t<NumItemsT>;
+    using accum_t  = ::cuda::std::__accumulator_t<ReductionOpT, detail::it_value_t<InputIteratorT>, T>;
+    using default_policy_selector =
+      detail::reduce_nondeterministic::policy_selector_from_types<accum_t, offset_t, ReductionOpT>;
     using policy_selector =
       ::cuda::std::execution::__query_result_or_t<TuningEnvT, detail::reduce::reduce_policy, default_policy_selector>;
 
-    return detail::reduce::dispatch_nondeterministic<accum_t>(
+    return detail::reduce_nondeterministic::dispatch<accum_t>(
       d_temp_storage,
       temp_storage_bytes,
       d_in,

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -90,25 +90,6 @@ struct DeviceReduceKernelSource
 template <typename PolicyHub>
 struct policy_selector_from_hub
 {
-  // not every PolicyHub may have a ReduceNondeterministicPolicy
-  template <typename ActivePolicy, typename ap_reduce_nondet = typename ActivePolicy::ReduceNondeterministicPolicy>
-  _CCCL_DEVICE_API constexpr auto convert_nondet_policy(int) const
-  {
-    return agent_reduce_policy{
-      ap_reduce_nondet::BLOCK_THREADS,
-      ap_reduce_nondet::ITEMS_PER_THREAD,
-      ap_reduce_nondet::VECTOR_LOAD_LENGTH,
-      ap_reduce_nondet::BLOCK_ALGORITHM,
-      ap_reduce_nondet::LOAD_MODIFIER,
-    };
-  }
-
-  template <typename>
-  _CCCL_DEVICE_API constexpr auto convert_nondet_policy(long) const
-  {
-    return agent_reduce_policy{};
-  }
-
   // this is only called in device code, so we can ignore the arch parameter
   _CCCL_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const -> reduce_policy
   {
@@ -129,9 +110,7 @@ struct policy_selector_from_hub
         ap_single_tile::VECTOR_LOAD_LENGTH,
         ap_single_tile::BLOCK_ALGORITHM,
         ap_single_tile::LOAD_MODIFIER,
-      },
-      convert_nondet_policy<ap>(0),
-    };
+      }};
   }
 };
 } // namespace detail::reduce

--- a/cub/cub/device/dispatch/dispatch_reduce_nondeterministic.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_nondeterministic.cuh
@@ -230,9 +230,9 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   _CubLog("Invoking NondeterministicDeviceReduceAtomicKernel<<<%llu, %d, 0, %p>>>(), %d items "
           "per thread, %d SM occupancy\n",
           (unsigned long long) reduce_grid_size,
-          active_policy.reduce_nondeterministic.threads_per_block,
+          active_policy.reduce.threads_per_block,
           (void*) stream,
-          active_policy.reduce_nondeterministic.items_per_thread,
+          active_policy.reduce.items_per_thread,
           sm_occupancy);
 #endif // CUB_DEBUG_LOG
 

--- a/cub/cub/device/dispatch/dispatch_reduce_nondeterministic.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_nondeterministic.cuh
@@ -21,13 +21,10 @@
 #include <cub/detail/launcher/cuda_runtime.cuh>
 #include <cub/detail/type_traits.cuh> // for cub::detail::invoke_result_t
 #include <cub/device/dispatch/kernels/kernel_reduce.cuh>
-#include <cub/device/dispatch/tuning/tuning_reduce.cuh>
+#include <cub/device/dispatch/tuning/tuning_reduce_nondeterministic.cuh>
 #include <cub/grid/grid_even_share.cuh>
-#include <cub/thread/thread_operators.cuh>
-#include <cub/thread/thread_store.cuh>
 #include <cub/util_debug.cuh>
 #include <cub/util_device.cuh>
-#include <cub/util_temporary_storage.cuh>
 #include <cub/util_type.cuh> // for cub::detail::non_void_value_t, cub::detail::value_t
 
 #include <cuda/std/__algorithm/max.h>
@@ -37,7 +34,7 @@
 
 CUB_NAMESPACE_BEGIN
 
-namespace detail::reduce
+namespace detail::reduce_nondeterministic
 {
 template <typename MaxPolicyT,
           typename InputIteratorT,
@@ -51,7 +48,7 @@ struct DeviceReduceNondeterministicKernelSource
 {
   CUB_DEFINE_KERNEL_GETTER(
     NondeterministicAtomicKernel,
-    NondeterministicDeviceReduceAtomicKernel<
+    reduce::NondeterministicDeviceReduceAtomicKernel<
       MaxPolicyT,
       InputIteratorT,
       OutputIteratorT,
@@ -160,9 +157,9 @@ template <typename OverrideAccumT = nondeterministic_no_override,
               TransformOpT>,
           typename KernelLauncherFactory = TripleChevronFactory>
 #if _CCCL_HAS_CONCEPTS()
-  requires reduce_policy_selector<PolicySelector>
+  requires reduce_nondeterministic_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch_nondeterministic(
+CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
   InputIteratorT d_in,
@@ -183,7 +180,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch_nondeterministic(
     return error;
   }
 
-  const reduce_policy active_policy = policy_selector(cc);
+  const reduce_nondeterministic_policy active_policy = policy_selector(cc);
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(NV_IS_HOST, ({
                  std::stringstream ss;
@@ -203,13 +200,10 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch_nondeterministic(
   }
 
   // Init kernel configuration
-  const int tile_size =
-    active_policy.reduce_nondeterministic.threads_per_block * active_policy.reduce_nondeterministic.items_per_thread;
+  const int tile_size = active_policy.reduce.threads_per_block * active_policy.reduce.items_per_thread;
   int sm_occupancy;
   if (const auto error = CubDebug(launcher_factory.MaxSmOccupancy(
-        sm_occupancy,
-        kernel_source.NondeterministicAtomicKernel(),
-        active_policy.reduce_nondeterministic.threads_per_block)))
+        sm_occupancy, kernel_source.NondeterministicAtomicKernel(), active_policy.reduce.threads_per_block)))
   {
     return error;
   }
@@ -243,7 +237,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch_nondeterministic(
 #endif // CUB_DEBUG_LOG
 
   // Invoke NondeterministicDeviceReduceAtomicKernel
-  launcher_factory(reduce_grid_size, active_policy.reduce_nondeterministic.threads_per_block, 0, stream)
+  launcher_factory(reduce_grid_size, active_policy.reduce.threads_per_block, 0, stream)
     .doit(
       kernel_source.NondeterministicAtomicKernel(), d_in, d_out, num_items, even_share, reduction_op, init, transform_op);
 
@@ -255,6 +249,6 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch_nondeterministic(
   // Sync the stream if specified to flush runtime errors
   return CubDebug(detail::DebugSyncStream(stream));
 }
-} // namespace detail::reduce
+} // namespace detail::reduce_nondeterministic
 
 CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/kernels/kernel_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_reduce.cuh
@@ -287,15 +287,16 @@ template <typename PolicySelector,
 #if _CCCL_HAS_CONCEPTS()
   requires reduce_nondeterministic::reduce_nondeterministic_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-_CCCL_KERNEL_ATTRIBUTES
-__launch_bounds__(int(current_policy<PolicySelector>().reduce.threads_per_block)) void NondeterministicDeviceReduceAtomicKernel(
-  _CCCL_GRID_CONSTANT const InputIteratorT d_in,
-  _CCCL_GRID_CONSTANT const OutputIteratorT d_out,
-  _CCCL_GRID_CONSTANT const OffsetT num_items,
-  GridEvenShare<OffsetT> even_share,
-  ReductionOpT reduction_op,
-  _CCCL_GRID_CONSTANT const InitT init,
-  TransformOpT transform_op)
+_CCCL_KERNEL_ATTRIBUTES __launch_bounds__(int(
+  current_policy<PolicySelector>()
+    .reduce
+    .threads_per_block)) void NondeterministicDeviceReduceAtomicKernel(_CCCL_GRID_CONSTANT const InputIteratorT d_in,
+                                                                       _CCCL_GRID_CONSTANT const OutputIteratorT d_out,
+                                                                       _CCCL_GRID_CONSTANT const OffsetT num_items,
+                                                                       GridEvenShare<OffsetT> even_share,
+                                                                       ReductionOpT reduction_op,
+                                                                       _CCCL_GRID_CONSTANT const InitT init,
+                                                                       TransformOpT transform_op)
 {
   // todo: This static_assert fails with nvc++ CUDA compilation.
   NV_IF_ELSE_TARGET(

--- a/cub/cub/device/dispatch/kernels/kernel_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_reduce.cuh
@@ -15,6 +15,7 @@
 
 #include <cub/agent/agent_reduce.cuh>
 #include <cub/device/dispatch/tuning/tuning_reduce.cuh>
+#include <cub/device/dispatch/tuning/tuning_reduce_nondeterministic.cuh>
 #include <cub/grid/grid_even_share.cuh>
 #include <cub/util_arch.cuh>
 
@@ -284,18 +285,17 @@ template <typename PolicySelector,
           typename InitT,
           typename TransformOpT>
 #if _CCCL_HAS_CONCEPTS()
-  requires reduce_policy_selector<PolicySelector>
+  requires reduce_nondeterministic::reduce_nondeterministic_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-_CCCL_KERNEL_ATTRIBUTES __launch_bounds__(int(
-  current_policy<PolicySelector>()
-    .reduce_nondeterministic
-    .threads_per_block)) void NondeterministicDeviceReduceAtomicKernel(_CCCL_GRID_CONSTANT const InputIteratorT d_in,
-                                                                       _CCCL_GRID_CONSTANT const OutputIteratorT d_out,
-                                                                       _CCCL_GRID_CONSTANT const OffsetT num_items,
-                                                                       GridEvenShare<OffsetT> even_share,
-                                                                       ReductionOpT reduction_op,
-                                                                       _CCCL_GRID_CONSTANT const InitT init,
-                                                                       TransformOpT transform_op)
+_CCCL_KERNEL_ATTRIBUTES
+__launch_bounds__(int(current_policy<PolicySelector>().reduce.threads_per_block)) void NondeterministicDeviceReduceAtomicKernel(
+  _CCCL_GRID_CONSTANT const InputIteratorT d_in,
+  _CCCL_GRID_CONSTANT const OutputIteratorT d_out,
+  _CCCL_GRID_CONSTANT const OffsetT num_items,
+  GridEvenShare<OffsetT> even_share,
+  ReductionOpT reduction_op,
+  _CCCL_GRID_CONSTANT const InitT init,
+  TransformOpT transform_op)
 {
   // todo: This static_assert fails with nvc++ CUDA compilation.
   NV_IF_ELSE_TARGET(
@@ -319,7 +319,7 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(int(
   }
 
   // Thread block type for reducing input tiles
-  static constexpr agent_reduce_policy policy = current_policy<PolicySelector>().reduce_nondeterministic;
+  static constexpr agent_reduce_policy policy = current_policy<PolicySelector>().reduce;
   // TODO(bgruber): pass policy directly as template argument to AgentReduce in C++20
   using agent_policy_t =
     AgentReducePolicy<policy.threads_per_block,

--- a/cub/cub/device/dispatch/tuning/tuning_reduce.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce.cuh
@@ -61,12 +61,10 @@ struct reduce_policy
 {
   agent_reduce_policy reduce;
   agent_reduce_policy single_tile;
-  agent_reduce_policy reduce_nondeterministic;
 
   _CCCL_API constexpr friend bool operator==(const reduce_policy& lhs, const reduce_policy& rhs)
   {
-    return lhs.reduce == rhs.reduce && lhs.single_tile == rhs.single_tile
-        && lhs.reduce_nondeterministic == rhs.reduce_nondeterministic;
+    return lhs.reduce == rhs.reduce && lhs.single_tile == rhs.single_tile;
   }
 
   _CCCL_API constexpr friend bool operator!=(const reduce_policy& lhs, const reduce_policy& rhs)
@@ -77,8 +75,7 @@ struct reduce_policy
 #if _CCCL_HOSTED()
   friend ::std::ostream& operator<<(::std::ostream& os, const reduce_policy& p)
   {
-    return os << "reduce_policy { .reduce = " << p.reduce << ", .single_tile = " << p.single_tile
-              << ", .reduce_nondeterministic = " << p.reduce_nondeterministic << " }";
+    return os << "reduce_policy { .reduce = " << p.reduce << ", .single_tile = " << p.single_tile << " }";
   }
 #endif // _CCCL_HOSTED()
 };
@@ -356,10 +353,7 @@ struct policy_selector
       auto [scaled_items, scaled_threads] = scale_mem_bound(sm100_tuning->threads, sm100_tuning->items, accum_size);
       rp                                  = agent_reduce_policy{
         scaled_threads, scaled_items, sm100_tuning->items_per_vec_load, BLOCK_REDUCE_WARP_REDUCTIONS, LOAD_LDG};
-
-      auto rp_nondet            = rp;
-      rp_nondet.block_algorithm = BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC;
-      return {rp, rp, rp_nondet};
+      return {rp, rp};
     }
 
     if (cc >= ::cuda::compute_capability{6, 0})
@@ -372,10 +366,7 @@ struct policy_selector
       auto [scaled_items, scaled_threads] = scale_mem_bound(threads_per_block, items_per_thread, accum_size);
       const auto rp =
         agent_reduce_policy{scaled_threads, scaled_items, items_per_vec_load, BLOCK_REDUCE_WARP_REDUCTIONS, LOAD_LDG};
-
-      auto rp_nondet            = rp;
-      rp_nondet.block_algorithm = BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC;
-      return {rp, rp, rp_nondet};
+      return {rp, rp};
     }
 
     // base policy is for 500
@@ -387,13 +378,9 @@ struct policy_selector
     auto [scaled_items, scaled_threads] = scale_mem_bound(threads_per_block, items_per_thread, accum_size);
     const auto rp =
       agent_reduce_policy{scaled_threads, scaled_items, items_per_vec_load, BLOCK_REDUCE_WARP_REDUCTIONS, LOAD_LDG};
-
-    auto rp_nondet            = rp;
-    rp_nondet.block_algorithm = BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC;
-    return {rp, rp, rp_nondet};
+    return {rp, rp};
   }
 };
-
 #if _CCCL_HAS_CONCEPTS()
 static_assert(reduce_policy_selector<policy_selector>);
 #endif // _CCCL_HAS_CONCEPTS()

--- a/cub/cub/device/dispatch/tuning/tuning_reduce_nondeterministic.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce_nondeterministic.cuh
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/device/dispatch/tuning/tuning_reduce.cuh>
+
+#include <cuda/__device/compute_capability.h>
+
+CUB_NAMESPACE_BEGIN
+namespace detail::reduce_nondeterministic
+{
+struct reduce_nondeterministic_policy
+{
+  reduce::agent_reduce_policy reduce;
+
+  _CCCL_API constexpr friend bool
+  operator==(const reduce_nondeterministic_policy& lhs, const reduce_nondeterministic_policy& rhs)
+  {
+    return lhs.reduce == rhs.reduce;
+  }
+
+  _CCCL_API constexpr friend bool
+  operator!=(const reduce_nondeterministic_policy& lhs, const reduce_nondeterministic_policy& rhs)
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const reduce_nondeterministic_policy& p)
+  {
+    return os << "reduce_nondeterministic_policy { .reduce = " << p.reduce << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
+#if _CCCL_HAS_CONCEPTS()
+template <typename T>
+concept reduce_nondeterministic_policy_selector = policy_selector<T, reduce_nondeterministic_policy>;
+#endif // _CCCL_HAS_CONCEPTS()
+
+struct policy_selector
+{
+  type_t accum_t;
+  op_kind_t operation_t;
+  int offset_size;
+  int accum_size;
+
+  [[nodiscard]] _CCCL_API constexpr auto operator()(::cuda::compute_capability cc) const
+    -> reduce_nondeterministic_policy
+  {
+    auto policy            = reduce::policy_selector{accum_t, operation_t, offset_size, accum_size}(cc).reduce;
+    policy.block_algorithm = BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC;
+    return {policy};
+  }
+};
+
+#if _CCCL_HAS_CONCEPTS()
+static_assert(reduce_nondeterministic_policy_selector<policy_selector>);
+#endif // _CCCL_HAS_CONCEPTS()
+
+// stateless version which can be passed to kernels
+template <typename AccumT, typename OffsetT, typename ReductionOpT>
+struct policy_selector_from_types
+{
+  [[nodiscard]] _CCCL_API constexpr auto operator()(::cuda::compute_capability cc) const
+    -> reduce_nondeterministic_policy
+  {
+    constexpr auto policies =
+      policy_selector{classify_type<AccumT>, classify_op<ReductionOpT>, int{sizeof(OffsetT)}, int{sizeof(AccumT)}};
+    return policies(cc);
+  }
+};
+} // namespace detail::reduce_nondeterministic
+
+CUB_NAMESPACE_END

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -138,7 +138,15 @@ C2H_TEST("Device reduce can be tuned", "[reduce][device]", block_sizes)
 
   // We are expecting that `unrelated_tuning` is ignored
   auto env = cuda::execution::tune(
-    reduce_tuning<target_block_size>{}, unrelated_tuning{}, unrelated_nondeterminisitc_reduce_tuning{});
+    reduce_tuning<target_block_size>{},
+    unrelated_tuning{}
+#  if _CCCL_CUDA_COMPILER(NVCC, >=, 12, 9)
+    // some rare combinations, like nvcc 12.0 + clang-14 in C++20, or nvcc 12.0 + GCC12 fail with:
+    // pod_tuple.h(130): error: Internal Compiler Error (codegen): "internal error during structure layout!"
+    ,
+    unrelated_nondeterminisitc_reduce_tuning{}
+#  endif // _CCCL_CUDA_COMPILER(NVCC, >=, 12, 9)
+  );
 
   REQUIRE(cudaSuccess == cub::DeviceReduce::Reduce(d_in, d_out.begin(), num_items, block_size_check, 0, env));
   REQUIRE(d_out[0] == num_items);
@@ -155,7 +163,15 @@ C2H_TEST("Device sum can be tuned", "[reduce][device]", block_sizes)
 
   // We are expecting that `unrelated_tuning` is ignored
   auto env = cuda::execution::tune(
-    reduce_tuning<target_block_size>{}, unrelated_tuning{}, unrelated_nondeterminisitc_reduce_tuning{});
+    reduce_tuning<target_block_size>{},
+    unrelated_tuning{}
+#  if _CCCL_CUDA_COMPILER(NVCC, >=, 12, 9)
+    // some rare combinations, like nvcc 12.0 + clang-14 in C++20, or nvcc 12.0 + GCC12 fail with:
+    // pod_tuple.h(130): error: Internal Compiler Error (codegen): "internal error during structure layout!"
+    ,
+    unrelated_nondeterminisitc_reduce_tuning{}
+#  endif // _CCCL_CUDA_COMPILER(NVCC, >=, 12, 9)
+  );
 
   REQUIRE(cudaSuccess == cub::DeviceReduce::Sum(d_in, d_out.begin(), num_items, env));
   REQUIRE(d_out[0] == num_items);

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -102,6 +102,15 @@ struct reduce_tuning
   }
 };
 
+struct unrelated_nondeterminisitc_reduce_tuning
+{
+  _CCCL_API constexpr auto operator()(cuda::compute_capability) const
+    -> cub::detail::reduce_nondeterministic::reduce_nondeterministic_policy
+  {
+    return {}; // just zero everything
+  }
+};
+
 struct unrelated_policy
 {};
 
@@ -128,7 +137,8 @@ C2H_TEST("Device reduce can be tuned", "[reduce][device]", block_sizes)
   auto d_out     = thrust::device_vector<int>(1);
 
   // We are expecting that `unrelated_tuning` is ignored
-  auto env = cuda::execution::tune(reduce_tuning<target_block_size>{}, unrelated_tuning{});
+  auto env = cuda::execution::tune(
+    reduce_tuning<target_block_size>{}, unrelated_tuning{}, unrelated_nondeterminisitc_reduce_tuning{});
 
   REQUIRE(cudaSuccess == cub::DeviceReduce::Reduce(d_in, d_out.begin(), num_items, block_size_check, 0, env));
   REQUIRE(d_out[0] == num_items);
@@ -144,7 +154,8 @@ C2H_TEST("Device sum can be tuned", "[reduce][device]", block_sizes)
   auto d_out     = thrust::device_vector<int>(1);
 
   // We are expecting that `unrelated_tuning` is ignored
-  auto env = cuda::execution::tune(reduce_tuning<target_block_size>{}, unrelated_tuning{});
+  auto env = cuda::execution::tune(
+    reduce_tuning<target_block_size>{}, unrelated_tuning{}, unrelated_nondeterminisitc_reduce_tuning{});
 
   REQUIRE(cudaSuccess == cub::DeviceReduce::Sum(d_in, d_out.begin(), num_items, env));
   REQUIRE(d_out[0] == num_items);
@@ -207,7 +218,7 @@ C2H_TEST("Device reduce uses environment", "[reduce][device]", requirements)
     }
     else if constexpr (cub::detail::is_non_deterministic_v<determinism_t>)
     {
-      using policy_t = cub::detail::reduce::policy_selector_from_types<accumulator_t, offset_t, op_t>;
+      using policy_t = cub::detail::reduce_nondeterministic::policy_selector_from_types<accumulator_t, offset_t, op_t>;
       auto* raw_ptr  = thrust::raw_pointer_cast(d_out.data());
 
       REQUIRE(
@@ -333,7 +344,7 @@ C2H_TEST("Device sum uses environment", "[reduce][device]", requirements)
     }
     else if constexpr (cub::detail::is_non_deterministic_v<determinism_t>)
     {
-      using policy_t = cub::detail::reduce::policy_selector_from_types<accumulator_t, offset_t, op_t>;
+      using policy_t = cub::detail::reduce_nondeterministic::policy_selector_from_types<accumulator_t, offset_t, op_t>;
       auto* raw_ptr  = thrust::raw_pointer_cast(d_out.data());
 
       REQUIRE(

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -98,7 +98,7 @@ struct reduce_tuning
   {
     const auto policy = cub::detail::reduce::agent_reduce_policy{
       ThreadsPerBlock, 1, 1, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_DEFAULT};
-    return {policy, policy, policy};
+    return {policy, policy};
   }
 };
 
@@ -212,7 +212,7 @@ C2H_TEST("Device reduce uses environment", "[reduce][device]", requirements)
 
       REQUIRE(
         cudaSuccess
-        == cub::detail::reduce::dispatch_nondeterministic(
+        == cub::detail::reduce_nondeterministic::dispatch(
           nullptr,
           expected_bytes_allocated,
           d_in,
@@ -338,7 +338,7 @@ C2H_TEST("Device sum uses environment", "[reduce][device]", requirements)
 
       REQUIRE(
         cudaSuccess
-        == cub::detail::reduce::dispatch_nondeterministic(
+        == cub::detail::reduce_nondeterministic::dispatch(
           nullptr,
           expected_bytes_allocated,
           d_in,

--- a/cub/test/catch2_test_device_reduce_nondeterministic.cu
+++ b/cub/test/catch2_test_device_reduce_nondeterministic.cu
@@ -40,9 +40,7 @@ struct custom_policy_selector
       4,
       cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS,
       cub::CacheLoadModifier::LOAD_DEFAULT};
-    auto rp_nd            = rp;
-    rp_nd.block_algorithm = cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC;
-    return {rp, rp, rp_nd};
+    return {rp, rp};
   }
 };
 
@@ -225,13 +223,13 @@ C2H_TEST("Nondeterministic Device reduce works with float and double on gpu with
 
   std::size_t temp_storage_bytes{};
 
-  auto error = cub::detail::reduce::dispatch_nondeterministic(
+  auto error = cub::detail::reduce_nondeterministic::dispatch(
     nullptr, temp_storage_bytes, input, raw_ptr, num_items, cuda::std::plus<type>{}, init_t{}, nullptr, transform_t{});
   REQUIRE(error == cudaSuccess);
 
   c2h::device_vector<std::uint8_t> temp_storage(temp_storage_bytes, thrust::no_init);
 
-  error = cub::detail::reduce::dispatch_nondeterministic(
+  error = cub::detail::reduce_nondeterministic::dispatch(
     thrust::raw_pointer_cast(temp_storage.data()),
     temp_storage_bytes,
     input,


### PR DESCRIPTION
This separates the non deterministic reduce tunings from the normal reduction tunings. This prepares for the public exposure of reduce tunings.