### PR TITLE
[libcu++] Make `cuda::compute_capability` structural type

### DIFF
--- a/libcudacxx/include/cuda/__device/compute_capability.h
+++ b/libcudacxx/include/cuda/__device/compute_capability.h
@@ -34,9 +34,9 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 //! @brief Type representing the CUDA compute capability.
 class compute_capability
 {
+public:
   int __cc_{}; //!< The stored compute capability in format 10 * major + minor.
 
-public:
   _CCCL_HIDE_FROM_ABI constexpr compute_capability() noexcept = default;
 
   //! @brief Constructs the object from compute capability \c __cc. The expected format is 10 * major + minor.

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/compute_capability.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/compute_capability.pass.cpp
@@ -233,6 +233,14 @@ TEST_FUNC constexpr bool test()
     assert(!(cc2 > cc1));
   }
 
+  // 12. Test that cuda::compute_capability is a structural type.
+#if _CCCL_STD_VER >= 2020
+  {
+    [[maybe_unused]] constexpr auto val =
+      cuda::std::integral_constant<cuda::compute_capability, cuda::compute_capability{100}>{};
+  }
+#endif // _CCCL_STD_VER >= 2020
+
   return true;
 }
 


### PR DESCRIPTION
Fixes #8730 