### PR TITLE
[cub] Simplify arch dispatch

### DIFF
--- a/cub/cub/detail/arch_dispatch.cuh
+++ b/cub/cub/detail/arch_dispatch.cuh
@@ -45,32 +45,18 @@ struct device_policy_getter : PolicySelector
 
 #if !defined(CUB_DEFINE_RUNTIME_POLICIES) && !_CCCL_COMPILER(NVRTC)
 #  if _CCCL_STD_VER < 2020
-template <typename PolicySelector, size_t N>
-_CCCL_API constexpr auto find_lowest_cc_with_same_policy(
-  PolicySelector policy_selector, size_t i, const ::cuda::std::array<::cuda::compute_capability, N>& all_ccs)
-  -> ::cuda::compute_capability
-{
-  const auto policy = policy_selector(all_ccs[i]);
-  while (i > 0 && policy_selector(all_ccs[i - 1]) == policy)
-  {
-    --i;
-  }
-  return all_ccs[i];
-}
-
-template <int CcMult, typename CudaArchSeq, typename PolicySelector, size_t... Is>
+template <typename CudaArchSeq, typename PolicySelector, size_t... Is>
 struct lowest_cc_resolver;
 
 // we keep the compile-time build up of the mapping table outside a template parameterized by a user-provided callable
-template <int CcMult, int... CudaCcs, typename PolicySelector, size_t... Is>
-struct lowest_cc_resolver<CcMult, ::cuda::std::integer_sequence<int, CudaCcs...>, PolicySelector, Is...>
+template <int... CudaCcs, typename PolicySelector, size_t... Is>
+struct lowest_cc_resolver<::cuda::std::integer_sequence<int, CudaCcs...>, PolicySelector, Is...>
 {
   static_assert(sizeof...(CudaCcs) == sizeof...(Is));
 
   using policy_t = decltype(PolicySelector{}(::cuda::compute_capability{}));
 
-  static constexpr ::cuda::compute_capability all_ccs[sizeof...(Is)]{
-    ::cuda::compute_capability{(CudaCcs * CcMult) / 10}...};
+  static constexpr ::cuda::compute_capability all_ccs[sizeof...(Is)]{::cuda::compute_capability{CudaCcs}...};
 
   // GCC 7 has issues reusing the constexpr array of tuning policies in find_lowest below (it loses the constexpr-ness)
 #    if _CCCL_COMPILER(GCC, >=, 8)
@@ -96,11 +82,13 @@ struct lowest_cc_resolver<CcMult, ::cuda::std::integer_sequence<int, CudaCcs...>
 };
 #  endif // if _CCCL_STD_VER < 2020
 
