### PR TITLE
Final env-passthrough 1/4

### DIFF
--- a/cub/cub/device/device_segmented_radix_sort.cuh
+++ b/cub/cub/device/device_segmented_radix_sort.cuh
@@ -458,7 +458,7 @@ public:
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_radix_sort_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-radix-sort-pairs-env
@@ -612,7 +612,7 @@ public:
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_radix_sort_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-radix-sort-pairs-db-env
@@ -926,7 +926,6 @@ public:
   //!   outside the specified segments ``d_keys.Current()[i]``,
   //!   ``d_values.Current()[i]``, ``d_keys.Alternate()[i]``,
   //!   ``d_values.Alternate()[i]`` will not be accessed nor modified.
-  //!   not to be modified.
   //! - Note, the size of any segment may not exceed ``INT_MAX``. Please consider using ``DeviceSegmentedSort`` instead,
   //!   if the size of at least one of your segments could exceed ``INT_MAX``.
   //! - @devicestorageP
@@ -1111,7 +1110,7 @@ public:
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_radix_sort_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-radix-sort-pairs-descending-env
@@ -1265,7 +1264,7 @@ public:
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_radix_sort_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-radix-sort-pairs-descending-db-env
@@ -1738,7 +1737,7 @@ public:
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_radix_sort_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-radix-sort-keys-env
@@ -1879,7 +1878,7 @@ public:
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_radix_sort_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-radix-sort-keys-db-env
@@ -2340,7 +2339,7 @@ public:
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_radix_sort_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-radix-sort-keys-descending-env
@@ -2479,7 +2478,7 @@ public:
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_radix_sort_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-radix-sort-keys-descending-db-env

--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -311,7 +311,13 @@ public:
   //!
   //! The code snippet below illustrates a custom min-reduction of a device vector of ``int`` data elements.
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin segmented-reduce-custommin
+  //!     :end-before: example-end segmented-reduce-custommin
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-reduce-reduce
@@ -447,13 +453,13 @@ public:
   //!
   //! The code snippet below illustrates a custom min-reduction of a device vector of ``int`` data elements.
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-reduce-reduce-env
   //!     :end-before: example-end segmented-reduce-reduce-env
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-reduce-reduce-env-determinism
@@ -557,7 +563,13 @@ public:
   //!
   //! The code snippet below illustrates a custom min-reduction of a device vector of ``int`` data elements.
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin segmented-reduce-custommin
+  //!     :end-before: example-end segmented-reduce-custommin
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin fixed-size-segmented-reduce-reduce
@@ -631,13 +643,7 @@ public:
   //!    First appears in CUDA Toolkit 13.4.
   //!
   //! - Does not support binary reduction operators that are non-commutative.
-  //! - Provides "run-to-run" determinism for pseudo-associative reduction
-  //!   (e.g., addition of floating point types) on the same GPU device.
-  //!   However, results for pseudo-associative reduction may be inconsistent
-  //!   from one device to a another device of a different compute-capability
-  //!   because CUB can employ different tile-sizing for different architectures.
   //! - Can use a specific stream or cuda memory resource through the ``env`` parameter
-  //! - @devicestorage
   //!
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
@@ -746,7 +752,7 @@ public:
   //!
   //! The code snippet below illustrates the sum reduction of a device vector of ``int`` data elements.
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-reduce-sum
@@ -858,15 +864,14 @@ public:
   //!   overlap ``[d_in + d_begin_offsets[s], d_in + d_end_offsets[s])``,
   //!   ``[d_begin_offsets, d_begin_offsets + num_segments)`` nor
   //!   ``[d_end_offsets, d_end_offsets + num_segments)``.
-  //! - Can use a specific stream or cuda memory resource through the `env` parameter.
-  //! - @devicestorage
+  //! - Can use a specific stream or cuda memory resource through the ``env`` parameter.
   //!
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
   //! The code snippet below illustrates the sum reduction of a device vector of ``int`` data elements.
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-reduce-sum-env
@@ -956,7 +961,7 @@ public:
   //!
   //! The code snippet below illustrates the sum reduction of a device vector of ``int`` data elements.
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin fixed-size-segmented-reduce-sum
@@ -1012,15 +1017,13 @@ public:
   }
 
   //! @rst
-  //! Computes a device-wide segmented sum using the addition (``+``) operator
-  //! and a fixed segment size.
+  //! Computes a device-wide segmented sum using the addition (``+``) operator.
   //!
   //! .. versionadded:: 3.4.0
   //!    First appears in CUDA Toolkit 13.4.
   //!
   //! - Uses ``0`` as the initial value of the reduction for each segment.
   //! - Can use a specific stream or cuda memory resource through the ``env`` parameter
