### PR TITLE
Allow public tuning of non-ByKey `cub::DeviceScan`

### DIFF
--- a/c/parallel/src/radix_sort.cu
+++ b/c/parallel/src/radix_sort.cu
@@ -257,8 +257,8 @@ using device_radix_sort_policy = {5};
 using namespace cub;
 using namespace cub::detail;
 using namespace cub::detail::radix_sort;
-using cub::detail::delay_constructor_policy;
-using cub::detail::delay_constructor_kind;
+using cub::LookbackDelayPolicy;
+using cub::LookbackDelayAlgorithm;
 static_assert(device_radix_sort_policy()(current_tuning_cc()) == {6}, "Host generated and JIT compiled policy mismatch");
 )XXX",
     input_keys_it.value_type.size, // 0

--- a/c/parallel/src/scan.cu
+++ b/c/parallel/src/scan.cu
@@ -358,8 +358,8 @@ struct __align__({1}) storage_t {{
 using device_scan_policy = {5};
 using namespace cub;
 using namespace cub::detail::scan;
-using cub::detail::delay_constructor_policy;
-using cub::detail::delay_constructor_kind;
+using cub::LookbackDelayPolicy;
+using cub::LookbackDelayAlgorithm;
 static_assert(device_scan_policy()(detail::current_tuning_cc()) == {6}, "Host generated and JIT compiled policy mismatch");
 )XXX",
     input_it.value_type.size, // 0

--- a/c/parallel/src/scan.cu
+++ b/c/parallel/src/scan.cu
@@ -209,12 +209,12 @@ struct scan_kernel_source
     return {build.description_bytes_per_tile, build.payload_bytes_per_tile};
   }
 
-  std::size_t look_ahead_tile_state_size() const
+  std::size_t lookahead_tile_state_size() const
   {
-    return look_ahead_tile_state_alignment();
+    return lookahead_tile_state_alignment();
   }
 
-  std::size_t look_ahead_tile_state_alignment() const
+  std::size_t lookahead_tile_state_alignment() const
   {
     constexpr int state_size = alignof(cub::detail::warpspeed::scan_state);
     return ::cuda::next_power_of_two(
@@ -228,7 +228,7 @@ struct scan_kernel_source
     return arg;
   }
 
-  static auto look_ahead_make_tile_state_kernel_arg(void* ts)
+  static auto lookahead_make_tile_state_kernel_arg(void* ts)
   {
     // we can ignore passing a wrong AccumT, since we only store a pointer, and the kernel will have the right type
     cub::detail::scan::tile_state_kernel_arg_t<scan_tile_state, char> arg;

--- a/c/parallel/src/unique_by_key.cu
+++ b/c/parallel/src/unique_by_key.cu
@@ -256,8 +256,8 @@ struct __align__({5}) num_out_storage_t {{
 using device_unique_by_key_policy = {12};
 using namespace cub;
 using namespace cub::detail::unique_by_key;
-using cub::detail::delay_constructor_policy;
-using cub::detail::delay_constructor_kind;
+using cub::LookbackDelayPolicy;
+using cub::LookbackDelayAlgorithm;
 static_assert(device_unique_by_key_policy()(detail::current_tuning_cc()) == {13}, "Host generated and JIT compiled policy mismatch");
 static_assert(
   cub::detail::unique_by_key::unique_by_key_vsmem_helper_t<

--- a/cub/benchmarks/bench/copy/memcpy.cu
+++ b/cub/benchmarks/bench/copy/memcpy.cu
@@ -90,14 +90,12 @@ struct policy_selector_t
         TUNE_LARGE_THREADS * TUNE_LARGE_BUFFER_BYTES_PER_THREAD,
         TUNE_WARP_LEVEL_THRESHOLD,
         TUNE_BLOCK_LEVEL_THRESHOLD,
-        cub::detail::delay_constructor_policy{
-          static_cast<cub::detail::delay_constructor_kind>(TUNE_BUFF_DELAY_CONSTRUCTOR_ID),
-          TUNE_BUFF_MAGIC_NS,
-          TUNE_BUFF_L2_WRITE_LATENCY_NS},
-        cub::detail::delay_constructor_policy{
-          static_cast<cub::detail::delay_constructor_kind>(TUNE_BLOCK_DELAY_CONSTRUCTOR_ID),
-          TUNE_BLOCK_MAGIC_NS,
-          TUNE_BLOCK_L2_WRITE_LATENCY_NS},
+        cub::LookbackDelayPolicy{static_cast<cub::LookbackDelayAlgorithm>(TUNE_BUFF_DELAY_CONSTRUCTOR_ID),
+                                 TUNE_BUFF_MAGIC_NS,
+                                 TUNE_BUFF_L2_WRITE_LATENCY_NS},
+        cub::LookbackDelayPolicy{static_cast<cub::LookbackDelayAlgorithm>(TUNE_BLOCK_DELAY_CONSTRUCTOR_ID),
+                                 TUNE_BLOCK_MAGIC_NS,
+                                 TUNE_BLOCK_L2_WRITE_LATENCY_NS},
 
       },
       {TUNE_LARGE_THREADS, TUNE_LARGE_BUFFER_BYTES_PER_THREAD},

--- a/cub/benchmarks/bench/partition/flagged.cu
+++ b/cub/benchmarks/bench/partition/flagged.cu
@@ -43,7 +43,7 @@ struct policy_selector
             TUNE_LOAD_ALGORITHM,
             TUNE_LOAD_MODIFIER,
             cub::BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy};
+            lookback_delay_policy};
   }
 };
 #endif // TUNE_BASE

--- a/cub/benchmarks/bench/partition/if.cu
+++ b/cub/benchmarks/bench/partition/if.cu
@@ -43,7 +43,7 @@ struct policy_selector
             TUNE_LOAD_ALGORITHM,
             TUNE_LOAD_MODIFIER,
             cub::BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy};
+            lookback_delay_policy};
   }
 };
 #endif // !TUNE_BASE

--- a/cub/benchmarks/bench/partition/three_way.cu
+++ b/cub/benchmarks/bench/partition/three_way.cu
@@ -25,7 +25,7 @@ struct policy_selector
             TUNE_TRANSPOSE == 0 ? cub::BLOCK_LOAD_DIRECT : cub::BLOCK_LOAD_WARP_TRANSPOSE,
             cub::LOAD_DEFAULT,
             cub::BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy};
+            lookback_delay_policy};
   }
 };
 #endif // !TUNE_BASE

--- a/cub/benchmarks/bench/reduce/by_key.cu
+++ b/cub/benchmarks/bench/reduce/by_key.cu
@@ -26,7 +26,7 @@ struct bench_reduce_by_key_policy_selector
       TUNE_TRANSPOSE == 0 ? cub::BLOCK_LOAD_DIRECT : cub::BLOCK_LOAD_WARP_TRANSPOSE,
       TUNE_LOAD == 0 ? cub::LOAD_DEFAULT : cub::LOAD_CA,
       cub::BLOCK_SCAN_WARP_SCANS,
-      delay_constructor_policy,
+      lookback_delay_policy,
     };
   }
 };

--- a/cub/benchmarks/bench/run_length_encode/encode.cu
+++ b/cub/benchmarks/bench/run_length_encode/encode.cu
@@ -26,7 +26,7 @@ struct bench_encode_policy_selector
       TUNE_TRANSPOSE == 0 ? cub::BLOCK_LOAD_DIRECT : cub::BLOCK_LOAD_WARP_TRANSPOSE,
       TUNE_LOAD == 0 ? cub::LOAD_DEFAULT : cub::LOAD_CA,
       cub::BLOCK_SCAN_WARP_SCANS,
-      delay_constructor_policy,
+      lookback_delay_policy,
     };
   }
 };

--- a/cub/benchmarks/bench/run_length_encode/non_trivial_runs.cu
+++ b/cub/benchmarks/bench/run_length_encode/non_trivial_runs.cu
@@ -28,7 +28,7 @@ struct bench_rle_policy_selector
       TUNE_LOAD == 0 ? cub::LOAD_DEFAULT : cub::LOAD_CA,
       static_cast<bool>(TUNE_TIME_SLICING),
       cub::BLOCK_SCAN_WARP_SCANS,
-      delay_constructor_policy,
+      lookback_delay_policy,
     };
   }
 };

--- a/cub/benchmarks/bench/scan/exclusive/by_key.cu
+++ b/cub/benchmarks/bench/scan/exclusive/by_key.cu
@@ -26,7 +26,7 @@ struct bench_scan_by_key_policy_selector
             TUNE_LOAD == 0 ? cub::LOAD_DEFAULT : cub::LOAD_CA,
             TUNE_TRANSPOSE == 0 ? cub::BLOCK_STORE_DIRECT : cub::BLOCK_STORE_WARP_TRANSPOSE,
             cub::BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy};
+            lookback_delay_policy};
   }
 };
 #endif // !TUNE_BASE

--- a/cub/benchmarks/bench/scan/policy_selector.h
+++ b/cub/benchmarks/bench/scan/policy_selector.h
@@ -15,14 +15,12 @@
 template <typename AccumT>
 struct policy_selector
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::scan::scan_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::ScanPolicy
   {
 #  if USES_WARPSPEED()
-    return {cub::detail::scan::scan_algorithm::warpspeed,
-            cub::detail::scan::scan_lookback_policy{},
-            cub::detail::scan::scan_warpspeed_policy{
-              TUNE_NUM_REDUCE_SCAN_WARPS,
+    return {cub::ScanAlgorithm::warpspeed,
+            cub::ScanLookbackPolicy{},
+            cub::ScanWarpspeedPolicy{TUNE_NUM_REDUCE_SCAN_WARPS,
               TUNE_NUM_LOOKBACK_ITEMS,
               TUNE_ITEMS_PLUS_ONE - 1,
               TUNE_LOOKBACK_STAGES,

--- a/cub/benchmarks/bench/scan/policy_selector.h
+++ b/cub/benchmarks/bench/scan/policy_selector.h
@@ -22,8 +22,8 @@ struct policy_selector
             cub::ScanLookbackPolicy{},
             cub::ScanWarpspeedPolicy{
               TUNE_NUM_REDUCE_SCAN_WARPS,
-              TUNE_NUM_LOOKBACK_ITEMS,
               TUNE_ITEMS_PLUS_ONE - 1,
+              TUNE_NUM_LOOKBACK_ITEMS,
               TUNE_LOOKBACK_STAGES,
               TUNE_BLOCK_IDX_STAGES}};
 #  else

--- a/cub/benchmarks/bench/scan/policy_selector.h
+++ b/cub/benchmarks/bench/scan/policy_selector.h
@@ -20,7 +20,8 @@ struct policy_selector
 #  if USES_WARPSPEED()
     return {cub::ScanAlgorithm::warpspeed,
             cub::ScanLookbackPolicy{},
-            cub::ScanWarpspeedPolicy{TUNE_NUM_REDUCE_SCAN_WARPS,
+            cub::ScanWarpspeedPolicy{
+              TUNE_NUM_REDUCE_SCAN_WARPS,
               TUNE_NUM_LOOKBACK_ITEMS,
               TUNE_ITEMS_PLUS_ONE - 1,
               TUNE_LOOKBACK_STAGES,
@@ -34,7 +35,7 @@ struct policy_selector
       TUNE_LOAD_MODIFIER,
       TUNE_STORE_ALGORITHM,
       cub::BLOCK_SCAN_WARP_SCANS,
-      delay_constructor_policy);
+      lookback_delay_policy);
 #  endif
   }
 };

--- a/cub/benchmarks/bench/select/flagged.cu
+++ b/cub/benchmarks/bench/select/flagged.cu
@@ -30,7 +30,7 @@ struct bench_policy_selector
             (TUNE_TRANSPOSE == 0 ? cub::BLOCK_LOAD_DIRECT : cub::BLOCK_LOAD_WARP_TRANSPOSE),
             (TUNE_LOAD == 0 ? cub::LOAD_DEFAULT : cub::LOAD_CA),
             cub::BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy};
+            lookback_delay_policy};
   }
 };
 #endif // !TUNE_BASE

--- a/cub/benchmarks/bench/select/if.cu
+++ b/cub/benchmarks/bench/select/if.cu
@@ -32,7 +32,7 @@ struct bench_policy_selector
             (TUNE_TRANSPOSE == 0 ? cub::BLOCK_LOAD_DIRECT : cub::BLOCK_LOAD_WARP_TRANSPOSE),
             (TUNE_LOAD == 0 ? cub::LOAD_DEFAULT : cub::LOAD_CA),
             cub::BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy};
+            lookback_delay_policy};
   }
 };
 #endif // !TUNE_BASE

--- a/cub/benchmarks/bench/select/unique.cu
+++ b/cub/benchmarks/bench/select/unique.cu
@@ -30,7 +30,7 @@ struct bench_policy_selector
             (TUNE_TRANSPOSE == 0 ? cub::BLOCK_LOAD_DIRECT : cub::BLOCK_LOAD_WARP_TRANSPOSE),
             (TUNE_LOAD == 0 ? cub::LOAD_DEFAULT : cub::LOAD_CA),
             cub::BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy};
+            lookback_delay_policy};
   }
 };
 #endif // !TUNE_BASE

--- a/cub/benchmarks/bench/select/unique_by_key.cu
+++ b/cub/benchmarks/bench/select/unique_by_key.cu
@@ -37,7 +37,7 @@ struct bench_unique_by_key_policy_selector
             TUNE_LOAD_ALGORITHM,
             TUNE_LOAD_MODIFIER,
             cub::BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy};
+            lookback_delay_policy};
   }
 };
 #endif // !TUNE_BASE

--- a/cub/cub/detail/delay_constructor.cuh
+++ b/cub/cub/detail/delay_constructor.cuh
@@ -30,7 +30,7 @@ enum class LookbackDelayAlgorithm
   exponential_backon_jitter_window,
   exponential_backon_jitter,
   exponential_backon,
-  reduce_by_key
+  __reduce_by_key //!< Internal
 };
 
 #if _CCCL_HOSTED()
@@ -54,8 +54,8 @@ inline ::std::ostream& operator<<(::std::ostream& os, LookbackDelayAlgorithm kin
       return os << "LookbackDelayAlgorithm::exponential_backon_jitter";
     case LookbackDelayAlgorithm::exponential_backon:
       return os << "LookbackDelayAlgorithm::exponential_backon";
-    case LookbackDelayAlgorithm::reduce_by_key:
-      return os << "LookbackDelayAlgorithm::reduce_by_key";
+    case LookbackDelayAlgorithm::__reduce_by_key:
+      return os << "LookbackDelayAlgorithm::__reduce_by_key";
     default:
       return os << "<unknown LookbackDelayAlgorithm: " << static_cast<int>(kind) << ">";
   }
@@ -132,7 +132,7 @@ inline constexpr auto lookback_delay_policy_from_type<exponential_backon_constru
 template <unsigned int Delay, unsigned int L2WriteLatency, unsigned int GridThreshold>
 inline constexpr auto
   lookback_delay_policy_from_type<reduce_by_key_delay_constructor_t<Delay, L2WriteLatency, GridThreshold>> =
-    LookbackDelayPolicy{LookbackDelayAlgorithm::reduce_by_key, Delay, L2WriteLatency};
+    LookbackDelayPolicy{LookbackDelayAlgorithm::__reduce_by_key, Delay, L2WriteLatency};
 
 template <LookbackDelayAlgorithm Kind, unsigned int Delay, unsigned int L2WriteLatency>
 struct delay_constructor_for;
@@ -186,7 +186,7 @@ struct delay_constructor_for<LookbackDelayAlgorithm::exponential_backon, Delay, 
 };
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
-struct delay_constructor_for<LookbackDelayAlgorithm::reduce_by_key, Delay, L2WriteLatency>
+struct delay_constructor_for<LookbackDelayAlgorithm::__reduce_by_key, Delay, L2WriteLatency>
 {
   using type = reduce_by_key_delay_constructor_t<Delay, L2WriteLatency>;
 };
@@ -211,7 +211,7 @@ _CCCL_HOST_DEVICE_API constexpr auto default_reduce_by_key_delay_constructor_pol
 {
   if (value_is_primitive_or_trivially_copyable && (value_size + key_size < 16))
   {
-    return LookbackDelayPolicy{LookbackDelayAlgorithm::reduce_by_key, 350, 450};
+    return LookbackDelayPolicy{LookbackDelayAlgorithm::__reduce_by_key, 350, 450};
   }
   return default_delay_constructor_policy(key_is_primitive_or_trivially_copyable);
 }

--- a/cub/cub/detail/delay_constructor.cuh
+++ b/cub/cub/detail/delay_constructor.cuh
@@ -93,46 +93,45 @@ struct LookbackDelayPolicy
 namespace detail
 {
 template <typename DelayConstructor>
-inline constexpr auto delay_constructor_policy_from_type = 0;
+inline constexpr auto lookback_delay_policy_from_type = 0;
 
 template <unsigned int L2WriteLatency>
-inline constexpr auto delay_constructor_policy_from_type<no_delay_constructor_t<L2WriteLatency>> =
+inline constexpr auto lookback_delay_policy_from_type<no_delay_constructor_t<L2WriteLatency>> =
   LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, L2WriteLatency};
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
-inline constexpr auto delay_constructor_policy_from_type<fixed_delay_constructor_t<Delay, L2WriteLatency>> =
+inline constexpr auto lookback_delay_policy_from_type<fixed_delay_constructor_t<Delay, L2WriteLatency>> =
   LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, Delay, L2WriteLatency};
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
-inline constexpr auto delay_constructor_policy_from_type<exponential_backoff_constructor_t<Delay, L2WriteLatency>> =
+inline constexpr auto lookback_delay_policy_from_type<exponential_backoff_constructor_t<Delay, L2WriteLatency>> =
   LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backoff, Delay, L2WriteLatency};
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
-inline constexpr auto
-  delay_constructor_policy_from_type<exponential_backoff_jitter_constructor_t<Delay, L2WriteLatency>> =
-    LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backoff_jitter, Delay, L2WriteLatency};
+inline constexpr auto lookback_delay_policy_from_type<exponential_backoff_jitter_constructor_t<Delay, L2WriteLatency>> =
+  LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backoff_jitter, Delay, L2WriteLatency};
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
 inline constexpr auto
-  delay_constructor_policy_from_type<exponential_backoff_jitter_window_constructor_t<Delay, L2WriteLatency>> =
+  lookback_delay_policy_from_type<exponential_backoff_jitter_window_constructor_t<Delay, L2WriteLatency>> =
     LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backoff_jitter_window, Delay, L2WriteLatency};
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
 inline constexpr auto
-  delay_constructor_policy_from_type<exponential_backon_jitter_window_constructor_t<Delay, L2WriteLatency>> =
+  lookback_delay_policy_from_type<exponential_backon_jitter_window_constructor_t<Delay, L2WriteLatency>> =
     LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, Delay, L2WriteLatency};
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
-inline constexpr auto delay_constructor_policy_from_type<exponential_backon_jitter_constructor_t<Delay, L2WriteLatency>> =
+inline constexpr auto lookback_delay_policy_from_type<exponential_backon_jitter_constructor_t<Delay, L2WriteLatency>> =
   LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter, Delay, L2WriteLatency};
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
-inline constexpr auto delay_constructor_policy_from_type<exponential_backon_constructor_t<Delay, L2WriteLatency>> =
+inline constexpr auto lookback_delay_policy_from_type<exponential_backon_constructor_t<Delay, L2WriteLatency>> =
   LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, Delay, L2WriteLatency};
 
 template <unsigned int Delay, unsigned int L2WriteLatency, unsigned int GridThreshold>
 inline constexpr auto
-  delay_constructor_policy_from_type<reduce_by_key_delay_constructor_t<Delay, L2WriteLatency, GridThreshold>> =
+  lookback_delay_policy_from_type<reduce_by_key_delay_constructor_t<Delay, L2WriteLatency, GridThreshold>> =
     LookbackDelayPolicy{LookbackDelayAlgorithm::reduce_by_key, Delay, L2WriteLatency};
 
 template <LookbackDelayAlgorithm Kind, unsigned int Delay, unsigned int L2WriteLatency>

--- a/cub/cub/detail/delay_constructor.cuh
+++ b/cub/cub/detail/delay_constructor.cuh
@@ -19,9 +19,8 @@
 
 CUB_NAMESPACE_BEGIN
 
-namespace detail
-{
-enum class delay_constructor_kind
+//! The delay algorithm used by decoupled lookback
+enum class LookbackDelayAlgorithm
 {
   no_delay,
   fixed_delay,
@@ -35,171 +34,174 @@ enum class delay_constructor_kind
 };
 
 #if _CCCL_HOSTED()
-inline ::std::ostream& operator<<(::std::ostream& os, delay_constructor_kind kind)
+inline ::std::ostream& operator<<(::std::ostream& os, LookbackDelayAlgorithm kind)
 {
   switch (kind)
   {
-    case delay_constructor_kind::no_delay:
-      return os << "delay_constructor_kind::no_delay";
-    case delay_constructor_kind::fixed_delay:
-      return os << "delay_constructor_kind::fixed_delay";
-    case delay_constructor_kind::exponential_backoff:
-      return os << "delay_constructor_kind::exponential_backoff";
-    case delay_constructor_kind::exponential_backoff_jitter:
-      return os << "delay_constructor_kind::exponential_backoff_jitter";
-    case delay_constructor_kind::exponential_backoff_jitter_window:
-      return os << "delay_constructor_kind::exponential_backoff_jitter_window";
-    case delay_constructor_kind::exponential_backon_jitter_window:
-      return os << "delay_constructor_kind::exponential_backon_jitter_window";
-    case delay_constructor_kind::exponential_backon_jitter:
-      return os << "delay_constructor_kind::exponential_backon_jitter";
-    case delay_constructor_kind::exponential_backon:
-      return os << "delay_constructor_kind::exponential_backon";
-    case delay_constructor_kind::reduce_by_key:
-      return os << "delay_constructor_kind::reduce_by_key";
+    case LookbackDelayAlgorithm::no_delay:
+      return os << "LookbackDelayAlgorithm::no_delay";
+    case LookbackDelayAlgorithm::fixed_delay:
+      return os << "LookbackDelayAlgorithm::fixed_delay";
+    case LookbackDelayAlgorithm::exponential_backoff:
+      return os << "LookbackDelayAlgorithm::exponential_backoff";
+    case LookbackDelayAlgorithm::exponential_backoff_jitter:
+      return os << "LookbackDelayAlgorithm::exponential_backoff_jitter";
+    case LookbackDelayAlgorithm::exponential_backoff_jitter_window:
+      return os << "LookbackDelayAlgorithm::exponential_backoff_jitter_window";
+    case LookbackDelayAlgorithm::exponential_backon_jitter_window:
+      return os << "LookbackDelayAlgorithm::exponential_backon_jitter_window";
+    case LookbackDelayAlgorithm::exponential_backon_jitter:
+      return os << "LookbackDelayAlgorithm::exponential_backon_jitter";
+    case LookbackDelayAlgorithm::exponential_backon:
+      return os << "LookbackDelayAlgorithm::exponential_backon";
+    case LookbackDelayAlgorithm::reduce_by_key:
+      return os << "LookbackDelayAlgorithm::reduce_by_key";
     default:
-      return os << "<unknown delay_constructor_kind: " << static_cast<int>(kind) << ">";
+      return os << "<unknown LookbackDelayAlgorithm: " << static_cast<int>(kind) << ">";
   }
 }
 #endif // _CCCL_HOSTED()
 
-struct delay_constructor_policy
+//! The policy configuring the delay algorithm used by decoupled lookback
+struct LookbackDelayPolicy
 {
-  delay_constructor_kind kind;
-  unsigned int delay;
-  unsigned int l2_write_latency;
+  LookbackDelayAlgorithm kind; //!< The algorithm used for delaying during decoupled lookback
+  unsigned int delay; //!< The delay in nanoseconds
+  unsigned int l2_write_latency; //!< The write latency of the L2 cache in nanoseconds
 
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const delay_constructor_policy& lhs, const delay_constructor_policy& rhs)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const LookbackDelayPolicy& lhs, const LookbackDelayPolicy& rhs)
   {
     return lhs.kind == rhs.kind && lhs.delay == rhs.delay && lhs.l2_write_latency == rhs.l2_write_latency;
   }
 
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const delay_constructor_policy& lhs, const delay_constructor_policy& rhs)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const LookbackDelayPolicy& lhs, const LookbackDelayPolicy& rhs)
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const delay_constructor_policy& p)
+  friend ::std::ostream& operator<<(::std::ostream& os, const LookbackDelayPolicy& p)
   {
-    return os << "delay_constructor_policy { .kind = " << p.kind << ", .delay = " << p.delay
+    return os << "LookbackDelayPolicy { .kind = " << p.kind << ", .delay = " << p.delay
               << ", .l2_write_latency = " << p.l2_write_latency << " }";
   }
 #endif // _CCCL_HOSTED()
 };
 
