### PR TITLE
[libcu++] Cleanup our lit config

### DIFF
--- a/libcudacxx/test/libcudacxx/lit.site.cfg.in
+++ b/libcudacxx/test/libcudacxx/lit.site.cfg.in
@@ -11,7 +11,6 @@ config.enable_exceptions        = True
 config.enable_experimental      = False
 config.enable_filesystem        = False
 config.enable_rtti              = False
-config.enable_shared            = False
 config.cxx_abi                  = "none"
 config.is_nvrtc                 = @LIBCUDACXX_CUDA_TEST_WITH_NVRTC@
 config.configuration_variant    = "libcudacxx"

--- a/libcudacxx/test/libcudacxx/lit.site.cfg.in
+++ b/libcudacxx/test/libcudacxx/lit.site.cfg.in
@@ -30,7 +30,6 @@ config.nvcc_host_compiler       = "@CMAKE_CUDA_HOST_COMPILER@"
 config.cuda_path                = "@CMAKE_CUDA_COMPILER_TOOLKIT_ROOT@"
 
 config.executor                 = "@LIBCUDACXX_EXECUTOR@"
-config.debug_build              = False
 config.maxIndividualTestTime    = @LIBCUDACXX_TEST_TIMEOUT@
 
 # Let the main config do the real work.

--- a/libcudacxx/test/libcudacxx/lit.site.cfg.in
+++ b/libcudacxx/test/libcudacxx/lit.site.cfg.in
@@ -8,7 +8,6 @@ config.cxx_library_root         = "@LIBCUDACXX_LIBRARY_DIR@"
 config.std                      = "@LIBCUDACXX_TEST_STANDARD_VER@"
 config.enable_tile              = "@LIBCUDACXX_ENABLE_TILE@"
 config.enable_exceptions        = True
-config.enable_experimental      = False
 config.cxx_abi                  = "none"
 config.is_nvrtc                 = @LIBCUDACXX_CUDA_TEST_WITH_NVRTC@
 config.configuration_variant    = "libcudacxx"

--- a/libcudacxx/test/libcudacxx/lit.site.cfg.in
+++ b/libcudacxx/test/libcudacxx/lit.site.cfg.in
@@ -14,7 +14,6 @@ config.configuration_variant    = "libcudacxx"
 config.host_triple              = "@LLVM_HOST_TRIPLE@"
 config.target_triple            = "@TARGET_TRIPLE@"
 config.use_target               = bool("@LIBCUDACXX_TARGET_TRIPLE@")
-config.generate_coverage        = False
 config.target_info              = "@LIBCUDACXX_TARGET_INFO@"
 config.test_linker_flags        = "@LIBCUDACXX_TEST_LINKER_FLAGS@"
 config.test_compiler_flags      = "@LIBCUDACXX_TEST_COMPILER_FLAGS@"

--- a/libcudacxx/test/libcudacxx/lit.site.cfg.in
+++ b/libcudacxx/test/libcudacxx/lit.site.cfg.in
@@ -10,7 +10,6 @@ config.enable_tile              = "@LIBCUDACXX_ENABLE_TILE@"
 config.enable_exceptions        = True
 config.enable_experimental      = False
 config.enable_filesystem        = False
-config.enable_rtti              = False
 config.cxx_abi                  = "none"
 config.is_nvrtc                 = @LIBCUDACXX_CUDA_TEST_WITH_NVRTC@
 config.configuration_variant    = "libcudacxx"

--- a/libcudacxx/test/libcudacxx/lit.site.cfg.in
+++ b/libcudacxx/test/libcudacxx/lit.site.cfg.in
@@ -33,7 +33,6 @@ config.executor                 = "@LIBCUDACXX_EXECUTOR@"
 config.has_libatomic            = False
 config.use_libatomic            = False
 config.debug_build              = False
-config.cxx_ext_threads          = False
 config.maxIndividualTestTime    = @LIBCUDACXX_TEST_TIMEOUT@
 
 # Let the main config do the real work.

--- a/libcudacxx/test/libcudacxx/lit.site.cfg.in
+++ b/libcudacxx/test/libcudacxx/lit.site.cfg.in
@@ -8,7 +8,6 @@ config.cxx_library_root         = "@LIBCUDACXX_LIBRARY_DIR@"
 config.std                      = "@LIBCUDACXX_TEST_STANDARD_VER@"
 config.enable_tile              = "@LIBCUDACXX_ENABLE_TILE@"
 config.enable_exceptions        = True
-config.cxx_abi                  = "none"
 config.is_nvrtc                 = @LIBCUDACXX_CUDA_TEST_WITH_NVRTC@
 config.configuration_variant    = "libcudacxx"
 config.host_triple              = "@LLVM_HOST_TRIPLE@"

