### PR TITLE
Improve reducer API for memory allocation & compute (#5638)

### DIFF
--- a/python/cuda_cccl/README.md
+++ b/python/cuda_cccl/README.md
@@ -44,6 +44,6 @@ conda install -c conda-forge cccl-python
 
 For complete documentation, examples, and API reference, visit:
 
-- **Full Documentation**: [nvidia.github.io/cccl/python](https://nvidia.github.io/cccl/python)
+- **Full Documentation**: [nvidia.github.io/cccl/python](https://nvidia.github.io/cccl/unstable/python)
 - **Repository**: [github.com/NVIDIA/cccl](https://github.com/NVIDIA/cccl)
 - **Examples**: [github.com/NVIDIA/cccl/tree/main/python/cuda_cccl/tests/compute/examples](https://github.com/NVIDIA/cccl/tree/main/python/cuda_cccl/tests/compute/examples) and [github.com/NVIDIA/cccl/tree/main/python/cuda_cccl/tests/coop/_experimental/examples](https://github.com/NVIDIA/cccl/tree/main/python/cuda_cccl/tests/coop/_experimental/examples)

--- a/python/cuda_cccl/cuda/compute/algorithms/_reduce.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_reduce.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 from typing import Callable
 
 import numpy as np
@@ -68,6 +70,32 @@ class _Reduce:
                 self.device_reduce_fn = self.build_result.compute_nondeterministic
             case _:
                 raise ValueError(f"Invalid determinism: {determinism}")
+
+    def __call__(
+        self,
+        *,
+        temp_storage,
+        d_in,
+        d_out,
+        num_items: int,
+        op: Callable | OpAdapter,
+        h_init: np.ndarray | GpuStruct,
+        stream=None,
+    ):
+        msg = (
+            "Use new get_temp_storage_bytes/compute functions instead "
+            "of treating instance as callable object"
+        )
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        return self._execute_call(
+            temp_storage=temp_storage,
+            d_in=d_in,
+            d_out=d_out,
+            num_items=num_items,
+            op=op,
+            h_init=h_init,
+            stream=stream
+        )
 
     def get_temp_storage_bytes(
         self,
@@ -224,17 +252,15 @@ def reduce_into(
         stream: CUDA stream for the operation (optional)
     """
     reducer = make_reduce_into(d_in=d_in, d_out=d_out, op=op, h_init=h_init, **kwargs)
-    tmp_storage_bytes = reducer(
-        temp_storage=None,
+    tmp_storage_bytes = reducer.get_temp_storage_bytes(
         d_in=d_in,
         d_out=d_out,
         num_items=num_items,
         op=op,
-        h_init=h_init,
-        stream=stream,
+        h_init=h_init
     )
     tmp_storage = TempStorageBuffer(tmp_storage_bytes, stream)
-    reducer(
+    reducer.compute(
         temp_storage=tmp_storage,
         d_in=d_in,
         d_out=d_out,

--- a/python/cuda_cccl/cuda/compute/algorithms/_reduce.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_reduce.py
@@ -69,7 +69,47 @@ class _Reduce:
             case _:
                 raise ValueError(f"Invalid determinism: {determinism}")
 
-    def __call__(
+    def get_temp_storage_bytes(
+        self,
+        *,
+        d_in,
+        d_out,
+        num_items: int,
+        op: Callable | OpAdapter,
+        h_init: np.ndarray | GpuStruct,
+    ):
+        return self._execute_call(
+            temp_storage=None,
+            d_in=d_in,
+            d_out=d_out,
+            num_items=num_items,
+            op=op,
+            h_init=h_init,
+            stream=None
+        )
+
+    def compute(
+        self,
+        *,
+        temp_storage,
+        d_in,
+        d_out,
+        num_items: int,
+        op: Callable | OpAdapter,
+        h_init: np.ndarray | GpuStruct,
+        stream=None,
+    ):
+        return self._execute_call(
+            temp_storage=temp_storage,
+            d_in=d_in,
+            d_out=d_out,
+            num_items=num_items,
+            op=op,
+            h_init=h_init,
+            stream=stream
+        )
+
+    def _execute_call(
         self,
         *,
         temp_storage,

--- a/python/cuda_cccl/tests/compute/test_reduce.py
+++ b/python/cuda_cccl/tests/compute/test_reduce.py
@@ -957,3 +957,37 @@ def test_reduce_bool():
 
     expected = True
     assert d_output.get()[0] == expected
+
+
+def test_reduce_get_temp_storage_bytes():
+    h_init = np.array([False])
+    h_input = random_int(1024, np.int64)
+    d_input = cp.array([True, False, True])
+    d_output = cp.empty_like(d_input, shape=(1,))
+
+    # Perform the reduction.
+    reducer = cuda.compute.make_reduce_into(
+        d_in=d_input,
+        d_out=d_output,
+        num_items=len(d_input),
+        op=OpKind.MAXIMUM,
+        h_init=h_init,
+    )
+    temp_storage_size = reducer.get_temp_storage_bytes(
+        d_in=d_input, 
+        d_out=d_output,
+        num_items=len(h_input), 
+        op=OpKind.MAXIMUM,
+        h_init=h_init
+    )
+    d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
+    reducer.compute(
+        temp_storage=d_temp_storage, 
+        d_in=d_input, 
+        d_out=d_output, 
+        num_items=len(h_input), 
+        op=OpKind.MAXIMUM,
+        h_init=h_init
+    )
+    expected = True
+    assert d_output.get()[0] == expected

--- a/python/cuda_cccl/tests/compute/test_reduce.py
+++ b/python/cuda_cccl/tests/compute/test_reduce.py
@@ -959,7 +959,7 @@ def test_reduce_bool():
     assert d_output.get()[0] == expected
 
 
-def test_reduce_get_temp_storage_bytes():
+def test_reduce_temp_storage_compute_api():
     h_init = np.array([False])
     h_input = random_int(1024, np.int64)
     d_input = cp.array([True, False, True])


### PR DESCRIPTION
Add 'get_temp_storage_bytes' and 'compute' functions to _Reduce class to improve API usability (as suggested by @kkraus14 and @shwina).