### PR TITLE
Fix sccache summary to count CUDA sub-tool cache hits/misses

### DIFF
--- a/.github/actions/workflow-results/prepare-execution-summary.py
+++ b/.github/actions/workflow-results/prepare-execution-summary.py
@@ -7,9 +7,10 @@ import json
 import os
 import re
 
-# sccache started reporting PTX/CUBIN hits.
-# We filter these out as they are not included in the `compile_requests` counter.
-sccache_languages = ["C/C++", "CUDA"]
+# rapidsai/sccache tracks CUDA sub-tool compilations (cudafe++, cicc, ptxas)
+# under separate language keys.  Count all of them so the reported rate matches
+# sccache's own "Cache hits rate".
+sccache_languages = {"C/C++", "CUDA", "CUDA (Device code)", "PTX", "CUBIN"}
 
 
 def job_succeeded(job):
@@ -88,15 +89,15 @@ def update_summary_entry(entry, job, job_times=None):
     sccache_stats = get_sccache_stats(job["id"])
     if sccache_stats:
         sccache_stats = sccache_stats["stats"]
-        requests = sccache_stats.get("compile_requests", 0)
-        hits = 0
-        if "cache_hits" in sccache_stats:
-            cache_hits = sccache_stats["cache_hits"]
-            if "counts" in cache_hits:
-                counts = cache_hits["counts"]
-                for lang, lang_hits in counts.items():
-                    if lang in sccache_languages:
-                        hits += lang_hits
+        hits = sum(
+            v for k, v in sccache_stats.get("cache_hits", {}).get("counts", {}).items()
+            if k in sccache_languages
+        )
+        misses = sum(
+            v for k, v in sccache_stats.get("cache_misses", {}).get("counts", {}).items()
+            if k in sccache_languages
+        )
+        requests = hits + misses
         if "sccache" not in entry:
             entry["sccache"] = {"requests": requests, "hits": hits}
         else:

--- a/.github/actions/workflow-results/prepare-execution-summary.py
+++ b/.github/actions/workflow-results/prepare-execution-summary.py
@@ -90,11 +90,13 @@ def update_summary_entry(entry, job, job_times=None):
     if sccache_stats:
         sccache_stats = sccache_stats["stats"]
         hits = sum(
-            v for k, v in sccache_stats.get("cache_hits", {}).get("counts", {}).items()
+            v
+            for k, v in sccache_stats.get("cache_hits", {}).get("counts", {}).items()
             if k in sccache_languages
         )
         misses = sum(
-            v for k, v in sccache_stats.get("cache_misses", {}).get("counts", {}).items()
+            v
+            for k, v in sccache_stats.get("cache_misses", {}).get("counts", {}).items()
             if k in sccache_languages
         )
         requests = hits + misses


### PR DESCRIPTION
## Summary

The sccache execution summary inflates the reported cache hit rate because CUDA sub-tool compilations are invisible to the metric.

The rapidsai/sccache fork tracks CUDA compilation sub-phases under separate language keys in its JSON stats:
- `"CUDA"` — nvcc driver pass
- `"CUDA (Device code)"` — cudafe++ pass
- `"PTX"` — cicc pass
- `"CUBIN"` — ptxas pass

The summary script only counted hits from `{"C/C++", "CUDA"}` and used `compile_requests` as the denominator. Since `compile_requests` only counts top-level nvcc invocations, sub-tool cache misses were invisible to both numerator and denominator — inflating the reported rate.

**Concrete example** from [run 25468002551](https://github.com/NVIDIA/cccl/actions/runs/25468002551), job CY (`cudax nvcc GCC / [CTK13.2 GCC15 C++20] Build`):

|  | Before (bug) | After (fix) |
|--|--|--|
| Hits | 707 | 707 |
| Denominator | 711 (`compile_requests`) | 763 (`hits + misses`) |
| Hidden misses | 56 (CUBIN=24, PTX=24, CUDA Device code=4, CUDA=4) | 0 |
| Reported rate | **99%** | **92%** |

This PR:
- Adds `"CUDA (Device code)"`, `"PTX"`, and `"CUBIN"` to the language filter
- Switches the denominator from `compile_requests` to `hits + misses` (matching sccache's own "Cache hits rate" calculation)

Related: NVIDIA/numba-cuda#878 (same fix for numba-cuda's sccache summary action)

## Test plan

- Reproduced locally with mock JSON matching the real CI run data — old logic gives 99%, new logic gives 92%
- The fix will be validated on the next CI run that produces sccache stats