### PR TITLE
Use the new tuning API internally for `detail::reduce[_nd]::dispatch[_nd]`

### DIFF
--- a/cub/benchmarks/bench/reduce/arg_extrema.cu
+++ b/cub/benchmarks/bench/reduce/arg_extrema.cu
@@ -26,7 +26,7 @@ struct tuned_policy_selector
       cub::LOAD_DEFAULT};
     auto rp_nondet            = rp;
     rp_nondet.block_algorithm = cub::BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC;
-    return {rp, rp, rp_nondet};
+    return {rp, rp};
   }
 };
 #endif // !TUNE_BASE

--- a/cub/benchmarks/bench/reduce/arg_extrema.cu
+++ b/cub/benchmarks/bench/reduce/arg_extrema.cu
@@ -1,12 +1,9 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <cub/device/device_reduce.cuh>
-#include <cub/device/dispatch/dispatch_streaming_reduce.cuh>
 #include <cub/device/dispatch/tuning/tuning_reduce.cuh>
 
-#include <cuda/__device/compute_capability.h>
-#include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
 #include <nvbench_helper.cuh>
@@ -37,71 +34,59 @@ struct tuned_policy_selector
 template <typename T, typename OpT>
 void arg_reduce(nvbench::state& state, nvbench::type_list<T, OpT>)
 {
-  // Offset type used within the kernel and to index within one partition
-  using per_partition_offset_t = int;
-
   // Offset type used to index within the total input in the range [d_in, d_in + num_items)
-  using global_offset_t = ::cuda::std::int64_t;
-
-  // Iterator providing the values being reduced
-  using values_it_t = T*;
-
-  auto const init = ::cuda::std::is_same_v<OpT, cub::detail::arg_min>
-                    ? ::cuda::std::numeric_limits<T>::max()
-                    : ::cuda::std::numeric_limits<T>::lowest();
+  using offset_t = ::cuda::std::int64_t;
 
   // Retrieve axis parameters
   const auto elements         = static_cast<std::size_t>(state.get_int64("Elements{io}"));
   thrust::device_vector<T> in = generate(elements);
-  thrust::device_vector<global_offset_t> out_index(1);
+  thrust::device_vector<offset_t> out_index(1);
   thrust::device_vector<T> out_extremum(1);
 
-  values_it_t d_in             = thrust::raw_pointer_cast(in.data());
-  global_offset_t* d_out_index = thrust::raw_pointer_cast(out_index.data());
-  T* d_out_extremum            = thrust::raw_pointer_cast(out_extremum.data());
-  auto const num_items         = static_cast<global_offset_t>(elements);
+  const T* d_in         = thrust::raw_pointer_cast(in.data());
+  offset_t* d_out_index = thrust::raw_pointer_cast(out_index.data());
+  T* d_out_extremum     = thrust::raw_pointer_cast(out_extremum.data());
 
   // Enable throughput calculations and add "Size" column to results.
   state.add_element_count(elements);
   state.add_global_memory_reads<T>(elements, "Size");
-  state.add_global_memory_writes<global_offset_t>(1);
+  state.add_global_memory_writes<offset_t>(1);
   state.add_global_memory_writes<T>(1);
 
-  // Allocate temporary storage
-  std::size_t temp_size;
-  cub::detail::reduce::dispatch_streaming_arg_reduce<per_partition_offset_t>(
-    nullptr,
-    temp_size,
-    d_in,
-    d_out_extremum,
-    d_out_index,
-    num_items,
-    OpT{},
-    nullptr /* stream */
-#if !TUNE_BASE
-    ,
-    tuned_policy_selector{}
-#endif // TUNE_BASE
-  );
-
-  thrust::device_vector<nvbench::uint8_t> temp(temp_size);
-  auto* temp_storage = thrust::raw_pointer_cast(temp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::reduce::dispatch_streaming_arg_reduce<per_partition_offset_t>(
-      temp_storage,
-      temp_size,
-      d_in,
-      d_out_extremum,
-      d_out_index,
-      num_items,
-      OpT{},
-      launch.get_stream()
+    auto env = cub_bench_env(
+      alloc,
+      launch
 #if !TUNE_BASE
-        ,
-      tuned_policy_selector{}
-#endif // TUNE_BASE
+      ,
+      cuda::execution::tune(tuned_policy_selector{})
+#endif // !TUNE_BASE
     );
+    if constexpr (::cuda::std::is_same_v<OpT, cub::detail::arg_min>)
+    {
+      _CCCL_TRY_CUDA_API(
+        cub::DeviceReduce::ArgMin,
+        "ArgMin failed",
+        d_in,
+        d_out_extremum,
+        d_out_index,
+        static_cast<offset_t>(elements),
+        cuda::std::less{},
+        env);
+    }
+    else
+    {
+      _CCCL_TRY_CUDA_API(
+        cub::DeviceReduce::ArgMax,
+        "ArgMax failed",
+        d_in,
+        d_out_extremum,
+        d_out_index,
+        static_cast<offset_t>(elements),
+        cuda::std::less{},
+        env);
+    }
   });
 }
 

--- a/cub/benchmarks/bench/reduce/arg_extrema.cu
+++ b/cub/benchmarks/bench/reduce/arg_extrema.cu
@@ -63,7 +63,7 @@ void arg_reduce(nvbench::state& state, nvbench::type_list<T, OpT>)
       cuda::execution::tune(tuned_policy_selector{})
 #endif // !TUNE_BASE
     );
