### PR TITLE
Skip header testing for the NVTX3 header.

### DIFF
--- a/libcudacxx/cmake/LibcudacxxInternalHeaderTesting.cmake
+++ b/libcudacxx/cmake/LibcudacxxInternalHeaderTesting.cmake
@@ -31,6 +31,9 @@ list(FILTER internal_headers EXCLUDE REGEX "__cuda/*")
 # generated cuda::ptx headers are not standalone
 list(FILTER internal_headers EXCLUDE REGEX "__ptx/instructions/generated")
 
+# don't check nvtx3.h - it's not our header
+list(FILTER internal_headers EXCLUDE REGEX ".*/__nvtx/nvtx3.h")
+
 function(libcudacxx_add_internal_header_test_target target_name)
   if (NOT ARGN)
     return()


### PR DESCRIPTION
We bundle NVTX3, but since it's not our header and makes some assumptions about the platform we need to exclude it.

## Description

Some platforms do not yet have NVTX3 and our testing fails when we try to compile this header.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