-  //! - @devicestorage
   //!
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
@@ -1110,13 +1113,7 @@ public:
   //!
   //! The code snippet below illustrates the min-reduction of a device vector of ``int`` data elements.
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_api.cu
-  //!     :language: c++
-  //!     :dedent:
-  //!     :start-after: example-begin segmented-reduce-custommin
-  //!     :end-before: example-end segmented-reduce-custommin
-  //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-reduce-min
@@ -1214,8 +1211,7 @@ public:
   }
 
   //! @rst
-  //! Computes a device-wide segmented minimum using the less-than (``<``) operator
-  //! and a fixed segment size.
+  //! Computes a device-wide segmented minimum using the less-than (``<``) operator.
   //!
   //! .. versionadded:: 3.4.0
   //!    First appears in CUDA Toolkit 13.4.
@@ -1238,7 +1234,7 @@ public:
   //!
   //! The code snippet below illustrates the min-reduction of a device vector of ``int`` data elements.
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-reduce-min-env
@@ -1330,13 +1326,7 @@ public:
   //!
   //! The code snippet below illustrates the min-reduction of a device vector of ``int`` data elements.
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_api.cu
-  //!     :language: c++
-  //!     :dedent:
-  //!     :start-after: example-begin segmented-reduce-custommin
-  //!     :end-before: example-end segmented-reduce-custommin
-  //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin fixed-size-segmented-reduce-min
@@ -1400,15 +1390,13 @@ public:
   }
 
   //! @rst
-  //! Computes a device-wide segmented minimum using the less-than (``<``) operator
-  //! and a fixed segment size.
+  //! Computes a device-wide segmented minimum using the less-than (``<``) operator.
   //!
   //! .. versionadded:: 3.4.0
   //!    First appears in CUDA Toolkit 13.4.
   //!
   //! - Uses ``::cuda::std::numeric_limits<T>::max()`` as the initial value of the reduction for each segment.
   //! - Can use a specific stream or cuda memory resource through the ``env`` parameter
-  //! - @devicestorage
   //!
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
@@ -1514,7 +1502,7 @@ public:
   //!
   //! The code snippet below illustrates the argmin-reduction of a device vector of ``int`` data elements.
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-reduce-argmin
@@ -1642,18 +1630,13 @@ public:
   //!
   //!   - The minimum of the *i*\ :sup:`th` segment is written to
   //!     ``d_out[i].value`` and its offset in that segment is written to ``d_out[i].key``.
-  //!   - The ``{1, std::numeric_limits<T>::max()}`` tuple is produced for zero-length inputs
+  //!   - The ``{1, ::cuda::std::numeric_limits<T>::max()}`` tuple is produced for zero-length inputs
   //!
-  //! - Does not support ``<`` operators that are non-commutative.
-  //! - Provides "run-to-run" determinism for pseudo-associative reduction
-  //!   (e.g., addition of floating point types) on the same GPU device.
-  //!   However, results for pseudo-associative reduction may be inconsistent
-  //!   from one device to a another device of a different compute-capability
-  //!   because CUB can employ different tile-sizing for different architectures.
   //! - When input a contiguous sequence of segments, a single sequence
   //!   ``segment_offsets`` (of length ``num_segments + 1``) can be aliased
   //!   for both the ``d_begin_offsets`` and ``d_end_offsets`` parameters (where
   //!   the latter is specified as ``segment_offsets + 1``).
+  //! - Does not support ``<`` operators that are non-commutative.
   //! - Let ``s`` be in ``[0, num_segments)``. The range
   //!   ``[d_out + d_begin_offsets[s], d_out + d_end_offsets[s])`` shall not
   //!   overlap ``[d_in + d_begin_offsets[s], d_in + d_end_offsets[s])``,
@@ -1666,7 +1649,7 @@ public:
   //!
   //! The code snippet below illustrates the argmin-reduction of a device vector of ``int`` data elements.
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-reduce-argmin-env
@@ -1777,7 +1760,7 @@ public:
   //!
   //! The code snippet below illustrates the argmin-reduction of a device vector of ``int`` data elements.
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin fixed-size-segmented-reduce-argmin
@@ -1832,8 +1815,7 @@ public:
 
   //! @rst
   //! Finds the first device-wide minimum in each segment using the
-  //! less-than (``<``) operator, also returning the in-segment index of that item,
-  //! with a fixed segment size.
+  //! less-than (``<``) operator, also returning the in-segment index of that item.
   //!
   //! .. versionadded:: 3.4.0
   //!    First appears in CUDA Toolkit 13.4.
@@ -1845,7 +1827,6 @@ public:
   //!     ``d_out[i].second`` and its offset in that segment is written to ``d_out[i].first``.
   //!   - The ``{1, ::cuda::std::numeric_limits<T>::max()}`` tuple is produced for zero-length inputs
   //! - Can use a specific stream or cuda memory resource through the ``env`` parameter
