### PR TITLE
Use `_CCCL_KERNEL_ATTRIBUTES` in `launch.h`

### DIFF
--- a/libcudacxx/include/cuda/__launch/launch.h
+++ b/libcudacxx/include/cuda/__launch/launch.h
@@ -290,9 +290,12 @@ inline constexpr bool __invoke_kernel_functor_with_config_v =
 // 2. With __launch_bounds__ for non-cluster launches with compile-time known block size.
 // 3. Fallback without any attributes.
 
+// GCC falsely throws the following error without the below suppression:
+//
+// libcudacxx/include/cuda/__launch/launch.h:311:119: error: '__visibility__' attribute ignored [-Werror=attributes]
+
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
-_CCCL_DIAG_SUPPRESS_CLANG("-Wattributes")
 
 template <class _Config, class _Kernel, class... _Args>
 _CCCL_KERNEL_ATTRIBUTES void

--- a/libcudacxx/include/cuda/__launch/launch.h
+++ b/libcudacxx/include/cuda/__launch/launch.h
@@ -290,8 +290,12 @@ inline constexpr bool __invoke_kernel_functor_with_config_v =
 // 2. With __launch_bounds__ for non-cluster launches with compile-time known block size.
 // 3. Fallback without any attributes.
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wattributes")
+
 template <class _Config, class _Kernel, class... _Args>
-__global__ static void
+_CCCL_KERNEL_ATTRIBUTES void
 // todo(dabayer): Re-enable this once cuda::launch with kernels that were compiled with .blocksareclusters directive is
 // fixed.
 //
@@ -316,7 +320,7 @@ __kernel_launcher_with_block_size(const _CCCL_GRID_CONSTANT _Config __conf, _Ker
 }
 
 template <class _Config, class _Kernel, class... _Args>
-__global__ static void _CCCL_LAUNCH_BOUNDS(::cuda::__max_nthreads_per_block<typename _Config::hierarchy_type>())
+_CCCL_KERNEL_ATTRIBUTES void _CCCL_LAUNCH_BOUNDS(::cuda::__max_nthreads_per_block<typename _Config::hierarchy_type>())
 __kernel_launcher_with_launch_bounds(const _CCCL_GRID_CONSTANT _Config __conf, _Kernel __kernel_fn, _Args... __args)
 {
   ::cuda::__assume_known_info<typename _Config::hierarchy_type>();
@@ -332,7 +336,8 @@ __kernel_launcher_with_launch_bounds(const _CCCL_GRID_CONSTANT _Config __conf, _
 }
 
 template <class _Config, class _Kernel, class... _Args>
-__global__ static void __kernel_launcher(const _CCCL_GRID_CONSTANT _Config __conf, _Kernel __kernel_fn, _Args... __args)
+_CCCL_KERNEL_ATTRIBUTES void
+__kernel_launcher(const _CCCL_GRID_CONSTANT _Config __conf, _Kernel __kernel_fn, _Args... __args)
 {
   ::cuda::__assume_known_info<typename _Config::hierarchy_type>();
 
@@ -345,6 +350,8 @@ __global__ static void __kernel_launcher(const _CCCL_GRID_CONSTANT _Config __con
     __kernel_fn(__args...);
   }
 }
+
+_CCCL_DIAG_POP
 
 // Return void pointer to work around NVCC bug with __restrict__
 template <class _Kernel, class _Config, class... _Args>


### PR DESCRIPTION
## Description

Replace `__global__` with `_CCCL_KERNEL_ATTRIBUTES` in `libcudacxx/include/cuda/__launch/launch.h`.

Follow-up to https://github.com/NVIDIA/cccl/pull/8882.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
