### PR TITLE
Add C++23 lvalue reference conversion constructors for tuple

### DIFF
--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -29,6 +29,7 @@
 #include <cuda/std/__tuple_dir/tuple_leaf.h>
 #include <cuda/std/__tuple_dir/tuple_size.h>
 #include <cuda/std/__tuple_dir/tuple_types.h>
+#include <cuda/std/__type_traits/common_reference.h>
 #include <cuda/std/__type_traits/is_nothrow_assignable.h>
 #include <cuda/std/__type_traits/is_nothrow_constructible.h>
 #include <cuda/std/__type_traits/is_nothrow_default_constructible.h>
@@ -246,6 +247,16 @@ public:
   template <class _Tuple,
             class _Constraints                                        = __tuple_like_constraints<_Tuple>,
             enable_if_t<!__expands_to_this_tuple<_Tuple>::value, int> = 0,
+            // clang-tidy is confused. We are already using _v here
+            enable_if_t<is_lvalue_reference_v<_Tuple>, int>          = 0, // NOLINT(modernize-type-traits)
+            enable_if_t<_Constraints::__implicit_constructible, int> = 0>
+  _CCCL_API constexpr tuple(_Tuple&& __t) noexcept(is_nothrow_constructible_v<_BaseT, _Tuple>)
+      : __base_(__t)
+  {}
+
+  template <class _Tuple,
+            class _Constraints                                        = __tuple_like_constraints<_Tuple>,
+            enable_if_t<!__expands_to_this_tuple<_Tuple>::value, int> = 0,
             enable_if_t<!is_lvalue_reference_v<_Tuple>, int>          = 0,
             enable_if_t<_Constraints::__explicit_constructible, int>  = 0>
   _CCCL_API constexpr explicit tuple(_Tuple&& __t) noexcept(is_nothrow_constructible_v<_BaseT, _Tuple>)
@@ -257,6 +268,15 @@ public:
             enable_if_t<!__expands_to_this_tuple<_Tuple>::value, int> = 0,
             enable_if_t<_Constraints::__explicit_constructible, int>  = 0>
   _CCCL_API constexpr explicit tuple(const _Tuple& __t) noexcept(is_nothrow_constructible_v<_BaseT, const _Tuple&>)
+      : __base_(__t)
+  {}
+
+  template <class _Tuple,
+            class _Constraints                                        = __tuple_like_constraints<_Tuple>,
+            enable_if_t<!__expands_to_this_tuple<_Tuple>::value, int> = 0,
+            enable_if_t<is_lvalue_reference_v<_Tuple>, int>           = 0,
+            enable_if_t<_Constraints::__explicit_constructible, int>  = 0>
+  _CCCL_API constexpr explicit tuple(_Tuple&& __t) noexcept(is_nothrow_constructible_v<_BaseT, _Tuple>)
       : __base_(__t)
   {}
 
@@ -434,6 +454,53 @@ public:
     return true;
   }
 };
+
+namespace __tuple_common_ref
+{
+// Equivalent to __type_pair in type_list.h, but reimplemented here because we don't want to
+// pull in 1k lines of templates just for this.
+template <typename _Tp, typename _Up>
+struct __type_pair
+{
+  using __first  = _Tp;
+  using __second = _Up;
+};
+} // namespace __tuple_common_ref
+
+template <class... _TypePairs>
+_CCCL_CONCEPT __tuple_of_common_references = _CCCL_REQUIRES_EXPR((variadic _TypePairs), )(
+  typename(tuple<common_reference_t<typename _TypePairs::__first, typename _TypePairs::__second>...>));
+
+template <class... _TTypes, class... _UTypes, template <class> class _TQual, template <class> class _UQual>
+struct basic_common_reference<
+  tuple<_TTypes...>,
+  tuple<_UTypes...>,
+  _TQual,
+  _UQual,
+  enable_if_t<__tuple_of_common_references<__tuple_common_ref::__type_pair<_TQual<_TTypes>, _UQual<_UTypes>>...>>>
+{
+  using type _CCCL_NODEBUG = tuple<common_reference_t<_TQual<_TTypes>, _UQual<_UTypes>>...>;
+};
+
+template <class... _TypePairs>
+_CCCL_CONCEPT __tuple_of_common_types = _CCCL_REQUIRES_EXPR((variadic _TypePairs), )(
+  typename(tuple<common_type_t<typename _TypePairs::__first, typename _TypePairs::__second>...>));
+
+template <class, class, class = void>
+struct __tuple_common_type
+{};
+
+template <class... _TTypes, class... _UTypes>
+struct __tuple_common_type<tuple<_TTypes...>,
+                           tuple<_UTypes...>,
+                           enable_if_t<__tuple_of_common_types<__tuple_common_ref::__type_pair<_TTypes, _UTypes>...>>>
+{
+  using type _CCCL_NODEBUG = tuple<common_type_t<_TTypes, _UTypes>...>;
+};
+
+template <class... _TTypes, class... _UTypes>
+struct common_type<tuple<_TTypes...>, tuple<_UTypes...>> : __tuple_common_type<tuple<_TTypes...>, tuple<_UTypes...>>
+{};
 
 template <class... _Tp>
 _CCCL_DEDUCTION_GUIDE_ATTRIBUTES tuple(_Tp...) -> tuple<_Tp...>;

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -226,6 +226,95 @@ private:
   {}
 
 public:
+  template <class _Tuple>
+  using __utypes_tuple_constraints =
+    // clang-tidy has fallen off its rocker and claims we can use the non-existent
+    // __tuple_like_with_size_v here.
+    _If<__tuple_like_with_size<_Tuple, sizeof...(_Tp)>, // NOLINT(modernize-type-traits)
+        typename __tuple_constraints<_Tp...>::template __utypes_tuple_constraints<_Tuple>,
+        __invalid_tuple_constraints>;
+
+  template <class... _UTypes,
+            class _Tuple                                             = tuple<_UTypes...>&,
+            class _Constraints                                       = __utypes_tuple_constraints<_Tuple>,
+            enable_if_t<_Constraints::__implicit_constructible, int> = 0>
+  _CCCL_API constexpr tuple(tuple<_UTypes...>& __t) noexcept(is_nothrow_constructible_v<_BaseT, _Tuple>)
+      : __base_(__t)
+  {}
+
+  template <class... _UTypes,
+            class _Tuple                                             = tuple<_UTypes...>&,
+            class _Constraints                                       = __utypes_tuple_constraints<_Tuple>,
+            enable_if_t<_Constraints::__explicit_constructible, int> = 0>
+  _CCCL_API constexpr explicit tuple(tuple<_UTypes...>& __t) noexcept(is_nothrow_constructible_v<_BaseT, _Tuple>)
+      : __base_(__t)
+  {}
+
+  // ------------------------------------------------------------------------------------------
+
+  template <class... _UTypes,
+            class _Tuple                                             = const tuple<_UTypes...>&,
+            class _Constraints                                       = __utypes_tuple_constraints<_Tuple>,
+            enable_if_t<_Constraints::__implicit_constructible, int> = 0>
+  _CCCL_API constexpr tuple(const tuple<_UTypes...>& __t) noexcept(is_nothrow_constructible_v<_BaseT, _Tuple>)
+      : __base_(__t)
+  {}
+
+  template <class... _UTypes,
+            class _Tuple                                             = const tuple<_UTypes...>&,
+            class _Constraints                                       = __utypes_tuple_constraints<_Tuple>,
+            enable_if_t<_Constraints::__explicit_constructible, int> = 0>
+  _CCCL_API constexpr explicit tuple(const tuple<_UTypes...>& __t) noexcept(is_nothrow_constructible_v<_BaseT, _Tuple>)
+      : __base_(__t)
+  {}
+
+  // ------------------------------------------------------------------------------------------
+
+  template <class... _UTypes,
+            class _Tuple                                             = tuple<_UTypes...>&&,
+            class _Constraints                                       = __utypes_tuple_constraints<_Tuple>,
+            enable_if_t<_Constraints::__implicit_constructible, int> = 0>
+  _CCCL_API constexpr tuple(tuple<_UTypes...>&& __t) noexcept(is_nothrow_constructible_v<_BaseT, _Tuple>)
+      : __base_(::cuda::std::move(__t))
+  {}
+
+  template <class... _UTypes,
+            class _Tuple                                             = tuple<_UTypes...>&&,
+            class _Constraints                                       = __utypes_tuple_constraints<_Tuple>,
+            enable_if_t<_Constraints::__explicit_constructible, int> = 0>
+  _CCCL_API constexpr explicit tuple(tuple<_UTypes...>&& __t) noexcept(is_nothrow_constructible_v<_BaseT, _Tuple>)
+      : __base_(::cuda::std::move(__t))
+  {}
+
+  // ------------------------------------------------------------------------------------------
+
+  template <class... _UTypes,
+            class _Tuple                                             = const tuple<_UTypes...>&&,
+            class _Constraints                                       = __utypes_tuple_constraints<_Tuple>,
+            enable_if_t<_Constraints::__implicit_constructible, int> = 0>
+  _CCCL_API constexpr tuple(const tuple<_UTypes...>&& __t) noexcept(is_nothrow_constructible_v<_BaseT, _Tuple>)
+      : __base_(::cuda::std::move(__t))
+  {}
+
+  template <class... _UTypes,
+            class _Tuple                                             = const tuple<_UTypes...>&&,
+            class _Constraints                                       = __utypes_tuple_constraints<_Tuple>,
+            enable_if_t<_Constraints::__explicit_constructible, int> = 0>
+  _CCCL_API constexpr explicit tuple(const tuple<_UTypes...>&& __t) noexcept(is_nothrow_constructible_v<_BaseT, _Tuple>)
+      : __base_(::cuda::std::move(__t))
+  {}
+
+  // ------------------------------------------------------------------------------------------
+
+  template <class _Tuple,
+            class _Constraints                                        = __tuple_like_constraints<_Tuple>,
+            enable_if_t<!__expands_to_this_tuple<_Tuple>::value, int> = 0,
+            enable_if_t<is_lvalue_reference_v<_Tuple>, int>           = 0,
+            enable_if_t<_Constraints::__explicit_constructible, int>  = 0>
+  _CCCL_API constexpr explicit tuple(_Tuple&& __t) noexcept(is_nothrow_constructible_v<_BaseT, _Tuple>)
+      : __base_(__t)
+  {}
+
   template <class _Tuple,
             class _Constraints                                        = __tuple_like_constraints<_Tuple>,
             enable_if_t<!__expands_to_this_tuple<_Tuple>::value, int> = 0,