+namespace detail
+{
 template <typename DelayConstructor>
 inline constexpr auto delay_constructor_policy_from_type = 0;
 
 template <unsigned int L2WriteLatency>
 inline constexpr auto delay_constructor_policy_from_type<no_delay_constructor_t<L2WriteLatency>> =
-  delay_constructor_policy{delay_constructor_kind::no_delay, 0, L2WriteLatency};
+  LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, L2WriteLatency};
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
 inline constexpr auto delay_constructor_policy_from_type<fixed_delay_constructor_t<Delay, L2WriteLatency>> =
-  delay_constructor_policy{delay_constructor_kind::fixed_delay, Delay, L2WriteLatency};
+  LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, Delay, L2WriteLatency};
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
 inline constexpr auto delay_constructor_policy_from_type<exponential_backoff_constructor_t<Delay, L2WriteLatency>> =
-  delay_constructor_policy{delay_constructor_kind::exponential_backoff, Delay, L2WriteLatency};
+  LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backoff, Delay, L2WriteLatency};
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
 inline constexpr auto
   delay_constructor_policy_from_type<exponential_backoff_jitter_constructor_t<Delay, L2WriteLatency>> =
-    delay_constructor_policy{delay_constructor_kind::exponential_backoff_jitter, Delay, L2WriteLatency};
+    LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backoff_jitter, Delay, L2WriteLatency};
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
 inline constexpr auto
   delay_constructor_policy_from_type<exponential_backoff_jitter_window_constructor_t<Delay, L2WriteLatency>> =
-    delay_constructor_policy{delay_constructor_kind::exponential_backoff_jitter_window, Delay, L2WriteLatency};
+    LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backoff_jitter_window, Delay, L2WriteLatency};
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
 inline constexpr auto
   delay_constructor_policy_from_type<exponential_backon_jitter_window_constructor_t<Delay, L2WriteLatency>> =
-    delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, Delay, L2WriteLatency};
+    LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, Delay, L2WriteLatency};
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
 inline constexpr auto delay_constructor_policy_from_type<exponential_backon_jitter_constructor_t<Delay, L2WriteLatency>> =
-  delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter, Delay, L2WriteLatency};
+  LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter, Delay, L2WriteLatency};
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
 inline constexpr auto delay_constructor_policy_from_type<exponential_backon_constructor_t<Delay, L2WriteLatency>> =
-  delay_constructor_policy{delay_constructor_kind::exponential_backon, Delay, L2WriteLatency};
+  LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, Delay, L2WriteLatency};
 
 template <unsigned int Delay, unsigned int L2WriteLatency, unsigned int GridThreshold>
 inline constexpr auto
   delay_constructor_policy_from_type<reduce_by_key_delay_constructor_t<Delay, L2WriteLatency, GridThreshold>> =
-    delay_constructor_policy{delay_constructor_kind::reduce_by_key, Delay, L2WriteLatency};
+    LookbackDelayPolicy{LookbackDelayAlgorithm::reduce_by_key, Delay, L2WriteLatency};
 
-template <delay_constructor_kind Kind, unsigned int Delay, unsigned int L2WriteLatency>
+template <LookbackDelayAlgorithm Kind, unsigned int Delay, unsigned int L2WriteLatency>
 struct delay_constructor_for;
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
-struct delay_constructor_for<delay_constructor_kind::no_delay, Delay, L2WriteLatency>
+struct delay_constructor_for<LookbackDelayAlgorithm::no_delay, Delay, L2WriteLatency>
 {
   using type = no_delay_constructor_t<L2WriteLatency>;
 };
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
-struct delay_constructor_for<delay_constructor_kind::fixed_delay, Delay, L2WriteLatency>
+struct delay_constructor_for<LookbackDelayAlgorithm::fixed_delay, Delay, L2WriteLatency>
 {
   using type = fixed_delay_constructor_t<Delay, L2WriteLatency>;
 };
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
-struct delay_constructor_for<delay_constructor_kind::exponential_backoff, Delay, L2WriteLatency>
+struct delay_constructor_for<LookbackDelayAlgorithm::exponential_backoff, Delay, L2WriteLatency>
 {
   using type = exponential_backoff_constructor_t<Delay, L2WriteLatency>;
 };
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
-struct delay_constructor_for<delay_constructor_kind::exponential_backoff_jitter, Delay, L2WriteLatency>
+struct delay_constructor_for<LookbackDelayAlgorithm::exponential_backoff_jitter, Delay, L2WriteLatency>
 {
   using type = exponential_backoff_jitter_constructor_t<Delay, L2WriteLatency>;
 };
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
-struct delay_constructor_for<delay_constructor_kind::exponential_backoff_jitter_window, Delay, L2WriteLatency>
+struct delay_constructor_for<LookbackDelayAlgorithm::exponential_backoff_jitter_window, Delay, L2WriteLatency>
 {
   using type = exponential_backoff_jitter_window_constructor_t<Delay, L2WriteLatency>;
 };
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
-struct delay_constructor_for<delay_constructor_kind::exponential_backon_jitter_window, Delay, L2WriteLatency>
+struct delay_constructor_for<LookbackDelayAlgorithm::exponential_backon_jitter_window, Delay, L2WriteLatency>
 {
   using type = exponential_backon_jitter_window_constructor_t<Delay, L2WriteLatency>;
 };
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
-struct delay_constructor_for<delay_constructor_kind::exponential_backon_jitter, Delay, L2WriteLatency>
+struct delay_constructor_for<LookbackDelayAlgorithm::exponential_backon_jitter, Delay, L2WriteLatency>
 {
   using type = exponential_backon_jitter_constructor_t<Delay, L2WriteLatency>;
 };
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
-struct delay_constructor_for<delay_constructor_kind::exponential_backon, Delay, L2WriteLatency>
+struct delay_constructor_for<LookbackDelayAlgorithm::exponential_backon, Delay, L2WriteLatency>
 {
   using type = exponential_backon_constructor_t<Delay, L2WriteLatency>;
 };
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
-struct delay_constructor_for<delay_constructor_kind::reduce_by_key, Delay, L2WriteLatency>
+struct delay_constructor_for<LookbackDelayAlgorithm::reduce_by_key, Delay, L2WriteLatency>
 {
   using type = reduce_by_key_delay_constructor_t<Delay, L2WriteLatency>;
 };
 
-template <delay_constructor_kind Kind, unsigned int Delay, unsigned int L2WriteLatency>
+template <LookbackDelayAlgorithm Kind, unsigned int Delay, unsigned int L2WriteLatency>
 using delay_constructor_t = typename delay_constructor_for<Kind, Delay, L2WriteLatency>::type;
 
 _CCCL_HOST_DEVICE_API constexpr auto default_delay_constructor_policy(bool is_primitive_or_trivially_copyable)
 {
   if (is_primitive_or_trivially_copyable)
   {
-    return delay_constructor_policy{delay_constructor_kind::fixed_delay, 350, 450};
+    return LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 350, 450};
   }
-  return delay_constructor_policy{delay_constructor_kind::no_delay, 0, 450};
+  return LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 450};
 }
 
 _CCCL_HOST_DEVICE_API constexpr auto default_reduce_by_key_delay_constructor_policy(
@@ -210,7 +212,7 @@ _CCCL_HOST_DEVICE_API constexpr auto default_reduce_by_key_delay_constructor_pol
 {
   if (value_is_primitive_or_trivially_copyable && (value_size + key_size < 16))
   {
-    return delay_constructor_policy{delay_constructor_kind::reduce_by_key, 350, 450};
+    return LookbackDelayPolicy{LookbackDelayAlgorithm::reduce_by_key, 350, 450};
   }
   return default_delay_constructor_policy(key_is_primitive_or_trivially_copyable);
 }

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -83,6 +83,24 @@ CUB_NAMESPACE_BEGIN
 //!
 //! @linear_performance{prefix scan}
 //!
+//! Tuning
+//! +++++++++++++++++++++++++++++++++++++++++++++
+//!
+//! All non-ByKey algorithms in DeviceScan that accept an environment can be tuned by passing a custom :ref:`policy
+//! selector <cub-policy-selectors>` that returns a @ref ScanPolicy, as shown in the example below:
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_scan_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin exclusive-sum-policy-selector
+//!      :end-before: example-end exclusive-sum-policy-selector
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_scan_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin exclusive-sum-tuning
+//!      :end-before: example-end exclusive-sum-tuning
+//!
 //! @endrst
 struct DeviceScan
 {

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -496,7 +496,7 @@ public:
       OffsetT num_items,
       int pass_radix_bits,
       detail::radix_sort::radix_sort_upsweep_policy upsweep_policy,
-      detail::radix_sort::scan_policy scan_policy,
+      ScanPolicy scan_policy,
       detail::radix_sort::radix_sort_downsweep_policy downsweep_policy,
       KernelLauncherFactory launcher_factory)
     {

--- a/cub/cub/device/dispatch/dispatch_rle.cuh
+++ b/cub/cub/device/dispatch/dispatch_rle.cuh
@@ -230,7 +230,7 @@ struct policy_selector_from_hub
       RleSweepPolicyT::LOAD_MODIFIER,
       RleSweepPolicyT::STORE_WARP_TIME_SLICING,
       RleSweepPolicyT::SCAN_ALGORITHM,
-      delay_constructor_policy_from_type<typename RleSweepPolicyT::detail::delay_constructor_t>,
+      lookback_delay_policy_from_type<typename RleSweepPolicyT::detail::delay_constructor_t>,
     };
   }
 };

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -489,6 +489,12 @@ struct DispatchScan
     }
 
     CUB_DETAIL_CONSTEXPR_ISH const ScanWarpspeedPolicy warpspeed_policy = policy_getter().warpspeed;
+    CUB_DETAIL_STATIC_ISH_ASSERT(warpspeed_policy.num_reduce_and_scan_warps >= 1,
+                                 "Warpspeed scan policy have at least 1 warp for reducing and scanning");
+    CUB_DETAIL_STATIC_ISH_ASSERT(warpspeed_policy.look_ahead_items_per_thread >= 1,
+                                 "Warpspeed scan policy must look ahead at least 1 item per thread");
+    CUB_DETAIL_STATIC_ISH_ASSERT(
+      warpspeed_policy.items_per_thread >= 1, "Warpspeed scan policy must have at least 1 item per thread");
 
     const int grid_dim =
       static_cast<int>(::cuda::ceil_div(num_items, static_cast<OffsetT>(warpspeed_policy.tile_size())));
@@ -658,7 +664,10 @@ struct DispatchScan
   CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t __invoke_lookback_algorithm(PolicyGetter policy_getter)
   {
     CUB_DETAIL_CONSTEXPR_ISH const ScanLookbackPolicy active_policy = policy_getter().lookback;
-
+    CUB_DETAIL_STATIC_ISH_ASSERT(
+      active_policy.threads_per_block >= 1, "Lookback scan policy must have at least 1 thread per block");
+    CUB_DETAIL_STATIC_ISH_ASSERT(
+      active_policy.items_per_thread >= 1, "Lookback scan policy must have at least 1 item per thread");
     CUB_DETAIL_STATIC_ISH_ASSERT(active_policy.load_modifier != CacheLoadModifier::LOAD_LDG,
                                  "The memory consistency model does not apply to texture accesses");
 

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -165,7 +165,7 @@ _CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> ScanPolicy
       scan_policy_t::LOAD_MODIFIER,
       scan_policy_t::STORE_ALGORITHM,
       scan_policy_t::SCAN_ALGORITHM,
-      detail::delay_constructor_policy_from_type<typename scan_policy_t::detail::delay_constructor_t>},
+      detail::lookback_delay_policy_from_type<typename scan_policy_t::detail::delay_constructor_t>},
     ScanWarpspeedPolicy{}};
 }
 

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -150,15 +150,15 @@ struct DeviceScanKernelSource
 
 // TODO(griwes): remove in CCCL 4.0 when we drop the scan dispatcher after publishing the tuning API
 template <typename LegacyActivePolicy>
-_CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> scan_policy
+_CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> ScanPolicy
 {
   // this does not convert any warpspeed policy data, which is fine because we merged warpspeed scan during the CCCL 3.4
   // development cycle, so it never had user exposure through the policy_hub, and we can just only support it through
   // the policy_selector.
   using scan_policy_t = typename LegacyActivePolicy::ScanPolicyT;
-  return scan_policy{
-    scan_algorithm::lookback,
-    scan_lookback_policy{
+  return ScanPolicy{
+    ScanAlgorithm::lookback,
+    ScanLookbackPolicy{
       scan_policy_t::BLOCK_THREADS,
       scan_policy_t::ITEMS_PER_THREAD,
       scan_policy_t::LOAD_ALGORITHM,
@@ -166,14 +166,14 @@ _CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> scan_policy
       scan_policy_t::STORE_ALGORITHM,
       scan_policy_t::SCAN_ALGORITHM,
       detail::delay_constructor_policy_from_type<typename scan_policy_t::detail::delay_constructor_t>},
-    scan_warpspeed_policy{}};
+    ScanWarpspeedPolicy{}};
 }
 
 // TODO(griwes): remove in CCCL 4.0 when we drop the scan dispatcher after publishing the tuning API
 template <typename PolicyHub>
 struct policy_selector_from_hub
 {
-  [[nodiscard]] _CCCL_DEVICE_API constexpr auto operator()(::cuda::compute_capability /*cc*/) const -> scan_policy
+  [[nodiscard]] _CCCL_DEVICE_API constexpr auto operator()(::cuda::compute_capability /*cc*/) const -> ScanPolicy
   {
     return convert_policy<typename PolicyHub::MaxPolicy::ActivePolicy>();
   }
@@ -488,7 +488,7 @@ struct DispatchScan
       return cudaSuccess;
     }
 
-    CUB_DETAIL_CONSTEXPR_ISH const detail::scan::scan_warpspeed_policy warpspeed_policy = policy_getter().warpspeed;
+    CUB_DETAIL_CONSTEXPR_ISH const ScanWarpspeedPolicy warpspeed_policy = policy_getter().warpspeed;
 
     const int grid_dim =
       static_cast<int>(::cuda::ceil_div(num_items, static_cast<OffsetT>(warpspeed_policy.tile_size())));
@@ -657,7 +657,7 @@ struct DispatchScan
   template <typename PolicyGetter>
   CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t __invoke_lookback_algorithm(PolicyGetter policy_getter)
   {
-    CUB_DETAIL_CONSTEXPR_ISH const detail::scan::scan_lookback_policy active_policy = policy_getter().lookback;
+    CUB_DETAIL_CONSTEXPR_ISH const ScanLookbackPolicy active_policy = policy_getter().lookback;
 
     CUB_DETAIL_STATIC_ISH_ASSERT(active_policy.load_modifier != CacheLoadModifier::LOAD_LDG,
                                  "The memory consistency model does not apply to texture accesses");
@@ -791,7 +791,7 @@ struct DispatchScan
   template <typename PolicyGetter>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t __invoke(PolicyGetter policy_getter)
   {
-    if CUB_DETAIL_CONSTEXPR_ISH (policy_getter().algorithm == detail::scan::scan_algorithm::warpspeed)
+    if CUB_DETAIL_CONSTEXPR_ISH (policy_getter().algorithm == ScanAlgorithm::warpspeed)
     {
       return __invoke_warpspeed_algorithm(policy_getter);
     }

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -489,7 +489,7 @@ struct DispatchScan
     }
 
     CUB_DETAIL_CONSTEXPR_ISH const ScanWarpspeedPolicy warpspeed_policy = policy_getter().warpspeed;
-    CUB_DETAIL_STATIC_ISH_ASSERT(warpspeed_policy.num_reduce_and_scan_warps >= 1,
+    CUB_DETAIL_STATIC_ISH_ASSERT(warpspeed_policy.reduce_and_scan_warps >= 1,
                                  "Warpspeed scan policy have at least 1 warp for reducing and scanning");
     CUB_DETAIL_STATIC_ISH_ASSERT(
       warpspeed_policy.items_per_thread >= 1, "Warpspeed scan policy must have at least 1 item per thread");

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -123,12 +123,12 @@ struct DeviceScanKernelSource
     return {};
   }
 
-  CUB_RUNTIME_FUNCTION static constexpr ::cuda::std::size_t look_ahead_tile_state_size()
+  CUB_RUNTIME_FUNCTION static constexpr ::cuda::std::size_t lookahead_tile_state_size()
   {
     return sizeof(warpspeed::tile_state_t<AccumT>);
   }
 
-  CUB_RUNTIME_FUNCTION static constexpr ::cuda::std::size_t look_ahead_tile_state_alignment()
+  CUB_RUNTIME_FUNCTION static constexpr ::cuda::std::size_t lookahead_tile_state_alignment()
   {
     return alignof(warpspeed::tile_state_t<AccumT>);
   }
@@ -140,7 +140,7 @@ struct DeviceScanKernelSource
     return arg;
   }
 
-  CUB_RUNTIME_FUNCTION static constexpr auto look_ahead_make_tile_state_kernel_arg(void* ts)
+  CUB_RUNTIME_FUNCTION static constexpr auto lookahead_make_tile_state_kernel_arg(void* ts)
   {
     tile_state_kernel_arg_t<ScanTileStateT, AccumT> arg;
     ::cuda::std::__construct_at(&arg.warpspeed, static_cast<warpspeed::tile_state_t<AccumT>*>(ts));
@@ -491,7 +491,7 @@ struct DispatchScan
     CUB_DETAIL_CONSTEXPR_ISH const ScanWarpspeedPolicy warpspeed_policy = policy_getter().warpspeed;
     CUB_DETAIL_STATIC_ISH_ASSERT(warpspeed_policy.num_reduce_and_scan_warps >= 1,
                                  "Warpspeed scan policy have at least 1 warp for reducing and scanning");
-    CUB_DETAIL_STATIC_ISH_ASSERT(warpspeed_policy.look_ahead_items_per_thread >= 1,
+    CUB_DETAIL_STATIC_ISH_ASSERT(warpspeed_policy.lookahead_items_per_thread >= 1,
                                  "Warpspeed scan policy must look ahead at least 1 item per thread");
     CUB_DETAIL_STATIC_ISH_ASSERT(
       warpspeed_policy.items_per_thread >= 1, "Warpspeed scan policy must have at least 1 item per thread");
@@ -501,7 +501,7 @@ struct DispatchScan
 
     if (d_temp_storage == nullptr)
     {
-      temp_storage_bytes = static_cast<size_t>(grid_dim) * kernel_source.look_ahead_tile_state_size();
+      temp_storage_bytes = static_cast<size_t>(grid_dim) * kernel_source.lookahead_tile_state_size();
       return cudaSuccess;
     }
 
@@ -524,7 +524,7 @@ struct DispatchScan
     }
 
     // TODO(bgruber): we probably need to ensure alignment of d_temp_storage
-    _CCCL_ASSERT(::cuda::is_aligned(d_temp_storage, kernel_source.look_ahead_tile_state_alignment()), "");
+    _CCCL_ASSERT(::cuda::is_aligned(d_temp_storage, kernel_source.lookahead_tile_state_alignment()), "");
 
     auto scan_kernel                 = kernel_source.ScanKernel();
     [[maybe_unused]] auto kernel_src = kernel_source; // need to pull a copy to not access `this` during const. eval.
@@ -599,7 +599,7 @@ struct DispatchScan
                              stream,
                              /* dependent_launch */ ptx_version >= 900)
               .doit(kernel_source.InitKernel(),
-                    kernel_source.look_ahead_make_tile_state_kernel_arg(d_temp_storage),
+                    kernel_source.lookahead_make_tile_state_kernel_arg(d_temp_storage),
                     grid_dim)))
       {
         return error;
@@ -631,7 +631,7 @@ struct DispatchScan
               .doit(scan_kernel,
                     THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_in),
                     THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_out),
-                    kernel_source.look_ahead_make_tile_state_kernel_arg(d_temp_storage),
+                    kernel_source.lookahead_make_tile_state_kernel_arg(d_temp_storage),
                     /* start_tile, unused */ 0,
                     ::cuda::std::move(scan_op),
                     init_value,

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -491,10 +491,10 @@ struct DispatchScan
     CUB_DETAIL_CONSTEXPR_ISH const ScanWarpspeedPolicy warpspeed_policy = policy_getter().warpspeed;
     CUB_DETAIL_STATIC_ISH_ASSERT(warpspeed_policy.num_reduce_and_scan_warps >= 1,
                                  "Warpspeed scan policy have at least 1 warp for reducing and scanning");
-    CUB_DETAIL_STATIC_ISH_ASSERT(warpspeed_policy.lookahead_items_per_thread >= 1,
-                                 "Warpspeed scan policy must look ahead at least 1 item per thread");
     CUB_DETAIL_STATIC_ISH_ASSERT(
       warpspeed_policy.items_per_thread >= 1, "Warpspeed scan policy must have at least 1 item per thread");
+    CUB_DETAIL_STATIC_ISH_ASSERT(warpspeed_policy.lookahead_items_per_thread >= 1,
+                                 "Warpspeed scan policy must look ahead at least 1 item per thread");
 
     const int grid_dim =
       static_cast<int>(::cuda::ceil_div(num_items, static_cast<OffsetT>(warpspeed_policy.tile_size())));

--- a/cub/cub/device/dispatch/dispatch_select_if.cuh
+++ b/cub/cub/device/dispatch/dispatch_select_if.cuh
@@ -400,7 +400,7 @@ struct policy_selector_from_hub
       active_policy::LOAD_ALGORITHM,
       active_policy::LOAD_MODIFIER,
       active_policy::SCAN_ALGORITHM,
-      delay_constructor_policy_from_type<typename active_policy::detail::delay_constructor_t>};
+      lookback_delay_policy_from_type<typename active_policy::detail::delay_constructor_t>};
   }
 };
 } // namespace detail::select

--- a/cub/cub/device/dispatch/dispatch_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/dispatch_three_way_partition.cuh
@@ -83,7 +83,7 @@ struct policy_selector_from_hub
       active_policy::LOAD_ALGORITHM,
       active_policy::LOAD_MODIFIER,
       active_policy::SCAN_ALGORITHM,
