### PR TITLE
Add in-place overloads for `DeviceSelect::Unique`

### DIFF
--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -2264,34 +2264,11 @@ public:
   //!
   //! The code snippet below illustrates the in-place compaction of items selected from an ``int`` device vector.
   //!
-  //! .. code-block:: c++
-  //!
-  //!    #include <cub/cub.cuh>   // or equivalently <cub/device/device_select.cuh>
-  //!
-  //!    // Declare, allocate, and initialize device-accessible pointers
-  //!    // for input and output
-  //!    int  num_items;              // e.g., 8
-  //!    int  *d_data;                // e.g., [0, 2, 2, 9, 5, 5, 5, 8]
-  //!    int  *d_num_selected_out;    // e.g., [ ]
-  //!    ...
-  //!
-  //!    // Determine temporary device storage requirements
-  //!    void     *d_temp_storage = nullptr;
-  //!    size_t   temp_storage_bytes = 0;
-  //!    cub::DeviceSelect::Unique(
-  //!      d_temp_storage, temp_storage_bytes,
-  //!      d_data, d_num_selected_out, num_items);
-  //!
-  //!    // Allocate temporary storage
-  //!    cudaMalloc(&d_temp_storage, temp_storage_bytes);
-  //!
-  //!    // Run selection
-  //!    cub::DeviceSelect::Unique(
-  //!      d_temp_storage, temp_storage_bytes,
-  //!      d_data, d_num_selected_out, num_items);
-  //!
-  //!    // d_data                <-- [0, 2, 9, 5, 8]
-  //!    // d_num_selected_out    <-- [5]
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_select_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin select-unique-inplace
+  //!     :end-before: example-end select-unique-inplace
   //!
   //! @endrst
   //!
@@ -2366,34 +2343,17 @@ public:
   //!
   //! The code snippet below illustrates the in-place compaction of items selected from an ``int`` device vector.
   //!
-  //! .. code-block:: c++
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_select_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin select-unique-inplace-eqop-myequalityop
+  //!     :end-before: example-end select-unique-inplace-eqop-myequalityop
   //!
-  //!    #include <cub/cub.cuh>   // or equivalently <cub/device/device_select.cuh>
-  //!
-  //!    // Declare, allocate, and initialize device-accessible pointers
-  //!    // for input and output
-  //!    int  num_items;              // e.g., 8
-  //!    int  *d_data;                // e.g., [0, 2, 2, 9, 5, 5, 5, 8]
-  //!    int  *d_num_selected_out;    // e.g., [ ]
-  //!    ...
-  //!
-  //!    // Determine temporary device storage requirements
-  //!    void     *d_temp_storage = nullptr;
-  //!    size_t   temp_storage_bytes = 0;
-  //!    cub::DeviceSelect::Unique(
-  //!      d_temp_storage, temp_storage_bytes,
-  //!      d_data, d_num_selected_out, num_items, my_equality_op);
-  //!
-  //!    // Allocate temporary storage
-  //!    cudaMalloc(&d_temp_storage, temp_storage_bytes);
-  //!
-  //!    // Run selection
-  //!    cub::DeviceSelect::Unique(
-  //!      d_temp_storage, temp_storage_bytes,
-  //!      d_data, d_num_selected_out, num_items, my_equality_op);
-  //!
-  //!    // d_data                <-- [0, 2, 9, 5, 8]
-  //!    // d_num_selected_out    <-- [5]
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_select_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin select-unique-inplace-eqop
+  //!     :end-before: example-end select-unique-inplace-eqop
   //!
   //! @endrst
   //!

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -1606,6 +1606,197 @@ public:
   }
 
   //! @rst
