### PR TITLE
[Tile] Mark some algorithms as `_CCCL_HOST_DEVICE_API`

### DIFF
--- a/docs/libcudacxx/tile.rst
+++ b/docs/libcudacxx/tile.rst
@@ -52,7 +52,7 @@ C++ mathematical operations
 
 We rely heavily on compiler builtins or cuda runtime functions to implement C++ standard math functions such
 as ``cuda::std::exp``. Those compiler builtins are not currently supported in tile mode, so the following headers
-are mostly unsupported:
+are mostly unsupported in a tile kernel:
 
     - <cuda/std/cmath>
     - <cuda/std/complex>
@@ -64,7 +64,26 @@ C++ customization point objects
 The standard library uses __ Customization Point Objects __ to enable user-customization of the behavior of many
 algorithms and ranges. We rely heavily on those for most of our iterator machinery such as e.g `cuda::std::begin`.
 
-Those CPOs are currently not accessible in a tile program.
+Those CPOs are currently not accessible in a tile kernel.
+
+C++ return statements in loops and switches
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tile currently does not support return statements inside of a ``switch`` or a loop. We can work around most places but
+not all. This mainly affects algorithms and arch traits.
+
+In ``<cuda/std/algorithm>`` the following algorithms are not supported in a tile kernel
+
+    - ``cuda::std::equal_range``
+    - ``cuda::std::find_end``
+    - ``cuda::std::find_first_of``
+    - ``cuda::std::partition``
+    - ``cuda::std::search``
+    - ``cuda::std::search_n``
+
+Besides that the content of the following headers is unsupported in a tile program
+
+    - ``<cuda/std/devices>``
 
 
 CUDA device intrinsics

