### PR TITLE
[Tile] Make `arch_id` `_CCCL_HOST_DEVICE_API`

### DIFF
--- a/libcudacxx/include/cuda/__device/arch_id.h
+++ b/libcudacxx/include/cuda/__device/arch_id.h
@@ -51,29 +51,29 @@ enum class arch_id : int
     _OP) " is deprecated and will be deleted in the next major release. Compare cuda::compute_capabilities of the " \
          "given "                                                                                                   \
          "cuda::arch_id instead.")
-[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(<) _CCCL_API constexpr bool
+[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(<) _CCCL_HOST_DEVICE_API constexpr bool
 operator<(arch_id __lhs, arch_id __rhs) noexcept
 {
   return ::cuda::std::to_underlying(__lhs) < ::cuda::std::to_underlying(__rhs);
 }
-[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(<=) _CCCL_API constexpr bool
+[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(<=) _CCCL_HOST_DEVICE_API constexpr bool
 operator<=(arch_id __lhs, arch_id __rhs) noexcept
 {
   return ::cuda::std::to_underlying(__lhs) <= ::cuda::std::to_underlying(__rhs);
 }
-[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(>) _CCCL_API constexpr bool
+[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(>) _CCCL_HOST_DEVICE_API constexpr bool
 operator>(arch_id __lhs, arch_id __rhs) noexcept
 {
   return ::cuda::std::to_underlying(__lhs) > ::cuda::std::to_underlying(__rhs);
 }
-[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(>=) _CCCL_API constexpr bool
+[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(>=) _CCCL_HOST_DEVICE_API constexpr bool
 operator>=(arch_id __lhs, arch_id __rhs) noexcept
 {
   return ::cuda::std::to_underlying(__lhs) >= ::cuda::std::to_underlying(__rhs);
 }
 #undef _CCCL_DEPRECATED_ARCH_ID_COMPARISONS
 
-[[nodiscard]] _CCCL_API constexpr auto __all_arch_ids() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto __all_arch_ids() noexcept
 {
   return ::cuda::std::array{
 #define _CCCL_MAKE_ARCH_ID(_CC)          arch_id::sm_##_CC,
@@ -85,12 +85,12 @@ operator>=(arch_id __lhs, arch_id __rhs) noexcept
   };
 }
 
-[[nodiscard]] _CCCL_API constexpr bool __is_specific_arch(arch_id __arch) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr bool __is_specific_arch(arch_id __arch) noexcept
 {
   return ::cuda::std::to_underlying(__arch) > __arch_specific_id_multiplier;
 }
 
-[[nodiscard]] _CCCL_API constexpr bool __has_known_arch(compute_capability __cc) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr bool __has_known_arch(compute_capability __cc) noexcept
 {
   switch (__cc.get())
   {
@@ -103,7 +103,7 @@ operator>=(arch_id __lhs, arch_id __rhs) noexcept
   }
 }
 
-[[nodiscard]] _CCCL_API constexpr bool __has_known_specific_arch(compute_capability __cc) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr bool __has_known_specific_arch(compute_capability __cc) noexcept
 {
   switch (__cc.get())
   {
@@ -121,7 +121,7 @@ operator>=(arch_id __lhs, arch_id __rhs) noexcept
 //! @param __cc The compute capability. Must have a corresponding architecture id.
 //!
 //! @returns The architecture id.
-[[nodiscard]] _CCCL_API constexpr arch_id to_arch_id(compute_capability __cc) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_id to_arch_id(compute_capability __cc) noexcept
 {
   _CCCL_ASSERT(::cuda::__has_known_arch(__cc), "this compute capability cannot be converted to arch id");
   return static_cast<arch_id>(__cc.get());
@@ -132,7 +132,7 @@ operator>=(arch_id __lhs, arch_id __rhs) noexcept
 //! @param __cc The compute capability. Must have a corresponding architecture specific id.
 //!
 //! @returns The architecture specific id.
-[[nodiscard]] _CCCL_API constexpr arch_id to_arch_specific_id(compute_capability __cc) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_id to_arch_specific_id(compute_capability __cc) noexcept
 {
   _CCCL_ASSERT(::cuda::__has_known_specific_arch(__cc),
                "this compute capability cannot be converted to arch specific id");

--- a/libcudacxx/include/cuda/__device/arch_traits.h
+++ b/libcudacxx/include/cuda/__device/arch_traits.h
@@ -155,7 +155,7 @@ struct arch_traits_t
   bool tma_supported;
 };
 
-[[nodiscard]] _CCCL_API constexpr arch_traits_t __common_arch_traits(arch_id __arch_id) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t __common_arch_traits(arch_id __arch_id) noexcept
 {
   const compute_capability __cc{__arch_id};
 
@@ -200,10 +200,10 @@ struct arch_traits_t
 
 //! @brief Gets the architecture traits for the given architecture id \c _Id.
 template <arch_id _Id>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits() noexcept;
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits() noexcept;
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_50>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_50>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_50);
   __traits.max_resident_grids                   = 32;
@@ -216,7 +216,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_52>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_52>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_52);
   __traits.max_resident_grids                   = 32;
@@ -229,7 +229,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_53>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_53>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_53);
   __traits.max_resident_grids                   = 32;
@@ -243,7 +243,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_60>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_60>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_60);
   __traits.max_shared_memory_per_multiprocessor = 64 * 1024;
@@ -255,7 +255,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_61>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_61>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_61);
   __traits.max_shared_memory_per_multiprocessor = 96 * 1024;
@@ -267,7 +267,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_62>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_62>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_62);
   __traits.max_shared_memory_per_multiprocessor = 64 * 1024;
@@ -281,7 +281,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_70>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_70>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_70);
   __traits.max_shared_memory_per_multiprocessor = 96 * 1024;
@@ -295,7 +295,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_75>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_75>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_75);
   __traits.max_shared_memory_per_multiprocessor = 64 * 1024;
@@ -308,7 +308,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_80>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_80>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_80);
   __traits.max_shared_memory_per_multiprocessor = 164 * 1024;
@@ -321,7 +321,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_86>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_86>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_86);
   __traits.max_shared_memory_per_multiprocessor = 100 * 1024;
@@ -334,7 +334,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_87>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_87>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_87);
   __traits.max_shared_memory_per_multiprocessor = 164 * 1024;
@@ -347,7 +347,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_88>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_88>() noexcept
 {
   auto __traits                     = ::cuda::arch_traits<arch_id::sm_86>();
   __traits.arch_id                  = arch_id::sm_88;
@@ -358,7 +358,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_89>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_89>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_89);
   __traits.max_shared_memory_per_multiprocessor = 100 * 1024;
@@ -371,7 +371,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_90>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_90>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_90);
   __traits.max_shared_memory_per_multiprocessor = 228 * 1024;