+  //! Given an input sequence ``d_data`` having runs of consecutive equal-valued keys,
+  //! only the first key from each run is selectively compacted in-place.
+  //! The total number of items selected is written to ``d_num_selected_out``.
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! This is an environment-based API that allows customization of:
+  //!
+  //! - Stream: Query via ``cuda::get_stream``
+  //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
+  //!
+  //! - The ``==`` equality operator is used to determine whether keys are equivalent.
+  //! - Copies of the selected items are compacted in ``d_data`` and maintain their original relative ordering.
+  //!
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates the in-place compaction of items selected from an ``int`` device vector
+  //! using environment-based API:
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_select_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin select-unique-inplace-env
+  //!     :end-before: example-end select-unique-inplace-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam IteratorT
+  //!   **[inferred]** Random-access iterator type for reading and writing items @iterator
+  //!
+  //! @tparam NumSelectedIteratorT
+  //!   **[inferred]** Output iterator type for recording the number of items selected @iterator
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., `cuda::std::execution::env<...>`)
+  //!
+  //! @param[in,out] d_data
+  //!   Pointer to the sequence of data items
+  //!
+  //! @param[out] d_num_selected_out
+  //!   Pointer to the output total number of items selected
+  //!
+  //! @param[in] num_items
+  //!   Total number of input items (i.e., length of `d_data`)
+  //!
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  template <typename IteratorT,
+            typename NumSelectedIteratorT,
+            typename NumItemsT,
+            typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
+#ifdef _CCCL_DOXYGEN_INVOKED
+            void,
+#else
+            ::cuda::std::execution::env<>,
+#endif
+            ::cuda::std::enable_if_t<!::cuda::std::is_same_v<IteratorT, void*>, int>                           = 0,
+            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int>                               = 0,
+            ::cuda::std::enable_if_t<!::cuda::std::indirect_binary_predicate<EnvT, IteratorT, IteratorT>, int> = 0>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
+  Unique(IteratorT d_data, NumSelectedIteratorT d_num_selected_out, NumItemsT num_items, EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSelect::Unique");
+
+    using offset_t = ::cuda::std::int64_t;
+
+    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
+      using tuning_t = decltype(tuning);
+      return select_impl<tuning_t, SelectImpl::SelectPotentiallyInPlace>(
+        storage,
+        bytes,
+        d_data,
+        static_cast<NullType*>(nullptr),
+        d_data,
+        d_num_selected_out,
+        static_cast<offset_t>(num_items),
+        NullType{},
+        ::cuda::std::equal_to<>{},
+        stream);
+    });
+  }
+
+  //! @rst
+  //! Given an input sequence ``d_data`` having runs of consecutive equal-valued keys,
+  //! only the first key from each run is selectively compacted in-place.
+  //! The total number of items selected is written to ``d_num_selected_out``.
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! This is an environment-based API that allows customization of:
+  //!
+  //! - Stream: Query via ``cuda::get_stream``
+  //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
+  //!
+  //! - The user-provided equality operator, ``equality_op``, is used to determine whether keys are equivalent.
+  //! - Copies of the selected items are compacted in ``d_data`` and maintain their original relative ordering.
+  //!
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates the in-place compaction of items selected from an ``int`` device vector
+  //! using a custom equality operator:
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_select_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin select-unique-inplace-eqop-env
+  //!     :end-before: example-end select-unique-inplace-eqop-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam IteratorT
+  //!   **[inferred]** Random-access iterator type for reading and writing items @iterator
+  //!
+  //! @tparam NumSelectedIteratorT
+  //!   **[inferred]** Output iterator type for recording the number of items selected @iterator
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
+  //! @tparam EqualityOpT
+  //!   **[inferred]** Type of equality_op
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., ``cuda::std::execution::env<...>``)
+  //!
+  //! @param[in,out] d_data
+  //!   Pointer to the sequence of data items
+  //!
+  //! @param[out] d_num_selected_out
+  //!   Pointer to the output total number of items selected
+  //!
+  //! @param[in] num_items
+  //!   Total number of input items (i.e., length of `d_data`)
+  //!
+  //! @param[in] equality_op
+  //!   Binary equality operator
+  //!
+  //! @param[in] env
+  //!   @rst
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  //!   @endrst
+  template <typename IteratorT,
+            typename NumSelectedIteratorT,
+            typename NumItemsT,
+            typename EqualityOpT,
+            typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
+#ifdef _CCCL_DOXYGEN_INVOKED
+            void,
+#else
+            ::cuda::std::execution::env<>,
+#endif
+            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int>     = 0,
+            ::cuda::std::enable_if_t<!::cuda::std::is_same_v<IteratorT, void*>, int> = 0,
+            ::cuda::std::enable_if_t<::cuda::std::indirect_binary_predicate<EqualityOpT, IteratorT, IteratorT>, int> = 0>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
+  Unique(IteratorT d_data,
+         NumSelectedIteratorT d_num_selected_out,
+         NumItemsT num_items,
+         EqualityOpT equality_op,
+         EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSelect::Unique");
+
+    using offset_t = ::cuda::std::int64_t;
+
+    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
+      using tuning_t = decltype(tuning);
+      return select_impl<tuning_t, SelectImpl::SelectPotentiallyInPlace>(
+        storage,
+        bytes,
+        d_data,
+        static_cast<NullType*>(nullptr),
+        d_data,
+        d_num_selected_out,
+        static_cast<offset_t>(num_items),
+        NullType{},
+        equality_op,
+        stream);
+    });
+  }
+
+  //! @rst
   //! Given an input sequence ``d_keys_in`` and ``d_values_in`` with runs of key-value pairs with consecutive
   //! equal-valued keys, only the first key and its value from each run is selectively copied
   //! to ``d_keys_out`` and ``d_values_out``.
@@ -2062,6 +2253,219 @@ public:
       d_num_selected_out,
       SelectOp{},
       EqualityOp{},
