### PR TITLE
Do not override accumulator type in reduce benchmarks

### DIFF
--- a/cub/benchmarks/bench/reduce/base.cuh
+++ b/cub/benchmarks/bench/reduce/base.cuh
@@ -46,28 +46,6 @@ void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   state.add_global_memory_reads<T>(elements, "Size");
   state.add_global_memory_writes<T>(1);
 
-  // FIXME(bgruber): the previous implementation did target cub::DispatchReduce, and provided T as accumulator type.
-  // This is not realistic, since a user cannot override the accumulator type the same way at the public API. For
-  // example, reducing I8 over cuda::std::plus deduces accumulator type I32 at the public API, but the benchmark forces
-  // it to I8. This skews the MemBoundScaling, leading to 20% regression for the same tuning when the public API is
-  // called (with accum_t I32) over the benchmark (forced accum_t of I8). See also:
-  // https://github.com/NVIDIA/cccl/issues/6576
-#if 0
-  auto mr = cuda::device_default_memory_pool(cuda::devices[0]);
-  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    auto env = ::cuda::std::execution::env{
-      ::cuda::stream_ref{launch.get_stream().get_stream()},
-      mr
-#  if !TUNE_BASE
-      ,
-      ::cuda::execution::tune(policy_selector<T>{})
-#  endif
-    };
-    static_assert(::cuda::std::execution::__queryable_with<decltype(env), ::cuda::mr::__get_memory_resource_t>);
-    (void) cub::DeviceReduce::Reduce(d_in, d_out, elements, op_t{}, init_t{}, env);
-  });
-#endif
-
   // So for now, we have to call into the dispatcher again to override the accumulator type:
   auto transform_op = ::cuda::std::identity{};
 

--- a/cub/benchmarks/bench/reduce/base.cuh
+++ b/cub/benchmarks/bench/reduce/base.cuh
@@ -72,7 +72,7 @@ void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   auto transform_op = ::cuda::std::identity{};
 
   std::size_t temp_size;
