### PR TITLE
[Tile] Disable tests that complained about use of global variable

### DIFF
--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_for_each.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_for_each.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 #include <cuda/std/algorithm.ranges.for_each.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_for_each_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_for_each_n.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 #include <cuda/std/algorithm.ranges.for_each_n.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/shuffle.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/shuffle.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 #include <cuda/std/algorithm.shuffle.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.rotate/rotate_copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.rotate/rotate_copy.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // <algorithm>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.shift/shift_left.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.shift/shift_left.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // <algorithm>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.shift/shift_right.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.shift/shift_right.pass.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: a non-__tile__ variable cannot be used in tile code
 
 // <algorithm>

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop.while/end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop.while/end.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // constexpr auto end();
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop/dangling.cache.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop/dangling.cache.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // If we have a copy-propagating cache, when we copy ZeroOnDestroy, we will get a
 // dangling reference to the copied-from object. This test ensures that we do not
 // propagate the cache on copy.

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/adaptor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/adaptor.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // cuda::std::views::filter
 
 #include <cuda/std/concepts>

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/begin.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/begin.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // constexpr iterator begin();
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/ctor.default.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // filter_view() requires cuda::std::default_initializable<View> &&
 //                        cuda::std::default_initializable<Pred> = default;
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/ctor.view_pred.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/ctor.view_pred.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // constexpr filter_view(View, Pred); // explicit since C++23
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/compare.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // friend constexpr bool operator==(iterator const&, iterator const&)
 //  requires equality_comparable<iterator_t<V>>
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/decrement.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/decrement.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // constexpr iterator& operator--() requires bidirectional_range<V>;
 // constexpr iterator operator--(int) requires bidirectional_range<V>;
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/increment.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/increment.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // constexpr iterator& operator++();
 // constexpr void operator++(int);
 // constexpr iterator operator++(int) requires forward_range<V>;

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/iter_move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/iter_move.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // friend constexpr range_rvalue_reference_t<V> iter_move(iterator const& i)
 //  noexcept(noexcept(ranges::iter_move(i.current_)));
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/iter_swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/iterator/iter_swap.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // friend constexpr void iter_swap(iterator const& x, iterator const& y)
 //  noexcept(noexcept(ranges::iter_swap(x.current_, y.current_)))
 //  requires(indirectly_swappable<iterator_t<V>>);

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/base.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/base.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // constexpr sentinel_t<V> base() const;
 
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/compare.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // friend constexpr bool operator==(iterator const&, sentinel const&);
 
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/ctor.parent.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.filter/sentinel/ctor.parent.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // constexpr explicit sentinel(filter_view&);
 
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.reverse/end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.reverse/end.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // constexpr reverse_iterator<iterator_t<V>> end();
 // constexpr auto end() const requires common_range<const V>;
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.transform/iterator/deref.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.transform/iterator/deref.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a non-__tile__ variable cannot be used in tile code
+
 // transform_view::<iterator>::operator*
 
 #include <cuda/std/ranges>

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.cons/copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.cons/copy.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// error: a non-__tile__ variable cannot be used in tile code
-
 // <cuda/std/string_view>
 
 // constexpr basic_string_view(const basic_string_view&) noexcept = default;


### PR DESCRIPTION
The test do not fail to compile anymore but crash at runtime trying to access a non-tile variable

Also disable tests that fail to compile