### PR TITLE
[Thrust] Fix value type calculation of `thrust::zip_iterator`

### DIFF
--- a/cub/test/catch2_test_device_for_api.cu
+++ b/cub/test/catch2_test_device_for_api.cu
@@ -8,6 +8,10 @@
 #include <thrust/count.h>
 #include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/device_vector.h>
+#include <thrust/iterator/zip_iterator.h>
+
+#include <cuda/iterator>
+#include <cuda/std/tuple>
 
 #include <c2h/catch2_test_helper.h>
 
@@ -47,6 +51,26 @@ struct odd_count_t
   }
 };
 // example-end bulk-odd-count-t
+
+struct assign_zip_value_t
+{
+  template <class Tuple>
+  __device__ void operator()(Tuple tuple) const
+  {
+    cuda::std::get<1>(tuple) = cuda::std::get<0>(tuple);
+  }
+};
+
+template <class OutputIt>
+struct tabulate_output_op
+{
+  OutputIt output;
+
+  __device__ void operator()(int idx, int value) const
+  {
+    output[idx] = value;
+  }
+};
 
 C2H_TEST("Device bulk works with temporary storage", "[bulk][device]")
 {
@@ -142,6 +166,40 @@ C2H_TEST("Device for each n works without temporary storage", "[for_each][device
   // example-end for-each-n-wo-temp-storage
 
   REQUIRE(vec == expected);
+}
+
+C2H_TEST("Device for each n works with a tabulate output iterator in a thrust zip iterator", "[for_each][device]")
+{
+  c2h::device_vector<int> input = {1, 2, 3, 4};
+  c2h::device_vector<int> output(input.size());
+
+  auto output_it = cuda::tabulate_output_iterator{tabulate_output_op<decltype(output.begin())>{output.begin()}};
+  auto zipped_it = thrust::make_zip_iterator(input.begin(), output_it);
+
+  auto result = cub::DeviceFor::ForEachN(zipped_it, input.size(), assign_zip_value_t{});
+  if (result != cudaSuccess)
+  {
+    std::cerr << "ForEachN operation failed with error code: " << result << '\n';
+  }
+
+  REQUIRE(output == input);
+}
+
+C2H_TEST("Device for each n works with a tabulate output iterator in a cuda zip iterator", "[for_each][device]")
+{
+  c2h::device_vector<int> input = {1, 2, 3, 4};
+  c2h::device_vector<int> output(input.size());
+
+  auto output_it = cuda::tabulate_output_iterator{tabulate_output_op<decltype(output.begin())>{output.begin()}};
+  auto zipped_it = cuda::make_zip_iterator(input.begin(), output_it);
+
+  auto result = cub::DeviceFor::ForEachN(zipped_it, input.size(), assign_zip_value_t{});
+  if (result != cudaSuccess)
+  {
+    std::cerr << "ForEachN operation failed with error code: " << result << '\n';
+  }
+
+  REQUIRE(output == input);
 }
 
 C2H_TEST("Device for each works with temporary storage", "[for_each][device]")

--- a/thrust/testing/catch2_test_binary_search.cu
+++ b/thrust/testing/catch2_test_binary_search.cu
@@ -3,6 +3,7 @@
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 
+#include <cuda/iterator>
 #include <cuda/std/cstdint>
 
 #include "catch2_test_helper.h"
@@ -64,6 +65,32 @@ TEST_CASE("ScalarLowerBoundDispatchImplicit", "[binary_search]")
   thrust::lower_bound(thrust::retag<my_tag>(vec.begin()), thrust::retag<my_tag>(vec.end()), 0);
 
   CHECK(13 == vec.front());
+}
+
+template <class OutputIt>
+struct tabulate_lower_bound_output_op
+{
+  OutputIt output;
+
+  _CCCL_DEVICE void operator()(int idx, int value) const
+  {
+    output[idx] = value;
+  }
+};
+
+TEST_CASE("VectorLowerBoundWithTabulateOutputIterator", "[binary_search]")
+{
+  thrust::device_vector<int> haystack = {0, 2, 4, 6};
+  thrust::device_vector<int> needles  = {1, 3, 5, 7};
+  thrust::device_vector<int> output(needles.size());
+
+  auto output_it =
+    cuda::tabulate_output_iterator{tabulate_lower_bound_output_op<decltype(output.begin())>{output.begin()}};
+
+  thrust::lower_bound(haystack.begin(), haystack.end(), needles.begin(), needles.end(), output_it);
+
+  thrust::device_vector<int> expected = {1, 2, 3, 4};
+  CHECK(output == expected);
 }
 
 TEMPLATE_LIST_TEST_CASE("ScalarUpperBoundSimple", "[binary_search]", vector_list)

--- a/thrust/testing/zip_iterator.cu
+++ b/thrust/testing/zip_iterator.cu
@@ -4,6 +4,7 @@
 #include <thrust/sequence.h>
 #include <thrust/transform.h>
 