-    if constexpr (::cuda::std::is_same_v<OpT, cub::detail::arg_min>)
+    if constexpr (cuda::std::is_same_v<OpT, cub::detail::arg_min>)
     {
       _CCCL_TRY_CUDA_API(
         cub::DeviceReduce::ArgMin,

--- a/cub/benchmarks/bench/reduce/arg_extrema.cu
+++ b/cub/benchmarks/bench/reduce/arg_extrema.cu
@@ -35,7 +35,7 @@ template <typename T, typename OpT>
 void arg_reduce(nvbench::state& state, nvbench::type_list<T, OpT>)
 {
   // Offset type used to index within the total input in the range [d_in, d_in + num_items)
-  using offset_t = ::cuda::std::int64_t;
+  using offset_t = cuda::std::int64_t;
 
   // Retrieve axis parameters
   const auto elements         = static_cast<std::size_t>(state.get_int64("Elements{io}"));

--- a/cub/benchmarks/bench/reduce/base.cuh
+++ b/cub/benchmarks/bench/reduce/base.cuh
@@ -1,12 +1,9 @@
-// SPDX-FileCopyrightText: Copyright (c) 2011-2023, NVIDIA CORPORATION. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2011-2026, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: BSD-3
 
 #pragma once
 
 #include <cub/device/device_reduce.cuh>
-
-#include <cuda/__device/all_devices.h>
-#include <cuda/__memory_pool/device_memory_pool.h>
 
 #include <nvbench_helper.cuh>
 
@@ -29,11 +26,10 @@ struct policy_selector
 template <typename T, typename OffsetT>
 void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 {
-  using offset_t = cub::detail::choose_offset_t<OffsetT>;
-  using init_t   = T;
+  using init_t = T;
 
   // Retrieve axis parameters
-  const auto elements = static_cast<offset_t>(state.get_int64("Elements{io}"));
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements{io}"));
 
   thrust::device_vector<T> in = generate(elements);
   thrust::device_vector<T> out(1);
@@ -46,45 +42,18 @@ void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   state.add_global_memory_reads<T>(elements, "Size");
   state.add_global_memory_writes<T>(1);
 
-  // So for now, we have to call into the dispatcher again to override the accumulator type:
-  auto transform_op = ::cuda::std::identity{};
-
-  std::size_t temp_size;
-  cub::detail::reduce::dispatch(
-    nullptr,
-    temp_size,
-    d_in,
-    d_out,
-    elements,
-    op_t{},
-    init_t{},
-    nullptr /* stream */,
-    transform_op
-#if !TUNE_BASE
-    ,
-    policy_selector<T>{}
-#endif
-  );
-
-  thrust::device_vector<nvbench::uint8_t> temp(temp_size, thrust::no_init);
-  auto* temp_storage = thrust::raw_pointer_cast(temp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::reduce::dispatch(
-      temp_storage,
-      temp_size,
-      d_in,
-      d_out,
-      elements,
-      op_t{},
-      init_t{},
-      launch.get_stream(),
-      transform_op
+    auto env = cub_bench_env(
+      alloc,
+      launch
 #if !TUNE_BASE
       ,
-      policy_selector<T>{}
-#endif
+      cuda::execution::tune(policy_selector<T>{})
+#endif // !TUNE_BASE
     );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceReduce::Reduce, "Reduce failed", d_in, d_out, static_cast<OffsetT>(elements), op_t{}, init_t{}, env);
   });
 }
 

--- a/cub/benchmarks/bench/reduce/base.cuh
+++ b/cub/benchmarks/bench/reduce/base.cuh
@@ -49,7 +49,7 @@ void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
       launch
 #if !TUNE_BASE
       ,
-      cuda::execution::tune(policy_selector<T>{})
+      cuda::execution::tune(policy_selector<cuda::std::__accumulator_t<opt_t, T, init_t>>{})
 #endif // !TUNE_BASE
     );
     _CCCL_TRY_CUDA_API(

--- a/cub/benchmarks/bench/reduce/base.cuh
+++ b/cub/benchmarks/bench/reduce/base.cuh
@@ -29,7 +29,7 @@ void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   using init_t = T;
 
   // Retrieve axis parameters
-  const auto elements = static_cast<std::size_t>(state.get_int64("Elements{io}"));
+  const auto elements = state.get_int64("Elements{io}");
 
   thrust::device_vector<T> in = generate(elements);
   thrust::device_vector<T> out(1);

--- a/cub/benchmarks/bench/reduce/base.cuh
+++ b/cub/benchmarks/bench/reduce/base.cuh
@@ -18,7 +18,7 @@ struct policy_selector
       cub::detail::scale_mem_bound(TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, int{sizeof(AccumT)});
     const auto policy = cub::detail::reduce::agent_reduce_policy{
       threads, items, 1 << TUNE_ITEMS_PER_VEC_LOAD_POW2, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_DEFAULT};
-    return {policy, policy, policy};
+    return {policy, policy};
   }
 };
 #endif // !TUNE_BASE

--- a/cub/benchmarks/bench/reduce/base.cuh
+++ b/cub/benchmarks/bench/reduce/base.cuh
@@ -49,7 +49,7 @@ void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
       launch
 #if !TUNE_BASE
       ,
-      cuda::execution::tune(policy_selector<cuda::std::__accumulator_t<opt_t, T, init_t>>{})
+      cuda::execution::tune(policy_selector<cuda::std::__accumulator_t<op_t, T, init_t>>{})
 #endif // !TUNE_BASE
     );
     _CCCL_TRY_CUDA_API(

--- a/cub/benchmarks/bench/reduce/deterministic.cu
+++ b/cub/benchmarks/bench/reduce/deterministic.cu
@@ -1,7 +1,10 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: BSD-3
 
-#include <cub/device/dispatch/dispatch_reduce_deterministic.cuh>
+#include <cub/device/device_reduce.cuh>
+
+#include <cuda/execution.determinism.h>
+#include <cuda/execution.require.h>
 
 #include <nvbench_helper.cuh>
 
@@ -26,8 +29,7 @@ struct policy_selector_t
 template <class T>
 void deterministic_sum(nvbench::state& state, nvbench::type_list<T>)
 {
-  using init_t      = T;
-  using transform_t = ::cuda::std::identity;
+  using init_t = T;
 
   const auto elements = static_cast<int>(state.get_int64("Elements{io}"));
 
@@ -40,28 +42,19 @@ void deterministic_sum(nvbench::state& state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements, "Size");
   state.add_global_memory_writes<T>(out.size());
 
-  std::size_t temp_storage_bytes{};
-  cub::detail::rfa::dispatch(
-    nullptr, temp_storage_bytes, d_in, d_out, elements, init_t{}, /* stream */ nullptr, transform_t{});
-
-  thrust::device_vector<nvbench::uint8_t> temp_storage(temp_storage_bytes);
-  auto* d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    cub::detail::rfa::dispatch(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_in,
-      d_out,
-      elements,
-      init_t{},
-      launch.get_stream(),
-      transform_t{}
+    auto env = cub_bench_env(
+      alloc,
+      launch,
+      cuda::execution::require(cuda::execution::determinism::gpu_to_gpu)
 #if !TUNE_BASE
-      ,
-      policy_selector_t{}
+        ,
+      cuda::execution::tune(policy_selector_t{})
 #endif // !TUNE_BASE
     );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceReduce::Reduce, "Reduce failed", d_in, d_out, elements, cuda::std::plus<>{}, init_t{}, env);
   });
 }
 