--- a/libcudacxx/test/libcudacxx/lit.site.cfg.in
+++ b/libcudacxx/test/libcudacxx/lit.site.cfg.in
@@ -33,7 +33,6 @@ config.executor                 = "@LIBCUDACXX_EXECUTOR@"
 config.has_libatomic            = False
 config.use_libatomic            = False
 config.debug_build              = False
-config.libcxxabi_shared         = False
 config.cxx_ext_threads          = False
 config.maxIndividualTestTime    = @LIBCUDACXX_TEST_TIMEOUT@
 

--- a/libcudacxx/test/libcudacxx/lit.site.cfg.in
+++ b/libcudacxx/test/libcudacxx/lit.site.cfg.in
@@ -10,7 +10,6 @@ config.enable_tile              = "@LIBCUDACXX_ENABLE_TILE@"
 config.enable_exceptions        = True
 config.is_nvrtc                 = @LIBCUDACXX_CUDA_TEST_WITH_NVRTC@
 config.configuration_variant    = "libcudacxx"
-config.host_triple              = "@LLVM_HOST_TRIPLE@"
 config.target_triple            = "@TARGET_TRIPLE@"
 config.use_target               = bool("@LIBCUDACXX_TARGET_TRIPLE@")
 config.target_info              = "@LIBCUDACXX_TARGET_INFO@"

--- a/libcudacxx/test/libcudacxx/lit.site.cfg.in
+++ b/libcudacxx/test/libcudacxx/lit.site.cfg.in
@@ -30,7 +30,6 @@ config.nvcc_host_compiler       = "@CMAKE_CUDA_HOST_COMPILER@"
 config.cuda_path                = "@CMAKE_CUDA_COMPILER_TOOLKIT_ROOT@"
 
 config.executor                 = "@LIBCUDACXX_EXECUTOR@"
-config.llvm_unwinder            = False
 config.has_libatomic            = False
 config.use_libatomic            = False
 config.debug_build              = False

--- a/libcudacxx/test/libcudacxx/lit.site.cfg.in
+++ b/libcudacxx/test/libcudacxx/lit.site.cfg.in
@@ -30,8 +30,6 @@ config.nvcc_host_compiler       = "@CMAKE_CUDA_HOST_COMPILER@"
 config.cuda_path                = "@CMAKE_CUDA_COMPILER_TOOLKIT_ROOT@"
 
 config.executor                 = "@LIBCUDACXX_EXECUTOR@"
-config.has_libatomic            = False
-config.use_libatomic            = False
 config.debug_build              = False
 config.maxIndividualTestTime    = @LIBCUDACXX_TEST_TIMEOUT@
 

--- a/libcudacxx/test/libcudacxx/lit.site.cfg.in
+++ b/libcudacxx/test/libcudacxx/lit.site.cfg.in
@@ -12,7 +12,6 @@ config.enable_experimental      = False
 config.enable_filesystem        = False
 config.enable_rtti              = False
 config.enable_shared            = False
-config.enable_32bit             = False
 config.cxx_abi                  = "none"
 config.is_nvrtc                 = @LIBCUDACXX_CUDA_TEST_WITH_NVRTC@
 config.configuration_variant    = "libcudacxx"

--- a/libcudacxx/test/libcudacxx/lit.site.cfg.in
+++ b/libcudacxx/test/libcudacxx/lit.site.cfg.in
@@ -9,7 +9,6 @@ config.std                      = "@LIBCUDACXX_TEST_STANDARD_VER@"
 config.enable_tile              = "@LIBCUDACXX_ENABLE_TILE@"
 config.enable_exceptions        = True
 config.enable_experimental      = False
-config.enable_filesystem        = False
 config.cxx_abi                  = "none"
 config.is_nvrtc                 = @LIBCUDACXX_CUDA_TEST_WITH_NVRTC@
 config.configuration_variant    = "libcudacxx"

--- a/libcudacxx/test/utils/libcudacxx/compiler.py
+++ b/libcudacxx/test/utils/libcudacxx/compiler.py
@@ -116,9 +116,6 @@ class CXXCompiler(object):
                 patchlevel = int(macros["__NVCOMPILER_PATCHLEVEL__"].strip())
             elif "__clang__" in macros.keys():
                 compiler_type = "clang"
-                # Treat Apple's LLVM fork differently.
-                if "__apple_build_version__" in macros.keys():
-                    compiler_type = "apple-clang"
                 major_ver = int(macros["__clang_major__"])
                 minor_ver = int(macros["__clang_minor__"])
                 patchlevel = int(macros["__clang_patchlevel__"])

--- a/libcudacxx/test/utils/libcudacxx/dumpversion.cpp
+++ b/libcudacxx/test/utils/libcudacxx/dumpversion.cpp
@@ -27,12 +27,7 @@ int main()
   minor_version = ___NVCOMPILER_MINOR__;
   patch_level   = ___NVCOMPILER_PATCHLEVEL__;
 #elif defined(__clang__)
-// Treat Apple's LLVM fork differently.
-#  if defined(__apple_build_version__)
-  compiler_type = "apple-clang";
-#  else
   compiler_type = "clang";