+#include <cuda/iterator>
 #include <cuda/std/type_traits>
 
 #include <unittest/unittest.h>
@@ -15,27 +16,112 @@ void TestZipIteratorTraits()
 {
   using base_it = thrust::host_vector<int>::iterator;
 
-  using it        = thrust::zip_iterator<cuda::std::tuple<base_it, base_it>>;
-  using traits    = cuda::std::iterator_traits<it>;
-  using reference = thrust::detail::tuple_of_iterator_references<int&, int&>;
+  {
+    using it        = thrust::zip_iterator<cuda::std::tuple<base_it, base_it>>;
+    using traits    = cuda::std::iterator_traits<it>;
+    using reference = thrust::detail::tuple_of_iterator_references<int&, int&>;
 
-  static_assert(cuda::std::is_same_v<traits::difference_type, ptrdiff_t>);
-  static_assert(cuda::std::is_same_v<traits::value_type, cuda::std::tuple<int, int>>);
-  static_assert(cuda::std::is_same_v<traits::pointer, void>);
+    static_assert(cuda::std::is_same_v<traits::difference_type, ptrdiff_t>);
+    static_assert(cuda::std::is_same_v<traits::value_type, cuda::std::tuple<int, int>>);
+    static_assert(cuda::std::is_same_v<traits::pointer, void>);
 
-  static_assert(cuda::std::is_same_v<traits::reference, reference>);
-  static_assert(cuda::std::is_same_v<traits::iterator_category, ::cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::is_same_v<traits::reference, reference>);
+    static_assert(cuda::std::is_same_v<traits::iterator_category, ::cuda::std::random_access_iterator_tag>);
 
-  static_assert(cuda::std::is_same_v<thrust::iterator_traversal_t<it>, thrust::random_access_traversal_tag>);
+    static_assert(cuda::std::is_same_v<thrust::iterator_traversal_t<it>, thrust::random_access_traversal_tag>);
 
-  static_assert(cuda::std::__has_random_access_traversal<it>);
+    static_assert(cuda::std::__has_random_access_traversal<it>);
 
-  static_assert(!cuda::std::output_iterator<it, int>);
-  static_assert(cuda::std::input_iterator<it>);
-  static_assert(cuda::std::forward_iterator<it>);
-  static_assert(cuda::std::bidirectional_iterator<it>);
-  static_assert(cuda::std::random_access_iterator<it>);
-  static_assert(!cuda::std::contiguous_iterator<it>);
+    static_assert(!cuda::std::output_iterator<it, int>);
+    static_assert(cuda::std::input_iterator<it>);
+    static_assert(cuda::std::forward_iterator<it>);
+    static_assert(cuda::std::bidirectional_iterator<it>);
+    static_assert(cuda::std::random_access_iterator<it>);
+    static_assert(!cuda::std::contiguous_iterator<it>);
+  }
+
+  { // working with proxy iterator cuda::discard_iterator
+    using it         = thrust::zip_iterator<cuda::std::tuple<base_it, cuda::discard_iterator>>;
+    using traits     = cuda::std::iterator_traits<it>;
+    using value_type = cuda::std::tuple<int, cuda::discard_iterator::__discard_proxy>;
+    using reference  = thrust::detail::tuple_of_iterator_references<int&, cuda::discard_iterator::__discard_proxy>;
+
+    static_assert(cuda::std::is_same_v<typename traits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::is_same_v<typename traits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::is_same_v<typename traits::value_type, value_type>);
+    static_assert(cuda::std::is_same_v<typename traits::reference, reference>);
+
+    static_assert(!cuda::std::output_iterator<it, int>);
+    static_assert(cuda::std::input_iterator<it>);
+    static_assert(cuda::std::forward_iterator<it>);
+    static_assert(cuda::std::bidirectional_iterator<it>);
+    static_assert(cuda::std::random_access_iterator<it>);
+    static_assert(!cuda::std::contiguous_iterator<it>);
+  }
+
+  { // working with proxy iterator cuda::tabulate_output_iterator
+    using it =
+      thrust::zip_iterator<cuda::std::tuple<base_it, cuda::tabulate_output_iterator<cuda::std::plus<>, short>>>;
+    using traits     = cuda::std::iterator_traits<it>;
+    using value_type = cuda::std::tuple<int, cuda::__tabulate_proxy<cuda::std::plus<>, short>>;
+    using reference =
+      thrust::detail::tuple_of_iterator_references<int&, cuda::__tabulate_proxy<cuda::std::plus<>, short>>;
+
+    static_assert(cuda::std::is_same_v<typename traits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::is_same_v<typename traits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::is_same_v<typename traits::value_type, value_type>);
+    static_assert(cuda::std::is_same_v<typename traits::reference, reference>);
+
+    static_assert(!cuda::std::output_iterator<it, int>);
+    static_assert(cuda::std::input_iterator<it>);
+    static_assert(cuda::std::forward_iterator<it>);
+    static_assert(cuda::std::bidirectional_iterator<it>);
+    static_assert(cuda::std::random_access_iterator<it>);
+    static_assert(!cuda::std::contiguous_iterator<it>);
+  }
+
+  { // working with proxy iterator cuda::transform_output_iterator
+    using it =
+      thrust::zip_iterator<cuda::std::tuple<base_it, cuda::transform_output_iterator<cuda::std::plus<>, short*>>>;
+    using traits     = cuda::std::iterator_traits<it>;
+    using value_type = cuda::std::tuple<int, cuda::__transform_output_proxy<cuda::std::plus<>, short*>>;
+    using reference =
+      thrust::detail::tuple_of_iterator_references<int&, cuda::__transform_output_proxy<cuda::std::plus<>, short*>>;
+
+    static_assert(cuda::std::is_same_v<typename traits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::is_same_v<typename traits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::is_same_v<typename traits::value_type, value_type>);
+    static_assert(cuda::std::is_same_v<typename traits::reference, reference>);
+
+    static_assert(!cuda::std::output_iterator<it, int>);
+    static_assert(cuda::std::input_iterator<it>);
+    static_assert(cuda::std::forward_iterator<it>);
+    static_assert(cuda::std::bidirectional_iterator<it>);
+    static_assert(cuda::std::random_access_iterator<it>);
+    static_assert(!cuda::std::contiguous_iterator<it>);
+  }
+
+  { // working with proxy iterator cuda::transform_input_output_iterator
+    using it = thrust::zip_iterator<
+      cuda::std::tuple<base_it, cuda::transform_input_output_iterator<cuda::std::negate<>, cuda::std::plus<>, short*>>>;
+    using traits     = cuda::std::iterator_traits<it>;
+    using value_type = cuda::std::tuple<int, int>;
+    using reference  = thrust::detail::tuple_of_iterator_references<
+       int&,
+       cuda::__transform_input_output_proxy<cuda::std::negate<>, cuda::std::plus<>, short*>>;
+
+    static_assert(cuda::std::is_same_v<typename traits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::is_same_v<typename traits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::is_same_v<typename traits::value_type, value_type>);
+    static_assert(cuda::std::is_same_v<typename traits::reference, reference>);
+
+    static_assert(!cuda::std::output_iterator<it, int>);
+    static_assert(cuda::std::input_iterator<it>);
+    static_assert(cuda::std::forward_iterator<it>);
+    static_assert(cuda::std::bidirectional_iterator<it>);
+    static_assert(cuda::std::random_access_iterator<it>);
+    static_assert(!cuda::std::contiguous_iterator<it>);
+  }
 }
 DECLARE_UNITTEST(TestZipIteratorTraits);
 

