### PR TITLE
Rename `BlockThreads` to `ThreadsPerBlock`

### DIFF
--- a/c2h/include/c2h/fill_striped.h
+++ b/c2h/include/c2h/fill_striped.h
@@ -44,12 +44,12 @@ struct scalar_to_vec_t<VectorT, ::cuda::std::void_t<decltype(VectorT::x)>>
   }
 };
 
-template <int LogicalWarpThreads, int ItemsPerThread, int BlockThreads, typename IteratorT>
+template <int LogicalWarpThreads, int ItemsPerThread, int ThreadsPerBlock, typename IteratorT>
 void fill_striped(IteratorT it)
 {
   using T = cub::detail::it_value_t<IteratorT>;
 
-  constexpr int warps_in_block = BlockThreads / LogicalWarpThreads;
+  constexpr int warps_in_block = ThreadsPerBlock / LogicalWarpThreads;
   constexpr int items_per_warp = LogicalWarpThreads * ItemsPerThread;
   scalar_to_vec_t<T> convert;
 

--- a/cub/benchmarks/bench/segmented_scan/base.cuh
+++ b/cub/benchmarks/bench/segmented_scan/base.cuh
@@ -27,14 +27,14 @@
 #    define TUNE_LOAD_MODIFIER cub::LOAD_CA
 #  endif // TUNE_LOAD
 
-template <int BlockThreads, int ItemsPerThread, int MaxSegmentsPerBlock>
+template <int ThreadsPerBlock, int ItemsPerThread, int MaxSegmentsPerBlock>
 struct policy_selector_t
 {
   [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
     -> cub::detail::segmented_scan::segmented_scan_policy
   {
     return cub::detail::segmented_scan::segmented_scan_policy{cub::detail::segmented_scan::block_segmented_scan_policy{
-      BlockThreads,
+      ThreadsPerBlock,
       ItemsPerThread,
       TUNE_BLOCK_LOAD_ALGORITHM,
       TUNE_LOAD_MODIFIER,

--- a/cub/cub/agent/agent_adjacent_difference.cuh
+++ b/cub/cub/agent/agent_adjacent_difference.cuh
@@ -24,14 +24,14 @@
 
 CUB_NAMESPACE_BEGIN
 
-template <int BlockThreads,
+template <int ThreadsPerBlock,
           int ItemsPerThread                      = 1,
           cub::BlockLoadAlgorithm LoadAlgorithm   = cub::BLOCK_LOAD_DIRECT,
           cub::CacheLoadModifier LoadModifier     = cub::LOAD_LDG,
           cub::BlockStoreAlgorithm StoreAlgorithm = cub::BLOCK_STORE_DIRECT>
 struct AgentAdjacentDifferencePolicy
 {
-  static constexpr int BLOCK_THREADS    = BlockThreads;
+  static constexpr int BLOCK_THREADS    = ThreadsPerBlock;
   static constexpr int ITEMS_PER_THREAD = ItemsPerThread;
   static constexpr int ITEMS_PER_TILE   = BLOCK_THREADS * ITEMS_PER_THREAD;
 

--- a/cub/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/cub/agent/agent_batch_memcpy.cuh
@@ -448,7 +448,7 @@ private:
 /**
  * Parameterizable tuning policy type for AgentBatchMemcpy
  */
-template <uint32_t BlockThreads,
+template <uint32_t ThreadsPerBlock,
           uint32_t BuffersPerThread,
           uint32_t TlevBytesPerThread,
           bool PreferPow2Bits,
@@ -460,7 +460,7 @@ template <uint32_t BlockThreads,
 struct AgentBatchMemcpyPolicy
 {
   /// Threads per thread block
-  static constexpr uint32_t BLOCK_THREADS = BlockThreads;
+  static constexpr uint32_t BLOCK_THREADS = ThreadsPerBlock;
   /// Items per thread (per tile of input)
   static constexpr uint32_t BUFFERS_PER_THREAD = BuffersPerThread;
   /// The number of bytes that each thread will work on with each iteration of reading in bytes

--- a/cub/cub/agent/agent_find.cuh
+++ b/cub/cub/agent/agent_find.cuh
@@ -21,7 +21,7 @@
 CUB_NAMESPACE_BEGIN
 namespace detail::find
 {
-template <int BlockThreads,
+template <int ThreadsPerBlock,
           int ItemsPerThread,
           int VecSize,
           CacheLoadModifier LoadModifier,
@@ -36,7 +36,7 @@ struct agent_t
   // Vector type of InputT for data movement
   using VectorT = typename CubVector<InputT, VecSize>::Type;
 
-  static constexpr int tile_size = BlockThreads * ItemsPerThread;
+  static constexpr int tile_size = ThreadsPerBlock * ItemsPerThread;
 
   // Can vectorize according to the policy if the input iterator is a native pointer to a primitive type
   static constexpr bool attempt_vectorization =
@@ -100,14 +100,14 @@ struct agent_t
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < number_of_vectors; ++i)
     {
-      vec_items[i] = d_vec_in[BlockThreads * i];
+      vec_items[i] = d_vec_in[ThreadsPerBlock * i];
     }
 
     for (int i = 0; i < ItemsPerThread; ++i)
     {
       OffsetT nth_vector_of_thread = i / VecSize;
       OffsetT element_in_vector    = i % VecSize;
-      OffsetT vector_of_tile       = nth_vector_of_thread * BlockThreads + threadIdx.x;
+      OffsetT vector_of_tile       = nth_vector_of_thread * ThreadsPerBlock + threadIdx.x;
 
       OffsetT index = tile_offset + vector_of_tile * VecSize + element_in_vector;
 

--- a/cub/cub/agent/agent_for.cuh
+++ b/cub/cub/agent/agent_for.cuh
@@ -20,10 +20,10 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail::for_each
 {
-template <int BlockThreads, int ItemsPerThread>
+template <int ThreadsPerBlock, int ItemsPerThread>
 struct policy_t
 {
-  static constexpr int block_threads    = BlockThreads;
+  static constexpr int block_threads    = ThreadsPerBlock;
   static constexpr int items_per_thread = ItemsPerThread;
 };
 

--- a/cub/cub/agent/agent_histogram.cuh
+++ b/cub/cub/agent/agent_histogram.cuh
@@ -56,7 +56,7 @@ inline ::std::ostream& operator<<(::std::ostream& os, BlockHistogramMemoryPrefer
 
 //! Parameterizable tuning policy type for AgentHistogram
 //!
-//! @tparam BlockThreads
+//! @tparam ThreadsPerBlock
 //!   Threads per thread block
 //!
 //! @tparam PixelsPerThread
@@ -79,7 +79,7 @@ inline ::std::ostream& operator<<(::std::ostream& os, BlockHistogramMemoryPrefer
 //!
 //! @tparam VecSize
 //!   Vector size for samples loading (1, 2, 4)
-template <int BlockThreads,
+template <int ThreadsPerBlock,
           int PixelsPerThread,
           BlockLoadAlgorithm LoadAlgorithm,
           CacheLoadModifier LoadModifier,
@@ -90,7 +90,7 @@ template <int BlockThreads,
 struct AgentHistogramPolicy
 {
   /// Threads per thread block
-  static constexpr int BLOCK_THREADS = BlockThreads;
+  static constexpr int BLOCK_THREADS = ThreadsPerBlock;
   /// Pixels per thread (per tile of input)
   static constexpr int PIXELS_PER_THREAD = PixelsPerThread;
 

--- a/cub/cub/agent/agent_merge.cuh
+++ b/cub/cub/agent/agent_merge.cuh
@@ -35,7 +35,7 @@ namespace detail::merge
 {
 // TODO(bgruber): can we unify this one with AgentMerge in agent_merge_sort.cuh?
 // TODO(bgruber): pass a merge_policy by value instead of individual template parameters in C++20
-template <int BlockThreads,
+template <int ThreadsPerBlock,
           int ItemsPerThread,
           CacheLoadModifier LoadModifier,
           BlockStoreAlgorithm StoreAlgorithm,
@@ -50,16 +50,16 @@ template <int BlockThreads,
           typename CompareOp>
 struct agent_t
 {
-  static constexpr int block_threads  = BlockThreads; // also used for kernel launch bounds and dispatch logic
-  static constexpr int items_per_tile = ItemsPerThread * BlockThreads; // also used by dispatch logic
+  static constexpr int block_threads  = ThreadsPerBlock; // also used for kernel launch bounds and dispatch logic
+  static constexpr int items_per_tile = ItemsPerThread * ThreadsPerBlock; // also used by dispatch logic
 
   // key and value type are taken from the first input sequence (consistent with old Thrust behavior)
   using key_type  = it_value_t<KeysIt1>;
   using item_type = it_value_t<ItemsIt1>;
 
-  using block_load_to_shared = BlockLoadToShared<BlockThreads>;
-  using block_store_keys     = BlockStore<key_type, BlockThreads, ItemsPerThread, StoreAlgorithm>;
-  using block_store_items    = BlockStore<item_type, BlockThreads, ItemsPerThread, StoreAlgorithm>;
+  using block_load_to_shared = BlockLoadToShared<ThreadsPerBlock>;
+  using block_store_keys     = BlockStore<key_type, ThreadsPerBlock, ItemsPerThread, StoreAlgorithm>;
+  using block_store_items    = BlockStore<item_type, ThreadsPerBlock, ItemsPerThread, StoreAlgorithm>;
 
   template <typename ValueT, typename Iter1, typename Iter2>
   static constexpr bool use_block_load_to_shared =
@@ -190,13 +190,13 @@ struct agent_t
     {
       auto keys1_in_cm = try_make_cache_modified_iterator<LoadModifier>(keys1_in);
       auto keys2_in_cm = try_make_cache_modified_iterator<LoadModifier>(keys2_in);
-      merge_sort::gmem_to_reg<BlockThreads, IsFullTile>(
+      merge_sort::gmem_to_reg<ThreadsPerBlock, IsFullTile>(
         keys_loc, keys1_in_cm + keys1_beg, keys2_in_cm + keys2_beg, keys1_count_tile, keys2_count_tile);
       keys1_shared = &storage.keys_shared[0];
       // Needed for using keys1_shared as one big buffer including both ranges in SerialMerge
       keys2_offset = keys1_count_tile;
       keys2_shared = keys1_shared + keys2_offset;
-      merge_sort::reg_to_shared<BlockThreads>(keys1_shared, keys_loc);
+      merge_sort::reg_to_shared<ThreadsPerBlock>(keys1_shared, keys_loc);
       __syncthreads();
     }
 
@@ -290,7 +290,7 @@ struct agent_t
         {
           auto items1_in_cm = try_make_cache_modified_iterator<LoadModifier>(items1_in);
           auto items2_in_cm = try_make_cache_modified_iterator<LoadModifier>(items2_in);
-          merge_sort::gmem_to_reg<BlockThreads, IsFullTile>(
+          merge_sort::gmem_to_reg<ThreadsPerBlock, IsFullTile>(
             items_loc, items1_in_cm + keys1_beg, items2_in_cm + keys2_beg, keys1_count_tile, keys2_count_tile);
           __syncthreads(); // block_store_keys above uses SMEM, so make sure all threads are done before we write to it
           items1_shared = &storage.items_shared[0];
@@ -299,7 +299,7 @@ struct agent_t
             const int items2_offset = keys1_count_tile;
             translate_indices(items2_offset);
           }
-          merge_sort::reg_to_shared<BlockThreads>(items1_shared, items_loc);
+          merge_sort::reg_to_shared<ThreadsPerBlock>(items1_shared, items_loc);
           __syncthreads();
         }
       }

--- a/cub/cub/agent/agent_radix_sort_downsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_downsweep.cuh
@@ -42,7 +42,7 @@ CUB_NAMESPACE_BEGIN
 /**
  * @brief Parameterizable tuning policy type for AgentRadixSortDownsweep
  *
- * @tparam NominalBlockThreads4B
+ * @tparam NominalThreadsPerBlock4B
  *   Threads per thread block
  *
  * @tparam NominalItemsPerThread4B
@@ -66,7 +66,7 @@ CUB_NAMESPACE_BEGIN
  * @tparam RadixBits
  *   The number of radix bits, i.e., log2(bins)
  */
-template <int NominalBlockThreads4B,
+template <int NominalThreadsPerBlock4B,
           int NominalItemsPerThread4B,
           typename ComputeT,
           BlockLoadAlgorithm LoadAlgorithm,
@@ -74,7 +74,7 @@ template <int NominalBlockThreads4B,
           RadixRankAlgorithm RankAlgorithm,
           BlockScanAlgorithm ScanAlgorithm,
           int RadixBits,
-          typename ScalingType = detail::RegBoundScaling<NominalBlockThreads4B, NominalItemsPerThread4B, ComputeT>>
+          typename ScalingType = detail::RegBoundScaling<NominalThreadsPerBlock4B, NominalItemsPerThread4B, ComputeT>>
 struct AgentRadixSortDownsweepPolicy : ScalingType
 {
   /// The number of radix bits, i.e., log2(bins)

--- a/cub/cub/agent/agent_radix_sort_histogram.cuh
+++ b/cub/cub/agent/agent_radix_sort_histogram.cuh
@@ -36,10 +36,10 @@
 CUB_NAMESPACE_BEGIN
 
 //! @param ComputeT If void, use NOMINAL_4B_NUM_PARTS directly for NUM_PARTS. Otherwise, perform scaling.
-template <int BlockThreads, int ItemsPerThread, int NOMINAL_4B_NUM_PARTS, typename ComputeT, int RadixBits>
+template <int ThreadsPerBlock, int ItemsPerThread, int NOMINAL_4B_NUM_PARTS, typename ComputeT, int RadixBits>
 struct AgentRadixSortHistogramPolicy
 {
-  static constexpr int BLOCK_THREADS    = BlockThreads;
+  static constexpr int BLOCK_THREADS    = ThreadsPerBlock;
   static constexpr int ITEMS_PER_THREAD = ItemsPerThread;
 
   // need to discard sizeof(ComputeType) in case it's void
@@ -66,10 +66,10 @@ struct AgentRadixSortHistogramPolicy
   static constexpr int RADIX_BITS = RadixBits;
 };
 
-template <int BlockThreads, int RadixBits>
+template <int ThreadsPerBlock, int RadixBits>
 struct AgentRadixSortExclusiveSumPolicy
 {
-  static constexpr int BLOCK_THREADS = BlockThreads;
+  static constexpr int BLOCK_THREADS = ThreadsPerBlock;
   static constexpr int RADIX_BITS    = RadixBits;
 };
 

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -66,7 +66,7 @@ inline ::std::ostream& operator<<(::std::ostream& os, RadixSortStoreAlgorithm al
 }
 #endif // _CCCL_HOSTED() && !_CCCL_DOXYGEN_INVOKED
 
-template <int NominalBlockThreads4B,
+template <int NominalThreadsPerBlock4B,
           int NominalItemsPerThread4B,
           typename ComputeT,
           /** Number of private histograms to use in the ranker;
@@ -78,7 +78,7 @@ template <int NominalBlockThreads4B,
           BlockScanAlgorithm ScanAlgorithm,
           RadixSortStoreAlgorithm StoreAlgorithm,
           int RadixBits,
-          typename ScalingType = detail::RegBoundScaling<NominalBlockThreads4B, NominalItemsPerThread4B, ComputeT>>
+          typename ScalingType = detail::RegBoundScaling<NominalThreadsPerBlock4B, NominalItemsPerThread4B, ComputeT>>
 struct AgentRadixSortOnesweepPolicy : ScalingType
 {
   static constexpr int RANK_NUM_PARTS                      = RankNumParts;

--- a/cub/cub/agent/agent_radix_sort_upsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_upsweep.cuh
@@ -43,7 +43,7 @@ CUB_NAMESPACE_BEGIN
 /**
  * @brief Parameterizable tuning policy type for AgentRadixSortUpsweep
  *
- * @tparam NominalBlockThreads4B
+ * @tparam NominalThreadsPerBlock4B
  *   Threads per thread block
  *
  * @tparam NominalItemsPerThread4B
@@ -58,12 +58,12 @@ CUB_NAMESPACE_BEGIN
  * @tparam RadixBits
  *   The number of radix bits, i.e., log2(bins)
  */
-template <int NominalBlockThreads4B,
+template <int NominalThreadsPerBlock4B,
           int NominalItemsPerThread4B,
           typename ComputeT,
           CacheLoadModifier LoadModifier,
           int RadixBits,
-          typename ScalingType = detail::RegBoundScaling<NominalBlockThreads4B, NominalItemsPerThread4B, ComputeT>>
+          typename ScalingType = detail::RegBoundScaling<NominalThreadsPerBlock4B, NominalItemsPerThread4B, ComputeT>>
 struct AgentRadixSortUpsweepPolicy : ScalingType
 {
   /// The number of radix bits, i.e., log2(bins)

--- a/cub/cub/agent/agent_reduce.cuh
+++ b/cub/cub/agent/agent_reduce.cuh
@@ -45,20 +45,20 @@ CUB_NAMESPACE_BEGIN
 // TODO(bgruber): deprecate once we publish the tuning API
 /**
  * Parameterizable tuning policy type for AgentReduce
- * @tparam NominalBlockThreads4B Threads per thread block
+ * @tparam NominalThreadsPerBlock4B Threads per thread block
  * @tparam NominalItemsPerThread4B Items per thread (per tile of input)
  * @tparam ComputeT Dominant compute type
  * @tparam VectorLoadLength Number of items per vectorized load
  * @tparam BlockAlgorithm Cooperative block-wide reduction algorithm to use
  * @tparam LoadModifier Cache load modifier for reading input elements
  */
-template <int NominalBlockThreads4B,
+template <int NominalThreadsPerBlock4B,
           int NominalItemsPerThread4B,
           typename ComputeT,
           int VectorLoadLength,
           BlockReduceAlgorithm BlockAlgorithm,
           CacheLoadModifier LoadModifier,
-          typename ScalingType = detail::MemBoundScaling<NominalBlockThreads4B, NominalItemsPerThread4B, ComputeT>>
+          typename ScalingType = detail::MemBoundScaling<NominalThreadsPerBlock4B, NominalItemsPerThread4B, ComputeT>>
 struct AgentReducePolicy : ScalingType
 {
   /// Number of items per vectorized load

--- a/cub/cub/agent/agent_reduce.cuh
+++ b/cub/cub/agent/agent_reduce.cuh
@@ -73,14 +73,14 @@ struct AgentReducePolicy : ScalingType
 
 /**
  * Parameterizable tuning policy type for AgentWarpReduce
- * @tparam BlockThreads Threads per thread block
+ * @tparam ThreadsPerBlock Threads per thread block
  * @tparam WarpThreads Threads per warp
  * @tparam NominalItemsPerThread4B Items per thread (per tile of input)
  * @tparam ComputeT Dominant compute type
  * @tparam VectorLoadLength Number of items per vectorized load
  * @tparam LoadModifier Cache load modifier for reading input elements
  */
-template <int BlockThreads,
+template <int ThreadsPerBlock,
           int WarpThreads,
           int NominalItemsPerThread4B,
           typename ComputeT,
@@ -95,7 +95,7 @@ struct AgentWarpReducePolicy
   static constexpr int VECTOR_LOAD_LENGTH = VectorLoadLength;
 
   /// Number of threads per block
-  static constexpr int BLOCK_THREADS = BlockThreads;
+  static constexpr int BLOCK_THREADS = ThreadsPerBlock;
 
   /// Number of items per thread. When `ComputeT` is `void`, the nominal value is used as-is (no scaling),
   /// allowing to pass actual items_per_thread to opt out of the legacy 4B scaling.

--- a/cub/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/cub/agent/agent_reduce_by_key.cuh
@@ -39,7 +39,7 @@ CUB_NAMESPACE_BEGIN
 /**
  * @brief Parameterizable tuning policy type for AgentReduceByKey
  *
- * @tparam BlockThreads
+ * @tparam ThreadsPerBlock
  *   Threads per thread block
  *
  * @tparam ItemsPerThread
@@ -58,7 +58,7 @@ CUB_NAMESPACE_BEGIN
  *   Implementation detail, do not specify directly, requirements on the
  *   content of this type are subject to breaking change.
  */
-template <int BlockThreads,
+template <int ThreadsPerBlock,
           int ItemsPerThread,
           BlockLoadAlgorithm LoadAlgorithm,
           CacheLoadModifier LoadModifier,
@@ -67,7 +67,7 @@ template <int BlockThreads,
 struct AgentReduceByKeyPolicy
 {
   ///< Threads per thread block
-  static constexpr int BLOCK_THREADS = BlockThreads;
+  static constexpr int BLOCK_THREADS = ThreadsPerBlock;
 
   ///< Items per thread (per tile of input)
   static constexpr int ITEMS_PER_THREAD = ItemsPerThread;

--- a/cub/cub/agent/agent_rle.cuh
+++ b/cub/cub/agent/agent_rle.cuh
@@ -44,7 +44,7 @@ CUB_NAMESPACE_BEGIN
 /**
  * Parameterizable tuning policy type for AgentRle
  *
- * @tparam BlockThreads
+ * @tparam ThreadsPerBlock
  *   Threads per thread block
  *
  * @tparam ItemsPerThread
@@ -68,7 +68,7 @@ CUB_NAMESPACE_BEGIN
  *   Implementation detail, do not specify directly, requirements on the
  *   content of this type are subject to breaking change.
  */
-template <int BlockThreads,
+template <int ThreadsPerBlock,
           int ItemsPerThread,
           BlockLoadAlgorithm LoadAlgorithm,
           CacheLoadModifier LoadModifier,
@@ -78,7 +78,7 @@ template <int BlockThreads,
 struct AgentRlePolicy
 {
   /// Threads per thread block
-  static constexpr int BLOCK_THREADS = BlockThreads;
+  static constexpr int BLOCK_THREADS = ThreadsPerBlock;
 
   /// Items per thread (per tile of input)
   static constexpr int ITEMS_PER_THREAD = ItemsPerThread;

--- a/cub/cub/agent/agent_scan.cuh
+++ b/cub/cub/agent/agent_scan.cuh
@@ -41,7 +41,7 @@ CUB_NAMESPACE_BEGIN
 /**
  * @brief Parameterizable tuning policy type for AgentScan
  *
- * @tparam NominalBlockThreads4B
+ * @tparam NominalThreadsPerBlock4B
  *   Threads per thread block
  *
  * @tparam NominalItemsPerThread4B
@@ -66,14 +66,14 @@ CUB_NAMESPACE_BEGIN
  *   Implementation detail, do not specify directly, requirements on the
  *   content of this type are subject to breaking change.
  */
-template <int NominalBlockThreads4B,
+template <int NominalThreadsPerBlock4B,
           int NominalItemsPerThread4B,
           typename ComputeT,
           BlockLoadAlgorithm LoadAlgorithm,
           CacheLoadModifier LoadModifier,
           BlockStoreAlgorithm StoreAlgorithm,
           BlockScanAlgorithm ScanAlgorithm,
-          typename ScalingType = detail::MemBoundScaling<NominalBlockThreads4B, NominalItemsPerThread4B, ComputeT>,
+          typename ScalingType = detail::MemBoundScaling<NominalThreadsPerBlock4B, NominalItemsPerThread4B, ComputeT>,
           typename DelayConstructorT = detail::default_delay_constructor_t<ComputeT>>
 struct AgentScanPolicy : ScalingType
 {

--- a/cub/cub/agent/agent_scan_by_key.cuh
+++ b/cub/cub/agent/agent_scan_by_key.cuh
@@ -46,7 +46,7 @@ CUB_NAMESPACE_BEGIN
  *   Implementation detail, do not specify directly, requirements on the
  *   content of this type are subject to breaking change.
  */
-template <int BlockThreads,
+template <int ThreadsPerBlock,
           int ItemsPerThread                 = 1,
           BlockLoadAlgorithm LoadAlgorithm   = BLOCK_LOAD_DIRECT,
           CacheLoadModifier LoadModifier     = LOAD_DEFAULT,
@@ -55,7 +55,7 @@ template <int BlockThreads,
           typename DelayConstructorT         = detail::fixed_delay_constructor_t<350, 450>>
 struct AgentScanByKeyPolicy
 {
-  static constexpr int BLOCK_THREADS    = BlockThreads;
+  static constexpr int BLOCK_THREADS    = ThreadsPerBlock;
   static constexpr int ITEMS_PER_THREAD = ItemsPerThread;
 
   static constexpr BlockLoadAlgorithm LOAD_ALGORITHM   = LoadAlgorithm;

--- a/cub/cub/agent/agent_select_if.cuh
+++ b/cub/cub/agent/agent_select_if.cuh
@@ -47,7 +47,7 @@ CUB_NAMESPACE_BEGIN
 /**
  * Parameterizable tuning policy type for AgentSelectIf
  *
- * @tparam BlockThreads
+ * @tparam ThreadsPerBlock
  *   Threads per thread block
  *
  * @tparam ItemsPerThread
@@ -66,7 +66,7 @@ CUB_NAMESPACE_BEGIN
  *   Implementation detail, do not specify directly, requirements on the
  *   content of this type are subject to breaking change.
  */
-template <int BlockThreads,
+template <int ThreadsPerBlock,
           int ItemsPerThread,
           BlockLoadAlgorithm LoadAlgorithm,
           CacheLoadModifier LoadModifier,
@@ -75,7 +75,7 @@ template <int BlockThreads,
 struct AgentSelectIfPolicy
 {
   /// Threads per thread block
-  static constexpr int BLOCK_THREADS = BlockThreads;
+  static constexpr int BLOCK_THREADS = ThreadsPerBlock;
 
   /// Items per thread (per tile of input)
   static constexpr int ITEMS_PER_THREAD = ItemsPerThread;

--- a/cub/cub/agent/agent_sub_warp_merge_sort.cuh
+++ b/cub/cub/agent/agent_sub_warp_merge_sort.cuh
@@ -24,7 +24,7 @@
 
 CUB_NAMESPACE_BEGIN
 
-template <int BlockThreadsArg,
+template <int ThreadsPerBlock,
           int WarpThreadsArg,
           int ItemsPerThreadArg,
           cub::WarpLoadAlgorithm LoadAlgorithmArg   = cub::WARP_LOAD_DIRECT,
@@ -32,7 +32,7 @@ template <int BlockThreadsArg,
           cub::WarpStoreAlgorithm StoreAlgorithmArg = cub::WARP_STORE_DIRECT>
 struct AgentSubWarpMergeSortPolicy
 {
-  static constexpr int BLOCK_THREADS      = BlockThreadsArg;
+  static constexpr int BLOCK_THREADS      = ThreadsPerBlock;
   static constexpr int WARP_THREADS       = WarpThreadsArg;
   static constexpr int ITEMS_PER_THREAD   = ItemsPerThreadArg;
   static constexpr int ITEMS_PER_TILE     = WARP_THREADS * ITEMS_PER_THREAD;

--- a/cub/cub/agent/agent_three_way_partition.cuh
+++ b/cub/cub/agent/agent_three_way_partition.cuh
@@ -33,7 +33,7 @@ CUB_NAMESPACE_BEGIN
  * Tuning policy types
  ******************************************************************************/
 
-template <int BlockThreads,
+template <int ThreadsPerBlock,
           int ItemsPerThread,
           BlockLoadAlgorithm LoadAlgorithm,
           CacheLoadModifier LoadModifier,
@@ -41,7 +41,7 @@ template <int BlockThreads,
           class DelayConstructorT = detail::fixed_delay_constructor_t<350, 450>>
 struct AgentThreeWayPartitionPolicy
 {
-  static constexpr int BLOCK_THREADS                 = BlockThreads;
+  static constexpr int BLOCK_THREADS                 = ThreadsPerBlock;
   static constexpr int ITEMS_PER_THREAD              = ItemsPerThread;
   static constexpr BlockLoadAlgorithm LOAD_ALGORITHM = LoadAlgorithm;
   static constexpr CacheLoadModifier LOAD_MODIFIER   = LoadModifier;

--- a/cub/cub/agent/agent_topk.cuh
+++ b/cub/cub/agent/agent_topk.cuh
@@ -29,7 +29,7 @@ namespace detail::topk
 {
 //! @brief Parameterizable tuning policy type for AgentTopK
 //!
-//! @tparam BlockThreads
+//! @tparam ThreadsPerBlock
 //!   Threads per thread block
 //!
 //! @tparam ItemsPerThread
@@ -44,14 +44,14 @@ namespace detail::topk
 //! @tparam ScanAlgorithm
 //!   The BlockScan algorithm to use
 //!
-template <int BlockThreads,
+template <int ThreadsPerBlock,
           int ItemsPerThread,
           int BitsPerPass,
           BlockLoadAlgorithm LoadAlgorithm,
           BlockScanAlgorithm ScanAlgorithm>
 struct AgentTopKPolicy
 {
-  static constexpr int block_threads                 = BlockThreads;
+  static constexpr int block_threads                 = ThreadsPerBlock;
   static constexpr int items_per_thread              = ItemsPerThread;
   static constexpr int bits_per_pass                 = BitsPerPass;
   static constexpr BlockLoadAlgorithm load_algorithm = LoadAlgorithm;

--- a/cub/cub/agent/agent_unique_by_key.cuh
+++ b/cub/cub/agent/agent_unique_by_key.cuh
@@ -38,7 +38,7 @@ CUB_NAMESPACE_BEGIN
  *   Implementation detail, do not specify directly, requirements on the
  *   content of this type are subject to breaking change.
  */
-template <int BlockThreads,
+template <int ThreadsPerBlock,
           int ItemsPerThread                    = 1,
           cub::BlockLoadAlgorithm LoadAlgorithm = cub::BLOCK_LOAD_DIRECT,
           cub::CacheLoadModifier LoadModifier   = cub::LOAD_LDG,
@@ -46,7 +46,7 @@ template <int BlockThreads,
           typename DelayConstructorT            = detail::fixed_delay_constructor_t<350, 450>>
 struct AgentUniqueByKeyPolicy
 {
-  static constexpr int BLOCK_THREADS                      = BlockThreads;
+  static constexpr int BLOCK_THREADS                      = ThreadsPerBlock;
   static constexpr int ITEMS_PER_THREAD                   = ItemsPerThread;
   static constexpr cub::BlockLoadAlgorithm LOAD_ALGORITHM = LoadAlgorithm;
   static constexpr cub::CacheLoadModifier LOAD_MODIFIER   = LoadModifier;

--- a/cub/cub/block/block_load.cuh
+++ b/cub/cub/block/block_load.cuh
@@ -281,7 +281,7 @@ LoadDirectBlockedVectorized(int linear_tid, T* block_src_ptr, T (&dst_items)[Ite
 //!
 //! @endrst
 //!
-//! @tparam BlockThreads
+//! @tparam ThreadsPerBlock
 //!   The thread block size in threads
 //!
 //! @tparam T
@@ -302,27 +302,27 @@ LoadDirectBlockedVectorized(int linear_tid, T* block_src_ptr, T (&dst_items)[Ite
 //!
 //! @param[out] dst_items
 //!   Destination to load data into
-template <int BlockThreads, typename T, int ItemsPerThread, typename RandomAccessIterator>
+template <int ThreadsPerBlock, typename T, int ItemsPerThread, typename RandomAccessIterator>
 _CCCL_DEVICE _CCCL_FORCEINLINE void
 LoadDirectStriped(int linear_tid, RandomAccessIterator block_src_it, T (&dst_items)[ItemsPerThread])
 {
   _CCCL_PRAGMA_UNROLL_FULL()
   for (int i = 0; i < ItemsPerThread; i++)
   {
-    dst_items[i] = block_src_it[linear_tid + i * BlockThreads];
+    dst_items[i] = block_src_it[linear_tid + i * ThreadsPerBlock];
   }
 }
 
 namespace detail
 {
-template <int BlockThreads, typename T, int ItemsPerThread, typename RandomAccessIterator, typename TransformOpT>
+template <int ThreadsPerBlock, typename T, int ItemsPerThread, typename RandomAccessIterator, typename TransformOpT>
 _CCCL_DEVICE _CCCL_FORCEINLINE void load_transform_direct_striped(
   int linear_tid, RandomAccessIterator block_src_it, T (&dst_items)[ItemsPerThread], TransformOpT transform_op)
 {
   _CCCL_PRAGMA_UNROLL_FULL()
   for (int i = 0; i < ItemsPerThread; i++)
   {
-    dst_items[i] = transform_op(block_src_it[linear_tid + i * BlockThreads]);
+    dst_items[i] = transform_op(block_src_it[linear_tid + i * ThreadsPerBlock]);
   }
 }
 } // namespace detail
@@ -337,7 +337,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void load_transform_direct_striped(
 //!
 //! @endrst
 //!
-//! @tparam BlockThreads
+//! @tparam ThreadsPerBlock
 //!   The thread block size in threads
 //!
 //! @tparam T
@@ -361,14 +361,14 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void load_transform_direct_striped(
 //!
 //! @param[in] block_items_end
 //!   Number of valid items to load
-template <int BlockThreads, typename T, int ItemsPerThread, typename RandomAccessIterator>
+template <int ThreadsPerBlock, typename T, int ItemsPerThread, typename RandomAccessIterator>
 _CCCL_DEVICE _CCCL_FORCEINLINE void LoadDirectStriped(
   int linear_tid, RandomAccessIterator block_src_it, T (&dst_items)[ItemsPerThread], int block_items_end)
 {
   _CCCL_PRAGMA_UNROLL_FULL()
   for (int i = 0; i < ItemsPerThread; i++)
   {
-    const auto src_pos = linear_tid + i * BlockThreads;
+    const auto src_pos = linear_tid + i * ThreadsPerBlock;
     if (src_pos < block_items_end)
     {
       dst_items[i] = block_src_it[src_pos];
@@ -387,7 +387,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void LoadDirectStriped(
 //!
 //! @endrst
 //!
-//! @tparam BlockThreads
+//! @tparam ThreadsPerBlock
 //!   The thread block size in threads
 //!
 //! @tparam T
@@ -414,7 +414,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void LoadDirectStriped(
 //!
 //! @param[in] oob_default
 //!   Default value to assign out-of-bound items
-template <int BlockThreads, typename T, typename DefaultT, int ItemsPerThread, typename RandomAccessIterator>
+template <int ThreadsPerBlock, typename T, typename DefaultT, int ItemsPerThread, typename RandomAccessIterator>
 _CCCL_DEVICE _CCCL_FORCEINLINE void LoadDirectStriped(
   int linear_tid,
   RandomAccessIterator block_src_it,
@@ -428,7 +428,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void LoadDirectStriped(
     dst_items[i] = oob_default;
   }
 
-  LoadDirectStriped<BlockThreads>(linear_tid, block_src_it, dst_items, block_items_end);
+  LoadDirectStriped<ThreadsPerBlock>(linear_tid, block_src_it, dst_items, block_items_end);
 }
 
 //! @}
@@ -684,7 +684,7 @@ enum BlockLoadAlgorithm
   //! Usage Considerations
   //! ++++++++++++++++++++++++++
   //!
-  //! - BlockThreads must be a multiple of WARP_THREADS
+  //! - ThreadsPerBlock must be a multiple of WARP_THREADS
   //!
   //! Performance Considerations
   //! ++++++++++++++++++++++++++
@@ -710,7 +710,7 @@ enum BlockLoadAlgorithm
   //! Usage Considerations
   //! ++++++++++++++++++++++++++
   //!
-  //! - BlockThreads must be a multiple of WARP_THREADS
+  //! - ThreadsPerBlock must be a multiple of WARP_THREADS
   //!
   //! Performance Considerations
   //! ++++++++++++++++++++++++++
@@ -843,7 +843,7 @@ template <typename T,
           int BlockDimZ                = 1>
 class BlockLoad
 {
-  static constexpr int BlockThreads = BlockDimX * BlockDimY * BlockDimZ; // total threads in the block
+  static constexpr int ThreadsPerBlock = BlockDimX * BlockDimY * BlockDimZ; // total threads in the block
 
   // transposing load algorithms need a BlockExchange
   using block_exchange =
@@ -855,8 +855,8 @@ class BlockLoad
                   BlockDimZ>;
 
   static_assert((Algorithm != BLOCK_LOAD_WARP_TRANSPOSE && Algorithm != BLOCK_LOAD_WARP_TRANSPOSE_TIMESLICED)
-                  || (BlockThreads % detail::warp_threads == 0),
-                "BlockThreads must be a multiple of warp_threads for this BlockLoadAlgorithm");
+                  || (ThreadsPerBlock % detail::warp_threads == 0),
+                "ThreadsPerBlock must be a multiple of warp_threads for this BlockLoadAlgorithm");
 
   _CCCL_API static constexpr auto temp_storage_helper()
   {
@@ -972,7 +972,7 @@ public:
     }
     else if constexpr (Algorithm == BLOCK_LOAD_STRIPED)
     {
-      LoadDirectStriped<BlockThreads>(linear_tid, block_src_it, dst_items);
+      LoadDirectStriped<ThreadsPerBlock>(linear_tid, block_src_it, dst_items);
     }
     else if constexpr (Algorithm == BLOCK_LOAD_VECTORIZE)
     {
@@ -992,7 +992,7 @@ public:
     }
     else if constexpr (Algorithm == BLOCK_LOAD_TRANSPOSE)
     {
-      LoadDirectStriped<BlockThreads>(linear_tid, block_src_it, dst_items);
+      LoadDirectStriped<ThreadsPerBlock>(linear_tid, block_src_it, dst_items);
       block_exchange(temp_storage).StripedToBlocked(dst_items, dst_items);
     }
     else if constexpr (Algorithm == BLOCK_LOAD_WARP_TRANSPOSE || Algorithm == BLOCK_LOAD_WARP_TRANSPOSE_TIMESLICED)
@@ -1061,11 +1061,11 @@ public:
     }
     else if constexpr (Algorithm == BLOCK_LOAD_STRIPED)
     {
-      LoadDirectStriped<BlockThreads>(linear_tid, block_src_it, dst_items, block_items_end);
+      LoadDirectStriped<ThreadsPerBlock>(linear_tid, block_src_it, dst_items, block_items_end);
     }
     else if constexpr (Algorithm == BLOCK_LOAD_TRANSPOSE)
     {
-      LoadDirectStriped<BlockThreads>(linear_tid, block_src_it, dst_items, block_items_end);
+      LoadDirectStriped<ThreadsPerBlock>(linear_tid, block_src_it, dst_items, block_items_end);
       block_exchange(temp_storage).StripedToBlocked(dst_items, dst_items);
     }
     else if constexpr (Algorithm == BLOCK_LOAD_WARP_TRANSPOSE || Algorithm == BLOCK_LOAD_WARP_TRANSPOSE_TIMESLICED)
@@ -1137,11 +1137,11 @@ public:
     }
     else if constexpr (Algorithm == BLOCK_LOAD_STRIPED)
     {
-      LoadDirectStriped<BlockThreads>(linear_tid, block_src_it, dst_items, block_items_end, oob_default);
+      LoadDirectStriped<ThreadsPerBlock>(linear_tid, block_src_it, dst_items, block_items_end, oob_default);
     }
     else if constexpr (Algorithm == BLOCK_LOAD_TRANSPOSE)
     {
-      LoadDirectStriped<BlockThreads>(linear_tid, block_src_it, dst_items, block_items_end, oob_default);
+      LoadDirectStriped<ThreadsPerBlock>(linear_tid, block_src_it, dst_items, block_items_end, oob_default);
       block_exchange(temp_storage).StripedToBlocked(dst_items, dst_items);
     }
     else if constexpr (Algorithm == BLOCK_LOAD_WARP_TRANSPOSE || Algorithm == BLOCK_LOAD_WARP_TRANSPOSE_TIMESLICED)

--- a/cub/cub/block/block_raking_layout.cuh
+++ b/cub/cub/block/block_raking_layout.cuh
@@ -41,10 +41,10 @@ CUB_NAMESPACE_BEGIN
 //! @tparam T
 //!   The data type to be exchanged.
 //!
-//! @tparam BlockThreads
+//! @tparam ThreadsPerBlock
 //!   The thread block size in threads.
 //!
-template <typename T, int BlockThreads>
+template <typename T, int ThreadsPerBlock>
 struct BlockRakingLayout
 {
   //---------------------------------------------------------------------
@@ -52,15 +52,15 @@ struct BlockRakingLayout
   //---------------------------------------------------------------------
 
   /// The total number of elements that need to be cooperatively reduced
-  static constexpr int SHARED_ELEMENTS = BlockThreads;
+  static constexpr int SHARED_ELEMENTS = ThreadsPerBlock;
 
   /// Maximum number of warp-synchronous raking threads
-  static constexpr int MAX_RAKING_THREADS = ::cuda::std::min(BlockThreads, detail::warp_threads);
+  static constexpr int MAX_RAKING_THREADS = ::cuda::std::min(ThreadsPerBlock, detail::warp_threads);
 
   /// Number of raking elements per warp-synchronous raking thread (rounded up)
   static constexpr int SEGMENT_LENGTH = (SHARED_ELEMENTS + MAX_RAKING_THREADS - 1) / MAX_RAKING_THREADS;
 
-  /// Never use a raking thread that will have no valid data (e.g., when BlockThreads is 62 and SEGMENT_LENGTH is 2,
+  /// Never use a raking thread that will have no valid data (e.g., when ThreadsPerBlock is 62 and SEGMENT_LENGTH is 2,
   /// we should only use 31 raking threads)
   static constexpr int RAKING_THREADS = (SHARED_ELEMENTS + SEGMENT_LENGTH - 1) / SEGMENT_LENGTH;
 

--- a/cub/cub/block/block_store.cuh
+++ b/cub/cub/block/block_store.cuh
@@ -678,7 +678,7 @@ class BlockStore
 
   static_assert((Algorithm != BLOCK_STORE_WARP_TRANSPOSE && Algorithm != BLOCK_STORE_WARP_TRANSPOSE_TIMESLICED)
                   || (BLOCK_THREADS % detail::warp_threads == 0),
-                "BlockThreads must be a multiple of warp_threads for this BlockStoreAlgorithm");
+                "Threads per block must be a multiple of warp_threads for this BlockStoreAlgorithm");
 
   _CCCL_API static constexpr auto temp_storage_helper()
   {

--- a/cub/cub/block/specializations/block_topk_air.cuh
+++ b/cub/cub/block/specializations/block_topk_air.cuh
@@ -52,7 +52,7 @@ struct compare_key_prefix_op
 //! the histogram in shared memory is updated. (2) Partitioning scatters the top-k items (key
 //! prefix <= k-th prefix) into shared memory via atomic counters, then each thread reads back
 //! its portion. Supports key-only and key-value selection.
-template <typename KeyT, int BlockThreads, int ItemsPerThread, typename ValueT = NullType, int RadixBits = 8>
+template <typename KeyT, int ThreadsPerBlock, int ItemsPerThread, typename ValueT = NullType, int RadixBits = 8>
 class block_topk_air
 {
 private:
@@ -60,7 +60,7 @@ private:
   // Whether to include all items tied with the k-th key when selecting top-k
   static constexpr bool expand_k_to_include_ties = false;
 
-  static constexpr int block_threads    = BlockThreads;
+  static constexpr int block_threads    = ThreadsPerBlock;
   static constexpr int items_per_thread = ItemsPerThread;
   static constexpr int tile_items       = block_threads * items_per_thread;
   static constexpr int num_buckets      = int{1u << RadixBits};
@@ -502,7 +502,7 @@ public:
 
   _CCCL_DEVICE_API _CCCL_FORCEINLINE block_topk_air(TempStorage& storage)
       : storage(storage.Alias())
-      , linear_tid(RowMajorTid(BlockThreads, 1, 1))
+      , linear_tid(RowMajorTid(ThreadsPerBlock, 1, 1))
   {}
 
   template <detail::topk::select SelectDirection, bool IsFullTile>

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -283,13 +283,13 @@ struct DispatchReduce
 #ifdef CUB_DEBUG_LOG
     _CubLog("Invoking DeviceReduceSingleTileKernel<<<1, %d, 0, %lld>>>(), "
             "%d items per thread\n",
-            policy.SingleTile().BlockThreads(),
+            policy.SingleTile().ThreadsPerBlock(),
             (long long) stream,
             policy.SingleTile().ItemsPerThread());
 #endif // CUB_DEBUG_LOG
 
     // Invoke single_reduce_sweep_kernel
-    launcher_factory(1, policy.SingleTile().BlockThreads(), 0, stream)
+    launcher_factory(1, policy.SingleTile().ThreadsPerBlock(), 0, stream)
       .doit(single_tile_kernel, d_in, d_out, num_items, reduction_op, init, transform_op);
 
     // Check for failure to launch
@@ -382,14 +382,14 @@ struct DispatchReduce
     _CubLog("Invoking DeviceReduceKernel<<<%lu, %d, 0, %lld>>>(), %d items "
             "per thread, %d SM occupancy\n",
             (unsigned long) reduce_grid_size,
-            active_policy.Reduce().BlockThreads(),
+            active_policy.Reduce().ThreadsPerBlock(),
             (long long) stream,
             active_policy.Reduce().ItemsPerThread(),
             reduce_config.sm_occupancy);
 #endif // CUB_DEBUG_LOG
 
     // Invoke DeviceReduceKernel
-    launcher_factory(reduce_grid_size, active_policy.Reduce().BlockThreads(), 0, stream)
+    launcher_factory(reduce_grid_size, active_policy.Reduce().ThreadsPerBlock(), 0, stream)
       .doit(reduce_kernel, d_in, d_block_reductions, num_items, even_share, reduction_op, transform_op);
 
     // Check for failure to launch
@@ -408,13 +408,13 @@ struct DispatchReduce
 #ifdef CUB_DEBUG_LOG
     _CubLog("Invoking DeviceReduceSingleTileKernel<<<1, %d, 0, %lld>>>(), "
             "%d items per thread\n",
-            active_policy.SingleTile().BlockThreads(),
+            active_policy.SingleTile().ThreadsPerBlock(),
             (long long) stream,
             active_policy.SingleTile().ItemsPerThread());
 #endif // CUB_DEBUG_LOG
 
     // Invoke DeviceReduceSingleTileKernel
-    launcher_factory(1, active_policy.SingleTile().BlockThreads(), 0, stream)
+    launcher_factory(1, active_policy.SingleTile().ThreadsPerBlock(), 0, stream)
       .doit(
         single_tile_kernel, d_block_reductions, d_out, reduce_grid_size, reduction_op, init, ::cuda::std::identity{});
 
@@ -438,7 +438,7 @@ struct DispatchReduce
   {
     auto wrapped_policy = detail::reduce::MakeReducePolicyWrapper(active_policy);
     if (num_items <= static_cast<OffsetT>(
-          wrapped_policy.SingleTile().BlockThreads() * wrapped_policy.SingleTile().ItemsPerThread()))
+          wrapped_policy.SingleTile().ThreadsPerBlock() * wrapped_policy.SingleTile().ItemsPerThread()))
     {
       // Small, single tile size
       return InvokeSingleTile(kernel_source.SingleTileKernel(), wrapped_policy);

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -366,7 +366,7 @@ struct DispatchScan
     policy.CheckLoadModifier();
 
     // Number of input tiles
-    const int tile_size = policy.Scan().BlockThreads() * policy.Scan().ItemsPerThread();
+    const int tile_size = policy.Scan().ThreadsPerBlock() * policy.Scan().ItemsPerThread();
     const int num_tiles = static_cast<int>(::cuda::ceil_div(num_items, tile_size));
 
     auto tile_state = kernel_source.TileState();
@@ -429,7 +429,7 @@ struct DispatchScan
     // Get SM occupancy for scan_kernel
     int scan_sm_occupancy;
     if (const auto error =
-          CubDebug(launcher_factory.MaxSmOccupancy(scan_sm_occupancy, scan_kernel, policy.Scan().BlockThreads())))
+          CubDebug(launcher_factory.MaxSmOccupancy(scan_sm_occupancy, scan_kernel, policy.Scan().ThreadsPerBlock())))
     {
       return error;
     }
@@ -451,7 +451,7 @@ struct DispatchScan
               "per thread, %d SM occupancy\n",
               start_tile,
               scan_grid_size,
-              policy.Scan().BlockThreads(),
+              policy.Scan().ThreadsPerBlock(),
               (long long) stream,
               policy.Scan().ItemsPerThread(),
               scan_sm_occupancy);
@@ -459,7 +459,7 @@ struct DispatchScan
 
       // Invoke scan_kernel
       if (const auto error = CubDebug(
-            launcher_factory(scan_grid_size, policy.Scan().BlockThreads(), 0, stream, /* use_pdl */ true)
+            launcher_factory(scan_grid_size, policy.Scan().ThreadsPerBlock(), 0, stream, /* use_pdl */ true)
               .doit(scan_kernel,
                     THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_in),
                     THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_out),

--- a/cub/cub/device/dispatch/dispatch_segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_segmented_reduce.cuh
@@ -301,15 +301,17 @@ struct DispatchSegmentedReduce
         _CubLog("Invoking SegmentedDeviceReduceKernel<<<%ld, %d, 0, %lld>>>(), "
                 "%d items per thread, %d SM occupancy\n",
                 num_current_segments,
-                policy.SegmentedReduce().BlockThreads(),
+                policy.SegmentedReduce().ThreadsPerBlock(),
                 (long long) stream,
                 policy.SegmentedReduce().ItemsPerThread(),
                 segmented_reduce_config.sm_occupancy);
 #endif // CUB_DEBUG_LOG
 
         // Invoke DeviceSegmentedReduceKernel
-        launcher_factory(
-          static_cast<::cuda::std::uint32_t>(num_current_segments), policy.SegmentedReduce().BlockThreads(), 0, stream)
+        launcher_factory(static_cast<::cuda::std::uint32_t>(num_current_segments),
+                         policy.SegmentedReduce().ThreadsPerBlock(),
+                         0,
+                         stream)
           .doit(segmented_reduce_kernel,
                 d_in,
                 d_out,

--- a/cub/cub/device/dispatch/dispatch_segmented_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_segmented_sort.cuh
@@ -885,8 +885,8 @@ private:
                 small_segments_indices.get(),
                 stream,
                 launcher_factory,
-                wrapped_policy.LargeSegmentBlockThreads(),
-                wrapped_policy.SmallSegmentBlockThreads(),
+                wrapped_policy.LargeSegmentThreadsPerBlock(),
+                wrapped_policy.SmallSegmentThreadsPerBlock(),
                 wrapped_policy.SegmentsPerMediumBlock(),
                 wrapped_policy.SegmentsPerSmallBlock()))
           {
@@ -909,7 +909,7 @@ private:
     WrappedPolicyT wrapped_policy)
   {
     const auto blocks_in_grid   = static_cast<local_segment_index_t>(num_segments);
-    const auto threads_in_block = static_cast<unsigned int>(wrapped_policy.LargeSegmentBlockThreads());
+    const auto threads_in_block = static_cast<unsigned int>(wrapped_policy.LargeSegmentThreadsPerBlock());
 
 // Log kernel configuration
 #ifdef CUB_DEBUG_LOG

--- a/cub/cub/device/dispatch/dispatch_segmented_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_segmented_sort.cuh
@@ -835,8 +835,8 @@ private:
               large_and_medium_segments_indices.get(),                                  \
               small_segments_indices.get(),                                             \
               launcher_factory,                                                         \
-              wrapped_policy.large_segment.BlockThreads(),                              \
-              wrapped_policy.small_segment.BlockThreads(),                              \
+              wrapped_policy.large_segment.ThreadsPerBlock(),                           \
+              wrapped_policy.small_segment.ThreadsPerBlock(),                           \
               wrapped_policy.medium_segment.SegmentsPerBlock(),                         \
               wrapped_policy.small_segment.SegmentsPerBlock())))                        \
     {                                                                                   \

--- a/cub/cub/device/dispatch/dispatch_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/dispatch_three_way_partition.cuh
@@ -364,7 +364,7 @@ struct DispatchThreeWayPartitionIf
          ScanInitKernelPtrT three_way_partition_init_kernel,
          SelectIfKernelPtrT three_way_partition_kernel)
   {
-    const int block_threads    = policy.ThreeWayPartition().BlockThreads();
+    const int block_threads    = policy.ThreeWayPartition().ThreadsPerBlock();
     const int items_per_thread = policy.ThreeWayPartition().ItemsPerThread();
     return __invoke(block_threads, items_per_thread, three_way_partition_init_kernel, three_way_partition_kernel);
   }

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -114,7 +114,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void unrolled_for(int count, F&& body)
 // This kernel guarantees that objects passed as arguments to the user-provided transformation function f reside in
 // global memory. No intermediate copies are taken. If the parameter type of f is a reference, taking the address of the
 // parameter yields a global memory address.
-template <int BlockThreads,
+template <int ThreadsPerBlock,
           int PrefetchByteStride,
           int UnrollFactor,
           typename Offset,
@@ -130,10 +130,9 @@ _CCCL_DEVICE void transform_kernel_prefetch(
   RandomAccessIteratorOut out,
   RandomAccessIteratorIn... ins)
 {
-  constexpr int block_threads = BlockThreads;
-  const int tile_size         = block_threads * num_elem_per_thread;
-  const Offset offset         = static_cast<Offset>(blockIdx.x) * tile_size;
-  const int valid_items       = static_cast<int>((::cuda::std::min) (num_items - offset, Offset{tile_size}));
+  const int tile_size   = ThreadsPerBlock * num_elem_per_thread;
+  const Offset offset   = static_cast<Offset>(blockIdx.x) * tile_size;
+  const int valid_items = static_cast<int>((::cuda::std::min) (num_items - offset, Offset{tile_size}));
 
   // move index and iterator domain to the block/thread index, to reduce arithmetic in the loops below
   {
@@ -142,11 +141,11 @@ _CCCL_DEVICE void transform_kernel_prefetch(
   }
 
   _CCCL_PDL_GRID_DEPENDENCY_SYNC();
-  (..., prefetch_tile<block_threads, PrefetchByteStride>(ins, valid_items));
+  (..., prefetch_tile<ThreadsPerBlock, PrefetchByteStride>(ins, valid_items));
 
   auto process_tile = [&](auto full_tile, auto... ins2 /* nvcc fails to compile when just using the captured ins */) {
     unrolled_for<UnrollFactor>(num_elem_per_thread, [&](int j) {
-      const int idx = j * block_threads + threadIdx.x;
+      const int idx = j * ThreadsPerBlock + threadIdx.x;
       if (full_tile || idx < valid_items)
       {
         if (pred(THRUST_NS_QUALIFIER::raw_reference_cast(ins2[idx])...))
@@ -420,7 +419,7 @@ _CCCL_HOST_DEVICE auto make_aligned_base_ptr(const T* ptr, int alignment) -> ali
   return aligned_base_ptr<T>{base_ptr, static_cast<int>(raw_ptr - base_ptr)};
 }
 
-template <int BlockThreads>
+template <int ThreadsPerBlock>
 _CCCL_DEVICE void memcpy_async_aligned(void* dst, const void* src, unsigned int bytes_to_copy)
 {
   _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<ldgsts_size_and_align>(src), "");
@@ -430,7 +429,7 @@ _CCCL_DEVICE void memcpy_async_aligned(void* dst, const void* src, unsigned int 
   // allowing unrolling generates a LOT more instructions and is usually slower (confirmed by benchmark)
   _CCCL_PRAGMA_NOUNROLL()
   for (unsigned int offset = threadIdx.x * ldgsts_size_and_align; offset < bytes_to_copy;
-       offset += BlockThreads * ldgsts_size_and_align)
+       offset += ThreadsPerBlock * ldgsts_size_and_align)
   {
     asm volatile(
       "cp.async.cg.shared.global [%0], [%1], %2, %3;"
@@ -447,7 +446,7 @@ _CCCL_DEVICE void memcpy_async_aligned(void* dst, const void* src, unsigned int 
   asm volatile("cp.async.commit_group;"); // same as: __pipeline_commit();
 }
 
-template <int BlockThreads>
+template <int ThreadsPerBlock>
 _CCCL_DEVICE void memcpy_async_maybe_unaligned(void* dst, const void* src, unsigned int bytes_to_copy, int head_padding)
 {
   // early exiting if (head_padding == 0 && bytes_to_copy % ldgsts_size_and_align == 0) does not yield a benefit
@@ -476,7 +475,7 @@ _CCCL_DEVICE void memcpy_async_maybe_unaligned(void* dst, const void* src, unsig
     _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<ldgsts_size_and_align>(dst_ptr + head_bytes), "");
     _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<ldgsts_size_and_align>(src_ptr + head_bytes), "");
     _CCCL_ASSERT(aligned_bytes_to_copy % ldgsts_size_and_align == 0, "");
-    memcpy_async_aligned<BlockThreads>(dst_ptr + head_bytes, src_ptr + head_bytes, aligned_bytes_to_copy);
+    memcpy_async_aligned<ThreadsPerBlock>(dst_ptr + head_bytes, src_ptr + head_bytes, aligned_bytes_to_copy);
   }
 
   // TODO(bgruber): ahendriksen suggested to copy elements instead of bytes, but it generates about 20 instructions more
@@ -502,7 +501,7 @@ _CCCL_DEVICE void memcpy_async_maybe_unaligned(void* dst, const void* src, unsig
 
 // Turning this function into a lambda will make nvcc generate it once for each iterator instead of for each distinct
 // value type (which may be less).
-template <int BlockThreads, typename AlignedPtr, typename Offset>
+template <int ThreadsPerBlock, typename AlignedPtr, typename Offset>
 _CCCL_DEVICE auto
 copy_and_return_smem_dst(AlignedPtr aligned_ptr, int& smem_offset, Offset offset, char* smem, int valid_items)
 {
@@ -531,13 +530,13 @@ copy_and_return_smem_dst(AlignedPtr aligned_ptr, int& smem_offset, Offset offset
   }
 
   smem_offset += bytes_to_copy; // leaves aligned address for follow-up copy
-  memcpy_async_aligned<BlockThreads>(dst, src, bytes_to_copy);
+  memcpy_async_aligned<ThreadsPerBlock>(dst, src, bytes_to_copy);
   const char* const dst_start_of_data = dst + (alignof(T) < ldgsts_size_and_align ? aligned_ptr.head_padding : 0);
   _CCCL_ASSERT(reinterpret_cast<uintptr_t>(dst_start_of_data) % alignof(T) == 0, "");
   return reinterpret_cast<const T*>(dst_start_of_data);
 }
 
-template <int BlockThreads, typename AlignedPtr, typename Offset>
+template <int ThreadsPerBlock, typename AlignedPtr, typename Offset>
 _CCCL_DEVICE auto copy_and_return_smem_dst_fallback(
   AlignedPtr aligned_ptr, int& smem_offset, Offset offset, char* smem, int valid_items, int tile_size)
 {
@@ -560,7 +559,7 @@ _CCCL_DEVICE auto copy_and_return_smem_dst_fallback(
   _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(src), "");
   _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(dst), "");
   const int bytes_to_copy = int{sizeof(T)} * valid_items;
-  memcpy_async_maybe_unaligned<BlockThreads>(dst, src, bytes_to_copy, head_padding);
+  memcpy_async_maybe_unaligned<ThreadsPerBlock>(dst, src, bytes_to_copy, head_padding);
 
   // add ldgsts_size_and_align to account for this tile's head padding
   smem_offset += ldgsts_size_and_align + int{sizeof(T)} * tile_size;

--- a/cub/cub/device/dispatch/tuning/tuning_merge_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_merge_sort.cuh
@@ -25,14 +25,14 @@
 
 CUB_NAMESPACE_BEGIN
 
-template <int BlockThreads,
+template <int ThreadsPerBlock,
           int ItemsPerThread                      = 1,
           cub::BlockLoadAlgorithm LoadAlgorithm   = cub::BLOCK_LOAD_DIRECT,
           cub::CacheLoadModifier LoadModifier     = cub::LOAD_LDG,
           cub::BlockStoreAlgorithm StoreAlgorithm = cub::BLOCK_STORE_DIRECT>
 struct AgentMergeSortPolicy
 {
-  static constexpr int BLOCK_THREADS    = BlockThreads;
+  static constexpr int BLOCK_THREADS    = ThreadsPerBlock;
   static constexpr int ITEMS_PER_THREAD = ItemsPerThread;
   static constexpr int ITEMS_PER_TILE   = BLOCK_THREADS * ITEMS_PER_THREAD;
 

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -827,7 +827,7 @@ struct RadixSortPolicyWrapper<
   }
 
   template <typename PolicyT>
-  _CCCL_HOST_DEVICE static constexpr int BlockThreads(PolicyT /*policy*/)
+  _CCCL_HOST_DEVICE static constexpr int ThreadsPerBlock(PolicyT /*policy*/)
   {
     return PolicyT::BLOCK_THREADS;
   }

--- a/cub/cub/device/dispatch/tuning/tuning_segmented_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_segmented_sort.cuh
@@ -314,7 +314,7 @@ struct SegmentedSortPolicyWrapper<StaticPolicyT,
     return StaticPolicyT::LargeSegmentPolicy::RADIX_BITS;
   }
 
-  _CCCL_HOST_DEVICE static constexpr int LargeSegmentBlockThreads()
+  _CCCL_HOST_DEVICE static constexpr int LargeSegmentThreadsPerBlock()
   {
     return StaticPolicyT::LargeSegmentPolicy::BLOCK_THREADS;
   }
@@ -324,7 +324,7 @@ struct SegmentedSortPolicyWrapper<StaticPolicyT,
     return StaticPolicyT::LargeSegmentPolicy::ITEMS_PER_THREAD;
   }
 
-  _CCCL_HOST_DEVICE static constexpr int SmallSegmentBlockThreads()
+  _CCCL_HOST_DEVICE static constexpr int SmallSegmentThreadsPerBlock()
   {
     return StaticPolicyT::SmallSegmentPolicy::BLOCK_THREADS;
   }

--- a/cub/cub/util_arch.cuh
+++ b/cub/cub/util_arch.cuh
@@ -137,11 +137,12 @@ scale_reg_bound(int nominal_4B_block_threads, int nominal_4B_items_per_thread, i
   return {items_per_thread, block_threads};
 }
 
-template <int Nominal4ByteBlockThreads, int Nominal4ByteItemsPerThread, typename T>
+template <int Nominal4ByteThreadsPerBlock, int Nominal4ByteItemsPerThread, typename T>
 struct RegBoundScaling
 {
 private:
-  static constexpr auto result = scale_reg_bound(Nominal4ByteBlockThreads, Nominal4ByteItemsPerThread, int{sizeof(T)});
+  static constexpr auto result =
+    scale_reg_bound(Nominal4ByteThreadsPerBlock, Nominal4ByteItemsPerThread, int{sizeof(T)});
 
 public:
   static constexpr int ITEMS_PER_THREAD = result.items_per_thread;
@@ -159,22 +160,23 @@ scale_mem_bound(int nominal_4B_block_threads, int nominal_4B_items_per_thread, i
   return {items_per_thread, block_threads};
 }
 
-template <int Nominal4ByteBlockThreads, int Nominal4ByteItemsPerThread, typename T>
+template <int Nominal4ByteThreadsPerBlock, int Nominal4ByteItemsPerThread, typename T>
 struct MemBoundScaling
 {
 private:
-  static constexpr auto result = scale_mem_bound(Nominal4ByteBlockThreads, Nominal4ByteItemsPerThread, int{sizeof(T)});
+  static constexpr auto result =
+    scale_mem_bound(Nominal4ByteThreadsPerBlock, Nominal4ByteItemsPerThread, int{sizeof(T)});
 
 public:
   static constexpr int ITEMS_PER_THREAD = result.items_per_thread;
   static constexpr int BLOCK_THREADS    = result.block_threads;
 };
 
-template <int Nominal4ByteBlockThreads, int Nominal4ByteItemsPerThread, typename = void>
+template <int Nominal4ByteThreadsPerBlock, int Nominal4ByteItemsPerThread, typename = void>
 struct NoScaling
 {
   static constexpr int ITEMS_PER_THREAD = Nominal4ByteItemsPerThread;
-  static constexpr int BLOCK_THREADS    = Nominal4ByteBlockThreads;
+  static constexpr int BLOCK_THREADS    = Nominal4ByteThreadsPerBlock;
 };
 
 [[nodiscard]] _CCCL_API constexpr ::cuda::compute_capability current_tuning_cc() noexcept

--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -678,7 +678,7 @@ _CCCL_CONCEPT always_true = true;
 // TODO(bgruber): drop in CCCL 4.0 when we drop the dispatchers
 // Generic agent policy
 CUB_DETAIL_POLICY_WRAPPER_DEFINE(
-  GenericAgentPolicy, (always_true), (BLOCK_THREADS, BlockThreads, int), (ITEMS_PER_THREAD, ItemsPerThread, int) )
+  GenericAgentPolicy, (always_true), (BLOCK_THREADS, ThreadsPerBlock, int), (ITEMS_PER_THREAD, ItemsPerThread, int) )
 
 // TODO(bgruber): drop in CCCL 4.0 when we drop the dispatchers
 _CCCL_TEMPLATE(typename PolicyT)
@@ -727,7 +727,7 @@ struct KernelConfig
   CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t
   Init(KernelPtrT kernel_ptr, AgentPolicyT agent_policy = {}, LauncherFactory launcher_factory = {})
   {
-    block_threads    = cub::detail::MakePolicyWrapper(agent_policy).BlockThreads();
+    block_threads    = cub::detail::MakePolicyWrapper(agent_policy).ThreadsPerBlock();
     items_per_thread = cub::detail::MakePolicyWrapper(agent_policy).ItemsPerThread();
     tile_size        = block_threads * items_per_thread;
     return launcher_factory.MaxSmOccupancy(sm_occupancy, kernel_ptr, block_threads);

--- a/cub/test/catch2_test_device_adjacent_difference_env.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_env.cu
@@ -165,13 +165,13 @@ struct block_size_extracting_minus_t
   }
 };
 
-template <int BlockThreads>
+template <int ThreadsPerBlock>
 struct adj_diff_tuning
 {
   _CCCL_API constexpr auto operator()(cuda::compute_capability) const
     -> cub::detail::adjacent_difference::adjacent_difference_policy
   {
-    return {BlockThreads, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_STORE_DIRECT};
+    return {ThreadsPerBlock, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_STORE_DIRECT};
   }
 };
 

--- a/cub/test/catch2_test_device_for_env.cu
+++ b/cub/test/catch2_test_device_for_env.cu
@@ -147,12 +147,12 @@ C2H_TEST("DeviceFor::ForEachCopy env uses custom stream", "[for][env]")
   REQUIRE(count == expected_count);
 }
 
-template <int BlockThreads>
+template <int ThreadsPerBlock>
 struct for_each_tuning
 {
   _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::detail::for_each::for_policy
   {
-    return {BlockThreads, 2};
+    return {ThreadsPerBlock, 2};
   }
 };
 

--- a/cub/test/catch2_test_device_merge_env.cu
+++ b/cub/test/catch2_test_device_merge_env.cu
@@ -26,12 +26,12 @@ namespace stdexec = cuda::std::execution;
 
 using block_size_extracting_less_t = block_size_extracting_op<cuda::std::less<>>;
 
-template <int BlockThreads>
+template <int ThreadsPerBlock>
 struct merge_tuning
 {
   _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::detail::merge::merge_policy
   {
-    return {BlockThreads, 1, cub::LOAD_DEFAULT, cub::BLOCK_STORE_WARP_TRANSPOSE, false};
+    return {ThreadsPerBlock, 1, cub::LOAD_DEFAULT, cub::BLOCK_STORE_WARP_TRANSPOSE, false};
   }
 };
 

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -32,12 +32,12 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceMergeSort::StableSortKeysCopy, device_merge_st
 
 namespace stdexec = cuda::std::execution;
 
-template <int BlockThreads>
+template <int ThreadsPerBlock>
 struct merge_sort_tuning
 {
   _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::detail::merge_sort::merge_sort_policy
   {
-    return {BlockThreads, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_STORE_DIRECT};
+    return {ThreadsPerBlock, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_STORE_DIRECT};
   }
 };
 

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -91,13 +91,13 @@ TEST_CASE("Device sum works with default environment", "[reduce][device]")
   REQUIRE(d_out[0] == num_items);
 }
 
-template <int BlockThreads>
+template <int ThreadsPerBlock>
 struct reduce_tuning
 {
   _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::detail::reduce::reduce_policy
   {
     const auto policy = cub::detail::reduce::agent_reduce_policy{
-      BlockThreads, 1, 1, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_DEFAULT};
+      ThreadsPerBlock, 1, 1, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_DEFAULT};
     return {policy, policy, policy};
   }
 };

--- a/cub/test/catch2_test_device_run_length_encode_env.cu
+++ b/cub/test/catch2_test_device_run_length_encode_env.cu
@@ -28,23 +28,23 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceRunLengthEncode::NonTrivialRuns, non_trivial_r
 
 namespace stdexec = cuda::std::execution;
 
-template <int BlockThreads>
+template <int ThreadsPerBlock>
 struct rle_encode_tuning
 {
   _CCCL_API constexpr auto operator()(cuda::compute_capability) const
     -> cub::detail::reduce_by_key::reduce_by_key_policy
   {
-    return {BlockThreads, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_SCAN_WARP_SCANS, {}};
+    return {ThreadsPerBlock, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_SCAN_WARP_SCANS, {}};
   }
 };
 
-template <int BlockThreads>
+template <int ThreadsPerBlock>
 struct rle_non_trivial_runs_tuning
 {
   _CCCL_API constexpr auto operator()(cuda::compute_capability) const
     -> cub::detail::rle::non_trivial_runs::rle_non_trivial_runs_policy
   {
-    return {BlockThreads, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, false, cub::BLOCK_SCAN_WARP_SCANS, {}};
+    return {ThreadsPerBlock, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, false, cub::BLOCK_SCAN_WARP_SCANS, {}};
   }
 };
 

--- a/cub/test/catch2_test_device_scan_env.cu
+++ b/cub/test/catch2_test_device_scan_env.cu
@@ -105,13 +105,13 @@ TEST_CASE("Device scan exclusive sum works with default environment", "[sum][dev
   REQUIRE(d_out[1] == value_t{} + d_in[0]);
 }
 
-template <int BlockThreads>
+template <int ThreadsPerBlock>
 struct scan_tuning
 {
   _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::detail::scan::scan_policy
   {
     return {cub::detail::scan::scan_algorithm::lookback,
-            {BlockThreads,
+            {ThreadsPerBlock,
              1,
              cub::BlockLoadAlgorithm::BLOCK_LOAD_WARP_TRANSPOSE,
              cub::CacheLoadModifier::LOAD_DEFAULT,

--- a/cub/test/catch2_test_device_segmented_reduce_env.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_env.cu
@@ -362,17 +362,17 @@ C2H_TEST("Device segmented argmax uses environment", "[segmented_reduce][device]
   REQUIRE(d_out == expected);
 }
 
-template <int BlockThreads>
+template <int ThreadsPerBlock>
 struct segmented_reduce_tuning
 {
   _CCCL_API constexpr auto operator()(::cuda::compute_capability) const
     -> cub::detail::segmented_reduce::segmented_reduce_policy
   {
     auto rp = cub::detail::reduce::agent_reduce_policy{
-      BlockThreads, 1, 1, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_DEFAULT};
+      ThreadsPerBlock, 1, 1, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_DEFAULT};
     return {rp,
-            cub::detail::segmented_reduce::warp_reduce_policy{BlockThreads, 1, 1, 1, cub::LOAD_DEFAULT},
-            cub::detail::segmented_reduce::warp_reduce_policy{BlockThreads, 32, 1, 1, cub::LOAD_DEFAULT}};
+            cub::detail::segmented_reduce::warp_reduce_policy{ThreadsPerBlock, 1, 1, 1, cub::LOAD_DEFAULT},
+            cub::detail::segmented_reduce::warp_reduce_policy{ThreadsPerBlock, 32, 1, 1, cub::LOAD_DEFAULT}};
   }
 };
 

--- a/cub/test/catch2_test_device_segmented_scan_multi_segment.cu
+++ b/cub/test/catch2_test_device_segmented_scan_multi_segment.cu
@@ -84,14 +84,14 @@ using itp_list =
                  cuda::std::integral_constant<int, 3>,
                  cuda::std::integral_constant<int, 8>>;
 
-template <int BlockThreads, int ItemsPerThread, int MaxSegmentsPerBlock>
+template <int ThreadsPerBlock, int ItemsPerThread, int MaxSegmentsPerBlock>
 struct policy_selector_t
 {
   [[nodiscard]] _CCCL_API constexpr auto operator()(::cuda::compute_capability) const
     -> cub::detail::segmented_scan::segmented_scan_policy
   {
     return cub::detail::segmented_scan::segmented_scan_policy{cub::detail::segmented_scan::block_segmented_scan_policy{
-      BlockThreads,
+      ThreadsPerBlock,
       ItemsPerThread,
       cub::BLOCK_LOAD_WARP_TRANSPOSE,
       cub::LOAD_DEFAULT,

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -739,7 +739,7 @@ C2H_TEST("DeviceTransform::Transform does not effect unrelated kernel's static S
 
 #if TEST_LAUNCH == 0
 
-template <int BlockThreads, int ItemsPerPthread, typename T>
+template <int ThreadsPerBlock, int ItemsPerPthread, typename T>
 __global__ void fill_pdl_kernel(T* data, size_t n, T value)
 {
   // we trigger the next kernel's launch very soon and wait a bit for it to spin up before starting to write. this way
@@ -748,7 +748,7 @@ __global__ void fill_pdl_kernel(T* data, size_t n, T value)
   _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
   NV_IF_TARGET(NV_PROVIDES_SM_70, __nanosleep(100'000);); // must be enough to cover the next kernel's launch overhead
 
-  const int tile_size = ItemsPerPthread * BlockThreads;
+  const int tile_size = ItemsPerPthread * ThreadsPerBlock;
   const size_t offset = size_t{blockIdx.x} * tile_size;
 
   data += offset;
@@ -756,7 +756,7 @@ __global__ void fill_pdl_kernel(T* data, size_t n, T value)
 
   for (int j = 0; j < ItemsPerPthread; j++)
   {
-    const int i = threadIdx.x + j * BlockThreads;
+    const int i = threadIdx.x + j * ThreadsPerBlock;
     if (i < n)
     {
       data[i] = value;

--- a/cub/test/catch2_test_util_arch.cu
+++ b/cub/test/catch2_test_util_arch.cu
@@ -8,14 +8,14 @@
 template <auto V>
 struct show;
 
-template <int Nominal4ByteBlockThreads,
+template <int Nominal4ByteThreadsPerBlock,
           int Nominal4ByteItemsPerThread,
           typename ComputeT,
-          int ExpectedBlockThreads,
+          int ExpectedThreadsPerBlock,
           int ExpectedItemsPerThread>
 void check_mem_bound_scaling()
 {
-  using mbs = cub::detail::MemBoundScaling<Nominal4ByteBlockThreads, Nominal4ByteItemsPerThread, ComputeT>;
+  using mbs = cub::detail::MemBoundScaling<Nominal4ByteThreadsPerBlock, Nominal4ByteItemsPerThread, ComputeT>;
 
   if constexpr (mbs::ITEMS_PER_THREAD != ExpectedItemsPerThread)
   {
@@ -23,11 +23,11 @@ void check_mem_bound_scaling()
   }
   STATIC_REQUIRE(mbs::ITEMS_PER_THREAD == ExpectedItemsPerThread);
 
-  if constexpr (mbs::BLOCK_THREADS != ExpectedBlockThreads)
+  if constexpr (mbs::BLOCK_THREADS != ExpectedThreadsPerBlock)
   {
     show<mbs::BLOCK_THREADS>::asdf();
   }
-  STATIC_REQUIRE(mbs::BLOCK_THREADS == ExpectedBlockThreads);
+  STATIC_REQUIRE(mbs::BLOCK_THREADS == ExpectedThreadsPerBlock);
 }
 
 C2H_TEST("MemBoundScaling", "[util][arch]")
@@ -62,14 +62,14 @@ C2H_TEST("MemBoundScaling", "[util][arch]")
   check_mem_bound_scaling<256, 10000, large_t, 32, 39>();
 }
 
-template <int Nominal4ByteBlockThreads,
+template <int Nominal4ByteThreadsPerBlock,
           int Nominal4ByteItemsPerThread,
           typename ComputeT,
-          int ExpectedBlockThreads,
+          int ExpectedThreadsPerBlock,
           int ExpectedItemsPerThread>
 void check_reg_bound_scaling()
 {
-  using mbs = cub::detail::RegBoundScaling<Nominal4ByteBlockThreads, Nominal4ByteItemsPerThread, ComputeT>;
+  using mbs = cub::detail::RegBoundScaling<Nominal4ByteThreadsPerBlock, Nominal4ByteItemsPerThread, ComputeT>;
 
   if constexpr (mbs::ITEMS_PER_THREAD != ExpectedItemsPerThread)
   {
@@ -77,11 +77,11 @@ void check_reg_bound_scaling()
   }
   STATIC_REQUIRE(mbs::ITEMS_PER_THREAD == ExpectedItemsPerThread);
 
-  if constexpr (mbs::BLOCK_THREADS != ExpectedBlockThreads)
+  if constexpr (mbs::BLOCK_THREADS != ExpectedThreadsPerBlock)
   {
     show<mbs::BLOCK_THREADS>::asdf();
   }
-  STATIC_REQUIRE(mbs::BLOCK_THREADS == ExpectedBlockThreads);
+  STATIC_REQUIRE(mbs::BLOCK_THREADS == ExpectedThreadsPerBlock);
 }
 
 C2H_TEST("RegBoundScaling", "[util][arch]")

--- a/cub/test/catch2_test_vsmem.cu
+++ b/cub/test/catch2_test_vsmem.cu
@@ -46,11 +46,11 @@ struct launch_config_test_info_t
 //----------------------------------------------------------------------------
 // Tuning policy definition
 //----------------------------------------------------------------------------
-template <int BlockThreads, int ItemsPerThread>
+template <int ThreadsPerBlock, int ItemsPerThread>
 struct agent_dummy_algorithm_policy_t
 {
   static constexpr int ITEMS_PER_THREAD = ItemsPerThread;
-  static constexpr int BLOCK_THREADS    = BlockThreads;
+  static constexpr int BLOCK_THREADS    = ThreadsPerBlock;
 };
 
 //----------------------------------------------------------------------------

--- a/cub/test/test_block_radix_rank.cu
+++ b/cub/test/test_block_radix_rank.cu
@@ -23,16 +23,16 @@ bool g_verbose = false;
 cub::CachingDeviceAllocator g_allocator(true);
 
 template <cub::RadixRankAlgorithm RankAlgorithm,
-          int BlockThreads,
+          int ThreadsPerBlock,
           int ItemsPerThread,
           int RadixBits,
           cub::BlockScanAlgorithm ScanAlgorithm,
           int Descending,
           typename Key>
-__launch_bounds__(BlockThreads, 1) __global__ void kernel(Key* d_keys, int* d_ranks)
+__launch_bounds__(ThreadsPerBlock, 1) __global__ void kernel(Key* d_keys, int* d_ranks)
 {
   using block_radix_rank =
-    cub::detail::block_radix_rank_t<RankAlgorithm, BlockThreads, RadixBits, Descending, ScanAlgorithm>;
+    cub::detail::block_radix_rank_t<RankAlgorithm, ThreadsPerBlock, RadixBits, Descending, ScanAlgorithm>;
 
   using storage_t = typename block_radix_rank::TempStorage;
 
@@ -128,7 +128,7 @@ void Initialize(GenMode gen_mode, Key* h_keys, int* h_reference_ranks, int num_i
 }
 
 template <cub::RadixRankAlgorithm RankAlgorithm,
-          int BlockThreads,
+          int ThreadsPerBlock,
           int ItemsPerThread,
           int RadixBits,
           cub::BlockScanAlgorithm ScanAlgorithm,
@@ -136,7 +136,7 @@ template <cub::RadixRankAlgorithm RankAlgorithm,
           typename Key>
 void TestDriver(GenMode gen_mode)
 {
-  constexpr int tile_size = BlockThreads * ItemsPerThread;
+  constexpr int tile_size = ThreadsPerBlock * ItemsPerThread;
 
   // Allocate host arrays
   std::unique_ptr<Key[]> h_keys(new Key[tile_size]);
@@ -157,8 +157,8 @@ void TestDriver(GenMode gen_mode)
   CubDebugExit(cudaMemcpy(d_keys, h_keys.get(), sizeof(Key) * tile_size, cudaMemcpyHostToDevice));
 
   // Run kernel
-  kernel<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, ScanAlgorithm, Descending, Key>
-    <<<1, BlockThreads>>>(d_keys, d_ranks);
+  kernel<RankAlgorithm, ThreadsPerBlock, ItemsPerThread, RadixBits, ScanAlgorithm, Descending, Key>
+    <<<1, ThreadsPerBlock>>>(d_keys, d_ranks);
 
   // Flush kernel output / errors
   CubDebugExit(cudaPeekAtLastError());
@@ -180,7 +180,7 @@ void TestDriver(GenMode gen_mode)
 }
 
 template <cub::RadixRankAlgorithm RankAlgorithm,
-          int BlockThreads,
+          int ThreadsPerBlock,
           int ItemsPerThread,
           int RadixBits,
           cub::BlockScanAlgorithm ScanAlgorithm,
@@ -188,13 +188,13 @@ template <cub::RadixRankAlgorithm RankAlgorithm,
           typename Key>
 void TestValid(cuda::std::true_type /*fits_smem_capacity*/)
 {
-  TestDriver<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, ScanAlgorithm, Descending, Key>(UNIFORM);
+  TestDriver<RankAlgorithm, ThreadsPerBlock, ItemsPerThread, RadixBits, ScanAlgorithm, Descending, Key>(UNIFORM);
 
-  TestDriver<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, ScanAlgorithm, Descending, Key>(INTEGER_SEED);
+  TestDriver<RankAlgorithm, ThreadsPerBlock, ItemsPerThread, RadixBits, ScanAlgorithm, Descending, Key>(INTEGER_SEED);
 }
 
 template <cub::RadixRankAlgorithm RankAlgorithm,
-          int BlockThreads,
+          int ThreadsPerBlock,
           int ItemsPerThread,
           int RadixBits,
           cub::BlockScanAlgorithm ScanAlgorithm,
@@ -204,7 +204,7 @@ void TestValid(cuda::std::false_type fits_smem_capacity)
 {}
 
 template <cub::RadixRankAlgorithm RankAlgorithm,
-          int BlockThreads,
+          int ThreadsPerBlock,
           int ItemsPerThread,
           int RadixBits,
           cub::BlockScanAlgorithm ScanAlgorithm,
@@ -214,79 +214,80 @@ void Test()
 {
   // Check size of smem storage for the target arch to make sure it will fit
   using block_radix_rank =
-    cub::detail::block_radix_rank_t<RankAlgorithm, BlockThreads, RadixBits, Descending, ScanAlgorithm>;
+    cub::detail::block_radix_rank_t<RankAlgorithm, ThreadsPerBlock, RadixBits, Descending, ScanAlgorithm>;
   using storage_t = typename block_radix_rank::TempStorage;
 
   cuda::std::bool_constant<(sizeof(storage_t) <= cub::detail::max_smem_per_block)> fits_smem_capacity;
 
-  TestValid<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, ScanAlgorithm, Descending, Key>(fits_smem_capacity);
+  TestValid<RankAlgorithm, ThreadsPerBlock, ItemsPerThread, RadixBits, ScanAlgorithm, Descending, Key>(
+    fits_smem_capacity);
 }
 
 template <cub::RadixRankAlgorithm RankAlgorithm,
-          int BlockThreads,
+          int ThreadsPerBlock,
           int ItemsPerThread,
           int RadixBits,
           cub::BlockScanAlgorithm ScanAlgorithm,
           typename Key>
 void Test()
 {
-  Test<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, ScanAlgorithm, true, Key>();
-  Test<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, ScanAlgorithm, false, Key>();
+  Test<RankAlgorithm, ThreadsPerBlock, ItemsPerThread, RadixBits, ScanAlgorithm, true, Key>();
+  Test<RankAlgorithm, ThreadsPerBlock, ItemsPerThread, RadixBits, ScanAlgorithm, false, Key>();
 }
 
 template <cub::RadixRankAlgorithm RankAlgorithm,
-          int BlockThreads,
+          int ThreadsPerBlock,
           int ItemsPerThread,
           int RadixBits,
           cub::BlockScanAlgorithm ScanAlgorithm>
 void Test()
 {
-  Test<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, ScanAlgorithm, std::uint8_t>();
-  Test<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, ScanAlgorithm, std::uint16_t>();
+  Test<RankAlgorithm, ThreadsPerBlock, ItemsPerThread, RadixBits, ScanAlgorithm, std::uint8_t>();
+  Test<RankAlgorithm, ThreadsPerBlock, ItemsPerThread, RadixBits, ScanAlgorithm, std::uint16_t>();
 }
 
-template <cub::RadixRankAlgorithm RankAlgorithm, int BlockThreads, int ItemsPerThread, int RadixBits>
+template <cub::RadixRankAlgorithm RankAlgorithm, int ThreadsPerBlock, int ItemsPerThread, int RadixBits>
 void Test()
 {
-  Test<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, cub::BLOCK_SCAN_RAKING>();
-  Test<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, cub::BLOCK_SCAN_WARP_SCANS>();
+  Test<RankAlgorithm, ThreadsPerBlock, ItemsPerThread, RadixBits, cub::BLOCK_SCAN_RAKING>();
+  Test<RankAlgorithm, ThreadsPerBlock, ItemsPerThread, RadixBits, cub::BLOCK_SCAN_WARP_SCANS>();
 }
 
-template <cub::RadixRankAlgorithm RankAlgorithm, int BlockThreads, int ItemsPerThread>
+template <cub::RadixRankAlgorithm RankAlgorithm, int ThreadsPerBlock, int ItemsPerThread>
 void Test()
 {
-  Test<RankAlgorithm, BlockThreads, ItemsPerThread, 1>();
-  Test<RankAlgorithm, BlockThreads, ItemsPerThread, 5>();
+  Test<RankAlgorithm, ThreadsPerBlock, ItemsPerThread, 1>();
+  Test<RankAlgorithm, ThreadsPerBlock, ItemsPerThread, 5>();
 }
 
-template <cub::RadixRankAlgorithm RankAlgorithm, int BlockThreads>
+template <cub::RadixRankAlgorithm RankAlgorithm, int ThreadsPerBlock>
 void Test()
 {
-  Test<RankAlgorithm, BlockThreads, 1>();
-  Test<RankAlgorithm, BlockThreads, 4>();
+  Test<RankAlgorithm, ThreadsPerBlock, 1>();
+  Test<RankAlgorithm, ThreadsPerBlock, 4>();
 }
 
-template <int BlockThreads>
+template <int ThreadsPerBlock>
 void Test(cuda::std::true_type /* multiple of hw warp */)
 {
-  Test<cub::RadixRankAlgorithm::RADIX_RANK_MATCH, BlockThreads>();
+  Test<cub::RadixRankAlgorithm::RADIX_RANK_MATCH, ThreadsPerBlock>();
 
   // TODO(senior-zero):
   // - RADIX_RANK_MATCH_EARLY_COUNTS_ANY
   // - RADIX_RANK_MATCH_EARLY_COUNTS_ATOMIC_OR
 }
 
-template <int BlockThreads>
+template <int ThreadsPerBlock>
 void Test(cuda::std::false_type /* multiple of hw warp */)
 {}
 
-template <int BlockThreads>
+template <int ThreadsPerBlock>
 void Test()
 {
-  Test<cub::RadixRankAlgorithm::RADIX_RANK_BASIC, BlockThreads>();
-  Test<cub::RadixRankAlgorithm::RADIX_RANK_MEMOIZE, BlockThreads>();
+  Test<cub::RadixRankAlgorithm::RADIX_RANK_BASIC, ThreadsPerBlock>();
+  Test<cub::RadixRankAlgorithm::RADIX_RANK_MEMOIZE, ThreadsPerBlock>();
 
-  Test<BlockThreads>(cuda::std::bool_constant < (BlockThreads % 32) == 0 > {});
+  Test<ThreadsPerBlock>(cuda::std::bool_constant < (ThreadsPerBlock % 32) == 0 > {});
 }
 
 int main(int argc, char** argv)

--- a/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
@@ -118,8 +118,8 @@ using __dims_of_t = typename _Config::hierarchy_type;
 // sender. The receiver is where most algorithms do their work, so we want the receiver to
 // tell us how to launch the kernel that completes it. Thus, the launch configuration is
 // read from the outer receiver's environment.
-template <int _BlockThreads, class _Rcvr, class _Variant>
-_CCCL_VISIBILITY_HIDDEN __launch_bounds__(_BlockThreads) __global__
+template <int _ThreadsPerBlock, class _Rcvr, class _Variant>
+_CCCL_VISIBILITY_HIDDEN __launch_bounds__(_ThreadsPerBlock) __global__
   void __completion_kernel(__state_base_t<_Rcvr, _Variant>* __state)
 {
   _CCCL_ASSERT(__state->__results_.__index() != __npos, "__completion_kernel called with empty results");

--- a/cudax/include/cuda/experimental/__execution/stream/scheduler.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/scheduler.cuh
@@ -46,9 +46,9 @@ namespace cuda::experimental
 {
 namespace execution
 {
-template <int _BlockThreads, class _Tag, class _Rcvr>
+template <int _ThreadsPerBlock, class _Tag, class _Rcvr>
 //_CCCL_VISIBILITY_HIDDEN
-__launch_bounds__(_BlockThreads) __global__ void __stream_complete(_Tag, _Rcvr* __rcvr)
+__launch_bounds__(_ThreadsPerBlock) __global__ void __stream_complete(_Tag, _Rcvr* __rcvr)
 {
   _Tag{}(static_cast<_Rcvr&&>(*__rcvr));
 }

--- a/libcudacxx/test/libcudacxx/cuda/execution/tune.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/execution/tune.pass.cpp
@@ -17,12 +17,12 @@ struct reduce_policy
   int block_threads;
 };
 
-template <int BlockThreads, class T>
+template <int ThreadsPerBlock, class T>
 struct reduce_policy_selector
 {
   TEST_FUNC constexpr auto operator()(cuda::compute_capability) const -> reduce_policy
   {
-    return {BlockThreads / sizeof(T)};
+    return {ThreadsPerBlock / sizeof(T)};
   }
 };
 

--- a/nvbench_helper/nvbench_helper/device_side_benchmark.cuh
+++ b/nvbench_helper/nvbench_helper/device_side_benchmark.cuh
@@ -32,8 +32,8 @@ __device__ __forceinline__ static void sink(T value)
   }
 }
 
-template <int BlockThreads, int UnrollFactor, typename ActionT, typename T>
-__launch_bounds__(BlockThreads) __global__ static void benchmark_kernel(_CCCL_GRID_CONSTANT const ActionT action)
+template <int ThreadsPerBlock, int UnrollFactor, typename ActionT, typename T>
+__launch_bounds__(ThreadsPerBlock) __global__ static void benchmark_kernel(_CCCL_GRID_CONSTANT const ActionT action)
 {
   auto data = generate_random_data<T>();
   cuda::static_for<UnrollFactor>([&]([[maybe_unused]] auto _) {


### PR DESCRIPTION
After some internal discussion in the context of how we name tuning policy members, we concluded that the term "threads per block" was more comprehensible than "block threads". This PR:

* Renames exact matches of `BlockThreads` in template parameters to `ThreadsPerBlock`
* The use of `BlockThreads` in a single `static_assert`
* All matches of `BlockThreads()` functions in tuning policy wrappers (internal stuff in CUB for CCCL.C)
* The remaining uses of `BlockThreads`

One commit each.