-#  endif
   major_version = __clang_major__;
   minor_version = __clang_minor__;
   patch_level   = __clang_patchlevel__;

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -1126,18 +1126,16 @@ class Configuration(object):
             self.config.available_features.add("libcpp-no-exceptions")
 
     def configure_compile_flags_rtti(self):
-        enable_rtti = self.get_lit_bool("enable_rtti", True)
-        if not enable_rtti:
-            self.config.available_features.add("libcpp-no-rtti")
-            if self.cxx.type == "nvcc":
-                self.cxx.compile_flags += ["-Xcompiler"]
-            if "nvhpc" in self.config.available_features:
-                self.cxx.compile_flags += ["--no_rtti"]
-            elif "msvc" in self.config.available_features:
-                self.cxx.compile_flags += ["/GR-"]
-                self.cxx.compile_flags += ["-D_SILENCE_CXX20_CISO646_REMOVED_WARNING"]
-            else:
-                self.cxx.compile_flags += ["-fno-rtti"]
+        self.config.available_features.add("libcpp-no-rtti")
+        if self.cxx.type == "nvcc":
+            self.cxx.compile_flags += ["-Xcompiler"]
+        if "nvhpc" in self.config.available_features:
+            self.cxx.compile_flags += ["--no_rtti"]
+        elif "msvc" in self.config.available_features:
+            self.cxx.compile_flags += ["/GR-"]
+            self.cxx.compile_flags += ["-D_SILENCE_CXX20_CISO646_REMOVED_WARNING"]
+        else:
+            self.cxx.compile_flags += ["-fno-rtti"]
 
     def configure_compile_flags_abi_version(self):
         abi_unstable = self.get_lit_bool("abi_unstable")

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -585,13 +585,6 @@ class Configuration(object):
                 % self.cxx_stdlib_under_test
             )
         self.config.available_features.add(self.cxx_stdlib_under_test)
-        if self.cxx_stdlib_under_test == "libstdc++":
-            self.config.available_features.add("libstdc++")
-            # Manually enable the experimental and filesystem tests for libstdc++
-            # if the options aren't present.
-            # FIXME this is a hack.
-            if self.get_lit_conf("enable_experimental") is None:
-                self.config.enable_experimental = "true"
 
     def configure_use_clang_verify(self):
         if self.cxx.type == "nvrtcc":
@@ -1227,12 +1220,6 @@ class Configuration(object):
                     self.cxx.link_flags += ["-Wl,-rpath," + self.abi_library_root]
             else:
                 self.add_path(self.exec_env, self.abi_library_root)
-
-    def configure_link_flags_cxx_library(self):
-        libcxx_experimental = self.get_lit_bool("enable_experimental", default=False)
-        if libcxx_experimental:
-            self.config.available_features.add("c++experimental")
-            self.cxx.link_flags += ["-lc++experimental"]
 
     def configure_link_flags_abi_library(self):
         cxx_abi = self.get_lit_conf("cxx_abi", "libcxxabi")

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -79,7 +79,6 @@ class Configuration(object):
         self.exec_env = dict(os.environ)
         self.exec_env["CUDA_MODULE_LOADING"] = "EAGER"
         self.use_target = False
-        self.use_system_cxx_lib = False
         self.use_clang_verify = False
         self.long_tests = None
         self.execute_external = False
@@ -273,7 +272,6 @@ class Configuration(object):
 
     def configure(self):
         self.configure_executor()
-        self.configure_use_system_cxx_lib()
         self.configure_target_info()
         self.configure_cxx()
         self.configure_triple()
@@ -548,27 +546,6 @@ class Configuration(object):
             "cxx_runtime_root", self.cxx_library_root
         )
 