-template <int CcMult, int... CudaCcs, typename PolicySelector, typename FunctorT, size_t... Is>
+template <typename PolicySelector, typename FunctorT, size_t... Is>
 CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_to_cc_list(
   PolicySelector policy_selector, ::cuda::compute_capability device_cc, FunctorT&& f, ::cuda::std::index_sequence<Is...>)
 {
-  _CCCL_ASSERT(((device_cc == ::cuda::compute_capability{(CudaCcs * CcMult) / 10}) || ...),
+  constexpr auto all_ccs = ::cuda::__target_compute_capabilities();
+
+  _CCCL_ASSERT(((device_cc == all_ccs[Is]) || ...),
                "device_cc must appear in the list of compute capabilities compiled for");
 
   cudaError_t e = cudaErrorInvalidDeviceFunction;
@@ -110,32 +98,20 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_to_cc_list(
   // in the same integral_constant type passed to f
   using policy_t = decltype(policy_selector(::cuda::compute_capability{}));
   (...,
-   (device_cc == ::cuda::compute_capability{(CudaCcs * CcMult) / 10}
-      ? (e = f(::cuda::std::integral_constant<policy_t,
-                                              policy_selector(::cuda::compute_capability{(CudaCcs * CcMult) / 10})>{}))
-      : cudaSuccess));
+   (device_cc == all_ccs[Is] ? (e = f(::cuda::std::integral_constant<policy_t, policy_selector(all_ccs[Is])>{}))
+                             : cudaSuccess));
 #  else // if _CCCL_STD_VER >= 2020
   // In C++17, we have to collapse architectures with the same policies ourselves, so we instantiate call_for_arch once
   // per policy on the lowest ArchId which produces the same policy
-  using resolver_t = lowest_cc_resolver<CcMult, ::cuda::std::integer_sequence<int, CudaCcs...>, PolicySelector, Is...>;
+  using resolver_t =
+    lowest_cc_resolver<::cuda::std::integer_sequence<int, all_ccs[Is].get()...>, PolicySelector, Is...>;
   (...,
-   (device_cc == ::cuda::compute_capability{(CudaCcs * CcMult) / 10}
+   (device_cc == all_ccs[Is]
       ? (e = f(policy_getter<PolicySelector, resolver_t::lowest_cc_with_same_policy[Is].get()>{policy_selector}))
       : cudaSuccess));
 
 #  endif // if _CCCL_STD_VER >= 2020
   return e;
-}
-
-template <typename PolicySelector, typename FunctorT, size_t... Is>
-CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_all_ccs_helper(
-  PolicySelector policy_selector,
-  ::cuda::compute_capability device_cc,
-  FunctorT&& f,
-  ::cuda::std::index_sequence<Is...> seq)
-{
-  static constexpr auto all_ccs = ::cuda::__all_compute_capabilities();
-  return dispatch_to_cc_list<10, static_cast<int>(all_ccs[Is])...>(policy_selector, device_cc, f, seq);
 }
 
 //! Takes a policy hub and instantiates f with the minimum possible number of nullary functor types that return a policy
@@ -148,24 +124,11 @@ dispatch_compute_cap(PolicySelector policy_selector, ::cuda::compute_capability 
 {
   // when not using CCCL.C, policy_selector is empty since all information is contained in its type
   static_assert(::cuda::std::is_empty_v<PolicySelector>);
-
-  // if we have __CUDA_ARCH_LIST__ or NV_TARGET_SM_INTEGER_LIST, we only poll the policy hub for those arches.
-#  ifdef __CUDA_ARCH_LIST__
-  [[maybe_unused]] static constexpr auto cc_seq = ::cuda::std::integer_sequence<int, __CUDA_ARCH_LIST__>{};
-  return dispatch_to_cc_list<1, __CUDA_ARCH_LIST__>(
-    policy_selector, device_cc, ::cuda::std::forward<F>(f), ::cuda::std::make_index_sequence<cc_seq.size()>{});
-#  elif defined(NV_TARGET_SM_INTEGER_LIST)
-  [[maybe_unused]] static constexpr auto cc_seq = ::cuda::std::integer_sequence<int, NV_TARGET_SM_INTEGER_LIST>{};
-  return dispatch_to_cc_list<10, NV_TARGET_SM_INTEGER_LIST>(
-    policy_selector, device_cc, ::cuda::std::forward<F>(f), ::cuda::std::make_index_sequence<cc_seq.size()>{});
-#  else
-  // some compilers don't tell us what arches we are compiling for, so we test all of them
-  return dispatch_all_ccs_helper(
+  return dispatch_to_cc_list(
     policy_selector,
     device_cc,
     ::cuda::std::forward<F>(f),
-    ::cuda::std::make_index_sequence<::cuda::__all_compute_capabilities().size()>{});
-#  endif
+    ::cuda::std::make_index_sequence<::cuda::__target_compute_capabilities().size()>{});
 }
 
 #else // !defined(CUB_DEFINE_RUNTIME_POLICIES) && !_CCCL_COMPILER(NVRTC)

--- a/cub/test/catch2_test_arch_dispatch.cu
+++ b/cub/test/catch2_test_arch_dispatch.cu
@@ -7,14 +7,6 @@
 
 #include <c2h/catch2_test_helper.h>
 
-#ifdef __CUDA_ARCH_LIST__
-#  define CUDA_SM_LIST       __CUDA_ARCH_LIST__
-#  define CUDA_SM_LIST_SCALE 1
-#elif defined(NV_TARGET_SM_INTEGER_LIST)
-#  define CUDA_SM_LIST       NV_TARGET_SM_INTEGER_LIST
-#  define CUDA_SM_LIST_SCALE 10
-#endif
-
 using cuda::compute_capability;
 
 struct a_policy
@@ -40,14 +32,18 @@ struct policy_selector_all
   }
 };
 
-#ifdef CUDA_SM_LIST
-template <int SelectedPolicyCC, int... ArchList>
-void check_arch_is_in_list()
+template <int SelectedPolicyCC, cuda::std::size_t N>
+void check_arch_is_in_list(cuda::std::array<compute_capability, N> cc_list)
 {
-  static_assert(
-    ((compute_capability{SelectedPolicyCC} == compute_capability{ArchList * CUDA_SM_LIST_SCALE / 10}) || ...));
+  for (const auto cc : cc_list)
+  {
+    if (compute_capability{SelectedPolicyCC} == cc)
+    {
+      return;
+    }
+  }
+  FAIL("SelectedPolicyCC is not present in cc_list");
 }
-#endif // CUDA_SM_LIST
 
 struct closure_all
 {
@@ -56,9 +52,7 @@ struct closure_all
   template <typename PolicyGetter>
   CUB_RUNTIME_FUNCTION auto operator()(PolicyGetter policy_getter) const -> cudaError_t
   {
-#ifdef CUDA_SM_LIST
-    check_arch_is_in_list<PolicyGetter{}().value, CUDA_SM_LIST>();
-#endif // CUDA_SM_LIST
+    check_arch_is_in_list<PolicyGetter{}().value>(cuda::__target_compute_capabilities());
     constexpr a_policy active_policy = policy_getter();
     // since an individual policy is generated per architecture, we can do an exact comparison here
     REQUIRE(active_policy.value == cc);
@@ -68,14 +62,8 @@ struct closure_all
 
 C2H_TEST("dispatch_compute_cap prunes based on __CUDA_ARCH_LIST__/NV_TARGET_SM_INTEGER_LIST", "[util][dispatch]")
 {
-#ifdef CUDA_SM_LIST
-  for (const int sm_val : {CUDA_SM_LIST})
+  for (const auto cc : cuda::__target_compute_capabilities())
   {
-    const compute_capability cc{sm_val * CUDA_SM_LIST_SCALE / 10};
-#else
-  for (const compute_capability cc : cuda::__all_compute_capabilities())
-  {
-#endif
     CHECK(cub::detail::dispatch_compute_cap(policy_selector_all{}, cc, closure_all{cc.get()}) == cudaSuccess);
   }
 }
@@ -129,14 +117,8 @@ struct policy_selector_minimal
 
 C2H_TEST("dispatch_compute_cap invokes correct policy", "[util][dispatch]")
 {
-#ifdef CUDA_SM_LIST
-  for (const int sm_val : {CUDA_SM_LIST})
+  for (const auto cc : cuda::__target_compute_capabilities())
   {
-    const compute_capability cc{sm_val * CUDA_SM_LIST_SCALE / 10};
-#else
-  for (const compute_capability cc : cuda::__all_compute_capabilities())
-  {
-#endif
     const auto closure_some = check_policy_closure<3>{cc.get(), cuda::std::array{60, 80, 100}};
     CHECK(cub::detail::dispatch_compute_cap(policy_selector_some{}, cc, closure_some) == cudaSuccess);
 

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/target_compute_capabilities.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/target_compute_capabilities.pass.cpp
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/devices>
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/cstddef>
+
+#include "test_macros.h"
+
+template <cuda::std::size_t N>
+TEST_FUNC constexpr auto make_all_ccs_ref(cuda::std::array<int, N> vs, int scale)
+{
+  cuda::std::array<cuda::compute_capability, N> ret;
+  for (cuda::std::size_t i = 0; i < N; ++i)
+  {
+    ret[i] = cuda::compute_capability{vs[i] / scale};
+  }
+  return ret;
+}
+
+TEST_FUNC constexpr bool test()
+{
+  // 1. Test signature.
+  static_assert(cuda::std::__is_cuda_std_array_v<decltype(cuda::__target_compute_capabilities())>);
+  static_assert(noexcept(cuda::__target_compute_capabilities()));
+
+  // 2. Test that all values are present.
+  const auto all_ccs = cuda::__target_compute_capabilities();
+
+#if defined(__CUDA_ARCH_LIST__)
+  const auto all_ccs_ref = make_all_ccs_ref(cuda::std::array{__CUDA_ARCH_LIST__}, 10);
+#elif defined(NV_TARGET_SM_INTEGER_LIST)
+  const auto all_ccs_ref = make_all_ccs_ref(cuda::std::array{NV_TARGET_SM_INTEGER_LIST}, 1);
+#else
+  const auto all_ccs_ref = ::cuda::__all_compute_capabilities();
+#endif
+
+  assert(all_ccs.size() == all_ccs_ref.size());
+  for (cuda::std::size_t i = 0; i < all_ccs.size(); ++i)
+  {
+    assert(all_ccs[i] == all_ccs_ref[i]);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}


### PR DESCRIPTION
This PR uses `cuda::__target_compute_capabilities` function to simplify cub's arch dispatch. I've also added a test for `cuda::__target_compute_capabilities`, so we are sure it does what we think it should do.