@@ -385,7 +385,7 @@ template <>
 
 // No sm_90a specific fields for now.
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_90a>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_90a>() noexcept
 {
   auto __traits    = ::cuda::arch_traits<arch_id::sm_90>();
   __traits.arch_id = arch_id::sm_90a;
@@ -393,7 +393,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_100>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_100>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_90);
   __traits.max_shared_memory_per_multiprocessor = 228 * 1024;
@@ -406,7 +406,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_100a>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_100a>() noexcept
 {
   auto __traits    = ::cuda::arch_traits<arch_id::sm_100>();
   __traits.arch_id = arch_id::sm_100a;
@@ -414,7 +414,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_103>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_103>() noexcept
 {
   auto __traits                     = ::cuda::arch_traits<arch_id::sm_100>();
   __traits.arch_id                  = arch_id::sm_103;
@@ -425,7 +425,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_103a>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_103a>() noexcept
 {
   auto __traits    = ::cuda::arch_traits<arch_id::sm_103>();
   __traits.arch_id = arch_id::sm_103a;
@@ -433,7 +433,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_110>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_110>() noexcept
 {
   auto __traits                           = ::cuda::arch_traits<arch_id::sm_100>();
   __traits.arch_id                        = arch_id::sm_110;
@@ -447,7 +447,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_110a>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_110a>() noexcept
 {
   auto __traits    = ::cuda::arch_traits<arch_id::sm_110>();
   __traits.arch_id = arch_id::sm_110a;
@@ -455,7 +455,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_120>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_120>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_120);
   __traits.max_shared_memory_per_multiprocessor = 100 * 1024;
@@ -468,7 +468,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_120a>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_120a>() noexcept
 {
   auto __traits    = ::cuda::arch_traits<arch_id::sm_120>();
   __traits.arch_id = arch_id::sm_120a;
@@ -476,7 +476,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_121>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_121>() noexcept
 {
   auto __traits                     = ::cuda::arch_traits<arch_id::sm_120>();
   __traits.arch_id                  = arch_id::sm_121;
@@ -487,7 +487,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_121a>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_121a>() noexcept
 {
   auto __traits    = ::cuda::arch_traits<arch_id::sm_121>();
   __traits.arch_id = arch_id::sm_121a;
@@ -497,7 +497,7 @@ template <>
 //! @brief Gets the architecture traits for the given architecture id \c __id.
 //!
 //! @throws cuda::cuda_error if the \c __id is not a known architecture.
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits_for(arch_id __id)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits_for(arch_id __id)
 {
   switch (__id)
   {
@@ -523,7 +523,7 @@ template <>
 //! @brief Gets the architecture traits for the given compute capability \c __cc.
 //!
 //! @throws cuda::cuda_error if the \c __cc doesn't have a corresponding architecture id.
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits_for(compute_capability __cc)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits_for(compute_capability __cc)
 {
   return ::cuda::arch_traits_for(::cuda::to_arch_id(__cc));
 }

--- a/libcudacxx/include/cuda/__device/compute_capability.h
+++ b/libcudacxx/include/cuda/__device/compute_capability.h
@@ -42,7 +42,7 @@ public:
   //! @brief Constructs the object from compute capability \c __cc. The expected format is 10 * major + minor.
   //!
   //! @param __cc Compute capability.
-  _CCCL_API explicit constexpr compute_capability(int __cc) noexcept
+  _CCCL_HOST_DEVICE_API explicit constexpr compute_capability(int __cc) noexcept
       : __cc_{__cc}
   {}
 
@@ -50,7 +50,7 @@ public:
   //!
   //! @param __major The major compute capability.
   //! @param __minor The minor compute capability. Must be less than 10.
-  _CCCL_API constexpr compute_capability(int __major, int __minor) noexcept
+  _CCCL_HOST_DEVICE_API constexpr compute_capability(int __major, int __minor) noexcept
       : __cc_{10 * __major + __minor}
   {
     _CCCL_ASSERT(__minor < 10, "invalid minor compute capability");
@@ -59,7 +59,7 @@ public:
   //! @brief Constructs the object from the architecture id.
   //!
   //! @param __arch_id The architecture id.
-  _CCCL_API explicit constexpr compute_capability(arch_id __arch_id) noexcept
+  _CCCL_HOST_DEVICE_API explicit constexpr compute_capability(arch_id __arch_id) noexcept
   {
     const auto __val = ::cuda::std::to_underlying(__arch_id);
     if (__val > __arch_specific_id_multiplier)
@@ -79,7 +79,7 @@ public:
   //! @brief Gets the stored compute capability.
   //!
   //! @return The stored compute capability in format 10 * major + minor.
-  [[nodiscard]] _CCCL_API constexpr int get() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr int get() const noexcept
   {
     return __cc_;
   }
@@ -93,7 +93,7 @@ public:
   [[nodiscard]]
   CCCL_DEPRECATED_BECAUSE("This symbol is deprecated because it collides with major(...) macro defined in "
                           "<sys/sysmacros.h> and will be removed in next major release. Use cc.major_cap() instead.")
-  _CCCL_API constexpr int major() const noexcept
+  _CCCL_HOST_DEVICE_API constexpr int major() const noexcept
   {
     return major_cap();
   }
@@ -101,7 +101,7 @@ public:
   //! @brief Gets the major compute capability.
   //!
   //! @return Major compute capability.
-  [[nodiscard]] _CCCL_API constexpr int major_cap() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr int major_cap() const noexcept
   {
     return __cc_ / 10;
   }
@@ -115,7 +115,7 @@ public:
   [[nodiscard]]
   CCCL_DEPRECATED_BECAUSE("This symbol is deprecated because it collides with minor(...) macro defined in "
                           "<sys/sysmacros.h> and will be removed in next major release. Use cc.minor_cap() instead.")
-  _CCCL_API constexpr int minor() const noexcept
+  _CCCL_HOST_DEVICE_API constexpr int minor() const noexcept
   {
     return minor_cap();
   }
@@ -123,7 +123,7 @@ public:
   //! @brief Gets the minor compute capability.
   //!
   //! @return Minor compute capability. The value is always less than 10.
-  [[nodiscard]] _CCCL_API constexpr int minor_cap() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr int minor_cap() const noexcept
   {
     return __cc_ % 10;
   }
@@ -131,62 +131,68 @@ public:
   //! @brief Conversion operator to \c int.
   //!
   //! @return The stored compute capability in format 10 * major + minor.
-  _CCCL_API explicit constexpr operator int() const noexcept
+  _CCCL_HOST_DEVICE_API explicit constexpr operator int() const noexcept
   {
     return __cc_;
   }
 
   //! @brief Equality operator.
-  [[nodiscard]] _CCCL_API friend constexpr bool operator==(compute_capability __lhs, compute_capability __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator==(compute_capability __lhs, compute_capability __rhs) noexcept
   {
     return __lhs.__cc_ == __rhs.__cc_;
   }
 
   //! @brief Inequality operator.
-  [[nodiscard]] _CCCL_API friend constexpr bool operator!=(compute_capability __lhs, compute_capability __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator!=(compute_capability __lhs, compute_capability __rhs) noexcept
   {
     return __lhs.__cc_ != __rhs.__cc_;
   }
 
   //! @brief Less than operator.
-  [[nodiscard]] _CCCL_API friend constexpr bool operator<(compute_capability __lhs, compute_capability __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator<(compute_capability __lhs, compute_capability __rhs) noexcept
   {
     return __lhs.__cc_ < __rhs.__cc_;
   }
 
   //! @brief Less than or equal to operator.
-  [[nodiscard]] _CCCL_API friend constexpr bool operator<=(compute_capability __lhs, compute_capability __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator<=(compute_capability __lhs, compute_capability __rhs) noexcept
   {
     return __lhs.__cc_ <= __rhs.__cc_;
   }
 
   //! @brief Greater than operator.
-  [[nodiscard]] _CCCL_API friend constexpr bool operator>(compute_capability __lhs, compute_capability __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator>(compute_capability __lhs, compute_capability __rhs) noexcept
   {
     return __lhs.__cc_ > __rhs.__cc_;
   }
 
   //! @brief Greater than or equal to operator.
-  [[nodiscard]] _CCCL_API friend constexpr bool operator>=(compute_capability __lhs, compute_capability __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator>=(compute_capability __lhs, compute_capability __rhs) noexcept
   {
     return __lhs.__cc_ >= __rhs.__cc_;
   }
 };
 
 template <int... _Vs>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __make_all_compute_capabilities() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API _CCCL_CONSTEVAL auto __make_all_compute_capabilities() noexcept
 {
   return ::cuda::std::array{compute_capability{_Vs}...};
 }
 
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __all_compute_capabilities() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API _CCCL_CONSTEVAL auto __all_compute_capabilities() noexcept
 {
   return ::cuda::__make_all_compute_capabilities<_CCCL_KNOWN_CUDA_ARCH_LIST>();
 }
 
 #if _CCCL_CUDA_COMPILATION()
 template <int... _Vs>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __make_cc_list() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API _CCCL_CONSTEVAL auto __make_cc_list() noexcept
 {
 #  if defined(__CUDA_ARCH_LIST__)
   return ::cuda::std::array{compute_capability{_Vs / 10}...};
@@ -199,7 +205,7 @@ template <int... _Vs>
 #  endif // ^^^ no arch list ^^^
 }
 
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __target_compute_capabilities() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API _CCCL_CONSTEVAL auto __target_compute_capabilities() noexcept
 {
 #  if defined(__CUDA_ARCH_LIST__)
   return ::cuda::__make_cc_list<__CUDA_ARCH_LIST__>();

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/all_arch_ids.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/all_arch_ids.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: return in loop statement is not supported
+
 #include <cuda/devices>
 #include <cuda/std/array>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_id.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_id.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: return in loop statement is not supported
+
 #include <cuda/devices>
 #include <cuda/std/cassert>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_id_fmt.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_id_fmt.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: return in loop statement is not supported
+
 #include <cuda/devices>
 
 #if __cpp_lib_format >= 201907L

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/compute_capability.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/compute_capability.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: return in loop statement is not supported
+
 // ADDITIONAL_COMPILE_DEFINITIONS: CCCL_IGNORE_DEPRECATED_API
 
 #include <cuda/devices>

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/compute_capability_fmt.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/compute_capability_fmt.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: return in loop statement is not supported
+
 #include <cuda/devices>
 
 #if __cpp_lib_format >= 201907L

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/is_specific_arch.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/is_specific_arch.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: return in loop statement is not supported
+
 #include <cuda/devices>
 #include <cuda/std/array>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/target_compute_capabilities.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/target_compute_capabilities.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: return in loop statement is not supported
+
 #include <cuda/devices>
 #include <cuda/std/array>
 #include <cuda/std/cassert>


### PR DESCRIPTION
It relies on returns inside switch statements, which is currently not supported
