### PR TITLE
Final env-passthrough 2/4

### DIFF
--- a/cub/cub/device/device_adjacent_difference.cuh
+++ b/cub/cub/device/device_adjacent_difference.cuh
@@ -22,6 +22,9 @@
 #include <cuda/__functional/call_or.h>
 #include <cuda/__stream/get_stream.h>
 #include <cuda/std/__execution/env.h>
+#include <cuda/std/__iterator/concepts.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
@@ -537,6 +540,7 @@ struct DeviceAdjacentDifference
   //! This is an environment-based API that allows customization of:
   //!
   //! - Stream: Query via ``cuda::get_stream``
+  //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
   //!
   //! Overview
   //! +++++++++++++++++++++++++++++++++++++++++++++
@@ -596,12 +600,18 @@ struct DeviceAdjacentDifference
   //!   @endrst
   template <typename InputIteratorT,
             typename OutputIteratorT,
-            typename DifferenceOpT,
-            typename NumItemsT,
-            typename EnvT = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<!::cuda::std::is_same_v<InputIteratorT, void*>, int> = 0>
+            typename DifferenceOpT        = ::cuda::std::minus<>,
+            typename NumItemsT            = uint32_t,
+            typename EnvT                 = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_integral_v<EnvT>
+                                       && ::cuda::std::input_or_output_iterator<InputIteratorT>,
+                                     int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t SubtractLeftCopy(
-    InputIteratorT d_input, OutputIteratorT d_output, NumItemsT num_items, DifferenceOpT difference_op, EnvT env = {})
+    InputIteratorT d_input,
+    OutputIteratorT d_output,
+    NumItemsT num_items,
+    DifferenceOpT difference_op = {},
+    EnvT env                    = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceAdjacentDifference::SubtractLeftCopy");
 
@@ -631,6 +641,7 @@ struct DeviceAdjacentDifference
   //! This is an environment-based API that allows customization of:
   //!
   //! - Stream: Query via ``cuda::get_stream``
+  //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
   //!
   //! Overview
   //! +++++++++++++++++++++++++++++++++++++++++++++
@@ -681,12 +692,14 @@ struct DeviceAdjacentDifference
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
   template <typename RandomAccessIteratorT,