@@ -247,16 +336,6 @@ public:
   template <class _Tuple,
             class _Constraints                                        = __tuple_like_constraints<_Tuple>,
             enable_if_t<!__expands_to_this_tuple<_Tuple>::value, int> = 0,
-            // clang-tidy is confused. We are already using _v here
-            enable_if_t<is_lvalue_reference_v<_Tuple>, int>          = 0, // NOLINT(modernize-type-traits)
-            enable_if_t<_Constraints::__implicit_constructible, int> = 0>
-  _CCCL_API constexpr tuple(_Tuple&& __t) noexcept(is_nothrow_constructible_v<_BaseT, _Tuple>)
-      : __base_(__t)
-  {}
-
-  template <class _Tuple,
-            class _Constraints                                        = __tuple_like_constraints<_Tuple>,
-            enable_if_t<!__expands_to_this_tuple<_Tuple>::value, int> = 0,
             enable_if_t<!is_lvalue_reference_v<_Tuple>, int>          = 0,
             enable_if_t<_Constraints::__explicit_constructible, int>  = 0>
   _CCCL_API constexpr explicit tuple(_Tuple&& __t) noexcept(is_nothrow_constructible_v<_BaseT, _Tuple>)
@@ -268,15 +347,6 @@ public:
             enable_if_t<!__expands_to_this_tuple<_Tuple>::value, int> = 0,
             enable_if_t<_Constraints::__explicit_constructible, int>  = 0>
   _CCCL_API constexpr explicit tuple(const _Tuple& __t) noexcept(is_nothrow_constructible_v<_BaseT, const _Tuple&>)
-      : __base_(__t)
-  {}
-
-  template <class _Tuple,
-            class _Constraints                                        = __tuple_like_constraints<_Tuple>,
-            enable_if_t<!__expands_to_this_tuple<_Tuple>::value, int> = 0,
-            enable_if_t<is_lvalue_reference_v<_Tuple>, int>           = 0,
-            enable_if_t<_Constraints::__explicit_constructible, int>  = 0>
-  _CCCL_API constexpr explicit tuple(_Tuple&& __t) noexcept(is_nothrow_constructible_v<_BaseT, _Tuple>)
       : __base_(__t)
   {}
 

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -27,6 +27,7 @@
 #include <cuda/std/__tuple_dir/tuple_size.h>
 #include <cuda/std/__tuple_dir/tuple_types.h>
 #include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/conjunction.h>
 #include <cuda/std/__type_traits/disjunction.h>
 #include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_assignable.h>
@@ -49,6 +50,8 @@
 #include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_arg_t;
 
 template <class... _Tp>
 inline constexpr bool __tuple_all_copy_assignable_v = (is_copy_assignable_v<_Tp> && ...);
