### PR TITLE
Do not sync in `caching_allocator_t::deallocate`

### DIFF
--- a/nvbench_helper/nvbench_helper/nvbench_helper.cuh
+++ b/nvbench_helper/nvbench_helper/nvbench_helper.cuh
@@ -573,7 +573,7 @@ struct caching_allocator_t
     return result;
   }
 
-  void deallocate(char* ptr, size_t, bool check_stream = true)
+  void deallocate(char* ptr, size_t, [[maybe_unused]] bool check_stream = true)
   {
 #if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
     if (check_stream && first_async_stream != ::cuda::invalid_stream)

--- a/nvbench_helper/nvbench_helper/nvbench_helper.cuh
+++ b/nvbench_helper/nvbench_helper/nvbench_helper.cuh
@@ -547,6 +547,15 @@ struct caching_allocator_t
 
   char* allocate(std::ptrdiff_t num_bytes)
   {
+#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+    if (first_async_stream != ::cuda::invalid_stream)
+    {
+      // there was already an async allocate
+      throw std::runtime_error("caching_allocator_t is not intended to be used asynchronously and synchronously at the "
+                               "same time");
+    }
+#endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+
     value_type* result{};
     auto free_block = free_blocks.find(num_bytes);
 
@@ -564,8 +573,17 @@ struct caching_allocator_t
     return result;
   }
 
-  void deallocate(char* ptr, size_t)
+  void deallocate(char* ptr, size_t, bool check_stream = true)
   {
+#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+    if (check_stream && first_async_stream != ::cuda::invalid_stream)
+    {
+      // there was already an async allocate
+      throw std::runtime_error("caching_allocator_t is not intended to be used asynchronously and synchronously at the "
+                               "same time");
+    }
+#endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+
     auto iter = allocated_blocks.find(ptr);
     if (iter == allocated_blocks.end())
     {
@@ -590,6 +608,15 @@ struct caching_allocator_t
 
   void* allocate(::cuda::stream_ref __stream, size_t num_bytes, size_t)
   {
+    if (first_async_stream == ::cuda::invalid_stream)
+    {
+      first_async_stream = __stream;
+    }
+    else if (first_async_stream != __stream)
+    {
+      throw std::runtime_error("caching_allocator_t is not intended to be used asynchronously from multiple streams");
+    }
+
     value_type* result{};
     auto free_block = free_blocks.find(num_bytes);
 
@@ -615,8 +642,14 @@ struct caching_allocator_t
 
   void deallocate(::cuda::stream_ref __stream, void* ptr, size_t num_bytes, size_t)
   {
-    __stream.sync();
-    deallocate(static_cast<char*>(ptr), num_bytes);
+    if (first_async_stream != __stream)
+    {
+      throw std::runtime_error("caching_allocator_t is not intended to be used asynchronously from multiple streams");
+    }
+
+    // there is no need to sync the stream here and we can just insert the allocation into the free list, because the
+    // next allocation can only be done from the same stream again.
+    deallocate(static_cast<char*>(ptr), num_bytes, false);
   }
 #endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
 
@@ -626,6 +659,10 @@ private:
 
   free_blocks_type free_blocks;
   allocated_blocks_type allocated_blocks;
+
+#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+  ::cuda::stream_ref first_async_stream{::cuda::invalid_stream}; // just to detect wrong usage patterns
+#endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
 
   void free_all()
   {


### PR DESCRIPTION
This leads to deadlocks in benchmarks.

Fixes: #8901