### PR TITLE
docs: fix duplicated words in host_stub_visibility and permutation_iterator comments

### DIFF
--- a/docs/cccl/development/visibility/host_stub_visibility.rst
+++ b/docs/cccl/development/visibility/host_stub_visibility.rst
@@ -69,7 +69,7 @@ However, imagine that there are two shared libraries: ``lib_a`` and ``lib_b`` bo
     add_library(lib_b SHARED tu_b.cu)
     target_link_libraries(host_stub_visibility PRIVATE lib_a lib_b)
 
-Each library will have it's own fatbinary: ``d_kernel_a`` and ``d_kernel_b``, but the compiler
+Each library will have its own fatbinary: ``d_kernel_a`` and ``d_kernel_b``, but the compiler
 generated host stub function ``h_kernel`` has weak external linkage, so after dynamic linkage, we'll end up having
 only one of them.
 

--- a/docs/cccl/development/visibility/host_stub_visibility.rst
+++ b/docs/cccl/development/visibility/host_stub_visibility.rst
@@ -69,7 +69,7 @@ However, imagine that there are two shared libraries: ``lib_a`` and ``lib_b`` bo
     add_library(lib_b SHARED tu_b.cu)
     target_link_libraries(host_stub_visibility PRIVATE lib_a lib_b)
 
-Each library will have it's own fatbinary: ``d_kernel_a`` and ``d_kernel_b``, but the the compiler
+Each library will have it's own fatbinary: ``d_kernel_a`` and ``d_kernel_b``, but the compiler
 generated host stub function ``h_kernel`` has weak external linkage, so after dynamic linkage, we'll end up having
 only one of them.
 

--- a/libcudacxx/include/cuda/__iterator/permutation_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/permutation_iterator.h
@@ -164,7 +164,7 @@ public:
   {}
 
   //! @brief Constructs an @c permutation_iterator from an iterator and an optional index
-  //! @param __iter The iterator to to index from
+  //! @param __iter The iterator to index from
   //! @param __index The iterator with the permutations
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr permutation_iterator(_Iter __iter, _Index __index) noexcept(


### PR DESCRIPTION
Two one-line typo fixes for duplicated words:
- `docs/cccl/development/visibility/host_stub_visibility.rst` — "but the the compiler" → "but the compiler"
- `libcudacxx/include/cuda/__iterator/permutation_iterator.h` — "The iterator to to index from" → "The iterator to index from"

No code/behavior change.