### PR TITLE
Refactor extraction of tuning policy selectors

### DIFF
--- a/cub/cub/device/device_merge.cuh
+++ b/cub/cub/device/device_merge.cuh
@@ -212,10 +212,8 @@ struct DeviceMerge
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceMerge::MergeKeys");
 
-    using default_policy_selector =
-      detail::merge::policy_selector_from_types<KeyIteratorIn1, NullType*, KeyIteratorIn2, NullType*, int64_t>;
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+    return detail::dispatch_with_env(
+      env, [&](auto tuning_env, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return detail::merge::dispatch(
           d_temp_storage,
           temp_storage_bytes,
@@ -229,7 +227,7 @@ struct DeviceMerge
           static_cast<NullType*>(nullptr),
           compare_op,
           stream,
-          policy_selector);
+          tuning_env);
       });
   }
 
@@ -437,10 +435,9 @@ struct DeviceMerge
     EnvT env             = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceMerge::MergePairs");
-    using default_policy_selector = detail::merge::
-      policy_selector_from_types<KeyIteratorIn1, ValueIteratorIn1, KeyIteratorIn2, ValueIteratorIn2, int64_t>;
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+
+    return detail::dispatch_with_env(
+      env, [&](auto tuning_env, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return detail::merge::dispatch(
           d_temp_storage,
           temp_storage_bytes,
@@ -454,7 +451,7 @@ struct DeviceMerge
           values_out,
           compare_op,
           stream,
-          policy_selector);
+          tuning_env);
       });
   }
 };

--- a/cub/cub/device/device_merge.cuh
+++ b/cub/cub/device/device_merge.cuh
@@ -221,10 +221,8 @@ struct DeviceMerge
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceMerge::MergeKeys");
 
-    using default_policy_selector =
-      detail::merge::policy_selector_from_types<KeyIteratorIn1, NullType*, KeyIteratorIn2, NullType*, int64_t>;
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+    return detail::dispatch_with_env(
+      env, [&](auto tuning_env, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return detail::merge::dispatch(
           d_temp_storage,
           temp_storage_bytes,
@@ -238,7 +236,7 @@ struct DeviceMerge
           static_cast<NullType*>(nullptr),
           compare_op,
           stream,
-          policy_selector);
+          tuning_env);
       });
   }
 
@@ -446,10 +444,9 @@ struct DeviceMerge
     const EnvT& env      = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceMerge::MergePairs");
-    using default_policy_selector = detail::merge::
-      policy_selector_from_types<KeyIteratorIn1, ValueIteratorIn1, KeyIteratorIn2, ValueIteratorIn2, int64_t>;
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+
+    return detail::dispatch_with_env(
+      env, [&](auto tuning_env, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return detail::merge::dispatch(
           d_temp_storage,
           temp_storage_bytes,
@@ -463,7 +460,7 @@ struct DeviceMerge
           values_out,
           compare_op,
           stream,
-          policy_selector);
+          tuning_env);
       });
   }
 };

--- a/cub/cub/device/device_merge_sort.cuh
+++ b/cub/cub/device/device_merge_sort.cuh
@@ -138,8 +138,8 @@ private:
     TuningEnvT = {})
   {
     using default_policy_selector_t = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
-    using policy_selector_t         = ::cuda::std::execution::
-      __query_result_or_t<TuningEnvT, detail::merge_sort::merge_sort_policy, default_policy_selector_t>;
+    using policy_selector_t =
+      ::cuda::std::execution::__query_result_or_t<TuningEnvT, DeviceMergeSort, default_policy_selector_t>;
     return detail::merge_sort::dispatch(
       d_temp_storage,
       temp_storage_bytes,

--- a/cub/cub/device/device_merge_sort.cuh
+++ b/cub/cub/device/device_merge_sort.cuh
@@ -115,6 +115,44 @@ private:
     return "cub::DeviceMergeSort";
   }
 
+  // TODO(bgruber): I would ideally like to have the logic of extracting the policy selector from the tuning environment
+  // inside the dispatch function, but this will not work with CCCL.C, which needs to pass a stateful policy selector.
+  // Refactor this once we have a host code JIT compiler.
+  template <typename KeyInputIteratorT,
+            typename ValueInputIteratorT,
+            typename KeyIteratorT,
+            typename ValueIteratorT,
+            typename OffsetT,
+            typename CompareOpT,
+            typename TuningEnvT = ::cuda::std::execution::env<>>
+  CUB_RUNTIME_FUNCTION static auto select_tuning_and_dispatch(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    KeyInputIteratorT d_input_keys,
+    ValueInputIteratorT d_input_values,
+    KeyIteratorT d_output_keys,
+    ValueIteratorT d_output_values,
+    OffsetT num_items,
+    CompareOpT compare_op,
+    cudaStream_t stream,
+    TuningEnvT = {})
+  {
+    using default_policy_selector_t = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
+    using policy_selector_t         = ::cuda::std::execution::
+      __query_result_or_t<TuningEnvT, detail::merge_sort::merge_sort_policy, default_policy_selector_t>;
+    return detail::merge_sort::dispatch(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_input_keys,
+      d_input_values,
+      d_output_keys,
+      d_output_values,
+      num_items,
+      compare_op,
+      stream,
+      policy_selector_t{});
+  }
+
   // Internal version without NVTX range
   template <typename KeyIteratorT, typename ValueIteratorT, typename OffsetT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t SortPairsNoNVTX(
@@ -315,23 +353,20 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
-    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
-
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
-        return detail::merge_sort::dispatch(
-          storage,
-          bytes,
-          d_keys,
-          d_values,
-          d_keys,
-          d_values,
-          static_cast<ChooseOffsetT>(num_items),
-          compare_op,
-          stream,
-          policy_selector);
-      });
+    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
+      return select_tuning_and_dispatch(
+        storage,
+        bytes,
+        d_keys,
+        d_values,
+        d_keys,
+        d_values,
+        static_cast<ChooseOffsetT>(num_items),
+        compare_op,
+        stream,
+        tuning_env);
+    });
   }
 
   /**
@@ -567,23 +602,20 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
-    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
-
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
-        return detail::merge_sort::dispatch(
-          storage,
-          bytes,
-          d_input_keys,
-          d_input_values,
-          d_output_keys,
-          d_output_values,
-          static_cast<ChooseOffsetT>(num_items),
-          compare_op,
-          stream,
-          policy_selector);
-      });
+    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
+      return select_tuning_and_dispatch(
+        storage,
+        bytes,
+        d_input_keys,
+        d_input_values,
+        d_output_keys,
+        d_output_values,
+        static_cast<ChooseOffsetT>(num_items),
+        compare_op,
+        stream,
+        tuning_env);
+    });
   }
 
 private:
@@ -766,23 +798,20 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
-    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
-
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
-        return detail::merge_sort::dispatch(
-          storage,
-          bytes,
-          d_keys,
-          static_cast<NullType*>(nullptr),
-          d_keys,
-          static_cast<NullType*>(nullptr),
-          static_cast<ChooseOffsetT>(num_items),
-          compare_op,
-          stream,
-          policy_selector);
-      });
+    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
+      return select_tuning_and_dispatch(
+        storage,
+        bytes,
+        d_keys,
+        static_cast<NullType*>(nullptr),
+        d_keys,
+        static_cast<NullType*>(nullptr),
+        static_cast<ChooseOffsetT>(num_items),
+        compare_op,
+        stream,
+        tuning_env);
+    });
   }
 
 private:
@@ -994,23 +1023,20 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
-    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
-
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
-        return detail::merge_sort::dispatch(
-          storage,
-          bytes,
-          d_input_keys,
-          static_cast<NullType*>(nullptr),
-          d_output_keys,
-          static_cast<NullType*>(nullptr),
-          static_cast<ChooseOffsetT>(num_items),
-          compare_op,
-          stream,
-          policy_selector);
-      });
+    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
+      return select_tuning_and_dispatch(
+        storage,
+        bytes,
+        d_input_keys,
+        static_cast<NullType*>(nullptr),
+        d_output_keys,
+        static_cast<NullType*>(nullptr),
+        static_cast<ChooseOffsetT>(num_items),
+        compare_op,
+        stream,
+        tuning_env);
+    });
   }
 
   /**
@@ -1189,23 +1215,20 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
-    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
-
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
-        return detail::merge_sort::dispatch(
-          storage,
-          bytes,
-          d_keys,
-          d_values,
-          d_keys,
-          d_values,
-          static_cast<ChooseOffsetT>(num_items),
-          compare_op,
-          stream,
-          policy_selector);
-      });
+    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
+      return select_tuning_and_dispatch(
+        storage,
+        bytes,
+        d_keys,
+        d_values,
+        d_keys,
+        d_values,
+        static_cast<ChooseOffsetT>(num_items),
+        compare_op,
+        stream,
+        tuning_env);
+    });
   }
 
   /**
@@ -1365,23 +1388,20 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
-    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
-
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
-        return detail::merge_sort::dispatch(
-          storage,
-          bytes,
-          d_keys,
-          static_cast<NullType*>(nullptr),
-          d_keys,
-          static_cast<NullType*>(nullptr),
-          static_cast<ChooseOffsetT>(num_items),
-          compare_op,
-          stream,
-          policy_selector);
-      });
+    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
+      return select_tuning_and_dispatch(
+        storage,
+        bytes,
+        d_keys,
+        static_cast<NullType*>(nullptr),
+        d_keys,
+        static_cast<NullType*>(nullptr),
+        static_cast<ChooseOffsetT>(num_items),
+        compare_op,
+        stream,
+        tuning_env);
+    });
   }
 
   /**
@@ -1566,23 +1586,20 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
-    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
-
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
-        return detail::merge_sort::dispatch(
-          storage,
-          bytes,
-          d_input_keys,
-          static_cast<NullType*>(nullptr),
-          d_output_keys,
-          static_cast<NullType*>(nullptr),
-          static_cast<ChooseOffsetT>(num_items),
-          compare_op,
-          stream,
-          policy_selector);
-      });
+    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
+      return select_tuning_and_dispatch(
+        storage,
+        bytes,
+        d_input_keys,
+        static_cast<NullType*>(nullptr),
+        d_output_keys,
+        static_cast<NullType*>(nullptr),
+        static_cast<ChooseOffsetT>(num_items),
+        compare_op,
+        stream,
+        tuning_env);
+    });
   }
 };
 

--- a/cub/cub/device/device_merge_sort.cuh
+++ b/cub/cub/device/device_merge_sort.cuh
@@ -154,18 +154,17 @@ private:
   }
 
   // Internal version without NVTX range
-  template <typename KeyIteratorT, typename ValueIteratorT, typename OffsetT, typename CompareOpT>
+  template <typename KeyIteratorT, typename ValueIteratorT, typename NumItemsT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t SortPairsNoNVTX(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyIteratorT d_keys,
     ValueIteratorT d_values,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
-
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::merge_sort::dispatch(
       d_temp_storage,
       temp_storage_bytes,
@@ -173,7 +172,7 @@ private:
       d_values,
       d_keys,
       d_values,
-      static_cast<ChooseOffsetT>(num_items),
+      static_cast<offset_t>(num_items),
       compare_op,
       stream);
   }
@@ -234,8 +233,8 @@ public:
    * @tparam ValueIteratorT
    *   is a model of [Random Access Iterator], and `ValueIteratorT` is mutable.
    *
-   * @tparam OffsetT
-   *   is an integer type for global offsets.
+   * @tparam NumItemsT
+   *   **[inferred]** Integer type to express the number of items
    *
    * @tparam CompareOpT
    *   is a type of callable object with the signature
@@ -274,13 +273,13 @@ public:
    *    First appears in CUDA Toolkit 12.3.
    * @endrst
    */
