### PR TITLE
Workaround a gcc issue

### DIFF
--- a/cub/test/catch2_test_device_segmented_reduce_env.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_env.cu
@@ -370,9 +370,11 @@ struct segmented_reduce_tuning
   {
     auto rp = cub::detail::reduce::agent_reduce_policy{
       ThreadsPerBlock, 1, 1, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_DEFAULT};
-    return {rp,
-            cub::detail::segmented_reduce::warp_reduce_policy{ThreadsPerBlock, 1, 1, 1, cub::LOAD_DEFAULT},
-            cub::detail::segmented_reduce::warp_reduce_policy{ThreadsPerBlock, 32, 1, 1, cub::LOAD_DEFAULT}};
+    // need the repetition of the return type for GCC9
+    return cub::detail::segmented_reduce::segmented_reduce_policy{
+      rp,
+      cub::detail::segmented_reduce::warp_reduce_policy{ThreadsPerBlock, 1, 1, 1, cub::LOAD_DEFAULT},
+      cub::detail::segmented_reduce::warp_reduce_policy{ThreadsPerBlock, 32, 1, 1, cub::LOAD_DEFAULT}};
   }
 };
 


### PR DESCRIPTION
Fixes:
```
error: could not convert ‘{rp, ...}’ from ‘<brace-enclosed initializer list>’ to ‘cub::...::segmented_reduce_policy’
```

This came up in the nightly builds. See for example: https://github.com/NVIDIA/cccl/actions/runs/25381896067/job/74432291955