### PR TITLE
ci: declare permissions on the four project-automation workflows

### DIFF
--- a/.github/workflows/project_automation_set_in_review.yml
+++ b/.github/workflows/project_automation_set_in_review.yml
@@ -33,6 +33,9 @@ env:
  STATUS_FIELD_ID: "PVTSSF_lADOABpemM4AEhOIzgCmnYc"
  IN_REVIEW_PROJECT_OPTION_ID: "c6b49c6b"
 
+# Workflow token unused: every step authenticates via tibdex/github-app-token.
+permissions: {}
+
 jobs:
   query_and_mutate_project_fields:
     if: github.repository == 'NVIDIA/cccl'

--- a/.github/workflows/project_automation_set_roadmap.yml
+++ b/.github/workflows/project_automation_set_roadmap.yml
@@ -35,6 +35,9 @@ env:
  PROJECT_ID: "PVT_kwDOABpemM4AEhOI"
  ROADMAP_FIELD_ID: "PVTSSF_lADOABpemM4AEhOIzgC_MXI"
 
+# Workflow token unused: every step authenticates via tibdex/github-app-token.
+permissions: {}
+
 jobs:
   set_roadmap_value:
     if: github.repository == 'NVIDIA/cccl'

--- a/.github/workflows/project_automation_sync_pr_issues.yml
+++ b/.github/workflows/project_automation_sync_pr_issues.yml
@@ -33,6 +33,9 @@ env:
  WORKING_SPRINT_FIELD_ID: "PVTIF_lADOABpemM4AEhOIzgJlRho"
  START_SPRINT_FIELD_ID: "PVTIF_lADOABpemM4AEhOIzgJlRhU"
 
+# Workflow token unused: every step authenticates via tibdex/github-app-token.
+permissions: {}
+
 jobs:
   query_and_mutate_project_fields:
     if: github.repository == 'NVIDIA/cccl'

--- a/.github/workflows/triage_rotation.yml
+++ b/.github/workflows/triage_rotation.yml
@@ -27,6 +27,8 @@ jobs:
   assign_issues:
     runs-on: ubuntu-latest
     if: ${{ ! contains(fromJSON('["OWNER", "MEMBER", "CONTRIBUTOR", "COLLABORATOR"]'), github.event.issue.author_association)}}
+    permissions:
+      issues: write # assign user, add label, post comment via gh CLI
     steps:
       - name: Calculate assignee
         id: calculate_assignee


### PR DESCRIPTION
The four project-automation workflows currently leave the workflow `GITHUB_TOKEN` scope implicit even though they trigger on `pull_request_target` and `issues` (the elevated-context paths).

This patch pins each to its minimum:

- `.github/workflows/project_automation_set_in_review.yml` -- `permissions: {}` (workflow scope). Every step authenticates via `tibdex/github-app-token@v1.8.0` with `CCCL_AUTH_APP_ID` + `CCCL_AUTH_APP_PEM`, so the workflow's own `GITHUB_TOKEN` has nothing to do.
- `.github/workflows/project_automation_set_roadmap.yml` -- same shape, `permissions: {}`.
- `.github/workflows/project_automation_sync_pr_issues.yml` -- same shape, `permissions: {}`.
- `.github/workflows/triage_rotation.yml` -- `permissions: issues: write` per job. This one *does* use `github.token` (via `GH_TOKEN: ${{ github.token }}`) for `gh issue edit --add-label`, `gh issue comment`, and a GraphQL `addAssigneesToAssignable` mutation. `issues: write` is the minimum that covers all three.

Why this matters: `pull_request_target` and `issues` triggers run with the default-branch token grant, not the read-only fork-PR grant. Without an explicit `permissions:` block, the token gets whatever the repo default is, which can change. Pinning the scope keeps the contract documented in-file and aligns these four with `backport-prs.yml`, `bench.yml`, `blackduck-sca.yml`, and the rest of the hardened set.

Third-party action exposure that motivates the explicit scope: `tibdex/github-app-token@v1.8.0` runs inside the workflow context. An explicit `permissions: {}` keeps any hypothetical compromise (cf. `tj-actions/changed-files` CVE-2025-30066) contained to the app token's installation scope rather than letting it also reach the workflow token.

No behavioural change to any of the four.