-  //! - @devicestorage
   //!
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
@@ -1916,7 +1897,7 @@ public:
   //!
   //! The code snippet below illustrates the max-reduction of a device vector of ``int`` data elements.
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-reduce-max
@@ -2038,7 +2019,7 @@ public:
   //!
   //! The code snippet below illustrates the max-reduction of a device vector of ``int`` data elements.
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-reduce-max-env
@@ -2137,7 +2118,7 @@ public:
   //!
   //! The code snippet below illustrates the max-reduction of a device vector of ``int`` data elements.
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin fixed-size-segmented-reduce-max
@@ -2201,15 +2182,13 @@ public:
   }
 
   //! @rst
-  //! Computes a device-wide segmented maximum using the greater-than (``>``) operator
-  //! and a fixed segment size.
+  //! Computes a device-wide segmented maximum using the greater-than (``>``) operator.
   //!
   //! .. versionadded:: 3.4.0
   //!    First appears in CUDA Toolkit 13.4.
   //!
   //! - Uses ``::cuda::std::numeric_limits<T>::lowest()`` as the initial value of the reduction.
   //! - Can use a specific stream or cuda memory resource through the ``env`` parameter
-  //! - @devicestorage
   //!
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
@@ -2314,7 +2293,7 @@ public:
   //! The code snippet below illustrates the argmax-reduction of a device vector
   //! of `int` data elements.
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-reduce-argmax
@@ -2434,7 +2413,7 @@ public:
 
   //! @rst
   //! Finds the first device-wide maximum in each segment using the
-  //! greater-than (``>``) operator, also returning the in-segment index of that item.
+  //! greater-than (``>``) operator, also returning the in-segment index of that item
   //!
   //! .. versionadded:: 3.4.0
   //!    First appears in CUDA Toolkit 13.4.
@@ -2446,16 +2425,11 @@ public:
   //!     ``d_out[i].value`` and its offset in that segment is written to ``d_out[i].key``.
   //!   - The ``{1, ::cuda::std::numeric_limits<T>::lowest()}`` tuple is produced for zero-length inputs
   //!
-  //! - Does not support ``>`` operators that are non-commutative.
-  //! - Provides "run-to-run" determinism for pseudo-associative reduction
-  //!   (e.g., addition of floating point types) on the same GPU device.
-  //!   However, results for pseudo-associative reduction may be inconsistent
-  //!   from one device to a another device of a different compute-capability
-  //!   because CUB can employ different tile-sizing for different architectures.
   //! - When input a contiguous sequence of segments, a single sequence
   //!   ``segment_offsets`` (of length ``num_segments + 1``) can be aliased
   //!   for both the ``d_begin_offsets`` and ``d_end_offsets`` parameters (where
   //!   the latter is specified as ``segment_offsets + 1``).
+  //! - Does not support ``>`` operators that are non-commutative.
   //! - Let ``s`` be in ``[0, num_segments)``. The range
   //!   ``[d_out + d_begin_offsets[s], d_out + d_end_offsets[s])`` shall not
   //!   overlap ``[d_in + d_begin_offsets[s], d_in + d_end_offsets[s])``,
@@ -2468,7 +2442,7 @@ public:
   //!
   //! The code snippet below illustrates the argmax-reduction of a device vector of ``int`` data elements.
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin segmented-reduce-argmax-env
@@ -2580,7 +2554,7 @@ public:
   //! The code snippet below illustrates the argmax-reduction of a device vector
   //! of `int` data elements.
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin fixed-size-segmented-reduce-argmax
@@ -2637,20 +2611,18 @@ public:
 
   //! @rst
   //! Finds the first device-wide maximum in each segment using the
-  //! greater-than (``>``) operator, also returning the in-segment index of that item,
-  //! with a fixed segment size.
+  //! greater-than (``>``) operator, also returning the in-segment index of that item
   //!
   //! .. versionadded:: 3.4.0
   //!    First appears in CUDA Toolkit 13.4.
   //!
-  //! - The output value type of ``d_out`` is ``cuda::std::pair<int, T>``
+  //! - The output value type of ``d_out`` is ``::cuda::std::pair<int, T>``
   //!   (assuming the value type of ``d_in`` is ``T``)
   //!
   //!   - The maximum of the *i*\ :sup:`th` segment is written to
   //!     ``d_out[i].second`` and its offset in that segment is written to ``d_out[i].first``.
   //!   - The ``{1, ::cuda::std::numeric_limits<T>::lowest()}`` tuple is produced for zero-length inputs
   //! - Can use a specific stream or cuda memory resource through the ``env`` parameter
-  //! - @devicestorage
   //!
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++

--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -643,6 +643,11 @@ public:
   //!    First appears in CUDA Toolkit 13.4.
   //!
   //! - Does not support binary reduction operators that are non-commutative.
+  //! - Provides "run-to-run" determinism for pseudo-associative reduction
+  //!   (e.g., addition of floating point types) on the same GPU device.
+  //!   However, results for pseudo-associative reduction may be inconsistent
+  //!   from one device to a another device of a different compute-capability
+  //!   because CUB can employ different tile-sizing for different architectures.
   //! - Can use a specific stream or cuda memory resource through the ``env`` parameter
   //!
   //! Snippet