+      static_cast<OffsetT>(num_items),
+      stream);
+  }
+
+  //! @rst
+  //! Given an input sequence ``d_data`` having runs of consecutive equal-valued keys,
+  //! only the first key from each run is selectively compacted in-place.
+  //! The total number of items selected is written to ``d_num_selected_out``.
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! - The ``==`` equality operator is used to determine whether keys are equivalent
+  //! - Copies of the selected items are compacted in ``d_data`` and maintain their original relative ordering.
+  //! - @devicestorage
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates the in-place compaction of items selected from an ``int`` device vector.
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>   // or equivalently <cub/device/device_select.cuh>
+  //!
+  //!    // Declare, allocate, and initialize device-accessible pointers
+  //!    // for input and output
+  //!    int  num_items;              // e.g., 8
+  //!    int  *d_data;                // e.g., [0, 2, 2, 9, 5, 5, 5, 8]
+  //!    int  *d_num_selected_out;    // e.g., [ ]
+  //!    ...
+  //!
+  //!    // Determine temporary device storage requirements
+  //!    void     *d_temp_storage = nullptr;
+  //!    size_t   temp_storage_bytes = 0;
+  //!    cub::DeviceSelect::Unique(
+  //!      d_temp_storage, temp_storage_bytes,
+  //!      d_data, d_num_selected_out, num_items);
+  //!
+  //!    // Allocate temporary storage
+  //!    cudaMalloc(&d_temp_storage, temp_storage_bytes);
+  //!
+  //!    // Run selection
+  //!    cub::DeviceSelect::Unique(
+  //!      d_temp_storage, temp_storage_bytes,
+  //!      d_data, d_num_selected_out, num_items);
+  //!
+  //!    // d_data                <-- [0, 2, 9, 5, 8]
+  //!    // d_num_selected_out    <-- [5]
+  //!
+  //! @endrst
+  //!
+  //! @tparam IteratorT
+  //!   **[inferred]** Random-access iterator type for reading and writing items @iterator
+  //!
+  //! @tparam NumSelectedIteratorT
+  //!   **[inferred]** Output iterator type for recording the number of items selected @iterator
+  //!
+  //! @param[in] d_temp_storage
+  //!   Device-accessible allocation of temporary storage. When `nullptr`, the
+  //!   required allocation size is written to `temp_storage_bytes` and no work is done.
+  //!
+  //! @param[in,out] temp_storage_bytes
+  //!   Reference to size in bytes of `d_temp_storage` allocation
+  //!
+  //! @param[in,out] d_data
+  //!   Pointer to the sequence of data items
+  //!
+  //! @param[out] d_num_selected_out
+  //!   Pointer to the output total number of items selected
+  //!
+  //! @param[in] num_items
+  //!   Total number of input items (i.e., length of `d_data`)
+  //!
+  //! @param[in] stream
+  //!   @rst
+  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   @endrst
+  template <typename IteratorT, typename NumSelectedIteratorT>
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Unique(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    IteratorT d_data,
+    NumSelectedIteratorT d_num_selected_out,
+    ::cuda::std::int64_t num_items,
+    cudaStream_t stream = nullptr)
+  {
+    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSelect::Unique");
+
+    using OffsetT    = ::cuda::std::int64_t;
+    using SelectOp   = NullType; // Selection op (not used)
+    using EqualityOp = ::cuda::std::equal_to<>; // Default == operator
+
+    return detail::select::dispatch<SelectImpl::SelectPotentiallyInPlace>(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_data,
+      static_cast<NullType*>(nullptr),
+      d_data,
+      d_num_selected_out,
+      SelectOp{},
+      EqualityOp{},
+      static_cast<OffsetT>(num_items),
+      stream);
+  }
+
+  //! @rst
+  //! Given an input sequence ``d_data`` having runs of consecutive equal-valued keys,
+  //! only the first key from each run is selectively compacted in-place.
+  //! The total number of items selected is written to ``d_num_selected_out``.
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! - The user-provided equality operator, ``equality_op``, is used to determine whether keys are equivalent.
+  //! - Copies of the selected items are compacted in ``d_data`` and maintain their original relative ordering.
+  //! - @devicestorage
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates the in-place compaction of items selected from an ``int`` device vector.
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>   // or equivalently <cub/device/device_select.cuh>
+  //!
+  //!    // Declare, allocate, and initialize device-accessible pointers
+  //!    // for input and output
+  //!    int  num_items;              // e.g., 8
+  //!    int  *d_data;                // e.g., [0, 2, 2, 9, 5, 5, 5, 8]
+  //!    int  *d_num_selected_out;    // e.g., [ ]
+  //!    ...
+  //!
+  //!    // Determine temporary device storage requirements
+  //!    void     *d_temp_storage = nullptr;
+  //!    size_t   temp_storage_bytes = 0;
+  //!    cub::DeviceSelect::Unique(
+  //!      d_temp_storage, temp_storage_bytes,
+  //!      d_data, d_num_selected_out, num_items, my_equality_op);
+  //!
+  //!    // Allocate temporary storage
+  //!    cudaMalloc(&d_temp_storage, temp_storage_bytes);
+  //!
+  //!    // Run selection
+  //!    cub::DeviceSelect::Unique(
+  //!      d_temp_storage, temp_storage_bytes,
+  //!      d_data, d_num_selected_out, num_items, my_equality_op);
+  //!
+  //!    // d_data                <-- [0, 2, 9, 5, 8]
+  //!    // d_num_selected_out    <-- [5]
+  //!
+  //! @endrst
+  //!
+  //! @tparam IteratorT
+  //!   **[inferred]** Random-access iterator type for reading and writing items @iterator
+  //!
+  //! @tparam NumSelectedIteratorT
+  //!   **[inferred]** Output iterator type for recording the number of items selected @iterator
+  //!
+  //! @tparam EqualityOpT
+  //!   **[inferred]** Type of equality_op
+  //!
+  //! @param[in] d_temp_storage
+  //!   Device-accessible allocation of temporary storage. When `nullptr`, the
+  //!   required allocation size is written to `temp_storage_bytes` and no work is done.
+  //!
+  //! @param[in,out] temp_storage_bytes
+  //!   Reference to size in bytes of `d_temp_storage` allocation
+  //!
+  //! @param[in,out] d_data
+  //!   Pointer to the sequence of data items
+  //!
+  //! @param[out] d_num_selected_out
+  //!   Pointer to the output total number of items selected
+  //!
+  //! @param[in] num_items
+  //!   Total number of input items (i.e., length of `d_data`)
+  //!
+  //! @param[in] equality_op
+  //!   Binary predicate to determine equality
+  //!
+  //! @param[in] stream
+  //!   @rst
+  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   @endrst
+  template <typename IteratorT,
+            typename NumSelectedIteratorT,
+            typename EqualityOpT,
+            ::cuda::std::enable_if_t<::cuda::std::indirect_binary_predicate<EqualityOpT, IteratorT, IteratorT>, int> = 0>
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Unique(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    IteratorT d_data,
+    NumSelectedIteratorT d_num_selected_out,
+    ::cuda::std::int64_t num_items,
+    EqualityOpT equality_op,
+    cudaStream_t stream = nullptr)
+  {
+    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSelect::Unique");
+
+    using OffsetT   = ::cuda::std::int64_t;
+    using SelectOpT = NullType; // Selection op (not used)
+
+    return detail::select::dispatch<SelectImpl::SelectPotentiallyInPlace>(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_data,
+      static_cast<NullType*>(nullptr),
+      d_data,
+      d_num_selected_out,
+      SelectOpT{},
+      equality_op,
       static_cast<OffsetT>(num_items),
       stream);
   }

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -1642,9 +1642,6 @@ public:
   //! @tparam NumSelectedIteratorT
   //!   **[inferred]** Output iterator type for recording the number of items selected @iterator
   //!