-            typename DifferenceOpT,
-            typename NumItemsT,
-            typename EnvT = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<!::cuda::std::is_same_v<RandomAccessIteratorT, void*>, int> = 0>
+            typename DifferenceOpT        = ::cuda::std::minus<>,
+            typename NumItemsT            = uint32_t,
+            typename EnvT                 = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_integral_v<EnvT>
+                                       && ::cuda::std::input_or_output_iterator<RandomAccessIteratorT>,
+                                     int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t
-  SubtractLeft(RandomAccessIteratorT d_input, NumItemsT num_items, DifferenceOpT difference_op, EnvT env = {})
+  SubtractLeft(RandomAccessIteratorT d_input, NumItemsT num_items, DifferenceOpT difference_op = {}, EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceAdjacentDifference::SubtractLeft");
 
@@ -717,6 +730,7 @@ struct DeviceAdjacentDifference
   //! This is an environment-based API that allows customization of:
   //!
   //! - Stream: Query via ``cuda::get_stream``
+  //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
   //!
   //! Overview
   //! +++++++++++++++++++++++++++++++++++++++++++++
@@ -778,12 +792,18 @@ struct DeviceAdjacentDifference
   //!   @endrst
   template <typename InputIteratorT,
             typename OutputIteratorT,
-            typename DifferenceOpT,
-            typename NumItemsT,
-            typename EnvT = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<!::cuda::std::is_same_v<InputIteratorT, void*>, int> = 0>
+            typename DifferenceOpT        = ::cuda::std::minus<>,
+            typename NumItemsT            = uint32_t,
+            typename EnvT                 = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_integral_v<EnvT>
+                                       && ::cuda::std::input_or_output_iterator<InputIteratorT>,
+                                     int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t SubtractRightCopy(
-    InputIteratorT d_input, OutputIteratorT d_output, NumItemsT num_items, DifferenceOpT difference_op, EnvT env = {})
+    InputIteratorT d_input,
+    OutputIteratorT d_output,
+    NumItemsT num_items,
+    DifferenceOpT difference_op = {},
+    EnvT env                    = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceAdjacentDifference::SubtractRightCopy");
 
@@ -813,6 +833,7 @@ struct DeviceAdjacentDifference
   //! This is an environment-based API that allows customization of:
   //!
   //! - Stream: Query via ``cuda::get_stream``
+  //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
   //!
   //! Overview
   //! +++++++++++++++++++++++++++++++++++++++++++++
@@ -863,12 +884,14 @@ struct DeviceAdjacentDifference
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
   template <typename RandomAccessIteratorT,
-            typename DifferenceOpT,
-            typename NumItemsT,
-            typename EnvT = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<!::cuda::std::is_same_v<RandomAccessIteratorT, void*>, int> = 0>
+            typename DifferenceOpT        = ::cuda::std::minus<>,
+            typename NumItemsT            = uint32_t,
+            typename EnvT                 = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_integral_v<EnvT>
+                                       && ::cuda::std::input_or_output_iterator<RandomAccessIteratorT>,
+                                     int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t
-  SubtractRight(RandomAccessIteratorT d_input, NumItemsT num_items, DifferenceOpT difference_op, EnvT env = {})
+  SubtractRight(RandomAccessIteratorT d_input, NumItemsT num_items, DifferenceOpT difference_op = {}, EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceAdjacentDifference::SubtractRight");
 

--- a/cub/cub/device/device_adjacent_difference.cuh
+++ b/cub/cub/device/device_adjacent_difference.cuh
@@ -155,19 +155,10 @@ struct DeviceAdjacentDifference
   //! @endrst
   //!
   //! @tparam InputIteratorT
-  //!   @rst
-  //!   is a model of `Input Iterator <https://en.cppreference.com/w/cpp/iterator/input_iterator>`_,
-  //!   and ``x`` and ``y`` are objects of ``InputIteratorT``'s ``value_type``, then
-  //!   ``x - y`` is defined, and ``InputIteratorT``'s ``value_type`` is convertible to
-  //!   a type in ``OutputIteratorT``'s set of ``value_types``, and the return type
-  //!   of ``x - y`` is convertible to a type in ``OutputIteratorT``'s set of
-  //!   ``value_types``.
-  //!   @endrst
+  //!   **[inferred]** Random-access input iterator type for reading input elements @iterator
   //!
   //! @tparam OutputIteratorT
-  //!   @rst
-  //!   is a model of `Output Iterator <https://en.cppreference.com/w/cpp/iterator/output_iterator>`_.
-  //!   @endrst
+  //!   **[inferred]** Random-access output iterator type for writing output elements @iterator
   //!
   //! @tparam DifferenceOpT
   //!   Its `result_type` is convertible to a type in `OutputIteratorT`'s set of `value_types`.
@@ -277,13 +268,7 @@ struct DeviceAdjacentDifference
   //! @endrst
   //!
   //! @tparam RandomAccessIteratorT
-  //!   @rst
-  //!   is a model of `Random Access Iterator <https://en.cppreference.com/w/cpp/iterator/random_access_iterator>`_,
-  //!   ``RandomAccessIteratorT`` is mutable. If ``x`` and ``y`` are objects of
-  //!   ``RandomAccessIteratorT``'s ``value_type``, and ``x - y`` is defined, then the
-  //!   return type of ``x - y`` should be convertible to a type in
-  //!   ``RandomAccessIteratorT``'s set of ``value_types``.
-  //!   @endrst
+  //!   **[inferred]** Random-access iterator type for reading and writing elements @iterator
   //!
   //! @tparam DifferenceOpT
   //!   Its `result_type` is convertible to a type in `RandomAccessIteratorT`'s
@@ -394,22 +379,13 @@ struct DeviceAdjacentDifference
   //! @endrst
   //!
   //! @tparam InputIteratorT
-  //!   @rst
-  //!   is a model of `Input Iterator <https://en.cppreference.com/w/cpp/iterator/input_iterator>`_,
-  //!   and ``x`` and ``y`` are objects of ``InputIteratorT``'s ``value_type``, then
-  //!   ``x - y`` is defined, and ``InputIteratorT``'s ``value_type`` is convertible to
-  //!   a type in ``OutputIteratorT``'s set of ``value_types``, and the return type
-  //!   of ``x - y`` is convertible to a type in ``OutputIteratorT``'s set of
-  //!   ``value_types``.
-  //!   @endrst
+  //!   **[inferred]** Random-access input iterator type for reading input elements @iterator
   //!
   //! @tparam OutputIteratorT
-  //!   @rst
-  //!   is a model of `Output Iterator <https://en.cppreference.com/w/cpp/iterator/output_iterator>`_.
-  //!   @endrst
+  //!   **[inferred]** Random-access output iterator type for writing output elements @iterator
   //!
   //! @tparam DifferenceOpT
-  //!   Its `result_type` is convertible to a type in `RandomAccessIteratorT`'s
+  //!   Its `result_type` is convertible to a type in `OutputIteratorT`'s
   //!   set of `value_types`.
   //!
   //! @tparam NumItemsT
@@ -507,13 +483,7 @@ struct DeviceAdjacentDifference
   //! @endrst
   //!
   //! @tparam RandomAccessIteratorT
-  //!   @rst
-  //!   is a model of `Random Access Iterator <https://en.cppreference.com/w/cpp/iterator/random_access_iterator>`_,
-  //!   ``RandomAccessIteratorT`` is mutable. If ``x`` and ``y`` are objects of
-  //!   ``RandomAccessIteratorT``'s `value_type`, and ``x - y`` is defined, then the
-  //!   return type of ``x - y`` should be convertible to a type in
-  //!   ``RandomAccessIteratorT``'s set of ``value_types``.
-  //!   @endrst
+  //!   **[inferred]** Random-access iterator type for reading and writing elements @iterator
   //!
   //! @tparam DifferenceOpT
   //!   Its `result_type` is convertible to a type in `RandomAccessIteratorT`'s

--- a/cub/cub/device/device_adjacent_difference.cuh
+++ b/cub/cub/device/device_adjacent_difference.cuh
@@ -22,7 +22,6 @@
 #include <cuda/__functional/call_or.h>
 #include <cuda/__stream/get_stream.h>
 #include <cuda/std/__execution/env.h>
-#include <cuda/std/__iterator/concepts.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/cstdint>
@@ -600,12 +599,10 @@ struct DeviceAdjacentDifference
   //!   @endrst
   template <typename InputIteratorT,
             typename OutputIteratorT,
-            typename DifferenceOpT        = ::cuda::std::minus<>,
-            typename NumItemsT            = uint32_t,
-            typename EnvT                 = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_integral_v<EnvT>
-                                       && ::cuda::std::input_or_output_iterator<InputIteratorT>,
-                                     int> = 0>
+            typename DifferenceOpT                                               = ::cuda::std::minus<>,
+            typename NumItemsT                                                   = uint32_t,
+            typename EnvT                                                        = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t SubtractLeftCopy(
     InputIteratorT d_input,
     OutputIteratorT d_output,
@@ -692,12 +689,10 @@ struct DeviceAdjacentDifference
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
   template <typename RandomAccessIteratorT,
-            typename DifferenceOpT        = ::cuda::std::minus<>,
-            typename NumItemsT            = uint32_t,
-            typename EnvT                 = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_integral_v<EnvT>
-                                       && ::cuda::std::input_or_output_iterator<RandomAccessIteratorT>,
-                                     int> = 0>
+            typename DifferenceOpT                                               = ::cuda::std::minus<>,
+            typename NumItemsT                                                   = uint32_t,
+            typename EnvT                                                        = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t
   SubtractLeft(RandomAccessIteratorT d_input, NumItemsT num_items, DifferenceOpT difference_op = {}, EnvT env = {})
   {
@@ -792,12 +787,10 @@ struct DeviceAdjacentDifference
   //!   @endrst
   template <typename InputIteratorT,
             typename OutputIteratorT,
-            typename DifferenceOpT        = ::cuda::std::minus<>,
-            typename NumItemsT            = uint32_t,
-            typename EnvT                 = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_integral_v<EnvT>
-                                       && ::cuda::std::input_or_output_iterator<InputIteratorT>,
-                                     int> = 0>
+            typename DifferenceOpT                                               = ::cuda::std::minus<>,
+            typename NumItemsT                                                   = uint32_t,
+            typename EnvT                                                        = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t SubtractRightCopy(
     InputIteratorT d_input,
     OutputIteratorT d_output,
@@ -884,12 +877,10 @@ struct DeviceAdjacentDifference
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
   template <typename RandomAccessIteratorT,
-            typename DifferenceOpT        = ::cuda::std::minus<>,
-            typename NumItemsT            = uint32_t,
-            typename EnvT                 = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_integral_v<EnvT>
-                                       && ::cuda::std::input_or_output_iterator<RandomAccessIteratorT>,
-                                     int> = 0>
+            typename DifferenceOpT                                               = ::cuda::std::minus<>,
+            typename NumItemsT                                                   = uint32_t,
+            typename EnvT                                                        = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t
   SubtractRight(RandomAccessIteratorT d_input, NumItemsT num_items, DifferenceOpT difference_op = {}, EnvT env = {})
   {

--- a/cub/cub/device/device_adjacent_difference.cuh
+++ b/cub/cub/device/device_adjacent_difference.cuh
@@ -689,10 +689,10 @@ struct DeviceAdjacentDifference
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
   template <typename RandomAccessIteratorT,
-            typename DifferenceOpT                                               = ::cuda::std::minus<>,
-            typename NumItemsT                                                   = uint32_t,
-            typename EnvT                                                        = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
+            typename DifferenceOpT = ::cuda::std::minus<>,
+            typename NumItemsT     = uint32_t,
+            typename EnvT          = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_integral_v<EnvT>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t
   SubtractLeft(RandomAccessIteratorT d_input, NumItemsT num_items, DifferenceOpT difference_op = {}, EnvT env = {})
   {
@@ -877,10 +877,10 @@ struct DeviceAdjacentDifference
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
   template <typename RandomAccessIteratorT,
-            typename DifferenceOpT                                               = ::cuda::std::minus<>,
-            typename NumItemsT                                                   = uint32_t,
-            typename EnvT                                                        = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
+            typename DifferenceOpT = ::cuda::std::minus<>,
+            typename NumItemsT     = uint32_t,
+            typename EnvT          = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_integral_v<EnvT>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t
   SubtractRight(RandomAccessIteratorT d_input, NumItemsT num_items, DifferenceOpT difference_op = {}, EnvT env = {})
   {

--- a/cub/cub/device/device_copy.cuh
+++ b/cub/cub/device/device_copy.cuh
@@ -24,8 +24,6 @@
 #include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
 
 #include <cuda/std/__execution/env.h>
-#include <cuda/std/__type_traits/enable_if.h>
-#include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/cstdint>
 #include <cuda/std/mdspan>
 
@@ -226,11 +224,7 @@ struct DeviceCopy
   //!
   //! @param[in] env
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
-  template <typename InputIt,
-            typename OutputIt,
-            typename SizeIteratorT,
-            typename EnvT                                                    = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<!::cuda::std::is_integral_v<EnvT>, int> = 0>
+  template <typename InputIt, typename OutputIt, typename SizeIteratorT, typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
   Batched(InputIt input_it, OutputIt output_it, SizeIteratorT sizes, ::cuda::std::int64_t num_ranges, EnvT env = {})
   {
@@ -437,8 +431,7 @@ struct DeviceCopy
             typename Extents_Out,
             typename Layout_Out,
             typename Accessor_Out,
-            typename EnvT                                                    = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<!::cuda::std::is_integral_v<EnvT>, int> = 0>
+            typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t
   Copy(::cuda::std::mdspan<T_In, Extents_In, Layout_In, Accessor_In> mdspan_in,
        ::cuda::std::mdspan<T_Out, Extents_Out, Layout_Out, Accessor_Out> mdspan_out,

--- a/cub/cub/device/device_copy.cuh
+++ b/cub/cub/device/device_copy.cuh
@@ -24,6 +24,8 @@
 #include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
 
 #include <cuda/std/__execution/env.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/cstdint>
 #include <cuda/std/mdspan>
 
@@ -177,8 +179,6 @@ struct DeviceCopy
   //! - Stream: Query via ``cuda::get_stream``
   //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
   //!
-  //! - This operation provides ``gpu_to_gpu`` determinism: results are identical across different GPU architectures.
-  //!
   //! .. note::
   //!
   //!    If any input range aliases any output range the behavior is undefined.
@@ -226,7 +226,11 @@ struct DeviceCopy
   //!
   //! @param[in] env
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
-  template <typename InputIt, typename OutputIt, typename SizeIteratorT, typename EnvT = ::cuda::std::execution::env<>>
+  template <typename InputIt,
+            typename OutputIt,
+            typename SizeIteratorT,
+            typename EnvT                                                    = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<!::cuda::std::is_integral_v<EnvT>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
   Batched(InputIt input_it, OutputIt output_it, SizeIteratorT sizes, ::cuda::std::int64_t num_ranges, EnvT env = {})
   {
@@ -360,16 +364,14 @@ struct DeviceCopy
   //! .. versionadded:: 3.4.0
   //!    First appears in CUDA Toolkit 13.4.
   //!
+  //! This function performs a parallel copy operation between two mdspan objects with potentially different layouts but
+  //! identical extents. The copy operation handles arbitrary-dimensional arrays and automatically manages layout
+  //! transformations.
+  //!
   //! This is an environment-based API that allows customization of:
   //!
   //! - Stream: Query via ``cuda::get_stream``
   //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
-  //!
-  //! - This operation provides ``gpu_to_gpu`` determinism: results are identical across different GPU architectures.
-  //!
-  //! This function performs a parallel copy operation between two mdspan objects with potentially different layouts but
-  //! identical extents. The copy operation handles arbitrary-dimensional arrays and automatically manages layout
-  //! transformations.
   //!
   //! Preconditions
   //! +++++++++++++
@@ -435,7 +437,8 @@ struct DeviceCopy
             typename Extents_Out,
             typename Layout_Out,
             typename Accessor_Out,
-            typename EnvT = ::cuda::std::execution::env<>>
+            typename EnvT                                                    = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<!::cuda::std::is_integral_v<EnvT>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t
   Copy(::cuda::std::mdspan<T_In, Extents_In, Layout_In, Accessor_In> mdspan_in,
        ::cuda::std::mdspan<T_Out, Extents_Out, Layout_Out, Accessor_Out> mdspan_out,

--- a/cub/cub/device/device_find.cuh
+++ b/cub/cub/device/device_find.cuh
@@ -116,10 +116,10 @@ struct DeviceFind
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
   //! For each ``value`` in ``[d_values, d_values + values_num_items)``, performs a binary search in the range
-  //! ``[d_range, d_range + range_num_items)``, using ``comp`` as the comparator to find the iterator to the element
-  //! of said range which **is not** ordered **before** ``value``.
+  //! ``[d_range, d_range + range_num_items)``, using ``comp`` as the comparator to find the iterator to the
+  //! **first** element of said range which **is not** ordered **before** ``value``.
   //!
-  //! - The range ``[first, last)`` must be sorted consistently with ``comp``.
+  //! - The range ``[d_range, d_range + range_num_items)`` must be sorted consistently with ``comp``.
   //!
   //! .. versionadded:: 3.3.0
   //!
@@ -236,8 +236,8 @@ struct DeviceFind
   //!
   //! For each ``value`` in ``[d_values, d_values + values_num_items)``, performs a binary search in the range
   //! ``[d_range, d_range + range_num_items)``,
-  //! using ``comp`` as the comparator to find the iterator to the element of said range which **is** ordered
-  //! **after** ``value``.
+  //! using ``comp`` as the comparator to find the iterator to the **first** element of said range which **is**
+  //! ordered **after** ``value``.
   //!
   //! - The range ``[d_range, d_range + range_num_items)`` must be sorted consistently with ``comp``.
   //!
@@ -352,6 +352,11 @@ struct DeviceFind
   //! @rst
   //! Finds the first element in the input sequence that satisfies the given predicate.
   //!
+  //! - The search terminates at the first element where the predicate evaluates to true.
+  //! - The index of the found element is written to ``d_out``.
+  //! - If no element satisfies the predicate, ``num_items`` is written to ``d_out``.
+  //! - The range ``[d_out, d_out + 1)`` shall not overlap ``[d_in, d_in + num_items)`` in any way.
+  //!
   //! .. versionadded:: 3.4.0
   //!    First appears in CUDA Toolkit 13.4.
   //!
@@ -360,11 +365,7 @@ struct DeviceFind
   //! - Stream: Query via ``cuda::get_stream``
   //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
   //!
-  //! - The search terminates at the first element where the predicate evaluates to true.
-  //! - The index of the found element is written to ``d_out``.
-  //! - If no element satisfies the predicate, ``num_items`` is written to ``d_out``.
-  //! - The range ``[d_out, d_out + 1)`` shall not overlap ``[d_in, d_in + num_items)`` in any way.
-  //!
+
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
@@ -434,8 +435,8 @@ struct DeviceFind
 
   //! @rst
   //! For each ``value`` in ``[d_values, d_values + values_num_items)``, performs a binary search in the range
-  //! ``[d_range, d_range + range_num_items)``, using ``comp`` as the comparator to find the iterator to the element
-  //! of said range which **is not** ordered **before** ``value``.
+  //! ``[d_range, d_range + range_num_items)``, using ``comp`` as the comparator to find the iterator to the
+  //! **first** element of said range which **is not** ordered **before** ``value``.
   //!
   //! .. versionadded:: 3.4.0
   //!    First appears in CUDA Toolkit 13.4.
@@ -554,8 +555,8 @@ struct DeviceFind
   //! @rst
   //! For each ``value`` in ``[d_values, d_values + values_num_items)``, performs a binary search in the range
   //! ``[d_range, d_range + range_num_items)``,
-  //! using ``comp`` as the comparator to find the iterator to the element of said range which **is** ordered
-  //! **after** ``value``.
+  //! using ``comp`` as the comparator to find the iterator to the **first** element of said range which **is**
+  //! ordered **after** ``value``.
   //!
   //! .. versionadded:: 3.4.0
   //!    First appears in CUDA Toolkit 13.4.

--- a/cub/cub/device/device_partition.cuh
+++ b/cub/cub/device/device_partition.cuh
@@ -24,6 +24,8 @@
 #include <cub/device/dispatch/dispatch_three_way_partition.cuh>
 
 #include <cuda/std/__execution/env.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
@@ -986,7 +988,8 @@ public:
             typename SelectFirstPartOp,
             typename SelectSecondPartOp,
             typename NumItemsT,
-            typename EnvT = ::cuda::std::execution::env<>>
+            typename EnvT = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<!::cuda::std::is_same_v<FirstOutputIteratorT, size_t>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
   If(InputIteratorT d_in,
      FirstOutputIteratorT d_first_part_out,

--- a/cub/cub/device/device_partition.cuh
+++ b/cub/cub/device/device_partition.cuh
@@ -24,8 +24,6 @@
 #include <cub/device/dispatch/dispatch_three_way_partition.cuh>
 
 #include <cuda/std/__execution/env.h>
-#include <cuda/std/__type_traits/enable_if.h>
-#include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
@@ -238,6 +236,9 @@ public:
   //! ``d_in`` into a partitioned sequence ``d_out``.
   //! The total number of items copied into the first partition is written to ``d_num_selected_out``.
   //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
   //! This is an environment-based API that allows customization of:
   //!
   //! - Stream: Query via ``cuda::get_stream``
@@ -306,11 +307,7 @@ public:
             typename OutputIteratorT,
             typename NumSelectedIteratorT,
             typename NumItemsT,
-            typename EnvT = ::cuda::std::execution::env<>,
-            typename ::cuda::std::enable_if_t<
-              ::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<InputIteratorT, void*>
-                && !::cuda::std::is_same_v<FlagIterator, size_t&>,
-              int> = 0>
+            typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Flagged(
     InputIteratorT d_in,
     FlagIterator d_flags,
@@ -493,6 +490,9 @@ public:
   //! a partitioned sequence ``d_out``. The total number of items copied into the first partition is written
   //! to ``d_num_selected_out``.
   //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
   //! This is an environment-based API that allows customization of:
   //!
   //! - Stream: Query via ``cuda::get_stream``
@@ -553,15 +553,12 @@ public:
   //!
   //! @param[in] env
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
-  template <
-    typename InputIteratorT,
-    typename OutputIteratorT,
-    typename NumSelectedIteratorT,
-    typename SelectOp,
-    typename NumItemsT,
-    typename EnvT = ::cuda::std::execution::env<>,
-    typename ::cuda::std::
-      enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<InputIteratorT, void*>, int> = 0>
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename NumSelectedIteratorT,
+            typename SelectOp,
+            typename NumItemsT,
+            typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
   If(InputIteratorT d_in,
      OutputIteratorT d_out,
@@ -882,6 +879,9 @@ public:
   //! @rst
   //! Uses two functors to split the corresponding items from ``d_in`` into three partitioned sequences
   //! ``d_first_part_out``, ``d_second_part_out``, and ``d_unselected_out``.
+  //! The total number of items copied into the first partition is written
+  //! to ``d_num_selected_out[0]``, while the total number of items copied into the second partition is written
+  //! to ``d_num_selected_out[1]``.
   //!
   //! .. versionadded:: 3.4.0
   //!    First appears in CUDA Toolkit 13.4.
@@ -896,9 +896,11 @@ public:
   //! - Copies of the items selected by ``select_second_part_op`` are compacted
   //!   into ``d_second_part_out`` and maintain their original relative ordering.
   //! - Copies of the unselected items are compacted into the ``d_unselected_out`` in reverse order.
-  //! - The total number of items copied into the first partition is written
-  //!   to ``d_num_selected_out[0]``, while the total number of items copied into the second partition is written
-  //!   to ``d_num_selected_out[1]``.
+  //! - The ranges ``[d_out, d_out + num_items)``,
+  //!   ``[d_first_part_out, d_first_part_out + d_num_selected_out[0])``,
+  //!   ``[d_second_part_out, d_second_part_out + d_num_selected_out[1])``,
+  //!   ``[d_unselected_out, d_unselected_out + num_items - d_num_selected_out[0] - d_num_selected_out[1])``,
+  //!   shall not overlap in any way.
   //!
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
@@ -984,8 +986,7 @@ public:
             typename SelectFirstPartOp,
             typename SelectSecondPartOp,
             typename NumItemsT,
-            typename EnvT = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<!::cuda::std::is_arithmetic_v<FirstOutputIteratorT>, int> = 0>
+            typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
   If(InputIteratorT d_in,
      FirstOutputIteratorT d_first_part_out,

--- a/cub/cub/device/device_run_length_encode.cuh
+++ b/cub/cub/device/device_run_length_encode.cuh
@@ -29,8 +29,6 @@
 
 #include <cuda/__iterator/constant_iterator.h>
 #include <cuda/std/__execution/env.h>
-#include <cuda/std/__type_traits/enable_if.h>
-#include <cuda/std/__type_traits/is_same.h>
 
 CUB_NAMESPACE_BEGIN
 
@@ -131,6 +129,9 @@ struct DeviceRunLengthEncode
   //! @tparam NumRunsOutputIteratorT
   //!   **[inferred]** Output iterator type for recording the number of runs encountered @iterator
   //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
   //! @param[in] d_temp_storage
   //!   Device-accessible allocation of temporary storage. When `nullptr`, the
   //!   required allocation size is written to `temp_storage_bytes` and no work is done.
@@ -151,7 +152,7 @@ struct DeviceRunLengthEncode
   //!   Pointer to total number of runs
   //!
   //! @param[in] num_items
-  //!   Total number of associated key+value pairs (i.e., the length of `d_in_keys` and `d_in_values`)
+  //!   Total number of input items (i.e., the length of `d_in`)
   //!
   //! @param[in] stream
   //!   @rst
@@ -283,8 +284,7 @@ struct DeviceRunLengthEncode
             typename LengthsOutputIteratorT,
             typename NumRunsOutputIteratorT,
             typename NumItemsT,
-            typename EnvT = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<!::cuda::std::is_same_v<InputIteratorT, void*>, int> = 0>
+            typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Encode(
     InputIteratorT d_in,
     UniqueOutputIteratorT d_unique_out,
@@ -394,6 +394,9 @@ struct DeviceRunLengthEncode
   //! @tparam NumRunsOutputIteratorT
   //!   **[inferred]** Output iterator type for recording the number of runs encountered @iterator
   //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
   //! @param[in] d_temp_storage
   //!   Device-accessible allocation of temporary storage. When `nullptr`, the
   //!   required allocation size is written to `temp_storage_bytes` and no work is done.
@@ -415,7 +418,7 @@ struct DeviceRunLengthEncode
   //!   Pointer to total number of runs (i.e., length of `d_offsets_out`)
   //!
   //! @param[in] num_items
-  //!   Total number of associated key+value pairs (i.e., the length of `d_in_keys` and `d_in_values`)
+  //!   Total number of input items (i.e., the length of `d_in`)
   //!
   //! @param[in] stream
   //!   @rst
@@ -530,8 +533,7 @@ struct DeviceRunLengthEncode
             typename LengthsOutputIteratorT,
             typename NumRunsOutputIteratorT,
             typename NumItemsT,
-            typename EnvT = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<!::cuda::std::is_same_v<InputIteratorT, void*>, int> = 0>
+            typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t NonTrivialRuns(
     InputIteratorT d_in,
     OffsetsOutputIteratorT d_offsets_out,

--- a/cub/test/catch2_test_device_adjacent_difference_api.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_api.cu
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "insert_nested_NVTX_range_guard.h"
+
+#include <cub/device/device_adjacent_difference.cuh>
+
+#include <c2h/catch2_test_helper.h>
+
+// Guard: the legacy memory-size query call with all defaults (no explicit difference_op,
+// no explicit stream) must resolve unambiguously to the legacy temp-storage overload
+// when the env passthrough overload is also visible. If the env overload's SFINAE
+// is too loose, this becomes "ambiguous overload" or silently dispatches to env.
+
+C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy legacy size-query is unambiguous", "[adjacent_difference][device]")
+{
+  int* d_in    = nullptr;
+  int* d_out   = nullptr;
+  size_t bytes = 0;
+  int n        = 0;
+
+  REQUIRE(cudaSuccess == cub::DeviceAdjacentDifference::SubtractLeftCopy(nullptr, bytes, d_in, d_out, n));
+}
+
+C2H_TEST("DeviceAdjacentDifference::SubtractLeft legacy size-query is unambiguous", "[adjacent_difference][device]")
+{
+  int* d_in    = nullptr;
+  size_t bytes = 0;
+  int n        = 0;
+
+  REQUIRE(cudaSuccess == cub::DeviceAdjacentDifference::SubtractLeft(nullptr, bytes, d_in, n));
+}
+
+C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy legacy size-query is unambiguous",
+         "[adjacent_difference][device]")
+{
+  int* d_in    = nullptr;
+  int* d_out   = nullptr;
+  size_t bytes = 0;
+  int n        = 0;
+
+  REQUIRE(cudaSuccess == cub::DeviceAdjacentDifference::SubtractRightCopy(nullptr, bytes, d_in, d_out, n));
+}
+
+C2H_TEST("DeviceAdjacentDifference::SubtractRight legacy size-query is unambiguous", "[adjacent_difference][device]")
+{
+  int* d_in    = nullptr;
+  size_t bytes = 0;
+  int n        = 0;
+
+  REQUIRE(cudaSuccess == cub::DeviceAdjacentDifference::SubtractRight(nullptr, bytes, d_in, n));
+}
+
+// todo(giannis): extract examples from the docs to literalinclude extracts here

--- a/cub/test/catch2_test_device_copy_api.cu
+++ b/cub/test/catch2_test_device_copy_api.cu
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "insert_nested_NVTX_range_guard.h"
+
+#include <cub/device/device_copy.cuh>
+
+#include <cuda/std/cstdint>
+
+#include <c2h/catch2_test_helper.h>
+
+// Guard: the legacy memory-size query call with all defaults (no explicit stream)
+// must resolve unambiguously to the legacy temp-storage overload when the env
+// passthrough overload is also visible. If the env overload's SFINAE is too loose,
+// this becomes "ambiguous overload" or silently dispatches to env.
+
+C2H_TEST("DeviceCopy::Batched legacy size-query is unambiguous", "[copy][device]")
+{
+  // DeviceCopy::Batched takes iterator-of-iterators for input/output ranges.
+  int** in                        = nullptr;
+  int** out                       = nullptr;
+  size_t* sizes                   = nullptr;
+  size_t bytes                    = 0;
+  ::cuda::std::int64_t num_ranges = 0;
+
+  REQUIRE(cudaSuccess == cub::DeviceCopy::Batched(nullptr, bytes, in, out, sizes, num_ranges));
+}
+
+// todo(giannis): extract examples from the docs to literalinclude extracts here
+
+// TODO(giannis): move the DeviceCopy::Copy (mdspan) tests from
+// catch2_test_device_copy_mdspan_api.cu here, so all DeviceCopy api tests live together.

--- a/cub/test/catch2_test_device_copy_env_api.cu
+++ b/cub/test/catch2_test_device_copy_env_api.cu
@@ -39,19 +39,19 @@ C2H_TEST("cub::DeviceCopy::Batched accepts env with stream", "[copy][env]")
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceCopy::Batched(
     thrust::raw_pointer_cast(d_input_ptrs.data()),
     thrust::raw_pointer_cast(d_output_ptrs.data()),
     thrust::raw_pointer_cast(d_sizes.data()),
     num_ranges,
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceCopy::Batched failed with status: " << error << '\n';
   }
   // example-end copy-batched-env
+  stream.sync();
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(d_dst == d_src);
@@ -78,14 +78,14 @@ C2H_TEST("cub::DeviceCopy::Copy mdspan accepts env with stream", "[copy][env]")
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
-  auto error = cub::DeviceCopy::Copy(mdspan_in, mdspan_out, env);
+  auto error = cub::DeviceCopy::Copy(mdspan_in, mdspan_out, stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceCopy::Copy failed with status: " << error << '\n';
   }
   // example-end copy-mdspan-env
+  stream.sync();
 
   REQUIRE(error == cudaSuccess);
   // Verify the data was copied

--- a/cub/test/catch2_test_device_find_api.cu
+++ b/cub/test/catch2_test_device_find_api.cu
@@ -118,3 +118,46 @@ C2H_TEST("cub::DeviceFind::UpperBound works with int data elements", "[find][dev
 
   REQUIRE(d_output == expected);
 }
+
+// Guard: the legacy memory-size query call with all defaults (no explicit stream)
+// must resolve unambiguously to the legacy temp-storage overload when the env
+// passthrough overload is also visible. If the env overload's SFINAE is too loose,
+// this becomes "ambiguous overload" or silently dispatches to env.
+
+C2H_TEST("DeviceFind::FindIf legacy size-query is unambiguous", "[find][device]")
+{
+  int* d_in    = nullptr;
+  int* d_out   = nullptr;
+  size_t bytes = 0;
+  int n        = 0;
+
+  REQUIRE(cudaSuccess == cub::DeviceFind::FindIf(nullptr, bytes, d_in, d_out, is_greater_than_t{0}, n));
+}
+
+C2H_TEST("DeviceFind::LowerBound legacy size-query is unambiguous", "[find][device]")
+{
+  int* d_range  = nullptr;
+  int* d_values = nullptr;
+  int* d_output = nullptr;
+  size_t bytes  = 0;
+  int range_n   = 0;
+  int values_n  = 0;
+
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceFind::LowerBound(nullptr, bytes, d_range, range_n, d_values, values_n, d_output, cuda::std::less{}));
+}
+
+C2H_TEST("DeviceFind::UpperBound legacy size-query is unambiguous", "[find][device]")
+{
+  int* d_range  = nullptr;
+  int* d_values = nullptr;
+  int* d_output = nullptr;
+  size_t bytes  = 0;
+  int range_n   = 0;
+  int values_n  = 0;
+
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceFind::UpperBound(nullptr, bytes, d_range, range_n, d_values, values_n, d_output, cuda::std::less{}));
+}

--- a/cub/test/catch2_test_device_partition_api.cu
+++ b/cub/test/catch2_test_device_partition_api.cu
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "insert_nested_NVTX_range_guard.h"
+
+#include <cub/device/device_partition.cuh>
+
+#include <c2h/catch2_test_helper.h>
+
+struct always_true_t
+{
+  __host__ __device__ bool operator()(int) const
+  {
+    return true;
+  }
+};
+
+// Guard: the legacy memory-size query call with all defaults (no explicit stream)
+// must resolve unambiguously to the legacy temp-storage overload when the env
+// passthrough overload is also visible. If the env overload's SFINAE is too loose,
+// this becomes "ambiguous overload" or silently dispatches to env.
+
+C2H_TEST("DevicePartition::Flagged legacy size-query is unambiguous", "[partition][device]")
+{
+  int* d_in           = nullptr;
+  int* d_flags        = nullptr;
+  int* d_out          = nullptr;
+  int* d_num_selected = nullptr;
+  size_t bytes        = 0;
+  int n               = 0;
+
+  REQUIRE(cudaSuccess == cub::DevicePartition::Flagged(nullptr, bytes, d_in, d_flags, d_out, d_num_selected, n));
+}
+
+C2H_TEST("DevicePartition::If legacy size-query is unambiguous", "[partition][device]")
+{
+  int* d_in           = nullptr;
+  int* d_out          = nullptr;
+  int* d_num_selected = nullptr;
+  size_t bytes        = 0;
+  int n               = 0;
+
+  REQUIRE(cudaSuccess == cub::DevicePartition::If(nullptr, bytes, d_in, d_out, d_num_selected, n, always_true_t{}));
+}
+
+C2H_TEST("DevicePartition::If three-way legacy size-query is unambiguous", "[partition][device]")
+{
+  int* d_in           = nullptr;
+  int* d_first_part   = nullptr;
+  int* d_second_part  = nullptr;
+  int* d_unselected   = nullptr;
+  int* d_num_selected = nullptr;
+  size_t bytes        = 0;
+  int n               = 0;
+
+  REQUIRE(
+    cudaSuccess
+    == cub::DevicePartition::If(
+      nullptr,
+      bytes,
+      d_in,
+      d_first_part,
+      d_second_part,
+      d_unselected,
+      d_num_selected,
+      n,
+      always_true_t{},
+      always_true_t{}));
+}
+
+// todo(giannis): extract examples from the docs to literalinclude extracts here

--- a/cub/test/catch2_test_device_partition_api.cu
+++ b/cub/test/catch2_test_device_partition_api.cu
@@ -7,14 +7,6 @@
 
 #include <c2h/catch2_test_helper.h>
 
-struct always_true_t
-{
-  __host__ __device__ bool operator()(int) const
-  {
-    return true;
-  }
-};
-
 // Guard: the legacy memory-size query call with all defaults (no explicit stream)
 // must resolve unambiguously to the legacy temp-storage overload when the env
 // passthrough overload is also visible. If the env overload's SFINAE is too loose,
@@ -40,7 +32,8 @@ C2H_TEST("DevicePartition::If legacy size-query is unambiguous", "[partition][de
   size_t bytes        = 0;
   int n               = 0;
 
-  REQUIRE(cudaSuccess == cub::DevicePartition::If(nullptr, bytes, d_in, d_out, d_num_selected, n, always_true_t{}));
+  REQUIRE(
+    cudaSuccess == cub::DevicePartition::If(nullptr, bytes, d_in, d_out, d_num_selected, n, ::cuda::always_true{}));
 }
 
 C2H_TEST("DevicePartition::If three-way legacy size-query is unambiguous", "[partition][device]")
@@ -64,8 +57,8 @@ C2H_TEST("DevicePartition::If three-way legacy size-query is unambiguous", "[par
       d_unselected,
       d_num_selected,
       n,
-      always_true_t{},
-      always_true_t{}));
+      ::cuda::always_true{},
+      ::cuda::always_true{}));
 }
 
 // todo(giannis): extract examples from the docs to literalinclude extracts here

--- a/cub/test/catch2_test_device_partition_env_api.cu
+++ b/cub/test/catch2_test_device_partition_env_api.cu
@@ -36,9 +36,9 @@ C2H_TEST("cub::DevicePartition::If accepts env with stream", "[partition][env]")
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
-  auto error = cub::DevicePartition::If(input.begin(), output.begin(), num_selected.begin(), input.size(), le, env);
+  auto error =
+    cub::DevicePartition::If(input.begin(), output.begin(), num_selected.begin(), input.size(), le, stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DevicePartition::If failed with status: " << error << '\n';
@@ -48,6 +48,7 @@ C2H_TEST("cub::DevicePartition::If accepts env with stream", "[partition][env]")
   thrust::device_vector<int> expected_output{1, 2, 3, 4, 8, 7, 6, 5};
   thrust::device_vector<int> expected_num_selected{4};
   // example-end partition-if-env
+  stream.sync();
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(output == expected_output);
@@ -64,10 +65,9 @@ C2H_TEST("cub::DevicePartition::Flagged accepts env with stream", "[partition][e
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DevicePartition::Flagged(
-    input.begin(), flags.begin(), output.begin(), num_selected.begin(), input.size(), env);
+    input.begin(), flags.begin(), output.begin(), num_selected.begin(), input.size(), stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DevicePartition::Flagged failed with status: " << error << '\n';
@@ -77,6 +77,7 @@ C2H_TEST("cub::DevicePartition::Flagged accepts env with stream", "[partition][e
   thrust::device_vector<int> expected_output{1, 4, 6, 7, 8, 5, 3, 2};
   thrust::device_vector<int> expected_num_selected{4};
   // example-end partition-flagged-env
+  stream.sync();
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(output == expected_output);

--- a/cub/test/catch2_test_device_run_length_encode_api.cu
+++ b/cub/test/catch2_test_device_run_length_encode_api.cu
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "insert_nested_NVTX_range_guard.h"
+
+#include <cub/device/device_run_length_encode.cuh>
+
+#include <c2h/catch2_test_helper.h>
+
+// Guard: the legacy memory-size query call with all defaults (no explicit stream)
+// must resolve unambiguously to the legacy temp-storage overload when the env
+// passthrough overload is also visible. If the env overload's SFINAE is too loose,
+// this becomes "ambiguous overload" or silently dispatches to env.
+
+C2H_TEST("DeviceRunLengthEncode::Encode legacy size-query is unambiguous", "[run_length_encode][device]")
+{
+  int* d_in       = nullptr;
+  int* d_unique   = nullptr;
+  int* d_lengths  = nullptr;
+  int* d_num_runs = nullptr;
+  size_t bytes    = 0;
+  int n           = 0;
+
+  REQUIRE(cudaSuccess == cub::DeviceRunLengthEncode::Encode(nullptr, bytes, d_in, d_unique, d_lengths, d_num_runs, n));
+}
+
+C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns legacy size-query is unambiguous", "[run_length_encode][device]")
+{
+  int* d_in       = nullptr;
+  int* d_offsets  = nullptr;
+  int* d_lengths  = nullptr;
+  int* d_num_runs = nullptr;
+  size_t bytes    = 0;
+  int n           = 0;
+
+  REQUIRE(cudaSuccess
+          == cub::DeviceRunLengthEncode::NonTrivialRuns(nullptr, bytes, d_in, d_offsets, d_lengths, d_num_runs, n));
+}
+
+// todo(giannis): extract examples from the docs to literalinclude extracts here

--- a/cub/test/catch2_test_device_run_length_encode_env_api.cu
+++ b/cub/test/catch2_test_device_run_length_encode_env_api.cu
@@ -24,10 +24,9 @@ C2H_TEST("cub::DeviceRunLengthEncode::Encode accepts env with stream", "[run_len
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceRunLengthEncode::Encode(
-    input.begin(), unique_out.begin(), counts_out.begin(), num_runs_out.begin(), input.size(), env);
+    input.begin(), unique_out.begin(), counts_out.begin(), num_runs_out.begin(), input.size(), stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceRunLengthEncode::Encode failed with status: " << error << '\n';
@@ -37,6 +36,7 @@ C2H_TEST("cub::DeviceRunLengthEncode::Encode accepts env with stream", "[run_len
   thrust::device_vector<int> expected_counts{1, 2, 1, 3, 1};
   thrust::device_vector<int> expected_num_runs{5};
   // example-end encode-env
+  stream.sync();
 
   REQUIRE(error == cudaSuccess);
   unique_out.resize(num_runs_out[0]);
@@ -56,10 +56,9 @@ C2H_TEST("cub::DeviceRunLengthEncode::NonTrivialRuns accepts env with stream", "
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceRunLengthEncode::NonTrivialRuns(
-    input.begin(), offsets_out.begin(), lengths_out.begin(), num_runs_out.begin(), input.size(), env);
+    input.begin(), offsets_out.begin(), lengths_out.begin(), num_runs_out.begin(), input.size(), stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceRunLengthEncode::NonTrivialRuns failed with status: " << error << '\n';
@@ -69,6 +68,7 @@ C2H_TEST("cub::DeviceRunLengthEncode::NonTrivialRuns accepts env with stream", "
   thrust::device_vector<int> expected_lengths{2, 3};
   thrust::device_vector<int> expected_num_runs{2};
   // example-end non-trivial-runs-env
+  stream.sync();
 
   REQUIRE(error == cudaSuccess);
   offsets_out.resize(num_runs_out[0]);


### PR DESCRIPTION
Handles https://github.com/NVIDIA/cccl/issues/8175 for

  - DeviceAdjacentDifference
  - DeviceCopy
  - DevicePartition
  - DeviceRunLengthEncode
  - DeviceFind

the most serious issues have to do with defaults in adjacentdifference and ambiguities they were created.

I chose to start introducing non-env api file tests to check that the non-env APIs work in their minimal form. That is when default args are not explicitly passed. These files will facilitate as ground for extracting the example snippets from non env overloads from doxygen to literalincludes later on.