### PR TITLE
[cudax] Implement `binary_partition` mapping for threads within warp

### DIFF
--- a/cudax/include/cuda/experimental/__group/fwd.cuh
+++ b/cudax/include/cuda/experimental/__group/fwd.cuh
@@ -69,6 +69,9 @@ class group;
 
 // mappings
 
+template <class _Fn>
+class binary_partition;
+
 template <::cuda::std::size_t _Count = ::cuda::std::dynamic_extent, bool _IsExhaustive = true>
 class group_by;
 

--- a/cudax/include/cuda/experimental/__group/mapping/binary_partition.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/binary_partition.cuh
@@ -1,0 +1,102 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_EXPERIMENTAL___GROUP_MAPPING_BINARY_PARTITION_CUH
+#define _CUDA_EXPERIMENTAL___GROUP_MAPPING_BINARY_PARTITION_CUH
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__ptx/instructions/get_sreg.h>
+#include <cuda/__warp/lane_mask.h>
+#include <cuda/hierarchy>
+#include <cuda/std/__bit/popcount.h>
+#include <cuda/std/__functional/invoke.h>
+#include <cuda/std/__fwd/span.h>
+#include <cuda/std/__type_traits/is_move_constructible.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__utility/move.h>
+
+#include <cuda/experimental/__group/fwd.cuh>
+#include <cuda/experimental/__group/mapping/mapping_result.cuh>
+
+#include <cuda/std/__cccl/prologue.h>
+
+#if !defined(_CCCL_DOXYGEN_INVOKED)
+
+namespace cuda::experimental
+{
+template <class _Fn>
+class binary_partition
+{
+  static_assert(::cuda::std::is_move_constructible_v<_Fn>, "_Fn must be move constructible");
+
+  _Fn __fn_;
+
+public:
+  _CCCL_DEVICE_API explicit binary_partition(_Fn __fn) noexcept(::cuda::std::is_nothrow_move_constructible_v<_Fn>)
+      : __fn_(::cuda::std::move(__fn))
+  {}
+
+  template <class _ParentGroup, class _PrevMappingResult>
+  [[nodiscard]] _CCCL_DEVICE_API auto
+  map(const _ParentGroup& __parent, const _PrevMappingResult& __prev_mapping_result) noexcept(
+    ::cuda::std::is_nothrow_invocable_v<_Fn, const _PrevMappingResult&>)
+  {
+    static_assert(::cuda::std::is_same_v<typename _ParentGroup::level_type, warp_level>,
+                  "binary_partition can be only used within warp_level");
+
+    constexpr auto __static_prev_ngroups = _PrevMappingResult::static_group_count();
+    constexpr auto __static_ngroups =
+      (__static_prev_ngroups != ::cuda::std::dynamic_extent)
+        ? (__static_prev_ngroups * 2)
+        : ::cuda::std::dynamic_extent;
+
+    using _MappingResult =
+      __mapping_result<__static_ngroups, ::cuda::std::dynamic_extent, _PrevMappingResult::is_always_exhaustive(), false>;
+
+    if (!__prev_mapping_result.is_valid())
+    {
+      return _MappingResult::invalid();
+    }
+
+    const auto __pred      = static_cast<bool>(__fn_(__prev_mapping_result));
+    const auto __prev_mask = __prev_mapping_result.lane_mask().value();
+
+    auto __match_mask = ::__ballot_sync(__prev_mask, __pred);
+    if (!__pred)
+    {
+      __match_mask = (~__match_mask) & __prev_mask;
+    }
+    return _MappingResult{
+      __prev_mapping_result.group_count() * 2,
+      __prev_mapping_result.group_rank() + ((__pred) ? __prev_mapping_result.group_count() : 0u),
+      static_cast<unsigned>(::cuda::std::popcount(__match_mask)),
+      static_cast<unsigned>(::cuda::std::popcount(__match_mask & ::cuda::ptx::get_sreg_lanemask_lt())),
+      ::cuda::device::lane_mask{__match_mask}};
+  }
+};
+
+template <class _PredFn>
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES binary_partition(_PredFn) -> binary_partition<_PredFn>;
+} // namespace cuda::experimental
+
+#endif // !_CCCL_DOXYGEN_INVOKED
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_EXPERIMENTAL___GROUP_MAPPING_BINARY_PARTITION_CUH

--- a/cudax/include/cuda/experimental/__group/this_group.cuh
+++ b/cudax/include/cuda/experimental/__group/this_group.cuh
@@ -208,7 +208,8 @@ public:
   using level_type   = thread_level;
   using mapping_type = void;
   using typename __base_type::__mapping_result_type;
-  using hierarchy_type = _Hierarchy;
+  using hierarchy_type    = _Hierarchy;
+  using synchronizer_type = void;
 
   using __base_type::__base_type;
   using __base_type::count;
