### PR TITLE
[Tile] Avoid returns inside loops in `mdspan`

### DIFF
--- a/libcudacxx/include/cuda/__mdspan/layout_stride_relaxed.h
+++ b/libcudacxx/include/cuda/__mdspan/layout_stride_relaxed.h
@@ -65,12 +65,18 @@ template <class _StridedMapping>
   using _RankType       = typename _StridedMapping::rank_type;
   constexpr auto __rank = _Extents::rank();
   // Check if any extent is zero - can't call mapping(0,...) in that case
+  bool __extent_is_zero = false;
   for (_RankType __r = 0; __r != __rank; ++__r)
   {
     if (__mapping.extents().extent(__r) == 0)
     {
-      return typename _StridedMapping::index_type{0};
+      __extent_is_zero = true;
+      break;
     }
+  }
+  if (__extent_is_zero)
+  {
+    return typename _StridedMapping::index_type{0};
   }
   return ::cuda::__layout_stride_relaxed_compute_offset(__mapping, ::cuda::std::make_index_sequence<__rank>{});
 }
@@ -141,14 +147,16 @@ private:
 
   [[nodiscard]] _CCCL_API constexpr bool __has_positive_strides() const noexcept
   {
+    bool __result = true;
     for (rank_type __r = 0; __r != __rank_; ++__r)
     {
       if (strides().stride(__r) <= 0)
       {
-        return false;
+        __result = false;
+        break;
       }
     }
-    return true;
+    return __result;
   }
 
 public:
@@ -265,12 +273,14 @@ public:
       // __min_dot tracks the total positive magnitude of the negative contributions
       index_type __dot{1};
       offset_type __min_dot{0};
+      bool __stride_is_negative = false;
       for (rank_type __r = 0; __r < __rank_; ++__r)
       {
         const auto __ext = extents().extent(__r);
         if (__ext == index_type{0})
         {
-          return index_type{0};
+          __stride_is_negative = true;
+          break;
         }
         const auto __stride_val = strides().stride(__r);
         _CCCL_ASSERT(::cuda::std::in_range<index_type>(::cuda::uabs(__stride_val)),
@@ -300,7 +310,7 @@ public:
                    "layout_stride_relaxed::mapping: offset is insufficient for negative strides");
       _CCCL_ASSERT(!::cuda::add_overflow<index_type>(__offset_val, __dot),
                    "layout_stride_relaxed::mapping: required_span_size is not representable as index_type");
-      return static_cast<index_type>(__offset_val + __dot);
+      return __stride_is_negative ? index_type{0} : static_cast<index_type>(__offset_val + __dot);
     }
   }
 

--- a/libcudacxx/include/cuda/__mdspan/strides.h
+++ b/libcudacxx/include/cuda/__mdspan/strides.h
@@ -229,14 +229,16 @@ public:
     }
     else
     {
+      bool __result = true;
       for (rank_type __r = 0; __r != __rank_; __r++)
       {
         if (::cuda::std::cmp_not_equal(__lhs.stride(__r), __rhs.stride(__r)))
         {
-          return false;
+          __result = false;
+          break;
         }
       }
-      return true;
+      return __result;
     }
   }
 

--- a/libcudacxx/include/cuda/std/__mdspan/extents.h
+++ b/libcudacxx/include/cuda/std/__mdspan/extents.h
@@ -362,14 +362,16 @@ _CCCL_TEMPLATE(class _To, class _From, size_t _Size)
 _CCCL_REQUIRES(__cccl_is_integer_v<_To>)
 [[nodiscard]] _CCCL_API constexpr bool __are_representable_as(span<_From, _Size> __values)
 {
+  bool __result = true;
   for (size_t __i = 0; __i != _Size; __i++)
   {
     if (!__mdspan_detail::__is_representable_as<_To>(__values[__i]))
     {
-      return false;
+      __result = false;
+      break;
     }
   }
-  return true;
+  return __result;
 }
 
 // ------------------------------------------------------------------
