### PR TITLE
[Tile] Reenable chrono tests after compiler segfault was fixed

### DIFF
--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/supported_sizes.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/supported_sizes.fail.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: asm statement is unsupported in tile code
-
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.assign/assign_value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.assign/assign_value.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/optional>
 
 // template <class U> optional<T>& operator=(U&& v);

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.cons/char_ptr_ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.cons/char_ptr_ctor.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile && !c++17
-// nvbug6085905: Segmentation fault (core dumped) tileiras
-
 // template <class charT>
 //     explicit bitset(const charT* str,
 //                     typename basic_string_view<charT>::size_type n = basic_string_view<charT>::npos, //

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.cons/string_view_ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.cons/string_view_ctor.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile && !c++17
-// nvbug6085905: Segmentation fault (core dumped) tileiras
-
 //    template<class charT, class traits>
 //        explicit bitset(
 //            const basic_string_view<charT,traits>& str,

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/flip_all.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/flip_all.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile && !c++17
-// nvbug6085905: Segmentation fault (core dumped) tileiras
-
 // bitset<N>& flip(); // constexpr since C++23
 
 #include <cuda/std/bitset>

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/op_xor_eq.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/op_xor_eq.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: enable-tile && !c++17
-// nvbug6085905: Segmentation fault (core dumped) tileiras
-
 // bitset<N>& operator^=(const bitset<N>& rhs); // constexpr since C++23
 
 #include <cuda/std/bitset>

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.md/time.cal.md.nonmembers/comparisons.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.md/time.cal.md.nonmembers/comparisons.pass.cpp
@@ -20,9 +20,6 @@
 //      Otherwise, if x.month() > y.month() returns false.
 //      Otherwise, returns x.day() < y.day().
 
-// XFAIL: enable-tile
-// Segmentation fault, see nvbug6072674
-
 #include <cuda/std/cassert>
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.mdlast/comparisons.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.mdlast/comparisons.pass.cpp
@@ -15,9 +15,6 @@
 // constexpr bool operator< (const month_day& x, const month_day& y) noexcept;
 //   Returns: x.month() < y.month()
 
-// XFAIL: enable-tile
-// Segmentation fault, see nvbug6072674
-
 #include <cuda/std/cassert>
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/comparisons.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/comparisons.pass.cpp
@@ -18,9 +18,6 @@
 //      Otherwise, if x.year() > y.year() returns false.
 //      Otherwise, returns x.month() < y.month().
 
-// XFAIL: enable-tile
-// Segmentation fault, see nvbug6072674
-
 #include <cuda/std/cassert>
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/comparisons.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/comparisons.pass.cpp
@@ -20,9 +20,6 @@
 //      Otherwise, if x.month() > y.month() returns false.
 //      Otherwise, returns x.day() < y.day()
 
-// XFAIL: enable-tile
-// Segmentation fault, see nvbug6072674
-
 #include <cuda/std/cassert>
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/comparisons.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/comparisons.pass.cpp
@@ -18,9 +18,6 @@
 //      Otherwise, if x.year() > y.year(), returns false.
 //      Otherwise, returns x.month_day_last() < y.month_day_last()
 
-// XFAIL: enable-tile
-// Segmentation fault, see nvbug6072674
-
 #include <cuda/std/cassert>
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/comparisons.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/comparisons.pass.cpp
@@ -13,9 +13,6 @@
 //   Returns: x.year() == y.year() && x.month() == y.month() && x.weekday_indexed() == y.weekday_indexed()
 //
 
-// XFAIL: enable-tile
-// Segmentation fault, see nvbug6072674
-
 #include <cuda/std/cassert>
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/comparisons.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/comparisons.pass.cpp
@@ -13,9 +13,6 @@
 //   Returns: x.year() == y.year() && x.month() == y.month() && x.weekday_last() == y.weekday_last()
 //
 
-// XFAIL: enable-tile
-// Segmentation fault, see nvbug6072674
-
 #include <cuda/std/cassert>
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_sfinae.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_sfinae.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 


### PR DESCRIPTION
This reenables a bunch of tests after the compiler team was able to fix a bunch of tests