### PR TITLE
Specialize `basic_common_reference` and `common_type` for tuples

### DIFF
--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -29,6 +29,7 @@
 #include <cuda/std/__tuple_dir/tuple_leaf.h>
 #include <cuda/std/__tuple_dir/tuple_size.h>
 #include <cuda/std/__tuple_dir/tuple_types.h>
+#include <cuda/std/__type_traits/common_reference.h>
 #include <cuda/std/__type_traits/is_nothrow_assignable.h>
 #include <cuda/std/__type_traits/is_nothrow_constructible.h>
 #include <cuda/std/__type_traits/is_nothrow_default_constructible.h>
@@ -434,6 +435,53 @@ public:
     return true;
   }
 };
+
+namespace __tuple_common_ref
+{
+// Equivalent to __type_pair in type_list.h, but reimplemented here because we don't want to
+// pull in 1k lines of templates just for this.
+template <typename _Tp, typename _Up>
+struct __type_pair
+{
+  using __first  = _Tp;
+  using __second = _Up;
+};
+} // namespace __tuple_common_ref
+
+template <class... _TypePairs>
+_CCCL_CONCEPT __tuple_of_common_references = _CCCL_REQUIRES_EXPR((variadic _TypePairs), )(
+  typename(tuple<common_reference_t<typename _TypePairs::__first, typename _TypePairs::__second>...>));
+
+template <class... _TTypes, class... _UTypes, template <class> class _TQual, template <class> class _UQual>
+struct basic_common_reference<
+  tuple<_TTypes...>,
+  tuple<_UTypes...>,
+  _TQual,
+  _UQual,
+  enable_if_t<__tuple_of_common_references<__tuple_common_ref::__type_pair<_TQual<_TTypes>, _UQual<_UTypes>>...>>>
+{
+  using type _CCCL_NODEBUG = tuple<common_reference_t<_TQual<_TTypes>, _UQual<_UTypes>>...>;
+};
+
+template <class... _TypePairs>
+_CCCL_CONCEPT __tuple_of_common_types = _CCCL_REQUIRES_EXPR((variadic _TypePairs), )(
+  typename(tuple<common_type_t<typename _TypePairs::__first, typename _TypePairs::__second>...>));
+
+template <class, class, class = void>
+struct __tuple_common_type
+{};
+
+template <class... _TTypes, class... _UTypes>
+struct __tuple_common_type<tuple<_TTypes...>,
+                           tuple<_UTypes...>,
+                           enable_if_t<__tuple_of_common_types<__tuple_common_ref::__type_pair<_TTypes, _UTypes>...>>>
+{
+  using type _CCCL_NODEBUG = tuple<common_type_t<_TTypes, _UTypes>...>;
+};
+
+template <class... _TTypes, class... _UTypes>
+struct common_type<tuple<_TTypes...>, tuple<_UTypes...>> : __tuple_common_type<tuple<_TTypes...>, tuple<_UTypes...>>
+{};
 
 template <class... _Tp>
 _CCCL_DEDUCTION_GUIDE_ATTRIBUTES tuple(_Tp...) -> tuple<_Tp...>;

--- a/libcudacxx/include/cuda/std/__type_traits/common_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/common_reference.h
@@ -209,7 +209,7 @@ struct __common_reference_sub_bullet1<
 
 // sub-bullet 2 - Otherwise, if basic_common_reference<remove_cvref_t<T1>, remove_cvref_t<T2>, XREF(T1), XREF(T2)>::type
 // is well-formed, then the member typedef `type` denotes that type.
