### PR TITLE
[Tile] Disable test that relies on dynamic memory

### DIFF
--- a/libcudacxx/test/libcudacxx/std/random/valid_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/random/valid_types.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// error: dynamic memory allocation is unsupported in tile code
+
 // <random>
 //
 // Verify [rand.req.genl]/1.6 and /1.7 (C++26, P4037R1) for the set of integer


### PR DESCRIPTION
No dynamic memory allocation in tile mode and the seed sequence allocates 