-      delay_constructor_policy_from_type<typename active_policy::detail::delay_constructor_t>};
+      lookback_delay_policy_from_type<typename active_policy::detail::delay_constructor_t>};
   }
 };
 } // namespace detail::three_way_partition

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -148,21 +148,21 @@ __launch_bounds__(current_policy<PolicySelector>().scan.lookback.threads_per_blo
   _CCCL_KERNEL_ATTRIBUTES void RadixSortScanBinsKernel(
     _CCCL_GRID_CONSTANT OffsetT* const d_spine, _CCCL_GRID_CONSTANT const int num_counts)
 {
-  static constexpr scan_policy active_policy = current_policy<PolicySelector>().scan;
-  static_assert(active_policy.algorithm == scan_algorithm::lookback);
-  static constexpr scan_lookback_policy policy = active_policy.lookback;
-  using ScanPolicy                             = AgentScanPolicy<
-                                0,
-                                0,
-                                void,
-                                policy.load_algorithm,
-                                policy.load_modifier,
-                                policy.store_algorithm,
-                                policy.scan_algorithm,
-                                NoScaling<policy.threads_per_block, policy.items_per_thread>,
-                                delay_constructor_t<policy.delay_constructor.kind,
-                                                    policy.delay_constructor.delay,
-                                                    policy.delay_constructor.l2_write_latency>>;
+  static constexpr ScanPolicy active_policy = current_policy<PolicySelector>().scan;
+  static_assert(active_policy.algorithm == ScanAlgorithm::lookback);
+  static constexpr ScanLookbackPolicy policy = active_policy.lookback;
+  using ScanPolicy                           = AgentScanPolicy<
+                              0,
+                              0,
+                              void,
+                              policy.load_algorithm,
+                              policy.load_modifier,
+                              policy.store_algorithm,
+                              policy.scan_algorithm,
+                              NoScaling<policy.threads_per_block, policy.items_per_thread>,
+                              delay_constructor_t<policy.delay_constructor.kind,
+                                                  policy.delay_constructor.delay,
+                                                  policy.delay_constructor.l2_write_latency>>;
 
   // Parameterize the AgentScan type for the current configuration
   using AgentScanT = scan::AgentScan<ScanPolicy, OffsetT*, OffsetT*, ::cuda::std::plus<>, OffsetT, OffsetT, OffsetT>;

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -160,9 +160,7 @@ __launch_bounds__(current_policy<PolicySelector>().scan.lookback.threads_per_blo
                               policy.store_algorithm,
                               policy.scan_algorithm,
                               NoScaling<policy.threads_per_block, policy.items_per_thread>,
-                              delay_constructor_t<policy.delay_constructor.kind,
-                                                  policy.delay_constructor.delay,
-                                                  policy.delay_constructor.l2_write_latency>>;
+                              delay_constructor_t<policy.lookback_delay.kind, policy.lookback_delay.delay, policy.lookback_delay.l2_write_latency>>;
 
   // Parameterize the AgentScan type for the current configuration
   using AgentScanT = scan::AgentScan<ScanPolicy, OffsetT*, OffsetT*, ::cuda::std::plus<>, OffsetT, OffsetT, OffsetT>;

--- a/cub/cub/device/dispatch/kernels/kernel_scan.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan.cuh
@@ -66,8 +66,8 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(128) void DeviceScanInitKernel(
   _CCCL_PDL_TRIGGER_NEXT_LAUNCH(); // beneficial for all problem sizes in cub.bench.scan.exclusive.sum.base
 
 #if _CCCL_CUDACC_AT_LEAST(12, 8)
-  constexpr scan_policy policy = current_policy<PolicySelectorT>();
-  if constexpr (policy.algorithm == scan_algorithm::warpspeed)
+  constexpr ScanPolicy policy = current_policy<PolicySelectorT>();
+  if constexpr (policy.algorithm == ScanAlgorithm::warpspeed)
   {
     device_scan_init_warpspeed_body(tile_state.warpspeed, num_tiles);
   }
@@ -116,9 +116,9 @@ _CCCL_EXEC_CHECK_DISABLE
 template <typename PolicySelector>
 [[nodiscard]] _CCCL_HOST_DEVICE_API _CCCL_CONSTEVAL int get_device_scan_launch_bounds() noexcept
 {
-  constexpr scan_policy policy = current_policy<PolicySelector>();
+  constexpr ScanPolicy policy = current_policy<PolicySelector>();
 #if _CCCL_CUDACC_AT_LEAST(12, 8)
-  if constexpr (policy.algorithm == scan_algorithm::warpspeed)
+  if constexpr (policy.algorithm == ScanAlgorithm::warpspeed)
   {
     return num_total_threads(policy.warpspeed);
   }
@@ -201,8 +201,8 @@ __launch_bounds__(device_scan_launch_bounds<PolicySelector>, 1) _CCCL_KERNEL_ATT
   _CCCL_GRID_CONSTANT const OffsetT num_items,
   _CCCL_GRID_CONSTANT const int num_stages)
 {
-  static constexpr scan_policy active_policy = current_policy<PolicySelector>();
-  if constexpr (active_policy.algorithm == scan_algorithm::warpspeed)
+  static constexpr ScanPolicy active_policy = current_policy<PolicySelector>();
+  if constexpr (active_policy.algorithm == ScanAlgorithm::warpspeed)
   {
 #if _CCCL_CUDACC_AT_LEAST(12, 8)
     NV_IF_TARGET(
@@ -218,7 +218,7 @@ __launch_bounds__(device_scan_launch_bounds<PolicySelector>, 1) _CCCL_KERNEL_ATT
   }
   else
   {
-    static constexpr scan_lookback_policy policy = active_policy.lookback;
+    static constexpr ScanLookbackPolicy policy = active_policy.lookback;
     static_assert(policy.load_modifier != CacheLoadModifier::LOAD_LDG,
                   "The memory consistency model does not apply to texture accesses");
     using ScanPolicyT = AgentScanPolicy<

--- a/cub/cub/device/dispatch/kernels/kernel_scan.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan.cuh
@@ -230,9 +230,7 @@ __launch_bounds__(device_scan_launch_bounds<PolicySelector>, 1) _CCCL_KERNEL_ATT
       policy.store_algorithm,
       policy.scan_algorithm,
       NoScaling<policy.threads_per_block, policy.items_per_thread>,
-      delay_constructor_t<policy.delay_constructor.kind,
-                          policy.delay_constructor.delay,
-                          policy.delay_constructor.l2_write_latency>>;
+      delay_constructor_t<policy.lookback_delay.kind, policy.lookback_delay.delay, policy.lookback_delay.l2_write_latency>>;
 
     // Thread block type for scanning input tiles
     using AgentScanT = detail::scan::AgentScan<

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -47,7 +47,7 @@ namespace __scan_detail = CUB_NS_QUALIFIER::detail::scan;
 _CCCL_HOST_DEVICE_API constexpr int num_total_threads(const ScanWarpspeedPolicy& policy)
 {
   const auto num_total_warps = 2 * policy.num_reduce_and_scan_warps + 1 /*num_load_warps*/
-                             + 1 /*num_sched_warps*/ + 1 /*num_look_ahead_warps*/;
+                             + 1 /*num_sched_warps*/ + 1 /*num_lookahead_warps*/;
   return num_total_warps * warp_threads;
 }
 
@@ -277,8 +277,8 @@ struct warpspeed_scan_closure
     squad_lookahead(policy),
   };
 
-  static constexpr int tile_size                   = policy.tile_size();
-  static constexpr int look_ahead_items_per_thread = policy.look_ahead_items_per_thread;
+  static constexpr int tile_size                  = policy.tile_size();
+  static constexpr int lookahead_items_per_thread = policy.lookahead_items_per_thread;
 
   // We might try to instantiate the kernel with huge types which would lead to a small tile size. Ensure its never 0
   static constexpr int elemPerThread = policy.items_per_thread;
@@ -326,7 +326,7 @@ struct warpspeed_scan_closure
 
     if (!is_first_tile)
     {
-      AccumT regAggrExclusiveCta = warpspeed::warpIncrementalLookahead<look_ahead_items_per_thread>(
+      AccumT regAggrExclusiveCta = warpspeed::warpIncrementalLookahead<lookahead_items_per_thread>(
         specialRegisters, params.ptrTileStates, idxTilePrev, AggrExclusiveCtaPrev, idxTile, scan_op);
       if (squad.isLeaderThread())
       {

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -46,7 +46,7 @@ namespace __scan_detail = CUB_NS_QUALIFIER::detail::scan;
 
 _CCCL_HOST_DEVICE_API constexpr int num_total_threads(const ScanWarpspeedPolicy& policy)
 {
-  const auto num_total_warps = 2 * policy.num_reduce_and_scan_warps + 1 /*num_load_warps*/
+  const auto num_total_warps = 2 * policy.reduce_and_scan_warps + 1 /*num_load_warps*/
                              + 1 /*num_sched_warps*/ + 1 /*num_lookahead_warps*/;
   return num_total_warps * warp_threads;
 }

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -44,7 +44,7 @@ namespace detail::scan
 namespace __cub_detail  = CUB_NS_QUALIFIER::detail;
 namespace __scan_detail = CUB_NS_QUALIFIER::detail::scan;
 
-_CCCL_HOST_DEVICE_API constexpr int num_total_threads(const scan_warpspeed_policy& policy)
+_CCCL_HOST_DEVICE_API constexpr int num_total_threads(const ScanWarpspeedPolicy& policy)
 {
   const auto num_total_warps = 2 * policy.num_reduce_and_scan_warps + 1 /*num_load_warps*/
                              + 1 /*num_sched_warps*/ + 1 /*num_look_ahead_warps*/;
@@ -65,7 +65,7 @@ struct scanKernelParams
 template <typename PolicySelector, typename InputT, typename OutputT, typename AccumT>
 struct ScanResources
 {
-  static constexpr scan_warpspeed_policy policy = current_policy<PolicySelector>().warpspeed;
+  static constexpr ScanWarpspeedPolicy policy = current_policy<PolicySelector>().warpspeed;
 
   // align to at least 16 bytes (InputT/OutputT may be aligned higher) so each stage starts correctly aligned
   struct alignas(::cuda::std::max({::cuda::std::size_t{16}, alignof(InputT), alignof(OutputT)})) in_out_t
@@ -262,8 +262,7 @@ template <typename PolicySelector,
           bool ForceInclusive>
 struct warpspeed_scan_closure
 {
-  static constexpr scan_warpspeed_policy policy = current_policy<PolicySelector>().warpspeed;
-
+  static constexpr ScanWarpspeedPolicy policy          = current_policy<PolicySelector>().warpspeed;
   static constexpr warpspeed::SquadDesc squadReduce    = squad_reduce(policy);
   static constexpr warpspeed::SquadDesc squadScanStore = squad_scan_store(policy);
   static constexpr warpspeed::SquadDesc squadLoad      = squad_load(policy);
@@ -837,7 +836,7 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void device_scan_warpspeed_body(
   // Cache special registers at the start of kernel, since getting them takes a few cycles
   warpspeed::SpecialRegisters specialRegisters = warpspeed::getSpecialRegisters();
 
-  static constexpr scan_warpspeed_policy policy = current_policy<PolicySelector>().warpspeed;
+  static constexpr ScanWarpspeedPolicy policy = current_policy<PolicySelector>().warpspeed;
 
   // Set up the shared memory resources
   auto res = [&] {
@@ -894,7 +893,7 @@ device_scan_init_warpspeed_body(warpspeed::tile_state_t<AccumT>* tile_states, co
 }
 
 template <typename InputT, typename OutputT, typename AccumT>
-_CCCL_HOST_DEVICE_API constexpr auto smem_for_stages(const scan_warpspeed_policy& policy, int num_stages) -> int
+_CCCL_HOST_DEVICE_API constexpr auto smem_for_stages(const ScanWarpspeedPolicy& policy, int num_stages) -> int
 {
   return smem_for_stages(
     policy,

--- a/cub/cub/device/dispatch/tuning/tuning_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_batch_memcpy.cuh
@@ -33,8 +33,8 @@ struct small_buffer_policy
   int block_level_tile_size;
   int warp_level_threshold;
   int block_level_threshold;
-  delay_constructor_policy buff_delay_constructor;
-  delay_constructor_policy block_delay_constructor;
+  LookbackDelayPolicy buff_delay_constructor;
+  LookbackDelayPolicy block_delay_constructor;
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const small_buffer_policy& lhs, const small_buffer_policy& rhs)

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -31,10 +31,6 @@ CUB_NAMESPACE_BEGIN
 namespace detail::radix_sort
 {
 using detail::scan::make_mem_scaled_lookback_scan_policy;
-using detail::scan::scan_algorithm;
-using detail::scan::scan_lookback_policy;
-using detail::scan::scan_policy;
-using detail::scan::scan_warpspeed_policy;
 
 struct radix_sort_histogram_policy
 {
@@ -256,7 +252,7 @@ struct radix_sort_policy
   radix_sort_histogram_policy histogram;
   radix_sort_exclusive_sum_policy exclusive_sum;
   radix_sort_onesweep_policy onesweep;
-  scan_policy scan;
+  ScanPolicy scan;
   radix_sort_downsweep_policy downsweep;
   radix_sort_downsweep_policy alt_downsweep;
   radix_sort_upsweep_policy upsweep;
@@ -889,9 +885,9 @@ _CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> radix_sort_policy
     one_pol::STORE_ALGORITHM};
 
   using scan_pol  = typename active_policy::ScanPolicy;
-  const auto scan = scan_policy{
-    scan_algorithm::lookback,
-    scan_lookback_policy{
+  const auto scan = ScanPolicy{
+    ScanAlgorithm::lookback,
+    ScanLookbackPolicy{
       scan_pol::BLOCK_THREADS,
       scan_pol::ITEMS_PER_THREAD,
       scan_pol::LOAD_ALGORITHM,

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -894,7 +894,7 @@ _CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> radix_sort_policy
       scan_pol::LOAD_MODIFIER,
       scan_pol::STORE_ALGORITHM,
       scan_pol::SCAN_ALGORITHM,
-      delay_constructor_policy_from_type<typename scan_pol::detail::delay_constructor_t>},
+      lookback_delay_policy_from_type<typename scan_pol::detail::delay_constructor_t>},
     {}};
 
   const auto downsweep     = radix_sort::convert_downsweep_policy(typename active_policy::DownsweepPolicy{});

--- a/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
@@ -1644,7 +1644,7 @@ struct policy_selector_from_hub
       ReduceByKeyPolicyT::LOAD_ALGORITHM,
       ReduceByKeyPolicyT::LOAD_MODIFIER,
       ReduceByKeyPolicyT::SCAN_ALGORITHM,
-      delay_constructor_policy_from_type<typename ReduceByKeyPolicyT::detail::delay_constructor_t>,
+      lookback_delay_policy_from_type<typename ReduceByKeyPolicyT::detail::delay_constructor_t>,
     };
   }
 };

--- a/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
@@ -949,7 +949,7 @@ struct reduce_by_key_policy
   BlockLoadAlgorithm load_algorithm;
   CacheLoadModifier load_modifier;
   BlockScanAlgorithm scan_algorithm;
-  delay_constructor_policy delay_constructor;
+  LookbackDelayPolicy delay_constructor;
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const reduce_by_key_policy& lhs, const reduce_by_key_policy& rhs)
@@ -1036,7 +1036,7 @@ struct policy_selector
                 BLOCK_LOAD_DIRECT,
                 LOAD_CA,
                 BLOCK_SCAN_WARP_SCANS,
-                {delay_constructor_kind::exponential_backon_jitter_window, 2044, 240}};
+                {LookbackDelayAlgorithm::exponential_backon_jitter_window, 2044, 240}};
       }
       if (key_size == 1 && accum_size == 2)
       {
@@ -1046,7 +1046,7 @@ struct policy_selector
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                {delay_constructor_kind::exponential_backoff_jitter_window, 224, 390}};
+                {LookbackDelayAlgorithm::exponential_backoff_jitter_window, 224, 390}};
       }
       if (key_size == 1 && accum_size == 4)
       {
@@ -1056,7 +1056,7 @@ struct policy_selector
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                {delay_constructor_kind::exponential_backoff, 248, 285}};
+                {LookbackDelayAlgorithm::exponential_backoff, 248, 285}};
       }
       if (key_size == 1 && accum_size == 8)
       {
@@ -1066,7 +1066,7 @@ struct policy_selector
                 BLOCK_LOAD_WARP_TRANSPOSE,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                {delay_constructor_kind::fixed_delay, 132, 540}};
+                {LookbackDelayAlgorithm::fixed_delay, 132, 540}};
       }
       if (key_size == 2 && accum_size == 1)
       {
@@ -1076,7 +1076,7 @@ struct policy_selector
                 BLOCK_LOAD_WARP_TRANSPOSE,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                {delay_constructor_kind::exponential_backoff, 164, 290}};
+                {LookbackDelayAlgorithm::exponential_backoff, 164, 290}};
       }
       if (key_size == 2 && accum_size == 2)
       {
@@ -1086,7 +1086,7 @@ struct policy_selector
                 BLOCK_LOAD_WARP_TRANSPOSE,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                {delay_constructor_kind::exponential_backoff, 180, 975}};
+                {LookbackDelayAlgorithm::exponential_backoff, 180, 975}};
       }
       if (key_size == 2 && accum_size == 4 && accum_t != type_t::float32) // I16, F32, I32 regressed, fall back to SM90
       {
@@ -1096,7 +1096,7 @@ struct policy_selector
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                {delay_constructor_kind::exponential_backoff, 224, 550}};
+                {LookbackDelayAlgorithm::exponential_backoff, 224, 550}};
       }
       if (key_size == 2 && accum_size == 8)
       {
@@ -1106,7 +1106,7 @@ struct policy_selector
                 BLOCK_LOAD_WARP_TRANSPOSE,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                {delay_constructor_kind::fixed_delay, 156, 725}};
+                {LookbackDelayAlgorithm::fixed_delay, 156, 725}};
       }
       if (key_size == 4 && accum_size == 1)
       {
@@ -1116,7 +1116,7 @@ struct policy_selector
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                {delay_constructor_kind::exponential_backoff, 324, 285}};
+                {LookbackDelayAlgorithm::exponential_backoff, 324, 285}};
       }
       if (key_size == 4 && accum_size == 2)
       {
@@ -1126,7 +1126,7 @@ struct policy_selector
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                {delay_constructor_kind::exponential_backon_jitter_window, 1984, 115}};
+                {LookbackDelayAlgorithm::exponential_backon_jitter_window, 1984, 115}};
       }
       if (key_size == 4 && accum_size == 4)
       {
@@ -1136,7 +1136,7 @@ struct policy_selector
                 BLOCK_LOAD_WARP_TRANSPOSE,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                {delay_constructor_kind::exponential_backon_jitter_window, 476, 1005}};
+                {LookbackDelayAlgorithm::exponential_backon_jitter_window, 476, 1005}};
       }
       if (key_size == 4 && accum_size == 8)
       {
@@ -1146,7 +1146,7 @@ struct policy_selector
                 BLOCK_LOAD_WARP_TRANSPOSE,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                {delay_constructor_kind::exponential_backon, 1868, 145}};
+                {LookbackDelayAlgorithm::exponential_backon, 1868, 145}};
       }
       if (key_size == 8 && accum_size == 1)
       {
@@ -1156,7 +1156,7 @@ struct policy_selector
                 BLOCK_LOAD_WARP_TRANSPOSE,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                {delay_constructor_kind::exponential_backon_jitter_window, 1940, 460}};
+                {LookbackDelayAlgorithm::exponential_backon_jitter_window, 1940, 460}};
       }
       if (key_size == 8 && accum_size == 2)
       {
@@ -1166,7 +1166,7 @@ struct policy_selector
                 BLOCK_LOAD_WARP_TRANSPOSE,
                 LOAD_CA,
                 BLOCK_SCAN_WARP_SCANS,
-                {delay_constructor_kind::exponential_backoff, 392, 550}};
+                {LookbackDelayAlgorithm::exponential_backoff, 392, 550}};
       }
       if (key_size == 8 && accum_size == 4)
       {
@@ -1176,7 +1176,7 @@ struct policy_selector
                 BLOCK_LOAD_WARP_TRANSPOSE,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                {delay_constructor_kind::exponential_backoff, 244, 475}};
+                {LookbackDelayAlgorithm::exponential_backoff, 244, 475}};
       }
       if (key_size == 8 && accum_size == 8)
       {
@@ -1186,7 +1186,7 @@ struct policy_selector
                 BLOCK_LOAD_WARP_TRANSPOSE,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                {delay_constructor_kind::exponential_backoff, 196, 340}};
+                {LookbackDelayAlgorithm::exponential_backoff, 196, 340}};
       }
     }
 
@@ -1197,12 +1197,12 @@ struct policy_selector
         if (key_size == 1 && accum_size == 1)
         {
           return {
-            256, 13, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {delay_constructor_kind::no_delay, 0, 720}};
+            256, 13, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 720}};
         }
         if (key_size == 1 && accum_size == 2)
         {
           return {
-            320, 23, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {delay_constructor_kind::no_delay, 0, 865}};
+            320, 23, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 865}};
         }
         if (key_size == 1 && accum_size == 4)
         {
@@ -1211,7 +1211,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 735}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 735}};
         }
         if (key_size == 1 && accum_size == 8)
         {
@@ -1220,7 +1220,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 580}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 580}};
         }
         if (key_size == 1 && accum_size == 16)
         {
@@ -1229,12 +1229,12 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1100}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1100}};
         }
         if (key_size == 2 && accum_size == 1)
         {
           return {
-            128, 23, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {delay_constructor_kind::no_delay, 0, 985}};
+            128, 23, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 985}};
         }
         if (key_size == 2 && accum_size == 2)
         {
@@ -1243,7 +1243,7 @@ struct policy_selector
                   BLOCK_LOAD_DIRECT,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::fixed_delay, 276, 650}};
+                  {LookbackDelayAlgorithm::fixed_delay, 276, 650}};
         }
         if (key_size == 2 && accum_size == 4)
         {
@@ -1252,7 +1252,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::fixed_delay, 240, 765}};
+                  {LookbackDelayAlgorithm::fixed_delay, 240, 765}};
         }
         if (key_size == 2 && accum_size == 8)
         {
@@ -1261,7 +1261,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1190}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1190}};
         }
         if (key_size == 2 && accum_size == 16)
         {
@@ -1270,7 +1270,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1175}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1175}};
         }
         if (key_size == 4 && accum_size == 1)
         {
@@ -1279,7 +1279,7 @@ struct policy_selector
                   BLOCK_LOAD_DIRECT,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::fixed_delay, 404, 645}};
+                  {LookbackDelayAlgorithm::fixed_delay, 404, 645}};
         }
         if (key_size == 4 && accum_size == 2)
         {
@@ -1288,7 +1288,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1160}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1160}};
         }
         if (key_size == 4 && accum_size == 4)
         {
@@ -1297,7 +1297,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1170}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1170}};
         }
         if (key_size == 4 && accum_size == 8)
         {
@@ -1306,7 +1306,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1055}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1055}};
         }
         if (key_size == 4 && accum_size == 16)
         {
@@ -1315,7 +1315,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1195}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1195}};
         }
         if (key_size == 8 && accum_size == 1)
         {
@@ -1324,7 +1324,7 @@ struct policy_selector
                   BLOCK_LOAD_DIRECT,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1170}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1170}};
         }
         if (key_size == 8 && accum_size == 2)
         {
@@ -1333,7 +1333,7 @@ struct policy_selector
                   BLOCK_LOAD_DIRECT,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::fixed_delay, 236, 1030}};
+                  {LookbackDelayAlgorithm::fixed_delay, 236, 1030}};
         }
         if (key_size == 8 && accum_size == 4)
         {
@@ -1342,7 +1342,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::fixed_delay, 152, 560}};
+                  {LookbackDelayAlgorithm::fixed_delay, 152, 560}};
         }
         if (key_size == 8 && accum_size == 8)
         {
@@ -1351,7 +1351,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1030}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1030}};
         }
         if (key_size == 8 && accum_size == 16)
         {
@@ -1360,7 +1360,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1125}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1125}};
         }
         if (key_size == 16 && accum_size == 1)
         {
@@ -1369,7 +1369,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1080}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1080}};
         }
         if (key_size == 16 && accum_size == 2)
         {
@@ -1378,7 +1378,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::fixed_delay, 320, 1005}};
+                  {LookbackDelayAlgorithm::fixed_delay, 320, 1005}};
         }
         if (key_size == 16 && accum_size == 4)
         {
@@ -1387,7 +1387,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::fixed_delay, 232, 1100}};
+                  {LookbackDelayAlgorithm::fixed_delay, 232, 1100}};
         }
         if (key_size == 16 && accum_size == 8)
         {
@@ -1396,7 +1396,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1195}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1195}};
         }
         if (key_size == 16 && accum_size == 16)
         {
@@ -1405,7 +1405,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1150}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1150}};
         }
       }
 
@@ -1425,12 +1425,12 @@ struct policy_selector
         if (key_size == 1 && accum_size == 1)
         {
           return {
-            256, 13, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {delay_constructor_kind::no_delay, 0, 975}};
+            256, 13, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 975}};
         }
         if (key_size == 1 && accum_size == 2)
         {
           return {
-            224, 12, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {delay_constructor_kind::no_delay, 0, 840}};
+            224, 12, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 840}};
         }
         if (key_size == 1 && accum_size == 4)
         {
@@ -1439,12 +1439,12 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 760}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 760}};
         }
         if (key_size == 1 && accum_size == 8)
         {
           return {
-            224, 7, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {delay_constructor_kind::no_delay, 0, 1070}};
+            224, 7, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 1070}};
         }
         if (key_size == 1 && accum_size == 16)
         {
@@ -1453,12 +1453,12 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1175}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1175}};
         }
         if (key_size == 2 && accum_size == 1)
         {
           return {
-            256, 11, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {delay_constructor_kind::no_delay, 0, 620}};
+            256, 11, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 620}};
         }
         if (key_size == 2 && accum_size == 2)
         {
@@ -1467,7 +1467,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 640}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 640}};
         }
         if (key_size == 2 && accum_size == 4)
         {
@@ -1476,7 +1476,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 905}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 905}};
         }
         if (key_size == 2 && accum_size == 8)
         {
@@ -1485,7 +1485,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 810}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 810}};
         }
         if (key_size == 2 && accum_size == 16)
         {
@@ -1494,7 +1494,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1115}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1115}};
         }
         if (key_size == 4 && accum_size == 1)
         {
@@ -1503,7 +1503,7 @@ struct policy_selector
                   BLOCK_LOAD_DIRECT,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1110}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1110}};
         }
         if (key_size == 4 && accum_size == 2)
         {
@@ -1512,7 +1512,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1200}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1200}};
         }
         if (key_size == 4 && accum_size == 4)
         {
@@ -1521,7 +1521,7 @@ struct policy_selector
                   BLOCK_LOAD_DIRECT,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1110}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1110}};
         }
         if (key_size == 4 && accum_size == 8)
         {
@@ -1530,7 +1530,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1165}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1165}};
         }
         if (key_size == 4 && accum_size == 16)
         {
@@ -1539,7 +1539,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1100}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1100}};
         }
         if (key_size == 8 && accum_size == 1)
         {
@@ -1548,17 +1548,17 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1175}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1175}};
         }
         if (key_size == 8 && accum_size == 2)
         {
           return {
-            224, 7, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {delay_constructor_kind::no_delay, 0, 1075}};
+            224, 7, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 1075}};
         }
         if (key_size == 8 && accum_size == 4)
         {
           return {
-            384, 7, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {delay_constructor_kind::no_delay, 0, 1040}};
+            384, 7, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 1040}};
         }
         if (key_size == 8 && accum_size == 8)
         {
@@ -1567,7 +1567,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1080}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1080}};
         }
         if (key_size == 8 && accum_size == 16)
         {
@@ -1576,12 +1576,12 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 430}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 430}};
         }
         if (key_size == 16 && accum_size == 1)
         {
           return {
-            192, 7, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {delay_constructor_kind::no_delay, 0, 1105}};
+            192, 7, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 1105}};
         }
         if (key_size == 16 && accum_size == 2)
         {
@@ -1590,7 +1590,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 755}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 755}};
         }
         if (key_size == 16 && accum_size == 4)
         {
@@ -1599,12 +1599,12 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 535}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 535}};
         }
         if (key_size == 16 && accum_size == 8)
         {
           return {
-            192, 7, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {delay_constructor_kind::no_delay, 0, 1035}};
+            192, 7, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 1035}};
         }
         if (key_size == 16 && accum_size == 16)
         {
@@ -1613,7 +1613,7 @@ struct policy_selector
                   BLOCK_LOAD_WARP_TRANSPOSE,
                   LOAD_DEFAULT,
                   BLOCK_SCAN_WARP_SCANS,
-                  {delay_constructor_kind::no_delay, 0, 1090}};
+                  {LookbackDelayAlgorithm::no_delay, 0, 1090}};
         }
       }
 