--- a/thrust/thrust/iterator/zip_iterator.h
+++ b/thrust/thrust/iterator/zip_iterator.h
@@ -31,6 +31,7 @@
 #include <thrust/iterator/iterator_facade.h>
 #include <thrust/iterator/iterator_traits.h>
 
+#include <cuda/__iterator/zip_common.h>
 #include <cuda/std/__iterator/advance.h>
 #include <cuda/std/__iterator/distance.h>
 #include <cuda/std/__type_traits/conditional.h>
@@ -58,18 +59,11 @@ struct make_zip_iterator_base
 template <typename... Its>
 struct make_zip_iterator_base<::cuda::std::tuple<Its...>>
 {
-  // We need this to make proxy iterators work because those have a void reference type
-  template <class Iter>
-  using zip_iterator_reference_t =
-    ::cuda::std::conditional_t<::cuda::std::is_same_v<it_reference_t<Iter>, void>,
-                               decltype(*::cuda::std::declval<Iter>()),
-                               it_reference_t<Iter>>;
-
   // reference type is the type of the tuple obtained from the iterator's reference types.
-  using reference = tuple_of_iterator_references<zip_iterator_reference_t<Its>...>;
+  using reference = tuple_of_iterator_references<::cuda::__zip_maybe_proxy_reference_t<Its>...>;
 
   // Boost's Value type is the same as reference type. using value_type = reference;
-  using value_type = ::cuda::std::tuple<it_value_t<Its>...>;
+  using value_type = ::cuda::std::tuple<::cuda::__zip_maybe_proxy_value_type_t<Its>...>;
 
   // Difference type is the first iterator's difference type
   using difference_type = it_difference_t<::cuda::std::tuple_element_t<0, ::cuda::std::tuple<Its...>>>;


### PR DESCRIPTION
`zip_iterator` needs to detect the effective `iter_value_t` of the input iterators and not just take their value type.

This is necessary because proxy iterators can have a value type of `void`, and we cannnot instantiate a `tuple<void>`

Use the same machinery as the `cuda::zip_iterator` uses

Fixes #8779
