### PR TITLE
[Tile] Avoid call to `delete[]` in unique_ptr

### DIFF
--- a/libcudacxx/include/cuda/std/__memory/unique_ptr.h
+++ b/libcudacxx/include/cuda/std/__memory/unique_ptr.h
@@ -93,7 +93,11 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_delete<_Tp[]>
   operator()(_Up* __ptr) const noexcept
   {
     static_assert(sizeof(_Up) >= 0, "cannot delete an incomplete type");
+#if _CCCL_TILE_COMPILATION()
+    _CCCL_ASSERT(false, "Cannot call delete[] in a tile program");
+#else // ^^^ _CCCL_TILE_COMPILATION() ^^^ / vvv !_CCCL_TILE_COMPILATION() vvv
     delete[] __ptr;
+#endif // !_CCCL_TILE_COMPILATION()
   }
 };
 

--- a/libcudacxx/include/cuda/std/__memory/unique_ptr.h
+++ b/libcudacxx/include/cuda/std/__memory/unique_ptr.h
@@ -94,7 +94,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_delete<_Tp[]>
   {
     static_assert(sizeof(_Up) >= 0, "cannot delete an incomplete type");
 #if _CCCL_TILE_COMPILATION()
-    _CCCL_ASSERT(false, "Cannot call delete[] in a tile program");
+    _CCCL_VERIFY(false, "Cannot call delete[] in a tile program");
 #else // ^^^ _CCCL_TILE_COMPILATION() ^^^ / vvv !_CCCL_TILE_COMPILATION() vvv
     delete[] __ptr;
 #endif // !_CCCL_TILE_COMPILATION()


### PR DESCRIPTION
We cannot use it anyhow, but that breaks including headers, even if we do not use it

Instead terminate if we ever encounter it to ensure that we do not silently leak memory