--- a/cub/cub/device/dispatch/tuning/tuning_rle_encode.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_rle_encode.cuh
@@ -369,7 +369,7 @@ struct policy_selector
           BLOCK_LOAD_DIRECT,
           LOAD_CA,
           BLOCK_SCAN_WARP_SCANS,
-          {delay_constructor_kind::exponential_backon, 468, 300}};
+          {LookbackDelayAlgorithm::exponential_backon, 468, 300}};
       }
       if (key_size == 2)
       {
@@ -379,7 +379,7 @@ struct policy_selector
           BLOCK_LOAD_DIRECT,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          {delay_constructor_kind::exponential_backon, 376, 420}};
+          {LookbackDelayAlgorithm::exponential_backon, 376, 420}};
       }
       if (key_size == 4)
       {
@@ -389,7 +389,7 @@ struct policy_selector
           BLOCK_LOAD_DIRECT,
           LOAD_CA,
           BLOCK_SCAN_WARP_SCANS,
-          {delay_constructor_kind::exponential_backon, 956, 70}};
+          {LookbackDelayAlgorithm::exponential_backon, 956, 70}};
       }
       if (key_size == 8)
       {
@@ -399,7 +399,7 @@ struct policy_selector
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          {delay_constructor_kind::exponential_backoff, 188, 765}};
+          {LookbackDelayAlgorithm::exponential_backoff, 188, 765}};
       }
     }
 
@@ -410,12 +410,12 @@ struct policy_selector
         if (key_is_primitive && key_size == 1)
         {
           return rle_encode_policy{
-            256, 13, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {delay_constructor_kind::no_delay, 0, 620}};
+            256, 13, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 620}};
         }
         if (key_is_primitive && key_size == 2)
         {
           return rle_encode_policy{
-            128, 22, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {delay_constructor_kind::no_delay, 0, 775}};
+            128, 22, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 775}};
         }
         if (key_is_primitive && key_size == 4)
         {
@@ -425,7 +425,7 @@ struct policy_selector
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::fixed_delay, 284, 480}};
+            {LookbackDelayAlgorithm::fixed_delay, 284, 480}};
         }
         if (key_is_primitive && key_size == 8)
         {
@@ -435,7 +435,7 @@ struct policy_selector
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::no_delay, 0, 515}};
+            {LookbackDelayAlgorithm::no_delay, 0, 515}};
         }
         if (key_t == type_t::int128 || key_t == type_t::uint128)
         {
@@ -445,7 +445,7 @@ struct policy_selector
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::fixed_delay, 428, 930}};
+            {LookbackDelayAlgorithm::fixed_delay, 428, 930}};
         }
       }
 
@@ -465,12 +465,12 @@ struct policy_selector
         if (key_is_primitive && key_size == 1)
         {
           return rle_encode_policy{
-            256, 14, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {delay_constructor_kind::no_delay, 0, 640}};
+            256, 14, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 640}};
         }
         if (key_is_primitive && key_size == 2)
         {
           return rle_encode_policy{
-            256, 13, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {delay_constructor_kind::no_delay, 0, 900}};
+            256, 13, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 900}};
         }
         if (key_is_primitive && key_size == 4)
         {
@@ -480,7 +480,7 @@ struct policy_selector
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::no_delay, 0, 1080}};
+            {LookbackDelayAlgorithm::no_delay, 0, 1080}};
         }
         if (key_is_primitive && key_size == 8)
         {
@@ -490,7 +490,7 @@ struct policy_selector
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::no_delay, 0, 1075}};
+            {LookbackDelayAlgorithm::no_delay, 0, 1075}};
         }
         if (key_t == type_t::int128 || key_t == type_t::uint128)
         {
@@ -500,7 +500,7 @@ struct policy_selector
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::no_delay, 0, 630}};
+            {LookbackDelayAlgorithm::no_delay, 0, 630}};
         }
       }
 

--- a/cub/cub/device/dispatch/tuning/tuning_rle_non_trivial_runs.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_rle_non_trivial_runs.cuh
@@ -338,7 +338,7 @@ struct rle_non_trivial_runs_policy
   CacheLoadModifier load_modifier;
   bool store_with_time_slicing;
   BlockScanAlgorithm scan_algorithm;
-  delay_constructor_policy delay_constructor = {delay_constructor_kind::fixed_delay, 350, 450};
+  LookbackDelayPolicy delay_constructor = {LookbackDelayAlgorithm::fixed_delay, 350, 450};
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const rle_non_trivial_runs_policy& lhs, const rle_non_trivial_runs_policy& rhs)
@@ -416,7 +416,7 @@ struct policy_selector
             LOAD_CA,
             false,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::exponential_backoff, 64, 315}};
+            {LookbackDelayAlgorithm::exponential_backoff, 64, 315}};
         }
         if (key_size == 2)
         {
@@ -428,7 +428,7 @@ struct policy_selector
             LOAD_DEFAULT,
             false,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::exponential_backon, 116, 340}};
+            {LookbackDelayAlgorithm::exponential_backon, 116, 340}};
         }
         if (key_size == 4)
         {
@@ -440,7 +440,7 @@ struct policy_selector
             LOAD_DEFAULT,
             false,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::exponential_backoff, 252, 470}};
+            {LookbackDelayAlgorithm::exponential_backoff, 252, 470}};
         }
         if (key_size == 8 && key_type != type_t::float64) // fall back to SM90 for double
         {
@@ -452,7 +452,7 @@ struct policy_selector
             LOAD_DEFAULT,
             false,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::exponential_backoff, 28, 520}};
+            {LookbackDelayAlgorithm::exponential_backoff, 28, 520}};
         }
       }
 
@@ -472,7 +472,7 @@ struct policy_selector
             LOAD_DEFAULT,
             false,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::no_delay, 0, 385}};
+            {LookbackDelayAlgorithm::no_delay, 0, 385}};
         }
         if (key_is_primitive && key_size == 2)
         {
@@ -483,7 +483,7 @@ struct policy_selector
             LOAD_DEFAULT,
             false,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::no_delay, 0, 675}};
+            {LookbackDelayAlgorithm::no_delay, 0, 675}};
         }
         if (key_is_primitive && key_size == 4)
         {
@@ -494,7 +494,7 @@ struct policy_selector
             LOAD_DEFAULT,
             false,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::no_delay, 0, 695}};
+            {LookbackDelayAlgorithm::no_delay, 0, 695}};
         }
         if (key_is_primitive && key_size == 8)
         {
@@ -505,7 +505,7 @@ struct policy_selector
             LOAD_DEFAULT,
             false,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::no_delay, 0, 840}};
+            {LookbackDelayAlgorithm::no_delay, 0, 840}};
         }
         if (key_type == type_t::int128 || key_type == type_t::uint128)
         {
@@ -516,7 +516,7 @@ struct policy_selector
             LOAD_DEFAULT,
             false,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::fixed_delay, 484, 1150}};
+            {LookbackDelayAlgorithm::fixed_delay, 484, 1150}};
         }
       }
 
@@ -543,7 +543,7 @@ struct policy_selector
             LOAD_DEFAULT,
             false,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::no_delay, 0, 630}};
+            {LookbackDelayAlgorithm::no_delay, 0, 630}};
         }
         if (key_is_primitive && key_size == 2)
         {
@@ -554,7 +554,7 @@ struct policy_selector
             LOAD_DEFAULT,
             false,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::no_delay, 0, 1015}};
+            {LookbackDelayAlgorithm::no_delay, 0, 1015}};
         }
         if (key_is_primitive && key_size == 4)
         {
@@ -565,7 +565,7 @@ struct policy_selector
             LOAD_DEFAULT,
             false,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::no_delay, 0, 915}};
+            {LookbackDelayAlgorithm::no_delay, 0, 915}};
         }
         if (key_is_primitive && key_size == 8)
         {
@@ -576,7 +576,7 @@ struct policy_selector
             LOAD_DEFAULT,
             false,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::no_delay, 0, 1065}};
+            {LookbackDelayAlgorithm::no_delay, 0, 1065}};
         }
         if (key_type == type_t::int128 || key_type == type_t::uint128)
         {
@@ -587,7 +587,7 @@ struct policy_selector
             LOAD_DEFAULT,
             false,
             BLOCK_SCAN_WARP_SCANS,
-            {delay_constructor_kind::no_delay, 0, 1050}};
+            {LookbackDelayAlgorithm::no_delay, 0, 1050}};
         }
       }
       // no tuning for SM80, use a default policy

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -109,18 +109,18 @@ struct ScanWarpspeedPolicy
   int num_reduce_and_scan_warps; //!< Number of warps used for reduction and scanning
   int look_ahead_items_per_thread; //!< Number of look-ahead items per thread in the lookback warp
   int items_per_thread; //!< Number of items processed per reduction and scanning thread
+
   // For the number of stages below, a positive value is taken directly, otherwise it is added to the runtime determined
   // number of stages. For example, a value of 2 means two stages. A value of -2 means runtime number of stages - 2.
   // Therefore, a value of 0 just takes the number of stages.
-  // TODO(bgruber): should we rather have two values? A stage bias (additive) and a stage scale (multiplicative)?
 
   // We do not need too many stages for lookahead since the lookahead warp is the bottleneck. As soon as it produces a
   // new value, it will be consumed by the scanStore squad, releasing the stage. So just always use 2 stages.
-  int lookahead_stages = 2;
+  int lookahead_stages = 2; //!< Number of pipeline stages for the lookahead squad
 
   // If one less than the number of stages, we find a small speedup compared to setting it equal to num_stages. Not sure
   // why.
-  int block_idx_stages = -1;
+  int block_idx_stages = -1; //!< Number of pipeline stages for stealing block indices
 
   _CCCL_HOST_DEVICE_API constexpr int tile_size() const noexcept
   {

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -74,17 +74,19 @@ struct ScanLookbackPolicy
   CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
   BlockStoreAlgorithm store_algorithm; //!< The @ref BlockStoreAlgorithm used for storing items to global memory
   BlockScanAlgorithm scan_algorithm; //!< The @ref BlockScanAlgorithm used for scanning within a thread block
-  LookbackDelayPolicy delay_constructor; //!< The policy configuring the delay used in decoupled lookback
+  LookbackDelayPolicy lookback_delay; //!< The policy configuring the delay used in decoupled lookback
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const ScanLookbackPolicy& lhs, const ScanLookbackPolicy& rhs)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const ScanLookbackPolicy& lhs, const ScanLookbackPolicy& rhs)
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
         && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
         && lhs.store_algorithm == rhs.store_algorithm && lhs.scan_algorithm == rhs.scan_algorithm
-        && lhs.delay_constructor == rhs.delay_constructor;
+        && lhs.lookback_delay == rhs.lookback_delay;
   }
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool operator!=(const ScanLookbackPolicy& lhs, const ScanLookbackPolicy& rhs)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const ScanLookbackPolicy& lhs, const ScanLookbackPolicy& rhs)
   {
     return !(lhs == rhs);
   }
@@ -96,7 +98,7 @@ struct ScanLookbackPolicy
         << "ScanLookbackPolicy { .threads_per_block = " << p.threads_per_block
         << ", .items_per_thread = " << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm
         << ", .load_modifier = " << p.load_modifier << ", .store_algorithm = " << p.store_algorithm
-        << ", .scan_algorithm = " << p.scan_algorithm << ", .delay_constructor = " << p.delay_constructor << " }";
+        << ", .scan_algorithm = " << p.scan_algorithm << ", .lookback_delay = " << p.lookback_delay << " }";
   }
 #endif // _CCCL_HOSTED()
 };
@@ -125,8 +127,7 @@ struct ScanWarpspeedPolicy
     return items_per_thread * num_reduce_and_scan_warps * cub::detail::warp_threads;
   }
 
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const ScanWarpspeedPolicy& lhs, const ScanWarpspeedPolicy& rhs)
+  _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const ScanWarpspeedPolicy& lhs, const ScanWarpspeedPolicy& rhs)
   {
     return lhs.num_reduce_and_scan_warps == rhs.num_reduce_and_scan_warps
         && lhs.look_ahead_items_per_thread == rhs.look_ahead_items_per_thread
@@ -134,8 +135,7 @@ struct ScanWarpspeedPolicy
         && lhs.block_idx_stages == rhs.block_idx_stages;
   }
 
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const ScanWarpspeedPolicy& lhs, const ScanWarpspeedPolicy& rhs)
+  _CCCL_HOST_DEVICE_API constexpr friend bool operator!=(const ScanWarpspeedPolicy& lhs, const ScanWarpspeedPolicy& rhs)
   {
     return !(lhs == rhs);
   }
@@ -989,9 +989,8 @@ struct policy_selector
     return {};
   }
 
-  _CCCL_HOST_DEVICE_API constexpr bool
-  can_use_warpspeed([[maybe_unused]] ::cuda::compute_capability cc,
-                    [[maybe_unused]] const ScanWarpspeedPolicy& warpspeed_policy) const
+  _CCCL_HOST_DEVICE_API constexpr bool can_use_warpspeed(
+    [[maybe_unused]] ::cuda::compute_capability cc, [[maybe_unused]] const ScanWarpspeedPolicy& warpspeed_policy) const
   {
     // We need `cuda::std::is_constant_evaluated` for the compile-time SMEM computation. And we need PTX ISA 8.6.
     // MSVC + nvcc < 13.1 just fails to compile `cub.test.device.scan.lid_1.types_0` with `Internal error` and nothing

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -107,8 +107,8 @@ struct ScanLookbackPolicy
 struct ScanWarpspeedPolicy
 {
   int num_reduce_and_scan_warps; //!< Number of warps used for reduction and scanning
-  int lookahead_items_per_thread; //!< Number of look-ahead items per thread in the lookback warp
   int items_per_thread; //!< Number of items processed per reduction and scanning thread
+  int lookahead_items_per_thread; //!< Number of look-ahead items per thread in the lookback warp
 
   // For the number of stages below, a positive value is taken directly, otherwise it is added to the runtime determined
   // number of stages. For example, a value of 2 means two stages. A value of -2 means runtime number of stages - 2.
@@ -130,9 +130,9 @@ struct ScanWarpspeedPolicy
   _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const ScanWarpspeedPolicy& lhs, const ScanWarpspeedPolicy& rhs)
   {
     return lhs.num_reduce_and_scan_warps == rhs.num_reduce_and_scan_warps
+        && lhs.items_per_thread == rhs.items_per_thread
         && lhs.lookahead_items_per_thread == rhs.lookahead_items_per_thread
-        && lhs.items_per_thread == rhs.items_per_thread && lhs.lookahead_stages == rhs.lookahead_stages
-        && lhs.block_idx_stages == rhs.block_idx_stages;
+        && lhs.lookahead_stages == rhs.lookahead_stages && lhs.block_idx_stages == rhs.block_idx_stages;
   }
 
   _CCCL_HOST_DEVICE_API constexpr friend bool operator!=(const ScanWarpspeedPolicy& lhs, const ScanWarpspeedPolicy& rhs)
@@ -145,9 +145,9 @@ struct ScanWarpspeedPolicy
   {
     return os
         << "ScanWarpspeedPolicy { .num_reduce_and_scan_warps = " << p.num_reduce_and_scan_warps
+        << ", .items_per_thread = " << p.items_per_thread
         << ", .lookahead_items_per_thread = " << p.lookahead_items_per_thread
-        << ", .items_per_thread = " << p.items_per_thread << ", .lookahead_stages = " << p.lookahead_stages
-        << ", .block_idx_stages = " << p.block_idx_stages << " }";
+        << ", .lookahead_stages = " << p.lookahead_stages << ", .block_idx_stages = " << p.block_idx_stages << " }";
   }
 #endif // _CCCL_HOSTED()
 };
