### PR TITLE
Fix nightly GCC8 build regressions in bit_cast and DeviceReduce

### DIFF
--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -21,11 +21,6 @@ workflows:
   #       args: '--preset libcudacxx --lit-tests "cuda/utility/basic_any.pass.cpp"' }
   #
   override:
-    # Targeted repro of nightly 25713127213 failures. Reset before merging.
-    # libcu++ bit_cast<__float128> regression: memcpy fallback fires on GCC 8/9/10 (no __builtin_bit_cast) with CTK 12.0/12.X.
-    - {jobs: ['build'], project: 'libcudacxx', std: 'all', ctk: ['12.0', '12.X'], cxx: ['gcc8', 'gcc9', 'gcc10']}
-    # CUB device_reduce -Wunused-but-set-parameter regression: GCC 8 only.
-    - {jobs: ['build'], project: 'cub',        std: 17,    ctk: ['12.0', '12.X'], cxx: ['gcc8']}
 
   pull_request:
     # Old CTK: Oldest/newest supported host compilers:

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -21,6 +21,11 @@ workflows:
   #       args: '--preset libcudacxx --lit-tests "cuda/utility/basic_any.pass.cpp"' }
   #
   override:
+    # Targeted repro of nightly 25713127213 failures. Reset before merging.
+    # libcu++ bit_cast<__float128> regression: memcpy fallback fires on GCC 8/9/10 (no __builtin_bit_cast) with CTK 12.0/12.X.
+    - {jobs: ['build'], project: 'libcudacxx', std: 'all', ctk: ['12.0', '12.X'], cxx: ['gcc8', 'gcc9', 'gcc10']}
+    # CUB device_reduce -Wunused-but-set-parameter regression: GCC 8 only.
+    - {jobs: ['build'], project: 'cub',        std: 17,    ctk: ['12.0', '12.X'], cxx: ['gcc8']}
 
   pull_request:
     # Old CTK: Oldest/newest supported host compilers:

--- a/ci/util/build_and_test_targets.sh
+++ b/ci/util/build_and_test_targets.sh
@@ -73,7 +73,7 @@ if [[ -n "${CONFIGURE_OVERRIDE}" ]]; then
   if [[ -n "${PRESET}" ]]; then
     echo "::warning:: --preset ignored due to --configure-override" >&2
   fi
-  if [[ "${#CMAKE_OPTIONS}" -gt 0 ]]; then
+  if [[ "${#CMAKE_OPTIONS[@]}" -gt 0 ]]; then
     echo "::warning:: --cmake-options ignored due to --configure-override" >&2
   fi
 fi
@@ -103,7 +103,7 @@ if [[ -z "${BUILD_DIR}" ]]; then
   exit 1
 fi
 
-if [[ "${#BUILD_TARGETS}" -gt 0 ]]; then
+if [[ "${#BUILD_TARGETS[@]}" -gt 0 ]]; then
   if ! (set -x; ninja -C "${BUILD_DIR}" "${BUILD_TARGETS[@]}"); then
     echo "::endgroup::"
     echo "🔴🛠️ Ninja build failed for targets ($(elapsed_time)): ${BUILD_TARGETS[*]@Q}"
@@ -111,7 +111,7 @@ if [[ "${#BUILD_TARGETS}" -gt 0 ]]; then
   fi
 fi
 
-if [[ "${#CTEST_TARGETS}" -gt 0 ]]; then
+if [[ "${#CTEST_TARGETS[@]}" -gt 0 ]]; then
   for t in "${CTEST_TARGETS[@]}"; do
     if ! (set -x; ctest --test-dir "${BUILD_DIR}" -R "$t" -V --output-on-failure); then
       echo "::endgroup::"
@@ -121,7 +121,7 @@ if [[ "${#CTEST_TARGETS}" -gt 0 ]]; then
   done
 fi
 
-if [[ "${#LIT_PRECOMPILE_TESTS}" -gt 0 || "${#LIT_TESTS}" -gt 0 ]]; then
+if [[ "${#LIT_PRECOMPILE_TESTS[@]}" -gt 0 || "${#LIT_TESTS[@]}" -gt 0 ]]; then
   lit_site_cfg="${BUILD_DIR}/libcudacxx/test/libcudacxx/lit.site.cfg"
   if [[ ! -f "${lit_site_cfg}" ]]; then
     echo "::endgroup::"