@@ -260,7 +261,8 @@ public:
   using level_type   = warp_level;
   using mapping_type = void;
   using typename __base_type::__mapping_result_type;
-  using hierarchy_type = _Hierarchy;
+  using hierarchy_type    = _Hierarchy;
+  using synchronizer_type = void;
 
   using __base_type::__base_type;
   using __base_type::count;
@@ -319,7 +321,8 @@ public:
   using level_type   = block_level;
   using mapping_type = void;
   using typename __base_type::__mapping_result_type;
-  using hierarchy_type = _Hierarchy;
+  using hierarchy_type    = _Hierarchy;
+  using synchronizer_type = void;
 
   using __base_type::__base_type;
   using __base_type::count;
@@ -376,7 +379,8 @@ public:
   using level_type   = cluster_level;
   using mapping_type = void;
   using typename __base_type::__mapping_result_type;
-  using hierarchy_type = _Hierarchy;
+  using hierarchy_type    = _Hierarchy;
+  using synchronizer_type = void;
 
   using __base_type::__base_type;
   using __base_type::count;
@@ -515,7 +519,8 @@ public:
   using level_type   = grid_level;
   using mapping_type = void;
   using typename __base_type::__mapping_result_type;
-  using hierarchy_type = _Hierarchy;
+  using hierarchy_type    = _Hierarchy;
+  using synchronizer_type = void;
 
   using __base_type::__base_type;
 

--- a/cudax/include/cuda/experimental/group.cuh
+++ b/cudax/include/cuda/experimental/group.cuh
@@ -25,6 +25,7 @@
 #include <cuda/experimental/__group/fwd.cuh>
 #include <cuda/experimental/__group/group.cuh>
 #include <cuda/experimental/__group/implicit_hierarchy.cuh>
+#include <cuda/experimental/__group/mapping/binary_partition.cuh>
 #include <cuda/experimental/__group/mapping/composite_mapping.cuh>
 #include <cuda/experimental/__group/mapping/group_as.cuh>
 #include <cuda/experimental/__group/mapping/group_by.cuh>

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -136,6 +136,9 @@ cudax_add_catch2_test(test_target algorithm
     algorithm/copy.cu
 )
 
+cudax_add_catch2_test(test_target group.mapping.binary_partition
+    group/mapping/binary_partition.cu
+)
 cudax_add_catch2_test(test_target group.mapping.composite_mapping
     group/mapping/composite_mapping.cu
 )