-    def configure_use_system_cxx_lib(self):
-        # This test suite supports testing against either the system library or
-        # the locally built one; the former mode is useful for testing ABI
-        # compatibility between the current headers and a shipping dynamic
-        # library.
-        # Default to testing against the locally built libc++ library.
-        self.use_system_cxx_lib = self.get_lit_conf("use_system_cxx_lib")
-        if self.use_system_cxx_lib == "true":
-            self.use_system_cxx_lib = True
-        elif self.use_system_cxx_lib == "false":
-            self.use_system_cxx_lib = False
-        elif self.use_system_cxx_lib:
-            assert os.path.isdir(self.use_system_cxx_lib), (
-                "the specified use_system_cxx_lib parameter (%s) is not a valid directory"
-                % self.use_system_cxx_lib
-            )
-            self.use_system_cxx_lib = os.path.abspath(self.use_system_cxx_lib)
-        self.lit_config.note(
-            "inferred use_system_cxx_lib as: %r" % self.use_system_cxx_lib
-        )
-
     def configure_cxx_stdlib_under_test(self):
         self.cxx_stdlib_under_test = self.get_lit_conf(
             "cxx_stdlib_under_test", "libc++"
@@ -649,26 +626,6 @@ class Configuration(object):
         self.target_info.add_locale_features(self.config.available_features)
 
         target_platform = self.target_info.platform()
-
-        # Write an "available feature" that combines the triple when
-        # use_system_cxx_lib is enabled. This is so that we can easily write
-        # XFAIL markers for tests that are known to fail with versions of
-        # libc++ as were shipped with a particular triple.
-        if self.use_system_cxx_lib:
-            self.config.available_features.add("with_system_cxx_lib")
-            self.config.available_features.add(
-                "with_system_cxx_lib=%s" % self.config.target_triple
-            )
-
-            # Add subcomponents individually.
-            target_components = self.config.target_triple.split("-")
-            for component in target_components:
-                self.config.available_features.add("with_system_cxx_lib=%s" % component)
-
-            # Add available features for more generic versions of the target
-            # triple attached to  with_system_cxx_lib.
-            if self.use_deployment:
-                self.add_deployment_feature("with_system_cxx_lib")
 
         # Configure the availability feature. Availability is only enabled
         # with libc++, because other standard libraries do not provide
@@ -1179,20 +1136,9 @@ class Configuration(object):
         self.cxx.link_flags += shlex.split(link_flags_str)
 
     def configure_link_flags_cxx_library_path(self):
-        if not self.use_system_cxx_lib:
-            if self.cxx_library_root:
-                self.cxx.link_flags += ["-L" + self.cxx_library_root]
-            if self.cxx_runtime_root:
-                if not self.is_windows:
-                    if self.cxx.type == "nvcc":
-                        self.cxx.link_flags += [
-                            "-Xcompiler",
-                            '"-Wl,-rpath,' + self.cxx_runtime_root + '"',
-                        ]
-                    else:
-                        self.cxx.link_flags += ["-Wl,-rpath," + self.cxx_runtime_root]
-        elif os.path.isdir(str(self.use_system_cxx_lib)):
-            self.cxx.link_flags += ["-L" + self.use_system_cxx_lib]
+        if self.cxx_library_root:
+            self.cxx.link_flags += ["-L" + self.cxx_library_root]
+        if self.cxx_runtime_root:
             if not self.is_windows:
                 if self.cxx.type == "nvcc":
                     self.cxx.link_flags += [
@@ -1200,7 +1146,7 @@ class Configuration(object):
                         '"-Wl,-rpath,' + self.cxx_runtime_root + '"',
                     ]
                 else:
-                    self.cxx.link_flags += ["-Wl,-rpath," + self.use_system_cxx_lib]
+                    self.cxx.link_flags += ["-Wl,-rpath," + self.cxx_runtime_root]
         additional_flags = self.get_lit_conf("test_linker_flags")
         if additional_flags:
             self.cxx.link_flags += shlex.split(additional_flags)
@@ -1599,41 +1545,6 @@ class Configuration(object):
         self.lit_config.note(
             "computed target_triple as: %r" % self.config.target_triple
         )
-
-        # If we're testing a system libc++ as opposed to the upstream LLVM one,
-        # take the version of the system libc++ into account to compute which
-        # features are enabled/disabled. Otherwise, disable availability markup,
-        # which is not relevant for non-shipped flavors of libc++.
-        if self.use_system_cxx_lib:
-            # Dylib support for shared_mutex was added in macosx10.12.
-            if name == "macosx" and version in ("10.%s" % v for v in range(7, 12)):
-                self.config.available_features.add("dylib-has-no-shared_mutex")
-                self.lit_config.note(
-                    "shared_mutex is not supported by the deployment target"
-                )
-            # Throwing bad_optional_access, bad_variant_access and bad_any_cast is
-            # supported starting in macosx10.14.
-            if name == "macosx" and version in ("10.%s" % v for v in range(7, 14)):
-                self.config.available_features.add("dylib-has-no-bad_optional_access")
-                self.lit_config.note(
-                    "throwing bad_optional_access is not supported by the deployment target"
-                )
-
-                self.config.available_features.add("dylib-has-no-bad_variant_access")
-                self.lit_config.note(
-                    "throwing bad_variant_access is not supported by the deployment target"
-                )
-
-                self.config.available_features.add("dylib-has-no-bad_any_cast")
-                self.lit_config.note(
-                    "throwing bad_any_cast is not supported by the deployment target"
-                )
-            # Filesystem is support on Apple platforms starting with macosx10.15.
-            if name == "macosx" and version in ("10.%s" % v for v in range(7, 15)):
-                self.config.available_features.add("dylib-has-no-filesystem")
-                self.lit_config.note(
-                    "the deployment target does not support <filesystem>"
-                )
 
     def configure_env(self):
         self.target_info.configure_env(self.exec_env)

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -634,9 +634,6 @@ class Configuration(object):
             self.config.available_features.add("availability")
             self.add_deployment_feature("availability")
 
-        if platform.system() == "Darwin":
-            self.config.available_features.add("apple-darwin")
-
         # Insert the platform name into the available features as a lower case.
         self.config.available_features.add(target_platform)
 
@@ -1476,37 +1473,6 @@ class Configuration(object):
 
         # Save the triple (and warn on Apple platforms).
         self.config.target_triple = target_triple
-        if self.use_target and "apple" in target_triple:
-            self.lit_config.warning(
-                "consider using arch and platform instead"
-                " of target_triple on Apple platforms"
-            )
-
-        # If no target triple was given, try to infer it from the compiler
-        # under test.
-        if not self.config.target_triple:
-            target_triple = (
-                self.cxx if self.cxx.type != "nvcc" else self.cxx.host_cxx
-            ).getTriple()
-            # Drop sub-major version components from the triple, because the
-            # current XFAIL handling expects exact matches for feature checks.
-            # Example: x86_64-apple-darwin14.0.0 -> x86_64-apple-darwin14
-            # The 5th group handles triples greater than 3 parts
-            # (ex x86_64-pc-linux-gnu).
-            target_triple = re.sub(
-                r"([^-]+)-([^-]+)-([^.]+)([^-]*)(.*)", r"\1-\2-\3\5", target_triple
-            )
-            # linux-gnu is needed in the triple to properly identify linuxes
-            # that use GLIBC. Handle redhat and opensuse triples as special
-            # cases and append the missing `-gnu` portion.
-            if target_triple.endswith("redhat-linux") or target_triple.endswith(
-                "suse-linux"
-            ):
-                target_triple += "-gnu"
-            self.config.target_triple = target_triple
-            self.lit_config.note(
-                "inferred target_triple as: %r" % self.config.target_triple
-            )
 
     def configure_deployment(self):
         assert self.use_deployment is not None

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -1324,17 +1324,7 @@ class Configuration(object):
             # then link it.
             testing_libcxxabi = self.get_lit_conf("name", "") == "libc++abi"
             if self.target_info.allow_cxxabi_link() or testing_libcxxabi:
-                libcxxabi_shared = self.get_lit_bool("libcxxabi_shared", default=True)
-                if libcxxabi_shared:
-                    self.cxx.link_flags += ["-lc++abi"]
-                else:
-                    cxxabi_library_root = self.get_lit_conf("abi_library_path")
-                    if cxxabi_library_root:
-                        libname = self.make_static_lib_name("c++abi")
-                        abs_path = os.path.join(cxxabi_library_root, libname)
-                        self.cxx.link_flags += [abs_path]
-                    else:
-                        self.cxx.link_flags += ["-lc++abi"]
+                self.cxx.link_flags += ["-lc++abi"]
         elif cxx_abi == "libcxxrt":
             self.cxx.link_flags += ["-lcxxrt"]
         elif cxx_abi == "vcruntime":

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -77,7 +77,6 @@ class Configuration(object):
         self.cxx_runtime_root = None
         self.abi_library_root = None
         self.link_shared = self.get_lit_bool("enable_shared", default=True)
-        self.debug_build = self.get_lit_bool("debug_build", default=False)
         self.exec_env = dict(os.environ)
         self.exec_env["CUDA_MODULE_LOADING"] = "EAGER"
         self.use_target = False
@@ -977,12 +976,7 @@ class Configuration(object):
         gcc_toolchain = self.get_lit_conf("gcc_toolchain")
         if gcc_toolchain:
             self.cxx.flags += ["--gcc-toolchain=" + gcc_toolchain]
-        # NOTE: the _DEBUG definition must precede the triple check because for
-        # the Windows build of libc++, the forced inclusion of a header requires
-        # that _DEBUG is defined.  Incorrect ordering will result in -target
-        # being elided.
-        if self.is_windows and self.debug_build:
-            self.cxx.compile_flags += ["-D_DEBUG"]
+
         if self.use_target:
             if not self.cxx.addFlagIfSupported(
                 ["--target=" + self.config.target_triple]
@@ -1032,15 +1026,7 @@ class Configuration(object):
                 os.path.join(support_path, "msvc_stdlib_force_include.h"),
             ]
             pass
-        if (
-            self.is_windows
-            and self.debug_build
-            and self.cxx_stdlib_under_test != "msvc"
-        ):
-            self.cxx.compile_flags += [
-                "-include",
-                os.path.join(support_path, "set_windows_crt_report_mode.h"),
-            ]
+
         cxx_headers = self.get_lit_conf("cxx_headers")
         if cxx_headers == "" or (
             cxx_headers is None and self.cxx_stdlib_under_test != "libc++"
@@ -1325,14 +1311,14 @@ class Configuration(object):
         elif cxx_abi == "libcxxrt":
             self.cxx.link_flags += ["-lcxxrt"]
         elif cxx_abi == "vcruntime":
-            debug_suffix = "d" if self.debug_build else ""
+            debug_suffix = "d"
             self.cxx.link_flags += [
                 "-l%s%s" % (lib, debug_suffix)
                 for lib in ["vcruntime", "ucrt", "msvcrt"]
             ]
         elif cxx_abi == "none" or cxx_abi == "default":
             if self.is_windows:
-                debug_suffix = "d" if self.debug_build else ""
+                debug_suffix = "d"
                 self.cxx.link_flags += ["-lmsvcrt%s" % debug_suffix]
         else:
             self.lit_config.fatal("C++ ABI setting %s unsupported for tests" % cxx_abi)

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -1341,8 +1341,6 @@ class Configuration(object):
             self.lit_config.fatal("C++ ABI setting %s unsupported for tests" % cxx_abi)
 
     def configure_extra_library_flags(self):
-        if self.get_lit_bool("cxx_ext_threads", default=False):
-            self.cxx.link_flags += ["-lc++external_threads"]
         self.target_info.add_cxx_link_flags(self.cxx.link_flags)
 
     def configure_color_diagnostics(self):

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -964,9 +964,6 @@ class Configuration(object):
         self.configure_compile_flags_exceptions()
         self.configure_compile_flags_rtti()
         self.configure_compile_flags_abi_version()
-        enable_32bit = self.get_lit_bool("enable_32bit", False)
-        if enable_32bit:
-            self.cxx.flags += ["-m32"]
         # Use verbose output for better errors
         if not self.cxx.use_ccache or self.cxx.type == "msvc":
             self.cxx.flags += ["-v"]

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -76,7 +76,6 @@ class Configuration(object):
         self.cxx_library_root = None
         self.cxx_runtime_root = None
         self.abi_library_root = None
-        self.link_shared = self.get_lit_bool("enable_shared", default=True)
         self.exec_env = dict(os.environ)
         self.exec_env["CUDA_MODULE_LOADING"] = "EAGER"
         self.use_target = False
@@ -1218,7 +1217,6 @@ class Configuration(object):
                         if self.cxx.type == "nvcc":
                             self.cxx.link_flags += ["-Xcompiler"]
                         self.cxx.link_flags += ["-nostdlib"]
-            self.configure_link_flags_cxx_library()
             self.configure_link_flags_abi_library()
             self.configure_extra_library_flags()
         elif self.cxx_stdlib_under_test == "libstdc++":
@@ -1239,8 +1237,6 @@ class Configuration(object):
         if not self.use_system_cxx_lib:
             if self.cxx_library_root:
                 self.cxx.link_flags += ["-L" + self.cxx_library_root]
-                if self.is_windows and self.link_shared:
-                    self.add_path(self.cxx.compile_env, self.cxx_library_root)
             if self.cxx_runtime_root:
                 if not self.is_windows:
                     if self.cxx.type == "nvcc":
@@ -1250,8 +1246,6 @@ class Configuration(object):
                         ]
                     else:
                         self.cxx.link_flags += ["-Wl,-rpath," + self.cxx_runtime_root]
-                elif self.is_windows and self.link_shared:
-                    self.add_path(self.exec_env, self.cxx_runtime_root)
         elif os.path.isdir(str(self.use_system_cxx_lib)):
             self.cxx.link_flags += ["-L" + self.use_system_cxx_lib]
             if not self.is_windows:
@@ -1262,8 +1256,6 @@ class Configuration(object):
                     ]
                 else:
                     self.cxx.link_flags += ["-Wl,-rpath," + self.use_system_cxx_lib]
