### PR TITLE
[cub] Add future arch test

### DIFF
--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -230,16 +230,17 @@ function(
     if (
       "${test_src}" MATCHES "test_future_arch\\.cu$"
       AND "${CMAKE_CUDA_COMPILER_ID}" STREQUAL "NVIDIA"
+      AND "${CMAKE_CUDA_COMPILER_VERSION}" VERSION_GREATER_EQUAL "13.0.0"
     )
       # In future arch test, we replace __CUDA_ARCH__ and __CUDA_ARCH_LIST__ with our own values. However, nvcc
       # preincludes <cuda_runtime.h> header, already working with __CUDA_ARCH__. So, we define the <cuda_runtime.h>'s
       # include guard macro so we can modify the values before including the header inside the source file.
       target_compile_definitions(${test_target} PRIVATE __CUDA_RUNTIME_H__)
 
-      # Force only 1 architecture to be compiled. The test doesn't actually run any code, so it doesn't matter.
+      # Force only 1 architecture to be compiled. It must be the newest supported architecture.
       set_target_properties(
         ${test_target}
-        PROPERTIES CUDA_ARCHITECTURES "75-virtual"
+        PROPERTIES CUDA_ARCHITECTURES "121-virtual"
       )
     endif()
 

--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -227,6 +227,22 @@ function(
       target_link_libraries(${test_target} PRIVATE nvtx3-cpp)
     endif()
 
+    if (
+      "${test_src}" MATCHES "test_future_arch\\.cu$"
+      AND "${CMAKE_CUDA_COMPILER_ID}" STREQUAL "NVIDIA"
+    )
+      # In future arch test, we replace __CUDA_ARCH__ and __CUDA_ARCH_LIST__ with our own values. However, nvcc
+      # preincludes <cuda_runtime.h> header, already working with __CUDA_ARCH__. So, we define the <cuda_runtime.h>'s
+      # include guard macro so we can modify the values before including the header inside the source file.
+      target_compile_definitions(${test_target} PRIVATE __CUDA_RUNTIME_H__)
+
+      # Force only 1 architecture to be compiled. The test doesn't actually run any code, so it doesn't matter.
+      set_target_properties(
+        ${test_target}
+        PROPERTIES CUDA_ARCHITECTURES "75-virtual"
+      )
+    endif()
+
     if (is_fail_test)
       cccl_add_xfail_compile_target_test(
         ${test_target}

--- a/cub/test/test_future_arch.cu
+++ b/cub/test/test_future_arch.cu
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// This is a compile-only test that checks whether cub can handle a future (unknown) architecture. Currently, works only
+// with nvcc.
+
+#if defined(__NVCC__)
+#  define TEST_CUDA_ARCH 1000000
+
+// Replace __CUDA_ARCH__ only in device code.
+#  if defined(__CUDA_ARCH__)
+#    undef __CUDA_ARCH__
+#    define __CUDA_ARCH__ TEST_CUDA_ARCH
+#  endif // __CUDA_ARCH__
+
+// __CUDA_ARCH_LIST__ is defined in both host and device code.
+#  undef __CUDA_ARCH_LIST__
+#  define __CUDA_ARCH_LIST__ TEST_CUDA_ARCH
+
+// We need to undefine the include guard before including <cuda_runtime.h>. It was defined by us in CMake.
+#  undef __CUDA_RUNTIME_H__
+#  include <cuda_runtime.h>
+#endif // __NVCC__
+
+#include <cub/device/device_reduce.cuh>
+
+#include <cuda/std/cstddef>
+
+cudaError_t compile_only_fn(void* tmp_storage, cuda::std::size_t tmp_storage_size, int* in, int* out, int nitems)
+{
+  return cub::DeviceReduce::Sum(tmp_storage, tmp_storage_size, in, out, nitems);
+}
+
+int main() {}

--- a/cub/test/test_future_arch.cu
+++ b/cub/test/test_future_arch.cu
@@ -4,7 +4,7 @@
 // This is a compile-only test that checks whether cub can handle a future (unknown) architecture. Currently, works only
 // with nvcc.
 
-#if defined(__NVCC__)
+#if defined(__NVCC__) && __CUDACC_VER_MAJOR__ >= 13
 #  define TEST_CUDA_ARCH 1000000
 
 // Replace __CUDA_ARCH__ only in device code.
@@ -20,7 +20,7 @@
 // We need to undefine the include guard before including <cuda_runtime.h>. It was defined by us in CMake.
 #  undef __CUDA_RUNTIME_H__
 #  include <cuda_runtime.h>
-#endif // __NVCC__
+#endif // __NVCC__ && is at least 13.0
 
 #include <cub/device/device_reduce.cuh>
 

--- a/cub/test/test_future_arch.cu
+++ b/cub/test/test_future_arch.cu
@@ -5,7 +5,7 @@
 // with nvcc.
 
 #if defined(__NVCC__) && __CUDACC_VER_MAJOR__ >= 13
-#  define TEST_CUDA_ARCH 1000000
+#  define TEST_CUDA_ARCH 9900
 
 // Replace __CUDA_ARCH__ only in device code.
 #  if defined(__CUDA_ARCH__)


### PR DESCRIPTION
This PR adds a compile test that checks whether CUB can be used with a future (unknown) architecture. I had to do some awful hacks to make it work.