### PR TITLE
ArgMin/Max fixes and improvements

### DIFF
--- a/cub/benchmarks/bench/reduce/arg_extrema.cu
+++ b/cub/benchmarks/bench/reduce/arg_extrema.cu
@@ -73,8 +73,8 @@ void arg_reduce(nvbench::state& state, nvbench::type_list<T, OpT>)
     nullptr,
     temp_size,
     d_in,
-    d_out_index,
     d_out_extremum,
+    d_out_index,
     num_items,
     OpT{},
     nullptr /* stream */
@@ -92,8 +92,8 @@ void arg_reduce(nvbench::state& state, nvbench::type_list<T, OpT>)
       temp_storage,
       temp_size,
       d_in,
-      d_out_index,
       d_out_extremum,
+      d_out_index,
       num_items,
       OpT{},
       launch.get_stream()

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -881,7 +881,7 @@ private:
       d_min_out,
       d_index_out,
       static_cast<GlobalOffsetT>(num_items),
-      detail::arg_less{compare_op},
+      detail::arg_reduce_op{compare_op},
       stream);
   }
 
@@ -1072,7 +1072,7 @@ private:
           d_min_out,
           d_index_out,
           static_cast<GlobalOffsetT>(num_items),
-          detail::arg_less{compare_op},
+          detail::arg_reduce_op{compare_op},
           stream.get()))
     {
       return error;
@@ -1093,7 +1093,7 @@ private:
       d_min_out,
       d_index_out,
       static_cast<GlobalOffsetT>(num_items),
-      detail::arg_less{compare_op},
+      detail::arg_reduce_op{compare_op},
       stream.get());
 
     // Try to deallocate regardless of the error to avoid memory leaks
@@ -1209,7 +1209,8 @@ public:
     ::cuda::std::int64_t num_items,
     EnvT env = {})
   {
-    return ArgMin(d_in, d_min_out, d_index_out, num_items, ::cuda::std::less{}, env);
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMin");
+    return __arg_min_env(d_in, d_min_out, d_index_out, num_items, ::cuda::std::less{}, env);
   }
 
   //! @rst
@@ -1654,14 +1655,7 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceReduce::ArgMax");
     return __arg_min(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_in,
-      d_max_out,
-      d_index_out,
-      num_items,
-      detail::arg_less{detail::swap_args{compare_op}},
-      stream);
+      d_temp_storage, temp_storage_bytes, d_in, d_max_out, d_index_out, num_items, detail::swap_args{compare_op}, stream);
   }
 
   //! @rst
@@ -1680,8 +1674,9 @@ public:
     ::cuda::std::int64_t num_items,
     cudaStream_t stream = nullptr)
   {
-    return ArgMax(
-      d_temp_storage, temp_storage_bytes, d_in, d_max_out, d_index_out, num_items, ::cuda::std::less{}, stream);
+    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceReduce::ArgMax");
+    return __arg_min(
+      d_temp_storage, temp_storage_bytes, d_in, d_max_out, d_index_out, num_items, ::cuda::std::greater{}, stream);
   }
 
   //! @rst
@@ -1898,7 +1893,7 @@ public:
     EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMax");
-    return __arg_min_env(d_in, d_max_out, d_index_out, num_items, detail::arg_less{detail::swap_args{compare_op}}, env);
+    return __arg_min_env(d_in, d_max_out, d_index_out, num_items, detail::swap_args{compare_op}, env);
   }
 
   //! @overload
@@ -1918,7 +1913,7 @@ public:
          EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMax");
-    return __arg_min_env(d_in, d_max_out, d_index_out, num_items, detail::arg_max{}, env);
+    return __arg_min_env(d_in, d_max_out, d_index_out, num_items, ::cuda::std::greater{}, env);
   }
 
   //! @rst

--- a/cub/cub/thread/thread_operators.cuh
+++ b/cub/cub/thread/thread_operators.cuh
@@ -106,9 +106,10 @@ struct ArgMin
 
 namespace detail
 {
-// Less-than comparator for an index/value pair that compares values first, and indices when the values are equal
+// Uses a user-defined less-than comparator to return the minimum of an index/value pair. Compares values first, and
+// indices when the values are equal.
 template <typename ValueLessThen = ::cuda::std::less<>>
-struct arg_less : ValueLessThen
+struct arg_reduce_op : ValueLessThen
 {
   template <typename T, typename OffsetT>
   _CCCL_HOST_DEVICE _CCCL_FORCEINLINE ::cuda::std::pair<OffsetT, T>
@@ -138,10 +139,10 @@ struct arg_less : ValueLessThen
 };
 
 template <typename ValueLessThen>
-arg_less(ValueLessThen) -> arg_less<ValueLessThen>;
+arg_reduce_op(ValueLessThen) -> arg_reduce_op<ValueLessThen>;
 
 /// @brief Arg min functor (keeps the value and offset of the first occurrence of the smallest item)
-using arg_min = arg_less<::cuda::std::less<>>;
+using arg_min = arg_reduce_op<::cuda::std::less<>>;
 
 //! @brief Binary functor swapping the arguments to ``operator()`` before forwarding to an inner functor
 template <typename Predicate>
@@ -158,7 +159,7 @@ template <typename Predicate>
 swap_args(Predicate) -> swap_args<Predicate>;
 
 /// @brief Arg max functor (keeps the value and offset of the first occurrence of the larger item)
-using arg_max = arg_less<swap_args<::cuda::std::less<>>>;
+using arg_max = arg_reduce_op<swap_args<::cuda::std::less<>>>;
 
 template <typename ScanOpT>
 struct ScanBySegmentOp


### PR DESCRIPTION
There were a couple of oversights in #8285, which are fixed by this PR:

* arguments to `dispatch_streaming_arg_reduce` are passed in the wrong order in the `arg_extrema.cu` benchmark
* `arg_less` wasn't a good name since it does not return bool. `arg_min` would be right, but that name is taken. So it's `arg_reduce_op`.
* Call `__arg_min` directly in some device level APIs to avoid one additional function call