-            if self.is_windows and self.link_shared:
-                self.add_path(self.cxx.compile_env, self.use_system_cxx_lib)
         additional_flags = self.get_lit_conf("test_linker_flags")
         if additional_flags:
             self.cxx.link_flags += shlex.split(additional_flags)
@@ -1289,8 +1281,6 @@ class Configuration(object):
         if libcxx_experimental:
             self.config.available_features.add("c++experimental")
             self.cxx.link_flags += ["-lc++experimental"]
-        if self.link_shared:
-            self.cxx.link_flags += ["-lc++"]
 
     def configure_link_flags_abi_library(self):
         cxx_abi = self.get_lit_conf("cxx_abi", "libcxxabi")

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -294,7 +294,6 @@ class Configuration(object):
             self.configure_debug_mode()
             self.configure_warnings()
             self.configure_sanitizer()
-            self.configure_coverage()
             self.configure_modules()
             self.configure_coroutines()
             self.configure_substitutions()
@@ -1456,12 +1455,6 @@ class Configuration(object):
                     ]
                 else:
                     self.cxx.link_flags += ["-Wl,-rpath," + os.path.dirname(san_lib)]
-
-    def configure_coverage(self):
-        self.generate_coverage = self.get_lit_bool("generate_coverage", False)
-        if self.generate_coverage:
-            self.cxx.flags += ["-g", "--coverage"]
-            self.cxx.compile_flags += ["-O0"]
 
     def configure_coroutines(self):
         if self.cxx.hasCompileFlag("-fcoroutines-ts"):

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -287,7 +287,6 @@ class Configuration(object):
         self.configure_no_execute()
         self.configure_execute_external()
         self.configure_compile_flags()