@@ -947,14 +947,14 @@ struct policy_selector
         {
           case 1:
             // wrps_4.lbi_8.ipt_160 ()  1.264254  1.264254  1.264254  1.264254
-            return ScanWarpspeedPolicy{4, 8, 160 - 1};
+            return ScanWarpspeedPolicy{4, 160 - 1, 8};
             // TODO(gonidelis): we found this tuning but it regressed:
             // wrps_3.lbi_4.ipt_96 ()  1.454824  1.247212  1.450590  1.560418
-            // return ScanWarpspeedPolicy{3, 4, 96 - 1};
+            // return ScanWarpspeedPolicy{3, 96 - 1, 4};
           case 2:
             // TODO(gonidelis): we found this tuning but it regresses large problems, we should revisit this
             // // wrps_4.lbi_2.ipt_96 ()  1.082511  0.929516  1.091523  1.264033
-            // return ScanWarpspeedPolicy{4, 2, 96 - 1};
+            // return ScanWarpspeedPolicy{4, 96 - 1, 2};
             // clang-format off
             //|   I16   |      I64      |      2^16      |  17.304 us |       1.07% |  15.244 us |       0.77% |    -2.060 us | -11.91% |   FAST   |
             //|   I16   |      I64      |      2^20      |  19.466 us |       1.21% |  17.266 us |       2.93% |    -2.200 us | -11.30% |   FAST   |
@@ -963,21 +963,21 @@ struct policy_selector
             //|   I16   |      I64      |      2^32      |   3.238 ms |       0.53% |   3.429 ms |       0.53% |   191.299 us |   5.91% |   SLOW   |
             // clang-format on
             // wrps_6.lbi_2.ipt_96 ()  1.167633  1.167633  1.167633  1.167633
-            return ScanWarpspeedPolicy{6, 2, 96 - 1};
+            return ScanWarpspeedPolicy{6, 96 - 1, 2};
           case 4:
             if (input_type == type_t::float32)
             {
               // wrps_4.lbi_3.ipt_88 ()  1.047200  1.002119  1.042654  1.081102
-              return ScanWarpspeedPolicy{4, 3, 88 - 1};
+              return ScanWarpspeedPolicy{4, 88 - 1, 3};
             }
             // wrps_4.lbi_3.ipt_80 ()  1.019078  0.999708  1.017346  1.052592
-            return ScanWarpspeedPolicy{4, 3, 80 - 1};
+            return ScanWarpspeedPolicy{4, 80 - 1, 3};
           case 8:
             // wrps_2.lbi_5.ipt_88 ()  1.085781   1.0  1.079245  1.103545
-            return ScanWarpspeedPolicy{2, 5, 88 - 1};
+            return ScanWarpspeedPolicy{2, 88 - 1, 5};
           case 16:
             // wrps_5.lbi_8.ipt_16 ()  1.159883  1.000000  1.143709  1.275821
-            return ScanWarpspeedPolicy{5, 8, 16 - 1};
+            return ScanWarpspeedPolicy{5, 16 - 1, 8};
             // TODO(bgruber): tune for more data types
           default:
             break;

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -106,7 +106,7 @@ struct ScanLookbackPolicy
 //! The tuning policy for the warpspeed scan algorithm in @ref DeviceScan.
 struct ScanWarpspeedPolicy
 {
-  int num_reduce_and_scan_warps; //!< Number of warps used for reduction and scanning
+  int reduce_and_scan_warps; //!< Number of warps used for reduction and scanning
   int items_per_thread; //!< Number of items processed per reduction and scanning thread
   int lookahead_items_per_thread; //!< Number of look-ahead items per thread in the lookback warp
 
@@ -124,13 +124,12 @@ struct ScanWarpspeedPolicy
 
   _CCCL_HOST_DEVICE_API constexpr int tile_size() const noexcept
   {
-    return items_per_thread * num_reduce_and_scan_warps * cub::detail::warp_threads;
+    return items_per_thread * reduce_and_scan_warps * cub::detail::warp_threads;
   }
 
   _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const ScanWarpspeedPolicy& lhs, const ScanWarpspeedPolicy& rhs)
   {
-    return lhs.num_reduce_and_scan_warps == rhs.num_reduce_and_scan_warps
-        && lhs.items_per_thread == rhs.items_per_thread
+    return lhs.reduce_and_scan_warps == rhs.reduce_and_scan_warps && lhs.items_per_thread == rhs.items_per_thread
         && lhs.lookahead_items_per_thread == rhs.lookahead_items_per_thread
         && lhs.lookahead_stages == rhs.lookahead_stages && lhs.block_idx_stages == rhs.block_idx_stages;
   }
@@ -144,9 +143,8 @@ struct ScanWarpspeedPolicy
   friend ::std::ostream& operator<<(::std::ostream& os, const ScanWarpspeedPolicy& p)
   {
     return os
-        << "ScanWarpspeedPolicy { .num_reduce_and_scan_warps = " << p.num_reduce_and_scan_warps
-        << ", .items_per_thread = " << p.items_per_thread
-        << ", .lookahead_items_per_thread = " << p.lookahead_items_per_thread
+        << "ScanWarpspeedPolicy { .reduce_and_scan_warps = " << p.reduce_and_scan_warps << ", .items_per_thread = "
+        << p.items_per_thread << ", .lookahead_items_per_thread = " << p.lookahead_items_per_thread
         << ", .lookahead_stages = " << p.lookahead_stages << ", .block_idx_stages = " << p.block_idx_stages << " }";
   }
 #endif // _CCCL_HOSTED()
@@ -713,12 +711,12 @@ _CCCL_HOST_DEVICE_API constexpr auto make_mem_scaled_lookback_scan_policy(
 
 _CCCL_HOST_DEVICE_API constexpr warpspeed::SquadDesc squad_reduce(const ScanWarpspeedPolicy& policy)
 {
-  return warpspeed::SquadDesc{0, policy.num_reduce_and_scan_warps};
+  return warpspeed::SquadDesc{0, policy.reduce_and_scan_warps};
 }
 
 _CCCL_HOST_DEVICE_API constexpr warpspeed::SquadDesc squad_scan_store(const ScanWarpspeedPolicy& policy)
 {
-  return warpspeed::SquadDesc{1, policy.num_reduce_and_scan_warps};
+  return warpspeed::SquadDesc{1, policy.reduce_and_scan_warps};
 }
 
 _CCCL_HOST_DEVICE_API constexpr warpspeed::SquadDesc squad_load(const ScanWarpspeedPolicy&)
@@ -887,9 +885,9 @@ struct policy_selector
 #if _CCCL_COMPILER(NVHPC)
     // need to reduce the number of threads to <= 256, so each thread can use up to 255 registers. This avoids an
     // error in ptxas, see also: https://github.com/NVIDIA/cccl/issues/7700.
-    warpspeed_policy.num_reduce_and_scan_warps = 2;
+    warpspeed_policy.reduce_and_scan_warps = 2;
 #else // _CCCL_COMPILER(NVHPC)
-    warpspeed_policy.num_reduce_and_scan_warps = 4;
+    warpspeed_policy.reduce_and_scan_warps = 4;
 #endif // _CCCL_COMPILER(NVHPC)
 
     // TODO(bgruber): 5 is a bit better for complex<float>

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -43,6 +43,141 @@
 
 CUB_NAMESPACE_BEGIN
 
+//! The algorithm used by the scan policy.
+enum class ScanAlgorithm
+{
+  lookback,
+  warpspeed
+};
+
+#if _CCCL_HOSTED()
+inline ::std::ostream& operator<<(::std::ostream& os, ScanAlgorithm algorithm)
+{
+  switch (algorithm)
+  {
+    case ScanAlgorithm::lookback:
+      return os << "ScanAlgorithm::lookback";
+    case ScanAlgorithm::warpspeed:
+      return os << "ScanAlgorithm::warpspeed";
+    default:
+      return os << "ScanAlgorithm::<unknown>";
+  }
+}
+#endif // _CCCL_HOSTED()
+
+//! The tuning policy for the lookback scan algorithm in @ref DeviceScan.
+struct ScanLookbackPolicy
+{
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int items_per_thread; //!< Number of items processed per thread
+  BlockLoadAlgorithm load_algorithm; //!< The @ref BlockLoadAlgorithm used for loading items from global memory
+  CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
+  BlockStoreAlgorithm store_algorithm; //!< The @ref BlockStoreAlgorithm used for storing items to global memory
+  BlockScanAlgorithm scan_algorithm; //!< The @ref BlockScanAlgorithm used for scanning within a thread block
+  detail::delay_constructor_policy delay_constructor; //!< The delay constructor policy
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const ScanLookbackPolicy& lhs, const ScanLookbackPolicy& rhs)
+  {
+    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
+        && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
+        && lhs.store_algorithm == rhs.store_algorithm && lhs.scan_algorithm == rhs.scan_algorithm
+        && lhs.delay_constructor == rhs.delay_constructor;
+  }
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool operator!=(const ScanLookbackPolicy& lhs, const ScanLookbackPolicy& rhs)
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const ScanLookbackPolicy& p)
+  {
+    return os
+        << "ScanLookbackPolicy { .threads_per_block = " << p.threads_per_block
+        << ", .items_per_thread = " << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm
+        << ", .load_modifier = " << p.load_modifier << ", .store_algorithm = " << p.store_algorithm
+        << ", .scan_algorithm = " << p.scan_algorithm << ", .delay_constructor = " << p.delay_constructor << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
+//! The tuning policy for the warpspeed scan algorithm in @ref DeviceScan.
+struct ScanWarpspeedPolicy
+{
+  int num_reduce_and_scan_warps; //!< Number of warps used for reduction and scanning
+  int look_ahead_items_per_thread; //!< Number of look-ahead items per thread in the lookback warp
+  int items_per_thread; //!< Number of items processed per reduction and scanning thread
+  // For the number of stages below, a positive value is taken directly, otherwise it is added to the runtime determined
+  // number of stages. For example, a value of 2 means two stages. A value of -2 means runtime number of stages - 2.
+  // Therefore, a value of 0 just takes the number of stages.
+  // TODO(bgruber): should we rather have two values? A stage bias (additive) and a stage scale (multiplicative)?
+
+  // We do not need too many stages for lookahead since the lookahead warp is the bottleneck. As soon as it produces a
+  // new value, it will be consumed by the scanStore squad, releasing the stage. So just always use 2 stages.
+  int lookahead_stages = 2;
+
+  // If one less than the number of stages, we find a small speedup compared to setting it equal to num_stages. Not sure
+  // why.
+  int block_idx_stages = -1;
+
+  _CCCL_HOST_DEVICE_API constexpr int tile_size() const noexcept
+  {
+    return items_per_thread * num_reduce_and_scan_warps * cub::detail::warp_threads;
+  }
+
+  _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const ScanWarpspeedPolicy& lhs, const ScanWarpspeedPolicy& rhs)
+  {
+    return lhs.num_reduce_and_scan_warps == rhs.num_reduce_and_scan_warps
+        && lhs.look_ahead_items_per_thread == rhs.look_ahead_items_per_thread
+        && lhs.items_per_thread == rhs.items_per_thread && lhs.lookahead_stages == rhs.lookahead_stages
+        && lhs.block_idx_stages == rhs.block_idx_stages;
+  }
+
+  _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const ScanWarpspeedPolicy& lhs, const ScanWarpspeedPolicy& rhs)
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const ScanWarpspeedPolicy& p)
+  {
+    return os
+        << "ScanWarpspeedPolicy { .num_reduce_and_scan_warps = " << p.num_reduce_and_scan_warps
+        << ", .look_ahead_items_per_thread = " << p.look_ahead_items_per_thread
+        << ", .items_per_thread = " << p.items_per_thread << ", .lookahead_stages = " << p.lookahead_stages
+        << ", .block_idx_stages = " << p.block_idx_stages << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
+//! The tuning policy for all algorithms in @ref DeviceScan.
+struct ScanPolicy
+{
+  ScanAlgorithm algorithm; //!< The scan algorithm to use
+  ScanLookbackPolicy lookback; //!< The lookback scan policy (used when algorithm is lookback, otherwise ignored)
+  ScanWarpspeedPolicy warpspeed; //!< The warpspeed scan policy (used when algorithm is warpspeed, otherwise ignored)
+
+  [[nodiscard]] _CCCL_API constexpr friend bool operator==(const ScanPolicy& lhs, const ScanPolicy& rhs)
+  {
+    return lhs.lookback == rhs.lookback && lhs.warpspeed == rhs.warpspeed && lhs.algorithm == rhs.algorithm;
+  }
+
+  [[nodiscard]] _CCCL_API constexpr friend bool operator!=(const ScanPolicy& lhs, const ScanPolicy& rhs)
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const ScanPolicy& p)
+  {
+    return os << "ScanPolicy { .algorithm = " << p.algorithm << ", .lookback = " << p.lookback
+              << ", .warpspeed = " << p.warpspeed << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
 namespace detail::scan
 {
 // TODO(bgruber): remove this in CCCL 4.0 when we remove the public scan dispatcher
@@ -547,143 +682,9 @@ struct policy_hub
   using MaxPolicy = Policy1000;
 };
 
-struct scan_lookback_policy
-{
-  int threads_per_block;
-  int items_per_thread;
-  BlockLoadAlgorithm load_algorithm;
-  CacheLoadModifier load_modifier;
-  BlockStoreAlgorithm store_algorithm;
-  BlockScanAlgorithm scan_algorithm;
-  delay_constructor_policy delay_constructor;
-
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const scan_lookback_policy& lhs, const scan_lookback_policy& rhs)
-  {
-    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
-        && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
-        && lhs.store_algorithm == rhs.store_algorithm && lhs.scan_algorithm == rhs.scan_algorithm
-        && lhs.delay_constructor == rhs.delay_constructor;
-  }
-
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const scan_lookback_policy& lhs, const scan_lookback_policy& rhs)
-  {
-    return !(lhs == rhs);
-  }
-
-#if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const scan_lookback_policy& p)
-  {
-    return os
-        << "scan_lookback_policy { .threads_per_block = " << p.threads_per_block
-        << ", .items_per_thread = " << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm
-        << ", .load_modifier = " << p.load_modifier << ", .store_algorithm = " << p.store_algorithm
-        << ", .scan_algorithm = " << p.scan_algorithm << ", .delay_constructor = " << p.delay_constructor << " }";
-  }
-#endif // _CCCL_HOSTED()
-};
-
-struct scan_warpspeed_policy
-{
-  int num_reduce_and_scan_warps;
-  int look_ahead_items_per_thread;
-  int items_per_thread;
-
-  // For the number of stages below, a positive value is taken directly, otherwise it is added to the runtime determined
-  // number of stages. For example, a value of 2 means two stages. A value of -2 means runtime number of stages - 2.
-  // Therefore, a value of 0 just takes the number of stages.
-  // TODO(bgruber): should we rather have two values? A stage bias (additive) and a stage scale (multiplicative)?
-
-  // We do not need too many stages for lookahead since the lookahead warp is the bottleneck. As soon as it produces a
-  // new value, it will be consumed by the scanStore squad, releasing the stage. So just always use 2 stages.
-  int lookahead_stages = 2;
-
-  // If one less than the number of stages, we find a small speedup compared to setting it equal to num_stages. Not sure
-  // why.
-  int block_idx_stages = -1;
-
-  _CCCL_HOST_DEVICE_API constexpr int tile_size() const noexcept
-  {
-    return items_per_thread * num_reduce_and_scan_warps * warp_threads;
-  }
-
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const scan_warpspeed_policy& lhs, const scan_warpspeed_policy& rhs)
-  {
-    return lhs.num_reduce_and_scan_warps == rhs.num_reduce_and_scan_warps
-        && lhs.look_ahead_items_per_thread == rhs.look_ahead_items_per_thread
-        && lhs.items_per_thread == rhs.items_per_thread && lhs.lookahead_stages == rhs.lookahead_stages
-        && lhs.block_idx_stages == rhs.block_idx_stages;
-  }
-
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const scan_warpspeed_policy& lhs, const scan_warpspeed_policy& rhs)
-  {
-    return !(lhs == rhs);
-  }
-
-#if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const scan_warpspeed_policy& p)
-  {
-    return os
-        << "scan_warpspeed_policy { .num_reduce_and_scan_warps = " << p.num_reduce_and_scan_warps
-        << ", .look_ahead_items_per_thread = " << p.look_ahead_items_per_thread
-        << ", .items_per_thread = " << p.items_per_thread << ", .lookahead_stages = " << p.lookahead_stages
-        << ", .block_idx_stages = " << p.block_idx_stages << " }";
-  }
-#endif // _CCCL_HOSTED()
-};
-
-enum class scan_algorithm
-{
-  lookback,
-  warpspeed
-};
-
-#if _CCCL_HOSTED()
-inline ::std::ostream& operator<<(::std::ostream& os, scan_algorithm algorithm)
-{
-  switch (algorithm)
-  {
-    case scan_algorithm::lookback:
-      return os << "scan_algorithm::lookback";
-    case scan_algorithm::warpspeed:
-      return os << "scan_algorithm::warpspeed";
-    default:
-      return os << "scan_algorithm::<unknown>";
-  }
-}
-#endif // _CCCL_HOSTED()
-
-struct scan_policy
-{
-  scan_algorithm algorithm;
-  scan_lookback_policy lookback;
-  scan_warpspeed_policy warpspeed;
-
-  _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const scan_policy& lhs, const scan_policy& rhs)
-  {
-    return lhs.lookback == rhs.lookback && lhs.warpspeed == rhs.warpspeed && lhs.algorithm == rhs.algorithm;
-  }
-
-  _CCCL_HOST_DEVICE_API constexpr friend bool operator!=(const scan_policy& lhs, const scan_policy& rhs)
-  {
-    return !(lhs == rhs);
-  }
-
-#if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const scan_policy& p)
-  {
-    return os << "scan_policy { .algorithm = " << p.algorithm << ", .lookback = " << p.lookback
-              << ", .warpspeed = " << p.warpspeed << " }";
-  }
-#endif // _CCCL_HOSTED()
-};
-
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>
-concept scan_policy_selector = policy_selector<T, scan_policy>;
+concept scan_policy_selector = policy_selector<T, ScanPolicy>;
 #endif // _CCCL_HAS_CONCEPTS()
 
 _CCCL_HOST_DEVICE_API constexpr auto make_mem_scaled_lookback_scan_policy(
@@ -694,12 +695,12 @@ _CCCL_HOST_DEVICE_API constexpr auto make_mem_scaled_lookback_scan_policy(
   CacheLoadModifier load_modifier,
   BlockStoreAlgorithm store_algorithm,
   BlockScanAlgorithm scan_algorithm,
-  delay_constructor_policy delay_constructor = {delay_constructor_kind::fixed_delay, 350, 450}) -> scan_policy
+  delay_constructor_policy delay_constructor = {delay_constructor_kind::fixed_delay, 350, 450}) -> ScanPolicy
 {
   const auto scaled = scale_mem_bound(nominal_4b_threads_per_block, nominal_4b_items_per_thread, compute_t_size);
-  return scan_policy{
-    scan_algorithm::lookback,
-    scan_lookback_policy{
+  return ScanPolicy{
+    ScanAlgorithm::lookback,
+    ScanLookbackPolicy{
       scaled.threads_per_block,
       scaled.items_per_thread,
       load_algorithm,
@@ -707,30 +708,30 @@ _CCCL_HOST_DEVICE_API constexpr auto make_mem_scaled_lookback_scan_policy(
       store_algorithm,
       scan_algorithm,
       delay_constructor},
-    scan_warpspeed_policy{}};
+    ScanWarpspeedPolicy{}};
 }
 
-_CCCL_HOST_DEVICE_API constexpr warpspeed::SquadDesc squad_reduce(const scan_warpspeed_policy& policy)
+_CCCL_HOST_DEVICE_API constexpr warpspeed::SquadDesc squad_reduce(const ScanWarpspeedPolicy& policy)
 {
   return warpspeed::SquadDesc{0, policy.num_reduce_and_scan_warps};
 }
 
-_CCCL_HOST_DEVICE_API constexpr warpspeed::SquadDesc squad_scan_store(const scan_warpspeed_policy& policy)
+_CCCL_HOST_DEVICE_API constexpr warpspeed::SquadDesc squad_scan_store(const ScanWarpspeedPolicy& policy)
 {
   return warpspeed::SquadDesc{1, policy.num_reduce_and_scan_warps};
 }
 
-_CCCL_HOST_DEVICE_API constexpr warpspeed::SquadDesc squad_load(const scan_warpspeed_policy&)
+_CCCL_HOST_DEVICE_API constexpr warpspeed::SquadDesc squad_load(const ScanWarpspeedPolicy&)
 {
   return warpspeed::SquadDesc{2, 1}; // no point in being more than 1 warp
 }
 
-_CCCL_HOST_DEVICE_API constexpr warpspeed::SquadDesc squad_sched(const scan_warpspeed_policy&)
+_CCCL_HOST_DEVICE_API constexpr warpspeed::SquadDesc squad_sched(const ScanWarpspeedPolicy&)
 {
   return warpspeed::SquadDesc{3, 1}; // no point in being more than 1 warp
 }
 
-_CCCL_HOST_DEVICE_API constexpr warpspeed::SquadDesc squad_lookahead(const scan_warpspeed_policy&)
+_CCCL_HOST_DEVICE_API constexpr warpspeed::SquadDesc squad_lookahead(const ScanWarpspeedPolicy&)
 {
   return warpspeed::SquadDesc{4, 1}; // must have 1 warp
 }
@@ -771,7 +772,7 @@ struct ScanResourcesRaw
 
 template <typename SmemInOutT, typename SmemNextBlockIdxT, typename SmemSumExclusiveCtaT, typename SmemSumThreadAndWarpT>
 _CCCL_HOST_DEVICE_API constexpr void setup_scan_resources(
-  const scan_warpspeed_policy& policy,
+  const ScanWarpspeedPolicy& policy,
   warpspeed::SyncHandler& syncHandler,
   warpspeed::SmemAllocator& smemAllocator,
   SmemInOutT& smemInOut,
@@ -801,7 +802,7 @@ _CCCL_HOST_DEVICE_API constexpr void setup_scan_resources(
 }
 
 _CCCL_HOST_DEVICE_API constexpr auto smem_for_stages(
-  const scan_warpspeed_policy& policy,
+  const ScanWarpspeedPolicy& policy,
   int num_stages,
   int input_size,
   int input_align,
@@ -878,9 +879,9 @@ struct policy_selector
   bool benchmark_match;
   bool require_stable_reduction_order = false;
 
-  _CCCL_HOST_DEVICE_API constexpr auto get_sm100_fallback_warpspeed_policy() const -> scan_warpspeed_policy
+  _CCCL_HOST_DEVICE_API constexpr auto get_sm100_fallback_warpspeed_policy() const -> ScanWarpspeedPolicy
   {
-    scan_warpspeed_policy warpspeed_policy{};
+    ScanWarpspeedPolicy warpspeed_policy{};
 
     // TODO(bgruber): tune this
 #if _CCCL_COMPILER(NVHPC)
@@ -913,7 +914,7 @@ struct policy_selector
     return warpspeed_policy;
   }
 
-  _CCCL_HOST_DEVICE_API constexpr auto get_sm120_fallback_warpspeed_policy() const -> scan_warpspeed_policy
+  _CCCL_HOST_DEVICE_API constexpr auto get_sm120_fallback_warpspeed_policy() const -> ScanWarpspeedPolicy
   {
     auto policy = get_sm100_fallback_warpspeed_policy();
     if (operation_t == op_kind_t::other && is_arithmetic_type(input_type))
@@ -931,7 +932,7 @@ struct policy_selector
   }
 
   _CCCL_HOST_DEVICE_API constexpr auto get_warpspeed_policy(::cuda::compute_capability cc) const
-    -> ::cuda::std::optional<scan_warpspeed_policy>
+    -> ::cuda::std::optional<ScanWarpspeedPolicy>
   {
     if (cc >= ::cuda::compute_capability{12, 0})
     {
@@ -946,14 +947,14 @@ struct policy_selector
         {
           case 1:
             // wrps_4.lbi_8.ipt_160 ()  1.264254  1.264254  1.264254  1.264254
-            return scan_warpspeed_policy{4, 8, 160 - 1};
+            return ScanWarpspeedPolicy{4, 8, 160 - 1};
             // TODO(gonidelis): we found this tuning but it regressed:
             // wrps_3.lbi_4.ipt_96 ()  1.454824  1.247212  1.450590  1.560418
-            // return scan_warpspeed_policy{3, 4, 96 - 1};
+            // return ScanWarpspeedPolicy{3, 4, 96 - 1};
           case 2:
             // TODO(gonidelis): we found this tuning but it regresses large problems, we should revisit this
             // // wrps_4.lbi_2.ipt_96 ()  1.082511  0.929516  1.091523  1.264033
-            // return scan_warpspeed_policy{4, 2, 96 - 1};
+            // return ScanWarpspeedPolicy{4, 2, 96 - 1};
             // clang-format off
             //|   I16   |      I64      |      2^16      |  17.304 us |       1.07% |  15.244 us |       0.77% |    -2.060 us | -11.91% |   FAST   |
             //|   I16   |      I64      |      2^20      |  19.466 us |       1.21% |  17.266 us |       2.93% |    -2.200 us | -11.30% |   FAST   |
@@ -962,21 +963,21 @@ struct policy_selector
             //|   I16   |      I64      |      2^32      |   3.238 ms |       0.53% |   3.429 ms |       0.53% |   191.299 us |   5.91% |   SLOW   |
             // clang-format on
             // wrps_6.lbi_2.ipt_96 ()  1.167633  1.167633  1.167633  1.167633
-            return scan_warpspeed_policy{6, 2, 96 - 1};
+            return ScanWarpspeedPolicy{6, 2, 96 - 1};
           case 4:
             if (input_type == type_t::float32)
             {
               // wrps_4.lbi_3.ipt_88 ()  1.047200  1.002119  1.042654  1.081102
-              return scan_warpspeed_policy{4, 3, 88 - 1};
+              return ScanWarpspeedPolicy{4, 3, 88 - 1};
             }
             // wrps_4.lbi_3.ipt_80 ()  1.019078  0.999708  1.017346  1.052592
-            return scan_warpspeed_policy{4, 3, 80 - 1};
+            return ScanWarpspeedPolicy{4, 3, 80 - 1};
           case 8:
             // wrps_2.lbi_5.ipt_88 ()  1.085781   1.0  1.079245  1.103545
-            return scan_warpspeed_policy{2, 5, 88 - 1};
+            return ScanWarpspeedPolicy{2, 5, 88 - 1};
           case 16:
             // wrps_5.lbi_8.ipt_16 ()  1.159883  1.000000  1.143709  1.275821
-            return scan_warpspeed_policy{5, 8, 16 - 1};
+            return ScanWarpspeedPolicy{5, 8, 16 - 1};
             // TODO(bgruber): tune for more data types
           default:
             break;
@@ -990,7 +991,7 @@ struct policy_selector
 
   _CCCL_HOST_DEVICE_API constexpr bool
   can_use_warpspeed([[maybe_unused]] ::cuda::compute_capability cc,
-                    [[maybe_unused]] const scan_warpspeed_policy& warpspeed_policy) const
+                    [[maybe_unused]] const ScanWarpspeedPolicy& warpspeed_policy) const
   {
     // We need `cuda::std::is_constant_evaluated` for the compile-time SMEM computation. And we need PTX ISA 8.6.
     // MSVC + nvcc < 13.1 just fails to compile `cub.test.device.scan.lid_1.types_0` with `Internal error` and nothing
@@ -1032,7 +1033,7 @@ struct policy_selector
 #endif
   }
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> scan_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> ScanPolicy
   {
     // we first try to get the valid warpspeed implementation. if we can't run it, fall back to the old scan impl.
     if (!require_stable_reduction_order)
@@ -1040,7 +1041,7 @@ struct policy_selector
       const auto warpspeed_policy_opt = get_warpspeed_policy(cc);
       if (warpspeed_policy_opt && can_use_warpspeed(cc, *warpspeed_policy_opt))
       {
-        return {scan_algorithm::warpspeed, scan_lookback_policy{}, *warpspeed_policy_opt};
+        return {ScanAlgorithm::warpspeed, ScanLookbackPolicy{}, *warpspeed_policy_opt};
       }
     }
 
@@ -1452,7 +1453,7 @@ template <typename InputIteratorT,
           bool StableReductionOrder = false>
 struct policy_selector_from_types
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> scan_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> ScanPolicy
   {
     using InputValueT  = it_value_t<InputIteratorT>;
     using OutputValueT = it_value_t<OutputIteratorT>;

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -74,7 +74,7 @@ struct ScanLookbackPolicy
   CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
   BlockStoreAlgorithm store_algorithm; //!< The @ref BlockStoreAlgorithm used for storing items to global memory
   BlockScanAlgorithm scan_algorithm; //!< The @ref BlockScanAlgorithm used for scanning within a thread block
-  detail::delay_constructor_policy delay_constructor; //!< The delay constructor policy
+  LookbackDelayPolicy delay_constructor; //!< The policy configuring the delay used in decoupled lookback
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const ScanLookbackPolicy& lhs, const ScanLookbackPolicy& rhs)
   {
@@ -695,7 +695,7 @@ _CCCL_HOST_DEVICE_API constexpr auto make_mem_scaled_lookback_scan_policy(
   CacheLoadModifier load_modifier,
   BlockStoreAlgorithm store_algorithm,
   BlockScanAlgorithm scan_algorithm,
-  delay_constructor_policy delay_constructor = {delay_constructor_kind::fixed_delay, 350, 450}) -> ScanPolicy
+  LookbackDelayPolicy delay_constructor = {LookbackDelayAlgorithm::fixed_delay, 350, 450}) -> ScanPolicy
 {
   const auto scaled = scale_mem_bound(nominal_4b_threads_per_block, nominal_4b_items_per_thread, compute_t_size);
   return ScanPolicy{
@@ -1074,7 +1074,7 @@ struct policy_selector
                 LOAD_DEFAULT,
                 BLOCK_STORE_WARP_TRANSPOSE,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backon, 768, 820});
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 768, 820});
             case 2:
               // ipt_13.tpb_512.ns_1384.dcid_7.l2w_720.trp_1.ld_0 1.128443  1.002841  1.119688  1.307692
               return make_mem_scaled_lookback_scan_policy(
@@ -1085,7 +1085,7 @@ struct policy_selector
                 LOAD_DEFAULT,
                 BLOCK_STORE_WARP_TRANSPOSE,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backon, 1384, 720});
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 1384, 720});
             case 4:
               // ipt_22.tpb_384.ns_1904.dcid_6.l2w_830.trp_1.ld_0 1.148442  0.997167  1.139902  1.462651
               return make_mem_scaled_lookback_scan_policy(
@@ -1096,7 +1096,7 @@ struct policy_selector
                 LOAD_DEFAULT,
                 BLOCK_STORE_WARP_TRANSPOSE,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter, 1904, 830});
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter, 1904, 830});
             case 8:
               // ipt_23.tpb_416.ns_772.dcid_5.l2w_710.trp_1.ld_0 1.089468  1.015581  1.085630  1.264583
               return make_mem_scaled_lookback_scan_policy(
@@ -1107,7 +1107,7 @@ struct policy_selector
                 LOAD_DEFAULT,
                 BLOCK_STORE_WARP_TRANSPOSE,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 772, 710});
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 772, 710});
             default:
               break;
           }
@@ -1126,7 +1126,7 @@ struct policy_selector
                 LOAD_CA,
                 BLOCK_STORE_WARP_TRANSPOSE,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backon, 228, 775});
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 228, 775});
             case 2:
               // todo(gonidelis): Regresses for large inputs. Find better tuning.
               // ipt_13.tpb_288.ns_1520.dcid_5.l2w_895.trp_1.ld_1 1.080934  0.983509  1.077724  1.305288
