### PR TITLE
[Tile] Reenable tests that were blocked on atomics

### DIFF
--- a/libcudacxx/test/libcudacxx/libcxx/atomics/atomics.order/memory_order.underlying_type.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/atomics/atomics.order/memory_order.underlying_type.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: asm statement is unsupported in tile code
-
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/libcxx/atomics/version.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/atomics/version.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: asm statement is unsupported in tile code
-
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.lockfree/lockfree.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.lockfree/lockfree.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: asm statement is unsupported in tile code
-
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.order/kill_dependency.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.order/kill_dependency.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: asm statement is unsupported in tile code
-
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.order/memory_order.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.order/memory_order.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: asm statement is unsupported in tile code
-
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/cstdint_typedefs.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/cstdint_typedefs.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: asm statement is unsupported in tile code
-
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral_typedefs.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral_typedefs.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: asm statement is unsupported in tile code
-
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/max.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/max.pass.cpp
@@ -6,10 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
-// error: asm statement is unsupported in tile code
-
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/version.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/version.pass.cpp
@@ -6,10 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
-// error: asm statement is unsupported in tile code
-
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.latch/max.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.latch/max.pass.cpp
@@ -6,10 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
-// error: asm statement is unsupported in tile code
-
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.latch/version.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.latch/version.pass.cpp
@@ -6,10 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
-// error: asm statement is unsupported in tile code
-
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/max.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/max.pass.cpp
@@ -6,10 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
-// error: asm statement is unsupported in tile code
-
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 

--- a/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/version.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/version.pass.cpp
@@ -6,10 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: accessing gridDim/blockDim/blockIdx/threadIdx/warpSize is unsupported in tile code
-// error: asm statement is unsupported in tile code
-
 // UNSUPPORTED: libcpp-has-no-threads
 // UNSUPPORTED: pre-sm-70
 


### PR DESCRIPTION
Those tests just check traits, so its fine to enable them