-        self.configure_filesystem_compile_flags()
         self.configure_link_flags()
         self.configure_env()
         self.configure_color_diagnostics()
@@ -703,9 +702,8 @@ class Configuration(object):
         if self.long_tests:
             self.config.available_features.add("long_tests")
 
-        if not self.get_lit_bool("enable_filesystem", default=True):
-            self.config.available_features.add("c++filesystem-disabled")
-            self.config.available_features.add("dylib-has-no-filesystem")
+        self.config.available_features.add("c++filesystem-disabled")
+        self.config.available_features.add("dylib-has-no-filesystem")
 
         # Run a compile test for the -fsized-deallocation flag. This is needed
         # in test/std/language.support/support.dynamic/new.delete
@@ -1142,50 +1140,6 @@ class Configuration(object):
         if abi_unstable:
             self.config.available_features.add("libcpp-abi-unstable")
             self.cxx.compile_flags += ["-D_LIBCUDACXX_ABI_UNSTABLE"]
-
-    def configure_filesystem_compile_flags(self):
-        if not self.get_lit_bool("enable_filesystem", default=True):
-            return
-
-        static_env = os.path.join(
-            self.libcudacxx_src_root,
-            "test",
-            "libcudacxx",
-            "std",
-            "input.output",
-            "filesystems",
-            "Inputs",
-            "static_test_env",
-        )
-        static_env = os.path.realpath(static_env)
-        assert os.path.isdir(static_env)
-        self.cxx.compile_flags += [
-            '-DLIBCXX_FILESYSTEM_STATIC_TEST_ROOT="%s"' % static_env
-        ]
-
-        dynamic_env = os.path.join(
-            self.config.test_exec_root, "filesystem", "Output", "dynamic_env"
-        )
-        dynamic_env = os.path.realpath(dynamic_env)
-        if not os.path.isdir(dynamic_env):
-            os.makedirs(dynamic_env)
-        self.cxx.compile_flags += [
-            '-DLIBCXX_FILESYSTEM_DYNAMIC_TEST_ROOT="%s"' % dynamic_env
-        ]
-        self.exec_env["LIBCXX_FILESYSTEM_DYNAMIC_TEST_ROOT"] = "%s" % dynamic_env
-
-        dynamic_helper = os.path.join(
-            self.libcudacxx_src_root,
-            "test",
-            "support",
-            "filesystem_dynamic_test_helper.py",
-        )
-        assert os.path.isfile(dynamic_helper)
-
-        self.cxx.compile_flags += [
-            '-DLIBCXX_FILESYSTEM_DYNAMIC_TEST_HELPER="%s %s"'
-            % (sys.executable, dynamic_helper)
-        ]
 
     def configure_link_flags(self):
         nvcc_host_compiler = self.get_lit_conf("nvcc_host_compiler")

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -1161,8 +1161,9 @@ class Configuration(object):
                         if self.cxx.type == "nvcc":
                             self.cxx.link_flags += ["-Xcompiler"]
                         self.cxx.link_flags += ["-nostdlib"]
