### PR TITLE
[libcu++] Ensure that cuda iterators work with all host only types

### DIFF
--- a/libcudacxx/include/cuda/__iterator/constant_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/constant_iterator.h
@@ -148,6 +148,7 @@ public:
   }
 
   //! @brief Increments the stored index
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr constant_iterator& operator++() noexcept
   {
     ++__index();
@@ -164,6 +165,7 @@ public:
   }
 
   //! @brief Decrements the stored index
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr constant_iterator& operator--() noexcept
   {
     if constexpr (::cuda::std::is_signed_v<_Index> || !::cuda::std::is_integral_v<_Index>)
@@ -189,6 +191,7 @@ public:
 
   //! @brief Advances a @c constant_iterator by a given number of elements
   //! @param __n The amount of elements to advance
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr constant_iterator& operator+=(difference_type __n) noexcept
   {
     if constexpr (::cuda::std::is_signed_v<_Index> || !::cuda::std::is_integral_v<_Index>)
@@ -202,6 +205,7 @@ public:
   //! @brief Creates a copy of a @c constant_iterator advanced by a given number of elements
   //! @param __iter The @c constant_iterator to advance
   //! @param __n The amount of elements to advance
+  _CCCL_EXEC_CHECK_DISABLE
   template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
   [[nodiscard]] _CCCL_API friend constexpr constant_iterator operator+(
     const constant_iterator& __iter, difference_type __n) noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Tp>)
@@ -216,6 +220,7 @@ public:
   //! @brief Creates a copy of a @c constant_iterator advanced by a given number of elements
   //! @param __n The amount of elements to advance
   //! @param __iter The @c constant_iterator to advance
+  _CCCL_EXEC_CHECK_DISABLE
   template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
   [[nodiscard]] _CCCL_API friend constexpr constant_iterator operator+(
     difference_type __n, const constant_iterator& __iter) noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Tp>)
@@ -229,6 +234,7 @@ public:
 
   //! @brief Decrements a @c constant_iterator by a given number of elements
   //! @param __n The amount of elements to decrement
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr constant_iterator& operator-=(difference_type __n) noexcept
   {
     if constexpr (::cuda::std::is_signed_v<_Index>)
@@ -242,6 +248,7 @@ public:
   //! @brief Creates a copy of a @c constant_iterator decremented by a given number of elements
   //! @param __n The amount of elements to decrement
   //! @param __iter The @c constant_iterator to decrement
+  _CCCL_EXEC_CHECK_DISABLE
   template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
   [[nodiscard]] _CCCL_API friend constexpr constant_iterator operator-(
     const constant_iterator& __iter, difference_type __n) noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Tp>)

--- a/libcudacxx/include/cuda/__iterator/constant_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/constant_iterator.h
@@ -102,6 +102,7 @@ public:
   using reference = _Tp;
   using pointer   = void;
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
   _CCCL_REQUIRES(::cuda::std::default_initializable<_Tp2>)
   _CCCL_API constexpr constant_iterator() noexcept(::cuda::std::is_nothrow_default_constructible_v<_Tp2>)
