### PR TITLE
[Tile] Reenable tests that were blocked on format accessing bitfields

### DIFF
--- a/libcudacxx/test/libcudacxx/libcxx/text/format/format.arguments/format.arg/arg_t.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/text/format/format.arguments/format.arg/arg_t.compile.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: bit field read/write is unsupported in tile code
-
 // <cuda/std/format>
 
 // cuda::std::__fmt_arg_t

--- a/libcudacxx/test/libcudacxx/libcxx/text/format/format.arguments/format.arg/determine_arg_t.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/text/format/format.arguments/format.arg/determine_arg_t.compile.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: bit field read/write is unsupported in tile code
-
 // <cuda/std/format>
 
 // cuda::std::__fmt_determine_arg_t

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg.store/make_wformat_args.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg.store/make_wformat_args.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: bit field read/write is unsupported in tile code
-
 // <cuda/std/format>
 
 // template<class... Args>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/ctad.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/ctad.compile.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: bit field read/write is unsupported in tile code
-
 // <cuda/std/format>
 
 // template<class Context, class... Args>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/types.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/types.compile.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: bit field read/write is unsupported in tile code
-
 // <cuda/std/format>
 
 // Namespace std typedefs:

--- a/libcudacxx/test/libcudacxx/std/text/format/format.error/format.error.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.error/format.error.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: bit field read/write is unsupported in tile code
-
 // UNSUPPORTED: nvrtc
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/advance_to.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/advance_to.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: bit field read/write is unsupported in tile code
-
 // <cuda/std/format>
 
 // constexpr void advance_to(const_iterator it);

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/begin.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/begin.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: bit field read/write is unsupported in tile code
-
 // <cuda/std/format>
 
 // constexpr begin() const noexcept;

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/check_arg_id.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/check_arg_id.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: bit field read/write is unsupported in tile code
-
 // <cuda/std/format>
 
 // constexpr void check_arg_id(size_t id);

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/ctor.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: bit field read/write is unsupported in tile code
-
 // <cuda/std/format>
 
 // constexpr explicit

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/end.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: bit field read/write is unsupported in tile code
-
 // <cuda/std/format>
 
 // constexpr end() const noexcept;

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/next_arg_id.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/next_arg_id.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: bit field read/write is unsupported in tile code
-
 // <cuda/std/format>
 
 // constexpr size_t next_arg_id();

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/types.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/types.compile.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: bit field read/write is unsupported in tile code
-
 // <cuda/std/format>
 
 // Class typedefs:


### PR DESCRIPTION
Tests that do not access the bitfields pass