--- a/cudax/test/group/mapping/binary_partition.cu
+++ b/cudax/test/group/mapping/binary_partition.cu
@@ -1,0 +1,206 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/devices>
+#include <cuda/hierarchy>
+#include <cuda/launch>
+#include <cuda/std/cstddef>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+#include <cuda/stream>
+
+#include <cuda/experimental/group.cuh>
+
+#include "group_testing.cuh"
+
+namespace
+{
+struct AlwaysTruePredFn
+{
+  template <class MappingResult>
+  __device__ bool operator()(MappingResult mapping_result)
+  {
+    return true;
+  }
+};
+
+struct AlwaysFalsePredFn
+{
+  template <class MappingResult>
+  __device__ bool operator()(MappingResult mapping_result) noexcept
+  {
+    return false;
+  }
+};
+
+struct IsEvenPredFn
+{
+  template <class MappingResult>
+  __device__ bool operator()(MappingResult mapping_result)
+  {
+    return mapping_result.rank() % 2 == 0;
+  }
+};
+
+template <class Config>
+__device__ void test_binary_partition(Config config)
+{
+  // Always true predicate.
+  {
+    using Pred    = AlwaysTruePredFn;
+    using Mapping = cudax::binary_partition<Pred>;
+
+    // Test constructor from pred_fn.
+    {
+      static_assert(cuda::std::is_nothrow_constructible_v<Mapping, Pred>);
+      cudax::binary_partition mapping{Pred{}};
+    }
+
+    // Test map(...).
+    {
+      const cudax::this_warp parent_group{config};
+      const ThreadsInWarpMappingResult prev_mapping_result;
+
+      static_assert(
+        cudax::__group_mapping_result<decltype(cuda::std::declval<Mapping>().map(parent_group, prev_mapping_result))>);
+      static_assert(!noexcept(cuda::std::declval<Mapping>().map(parent_group, prev_mapping_result)));
+
+      Mapping mapping{Pred{}};
+      auto result  = mapping.map(parent_group, prev_mapping_result);
+      using Result = decltype(result);
+
+      static_assert(Result::static_group_count() == 2);
+      REQUIRE(result.group_count() == 2);
+      REQUIRE(result.group_rank() == 1);
+
+      static_assert(Result::static_count() == cuda::std::dynamic_extent);
+      REQUIRE(result.count() == cuda::gpu_thread.count(cuda::warp));
+      REQUIRE(result.rank() == cuda::gpu_thread.rank(cuda::warp));
+
+      REQUIRE(result.lane_mask() == cuda::device::lane_mask::all());
+
+      REQUIRE(result.is_valid());
+      static_assert(Result::is_always_exhaustive());
+      static_assert(!Result::is_always_contiguous());
+    }
+  }
+
+  // Always false predicate.
+  {
+    using Pred    = AlwaysFalsePredFn;
+    using Mapping = cudax::binary_partition<Pred>;
+
+    // Test constructor from pred_fn.
+    {
+      static_assert(cuda::std::is_nothrow_constructible_v<Mapping, Pred>);
+      cudax::binary_partition mapping{Pred{}};
+    }
+
+    // Test map(...).
+    {
+      const cudax::this_warp parent_group{config};
+      const ThreadsInWarpMappingResult prev_mapping_result;
+
+      static_assert(
+        cudax::__group_mapping_result<decltype(cuda::std::declval<Mapping>().map(parent_group, prev_mapping_result))>);
+      static_assert(noexcept(cuda::std::declval<Mapping>().map(parent_group, prev_mapping_result)));
+
+      Mapping mapping{Pred{}};
+      auto result  = mapping.map(parent_group, prev_mapping_result);
+      using Result = decltype(result);
+
+      static_assert(Result::static_group_count() == 2);
+      REQUIRE(result.group_count() == 2);
+      REQUIRE(result.group_rank() == 0);
+
+      static_assert(Result::static_count() == cuda::std::dynamic_extent);
+      REQUIRE(result.count() == cuda::gpu_thread.count(cuda::warp));
+      REQUIRE(result.rank() == cuda::gpu_thread.rank(cuda::warp));
+
+      REQUIRE(result.lane_mask() == cuda::device::lane_mask::all());
+
+      REQUIRE(result.is_valid());
+      static_assert(Result::is_always_exhaustive());
+      static_assert(!Result::is_always_contiguous());
+    }
+  }
+
+  // True for even ranks predicate.
+  {
+    using Pred    = IsEvenPredFn;
+    using Mapping = cudax::binary_partition<Pred>;
+
+    // Test constructor from pred_fn.
+    {
+      static_assert(cuda::std::is_nothrow_constructible_v<Mapping, Pred>);
+      cudax::binary_partition mapping{Pred{}};
+    }
+
+    // Test map(...).
+    {
+      const cudax::this_warp parent_group{config};
+      const ThreadsInWarpMappingResult prev_mapping_result;
+
+      static_assert(
+        cudax::__group_mapping_result<decltype(cuda::std::declval<Mapping>().map(parent_group, prev_mapping_result))>);
+      static_assert(!noexcept(cuda::std::declval<Mapping>().map(parent_group, prev_mapping_result)));
+
+      Mapping mapping{Pred{}};
+      auto result  = mapping.map(parent_group, prev_mapping_result);
+      using Result = decltype(result);
+
+      static_assert(Result::static_group_count() == 2);
+      REQUIRE(result.group_count() == 2);
+      REQUIRE(result.group_rank() == (cuda::gpu_thread.rank(cuda::warp) % 2 == 0));
+
+      static_assert(Result::static_count() == cuda::std::dynamic_extent);
+      REQUIRE(result.count() == cuda::gpu_thread.count(cuda::warp) / 2);
+      REQUIRE(result.rank() == cuda::gpu_thread.rank(cuda::warp) / 2);
+
+      const auto lane_mask_ref =
+        (cuda::gpu_thread.rank(cuda::warp) % 2 == 0)
+          ? cuda::device::lane_mask{0x5555'5555u}
+          : cuda::device::lane_mask(0xaaaa'aaaau);
+      REQUIRE(result.lane_mask() == lane_mask_ref);
+
+      REQUIRE(result.is_valid());
+      static_assert(Result::is_always_exhaustive());
+      static_assert(!Result::is_always_contiguous());
+    }
+  }
+}
+
+struct TestKernel
+{
+  template <class Config>
+  __device__ void operator()(const Config& config)
+  {
+    test_binary_partition(config);
+  }
+};
+} // namespace
+
+C2H_TEST("Binary partition mapping", "[group]")
+{
+  const auto device = cuda::devices[0];
+
+  const cuda::stream stream{device};
+
+  {
+    const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims<8, 4>());
+    cuda::launch(stream, config, TestKernel{});
+  }
+  {
+    const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims(dim3{8, 4}));
+    cuda::launch(stream, config, TestKernel{});
+  }
+
+  stream.sync();
+}


### PR DESCRIPTION
This PR implements `binary_partition` mapping that splits each group into 2 parts based on whether a predicate function returns `true` or `false`. It is currently implemented only for threads within warp.

From what I've seen, cooperative groups use `__ballot_sync` for voting, however I used newer and more flexible `__match_any_sync`. The generated SASS is almost identical, but I'm not sure whether there isn't some overhead introduced when using the `MATCH.ANY` instruction.