--- a/cub/benchmarks/bench/reduce/nondeterministic.cu
+++ b/cub/benchmarks/bench/reduce/nondeterministic.cu
@@ -63,7 +63,7 @@ void nondeterministic_sum(nvbench::state& state, nvbench::type_list<T, OffsetT>)
       cuda::execution::require(cuda::execution::determinism::not_guaranteed)
 #if !TUNE_BASE
         ,
-      cuda::execution::tune(policy_selector<cuda::std::__accumulator_t<opt_t, T, init_t>>{})
+      cuda::execution::tune(policy_selector<cuda::std::__accumulator_t<op_t, T, init_t>>{})
 #endif // !TUNE_BASE
     );
     _CCCL_TRY_CUDA_API(

--- a/cub/benchmarks/bench/reduce/nondeterministic.cu
+++ b/cub/benchmarks/bench/reduce/nondeterministic.cu
@@ -1,7 +1,10 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include <cub/device/dispatch/dispatch_reduce_nondeterministic.cuh>
+#include <cub/device/device_reduce.cuh>
+
+#include <cuda/execution.determinism.h>
+#include <cuda/execution.require.h>
 
 #include <nvbench_helper.cuh>
 
@@ -35,9 +38,8 @@ struct policy_selector
 template <typename T, typename OffsetT>
 void nondeterministic_sum(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 {
-  using offset_t = cub::detail::choose_offset_t<OffsetT>;
-  using op_t     = cuda::std::plus<>;
-  using init_t   = T;
+  using op_t   = cuda::std::plus<>;
+  using init_t = T;
 
   // Retrieve axis parameters
   const auto elements = static_cast<std::size_t>(state.get_int64("Elements{io}"));
@@ -53,45 +55,19 @@ void nondeterministic_sum(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   state.add_global_memory_reads<T>(elements, "Size");
   state.add_global_memory_writes<T>(1);
 
-  auto transform_op = ::cuda::std::identity{};
-
-  // Allocate temporary storage:
-  std::size_t temp_size;
-  cub::detail::reduce_nondeterministic::dispatch(
-    nullptr,
-    temp_size,
-    d_in,
-    d_out,
-    static_cast<offset_t>(elements),
-    op_t{},
-    init_t{},
-    nullptr /* stream */,
-    transform_op
-#if !TUNE_BASE
-    ,
-    policy_selector<T>{}
-#endif
-  );
-
-  thrust::device_vector<nvbench::uint8_t> temp(temp_size, thrust::no_init);
-  auto* temp_storage = thrust::raw_pointer_cast(temp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::reduce_nondeterministic::dispatch(
-      temp_storage,
-      temp_size,
-      d_in,
-      d_out,
-      static_cast<offset_t>(elements),
-      op_t{},
-      init_t{},
-      launch.get_stream(),
-      transform_op
+    auto env = cub_bench_env(
+      alloc,
+      launch,
+      cuda::execution::require(cuda::execution::determinism::not_guaranteed)
 #if !TUNE_BASE
-      ,
-      policy_selector{}
-#endif
+        ,
+      cuda::execution::tune(policy_selector<T>{})
+#endif // !TUNE_BASE
     );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceReduce::Reduce, "Reduce failed", d_in, d_out, static_cast<OffsetT>(elements), op_t{}, init_t{}, env);
   });
 }
 

--- a/cub/benchmarks/bench/reduce/nondeterministic.cu
+++ b/cub/benchmarks/bench/reduce/nondeterministic.cu
@@ -63,7 +63,7 @@ void nondeterministic_sum(nvbench::state& state, nvbench::type_list<T, OffsetT>)
       cuda::execution::require(cuda::execution::determinism::not_guaranteed)
 #if !TUNE_BASE
         ,
-      cuda::execution::tune(policy_selector<T>{})
+      cuda::execution::tune(policy_selector<cuda::std::__accumulator_t<opt_t, T, init_t>>{})
 #endif // !TUNE_BASE
     );
     _CCCL_TRY_CUDA_API(

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -1058,7 +1058,7 @@ private:
     using GlobalOffsetT           = ::cuda::std::int64_t; // in the range [d_in, d_in + num_items)
     using input_value_t           = detail::it_value_t<InputIteratorT>;
     using output_extremum_t       = detail::non_void_value_t<ExtremumOutIteratorT, input_value_t>;
-    using reduce_op_t             = detail::arg_less<CompareOpT>;
+    using reduce_op_t             = detail::arg_reduce_op<CompareOpT>;
     using default_policy_selector = detail::reduce::
       policy_selector_from_types<KeyValuePair<PerPartitionOffsetT, output_extremum_t>, PerPartitionOffsetT, reduce_op_t>;
 

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -1054,59 +1054,27 @@ private:
     static_assert(!::cuda::std::is_same_v<requested_determinism_t, ::cuda::execution::determinism::gpu_to_gpu_t>,
                   "gpu_to_gpu determinism is not supported");
 
-    // Query relevant properties from the environment
-    auto stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, env);
-    auto mr     = ::cuda::__call_or(::cuda::mr::get_memory_resource, detail::device_memory_resource{}, env);
+    using PerPartitionOffsetT     = int; // used by the kernel to index within one partition
+    using GlobalOffsetT           = ::cuda::std::int64_t; // in the range [d_in, d_in + num_items)
+    using input_value_t           = detail::it_value_t<InputIteratorT>;
+    using output_extremum_t       = detail::non_void_value_t<ExtremumOutIteratorT, input_value_t>;
+    using reduce_op_t             = detail::arg_less<CompareOpT>;
+    using default_policy_selector = detail::reduce::
+      policy_selector_from_types<KeyValuePair<PerPartitionOffsetT, output_extremum_t>, PerPartitionOffsetT, reduce_op_t>;
 
-    using PerPartitionOffsetT = int; // used by the kernel to index within one partition
-    using GlobalOffsetT       = ::cuda::std::int64_t; // in the range [d_in, d_in + num_items)
-
-    void* d_temp_storage      = nullptr;
-    size_t temp_storage_bytes = 0;
-
-    // Query the required temporary storage size
-    if (const auto error = detail::reduce::dispatch_streaming_arg_reduce<PerPartitionOffsetT>(
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+        return detail::reduce::dispatch_streaming_arg_reduce<PerPartitionOffsetT>(
           d_temp_storage,
           temp_storage_bytes,
           d_in,
           d_min_out,
           d_index_out,
           static_cast<GlobalOffsetT>(num_items),
-          detail::arg_reduce_op{compare_op},
-          stream.get()))
-    {
-      return error;
-    }
-
-    // TODO(gevtushenko): use uninitialized buffer when it's available
-    if (const auto error =
-          CubDebug(detail::temporary_storage::allocate(stream, d_temp_storage, temp_storage_bytes, mr)))
-    {
-      return error;
-    }
-
-    // Run the algorithm
-    const auto error = detail::reduce::dispatch_streaming_arg_reduce<PerPartitionOffsetT>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_in,
-      d_min_out,
-      d_index_out,
-      static_cast<GlobalOffsetT>(num_items),
-      detail::arg_reduce_op{compare_op},
-      stream.get());
-
-    // Try to deallocate regardless of the error to avoid memory leaks
-    const auto deallocate_error =
-      CubDebug(detail::temporary_storage::deallocate(stream, d_temp_storage, temp_storage_bytes, mr));
-
-    if (error != cudaSuccess)
-    {
-      // Reduction error takes precedence over deallocation error since it happens first
-      return error;
-    }
-
-    return deallocate_error;
+          reduce_op_t{compare_op},
+          stream,
+          policy_selector);
+      });
   }
 
 public:
