### PR TITLE
[CUB] Do not use raw kernels

### DIFF
--- a/cub/cub/device/dispatch/dispatch_find.cuh
+++ b/cub/cub/device/dispatch/dispatch_find.cuh
@@ -40,7 +40,7 @@ CUB_NAMESPACE_BEGIN
 namespace detail::find
 {
 template <typename ValueType, typename OffsetT>
-__launch_bounds__(1) __global__ void init_found_pos_pointer(ValueType* found_pos_ptr, OffsetT num_items)
+__launch_bounds__(1) _CCCL_KERNEL_ATTRIBUTES void init_found_pos_pointer(ValueType* found_pos_ptr, OffsetT num_items)
 {
   // we immediately trigger launching the find kernel, before waiting for a previous kernel
   _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
@@ -72,8 +72,8 @@ __launch_bounds__(int(current_policy<PolicySelector>().threads_per_block)) _CCCL
 }
 
 template <typename ValueType, typename OutputIteratorT>
-__launch_bounds__(1) __global__
-  void copy_final_result_to_output_iterator(ValueType* found_pos_ptr, OutputIteratorT d_out)
+__launch_bounds__(1)
+  _CCCL_KERNEL_ATTRIBUTES void copy_final_result_to_output_iterator(ValueType* found_pos_ptr, OutputIteratorT d_out)
 {
   _CCCL_PDL_GRID_DEPENDENCY_SYNC();
   *d_out = *found_pos_ptr;

--- a/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
@@ -123,8 +123,8 @@ __launch_bounds__(int(
     KParameterT,
     SelectDirectionParameterT,
     NumSegmentsParameterT,
-    LargeSegmentTileOffsetT>::policy.worker_per_segment_policy.threads_per_block)) __global__
-  void device_segmented_topk_kernel(
+    LargeSegmentTileOffsetT>::policy.worker_per_segment_policy.threads_per_block))
+  _CCCL_KERNEL_ATTRIBUTES void device_segmented_topk_kernel(
     KeyInputItItT d_key_segments_it,
     KeyOutputItItT d_key_segments_out_it,
     ValueInputItItT d_value_segments_it,

--- a/cub/cub/grid/grid_queue.cuh
+++ b/cub/cub/grid/grid_queue.cuh
@@ -191,7 +191,7 @@ public:
  * Reset grid queue (call with 1 block of 1 thread)
  */
 template <typename OffsetT>
-__global__ void FillAndResetDrainKernel(GridQueue<OffsetT> grid_queue, OffsetT num_items)
+_CCCL_KERNEL_ATTRIBUTES void FillAndResetDrainKernel(GridQueue<OffsetT> grid_queue, OffsetT num_items)
 {
   grid_queue.FillAndResetDrain(num_items);
 }

--- a/libcudacxx/include/cuda/__launch/launch.h
+++ b/libcudacxx/include/cuda/__launch/launch.h
@@ -291,7 +291,7 @@ inline constexpr bool __invoke_kernel_functor_with_config_v =
 // 3. Fallback without any attributes.
 
 template <class _Config, class _Kernel, class... _Args>
-__global__ static void
+_CCCL_KERNEL_ATTRIBUTES static void
 // todo(dabayer): Re-enable this once cuda::launch with kernels that were compiled with .blocksareclusters directive is
 // fixed.
 //
@@ -316,8 +316,9 @@ __kernel_launcher_with_block_size(const _CCCL_GRID_CONSTANT _Config __conf, _Ker
 }
 
 template <class _Config, class _Kernel, class... _Args>
-__global__ static void _CCCL_LAUNCH_BOUNDS(::cuda::__max_nthreads_per_block<typename _Config::hierarchy_type>())
-__kernel_launcher_with_launch_bounds(const _CCCL_GRID_CONSTANT _Config __conf, _Kernel __kernel_fn, _Args... __args)
+_CCCL_KERNEL_ATTRIBUTES static void
+  _CCCL_LAUNCH_BOUNDS(::cuda::__max_nthreads_per_block<typename _Config::hierarchy_type>())
+  __kernel_launcher_with_launch_bounds(const _CCCL_GRID_CONSTANT _Config __conf, _Kernel __kernel_fn, _Args... __args)
 {
   ::cuda::__assume_known_info<typename _Config::hierarchy_type>();
 
@@ -332,7 +333,8 @@ __kernel_launcher_with_launch_bounds(const _CCCL_GRID_CONSTANT _Config __conf, _
 }
 
 template <class _Config, class _Kernel, class... _Args>
-__global__ static void __kernel_launcher(const _CCCL_GRID_CONSTANT _Config __conf, _Kernel __kernel_fn, _Args... __args)
+_CCCL_KERNEL_ATTRIBUTES static void
+__kernel_launcher(const _CCCL_GRID_CONSTANT _Config __conf, _Kernel __kernel_fn, _Args... __args)
 {
   ::cuda::__assume_known_info<typename _Config::hierarchy_type>();
 


### PR DESCRIPTION
we should not use raw `__global__` but always use `_CCCL_KERNEL_ATTRIBUTES`