-            self.configure_link_flags_abi_library()
-            self.configure_extra_library_flags()
+            if self.is_windows:
+                self.cxx.link_flags += ["-lmsvcrtd"]
+            self.target_info.add_cxx_link_flags(self.cxx.link_flags)
         elif self.cxx_stdlib_under_test == "libstdc++":
             self.config.available_features.add("c++experimental")
             self.cxx.link_flags += ["-lstdc++fs", "-lm", "-pthread"]
@@ -1219,37 +1220,6 @@ class Configuration(object):
                     self.cxx.link_flags += ["-Wl,-rpath," + self.abi_library_root]
             else:
                 self.add_path(self.exec_env, self.abi_library_root)
-
-    def configure_link_flags_abi_library(self):
-        cxx_abi = self.get_lit_conf("cxx_abi", "libcxxabi")
-        if cxx_abi == "libstdc++":
-            self.cxx.link_flags += ["-lstdc++"]
-        elif cxx_abi == "libsupc++":
-            self.cxx.link_flags += ["-lsupc++"]
-        elif cxx_abi == "libcxxabi":
-            # If the C++ library requires explicitly linking to libc++abi, or
-            # if we're testing libc++abi itself (the test configs are shared),
-            # then link it.
-            testing_libcxxabi = self.get_lit_conf("name", "") == "libc++abi"
-            if self.target_info.allow_cxxabi_link() or testing_libcxxabi:
-                self.cxx.link_flags += ["-lc++abi"]
-        elif cxx_abi == "libcxxrt":
-            self.cxx.link_flags += ["-lcxxrt"]
-        elif cxx_abi == "vcruntime":
-            debug_suffix = "d"
-            self.cxx.link_flags += [
-                "-l%s%s" % (lib, debug_suffix)
-                for lib in ["vcruntime", "ucrt", "msvcrt"]
-            ]
-        elif cxx_abi == "none" or cxx_abi == "default":
-            if self.is_windows:
-                debug_suffix = "d"
-                self.cxx.link_flags += ["-lmsvcrt%s" % debug_suffix]
-        else:
-            self.lit_config.fatal("C++ ABI setting %s unsupported for tests" % cxx_abi)
-
-    def configure_extra_library_flags(self):
-        self.target_info.add_cxx_link_flags(self.cxx.link_flags)
 
     def configure_color_diagnostics(self):
         use_color = self.get_lit_conf("color_diagnostics")

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -724,9 +724,6 @@ class Configuration(object):
         if self.cxx.hasCompileFlag("-fdelayed-template-parsing"):
             self.config.available_features.add("fdelayed-template-parsing")
 
