### PR TITLE
[Tile] Mark threading support as `_CCCL_HOST_DEVICE_API`

### DIFF
--- a/libcudacxx/include/cuda/std/__thread/threading_support.h
+++ b/libcudacxx/include/cuda/std/__thread/threading_support.h
@@ -51,13 +51,13 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 #  define __LIBCUDACXX_ASM_THREAD_YIELD (;)
 #endif // ! _CCCL_ARCH(X86_64)
 
-_CCCL_API inline void __cccl_thread_yield_processor()
+_CCCL_HOST_DEVICE_API inline void __cccl_thread_yield_processor()
 {
   NV_IF_TARGET(NV_IS_HOST, __LIBCUDACXX_ASM_THREAD_YIELD)
 }
 
 template <class _Fn>
-_CCCL_API inline bool __cccl_thread_poll_with_backoff(
+_CCCL_HOST_DEVICE_API inline bool __cccl_thread_poll_with_backoff(
   _Fn&& __f, ::cuda::std::chrono::nanoseconds __max = ::cuda::std::chrono::nanoseconds::zero())
 {
   ::cuda::std::chrono::high_resolution_clock::time_point const __start =

--- a/libcudacxx/include/cuda/std/__thread/threading_support_cuda.h
+++ b/libcudacxx/include/cuda/std/__thread/threading_support_cuda.h
@@ -29,9 +29,9 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-_CCCL_API inline void __cccl_thread_yield() {}
+_CCCL_HOST_DEVICE_API inline void __cccl_thread_yield() {}
 
-_CCCL_API inline void __cccl_thread_sleep_for(::cuda::std::chrono::nanoseconds __ns){
+_CCCL_HOST_DEVICE_API inline void __cccl_thread_sleep_for(::cuda::std::chrono::nanoseconds __ns){
   NV_IF_TARGET(NV_PROVIDES_SM_70, ({
                  auto const __step = __ns.count();
                  _CCCL_ASSERT(__step < numeric_limits<unsigned>::max(), "invalid nanoseconds count");

--- a/libcudacxx/include/cuda/std/__thread/threading_support_external.h
+++ b/libcudacxx/include/cuda/std/__thread/threading_support_external.h
@@ -28,9 +28,9 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-_CCCL_API inline void __cccl_thread_yield();
+_CCCL_HOST_DEVICE_API inline void __cccl_thread_yield();
 
-_CCCL_API inline void __cccl_thread_sleep_for(::cuda::std::chrono::nanoseconds __ns);
+_CCCL_HOST_DEVICE_API inline void __cccl_thread_sleep_for(::cuda::std::chrono::nanoseconds __ns);
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__thread/threading_support_pthread.h
+++ b/libcudacxx/include/cuda/std/__thread/threading_support_pthread.h
@@ -73,7 +73,7 @@ using __cccl_tls_key = pthread_key_t;
 
 #  define _LIBCUDACXX_TLS_DESTRUCTOR_CC
 
-[[nodiscard]] _CCCL_API constexpr timespec __cccl_to_timespec(const ::cuda::std::chrono::nanoseconds& __ns)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr timespec __cccl_to_timespec(const ::cuda::std::chrono::nanoseconds& __ns)
 {
   constexpr auto __ts_sec_max = numeric_limits<time_t>::max();
 
@@ -95,39 +95,39 @@ using __cccl_tls_key = pthread_key_t;
 
 // Semaphore
 
-_CCCL_API inline bool __cccl_semaphore_init(__cccl_semaphore_t* __sem, int __init)
+_CCCL_HOST_DEVICE_API inline bool __cccl_semaphore_init(__cccl_semaphore_t* __sem, int __init)
 {
   return sem_init(__sem, 0, __init) == 0;
 }
 
-_CCCL_API inline bool __cccl_semaphore_destroy(__cccl_semaphore_t* __sem)
+_CCCL_HOST_DEVICE_API inline bool __cccl_semaphore_destroy(__cccl_semaphore_t* __sem)
 {
   return sem_destroy(__sem) == 0;
 }
 
-_CCCL_API inline bool __cccl_semaphore_post(__cccl_semaphore_t* __sem)
+_CCCL_HOST_DEVICE_API inline bool __cccl_semaphore_post(__cccl_semaphore_t* __sem)
 {
   return sem_post(__sem) == 0;
 }
 
-_CCCL_API inline bool __cccl_semaphore_wait(__cccl_semaphore_t* __sem)
+_CCCL_HOST_DEVICE_API inline bool __cccl_semaphore_wait(__cccl_semaphore_t* __sem)
 {
   return sem_wait(__sem) == 0;
 }
 
-_CCCL_API inline bool
+_CCCL_HOST_DEVICE_API inline bool
 __cccl_semaphore_wait_timed(__cccl_semaphore_t* __sem, ::cuda::std::chrono::nanoseconds const& __ns)
 {
   const auto __ts = __cccl_to_timespec(__ns);
   return sem_timedwait(__sem, &__ts) == 0;
 }
 
-_CCCL_API inline void __cccl_thread_yield()
+_CCCL_HOST_DEVICE_API inline void __cccl_thread_yield()
 {
   sched_yield();
 }
 
-_CCCL_API inline void __cccl_thread_sleep_for(::cuda::std::chrono::nanoseconds __ns)
+_CCCL_HOST_DEVICE_API inline void __cccl_thread_sleep_for(::cuda::std::chrono::nanoseconds __ns)
 {
   auto __ts = __cccl_to_timespec(__ns);
   while (nanosleep(&__ts, &__ts) == -1 && errno == EINTR)

--- a/libcudacxx/include/cuda/std/__thread/threading_support_win32.h
+++ b/libcudacxx/include/cuda/std/__thread/threading_support_win32.h
@@ -65,12 +65,12 @@ using __cccl_tls_key = long;
 
 #  define _LIBCUDACXX_TLS_DESTRUCTOR_CC __stdcall
 
-_CCCL_API inline void __cccl_thread_yield()
+_CCCL_HOST_DEVICE_API inline void __cccl_thread_yield()
 {
   SwitchToThread();
 }
 
-_CCCL_API inline void __cccl_thread_sleep_for(chrono::nanoseconds __ns)
+_CCCL_HOST_DEVICE_API inline void __cccl_thread_sleep_for(chrono::nanoseconds __ns)
 {
   using namespace chrono;
   // round-up to the nearest millisecond


### PR DESCRIPTION
In tile all the concurency is done by compiler