@@ -1529,7 +1497,10 @@ public:
     // TODO(NaderAlAwar): Relax this once non-deterministic implementation for min / max is available
     using determinism_t = ::cuda::execution::determinism::run_to_run_t;
 
-    using OutputT = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::it_value_t<InputIteratorT>>;
+    using OutputT  = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::it_value_t<InputIteratorT>>;
+    using OffsetT  = detail::choose_offset_t<NumItemsT>;
+    using accum_t  = OutputT;
+    using max_op_t = ::cuda::maximum<>;
 
     using InitT    = OutputT;
     using limits_t = ::cuda::std::numeric_limits<InitT>;
@@ -2268,20 +2239,27 @@ public:
     using OffsetT    = detail::choose_offset_t<NumItemsT>;
     using EqualityOp = ::cuda::std::equal_to<>;
 
-    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::reduce_by_key::dispatch(
-        storage,
-        bytes,
-        d_keys_in,
-        d_unique_out,
-        d_values_in,
-        d_aggregates_out,
-        d_num_runs_out,
-        EqualityOp{},
-        reduction_op,
-        static_cast<OffsetT>(num_items),
-        stream);
-    });
+    using AccumT = ::cuda::std::
+      __accumulator_t<ReductionOpT, detail::it_value_t<ValuesInputIteratorT>, detail::it_value_t<ValuesInputIteratorT>>;
+    using KeyT = detail::non_void_value_t<UniqueOutputIteratorT, detail::it_value_t<KeysInputIteratorT>>;
+    using default_policy_selector = detail::reduce_by_key::policy_selector_from_types<ReductionOpT, AccumT, KeyT>;
+
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* storage, size_t& bytes, cudaStream_t stream) {
+        return detail::reduce_by_key::dispatch(
+          storage,
+          bytes,
+          d_keys_in,
+          d_unique_out,
+          d_values_in,
+          d_aggregates_out,
+          d_num_runs_out,
+          EqualityOp{},
+          reduction_op,
+          static_cast<OffsetT>(num_items),
+          stream,
+          policy_selector);
+      });
   }
 
   //! @rst

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -1498,10 +1498,6 @@ public:
     using determinism_t = ::cuda::execution::determinism::run_to_run_t;
 
     using OutputT  = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::it_value_t<InputIteratorT>>;
-    using OffsetT  = detail::choose_offset_t<NumItemsT>;
-    using accum_t  = OutputT;
-    using max_op_t = ::cuda::maximum<>;
-
     using InitT    = OutputT;
     using limits_t = ::cuda::std::numeric_limits<InitT>;
 

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -35,62 +35,6 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMax, device_arg_max);
 
 namespace stdexec = cuda::std::execution;
 
