### PR TITLE
[Tile] Disable use of `__builtin_countl` in tile mode

### DIFF
--- a/libcudacxx/include/cuda/std/__bit/countl.h
+++ b/libcudacxx/include/cuda/std/__bit/countl.h
@@ -49,6 +49,12 @@
 #  undef _CCCL_BUILTIN_CLZG
 #endif // (_CCCL_CUDA_COMPILER(NVCC) && _CCCL_DEVICE_COMPILATION()) || _CCCL_CUDA_COMPILER(NVCC, <, 13)
 
+#if _CCCL_TILE_COMPILATION() // nvbug6084444: error: "call to non-tile function not supported!"
+#  undef _CCCL_BUILTIN_CLZ
+#  undef _CCCL_BUILTIN_CLZLL
+#  undef _CCCL_BUILTIN_CLZG
+#endif // _CCCL_TILE_COMPILATION()
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if !defined(_CCCL_BUILTIN_CLZG)

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.count/countl_one.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.count/countl_one.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6084444: error: "call to non-tile function not supported!"
-
 // template <class T>
 //   constexpr int countl_one(T x) noexcept;
 

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.count/countl_zero.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.count/countl_zero.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6084444: error: "call to non-tile function not supported!"
-
 // template <class T>
 //   constexpr int countl_zero(T x) noexcept;
 


### PR DESCRIPTION
The builtin is not available, so we need to disable it until it is implemented.

See nvbug6084444