-  cub::detail::reduce::dispatch</* OverrideAccumT = */ T>(
+  cub::detail::reduce::dispatch(
     nullptr,
     temp_size,
     d_in,
@@ -92,7 +92,7 @@ void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   auto* temp_storage = thrust::raw_pointer_cast(temp.data());
 
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::reduce::dispatch</* OverrideAccumT = */ T>(
+    cub::detail::reduce::dispatch(
       temp_storage,
       temp_size,
       d_in,

--- a/cub/benchmarks/bench/reduce/deterministic.cu
+++ b/cub/benchmarks/bench/reduce/deterministic.cu
@@ -54,7 +54,7 @@ void deterministic_sum(nvbench::state& state, nvbench::type_list<T>)
       d_in,
       d_out,
       elements,
-      {},
+      init_t{},
       launch.get_stream(),
       transform_t{}
 #if !TUNE_BASE

--- a/cub/benchmarks/bench/reduce/deterministic.cu
+++ b/cub/benchmarks/bench/reduce/deterministic.cu
@@ -26,11 +26,7 @@ struct policy_selector_t
 template <class T>
 void deterministic_sum(nvbench::state& state, nvbench::type_list<T>)
 {
-  using input_it_t  = const T*;
-  using output_it_t = T*;
-
   using init_t      = T;
-  using accum_t     = T;
   using transform_t = ::cuda::std::identity;
 
   const auto elements = static_cast<int>(state.get_int64("Elements{io}"));
@@ -38,33 +34,34 @@ void deterministic_sum(nvbench::state& state, nvbench::type_list<T>)
   thrust::device_vector<T> in = generate(elements);
   thrust::device_vector<T> out(1);
 
-  input_it_t d_in   = thrust::raw_pointer_cast(in.data());
-  output_it_t d_out = thrust::raw_pointer_cast(out.data());
+  const T* d_in = thrust::raw_pointer_cast(in.data());
+  T* d_out      = thrust::raw_pointer_cast(out.data());
   state.add_element_count(elements);
   state.add_global_memory_reads<T>(elements, "Size");
   state.add_global_memory_writes<T>(out.size());
 
   std::size_t temp_storage_bytes{};
-  // we explicitly provide template arguments to override accum_t
-  cub::detail::rfa::dispatch<input_it_t, output_it_t, int, init_t, transform_t, accum_t>(
-    nullptr, temp_storage_bytes, d_in, d_out, elements, init_t{}, /* stream */ nullptr);
+  cub::detail::rfa::dispatch(
+    nullptr, temp_storage_bytes, d_in, d_out, elements, init_t{}, /* stream */ nullptr, transform_t{});
 
   thrust::device_vector<nvbench::uint8_t> temp_storage(temp_storage_bytes);
   auto* d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
 
   state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    cub::detail::rfa::dispatch<
-      input_it_t,
-      output_it_t,
-      int,
-      init_t,
-      transform_t,
-      accum_t
+    cub::detail::rfa::dispatch(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_in,
+      d_out,
+      elements,
+      {},
+      launch.get_stream(),
+      transform_t{}
 #if !TUNE_BASE
       ,
-      policy_selector_t
+      policy_selector_t{}
 #endif // !TUNE_BASE
-      >(d_temp_storage, temp_storage_bytes, d_in, d_out, elements, {}, launch.get_stream());
+    );
   });
 }
 

--- a/cub/benchmarks/bench/reduce/nondeterministic.cu
+++ b/cub/benchmarks/bench/reduce/nondeterministic.cu
@@ -57,7 +57,7 @@ void nondeterministic_sum(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 
   // Allocate temporary storage:
   std::size_t temp_size;
-  cub::detail::reduce_nondeterministic::dispatch</* OverrideAccumT = */ T>(
+  cub::detail::reduce_nondeterministic::dispatch(
     nullptr,
     temp_size,
     d_in,
@@ -77,7 +77,7 @@ void nondeterministic_sum(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   auto* temp_storage = thrust::raw_pointer_cast(temp.data());
 
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::reduce_nondeterministic::dispatch</* OverrideAccumT = */ T>(
+    cub::detail::reduce_nondeterministic::dispatch(
       temp_storage,
       temp_size,
       d_in,

--- a/cub/benchmarks/bench/transform_reduce/sum.cu
+++ b/cub/benchmarks/bench/transform_reduce/sum.cu
@@ -57,7 +57,7 @@ void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 
   // Allocate temporary storage:
   std::size_t temp_size;
-  cub::detail::reduce::dispatch</* OverrideAccumT = */ T>(
+  cub::detail::reduce::dispatch(
     nullptr,
     temp_size,
     d_in,
@@ -77,7 +77,7 @@ void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   auto* temp_storage = thrust::raw_pointer_cast(temp.data());
 
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::reduce::dispatch</* OverrideAccumT = */ T>(
+    cub::detail::reduce::dispatch(
       temp_storage,
       temp_size,
       d_in,


### PR DESCRIPTION
CUB's benchmark hardcoded the value type as the accumulator type, which is what Thrust does, but not what a user would typically get at CUB's public API. Not only does this waste tuning effort, since the found tunings do not apply to how users use the API, it also inhibits evolution like using CUB's public API in benchmarks. This PR fixes this, but it changes the performance reported by the benchmarks since they now cover a different workload.

Here is the performance impact caused by this change. Note that a regression does not mean any CUB algorithm got slower. We are just changing the workload of the benchmark. That means a comparison is actually meaningless. However, people and QA may notice a change in their results over time, so I provide the numbers here which they should expect:

`cub.bench.reduce.sum.base`
```
## [0] NVIDIA H200 NVL

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   7.048 us |       6.61% |   6.871 us |       5.66% | -0.177 us |  -2.51% |  🔵 SAME  |
|   I8    |      I32      |      2^20      |   8.015 us |       4.70% |   8.057 us |       8.55% |  0.042 us |   0.53% |  🔵 SAME  |
|   I8    |      I32      |      2^24      |  14.611 us |       3.55% |  14.029 us |       3.51% | -0.583 us |  -3.99% |  🟢 FAST  |
|   I8    |      I32      |      2^28      |  81.245 us |       2.55% |  82.623 us |       2.89% |  1.378 us |   1.70% |  🔵 SAME  |
|   I8    |      I64      |      2^16      |   7.543 us |       4.20% |   7.265 us |       4.04% | -0.277 us |  -3.68% |  🔵 SAME  |
|   I8    |      I64      |      2^20      |   8.100 us |       4.21% |   7.934 us |       4.36% | -0.166 us |  -2.05% |  🔵 SAME  |
|   I8    |      I64      |      2^24      |  14.707 us |       3.92% |  14.019 us |       3.77% | -0.688 us |  -4.68% |  🟢 FAST  |
|   I8    |      I64      |      2^28      |  82.154 us |       2.85% |  83.247 us |       2.76% |  1.093 us |   1.33% |  🔵 SAME  |
|   I16   |      I32      |      2^16      |   7.469 us |       6.18% |   7.204 us |       5.92% | -0.264 us |  -3.54% |  🔵 SAME  |
|   I16   |      I32      |      2^20      |   8.513 us |       7.05% |   8.240 us |       4.99% | -0.273 us |  -3.21% |  🔵 SAME  |
|   I16   |      I32      |      2^24      |  20.282 us |       2.92% |  19.250 us |       3.16% | -1.032 us |  -5.09% |  🟢 FAST  |
|   I16   |      I32      |      2^28      | 141.263 us |       2.48% | 141.356 us |       2.48% |  0.094 us |   0.07% |  🔵 SAME  |
|   I16   |      I64      |      2^16      |   7.576 us |       4.19% |   7.330 us |       4.84% | -0.246 us |  -3.24% |  🔵 SAME  |
|   I16   |      I64      |      2^20      |   8.662 us |       5.26% |   8.487 us |       4.36% | -0.175 us |  -2.02% |  🔵 SAME  |
|   I16   |      I64      |      2^24      |  20.373 us |       2.94% |  19.273 us |       3.15% | -1.100 us |  -5.40% |  🟢 FAST  |
|   I16   |      I64      |      2^28      | 141.953 us |       2.51% | 141.580 us |       2.39% | -0.372 us |  -0.26% |  🔵 SAME  |
|   I32   |      I32      |      2^16      |   7.600 us |       4.30% |   7.617 us |       4.37% |  0.018 us |   0.23% |  🔵 SAME  |
|   I32   |      I32      |      2^20      |   9.242 us |       4.32% |   9.253 us |       4.19% |  0.011 us |   0.12% |  🔵 SAME  |
|   I32   |      I32      |      2^24      |  29.453 us |       2.65% |  29.506 us |       2.67% |  0.054 us |   0.18% |  🔵 SAME  |
|   I32   |      I32      |      2^28      | 260.999 us |       1.98% | 261.077 us |       2.13% |  0.078 us |   0.03% |  🔵 SAME  |
|   I32   |      I64      |      2^16      |   7.623 us |       5.89% |   7.620 us |       5.78% | -0.002 us |  -0.03% |  🔵 SAME  |
|   I32   |      I64      |      2^20      |   9.284 us |       4.21% |   9.297 us |       4.40% |  0.014 us |   0.15% |  🔵 SAME  |
|   I32   |      I64      |      2^24      |  29.436 us |       2.80% |  29.456 us |       2.74% |  0.020 us |   0.07% |  🔵 SAME  |
|   I32   |      I64      |      2^28      | 261.191 us |       2.16% | 260.953 us |       1.98% | -0.238 us |  -0.09% |  🔵 SAME  |
|   I64   |      I32      |      2^16      |   7.649 us |       5.60% |   7.671 us |       6.06% |  0.022 us |   0.29% |  🔵 SAME  |
|   I64   |      I32      |      2^20      |  10.971 us |       3.68% |  10.964 us |       4.35% | -0.007 us |  -0.07% |  🔵 SAME  |
|   I64   |      I32      |      2^24      |  48.279 us |       1.88% |  48.233 us |       1.88% | -0.046 us |  -0.09% |  🔵 SAME  |
|   I64   |      I32      |      2^28      | 505.879 us |       1.46% | 505.769 us |       1.49% | -0.109 us |  -0.02% |  🔵 SAME  |
|   I64   |      I64      |      2^16      |   7.524 us |       5.70% |   7.524 us |       4.33% |  0.000 us |   0.00% |  🔵 SAME  |
|   I64   |      I64      |      2^20      |  11.046 us |       3.71% |  11.019 us |       3.64% | -0.027 us |  -0.24% |  🔵 SAME  |
|   I64   |      I64      |      2^24      |  48.299 us |       1.93% |  48.443 us |       1.89% |  0.144 us |   0.30% |  🔵 SAME  |
|   I64   |      I64      |      2^28      | 505.814 us |       1.44% | 506.144 us |       1.52% |  0.330 us |   0.07% |  🔵 SAME  |
|  I128   |      I32      |      2^16      |   8.540 us |       4.64% |   8.603 us |       5.28% |  0.064 us |   0.74% |  🔵 SAME  |
|  I128   |      I32      |      2^20      |  18.026 us |       3.22% |  17.870 us |       2.73% | -0.156 us |  -0.86% |  🔵 SAME  |
|  I128   |      I32      |      2^24      |  98.238 us |       1.00% |  98.177 us |       1.06% | -0.061 us |  -0.06% |  🔵 SAME  |
|  I128   |      I32      |      2^28      |   1.053 ms |       1.03% |   1.053 ms |       1.04% | -0.016 us |  -0.00% |  🔵 SAME  |
|  I128   |      I64      |      2^16      |   8.665 us |       4.00% |   8.664 us |       4.87% | -0.001 us |  -0.01% |  🔵 SAME  |
|  I128   |      I64      |      2^20      |  18.002 us |       3.27% |  17.907 us |       2.75% | -0.095 us |  -0.53% |  🔵 SAME  |
|  I128   |      I64      |      2^24      |  93.476 us |       0.94% |  93.362 us |       1.07% | -0.114 us |  -0.12% |  🔵 SAME  |
|  I128   |      I64      |      2^28      |   1.042 ms |       1.00% |   1.041 ms |       1.06% | -0.614 us |  -0.06% |  🔵 SAME  |
|   F32   |      I32      |      2^16      |   7.486 us |       4.24% |   7.473 us |       5.82% | -0.013 us |  -0.17% |  🔵 SAME  |
|   F32   |      I32      |      2^20      |   9.137 us |       3.78% |   9.230 us |       4.15% |  0.093 us |   1.02% |  🔵 SAME  |
|   F32   |      I32      |      2^24      |  29.120 us |       2.69% |  29.188 us |       2.62% |  0.069 us |   0.24% |  🔵 SAME  |
|   F32   |      I32      |      2^28      | 260.716 us |       2.15% | 260.583 us |       2.17% | -0.133 us |  -0.05% |  🔵 SAME  |
|   F32   |      I64      |      2^16      |   7.439 us |       5.81% |   7.477 us |       5.72% |  0.039 us |   0.52% |  🔵 SAME  |
|   F32   |      I64      |      2^20      |   9.293 us |       3.53% |   9.272 us |       4.35% | -0.022 us |  -0.23% |  🔵 SAME  |
|   F32   |      I64      |      2^24      |  29.445 us |       2.67% |  29.376 us |       2.54% | -0.069 us |  -0.24% |  🔵 SAME  |
|   F32   |      I64      |      2^28      | 261.084 us |       2.17% | 260.733 us |       2.14% | -0.351 us |  -0.13% |  🔵 SAME  |
|   F64   |      I32      |      2^16      |   7.529 us |       5.53% |   7.510 us |       4.25% | -0.019 us |  -0.25% |  🔵 SAME  |
|   F64   |      I32      |      2^20      |  10.993 us |       4.33% |  10.878 us |       4.33% | -0.114 us |  -1.04% |  🔵 SAME  |
|   F64   |      I32      |      2^24      |  48.484 us |       1.82% |  48.383 us |       1.91% | -0.100 us |  -0.21% |  🔵 SAME  |
|   F64   |      I32      |      2^28      | 506.180 us |       1.39% | 505.936 us |       1.42% | -0.244 us |  -0.05% |  🔵 SAME  |
|   F64   |      I64      |      2^16      |   7.502 us |       4.21% |   7.516 us |       4.27% |  0.014 us |   0.18% |  🔵 SAME  |
|   F64   |      I64      |      2^20      |  10.974 us |       3.82% |  10.878 us |       4.37% | -0.096 us |  -0.87% |  🔵 SAME  |
|   F64   |      I64      |      2^24      |  48.366 us |       1.89% |  48.361 us |       1.86% | -0.005 us |  -0.01% |  🔵 SAME  |
|   F64   |      I64      |      2^28      | 505.994 us |       1.48% | 505.846 us |       1.43% | -0.148 us |  -0.03% |  🔵 SAME  |
|   C32   |      I32      |      2^16      |   7.472 us |       5.71% |   7.451 us |       4.95% | -0.021 us |  -0.29% |  🔵 SAME  |
|   C32   |      I32      |      2^20      |  10.837 us |       4.37% |  10.779 us |       3.76% | -0.057 us |  -0.53% |  🔵 SAME  |
|   C32   |      I32      |      2^24      |  49.563 us |       1.72% |  49.347 us |       1.80% | -0.216 us |  -0.44% |  🔵 SAME  |
|   C32   |      I32      |      2^28      | 507.321 us |       1.40% | 507.022 us |       1.51% | -0.299 us |  -0.06% |  🔵 SAME  |
|   C32   |      I64      |      2^16      |   7.599 us |       4.41% |   7.592 us |       5.43% | -0.006 us |  -0.08% |  🔵 SAME  |
|   C32   |      I64      |      2^20      |  11.014 us |       3.61% |  10.941 us |       4.43% | -0.073 us |  -0.66% |  🔵 SAME  |
|   C32   |      I64      |      2^24      |  49.677 us |       1.75% |  49.770 us |       1.68% |  0.092 us |   0.19% |  🔵 SAME  |
|   C32   |      I64      |      2^28      | 508.652 us |       1.51% | 508.585 us |       1.48% | -0.067 us |  -0.01% |  🔵 SAME  |
```

`cub.bench.reduce.deterministic.base`
```
## [0] NVIDIA H200 NVL

|  T{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   F32   |      2^16      |  12.664 us |       3.56% |  12.676 us |       3.79% |  0.012 us |   0.10% |  🔵 SAME  |
|   F32   |      2^20      |  15.584 us |       4.09% |  15.414 us |       3.20% | -0.170 us |  -1.09% |  🔵 SAME  |
|   F32   |      2^24      |  54.495 us |       1.12% |  54.691 us |       1.09% |  0.196 us |   0.36% |  🔵 SAME  |
|   F32   |      2^28      | 383.102 us |       0.43% | 383.135 us |       0.44% |  0.033 us |   0.01% |  🔵 SAME  |
|   F64   |      2^16      |  13.286 us |       4.31% |  13.089 us |       3.75% | -0.197 us |  -1.48% |  🔵 SAME  |
|   F64   |      2^20      |  24.281 us |       2.31% |  24.061 us |       1.98% | -0.219 us |  -0.90% |  🔵 SAME  |
|   F64   |      2^24      | 111.255 us |       0.81% | 111.148 us |       0.78% | -0.107 us |  -0.10% |  🔵 SAME  |
|   F64   |      2^28      | 654.196 us |       0.66% | 652.695 us |       0.58% | -1.501 us |  -0.23% |  🔵 SAME  |
```

`cub.bench.reduce.nondeterministic.base`
```
## [0] NVIDIA H200 NVL

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I32   |      I32      |      2^16      |   5.648 us |       4.47% |   5.625 us |       3.44% | -0.023 us |  -0.40% |  🔵 SAME  |
|   I32   |      I32      |      2^20      |   7.611 us |       3.39% |   7.597 us |       3.65% | -0.014 us |  -0.18% |  🔵 SAME  |
|   I32   |      I32      |      2^24      |  27.278 us |       2.52% |  27.285 us |       2.49% |  0.007 us |   0.03% |  🔵 SAME  |
|   I32   |      I32      |      2^28      | 259.453 us |       2.03% | 259.643 us |       1.89% |  0.190 us |   0.07% |  🔵 SAME  |
|   I32   |      I64      |      2^16      |   5.838 us |       2.80% |   5.849 us |       3.14% |  0.012 us |   0.20% |  🔵 SAME  |
|   I32   |      I64      |      2^20      |   7.611 us |       3.70% |   7.617 us |       3.71% |  0.007 us |   0.09% |  🔵 SAME  |
|   I32   |      I64      |      2^24      |  27.399 us |       2.51% |  27.417 us |       2.62% |  0.019 us |   0.07% |  🔵 SAME  |
|   I32   |      I64      |      2^28      | 259.618 us |       1.85% | 259.388 us |       2.01% | -0.231 us |  -0.09% |  🔵 SAME  |
|   I64   |      I32      |      2^16      |   6.062 us |       3.44% |   6.084 us |       4.02% |  0.021 us |   0.35% |  🔵 SAME  |
|   I64   |      I32      |      2^20      |   9.129 us |       2.39% |   9.121 us |       2.50% | -0.008 us |  -0.09% |  🔵 SAME  |
|   I64   |      I32      |      2^24      |  45.099 us |       1.80% |  45.126 us |       1.86% |  0.027 us |   0.06% |  🔵 SAME  |
|   I64   |      I32      |      2^28      | 502.158 us |       1.47% | 502.036 us |       1.42% | -0.122 us |  -0.02% |  🔵 SAME  |
|   I64   |      I64      |      2^16      |   6.126 us |       4.18% |   6.098 us |       3.84% | -0.027 us |  -0.45% |  🔵 SAME  |
|   I64   |      I64      |      2^20      |   9.275 us |       2.44% |   9.276 us |       2.47% |  0.002 us |   0.02% |  🔵 SAME  |
|   I64   |      I64      |      2^24      |  45.294 us |       1.86% |  45.256 us |       1.84% | -0.038 us |  -0.08% |  🔵 SAME  |
|   I64   |      I64      |      2^28      | 502.320 us |       1.41% | 502.507 us |       1.49% |  0.187 us |   0.04% |  🔵 SAME  |
|   F32   |      I32      |      2^16      |   6.158 us |       3.70% |   6.154 us |       3.91% | -0.004 us |  -0.06% |  🔵 SAME  |
|   F32   |      I32      |      2^20      |   7.806 us |       3.40% |   7.821 us |       3.43% |  0.015 us |   0.19% |  🔵 SAME  |
|   F32   |      I32      |      2^24      |  27.517 us |       2.59% |  27.489 us |       2.60% | -0.028 us |  -0.10% |  🔵 SAME  |
|   F32   |      I32      |      2^28      | 259.922 us |       1.93% | 260.132 us |       1.95% |  0.210 us |   0.08% |  🔵 SAME  |
|   F32   |      I64      |      2^16      |   6.098 us |       3.58% |   6.077 us |       3.69% | -0.021 us |  -0.34% |  🔵 SAME  |
|   F32   |      I64      |      2^20      |   7.761 us |       3.57% |   7.728 us |       3.10% | -0.033 us |  -0.43% |  🔵 SAME  |
|   F32   |      I64      |      2^24      |  27.484 us |       2.49% |  27.502 us |       2.49% |  0.018 us |   0.06% |  🔵 SAME  |
|   F32   |      I64      |      2^28      | 259.938 us |       1.76% | 260.016 us |       1.82% |  0.078 us |   0.03% |  🔵 SAME  |
|   F64   |      I32      |      2^16      |   6.165 us |       3.17% |   6.152 us |       3.22% | -0.013 us |  -0.21% |  🔵 SAME  |
|   F64   |      I32      |      2^20      |   9.128 us |       1.47% |   9.121 us |       1.60% | -0.007 us |  -0.07% |  🔵 SAME  |
|   F64   |      I32      |      2^24      |  45.134 us |       1.90% |  45.126 us |       1.86% | -0.008 us |  -0.02% |  🔵 SAME  |
|   F64   |      I32      |      2^28      | 502.068 us |       1.29% | 502.318 us |       1.30% |  0.250 us |   0.05% |  🔵 SAME  |
|   F64   |      I64      |      2^16      |   6.107 us |       3.93% |   6.090 us |       3.69% | -0.017 us |  -0.27% |  🔵 SAME  |
|   F64   |      I64      |      2^20      |   9.350 us |       2.68% |   9.341 us |       2.55% | -0.009 us |  -0.10% |  🔵 SAME  |
|   F64   |      I64      |      2^24      |  45.451 us |       1.94% |  45.405 us |       1.96% | -0.046 us |  -0.10% |  🔵 SAME  |
|   F64   |      I64      |      2^28      | 502.327 us |       1.30% | 502.640 us |       1.48% |  0.312 us |   0.06% |  🔵 SAME  |
```

`cub.bench.transform_reduce.sum.base`
```
## [0] NVIDIA H200 NVL

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   7.376 us |       3.42% |   7.192 us |       3.53% | -0.184 us |  -2.50% |  🔵 SAME  |
|   I8    |      I32      |      2^20      |   9.391 us |       2.72% |   9.361 us |       2.82% | -0.030 us |  -0.32% |  🔵 SAME  |
|   I8    |      I32      |      2^24      |  14.617 us |       3.21% |  14.282 us |       3.12% | -0.335 us |  -2.29% |  🔵 SAME  |
|   I8    |      I32      |      2^28      |  83.863 us |       2.59% |  86.532 us |       2.28% |  2.669 us |   3.18% |  🔴 SLOW  |
|   I8    |      I64      |      2^16      |   7.530 us |       3.59% |   7.306 us |       3.32% | -0.224 us |  -2.97% |  🔵 SAME  |
|   I8    |      I64      |      2^20      |   9.417 us |       2.99% |   9.349 us |       2.31% | -0.068 us |  -0.72% |  🔵 SAME  |
|   I8    |      I64      |      2^24      |  14.672 us |       2.92% |  14.411 us |       2.97% | -0.261 us |  -1.78% |  🔵 SAME  |
|   I8    |      I64      |      2^28      |  84.040 us |       2.41% |  87.497 us |       2.02% |  3.457 us |   4.11% |  🔴 SLOW  |
|   I16   |      I32      |      2^16      |   7.475 us |       3.48% |   7.200 us |       3.50% | -0.275 us |  -3.68% |  🟢 FAST  |
|   I16   |      I32      |      2^20      |   8.400 us |       3.28% |   8.224 us |       2.89% | -0.177 us |  -2.10% |  🔵 SAME  |
|   I16   |      I32      |      2^24      |  20.300 us |       2.83% |  19.209 us |       2.98% | -1.092 us |  -5.38% |  🟢 FAST  |
|   I16   |      I32      |      2^28      | 141.483 us |       2.71% | 142.025 us |       2.31% |  0.543 us |   0.38% |  🔵 SAME  |
|   I16   |      I64      |      2^16      |   7.578 us |       3.42% |   7.284 us |       3.88% | -0.294 us |  -3.88% |  🟢 FAST  |
|   I16   |      I64      |      2^20      |   8.656 us |       3.09% |   8.454 us |       2.93% | -0.202 us |  -2.34% |  🔵 SAME  |
|   I16   |      I64      |      2^24      |  20.383 us |       2.75% |  19.254 us |       3.04% | -1.129 us |  -5.54% |  🟢 FAST  |
|   I16   |      I64      |      2^28      | 141.957 us |       2.53% | 142.136 us |       2.13% |  0.178 us |   0.13% |  🔵 SAME  |
|   I32   |      I32      |      2^16      |   7.504 us |       3.28% |   7.518 us |       3.31% |  0.014 us |   0.18% |  🔵 SAME  |
|   I32   |      I32      |      2^20      |   9.183 us |       3.46% |   9.184 us |       3.58% |  0.001 us |   0.01% |  🔵 SAME  |
|   I32   |      I32      |      2^24      |  29.377 us |       2.41% |  29.385 us |       2.46% |  0.008 us |   0.03% |  🔵 SAME  |
|   I32   |      I32      |      2^28      | 261.115 us |       2.03% | 261.227 us |       2.12% |  0.112 us |   0.04% |  🔵 SAME  |
|   I32   |      I64      |      2^16      |   7.573 us |       3.57% |   7.610 us |       3.83% |  0.037 us |   0.49% |  🔵 SAME  |
|   I32   |      I64      |      2^20      |   9.272 us |       3.60% |   9.237 us |       3.41% | -0.035 us |  -0.38% |  🔵 SAME  |
|   I32   |      I64      |      2^24      |  29.438 us |       2.37% |  29.338 us |       2.52% | -0.099 us |  -0.34% |  🔵 SAME  |
|   I32   |      I64      |      2^28      | 261.134 us |       1.95% | 261.199 us |       2.08% |  0.065 us |   0.02% |  🔵 SAME  |
|   I64   |      I32      |      2^16      |   7.699 us |       3.54% |   7.711 us |       3.96% |  0.012 us |   0.15% |  🔵 SAME  |
|   I64   |      I32      |      2^20      |  11.327 us |       3.29% |  11.258 us |       3.18% | -0.069 us |  -0.61% |  🔵 SAME  |
|   I64   |      I32      |      2^24      |  48.745 us |       1.75% |  48.531 us |       1.80% | -0.213 us |  -0.44% |  🔵 SAME  |
|   I64   |      I32      |      2^28      | 506.427 us |       1.42% | 506.263 us |       1.43% | -0.164 us |  -0.03% |  🔵 SAME  |
|   I64   |      I64      |      2^16      |   7.809 us |       3.76% |   7.841 us |       3.72% |  0.032 us |   0.41% |  🔵 SAME  |
|   I64   |      I64      |      2^20      |  11.411 us |       3.35% |  11.362 us |       3.32% | -0.050 us |  -0.43% |  🔵 SAME  |
|   I64   |      I64      |      2^24      |  48.797 us |       1.77% |  48.693 us |       1.82% | -0.104 us |  -0.21% |  🔵 SAME  |
|   I64   |      I64      |      2^28      | 505.817 us |       1.55% | 505.711 us |       1.58% | -0.106 us |  -0.02% |  🔵 SAME  |
|  I128   |      I32      |      2^16      |   9.012 us |       2.99% |   9.076 us |       3.37% |  0.064 us |   0.71% |  🔵 SAME  |
|  I128   |      I32      |      2^20      |  20.011 us |       1.74% |  20.148 us |       2.27% |  0.136 us |   0.68% |  🔵 SAME  |
|  I128   |      I32      |      2^24      |  98.300 us |       0.88% |  98.334 us |       0.88% |  0.034 us |   0.03% |  🔵 SAME  |
|  I128   |      I32      |      2^28      |   1.786 ms |       3.80% |   1.782 ms |       4.13% | -3.900 us |  -0.22% |  🔵 SAME  |
|  I128   |      I64      |      2^16      |   9.072 us |       3.47% |   9.061 us |       3.27% | -0.011 us |  -0.12% |  🔵 SAME  |
|  I128   |      I64      |      2^20      |  18.418 us |       2.36% |  18.497 us |       2.27% |  0.079 us |   0.43% |  🔵 SAME  |
|  I128   |      I64      |      2^24      |  94.960 us |       1.01% |  94.946 us |       0.93% | -0.014 us |  -0.02% |  🔵 SAME  |
|  I128   |      I64      |      2^28      |   1.043 ms |       0.77% |   1.043 ms |       0.76% |  0.044 us |   0.00% |  🔵 SAME  |
|   F32   |      I32      |      2^16      |   7.756 us |       4.13% |   7.751 us |       4.03% | -0.005 us |  -0.06% |  🔵 SAME  |
|   F32   |      I32      |      2^20      |   9.507 us |       3.24% |   9.369 us |       3.37% | -0.138 us |  -1.45% |  🔵 SAME  |
|   F32   |      I32      |      2^24      |  29.566 us |       2.45% |  29.424 us |       2.41% | -0.142 us |  -0.48% |  🔵 SAME  |
|   F32   |      I32      |      2^28      | 261.399 us |       2.14% | 261.366 us |       2.12% | -0.032 us |  -0.01% |  🔵 SAME  |
|   F32   |      I64      |      2^16      |   7.764 us |       3.20% |   7.726 us |       3.45% | -0.038 us |  -0.49% |  🔵 SAME  |
|   F32   |      I64      |      2^20      |   9.611 us |       3.42% |   9.516 us |       3.17% | -0.095 us |  -0.99% |  🔵 SAME  |
|   F32   |      I64      |      2^24      |  30.763 us |       2.42% |  30.684 us |       2.37% | -0.079 us |  -0.26% |  🔵 SAME  |
|   F32   |      I64      |      2^28      | 262.895 us |       2.07% | 262.878 us |       2.04% | -0.016 us |  -0.01% |  🔵 SAME  |
|   F64   |      I32      |      2^16      |   7.725 us |       3.38% |   7.766 us |       3.42% |  0.042 us |   0.54% |  🔵 SAME  |
|   F64   |      I32      |      2^20      |  11.114 us |       3.46% |  11.230 us |       3.21% |  0.117 us |   1.05% |  🔵 SAME  |
|   F64   |      I32      |      2^24      |  48.769 us |       1.78% |  48.711 us |       1.80% | -0.058 us |  -0.12% |  🔵 SAME  |
|   F64   |      I32      |      2^28      | 506.342 us |       1.47% | 506.497 us |       1.42% |  0.155 us |   0.03% |  🔵 SAME  |
|   F64   |      I64      |      2^16      |   7.798 us |       3.63% |   7.850 us |       4.07% |  0.052 us |   0.67% |  🔵 SAME  |
|   F64   |      I64      |      2^20      |  11.174 us |       3.34% |  11.231 us |       3.27% |  0.058 us |   0.52% |  🔵 SAME  |
|   F64   |      I64      |      2^24      |  48.811 us |       1.76% |  48.741 us |       1.76% | -0.069 us |  -0.14% |  🔵 SAME  |
|   F64   |      I64      |      2^28      | 506.377 us |       1.47% | 506.274 us |       1.47% | -0.103 us |  -0.02% |  🔵 SAME  |
|   C32   |      I32      |      2^16      |   8.057 us |       3.81% |   8.108 us |       3.49% |  0.051 us |   0.63% |  🔵 SAME  |
|   C32   |      I32      |      2^20      |  11.412 us |       3.54% |  11.425 us |       3.13% |  0.013 us |   0.11% |  🔵 SAME  |
|   C32   |      I32      |      2^24      |  50.075 us |       1.71% |  50.145 us |       1.65% |  0.071 us |   0.14% |  🔵 SAME  |
|   C32   |      I32      |      2^28      | 513.208 us |       1.35% | 513.477 us |       1.40% |  0.270 us |   0.05% |  🔵 SAME  |
|   C32   |      I64      |      2^16      |   8.113 us |       3.17% |   8.137 us |       2.91% |  0.024 us |   0.30% |  🔵 SAME  |
|   C32   |      I64      |      2^20      |  11.532 us |       3.11% |  11.603 us |       3.22% |  0.070 us |   0.61% |  🔵 SAME  |
|   C32   |      I64      |      2^24      |  49.826 us |       1.67% |  49.795 us |       1.73% | -0.031 us |  -0.06% |  🔵 SAME  |
|   C32   |      I64      |      2^28      | 507.286 us |       1.44% | 507.172 us |       1.35% | -0.114 us |  -0.02% |  🔵 SAME  |
```

Fixes: #6576