@@ -1017,7 +1022,8 @@ public:
   }
 
   //! @rst
-  //! Computes a device-wide segmented sum using the addition (``+``) operator.
+  //! Computes a device-wide segmented sum using the addition (``+``) operator
+  //! and a fixed segment size.
   //!
   //! .. versionadded:: 3.4.0
   //!    First appears in CUDA Toolkit 13.4.
@@ -1390,7 +1396,8 @@ public:
   }
 
   //! @rst
-  //! Computes a device-wide segmented minimum using the less-than (``<``) operator.
+  //! Computes a device-wide segmented minimum using the less-than (``<``) operator
+  //! and a fixed segment size.
   //!
   //! .. versionadded:: 3.4.0
   //!    First appears in CUDA Toolkit 13.4.
@@ -1815,7 +1822,8 @@ public:
 
   //! @rst
   //! Finds the first device-wide minimum in each segment using the
-  //! less-than (``<``) operator, also returning the in-segment index of that item.
+  //! less-than (``<``) operator, also returning the in-segment index of that item,
+  //! with a fixed segment size.
   //!
   //! .. versionadded:: 3.4.0
   //!    First appears in CUDA Toolkit 13.4.
@@ -2182,7 +2190,8 @@ public:
   }
 
   //! @rst
-  //! Computes a device-wide segmented maximum using the greater-than (``>``) operator.
+  //! Computes a device-wide segmented maximum using the greater-than (``>``) operator
+  //! and a fixed segment size.
   //!
   //! .. versionadded:: 3.4.0
   //!    First appears in CUDA Toolkit 13.4.
@@ -2611,7 +2620,8 @@ public:
 
   //! @rst
   //! Finds the first device-wide maximum in each segment using the
-  //! greater-than (``>``) operator, also returning the in-segment index of that item
+  //! greater-than (``>``) operator, also returning the in-segment index of that item,
+  //! with a fixed segment size.
   //!
   //! .. versionadded:: 3.4.0
   //!    First appears in CUDA Toolkit 13.4.

--- a/cub/cub/device/device_segmented_sort.cuh
+++ b/cub/cub/device/device_segmented_sort.cuh
@@ -329,7 +329,7 @@ public:
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_sort_keys_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_sort_keys_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin sort-keys-env
@@ -574,7 +574,7 @@ public:
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_sort_keys_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_sort_keys_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin sort-keys-descending-env
@@ -830,7 +830,7 @@ public:
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_sort_keys_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_sort_keys_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin sort-keys-db-env
@@ -1077,7 +1077,7 @@ public:
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_sort_keys_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_sort_keys_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin sort-keys-descending-db-env
@@ -1317,7 +1317,7 @@ public:
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_sort_keys_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_sort_keys_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin stable-sort-keys-env
@@ -1566,7 +1566,7 @@ public:
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_sort_keys_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_sort_keys_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin stable-sort-keys-descending-env
@@ -1828,7 +1828,7 @@ public:
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_sort_keys_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_sort_keys_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin stable-sort-keys-db-env
@@ -1930,7 +1930,7 @@ public:
   //!   ``[alt, alt + num_items)``. Both ranges shall not overlap
   //!   ``[d_begin_offsets, d_begin_offsets + num_segments)`` nor
   //!   ``[d_end_offsets, d_end_offsets + num_segments)`` in any way.
-  //! - Segments are not required to be contiguous. For all index values ```i`
+  //! - Segments are not required to be contiguous. For all index values ``i``
   //!   outside the specified segments ``d_keys.Current()[i]``,
   //!   ``d_keys[i].Alternate()[i]`` will not be accessed nor modified.
   //!
@@ -2078,7 +2078,7 @@ public:
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
-  //! .. literalinclude:: ../../test/catch2_test_device_segmented_sort_keys_env_api.cu
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_sort_keys_env_api.cu
   //!     :language: c++
   //!     :dedent:
   //!     :start-after: example-begin stable-sort-keys-descending-db-env
@@ -2518,7 +2518,7 @@ public:
   //!   for both the ``d_begin_offsets`` and ``d_end_offsets`` parameters (where
   //!   the latter is specified as ``segment_offsets + 1``).
   //! - SortPairsDescending is not guaranteed to be stable. That is, suppose that
-  // ``i`` and ``j`` are equivalent: neither one is less than the other. It is not
+  //!   ``i`` and ``j`` are equivalent: neither one is less than the other. It is not
   //!   guaranteed that the relative order of these two elements will be
   //!   preserved by sort.
   //! - Let ``in`` be one of ``{d_keys_in, d_values_in}`` and ``out`` be any of
@@ -4149,11 +4149,25 @@ public:
   //!   within each DoubleBuffer wrapper to reference which of the two buffers
   //!   now contains the sorted output sequence (a function of the number of key bits
   //!   specified and the targeted device architecture).
