### PR TITLE
Also disable warpspeed scan below NVRTC 13.4

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -998,14 +998,14 @@ struct policy_selector
   || ((_CCCL_COMPILER(MSVC) && _CCCL_CUDA_COMPILER(NVCC, <, 13, 1))) || defined(CCCL_DISABLE_WARPSPEED_SCAN)
     return false;
 #else
-#  if _CCCL_CUDA_COMPILER(NVCC, <, 13, 4)
+#  if _CCCL_CUDACC_BELOW(13, 4)
     if (cc == ::cuda::compute_capability{12, 0})
     {
       // Unfortunately, there seems to be a codegen bug in nvcc when targeting GB20x GPUs (sm120), so let's disable
       // warpspeed scan until this is resolved. See: https://github.com/NVIDIA/cccl/issues/8528
       return false;
     }
-#  endif //_CCCL_CUDA_COMPILER(NVCC, <, 13, 4)
+#  endif // _CCCL_CUDACC_BELOW(13, 4)
 
     if (!input_contiguous || !output_contiguous || !input_trivially_copyable || !output_trivially_copyable
         || !output_default_constructible)


### PR DESCRIPTION
Follow-up to #8922 

Fixed CCCL.C failing on SM120 with:
```
test(19): error: static assertion failed with "Host generated and JIT compiled policy mismatch"
  static_assert(device_scan_policy()(detail::current_tuning_cc()) == scan_policy { .algorithm = scan_algorithm::lookback, .lookback = scan_lookback_policy { .threads_per_block = 416, .items_per_thread = 19, .load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE, .load_modifier = LOAD_CA, .store_algorithm = BLOCK_STORE_WARP_TRANSPOSE, .scan_algorithm = BLOCK_SCAN_WARP_SCANS, .delay_constructor = delay_constructor_policy { .kind = delay_constructor_kind::exponential_backon, .delay = 956, .l2_write_latency = 550 } }, .warpspeed = scan_warpspeed_policy { .num_reduce_and_scan_warps = 0, .look_ahead_items_per_thread = 0, .items_per_thread = 0 } }, "Host generated and JIT compiled policy mismatch");
  ^

```