@@ -1141,7 +1141,7 @@ struct policy_selector
                 LOAD_CA,
                 BLOCK_STORE_WARP_TRANSPOSE,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backon, 956, 550});
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 956, 550});
             case 8:
               if (accum_type == type_t::float64)
               {
@@ -1156,7 +1156,7 @@ struct policy_selector
                 LOAD_DEFAULT,
                 BLOCK_STORE_WARP_TRANSPOSE,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backoff, 328, 965});
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backoff, 328, 965});
             default:
               break;
           }
@@ -1181,7 +1181,7 @@ struct policy_selector
                 LOAD_DEFAULT,
                 BLOCK_STORE_WARP_TRANSPOSE,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::fixed_delay, 168, 1140});
+                LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 168, 1140});
             case 2:
               return make_mem_scaled_lookback_scan_policy(
                 512,
@@ -1191,7 +1191,7 @@ struct policy_selector
                 LOAD_DEFAULT,
                 BLOCK_STORE_WARP_TRANSPOSE,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::fixed_delay, 376, 1125});
+                LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 376, 1125});
             case 4:
               if (accum_type == type_t::float32)
               {
@@ -1203,7 +1203,7 @@ struct policy_selector
                   LOAD_DEFAULT,
                   BLOCK_STORE_WARP_TRANSPOSE,
                   BLOCK_SCAN_WARP_SCANS,
-                  delay_constructor_policy{delay_constructor_kind::fixed_delay, 688, 1140});
+                  LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 688, 1140});
               }
               return make_mem_scaled_lookback_scan_policy(
                 128,
@@ -1213,7 +1213,7 @@ struct policy_selector
                 LOAD_DEFAULT,
                 BLOCK_STORE_WARP_TRANSPOSE,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::fixed_delay, 648, 1245});
+                LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 648, 1245});
             case 8:
               if (accum_type == type_t::float64)
               {
@@ -1225,7 +1225,7 @@ struct policy_selector
                   LOAD_DEFAULT,
                   BLOCK_STORE_WARP_TRANSPOSE,
                   BLOCK_SCAN_WARP_SCANS,
-                  delay_constructor_policy{delay_constructor_kind::fixed_delay, 576, 1215});
+                  LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 576, 1215});
               }
               return make_mem_scaled_lookback_scan_policy(
                 224,
@@ -1235,7 +1235,7 @@ struct policy_selector
                 LOAD_DEFAULT,
                 BLOCK_STORE_WARP_TRANSPOSE,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::fixed_delay, 632, 1290});
+                LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 632, 1290});
             default:
               break;
           }
@@ -1253,7 +1253,7 @@ struct policy_selector
             LOAD_DEFAULT,
             BLOCK_STORE_WARP_TRANSPOSE,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 860, 630});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 860, 630});
         }
 #endif
       }
@@ -1290,7 +1290,7 @@ struct policy_selector
                 LOAD_DEFAULT,
                 BLOCK_STORE_WARP_TRANSPOSE,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::fixed_delay, 368, 725});
+                LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 368, 725});
             case 2:
               return make_mem_scaled_lookback_scan_policy(
                 352,
@@ -1300,7 +1300,7 @@ struct policy_selector
                 LOAD_DEFAULT,
                 BLOCK_STORE_WARP_TRANSPOSE,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::fixed_delay, 488, 1040});
+                LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 488, 1040});
             case 4:
               if (accum_type == type_t::float32)
               {
@@ -1312,7 +1312,7 @@ struct policy_selector
                   LOAD_DEFAULT,
                   BLOCK_STORE_WARP_TRANSPOSE,
                   BLOCK_SCAN_WARP_SCANS,
-                  delay_constructor_policy{delay_constructor_kind::fixed_delay, 724, 1050});
+                  LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 724, 1050});
               }
               return make_mem_scaled_lookback_scan_policy(
                 320,
@@ -1322,7 +1322,7 @@ struct policy_selector
                 LOAD_DEFAULT,
                 BLOCK_STORE_WARP_TRANSPOSE,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::fixed_delay, 268, 1180});
+                LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 268, 1180});
             case 8:
               if (accum_type == type_t::float64)
               {
@@ -1334,7 +1334,7 @@ struct policy_selector
                   LOAD_DEFAULT,
                   BLOCK_STORE_WARP_TRANSPOSE,
                   BLOCK_SCAN_WARP_SCANS,
-                  delay_constructor_policy{delay_constructor_kind::fixed_delay, 388, 1100});
+                  LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 388, 1100});
               }
               return make_mem_scaled_lookback_scan_policy(
                 288,
@@ -1344,7 +1344,7 @@ struct policy_selector
                 LOAD_DEFAULT,
                 BLOCK_STORE_WARP_TRANSPOSE,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::fixed_delay, 716, 785});
+                LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 716, 785});
             default:
               break;
           }
@@ -1362,7 +1362,7 @@ struct policy_selector
             LOAD_DEFAULT,
             BLOCK_STORE_DIRECT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1200});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1200});
         }
 #endif
       }
@@ -1382,7 +1382,7 @@ struct policy_selector
           LOAD_DEFAULT,
           BLOCK_STORE_WARP_TRANSPOSE,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::fixed_delay, 628, 520});
+          LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 628, 520});
       }
 
       return make_mem_scaled_lookback_scan_policy(

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -107,7 +107,7 @@ struct ScanLookbackPolicy
 struct ScanWarpspeedPolicy
 {
   int num_reduce_and_scan_warps; //!< Number of warps used for reduction and scanning
-  int look_ahead_items_per_thread; //!< Number of look-ahead items per thread in the lookback warp
+  int lookahead_items_per_thread; //!< Number of look-ahead items per thread in the lookback warp
   int items_per_thread; //!< Number of items processed per reduction and scanning thread
 
   // For the number of stages below, a positive value is taken directly, otherwise it is added to the runtime determined
@@ -130,7 +130,7 @@ struct ScanWarpspeedPolicy
   _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const ScanWarpspeedPolicy& lhs, const ScanWarpspeedPolicy& rhs)
   {
     return lhs.num_reduce_and_scan_warps == rhs.num_reduce_and_scan_warps
-        && lhs.look_ahead_items_per_thread == rhs.look_ahead_items_per_thread
+        && lhs.lookahead_items_per_thread == rhs.lookahead_items_per_thread
         && lhs.items_per_thread == rhs.items_per_thread && lhs.lookahead_stages == rhs.lookahead_stages
         && lhs.block_idx_stages == rhs.block_idx_stages;
   }
@@ -145,7 +145,7 @@ struct ScanWarpspeedPolicy
   {
     return os
         << "ScanWarpspeedPolicy { .num_reduce_and_scan_warps = " << p.num_reduce_and_scan_warps
-        << ", .look_ahead_items_per_thread = " << p.look_ahead_items_per_thread
+        << ", .lookahead_items_per_thread = " << p.lookahead_items_per_thread
         << ", .items_per_thread = " << p.items_per_thread << ", .lookahead_stages = " << p.lookahead_stages
         << ", .block_idx_stages = " << p.block_idx_stages << " }";
   }
@@ -893,7 +893,7 @@ struct policy_selector
 #endif // _CCCL_COMPILER(NVHPC)
 
     // TODO(bgruber): 5 is a bit better for complex<float>
-    warpspeed_policy.look_ahead_items_per_thread = accum_size == 2 ? 3 : 4;
+    warpspeed_policy.lookahead_items_per_thread = accum_size == 2 ? 3 : 4;
 
     // manual tuning based on cub.bench.scan.exclusive.sum.base
     // 256 / sizeof(InputValueT) - 1 should minimize bank conflicts (and fits into 48KiB SMEM)

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -1040,7 +1040,7 @@ _CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> scan_by_key_policy
           policy_t::LOAD_MODIFIER,
           policy_t::STORE_ALGORITHM,
           policy_t::SCAN_ALGORITHM,
-          delay_constructor_policy_from_type<typename policy_t::detail::delay_constructor_t>};
+          lookback_delay_policy_from_type<typename policy_t::detail::delay_constructor_t>};
 }
 
 // TODO(griwes): remove in CCCL 4.0 when we drop the scan dispatcher after publishing the tuning API
@@ -1113,7 +1113,7 @@ struct policy_selector
                         LOAD_DEFAULT,
                         BLOCK_STORE_WARP_TRANSPOSE,
                         BLOCK_SCAN_WARP_SCANS,
-                        delay_constructor_policy_from_type<no_delay_constructor_t<745>>};
+                        lookback_delay_policy_from_type<no_delay_constructor_t<745>>};
               case 2:
                 // ipt_13.tpb_288.ns_388.dcid_1.l2w_570.trp_1.ld_0 1.228612   1.0  1.216841  1.416167
                 return {288,
@@ -1122,7 +1122,7 @@ struct policy_selector
                         LOAD_DEFAULT,
                         BLOCK_STORE_WARP_TRANSPOSE,
                         BLOCK_SCAN_WARP_SCANS,
-                        delay_constructor_policy_from_type<fixed_delay_constructor_t<388, 570>>};
+                        lookback_delay_policy_from_type<fixed_delay_constructor_t<388, 570>>};
               case 4:
                 // ipt_19.tpb_224.ns_1028.dcid_5.l2w_910.trp_1.ld_1 1.163440   1.0  1.146400  1.260684
                 return {224,
@@ -1131,7 +1131,7 @@ struct policy_selector
                         LOAD_CA,
                         BLOCK_STORE_WARP_TRANSPOSE,
                         BLOCK_SCAN_WARP_SCANS,
-                        delay_constructor_policy_from_type<exponential_backon_jitter_window_constructor_t<1028, 910>>};
+                        lookback_delay_policy_from_type<exponential_backon_jitter_window_constructor_t<1028, 910>>};
               case 8:
                 // ipt_18.tpb_192.ns_432.dcid_1.l2w_1035.trp_1.ld_1 1.177638  0.985417  1.157164  1.296477
                 return {192,
@@ -1140,7 +1140,7 @@ struct policy_selector
                         LOAD_CA,
                         BLOCK_STORE_WARP_TRANSPOSE,
                         BLOCK_SCAN_WARP_SCANS,
-                        delay_constructor_policy_from_type<fixed_delay_constructor_t<432, 1035>>};
+                        lookback_delay_policy_from_type<fixed_delay_constructor_t<432, 1035>>};
               default:
                 break;
             }
@@ -1156,7 +1156,7 @@ struct policy_selector
                         LOAD_DEFAULT,
                         BLOCK_STORE_WARP_TRANSPOSE,
                         BLOCK_SCAN_WARP_SCANS,
-                        delay_constructor_policy_from_type<no_delay_constructor_t<1900>>};
+                        lookback_delay_policy_from_type<no_delay_constructor_t<1900>>};
               case 2:
                 // ipt_14.tpb_160.ns_1736.dcid_7.l2w_170.trp_1.ld_0 1.095207  1.065061  1.100302  1.142857
                 return {160,
@@ -1165,7 +1165,7 @@ struct policy_selector
                         LOAD_DEFAULT,
                         BLOCK_STORE_WARP_TRANSPOSE,
                         BLOCK_SCAN_WARP_SCANS,
-                        delay_constructor_policy_from_type<exponential_backon_constructor_t<1736, 170>>};
+                        lookback_delay_policy_from_type<exponential_backon_constructor_t<1736, 170>>};
               case 4:
                 // ipt_14.tpb_160.ns_336.dcid_1.l2w_805.trp_1.ld_0 1.119313  1.095238  1.122013  1.148681
                 return {160,
@@ -1174,7 +1174,7 @@ struct policy_selector
                         LOAD_DEFAULT,
                         BLOCK_STORE_WARP_TRANSPOSE,
                         BLOCK_SCAN_WARP_SCANS,
-                        delay_constructor_policy_from_type<fixed_delay_constructor_t<336, 805>>};
+                        lookback_delay_policy_from_type<fixed_delay_constructor_t<336, 805>>};
               case 8:
                 return {224,
                         13,
@@ -1182,7 +1182,7 @@ struct policy_selector
                         LOAD_CA,
                         BLOCK_STORE_WARP_TRANSPOSE,
                         BLOCK_SCAN_WARP_SCANS,
-                        delay_constructor_policy_from_type<exponential_backoff_constructor_t<348, 735>>};
+                        lookback_delay_policy_from_type<exponential_backoff_constructor_t<348, 735>>};
               default:
                 break;
             }
@@ -1199,7 +1199,7 @@ struct policy_selector
                         LOAD_CA,
                         BLOCK_STORE_WARP_TRANSPOSE,
                         BLOCK_SCAN_WARP_SCANS,
-                        delay_constructor_policy_from_type<exponential_backon_constructor_t<1436, 155>>};
+                        lookback_delay_policy_from_type<exponential_backon_constructor_t<1436, 155>>};
               case 2:
                 // ipt_13.tpb_288.ns_620.dcid_7.l2w_925.trp_1.ld_2 1.050929  1.000000  1.047178  1.115809
                 return {288,
@@ -1208,7 +1208,7 @@ struct policy_selector
                         LOAD_CA,
                         BLOCK_STORE_WARP_TRANSPOSE,
                         BLOCK_SCAN_WARP_SCANS,
-                        delay_constructor_policy_from_type<exponential_backon_constructor_t<620, 925>>};
+                        lookback_delay_policy_from_type<exponential_backon_constructor_t<620, 925>>};
               case 4:
                 // ipt_20.tpb_224.ns_1856.dcid_5.l2w_280.trp_1.ld_1 1.247248  1.000000  1.220196  1.446328
                 return {224,
@@ -1217,7 +1217,7 @@ struct policy_selector
                         LOAD_CA,
                         BLOCK_STORE_WARP_TRANSPOSE,
                         BLOCK_SCAN_WARP_SCANS,
-                        delay_constructor_policy_from_type<exponential_backon_jitter_window_constructor_t<1856, 280>>};
+                        lookback_delay_policy_from_type<exponential_backon_jitter_window_constructor_t<1856, 280>>};
               case 8:
                 // ipt_14.tpb_224.ns_464.dcid_2.l2w_680.trp_1.ld_1 1.070831  1.002088  1.064736  1.105437
                 return {224,
@@ -1226,7 +1226,7 @@ struct policy_selector
                         LOAD_CA,
                         BLOCK_STORE_WARP_TRANSPOSE,
                         BLOCK_SCAN_WARP_SCANS,
-                        delay_constructor_policy_from_type<exponential_backoff_constructor_t<464, 860>>};
+                        lookback_delay_policy_from_type<exponential_backoff_constructor_t<464, 860>>};
               default:
                 break;
             }
@@ -1242,7 +1242,7 @@ struct policy_selector
                         LOAD_DEFAULT,
                         BLOCK_STORE_WARP_TRANSPOSE,
                         BLOCK_SCAN_WARP_SCANS,
-                        delay_constructor_policy_from_type<no_delay_constructor_t<532>>};
+                        lookback_delay_policy_from_type<no_delay_constructor_t<532>>};
               case 2:
                 // todo(gonidlelis): Significant regression. Search more workloads.
                 // ipt_15.tpb_288.ns_988.dcid_7.l2w_335.trp_1.ld_0 1.064413  0.866667  1.045946  1.116803
@@ -1252,7 +1252,7 @@ struct policy_selector
                         LOAD_DEFAULT,
                         BLOCK_STORE_WARP_TRANSPOSE,
                         BLOCK_SCAN_WARP_SCANS,
-                        delay_constructor_policy_from_type<exponential_backon_constructor_t<988, 335>>};
+                        lookback_delay_policy_from_type<exponential_backon_constructor_t<988, 335>>};
               case 4:
                 // ipt_22.tpb_160.ns_1032.dcid_5.l2w_505.trp_1.ld_2 1.184805  1.000000  1.164843  1.338536
                 return {160,
@@ -1261,7 +1261,7 @@ struct policy_selector
                         LOAD_CA,
                         BLOCK_STORE_WARP_TRANSPOSE,
                         BLOCK_SCAN_WARP_SCANS,
-                        delay_constructor_policy_from_type<exponential_backon_jitter_window_constructor_t<1032, 505>>};
+                        lookback_delay_policy_from_type<exponential_backon_jitter_window_constructor_t<1032, 505>>};
               case 8:
                 // ipt_23.tpb_256.ns_1232.dcid_0.l2w_810.trp_1.ld_0 1.067631  1.000000  1.059607  1.135646
                 return {256,
@@ -1270,7 +1270,7 @@ struct policy_selector
                         LOAD_DEFAULT,
                         BLOCK_STORE_WARP_TRANSPOSE,
                         BLOCK_SCAN_WARP_SCANS,
-                        delay_constructor_policy_from_type<no_delay_constructor_t<1232>>};
+                        lookback_delay_policy_from_type<no_delay_constructor_t<1232>>};
               default:
                 break;
             }
@@ -1299,7 +1299,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_DIRECT,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<no_delay_constructor_t<650>>};
+                          lookback_delay_policy_from_type<no_delay_constructor_t<650>>};
                 case 2:
                   return {256,
                           16,
@@ -1307,7 +1307,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<124, 995>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<124, 995>>};
                 case 4:
                   return {128,
                           15,
@@ -1315,7 +1315,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<488, 545>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<488, 545>>};
                 case 8:
                   return {224,
                           10,
@@ -1323,7 +1323,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<488, 1070>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<488, 1070>>};
                 default:
                   break;
               }
@@ -1338,7 +1338,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_DIRECT,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<136, 785>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<136, 785>>};
                 case 2:
                   return {128,
                           20,
@@ -1346,7 +1346,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<no_delay_constructor_t<445>>};
+                          lookback_delay_policy_from_type<no_delay_constructor_t<445>>};
                 case 4:
                   return {128,
                           22,
@@ -1354,7 +1354,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<312, 865>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<312, 865>>};
                 case 8:
                   return {224,
                           10,
@@ -1362,7 +1362,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<352, 1170>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<352, 1170>>};
                 default:
                   break;
               }
@@ -1377,7 +1377,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_DIRECT,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<no_delay_constructor_t<850>>};
+                          lookback_delay_policy_from_type<no_delay_constructor_t<850>>};
                 case 2:
                   return {256,
                           14,
@@ -1385,7 +1385,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<128, 965>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<128, 965>>};
                 case 4:
                   return {288,
                           14,
@@ -1393,7 +1393,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<700, 1005>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<700, 1005>>};
                 case 8:
                   return {224,
                           14,
@@ -1401,7 +1401,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<556, 1195>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<556, 1195>>};
                 default:
                   break;
               }
@@ -1416,7 +1416,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_DIRECT,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<504, 1010>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<504, 1010>>};
                 case 2:
                   return {224,
                           10,
@@ -1424,7 +1424,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<420, 970>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<420, 970>>};
                 case 4:
                   return {192,
                           10,
@@ -1432,7 +1432,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<500, 1125>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<500, 1125>>};
                 case 8:
                   return {224,
                           11,
@@ -1440,7 +1440,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<600, 930>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<600, 930>>};
                 default:
                   break;
               }
@@ -1464,7 +1464,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<936, 1105>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<936, 1105>>};
                 default:
                   break;
               }
@@ -1479,7 +1479,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<504, 1190>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<504, 1190>>};
                 default:
                   break;
               }
@@ -1494,7 +1494,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<512, 1030>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<512, 1030>>};
                 default:
                   break;
               }
@@ -1509,7 +1509,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<364, 1085>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<364, 1085>>};
                 default:
                   break;
               }
@@ -1531,7 +1531,7 @@ struct policy_selector
                       LOAD_DEFAULT,
                       BLOCK_STORE_WARP_TRANSPOSE,
                       BLOCK_SCAN_WARP_SCANS,
-                      delay_constructor_policy_from_type<fixed_delay_constructor_t<500, 975>>};
+                      lookback_delay_policy_from_type<fixed_delay_constructor_t<500, 975>>};
             case 2:
               return {224,
                       10,
@@ -1539,7 +1539,7 @@ struct policy_selector
                       LOAD_DEFAULT,
                       BLOCK_STORE_WARP_TRANSPOSE,
                       BLOCK_SCAN_WARP_SCANS,
-                      delay_constructor_policy_from_type<fixed_delay_constructor_t<164, 1075>>};
+                      lookback_delay_policy_from_type<fixed_delay_constructor_t<164, 1075>>};
             case 4:
               return {256,
                       9,
@@ -1547,7 +1547,7 @@ struct policy_selector
                       LOAD_DEFAULT,
                       BLOCK_STORE_WARP_TRANSPOSE,
                       BLOCK_SCAN_WARP_SCANS,
-                      delay_constructor_policy_from_type<fixed_delay_constructor_t<268, 1120>>};
+                      lookback_delay_policy_from_type<fixed_delay_constructor_t<268, 1120>>};
             case 8:
               return {192,
                       9,
@@ -1555,7 +1555,7 @@ struct policy_selector
                       LOAD_DEFAULT,
                       BLOCK_STORE_WARP_TRANSPOSE,
                       BLOCK_SCAN_WARP_SCANS,
-                      delay_constructor_policy_from_type<fixed_delay_constructor_t<320, 1200>>};
+                      lookback_delay_policy_from_type<fixed_delay_constructor_t<320, 1200>>};
             default:
               break;
           }
@@ -1572,7 +1572,7 @@ struct policy_selector
                       LOAD_DEFAULT,
                       BLOCK_STORE_WARP_TRANSPOSE,
                       BLOCK_SCAN_WARP_SCANS,
-                      delay_constructor_policy_from_type<fixed_delay_constructor_t<364, 1050>>};
+                      lookback_delay_policy_from_type<fixed_delay_constructor_t<364, 1050>>};
             default:
               break;
           }
@@ -1606,7 +1606,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_DIRECT,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<no_delay_constructor_t<795>>};
+                          lookback_delay_policy_from_type<no_delay_constructor_t<795>>};
                 case 2:
                   return {288,
                           12,
@@ -1614,7 +1614,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<no_delay_constructor_t<825>>};
+                          lookback_delay_policy_from_type<no_delay_constructor_t<825>>};
                 case 4:
                   return {256,
                           15,
@@ -1622,7 +1622,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<no_delay_constructor_t<640>>};
+                          lookback_delay_policy_from_type<no_delay_constructor_t<640>>};
                 case 8:
                   return {192,
                           10,
@@ -1630,7 +1630,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<124, 1040>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<124, 1040>>};
                 default:
                   break;
               }
@@ -1645,7 +1645,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_DIRECT,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<no_delay_constructor_t<1070>>};
+                          lookback_delay_policy_from_type<no_delay_constructor_t<1070>>};
                 case 2:
                   return {320,
                           14,
@@ -1653,7 +1653,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<no_delay_constructor_t<625>>};
+                          lookback_delay_policy_from_type<no_delay_constructor_t<625>>};
                 case 4:
                   return {256,
                           15,
@@ -1661,7 +1661,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<no_delay_constructor_t<1055>>};
+                          lookback_delay_policy_from_type<no_delay_constructor_t<1055>>};
                 case 8:
                   return {160,
                           17,
@@ -1669,7 +1669,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<160, 695>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<160, 695>>};
                 default:
                   break;
               }
@@ -1684,7 +1684,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_DIRECT,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<no_delay_constructor_t<1130>>};
+                          lookback_delay_policy_from_type<no_delay_constructor_t<1130>>};
                 case 2:
                   return {256,
                           12,
@@ -1692,7 +1692,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<no_delay_constructor_t<1130>>};
+                          lookback_delay_policy_from_type<no_delay_constructor_t<1130>>};
                 case 4:
                   return {256,
                           15,
@@ -1700,7 +1700,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<no_delay_constructor_t<1140>>};
+                          lookback_delay_policy_from_type<no_delay_constructor_t<1140>>};
                 case 8:
                   return {256,
                           9,
@@ -1708,7 +1708,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<888, 635>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<888, 635>>};
                 default:
                   break;
               }
@@ -1723,7 +1723,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<no_delay_constructor_t<1120>>};
+                          lookback_delay_policy_from_type<no_delay_constructor_t<1120>>};
                 case 2:
                   return {256,
                           10,
@@ -1731,7 +1731,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<no_delay_constructor_t<1115>>};
+                          lookback_delay_policy_from_type<no_delay_constructor_t<1115>>};
                 case 4:
                   return {224,
                           13,
@@ -1739,7 +1739,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<fixed_delay_constructor_t<24, 1060>>};
+                          lookback_delay_policy_from_type<fixed_delay_constructor_t<24, 1060>>};
                 case 8:
                   return {224,
                           10,
@@ -1747,7 +1747,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<no_delay_constructor_t<1160>>};
+                          lookback_delay_policy_from_type<no_delay_constructor_t<1160>>};
                 default:
                   break;
               }
