### PR TITLE
Allow public tuning of non-ByKey `cub::DeviceReduce`

### DIFF
--- a/cub/benchmarks/bench/reduce/arg_extrema.cu
+++ b/cub/benchmarks/bench/reduce/arg_extrema.cu
@@ -15,17 +15,14 @@
 #if !TUNE_BASE
 struct tuned_policy_selector
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::reduce::reduce_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::ReducePolicy
   {
-    cub::detail::reduce::agent_reduce_policy rp{
+    cub::ReducePassPolicy rp{
       TUNE_THREADS_PER_BLOCK,
       TUNE_ITEMS_PER_THREAD,
       1 << TUNE_ITEMS_PER_VEC_LOAD_POW2,
       cub::BLOCK_REDUCE_WARP_REDUCTIONS,
       cub::LOAD_DEFAULT};
-    auto rp_nondet            = rp;
-    rp_nondet.block_algorithm = cub::BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC;
     return {rp, rp};
   }
 };

--- a/cub/benchmarks/bench/reduce/base.cuh
+++ b/cub/benchmarks/bench/reduce/base.cuh
@@ -11,12 +11,11 @@
 template <typename AccumT>
 struct policy_selector
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::reduce::reduce_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::ReducePolicy
   {
     const auto [items, threads] =
       cub::detail::scale_mem_bound(TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, int{sizeof(AccumT)});
-    const auto policy = cub::detail::reduce::agent_reduce_policy{
+    const auto policy = cub::ReducePassPolicy{
       threads, items, 1 << TUNE_ITEMS_PER_VEC_LOAD_POW2, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_DEFAULT};
     return {policy, policy};
   }

--- a/cub/benchmarks/bench/reduce/deterministic.cu
+++ b/cub/benchmarks/bench/reduce/deterministic.cu
@@ -17,10 +17,9 @@
 #if !TUNE_BASE
 struct policy_selector_t
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::reduce::reduce_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::ReducePolicy
   {
-    const auto p = cub::detail::reduce::agent_reduce_policy{
+    const auto p = cub::ReducePassPolicy{
       TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, 1, cub::BLOCK_REDUCE_RAKING, cub::LOAD_DEFAULT};
     return {p, p};
   }

--- a/cub/benchmarks/bench/reduce/nondeterministic.cu
+++ b/cub/benchmarks/bench/reduce/nondeterministic.cu
@@ -19,12 +19,11 @@
 template <typename AccumT>
 struct policy_selector
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::reduce::reduce_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::ReducePolicy
   {
     const auto [items, threads] =
       cub::detail::scale_mem_bound(TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, int{sizeof(AccumT)});
-    const auto policy = cub::detail::reduce::agent_reduce_policy{
+    const auto policy = cub::ReducePassPolicy{
       threads,
       items,
       1 << TUNE_ITEMS_PER_VEC_LOAD_POW2,

--- a/cub/benchmarks/bench/segmented_reduce/base.cuh
+++ b/cub/benchmarks/bench/segmented_reduce/base.cuh
@@ -29,7 +29,7 @@ struct policy_selector
       cub::detail::scale_mem_bound(TUNE_L_NOMINAL_4B_THREADS_PER_BLOCK, TUNE_M_NOMINAL_4B_ITEMS_PER_THREAD, accum_size)
         .items_per_thread;
 
-    const auto rp = cub::agent_reduce_policy{
+    const auto rp = cub::ReducePassPolicy{
       l_threads, l_items, TUNE_ITEMS_PER_VEC_LOAD, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_LDG};
     return {
       rp,

--- a/cub/benchmarks/bench/transform_reduce/sum.cu
+++ b/cub/benchmarks/bench/transform_reduce/sum.cu
@@ -13,12 +13,11 @@
 template <typename AccumT>
 struct policy_selector
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::reduce::reduce_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::ReducePolicy
   {
     const auto [items, threads] =
       cub::detail::scale_mem_bound(TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, int{sizeof(AccumT)});
-    const auto policy = cub::detail::reduce::agent_reduce_policy{
+    const auto policy = cub::ReducePassPolicy{
       threads, items, 1 << TUNE_ITEMS_PER_VEC_LOAD_POW2, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_DEFAULT};
     return {policy, policy};
   }

--- a/cub/cub/agent/agent_reduce.cuh
+++ b/cub/cub/agent/agent_reduce.cuh
@@ -42,7 +42,8 @@ CUB_NAMESPACE_BEGIN
  * Tuning policy types
  ******************************************************************************/
 
-// TODO(bgruber): deprecate once we publish the tuning API
+namespace detail
+{
 /**
  * Parameterizable tuning policy type for AgentReduce
  * @tparam NominalThreadsPerBlock4B Threads per thread block
@@ -58,8 +59,8 @@ template <int NominalThreadsPerBlock4B,
           int VectorLoadLength,
           BlockReduceAlgorithm BlockAlgorithm,
           CacheLoadModifier LoadModifier,
-          typename ScalingType = detail::MemBoundScaling<NominalThreadsPerBlock4B, NominalItemsPerThread4B, ComputeT>>
-struct AgentReducePolicy : ScalingType
+          typename ScalingType = MemBoundScaling<NominalThreadsPerBlock4B, NominalItemsPerThread4B, ComputeT>>
+struct agent_reduce_policy : ScalingType
 {
   /// Number of items per vectorized load
   static constexpr int VECTOR_LOAD_LENGTH = VectorLoadLength;
@@ -70,6 +71,23 @@ struct AgentReducePolicy : ScalingType
   /// Cache load modifier for reading input elements
   static constexpr CacheLoadModifier LOAD_MODIFIER = LoadModifier;
 };
+} // namespace detail
+
+template <int NominalThreadsPerBlock4B,
+          int NominalItemsPerThread4B,
+          typename ComputeT,
+          int VectorLoadLength,
+          BlockReduceAlgorithm BlockAlgorithm,
+          CacheLoadModifier LoadModifier,
+          typename ScalingType = detail::MemBoundScaling<NominalThreadsPerBlock4B, NominalItemsPerThread4B, ComputeT>>
+using AgentReducePolicy CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceReduce") = detail::agent_reduce_policy<
+  NominalThreadsPerBlock4B,
+  NominalItemsPerThread4B,
+  ComputeT,
+  VectorLoadLength,
+  BlockAlgorithm,
+  LoadModifier,
+  ScalingType>;
 
 /**
  * Parameterizable tuning policy type for AgentWarpReduce

--- a/cub/cub/agent/agent_reduce.cuh
+++ b/cub/cub/agent/agent_reduce.cuh
@@ -44,6 +44,7 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail
 {
+// TODO(bgruber): drop in CCCL 4.0
 /**
  * Parameterizable tuning policy type for AgentReduce
  * @tparam NominalThreadsPerBlock4B Threads per thread block
@@ -73,6 +74,7 @@ struct agent_reduce_policy : ScalingType
 };
 } // namespace detail
 
+//! Deprecated [Since 3.5]
 template <int NominalThreadsPerBlock4B,
           int NominalItemsPerThread4B,
           typename ComputeT,

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -89,6 +89,22 @@ inline constexpr bool is_non_deterministic_v =
 //! Tuning
 //! +++++++++++++++++++++++++++++++++++++++++++++
 //!
+//! All algorithms in DeviceReduce that accept an environment (except ``ReduceByKey``) can be tuned by passing a custom
+//! :ref:`policy selector <cub-policy-selectors>` that returns a @ref ReducePolicy, as shown in the
+//! example below:
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_reduce_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin reduce-policy-selector
+//!      :end-before: example-end reduce-policy-selector
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_reduce_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin reduce-tuning
+//!      :end-before: example-end reduce-tuning
+//!
 //! ``DeviceReduce::ReduceByKey`` can be tuned by passing a custom
 //! :ref:`policy selector <cub-policy-selectors>` that returns a @ref ReduceByKeyPolicy, as shown in the
 //! example below:

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -138,6 +138,7 @@ struct policy_selector_from_hub
  * Single-problem dispatch
  *****************************************************************************/
 
+// TODO(bgruber): drop in CCCL 4.0
 /**
  * @brief Utility class for dispatching the appropriately-tuned kernels for
  *        device-wide reduction

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -576,7 +576,7 @@ template <
     AccumT,
     TransformOpT>,
   typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
-using DispatchTransformReduce CCCL_DEPRECATED_BECAUSE("Please use DeviceReduce") =
+_CCCL_SUPPRESS_DEPRECATED_PUSH using DispatchTransformReduce CCCL_DEPRECATED_BECAUSE("Please use DeviceReduce") =
   DispatchReduce<InputIteratorT,
                  OutputIteratorT,
                  OffsetT,
@@ -587,6 +587,7 @@ using DispatchTransformReduce CCCL_DEPRECATED_BECAUSE("Please use DeviceReduce")
                  PolicyHub,
                  KernelSource,
                  KernelLauncherFactory>;
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 namespace detail::reduce
 {

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -856,11 +856,11 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
                   && (!::cuda::std::is_integral_v<AccumT> || !is_cuda_binary_operator<ReductionOpT>) )
     {
       CUB_DETAIL_STATIC_ISH_ASSERT(
-        active_policy.multi_tile.block_algorithm != BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
-        "A run-to-run deterministic reduction must not use a non-deterministic block_algorithm");
+        active_policy.multi_tile.reduce_algorithm != BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
+        "A run-to-run deterministic reduction must not use a non-deterministic reduce_algorithm");
       CUB_DETAIL_STATIC_ISH_ASSERT(
-        active_policy.single_tile.block_algorithm != BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
-        "A run-to-run deterministic reduction must not use a non-deterministic block_algorithm");
+        active_policy.single_tile.reduce_algorithm != BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
+        "A run-to-run deterministic reduction must not use a non-deterministic reduce_algorithm");
     }
 
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -554,6 +554,7 @@ struct CCCL_DEPRECATED_BECAUSE("Please use DeviceReduce") DispatchReduce
  * @tparam InitValueT
  *   Initial value type
  */
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <
   typename InputIteratorT,
   typename OutputIteratorT,
@@ -576,7 +577,7 @@ template <
     AccumT,
     TransformOpT>,
   typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
-_CCCL_SUPPRESS_DEPRECATED_PUSH using DispatchTransformReduce CCCL_DEPRECATED_BECAUSE("Please use DeviceReduce") =
+using DispatchTransformReduce CCCL_DEPRECATED_BECAUSE("Please use DeviceReduce") =
   DispatchReduce<InputIteratorT,
                  OutputIteratorT,
                  OffsetT,

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -110,20 +110,20 @@ template <typename PolicyHub>
 struct policy_selector_from_hub
 {
   // this is only called in device code, so we can ignore the arch parameter
-  _CCCL_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const -> reduce_policy
+  _CCCL_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const -> ReducePolicy
   {
     using ap             = typename PolicyHub::MaxPolicy::ActivePolicy;
     using ap_reduce      = typename ap::ReducePolicy;
     using ap_single_tile = typename ap::SingleTilePolicy;
-    return reduce_policy{
-      agent_reduce_policy{
+    return ReducePolicy{
+      ReducePassPolicy{
         ap_reduce::BLOCK_THREADS,
         ap_reduce::ITEMS_PER_THREAD,
         ap_reduce::VECTOR_LOAD_LENGTH,
         ap_reduce::BLOCK_ALGORITHM,
         ap_reduce::LOAD_MODIFIER,
       },
-      agent_reduce_policy{
+      ReducePassPolicy{
         ap_single_tile::BLOCK_THREADS,
         ap_single_tile::ITEMS_PER_THREAD,
         ap_single_tile::VECTOR_LOAD_LENGTH,
@@ -138,7 +138,6 @@ struct policy_selector_from_hub
  * Single-problem dispatch
  *****************************************************************************/
 
-// TODO(bgruber): deprecate once we publish the tuning API
 /**
  * @brief Utility class for dispatching the appropriately-tuned kernels for
  *        device-wide reduction
@@ -178,7 +177,7 @@ template <
     AccumT,
     TransformOpT>,
   typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
-struct DispatchReduce
+struct CCCL_DEPRECATED_BECAUSE("Please use DeviceReduce") DispatchReduce
 {
   //---------------------------------------------------------------------------
   // Problem state
@@ -530,7 +529,6 @@ struct DispatchReduce
   }
 };
 
-// TODO(bgruber): deprecate once we publish the tuning API and drop in CCCL 4.0
 /**
  * @brief Utility class for dispatching the appropriately-tuned kernels for
  *        device-wide transform reduce
@@ -577,7 +575,7 @@ template <
     AccumT,
     TransformOpT>,
   typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
-using DispatchTransformReduce =
+using DispatchTransformReduce CCCL_DEPRECATED_BECAUSE("Please use DeviceReduce") =
   DispatchReduce<InputIteratorT,
                  OutputIteratorT,
                  OffsetT,
@@ -621,7 +619,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_regular_size_reduce(
   InitValueT init,
   cudaStream_t stream,
   TransformOpT transform_op,
-  reduce_policy active_policy,
+  ReducePolicy active_policy,
   KernelSource kernel_source,
   KernelLauncherFactory launcher_factory)
 {
@@ -633,10 +631,10 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_regular_size_reduce(
   }
 
   // Init regular kernel configuration
-  const auto tile_size = active_policy.reduce.threads_per_block * active_policy.reduce.items_per_thread;
+  const auto tile_size = active_policy.multi_tile.threads_per_block * active_policy.multi_tile.items_per_thread;
   int sm_occupancy     = 0;
   if (const auto error = CubDebug(launcher_factory.MaxSmOccupancy(
-        sm_occupancy, kernel_source.ReductionKernel(), active_policy.reduce.threads_per_block)))
+        sm_occupancy, kernel_source.ReductionKernel(), active_policy.multi_tile.threads_per_block)))
   {
     return error;
   }
@@ -696,9 +694,9 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_regular_size_reduce(
   _CubLog("Invoking DeviceReduceKernel<<<%lu, %d, 0, %lld>>>(), %d items "
           "per thread, %d SM occupancy\n",
           (unsigned long) reduce_grid_size,
-          active_policy.reduce.threads_per_block,
+          active_policy.multi_tile.threads_per_block,
           (long long) stream,
-          active_policy.reduce.items_per_thread,
+          active_policy.multi_tile.items_per_thread,
           sm_occupancy);
 #endif // CUB_DEBUG_LOG
 
@@ -714,7 +712,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_regular_size_reduce(
     }
   }();
   if (const auto error = CubDebug(
-        launcher_factory(reduce_grid_size, active_policy.reduce.threads_per_block, 0, stream)
+        launcher_factory(reduce_grid_size, active_policy.multi_tile.threads_per_block, 0, stream)
           .doit(kernel_source.ReductionKernel(),
                 d_in,
                 reduce_kernel_output,
@@ -851,14 +849,14 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   }
 
   return dispatch_compute_cap(policy_selector, cc, [&](auto policy_getter) {
-    CUB_DETAIL_CONSTEXPR_ISH const reduce_policy active_policy = policy_getter();
+    CUB_DETAIL_CONSTEXPR_ISH const ReducePolicy active_policy = policy_getter();
 
     // known operators for integers are stable, even when using a non-deterministic reduction order
     if constexpr (StableReductionOrder
                   && (!::cuda::std::is_integral_v<AccumT> || !is_cuda_binary_operator<ReductionOpT>) )
     {
       CUB_DETAIL_STATIC_ISH_ASSERT(
-        active_policy.reduce.block_algorithm != BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
+        active_policy.multi_tile.block_algorithm != BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
         "A run-to-run deterministic reduction must not use a non-deterministic block_algorithm");
       CUB_DETAIL_STATIC_ISH_ASSERT(
         active_policy.single_tile.block_algorithm != BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,

--- a/cub/cub/device/dispatch/dispatch_reduce_deterministic.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_deterministic.cuh
@@ -44,7 +44,6 @@ namespace detail::rfa
 {
 using cuda::execution::determinism::__determinism_t;
 using reduce::policy_selector_from_types;
-using reduce::reduce_policy;
 
 template <typename Invocable, typename InputT>
 using transformed_input_t = ::cuda::std::decay_t<::cuda::std::invoke_result_t<Invocable, InputT>>;
@@ -101,7 +100,7 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t invok
   InitValueT init,
   cudaStream_t stream,
   TransformOpT transform_op,
-  reduce_policy active_policy,
+  ReducePolicy active_policy,
   KernelLauncherFactory launcher_factory)
 {
   // Return if the caller is simply requesting the size of the storage allocation
@@ -170,7 +169,7 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t invok
   InitValueT init,
   cudaStream_t stream,
   TransformOpT transform_op,
-  reduce_policy active_policy,
+  ReducePolicy active_policy,
   KernelLauncherFactory launcher_factory)
 {
   int sm_count;
@@ -183,7 +182,7 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t invok
   if (const auto error = CubDebug(reduce_config.__init(
         detail::reduce::
           DeterministicDeviceReduceKernel<PolicySelector, InputIteratorT, ReductionOpT, DeterministicAccumT, TransformOpT>,
-        active_policy.reduce)))
+        active_policy.multi_tile)))
   {
     return error;
   }
@@ -242,14 +241,14 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t invok
     _CubLog("Invoking DeterministicDeviceReduceKernel<<<%d, %d, 0, %lld>>>(), %d items "
             "per thread, %d SM occupancy\n",
             current_grid_size,
-            active_policy.reduce.threads_per_block,
+            active_policy.multi_tile.threads_per_block,
             (long long) stream,
-            active_policy.reduce.items_per_thread,
+            active_policy.multi_tile.items_per_thread,
             reduce_config.sm_occupancy);
 #endif // CUB_DEBUG_LOG
 
     if (const auto error = CubDebug(
-          launcher_factory(current_grid_size, active_policy.reduce.threads_per_block, 0, stream)
+          launcher_factory(current_grid_size, active_policy.multi_tile.threads_per_block, 0, stream)
             .doit(detail::reduce::DeterministicDeviceReduceKernel<PolicySelector,
                                                                   InputIteratorT,
                                                                   ReductionOpT,
@@ -351,7 +350,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
     return error;
   }
 
-  const reduce_policy active_policy = policy_selector(cc);
+  const ReducePolicy active_policy = policy_selector(cc);
 
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(NV_IS_HOST, ({

--- a/cub/cub/device/dispatch/kernels/kernel_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_reduce.cuh
@@ -184,7 +184,7 @@ __launch_bounds__(int(current_policy<PolicySelector>().multi_tile.threads_per_bl
     0,
     AccumT,
     policy.vec_size,
-    policy.block_algorithm,
+    policy.reduce_algorithm,
     policy.load_modifier,
     NoScaling<policy.threads_per_block, policy.items_per_thread, AccumT>>;
 
@@ -292,7 +292,7 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(
     0,
     AccumT,
     policy.vec_size,
-    policy.block_algorithm,
+    policy.reduce_algorithm,
     policy.load_modifier,
     NoScaling<policy.threads_per_block, policy.items_per_thread, AccumT>>;
 

--- a/cub/cub/device/dispatch/kernels/kernel_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_reduce.cuh
@@ -151,7 +151,7 @@ template <typename PolicySelector,
   requires reduce_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
 _CCCL_KERNEL_ATTRIBUTES
-__launch_bounds__(int(current_policy<PolicySelector>().reduce.threads_per_block)) void DeviceReduceKernel(
+__launch_bounds__(int(current_policy<PolicySelector>().multi_tile.threads_per_block)) void DeviceReduceKernel(
   _CCCL_GRID_CONSTANT const InputIteratorT d_in,
   _CCCL_GRID_CONSTANT const OutputIteratorT d_out,
   _CCCL_GRID_CONSTANT const OffsetT num_items,
@@ -160,7 +160,7 @@ __launch_bounds__(int(current_policy<PolicySelector>().reduce.threads_per_block)
   [[maybe_unused]] _CCCL_GRID_CONSTANT const InitValueT init,
   TransformOpT transform_op)
 {
-  static constexpr agent_reduce_policy policy = current_policy<PolicySelector>().reduce;
+  static constexpr ReducePassPolicy policy = current_policy<PolicySelector>().multi_tile;
   if constexpr (!StableReductionOrder)
   {
     static_assert(detail::is_cuda_std_plus_v<ReductionOpT>,
@@ -179,14 +179,14 @@ __launch_bounds__(int(current_policy<PolicySelector>().reduce.threads_per_block)
   }
 
   // TODO(bgruber): pass policy directly as template argument to AgentReduce in C++20
-  using agent_policy_t =
-    AgentReducePolicy<0,
-                      0,
-                      AccumT,
-                      policy.vec_size,
-                      policy.block_algorithm,
-                      policy.load_modifier,
-                      NoScaling<policy.threads_per_block, policy.items_per_thread, AccumT>>;
+  using agent_policy_t = detail::agent_reduce_policy<
+    0,
+    0,
+    AccumT,
+    policy.vec_size,
+    policy.block_algorithm,
+    policy.load_modifier,
+    NoScaling<policy.threads_per_block, policy.items_per_thread, AccumT>>;
 
   // Thread block type for reducing input tiles
   using AgentReduceT = AgentReduce<agent_policy_t, InputIteratorT, OffsetT, ReductionOpT, AccumT, TransformOpT>;
@@ -285,16 +285,16 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(
                                        _CCCL_GRID_CONSTANT const InitValueT init,
                                        TransformOpT transform_op)
 {
-  static constexpr agent_reduce_policy policy = current_policy<PolicySelector>().single_tile;
+  static constexpr ReducePassPolicy policy = current_policy<PolicySelector>().single_tile;
   // TODO(bgruber): pass policy directly as template argument to AgentReduce in C++20
-  using agent_policy_t =
-    AgentReducePolicy<0,
-                      0,
-                      AccumT,
-                      policy.vec_size,
-                      policy.block_algorithm,
-                      policy.load_modifier,
-                      NoScaling<policy.threads_per_block, policy.items_per_thread, AccumT>>;
+  using agent_policy_t = detail::agent_reduce_policy<
+    0,
+    0,
+    AccumT,
+    policy.vec_size,
+    policy.block_algorithm,
+    policy.load_modifier,
+    NoScaling<policy.threads_per_block, policy.items_per_thread, AccumT>>;
 
   // Thread block type for reducing input tiles
   using AgentReduceT = AgentReduce<agent_policy_t, InputIteratorT, OffsetT, ReductionOpT, AccumT, TransformOpT>;

--- a/cub/cub/device/dispatch/kernels/kernel_reduce_deterministic.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_reduce_deterministic.cuh
@@ -57,7 +57,7 @@ namespace detail::reduce
  */
 template <typename PolicySelector, typename InputIteratorT, typename ReductionOpT, typename AccumT, typename TransformOpT>
 _CCCL_KERNEL_ATTRIBUTES
-__launch_bounds__(int(current_policy<PolicySelector>().reduce.threads_per_block)) void DeterministicDeviceReduceKernel(
+__launch_bounds__(int(current_policy<PolicySelector>().multi_tile.threads_per_block)) void DeterministicDeviceReduceKernel(
   InputIteratorT d_in,
   AccumT* d_out,
   int num_items,
@@ -65,9 +65,9 @@ __launch_bounds__(int(current_policy<PolicySelector>().reduce.threads_per_block)
   TransformOpT transform_op,
   const int reduce_grid_size)
 {
-  constexpr agent_reduce_policy policy = current_policy<PolicySelector>().reduce;
-  constexpr int items_per_thread       = policy.items_per_thread;
-  constexpr int threads_per_block      = policy.threads_per_block;
+  constexpr ReducePassPolicy policy = current_policy<PolicySelector>().multi_tile;
+  constexpr int items_per_thread    = policy.items_per_thread;
+  constexpr int threads_per_block   = policy.threads_per_block;
 
   using block_reduce_t = BlockReduce<AccumT, threads_per_block, policy.block_algorithm>;
 
@@ -197,8 +197,8 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(
                                                     InitValueT init,
                                                     TransformOpT transform_op)
 {
-  constexpr agent_reduce_policy policy = current_policy<PolicySelector>().single_tile;
-  constexpr int threads_per_block      = policy.threads_per_block;
+  constexpr ReducePassPolicy policy = current_policy<PolicySelector>().single_tile;
+  constexpr int threads_per_block   = policy.threads_per_block;
 
   using block_reduce_t = BlockReduce<AccumT, threads_per_block, policy.block_algorithm>;
 

--- a/cub/cub/device/dispatch/kernels/kernel_reduce_deterministic.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_reduce_deterministic.cuh
@@ -69,7 +69,7 @@ __launch_bounds__(int(current_policy<PolicySelector>().multi_tile.threads_per_bl
   constexpr int items_per_thread    = policy.items_per_thread;
   constexpr int threads_per_block   = policy.threads_per_block;
 
-  using block_reduce_t = BlockReduce<AccumT, threads_per_block, policy.block_algorithm>;
+  using block_reduce_t = BlockReduce<AccumT, threads_per_block, policy.reduce_algorithm>;
 
   // Shared memory storage
   __shared__ typename block_reduce_t::TempStorage temp_storage;
@@ -200,7 +200,7 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(
   constexpr ReducePassPolicy policy = current_policy<PolicySelector>().single_tile;
   constexpr int threads_per_block   = policy.threads_per_block;
 
-  using block_reduce_t = BlockReduce<AccumT, threads_per_block, policy.block_algorithm>;
+  using block_reduce_t = BlockReduce<AccumT, threads_per_block, policy.reduce_algorithm>;
 
   // Shared memory storage
   __shared__ typename block_reduce_t::TempStorage temp_storage;

--- a/cub/cub/device/dispatch/kernels/kernel_segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_segmented_reduce.cuh
@@ -132,7 +132,7 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(current_policy<PolicySelector>().large
                         0,
                         void,
                         large_pol.vec_size,
-                        large_pol.block_algorithm,
+                        large_pol.reduce_algorithm,
                         large_pol.load_modifier,
                         NoScaling<large_pol.threads_per_block, large_pol.items_per_thread>>;
   using AgentReduceT = reduce::AgentReduce<large_agent_policy_t, InputIteratorT, OffsetT, ReductionOpT, AccumT>;
@@ -338,7 +338,7 @@ __launch_bounds__(current_policy<PolicySelector>().large_reduce.threads_per_bloc
                         0,
                         void,
                         large_pol.vec_size,
-                        large_pol.block_algorithm,
+                        large_pol.reduce_algorithm,
                         large_pol.load_modifier,
                         NoScaling<large_pol.threads_per_block, large_pol.items_per_thread>>;
   using AgentReduceT = reduce::AgentReduce<large_agent_policy_t, InputIteratorT, int, ReductionOpT, AccumT>;

--- a/cub/cub/device/dispatch/kernels/kernel_segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_segmented_reduce.cuh
@@ -124,17 +124,17 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(current_policy<PolicySelector>().large
   static constexpr segmented_reduce_policy full_policy = current_policy<PolicySelector>();
 
   // Large segment agent (one block per segment)
-  static constexpr reduce::agent_reduce_policy large_pol = full_policy.large_reduce;
+  static constexpr ReducePassPolicy large_pol = full_policy.large_reduce;
 
   // TODO(bgruber): pass policy directly as template argument to AgentReduce in C++20
   using large_agent_policy_t =
-    AgentReducePolicy<0,
-                      0,
-                      void,
-                      large_pol.vec_size,
-                      large_pol.block_algorithm,
-                      large_pol.load_modifier,
-                      NoScaling<large_pol.threads_per_block, large_pol.items_per_thread>>;
+    agent_reduce_policy<0,
+                        0,
+                        void,
+                        large_pol.vec_size,
+                        large_pol.block_algorithm,
+                        large_pol.load_modifier,
+                        NoScaling<large_pol.threads_per_block, large_pol.items_per_thread>>;
   using AgentReduceT = reduce::AgentReduce<large_agent_policy_t, InputIteratorT, OffsetT, ReductionOpT, AccumT>;
 
   // Medium segment agent (one warp per segment)
@@ -330,17 +330,17 @@ __launch_bounds__(current_policy<PolicySelector>().large_reduce.threads_per_bloc
   static constexpr segmented_reduce_policy full_policy = current_policy<PolicySelector>();
 
   // Large segment agent (one block per segment)
-  static constexpr reduce::agent_reduce_policy large_pol = full_policy.large_reduce;
+  static constexpr ReducePassPolicy large_pol = full_policy.large_reduce;
 
   // TODO(bgruber): pass policy directly as template argument to AgentReduce in C++20
   using large_agent_policy_t =
-    AgentReducePolicy<0,
-                      0,
-                      void,
-                      large_pol.vec_size,
-                      large_pol.block_algorithm,
-                      large_pol.load_modifier,
-                      NoScaling<large_pol.threads_per_block, large_pol.items_per_thread>>;
+    agent_reduce_policy<0,
+                        0,
+                        void,
+                        large_pol.vec_size,
+                        large_pol.block_algorithm,
+                        large_pol.load_modifier,
+                        NoScaling<large_pol.threads_per_block, large_pol.items_per_thread>>;
   using AgentReduceT = reduce::AgentReduce<large_agent_policy_t, InputIteratorT, int, ReductionOpT, AccumT>;
 
   // Medium segment agent (one warp per segment)

--- a/cub/cub/device/dispatch/tuning/tuning_reduce.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce.cuh
@@ -32,14 +32,14 @@ struct ReducePassPolicy
   int threads_per_block; //!< Number of threads in a CUDA block
   int items_per_thread; //!< Number of items processed per thread
   int vec_size; //!< Number of items per vectorized load
-  BlockReduceAlgorithm block_algorithm; //!< The @ref BlockReduceAlgorithm to use
+  BlockReduceAlgorithm reduce_algorithm; //!< The @ref BlockReduceAlgorithm to use
   CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const ReducePassPolicy& lhs, const ReducePassPolicy& rhs) noexcept
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
-        && lhs.vec_size == rhs.vec_size && lhs.block_algorithm == rhs.block_algorithm
+        && lhs.vec_size == rhs.vec_size && lhs.reduce_algorithm == rhs.reduce_algorithm
         && lhs.load_modifier == rhs.load_modifier;
   }
 
@@ -54,7 +54,7 @@ struct ReducePassPolicy
   {
     return os << "ReducePassPolicy { .threads_per_block = " << p.threads_per_block
               << ", .items_per_thread = " << p.items_per_thread << ", .vec_size = " << p.vec_size
-              << ", .block_algorithm = " << p.block_algorithm << ", .load_modifier = " << p.load_modifier << " }";
+              << ", .reduce_algorithm = " << p.reduce_algorithm << ", .load_modifier = " << p.load_modifier << " }";
   }
 #endif // _CCCL_HOSTED()
 };
@@ -450,7 +450,7 @@ struct policy_selector
     auto policy = get_two_phase_tuning(cc);
     if (determinism == __determinism_t::__not_guaranteed)
     {
-      policy.multi_tile.block_algorithm = BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC;
+      policy.multi_tile.reduce_algorithm = BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC;
     }
     return policy;
   }

--- a/cub/cub/device/dispatch/tuning/tuning_reduce.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce.cuh
@@ -59,7 +59,7 @@ struct ReducePassPolicy
 #endif // _CCCL_HOSTED()
 };
 
-//! The tuning policy for all algorithms in @ref DeviceReduce.
+//! The tuning policy for all algorithms in @ref DeviceReduce, except ``ReduceByKey``
 struct ReducePolicy
 {
   ReducePassPolicy multi_tile; //!< Policy used for the multi-tile (first) pass

--- a/cub/cub/device/dispatch/tuning/tuning_reduce.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce.cuh
@@ -25,65 +25,72 @@
 #include <cuda/std/optional>
 
 CUB_NAMESPACE_BEGIN
-namespace detail::reduce
-{
-// TODO(bgruber): bikeshed name before we make the tuning API public
-struct agent_reduce_policy // equivalent of AgentReducePolicy
-{
-  int threads_per_block;
-  int items_per_thread;
-  int vec_size;
-  BlockReduceAlgorithm block_algorithm;
-  CacheLoadModifier load_modifier;
 
-  _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const agent_reduce_policy& lhs, const agent_reduce_policy& rhs)
+//! The tuning policy for a single pass (multi-tile or single-tile) of all reduction algorithms in @ref DeviceReduce.
+struct ReducePassPolicy
+{
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int items_per_thread; //!< Number of items processed per thread
+  int vec_size; //!< Number of items per vectorized load
+  BlockReduceAlgorithm block_algorithm; //!< The @ref BlockReduceAlgorithm to use
+  CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const ReducePassPolicy& lhs, const ReducePassPolicy& rhs) noexcept
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
         && lhs.vec_size == rhs.vec_size && lhs.block_algorithm == rhs.block_algorithm
         && lhs.load_modifier == rhs.load_modifier;
   }
 
-  _CCCL_HOST_DEVICE_API constexpr friend bool operator!=(const agent_reduce_policy& lhs, const agent_reduce_policy& rhs)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const ReducePassPolicy& lhs, const ReducePassPolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const agent_reduce_policy& p)
+  friend ::std::ostream& operator<<(::std::ostream& os, const ReducePassPolicy& p)
   {
-    return os << "agent_reduce_policy { .threads_per_block = " << p.threads_per_block
+    return os << "ReducePassPolicy { .threads_per_block = " << p.threads_per_block
               << ", .items_per_thread = " << p.items_per_thread << ", .vec_size = " << p.vec_size
               << ", .block_algorithm = " << p.block_algorithm << ", .load_modifier = " << p.load_modifier << " }";
   }
 #endif // _CCCL_HOSTED()
 };
 
-struct reduce_policy
+//! The tuning policy for all algorithms in @ref DeviceReduce.
+struct ReducePolicy
 {
-  agent_reduce_policy reduce;
-  agent_reduce_policy single_tile;
+  ReducePassPolicy multi_tile; //!< Policy used for the multi-tile (first) pass
+  ReducePassPolicy single_tile; //!< Policy used for the single-tile pass. Used as second pass after the multi-tile pass
+                                //!< in some cases, or when the problem size fits into a single tile.
 
-  _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const reduce_policy& lhs, const reduce_policy& rhs)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const ReducePolicy& lhs, const ReducePolicy& rhs) noexcept
   {
-    return lhs.reduce == rhs.reduce && lhs.single_tile == rhs.single_tile;
+    return lhs.multi_tile == rhs.multi_tile && lhs.single_tile == rhs.single_tile;
   }
 
-  _CCCL_HOST_DEVICE_API constexpr friend bool operator!=(const reduce_policy& lhs, const reduce_policy& rhs)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const ReducePolicy& lhs, const ReducePolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const reduce_policy& p)
+  friend ::std::ostream& operator<<(::std::ostream& os, const ReducePolicy& p)
   {
-    return os << "reduce_policy { .reduce = " << p.reduce << ", .single_tile = " << p.single_tile << " }";
+    return os << "ReducePolicy { .multi_tile = " << p.multi_tile << ", .single_tile = " << p.single_tile << " }";
   }
 #endif // _CCCL_HOSTED()
 };
 
+namespace detail::reduce
+{
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>
-concept reduce_policy_selector = policy_selector<T, reduce_policy>;
+concept reduce_policy_selector = policy_selector<T, ReducePolicy>;
 #endif // _CCCL_HAS_CONCEPTS()
 
 // TODO(bgruber): remove in CCCL 4.0 when we drop the dispatchers
@@ -252,24 +259,24 @@ struct policy_hub
 
     // ReducePolicy (GTX Titan: 255.1 GB/s @ 48M 4B items; 228.7 GB/s @ 192M 1B items)
     using ReducePolicy =
-      AgentReducePolicy<threads_per_block,
-                        items_per_thread,
-                        AccumT,
-                        items_per_vec_load,
-                        BLOCK_REDUCE_WARP_REDUCTIONS,
-                        LOAD_LDG>;
+      agent_reduce_policy<threads_per_block,
+                          items_per_thread,
+                          AccumT,
+                          items_per_vec_load,
+                          BLOCK_REDUCE_WARP_REDUCTIONS,
+                          LOAD_LDG>;
 
     using SingleTilePolicy      = ReducePolicy;
     using SegmentedReducePolicy = ReducePolicy;
 
     using ReduceNondeterministicPolicy =
-      AgentReducePolicy<ReducePolicy::BLOCK_THREADS,
-                        ReducePolicy::ITEMS_PER_THREAD,
-                        AccumT,
-                        ReducePolicy::VECTOR_LOAD_LENGTH,
-                        BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
-                        ReducePolicy::LOAD_MODIFIER,
-                        NoScaling<ReducePolicy::BLOCK_THREADS, ReducePolicy::ITEMS_PER_THREAD>>;
+      agent_reduce_policy<ReducePolicy::BLOCK_THREADS,
+                          ReducePolicy::ITEMS_PER_THREAD,
+                          AccumT,
+                          ReducePolicy::VECTOR_LOAD_LENGTH,
+                          BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
+                          ReducePolicy::LOAD_MODIFIER,
+                          NoScaling<ReducePolicy::BLOCK_THREADS, ReducePolicy::ITEMS_PER_THREAD>>;
   };
 
   struct Policy600 : ChainedPolicy<600, Policy600, Policy500>
@@ -280,24 +287,24 @@ struct policy_hub
 
     // ReducePolicy (P100: 591 GB/s @ 64M 4B items; 583 GB/s @ 256M 1B items)
     using ReducePolicy =
-      AgentReducePolicy<threads_per_block,
-                        items_per_thread,
-                        AccumT,
-                        items_per_vec_load,
-                        BLOCK_REDUCE_WARP_REDUCTIONS,
-                        LOAD_LDG>;
+      agent_reduce_policy<threads_per_block,
+                          items_per_thread,
+                          AccumT,
+                          items_per_vec_load,
+                          BLOCK_REDUCE_WARP_REDUCTIONS,
+                          LOAD_LDG>;
 
     using SingleTilePolicy      = ReducePolicy;
     using SegmentedReducePolicy = ReducePolicy;
 
     using ReduceNondeterministicPolicy =
-      AgentReducePolicy<ReducePolicy::BLOCK_THREADS,
-                        ReducePolicy::ITEMS_PER_THREAD,
-                        AccumT,
-                        ReducePolicy::VECTOR_LOAD_LENGTH,
-                        BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
-                        ReducePolicy::LOAD_MODIFIER,
-                        NoScaling<ReducePolicy::BLOCK_THREADS, ReducePolicy::ITEMS_PER_THREAD>>;
+      agent_reduce_policy<ReducePolicy::BLOCK_THREADS,
+                          ReducePolicy::ITEMS_PER_THREAD,
+                          AccumT,
+                          ReducePolicy::VECTOR_LOAD_LENGTH,
+                          BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
+                          ReducePolicy::LOAD_MODIFIER,
+                          NoScaling<ReducePolicy::BLOCK_THREADS, ReducePolicy::ITEMS_PER_THREAD>>;
   };
 
   struct Policy1000 : ChainedPolicy<1000, Policy1000, Policy600>
@@ -305,12 +312,12 @@ struct policy_hub
     // Use values from tuning if a specialization exists, otherwise pick Policy600
     template <typename Tuning>
     static _CCCL_HOST_DEVICE auto select_agent_policy(int)
-      -> AgentReducePolicy<Tuning::threads,
-                           Tuning::items,
-                           AccumT,
-                           Tuning::items_per_vec_load,
-                           BLOCK_REDUCE_WARP_REDUCTIONS,
-                           LOAD_LDG>;
+      -> agent_reduce_policy<Tuning::threads,
+                             Tuning::items,
+                             AccumT,
+                             Tuning::items_per_vec_load,
+                             BLOCK_REDUCE_WARP_REDUCTIONS,
+                             LOAD_LDG>;
     // use Policy600 as DefaultPolicy
     template <typename Tuning>
     static _CCCL_HOST_DEVICE auto select_agent_policy(long) -> typename Policy600::ReducePolicy;
@@ -326,13 +333,13 @@ struct policy_hub
     using SegmentedReducePolicy = ReducePolicy;
 
     using ReduceNondeterministicPolicy =
-      AgentReducePolicy<ReducePolicy::BLOCK_THREADS,
-                        ReducePolicy::ITEMS_PER_THREAD,
-                        AccumT,
-                        ReducePolicy::VECTOR_LOAD_LENGTH,
-                        BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
-                        ReducePolicy::LOAD_MODIFIER,
-                        NoScaling<ReducePolicy::BLOCK_THREADS, ReducePolicy::ITEMS_PER_THREAD>>;
+      agent_reduce_policy<ReducePolicy::BLOCK_THREADS,
+                          ReducePolicy::ITEMS_PER_THREAD,
+                          AccumT,
+                          ReducePolicy::VECTOR_LOAD_LENGTH,
+                          BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
+                          ReducePolicy::LOAD_MODIFIER,
+                          NoScaling<ReducePolicy::BLOCK_THREADS, ReducePolicy::ITEMS_PER_THREAD>>;
   };
 
   using MaxPolicy = Policy1000;
@@ -349,7 +356,7 @@ struct policy_selector
   __determinism_t determinism = __determinism_t::__run_to_run;
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto get_deterministic_tuning(::cuda::compute_capability cc) const
-    -> reduce_policy
+    -> ReducePolicy
   {
     if (cc >= ::cuda::compute_capability{9, 0})
     {
@@ -395,15 +402,15 @@ struct policy_selector
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto get_two_phase_tuning(::cuda::compute_capability cc) const
-    -> reduce_policy
+    -> ReducePolicy
   {
     // if we don't have a tuning for sm100, fall through
     auto sm100_tuning = get_sm100_tuning(accum_t, operation_t, offset_size, accum_size);
     if (cc >= ::cuda::compute_capability{10, 0} && sm100_tuning)
     {
-      agent_reduce_policy rp{};
+      ReducePassPolicy rp{};
       auto [scaled_items, scaled_threads] = scale_mem_bound(sm100_tuning->threads, sm100_tuning->items, accum_size);
-      rp                                  = agent_reduce_policy{
+      rp                                  = ReducePassPolicy{
         scaled_threads, scaled_items, sm100_tuning->items_per_vec_load, BLOCK_REDUCE_WARP_REDUCTIONS, LOAD_LDG};
       return {rp, rp};
     }
@@ -417,7 +424,7 @@ struct policy_selector
       // ReducePolicy (P100: 591 GB/s @ 64M 4B items; 583 GB/s @ 256M 1B items)
       auto [scaled_items, scaled_threads] = scale_mem_bound(threads_per_block, items_per_thread, accum_size);
       const auto rp =
-        agent_reduce_policy{scaled_threads, scaled_items, items_per_vec_load, BLOCK_REDUCE_WARP_REDUCTIONS, LOAD_LDG};
+        ReducePassPolicy{scaled_threads, scaled_items, items_per_vec_load, BLOCK_REDUCE_WARP_REDUCTIONS, LOAD_LDG};
       return {rp, rp};
     }
 
@@ -429,11 +436,11 @@ struct policy_selector
 
     auto [scaled_items, scaled_threads] = scale_mem_bound(threads_per_block, items_per_thread, accum_size);
     const auto rp =
-      agent_reduce_policy{scaled_threads, scaled_items, items_per_vec_load, BLOCK_REDUCE_WARP_REDUCTIONS, LOAD_LDG};
+      ReducePassPolicy{scaled_threads, scaled_items, items_per_vec_load, BLOCK_REDUCE_WARP_REDUCTIONS, LOAD_LDG};
     return {rp, rp};
   }
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> reduce_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> ReducePolicy
   {
     if (determinism == __determinism_t::__gpu_to_gpu)
     {
@@ -443,7 +450,7 @@ struct policy_selector
     auto policy = get_two_phase_tuning(cc);
     if (determinism == __determinism_t::__not_guaranteed)
     {
-      policy.reduce.block_algorithm = BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC;
+      policy.multi_tile.block_algorithm = BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC;
     }
     return policy;
   }
@@ -459,7 +466,7 @@ template <typename AccumT,
           __determinism_t Determinism = __determinism_t::__run_to_run>
 struct policy_selector_from_types
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> reduce_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> ReducePolicy
   {
     constexpr auto policies = policy_selector{
       classify_type<AccumT>, classify_op<ReductionOpT>, int{sizeof(OffsetT)}, int{sizeof(AccumT)}, Determinism};

--- a/cub/cub/device/dispatch/tuning/tuning_segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_segmented_reduce.cuh
@@ -65,7 +65,7 @@ struct warp_reduce_policy
 
 struct segmented_reduce_policy
 {
-  reduce::agent_reduce_policy large_reduce;
+  ReducePassPolicy large_reduce;
   warp_reduce_policy small_reduce;
   warp_reduce_policy medium_reduce;
 
@@ -109,7 +109,7 @@ struct policy_selector
     constexpr int small_threads_per_warp  = 1;
     constexpr int medium_threads_per_warp = 32;
 
-    const auto rp = reduce::policy_selector{accum_t, operation_t, offset_size, accum_size}(cc).reduce;
+    const auto rp = reduce::policy_selector{accum_t, operation_t, offset_size, accum_size}(cc).multi_tile;
 
     return segmented_reduce_policy{
       rp,
@@ -156,12 +156,12 @@ struct policy_hub
 
   public:
     using ReducePolicy =
-      cub::AgentReducePolicy<nominal_4b_large_threads_per_block,
-                             nominal_4b_large_items_per_thread,
-                             AccumT,
-                             items_per_vec_load,
-                             cub::BLOCK_REDUCE_WARP_REDUCTIONS,
-                             cub::LOAD_LDG>;
+      agent_reduce_policy<nominal_4b_large_threads_per_block,
+                          nominal_4b_large_items_per_thread,
+                          AccumT,
+                          items_per_vec_load,
+                          cub::BLOCK_REDUCE_WARP_REDUCTIONS,
+                          cub::LOAD_LDG>;
 
     using SmallReducePolicy =
       cub::AgentWarpReducePolicy<ReducePolicy::BLOCK_THREADS,

--- a/cub/test/catch2_test_device_reduce_deterministic.cu
+++ b/cub/test/catch2_test_device_reduce_deterministic.cu
@@ -24,11 +24,9 @@ using float_type_list = c2h::type_list<float, double>;
 template <int ItemsPerThread, int BlockSize>
 struct custom_policy_selector
 {
-  _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const
-    -> cub::detail::reduce::reduce_policy
+  _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const -> cub::ReducePolicy
   {
-    const auto p = cub::detail::reduce::agent_reduce_policy{
-      BlockSize, ItemsPerThread, 1, cub::BLOCK_REDUCE_RAKING, cub::LOAD_DEFAULT};
+    const auto p = cub::ReducePassPolicy{BlockSize, ItemsPerThread, 1, cub::BLOCK_REDUCE_RAKING, cub::LOAD_DEFAULT};
     return {p, p};
   }
 };

--- a/cub/test/catch2_test_device_reduce_dispatcher.cu
+++ b/cub/test/catch2_test_device_reduce_dispatcher.cu
@@ -4,6 +4,9 @@
 // TODO(bgruber): Drop this entire test in CCCL 4.0 when we drop all CUB dispatchers
 // This file tests calling cub::DispatchReduce directly
 
+// disable deprecation warnings for DispatchReduce and AgentReducePolicy
+#define CCCL_IGNORE_DEPRECATED_API
+
 #include "insert_nested_NVTX_range_guard.h"
 
 #include <cub/device/dispatch/dispatch_reduce.cuh>

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -39,10 +39,10 @@ using cuda::execution::determinism::__determinism_t;
 template <int ThreadsPerBlock>
 struct reduce_tuning
 {
-  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::detail::reduce::reduce_policy
+  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::ReducePolicy
   {
-    const auto policy = cub::detail::reduce::agent_reduce_policy{
-      ThreadsPerBlock, 1, 1, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_DEFAULT};
+    const auto policy =
+      cub::ReducePassPolicy{ThreadsPerBlock, 1, 1, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_DEFAULT};
     return {policy, policy};
   }
 };
@@ -1062,6 +1062,54 @@ C2H_TEST("Device ArgMax with compare_op uses environment", "[reduce][device]")
 }
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
+C2H_TEST("ReducePassPolicy", "[reduce][device]")
+{
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::ReducePassPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ReducePassPolicy>);
+
+  // aggregate init
+  constexpr auto p1 = cub::ReducePassPolicy{
+    256, 16, 4, cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS, cub::CacheLoadModifier::LOAD_LDG};
+
+#  if _CCCL_STD_VER >= 2020
+  // designated init
+  constexpr auto p2 = cub::ReducePassPolicy{
+    .threads_per_block = 256,
+    .items_per_thread  = 16,
+    .vec_size          = 4,
+    .block_algorithm   = cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS,
+    .load_modifier     = cub::CacheLoadModifier::LOAD_LDG};
+#  else // _CCCL_STD_VER >= 2020
+  constexpr auto p2 = p1;
+#  endif // _CCCL_STD_VER >= 2020
+
+  // comparison
+  STATIC_REQUIRE(p1 == p2);
+  STATIC_REQUIRE_FALSE(p1 != p2);
+}
+
+C2H_TEST("ReducePolicy", "[reduce][device]")
+{
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::ReducePolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ReducePolicy>);
+
+  // aggregate init
+  constexpr auto pass = cub::ReducePassPolicy{
+    256, 16, 4, cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS, cub::CacheLoadModifier::LOAD_LDG};
+  constexpr auto p1 = cub::ReducePolicy{pass, pass};
+
+#  if _CCCL_STD_VER >= 2020
+  // designated init
+  constexpr auto p2 = cub::ReducePolicy{.multi_tile = pass, .single_tile = pass};
+#  else // _CCCL_STD_VER >= 2020
+  constexpr auto p2 = p1;
+#  endif // _CCCL_STD_VER >= 2020
+
+  // comparison
+  STATIC_REQUIRE(p1 == p2);
+  STATIC_REQUIRE_FALSE(p1 != p2);
+}
+
 C2H_TEST("ReduceByKeyPolicy", "[reduce][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::ReduceByKeyPolicy>);

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -1077,7 +1077,7 @@ C2H_TEST("ReducePassPolicy", "[reduce][device]")
     .threads_per_block = 256,
     .items_per_thread  = 16,
     .vec_size          = 4,
-    .block_algorithm   = cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS,
+    .reduce_algorithm  = cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS,
     .load_modifier     = cub::CacheLoadModifier::LOAD_LDG};
 #  else // _CCCL_STD_VER >= 2020
   constexpr auto p2 = p1;

--- a/cub/test/catch2_test_device_reduce_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_env_api.cu
@@ -669,7 +669,7 @@ struct ReducePolicySelector
       .threads_per_block = 256,
       .items_per_thread  = cc > cuda::compute_capability{9, 0} ? 20 : 16,
       .vec_size          = 4,
-      .block_algorithm   = cub::BLOCK_REDUCE_WARP_REDUCTIONS,
+      .reduce_algorithm  = cub::BLOCK_REDUCE_WARP_REDUCTIONS,
       .load_modifier     = cub::LOAD_LDG};
     return {.multi_tile = pass, .single_tile = pass};
   }

--- a/cub/test/catch2_test_device_reduce_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_env_api.cu
@@ -9,6 +9,7 @@
 
 #include <cuda/__execution/determinism.h>
 #include <cuda/__execution/require.h>
+#include <cuda/__execution/tune.h>
 #include <cuda/devices>
 #include <cuda/std/__execution/env.h>
 #include <cuda/stream>
@@ -656,3 +657,43 @@ C2H_TEST("cub::DeviceReduce::Sum queries both stream and resource from composed 
   REQUIRE(bytes_allocated > 0);
   REQUIRE(bytes_deallocated == bytes_allocated);
 }
+
+#if _CCCL_STD_VER >= 2020
+
+// example-begin reduce-policy-selector
+struct ReducePolicySelector
+{
+  __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::ReducePolicy
+  {
+    auto pass = cub::ReducePassPolicy{
+      .threads_per_block = 256,
+      .items_per_thread  = cc > cuda::compute_capability{9, 0} ? 20 : 16,
+      .vec_size          = 4,
+      .block_algorithm   = cub::BLOCK_REDUCE_WARP_REDUCTIONS,
+      .load_modifier     = cub::LOAD_LDG};
+    return {.multi_tile = pass, .single_tile = pass};
+  }
+};
+// example-end reduce-policy-selector
+
+C2H_TEST("cub::DeviceReduce::Reduce env-based API with tuning", "[reduce][env]")
+{
+  // example-begin reduce-tuning
+  auto input  = thrust::device_vector<int>{1, 2, 3, 4, 5};
+  auto output = thrust::device_vector<int>(1, thrust::no_init);
+
+  const auto error = cub::DeviceReduce::Reduce(
+    input.begin(), output.begin(), input.size(), cuda::std::plus{}, 0, cuda::execution::tune(ReducePolicySelector{}));
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceReduce::Reduce failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected{15};
+  // example-end reduce-tuning
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(output == expected);
+}
+
+#endif // _CCCL_STD_VER >= 2020

--- a/cub/test/catch2_test_device_reduce_nondeterministic.cu
+++ b/cub/test/catch2_test_device_reduce_nondeterministic.cu
@@ -32,10 +32,9 @@ using float_type_list =
 template <int ItemsPerThread, int BlockSize>
 struct custom_policy_selector
 {
-  _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const
-    -> cub::detail::reduce::reduce_policy
+  _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const -> cub::ReducePolicy
   {
-    const auto rp = cub::detail::reduce::agent_reduce_policy{
+    const auto rp = cub::ReducePassPolicy{
       BlockSize,
       ItemsPerThread,
       4,

--- a/cub/test/catch2_test_device_segmented_reduce_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_custom_policy_hub.cu
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// TODO(bgruber): drop this test with CCCL 4.0 when we drop the segmented reduce dispatcher
+
+// disable deprecation warnings for AgentReducePolicy
+#define CCCL_IGNORE_DEPRECATED_API
+
 #include "insert_nested_NVTX_range_guard.h"
 
 #include <cub/device/dispatch/dispatch_segmented_reduce.cuh>

--- a/cub/test/catch2_test_device_segmented_reduce_env.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_env.cu
@@ -368,8 +368,7 @@ struct segmented_reduce_tuning
   _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const
     -> cub::detail::segmented_reduce::segmented_reduce_policy
   {
-    auto rp = cub::detail::reduce::agent_reduce_policy{
-      ThreadsPerBlock, 1, 1, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_DEFAULT};
+    auto rp = cub::ReducePassPolicy{ThreadsPerBlock, 1, 1, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_DEFAULT};
     // need the repetition of the return type for GCC9
     return cub::detail::segmented_reduce::segmented_reduce_policy{
       rp,

--- a/docs/cub/tuning.rst
+++ b/docs/cub/tuning.rst
@@ -43,13 +43,13 @@ taking a ``cuda::compute_capability`` and returning the algorithm's policy struc
 .. code:: c++
 
     template <typename T>
-    struct CustomReducePolicySelector {
+    struct my_reduce_tuning {
       __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::ReducePolicy {
         // tuning for Hopper and later
         if (cc >= cuda::compute_capability(9, 0)) {
           const auto pass = cub::ReducePassPolicy{
             .threads_per_block = 512,
-            .items_per_thread = 64 / sizeof(T), // 8 double, 16 float, 32 half_t, ...
+            .items_per_thread = std::max(64 / sizeof(T), 1), // 8 double, 16 float, 32 half_t, ...
             .vec_size = 2,
             .reduce_algorithm = cub::BLOCK_REDUCE_WARP_REDUCTIONS,
             .load_modifier = cub::LOAD_DEFAULT

--- a/docs/cub/tuning.rst
+++ b/docs/cub/tuning.rst
@@ -40,34 +40,31 @@ Defining a policy selector
 A policy selector is any type with a :code:`__host__`,  :code:`__device__`, :code:`constexpr`, and :code:`const` call operator
 taking a ``cuda::compute_capability`` and returning the algorithm's policy struct:
 
-..
-    TODO(bgruber): we have to update this example again after the reduce tuning API has been actually released
-
 .. code:: c++
 
     template <typename T>
-    struct my_reduce_tuning {
+    struct CustomReducePolicySelector {
       __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::ReducePolicy {
         // tuning for Hopper and later
         if (cc >= cuda::compute_capability(9, 0)) {
-          const auto policy = cub::detail::agent_reduce_policy{
+          const auto pass = cub::ReducePassPolicy{
             .threads_per_block = 512,
             .items_per_thread = 64 / sizeof(T), // 8 double, 16 float, 32 half_t, ...
-            .vector_load_length = 2,
-            .block_algorithm = cub::BLOCK_REDUCE_WARP_REDUCTIONS,
+            .vec_size = 2,
+            .reduce_algorithm = cub::BLOCK_REDUCE_WARP_REDUCTIONS,
             .load_modifier = cub::LOAD_DEFAULT
           };
-          return {policy, policy, policy, policy};
+          return { .multi_tile = pass, .single_tile = pass };
         }
         // fallback for older GPUs
-        const auto policy = cub::detail::agent_reduce_policy{
+        const auto policy = cub::ReducePassPolicy{
           .threads_per_block = 256,
           .items_per_thread = 12,
-          .vector_load_length = 1,
-          .block_algorithm = cub::BLOCK_REDUCE_WARP_REDUCTIONS,
+          .vec_size = 1,
+          .reduce_algorithm = cub::BLOCK_REDUCE_WARP_REDUCTIONS,
           .load_modifier = cub::LOAD_DEFAULT
         };
-        return {policy, policy, policy, policy};
+        return { .multi_tile = pass, .single_tile = pass };
       }
     };
 

--- a/docs/cub/tuning.rst
+++ b/docs/cub/tuning.rst
@@ -57,7 +57,7 @@ taking a ``cuda::compute_capability`` and returning the algorithm's policy struc
           return { .multi_tile = pass, .single_tile = pass };
         }
         // fallback for older GPUs
-        const auto policy = cub::ReducePassPolicy{
+        const auto pass = cub::ReducePassPolicy{
           .threads_per_block = 256,
           .items_per_thread = 12,
           .vec_size = 1,

--- a/docs/cub/tuning_infra.rst
+++ b/docs/cub/tuning_infra.rst
@@ -134,9 +134,6 @@ and the returned value is included in the environment passed to the CUB API.
 The following code is included in the benchmark for the policy selector to be enabled
 and the parameters to have effect in execution:
 
-..
-    TODO(bgruber): we have to update this example again after the reduce tuning API has been actually released
-
 .. code:: c++
 
   #if !TUNE_BASE
@@ -145,14 +142,14 @@ and the parameters to have effect in execution:
     _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability /*cc*/) const -> cub::ReducePolicy {
       const auto [items, threads] = cub::detail::scale_mem_bound(
                                      TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, sizeof(T));
-      const auto policy = cub::detail::agent_reduce_policy{
+      const auto pass = cub::ReducePassPolicy{
         .threads_per_block = threads,
         .items_per_thread = items,
-        .vector_load_length = 1 << TUNE_ITEMS_PER_VEC_LOAD_POW2,
-        .block_algorithm = cub::BLOCK_REDUCE_WARP_REDUCTIONS,
+        .vec_size = 1 << TUNE_ITEMS_PER_VEC_LOAD_POW2,
+        .reduce_algorithm = cub::BLOCK_REDUCE_WARP_REDUCTIONS,
         .load_modifier = cub::LOAD_DEFAULT
       };
-      return {policy, policy, policy, policy};
+      return { .multi_tile = pass, .single_tile = pass};
     }
   };
   #endif


### PR DESCRIPTION
- [x] #8826
- [x] add more `Device reduce can be tuned` tests that cover the two other determinisms
- [x] #7671 is sufficiently approved to proceed with this PR. The remaining discussion can continue here.
- [x] #9349
- [x] #9639
- [x] Bikeshedding
- [x] Remove the `My` from the policy selector names in the API example
- [x] We should not need to provide multiple policy selectors to `DeviceReduce::Sum` and rather use a struct with appropriate sub members, like `DeviceTransform`. There is not actually a difference between the two cases (as I tried to argue).
- [x] Deprecate the agent policy
- [x] Rename `block_algorithm` to `reduce_algorithm`.


Fixes: #7577