@@ -603,14 +605,16 @@ public:
     }
     else if constexpr (rank() != 0)
     {
+      bool __result = true;
       for (rank_type __r = 0; __r != __rank_; __r++)
       {
         if (::cuda::std::cmp_not_equal(__lhs.extent(__r), __rhs.extent(__r)))
         {
-          return false;
+          __result = false;
+          break;
         }
       }
-      return true;
+      return __result;
     }
     else // MSVC needs this or it complains about unreachable code in the first condition
     {
@@ -651,6 +655,7 @@ template <class _Extents>
 [[nodiscard]] _CCCL_API constexpr bool __required_span_size_is_representable(const _Extents& __ext) noexcept
 {
   using ::cuda::std::__mdspan_detail::__mul_overflow;
+  bool __result = true;
   if constexpr (_Extents::rank() != 0)
   {
     using __index_type  = typename _Extents::index_type;
@@ -660,11 +665,12 @@ template <class _Extents>
     {
       if (__mul_overflow(__prod, __ext.extent(__r), &__prod))
       {
-        return false;
+        __result = false;
+        break;
       }
     }
   }
-  return true;
+  return __result;
 }
 
 // Function to check whether a set of indices are a multidimensional

--- a/libcudacxx/include/cuda/std/__mdspan/layout_left.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_left.h
@@ -146,14 +146,16 @@ public:
   {
     // avoid warning when comparing signed and unsigner integers and pick the wider of two types
     using _CommonType = common_type_t<index_type, typename _OtherMappping::index_type>;
+    bool __result     = true;
     for (rank_type __r = 0; __r != extents_type::rank(); __r++)
     {
       if (static_cast<_CommonType>(stride(__r)) != static_cast<_CommonType>(__other.stride(__r)))
       {
-        return false;
+        __result = false;
+        break;
       }
     }
-    return true;
+    return __result;
   }
 
   _CCCL_TEMPLATE(class _OtherExtents)

--- a/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
@@ -122,6 +122,7 @@ private:
     const extents_type& __ext, [[maybe_unused]] span<_OtherIndexType, extents_type::rank()> __strides)
   {
     // nvcc believes strides is unused here
+    bool __result = true;
     if constexpr (extents_type::rank() != 0)
     {
       index_type __size = 1;
@@ -130,26 +131,30 @@ private:
         // We can only check correct conversion of _OtherIndexType if it is an integral
         if (__conversion_may_overflow(__strides[__r]))
         {
-          return false;
+          __result = false;
+          break;
         }
         if (__ext.extent(__r) == index_type{0})
         {
-          return true;
+          __result = true;
+          break;
         }
 
         index_type __prod = (__ext.extent(__r) - 1);
         if (::cuda::std::__mdspan_detail::__mul_overflow(__prod, static_cast<index_type>(__strides[__r]), &__prod))
         {
-          return false;
+          __result = false;
+          break;
         }
         if (__add_overflow(__size, __prod, &__size))
         {
-          return false;
+          __result = false;
+          break;
         }
       }
     }
 
-    return true;
+    return __result;
   }
 
   // compute offset of a strided layout mapping
@@ -258,15 +263,17 @@ public:
     __bubble_sort_by_strides(__permute);
 
     // check that this permutations represents a growing set
+    bool __result = true;
     for (rank_type __i = 1; __i < __rank_; __i++)
     {
       if (static_cast<index_type>(__strides()[__permute[__i]])
           < static_cast<index_type>(__strides()[__permute[__i - 1]]) * extents().extent(__permute[__i - 1]))
       {
-        return false;
+        __result = false;
+        break;
       }
     }
-    return true;
+    return __result;
   }
   [[nodiscard]] _CCCL_API constexpr bool __check_unique_mapping(index_sequence<>) const noexcept
   {
@@ -476,14 +483,17 @@ public:
               __r_largest = __r;
             }
           }
+
+          bool __result = true;
           for (rank_type __r = 0; __r != __rank_; __r++)
           {
             if (extents().extent(__r) == 0 && __r != __r_largest)
             {
-              return false;
+              __result = false;
+              break;
             }
           }
-          return true;
+          return __result;
         }
       }
       else

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -441,6 +441,7 @@ public:
   template <size_t... _Idxs>
   [[nodiscard]] _CCCL_API constexpr bool __check_size() const noexcept
   {
+    bool __result = true;
     if constexpr (extents_type::rank() > 0) // MSVC raises a warning even with __r != extents_type::rank()
     {
       size_t __prod = 1;
@@ -449,11 +450,12 @@ public:
         const auto __extent = static_cast<size_t>(mapping().extents().extent(__r));
         if (__mdspan_detail::__mul_overflow(__prod, __extent, &__prod))
         {
-          return false;
+          __result = false;
+          break;
         }
       }
     }
-    return true;
+    return __result;
   }
 
   template <size_t... _Idxs>


### PR DESCRIPTION
tile does not allow returns inside of loops currently

So avoid them by querying the current state