@@ -1771,7 +1771,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<no_delay_constructor_t<1095>>};
+                          lookback_delay_policy_from_type<no_delay_constructor_t<1095>>};
                 default:
                   break;
               }
@@ -1786,7 +1786,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<no_delay_constructor_t<1105>>};
+                          lookback_delay_policy_from_type<no_delay_constructor_t<1105>>};
                 default:
                   break;
               }
@@ -1801,7 +1801,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<no_delay_constructor_t<1100>>};
+                          lookback_delay_policy_from_type<no_delay_constructor_t<1100>>};
                 default:
                   break;
               }
@@ -1816,7 +1816,7 @@ struct policy_selector
                           LOAD_DEFAULT,
                           BLOCK_STORE_WARP_TRANSPOSE,
                           BLOCK_SCAN_WARP_SCANS,
-                          delay_constructor_policy_from_type<no_delay_constructor_t<220>>};
+                          lookback_delay_policy_from_type<no_delay_constructor_t<220>>};
                 default:
                   break;
               }
@@ -1838,7 +1838,7 @@ struct policy_selector
                       LOAD_DEFAULT,
                       BLOCK_STORE_WARP_TRANSPOSE,
                       BLOCK_SCAN_WARP_SCANS,
-                      delay_constructor_policy_from_type<fixed_delay_constructor_t<144, 1120>>};
+                      lookback_delay_policy_from_type<fixed_delay_constructor_t<144, 1120>>};
             case 2:
               return {192,
                       7,
@@ -1846,7 +1846,7 @@ struct policy_selector
                       LOAD_DEFAULT,
                       BLOCK_STORE_WARP_TRANSPOSE,
                       BLOCK_SCAN_WARP_SCANS,
-                      delay_constructor_policy_from_type<fixed_delay_constructor_t<364, 780>>};
+                      lookback_delay_policy_from_type<fixed_delay_constructor_t<364, 780>>};
             case 4:
               return {256,
                       7,
@@ -1854,7 +1854,7 @@ struct policy_selector
                       LOAD_DEFAULT,
                       BLOCK_STORE_WARP_TRANSPOSE,
                       BLOCK_SCAN_WARP_SCANS,
-                      delay_constructor_policy_from_type<no_delay_constructor_t<1170>>};
+                      lookback_delay_policy_from_type<no_delay_constructor_t<1170>>};
             case 8:
               return {128,
                       15,
@@ -1862,7 +1862,7 @@ struct policy_selector
                       LOAD_DEFAULT,
                       BLOCK_STORE_WARP_TRANSPOSE,
                       BLOCK_SCAN_WARP_SCANS,
-                      delay_constructor_policy_from_type<no_delay_constructor_t<1030>>};
+                      lookback_delay_policy_from_type<no_delay_constructor_t<1030>>};
             default:
               break;
           }
@@ -1879,7 +1879,7 @@ struct policy_selector
                       LOAD_DEFAULT,
                       BLOCK_STORE_WARP_TRANSPOSE,
                       BLOCK_SCAN_WARP_SCANS,
-                      delay_constructor_policy_from_type<no_delay_constructor_t<1160>>};
+                      lookback_delay_policy_from_type<no_delay_constructor_t<1160>>};
             default:
               break;
           }

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -42,7 +42,7 @@ struct scan_by_key_policy
   CacheLoadModifier load_modifier;
   BlockStoreAlgorithm store_algorithm;
   BlockScanAlgorithm scan_algorithm;
-  delay_constructor_policy delay_constructor;
+  LookbackDelayPolicy delay_constructor;
 
   _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const scan_by_key_policy& lhs, const scan_by_key_policy& rhs)
   {

--- a/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
@@ -1598,7 +1598,7 @@ struct select_if_policy
   BlockLoadAlgorithm load_algorithm;
   CacheLoadModifier load_modifier;
   BlockScanAlgorithm scan_algorithm;
-  delay_constructor_policy delay_constructor;
+  LookbackDelayPolicy delay_constructor;
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const select_if_policy& lhs, const select_if_policy& rhs)
@@ -1653,7 +1653,7 @@ private:
       BLOCK_LOAD_DIRECT,
       load_modifier,
       BLOCK_SCAN_WARP_SCANS,
-      delay_constructor_policy{delay_constructor_kind::fixed_delay, 350, 450}};
+      LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 350, 450}};
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto make_scaled_policy(
@@ -1661,7 +1661,7 @@ private:
     int nominal_4b_items,
     BlockLoadAlgorithm load_alg,
     CacheLoadModifier load_mod,
-    delay_constructor_policy delay) const -> select_if_policy
+    LookbackDelayPolicy delay) const -> select_if_policy
   {
     const int items_per_thread = nominal_4B_items_to_items(nominal_4b_items, input_size_bytes);
     return select_if_policy{threads_per_block, items_per_thread, load_alg, load_mod, BLOCK_SCAN_WARP_SCANS, delay};
@@ -1682,7 +1682,7 @@ private:
           BLOCK_LOAD_DIRECT,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1140}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1140}};
       }
       if (has_flags && not keep_rejects)
       {
@@ -1692,7 +1692,7 @@ private:
           BLOCK_LOAD_DIRECT,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::fixed_delay, 464, 1025}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 464, 1025}};
       }
       if (not has_flags && keep_rejects)
       {
@@ -1702,7 +1702,7 @@ private:
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::fixed_delay, 400, 1090}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 400, 1090}};
       }
       if (has_flags && keep_rejects)
       {
@@ -1712,7 +1712,7 @@ private:
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::fixed_delay, 400, 1090}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 400, 1090}};
       }
     }
 
@@ -1732,7 +1732,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::no_delay, 0, 395}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 395}};
         case 2:
           return select_if_policy{
             576,
@@ -1740,7 +1740,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::no_delay, 0, 870}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 870}};
         case 4:
           return select_if_policy{
             256,
@@ -1748,7 +1748,7 @@ private:
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1130}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1130}};
         case 8:
           return select_if_policy{
             192,
@@ -1756,7 +1756,7 @@ private:
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 832, 1165}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 832, 1165}};
         default:
           break;
       }
@@ -1772,7 +1772,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::no_delay, 0, 735}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 735}};
         case 2:
           return select_if_policy{
             256,
@@ -1780,7 +1780,7 @@ private:
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1155}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1155}};
         case 4:
           return select_if_policy{
             320,
@@ -1788,7 +1788,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 124, 1115}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 124, 1115}};
         case 8:
           return select_if_policy{
             384,
@@ -1796,7 +1796,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1130}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1130}};
         default:
           break;
       }
@@ -1812,7 +1812,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::no_delay, 0, 510}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 510}};
         case 2:
           return select_if_policy{
             224,
@@ -1820,7 +1820,7 @@ private:
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1045}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1045}};
         case 4:
           return select_if_policy{
             192,
@@ -1828,7 +1828,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1040}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1040}};
         case 8:
           return select_if_policy{
             192,
@@ -1836,7 +1836,7 @@ private:
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 68, 1160}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 68, 1160}};
         default:
           break;
       }
@@ -1852,7 +1852,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::no_delay, 0, 595}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 595}};
         case 2:
           return select_if_policy{
             224,
@@ -1860,7 +1860,7 @@ private:
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1105}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1105}};
         case 4:
           return select_if_policy{
             192,
@@ -1868,7 +1868,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 912, 1025}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 912, 1025}};
         case 8:
           return select_if_policy{
             192,
@@ -1876,7 +1876,7 @@ private:
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 884, 1130}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 884, 1130}};
         default:
           break;
       }
@@ -1899,7 +1899,7 @@ private:
           BLOCK_LOAD_DIRECT,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::fixed_delay, 460, 1145}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 460, 1145}};
       }
       if (has_flags && not keep_rejects)
       {
@@ -1909,7 +1909,7 @@ private:
           BLOCK_LOAD_DIRECT,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::fixed_delay, 284, 1130}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 284, 1130}};
       }
       if (not has_flags && keep_rejects)
       {
@@ -1919,7 +1919,7 @@ private:
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::fixed_delay, 1616, 1115}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 1616, 1115}};
       }
       if (has_flags && keep_rejects)
       {
@@ -1929,7 +1929,7 @@ private:
           BLOCK_LOAD_DIRECT,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::fixed_delay, 720, 1105}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 720, 1105}};
       }
     }
 
@@ -1949,7 +1949,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::no_delay, 0, 580}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 580}};
         case 2:
           return select_if_policy{
             256,
@@ -1957,7 +1957,7 @@ private:
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 320, 605}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 320, 605}};
         case 4:
           return select_if_policy{
             384,
@@ -1965,7 +1965,7 @@ private:
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 76, 1150}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 76, 1150}};
         case 8:
           return select_if_policy{
             384,
@@ -1973,7 +1973,7 @@ private:
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 380, 1140}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 380, 1140}};
         default:
           break;
       }
@@ -1989,7 +1989,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::no_delay, 0, 715}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 715}};
         case 2:
           return select_if_policy{
             448,
@@ -1997,7 +1997,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 504, 765}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 504, 765}};
         case 4:
           return select_if_policy{
             384,
@@ -2005,7 +2005,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 415, 1125}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 415, 1125}};
         case 8:
           return select_if_policy{
             384,
@@ -2013,7 +2013,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 360, 1170}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 360, 1170}};
         default:
           break;
       }
@@ -2029,7 +2029,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 908, 995}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 908, 995}};
         case 2:
           return select_if_policy{
             320,
@@ -2037,7 +2037,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 500, 560}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 500, 560}};
         case 4:
           return select_if_policy{
             256,
@@ -2045,7 +2045,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 536, 1055}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 536, 1055}};
         case 8:
           return select_if_policy{
             128,
@@ -2053,7 +2053,7 @@ private:
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 512, 1075}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 512, 1075}};
         default:
           break;
       }
@@ -2069,7 +2069,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 580, 850}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 580, 850}};
         case 2:
           return select_if_policy{
             512,
@@ -2077,7 +2077,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 388, 1055}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 388, 1055}};
         case 4:
           return select_if_policy{
             256,
@@ -2085,7 +2085,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 72, 1165}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 72, 1165}};
         case 8:
           return select_if_policy{
             224,
@@ -2093,7 +2093,7 @@ private:
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 532, 1180}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 532, 1180}};
         default:
           break;
       }
@@ -2120,7 +2120,7 @@ private:
           22,
           BLOCK_LOAD_DIRECT,
           LOAD_DEFAULT,
-          delay_constructor_policy{delay_constructor_kind::exponential_backoff, 0, 915});
+          LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backoff, 0, 915});
       }
       if (input_size_bytes == 1 && may_alias)
       {
@@ -2130,7 +2130,7 @@ private:
           20,
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
-          delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter, 596, 295});
+          LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter, 596, 295});
       }
       if (input_size_bytes == 4 && not may_alias)
       {
@@ -2140,7 +2140,7 @@ private:
           15,
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
-          delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 1508, 585});
+          LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 1508, 585});
       }
     }
 
@@ -2155,7 +2155,7 @@ private:
           20,
           BLOCK_LOAD_DIRECT,
           LOAD_DEFAULT,
-          delay_constructor_policy{delay_constructor_kind::exponential_backon, 84, 480});
+          LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 84, 480});
       }
       if (input_size_bytes == 1 && may_alias)
       {
@@ -2165,7 +2165,7 @@ private:
           20,
           BLOCK_LOAD_DIRECT,
           LOAD_DEFAULT,
-          delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter, 360, 380});
+          LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter, 360, 380});
       }
       if (input_size_bytes == 2 && not may_alias)
       {
@@ -2175,7 +2175,7 @@ private:
           22,
           BLOCK_LOAD_DIRECT,
           LOAD_DEFAULT,
-          delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 1292, 750});
+          LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 1292, 750});
       }
       if (input_size_bytes == 2 && may_alias)
       {
@@ -2185,7 +2185,7 @@ private:
           20,
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
-          delay_constructor_policy{delay_constructor_kind::exponential_backoff, 136, 760});
+          LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backoff, 136, 760});
       }
       if (input_size_bytes == 4 && not may_alias)
       {
@@ -2195,7 +2195,7 @@ private:
           14,
           BLOCK_LOAD_DIRECT,
           LOAD_DEFAULT,
-          delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter, 844, 675});
+          LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter, 844, 675});
       }
       if (input_size_bytes == 4 && may_alias)
       {
@@ -2205,7 +2205,7 @@ private:
           14,
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
-          delay_constructor_policy{delay_constructor_kind::exponential_backon, 524, 635});
+          LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 524, 635});
       }
       if (input_size_bytes == 8 && not may_alias)
       {
@@ -2215,7 +2215,7 @@ private:
           22,
           BLOCK_LOAD_DIRECT,
           LOAD_CA,
-          delay_constructor_policy{delay_constructor_kind::exponential_backon, 660, 1030});
+          LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 660, 1030});
       }
       if (input_size_bytes == 8 && may_alias)
       {
@@ -2225,7 +2225,7 @@ private:
           21,
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_CA,
-          delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 1316, 990});
+          LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 1316, 990});
       }
       return {};
     }
@@ -2243,7 +2243,7 @@ private:
             15,
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon, 676, 500});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 676, 500});
         }
         if (offset_size_bytes == 4 && input_size_bytes == 2)
         {
@@ -2253,7 +2253,7 @@ private:
             22,
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter, 1756, 615});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter, 1756, 615});
         }
         if (offset_size_bytes == 4 && input_size_bytes == 4)
         {
@@ -2263,7 +2263,7 @@ private:
             19,
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 716, 570});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 716, 570});
         }
         if (offset_size_bytes == 8 && input_size_bytes == 1)
         {
@@ -2273,7 +2273,7 @@ private:
             22,
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon, 368, 680});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 368, 680});
         }
         if (offset_size_bytes == 8 && input_size_bytes == 2)
         {
@@ -2283,7 +2283,7 @@ private:
             20,
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter, 516, 635});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter, 516, 635});
         }
         if (offset_size_bytes == 8 && input_size_bytes == 4)
         {
@@ -2293,7 +2293,7 @@ private:
             18,
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 1712, 825});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 1712, 825});
         }
       }
       else // not distinct_partitions
@@ -2306,7 +2306,7 @@ private:
             22,
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backoff, 68, 990});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backoff, 68, 990});
         }
         if (offset_size_bytes == 4 && input_size_bytes == 2)
         {
@@ -2316,7 +2316,7 @@ private:
             22,
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 560, 640});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 560, 640});
         }
         if (offset_size_bytes == 4 && input_size_bytes == 4)
         {
@@ -2326,7 +2326,7 @@ private:
             19,
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 724, 970});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 724, 970});
         }
         if (offset_size_bytes == 8 && input_size_bytes == 1)
         {
@@ -2336,7 +2336,7 @@ private:
             20,
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter, 1016, 545});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter, 1016, 545});
         }
         if (offset_size_bytes == 8 && input_size_bytes == 2)
         {
@@ -2346,7 +2346,7 @@ private:
             22,
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backoff, 124, 690});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backoff, 124, 690});
         }
         if (offset_size_bytes == 8 && input_size_bytes == 4)
         {
@@ -2356,7 +2356,7 @@ private:
             19,
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter, 1884, 950});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter, 1884, 950});
         }
         if (offset_size_bytes == 8 && input_size_bytes == 8)
         {
@@ -2366,7 +2366,7 @@ private:
             23,
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backoff, 0, 1200});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backoff, 0, 1200});
         }
       }
     }
@@ -2384,7 +2384,7 @@ private:
             20,
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon, 964, 385});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 964, 385});
         }
         if (offset_size_bytes == 4 && input_size_bytes == 8)
         {
@@ -2394,7 +2394,7 @@ private:
             21,
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon, 300, 580});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 300, 580});
         }
         if (offset_size_bytes == 8 && input_size_bytes == 1)
         {
@@ -2404,7 +2404,7 @@ private:
             20,
             BLOCK_LOAD_DIRECT,
             LOAD_CA,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter, 240, 845});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter, 240, 845});
         }
         if (offset_size_bytes == 8 && input_size_bytes == 2)
         {
@@ -2414,7 +2414,7 @@ private:
             14,
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon, 1428, 830});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 1428, 830});
         }
         if (offset_size_bytes == 8 && input_size_bytes == 4)
         {
@@ -2424,7 +2424,7 @@ private:
             14,
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 1204, 635});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 1204, 635});
         }
         if (offset_size_bytes == 8 && input_size_bytes == 8)
         {
@@ -2434,7 +2434,7 @@ private:
             19,
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon, 1016, 875});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 1016, 875});
         }
       }
       else // not distinct_partitions
@@ -2447,7 +2447,7 @@ private:
             24,
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 2024, 835});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 2024, 835});
         }
         if (offset_size_bytes == 4 && input_size_bytes == 4)
         {
@@ -2457,7 +2457,7 @@ private:
             11,
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon, 476, 665});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 476, 665});
         }
         if (offset_size_bytes == 4 && input_size_bytes == 8)
         {
@@ -2467,7 +2467,7 @@ private:
             20,
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 1420, 525});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 1420, 525});
         }
         if (offset_size_bytes == 8 && input_size_bytes == 1)
         {
@@ -2477,7 +2477,7 @@ private:
             12,
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 0, 850});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 0, 850});
         }
         if (offset_size_bytes == 8 && input_size_bytes == 2)
         {
@@ -2487,7 +2487,7 @@ private:
             12,
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon, 1552, 730});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 1552, 730});
         }
         if (offset_size_bytes == 8 && input_size_bytes == 4)
         {
@@ -2497,7 +2497,7 @@ private:
             14,
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 1444, 655});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 1444, 655});
         }
         if (offset_size_bytes == 8 && input_size_bytes == 8)
         {
@@ -2507,7 +2507,7 @@ private:
             11,
             BLOCK_LOAD_DIRECT,
             LOAD_DEFAULT,
-            delay_constructor_policy{delay_constructor_kind::exponential_backoff, 536, 845});
+            LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backoff, 536, 845});
         }
       }
     }

--- a/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
@@ -423,7 +423,7 @@ struct three_way_partition_policy
   BlockLoadAlgorithm load_algorithm;
   CacheLoadModifier load_modifier;
   BlockScanAlgorithm scan_algorithm;
-  delay_constructor_policy delay_constructor;
+  LookbackDelayPolicy delay_constructor;
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const three_way_partition_policy& lhs, const three_way_partition_policy& rhs)
@@ -491,7 +491,7 @@ struct policy_selector
           BLOCK_LOAD_DIRECT,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter, 72, 840}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter, 72, 840}};
       }
       if (offset_size == 4 && input_size == 8)
       {
@@ -501,7 +501,7 @@ struct policy_selector
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter, 8, 845}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter, 8, 845}};
       }
 
       // TODO(gonidelis): Add tunings for I128.
@@ -515,7 +515,7 @@ struct policy_selector
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 544, 500}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 544, 500}};
       }
 
       if (offset_size == 8 && input_size == 4)
@@ -527,7 +527,7 @@ struct policy_selector
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter, 144, 280}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter, 144, 280}};
       }
 
       if (offset_size == 8 && input_size == 8)
@@ -539,7 +539,7 @@ struct policy_selector
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::exponential_backon, 872, 620}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 872, 620}};
       }
 
       // TODO(gonidelis): Add tunings for I128.
@@ -557,7 +557,7 @@ struct policy_selector
           BLOCK_LOAD_DIRECT,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::no_delay, 0, 445}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 445}};
       }
       if (offset_size == 4 && input_size == 2)
       {
@@ -567,7 +567,7 @@ struct policy_selector
           BLOCK_LOAD_DIRECT,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::fixed_delay, 104, 512}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 104, 512}};
       }
       if (offset_size == 4 && input_size == 4)
       {
@@ -577,7 +577,7 @@ struct policy_selector
           BLOCK_LOAD_DIRECT,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1105}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1105}};
       }
       if (offset_size == 4 && input_size == 8)
       {
@@ -587,7 +587,7 @@ struct policy_selector
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::fixed_delay, 464, 1165}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 464, 1165}};
       }
       if (offset_size == 4 && input_size == 16)
       {
@@ -597,7 +597,7 @@ struct policy_selector
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1040}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1040}};
       }
       if (offset_size == 8 && input_size == 1)
       {
@@ -607,7 +607,7 @@ struct policy_selector
           BLOCK_LOAD_DIRECT,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::fixed_delay, 4, 285}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 4, 285}};
       }
       if (offset_size == 8 && input_size == 2)
       {
@@ -617,7 +617,7 @@ struct policy_selector
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::no_delay, 0, 245}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 245}};
       }
       if (offset_size == 8 && input_size == 4)
       {
@@ -627,7 +627,7 @@ struct policy_selector
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::no_delay, 0, 910}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 910}};
       }
       if (offset_size == 8 && input_size == 8)
       {
@@ -637,7 +637,7 @@ struct policy_selector
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1145}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1145}};
       }
       if (offset_size == 8 && input_size == 16)
       {
@@ -647,7 +647,7 @@ struct policy_selector
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1050}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1050}};
       }
       return default_policy;
     }
@@ -667,7 +667,7 @@ struct policy_selector
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::no_delay, 0, 910}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 910}};
       }
       if (offset_size == 4 && input_size == 4)
       {
@@ -677,7 +677,7 @@ struct policy_selector
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1120}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1120}};
       }
       if (offset_size == 4 && input_size == 8)
       {
@@ -687,7 +687,7 @@ struct policy_selector
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::fixed_delay, 264, 1080}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 264, 1080}};
       }
       if (offset_size == 4 && input_size == 16)
       {
@@ -697,7 +697,7 @@ struct policy_selector
           BLOCK_LOAD_WARP_TRANSPOSE,
           LOAD_DEFAULT,
           BLOCK_SCAN_WARP_SCANS,
-          delay_constructor_policy{delay_constructor_kind::fixed_delay, 672, 1120}};
+          LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 672, 1120}};
       }
       return default_policy;
     }

--- a/cub/cub/device/dispatch/tuning/tuning_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_unique_by_key.cuh
@@ -1519,7 +1519,7 @@ _CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> unique_by_key_policy
           policy_t::LOAD_ALGORITHM,
           policy_t::LOAD_MODIFIER,
           policy_t::SCAN_ALGORITHM,
-          delay_constructor_policy_from_type<typename policy_t::detail::delay_constructor_t>};
+          lookback_delay_policy_from_type<typename policy_t::detail::delay_constructor_t>};
 }
 
 template <typename PolicyHub>

--- a/cub/cub/device/dispatch/tuning/tuning_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_unique_by_key.cuh
@@ -38,7 +38,7 @@ struct unique_by_key_policy
   BlockLoadAlgorithm load_algorithm;
   CacheLoadModifier load_modifier;
   BlockScanAlgorithm scan_algorithm;
-  delay_constructor_policy delay_constructor;
+  LookbackDelayPolicy delay_constructor;
 
   _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const unique_by_key_policy& lhs, const unique_by_key_policy& rhs)
@@ -884,7 +884,7 @@ private:
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_LDG,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 350, 450}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 350, 450}};
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto get_sm100_tuning() const
@@ -910,7 +910,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 948, 955}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 948, 955}};
             case 2:
               // ipt_14.tpb_512.trp_0.ld_0.ns_1228.dcid_7.l2w_320 1.151229  1.007229  1.151131  1.443520
               return unique_by_key_policy{
@@ -919,7 +919,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backon, 1228, 320}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 1228, 320}};
             case 4:
               // ipt_14.tpb_512.trp_0.ld_0.ns_2016.dcid_7.l2w_620 1.165300  1.095238  1.164478  1.266667
               return unique_by_key_policy{
@@ -928,7 +928,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backon, 2016, 620}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 2016, 620}};
             case 8:
               // ipt_10.tpb_384.trp_0.ld_0.ns_1728.dcid_5.l2w_980 1.118716  0.997167  1.116537  1.400000
               return unique_by_key_policy{
@@ -937,7 +937,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 1728, 980}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 1728, 980}};
             default:
               return {};
           }
@@ -952,7 +952,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backon, 508, 1020}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 508, 1020}};
             case 2:
               // ipt_12.tpb_384.trp_0.ld_0.ns_928.dcid_7.l2w_605 1.166564  0.997579  1.154805  1.406709
               return unique_by_key_policy{
@@ -961,7 +961,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backon, 928, 605}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 928, 605}};
             case 4:
               // ipt_11.tpb_384.trp_0.ld_1.ns_1620.dcid_7.l2w_810 1.144483  1.011085  1.152798  1.393750
               return unique_by_key_policy{
@@ -970,7 +970,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_CA,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backon, 1620, 810}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 1620, 810}};
             case 8:
               // ipt_10.tpb_384.trp_0.ld_0.ns_1984.dcid_5.l2w_935 1.605554  1.177083  1.564488  1.946224
               return unique_by_key_policy{
@@ -979,7 +979,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 1984, 935}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 1984, 935}};
             default:
               return {};
           }
