### PR TITLE
[Tile] Disable more tests that rely on return statement inside loop

### DIFF
--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/pair_like.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/pair_like.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <mdspan>
 
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop.while/adaptor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop.while/adaptor.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // cuda::std::views::drop_while
 
 // #include <cuda/std/algorithm>


### PR DESCRIPTION
Currently return statements in loops are not allowed and sometimes the compiler trips over them.

Disable 2 tests until that is fixed