### PR TITLE
[cudax] Implement `identity_mapping`

### DIFF
--- a/cudax/include/cuda/experimental/__group/fwd.cuh
+++ b/cudax/include/cuda/experimental/__group/fwd.cuh
@@ -75,6 +75,8 @@ class group_by;
 template <class _Data, bool _IsExahustive>
 class group_as;
 
+class identity_mapping;
+
 // synchronizers
 
 class lane_synchronizer;

--- a/cudax/include/cuda/experimental/__group/mapping/identity_mapping.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/identity_mapping.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_EXPERIMENTAL_GROUP
-#define _CUDA_EXPERIMENTAL_GROUP
+#ifndef _CUDA_EXPERIMENTAL___GROUP_MAPPING_IDENTITY_MAPPING_CUH
+#define _CUDA_EXPERIMENTAL___GROUP_MAPPING_IDENTITY_MAPPING_CUH
 
 #include <cuda/std/detail/__config>
 
@@ -21,18 +21,30 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/experimental/__group/concepts.cuh>
 #include <cuda/experimental/__group/fwd.cuh>
-#include <cuda/experimental/__group/group.cuh>
-#include <cuda/experimental/__group/implicit_hierarchy.cuh>
-#include <cuda/experimental/__group/mapping/composite_mapping.cuh>
-#include <cuda/experimental/__group/mapping/group_as.cuh>
-#include <cuda/experimental/__group/mapping/group_by.cuh>
-#include <cuda/experimental/__group/mapping/identity_mapping.cuh>
-#include <cuda/experimental/__group/queries.cuh>
-#include <cuda/experimental/__group/synchronizer/barrier_synchronizer.cuh>
-#include <cuda/experimental/__group/synchronizer/lane_synchronizer.cuh>
-#include <cuda/experimental/__group/this_group.cuh>
-#include <cuda/experimental/__group/traits.cuh>
 
-#endif // _CUDA_EXPERIMENTAL_GROUP
+#include <cuda/std/__cccl/prologue.h>
+
+#if !defined(_CCCL_DOXYGEN_INVOKED)
+
+namespace cuda::experimental
+{
+class identity_mapping
+{
+public:
+  _CCCL_HIDE_FROM_ABI explicit identity_mapping() = default;
+
+  template <class _ParentGroup, class _PrevMappingResult>
+  [[nodiscard]] _CCCL_DEVICE_API auto
+  map(const _ParentGroup&, const _PrevMappingResult& __prev_mapping_result) const noexcept
+  {
+    return __prev_mapping_result;
+  }
+};
+} // namespace cuda::experimental
+
+#endif // !_CCCL_DOXYGEN_INVOKED
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_EXPERIMENTAL___GROUP_MAPPING_IDENTITY_MAPPING_CUH

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -144,6 +144,11 @@ cudax_add_catch2_test(test_target group.mapping.group_by
 )
 target_compile_definitions(${test_target} PUBLIC _CUDAX_GROUP)
 
+cudax_add_catch2_test(test_target group.mapping.identity_mapping
+    group/mapping/identity_mapping.cu
+)
+target_compile_definitions(${test_target} PUBLIC _CUDAX_GROUP)
+
 cudax_add_catch2_test(test_target group.synchronizer.lane_synchronizer
     group/synchronizer/lane_synchronizer.cu
 )

--- a/cudax/test/group/mapping/identity_mapping.cu
+++ b/cudax/test/group/mapping/identity_mapping.cu
@@ -1,0 +1,97 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/devices>
+#include <cuda/hierarchy>
+#include <cuda/launch>
+#include <cuda/std/cstddef>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+#include <cuda/stream>
+
+#include <cuda/experimental/group.cuh>
+
+#include "group_testing.cuh"
+
+namespace
+{
+template <class Config>
+__device__ void test_identity_mapping(Config config)
+{
+  using Mapping = cudax::identity_mapping;
+
+  // Test default constructor.
+  {
+    static_assert(cuda::std::is_trivially_default_constructible_v<Mapping>);
+    static_assert(cuda::std::is_empty_v<Mapping>);
+
+    [[maybe_unused]] cudax::identity_mapping mapping;
+  }
+
+  // Test map(...).
+  {
+    const cudax::this_warp parent_group{config};
+    const ThreadsInWarpMappingResult prev_mapping_result;
+
+    static_assert(cudax::__group_mapping_result<decltype(cuda::std::declval<const Mapping>().map(
+                    parent_group, prev_mapping_result))>);
+    static_assert(noexcept(cuda::std::declval<const Mapping>().map(parent_group, prev_mapping_result)));
+
+    const Mapping mapping;
+    auto result  = mapping.map(parent_group, prev_mapping_result);
+    using Result = decltype(result);
+
+    static_assert(cuda::std::is_same_v<Result, ThreadsInWarpMappingResult>);
+
+    static_assert(Result::static_group_count() == ThreadsInWarpMappingResult::static_group_count());
+    CUDAX_CHECK(result.group_count() == prev_mapping_result.group_count());
+    CUDAX_CHECK(result.group_rank() == prev_mapping_result.group_rank());
+
+    static_assert(Result::static_count() == ThreadsInWarpMappingResult::static_count());
+    CUDAX_CHECK(result.count() == prev_mapping_result.count());
+    CUDAX_CHECK(result.rank() == prev_mapping_result.rank());
+
+    CUDAX_CHECK(result.is_valid() == prev_mapping_result.is_valid());
+    static_assert(Result::is_always_exhaustive() == ThreadsInWarpMappingResult::is_always_exhaustive());
+    static_assert(Result::is_always_contiguous() == ThreadsInWarpMappingResult::is_always_contiguous());
+  }
+}
+
+struct TestKernel
+{
+  template <class Config>
+  __device__ void operator()(const Config& config)
+  {
+    test_identity_mapping(config);
+    test_identity_mapping(config);
+    test_identity_mapping(config);
+    test_identity_mapping(config);
+    test_identity_mapping(config);
+  }
+};
+} // namespace
+
+C2H_TEST("Identity mapping", "[group]")
+{
+  const auto device = cuda::devices[0];
+
+  const cuda::stream stream{device};
+
+  {
+    const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims<8, 4>());
+    cuda::launch(stream, config, TestKernel{});
+  }
+  {
+    const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims(dim3{8, 4}));
+    cuda::launch(stream, config, TestKernel{});
+  }
+
+  stream.sync();
+}


### PR DESCRIPTION
This PR implements `cudax::identity_mapping`, that just returns the previous mapping. It's trivial, however, I think it could be useful for some generic programming. 