@@ -994,7 +994,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backon, 1136, 605}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 1136, 605}};
             case 2:
               // ipt_11.tpb_384.trp_0.ld_0.ns_656.dcid_7.l2w_825 1.216312  1.090485  1.211800  1.535714
               return unique_by_key_policy{
@@ -1003,7 +1003,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backon, 656, 825}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 656, 825}};
             case 8:
               // ipt_10.tpb_384.trp_0.ld_0.ns_1012.dcid_5.l2w_800 1.164713  1.014819  1.174307  1.526042
               return unique_by_key_policy{
@@ -1012,7 +1012,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 1012, 800}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 1012, 800}};
             default:
               return {};
           }
@@ -1027,7 +1027,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 864, 1130}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 864, 1130}};
             case 4:
               // ipt_10.tpb_384.trp_0.ld_0.ns_772.dcid_5.l2w_665 1.152243  1.019816  1.166636  1.517526
               return unique_by_key_policy{
@@ -1036,7 +1036,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::exponential_backon_jitter_window, 772, 665}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 772, 665}};
             default:
               return {};
           }
@@ -1070,7 +1070,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 550}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 550}};
             case 2:
               return unique_by_key_policy{
                 448,
@@ -1078,7 +1078,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 725}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 725}};
             case 4:
               return unique_by_key_policy{
                 256,
@@ -1086,7 +1086,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1130}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1130}};
             case 8:
               return unique_by_key_policy{
                 512,
@@ -1094,7 +1094,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1100}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1100}};
             default:
               return {};
           }
@@ -1108,7 +1108,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 640}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 640}};
             case 2:
               return unique_by_key_policy{
                 288,
@@ -1116,7 +1116,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::fixed_delay, 404, 710}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 404, 710}};
             case 4:
               return unique_by_key_policy{
                 512,
@@ -1124,7 +1124,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 525}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 525}};
             case 8:
               return unique_by_key_policy{
                 256,
@@ -1132,7 +1132,7 @@ private:
                 BLOCK_LOAD_WARP_TRANSPOSE,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1200}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1200}};
             default:
               return {};
           }
@@ -1146,7 +1146,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::fixed_delay, 348, 580}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 348, 580}};
             case 2:
               return unique_by_key_policy{
                 384,
@@ -1154,7 +1154,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1060}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1060}};
             case 4:
               return unique_by_key_policy{
                 512,
@@ -1162,7 +1162,7 @@ private:
                 BLOCK_LOAD_WARP_TRANSPOSE,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1045}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1045}};
             case 8:
               return unique_by_key_policy{
                 512,
@@ -1170,7 +1170,7 @@ private:
                 BLOCK_LOAD_WARP_TRANSPOSE,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1120}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1120}};
             default:
               return {};
           }
@@ -1184,7 +1184,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1060}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1060}};
             case 2:
               return unique_by_key_policy{
                 384,
@@ -1192,7 +1192,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::fixed_delay, 964, 1125}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 964, 1125}};
             case 4:
               return unique_by_key_policy{
                 640,
@@ -1200,7 +1200,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1070}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1070}};
             case 8:
               return unique_by_key_policy{
                 448,
@@ -1208,7 +1208,7 @@ private:
                 BLOCK_LOAD_WARP_TRANSPOSE,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1190}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1190}};
             default:
               return {};
           }
@@ -1228,7 +1228,7 @@ private:
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 344, 1165}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 344, 1165}};
         case 2:
           return unique_by_key_policy{
             224,
@@ -1236,7 +1236,7 @@ private:
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 424, 1055}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 424, 1055}};
         case 4:
           return unique_by_key_policy{
             384,
@@ -1244,7 +1244,7 @@ private:
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1025}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1025}};
         case 8:
           return unique_by_key_policy{
             256,
@@ -1252,7 +1252,7 @@ private:
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1155}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1155}};
         default:
           return {};
       }
@@ -1283,7 +1283,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 835}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 835}};
             case 2:
               return unique_by_key_policy{
                 256,
@@ -1291,7 +1291,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 765}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 765}};
             case 4:
               return unique_by_key_policy{
                 256,
@@ -1299,7 +1299,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1155}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1155}};
             case 8:
               return unique_by_key_policy{
                 224,
@@ -1307,7 +1307,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1065}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1065}};
             default:
               return {};
           }
@@ -1321,7 +1321,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1020}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1020}};
             case 2:
               return unique_by_key_policy{
                 192,
@@ -1329,7 +1329,7 @@ private:
                 BLOCK_LOAD_WARP_TRANSPOSE,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::fixed_delay, 328, 1080}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 328, 1080}};
             case 4:
               return unique_by_key_policy{
                 256,
@@ -1337,7 +1337,7 @@ private:
                 BLOCK_LOAD_WARP_TRANSPOSE,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 535}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 535}};
             case 8:
               return unique_by_key_policy{
                 256,
@@ -1345,7 +1345,7 @@ private:
                 BLOCK_LOAD_WARP_TRANSPOSE,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1055}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1055}};
             default:
               return {};
           }
@@ -1359,7 +1359,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1120}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1120}};
             case 2:
               return unique_by_key_policy{
                 256,
@@ -1367,7 +1367,7 @@ private:
                 BLOCK_LOAD_WARP_TRANSPOSE,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1185}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1185}};
             case 4:
               return unique_by_key_policy{
                 256,
@@ -1375,7 +1375,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::no_delay, 0, 1115}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1115}};
             case 8:
               return unique_by_key_policy{
                 256,
@@ -1383,7 +1383,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::fixed_delay, 320, 1115}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 320, 1115}};
             default:
               return {};
           }
@@ -1397,7 +1397,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::fixed_delay, 24, 555}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 24, 555}};
             case 2:
               return unique_by_key_policy{
                 256,
@@ -1405,7 +1405,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::fixed_delay, 324, 1105}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 324, 1105}};
             case 4:
               return unique_by_key_policy{
                 256,
@@ -1413,7 +1413,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::fixed_delay, 740, 1105}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 740, 1105}};
             case 8:
               return unique_by_key_policy{
                 192,
@@ -1421,7 +1421,7 @@ private:
                 BLOCK_LOAD_DIRECT,
                 LOAD_DEFAULT,
                 BLOCK_SCAN_WARP_SCANS,
-                delay_constructor_policy{delay_constructor_kind::fixed_delay, 764, 1155}};
+                LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 764, 1155}};
             default:
               return {};
           }
@@ -1441,7 +1441,7 @@ private:
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 248, 1200}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 248, 1200}};
         case 8:
           return unique_by_key_policy{
             128,
@@ -1449,7 +1449,7 @@ private:
             BLOCK_LOAD_WARP_TRANSPOSE,
             LOAD_DEFAULT,
             BLOCK_SCAN_WARP_SCANS,
-            delay_constructor_policy{delay_constructor_kind::fixed_delay, 992, 1135}};
+            LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 992, 1135}};
         default:
           return {};
       }

--- a/cub/test/catch2_test_device_partition_env.cu
+++ b/cub/test/catch2_test_device_partition_env.cu
@@ -292,7 +292,7 @@ struct partition_policy_selector
             cub::BLOCK_LOAD_DIRECT,
             cub::LOAD_DEFAULT,
             cub::BLOCK_SCAN_WARP_SCANS,
-            cub::detail::delay_constructor_policy{cub::detail::delay_constructor_kind::fixed_delay, 350, 450}};
+            cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 350, 450}};
   }
 };
 
@@ -307,7 +307,7 @@ struct three_way_partition_policy_selector
             cub::BLOCK_LOAD_DIRECT,
             cub::LOAD_DEFAULT,
             cub::BLOCK_SCAN_WARP_SCANS,
-            cub::detail::delay_constructor_policy{cub::detail::delay_constructor_kind::fixed_delay, 350, 450}};
+            cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 350, 450}};
   }
 };
 

--- a/cub/test/catch2_test_device_scan_env.cu
+++ b/cub/test/catch2_test_device_scan_env.cu
@@ -615,7 +615,7 @@ C2H_TEST("ScanPolicy", "[scan][device]")
       cub::CacheLoadModifier::LOAD_DEFAULT,
       cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
       cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING,
-      cub::detail::delay_constructor_policy{}},
+      cub::LookbackDelayPolicy{}},
     cub::ScanWarpspeedPolicy{}};
 
 #  if _CCCL_STD_VER >= 2020
@@ -630,7 +630,7 @@ C2H_TEST("ScanPolicy", "[scan][device]")
         .load_modifier     = cub::CacheLoadModifier::LOAD_DEFAULT,
         .store_algorithm   = cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
         .scan_algorithm    = cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING,
-        .delay_constructor = cub::detail::delay_constructor_policy{}},
+        .delay_constructor = cub::LookbackDelayPolicy{}},
     .warpspeed = cub::ScanWarpspeedPolicy{}};
 #  else // _CCCL_STD_VER >= 2020
   constexpr auto p2 = p1;

--- a/cub/test/catch2_test_device_scan_env.cu
+++ b/cub/test/catch2_test_device_scan_env.cu
@@ -615,7 +615,7 @@ C2H_TEST("ScanPolicy", "[scan][device]")
       cub::CacheLoadModifier::LOAD_DEFAULT,
       cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
       cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING,
-      cub::LookbackDelayPolicy{}},
+      cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 832, 1165}},
     cub::ScanWarpspeedPolicy{}};
 
 #  if _CCCL_STD_VER >= 2020
@@ -630,7 +630,7 @@ C2H_TEST("ScanPolicy", "[scan][device]")
         .load_modifier     = cub::CacheLoadModifier::LOAD_DEFAULT,
         .store_algorithm   = cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
         .scan_algorithm    = cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING,
-        .lookback_delay    = cub::LookbackDelayPolicy{}},
+        .lookback_delay    = cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 832, 1165}},
     .warpspeed = cub::ScanWarpspeedPolicy{}};
 #  else // _CCCL_STD_VER >= 2020
   constexpr auto p2 = p1;

--- a/cub/test/catch2_test_device_scan_env.cu
+++ b/cub/test/catch2_test_device_scan_env.cu
@@ -129,9 +129,9 @@ TEST_CASE("Device scan inclusive-scan-init works with default environment", "[sc
 template <int ThreadsPerBlock>
 struct scan_tuning
 {
-  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::detail::scan::scan_policy
+  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::ScanPolicy
   {
-    return {cub::detail::scan::scan_algorithm::lookback,
+    return {cub::ScanAlgorithm::lookback,
             {ThreadsPerBlock,
              1,
              cub::BlockLoadAlgorithm::BLOCK_LOAD_WARP_TRANSPOSE,
@@ -592,3 +592,52 @@ C2H_TEST("Device scan inclusive-scan in-place uses environment", "[scan][device]
   auto expected = c2h::device_vector<int>{1, 3, 6, 10};
   REQUIRE(d_data == expected);
 }
+
+#if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
+C2H_TEST("ScanPolicy", "[scan][device]")
+{
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::ScanPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ScanPolicy>);
+
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::ScanLookbackPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ScanLookbackPolicy>);
+
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::ScanWarpspeedPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ScanWarpspeedPolicy>);
+
+  // aggregate init
+  constexpr auto p1 = cub::ScanPolicy{
+    cub::ScanAlgorithm::lookback,
+    cub::ScanLookbackPolicy{
+      256,
+      11,
+      cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+      cub::CacheLoadModifier::LOAD_DEFAULT,
+      cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+      cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING,
+      cub::detail::delay_constructor_policy{}},
+    cub::ScanWarpspeedPolicy{}};
+
+#  if _CCCL_STD_VER >= 2020
+  // designated init
+  constexpr auto p2 = cub::ScanPolicy{
+    .algorithm = cub::ScanAlgorithm::lookback,
+    .lookback =
+      cub::ScanLookbackPolicy{
+        .threads_per_block = 256,
+        .items_per_thread  = 11,
+        .load_algorithm    = cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+        .load_modifier     = cub::CacheLoadModifier::LOAD_DEFAULT,
+        .store_algorithm   = cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+        .scan_algorithm    = cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING,
+        .delay_constructor = cub::detail::delay_constructor_policy{}},
+    .warpspeed = cub::ScanWarpspeedPolicy{}};
+#  else // _CCCL_STD_VER >= 2020
+  constexpr auto p2 = p1;
+#  endif // _CCCL_STD_VER >= 2020
+
+  // comparison
+  STATIC_REQUIRE(p1 == p2);
+  STATIC_REQUIRE_FALSE(p1 != p2);
+}
+#endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_scan_env.cu
+++ b/cub/test/catch2_test_device_scan_env.cu
@@ -630,7 +630,7 @@ C2H_TEST("ScanPolicy", "[scan][device]")
         .load_modifier     = cub::CacheLoadModifier::LOAD_DEFAULT,
         .store_algorithm   = cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
         .scan_algorithm    = cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING,
-        .delay_constructor = cub::LookbackDelayPolicy{}},
+        .lookback_delay    = cub::LookbackDelayPolicy{}},
     .warpspeed = cub::ScanWarpspeedPolicy{}};
 #  else // _CCCL_STD_VER >= 2020
   constexpr auto p2 = p1;

--- a/cub/test/catch2_test_device_scan_env_api.cu
+++ b/cub/test/catch2_test_device_scan_env_api.cu
@@ -445,7 +445,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveSum env-based API with tuning", "[scan][env]
 {
   // example-begin exclusive-sum-tuning
   auto input  = thrust::device_vector<int>{1, 2, 3, 4};
-  auto output = thrust::device_vector<int>(4);
+  auto output = thrust::device_vector<int>(4, thrust::no_init);
 
   const auto error = cub::DeviceScan::ExclusiveSum(
     input.begin(), output.begin(), input.size(), cuda::execution::tune(ScanPolicySelector{}));

--- a/cub/test/catch2_test_device_scan_env_api.cu
+++ b/cub/test/catch2_test_device_scan_env_api.cu
@@ -434,7 +434,7 @@ struct ScanPolicySelector
           .load_modifier     = cub::LOAD_DEFAULT,
           .store_algorithm   = cub::BLOCK_STORE_WARP_TRANSPOSE,
           .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
-          .lookback_delay    = cub::LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 832, 1165}},
+          .lookback_delay    = cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 832, 1165}},
       .warpspeed = cub::ScanWarpspeedPolicy{} // ignored since algorithm is lookback
     };
   }

--- a/cub/test/catch2_test_device_scan_env_api.cu
+++ b/cub/test/catch2_test_device_scan_env_api.cu
@@ -434,7 +434,7 @@ struct MyPolicySelector
           .load_modifier     = cub::LOAD_DEFAULT,
           .store_algorithm   = cub::BLOCK_STORE_WARP_TRANSPOSE,
           .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
-          .delay_constructor = cub::detail::delay_constructor_policy{}},
+          .delay_constructor = cub::LookbackDelayPolicy{}},
       .warpspeed = cub::ScanWarpspeedPolicy{} // ignored since algorithm is lookback
     };
   }

--- a/cub/test/catch2_test_device_scan_env_api.cu
+++ b/cub/test/catch2_test_device_scan_env_api.cu
@@ -434,7 +434,7 @@ struct ScanPolicySelector
           .load_modifier     = cub::LOAD_DEFAULT,
           .store_algorithm   = cub::BLOCK_STORE_WARP_TRANSPOSE,
           .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
-          .delay_constructor = cub::LookbackDelayPolicy{}},
+          .lookback_delay    = cub::LookbackDelayPolicy{}},
       .warpspeed = cub::ScanWarpspeedPolicy{} // ignored since algorithm is lookback
     };
   }

--- a/cub/test/catch2_test_device_scan_env_api.cu
+++ b/cub/test/catch2_test_device_scan_env_api.cu
@@ -9,6 +9,7 @@
 
 #include <cuda/__execution/determinism.h>
 #include <cuda/__execution/require.h>
+#include <cuda/__execution/tune.h>
 #include <cuda/devices>
 #include <cuda/stream>
 
@@ -415,3 +416,49 @@ C2H_TEST("cub::DeviceScan::InclusiveScan in-place accepts stream", "[scan][env]"
   REQUIRE(error == cudaSuccess);
   REQUIRE(data == expected);
 }
+
+#if _CCCL_STD_VER >= 2020
+
+// example-begin exclusive-sum-policy-selector
+struct MyPolicySelector
+{
+  __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::ScanPolicy
+  {
+    return {
+      .algorithm = cub::ScanAlgorithm::lookback,
+      .lookback =
+        cub::ScanLookbackPolicy{
+          .threads_per_block = 256,
+          .items_per_thread  = cc > cuda::compute_capability{9, 0} ? 15 : 12,
+          .load_algorithm    = cub::BLOCK_LOAD_WARP_TRANSPOSE,
+          .load_modifier     = cub::LOAD_DEFAULT,
+          .store_algorithm   = cub::BLOCK_STORE_WARP_TRANSPOSE,
+          .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
+          .delay_constructor = cub::detail::delay_constructor_policy{}},
+      .warpspeed = cub::ScanWarpspeedPolicy{} // ignored since algorithm is lookback
+    };
+  }
+};
+// example-end exclusive-sum-policy-selector
+
+C2H_TEST("cub::DeviceScan::ExclusiveSum env-based API with tuning", "[scan][env]")
+{
+  // example-begin exclusive-sum-tuning
+  auto input  = thrust::device_vector<int>{1, 2, 3, 4};
+  auto output = thrust::device_vector<int>(4);
+
+  const auto error = cub::DeviceScan::ExclusiveSum(
+    input.begin(), output.begin(), input.size(), cuda::execution::tune(MyPolicySelector{}));
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceScan::ExclusiveSum failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected{0, 1, 3, 6};
+  // example-end exclusive-sum-tuning
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(output == expected);
+}
+
+#endif // _CCCL_STD_VER >= 2020

--- a/cub/test/catch2_test_device_scan_env_api.cu
+++ b/cub/test/catch2_test_device_scan_env_api.cu
@@ -434,7 +434,7 @@ struct ScanPolicySelector
           .load_modifier     = cub::LOAD_DEFAULT,
           .store_algorithm   = cub::BLOCK_STORE_WARP_TRANSPOSE,
           .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
-          .lookback_delay    = cub::LookbackDelayPolicy{}},
+          .lookback_delay    = cub::LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 832, 1165}},
       .warpspeed = cub::ScanWarpspeedPolicy{} // ignored since algorithm is lookback
     };
   }

--- a/cub/test/catch2_test_device_scan_env_api.cu
+++ b/cub/test/catch2_test_device_scan_env_api.cu
@@ -420,7 +420,7 @@ C2H_TEST("cub::DeviceScan::InclusiveScan in-place accepts stream", "[scan][env]"
 #if _CCCL_STD_VER >= 2020
 
 // example-begin exclusive-sum-policy-selector
-struct MyPolicySelector
+struct ScanPolicySelector
 {
   __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::ScanPolicy
   {
@@ -448,7 +448,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveSum env-based API with tuning", "[scan][env]
   auto output = thrust::device_vector<int>(4);
 
   const auto error = cub::DeviceScan::ExclusiveSum(
-    input.begin(), output.begin(), input.size(), cuda::execution::tune(MyPolicySelector{}));
+    input.begin(), output.begin(), input.size(), cuda::execution::tune(ScanPolicySelector{}));
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceScan::ExclusiveSum failed with status: " << error << '\n';

--- a/cub/test/catch2_test_device_select_env.cu
+++ b/cub/test/catch2_test_device_select_env.cu
@@ -1104,7 +1104,7 @@ struct select_tuning
             cub::BLOCK_LOAD_DIRECT,
             cub::LOAD_DEFAULT,
             cub::BLOCK_SCAN_WARP_SCANS,
-            cub::detail::delay_constructor_policy{cub::detail::delay_constructor_kind::fixed_delay, 350, 450}};
+            cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 350, 450}};
   }
 };
 
@@ -1119,7 +1119,7 @@ struct unique_by_key_tuning
             cub::BLOCK_LOAD_DIRECT,
             cub::LOAD_DEFAULT,
             cub::BLOCK_SCAN_WARP_SCANS,
-            cub::detail::delay_constructor_policy{cub::detail::delay_constructor_kind::fixed_delay, 350, 450}};
+            cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 350, 450}};
   }
 };
 

--- a/nvbench_helper/nvbench_helper/look_back_helper.cuh
+++ b/nvbench_helper/nvbench_helper/look_back_helper.cuh
@@ -17,7 +17,7 @@ using delay_constructor_t =
                                    TUNE_MAGIC_NS,
                                    TUNE_L2_WRITE_LATENCY_NS>;
 
-inline constexpr auto delay_constructor_policy = cub::LookbackDelayPolicy{
+inline constexpr auto lookback_delay_policy = cub::LookbackDelayPolicy{
   static_cast<cub::LookbackDelayAlgorithm>(TUNE_DELAY_CONSTRUCTOR_ID), TUNE_MAGIC_NS, TUNE_L2_WRITE_LATENCY_NS};
 
 #endif // !TUNE_BASE

--- a/nvbench_helper/nvbench_helper/look_back_helper.cuh
+++ b/nvbench_helper/nvbench_helper/look_back_helper.cuh
@@ -13,11 +13,11 @@
 #  endif
 
 using delay_constructor_t =
-  cub::detail::delay_constructor_t<static_cast<cub::detail::delay_constructor_kind>(TUNE_DELAY_CONSTRUCTOR_ID),
+  cub::detail::delay_constructor_t<static_cast<cub::LookbackDelayAlgorithm>(TUNE_DELAY_CONSTRUCTOR_ID),
                                    TUNE_MAGIC_NS,
                                    TUNE_L2_WRITE_LATENCY_NS>;
 
-inline constexpr auto delay_constructor_policy = cub::detail::delay_constructor_policy{
-  static_cast<cub::detail::delay_constructor_kind>(TUNE_DELAY_CONSTRUCTOR_ID), TUNE_MAGIC_NS, TUNE_L2_WRITE_LATENCY_NS};
+inline constexpr auto delay_constructor_policy = cub::LookbackDelayPolicy{
+  static_cast<cub::LookbackDelayAlgorithm>(TUNE_DELAY_CONSTRUCTOR_ID), TUNE_MAGIC_NS, TUNE_L2_WRITE_LATENCY_NS};
 
 #endif // !TUNE_BASE

--- a/thrust/testing/scan.cu
+++ b/thrust/testing/scan.cu
@@ -812,7 +812,7 @@ void TestInclusiveScanForInvalidValues()
   ASSERT_EQUAL(cub::detail::ptx_compute_cap(cc), cudaSuccess);
   using policy_selector_t = cub::detail::scan::
     policy_selector_from_types<const value_t*, value_t*, value_t, unsigned long long, checking_identity>;
-  if (policy_selector_t{}(cc).algorithm == cub::detail::scan::scan_algorithm::warpspeed)
+  if (policy_selector_t{}(cc).algorithm == cub::ScanAlgorithm::warpspeed)
 #endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
   {
     for (int n : {1, 100, 10'000})


### PR DESCRIPTION
This PR makes all tuning policies required for `cub::DeviceScan` public and adds tests+documentation.

- [x] #7671 is sufficiently approved to proceed with this PR. The remaining discussion can continue here.
- [x] Bikeshedding

`DispatchScan` and `AgentScanPolicy` will be deprecated in a follow-up PR: #9234

Fixes: #8578

### New public entities

| Entity | Enumerators / Data Members |
|--------|--------------|
| `cub::LookbackDelayAlgorithm` | `no_delay`, `fixed_delay`, `exponential_backoff`, `exponential_backoff_jitter`, `exponential_backoff_jitter_window`, `exponential_backon_jitter_window`, `exponential_backon_jitter`, `exponential_backon` |
| `cub::LookbackDelayPolicy` | `kind` (`LookbackDelayAlgorithm`), `delay`, `l2_write_latency` |
| `cub::ScanAlgorithm` | `lookback`, `warpspeed` |
| `cub::ScanLookbackPolicy` | `threads_per_block`, `items_per_thread`, `load_algorithm`, `load_modifier`, `store_algorithm`, `scan_algorithm`, `delay_constructor` (`LookbackDelayPolicy`) |
| `cub::ScanWarpspeedPolicy` | `reduce_and_scan_warps`, `items_per_thread`, `lookahead_items_per_thread`, `lookahead_stages`, `block_idx_stages` |
| `cub::ScanPolicy` | `algorithm` (`ScanAlgorithm`), `lookback` (`ScanLookbackPolicy`), `warpspeed` (`ScanWarpspeedPolicy`) |
