### PR TITLE
Fix `mdspan` `layout_stride` ABI failure in MSVC

### DIFF
--- a/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
@@ -50,6 +50,25 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 namespace __layout_stride_detail
 {
+template <class _Extents, class _StrideArray, bool = (_Extents::rank() == 0)>
+struct _CCCL_DECLSPEC_EMPTY_BASES __mapping_base : __mdspan_ebco<_Extents, _StrideArray>
+{
+  using __base = __mdspan_ebco<_Extents, _StrideArray>;
+  using __base::__base;
+};
+
+template <class _Extents, class _StrideArray>
+struct _CCCL_DECLSPEC_EMPTY_BASES __mapping_base<_Extents, _StrideArray, true> : __mdspan_ebco<_Extents>
+{
+  using __base = __mdspan_ebco<_Extents>;
+  using __base::__base;
+
+  _CCCL_API constexpr __mapping_base(const _Extents& __ext,
+                                     const _StrideArray&) noexcept(is_nothrow_constructible_v<__base, const _Extents&>)
+      : __base(__ext)
+  {}
+};
+
 template <class _StridedLayoutMapping, class _Extents>
 _CCCL_CONCEPT __can_convert = _CCCL_REQUIRES_EXPR((_StridedLayoutMapping, _Extents))(
   requires(__mdspan_detail::__layout_mapping_alike<_StridedLayoutMapping>),
@@ -70,8 +89,9 @@ struct __constraints
 
 template <class _Extents>
 class _CCCL_DECLSPEC_EMPTY_BASES layout_stride::mapping
-    : private __mdspan_ebco<_Extents,
-                            __mdspan_detail::__possibly_empty_array<typename _Extents::index_type, _Extents::rank()>>
+    : private __layout_stride_detail::__mapping_base<
+        _Extents,
+        __mdspan_detail::__possibly_empty_array<typename _Extents::index_type, _Extents::rank()>>
 {
 public:
   static_assert(__is_cuda_std_extents_v<_Extents>,
@@ -82,7 +102,9 @@ public:
   using size_type    = typename extents_type::size_type;
   using rank_type    = typename extents_type::rank_type;
   using layout_type  = layout_stride;
-  using __base = __mdspan_ebco<_Extents, __mdspan_detail::__possibly_empty_array<index_type, extents_type::rank()>>;
+  using __base =
+    __layout_stride_detail::__mapping_base<_Extents,
+                                           __mdspan_detail::__possibly_empty_array<index_type, extents_type::rank()>>;
 
   template <class, class, class, class>
   friend class mdspan;

--- a/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
@@ -344,7 +344,7 @@ public:
   _CCCL_REQUIRES(__layout_stride_detail::__can_convert<_StridedLayoutMapping, _Extents> _CCCL_AND
                    __layout_stride_detail::__constraints::__converts_implicit<_StridedLayoutMapping, _Extents>)
   _CCCL_API constexpr mapping(const _StridedLayoutMapping& __other) noexcept
-      : __base(__other.extents(), __to_strides_array(__other, __rank_sequence))
+      : __base(extents_type(__other.extents()), __to_strides_array(__other, __rank_sequence))
   {
     _CCCL_ASSERT(__check_mapped_strides(__other, __rank_sequence),
                  "layout_stride::mapping converting ctor: all strides must be greater than 0");
@@ -358,7 +358,7 @@ public:
   _CCCL_REQUIRES(__layout_stride_detail::__can_convert<_StridedLayoutMapping, _Extents> _CCCL_AND(
     !__layout_stride_detail::__constraints::__converts_implicit<_StridedLayoutMapping, _Extents>))
   _CCCL_API explicit constexpr mapping(const _StridedLayoutMapping& __other) noexcept
-      : __base(__other.extents(), __to_strides_array(__other, __rank_sequence))
+      : __base(extents_type(__other.extents()), __to_strides_array(__other, __rank_sequence))
   {
     _CCCL_ASSERT(__check_mapped_strides(__other, __rank_sequence),
                  "layout_stride::mapping converting ctor: all strides must be greater than 0");

--- a/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
@@ -442,7 +442,14 @@ public:
     // However, mdspan does check this on its own, so for now we avoid double checking in hardened mode
     //_CCCL_ASSERT(__mdspan_detail::__is_multidimensional_index_in(__extents_, __idx...),
     //             "layout_stride::mapping: out of bounds indexing");
-    return __op_index(__strides(), ::cuda::std::make_index_sequence<sizeof...(_Indices)>(), __idx...);
+    if constexpr (extents_type::rank() == 0)
+    {
+      return index_type{0};
+    }
+    else
+    {
+      return __op_index(__strides(), ::cuda::std::make_index_sequence<sizeof...(_Indices)>(), __idx...);
+    }
   }
 
   [[nodiscard]] _CCCL_API static constexpr bool is_always_unique() noexcept

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_left/no_unique_address.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_left/no_unique_address.pass.cpp
@@ -15,14 +15,12 @@
 #include "test_macros.h"
 
 template <class Mapping>
-TEST_FUNC void test(Mapping map, [[maybe_unused]] size_t expected_size)
+TEST_FUNC void test(Mapping map, size_t expected_size)
 {
   assert(map.extents().extent(0) == 42);
   assert(map.extents().extent(1) == 1337);
   assert(map.extents().extent(2) == 7);
-#if _CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS()
   assert(sizeof(Mapping) == expected_size);
-#endif // _CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS()
 }
 
 template <class Mapping>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_left/no_unique_address.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_left/no_unique_address.pass.cpp
@@ -15,12 +15,14 @@
 #include "test_macros.h"
 
 template <class Mapping>
-TEST_FUNC void test(Mapping map, size_t expected_size)
+TEST_FUNC void test(Mapping map, [[maybe_unused]] size_t expected_size)
 {
   assert(map.extents().extent(0) == 42);
   assert(map.extents().extent(1) == 1337);
   assert(map.extents().extent(2) == 7);
+#if _CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS()
   assert(sizeof(Mapping) == expected_size);
+#endif // _CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS()
 }
 
 template <class Mapping>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_right/no_unique_address.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_right/no_unique_address.pass.cpp
@@ -15,12 +15,14 @@
 #include "test_macros.h"
 
 template <class Mapping>
-TEST_FUNC void test(Mapping map, size_t expected_size)
+TEST_FUNC void test(Mapping map, [[maybe_unused]] size_t expected_size)
 {
   assert(map.extents().extent(0) == 42);
   assert(map.extents().extent(1) == 1337);
   assert(map.extents().extent(2) == 7);
+#if _CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS()
   assert(sizeof(Mapping) == expected_size);
+#endif // _CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS()
 }
 
 template <class Mapping>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride/no_unique_address.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride/no_unique_address.pass.cpp
@@ -18,7 +18,7 @@
 #include "test_macros.h"
 
 template <class Mapping>
-TEST_FUNC void test([[maybe_unused]] Mapping map, size_t expected_size)
+TEST_FUNC void test([[maybe_unused]] Mapping map, [[maybe_unused]] size_t expected_size)
 {
   using extents = typename Mapping::extents_type;
   if constexpr (extents::rank() > 0)
@@ -31,7 +31,9 @@ TEST_FUNC void test([[maybe_unused]] Mapping map, size_t expected_size)
     assert(map.strides()[1] == map.extents().extent(0) * map.strides()[0]);
     assert(map.strides()[2] == map.extents().extent(1) * map.strides()[1]);
   }
+#if _CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS()
   assert(sizeof(Mapping) == expected_size);
+#endif // _CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS()
 }
 
 template <class Mapping>


### PR DESCRIPTION
## Description

Fixes https://github.com/NVIDIA/cccl/issues/8953

The `sizeof()` failure is due to ABI mismatch between MSVC/NVCC for double inheritance of the same empty class.

Fix: add an extra level of indirection + specialization for rank=0