+  //! - When the input is a contiguous sequence of segments, a single sequence
+  //!   ``segment_offsets`` (of length ``num_segments + 1``) can be aliased
+  //!   for both the ``d_begin_offsets`` and ``d_end_offsets`` parameters (where
+  //!   the latter is specified as ``segment_offsets + 1``).
   //! - StableSortPairs is stable: it preserves the relative ordering of
   //!   equivalent elements. That is, if ``x`` and ``y`` are elements such that
   //!   ``x`` precedes ``y``, and if the two elements are equivalent (neither
   //!   ``x < y`` nor ``y < x``) then a postcondition of stable sort is that
   //!   ``x`` still precedes ``y``.
+  //! - Let ``cur`` be one of ``{d_keys.Current(), d_values.Current()}`` and ``alt``
+  //!   be any of ``{d_keys.Alternate(), d_values.Alternate()}``. The range
+  //!   ``[cur, cur + num_items)`` shall not overlap
+  //!   ``[alt, alt + num_items)``. Both ranges shall not overlap
+  //!   ``[d_begin_offsets, d_begin_offsets + num_segments)`` nor
+  //!   ``[d_end_offsets, d_end_offsets + num_segments)`` in any way.
+  //! - Segments are not required to be contiguous. For all index values ``i``
+  //!   outside the specified segments ``d_keys.Current()[i]``,
+  //!   ``d_values.Current()[i]``, ``d_keys.Alternate()[i]``,
+  //!   ``d_values.Alternate()[i]`` will not be accessed nor modified.
   //!
   //! Snippet
   //!
@@ -4432,11 +4446,25 @@ public:
   //!   within each DoubleBuffer wrapper to reference which of the two buffers
   //!   now contains the sorted output sequence (a function of the number of key bits
   //!   specified and the targeted device architecture).
+  //! - When the input is a contiguous sequence of segments, a single sequence
+  //!   ``segment_offsets`` (of length ``num_segments + 1``) can be aliased
+  //!   for both the ``d_begin_offsets`` and ``d_end_offsets`` parameters (where
+  //!   the latter is specified as ``segment_offsets + 1``).
   //! - StableSortPairsDescending is stable: it preserves the relative ordering
   //!   of equivalent elements. That is, if ``x`` and ``y`` are elements such that
   //!   ``x`` precedes ``y``, and if the two elements are equivalent (neither
   //!   ``x < y`` nor ``y < x``) then a postcondition of stable sort is that
   //!   ``x`` still precedes ``y``.
+  //! - Let ``cur`` be one of ``{d_keys.Current(), d_values.Current()}`` and ``alt``
+  //!   be any of ``{d_keys.Alternate(), d_values.Alternate()}``. The range
+  //!   ``[cur, cur + num_items)`` shall not overlap
+  //!   ``[alt, alt + num_items)``. Both ranges shall not overlap
+  //!   ``[d_begin_offsets, d_begin_offsets + num_segments)`` nor
+  //!   ``[d_end_offsets, d_end_offsets + num_segments)`` in any way.
+  //! - Segments are not required to be contiguous. For all index values ``i``
+  //!   outside the specified segments ``d_keys.Current()[i]``,
+  //!   ``d_values.Current()[i]``, ``d_keys.Alternate()[i]``,
+  //!   ``d_values.Alternate()[i]`` will not be accessed nor modified.
   //!
   //! Snippet
   //!

