### PR TITLE
[cub] Use `REQUIRE_CUDART` in catch2 tests

### DIFF
--- a/cub/test/catch2_radix_sort_helper.cuh
+++ b/cub/test/catch2_radix_sort_helper.cuh
@@ -56,12 +56,12 @@ public:
 
   void initialize()
   {
-    REQUIRE(cudaSuccess == cudaMallocHost(&m_selector, sizeof(int)));
+    REQUIRE_CUDART(cudaMallocHost(&m_selector, sizeof(int)));
   }
 
   void finalize()
   {
-    REQUIRE(cudaSuccess == cudaFreeHost(m_selector));
+    REQUIRE_CUDART(cudaFreeHost(m_selector));
     m_selector = nullptr;
   }
 
@@ -113,12 +113,12 @@ public:
 
   void initialize()
   {
-    REQUIRE(cudaSuccess == cudaMallocHost(&m_selector, sizeof(int)));
+    REQUIRE_CUDART(cudaMallocHost(&m_selector, sizeof(int)));
   }
 
   void finalize()
   {
-    REQUIRE(cudaSuccess == cudaFreeHost(m_selector));
+    REQUIRE_CUDART(cudaFreeHost(m_selector));
     m_selector = nullptr;
   }
 

--- a/cub/test/catch2_segmented_sort_helper.cuh
+++ b/cub/test/catch2_segmented_sort_helper.cuh
@@ -521,7 +521,7 @@ void generate_unsorted_derived_inputs(
   }
 
   // The for_each calls are using nosync policies:
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 // Verifies the results of sorting the segmented key/value arrays produced by generate_unsorted_derived_inputs.
@@ -1112,12 +1112,12 @@ public:
 
   void initialize()
   {
-    REQUIRE(cudaSuccess == cudaMallocHost(&m_selectors, 2 * sizeof(int)));
+    REQUIRE_CUDART(cudaMallocHost(&m_selectors, 2 * sizeof(int)));
   }
 
   void finalize()
   {
-    REQUIRE(cudaSuccess == cudaFreeHost(m_selectors));
+    REQUIRE_CUDART(cudaFreeHost(m_selectors));
     m_selectors = nullptr;
   }
 
@@ -1605,10 +1605,10 @@ c2h::device_vector<int> generate_edge_case_offsets()
   using MaxPolicyT = typename cub::detail::segmented_sort::policy_hub<KeyT, ValueT>::MaxPolicy;
 
   int ptx_version = 0;
-  REQUIRE(cudaSuccess == CubDebug(cub::PtxVersion(ptx_version)));
+  REQUIRE_CUDART(CubDebug(cub::PtxVersion(ptx_version)));
 
   generate_edge_case_offsets_dispatch dispatch;
-  REQUIRE(cudaSuccess == CubDebug(MaxPolicyT::Invoke(ptx_version, dispatch)));
+  REQUIRE_CUDART(CubDebug(MaxPolicyT::Invoke(ptx_version, dispatch)));
 
   return dispatch.generate_offsets();
 }
@@ -1646,7 +1646,7 @@ inline int generate_unspecified_segments_offsets(
   thrust::scatter(
     c2h::nosync_device_policy, const_zero_begin, const_zero_end, erase_indices.cbegin(), d_end_offsets.begin());
 
-  REQUIRE(cudaSuccess == CubDebug(cudaDeviceSynchronize()));
+  REQUIRE_CUDART(CubDebug(cudaDeviceSynchronize()));
 
   // Add more items to place another unspecified segment at the end.
   const int num_items = d_end_offsets.back() + 243;

--- a/cub/test/catch2_test_block_adjacent_difference.cu
+++ b/cub/test/catch2_test_block_adjacent_difference.cu
@@ -150,8 +150,8 @@ void block_adj_diff(c2h::device_vector<T>& data, bool in_place, ActionT action)
   block_adj_diff_kernel<ThreadsInBlock, ItemsPerThread, T, ActionT>
     <<<1, ThreadsInBlock>>>(thrust::raw_pointer_cast(data.data()), action, in_place);
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 template <bool ReadLeft, class T>

--- a/cub/test/catch2_test_block_histogram.cu
+++ b/cub/test/catch2_test_block_histogram.cu
@@ -43,8 +43,8 @@ void block_histogram(c2h::device_vector<SampleT>& d_samples, c2h::device_vector<
   block_histogram_kernel<Bins, ThreadsInBlock, ItemsPerThread, Algorithm>
     <<<1, ThreadsInBlock>>>(thrust::raw_pointer_cast(d_samples.data()), thrust::raw_pointer_cast(d_histogram.data()));
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 // %PARAM% TEST_BINS bins 32:256:1024

--- a/cub/test/catch2_test_block_load.cu
+++ b/cub/test/catch2_test_block_load.cu
@@ -80,8 +80,8 @@ void test_block_load(const c2h::device_vector<T>& d_input, InputIteratorT input)
   c2h::device_vector<T> d_output(d_input.size());
   kernel<ItemsPerThread, ThreadsInBlock, LoadAlgorithm><<<1, ThreadsInBlock>>>(
     sufficient_resources, input, thrust::raw_pointer_cast(d_output.data()), static_cast<int>(d_input.size()));
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(d_input == d_output);
 }
 

--- a/cub/test/catch2_test_block_load_to_shared.cu
+++ b/cub/test/catch2_test_block_load_to_shared.cu
@@ -116,8 +116,8 @@ void test_block_load(const c2h::device_vector<T>& d_input, InputPointerT input)
     c2h::device_vector<T> d_output(d_input.size());
     kernel<ItemsPerThread, ThreadsInBlock, Mode>
       <<<1, ThreadsInBlock>>>(input, thrust::raw_pointer_cast(d_output.data()), static_cast<int>(d_input.size()));
-    REQUIRE(cudaSuccess == cudaPeekAtLastError());
-    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+    REQUIRE_CUDART(cudaPeekAtLastError());
+    REQUIRE_CUDART(cudaDeviceSynchronize());
     REQUIRE(d_input == d_output);
   }
 }
@@ -169,8 +169,8 @@ void test_block_load_dyn_smem_dst(const c2h::device_vector<T>& d_input, InputPoi
   kernel_dyn_smem_dst<block_dim_x, block_dim_y, block_dim_z>
     <<<1, dim3{block_dim_x, block_dim_y, block_dim_z}, buffer_size>>>(
       input, thrust::raw_pointer_cast(d_output.data()), static_cast<int>(d_input.size()));
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(d_input == d_output);
 }
 

--- a/cub/test/catch2_test_block_merge_sort.cu
+++ b/cub/test/catch2_test_block_merge_sort.cu
@@ -147,8 +147,8 @@ void block_merge_sort(c2h::device_vector<KeyT>& keys, ActionT action)
     cuda::std::numeric_limits<KeyT>::max(),
     action);
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 template <int ItemsPerThread, int ThreadsInBlock, class KeyT, class ValueT, class ActionT>
@@ -161,8 +161,8 @@ void block_merge_sort(c2h::device_vector<KeyT>& keys, c2h::device_vector<ValueT>
     cuda::std::numeric_limits<KeyT>::max(),
     action);
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 // %PARAM% THREADS_IN_BLOCK bs 64:256

--- a/cub/test/catch2_test_block_radix_sort.cuh
+++ b/cub/test/catch2_test_block_radix_sort.cuh
@@ -72,8 +72,8 @@ void block_radix_sort(
   kernel<InputIteratorT, OutputIteratorT, ActionT, ItemsPerThread, ThreadsInBlock, RadixBits, Memoize, Algorithm, ShmemConfig>
     <<<1, ThreadsInBlock>>>(action, input, output, begin_bit, end_bit, striped);
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 template <typename InputKeyIteratorT,
@@ -172,8 +172,8 @@ void block_radix_sort(
          ShmemConfig>
     <<<1, ThreadsInBlock>>>(action, input_keys, input_values, output_keys, output_values, begin_bit, end_bit, striped);
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 struct sort_op_t

--- a/cub/test/catch2_test_block_radix_sort_custom.cu
+++ b/cub/test/catch2_test_block_radix_sort_custom.cu
@@ -943,66 +943,66 @@ __global__ void sort_pairs_descending_blocked_to_striped_bits()
 TEST_CASE("Block radix sort works in some corner cases", "[radix][sort][block]")
 {
   sort_keys<<<1, 2>>>();
-  REQUIRE(cudaSuccess == cudaGetLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaGetLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   sort_keys_bits<<<1, 2>>>();
-  REQUIRE(cudaSuccess == cudaGetLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaGetLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   sort_keys_descending<<<1, 2>>>();
-  REQUIRE(cudaSuccess == cudaGetLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaGetLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   sort_keys_descending_bits<<<1, 2>>>();
-  REQUIRE(cudaSuccess == cudaGetLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaGetLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   sort_pairs<<<1, 2>>>();
-  REQUIRE(cudaSuccess == cudaGetLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaGetLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   sort_pairs_bits<<<1, 2>>>();
-  REQUIRE(cudaSuccess == cudaGetLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaGetLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   sort_pairs_descending<<<1, 2>>>();
-  REQUIRE(cudaSuccess == cudaGetLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaGetLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   sort_pairs_descending_bits<<<1, 2>>>();
-  REQUIRE(cudaSuccess == cudaGetLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaGetLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   sort_keys_blocked_to_striped<<<1, 2>>>();
-  REQUIRE(cudaSuccess == cudaGetLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaGetLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   sort_keys_blocked_to_striped_bits<<<1, 2>>>();
-  REQUIRE(cudaSuccess == cudaGetLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaGetLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   sort_pairs_blocked_to_striped<<<1, 2>>>();
-  REQUIRE(cudaSuccess == cudaGetLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaGetLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   sort_pairs_blocked_to_striped_bits<<<1, 2>>>();
-  REQUIRE(cudaSuccess == cudaGetLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaGetLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   sort_keys_descending_blocked_to_striped<<<1, 2>>>();
-  REQUIRE(cudaSuccess == cudaGetLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaGetLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   sort_keys_descending_blocked_to_striped_bits<<<1, 2>>>();
-  REQUIRE(cudaSuccess == cudaGetLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaGetLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   sort_pairs_descending_blocked_to_striped<<<1, 2>>>();
-  REQUIRE(cudaSuccess == cudaGetLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaGetLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   sort_pairs_descending_blocked_to_striped_bits<<<1, 2>>>();
-  REQUIRE(cudaSuccess == cudaGetLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaGetLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }

--- a/cub/test/catch2_test_block_reduce.cu
+++ b/cub/test/catch2_test_block_reduce.cu
@@ -59,8 +59,8 @@ void block_reduce(c2h::device_vector<T>& in, c2h::device_vector<T>& out, ActionT
   block_reduce_kernel<Algorithm, ItemsPerThread, BlockDimX, BlockDimY, BlockDimZ, T, ActionT><<<1, block_dims>>>(
     thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), static_cast<int>(in.size()), action);
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 struct sum_partial_tile_op_t

--- a/cub/test/catch2_test_block_scan.cu
+++ b/cub/test/catch2_test_block_scan.cu
@@ -77,8 +77,8 @@ void block_scan(c2h::device_vector<T>& in, c2h::device_vector<T>& out, ActionT a
   block_scan_kernel<Algorithm, ItemsPerThread, BlockDimX, BlockDimY, BlockDimZ, T, ActionT>
     <<<1, block_dims>>>(thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), action);
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 template <cub::BlockScanAlgorithm Algorithm, int BlockDimX, int BlockDimY, int BlockDimZ, class T, class ActionT>
@@ -89,8 +89,8 @@ void block_scan_single(c2h::device_vector<T>& in, c2h::device_vector<T>& out, Ac
   block_scan_single_kernel<Algorithm, BlockDimX, BlockDimY, BlockDimZ, T, ActionT>
     <<<1, block_dims>>>(thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), action);
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 enum class scan_mode

--- a/cub/test/catch2_test_block_scan_api.cu
+++ b/cub/test/catch2_test_block_scan_api.cu
@@ -46,8 +46,8 @@ C2H_TEST("Block array-based inclusive scan works with initial value", "[scan][bl
   c2h::device_vector<int> d_out(block_num_threads * num_items_per_thread);
 
   InclusiveBlockScanKernel<<<1, block_num_threads>>>(thrust::raw_pointer_cast(d_out.data()));
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   c2h::host_vector<int> expected(d_out.size());
   for (size_t i = 0; i < expected.size() - 1; i += 2)
@@ -102,8 +102,8 @@ C2H_TEST("Block array-based inclusive scan with block aggregate works with initi
   c2h::device_vector<int> d_block_aggregate(1);
   InclusiveBlockScanKernelAggregate<<<1, block_num_threads>>>(
     thrust::raw_pointer_cast(d_out.data()), thrust::raw_pointer_cast(d_block_aggregate.data()));
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   c2h::host_vector<int> expected(d_out.size());
   for (size_t i = 0; i < expected.size() - 1; i += 2)

--- a/cub/test/catch2_test_block_shuffle.cu
+++ b/cub/test/catch2_test_block_shuffle.cu
@@ -147,8 +147,8 @@ void block_shuffle(c2h::device_vector<T>& data, ActionT action)
   block_shuffle_kernel<BlockDimX, BlockDimY, BlockDimZ, ItemsPerThread>
     <<<1, block>>>(thrust::raw_pointer_cast(data.data()), action);
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 // %PARAM% MULTI_DIM mdim 0:1

--- a/cub/test/catch2_test_block_store.cu
+++ b/cub/test/catch2_test_block_store.cu
@@ -95,8 +95,8 @@ void block_store(InputIteratorT input, OutputIteratorT output, int num_items)
   kernel<InputIteratorT, OutputIteratorT, ItemsPerThread, ThreadsInBlock, StoreAlgorithm>
     <<<1, ThreadsInBlock>>>(std::integral_constant<bool, sufficient_resources>{}, input, output, num_items);
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 // %PARAM% IPT it 1:11

--- a/cub/test/catch2_test_c2h_checked_cuda_allocator.cu
+++ b/cub/test/catch2_test_c2h_checked_cuda_allocator.cu
@@ -13,8 +13,7 @@ std::size_t get_alloc_bytes()
 {
   std::size_t free_bytes{};
   std::size_t total_bytes{};
-  cudaError_t status = cudaMemGetInfo(&free_bytes, &total_bytes);
-  REQUIRE(status == cudaSuccess);
+  REQUIRE_CUDART(cudaMemGetInfo(&free_bytes, &total_bytes));
 
   // Find a size that's > free but < total, preferring to return more than total if the values are
   // too close.

--- a/cub/test/catch2_test_device_adjacent_difference_env.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_env.cu
@@ -35,9 +35,8 @@ TEST_CASE("Device adjacent difference subtract left copy works with default envi
   auto input  = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
   auto output = c2h::device_vector<int>(8);
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceAdjacentDifference::SubtractLeftCopy(
-            input.begin(), output.begin(), input.size(), cuda::std::minus{}));
+  REQUIRE_CUDART(
+    cub::DeviceAdjacentDifference::SubtractLeftCopy(input.begin(), output.begin(), input.size(), cuda::std::minus{}));
 
   c2h::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
   REQUIRE(output == expected);
@@ -47,7 +46,7 @@ TEST_CASE("Device adjacent difference subtract left works with default environme
 {
   auto data = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
 
-  REQUIRE(cudaSuccess == cub::DeviceAdjacentDifference::SubtractLeft(data.begin(), data.size(), cuda::std::minus{}));
+  REQUIRE_CUDART(cub::DeviceAdjacentDifference::SubtractLeft(data.begin(), data.size(), cuda::std::minus{}));
 
   c2h::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
   REQUIRE(data == expected);
@@ -59,9 +58,8 @@ TEST_CASE("Device adjacent difference subtract right copy works with default env
   auto input  = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
   auto output = c2h::device_vector<int>(8);
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceAdjacentDifference::SubtractRightCopy(
-            input.begin(), output.begin(), input.size(), cuda::std::minus{}));
+  REQUIRE_CUDART(
+    cub::DeviceAdjacentDifference::SubtractRightCopy(input.begin(), output.begin(), input.size(), cuda::std::minus{}));
 
   c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
   REQUIRE(output == expected);
@@ -71,7 +69,7 @@ TEST_CASE("Device adjacent difference subtract right works with default environm
 {
   auto data = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
 
-  REQUIRE(cudaSuccess == cub::DeviceAdjacentDifference::SubtractRight(data.begin(), data.size(), cuda::std::minus{}));
+  REQUIRE_CUDART(cub::DeviceAdjacentDifference::SubtractRight(data.begin(), data.size(), cuda::std::minus{}));
 
   c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
   REQUIRE(data == expected);
@@ -85,9 +83,8 @@ C2H_TEST("Device adjacent difference subtract left copy uses environment", "[adj
   auto output = c2h::device_vector<int>(8);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceAdjacentDifference::SubtractLeftCopy(
-            nullptr, expected_bytes_allocated, input.begin(), output.begin(), input.size(), cuda::std::minus{}));
+  REQUIRE_CUDART(cub::DeviceAdjacentDifference::SubtractLeftCopy(
+    nullptr, expected_bytes_allocated, input.begin(), output.begin(), input.size(), cuda::std::minus{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -102,9 +99,8 @@ C2H_TEST("Device adjacent difference subtract left uses environment", "[adjacent
   auto data = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceAdjacentDifference::SubtractLeft(
-            nullptr, expected_bytes_allocated, data.begin(), data.size(), cuda::std::minus{}));
+  REQUIRE_CUDART(cub::DeviceAdjacentDifference::SubtractLeft(
+    nullptr, expected_bytes_allocated, data.begin(), data.size(), cuda::std::minus{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -120,9 +116,8 @@ C2H_TEST("Device adjacent difference subtract right copy uses environment", "[ad
   auto output = c2h::device_vector<int>(8);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceAdjacentDifference::SubtractRightCopy(
-            nullptr, expected_bytes_allocated, input.begin(), output.begin(), input.size(), cuda::std::minus{}));
+  REQUIRE_CUDART(cub::DeviceAdjacentDifference::SubtractRightCopy(
+    nullptr, expected_bytes_allocated, input.begin(), output.begin(), input.size(), cuda::std::minus{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -137,9 +132,8 @@ C2H_TEST("Device adjacent difference subtract right uses environment", "[adjacen
   auto data = c2h::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceAdjacentDifference::SubtractRight(
-            nullptr, expected_bytes_allocated, data.begin(), data.size(), cuda::std::minus{}));
+  REQUIRE_CUDART(cub::DeviceAdjacentDifference::SubtractRight(
+    nullptr, expected_bytes_allocated, data.begin(), data.size(), cuda::std::minus{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 

--- a/cub/test/catch2_test_device_adjacent_difference_env_api.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_env_api.cu
@@ -33,7 +33,7 @@ C2H_TEST("cub::DeviceAdjacentDifference::SubtractLeftCopy accepts stream", "[adj
   thrust::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
   // example-end subtract-left-copy-env-stream
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -55,7 +55,7 @@ C2H_TEST("cub::DeviceAdjacentDifference::SubtractLeft accepts stream", "[adjacen
   // example-end subtract-left-env-stream
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(data == expected);
 }
 
@@ -79,7 +79,7 @@ C2H_TEST("cub::DeviceAdjacentDifference::SubtractRightCopy accepts stream", "[ad
   // example-end subtract-right-copy-env-stream
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -101,6 +101,6 @@ C2H_TEST("cub::DeviceAdjacentDifference::SubtractRight accepts stream", "[adjace
   // example-end subtract-right-env-stream
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(data == expected);
 }

--- a/cub/test/catch2_test_device_copy_env.cu
+++ b/cub/test/catch2_test_device_copy_env.cu
@@ -63,7 +63,7 @@ TEST_CASE("DeviceCopy::Batched works with default environment", "[copy][device]"
     iota, index_to_ptr<int>{thrust::raw_pointer_cast(d_dst.data()), thrust::raw_pointer_cast(d_offsets.data())});
   auto sizes = thrust::make_transform_iterator(iota, get_size{thrust::raw_pointer_cast(d_offsets.data())});
 
-  REQUIRE(cudaSuccess == cub::DeviceCopy::Batched(input_it, output_it, sizes, num_ranges));
+  REQUIRE_CUDART(cub::DeviceCopy::Batched(input_it, output_it, sizes, num_ranges));
 
   REQUIRE(d_dst == d_src);
 }
@@ -87,8 +87,7 @@ C2H_TEST("DeviceCopy::Batched uses environment", "[copy][device]")
   auto sizes = thrust::make_transform_iterator(iota, get_size{thrust::raw_pointer_cast(d_offsets.data())});
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess == cub::DeviceCopy::Batched(nullptr, expected_bytes_allocated, input_it, output_it, sizes, num_ranges));
+  REQUIRE_CUDART(cub::DeviceCopy::Batched(nullptr, expected_bytes_allocated, input_it, output_it, sizes, num_ranges));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -114,18 +113,17 @@ TEST_CASE("DeviceCopy::Batched uses custom stream", "[copy][device]")
   auto sizes = thrust::make_transform_iterator(iota, get_size{thrust::raw_pointer_cast(d_offsets.data())});
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess == cub::DeviceCopy::Batched(nullptr, expected_bytes_allocated, input_it, output_it, sizes, num_ranges));
+  REQUIRE_CUDART(cub::DeviceCopy::Batched(nullptr, expected_bytes_allocated, input_it, output_it, sizes, num_ranges));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
 
   device_copy_batched(input_it, output_it, sizes, num_ranges, env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
   REQUIRE(d_dst == d_src);
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }

--- a/cub/test/catch2_test_device_copy_env_api.cu
+++ b/cub/test/catch2_test_device_copy_env_api.cu
@@ -53,7 +53,7 @@ C2H_TEST("cub::DeviceCopy::Batched accepts env with stream", "[copy][env]")
   }
   // example-end copy-batched-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_dst == d_src);
 }
 
@@ -87,7 +87,7 @@ C2H_TEST("cub::DeviceCopy::Copy mdspan accepts env with stream", "[copy][env]")
   }
   // example-end copy-mdspan-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   // Verify the data was copied
   REQUIRE(d_input == d_output);
 }

--- a/cub/test/catch2_test_device_copy_mdspan_api.cu
+++ b/cub/test/catch2_test_device_copy_mdspan_api.cu
@@ -10,11 +10,6 @@
 
 #include <c2h/catch2_test_helper.h>
 
-void check_status(cudaError_t status)
-{
-  REQUIRE(status == cudaSuccess);
-}
-
 C2H_TEST("DeviceCopy::Copy Mdspan API example", "[copy][mdspan]")
 {
   // clang-format off
@@ -37,16 +32,14 @@ C2H_TEST("DeviceCopy::Copy Mdspan API example", "[copy][mdspan]")
   // Determine temporary device storage requirements
   void*  d_temp_storage     = nullptr;
   size_t temp_storage_bytes = 0;
-  auto status = cub::DeviceCopy::Copy(d_temp_storage, temp_storage_bytes, mdspan_in, mdspan_out);
-  check_status(status);
+  REQUIRE_CUDART(cub::DeviceCopy::Copy(d_temp_storage, temp_storage_bytes, mdspan_in, mdspan_out));
 
   // Allocate temporary storage using thrust::device_vector
   thrust::device_vector<char> temp_storage(temp_storage_bytes, thrust::no_init);
   d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
 
   // Run copy algorithm
-  status = cub::DeviceCopy::Copy(d_temp_storage, temp_storage_bytes, mdspan_in, mdspan_out);
-  check_status(status);
+  REQUIRE_CUDART(cub::DeviceCopy::Copy(d_temp_storage, temp_storage_bytes, mdspan_in, mdspan_out));
 // example-end copy-mdspan-example-op
   // clang-format on
   REQUIRE(d_input == d_output);

--- a/cub/test/catch2_test_device_decoupled_look_back.cu
+++ b/cub/test/catch2_test_device_decoupled_look_back.cu
@@ -121,20 +121,19 @@ C2H_TEST("Decoupled look-back works with various message types", "[decoupled loo
 
   // Initialize temporary storage
   scan_tile_state_t tile_status;
-  cudaError_t status = tile_status.Init(num_tiles, d_temp_storage, temp_storage_bytes);
-  REQUIRE(status == cudaSuccess);
+  REQUIRE_CUDART(tile_status.Init(num_tiles, d_temp_storage, temp_storage_bytes));
 
   constexpr unsigned int threads_in_init_block = 256;
   const unsigned int blocks_in_init_grid       = cuda::ceil_div(num_tiles, threads_in_init_block);
   init_kernel<<<blocks_in_init_grid, threads_in_init_block>>>(tile_status, num_tiles);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   // Launch decoupled look-back
   constexpr unsigned int threads_in_block = 256;
   decoupled_look_back_kernel<<<num_tiles, threads_in_block>>>(tile_status, d_tile_data);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   REQUIRE(reference == tile_data);
 }

--- a/cub/test/catch2_test_device_exclusive_scan_noncommutative.cu
+++ b/cub/test/catch2_test_device_exclusive_scan_noncommutative.cu
@@ -147,7 +147,7 @@ C2H_TEST("Device exclusive scan works with non-commutative bicyclic monoid opera
   size_t tmp_size{};
   cudaError_t status1 =
     cub::DeviceScan::ExclusiveScan(nullptr, tmp_size, d_input, d_output, op_t{}, init_value, num_items);
-  REQUIRE(cudaSuccess == status1);
+  REQUIRE_CUDART(status1);
   REQUIRE(tmp_size > 0);
 
   using cuda::std::byte;
@@ -157,7 +157,7 @@ C2H_TEST("Device exclusive scan works with non-commutative bicyclic monoid opera
 
   cudaError_t status2 =
     cub::DeviceScan::ExclusiveScan(d_tmp, tmp_size, d_input, d_output, op_t{}, init_value, num_items);
-  REQUIRE(cudaSuccess == status2);
+  REQUIRE_CUDART(status2);
 
   // transfer to host_vector is synchronizing
   c2h::host_vector<pair_t> h_output(output);
@@ -204,7 +204,7 @@ C2H_TEST("Device exclusive scan works with PropagateLastWrite operator", "[scan]
   size_t tmp_size{};
   cudaError_t status1 =
     cub::DeviceScan::ExclusiveScan(nullptr, tmp_size, d_input, d_output, op, empty_stack_symbol, num_items);
-  REQUIRE(cudaSuccess == status1);
+  REQUIRE_CUDART(status1);
   REQUIRE(tmp_size > 0);
 
   using cuda::std::byte;
@@ -214,7 +214,7 @@ C2H_TEST("Device exclusive scan works with PropagateLastWrite operator", "[scan]
 
   cudaError_t status2 =
     cub::DeviceScan::ExclusiveScan(d_tmp, tmp_size, d_input, d_output, op, empty_stack_symbol, num_items);
-  REQUIRE(cudaSuccess == status2);
+  REQUIRE_CUDART(status2);
 
   // transfer to host_vector is synchronizing
   c2h::host_vector<symbol_t> h_output(output);
@@ -272,7 +272,7 @@ C2H_TEST("Device exclusive scan PropagateLastWrite reproduces original bug-repor
   size_t tmp_size{};
   cudaError_t status1 =
     cub::DeviceScan::ExclusiveScan(nullptr, tmp_size, d_input, d_output, op, empty_stack_symbol, num_elements);
-  REQUIRE(cudaSuccess == status1);
+  REQUIRE_CUDART(status1);
 
   using cuda::std::byte;
 
@@ -281,7 +281,7 @@ C2H_TEST("Device exclusive scan PropagateLastWrite reproduces original bug-repor
 
   cudaError_t status2 =
     cub::DeviceScan::ExclusiveScan(d_tmp, tmp_size, d_input, d_output, op, empty_stack_symbol, num_elements);
-  REQUIRE(cudaSuccess == status2);
+  REQUIRE_CUDART(status2);
 
   c2h::host_vector<symbol_t> h_output(output);
   REQUIRE(h_expected == h_output);

--- a/cub/test/catch2_test_device_find_env.cu
+++ b/cub/test/catch2_test_device_find_env.cu
@@ -44,7 +44,7 @@ TEST_CASE("Device FindIf works with default environment", "[find][device]")
   is_greater_than_t predicate{4};
 
   auto error = cub::DeviceFind::FindIf(d_in.begin(), d_out.begin(), predicate, num_items);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_out[0] == 5);
 }
 
@@ -56,7 +56,7 @@ TEST_CASE("Device FindIf no match returns num_items with default environment", "
   is_greater_than_t predicate{100};
 
   auto error = cub::DeviceFind::FindIf(d_in.begin(), d_out.begin(), predicate, num_items);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_out[0] == num_items);
 }
 
@@ -66,14 +66,13 @@ TEST_CASE("Device LowerBound works with default environment", "[find][device]")
   auto d_values = c2h::device_vector<int>{1, 3, 5, 7};
   auto d_output = c2h::device_vector<int>(4);
 
-  auto error = cub::DeviceFind::LowerBound(
+  REQUIRE_CUDART(cub::DeviceFind::LowerBound(
     d_range.begin(),
     static_cast<int>(d_range.size()),
     d_values.begin(),
     static_cast<int>(d_values.size()),
     d_output.begin(),
-    cuda::std::less{});
-  REQUIRE(error == cudaSuccess);
+    cuda::std::less{}));
 
   c2h::device_vector<int> expected = {1, 2, 3, 4};
   REQUIRE(d_output == expected);
@@ -85,14 +84,13 @@ TEST_CASE("Device UpperBound works with default environment", "[find][device]")
   auto d_values = c2h::device_vector<int>{1, 3, 5, 7};
   auto d_output = c2h::device_vector<int>(4);
 
-  auto error = cub::DeviceFind::UpperBound(
+  REQUIRE_CUDART(cub::DeviceFind::UpperBound(
     d_range.begin(),
     static_cast<int>(d_range.size()),
     d_values.begin(),
     static_cast<int>(d_values.size()),
     d_output.begin(),
-    cuda::std::less{});
-  REQUIRE(error == cudaSuccess);
+    cuda::std::less{}));
 
   c2h::device_vector<int> expected = {1, 2, 3, 4};
   REQUIRE(d_output == expected);
@@ -108,9 +106,8 @@ C2H_TEST("Device FindIf uses environment", "[find][device]")
   is_greater_than_t predicate{4};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceFind::FindIf(nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), predicate, num_items));
+  REQUIRE_CUDART(
+    cub::DeviceFind::FindIf(nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), predicate, num_items));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -126,17 +123,15 @@ C2H_TEST("Device LowerBound uses environment", "[find][device]")
   auto d_output = c2h::device_vector<int>(4);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceFind::LowerBound(
-      nullptr,
-      expected_bytes_allocated,
-      d_range.begin(),
-      static_cast<int>(d_range.size()),
-      d_values.begin(),
-      static_cast<int>(d_values.size()),
-      d_output.begin(),
-      cuda::std::less{}));
+  REQUIRE_CUDART(cub::DeviceFind::LowerBound(
+    nullptr,
+    expected_bytes_allocated,
+    d_range.begin(),
+    static_cast<int>(d_range.size()),
+    d_values.begin(),
+    static_cast<int>(d_values.size()),
+    d_output.begin(),
+    cuda::std::less{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -160,17 +155,15 @@ C2H_TEST("Device UpperBound uses environment", "[find][device]")
   auto d_output = c2h::device_vector<int>(4);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceFind::UpperBound(
-      nullptr,
-      expected_bytes_allocated,
-      d_range.begin(),
-      static_cast<int>(d_range.size()),
-      d_values.begin(),
-      static_cast<int>(d_values.size()),
-      d_output.begin(),
-      cuda::std::less{}));
+  REQUIRE_CUDART(cub::DeviceFind::UpperBound(
+    nullptr,
+    expected_bytes_allocated,
+    d_range.begin(),
+    static_cast<int>(d_range.size()),
+    d_values.begin(),
+    static_cast<int>(d_values.size()),
+    d_output.begin(),
+    cuda::std::less{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 

--- a/cub/test/catch2_test_device_find_env_api.cu
+++ b/cub/test/catch2_test_device_find_env_api.cu
@@ -46,7 +46,7 @@ C2H_TEST("cub::DeviceFind::FindIf accepts env with stream", "[find][env]")
   // example-end find-if-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_out[0] == expected);
 }
 
@@ -77,7 +77,7 @@ C2H_TEST("cub::DeviceFind::LowerBound accepts env with stream", "[find][env]")
   // example-end lower-bound-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_output == expected);
 }
 
@@ -108,6 +108,6 @@ C2H_TEST("cub::DeviceFind::UpperBound accepts env with stream", "[find][env]")
   // example-end upper-bound-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_output == expected);
 }

--- a/cub/test/catch2_test_device_for_env.cu
+++ b/cub/test/catch2_test_device_for_env.cu
@@ -57,9 +57,8 @@ C2H_TEST("DeviceFor::Bulk env uses custom stream", "[for][env]")
   cuda::stream stream{cuda::devices[0]};
   auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
 
-  auto error = cub::DeviceFor::Bulk(4, op, env);
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
+  REQUIRE_CUDART(cub::DeviceFor::Bulk(4, op, env));
+  REQUIRE_CUDART(cudaStreamSynchronize(stream.get()));
 
   c2h::device_vector<int> expected{1, 4, 9, 16};
   REQUIRE(vec == expected);
@@ -77,9 +76,8 @@ C2H_TEST("DeviceFor::ForEachN env uses custom stream", "[for][env]")
   cuda::stream stream{cuda::devices[0]};
   auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
 
-  auto error = cub::DeviceFor::ForEachN(vec.begin(), static_cast<int>(vec.size()), op, env);
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
+  REQUIRE_CUDART(cub::DeviceFor::ForEachN(vec.begin(), static_cast<int>(vec.size()), op, env));
+  REQUIRE_CUDART(cudaStreamSynchronize(stream.get()));
 
   c2h::device_vector<int> expected{1, 4, 9, 16};
   REQUIRE(vec == expected);
@@ -97,9 +95,8 @@ C2H_TEST("DeviceFor::ForEach env uses custom stream", "[for][env]")
   cuda::stream stream{cuda::devices[0]};
   auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
 
-  auto error = cub::DeviceFor::ForEach(vec.begin(), vec.end(), op, env);
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
+  REQUIRE_CUDART(cub::DeviceFor::ForEach(vec.begin(), vec.end(), op, env));
+  REQUIRE_CUDART(cudaStreamSynchronize(stream.get()));
 
   c2h::device_vector<int> expected{1, 4, 9, 16};
   REQUIRE(vec == expected);
@@ -118,9 +115,8 @@ C2H_TEST("DeviceFor::ForEachCopyN env uses custom stream", "[for][env]")
   cuda::stream stream{cuda::devices[0]};
   auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
 
-  auto error = cub::DeviceFor::ForEachCopyN(vec.begin(), static_cast<int>(vec.size()), op, env);
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
+  REQUIRE_CUDART(cub::DeviceFor::ForEachCopyN(vec.begin(), static_cast<int>(vec.size()), op, env));
+  REQUIRE_CUDART(cudaStreamSynchronize(stream.get()));
 
   c2h::device_vector<int> expected_count{2};
   REQUIRE(count == expected_count);
@@ -139,9 +135,8 @@ C2H_TEST("DeviceFor::ForEachCopy env uses custom stream", "[for][env]")
   cuda::stream stream{cuda::devices[0]};
   auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
 
-  auto error = cub::DeviceFor::ForEachCopy(vec.begin(), vec.end(), op, env);
-  REQUIRE(error == cudaSuccess);
-  REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
+  REQUIRE_CUDART(cub::DeviceFor::ForEachCopy(vec.begin(), vec.end(), op, env));
+  REQUIRE_CUDART(cudaStreamSynchronize(stream.get()));
 
   c2h::device_vector<int> expected_count{2};
   REQUIRE(count == expected_count);
@@ -179,7 +174,7 @@ C2H_TEST("DeviceFor::Bulk can be tuned", "[for][device]", block_sizes)
   block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::tune(for_each_tuning<target_block_size>{});
 
-  REQUIRE(cudaSuccess == cub::DeviceFor::Bulk(4, op, env));
+  REQUIRE_CUDART(cub::DeviceFor::Bulk(4, op, env));
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
@@ -191,7 +186,7 @@ C2H_TEST("DeviceFor::ForEachN can be tuned", "[for][device]", block_sizes)
   block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::tune(for_each_tuning<target_block_size>{});
 
-  REQUIRE(cudaSuccess == cub::DeviceFor::ForEachN(d_data.begin(), static_cast<int>(d_data.size()), op, env));
+  REQUIRE_CUDART(cub::DeviceFor::ForEachN(d_data.begin(), static_cast<int>(d_data.size()), op, env));
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
@@ -203,7 +198,7 @@ C2H_TEST("DeviceFor::ForEach can be tuned", "[for][device]", block_sizes)
   block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::tune(for_each_tuning<target_block_size>{});
 
-  REQUIRE(cudaSuccess == cub::DeviceFor::ForEach(d_data.begin(), d_data.end(), op, env));
+  REQUIRE_CUDART(cub::DeviceFor::ForEach(d_data.begin(), d_data.end(), op, env));
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
@@ -215,7 +210,7 @@ C2H_TEST("DeviceFor::ForEachCopyN can be tuned", "[for][device]", block_sizes)
   block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::tune(for_each_tuning<target_block_size>{});
 
-  REQUIRE(cudaSuccess == cub::DeviceFor::ForEachCopyN(d_data.begin(), static_cast<int>(d_data.size()), op, env));
+  REQUIRE_CUDART(cub::DeviceFor::ForEachCopyN(d_data.begin(), static_cast<int>(d_data.size()), op, env));
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
@@ -227,6 +222,6 @@ C2H_TEST("DeviceFor::ForEachCopy can be tuned", "[for][device]", block_sizes)
   block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::tune(for_each_tuning<target_block_size>{});
 
-  REQUIRE(cudaSuccess == cub::DeviceFor::ForEachCopy(d_data.begin(), d_data.end(), op, env));
+  REQUIRE_CUDART(cub::DeviceFor::ForEachCopy(d_data.begin(), d_data.end(), op, env));
   REQUIRE(d_block_size[0] == target_block_size);
 }

--- a/cub/test/catch2_test_device_for_env_api.cu
+++ b/cub/test/catch2_test_device_for_env_api.cu
@@ -71,7 +71,7 @@ C2H_TEST("cub::DeviceFor::Bulk env-based API", "[for][env]")
   thrust::device_vector<int> expected{1, 4, 9, 16};
   // example-end bulk-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(vec == expected);
 }
 
@@ -94,7 +94,7 @@ C2H_TEST("cub::DeviceFor::ForEachN env-based API", "[for][env]")
   thrust::device_vector<int> expected{1, 4, 9, 16};
   // example-end for-each-n-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(vec == expected);
 }
 
@@ -117,7 +117,7 @@ C2H_TEST("cub::DeviceFor::ForEach env-based API", "[for][env]")
   thrust::device_vector<int> expected{1, 4, 9, 16};
   // example-end for-each-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(vec == expected);
 }
 
@@ -141,7 +141,7 @@ C2H_TEST("cub::DeviceFor::ForEachCopyN env-based API", "[for][env]")
   thrust::device_vector<int> expected_count{2};
   // example-end for-each-copy-n-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(count == expected_count);
 }
 
@@ -165,6 +165,6 @@ C2H_TEST("cub::DeviceFor::ForEachCopy env-based API", "[for][env]")
   thrust::device_vector<int> expected_count{2};
   // example-end for-each-copy-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(count == expected_count);
 }

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -752,7 +752,7 @@ C2H_TEST_LIST(
   const int valid_num_levels = valid_num_bins + 1;
 
   temp_storage_bytes = canary_bytes;
-  const auto error2  = cub::DeviceHistogram::HistogramEven(
+  REQUIRE_CUDART(cub::DeviceHistogram::HistogramEven(
     nullptr,
     temp_storage_bytes,
     d_samples,
@@ -760,9 +760,8 @@ C2H_TEST_LIST(
     valid_num_levels,
     lower_level,
     static_cast<level_t>(valid_num_bins), // upper_level must accommodate all bins
-    num_samples);
+    num_samples));
 
-  CHECK(error2 == cudaSuccess);
   CHECK(temp_storage_bytes != canary_bytes);
 }
 #endif // TEST_LAUNCH == 0

--- a/cub/test/catch2_test_device_histogram_env.cu
+++ b/cub/test/catch2_test_device_histogram_env.cu
@@ -47,15 +47,13 @@ TEST_CASE("DeviceHistogram::HistogramEven works with default environment", "[his
   int upper_level  = 5;
   auto d_histogram = c2h::device_vector<int>(num_levels - 1, 0);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::HistogramEven(
-      thrust::raw_pointer_cast(d_samples.data()),
-      thrust::raw_pointer_cast(d_histogram.data()),
-      num_levels,
-      lower_level,
-      upper_level,
-      num_samples));
+  REQUIRE_CUDART(cub::DeviceHistogram::HistogramEven(
+    thrust::raw_pointer_cast(d_samples.data()),
+    thrust::raw_pointer_cast(d_histogram.data()),
+    num_levels,
+    lower_level,
+    upper_level,
+    num_samples));
 
   c2h::device_vector<int> expected{2, 2, 2, 1, 1};
   REQUIRE(d_histogram == expected);
@@ -69,13 +67,12 @@ TEST_CASE("DeviceHistogram::HistogramRange works with default environment", "[hi
   int num_levels   = static_cast<int>(d_levels.size());
   auto d_histogram = c2h::device_vector<int>(num_levels - 1, 0);
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceHistogram::HistogramRange(
-            thrust::raw_pointer_cast(d_samples.data()),
-            thrust::raw_pointer_cast(d_histogram.data()),
-            num_levels,
-            thrust::raw_pointer_cast(d_levels.data()),
-            num_samples));
+  REQUIRE_CUDART(cub::DeviceHistogram::HistogramRange(
+    thrust::raw_pointer_cast(d_samples.data()),
+    thrust::raw_pointer_cast(d_histogram.data()),
+    num_levels,
+    thrust::raw_pointer_cast(d_levels.data()),
+    num_samples));
 
   c2h::device_vector<int> expected{1, 5, 0, 2};
   REQUIRE(d_histogram == expected);
@@ -103,9 +100,8 @@ TEST_CASE("DeviceHistogram::MultiHistogramEven works with default environment", 
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-            thrust::raw_pointer_cast(d_samples.data()), d_histogram, num_levels, lower_level, upper_level, num_pixels));
+  REQUIRE_CUDART(cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
+    thrust::raw_pointer_cast(d_samples.data()), d_histogram, num_levels, lower_level, upper_level, num_pixels));
 
   c2h::device_vector<int> expected_r{1, 0, 0, 1};
   c2h::device_vector<int> expected_g{0, 0, 1, 0};
@@ -144,9 +140,8 @@ TEST_CASE("DeviceHistogram::MultiHistogramRange works with default environment",
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-            thrust::raw_pointer_cast(d_samples.data()), d_histogram, num_levels, d_levels, num_pixels));
+  REQUIRE_CUDART(cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
+    thrust::raw_pointer_cast(d_samples.data()), d_histogram, num_levels, d_levels, num_pixels));
 
   c2h::device_vector<int> expected_r{1, 1};
   c2h::device_vector<int> expected_g{1, 1};
@@ -168,17 +163,15 @@ TEST_CASE("DeviceHistogram::HistogramEven 2D works with default environment", "[
   size_t row_stride_bytes = 4 * sizeof(int);
   auto d_histogram        = c2h::device_vector<int>(num_levels - 1, 0);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::HistogramEven(
-      thrust::raw_pointer_cast(d_samples.data()),
-      thrust::raw_pointer_cast(d_histogram.data()),
-      num_levels,
-      lower_level,
-      upper_level,
-      num_row_samples,
-      num_rows,
-      row_stride_bytes));
+  REQUIRE_CUDART(cub::DeviceHistogram::HistogramEven(
+    thrust::raw_pointer_cast(d_samples.data()),
+    thrust::raw_pointer_cast(d_histogram.data()),
+    num_levels,
+    lower_level,
+    upper_level,
+    num_row_samples,
+    num_rows,
+    row_stride_bytes));
 
   c2h::device_vector<int> expected{2, 2, 2};
   REQUIRE(d_histogram == expected);
@@ -194,16 +187,14 @@ TEST_CASE("DeviceHistogram::HistogramRange 2D works with default environment", "
   size_t row_stride_bytes = 4 * sizeof(int);
   auto d_histogram        = c2h::device_vector<int>(num_levels - 1, 0);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::HistogramRange(
-      thrust::raw_pointer_cast(d_samples.data()),
-      thrust::raw_pointer_cast(d_histogram.data()),
-      num_levels,
-      thrust::raw_pointer_cast(d_levels.data()),
-      num_row_samples,
-      num_rows,
-      row_stride_bytes));
+  REQUIRE_CUDART(cub::DeviceHistogram::HistogramRange(
+    thrust::raw_pointer_cast(d_samples.data()),
+    thrust::raw_pointer_cast(d_histogram.data()),
+    num_levels,
+    thrust::raw_pointer_cast(d_levels.data()),
+    num_row_samples,
+    num_rows,
+    row_stride_bytes));
 
   c2h::device_vector<int> expected{2, 2, 2};
   REQUIRE(d_histogram == expected);
@@ -237,17 +228,15 @@ TEST_CASE("DeviceHistogram::MultiHistogramEven 2D works with default environment
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-      thrust::raw_pointer_cast(d_samples.data()),
-      d_histogram,
-      num_levels,
-      lower_level,
-      upper_level,
-      num_row_pixels,
-      num_rows,
-      row_stride_bytes));
+  REQUIRE_CUDART(cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
+    thrust::raw_pointer_cast(d_samples.data()),
+    d_histogram,
+    num_levels,
+    lower_level,
+    upper_level,
+    num_row_pixels,
+    num_rows,
+    row_stride_bytes));
 
   // R: 0,3,1,2 → bin[0]=1, bin[1]=1, bin[2]=1, bin[3]=1
   c2h::device_vector<int> expected_r{1, 1, 1, 1};
@@ -293,16 +282,14 @@ TEST_CASE("DeviceHistogram::MultiHistogramRange 2D works with default environmen
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-      thrust::raw_pointer_cast(d_samples.data()),
-      d_histogram,
-      num_levels,
-      d_levels,
-      num_row_pixels,
-      num_rows,
-      row_stride_bytes));
+  REQUIRE_CUDART(cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
+    thrust::raw_pointer_cast(d_samples.data()),
+    d_histogram,
+    num_levels,
+    d_levels,
+    num_row_pixels,
+    num_rows,
+    row_stride_bytes));
 
   // R: 0,3,1,2 → [0,2)=2, [2,4)=2
   c2h::device_vector<int> expected_r{2, 2};
@@ -327,17 +314,15 @@ C2H_TEST("DeviceHistogram::HistogramEven uses environment", "[histogram][device]
   auto d_histogram = c2h::device_vector<int>(num_levels - 1, 0);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::HistogramEven(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(d_samples.data()),
-      thrust::raw_pointer_cast(d_histogram.data()),
-      num_levels,
-      lower_level,
-      upper_level,
-      num_samples));
+  REQUIRE_CUDART(cub::DeviceHistogram::HistogramEven(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(d_samples.data()),
+    thrust::raw_pointer_cast(d_histogram.data()),
+    num_levels,
+    lower_level,
+    upper_level,
+    num_samples));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -364,20 +349,18 @@ TEST_CASE("DeviceHistogram::HistogramEven uses custom stream", "[histogram][devi
   auto d_histogram = c2h::device_vector<int>(num_levels - 1, 0);
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::HistogramEven(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(d_samples.data()),
-      thrust::raw_pointer_cast(d_histogram.data()),
-      num_levels,
-      lower_level,
-      upper_level,
-      num_samples));
+  REQUIRE_CUDART(cub::DeviceHistogram::HistogramEven(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(d_samples.data()),
+    thrust::raw_pointer_cast(d_histogram.data()),
+    num_levels,
+    lower_level,
+    upper_level,
+    num_samples));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -391,12 +374,12 @@ TEST_CASE("DeviceHistogram::HistogramEven uses custom stream", "[histogram][devi
     num_samples,
     env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<int> expected{2, 2, 2, 1, 1};
   REQUIRE(d_histogram == expected);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 C2H_TEST("DeviceHistogram::HistogramRange uses environment", "[histogram][device]")
@@ -408,16 +391,14 @@ C2H_TEST("DeviceHistogram::HistogramRange uses environment", "[histogram][device
   auto d_histogram = c2h::device_vector<int>(num_levels - 1, 0);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::HistogramRange(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(d_samples.data()),
-      thrust::raw_pointer_cast(d_histogram.data()),
-      num_levels,
-      thrust::raw_pointer_cast(d_levels.data()),
-      num_samples));
+  REQUIRE_CUDART(cub::DeviceHistogram::HistogramRange(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(d_samples.data()),
+    thrust::raw_pointer_cast(d_histogram.data()),
+    num_levels,
+    thrust::raw_pointer_cast(d_levels.data()),
+    num_samples));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -442,19 +423,17 @@ TEST_CASE("DeviceHistogram::HistogramRange uses custom stream", "[histogram][dev
   auto d_histogram = c2h::device_vector<int>(num_levels - 1, 0);
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::HistogramRange(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(d_samples.data()),
-      thrust::raw_pointer_cast(d_histogram.data()),
-      num_levels,
-      thrust::raw_pointer_cast(d_levels.data()),
-      num_samples));
+  REQUIRE_CUDART(cub::DeviceHistogram::HistogramRange(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(d_samples.data()),
+    thrust::raw_pointer_cast(d_histogram.data()),
+    num_levels,
+    thrust::raw_pointer_cast(d_levels.data()),
+    num_samples));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -467,12 +446,12 @@ TEST_CASE("DeviceHistogram::HistogramRange uses custom stream", "[histogram][dev
     num_samples,
     env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<int> expected{1, 5, 0, 2};
   REQUIRE(d_histogram == expected);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 C2H_TEST("DeviceHistogram::MultiHistogramEven uses environment", "[histogram][device]")
@@ -497,17 +476,15 @@ C2H_TEST("DeviceHistogram::MultiHistogramEven uses environment", "[histogram][de
     thrust::raw_pointer_cast(d_histogram_b.data())};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(d_samples.data()),
-      d_histogram,
-      num_levels,
-      lower_level,
-      upper_level,
-      num_pixels));
+  REQUIRE_CUDART(cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(d_samples.data()),
+    d_histogram,
+    num_levels,
+    lower_level,
+    upper_level,
+    num_pixels));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -544,20 +521,18 @@ TEST_CASE("DeviceHistogram::MultiHistogramEven uses custom stream", "[histogram]
     thrust::raw_pointer_cast(d_histogram_b.data())};
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(d_samples.data()),
-      d_histogram,
-      num_levels,
-      lower_level,
-      upper_level,
-      num_pixels));
+  REQUIRE_CUDART(cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(d_samples.data()),
+    d_histogram,
+    num_levels,
+    lower_level,
+    upper_level,
+    num_pixels));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -565,7 +540,7 @@ TEST_CASE("DeviceHistogram::MultiHistogramEven uses custom stream", "[histogram]
   multi_histogram_even<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
     thrust::raw_pointer_cast(d_samples.data()), d_histogram, num_levels, lower_level, upper_level, num_pixels, env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<int> expected_r{1, 0, 0, 1};
   c2h::device_vector<int> expected_g{0, 0, 1, 0};
@@ -574,7 +549,7 @@ TEST_CASE("DeviceHistogram::MultiHistogramEven uses custom stream", "[histogram]
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 C2H_TEST("DeviceHistogram::MultiHistogramRange uses environment", "[histogram][device]")
@@ -606,16 +581,14 @@ C2H_TEST("DeviceHistogram::MultiHistogramRange uses environment", "[histogram][d
     thrust::raw_pointer_cast(d_histogram_b.data())};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(d_samples.data()),
-      d_histogram,
-      num_levels,
-      d_levels,
-      num_pixels));
+  REQUIRE_CUDART(cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(d_samples.data()),
+    d_histogram,
+    num_levels,
+    d_levels,
+    num_pixels));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -659,19 +632,17 @@ TEST_CASE("DeviceHistogram::MultiHistogramRange uses custom stream", "[histogram
     thrust::raw_pointer_cast(d_histogram_b.data())};
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(d_samples.data()),
-      d_histogram,
-      num_levels,
-      d_levels,
-      num_pixels));
+  REQUIRE_CUDART(cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(d_samples.data()),
+    d_histogram,
+    num_levels,
+    d_levels,
+    num_pixels));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -679,7 +650,7 @@ TEST_CASE("DeviceHistogram::MultiHistogramRange uses custom stream", "[histogram
   multi_histogram_range<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
     thrust::raw_pointer_cast(d_samples.data()), d_histogram, num_levels, d_levels, num_pixels, env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<int> expected_r{1, 1};
   c2h::device_vector<int> expected_g{1, 1};
@@ -688,7 +659,7 @@ TEST_CASE("DeviceHistogram::MultiHistogramRange uses custom stream", "[histogram
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 C2H_TEST("DeviceHistogram::HistogramEven 2D uses environment", "[histogram][device]")
@@ -703,19 +674,17 @@ C2H_TEST("DeviceHistogram::HistogramEven 2D uses environment", "[histogram][devi
   auto d_histogram        = c2h::device_vector<int>(num_levels - 1, 0);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::HistogramEven(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(d_samples.data()),
-      thrust::raw_pointer_cast(d_histogram.data()),
-      num_levels,
-      lower_level,
-      upper_level,
-      num_row_samples,
-      num_rows,
-      row_stride_bytes));
+  REQUIRE_CUDART(cub::DeviceHistogram::HistogramEven(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(d_samples.data()),
+    thrust::raw_pointer_cast(d_histogram.data()),
+    num_levels,
+    lower_level,
+    upper_level,
+    num_row_samples,
+    num_rows,
+    row_stride_bytes));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -746,22 +715,20 @@ TEST_CASE("DeviceHistogram::HistogramEven 2D uses custom stream", "[histogram][d
   auto d_histogram        = c2h::device_vector<int>(num_levels - 1, 0);
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::HistogramEven(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(d_samples.data()),
-      thrust::raw_pointer_cast(d_histogram.data()),
-      num_levels,
-      lower_level,
-      upper_level,
-      num_row_samples,
-      num_rows,
-      row_stride_bytes));
+  REQUIRE_CUDART(cub::DeviceHistogram::HistogramEven(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(d_samples.data()),
+    thrust::raw_pointer_cast(d_histogram.data()),
+    num_levels,
+    lower_level,
+    upper_level,
+    num_row_samples,
+    num_rows,
+    row_stride_bytes));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -777,12 +744,12 @@ TEST_CASE("DeviceHistogram::HistogramEven 2D uses custom stream", "[histogram][d
     row_stride_bytes,
     env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<int> expected{2, 2, 2};
   REQUIRE(d_histogram == expected);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 C2H_TEST("DeviceHistogram::HistogramRange 2D uses environment", "[histogram][device]")
@@ -796,18 +763,16 @@ C2H_TEST("DeviceHistogram::HistogramRange 2D uses environment", "[histogram][dev
   auto d_histogram        = c2h::device_vector<int>(num_levels - 1, 0);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::HistogramRange(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(d_samples.data()),
-      thrust::raw_pointer_cast(d_histogram.data()),
-      num_levels,
-      thrust::raw_pointer_cast(d_levels.data()),
-      num_row_samples,
-      num_rows,
-      row_stride_bytes));
+  REQUIRE_CUDART(cub::DeviceHistogram::HistogramRange(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(d_samples.data()),
+    thrust::raw_pointer_cast(d_histogram.data()),
+    num_levels,
+    thrust::raw_pointer_cast(d_levels.data()),
+    num_row_samples,
+    num_rows,
+    row_stride_bytes));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -836,21 +801,19 @@ TEST_CASE("DeviceHistogram::HistogramRange 2D uses custom stream", "[histogram][
   auto d_histogram        = c2h::device_vector<int>(num_levels - 1, 0);
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::HistogramRange(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(d_samples.data()),
-      thrust::raw_pointer_cast(d_histogram.data()),
-      num_levels,
-      thrust::raw_pointer_cast(d_levels.data()),
-      num_row_samples,
-      num_rows,
-      row_stride_bytes));
+  REQUIRE_CUDART(cub::DeviceHistogram::HistogramRange(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(d_samples.data()),
+    thrust::raw_pointer_cast(d_histogram.data()),
+    num_levels,
+    thrust::raw_pointer_cast(d_levels.data()),
+    num_row_samples,
+    num_rows,
+    row_stride_bytes));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -865,12 +828,12 @@ TEST_CASE("DeviceHistogram::HistogramRange 2D uses custom stream", "[histogram][
     row_stride_bytes,
     env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<int> expected{2, 2, 2};
   REQUIRE(d_histogram == expected);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 C2H_TEST("DeviceHistogram::MultiHistogramEven 2D uses environment", "[histogram][device]")
@@ -899,19 +862,17 @@ C2H_TEST("DeviceHistogram::MultiHistogramEven 2D uses environment", "[histogram]
     thrust::raw_pointer_cast(d_histogram_b.data())};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(d_samples.data()),
-      d_histogram,
-      num_levels,
-      lower_level,
-      upper_level,
-      num_row_pixels,
-      num_rows,
-      row_stride_bytes));
+  REQUIRE_CUDART(cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(d_samples.data()),
+    d_histogram,
+    num_levels,
+    lower_level,
+    upper_level,
+    num_row_pixels,
+    num_rows,
+    row_stride_bytes));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -960,22 +921,20 @@ TEST_CASE("DeviceHistogram::MultiHistogramEven 2D uses custom stream", "[histogr
     thrust::raw_pointer_cast(d_histogram_b.data())};
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(d_samples.data()),
-      d_histogram,
-      num_levels,
-      lower_level,
-      upper_level,
-      num_row_pixels,
-      num_rows,
-      row_stride_bytes));
+  REQUIRE_CUDART(cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(d_samples.data()),
+    d_histogram,
+    num_levels,
+    lower_level,
+    upper_level,
+    num_row_pixels,
+    num_rows,
+    row_stride_bytes));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -991,7 +950,7 @@ TEST_CASE("DeviceHistogram::MultiHistogramEven 2D uses custom stream", "[histogr
     row_stride_bytes,
     env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<int> expected_r{1, 1, 1, 1};
   c2h::device_vector<int> expected_g{0, 1, 1, 1};
@@ -1000,7 +959,7 @@ TEST_CASE("DeviceHistogram::MultiHistogramEven 2D uses custom stream", "[histogr
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 C2H_TEST("DeviceHistogram::MultiHistogramRange 2D uses environment", "[histogram][device]")
@@ -1036,18 +995,16 @@ C2H_TEST("DeviceHistogram::MultiHistogramRange 2D uses environment", "[histogram
     thrust::raw_pointer_cast(d_histogram_b.data())};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(d_samples.data()),
-      d_histogram,
-      num_levels,
-      d_levels,
-      num_row_pixels,
-      num_rows,
-      row_stride_bytes));
+  REQUIRE_CUDART(cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(d_samples.data()),
+    d_histogram,
+    num_levels,
+    d_levels,
+    num_row_pixels,
+    num_rows,
+    row_stride_bytes));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -1102,21 +1059,19 @@ TEST_CASE("DeviceHistogram::MultiHistogramRange 2D uses custom stream", "[histog
     thrust::raw_pointer_cast(d_histogram_b.data())};
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(d_samples.data()),
-      d_histogram,
-      num_levels,
-      d_levels,
-      num_row_pixels,
-      num_rows,
-      row_stride_bytes));
+  REQUIRE_CUDART(cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(d_samples.data()),
+    d_histogram,
+    num_levels,
+    d_levels,
+    num_row_pixels,
+    num_rows,
+    row_stride_bytes));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -1131,7 +1086,7 @@ TEST_CASE("DeviceHistogram::MultiHistogramRange 2D uses custom stream", "[histog
     row_stride_bytes,
     env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<int> expected_r{2, 2};
   c2h::device_vector<int> expected_g{2, 2};
@@ -1140,5 +1095,5 @@ TEST_CASE("DeviceHistogram::MultiHistogramRange 2D uses custom stream", "[histog
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }

--- a/cub/test/catch2_test_device_histogram_env_api.cu
+++ b/cub/test/catch2_test_device_histogram_env_api.cu
@@ -46,7 +46,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramEven accepts env with stream", "[histog
   // example-end histogram-even-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_histogram == expected);
 }
 
@@ -89,7 +89,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramEven accepts env with stream (2D)", "[h
   // example-end histogram-even-2d-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_histogram == expected);
 }
 
@@ -122,7 +122,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramRange accepts env with stream", "[histo
   // example-end histogram-range-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_histogram == expected);
 }
 
@@ -163,7 +163,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramRange accepts env with stream (2D)", "[
   // example-end histogram-range-2d-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_histogram == expected);
 }
 
@@ -214,7 +214,7 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramEven accepts env with stream (1D)"
   // example-end multi-histogram-even-1d-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_histogram_r == expected_r);
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
@@ -278,7 +278,7 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramEven accepts env with stream (2D)"
   // example-end multi-histogram-even-2d-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_histogram_r == expected_r);
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
@@ -336,7 +336,7 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramRange accepts env with stream (1D)
   // example-end multi-histogram-range-1d-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_histogram_r == expected_r);
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
@@ -406,7 +406,7 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramRange accepts env with stream (2D)
   // example-end multi-histogram-range-2d-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_histogram_r == expected_r);
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);

--- a/cub/test/catch2_test_device_memcpy_env.cu
+++ b/cub/test/catch2_test_device_memcpy_env.cu
@@ -64,7 +64,7 @@ TEST_CASE("DeviceMemcpy::Batched works with default environment", "[memcpy][devi
     iota, index_to_ptr<int>{thrust::raw_pointer_cast(d_dst.data()), thrust::raw_pointer_cast(d_offsets.data())});
   auto sizes = cuda::transform_iterator(iota, get_size{thrust::raw_pointer_cast(d_offsets.data())});
 
-  REQUIRE(cudaSuccess == cub::DeviceMemcpy::Batched(input_it, output_it, sizes, num_buffers));
+  REQUIRE_CUDART(cub::DeviceMemcpy::Batched(input_it, output_it, sizes, num_buffers));
 
   REQUIRE(d_dst == d_src);
 }
@@ -88,8 +88,8 @@ C2H_TEST("DeviceMemcpy::Batched uses environment", "[memcpy][device]")
   auto sizes = cuda::transform_iterator(iota, get_size{thrust::raw_pointer_cast(d_offsets.data())});
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceMemcpy::Batched(nullptr, expected_bytes_allocated, input_it, output_it, sizes, num_buffers));
+  REQUIRE_CUDART(
+    cub::DeviceMemcpy::Batched(nullptr, expected_bytes_allocated, input_it, output_it, sizes, num_buffers));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -117,8 +117,8 @@ TEST_CASE("DeviceMemcpy::Batched uses custom stream", "[memcpy][device]")
   cuda::stream custom_stream(cuda::device_ref{0});
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceMemcpy::Batched(nullptr, expected_bytes_allocated, input_it, output_it, sizes, num_buffers));
+  REQUIRE_CUDART(
+    cub::DeviceMemcpy::Batched(nullptr, expected_bytes_allocated, input_it, output_it, sizes, num_buffers));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};

--- a/cub/test/catch2_test_device_memcpy_env_api.cu
+++ b/cub/test/catch2_test_device_memcpy_env_api.cu
@@ -63,7 +63,7 @@ C2H_TEST("cub::DeviceMemcpy::Batched accepts env with stream", "[memcpy][env]")
   // example-end memcpy-batched-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_dst_a == expected_a);
   REQUIRE(d_dst_b == expected_b);
 }

--- a/cub/test/catch2_test_device_merge.cu
+++ b/cub/test/catch2_test_device_merge.cu
@@ -107,7 +107,7 @@ C2H_TEST("DeviceMerge::MergeKeys almost tile-sized input sizes", "[merge][device
   using offset_t = int;
 
   cuda::compute_capability cc{};
-  REQUIRE(cub::detail::ptx_compute_cap(cc) == cudaSuccess);
+  REQUIRE_CUDART(cub::detail::ptx_compute_cap(cc));
   const offset_t items_per_tile =
     cub::detail::merge::policy_selector_from_types<key_t, cub::NullType, offset_t>{}(cc).items_per_thread;
 

--- a/cub/test/catch2_test_device_merge_env.cu
+++ b/cub/test/catch2_test_device_merge_env.cu
@@ -46,10 +46,8 @@ TEST_CASE("DeviceMerge::MergeKeys works with default environment", "[merge][devi
   auto keys2  = c2h::device_vector<int>{0, 3, 3, 4};
   auto result = c2h::device_vector<int>(7);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMerge::MergeKeys(
-      keys1.begin(), static_cast<int>(keys1.size()), keys2.begin(), static_cast<int>(keys2.size()), result.begin()));
+  REQUIRE_CUDART(cub::DeviceMerge::MergeKeys(
+    keys1.begin(), static_cast<int>(keys1.size()), keys2.begin(), static_cast<int>(keys2.size()), result.begin()));
 
   c2h::device_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
   REQUIRE(result == expected);
@@ -65,17 +63,15 @@ TEST_CASE("DeviceMerge::MergePairs works with default environment", "[merge][dev
   auto result_keys   = c2h::device_vector<int>(7);
   auto result_values = c2h::device_vector<char>(7);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMerge::MergePairs(
-      keys1.begin(),
-      values1.begin(),
-      static_cast<int>(keys1.size()),
-      keys2.begin(),
-      values2.begin(),
-      static_cast<int>(keys2.size()),
-      result_keys.begin(),
-      result_values.begin()));
+  REQUIRE_CUDART(cub::DeviceMerge::MergePairs(
+    keys1.begin(),
+    values1.begin(),
+    static_cast<int>(keys1.size()),
+    keys2.begin(),
+    values2.begin(),
+    static_cast<int>(keys2.size()),
+    result_keys.begin(),
+    result_values.begin()));
 
   c2h::device_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
   c2h::device_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
@@ -97,16 +93,14 @@ C2H_TEST("DeviceMerge::MergeKeys can be tuned", "[merge][device]", block_sizes)
 
   auto env = cuda::execution::tune(merge_tuning<target_block_size>{});
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMerge::MergeKeys(
-      keys1.begin(),
-      static_cast<int>(keys1.size()),
-      keys2.begin(),
-      static_cast<int>(keys2.size()),
-      result.begin(),
-      block_size_check,
-      env));
+  REQUIRE_CUDART(cub::DeviceMerge::MergeKeys(
+    keys1.begin(),
+    static_cast<int>(keys1.size()),
+    keys2.begin(),
+    static_cast<int>(keys2.size()),
+    result.begin(),
+    block_size_check,
+    env));
 
   c2h::device_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
   REQUIRE(result == expected);
@@ -128,19 +122,17 @@ C2H_TEST("DeviceMerge::MergePairs can be tuned", "[merge][device]", block_sizes)
 
   auto env = cuda::execution::tune(merge_tuning<target_block_size>{});
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMerge::MergePairs(
-      keys1.begin(),
-      values1.begin(),
-      static_cast<int>(keys1.size()),
-      keys2.begin(),
-      values2.begin(),
-      static_cast<int>(keys2.size()),
-      result_keys.begin(),
-      result_values.begin(),
-      block_size_check,
-      env));
+  REQUIRE_CUDART(cub::DeviceMerge::MergePairs(
+    keys1.begin(),
+    values1.begin(),
+    static_cast<int>(keys1.size()),
+    keys2.begin(),
+    values2.begin(),
+    static_cast<int>(keys2.size()),
+    result_keys.begin(),
+    result_values.begin(),
+    block_size_check,
+    env));
 
   c2h::device_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
   c2h::device_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
@@ -156,16 +148,14 @@ C2H_TEST("DeviceMerge::MergeKeys uses environment", "[merge][device]")
   auto result = c2h::device_vector<int>(7);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMerge::MergeKeys(
-      nullptr,
-      expected_bytes_allocated,
-      keys1.begin(),
-      static_cast<int>(keys1.size()),
-      keys2.begin(),
-      static_cast<int>(keys2.size()),
-      result.begin()));
+  REQUIRE_CUDART(cub::DeviceMerge::MergeKeys(
+    nullptr,
+    expected_bytes_allocated,
+    keys1.begin(),
+    static_cast<int>(keys1.size()),
+    keys2.begin(),
+    static_cast<int>(keys2.size()),
+    result.begin()));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -188,19 +178,17 @@ TEST_CASE("DeviceMerge::MergeKeys uses custom stream", "[merge][device]")
   auto result = c2h::device_vector<int>(7);
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMerge::MergeKeys(
-      nullptr,
-      expected_bytes_allocated,
-      keys1.begin(),
-      static_cast<int>(keys1.size()),
-      keys2.begin(),
-      static_cast<int>(keys2.size()),
-      result.begin()));
+  REQUIRE_CUDART(cub::DeviceMerge::MergeKeys(
+    nullptr,
+    expected_bytes_allocated,
+    keys1.begin(),
+    static_cast<int>(keys1.size()),
+    keys2.begin(),
+    static_cast<int>(keys2.size()),
+    result.begin()));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -213,12 +201,12 @@ TEST_CASE("DeviceMerge::MergeKeys uses custom stream", "[merge][device]")
              cuda::std::less<>{},
              env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
   REQUIRE(result == expected);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 C2H_TEST("DeviceMerge::MergePairs uses environment", "[merge][device]")
@@ -232,19 +220,17 @@ C2H_TEST("DeviceMerge::MergePairs uses environment", "[merge][device]")
   auto result_values = c2h::device_vector<char>(7);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMerge::MergePairs(
-      nullptr,
-      expected_bytes_allocated,
-      keys1.begin(),
-      values1.begin(),
-      static_cast<int>(keys1.size()),
-      keys2.begin(),
-      values2.begin(),
-      static_cast<int>(keys2.size()),
-      result_keys.begin(),
-      result_values.begin()));
+  REQUIRE_CUDART(cub::DeviceMerge::MergePairs(
+    nullptr,
+    expected_bytes_allocated,
+    keys1.begin(),
+    values1.begin(),
+    static_cast<int>(keys1.size()),
+    keys2.begin(),
+    values2.begin(),
+    static_cast<int>(keys2.size()),
+    result_keys.begin(),
+    result_values.begin()));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -277,22 +263,20 @@ TEST_CASE("DeviceMerge::MergePairs uses custom stream", "[merge][device]")
   auto result_values = c2h::device_vector<char>(7);
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMerge::MergePairs(
-      nullptr,
-      expected_bytes_allocated,
-      keys1.begin(),
-      values1.begin(),
-      static_cast<int>(keys1.size()),
-      keys2.begin(),
-      values2.begin(),
-      static_cast<int>(keys2.size()),
-      result_keys.begin(),
-      result_values.begin()));
+  REQUIRE_CUDART(cub::DeviceMerge::MergePairs(
+    nullptr,
+    expected_bytes_allocated,
+    keys1.begin(),
+    values1.begin(),
+    static_cast<int>(keys1.size()),
+    keys2.begin(),
+    values2.begin(),
+    static_cast<int>(keys2.size()),
+    result_keys.begin(),
+    result_values.begin()));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -309,12 +293,12 @@ TEST_CASE("DeviceMerge::MergePairs uses custom stream", "[merge][device]")
     cuda::std::less<>{},
     env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
   c2h::device_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }

--- a/cub/test/catch2_test_device_merge_env_api.cu
+++ b/cub/test/catch2_test_device_merge_env_api.cu
@@ -41,7 +41,7 @@ C2H_TEST("cub::DeviceMerge::MergeKeys accepts env with stream", "[merge][env]")
   // example-end merge-keys-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(result == expected);
 }
 
@@ -80,7 +80,7 @@ C2H_TEST("cub::DeviceMerge::MergePairs accepts env with stream", "[merge][env]")
   // example-end merge-pairs-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }

--- a/cub/test/catch2_test_device_merge_no_unroll.cu
+++ b/cub/test/catch2_test_device_merge_no_unroll.cu
@@ -88,7 +88,7 @@ C2H_TEST("DeviceMerge::MergeKeys large key types", "[merge][device]", c2h::type_
     6346,
     cuda::std::less<key_t>{},
     [](const key_t* k1, offset_t s1, const key_t* k2, offset_t s2, key_t* r, cuda::std::less<key_t> co) {
-      REQUIRE(cub::DeviceMerge::MergeKeys(k1, s1, k2, s2, r, co, cuda::execution::tune(fixed_policy_selector{}))
-              == cudaSuccess);
+      REQUIRE_CUDART(
+        cub::DeviceMerge::MergeKeys(k1, s1, k2, s2, r, co, cuda::execution::tune(fixed_policy_selector{})));
     });
 }

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -49,9 +49,8 @@ TEST_CASE("DeviceMergeSort::SortPairs works with default environment", "[merge_s
   auto d_keys   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_values = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceMergeSort::SortPairs(
-            d_keys.data().get(), d_values.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}));
+  REQUIRE_CUDART(cub::DeviceMergeSort::SortPairs(
+    d_keys.data().get(), d_values.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}));
 
   c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
@@ -63,9 +62,8 @@ TEST_CASE("DeviceMergeSort::SortKeys works with default environment", "[merge_so
 {
   auto d_keys = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMergeSort::SortKeys(d_keys.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}));
+  REQUIRE_CUDART(
+    cub::DeviceMergeSort::SortKeys(d_keys.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}));
 
   c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(d_keys == expected_keys);
@@ -76,9 +74,8 @@ TEST_CASE("DeviceMergeSort::StableSortPairs works with default environment", "[m
   auto d_keys   = c2h::device_vector<int>{8, 6, 6, 5, 3, 0, 9};
   auto d_values = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceMergeSort::StableSortPairs(
-            d_keys.data().get(), d_values.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}));
+  REQUIRE_CUDART(cub::DeviceMergeSort::StableSortPairs(
+    d_keys.data().get(), d_values.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}));
 
   c2h::device_vector<int> expected_keys{0, 3, 5, 6, 6, 8, 9};
   c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
@@ -90,9 +87,8 @@ TEST_CASE("DeviceMergeSort::StableSortKeys works with default environment", "[me
 {
   auto d_keys = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceMergeSort::StableSortKeys(
-            d_keys.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}));
+  REQUIRE_CUDART(
+    cub::DeviceMergeSort::StableSortKeys(d_keys.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}));
 
   c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(d_keys == expected_keys);
@@ -105,15 +101,13 @@ TEST_CASE("DeviceMergeSort::SortPairsCopy works with default environment", "[mer
   auto d_keys_out   = c2h::device_vector<int>(7);
   auto d_values_out = c2h::device_vector<int>(7);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMergeSort::SortPairsCopy(
-      d_keys_in.data().get(),
-      d_values_in.data().get(),
-      d_keys_out.data().get(),
-      d_values_out.data().get(),
-      static_cast<int>(d_keys_in.size()),
-      cuda::std::less<int>{}));
+  REQUIRE_CUDART(cub::DeviceMergeSort::SortPairsCopy(
+    d_keys_in.data().get(),
+    d_values_in.data().get(),
+    d_keys_out.data().get(),
+    d_values_out.data().get(),
+    static_cast<int>(d_keys_in.size()),
+    cuda::std::less<int>{}));
 
   c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
@@ -126,10 +120,8 @@ TEST_CASE("DeviceMergeSort::SortKeysCopy works with default environment", "[merg
   auto d_keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_keys_out = c2h::device_vector<int>(7);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMergeSort::SortKeysCopy(
-      d_keys_in.data().get(), d_keys_out.data().get(), static_cast<int>(d_keys_in.size()), cuda::std::less<int>{}));
+  REQUIRE_CUDART(cub::DeviceMergeSort::SortKeysCopy(
+    d_keys_in.data().get(), d_keys_out.data().get(), static_cast<int>(d_keys_in.size()), cuda::std::less<int>{}));
 
   c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(d_keys_out == expected_keys);
@@ -140,10 +132,8 @@ TEST_CASE("DeviceMergeSort::StableSortKeysCopy works with default environment", 
   auto d_keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_keys_out = c2h::device_vector<int>(7);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMergeSort::StableSortKeysCopy(
-      d_keys_in.data().get(), d_keys_out.data().get(), static_cast<int>(d_keys_in.size()), cuda::std::less<int>{}));
+  REQUIRE_CUDART(cub::DeviceMergeSort::StableSortKeysCopy(
+    d_keys_in.data().get(), d_keys_out.data().get(), static_cast<int>(d_keys_in.size()), cuda::std::less<int>{}));
 
   c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(d_keys_out == expected_keys);
@@ -157,15 +147,13 @@ C2H_TEST("DeviceMergeSort::SortPairs uses environment", "[merge_sort][device]")
   auto d_values = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMergeSort::SortPairs(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys.data().get(),
-      d_values.data().get(),
-      static_cast<int>(d_keys.size()),
-      cuda::std::less<int>{}));
+  REQUIRE_CUDART(cub::DeviceMergeSort::SortPairs(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys.data().get(),
+    d_values.data().get(),
+    static_cast<int>(d_keys.size()),
+    cuda::std::less<int>{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -183,10 +171,8 @@ C2H_TEST("DeviceMergeSort::SortKeys uses environment", "[merge_sort][device]")
   auto d_keys = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMergeSort::SortKeys(
-      nullptr, expected_bytes_allocated, d_keys.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}));
+  REQUIRE_CUDART(cub::DeviceMergeSort::SortKeys(
+    nullptr, expected_bytes_allocated, d_keys.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -202,15 +188,13 @@ C2H_TEST("DeviceMergeSort::StableSortPairs uses environment", "[merge_sort][devi
   auto d_values = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMergeSort::StableSortPairs(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys.data().get(),
-      d_values.data().get(),
-      static_cast<int>(d_keys.size()),
-      cuda::std::less<int>{}));
+  REQUIRE_CUDART(cub::DeviceMergeSort::StableSortPairs(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys.data().get(),
+    d_values.data().get(),
+    static_cast<int>(d_keys.size()),
+    cuda::std::less<int>{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -228,10 +212,8 @@ C2H_TEST("DeviceMergeSort::StableSortKeys uses environment", "[merge_sort][devic
   auto d_keys = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMergeSort::StableSortKeys(
-      nullptr, expected_bytes_allocated, d_keys.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}));
+  REQUIRE_CUDART(cub::DeviceMergeSort::StableSortKeys(
+    nullptr, expected_bytes_allocated, d_keys.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -247,18 +229,16 @@ TEST_CASE("DeviceMergeSort::SortPairs uses custom stream", "[merge_sort][device]
   auto d_values = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMergeSort::SortPairs(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys.data().get(),
-      d_values.data().get(),
-      static_cast<int>(d_keys.size()),
-      cuda::std::less<int>{}));
+  REQUIRE_CUDART(cub::DeviceMergeSort::SortPairs(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys.data().get(),
+    d_values.data().get(),
+    static_cast<int>(d_keys.size()),
+    cuda::std::less<int>{}));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -266,13 +246,13 @@ TEST_CASE("DeviceMergeSort::SortPairs uses custom stream", "[merge_sort][device]
   device_merge_sort_pairs(
     d_keys.data().get(), d_values.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}, env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   REQUIRE(d_keys == expected_keys);
   REQUIRE(d_values == expected_values);
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 TEST_CASE("DeviceMergeSort::StableSortKeys uses custom stream", "[merge_sort][device]")
@@ -280,24 +260,22 @@ TEST_CASE("DeviceMergeSort::StableSortKeys uses custom stream", "[merge_sort][de
   auto d_keys = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMergeSort::StableSortKeys(
-      nullptr, expected_bytes_allocated, d_keys.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}));
+  REQUIRE_CUDART(cub::DeviceMergeSort::StableSortKeys(
+    nullptr, expected_bytes_allocated, d_keys.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
 
   device_merge_stable_sort_keys(d_keys.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}, env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(d_keys == expected_keys);
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 C2H_TEST("DeviceMergeSort::SortPairsCopy uses environment", "[merge_sort][device]")
@@ -308,17 +286,15 @@ C2H_TEST("DeviceMergeSort::SortPairsCopy uses environment", "[merge_sort][device
   auto d_values_out = c2h::device_vector<int>(7);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMergeSort::SortPairsCopy(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys_in.data().get(),
-      d_values_in.data().get(),
-      d_keys_out.data().get(),
-      d_values_out.data().get(),
-      static_cast<int>(d_keys_in.size()),
-      cuda::std::less<int>{}));
+  REQUIRE_CUDART(cub::DeviceMergeSort::SortPairsCopy(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys_in.data().get(),
+    d_values_in.data().get(),
+    d_keys_out.data().get(),
+    d_values_out.data().get(),
+    static_cast<int>(d_keys_in.size()),
+    cuda::std::less<int>{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -343,15 +319,13 @@ C2H_TEST("DeviceMergeSort::SortKeysCopy uses environment", "[merge_sort][device]
   auto d_keys_out = c2h::device_vector<int>(7);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMergeSort::SortKeysCopy(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys_in.data().get(),
-      d_keys_out.data().get(),
-      static_cast<int>(d_keys_in.size()),
-      cuda::std::less<int>{}));
+  REQUIRE_CUDART(cub::DeviceMergeSort::SortKeysCopy(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys_in.data().get(),
+    d_keys_out.data().get(),
+    static_cast<int>(d_keys_in.size()),
+    cuda::std::less<int>{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -368,15 +342,13 @@ C2H_TEST("DeviceMergeSort::StableSortKeysCopy uses environment", "[merge_sort][d
   auto d_keys_out = c2h::device_vector<int>(7);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMergeSort::StableSortKeysCopy(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys_in.data().get(),
-      d_keys_out.data().get(),
-      static_cast<int>(d_keys_in.size()),
-      cuda::std::less<int>{}));
+  REQUIRE_CUDART(cub::DeviceMergeSort::StableSortKeysCopy(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys_in.data().get(),
+    d_keys_out.data().get(),
+    static_cast<int>(d_keys_in.size()),
+    cuda::std::less<int>{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -395,15 +367,13 @@ TEST_CASE("DeviceMergeSort::SortKeysCopy uses custom stream", "[merge_sort][devi
   cuda::stream stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMergeSort::SortKeysCopy(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys_in.data().get(),
-      d_keys_out.data().get(),
-      static_cast<int>(d_keys_in.size()),
-      cuda::std::less<int>{}));
+  REQUIRE_CUDART(cub::DeviceMergeSort::SortKeysCopy(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys_in.data().get(),
+    d_keys_out.data().get(),
+    static_cast<int>(d_keys_in.size()),
+    cuda::std::less<int>{}));
 
   cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref, expected_allocation_size(expected_bytes_allocated)};
@@ -425,15 +395,13 @@ TEST_CASE("DeviceMergeSort::StableSortKeysCopy uses custom stream", "[merge_sort
   cuda::stream stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceMergeSort::StableSortKeysCopy(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys_in.data().get(),
-      d_keys_out.data().get(),
-      static_cast<int>(d_keys_in.size()),
-      cuda::std::less<int>{}));
+  REQUIRE_CUDART(cub::DeviceMergeSort::StableSortKeysCopy(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys_in.data().get(),
+    d_keys_out.data().get(),
+    static_cast<int>(d_keys_in.size()),
+    cuda::std::less<int>{}));
 
   cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref, expected_allocation_size(expected_bytes_allocated)};
@@ -461,9 +429,8 @@ C2H_TEST("DeviceMergeSort::SortPairs can be tuned", "[merge_sort][device]", bloc
   auto compare_op = block_size_compare_t{thrust::raw_pointer_cast(d_block_size.data())};
   auto env        = cuda::execution::tune(merge_sort_tuning<target_block_size>{});
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceMergeSort::SortPairs(
-            d_keys.data().get(), d_values.data().get(), static_cast<int>(d_keys.size()), compare_op, env));
+  REQUIRE_CUDART(cub::DeviceMergeSort::SortPairs(
+    d_keys.data().get(), d_values.data().get(), static_cast<int>(d_keys.size()), compare_op, env));
   REQUIRE(d_block_size[0] == target_block_size);
 }
 

--- a/cub/test/catch2_test_device_merge_sort_env_api.cu
+++ b/cub/test/catch2_test_device_merge_sort_env_api.cu
@@ -31,7 +31,7 @@ C2H_TEST("cub::DeviceMergeSort::SortPairs env-based API", "[merge_sort][env]")
   thrust::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   // example-end sort-pairs-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_keys == expected_keys);
   REQUIRE(d_values == expected_values);
 }
@@ -51,7 +51,7 @@ C2H_TEST("cub::DeviceMergeSort::SortKeys env-based API", "[merge_sort][env]")
   thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   // example-end sort-keys-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_keys == expected_keys);
 }
 
@@ -72,7 +72,7 @@ C2H_TEST("cub::DeviceMergeSort::StableSortPairs env-based API", "[merge_sort][en
   thrust::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   // example-end stable-sort-pairs-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_keys == expected_keys);
   REQUIRE(d_values == expected_values);
 }
@@ -92,7 +92,7 @@ C2H_TEST("cub::DeviceMergeSort::StableSortKeys env-based API", "[merge_sort][env
   thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   // example-end stable-sort-keys-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_keys == expected_keys);
 }
 
@@ -124,7 +124,7 @@ C2H_TEST("cub::DeviceMergeSort::SortPairsCopy env-based API", "[merge_sort][env]
   thrust::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   // example-end sort-pairs-copy-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_keys_out == expected_keys);
   REQUIRE(d_values_out == expected_values);
 }
@@ -152,7 +152,7 @@ C2H_TEST("cub::DeviceMergeSort::SortKeysCopy env-based API", "[merge_sort][env]"
   thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   // example-end sort-keys-copy-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_keys_out == expected_keys);
 }
 
@@ -179,6 +179,6 @@ C2H_TEST("cub::DeviceMergeSort::StableSortKeysCopy env-based API", "[merge_sort]
   thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   // example-end stable-sort-keys-copy-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_keys_out == expected_keys);
 }

--- a/cub/test/catch2_test_device_partition_env.cu
+++ b/cub/test/catch2_test_device_partition_env.cu
@@ -51,8 +51,7 @@ TEST_CASE("Device partition works with default environment", "[partition][device
   less_than_t<value_t> select_op{5};
 
   // launch wrapper always assumes the last argument is the environment
-  REQUIRE(
-    cudaSuccess == cub::DevicePartition::If(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op));
+  REQUIRE_CUDART(cub::DevicePartition::If(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op));
 
   c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 8, 7, 6, 5};
   c2h::device_vector<int> expected_num_selected{4};
@@ -73,9 +72,8 @@ TEST_CASE("Device partition flagged works with default environment", "[partition
   auto d_num_selected   = c2h::device_vector<int>(1);
 
   // launch wrapper always assumes the last argument is the environment
-  REQUIRE(
-    cudaSuccess
-    == cub::DevicePartition::Flagged(d_in.begin(), d_flags.begin(), d_out.begin(), d_num_selected.begin(), num_items));
+  REQUIRE_CUDART(
+    cub::DevicePartition::Flagged(d_in.begin(), d_flags.begin(), d_out.begin(), d_num_selected.begin(), num_items));
 
   c2h::device_vector<value_t> expected_output{1, 4, 6, 7, 8, 5, 3, 2};
   c2h::device_vector<int> expected_num_selected{4};
@@ -95,7 +93,7 @@ TEST_CASE("Device partition three-way works with default environment", "[partiti
   less_than_t<int> small_selector{7};
   greater_than_t<int> large_selector{50};
 
-  auto error = cub::DevicePartition::If(
+  REQUIRE_CUDART(cub::DevicePartition::If(
     d_in.begin(),
     d_small_out.begin(),
     d_large_out.begin(),
@@ -103,8 +101,7 @@ TEST_CASE("Device partition three-way works with default environment", "[partiti
     d_num_selected.begin(),
     static_cast<int>(d_in.size()),
     small_selector,
-    large_selector);
-  REQUIRE(error == cudaSuccess);
+    large_selector));
 
   REQUIRE(d_num_selected[0] == 5);
   REQUIRE(d_num_selected[1] == 1);
@@ -132,10 +129,8 @@ C2H_TEST("Device partition uses environment", "[partition][device]")
 
   size_t expected_bytes_allocated{};
   // calculate expected_bytes_allocated - call CUB API directly, not through wrapper
-  REQUIRE(
-    cudaSuccess
-    == cub::DevicePartition::If(
-      nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op));
+  REQUIRE_CUDART(cub::DevicePartition::If(
+    nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)}; // temp storage size
 
@@ -161,16 +156,8 @@ C2H_TEST("Device partition flagged uses environment", "[partition][device]")
   auto d_num_selected   = c2h::device_vector<int>(1);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DevicePartition::Flagged(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_flags.begin(),
-      d_out.begin(),
-      d_num_selected.begin(),
-      num_items));
+  REQUIRE_CUDART(cub::DevicePartition::Flagged(
+    nullptr, expected_bytes_allocated, d_in.begin(), d_flags.begin(), d_out.begin(), d_num_selected.begin(), num_items));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)}; // temp storage size
 
@@ -196,19 +183,17 @@ C2H_TEST("Device partition three-way uses environment", "[partition][device]")
   greater_than_t<int> large_selector{50};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DevicePartition::If(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_small_out.begin(),
-      d_large_out.begin(),
-      d_unselected_out.begin(),
-      d_num_selected.begin(),
-      static_cast<int>(d_in.size()),
-      small_selector,
-      large_selector));
+  REQUIRE_CUDART(cub::DevicePartition::If(
+    nullptr,
+    expected_bytes_allocated,
+    d_in.begin(),
+    d_small_out.begin(),
+    d_large_out.begin(),
+    d_unselected_out.begin(),
+    d_num_selected.begin(),
+    static_cast<int>(d_in.size()),
+    small_selector,
+    large_selector));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -246,20 +231,18 @@ TEST_CASE("Device partition uses custom stream", "[partition][device]")
   less_than_t<value_t> select_op{5};
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DevicePartition::If(
-      nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op));
+  REQUIRE_CUDART(cub::DevicePartition::If(
+    nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
 
   device_partition_if(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op, env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 8, 7, 6, 5};
   c2h::device_vector<int> expected_num_selected{4};
@@ -267,5 +250,5 @@ TEST_CASE("Device partition uses custom stream", "[partition][device]")
   REQUIRE(d_num_selected == expected_num_selected);
   REQUIRE(d_out == expected_output);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }

--- a/cub/test/catch2_test_device_partition_env_api.cu
+++ b/cub/test/catch2_test_device_partition_env_api.cu
@@ -49,7 +49,7 @@ C2H_TEST("cub::DevicePartition::If accepts env with stream", "[partition][env]")
   thrust::device_vector<int> expected_num_selected{4};
   // example-end partition-if-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected_output);
   REQUIRE(num_selected == expected_num_selected);
 }
@@ -78,7 +78,7 @@ C2H_TEST("cub::DevicePartition::Flagged accepts env with stream", "[partition][e
   thrust::device_vector<int> expected_num_selected{4};
   // example-end partition-flagged-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected_output);
   REQUIRE(num_selected == expected_num_selected);
 }
@@ -118,7 +118,7 @@ C2H_TEST("cub::DevicePartition::If three-way accepts env with stream", "[partiti
   // example-end partition-three-way-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(num_selected_out[0] == 5);
   REQUIRE(num_selected_out[1] == 1);
   small_out.resize(num_selected_out[0]);

--- a/cub/test/catch2_test_device_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_radix_sort_env.cu
@@ -93,13 +93,12 @@ TEST_CASE("Device radix sort pairs works with default environment", "[radix_sort
   auto values_in  = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
   auto values_out = c2h::device_vector<int>(7);
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceRadixSort::SortPairs(
-            keys_in.data().get(),
-            keys_out.data().get(),
-            values_in.data().get(),
-            values_out.data().get(),
-            static_cast<int>(keys_in.size())));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortPairs(
+    keys_in.data().get(),
+    keys_out.data().get(),
+    values_in.data().get(),
+    values_out.data().get(),
+    static_cast<int>(keys_in.size())));
 
   c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
@@ -115,13 +114,12 @@ TEST_CASE("Device radix sort pairs descending works with default environment", "
   auto values_in  = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
   auto values_out = c2h::device_vector<int>(7);
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceRadixSort::SortPairsDescending(
-            keys_in.data().get(),
-            keys_out.data().get(),
-            values_in.data().get(),
-            values_out.data().get(),
-            static_cast<int>(keys_in.size())));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortPairsDescending(
+    keys_in.data().get(),
+    keys_out.data().get(),
+    values_in.data().get(),
+    values_out.data().get(),
+    static_cast<int>(keys_in.size())));
 
   c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
   c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
@@ -135,13 +133,12 @@ TEST_CASE("Device radix sort keys works with default environment", "[radix_sort]
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceRadixSort::SortKeys(
-            keys_in.data().get(),
-            keys_out.data().get(),
-            static_cast<int>(keys_in.size()),
-            0,
-            static_cast<int>(static_cast<int>(sizeof(int) * 8))));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeys(
+    keys_in.data().get(),
+    keys_out.data().get(),
+    static_cast<int>(keys_in.size()),
+    0,
+    static_cast<int>(static_cast<int>(sizeof(int) * 8))));
 
   c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
 
@@ -153,9 +150,8 @@ TEST_CASE("Device radix sort keys descending works with default environment", "[
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceRadixSort::SortKeysDescending(
-            keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size())));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeysDescending(
+    keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size())));
 
   c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
 
@@ -167,15 +163,13 @@ TEST_CASE("Device radix sort keys decomposer+bits works with default environment
   auto keys_in  = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out = c2h::device_vector<custom_key_t>(7);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortKeys(
-      keys_in.data().get(),
-      keys_out.data().get(),
-      static_cast<int>(keys_in.size()),
-      keys_decomposer_t{},
-      0,
-      static_cast<int>(sizeof(int) * 8)));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeys(
+    keys_in.data().get(),
+    keys_out.data().get(),
+    static_cast<int>(keys_in.size()),
+    keys_decomposer_t{},
+    0,
+    static_cast<int>(sizeof(int) * 8)));
 
   c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
   REQUIRE(keys_out == expected);
@@ -186,9 +180,8 @@ TEST_CASE("Device radix sort keys decomposer works with default environment", "[
   auto keys_in  = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out = c2h::device_vector<custom_key_t>(7);
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceRadixSort::SortKeys(
-            keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size()), keys_decomposer_t{}));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeys(
+    keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size()), keys_decomposer_t{}));
 
   c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
   REQUIRE(keys_out == expected);
@@ -201,8 +194,7 @@ TEST_CASE("Device radix sort keys DB decomposer works with default environment",
 
   cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
 
-  REQUIRE(
-    cudaSuccess == cub::DeviceRadixSort::SortKeys(d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeys(d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}));
 
   c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
@@ -216,9 +208,8 @@ TEST_CASE("Device radix sort keys DB decomposer+bits works with default environm
 
   cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceRadixSort::SortKeys(
-            d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, 0, static_cast<int>(sizeof(int) * 8)));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeys(
+    d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, 0, static_cast<int>(sizeof(int) * 8)));
 
   c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
@@ -232,15 +223,13 @@ TEST_CASE("Device radix sort pairs decomposer works with default environment", "
   auto values_in  = c2h::device_vector<int>{0, 1, 2};
   auto values_out = c2h::device_vector<int>(3);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortPairs(
-      keys_in.data().get(),
-      keys_out.data().get(),
-      values_in.data().get(),
-      values_out.data().get(),
-      static_cast<int>(keys_in.size()),
-      pairs_decomposer_t{}));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortPairs(
+    keys_in.data().get(),
+    keys_out.data().get(),
+    values_in.data().get(),
+    values_out.data().get(),
+    static_cast<int>(keys_in.size()),
+    pairs_decomposer_t{}));
 
   c2h::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
   REQUIRE(keys_out == expected_keys);
@@ -255,17 +244,15 @@ TEST_CASE("Device radix sort pairs decomposer with bits works with default envir
   auto values_in  = c2h::device_vector<int>{0, 1, 2};
   auto values_out = c2h::device_vector<int>(3);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortPairs(
-      keys_in.data().get(),
-      keys_out.data().get(),
-      values_in.data().get(),
-      values_out.data().get(),
-      static_cast<int>(keys_in.size()),
-      pairs_decomposer_t{},
-      0,
-      sizeof(int) * 8));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortPairs(
+    keys_in.data().get(),
+    keys_out.data().get(),
+    values_in.data().get(),
+    values_out.data().get(),
+    static_cast<int>(keys_in.size()),
+    pairs_decomposer_t{},
+    0,
+    sizeof(int) * 8));
 
   c2h::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
   REQUIRE(keys_out == expected_keys);
@@ -278,15 +265,13 @@ TEST_CASE("Device radix sort keys descending decomposer+bits works with default 
   auto keys_in  = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out = c2h::device_vector<custom_key_t>(7);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortKeysDescending(
-      keys_in.data().get(),
-      keys_out.data().get(),
-      static_cast<int>(keys_in.size()),
-      keys_decomposer_t{},
-      0,
-      static_cast<int>(sizeof(int) * 8)));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeysDescending(
+    keys_in.data().get(),
+    keys_out.data().get(),
+    static_cast<int>(keys_in.size()),
+    keys_decomposer_t{},
+    0,
+    static_cast<int>(sizeof(int) * 8)));
 
   c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   REQUIRE(keys_out == expected);
@@ -297,9 +282,8 @@ TEST_CASE("Device radix sort keys descending decomposer works with default envir
   auto keys_in  = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out = c2h::device_vector<custom_key_t>(7);
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceRadixSort::SortKeysDescending(
-            keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size()), keys_decomposer_t{}));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeysDescending(
+    keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size()), keys_decomposer_t{}));
 
   c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   REQUIRE(keys_out == expected);
@@ -312,8 +296,8 @@ TEST_CASE("Device radix sort keys descending DB decomposer works with default en
 
   cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceRadixSort::SortKeysDescending(d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}));
+  REQUIRE_CUDART(
+    cub::DeviceRadixSort::SortKeysDescending(d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}));
 
   c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
@@ -327,9 +311,8 @@ TEST_CASE("Device radix sort keys descending DB decomposer+bits works with defau
 
   cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceRadixSort::SortKeysDescending(
-            d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, 0, static_cast<int>(sizeof(int) * 8)));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeysDescending(
+    d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, 0, static_cast<int>(sizeof(int) * 8)));
 
   c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
@@ -343,17 +326,15 @@ TEST_CASE("Device radix sort pairs descending decomposer+bits works with default
   auto values_in  = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
   auto values_out = c2h::device_vector<int>(7);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortPairsDescending(
-      keys_in.data().get(),
-      keys_out.data().get(),
-      values_in.data().get(),
-      values_out.data().get(),
-      static_cast<int>(keys_in.size()),
-      keys_decomposer_t{},
-      0,
-      static_cast<int>(sizeof(int) * 8)));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortPairsDescending(
+    keys_in.data().get(),
+    keys_out.data().get(),
+    values_in.data().get(),
+    values_out.data().get(),
+    static_cast<int>(keys_in.size()),
+    keys_decomposer_t{},
+    0,
+    static_cast<int>(sizeof(int) * 8)));
 
   c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
@@ -368,15 +349,13 @@ TEST_CASE("Device radix sort pairs descending decomposer works with default envi
   auto values_in  = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
   auto values_out = c2h::device_vector<int>(7);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortPairsDescending(
-      keys_in.data().get(),
-      keys_out.data().get(),
-      values_in.data().get(),
-      values_out.data().get(),
-      static_cast<int>(keys_in.size()),
-      keys_decomposer_t{}));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortPairsDescending(
+    keys_in.data().get(),
+    keys_out.data().get(),
+    values_in.data().get(),
+    values_out.data().get(),
+    static_cast<int>(keys_in.size()),
+    keys_decomposer_t{}));
 
   c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
@@ -394,9 +373,8 @@ TEST_CASE("Device radix sort pairs descending DB decomposer works with default e
   cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
   cub::DoubleBuffer<int> d_values(values_buf0.data().get(), values_buf1.data().get());
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceRadixSort::SortPairsDescending(
-            d_keys, d_values, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortPairsDescending(
+    d_keys, d_values, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}));
 
   c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
@@ -417,10 +395,8 @@ TEST_CASE("Device radix sort pairs descending DB decomposer+bits works with defa
   cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
   cub::DoubleBuffer<int> d_values(values_buf0.data().get(), values_buf1.data().get());
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortPairsDescending(
-      d_keys, d_values, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, 0, static_cast<int>(sizeof(int) * 8)));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortPairsDescending(
+    d_keys, d_values, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, 0, static_cast<int>(sizeof(int) * 8)));
 
   c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
@@ -441,16 +417,14 @@ C2H_TEST("Device radix sort pairs uses environment", "[radix_sort][device]")
 
   size_t expected_bytes_allocated{};
   // calculate expected_bytes_allocated - call CUB API directly, not through wrapper
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortPairs(
-      nullptr,
-      expected_bytes_allocated,
-      keys_in.data().get(),
-      keys_out.data().get(),
-      values_in.data().get(),
-      values_out.data().get(),
-      static_cast<int>(keys_in.size())));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortPairs(
+    nullptr,
+    expected_bytes_allocated,
+    keys_in.data().get(),
+    keys_out.data().get(),
+    values_in.data().get(),
+    values_out.data().get(),
+    static_cast<int>(keys_in.size())));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -479,16 +453,14 @@ C2H_TEST("Device radix sort pairs descending uses environment", "[radix_sort][de
   auto values_out = c2h::device_vector<int>(7);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortPairsDescending(
-      nullptr,
-      expected_bytes_allocated,
-      keys_in.data().get(),
-      keys_out.data().get(),
-      values_in.data().get(),
-      values_out.data().get(),
-      static_cast<int>(keys_in.size())));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortPairsDescending(
+    nullptr,
+    expected_bytes_allocated,
+    keys_in.data().get(),
+    keys_out.data().get(),
+    values_in.data().get(),
+    values_out.data().get(),
+    static_cast<int>(keys_in.size())));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -515,10 +487,8 @@ C2H_TEST("Device radix sort keys uses environment", "[radix_sort][device]")
   auto keys_out = c2h::device_vector<int>(7);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortKeys(
-      nullptr, expected_bytes_allocated, keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size())));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeys(
+    nullptr, expected_bytes_allocated, keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size())));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -541,16 +511,14 @@ C2H_TEST("Device radix sort keys descending uses environment", "[radix_sort][dev
   auto keys_out = c2h::device_vector<int>(7);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortKeysDescending(
-      nullptr,
-      expected_bytes_allocated,
-      keys_in.data().get(),
-      keys_out.data().get(),
-      static_cast<int>(keys_in.size()),
-      0,
-      static_cast<int>(static_cast<int>(sizeof(int) * 8))));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeysDescending(
+    nullptr,
+    expected_bytes_allocated,
+    keys_in.data().get(),
+    keys_out.data().get(),
+    static_cast<int>(keys_in.size()),
+    0,
+    static_cast<int>(static_cast<int>(sizeof(int) * 8))));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -577,16 +545,14 @@ TEST_CASE("Device radix sort pairs uses custom stream", "[radix_sort][device]")
   cuda::stream custom_stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortPairs(
-      nullptr,
-      expected_bytes_allocated,
-      keys_in.data().get(),
-      keys_out.data().get(),
-      values_in.data().get(),
-      values_out.data().get(),
-      static_cast<int>(keys_in.size())));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortPairs(
+    nullptr,
+    expected_bytes_allocated,
+    keys_in.data().get(),
+    keys_out.data().get(),
+    values_in.data().get(),
+    values_out.data().get(),
+    static_cast<int>(keys_in.size())));
 
   cuda::stream_ref stream_ref{custom_stream};
   auto env = stdexec::env{stream_ref, expected_allocation_size(expected_bytes_allocated)};
@@ -620,16 +586,14 @@ TEST_CASE("Device radix sort pairs descending uses custom stream", "[radix_sort]
   cuda::stream custom_stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortPairsDescending(
-      nullptr,
-      expected_bytes_allocated,
-      keys_in.data().get(),
-      keys_out.data().get(),
-      values_in.data().get(),
-      values_out.data().get(),
-      static_cast<int>(keys_in.size())));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortPairsDescending(
+    nullptr,
+    expected_bytes_allocated,
+    keys_in.data().get(),
+    keys_out.data().get(),
+    values_in.data().get(),
+    values_out.data().get(),
+    static_cast<int>(keys_in.size())));
 
   cuda::stream_ref stream_ref{custom_stream};
   auto env = stdexec::env{stream_ref, expected_allocation_size(expected_bytes_allocated)};
@@ -661,10 +625,8 @@ TEST_CASE("Device radix sort keys uses custom stream", "[radix_sort][device]")
   cuda::stream custom_stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortKeys(
-      nullptr, expected_bytes_allocated, keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size())));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeys(
+    nullptr, expected_bytes_allocated, keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size())));
 
   cuda::stream_ref stream_ref{custom_stream};
   auto env = stdexec::env{stream_ref, expected_allocation_size(expected_bytes_allocated)};
@@ -690,10 +652,8 @@ TEST_CASE("Device radix sort keys descending uses custom stream", "[radix_sort][
   cuda::stream custom_stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortKeysDescending(
-      nullptr, expected_bytes_allocated, keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size())));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeysDescending(
+    nullptr, expected_bytes_allocated, keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size())));
 
   cuda::stream_ref stream_ref{custom_stream};
   auto env = stdexec::env{stream_ref, expected_allocation_size(expected_bytes_allocated)};
@@ -721,16 +681,14 @@ TEST_CASE("Device radix sort pairs decomposer uses custom stream", "[radix_sort]
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortPairs(
-      keys_in.data().get(),
-      keys_out.data().get(),
-      values_in.data().get(),
-      values_out.data().get(),
-      static_cast<int>(keys_in.size()),
-      pairs_decomposer_t{},
-      stream_ref));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortPairs(
+    keys_in.data().get(),
+    keys_out.data().get(),
+    values_in.data().get(),
+    values_out.data().get(),
+    static_cast<int>(keys_in.size()),
+    pairs_decomposer_t{},
+    stream_ref));
 
   stream.sync();
 
@@ -752,9 +710,8 @@ TEST_CASE("Device radix sort pairs DB decomposer works with default environment"
   cub::DoubleBuffer<custom_pair_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
   cub::DoubleBuffer<int> d_values(values_buf0.data().get(), values_buf1.data().get());
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortPairs(d_keys, d_values, static_cast<int>(keys_buf0.size()), pairs_decomposer_t{}));
+  REQUIRE_CUDART(
+    cub::DeviceRadixSort::SortPairs(d_keys, d_values, static_cast<int>(keys_buf0.size()), pairs_decomposer_t{}));
 
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   c2h::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
@@ -774,9 +731,8 @@ TEST_CASE("Device radix sort pairs DB decomposer with bits works with default en
   cub::DoubleBuffer<custom_pair_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
   cub::DoubleBuffer<int> d_values(values_buf0.data().get(), values_buf1.data().get());
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceRadixSort::SortPairs(
-            d_keys, d_values, static_cast<int>(keys_buf0.size()), pairs_decomposer_t{}, 0, sizeof(int) * 8));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortPairs(
+    d_keys, d_values, static_cast<int>(keys_buf0.size()), pairs_decomposer_t{}, 0, sizeof(int) * 8));
 
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   c2h::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
@@ -801,9 +757,8 @@ TEST_CASE("Device radix sort pairs DB decomposer uses custom stream", "[radix_so
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceRadixSort::SortPairs(
-            d_keys, d_values, static_cast<int>(keys_buf0.size()), pairs_decomposer_t{}, stream_ref));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortPairs(
+    d_keys, d_values, static_cast<int>(keys_buf0.size()), pairs_decomposer_t{}, stream_ref));
 
   stream.sync();
 
@@ -824,16 +779,14 @@ TEST_CASE("Device radix sort keys decomposer+bits uses custom stream", "[radix_s
   cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortKeys(
-      keys_in.data().get(),
-      keys_out.data().get(),
-      static_cast<int>(keys_in.size()),
-      keys_decomposer_t{},
-      0,
-      static_cast<int>(sizeof(int) * 8),
-      env));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeys(
+    keys_in.data().get(),
+    keys_out.data().get(),
+    static_cast<int>(keys_in.size()),
+    keys_decomposer_t{},
+    0,
+    static_cast<int>(sizeof(int) * 8),
+    env));
 
   stream.sync();
   c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
@@ -849,9 +802,8 @@ TEST_CASE("Device radix sort keys decomposer uses custom stream", "[radix_sort][
   cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceRadixSort::SortKeys(
-            keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size()), keys_decomposer_t{}, env));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeys(
+    keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size()), keys_decomposer_t{}, env));
 
   stream.sync();
   c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
@@ -869,8 +821,7 @@ TEST_CASE("Device radix sort keys DB decomposer uses custom stream", "[radix_sor
   cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceRadixSort::SortKeys(d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, env));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeys(d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, env));
 
   stream.sync();
   c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
@@ -889,10 +840,8 @@ TEST_CASE("Device radix sort keys DB decomposer+bits uses custom stream", "[radi
   cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortKeys(
-      d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, 0, static_cast<int>(sizeof(int) * 8), env));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeys(
+    d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, 0, static_cast<int>(sizeof(int) * 8), env));
 
   stream.sync();
   c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
@@ -909,16 +858,14 @@ TEST_CASE("Device radix sort keys descending decomposer+bits uses custom stream"
   cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortKeysDescending(
-      keys_in.data().get(),
-      keys_out.data().get(),
-      static_cast<int>(keys_in.size()),
-      keys_decomposer_t{},
-      0,
-      static_cast<int>(sizeof(int) * 8),
-      env));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeysDescending(
+    keys_in.data().get(),
+    keys_out.data().get(),
+    static_cast<int>(keys_in.size()),
+    keys_decomposer_t{},
+    0,
+    static_cast<int>(sizeof(int) * 8),
+    env));
 
   stream.sync();
   c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
@@ -934,9 +881,8 @@ TEST_CASE("Device radix sort keys descending decomposer uses custom stream", "[r
   cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceRadixSort::SortKeysDescending(
-            keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size()), keys_decomposer_t{}, env));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeysDescending(
+    keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size()), keys_decomposer_t{}, env));
 
   stream.sync();
   c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
@@ -954,9 +900,8 @@ TEST_CASE("Device radix sort keys descending DB decomposer uses custom stream", 
   cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortKeysDescending(d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, env));
+  REQUIRE_CUDART(
+    cub::DeviceRadixSort::SortKeysDescending(d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, env));
 
   stream.sync();
   c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
@@ -975,10 +920,8 @@ TEST_CASE("Device radix sort keys descending DB decomposer+bits uses custom stre
   cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortKeysDescending(
-      d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, 0, static_cast<int>(sizeof(int) * 8), env));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortKeysDescending(
+    d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, 0, static_cast<int>(sizeof(int) * 8), env));
 
   stream.sync();
   c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
@@ -997,18 +940,16 @@ TEST_CASE("Device radix sort pairs descending decomposer+bits uses custom stream
   cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortPairsDescending(
-      keys_in.data().get(),
-      keys_out.data().get(),
-      values_in.data().get(),
-      values_out.data().get(),
-      static_cast<int>(keys_in.size()),
-      keys_decomposer_t{},
-      0,
-      static_cast<int>(sizeof(int) * 8),
-      env));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortPairsDescending(
+    keys_in.data().get(),
+    keys_out.data().get(),
+    values_in.data().get(),
+    values_out.data().get(),
+    static_cast<int>(keys_in.size()),
+    keys_decomposer_t{},
+    0,
+    static_cast<int>(sizeof(int) * 8),
+    env));
 
   stream.sync();
   c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
@@ -1028,16 +969,14 @@ TEST_CASE("Device radix sort pairs descending decomposer uses custom stream", "[
   cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortPairsDescending(
-      keys_in.data().get(),
-      keys_out.data().get(),
-      values_in.data().get(),
-      values_out.data().get(),
-      static_cast<int>(keys_in.size()),
-      keys_decomposer_t{},
-      env));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortPairsDescending(
+    keys_in.data().get(),
+    keys_out.data().get(),
+    values_in.data().get(),
+    values_out.data().get(),
+    static_cast<int>(keys_in.size()),
+    keys_decomposer_t{},
+    env));
 
   stream.sync();
   c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
@@ -1060,9 +999,8 @@ TEST_CASE("Device radix sort pairs descending DB decomposer uses custom stream",
   cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceRadixSort::SortPairsDescending(
-            d_keys, d_values, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, env));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortPairsDescending(
+    d_keys, d_values, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, env));
 
   stream.sync();
   c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
@@ -1087,16 +1025,14 @@ TEST_CASE("Device radix sort pairs descending DB decomposer+bits uses custom str
   cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRadixSort::SortPairsDescending(
-      d_keys,
-      d_values,
-      static_cast<int>(keys_buf0.size()),
-      keys_decomposer_t{},
-      0,
-      static_cast<int>(sizeof(int) * 8),
-      env));
+  REQUIRE_CUDART(cub::DeviceRadixSort::SortPairsDescending(
+    d_keys,
+    d_values,
+    static_cast<int>(keys_buf0.size()),
+    keys_decomposer_t{},
+    0,
+    static_cast<int>(sizeof(int) * 8),
+    env));
 
   stream.sync();
   c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
@@ -1143,7 +1079,7 @@ std::size_t measure_allocated_bytes(CallableT&& run, PolicySelector policy_selec
   auto env                 = stdexec::env{device_memory_resource{stream.get(), &bytes_allocated, &bytes_deallocated},
                           stream,
                           cuda::execution::tune(policy_selector)};
-  REQUIRE(cudaSuccess == run(env));
+  REQUIRE_CUDART(run(env));
   stream.sync();
   CHECK(bytes_allocated > 0);
   CHECK(bytes_allocated == bytes_deallocated);

--- a/cub/test/catch2_test_device_radix_sort_env_api.cu
+++ b/cub/test/catch2_test_device_radix_sort_env_api.cu
@@ -101,7 +101,7 @@ C2H_TEST("cub::DeviceRadixSort::SortPairs env-based API", "[radix_sort][env]")
   thrust::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   // example-end radix-sort-pairs-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -130,7 +130,7 @@ C2H_TEST("cub::DeviceRadixSort::SortPairsDescending env-based API", "[radix_sort
   thrust::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
   // example-end radix-sort-pairs-descending-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -152,7 +152,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeys env-based API", "[radix_sort][env]")
   thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   // example-end radix-sort-keys-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected_keys);
 }
 
@@ -174,7 +174,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeys DoubleBuffer env-based API", "[radix_so
   thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   // example-end radix-sort-keys-db-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   REQUIRE(keys == expected_keys);
 }
@@ -196,7 +196,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeysDescending env-based API", "[radix_sort]
   thrust::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
   // example-end radix-sort-keys-descending-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected_keys);
 }
 
@@ -218,7 +218,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeysDescending DoubleBuffer env-based API", 
   thrust::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
   // example-end radix-sort-keys-descending-db-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   REQUIRE(keys == expected_keys);
 }
@@ -251,7 +251,7 @@ C2H_TEST("cub::DeviceRadixSort::SortPairs decomposer with bits env-based API", "
   // example-end radix-sort-pairs-decomposer-bits-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   thrust::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
   REQUIRE(keys_out == expected_keys);
   thrust::device_vector<int> expected_values{1, 2, 0};
@@ -284,7 +284,7 @@ C2H_TEST("cub::DeviceRadixSort::SortPairs decomposer env-based API", "[radix_sor
   // example-end radix-sort-pairs-decomposer-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   thrust::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
   REQUIRE(keys_out == expected_keys);
   thrust::device_vector<int> expected_values{1, 2, 0};
@@ -314,7 +314,7 @@ C2H_TEST("cub::DeviceRadixSort::SortPairs DoubleBuffer decomposer env-based API"
   // example-end radix-sort-pairs-db-decomposer-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   thrust::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
   REQUIRE(keys == expected_keys);
@@ -346,7 +346,7 @@ C2H_TEST("cub::DeviceRadixSort::SortPairs DoubleBuffer decomposer with bits env-
   // example-end radix-sort-pairs-db-decomposer-bits-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   thrust::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
   REQUIRE(keys == expected_keys);
@@ -377,7 +377,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeys decomposer+bits env-based API", "[radix
   // example-end radix-sort-keys-decomposer-bits-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected);
 }
 
@@ -397,7 +397,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeys decomposer env-based API", "[radix_sort
   // example-end radix-sort-keys-decomposer-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected);
 }
 
@@ -419,7 +419,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeys DB decomposer env-based API", "[radix_s
   // example-end radix-sort-keys-db-decomposer-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   REQUIRE(keys == expected);
 }
@@ -442,7 +442,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeys DB decomposer+bits env-based API", "[ra
   // example-end radix-sort-keys-db-decomposer-bits-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   REQUIRE(keys == expected);
 }
@@ -469,7 +469,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeysDescending decomposer+bits env-based API
   // example-end radix-sort-keys-descending-decomposer-bits-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected);
 }
 
@@ -489,7 +489,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeysDescending decomposer env-based API", "[
   // example-end radix-sort-keys-descending-decomposer-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected);
 }
 
@@ -511,7 +511,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeysDescending DB decomposer env-based API",
   // example-end radix-sort-keys-descending-db-decomposer-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   REQUIRE(keys == expected);
 }
@@ -534,7 +534,7 @@ C2H_TEST("cub::DeviceRadixSort::SortKeysDescending DB decomposer+bits env-based 
   // example-end radix-sort-keys-descending-db-decomposer-bits-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   REQUIRE(keys == expected);
 }
@@ -566,7 +566,7 @@ C2H_TEST("cub::DeviceRadixSort::SortPairsDescending decomposer+bits env-based AP
   // example-end radix-sort-pairs-descending-decomposer-bits-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -596,7 +596,7 @@ C2H_TEST("cub::DeviceRadixSort::SortPairsDescending decomposer env-based API", "
   // example-end radix-sort-pairs-descending-decomposer-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -623,7 +623,7 @@ C2H_TEST("cub::DeviceRadixSort::SortPairsDescending DB decomposer env-based API"
   // example-end radix-sort-pairs-descending-db-decomposer-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   auto& keys   = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   auto& values = d_values.selector == 0 ? values_buf0 : values_buf1;
   REQUIRE(keys == expected_keys);
@@ -652,7 +652,7 @@ C2H_TEST("cub::DeviceRadixSort::SortPairsDescending DB decomposer+bits env-based
   // example-end radix-sort-pairs-descending-db-decomposer-bits-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   auto& keys   = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   auto& values = d_values.selector == 0 ? values_buf0 : values_buf1;
   REQUIRE(keys == expected_keys);

--- a/cub/test/catch2_test_device_reduce_deterministic.cu
+++ b/cub/test/catch2_test_device_reduce_deterministic.cu
@@ -45,9 +45,8 @@ C2H_TEST("Deterministic Device reduce works with float and double on gpu", "[red
   const type* d_input_ptr = thrust::raw_pointer_cast(d_input.data());
 
   const auto env = cuda::execution::require(cuda::execution::determinism::gpu_to_gpu);
-  auto error =
-    cub::DeviceReduce::Reduce(d_input_ptr, d_output.begin(), num_items, cuda::std::plus<type>{}, type{}, env);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(
+    cub::DeviceReduce::Reduce(d_input_ptr, d_output.begin(), num_items, cuda::std::plus<type>{}, type{}, env));
 
   c2h::host_vector<type> h_input = d_input;
 
@@ -110,8 +109,7 @@ C2H_TEST("Deterministic Device reduce works with float and double on gpu with la
   c2h::device_vector<type> d_output(1);
 
   const auto env = cuda::execution::require(cuda::execution::determinism::gpu_to_gpu);
-  auto error = cub::DeviceReduce::Reduce(d_input, d_output.begin(), num_items, cuda::std::plus<type>{}, type{}, env);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(cub::DeviceReduce::Reduce(d_input, d_output.begin(), num_items, cuda::std::plus<type>{}, type{}, env));
 
   // expected sum must be zero, as there would be equal number of positive and negative values
   // in the input and they will cancel each other out
@@ -154,13 +152,10 @@ C2H_TEST("Deterministic Device reduce works with float and double and is determi
   auto env2 = cuda::std::execution::env{cuda::execution::require(cuda::execution::determinism::gpu_to_gpu),
                                         cuda::execution::tune(custom_policy_selector<2, 256>{})};
 
-  auto error1 =
-    cub::DeviceReduce::Reduce(d_input.begin(), d_output_p1.begin(), num_items, cuda::std::plus<type>{}, type{}, env1);
-  REQUIRE(error1 == cudaSuccess);
-
-  auto error2 =
-    cub::DeviceReduce::Reduce(d_input.begin(), d_output_p2.begin(), num_items, cuda::std::plus<type>{}, type{}, env2);
-  REQUIRE(error2 == cudaSuccess);
+  REQUIRE_CUDART(
+    cub::DeviceReduce::Reduce(d_input.begin(), d_output_p1.begin(), num_items, cuda::std::plus<type>{}, type{}, env1));
+  REQUIRE_CUDART(
+    cub::DeviceReduce::Reduce(d_input.begin(), d_output_p2.begin(), num_items, cuda::std::plus<type>{}, type{}, env2));
 
   c2h::host_vector<type> h_input = d_input;
   c2h::host_vector<type> h_expected(1);
@@ -189,9 +184,8 @@ C2H_TEST("Deterministic Device reduce works with float and double on gpu with di
 
     c2h::device_vector<type> d_output(1);
 
-    auto error =
-      cub::DeviceReduce::Reduce(d_input.begin(), d_output.begin(), num_items, cuda::std::plus<type>{}, type{}, env);
-    REQUIRE(error == cudaSuccess);
+    REQUIRE_CUDART(
+      cub::DeviceReduce::Reduce(d_input.begin(), d_output.begin(), num_items, cuda::std::plus<type>{}, type{}, env));
 
     c2h::host_vector<type> h_input = d_input;
 
@@ -210,8 +204,7 @@ C2H_TEST("Deterministic Device reduce works with float and double on gpu with di
     cuda::constant_iterator<type> input(1.0f);
     c2h::device_vector<type> d_output(1);
 
-    auto error = cub::DeviceReduce::Reduce(input, d_output.begin(), num_items, cuda::std::plus<type>{}, type{}, env);
-    REQUIRE(error == cudaSuccess);
+    REQUIRE_CUDART(cub::DeviceReduce::Reduce(input, d_output.begin(), num_items, cuda::std::plus<type>{}, type{}, env));
 
     c2h::host_vector<type> h_expected(1);
     // Requires `std::accumulate` to produce deterministic result which is required for comparison
@@ -252,15 +245,13 @@ C2H_TEST("Deterministic Device reduce works with float and double on gpu with di
 
   std::size_t temp_storage_bytes{};
 
-  auto error = cub::detail::rfa::dispatch<input_it_t, output_it_t, int, init_t, transform_t, accum_t>(
-    nullptr, temp_storage_bytes, input, d_output.begin(), num_items);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(cub::detail::rfa::dispatch<input_it_t, output_it_t, int, init_t, transform_t, accum_t>(
+    nullptr, temp_storage_bytes, input, d_output.begin(), num_items));
 
   c2h::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
 
-  error = cub::detail::rfa::dispatch<input_it_t, output_it_t, int, init_t, transform_t, accum_t>(
-    thrust::raw_pointer_cast(temp_storage.data()), temp_storage_bytes, input, d_output.begin(), num_items);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(cub::detail::rfa::dispatch<input_it_t, output_it_t, int, init_t, transform_t, accum_t>(
+    thrust::raw_pointer_cast(temp_storage.data()), temp_storage_bytes, input, d_output.begin(), num_items));
 
   auto h_input = cuda::transform_iterator(input, transform_t{});
 
@@ -289,9 +280,8 @@ C2H_TEST("Deterministic Device reduce works with float and double on gpu with di
     static_cast<type>(42), cuda::std::numeric_limits<type>::max(), cuda::std::numeric_limits<type>::min());
 
   const auto env = cuda::execution::require(cuda::execution::determinism::gpu_to_gpu);
-  auto error =
-    cub::DeviceReduce::Reduce(d_input.begin(), d_output.begin(), num_items, cuda::std::plus<type>{}, init_value, env);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(
+    cub::DeviceReduce::Reduce(d_input.begin(), d_output.begin(), num_items, cuda::std::plus<type>{}, init_value, env));
 
   c2h::host_vector<type> h_input = d_input;
   c2h::host_vector<type> h_expected(1);
@@ -339,9 +329,8 @@ C2H_TEST("Deterministic Device reduce works with integral types on gpu with diff
     {
       c2h::device_vector<type> d_output(1);
 
-      auto error =
-        cub::DeviceReduce::Reduce(d_input.begin(), d_output.begin(), num_items, cuda::std::plus<type>{}, init_t{}, env);
-      REQUIRE(error == cudaSuccess);
+      REQUIRE_CUDART(cub::DeviceReduce::Reduce(
+        d_input.begin(), d_output.begin(), num_items, cuda::std::plus<type>{}, init_t{}, env));
 
       c2h::host_vector<type> h_input = d_input;
 
@@ -361,9 +350,8 @@ C2H_TEST("Deterministic Device reduce works with integral types on gpu with diff
 
       init_t init_value{};
 
-      auto error = cub::DeviceReduce::Reduce(
-        d_input.begin(), d_output.begin(), num_items, cuda::std::bit_xor<>{}, init_value, env);
-      REQUIRE(error == cudaSuccess);
+      REQUIRE_CUDART(cub::DeviceReduce::Reduce(
+        d_input.begin(), d_output.begin(), num_items, cuda::std::bit_xor<>{}, init_value, env));
 
       c2h::host_vector<type> h_input = d_input;
       c2h::host_vector<type> h_expected(1);
@@ -379,9 +367,8 @@ C2H_TEST("Deterministic Device reduce works with integral types on gpu with diff
 
       init_t init_value{};
 
-      auto error = cub::DeviceReduce::Reduce(
-        d_input.begin(), d_output.begin(), num_items, cuda::std::logical_or<>{}, init_value, env);
-      REQUIRE(error == cudaSuccess);
+      REQUIRE_CUDART(cub::DeviceReduce::Reduce(
+        d_input.begin(), d_output.begin(), num_items, cuda::std::logical_or<>{}, init_value, env));
 
       c2h::host_vector<type> h_input = d_input;
       c2h::host_vector<type> h_expected(1);
@@ -398,9 +385,8 @@ C2H_TEST("Deterministic Device reduce works with integral types on gpu with diff
 
     init_t init_value{cuda::std::numeric_limits<init_t>::max()};
 
-    auto error =
-      cub::DeviceReduce::Reduce(d_input.begin(), d_output.begin(), num_items, cuda::minimum<init_t>{}, init_value, env);
-    REQUIRE(error == cudaSuccess);
+    REQUIRE_CUDART(cub::DeviceReduce::Reduce(
+      d_input.begin(), d_output.begin(), num_items, cuda::minimum<init_t>{}, init_value, env));
 
     c2h::host_vector<type> h_input = d_input;
     c2h::host_vector<type> h_expected(1);
@@ -416,9 +402,8 @@ C2H_TEST("Deterministic Device reduce works with integral types on gpu with diff
 
     init_t init_value{cuda::std::numeric_limits<init_t>::min()};
 
-    auto error =
-      cub::DeviceReduce::Reduce(d_input.begin(), d_output.begin(), num_items, cuda::maximum<init_t>{}, init_value, env);
-    REQUIRE(error == cudaSuccess);
+    REQUIRE_CUDART(cub::DeviceReduce::Reduce(
+      d_input.begin(), d_output.begin(), num_items, cuda::maximum<init_t>{}, init_value, env));
 
     c2h::host_vector<type> h_input = d_input;
     c2h::host_vector<type> h_expected(1);

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -95,10 +95,10 @@ TEST_CASE("Device reduce works with default environment", "[reduce][device]")
   using offset_t    = cub::detail::choose_offset_t<num_items_t>;
 
   int current_device{};
-  REQUIRE(cudaSuccess == cudaGetDevice(&current_device));
+  REQUIRE_CUDART(cudaGetDevice(&current_device));
 
   cuda::compute_capability cc{};
-  REQUIRE(cudaSuccess == cub::detail::ptx_compute_cap(cc, current_device));
+  REQUIRE_CUDART(cub::detail::ptx_compute_cap(cc, current_device));
 
   unsigned int target_block_size =
     cub::detail::reduce::policy_selector_from_types<value_t, offset_t, block_size_check_plus_t>{}(cc)
@@ -110,7 +110,7 @@ TEST_CASE("Device reduce works with default environment", "[reduce][device]")
   auto d_in  = cuda::constant_iterator(value_t{1});
   auto d_out = thrust::device_vector<value_t>(1);
 
-  REQUIRE(cudaSuccess == cub::DeviceReduce::Reduce(d_in, d_out.begin(), num_items, block_size_check, value_t{0}));
+  REQUIRE_CUDART(cub::DeviceReduce::Reduce(d_in, d_out.begin(), num_items, block_size_check, value_t{0}));
   REQUIRE(d_out[0] == num_items);
 
   // Make sure we use default tuning
@@ -123,17 +123,17 @@ TEST_CASE("Device Sum works with default environment", "[reduce][device]")
   using value_t     = int;
 
   int current_device{};
-  REQUIRE(cudaSuccess == cudaGetDevice(&current_device));
+  REQUIRE_CUDART(cudaGetDevice(&current_device));
 
   int ptx_version{};
-  REQUIRE(cudaSuccess == cub::PtxVersion(ptx_version, current_device));
+  REQUIRE_CUDART(cub::PtxVersion(ptx_version, current_device));
 
   num_items_t num_items = 1;
 
   auto d_in  = cuda::constant_iterator(value_t{1});
   auto d_out = thrust::device_vector<value_t>(1);
 
-  REQUIRE(cudaSuccess == cub::DeviceReduce::Sum(d_in, d_out.begin(), num_items));
+  REQUIRE_CUDART(cub::DeviceReduce::Sum(d_in, d_out.begin(), num_items));
   REQUIRE(d_out[0] == num_items);
 }
 #endif
@@ -369,9 +369,8 @@ C2H_TEST("Device reduce uses environment", "[reduce][device]", requirements)
   auto kernels = [&]() {
     if constexpr (std::is_same_v<determinism_t, cuda::execution::determinism::run_to_run_t>)
     {
-      REQUIRE(
-        cudaSuccess
-        == cub::DeviceReduce::Reduce(nullptr, expected_bytes_allocated, d_in, d_out.begin(), num_items, op_t{}, init));
+      REQUIRE_CUDART(
+        cub::DeviceReduce::Reduce(nullptr, expected_bytes_allocated, d_in, d_out.begin(), num_items, op_t{}, init));
 
       using policy_t = cub::detail::reduce::policy_selector_from_types<accumulator_t, offset_t, op_t>;
       return cuda::std::array<void*, 3>{
@@ -402,18 +401,16 @@ C2H_TEST("Device reduce uses environment", "[reduce][device]", requirements)
       using policy_t = cub::detail::reduce_nondeterministic::policy_selector_from_types<accumulator_t, offset_t, op_t>;
       auto* raw_ptr  = thrust::raw_pointer_cast(d_out.data());
 
-      REQUIRE(
-        cudaSuccess
-        == cub::detail::reduce_nondeterministic::dispatch(
-          nullptr,
-          expected_bytes_allocated,
-          d_in,
-          raw_ptr,
-          num_items,
-          op_t{},
-          init,
-          /* stream */ nullptr,
-          transform_t{}));
+      REQUIRE_CUDART(cub::detail::reduce_nondeterministic::dispatch(
+        nullptr,
+        expected_bytes_allocated,
+        d_in,
+        raw_ptr,
+        num_items,
+        op_t{},
+        init,
+        /* stream */ nullptr,
+        transform_t{}));
 
       return cuda::std::array<void*, 1>{reinterpret_cast<void*>(
         cub::detail::reduce::NondeterministicDeviceReduceAtomicKernel<
@@ -434,10 +431,9 @@ C2H_TEST("Device reduce uses environment", "[reduce][device]", requirements)
       using deterministic_accum_t = deterministic_add_t::DeterministicAcc;
       using output_it_t           = decltype(d_out.begin());
 
-      REQUIRE(cudaSuccess
-              == cub::detail::rfa::
-                dispatch<decltype(d_in), decltype(d_out.begin()), offset_t, init_t, transform_t, accumulator_t>(
-                  nullptr, expected_bytes_allocated, d_in, d_out.begin(), num_items, init));
+      REQUIRE_CUDART(
+        cub::detail::rfa::dispatch<decltype(d_in), decltype(d_out.begin()), offset_t, init_t, transform_t, accumulator_t>(
+          nullptr, expected_bytes_allocated, d_in, d_out.begin(), num_items, init));
 
       auto k1 = cub::detail::reduce::DeterministicDeviceReduceSingleTileKernel<
         policy_t,
@@ -497,7 +493,7 @@ C2H_TEST("Device sum uses environment", "[reduce][device]", requirements)
   auto kernels = [&]() {
     if constexpr (std::is_same_v<determinism_t, cuda::execution::determinism::run_to_run_t>)
     {
-      REQUIRE(cudaSuccess == cub::DeviceReduce::Sum(nullptr, expected_bytes_allocated, d_in, d_out.begin(), num_items));
+      REQUIRE_CUDART(cub::DeviceReduce::Sum(nullptr, expected_bytes_allocated, d_in, d_out.begin(), num_items));
 
       using policy_t = cub::detail::reduce::policy_selector_from_types<accumulator_t, offset_t, op_t>;
       return cuda::std::array<void*, 3>{
@@ -528,18 +524,16 @@ C2H_TEST("Device sum uses environment", "[reduce][device]", requirements)
       using policy_t = cub::detail::reduce_nondeterministic::policy_selector_from_types<accumulator_t, offset_t, op_t>;
       auto* raw_ptr  = thrust::raw_pointer_cast(d_out.data());
 
-      REQUIRE(
-        cudaSuccess
-        == cub::detail::reduce_nondeterministic::dispatch(
-          nullptr,
-          expected_bytes_allocated,
-          d_in,
-          raw_ptr,
-          num_items,
-          op_t{},
-          init,
-          /* stream */ nullptr,
-          transform_t{}));
+      REQUIRE_CUDART(cub::detail::reduce_nondeterministic::dispatch(
+        nullptr,
+        expected_bytes_allocated,
+        d_in,
+        raw_ptr,
+        num_items,
+        op_t{},
+        init,
+        /* stream */ nullptr,
+        transform_t{}));
 
       return cuda::std::array<void*, 1>{reinterpret_cast<void*>(
         cub::detail::reduce::NondeterministicDeviceReduceAtomicKernel<
@@ -560,10 +554,9 @@ C2H_TEST("Device sum uses environment", "[reduce][device]", requirements)
       using deterministic_accum_t = deterministic_add_t::DeterministicAcc;
       using output_it_t           = decltype(d_out.begin());
 
-      REQUIRE(cudaSuccess
-              == cub::detail::rfa::
-                dispatch<decltype(d_in), decltype(d_out.begin()), offset_t, init_t, transform_t, accumulator_t>(
-                  nullptr, expected_bytes_allocated, d_in, d_out.begin(), num_items, init));
+      REQUIRE_CUDART(
+        cub::detail::rfa::dispatch<decltype(d_in), decltype(d_out.begin()), offset_t, init_t, transform_t, accumulator_t>(
+          nullptr, expected_bytes_allocated, d_in, d_out.begin(), num_items, init));
 
       auto k1 = cub::detail::reduce::DeterministicDeviceReduceSingleTileKernel<
         policy_t,
@@ -609,8 +602,7 @@ TEST_CASE("Device Min works with default environment", "[reduce][device]")
   auto input  = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
   auto output = c2h::device_vector<float>(1);
 
-  auto error = cub::DeviceReduce::Min(input.begin(), output.begin(), static_cast<int>(input.size()));
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(cub::DeviceReduce::Min(input.begin(), output.begin(), static_cast<int>(input.size())));
   REQUIRE(output[0] == 0.0f);
 }
 
@@ -619,8 +611,7 @@ TEST_CASE("Device Max works with default environment", "[reduce][device]")
   auto input  = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
   auto output = c2h::device_vector<float>(1);
 
-  auto error = cub::DeviceReduce::Max(input.begin(), output.begin(), static_cast<int>(input.size()));
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(cub::DeviceReduce::Max(input.begin(), output.begin(), static_cast<int>(input.size())));
   REQUIRE(output[0] == 4.0f);
 }
 
@@ -631,9 +622,8 @@ TEST_CASE("Device TransformReduce works with default environment", "[reduce][dev
 
   auto negate = cuda::std::negate<int>{};
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceReduce::TransformReduce(
-            d_in.begin(), d_out.begin(), static_cast<int>(d_in.size()), cuda::std::plus<int>{}, negate, 0));
+  REQUIRE_CUDART(cub::DeviceReduce::TransformReduce(
+    d_in.begin(), d_out.begin(), static_cast<int>(d_in.size()), cuda::std::plus<int>{}, negate, 0));
 
   REQUIRE(d_out[0] == -10);
 }
@@ -646,16 +636,14 @@ TEST_CASE("Device ReduceByKey works with default environment", "[reduce][device]
   auto d_aggregates_out = c2h::device_vector<int>(8);
   auto d_num_runs_out   = c2h::device_vector<int>(1);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceReduce::ReduceByKey(
-      d_keys_in.begin(),
-      d_unique_out.begin(),
-      d_values_in.begin(),
-      d_aggregates_out.begin(),
-      d_num_runs_out.begin(),
-      cuda::minimum<int>{},
-      static_cast<int>(d_keys_in.size())));
+  REQUIRE_CUDART(cub::DeviceReduce::ReduceByKey(
+    d_keys_in.begin(),
+    d_unique_out.begin(),
+    d_values_in.begin(),
+    d_aggregates_out.begin(),
+    d_num_runs_out.begin(),
+    cuda::minimum<int>{},
+    static_cast<int>(d_keys_in.size())));
 
   REQUIRE(d_num_runs_out[0] == 5);
   c2h::device_vector<int> expected_keys{0, 2, 9, 5, 8};
@@ -672,9 +660,8 @@ TEST_CASE("Device ArgMin works with default environment", "[reduce][device]")
   auto min_output   = c2h::device_vector<float>(1);
   auto index_output = c2h::device_vector<cuda::std::int64_t>(1);
 
-  auto error =
-    cub::DeviceReduce::ArgMin(input.begin(), min_output.begin(), index_output.begin(), static_cast<int>(input.size()));
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(
+    cub::DeviceReduce::ArgMin(input.begin(), min_output.begin(), index_output.begin(), static_cast<int>(input.size())));
   REQUIRE(min_output[0] == 0.0f);
   REQUIRE(index_output[0] == 3);
 }
@@ -685,9 +672,8 @@ TEST_CASE("Device ArgMax works with default environment", "[reduce][device]")
   auto max_output   = c2h::device_vector<float>(1);
   auto index_output = c2h::device_vector<cuda::std::int64_t>(1);
 
-  auto error =
-    cub::DeviceReduce::ArgMax(input.begin(), max_output.begin(), index_output.begin(), static_cast<int>(input.size()));
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(
+    cub::DeviceReduce::ArgMax(input.begin(), max_output.begin(), index_output.begin(), static_cast<int>(input.size())));
   REQUIRE(max_output[0] == 4.0f);
   REQUIRE(index_output[0] == 2);
 }
@@ -698,9 +684,8 @@ TEST_CASE("Device ArgMin with compare_op works with default environment", "[redu
   auto min_output   = c2h::device_vector<float>(1);
   auto index_output = c2h::device_vector<cuda::std::int64_t>(1);
 
-  auto error = cub::DeviceReduce::ArgMin(
-    input.begin(), min_output.begin(), index_output.begin(), static_cast<int>(input.size()), cuda::std::less{});
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(cub::DeviceReduce::ArgMin(
+    input.begin(), min_output.begin(), index_output.begin(), static_cast<int>(input.size()), cuda::std::less{}));
   REQUIRE(min_output[0] == 0.0f);
   REQUIRE(index_output[0] == 3);
 }
@@ -711,9 +696,8 @@ TEST_CASE("Device ArgMax with compare_op works with default environment", "[redu
   auto max_output   = c2h::device_vector<float>(1);
   auto index_output = c2h::device_vector<cuda::std::int64_t>(1);
 
-  auto error = cub::DeviceReduce::ArgMax(
-    input.begin(), max_output.begin(), index_output.begin(), static_cast<int>(input.size()), cuda::std::less{});
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(cub::DeviceReduce::ArgMax(
+    input.begin(), max_output.begin(), index_output.begin(), static_cast<int>(input.size()), cuda::std::less{}));
   REQUIRE(max_output[0] == 4.0f);
   REQUIRE(index_output[0] == 2);
 }
@@ -728,17 +712,15 @@ C2H_TEST("Device TransformReduce uses environment", "[reduce][device]")
   auto negate = cuda::std::negate<int>{};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceReduce::TransformReduce(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_out.begin(),
-      static_cast<int>(d_in.size()),
-      cuda::std::plus<int>{},
-      negate,
-      0));
+  REQUIRE_CUDART(cub::DeviceReduce::TransformReduce(
+    nullptr,
+    expected_bytes_allocated,
+    d_in.begin(),
+    d_out.begin(),
+    static_cast<int>(d_in.size()),
+    cuda::std::plus<int>{},
+    negate,
+    0));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -754,9 +736,8 @@ C2H_TEST("Device Min uses environment", "[reduce][device]")
   auto output = c2h::device_vector<float>(1);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceReduce::Min(
-            nullptr, expected_bytes_allocated, input.begin(), output.begin(), static_cast<int>(input.size())));
+  REQUIRE_CUDART(cub::DeviceReduce::Min(
+    nullptr, expected_bytes_allocated, input.begin(), output.begin(), static_cast<int>(input.size())));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -771,9 +752,8 @@ C2H_TEST("Device Max uses environment", "[reduce][device]")
   auto output = c2h::device_vector<float>(1);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceReduce::Max(
-            nullptr, expected_bytes_allocated, input.begin(), output.begin(), static_cast<int>(input.size())));
+  REQUIRE_CUDART(cub::DeviceReduce::Max(
+    nullptr, expected_bytes_allocated, input.begin(), output.begin(), static_cast<int>(input.size())));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -791,18 +771,16 @@ C2H_TEST("Device ReduceByKey uses environment", "[reduce][device]")
   auto d_num_runs_out   = c2h::device_vector<int>(1);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceReduce::ReduceByKey(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys_in.begin(),
-      d_unique_out.begin(),
-      d_values_in.begin(),
-      d_aggregates_out.begin(),
-      d_num_runs_out.begin(),
-      cuda::minimum<int>{},
-      static_cast<int>(d_keys_in.size())));
+  REQUIRE_CUDART(cub::DeviceReduce::ReduceByKey(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys_in.begin(),
+    d_unique_out.begin(),
+    d_values_in.begin(),
+    d_aggregates_out.begin(),
+    d_num_runs_out.begin(),
+    cuda::minimum<int>{},
+    static_cast<int>(d_keys_in.size())));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -832,15 +810,13 @@ C2H_TEST("Device ArgMin uses environment", "[reduce][device]")
   auto index_output = c2h::device_vector<cuda::std::int64_t>(1);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceReduce::ArgMin(
-      nullptr,
-      expected_bytes_allocated,
-      input.begin(),
-      min_output.begin(),
-      index_output.begin(),
-      static_cast<int>(input.size())));
+  REQUIRE_CUDART(cub::DeviceReduce::ArgMin(
+    nullptr,
+    expected_bytes_allocated,
+    input.begin(),
+    min_output.begin(),
+    index_output.begin(),
+    static_cast<int>(input.size())));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -857,16 +833,14 @@ C2H_TEST("Device ArgMin with compare_op uses environment", "[reduce][device]")
   auto index_output = c2h::device_vector<cuda::std::int64_t>(1);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceReduce::ArgMin(
-      nullptr,
-      expected_bytes_allocated,
-      input.begin(),
-      min_output.begin(),
-      index_output.begin(),
-      static_cast<int>(input.size()),
-      cuda::std::less{}));
+  REQUIRE_CUDART(cub::DeviceReduce::ArgMin(
+    nullptr,
+    expected_bytes_allocated,
+    input.begin(),
+    min_output.begin(),
+    index_output.begin(),
+    static_cast<int>(input.size()),
+    cuda::std::less{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -884,15 +858,13 @@ C2H_TEST("Device ArgMax uses environment", "[reduce][device]")
   auto index_output = c2h::device_vector<cuda::std::int64_t>(1);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceReduce::ArgMax(
-      nullptr,
-      expected_bytes_allocated,
-      input.begin(),
-      max_output.begin(),
-      index_output.begin(),
-      static_cast<int>(input.size())));
+  REQUIRE_CUDART(cub::DeviceReduce::ArgMax(
+    nullptr,
+    expected_bytes_allocated,
+    input.begin(),
+    max_output.begin(),
+    index_output.begin(),
+    static_cast<int>(input.size())));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -909,16 +881,14 @@ C2H_TEST("Device ArgMax with compare_op uses environment", "[reduce][device]")
   auto index_output = c2h::device_vector<cuda::std::int64_t>(1);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceReduce::ArgMax(
-      nullptr,
-      expected_bytes_allocated,
-      input.begin(),
-      max_output.begin(),
-      index_output.begin(),
-      static_cast<int>(input.size()),
-      cuda::std::less{}));
+  REQUIRE_CUDART(cub::DeviceReduce::ArgMax(
+    nullptr,
+    expected_bytes_allocated,
+    input.begin(),
+    max_output.begin(),
+    index_output.begin(),
+    static_cast<int>(input.size()),
+    cuda::std::less{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 

--- a/cub/test/catch2_test_device_reduce_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_env_api.cu
@@ -36,7 +36,7 @@ C2H_TEST("cub::DeviceReduce::Reduce accepts run_to_run determinism requirements"
   thrust::device_vector<float> expected{6.0f};
   // example-end reduce-env-determinism
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -59,7 +59,7 @@ C2H_TEST("cub::DeviceReduce::Reduce accepts not_guaranteed determinism requireme
   thrust::device_vector<float> expected{6.0f};
   // example-end reduce-env-non-determinism
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -84,7 +84,7 @@ C2H_TEST("cub::DeviceReduce::Reduce accepts stream", "[reduce][env]")
   // example-end reduce-env-stream
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -106,7 +106,7 @@ C2H_TEST("cub::DeviceReduce::Sum accepts run_to_run determinism requirements", "
   thrust::device_vector<float> expected{6.0f};
   // example-end sum-env-determinism
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -127,7 +127,7 @@ C2H_TEST("cub::DeviceReduce::Sum accepts not_guaranteed determinism requirements
   thrust::device_vector<float> expected{6.0f};
   // example-end sum-env-non-determinism
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -150,7 +150,7 @@ C2H_TEST("cub::DeviceReduce::Sum accepts stream", "[reduce][env]")
   // example-end sum-env-stream
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -171,7 +171,7 @@ C2H_TEST("cub::DeviceReduce::Min accepts run_to_run determinism requirements", "
   thrust::device_vector<float> expected{0.0f};
   // example-end min-env-determinism
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -192,7 +192,7 @@ C2H_TEST("cub::DeviceReduce::Min accepts not_guaranteed determinism requirements
   thrust::device_vector<float> expected{0.0f};
   // example-end min-env-non-determinism
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -215,7 +215,7 @@ C2H_TEST("cub::DeviceReduce::Min accepts stream", "[reduce][env]")
   // example-end min-env-stream
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -236,7 +236,7 @@ C2H_TEST("cub::DeviceReduce::Max accepts run_to_run determinism requirements", "
   thrust::device_vector<float> expected{3.0f};
   // example-end max-env-determinism
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -257,7 +257,7 @@ C2H_TEST("cub::DeviceReduce::Max accepts not_guaranteed determinism requirements
   thrust::device_vector<float> expected{3.0f};
   // example-end max-env-non-determinism
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -280,7 +280,7 @@ C2H_TEST("cub::DeviceReduce::Max accepts stream", "[reduce][env]")
   // example-end max-env-stream
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -303,7 +303,7 @@ C2H_TEST("cub::DeviceReduce::ArgMin accepts run_to_run determinism requirements"
   thrust::device_vector<cuda::std::int64_t> expected_index{3};
   // example-end argmin-env-determinism
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(min_output == expected_min);
   REQUIRE(index_output == expected_index);
 }
@@ -327,7 +327,7 @@ C2H_TEST("cub::DeviceReduce::ArgMin accepts not_guaranteed determinism requireme
   thrust::device_vector<cuda::std::int64_t> expected_index{3};
   // example-end argmin-env-non-determinism
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(min_output == expected_min);
   REQUIRE(index_output == expected_index);
 }
@@ -354,7 +354,7 @@ C2H_TEST("cub::DeviceReduce::ArgMin accepts stream", "[reduce][env]")
   // example-end argmin-env-stream
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(min_output == expected_min);
   REQUIRE(index_output == expected_index);
 }
@@ -378,7 +378,7 @@ C2H_TEST("cub::DeviceReduce::ArgMax accepts run_to_run determinism requirements"
   thrust::device_vector<cuda::std::int64_t> expected_index{2};
   // example-end argmax-env-determinism
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(max_output == expected_max);
   REQUIRE(index_output == expected_index);
 }
@@ -402,7 +402,7 @@ C2H_TEST("cub::DeviceReduce::ArgMax accepts not_guaranteed determinism requireme
   thrust::device_vector<cuda::std::int64_t> expected_index{2};
   // example-end argmax-env-non-determinism
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(max_output == expected_max);
   REQUIRE(index_output == expected_index);
 }
@@ -428,7 +428,7 @@ C2H_TEST("cub::DeviceReduce::ArgMax accepts stream", "[reduce][env]")
   thrust::device_vector<cuda::std::int64_t> expected_index{2};
   // example-end argmax-env-stream
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(max_output == expected_max);
   REQUIRE(index_output == expected_index);
 }
@@ -454,7 +454,7 @@ C2H_TEST("cub::DeviceReduce::TransformReduce accepts determinism requirements", 
   thrust::device_vector<float> expected{-10.0f};
   // example-end transform-reduce-env-determinism
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -479,7 +479,7 @@ C2H_TEST("cub::DeviceReduce::TransformReduce accepts not_guaranteed determinism 
   thrust::device_vector<float> expected{-10.0f};
   // example-end transform-reduce-env-non-determinism
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -506,7 +506,7 @@ C2H_TEST("cub::DeviceReduce::TransformReduce accepts stream", "[reduce][env]")
   // example-end transform-reduce-env-stream
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -539,7 +539,7 @@ C2H_TEST("cub::DeviceReduce::ReduceByKey accepts run_to_run determinism requirem
   thrust::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
   // example-end reduce-by-key-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(num_runs_out[0] == 5);
   unique_keys_out.resize(5);
   aggregates_out.resize(5);
@@ -576,7 +576,7 @@ C2H_TEST("cub::DeviceReduce::ReduceByKey accepts not_guaranteed determinism requ
   thrust::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
   // example-end reduce-by-key-env-non-determinism
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(num_runs_out[0] == 5);
   unique_keys_out.resize(5);
   aggregates_out.resize(5);
@@ -615,7 +615,7 @@ C2H_TEST("cub::DeviceReduce::ReduceByKey accepts stream", "[reduce][env]")
   // example-end reduce-by-key-env-stream
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(num_runs_out[0] == 5);
   unique_keys_out.resize(5);
   aggregates_out.resize(5);
@@ -639,7 +639,7 @@ C2H_TEST("cub::DeviceReduce::Sum queries both stream and resource from composed 
   auto error = cub::DeviceReduce::Sum(input.begin(), output.begin(), static_cast<int>(input.size()), env);
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output[0] == 15);
   REQUIRE(bytes_allocated > 0);
   REQUIRE(bytes_deallocated == bytes_allocated);

--- a/cub/test/catch2_test_device_reduce_nondeterministic.cu
+++ b/cub/test/catch2_test_device_reduce_nondeterministic.cu
@@ -59,9 +59,8 @@ C2H_TEST("Nondeterministic Device reduce works with float and double on gpu",
   c2h::device_vector<type> d_output(1);
 
   const auto env = cuda::execution::require(cuda::execution::determinism::not_guaranteed);
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceReduce::Reduce(d_input.begin(), d_output.begin(), num_items, cuda::std::plus<type>{}, type{}, env));
+  REQUIRE_CUDART(
+    cub::DeviceReduce::Reduce(d_input.begin(), d_output.begin(), num_items, cuda::std::plus<type>{}, type{}, env));
 
   c2h::host_vector<type> h_input  = d_input;
   c2h::host_vector<type> h_actual = d_output;
@@ -142,10 +141,8 @@ C2H_TEST("Nondeterministic Device reduce works with float and double on gpu with
   auto env2 = cuda::std::execution::env{cuda::execution::require(cuda::execution::determinism::not_guaranteed),
                                         cuda::execution::tune(custom_policy_selector<2, 256>{})};
 
-  REQUIRE(
-    cudaSuccess == cub::DeviceReduce::Reduce(d_input.begin(), d_output_p1.begin(), num_items, min_op, init, env1));
-  REQUIRE(
-    cudaSuccess == cub::DeviceReduce::Reduce(d_input.begin(), d_output_p2.begin(), num_items, min_op, init, env2));
+  REQUIRE_CUDART(cub::DeviceReduce::Reduce(d_input.begin(), d_output_p1.begin(), num_items, min_op, init, env1));
+  REQUIRE_CUDART(cub::DeviceReduce::Reduce(d_input.begin(), d_output_p2.begin(), num_items, min_op, init, env2));
 
   REQUIRE_EQ_WITH_NAN_MATCHING(d_output_p1, d_output_p2);
 }
@@ -166,9 +163,8 @@ C2H_TEST("Nondeterministic Device reduce works with float and double on gpu with
 
     c2h::device_vector<type> d_output(1);
 
-    REQUIRE(
-      cudaSuccess
-      == cub::DeviceReduce::Reduce(d_input.begin(), d_output.begin(), num_items, cuda::std::plus<type>{}, type{}, env));
+    REQUIRE_CUDART(
+      cub::DeviceReduce::Reduce(d_input.begin(), d_output.begin(), num_items, cuda::std::plus<type>{}, type{}, env));
 
     c2h::host_vector<type> h_input = d_input;
 
@@ -185,8 +181,7 @@ C2H_TEST("Nondeterministic Device reduce works with float and double on gpu with
     cuda::constant_iterator<type> input(1.0f);
     c2h::device_vector<type> d_output(1);
 
-    REQUIRE(cudaSuccess
-            == cub::DeviceReduce::Reduce(input, d_output.begin(), num_items, cuda::std::plus<type>{}, type{}, env));
+    REQUIRE_CUDART(cub::DeviceReduce::Reduce(input, d_output.begin(), num_items, cuda::std::plus<type>{}, type{}, env));
 
     c2h::host_vector<type> h_output = d_output;
     REQUIRE(h_output[0] == static_cast<type>(num_items));
@@ -224,13 +219,12 @@ C2H_TEST("Nondeterministic Device reduce works with float and double on gpu with
 
   std::size_t temp_storage_bytes{};
 
-  auto error = cub::detail::reduce_nondeterministic::dispatch(
-    nullptr, temp_storage_bytes, input, raw_ptr, num_items, cuda::std::plus<type>{}, init_t{}, nullptr, transform_t{});
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(cub::detail::reduce_nondeterministic::dispatch(
+    nullptr, temp_storage_bytes, input, raw_ptr, num_items, cuda::std::plus<type>{}, init_t{}, nullptr, transform_t{}));
 
   c2h::device_vector<std::uint8_t> temp_storage(temp_storage_bytes, thrust::no_init);
 
-  error = cub::detail::reduce_nondeterministic::dispatch(
+  REQUIRE_CUDART(cub::detail::reduce_nondeterministic::dispatch(
     thrust::raw_pointer_cast(temp_storage.data()),
     temp_storage_bytes,
     input,
@@ -239,8 +233,7 @@ C2H_TEST("Nondeterministic Device reduce works with float and double on gpu with
     cuda::std::plus<type>{},
     init_t{},
     nullptr,
-    transform_t{});
-  REQUIRE(error == cudaSuccess);
+    transform_t{}));
 
   auto h_input = cuda::transform_iterator(input, transform_t{});
 
@@ -267,9 +260,8 @@ C2H_TEST("Nondeterministic Device reduce works with float and double on gpu with
   const type init_value = static_cast<type>(GENERATE(42, -42, 0));
 
   const auto env = cuda::execution::require(cuda::execution::determinism::not_guaranteed);
-  REQUIRE(cudaSuccess
-          == cub::DeviceReduce::Reduce(
-            d_input.begin(), d_output.begin(), num_items, cuda::std::plus<type>{}, init_value, env));
+  REQUIRE_CUDART(
+    cub::DeviceReduce::Reduce(d_input.begin(), d_output.begin(), num_items, cuda::std::plus<type>{}, init_value, env));
 
   c2h::host_vector<type> h_input = d_input;
   c2h::host_vector<type> h_expected(1);
@@ -316,9 +308,8 @@ C2H_TEST("Nondeterministic Device reduce works with various types on gpu with di
 
   c2h::device_vector<type> d_output(1);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceReduce::Reduce(d_input.begin(), d_output.begin(), num_items, cuda::std::plus<type>{}, type{}, env));
+  REQUIRE_CUDART(
+    cub::DeviceReduce::Reduce(d_input.begin(), d_output.begin(), num_items, cuda::std::plus<type>{}, type{}, env));
 
   c2h::host_vector<type> h_input = d_input;
 

--- a/cub/test/catch2_test_device_run_length_encode_env.cu
+++ b/cub/test/catch2_test_device_run_length_encode_env.cu
@@ -60,9 +60,8 @@ TEST_CASE("DeviceRunLengthEncode::Encode works with default environment", "[run_
   auto d_counts_out   = c2h::device_vector<int>(8);
   auto d_num_runs_out = c2h::device_vector<int>(1);
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceRunLengthEncode::Encode(
-            d_in.begin(), d_unique_out.begin(), d_counts_out.begin(), d_num_runs_out.begin(), (int) d_in.size()));
+  REQUIRE_CUDART(cub::DeviceRunLengthEncode::Encode(
+    d_in.begin(), d_unique_out.begin(), d_counts_out.begin(), d_num_runs_out.begin(), (int) d_in.size()));
 
   c2h::device_vector<int> expected_unique{0, 2, 9, 5, 8};
   c2h::device_vector<int> expected_counts{1, 2, 1, 3, 1};
@@ -82,9 +81,8 @@ TEST_CASE("DeviceRunLengthEncode::NonTrivialRuns works with default environment"
   auto d_lengths_out  = c2h::device_vector<int>(8);
   auto d_num_runs_out = c2h::device_vector<int>(1);
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceRunLengthEncode::NonTrivialRuns(
-            d_in.begin(), d_offsets_out.begin(), d_lengths_out.begin(), d_num_runs_out.begin(), (int) d_in.size()));
+  REQUIRE_CUDART(cub::DeviceRunLengthEncode::NonTrivialRuns(
+    d_in.begin(), d_offsets_out.begin(), d_lengths_out.begin(), d_num_runs_out.begin(), (int) d_in.size()));
 
   c2h::device_vector<int> expected_offsets{1, 4};
   c2h::device_vector<int> expected_lengths{2, 3};
@@ -108,16 +106,14 @@ C2H_TEST("DeviceRunLengthEncode::Encode uses environment", "[run_length_encode][
   int num_items       = static_cast<int>(d_in.size());
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRunLengthEncode::Encode(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_unique_out.begin(),
-      d_counts_out.begin(),
-      d_num_runs_out.begin(),
-      num_items));
+  REQUIRE_CUDART(cub::DeviceRunLengthEncode::Encode(
+    nullptr,
+    expected_bytes_allocated,
+    d_in.begin(),
+    d_unique_out.begin(),
+    d_counts_out.begin(),
+    d_num_runs_out.begin(),
+    num_items));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -144,16 +140,14 @@ C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns uses environment", "[run_length_
   int num_items       = static_cast<int>(d_in.size());
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRunLengthEncode::NonTrivialRuns(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_offsets_out.begin(),
-      d_lengths_out.begin(),
-      d_num_runs_out.begin(),
-      num_items));
+  REQUIRE_CUDART(cub::DeviceRunLengthEncode::NonTrivialRuns(
+    nullptr,
+    expected_bytes_allocated,
+    d_in.begin(),
+    d_offsets_out.begin(),
+    d_lengths_out.begin(),
+    d_num_runs_out.begin(),
+    num_items));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -182,16 +176,14 @@ TEST_CASE("DeviceRunLengthEncode::Encode uses custom stream", "[run_length_encod
   cuda::stream custom_stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRunLengthEncode::Encode(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_unique_out.begin(),
-      d_counts_out.begin(),
-      d_num_runs_out.begin(),
-      num_items));
+  REQUIRE_CUDART(cub::DeviceRunLengthEncode::Encode(
+    nullptr,
+    expected_bytes_allocated,
+    d_in.begin(),
+    d_unique_out.begin(),
+    d_counts_out.begin(),
+    d_num_runs_out.begin(),
+    num_items));
 
   cuda::stream_ref stream_ref{custom_stream};
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, stream_ref};
@@ -224,16 +216,14 @@ TEST_CASE("DeviceRunLengthEncode::NonTrivialRuns uses custom stream", "[run_leng
   cuda::stream custom_stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceRunLengthEncode::NonTrivialRuns(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_offsets_out.begin(),
-      d_lengths_out.begin(),
-      d_num_runs_out.begin(),
-      num_items));
+  REQUIRE_CUDART(cub::DeviceRunLengthEncode::NonTrivialRuns(
+    nullptr,
+    expected_bytes_allocated,
+    d_in.begin(),
+    d_offsets_out.begin(),
+    d_lengths_out.begin(),
+    d_num_runs_out.begin(),
+    num_items));
 
   cuda::stream_ref stream_ref{custom_stream};
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, stream_ref};

--- a/cub/test/catch2_test_device_run_length_encode_env_api.cu
+++ b/cub/test/catch2_test_device_run_length_encode_env_api.cu
@@ -38,7 +38,7 @@ C2H_TEST("cub::DeviceRunLengthEncode::Encode accepts env with stream", "[run_len
   thrust::device_vector<int> expected_num_runs{5};
   // example-end encode-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   unique_out.resize(num_runs_out[0]);
   counts_out.resize(num_runs_out[0]);
   REQUIRE(unique_out == expected_unique);
@@ -70,7 +70,7 @@ C2H_TEST("cub::DeviceRunLengthEncode::NonTrivialRuns accepts env with stream", "
   thrust::device_vector<int> expected_num_runs{2};
   // example-end non-trivial-runs-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   offsets_out.resize(num_runs_out[0]);
   lengths_out.resize(num_runs_out[0]);
   REQUIRE(offsets_out == expected_offsets);

--- a/cub/test/catch2_test_device_scan_by_key_env.cu
+++ b/cub/test/catch2_test_device_scan_by_key_env.cu
@@ -37,7 +37,7 @@ TEST_CASE("Device scan exclusive-sum-by-key works with default environment", "[s
   auto d_in      = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_out     = thrust::device_vector<int>(num_items);
 
-  REQUIRE(cudaSuccess == cub::DeviceScan::ExclusiveSumByKey(d_keys.begin(), d_in.begin(), d_out.begin(), num_items));
+  REQUIRE_CUDART(cub::DeviceScan::ExclusiveSumByKey(d_keys.begin(), d_in.begin(), d_out.begin(), num_items));
 
   thrust::device_vector<int> expected{0, 8, 0, 7, 12, 0, 0};
   REQUIRE(d_out == expected);
@@ -53,10 +53,10 @@ TEST_CASE("Device scan exclusive-scan-by-key works with default environment", "[
   using selector_t = cub::detail::scan_by_key::policy_selector_from_types<key_t, accum_t, value_t, block_size_check_t>;
 
   int current_device{};
-  REQUIRE(cudaSuccess == cudaGetDevice(&current_device));
+  REQUIRE_CUDART(cudaGetDevice(&current_device));
 
   cudaDeviceProp device_props{};
-  REQUIRE(cudaSuccess == cudaGetDeviceProperties(&device_props, current_device));
+  REQUIRE_CUDART(cudaGetDeviceProperties(&device_props, current_device));
 
   const auto target_block_size =
     selector_t{}(cuda::compute_capability{device_props.major, device_props.minor}).threads_per_block;
@@ -69,9 +69,8 @@ TEST_CASE("Device scan exclusive-scan-by-key works with default environment", "[
   auto d_out = thrust::device_vector<value_t>(1);
   auto init  = value_t{0};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceScan::ExclusiveScanByKey(d_keys.begin(), d_in, d_out.begin(), block_size_check, init, num_items));
+  REQUIRE_CUDART(
+    cub::DeviceScan::ExclusiveScanByKey(d_keys.begin(), d_in, d_out.begin(), block_size_check, init, num_items));
 
   REQUIRE(d_out[0] == init);
   REQUIRE(d_block_size[0] == static_cast<unsigned int>(target_block_size));
@@ -84,7 +83,7 @@ TEST_CASE("Device scan inclusive-sum-by-key works with default environment", "[s
   auto d_in      = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_out     = thrust::device_vector<int>(num_items);
 
-  REQUIRE(cudaSuccess == cub::DeviceScan::InclusiveSumByKey(d_keys.begin(), d_in.begin(), d_out.begin(), num_items));
+  REQUIRE_CUDART(cub::DeviceScan::InclusiveSumByKey(d_keys.begin(), d_in.begin(), d_out.begin(), num_items));
 
   thrust::device_vector<int> expected{8, 14, 7, 12, 15, 0, 9};
   REQUIRE(d_out == expected);
@@ -100,10 +99,10 @@ TEST_CASE("Device scan inclusive-scan-by-key works with default environment", "[
   using selector_t = cub::detail::scan_by_key::policy_selector_from_types<key_t, accum_t, value_t, block_size_check_t>;
 
   int current_device{};
-  REQUIRE(cudaSuccess == cudaGetDevice(&current_device));
+  REQUIRE_CUDART(cudaGetDevice(&current_device));
 
   cudaDeviceProp device_props{};
-  REQUIRE(cudaSuccess == cudaGetDeviceProperties(&device_props, current_device));
+  REQUIRE_CUDART(cudaGetDeviceProperties(&device_props, current_device));
 
   const auto target_block_size =
     selector_t{}(cuda::compute_capability{device_props.major, device_props.minor}).threads_per_block;
@@ -115,8 +114,7 @@ TEST_CASE("Device scan inclusive-scan-by-key works with default environment", "[
   auto d_in  = cuda::constant_iterator(value_t{1});
   auto d_out = thrust::device_vector<value_t>(1);
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceScan::InclusiveScanByKey(d_keys.begin(), d_in, d_out.begin(), block_size_check, num_items));
+  REQUIRE_CUDART(cub::DeviceScan::InclusiveScanByKey(d_keys.begin(), d_in, d_out.begin(), block_size_check, num_items));
 
   REQUIRE(d_out[0] == value_t{1});
   REQUIRE(d_block_size[0] == static_cast<unsigned int>(target_block_size));
@@ -134,16 +132,8 @@ C2H_TEST("Device scan exclusive-sum-by-key uses environment", "[scan][by_key][de
   auto d_out            = thrust::device_vector<float>(num_items);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceScan::ExclusiveSumByKey(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys.begin(),
-      d_in.begin(),
-      d_out.begin(),
-      num_items,
-      cuda::std::equal_to<>{}));
+  REQUIRE_CUDART(cub::DeviceScan::ExclusiveSumByKey(
+    nullptr, expected_bytes_allocated, d_keys.begin(), d_in.begin(), d_out.begin(), num_items, cuda::std::equal_to<>{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -165,18 +155,16 @@ C2H_TEST("Device scan exclusive-scan-by-key uses environment", "[scan][by_key][d
   auto init             = 0.0f;
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceScan::ExclusiveScanByKey(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys.begin(),
-      d_in.begin(),
-      d_out.begin(),
-      scan_op_t{},
-      init,
-      num_items,
-      cuda::std::equal_to<>{}));
+  REQUIRE_CUDART(cub::DeviceScan::ExclusiveScanByKey(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys.begin(),
+    d_in.begin(),
+    d_out.begin(),
+    scan_op_t{},
+    init,
+    num_items,
+    cuda::std::equal_to<>{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -197,16 +185,8 @@ C2H_TEST("Device scan inclusive-sum-by-key uses environment", "[scan][by_key][de
   auto d_out            = thrust::device_vector<float>(num_items);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceScan::InclusiveSumByKey(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys.begin(),
-      d_in.begin(),
-      d_out.begin(),
-      num_items,
-      cuda::std::equal_to<>{}));
+  REQUIRE_CUDART(cub::DeviceScan::InclusiveSumByKey(
+    nullptr, expected_bytes_allocated, d_keys.begin(), d_in.begin(), d_out.begin(), num_items, cuda::std::equal_to<>{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -227,17 +207,15 @@ C2H_TEST("Device scan inclusive-scan-by-key uses environment", "[scan][by_key][d
   auto d_out            = thrust::device_vector<float>(num_items);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceScan::InclusiveScanByKey(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys.begin(),
-      d_in.begin(),
-      d_out.begin(),
-      scan_op_t{},
-      num_items,
-      cuda::std::equal_to<>{}));
+  REQUIRE_CUDART(cub::DeviceScan::InclusiveScanByKey(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys.begin(),
+    d_in.begin(),
+    d_out.begin(),
+    scan_op_t{},
+    num_items,
+    cuda::std::equal_to<>{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 

--- a/cub/test/catch2_test_device_scan_by_key_env_api.cu
+++ b/cub/test/catch2_test_device_scan_by_key_env_api.cu
@@ -35,7 +35,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveSumByKey accepts stream environment", "[scan
   thrust::device_vector<float> expected{0.0f, 8.0f, 0.0f, 7.0f, 12.0f, 0.0f, 0.0f};
   // example-end exclusive-sum-by-key-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -62,7 +62,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScanByKey accepts stream environment", "[sca
   thrust::device_vector<float> expected{0.0f, 8.0f, 0.0f, 7.0f, 12.0f, 0.0f, 0.0f};
   // example-end exclusive-scan-by-key-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -87,7 +87,7 @@ C2H_TEST("cub::DeviceScan::InclusiveSumByKey accepts stream environment", "[scan
   thrust::device_vector<float> expected{8.0f, 14.0f, 7.0f, 12.0f, 15.0f, 0.0f, 9.0f};
   // example-end inclusive-sum-by-key-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -113,6 +113,6 @@ C2H_TEST("cub::DeviceScan::InclusiveScanByKey accepts stream environment", "[sca
   thrust::device_vector<float> expected{8.0f, 14.0f, 7.0f, 12.0f, 15.0f, 0.0f, 9.0f};
   // example-end inclusive-scan-by-key-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }

--- a/cub/test/catch2_test_device_scan_env.cu
+++ b/cub/test/catch2_test_device_scan_env.cu
@@ -57,14 +57,14 @@ TEST_CASE("Device scan exclusive scan works with default environment", "[scan][d
     policy_selector_from_types<decltype(d_in), decltype(d_out.begin()), value_t, offset_t, block_size_check_t>;
 
   cuda::compute_capability cc;
-  REQUIRE(cudaSuccess == cub::detail::ptx_compute_cap(cc));
+  REQUIRE_CUDART(cub::detail::ptx_compute_cap(cc));
   const unsigned int target_block_size = selector_t{}(cc).lookback.threads_per_block;
 
   c2h::device_vector<unsigned int> d_block_size(1);
   block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
 
   auto init = value_t{42};
-  REQUIRE(cudaSuccess == cub::DeviceScan::ExclusiveScan(d_in, d_out.begin(), block_size_check, init, num_items));
+  REQUIRE_CUDART(cub::DeviceScan::ExclusiveScan(d_in, d_out.begin(), block_size_check, init, num_items));
   REQUIRE(d_out[0] == init);
   REQUIRE(d_out[1] == (init + value_t{1}));
 
@@ -84,8 +84,8 @@ TEST_CASE("Device scan exclusive scan with FutureValue works with default enviro
   auto init_value_vec = c2h::device_vector<int>{42};
   auto future_init    = cub::FutureValue<int>(thrust::raw_pointer_cast(init_value_vec.data()));
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceScan::ExclusiveScan(d_in.begin(), d_out.begin(), cuda::std::plus{}, future_init, num_items));
+  REQUIRE_CUDART(
+    cub::DeviceScan::ExclusiveScan(d_in.begin(), d_out.begin(), cuda::std::plus{}, future_init, num_items));
 
   auto expected = c2h::device_vector<int>{42, 43, 44, 45};
   REQUIRE(d_out == expected);
@@ -101,7 +101,7 @@ TEST_CASE("Device scan exclusive sum works with default environment", "[sum][dev
   auto d_in  = cuda::constant_iterator(value_t{1});
   auto d_out = c2h::device_vector<value_t>(num_items);
 
-  REQUIRE(cudaSuccess == cub::DeviceScan::ExclusiveSum(d_in, d_out.begin(), num_items));
+  REQUIRE_CUDART(cub::DeviceScan::ExclusiveSum(d_in, d_out.begin(), num_items));
   REQUIRE(d_out[0] == value_t{});
   REQUIRE(d_out[1] == value_t{} + d_in[0]);
 }
@@ -117,7 +117,7 @@ TEST_CASE("Device scan inclusive-scan-init works with default environment", "[sc
 
   value_t init{10};
 
-  REQUIRE(cudaSuccess == cub::DeviceScan::InclusiveScanInit(d_in, d_out.begin(), cuda::std::plus{}, init, num_items));
+  REQUIRE_CUDART(cub::DeviceScan::InclusiveScanInit(d_in, d_out.begin(), cuda::std::plus{}, init, num_items));
 
   REQUIRE(thrust::equal(d_out.begin(), d_out.end(), thrust::make_counting_iterator(init + 1)));
 }
@@ -172,7 +172,7 @@ C2H_TEST("Device scan exclusive-scan can be tuned", "[scan][device]", block_size
   // We are expecting that `unrelated_tuning` is ignored
   auto env = cuda::execution::tune(scan_tuning<target_block_size>{}, unrelated_tuning{});
 
-  REQUIRE(cudaSuccess == cub::DeviceScan::ExclusiveScan(d_in, d_out.begin(), block_size_check, init, num_items, env));
+  REQUIRE_CUDART(cub::DeviceScan::ExclusiveScan(d_in, d_out.begin(), block_size_check, init, num_items, env));
 
   REQUIRE(thrust::equal(d_out.begin(), d_out.end(), thrust::make_counting_iterator(init)));
   REQUIRE(d_block_size[0] == target_block_size);
@@ -192,7 +192,7 @@ C2H_TEST("Device scan exclusive-sum can be tuned", "[scan][device]", block_sizes
   // We are expecting that `unrelated_tuning` is ignored
   auto env = cuda::execution::tune(scan_tuning<target_block_size>{}, unrelated_tuning{});
 
-  REQUIRE(cudaSuccess == cub::DeviceScan::ExclusiveSum(d_in, d_out.begin(), num_items, env));
+  REQUIRE_CUDART(cub::DeviceScan::ExclusiveSum(d_in, d_out.begin(), num_items, env));
 
   REQUIRE(thrust::equal(d_out.begin(), d_out.end(), thrust::counting_iterator<int>(0)));
   REQUIRE(d_block_size[0] == target_block_size);
@@ -208,7 +208,7 @@ TEST_CASE("Device scan inclusive sum works with default environment", "[sum][dev
   auto d_in  = c2h::device_vector<value_t>{1, 1, 1};
   auto d_out = c2h::device_vector<value_t>(num_items);
 
-  REQUIRE(cudaSuccess == cub::DeviceScan::InclusiveSum(d_in.begin(), d_out.begin(), num_items));
+  REQUIRE_CUDART(cub::DeviceScan::InclusiveSum(d_in.begin(), d_out.begin(), num_items));
 
   auto expected = c2h::device_vector<value_t>{1, 2, 3};
   REQUIRE(d_out == expected);
@@ -228,13 +228,13 @@ TEST_CASE("Device scan inclusive-scan works with default environment", "[scan][d
     policy_selector_from_types<decltype(d_in), decltype(d_out.begin()), value_t, offset_t, block_size_check_t>;
 
   cuda::compute_capability cc;
-  REQUIRE(cudaSuccess == cub::detail::ptx_compute_cap(cc));
+  REQUIRE_CUDART(cub::detail::ptx_compute_cap(cc));
   const unsigned int target_block_size = selector_t{}(cc).lookback.threads_per_block;
 
   c2h::device_vector<unsigned int> d_block_size(1);
   block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
 
-  REQUIRE(cudaSuccess == cub::DeviceScan::InclusiveScan(d_in, d_out.begin(), block_size_check, num_items));
+  REQUIRE_CUDART(cub::DeviceScan::InclusiveScan(d_in, d_out.begin(), block_size_check, num_items));
   REQUIRE(d_out[0] == d_in[0]);
   REQUIRE(d_out[1] == d_in[0] + d_in[1]);
 
@@ -255,7 +255,7 @@ C2H_TEST("Device scan inclusive-scan can be tuned", "[scan][device]", block_size
   // We are expecting that `unrelated_tuning` is ignored
   auto env = cuda::execution::tune(scan_tuning<target_block_size>{}, unrelated_tuning{});
 
-  REQUIRE(cudaSuccess == cub::DeviceScan::InclusiveScan(d_in, d_out.begin(), block_size_check, num_items, env));
+  REQUIRE_CUDART(cub::DeviceScan::InclusiveScan(d_in, d_out.begin(), block_size_check, num_items, env));
 
   REQUIRE(thrust::equal(d_out.begin(), d_out.end(), thrust::make_counting_iterator(1)));
   REQUIRE(d_block_size[0] == target_block_size);
@@ -276,8 +276,7 @@ C2H_TEST("Device scan inclusive-scan-init can be tuned", "[scan][device]", block
   // We are expecting that `unrelated_tuning` is ignored
   auto env = cuda::execution::tune(scan_tuning<target_block_size>{}, unrelated_tuning{});
 
-  REQUIRE(
-    cudaSuccess == cub::DeviceScan::InclusiveScanInit(d_in, d_out.begin(), block_size_check, init, num_items, env));
+  REQUIRE_CUDART(cub::DeviceScan::InclusiveScanInit(d_in, d_out.begin(), block_size_check, init, num_items, env));
 
   REQUIRE(thrust::equal(d_out.begin(), d_out.end(), thrust::make_counting_iterator(init + 1)));
   REQUIRE(d_block_size[0] == target_block_size);
@@ -287,8 +286,7 @@ TEST_CASE("Device scan exclusive sum in-place works with default environment", "
 {
   auto d_data = c2h::device_vector<int>{1, 2, 3, 4};
 
-  auto error = cub::DeviceScan::ExclusiveSum(d_data.begin(), static_cast<int>(d_data.size()));
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(cub::DeviceScan::ExclusiveSum(d_data.begin(), static_cast<int>(d_data.size())));
 
   auto expected = c2h::device_vector<int>{0, 1, 3, 6};
   REQUIRE(d_data == expected);
@@ -298,8 +296,8 @@ TEST_CASE("Device scan exclusive scan in-place works with default environment", 
 {
   auto d_data = c2h::device_vector<int>{1, 2, 3, 4};
 
-  auto error = cub::DeviceScan::ExclusiveScan(d_data.begin(), cuda::std::plus{}, 42, static_cast<int>(d_data.size()));
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(
+    cub::DeviceScan::ExclusiveScan(d_data.begin(), cuda::std::plus{}, 42, static_cast<int>(d_data.size())));
 
   auto expected = c2h::device_vector<int>{42, 43, 45, 48};
   REQUIRE(d_data == expected);
@@ -309,8 +307,7 @@ TEST_CASE("Device scan inclusive sum in-place works with default environment", "
 {
   auto d_data = c2h::device_vector<int>{1, 2, 3, 4};
 
-  auto error = cub::DeviceScan::InclusiveSum(d_data.begin(), static_cast<int>(d_data.size()));
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(cub::DeviceScan::InclusiveSum(d_data.begin(), static_cast<int>(d_data.size())));
 
   auto expected = c2h::device_vector<int>{1, 3, 6, 10};
   REQUIRE(d_data == expected);
@@ -320,8 +317,7 @@ TEST_CASE("Device scan inclusive scan in-place works with default environment", 
 {
   auto d_data = c2h::device_vector<int>{1, 2, 3, 4};
 
-  auto error = cub::DeviceScan::InclusiveScan(d_data.begin(), cuda::std::plus{}, static_cast<int>(d_data.size()));
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(cub::DeviceScan::InclusiveScan(d_data.begin(), cuda::std::plus{}, static_cast<int>(d_data.size())));
 
   auto expected = c2h::device_vector<int>{1, 3, 6, 10};
   REQUIRE(d_data == expected);
@@ -334,9 +330,8 @@ TEST_CASE("Device scan exclusive scan with FutureValue in-place works with defau
   auto init_value_vec = c2h::device_vector<int>{42};
   auto future_init    = cub::FutureValue<int>(thrust::raw_pointer_cast(init_value_vec.data()));
 
-  auto error =
-    cub::DeviceScan::ExclusiveScan(d_data.begin(), cuda::std::plus{}, future_init, static_cast<int>(d_data.size()));
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(
+    cub::DeviceScan::ExclusiveScan(d_data.begin(), cuda::std::plus{}, future_init, static_cast<int>(d_data.size())));
 
   auto expected = c2h::device_vector<int>{42, 43, 45, 48};
   REQUIRE(d_data == expected);
@@ -358,9 +353,8 @@ C2H_TEST("Device scan exclusive-scan uses environment", "[scan][device]")
   init_t init{42.0f};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceScan::ExclusiveScan(
-            nullptr, expected_bytes_allocated, d_in, d_out.begin(), scan_op_t{}, init, num_items));
+  REQUIRE_CUDART(cub::DeviceScan::ExclusiveScan(
+    nullptr, expected_bytes_allocated, d_in, d_out.begin(), scan_op_t{}, init, num_items));
 
   auto env = stdexec::env{cuda::execution::require(cuda::execution::determinism::not_guaranteed), // determinism
                           expected_allocation_size(expected_bytes_allocated)}; // temp storage size
@@ -383,9 +377,8 @@ C2H_TEST("Device scan exclusive-scan with FutureValue uses environment", "[scan]
   auto future_init    = cub::FutureValue<int>(thrust::raw_pointer_cast(init_value_vec.data()));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceScan::ExclusiveScan(
-            nullptr, expected_bytes_allocated, d_in, d_out.begin(), scan_op_t{}, future_init, num_items));
+  REQUIRE_CUDART(cub::DeviceScan::ExclusiveScan(
+    nullptr, expected_bytes_allocated, d_in, d_out.begin(), scan_op_t{}, future_init, num_items));
 
   auto env = stdexec::env{cuda::execution::require(cuda::execution::determinism::not_guaranteed), // determinism
                           expected_allocation_size(expected_bytes_allocated)}; // temp storage size
@@ -405,8 +398,7 @@ C2H_TEST("Device scan exclusive-sum uses environment", "[scan][device]")
   auto d_out            = c2h::device_vector<float>(num_items);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess == cub::DeviceScan::ExclusiveSum(nullptr, expected_bytes_allocated, d_in, d_out.begin(), num_items));
+  REQUIRE_CUDART(cub::DeviceScan::ExclusiveSum(nullptr, expected_bytes_allocated, d_in, d_out.begin(), num_items));
 
   auto env = stdexec::env{cuda::execution::require(cuda::execution::determinism::not_guaranteed), // determinism
                           expected_allocation_size(expected_bytes_allocated)}; // temp storage size
@@ -425,8 +417,8 @@ C2H_TEST("Device scan inclusive-sum uses environment", "[scan][device]")
   auto d_out            = c2h::device_vector<int>(num_items);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceScan::InclusiveSum(nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), num_items));
+  REQUIRE_CUDART(
+    cub::DeviceScan::InclusiveSum(nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), num_items));
 
   auto env = stdexec::env{cuda::execution::require(cuda::execution::determinism::not_guaranteed), // determinism
                           expected_allocation_size(expected_bytes_allocated)}; // temp storage size
@@ -452,9 +444,8 @@ C2H_TEST("Device scan inclusive-scan uses environment", "[scan][device]")
   auto d_out            = c2h::device_vector<float>(num_items);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceScan::InclusiveScan(nullptr, expected_bytes_allocated, d_in, d_out.begin(), scan_op_t{}, num_items));
+  REQUIRE_CUDART(
+    cub::DeviceScan::InclusiveScan(nullptr, expected_bytes_allocated, d_in, d_out.begin(), scan_op_t{}, num_items));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)}; // temp storage size
 
@@ -473,9 +464,8 @@ C2H_TEST("Device scan inclusive-scan-init uses environment", "[scan][device]")
   float init            = 10.0f;
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceScan::InclusiveScanInit(
-            nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), cuda::std::plus{}, init, num_items));
+  REQUIRE_CUDART(cub::DeviceScan::InclusiveScanInit(
+    nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), cuda::std::plus{}, init, num_items));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)}; // temp storage size
 
@@ -490,9 +480,8 @@ C2H_TEST("Device scan exclusive-sum in-place uses environment", "[scan][device]"
   auto d_data = c2h::device_vector<int>{1, 2, 3, 4};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceScan::ExclusiveSum(
-            nullptr, expected_bytes_allocated, d_data.begin(), d_data.begin(), static_cast<int>(d_data.size())));
+  REQUIRE_CUDART(cub::DeviceScan::ExclusiveSum(
+    nullptr, expected_bytes_allocated, d_data.begin(), d_data.begin(), static_cast<int>(d_data.size())));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -507,16 +496,14 @@ C2H_TEST("Device scan exclusive-scan in-place uses environment", "[scan][device]
   auto d_data = c2h::device_vector<int>{1, 2, 3, 4};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceScan::ExclusiveScan(
-      nullptr,
-      expected_bytes_allocated,
-      d_data.begin(),
-      d_data.begin(),
-      cuda::std::plus{},
-      42,
-      static_cast<int>(d_data.size())));
+  REQUIRE_CUDART(cub::DeviceScan::ExclusiveScan(
+    nullptr,
+    expected_bytes_allocated,
+    d_data.begin(),
+    d_data.begin(),
+    cuda::std::plus{},
+    42,
+    static_cast<int>(d_data.size())));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -534,16 +521,14 @@ C2H_TEST("Device scan exclusive-scan with FutureValue in-place uses environment"
   auto future_init    = cub::FutureValue<int>(thrust::raw_pointer_cast(init_value_vec.data()));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceScan::ExclusiveScan(
-      nullptr,
-      expected_bytes_allocated,
-      d_data.begin(),
-      d_data.begin(),
-      cuda::std::plus{},
-      future_init,
-      static_cast<int>(d_data.size())));
+  REQUIRE_CUDART(cub::DeviceScan::ExclusiveScan(
+    nullptr,
+    expected_bytes_allocated,
+    d_data.begin(),
+    d_data.begin(),
+    cuda::std::plus{},
+    future_init,
+    static_cast<int>(d_data.size())));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -558,9 +543,8 @@ C2H_TEST("Device scan inclusive-sum in-place uses environment", "[scan][device]"
   auto d_data = c2h::device_vector<int>{1, 2, 3, 4};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceScan::InclusiveSum(
-            nullptr, expected_bytes_allocated, d_data.begin(), d_data.begin(), static_cast<int>(d_data.size())));
+  REQUIRE_CUDART(cub::DeviceScan::InclusiveSum(
+    nullptr, expected_bytes_allocated, d_data.begin(), d_data.begin(), static_cast<int>(d_data.size())));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -575,15 +559,13 @@ C2H_TEST("Device scan inclusive-scan in-place uses environment", "[scan][device]
   auto d_data = c2h::device_vector<int>{1, 2, 3, 4};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceScan::InclusiveScan(
-      nullptr,
-      expected_bytes_allocated,
-      d_data.begin(),
-      d_data.begin(),
-      cuda::std::plus{},
-      static_cast<int>(d_data.size())));
+  REQUIRE_CUDART(cub::DeviceScan::InclusiveScan(
+    nullptr,
+    expected_bytes_allocated,
+    d_data.begin(),
+    d_data.begin(),
+    cuda::std::plus{},
+    static_cast<int>(d_data.size())));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 

--- a/cub/test/catch2_test_device_scan_env_api.cu
+++ b/cub/test/catch2_test_device_scan_env_api.cu
@@ -35,7 +35,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScan accepts run_to_run determinism requirem
   thrust::device_vector<int> expected{0, 0, 1, 3};
   // example-end exclusive-scan-env-determinism
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -62,7 +62,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScan accepts stream and not_guaranteed deter
   // example-end exclusive-scan-env-stream
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -83,7 +83,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveSum accepts run_to_run determinism requireme
   thrust::device_vector<int> expected{0, 0, 1, 3};
   // example-end exclusive-sum-env-determinism
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -108,7 +108,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveSum accepts stream and not_guaranteed determ
   // example-end exclusive-sum-env-stream
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -129,7 +129,7 @@ C2H_TEST("cub::DeviceScan::InclusiveSum accepts run_to_run determinism requireme
   thrust::device_vector<int> expected{1, 3, 6, 10};
   // example-end inclusive-sum-env-determinism
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -154,7 +154,7 @@ C2H_TEST("cub::DeviceScan::InclusiveSum accepts stream and not_guaranteed determ
   // example-end inclusive-sum-env-stream
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -179,7 +179,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScan with FutureValue accepts environment", 
   thrust::device_vector<int> expected{5, 13, 19, 26, 31, 34, 34};
   // example-end exclusive-scan-future-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -207,7 +207,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScan with FutureValue accepts stream environ
   // example-end exclusive-scan-future-env-stream
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -227,7 +227,7 @@ C2H_TEST("cub::DeviceScan::InclusiveScan accepts environment", "[scan][env]")
   thrust::device_vector<int> expected{1, 3, 6, 10};
   // example-end inclusive-scan-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -252,7 +252,7 @@ C2H_TEST("cub::DeviceScan::InclusiveScan accepts stream environment", "[scan][en
   // example-end inclusive-scan-env-stream
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -273,7 +273,7 @@ C2H_TEST("cub::DeviceScan::InclusiveScanInit accepts environment", "[scan][env]"
   thrust::device_vector<int> expected{11, 13, 16, 20};
   // example-end inclusive-scan-init-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -299,7 +299,7 @@ C2H_TEST("cub::DeviceScan::InclusiveScanInit accepts stream environment", "[scan
   // example-end inclusive-scan-init-env-stream
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected);
 }
 
@@ -321,7 +321,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveSum in-place accepts stream", "[scan][env]")
   // example-end exclusive-sum-inplace-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(data == expected);
 }
 
@@ -344,7 +344,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScan in-place accepts stream", "[scan][env]"
   // example-end exclusive-scan-inplace-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(data == expected);
 }
 
@@ -370,7 +370,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScan with FutureValue in-place accepts strea
   // example-end exclusive-scan-future-inplace-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(data == expected);
 }
 
@@ -392,7 +392,7 @@ C2H_TEST("cub::DeviceScan::InclusiveSum in-place accepts stream", "[scan][env]")
   // example-end inclusive-sum-inplace-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(data == expected);
 }
 
@@ -415,6 +415,6 @@ C2H_TEST("cub::DeviceScan::InclusiveScan in-place accepts stream", "[scan][env]"
   // example-end inclusive-scan-inplace-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(data == expected);
 }

--- a/cub/test/catch2_test_device_scan_noncommutative.cu
+++ b/cub/test/catch2_test_device_scan_noncommutative.cu
@@ -62,7 +62,7 @@ C2H_TEST("Device inclusive scan works with non-commutative operator", "[scan][de
 
   size_t tmp_size{};
   cudaError_t status1 = cub::DeviceScan::InclusiveScan(nullptr, tmp_size, d_input, d_output, op_t{}, input.size());
-  REQUIRE(cudaSuccess == status1);
+  REQUIRE_CUDART(status1);
   REQUIRE(tmp_size > 0);
 
   using cuda::std::byte;
@@ -73,7 +73,7 @@ C2H_TEST("Device inclusive scan works with non-commutative operator", "[scan][de
   REQUIRE(d_tmp != nullptr);
 
   cudaError_t status2 = cub::DeviceScan::InclusiveScan(d_tmp, tmp_size, d_input, d_output, op_t{}, input.size());
-  REQUIRE(cudaSuccess == status2);
+  REQUIRE_CUDART(status2);
 
   // transfer to host_vector is synchronizing
   c2h::host_vector<pair_t> h_output(output);

--- a/cub/test/catch2_test_device_segmented_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_env.cu
@@ -34,17 +34,15 @@ TEST_CASE("DeviceSegmentedRadixSort::SortPairs works with default environment", 
   auto values_out = c2h::device_vector<int>(7);
   auto offsets    = c2h::device_vector<int>{0, 3, 3, 7};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedRadixSort::SortPairs(
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      thrust::raw_pointer_cast(values_in.data()),
-      thrust::raw_pointer_cast(values_out.data()),
-      static_cast<int>(keys_in.size()),
-      3,
-      offsets.begin(),
-      offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortPairs(
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    thrust::raw_pointer_cast(values_in.data()),
+    thrust::raw_pointer_cast(values_out.data()),
+    static_cast<int>(keys_in.size()),
+    3,
+    offsets.begin(),
+    offsets.begin() + 1));
 
   c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
   c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
@@ -61,17 +59,15 @@ TEST_CASE("DeviceSegmentedRadixSort::SortPairsDescending works with default envi
   auto values_out = c2h::device_vector<int>(7);
   auto offsets    = c2h::device_vector<int>{0, 3, 3, 7};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedRadixSort::SortPairsDescending(
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      thrust::raw_pointer_cast(values_in.data()),
-      thrust::raw_pointer_cast(values_out.data()),
-      static_cast<int>(keys_in.size()),
-      3,
-      offsets.begin(),
-      offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortPairsDescending(
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    thrust::raw_pointer_cast(values_in.data()),
+    thrust::raw_pointer_cast(values_out.data()),
+    static_cast<int>(keys_in.size()),
+    3,
+    offsets.begin(),
+    offsets.begin() + 1));
 
   c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
   c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
@@ -85,15 +81,13 @@ TEST_CASE("DeviceSegmentedRadixSort::SortKeys works with default environment", "
   auto keys_out = c2h::device_vector<int>(7);
   auto offsets  = c2h::device_vector<int>{0, 3, 3, 7};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedRadixSort::SortKeys(
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      static_cast<int>(keys_in.size()),
-      3,
-      offsets.begin(),
-      offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortKeys(
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    static_cast<int>(keys_in.size()),
+    3,
+    offsets.begin(),
+    offsets.begin() + 1));
 
   c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
   REQUIRE(keys_out == expected_keys);
@@ -106,15 +100,13 @@ TEST_CASE("DeviceSegmentedRadixSort::SortKeysDescending works with default envir
   auto keys_out = c2h::device_vector<int>(7);
   auto offsets  = c2h::device_vector<int>{0, 3, 3, 7};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedRadixSort::SortKeysDescending(
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      static_cast<int>(keys_in.size()),
-      3,
-      offsets.begin(),
-      offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortKeysDescending(
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    static_cast<int>(keys_in.size()),
+    3,
+    offsets.begin(),
+    offsets.begin() + 1));
 
   c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
   REQUIRE(keys_out == expected_keys);
@@ -129,9 +121,8 @@ TEST_CASE("DeviceSegmentedRadixSort::SortKeys DoubleBuffer works with default en
 
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf.data()), thrust::raw_pointer_cast(keys_alt.data()));
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceSegmentedRadixSort::SortKeys(
-            d_keys, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortKeys(
+    d_keys, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1));
 
   c2h::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
@@ -149,9 +140,8 @@ TEST_CASE("DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer works with 
 
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf.data()), thrust::raw_pointer_cast(keys_alt.data()));
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceSegmentedRadixSort::SortKeysDescending(
-            d_keys, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortKeysDescending(
+    d_keys, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1));
 
   c2h::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
@@ -171,19 +161,17 @@ C2H_TEST("DeviceSegmentedRadixSort::SortPairs uses environment", "[segmented_rad
   auto offsets    = c2h::device_vector<int>{0, 3, 3, 7};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedRadixSort::SortPairs(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      thrust::raw_pointer_cast(values_in.data()),
-      thrust::raw_pointer_cast(values_out.data()),
-      static_cast<::cuda::std::int64_t>(keys_in.size()),
-      static_cast<::cuda::std::int64_t>(3),
-      offsets.begin(),
-      offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortPairs(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    thrust::raw_pointer_cast(values_in.data()),
+    thrust::raw_pointer_cast(values_out.data()),
+    static_cast<::cuda::std::int64_t>(keys_in.size()),
+    static_cast<::cuda::std::int64_t>(3),
+    offsets.begin(),
+    offsets.begin() + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -215,19 +203,17 @@ C2H_TEST("DeviceSegmentedRadixSort::SortPairsDescending uses environment", "[seg
   auto offsets    = c2h::device_vector<int>{0, 3, 3, 7};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedRadixSort::SortPairsDescending(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      thrust::raw_pointer_cast(values_in.data()),
-      thrust::raw_pointer_cast(values_out.data()),
-      static_cast<::cuda::std::int64_t>(keys_in.size()),
-      static_cast<::cuda::std::int64_t>(3),
-      offsets.begin(),
-      offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortPairsDescending(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    thrust::raw_pointer_cast(values_in.data()),
+    thrust::raw_pointer_cast(values_out.data()),
+    static_cast<::cuda::std::int64_t>(keys_in.size()),
+    static_cast<::cuda::std::int64_t>(3),
+    offsets.begin(),
+    offsets.begin() + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -257,17 +243,15 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeys uses environment", "[segmented_radi
   auto offsets  = c2h::device_vector<int>{0, 3, 3, 7};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedRadixSort::SortKeys(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      static_cast<::cuda::std::int64_t>(keys_in.size()),
-      static_cast<::cuda::std::int64_t>(3),
-      offsets.begin(),
-      offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortKeys(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    static_cast<::cuda::std::int64_t>(keys_in.size()),
+    static_cast<::cuda::std::int64_t>(3),
+    offsets.begin(),
+    offsets.begin() + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -293,17 +277,15 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeysDescending uses environment", "[segm
   auto offsets  = c2h::device_vector<int>{0, 3, 3, 7};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedRadixSort::SortKeysDescending(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      static_cast<::cuda::std::int64_t>(keys_in.size()),
-      static_cast<::cuda::std::int64_t>(3),
-      offsets.begin(),
-      offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortKeysDescending(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    static_cast<::cuda::std::int64_t>(keys_in.size()),
+    static_cast<::cuda::std::int64_t>(3),
+    offsets.begin(),
+    offsets.begin() + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -331,22 +313,20 @@ TEST_CASE("DeviceSegmentedRadixSort::SortPairs uses custom stream", "[segmented_
   auto offsets    = c2h::device_vector<int>{0, 3, 3, 7};
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedRadixSort::SortPairs(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      thrust::raw_pointer_cast(values_in.data()),
-      thrust::raw_pointer_cast(values_out.data()),
-      static_cast<::cuda::std::int64_t>(keys_in.size()),
-      static_cast<::cuda::std::int64_t>(3),
-      offsets.begin(),
-      offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortPairs(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    thrust::raw_pointer_cast(values_in.data()),
+    thrust::raw_pointer_cast(values_out.data()),
+    static_cast<::cuda::std::int64_t>(keys_in.size()),
+    static_cast<::cuda::std::int64_t>(3),
+    offsets.begin(),
+    offsets.begin() + 1));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -364,14 +344,14 @@ TEST_CASE("DeviceSegmentedRadixSort::SortPairs uses custom stream", "[segmented_
     static_cast<int>(sizeof(int) * 8),
     env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
   c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 TEST_CASE("DeviceSegmentedRadixSort::SortPairsDescending uses custom stream", "[segmented_radix_sort][device]")
@@ -383,22 +363,20 @@ TEST_CASE("DeviceSegmentedRadixSort::SortPairsDescending uses custom stream", "[
   auto offsets    = c2h::device_vector<int>{0, 3, 3, 7};
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedRadixSort::SortPairsDescending(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      thrust::raw_pointer_cast(values_in.data()),
-      thrust::raw_pointer_cast(values_out.data()),
-      static_cast<::cuda::std::int64_t>(keys_in.size()),
-      static_cast<::cuda::std::int64_t>(3),
-      offsets.begin(),
-      offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortPairsDescending(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    thrust::raw_pointer_cast(values_in.data()),
+    thrust::raw_pointer_cast(values_out.data()),
+    static_cast<::cuda::std::int64_t>(keys_in.size()),
+    static_cast<::cuda::std::int64_t>(3),
+    offsets.begin(),
+    offsets.begin() + 1));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -416,14 +394,14 @@ TEST_CASE("DeviceSegmentedRadixSort::SortPairsDescending uses custom stream", "[
     static_cast<int>(sizeof(int) * 8),
     env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
   c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 TEST_CASE("DeviceSegmentedRadixSort::SortKeys uses custom stream", "[segmented_radix_sort][device]")
@@ -433,20 +411,18 @@ TEST_CASE("DeviceSegmentedRadixSort::SortKeys uses custom stream", "[segmented_r
   auto offsets  = c2h::device_vector<int>{0, 3, 3, 7};
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedRadixSort::SortKeys(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      static_cast<::cuda::std::int64_t>(keys_in.size()),
-      static_cast<::cuda::std::int64_t>(3),
-      offsets.begin(),
-      offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortKeys(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    static_cast<::cuda::std::int64_t>(keys_in.size()),
+    static_cast<::cuda::std::int64_t>(3),
+    offsets.begin(),
+    offsets.begin() + 1));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -462,12 +438,12 @@ TEST_CASE("DeviceSegmentedRadixSort::SortKeys uses custom stream", "[segmented_r
     static_cast<int>(sizeof(int) * 8),
     env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
   REQUIRE(keys_out == expected_keys);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 TEST_CASE("DeviceSegmentedRadixSort::SortKeysDescending uses custom stream", "[segmented_radix_sort][device]")
@@ -477,20 +453,18 @@ TEST_CASE("DeviceSegmentedRadixSort::SortKeysDescending uses custom stream", "[s
   auto offsets  = c2h::device_vector<int>{0, 3, 3, 7};
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedRadixSort::SortKeysDescending(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      static_cast<::cuda::std::int64_t>(keys_in.size()),
-      static_cast<::cuda::std::int64_t>(3),
-      offsets.begin(),
-      offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortKeysDescending(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    static_cast<::cuda::std::int64_t>(keys_in.size()),
+    static_cast<::cuda::std::int64_t>(3),
+    offsets.begin(),
+    offsets.begin() + 1));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -506,12 +480,12 @@ TEST_CASE("DeviceSegmentedRadixSort::SortKeysDescending uses custom stream", "[s
     static_cast<int>(sizeof(int) * 8),
     env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
   REQUIRE(keys_out == expected_keys);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 C2H_TEST("DeviceSegmentedRadixSort::SortKeys DoubleBuffer uses environment", "[segmented_radix_sort][device]")
@@ -523,16 +497,14 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeys DoubleBuffer uses environment", "[s
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf.data()), thrust::raw_pointer_cast(keys_alt.data()));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedRadixSort::SortKeys(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys,
-      static_cast<::cuda::std::int64_t>(keys_buf.size()),
-      static_cast<::cuda::std::int64_t>(3),
-      offsets.begin(),
-      offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortKeys(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys,
+    static_cast<::cuda::std::int64_t>(keys_buf.size()),
+    static_cast<::cuda::std::int64_t>(3),
+    offsets.begin(),
+    offsets.begin() + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -562,16 +534,14 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer uses environ
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf.data()), thrust::raw_pointer_cast(keys_alt.data()));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedRadixSort::SortKeysDescending(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys,
-      static_cast<::cuda::std::int64_t>(keys_buf.size()),
-      static_cast<::cuda::std::int64_t>(3),
-      offsets.begin(),
-      offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortKeysDescending(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys,
+    static_cast<::cuda::std::int64_t>(keys_buf.size()),
+    static_cast<::cuda::std::int64_t>(3),
+    offsets.begin(),
+    offsets.begin() + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -605,9 +575,8 @@ TEST_CASE("DeviceSegmentedRadixSort::SortPairs DoubleBuffer works with default e
   cub::DoubleBuffer<int> d_values(
     thrust::raw_pointer_cast(values_buf.data()), thrust::raw_pointer_cast(values_alt.data()));
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceSegmentedRadixSort::SortPairs(
-            d_keys, d_values, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortPairs(
+    d_keys, d_values, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1));
 
   c2h::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
@@ -633,9 +602,8 @@ TEST_CASE("DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer works with
   cub::DoubleBuffer<int> d_values(
     thrust::raw_pointer_cast(values_buf.data()), thrust::raw_pointer_cast(values_alt.data()));
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceSegmentedRadixSort::SortPairsDescending(
-            d_keys, d_values, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortPairsDescending(
+    d_keys, d_values, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1));
 
   c2h::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
@@ -661,17 +629,15 @@ C2H_TEST("DeviceSegmentedRadixSort::SortPairs DoubleBuffer uses environment", "[
     thrust::raw_pointer_cast(values_buf.data()), thrust::raw_pointer_cast(values_alt.data()));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedRadixSort::SortPairs(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys,
-      d_values,
-      static_cast<::cuda::std::int64_t>(keys_buf.size()),
-      static_cast<::cuda::std::int64_t>(3),
-      offsets.begin(),
-      offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortPairs(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys,
+    d_values,
+    static_cast<::cuda::std::int64_t>(keys_buf.size()),
+    static_cast<::cuda::std::int64_t>(3),
+    offsets.begin(),
+    offsets.begin() + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -711,17 +677,15 @@ C2H_TEST("DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer uses enviro
     thrust::raw_pointer_cast(values_buf.data()), thrust::raw_pointer_cast(values_alt.data()));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedRadixSort::SortPairsDescending(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys,
-      d_values,
-      static_cast<::cuda::std::int64_t>(keys_buf.size()),
-      static_cast<::cuda::std::int64_t>(3),
-      offsets.begin(),
-      offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortPairsDescending(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys,
+    d_values,
+    static_cast<::cuda::std::int64_t>(keys_buf.size()),
+    static_cast<::cuda::std::int64_t>(3),
+    offsets.begin(),
+    offsets.begin() + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -760,20 +724,18 @@ TEST_CASE("DeviceSegmentedRadixSort::SortPairs DoubleBuffer uses custom stream",
     thrust::raw_pointer_cast(values_buf.data()), thrust::raw_pointer_cast(values_alt.data()));
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedRadixSort::SortPairs(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys,
-      d_values,
-      static_cast<::cuda::std::int64_t>(keys_buf.size()),
-      static_cast<::cuda::std::int64_t>(3),
-      offsets.begin(),
-      offsets.begin() + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedRadixSort::SortPairs(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys,
+    d_values,
+    static_cast<::cuda::std::int64_t>(keys_buf.size()),
+    static_cast<::cuda::std::int64_t>(3),
+    offsets.begin(),
+    offsets.begin() + 1));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -789,7 +751,7 @@ TEST_CASE("DeviceSegmentedRadixSort::SortPairs DoubleBuffer uses custom stream",
     static_cast<int>(sizeof(int) * 8),
     env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
@@ -801,5 +763,5 @@ TEST_CASE("DeviceSegmentedRadixSort::SortPairs DoubleBuffer uses custom stream",
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }

--- a/cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
@@ -48,7 +48,7 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortPairs env with stream", "[segmented
   // example-end segmented-radix-sort-pairs-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -87,7 +87,7 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortPairsDescending env with stream", "
   // example-end segmented-radix-sort-pairs-descending-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -121,7 +121,7 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortKeys env with stream", "[segmented_
   // example-end segmented-radix-sort-keys-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected_keys);
 }
 
@@ -154,7 +154,7 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortKeysDescending env with stream", "[
   // example-end segmented-radix-sort-keys-descending-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected_keys);
 }
 
@@ -181,7 +181,7 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortKeys DoubleBuffer env with stream",
   // example-end segmented-radix-sort-keys-db-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 
   thrust::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
@@ -213,7 +213,7 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer env wit
   // example-end segmented-radix-sort-keys-descending-db-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 
   thrust::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
@@ -256,7 +256,7 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortPairs DoubleBuffer env with stream"
   // example-end segmented-radix-sort-pairs-db-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 
   thrust::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
@@ -304,7 +304,7 @@ C2H_TEST("cub::DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer env wi
   // example-end segmented-radix-sort-pairs-descending-db-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 
   thrust::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);

--- a/cub/test/catch2_test_device_segmented_reduce_env.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_env.cu
@@ -41,9 +41,8 @@ TEST_CASE("Device segmented reduce works with default environment", "[segmented_
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<int> d_out(3);
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceSegmentedReduce::Reduce(
-            d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, ::cuda::std::plus<>{}, 0));
+  REQUIRE_CUDART(cub::DeviceSegmentedReduce::Reduce(
+    d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, ::cuda::std::plus<>{}, 0));
 
   thrust::device_vector<int> expected{26, 12, 3};
   REQUIRE(d_out == expected);
@@ -57,9 +56,8 @@ TEST_CASE("Device segmented sum works with default environment", "[segmented_red
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<int> d_out(3);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedReduce::Sum(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
+  REQUIRE_CUDART(
+    cub::DeviceSegmentedReduce::Sum(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
 
   thrust::device_vector<int> expected{26, 12, 3};
   REQUIRE(d_out == expected);
@@ -73,9 +71,8 @@ TEST_CASE("Device segmented min works with default environment", "[segmented_red
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<int> d_out(3);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedReduce::Min(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
+  REQUIRE_CUDART(
+    cub::DeviceSegmentedReduce::Min(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
 
   thrust::device_vector<int> expected{5, 0, 1};
   REQUIRE(d_out == expected);
@@ -89,9 +86,8 @@ TEST_CASE("Device segmented max works with default environment", "[segmented_red
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<int> d_out(3);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedReduce::Max(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
+  REQUIRE_CUDART(
+    cub::DeviceSegmentedReduce::Max(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
 
   thrust::device_vector<int> expected{8, 9, 2};
   REQUIRE(d_out == expected);
@@ -105,9 +101,8 @@ TEST_CASE("Device segmented argmin works with default environment", "[segmented_
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<cub::KeyValuePair<int, int>> d_out(3);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedReduce::ArgMin(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
+  REQUIRE_CUDART(
+    cub::DeviceSegmentedReduce::ArgMin(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
 
   thrust::host_vector<cub::KeyValuePair<int, int>> h_out(d_out);
   REQUIRE(h_out[0].key == 3);
@@ -126,9 +121,8 @@ TEST_CASE("Device segmented argmax works with default environment", "[segmented_
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<cub::KeyValuePair<int, int>> d_out(3);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedReduce::ArgMax(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
+  REQUIRE_CUDART(
+    cub::DeviceSegmentedReduce::ArgMax(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
 
   thrust::host_vector<cub::KeyValuePair<int, int>> h_out(d_out);
   REQUIRE(h_out[0].key == 0);
@@ -146,9 +140,8 @@ TEST_CASE("Device fixed-size segmented reduce works with default environment", "
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
   thrust::device_vector<int> d_out(2);
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceSegmentedReduce::Reduce(
-            d_in.begin(), d_out.begin(), num_segments, segment_size, ::cuda::std::plus<>{}, 0));
+  REQUIRE_CUDART(cub::DeviceSegmentedReduce::Reduce(
+    d_in.begin(), d_out.begin(), num_segments, segment_size, ::cuda::std::plus<>{}, 0));
 
   thrust::device_vector<int> expected{21, 8};
   REQUIRE(d_out == expected);
@@ -161,7 +154,7 @@ TEST_CASE("Device fixed-size segmented sum works with default environment", "[se
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
   thrust::device_vector<int> d_out(2);
 
-  REQUIRE(cudaSuccess == cub::DeviceSegmentedReduce::Sum(d_in.begin(), d_out.begin(), num_segments, segment_size));
+  REQUIRE_CUDART(cub::DeviceSegmentedReduce::Sum(d_in.begin(), d_out.begin(), num_segments, segment_size));
 
   thrust::device_vector<int> expected{21, 8};
   REQUIRE(d_out == expected);
@@ -174,7 +167,7 @@ TEST_CASE("Device fixed-size segmented min works with default environment", "[se
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
   thrust::device_vector<int> d_out(2);
 
-  REQUIRE(cudaSuccess == cub::DeviceSegmentedReduce::Min(d_in.begin(), d_out.begin(), num_segments, segment_size));
+  REQUIRE_CUDART(cub::DeviceSegmentedReduce::Min(d_in.begin(), d_out.begin(), num_segments, segment_size));
 
   thrust::device_vector<int> expected{6, 0};
   REQUIRE(d_out == expected);
@@ -187,7 +180,7 @@ TEST_CASE("Device fixed-size segmented max works with default environment", "[se
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
   thrust::device_vector<int> d_out(2);
 
-  REQUIRE(cudaSuccess == cub::DeviceSegmentedReduce::Max(d_in.begin(), d_out.begin(), num_segments, segment_size));
+  REQUIRE_CUDART(cub::DeviceSegmentedReduce::Max(d_in.begin(), d_out.begin(), num_segments, segment_size));
 
   thrust::device_vector<int> expected{8, 5};
   REQUIRE(d_out == expected);
@@ -200,7 +193,7 @@ TEST_CASE("Device fixed-size segmented argmin works with default environment", "
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
   thrust::device_vector<cuda::std::pair<int, int>> d_out(2);
 
-  REQUIRE(cudaSuccess == cub::DeviceSegmentedReduce::ArgMin(d_in.begin(), d_out.begin(), num_segments, segment_size));
+  REQUIRE_CUDART(cub::DeviceSegmentedReduce::ArgMin(d_in.begin(), d_out.begin(), num_segments, segment_size));
 
   thrust::device_vector<cuda::std::pair<int, int>> expected{{1, 6}, {2, 0}};
   REQUIRE(d_out == expected);
@@ -213,7 +206,7 @@ TEST_CASE("Device fixed-size segmented argmax works with default environment", "
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
   thrust::device_vector<cuda::std::pair<int, int>> d_out(2);
 
-  REQUIRE(cudaSuccess == cub::DeviceSegmentedReduce::ArgMax(d_in.begin(), d_out.begin(), num_segments, segment_size));
+  REQUIRE_CUDART(cub::DeviceSegmentedReduce::ArgMax(d_in.begin(), d_out.begin(), num_segments, segment_size));
 
   thrust::device_vector<cuda::std::pair<int, int>> expected{{0, 8}, {0, 5}};
   REQUIRE(d_out == expected);
@@ -230,18 +223,16 @@ C2H_TEST("Device segmented reduce uses environment", "[segmented_reduce][device]
   thrust::device_vector<int> d_out(3);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedReduce::Reduce(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_out.begin(),
-      num_segments,
-      d_offsets_it,
-      d_offsets_it + 1,
-      ::cuda::std::plus<>{},
-      0));
+  REQUIRE_CUDART(cub::DeviceSegmentedReduce::Reduce(
+    nullptr,
+    expected_bytes_allocated,
+    d_in.begin(),
+    d_out.begin(),
+    num_segments,
+    d_offsets_it,
+    d_offsets_it + 1,
+    ::cuda::std::plus<>{},
+    0));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -261,10 +252,8 @@ C2H_TEST("Device segmented sum uses environment", "[segmented_reduce][device]")
   thrust::device_vector<int> d_out(3);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedReduce::Sum(
-      nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedReduce::Sum(
+    nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -283,10 +272,8 @@ C2H_TEST("Device segmented min uses environment", "[segmented_reduce][device]")
   thrust::device_vector<int> d_out(3);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedReduce::Min(
-      nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedReduce::Min(
+    nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -305,10 +292,8 @@ C2H_TEST("Device segmented max uses environment", "[segmented_reduce][device]")
   thrust::device_vector<int> d_out(3);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedReduce::Max(
-      nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedReduce::Max(
+    nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -327,10 +312,8 @@ C2H_TEST("Device segmented argmin uses environment", "[segmented_reduce][device]
   thrust::device_vector<cub::KeyValuePair<int, int>> d_out(3);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedReduce::ArgMin(
-      nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedReduce::ArgMin(
+    nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -349,10 +332,8 @@ C2H_TEST("Device segmented argmax uses environment", "[segmented_reduce][device]
   thrust::device_vector<cub::KeyValuePair<int, int>> d_out(3);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedReduce::ArgMax(
-      nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedReduce::ArgMax(
+    nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 

--- a/cub/test/catch2_test_device_segmented_reduce_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_env_api.cu
@@ -42,7 +42,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Sum accepts env with stream and determinis
 
   stream.sync();
   REQUIRE(d_out == expected);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 }
 
 C2H_TEST("cub::DeviceSegmentedReduce::Sum accepts stream", "[segmented_reduce][env]")
@@ -69,7 +69,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Sum accepts stream", "[segmented_reduce][e
 
   stream.sync();
   REQUIRE(d_out == expected);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 }
 
 C2H_TEST("cub::DeviceSegmentedReduce::Sum accepts run_to_run determinism requirements", "[segmented_reduce][env]")
@@ -94,7 +94,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Sum accepts run_to_run determinism require
   // example-end segmented-reduce-sum-env-determinism
 
   REQUIRE(d_out == expected);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 }
 
 C2H_TEST("cub::DeviceSegmentedReduce::Sum accepts not_guaranteed determinism requirements", "[segmented_reduce][env]")
@@ -119,7 +119,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Sum accepts not_guaranteed determinism req
   // example-end segmented-reduce-sum-env-non-determinism
 
   REQUIRE(d_out == expected);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 }
 
 C2H_TEST("cub::DeviceSegmentedReduce::Reduce env-based API", "[segmented_reduce][env]")
@@ -146,7 +146,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Reduce env-based API", "[segmented_reduce]
   stream.sync();
 
   REQUIRE(d_out == expected);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 }
 
 C2H_TEST("cub::DeviceSegmentedReduce::Min env-based API", "[segmented_reduce][env]")
@@ -173,7 +173,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Min env-based API", "[segmented_reduce][en
   stream.sync();
 
   REQUIRE(d_out == expected);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 }
 
 C2H_TEST("cub::DeviceSegmentedReduce::Max env-based API", "[segmented_reduce][env]")
@@ -200,7 +200,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Max env-based API", "[segmented_reduce][en
   stream.sync();
 
   REQUIRE(d_out == expected);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 }
 
 C2H_TEST("cub::DeviceSegmentedReduce::ArgMin env-based API", "[segmented_reduce][env]")
@@ -270,7 +270,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Min accepts run_to_run determinism require
   thrust::device_vector<int> expected{6, std::numeric_limits<int>::max(), 0};
 
   REQUIRE(d_out == expected);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 }
 
 C2H_TEST("cub::DeviceSegmentedReduce::Min accepts not_guaranteed determinism requirements", "[segmented_reduce][env]")
@@ -288,7 +288,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Min accepts not_guaranteed determinism req
   thrust::device_vector<int> expected{6, std::numeric_limits<int>::max(), 0};
 
   REQUIRE(d_out == expected);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 }
 
 C2H_TEST("cub::DeviceSegmentedReduce::Max accepts run_to_run determinism requirements", "[segmented_reduce][env]")
@@ -306,7 +306,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Max accepts run_to_run determinism require
   thrust::device_vector<int> expected{8, std::numeric_limits<int>::lowest(), 9};
 
   REQUIRE(d_out == expected);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 }
 
 C2H_TEST("cub::DeviceSegmentedReduce::Max accepts not_guaranteed determinism requirements", "[segmented_reduce][env]")
@@ -324,7 +324,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Max accepts not_guaranteed determinism req
   thrust::device_vector<int> expected{8, std::numeric_limits<int>::lowest(), 9};
 
   REQUIRE(d_out == expected);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 }
 
 C2H_TEST("cub::DeviceSegmentedReduce::ArgMin accepts run_to_run determinism requirements", "[segmented_reduce][env]")
@@ -340,7 +340,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::ArgMin accepts run_to_run determinism requ
   auto error =
     cub::DeviceSegmentedReduce::ArgMin(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 
   thrust::device_vector<cub::KeyValuePair<int, int>> expected{{1, 6}, {1, std::numeric_limits<int>::max()}, {2, 0}};
   REQUIRE(d_out == expected);
@@ -360,7 +360,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::ArgMin accepts not_guaranteed determinism 
   auto error =
     cub::DeviceSegmentedReduce::ArgMin(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 
   thrust::device_vector<cub::KeyValuePair<int, int>> expected{{1, 6}, {1, std::numeric_limits<int>::max()}, {2, 0}};
   REQUIRE(d_out == expected);
@@ -379,7 +379,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::ArgMax accepts run_to_run determinism requ
   auto error =
     cub::DeviceSegmentedReduce::ArgMax(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 
   thrust::device_vector<cub::KeyValuePair<int, int>> expected{{0, 8}, {1, std::numeric_limits<int>::lowest()}, {3, 9}};
   REQUIRE(d_out == expected);
@@ -399,7 +399,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::ArgMax accepts not_guaranteed determinism 
   auto error =
     cub::DeviceSegmentedReduce::ArgMax(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 
   thrust::device_vector<cub::KeyValuePair<int, int>> expected{{0, 8}, {1, std::numeric_limits<int>::lowest()}, {3, 9}};
   REQUIRE(d_out == expected);
@@ -427,7 +427,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Reduce accepts run_to_run determinism requ
   // example-end segmented-reduce-reduce-env-determinism
 
   REQUIRE(d_out == expected);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 }
 
 C2H_TEST("cub::DeviceSegmentedReduce::Reduce accepts not_guaranteed determinism requirements",
@@ -451,7 +451,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Reduce accepts not_guaranteed determinism 
   }
 
   REQUIRE(d_out == expected);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 }
 C2H_TEST("cub::DeviceSegmentedReduce::Reduce fixed-size env-based API", "[segmented_reduce][env]")
 {
@@ -476,7 +476,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Reduce fixed-size env-based API", "[segmen
   stream.sync();
 
   REQUIRE(d_out == expected);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 }
 
 C2H_TEST("cub::DeviceSegmentedReduce::Sum fixed-size env-based API", "[segmented_reduce][env]")
@@ -501,7 +501,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Sum fixed-size env-based API", "[segmented
   stream.sync();
 
   REQUIRE(d_out == expected);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 }
 
 C2H_TEST("cub::DeviceSegmentedReduce::Min fixed-size env-based API", "[segmented_reduce][env]")
@@ -526,7 +526,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Min fixed-size env-based API", "[segmented
   stream.sync();
 
   REQUIRE(d_out == expected);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 }
 
 C2H_TEST("cub::DeviceSegmentedReduce::Max fixed-size env-based API", "[segmented_reduce][env]")
@@ -551,7 +551,7 @@ C2H_TEST("cub::DeviceSegmentedReduce::Max fixed-size env-based API", "[segmented
   stream.sync();
 
   REQUIRE(d_out == expected);
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
 }
 
 C2H_TEST("cub::DeviceSegmentedReduce::ArgMin fixed-size env-based API", "[segmented_reduce][env]")

--- a/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
@@ -204,12 +204,10 @@ struct dispatch_helper
   {
     // Get PTX version
     int ptx_version = 0;
-    cudaError error = cub::PtxVersion(ptx_version);
-    REQUIRE(error == cudaSuccess);
+    REQUIRE_CUDART(cub::PtxVersion(ptx_version));
 
     dispatch_helper dispatch{};
-    error = PolicyHub::MaxPolicy::Invoke(ptx_version, dispatch);
-    REQUIRE(error == cudaSuccess);
+    REQUIRE_CUDART(PolicyHub::MaxPolicy::Invoke(ptx_version, dispatch));
     return dispatch.thresholds;
   }
 };

--- a/cub/test/catch2_test_device_segmented_reduce_max_seg_size.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_max_seg_size.cu
@@ -32,7 +32,7 @@ C2H_TEST("Device segmented reduce works with dynamic max segment sizes",
   using init_t  = input_t;
 
   cuda::compute_capability cc{};
-  REQUIRE(cudaSuccess == cub::detail::ptx_compute_cap(cc));
+  REQUIRE_CUDART(cub::detail::ptx_compute_cap(cc));
   auto full_policy = cub::detail::segmented_reduce::policy_selector_from_types<accum_t, offset_t, op_t>{}(cc);
 
   const int small_segment_size  = full_policy.small_reduce.items_per_tile();
@@ -119,7 +119,7 @@ C2H_TEST("Device segmented reduce works with dynamic max segment sizes",
     nullptr,
     cub::detail::segmented_reduce::policy_selector_from_types<accum_t, offset_t, op_t>{});
 
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   // Verify result
   REQUIRE(expected_result == out_result);

--- a/cub/test/catch2_test_device_segmented_scan_api.cu
+++ b/cub/test/catch2_test_device_segmented_scan_api.cu
@@ -62,7 +62,7 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum API with two offsets w
   thrust::device_vector<int> expected{0, 1, 3, 0, 4, 0, 6, 13};
   // example-end exclusive-segmented-sum-two-offsets
 
-  REQUIRE(status == cudaSuccess);
+  REQUIRE_CUDART(status);
   REQUIRE(output == expected);
 }
 
@@ -114,7 +114,7 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum API with three offsets
   thrust::device_vector<int> expected{0, 1, 3, 0, 5, 11, 0, 9, 19};
   // example-end exclusive-segmented-sum-three-offsets
 
-  REQUIRE(status == cudaSuccess);
+  REQUIRE_CUDART(status);
   REQUIRE(output == expected);
 }
 
@@ -151,7 +151,7 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum API with two offsets w
   thrust::device_vector<int> expected{2, 3, 4, 2, 3, 2, 3, 4};
   // example-end inclusive-segmented-sum-two-offsets
 
-  REQUIRE(status == cudaSuccess);
+  REQUIRE_CUDART(status);
   // input was modified inplace
   REQUIRE(input == expected);
 }
@@ -210,7 +210,7 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum API with three offsets
   auto expected = thrust::device_vector<int>{h_expected};
   // example-end inclusive-segmented-sum-three-offsets
 
-  REQUIRE(status == cudaSuccess);
+  REQUIRE_CUDART(status);
   REQUIRE(output == expected);
 }
 
@@ -272,7 +272,7 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit API with two offs
   auto expected = thrust::device_vector<unsigned>{h_expected};
   // example-end inclusive-segmented-scan-init-two-offsets
 
-  REQUIRE(status == cudaSuccess);
+  REQUIRE_CUDART(status);
   REQUIRE(expected == output);
 }
 
@@ -347,7 +347,7 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan API with two offsets 
     auto out_b = h_input.begin() + h_offsets[id];
     compute_exclusive_scan_reference(inp_b, inp_e, out_b, init_value, scan_op);
   }
-  REQUIRE(status == cudaSuccess);
+  REQUIRE_CUDART(status);
   REQUIRE(output == h_input);
 }
 
@@ -410,5 +410,5 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan API with three offset
 
   // example-end inclusive-segmented-scan-three-offsets
   REQUIRE(output == expected);
-  REQUIRE(status == cudaSuccess);
+  REQUIRE_CUDART(status);
 }

--- a/cub/test/catch2_test_device_segmented_scan_env.cu
+++ b/cub/test/catch2_test_device_segmented_scan_env.cu
@@ -43,9 +43,8 @@ TEST_CASE("Device segmented exclusive sum works with default environment", "[seg
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<int> d_out(d_in.size());
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceSegmentedScan::ExclusiveSegmentedSum(
-            d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::ExclusiveSegmentedSum(
+    d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments));
 
   thrust::device_vector<int> expected{0, 8, 14, 21, 0, 3, 3, 0, 1};
   REQUIRE(d_out == expected);
@@ -59,9 +58,8 @@ TEST_CASE("Device segmented exclusive scan works with default environment", "[se
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<int> d_out(d_in.size());
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
-            d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, ::cuda::std::plus<>{}, 100));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
+    d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, ::cuda::std::plus<>{}, 100));
 
   thrust::device_vector<int> expected{100, 108, 114, 121, 100, 103, 103, 100, 101};
   REQUIRE(d_out == expected);
@@ -75,9 +73,8 @@ TEST_CASE("Device segmented inclusive sum works with default environment", "[seg
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<int> d_out(d_in.size());
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceSegmentedScan::InclusiveSegmentedSum(
-            d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::InclusiveSegmentedSum(
+    d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments));
 
   thrust::device_vector<int> expected{8, 14, 21, 26, 3, 3, 12, 1, 3};
   REQUIRE(d_out == expected);
@@ -91,9 +88,8 @@ TEST_CASE("Device segmented inclusive scan works with default environment", "[se
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<int> d_out(d_in.size());
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceSegmentedScan::InclusiveSegmentedScan(
-            d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, ::cuda::std::plus<>{}));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::InclusiveSegmentedScan(
+    d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, ::cuda::std::plus<>{}));
 
   thrust::device_vector<int> expected{8, 14, 21, 26, 3, 3, 12, 1, 3};
   REQUIRE(d_out == expected);
@@ -107,9 +103,8 @@ TEST_CASE("Device segmented inclusive scan init works with default environment",
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<int> d_out(d_in.size());
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
-            d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, ::cuda::std::plus<>{}, 100));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
+    d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, ::cuda::std::plus<>{}, 100));
 
   thrust::device_vector<int> expected{108, 114, 121, 126, 103, 103, 112, 101, 103};
   REQUIRE(d_out == expected);
@@ -127,9 +122,8 @@ TEST_CASE("Device segmented exclusive sum with separate offsets works with defau
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
   thrust::device_vector<int> d_out(10, sentinel);
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceSegmentedScan::ExclusiveSegmentedSum(
-            d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::ExclusiveSegmentedSum(
+    d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments));
 
   thrust::device_vector<int> expected{0, 1, 3, sentinel, 0, 4, sentinel, 0, 6, 13};
   REQUIRE(d_out == expected);
@@ -147,10 +141,8 @@ TEST_CASE("Device segmented exclusive scan with separate offsets works with defa
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
   thrust::device_vector<int> d_out(10, sentinel);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
-      d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}, 100));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
+    d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}, 100));
 
   thrust::device_vector<int> expected{100, 101, 103, sentinel, 100, 104, sentinel, 100, 106, 113};
   REQUIRE(d_out == expected);
@@ -168,9 +160,8 @@ TEST_CASE("Device segmented inclusive sum with separate offsets works with defau
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
   thrust::device_vector<int> d_out(10, sentinel);
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceSegmentedScan::InclusiveSegmentedSum(
-            d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::InclusiveSegmentedSum(
+    d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments));
 
   thrust::device_vector<int> expected{1, 3, 6, sentinel, 4, 9, sentinel, 6, 13, 21};
   REQUIRE(d_out == expected);
@@ -188,10 +179,8 @@ TEST_CASE("Device segmented inclusive scan with separate offsets works with defa
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
   thrust::device_vector<int> d_out(10, sentinel);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedScan::InclusiveSegmentedScan(
-      d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::InclusiveSegmentedScan(
+    d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}));
 
   thrust::device_vector<int> expected{1, 3, 6, sentinel, 4, 9, sentinel, 6, 13, 21};
   REQUIRE(d_out == expected);
@@ -209,10 +198,8 @@ TEST_CASE("Device segmented inclusive scan init with separate offsets works with
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
   thrust::device_vector<int> d_out(10, sentinel);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
-      d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}, 100));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
+    d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}, 100));
 
   thrust::device_vector<int> expected{101, 103, 106, sentinel, 104, 109, sentinel, 106, 113, 121};
   REQUIRE(d_out == expected);
@@ -229,10 +216,8 @@ C2H_TEST("Device segmented exclusive sum uses environment", "[segmented_scan][de
   thrust::device_vector<int> d_out(d_in.size());
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedScan::ExclusiveSegmentedSum(
-      nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::ExclusiveSegmentedSum(
+    nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -251,18 +236,16 @@ C2H_TEST("Device segmented exclusive scan uses environment", "[segmented_scan][d
   thrust::device_vector<int> d_out(d_in.size());
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_out.begin(),
-      d_offsets_it,
-      d_offsets_it + 1,
-      num_segments,
-      ::cuda::std::plus<>{},
-      100));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
+    nullptr,
+    expected_bytes_allocated,
+    d_in.begin(),
+    d_out.begin(),
+    d_offsets_it,
+    d_offsets_it + 1,
+    num_segments,
+    ::cuda::std::plus<>{},
+    100));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -282,10 +265,8 @@ C2H_TEST("Device segmented inclusive sum uses environment", "[segmented_scan][de
   thrust::device_vector<int> d_out(d_in.size());
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedScan::InclusiveSegmentedSum(
-      nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::InclusiveSegmentedSum(
+    nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -304,17 +285,15 @@ C2H_TEST("Device segmented inclusive scan uses environment", "[segmented_scan][d
   thrust::device_vector<int> d_out(d_in.size());
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedScan::InclusiveSegmentedScan(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_out.begin(),
-      d_offsets_it,
-      d_offsets_it + 1,
-      num_segments,
-      ::cuda::std::plus<>{}));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::InclusiveSegmentedScan(
+    nullptr,
+    expected_bytes_allocated,
+    d_in.begin(),
+    d_out.begin(),
+    d_offsets_it,
+    d_offsets_it + 1,
+    num_segments,
+    ::cuda::std::plus<>{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -334,18 +313,16 @@ C2H_TEST("Device segmented inclusive scan init uses environment", "[segmented_sc
   thrust::device_vector<int> d_out(d_in.size());
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_out.begin(),
-      d_offsets_it,
-      d_offsets_it + 1,
-      num_segments,
-      ::cuda::std::plus<>{},
-      100));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
+    nullptr,
+    expected_bytes_allocated,
+    d_in.begin(),
+    d_out.begin(),
+    d_offsets_it,
+    d_offsets_it + 1,
+    num_segments,
+    ::cuda::std::plus<>{},
+    100));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -368,17 +345,15 @@ C2H_TEST("Device segmented exclusive sum with separate offsets uses environment"
   thrust::device_vector<int> d_out(10, sentinel);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedScan::ExclusiveSegmentedSum(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_out.begin(),
-      d_in_off_it,
-      d_in_off_it + 1,
-      d_out_off_it,
-      num_segments));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::ExclusiveSegmentedSum(
+    nullptr,
+    expected_bytes_allocated,
+    d_in.begin(),
+    d_out.begin(),
+    d_in_off_it,
+    d_in_off_it + 1,
+    d_out_off_it,
+    num_segments));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -401,19 +376,17 @@ C2H_TEST("Device segmented exclusive scan with separate offsets uses environment
   thrust::device_vector<int> d_out(10, sentinel);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_out.begin(),
-      d_in_off_it,
-      d_in_off_it + 1,
-      d_out_off_it,
-      num_segments,
-      ::cuda::std::plus<>{},
-      100));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
+    nullptr,
+    expected_bytes_allocated,
+    d_in.begin(),
+    d_out.begin(),
+    d_in_off_it,
+    d_in_off_it + 1,
+    d_out_off_it,
+    num_segments,
+    ::cuda::std::plus<>{},
+    100));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -444,17 +417,15 @@ C2H_TEST("Device segmented inclusive sum with separate offsets uses environment"
   thrust::device_vector<int> d_out(10, sentinel);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedScan::InclusiveSegmentedSum(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_out.begin(),
-      d_in_off_it,
-      d_in_off_it + 1,
-      d_out_off_it,
-      num_segments));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::InclusiveSegmentedSum(
+    nullptr,
+    expected_bytes_allocated,
+    d_in.begin(),
+    d_out.begin(),
+    d_in_off_it,
+    d_in_off_it + 1,
+    d_out_off_it,
+    num_segments));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -477,18 +448,16 @@ C2H_TEST("Device segmented inclusive scan with separate offsets uses environment
   thrust::device_vector<int> d_out(10, sentinel);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedScan::InclusiveSegmentedScan(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_out.begin(),
-      d_in_off_it,
-      d_in_off_it + 1,
-      d_out_off_it,
-      num_segments,
-      ::cuda::std::plus<>{}));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::InclusiveSegmentedScan(
+    nullptr,
+    expected_bytes_allocated,
+    d_in.begin(),
+    d_out.begin(),
+    d_in_off_it,
+    d_in_off_it + 1,
+    d_out_off_it,
+    num_segments,
+    ::cuda::std::plus<>{}));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -511,19 +480,17 @@ C2H_TEST("Device segmented inclusive scan init with separate offsets uses enviro
   thrust::device_vector<int> d_out(10, sentinel);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_out.begin(),
-      d_in_off_it,
-      d_in_off_it + 1,
-      d_out_off_it,
-      num_segments,
-      ::cuda::std::plus<>{},
-      100));
+  REQUIRE_CUDART(cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
+    nullptr,
+    expected_bytes_allocated,
+    d_in.begin(),
+    d_out.begin(),
+    d_in_off_it,
+    d_in_off_it + 1,
+    d_out_off_it,
+    num_segments,
+    ::cuda::std::plus<>{},
+    100));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 

--- a/cub/test/catch2_test_device_segmented_scan_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_scan_env_api.cu
@@ -37,7 +37,7 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum accepts stream", "[seg
   // example-end exclusive-segmented-sum-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_out == expected);
 }
 
@@ -64,7 +64,7 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan accepts stream", "[se
   // example-end exclusive-segmented-scan-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_out == expected);
 }
 
@@ -91,7 +91,7 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum accepts stream", "[seg
   // example-end inclusive-segmented-sum-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_out == expected);
 }
 
@@ -118,7 +118,7 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan accepts stream", "[se
   // example-end inclusive-segmented-scan-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_out == expected);
 }
 
@@ -145,7 +145,7 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit accepts stream", 
   // example-end inclusive-segmented-scan-init-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_out == expected);
 }
 
@@ -175,7 +175,7 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum (separate offsets) acc
   // example-end exclusive-segmented-sum-separate-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_out == expected);
 }
 
@@ -213,7 +213,7 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan (separate offsets) ac
   // example-end exclusive-segmented-scan-separate-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_out == expected);
 }
 
@@ -243,7 +243,7 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum (separate offsets) acc
   // example-end inclusive-segmented-sum-separate-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_out == expected);
 }
 
@@ -280,7 +280,7 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan (separate offsets) ac
   // example-end inclusive-segmented-scan-separate-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_out == expected);
 }
 
@@ -319,6 +319,6 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit (separate offsets
   // example-end inclusive-segmented-scan-init-separate-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(d_out == expected);
 }

--- a/cub/test/catch2_test_device_segmented_scan_noncommutative.cu
+++ b/cub/test/catch2_test_device_segmented_scan_noncommutative.cu
@@ -93,7 +93,7 @@ C2H_TEST("Device inclusive segmented scan works with non-commutative operator", 
   size_t tmp_size{};
   cudaError_t status1 = cub::DeviceSegmentedScan::InclusiveSegmentedScan(
     nullptr, tmp_size, d_input, d_output, d_offsets, d_offsets + 1, num_segments, op_t{});
-  REQUIRE(cudaSuccess == status1);
+  REQUIRE_CUDART(status1);
   REQUIRE(tmp_size > 0);
 
   using cuda::std::byte;
@@ -105,7 +105,7 @@ C2H_TEST("Device inclusive segmented scan works with non-commutative operator", 
 
   cudaError_t status2 = cub::DeviceSegmentedScan::InclusiveSegmentedScan(
     d_tmp, tmp_size, d_input, d_output, d_offsets, d_offsets + 1, num_segments, op_t{});
-  REQUIRE(cudaSuccess == status2);
+  REQUIRE_CUDART(status2);
 
   // transfer to host_vector is synchronizing
   c2h::host_vector<pair_t> h_output(output);

--- a/cub/test/catch2_test_device_segmented_sort_keys_env.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys_env.cu
@@ -31,15 +31,13 @@ TEST_CASE("DeviceSegmentedSort::SortKeys works with default environment", "[segm
   auto keys_out = c2h::device_vector<int>(7);
   auto offsets  = c2h::device_vector<int>{0, 3, 7};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::SortKeys(
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      static_cast<cuda::std::int64_t>(keys_in.size()),
-      2,
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortKeys(
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    static_cast<cuda::std::int64_t>(keys_in.size()),
+    2,
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
   REQUIRE(keys_out == expected);
@@ -51,15 +49,13 @@ TEST_CASE("DeviceSegmentedSort::SortKeysDescending works with default environmen
   auto keys_out = c2h::device_vector<int>(7);
   auto offsets  = c2h::device_vector<int>{0, 3, 7};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::SortKeysDescending(
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      static_cast<cuda::std::int64_t>(keys_in.size()),
-      2,
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortKeysDescending(
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    static_cast<cuda::std::int64_t>(keys_in.size()),
+    2,
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
   REQUIRE(keys_out == expected);
@@ -71,15 +67,13 @@ TEST_CASE("DeviceSegmentedSort::StableSortKeys works with default environment", 
   auto keys_out = c2h::device_vector<int>(7);
   auto offsets  = c2h::device_vector<int>{0, 3, 7};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::StableSortKeys(
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      static_cast<cuda::std::int64_t>(keys_in.size()),
-      2,
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::StableSortKeys(
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    static_cast<cuda::std::int64_t>(keys_in.size()),
+    2,
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
   REQUIRE(keys_out == expected);
@@ -92,15 +86,13 @@ TEST_CASE("DeviceSegmentedSort::StableSortKeysDescending works with default envi
   auto keys_out = c2h::device_vector<int>(7);
   auto offsets  = c2h::device_vector<int>{0, 3, 7};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::StableSortKeysDescending(
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      static_cast<cuda::std::int64_t>(keys_in.size()),
-      2,
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::StableSortKeysDescending(
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    static_cast<cuda::std::int64_t>(keys_in.size()),
+    2,
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
   REQUIRE(keys_out == expected);
@@ -114,13 +106,12 @@ TEST_CASE("DeviceSegmentedSort::SortKeys DoubleBuffer works with default environ
 
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf0.data()), thrust::raw_pointer_cast(keys_buf1.data()));
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceSegmentedSort::SortKeys(
-            d_keys,
-            static_cast<cuda::std::int64_t>(keys_buf0.size()),
-            2,
-            thrust::raw_pointer_cast(offsets.data()),
-            thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortKeys(
+    d_keys,
+    static_cast<cuda::std::int64_t>(keys_buf0.size()),
+    2,
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
   c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
@@ -136,13 +127,12 @@ TEST_CASE("DeviceSegmentedSort::SortKeysDescending DoubleBuffer works with defau
 
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf0.data()), thrust::raw_pointer_cast(keys_buf1.data()));
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceSegmentedSort::SortKeysDescending(
-            d_keys,
-            static_cast<cuda::std::int64_t>(keys_buf0.size()),
-            2,
-            thrust::raw_pointer_cast(offsets.data()),
-            thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortKeysDescending(
+    d_keys,
+    static_cast<cuda::std::int64_t>(keys_buf0.size()),
+    2,
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
   c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
@@ -158,13 +148,12 @@ TEST_CASE("DeviceSegmentedSort::StableSortKeys DoubleBuffer works with default e
 
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf0.data()), thrust::raw_pointer_cast(keys_buf1.data()));
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceSegmentedSort::StableSortKeys(
-            d_keys,
-            static_cast<cuda::std::int64_t>(keys_buf0.size()),
-            2,
-            thrust::raw_pointer_cast(offsets.data()),
-            thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::StableSortKeys(
+    d_keys,
+    static_cast<cuda::std::int64_t>(keys_buf0.size()),
+    2,
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
   c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
@@ -180,13 +169,12 @@ TEST_CASE("DeviceSegmentedSort::StableSortKeysDescending DoubleBuffer works with
 
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf0.data()), thrust::raw_pointer_cast(keys_buf1.data()));
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceSegmentedSort::StableSortKeysDescending(
-            d_keys,
-            static_cast<cuda::std::int64_t>(keys_buf0.size()),
-            2,
-            thrust::raw_pointer_cast(offsets.data()),
-            thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::StableSortKeysDescending(
+    d_keys,
+    static_cast<cuda::std::int64_t>(keys_buf0.size()),
+    2,
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
   c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
@@ -202,17 +190,15 @@ C2H_TEST("DeviceSegmentedSort::SortKeys uses environment", "[segmented_sort][key
   auto offsets  = c2h::device_vector<int>{0, 3, 7};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::SortKeys(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      static_cast<::cuda::std::int64_t>(keys_in.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortKeys(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    static_cast<::cuda::std::int64_t>(keys_in.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -235,17 +221,15 @@ C2H_TEST("DeviceSegmentedSort::SortKeysDescending uses environment", "[segmented
   auto offsets  = c2h::device_vector<int>{0, 3, 7};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::SortKeysDescending(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      static_cast<::cuda::std::int64_t>(keys_in.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortKeysDescending(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    static_cast<::cuda::std::int64_t>(keys_in.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -269,17 +253,15 @@ C2H_TEST("DeviceSegmentedSort::StableSortKeys uses environment", "[segmented_sor
   auto offsets  = c2h::device_vector<int>{0, 3, 7};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::StableSortKeys(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      static_cast<::cuda::std::int64_t>(keys_in.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::StableSortKeys(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    static_cast<::cuda::std::int64_t>(keys_in.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -303,17 +285,15 @@ C2H_TEST("DeviceSegmentedSort::StableSortKeysDescending uses environment", "[seg
   auto offsets  = c2h::device_vector<int>{0, 3, 7};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::StableSortKeysDescending(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      static_cast<::cuda::std::int64_t>(keys_in.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::StableSortKeysDescending(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    static_cast<::cuda::std::int64_t>(keys_in.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -339,16 +319,14 @@ C2H_TEST("DeviceSegmentedSort::SortKeys DoubleBuffer uses environment", "[segmen
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf0.data()), thrust::raw_pointer_cast(keys_buf1.data()));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::SortKeys(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys,
-      static_cast<::cuda::std::int64_t>(keys_buf0.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortKeys(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys,
+    static_cast<::cuda::std::int64_t>(keys_buf0.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -373,16 +351,14 @@ C2H_TEST("DeviceSegmentedSort::SortKeysDescending DoubleBuffer uses environment"
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf0.data()), thrust::raw_pointer_cast(keys_buf1.data()));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::SortKeysDescending(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys,
-      static_cast<::cuda::std::int64_t>(keys_buf0.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortKeysDescending(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys,
+    static_cast<::cuda::std::int64_t>(keys_buf0.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -408,16 +384,14 @@ C2H_TEST("DeviceSegmentedSort::StableSortKeys DoubleBuffer uses environment", "[
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf0.data()), thrust::raw_pointer_cast(keys_buf1.data()));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::StableSortKeys(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys,
-      static_cast<::cuda::std::int64_t>(keys_buf0.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::StableSortKeys(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys,
+    static_cast<::cuda::std::int64_t>(keys_buf0.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -444,16 +418,14 @@ C2H_TEST("DeviceSegmentedSort::StableSortKeysDescending DoubleBuffer uses enviro
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf0.data()), thrust::raw_pointer_cast(keys_buf1.data()));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::StableSortKeysDescending(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys,
-      static_cast<::cuda::std::int64_t>(keys_buf0.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::StableSortKeysDescending(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys,
+    static_cast<::cuda::std::int64_t>(keys_buf0.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 

--- a/cub/test/catch2_test_device_segmented_sort_keys_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys_env_api.cu
@@ -41,7 +41,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeys env-based API", "[segmented_sort][k
   // example-end sort-keys-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected);
 }
 
@@ -72,7 +72,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeysDescending env-based API", "[segment
   // example-end sort-keys-descending-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected);
 }
 
@@ -104,7 +104,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeys DoubleBuffer env-based API", "[segm
   // example-end sort-keys-db-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   thrust::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);
 }
@@ -137,7 +137,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortKeysDescending DoubleBuffer env-based AP
   // example-end sort-keys-descending-db-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   thrust::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);
 }
@@ -169,7 +169,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortKeys env-based API", "[segmented_s
   // example-end stable-sort-keys-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected);
 }
 
@@ -200,7 +200,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortKeysDescending env-based API", "[s
   // example-end stable-sort-keys-descending-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected);
 }
 
@@ -232,7 +232,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortKeys DoubleBuffer env-based API", 
   // example-end stable-sort-keys-db-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   thrust::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);
 }
@@ -266,7 +266,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortKeysDescending DoubleBuffer env-ba
   // example-end stable-sort-keys-descending-db-env
 
   stream.sync();
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   thrust::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);
 }

--- a/cub/test/catch2_test_device_segmented_sort_pairs_env.cu
+++ b/cub/test/catch2_test_device_segmented_sort_pairs_env.cu
@@ -37,17 +37,15 @@ TEST_CASE("DeviceSegmentedSort::StableSortPairs works with default environment",
   auto values_out = c2h::device_vector<int>(7);
   auto offsets    = c2h::device_vector<int>{0, 3, 7};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::StableSortPairs(
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      thrust::raw_pointer_cast(values_in.data()),
-      thrust::raw_pointer_cast(values_out.data()),
-      static_cast<int>(keys_in.size()),
-      2,
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::StableSortPairs(
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    thrust::raw_pointer_cast(values_in.data()),
+    thrust::raw_pointer_cast(values_out.data()),
+    static_cast<int>(keys_in.size()),
+    2,
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
   c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
@@ -64,17 +62,15 @@ TEST_CASE("DeviceSegmentedSort::StableSortPairsDescending works with default env
   auto values_out = c2h::device_vector<int>(7);
   auto offsets    = c2h::device_vector<int>{0, 3, 7};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::StableSortPairsDescending(
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      thrust::raw_pointer_cast(values_in.data()),
-      thrust::raw_pointer_cast(values_out.data()),
-      static_cast<int>(keys_in.size()),
-      2,
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::StableSortPairsDescending(
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    thrust::raw_pointer_cast(values_in.data()),
+    thrust::raw_pointer_cast(values_out.data()),
+    static_cast<int>(keys_in.size()),
+    2,
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
   c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
@@ -90,17 +86,15 @@ TEST_CASE("DeviceSegmentedSort::SortPairs nonstable works with default environme
   auto values_out = c2h::device_vector<int>(7);
   auto offsets    = c2h::device_vector<int>{0, 3, 7};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::SortPairs(
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      thrust::raw_pointer_cast(values_in.data()),
-      thrust::raw_pointer_cast(values_out.data()),
-      static_cast<int>(keys_in.size()),
-      2,
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortPairs(
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    thrust::raw_pointer_cast(values_in.data()),
+    thrust::raw_pointer_cast(values_out.data()),
+    static_cast<int>(keys_in.size()),
+    2,
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
   c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
@@ -117,17 +111,15 @@ TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable works with default
   auto values_out = c2h::device_vector<int>(7);
   auto offsets    = c2h::device_vector<int>{0, 3, 7};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::SortPairsDescending(
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      thrust::raw_pointer_cast(values_in.data()),
-      thrust::raw_pointer_cast(values_out.data()),
-      static_cast<int>(keys_in.size()),
-      2,
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortPairsDescending(
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    thrust::raw_pointer_cast(values_in.data()),
+    thrust::raw_pointer_cast(values_out.data()),
+    static_cast<int>(keys_in.size()),
+    2,
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
   c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
@@ -148,15 +140,13 @@ TEST_CASE("DeviceSegmentedSort::SortPairs nonstable DoubleBuffer works with defa
   cub::DoubleBuffer<int> d_values(
     thrust::raw_pointer_cast(values_buf0.data()), thrust::raw_pointer_cast(values_buf1.data()));
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::SortPairs(
-      d_keys,
-      d_values,
-      static_cast<int>(keys_buf0.size()),
-      2,
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortPairs(
+    d_keys,
+    d_values,
+    static_cast<int>(keys_buf0.size()),
+    2,
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
   c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
@@ -179,15 +169,13 @@ TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer works
   cub::DoubleBuffer<int> d_values(
     thrust::raw_pointer_cast(values_buf0.data()), thrust::raw_pointer_cast(values_buf1.data()));
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::SortPairsDescending(
-      d_keys,
-      d_values,
-      static_cast<int>(keys_buf0.size()),
-      2,
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortPairsDescending(
+    d_keys,
+    d_values,
+    static_cast<int>(keys_buf0.size()),
+    2,
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
   c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
@@ -210,19 +198,17 @@ TEST_CASE("DeviceSegmentedSort::SortPairs nonstable uses custom stream", "[segme
   cuda::stream stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::SortPairs(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      thrust::raw_pointer_cast(values_in.data()),
-      thrust::raw_pointer_cast(values_out.data()),
-      static_cast<::cuda::std::int64_t>(keys_in.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortPairs(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    thrust::raw_pointer_cast(values_in.data()),
+    thrust::raw_pointer_cast(values_out.data()),
+    static_cast<::cuda::std::int64_t>(keys_in.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -257,19 +243,17 @@ TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable uses custom stream
   cuda::stream stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::SortPairsDescending(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      thrust::raw_pointer_cast(values_in.data()),
-      thrust::raw_pointer_cast(values_out.data()),
-      static_cast<::cuda::std::int64_t>(keys_in.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortPairsDescending(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    thrust::raw_pointer_cast(values_in.data()),
+    thrust::raw_pointer_cast(values_out.data()),
+    static_cast<::cuda::std::int64_t>(keys_in.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -308,17 +292,15 @@ TEST_CASE("DeviceSegmentedSort::SortPairs nonstable DoubleBuffer uses custom str
   cuda::stream stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::SortPairs(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys,
-      d_values,
-      static_cast<::cuda::std::int64_t>(keys_buf0.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortPairs(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys,
+    d_values,
+    static_cast<::cuda::std::int64_t>(keys_buf0.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -357,17 +339,15 @@ TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer uses 
   cuda::stream stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::SortPairsDescending(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys,
-      d_values,
-      static_cast<::cuda::std::int64_t>(keys_buf0.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortPairsDescending(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys,
+    d_values,
+    static_cast<::cuda::std::int64_t>(keys_buf0.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -400,19 +380,17 @@ C2H_TEST("DeviceSegmentedSort::StableSortPairs uses environment", "[segmented_so
   auto offsets    = c2h::device_vector<int>{0, 3, 7};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::StableSortPairs(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      thrust::raw_pointer_cast(values_in.data()),
-      thrust::raw_pointer_cast(values_out.data()),
-      static_cast<::cuda::std::int64_t>(keys_in.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::StableSortPairs(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    thrust::raw_pointer_cast(values_in.data()),
+    thrust::raw_pointer_cast(values_out.data()),
+    static_cast<::cuda::std::int64_t>(keys_in.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -442,19 +420,17 @@ C2H_TEST("DeviceSegmentedSort::StableSortPairsDescending uses environment", "[se
   auto offsets    = c2h::device_vector<int>{0, 3, 7};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::StableSortPairsDescending(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      thrust::raw_pointer_cast(values_in.data()),
-      thrust::raw_pointer_cast(values_out.data()),
-      static_cast<::cuda::std::int64_t>(keys_in.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::StableSortPairsDescending(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    thrust::raw_pointer_cast(values_in.data()),
+    thrust::raw_pointer_cast(values_out.data()),
+    static_cast<::cuda::std::int64_t>(keys_in.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -488,17 +464,15 @@ C2H_TEST("DeviceSegmentedSort::StableSortPairs DoubleBuffer uses environment", "
     thrust::raw_pointer_cast(values_buf0.data()), thrust::raw_pointer_cast(values_buf1.data()));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::StableSortPairs(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys,
-      d_values,
-      static_cast<::cuda::std::int64_t>(keys_buf0.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::StableSortPairs(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys,
+    d_values,
+    static_cast<::cuda::std::int64_t>(keys_buf0.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -533,17 +507,15 @@ C2H_TEST("DeviceSegmentedSort::StableSortPairsDescending DoubleBuffer uses envir
     thrust::raw_pointer_cast(values_buf0.data()), thrust::raw_pointer_cast(values_buf1.data()));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::StableSortPairsDescending(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys,
-      d_values,
-      static_cast<::cuda::std::int64_t>(keys_buf0.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::StableSortPairsDescending(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys,
+    d_values,
+    static_cast<::cuda::std::int64_t>(keys_buf0.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -573,19 +545,17 @@ C2H_TEST("DeviceSegmentedSort::SortPairs nonstable uses environment", "[segmente
   auto offsets    = c2h::device_vector<int>{0, 3, 7};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::SortPairs(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      thrust::raw_pointer_cast(values_in.data()),
-      thrust::raw_pointer_cast(values_out.data()),
-      static_cast<::cuda::std::int64_t>(keys_in.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortPairs(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    thrust::raw_pointer_cast(values_in.data()),
+    thrust::raw_pointer_cast(values_out.data()),
+    static_cast<::cuda::std::int64_t>(keys_in.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -615,19 +585,17 @@ C2H_TEST("DeviceSegmentedSort::SortPairsDescending nonstable uses environment", 
   auto offsets    = c2h::device_vector<int>{0, 3, 7};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::SortPairsDescending(
-      nullptr,
-      expected_bytes_allocated,
-      thrust::raw_pointer_cast(keys_in.data()),
-      thrust::raw_pointer_cast(keys_out.data()),
-      thrust::raw_pointer_cast(values_in.data()),
-      thrust::raw_pointer_cast(values_out.data()),
-      static_cast<::cuda::std::int64_t>(keys_in.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortPairsDescending(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    thrust::raw_pointer_cast(values_in.data()),
+    thrust::raw_pointer_cast(values_out.data()),
+    static_cast<::cuda::std::int64_t>(keys_in.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -661,17 +629,15 @@ C2H_TEST("DeviceSegmentedSort::SortPairs nonstable DoubleBuffer uses environment
     thrust::raw_pointer_cast(values_buf0.data()), thrust::raw_pointer_cast(values_buf1.data()));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::SortPairs(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys,
-      d_values,
-      static_cast<::cuda::std::int64_t>(keys_buf0.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortPairs(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys,
+    d_values,
+    static_cast<::cuda::std::int64_t>(keys_buf0.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -705,17 +671,15 @@ C2H_TEST("DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer uses e
     thrust::raw_pointer_cast(values_buf0.data()), thrust::raw_pointer_cast(values_buf1.data()));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSegmentedSort::SortPairsDescending(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys,
-      d_values,
-      static_cast<::cuda::std::int64_t>(keys_buf0.size()),
-      static_cast<::cuda::std::int64_t>(2),
-      thrust::raw_pointer_cast(offsets.data()),
-      thrust::raw_pointer_cast(offsets.data()) + 1));
+  REQUIRE_CUDART(cub::DeviceSegmentedSort::SortPairsDescending(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys,
+    d_values,
+    static_cast<::cuda::std::int64_t>(keys_buf0.size()),
+    static_cast<::cuda::std::int64_t>(2),
+    thrust::raw_pointer_cast(offsets.data()),
+    thrust::raw_pointer_cast(offsets.data()) + 1));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 

--- a/cub/test/catch2_test_device_segmented_sort_pairs_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_sort_pairs_env_api.cu
@@ -47,7 +47,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortPairs env-based API", "[segmented_
   // example-end stable-sort-pairs-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -85,7 +85,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortPairsDescending env-based API", "[
   // example-end stable-sort-pairs-descending-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -125,7 +125,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortPairs DoubleBuffer env-based API",
   // example-end stable-sort-pairs-db-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   thrust::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
   thrust::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
   REQUIRE(result_keys == expected_keys);
@@ -169,7 +169,7 @@ C2H_TEST("cub::DeviceSegmentedSort::StableSortPairsDescending DoubleBuffer env-b
   // example-end stable-sort-pairs-descending-db-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   thrust::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
   thrust::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
   REQUIRE(result_keys == expected_keys);
@@ -209,7 +209,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortPairs nonstable env-based API", "[segmen
   // example-end sort-pairs-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -247,7 +247,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortPairsDescending nonstable env-based API"
   // example-end sort-pairs-descending-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -287,7 +287,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortPairs nonstable DoubleBuffer env-based A
   // example-end sort-pairs-db-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   thrust::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
   thrust::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
   REQUIRE(result_keys == expected_keys);
@@ -330,7 +330,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer e
   // example-end sort-pairs-descending-db-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   thrust::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
   thrust::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
   REQUIRE(result_keys == expected_keys);

--- a/cub/test/catch2_test_device_select_env.cu
+++ b/cub/test/catch2_test_device_select_env.cu
@@ -49,8 +49,7 @@ TEST_CASE("Device select works with default environment", "[select][device]")
   less_than_t<value_t> select_op{5};
 
   // launch wrapper always assumes the last argument is the environment
-  REQUIRE(
-    cudaSuccess == cub::DeviceSelect::If(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op));
+  REQUIRE_CUDART(cub::DeviceSelect::If(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op));
 
   c2h::device_vector<value_t> expected_output{1, 2, 3, 4};
   c2h::device_vector<int> expected_num_selected{4};
@@ -72,9 +71,8 @@ TEST_CASE("Device select flagged works with default environment", "[select][devi
   auto d_num_selected   = c2h::device_vector<unsigned int>(1);
 
   // launch wrapper always assumes the last argument is the environment
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::Flagged(d_in.begin(), d_flags.begin(), d_out.begin(), d_num_selected.begin(), num_items));
+  REQUIRE_CUDART(
+    cub::DeviceSelect::Flagged(d_in.begin(), d_flags.begin(), d_out.begin(), d_num_selected.begin(), num_items));
 
   c2h::device_vector<value_t> expected_output{1, 4, 6, 7};
   c2h::device_vector<int> expected_num_selected{4};
@@ -97,9 +95,8 @@ TEST_CASE("Device select flagged_if works with default environment", "[select][d
 
   mod_n<int> select_op{2};
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceSelect::FlaggedIf(
-            d_in.begin(), d_flags.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op));
+  REQUIRE_CUDART(cub::DeviceSelect::FlaggedIf(
+    d_in.begin(), d_flags.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op));
 
   c2h::device_vector<value_t> expected_output{1, 4, 6, 7};
   c2h::device_vector<int> expected_num_selected{4};
@@ -119,8 +116,7 @@ TEST_CASE("Device select flagged in-place works with default environment", "[sel
   auto d_flags          = c2h::device_vector<char>{1, 0, 0, 1, 0, 1, 1, 0};
   auto d_num_selected   = c2h::device_vector<unsigned int>(1);
 
-  REQUIRE(
-    cudaSuccess == cub::DeviceSelect::Flagged(d_data.begin(), d_flags.begin(), d_num_selected.begin(), num_items));
+  REQUIRE_CUDART(cub::DeviceSelect::Flagged(d_data.begin(), d_flags.begin(), d_num_selected.begin(), num_items));
 
   c2h::device_vector<value_t> expected_output{1, 4, 6, 7};
   c2h::device_vector<int> expected_num_selected{4};
@@ -141,7 +137,7 @@ TEST_CASE("Device select if in-place works with default environment", "[select][
 
   less_than_t<value_t> select_op{5};
 
-  REQUIRE(cudaSuccess == cub::DeviceSelect::If(d_data.begin(), d_num_selected.begin(), num_items, select_op));
+  REQUIRE_CUDART(cub::DeviceSelect::If(d_data.begin(), d_num_selected.begin(), num_items, select_op));
 
   c2h::device_vector<value_t> expected_output{1, 2, 3, 4};
   c2h::device_vector<int> expected_num_selected{4};
@@ -163,9 +159,8 @@ TEST_CASE("Device select flagged_if in-place works with default environment", "[
 
   mod_n<int> select_op{2};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::FlaggedIf(d_data.begin(), d_flags.begin(), d_num_selected.begin(), num_items, select_op));
+  REQUIRE_CUDART(
+    cub::DeviceSelect::FlaggedIf(d_data.begin(), d_flags.begin(), d_num_selected.begin(), num_items, select_op));
 
   c2h::device_vector<value_t> expected_output{1, 4, 6, 7};
   c2h::device_vector<int> expected_num_selected{4};
@@ -185,7 +180,7 @@ TEST_CASE("Device select unique works with default environment", "[select][devic
   auto d_out            = c2h::device_vector<value_t>(num_items);
   auto d_num_selected   = c2h::device_vector<unsigned int>(1);
 
-  REQUIRE(cudaSuccess == cub::DeviceSelect::Unique(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items));
+  REQUIRE_CUDART(cub::DeviceSelect::Unique(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items));
 
   c2h::device_vector<value_t> expected_output{0, 2, 9, 5, 8};
   c2h::device_vector<int> expected_num_selected{5};
@@ -207,8 +202,7 @@ TEST_CASE("Device select unique with custom equality_op works with default envir
 
   eq_mod3_t<value_t> eq_mod3{};
 
-  REQUIRE(
-    cudaSuccess == cub::DeviceSelect::Unique(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, eq_mod3));
+  REQUIRE_CUDART(cub::DeviceSelect::Unique(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, eq_mod3));
 
   c2h::device_vector<value_t> expected_output{0, 1, 2};
   c2h::device_vector<int> expected_num_selected{3};
@@ -227,7 +221,7 @@ TEST_CASE("Device select unique in-place works with default environment", "[sele
   auto d_data           = c2h::device_vector<value_t>{0, 2, 2, 9, 5, 5, 5, 8};
   auto d_num_selected   = c2h::device_vector<unsigned int>(1);
 
-  REQUIRE(cudaSuccess == cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items));
+  REQUIRE_CUDART(cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items));
 
   c2h::device_vector<value_t> expected_output{0, 2, 9, 5, 8};
   c2h::device_vector<int> expected_num_selected{5};
@@ -248,7 +242,7 @@ TEST_CASE("Device select unique in-place with custom equality_op works with defa
 
   eq_mod3_t<value_t> eq_mod3{};
 
-  REQUIRE(cudaSuccess == cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items, eq_mod3));
+  REQUIRE_CUDART(cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items, eq_mod3));
 
   c2h::device_vector<value_t> expected_output{0, 1, 2};
   c2h::device_vector<int> expected_num_selected{3};
@@ -270,15 +264,8 @@ TEST_CASE("Device select unique_by_key works with default environment", "[select
   auto d_values_out     = c2h::device_vector<value_t>(num_items);
   auto d_num_selected   = c2h::device_vector<unsigned int>(1);
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::UniqueByKey(
-      d_keys_in.begin(),
-      d_values_in.begin(),
-      d_keys_out.begin(),
-      d_values_out.begin(),
-      d_num_selected.begin(),
-      num_items));
+  REQUIRE_CUDART(cub::DeviceSelect::UniqueByKey(
+    d_keys_in.begin(), d_values_in.begin(), d_keys_out.begin(), d_values_out.begin(), d_num_selected.begin(), num_items));
 
   c2h::device_vector<value_t> expected_keys{0, 2, 9, 5, 8};
   c2h::device_vector<value_t> expected_values{1, 2, 4, 5, 8};
@@ -305,16 +292,14 @@ TEST_CASE("Device select unique_by_key works with default environment and explic
 
   auto env = stdexec::env{};
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::UniqueByKey(
-      d_keys_in.begin(),
-      d_values_in.begin(),
-      d_keys_out.begin(),
-      d_values_out.begin(),
-      d_num_selected.begin(),
-      num_items,
-      env));
+  REQUIRE_CUDART(cub::DeviceSelect::UniqueByKey(
+    d_keys_in.begin(),
+    d_values_in.begin(),
+    d_keys_out.begin(),
+    d_values_out.begin(),
+    d_num_selected.begin(),
+    num_items,
+    env));
 
   c2h::device_vector<value_t> expected_keys{0, 2, 9, 5, 8};
   c2h::device_vector<value_t> expected_values{1, 2, 4, 5, 8};
@@ -336,10 +321,10 @@ TEST_CASE("Device select unique_by_key default tuning chooses target block size"
   using selector_t = cub::detail::unique_by_key::policy_selector_from_types<key_t, value_t>;
 
   int current_device{};
-  REQUIRE(cudaSuccess == cudaGetDevice(&current_device));
+  REQUIRE_CUDART(cudaGetDevice(&current_device));
 
   cuda::compute_capability cc{};
-  REQUIRE(cudaSuccess == cub::detail::ptx_compute_cap(cc, current_device));
+  REQUIRE_CUDART(cub::detail::ptx_compute_cap(cc, current_device));
 
   const auto target_block_size = selector_t{}(cc).threads_per_block;
 
@@ -352,16 +337,14 @@ TEST_CASE("Device select unique_by_key default tuning chooses target block size"
   block_size_check_t equality_op{thrust::raw_pointer_cast(d_block_size.data())};
   auto d_values_in = cuda::constant_iterator(value_t{1});
 
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::UniqueByKey(
-      d_keys_in.begin(),
-      d_values_in,
-      d_keys_out.begin(),
-      d_values_out.begin(),
-      d_num_selected.begin(),
-      num_items,
-      equality_op));
+  REQUIRE_CUDART(cub::DeviceSelect::UniqueByKey(
+    d_keys_in.begin(),
+    d_values_in,
+    d_keys_out.begin(),
+    d_values_out.begin(),
+    d_num_selected.begin(),
+    num_items,
+    equality_op));
 
   REQUIRE(d_num_selected[0] == 1);
   REQUIRE(d_keys_out[0] == key_t{0});
@@ -385,10 +368,8 @@ C2H_TEST("Device select uses environment", "[select][device]")
 
   size_t expected_bytes_allocated{};
   // calculate expected_bytes_allocated - call CUB API directly, not through wrapper
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::If(
-      nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op));
+  REQUIRE_CUDART(cub::DeviceSelect::If(
+    nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)}; // temp storage size
 
@@ -414,16 +395,8 @@ C2H_TEST("Device select flagged uses environment", "[select][device]")
   auto d_num_selected   = c2h::device_vector<unsigned int>(1);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::Flagged(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_flags.begin(),
-      d_out.begin(),
-      d_num_selected.begin(),
-      num_items));
+  REQUIRE_CUDART(cub::DeviceSelect::Flagged(
+    nullptr, expected_bytes_allocated, d_in.begin(), d_flags.begin(), d_out.begin(), d_num_selected.begin(), num_items));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)}; // temp storage size
 
@@ -451,17 +424,15 @@ C2H_TEST("Device select flagged_if uses environment", "[select][device]")
   mod_n<int> select_op{2};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::FlaggedIf(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_flags.begin(),
-      d_out.begin(),
-      d_num_selected.begin(),
-      num_items,
-      select_op));
+  REQUIRE_CUDART(cub::DeviceSelect::FlaggedIf(
+    nullptr,
+    expected_bytes_allocated,
+    d_in.begin(),
+    d_flags.begin(),
+    d_out.begin(),
+    d_num_selected.begin(),
+    num_items,
+    select_op));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -487,21 +458,18 @@ C2H_TEST("Device select flagged in-place uses environment", "[select][device]")
   auto d_num_selected   = c2h::device_vector<unsigned int>(1);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::Flagged(
-      nullptr,
-      expected_bytes_allocated,
-      d_data.begin(),
-      d_flags.begin(),
-      d_data.begin(),
-      d_num_selected.begin(),
-      num_items));
+  REQUIRE_CUDART(cub::DeviceSelect::Flagged(
+    nullptr,
+    expected_bytes_allocated,
+    d_data.begin(),
+    d_flags.begin(),
+    d_data.begin(),
+    d_num_selected.begin(),
+    num_items));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
-  REQUIRE(
-    cudaSuccess == cub::DeviceSelect::Flagged(d_data.begin(), d_flags.begin(), d_num_selected.begin(), num_items, env));
+  REQUIRE_CUDART(cub::DeviceSelect::Flagged(d_data.begin(), d_flags.begin(), d_num_selected.begin(), num_items, env));
 
   c2h::device_vector<value_t> expected_output{1, 3, 5, 7, 9};
   c2h::device_vector<int> expected_num_selected{5};
@@ -523,14 +491,12 @@ C2H_TEST("Device select if in-place uses environment", "[select][device]")
   less_than_t<value_t> select_op{6};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::If(
-      nullptr, expected_bytes_allocated, d_data.begin(), d_data.begin(), d_num_selected.begin(), num_items, select_op));
+  REQUIRE_CUDART(cub::DeviceSelect::If(
+    nullptr, expected_bytes_allocated, d_data.begin(), d_data.begin(), d_num_selected.begin(), num_items, select_op));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
-  REQUIRE(cudaSuccess == cub::DeviceSelect::If(d_data.begin(), d_num_selected.begin(), num_items, select_op, env));
+  REQUIRE_CUDART(cub::DeviceSelect::If(d_data.begin(), d_num_selected.begin(), num_items, select_op, env));
 
   c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 5};
   c2h::device_vector<int> expected_num_selected{5};
@@ -553,23 +519,20 @@ C2H_TEST("Device select flagged_if in-place uses environment", "[select][device]
   mod_n<int> select_op{2};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::FlaggedIf(
-      nullptr,
-      expected_bytes_allocated,
-      d_data.begin(),
-      d_flags.begin(),
-      d_data.begin(),
-      d_num_selected.begin(),
-      num_items,
-      select_op));
+  REQUIRE_CUDART(cub::DeviceSelect::FlaggedIf(
+    nullptr,
+    expected_bytes_allocated,
+    d_data.begin(),
+    d_flags.begin(),
+    d_data.begin(),
+    d_num_selected.begin(),
+    num_items,
+    select_op));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
-  REQUIRE(cudaSuccess
-          == cub::DeviceSelect::FlaggedIf(
-            d_data.begin(), d_flags.begin(), d_num_selected.begin(), num_items, select_op, env));
+  REQUIRE_CUDART(
+    cub::DeviceSelect::FlaggedIf(d_data.begin(), d_flags.begin(), d_num_selected.begin(), num_items, select_op, env));
 
   c2h::device_vector<value_t> expected_output{1, 3, 5, 7, 9};
   c2h::device_vector<int> expected_num_selected{5};
@@ -590,9 +553,8 @@ C2H_TEST("Device select unique uses environment", "[select][device]")
   auto d_num_selected   = c2h::device_vector<unsigned int>(1);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceSelect::Unique(
-            nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items));
+  REQUIRE_CUDART(cub::DeviceSelect::Unique(
+    nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -619,10 +581,8 @@ C2H_TEST("Device select unique with custom equality_op uses environment", "[sele
   eq_mod3_t<value_t> eq_mod3{};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::Unique(
-      nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, eq_mod3));
+  REQUIRE_CUDART(cub::DeviceSelect::Unique(
+    nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, eq_mod3));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -646,13 +606,12 @@ C2H_TEST("Device select unique in-place uses environment", "[select][device]")
   auto d_num_selected   = c2h::device_vector<unsigned int>(1);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::Unique(nullptr, expected_bytes_allocated, d_data.begin(), d_num_selected.begin(), num_items));
+  REQUIRE_CUDART(
+    cub::DeviceSelect::Unique(nullptr, expected_bytes_allocated, d_data.begin(), d_num_selected.begin(), num_items));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
-  REQUIRE(cudaSuccess == cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items, env));
+  REQUIRE_CUDART(cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items, env));
 
   c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 5};
   c2h::device_vector<int> expected_num_selected{5};
@@ -674,13 +633,12 @@ C2H_TEST("Device select unique in-place with custom equality_op uses environment
   eq_mod3_t<value_t> eq_mod3{};
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceSelect::Unique(
-            nullptr, expected_bytes_allocated, d_data.begin(), d_num_selected.begin(), num_items, eq_mod3));
+  REQUIRE_CUDART(cub::DeviceSelect::Unique(
+    nullptr, expected_bytes_allocated, d_data.begin(), d_num_selected.begin(), num_items, eq_mod3));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
-  REQUIRE(cudaSuccess == cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items, eq_mod3, env));
+  REQUIRE_CUDART(cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items, eq_mod3, env));
 
   c2h::device_vector<value_t> expected_output{0, 1, 2};
   c2h::device_vector<int> expected_num_selected{3};
@@ -703,17 +661,15 @@ C2H_TEST("Device select unique_by_key uses environment", "[select][device]")
   auto d_num_selected   = c2h::device_vector<unsigned int>(1);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::UniqueByKey(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys_in.begin(),
-      d_values_in.begin(),
-      d_keys_out.begin(),
-      d_values_out.begin(),
-      d_num_selected.begin(),
-      num_items));
+  REQUIRE_CUDART(cub::DeviceSelect::UniqueByKey(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys_in.begin(),
+    d_values_in.begin(),
+    d_keys_out.begin(),
+    d_values_out.begin(),
+    d_num_selected.begin(),
+    num_items));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -751,17 +707,15 @@ C2H_TEST("Device select unique_by_key uses environment without equality_op", "[s
   auto d_num_selected   = c2h::device_vector<int>(1);
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::UniqueByKey(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys_in.begin(),
-      d_values_in.begin(),
-      d_keys_out.begin(),
-      d_values_out.begin(),
-      d_num_selected.begin(),
-      num_items));
+  REQUIRE_CUDART(cub::DeviceSelect::UniqueByKey(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys_in.begin(),
+    d_values_in.begin(),
+    d_keys_out.begin(),
+    d_values_out.begin(),
+    d_num_selected.begin(),
+    num_items));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -798,20 +752,18 @@ TEST_CASE("Device select uses custom stream", "[select][device]")
   less_than_t<value_t> select_op{5};
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::If(
-      nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op));
+  REQUIRE_CUDART(cub::DeviceSelect::If(
+    nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
 
   device_select_if(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op, env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<value_t> expected_output{1, 2, 3, 4};
   c2h::device_vector<int> expected_num_selected{4};
@@ -820,7 +772,7 @@ TEST_CASE("Device select uses custom stream", "[select][device]")
   d_out.resize(d_num_selected[0]);
   REQUIRE(d_out == expected_output);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 TEST_CASE("Device select flagged uses custom stream", "[select][device]")
@@ -835,26 +787,18 @@ TEST_CASE("Device select flagged uses custom stream", "[select][device]")
   auto d_num_selected   = c2h::device_vector<unsigned int>(1);
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::Flagged(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_flags.begin(),
-      d_out.begin(),
-      d_num_selected.begin(),
-      num_items));
+  REQUIRE_CUDART(cub::DeviceSelect::Flagged(
+    nullptr, expected_bytes_allocated, d_in.begin(), d_flags.begin(), d_out.begin(), d_num_selected.begin(), num_items));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
 
   device_select_flagged(d_in.begin(), d_flags.begin(), d_out.begin(), d_num_selected.begin(), num_items, env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<value_t> expected_output{1, 4, 6, 7};
   c2h::device_vector<int> expected_num_selected{4};
@@ -863,7 +807,7 @@ TEST_CASE("Device select flagged uses custom stream", "[select][device]")
   d_out.resize(d_num_selected[0]);
   REQUIRE(d_out == expected_output);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 TEST_CASE("Device select flagged_if uses custom stream", "[select][device]")
@@ -880,20 +824,18 @@ TEST_CASE("Device select flagged_if uses custom stream", "[select][device]")
   mod_n<int> select_op{2};
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::FlaggedIf(
-      nullptr,
-      expected_bytes_allocated,
-      d_in.begin(),
-      d_flags.begin(),
-      d_out.begin(),
-      d_num_selected.begin(),
-      num_items,
-      select_op));
+  REQUIRE_CUDART(cub::DeviceSelect::FlaggedIf(
+    nullptr,
+    expected_bytes_allocated,
+    d_in.begin(),
+    d_flags.begin(),
+    d_out.begin(),
+    d_num_selected.begin(),
+    num_items,
+    select_op));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -901,7 +843,7 @@ TEST_CASE("Device select flagged_if uses custom stream", "[select][device]")
   device_select_flagged_if(
     d_in.begin(), d_flags.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op, env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<value_t> expected_output{1, 4, 6, 7};
   c2h::device_vector<int> expected_num_selected{4};
@@ -910,7 +852,7 @@ TEST_CASE("Device select flagged_if uses custom stream", "[select][device]")
   d_out.resize(d_num_selected[0]);
   REQUIRE(d_out == expected_output);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 TEST_CASE("Device select unique uses custom stream", "[select][device]")
@@ -924,19 +866,18 @@ TEST_CASE("Device select unique uses custom stream", "[select][device]")
   auto d_num_selected   = c2h::device_vector<unsigned int>(1);
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceSelect::Unique(
-            nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items));
+  REQUIRE_CUDART(cub::DeviceSelect::Unique(
+    nullptr, expected_bytes_allocated, d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
 
   device_select_unique(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<value_t> expected_output{0, 2, 9, 5, 8};
   c2h::device_vector<int> expected_num_selected{5};
@@ -945,7 +886,7 @@ TEST_CASE("Device select unique uses custom stream", "[select][device]")
   d_out.resize(d_num_selected[0]);
   REQUIRE(d_out == expected_output);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 TEST_CASE("Device select unique in-place uses custom stream", "[select][device]")
@@ -958,19 +899,18 @@ TEST_CASE("Device select unique in-place uses custom stream", "[select][device]"
   auto d_num_selected   = c2h::device_vector<unsigned int>(1);
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::Unique(nullptr, expected_bytes_allocated, d_data.begin(), d_num_selected.begin(), num_items));
+  REQUIRE_CUDART(
+    cub::DeviceSelect::Unique(nullptr, expected_bytes_allocated, d_data.begin(), d_num_selected.begin(), num_items));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
 
-  REQUIRE(cudaSuccess == cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items, env));
+  REQUIRE_CUDART(cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items, env));
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<value_t> expected_output{0, 2, 9, 5, 8};
   c2h::device_vector<int> expected_num_selected{5};
@@ -979,7 +919,7 @@ TEST_CASE("Device select unique in-place uses custom stream", "[select][device]"
   d_data.resize(d_num_selected[0]);
   REQUIRE(d_data == expected_output);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 TEST_CASE("Device select unique in-place with custom equality_op uses custom stream", "[select][device]")
@@ -994,19 +934,18 @@ TEST_CASE("Device select unique in-place with custom equality_op uses custom str
   eq_mod3_t<value_t> eq_mod3{};
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceSelect::Unique(
-            nullptr, expected_bytes_allocated, d_data.begin(), d_num_selected.begin(), num_items, eq_mod3));
+  REQUIRE_CUDART(cub::DeviceSelect::Unique(
+    nullptr, expected_bytes_allocated, d_data.begin(), d_num_selected.begin(), num_items, eq_mod3));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
 
-  REQUIRE(cudaSuccess == cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items, eq_mod3, env));
+  REQUIRE_CUDART(cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items, eq_mod3, env));
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<value_t> expected_output{0, 1, 2};
   c2h::device_vector<int> expected_num_selected{3};
@@ -1015,7 +954,7 @@ TEST_CASE("Device select unique in-place with custom equality_op uses custom str
   d_data.resize(d_num_selected[0]);
   REQUIRE(d_data == expected_output);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }
 
 TEST_CASE("Device select unique_by_key uses custom stream", "[select][device]")
@@ -1031,20 +970,18 @@ TEST_CASE("Device select unique_by_key uses custom stream", "[select][device]")
   auto d_num_selected   = c2h::device_vector<unsigned int>(1);
 
   cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  REQUIRE_CUDART(cudaStreamCreate(&custom_stream));
 
   size_t expected_bytes_allocated{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceSelect::UniqueByKey(
-      nullptr,
-      expected_bytes_allocated,
-      d_keys_in.begin(),
-      d_values_in.begin(),
-      d_keys_out.begin(),
-      d_values_out.begin(),
-      d_num_selected.begin(),
-      num_items));
+  REQUIRE_CUDART(cub::DeviceSelect::UniqueByKey(
+    nullptr,
+    expected_bytes_allocated,
+    d_keys_in.begin(),
+    d_values_in.begin(),
+    d_keys_out.begin(),
+    d_values_out.begin(),
+    d_num_selected.begin(),
+    num_items));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -1059,7 +996,7 @@ TEST_CASE("Device select unique_by_key uses custom stream", "[select][device]")
     ::cuda::std::equal_to<>{},
     env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(custom_stream));
 
   c2h::device_vector<value_t> expected_keys{0, 2, 9, 5, 8};
   c2h::device_vector<value_t> expected_values{1, 2, 4, 5, 8};
@@ -1071,5 +1008,5 @@ TEST_CASE("Device select unique_by_key uses custom stream", "[select][device]")
   REQUIRE(d_keys_out == expected_keys);
   REQUIRE(d_values_out == expected_values);
 
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+  REQUIRE_CUDART(cudaStreamDestroy(custom_stream));
 }

--- a/cub/test/catch2_test_device_select_env_api.cu
+++ b/cub/test/catch2_test_device_select_env_api.cu
@@ -37,7 +37,7 @@ C2H_TEST("cub::DeviceSelect::If accepts env with stream", "[select][env]")
   thrust::device_vector<int> expected_num_selected{4};
   // example-end select-if-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected_output);
   REQUIRE(num_selected == expected_num_selected);
 }
@@ -65,7 +65,7 @@ C2H_TEST("cub::DeviceSelect::Flagged accepts env with stream", "[select][env]")
   thrust::device_vector<int> expected_num_selected{4};
   // example-end select-flagged-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected_output);
   REQUIRE(num_selected == expected_num_selected);
 }
@@ -94,7 +94,7 @@ C2H_TEST("cub::DeviceSelect::FlaggedIf accepts env with stream", "[select][env]"
   thrust::device_vector<int> expected_num_selected{4};
   // example-end select-flaggedif-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected_output);
   REQUIRE(num_selected == expected_num_selected);
 }
@@ -120,7 +120,7 @@ C2H_TEST("cub::DeviceSelect::Flagged in-place accepts env with stream", "[select
   thrust::device_vector<int> expected_num_selected{4};
   // example-end select-flagged-inplace-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(num_selected == expected_num_selected);
   data.resize(num_selected[0]);
   REQUIRE(data == expected_output);
@@ -147,7 +147,7 @@ C2H_TEST("cub::DeviceSelect::If in-place accepts env with stream", "[select][env
   thrust::device_vector<int> expected_num_selected{4};
   // example-end select-if-inplace-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(num_selected == expected_num_selected);
   data.resize(num_selected[0]);
   REQUIRE(data == expected_output);
@@ -176,7 +176,7 @@ C2H_TEST("cub::DeviceSelect::FlaggedIf in-place accepts env with stream", "[sele
   thrust::device_vector<int> expected_num_selected{4};
   // example-end select-flaggedif-inplace-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(num_selected == expected_num_selected);
   data.resize(num_selected[0]);
   REQUIRE(data == expected_output);
@@ -203,7 +203,7 @@ C2H_TEST("cub::DeviceSelect::Unique accepts env with stream", "[select][env]")
   thrust::device_vector<int> expected_num_selected{5};
   // example-end select-unique-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(output == expected_output);
   REQUIRE(num_selected == expected_num_selected);
 }
@@ -235,7 +235,7 @@ C2H_TEST("cub::DeviceSelect::Unique with custom equality_op accepts env with str
   // example-end select-unique-eqop-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(num_selected == expected_num_selected);
   output.resize(num_selected[0]);
   REQUIRE(output == expected_output);
@@ -262,7 +262,7 @@ C2H_TEST("cub::DeviceSelect::Unique in-place accepts env with stream", "[select]
   // example-end select-unique-inplace-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(num_selected == expected_num_selected);
   data.resize(num_selected[0]);
   REQUIRE(data == expected_output);
@@ -293,7 +293,7 @@ C2H_TEST("cub::DeviceSelect::Unique in-place with custom equality_op accepts env
   // example-end select-unique-inplace-eqop-env
   stream.sync();
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(num_selected == expected_num_selected);
   data.resize(num_selected[0]);
   REQUIRE(data == expected_output);
@@ -331,7 +331,7 @@ C2H_TEST("cub::DeviceSelect::UniqueByKey accepts env with stream", "[select][env
   thrust::device_vector<int> expected_num_selected{5};
   // example-end select-uniquebykey-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
   REQUIRE(num_selected == expected_num_selected);
@@ -364,7 +364,7 @@ C2H_TEST("cub::DeviceSelect::UniqueByKey accepts env with stream without equalit
   thrust::device_vector<int> expected_num_selected{5};
   // example-end select-uniquebykey-default-eq-env
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
   REQUIRE(num_selected == expected_num_selected);
@@ -391,7 +391,7 @@ C2H_TEST("cub::DeviceSelect::UniqueByKey accepts default env without equality_op
   thrust::device_vector<int> expected_values{1, 2, 4, 5, 8};
   thrust::device_vector<int> expected_num_selected{5};
 
-  REQUIRE(error == cudaSuccess);
+  REQUIRE_CUDART(error);
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
   REQUIRE(num_selected == expected_num_selected);

--- a/cub/test/catch2_test_device_topk_env.cu
+++ b/cub/test/catch2_test_device_topk_env.cu
@@ -62,21 +62,18 @@ C2H_TEST("DeviceTopK::MaxKeys can be tuned", "[topk][device]", block_sizes)
   auto env = stdexec::env{topk_requirements(), cuda::execution::tune(topk_tuning<target_block_size>{})};
 
   size_t temp_size{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceTopK::MaxKeys(
-            nullptr, temp_size, input, d_keys_out.begin(), /* elements */ 1024, d_keys_out.size(), env));
+  REQUIRE_CUDART(cub::DeviceTopK::MaxKeys(
+    nullptr, temp_size, input, d_keys_out.begin(), /* elements */ 1024, d_keys_out.size(), env));
 
   c2h::device_vector<char> temp(temp_size, thrust::no_init);
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceTopK::MaxKeys(
-      thrust::raw_pointer_cast(temp.data()),
-      temp_size,
-      input,
-      d_keys_out.begin(),
-      /* elements */ 1024,
-      d_keys_out.size(),
-      env));
+  REQUIRE_CUDART(cub::DeviceTopK::MaxKeys(
+    thrust::raw_pointer_cast(temp.data()),
+    temp_size,
+    input,
+    d_keys_out.begin(),
+    /* elements */ 1024,
+    d_keys_out.size(),
+    env));
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
@@ -91,21 +88,18 @@ C2H_TEST("DeviceTopK::MinKeys can be tuned", "[topk][device]", block_sizes)
   auto env = stdexec::env{topk_requirements(), cuda::execution::tune(topk_tuning<target_block_size>{})};
 
   size_t temp_size{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceTopK::MinKeys(
-            nullptr, temp_size, input, d_keys_out.begin(), /* elements */ 1024, d_keys_out.size(), env));
+  REQUIRE_CUDART(cub::DeviceTopK::MinKeys(
+    nullptr, temp_size, input, d_keys_out.begin(), /* elements */ 1024, d_keys_out.size(), env));
 
   c2h::device_vector<char> temp(temp_size, thrust::no_init);
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceTopK::MinKeys(
-      thrust::raw_pointer_cast(temp.data()),
-      temp_size,
-      input,
-      d_keys_out.begin(),
-      /* elements */ 1024,
-      d_keys_out.size(),
-      env));
+  REQUIRE_CUDART(cub::DeviceTopK::MinKeys(
+    thrust::raw_pointer_cast(temp.data()),
+    temp_size,
+    input,
+    d_keys_out.begin(),
+    /* elements */ 1024,
+    d_keys_out.size(),
+    env));
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
@@ -122,23 +116,20 @@ C2H_TEST("DeviceTopK::MaxPairs can be tuned", "[topk][device]", block_sizes)
   auto env = stdexec::env{topk_requirements(), cuda::execution::tune(topk_tuning<target_block_size>{})};
 
   size_t temp_size{};
-  REQUIRE(cudaSuccess
-          == cub::DeviceTopK::MaxPairs(
-            nullptr, temp_size, input, d_keys_out.begin(), values_in, d_values_out.begin(), 1024, 3, env));
+  REQUIRE_CUDART(cub::DeviceTopK::MaxPairs(
+    nullptr, temp_size, input, d_keys_out.begin(), values_in, d_values_out.begin(), 1024, 3, env));
 
   c2h::device_vector<char> temp(temp_size, thrust::no_init);
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceTopK::MaxPairs(
-      thrust::raw_pointer_cast(temp.data()),
-      temp_size,
-      input,
-      d_keys_out.begin(),
-      values_in,
-      d_values_out.begin(),
-      1024,
-      3,
-      env));
+  REQUIRE_CUDART(cub::DeviceTopK::MaxPairs(
+    thrust::raw_pointer_cast(temp.data()),
+    temp_size,
+    input,
+    d_keys_out.begin(),
+    values_in,
+    d_values_out.begin(),
+    1024,
+    3,
+    env));
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
@@ -155,32 +146,28 @@ C2H_TEST("DeviceTopK::MinPairs can be tuned", "[topk][device]", block_sizes)
   auto env = stdexec::env{topk_requirements(), cuda::execution::tune(topk_tuning<target_block_size>{})};
 
   size_t temp_size{};
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceTopK::MinPairs(
-      nullptr,
-      temp_size,
-      input,
-      d_keys_out.begin(),
-      values_in,
-      d_values_out.begin(),
-      /* elements */ 1024,
-      d_keys_out.size(),
-      env));
+  REQUIRE_CUDART(cub::DeviceTopK::MinPairs(
+    nullptr,
+    temp_size,
+    input,
+    d_keys_out.begin(),
+    values_in,
+    d_values_out.begin(),
+    /* elements */ 1024,
+    d_keys_out.size(),
+    env));
 
   c2h::device_vector<char> temp(temp_size, thrust::no_init);
-  REQUIRE(
-    cudaSuccess
-    == cub::DeviceTopK::MinPairs(
-      thrust::raw_pointer_cast(temp.data()),
-      temp_size,
-      input,
-      d_keys_out.begin(),
-      values_in,
-      d_values_out.begin(),
-      1024,
-      3,
-      env));
+  REQUIRE_CUDART(cub::DeviceTopK::MinPairs(
+    thrust::raw_pointer_cast(temp.data()),
+    temp_size,
+    input,
+    d_keys_out.begin(),
+    values_in,
+    d_values_out.begin(),
+    1024,
+    3,
+    env));
   REQUIRE(d_block_size[0] == target_block_size);
 }
 

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -733,7 +733,7 @@ __global__ void unrelated_kernel()
 C2H_TEST("DeviceTransform::Transform does not effect unrelated kernel's static SMEM consumption", "[device][transform]")
 {
   cudaFuncAttributes attrs;
-  REQUIRE(cudaFuncGetAttributes(&attrs, unrelated_kernel) == cudaSuccess);
+  REQUIRE_CUDART(cudaFuncGetAttributes(&attrs, unrelated_kernel));
   REQUIRE(attrs.sharedSizeBytes == 4 + 12);
 }
 

--- a/cub/test/catch2_test_device_transform_env.cu
+++ b/cub/test/catch2_test_device_transform_env.cu
@@ -66,8 +66,8 @@ void check_graph_nodes_with_different_streams(F call_cub_api)
 {
   // create stream and begin capture
   cuda::stream stream{cuda::devices[0]};
-  // REQUIRE(cudaStreamCreate(&stream) == cudaSuccess);
-  REQUIRE(cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeGlobal) == cudaSuccess);
+  // REQUIRE_CUDART(cudaStreamCreate(&stream));
+  REQUIRE_CUDART(cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeGlobal));
 
   // test various streams
   SECTION("cudaStream_t")
@@ -113,20 +113,20 @@ void check_graph_nodes_with_different_streams(F call_cub_api)
 
   // end capture and check that we captured 1 node
   cudaGraph_t graph;
-  REQUIRE(cudaGraphCreate(&graph, 0) == cudaSuccess);
-  REQUIRE(cudaStreamEndCapture(stream.get(), &graph) == cudaSuccess);
+  REQUIRE_CUDART(cudaGraphCreate(&graph, 0));
+  REQUIRE_CUDART(cudaStreamEndCapture(stream.get(), &graph));
   size_t num_nodes = 0;
-  REQUIRE(cudaGraphGetNodes(graph, nullptr, &num_nodes) == cudaSuccess);
+  REQUIRE_CUDART(cudaGraphGetNodes(graph, nullptr, &num_nodes));
   CHECK(num_nodes == 1);
 
   // run the graph so we can check the results later
   cudaGraphExec_t exec{};
-  REQUIRE(cudaGraphInstantiate(&exec, graph, nullptr, nullptr, 0) == cudaSuccess);
-  REQUIRE(cudaGraphLaunch(exec, stream.get()) == cudaSuccess);
-  REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
+  REQUIRE_CUDART(cudaGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
+  REQUIRE_CUDART(cudaGraphLaunch(exec, stream.get()));
+  REQUIRE_CUDART(cudaStreamSynchronize(stream.get()));
 
   // tear down
-  REQUIRE(cudaGraphDestroy(graph) == cudaSuccess);
+  REQUIRE_CUDART(cudaGraphDestroy(graph));
 }
 
 C2H_TEST("DeviceTransform::Transform custom stream", "[device][transform]")
@@ -166,7 +166,7 @@ C2H_TEST("DeviceTransform::Generate custom stream", "[device][transform]")
   c2h::device_vector<type> result(num_items, thrust::no_init);
 
   cudaStream_t stream;
-  REQUIRE(cudaStreamCreate(&stream) == cudaSuccess);
+  REQUIRE_CUDART(cudaStreamCreate(&stream));
 
   check_graph_nodes_with_different_streams([&](auto streamish) {
     cub::DeviceTransform::Generate(result.begin(), num_items, generator, streamish);
@@ -271,9 +271,9 @@ C2H_TEST("DeviceTransform::Transform can be tuned", "[reduce][device]")
   c2h::device_vector<unsigned> result(3 * 8, thrust::no_init);
 
   auto env = cuda::execution::tune(my_policy_selector{});
-  REQUIRE(cudaSuccess
-          == cub::DeviceTransform::Transform(cuda::std::tuple{}, result.data(), result.size(), get_thread_id{}, env));
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(
+    cub::DeviceTransform::Transform(cuda::std::tuple{}, result.data(), result.size(), get_thread_id{}, env));
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   c2h::device_vector<unsigned> expected{0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7};
   REQUIRE(result == expected);
@@ -285,8 +285,8 @@ C2H_TEST("DeviceTransform::Transform can be tuned with custom stream", "[reduce]
 
   cuda::stream stream{cuda::devices[0]};
   auto env = cuda::std::execution::env{cuda::stream_ref{stream}, cuda::execution::tune(my_policy_selector{})};
-  REQUIRE(cudaSuccess
-          == cub::DeviceTransform::Transform(cuda::std::tuple{}, result.data(), result.size(), get_thread_id{}, env));
+  REQUIRE_CUDART(
+    cub::DeviceTransform::Transform(cuda::std::tuple{}, result.data(), result.size(), get_thread_id{}, env));
   stream.sync();
 
   c2h::device_vector<unsigned> expected{0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7};

--- a/cub/test/catch2_test_env_launch_helper.h
+++ b/cub/test/catch2_test_env_launch_helper.h
@@ -302,7 +302,7 @@ void launch(ActionT action, Args... args)
   else
   {
     // Create new stream one otherwise
-    REQUIRE(cudaStreamCreate(&stream) == cudaSuccess);
+    REQUIRE_CUDART(cudaStreamCreate(&stream));
   }
 
   // cuda graphs do not support default stream
@@ -321,36 +321,36 @@ void launch(ActionT action, Args... args)
   auto fixed_args = replace_back(cuda::std::make_index_sequence<env_idx>{}, tuple, fixed_env);
 
   cudaGraph_t graph{};
-  REQUIRE(cudaSuccess == cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal));
+  REQUIRE_CUDART(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal));
 
   cuda::std::apply(
     [stream, action](auto... args) {
       // Make sure specified stream is used
       stream_scope scope(stream);
       cudaError_t error = action(args...);
-      REQUIRE(cudaSuccess == error);
+      REQUIRE_CUDART(error);
     },
     fixed_args);
 
-  REQUIRE(cudaSuccess == cudaStreamEndCapture(stream, &graph));
+  REQUIRE_CUDART(cudaStreamEndCapture(stream, &graph));
 
   cudaGraphExec_t exec{};
-  REQUIRE(cudaSuccess == cudaGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
+  REQUIRE_CUDART(cudaGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
 
-  REQUIRE(cudaSuccess == cudaGraphLaunch(exec, stream));
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(stream));
+  REQUIRE_CUDART(cudaGraphLaunch(exec, stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(stream));
 
   // Make sure there are no memory leaks
   REQUIRE(bytes_deallocated == bytes_allocated);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
-  REQUIRE(cudaSuccess == cudaGraphExecDestroy(exec));
-  REQUIRE(cudaSuccess == cudaGraphDestroy(graph));
+  REQUIRE_CUDART(cudaGraphExecDestroy(exec));
+  REQUIRE_CUDART(cudaGraphDestroy(graph));
 
   if constexpr (!cuda::std::execution::__queryable_with<env_t, cuda::get_stream_t>)
   {
-    REQUIRE(cudaSuccess == cudaStreamDestroy(stream));
+    REQUIRE_CUDART(cudaStreamDestroy(stream));
   }
 
   if constexpr (cuda::std::execution::__queryable_with<env_t, get_expected_allocation_size_t>)
@@ -422,14 +422,14 @@ void launch(ActionT action, Args... args)
   cuda::std::apply(
     [&](auto... args) {
       device_side_api_launch_kernel<<<1, 1>>>(thrust::raw_pointer_cast(d_error.data()), action, args...);
-      REQUIRE(cudaSuccess == d_error[0]);
+      REQUIRE_CUDART(d_error[0]);
     },
     fixed_args);
 
   REQUIRE(d_allocated[0] == expected_bytes_allocated);
   REQUIRE(d_allocated[0] == d_deallocated[0]);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 #else // TEST_LAUNCH == 0
@@ -457,7 +457,7 @@ void launch(ActionT action, Args... args)
   else
   {
     // Create new stream one otherwise
-    REQUIRE(cudaStreamCreate(&stream) == cudaSuccess);
+    REQUIRE_CUDART(cudaStreamCreate(&stream));
   }
 
   size_t bytes_allocated{};
@@ -493,18 +493,18 @@ void launch(ActionT action, Args... args)
       stream_scope allowed_stream(stream);
       kernel_scope allowed_kernels(kernels);
       cudaError_t error = action(args...);
-      REQUIRE(cudaSuccess == error);
+      REQUIRE_CUDART(error);
     },
     fixed_args);
 
   // Make sure there are no memory leaks
   REQUIRE(bytes_deallocated == bytes_allocated);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   if constexpr (!cuda::std::execution::__queryable_with<env_t, cuda::get_stream_t>)
   {
-    REQUIRE(cudaSuccess == cudaStreamDestroy(stream));
+    REQUIRE_CUDART(cudaStreamDestroy(stream));
   }
 
   if constexpr (cuda::std::execution::__queryable_with<env_t, get_expected_allocation_size_t>)

--- a/cub/test/catch2_test_launch_helper.h
+++ b/cub/test/catch2_test_launch_helper.h
@@ -94,30 +94,30 @@ template <class ActionT, class... Args>
 void launch(ActionT action, Args... args)
 {
   cudaStream_t stream{};
-  REQUIRE(cudaSuccess == cudaStreamCreate(&stream));
+  REQUIRE_CUDART(cudaStreamCreate(&stream));
 
   std::size_t temp_storage_bytes{};
   cudaError_t error = action(nullptr, temp_storage_bytes, args..., stream);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == error);
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(error);
 
   c2h::device_vector<std::uint8_t> temp_storage(temp_storage_bytes, thrust::no_init);
 
   cudaGraph_t graph{};
-  REQUIRE(cudaSuccess == cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal));
+  REQUIRE_CUDART(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal));
   error = action(thrust::raw_pointer_cast(temp_storage.data()), temp_storage_bytes, args..., stream);
-  REQUIRE(cudaSuccess == cudaStreamEndCapture(stream, &graph));
-  REQUIRE(cudaSuccess == error);
+  REQUIRE_CUDART(cudaStreamEndCapture(stream, &graph));
+  REQUIRE_CUDART(error);
 
   cudaGraphExec_t exec{};
-  REQUIRE(cudaSuccess == cudaGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
+  REQUIRE_CUDART(cudaGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
 
-  REQUIRE(cudaSuccess == cudaGraphLaunch(exec, stream));
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(stream));
+  REQUIRE_CUDART(cudaGraphLaunch(exec, stream));
+  REQUIRE_CUDART(cudaStreamSynchronize(stream));
 
-  REQUIRE(cudaSuccess == cudaGraphExecDestroy(exec));
-  REQUIRE(cudaSuccess == cudaGraphDestroy(graph));
-  REQUIRE(cudaSuccess == cudaStreamDestroy(stream));
+  REQUIRE_CUDART(cudaGraphExecDestroy(exec));
+  REQUIRE_CUDART(cudaGraphDestroy(graph));
+  REQUIRE_CUDART(cudaStreamDestroy(stream));
 }
 
 #elif TEST_LAUNCH == 1
@@ -158,9 +158,9 @@ void launch(ActionT action, Args... args)
     thrust::raw_pointer_cast(d_error.data()),
     action,
     args...);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
-  REQUIRE(cudaSuccess == d_error[0]);
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
+  REQUIRE_CUDART(d_error[0]);
 
   c2h::device_vector<std::uint8_t> temp_storage(d_temp_storage_bytes[0], thrust::no_init);
 
@@ -170,9 +170,9 @@ void launch(ActionT action, Args... args)
     thrust::raw_pointer_cast(d_error.data()),
     action,
     args...);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
-  REQUIRE(cudaSuccess == d_error[0]);
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
+  REQUIRE_CUDART(d_error[0]);
 }
 
 #else // TEST_LAUNCH == 0
@@ -182,18 +182,18 @@ void launch(ActionT action, Args... args)
 {
   std::size_t temp_storage_bytes{};
   cudaError_t error = action(nullptr, temp_storage_bytes, args...);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
-  REQUIRE(cudaSuccess == error);
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
+  REQUIRE_CUDART(error);
 
   REQUIRE(temp_storage_bytes > 0); // required by API contract
 
   c2h::device_vector<std::uint8_t> temp_storage(temp_storage_bytes, thrust::no_init);
 
   error = action(thrust::raw_pointer_cast(temp_storage.data()), temp_storage_bytes, args...);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
-  REQUIRE(cudaSuccess == error);
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
+  REQUIRE_CUDART(error);
 }
 
 #endif // TEST_LAUNCH == 0

--- a/cub/test/catch2_test_thread_scan_exclusive_partial.cu
+++ b/cub/test/catch2_test_thread_scan_exclusive_partial.cu
@@ -191,8 +191,8 @@ C2H_TEST("ThreadScanExclusive Integral Type Tests",
     prefix,
     apply_prefix,
     filler);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   if (!apply_prefix)
   {
     // Undefined for exclusive scan
@@ -248,8 +248,8 @@ C2H_TEST("ThreadScanExclusive Floating-Point Type Tests",
     prefix,
     apply_prefix,
     filler);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   if (!apply_prefix)
   {
     // Undefined for exclusive scan
@@ -310,8 +310,8 @@ C2H_TEST("ThreadScanExclusive Narrow PrecisionType Tests",
     *unwrap_it(&prefix),
     apply_prefix,
     *unwrap_it(&filler));
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   if (!apply_prefix)
   {
     // Undefined for exclusive scan
@@ -345,8 +345,8 @@ C2H_TEST("ThreadScanExclusive Container Tests", "[scan][thread]")
     valid_items,
     0,
     true);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(reference_result == d_out);
 
   thrust::fill(d_out.begin(), d_out.end(), 0);
@@ -357,8 +357,8 @@ C2H_TEST("ThreadScanExclusive Container Tests", "[scan][thread]")
     valid_items,
     0,
     true);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(reference_result == d_out);
 
 #if _CCCL_STD_VER >= 2023
@@ -370,8 +370,8 @@ C2H_TEST("ThreadScanExclusive Container Tests", "[scan][thread]")
     valid_items,
     0,
     true);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(reference_result == d_out);
 #endif // _CCCL_STD_VER >= 2023
 }
@@ -413,8 +413,8 @@ C2H_TEST("ThreadScanExclusive Invalid Test", "[scan][thread]")
     prefix,
     apply_prefix,
     segment{});
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(error_flag.front() == false);
   if (!apply_prefix && valid_items > 0)
   {

--- a/cub/test/catch2_test_thread_scan_inclusive_partial.cu
+++ b/cub/test/catch2_test_thread_scan_inclusive_partial.cu
@@ -199,8 +199,8 @@ C2H_TEST("ThreadScanInclusive Integral Type Tests",
     prefix,
     apply_prefix,
     filler);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(reference_result == d_out);
 }
 
@@ -259,8 +259,8 @@ C2H_TEST("ThreadScanInclusive Floating-Point Type Tests",
     prefix,
     apply_prefix,
     filler);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(reference_result == d_out);
 }
 
@@ -315,8 +315,8 @@ C2H_TEST("ThreadScanInclusive Narrow PrecisionType Tests",
     *unwrap_it(&prefix),
     apply_prefix,
     *unwrap_it(&filler));
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(reference_result == d_out);
 }
 
@@ -345,8 +345,8 @@ C2H_TEST("ThreadScanInclusive Container Tests", "[scan][thread]")
     valid_items,
     0,
     true);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(reference_result == d_out);
 
   thrust::fill(d_out.begin(), d_out.end(), 0);
@@ -357,8 +357,8 @@ C2H_TEST("ThreadScanInclusive Container Tests", "[scan][thread]")
     valid_items,
     0,
     true);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(reference_result == d_out);
 
 #if _CCCL_STD_VER >= 2023
@@ -370,8 +370,8 @@ C2H_TEST("ThreadScanInclusive Container Tests", "[scan][thread]")
     valid_items,
     0,
     true);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(reference_result == d_out);
 #endif // _CCCL_STD_VER >= 2023
 }
@@ -413,8 +413,8 @@ C2H_TEST("ThreadScanInclusive Invalid Test", "[scan][thread]")
     prefix,
     apply_prefix,
     segment{});
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(error_flag.front() == false);
   REQUIRE(reference_result == d_out);
 }

--- a/cub/test/catch2_test_util_choose_offset.cu
+++ b/cub/test/catch2_test_util_choose_offset.cu
@@ -36,14 +36,12 @@ C2H_TEST("Tests choose_signed_offset", "[util][type]")
   STATIC_REQUIRE(cuda::std::is_same_v<cub::detail::choose_signed_offset_t<std::int64_t>, std::int64_t>);
 
   // Offset type covers maximum number representable by a signed 32-bit integer
-  REQUIRE(cudaSuccess
-          == cub::detail::choose_signed_offset<std::int32_t>::is_exceeding_offset_type(
-            cuda::std::numeric_limits<std::int32_t>::max()));
+  REQUIRE_CUDART(cub::detail::choose_signed_offset<std::int32_t>::is_exceeding_offset_type(
+    cuda::std::numeric_limits<std::int32_t>::max()));
 
   // Offset type covers maximum number representable by a signed 64-bit integer
-  REQUIRE(cudaSuccess
-          == cub::detail::choose_signed_offset<std::int64_t>::is_exceeding_offset_type(
-            cuda::std::numeric_limits<std::int64_t>::max()));
+  REQUIRE_CUDART(cub::detail::choose_signed_offset<std::int64_t>::is_exceeding_offset_type(
+    cuda::std::numeric_limits<std::int64_t>::max()));
 
   // Offset type does not support maximum number representable by an unsigned 64-bit integer
   REQUIRE(cudaErrorInvalidValue

--- a/cub/test/catch2_test_util_device.cu
+++ b/cub/test/catch2_test_util_device.cu
@@ -84,7 +84,7 @@ C2H_TEST("CUB correctly identifies the ptx version the kernel was compiled for",
 C2H_TEST("PtxVersion returns a value from __CUDA_ARCH_LIST__/NV_TARGET_SM_INTEGER_LIST", "[util][dispatch]")
 {
   int ptx_version = 0;
-  REQUIRE(cub::PtxVersion(ptx_version) == cudaSuccess);
+  REQUIRE_CUDART(cub::PtxVersion(ptx_version));
   auto cc_list = std::vector<int>{CUDA_SM_LIST};
   for (auto& cc : cc_list)
   {
@@ -304,11 +304,10 @@ C2H_TEST("MaxPotentialDynamicSmemBytes", "[util][launch]")
 
   // 1. Test positive case.
   int dyn_smem_size{};
-  REQUIRE(
-    cub::MaxPotentialDynamicSmemBytes(dyn_smem_size, test_max_potential_dynamic_smem_bytes_kernel) == cudaSuccess);
+  REQUIRE_CUDART(cub::MaxPotentialDynamicSmemBytes(dyn_smem_size, test_max_potential_dynamic_smem_bytes_kernel));
   REQUIRE(dyn_smem_size == expected);
 
   // 2. Test that we return -1 if an error occurs.
-  REQUIRE(cub::MaxPotentialDynamicSmemBytes(dyn_smem_size, nullptr) != cudaSuccess);
+  REQUIRE_CUDART(cub::MaxPotentialDynamicSmemBytes(dyn_smem_size, nullptr));
   REQUIRE(dyn_smem_size == -1);
 }

--- a/cub/test/catch2_test_util_device.cu
+++ b/cub/test/catch2_test_util_device.cu
@@ -51,10 +51,10 @@ C2H_TEST("CUB correctly identifies the ptx version the kernel was compiled for",
   // Query the arch the kernel was actually compiled for
   int ptx_version = [&]() -> int {
     int* buffer{};
-    cudaMallocHost(&buffer, sizeof(*buffer));
+    REQUIRE_CUDART(cudaMallocHost(&buffer, sizeof(*buffer)));
     get_cuda_cc_from_kernel(thrust::raw_pointer_cast(cuda_cc.data()), buffer);
     int result = *buffer;
-    cudaFreeHost(buffer);
+    REQUIRE_CUDART(cudaFreeHost(buffer));
     return result;
   }();
 

--- a/cub/test/catch2_test_vsmem.cu
+++ b/cub/test/catch2_test_vsmem.cu
@@ -418,7 +418,7 @@ C2H_TEST("Virtual shared memory works within algorithms", "[util][vsmem]", type_
 
   // Setup vsmem test
   launch_config_test_info_t* launch_config_info = nullptr;
-  cudaMallocHost(&launch_config_info, sizeof(launch_config_test_info_t));
+  REQUIRE_CUDART(cudaMallocHost(&launch_config_info, sizeof(launch_config_test_info_t)));
   c2h::device_vector<kernel_test_info_t> device_kernel_test_info(1);
   dummy_algorithm(
     in_ptr, out_ptr, num_items, thrust::raw_pointer_cast(device_kernel_test_info.data()), launch_config_info);
@@ -445,5 +445,5 @@ C2H_TEST("Virtual shared memory works within algorithms", "[util][vsmem]", type_
     REQUIRE(launch_config_info->config_vsmem_per_block >= expected_vsmem_per_block);
   }
 
-  cudaFreeHost(launch_config_info);
+  REQUIRE_CUDART(cudaFreeHost(launch_config_info));
 }

--- a/cub/test/catch2_test_warp_exchange.cuh
+++ b/cub/test/catch2_test_warp_exchange.cuh
@@ -105,8 +105,8 @@ void warp_scatter_strided(c2h::device_vector<InputT>& in, c2h::device_vector<Out
   scatter_kernel<LOGICAL_WARP_THREADS, ITEMS_PER_THREAD, TOTAL_WARPS, Alg, InputT, OutputT>
     <<<1, LOGICAL_WARP_THREADS * TOTAL_WARPS>>>(
       thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()));
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 template <int LOGICAL_WARP_THREADS,
@@ -162,8 +162,8 @@ void warp_exchange(c2h::device_vector<InputT>& in, c2h::device_vector<OutputT>& 
   kernel<LOGICAL_WARP_THREADS, ITEMS_PER_THREAD, TOTAL_WARPS, Alg, InputT, OutputT, ActionT>
     <<<1, LOGICAL_WARP_THREADS * TOTAL_WARPS>>>(
       thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), action);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 struct blocked_to_striped

--- a/cub/test/catch2_test_warp_load.cu
+++ b/cub/test/catch2_test_warp_load.cu
@@ -50,8 +50,8 @@ void warp_load(InputIteratorT input_iterator, ActionT action, int* error_counter
 {
   warp_load_kernel<LoadAlgorithm, LOGICAL_WARP_THREADS, ITEMS_PER_THREAD, TOTAL_WARPS, T, InputIteratorT, ActionT>
     <<<1, TOTAL_WARPS * LOGICAL_WARP_THREADS>>>(input_iterator, action, error_counter);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 /**

--- a/cub/test/catch2_test_warp_merge_sort.cu
+++ b/cub/test/catch2_test_warp_merge_sort.cu
@@ -285,8 +285,8 @@ void warp_merge_sort(
     <<<1, LOGICAL_WARP_THREADS * TOTAL_WARPS>>>(
       thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), segment_sizes, oob_default, action);
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 /**
@@ -318,8 +318,8 @@ void warp_merge_sort(
       oob_default,
       action);
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 /**

--- a/cub/test/catch2_test_warp_scan.cu
+++ b/cub/test/catch2_test_warp_scan.cu
@@ -43,8 +43,8 @@ void warp_combine_scan(
     thrust::raw_pointer_cast(exclusive_out.data()),
     action);
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 template <int LOGICAL_WARP_THREADS, int TOTAL_WARPS, class T, class ActionT>
@@ -75,8 +75,8 @@ void warp_scan(c2h::device_vector<T>& in, c2h::device_vector<T>& out, ActionT ac
   warp_scan_kernel<LOGICAL_WARP_THREADS, TOTAL_WARPS, T, ActionT><<<1, LOGICAL_WARP_THREADS * TOTAL_WARPS>>>(
     thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), action);
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 enum class scan_mode

--- a/cub/test/catch2_test_warp_scan_api.cu
+++ b/cub/test/catch2_test_warp_scan_api.cu
@@ -66,8 +66,8 @@ C2H_TEST("Warp array-based inclusive scan works with initial value", "[scan][war
   c2h::device_vector<int> d_out(num_warps * 32);
 
   InclusiveWarpScanKernel<<<1, num_warps * 32>>>(thrust::raw_pointer_cast(d_out.data()));
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   c2h::host_vector<int> expected(d_out.size());
 
@@ -123,8 +123,8 @@ C2H_TEST("Warp array-based inclusive scan aggregate works with initial value", "
 
   InclusiveWarpScanKernelAggr<<<1, num_warps * 32>>>(
     thrust::raw_pointer_cast(d_out.data()), thrust::raw_pointer_cast(d_warp_aggregate.data()));
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   c2h::host_vector<int> expected(d_out.size());
   c2h::host_vector<int> expected_aggr{};
@@ -199,8 +199,8 @@ C2H_TEST("Warp array-based partial inclusive scan works with initial value", "[s
   c2h::device_vector<int> d_out(num_warps * 32);
 
   InclusiveWarpScanPartialKernel<<<1, num_warps * 32>>>(thrust::raw_pointer_cast(d_out.data()));
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   c2h::host_vector<int> expected(d_out.size());
 
@@ -277,8 +277,8 @@ C2H_TEST("Warp array-based partial inclusive scan aggregate works with initial v
 
   InclusiveWarpScanPartialKernelAggr<<<1, num_warps * 32>>>(
     thrust::raw_pointer_cast(d_out.data()), thrust::raw_pointer_cast(d_warp_aggregate.data()));
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   c2h::host_vector<int> expected(d_out.size());
   c2h::host_vector<int> expected_aggr{};

--- a/cub/test/catch2_test_warp_scan_partial_helper.cuh
+++ b/cub/test/catch2_test_warp_scan_partial_helper.cuh
@@ -53,8 +53,8 @@ void warp_combine_scan(
     valid_items,
     filler);
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 template <int LogicalWarpThreads, int TotalWarps, class T, class ActionT>
@@ -85,8 +85,8 @@ void warp_scan(c2h::device_vector<T>& in, c2h::device_vector<T>& out, ActionT ac
   warp_scan_kernel<LogicalWarpThreads, TotalWarps, T, ActionT><<<1, LogicalWarpThreads * TotalWarps>>>(
     thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), action, valid_items);
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 enum class scan_mode

--- a/cub/test/internal/catch2_test_integer_utils.cu
+++ b/cub/test/internal/catch2_test_integer_utils.cu
@@ -118,11 +118,11 @@ C2H_TEST("Split/Merge Integers", "[Split/Merge][Random]", integral_types)
   c2h::device_vector<T> d_in(num_items);
   c2h::gen(C2H_SEED(1), d_in);
   test_int_kernel<<<cuda::ceil_div(num_items, 256), 256>>>(thrust::raw_pointer_cast(d_in.data()), num_items);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   test_int_special_values_kernel<<<1, 1>>>();
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 C2H_TEST(
@@ -134,9 +134,9 @@ C2H_TEST(
   c2h::device_vector<T> d_in(num_items);
   c2h::gen(C2H_SEED(1), d_in);
   test_float_kernel<<<cuda::ceil_div(num_items, 256), 256>>>(Op{}, thrust::raw_pointer_cast(d_in.data()), num_items);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   test_float_special_values_kernel<T><<<1, 1>>>(Op{});
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }

--- a/cub/test/thread_reduce/catch2_test_thread_reduce.cu
+++ b/cub/test/thread_reduce/catch2_test_thread_reduce.cu
@@ -255,8 +255,8 @@ void run_thread_reduce_kernel(
     default:
       FAIL("Unsupported number of items");
   }
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 constexpr int max_size  = 16;
@@ -344,21 +344,21 @@ C2H_TEST("ThreadReduce Container Tests", "[reduce][thread]")
 
   thread_reduce_kernel_array<max_size>
     <<<1, 1>>>(thrust::raw_pointer_cast(d_in.data()), thrust::raw_pointer_cast(d_out.data()), cuda::std::plus<>{});
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   verify_results(reference_result, c2h::host_vector<int>(d_out)[0]);
 
   thread_reduce_kernel_span<max_size>
     <<<1, 1>>>(thrust::raw_pointer_cast(d_in.data()), thrust::raw_pointer_cast(d_out.data()), cuda::std::plus<>{});
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   verify_results(reference_result, c2h::host_vector<int>(d_out)[0]);
 
 #if _CCCL_STD_VER >= 2023
   thread_reduce_kernel_mdspan<max_size>
     <<<1, 1>>>(thrust::raw_pointer_cast(d_in.data()), thrust::raw_pointer_cast(d_out.data()), cuda::std::plus<>{});
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   verify_results(reference_result, c2h::host_vector<int>(d_out)[0]);
 #endif // _CCCL_STD_VER >= 2023
 }

--- a/cub/test/thread_reduce/catch2_test_thread_reduce_check_sass.cu
+++ b/cub/test/thread_reduce/catch2_test_thread_reduce_check_sass.cu
@@ -128,8 +128,8 @@ void run_thread_reduce_kernel(
 {
   thread_reduce_kernel<18>
     <<<1, 1>>>(thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), reduce_operator);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 /***********************************************************************************************************************

--- a/cub/test/thread_reduce/catch2_test_thread_reduce_partial.cu
+++ b/cub/test/thread_reduce/catch2_test_thread_reduce_partial.cu
@@ -145,8 +145,8 @@ C2H_TEST("ThreadReduce Integral Type Tests",
     compute_single_problem_reference(h_in.cbegin(), h_in.cbegin() + bounded_valid_items, reduce_op, operator_identity);
   thread_reduce_partial_kernel<num_items>
     <<<1, 1>>>(thrust::raw_pointer_cast(d_in.data()), thrust::raw_pointer_cast(d_out.data()), reduce_op, valid_items);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(reference_result == c2h::host_vector<accum_t>(d_out)[0]);
 }
 
@@ -177,8 +177,8 @@ C2H_TEST("ThreadReduce Floating-Point Type Tests",
     compute_single_problem_reference(h_in.cbegin(), h_in.cbegin() + bounded_valid_items, reduce_op, operator_identity);
   thread_reduce_partial_kernel<num_items>
     <<<1, 1>>>(thrust::raw_pointer_cast(d_in.data()), thrust::raw_pointer_cast(d_out.data()), reduce_op, valid_items);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(reference_result == c2h::host_vector<accum_t>(d_out)[0]);
 }
 
@@ -216,8 +216,8 @@ C2H_TEST("ThreadReduce Narrow PrecisionType Tests",
     unwrap_it(thrust::raw_pointer_cast(d_out.data())),
     reduce_op,
     valid_items);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(reference_result == c2h::host_vector<accum_t>(d_out)[0]);
 }
 
@@ -241,21 +241,21 @@ C2H_TEST("ThreadReduce Container Tests", "[reduce][thread]")
 
   thread_reduce_partial_kernel_array<max_size>
     <<<1, 1>>>(thrust::raw_pointer_cast(d_in.data()), thrust::raw_pointer_cast(d_out.data()), op_t{}, valid_items);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(reference_result == c2h::host_vector<int>(d_out)[0]);
 
   thread_reduce_partial_kernel_span<max_size>
     <<<1, 1>>>(thrust::raw_pointer_cast(d_in.data()), thrust::raw_pointer_cast(d_out.data()), op_t{}, valid_items);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(reference_result == c2h::host_vector<int>(d_out)[0]);
 
 #if _CCCL_STD_VER >= 2023
   thread_reduce_partial_kernel_mdspan<max_size>
     <<<1, 1>>>(thrust::raw_pointer_cast(d_in.data()), thrust::raw_pointer_cast(d_out.data()), op_t{}, valid_items);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(reference_result == c2h::host_vector<int>(d_out)[0]);
 #endif // _CCCL_STD_VER >= 2023
 }
@@ -286,8 +286,8 @@ C2H_TEST("ThreadReducePartial does not invoke the reduction operator on invalid 
     thrust::raw_pointer_cast(d_out.data()),
     merge_segments_op{thrust::raw_pointer_cast(error_flag.data())},
     valid_items);
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
   REQUIRE(error_flag.front() == false);
   if (valid_items > 0)
   {

--- a/cub/test/warp/catch2_test_warp_reduce.cu
+++ b/cub/test/warp/catch2_test_warp_reduce.cu
@@ -137,8 +137,8 @@ void warp_reduce_launch(c2h::device_vector<T>& input, c2h::device_vector<T>& out
   warp_reduce_kernel<LogicalWarpThreads, EnableNumItems><<<1, total_warps * warp_size>>>(
     thrust::raw_pointer_cast(input.data()), thrust::raw_pointer_cast(output.data()), args...);
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 template <int LogicalWarpThreads, typename T, typename... TArgs>
@@ -147,8 +147,8 @@ void warp_reduce_multiple_items_launch(c2h::device_vector<T>& input, c2h::device
   warp_reduce_multiple_items_kernel<LogicalWarpThreads><<<1, total_warps * warp_size>>>(
     thrust::raw_pointer_cast(input.data()), thrust::raw_pointer_cast(output.data()), args...);
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 /***********************************************************************************************************************

--- a/cub/test/warp/catch2_test_warp_reduce_batched.cu
+++ b/cub/test/warp/catch2_test_warp_reduce_batched.cu
@@ -278,11 +278,8 @@ void test_warp_reduce_batched(ReductionOp reduction_op = ReductionOp{})
     }
   }
 
-  cudaError_t err = cudaPeekAtLastError();
-  REQUIRE(err == cudaSuccess);
-
-  err = cudaDeviceSynchronize();
-  REQUIRE(err == cudaSuccess);
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   // Host-side: construct mdspans once; pass to reference and verify
   c2h::host_vector<T> h_input  = d_input;

--- a/cub/test/warp/catch2_test_warp_reduce_batched_api.cu
+++ b/cub/test/warp/catch2_test_warp_reduce_batched_api.cu
@@ -47,8 +47,8 @@ C2H_TEST("WarpReduceBatched overview documentation kernel", "[warp][reduce][batc
   c2h::device_vector<int> d_out(6);
 
   WarpReduceBatchedOverviewKernel<<<1, 64>>>(thrust::raw_pointer_cast(d_out.data()));
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   c2h::host_vector<int> expected{30, 31, 32, 62, 63, 64};
   REQUIRE(expected == d_out);
@@ -90,8 +90,8 @@ C2H_TEST("WarpReduceBatched::Reduce documentation kernel", "[warp][reduce][batch
   c2h::device_vector<int> d_out(3);
 
   WarpReduceBatchedReduceApiKernel<<<1, 64>>>(thrust::raw_pointer_cast(d_out.data()));
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   c2h::host_vector<int> expected{14, 15, 16};
   REQUIRE(expected == d_out);
@@ -150,8 +150,8 @@ C2H_TEST("WarpReduceBatched::ReduceToStriped documentation kernel", "[warp][redu
   c2h::device_vector<int> d_out(6);
 
   WarpReduceBatchedReduceToStripedApiKernel<<<1, 8>>>(thrust::raw_pointer_cast(d_out.data()));
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   c2h::host_vector<int> expected{0, 1, 2, 4, 5, 6};
   REQUIRE(expected == d_out);
@@ -211,8 +211,8 @@ C2H_TEST("WarpReduceBatched::ReduceToBlocked documentation kernel", "[warp][redu
   c2h::device_vector<int> d_out(6);
 
   WarpReduceBatchedReduceToBlockedApiKernel<<<1, 8>>>(thrust::raw_pointer_cast(d_out.data()));
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   c2h::host_vector<int> expected{0, 1, 2, 4, 5, 6};
   REQUIRE(expected == d_out);
@@ -250,8 +250,8 @@ C2H_TEST("WarpReduceBatched::Sum documentation kernel", "[warp][reduce][batched]
   c2h::device_vector<int> d_out(6);
 
   WarpReduceBatchedSumApiKernel<<<1, 8>>>(thrust::raw_pointer_cast(d_out.data()));
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   c2h::host_vector<int> expected{2, 6, 10, 18, 22, 26};
   REQUIRE(expected == d_out);
@@ -298,8 +298,8 @@ C2H_TEST("WarpReduceBatched::SumToStriped documentation kernel", "[warp][reduce]
   c2h::device_vector<int> d_out(20);
 
   WarpReduceBatchedSumToStripedApiKernel<<<1, 8>>>(thrust::raw_pointer_cast(d_out.data()));
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   c2h::host_vector<int> expected{-3, -1, 1, 3, 5, 1, 3, 5, 7, 9, 5, 7, 9, 11, 13, 9, 11, 13, 15, 17};
   REQUIRE(expected == d_out);
@@ -346,8 +346,8 @@ C2H_TEST("WarpReduceBatched::SumToBlocked documentation kernel", "[warp][reduce]
   c2h::device_vector<int> d_out(20);
 
   WarpReduceBatchedSumToBlockedApiKernel<<<1, 8>>>(thrust::raw_pointer_cast(d_out.data()));
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 
   c2h::host_vector<int> expected{-3, -1, 1, 3, 5, 1, 3, 5, 7, 9, 5, 7, 9, 11, 13, 9, 11, 13, 15, 17};
   REQUIRE(expected == d_out);

--- a/cub/test/warp/catch2_test_warp_segmented_reduce.cu
+++ b/cub/test/warp/catch2_test_warp_segmented_reduce.cu
@@ -109,8 +109,8 @@ void warp_reduce(c2h::device_vector<T>& in, c2h::device_vector<T>& out, ActionT 
   warp_reduce_kernel<LOGICAL_WARP_THREADS, TOTAL_WARPS, T, ActionT><<<1, LOGICAL_WARP_THREADS * TOTAL_WARPS>>>(
     thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), action);
 
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE_CUDART(cudaPeekAtLastError());
+  REQUIRE_CUDART(cudaDeviceSynchronize());
 }
 
 /**


### PR DESCRIPTION
This PR replaces `REQUIRE(cudaSuccess == /*expr*/)` with `REQUIRE_CUDART` macro. I've used it even for CUB calls since they return `cudaResult_t`, too. I'm not sure if it's the best option, maybe adding `REQUIRE_CUB` would be a better solution