-template <class, class, template <class> class, template <class> class>
+template <class, class, template <class> class, template <class> class, class = void>
 struct basic_common_reference
 {};
 

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.traits/common_reference.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.traits/common_reference.compile.pass.cpp
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/tuple>
+
+// template<class... TTypes, class... UTypes, template<class> class TQual,
+//          template<class> class UQual>
+//   struct basic_common_reference<tuple<TTypes...>, tuple<UTypes...>, TQual, UQual>;
+
+#include <cuda/std/tuple>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+struct no_common_reference
+{};
+
+template <class T>
+struct X
+{};
+
+template <class T>
+struct Y
+{};
+
+struct common_ref
+{};
+
+template <template <class> class TQual, template <class> class UQual>
+struct cuda::std::basic_common_reference<X<int>, Y<int>, TQual, UQual>
+{
+  using type = common_ref;
+};
+
+template <template <class> class TQual, template <class> class UQual>
+struct cuda::std::basic_common_reference<Y<int>, X<int>, TQual, UQual>
+{
+  using type = common_ref;
+};
+
+template <class... Args>
+TEST_FUNC constexpr auto has_common_reference_imp(int)
+  -> decltype(sizeof(typename cuda::std::common_reference<Args...>::type), bool{})
+{
+  return true;
+}
+
+template <class... Args>
+TEST_FUNC constexpr bool has_common_reference_imp(long)
+{
+  return false;
+}
+
+template <class... Args>
+inline constexpr bool has_common_reference =
+  cuda::std::integral_constant<bool, has_common_reference_imp<Args...>(0)>::value;
+
+TEST_FUNC constexpr bool test()
+{
+  {
+    using T = cuda::std::tuple<int>;
+    static_assert(cuda::std::same_as<cuda::std::common_reference_t<T, T>, T>);
+  }
+  {
+    using T        = cuda::std::tuple<int&, const long&>;
+    using U        = cuda::std::tuple<const int&, long&>;
+    using Expected = cuda::std::tuple<const int&, const long&>;
+    static_assert(has_common_reference<T, U>);
+    static_assert(cuda::std::same_as<cuda::std::common_reference_t<T, U>, Expected>);
+  }
+  {
+    using T        = cuda::std::tuple<X<int>>;
+    using U        = cuda::std::tuple<Y<int>>;
+    using Expected = cuda::std::tuple<common_ref>;
+    static_assert(has_common_reference<T, U>);
+    static_assert(cuda::std::same_as<cuda::std::common_reference_t<T, U>, Expected>);
+  }
+  {
+    using T = cuda::std::tuple<X<double>>;
+    using U = cuda::std::tuple<Y<double>>;
+    // Only X<int> and Y<int> are specialized
+    static_assert(!has_common_reference<T, U>);
+  }
+  {
+    using T = cuda::std::tuple<int>;
+    using U = cuda::std::tuple<int, int>;
+    static_assert(!has_common_reference<T, U>);
+  }
+  {
+    using T = cuda::std::tuple<int, no_common_reference>;
+    using U = cuda::std::tuple<int, int>;
+    static_assert(!has_common_reference<T, U>);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.traits/common_type.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.traits/common_type.compile.pass.cpp
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/tuple>
+
+// template<class... TTypes, class... UTypes>
+//   struct common_type<tuple<TTypes...>, tuple<UTypes...>>;
+
+#include <cuda/std/tuple>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+struct no_common_type
+{};
+
+template <class... Args>
+TEST_FUNC constexpr auto has_common_type_imp(int)
+  -> decltype(sizeof(typename cuda::std::common_type<Args...>::type), bool{})
+{
+  return true;
+}
+
+template <class... Args>
+TEST_FUNC constexpr bool has_common_type_imp(long)
+{
+  return false;
+}
+
+template <class... Args>
+static constexpr bool has_common_type = cuda::std::integral_constant<bool, has_common_type_imp<Args...>(0)>::value;
+
+TEST_FUNC constexpr bool test()
+{
+  {
+    using T = cuda::std::tuple<int>;
+    static_assert(has_common_type<T, T>);
+    static_assert(cuda::std::same_as<cuda::std::common_type_t<T, T>, T>);
+  }
+  {
+    using T        = cuda::std::tuple<const int, short, const long&>;
+    using U        = cuda::std::tuple<int, long, volatile long&>;
+    using Expected = cuda::std::tuple<int, long, long>;
+    static_assert(has_common_type<T, U>);
+    static_assert(cuda::std::same_as<cuda::std::common_type_t<T, U>, Expected>);
+  }
+  {
+    using T = cuda::std::tuple<int>;
+    using U = cuda::std::tuple<int, int>;
+    static_assert(!has_common_type<T, U>);
+  }
+  {
+    using T = cuda::std::tuple<int, no_common_type>;
+    using U = cuda::std::tuple<int, int>;
+    static_assert(!has_common_type<T, U>);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  static_assert(test());
+  return 0;
+}


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

Requires https://github.com/NVIDIA/cccl/pull/8886

Add the C++23 `common_type` specialization for tuples (https://en.cppreference.com/cpp/utility/tuple/common_type).

This is needed for `zip_view` such that `const`-qualified ranges may be used.
```c++
const std::vector<int> v;

// Currently fails to compile because cuda::std::views::zip() does not model input_range
// because cuda::std::common_reference_with<ref_t&&, val_t&>, where:
//
// ref_t = cuda::std::iter_reference_t<iter_t>; // cuda::std::tuple<const int &, const int &>
// val_t = cuda::std::iter_value_t<iter_t>; // cuda::std::tuple<int, int>
//
// Is not satisfied
cuda::std::views::zip(v, v) | cuda::std::views::transform(...);
```

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