@@ -130,7 +130,7 @@ if [[ "${#LIT_PRECOMPILE_TESTS}" -gt 0 || "${#LIT_TESTS}" -gt 0 ]]; then
   fi
 fi
 
-if [[ "${#LIT_PRECOMPILE_TESTS}" -gt 0 ]]; then
+if [[ "${#LIT_PRECOMPILE_TESTS[@]}" -gt 0 ]]; then
   for t in "${LIT_PRECOMPILE_TESTS[@]}"; do
     t_path="libcudacxx/test/libcudacxx/${t}"
     if ! (set -x; LIBCUDACXX_SITE_CONFIG="${lit_site_cfg}" lit -v "-Dexecutor=NoopExecutor()" "${t_path}"); then
@@ -141,7 +141,7 @@ if [[ "${#LIT_PRECOMPILE_TESTS}" -gt 0 ]]; then
   done
 fi
 
-if [[ "${#LIT_TESTS}" -gt 0 ]]; then
+if [[ "${#LIT_TESTS[@]}" -gt 0 ]]; then
   for t in "${LIT_TESTS[@]}"; do
     t_path="libcudacxx/test/libcudacxx/${t}"
     if ! (set -x; LIBCUDACXX_SITE_CONFIG="${lit_site_cfg}" lit -v "${t_path}"); then

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -116,6 +116,8 @@ private:
 
       if constexpr (Determinism == ::cuda::execution::determinism::__determinism_t::__gpu_to_gpu)
       {
+        // Only instantiated with `plus<float|double>`; RFA hardcodes `deterministic_sum_t<accum_t>`.
+        (void) reduction_op;
         using default_policy_selector = detail::rfa::policy_selector_from_types<accum_t>;
         using policy_selector =
           ::cuda::std::execution::__query_result_or_t<tuning_env_t, detail::rfa::rfa_policy, default_policy_selector>;

--- a/libcudacxx/include/cuda/std/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy.h
@@ -86,13 +86,16 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
 _CCCL_API constexpr bool __constexpr_tail_overlap(_Tp* __first, _Up* __needle, [[maybe_unused]] _Tp* __last)
 {
-#if !_CCCL_TILE_COMPILATION() // pointer values cannot be compared
+  // Without the builtin, is_constant_evaluated() is hard-coded to false, so the runtime branch is
+  // selected even during constant evaluation -- where the pointer compare below is ill-formed. Fall
+  // through to the constexpr-safe path on compilers that lack the builtin (notably GCC 8).
+#if defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)
   if (!::cuda::std::is_constant_evaluated())
   {
     return __first < __needle;
   }
   else
-#endif // !_CCCL_TILE_COMPILATION()
+#endif // _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
   {
 #if defined(_CCCL_BUILTIN_CONSTANT_P)
     NV_IF_ELSE_TARGET(NV_IS_HOST,

--- a/libcudacxx/include/cuda/std/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy.h
@@ -86,16 +86,11 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
 _CCCL_API constexpr bool __constexpr_tail_overlap(_Tp* __first, _Up* __needle, [[maybe_unused]] _Tp* __last)
 {
-  // Without the builtin, is_constant_evaluated() is hard-coded to false, so the runtime branch is
-  // selected even during constant evaluation -- where the pointer compare below is ill-formed. Fall
-  // through to the constexpr-safe path on compilers that lack the builtin (notably GCC 8).
-#if defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)
-  if (!::cuda::std::is_constant_evaluated())
+  if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
     return __first < __needle;
   }
   else
-#endif // _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
   {
 #if defined(_CCCL_BUILTIN_CONSTANT_P)
     NV_IF_ELSE_TARGET(NV_IS_HOST,

--- a/libcudacxx/include/cuda/std/__bit/bit_cast.h
+++ b/libcudacxx/include/cuda/std/__bit/bit_cast.h
@@ -23,7 +23,7 @@
 
 #include <cuda/__type_traits/is_trivially_copyable.h>
 #include <cuda/std/__concepts/concept_macros.h>
-#include <cuda/std/__concepts/constructible.h>
+#include <cuda/std/__type_traits/is_default_constructible.h>
 #include <cuda/std/cstring>
 
 #include <cuda/std/__cccl/prologue.h>
@@ -51,10 +51,8 @@ _CCCL_DIAG_SUPPRESS_GCC("-Wclass-memaccess")
 template <class _To, class _From>
 [[nodiscard]] _CCCL_API inline _To __bit_cast_memcpy(const _From& __from) noexcept
 {
-#if !_CCCL_COMPILER(GCC, <=, 7)
-  static_assert(::cuda::std::default_initializable<_To>,
-                "bit_cast memcpy fallback requires the destination type to be default initializable");
-#endif // !_CCCL_COMPILER(GCC, <=, 7)
+  static_assert(::cuda::std::is_default_constructible_v<_To>,
+                "bit_cast memcpy fallback requires the destination type to be default constructible");
   _To __temp;
   ::cuda::std::memcpy(&__temp, &__from, sizeof(_To));
   return __temp;

--- a/libcudacxx/include/cuda/std/__bit/bit_cast.h
+++ b/libcudacxx/include/cuda/std/__bit/bit_cast.h
@@ -51,8 +51,10 @@ _CCCL_DIAG_SUPPRESS_GCC("-Wclass-memaccess")
 template <class _To, class _From>
 [[nodiscard]] _CCCL_API inline _To __bit_cast_memcpy(const _From& __from) noexcept
 {
-  static_assert(::cuda::std::is_default_constructible_v<_To>,
+#if !_CCCL_COMPILER(GCC, <=, 8)
+  static_assert(::cuda::std::default_initializable<_To>,
                 "bit_cast memcpy fallback requires the destination type to be default constructible");
+#endif // !_CCCL_COMPILER(GCC, <=, 8)
   _To __temp;
   ::cuda::std::memcpy(&__temp, &__from, sizeof(_To));
   return __temp;

--- a/libcudacxx/include/cuda/std/__bit/bit_cast.h
+++ b/libcudacxx/include/cuda/std/__bit/bit_cast.h
@@ -23,7 +23,7 @@
 
 #include <cuda/__type_traits/is_trivially_copyable.h>
 #include <cuda/std/__concepts/concept_macros.h>
-#include <cuda/std/__type_traits/is_default_constructible.h>
+#include <cuda/std/__concepts/constructible.h>
 #include <cuda/std/cstring>
 
 #include <cuda/std/__cccl/prologue.h>

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/ctor.pass.cpp
@@ -123,7 +123,7 @@ template <int Bytes, int N>
 TEST_FUNC constexpr void test_generator()
 {
   using Mask = simd::basic_mask<Bytes, simd::fixed_size<N>>;
-#if _CCCL_COMPILER(GCC, !=, 7)
+#if _CCCL_COMPILER(GCC, >=, 9)
   static_assert(!noexcept(Mask(is_even{})));
 #endif
 


### PR DESCRIPTION
## Summary

Two unrelated regressions surfaced together in the [2026-05-12 nightly run on `main`](https://github.com/NVIDIA/cccl/actions/runs/25713127213). Both block all GCC builds on older CTKs (12.0, 12.X) for libcu++, and all GCC 8 CUB builds.

### libcu++: `bit_cast<__float128>` static_assert fires

`__bit_cast_memcpy` is reached on GCC 8/9/10 because those host compilers don't provide `__builtin_bit_cast`. Commit 8b28e1d244 (#8265) replaced `is_trivially_default_constructible_v` with the C++20-style `default_initializable` concept; the concept emulation evaluates **false** for `__float128` in C++17 mode, even though the built-in scalar is default-initializable.

Restore an equivalent type trait (`is_default_constructible_v`), which queries the compiler builtin directly and works on every supported GCC. The `_CCCL_COMPILER(GCC, <=, 7)` gate is no longer needed and is removed.

### CUB: `DeviceReduce::reduce_impl` flags `reduction_op` as unused

Commit b60f063594 (#8851) merged the three determinism overloads into a single `if constexpr` template. The `__gpu_to_gpu` branch dispatches to RFA, which hardcodes `deterministic_sum_t<accum_t>` internally and does not accept a reduction operator. GCC 8's `-Werror=unused-but-set-parameter` flags `reduction_op` because that branch never references it.

The parameter must remain in the signature (the other two branches use it). The invariant — enforced upstream by `__transform_reduce`'s `float_double_plus` check — is acknowledged with `(void) reduction_op` plus a one-line note inside the branch.

### CI override

`ci/matrix.yaml` carries a temporary `workflows.override` reproducing the failures on PR CI:
- libcu++ build on GCC 8/9/10 × CTK 12.0/12.X × all stds
- CUB build on GCC 8 × CTK 12.0/12.X × C++17

**Reset to empty before merging.**

## Test plan

- [ ] Override-matrix PR CI passes on this branch
- [ ] Reset `workflows.override` to empty
- [ ] Full PR CI passes after override reset
