### PR TITLE
[Tile] Avoid taking the address of a function in tile mode

### DIFF
--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/nullptr_t.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/nullptr_t.pass.cpp
@@ -86,9 +86,11 @@ int main(int, char**)
     test_conversions<cuda::std::nullptr_t>();
     test_conversions<void*>();
     test_conversions<A*>();
+#if !_CCCL_TILE_COMPILATION() // error: taking address of a function is unsupported in tile code
     test_conversions<void (*)()>();
     test_conversions<void (A::*)()>();
     test_conversions<int A::*>();
+#endif // !_CCCL_TILE_COMPILATION()
   }
   {
     // TODO Enable this assertion when all compilers implement core DR 583.
@@ -96,7 +98,9 @@ int main(int, char**)
     test_comparisons<cuda::std::nullptr_t>();
     test_comparisons<void*>();
     test_comparisons<A*>();
+#if !_CCCL_TILE_COMPILATION() // error: taking address of a function is unsupported in tile code
     test_comparisons<void (*)()>();
+#endif // !_CCCL_TILE_COMPILATION()
   }
   test_nullptr_conversions();
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop.while/begin.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.drop.while/begin.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+
 // constexpr auto begin();
 
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.bind_front/bind_front.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.bind_front/bind_front.pass.cpp
@@ -7,6 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: function-to-pointer decay is unsupported in tile code
+// error: taking address of a function is unsupported in tile code
+
 // functional
 
 // template <class F, class... Args>

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.not_fn/not_fn.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.not_fn/not_fn.pass.cpp
@@ -535,12 +535,12 @@ TEST_FUNC void call_operator_sfinae_test()
     static_assert(cuda::std::is_invocable<T>::value); // callable only with no args
     static_assert(!cuda::std::is_invocable<T, bool>::value);
   }
-#endif // !_CCCL_TILE_COMPILATION()
   { // violates const correctness (member function pointer)
     using T = decltype(cuda::std::not_fn(&MemFunCallable::return_value_nc));
     static_assert(cuda::std::is_invocable<T, MemFunCallable&>::value);
     static_assert(!cuda::std::is_invocable<T, const MemFunCallable&>::value);
   }
+#endif // !_CCCL_TILE_COMPILATION()
   { // violates const correctness (call object)
     using Obj = CopyCallable<bool>;
     using NCT = decltype(cuda::std::not_fn(Obj{true}));

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.member/is_corresponding_member.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.member/is_corresponding_member.pass.cpp
@@ -71,8 +71,10 @@ TEST_FUNC constexpr bool test()
   assert(!cuda::std::is_corresponding_member(&A::m4, &A::m2));
   assert(!cuda::std::is_corresponding_member(&A::m4, &A::m3));
 
+#  if !_CCCL_TILE_COMPILATION() // error: taking address of a function is unsupported in tile code
   // 4. Member functions should not be corresponding
   assert(!cuda::std::is_corresponding_member(&A::fn, &A::fn));
+#  endif // !_CCCL_TILE_COMPILATION()
 
   // 5. If nullptr is passed, it should not be corresponding
   assert(!cuda::std::is_corresponding_member(static_cast<int A::*>(nullptr), static_cast<int A::*>(nullptr)));

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.member/is_pointer_interconvertible_with_class.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.member/is_pointer_interconvertible_with_class.pass.cpp
@@ -62,9 +62,11 @@ TEST_FUNC constexpr bool test()
   // 4. Non-standard layout class members are not pointer interconvertible with the class itself
   assert(!cuda::std::is_pointer_interconvertible_with_class(&NonStandard::mns1));
 
+#  if !_CCCL_TILE_COMPILATION() // error: taking address of a function is unsupported in tile code
   // 5. Member functions are not pointer interconvertible with the class itself
   assert(!cuda::std::is_pointer_interconvertible_with_class(&A::fn));
   assert(!cuda::std::is_pointer_interconvertible_with_class(&B::fn));
+#  endif // !_CCCL_TILE_COMPILATION()
 
   // 7. is_pointer_interconvertible_with_class always returns false for nullptr
   assert(!cuda::std::is_pointer_interconvertible_with_class(static_cast<int A::*>(nullptr)));


### PR DESCRIPTION
Its forbidden in tile mode, so we need to disable those parts of the tests that do.