### PR TITLE
[Tile] Improve overlapping range check for `cuda::std::copy`

### DIFF
--- a/libcudacxx/include/cuda/std/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy.h
@@ -86,13 +86,22 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
 _CCCL_API constexpr bool __constexpr_tail_overlap(_Tp* __first, _Up* __needle, [[maybe_unused]] _Tp* __last)
 {
+#if !_CCCL_TILE_COMPILATION() // pointer values cannot be compared
+  if (!::cuda::std::is_constant_evaluated())
+  {
+    return __first < __needle;
+  }
+  else
+#endif // !_CCCL_TILE_COMPILATION()
+  {
 #if defined(_CCCL_BUILTIN_CONSTANT_P)
-  NV_IF_ELSE_TARGET(NV_IS_HOST,
-                    (return _CCCL_BUILTIN_CONSTANT_P(__first < __needle) && __first < __needle;),
-                    (return __constexpr_tail_overlap_fallback(__first, __needle, __last);))
+    NV_IF_ELSE_TARGET(NV_IS_HOST,
+                      (return _CCCL_BUILTIN_CONSTANT_P(__first < __needle) && __first < __needle;),
+                      (return __constexpr_tail_overlap_fallback(__first, __needle, __last);))
 #else // ^^^ _CCCL_BUILTIN_CONSTANT_P ^^^ / vvv !_CCCL_BUILTIN_CONSTANT_P vvv
-  return __constexpr_tail_overlap_fallback(__first, __needle, __last);
+    return __constexpr_tail_overlap_fallback(__first, __needle, __last);
 #endif // !_CCCL_BUILTIN_CONSTANT_P
+  }
 }
 
 _CCCL_EXEC_CHECK_DISABLE
@@ -110,8 +119,7 @@ _CCCL_API constexpr pair<_Tp*, _Up*> __copy(_Tp* __first, _Tp* __last, _Up* __re
     {
       return pair{__last, __result + __n};
     }
-    if ((!::cuda::std::is_constant_evaluated() && __first < __result)
-        || __constexpr_tail_overlap(__first, __result, __last))
+    if (__constexpr_tail_overlap(__first, __result, __last))
     {
       for (ptrdiff_t __i = __n; __i > 0; --__i)
       {


### PR DESCRIPTION
We are currently directly checking whether `__first < __result` which is technically UB if the two pointers to not originate from the same object / array

The tile compiler has better insight into the variables, so it fails to compile the construct we have with the chained conditions. 

Pull it out into the function to both cleanup the code and make tile work