### PR TITLE
Revert "[libcu++] Fix concurent return value writes during device testing (#8957)"

### DIFF
--- a/libcudacxx/test/libcudacxx/force_include.h
+++ b/libcudacxx/test/libcudacxx/force_include.h
@@ -62,8 +62,7 @@ __global__
   void
   fake_main_kernel(int* ret)
 {
-  // We need to use atomicCAS to make sure we don't overwrite previous non-zero value.
-  atomicCAS(ret, 0, fake_main(0, nullptr));
+  *ret = fake_main(0, nullptr);
 }
 
 #define CUDA_CALL(err, ...)                                                                              \


### PR DESCRIPTION
This reverts commit d2f9824c43c0a0262ce727e9dffd17d6aeeb09a1.

In tile mode we cannot use atommicCAS, so this breaks all our tests