-        if self.get_lit_bool("has_libatomic", False):
-            self.config.available_features.add("libatomic")
-
         if self.get_lit_bool("enable_tile", False):
             self.config.available_features.add("enable-tile")
 

--- a/libcudacxx/test/utils/libcudacxx/test/target_info.py
+++ b/libcudacxx/test/utils/libcudacxx/test/target_info.py
@@ -219,20 +219,13 @@ class LinuxLocalTI(DefaultTargetInfo):
         enable_threads = (
             "libcpp-has-no-threads" not in self.full_config.config.available_features
         )
-        llvm_unwinder = self.full_config.get_lit_bool("llvm_unwinder", False)
         shared_libcxx = self.full_config.get_lit_bool("enable_shared", True)
-        flags += ["-lm"]
-        if not llvm_unwinder:
-            flags += ["-lgcc_s", "-lgcc"]
+        flags += ["-lm", "-lgcc_s", "-lgcc"]
         if enable_threads:
             flags += ["-lpthread"]
             if not shared_libcxx:
                 flags += ["-lrt"]
         flags += ["-lc"]
-        if llvm_unwinder:
-            flags += ["-lunwind", "-ldl"]
-        else:
-            flags += ["-lgcc_s"]
         builtins_lib = self.full_config.get_lit_conf("builtins_library")
         if builtins_lib:
             flags += [builtins_lib]

--- a/libcudacxx/test/utils/libcudacxx/test/target_info.py
+++ b/libcudacxx/test/utils/libcudacxx/test/target_info.py
@@ -160,9 +160,6 @@ class DarwinLocalTI(DefaultTargetInfo):
         # Configure the library path for libc++
         if self.full_config.cxx_runtime_root:
             library_paths += [self.full_config.cxx_runtime_root]
-        elif self.full_config.use_system_cxx_lib:
-            if os.path.isdir(str(self.full_config.use_system_cxx_lib)):
-                library_paths += [self.full_config.use_system_cxx_lib]
 
         # Configure the abi library path
         if self.full_config.abi_library_root:

--- a/libcudacxx/test/utils/libcudacxx/test/target_info.py
+++ b/libcudacxx/test/utils/libcudacxx/test/target_info.py
@@ -8,7 +8,6 @@
 
 import importlib
 import locale
-import os
 import platform
 import re
 import subprocess

--- a/libcudacxx/test/utils/libcudacxx/test/target_info.py
+++ b/libcudacxx/test/utils/libcudacxx/test/target_info.py
@@ -231,9 +231,6 @@ class LinuxLocalTI(DefaultTargetInfo):
             flags += [builtins_lib]
         else:
             flags += ["-lgcc"]
-        use_libatomic = self.full_config.get_lit_bool("use_libatomic", False)
-        if use_libatomic:
-            flags += ["-latomic"]
         san = self.full_config.get_lit_conf("use_sanitizer", "").strip()
         if san:
             # The libraries and their order are taken from the

--- a/libcudacxx/test/utils/libcudacxx/test/target_info.py
+++ b/libcudacxx/test/utils/libcudacxx/test/target_info.py
@@ -219,12 +219,9 @@ class LinuxLocalTI(DefaultTargetInfo):
         enable_threads = (
             "libcpp-has-no-threads" not in self.full_config.config.available_features
         )
-        shared_libcxx = self.full_config.get_lit_bool("enable_shared", True)
         flags += ["-lm", "-lgcc_s", "-lgcc"]
         if enable_threads:
-            flags += ["-lpthread"]
-            if not shared_libcxx:
-                flags += ["-lrt"]
+            flags += ["-lpthread", "-lrt"]
         flags += ["-lc"]
         builtins_lib = self.full_config.get_lit_conf("builtins_library")
         if builtins_lib:


### PR DESCRIPTION
We inherited the full libc++ config and lot of the options are not used at all

We have a long term goal to clean our lit handling up more and more and rely on cmake for most of the information.

This starts the process by removing a bunch of flags. I did not find a difference in the generated output