### PR TITLE
[Tile] Avoid returns in loops in string functions

### DIFF
--- a/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
+++ b/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
@@ -168,17 +168,19 @@ template <class _CharT>
 {
   using _UCharT = __make_nbit_uint_t<sizeof(_CharT) * CHAR_BIT>;
 
+  bool __reached_end = false;
   while (*__lhs == *__rhs)
   {
     if (*__lhs == _CharT('\0'))
     {
-      return 0;
+      __reached_end = true;
+      break;
     }
 
     ++__lhs;
     ++__rhs;
   }
-  return (static_cast<_UCharT>(*__lhs) < static_cast<_UCharT>(*__rhs)) ? -1 : 1;
+  return __reached_end ? 0 : (static_cast<_UCharT>(*__lhs) < static_cast<_UCharT>(*__rhs)) ? -1 : 1;
 }
 
 #if !_CCCL_COMPILER(NVRTC)
@@ -214,22 +216,24 @@ __cccl_strncmp_impl_constexpr(const _CharT* __lhs, const _CharT* __rhs, size_t _
 {
   using _UCharT = __make_nbit_uint_t<sizeof(_CharT) * CHAR_BIT>;
 
+  int __result = 0;
   while (__n--)
   {
     if (*__lhs != *__rhs)
     {
-      return (static_cast<_UCharT>(*__lhs) < static_cast<_UCharT>(*__rhs)) ? -1 : 1;
+      __result = (static_cast<_UCharT>(*__lhs) < static_cast<_UCharT>(*__rhs)) ? -1 : 1;
+      break;
     }
 
     if (*__lhs == _CharT('\0'))
     {
-      return 0;
+      break;
     }
 
     ++__lhs;
     ++__rhs;
   }
-  return 0;
+  return __result;
 }
 
 #if !_CCCL_COMPILER(NVRTC)
@@ -262,15 +266,17 @@ template <class _CharT>
 template <class _CharT>
 [[nodiscard]] _CCCL_API constexpr _CharT* __cccl_strchr_impl_constexpr(_CharT* __ptr, _CharT __c) noexcept
 {
+  bool __reached_end = false;
   while (*__ptr != __c)
   {
     if (*__ptr == _CharT('\0'))
     {
-      return nullptr;
+      __reached_end = true;
+      break;
     }
     ++__ptr;
   }
-  return __ptr;
+  return __reached_end ? nullptr : __ptr;
 }
 
 #if !_CCCL_COMPILER(NVRTC)
@@ -354,15 +360,17 @@ template <class _CharT>
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp* __cccl_memchr_impl_constexpr(_Tp* __ptr, _Tp __c, size_t __n) noexcept
 {
+  _Tp* __result = nullptr;
   while (__n--)
   {
     if (*__ptr == __c)
     {
-      return __ptr;
+      __result = __ptr;
+      break;
     }
     ++__ptr;
   }
-  return nullptr;
+  return __result;
 }
 
 #if !_CCCL_COMPILER(NVRTC)
@@ -450,16 +458,18 @@ __cccl_memcmp_impl_constexpr(const _Tp* __lhs, const _Tp* __rhs, size_t __n) noe
 {
   using _Up = __make_nbit_uint_t<sizeof(_Tp) * CHAR_BIT>;
 
+  int __result = 0;
   while (__n--)
   {
     if (*__lhs != *__rhs)
     {
-      return static_cast<_Up>(*__lhs) < static_cast<_Up>(*__rhs) ? -1 : 1;
+      __result = static_cast<_Up>(*__lhs) < static_cast<_Up>(*__rhs) ? -1 : 1;
+      break;
     }
     ++__lhs;
     ++__rhs;
   }
-  return 0;
+  return __result;
 }
 
 #if !_CCCL_COMPILER(NVRTC)

--- a/libcudacxx/include/cuda/std/__string/helper_functions.h
+++ b/libcudacxx/include/cuda/std/__string/helper_functions.h
@@ -73,14 +73,16 @@ __cccl_search_substring(const _CharT* __first1, const _CharT* __last1, const _Ch
     // Check whether __first1 still has at least __len2 bytes.
     if (__len1 < __len2)
     {
-      return __last1;
+      // return __last1;
+      break;
     }
 
     // Find __f2 the first byte matching in __first1.
     __first1 = _Traits::find(__first1, __len1 - __len2 + 1, __f2);
     if (__first1 == 0)
     {
-      return __last1;
+      // return __last1;
+      break;
     }
 
     // It is faster to compare from the first byte of __first1 even if we
@@ -90,11 +92,14 @@ __cccl_search_substring(const _CharT* __first1, const _CharT* __last1, const _Ch
     // the string.
     if (_Traits::compare(__first1, __first2, __len2) == 0)
     {
-      return __first1;
+      // return __first1;
+      __last1 = __first1;
+      break;
     }
 
     ++__first1;
   }
+  return __last1;
 }
 
 template <class _CharT, class _SizeT, class _Traits, _SizeT __npos>
@@ -135,14 +140,16 @@ _CCCL_API constexpr _SizeT __cccl_str_rfind(const _CharT* __p, _SizeT __sz, _Cha
   {
     __pos = __sz;
   }
+  _SizeT __result = __npos;
   for (const _CharT* __ps = __p + __pos; __ps != __p;)
   {
     if (_Traits::eq(*--__ps, __c))
     {
-      return static_cast<_SizeT>(__ps - __p);
+      __result = static_cast<_SizeT>(__ps - __p);
+      break;
     }
   }
-  return __npos;
+  return __result;
 }
 
 template <class _CharT, class _SizeT, class _Traits, _SizeT __npos>
@@ -199,14 +206,16 @@ __cccl_str_find_last_of(const _CharT* __p, _SizeT __sz, const _CharT* __s, _Size
   {
     __pos = __sz;
   }
+  _SizeT __result = __npos;
   for (const _CharT* __ps = __p + __pos; __ps != __p;)
   {
     if (_Traits::find(__s, __n, *--__ps) != nullptr)
     {
-      return static_cast<_SizeT>(__ps - __p);
+      __result = static_cast<_SizeT>(__ps - __p);
+      break;
     }
   }
-  return __npos;
+  return __result;
 }
 
 template <class _CharT, class _SizeT, class _Traits, _SizeT __npos>
@@ -218,20 +227,23 @@ __cccl_str_find_first_not_of(const _CharT* __p, _SizeT __sz, const _CharT* __s, 
     return __npos;
   }
   const _CharT* __pe = __p + __sz;
+  _SizeT __result    = __npos;
   for (const _CharT* __ps = __p + __pos; __ps != __pe; ++__ps)
   {
     if (_Traits::find(__s, __n, *__ps) == nullptr)
     {
-      return static_cast<_SizeT>(__ps - __p);
+      __result = static_cast<_SizeT>(__ps - __p);
+      break;
     }
   }
-  return __npos;
+  return __result;
 }
 
 template <class _CharT, class _SizeT, class _Traits, _SizeT __npos>
 _CCCL_API constexpr _SizeT
 __cccl_str_find_first_not_of(const _CharT* __p, _SizeT __sz, _CharT __c, _SizeT __pos) noexcept
 {
+  _SizeT __result = __npos;
   if (__pos < __sz)
   {
     const _CharT* __pe = __p + __sz;
@@ -239,11 +251,12 @@ __cccl_str_find_first_not_of(const _CharT* __p, _SizeT __sz, _CharT __c, _SizeT 
     {
       if (!_Traits::eq(*__ps, __c))
       {
-        return static_cast<_SizeT>(__ps - __p);
+        __result = static_cast<_SizeT>(__ps - __p);
+        break;
       }
     }
   }
-  return __npos;
+  return __result;
 }
 
 template <class _CharT, class _SizeT, class _Traits, _SizeT __npos>
@@ -258,14 +271,17 @@ __cccl_str_find_last_not_of(const _CharT* __p, _SizeT __sz, const _CharT* __s, _
   {
     __pos = __sz;
   }
+
+  _SizeT __result = __npos;
   for (const _CharT* __ps = __p + __pos; __ps != __p;)
   {
     if (_Traits::find(__s, __n, *--__ps) == nullptr)
     {
-      return static_cast<_SizeT>(__ps - __p);
+      __result = static_cast<_SizeT>(__ps - __p);
+      break;
     }
   }
-  return __npos;
+  return __result;
 }
 
 template <class _CharT, class _SizeT, class _Traits, _SizeT __npos>
@@ -279,14 +295,16 @@ _CCCL_API constexpr _SizeT __cccl_str_find_last_not_of(const _CharT* __p, _SizeT
   {
     __pos = __sz;
   }
+  _SizeT __result = __npos;
   for (const _CharT* __ps = __p + __pos; __ps != __p;)
   {
     if (!_Traits::eq(*--__ps, __c))
     {
-      return static_cast<_SizeT>(__ps - __p);
+      __result = static_cast<_SizeT>(__ps - __p);
+      break;
     }
   }
-  return __npos;
+  return __result;
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__string/string_view.h
+++ b/libcudacxx/include/cuda/std/__string/string_view.h
@@ -80,17 +80,20 @@ private:
   [[nodiscard]] _CCCL_API static constexpr int
   __compare_(char const* __s1, size_t __len1, char const* __s2, size_t __len2, size_t __n) noexcept
   {
+    int __result = int(__len1) - int(__len2);
     if (__n)
     {
       for (;; ++__s1, ++__s2)
       {
         if (*__s1 < *__s2)
         {
-          return -1;
+          __result = -1;
+          break;
         }
         if (*__s2 < *__s1)
         {
-          return 1;
+          __result = 1;
+          break;
         }
         if (0 == --__n)
         {
@@ -98,14 +101,15 @@ private:
         }
       }
     }
-    return int(__len1) - int(__len2);
+    return __result;
   }
 
   template <bool _Forward>
   [[nodiscard]] _CCCL_API static constexpr ptrdiff_t
   __find(const char* __needle, size_t __needle_size, const char* __haystack_begin, const char* __haystack_end) noexcept
   {
-    char const* __it = __haystack_begin;
+    ptrdiff_t __result = -1;
+    char const* __it   = __haystack_begin;
     for (; __it != __haystack_end; (_Forward ? ++__it : --__it))
     {
       size_t __i = 0;
@@ -118,10 +122,11 @@ private:
       }
       if (__i == __needle_size)
       {
-        return _Forward ? __it - __haystack_begin : __it - __haystack_end - 1;
+        __result = _Forward ? __it - __haystack_begin : __it - __haystack_end - 1;
+        break;
       }
     }
-    return -1;
+    return __result;
   }
 
 public:


### PR DESCRIPTION
tile does not allow return statements inside loops, so avoid them when possible