### PR TITLE
Move segmented radix sort policies to own header

### DIFF
--- a/cub/benchmarks/bench/segmented_radix_sort/keys.cu
+++ b/cub/benchmarks/bench/segmented_radix_sort/keys.cu
@@ -47,7 +47,7 @@ void seg_radix_sort(nvbench::state& state,
 
   std::size_t temp_storage_bytes{};
   std::uint8_t* d_temp_storage{};
-  cub::detail::radix_sort::dispatch<cub::SortOrder::Ascending, segment_size_t>(
+  cub::detail::segmented_radix_sort::dispatch<cub::SortOrder::Ascending, segment_size_t>(
     d_temp_storage,
     temp_storage_bytes,
     d_keys,
@@ -69,7 +69,7 @@ void seg_radix_sort(nvbench::state& state,
                cub::DoubleBuffer<key_t> keys     = d_keys;
                cub::DoubleBuffer<value_t> values = d_values;
 
-               cub::detail::radix_sort::dispatch<cub::SortOrder::Ascending, segment_size_t>(
+               cub::detail::segmented_radix_sort::dispatch<cub::SortOrder::Ascending, segment_size_t>(
                  d_temp_storage,
                  temp_storage_bytes,
                  keys,

--- a/cub/cub/device/device_segmented_radix_sort.cuh
+++ b/cub/cub/device/device_segmented_radix_sort.cuh
@@ -229,7 +229,7 @@ public:
     DoubleBuffer<KeyT> d_keys(const_cast<KeyT*>(d_keys_in), d_keys_out);
     DoubleBuffer<ValueT> d_values(const_cast<ValueT*>(d_values_in), d_values_out);
 
-    return detail::radix_sort::dispatch<SortOrder::Ascending, SegmentSizeT>(
+    return detail::segmented_radix_sort::dispatch<SortOrder::Ascending, SegmentSizeT>(
       d_temp_storage,
       temp_storage_bytes,
       d_keys,
@@ -408,7 +408,7 @@ public:
     // Signed integer type for global offsets
     using SegmentSizeT = ::cuda::std::int32_t;
 
-    return detail::radix_sort::dispatch<SortOrder::Ascending, SegmentSizeT>(
+    return detail::segmented_radix_sort::dispatch<SortOrder::Ascending, SegmentSizeT>(
       d_temp_storage,
       temp_storage_bytes,
       d_keys,
@@ -551,7 +551,7 @@ public:
     DoubleBuffer<ValueT> d_values(const_cast<ValueT*>(d_values_in), d_values_out);
 
     return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::radix_sort::dispatch<SortOrder::Ascending, SegmentSizeT>(
+      return detail::segmented_radix_sort::dispatch<SortOrder::Ascending, SegmentSizeT>(
         storage,
         bytes,
         d_keys,
@@ -698,7 +698,7 @@ public:
     using SegmentSizeT = ::cuda::std::int32_t;
 
     return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::radix_sort::dispatch<SortOrder::Ascending, SegmentSizeT>(
+      return detail::segmented_radix_sort::dispatch<SortOrder::Ascending, SegmentSizeT>(
         storage,
         bytes,
         d_keys,
@@ -878,7 +878,7 @@ public:
     DoubleBuffer<KeyT> d_keys(const_cast<KeyT*>(d_keys_in), d_keys_out);
     DoubleBuffer<ValueT> d_values(const_cast<ValueT*>(d_values_in), d_values_out);
 
-    return detail::radix_sort::dispatch<SortOrder::Descending, SegmentSizeT>(
+    return detail::segmented_radix_sort::dispatch<SortOrder::Descending, SegmentSizeT>(
       d_temp_storage,
       temp_storage_bytes,
       d_keys,
@@ -1060,7 +1060,7 @@ public:
     // Signed integer type for global offsets
     using SegmentSizeT = ::cuda::std::int32_t;
 
-    return detail::radix_sort::dispatch<SortOrder::Descending, SegmentSizeT>(
+    return detail::segmented_radix_sort::dispatch<SortOrder::Descending, SegmentSizeT>(
       d_temp_storage,
       temp_storage_bytes,
       d_keys,
@@ -1203,7 +1203,7 @@ public:
     DoubleBuffer<ValueT> d_values(const_cast<ValueT*>(d_values_in), d_values_out);
 
     return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::radix_sort::dispatch<SortOrder::Descending, SegmentSizeT>(
+      return detail::segmented_radix_sort::dispatch<SortOrder::Descending, SegmentSizeT>(
         storage,
         bytes,
         d_keys,
@@ -1350,7 +1350,7 @@ public:
     using SegmentSizeT = ::cuda::std::int32_t;
 
     return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::radix_sort::dispatch<SortOrder::Descending, SegmentSizeT>(
+      return detail::segmented_radix_sort::dispatch<SortOrder::Descending, SegmentSizeT>(
         storage,
         bytes,
         d_keys,
@@ -1517,7 +1517,7 @@ public:
     DoubleBuffer<KeyT> d_keys(const_cast<KeyT*>(d_keys_in), d_keys_out);
     DoubleBuffer<NullType> d_values;
 
-    return detail::radix_sort::dispatch<SortOrder::Ascending, SegmentSizeT>(
+    return detail::segmented_radix_sort::dispatch<SortOrder::Ascending, SegmentSizeT>(
       d_temp_storage,
       temp_storage_bytes,
       d_keys,
@@ -1688,7 +1688,7 @@ public:
     // Null value type
     DoubleBuffer<NullType> d_values;
 
-    return detail::radix_sort::dispatch<SortOrder::Ascending, SegmentSizeT>(
+    return detail::segmented_radix_sort::dispatch<SortOrder::Ascending, SegmentSizeT>(
       d_temp_storage,
       temp_storage_bytes,
       d_keys,
@@ -1820,7 +1820,7 @@ public:
     DoubleBuffer<NullType> d_values;
 
     return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::radix_sort::dispatch<SortOrder::Ascending, SegmentSizeT>(
+      return detail::segmented_radix_sort::dispatch<SortOrder::Ascending, SegmentSizeT>(
         storage,
         bytes,
         d_keys,
@@ -1958,7 +1958,7 @@ public:
     DoubleBuffer<NullType> d_values;
 
     return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::radix_sort::dispatch<SortOrder::Ascending, SegmentSizeT>(
+      return detail::segmented_radix_sort::dispatch<SortOrder::Ascending, SegmentSizeT>(
         storage,
         bytes,
         d_keys,
@@ -2121,7 +2121,7 @@ public:
     DoubleBuffer<KeyT> d_keys(const_cast<KeyT*>(d_keys_in), d_keys_out);
     DoubleBuffer<NullType> d_values;
 
-    return detail::radix_sort::dispatch<SortOrder::Descending, SegmentSizeT>(
+    return detail::segmented_radix_sort::dispatch<SortOrder::Descending, SegmentSizeT>(
       d_temp_storage,
       temp_storage_bytes,
       d_keys,
@@ -2290,7 +2290,7 @@ public:
     // Null value type
     DoubleBuffer<NullType> d_values;
 
-    return detail::radix_sort::dispatch<SortOrder::Descending, SegmentSizeT>(
+    return detail::segmented_radix_sort::dispatch<SortOrder::Descending, SegmentSizeT>(
       d_temp_storage,
       temp_storage_bytes,
       d_keys,
@@ -2420,7 +2420,7 @@ public:
     DoubleBuffer<NullType> d_values;
 
     return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::radix_sort::dispatch<SortOrder::Descending, SegmentSizeT>(
+      return detail::segmented_radix_sort::dispatch<SortOrder::Descending, SegmentSizeT>(
         storage,
         bytes,
         d_keys,
@@ -2558,7 +2558,7 @@ public:
     DoubleBuffer<NullType> d_values;
 
     return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::radix_sort::dispatch<SortOrder::Descending, SegmentSizeT>(
+      return detail::segmented_radix_sort::dispatch<SortOrder::Descending, SegmentSizeT>(
         storage,
         bytes,
         d_keys,

--- a/cub/cub/device/dispatch/dispatch_segmented_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_segmented_radix_sort.cuh
@@ -21,7 +21,7 @@
 #endif // no system header
 
 #include <cub/device/dispatch/kernels/kernel_segmented_radix_sort.cuh>
-#include <cub/device/dispatch/tuning/tuning_radix_sort.cuh>
+#include <cub/device/dispatch/tuning/tuning_segmented_radix_sort.cuh>
 #include <cub/util_debug.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_math.cuh>
@@ -44,7 +44,7 @@ _CCCL_DIAG_SUPPRESS_CLANG("-Wpass-failed")
 
 CUB_NAMESPACE_BEGIN
 
-namespace detail::radix_sort
+namespace detail::segmented_radix_sort
 {
 template <typename PolicySelectorT,
           SortOrder Order,
@@ -94,7 +94,7 @@ struct DeviceSegmentedRadixSortKernelSource
     return sizeof(ValueT);
   }
 };
-} // namespace detail::radix_sort
+} // namespace detail::segmented_radix_sort
 
 /******************************************************************************
  * Segmented dispatch
@@ -131,7 +131,7 @@ template <SortOrder Order,
           typename SegmentSizeT,
           typename PolicyHub    = detail::radix_sort::policy_hub<KeyT, ValueT, SegmentSizeT>,
           typename DecomposerT  = detail::identity_decomposer_t,
-          typename KernelSource = detail::radix_sort::DeviceSegmentedRadixSortKernelSource<
+          typename KernelSource = detail::segmented_radix_sort::DeviceSegmentedRadixSortKernelSource<
             detail::radix_sort::policy_selector_from_hub<PolicyHub>,
             Order,
             KeyT,
@@ -638,7 +638,7 @@ struct DispatchSegmentedRadixSort
   }
 };
 
-namespace detail::radix_sort
+namespace detail::segmented_radix_sort
 {
 template <typename KeyT,
           typename ValueT,
@@ -647,7 +647,7 @@ template <typename KeyT,
           typename DecomposerT,
           typename KernelSource,
           typename KernelLauncherFactory>
-CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_passes_segmented_radix_sort(
+CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_passes(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
   DoubleBuffer<KeyT>& d_keys,
@@ -661,7 +661,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_passes_segmented_radix
   bool is_overwrite_okay,
   cudaStream_t stream,
   DecomposerT decomposer,
-  radix_sort_policy active_policy,
+  segmented_radix_sort_policy active_policy,
   KernelSource kernel_source,
   KernelLauncherFactory launcher_factory)
 {
@@ -875,7 +875,7 @@ template <SortOrder Order,
               DecomposerT>,
           typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
 #if _CCCL_HAS_CONCEPTS()
-  requires radix_sort_policy_selector<PolicySelector>
+  requires segmented_radix_sort_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
 CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   void* d_temp_storage,
@@ -909,8 +909,18 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   {
     return error;
   }
+  const segmented_radix_sort_policy active_policy = policy_selector(cc);
 
-  const radix_sort_policy active_policy = policy_selector(cc);
+#if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
+  NV_IF_TARGET(NV_IS_HOST, ({
+                 ::std::stringstream ss;
+                 ss << active_policy;
+                 _CubLog("Dispatching DeviceSegmentedRadixSort to compute capability %d.%d with tuning: %s\n",
+                         cc.major_cap(),
+                         cc.minor_cap(),
+                         ss.str().c_str());
+               }))
+#endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
 
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(NV_IS_HOST, ({
@@ -923,7 +933,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
                }))
 #endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
 
-  return invoke_passes_segmented_radix_sort(
+  return invoke_passes(
     d_temp_storage,
     temp_storage_bytes,
     d_keys,
@@ -941,7 +951,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
     kernel_source,
     launcher_factory);
 }
-} // namespace detail::radix_sort
+} // namespace detail::segmented_radix_sort
 
 CUB_NAMESPACE_END
 

--- a/cub/cub/device/dispatch/dispatch_segmented_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_segmented_radix_sort.cuh
@@ -94,6 +94,27 @@ struct DeviceSegmentedRadixSortKernelSource
     return sizeof(ValueT);
   }
 };
+
+// TODO(bgruber): remove in CCCL 4.0 when we drop the radix sort dispatcher after publishing the tuning API
+template <typename LegacyActivePolicy>
+_CCCL_API constexpr auto convert_policy() -> segmented_radix_sort_policy
+{
+  using active_policy = LegacyActivePolicy;
+
+  const auto segmented     = radix_sort::convert_downsweep_policy(typename active_policy::SegmentedPolicy{});
+  const auto alt_segmented = radix_sort::convert_downsweep_policy(typename active_policy::AltSegmentedPolicy{});
+  return segmented_radix_sort_policy{segmented, alt_segmented};
+}
+
+// TODO(bgruber): remove in CCCL 4.0 when we drop the radix sort dispatcher after publishing the tuning API
+template <typename PolicyHub>
+struct policy_selector_from_hub
+{
+  _CCCL_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const -> segmented_radix_sort_policy
+  {
+    return convert_policy<typename PolicyHub::MaxPolicy::ActivePolicy>();
+  }
+};
 } // namespace detail::segmented_radix_sort
 
 /******************************************************************************
@@ -132,7 +153,7 @@ template <SortOrder Order,
           typename PolicyHub    = detail::radix_sort::policy_hub<KeyT, ValueT, SegmentSizeT>,
           typename DecomposerT  = detail::identity_decomposer_t,
           typename KernelSource = detail::segmented_radix_sort::DeviceSegmentedRadixSortKernelSource<
-            detail::radix_sort::policy_selector_from_hub<PolicyHub>,
+            detail::segmented_radix_sort::policy_selector_from_hub<PolicyHub>,
             Order,
             KeyT,
             ValueT,

--- a/cub/cub/device/dispatch/kernels/kernel_segmented_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_segmented_radix_sort.cuh
@@ -17,7 +17,7 @@
 #include <cub/agent/agent_radix_sort_upsweep.cuh>
 #include <cub/block/block_scan.cuh>
 #include <cub/device/dispatch/dispatch_common.cuh>
-#include <cub/device/dispatch/tuning/tuning_radix_sort.cuh>
+#include <cub/device/dispatch/tuning/tuning_segmented_radix_sort.cuh>
 #include <cub/util_arch.cuh>
 
 #include <cuda/__device/compute_capability.h>
@@ -27,7 +27,7 @@
 
 CUB_NAMESPACE_BEGIN
 
-namespace detail::radix_sort
+namespace detail::segmented_radix_sort
 {
 _CCCL_EXEC_CHECK_DISABLE
 template <typename PolicySelector, bool AltDigitBits>
@@ -125,7 +125,7 @@ __launch_bounds__(segmented_radix_sort_kernel_launch_bounds<PolicySelector, AltD
   // Constants
   //
 
-  static constexpr radix_sort_policy policy                  = current_policy<PolicySelector>();
+  static constexpr segmented_radix_sort_policy policy        = current_policy<PolicySelector>();
   static constexpr radix_sort_downsweep_policy active_policy = AltDigitBits ? policy.alt_segmented : policy.segmented;
 
   static constexpr int threads_per_block = active_policy.threads_per_block;
@@ -140,7 +140,7 @@ __launch_bounds__(segmented_radix_sort_kernel_launch_bounds<PolicySelector, AltD
                                 active_policy.radix_bits,
                                 NoScaling<active_policy.threads_per_block, active_policy.items_per_thread>>;
 
-  using BlockUpsweepT = AgentRadixSortUpsweep<ActiveUpsweepPolicyT, KeyT, SegmentSizeT, DecomposerT>;
+  using BlockUpsweepT = radix_sort::AgentRadixSortUpsweep<ActiveUpsweepPolicyT, KeyT, SegmentSizeT, DecomposerT>;
 
   using DigitScanT = BlockScan<SegmentSizeT, threads_per_block>;
 
@@ -155,8 +155,13 @@ __launch_bounds__(segmented_radix_sort_kernel_launch_bounds<PolicySelector, AltD
     active_policy.radix_bits,
     NoScaling<active_policy.threads_per_block, active_policy.items_per_thread>>;
 
-  using BlockDownsweepT =
-    AgentRadixSortDownsweep<ActiveDownsweepPolicyT, Order == SortOrder::Descending, KeyT, ValueT, SegmentSizeT, DecomposerT>;
+  using BlockDownsweepT = radix_sort::AgentRadixSortDownsweep<
+    ActiveDownsweepPolicyT,
+    Order == SortOrder::Descending,
+    KeyT,
+    ValueT,
+    SegmentSizeT,
+    DecomposerT>;
 
   /// Number of bin-starting offsets tracked per thread
   static constexpr int bins_tracked_per_thread = BlockDownsweepT::BINS_TRACKED_PER_THREAD;
@@ -284,6 +289,6 @@ __launch_bounds__(segmented_radix_sort_kernel_launch_bounds<PolicySelector, AltD
     decomposer);
   downsweep.ProcessRegion(SegmentSizeT{0}, num_items);
 }
-} // namespace detail::radix_sort
+} // namespace detail::segmented_radix_sort
 
 CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/kernels/kernel_segmented_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_segmented_radix_sort.cuh
@@ -107,7 +107,7 @@ template <typename PolicySelector,
           typename SegmentSizeT,
           typename DecomposerT = detail::identity_decomposer_t>
 #if _CCCL_HAS_CONCEPTS()
-  requires radix_sort_policy_selector<PolicySelector>
+  requires segmented_radix_sort_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
 __launch_bounds__(segmented_radix_sort_kernel_launch_bounds<PolicySelector, AltDigitBits>())
   _CCCL_KERNEL_ATTRIBUTES void DeviceSegmentedRadixSortKernel(

--- a/cub/cub/device/dispatch/kernels/kernel_segmented_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_segmented_radix_sort.cuh
@@ -33,7 +33,7 @@ _CCCL_EXEC_CHECK_DISABLE
 template <typename PolicySelector, bool AltDigitBits>
 [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL int segmented_radix_sort_kernel_launch_bounds() noexcept
 {
-  constexpr auto policy = current_policy<PolicySelector>();
+  constexpr segmented_radix_sort_policy policy = current_policy<PolicySelector>();
   return AltDigitBits ? policy.alt_segmented.threads_per_block : policy.segmented.threads_per_block;
 }
 

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -898,8 +898,8 @@ _CCCL_API constexpr auto convert_policy() -> radix_sort_policy
       delay_constructor_policy_from_type<typename scan_pol::detail::delay_constructor_t>},
     {}};
 
-  const auto downsweep     = convert_downsweep_policy(typename active_policy::DownsweepPolicy{});
-  const auto alt_downsweep = convert_downsweep_policy(typename active_policy::AltDownsweepPolicy{});
+  const auto downsweep     = radix_sort::convert_downsweep_policy(typename active_policy::DownsweepPolicy{});
+  const auto alt_downsweep = radix_sort::convert_downsweep_policy(typename active_policy::AltDownsweepPolicy{});
 
   using up_pol       = typename active_policy::UpsweepPolicy;
   const auto upsweep = radix_sort_upsweep_policy{
@@ -909,7 +909,7 @@ _CCCL_API constexpr auto convert_policy() -> radix_sort_policy
   const auto alt_upsweep = radix_sort_upsweep_policy{
     alt_up_pol::BLOCK_THREADS, alt_up_pol::ITEMS_PER_THREAD, alt_up_pol::RADIX_BITS, alt_up_pol::LOAD_MODIFIER};
 
-  const auto single_tile = convert_downsweep_policy(typename active_policy::SingleTilePolicy{});
+  const auto single_tile = radix_sort::convert_downsweep_policy(typename active_policy::SingleTilePolicy{});
 
   return radix_sort_policy{
     active_policy::ONESWEEP,

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -260,17 +260,13 @@ struct radix_sort_policy
   radix_sort_upsweep_policy upsweep;
   radix_sort_upsweep_policy alt_upsweep;
   radix_sort_downsweep_policy single_tile;
-  // TODO(bgruber): move those over to segmented radix sort when we port it
-  radix_sort_downsweep_policy segmented;
-  radix_sort_downsweep_policy alt_segmented;
 
   _CCCL_API constexpr friend bool operator==(const radix_sort_policy& lhs, const radix_sort_policy& rhs)
   {
     return lhs.use_onesweep == rhs.use_onesweep && lhs.onesweep_radix_bits == rhs.onesweep_radix_bits
         && lhs.histogram == rhs.histogram && lhs.exclusive_sum == rhs.exclusive_sum && lhs.onesweep == rhs.onesweep
         && lhs.scan == rhs.scan && lhs.downsweep == rhs.downsweep && lhs.alt_downsweep == rhs.alt_downsweep
-        && lhs.upsweep == rhs.upsweep && lhs.alt_upsweep == rhs.alt_upsweep && lhs.single_tile == rhs.single_tile
-        && lhs.segmented == rhs.segmented && lhs.alt_segmented == rhs.alt_segmented;
+        && lhs.upsweep == rhs.upsweep && lhs.alt_upsweep == rhs.alt_upsweep && lhs.single_tile == rhs.single_tile;
   }
 
   _CCCL_API constexpr friend bool operator!=(const radix_sort_policy& lhs, const radix_sort_policy& rhs)
@@ -286,8 +282,7 @@ struct radix_sort_policy
         << ", .onesweep_radix_bits = " << p.onesweep_radix_bits << ", .histogram = " << p.histogram
         << ", .exclusive_sum = " << p.exclusive_sum << ", .onesweep = " << p.onesweep << ", .scan = " << p.scan
         << ", .downsweep = " << p.downsweep << ", .alt_downsweep = " << p.alt_downsweep << ", .upsweep = " << p.upsweep
-        << ", .alt_upsweep = " << p.alt_upsweep << ", .single_tile = " << p.single_tile
-        << ", .segmented = " << p.segmented << ", .alt_segmented = " << p.alt_segmented << " }";
+        << ", .alt_upsweep = " << p.alt_upsweep << ", .single_tile = " << p.single_tile << " }";
   }
 #endif // _CCCL_HOSTED()
 };
@@ -913,9 +908,7 @@ _CCCL_API constexpr auto convert_policy() -> radix_sort_policy
   const auto alt_upsweep = radix_sort_upsweep_policy{
     alt_up_pol::BLOCK_THREADS, alt_up_pol::ITEMS_PER_THREAD, alt_up_pol::RADIX_BITS, alt_up_pol::LOAD_MODIFIER};
 
-  const auto single_tile   = convert_downsweep_policy(typename active_policy::SingleTilePolicy{});
-  const auto segmented     = convert_downsweep_policy(typename active_policy::SegmentedPolicy{});
-  const auto alt_segmented = convert_downsweep_policy(typename active_policy::AltSegmentedPolicy{});
+  const auto single_tile = convert_downsweep_policy(typename active_policy::SingleTilePolicy{});
 
   return radix_sort_policy{
     active_policy::ONESWEEP,
@@ -928,9 +921,7 @@ _CCCL_API constexpr auto convert_policy() -> radix_sort_policy
     alt_downsweep,
     upsweep,
     alt_upsweep,
-    single_tile,
-    segmented,
-    alt_segmented};
+    single_tile};
 }
 
 // TODO(bgruber): remove in CCCL 4.0 when we drop the radix sort dispatcher after publishing the tuning API
@@ -1688,7 +1679,6 @@ struct policy_selector
   {
     const int primary_radix_bits     = (key_size > 1) ? 7 : 5;
     const int single_tile_radix_bits = (key_size > 1) ? 6 : 5;
-    const int segmented_radix_bits   = (key_size > 1) ? 6 : 5;
     const int onesweep_radix_bits    = 8;
 
     const auto histogram = radix_sort_histogram_policy{128, 16, __scale_num_parts(1, key_size), onesweep_radix_bits};
@@ -1784,26 +1774,6 @@ struct policy_selector
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS);
 
-    const auto segmented = make_reg_scaled_radix_sort_downsweep_policy(
-      192,
-      39,
-      __dominant_size(),
-      segmented_radix_bits,
-      BLOCK_LOAD_TRANSPOSE,
-      LOAD_DEFAULT,
-      RADIX_RANK_MEMOIZE,
-      BLOCK_SCAN_WARP_SCANS);
-
-    const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
-      384,
-      11,
-      __dominant_size(),
-      segmented_radix_bits - 1,
-      BLOCK_LOAD_TRANSPOSE,
-      LOAD_DEFAULT,
-      RADIX_RANK_MEMOIZE,
-      BLOCK_SCAN_WARP_SCANS);
-
     return radix_sort_policy{
       /* use_onesweep */ true,
       onesweep_radix_bits,
@@ -1815,15 +1785,11 @@ struct policy_selector
       alt_downsweep,
       upsweep,
       alt_upsweep,
-      single_tile,
-      segmented,
-      alt_segmented};
+      single_tile};
   }
 
   [[nodiscard]] _CCCL_API constexpr auto operator()(::cuda::compute_capability cc) const -> radix_sort_policy
   {
-    // TODO(bgruber): we should probably separate the segmented policies and move them somewhere else
-
     if (cc >= ::cuda::compute_capability{10, 0})
     {
       return make_onesweep_small_key_policy(get_sm100_tuning(key_size, value_size, offset_size, key_type));
@@ -1838,7 +1804,6 @@ struct policy_selector
     {
       const int primary_radix_bits     = (key_size > 1) ? 7 : 5;
       const int single_tile_radix_bits = (key_size > 1) ? 6 : 5;
-      const int segmented_radix_bits   = (key_size > 1) ? 6 : 5;
       const bool use_onesweep          = key_size >= int{sizeof(uint32_t)};
       const int onesweep_radix_bits    = 8;
       const bool offset_64bit          = offset_size == 8;
@@ -1902,26 +1867,6 @@ struct policy_selector
         RADIX_RANK_MEMOIZE,
         BLOCK_SCAN_WARP_SCANS);
 
-      const auto segmented = make_reg_scaled_radix_sort_downsweep_policy(
-        192,
-        39,
-        __dominant_size(),
-        segmented_radix_bits,
-        BLOCK_LOAD_TRANSPOSE,
-        LOAD_DEFAULT,
-        RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
-
-      const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
-        384,
-        11,
-        __dominant_size(),
-        segmented_radix_bits - 1,
-        BLOCK_LOAD_TRANSPOSE,
-        LOAD_DEFAULT,
-        RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
-
       return radix_sort_policy{
         use_onesweep,
         onesweep_radix_bits,
@@ -1933,16 +1878,13 @@ struct policy_selector
         alt_downsweep,
         upsweep,
         alt_upsweep,
-        single_tile,
-        segmented,
-        alt_segmented};
+        single_tile};
     }
 
     if (cc >= ::cuda::compute_capability{7, 0})
     {
       const int primary_radix_bits     = (key_size > 1) ? 7 : 5; // 7.62B 32b keys/s (GV100)
       const int single_tile_radix_bits = (key_size > 1) ? 6 : 5;
-      const int segmented_radix_bits   = (key_size > 1) ? 6 : 5; // 8.7B 32b segmented keys/s (GV100)
       const bool use_onesweep = key_size >= int{sizeof(uint32_t)}; // 15.8B 32b keys/s (V100-SXM2, 64M random keys)
       const int onesweep_radix_bits = 8;
       const bool offset_64bit       = offset_size == 8;
@@ -2006,26 +1948,6 @@ struct policy_selector
         RADIX_RANK_MEMOIZE,
         BLOCK_SCAN_WARP_SCANS);
 
-      const auto segmented = make_reg_scaled_radix_sort_downsweep_policy(
-        192,
-        39,
-        __dominant_size(),
-        segmented_radix_bits,
-        BLOCK_LOAD_TRANSPOSE,
-        LOAD_DEFAULT,
-        RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
-
-      const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
-        384,
-        11,
-        __dominant_size(),
-        segmented_radix_bits - 1,
-        BLOCK_LOAD_TRANSPOSE,
-        LOAD_DEFAULT,
-        RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
-
       return radix_sort_policy{
         use_onesweep,
         onesweep_radix_bits,
@@ -2037,9 +1959,7 @@ struct policy_selector
         alt_downsweep,
         upsweep,
         alt_upsweep,
-        single_tile,
-        segmented,
-        alt_segmented};
+        single_tile};
     }
 
     if (cc >= ::cuda::compute_capability{6, 2})
@@ -2111,9 +2031,6 @@ struct policy_selector
         RADIX_RANK_MEMOIZE,
         BLOCK_SCAN_WARP_SCANS);
 
-      const auto segmented     = downsweep;
-      const auto alt_segmented = alt_downsweep;
-
       return radix_sort_policy{
         use_onesweep,
         onesweep_radix_bits,
@@ -2125,16 +2042,13 @@ struct policy_selector
         alt_downsweep,
         upsweep,
         alt_upsweep,
-        single_tile,
-        segmented,
-        alt_segmented};
+        single_tile};
     }
 
     if (cc >= ::cuda::compute_capability{6, 1})
     {
       const int primary_radix_bits     = (key_size > 1) ? 7 : 5; // 3.4B 32b keys/s, 1.83B 32b pairs/s (1080)
       const int single_tile_radix_bits = (key_size > 1) ? 6 : 5;
-      const int segmented_radix_bits   = (key_size > 1) ? 6 : 5; // 3.3B 32b segmented keys/s (1080)
       const bool use_onesweep          = key_size >= int{sizeof(uint32_t)}; // 10.0B 32b keys/s (GP100, 64M random keys)
       const int onesweep_radix_bits    = 8;
 
@@ -2197,26 +2111,6 @@ struct policy_selector
         RADIX_RANK_MEMOIZE,
         BLOCK_SCAN_WARP_SCANS);
 
-      const auto segmented = make_reg_scaled_radix_sort_downsweep_policy(
-        192,
-        39,
-        __dominant_size(),
-        segmented_radix_bits,
-        BLOCK_LOAD_TRANSPOSE,
-        LOAD_DEFAULT,
-        RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
-
-      const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
-        384,
-        11,
-        __dominant_size(),
-        segmented_radix_bits - 1,
-        BLOCK_LOAD_TRANSPOSE,
-        LOAD_DEFAULT,
-        RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
-
       return radix_sort_policy{
         use_onesweep,
         onesweep_radix_bits,
@@ -2228,16 +2122,13 @@ struct policy_selector
         alt_downsweep,
         upsweep,
         alt_upsweep,
-        single_tile,
-        segmented,
-        alt_segmented};
+        single_tile};
     }
 
     if (cc >= ::cuda::compute_capability{6, 0})
     {
       const int primary_radix_bits     = (key_size > 1) ? 7 : 5; // 6.9B 32b keys/s (Quadro P100)
       const int single_tile_radix_bits = (key_size > 1) ? 6 : 5;
-      const int segmented_radix_bits   = (key_size > 1) ? 6 : 5; // 5.9B 32b segmented keys/s (Quadro P100)
       const bool use_onesweep          = key_size >= int{sizeof(uint32_t)}; // 10.0B 32b keys/s (GP100, 64M random keys)
       const int onesweep_radix_bits    = 8;
       const bool offset_64bit          = (offset_size == 8);
@@ -2304,26 +2195,6 @@ struct policy_selector
         RADIX_RANK_MEMOIZE,
         BLOCK_SCAN_WARP_SCANS);
 
-      const auto segmented = make_reg_scaled_radix_sort_downsweep_policy(
-        192,
-        39,
-        __dominant_size(),
-        segmented_radix_bits,
-        BLOCK_LOAD_TRANSPOSE,
-        LOAD_DEFAULT,
-        RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
-
-      const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
-        384,
-        11,
-        __dominant_size(),
-        segmented_radix_bits - 1,
-        BLOCK_LOAD_TRANSPOSE,
-        LOAD_DEFAULT,
-        RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
-
       return radix_sort_policy{
         use_onesweep,
         onesweep_radix_bits,
@@ -2335,15 +2206,12 @@ struct policy_selector
         alt_downsweep,
         upsweep,
         alt_upsweep,
-        single_tile,
-        segmented,
-        alt_segmented};
+        single_tile};
     }
 
     // SM50
     const int primary_radix_bits     = (key_size > 1) ? 7 : 5; // 3.5B 32b keys/s, 1.92B 32b pairs/s (TitanX)
     const int single_tile_radix_bits = (key_size > 1) ? 6 : 5;
-    const int segmented_radix_bits   = (key_size > 1) ? 6 : 5; // 3.1B 32b segmented keys/s (TitanX)
     const bool use_onesweep          = false;
     const int onesweep_radix_bits    = 8;
 
@@ -2409,26 +2277,6 @@ struct policy_selector
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS);
 
-    const auto segmented = make_reg_scaled_radix_sort_downsweep_policy(
-      192,
-      31,
-      __dominant_size(),
-      segmented_radix_bits,
-      BLOCK_LOAD_WARP_TRANSPOSE,
-      LOAD_DEFAULT,
-      RADIX_RANK_MEMOIZE,
-      BLOCK_SCAN_WARP_SCANS);
-
-    const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
-      256,
-      11,
-      __dominant_size(),
-      segmented_radix_bits - 1,
-      BLOCK_LOAD_WARP_TRANSPOSE,
-      LOAD_DEFAULT,
-      RADIX_RANK_MEMOIZE,
-      BLOCK_SCAN_WARP_SCANS);
-
     return radix_sort_policy{
       use_onesweep,
       onesweep_radix_bits,
@@ -2440,9 +2288,7 @@ struct policy_selector
       alt_downsweep,
       upsweep,
       alt_upsweep,
-      single_tile,
-      segmented,
-      alt_segmented};
+      single_tile};
   }
 };
 

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -849,23 +849,24 @@ _CCCL_HOST_DEVICE RadixSortPolicyWrapper<PolicyT> MakeRadixSortPolicyWrapper(Pol
 }
 
 // TODO(bgruber): remove in CCCL 4.0 when we drop the radix sort dispatcher after publishing the tuning API
+template <typename DownsweepPolicy>
+_CCCL_API constexpr auto convert_downsweep_policy(DownsweepPolicy)
+{
+  return radix_sort_downsweep_policy{
+    DownsweepPolicy::BLOCK_THREADS,
+    DownsweepPolicy::ITEMS_PER_THREAD,
+    DownsweepPolicy::RADIX_BITS,
+    DownsweepPolicy::LOAD_ALGORITHM,
+    DownsweepPolicy::LOAD_MODIFIER,
+    DownsweepPolicy::RANK_ALGORITHM,
+    DownsweepPolicy::SCAN_ALGORITHM};
+};
+
+// TODO(bgruber): remove in CCCL 4.0 when we drop the radix sort dispatcher after publishing the tuning API
 template <typename LegacyActivePolicy>
 _CCCL_API constexpr auto convert_policy() -> radix_sort_policy
 {
   using active_policy = LegacyActivePolicy;
-
-  auto convert_downsweep_policy = [](auto p) {
-    (void) p;
-    using p_t = decltype(p);
-    return radix_sort_downsweep_policy{
-      p_t::BLOCK_THREADS,
-      p_t::ITEMS_PER_THREAD,
-      p_t::RADIX_BITS,
-      p_t::LOAD_ALGORITHM,
-      p_t::LOAD_MODIFIER,
-      p_t::RANK_ALGORITHM,
-      p_t::SCAN_ALGORITHM};
-  };
 
   using hist_pol       = typename active_policy::HistogramPolicy;
   const auto histogram = radix_sort_histogram_policy{

--- a/cub/cub/device/dispatch/tuning/tuning_segmented_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_segmented_radix_sort.cuh
@@ -1,0 +1,305 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/device/dispatch/tuning/tuning_radix_sort.cuh>
+
+#include <cuda/__device/compute_capability.h>
+#include <cuda/std/__host_stdlib/ostream>
+
+CUB_NAMESPACE_BEGIN
+namespace detail::segmented_radix_sort
+{
+using radix_sort::make_reg_scaled_radix_sort_downsweep_policy;
+using radix_sort::radix_sort_downsweep_policy;
+
+struct segmented_radix_sort_policy
+{
+  radix_sort_downsweep_policy segmented;
+  radix_sort_downsweep_policy alt_segmented;
+
+  _CCCL_API constexpr friend bool
+  operator==(const segmented_radix_sort_policy& lhs, const segmented_radix_sort_policy& rhs)
+  {
+    return lhs.segmented == rhs.segmented && lhs.alt_segmented == rhs.alt_segmented;
+  }
+
+  _CCCL_API constexpr friend bool
+  operator!=(const segmented_radix_sort_policy& lhs, const segmented_radix_sort_policy& rhs)
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const segmented_radix_sort_policy& p)
+  {
+    return os << "segmented_radix_sort_policy { .segmented = " << p.segmented
+              << ", .alt_segmented = " << p.alt_segmented << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
+#if _CCCL_HAS_CONCEPTS()
+template <typename T>
+concept segmented_radix_sort_policy_selector = detail::policy_selector<T, segmented_radix_sort_policy>;
+#endif // _CCCL_HAS_CONCEPTS()
+
+struct policy_selector
+{
+  int key_size;
+  int value_size; // when 0, indicates keys-only
+
+  // Dominant-sized key/value type
+  [[nodiscard]] _CCCL_API constexpr int __dominant_size() const
+  {
+    return ::cuda::std::max(value_size, key_size);
+  }
+
+  [[nodiscard]] _CCCL_API constexpr auto operator()(::cuda::compute_capability cc) const -> segmented_radix_sort_policy
+  {
+    if (cc >= ::cuda::compute_capability{10, 0})
+    {
+      const int segmented_radix_bits = (key_size > 1) ? 6 : 5;
+
+      const auto segmented = make_reg_scaled_radix_sort_downsweep_policy(
+        192,
+        39,
+        __dominant_size(),
+        segmented_radix_bits,
+        BLOCK_LOAD_TRANSPOSE,
+        LOAD_DEFAULT,
+        RADIX_RANK_MEMOIZE,
+        BLOCK_SCAN_WARP_SCANS);
+
+      const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
+        384,
+        11,
+        __dominant_size(),
+        segmented_radix_bits - 1,
+        BLOCK_LOAD_TRANSPOSE,
+        LOAD_DEFAULT,
+        RADIX_RANK_MEMOIZE,
+        BLOCK_SCAN_WARP_SCANS);
+
+      return segmented_radix_sort_policy{segmented, alt_segmented};
+    }
+
+    if (cc >= ::cuda::compute_capability{9, 0})
+    {
+      const int segmented_radix_bits = (key_size > 1) ? 6 : 5;
+
+      const auto segmented = make_reg_scaled_radix_sort_downsweep_policy(
+        192,
+        39,
+        __dominant_size(),
+        segmented_radix_bits,
+        BLOCK_LOAD_TRANSPOSE,
+        LOAD_DEFAULT,
+        RADIX_RANK_MEMOIZE,
+        BLOCK_SCAN_WARP_SCANS);
+
+      const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
+        384,
+        11,
+        __dominant_size(),
+        segmented_radix_bits - 1,
+        BLOCK_LOAD_TRANSPOSE,
+        LOAD_DEFAULT,
+        RADIX_RANK_MEMOIZE,
+        BLOCK_SCAN_WARP_SCANS);
+
+      return segmented_radix_sort_policy{segmented, alt_segmented};
+    }
+
+    if (cc >= ::cuda::compute_capability{8, 0})
+    {
+      const int segmented_radix_bits = (key_size > 1) ? 6 : 5;
+
+      const auto segmented = make_reg_scaled_radix_sort_downsweep_policy(
+        192,
+        39,
+        __dominant_size(),
+        segmented_radix_bits,
+        BLOCK_LOAD_TRANSPOSE,
+        LOAD_DEFAULT,
+        RADIX_RANK_MEMOIZE,
+        BLOCK_SCAN_WARP_SCANS);
+
+      const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
+        384,
+        11,
+        __dominant_size(),
+        segmented_radix_bits - 1,
+        BLOCK_LOAD_TRANSPOSE,
+        LOAD_DEFAULT,
+        RADIX_RANK_MEMOIZE,
+        BLOCK_SCAN_WARP_SCANS);
+
+      return segmented_radix_sort_policy{segmented, alt_segmented};
+    }
+
+    if (cc >= ::cuda::compute_capability{7, 0})
+    {
+      const int segmented_radix_bits = (key_size > 1) ? 6 : 5;
+
+      const auto segmented = make_reg_scaled_radix_sort_downsweep_policy(
+        192,
+        39,
+        __dominant_size(),
+        segmented_radix_bits,
+        BLOCK_LOAD_TRANSPOSE,
+        LOAD_DEFAULT,
+        RADIX_RANK_MEMOIZE,
+        BLOCK_SCAN_WARP_SCANS);
+
+      const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
+        384,
+        11,
+        __dominant_size(),
+        segmented_radix_bits - 1,
+        BLOCK_LOAD_TRANSPOSE,
+        LOAD_DEFAULT,
+        RADIX_RANK_MEMOIZE,
+        BLOCK_SCAN_WARP_SCANS);
+
+      return segmented_radix_sort_policy{segmented, alt_segmented};
+    }
+
+    if (cc >= ::cuda::compute_capability{6, 2})
+    {
+      // SM62: segmented policies match the downsweep policies
+      const int primary_radix_bits = 5;
+      const int alt_radix_bits     = primary_radix_bits - 1;
+
+      const auto segmented = make_reg_scaled_radix_sort_downsweep_policy(
+        256,
+        16,
+        __dominant_size(),
+        primary_radix_bits,
+        BLOCK_LOAD_TRANSPOSE,
+        LOAD_DEFAULT,
+        RADIX_RANK_MEMOIZE,
+        BLOCK_SCAN_RAKING_MEMOIZE);
+
+      const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
+        256,
+        16,
+        __dominant_size(),
+        alt_radix_bits,
+        BLOCK_LOAD_TRANSPOSE,
+        LOAD_DEFAULT,
+        RADIX_RANK_MEMOIZE,
+        BLOCK_SCAN_RAKING_MEMOIZE);
+
+      return segmented_radix_sort_policy{segmented, alt_segmented};
+    }
+
+    if (cc >= ::cuda::compute_capability{6, 1})
+    {
+      const int segmented_radix_bits = (key_size > 1) ? 6 : 5;
+
+      const auto segmented = make_reg_scaled_radix_sort_downsweep_policy(
+        192,
+        39,
+        __dominant_size(),
+        segmented_radix_bits,
+        BLOCK_LOAD_TRANSPOSE,
+        LOAD_DEFAULT,
+        RADIX_RANK_MEMOIZE,
+        BLOCK_SCAN_WARP_SCANS);
+
+      const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
+        384,
+        11,
+        __dominant_size(),
+        segmented_radix_bits - 1,
+        BLOCK_LOAD_TRANSPOSE,
+        LOAD_DEFAULT,
+        RADIX_RANK_MEMOIZE,
+        BLOCK_SCAN_WARP_SCANS);
+
+      return segmented_radix_sort_policy{segmented, alt_segmented};
+    }
+
+    if (cc >= ::cuda::compute_capability{6, 0})
+    {
+      const int segmented_radix_bits = (key_size > 1) ? 6 : 5;
+
+      const auto segmented = make_reg_scaled_radix_sort_downsweep_policy(
+        192,
+        39,
+        __dominant_size(),
+        segmented_radix_bits,
+        BLOCK_LOAD_TRANSPOSE,
+        LOAD_DEFAULT,
+        RADIX_RANK_MEMOIZE,
+        BLOCK_SCAN_WARP_SCANS);
+
+      const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
+        384,
+        11,
+        __dominant_size(),
+        segmented_radix_bits - 1,
+        BLOCK_LOAD_TRANSPOSE,
+        LOAD_DEFAULT,
+        RADIX_RANK_MEMOIZE,
+        BLOCK_SCAN_WARP_SCANS);
+
+      return segmented_radix_sort_policy{segmented, alt_segmented};
+    }
+
+    // SM50
+    const int segmented_radix_bits = (key_size > 1) ? 6 : 5;
+
+    const auto segmented = make_reg_scaled_radix_sort_downsweep_policy(
+      192,
+      31,
+      __dominant_size(),
+      segmented_radix_bits,
+      BLOCK_LOAD_WARP_TRANSPOSE,
+      LOAD_DEFAULT,
+      RADIX_RANK_MEMOIZE,
+      BLOCK_SCAN_WARP_SCANS);
+
+    const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
+      256,
+      11,
+      __dominant_size(),
+      segmented_radix_bits - 1,
+      BLOCK_LOAD_WARP_TRANSPOSE,
+      LOAD_DEFAULT,
+      RADIX_RANK_MEMOIZE,
+      BLOCK_SCAN_WARP_SCANS);
+
+    return segmented_radix_sort_policy{segmented, alt_segmented};
+  }
+};
+
+#if _CCCL_HAS_CONCEPTS()
+static_assert(segmented_radix_sort_policy_selector<policy_selector>);
+#endif // _CCCL_HAS_CONCEPTS()
+
+template <typename KeyT, typename ValueT, typename OffsetT>
+struct policy_selector_from_types
+{
+  [[nodiscard]] _CCCL_API constexpr auto operator()(cuda::compute_capability cc) const -> segmented_radix_sort_policy
+  {
+    constexpr auto policies =
+      policy_selector{int{sizeof(KeyT)}, ::cuda::std::is_same_v<ValueT, NullType> ? 0 : int{sizeof(ValueT)}};
+    return policies(cc);
+  }
+};
+} // namespace detail::segmented_radix_sort
+
+CUB_NAMESPACE_END


### PR DESCRIPTION
- [x] No SASS changes for `cub.bench.segmented_radix_sort.keys.base` for SM `75;80;90;100`