@@ -132,12 +133,14 @@ public:
     return static_cast<difference_type>(__index());
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   //! @brief Returns the stored value
   [[nodiscard]] _CCCL_API constexpr reference operator*() const noexcept
   {
     return __value();
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   //! @brief Returns the stored value
   [[nodiscard]] _CCCL_API constexpr reference operator[](difference_type) const noexcept
   {

--- a/libcudacxx/include/cuda/__iterator/constant_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/constant_iterator.h
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/__fwd/iterator.h>
+#include <cuda/std/__concepts/constructible.h>
 #include <cuda/std/__iterator/concepts.h>
 #include <cuda/std/__iterator/iterator_traits.h>
 #include <cuda/std/__ranges/compressed_movable_box.h>

--- a/libcudacxx/include/cuda/__iterator/permutation_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/permutation_iterator.h
@@ -97,7 +97,18 @@ private:
   _Iter __iter_;
   _Index __index_;
 
+#ifndef _CCCL_DOXYGEN_INVOKED // Internal helpers
   // We need to factor these out because old gcc chokes with using arguments in friend functions
+  template <class _Iter1>
+  static constexpr bool __nothrow_plus =
+    ::cuda::std::is_nothrow_copy_constructible_v<_Iter1> && ::cuda::std::is_nothrow_copy_constructible_v<_Index>
+    && noexcept(::cuda::std::declval<const _Index&>() + ::cuda::std::iter_difference_t<_Index>());
+
+  template <class _Iter1>
+  static constexpr bool __nothrow_minus =
+    ::cuda::std::is_nothrow_copy_constructible_v<_Iter1> && ::cuda::std::is_nothrow_copy_constructible_v<_Index>
+    && noexcept(::cuda::std::declval<const _Index&>() - ::cuda::std::iter_difference_t<_Index>());
+
   template <class _Iter1>
   static constexpr bool __nothrow_difference =
     noexcept(::cuda::std::declval<_Iter1>() - ::cuda::std::declval<_Iter1>());
@@ -115,6 +126,7 @@ private:
   template <class _Iter1, class _Iter2>
   static constexpr bool __nothrow_greater_equal =
     noexcept(::cuda::std::declval<_Iter1>() >= ::cuda::std::declval<_Iter2>());
+#endif // _CCCL_DOXYGEN_INVOKED
 
 public:
   using iterator_type       = _Iter;
@@ -280,11 +292,9 @@ public:
   //! @param __n The number of elements to advance
   //! @return Equivalent to ``permutation_iterator{iter, index + __n}``
   _CCCL_EXEC_CHECK_DISABLE
-  template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
+  template <class _Iter2 = _Iter> // Must be template, or the compiler complains about a nonliteral return type
   [[nodiscard]] _CCCL_API friend constexpr permutation_iterator
-  operator+(const permutation_iterator& __iter, difference_type __n) noexcept( //
-    noexcept(::cuda::std::declval<const _Index&>() + difference_type{})
-    && ::cuda::std::is_nothrow_copy_constructible_v<_Iter> && ::cuda::std::is_nothrow_copy_constructible_v<_Index>)
+  operator+(const permutation_iterator& __iter, difference_type __n) noexcept(__nothrow_plus<_Iter2>)
   {
     return permutation_iterator{__iter.__iter_, __iter.__index_ + __n};
   }
@@ -294,11 +304,9 @@ public:
   //! @param __iter The original @c permutation_iterator
   //! @return Equivalent to ``permutation_iterator{iter, index + __n}``
   _CCCL_EXEC_CHECK_DISABLE
-  template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
+  template <class _Iter2 = _Iter> // Must be template, or the compiler complains about a nonliteral return type
   [[nodiscard]] _CCCL_API friend constexpr permutation_iterator
-  operator+(difference_type __n, const permutation_iterator& __iter) noexcept(
-    noexcept(::cuda::std::declval<const _Index&>() + difference_type{})
-    && ::cuda::std::is_nothrow_copy_constructible_v<_Iter> && ::cuda::std::is_nothrow_copy_constructible_v<_Index>)
+  operator+(difference_type __n, const permutation_iterator& __iter) noexcept(__nothrow_plus<_Iter2>)
   {
     return permutation_iterator{__iter.__iter_, __iter.__index_ + __n};
   }
@@ -308,11 +316,9 @@ public:
   //! @param __n The number of elements to decrement
   //! @return Equivalent to ``permutation_iterator{iter, index - __n}``
   _CCCL_EXEC_CHECK_DISABLE
-  template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
+  template <class _Iter2 = _Iter> // Must be template, or the compiler complains about a nonliteral return type
   [[nodiscard]] _CCCL_API friend constexpr permutation_iterator
-  operator-(const permutation_iterator& __iter, difference_type __n) noexcept( //
-    noexcept(::cuda::std::declval<const _Index&>() - difference_type{})
-    && ::cuda::std::is_nothrow_copy_constructible_v<_Iter> && ::cuda::std::is_nothrow_copy_constructible_v<_Index>)
+  operator-(const permutation_iterator& __iter, difference_type __n) noexcept(__nothrow_minus<_Iter2>)
   {
     return permutation_iterator{__iter.__iter_, __iter.__index_ - __n};
   }

--- a/libcudacxx/include/cuda/__iterator/permutation_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/permutation_iterator.h
@@ -283,7 +283,7 @@ public:
   template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
   [[nodiscard]] _CCCL_API friend constexpr permutation_iterator
   operator+(const permutation_iterator& __iter, difference_type __n) noexcept( //
-    noexcept(__iter.__index_ + __n)
+    noexcept(::cuda::std::declval<const _Index&>() + difference_type{})
     && ::cuda::std::is_nothrow_copy_constructible_v<_Iter> && ::cuda::std::is_nothrow_copy_constructible_v<_Index>)
   {
     return permutation_iterator{__iter.__iter_, __iter.__index_ + __n};
@@ -297,7 +297,7 @@ public:
   template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
   [[nodiscard]] _CCCL_API friend constexpr permutation_iterator
   operator+(difference_type __n, const permutation_iterator& __iter) noexcept(
-    noexcept(__iter.__index_ + __n)
+    noexcept(::cuda::std::declval<const _Index&>() + difference_type{})
     && ::cuda::std::is_nothrow_copy_constructible_v<_Iter> && ::cuda::std::is_nothrow_copy_constructible_v<_Index>)
   {
     return permutation_iterator{__iter.__iter_, __iter.__index_ + __n};
@@ -311,7 +311,7 @@ public:
   template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
   [[nodiscard]] _CCCL_API friend constexpr permutation_iterator
   operator-(const permutation_iterator& __iter, difference_type __n) noexcept( //
-    noexcept(__iter.__index_ - __n)
+    noexcept(::cuda::std::declval<const _Index&>() - difference_type{})
     && ::cuda::std::is_nothrow_copy_constructible_v<_Iter> && ::cuda::std::is_nothrow_copy_constructible_v<_Index>)
   {
     return permutation_iterator{__iter.__iter_, __iter.__index_ - __n};

--- a/libcudacxx/include/cuda/__iterator/permutation_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/permutation_iterator.h
@@ -280,6 +280,7 @@ public:
   //! @param __n The number of elements to advance
   //! @return Equivalent to ``permutation_iterator{iter, index + __n}``
   _CCCL_EXEC_CHECK_DISABLE
+  template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
   [[nodiscard]] _CCCL_API friend constexpr permutation_iterator
   operator+(const permutation_iterator& __iter, difference_type __n) noexcept( //
     noexcept(__iter.__index_ + __n)
@@ -293,6 +294,7 @@ public:
   //! @param __iter The original @c permutation_iterator
   //! @return Equivalent to ``permutation_iterator{iter, index + __n}``
   _CCCL_EXEC_CHECK_DISABLE
+  template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
   [[nodiscard]] _CCCL_API friend constexpr permutation_iterator
   operator+(difference_type __n, const permutation_iterator& __iter) noexcept(
     noexcept(__iter.__index_ + __n)
@@ -306,6 +308,7 @@ public:
   //! @param __n The number of elements to decrement
   //! @return Equivalent to ``permutation_iterator{iter, index - __n}``
   _CCCL_EXEC_CHECK_DISABLE
+  template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
   [[nodiscard]] _CCCL_API friend constexpr permutation_iterator
   operator-(const permutation_iterator& __iter, difference_type __n) noexcept( //
     noexcept(__iter.__index_ - __n)

--- a/libcudacxx/include/cuda/__iterator/permutation_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/permutation_iterator.h
@@ -27,6 +27,7 @@
 #include <cuda/std/__iterator/concepts.h>
 #include <cuda/std/__iterator/iterator_traits.h>
 #include <cuda/std/__type_traits/is_nothrow_copy_constructible.h>
+#include <cuda/std/__type_traits/is_nothrow_default_constructible.h>
 #include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
 #include <cuda/std/__utility/declval.h>
 #include <cuda/std/__utility/move.h>
@@ -93,8 +94,8 @@ template <class _Iter, class _Index>
 class permutation_iterator
 {
 private:
-  _Iter __iter_   = {};
-  _Index __index_ = {};
+  _Iter __iter_;
+  _Index __index_;
 
   // We need to factor these out because old gcc chokes with using arguments in friend functions
   template <class _Iter1>
@@ -142,7 +143,13 @@ public:
 
   //! @brief Default constructs an @c permutation_iterator with a value initialized iterator and index
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_HIDE_FROM_ABI constexpr permutation_iterator() = default;
+  _CCCL_TEMPLATE(class _Iter2 = _Iter, class _Index2 = _Index)
+  _CCCL_REQUIRES(::cuda::std::default_initializable<_Iter2> _CCCL_AND ::cuda::std::default_initializable<_Index2>)
+  _CCCL_API constexpr permutation_iterator() noexcept(
+    ::cuda::std::is_nothrow_default_constructible_v<_Iter2> && ::cuda::std::is_nothrow_default_constructible_v<_Index2>)
+      : __iter_()
+      , __index_()
+  {}
 
   //! @brief Constructs an @c permutation_iterator from an iterator and an optional index
   //! @param __iter The iterator to to index from

--- a/libcudacxx/include/cuda/__iterator/shuffle_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/shuffle_iterator.h
@@ -110,9 +110,9 @@ public:
   using pointer   = void;
 
   _CCCL_EXEC_CHECK_DISABLE // NVCC 12.0 fails to default construct when _CCCL_TEMPLATE is used
-  template <bool _IsDefaultConstructible                           = ::cuda::std::default_initializable<_Bijection>,
-            ::cuda::std::enable_if_t<_IsDefaultConstructible, int> = 0>
-  _CCCL_API constexpr shuffle_iterator()
+  template <class _Bijection2                                                              = _Bijection,
+            ::cuda::std::enable_if_t<::cuda::std::default_initializable<_Bijection2>, int> = 0>
+  _CCCL_API constexpr shuffle_iterator() noexcept(::cuda::std::is_nothrow_default_constructible_v<_Bijection2>)
       : __bijection_()
       , __current_(0)
   {}

--- a/libcudacxx/include/cuda/__iterator/shuffle_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/shuffle_iterator.h
@@ -44,6 +44,9 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
+_CCCL_BEGIN_NV_DIAG_SUPPRESS(20011) // calling a __host__ function from a __host__ __device__ function shuffle_iterator
+                                    // is not allowed
+
 //! @addtogroup iterators
 //! @{
 
@@ -154,6 +157,7 @@ public:
   }
 
   //! @brief Increments the @c permutation_iterator
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr shuffle_iterator& operator++() noexcept
   {
     ++__current_;
@@ -161,6 +165,7 @@ public:
   }
 
   //! @brief Increments the @c permutation_iterator
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr shuffle_iterator operator++(int) noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Bijection>)
   {
     auto __tmp = *this;
@@ -169,6 +174,7 @@ public:
   }
 
   //! @brief Decrements the @c permutation_iterator
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr shuffle_iterator& operator--() noexcept
   {
     --__current_;
@@ -176,6 +182,7 @@ public:
   }
 
   //! @brief Decrements the @c permutation_iterator
+  _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API constexpr shuffle_iterator
   operator--(int) noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Bijection>)
   {
@@ -186,6 +193,7 @@ public:
 
   //! @brief Advances the @c permutation_iterator by a given number of elements
   //! @param __n The number of elements to advance
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr shuffle_iterator& operator+=(difference_type __n) noexcept
   {
 #if _CCCL_COMPILER(MSVC) // C4308: negative integral constant converted to unsigned type
@@ -199,6 +207,7 @@ public:
   //! @brief Returns a copy of a @c shuffle_iterator incremented by a given number of elements
   //! @param __iter The @c shuffle_iterator to copy
   //! @param __n The number of elements to increment
+  _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API friend constexpr shuffle_iterator
   operator+(shuffle_iterator __iter, difference_type __n) noexcept
   {
@@ -213,6 +222,7 @@ public:
   //! @brief Returns a copy of a @c shuffle_iterator incremented by a given number of elements
   //! @param __n The number of elements to increment
   //! @param __iter The @c shuffle_iterator to copy
+  _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API friend constexpr shuffle_iterator
   operator+(difference_type __n, shuffle_iterator __iter) noexcept
   {
@@ -226,6 +236,7 @@ public:
 
   //! @brief Decrements the @c permutation_iterator by a given number of elements
   //! @param __n The number of elements to decrement
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr shuffle_iterator& operator-=(difference_type __n) noexcept
   {
 #if _CCCL_COMPILER(MSVC) // C4308: negative integral constant converted to unsigned type
@@ -239,6 +250,7 @@ public:
   //! @brief Returns a copy of a @c shuffle_iterator decremented by a given number of elements
   //! @param __iter The @c shuffle_iterator to copy
   //! @param __n The number of elements to decrement
+  _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API friend constexpr shuffle_iterator
   operator-(shuffle_iterator __iter, difference_type __n) noexcept
   {
@@ -333,6 +345,8 @@ template <class _Bijection, class _IndexType>
 }
 
 //! @}
+
+_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__iterator/shuffle_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/shuffle_iterator.h
@@ -92,8 +92,8 @@ template <class _IndexType, class _Bijection>
 class shuffle_iterator
 {
 private:
-  _Bijection __bijection_{};
-  _IndexType __current_{0};
+  _Bijection __bijection_;
+  _IndexType __current_;
 
   static_assert(::cuda::std::is_integral_v<_IndexType>, "_IndexType must be an integral type");
   static_assert(__is_bijection<_Bijection>, "_Bijection must be a valid bijection function");
@@ -109,8 +109,13 @@ public:
   using reference = _IndexType;
   using pointer   = void;
 
-  _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_HIDE_FROM_ABI constexpr shuffle_iterator() noexcept = default;
+  _CCCL_EXEC_CHECK_DISABLE // NVCC 12.0 fails to default construct when _CCCL_TEMPLATE is used
+  template <bool _IsDefaultConstructible                           = ::cuda::std::default_initializable<_Bijection>,
+            ::cuda::std::enable_if_t<_IsDefaultConstructible, int> = 0>
+  _CCCL_API constexpr shuffle_iterator()
+      : __bijection_()
+      , __current_(0)
+  {}
 
   //! @brief Constructs a @c shuffle_iterator from a given bijection and an optional start position
   //! @param __bijection The bijection representing the shuffled integer sequence
@@ -208,8 +213,9 @@ public:
   //! @param __iter The @c shuffle_iterator to copy
   //! @param __n The number of elements to increment
   _CCCL_EXEC_CHECK_DISABLE
-  [[nodiscard]] _CCCL_API friend constexpr shuffle_iterator
-  operator+(shuffle_iterator __iter, difference_type __n) noexcept
+  template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
+  [[nodiscard]]
+  _CCCL_API friend constexpr shuffle_iterator operator+(shuffle_iterator __iter, difference_type __n) noexcept
   {
 #if _CCCL_COMPILER(MSVC) // C4308: negative integral constant converted to unsigned type
     __iter.__current_ = static_cast<value_type>(static_cast<difference_type>(__iter.__current_) + __n);
@@ -223,8 +229,9 @@ public:
   //! @param __n The number of elements to increment
   //! @param __iter The @c shuffle_iterator to copy
   _CCCL_EXEC_CHECK_DISABLE
-  [[nodiscard]] _CCCL_API friend constexpr shuffle_iterator
-  operator+(difference_type __n, shuffle_iterator __iter) noexcept
+  template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
+  [[nodiscard]]
+  _CCCL_API friend constexpr shuffle_iterator operator+(difference_type __n, shuffle_iterator __iter) noexcept
   {
 #if _CCCL_COMPILER(MSVC) // C4308: negative integral constant converted to unsigned type
     __iter.__current_ = static_cast<value_type>(static_cast<difference_type>(__iter.__current_) + __n);
@@ -251,8 +258,9 @@ public:
   //! @param __iter The @c shuffle_iterator to copy
   //! @param __n The number of elements to decrement
   _CCCL_EXEC_CHECK_DISABLE
-  [[nodiscard]] _CCCL_API friend constexpr shuffle_iterator
-  operator-(shuffle_iterator __iter, difference_type __n) noexcept
+  template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
+  [[nodiscard]]
+  _CCCL_API friend constexpr shuffle_iterator operator-(shuffle_iterator __iter, difference_type __n) noexcept
   {
 #if _CCCL_COMPILER(MSVC) // C4308: negative integral constant converted to unsigned type
     __iter.__current_ = static_cast<value_type>(static_cast<difference_type>(__iter.__current_) - __n);

--- a/libcudacxx/include/cuda/__iterator/shuffle_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/shuffle_iterator.h
@@ -106,11 +106,13 @@ public:
   using reference = _IndexType;
   using pointer   = void;
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HIDE_FROM_ABI constexpr shuffle_iterator() noexcept = default;
 
   //! @brief Constructs a @c shuffle_iterator from a given bijection and an optional start position
   //! @param __bijection The bijection representing the shuffled integer sequence
   //! @param __start The position of the iterator in the shuffled integer sequence
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr shuffle_iterator(_Bijection __bijection, value_type __start = 0) noexcept(
     ::cuda::std::is_nothrow_move_constructible_v<_Bijection>)
       : __bijection_(::cuda::std::move(__bijection))
@@ -122,6 +124,7 @@ public:
   //! @param __num_elements The size of the bijection sequence
   //! @param __gen The random number generator to initialize the bijection
   //! @param __start The optional stating index of the @c shuffle_iterator in the bijection sequence
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _RNG> // constraining here breaks CTAD
   _CCCL_API explicit constexpr shuffle_iterator(value_type __num_elements, _RNG&& __gen, value_type __start = 0) //
     noexcept(::cuda::std::is_nothrow_constructible_v<_Bijection, value_type, _RNG>)
@@ -130,6 +133,7 @@ public:
   {}
 
   //! @brief Dereferences the @c shuffle_iterator by invoking the bijection with the stored index
+  _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API constexpr value_type operator*() const noexcept(noexcept(__bijection_(0)))
   {
     _CCCL_ASSERT(__current_ < static_cast<value_type>(__bijection_.size()),
@@ -140,6 +144,7 @@ public:
   //! @brief Subscripts the @c shuffle_iterator by invoking the bijection with the stored index advanced by a given
   //! number of elements
   //! @param __n The additional number of elements
+  _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API constexpr value_type operator[](difference_type __n) const noexcept(noexcept(__bijection_(0)))
   {
     _CCCL_ASSERT(static_cast<value_type>(static_cast<difference_type>(__current_) + __n)

--- a/libcudacxx/include/cuda/__iterator/strided_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/strided_iterator.h
@@ -246,8 +246,9 @@ public:
   //! @param __iter The @c strided_iterator to advance
   //! @param __n The number of steps to increment
   _CCCL_EXEC_CHECK_DISABLE
-  [[nodiscard]] _CCCL_API friend constexpr strided_iterator
-  operator+(const strided_iterator& __iter, difference_type __n) noexcept(
+  template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
+  [[nodiscard]]
+  _CCCL_API friend constexpr strided_iterator operator+(const strided_iterator& __iter, difference_type __n) noexcept(
     ::cuda::std::is_nothrow_copy_constructible_v<_Iter> && noexcept(::cuda::std::declval<const _Iter&>() + __n))
   {
     return strided_iterator{__iter.__iter() + __iter.stride() * __n, __iter.__stride()};
@@ -257,8 +258,9 @@ public:
   //! @param __n The number of steps to increment
   //! @param __iter The @c strided_iterator to advance
   _CCCL_EXEC_CHECK_DISABLE
-  [[nodiscard]] _CCCL_API friend constexpr strided_iterator
-  operator+(difference_type __n, const strided_iterator& __iter) noexcept(
+  template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
+  [[nodiscard]]
+  _CCCL_API friend constexpr strided_iterator operator+(difference_type __n, const strided_iterator& __iter) noexcept(
     ::cuda::std::is_nothrow_copy_constructible_v<_Iter> && noexcept(::cuda::std::declval<const _Iter&>() + __n))
   {
     return strided_iterator{__iter.__iter() + __iter.stride() * __n, __iter.__stride()};
@@ -279,8 +281,9 @@ public:
   //! @param __n The number of steps to decrement
   //! @param __iter The @c strided_iterator to decrement
   _CCCL_EXEC_CHECK_DISABLE
-  [[nodiscard]] _CCCL_API friend constexpr strided_iterator
-  operator-(const strided_iterator& __iter, difference_type __n) noexcept(
+  template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
+  [[nodiscard]]
+  _CCCL_API friend constexpr strided_iterator operator-(const strided_iterator& __iter, difference_type __n) noexcept(
     ::cuda::std::is_nothrow_copy_constructible_v<_Iter> && noexcept(::cuda::std::declval<const _Iter&>() - __n))
   {
     return strided_iterator{__iter.__iter() - __iter.stride() * __n, __iter.__stride()};

--- a/libcudacxx/include/cuda/__iterator/strided_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/strided_iterator.h
@@ -25,6 +25,7 @@
 #if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 #  include <cuda/std/__compare/three_way_comparable.h>
 #endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+#include <cuda/std/__concepts/constructible.h>
 #include <cuda/std/__concepts/equality_comparable.h>
 #include <cuda/std/__concepts/totally_ordered.h>
 #include <cuda/std/__iterator/iterator_traits.h>

--- a/libcudacxx/include/cuda/__iterator/strided_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/strided_iterator.h
@@ -242,14 +242,19 @@ public:
     return *this;
   }
 
+  template <class _Iter2>
+  static constexpr bool __nothrow_plus =
+    ::cuda::std::is_nothrow_copy_constructible_v<_Iter2>
+    && noexcept(::cuda::std::declval<const _Iter2&>() + difference_type());
+
   //! @brief Returns a copy of a @c strided_iterator incremented by a given number of steps
   //! @param __iter The @c strided_iterator to advance
   //! @param __n The number of steps to increment
   _CCCL_EXEC_CHECK_DISABLE
   template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
   [[nodiscard]]
-  _CCCL_API friend constexpr strided_iterator operator+(const strided_iterator& __iter, difference_type __n) noexcept(
-    ::cuda::std::is_nothrow_copy_constructible_v<_Iter> && noexcept(::cuda::std::declval<const _Iter&>() + __n))
+  _CCCL_API friend constexpr strided_iterator
+  operator+(const strided_iterator& __iter, difference_type __n) noexcept(__nothrow_plus<_Iter>)
   {
     return strided_iterator{__iter.__iter() + __iter.stride() * __n, __iter.__stride()};
   }
@@ -260,8 +265,8 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
   [[nodiscard]]
-  _CCCL_API friend constexpr strided_iterator operator+(difference_type __n, const strided_iterator& __iter) noexcept(
-    ::cuda::std::is_nothrow_copy_constructible_v<_Iter> && noexcept(::cuda::std::declval<const _Iter&>() + __n))
+  _CCCL_API friend constexpr strided_iterator
+  operator+(difference_type __n, const strided_iterator& __iter) noexcept(__nothrow_plus<_Iter>)
   {
     return strided_iterator{__iter.__iter() + __iter.stride() * __n, __iter.__stride()};
   }
@@ -277,14 +282,19 @@ public:
     return *this;
   }
 
+  template <class _Iter2>
+  static constexpr bool __nothrow_minus =
+    ::cuda::std::is_nothrow_copy_constructible_v<_Iter2>
+    && noexcept(::cuda::std::declval<const _Iter2&>() - difference_type());
+
   //! @brief Returns a copy of a @c strided_iterator decremented by a given number of steps
   //! @param __n The number of steps to decrement
   //! @param __iter The @c strided_iterator to decrement
   _CCCL_EXEC_CHECK_DISABLE
   template <int = 0> // Must be template, or the compiler complains about a nonliteral return type
   [[nodiscard]]
-  _CCCL_API friend constexpr strided_iterator operator-(const strided_iterator& __iter, difference_type __n) noexcept(
-    ::cuda::std::is_nothrow_copy_constructible_v<_Iter> && noexcept(::cuda::std::declval<const _Iter&>() - __n))
+  _CCCL_API friend constexpr strided_iterator
+  operator-(const strided_iterator& __iter, difference_type __n) noexcept(__nothrow_minus<_Iter>)
   {
     return strided_iterator{__iter.__iter() - __iter.stride() * __n, __iter.__stride()};
   }

--- a/libcudacxx/include/cuda/__iterator/tabulate_output_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/tabulate_output_iterator.h
@@ -159,6 +159,7 @@ public:
   //! @brief Constructs a @c tabulate_output_iterator with a given functor and an optional index
   //! @param __func the output function
   //! @param __index the position in the output sequence
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr tabulate_output_iterator(_Fn __func, _Index __index = 0) noexcept(
     ::cuda::std::is_nothrow_move_constructible_v<_Fn>)
       : __store_(__index, ::cuda::std::move(__func))
@@ -208,6 +209,7 @@ public:
   }
 
   //! @brief Increments the @c tabulate_output_iterator by incrementing the stored index
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr tabulate_output_iterator
   operator++(int) noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Fn>)
   {
@@ -224,6 +226,7 @@ public:
   }
 
   //! @brief Decrements the @c tabulate_output_iterator by decrementing the stored index
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr tabulate_output_iterator
   operator--(int) noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Fn>)
   {

--- a/libcudacxx/include/cuda/__iterator/tabulate_output_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/tabulate_output_iterator.h
@@ -202,6 +202,7 @@ public:
   }
 
   //! @brief Increments the @c tabulate_output_iterator by incrementing the stored index
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr tabulate_output_iterator& operator++() noexcept
   {
     ++__index();
@@ -219,6 +220,7 @@ public:
   }
 
   //! @brief Decrements the @c tabulate_output_iterator by decrementing the stored index
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr tabulate_output_iterator& operator--() noexcept
   {
     --__index();
@@ -237,6 +239,7 @@ public:
 
   //! @brief Returns a copy of this @c tabulate_output_iterator advanced a given number of elements
   //! @param __n The number of elements to advance
+  _CCCL_EXEC_CHECK_DISABLE
   template <int = 0> // Template because compiler will complain about non-literal return type if _Fn is not a literal
   [[nodiscard]] _CCCL_API friend constexpr tabulate_output_iterator
   operator+(const tabulate_output_iterator& __iter, difference_type __n) //
@@ -248,6 +251,7 @@ public:
   //! @brief Returns a copy of a @c tabulate_output_iterator advanced a given number of elements
   //! @param __n The number of elements to advance
   //! @param __iter The original @c tabulate_output_iterator
+  _CCCL_EXEC_CHECK_DISABLE
   template <int = 0> // Template because compiler will complain about non-literal return type if _Fn is not a literal
   [[nodiscard]] _CCCL_API friend constexpr tabulate_output_iterator
   operator+(difference_type __n, const tabulate_output_iterator& __iter) //
@@ -258,6 +262,7 @@ public:
 
   //! @brief Advances the @c tabulate_output_iterator by a given number of elements
   //! @param __n The number of elements to advance
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr tabulate_output_iterator& operator+=(difference_type __n) noexcept
   {
     __index() += __n;
@@ -266,6 +271,7 @@ public:
 
   //! @brief Returns a copy of this @c tabulate_output_iterator decremented a given number of elements
   //! @param __n The number of elements to decremented
+  _CCCL_EXEC_CHECK_DISABLE
   template <int = 0> // Template because compiler will complain about non-literal return type if _Fn is not a literal
   [[nodiscard]] _CCCL_API friend constexpr tabulate_output_iterator
   operator-(const tabulate_output_iterator& __iter, difference_type __n) //
@@ -278,11 +284,12 @@ public:
   [[nodiscard]] _CCCL_API friend constexpr difference_type
   operator-(const tabulate_output_iterator& __lhs, const tabulate_output_iterator& __rhs) noexcept
   {
-    return __rhs.__index() - __lhs.__index();
+    return __lhs.__index() - __rhs.__index();
   }
 
   //! @brief Decrements the @c tabulate_output_iterator by a given number of elements
   //! @param __n The number of elements to decrement
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr tabulate_output_iterator& operator-=(difference_type __n) noexcept
   {
     __index() -= __n;

--- a/libcudacxx/include/cuda/__iterator/tabulate_output_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/tabulate_output_iterator.h
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/__fwd/iterator.h>
+#include <cuda/std/__concepts/constructible.h>
 #include <cuda/std/__functional/invoke.h>
 #include <cuda/std/__iterator/concepts.h>
 #include <cuda/std/__iterator/iterator_traits.h>

--- a/libcudacxx/include/cuda/__iterator/zip_common.h
+++ b/libcudacxx/include/cuda/__iterator/zip_common.h
@@ -21,6 +21,7 @@
 #endif // no system header
 
 #include <cuda/__fwd/iterator.h>
+#include <cuda/std/__concepts/constructible.h>
 #include <cuda/std/__fwd/pair.h>
 #include <cuda/std/__fwd/tuple.h>
 #include <cuda/std/__iterator/concepts.h>

--- a/libcudacxx/include/cuda/__iterator/zip_transform_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_transform_iterator.h
@@ -26,6 +26,7 @@
 #  include <cuda/std/__compare/three_way_comparable.h>
 #endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 #include <cuda/__iterator/zip_common.h>
+#include <cuda/std/__concepts/constructible.h>
 #include <cuda/std/__concepts/convertible_to.h>
 #include <cuda/std/__concepts/equality_comparable.h>
 #include <cuda/std/__functional/invoke.h>

--- a/libcudacxx/include/cuda/__random/random_bijection.h
+++ b/libcudacxx/include/cuda/__random/random_bijection.h
@@ -48,37 +48,43 @@ private:
   static_assert(::cuda::std::is_convertible_v<_IndexType, typename _Bijection::index_type>,
                 "_IndexType must be convertible to _Bijection::index_type");
 
-  _Bijection __bijection{};
-  _IndexType __num_elements{};
+  _Bijection __bijection_;
+  _IndexType __num_elements_;
 
 public:
   using index_type = _IndexType;
 
-  _CCCL_HIDE_FROM_ABI constexpr random_bijection() noexcept = default;
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _Bijection2 = _Bijection)
+  _CCCL_REQUIRES(::cuda::std::default_initializable<_Bijection2>)
+  _CCCL_API constexpr random_bijection() noexcept(::cuda::std::is_nothrow_default_constructible_v<_Bijection2>)
+      : __bijection_()
+      , __num_elements_(0)
+  {}
 
   template <class _RNG>
   _CCCL_API constexpr random_bijection(_IndexType __num_elements, _RNG&& __gen) noexcept
-      : __bijection(__num_elements, ::cuda::std::forward<_RNG>(__gen))
-      , __num_elements(__num_elements)
+      : __bijection_(__num_elements, ::cuda::std::forward<_RNG>(__gen))
+      , __num_elements_(__num_elements)
   {}
 
   [[nodiscard]] _CCCL_API constexpr _IndexType operator()(_IndexType __n) const noexcept
   {
     // The initial index must be be in the range [0, __num_elemments]
-    // If __n < __num_elements Iterating a __bijection like this will always terminate.
-    // If __n >= __num_elements, then this may loop forever.
-    _CCCL_ASSERT(__n < __num_elements, "random_bijection::operator(): index out of range");
+    // If __n < __num_elements_ Iterating a __bijection_ like this will always terminate.
+    // If __n >= __num_elements_, then this may loop forever.
+    _CCCL_ASSERT(__n < __num_elements_, "random_bijection::operator(): index out of range");
     do
     {
-      __n = static_cast<_IndexType>(__bijection(__n));
-    } while (__n >= __num_elements);
+      __n = static_cast<_IndexType>(__bijection_(__n));
+    } while (__n >= __num_elements_);
 
     return __n;
   }
 
   [[nodiscard]] _CCCL_API constexpr _IndexType size() const noexcept
   {
-    return __num_elements;
+    return __num_elements_;
   }
 };
 

--- a/libcudacxx/include/cuda/__random/random_bijection.h
+++ b/libcudacxx/include/cuda/__random/random_bijection.h
@@ -23,8 +23,10 @@
 
 #include <cuda/__fwd/random.h>
 #include <cuda/__random/feistel_bijection.h>
+#include <cuda/std/__concepts/constructible.h>
 #include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_nothrow_default_constructible.h>
 #include <cuda/std/__utility/forward.h>
 #include <cuda/std/cstdint>
 

--- a/libcudacxx/include/cuda/std/__ranges/compressed_movable_box.h
+++ b/libcudacxx/include/cuda/std/__ranges/compressed_movable_box.h
@@ -56,6 +56,8 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+_CCCL_BEGIN_NV_DIAG_SUPPRESS(20011) // calling a __host__ function from a __host__ __device__ function is not allowed
+
 //! @brief Different alternatives for @c __compressed_box_base
 // This is effectively a __movable-box__ that does not rely on `[[no_unique_address]]`
 enum class __compressed_box_specialization
@@ -889,6 +891,8 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_movable_box<_Elem1, _Elem2, _Elem
     swap(__x.__get<2>(), __y.__get<2>());
   }
 };
+
+_CCCL_END_NV_DIAG_SUPPRESS()
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__ranges/compressed_movable_box.h
+++ b/libcudacxx/include/cuda/std/__ranges/compressed_movable_box.h
@@ -202,6 +202,8 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_storage
     _CCCL_API constexpr __storage(in_place_t, _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
         : __val_(::cuda::std::forward<_Args>(__args)...)
     {}
+
+    _CCCL_EXEC_CHECK_DISABLE
     _CCCL_API _CCCL_CONSTEXPR_CXX20 ~__storage() noexcept {}
   };
   __storage __storage_{};
@@ -463,6 +465,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_copy_assign_base<_Index, _Tp,
     copyable<_Tp> ? is_nothrow_copy_constructible_v<_Tp> && is_nothrow_copy_assignable_v<_Tp>
                   : is_nothrow_copy_constructible_v<_Tp>;
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API _CCCL_CONSTEXPR_CXX20 __compressed_box_copy_assign_base&
   operator=(const __compressed_box_copy_assign_base& __other) noexcept(__nothrow_copy_assignable)
   {
@@ -559,6 +562,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_move_assign_base<_Index, _Tp,
     movable<_Tp> ? is_nothrow_move_constructible_v<_Tp> && is_nothrow_move_assignable_v<_Tp>
                  : is_nothrow_move_constructible_v<_Tp>;
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API _CCCL_CONSTEXPR_CXX20 __compressed_box_move_assign_base&
   operator=(__compressed_box_move_assign_base&& __other) noexcept(__nothrow_move_assignable)
   {

--- a/libcudacxx/test/libcudacxx/cuda/iterators/constant_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/constant_iterator/host_only_types.pass.cpp
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include "host_device_types.h"
+#include "test_macros.h"
+
+void test()
+{
+  cuda::constant_iterator iter{host_only_type{42}};
+  assert(iter[1].val_ == 42);
+}
+
+int main(int arg, char** argv)
+{
+  NV_IF_TARGET(NV_IS_HOST, (test();))
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/constant_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/constant_iterator/host_only_types.pass.cpp
@@ -53,6 +53,7 @@ void test()
 
   {
     assert(iter1 + 1 == iter2);
+    assert(1 + iter1 == iter2);
     assert(iter1 - 1 != iter2);
     assert(iter2 - iter1 == 1);
   }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/constant_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/constant_iterator/host_only_types.pass.cpp
@@ -19,8 +19,58 @@
 
 void test()
 {
-  cuda::constant_iterator iter{host_only_type{42}};
-  assert(iter[1].val_ == 42);
+  {
+    using constant_iterator = cuda::constant_iterator<host_only_type, int>;
+
+    const constant_iterator default_constructed{};
+    constant_iterator value_constructed{host_only_type{}};
+
+    constant_iterator copy_constructed{default_constructed};
+    constant_iterator move_constructed{::cuda::std::move(value_constructed)};
+
+    [[maybe_unused]] constant_iterator copy_assigned{};
+    copy_assigned = copy_constructed;
+
+    [[maybe_unused]] constant_iterator move_assigned{};
+    move_assigned = ::cuda::std::move(move_constructed);
+
+    [[maybe_unused]] constant_iterator value_index_constructed{host_only_type{}, 42};
+  }
+
+  cuda::constant_iterator iter1{host_only_type{42}, 100};
+  const cuda::constant_iterator iter2{host_only_type{1337}, 101};
+  assert(iter1 != iter2);
+
+  {
+    assert(++iter1 == iter2);
+    assert(--iter1 != iter2);
+  }
+
+  {
+    assert(iter1++ != iter2);
+    assert(iter1-- == iter2);
+  }
+
+  {
+    assert(iter1 + 1 == iter2);
+    assert(iter1 - 1 != iter2);
+    assert(iter2 - iter1 == 1);
+  }
+
+  {
+    iter1 += 1;
+    assert(iter1 == iter2);
+    iter1 -= 1;
+    assert(iter1 != iter2);
+  }
+
+  {
+    assert(iter1[1] == host_only_type{42});
+    assert(*iter1 == host_only_type{42});
+
+    assert(iter2[1] == host_only_type{1337});
+    assert(*iter2 == host_only_type{1337});
+  }
 }
 
 int main(int arg, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/permutation_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/permutation_iterator/host_only_types.pass.cpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include <vector>
+
+#include "test_macros.h"
+
+void test()
+{
+  std::vector<int> vec{1, 2, 3, 0};
+  cuda::permutation_iterator iter{vec.begin(), vec.begin()};
+  assert(iter[1] == vec[vec[1]]);
+}
+
+int main(int arg, char** argv)
+{
+  NV_IF_TARGET(NV_IS_HOST, (test();))
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/permutation_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/permutation_iterator/host_only_types.pass.cpp
@@ -55,6 +55,7 @@ void test()
 
   {
     assert(iter1 + 1 == iter2);
+    assert(1 + iter1 == iter2);
     assert(iter1 - 1 != iter2);
     assert(iter2 - iter1 == 1);
   }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/permutation_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/permutation_iterator/host_only_types.pass.cpp
@@ -21,8 +21,68 @@
 void test()
 {
   std::vector<int> vec{1, 2, 3, 0};
-  cuda::permutation_iterator iter{vec.begin(), vec.begin()};
-  assert(iter[1] == vec[vec[1]]);
+
+  { // constructors
+    using Iter                 = typename std::vector<int>::iterator;
+    using permutation_iterator = cuda::permutation_iterator<Iter, Iter>;
+
+    const permutation_iterator default_constructed{};
+    permutation_iterator value_constructed{vec.begin(), vec.begin()};
+
+    permutation_iterator copy_constructed{default_constructed};
+    permutation_iterator move_constructed{::cuda::std::move(value_constructed)};
+
+    [[maybe_unused]] permutation_iterator copy_assigned{};
+    copy_assigned = copy_constructed;
+
+    [[maybe_unused]] permutation_iterator move_assigned{};
+    move_assigned = ::cuda::std::move(move_constructed);
+  }
+
+  cuda::permutation_iterator iter1{vec.begin(), vec.begin()};
+  const cuda::permutation_iterator iter2{vec.begin(), vec.begin() + 1};
+  assert(iter1 != iter2);
+
+  {
+    assert(++iter1 == iter2);
+    assert(--iter1 != iter2);
+  }
+
+  {
+    assert(iter1++ != iter2);
+    assert(iter1-- == iter2);
+  }
+
+  {
+    assert(iter1 + 1 == iter2);
+    assert(iter1 - 1 != iter2);
+    assert(iter2 - iter1 == 1);
+  }
+
+  {
+    iter1 += 1;
+    assert(iter1 == iter2);
+    iter1 -= 1;
+    assert(iter1 != iter2);
+  }
+
+  {
+    assert(iter1[1] == vec[vec[1]]);
+    assert(*iter1 == vec[vec[0]]);
+
+    assert(iter2[1] == vec[vec[2]]);
+    assert(*iter2 == vec[vec[1]]);
+  }
+
+  {
+    assert(iter1.base() == vec.begin());
+    assert(iter2.base() == vec.begin());
+  }
+
+  {
+    cuda::std::ranges::iter_swap(iter1, iter2);
+    assert(cuda::std::ranges::iter_move(iter1) == vec[vec[0]]);
+  }
 }
 
 int main(int arg, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/permutation_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/permutation_iterator/host_only_types.pass.cpp
@@ -14,16 +14,15 @@
 #include <cuda/iterator>
 #include <cuda/std/cassert>
 
-#include <vector>
-
+#include "host_device_types.h"
 #include "test_macros.h"
 
 void test()
 {
-  std::vector<int> vec{1, 2, 3, 0};
+  host_only_container vec{};
 
   { // constructors
-    using Iter                 = typename std::vector<int>::iterator;
+    using Iter                 = typename host_only_container::iterator;
     using permutation_iterator = cuda::permutation_iterator<Iter, Iter>;
 
     const permutation_iterator default_constructed{};

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/host_only_types.pass.cpp
@@ -23,8 +23,14 @@ struct host_bijection
   host_bijection() {}
   host_bijection(const host_bijection&) {}
   host_bijection(host_bijection&&) {}
-  host_bijection& operator=(const host_bijection&) {}
-  host_bijection& operator=(host_bijection&&) {}
+  host_bijection& operator=(const host_bijection&)
+  {
+    return *this;
+  }
+  host_bijection& operator=(host_bijection&&)
+  {
+    return *this;
+  }
   ~host_bijection() {}
 
   template <class RNG>

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/host_only_types.pass.cpp
@@ -53,7 +53,7 @@ struct host_bijection
 void test()
 {
   // taken from host_bijection
-  constexpr int random_indices[] = {4, 1, 2, 0, 3};
+  constexpr uint32_t random_indices[] = {4, 1, 2, 0, 3};
   cuda::shuffle_iterator iter{host_bijection{}};
   assert(iter[1] == random_indices[1]);
 }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/host_only_types.pass.cpp
@@ -90,6 +90,7 @@ void test()
 
   {
     assert(iter1 + 1 == iter2);
+    assert(1 + iter1 == iter2);
     assert(iter1 - 1 != iter2);
     assert(iter2 - iter1 == 1);
   }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/host_only_types.pass.cpp
@@ -54,8 +54,60 @@ void test()
 {
   // taken from host_bijection
   constexpr uint32_t random_indices[] = {4, 1, 2, 0, 3};
-  cuda::shuffle_iterator iter{host_bijection{}};
-  assert(iter[1] == random_indices[1]);
+
+  { // constructors
+    using shuffle_iterator = cuda::shuffle_iterator<int, host_bijection>;
+
+    const shuffle_iterator default_constructed{};
+    shuffle_iterator value_constructed{host_bijection{}};
+
+    shuffle_iterator copy_constructed{default_constructed};
+    shuffle_iterator move_constructed{::cuda::std::move(value_constructed)};
+
+    [[maybe_unused]] shuffle_iterator copy_assigned{};
+    copy_assigned = copy_constructed;
+
+    [[maybe_unused]] shuffle_iterator move_assigned{};
+    move_assigned = ::cuda::std::move(move_constructed);
+
+    [[maybe_unused]] shuffle_iterator bijection_value_constructed{host_bijection{}, 0};
+    [[maybe_unused]] shuffle_iterator size_bijection_value_constructed{4, host_bijection{}, 0};
+  }
+
+  cuda::shuffle_iterator iter1{host_bijection{}, 0};
+  const cuda::shuffle_iterator iter2{host_bijection{}, 1};
+  assert(iter1 != iter2);
+
+  {
+    assert(++iter1 == iter2);
+    assert(--iter1 != iter2);
+  }
+
+  {
+    assert(iter1++ != iter2);
+    assert(iter1-- == iter2);
+  }
+
+  {
+    assert(iter1 + 1 == iter2);
+    assert(iter1 - 1 != iter2);
+    assert(iter2 - iter1 == 1);
+  }
+
+  {
+    iter1 += 1;
+    assert(iter1 == iter2);
+    iter1 -= 1;
+    assert(iter1 != iter2);
+  }
+
+  {
+    assert(iter1[1] == random_indices[1]);
+    assert(*iter1 == random_indices[0]);
+
+    assert(iter2[1] == random_indices[2]);
+    assert(*iter2 == random_indices[1]);
+  }
 }
 
 int main(int arg, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/host_only_types.pass.cpp
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct host_bijection
+{
+  using index_type = uint32_t;
+
+  host_bijection() {}
+  host_bijection(const host_bijection&) {}
+  host_bijection(host_bijection&&) {}
+  host_bijection& operator=(const host_bijection&) {}
+  host_bijection& operator=(host_bijection&&) {}
+  ~host_bijection() {}
+
+  template <class RNG>
+  constexpr host_bijection(index_type, RNG&&) noexcept
+  {}
+
+  [[nodiscard]] constexpr index_type size() const noexcept
+  {
+    return 5;
+  }
+
+  [[nodiscard]] constexpr index_type operator()(index_type n) const noexcept
+  {
+    return __random_indices[n];
+  }
+
+  uint32_t __random_indices[5] = {4, 1, 2, 0, 3};
+};
+
+void test()
+{
+  // taken from host_bijection
+  constexpr int random_indices[] = {4, 1, 2, 0, 3};
+  cuda::shuffle_iterator iter{host_bijection{}};
+  assert(iter[1] == random_indices[1]);
+}
+
+int main(int arg, char** argv)
+{
+  NV_IF_TARGET(NV_IS_HOST, (test();))
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/host_only_types.pass.cpp
@@ -57,6 +57,7 @@ void test()
 
   {
     assert(iter1 + 1 == iter2);
+    assert(1 + iter1 == iter2);
     assert(iter1 - 1 != iter2);
     assert(iter2 - iter1 == 1);
   }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/host_only_types.pass.cpp
@@ -14,16 +14,14 @@
 #include <cuda/iterator>
 #include <cuda/std/cassert>
 
-#include <vector>
-
 #include "host_device_types.h"
 #include "test_macros.h"
 
 void test()
 {
-  std::vector<int> vec{1, 2, 3, 4, 5};
+  host_only_container vec{};
   {
-    using Iter             = typename std::vector<int>::iterator;
+    using Iter             = typename host_only_container::iterator;
     using strided_iterator = cuda::strided_iterator<Iter, ::std::integral_constant<int, 2>>;
 
     const strided_iterator default_constructed{};

--- a/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/host_only_types.pass.cpp
@@ -16,31 +16,33 @@
 
 #include <vector>
 
+#include "host_device_types.h"
 #include "test_macros.h"
 
 void test()
 {
-  std::vector<int> vec{1, 2, 3, 4};
-
+  std::vector<int> vec{1, 2, 3, 4, 5};
   {
-    using Iter         = typename std::vector<int>::iterator;
-    using zip_iterator = cuda::zip_iterator<Iter, Iter>;
+    using Iter             = typename std::vector<int>::iterator;
+    using strided_iterator = cuda::strided_iterator<Iter, ::std::integral_constant<int, 2>>;
 
-    const zip_iterator default_constructed{};
-    zip_iterator value_constructed{vec.begin(), vec.begin()};
+    const strided_iterator default_constructed{};
+    strided_iterator value_constructed{vec.begin()};
 
-    zip_iterator copy_constructed{default_constructed};
-    zip_iterator move_constructed{::cuda::std::move(value_constructed)};
+    strided_iterator copy_constructed{default_constructed};
+    strided_iterator move_constructed{::cuda::std::move(value_constructed)};
 
-    [[maybe_unused]] zip_iterator copy_assigned{};
+    [[maybe_unused]] strided_iterator copy_assigned{};
     copy_assigned = copy_constructed;
 
-    [[maybe_unused]] zip_iterator move_assigned{};
+    [[maybe_unused]] strided_iterator move_assigned{};
     move_assigned = ::cuda::std::move(move_constructed);
+
+    [[maybe_unused]] strided_iterator iter_stride_constructed{vec.begin(), ::std::integral_constant<int, 2>{}};
   }
 
-  cuda::zip_iterator iter1{vec.begin(), vec.begin() + 1};
-  const cuda::zip_iterator iter2{vec.begin() + 1, vec.begin() + 2};
+  cuda::strided_iterator iter1{vec.begin(), ::std::integral_constant<int, 2>{}};
+  const cuda::strided_iterator iter2{vec.begin() + 2, ::std::integral_constant<int, 2>{}};
   assert(iter1 != iter2);
 
   {
@@ -67,11 +69,11 @@ void test()
   }
 
   {
-    assert((iter1[1] == cuda::std::tuple{vec[1], vec[2]}));
-    assert((iter2[1] == cuda::std::tuple{vec[2], vec[3]}));
+    assert(iter1[1] == 3);
+    assert(*iter1 == 1);
 
-    assert((*iter1 == cuda::std::tuple{vec[0], vec[1]}));
-    assert((*iter2 == cuda::std::tuple{vec[1], vec[2]}));
+    assert(iter2[1] == 5);
+    assert(*iter2 == 3);
   }
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/host_only_types.pass.cpp
@@ -76,6 +76,7 @@ void test()
 
   {
     assert(iter1 + 1 == iter2);
+    assert(1 + iter1 == iter2);
     assert(iter1 - 1 != iter2);
     assert(iter2 - iter1 == 1);
   }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/host_only_types.pass.cpp
@@ -26,8 +26,14 @@ struct host_functor
   host_functor() {}
   host_functor(const host_functor&) {}
   host_functor(host_functor&&) {}
-  host_functor& operator=(const host_functor&) {}
-  host_functor& operator=(host_functor&&) {}
+  host_functor& operator=(const host_functor&)
+  {
+    return *this;
+  }
+  host_functor& operator=(host_functor&&)
+  {
+    return *this;
+  }
   ~host_functor() {}
 };
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/host_only_types.pass.cpp
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct host_functor
+{
+  void operator()(const cuda::std::ptrdiff_t val, const int expected) const noexcept
+  {
+    assert(val == expected); // asserts that the assigned value matches the index
+  }
+
+  host_functor() {}
+  host_functor(const host_functor&) {}
+  host_functor(host_functor&&) {}
+  host_functor& operator=(const host_functor&) {}
+  host_functor& operator=(host_functor&&) {}
+  ~host_functor() {}
+};
+
+void test()
+{
+  cuda::tabulate_output_iterator iter{host_functor{}, 10};
+  iter[1] = 1 + 10;
+}
+
+int main(int arg, char** argv)
+{
+  NV_IF_TARGET(NV_IS_HOST, (test();))
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/host_only_types.pass.cpp
@@ -42,8 +42,58 @@ struct host_functor
 
 void test()
 {
-  cuda::tabulate_output_iterator iter{host_functor{}, 10};
-  iter[1] = 1 + 10;
+  {
+    using tabulate_output_iterator = cuda::tabulate_output_iterator<host_functor, int>;
+
+    const tabulate_output_iterator default_constructed{};
+    tabulate_output_iterator value_constructed{host_functor{}};
+
+    tabulate_output_iterator copy_constructed{default_constructed};
+    tabulate_output_iterator move_constructed{::cuda::std::move(value_constructed)};
+
+    [[maybe_unused]] tabulate_output_iterator copy_assigned{};
+    copy_assigned = copy_constructed;
+
+    [[maybe_unused]] tabulate_output_iterator move_assigned{};
+    move_assigned = ::cuda::std::move(move_constructed);
+
+    [[maybe_unused]] tabulate_output_iterator func_index_constructed{host_functor{}, 42};
+  }
+
+  cuda::tabulate_output_iterator iter1{host_functor{}, 100};
+  const cuda::tabulate_output_iterator iter2{host_functor{}, 101};
+  assert(iter1 != iter2);
+
+  {
+    assert(++iter1 == iter2);
+    assert(--iter1 != iter2);
+  }
+
+  {
+    assert(iter1++ != iter2);
+    assert(iter1-- == iter2);
+  }
+
+  {
+    assert(iter1 + 1 == iter2);
+    assert(iter1 - 1 != iter2);
+    assert(iter2 - iter1 == 1);
+  }
+
+  {
+    iter1 += 1;
+    assert(iter1 == iter2);
+    iter1 -= 1;
+    assert(iter1 != iter2);
+  }
+
+  {
+    iter1[1] = 1 + 100;
+    *iter1   = 0 + 100;
+
+    iter2[1] = 1 + 101;
+    *iter2   = 0 + 101;
+  }
 }
 
 int main(int arg, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/host_only_types.pass.cpp
@@ -18,6 +18,9 @@
 
 struct host_functor
 {
+  // nvbug6163849: if the struct is empty NVCC fails with a host device access warning
+  int val_ = 0;
+
   void operator()(const cuda::std::ptrdiff_t val, const int expected) const noexcept
   {
     assert(val == expected); // asserts that the assigned value matches the index

--- a/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/minus.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/minus.pass.cpp
@@ -37,9 +37,9 @@ TEST_FUNC constexpr bool test()
   { // <iterator> - <iterator>
     cuda::tabulate_output_iterator iter1{func, 5};
     cuda::tabulate_output_iterator iter2{func, 10};
-    assert(iter1 - iter2 == 5);
+    assert(iter1 - iter2 == -5);
     assert(iter1 - iter1 == 0);
-    assert(iter2 - iter1 == -5);
+    assert(iter2 - iter1 == 5);
 
     static_assert(noexcept(iter1 - iter2));
     static_assert(cuda::std::same_as<decltype(iter1 - iter2), int>);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/host_only_types.pass.cpp
@@ -92,6 +92,7 @@ void test()
 
   {
     assert(iter1 + 1 == iter2);
+    assert(1 + iter1 == iter2);
     assert(iter1 - 1 != iter2);
     assert(iter2 - iter1 == 1);
   }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/host_only_types.pass.cpp
@@ -57,8 +57,75 @@ struct host_plus_value
 void test()
 {
   std::vector<int> vec{1, 2, 3, 4};
-  cuda::transform_input_output_iterator iter{vec.begin(), host_plus_value{42}, host_plus_value{42}};
-  assert(iter[1] == vec[1] + 42);
+
+  {
+    using Iter = typename std::vector<int>::iterator;
+    using transform_input_output_iterator =
+      cuda::transform_input_output_iterator<host_plus_value, host_plus_value, Iter>;
+
+    const transform_input_output_iterator default_constructed{};
+    transform_input_output_iterator value_constructed{vec.begin(), host_plus_value{42}, host_plus_value{1337}};
+
+    transform_input_output_iterator copy_constructed{default_constructed};
+    transform_input_output_iterator move_constructed{::cuda::std::move(value_constructed)};
+
+    [[maybe_unused]] transform_input_output_iterator copy_assigned{};
+    copy_assigned = copy_constructed;
+
+    [[maybe_unused]] transform_input_output_iterator move_assigned{};
+    move_assigned = ::cuda::std::move(move_constructed);
+  }
+
+  cuda::transform_input_output_iterator iter1{vec.begin(), host_plus_value{42}, host_plus_value{1337}};
+  const cuda::transform_input_output_iterator iter2{vec.begin() + 1, host_plus_value{42}, host_plus_value{1337}};
+  assert(iter1 != iter2);
+
+  {
+    assert(++iter1 == iter2);
+    assert(--iter1 != iter2);
+  }
+
+  {
+    assert(iter1++ != iter2);
+    assert(iter1-- == iter2);
+  }
+
+  {
+    assert(iter1 + 1 == iter2);
+    assert(iter1 - 1 != iter2);
+    assert(iter2 - iter1 == 1);
+  }
+
+  {
+    iter1 += 1;
+    assert(iter1 == iter2);
+    iter1 -= 1;
+    assert(iter1 != iter2);
+  }
+
+  {
+    assert(iter1[1] == vec[1] + 42);
+    assert(*iter1 == vec[0] + 42);
+  }
+
+  {
+    iter1[1] = 1;
+    assert(iter1[1] == (1337 + 1) + 42);
+
+    *iter1 = 2;
+    assert(*iter1 == (1337 + 2) + 42);
+
+    iter2[1] = 1;
+    assert(iter2[1] == (1337 + 1) + 42);
+
+    *iter2 = 2;
+    assert(*iter2 == (1337 + 2) + 42);
+  }
+
+  {
+    assert(iter1.base() == vec.begin());
+    assert(iter2.base() == vec.begin() + 1);
+  }
 }
 
 int main(int arg, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/host_only_types.pass.cpp
@@ -14,8 +14,7 @@
 #include <cuda/iterator>
 #include <cuda/std/cassert>
 
-#include <vector>
-
+#include "host_device_types.h"
 #include "test_macros.h"
 
 struct host_plus_value
@@ -56,10 +55,10 @@ struct host_plus_value
 
 void test()
 {
-  std::vector<int> vec{1, 2, 3, 4};
+  host_only_container vec{};
 
   {
-    using Iter = typename std::vector<int>::iterator;
+    using Iter = typename host_only_container::iterator;
     using transform_input_output_iterator =
       cuda::transform_input_output_iterator<host_plus_value, host_plus_value, Iter>;
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/host_only_types.pass.cpp
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include <vector>
+
+#include "test_macros.h"
+
+struct host_plus_value
+{
+  int value_;
+
+  host_plus_value(const int value = 42) noexcept
+      : value_(value)
+  {}
+
+  host_plus_value(const host_plus_value& other) noexcept
+      : value_(other.value_)
+  {}
+
+  host_plus_value(host_plus_value&& other) noexcept
+      : value_(other.value_)
+  {}
+
+  host_plus_value& operator=(const host_plus_value& other) noexcept
+  {
+    value_ = other.value_;
+    return *this;
+  }
+
+  host_plus_value& operator=(host_plus_value&& other) noexcept
+  {
+    value_ = other.value_;
+    return *this;
+  }
+
+  int operator()(const int& val) const noexcept
+  {
+    return val + value_;
+  }
+
+  ~host_plus_value() noexcept {}
+};
+
+void test()
+{
+  std::vector<int> vec{1, 2, 3, 4};
+  cuda::transform_input_output_iterator iter{vec.begin(), host_plus_value{42}, host_plus_value{42}};
+  assert(iter[1] == vec[1] + 42);
+}
+
+int main(int arg, char** argv)
+{
+  NV_IF_TARGET(NV_IS_HOST, (test();))
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/host_only_types.pass.cpp
@@ -57,8 +57,63 @@ struct host_plus_value
 void test()
 {
   std::vector<int> vec{1, 2, 3, 4};
-  cuda::transform_iterator iter{vec.begin(), host_plus_value{42}};
-  assert(iter[1] == vec[1] + 42);
+
+  {
+    using Iter               = typename std::vector<int>::iterator;
+    using transform_iterator = cuda::transform_iterator<host_plus_value, Iter>;
+
+    const transform_iterator default_constructed{};
+    transform_iterator value_constructed{vec.begin(), host_plus_value{42}};
+
+    transform_iterator copy_constructed{default_constructed};
+    transform_iterator move_constructed{::cuda::std::move(value_constructed)};
+
+    [[maybe_unused]] transform_iterator copy_assigned{};
+    copy_assigned = copy_constructed;
+
+    [[maybe_unused]] transform_iterator move_assigned{};
+    move_assigned = ::cuda::std::move(move_constructed);
+  }
+
+  cuda::transform_iterator iter1{vec.begin(), host_plus_value{42}};
+  const cuda::transform_iterator iter2{vec.begin() + 1, host_plus_value{42}};
+  assert(iter1 != iter2);
+
+  {
+    assert(++iter1 == iter2);
+    assert(--iter1 != iter2);
+  }
+
+  {
+    assert(iter1++ != iter2);
+    assert(iter1-- == iter2);
+  }
+
+  {
+    assert(iter1 + 1 == iter2);
+    assert(iter1 - 1 != iter2);
+    assert(iter2 - iter1 == 1);
+  }
+
+  {
+    iter1 += 1;
+    assert(iter1 == iter2);
+    iter1 -= 1;
+    assert(iter1 != iter2);
+  }
+
+  {
+    assert(iter1[1] == vec[1] + 42);
+    assert(*iter1 == vec[0] + 42);
+
+    assert(iter2[1] == vec[2] + 42);
+    assert(*iter2 == vec[1] + 42);
+  }
+
+  {
+    assert(iter1.base() == vec.begin());
+    assert(iter2.base() == vec.begin() + 1);
+  }
 }
 
 int main(int arg, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/host_only_types.pass.cpp
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include <vector>
+
+#include "test_macros.h"
+
+struct host_plus_value
+{
+  int value_;
+
+  host_plus_value(const int value = 42) noexcept
+      : value_(value)
+  {}
+
+  host_plus_value(const host_plus_value& other) noexcept
+      : value_(other.value_)
+  {}
+
+  host_plus_value(host_plus_value&& other) noexcept
+      : value_(other.value_)
+  {}
+
+  host_plus_value& operator=(const host_plus_value& other) noexcept
+  {
+    value_ = other.value_;
+    return *this;
+  }
+
+  host_plus_value& operator=(host_plus_value&& other) noexcept
+  {
+    value_ = other.value_;
+    return *this;
+  }
+
+  int operator()(const int& val) const noexcept
+  {
+    return val + value_;
+  }
+
+  ~host_plus_value() noexcept {}
+};
+
+void test()
+{
+  std::vector<int> vec{1, 2, 3, 4};
+  cuda::transform_iterator iter{vec.begin(), host_plus_value{42}};
+  assert(iter[1] == vec[1] + 42);
+}
+
+int main(int arg, char** argv)
+{
+  NV_IF_TARGET(NV_IS_HOST, (test();))
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/host_only_types.pass.cpp
@@ -14,8 +14,7 @@
 #include <cuda/iterator>
 #include <cuda/std/cassert>
 
-#include <vector>
-
+#include "host_device_types.h"
 #include "test_macros.h"
 
 struct host_plus_value
@@ -56,10 +55,10 @@ struct host_plus_value
 
 void test()
 {
-  std::vector<int> vec{1, 2, 3, 4};
+  host_only_container vec{};
 
   {
-    using Iter               = typename std::vector<int>::iterator;
+    using Iter               = typename host_only_container::iterator;
     using transform_iterator = cuda::transform_iterator<host_plus_value, Iter>;
 
     const transform_iterator default_constructed{};

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/host_only_types.pass.cpp
@@ -91,6 +91,7 @@ void test()
 
   {
     assert(iter1 + 1 == iter2);
+    assert(1 + iter1 == iter2);
     assert(iter1 - 1 != iter2);
     assert(iter2 - iter1 == 1);
   }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/host_only_types.pass.cpp
@@ -79,6 +79,7 @@ void test()
 
   {
     assert(iter1 + 1 == iter2);
+    assert(1 + iter1 == iter2);
     assert(iter1 - 1 != iter2);
     assert(iter2 - iter1 == 1);
   }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/host_only_types.pass.cpp
@@ -28,8 +28,14 @@ struct host_functor
   host_functor() {}
   host_functor(const host_functor&) {}
   host_functor(host_functor&&) {}
-  host_functor& operator=(const host_functor&) {}
-  host_functor& operator=(host_functor&&) {}
+  host_functor& operator=(const host_functor&)
+  {
+    return *this;
+  }
+  host_functor& operator=(host_functor&&)
+  {
+    return *this;
+  }
   ~host_functor() {}
 };
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/host_only_types.pass.cpp
@@ -45,9 +45,69 @@ struct host_functor
 void test()
 {
   std::vector<int> vec{1, 2, 3, 4};
-  cuda::transform_output_iterator iter{vec.begin(), host_functor{}};
-  iter[1] = 1337;
-  assert(vec[1] == 1337 + 42);
+
+  {
+    using Iter                      = typename std::vector<int>::iterator;
+    using transform_output_iterator = cuda::transform_output_iterator<host_functor, Iter>;
+
+    const transform_output_iterator default_constructed{};
+    transform_output_iterator value_constructed{vec.begin(), host_functor{}};
+
+    transform_output_iterator copy_constructed{default_constructed};
+    transform_output_iterator move_constructed{::cuda::std::move(value_constructed)};
+
+    [[maybe_unused]] transform_output_iterator copy_assigned{};
+    copy_assigned = copy_constructed;
+
+    [[maybe_unused]] transform_output_iterator move_assigned{};
+    move_assigned = ::cuda::std::move(move_constructed);
+  }
+
+  cuda::transform_output_iterator iter1{vec.begin(), host_functor{}};
+  const cuda::transform_output_iterator iter2{vec.begin() + 1, host_functor{}};
+  assert(iter1 != iter2);
+
+  {
+    assert(++iter1 == iter2);
+    assert(--iter1 != iter2);
+  }
+
+  {
+    assert(iter1++ != iter2);
+    assert(iter1-- == iter2);
+  }
+
+  {
+    assert(iter1 + 1 == iter2);
+    assert(iter1 - 1 != iter2);
+    assert(iter2 - iter1 == 1);
+  }
+
+  {
+    iter1 += 1;
+    assert(iter1 == iter2);
+    iter1 -= 1;
+    assert(iter1 != iter2);
+  }
+
+  {
+    iter1[1] = 1337;
+    assert(vec[1] == 1337 + 42);
+
+    *iter1 = 1337;
+    assert(vec[0] == 1337 + 42);
+
+    iter2[1] = 1;
+    assert(vec[2] == 1 + 42);
+
+    *iter2 = 1;
+    assert(vec[1] == 1 + 42);
+  }
+
+  {
+    assert(iter1.base() == vec.begin());
+    assert(iter2.base() == vec.begin() + 1);
+  }
 }
 
 int main(int arg, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/host_only_types.pass.cpp
@@ -14,8 +14,7 @@
 #include <cuda/iterator>
 #include <cuda/std/cassert>
 
-#include <vector>
-
+#include "host_device_types.h"
 #include "test_macros.h"
 
 struct host_functor
@@ -44,10 +43,10 @@ struct host_functor
 
 void test()
 {
-  std::vector<int> vec{1, 2, 3, 4};
+  host_only_container vec{};
 
   {
-    using Iter                      = typename std::vector<int>::iterator;
+    using Iter                      = typename host_only_container::iterator;
     using transform_output_iterator = cuda::transform_output_iterator<host_functor, Iter>;
 
     const transform_output_iterator default_constructed{};

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/host_only_types.pass.cpp
@@ -20,6 +20,9 @@
 
 struct host_functor
 {
+  // nvbug6163849: if the struct is empty NVCC fails with a host device access warning
+  int val_ = 0;
+
   int operator()(const int val) const noexcept
   {
     return val + 42;

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/host_only_types.pass.cpp
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include <vector>
+
+#include "test_macros.h"
+
+struct host_functor
+{
+  int operator()(const int val) const noexcept
+  {
+    return val + 42;
+  }
+
+  host_functor() {}
+  host_functor(const host_functor&) {}
+  host_functor(host_functor&&) {}
+  host_functor& operator=(const host_functor&) {}
+  host_functor& operator=(host_functor&&) {}
+  ~host_functor() {}
+};
+
+void test()
+{
+  std::vector<int> vec{1, 2, 3, 4};
+  cuda::transform_output_iterator iter{vec.begin(), host_functor{}};
+  iter[1] = 1337;
+  assert(vec[1] == 1337 + 42);
+}
+
+int main(int arg, char** argv)
+{
+  NV_IF_TARGET(NV_IS_HOST, (test();))
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/host_only_types.pass.cpp
@@ -14,16 +14,15 @@
 #include <cuda/iterator>
 #include <cuda/std/cassert>
 
-#include <vector>
-
+#include "host_device_types.h"
 #include "test_macros.h"
 
 void test()
 {
-  std::vector<int> vec{1, 2, 3, 4};
+  host_only_container vec{};
 
   {
-    using Iter         = typename std::vector<int>::iterator;
+    using Iter         = typename host_only_container::iterator;
     using zip_iterator = cuda::zip_iterator<Iter, Iter>;
 
     const zip_iterator default_constructed{};

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/host_only_types.pass.cpp
@@ -55,6 +55,7 @@ void test()
 
   {
     assert(iter1 + 1 == iter2);
+    assert(1 + iter1 == iter2);
     assert(iter1 - 1 != iter2);
     assert(iter2 - iter1 == 1);
   }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/host_only_types.pass.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include <vector>
+
+#include "test_macros.h"
+
+void test()
+{
+  std::vector<int> vec{1, 2, 3, 4};
+  cuda::zip_iterator iter{vec.begin(), vec.begin() + 1};
+  assert(cuda::std::get<0>(iter[1]) == vec[1]);
+  assert(cuda::std::get<1>(iter[1]) == vec[2]);
+}
+
+int main(int arg, char** argv)
+{
+  NV_IF_TARGET(NV_IS_HOST, (test();))
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_transform_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_transform_iterator/host_only_types.pass.cpp
@@ -14,8 +14,7 @@
 #include <cuda/iterator>
 #include <cuda/std/cassert>
 
-#include <vector>
-
+#include "host_device_types.h"
 #include "test_macros.h"
 
 struct host_plus_value
@@ -56,10 +55,10 @@ struct host_plus_value
 
 void test()
 {
-  std::vector<int> vec{1, 2, 3, 4};
+  host_only_container vec{};
 
   {
-    using Iter                   = typename std::vector<int>::iterator;
+    using Iter                   = typename host_only_container::iterator;
     using zip_transform_iterator = cuda::zip_transform_iterator<host_plus_value, Iter>;
 
     const zip_transform_iterator default_constructed{};

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_transform_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_transform_iterator/host_only_types.pass.cpp
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include <vector>
+
+#include "test_macros.h"
+
+struct host_plus_value
+{
+  int value_;
+
+  host_plus_value(const int value = 42) noexcept
+      : value_(value)
+  {}
+
+  host_plus_value(const host_plus_value& other) noexcept
+      : value_(other.value_)
+  {}
+
+  host_plus_value(host_plus_value&& other) noexcept
+      : value_(other.value_)
+  {}
+
+  host_plus_value& operator=(const host_plus_value& other) noexcept
+  {
+    value_ = other.value_;
+    return *this;
+  }
+
+  host_plus_value& operator=(host_plus_value&& other) noexcept
+  {
+    value_ = other.value_;
+    return *this;
+  }
+
+  int operator()(const int& val) const noexcept
+  {
+    return val + value_;
+  }
+
+  ~host_plus_value() noexcept {}
+};
+
+void test()
+{
+  std::vector<int> vec{1, 2, 3, 4};
+  cuda::zip_transform_iterator iter{host_plus_value{42}, vec.begin()};
+  assert(iter[1] == vec[1] + 42);
+}
+
+int main(int arg, char** argv)
+{
+  NV_IF_TARGET(NV_IS_HOST, (test();))
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_transform_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_transform_iterator/host_only_types.pass.cpp
@@ -57,8 +57,58 @@ struct host_plus_value
 void test()
 {
   std::vector<int> vec{1, 2, 3, 4};
-  cuda::zip_transform_iterator iter{host_plus_value{42}, vec.begin()};
-  assert(iter[1] == vec[1] + 42);
+
+  {
+    using Iter                   = typename std::vector<int>::iterator;
+    using zip_transform_iterator = cuda::zip_transform_iterator<host_plus_value, Iter>;
+
+    const zip_transform_iterator default_constructed{};
+    zip_transform_iterator value_constructed{host_plus_value{42}, vec.begin()};
+
+    zip_transform_iterator copy_constructed{default_constructed};
+    zip_transform_iterator move_constructed{::cuda::std::move(value_constructed)};
+
+    [[maybe_unused]] zip_transform_iterator copy_assigned{};
+    copy_assigned = copy_constructed;
+
+    [[maybe_unused]] zip_transform_iterator move_assigned{};
+    move_assigned = ::cuda::std::move(move_constructed);
+  }
+
+  cuda::zip_transform_iterator iter1{host_plus_value{42}, vec.begin()};
+  const cuda::zip_transform_iterator iter2{host_plus_value{42}, vec.begin() + 1};
+  assert(iter1 != iter2);
+
+  {
+    assert(++iter1 == iter2);
+    assert(--iter1 != iter2);
+  }
+
+  {
+    assert(iter1++ != iter2);
+    assert(iter1-- == iter2);
+  }
+
+  {
+    assert(iter1 + 1 == iter2);
+    assert(iter1 - 1 != iter2);
+    assert(iter2 - iter1 == 1);
+  }
+
+  {
+    iter1 += 1;
+    assert(iter1 == iter2);
+    iter1 -= 1;
+    assert(iter1 != iter2);
+  }
+
+  {
+    assert((iter1[1] == vec[1] + 42));
+    assert((iter2[1] == vec[2] + 42));
+
+    assert((*iter1 == vec[0] + 42));
+    assert((*iter2 == vec[1] + 42));
+  }
 }
 
 int main(int arg, char** argv)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_transform_iterator/host_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_transform_iterator/host_only_types.pass.cpp
@@ -91,6 +91,7 @@ void test()
 
   {
     assert(iter1 + 1 == iter2);
+    assert(1 + iter1 == iter2);
     assert(iter1 - 1 != iter2);
     assert(iter2 - iter1 == 1);
   }

--- a/libcudacxx/test/support/host_device_types.h
+++ b/libcudacxx/test/support/host_device_types.h
@@ -13,6 +13,7 @@
 #include <cuda/std/initializer_list>
 #include <cuda/std/utility>
 
+#include "test_iterators.h"
 #include "test_macros.h"
 
 #if !_CCCL_COMPILER(NVRTC)
@@ -77,6 +78,51 @@ struct host_only_type
   void swap(host_only_type& other) noexcept
   {
     cuda::std::swap(val_, other.val_);
+  }
+};
+
+struct host_only_container
+{
+  using iterator = host_only_iterator<int*>;
+
+  int data_[6] = {1, 2, 3, 4, 5, 6};
+
+  host_only_container() noexcept {}
+  host_only_container(const host_only_container&) noexcept {}
+  host_only_container(host_only_container&&) noexcept {}
+  host_only_container& operator=(const host_only_container&) noexcept
+  {
+    return *this;
+  }
+  host_only_container& operator=(host_only_container&&) noexcept
+  {
+    return *this;
+  }
+
+  host_only_iterator<int*> begin()
+  {
+    return host_only_iterator{data_};
+  }
+  host_only_iterator<const int*> begin() const
+  {
+    return host_only_iterator{data_};
+  }
+  host_only_iterator<int*> end()
+  {
+    return host_only_iterator{data_ + 6};
+  }
+  host_only_iterator<const int*> end() const
+  {
+    return host_only_iterator{data_ + 6};
+  }
+
+  int& operator[](const size_t index) noexcept
+  {
+    return data_[index];
+  }
+  const int& operator[](const size_t index) const noexcept
+  {
+    return data_[index];
   }
 };
 #endif // !_CCCL_COMPILER(NVRTC)


### PR DESCRIPTION
We had reports that `__compressed_movable_box` was not friendly to host only types that were not trivially destructible

This ensures that we add the proper execution suppression macros and also adds a bunch of tests to verify that the cuda iterators work with host only types

Fixes #8382