-  //! @tparam NumItemsT
-  //!   **[inferred]** Type of num_items
-  //!
   //! @tparam EnvT
   //!   **[inferred]** Environment type (e.g., `cuda::std::execution::env<...>`)
   //!
@@ -1661,7 +1658,6 @@ public:
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   template <typename IteratorT,
             typename NumSelectedIteratorT,
-            typename NumItemsT,
             typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
 #ifdef _CCCL_DOXYGEN_INVOKED
             void,
@@ -1669,10 +1665,9 @@ public:
             ::cuda::std::execution::env<>,
 #endif
             ::cuda::std::enable_if_t<!::cuda::std::is_same_v<IteratorT, void*>, int>                           = 0,
-            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int>                               = 0,
             ::cuda::std::enable_if_t<!::cuda::std::indirect_binary_predicate<EnvT, IteratorT, IteratorT>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
-  Unique(IteratorT d_data, NumSelectedIteratorT d_num_selected_out, NumItemsT num_items, EnvT env = {})
+  Unique(IteratorT d_data, NumSelectedIteratorT d_num_selected_out, ::cuda::std::int64_t num_items, EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSelect::Unique");
 
@@ -1731,9 +1726,6 @@ public:
   //! @tparam NumSelectedIteratorT
   //!   **[inferred]** Output iterator type for recording the number of items selected @iterator
   //!
-  //! @tparam NumItemsT
-  //!   **[inferred]** Type of num_items
-  //!
   //! @tparam EqualityOpT
   //!   **[inferred]** Type of equality_op
   //!
@@ -1758,7 +1750,6 @@ public:
   //!   @endrst
   template <typename IteratorT,
             typename NumSelectedIteratorT,
-            typename NumItemsT,
             typename EqualityOpT,
             typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
 #ifdef _CCCL_DOXYGEN_INVOKED
@@ -1766,13 +1757,12 @@ public:
 #else
             ::cuda::std::execution::env<>,
 #endif
-            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int>     = 0,
             ::cuda::std::enable_if_t<!::cuda::std::is_same_v<IteratorT, void*>, int> = 0,
             ::cuda::std::enable_if_t<::cuda::std::indirect_binary_predicate<EqualityOpT, IteratorT, IteratorT>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
   Unique(IteratorT d_data,
          NumSelectedIteratorT d_num_selected_out,
-         NumItemsT num_items,
+         ::cuda::std::int64_t num_items,
          EqualityOpT equality_op,
          EnvT env = {})
   {

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -1658,13 +1658,8 @@ public:
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   template <typename IteratorT,
             typename NumSelectedIteratorT,
-            typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
-#ifdef _CCCL_DOXYGEN_INVOKED
-            void,
-#else
-            ::cuda::std::execution::env<>,
-#endif
-            ::cuda::std::enable_if_t<!::cuda::std::is_same_v<IteratorT, void*>, int>                           = 0,
+            typename EnvT                                                            = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<!::cuda::std::is_same_v<IteratorT, void*>, int> = 0,
             ::cuda::std::enable_if_t<!::cuda::std::indirect_binary_predicate<EnvT, IteratorT, IteratorT>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
   Unique(IteratorT d_data, NumSelectedIteratorT d_num_selected_out, ::cuda::std::int64_t num_items, EnvT env = {})
@@ -1751,12 +1746,7 @@ public:
   template <typename IteratorT,
             typename NumSelectedIteratorT,
             typename EqualityOpT,
-            typename EnvT = // Doxygen cannot resolve ::cuda::std::execution::env
-#ifdef _CCCL_DOXYGEN_INVOKED
-            void,
-#else
-            ::cuda::std::execution::env<>,
-#endif
+            typename EnvT                                                            = ::cuda::std::execution::env<>,
             ::cuda::std::enable_if_t<!::cuda::std::is_same_v<IteratorT, void*>, int> = 0,
             ::cuda::std::enable_if_t<::cuda::std::indirect_binary_predicate<EqualityOpT, IteratorT, IteratorT>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t

--- a/cub/test/catch2_test_device_select_api.cu
+++ b/cub/test/catch2_test_device_select_api.cu
@@ -101,3 +101,80 @@ C2H_TEST("cub::DeviceSelect::FlaggedIf in-place works with int data elements", "
   d_data.resize(d_num_selected_out[0]);
   REQUIRE(d_data == expected);
 }
+
+C2H_TEST("cub::DeviceSelect::Unique in-place works with int data elements", "[select][device]")
+{
+  // example-begin select-unique-inplace
+  constexpr int num_items                       = 8;
+  thrust::device_vector<int> d_data             = {0, 2, 2, 9, 5, 5, 5, 8};
+  thrust::device_vector<int> d_num_selected_out = {0};
+
+  // Determine temporary device storage requirements
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSelect::Unique(nullptr, temp_storage_bytes, d_data.begin(), d_num_selected_out.begin(), num_items);
+
+  // Allocate temporary storage
+  thrust::device_vector<char> temp_storage(temp_storage_bytes, thrust::no_init);
+
+  // Run selection
+  cub::DeviceSelect::Unique(
+    thrust::raw_pointer_cast(temp_storage.data()),
+    temp_storage_bytes,
+    d_data.begin(),
+    d_num_selected_out.begin(),
+    num_items);
+
+  // Resize input to new length
+  d_data.resize(d_num_selected_out[0]);
+
+  thrust::device_vector<int> expected{0, 2, 9, 5, 8};
+  // example-end select-unique-inplace
+
+  REQUIRE(d_num_selected_out[0] == static_cast<int>(expected.size()));
+  REQUIRE(d_data == expected);
+}
+
+// example-begin select-unique-inplace-eqop-myequalityop
+struct my_equality_op
+{
+  __host__ __device__ bool operator()(int lhs, int rhs) const
+  {
+    return lhs == rhs;
+  }
+};
+// example-end select-unique-inplace-eqop-myequalityop
+
+C2H_TEST("cub::DeviceSelect::Unique in-place with equality_op works with int data elements", "[select][device]")
+{
+  // example-begin select-unique-inplace-eqop
+  constexpr int num_items                       = 8;
+  thrust::device_vector<int> d_data             = {0, 2, 2, 9, 5, 5, 5, 8};
+  thrust::device_vector<int> d_num_selected_out = {0};
+  my_equality_op equality_op{};
+
+  // Determine temporary device storage requirements
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSelect::Unique(
+    nullptr, temp_storage_bytes, d_data.begin(), d_num_selected_out.begin(), num_items, equality_op);
+
+  // Allocate temporary storage
+  thrust::device_vector<char> temp_storage(temp_storage_bytes, thrust::no_init);
+
+  // Run selection
+  cub::DeviceSelect::Unique(
+    thrust::raw_pointer_cast(temp_storage.data()),
+    temp_storage_bytes,
+    d_data.begin(),
+    d_num_selected_out.begin(),
+    num_items,
+    equality_op);
+
+  // Resize input to new length
+  d_data.resize(d_num_selected_out[0]);
+
+  thrust::device_vector<int> expected{0, 2, 9, 5, 8};
+  // example-end select-unique-inplace-eqop
+
+  REQUIRE(d_num_selected_out[0] == static_cast<int>(expected.size()));
+  REQUIRE(d_data == expected);
+}

--- a/cub/test/catch2_test_device_select_env.cu
+++ b/cub/test/catch2_test_device_select_env.cu
@@ -646,9 +646,9 @@ C2H_TEST("Device select unique in-place uses environment", "[select][device]")
   auto d_num_selected   = c2h::device_vector<unsigned int>(1);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceSelect::Unique(
-            nullptr, expected_bytes_allocated, d_data.begin(), d_data.begin(), d_num_selected.begin(), num_items));
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSelect::Unique(nullptr, expected_bytes_allocated, d_data.begin(), d_num_selected.begin(), num_items));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -674,10 +674,9 @@ C2H_TEST("Device select unique in-place with custom equality_op uses environment
   eq_mod3_t<value_t> eq_mod3{};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::Unique(
-      nullptr, expected_bytes_allocated, d_data.begin(), d_data.begin(), d_num_selected.begin(), num_items, eq_mod3));
+  REQUIRE(cudaSuccess
+          == cub::DeviceSelect::Unique(
+            nullptr, expected_bytes_allocated, d_data.begin(), d_num_selected.begin(), num_items, eq_mod3));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -962,9 +961,9 @@ TEST_CASE("Device select unique in-place uses custom stream", "[select][device]"
   REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceSelect::Unique(
-            nullptr, expected_bytes_allocated, d_data.begin(), d_data.begin(), d_num_selected.begin(), num_items));
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSelect::Unique(nullptr, expected_bytes_allocated, d_data.begin(), d_num_selected.begin(), num_items));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -998,10 +997,9 @@ TEST_CASE("Device select unique in-place with custom equality_op uses custom str
   REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::Unique(
-      nullptr, expected_bytes_allocated, d_data.begin(), d_data.begin(), d_num_selected.begin(), num_items, eq_mod3));
+  REQUIRE(cudaSuccess
+          == cub::DeviceSelect::Unique(
+            nullptr, expected_bytes_allocated, d_data.begin(), d_num_selected.begin(), num_items, eq_mod3));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};