@@ -196,16 +199,43 @@ struct __tuple_constraints
   template <class... _Args>
   struct __variadic_constraints
   {
-    static constexpr bool __constructible = __tuple_constructible<__tuple_types<_Args...>, __tuple_types<_Tp...>>;
+    // 12.3: otherwise, true_type
+    template <class... _Up>
+    static constexpr bool __disambiguation_constraints = true;
+
+    // 12.1: negation<is_same<remove_cvref_t<U0>, tuple>> if sizeof...(Types) is 1
+    template <class _U0>
+    static constexpr bool __disambiguation_constraints<_U0> = !is_same_v<remove_cvref_t<_U0>, tuple<_Tp...>>;
+
+    // 12.2: otherwise, bool_constant<!is_same_v<remove_cvref_t<U0>, allocator_arg_t> ||
+    //       is_same_v<remove_cvref_t<T0>, allocator_arg_t>> if sizeof...(Types) is 2 or 3
+    template <class _U0, class _U1>
+    static constexpr bool __disambiguation_constraints<_U0, _U1> =
+      !is_same_v<remove_cvref_t<_U0>, allocator_arg_t>
+      || is_same_v<remove_cvref_t<__type_index_c<0, _Tp...>>, allocator_arg_t>;
+
+    template <class _U0, class _U1, class _U2>
+    static constexpr bool __disambiguation_constraints<_U0, _U1, _U2> = __disambiguation_constraints<_U0, _U1>;
+
+    // Must be a function since the is_constructible check needs to be lazy
+    [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL bool __check_constructible() noexcept
+    {
+      if constexpr (__disambiguation_constraints<_Args...>)
+      {
+        return _And<is_constructible<_Tp, _Args>...>::value;
+      }
+      else
+      {
+        return false;
+      }
+    }
+
+    static constexpr bool __constructible = __check_constructible();
 
     static constexpr bool __implicit_constructible =
-      __tuple_constructible<__tuple_types<_Args...>, __tuple_types<_Tp...>>
-      && __tuple_convertible<__tuple_types<_Args...>, __tuple_types<_Tp...>>;
-
+      __constructible && __tuple_convertible<__tuple_types<_Args...>, __tuple_types<_Tp...>>;
     static constexpr bool __explicit_constructible =
-      __tuple_constructible<__tuple_types<_Args...>, __tuple_types<_Tp...>>
-      && !__tuple_convertible<__tuple_types<_Args...>, __tuple_types<_Tp...>>;
-
+      __constructible && !__tuple_convertible<__tuple_types<_Args...>, __tuple_types<_Tp...>>;
     static constexpr bool __nothrow_constructible = (is_nothrow_constructible_v<_Tp, _Args> && ...);
   };
 
@@ -266,6 +296,33 @@ struct __tuple_constraints
   using __tuple_like_constraints =
     conditional_t<sizeof...(_Tp) == 1,
                   __valid_tuple_like_constraints_rank_one<_Tuple>,
+                  __valid_tuple_like_constraints<_Tuple>>;
+
+  template <class _Tuple, class _DecayedOtherTuple = remove_cvref_t<_Tuple>>
+  struct __valid_utypes_constraints_rank_one
+  {
+    static constexpr bool __implicit_constructible = false;
+    static constexpr bool __explicit_constructible = false;
+  };
+
+  template <class _Tuple, class... _Up>
+  struct __valid_utypes_constraints_rank_one<_Tuple, tuple<_Up...>>
+  {
+    static constexpr bool __enable_singleton_utype_ctor =
+      !(is_convertible_v<_Tuple, _Tp> && ...) && !(is_constructible_v<_Tp, _Tuple> && ...)
+      && !(is_same_v<_Tp, _Up> && ...);
+
+    static constexpr bool __implicit_constructible =
+      __enable_singleton_utype_ctor && __valid_tuple_like_constraints_rank_one<_Tuple>::__implicit_constructible;
+
+    static constexpr bool __explicit_constructible =
+      __enable_singleton_utype_ctor && __valid_tuple_like_constraints_rank_one<_Tuple>::__explicit_constructible;
+  };
+
+  template <class _Tuple>
+  using __utypes_tuple_constraints =
+    conditional_t<sizeof...(_Tp) == 1,
+                  __valid_utypes_constraints_rank_one<_Tuple>,
                   __valid_tuple_like_constraints<_Tuple>>;
 
   template <class... _Up>

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -51,7 +51,7 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_arg_t;
+struct allocator_arg_t;
 
 template <class... _Tp>
 inline constexpr bool __tuple_all_copy_assignable_v = (is_copy_assignable_v<_Tp> && ...);

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -199,28 +199,41 @@ struct __tuple_constraints
   template <class... _Args>
   struct __variadic_constraints
   {
-    // 12.3: otherwise, true_type
+    // Must be a function because GCC7 does not allow us to specialize constexpr bools inside a
+    // template class context. We could fix this by defining them outside, but we need access
+    // to 2 template parameters packs (_Up... and _Tp...). I don't see a way to do this without
+    // templated outer classes, so constexpr function it is.
     template <class... _Up>
-    static constexpr bool __disambiguation_constraints = true;
+    [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL bool __disambiguation_constraints() noexcept
+    {
+      static_assert(sizeof...(_Tp) == sizeof...(_Up));
+      if constexpr (sizeof...(_Tp) == 1)
+      {
+        // 12.1: negation<is_same<remove_cvref_t<U0>, tuple>>
+        //       if sizeof...(Types) is 1
+        return !is_same_v<remove_cvref_t<_Up>..., tuple<_Tp...>>;
+      }
+      else if constexpr (sizeof...(_Tp) == 2 || sizeof...(_Tp) == 3)
+      {
+        // 12.2: otherwise, if sizeof...(Types) is 2 or 3
+        //       bool_constant<!is_same_v<remove_cvref_t<U0>, allocator_arg_t> || is_same_v<remove_cvref_t<T0>,
+        //       allocator_arg_t>>
+        using _U0 = __type_index_c<0, _Up...>;
+        using _T0 = __type_index_c<0, _Tp...>;
 
-    // 12.1: negation<is_same<remove_cvref_t<U0>, tuple>> if sizeof...(Types) is 1
-    template <class _U0>
-    static constexpr bool __disambiguation_constraints<_U0> = !is_same_v<remove_cvref_t<_U0>, tuple<_Tp...>>;
-
-    // 12.2: otherwise, bool_constant<!is_same_v<remove_cvref_t<U0>, allocator_arg_t> ||
-    //       is_same_v<remove_cvref_t<T0>, allocator_arg_t>> if sizeof...(Types) is 2 or 3
-    template <class _U0, class _U1>
-    static constexpr bool __disambiguation_constraints<_U0, _U1> =
-      !is_same_v<remove_cvref_t<_U0>, allocator_arg_t>
-      || is_same_v<remove_cvref_t<__type_index_c<0, _Tp...>>, allocator_arg_t>;
-
-    template <class _U0, class _U1, class _U2>
-    static constexpr bool __disambiguation_constraints<_U0, _U1, _U2> = __disambiguation_constraints<_U0, _U1>;
+        return !is_same_v<remove_cvref_t<_U0>, allocator_arg_t> || is_same_v<remove_cvref_t<_T0>, allocator_arg_t>;
+      }
+      else
+      {
+        // 12.3: otherwise, true_type
+        return true;
+      }
+    }
 
     // Must be a function since the is_constructible check needs to be lazy
     [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL bool __check_constructible() noexcept
     {
-      if constexpr (__disambiguation_constraints<_Args...>)
+      if constexpr (__disambiguation_constraints<_Args...>())
       {
         return _And<is_constructible<_Tp, _Args>...>::value;
       }

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -308,9 +308,24 @@ struct __tuple_constraints
   template <class _Tuple, class... _Up>
   struct __valid_utypes_constraints_rank_one<_Tuple, tuple<_Up...>>
   {
-    static constexpr bool __enable_singleton_utype_ctor =
-      !(is_convertible_v<_Tuple, _Tp> && ...) && !(is_constructible_v<_Tp, _Tuple> && ...)
-      && !(is_same_v<_Tp, _Up> && ...);
+    // Use consteval function to lazily evaluate the conditions.
+    [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL bool __check_enable_singleton_utype_ctor() noexcept
+    {
+      if constexpr ((is_same_v<_Tp, _Up> && ...))
+      { // NOLINT(bugprone-branch-clone)
+        return false;
+      }
+      else if constexpr ((is_convertible_v<_Tuple, _Tp> && ...))
+      {
+        return false;
+      }
+      else
+      {
+        return !(is_constructible_v<_Tp, _Tuple> && ...);
+      }
+    }
+
+    static constexpr bool __enable_singleton_utype_ctor = __check_enable_singleton_utype_ctor();
 
     static constexpr bool __implicit_constructible =
       __enable_singleton_utype_ctor && __valid_tuple_like_constraints_rank_one<_Tuple>::__implicit_constructible;

--- a/libcudacxx/include/cuda/std/__type_traits/common_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/common_reference.h
@@ -209,7 +209,7 @@ struct __common_reference_sub_bullet1<
 
 // sub-bullet 2 - Otherwise, if basic_common_reference<remove_cvref_t<T1>, remove_cvref_t<T2>, XREF(T1), XREF(T2)>::type
 // is well-formed, then the member typedef `type` denotes that type.
-template <class, class, template <class> class, template <class> class>
+template <class, class, template <class> class, template <class> class, class = void>
 struct basic_common_reference
 {};
 

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/PR31384.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/PR31384.pass.cpp
@@ -84,17 +84,11 @@ int main(int, char**)
   }
   count = 0;
   {
-    // FIXME: Libc++ incorrectly rejects this code.
-#ifndef _CUDA_STD_VERSION
-    cuda::std::tuple<Implicit> foo = ExplicitDerived<int>{42};
-    static_assert(cuda::std::is_convertible<ExplicitDerived<int>, cuda::std::tuple<Implicit>>::value,
-                  "correct STLs accept this");
-#else
-    static_assert(!cuda::std::is_convertible<ExplicitDerived<int>, cuda::std::tuple<Implicit>>::value,
-                  "libc++ incorrectly rejects this");
-#endif
+    [[maybe_unused]] cuda::std::tuple<Implicit> foo = ExplicitDerived<int>{42};
+    static_assert(cuda::std::is_convertible_v<ExplicitDerived<int>, cuda::std::tuple<Implicit>>);
     assert(count == 0);
-    [[maybe_unused]] cuda::std::tuple<Implicit> bar(ExplicitDerived<int>{42});
+    ExplicitDerived<int> d{42};
+    [[maybe_unused]] cuda::std::tuple<Implicit> bar(cuda::std::move(d));
     assert(count == 1);
   }
   count = 0;

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_const_move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_const_move.pass.cpp
@@ -1,0 +1,140 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <tuple>
+
+// template <class... Types>
+// template <class... UTypes>
+//   constexpr explicit(see below) tuple<Types>::tuple(const
+//   tuple<UTypes...>&&);
+//
+// Constraints:
+//  sizeof...(Types) equals sizeof...(UTypes) &&
+//  (is_constructible_v<Types, decltype(get<I>(FWD(u)))> && ...) is true &&
+//  (
+//    sizeof...(Types) is not 1 ||
+//    (
+//      !is_convertible_v<decltype(u), T> &&
+//      !is_constructible_v<T, decltype(u)> &&
+//      !is_same_v<T, U>
+//    )
+//  )
+
+#include <cuda/std/cassert>
+#include <cuda/std/tuple>
+
+#include "copy_move_types.h"
+#include "test_macros.h"
+
+// test: The expression inside explicit is equivalent to:
+// !(is_convertible_v<decltype(get<I>(FWD(u))), Types> && ...)
+static_assert(
+  cuda::std::is_convertible_v<const cuda::std::tuple<ConstMove>&&, cuda::std::tuple<ConvertibleFrom<ConstMove>>>);
+
+static_assert(cuda::std::is_convertible_v<const cuda::std::tuple<ConstMove, ConstMove>&&,
+                                          cuda::std::tuple<ConvertibleFrom<ConstMove>, ConvertibleFrom<ConstMove>>>);
+
+static_assert(!cuda::std::is_convertible_v<const cuda::std::tuple<MutableCopy>&&,
+                                           cuda::std::tuple<ExplicitConstructibleFrom<ConstMove>>>);
+
+static_assert(
+  !cuda::std::is_convertible_v<const cuda::std::tuple<ConstMove, ConstMove>&&,
+                               cuda::std::tuple<ConvertibleFrom<ConstMove>, ExplicitConstructibleFrom<ConstMove>>>);
+
+TEST_FUNC constexpr bool test()
+{
+  // test implicit conversions.
+  // sizeof...(Types) == 1
+  {
+    const cuda::std::tuple<ConstMove> t1{1};
+    cuda::std::tuple<ConvertibleFrom<ConstMove>> t2 = cuda::std::move(t1);
+    assert(cuda::std::get<0>(t2).v.val == 1);
+  }
+
+  // test implicit conversions.
+  // sizeof...(Types) > 1
+  {
+    const cuda::std::tuple<ConstMove, int> t1{1, 2};
+    cuda::std::tuple<ConvertibleFrom<ConstMove>, int> t2 = cuda::std::move(t1);
+    assert(cuda::std::get<0>(t2).v.val == 1);
+    assert(cuda::std::get<1>(t2) == 2);
+  }
+
+  // test explicit conversions.
+  // sizeof...(Types) == 1
+  {
+    const cuda::std::tuple<ConstMove> t1{1};
+    cuda::std::tuple<ExplicitConstructibleFrom<ConstMove>> t2{cuda::std::move(t1)};
+    assert(cuda::std::get<0>(t2).v.val == 1);
+  }
+
+  // test explicit conversions.
+  // sizeof...(Types) > 1
+  {
+    const cuda::std::tuple<ConstMove, int> t1{1, 2};
+    cuda::std::tuple<ExplicitConstructibleFrom<ConstMove>, int> t2{cuda::std::move(t1)};
+    assert(cuda::std::get<0>(t2).v.val == 1);
+    assert(cuda::std::get<1>(t2) == 2);
+  }
+
+  // test constraints
+
+  // sizeof...(Types) != sizeof...(UTypes)
+  static_assert(!cuda::std::is_constructible_v<cuda::std::tuple<int, int>, const cuda::std::tuple<int>&&>);
+  static_assert(!cuda::std::is_constructible_v<cuda::std::tuple<int, int, int>, const cuda::std::tuple<int, int>&&>);
+
+  // !(is_constructible_v<Types, decltype(get<I>(FWD(u)))> && ...)
+  static_assert(
+    !cuda::std::is_constructible_v<cuda::std::tuple<int, NoConstructorFromInt>, const cuda::std::tuple<int, int>&&>);
+
+  // sizeof...(Types) == 1 && other branch of "||" satisfied
+  {
+    const cuda::std::tuple<TracedCopyMove> t1{};
+    cuda::std::tuple<ConvertibleFrom<TracedCopyMove>> t2{cuda::std::move(t1)};
+    assert(constMoveCtrCalled(cuda::std::get<0>(t2).v));
+  }
+
+  // sizeof...(Types) == 1 && is_same_v<T, U>
+  {
+    const cuda::std::tuple<TracedCopyMove> t1{};
+    cuda::std::tuple<TracedCopyMove> t2{t1};
+    assert(!constMoveCtrCalled(cuda::std::get<0>(t2)));
+  }
+
+  // sizeof...(Types) != 1
+  {
+    const cuda::std::tuple<TracedCopyMove, TracedCopyMove> t1{};
+    cuda::std::tuple<TracedCopyMove, TracedCopyMove> t2{cuda::std::move(t1)};
+    assert(constMoveCtrCalled(cuda::std::get<0>(t2)));
+  }
+
+  // These two test points cause gcc to ICE
+#if !TEST_COMPILER(GCC) || TEST_COMPILER(GCC, >=, 13)
+  // sizeof...(Types) == 1 && is_convertible_v<decltype(u), T>
+  {
+    const cuda::std::tuple<CvtFromConstTupleRefRef> t1{};
+    cuda::std::tuple<ConvertibleFrom<CvtFromConstTupleRefRef>> t2{cuda::std::move(t1)};
+    assert(!constMoveCtrCalled(cuda::std::get<0>(t2).v));
+  }
+
+  // sizeof...(Types) == 1 && is_constructible_v<decltype(u), T>
+  {
+    const cuda::std::tuple<ExplicitCtrFromConstTupleRefRef> t1{};
+    cuda::std::tuple<ConvertibleFrom<ExplicitCtrFromConstTupleRefRef>> t2{cuda::std::move(t1)};
+    assert(!constMoveCtrCalled(cuda::std::get<0>(t2).v));
+  }
+#endif
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_lvalue.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_lvalue.pass.cpp
@@ -3,6 +3,7 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_lvalue.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_lvalue.pass.cpp
@@ -174,7 +174,14 @@ TEST_FUNC constexpr bool test()
   {
     cuda::std::tuple<TracedCopyMove, TracedCopyMove> t1{};
     cuda::std::tuple<TracedCopyMove, TracedCopyMove> t2{t1};
-    assert(nonConstCopyCtrCalled(cuda::std::get<0>(t2)));
+    // NOTE: LLVM's test has this as `assert(nonConstCopyCtrCalled())`, but I think this is
+    // wrong. One of the constraints on the lvalue-ref constructor in P2165 is that:
+    //
+    // - different-from<UTuple, tuple> [range.utility.helpers] is true
+    //
+    // So given equal objects, the t2{t1} constructor call should instead select the
+    // copy-constructor `tuple(const tuple& other)` (which our implementation does).
+    assert(!nonConstCopyCtrCalled(cuda::std::get<0>(t2)));
   }
 
   // These two test points cause gcc to ICE, because it cannot follow the (intentionally)

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_lvalue.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_lvalue.pass.cpp
@@ -1,0 +1,204 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/tuple>
+
+// template <class... Types>
+// template <class... UTypes>
+//   constexpr explicit(see below) tuple<Types>::tuple(tuple<UTypes...>&);
+//
+// Constraints:
+//  sizeof...(Types) equals sizeof...(UTypes) &&
+//  (is_constructible_v<Types, decltype(get<I>(FWD(u)))> && ...) is true &&
+//  (
+//    sizeof...(Types) is not 1 ||
+//    (
+//      !is_convertible_v<decltype(u), T> &&
+//      !is_constructible_v<T, decltype(u)> &&
+//      !is_same_v<T, U>
+//    )
+//  )
+
+#include <cuda/std/cassert>
+#include <cuda/std/tuple>
+#include <cuda/std/type_traits>
+
+#include "copy_move_types.h"
+#include "test_macros.h"
+
+struct ImplicitLvalue
+{
+  int* ptr_{};
+
+  TEST_FUNC constexpr ImplicitLvalue(int& x)
+      : ptr_(&x)
+  {}
+
+  TEST_FUNC ImplicitLvalue(const int&) = delete;
+};
+
+struct ExplicitLvalue
+{
+  int* ptr_{};
+
+  TEST_FUNC explicit constexpr ExplicitLvalue(int& x)
+      : ptr_(&x)
+  {}
+
+  TEST_FUNC ExplicitLvalue(const int&) = delete;
+};
+
+// test: The expression inside explicit is equivalent to:
+// !(is_convertible_v<decltype(get<I>(FWD(u))), Types> && ...)
+static_assert(
+  cuda::std::is_convertible_v<cuda::std::tuple<MutableCopy>&, cuda::std::tuple<ConvertibleFrom<MutableCopy>>>);
+
+static_assert(cuda::std::is_convertible_v<cuda::std::tuple<MutableCopy, MutableCopy>&,
+                                          cuda::std::tuple<ConvertibleFrom<MutableCopy>, ConvertibleFrom<MutableCopy>>>);
+
+static_assert(!cuda::std::is_convertible_v<cuda::std::tuple<MutableCopy>&,
+                                           cuda::std::tuple<ExplicitConstructibleFrom<MutableCopy>>>);
+
+static_assert(
+  !cuda::std::is_convertible_v<cuda::std::tuple<MutableCopy, MutableCopy>&,
+                               cuda::std::tuple<ConvertibleFrom<MutableCopy>, ExplicitConstructibleFrom<MutableCopy>>>);
+
+TEST_FUNC constexpr bool test()
+{
+  {
+    using Source = cuda::std::tuple<int>;
+    using Dest   = cuda::std::tuple<int&>;
+
+    static_assert(cuda::std::is_constructible_v<Dest, Source&>);
+    static_assert(cuda::std::is_convertible_v<Source&, Dest>);
+    static_assert(!cuda::std::is_constructible_v<Dest, const Source&>);
+
+    Source src(42);
+    Dest dst = src;
+    assert(&cuda::std::get<0>(dst) == &cuda::std::get<0>(src));
+
+    cuda::std::get<0>(src) = 43;
+    assert(cuda::std::get<0>(dst) == 43);
+  }
+  {
+    using Source = cuda::std::tuple<int>;
+    using Dest   = cuda::std::tuple<ImplicitLvalue>;
+
+    static_assert(cuda::std::is_constructible_v<Dest, Source&>);
+    static_assert(cuda::std::is_convertible_v<Source&, Dest>);
+    static_assert(!cuda::std::is_constructible_v<Dest, const Source&>);
+
+    Source src(42);
+    Dest dst = src;
+    assert(cuda::std::get<0>(dst).ptr_ == &cuda::std::get<0>(src));
+  }
+  {
+    using Source = cuda::std::tuple<int>;
+    using Dest   = cuda::std::tuple<ExplicitLvalue>;
+
+    static_assert(cuda::std::is_constructible_v<Dest, Source&>);
+    static_assert(!cuda::std::is_convertible_v<Source&, Dest>);
+    static_assert(!cuda::std::is_constructible_v<Dest, const Source&>);
+
+    Source src(42);
+    Dest dst(src);
+    assert(cuda::std::get<0>(dst).ptr_ == &cuda::std::get<0>(src));
+  }
+
+  // test implicit conversions.
+  // sizeof...(Types) == 1
+  {
+    cuda::std::tuple<MutableCopy> t1{1};
+    cuda::std::tuple<ConvertibleFrom<MutableCopy>> t2 = t1;
+    assert(cuda::std::get<0>(t2).v.val == 1);
+  }
+
+  // test implicit conversions.
+  // sizeof...(Types) > 1
+  {
+    cuda::std::tuple<MutableCopy, int> t1{1, 2};
+    cuda::std::tuple<ConvertibleFrom<MutableCopy>, int> t2 = t1;
+    assert(cuda::std::get<0>(t2).v.val == 1);
+    assert(cuda::std::get<1>(t2) == 2);
+  }
+
+  // test explicit conversions.
+  // sizeof...(Types) == 1
+  {
+    cuda::std::tuple<MutableCopy> t1{1};
+    cuda::std::tuple<ExplicitConstructibleFrom<MutableCopy>> t2{t1};
+    assert(cuda::std::get<0>(t2).v.val == 1);
+  }
+
+  // test explicit conversions.
+  // sizeof...(Types) > 1
+  {
+    cuda::std::tuple<MutableCopy, int> t1{1, 2};
+    cuda::std::tuple<ExplicitConstructibleFrom<MutableCopy>, int> t2{t1};
+    assert(cuda::std::get<0>(t2).v.val == 1);
+    assert(cuda::std::get<1>(t2) == 2);
+  }
+
+  // test constraints
+
+  // sizeof...(Types) != sizeof...(UTypes)
+  static_assert(!cuda::std::is_constructible_v<cuda::std::tuple<int, int>, cuda::std::tuple<int>&>);
+  static_assert(!cuda::std::is_constructible_v<cuda::std::tuple<int>, cuda::std::tuple<int, int>&>);
+  static_assert(!cuda::std::is_constructible_v<cuda::std::tuple<int, int, int>, cuda::std::tuple<int, int>&>);
+
+  // !(is_constructible_v<Types, decltype(get<I>(FWD(u)))> && ...)
+  static_assert(
+    !cuda::std::is_constructible_v<cuda::std::tuple<int, NoConstructorFromInt>, cuda::std::tuple<int, int>&>);
+
+  // sizeof...(Types) == 1 && other branch of "||" satisfied
+  {
+    cuda::std::tuple<TracedCopyMove> t1{};
+    cuda::std::tuple<ConvertibleFrom<TracedCopyMove>> t2{t1};
+    assert(nonConstCopyCtrCalled(cuda::std::get<0>(t2).v));
+  }
+
+  // sizeof...(Types) == 1 && is_same_v<T, U>
+  {
+    cuda::std::tuple<TracedCopyMove> t1{};
+    cuda::std::tuple<TracedCopyMove> t2{t1};
+    assert(!nonConstCopyCtrCalled(cuda::std::get<0>(t2)));
+  }
+
+  // sizeof...(Types) != 1
+  {
+    cuda::std::tuple<TracedCopyMove, TracedCopyMove> t1{};
+    cuda::std::tuple<TracedCopyMove, TracedCopyMove> t2{t1};
+    assert(nonConstCopyCtrCalled(cuda::std::get<0>(t2)));
+  }
+
+  // These two test points cause gcc to ICE, because it cannot follow the (intentionally)
+  // pathological construction chains and ends up thinking that __tuple_constructible is
+  // self-referential.
+#if !TEST_COMPILER(GCC) || TEST_COMPILER(GCC, >=, 13)
+  // sizeof...(Types) == 1 && is_convertible_v<decltype(u), T>
+  {
+    cuda::std::tuple<CvtFromTupleRef> t1{};
+    cuda::std::tuple<ConvertibleFrom<CvtFromTupleRef>> t2{t1};
+    assert(!nonConstCopyCtrCalled(cuda::std::get<0>(t2).v));
+  }
+
+  // sizeof...(Types) == 1 && is_constructible_v<decltype(u), T>
+  {
+    cuda::std::tuple<ExplicitCtrFromTupleRef> t1{};
+    cuda::std::tuple<ConvertibleFrom<ExplicitCtrFromTupleRef>> t2{t1};
+    assert(!nonConstCopyCtrCalled(cuda::std::get<0>(t2).v));
+  }
+#endif // !gcc || gcc-13+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_non_const_copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_non_const_copy.pass.cpp
@@ -174,14 +174,7 @@ TEST_FUNC constexpr bool test()
   {
     cuda::std::tuple<TracedCopyMove, TracedCopyMove> t1{};
     cuda::std::tuple<TracedCopyMove, TracedCopyMove> t2{t1};
-    // NOTE: LLVM's test has this as `assert(nonConstCopyCtrCalled())`, but I think this is
-    // wrong. One of the constraints on the lvalue-ref constructor in P2165 is that:
-    //
-    // - different-from<UTuple, tuple> [range.utility.helpers] is true
-    //
-    // So given equal objects, the t2{t1} constructor call should instead select the
-    // copy-constructor `tuple(const tuple& other)` (which our implementation does).
-    assert(!nonConstCopyCtrCalled(cuda::std::get<0>(t2)));
+    assert(nonConstCopyCtrCalled(cuda::std::get<0>(t2)));
   }
 
   // These two test points cause gcc to ICE, because it cannot follow the (intentionally)

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.traits/common_reference.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.traits/common_reference.compile.pass.cpp
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/tuple>
+
+// template<class... TTypes, class... UTypes, template<class> class TQual,
+//          template<class> class UQual>
+//   struct basic_common_reference<tuple<TTypes...>, tuple<UTypes...>, TQual, UQual>;
+
+#include <cuda/std/tuple>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+struct no_common_reference
+{};
+
+template <class T>
+struct X
+{};
+
+template <class T>
+struct Y
+{};
+
+struct common_ref
+{};
+
+template <template <class> class TQual, template <class> class UQual>
+struct cuda::std::basic_common_reference<X<int>, Y<int>, TQual, UQual>
+{
+  using type = common_ref;
+};
+
+template <template <class> class TQual, template <class> class UQual>
+struct cuda::std::basic_common_reference<Y<int>, X<int>, TQual, UQual>
+{
+  using type = common_ref;
+};
+
+template <class... Args>
+TEST_FUNC constexpr auto has_common_reference_imp(int)
+  -> decltype(sizeof(typename cuda::std::common_reference<Args...>::type), bool{})
+{
+  return true;
+}
+
+template <class... Args>
+TEST_FUNC constexpr bool has_common_reference_imp(long)
+{
+  return false;
+}
+
+template <class... Args>
+inline constexpr bool has_common_reference =
+  cuda::std::integral_constant<bool, has_common_reference_imp<Args...>(0)>::value;
+
+TEST_FUNC constexpr bool test()
+{
+  {
+    using T = cuda::std::tuple<int>;
+    static_assert(cuda::std::same_as<cuda::std::common_reference_t<T, T>, T>);
+  }
+  {
+    using T        = cuda::std::tuple<int&, const long&>;
+    using U        = cuda::std::tuple<const int&, long&>;
+    using Expected = cuda::std::tuple<const int&, const long&>;
+    static_assert(has_common_reference<T, U>);
+    static_assert(cuda::std::same_as<cuda::std::common_reference_t<T, U>, Expected>);
+  }
+  {
+    using T        = cuda::std::tuple<X<int>>;
+    using U        = cuda::std::tuple<Y<int>>;
+    using Expected = cuda::std::tuple<common_ref>;
+    static_assert(has_common_reference<T, U>);
+    static_assert(cuda::std::same_as<cuda::std::common_reference_t<T, U>, Expected>);
+  }
+  {
+    using T = cuda::std::tuple<X<double>>;
+    using U = cuda::std::tuple<Y<double>>;
+    // Only X<int> and Y<int> are specialized
+    static_assert(!has_common_reference<T, U>);
+  }
+  {
+    using T = cuda::std::tuple<int>;
+    using U = cuda::std::tuple<int, int>;
+    static_assert(!has_common_reference<T, U>);
+  }
+  {
+    using T = cuda::std::tuple<int, no_common_reference>;
+    using U = cuda::std::tuple<int, int>;
+    static_assert(!has_common_reference<T, U>);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.traits/common_type.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.traits/common_type.compile.pass.cpp
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/tuple>
+
+// template<class... TTypes, class... UTypes>
+//   struct common_type<tuple<TTypes...>, tuple<UTypes...>>;
+
+#include <cuda/std/tuple>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+struct no_common_type
+{};
+
+template <class... Args>
+TEST_FUNC constexpr auto has_common_type_imp(int)
+  -> decltype(sizeof(typename cuda::std::common_type<Args...>::type), bool{})
+{
+  return true;
+}
+
+template <class... Args>
+TEST_FUNC constexpr bool has_common_type_imp(long)
+{
+  return false;
+}
+
+template <class... Args>
+static constexpr bool has_common_type = cuda::std::integral_constant<bool, has_common_type_imp<Args...>(0)>::value;
+
+TEST_FUNC constexpr bool test()
+{
+  {
+    using T = cuda::std::tuple<int>;
+    static_assert(has_common_type<T, T>);
+    static_assert(cuda::std::same_as<cuda::std::common_type_t<T, T>, T>);
+  }
+  {
+    using T        = cuda::std::tuple<const int, short, const long&>;
+    using U        = cuda::std::tuple<int, long, volatile long&>;
+    using Expected = cuda::std::tuple<int, long, long>;
+    static_assert(has_common_type<T, U>);
+    static_assert(cuda::std::same_as<cuda::std::common_type_t<T, U>, Expected>);
+  }
+  {
+    using T = cuda::std::tuple<int>;
+    using U = cuda::std::tuple<int, int>;
+    static_assert(!has_common_type<T, U>);
+  }
+  {
+    using T = cuda::std::tuple<int, no_common_type>;
+    using U = cuda::std::tuple<int, int>;
+    static_assert(!has_common_type<T, U>);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/support/copy_move_types.h
+++ b/libcudacxx/test/support/copy_move_types.h
@@ -1,0 +1,489 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TEST_STD_UTILITIES_TUPLE_CNSTR_TYPES_H
+#define TEST_STD_UTILITIES_TUPLE_CNSTR_TYPES_H
+
+#include <cuda/std/tuple>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+#include "test_macros.h"
+
+#if !TEST_COMPILER(NVRTC)
+#  include "test_allocator.h"
+#endif
+
+// Types that can be used to test copy/move operations
+
+struct MutableCopy
+{
+  int val{};
+  bool alloc_constructed{false};
+
+  constexpr MutableCopy() = default;
+  TEST_FUNC constexpr MutableCopy(int _val)
+      : val(_val)
+  {}
+  constexpr MutableCopy(MutableCopy&)                 = default;
+  TEST_FUNC constexpr MutableCopy(const MutableCopy&) = delete;
+
+#if !TEST_COMPILER(NVRTC)
+  TEST_FUNC constexpr MutableCopy(cuda::std::allocator_arg_t, const test_allocator<int>&, MutableCopy& o)
+      : val(o.val)
+      , alloc_constructed(true)
+  {}
+#endif
+};
+
+#if !TEST_COMPILER(NVRTC)
+template <>
+struct cuda::std::uses_allocator<MutableCopy, test_allocator<int>> : cuda::std::true_type
+{};
+#endif
+
+struct ConstCopy
+{
+  int val{};
+  bool alloc_constructed{false};
+
+  constexpr ConstCopy() = default;
+  TEST_FUNC constexpr ConstCopy(int _val)
+      : val(_val)
+  {}
+  constexpr ConstCopy(const ConstCopy&)     = default;
+  TEST_FUNC constexpr ConstCopy(ConstCopy&) = delete;
+
+#if !TEST_COMPILER(NVRTC)
+  TEST_FUNC constexpr ConstCopy(cuda::std::allocator_arg_t, const test_allocator<int>&, const ConstCopy& o)
+      : val(o.val)
+      , alloc_constructed(true)
+  {}
+#endif
+};
+
+#if !TEST_COMPILER(NVRTC)
+template <>
+struct cuda::std::uses_allocator<ConstCopy, test_allocator<int>> : cuda::std::true_type
+{};
+#endif
+
+struct MutableMove
+{
+  int val{};
+  bool alloc_constructed{false};
+
+  constexpr MutableMove() = default;
+  TEST_FUNC constexpr MutableMove(int _val)
+      : val(_val)
+  {}
+  constexpr MutableMove(MutableMove&&)                 = default;
+  TEST_FUNC constexpr MutableMove(const MutableMove&&) = delete;
+
+#if !TEST_COMPILER(NVRTC)
+  TEST_FUNC constexpr MutableMove(cuda::std::allocator_arg_t, const test_allocator<int>&, MutableMove&& o)
+      : val(o.val)
+      , alloc_constructed(true)
+  {}
+#endif
+};
+
+#if !TEST_COMPILER(NVRTC)
+template <>
+struct cuda::std::uses_allocator<MutableMove, test_allocator<int>> : cuda::std::true_type
+{};
+#endif
+
+struct ConstMove
+{
+  int val{};
+  bool alloc_constructed{false};
+
+  constexpr ConstMove() = default;
+  TEST_FUNC constexpr ConstMove(int _val)
+      : val(_val)
+  {}
+  TEST_FUNC constexpr ConstMove(const ConstMove&& o) noexcept
+      : val(o.val)
+  {}
+  TEST_FUNC constexpr ConstMove(ConstMove&&) = delete;
+
+#if !TEST_COMPILER(NVRTC)
+  TEST_FUNC constexpr ConstMove(cuda::std::allocator_arg_t, const test_allocator<int>&, const ConstMove&& o)
+      : val(o.val)
+      , alloc_constructed(true)
+  {}
+#endif
+};
+
+#if !TEST_COMPILER(NVRTC)
+template <>
+struct cuda::std::uses_allocator<ConstMove, test_allocator<int>> : cuda::std::true_type
+{};
+#endif
+
+template <class T>
+struct ConvertibleFrom
+{
+  T v{};
+  bool alloc_constructed{false};
+
+  constexpr ConvertibleFrom() = default;
+
+  template <class U = T, cuda::std::enable_if_t<cuda::std::is_constructible_v<U, U&>, int> = 0>
+  TEST_FUNC constexpr ConvertibleFrom(T& _v)
+      : v(_v)
+  {}
+
+  template <class U                                                                                              = T,
+            cuda::std::enable_if_t<cuda::std::is_constructible_v<U, const U&> && !cuda::std::is_const_v<U>, int> = 0>
+  TEST_FUNC constexpr ConvertibleFrom(const T& _v)
+      : v(_v)
+  {}
+
+  template <class U = T, cuda::std::enable_if_t<cuda::std::is_constructible_v<U, U&&>, int> = 0>
+  TEST_FUNC constexpr ConvertibleFrom(T&& _v)
+      : v(cuda::std::move(_v))
+  {}
+
+  template <class U                                                                                               = T,
+            cuda::std::enable_if_t<cuda::std::is_constructible_v<U, const U&&> && !cuda::std::is_const_v<U>, int> = 0>
+  TEST_FUNC constexpr ConvertibleFrom(const T&& _v)
+      : v(cuda::std::move(_v))
+  {}
+
+#if !TEST_COMPILER(NVRTC)
+  template <class U, cuda::std::enable_if_t<cuda::std::is_constructible_v<ConvertibleFrom, U&&>, int> = 0>
+  TEST_FUNC constexpr ConvertibleFrom(cuda::std::allocator_arg_t, const test_allocator<int>&, U&& _u)
+      : ConvertibleFrom{cuda::std::forward<U>(_u)}
+  {
+    alloc_constructed = true;
+  }
+#endif
+};
+
+#if !TEST_COMPILER(NVRTC)
+template <class T>
+struct cuda::std::uses_allocator<ConvertibleFrom<T>, test_allocator<int>> : cuda::std::true_type
+{};
+#endif
+
+template <class T>
+struct ExplicitConstructibleFrom
+{
+  T v{};
+  bool alloc_constructed{false};
+
+  constexpr explicit ExplicitConstructibleFrom() = default;
+
+  template <class U = T, cuda::std::enable_if_t<cuda::std::is_constructible_v<U, U&>, int> = 0>
+  TEST_FUNC constexpr explicit ExplicitConstructibleFrom(T& _v)
+      : v(_v)
+  {}
+
+  template <class U                                                                                              = T,
+            cuda::std::enable_if_t<cuda::std::is_constructible_v<U, const U&> && !cuda::std::is_const_v<U>, int> = 0>
+  TEST_FUNC constexpr explicit ExplicitConstructibleFrom(const T& _v)
+      : v(_v)
+  {}
+
+  template <class U = T, cuda::std::enable_if_t<cuda::std::is_constructible_v<U, U&&>, int> = 0>
+  TEST_FUNC constexpr explicit ExplicitConstructibleFrom(T&& _v)
+      : v(cuda::std::move(_v))
+  {}
+
+  template <class U                                                                                               = T,
+            cuda::std::enable_if_t<cuda::std::is_constructible_v<U, const U&&> && !cuda::std::is_const_v<U>, int> = 0>
+  TEST_FUNC constexpr explicit ExplicitConstructibleFrom(const T&& _v)
+      : v(cuda::std::move(_v))
+  {}
+
+#if !TEST_COMPILER(NVRTC)
+  template <class U, cuda::std::enable_if_t<cuda::std::is_constructible_v<ExplicitConstructibleFrom, U&&>, int> = 0>
+  TEST_FUNC constexpr ExplicitConstructibleFrom(cuda::std::allocator_arg_t, const test_allocator<int>&, U&& _u)
+      : ExplicitConstructibleFrom{cuda::std::forward<U>(_u)}
+  {
+    alloc_constructed = true;
+  }
+#endif
+};
+
+#if !TEST_COMPILER(NVRTC)
+template <class T>
+struct cuda::std::uses_allocator<ExplicitConstructibleFrom<T>, test_allocator<int>> : cuda::std::true_type
+{};
+#endif
+
+struct TracedCopyMove
+{
+  int nonConstCopy       = 0;
+  int constCopy          = 0;
+  int nonConstMove       = 0;
+  int constMove          = 0;
+  bool alloc_constructed = false;
+
+  constexpr TracedCopyMove() = default;
+  TEST_FUNC constexpr TracedCopyMove(const TracedCopyMove& other)
+      : nonConstCopy(other.nonConstCopy)
+      , constCopy(other.constCopy + 1)
+      , nonConstMove(other.nonConstMove)
+      , constMove(other.constMove)
+  {}
+  TEST_FUNC constexpr TracedCopyMove(TracedCopyMove& other)
+      : nonConstCopy(other.nonConstCopy + 1)
+      , constCopy(other.constCopy)
+      , nonConstMove(other.nonConstMove)
+      , constMove(other.constMove)
+  {}
+
+  TEST_FUNC constexpr TracedCopyMove(TracedCopyMove&& other) noexcept
+      : nonConstCopy(other.nonConstCopy)
+      , constCopy(other.constCopy)
+      , nonConstMove(other.nonConstMove + 1)
+      , constMove(other.constMove)
+  {}
+
+  TEST_FUNC constexpr TracedCopyMove(const TracedCopyMove&& other) noexcept
+      : nonConstCopy(other.nonConstCopy)
+      , constCopy(other.constCopy)
+      , nonConstMove(other.nonConstMove)
+      , constMove(other.constMove + 1)
+  {}
+
+#if !TEST_COMPILER(NVRTC)
+  template <class U, cuda::std::enable_if_t<cuda::std::is_constructible_v<TracedCopyMove, U&&>, int> = 0>
+  TEST_FUNC constexpr TracedCopyMove(cuda::std::allocator_arg_t, const test_allocator<int>&, U&& _u)
+      : TracedCopyMove{cuda::std::forward<U>(_u)}
+  {
+    alloc_constructed = true;
+  }
+#endif
+};
+
+#if !TEST_COMPILER(NVRTC)
+template <>
+struct cuda::std::uses_allocator<TracedCopyMove, test_allocator<int>> : cuda::std::true_type
+{};
+#endif
+
+// If the constructor tuple(tuple<UTypes...>&) is not available,
+// the fallback call to `tuple(const tuple&) = default;` or any other
+// constructor that takes const ref would increment the constCopy.
+TEST_FUNC constexpr bool nonConstCopyCtrCalled(const TracedCopyMove& obj)
+{
+  return obj.nonConstCopy == 1 && obj.constCopy == 0 && obj.constMove == 0 && obj.nonConstMove == 0;
+}
+
+// If the constructor tuple(const tuple<UTypes...>&&) is not available,
+// the fallback call to `tuple(const tuple&) = default;` or any other
+// constructor that takes const ref would increment the constCopy.
+TEST_FUNC constexpr bool constMoveCtrCalled(const TracedCopyMove& obj)
+{
+  return obj.nonConstMove == 0 && obj.constMove == 1 && obj.constCopy == 0 && obj.nonConstCopy == 0;
+}
+
+struct NoConstructorFromInt
+{};
+
+struct CvtFromTupleRef : TracedCopyMove
+{
+  constexpr CvtFromTupleRef() = default;
+  TEST_FUNC constexpr CvtFromTupleRef(cuda::std::tuple<CvtFromTupleRef>& other)
+      : TracedCopyMove(static_cast<TracedCopyMove&>(cuda::std::get<0>(other)))
+  {}
+};
+
+struct ExplicitCtrFromTupleRef : TracedCopyMove
+{
+  constexpr explicit ExplicitCtrFromTupleRef() = default;
+  TEST_FUNC constexpr explicit ExplicitCtrFromTupleRef(cuda::std::tuple<ExplicitCtrFromTupleRef>& other)
+      : TracedCopyMove(static_cast<TracedCopyMove&>(cuda::std::get<0>(other)))
+  {}
+};
+
+struct CvtFromConstTupleRefRef : TracedCopyMove
+{
+  constexpr CvtFromConstTupleRefRef() = default;
+  TEST_FUNC constexpr CvtFromConstTupleRefRef(const cuda::std::tuple<CvtFromConstTupleRefRef>&& other)
+      : TracedCopyMove(static_cast<const TracedCopyMove&&>(cuda::std::get<0>(other)))
+  {}
+};
+
+struct ExplicitCtrFromConstTupleRefRef : TracedCopyMove
+{
+  constexpr explicit ExplicitCtrFromConstTupleRefRef() = default;
+  TEST_FUNC constexpr explicit ExplicitCtrFromConstTupleRefRef(
+    cuda::std::tuple<const ExplicitCtrFromConstTupleRefRef>&& other)
+      : TracedCopyMove(static_cast<const TracedCopyMove&&>(cuda::std::get<0>(other)))
+  {}
+};
+
+template <class T>
+TEST_FUNC constexpr void conversion_test(T)
+{}
+
+template <class T, class... Args>
+struct ImplicitlyConstructibleImpl
+{
+  template <class U, class... As>
+  TEST_FUNC static constexpr auto test(int)
+    -> decltype(conversion_test<U>({cuda::std::declval<As>()...}), cuda::std::true_type{});
+
+  template <class, class...>
+  TEST_FUNC static constexpr auto test(...) -> cuda::std::false_type;
+
+  static constexpr bool value = decltype(test<T, Args...>(0))::value;
+};
+
+template <class T, class... Args>
+inline constexpr bool ImplicitlyConstructible = ImplicitlyConstructibleImpl<T, Args...>::value;
+
+struct CopyAssign
+{
+  int val{};
+
+  constexpr CopyAssign() = default;
+  TEST_FUNC constexpr CopyAssign(int v)
+      : val(v)
+  {}
+
+  constexpr CopyAssign& operator=(const CopyAssign&) = default;
+
+  TEST_FUNC constexpr const CopyAssign& operator=(const CopyAssign&) const = delete;
+  TEST_FUNC constexpr CopyAssign& operator=(CopyAssign&&)                  = delete;
+  TEST_FUNC constexpr const CopyAssign& operator=(CopyAssign&&) const      = delete;
+};
+
+struct ConstCopyAssign
+{
+  mutable int val{};
+
+  constexpr ConstCopyAssign() = default;
+  TEST_FUNC constexpr ConstCopyAssign(int v)
+      : val(v)
+  {}
+
+  TEST_FUNC constexpr const ConstCopyAssign& operator=(const ConstCopyAssign& other) const
+  {
+    val = other.val;
+    return *this;
+  }
+
+  TEST_FUNC constexpr ConstCopyAssign& operator=(const ConstCopyAssign&)        = delete;
+  TEST_FUNC constexpr ConstCopyAssign& operator=(ConstCopyAssign&&)             = delete;
+  TEST_FUNC constexpr const ConstCopyAssign& operator=(ConstCopyAssign&&) const = delete;
+};
+
+struct MoveAssign
+{
+  int val{};
+
+  constexpr MoveAssign() = default;
+  TEST_FUNC constexpr MoveAssign(int v)
+      : val(v)
+  {}
+
+  constexpr MoveAssign& operator=(MoveAssign&&) = default;
+
+  TEST_FUNC constexpr MoveAssign& operator=(const MoveAssign&)             = delete;
+  TEST_FUNC constexpr const MoveAssign& operator=(const MoveAssign&) const = delete;
+  TEST_FUNC constexpr const MoveAssign& operator=(MoveAssign&&) const      = delete;
+};
+
+struct ConstMoveAssign
+{
+  mutable int val{};
+
+  constexpr ConstMoveAssign() = default;
+  TEST_FUNC constexpr ConstMoveAssign(int v)
+      : val(v)
+  {}
+
+  TEST_FUNC constexpr const ConstMoveAssign& operator=(ConstMoveAssign&& other) const noexcept
+  {
+    val = other.val;
+    return *this;
+  }
+
+  TEST_FUNC constexpr ConstMoveAssign& operator=(const ConstMoveAssign&)             = delete;
+  TEST_FUNC constexpr const ConstMoveAssign& operator=(const ConstMoveAssign&) const = delete;
+  TEST_FUNC constexpr ConstMoveAssign& operator=(ConstMoveAssign&&)                  = delete;
+};
+
+template <class T>
+struct AssignableFrom
+{
+  T v{};
+
+  constexpr AssignableFrom() = default;
+
+  template <class U, cuda::std::enable_if_t<cuda::std::is_constructible_v<T, U&&>, int> = 0>
+  TEST_FUNC constexpr AssignableFrom(U&& u)
+      : v(cuda::std::forward<U>(u))
+  {}
+
+  template <class U = T, cuda::std::enable_if_t<cuda::std::is_copy_assignable_v<U>, int> = 0>
+  TEST_FUNC constexpr AssignableFrom& operator=(const T& t)
+  {
+    v = t;
+    return *this;
+  }
+
+  template <class U = T, cuda::std::enable_if_t<cuda::std::is_move_assignable_v<U>, int> = 0>
+  TEST_FUNC constexpr AssignableFrom& operator=(T&& t)
+  {
+    v = cuda::std::move(t);
+    return *this;
+  }
+
+  template <class U = T, cuda::std::enable_if_t<cuda::std::is_assignable_v<const U&, const U&>, int> = 0>
+  TEST_FUNC constexpr const AssignableFrom& operator=(const T& t) const
+  {
+    v = t;
+    return *this;
+  }
+
+  template <class U = T, cuda::std::enable_if_t<cuda::std::is_assignable_v<const U&, U&&>, int> = 0>
+  TEST_FUNC constexpr const AssignableFrom& operator=(T&& t) const
+  {
+    v = cuda::std::move(t);
+    return *this;
+  }
+};
+
+struct TracedAssignment
+{
+  int copyAssign              = 0;
+  mutable int constCopyAssign = 0;
+  int moveAssign              = 0;
+  mutable int constMoveAssign = 0;
+
+  constexpr TracedAssignment() = default;
+
+  TEST_FUNC constexpr TracedAssignment& operator=(const TracedAssignment&)
+  {
+    copyAssign++;
+    return *this;
+  }
+  TEST_FUNC constexpr const TracedAssignment& operator=(const TracedAssignment&) const
+  {
+    constCopyAssign++;
+    return *this;
+  }
+  TEST_FUNC constexpr TracedAssignment& operator=(TracedAssignment&&) noexcept
+  {
+    moveAssign++;
+    return *this;
+  }
+  TEST_FUNC constexpr const TracedAssignment& operator=(TracedAssignment&&) const noexcept
+  {
+    constMoveAssign++;
+    return *this;
+  }
+};
+#endif // TEST_STD_UTILITIES_TUPLE_CNSTR_TYPES_H

--- a/libcudacxx/test/support/copy_move_types.h
+++ b/libcudacxx/test/support/copy_move_types.h
@@ -3,6 +3,7 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/libcudacxx/test/support/copy_move_types.h
+++ b/libcudacxx/test/support/copy_move_types.h
@@ -307,23 +307,6 @@ struct ExplicitCtrFromTupleRef : TracedCopyMove
   {}
 };
 
-struct CvtFromConstTupleRefRef : TracedCopyMove
-{
-  constexpr CvtFromConstTupleRefRef() = default;
-  TEST_FUNC constexpr CvtFromConstTupleRefRef(const cuda::std::tuple<CvtFromConstTupleRefRef>&& other)
-      : TracedCopyMove(static_cast<const TracedCopyMove&&>(cuda::std::get<0>(other)))
-  {}
-};
-
-struct ExplicitCtrFromConstTupleRefRef : TracedCopyMove
-{
-  constexpr explicit ExplicitCtrFromConstTupleRefRef() = default;
-  TEST_FUNC constexpr explicit ExplicitCtrFromConstTupleRefRef(
-    cuda::std::tuple<const ExplicitCtrFromConstTupleRefRef>&& other)
-      : TracedCopyMove(static_cast<const TracedCopyMove&&>(cuda::std::get<0>(other)))
-  {}
-};
-
 template <class T>
 TEST_FUNC constexpr void conversion_test(T)
 {}

--- a/libcudacxx/test/support/copy_move_types.h
+++ b/libcudacxx/test/support/copy_move_types.h
@@ -307,6 +307,23 @@ struct ExplicitCtrFromTupleRef : TracedCopyMove
   {}
 };
 
+struct CvtFromConstTupleRefRef : TracedCopyMove
+{
+  constexpr CvtFromConstTupleRefRef() = default;
+  TEST_FUNC constexpr CvtFromConstTupleRefRef(cuda::std::tuple<const CvtFromConstTupleRefRef>&& other)
+      : TracedCopyMove(static_cast<const TracedCopyMove&&>(cuda::std::get<0>(other)))
+  {}
+};
+
+struct ExplicitCtrFromConstTupleRefRef : TracedCopyMove
+{
+  constexpr explicit ExplicitCtrFromConstTupleRefRef() = default;
+  TEST_FUNC constexpr explicit ExplicitCtrFromConstTupleRefRef(
+    cuda::std::tuple<const ExplicitCtrFromConstTupleRefRef>&& other)
+      : TracedCopyMove(static_cast<const TracedCopyMove&&>(cuda::std::get<0>(other)))
+  {}
+};
+
 template <class T>
 TEST_FUNC constexpr void conversion_test(T)
 {}

--- a/libcudacxx/test/support/copy_move_types.h
+++ b/libcudacxx/test/support/copy_move_types.h
@@ -18,7 +18,7 @@
 
 #if !TEST_COMPILER(NVRTC)
 #  include "test_allocator.h"
-#endif
+#endif // !TEST_COMPILER(NVRTC)
 
 // Types that can be used to test copy/move operations
 
@@ -39,14 +39,14 @@ struct MutableCopy
       : val(o.val)
       , alloc_constructed(true)
   {}
-#endif
+#endif // !TEST_COMPILER(NVRTC)
 };
 
 #if !TEST_COMPILER(NVRTC)
 template <>
 struct cuda::std::uses_allocator<MutableCopy, test_allocator<int>> : cuda::std::true_type
 {};
-#endif
+#endif // !TEST_COMPILER(NVRTC)
 
 struct ConstCopy
 {
@@ -65,14 +65,14 @@ struct ConstCopy
       : val(o.val)
       , alloc_constructed(true)
   {}
-#endif
+#endif // !TEST_COMPILER(NVRTC)
 };
 
 #if !TEST_COMPILER(NVRTC)
 template <>
 struct cuda::std::uses_allocator<ConstCopy, test_allocator<int>> : cuda::std::true_type
 {};
-#endif
+#endif // !TEST_COMPILER(NVRTC)
 
 struct MutableMove
 {
@@ -91,14 +91,14 @@ struct MutableMove
       : val(o.val)
       , alloc_constructed(true)
   {}
-#endif
+#endif // !TEST_COMPILER(NVRTC)
 };
 
 #if !TEST_COMPILER(NVRTC)
 template <>
 struct cuda::std::uses_allocator<MutableMove, test_allocator<int>> : cuda::std::true_type
 {};
-#endif
+#endif // !TEST_COMPILER(NVRTC)
 
 struct ConstMove
 {
@@ -119,14 +119,14 @@ struct ConstMove
       : val(o.val)
       , alloc_constructed(true)
   {}
-#endif
+#endif // !TEST_COMPILER(NVRTC)
 };
 
 #if !TEST_COMPILER(NVRTC)
 template <>
 struct cuda::std::uses_allocator<ConstMove, test_allocator<int>> : cuda::std::true_type
 {};
-#endif
+#endif // !TEST_COMPILER(NVRTC)
 
 template <class T>
 struct ConvertibleFrom
@@ -165,14 +165,14 @@ struct ConvertibleFrom
   {
     alloc_constructed = true;
   }
-#endif
+#endif // !TEST_COMPILER(NVRTC)
 };
 
 #if !TEST_COMPILER(NVRTC)
 template <class T>
 struct cuda::std::uses_allocator<ConvertibleFrom<T>, test_allocator<int>> : cuda::std::true_type
 {};
-#endif
+#endif // !TEST_COMPILER(NVRTC)
 
 template <class T>
 struct ExplicitConstructibleFrom
@@ -211,14 +211,14 @@ struct ExplicitConstructibleFrom
   {
     alloc_constructed = true;
   }
-#endif
+#endif // !TEST_COMPILER(NVRTC)
 };
 
 #if !TEST_COMPILER(NVRTC)
 template <class T>
 struct cuda::std::uses_allocator<ExplicitConstructibleFrom<T>, test_allocator<int>> : cuda::std::true_type
 {};
-#endif
+#endif // !TEST_COMPILER(NVRTC)
 
 struct TracedCopyMove
 {
@@ -263,14 +263,14 @@ struct TracedCopyMove
   {
     alloc_constructed = true;
   }
-#endif
+#endif // !TEST_COMPILER(NVRTC)
 };
 
 #if !TEST_COMPILER(NVRTC)
 template <>
 struct cuda::std::uses_allocator<TracedCopyMove, test_allocator<int>> : cuda::std::true_type
 {};
-#endif
+#endif // !TEST_COMPILER(NVRTC)
 
 // If the constructor tuple(tuple<UTypes...>&) is not available,
 // the fallback call to `tuple(const tuple&) = default;` or any other
@@ -369,7 +369,8 @@ struct ConstCopyAssign
       : val(v)
   {}
 
-  TEST_FUNC constexpr const ConstCopyAssign& operator=(const ConstCopyAssign& other) const
+  TEST_FUNC constexpr const ConstCopyAssign& operator=( // NOLINT(misc-unconventional-assign-operator)
+    const ConstCopyAssign& other) const
   {
     val = other.val;
     return *this;
@@ -405,6 +406,7 @@ struct ConstMoveAssign
       : val(v)
   {}
 
+  // NOLINTNEXTLINE(misc-unconventional-assign-operator)
   TEST_FUNC constexpr const ConstMoveAssign& operator=(ConstMoveAssign&& other) const noexcept
   {
     val = other.val;
@@ -424,7 +426,7 @@ struct AssignableFrom
   constexpr AssignableFrom() = default;
 
   template <class U, cuda::std::enable_if_t<cuda::std::is_constructible_v<T, U&&>, int> = 0>
-  TEST_FUNC constexpr AssignableFrom(U&& u)
+  TEST_FUNC constexpr AssignableFrom(U&& u) // NOLINT(bugprone-forwarding-reference-overload)
       : v(cuda::std::forward<U>(u))
   {}
 
@@ -443,14 +445,16 @@ struct AssignableFrom
   }
 
   template <class U = T, cuda::std::enable_if_t<cuda::std::is_assignable_v<const U&, const U&>, int> = 0>
-  TEST_FUNC constexpr const AssignableFrom& operator=(const T& t) const
+  TEST_FUNC constexpr const AssignableFrom& operator=( // NOLINT(misc-unconventional-assign-operator)
+    const T& t) const
   {
     v = t;
     return *this;
   }
 
   template <class U = T, cuda::std::enable_if_t<cuda::std::is_assignable_v<const U&, U&&>, int> = 0>
-  TEST_FUNC constexpr const AssignableFrom& operator=(T&& t) const
+  TEST_FUNC constexpr const AssignableFrom& operator=( // NOLINT(misc-unconventional-assign-operator)
+    T&& t) const
   {
     v = cuda::std::move(t);
     return *this;
@@ -471,7 +475,8 @@ struct TracedAssignment
     copyAssign++;
     return *this;
   }
-  TEST_FUNC constexpr const TracedAssignment& operator=(const TracedAssignment&) const
+  TEST_FUNC constexpr const TracedAssignment& operator=( // NOLINT(misc-unconventional-assign-operator)
+    const TracedAssignment&) const
   {
     constCopyAssign++;
     return *this;
@@ -481,7 +486,8 @@ struct TracedAssignment
     moveAssign++;
     return *this;
   }
-  TEST_FUNC constexpr const TracedAssignment& operator=(TracedAssignment&&) const noexcept
+  TEST_FUNC constexpr const TracedAssignment& operator=( // NOLINT(misc-unconventional-assign-operator)
+    TracedAssignment&&) const noexcept
   {
     constMoveAssign++;
     return *this;


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

Add C++23 lvalue conversion constructors to `cuda::std::tuple`. This is _also_ needed by `zip_view` as, in conjunction with https://github.com/NVIDIA/cccl/pull/8885, it now means that in:
```c++
std::vector<int> v;

cuda::std::views::zip(v, v) | cuda::std::views::transform(...);
// Internally above, the zip_view iterator creates and holds a `tuple<int, int>`
// which it passes to the transform as `tuple<int, int> &`. The transform, however,
// expects to construct a `tuple<int&, int&>` which is _legal_ from a reference but
// currently cannot be done
```

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
