### PR TITLE
[Tile] Enable tests that relies on `__builtin_unreachable`

### DIFF
--- a/libcudacxx/include/cuda/std/__exception/terminate.h
+++ b/libcudacxx/include/cuda/std/__exception/terminate.h
@@ -43,8 +43,8 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_NOVERSION // purposefully not using versioning na
   NV_IF_ELSE_TARGET(NV_IS_HOST, (::exit(-1);), (assert(false);))
 #else // ^^^ _CCCL_TILE_COMPILATION() ^^^ / vvv !_CCCL_TILE_COMPILATION()
   NV_IF_ELSE_TARGET(NV_IS_HOST, (::exit(-1);), (::__trap();))
-  _CCCL_UNREACHABLE();
 #endif // !_CCCL_TILE_COMPILATION()
+  _CCCL_UNREACHABLE();
 }
 
 #if 0 // Expose once atomic is universally available

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/default_accessor/accessor.restrict.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/default_accessor/accessor.restrict.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 #include <cuda/mdspan>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/default_accessor/accessor.restrict.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/default_accessor/accessor.restrict.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 #include <cuda/mdspan>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_accessor/device_accessor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_accessor/device_accessor.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_accessor/device_accessor.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_accessor/device_accessor.runfail.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/index_operator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/index_operator.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // UNSUPPORTED: nvrtc

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride/no_unique_address.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride/no_unique_address.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // UNSUPPORTED: nvrtc
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_accessor/managed_accessor.1.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_accessor/managed_accessor.1.runfail.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_accessor/managed_accessor.2.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_accessor/managed_accessor.2.runfail.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_accessor/managed_accessor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_accessor/managed_accessor.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/mdspan_to_dlpack/mdspan_to_dlpack.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/mdspan_to_dlpack/mdspan_to_dlpack.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/mdspan_to_dlpack/mdspan_to_dlpack.wrapper.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/mdspan_to_dlpack/mdspan_to_dlpack.wrapper.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // UNSUPPORTED: nvrtc
 
 #include <cuda/mdspan>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_accessor/shared_mem_accessor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_accessor/shared_mem_accessor.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 #include <cuda/mdspan>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_accessor/shared_mem_accessor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_accessor/shared_mem_accessor.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: calling a __device__ function("__isShared(const void *)") is not allowed
+
 #include <cuda/mdspan>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/index_operator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/index_operator.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // UNSUPPORTED: nvrtc

--- a/libcudacxx/test/libcudacxx/cuda/utilities/variant/device_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/variant/device_only_types.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 #include <cuda/std/cassert>
 #include <cuda/std/variant>
 

--- a/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugated.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugated.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 #include <cuda/std/cassert>
 #include <cuda/std/complex>
 #include <cuda/std/linalg>

--- a/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugated.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugated.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 #include <cuda/std/cassert>
 #include <cuda/std/complex>
 #include <cuda/std/linalg>

--- a/libcudacxx/test/libcudacxx/std/linalg/accessors/scaled.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/accessors/scaled.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 #include <cuda/std/cassert>
 #include <cuda/std/linalg>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/std/linalg/accessors/scaled.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/accessors/scaled.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 #include <cuda/std/cassert>
 #include <cuda/std/linalg>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/std/linalg/layouts/transposed.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/layouts/transposed.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 #include <cuda/std/cassert>
 #include <cuda/std/cstddef>
 #include <cuda/std/linalg>

--- a/libcudacxx/test/libcudacxx/std/linalg/layouts/transposed.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/layouts/transposed.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: enable-tile
+// nvbug6076227: ICE when validating tile MLIR
+
 #include <cuda/std/cassert>
 #include <cuda/std/cstddef>
 #include <cuda/std/linalg>

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.unreachable/unreachable.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.unreachable/unreachable.runfail.cpp
@@ -8,9 +8,6 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: msvc
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 #include <cuda/std/utility>
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.relops/relops.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.relops/relops.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/std/variant>
 
 // template <class ...Types>

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.assign/copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.assign/copy.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.assign/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.assign/move.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.ctor/copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.ctor/copy.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.ctor/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.ctor/move.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.dtor/dtor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.dtor/dtor.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.mod/emplace_index_args.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.mod/emplace_index_args.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.mod/emplace_index_init_list_args.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.mod/emplace_index_init_list_args.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.mod/emplace_type_args.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.mod/emplace_type_args.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.mod/emplace_type_init_list_args.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.mod/emplace_type_init_list_args.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.status/index.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.status/index.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.status/valueless_by_exception.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.status/valueless_by_exception.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.swap/swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.swap/swap.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/std/variant>
 
 // template <class ...Types> class variant;

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_argument_forwarding.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_argument_forwarding.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/std/variant>
 // template <class Visitor, class... Variants>
 // constexpr see below visit(Visitor&& vis, Variants&&... vars);

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_call_operator_forwarding_multiple.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_call_operator_forwarding_multiple.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/std/variant>
 // template <class Visitor, class... Variants>
 // constexpr see below visit(Visitor&& vis, Variants&&... vars);

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_call_operator_forwarding_single.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_call_operator_forwarding_single.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/std/variant>
 // template <class Visitor, class... Variants>
 // constexpr see below visit(Visitor&& vis, Variants&&... vars);

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_caller_nonconst.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_caller_nonconst.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/std/variant>
 // template <class Visitor, class... Variants>
 // constexpr see below visit(Visitor&& vis, Variants&&... vars);

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_derived.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_derived.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/std/variant>
 // template <class Visitor, class... Variants>
 // constexpr see below visit(Visitor&& vis, Variants&&... vars);

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_exceptions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit/visit_exceptions.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/std/variant>
 // template <class Visitor, class... Variants>
 // constexpr see below visit(Visitor&& vis, Variants&&... vars);

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_argument_forwarding.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_argument_forwarding.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 // UNSUPPORTED: gcc-6

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_call_operator_forwarding_multiple.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_call_operator_forwarding_multiple.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 // UNSUPPORTED: gcc-6

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_call_operator_forwarding_single.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_call_operator_forwarding_single.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 // UNSUPPORTED: gcc-6

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_caller_nonconst.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_caller_nonconst.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
 


### PR DESCRIPTION
The compiler team has implemented the builtin in tile mode, so we can use it now