--- a/cub/test/catch2_test_device_memcpy_env_api.cu
+++ b/cub/test/catch2_test_device_memcpy_env_api.cu
@@ -46,14 +46,13 @@ C2H_TEST("cub::DeviceMemcpy::Batched accepts env with stream", "[memcpy][env]")
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceMemcpy::Batched(
     thrust::raw_pointer_cast(d_src_ptrs.data()),
     thrust::raw_pointer_cast(d_dst_ptrs.data()),
     thrust::raw_pointer_cast(d_sizes.data()),
     num_buffers,
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceMemcpy::Batched failed with status: " << error << '\n';
@@ -63,6 +62,7 @@ C2H_TEST("cub::DeviceMemcpy::Batched accepts env with stream", "[memcpy][env]")
   thrust::device_vector<int> expected_b{60};
   // example-end memcpy-batched-env
 
+  stream.sync();
   REQUIRE(error == cudaSuccess);
   REQUIRE(d_dst_a == expected_a);
   REQUIRE(d_dst_b == expected_b);

--- a/cub/test/catch2_test_device_merge_env_api.cu
+++ b/cub/test/catch2_test_device_merge_env_api.cu
@@ -23,7 +23,6 @@ C2H_TEST("cub::DeviceMerge::MergeKeys accepts env with stream", "[merge][env]")
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceMerge::MergeKeys(
     keys1.begin(),
@@ -32,7 +31,7 @@ C2H_TEST("cub::DeviceMerge::MergeKeys accepts env with stream", "[merge][env]")
     static_cast<int>(keys2.size()),
     result.begin(),
     cuda::std::less<>{},
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceMerge::MergeKeys failed with status: " << error << '\n';
@@ -41,6 +40,7 @@ C2H_TEST("cub::DeviceMerge::MergeKeys accepts env with stream", "[merge][env]")
   thrust::device_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
   // example-end merge-keys-env
 
+  stream.sync();
   REQUIRE(error == cudaSuccess);
   REQUIRE(result == expected);
 }
@@ -58,7 +58,6 @@ C2H_TEST("cub::DeviceMerge::MergePairs accepts env with stream", "[merge][env]")
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceMerge::MergePairs(
     keys1.begin(),
@@ -70,7 +69,7 @@ C2H_TEST("cub::DeviceMerge::MergePairs accepts env with stream", "[merge][env]")
     result_keys.begin(),
     result_values.begin(),
     cuda::std::less<>{},
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceMerge::MergePairs failed with status: " << error << '\n';
@@ -80,6 +79,7 @@ C2H_TEST("cub::DeviceMerge::MergePairs accepts env with stream", "[merge][env]")
   thrust::device_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
   // example-end merge-pairs-env
 
+  stream.sync();
   REQUIRE(error == cudaSuccess);
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);

--- a/cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
@@ -25,7 +25,6 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortPairs env with stream", "[segmented
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceSegmentedRadixSort::SortPairs(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -38,7 +37,7 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortPairs env with stream", "[segmented
     offsets.begin() + 1,
     0,
     static_cast<int>(sizeof(int) * 8),
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceSegmentedRadixSort::SortPairs failed with status: " << error << '\n';
@@ -65,7 +64,6 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortPairsDescending env with stream", "
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceSegmentedRadixSort::SortPairsDescending(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -78,7 +76,7 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortPairsDescending env with stream", "
     offsets.begin() + 1,
     0,
     static_cast<int>(sizeof(int) * 8),
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceSegmentedRadixSort::SortPairsDescending failed with status: " << error << '\n';
@@ -103,7 +101,6 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortKeys env with stream", "[segmented_
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceSegmentedRadixSort::SortKeys(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -114,7 +111,7 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortKeys env with stream", "[segmented_
     offsets.begin() + 1,
     0,
     static_cast<int>(sizeof(int) * 8),
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceSegmentedRadixSort::SortKeys failed with status: " << error << '\n';
@@ -137,7 +134,6 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortKeysDescending env with stream", "[
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceSegmentedRadixSort::SortKeysDescending(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -148,7 +144,7 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortKeysDescending env with stream", "[
     offsets.begin() + 1,
     0,
     static_cast<int>(sizeof(int) * 8),
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceSegmentedRadixSort::SortKeysDescending failed with status: " << error << '\n';

--- a/cub/test/catch2_test_device_segmented_reduce_api.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_api.cu
@@ -8,6 +8,7 @@
 #include <thrust/device_vector.h>
 #include <thrust/equal.h>
 
+#include <cuda/std/functional>
 #include <cuda/std/utility>
 
 #include <climits>

--- a/cub/test/catch2_test_device_segmented_reduce_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_env_api.cu
@@ -133,10 +133,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::Reduce env-based API", "[segmented_reduce]
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = ::cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceSegmentedReduce::Reduce(
-    d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, ::cuda::std::plus<>{}, 0, env);
+    d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, ::cuda::std::plus<>{}, 0, stream_ref);
   thrust::device_vector<int> expected{21, 0, 17};
 
   if (error != cudaSuccess)
@@ -161,10 +160,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::Min env-based API", "[segmented_reduce][en
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = ::cuda::std::execution::env{stream_ref};
 
-  auto error =
-    cub::DeviceSegmentedReduce::Min(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
+  auto error = cub::DeviceSegmentedReduce::Min(
+    d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, stream_ref);
   thrust::device_vector<int> expected{6, std::numeric_limits<int>::max(), 0};
 
   if (error != cudaSuccess)
@@ -189,10 +187,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::Max env-based API", "[segmented_reduce][en
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = ::cuda::std::execution::env{stream_ref};
 
-  auto error =
-    cub::DeviceSegmentedReduce::Max(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
+  auto error = cub::DeviceSegmentedReduce::Max(
+    d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, stream_ref);
   thrust::device_vector<int> expected{8, std::numeric_limits<int>::lowest(), 9};
 
   if (error != cudaSuccess)
@@ -217,10 +214,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::ArgMin env-based API", "[segmented_reduce]
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = ::cuda::std::execution::env{stream_ref};
 
-  auto error =
-    cub::DeviceSegmentedReduce::ArgMin(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
+  auto error = cub::DeviceSegmentedReduce::ArgMin(
+    d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, stream_ref);
 
   if (error != cudaSuccess)
   {
@@ -244,10 +240,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::ArgMax env-based API", "[segmented_reduce]
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = ::cuda::std::execution::env{stream_ref};
 
-  auto error =
-    cub::DeviceSegmentedReduce::ArgMax(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
+  auto error = cub::DeviceSegmentedReduce::ArgMax(
+    d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, stream_ref);
 
   if (error != cudaSuccess)
   {
@@ -468,10 +463,9 @@ C2H_TEST("cub::DeviceSegmentedReduce::Reduce fixed-size env-based API", "[segmen
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = ::cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceSegmentedReduce::Reduce(
-    d_in.begin(), d_out.begin(), num_segments, segment_size, ::cuda::std::plus<>{}, 0, env);
+    d_in.begin(), d_out.begin(), num_segments, segment_size, ::cuda::std::plus<>{}, 0, stream_ref);
   thrust::device_vector<int> expected{21, 8};
 
   if (error != cudaSuccess)
@@ -495,9 +489,8 @@ C2H_TEST("cub::DeviceSegmentedReduce::Sum fixed-size env-based API", "[segmented
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = ::cuda::std::execution::env{stream_ref};
 
-  auto error = cub::DeviceSegmentedReduce::Sum(d_in.begin(), d_out.begin(), num_segments, segment_size, env);
+  auto error = cub::DeviceSegmentedReduce::Sum(d_in.begin(), d_out.begin(), num_segments, segment_size, stream_ref);
   thrust::device_vector<int> expected{21, 8};
 
   if (error != cudaSuccess)
@@ -521,9 +514,8 @@ C2H_TEST("cub::DeviceSegmentedReduce::Min fixed-size env-based API", "[segmented
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = ::cuda::std::execution::env{stream_ref};
 
-  auto error = cub::DeviceSegmentedReduce::Min(d_in.begin(), d_out.begin(), num_segments, segment_size, env);
+  auto error = cub::DeviceSegmentedReduce::Min(d_in.begin(), d_out.begin(), num_segments, segment_size, stream_ref);
   thrust::device_vector<int> expected{6, 0};
 
   if (error != cudaSuccess)
@@ -547,9 +539,8 @@ C2H_TEST("cub::DeviceSegmentedReduce::Max fixed-size env-based API", "[segmented
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = ::cuda::std::execution::env{stream_ref};
 
-  auto error = cub::DeviceSegmentedReduce::Max(d_in.begin(), d_out.begin(), num_segments, segment_size, env);
+  auto error = cub::DeviceSegmentedReduce::Max(d_in.begin(), d_out.begin(), num_segments, segment_size, stream_ref);
   thrust::device_vector<int> expected{8, 5};
 
   if (error != cudaSuccess)
@@ -573,9 +564,8 @@ C2H_TEST("cub::DeviceSegmentedReduce::ArgMin fixed-size env-based API", "[segmen
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = ::cuda::std::execution::env{stream_ref};
 
-  auto error = cub::DeviceSegmentedReduce::ArgMin(d_in.begin(), d_out.begin(), num_segments, segment_size, env);
+  auto error = cub::DeviceSegmentedReduce::ArgMin(d_in.begin(), d_out.begin(), num_segments, segment_size, stream_ref);
 
   if (error != cudaSuccess)
   {
@@ -598,9 +588,8 @@ C2H_TEST("cub::DeviceSegmentedReduce::ArgMax fixed-size env-based API", "[segmen
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = ::cuda::std::execution::env{stream_ref};
 
-  auto error = cub::DeviceSegmentedReduce::ArgMax(d_in.begin(), d_out.begin(), num_segments, segment_size, env);
+  auto error = cub::DeviceSegmentedReduce::ArgMax(d_in.begin(), d_out.begin(), num_segments, segment_size, stream_ref);
 
   if (error != cudaSuccess)
   {

--- a/cub/test/catch2_test_device_segmented_sort_keys_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys_env_api.cu
@@ -23,7 +23,6 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeys env-based API", "[segmented_sort][k
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceSegmentedSort::SortKeys(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -32,7 +31,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeys env-based API", "[segmented_sort][k
     2,
     thrust::raw_pointer_cast(offsets.data()),
     thrust::raw_pointer_cast(offsets.data()) + 1,
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceSegmentedSort::SortKeys failed with status: " << error << '\n';
@@ -41,6 +40,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeys env-based API", "[segmented_sort][k
   thrust::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
   // example-end sort-keys-env
 
+  stream.sync();
   REQUIRE(error == cudaSuccess);
   REQUIRE(keys_out == expected);
 }
@@ -54,7 +54,6 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeysDescending env-based API", "[segment
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceSegmentedSort::SortKeysDescending(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -63,7 +62,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeysDescending env-based API", "[segment
     2,
     thrust::raw_pointer_cast(offsets.data()),
     thrust::raw_pointer_cast(offsets.data()) + 1,
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceSegmentedSort::SortKeysDescending failed with status: " << error << '\n';
@@ -72,6 +71,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeysDescending env-based API", "[segment
   thrust::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
   // example-end sort-keys-descending-env
 
+  stream.sync();
   REQUIRE(error == cudaSuccess);
   REQUIRE(keys_out == expected);
 }
@@ -87,7 +87,6 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeys DoubleBuffer env-based API", "[segm
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceSegmentedSort::SortKeys(
     d_keys,
@@ -95,7 +94,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeys DoubleBuffer env-based API", "[segm
     2,
     thrust::raw_pointer_cast(offsets.data()),
     thrust::raw_pointer_cast(offsets.data()) + 1,
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceSegmentedSort::SortKeys (DoubleBuffer) failed with status: " << error << '\n';
@@ -104,6 +103,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeys DoubleBuffer env-based API", "[segm
   thrust::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
   // example-end sort-keys-db-env
 
+  stream.sync();
   REQUIRE(error == cudaSuccess);
   thrust::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);
@@ -120,7 +120,6 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeysDescending DoubleBuffer env-based AP
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceSegmentedSort::SortKeysDescending(
     d_keys,
@@ -128,7 +127,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeysDescending DoubleBuffer env-based AP
     2,
     thrust::raw_pointer_cast(offsets.data()),
     thrust::raw_pointer_cast(offsets.data()) + 1,
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceSegmentedSort::SortKeysDescending (DoubleBuffer) failed with status: " << error << '\n';
@@ -137,6 +136,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeysDescending DoubleBuffer env-based AP
   thrust::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
   // example-end sort-keys-descending-db-env
 
+  stream.sync();
   REQUIRE(error == cudaSuccess);
   thrust::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);
@@ -151,7 +151,6 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortKeys env-based API", "[segmented_s
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceSegmentedSort::StableSortKeys(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -160,7 +159,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortKeys env-based API", "[segmented_s
     2,
     thrust::raw_pointer_cast(offsets.data()),
     thrust::raw_pointer_cast(offsets.data()) + 1,
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceSegmentedSort::StableSortKeys failed with status: " << error << '\n';
@@ -169,6 +168,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortKeys env-based API", "[segmented_s
   thrust::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
   // example-end stable-sort-keys-env
 
+  stream.sync();
   REQUIRE(error == cudaSuccess);
   REQUIRE(keys_out == expected);
 }
@@ -182,7 +182,6 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortKeysDescending env-based API", "[s
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceSegmentedSort::StableSortKeysDescending(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -191,7 +190,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortKeysDescending env-based API", "[s
     2,
     thrust::raw_pointer_cast(offsets.data()),
     thrust::raw_pointer_cast(offsets.data()) + 1,
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceSegmentedSort::StableSortKeysDescending failed with status: " << error << '\n';
@@ -200,6 +199,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortKeysDescending env-based API", "[s
   thrust::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
   // example-end stable-sort-keys-descending-env
 
+  stream.sync();
   REQUIRE(error == cudaSuccess);
   REQUIRE(keys_out == expected);
 }
@@ -215,7 +215,6 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortKeys DoubleBuffer env-based API", 
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceSegmentedSort::StableSortKeys(
     d_keys,
@@ -223,7 +222,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortKeys DoubleBuffer env-based API", 
     2,
     thrust::raw_pointer_cast(offsets.data()),
     thrust::raw_pointer_cast(offsets.data()) + 1,
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceSegmentedSort::StableSortKeys (DoubleBuffer) failed with status: " << error << '\n';
@@ -232,6 +231,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortKeys DoubleBuffer env-based API", 
   thrust::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
   // example-end stable-sort-keys-db-env
 
+  stream.sync();
   REQUIRE(error == cudaSuccess);
   thrust::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);
@@ -248,7 +248,6 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortKeysDescending DoubleBuffer env-ba
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceSegmentedSort::StableSortKeysDescending(
     d_keys,
@@ -256,7 +255,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortKeysDescending DoubleBuffer env-ba
     2,
     thrust::raw_pointer_cast(offsets.data()),
     thrust::raw_pointer_cast(offsets.data()) + 1,
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr
@@ -266,6 +265,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortKeysDescending DoubleBuffer env-ba
   thrust::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
   // example-end stable-sort-keys-descending-db-env
 
+  stream.sync();
   REQUIRE(error == cudaSuccess);
   thrust::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);


### PR DESCRIPTION
Handles https://github.com/NVIDIA/cccl/issues/8175 for 

- `DeviceSegmentedSort`
- `DeviceRadixSort`
- `DeviceSegmentedReduce`
- `DeviceMemCpy`
- `DeviceMerge`

no serious issues found, fixes are predominantly in the docs and have to do with snippet paths (even for non-env algorithms) and documentation conformity between non-env and env counterparts.

It also mainly makes the api tests use the `stream_ref` directly and not wrapped to an env before passing it to the algorithm.