### PR TITLE
[Tile] Avoid return in loop in `variant`

### DIFF
--- a/libcudacxx/include/cuda/std/__variant/variant_constraints.h
+++ b/libcudacxx/include/cuda/std/__variant/variant_constraints.h
@@ -52,7 +52,8 @@ _CCCL_API constexpr size_t __find_index()
     {
       if (__result != __not_found)
       {
-        return __ambiguous;
+        __result = __ambiguous;
+        break;
       }
       __result = __i;
     }


### PR DESCRIPTION
tile does not allow return statements in loops, so avoid them
