### PR TITLE
[libcu++] Fix clang tidy in atomic headers

### DIFF
--- a/libcudacxx/include/cuda/std/__atomic/api/owned.h
+++ b/libcudacxx/include/cuda/std/__atomic/api/owned.h
@@ -45,7 +45,7 @@ struct __atomic_common
   __atomic_storage_t<_Tp> __a;
 
 #if defined(_CCCL_ATOMIC_ALWAYS_LOCK_FREE)
-  static constexpr bool is_always_lock_free = _CCCL_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), 0);
+  static constexpr bool is_always_lock_free = _CCCL_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), nullptr);
 #endif // defined(_CCCL_ATOMIC_ALWAYS_LOCK_FREE)
 
   _LIBCUDACXX_ATOMIC_COMMON_IMPL(, )
@@ -64,7 +64,7 @@ struct __atomic_arithmetic
   __atomic_storage_t<_Tp> __a;
 
 #if defined(_CCCL_ATOMIC_ALWAYS_LOCK_FREE)
-  static constexpr bool is_always_lock_free = _CCCL_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), 0);
+  static constexpr bool is_always_lock_free = _CCCL_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), nullptr);
 #endif // defined(_CCCL_ATOMIC_ALWAYS_LOCK_FREE)
 
   _LIBCUDACXX_ATOMIC_COMMON_IMPL(, )
@@ -86,7 +86,7 @@ struct __atomic_bitwise
   __atomic_storage_t<_Tp> __a;
 
 #if defined(_CCCL_ATOMIC_ALWAYS_LOCK_FREE)
-  static constexpr bool is_always_lock_free = _CCCL_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), 0);
+  static constexpr bool is_always_lock_free = _CCCL_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), nullptr);
 #endif // defined(_CCCL_ATOMIC_ALWAYS_LOCK_FREE)
 
   _LIBCUDACXX_ATOMIC_COMMON_IMPL(, )
@@ -111,7 +111,7 @@ struct __atomic_pointer
   __atomic_storage_t<_Tp> __a;
 
 #if defined(_CCCL_ATOMIC_ALWAYS_LOCK_FREE)
-  static constexpr bool is_always_lock_free = _CCCL_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), 0);
+  static constexpr bool is_always_lock_free = _CCCL_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), nullptr);
 #endif // defined(_CCCL_ATOMIC_ALWAYS_LOCK_FREE)
 
   _LIBCUDACXX_ATOMIC_COMMON_IMPL(, )

--- a/libcudacxx/include/cuda/std/__atomic/api/reference.h
+++ b/libcudacxx/include/cuda/std/__atomic/api/reference.h
@@ -43,7 +43,7 @@ struct __atomic_ref_common
   __atomic_ref_storage<_Tp> __a;
 
 #if defined(_CCCL_ATOMIC_ALWAYS_LOCK_FREE)
-  static constexpr bool is_always_lock_free = _CCCL_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), 0);
+  static constexpr bool is_always_lock_free = _CCCL_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), nullptr);
 #endif // defined(_CCCL_ATOMIC_ALWAYS_LOCK_FREE)
 
   _LIBCUDACXX_ATOMIC_COMMON_IMPL(const, )
@@ -59,7 +59,7 @@ struct __atomic_ref_arithmetic
   __atomic_ref_storage<_Tp> __a;
 
 #if defined(_CCCL_ATOMIC_ALWAYS_LOCK_FREE)
-  static constexpr bool is_always_lock_free = _CCCL_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), 0);
+  static constexpr bool is_always_lock_free = _CCCL_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), nullptr);
 #endif // defined(_CCCL_ATOMIC_ALWAYS_LOCK_FREE)
 
   _LIBCUDACXX_ATOMIC_COMMON_IMPL(const, )
@@ -76,7 +76,7 @@ struct __atomic_ref_bitwise
   __atomic_ref_storage<_Tp> __a;
 
 #if defined(_CCCL_ATOMIC_ALWAYS_LOCK_FREE)
-  static constexpr bool is_always_lock_free = _CCCL_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), 0);
+  static constexpr bool is_always_lock_free = _CCCL_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), nullptr);
 #endif // defined(_CCCL_ATOMIC_ALWAYS_LOCK_FREE)
 
   _LIBCUDACXX_ATOMIC_COMMON_IMPL(const, )
@@ -94,7 +94,7 @@ struct __atomic_ref_pointer
   __atomic_ref_storage<_Tp> __a;
 
 #if defined(_CCCL_ATOMIC_ALWAYS_LOCK_FREE)
-  static constexpr bool is_always_lock_free = _CCCL_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), 0);
+  static constexpr bool is_always_lock_free = _CCCL_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), nullptr);
 #endif // defined(_CCCL_ATOMIC_ALWAYS_LOCK_FREE)
 
   _LIBCUDACXX_ATOMIC_COMMON_IMPL(const, )

--- a/libcudacxx/include/cuda/std/__atomic/platform.h
+++ b/libcudacxx/include/cuda/std/__atomic/platform.h
@@ -72,7 +72,7 @@ struct __atomic_is_always_lock_free
 {
   enum
   {
-    __value = _CCCL_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), 0)
+    __value = _CCCL_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), nullptr)
   };
 };
 #else


### PR DESCRIPTION
Somehow https://github.com/NVIDIA/cccl/pull/8802 fails on clang-tidy in atomic headers. This PR fixes the issue it was complaining about. We always pass nullptr to that macro, should we just remove the macro argument?