-  template <typename KeyIteratorT, typename ValueIteratorT, typename OffsetT, typename CompareOpT>
+  template <typename KeyIteratorT, typename ValueIteratorT, typename NumItemsT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t SortPairs(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyIteratorT d_keys,
     ValueIteratorT d_values,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
@@ -318,8 +317,8 @@ public:
   //! @tparam ValueIteratorT
   //!   **[inferred]** Random-access iterator type for values @iterator
   //!
-  //! @tparam OffsetT
-  //!   **[inferred]** Integer type for offsets
+  //! @tparam NumItemsT
+  //!   **[inferred]** Integer type to express the number of items
   //!
   //! @tparam CompareOpT
   //!   **[inferred]** Comparison function object type
@@ -345,15 +344,14 @@ public:
   //!   @endrst
   template <typename KeyIteratorT,
             typename ValueIteratorT,
-            typename OffsetT,
+            typename NumItemsT,
             typename CompareOpT,
             typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
-  SortPairs(KeyIteratorT d_keys, ValueIteratorT d_values, OffsetT num_items, CompareOpT compare_op, EnvT env = {})
+  SortPairs(KeyIteratorT d_keys, ValueIteratorT d_values, NumItemsT num_items, CompareOpT compare_op, EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
-
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
       return select_tuning_and_dispatch(
         storage,
@@ -362,7 +360,7 @@ public:
         d_values,
         d_keys,
         d_values,
-        static_cast<ChooseOffsetT>(num_items),
+        static_cast<offset_t>(num_items),
         compare_op,
         stream,
         tuning_env);
@@ -437,8 +435,8 @@ public:
    * @tparam ValueIteratorT
    *   is a model of [Random Access Iterator], and `ValueIteratorT` is mutable.
    *
-   * @tparam OffsetT
-   *   is an integer type for global offsets.
+   * @tparam NumItemsT
+   *   **[inferred]** Integer type to express the number of items
    *
    * @tparam CompareOpT
    *   is a type of callable object with the signature
@@ -487,7 +485,7 @@ public:
             typename ValueInputIteratorT,
             typename KeyIteratorT,
             typename ValueIteratorT,
-            typename OffsetT,
+            typename NumItemsT,
             typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t SortPairsCopy(
     void* d_temp_storage,
@@ -496,13 +494,12 @@ public:
     ValueInputIteratorT d_input_values,
     KeyIteratorT d_output_keys,
     ValueIteratorT d_output_values,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, GetName());
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
-
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::merge_sort::dispatch(
       d_temp_storage,
       temp_storage_bytes,
@@ -510,7 +507,7 @@ public:
       d_input_values,
       d_output_keys,
       d_output_values,
-      static_cast<ChooseOffsetT>(num_items),
+      static_cast<offset_t>(num_items),
       compare_op,
       stream);
   }
@@ -553,8 +550,8 @@ public:
   //! @tparam ValueIteratorT
   //!   **[inferred]** Random-access iterator type for output values @iterator
   //!
-  //! @tparam OffsetT
-  //!   **[inferred]** Integer type for offsets
+  //! @tparam NumItemsT
+  //!   **[inferred]** Integer type to express the number of items
   //!
   //! @tparam CompareOpT
   //!   **[inferred]** Comparison function object type
@@ -588,7 +585,7 @@ public:
             typename ValueInputIteratorT,
             typename KeyIteratorT,
             typename ValueIteratorT,
-            typename OffsetT,
+            typename NumItemsT,
             typename CompareOpT,
             typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t SortPairsCopy(
@@ -596,13 +593,12 @@ public:
     ValueInputIteratorT d_input_values,
     KeyIteratorT d_output_keys,
     ValueIteratorT d_output_values,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
-
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
       return select_tuning_and_dispatch(
         storage,
@@ -611,7 +607,7 @@ public:
         d_input_values,
         d_output_keys,
         d_output_values,
-        static_cast<ChooseOffsetT>(num_items),
+        static_cast<offset_t>(num_items),
         compare_op,
         stream,
         tuning_env);
@@ -620,17 +616,16 @@ public:
 
 private:
   // Internal version without NVTX range
-  template <typename KeyIteratorT, typename OffsetT, typename CompareOpT>
+  template <typename KeyIteratorT, typename NumItemsT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t SortKeysNoNVTX(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyIteratorT d_keys,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
-
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::merge_sort::dispatch(
       d_temp_storage,
       temp_storage_bytes,
@@ -638,7 +633,7 @@ private:
       static_cast<NullType*>(nullptr),
       d_keys,
       static_cast<NullType*>(nullptr),
-      static_cast<ChooseOffsetT>(num_items),
+      static_cast<offset_t>(num_items),
       compare_op,
       stream);
   }
@@ -693,8 +688,8 @@ public:
    *   ordering relation is a *strict weak ordering* as defined in
    *   the [LessThan Comparable] requirements.
    *
-   * @tparam OffsetT
-   *   is an integer type for global offsets.
+   * @tparam NumItemsT
+   *   **[inferred]** Integer type to express the number of items
    *
    * @tparam CompareOpT
    *   is a type of callable object with the signature
@@ -730,12 +725,12 @@ public:
    *    First appears in CUDA Toolkit 12.3.
    * @endrst
    */
-  template <typename KeyIteratorT, typename OffsetT, typename CompareOpT>
+  template <typename KeyIteratorT, typename NumItemsT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t SortKeys(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyIteratorT d_keys,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
@@ -770,8 +765,8 @@ public:
   //! @tparam KeyIteratorT
   //!   **[inferred]** Random-access iterator type for keys @iterator
   //!
-  //! @tparam OffsetT
-  //!   **[inferred]** Integer type for offsets
+  //! @tparam NumItemsT
+  //!   **[inferred]** Integer type to express the number of items
   //!
   //! @tparam CompareOpT
   //!   **[inferred]** Comparison function object type
@@ -792,13 +787,12 @@ public:
   //!   @rst
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
-  template <typename KeyIteratorT, typename OffsetT, typename CompareOpT, typename EnvT = ::cuda::std::execution::env<>>
+  template <typename KeyIteratorT, typename NumItemsT, typename CompareOpT, typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
-  SortKeys(KeyIteratorT d_keys, OffsetT num_items, CompareOpT compare_op, EnvT env = {})
+  SortKeys(KeyIteratorT d_keys, NumItemsT num_items, CompareOpT compare_op, EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
-
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
       return select_tuning_and_dispatch(
         storage,
@@ -807,7 +801,7 @@ public:
         static_cast<NullType*>(nullptr),
         d_keys,
         static_cast<NullType*>(nullptr),
-        static_cast<ChooseOffsetT>(num_items),
+        static_cast<offset_t>(num_items),
         compare_op,
         stream,
         tuning_env);
@@ -816,18 +810,17 @@ public:
 
 private:
   // Internal version without NVTX range
-  template <typename KeyInputIteratorT, typename KeyIteratorT, typename OffsetT, typename CompareOpT>
+  template <typename KeyInputIteratorT, typename KeyIteratorT, typename NumItemsT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t SortKeysCopyNoNVTX(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyInputIteratorT d_input_keys,
     KeyIteratorT d_output_keys,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
-
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::merge_sort::dispatch(
       d_temp_storage,
       temp_storage_bytes,
@@ -835,7 +828,7 @@ private:
       static_cast<NullType*>(nullptr),
       d_output_keys,
       static_cast<NullType*>(nullptr),
-      static_cast<ChooseOffsetT>(num_items),
+      static_cast<offset_t>(num_items),
       compare_op,
       stream);
   }
@@ -901,8 +894,8 @@ public:
    *   ordering relation is a *strict weak ordering* as defined in
    *   the [LessThan Comparable] requirements.
    *
-   * @tparam OffsetT
-   *   is an integer type for global offsets.
+   * @tparam NumItemsT
+   *   **[inferred]** Integer type to express the number of items
    *
    * @tparam CompareOpT
    *   is a type of callable object with the signature
@@ -941,13 +934,13 @@ public:
    *    First appears in CUDA Toolkit 12.3.
    * @endrst
    */
-  template <typename KeyInputIteratorT, typename KeyIteratorT, typename OffsetT, typename CompareOpT>
+  template <typename KeyInputIteratorT, typename KeyIteratorT, typename NumItemsT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t SortKeysCopy(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyInputIteratorT d_input_keys,
     KeyIteratorT d_output_keys,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
@@ -988,8 +981,8 @@ public:
   //! @tparam KeyIteratorT
   //!   **[inferred]** Random-access iterator type for output keys @iterator
   //!
-  //! @tparam OffsetT
-  //!   **[inferred]** Integer type for offsets
+  //! @tparam NumItemsT
+  //!   **[inferred]** Integer type to express the number of items
   //!
   //! @tparam CompareOpT
   //!   **[inferred]** Comparison function object type
@@ -1015,15 +1008,18 @@ public:
   //!   @endrst
   template <typename KeyInputIteratorT,
             typename KeyIteratorT,
-            typename OffsetT,
+            typename NumItemsT,
             typename CompareOpT,
             typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t SortKeysCopy(
-    KeyInputIteratorT d_input_keys, KeyIteratorT d_output_keys, OffsetT num_items, CompareOpT compare_op, EnvT env = {})
+    KeyInputIteratorT d_input_keys,
+    KeyIteratorT d_output_keys,
+    NumItemsT num_items,
+    CompareOpT compare_op,
+    EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
-
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
       return select_tuning_and_dispatch(
         storage,
@@ -1032,7 +1028,7 @@ public:
         static_cast<NullType*>(nullptr),
         d_output_keys,
         static_cast<NullType*>(nullptr),
-        static_cast<ChooseOffsetT>(num_items),
+        static_cast<offset_t>(num_items),
         compare_op,
         stream,
         tuning_env);
@@ -1094,8 +1090,8 @@ public:
    * @tparam ValueIteratorT
    *   is a model of [Random Access Iterator], and `ValueIteratorT` is mutable.
    *
-   * @tparam OffsetT
-   *   is an integer type for global offsets.
+   * @tparam NumItemsT
+   *   **[inferred]** Integer type to express the number of items
    *
    * @tparam CompareOpT
    *   is a type of callable object with the signature
@@ -1134,19 +1130,18 @@ public:
    *    First appears in CUDA Toolkit 12.3.
    * @endrst
    */
-  template <typename KeyIteratorT, typename ValueIteratorT, typename OffsetT, typename CompareOpT>
+  template <typename KeyIteratorT, typename ValueIteratorT, typename NumItemsT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t StableSortPairs(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyIteratorT d_keys,
     ValueIteratorT d_values,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, GetName());
-
-    return SortPairsNoNVTX<KeyIteratorT, ValueIteratorT, OffsetT, CompareOpT>(
+    return SortPairsNoNVTX<KeyIteratorT, ValueIteratorT, NumItemsT, CompareOpT>(
       d_temp_storage, temp_storage_bytes, d_keys, d_values, num_items, compare_op, stream);
   }
 
@@ -1180,8 +1175,8 @@ public:
   //! @tparam ValueIteratorT
   //!   **[inferred]** Random-access iterator type for values @iterator
   //!
-  //! @tparam OffsetT
-  //!   **[inferred]** Integer type for offsets
+  //! @tparam NumItemsT
+  //!   **[inferred]** Integer type to express the number of items
   //!
   //! @tparam CompareOpT
   //!   **[inferred]** Comparison function object type
@@ -1207,15 +1202,14 @@ public:
   //!   @endrst
   template <typename KeyIteratorT,
             typename ValueIteratorT,
-            typename OffsetT,
+            typename NumItemsT,
             typename CompareOpT,
             typename EnvT = ::cuda::std::execution::env<>>
-  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
-  StableSortPairs(KeyIteratorT d_keys, ValueIteratorT d_values, OffsetT num_items, CompareOpT compare_op, EnvT env = {})
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t StableSortPairs(
+    KeyIteratorT d_keys, ValueIteratorT d_values, NumItemsT num_items, CompareOpT compare_op, EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
-
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
       return select_tuning_and_dispatch(
         storage,
@@ -1224,7 +1218,7 @@ public:
         d_values,
         d_keys,
         d_values,
-        static_cast<ChooseOffsetT>(num_items),
+        static_cast<offset_t>(num_items),
         compare_op,
         stream,
         tuning_env);
@@ -1281,8 +1275,8 @@ public:
    *   ordering relation is a *strict weak ordering* as defined in
    *   the [LessThan Comparable] requirements.
    *
-   * @tparam OffsetT
-   *   is an integer type for global offsets.
+   * @tparam NumItemsT
+   *   **[inferred]** Integer type to express the number of items
    *
    * @tparam CompareOpT
    *   is a type of callable object with the signature
@@ -1318,18 +1312,17 @@ public:
    *    First appears in CUDA Toolkit 12.3.
    * @endrst
    */
-  template <typename KeyIteratorT, typename OffsetT, typename CompareOpT>
+  template <typename KeyIteratorT, typename NumItemsT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t StableSortKeys(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyIteratorT d_keys,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, GetName());
-
-    return SortKeysNoNVTX<KeyIteratorT, OffsetT, CompareOpT>(
+    return SortKeysNoNVTX<KeyIteratorT, NumItemsT, CompareOpT>(
       d_temp_storage, temp_storage_bytes, d_keys, num_items, compare_op, stream);
   }
 
@@ -1360,8 +1353,8 @@ public:
   //! @tparam KeyIteratorT
   //!   **[inferred]** Random-access iterator type for keys @iterator
   //!
-  //! @tparam OffsetT
-  //!   **[inferred]** Integer type for offsets
+  //! @tparam NumItemsT
+  //!   **[inferred]** Integer type to express the number of items
   //!
   //! @tparam CompareOpT
   //!   **[inferred]** Comparison function object type
@@ -1382,13 +1375,12 @@ public:
   //!   @rst
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
-  template <typename KeyIteratorT, typename OffsetT, typename CompareOpT, typename EnvT = ::cuda::std::execution::env<>>
+  template <typename KeyIteratorT, typename NumItemsT, typename CompareOpT, typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
-  StableSortKeys(KeyIteratorT d_keys, OffsetT num_items, CompareOpT compare_op, EnvT env = {})
+  StableSortKeys(KeyIteratorT d_keys, NumItemsT num_items, CompareOpT compare_op, EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
-
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
       return select_tuning_and_dispatch(
         storage,
@@ -1397,7 +1389,7 @@ public:
         static_cast<NullType*>(nullptr),
         d_keys,
         static_cast<NullType*>(nullptr),
-        static_cast<ChooseOffsetT>(num_items),
+        static_cast<offset_t>(num_items),
         compare_op,
         stream,
         tuning_env);
@@ -1464,8 +1456,8 @@ public:
    *   ordering relation is a *strict weak ordering* as defined in
    *   the [LessThan Comparable] requirements.
    *
-   * @tparam OffsetT
-   *   is an integer type for global offsets.
+   * @tparam NumItemsT
+   *   **[inferred]** Integer type to express the number of items
    *
    * @tparam CompareOpT
    *   is a type of callable object with the signature
@@ -1504,18 +1496,18 @@ public:
    *    First appears in CUDA Toolkit 12.3.
    * @endrst
    */
-  template <typename KeyInputIteratorT, typename KeyIteratorT, typename OffsetT, typename CompareOpT>
+  template <typename KeyInputIteratorT, typename KeyIteratorT, typename NumItemsT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t StableSortKeysCopy(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyInputIteratorT d_input_keys,
     KeyIteratorT d_output_keys,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, GetName());
-    return SortKeysCopyNoNVTX<KeyInputIteratorT, KeyIteratorT, OffsetT, CompareOpT>(
+    return SortKeysCopyNoNVTX<KeyInputIteratorT, KeyIteratorT, NumItemsT, CompareOpT>(
       d_temp_storage, temp_storage_bytes, d_input_keys, d_output_keys, num_items, compare_op, stream);
   }
 
@@ -1551,8 +1543,8 @@ public:
   //! @tparam KeyIteratorT
   //!   **[inferred]** Random-access iterator type for output keys @iterator
   //!
-  //! @tparam OffsetT
-  //!   **[inferred]** Integer type for offsets
+  //! @tparam NumItemsT
+  //!   **[inferred]** Integer type to express the number of items
   //!
   //! @tparam CompareOpT
   //!   **[inferred]** Comparison function object type
@@ -1578,15 +1570,18 @@ public:
   //!   @endrst
   template <typename KeyInputIteratorT,
             typename KeyIteratorT,
-            typename OffsetT,
+            typename NumItemsT,
             typename CompareOpT,
             typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t StableSortKeysCopy(
-    KeyInputIteratorT d_input_keys, KeyIteratorT d_output_keys, OffsetT num_items, CompareOpT compare_op, EnvT env = {})
+    KeyInputIteratorT d_input_keys,
+    KeyIteratorT d_output_keys,
+    NumItemsT num_items,
+    CompareOpT compare_op,
+    EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
-
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
       return select_tuning_and_dispatch(
         storage,
@@ -1595,7 +1590,7 @@ public:
         static_cast<NullType*>(nullptr),
         d_output_keys,
         static_cast<NullType*>(nullptr),
-        static_cast<ChooseOffsetT>(num_items),
+        static_cast<offset_t>(num_items),
         compare_op,
         stream,
         tuning_env);

--- a/cub/cub/device/device_merge_sort.cuh
+++ b/cub/cub/device/device_merge_sort.cuh
@@ -1026,7 +1026,7 @@ public:
     KeyIteratorT d_output_keys,
     NumItemsT num_items,
     CompareOpT compare_op,
-   const EnvT& env = {})
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
     using offset_t = detail::choose_offset_t<NumItemsT>;
@@ -1588,7 +1588,7 @@ public:
     KeyIteratorT d_output_keys,
     NumItemsT num_items,
     CompareOpT compare_op,
-   const EnvT& env = {})
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
     using offset_t = detail::choose_offset_t<NumItemsT>;

--- a/cub/cub/device/device_merge_sort.cuh
+++ b/cub/cub/device/device_merge_sort.cuh
@@ -148,8 +148,8 @@ private:
     TuningEnvT = {})
   {
     using default_policy_selector_t = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
-    using policy_selector_t         = ::cuda::std::execution::
-      __query_result_or_t<TuningEnvT, detail::merge_sort::merge_sort_policy, default_policy_selector_t>;
+    using policy_selector_t =
+      ::cuda::std::execution::__query_result_or_t<TuningEnvT, DeviceMergeSort, default_policy_selector_t>;
     return detail::merge_sort::dispatch(
       d_temp_storage,
       temp_storage_bytes,

--- a/cub/cub/device/device_merge_sort.cuh
+++ b/cub/cub/device/device_merge_sort.cuh
@@ -125,6 +125,44 @@ private:
     return "cub::DeviceMergeSort";
   }
 
+  // TODO(bgruber): I would ideally like to have the logic of extracting the policy selector from the tuning environment
+  // inside the dispatch function, but this will not work with CCCL.C, which needs to pass a stateful policy selector.
+  // Refactor this once we have a host code JIT compiler.
+  template <typename KeyInputIteratorT,
+            typename ValueInputIteratorT,
+            typename KeyIteratorT,
+            typename ValueIteratorT,
+            typename OffsetT,
+            typename CompareOpT,
+            typename TuningEnvT = ::cuda::std::execution::env<>>
+  CUB_RUNTIME_FUNCTION static auto select_tuning_and_dispatch(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    KeyInputIteratorT d_input_keys,
+    ValueInputIteratorT d_input_values,
+    KeyIteratorT d_output_keys,
+    ValueIteratorT d_output_values,
+    OffsetT num_items,
+    CompareOpT compare_op,
+    cudaStream_t stream,
+    TuningEnvT = {})
+  {
+    using default_policy_selector_t = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
+    using policy_selector_t         = ::cuda::std::execution::
+      __query_result_or_t<TuningEnvT, detail::merge_sort::merge_sort_policy, default_policy_selector_t>;
+    return detail::merge_sort::dispatch(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_input_keys,
+      d_input_values,
+      d_output_keys,
+      d_output_values,
+      num_items,
+      compare_op,
+      stream,
+      policy_selector_t{});
+  }
+
   // Internal version without NVTX range
   template <typename KeyIteratorT, typename ValueIteratorT, typename OffsetT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t SortPairsNoNVTX(
@@ -325,23 +363,20 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
-    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
-
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
-        return detail::merge_sort::dispatch(
-          storage,
-          bytes,
-          d_keys,
-          d_values,
-          d_keys,
-          d_values,
-          static_cast<ChooseOffsetT>(num_items),
-          compare_op,
-          stream,
-          policy_selector);
-      });
+    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
+      return select_tuning_and_dispatch(
+        storage,
+        bytes,
+        d_keys,
+        d_values,
+        d_keys,
+        d_values,
+        static_cast<ChooseOffsetT>(num_items),
+        compare_op,
+        stream,
+        tuning_env);
+    });
   }
 
   /**
@@ -577,23 +612,20 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
-    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
-
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
-        return detail::merge_sort::dispatch(
-          storage,
-          bytes,
-          d_input_keys,
-          d_input_values,
-          d_output_keys,
-          d_output_values,
-          static_cast<ChooseOffsetT>(num_items),
-          compare_op,
-          stream,
-          policy_selector);
-      });
+    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
+      return select_tuning_and_dispatch(
+        storage,
+        bytes,
+        d_input_keys,
+        d_input_values,
+        d_output_keys,
+        d_output_values,
+        static_cast<ChooseOffsetT>(num_items),
+        compare_op,
+        stream,
+        tuning_env);
+    });
   }
 
 private:
@@ -776,23 +808,20 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
-    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
-
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
-        return detail::merge_sort::dispatch(
-          storage,
-          bytes,
-          d_keys,
-          static_cast<NullType*>(nullptr),
-          d_keys,
-          static_cast<NullType*>(nullptr),
-          static_cast<ChooseOffsetT>(num_items),
-          compare_op,
-          stream,
-          policy_selector);
-      });
+    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
+      return select_tuning_and_dispatch(
+        storage,
+        bytes,
+        d_keys,
+        static_cast<NullType*>(nullptr),
+        d_keys,
+        static_cast<NullType*>(nullptr),
+        static_cast<ChooseOffsetT>(num_items),
+        compare_op,
+        stream,
+        tuning_env);
+    });
   }
 
 private:
@@ -1008,23 +1037,20 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
-    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
-
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
-        return detail::merge_sort::dispatch(
-          storage,
-          bytes,
-          d_input_keys,
-          static_cast<NullType*>(nullptr),
-          d_output_keys,
-          static_cast<NullType*>(nullptr),
-          static_cast<ChooseOffsetT>(num_items),
-          compare_op,
-          stream,
-          policy_selector);
-      });
+    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
+      return select_tuning_and_dispatch(
+        storage,
+        bytes,
+        d_input_keys,
+        static_cast<NullType*>(nullptr),
+        d_output_keys,
+        static_cast<NullType*>(nullptr),
+        static_cast<ChooseOffsetT>(num_items),
+        compare_op,
+        stream,
+        tuning_env);
+    });
   }
 
   /**
@@ -1203,23 +1229,20 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
-    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
-
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
-        return detail::merge_sort::dispatch(
-          storage,
-          bytes,
-          d_keys,
-          d_values,
-          d_keys,
-          d_values,
-          static_cast<ChooseOffsetT>(num_items),
-          compare_op,
-          stream,
-          policy_selector);
-      });
+    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
+      return select_tuning_and_dispatch(
+        storage,
+        bytes,
+        d_keys,
+        d_values,
+        d_keys,
+        d_values,
+        static_cast<ChooseOffsetT>(num_items),
+        compare_op,
+        stream,
+        tuning_env);
+    });
   }
 
   /**
@@ -1379,23 +1402,20 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
-    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
-
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
-        return detail::merge_sort::dispatch(
-          storage,
-          bytes,
-          d_keys,
-          static_cast<NullType*>(nullptr),
-          d_keys,
-          static_cast<NullType*>(nullptr),
-          static_cast<ChooseOffsetT>(num_items),
-          compare_op,
-          stream,
-          policy_selector);
-      });
+    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
+      return select_tuning_and_dispatch(
+        storage,
+        bytes,
+        d_keys,
+        static_cast<NullType*>(nullptr),
+        d_keys,
+        static_cast<NullType*>(nullptr),
+        static_cast<ChooseOffsetT>(num_items),
+        compare_op,
+        stream,
+        tuning_env);
+    });
   }
 
   /**
@@ -1584,23 +1604,20 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
-    using ChooseOffsetT           = detail::choose_offset_t<OffsetT>;
-    using default_policy_selector = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
-
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
-        return detail::merge_sort::dispatch(
-          storage,
-          bytes,
-          d_input_keys,
-          static_cast<NullType*>(nullptr),
-          d_output_keys,
-          static_cast<NullType*>(nullptr),
-          static_cast<ChooseOffsetT>(num_items),
-          compare_op,
-          stream,
-          policy_selector);
-      });
+    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
+      return select_tuning_and_dispatch(
+        storage,
+        bytes,
+        d_input_keys,
+        static_cast<NullType*>(nullptr),
+        d_output_keys,
+        static_cast<NullType*>(nullptr),
+        static_cast<ChooseOffsetT>(num_items),
+        compare_op,
+        stream,
+        tuning_env);
+    });
   }
 };
 

--- a/cub/cub/device/device_merge_sort.cuh
+++ b/cub/cub/device/device_merge_sort.cuh
@@ -164,18 +164,17 @@ private:
   }
 
   // Internal version without NVTX range
-  template <typename KeyIteratorT, typename ValueIteratorT, typename OffsetT, typename CompareOpT>
+  template <typename KeyIteratorT, typename ValueIteratorT, typename NumItemsT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t SortPairsNoNVTX(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyIteratorT d_keys,
     ValueIteratorT d_values,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
-
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::merge_sort::dispatch(
       d_temp_storage,
       temp_storage_bytes,
@@ -183,7 +182,7 @@ private:
       d_values,
       d_keys,
       d_values,
-      static_cast<ChooseOffsetT>(num_items),
+      static_cast<offset_t>(num_items),
       compare_op,
       stream);
   }
@@ -244,8 +243,8 @@ public:
    * @tparam ValueIteratorT
    *   is a model of [Random Access Iterator], and `ValueIteratorT` is mutable.
    *
-   * @tparam OffsetT
-   *   is an integer type for global offsets.
+   * @tparam NumItemsT
+   *   **[inferred]** Integer type to express the number of items
    *
    * @tparam CompareOpT
    *   is a type of callable object with the signature
@@ -284,13 +283,13 @@ public:
    *    First appears in CUDA Toolkit 12.3.
    * @endrst
    */
-  template <typename KeyIteratorT, typename ValueIteratorT, typename OffsetT, typename CompareOpT>
+  template <typename KeyIteratorT, typename ValueIteratorT, typename NumItemsT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t SortPairs(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyIteratorT d_keys,
     ValueIteratorT d_values,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
@@ -328,8 +327,8 @@ public:
   //! @tparam ValueIteratorT
   //!   **[inferred]** Random-access iterator type for values @iterator
   //!
-  //! @tparam OffsetT
-  //!   **[inferred]** Integer type for offsets
+  //! @tparam NumItemsT
+  //!   **[inferred]** Integer type to express the number of items
   //!
   //! @tparam CompareOpT
   //!   **[inferred]** Comparison function object type
@@ -355,15 +354,14 @@ public:
   //!   @endrst
   template <typename KeyIteratorT,
             typename ValueIteratorT,
-            typename OffsetT,
+            typename NumItemsT,
             typename CompareOpT,
             typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t SortPairs(
-    KeyIteratorT d_keys, ValueIteratorT d_values, OffsetT num_items, CompareOpT compare_op, const EnvT& env = {})
+    KeyIteratorT d_keys, ValueIteratorT d_values, NumItemsT num_items, CompareOpT compare_op, const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
-
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
       return select_tuning_and_dispatch(
         storage,
@@ -372,7 +370,7 @@ public:
         d_values,
         d_keys,
         d_values,
-        static_cast<ChooseOffsetT>(num_items),
+        static_cast<offset_t>(num_items),
         compare_op,
         stream,
         tuning_env);
@@ -447,8 +445,8 @@ public:
    * @tparam ValueIteratorT
    *   is a model of [Random Access Iterator], and `ValueIteratorT` is mutable.
    *
-   * @tparam OffsetT
-   *   is an integer type for global offsets.
+   * @tparam NumItemsT
+   *   **[inferred]** Integer type to express the number of items
    *
    * @tparam CompareOpT
    *   is a type of callable object with the signature
@@ -497,7 +495,7 @@ public:
             typename ValueInputIteratorT,
             typename KeyIteratorT,
             typename ValueIteratorT,
-            typename OffsetT,
+            typename NumItemsT,
             typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t SortPairsCopy(
     void* d_temp_storage,
@@ -506,13 +504,12 @@ public:
     ValueInputIteratorT d_input_values,
     KeyIteratorT d_output_keys,
     ValueIteratorT d_output_values,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, GetName());
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
-
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::merge_sort::dispatch(
       d_temp_storage,
       temp_storage_bytes,
@@ -520,7 +517,7 @@ public:
       d_input_values,
       d_output_keys,
       d_output_values,
-      static_cast<ChooseOffsetT>(num_items),
+      static_cast<offset_t>(num_items),
       compare_op,
       stream);
   }
@@ -563,8 +560,8 @@ public:
   //! @tparam ValueIteratorT
   //!   **[inferred]** Random-access iterator type for output values @iterator
   //!
-  //! @tparam OffsetT
-  //!   **[inferred]** Integer type for offsets
+  //! @tparam NumItemsT
+  //!   **[inferred]** Integer type to express the number of items
   //!
   //! @tparam CompareOpT
   //!   **[inferred]** Comparison function object type
@@ -598,7 +595,7 @@ public:
             typename ValueInputIteratorT,
             typename KeyIteratorT,
             typename ValueIteratorT,
-            typename OffsetT,
+            typename NumItemsT,
             typename CompareOpT,
             typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t SortPairsCopy(
@@ -606,13 +603,12 @@ public:
     ValueInputIteratorT d_input_values,
     KeyIteratorT d_output_keys,
     ValueIteratorT d_output_values,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
-
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
       return select_tuning_and_dispatch(
         storage,
@@ -621,7 +617,7 @@ public:
         d_input_values,
         d_output_keys,
         d_output_values,
-        static_cast<ChooseOffsetT>(num_items),
+        static_cast<offset_t>(num_items),
         compare_op,
         stream,
         tuning_env);
@@ -630,17 +626,16 @@ public:
 
 private:
   // Internal version without NVTX range
-  template <typename KeyIteratorT, typename OffsetT, typename CompareOpT>
+  template <typename KeyIteratorT, typename NumItemsT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t SortKeysNoNVTX(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyIteratorT d_keys,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
-
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::merge_sort::dispatch(
       d_temp_storage,
       temp_storage_bytes,
@@ -648,7 +643,7 @@ private:
       static_cast<NullType*>(nullptr),
       d_keys,
       static_cast<NullType*>(nullptr),
-      static_cast<ChooseOffsetT>(num_items),
+      static_cast<offset_t>(num_items),
       compare_op,
       stream);
   }
@@ -703,8 +698,8 @@ public:
    *   ordering relation is a *strict weak ordering* as defined in
    *   the [LessThan Comparable] requirements.
    *
-   * @tparam OffsetT
-   *   is an integer type for global offsets.
+   * @tparam NumItemsT
+   *   **[inferred]** Integer type to express the number of items
    *
    * @tparam CompareOpT
    *   is a type of callable object with the signature
@@ -740,12 +735,12 @@ public:
    *    First appears in CUDA Toolkit 12.3.
    * @endrst
    */
-  template <typename KeyIteratorT, typename OffsetT, typename CompareOpT>
+  template <typename KeyIteratorT, typename NumItemsT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t SortKeys(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyIteratorT d_keys,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
@@ -780,8 +775,8 @@ public:
   //! @tparam KeyIteratorT
   //!   **[inferred]** Random-access iterator type for keys @iterator
   //!
-  //! @tparam OffsetT
-  //!   **[inferred]** Integer type for offsets
+  //! @tparam NumItemsT
+  //!   **[inferred]** Integer type to express the number of items
   //!
   //! @tparam CompareOpT
   //!   **[inferred]** Comparison function object type
@@ -802,13 +797,12 @@ public:
   //!   @rst
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
-  template <typename KeyIteratorT, typename OffsetT, typename CompareOpT, typename EnvT = ::cuda::std::execution::env<>>
+  template <typename KeyIteratorT, typename NumItemsT, typename CompareOpT, typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
-  SortKeys(KeyIteratorT d_keys, OffsetT num_items, CompareOpT compare_op, const EnvT& env = {})
+  SortKeys(KeyIteratorT d_keys, NumItemsT num_items, CompareOpT compare_op, const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
-
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
       return select_tuning_and_dispatch(
         storage,
@@ -817,7 +811,7 @@ public:
         static_cast<NullType*>(nullptr),
         d_keys,
         static_cast<NullType*>(nullptr),
-        static_cast<ChooseOffsetT>(num_items),
+        static_cast<offset_t>(num_items),
         compare_op,
         stream,
         tuning_env);
@@ -826,18 +820,17 @@ public:
 
 private:
   // Internal version without NVTX range
-  template <typename KeyInputIteratorT, typename KeyIteratorT, typename OffsetT, typename CompareOpT>
+  template <typename KeyInputIteratorT, typename KeyIteratorT, typename NumItemsT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t SortKeysCopyNoNVTX(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyInputIteratorT d_input_keys,
     KeyIteratorT d_output_keys,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
-
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::merge_sort::dispatch(
       d_temp_storage,
       temp_storage_bytes,
@@ -845,7 +838,7 @@ private:
       static_cast<NullType*>(nullptr),
       d_output_keys,
       static_cast<NullType*>(nullptr),
-      static_cast<ChooseOffsetT>(num_items),
+      static_cast<offset_t>(num_items),
       compare_op,
       stream);
   }
@@ -911,8 +904,8 @@ public:
    *   ordering relation is a *strict weak ordering* as defined in
    *   the [LessThan Comparable] requirements.
    *
-   * @tparam OffsetT
-   *   is an integer type for global offsets.
+   * @tparam NumItemsT
+   *   **[inferred]** Integer type to express the number of items
    *
    * @tparam CompareOpT
    *   is a type of callable object with the signature
@@ -951,13 +944,13 @@ public:
    *    First appears in CUDA Toolkit 12.3.
    * @endrst
    */
-  template <typename KeyInputIteratorT, typename KeyIteratorT, typename OffsetT, typename CompareOpT>
+  template <typename KeyInputIteratorT, typename KeyIteratorT, typename NumItemsT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t SortKeysCopy(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyInputIteratorT d_input_keys,
     KeyIteratorT d_output_keys,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
@@ -998,8 +991,8 @@ public:
   //! @tparam KeyIteratorT
   //!   **[inferred]** Random-access iterator type for output keys @iterator
   //!
-  //! @tparam OffsetT
-  //!   **[inferred]** Integer type for offsets
+  //! @tparam NumItemsT
+  //!   **[inferred]** Integer type to express the number of items
   //!
   //! @tparam CompareOpT
   //!   **[inferred]** Comparison function object type
@@ -1025,19 +1018,18 @@ public:
   //!   @endrst
   template <typename KeyInputIteratorT,
             typename KeyIteratorT,
-            typename OffsetT,
+            typename NumItemsT,
             typename CompareOpT,
             typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t SortKeysCopy(
     KeyInputIteratorT d_input_keys,
     KeyIteratorT d_output_keys,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
-    const EnvT& env = {})
+   const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
-
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
       return select_tuning_and_dispatch(
         storage,
@@ -1046,7 +1038,7 @@ public:
         static_cast<NullType*>(nullptr),
         d_output_keys,
         static_cast<NullType*>(nullptr),
-        static_cast<ChooseOffsetT>(num_items),
+        static_cast<offset_t>(num_items),
         compare_op,
         stream,
         tuning_env);
@@ -1108,8 +1100,8 @@ public:
    * @tparam ValueIteratorT
    *   is a model of [Random Access Iterator], and `ValueIteratorT` is mutable.
    *
-   * @tparam OffsetT
-   *   is an integer type for global offsets.
+   * @tparam NumItemsT
+   *   **[inferred]** Integer type to express the number of items
    *
    * @tparam CompareOpT
    *   is a type of callable object with the signature
@@ -1148,19 +1140,18 @@ public:
    *    First appears in CUDA Toolkit 12.3.
    * @endrst
    */
-  template <typename KeyIteratorT, typename ValueIteratorT, typename OffsetT, typename CompareOpT>
+  template <typename KeyIteratorT, typename ValueIteratorT, typename NumItemsT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t StableSortPairs(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyIteratorT d_keys,
     ValueIteratorT d_values,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, GetName());
-
-    return SortPairsNoNVTX<KeyIteratorT, ValueIteratorT, OffsetT, CompareOpT>(
+    return SortPairsNoNVTX<KeyIteratorT, ValueIteratorT, NumItemsT, CompareOpT>(
       d_temp_storage, temp_storage_bytes, d_keys, d_values, num_items, compare_op, stream);
   }
 
@@ -1194,8 +1185,8 @@ public:
   //! @tparam ValueIteratorT
   //!   **[inferred]** Random-access iterator type for values @iterator
   //!
-  //! @tparam OffsetT
-  //!   **[inferred]** Integer type for offsets
+  //! @tparam NumItemsT
+  //!   **[inferred]** Integer type to express the number of items
   //!
   //! @tparam CompareOpT
   //!   **[inferred]** Comparison function object type
@@ -1221,15 +1212,14 @@ public:
   //!   @endrst
   template <typename KeyIteratorT,
             typename ValueIteratorT,
-            typename OffsetT,
+            typename NumItemsT,
             typename CompareOpT,
             typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t StableSortPairs(
-    KeyIteratorT d_keys, ValueIteratorT d_values, OffsetT num_items, CompareOpT compare_op, const EnvT& env = {})
+    KeyIteratorT d_keys, ValueIteratorT d_values, NumItemsT num_items, CompareOpT compare_op, const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
-
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
       return select_tuning_and_dispatch(
         storage,
@@ -1238,7 +1228,7 @@ public:
         d_values,
         d_keys,
         d_values,
-        static_cast<ChooseOffsetT>(num_items),
+        static_cast<offset_t>(num_items),
         compare_op,
         stream,
         tuning_env);
@@ -1295,8 +1285,8 @@ public:
    *   ordering relation is a *strict weak ordering* as defined in
    *   the [LessThan Comparable] requirements.
    *
-   * @tparam OffsetT
-   *   is an integer type for global offsets.
+   * @tparam NumItemsT
+   *   **[inferred]** Integer type to express the number of items
    *
    * @tparam CompareOpT
    *   is a type of callable object with the signature
@@ -1332,18 +1322,17 @@ public:
    *    First appears in CUDA Toolkit 12.3.
    * @endrst
    */
-  template <typename KeyIteratorT, typename OffsetT, typename CompareOpT>
+  template <typename KeyIteratorT, typename NumItemsT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t StableSortKeys(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyIteratorT d_keys,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, GetName());
-
-    return SortKeysNoNVTX<KeyIteratorT, OffsetT, CompareOpT>(
+    return SortKeysNoNVTX<KeyIteratorT, NumItemsT, CompareOpT>(
       d_temp_storage, temp_storage_bytes, d_keys, num_items, compare_op, stream);
   }
 
@@ -1374,8 +1363,8 @@ public:
   //! @tparam KeyIteratorT
   //!   **[inferred]** Random-access iterator type for keys @iterator
   //!
-  //! @tparam OffsetT
-  //!   **[inferred]** Integer type for offsets
+  //! @tparam NumItemsT
+  //!   **[inferred]** Integer type to express the number of items
   //!
   //! @tparam CompareOpT
   //!   **[inferred]** Comparison function object type
@@ -1396,13 +1385,12 @@ public:
   //!   @rst
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
-  template <typename KeyIteratorT, typename OffsetT, typename CompareOpT, typename EnvT = ::cuda::std::execution::env<>>
+  template <typename KeyIteratorT, typename NumItemsT, typename CompareOpT, typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
-  StableSortKeys(KeyIteratorT d_keys, OffsetT num_items, CompareOpT compare_op, const EnvT& env = {})
+  StableSortKeys(KeyIteratorT d_keys, NumItemsT num_items, CompareOpT compare_op, const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
-
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
       return select_tuning_and_dispatch(
         storage,
@@ -1411,7 +1399,7 @@ public:
         static_cast<NullType*>(nullptr),
         d_keys,
         static_cast<NullType*>(nullptr),
-        static_cast<ChooseOffsetT>(num_items),
+        static_cast<offset_t>(num_items),
         compare_op,
         stream,
         tuning_env);
@@ -1478,8 +1466,8 @@ public:
    *   ordering relation is a *strict weak ordering* as defined in
    *   the [LessThan Comparable] requirements.
    *
-   * @tparam OffsetT
-   *   is an integer type for global offsets.
+   * @tparam NumItemsT
+   *   **[inferred]** Integer type to express the number of items
    *
    * @tparam CompareOpT
    *   is a type of callable object with the signature
@@ -1518,18 +1506,18 @@ public:
    *    First appears in CUDA Toolkit 12.3.
    * @endrst
    */
-  template <typename KeyInputIteratorT, typename KeyIteratorT, typename OffsetT, typename CompareOpT>
+  template <typename KeyInputIteratorT, typename KeyIteratorT, typename NumItemsT, typename CompareOpT>
   CUB_RUNTIME_FUNCTION static cudaError_t StableSortKeysCopy(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyInputIteratorT d_input_keys,
     KeyIteratorT d_output_keys,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
     cudaStream_t stream = nullptr)
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, GetName());
-    return SortKeysCopyNoNVTX<KeyInputIteratorT, KeyIteratorT, OffsetT, CompareOpT>(
+    return SortKeysCopyNoNVTX<KeyInputIteratorT, KeyIteratorT, NumItemsT, CompareOpT>(
       d_temp_storage, temp_storage_bytes, d_input_keys, d_output_keys, num_items, compare_op, stream);
   }
 
@@ -1565,8 +1553,8 @@ public:
   //! @tparam KeyIteratorT
   //!   **[inferred]** Random-access iterator type for output keys @iterator
   //!
-  //! @tparam OffsetT
-  //!   **[inferred]** Integer type for offsets
+  //! @tparam NumItemsT
+  //!   **[inferred]** Integer type to express the number of items
   //!
   //! @tparam CompareOpT
   //!   **[inferred]** Comparison function object type
@@ -1592,19 +1580,18 @@ public:
   //!   @endrst
   template <typename KeyInputIteratorT,
             typename KeyIteratorT,
-            typename OffsetT,
+            typename NumItemsT,
             typename CompareOpT,
             typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t StableSortKeysCopy(
     KeyInputIteratorT d_input_keys,
     KeyIteratorT d_output_keys,
-    OffsetT num_items,
+    NumItemsT num_items,
     CompareOpT compare_op,
-    const EnvT& env = {})
+   const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
-
-    using ChooseOffsetT = detail::choose_offset_t<OffsetT>;
+    using offset_t = detail::choose_offset_t<NumItemsT>;
     return detail::dispatch_with_env(env, [&](auto tuning_env, void* storage, size_t& bytes, auto stream) {
       return select_tuning_and_dispatch(
         storage,
@@ -1613,7 +1600,7 @@ public:
         static_cast<NullType*>(nullptr),
         d_output_keys,
         static_cast<NullType*>(nullptr),
-        static_cast<ChooseOffsetT>(num_items),
+        static_cast<offset_t>(num_items),
         compare_op,
         stream,
         tuning_env);

--- a/cub/cub/device/device_merge_sort.cuh
+++ b/cub/cub/device/device_merge_sort.cuh
@@ -149,7 +149,7 @@ private:
   {
     using default_policy_selector_t = detail::merge_sort::policy_selector_from_types<KeyIteratorT>;
     using policy_selector_t =
-      ::cuda::std::execution::__query_result_or_t<TuningEnvT, DeviceMergeSort, default_policy_selector_t>;
+      ::cuda::std::execution::__query_result_or_t<TuningEnvT, MergeSortPolicy, default_policy_selector_t>;
     return detail::merge_sort::dispatch(
       d_temp_storage,
       temp_storage_bytes,

--- a/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
+++ b/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
@@ -332,18 +332,12 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   NumItemsT num_items,
   DifferenceOpT difference_op,
   cudaStream_t stream,
-  TuningEnvT tuning_env                  = {},
+  TuningEnvT                             = {},
   KernelLauncherFactory launcher_factory = {})
 {
-  using input_t  = detail::it_value_t<InputIteratorT>;
-  using offset_t = detail::choose_offset_t<NumItemsT>;
-  using default_policy_selector_t =
-    detail::adjacent_difference::policy_selector_from_types<InputIteratorT, AliasOpt == MayAlias::Yes>;
-  using default_policy_t = decltype(default_policy_selector_t{}(::cuda::compute_capability{}));
-
-  auto policy_selector =
-    ::cuda::std::execution::__query_or(tuning_env, default_policy_t{}, default_policy_selector_t{});
-  using policy_selector_t = decltype(policy_selector);
+  using default_policy_selector_t = policy_selector_from_types<InputIteratorT, AliasOpt == MayAlias::Yes>;
+  using policy_selector_t =
+    ::cuda::std::execution::__query_result_or_t<TuningEnvT, AdjacentDifferencePolicy, default_policy_selector_t>;
 #if _CCCL_HAS_CONCEPTS()
   static_assert(adjacent_difference_policy_selector<policy_selector_t>,
                 "Invalid policy_selector_t for adjacent_difference::dispatch");
@@ -355,7 +349,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
     return error;
   }
 
-  const AdjacentDifferencePolicy active_policy = policy_selector(cc);
+  const AdjacentDifferencePolicy active_policy = policy_selector_t{}(cc);
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(NV_IS_HOST, ({
                  ::std::stringstream ss;

--- a/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
+++ b/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
@@ -33,6 +33,7 @@
 #include <cuda/std/__execution/env.h>
 #include <cuda/std/__functional/invoke.h>
 #include <cuda/std/__host_stdlib/sstream>
+#include <cuda/std/__type_traits/decay.h>
 #include <cuda/std/__type_traits/is_empty.h>
 
 CUB_NAMESPACE_BEGIN
@@ -351,8 +352,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   using input_t  = detail::it_value_t<InputIteratorT>;
 
   using default_policy_selector_t = policy_selector_from_types<InputIteratorT, AliasOpt == MayAlias::Yes>;
-  using policy_selector_t =
-    ::cuda::std::execution::__query_result_or_t<TuningEnvT, AdjacentDifferencePolicy, default_policy_selector_t>;
+  using policy_selector_t         = ::cuda::std::decay_t<
+    ::cuda::std::execution::__query_result_or_t<TuningEnvT, AdjacentDifferencePolicy, default_policy_selector_t>>;
 #if _CCCL_HAS_CONCEPTS()
   static_assert(adjacent_difference_policy_selector<policy_selector_t>,
                 "Invalid policy_selector_t for adjacent_difference::dispatch");

--- a/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
+++ b/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
@@ -344,18 +344,12 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   NumItemsT num_items,
   DifferenceOpT difference_op,
   cudaStream_t stream,
-  TuningEnvT tuning_env                  = {},
+  TuningEnvT                             = {},
   KernelLauncherFactory launcher_factory = {})
 {
-  using input_t  = detail::it_value_t<InputIteratorT>;
-  using offset_t = detail::choose_offset_t<NumItemsT>;
-  using default_policy_selector_t =
-    detail::adjacent_difference::policy_selector_from_types<InputIteratorT, AliasOpt == MayAlias::Yes>;
-  using default_policy_t = decltype(default_policy_selector_t{}(::cuda::compute_capability{}));
-
-  auto policy_selector =
-    ::cuda::std::execution::__query_or(tuning_env, default_policy_t{}, default_policy_selector_t{});
-  using policy_selector_t = decltype(policy_selector);
+  using default_policy_selector_t = policy_selector_from_types<InputIteratorT, AliasOpt == MayAlias::Yes>;
+  using policy_selector_t =
+    ::cuda::std::execution::__query_result_or_t<TuningEnvT, AdjacentDifferencePolicy, default_policy_selector_t>;
 #if _CCCL_HAS_CONCEPTS()
   static_assert(adjacent_difference_policy_selector<policy_selector_t>,
                 "Invalid policy_selector_t for adjacent_difference::dispatch");
@@ -367,7 +361,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
     return error;
   }
 
-  const AdjacentDifferencePolicy active_policy = policy_selector(cc);
+  const AdjacentDifferencePolicy active_policy = policy_selector_t{}(cc);
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(NV_IS_HOST, ({
                  ::std::stringstream ss;

--- a/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
+++ b/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
@@ -347,6 +347,9 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   TuningEnvT                             = {},
   KernelLauncherFactory launcher_factory = {})
 {
+  using offset_t = detail::choose_offset_t<NumItemsT>;
+  using input_t  = detail::it_value_t<InputIteratorT>;
+
   using default_policy_selector_t = policy_selector_from_types<InputIteratorT, AliasOpt == MayAlias::Yes>;
   using policy_selector_t =
     ::cuda::std::execution::__query_result_or_t<TuningEnvT, AdjacentDifferencePolicy, default_policy_selector_t>;

--- a/cub/cub/device/dispatch/dispatch_merge.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge.cuh
@@ -24,6 +24,7 @@
 #include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
 
 #include <cuda/std/__algorithm/min.h>
+#include <cuda/std/__execution/env.h>
 #include <cuda/std/__host_stdlib/sstream>
 
 CUB_NAMESPACE_BEGIN
@@ -192,11 +193,8 @@ template <typename KeyIt1,
           typename ValueIt3,
           typename Offset,
           typename CompareOp,
-          typename PolicySelector        = policy_selector_from_types<KeyIt1, ValueIt1, KeyIt2, ValueIt2, Offset>,
+          typename TuningEnvT            = ::cuda::std::execution::env<>,
           typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
-#if _CCCL_HAS_CONCEPTS()
-  requires merge_policy_selector<PolicySelector>
-#endif // _CCCL_HAS_CONCEPTS()
 CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
@@ -210,16 +208,23 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   ValueIt3 d_values_out,
   CompareOp compare_op,
   cudaStream_t stream,
-  PolicySelector policy_selector         = {},
+  TuningEnvT                             = {},
   KernelLauncherFactory launcher_factory = {})
 {
+  using default_policy_selector_t = policy_selector_from_types<KeyIt1, ValueIt1, KeyIt2, ValueIt2, Offset>;
+  using policy_selector_t =
+    ::cuda::std::execution::__query_result_or_t<TuningEnvT, MergePolicy, default_policy_selector_t>;
+#if _CCCL_HAS_CONCEPTS()
+  static_assert(merge_policy_selector<policy_selector_t>);
+#endif // _CCCL_HAS_CONCEPTS()
+
   ::cuda::compute_capability cc{};
   if (const auto error = CubDebug(launcher_factory.PtxComputeCap(cc)))
   {
     return error;
   }
 
-  return dispatch_compute_cap(policy_selector, cc, [&](auto policy_getter) {
+  return dispatch_compute_cap(policy_selector_t{}, cc, [&](auto policy_getter) {
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
     NV_IF_TARGET(NV_IS_HOST, ({
                    std::stringstream ss;
@@ -273,7 +278,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
             THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
               partition_grid_size, threads_per_partition_block, 0, stream)
               .doit(device_partition_merge_path_kernel<
-                      PolicySelector,
+                      policy_selector_t,
                       KeyIt1,
                       ValueIt1,
                       KeyIt2,
@@ -304,7 +309,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
             THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
               static_cast<int>(num_tiles), static_cast<int>(AgentT::threads_per_block), 0, stream)
               .doit(
-                device_merge_kernel<PolicySelector, KeyIt1, ValueIt1, KeyIt2, ValueIt2, KeyIt3, ValueIt3, Offset, CompareOp>,
+                device_merge_kernel<policy_selector_t, KeyIt1, ValueIt1, KeyIt2, ValueIt2, KeyIt3, ValueIt3, Offset, CompareOp>,
                 d_keys1,
                 d_values1,
                 num_items1,

--- a/cub/cub/device/dispatch/dispatch_merge.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge.cuh
@@ -27,6 +27,7 @@
 #include <cuda/std/__algorithm/min.h>
 #include <cuda/std/__execution/env.h>
 #include <cuda/std/__host_stdlib/sstream>
+#include <cuda/std/__type_traits/decay.h>
 
 CUB_NAMESPACE_BEGIN
 namespace detail::merge
@@ -218,7 +219,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
 {
   using default_policy_selector_t = policy_selector_from_types<KeyIt1, ValueIt1, KeyIt2, ValueIt2, Offset>;
   using policy_selector_t =
-    ::cuda::std::execution::__query_result_or_t<TuningEnvT, MergePolicy, default_policy_selector_t>;
+    ::cuda::std::decay_t<::cuda::std::execution::__query_result_or_t<TuningEnvT, MergePolicy, default_policy_selector_t>>;
 #if _CCCL_HAS_CONCEPTS()
   static_assert(merge_policy_selector<policy_selector_t>);
 #endif // _CCCL_HAS_CONCEPTS()

--- a/cub/cub/device/dispatch/dispatch_merge.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge.cuh
@@ -25,6 +25,7 @@
 #include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
 
 #include <cuda/std/__algorithm/min.h>
+#include <cuda/std/__execution/env.h>
 #include <cuda/std/__host_stdlib/sstream>
 
 CUB_NAMESPACE_BEGIN
@@ -197,11 +198,8 @@ template <typename KeyIt1,
           typename ValueIt3,
           typename Offset,
           typename CompareOp,
-          typename PolicySelector        = policy_selector_from_types<KeyIt1, ValueIt1, KeyIt2, ValueIt2, Offset>,
+          typename TuningEnvT            = ::cuda::std::execution::env<>,
           typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
-#if _CCCL_HAS_CONCEPTS()
-  requires merge_policy_selector<PolicySelector>
-#endif // _CCCL_HAS_CONCEPTS()
 CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
@@ -215,16 +213,23 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   ValueIt3 d_values_out,
   CompareOp compare_op,
   cudaStream_t stream,
-  PolicySelector policy_selector         = {},
+  TuningEnvT                             = {},
   KernelLauncherFactory launcher_factory = {})
 {
+  using default_policy_selector_t = policy_selector_from_types<KeyIt1, ValueIt1, KeyIt2, ValueIt2, Offset>;
+  using policy_selector_t =
+    ::cuda::std::execution::__query_result_or_t<TuningEnvT, MergePolicy, default_policy_selector_t>;
+#if _CCCL_HAS_CONCEPTS()
+  static_assert(merge_policy_selector<policy_selector_t>);
+#endif // _CCCL_HAS_CONCEPTS()
+
   ::cuda::compute_capability cc{};
   if (const auto error = CubDebug(launcher_factory.PtxComputeCap(cc)))
   {
     return error;
   }
 
-  return dispatch_compute_cap(policy_selector, cc, [&](auto policy_getter) {
+  return dispatch_compute_cap(policy_selector_t{}, cc, [&](auto policy_getter) {
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
     NV_IF_TARGET(NV_IS_HOST, ({
                    std::stringstream ss;
@@ -280,7 +285,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
             THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
               partition_grid_size, threads_per_partition_block, 0, stream)
               .doit(device_partition_merge_path_kernel<
-                      PolicySelector,
+                      policy_selector_t,
                       KeyIt1,
                       ValueIt1,
                       KeyIt2,
@@ -311,7 +316,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
             THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
               static_cast<int>(num_tiles), static_cast<int>(AgentT::threads_per_block), 0, stream)
               .doit(
-                device_merge_kernel<PolicySelector, KeyIt1, ValueIt1, KeyIt2, ValueIt2, KeyIt3, ValueIt3, Offset, CompareOp>,
+                device_merge_kernel<policy_selector_t, KeyIt1, ValueIt1, KeyIt2, ValueIt2, KeyIt3, ValueIt3, Offset, CompareOp>,
                 d_keys1,
                 d_values1,
                 num_items1,


### PR DESCRIPTION
I realized that `dispatch_with_env_and_tuning` is not a good default mechanism for handling the policy selector extraction and defaulting, since it will lead to a lot of redundancy for setting up the default policy selector.

In this PR I am providing two alternatives:

1. for CUB APIs not exposed by CCCL.C we can pass the tuning environment to the dispatch function and handle the extraction there. This would not work with CCCL.C, which relies on stateful policy selectors.
2. for CUB API exposed by CCCL.C we provide a single wrapper function of the dispatch function in the device layer.