### PR TITLE
Drop override accum_t from reduce by key

### DIFF
--- a/cub/benchmarks/bench/reduce/by_key.cu
+++ b/cub/benchmarks/bench/reduce/by_key.cu
@@ -60,7 +60,7 @@ static void reduce(nvbench::state& state, nvbench::type_list<KeyT, ValueT, Offse
   const offset_t num_items = static_cast<offset_t>(elements);
 
   auto dispatch_on_stream = [&](cudaStream_t stream) {
-    return cub::detail::reduce_by_key::dispatch</* OverrideAccumT */ ValueT>(
+    return cub::detail::reduce_by_key::dispatch(
       d_temp_storage,
       temp_storage_bytes,
       d_in_keys,

--- a/cub/cub/device/device_run_length_encode.cuh
+++ b/cub/cub/device/device_run_length_encode.cuh
@@ -186,13 +186,11 @@ struct DeviceRunLengthEncode
     // Generator type for providing 1s values for run-length reduction
     using lengths_input_iterator_t = ::cuda::constant_iterator<length_t, offset_t>;
 
-    using accum_t = ::cuda::std::__accumulator_t<reduction_op, length_t, length_t>;
-
-    using key_t = cub::detail::non_void_value_t<UniqueOutputIteratorT, cub::detail::it_value_t<InputIteratorT>>;
-
+    using accum_t = ::cuda::std::__accumulator_t<reduction_op, length_t>;
+    using key_t   = cub::detail::non_void_value_t<UniqueOutputIteratorT, cub::detail::it_value_t<InputIteratorT>>;
     using policy_selector_t = detail::rle::encode::policy_selector_from_types<accum_t, key_t>;
 
-    return detail::reduce_by_key::dispatch_streaming</* OverrideAccumT */ accum_t>(
+    return detail::reduce_by_key::dispatch_streaming(
       d_temp_storage,
       temp_storage_bytes,
       d_in,
@@ -300,13 +298,13 @@ struct DeviceRunLengthEncode
     using offset_t                 = detail::choose_signed_offset_t<NumItemsT>;
     using length_t                 = cub::detail::non_void_value_t<LengthsOutputIteratorT, offset_t>;
     using lengths_input_iterator_t = ::cuda::constant_iterator<length_t, offset_t>;
-    using accum_t                  = ::cuda::std::__accumulator_t<reduction_op, length_t, length_t>;
+    using accum_t                  = ::cuda::std::__accumulator_t<reduction_op, length_t>;
     using key_t = cub::detail::non_void_value_t<UniqueOutputIteratorT, cub::detail::it_value_t<InputIteratorT>>;
     using default_policy_selector = detail::rle::encode::policy_selector_from_types<accum_t, key_t>;
 
     return detail::dispatch_with_env_and_tuning<default_policy_selector>(
       env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
-        return detail::reduce_by_key::dispatch_streaming<accum_t>(
+        return detail::reduce_by_key::dispatch_streaming(
           storage,
           bytes,
           d_in,

--- a/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
@@ -666,22 +666,17 @@ _CCCL_HOST_DEVICE_API auto determine_threads_items_vsmem(PolicyGetter policy_get
                             vsmem_helper_t::vsmem_per_block};
 }
 
-template <
-  typename OverrideAccumT = use_default,
-  typename KeysInputIteratorT,
-  typename UniqueOutputIteratorT,
-  typename ValuesInputIteratorT,
-  typename AggregatesOutputIteratorT,
-  typename NumRunsOutputIteratorT,
-  typename EqualityOpT,
-  typename ReductionOpT,
-  typename OffsetT,
-  typename AccumT = ::cuda::std::conditional_t<
-    !::cuda::std::is_same_v<OverrideAccumT, use_default>,
-    OverrideAccumT,
-    ::cuda::std::__accumulator_t<ReductionOpT, it_value_t<ValuesInputIteratorT>, it_value_t<ValuesInputIteratorT>>>,
-  typename KeyT           = non_void_value_t<UniqueOutputIteratorT, it_value_t<KeysInputIteratorT>>,
-  typename PolicySelector = policy_selector_from_types<ReductionOpT, AccumT, KeyT>>
+template <typename KeysInputIteratorT,
+          typename UniqueOutputIteratorT,
+          typename ValuesInputIteratorT,
+          typename AggregatesOutputIteratorT,
+          typename NumRunsOutputIteratorT,
+          typename EqualityOpT,
+          typename ReductionOpT,
+          typename OffsetT,
+          typename AccumT         = ::cuda::std::__accumulator_t<ReductionOpT, it_value_t<ValuesInputIteratorT>>,
+          typename KeyT           = non_void_value_t<UniqueOutputIteratorT, it_value_t<KeysInputIteratorT>>,
+          typename PolicySelector = policy_selector_from_types<ReductionOpT, AccumT, KeyT>>
 #if _CCCL_HAS_CONCEPTS()
   requires reduce_by_key::reduce_by_key_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()

--- a/cub/cub/device/dispatch/dispatch_streaming_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_streaming_reduce_by_key.cuh
@@ -32,24 +32,19 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail::reduce_by_key
 {
-template <
-  typename OverrideAccumT = use_default,
-  typename KeysInputIteratorT,
-  typename UniqueOutputIteratorT,
-  typename ValuesInputIteratorT,
-  typename AggregatesOutputIteratorT,
-  typename NumRunsOutputIteratorT,
-  typename EqualityOpT,
-  typename ReductionOpT,
-  typename OffsetT,
-  typename AccumT = ::cuda::std::conditional_t<
-    !::cuda::std::is_same_v<OverrideAccumT, use_default>,
-    OverrideAccumT,
-    ::cuda::std::__accumulator_t<ReductionOpT, it_value_t<ValuesInputIteratorT>, it_value_t<ValuesInputIteratorT>>>,
-  typename PolicySelector =
-    policy_selector_from_types<ReductionOpT,
-                               AccumT,
-                               non_void_value_t<UniqueOutputIteratorT, it_value_t<KeysInputIteratorT>>>>
+template <typename KeysInputIteratorT,
+          typename UniqueOutputIteratorT,
+          typename ValuesInputIteratorT,
+          typename AggregatesOutputIteratorT,
+          typename NumRunsOutputIteratorT,
+          typename EqualityOpT,
+          typename ReductionOpT,
+          typename OffsetT,
+          typename AccumT = ::cuda::std::__accumulator_t<ReductionOpT, it_value_t<ValuesInputIteratorT>>,
+          typename PolicySelector =
+            policy_selector_from_types<ReductionOpT,
+                                       AccumT,
+                                       non_void_value_t<UniqueOutputIteratorT, it_value_t<KeysInputIteratorT>>>>
 #if _CCCL_HAS_CONCEPTS()
   requires reduce_by_key_policy_selector<PolicySelector>
 #endif


### PR DESCRIPTION
This PR has the same motivation and goal as #8884 but for `reduce_by_key`.

- [x] Benchmark performance impact on `cub.bench.reduce.by_key.base`

Expected baseline shift. Notice that this PR does not change the performance of any CUB algorithm. It just redefines the benchmark.
```
## [0] NVIDIA H200

|  KeyT{ct}  |  ValueT{ct}  |  OffsetT{ct}  |  Elements{io}  |  MaxSegSize  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|------------|--------------|---------------|----------------|--------------|------------|-------------|------------|-------------|-------------|---------|----------|
|     I8     |      I8      |      I32      |      2^16      |     2^1      |   8.724 us |       5.68% |   9.004 us |       5.46% |    0.280 us |   3.20% |  🔵 SAME  |
|     I8     |      I8      |      I32      |      2^20      |     2^1      |  12.076 us |       3.47% |  12.234 us |       3.31% |    0.158 us |   1.31% |  🔵 SAME  |
|     I8     |      I8      |      I32      |      2^24      |     2^1      |  69.090 us |       1.06% |  68.337 us |       0.95% |   -0.753 us |  -1.09% |  🟢 FAST  |
|     I8     |      I8      |      I32      |      2^28      |     2^1      | 975.643 us |       0.44% | 952.048 us |       0.37% |  -23.595 us |  -2.42% |  🟢 FAST  |
|     I8     |      I8      |      I32      |      2^16      |     2^4      |   8.812 us |       6.18% |   9.008 us |       5.78% |    0.196 us |   2.22% |  🔵 SAME  |
|     I8     |      I8      |      I32      |      2^20      |     2^4      |  11.737 us |       4.34% |  11.722 us |       4.57% |   -0.016 us |  -0.13% |  🔵 SAME  |
|     I8     |      I8      |      I32      |      2^24      |     2^4      |  63.581 us |       1.05% |  57.427 us |       1.15% |   -6.154 us |  -9.68% |  🟢 FAST  |
|     I8     |      I8      |      I32      |      2^28      |     2^4      | 874.694 us |       0.27% | 765.042 us |       0.29% | -109.652 us | -12.54% |  🟢 FAST  |
|     I8     |      I8      |      I32      |      2^16      |     2^8      |   8.842 us |       4.96% |   8.826 us |       4.60% |   -0.016 us |  -0.18% |  🔵 SAME  |
|     I8     |      I8      |      I32      |      2^20      |     2^8      |  11.572 us |       4.69% |  11.591 us |       4.87% |    0.018 us |   0.16% |  🔵 SAME  |
|     I8     |      I8      |      I32      |      2^24      |     2^8      |  63.121 us |       1.02% |  56.236 us |       1.26% |   -6.886 us | -10.91% |  🟢 FAST  |
|     I8     |      I8      |      I32      |      2^28      |     2^8      | 866.027 us |       0.28% | 742.169 us |       0.33% | -123.858 us | -14.30% |  🟢 FAST  |
|     I8     |     I16      |      I32      |      2^16      |     2^1      |  10.912 us |       3.59% |   9.141 us |       4.82% |   -1.771 us | -16.23% |  🟢 FAST  |
|     I8     |     I16      |      I32      |      2^20      |     2^1      |  16.550 us |       3.65% |  12.464 us |       4.33% |   -4.086 us | -24.69% |  🟢 FAST  |
|     I8     |     I16      |      I32      |      2^24      |     2^1      | 100.627 us |       0.72% |  71.102 us |       0.99% |  -29.525 us | -29.34% |  🟢 FAST  |
|     I8     |     I16      |      I32      |      2^28      |     2^1      |   1.443 ms |       0.18% | 989.093 us |       0.46% | -453.466 us | -31.43% |  🟢 FAST  |
|     I8     |     I16      |      I32      |      2^16      |     2^4      |  10.189 us |       3.72% |   8.811 us |       4.72% |   -1.378 us | -13.52% |  🟢 FAST  |
|     I8     |     I16      |      I32      |      2^20      |     2^4      |  14.939 us |       2.99% |  11.840 us |       3.86% |   -3.099 us | -20.75% |  🟢 FAST  |
|     I8     |     I16      |      I32      |      2^24      |     2^4      |  83.905 us |       0.96% |  59.646 us |       1.35% |  -24.258 us | -28.91% |  🟢 FAST  |
|     I8     |     I16      |      I32      |      2^28      |     2^4      |   1.163 ms |       0.17% | 786.586 us |       0.35% | -376.716 us | -32.38% |  🟢 FAST  |
|     I8     |     I16      |      I32      |      2^16      |     2^8      |  10.142 us |       5.46% |   9.195 us |       6.12% |   -0.947 us |  -9.34% |  🟢 FAST  |
|     I8     |     I16      |      I32      |      2^20      |     2^8      |  14.929 us |       2.86% |  12.538 us |       3.70% |   -2.391 us | -16.02% |  🟢 FAST  |
|     I8     |     I16      |      I32      |      2^24      |     2^8      |  82.716 us |       0.94% |  62.081 us |       1.40% |  -20.635 us | -24.95% |  🟢 FAST  |
|     I8     |     I16      |      I32      |      2^28      |     2^8      |   1.153 ms |       0.11% | 789.041 us |       0.38% | -363.610 us | -31.55% |  🟢 FAST  |
|     I8     |     I32      |      I32      |      2^16      |     2^1      |   9.174 us |       5.71% |   9.196 us |       5.52% |    0.022 us |   0.24% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^20      |     2^1      |  12.738 us |       3.07% |  12.728 us |       3.01% |   -0.010 us |  -0.08% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^24      |     2^1      |  76.260 us |       1.34% |  76.199 us |       1.29% |   -0.061 us |  -0.08% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^28      |     2^1      |   1.057 ms |       0.62% |   1.057 ms |       0.60% |   -0.099 us |  -0.01% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^16      |     2^4      |   8.587 us |       5.54% |   8.585 us |       5.55% |   -0.002 us |  -0.02% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^20      |     2^4      |  12.015 us |       3.47% |  12.003 us |       3.39% |   -0.012 us |  -0.10% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^24      |     2^4      |  62.007 us |       1.49% |  62.090 us |       1.48% |    0.083 us |   0.13% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^28      |     2^4      | 812.153 us |       0.38% | 811.863 us |       0.37% |   -0.290 us |  -0.04% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^16      |     2^8      |   9.043 us |       5.45% |   9.012 us |       5.44% |   -0.031 us |  -0.35% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^20      |     2^8      |  12.710 us |       4.52% |  12.682 us |       4.18% |   -0.028 us |  -0.22% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^24      |     2^8      |  63.717 us |       1.33% |  63.782 us |       1.35% |    0.065 us |   0.10% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^28      |     2^8      | 804.528 us |       0.43% | 804.534 us |       0.43% |    0.006 us |   0.00% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^16      |     2^1      |   9.455 us |       4.13% |   9.487 us |       4.11% |    0.032 us |   0.33% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^20      |     2^1      |  15.606 us |       3.39% |  15.622 us |       3.34% |    0.016 us |   0.10% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^24      |     2^1      | 114.627 us |       0.85% | 114.559 us |       0.85% |   -0.069 us |  -0.06% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^28      |     2^1      |   1.655 ms |       0.42% |   1.656 ms |       0.44% |    0.373 us |   0.02% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^16      |     2^4      |   9.137 us |       4.48% |   9.131 us |       4.58% |   -0.007 us |  -0.07% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^20      |     2^4      |  13.822 us |       3.68% |  13.792 us |       3.56% |   -0.031 us |  -0.22% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^24      |     2^4      |  85.566 us |       1.02% |  85.583 us |       1.03% |    0.017 us |   0.02% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^28      |     2^4      |   1.173 ms |       0.28% |   1.173 ms |       0.29% |   -0.023 us |  -0.00% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^16      |     2^8      |   9.040 us |       4.57% |   9.049 us |       4.81% |    0.010 us |   0.11% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^20      |     2^8      |  13.595 us |       3.09% |  13.594 us |       3.07% |   -0.001 us |  -0.01% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^24      |     2^8      |  80.937 us |       1.11% |  81.080 us |       1.12% |    0.143 us |   0.18% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^28      |     2^8      |   1.087 ms |       0.35% |   1.086 ms |       0.35% |   -0.082 us |  -0.01% |  🔵 SAME  |
|     I8     |     I128     |      I32      |      2^16      |     2^1      |  12.392 us |       3.68% |  12.396 us |       3.87% |    0.004 us |   0.03% |  🔵 SAME  |
|     I8     |     I128     |      I32      |      2^20      |     2^1      |  30.098 us |       1.87% |  30.062 us |       2.05% |   -0.036 us |  -0.12% |  🔵 SAME  |
|     I8     |     I128     |      I32      |      2^24      |     2^1      | 287.320 us |       0.44% | 287.366 us |       0.44% |    0.045 us |   0.02% |  🔵 SAME  |
|     I8     |     I128     |      I32      |      2^28      |     2^1      |   4.399 ms |       0.17% |   4.399 ms |       0.18% |    0.157 us |   0.00% |  🔵 SAME  |
|     I8     |     I128     |      I32      |      2^16      |     2^4      |  11.785 us |       4.20% |  11.818 us |       4.49% |    0.032 us |   0.28% |  🔵 SAME  |
|     I8     |     I128     |      I32      |      2^20      |     2^4      |  26.762 us |       2.43% |  26.701 us |       2.30% |   -0.061 us |  -0.23% |  🔵 SAME  |
|     I8     |     I128     |      I32      |      2^24      |     2^4      | 237.107 us |       0.43% | 237.149 us |       0.43% |    0.043 us |   0.02% |  🔵 SAME  |
|     I8     |     I128     |      I32      |      2^28      |     2^4      |   3.597 ms |       0.10% |   3.597 ms |       0.10% |    0.321 us |   0.01% |  🔵 SAME  |
|     I8     |     I128     |      I32      |      2^16      |     2^8      |  11.650 us |       3.78% |  11.650 us |       3.80% |   -0.000 us |  -0.00% |  🔵 SAME  |
|     I8     |     I128     |      I32      |      2^20      |     2^8      |  26.220 us |       2.65% |  26.215 us |       2.45% |   -0.004 us |  -0.02% |  🔵 SAME  |
|     I8     |     I128     |      I32      |      2^24      |     2^8      | 229.260 us |       0.43% | 229.305 us |       0.42% |    0.045 us |   0.02% |  🔵 SAME  |
|     I8     |     I128     |      I32      |      2^28      |     2^8      |   3.464 ms |       0.10% |   3.465 ms |       0.10% |    0.214 us |   0.01% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^16      |     2^1      |   9.069 us |       4.64% |   9.062 us |       4.48% |   -0.007 us |  -0.08% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^20      |     2^1      |  12.895 us |       3.19% |  12.927 us |       3.31% |    0.032 us |   0.25% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^24      |     2^1      |  82.981 us |       1.13% |  82.994 us |       1.11% |    0.013 us |   0.02% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^28      |     2^1      |   1.168 ms |       0.55% |   1.168 ms |       0.53% |    0.036 us |   0.00% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^16      |     2^4      |   8.667 us |       5.51% |   8.657 us |       5.45% |   -0.010 us |  -0.12% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^20      |     2^4      |  12.128 us |       4.03% |  12.135 us |       4.15% |    0.007 us |   0.06% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^24      |     2^4      |  68.318 us |       1.29% |  68.393 us |       1.35% |    0.075 us |   0.11% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^28      |     2^4      | 916.390 us |       0.36% | 916.279 us |       0.36% |   -0.111 us |  -0.01% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^16      |     2^8      |   8.643 us |       4.56% |   8.644 us |       4.67% |    0.001 us |   0.01% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^20      |     2^8      |  12.083 us |       4.04% |  12.096 us |       4.02% |    0.013 us |   0.10% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^24      |     2^8      |  66.575 us |       1.29% |  66.568 us |       1.43% |   -0.007 us |  -0.01% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^28      |     2^8      | 876.343 us |       0.41% | 876.455 us |       0.39% |    0.111 us |   0.01% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^16      |     2^1      |   9.557 us |       4.26% |   9.551 us |       4.30% |   -0.007 us |  -0.07% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^20      |     2^1      |  15.901 us |       3.22% |  15.918 us |       3.31% |    0.017 us |   0.11% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^24      |     2^1      | 123.483 us |       0.70% | 123.566 us |       0.70% |    0.083 us |   0.07% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^28      |     2^1      |   1.802 ms |       0.39% |   1.802 ms |       0.41% |   -0.002 us |  -0.00% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^16      |     2^4      |   9.092 us |       4.12% |   9.108 us |       4.63% |    0.016 us |   0.18% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^20      |     2^4      |  14.017 us |       3.65% |  14.067 us |       3.70% |    0.050 us |   0.36% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^24      |     2^4      |  93.760 us |       0.87% |  93.777 us |       0.87% |    0.017 us |   0.02% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^28      |     2^4      |   1.311 ms |       0.24% |   1.311 ms |       0.25% |   -0.058 us |  -0.00% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^16      |     2^8      |   9.062 us |       4.55% |   9.078 us |       4.41% |    0.016 us |   0.18% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^20      |     2^8      |  13.908 us |       3.27% |  13.883 us |       3.27% |   -0.025 us |  -0.18% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^24      |     2^8      |  88.925 us |       0.95% |  88.941 us |       0.99% |    0.015 us |   0.02% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^28      |     2^8      |   1.220 ms |       0.27% |   1.220 ms |       0.29% |    0.243 us |   0.02% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^16      |     2^1      |   9.056 us |       5.28% |   9.058 us |       5.27% |    0.001 us |   0.01% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^20      |     2^1      |  16.857 us |       2.68% |  16.862 us |       2.58% |    0.005 us |   0.03% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^24      |     2^1      | 137.507 us |       0.61% | 137.419 us |       0.62% |   -0.088 us |  -0.06% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^28      |     2^1      |   2.049 ms |       0.42% |   2.049 ms |       0.40% |   -0.183 us |  -0.01% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^16      |     2^4      |   8.837 us |       5.48% |   8.834 us |       5.31% |   -0.003 us |  -0.04% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^20      |     2^4      |  15.783 us |       3.60% |  15.764 us |       3.65% |   -0.018 us |  -0.12% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^24      |     2^4      | 114.770 us |       0.72% | 114.694 us |       0.72% |   -0.075 us |  -0.07% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^28      |     2^4      |   1.664 ms |       0.23% |   1.664 ms |       0.17% |   -0.098 us |  -0.01% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^16      |     2^8      |   9.210 us |       4.86% |   9.253 us |       5.48% |    0.043 us |   0.46% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^20      |     2^8      |  15.554 us |       3.03% |  15.547 us |       3.07% |   -0.007 us |  -0.05% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^24      |     2^8      | 108.914 us |       0.74% | 108.905 us |       0.72% |   -0.009 us |  -0.01% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^28      |     2^8      |   1.555 ms |       0.14% |   1.555 ms |       0.15% |    0.019 us |   0.00% |  🔵 SAME  |
|    I16     |      I8      |      I32      |      2^16      |     2^1      |   9.545 us |       5.45% |   9.411 us |       5.72% |   -0.135 us |  -1.41% |  🔵 SAME  |
|    I16     |      I8      |      I32      |      2^20      |     2^1      |  13.345 us |       4.03% |  13.200 us |       4.41% |   -0.145 us |  -1.08% |  🔵 SAME  |
|    I16     |      I8      |      I32      |      2^24      |     2^1      |  77.823 us |       1.18% |  71.548 us |       0.79% |   -6.275 us |  -8.06% |  🟢 FAST  |
|    I16     |      I8      |      I32      |      2^28      |     2^1      |   1.090 ms |       0.53% | 983.399 us |       0.39% | -106.769 us |  -9.79% |  🟢 FAST  |
|    I16     |      I8      |      I32      |      2^16      |     2^4      |   9.221 us |       4.75% |   8.899 us |       4.85% |   -0.322 us |  -3.49% |  🔵 SAME  |
|    I16     |      I8      |      I32      |      2^20      |     2^4      |  12.452 us |       3.54% |  11.903 us |       3.55% |   -0.549 us |  -4.41% |  🟢 FAST  |
|    I16     |      I8      |      I32      |      2^24      |     2^4      |  65.243 us |       1.35% |  57.228 us |       1.08% |   -8.015 us | -12.28% |  🟢 FAST  |
|    I16     |      I8      |      I32      |      2^28      |     2^4      | 872.589 us |       0.34% | 746.511 us |       0.22% | -126.078 us | -14.45% |  🟢 FAST  |
|    I16     |      I8      |      I32      |      2^16      |     2^8      |   9.138 us |       5.41% |   8.842 us |       5.66% |   -0.297 us |  -3.24% |  🔵 SAME  |
|    I16     |      I8      |      I32      |      2^20      |     2^8      |  12.420 us |       3.47% |  11.857 us |       3.80% |   -0.563 us |  -4.53% |  🟢 FAST  |
|    I16     |      I8      |      I32      |      2^24      |     2^8      |  64.563 us |       1.51% |  56.078 us |       1.17% |   -8.485 us | -13.14% |  🟢 FAST  |
|    I16     |      I8      |      I32      |      2^28      |     2^8      | 846.000 us |       0.36% | 717.820 us |       0.29% | -128.180 us | -15.15% |  🟢 FAST  |
|    I16     |     I16      |      I32      |      2^16      |     2^1      |   8.867 us |       6.22% |   9.365 us |       5.96% |    0.499 us |   5.62% |  🔵 SAME  |
|    I16     |     I16      |      I32      |      2^20      |     2^1      |  13.064 us |       3.58% |  13.688 us |       3.23% |    0.623 us |   4.77% |  🔴 SLOW  |
|    I16     |     I16      |      I32      |      2^24      |     2^1      |  75.741 us |       0.91% |  83.828 us |       0.80% |    8.087 us |  10.68% |  🔴 SLOW  |
|    I16     |     I16      |      I32      |      2^28      |     2^1      |   1.049 ms |       0.42% |   1.179 ms |       0.36% |  130.538 us |  12.45% |  🔴 SLOW  |
|    I16     |     I16      |      I32      |      2^16      |     2^4      |   8.775 us |       6.04% |   8.909 us |       5.92% |    0.134 us |   1.53% |  🔵 SAME  |
|    I16     |     I16      |      I32      |      2^20      |     2^4      |  12.559 us |       3.80% |  12.217 us |       3.91% |   -0.342 us |  -2.72% |  🔵 SAME  |
|    I16     |     I16      |      I32      |      2^24      |     2^4      |  68.963 us |       0.82% |  67.595 us |       0.96% |   -1.368 us |  -1.98% |  🟢 FAST  |
|    I16     |     I16      |      I32      |      2^28      |     2^4      | 934.627 us |       0.16% | 911.458 us |       0.20% |  -23.169 us |  -2.48% |  🟢 FAST  |
|    I16     |     I16      |      I32      |      2^16      |     2^8      |   8.751 us |       5.96% |   8.901 us |       6.03% |    0.150 us |   1.72% |  🔵 SAME  |
|    I16     |     I16      |      I32      |      2^20      |     2^8      |  12.469 us |       4.33% |  12.111 us |       4.21% |   -0.357 us |  -2.86% |  🔵 SAME  |
|    I16     |     I16      |      I32      |      2^24      |     2^8      |  67.666 us |       0.78% |  65.518 us |       0.87% |   -2.148 us |  -3.17% |  🟢 FAST  |
|    I16     |     I16      |      I32      |      2^28      |     2^8      | 907.459 us |       0.21% | 860.287 us |       0.31% |  -47.172 us |  -5.20% |  🟢 FAST  |
|    I16     |     I32      |      I32      |      2^16      |     2^1      |   9.557 us |       4.12% |   9.562 us |       4.39% |    0.004 us |   0.05% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^20      |     2^1      |  13.906 us |       2.92% |  13.914 us |       2.98% |    0.008 us |   0.06% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^24      |     2^1      |  88.160 us |       0.88% |  88.157 us |       1.01% |   -0.003 us |  -0.00% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^28      |     2^1      |   1.239 ms |       0.48% |   1.239 ms |       0.48% |   -0.040 us |  -0.00% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^16      |     2^4      |   8.661 us |       5.40% |   8.664 us |       5.38% |    0.003 us |   0.04% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^20      |     2^4      |  12.331 us |       3.83% |  12.322 us |       3.84% |   -0.009 us |  -0.07% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^24      |     2^4      |  69.200 us |       0.86% |  69.188 us |       0.92% |   -0.012 us |  -0.02% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^28      |     2^4      | 923.188 us |       0.26% | 923.019 us |       0.22% |   -0.170 us |  -0.02% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^16      |     2^8      |   8.609 us |       4.44% |   8.615 us |       4.53% |    0.006 us |   0.07% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^20      |     2^8      |  12.186 us |       2.98% |  12.208 us |       3.13% |    0.022 us |   0.18% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^24      |     2^8      |  66.348 us |       1.02% |  66.378 us |       1.04% |    0.030 us |   0.05% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^28      |     2^8      | 864.456 us |       0.36% | 864.570 us |       0.37% |    0.114 us |   0.01% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^16      |     2^1      |   9.902 us |       5.05% |   9.887 us |       5.07% |   -0.015 us |  -0.16% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^20      |     2^1      |  16.351 us |       2.95% |  16.343 us |       3.01% |   -0.008 us |  -0.05% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^24      |     2^1      | 118.770 us |       0.79% | 118.739 us |       0.78% |   -0.031 us |  -0.03% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^28      |     2^1      |   1.704 ms |       0.43% |   1.704 ms |       0.42% |   -0.126 us |  -0.01% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^16      |     2^4      |   9.324 us |       4.43% |   9.307 us |       4.27% |   -0.017 us |  -0.18% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^20      |     2^4      |  14.166 us |       3.43% |  14.155 us |       3.42% |   -0.011 us |  -0.08% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^24      |     2^4      |  90.855 us |       0.87% |  90.938 us |       0.86% |    0.082 us |   0.09% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^28      |     2^4      |   1.248 ms |       0.22% |   1.248 ms |       0.23% |    0.125 us |   0.01% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^16      |     2^8      |   9.181 us |       4.32% |   9.153 us |       4.32% |   -0.028 us |  -0.31% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^20      |     2^8      |  13.896 us |       3.47% |  13.924 us |       3.60% |    0.028 us |   0.20% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^24      |     2^8      |  85.696 us |       0.99% |  85.743 us |       0.92% |    0.047 us |   0.05% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^28      |     2^8      |   1.152 ms |       0.32% |   1.151 ms |       0.31% |   -0.109 us |  -0.01% |  🔵 SAME  |
|    I16     |     I128     |      I32      |      2^16      |     2^1      |  12.451 us |       3.53% |  12.404 us |       3.25% |   -0.046 us |  -0.37% |  🔵 SAME  |
|    I16     |     I128     |      I32      |      2^20      |     2^1      |  30.385 us |       2.03% |  30.339 us |       1.98% |   -0.046 us |  -0.15% |  🔵 SAME  |
|    I16     |     I128     |      I32      |      2^24      |     2^1      | 291.778 us |       0.43% | 291.690 us |       0.43% |   -0.089 us |  -0.03% |  🔵 SAME  |
|    I16     |     I128     |      I32      |      2^28      |     2^1      |   4.467 ms |       0.17% |   4.467 ms |       0.16% |   -0.062 us |  -0.00% |  🔵 SAME  |
|    I16     |     I128     |      I32      |      2^16      |     2^4      |  11.853 us |       4.43% |  11.788 us |       4.57% |   -0.065 us |  -0.55% |  🔵 SAME  |
|    I16     |     I128     |      I32      |      2^20      |     2^4      |  27.010 us |       2.32% |  26.954 us |       2.19% |   -0.057 us |  -0.21% |  🔵 SAME  |
|    I16     |     I128     |      I32      |      2^24      |     2^4      | 239.230 us |       0.46% | 239.167 us |       0.43% |   -0.063 us |  -0.03% |  🔵 SAME  |
|    I16     |     I128     |      I32      |      2^28      |     2^4      |   3.625 ms |       0.10% |   3.625 ms |       0.10% |   -0.197 us |  -0.01% |  🔵 SAME  |
|    I16     |     I128     |      I32      |      2^16      |     2^8      |  11.724 us |       4.58% |  11.677 us |       5.00% |   -0.047 us |  -0.40% |  🔵 SAME  |
|    I16     |     I128     |      I32      |      2^20      |     2^8      |  26.735 us |       2.49% |  26.718 us |       2.61% |   -0.017 us |  -0.06% |  🔵 SAME  |
|    I16     |     I128     |      I32      |      2^24      |     2^8      | 231.536 us |       0.47% | 231.490 us |       0.45% |   -0.046 us |  -0.02% |  🔵 SAME  |
|    I16     |     I128     |      I32      |      2^28      |     2^8      |   3.492 ms |       0.10% |   3.492 ms |       0.10% |   -0.173 us |  -0.00% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^16      |     2^1      |   9.669 us |       5.33% |   9.680 us |       4.84% |    0.011 us |   0.12% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^20      |     2^1      |  14.276 us |       3.19% |  14.267 us |       3.03% |   -0.010 us |  -0.07% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^24      |     2^1      |  79.878 us |       1.10% |  79.868 us |       1.10% |   -0.010 us |  -0.01% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^28      |     2^1      |   1.095 ms |       0.57% |   1.094 ms |       0.53% |   -0.100 us |  -0.01% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^16      |     2^4      |   8.994 us |       5.85% |   9.049 us |       5.80% |    0.056 us |   0.62% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^20      |     2^4      |  12.759 us |       4.30% |  12.775 us |       4.12% |    0.016 us |   0.13% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^24      |     2^4      |  61.381 us |       1.16% |  61.393 us |       1.15% |    0.012 us |   0.02% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^28      |     2^4      | 780.230 us |       0.33% | 780.302 us |       0.29% |    0.072 us |   0.01% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^16      |     2^8      |   9.053 us |       5.27% |   9.034 us |       5.26% |   -0.019 us |  -0.21% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^20      |     2^8      |  12.634 us |       3.32% |  12.607 us |       3.50% |   -0.027 us |  -0.21% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^24      |     2^8      |  58.940 us |       1.24% |  59.010 us |       1.18% |    0.069 us |   0.12% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^28      |     2^8      | 732.314 us |       0.38% | 732.559 us |       0.36% |    0.245 us |   0.03% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^16      |     2^1      |  10.100 us |       5.16% |  10.105 us |       5.20% |    0.005 us |   0.05% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^20      |     2^1      |  16.672 us |       2.80% |  16.661 us |       2.69% |   -0.011 us |  -0.07% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^24      |     2^1      | 119.105 us |       0.90% | 119.058 us |       0.90% |   -0.047 us |  -0.04% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^28      |     2^1      |   1.706 ms |       0.43% |   1.706 ms |       0.43% |    0.090 us |   0.01% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^16      |     2^4      |   9.536 us |       5.95% |   9.548 us |       5.97% |    0.012 us |   0.12% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^20      |     2^4      |  14.546 us |       3.75% |  14.525 us |       3.67% |   -0.021 us |  -0.15% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^24      |     2^4      |  91.303 us |       0.89% |  91.293 us |       0.93% |   -0.010 us |  -0.01% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^28      |     2^4      |   1.251 ms |       0.22% |   1.251 ms |       0.21% |   -0.125 us |  -0.01% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^16      |     2^8      |   9.442 us |       4.80% |   9.423 us |       4.91% |   -0.019 us |  -0.20% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^20      |     2^8      |  14.327 us |       3.83% |  14.334 us |       3.90% |    0.007 us |   0.05% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^24      |     2^8      |  86.249 us |       0.92% |  86.279 us |       0.97% |    0.030 us |   0.03% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^28      |     2^8      |   1.159 ms |       0.29% |   1.159 ms |       0.32% |    0.053 us |   0.00% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^16      |     2^1      |   9.474 us |       4.87% |   9.430 us |       4.78% |   -0.045 us |  -0.47% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^20      |     2^1      |  18.140 us |       3.45% |  18.139 us |       3.39% |   -0.001 us |  -0.01% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^24      |     2^1      | 145.578 us |       0.70% | 145.567 us |       0.71% |   -0.011 us |  -0.01% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^28      |     2^1      |   2.172 ms |       0.43% |   2.172 ms |       0.45% |   -0.058 us |  -0.00% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^16      |     2^4      |   9.138 us |       4.62% |   9.140 us |       4.79% |    0.002 us |   0.03% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^20      |     2^4      |  16.497 us |       3.20% |  16.503 us |       3.14% |    0.006 us |   0.03% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^24      |     2^4      | 119.853 us |       0.88% | 119.809 us |       0.84% |   -0.044 us |  -0.04% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^28      |     2^4      |   1.741 ms |       0.20% |   1.741 ms |       0.21% |   -0.036 us |  -0.00% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^16      |     2^8      |   9.080 us |       6.33% |   9.102 us |       6.49% |    0.022 us |   0.24% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^20      |     2^8      |  16.194 us |       3.12% |  16.191 us |       3.00% |   -0.004 us |  -0.02% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^24      |     2^8      | 112.110 us |       0.80% | 112.089 us |       0.82% |   -0.022 us |  -0.02% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^28      |     2^8      |   1.602 ms |       0.17% |   1.602 ms |       0.16% |    0.093 us |   0.01% |  🔵 SAME  |
|    I32     |      I8      |      I32      |      2^16      |     2^1      |   9.514 us |       5.77% |   9.707 us |       5.38% |    0.193 us |   2.03% |  🔵 SAME  |
|    I32     |      I8      |      I32      |      2^20      |     2^1      |  14.326 us |       3.15% |  13.321 us |       3.35% |   -1.005 us |  -7.01% |  🟢 FAST  |
|    I32     |      I8      |      I32      |      2^24      |     2^1      |  81.957 us |       0.95% |  76.171 us |       1.38% |   -5.786 us |  -7.06% |  🟢 FAST  |
|    I32     |      I8      |      I32      |      2^28      |     2^1      |   1.135 ms |       0.44% |   1.018 ms |       0.57% | -116.290 us | -10.25% |  🟢 FAST  |
|    I32     |      I8      |      I32      |      2^16      |     2^4      |   9.086 us |       5.96% |   9.444 us |       6.24% |    0.358 us |   3.94% |  🔵 SAME  |
|    I32     |      I8      |      I32      |      2^20      |     2^4      |  13.015 us |       3.60% |  12.268 us |       3.84% |   -0.747 us |  -5.74% |  🟢 FAST  |
|    I32     |      I8      |      I32      |      2^24      |     2^4      |  65.384 us |       1.07% |  63.247 us |       1.76% |   -2.136 us |  -3.27% |  🟢 FAST  |
|    I32     |      I8      |      I32      |      2^28      |     2^4      | 853.604 us |       0.24% | 795.823 us |       0.38% |  -57.781 us |  -6.77% |  🟢 FAST  |
|    I32     |      I8      |      I32      |      2^16      |     2^8      |   9.100 us |       5.99% |   9.449 us |       5.78% |    0.348 us |   3.83% |  🔵 SAME  |
|    I32     |      I8      |      I32      |      2^20      |     2^8      |  12.901 us |       4.20% |  12.301 us |       4.24% |   -0.600 us |  -4.65% |  🟢 FAST  |
|    I32     |      I8      |      I32      |      2^24      |     2^8      |  63.279 us |       1.06% |  62.247 us |       1.62% |   -1.032 us |  -1.63% |  🟢 FAST  |
|    I32     |      I8      |      I32      |      2^28      |     2^8      | 817.834 us |       0.26% | 762.875 us |       0.46% |  -54.959 us |  -6.72% |  🟢 FAST  |
|    I32     |     I16      |      I32      |      2^16      |     2^1      |  10.236 us |       4.60% |   9.745 us |       4.60% |   -0.490 us |  -4.79% |  🟢 FAST  |
|    I32     |     I16      |      I32      |      2^20      |     2^1      |  14.242 us |       3.12% |  13.616 us |       3.21% |   -0.627 us |  -4.40% |  🟢 FAST  |
|    I32     |     I16      |      I32      |      2^24      |     2^1      |  89.203 us |       1.57% |  80.552 us |       1.33% |   -8.651 us |  -9.70% |  🟢 FAST  |
|    I32     |     I16      |      I32      |      2^28      |     2^1      |   1.242 ms |       0.63% |   1.081 ms |       0.63% | -161.379 us | -12.99% |  🟢 FAST  |
|    I32     |     I16      |      I32      |      2^16      |     2^4      |   9.442 us |       6.17% |   9.346 us |       5.87% |   -0.096 us |  -1.02% |  🔵 SAME  |
|    I32     |     I16      |      I32      |      2^20      |     2^4      |  12.730 us |       4.42% |  12.327 us |       4.44% |   -0.403 us |  -3.16% |  🔵 SAME  |
|    I32     |     I16      |      I32      |      2^24      |     2^4      |  68.143 us |       1.70% |  64.331 us |       1.45% |   -3.811 us |  -5.59% |  🟢 FAST  |
|    I32     |     I16      |      I32      |      2^28      |     2^4      | 886.410 us |       0.40% | 816.989 us |       0.41% |  -69.421 us |  -7.83% |  🟢 FAST  |
|    I32     |     I16      |      I32      |      2^16      |     2^8      |   9.411 us |       4.58% |   9.340 us |       4.97% |   -0.070 us |  -0.75% |  🔵 SAME  |
|    I32     |     I16      |      I32      |      2^20      |     2^8      |  12.660 us |       3.49% |  12.412 us |       3.62% |   -0.248 us |  -1.96% |  🔵 SAME  |
|    I32     |     I16      |      I32      |      2^24      |     2^8      |  65.694 us |       1.85% |  63.120 us |       1.84% |   -2.574 us |  -3.92% |  🟢 FAST  |
|    I32     |     I16      |      I32      |      2^28      |     2^8      | 830.751 us |       0.53% | 774.228 us |       0.55% |  -56.523 us |  -6.80% |  🟢 FAST  |
|    I32     |     I32      |      I32      |      2^16      |     2^1      |   9.836 us |       5.89% |   9.846 us |       5.90% |    0.010 us |   0.10% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^20      |     2^1      |  14.008 us |       3.61% |  13.973 us |       3.63% |   -0.035 us |  -0.25% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^24      |     2^1      |  86.890 us |       1.72% |  87.012 us |       1.65% |    0.122 us |   0.14% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^28      |     2^1      |   1.191 ms |       0.75% |   1.188 ms |       0.74% |   -3.138 us |  -0.26% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^16      |     2^4      |   9.160 us |       4.28% |   9.168 us |       4.27% |    0.008 us |   0.09% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^20      |     2^4      |  12.540 us |       4.12% |  12.529 us |       4.10% |   -0.011 us |  -0.09% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^24      |     2^4      |  66.547 us |       1.63% |  66.574 us |       1.57% |    0.027 us |   0.04% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^28      |     2^4      | 848.610 us |       0.42% | 848.557 us |       0.45% |   -0.053 us |  -0.01% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^16      |     2^8      |   9.080 us |       4.66% |   9.091 us |       4.79% |    0.012 us |   0.13% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^20      |     2^8      |  12.589 us |       3.34% |  12.561 us |       3.21% |   -0.028 us |  -0.22% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^24      |     2^8      |  64.260 us |       1.74% |  64.285 us |       1.84% |    0.024 us |   0.04% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^28      |     2^8      | 797.474 us |       0.59% | 797.380 us |       0.58% |   -0.094 us |  -0.01% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^16      |     2^1      |   9.590 us |       4.85% |   9.569 us |       5.02% |   -0.021 us |  -0.22% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^20      |     2^1      |  16.699 us |       3.11% |  16.726 us |       3.11% |    0.027 us |   0.16% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^24      |     2^1      | 130.952 us |       0.88% | 130.876 us |       0.80% |   -0.076 us |  -0.06% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^28      |     2^1      |   1.906 ms |       0.47% |   1.905 ms |       0.42% |   -0.400 us |  -0.02% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^16      |     2^4      |   9.191 us |       4.78% |   9.182 us |       4.71% |   -0.009 us |  -0.10% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^20      |     2^4      |  14.773 us |       3.57% |  14.741 us |       3.51% |   -0.032 us |  -0.22% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^24      |     2^4      |  99.583 us |       0.84% |  99.616 us |       0.93% |    0.033 us |   0.03% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^28      |     2^4      |   1.387 ms |       0.24% |   1.388 ms |       0.23% |    0.919 us |   0.07% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^16      |     2^8      |   9.097 us |       4.53% |   9.159 us |       4.32% |    0.063 us |   0.69% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^20      |     2^8      |  15.046 us |       2.93% |  15.017 us |       2.89% |   -0.030 us |  -0.20% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^24      |     2^8      |  94.280 us |       0.89% |  94.336 us |       0.92% |    0.056 us |   0.06% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^28      |     2^8      |   1.284 ms |       0.26% |   1.284 ms |       0.26% |   -0.168 us |  -0.01% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^16      |     2^1      |  12.970 us |       4.08% |  12.939 us |       3.94% |   -0.031 us |  -0.24% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^20      |     2^1      |  30.728 us |       2.09% |  30.701 us |       2.21% |   -0.026 us |  -0.09% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^24      |     2^1      | 294.890 us |       0.45% | 294.967 us |       0.44% |    0.077 us |   0.03% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^28      |     2^1      |   4.516 ms |       0.18% |   4.516 ms |       0.18% |    0.013 us |   0.00% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^16      |     2^4      |  11.899 us |       3.76% |  11.873 us |       3.57% |   -0.026 us |  -0.22% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^20      |     2^4      |  27.267 us |       2.57% |  27.248 us |       2.19% |   -0.020 us |  -0.07% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^24      |     2^4      | 241.126 us |       0.48% | 241.035 us |       0.49% |   -0.091 us |  -0.04% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^28      |     2^4      |   3.648 ms |       0.10% |   3.647 ms |       0.10% |   -0.349 us |  -0.01% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^16      |     2^8      |  11.682 us |       4.23% |  11.710 us |       4.39% |    0.028 us |   0.24% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^20      |     2^8      |  26.890 us |       2.31% |  26.915 us |       2.34% |    0.026 us |   0.10% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^24      |     2^8      | 233.023 us |       0.49% | 232.918 us |       0.46% |   -0.105 us |  -0.04% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^28      |     2^8      |   3.511 ms |       0.10% |   3.511 ms |       0.10% |    0.059 us |   0.00% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^16      |     2^1      |   9.674 us |       5.56% |   9.655 us |       5.41% |   -0.019 us |  -0.20% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^20      |     2^1      |  13.887 us |       3.64% |  13.889 us |       3.72% |    0.002 us |   0.02% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^24      |     2^1      |  86.682 us |       1.65% |  86.773 us |       1.63% |    0.091 us |   0.10% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^28      |     2^1      |   1.189 ms |       0.73% |   1.186 ms |       0.74% |   -2.834 us |  -0.24% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^16      |     2^4      |   9.089 us |       4.19% |   9.088 us |       4.14% |   -0.002 us |  -0.02% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^20      |     2^4      |  12.572 us |       3.73% |  12.557 us |       3.76% |   -0.015 us |  -0.12% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^24      |     2^4      |  66.687 us |       1.54% |  66.731 us |       1.57% |    0.045 us |   0.07% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^28      |     2^4      | 850.196 us |       0.43% | 850.132 us |       0.42% |   -0.063 us |  -0.01% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^16      |     2^8      |   9.210 us |       4.67% |   9.140 us |       4.35% |   -0.070 us |  -0.76% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^20      |     2^8      |  12.581 us |       3.68% |  12.588 us |       3.51% |    0.007 us |   0.06% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^24      |     2^8      |  64.165 us |       1.66% |  64.277 us |       1.64% |    0.112 us |   0.18% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^28      |     2^8      | 798.565 us |       0.53% | 798.548 us |       0.56% |   -0.017 us |  -0.00% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^16      |     2^1      |   9.736 us |       4.19% |   9.765 us |       4.01% |    0.029 us |   0.30% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^20      |     2^1      |  16.922 us |       2.50% |  16.919 us |       2.45% |   -0.003 us |  -0.02% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^24      |     2^1      | 131.694 us |       0.86% | 131.579 us |       0.80% |   -0.115 us |  -0.09% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^28      |     2^1      |   1.922 ms |       0.41% |   1.922 ms |       0.43% |   -0.114 us |  -0.01% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^16      |     2^4      |   9.298 us |       5.41% |   9.323 us |       5.69% |    0.025 us |   0.27% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^20      |     2^4      |  14.875 us |       3.02% |  14.923 us |       2.88% |    0.048 us |   0.32% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^24      |     2^4      | 100.694 us |       0.82% | 100.834 us |       0.82% |    0.140 us |   0.14% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^28      |     2^4      |   1.406 ms |       0.21% |   1.407 ms |       0.21% |    0.756 us |   0.05% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^16      |     2^8      |   9.261 us |       4.94% |   9.307 us |       5.28% |    0.047 us |   0.50% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^20      |     2^8      |  14.736 us |       3.58% |  14.727 us |       3.44% |   -0.010 us |  -0.06% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^24      |     2^8      |  94.977 us |       0.74% |  95.088 us |       0.79% |    0.111 us |   0.12% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^28      |     2^8      |   1.304 ms |       0.23% |   1.304 ms |       0.24% |   -0.030 us |  -0.00% |  🔵 SAME  |
|    I32     |     C32      |      I32      |      2^16      |     2^1      |   9.244 us |       4.91% |   9.267 us |       5.00% |    0.023 us |   0.25% |  🔵 SAME  |
|    I32     |     C32      |      I32      |      2^20      |     2^1      |  17.764 us |       2.95% |  17.712 us |       2.93% |   -0.053 us |  -0.30% |  🔵 SAME  |
|    I32     |     C32      |      I32      |      2^24      |     2^1      | 148.172 us |       0.72% | 147.536 us |       0.70% |   -0.636 us |  -0.43% |  🔵 SAME  |
|    I32     |     C32      |      I32      |      2^28      |     2^1      |   2.207 ms |       0.50% |   2.207 ms |       0.49% |   -0.500 us |  -0.02% |  🔵 SAME  |
|    I32     |     C32      |      I32      |      2^16      |     2^4      |   8.945 us |       4.36% |   8.993 us |       4.81% |    0.047 us |   0.53% |  🔵 SAME  |
|    I32     |     C32      |      I32      |      2^20      |     2^4      |  16.700 us |       3.12% |  16.686 us |       3.43% |   -0.014 us |  -0.09% |  🔵 SAME  |
|    I32     |     C32      |      I32      |      2^24      |     2^4      | 121.961 us |       0.77% | 122.278 us |       0.87% |    0.317 us |   0.26% |  🔵 SAME  |
|    I32     |     C32      |      I32      |      2^28      |     2^4      |   1.764 ms |       0.20% |   1.765 ms |       0.19% |    0.742 us |   0.04% |  🔵 SAME  |
|    I32     |     C32      |      I32      |      2^16      |     2^8      |   9.237 us |       5.94% |   9.242 us |       5.27% |    0.005 us |   0.06% |  🔵 SAME  |
|    I32     |     C32      |      I32      |      2^20      |     2^8      |  16.415 us |       3.17% |  16.412 us |       3.50% |   -0.003 us |  -0.02% |  🔵 SAME  |
|    I32     |     C32      |      I32      |      2^24      |     2^8      | 113.195 us |       0.74% | 113.656 us |       0.81% |    0.461 us |   0.41% |  🔵 SAME  |
|    I32     |     C32      |      I32      |      2^28      |     2^8      |   1.607 ms |       0.15% |   1.606 ms |       0.16% |   -0.473 us |  -0.03% |  🔵 SAME  |
|    I64     |      I8      |      I32      |      2^16      |     2^1      |   9.575 us |       5.81% |   9.739 us |       4.87% |    0.164 us |   1.72% |  🔵 SAME  |
|    I64     |      I8      |      I32      |      2^20      |     2^1      |  16.871 us |       3.62% |  16.582 us |       3.33% |   -0.289 us |  -1.71% |  🔵 SAME  |
|    I64     |      I8      |      I32      |      2^24      |     2^1      | 123.711 us |       1.10% | 113.378 us |       0.63% |  -10.333 us |  -8.35% |  🟢 FAST  |
|    I64     |      I8      |      I32      |      2^28      |     2^1      |   1.793 ms |       0.46% |   1.624 ms |       0.40% | -168.803 us |  -9.41% |  🟢 FAST  |
|    I64     |      I8      |      I32      |      2^16      |     2^4      |   9.199 us |       4.79% |   9.343 us |       4.75% |    0.143 us |   1.56% |  🔵 SAME  |
|    I64     |      I8      |      I32      |      2^20      |     2^4      |  15.151 us |       3.14% |  14.742 us |       3.62% |   -0.409 us |  -2.70% |  🔵 SAME  |
|    I64     |      I8      |      I32      |      2^24      |     2^4      |  98.607 us |       1.21% |  84.042 us |       0.88% |  -14.565 us | -14.77% |  🟢 FAST  |
|    I64     |      I8      |      I32      |      2^28      |     2^4      |   1.368 ms |       0.25% |   1.133 ms |       0.19% | -234.816 us | -17.17% |  🟢 FAST  |
|    I64     |      I8      |      I32      |      2^16      |     2^8      |   9.101 us |       5.81% |   9.241 us |       6.02% |    0.140 us |   1.54% |  🔵 SAME  |
|    I64     |      I8      |      I32      |      2^20      |     2^8      |  14.813 us |       3.23% |  14.551 us |       3.40% |   -0.262 us |  -1.77% |  🔵 SAME  |
|    I64     |      I8      |      I32      |      2^24      |     2^8      |  93.684 us |       1.22% |  80.226 us |       0.94% |  -13.459 us | -14.37% |  🟢 FAST  |
|    I64     |      I8      |      I32      |      2^28      |     2^8      |   1.269 ms |       0.28% |   1.059 ms |       0.19% | -210.642 us | -16.59% |  🟢 FAST  |
|    I64     |     I16      |      I32      |      2^16      |     2^1      |   9.501 us |       5.43% |   9.636 us |       5.39% |    0.135 us |   1.42% |  🔵 SAME  |
|    I64     |     I16      |      I32      |      2^20      |     2^1      |  16.538 us |       2.90% |  16.850 us |       3.46% |    0.312 us |   1.89% |  🔵 SAME  |
|    I64     |     I16      |      I32      |      2^24      |     2^1      | 120.415 us |       1.00% | 116.471 us |       0.74% |   -3.945 us |  -3.28% |  🟢 FAST  |
|    I64     |     I16      |      I32      |      2^28      |     2^1      |   1.737 ms |       0.44% |   1.674 ms |       0.46% |  -62.932 us |  -3.62% |  🟢 FAST  |
|    I64     |     I16      |      I32      |      2^16      |     2^4      |   9.069 us |       5.92% |   9.225 us |       5.06% |    0.157 us |   1.73% |  🔵 SAME  |
|    I64     |     I16      |      I32      |      2^20      |     2^4      |  14.794 us |       3.19% |  14.891 us |       3.29% |    0.097 us |   0.66% |  🔵 SAME  |
|    I64     |     I16      |      I32      |      2^24      |     2^4      |  93.972 us |       1.07% |  85.874 us |       0.89% |   -8.098 us |  -8.62% |  🟢 FAST  |
|    I64     |     I16      |      I32      |      2^28      |     2^4      |   1.288 ms |       0.20% |   1.156 ms |       0.20% | -132.170 us | -10.26% |  🟢 FAST  |
|    I64     |     I16      |      I32      |      2^16      |     2^8      |   8.956 us |       6.33% |   9.112 us |       5.94% |    0.157 us |   1.75% |  🔵 SAME  |
|    I64     |     I16      |      I32      |      2^20      |     2^8      |  14.537 us |       3.95% |  14.759 us |       3.09% |    0.221 us |   1.52% |  🔵 SAME  |
|    I64     |     I16      |      I32      |      2^24      |     2^8      |  89.053 us |       1.20% |  81.430 us |       0.96% |   -7.623 us |  -8.56% |  🟢 FAST  |
|    I64     |     I16      |      I32      |      2^28      |     2^8      |   1.192 ms |       0.25% |   1.066 ms |       0.24% | -125.267 us | -10.51% |  🟢 FAST  |
|    I64     |     I32      |      I32      |      2^16      |     2^1      |   9.800 us |       4.86% |   9.761 us |       5.70% |   -0.039 us |  -0.40% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^20      |     2^1      |  17.185 us |       3.06% |  17.151 us |       2.79% |   -0.034 us |  -0.20% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^24      |     2^1      | 122.769 us |       0.93% | 122.097 us |       0.93% |   -0.673 us |  -0.55% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^28      |     2^1      |   1.765 ms |       0.58% |   1.764 ms |       0.58% |   -0.252 us |  -0.01% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^16      |     2^4      |   9.394 us |       4.85% |   9.411 us |       6.14% |    0.017 us |   0.18% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^20      |     2^4      |  15.086 us |       3.42% |  15.143 us |       2.96% |    0.057 us |   0.37% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^24      |     2^4      |  88.591 us |       0.97% |  88.752 us |       1.00% |    0.161 us |   0.18% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^28      |     2^4      |   1.197 ms |       0.24% |   1.196 ms |       0.24% |   -0.298 us |  -0.02% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^16      |     2^8      |   9.427 us |       6.14% |   9.360 us |       6.22% |   -0.066 us |  -0.70% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^20      |     2^8      |  15.044 us |       3.40% |  15.013 us |       3.24% |   -0.030 us |  -0.20% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^24      |     2^8      |  83.740 us |       1.04% |  83.133 us |       1.04% |   -0.607 us |  -0.73% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^28      |     2^8      |   1.089 ms |       0.27% |   1.089 ms |       0.26% |    0.004 us |   0.00% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^16      |     2^1      |  10.885 us |       5.37% |  10.882 us |       5.08% |   -0.002 us |  -0.02% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^20      |     2^1      |  18.210 us |       3.25% |  18.154 us |       2.98% |   -0.056 us |  -0.31% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^24      |     2^1      | 148.483 us |       1.65% | 148.241 us |       1.56% |   -0.242 us |  -0.16% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^28      |     2^1      |   2.149 ms |       0.62% |   2.148 ms |       0.62% |   -1.195 us |  -0.06% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^16      |     2^4      |  10.107 us |       4.64% |  10.275 us |       5.38% |    0.169 us |   1.67% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^20      |     2^4      |  16.040 us |       3.91% |  16.043 us |       3.01% |    0.003 us |   0.02% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^24      |     2^4      | 108.900 us |       1.01% | 108.944 us |       1.12% |    0.044 us |   0.04% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^28      |     2^4      |   1.500 ms |       0.25% |   1.500 ms |       0.21% |   -0.133 us |  -0.01% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^16      |     2^8      |  10.215 us |       4.46% |  10.208 us |       5.69% |   -0.007 us |  -0.07% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^20      |     2^8      |  15.822 us |       3.14% |  15.783 us |       3.25% |   -0.039 us |  -0.25% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^24      |     2^8      | 103.086 us |       1.04% | 103.215 us |       1.06% |    0.130 us |   0.13% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^28      |     2^8      |   1.399 ms |       0.24% |   1.399 ms |       0.23% |    0.007 us |   0.00% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^16      |     2^1      |  13.063 us |       4.52% |  13.116 us |       4.44% |    0.053 us |   0.40% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^20      |     2^1      |  32.432 us |       2.28% |  32.481 us |       2.45% |    0.049 us |   0.15% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^24      |     2^1      | 312.594 us |       0.46% | 311.641 us |       0.50% |   -0.953 us |  -0.30% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^28      |     2^1      |   4.780 ms |       0.19% |   4.780 ms |       0.18% |   -0.363 us |  -0.01% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^16      |     2^4      |  12.500 us |       4.73% |  12.505 us |       4.10% |    0.005 us |   0.04% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^20      |     2^4      |  28.730 us |       2.23% |  28.742 us |       2.21% |    0.012 us |   0.04% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^24      |     2^4      | 249.935 us |       0.52% | 249.403 us |       0.50% |   -0.532 us |  -0.21% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^28      |     2^4      |   3.769 ms |       0.11% |   3.769 ms |       0.11% |   -0.680 us |  -0.02% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^16      |     2^8      |  12.360 us |       4.77% |  12.325 us |       4.76% |   -0.034 us |  -0.28% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^20      |     2^8      |  27.809 us |       2.56% |  27.835 us |       2.49% |    0.026 us |   0.09% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^24      |     2^8      | 239.655 us |       0.47% | 239.325 us |       0.45% |   -0.330 us |  -0.14% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^28      |     2^8      |   3.608 ms |       0.10% |   3.607 ms |       0.10% |   -0.694 us |  -0.02% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^16      |     2^1      |   9.630 us |       4.33% |   9.644 us |       5.55% |    0.013 us |   0.14% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^20      |     2^1      |  16.827 us |       3.00% |  16.838 us |       2.60% |    0.011 us |   0.07% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^24      |     2^1      | 122.442 us |       0.89% | 122.242 us |       0.87% |   -0.200 us |  -0.16% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^28      |     2^1      |   1.765 ms |       0.56% |   1.766 ms |       0.56% |    0.393 us |   0.02% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^16      |     2^4      |   9.123 us |       4.61% |   9.137 us |       5.70% |    0.014 us |   0.15% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^20      |     2^4      |  15.015 us |       3.32% |  15.024 us |       3.35% |    0.009 us |   0.06% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^24      |     2^4      |  88.740 us |       0.77% |  88.511 us |       0.82% |   -0.229 us |  -0.26% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^28      |     2^4      |   1.198 ms |       0.24% |   1.199 ms |       0.24% |    0.337 us |   0.03% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^16      |     2^8      |   9.112 us |       4.33% |   9.141 us |       4.94% |    0.029 us |   0.31% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^20      |     2^8      |  14.912 us |       3.47% |  14.908 us |       3.48% |   -0.004 us |  -0.03% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^24      |     2^8      |  83.215 us |       0.92% |  83.321 us |       0.90% |    0.106 us |   0.13% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^28      |     2^8      |   1.094 ms |       0.25% |   1.093 ms |       0.26% |   -0.316 us |  -0.03% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^16      |     2^1      |  10.532 us |       4.01% |  10.530 us |       4.02% |   -0.002 us |  -0.02% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^20      |     2^1      |  17.785 us |       2.74% |  17.906 us |       2.94% |    0.122 us |   0.68% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^24      |     2^1      | 147.676 us |       1.62% | 147.975 us |       1.59% |    0.299 us |   0.20% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^28      |     2^1      |   2.142 ms |       0.63% |   2.141 ms |       0.65% |   -0.940 us |  -0.04% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^16      |     2^4      |   9.769 us |       5.60% |   9.772 us |       4.28% |    0.003 us |   0.03% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^20      |     2^4      |  15.758 us |       2.73% |  15.859 us |       3.30% |    0.101 us |   0.64% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^24      |     2^4      | 107.775 us |       1.01% | 108.072 us |       0.98% |    0.297 us |   0.28% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^28      |     2^4      |   1.491 ms |       0.24% |   1.491 ms |       0.21% |   -0.069 us |  -0.00% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^16      |     2^8      |   9.650 us |       5.29% |   9.681 us |       4.64% |    0.031 us |   0.32% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^20      |     2^8      |  15.441 us |       3.37% |  15.342 us |       2.73% |   -0.099 us |  -0.64% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^24      |     2^8      | 101.804 us |       0.99% | 101.936 us |       1.06% |    0.132 us |   0.13% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^28      |     2^8      |   1.388 ms |       0.23% |   1.388 ms |       0.25% |    0.119 us |   0.01% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^16      |     2^1      |   9.394 us |       5.06% |   9.419 us |       5.21% |    0.025 us |   0.27% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^20      |     2^1      |  19.792 us |       2.70% |  19.719 us |       2.56% |   -0.073 us |  -0.37% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^24      |     2^1      | 171.859 us |       0.93% | 172.615 us |       0.90% |    0.756 us |   0.44% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^28      |     2^1      |   2.604 ms |       0.50% |   2.604 ms |       0.50% |    0.288 us |   0.01% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^16      |     2^4      |   9.126 us |       5.18% |   9.131 us |       5.79% |    0.006 us |   0.06% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^20      |     2^4      |  18.174 us |       3.08% |  18.122 us |       3.24% |   -0.052 us |  -0.29% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^24      |     2^4      | 138.530 us |       0.97% | 138.337 us |       0.99% |   -0.193 us |  -0.14% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^28      |     2^4      |   2.012 ms |       0.25% |   2.012 ms |       0.25% |    0.252 us |   0.01% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^16      |     2^8      |   9.312 us |       6.12% |   9.409 us |       6.18% |    0.097 us |   1.04% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^20      |     2^8      |  17.662 us |       2.91% |  17.533 us |       3.45% |   -0.129 us |  -0.73% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^24      |     2^8      | 124.234 us |       0.86% | 124.681 us |       0.87% |    0.447 us |   0.36% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^28      |     2^8      |   1.777 ms |       0.20% |   1.777 ms |       0.19% |   -0.029 us |  -0.00% |  🔵 SAME  |
|    I128    |      I8      |      I32      |      2^16      |     2^1      |  10.618 us |       5.23% |  10.390 us |       4.85% |   -0.228 us |  -2.15% |  🔵 SAME  |
|    I128    |      I8      |      I32      |      2^20      |     2^1      |  23.551 us |       3.31% |  22.712 us |       3.42% |   -0.839 us |  -3.56% |  🟢 FAST  |
|    I128    |      I8      |      I32      |      2^24      |     2^1      | 198.886 us |       1.00% | 185.044 us |       0.51% |  -13.842 us |  -6.96% |  🟢 FAST  |
|    I128    |      I8      |      I32      |      2^28      |     2^1      |   2.984 ms |       0.44% |   2.762 ms |       0.39% | -222.016 us |  -7.44% |  🟢 FAST  |
|    I128    |      I8      |      I32      |      2^16      |     2^4      |   9.928 us |       5.73% |   9.781 us |       6.06% |   -0.146 us |  -1.47% |  🔵 SAME  |
|    I128    |      I8      |      I32      |      2^20      |     2^4      |  20.336 us |       3.70% |  19.543 us |       3.84% |   -0.793 us |  -3.90% |  🟢 FAST  |
|    I128    |      I8      |      I32      |      2^24      |     2^4      | 147.202 us |       1.07% | 132.010 us |       0.66% |  -15.192 us | -10.32% |  🟢 FAST  |
|    I128    |      I8      |      I32      |      2^28      |     2^4      |   2.122 ms |       0.27% |   1.869 ms |       0.20% | -252.490 us | -11.90% |  🟢 FAST  |
|    I128    |      I8      |      I32      |      2^16      |     2^8      |   9.879 us |       4.74% |   9.669 us |       5.34% |   -0.210 us |  -2.12% |  🔵 SAME  |
|    I128    |      I8      |      I32      |      2^20      |     2^8      |  19.867 us |       3.60% |  19.282 us |       3.40% |   -0.585 us |  -2.94% |  🔵 SAME  |
|    I128    |      I8      |      I32      |      2^24      |     2^8      | 137.608 us |       1.07% | 124.076 us |       0.67% |  -13.532 us |  -9.83% |  🟢 FAST  |
|    I128    |      I8      |      I32      |      2^28      |     2^8      |   1.951 ms |       0.23% |   1.726 ms |       0.09% | -225.105 us | -11.54% |  🟢 FAST  |
|    I128    |     I16      |      I32      |      2^16      |     2^1      |  10.589 us |       4.31% |  10.480 us |       5.49% |   -0.109 us |  -1.03% |  🔵 SAME  |
|    I128    |     I16      |      I32      |      2^20      |     2^1      |  22.827 us |       2.50% |  22.881 us |       3.55% |    0.054 us |   0.24% |  🔵 SAME  |
|    I128    |     I16      |      I32      |      2^24      |     2^1      | 197.010 us |       0.61% | 188.094 us |       0.46% |   -8.916 us |  -4.53% |  🟢 FAST  |
|    I128    |     I16      |      I32      |      2^28      |     2^1      |   2.958 ms |       0.43% |   2.817 ms |       0.39% | -141.297 us |  -4.78% |  🟢 FAST  |
|    I128    |     I16      |      I32      |      2^16      |     2^4      |   9.870 us |       5.65% |   9.802 us |       5.32% |   -0.068 us |  -0.69% |  🔵 SAME  |
|    I128    |     I16      |      I32      |      2^20      |     2^4      |  19.089 us |       3.26% |  19.632 us |       2.96% |    0.543 us |   2.84% |  🔵 SAME  |
|    I128    |     I16      |      I32      |      2^24      |     2^4      | 140.491 us |       0.79% | 134.583 us |       0.65% |   -5.908 us |  -4.21% |  🟢 FAST  |
|    I128    |     I16      |      I32      |      2^28      |     2^4      |   2.016 ms |       0.24% |   1.915 ms |       0.21% | -100.665 us |  -4.99% |  🟢 FAST  |
|    I128    |     I16      |      I32      |      2^16      |     2^8      |   9.794 us |       5.17% |   9.652 us |       5.91% |   -0.142 us |  -1.45% |  🔵 SAME  |
|    I128    |     I16      |      I32      |      2^20      |     2^8      |  18.713 us |       3.51% |  19.205 us |       3.94% |    0.492 us |   2.63% |  🔵 SAME  |
|    I128    |     I16      |      I32      |      2^24      |     2^8      | 128.442 us |       0.73% | 124.820 us |       0.61% |   -3.623 us |  -2.82% |  🟢 FAST  |
|    I128    |     I16      |      I32      |      2^28      |     2^8      |   1.800 ms |       0.16% |   1.733 ms |       0.09% |  -66.907 us |  -3.72% |  🟢 FAST  |
|    I128    |     I32      |      I32      |      2^16      |     2^1      |  10.438 us |       4.63% |  10.515 us |       4.50% |    0.077 us |   0.73% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^20      |     2^1      |  22.953 us |       3.45% |  22.844 us |       3.16% |   -0.110 us |  -0.48% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^24      |     2^1      | 194.951 us |       0.43% | 195.411 us |       0.41% |    0.460 us |   0.24% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^28      |     2^1      |   2.935 ms |       0.45% |   2.935 ms |       0.45% |   -0.038 us |  -0.00% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^16      |     2^4      |   9.510 us |       4.56% |   9.538 us |       4.84% |    0.027 us |   0.29% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^20      |     2^4      |  19.727 us |       3.21% |  19.692 us |       3.48% |   -0.034 us |  -0.17% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^24      |     2^4      | 138.491 us |       0.63% | 138.528 us |       0.59% |    0.037 us |   0.03% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^28      |     2^4      |   1.982 ms |       0.20% |   1.982 ms |       0.20% |   -0.233 us |  -0.01% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^16      |     2^8      |   9.495 us |       5.72% |   9.469 us |       4.63% |   -0.026 us |  -0.27% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^20      |     2^8      |  19.313 us |       3.70% |  19.330 us |       3.79% |    0.017 us |   0.09% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^24      |     2^8      | 126.989 us |       0.60% | 127.051 us |       0.58% |    0.061 us |   0.05% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^28      |     2^8      |   1.773 ms |       0.11% |   1.773 ms |       0.11% |    0.199 us |   0.01% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^16      |     2^1      |  10.474 us |       4.55% |  10.488 us |       4.32% |    0.014 us |   0.13% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^20      |     2^1      |  25.211 us |       2.81% |  25.120 us |       2.71% |   -0.091 us |  -0.36% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^24      |     2^1      | 218.271 us |       0.87% | 218.483 us |       0.94% |    0.212 us |   0.10% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^28      |     2^1      |   3.284 ms |       0.47% |   3.284 ms |       0.45% |    0.365 us |   0.01% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^16      |     2^4      |   9.752 us |       5.58% |   9.762 us |       4.97% |    0.010 us |   0.10% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^20      |     2^4      |  21.527 us |       3.45% |  21.532 us |       3.33% |    0.005 us |   0.02% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^24      |     2^4      | 156.684 us |       0.91% | 156.495 us |       0.91% |   -0.189 us |  -0.12% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^28      |     2^4      |   2.268 ms |       0.19% |   2.268 ms |       0.20% |   -0.086 us |  -0.00% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^16      |     2^8      |   9.647 us |       5.37% |   9.706 us |       5.07% |    0.059 us |   0.61% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^20      |     2^8      |  20.861 us |       3.21% |  20.729 us |       2.94% |   -0.132 us |  -0.63% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^24      |     2^8      | 144.586 us |       0.97% | 144.401 us |       1.03% |   -0.185 us |  -0.13% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^28      |     2^8      |   2.057 ms |       0.21% |   2.056 ms |       0.20% |   -0.550 us |  -0.03% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^16      |     2^1      |  13.339 us |       3.58% |  13.344 us |       4.10% |    0.006 us |   0.04% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^20      |     2^1      |  36.264 us |       1.93% |  36.546 us |       2.28% |    0.282 us |   0.78% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^24      |     2^1      | 384.921 us |       0.43% | 384.693 us |       0.45% |   -0.228 us |  -0.06% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^28      |     2^1      |   5.951 ms |       0.18% |   5.952 ms |       0.19% |    0.953 us |   0.02% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^16      |     2^4      |  12.453 us |       4.02% |  12.484 us |       3.58% |    0.031 us |   0.25% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^20      |     2^4      |  31.873 us |       1.92% |  32.100 us |       2.02% |    0.227 us |   0.71% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^24      |     2^4      | 307.566 us |       0.44% | 307.286 us |       0.43% |   -0.281 us |  -0.09% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^28      |     2^4      |   4.692 ms |       0.10% |   4.692 ms |       0.10% |   -0.071 us |  -0.00% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^16      |     2^8      |  12.321 us |       4.32% |  12.272 us |       4.21% |   -0.049 us |  -0.40% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^20      |     2^8      |  31.113 us |       2.19% |  31.323 us |       2.32% |    0.211 us |   0.68% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^24      |     2^8      | 289.389 us |       0.48% | 289.924 us |       0.48% |    0.535 us |   0.18% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^28      |     2^8      |   4.395 ms |       0.10% |   4.396 ms |       0.10% |    1.007 us |   0.02% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^16      |     2^1      |  10.317 us |       4.34% |  10.237 us |       4.06% |   -0.080 us |  -0.78% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^20      |     2^1      |  22.960 us |       2.90% |  22.851 us |       3.60% |   -0.109 us |  -0.47% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^24      |     2^1      | 196.385 us |       0.42% | 196.499 us |       0.43% |    0.113 us |   0.06% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^28      |     2^1      |   2.954 ms |       0.46% |   2.954 ms |       0.45% |   -0.327 us |  -0.01% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^16      |     2^4      |   9.584 us |       5.20% |   9.588 us |       4.58% |    0.004 us |   0.04% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^20      |     2^4      |  19.690 us |       3.30% |  19.783 us |       3.68% |    0.093 us |   0.47% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^24      |     2^4      | 139.203 us |       0.62% | 139.610 us |       0.64% |    0.406 us |   0.29% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^28      |     2^4      |   1.995 ms |       0.13% |   1.995 ms |       0.21% |   -0.002 us |  -0.00% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^16      |     2^8      |   9.524 us |       4.96% |   9.482 us |       4.48% |   -0.042 us |  -0.44% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^20      |     2^8      |  19.379 us |       3.25% |  19.361 us |       3.09% |   -0.019 us |  -0.10% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^24      |     2^8      | 127.828 us |       0.62% | 127.683 us |       0.63% |   -0.145 us |  -0.11% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^28      |     2^8      |   1.785 ms |       0.10% |   1.785 ms |       0.11% |    0.084 us |   0.00% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^16      |     2^1      |  10.536 us |       4.55% |  10.607 us |       4.86% |    0.071 us |   0.67% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^20      |     2^1      |  25.284 us |       2.70% |  25.403 us |       2.68% |    0.119 us |   0.47% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^24      |     2^1      | 219.820 us |       0.81% | 219.565 us |       0.86% |   -0.255 us |  -0.12% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^28      |     2^1      |   3.303 ms |       0.44% |   3.303 ms |       0.43% |    0.099 us |   0.00% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^16      |     2^4      |   9.874 us |       4.59% |   9.816 us |       4.56% |   -0.058 us |  -0.59% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^20      |     2^4      |  21.656 us |       2.73% |  21.668 us |       2.89% |    0.012 us |   0.06% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^24      |     2^4      | 157.738 us |       0.81% | 157.878 us |       0.83% |    0.141 us |   0.09% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^28      |     2^4      |   2.287 ms |       0.19% |   2.287 ms |       0.19% |    0.119 us |   0.01% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^16      |     2^8      |   9.730 us |       5.08% |   9.779 us |       4.49% |    0.050 us |   0.51% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^20      |     2^8      |  21.084 us |       3.14% |  20.966 us |       2.76% |   -0.118 us |  -0.56% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^24      |     2^8      | 145.638 us |       0.87% | 145.886 us |       0.92% |    0.248 us |   0.17% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^28      |     2^8      |   2.077 ms |       0.17% |   2.077 ms |       0.16% |   -0.218 us |  -0.01% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^16      |     2^1      |   9.879 us |       4.51% |   9.847 us |       5.07% |   -0.032 us |  -0.32% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^20      |     2^1      |  28.428 us |       1.93% |  28.432 us |       2.14% |    0.004 us |   0.01% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^24      |     2^1      | 316.692 us |       0.44% | 315.606 us |       0.43% |   -1.087 us |  -0.34% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^28      |     2^1      |   4.918 ms |       0.29% |   4.920 ms |       0.30% |    1.824 us |   0.04% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^16      |     2^4      |   9.571 us |       5.36% |   9.682 us |       4.27% |    0.111 us |   1.16% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^20      |     2^4      |  25.865 us |       2.44% |  25.876 us |       2.36% |    0.011 us |   0.04% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^24      |     2^4      | 265.361 us |       0.45% | 264.393 us |       0.42% |   -0.967 us |  -0.36% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^28      |     2^4      |   4.077 ms |       0.09% |   4.079 ms |       0.10% |    2.044 us |   0.05% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^16      |     2^8      |   9.970 us |       4.84% |  10.037 us |       4.93% |    0.066 us |   0.67% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^20      |     2^8      |  25.381 us |       2.28% |  25.330 us |       2.47% |   -0.050 us |  -0.20% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^24      |     2^8      | 253.659 us |       0.41% | 252.925 us |       0.39% |   -0.734 us |  -0.29% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^28      |     2^8      |   3.879 ms |       0.08% |   3.880 ms |       0.09% |    0.852 us |   0.02% |  🔵 SAME  |
```