--- a/libcudacxx/include/cuda/std/__algorithm/equal_range.h
+++ b/libcudacxx/include/cuda/std/__algorithm/equal_range.h
@@ -43,7 +43,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Compare, class _Iter, class _Sent, class _Tp, class _Proj>
-_CCCL_API constexpr pair<_Iter, _Iter>
+_CCCL_HOST_DEVICE_API constexpr pair<_Iter, _Iter>
 __equal_range(_Iter __first, _Sent __last, const _Tp& __value, _Compare&& __comp, _Proj&& __proj)
 {
   auto __len  = _IterOps<_AlgPolicy>::distance(__first, __last);
@@ -74,7 +74,7 @@ __equal_range(_Iter __first, _Sent __last, const _Tp& __value, _Compare&& __comp
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Tp, class _Compare>
-[[nodiscard]] _CCCL_API constexpr pair<_ForwardIterator, _ForwardIterator>
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr pair<_ForwardIterator, _ForwardIterator>
 equal_range(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, _Compare __comp)
 {
   static_assert(__is_callable<_Compare, decltype(*__first), const _Tp&>::value, "The comparator has to be callable");
@@ -88,7 +88,7 @@ equal_range(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __valu
 }
 
 template <class _ForwardIterator, class _Tp>
-[[nodiscard]] _CCCL_API constexpr pair<_ForwardIterator, _ForwardIterator>
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr pair<_ForwardIterator, _ForwardIterator>
 equal_range(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
 {
   return ::cuda::std::equal_range(::cuda::std::move(__first), ::cuda::std::move(__last), __value, __less{});

--- a/libcudacxx/include/cuda/std/__algorithm/find_end.h
+++ b/libcudacxx/include/cuda/std/__algorithm/find_end.h
@@ -30,7 +30,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterator2>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator1 __find_end(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator1 __find_end(
   _ForwardIterator1 __first1,
   _ForwardIterator1 __last1,
   _ForwardIterator2 __first2,
@@ -85,7 +85,7 @@ template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterato
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _BidirectionalIterator1, class _BidirectionalIterator2>
-[[nodiscard]] _CCCL_API constexpr _BidirectionalIterator1 __find_end(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _BidirectionalIterator1 __find_end(
   _BidirectionalIterator1 __first1,
   _BidirectionalIterator1 __last1,
   _BidirectionalIterator2 __first2,
@@ -139,7 +139,7 @@ template <class _BinaryPredicate, class _BidirectionalIterator1, class _Bidirect
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _RandomAccessIterator1, class _RandomAccessIterator2>
-[[nodiscard]] _CCCL_API constexpr _RandomAccessIterator1 __find_end(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _RandomAccessIterator1 __find_end(
   _RandomAccessIterator1 __first1,
   _RandomAccessIterator1 __last1,
   _RandomAccessIterator2 __first2,
@@ -194,7 +194,7 @@ template <class _BinaryPredicate, class _RandomAccessIterator1, class _RandomAcc
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator1 find_end(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator1 find_end(
   _ForwardIterator1 __first1,
   _ForwardIterator1 __last1,
   _ForwardIterator2 __first2,
@@ -212,7 +212,7 @@ template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredica
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator1
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator1
 find_end(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2)
 {
   return ::cuda::std::find_end(__first1, __last1, __first2, __last2, __equal_to{});

--- a/libcudacxx/include/cuda/std/__algorithm/find_first_of.h
+++ b/libcudacxx/include/cuda/std/__algorithm/find_first_of.h
@@ -28,7 +28,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator1 __find_first_of_ce(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator1 __find_first_of_ce(
   _ForwardIterator1 __first1,
   _ForwardIterator1 __last1,
   _ForwardIterator2 __first2,
@@ -49,7 +49,7 @@ template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredica
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator1 find_first_of(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator1 find_first_of(
   _ForwardIterator1 __first1,
   _ForwardIterator1 __last1,
   _ForwardIterator2 __first2,
@@ -60,7 +60,7 @@ template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredica
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator1 find_first_of(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator1 find_first_of(
   _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2)
 {
   return ::cuda::std::__find_first_of_ce(__first1, __last1, __first2, __last2, __equal_to{});

--- a/libcudacxx/include/cuda/std/__algorithm/partition.h
+++ b/libcudacxx/include/cuda/std/__algorithm/partition.h
@@ -32,7 +32,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Predicate, class _AlgPolicy, class _ForwardIterator, class _Sentinel>
-_CCCL_API constexpr pair<_ForwardIterator, _ForwardIterator>
+_CCCL_HOST_DEVICE_API constexpr pair<_ForwardIterator, _ForwardIterator>
 __partition_impl(_ForwardIterator __first, _Sentinel __last, _Predicate __pred, forward_iterator_tag)
 {
   while (true)
@@ -62,7 +62,7 @@ __partition_impl(_ForwardIterator __first, _Sentinel __last, _Predicate __pred, 
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Predicate, class _AlgPolicy, class _BidirectionalIterator, class _Sentinel>
-_CCCL_API constexpr pair<_BidirectionalIterator, _BidirectionalIterator>
+_CCCL_HOST_DEVICE_API constexpr pair<_BidirectionalIterator, _BidirectionalIterator>
 __partition_impl(_BidirectionalIterator __first, _Sentinel __sentinel, _Predicate __pred, bidirectional_iterator_tag)
 {
   _BidirectionalIterator __original_last = _IterOps<_AlgPolicy>::next(__first, __sentinel);
@@ -96,7 +96,7 @@ __partition_impl(_BidirectionalIterator __first, _Sentinel __sentinel, _Predicat
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _ForwardIterator, class _Sentinel, class _Predicate, class _IterCategory>
-_CCCL_API constexpr pair<_ForwardIterator, _ForwardIterator>
+_CCCL_HOST_DEVICE_API constexpr pair<_ForwardIterator, _ForwardIterator>
 __partition(_ForwardIterator __first, _Sentinel __last, _Predicate&& __pred, _IterCategory __iter_category)
 {
   return ::cuda::std::__partition_impl<remove_cvref_t<_Predicate>&, _AlgPolicy>(
@@ -105,7 +105,8 @@ __partition(_ForwardIterator __first, _Sentinel __last, _Predicate&& __pred, _It
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Predicate>
-_CCCL_API constexpr _ForwardIterator partition(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)
+_CCCL_HOST_DEVICE_API constexpr _ForwardIterator
+partition(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)
 {
   using _IterCategory = __iterator_traits_category_or_concept_t<_ForwardIterator>;
   auto __result       = ::cuda::std::__partition<_ClassicAlgPolicy>(

--- a/libcudacxx/include/cuda/std/__algorithm/search.h
+++ b/libcudacxx/include/cuda/std/__algorithm/search.h
@@ -36,7 +36,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterator2>
-[[nodiscard]] _CCCL_API constexpr pair<_ForwardIterator1, _ForwardIterator1> __search(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr pair<_ForwardIterator1, _ForwardIterator1> __search(
   _ForwardIterator1 __first1,
   _ForwardIterator1 __last1,
   _ForwardIterator2 __first2,
@@ -88,7 +88,7 @@ template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterato
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _RandomAccessIterator1, class _RandomAccessIterator2>
-[[nodiscard]] _CCCL_API constexpr pair<_RandomAccessIterator1, _RandomAccessIterator1> __search(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr pair<_RandomAccessIterator1, _RandomAccessIterator1> __search(
   _RandomAccessIterator1 __first1,
   _RandomAccessIterator1 __last1,
   _RandomAccessIterator2 __first2,
@@ -146,7 +146,7 @@ template <class _BinaryPredicate, class _RandomAccessIterator1, class _RandomAcc
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator1
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator1
 search(_ForwardIterator1 __first1,
        _ForwardIterator1 __last1,
        _ForwardIterator2 __first2,
@@ -165,14 +165,14 @@ search(_ForwardIterator1 __first1,
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator1
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator1
 search(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2)
 {
   return ::cuda::std::search(__first1, __last1, __first2, __last2, __equal_to{});
 }
 
 template <class _ForwardIterator, class _Searcher>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator
 search(_ForwardIterator __f, _ForwardIterator __l, const _Searcher& __s)
 {
   return __s(__f, __l).first;

--- a/libcudacxx/include/cuda/std/__algorithm/search_n.h
+++ b/libcudacxx/include/cuda/std/__algorithm/search_n.h
@@ -31,7 +31,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _ForwardIterator, class _Size, class _Tp>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator __search_n(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator __search_n(
   _ForwardIterator __first,
   _ForwardIterator __last,
   _Size __count,
@@ -83,7 +83,7 @@ template <class _BinaryPredicate, class _ForwardIterator, class _Size, class _Tp
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _RandomAccessIterator, class _Size, class _Tp>
-[[nodiscard]] _CCCL_API constexpr _RandomAccessIterator __search_n(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _RandomAccessIterator __search_n(
   _RandomAccessIterator __first,
   _RandomAccessIterator __last,
   _Size __count,
@@ -137,7 +137,7 @@ template <class _BinaryPredicate, class _RandomAccessIterator, class _Size, clas
 }
 
 template <class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator
 search_n(_ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value_, _BinaryPredicate __pred)
 {
   return ::cuda::std::__search_n<add_lvalue_reference_t<_BinaryPredicate>>(
@@ -150,7 +150,7 @@ search_n(_ForwardIterator __first, _ForwardIterator __last, _Size __count, const
 }
 
 template <class _ForwardIterator, class _Size, class _Tp>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator
 search_n(_ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value_)
 {
   return ::cuda::std::search_n(__first, __last, __convert_to_integral(__count), __value_, __equal_to{});

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/equal_range.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/equal_range.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 #include <cuda/std/algorithm.equal_range.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_end.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 #include <cuda/std/algorithm.find_end.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_first_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_first_of.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 #include <cuda/std/algorithm.find_first_of.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 #include <cuda/std/algorithm.partition.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/search.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/search.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 #include <cuda/std/algorithm.search.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/search_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/search_n.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 #include <cuda/std/algorithm.search_n.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.end/find_end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.end/find_end.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <algorithm>
 
 // template<ForwardIterator Iter1, ForwardIterator Iter2>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.end/find_end_pred.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.end/find_end_pred.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <algorithm>
 
 // template<ForwardIterator Iter1, ForwardIterator Iter2,

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.first.of/find_first_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.first.of/find_first_of.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <algorithm>
 
 // template<InputIterator Iter1, ForwardIterator Iter2>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.first.of/find_first_of_pred.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.first.of/find_first_of_pred.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <algorithm>
 
 // template<InputIterator Iter1, ForwardIterator Iter2,

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <algorithm>
 
 // template<ForwardIterator Iter1, ForwardIterator Iter2>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search_n.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <algorithm>
 
 // template<class ForwardIterator, class Size, class T>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search_n_pred.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search_n_pred.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <algorithm>
 
 // template<class ForwardIterator, class Size, class T, class BinaryPredicate>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search_pred.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search_pred.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <algorithm>
 
 // template<ForwardIterator Iter1, ForwardIterator Iter2>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // CONSTEXPR_STEPS: 15000000
 
 // <algorithm>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range_comp.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // CONSTEXPR_STEPS: 15000000
 
 // <algorithm>


### PR DESCRIPTION
tile does not support return statements inside loops. For some algorithms its really invasive to rewrite them correctly, so just diable them.