-// Launcher helper always passes an environment.
-// We need a test of simple use to check if default environment works.
-// ifdef it out not to spend time compiling and running it twice.
-#if TEST_LAUNCH == 0
-using block_size_check_t = block_size_extracting_op<cuda::std::plus<>>;
-
-TEST_CASE("Device reduce works with default environment", "[reduce][device]")
-{
-  using num_items_t = int;
-  using value_t     = int;
-  using offset_t    = cub::detail::choose_offset_t<num_items_t>;
-
-  int current_device{};
-  REQUIRE(cudaSuccess == cudaGetDevice(&current_device));
-
-  cuda::compute_capability cc{};
-  REQUIRE(cudaSuccess == cub::detail::ptx_compute_cap(cc, current_device));
-
-  unsigned int target_block_size =
-    cub::detail::reduce::policy_selector_from_types<value_t, offset_t, block_size_check_t>{}(cc)
-      .single_tile.threads_per_block;
-
-  num_items_t num_items = 1;
-  c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
-  auto d_in  = cuda::constant_iterator(value_t{1});
-  auto d_out = thrust::device_vector<value_t>(1);
-
-  REQUIRE(cudaSuccess == cub::DeviceReduce::Reduce(d_in, d_out.begin(), num_items, block_size_check, value_t{0}));
-  REQUIRE(d_out[0] == num_items);
-
-  // Make sure we use default tuning
-  REQUIRE(d_block_size[0] == target_block_size);
-}
-
-TEST_CASE("Device sum works with default environment", "[reduce][device]")
-{
-  using num_items_t = int;
-  using value_t     = int;
-  using offset_t    = cub::detail::choose_offset_t<num_items_t>;
-
-  int current_device{};
-  REQUIRE(cudaSuccess == cudaGetDevice(&current_device));
-
-  int ptx_version{};
-  REQUIRE(cudaSuccess == cub::PtxVersion(ptx_version, current_device));
-
-  num_items_t num_items = 1;
-
-  auto d_in  = cuda::constant_iterator(value_t{1});
-  auto d_out = thrust::device_vector<value_t>(1);
-
-  REQUIRE(cudaSuccess == cub::DeviceReduce::Sum(d_in, d_out.begin(), num_items));
-  REQUIRE(d_out[0] == num_items);
-}
-
 template <int ThreadsPerBlock>
 struct reduce_tuning
 {
@@ -126,6 +70,62 @@ struct unrelated_tuning
 using block_sizes =
   c2h::type_list<cuda::std::integral_constant<unsigned int, 32>, cuda::std::integral_constant<unsigned int, 64>>;
 
+// Launcher helper always passes an environment.
+// We need a test of simple use to check if default environment works.
+// ifdef it out not to spend time compiling and running it twice.
+#if TEST_LAUNCH == 0
+using block_size_check_t = block_size_extracting_op<cuda::std::plus<>>;
+
+TEST_CASE("Device reduce works with default environment", "[reduce][device]")
+{
+  using num_items_t = int;
+  using value_t     = int;
+  using offset_t    = cub::detail::choose_offset_t<num_items_t>;
+
+  int current_device{};
+  REQUIRE(cudaSuccess == cudaGetDevice(&current_device));
+
+  cuda::compute_capability cc{};
+  REQUIRE(cudaSuccess == cub::detail::ptx_compute_cap(cc, current_device));
+
+  unsigned int target_block_size =
+    cub::detail::reduce::policy_selector_from_types<value_t, offset_t, block_size_check_t>{}(cc)
+      .single_tile.threads_per_block;
+
+  num_items_t num_items = 1;
+  c2h::device_vector<unsigned int> d_block_size(1);
+  block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
+  auto d_in  = cuda::constant_iterator(value_t{1});
+  auto d_out = thrust::device_vector<value_t>(1);
+
+  REQUIRE(cudaSuccess == cub::DeviceReduce::Reduce(d_in, d_out.begin(), num_items, block_size_check, value_t{0}));
+  REQUIRE(d_out[0] == num_items);
+
+  // Make sure we use default tuning
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+TEST_CASE("Device Sum works with default environment", "[reduce][device]")
+{
+  using num_items_t = int;
+  using value_t     = int;
+  using offset_t    = cub::detail::choose_offset_t<num_items_t>;
+
+  int current_device{};
+  REQUIRE(cudaSuccess == cudaGetDevice(&current_device));
+
+  int ptx_version{};
+  REQUIRE(cudaSuccess == cub::PtxVersion(ptx_version, current_device));
+
+  num_items_t num_items = 1;
+
+  auto d_in  = cuda::constant_iterator(value_t{1});
+  auto d_out = thrust::device_vector<value_t>(1);
+
+  REQUIRE(cudaSuccess == cub::DeviceReduce::Sum(d_in, d_out.begin(), num_items));
+  REQUIRE(d_out[0] == num_items);
+}
+
 C2H_TEST("Device reduce can be tuned", "[reduce][device]", block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
@@ -152,14 +152,61 @@ C2H_TEST("Device reduce can be tuned", "[reduce][device]", block_sizes)
   REQUIRE(d_out[0] == num_items);
   REQUIRE(d_block_size[0] == target_block_size);
 }
+#endif
 
-C2H_TEST("Device sum can be tuned", "[reduce][device]", block_sizes)
+#if TEST_LAUNCH != 1
+C2H_TEST("Device Sum can be tuned", "[reduce][device]", block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<unsigned int> d_block_size(1);
 
-  auto num_items = 1;
-  auto d_in      = cuda::constant_iterator(1);
-  auto d_out     = thrust::device_vector<int>(1);
+  auto d_in  = block_size_extracting_constant_iterator(1, thrust::raw_pointer_cast(d_block_size.data()));
+  auto d_out = c2h::device_vector<int>(1);
+
+  auto env = cuda::execution::tune(reduce_tuning<target_block_size>{});
+
+  device_reduce_sum(d_in, d_out.begin(), 1, env);
+  REQUIRE(d_out[0] == 1);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("Device Min can be tuned", "[reduce][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<unsigned int> d_block_size(1);
+
+  auto d_in  = block_size_extracting_constant_iterator(42, thrust::raw_pointer_cast(d_block_size.data()));
+  auto d_out = c2h::device_vector<int>(1);
+
+  auto env = cuda::execution::tune(reduce_tuning<target_block_size>{});
+
+  device_reduce_min(d_in, d_out.begin(), 1, env);
+  REQUIRE(d_out[0] == 42);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("Device Max can be tuned", "[reduce][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<unsigned int> d_block_size(1);
+
+  auto d_in  = block_size_extracting_constant_iterator(42, thrust::raw_pointer_cast(d_block_size.data()));
+  auto d_out = c2h::device_vector<int>(1);
+
+  auto env = cuda::execution::tune(reduce_tuning<target_block_size>{});
+
+  device_reduce_max(d_in, d_out.begin(), 1, env);
+  REQUIRE(d_out[0] == 42);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("Device TransformReduce can be tuned", "[reduce][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<unsigned int> d_block_size(1);
+
+  auto d_in  = block_size_extracting_constant_iterator(1, thrust::raw_pointer_cast(d_block_size.data()));
+  auto d_out = c2h::device_vector<int>(1);
 
   // We are expecting that `unrelated_tuning` is ignored
   auto env = cuda::execution::tune(
@@ -173,10 +220,52 @@ C2H_TEST("Device sum can be tuned", "[reduce][device]", block_sizes)
 #  endif // _CCCL_CUDA_COMPILER(NVCC, >=, 12, 9)
   );
 
-  REQUIRE(cudaSuccess == cub::DeviceReduce::Sum(d_in, d_out.begin(), num_items, env));
-  REQUIRE(d_out[0] == num_items);
+  device_transform_reduce(d_in, d_out.begin(), 1, cuda::std::plus<>{}, cuda::std::negate<int>{}, 0, env);
+  REQUIRE(d_out[0] == -1);
+  REQUIRE(d_block_size[0] == target_block_size);
 }
-#endif
+
+C2H_TEST("Device ArgMin can be tuned", "[reduce][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<unsigned int> d_block_size(1);
+  using compare_t = block_size_extracting_op<cuda::std::less<>>;
+  compare_t compare_op{thrust::raw_pointer_cast(d_block_size.data())};
+
+  auto input        = c2h::device_vector<int>{3, 1, 4, 0, 2};
+  auto min_output   = c2h::device_vector<int>(1);
+  auto index_output = c2h::device_vector<cuda::std::int64_t>(1);
+
+  auto env = cuda::execution::tune(reduce_tuning<target_block_size>{});
+
+  device_arg_min(
+    input.begin(), min_output.begin(), index_output.begin(), static_cast<int>(input.size()), compare_op, env);
+  REQUIRE(min_output[0] == 0);
+  REQUIRE(index_output[0] == 3);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("Device ArgMax can be tuned", "[reduce][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<unsigned int> d_block_size(1);
+  using compare_t = block_size_extracting_op<cuda::std::less<>>;
+  compare_t compare_op{thrust::raw_pointer_cast(d_block_size.data())};
+
+  auto input        = c2h::device_vector<int>{3, 1, 4, 0, 2};
+  auto max_output   = c2h::device_vector<int>(1);
+  auto index_output = c2h::device_vector<cuda::std::int64_t>(1);
+
+  auto env = cuda::execution::tune(reduce_tuning<target_block_size>{});
+
+  device_arg_max(
+    input.begin(), max_output.begin(), index_output.begin(), static_cast<int>(input.size()), compare_op, env);
+  REQUIRE(max_output[0] == 4);
+  REQUIRE(index_output[0] == 2);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+#endif // TEST_LAUNCH != 1
 
 using requirements =
   c2h::type_list<cuda::execution::determinism::gpu_to_gpu_t,

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -149,8 +149,13 @@ C2H_TEST("Device reduce can be tuned", "[reduce][device]", block_sizes)
 
   auto env = cuda::execution::tune(
     reduce_tuning<target_block_size>{}, // <-- should be taken
+#  if _CCCL_CUDA_COMPILER(NVCC, >=, 12, 1)
+    // some rare combinations, like nvcc 12.0 + clang-14 in C++20, or nvcc 12.0 + GCC12 fail with:
+    //   pod_tuple.h(130): error: Internal Compiler Error (codegen): "internal error during structure layout!"
+    // if we pass more than two policy selectors
     unrelated_tuning{}, // should be ignored
     nondeterministic_reduce_tuning<target_block_size * 2>{}, // should be ignored
+#  endif // _CCCL_CUDA_COMPILER(NVCC, >=, 12, 1)
     deterministic_reduce_tuning<target_block_size * 2>{} // should be ignored
   );
 
@@ -170,8 +175,10 @@ C2H_TEST("Device reduce not_guaranteed can be tuned", "[reduce][device]", block_
   auto env = cuda::std::execution::env{
     cuda::execution::require(cuda::execution::determinism::not_guaranteed),
     cuda::execution::tune(
+#  if _CCCL_CUDA_COMPILER(NVCC, >=, 12, 1)
       reduce_tuning<target_block_size * 2>{}, // should be ignored
       unrelated_tuning{}, // should be ignored
+#  endif // _CCCL_CUDA_COMPILER(NVCC, >=, 12, 1)
       nondeterministic_reduce_tuning<target_block_size>{}, // <-- should be taken
       deterministic_reduce_tuning<target_block_size * 2>{} // should be ignored
       )};
@@ -192,8 +199,10 @@ C2H_TEST("Device reduce run_to_run can be tuned", "[reduce][device]", block_size
     cuda::execution::require(cuda::execution::determinism::run_to_run),
     cuda::execution::tune(
       reduce_tuning<target_block_size>{}, // <-- should be taken
+#  if _CCCL_CUDA_COMPILER(NVCC, >=, 12, 1)
       unrelated_tuning{}, // should be ignored
       nondeterministic_reduce_tuning<target_block_size * 2>{}, // should be ignored
+#  endif // _CCCL_CUDA_COMPILER(NVCC, >=, 12, 1)
       deterministic_reduce_tuning<target_block_size * 2>{} // should be ignored
       )};
 
@@ -213,8 +222,10 @@ C2H_TEST("Device reduce gpu_to_gpu can be tuned", "[reduce][device]", block_size
   auto env = cuda::std::execution::env{
     cuda::execution::require(cuda::execution::determinism::gpu_to_gpu),
     cuda::execution::tune(
+#  if _CCCL_CUDA_COMPILER(NVCC, >=, 12, 1)
       reduce_tuning<target_block_size * 2>{}, // should be ignored
       unrelated_tuning{}, // should be ignored
+#  endif // _CCCL_CUDA_COMPILER(NVCC, >=, 12, 1)
       nondeterministic_reduce_tuning<target_block_size * 2>{}, // // should be ignored
       deterministic_reduce_tuning<target_block_size>{} // <-- should be taken
       )};
@@ -279,13 +290,10 @@ C2H_TEST("Device TransformReduce can be tuned", "[reduce][device]", block_sizes)
 
   auto env = cuda::execution::tune(
     reduce_tuning<target_block_size>{},
-    unrelated_tuning{} // should be ignored
-#  if _CCCL_CUDA_COMPILER(NVCC, >=, 12, 9)
-    // some rare combinations, like nvcc 12.0 + clang-14 in C++20, or nvcc 12.0 + GCC12 fail with:
-    // pod_tuple.h(130): error: Internal Compiler Error (codegen): "internal error during structure layout!"
-    ,
-    nondeterministic_reduce_tuning<target_block_size * 2>{} // should be ignored
+#  if _CCCL_CUDA_COMPILER(NVCC, >=, 12, 1)
+    unrelated_tuning{}, // should be ignored
 #  endif // _CCCL_CUDA_COMPILER(NVCC, >=, 12, 9)
+    nondeterministic_reduce_tuning<target_block_size * 2>{} // should be ignored
   );
 
   device_transform_reduce(d_in, d_out.begin(), 1, cuda::std::plus<>{}, cuda::std::negate<int>{}, 0, env);

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -46,12 +46,24 @@ struct reduce_tuning
   }
 };
 
-struct unrelated_nondeterminisitc_reduce_tuning
+template <int ThreadsPerBlock>
+struct nondeterministic_reduce_tuning
 {
   _CCCL_API constexpr auto operator()(cuda::compute_capability) const
     -> cub::detail::reduce_nondeterministic::reduce_nondeterministic_policy
   {
-    return {}; // just zero everything
+    return {cub::detail::reduce::agent_reduce_policy{
+      ThreadsPerBlock, 1, 1, cub::BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC, cub::LOAD_DEFAULT}};
+  }
+};
+
+template <int ThreadsPerBlock>
+struct deterministic_reduce_tuning
+{
+  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::detail::rfa::rfa_policy
+  {
+    return {cub::detail::rfa::reduce_policy{ThreadsPerBlock, 1, cub::BLOCK_REDUCE_WARP_REDUCTIONS},
+            cub::detail::rfa::single_tile_policy{ThreadsPerBlock, 1, cub::BLOCK_REDUCE_WARP_REDUCTIONS}};
   }
 };
 
@@ -70,12 +82,12 @@ struct unrelated_tuning
 using block_sizes =
   c2h::type_list<cuda::std::integral_constant<unsigned int, 32>, cuda::std::integral_constant<unsigned int, 64>>;
 
+using block_size_check_plus_t = block_size_extracting_op<cuda::std::plus<>>;
+
 // Launcher helper always passes an environment.
 // We need a test of simple use to check if default environment works.
 // ifdef it out not to spend time compiling and running it twice.
 #if TEST_LAUNCH == 0
-using block_size_check_t = block_size_extracting_op<cuda::std::plus<>>;
-
 TEST_CASE("Device reduce works with default environment", "[reduce][device]")
 {
   using num_items_t = int;
@@ -89,12 +101,12 @@ TEST_CASE("Device reduce works with default environment", "[reduce][device]")
   REQUIRE(cudaSuccess == cub::detail::ptx_compute_cap(cc, current_device));
 
   unsigned int target_block_size =
-    cub::detail::reduce::policy_selector_from_types<value_t, offset_t, block_size_check_t>{}(cc)
+    cub::detail::reduce::policy_selector_from_types<value_t, offset_t, block_size_check_plus_t>{}(cc)
       .single_tile.threads_per_block;
 
   num_items_t num_items = 1;
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
+  block_size_check_plus_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
   auto d_in  = cuda::constant_iterator(value_t{1});
   auto d_out = thrust::device_vector<value_t>(1);
 
@@ -109,7 +121,6 @@ TEST_CASE("Device Sum works with default environment", "[reduce][device]")
 {
   using num_items_t = int;
   using value_t     = int;
-  using offset_t    = cub::detail::choose_offset_t<num_items_t>;
 
   int current_device{};
   REQUIRE(cudaSuccess == cudaGetDevice(&current_device));
@@ -125,36 +136,94 @@ TEST_CASE("Device Sum works with default environment", "[reduce][device]")
   REQUIRE(cudaSuccess == cub::DeviceReduce::Sum(d_in, d_out.begin(), num_items));
   REQUIRE(d_out[0] == num_items);
 }
+#endif
 
+#if TEST_LAUNCH != 1
 C2H_TEST("Device reduce can be tuned", "[reduce][device]", block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
 
-  auto num_items = 1;
-  auto d_in      = cuda::constant_iterator(1);
-  auto d_out     = thrust::device_vector<int>(1);
+  auto d_in  = block_size_extracting_constant_iterator(1, thrust::raw_pointer_cast(d_block_size.data()));
+  auto d_out = thrust::device_vector<int>(1);
 
-  // We are expecting that `unrelated_tuning` is ignored
   auto env = cuda::execution::tune(
-    reduce_tuning<target_block_size>{},
-    unrelated_tuning{}
-#  if _CCCL_CUDA_COMPILER(NVCC, >=, 12, 9)
-    // some rare combinations, like nvcc 12.0 + clang-14 in C++20, or nvcc 12.0 + GCC12 fail with:
-    // pod_tuple.h(130): error: Internal Compiler Error (codegen): "internal error during structure layout!"
-    ,
-    unrelated_nondeterminisitc_reduce_tuning{}
-#  endif // _CCCL_CUDA_COMPILER(NVCC, >=, 12, 9)
+    reduce_tuning<target_block_size>{}, // <-- should be taken
+    unrelated_tuning{}, // should be ignored
+    nondeterministic_reduce_tuning<target_block_size * 2>{}, // should be ignored
+    deterministic_reduce_tuning<target_block_size * 2>{} // should be ignored
   );
 
-  REQUIRE(cudaSuccess == cub::DeviceReduce::Reduce(d_in, d_out.begin(), num_items, block_size_check, 0, env));
-  REQUIRE(d_out[0] == num_items);
+  device_reduce(d_in, d_out.begin(), 1, ::cuda::std::plus<>{}, 0, env);
+  REQUIRE(d_out[0] == 1);
   REQUIRE(d_block_size[0] == target_block_size);
 }
-#endif
 
-#if TEST_LAUNCH != 1
+C2H_TEST("Device reduce not_guaranteed can be tuned", "[reduce][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<unsigned int> d_block_size(1);
+
+  auto d_in  = block_size_extracting_constant_iterator(1, thrust::raw_pointer_cast(d_block_size.data()));
+  auto d_out = thrust::device_vector<int>(1);
+
+  auto env = cuda::std::execution::env{
+    cuda::execution::require(cuda::execution::determinism::not_guaranteed),
+    cuda::execution::tune(
+      reduce_tuning<target_block_size * 2>{}, // should be ignored
+      unrelated_tuning{}, // should be ignored
+      nondeterministic_reduce_tuning<target_block_size>{}, // <-- should be taken
+      deterministic_reduce_tuning<target_block_size * 2>{} // should be ignored
+      )};
+
+  device_reduce(d_in, d_out.begin(), 1, ::cuda::std::plus<>{}, 0, env);
+  REQUIRE(d_out[0] == 1);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+C2H_TEST("Device reduce run_to_run can be tuned", "[reduce][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<unsigned int> d_block_size(1);
+
+  auto d_in  = block_size_extracting_constant_iterator(1, thrust::raw_pointer_cast(d_block_size.data()));
+  auto d_out = thrust::device_vector<int>(1);
+
+  auto env = cuda::std::execution::env{
+    cuda::execution::require(cuda::execution::determinism::run_to_run),
+    cuda::execution::tune(
+      reduce_tuning<target_block_size>{}, // <-- should be taken
+      unrelated_tuning{}, // should be ignored
+      nondeterministic_reduce_tuning<target_block_size * 2>{}, // should be ignored
+      deterministic_reduce_tuning<target_block_size * 2>{} // should be ignored
+      )};
+
+  device_reduce(d_in, d_out.begin(), 1, ::cuda::std::plus<>{}, 0, env);
+  REQUIRE(d_out[0] == 1);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("Device reduce gpu_to_gpu can be tuned", "[reduce][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<unsigned int> d_block_size(1);
+
+  auto d_in  = block_size_extracting_constant_iterator(1, thrust::raw_pointer_cast(d_block_size.data()));
+  auto d_out = thrust::device_vector<int>(1);
+
+  auto env = cuda::std::execution::env{
+    cuda::execution::require(cuda::execution::determinism::gpu_to_gpu),
+    cuda::execution::tune(
+      reduce_tuning<target_block_size * 2>{}, // should be ignored
+      unrelated_tuning{}, // should be ignored
+      nondeterministic_reduce_tuning<target_block_size * 2>{}, // // should be ignored
+      deterministic_reduce_tuning<target_block_size>{} // <-- should be taken
+      )};
+
+  device_reduce(d_in, d_out.begin(), 1, ::cuda::std::plus<float>{}, 0, env); // make accum_t float to select RFA
+  REQUIRE(d_out[0] == 1);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
 C2H_TEST("Device Sum can be tuned", "[reduce][device]", block_sizes)
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
@@ -208,15 +277,14 @@ C2H_TEST("Device TransformReduce can be tuned", "[reduce][device]", block_sizes)
   auto d_in  = block_size_extracting_constant_iterator(1, thrust::raw_pointer_cast(d_block_size.data()));
   auto d_out = c2h::device_vector<int>(1);
 
-  // We are expecting that `unrelated_tuning` is ignored
   auto env = cuda::execution::tune(
     reduce_tuning<target_block_size>{},
-    unrelated_tuning{}
+    unrelated_tuning{} // should be ignored
 #  if _CCCL_CUDA_COMPILER(NVCC, >=, 12, 9)
     // some rare combinations, like nvcc 12.0 + clang-14 in C++20, or nvcc 12.0 + GCC12 fail with:
     // pod_tuple.h(130): error: Internal Compiler Error (codegen): "internal error during structure layout!"
     ,
-    unrelated_nondeterminisitc_reduce_tuning{}
+    nondeterministic_reduce_tuning<target_block_size * 2>{} // should be ignored
 #  endif // _CCCL_CUDA_COMPILER(NVCC, >=, 12, 9)
   );
 

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -159,7 +159,7 @@ C2H_TEST("Device reduce can be tuned", "[reduce][device]", block_sizes)
     deterministic_reduce_tuning<target_block_size * 2>{} // should be ignored
   );
 
-  device_reduce(d_in, d_out.begin(), 1, ::cuda::std::plus<>{}, 0, env);
+  device_reduce(d_in, d_out.begin(), 1, cuda::std::plus<>{}, 0, env);
   REQUIRE(d_out[0] == 1);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -183,7 +183,7 @@ C2H_TEST("Device reduce not_guaranteed can be tuned", "[reduce][device]", block_
       deterministic_reduce_tuning<target_block_size * 2>{} // should be ignored
       )};
 
-  device_reduce(d_in, d_out.begin(), 1, ::cuda::std::plus<>{}, 0, env);
+  device_reduce(d_in, d_out.begin(), 1, cuda::std::plus<>{}, 0, env);
   REQUIRE(d_out[0] == 1);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -206,7 +206,7 @@ C2H_TEST("Device reduce run_to_run can be tuned", "[reduce][device]", block_size
       deterministic_reduce_tuning<target_block_size * 2>{} // should be ignored
       )};
 
-  device_reduce(d_in, d_out.begin(), 1, ::cuda::std::plus<>{}, 0, env);
+  device_reduce(d_in, d_out.begin(), 1, cuda::std::plus<>{}, 0, env);
   REQUIRE(d_out[0] == 1);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -230,7 +230,7 @@ C2H_TEST("Device reduce gpu_to_gpu can be tuned", "[reduce][device]", block_size
       deterministic_reduce_tuning<target_block_size>{} // <-- should be taken
       )};
 
-  device_reduce(d_in, d_out.begin(), 1, ::cuda::std::plus<float>{}, 0, env); // make accum_t float to select RFA
+  device_reduce(d_in, d_out.begin(), 1, cuda::std::plus<float>{}, 0, env); // make accum_t float to select RFA
   REQUIRE(d_out[0] == 1);
   REQUIRE(d_block_size[0] == target_block_size);
 }


### PR DESCRIPTION
- [x] Merge before: #8851
- [x] #8884
- [x] #8897
- [x] No SASS changes on `cub.bench.reduce.sum.base` on SM`75;100`
- [x] No SASS changes on `cub.bench.reduce.nondeterministic.base` on SM`75;100`
- [x] No SASS changes on `cub.bench.reduce.deterministic.base` on SM`75;86;90`
- [x] No SASS changes on `cub.bench.reduce.arg_extrema.base` on SM`75;86;90` (diffed with #8897)

Fixes: #7948
Fixes: #7951
Fixes: #7960
Fixes: #7957