### PR TITLE
Use also a SM120 GPU in light CI for CCCL.C

### DIFF
--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -135,6 +135,7 @@ workflows:
     - {project: 'stdpar', jobs: ['build'], std: 'max', ctk: 'nvhpc', cxx: 'nvhpc'}
     # Python + support
     - {project: 'cccl_c_parallel', jobs: ['test'], ctk: '13.X', cxx: ['gcc13', 'msvc2022'], gpu: 'rtx2080', sm: 'gpu'}
+    - {project: 'cccl_c_parallel', jobs: ['test'], ctk: '13.X', cxx: 'gcc13', gpu: 'rtxpro6000', sm: 'gpu'}
     - {project: 'cccl_c_stf',      jobs: ['test'], ctk: '13.X', cxx: 'gcc13',               gpu: 'rtx2080', sm: 'gpu'}
     - {project: 'python', jobs: ['test'], ctk: '13.X', py_version: '3.14', gpu: 'l4', cxx: ['gcc13', 'msvc2022']}
     # Packaging / install


### PR DESCRIPTION
#8922 broke the build because the CI did not catch a CUB change affecting CCCL.C. CCCL.C only runs the light PR CI when CUB changes, which only tests on SM75. This PR adds a second run with SM120.

Thanks to @alliepiper for the analysis!