### PR TITLE
Remove numba-cuda upper bound while excluding versions that don't work

### DIFF
--- a/python/cuda_cccl/pyproject.toml
+++ b/python/cuda_cccl/pyproject.toml
@@ -56,22 +56,22 @@ minimal-sysctk13 = [
 cu12 = [
   "cuda-cccl[minimal-cu12]",
   "numba>=0.60.0",
-  "numba-cuda[cu12]>=0.23.0,<0.27.0",
+  "numba-cuda[cu12]>=0.23.0,!=0.27.*,!=0.28.*,!=0.29.*,!=0.30.0",
 ]
 cu13 = [
   "cuda-cccl[minimal-cu13]",
   "numba>=0.60.0",
-  "numba-cuda[cu13]>=0.23.0,<0.27.0",
+  "numba-cuda[cu13]>=0.23.0,!=0.27.*,!=0.28.*,!=0.29.*,!=0.30.0"
 ]
 sysctk12 = [
   "cuda-cccl[minimal-sysctk12]",
   "numba>=0.60.0",
-  "numba-cuda[cu12]>=0.23.0,<0.27.0",
+  "numba-cuda[cu12]>=0.23.0,!=0.27.*,!=0.28.*,!=0.29.*,!=0.30.0"
 ]
 sysctk13 = [
   "cuda-cccl[minimal-sysctk13]",
   "numba>=0.60.0",
-  "numba-cuda[cu13]>=0.23.0,<0.27.0",
+  "numba-cuda[cu13]>=0.23.0,!=0.27.*,!=0.28.*,!=0.29.*,!=0.30.0",
 ]
 test-cu12 = [
   # an undocumented way to inherit the dependencies of the cu12 extra.


### PR DESCRIPTION
## Description


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated numba-cuda dependency constraints to support additional versions across optional installation extras.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->