--- a/cub/test/catch2_test_device_select_env.cu
+++ b/cub/test/catch2_test_device_select_env.cu
@@ -218,6 +218,46 @@ TEST_CASE("Device select unique with custom equality_op works with default envir
   REQUIRE(d_out == expected_output);
 }
 
+TEST_CASE("Device select unique in-place works with default environment", "[select][device]")
+{
+  using value_t     = int;
+  using num_items_t = int;
+
+  num_items_t num_items = 8;
+  auto d_data           = c2h::device_vector<value_t>{0, 2, 2, 9, 5, 5, 5, 8};
+  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+
+  REQUIRE(cudaSuccess == cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items));
+
+  c2h::device_vector<value_t> expected_output{0, 2, 9, 5, 8};
+  c2h::device_vector<int> expected_num_selected{5};
+
+  REQUIRE(d_num_selected == expected_num_selected);
+  d_data.resize(d_num_selected[0]);
+  REQUIRE(d_data == expected_output);
+}
+
+TEST_CASE("Device select unique in-place with custom equality_op works with default environment", "[select][device]")
+{
+  using value_t     = int;
+  using num_items_t = int;
+
+  num_items_t num_items = 8;
+  auto d_data           = c2h::device_vector<value_t>{0, 3, 6, 1, 4, 7, 2, 5};
+  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+
+  eq_mod3_t<value_t> eq_mod3{};
+
+  REQUIRE(cudaSuccess == cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items, eq_mod3));
+
+  c2h::device_vector<value_t> expected_output{0, 1, 2};
+  c2h::device_vector<int> expected_num_selected{3};
+
+  REQUIRE(d_num_selected == expected_num_selected);
+  d_data.resize(d_num_selected[0]);
+  REQUIRE(d_data == expected_output);
+}
+
 TEST_CASE("Device select unique_by_key works with default environment", "[select][device]")
 {
   using value_t     = int;
@@ -596,6 +636,61 @@ C2H_TEST("Device select unique with custom equality_op uses environment", "[sele
   REQUIRE(d_out == expected_output);
 }
 
+C2H_TEST("Device select unique in-place uses environment", "[select][device]")
+{
+  using value_t     = int;
+  using num_items_t = int;
+
+  num_items_t num_items = 10;
+  auto d_data           = c2h::device_vector<value_t>{1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
+  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(cudaSuccess
+          == cub::DeviceSelect::Unique(
+            nullptr, expected_bytes_allocated, d_data.begin(), d_data.begin(), d_num_selected.begin(), num_items));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  REQUIRE(cudaSuccess == cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items, env));
+
+  c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 5};
+  c2h::device_vector<int> expected_num_selected{5};
+
+  REQUIRE(d_num_selected == expected_num_selected);
+  d_data.resize(d_num_selected[0]);
+  REQUIRE(d_data == expected_output);
+}
+
+C2H_TEST("Device select unique in-place with custom equality_op uses environment", "[select][device]")
+{
+  using value_t     = int;
+  using num_items_t = int;
+
+  num_items_t num_items = 8;
+  auto d_data           = c2h::device_vector<value_t>{0, 3, 6, 1, 4, 7, 2, 5};
+  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+
+  eq_mod3_t<value_t> eq_mod3{};
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSelect::Unique(
+      nullptr, expected_bytes_allocated, d_data.begin(), d_data.begin(), d_num_selected.begin(), num_items, eq_mod3));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  REQUIRE(cudaSuccess == cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items, eq_mod3, env));
+
+  c2h::device_vector<value_t> expected_output{0, 1, 2};
+  c2h::device_vector<int> expected_num_selected{3};
+
+  REQUIRE(d_num_selected == expected_num_selected);
+  d_data.resize(d_num_selected[0]);
+  REQUIRE(d_data == expected_output);
+}
+
 C2H_TEST("Device select unique_by_key uses environment", "[select][device]")
 {
   using value_t     = int;
@@ -850,6 +945,77 @@ TEST_CASE("Device select unique uses custom stream", "[select][device]")
   REQUIRE(d_num_selected == expected_num_selected);
   d_out.resize(d_num_selected[0]);
   REQUIRE(d_out == expected_output);
+
+  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+}
+
+TEST_CASE("Device select unique in-place uses custom stream", "[select][device]")
+{
+  using value_t     = int;
+  using num_items_t = int;
+
+  num_items_t num_items = 8;
+  auto d_data           = c2h::device_vector<value_t>{0, 2, 2, 9, 5, 5, 5, 8};
+  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+
+  cudaStream_t custom_stream;
+  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(cudaSuccess
+          == cub::DeviceSelect::Unique(
+            nullptr, expected_bytes_allocated, d_data.begin(), d_data.begin(), d_num_selected.begin(), num_items));
+
+  auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
+  auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
+
+  REQUIRE(cudaSuccess == cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items, env));
+
+  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+
+  c2h::device_vector<value_t> expected_output{0, 2, 9, 5, 8};
+  c2h::device_vector<int> expected_num_selected{5};
+
+  REQUIRE(d_num_selected == expected_num_selected);
+  d_data.resize(d_num_selected[0]);
+  REQUIRE(d_data == expected_output);
+
+  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+}
+
+TEST_CASE("Device select unique in-place with custom equality_op uses custom stream", "[select][device]")
+{
+  using value_t     = int;
+  using num_items_t = int;
+
+  num_items_t num_items = 8;
+  auto d_data           = c2h::device_vector<value_t>{0, 3, 6, 1, 4, 7, 2, 5};
+  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+
+  eq_mod3_t<value_t> eq_mod3{};
+
+  cudaStream_t custom_stream;
+  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSelect::Unique(
+      nullptr, expected_bytes_allocated, d_data.begin(), d_data.begin(), d_num_selected.begin(), num_items, eq_mod3));
+
+  auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
+  auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
+
+  REQUIRE(cudaSuccess == cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items, eq_mod3, env));
+
+  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+
+  c2h::device_vector<value_t> expected_output{0, 1, 2};
+  c2h::device_vector<int> expected_num_selected{3};
+
+  REQUIRE(d_num_selected == expected_num_selected);
+  d_data.resize(d_num_selected[0]);
+  REQUIRE(d_data == expected_output);
 
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }

--- a/cub/test/catch2_test_device_select_env_api.cu
+++ b/cub/test/catch2_test_device_select_env_api.cu
@@ -241,6 +241,64 @@ C2H_TEST("cub::DeviceSelect::Unique with custom equality_op accepts env with str
   REQUIRE(output == expected_output);
 }
 
+C2H_TEST("cub::DeviceSelect::Unique in-place accepts env with stream", "[select][env]")
+{
+  // example-begin select-unique-inplace-env
+  auto data         = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
+  auto num_selected = thrust::device_vector<int>(1);
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+  auto env = cuda::std::execution::env{stream_ref};
+
+  auto error = cub::DeviceSelect::Unique(data.begin(), num_selected.begin(), data.size(), env);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceSelect::Unique in-place failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected_output{0, 2, 9, 5, 8};
+  thrust::device_vector<int> expected_num_selected{5};
+  // example-end select-unique-inplace-env
+  stream.sync();
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(num_selected == expected_num_selected);
+  data.resize(num_selected[0]);
+  REQUIRE(data == expected_output);
+}
+
+C2H_TEST("cub::DeviceSelect::Unique in-place with custom equality_op accepts env with stream", "[select][env]")
+{
+  // example-begin select-unique-inplace-eqop-env
+  // Unique modulo 3 — consecutive elements are "equal" if they have the same remainder mod 3
+  auto data         = thrust::device_vector<int>{0, 3, 6, 1, 4, 7, 2, 5};
+  auto num_selected = thrust::device_vector<int>(1);
+
+  eq_mod3_t<int> eq_mod3{};
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceSelect::Unique(data.begin(), num_selected.begin(), data.size(), eq_mod3, stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceSelect::Unique in-place with custom equality_op failed with status: " << error << '\n';
+  }
+
+  // 0,3,6 all == mod 3 (consecutive), keep first (0); 1,4,7 all == mod 3 (consecutive), keep first (1);
+  // 2,5 == mod 3 (consecutive), keep first (2)
+  thrust::device_vector<int> expected_output{0, 1, 2};
+  thrust::device_vector<int> expected_num_selected{3};
+  // example-end select-unique-inplace-eqop-env
+  stream.sync();
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(num_selected == expected_num_selected);
+  data.resize(num_selected[0]);
+  REQUIRE(data == expected_output);
+}
+
 C2H_TEST("cub::DeviceSelect::UniqueByKey accepts env with stream", "[select][env]")
 {
   // example-begin select-uniquebykey-env

--- a/cub/test/catch2_test_device_select_unique.cu
+++ b/cub/test/catch2_test_device_select_unique.cu
@@ -320,20 +320,17 @@ C2H_TEST("DeviceSelect::Unique in-place empty and uniform data", "[device][selec
   c2h::device_vector<int> num_selected_out(1, 0);
   int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
 
-  if (num_items == 0)
+  SECTION("without predicate")
   {
-    SECTION("without predicate")
+    select_unique(data.begin(), d_first_num_selected_out, num_items);
+    if (num_items > 0)
     {
-      select_unique(data.begin(), d_first_num_selected_out, num_items);
-      if (num_items > 0)
-      {
-        REQUIRE(num_selected_out[0] == 1);
-        REQUIRE(data[0] == val);
-      }
-      else
-      {
-        REQUIRE(num_selected_out[0] == 0);
-      }
+      REQUIRE(num_selected_out[0] == 1);
+      REQUIRE(data[0] == val);
+    }
+    else
+    {
+      REQUIRE(num_selected_out[0] == 0);
     }
   }
 

--- a/cub/test/catch2_test_device_select_unique.cu
+++ b/cub/test/catch2_test_device_select_unique.cu
@@ -340,7 +340,7 @@ C2H_TEST("DeviceSelect::Unique in-place random data", "[device][select_unique]",
   using type = typename c2h::get<0, TestType>;
 
   const int num_items = GENERATE(take(4, random(1, 1000000)));
-  c2h::device_vector<type> data(num_items, thrust::no_init);
+  c2h::device_vector<type> data(num_items, thrust::default_init);
   c2h::gen(C2H_SEED(2), data, to_bound<type>(0), to_bound<type>(42));
 
   c2h::device_vector<int> num_selected_out(1, 0);

--- a/cub/test/catch2_test_device_select_unique.cu
+++ b/cub/test/catch2_test_device_select_unique.cu
@@ -308,6 +308,66 @@ C2H_TEST("DeviceSelect::Unique works with a different output type", "[device][se
   REQUIRE(reference == out);
 }
 
+C2H_TEST("DeviceSelect::Unique in-place empty and uniform data", "[device][select_unique]", types)
+{
+  using type         = typename c2h::get<0, TestType>;
+  constexpr auto val = static_cast<type>(1);
+
+  const int num_items = GENERATE(0, take(4, random(1, 1000000)));
+  c2h::device_vector<type> data(num_items, val);
+
+  // Needs to be device accessible
+  c2h::device_vector<int> num_selected_out(1, 0);
+  int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
+
+  SECTION("without predicate")
+  {
+    select_unique(data.begin(), d_first_num_selected_out, num_items);
+    REQUIRE(num_selected_out[0] == 1);
+    REQUIRE(data[0] == val);
+  }
+
+  SECTION("with predicate")
+  {
+    select_unique(data.begin(), d_first_num_selected_out, num_items, fake_equal_to{});
+    REQUIRE(num_selected_out[0] == 1);
+    REQUIRE(data[0] == val);
+  }
+}
+
+C2H_TEST("DeviceSelect::Unique in-place random data", "[device][select_unique]", all_types)
+{
+  using type = typename c2h::get<0, TestType>;
+
+  const int num_items = GENERATE(take(4, random(1, 1000000)));
+  c2h::device_vector<type> data(num_items, thrust::no_init);
+  c2h::gen(C2H_SEED(2), data, to_bound<type>(0), to_bound<type>(42));
+
+  c2h::device_vector<int> num_selected_out(1, 0);
+  int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
+
+  // Ensure that we create the same output as std
+  c2h::host_vector<type> reference = data;
+  const auto new_end               = std::unique(reference.begin(), reference.end());
+  reference.erase(new_end, reference.end());
+
+  SECTION("without predicate")
+  {
+    select_unique(data.begin(), d_first_num_selected_out, num_items);
+    REQUIRE(num_selected_std == num_selected_out[0]);
+    data.resize(num_selected_out[0]);
+    REQUIRE(reference == data);
+  }
+
+  SECTION("with predicate")
+  {
+    select_unique(data.begin(), d_first_num_selected_out, num_items, fake_equal_to{});
+    REQUIRE(num_selected_std == num_selected_out[0]);
+    data.resize(num_selected_out[0]);
+    REQUIRE(reference == data);
+  }
+}
+
 C2H_TEST("DeviceSelect::Unique works for very large number of items",
          "[device][select_unique][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
 try

--- a/cub/test/catch2_test_device_select_unique.cu
+++ b/cub/test/catch2_test_device_select_unique.cu
@@ -320,18 +320,35 @@ C2H_TEST("DeviceSelect::Unique in-place empty and uniform data", "[device][selec
   c2h::device_vector<int> num_selected_out(1, 0);
   int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
 
-  SECTION("without predicate")
+  if (num_items == 0)
   {
-    select_unique(data.begin(), d_first_num_selected_out, num_items);
-    REQUIRE(num_selected_out[0] == 1);
-    REQUIRE(data[0] == val);
+    SECTION("without predicate")
+    {
+      select_unique(data.begin(), d_first_num_selected_out, num_items);
+      if (num_items > 0)
+      {
+        REQUIRE(num_selected_out[0] == 1);
+        REQUIRE(data[0] == val);
+      }
+      else
+      {
+        REQUIRE(num_selected_out[0] == 0);
+      }
+    }
   }
 
   SECTION("with predicate")
   {
     select_unique(data.begin(), d_first_num_selected_out, num_items, fake_equal_to{});
-    REQUIRE(num_selected_out[0] == 1);
-    REQUIRE(data[0] == val);
+    if (num_items > 0)
+    {
+      REQUIRE(num_selected_out[0] == 1);
+      REQUIRE(data[0] == val);
+    }
+    else
+    {
+      REQUIRE(num_selected_out[0] == 0);
+    }
   }
 }
 

--- a/cub/test/catch2_test_device_select_unique.cu
+++ b/cub/test/catch2_test_device_select_unique.cu
@@ -354,7 +354,7 @@ C2H_TEST("DeviceSelect::Unique in-place random data", "[device][select_unique]",
   SECTION("without predicate")
   {
     select_unique(data.begin(), d_first_num_selected_out, num_items);
-    REQUIRE(num_selected_std == num_selected_out[0]);
+    REQUIRE(static_cast<int>(reference.size()) == num_selected_out[0]);
     data.resize(num_selected_out[0]);
     REQUIRE(reference == data);
   }
@@ -362,7 +362,7 @@ C2H_TEST("DeviceSelect::Unique in-place random data", "[device][select_unique]",
   SECTION("with predicate")
   {
     select_unique(data.begin(), d_first_num_selected_out, num_items, fake_equal_to{});
-    REQUIRE(num_selected_std == num_selected_out[0]);
+    REQUIRE(static_cast<int>(reference.size()) == num_selected_out[0]);
     data.resize(num_selected_out[0]);
     REQUIRE(reference == data);
   }


### PR DESCRIPTION
They were missing and are needed by Thrust to implement `std::unique`.

- [x] #8895