### PR TITLE
Fix mdspan support in modernized CUB interfaces

### DIFF
--- a/cub/cub/detail/type_traits.cuh
+++ b/cub/cub/detail/type_traits.cuh
@@ -73,7 +73,7 @@ inline constexpr bool is_fixed_size_random_access_range_v<::cuda::std::span<T, N
 
 template <typename T, typename E, typename L, typename A>
 inline constexpr bool is_fixed_size_random_access_range_v<::cuda::std::mdspan<T, E, L, A>> =
-  E::rank == 1 && E::rank_dynamic() == 0;
+  E::rank() == 1 && E::rank_dynamic() == 0;
 
 /***********************************************************************************************************************
  * static_size: a type trait that returns the number of elements in an Array-like type
@@ -94,7 +94,7 @@ inline constexpr int static_size_v<::cuda::std::span<T, N>> =
 
 template <typename T, typename E, typename L, typename A>
 inline constexpr int static_size_v<::cuda::std::mdspan<T, E, L, A>> =
-  ::cuda::std::enable_if_t<E::rank == 1 && E::rank_dynamic() == 0, int>{E::static_extent(0)};
+  ::cuda::std::enable_if_t<E::rank() == 1 && E::rank_dynamic() == 0, int>{E::static_extent(0)};
 
 template <typename T>
 using implicit_prom_t = decltype(+T{});

--- a/cub/test/catch2_test_thread_scan_exclusive_partial.cu
+++ b/cub/test/catch2_test_thread_scan_exclusive_partial.cu
@@ -7,6 +7,7 @@
 #include <cuda/std/__algorithm/clamp.h>
 #include <cuda/std/functional>
 #include <cuda/std/limits>
+#include <cuda/std/mdspan>
 
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_device_scan.cuh"
@@ -86,8 +87,6 @@ __global__ void thread_scan_exclusive_partial_kernel_span(
   }
 }
 
-#if _CCCL_STD_VER >= 2023
-
 template <int NumItems, typename T, typename ScanOperator>
 __global__ void thread_scan_exclusive_partial_kernel_mdspan(
   const T* d_in, T* d_out, ScanOperator scan_operator, int valid_items, T prefix, bool apply_prefix)
@@ -108,8 +107,6 @@ __global__ void thread_scan_exclusive_partial_kernel_mdspan(
     d_out[i] = thread_data[i];
   }
 }
-
-#endif // _CCCL_STD_VER >= 2023
 
 /***********************************************************************************************************************
  * Type list definition
@@ -361,7 +358,6 @@ C2H_TEST("ThreadScanExclusive Container Tests", "[scan][thread]")
   REQUIRE(cudaSuccess == cudaDeviceSynchronize());
   REQUIRE(reference_result == d_out);
 
-#if _CCCL_STD_VER >= 2023
   thrust::fill(d_out.begin(), d_out.end(), 0);
   thread_scan_exclusive_partial_kernel_mdspan<max_size><<<1, 1>>>(
     thrust::raw_pointer_cast(d_in.data()),
@@ -373,7 +369,6 @@ C2H_TEST("ThreadScanExclusive Container Tests", "[scan][thread]")
   REQUIRE(cudaSuccess == cudaPeekAtLastError());
   REQUIRE(cudaSuccess == cudaDeviceSynchronize());
   REQUIRE(reference_result == d_out);
-#endif // _CCCL_STD_VER >= 2023
 }
 
 C2H_TEST("ThreadScanExclusive Invalid Test", "[scan][thread]")

--- a/cub/test/catch2_test_thread_scan_inclusive_partial.cu
+++ b/cub/test/catch2_test_thread_scan_inclusive_partial.cu
@@ -7,6 +7,7 @@
 #include <cuda/std/__algorithm/clamp.h>
 #include <cuda/std/functional>
 #include <cuda/std/limits>
+#include <cuda/std/mdspan>
 
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_device_scan.cuh"
@@ -86,8 +87,6 @@ __global__ void thread_scan_inclusive_partial_kernel_span(
   }
 }
 
-#if _CCCL_STD_VER >= 2023
-
 template <int NumItems, typename T, typename ScanOperator>
 __global__ void thread_scan_inclusive_partial_kernel_mdspan(
   const T* d_in, T* d_out, ScanOperator scan_operator, int valid_items, T prefix, bool apply_prefix)
@@ -108,8 +107,6 @@ __global__ void thread_scan_inclusive_partial_kernel_mdspan(
     d_out[i] = thread_data[i];
   }
 }
-
-#endif // _CCCL_STD_VER >= 2023
 
 /***********************************************************************************************************************
  * Type list definition
@@ -361,7 +358,6 @@ C2H_TEST("ThreadScanInclusive Container Tests", "[scan][thread]")
   REQUIRE(cudaSuccess == cudaDeviceSynchronize());
   REQUIRE(reference_result == d_out);
 
-#if _CCCL_STD_VER >= 2023
   thrust::fill(d_out.begin(), d_out.end(), 0);
   thread_scan_inclusive_partial_kernel_mdspan<max_size><<<1, 1>>>(
     thrust::raw_pointer_cast(d_in.data()),
@@ -373,7 +369,6 @@ C2H_TEST("ThreadScanInclusive Container Tests", "[scan][thread]")
   REQUIRE(cudaSuccess == cudaPeekAtLastError());
   REQUIRE(cudaSuccess == cudaDeviceSynchronize());
   REQUIRE(reference_result == d_out);
-#endif // _CCCL_STD_VER >= 2023
 }
 
 C2H_TEST("ThreadScanInclusive Invalid Test", "[scan][thread]")

--- a/cub/test/thread_reduce/catch2_test_thread_reduce.cu
+++ b/cub/test/thread_reduce/catch2_test_thread_reduce.cu
@@ -8,6 +8,7 @@
 #include <cuda/functional>
 #include <cuda/std/functional>
 #include <cuda/std/limits>
+#include <cuda/std/mdspan>
 #include <cuda/std/type_traits>
 
 #include <cstring>
@@ -63,8 +64,6 @@ __global__ void thread_reduce_kernel_span(const T* d_in, T* d_out, ReduceOperato
   *d_out = cub::ThreadReduce(span, reduce_operator);
 }
 
-#if _CCCL_STD_VER >= 2023
-
 template <int NUM_ITEMS, typename T, typename ReduceOperator>
 __global__ void thread_reduce_kernel_mdspan(const T* d_in, T* d_out, ReduceOperator reduce_operator)
 {
@@ -79,8 +78,6 @@ __global__ void thread_reduce_kernel_mdspan(const T* d_in, T* d_out, ReduceOpera
   cuda::std::mdspan<T, Extent> mdspan(thread_data, cuda::std::extents<int, NUM_ITEMS>{});
   *d_out = cub::ThreadReduce(mdspan, reduce_operator);
 }
-
-#endif // _CCCL_STD_VER >= 2023
 
 /***********************************************************************************************************************
  * CUB operator to STD operator
@@ -354,11 +351,9 @@ C2H_TEST("ThreadReduce Container Tests", "[reduce][thread]")
   REQUIRE(cudaSuccess == cudaDeviceSynchronize());
   verify_results(reference_result, c2h::host_vector<int>(d_out)[0]);
 
-#if _CCCL_STD_VER >= 2023
   thread_reduce_kernel_mdspan<max_size>
     <<<1, 1>>>(thrust::raw_pointer_cast(d_in.data()), thrust::raw_pointer_cast(d_out.data()), cuda::std::plus<>{});
   REQUIRE(cudaSuccess == cudaPeekAtLastError());
   REQUIRE(cudaSuccess == cudaDeviceSynchronize());
   verify_results(reference_result, c2h::host_vector<int>(d_out)[0]);
-#endif // _CCCL_STD_VER >= 2023
 }

--- a/cub/test/thread_reduce/catch2_test_thread_reduce_partial.cu
+++ b/cub/test/thread_reduce/catch2_test_thread_reduce_partial.cu
@@ -9,6 +9,7 @@
 #include <cuda/std/__algorithm/clamp.h>
 #include <cuda/std/functional>
 #include <cuda/std/limits>
+#include <cuda/std/mdspan>
 #include <cuda/std/type_traits>
 
 #include "catch2_test_device_reduce.cuh"
@@ -68,8 +69,6 @@ thread_reduce_partial_kernel_span(const T* d_in, T* d_out, ReduceOperator reduce
   *d_out = cub::detail::ThreadReducePartial(span, reduce_operator, valid_items);
 }
 
-#if _CCCL_STD_VER >= 2023
-
 template <int NumItems, typename T, typename ReduceOperator>
 __global__ void
 thread_reduce_partial_kernel_mdspan(const T* d_in, T* d_out, ReduceOperator reduce_operator, int valid_items)
@@ -85,8 +84,6 @@ thread_reduce_partial_kernel_mdspan(const T* d_in, T* d_out, ReduceOperator redu
   cuda::std::mdspan<T, Extent> mdspan(thread_data, cuda::std::extents<int, NumItems>{});
   *d_out = cub::detail::ThreadReducePartial(mdspan, reduce_operator, valid_items);
 }
-
-#endif // _CCCL_STD_VER >= 2023
 
 /***********************************************************************************************************************
  * Type list definition
@@ -251,13 +248,11 @@ C2H_TEST("ThreadReduce Container Tests", "[reduce][thread]")
   REQUIRE(cudaSuccess == cudaDeviceSynchronize());
   REQUIRE(reference_result == c2h::host_vector<int>(d_out)[0]);
 
-#if _CCCL_STD_VER >= 2023
   thread_reduce_partial_kernel_mdspan<max_size>
     <<<1, 1>>>(thrust::raw_pointer_cast(d_in.data()), thrust::raw_pointer_cast(d_out.data()), op_t{}, valid_items);
   REQUIRE(cudaSuccess == cudaPeekAtLastError());
   REQUIRE(cudaSuccess == cudaDeviceSynchronize());
   REQUIRE(reference_result == c2h::host_vector<int>(d_out)[0]);
-#endif // _CCCL_STD_VER >= 2023
 }
 
 C2H_TEST("ThreadReducePartial does not invoke the reduction operator on invalid elements", "[reduce][thread]")


### PR DESCRIPTION
## Description

A growing number of CUB thread primitives accept not only C-style arrays, but any "fixed-size random access range" like `cuda::std::array`, `cuda::std::span` and 1D `cuda::std::mdspan`. See #1877 for context.

The tests for mdspan where not build/executed in the past due to `#if _CCCL_STD_VER >= 2023`. This is unnecessary as we have `operator[]` on 1D mdpsans even with C++17.

This PR
- removes the unnecessary preprocessor conditionals from tests
- Adds missing includes to tests
- Fixes helpers for handling of `mdspan` in the mentioned primitives (they were not compiling).

The later two issues did not surface before because the corresponding tests were not compiled.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
<!-- closes Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
