### PR TITLE
[Tile] Avoid internal usage of CPOs

### DIFF
--- a/docs/libcudacxx/tile.rst
+++ b/docs/libcudacxx/tile.rst
@@ -64,7 +64,8 @@ C++ customization point objects
 The standard library uses __ Customization Point Objects __ to enable user-customization of the behavior of many
 algorithms and ranges. We rely heavily on those for most of our iterator machinery such as e.g `cuda::std::begin`.
 
-Those CPOs are currently not accessible in a tile kernel.
+Those CPOs are currently not accessible in a tile kernel. A potential workaround is to construct an instance of the
+empty type, e.g. ``decltype(cuda::std::begin){}(container);``
 
 C++ return statements in loops and switches
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -328,7 +328,7 @@ public:
   buffer(::cuda::stream_ref __stream, _Resource&& __resource, _Range&& __range, [[maybe_unused]] const _Env& __env = {})
       : __buf_(::cuda::mr::__adapt_if_synchronous(::cuda::std::forward<_Resource>(__resource)),
                __stream,
-               static_cast<size_type>(::cuda::std::ranges::size(__range)),
+               static_cast<size_type>(::cuda::std::ranges::__size_cpo{}(__range)),
                __alignment_from_env(__env))
   {
     static_assert(::cuda::std::is_copy_constructible_v<::cuda::std::decay_t<_Resource>>,
@@ -336,7 +336,7 @@ public:
                   "cuda::mr::shared_resource can be used to attach shared ownership to a resource type.");
     using _Iter = ::cuda::std::ranges::iterator_t<_Range>;
     this->__copy_cross<_Iter>(
-      ::cuda::std::ranges::begin(__range),
+      ::cuda::std::ranges::__begin_cpo{}(__range),
       ::cuda::std::ranges::__unwrap_end(__range),
       __unwrapped_begin(),
       __buf_.size());
@@ -351,8 +351,8 @@ public:
   buffer(::cuda::stream_ref __stream, _Resource&& __resource, _Range&& __range, [[maybe_unused]] const _Env& __env = {})
       : __buf_(::cuda::mr::__adapt_if_synchronous(::cuda::std::forward<_Resource>(__resource)),
                __stream,
-               static_cast<size_type>(
-                 ::cuda::std::ranges::distance(::cuda::std::ranges::begin(__range), ::cuda::std::ranges::end(__range))),
+               static_cast<size_type>(::cuda::std::ranges::__distance_cpo{}(
+                 ::cuda::std::ranges::__begin_cpo{}(__range), ::cuda::std::ranges::__end_cpo{}(__range))),
                __alignment_from_env(__env))
   {
     static_assert(::cuda::std::is_copy_constructible_v<::cuda::std::decay_t<_Resource>>,
@@ -360,7 +360,7 @@ public:
                   "cuda::mr::shared_resource can be used to attach shared ownership to a resource type.");
     using _Iter = ::cuda::std::ranges::iterator_t<_Range>;
     this->__copy_cross<_Iter>(
-      ::cuda::std::ranges::begin(__range),
+      ::cuda::std::ranges::__begin_cpo{}(__range),
       ::cuda::std::ranges::__unwrap_end(__range),
       __unwrapped_begin(),
       __buf_.size());

--- a/libcudacxx/include/cuda/__iterator/zip_common.h
+++ b/libcudacxx/include/cuda/__iterator/zip_common.h
@@ -57,7 +57,7 @@ struct __zip_iter_constraints
     (::cuda::std::sized_sentinel_for<_Iterators, _Iterators> && ...) || __all_random_access;
 
   static constexpr bool __all_nothrow_iter_movable =
-    (noexcept(::cuda::std::ranges::iter_move(::cuda::std::declval<const _Iterators&>())) && ...)
+    (noexcept(::cuda::std::ranges::__iter_move_cpo{}(::cuda::std::declval<const _Iterators&>())) && ...)
     && (::cuda::std::is_nothrow_move_constructible_v<::cuda::std::iter_rvalue_reference_t<_Iterators>> && ...);
 
   static constexpr bool __all_indirectly_swappable = (::cuda::std::indirectly_swappable<_Iterators> && ...);
@@ -138,9 +138,9 @@ struct __zip_iter_move
   _CCCL_EXEC_CHECK_DISABLE
   template <class... _Iterators>
   [[nodiscard]] _CCCL_API constexpr __iter_move_ret<_Iterators...> operator()(const _Iterators&... __iters) const
-    noexcept(noexcept(__iter_move_ret<_Iterators...>{::cuda::std::ranges::iter_move(__iters)...}))
+    noexcept(noexcept(__iter_move_ret<_Iterators...>{::cuda::std::ranges::__iter_move_cpo{}(__iters)...}))
   {
-    return __iter_move_ret<_Iterators...>{::cuda::std::ranges::iter_move(__iters)...};
+    return __iter_move_ret<_Iterators...>{::cuda::std::ranges::__iter_move_cpo{}(__iters)...};
   }
 };
 

--- a/libcudacxx/include/cuda/__iterator/zip_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_iterator.h
@@ -491,7 +491,9 @@ public:
                                         ::cuda::std::index_sequence<_Indices...>) const
       noexcept(__zip_iter_constraints<_Iterators...>::__all_noexcept_swappable)
     {
-      (::cuda::std::ranges::iter_swap(::cuda::std::get<_Indices>(__iters1), ::cuda::std::get<_Indices>(__iters2)), ...);
+      (::cuda::std::ranges::__iter_swap_cpo{}(
+         ::cuda::std::get<_Indices>(__iters1), ::cuda::std::get<_Indices>(__iters2)),
+       ...);
     }
   };
 

--- a/libcudacxx/include/cuda/std/__algorithm/iter_swap.h
+++ b/libcudacxx/include/cuda/std/__algorithm/iter_swap.h
@@ -73,6 +73,9 @@ inline namespace __cpo
 {
 // This is a global constant to avoid breaking types that pull in `::std::iter_swap` via ADL
 _CCCL_GLOBAL_CONSTANT auto iter_swap = __iter_swap::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __iter_swap_cpo = __iter_swap::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__algorithm/iterator_operations.h
+++ b/libcudacxx/include/cuda/std/__algorithm/iterator_operations.h
@@ -58,13 +58,13 @@ struct _IterOps<_RangeAlgPolicy>
   template <class _Iter>
   using __difference_type = iter_difference_t<_Iter>;
 
-  static constexpr auto advance      = ::cuda::std::ranges::advance;
-  static constexpr auto distance     = ::cuda::std::ranges::distance;
-  static constexpr auto __iter_move  = ::cuda::std::ranges::iter_move;
-  static constexpr auto iter_swap    = ::cuda::std::ranges::iter_swap;
-  static constexpr auto next         = ::cuda::std::ranges::next;
-  static constexpr auto prev         = ::cuda::std::ranges::prev;
-  static constexpr auto __advance_to = ::cuda::std::ranges::advance;
+  static constexpr auto advance      = ::cuda::std::ranges::__advance_cpo{};
+  static constexpr auto distance     = ::cuda::std::ranges::__distance_cpo{};
+  static constexpr auto __iter_move  = ::cuda::std::ranges::__iter_move_cpo{};
+  static constexpr auto iter_swap    = ::cuda::std::ranges::__iter_swap_cpo{};
+  static constexpr auto next         = ::cuda::std::ranges::__next_cpo{};
+  static constexpr auto prev         = ::cuda::std::ranges::__prev_cpo{};
+  static constexpr auto __advance_to = ::cuda::std::ranges::__advance_cpo{};
 };
 
 struct _ClassicAlgPolicy
@@ -141,7 +141,7 @@ struct _IterOps<_ClassicAlgPolicy>
   template <class _Iter1, class _Iter2>
   _CCCL_API constexpr static void iter_swap(_Iter1&& __a, _Iter2&& __b)
   {
-    ::cuda::std::iter_swap(::cuda::std::forward<_Iter1>(__a), ::cuda::std::forward<_Iter2>(__b));
+    ::cuda::std::__iter_swap_cpo{}(::cuda::std::forward<_Iter1>(__a), ::cuda::std::forward<_Iter2>(__b));
   }
 
   // next

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_find_if.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_find_if.h
@@ -62,7 +62,8 @@ struct __fn
   _CCCL_REQUIRES(input_range<_Rp> _CCCL_AND indirect_unary_predicate<_Pred, projected<iterator_t<_Rp>, _Proj>>)
   [[nodiscard]] _CCCL_API constexpr borrowed_iterator_t<_Rp> operator()(_Rp&& __r, _Pred __pred, _Proj __proj = {}) const
   {
-    return __find_if_impl(::cuda::std::ranges::begin(__r), ::cuda::std::ranges::end(__r), __pred, __proj);
+    return __find_if_impl(
+      ::cuda::std::ranges::__begin_cpo{}(__r), ::cuda::std::ranges::__end_cpo{}(__r), __pred, __proj);
   }
 };
 _CCCL_END_NAMESPACE_CPO

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_for_each.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_for_each.h
@@ -67,7 +67,8 @@ public:
   _CCCL_API constexpr for_each_result<borrowed_iterator_t<_Range>, _Func>
   operator()(_Range&& __range, _Func __func, _Proj __proj = {}) const
   {
-    return __for_each_impl(::cuda::std::ranges::begin(__range), ::cuda::std::ranges::end(__range), __func, __proj);
+    return __for_each_impl(
+      ::cuda::std::ranges::__begin_cpo{}(__range), ::cuda::std::ranges::__end_cpo{}(__range), __func, __proj);
   }
 };
 _CCCL_END_NAMESPACE_CPO

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_min.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_min.h
@@ -60,8 +60,8 @@ struct __fn
                    _CCCL_AND indirectly_copyable_storable<iterator_t<_Rp>, range_value_t<_Rp>*>)
   [[nodiscard]] _CCCL_API constexpr range_value_t<_Rp> operator()(_Rp&& __r, _Comp __comp = {}, _Proj __proj = {}) const
   {
-    auto __first = ::cuda::std::ranges::begin(__r);
-    auto __last  = ::cuda::std::ranges::end(__r);
+    auto __first = ::cuda::std::ranges::__begin_cpo{}(__r);
+    auto __last  = ::cuda::std::ranges::__end_cpo{}(__r);
 
     _CCCL_ASSERT(__first != __last, "range must contain at least one element");
 

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_min_element.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_min_element.h
@@ -51,7 +51,8 @@ struct __fn
   [[nodiscard]] _CCCL_API constexpr borrowed_iterator_t<_Rp>
   operator()(_Rp&& __r, _Comp __comp = {}, _Proj __proj = {}) const
   {
-    return ::cuda::std::__min_element(::cuda::std::ranges::begin(__r), ::cuda::std::ranges::end(__r), __comp, __proj);
+    return ::cuda::std::__min_element(
+      ::cuda::std::ranges::__begin_cpo{}(__r), ::cuda::std::ranges::__end_cpo{}(__r), __comp, __proj);
   }
 };
 _CCCL_END_NAMESPACE_CPO

--- a/libcudacxx/include/cuda/std/__algorithm/unwrap_range.h
+++ b/libcudacxx/include/cuda/std/__algorithm/unwrap_range.h
@@ -45,7 +45,7 @@ struct __unwrap_range_impl
   _CCCL_API static constexpr auto __unwrap(_Iter __first, _Sent __sent)
     requires random_access_iterator<_Iter> && sized_sentinel_for<_Sent, _Iter>
   {
-    auto __last = ranges::next(__first, __sent);
+    auto __last = ::cuda::std::ranges::__next_cpo{}(__first, __sent);
     return pair{::cuda::std::__unwrap_iter(::cuda::std::move(__first)),
                 ::cuda::std::__unwrap_iter(::cuda::std::move(__last))};
   }

--- a/libcudacxx/include/cuda/std/__concepts/swappable.h
+++ b/libcudacxx/include/cuda/std/__concepts/swappable.h
@@ -158,6 +158,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto swap = __swap::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __swap_cpo = __swap::__fn;
 } // namespace __cpo
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 
@@ -165,18 +168,18 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if _CCCL_HAS_CONCEPTS()
 template <class _Tp>
-concept swappable = requires(_Tp& __a, _Tp& __b) { ::cuda::std::ranges::swap(__a, __b); };
+concept swappable = requires(_Tp& __a, _Tp& __b) { ::cuda::std::ranges::__swap_cpo{}(__a, __b); };
 
 template <class _Tp, class _Up>
 concept swappable_with = common_reference_with<_Tp, _Up> && requires(_Tp&& __t, _Up&& __u) {
-  ::cuda::std::ranges::swap(::cuda::std::forward<_Tp>(__t), ::cuda::std::forward<_Tp>(__t));
-  ::cuda::std::ranges::swap(::cuda::std::forward<_Up>(__u), ::cuda::std::forward<_Up>(__u));
-  ::cuda::std::ranges::swap(::cuda::std::forward<_Tp>(__t), ::cuda::std::forward<_Up>(__u));
-  ::cuda::std::ranges::swap(::cuda::std::forward<_Up>(__u), ::cuda::std::forward<_Tp>(__t));
+  ::cuda::std::ranges::__swap_cpo{}(::cuda::std::forward<_Tp>(__t), ::cuda::std::forward<_Tp>(__t));
+  ::cuda::std::ranges::__swap_cpo{}(::cuda::std::forward<_Up>(__u), ::cuda::std::forward<_Up>(__u));
+  ::cuda::std::ranges::__swap_cpo{}(::cuda::std::forward<_Tp>(__t), ::cuda::std::forward<_Up>(__u));
+  ::cuda::std::ranges::__swap_cpo{}(::cuda::std::forward<_Up>(__u), ::cuda::std::forward<_Tp>(__t));
 };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Tp>
-_CCCL_CONCEPT_FRAGMENT(__swappable_, requires(_Tp& __a, _Tp& __b)((::cuda::std::ranges::swap(__a, __b))));
+_CCCL_CONCEPT_FRAGMENT(__swappable_, requires(_Tp& __a, _Tp& __b)((::cuda::std::ranges::__swap_cpo{}(__a, __b))));
 
 template <class _Tp>
 _CCCL_CONCEPT swappable = _CCCL_FRAGMENT(__swappable_, _Tp);
@@ -186,10 +189,10 @@ _CCCL_CONCEPT_FRAGMENT(
   __swappable_with_,
   requires(_Tp&& __t, _Up&& __u)(
     requires(common_reference_with<_Tp, _Up>),
-    (::cuda::std::ranges::swap(::cuda::std::forward<_Tp>(__t), ::cuda::std::forward<_Tp>(__t))),
-    (::cuda::std::ranges::swap(::cuda::std::forward<_Up>(__u), ::cuda::std::forward<_Up>(__u))),
-    (::cuda::std::ranges::swap(::cuda::std::forward<_Tp>(__t), ::cuda::std::forward<_Up>(__u))),
-    (::cuda::std::ranges::swap(::cuda::std::forward<_Up>(__u), ::cuda::std::forward<_Tp>(__t)))));
+    (::cuda::std::ranges::__swap_cpo{}(::cuda::std::forward<_Tp>(__t), ::cuda::std::forward<_Tp>(__t))),
+    (::cuda::std::ranges::__swap_cpo{}(::cuda::std::forward<_Up>(__u), ::cuda::std::forward<_Up>(__u))),
+    (::cuda::std::ranges::__swap_cpo{}(::cuda::std::forward<_Tp>(__t), ::cuda::std::forward<_Up>(__u))),
+    (::cuda::std::ranges::__swap_cpo{}(::cuda::std::forward<_Up>(__u), ::cuda::std::forward<_Tp>(__t)))));
 
 template <class _Tp, class _Up>
 _CCCL_CONCEPT swappable_with = _CCCL_FRAGMENT(__swappable_with_, _Tp, _Up);

--- a/libcudacxx/include/cuda/std/__expected/expected_base.h
+++ b/libcudacxx/include/cuda/std/__expected/expected_base.h
@@ -63,7 +63,7 @@ struct __expected_construct_from_invoke_tag
 template <class _Tp, class _Err, bool = is_trivially_destructible_v<_Tp> && is_trivially_destructible_v<_Err>>
 union __expected_union_t
 {
-  struct __empty_t
+  struct __empty_cpo
   {};
 
   _CCCL_EXEC_CHECK_DISABLE
@@ -118,7 +118,7 @@ union __expected_union_t
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 ~__expected_union_t() {}
 
-  _CCCL_NO_UNIQUE_ADDRESS __empty_t __empty_;
+  _CCCL_NO_UNIQUE_ADDRESS __empty_cpo __empty_;
   _CCCL_NO_UNIQUE_ADDRESS _Tp __val_;
   _CCCL_NO_UNIQUE_ADDRESS _Err __unex_;
 };
@@ -126,7 +126,7 @@ union __expected_union_t
 template <class _Tp, class _Err>
 union __expected_union_t<_Tp, _Err, true>
 {
-  struct __empty_t
+  struct __empty_cpo
   {};
 
   _CCCL_EXEC_CHECK_DISABLE
@@ -177,7 +177,7 @@ union __expected_union_t<_Tp, _Err, true>
       : __unex_(::cuda::std::invoke(::cuda::std::forward<_Fun>(__fun), ::cuda::std::forward<_Args>(__args)...))
   {}
 
-  _CCCL_NO_UNIQUE_ADDRESS __empty_t __empty_;
+  _CCCL_NO_UNIQUE_ADDRESS __empty_cpo __empty_;
   _CCCL_NO_UNIQUE_ADDRESS _Tp __val_;
   _CCCL_NO_UNIQUE_ADDRESS _Err __unex_;
 };
@@ -751,7 +751,7 @@ struct __expected_destruct<void, _Err, false, false>
 {
   _CCCL_NO_UNIQUE_ADDRESS union __expected_union_t
   {
-    struct __empty_t
+    struct __empty_cpo
     {};
 
     _CCCL_API constexpr __expected_union_t() noexcept
@@ -779,7 +779,7 @@ struct __expected_destruct<void, _Err, false, false>
     _CCCL_EXEC_CHECK_DISABLE
     _CCCL_API inline _CCCL_CONSTEXPR_CXX20 ~__expected_union_t() {}
 
-    _CCCL_NO_UNIQUE_ADDRESS __empty_t __empty_;
+    _CCCL_NO_UNIQUE_ADDRESS __empty_cpo __empty_;
     _CCCL_NO_UNIQUE_ADDRESS _Err __unex_;
   } __union_{};
   bool __has_val_{true};
@@ -828,7 +828,7 @@ struct __expected_destruct<void, _Err, false, true>
   // Using `_CCCL_NO_UNIQUE_ADDRESS` here crashes nvcc
   /* _CCCL_NO_UNIQUE_ADDRESS */ union __expected_union_t
   {
-    struct __empty_t
+    struct __empty_cpo
     {};
 
     _CCCL_API constexpr __expected_union_t() noexcept
@@ -852,7 +852,7 @@ struct __expected_destruct<void, _Err, false, true>
         : __unex_(::cuda::std::invoke(::cuda::std::forward<_Fun>(__fun), ::cuda::std::forward<_Args>(__args)...))
     {}
 
-    _CCCL_NO_UNIQUE_ADDRESS __empty_t __empty_;
+    _CCCL_NO_UNIQUE_ADDRESS __empty_cpo __empty_;
     _CCCL_NO_UNIQUE_ADDRESS _Err __unex_;
   } __union_{};
   bool __has_val_{true};

--- a/libcudacxx/include/cuda/std/__iterator/access.h
+++ b/libcudacxx/include/cuda/std/__iterator/access.h
@@ -54,6 +54,9 @@ struct __fn
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto begin = __begin::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __begin_cpo = __begin::__fn;
 } // namespace __cpo
 
 namespace __end
@@ -83,6 +86,9 @@ struct __fn
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto end = __end::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __end_cpo = __end::__fn;
 } // namespace __cpo
 
 namespace __cbegin
@@ -90,10 +96,10 @@ namespace __cbegin
 struct __fn
 {
   template <class _Cp>
-  _CCCL_API constexpr auto operator()(const _Cp& __c) const noexcept(noexcept(::cuda::std::begin(__c)))
-    -> decltype(::cuda::std::begin(__c))
+  _CCCL_API constexpr auto operator()(const _Cp& __c) const noexcept(noexcept(::cuda::std::__begin_cpo{}(__c)))
+    -> decltype(::cuda::std::__begin_cpo{}(__c))
   {
-    return ::cuda::std::begin(__c);
+    return ::cuda::std::__begin_cpo{}(__c);
   }
 };
 } // namespace __cbegin
@@ -101,6 +107,9 @@ struct __fn
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto cbegin = __cbegin::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __cbegin_cpo = __cbegin::__fn;
 } // namespace __cpo
 
 namespace __cend
@@ -108,10 +117,10 @@ namespace __cend
 struct __fn
 {
   template <class _Cp>
-  _CCCL_API constexpr auto operator()(const _Cp& __c) const noexcept(noexcept(::cuda::std::end(__c)))
-    -> decltype(::cuda::std::end(__c))
+  _CCCL_API constexpr auto operator()(const _Cp& __c) const noexcept(noexcept(::cuda::std::__end_cpo{}(__c)))
+    -> decltype(::cuda::std::__end_cpo{}(__c))
   {
-    return ::cuda::std::end(__c);
+    return ::cuda::std::__end_cpo{}(__c);
   }
 };
 } // namespace __cend
@@ -119,6 +128,9 @@ struct __fn
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto cend = __cend::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __cend_cpo = __cend::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__iterator/advance.h
+++ b/libcudacxx/include/cuda/std/__iterator/advance.h
@@ -218,6 +218,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto advance = __advance::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __advance_cpo = __advance::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__iterator/common_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/common_iterator.h
@@ -387,23 +387,24 @@ public:
 
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(input_iterator<_Iter2>)
-  _CCCL_API friend constexpr iter_rvalue_reference_t<_Iter2>
-  iter_move(const common_iterator& __i) noexcept(noexcept(::cuda::std::ranges::iter_move(declval<const _Iter&>())))
+  _CCCL_API friend constexpr iter_rvalue_reference_t<_Iter2> iter_move(const common_iterator& __i) noexcept(
+    noexcept(::cuda::std::ranges::__iter_move_cpo{}(declval<const _Iter&>())))
   {
     _CCCL_ASSERT(__i.__hold_.__holds_first(), "Attempted to iter_move a non-dereferenceable common_iterator");
-    return ::cuda::std::ranges::iter_move(__i.__hold_.__first_);
+    return ::cuda::std::ranges::__iter_move_cpo{}(__i.__hold_.__first_);
   }
 
   _CCCL_TEMPLATE(class _I2, class _S2)
   _CCCL_REQUIRES(indirectly_swappable<_I2, _Iter>)
-  _CCCL_API friend constexpr void iter_swap(const common_iterator& __x, const common_iterator<_I2, _S2>& __y) noexcept(
-    noexcept(::cuda::std::ranges::iter_swap(::cuda::std::declval<const _Iter&>(), ::cuda::std::declval<const _I2&>())))
+  _CCCL_API friend constexpr void
+  iter_swap(const common_iterator& __x, const common_iterator<_I2, _S2>& __y) noexcept(noexcept(
+    ::cuda::std::ranges::__iter_swap_cpo{}(::cuda::std::declval<const _Iter&>(), ::cuda::std::declval<const _I2&>())))
   {
     const auto& __y_hold = __y.__get_hold();
 
     _CCCL_ASSERT(__x.__hold_.__holds_first(), "Attempted to iter_swap a non-dereferenceable common_iterator");
     _CCCL_ASSERT(__y_hold.__holds_first(), "Attempted to iter_swap a non-dereferenceable common_iterator");
-    return ::cuda::std::ranges::iter_swap(__x.__hold_.__first_, __y_hold.__first_);
+    return ::cuda::std::ranges::__iter_swap_cpo{}(__x.__hold_.__first_, __y_hold.__first_);
   }
 
   [[nodiscard]] _CCCL_API constexpr __variant_like<_Iter, _Sent>& __get_hold() noexcept

--- a/libcudacxx/include/cuda/std/__iterator/concepts.h
+++ b/libcudacxx/include/cuda/std/__iterator/concepts.h
@@ -65,7 +65,7 @@ concept __indirectly_readable_impl =
     typename iter_reference_t<_In>;
     typename iter_rvalue_reference_t<_In>;
     { *__i } -> same_as<iter_reference_t<_In>>;
-    { ::cuda::std::ranges::iter_move(__i) } -> same_as<iter_rvalue_reference_t<_In>>;
+    { ::cuda::std::ranges::__iter_move_cpo{}(__i) } -> same_as<iter_rvalue_reference_t<_In>>;
   } && common_reference_with<iter_reference_t<_In>&&, iter_value_t<_In>&>
   && common_reference_with<iter_reference_t<_In>&&, iter_rvalue_reference_t<_In>&&>
   && common_reference_with<iter_rvalue_reference_t<_In>&&, const iter_value_t<_In>&>;
@@ -295,7 +295,7 @@ _CCCL_CONCEPT_FRAGMENT(
     typename(iter_reference_t<_In>),
     typename(iter_rvalue_reference_t<_In>),
     requires(same_as<iter_reference_t<_In>, decltype(*__i)>),
-    requires(same_as<iter_rvalue_reference_t<_In>, decltype(::cuda::std::ranges::iter_move(__i))>),
+    requires(same_as<iter_rvalue_reference_t<_In>, decltype(::cuda::std::ranges::__iter_move_cpo{}(__i))>),
     requires(common_reference_with<iter_reference_t<_In>&&, iter_value_t<_In>&>),
     requires(common_reference_with<iter_reference_t<_In>&&, iter_rvalue_reference_t<_In>&&>),
     requires(common_reference_with<iter_rvalue_reference_t<_In>&&, const iter_value_t<_In>&>)));

--- a/libcudacxx/include/cuda/std/__iterator/counted_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/counted_iterator.h
@@ -407,20 +407,20 @@ public:
 
   template <class _I2>
   _CCCL_API friend constexpr auto iter_swap(const counted_iterator& __x, const counted_iterator<_I2>& __y) noexcept(
-    noexcept(::cuda::std::ranges::iter_swap(__x.__current_, __y.__current_)))
+    noexcept(::cuda::std::ranges::__iter_swap_cpo{}(__x.__current_, __y.__current_)))
     _CCCL_TRAILING_REQUIRES(void)(indirectly_swappable<_I2, _Iter>)
   {
     _CCCL_ASSERT(__x.__count_ > 0 && __y.__count_ > 0, "Iterators must not be past end of range.");
-    return ::cuda::std::ranges::iter_swap(__x.__current_, __y.__current_);
+    return ::cuda::std::ranges::__iter_swap_cpo{}(__x.__current_, __y.__current_);
   }
 
   _CCCL_TEMPLATE(class _I2 = _Iter)
   _CCCL_REQUIRES(input_iterator<_I2>)
   [[nodiscard]] _CCCL_API friend constexpr decltype(auto)
-  iter_move(const counted_iterator& __i) noexcept(noexcept(::cuda::std::ranges::iter_move(__i.base())))
+  iter_move(const counted_iterator& __i) noexcept(noexcept(::cuda::std::ranges::__iter_move_cpo{}(__i.base())))
   {
     _CCCL_ASSERT(__i.count() > 0, "Iterator must not be past end of range.");
-    return ::cuda::std::ranges::iter_move(__i.base());
+    return ::cuda::std::ranges::__iter_move_cpo{}(__i.base());
   }
 };
 _CCCL_CTAD_SUPPORTED_FOR_TYPE(counted_iterator);

--- a/libcudacxx/include/cuda/std/__iterator/distance.h
+++ b/libcudacxx/include/cuda/std/__iterator/distance.h
@@ -102,11 +102,11 @@ struct __fn
   {
     if constexpr (sized_range<_Rp>)
     {
-      return static_cast<range_difference_t<_Rp>>(::cuda::std::ranges::size(__r));
+      return static_cast<range_difference_t<_Rp>>(::cuda::std::ranges::__size_cpo{}(__r));
     }
     else
     {
-      return operator()(::cuda::std::ranges::begin(__r), ::cuda::std::ranges::end(__r));
+      return operator()(::cuda::std::ranges::__begin_cpo{}(__r), ::cuda::std::ranges::__end_cpo{}(__r));
     }
   }
 };
@@ -115,6 +115,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto distance = __distance::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __distance_cpo = __distance::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__iterator/iter_move.h
+++ b/libcudacxx/include/cuda/std/__iterator/iter_move.h
@@ -123,6 +123,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto iter_move = __iter_move::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __iter_move_cpo = __iter_move::__fn;
 } // namespace __cpo
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 
@@ -131,22 +134,23 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 #if _CCCL_HAS_CONCEPTS()
 template <__dereferenceable _Tp>
   requires requires(_Tp& __t) {
-    { ::cuda::std::ranges::iter_move(__t) } -> __can_reference;
+    { ::cuda::std::ranges::__iter_move_cpo{}(__t) } -> __can_reference;
   }
-using iter_rvalue_reference_t = decltype(::cuda::std::ranges::iter_move(::cuda::std::declval<_Tp&>()));
+using iter_rvalue_reference_t = decltype(::cuda::std::ranges::__iter_move_cpo{}(::cuda::std::declval<_Tp&>()));
 
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 
 template <class _Tp>
-_CCCL_CONCEPT_FRAGMENT(__can_iter_rvalue_reference_t_,
-                       requires(_Tp& __t)(requires(__dereferenceable<_Tp>),
-                                          requires(__can_reference<decltype(::cuda::std::ranges::iter_move(__t))>)));
+_CCCL_CONCEPT_FRAGMENT(
+  __can_iter_rvalue_reference_t_,
+  requires(_Tp& __t)(requires(__dereferenceable<_Tp>),
+                     requires(__can_reference<decltype(::cuda::std::ranges::__iter_move_cpo{}(__t))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __can_iter_rvalue_reference_t = _CCCL_FRAGMENT(__can_iter_rvalue_reference_t_, _Tp);
 
 template <class _Tp>
-using __iter_rvalue_reference_t = decltype(::cuda::std::ranges::iter_move(::cuda::std::declval<_Tp&>()));
+using __iter_rvalue_reference_t = decltype(::cuda::std::ranges::__iter_move_cpo{}(::cuda::std::declval<_Tp&>()));
 
 template <class _Tp>
 using iter_rvalue_reference_t = enable_if_t<__can_iter_rvalue_reference_t<_Tp>, __iter_rvalue_reference_t<_Tp>>;

--- a/libcudacxx/include/cuda/std/__iterator/iter_swap.h
+++ b/libcudacxx/include/cuda/std/__iterator/iter_swap.h
@@ -71,14 +71,14 @@ _CCCL_CONCEPT __readable_swappable = _CCCL_REQUIRES_EXPR((_T1, _T2))(
 template <class _T1, class _T2>
 _CCCL_CONCEPT __noexcept_readable_swappable = _CCCL_REQUIRES_EXPR((_T1, _T2), _T1&& __x, _T2&& __y) //
   (requires(__readable_swappable<_T1, _T2>),
-   noexcept(::cuda::std::ranges::swap(*::cuda::std::forward<_T1>(__x), *::cuda::std::forward<_T2>(__y))));
+   noexcept(::cuda::std::ranges::__swap_cpo{}(*::cuda::std::forward<_T1>(__x), *::cuda::std::forward<_T2>(__y))));
 #else // ^^^ _CCCL_HAS_NOEXCEPT_MANGLING() ^^^ / vvv !_CCCL_HAS_NOEXCEPT_MANGLING() vvv
 template <class _T1, class _T2, bool = __readable_swappable<_T1, _T2>>
 inline constexpr bool __noexcept_readable_swappable = false;
 
 template <class _T1, class _T2>
 inline constexpr bool __noexcept_readable_swappable<_T1, _T2, true> =
-  noexcept(::cuda::std::ranges::swap(*::cuda::std::declval<_T1>(), *::cuda::std::declval<_T2>()));
+  noexcept(::cuda::std::ranges::__swap_cpo{}(*::cuda::std::declval<_T1>(), *::cuda::std::declval<_T2>()));
 #endif // !_CCCL_HAS_NOEXCEPT_MANGLING()
 
 template <class _T1, class _T2>
@@ -93,8 +93,8 @@ template <class _T1, class _T2>
 _CCCL_CONCEPT __noexcept_movable_storable =
   _CCCL_REQUIRES_EXPR((_T1, _T2), _T1&& __x, _T2&& __y, iter_value_t<_T2> __old)(
     requires(__movable_storable<_T1, _T2>),
-    noexcept(iter_value_t<_T2>(::cuda::std::ranges::iter_move(__y))),
-    noexcept(*__y = ::cuda::std::ranges::iter_move(__x)),
+    noexcept(iter_value_t<_T2>(::cuda::std::ranges::__iter_move_cpo{}(__y))),
+    noexcept(*__y = ::cuda::std::ranges::__iter_move_cpo{}(__x)),
     noexcept(*::cuda::std::forward<_T1>(__x) = ::cuda::std::move(__old)));
 #else // ^^^ _CCCL_HAS_NOEXCEPT_MANGLING() ^^^ / vvv !_CCCL_HAS_NOEXCEPT_MANGLING() vvv
 template <class _T1, class _T2, bool = __movable_storable<_T1, _T2>>
@@ -102,9 +102,10 @@ inline constexpr bool __noexcept_movable_storable = false;
 
 template <class _T1, class _T2>
 inline constexpr bool __noexcept_movable_storable<_T1, _T2, true> =
-  noexcept(iter_value_t<_T2>(::cuda::std::ranges::iter_move(::cuda::std::declval<add_lvalue_reference_t<_T2>>())))
+  noexcept(
+    iter_value_t<_T2>(::cuda::std::ranges::__iter_move_cpo{}(::cuda::std::declval<add_lvalue_reference_t<_T2>>())))
   && noexcept(*::cuda::std::declval<add_lvalue_reference_t<_T2>>() =
-                ::cuda::std::ranges::iter_move(::cuda::std::declval<add_lvalue_reference_t<_T1>>()))
+                ::cuda::std::ranges::__iter_move_cpo{}(::cuda::std::declval<add_lvalue_reference_t<_T1>>()))
   && noexcept(*::cuda::std::declval<_T1>() = ::cuda::std::declval<iter_value_t<_T2>>());
 #endif // !_CCCL_HAS_NOEXCEPT_MANGLING()
 
@@ -121,15 +122,15 @@ struct __fn
   _CCCL_REQUIRES(__readable_swappable<_T1, _T2>)
   _CCCL_API constexpr void operator()(_T1&& __x, _T2&& __y) const noexcept(__noexcept_readable_swappable<_T1, _T2>)
   {
-    ::cuda::std::ranges::swap(*::cuda::std::forward<_T1>(__x), *::cuda::std::forward<_T2>(__y));
+    ::cuda::std::ranges::__swap_cpo{}(*::cuda::std::forward<_T1>(__x), *::cuda::std::forward<_T2>(__y));
   }
 
   _CCCL_TEMPLATE(class _T1, class _T2)
   _CCCL_REQUIRES(__movable_storable<_T2, _T1>)
   _CCCL_API constexpr void operator()(_T1&& __x, _T2&& __y) const noexcept(__noexcept_movable_storable<_T1, _T2>)
   {
-    iter_value_t<_T2> __old(::cuda::std::ranges::iter_move(__y));
-    *__y                            = ::cuda::std::ranges::iter_move(__x);
+    iter_value_t<_T2> __old(::cuda::std::ranges::__iter_move_cpo{}(__y));
+    *__y                            = ::cuda::std::ranges::__iter_move_cpo{}(__x);
     *::cuda::std::forward<_T1>(__x) = ::cuda::std::move(__old);
   }
 };
@@ -138,6 +139,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto iter_swap = __iter_swap::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __iter_swap_cpo = __iter_swap::__fn;
 } // namespace __cpo
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 
@@ -146,10 +150,10 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 template <class _I1, class _I2 = _I1>
 concept indirectly_swappable =
   indirectly_readable<_I1> && indirectly_readable<_I2> && requires(const _I1 __i1, const _I2 __i2) {
-    ::cuda::std::ranges::iter_swap(__i1, __i1);
-    ::cuda::std::ranges::iter_swap(__i2, __i2);
-    ::cuda::std::ranges::iter_swap(__i1, __i2);
-    ::cuda::std::ranges::iter_swap(__i2, __i1);
+    ::cuda::std::ranges::__iter_swap_cpo{}(__i1, __i1);
+    ::cuda::std::ranges::__iter_swap_cpo{}(__i2, __i2);
+    ::cuda::std::ranges::__iter_swap_cpo{}(__i1, __i2);
+    ::cuda::std::ranges::__iter_swap_cpo{}(__i2, __i1);
   };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv _CCCL_HAS_CONCEPTS() vvv
 template <class _I1, class _I2>
@@ -158,10 +162,10 @@ _CCCL_CONCEPT_FRAGMENT(
   requires(const _I1 __i1, const _I2 __i2)(
     requires(indirectly_readable<_I1>),
     requires(indirectly_readable<_I2>),
-    (::cuda::std::ranges::iter_swap(__i1, __i1)),
-    (::cuda::std::ranges::iter_swap(__i2, __i2)),
-    (::cuda::std::ranges::iter_swap(__i1, __i2)),
-    (::cuda::std::ranges::iter_swap(__i2, __i1))));
+    (::cuda::std::ranges::__iter_swap_cpo{}(__i1, __i1)),
+    (::cuda::std::ranges::__iter_swap_cpo{}(__i2, __i2)),
+    (::cuda::std::ranges::__iter_swap_cpo{}(__i1, __i2)),
+    (::cuda::std::ranges::__iter_swap_cpo{}(__i2, __i1))));
 
 template <class _I1, class _I2 = _I1>
 _CCCL_CONCEPT indirectly_swappable = _CCCL_FRAGMENT(__indirectly_swappable_, _I1, _I2);
@@ -172,7 +176,7 @@ inline constexpr bool __noexcept_swappable = false;
 
 template <class _I1, class _I2>
 inline constexpr bool __noexcept_swappable<_I1, _I2, enable_if_t<indirectly_swappable<_I1, _I2>>> =
-  noexcept(::cuda::std::ranges::iter_swap(::cuda::std::declval<_I1&>(), ::cuda::std::declval<_I2&>()));
+  noexcept(::cuda::std::ranges::__iter_swap_cpo{}(::cuda::std::declval<_I1&>(), ::cuda::std::declval<_I2&>()));
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__iterator/move_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/move_iterator.h
@@ -75,7 +75,7 @@ concept __move_iter_comparable = requires {
 
 template <class _Iter>
 inline constexpr bool __noexcept_move_iter_iter_move =
-  noexcept(::cuda::std::ranges::iter_move(::cuda::std::declval<const _Iter&>()));
+  noexcept(::cuda::std::ranges::__iter_move_cpo{}(::cuda::std::declval<const _Iter&>()));
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Iter, class = void>
 struct __move_iter_category_base
@@ -100,7 +100,7 @@ _CCCL_CONCEPT __move_iter_comparable = _CCCL_FRAGMENT(__move_iter_comparable_, _
 
 template <class _Iter>
 inline constexpr bool __noexcept_move_iter_iter_move =
-  noexcept(::cuda::std::ranges::iter_move(::cuda::std::declval<const _Iter&>()));
+  noexcept(::cuda::std::ranges::__iter_move_cpo{}(::cuda::std::declval<const _Iter&>()));
 #endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 
 _LIBCUDACXX_BEGIN_HIDDEN_FRIEND_NAMESPACE
@@ -188,12 +188,12 @@ public:
 
   [[nodiscard]] _CCCL_API constexpr reference operator*() const
   {
-    return ::cuda::std::ranges::iter_move(__current_);
+    return ::cuda::std::ranges::__iter_move_cpo{}(__current_);
   }
 
   [[nodiscard]] _CCCL_API constexpr reference operator[](difference_type __n) const
   {
-    return ::cuda::std::ranges::iter_move(__current_ + __n);
+    return ::cuda::std::ranges::__iter_move_cpo{}(__current_ + __n);
   }
 
   _CCCL_EXEC_CHECK_DISABLE
@@ -396,7 +396,7 @@ public:
   [[nodiscard]] _CCCL_API friend constexpr iter_rvalue_reference_t<_Iter>
   iter_move(const move_iterator& __i) noexcept(__noexcept_move_iter_iter_move<_Iter>)
   {
-    return ::cuda::std::ranges::iter_move(__i.__current_);
+    return ::cuda::std::ranges::__iter_move_cpo{}(__i.__current_);
   }
 
   _CCCL_EXEC_CHECK_DISABLE
@@ -405,7 +405,7 @@ public:
   iter_swap(const move_iterator& __x, const move_iterator<_Iter2>& __y) noexcept(__noexcept_swappable<_Iter, _Iter2>)
     _CCCL_TRAILING_REQUIRES(void)(indirectly_swappable<_Iter2, _Iter>)
   {
-    return ::cuda::std::ranges::iter_swap(__x.__current_, __y.__current_);
+    return ::cuda::std::ranges::__iter_swap_cpo{}(__x.__current_, __y.__current_);
   }
 };
 _CCCL_CTAD_SUPPORTED_FOR_TYPE(move_iterator);

--- a/libcudacxx/include/cuda/std/__iterator/next.h
+++ b/libcudacxx/include/cuda/std/__iterator/next.h
@@ -65,7 +65,7 @@ struct __fn
   _CCCL_REQUIRES(input_or_output_iterator<_Ip>)
   [[nodiscard]] _CCCL_API constexpr _Ip operator()(_Ip __x, iter_difference_t<_Ip> __n) const
   {
-    ::cuda::std::ranges::advance(__x, __n);
+    ::cuda::std::ranges::__advance_cpo{}(__x, __n);
     return __x;
   }
 
@@ -74,7 +74,7 @@ struct __fn
   _CCCL_REQUIRES(input_or_output_iterator<_Ip>&& sentinel_for<_Sp, _Ip>)
   [[nodiscard]] _CCCL_API constexpr _Ip operator()(_Ip __x, _Sp __bound_sentinel) const
   {
-    ::cuda::std::ranges::advance(__x, __bound_sentinel);
+    ::cuda::std::ranges::__advance_cpo{}(__x, __bound_sentinel);
     return __x;
   }
 
@@ -83,7 +83,7 @@ struct __fn
   _CCCL_REQUIRES(input_or_output_iterator<_Ip>&& sentinel_for<_Sp, _Ip>)
   [[nodiscard]] _CCCL_API constexpr _Ip operator()(_Ip __x, iter_difference_t<_Ip> __n, _Sp __bound_sentinel) const
   {
-    ::cuda::std::ranges::advance(__x, __n, __bound_sentinel);
+    ::cuda::std::ranges::__advance_cpo{}(__x, __n, __bound_sentinel);
     return __x;
   }
 };
@@ -92,6 +92,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto next = __next::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __next_cpo = __next::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__iterator/prev.h
+++ b/libcudacxx/include/cuda/std/__iterator/prev.h
@@ -63,7 +63,7 @@ struct __fn
   _CCCL_REQUIRES(bidirectional_iterator<_Ip>)
   [[nodiscard]] _CCCL_API constexpr _Ip operator()(_Ip __x, iter_difference_t<_Ip> __n) const
   {
-    ::cuda::std::ranges::advance(__x, -__n);
+    ::cuda::std::ranges::__advance_cpo{}(__x, -__n);
     return __x;
   }
 
@@ -72,7 +72,7 @@ struct __fn
   _CCCL_REQUIRES(bidirectional_iterator<_Ip>)
   [[nodiscard]] _CCCL_API constexpr _Ip operator()(_Ip __x, iter_difference_t<_Ip> __n, _Ip __bound_iter) const
   {
-    ::cuda::std::ranges::advance(__x, -__n, __bound_iter);
+    ::cuda::std::ranges::__advance_cpo{}(__x, -__n, __bound_iter);
     return __x;
   }
 };
@@ -81,6 +81,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto prev = __prev::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __prev_cpo = __prev::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__iterator/reverse_access.h
+++ b/libcudacxx/include/cuda/std/__iterator/reverse_access.h
@@ -62,6 +62,9 @@ struct __fn
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto rbegin = __rbegin::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __rbegin_cpo = __rbegin::__fn;
 } // namespace __cpo
 
 namespace __rend
@@ -97,6 +100,9 @@ struct __fn
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto rend = __rend::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __rend_cpo = __rend::__fn;
 } // namespace __cpo
 
 namespace __crbegin
@@ -104,10 +110,10 @@ namespace __crbegin
 struct __fn
 {
   template <class _Cp>
-  _CCCL_API constexpr auto operator()(const _Cp& __c) const noexcept(noexcept(::cuda::std::rbegin(__c)))
-    -> decltype(::cuda::std::rbegin(__c))
+  _CCCL_API constexpr auto operator()(const _Cp& __c) const noexcept(noexcept(::cuda::std::__rbegin_cpo{}(__c)))
+    -> decltype(::cuda::std::__rbegin_cpo{}(__c))
   {
-    return ::cuda::std::rbegin(__c);
+    return ::cuda::std::__rbegin_cpo{}(__c);
   }
 };
 } // namespace __crbegin
@@ -115,6 +121,9 @@ struct __fn
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto crbegin = __crbegin::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __crbegin_cpo = __crbegin::__fn;
 } // namespace __cpo
 
 namespace __crend
@@ -122,10 +131,10 @@ namespace __crend
 struct __fn
 {
   template <class _Cp>
-  _CCCL_API constexpr auto operator()(const _Cp& __c) const noexcept(noexcept(::cuda::std::rend(__c)))
-    -> decltype(::cuda::std::rend(__c))
+  _CCCL_API constexpr auto operator()(const _Cp& __c) const noexcept(noexcept(::cuda::std::__rend_cpo{}(__c)))
+    -> decltype(::cuda::std::__rend_cpo{}(__c))
   {
-    return ::cuda::std::rend(__c);
+    return ::cuda::std::__rend_cpo{}(__c);
   }
 };
 } // namespace __crend
@@ -133,6 +142,9 @@ struct __fn
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto crend = __crend::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __crend_cpo = __crend::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__iterator/reverse_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/reverse_iterator.h
@@ -61,7 +61,8 @@ inline constexpr bool __noexcept_rev_iter_iter_move = false;
 
 template <class _Iter>
 inline constexpr bool __noexcept_rev_iter_iter_move<_Iter, void_t<decltype(--::cuda::std::declval<_Iter&>())>> =
-  is_nothrow_copy_constructible_v<_Iter> && noexcept(::cuda::std::ranges::iter_move(--::cuda::std::declval<_Iter&>()));
+  is_nothrow_copy_constructible_v<_Iter>
+  && noexcept(::cuda::std::ranges::__iter_move_cpo{}(--::cuda::std::declval<_Iter&>()));
 
 template <class _Iter, class _Iter2, class = void>
 inline constexpr bool __noexcept_rev_iter_iter_swap = false;
@@ -69,7 +70,7 @@ inline constexpr bool __noexcept_rev_iter_iter_swap = false;
 template <class _Iter, class _Iter2>
 inline constexpr bool __noexcept_rev_iter_iter_swap<_Iter, _Iter2, enable_if_t<indirectly_swappable<_Iter, _Iter2>>> =
   is_nothrow_copy_constructible_v<_Iter> && is_nothrow_copy_constructible_v<_Iter2>
-  && noexcept(::cuda::std::ranges::iter_swap(--declval<_Iter&>(), --declval<_Iter2&>()));
+  && noexcept(::cuda::std::ranges::__iter_swap_cpo{}(--declval<_Iter&>(), --declval<_Iter2&>()));
 
 // MSVC has issues with `is_nothrow_convertible_v` sometimes, so do the noexcept expression
 template <class _Iter, class _Iter2, class = void>
@@ -247,7 +248,7 @@ public:
   iter_move(const reverse_iterator& __i) noexcept(__noexcept_rev_iter_iter_move<_Iter2>)
   {
     auto __tmp = __i.base();
-    return ::cuda::std::ranges::iter_move(--__tmp);
+    return ::cuda::std::ranges::__iter_move_cpo{}(--__tmp);
   }
 
   _CCCL_EXEC_CHECK_DISABLE
@@ -257,7 +258,7 @@ public:
   {
     auto __xtmp = __x.base();
     auto __ytmp = __y.base();
-    return ::cuda::std::ranges::iter_swap(--__xtmp, --__ytmp);
+    return ::cuda::std::ranges::__iter_swap_cpo{}(--__xtmp, --__ytmp);
   }
 
   _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/std/__iterator/variant_like.h
+++ b/libcudacxx/include/cuda/std/__iterator/variant_like.h
@@ -405,10 +405,10 @@ public:
       switch (__x.__contains_)
       {
         case __variant_like_state::__holds_first:
-          ::cuda::std::ranges::swap(__x.__first_, __y.__first_);
+          ::cuda::std::ranges::__swap_cpo{}(__x.__first_, __y.__first_);
           break;
         case __variant_like_state::__holds_second:
-          ::cuda::std::ranges::swap(__x.__second_, __y.__second_);
+          ::cuda::std::ranges::__swap_cpo{}(__x.__second_, __y.__second_);
           break;
         case __variant_like_state::__nothing:
           break;

--- a/libcudacxx/include/cuda/std/__memory/construct_at.h
+++ b/libcudacxx/include/cuda/std/__memory/construct_at.h
@@ -166,7 +166,7 @@ _CCCL_API constexpr void __destroy_at([[maybe_unused]] _Tp* __loc)
   }
   else if constexpr (is_array_v<_Tp>)
   {
-    ::cuda::std::__destroy(::cuda::std::begin(*__loc), ::cuda::std::end(*__loc));
+    ::cuda::std::__destroy(::cuda::std::__begin_cpo{}(*__loc), ::cuda::std::__end_cpo{}(*__loc));
   }
   else
   {
@@ -209,7 +209,7 @@ _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void destroy_at([[maybe_unused]] _Tp* __l
   }
   else if constexpr (is_array_v<_Tp>)
   {
-    ::cuda::std::__destroy(::cuda::std::begin(*__loc), ::cuda::std::end(*__loc));
+    ::cuda::std::__destroy(::cuda::std::__begin_cpo{}(*__loc), ::cuda::std::__end_cpo{}(*__loc));
   }
   else
   {

--- a/libcudacxx/include/cuda/std/__pstl/reverse.h
+++ b/libcudacxx/include/cuda/std/__pstl/reverse.h
@@ -64,7 +64,7 @@ struct __reverse_fn
 
   _CCCL_DEVICE_API constexpr void operator()(const iter_difference_t<_InputIterator> __index) const noexcept
   {
-    ::cuda::std::iter_swap(__first_ + __index, __last_ + __index);
+    ::cuda::std::__iter_swap_cpo{}(__first_ + __index, __last_ + __index);
   }
 };
 

--- a/libcudacxx/include/cuda/std/__pstl/swap_ranges.h
+++ b/libcudacxx/include/cuda/std/__pstl/swap_ranges.h
@@ -63,7 +63,8 @@ struct __swap_ranges_iter_swap_fn
   template <class _DifferenceType>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE constexpr void operator()(const _DifferenceType __index) const
   {
-    ::cuda::std::iter_swap(__first1 + __index, __first2 + static_cast<iter_difference_t<_InputIterator2>>(__index));
+    ::cuda::std::__iter_swap_cpo{}(
+      __first1 + __index, __first2 + static_cast<iter_difference_t<_InputIterator2>>(__index));
   }
 };
 

--- a/libcudacxx/include/cuda/std/__ranges/access.h
+++ b/libcudacxx/include/cuda/std/__ranges/access.h
@@ -134,12 +134,15 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto begin = __begin::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __begin_cpo = __begin::__fn;
 } // namespace __cpo
 
 // [range.range]
 
 template <class _Tp>
-using iterator_t = decltype(::cuda::std::ranges::begin(::cuda::std::declval<_Tp&>()));
+using iterator_t = decltype(::cuda::std::ranges::__begin_cpo{}(::cuda::std::declval<_Tp&>()));
 
 // [range.access.end]
 
@@ -230,6 +233,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto end = __end::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __end_cpo = __end::__fn;
 } // namespace __cpo
 
 // [range.access.cbegin]
@@ -241,20 +247,20 @@ struct __fn
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_lvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::begin(static_cast<const remove_reference_t<_Tp>&>(__t))))
-      -> decltype(::cuda::std::ranges::begin(static_cast<const remove_reference_t<_Tp>&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__begin_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t))))
+      -> decltype(::cuda::std::ranges::__begin_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t)))
   {
-    return ::cuda::std::ranges::begin(static_cast<const remove_reference_t<_Tp>&>(__t));
+    return ::cuda::std::ranges::__begin_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t));
   }
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_rvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::begin(static_cast<const _Tp&&>(__t))))
-      -> decltype(::cuda::std::ranges::begin(static_cast<const _Tp&&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__begin_cpo{}(static_cast<const _Tp&&>(__t))))
+      -> decltype(::cuda::std::ranges::__begin_cpo{}(static_cast<const _Tp&&>(__t)))
   {
-    return ::cuda::std::ranges::begin(static_cast<const _Tp&&>(__t));
+    return ::cuda::std::ranges::__begin_cpo{}(static_cast<const _Tp&&>(__t));
   }
 };
 _CCCL_END_NAMESPACE_CPO
@@ -262,6 +268,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto cbegin = __cbegin::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __cbegin_cpo = __cbegin::__fn;
 } // namespace __cpo
 
 // [range.access.cend]
@@ -273,20 +282,20 @@ struct __fn
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_lvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::end(static_cast<const remove_reference_t<_Tp>&>(__t))))
-      -> decltype(::cuda::std::ranges::end(static_cast<const remove_reference_t<_Tp>&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__end_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t))))
+      -> decltype(::cuda::std::ranges::__end_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t)))
   {
-    return ::cuda::std::ranges::end(static_cast<const remove_reference_t<_Tp>&>(__t));
+    return ::cuda::std::ranges::__end_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t));
   }
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_rvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::end(static_cast<const _Tp&&>(__t))))
-      -> decltype(::cuda::std::ranges::end(static_cast<const _Tp&&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__end_cpo{}(static_cast<const _Tp&&>(__t))))
+      -> decltype(::cuda::std::ranges::__end_cpo{}(static_cast<const _Tp&&>(__t)))
   {
-    return ::cuda::std::ranges::end(static_cast<const _Tp&&>(__t));
+    return ::cuda::std::ranges::__end_cpo{}(static_cast<const _Tp&&>(__t));
   }
 };
 _CCCL_END_NAMESPACE_CPO
@@ -294,6 +303,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto cend = __cend::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __cend_cpo = __cend::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__ranges/common_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/common_view.h
@@ -87,11 +87,11 @@ public:
   {
     if constexpr (random_access_range<_View> && sized_range<_View>)
     {
-      return ::cuda::std::ranges::begin(__base_);
+      return ::cuda::std::ranges::__begin_cpo{}(__base_);
     }
     else
     {
-      return common_iterator<iterator_t<_View>, sentinel_t<_View>>{::cuda::std::ranges::begin(__base_)};
+      return common_iterator<iterator_t<_View>, sentinel_t<_View>>{::cuda::std::ranges::__begin_cpo{}(__base_)};
     }
     _CCCL_UNREACHABLE();
   }
@@ -102,11 +102,12 @@ public:
   {
     if constexpr (random_access_range<const _View> && sized_range<const _View>)
     {
-      return ::cuda::std::ranges::begin(__base_);
+      return ::cuda::std::ranges::__begin_cpo{}(__base_);
     }
     else
     {
-      return common_iterator<iterator_t<const _View>, sentinel_t<const _View>>{::cuda::std::ranges::begin(__base_)};
+      return common_iterator<iterator_t<const _View>, sentinel_t<const _View>>{
+        ::cuda::std::ranges::__begin_cpo{}(__base_)};
     }
     _CCCL_UNREACHABLE();
   }
@@ -115,11 +116,11 @@ public:
   {
     if constexpr (random_access_range<_View> && sized_range<_View>)
     {
-      return ::cuda::std::ranges::begin(__base_) + ::cuda::std::ranges::size(__base_);
+      return ::cuda::std::ranges::__begin_cpo{}(__base_) + ::cuda::std::ranges::__size_cpo{}(__base_);
     }
     else
     {
-      return common_iterator<iterator_t<_View>, sentinel_t<_View>>{::cuda::std::ranges::end(__base_)};
+      return common_iterator<iterator_t<_View>, sentinel_t<_View>>{::cuda::std::ranges::__end_cpo{}(__base_)};
     }
     _CCCL_UNREACHABLE();
   }
@@ -130,11 +131,12 @@ public:
   {
     if constexpr (random_access_range<const _View> && sized_range<const _View>)
     {
-      return ::cuda::std::ranges::begin(__base_) + ::cuda::std::ranges::size(__base_);
+      return ::cuda::std::ranges::__begin_cpo{}(__base_) + ::cuda::std::ranges::__size_cpo{}(__base_);
     }
     else
     {
-      return common_iterator<iterator_t<const _View>, sentinel_t<const _View>>{::cuda::std::ranges::end(__base_)};
+      return common_iterator<iterator_t<const _View>, sentinel_t<const _View>>{
+        ::cuda::std::ranges::__end_cpo{}(__base_)};
     }
     _CCCL_UNREACHABLE();
   }
@@ -143,14 +145,14 @@ public:
   _CCCL_REQUIRES(sized_range<_View2>)
   [[nodiscard]] _CCCL_API constexpr auto size()
   {
-    return ::cuda::std::ranges::size(__base_);
+    return ::cuda::std::ranges::__size_cpo{}(__base_);
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(sized_range<const _View2>)
   [[nodiscard]] _CCCL_API constexpr auto size() const
   {
-    return ::cuda::std::ranges::size(__base_);
+    return ::cuda::std::ranges::__size_cpo{}(__base_);
   }
 };
 

--- a/libcudacxx/include/cuda/std/__ranges/concepts.h
+++ b/libcudacxx/include/cuda/std/__ranges/concepts.h
@@ -52,8 +52,8 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
 template <class _Tp>
 concept range = requires(_Tp& __t) {
-  ::cuda::std::ranges::begin(__t); // sometimes equality-preserving
-  ::cuda::std::ranges::end(__t);
+  ::cuda::std::ranges::__begin_cpo{}(__t); // sometimes equality-preserving
+  ::cuda::std::ranges::__end_cpo{}(__t);
 };
 
 template <class _Tp>
@@ -66,7 +66,7 @@ concept borrowed_range =
 // `iterator_t` defined in <__ranges/access.h>
 
 template <range _Rp>
-using sentinel_t = decltype(::cuda::std::ranges::end(::cuda::std::declval<_Rp&>()));
+using sentinel_t = decltype(::cuda::std::ranges::__end_cpo{}(::cuda::std::declval<_Rp&>()));
 
 template <range _Rp>
 using range_difference_t = iter_difference_t<iterator_t<_Rp>>;
@@ -85,10 +85,10 @@ using range_common_reference_t = iter_common_reference_t<iterator_t<_Rp>>;
 
 // [range.sized]
 template <class _Tp>
-concept sized_range = range<_Tp> && requires(_Tp& __t) { ::cuda::std::ranges::size(__t); };
+concept sized_range = range<_Tp> && requires(_Tp& __t) { ::cuda::std::ranges::__size_cpo{}(__t); };
 
 template <sized_range _Rp>
-using range_size_t = decltype(::cuda::std::ranges::size(::cuda::std::declval<_Rp&>()));
+using range_size_t = decltype(::cuda::std::ranges::__size_cpo{}(::cuda::std::declval<_Rp&>()));
 
 // `disable_sized_range` defined in `<__ranges/size.h>`
 
@@ -119,7 +119,7 @@ concept random_access_range = bidirectional_range<_Tp> && random_access_iterator
 
 template <class _Tp>
 concept contiguous_range = random_access_range<_Tp> && contiguous_iterator<iterator_t<_Tp>> && requires(_Tp& __t) {
-  { ::cuda::std::ranges::data(__t) } -> same_as<add_pointer_t<range_reference_t<_Tp>>>;
+  { ::cuda::std::ranges::__data_cpo{}(__t) } -> same_as<add_pointer_t<range_reference_t<_Tp>>>;
 };
 
 template <class _Tp>
@@ -141,8 +141,8 @@ template <class _Tp>
 _CCCL_CONCEPT range =
   _CCCL_REQUIRES_EXPR((_Tp), _Tp& __t)
   (
-    void(::cuda::std::ranges::begin(__t)),
-    void(::cuda::std::ranges::end(__t))
+    void(::cuda::std::ranges::__begin_cpo{}(__t)),
+    void(::cuda::std::ranges::__end_cpo{}(__t))
   );
 
 template <class _Tp>
@@ -166,7 +166,7 @@ _CCCL_CONCEPT borrowed_range = _CCCL_FRAGMENT(__borrowed_range_, _Range);
 // `iterator_t` defined in <__ranges/access.h>
 
 template <class _Rp>
-using sentinel_t = enable_if_t<range<_Rp>, decltype(::cuda::std::ranges::end(::cuda::std::declval<_Rp&>()))>;
+using sentinel_t = enable_if_t<range<_Rp>, decltype(::cuda::std::ranges::__end_cpo{}(::cuda::std::declval<_Rp&>()))>;
 
 template <class _Rp>
 using range_difference_t = enable_if_t<range<_Rp>, iter_difference_t<iterator_t<_Rp>>>;
@@ -185,14 +185,15 @@ using range_common_reference_t = enable_if_t<range<_Rp>, iter_common_reference_t
 
 // [range.sized]
 template <class _Tp>
-_CCCL_CONCEPT_FRAGMENT(__sized_range_,
-                       requires(_Tp& __t)(requires(range<_Tp>), typename(decltype(::cuda::std::ranges::size(__t)))));
+_CCCL_CONCEPT_FRAGMENT(
+  __sized_range_, requires(_Tp& __t)(requires(range<_Tp>), typename(decltype(::cuda::std::ranges::__size_cpo{}(__t)))));
 
 template <class _Tp>
 _CCCL_CONCEPT sized_range = _CCCL_FRAGMENT(__sized_range_, _Tp);
 
 template <class _Rp>
-using range_size_t = enable_if_t<sized_range<_Rp>, decltype(::cuda::std::ranges::size(::cuda::std::declval<_Rp&>()))>;
+using range_size_t =
+  enable_if_t<sized_range<_Rp>, decltype(::cuda::std::ranges::__size_cpo{}(::cuda::std::declval<_Rp&>()))>;
 
 // `disable_sized_range` defined in `<__ranges/size.h>`
 
@@ -254,7 +255,7 @@ _CCCL_CONCEPT_FRAGMENT(
   requires(_Tp& __t)(
     requires(random_access_range<_Tp>),
     requires(contiguous_iterator<iterator_t<_Tp>>),
-    requires(same_as<decltype(::cuda::std::ranges::data(__t)), add_pointer_t<range_reference_t<_Tp>>>)));
+    requires(same_as<decltype(::cuda::std::ranges::__data_cpo{}(__t)), add_pointer_t<range_reference_t<_Tp>>>)));
 
 template <class _Tp>
 _CCCL_CONCEPT contiguous_range = _CCCL_FRAGMENT(__contiguous_range_, _Tp);

--- a/libcudacxx/include/cuda/std/__ranges/data.h
+++ b/libcudacxx/include/cuda/std/__ranges/data.h
@@ -51,7 +51,7 @@ concept __member_data = __can_borrow<_Tp> && __workaround_52970<_Tp> && requires
 
 template <class _Tp>
 concept __ranges_begin_invocable = !__member_data<_Tp> && __can_borrow<_Tp> && requires(_Tp&& __t) {
-  { ::cuda::std::ranges::begin(__t) } -> contiguous_iterator;
+  { ::cuda::std::ranges::__begin_cpo{}(__t) } -> contiguous_iterator;
 };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Tp>
@@ -64,10 +64,11 @@ template <class _Tp>
 _CCCL_CONCEPT __member_data = _CCCL_FRAGMENT(__member_data_, _Tp);
 
 template <class _Tp>
-_CCCL_CONCEPT_FRAGMENT(__ranges_begin_invocable_,
-                       requires(_Tp&& __t)(requires(!__member_data<_Tp>),
-                                           requires(__can_borrow<_Tp>),
-                                           requires(contiguous_iterator<decltype(::cuda::std::ranges::begin(__t))>)));
+_CCCL_CONCEPT_FRAGMENT(
+  __ranges_begin_invocable_,
+  requires(_Tp&& __t)(requires(!__member_data<_Tp>),
+                      requires(__can_borrow<_Tp>),
+                      requires(contiguous_iterator<decltype(::cuda::std::ranges::__begin_cpo{}(__t))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __ranges_begin_invocable = _CCCL_FRAGMENT(__ranges_begin_invocable_, _Tp);
@@ -87,9 +88,9 @@ struct __fn
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__ranges_begin_invocable<_Tp>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::to_address(::cuda::std::ranges::begin(__t))))
+    noexcept(noexcept(::cuda::std::to_address(::cuda::std::ranges::__begin_cpo{}(__t))))
   {
-    return ::cuda::std::to_address(::cuda::std::ranges::begin(__t));
+    return ::cuda::std::to_address(::cuda::std::ranges::__begin_cpo{}(__t));
   }
 };
 _CCCL_END_NAMESPACE_CPO
@@ -97,6 +98,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto data = __data::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __data_cpo = __data::__fn;
 } // namespace __cpo
 
 // [range.prim.cdata]
@@ -107,19 +111,19 @@ struct __fn
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_lvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::data(static_cast<const remove_reference_t<_Tp>&>(__t))))
-      -> decltype(::cuda::std::ranges::data(static_cast<const remove_reference_t<_Tp>&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__data_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t))))
+      -> decltype(::cuda::std::ranges::__data_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t)))
   {
-    return ::cuda::std::ranges::data(static_cast<const remove_reference_t<_Tp>&>(__t));
+    return ::cuda::std::ranges::__data_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t));
   }
 
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_rvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::data(static_cast<const _Tp&&>(__t))))
-      -> decltype(::cuda::std::ranges::data(static_cast<const _Tp&&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__data_cpo{}(static_cast<const _Tp&&>(__t))))
+      -> decltype(::cuda::std::ranges::__data_cpo{}(static_cast<const _Tp&&>(__t)))
   {
-    return ::cuda::std::ranges::data(static_cast<const _Tp&&>(__t));
+    return ::cuda::std::ranges::__data_cpo{}(static_cast<const _Tp&&>(__t));
   }
 };
 _CCCL_END_NAMESPACE_CPO
@@ -127,6 +131,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto cdata = __cdata::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __cdata_cpo = __cdata::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__ranges/drop_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/drop_view.h
@@ -64,7 +64,7 @@ template <class _View, enable_if_t<view<_View>, int> = 0>
 #endif // !_CCCL_HAS_CONCEPTS()
 class drop_view : public view_interface<drop_view<_View>>
 {
-  // We cache begin() whenever ::cuda::std::ranges::next is not guaranteed O(1) to provide an
+  // We cache begin() whenever ::cuda::std::ranges::__next_cpo{} is not guaranteed O(1) to provide an
   // amortized O(1) begin() method. If this is an input_range, then we cannot cache
   // begin because begin is not equality preserving.
   // Note: drop_view<input-range>::begin() is still trivially amortized O(1) because
@@ -115,21 +115,22 @@ public:
   {
     if constexpr (random_access_range<_View2> && sized_range<_View2>)
     {
-      const auto __dist = ::cuda::std::min(::cuda::std::ranges::distance(__base_), __count_);
-      return ::cuda::std::ranges::begin(__base_) + __dist;
+      const auto __dist = ::cuda::std::min(::cuda::std::ranges::__distance_cpo{}(__base_), __count_);
+      return ::cuda::std::ranges::__begin_cpo{}(__base_) + __dist;
     }
     else if constexpr (_UseCache)
     {
       if (!__cached_begin_.__has_value())
       {
-        __cached_begin_.__emplace(
-          ::cuda::std::ranges::next(::cuda::std::ranges::begin(__base_), __count_, ::cuda::std::ranges::end(__base_)));
+        __cached_begin_.__emplace(::cuda::std::ranges::__next_cpo{}(
+          ::cuda::std::ranges::__begin_cpo{}(__base_), __count_, ::cuda::std::ranges::__end_cpo{}(__base_)));
       }
       return *__cached_begin_;
     }
     else
     {
-      return ::cuda::std::ranges::next(::cuda::std::ranges::begin(__base_), __count_, ::cuda::std::ranges::end(__base_));
+      return ::cuda::std::ranges::__next_cpo{}(
+        ::cuda::std::ranges::__begin_cpo{}(__base_), __count_, ::cuda::std::ranges::__end_cpo{}(__base_));
     }
   }
 
@@ -137,28 +138,28 @@ public:
   _CCCL_REQUIRES(random_access_range<const _View2>&& sized_range<const _View2>)
   _CCCL_API constexpr auto begin() const
   {
-    const auto __dist = ::cuda::std::min(::cuda::std::ranges::distance(__base_), __count_);
-    return ::cuda::std::ranges::begin(__base_) + __dist;
+    const auto __dist = ::cuda::std::min(::cuda::std::ranges::__distance_cpo{}(__base_), __count_);
+    return ::cuda::std::ranges::__begin_cpo{}(__base_) + __dist;
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES((!__simple_view<_View2>) )
   _CCCL_API constexpr auto end()
   {
-    return ::cuda::std::ranges::end(__base_);
+    return ::cuda::std::ranges::__end_cpo{}(__base_);
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(range<const _View2>)
   _CCCL_API constexpr auto end() const
   {
-    return ::cuda::std::ranges::end(__base_);
+    return ::cuda::std::ranges::__end_cpo{}(__base_);
   }
 
   template <class _Self = drop_view>
   _CCCL_API static constexpr auto __size(_Self& __self)
   {
-    const auto __s = ::cuda::std::ranges::size(__self.__base_);
+    const auto __s = ::cuda::std::ranges::__size_cpo{}(__self.__base_);
     const auto __c = static_cast<decltype(__s)>(__self.__count_);
     return __s < __c ? 0 : __s - __c;
   }
@@ -294,14 +295,14 @@ struct __fn
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Range&& __rng, _Np&& __n) const
     // Note: deliberately not forwarding `__rng` to guard against double moves.
     noexcept(noexcept(__passthrough_type_t<_RawRange>(
-      ::cuda::std::ranges::begin(__rng)
-        + ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__rng), ::cuda::std::forward<_Np>(__n)),
-      ::cuda::std::ranges::end(__rng)))) -> __passthrough_type_t<_RawRange>
+      ::cuda::std::ranges::__begin_cpo{}(__rng)
+        + ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__rng), ::cuda::std::forward<_Np>(__n)),
+      ::cuda::std::ranges::__end_cpo{}(__rng)))) -> __passthrough_type_t<_RawRange>
   {
     return __passthrough_type_t<_RawRange>(
-      ::cuda::std::ranges::begin(__rng)
-        + ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__rng), ::cuda::std::forward<_Np>(__n)),
-      ::cuda::std::ranges::end(__rng));
+      ::cuda::std::ranges::__begin_cpo{}(__rng)
+        + ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__rng), ::cuda::std::forward<_Np>(__n)),
+      ::cuda::std::ranges::__end_cpo{}(__rng));
   }
 
   // [range.drop.overview]: the `subrange (StoreSize == true)` case.
@@ -311,19 +312,20 @@ struct __fn
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Range&& __rng, _Np&& __n) const
     // Note: deliberately not forwarding `__rng` to guard against double moves.
     noexcept(noexcept(_RawRange(
-      ::cuda::std::ranges::begin(__rng)
-        + ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__rng), ::cuda::std::forward<_Np>(__n)),
-      ::cuda::std::ranges::end(__rng),
+      ::cuda::std::ranges::__begin_cpo{}(__rng)
+        + ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__rng), ::cuda::std::forward<_Np>(__n)),
+      ::cuda::std::ranges::__end_cpo{}(__rng),
       ::cuda::std::__to_unsigned_like(
-        ::cuda::std::ranges::distance(__rng)
-        - ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__rng), ::cuda::std::forward<_Np>(__n)))))) -> _RawRange
+        ::cuda::std::ranges::__distance_cpo{}(__rng)
+        - ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__rng), ::cuda::std::forward<_Np>(__n))))))
+      -> _RawRange
   {
     // Introducing local variables avoids calculating `min` and `distance` twice (at the cost of diverging from the
     // expression used in the `noexcept` clause and the return statement).
-    auto dist    = ::cuda::std::ranges::distance(__rng);
+    auto dist    = ::cuda::std::ranges::__distance_cpo{}(__rng);
     auto clamped = ::cuda::std::min<_Dist>(dist, ::cuda::std::forward<_Np>(__n));
-    return _RawRange(::cuda::std::ranges::begin(__rng) + clamped,
-                     ::cuda::std::ranges::end(__rng),
+    return _RawRange(::cuda::std::ranges::__begin_cpo{}(__rng) + clamped,
+                     ::cuda::std::ranges::__end_cpo{}(__rng),
                      ::cuda::std::__to_unsigned_like(dist - clamped));
   }
 
@@ -335,14 +337,14 @@ struct __fn
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Range&& __range, _Np&& __n) const
     noexcept(noexcept(::cuda::std::ranges::views::repeat(
       ::cuda::std::forward_like<_Range>(*__range.__value_),
-      ::cuda::std::ranges::distance(__range)
-        - ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__range), ::cuda::std::forward<_Np>(__n)))))
+      ::cuda::std::ranges::__distance_cpo{}(__range)
+        - ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__range), ::cuda::std::forward<_Np>(__n)))))
       -> _RawRange
   {
     return ::cuda::std::ranges::views::repeat(
       ::cuda::std::forward_like<_Range>(*__range.__value_),
-      ::cuda::std::ranges::distance(__range)
-        - ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__range), ::cuda::std::forward<_Np>(__n)));
+      ::cuda::std::ranges::__distance_cpo{}(__range)
+        - ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__range), ::cuda::std::forward<_Np>(__n)));
   }
 
   // [range.take.overview]: the `repeat_view` "otherwise" case.

--- a/libcudacxx/include/cuda/std/__ranges/drop_while_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/drop_while_view.h
@@ -128,7 +128,7 @@ public:
 
   [[nodiscard]] _CCCL_API constexpr auto end()
   {
-    return ::cuda::std::ranges::end(__base_);
+    return ::cuda::std::ranges::__end_cpo{}(__base_);
   }
 };
 

--- a/libcudacxx/include/cuda/std/__ranges/empty.h
+++ b/libcudacxx/include/cuda/std/__ranges/empty.h
@@ -38,12 +38,12 @@ template <class _Tp>
 concept __member_empty = __workaround_52970<_Tp> && requires(_Tp&& __t) { bool(__t.empty()); };
 
 template <class _Tp>
-concept __can_invoke_size = !__member_empty<_Tp> && requires(_Tp&& __t) { ::cuda::std::ranges::size(__t); };
+concept __can_invoke_size = !__member_empty<_Tp> && requires(_Tp&& __t) { ::cuda::std::ranges::__size_cpo{}(__t); };
 
 template <class _Tp>
 concept __can_compare_begin_end = !__member_empty<_Tp> && !__can_invoke_size<_Tp> && requires(_Tp&& __t) {
-  bool(::cuda::std::ranges::begin(__t) == ::cuda::std::ranges::end(__t));
-  { ::cuda::std::ranges::begin(__t) } -> forward_iterator;
+  bool(::cuda::std::ranges::__begin_cpo{}(__t) == ::cuda::std::ranges::__end_cpo{}(__t));
+  { ::cuda::std::ranges::__begin_cpo{}(__t) } -> forward_iterator;
 };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Tp>
@@ -53,8 +53,9 @@ template <class _Tp>
 _CCCL_CONCEPT __member_empty = _CCCL_FRAGMENT(__member_empty_, _Tp);
 
 template <class _Tp>
-_CCCL_CONCEPT_FRAGMENT(__can_invoke_size_,
-                       requires(_Tp&& __t)(requires(!__member_empty<_Tp>), ((void) ::cuda::std::ranges::size(__t))));
+_CCCL_CONCEPT_FRAGMENT(
+  __can_invoke_size_,
+  requires(_Tp&& __t)(requires(!__member_empty<_Tp>), ((void) ::cuda::std::ranges::__size_cpo{}(__t))));
 
 template <class _Tp>
 _CCCL_CONCEPT __can_invoke_size = _CCCL_FRAGMENT(__can_invoke_size_, _Tp);
@@ -64,8 +65,8 @@ _CCCL_CONCEPT_FRAGMENT(
   __can_compare_begin_end_,
   requires(_Tp&& __t)(requires(!__member_empty<_Tp>),
                       requires(!__can_invoke_size<_Tp>),
-                      (bool(::cuda::std::ranges::begin(__t) == ::cuda::std::ranges::end(__t))),
-                      requires(forward_iterator<decltype(::cuda::std::ranges::begin(__t))>)));
+                      (bool(::cuda::std::ranges::__begin_cpo{}(__t) == ::cuda::std::ranges::__end_cpo{}(__t))),
+                      requires(forward_iterator<decltype(::cuda::std::ranges::__begin_cpo{}(__t))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __can_compare_begin_end = _CCCL_FRAGMENT(__can_compare_begin_end_, _Tp);
@@ -82,17 +83,18 @@ struct __fn
 
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__can_invoke_size<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr bool operator()(_Tp&& __t) const noexcept(noexcept(::cuda::std::ranges::size(__t)))
+  [[nodiscard]] _CCCL_API constexpr bool operator()(_Tp&& __t) const
+    noexcept(noexcept(::cuda::std::ranges::__size_cpo{}(__t)))
   {
-    return ::cuda::std::ranges::size(__t) == 0;
+    return ::cuda::std::ranges::__size_cpo{}(__t) == 0;
   }
 
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__can_compare_begin_end<_Tp>)
   [[nodiscard]] _CCCL_API constexpr bool operator()(_Tp&& __t) const
-    noexcept(noexcept(bool(::cuda::std::ranges::begin(__t) == ::cuda::std::ranges::end(__t))))
+    noexcept(noexcept(bool(::cuda::std::ranges::__begin_cpo{}(__t) == ::cuda::std::ranges::__end_cpo{}(__t))))
   {
-    return ::cuda::std::ranges::begin(__t) == ::cuda::std::ranges::end(__t);
+    return ::cuda::std::ranges::__begin_cpo{}(__t) == ::cuda::std::ranges::__end_cpo{}(__t);
   }
 };
 _CCCL_END_NAMESPACE_CPO
@@ -100,6 +102,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto empty = __empty::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __empty_cpo = __empty::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__ranges/filter_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/filter_view.h
@@ -159,7 +159,7 @@ public:
     {
       __current_ = ::cuda::std::ranges::find_if(
         ::cuda::std::move(++__current_),
-        ::cuda::std::ranges::end(__parent_->__base_),
+        ::cuda::std::ranges::__end_cpo{}(__parent_->__base_),
         ::cuda::std::ref(*__parent_->__pred_));
       return *this;
     }
@@ -227,9 +227,9 @@ public:
 #endif // _LIBCUDACXX_HAS_NO_SPACESHIP_OPERATOR()
 
     [[nodiscard]] _CCCL_API friend constexpr range_rvalue_reference_t<_View>
-    iter_move(const __iterator& __it) noexcept(noexcept(::cuda::std::ranges::iter_move(__it.__current_)))
+    iter_move(const __iterator& __it) noexcept(noexcept(::cuda::std::ranges::__iter_move_cpo{}(__it.__current_)))
     {
-      return ::cuda::std::ranges::iter_move(__it.__current_);
+      return ::cuda::std::ranges::__iter_move_cpo{}(__it.__current_);
     }
 
     _CCCL_TEMPLATE(class _View2 = _View)
@@ -237,7 +237,7 @@ public:
     _CCCL_API friend constexpr void
     iter_swap(const __iterator& __x, const __iterator& __y) noexcept(__noexcept_swappable<iterator_t<_View2>>)
     {
-      ::cuda::std::ranges::iter_swap(__x.__current_, __y.__current_);
+      ::cuda::std::ranges::__iter_swap_cpo{}(__x.__current_, __y.__current_);
     }
   };
 
@@ -249,7 +249,7 @@ public:
     _CCCL_HIDE_FROM_ABI constexpr __sentinel() = default;
 
     _CCCL_API constexpr explicit __sentinel(filter_view& __parent)
-        : __end_{::cuda::std::ranges::end(__parent.__base_)}
+        : __end_{::cuda::std::ranges::__end_cpo{}(__parent.__base_)}
     {}
 
     [[nodiscard]] _CCCL_API constexpr sentinel_t<_View> base() const
@@ -343,7 +343,7 @@ public:
   {
     if constexpr (common_range<_View>)
     {
-      return __iterator{*this, ::cuda::std::ranges::end(__base_)};
+      return __iterator{*this, ::cuda::std::ranges::__end_cpo{}(__base_)};
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__ranges/owning_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/owning_view.h
@@ -92,63 +92,63 @@ public:
 
   [[nodiscard]] _CCCL_API constexpr iterator_t<_Rp> begin()
   {
-    return ::cuda::std::ranges::begin(__r_);
+    return ::cuda::std::ranges::__begin_cpo{}(__r_);
   }
   [[nodiscard]] _CCCL_API constexpr sentinel_t<_Rp> end()
   {
-    return ::cuda::std::ranges::end(__r_);
+    return ::cuda::std::ranges::__end_cpo{}(__r_);
   }
 
   _CCCL_TEMPLATE(class _Range = _Rp)
   _CCCL_REQUIRES(range<const _Range>)
   [[nodiscard]] _CCCL_API constexpr auto begin() const
   {
-    return ::cuda::std::ranges::begin(__r_);
+    return ::cuda::std::ranges::__begin_cpo{}(__r_);
   }
   _CCCL_TEMPLATE(class _Range = _Rp)
   _CCCL_REQUIRES(range<const _Range>)
   [[nodiscard]] _CCCL_API constexpr auto end() const
   {
-    return ::cuda::std::ranges::end(__r_);
+    return ::cuda::std::ranges::__end_cpo{}(__r_);
   }
 
   _CCCL_TEMPLATE(class _Range = _Rp)
   _CCCL_REQUIRES(invocable<::cuda::std::ranges::__empty::__fn, _Range&>)
   [[nodiscard]] _CCCL_API constexpr bool empty()
   {
-    return ::cuda::std::ranges::empty(__r_);
+    return ::cuda::std::ranges::__empty_cpo{}(__r_);
   }
   _CCCL_TEMPLATE(class _Range = _Rp)
   _CCCL_REQUIRES(invocable<::cuda::std::ranges::__empty::__fn, const _Range&>)
   [[nodiscard]] _CCCL_API constexpr bool empty() const
   {
-    return ::cuda::std::ranges::empty(__r_);
+    return ::cuda::std::ranges::__empty_cpo{}(__r_);
   }
 
   _CCCL_TEMPLATE(class _Range = _Rp)
   _CCCL_REQUIRES(sized_range<_Range>)
   [[nodiscard]] _CCCL_API constexpr auto size()
   {
-    return ::cuda::std::ranges::size(__r_);
+    return ::cuda::std::ranges::__size_cpo{}(__r_);
   }
   _CCCL_TEMPLATE(class _Range = _Rp)
   _CCCL_REQUIRES(sized_range<const _Range>)
   [[nodiscard]] _CCCL_API constexpr auto size() const
   {
-    return ::cuda::std::ranges::size(__r_);
+    return ::cuda::std::ranges::__size_cpo{}(__r_);
   }
 
   _CCCL_TEMPLATE(class _Range = _Rp)
   _CCCL_REQUIRES(contiguous_range<_Range>)
   [[nodiscard]] _CCCL_API constexpr auto data()
   {
-    return ::cuda::std::ranges::data(__r_);
+    return ::cuda::std::ranges::__data_cpo{}(__r_);
   }
   _CCCL_TEMPLATE(class _Range = _Rp)
   _CCCL_REQUIRES(contiguous_range<const _Range>)
   [[nodiscard]] _CCCL_API constexpr auto data() const
   {
-    return ::cuda::std::ranges::data(__r_);
+    return ::cuda::std::ranges::__data_cpo{}(__r_);
   }
 };
 _CCCL_CTAD_SUPPORTED_FOR_TYPE(owning_view);

--- a/libcudacxx/include/cuda/std/__ranges/rbegin.h
+++ b/libcudacxx/include/cuda/std/__ranges/rbegin.h
@@ -58,8 +58,8 @@ concept __unqualified_rbegin =
 template <class _Tp>
 concept __can_reverse =
   __can_borrow<_Tp> && !__member_rbegin<_Tp> && !__unqualified_rbegin<_Tp> && requires(_Tp&& __t) {
-    { ::cuda::std::ranges::begin(__t) } -> same_as<decltype(::cuda::std::ranges::end(__t))>;
-    { ::cuda::std::ranges::begin(__t) } -> bidirectional_iterator;
+    { ::cuda::std::ranges::__begin_cpo{}(__t) } -> same_as<decltype(::cuda::std::ranges::__end_cpo{}(__t))>;
+    { ::cuda::std::ranges::__begin_cpo{}(__t) } -> bidirectional_iterator;
   };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Tp>
@@ -90,8 +90,9 @@ _CCCL_CONCEPT_FRAGMENT(
     requires(__can_borrow<_Tp>),
     requires(!__member_rbegin<_Tp>),
     requires(!__unqualified_rbegin<_Tp>),
-    requires(same_as<decltype(::cuda::std::ranges::end(__t)), decltype(::cuda::std::ranges::begin(__t))>),
-    requires(bidirectional_iterator<decltype(::cuda::std::ranges::begin(__t))>)));
+    requires(
+      same_as<decltype(::cuda::std::ranges::__end_cpo{}(__t)), decltype(::cuda::std::ranges::__begin_cpo{}(__t))>),
+    requires(bidirectional_iterator<decltype(::cuda::std::ranges::__begin_cpo{}(__t))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __can_reverse = _CCCL_FRAGMENT(__can_reverse_, _Tp);
@@ -120,9 +121,10 @@ struct __fn
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__can_reverse<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(::cuda::std::ranges::end(__t)))
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
+    noexcept(noexcept(::cuda::std::ranges::__end_cpo{}(__t)))
   {
-    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::end(__t));
+    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::__end_cpo{}(__t));
   }
 
   _CCCL_TEMPLATE(class _Tp)
@@ -134,6 +136,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto rbegin = __rbegin::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __rbegin_cpo = __rbegin::__fn;
 } // namespace __cpo
 
 // [range.access.crbegin]
@@ -145,20 +150,20 @@ struct __fn
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_lvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::rbegin(static_cast<const remove_reference_t<_Tp>&>(__t))))
-      -> decltype(::cuda::std::ranges::rbegin(static_cast<const remove_reference_t<_Tp>&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__rbegin_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t))))
+      -> decltype(::cuda::std::ranges::__rbegin_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t)))
   {
-    return ::cuda::std::ranges::rbegin(static_cast<const remove_reference_t<_Tp>&>(__t));
+    return ::cuda::std::ranges::__rbegin_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t));
   }
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_rvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::rbegin(static_cast<const _Tp&&>(__t))))
-      -> decltype(::cuda::std::ranges::rbegin(static_cast<const _Tp&&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__rbegin_cpo{}(static_cast<const _Tp&&>(__t))))
+      -> decltype(::cuda::std::ranges::__rbegin_cpo{}(static_cast<const _Tp&&>(__t)))
   {
-    return ::cuda::std::ranges::rbegin(static_cast<const _Tp&&>(__t));
+    return ::cuda::std::ranges::__rbegin_cpo{}(static_cast<const _Tp&&>(__t));
   }
 };
 _CCCL_END_NAMESPACE_CPO
@@ -166,6 +171,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto crbegin = __crbegin::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __crbegin_cpo = __crbegin::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__ranges/ref_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/ref_view.h
@@ -79,32 +79,32 @@ public:
 
   _CCCL_API constexpr iterator_t<_Range> begin() const
   {
-    return ::cuda::std::ranges::begin(*__range_);
+    return ::cuda::std::ranges::__begin_cpo{}(*__range_);
   }
   _CCCL_API constexpr sentinel_t<_Range> end() const
   {
-    return ::cuda::std::ranges::end(*__range_);
+    return ::cuda::std::ranges::__end_cpo{}(*__range_);
   }
 
   _CCCL_TEMPLATE(class _Range2 = _Range)
   _CCCL_REQUIRES(invocable<::cuda::std::ranges::__empty::__fn, const _Range2&>)
   _CCCL_API constexpr bool empty() const
   {
-    return ::cuda::std::ranges::empty(*__range_);
+    return ::cuda::std::ranges::__empty_cpo{}(*__range_);
   }
 
   _CCCL_TEMPLATE(class _Range2 = _Range)
   _CCCL_REQUIRES(sized_range<_Range2>)
   _CCCL_API constexpr auto size() const
   {
-    return ::cuda::std::ranges::size(*__range_);
+    return ::cuda::std::ranges::__size_cpo{}(*__range_);
   }
 
   _CCCL_TEMPLATE(class _Range2 = _Range)
   _CCCL_REQUIRES(contiguous_range<_Range2>)
   _CCCL_API constexpr auto data() const
   {
-    return ::cuda::std::ranges::data(*__range_);
+    return ::cuda::std::ranges::__data_cpo{}(*__range_);
   }
 };
 

--- a/libcudacxx/include/cuda/std/__ranges/rend.h
+++ b/libcudacxx/include/cuda/std/__ranges/rend.h
@@ -47,21 +47,21 @@ void rend(const _Tp&) = delete;
 #if _CCCL_HAS_CONCEPTS()
 template <class _Tp>
 concept __member_rend = __can_borrow<_Tp> && __workaround_52970<_Tp> && requires(_Tp&& __t) {
-  ::cuda::std::ranges::rbegin(__t);
-  { _LIBCUDACXX_AUTO_CAST(__t.rend()) } -> sentinel_for<decltype(::cuda::std::ranges::rbegin(__t))>;
+  ::cuda::std::ranges::__rbegin_cpo{}(__t);
+  { _LIBCUDACXX_AUTO_CAST(__t.rend()) } -> sentinel_for<decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))>;
 };
 
 template <class _Tp>
 concept __unqualified_rend =
   !__member_rend<_Tp> && __can_borrow<_Tp> && __class_or_enum<remove_cvref_t<_Tp>> && requires(_Tp&& __t) {
-    ::cuda::std::ranges::rbegin(__t);
-    { _LIBCUDACXX_AUTO_CAST(rend(__t)) } -> sentinel_for<decltype(::cuda::std::ranges::rbegin(__t))>;
+    ::cuda::std::ranges::__rbegin_cpo{}(__t);
+    { _LIBCUDACXX_AUTO_CAST(rend(__t)) } -> sentinel_for<decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))>;
   };
 
 template <class _Tp>
 concept __can_reverse = __can_borrow<_Tp> && !__member_rend<_Tp> && !__unqualified_rend<_Tp> && requires(_Tp&& __t) {
-  { ::cuda::std::ranges::begin(__t) } -> same_as<decltype(::cuda::std::ranges::end(__t))>;
-  { ::cuda::std::ranges::begin(__t) } -> bidirectional_iterator;
+  { ::cuda::std::ranges::__begin_cpo{}(__t) } -> same_as<decltype(::cuda::std::ranges::__end_cpo{}(__t))>;
+  { ::cuda::std::ranges::__begin_cpo{}(__t) } -> bidirectional_iterator;
 };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Tp>
@@ -70,8 +70,9 @@ _CCCL_CONCEPT_FRAGMENT(
   requires(_Tp&& __t)(
     requires(__can_borrow<_Tp>),
     requires(__workaround_52970<_Tp>),
-    typename(decltype(::cuda::std::ranges::rbegin(__t))),
-    requires(sentinel_for<decltype(_LIBCUDACXX_AUTO_CAST(__t.rend())), decltype(::cuda::std::ranges::rbegin(__t))>)));
+    typename(decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))),
+    requires(
+      sentinel_for<decltype(_LIBCUDACXX_AUTO_CAST(__t.rend())), decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __member_rend = _CCCL_FRAGMENT(__member_rend_, _Tp);
@@ -83,8 +84,9 @@ _CCCL_CONCEPT_FRAGMENT(
     requires(!__member_rend<_Tp>),
     requires(__can_borrow<_Tp>),
     requires(__class_or_enum<remove_cvref_t<_Tp>>),
-    typename(decltype(::cuda::std::ranges::rbegin(__t))),
-    requires(sentinel_for<decltype(_LIBCUDACXX_AUTO_CAST(rend(__t))), decltype(::cuda::std::ranges::rbegin(__t))>)));
+    typename(decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))),
+    requires(
+      sentinel_for<decltype(_LIBCUDACXX_AUTO_CAST(rend(__t))), decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __unqualified_rend = _CCCL_FRAGMENT(__unqualified_rend_, _Tp);
@@ -96,8 +98,9 @@ _CCCL_CONCEPT_FRAGMENT(
     requires(!__member_rend<_Tp>),
     requires(!__unqualified_rend<_Tp>),
     requires(__can_borrow<_Tp>),
-    requires(same_as<decltype(::cuda::std::ranges::begin(__t)), decltype(::cuda::std::ranges::end(__t))>),
-    requires(bidirectional_iterator<decltype(::cuda::std::ranges::begin(__t))>)));
+    requires(
+      same_as<decltype(::cuda::std::ranges::__begin_cpo{}(__t)), decltype(::cuda::std::ranges::__end_cpo{}(__t))>),
+    requires(bidirectional_iterator<decltype(::cuda::std::ranges::__begin_cpo{}(__t))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __can_reverse = _CCCL_FRAGMENT(__can_reverse_, _Tp);
@@ -127,9 +130,10 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__can_reverse<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(::cuda::std::ranges::begin(__t)))
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
+    noexcept(noexcept(::cuda::std::ranges::__begin_cpo{}(__t)))
   {
-    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::begin(__t));
+    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::__begin_cpo{}(__t));
   }
 
   _CCCL_TEMPLATE(class _Tp)
@@ -141,6 +145,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto rend = __rend::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __rend_cpo = __rend::__fn;
 } // namespace __cpo
 
 // [range.access.crend]
@@ -152,20 +159,20 @@ struct __fn
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_lvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::rend(static_cast<const remove_reference_t<_Tp>&>(__t))))
-      -> decltype(::cuda::std::ranges::rend(static_cast<const remove_reference_t<_Tp>&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__rend_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t))))
+      -> decltype(::cuda::std::ranges::__rend_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t)))
   {
-    return ::cuda::std::ranges::rend(static_cast<const remove_reference_t<_Tp>&>(__t));
+    return ::cuda::std::ranges::__rend_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t));
   }
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_rvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::rend(static_cast<const _Tp&&>(__t))))
-      -> decltype(::cuda::std::ranges::rend(static_cast<const _Tp&&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__rend_cpo{}(static_cast<const _Tp&&>(__t))))
+      -> decltype(::cuda::std::ranges::__rend_cpo{}(static_cast<const _Tp&&>(__t)))
   {
-    return ::cuda::std::ranges::rend(static_cast<const _Tp&&>(__t));
+    return ::cuda::std::ranges::__rend_cpo{}(static_cast<const _Tp&&>(__t));
   }
 };
 _CCCL_END_NAMESPACE_CPO
@@ -173,6 +180,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto crend = __crend::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __crend_cpo = __crend::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__ranges/reverse_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/reverse_view.h
@@ -102,8 +102,8 @@ public:
       }
     }
 
-    auto __tmp = ::cuda::std::make_reverse_iterator(
-      ::cuda::std::ranges::next(::cuda::std::ranges::begin(__base_), ::cuda::std::ranges::end(__base_)));
+    auto __tmp = ::cuda::std::make_reverse_iterator(::cuda::std::ranges::__next_cpo{}(
+      ::cuda::std::ranges::__begin_cpo{}(__base_), ::cuda::std::ranges::__end_cpo{}(__base_)));
     if constexpr (_UseCache)
     {
       __cached_begin_.__emplace(__tmp);
@@ -115,40 +115,40 @@ public:
   _CCCL_REQUIRES(common_range<_View2>)
   _CCCL_API constexpr reverse_iterator<iterator_t<_View2>> begin()
   {
-    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::end(__base_));
+    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::__end_cpo{}(__base_));
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(common_range<const _View2>)
   _CCCL_API constexpr auto begin() const
   {
-    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::end(__base_));
+    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::__end_cpo{}(__base_));
   }
 
   _CCCL_API constexpr reverse_iterator<iterator_t<_View>> end()
   {
-    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::begin(__base_));
+    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::__begin_cpo{}(__base_));
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(common_range<const _View2>)
   _CCCL_API constexpr auto end() const
   {
-    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::begin(__base_));
+    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::__begin_cpo{}(__base_));
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(sized_range<_View2>)
   _CCCL_API constexpr auto size()
   {
-    return ::cuda::std::ranges::size(__base_);
+    return ::cuda::std::ranges::__size_cpo{}(__base_);
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(sized_range<const _View2>)
   _CCCL_API constexpr auto size() const
   {
-    return ::cuda::std::ranges::size(__base_);
+    return ::cuda::std::ranges::__size_cpo{}(__base_);
   }
 };
 

--- a/libcudacxx/include/cuda/std/__ranges/size.h
+++ b/libcudacxx/include/cuda/std/__ranges/size.h
@@ -67,10 +67,10 @@ concept __unqualified_size =
 template <class _Tp>
 concept __difference =
   !__member_size<_Tp> && !__unqualified_size<_Tp> && __class_or_enum<remove_cvref_t<_Tp>> && requires(_Tp&& __t) {
-    { ::cuda::std::ranges::begin(__t) } -> forward_iterator;
+    { ::cuda::std::ranges::__begin_cpo{}(__t) } -> forward_iterator;
     {
-      ::cuda::std::ranges::end(__t)
-    } -> sized_sentinel_for<decltype(::cuda::std::ranges::begin(::cuda::std::declval<_Tp>()))>;
+      ::cuda::std::ranges::__end_cpo{}(__t)
+    } -> sized_sentinel_for<decltype(::cuda::std::ranges::__begin_cpo{}(::cuda::std::declval<_Tp>()))>;
   };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Tp>
@@ -96,12 +96,13 @@ _CCCL_CONCEPT __unqualified_size = _CCCL_FRAGMENT(__unqualified_size_, _Tp);
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(
   __difference_,
-  requires(_Tp&& __t)(requires(!__member_size<_Tp>),
-                      requires(!__unqualified_size<_Tp>),
-                      requires(__class_or_enum<remove_cvref_t<_Tp>>),
-                      requires(forward_iterator<decltype(::cuda::std::ranges::begin(__t))>),
-                      requires(sized_sentinel_for<decltype(::cuda::std::ranges::end(__t)),
-                                                  decltype(::cuda::std::ranges::begin(::cuda::std::declval<_Tp>()))>)));
+  requires(_Tp&& __t)(
+    requires(!__member_size<_Tp>),
+    requires(!__unqualified_size<_Tp>),
+    requires(__class_or_enum<remove_cvref_t<_Tp>>),
+    requires(forward_iterator<decltype(::cuda::std::ranges::__begin_cpo{}(__t))>),
+    requires(sized_sentinel_for<decltype(::cuda::std::ranges::__end_cpo{}(__t)),
+                                decltype(::cuda::std::ranges::__begin_cpo{}(::cuda::std::declval<_Tp>()))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __difference = _CCCL_FRAGMENT(__difference_, _Tp);
@@ -147,11 +148,13 @@ struct __fn
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__difference<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::__to_unsigned_like(::cuda::std::ranges::end(__t) - ::cuda::std::ranges::begin(__t))))
-      -> decltype(::cuda::std::__to_unsigned_like(::cuda::std::ranges::end(__t) - ::cuda::std::ranges::begin(__t)))
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(
+    ::cuda::std::__to_unsigned_like(::cuda::std::ranges::__end_cpo{}(__t) - ::cuda::std::ranges::__begin_cpo{}(__t))))
+    -> decltype(::cuda::std::__to_unsigned_like(::cuda::std::ranges::__end_cpo{}(__t)
+                                                - ::cuda::std::ranges::__begin_cpo{}(__t)))
   {
-    return ::cuda::std::__to_unsigned_like(::cuda::std::ranges::end(__t) - ::cuda::std::ranges::begin(__t));
+    return ::cuda::std::__to_unsigned_like(
+      ::cuda::std::ranges::__end_cpo{}(__t) - ::cuda::std::ranges::__begin_cpo{}(__t));
   }
 };
 _CCCL_END_NAMESPACE_CPO
@@ -159,6 +162,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto size = __size::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __size_cpo = __size::__fn;
 } // namespace __cpo
 
 // [range.prim.ssize]
@@ -166,11 +172,12 @@ _CCCL_GLOBAL_CONSTANT auto size = __size::__fn{};
 _CCCL_BEGIN_NAMESPACE_CPO(__ssize)
 #if _CCCL_HAS_CONCEPTS()
 template <class _Tp>
-concept __can_ssize = requires(_Tp&& __t) { ::cuda::std::ranges::size(__t); };
+concept __can_ssize = requires(_Tp&& __t) { ::cuda::std::ranges::__size_cpo{}(__t); };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(
-  __can_ssize_, requires(_Tp&& __t)(requires(!is_unbounded_array_v<_Tp>), ((void) ::cuda::std::ranges::size(__t))));
+  __can_ssize_,
+  requires(_Tp&& __t)(requires(!is_unbounded_array_v<_Tp>), ((void) ::cuda::std::ranges::__size_cpo{}(__t))));
 
 template <class _Tp>
 _CCCL_CONCEPT __can_ssize = _CCCL_FRAGMENT(__can_ssize_, _Tp);
@@ -180,11 +187,12 @@ struct __fn
 {
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__can_ssize<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(::cuda::std::ranges::size(__t)))
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
+    noexcept(noexcept(::cuda::std::ranges::__size_cpo{}(__t)))
   {
-    using _Signed = make_signed_t<decltype(::cuda::std::ranges::size(__t))>;
+    using _Signed = make_signed_t<decltype(::cuda::std::ranges::__size_cpo{}(__t))>;
     using _Result = conditional_t<(sizeof(ptrdiff_t) > sizeof(_Signed)), ptrdiff_t, _Signed>;
-    return static_cast<_Result>(::cuda::std::ranges::size(__t));
+    return static_cast<_Result>(::cuda::std::ranges::__size_cpo{}(__t));
   }
 };
 _CCCL_END_NAMESPACE_CPO
@@ -192,6 +200,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto ssize = __ssize::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __ssize_cpo = __ssize::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__ranges/subrange.h
+++ b/libcudacxx/include/cuda/std/__ranges/subrange.h
@@ -274,19 +274,19 @@ public:
   _CCCL_TEMPLATE(class _Range)
   _CCCL_REQUIRES(__subrange_from_range<_Iter, _Sent, _Kind, _Range, !_StoreSize>)
   _CCCL_API constexpr subrange(_Range&& __range)
-      : subrange(::cuda::std::ranges::begin(__range), ::cuda::std::ranges::end(__range))
+      : subrange(::cuda::std::ranges::__begin_cpo{}(__range), ::cuda::std::ranges::__end_cpo{}(__range))
   {}
 
   _CCCL_TEMPLATE(class _Range)
   _CCCL_REQUIRES(__subrange_from_range<_Iter, _Sent, _Kind, _Range, _StoreSize>)
   _CCCL_API constexpr subrange(_Range&& __range)
-      : subrange(__range, ::cuda::std::ranges::size(__range))
+      : subrange(__range, ::cuda::std::ranges::__size_cpo{}(__range))
   {}
 
   _CCCL_TEMPLATE(class _Range)
   _CCCL_REQUIRES(__subrange_from_range_size<_Iter, _Sent, _Kind, _Range>)
   _CCCL_API constexpr subrange(_Range&& __range, make_unsigned_t<iter_difference_t<_Iter>> __n)
-      : subrange(::cuda::std::ranges::begin(__range), ::cuda::std::ranges::end(__range), __n)
+      : subrange(::cuda::std::ranges::__begin_cpo{}(__range), ::cuda::std::ranges::__end_cpo{}(__range), __n)
   {}
 
   // This often ICEs all of clang and old gcc when it encounteres a rvalue subrange in a pipe
@@ -367,7 +367,7 @@ public:
     {
       if (__n < 0)
       {
-        ::cuda::std::ranges::advance(__begin_, __n);
+        ::cuda::std::ranges::__advance_cpo{}(__begin_, __n);
         if constexpr (_StoreSize)
         {
           __size_ += ::cuda::std::__to_unsigned_like(-__n);
@@ -376,7 +376,7 @@ public:
       }
     }
 
-    [[maybe_unused]] const auto __d = __n - ::cuda::std::ranges::advance(__begin_, __n, __end_);
+    [[maybe_unused]] const auto __d = __n - ::cuda::std::ranges::__advance_cpo{}(__begin_, __n, __end_);
     if constexpr (_StoreSize)
     {
       __size_ -= ::cuda::std::__to_unsigned_like(__d);

--- a/libcudacxx/include/cuda/std/__ranges/take_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/take_view.h
@@ -179,18 +179,18 @@ public:
     {
       if constexpr (random_access_range<_View>)
       {
-        return ::cuda::std::ranges::begin(__base_);
+        return ::cuda::std::ranges::__begin_cpo{}(__base_);
       }
       else
       {
         using _DifferenceT = range_difference_t<_View>;
         auto __size        = size();
-        return counted_iterator(::cuda::std::ranges::begin(__base_), static_cast<_DifferenceT>(__size));
+        return counted_iterator(::cuda::std::ranges::__begin_cpo{}(__base_), static_cast<_DifferenceT>(__size));
       }
     }
     else
     {
-      return counted_iterator(::cuda::std::ranges::begin(__base_), __count_);
+      return counted_iterator(::cuda::std::ranges::__begin_cpo{}(__base_), __count_);
     }
   }
 
@@ -202,18 +202,18 @@ public:
     {
       if constexpr (random_access_range<const _View>)
       {
-        return ::cuda::std::ranges::begin(__base_);
+        return ::cuda::std::ranges::__begin_cpo{}(__base_);
       }
       else
       {
         using _DifferenceT = range_difference_t<const _View>;
         auto __size        = size();
-        return counted_iterator(::cuda::std::ranges::begin(__base_), static_cast<_DifferenceT>(__size));
+        return counted_iterator(::cuda::std::ranges::__begin_cpo{}(__base_), static_cast<_DifferenceT>(__size));
       }
     }
     else
     {
-      return counted_iterator(::cuda::std::ranges::begin(__base_), __count_);
+      return counted_iterator(::cuda::std::ranges::__begin_cpo{}(__base_), __count_);
     }
   }
 
@@ -225,7 +225,7 @@ public:
     {
       if constexpr (random_access_range<_View>)
       {
-        return ::cuda::std::ranges::begin(__base_) + size();
+        return ::cuda::std::ranges::__begin_cpo{}(__base_) + size();
       }
       else
       {
@@ -234,7 +234,7 @@ public:
     }
     else
     {
-      return __sentinel<false>{::cuda::std::ranges::end(__base_)};
+      return __sentinel<false>{::cuda::std::ranges::__end_cpo{}(__base_)};
     }
   }
 
@@ -246,7 +246,7 @@ public:
     {
       if constexpr (random_access_range<const _View>)
       {
-        return ::cuda::std::ranges::begin(__base_) + size();
+        return ::cuda::std::ranges::__begin_cpo{}(__base_) + size();
       }
       else
       {
@@ -255,7 +255,7 @@ public:
     }
     else
     {
-      return __sentinel<true>{::cuda::std::ranges::end(__base_)};
+      return __sentinel<true>{::cuda::std::ranges::__end_cpo{}(__base_)};
     }
   }
 
@@ -263,7 +263,7 @@ public:
   _CCCL_REQUIRES(sized_range<_View2>)
   [[nodiscard]] _CCCL_API constexpr auto size()
   {
-    const auto __n = ::cuda::std::ranges::size(__base_);
+    const auto __n = ::cuda::std::ranges::__size_cpo{}(__base_);
     return (::cuda::std::ranges::min) (__n, static_cast<decltype(__n)>(__count_));
   }
 
@@ -271,7 +271,7 @@ public:
   _CCCL_REQUIRES(sized_range<const _View2>)
   [[nodiscard]] _CCCL_API constexpr auto size() const
   {
-    auto __n = ::cuda::std::ranges::size(__base_);
+    auto __n = ::cuda::std::ranges::__size_cpo{}(__base_);
     return (::cuda::std::ranges::min) (__n, static_cast<decltype(__n)>(__count_));
   }
 };
@@ -381,15 +381,15 @@ struct __fn
   _CCCL_REQUIRES(__use_passthrough<_Range, _Np>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Range&& __rng, _Np&& __n) const
     noexcept(noexcept(__passthrough_type_t<_RawRange>(
-      ::cuda::std::ranges::begin(__rng),
-      ::cuda::std::ranges::begin(__rng)
-        + ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__rng), ::cuda::std::forward<_Np>(__n)))))
+      ::cuda::std::ranges::__begin_cpo{}(__rng),
+      ::cuda::std::ranges::__begin_cpo{}(__rng)
+        + ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__rng), ::cuda::std::forward<_Np>(__n)))))
       -> __passthrough_type_t<_RawRange>
   {
     return __passthrough_type_t<_RawRange>(
-      ::cuda::std::ranges::begin(__rng),
-      ::cuda::std::ranges::begin(__rng)
-        + ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__rng), ::cuda::std::forward<_Np>(__n)));
+      ::cuda::std::ranges::__begin_cpo{}(__rng),
+      ::cuda::std::ranges::__begin_cpo{}(__rng)
+        + ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__rng), ::cuda::std::forward<_Np>(__n)));
   }
 
   // [range.take.overview]: the `repeat_view` "_RawRange models sized_range" case.
@@ -399,10 +399,12 @@ struct __fn
                    __is_repeat_specialization<_RawRange> _CCCL_AND sized_range<_RawRange>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Range&& __range, _Np&& __n) const noexcept(noexcept(views::repeat(
     ::cuda::std::forward_like<_Range>(*__range.__value_),
-    ::cuda::std::min<_Dist>(ranges::distance(__range), ::cuda::std::forward<_Np>(__n))))) -> _RawRange
+    ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__range), ::cuda::std::forward<_Np>(__n)))))
+    -> _RawRange
   {
-    return views::repeat(::cuda::std::forward_like<_Range>(*__range.__value_),
-                         ::cuda::std::min<_Dist>(ranges::distance(__range), ::cuda::std::forward<_Np>(__n)));
+    return views::repeat(
+      ::cuda::std::forward_like<_Range>(*__range.__value_),
+      ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__range), ::cuda::std::forward<_Np>(__n)));
   }
 
   // [range.take.overview]: the `repeat_view` "otherwise" case.
@@ -423,15 +425,15 @@ struct __fn
   _CCCL_REQUIRES(__use_iota<_Range, _Np>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Range&& __rng, _Np&& __n) const
     noexcept(noexcept(::cuda::std::ranges::iota_view(
-      *::cuda::std::ranges::begin(__rng),
-      *::cuda::std::ranges::begin(__rng)
-        + ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__rng), ::cuda::std::forward<_Np>(__n)))))
+      *::cuda::std::ranges::__begin_cpo{}(__rng),
+      *::cuda::std::ranges::__begin_cpo{}(__rng)
+        + ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__rng), ::cuda::std::forward<_Np>(__n)))))
       -> iota_view<range_value_t<_RawRange>, _Dist>
   {
     return ::cuda::std::ranges::iota_view(
-      *::cuda::std::ranges::begin(__rng),
-      *::cuda::std::ranges::begin(__rng)
-        + ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__rng), ::cuda::std::forward<_Np>(__n)));
+      *::cuda::std::ranges::__begin_cpo{}(__rng),
+      *::cuda::std::ranges::__begin_cpo{}(__rng)
+        + ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__rng), ::cuda::std::forward<_Np>(__n)));
   }
 
   // [range.take.overview]: the "otherwise" case.

--- a/libcudacxx/include/cuda/std/__ranges/take_while_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/take_while_view.h
@@ -189,28 +189,28 @@ public:
   _CCCL_REQUIRES((!__simple_view<_View2>) )
   [[nodiscard]] _CCCL_API constexpr auto begin()
   {
-    return ::cuda::std::ranges::begin(__base_);
+    return ::cuda::std::ranges::__begin_cpo{}(__base_);
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(__take_while_const_is_range<_View2, _Pred>)
   [[nodiscard]] _CCCL_API constexpr auto begin() const
   {
-    return ::cuda::std::ranges::begin(__base_);
+    return ::cuda::std::ranges::__begin_cpo{}(__base_);
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES((!__simple_view<_View2>) )
   [[nodiscard]] _CCCL_API constexpr auto end()
   {
-    return __sentinel</*_Const=*/false>(::cuda::std::ranges::end(__base_), ::cuda::std::addressof(*__pred_));
+    return __sentinel</*_Const=*/false>(::cuda::std::ranges::__end_cpo{}(__base_), ::cuda::std::addressof(*__pred_));
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(__take_while_const_is_range<_View2, _Pred>)
   [[nodiscard]] _CCCL_API constexpr auto end() const
   {
-    return __sentinel</*_Const=*/true>(::cuda::std::ranges::end(__base_), ::cuda::std::addressof(*__pred_));
+    return __sentinel</*_Const=*/true>(::cuda::std::ranges::__end_cpo{}(__base_), ::cuda::std::addressof(*__pred_));
   }
 };
 

--- a/libcudacxx/include/cuda/std/__ranges/transform_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/transform_view.h
@@ -429,24 +429,24 @@ public:
 
   [[nodiscard]] _CCCL_API constexpr __iterator<false> begin()
   {
-    return __iterator<false>{*this, ::cuda::std::ranges::begin(__base_)};
+    return __iterator<false>{*this, ::cuda::std::ranges::__begin_cpo{}(__base_)};
   }
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(range<const _View2> _CCCL_AND __regular_invocable_with_range_ref<const _Fn&, const _View2>)
   [[nodiscard]] _CCCL_API constexpr __iterator<true> begin() const
   {
-    return __iterator<true>(*this, ::cuda::std::ranges::begin(__base_));
+    return __iterator<true>(*this, ::cuda::std::ranges::__begin_cpo{}(__base_));
   }
 
   [[nodiscard]] _CCCL_API constexpr auto end()
   {
     if constexpr (common_range<_View>)
     {
-      return __iterator<false>(*this, ::cuda::std::ranges::end(__base_));
+      return __iterator<false>(*this, ::cuda::std::ranges::__end_cpo{}(__base_));
     }
     else
     {
-      return __sentinel<false>(::cuda::std::ranges::end(__base_));
+      return __sentinel<false>(::cuda::std::ranges::__end_cpo{}(__base_));
     }
   }
 
@@ -456,11 +456,11 @@ public:
   {
     if constexpr (common_range<const _View>)
     {
-      return __iterator<true>(*this, ::cuda::std::ranges::end(__base_));
+      return __iterator<true>(*this, ::cuda::std::ranges::__end_cpo{}(__base_));
     }
     else
     {
-      return __sentinel<true>(::cuda::std::ranges::end(__base_));
+      return __sentinel<true>(::cuda::std::ranges::__end_cpo{}(__base_));
     }
   }
 
@@ -468,13 +468,13 @@ public:
   _CCCL_REQUIRES(sized_range<_View2>)
   [[nodiscard]] _CCCL_API constexpr auto size()
   {
-    return ::cuda::std::ranges::size(__base_);
+    return ::cuda::std::ranges::__size_cpo{}(__base_);
   }
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(sized_range<const _View2>)
   [[nodiscard]] _CCCL_API constexpr auto size() const
   {
-    return ::cuda::std::ranges::size(__base_);
+    return ::cuda::std::ranges::__size_cpo{}(__base_);
   }
 };
 

--- a/libcudacxx/include/cuda/std/__ranges/unwrap_end.h
+++ b/libcudacxx/include/cuda/std/__ranges/unwrap_end.h
@@ -35,12 +35,12 @@ _CCCL_REQUIRES(forward_range<_Range>)
 {
   if constexpr (common_range<_Range>)
   {
-    return ::cuda::std::ranges::end(__range);
+    return ::cuda::std::ranges::__end_cpo{}(__range);
   }
   else
   {
-    auto __ret = ::cuda::std::ranges::begin(__range);
-    ::cuda::std::ranges::advance(__ret, ::cuda::std::ranges::end(__range));
+    auto __ret = ::cuda::std::ranges::__begin_cpo{}(__range);
+    ::cuda::std::ranges::__advance_cpo{}(__ret, ::cuda::std::ranges::__end_cpo{}(__range));
     return __ret;
   }
 }

--- a/libcudacxx/include/cuda/std/__ranges/view_interface.h
+++ b/libcudacxx/include/cuda/std/__ranges/view_interface.h
@@ -41,10 +41,10 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
 #if _CCCL_HAS_CONCEPTS()
 template <class _Tp>
-concept __can_empty = requires(_Tp& __t) { ::cuda::std::ranges::empty(__t); };
+concept __can_empty = requires(_Tp& __t) { ::cuda::std::ranges::__empty_cpo{}(__t); };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Tp>
-_CCCL_CONCEPT_FRAGMENT(__can_empty_, requires(_Tp& __t)(typename(decltype(::cuda::std::ranges::empty(__t)))));
+_CCCL_CONCEPT_FRAGMENT(__can_empty_, requires(_Tp& __t)(typename(decltype(::cuda::std::ranges::__empty_cpo{}(__t)))));
 
 template <class _Tp>
 _CCCL_CONCEPT __can_empty = _CCCL_FRAGMENT(__can_empty_, _Tp);
@@ -75,42 +75,42 @@ public:
   _CCCL_REQUIRES(forward_range<_D2>)
   [[nodiscard]] _CCCL_API constexpr bool empty()
   {
-    return ::cuda::std::ranges::begin(__derived()) == ::cuda::std::ranges::end(__derived());
+    return ::cuda::std::ranges::__begin_cpo{}(__derived()) == ::cuda::std::ranges::__end_cpo{}(__derived());
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
   _CCCL_REQUIRES(forward_range<const _D2>)
   [[nodiscard]] _CCCL_API constexpr bool empty() const
   {
-    return ::cuda::std::ranges::begin(__derived()) == ::cuda::std::ranges::end(__derived());
+    return ::cuda::std::ranges::__begin_cpo{}(__derived()) == ::cuda::std::ranges::__end_cpo{}(__derived());
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
   _CCCL_REQUIRES(__can_empty<_D2>)
   _CCCL_API constexpr explicit operator bool()
   {
-    return !::cuda::std::ranges::empty(__derived());
+    return !::cuda::std::ranges::__empty_cpo{}(__derived());
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
   _CCCL_REQUIRES(__can_empty<const _D2>)
   _CCCL_API constexpr explicit operator bool() const
   {
-    return !::cuda::std::ranges::empty(__derived());
+    return !::cuda::std::ranges::__empty_cpo{}(__derived());
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
   _CCCL_REQUIRES(contiguous_iterator<iterator_t<_D2>>)
   _CCCL_API constexpr auto data()
   {
-    return ::cuda::std::to_address(::cuda::std::ranges::begin(__derived()));
+    return ::cuda::std::to_address(::cuda::std::ranges::__begin_cpo{}(__derived()));
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
   _CCCL_REQUIRES(range<const _D2> _CCCL_AND contiguous_iterator<iterator_t<const _D2>>)
   _CCCL_API constexpr auto data() const
   {
-    return ::cuda::std::to_address(::cuda::std::ranges::begin(__derived()));
+    return ::cuda::std::to_address(::cuda::std::ranges::__begin_cpo{}(__derived()));
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
@@ -118,7 +118,7 @@ public:
   _CCCL_API constexpr auto size()
   {
     return ::cuda::std::__to_unsigned_like(
-      ::cuda::std::ranges::end(__derived()) - ::cuda::std::ranges::begin(__derived()));
+      ::cuda::std::ranges::__end_cpo{}(__derived()) - ::cuda::std::ranges::__begin_cpo{}(__derived()));
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
@@ -126,7 +126,7 @@ public:
   _CCCL_API constexpr auto size() const
   {
     return ::cuda::std::__to_unsigned_like(
-      ::cuda::std::ranges::end(__derived()) - ::cuda::std::ranges::begin(__derived()));
+      ::cuda::std::ranges::__end_cpo{}(__derived()) - ::cuda::std::ranges::__begin_cpo{}(__derived()));
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
@@ -134,7 +134,7 @@ public:
   _CCCL_API constexpr decltype(auto) front()
   {
     _CCCL_ASSERT(!empty(), "Precondition `!empty()` not satisfied. `.front()` called on an empty view.");
-    return *::cuda::std::ranges::begin(__derived());
+    return *::cuda::std::ranges::__begin_cpo{}(__derived());
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
@@ -142,7 +142,7 @@ public:
   _CCCL_API constexpr decltype(auto) front() const
   {
     _CCCL_ASSERT(!empty(), "Precondition `!empty()` not satisfied. `.front()` called on an empty view.");
-    return *::cuda::std::ranges::begin(__derived());
+    return *::cuda::std::ranges::__begin_cpo{}(__derived());
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
@@ -150,7 +150,7 @@ public:
   _CCCL_API constexpr decltype(auto) back()
   {
     _CCCL_ASSERT(!empty(), "Precondition `!empty()` not satisfied. `.back()` called on an empty view.");
-    return *::cuda::std::ranges::prev(::cuda::std::ranges::end(__derived()));
+    return *::cuda::std::ranges::__prev_cpo{}(::cuda::std::ranges::__end_cpo{}(__derived()));
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
@@ -158,21 +158,21 @@ public:
   _CCCL_API constexpr decltype(auto) back() const
   {
     _CCCL_ASSERT(!empty(), "Precondition `!empty()` not satisfied. `.back()` called on an empty view.");
-    return *::cuda::std::ranges::prev(::cuda::std::ranges::end(__derived()));
+    return *::cuda::std::ranges::__prev_cpo{}(::cuda::std::ranges::__end_cpo{}(__derived()));
   }
 
   _CCCL_TEMPLATE(class _RARange = _Derived)
   _CCCL_REQUIRES(random_access_range<_RARange>)
   _CCCL_API constexpr decltype(auto) operator[](range_difference_t<_RARange> __index)
   {
-    return ::cuda::std::ranges::begin(__derived())[__index];
+    return ::cuda::std::ranges::__begin_cpo{}(__derived())[__index];
   }
 
   _CCCL_TEMPLATE(class _RARange = const _Derived)
   _CCCL_REQUIRES(random_access_range<_RARange>)
   _CCCL_API constexpr decltype(auto) operator[](range_difference_t<_RARange> __index) const
   {
-    return ::cuda::std::ranges::begin(__derived())[__index];
+    return ::cuda::std::ranges::__begin_cpo{}(__derived())[__index];
   }
 };
 

--- a/libcudacxx/include/cuda/std/__simd/basic_vec.h
+++ b/libcudacxx/include/cuda/std/__simd/basic_vec.h
@@ -198,7 +198,7 @@ public:
   {
     static_assert(__has_convert_flag_v<_Flags...> || __is_value_preserving_v<ranges::range_value_t<_Range>, value_type>,
                   "Conversion from range_value_t<R> to value_type is not value-preserving; use flag_convert");
-    const auto __data = ::cuda::std::ranges::data(__range);
+    const auto __data = ::cuda::std::ranges::__data_cpo{}(__range);
     __assert_load_store_alignment<basic_vec, ranges::range_value_t<_Range>, _Flags...>(__data);
     _CCCL_PRAGMA_UNROLL_FULL()
     for (__simd_size_type __i = 0; __i < __size; ++__i)
@@ -214,7 +214,7 @@ public:
   {
     static_assert(__has_convert_flag_v<_Flags...> || __is_value_preserving_v<ranges::range_value_t<_Range>, value_type>,
                   "Conversion from range_value_t<R> to value_type is not value-preserving; use flag_convert");
-    const auto __data = ranges::data(__range);
+    const auto __data = ::cuda::std::ranges::__data_cpo{}(__range);
     __assert_load_store_alignment<basic_vec, ranges::range_value_t<_Range>, _Flags...>(__data);
     _CCCL_PRAGMA_UNROLL_FULL()
     for (__simd_size_type __i = 0; __i < __size; ++__i)

--- a/libcudacxx/include/cuda/std/__type_traits/type_list.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_list.h
@@ -755,7 +755,7 @@ struct __type_concat_fn
 template <size_t _Count>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_maybe_concat_fn
 {
-  using __next_t _CCCL_NODEBUG_ALIAS = __type_maybe_concat_fn<(_Count < 8 ? 0 : _Count - 8)>;
+  using __next_cpo _CCCL_NODEBUG_ALIAS = __type_maybe_concat_fn<(_Count < 8 ? 0 : _Count - 8)>;
 
   template <class... _Ts,
             class... _As,
@@ -778,7 +778,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_maybe_concat_fn
     __type_list_ptr<_Gs...>, // 7
     __type_list_ptr<_Hs...>, // 8
     _Tail*... __tail) // rest
-    -> decltype(__next_t::__fn(
+    -> decltype(__next_cpo::__fn(
       __type_list_ptr<_Ts..., _As..., _Bs..., _Cs..., _Ds..., _Es..., _Fs..., _Gs..., _Hs...>{nullptr},
       __tail...,
       __type_list_ptr<>{nullptr},

--- a/libcudacxx/include/cuda/std/inplace_vector
+++ b/libcudacxx/include/cuda/std/inplace_vector
@@ -313,7 +313,7 @@ protected:
     iterator __curr = __dest;
     for (; __first != __last; ++__curr, (void) ++__first)
     {
-      ::new (::cuda::std::__voidify(*__curr)) _Tp(::cuda::std::ranges::iter_move(__first));
+      ::new (::cuda::std::__voidify(*__curr)) _Tp(::cuda::std::ranges::__iter_move_cpo{}(__first));
     }
     this->__size_ += static_cast<__size_type>(__curr - __dest);
   }
@@ -326,7 +326,7 @@ protected:
     auto __guard    = __make_exception_guard(_Rollback_change_size<__inplace_vector_storage>{this, __dest, __curr});
     for (; __first != __last; ++__curr, (void) ++__first)
     {
-      ::new (::cuda::std::__voidify(*__curr)) _Tp(::cuda::std::ranges::iter_move(__first));
+      ::new (::cuda::std::__voidify(*__curr)) _Tp(::cuda::std::ranges::__iter_move_cpo{}(__first));
     }
     __guard.__complete();
     this->__size_ += static_cast<__size_type>(__curr - __dest);
@@ -577,14 +577,14 @@ protected:
   _CCCL_API constexpr void __uninitialized_copy(_Iter __first, _Iter __last, iterator __dest) noexcept
   {
     ::cuda::std::copy(__first, __last, __dest);
-    __size_ += static_cast<__size_type>(::cuda::std::ranges::distance(__first, __last));
+    __size_ += static_cast<__size_type>(::cuda::std::ranges::__distance_cpo{}(__first, __last));
   }
 
   template <class _Iter>
   _CCCL_API constexpr void __uninitialized_move(_Iter __first, _Iter __last, iterator __dest) noexcept
   {
     ::cuda::std::copy(__first, __last, __dest);
-    __size_ += static_cast<__size_type>(::cuda::std::ranges::distance(__first, __last));
+    __size_ += static_cast<__size_type>(::cuda::std::ranges::__distance_cpo{}(__first, __last));
   }
 };
 
@@ -785,11 +785,11 @@ public:
   _CCCL_API constexpr inplace_vector(from_range_t, _Range&& __range)
       : __base()
   {
-    auto __first = ::cuda::std::ranges::begin(__range);
-    auto __last  = ::cuda::std::ranges::end(__range);
+    auto __first = ::cuda::std::ranges::__begin_cpo{}(__range);
+    auto __last  = ::cuda::std::ranges::__end_cpo{}(__range);
     for (; __first != __last; ++__first)
     {
-      emplace_back(::cuda::std::ranges::iter_move(__first));
+      emplace_back(::cuda::std::ranges::__iter_move_cpo{}(__first));
     }
   }
 
@@ -800,7 +800,7 @@ public:
   _CCCL_API constexpr inplace_vector(from_range_t, _Range&& __range)
       : __base()
   {
-    const auto __size = ::cuda::std::ranges::size(__range);
+    const auto __size = ::cuda::std::ranges::__size_cpo{}(__range);
     if (__size > 0)
     {
       if (_Capacity < __size)
@@ -809,7 +809,7 @@ public:
       }
 
       this->__uninitialized_move(
-        ::cuda::std::ranges::begin(__range), ::cuda::std::ranges::__unwrap_end(__range), this->begin());
+        ::cuda::std::ranges::__begin_cpo{}(__range), ::cuda::std::ranges::__unwrap_end(__range), this->begin());
     }
   }
 
@@ -820,8 +820,8 @@ public:
   _CCCL_API constexpr inplace_vector(from_range_t, _Range&& __range)
       : __base()
   {
-    const auto __count = static_cast<size_t>(
-      ::cuda::std::ranges::distance(::cuda::std::ranges::begin(__range), ::cuda::std::ranges::end(__range)));
+    const auto __count = static_cast<size_t>(::cuda::std::ranges::__distance_cpo{}(
+      ::cuda::std::ranges::__begin_cpo{}(__range), ::cuda::std::ranges::__end_cpo{}(__range)));
     if (__count > 0)
     {
       if (_Capacity < __count)
@@ -830,7 +830,7 @@ public:
       }
 
       this->__uninitialized_move(
-        ::cuda::std::ranges::begin(__range), ::cuda::std::ranges::__unwrap_end(__range), this->begin());
+        ::cuda::std::ranges::__begin_cpo{}(__range), ::cuda::std::ranges::__unwrap_end(__range), this->begin());
     }
   }
 
@@ -947,8 +947,8 @@ public:
     !::cuda::std::ranges::forward_range<_Range>))
   _CCCL_API constexpr void assign_range(_Range&& __range)
   {
-    auto __first      = ::cuda::std::ranges::begin(__range);
-    const auto __last = ::cuda::std::ranges::end(__range);
+    auto __first      = ::cuda::std::ranges::__begin_cpo{}(__range);
+    const auto __last = ::cuda::std::ranges::__end_cpo{}(__range);
     iterator __end    = this->end();
     for (iterator __current = this->begin(); __current != __end; ++__current, (void) ++__first)
     {
@@ -972,13 +972,13 @@ public:
       _CCCL_AND ::cuda::std::ranges::sized_range<_Range>)
   _CCCL_API constexpr void assign_range(_Range&& __range)
   {
-    const auto __size = ::cuda::std::ranges::size(__range);
+    const auto __size = ::cuda::std::ranges::__size_cpo{}(__range);
     if (_Capacity < __size)
     {
       _CCCL_THROW(::std::bad_alloc);
     }
 
-    const auto __first = ::cuda::std::ranges::begin(__range);
+    const auto __first = ::cuda::std::ranges::__begin_cpo{}(__range);
     const auto __last  = ::cuda::std::ranges::__unwrap_end(__range);
     if (static_cast<size_type>(__size) < this->size())
     {
@@ -999,9 +999,9 @@ public:
       _CCCL_AND(!::cuda::std::ranges::sized_range<_Range>))
   _CCCL_API constexpr void assign_range(_Range&& __range)
   {
-    const auto __first = ::cuda::std::ranges::begin(__range);
+    const auto __first = ::cuda::std::ranges::__begin_cpo{}(__range);
     const auto __last  = ::cuda::std::ranges::__unwrap_end(__range);
-    const auto __size  = static_cast<size_type>(::cuda::std::ranges::distance(__first, __last));
+    const auto __size  = static_cast<size_type>(::cuda::std::ranges::__distance_cpo{}(__first, __last));
     if (_Capacity < __size)
     {
       _CCCL_THROW(::std::bad_alloc);
@@ -1301,8 +1301,8 @@ public:
   _CCCL_API constexpr iterator insert_range(const_iterator __cpos, _Range&& __range)
   {
     // add all new elements to the back then rotate
-    auto __first             = ::cuda::std::ranges::begin(__range);
-    auto __last              = ::cuda::std::ranges::end(__range);
+    auto __first             = ::cuda::std::ranges::__begin_cpo{}(__range);
+    auto __last              = ::cuda::std::ranges::__end_cpo{}(__range);
     const iterator __old_end = this->end();
     for (; __first != __last; ++__first)
     {
@@ -1319,7 +1319,7 @@ public:
     ::cuda::std::ranges::__container_compatible_range<_Range, _Tp> _CCCL_AND ::cuda::std::ranges::forward_range<_Range>)
   _CCCL_API constexpr iterator insert_range(const_iterator __cpos, _Range&& __range)
   {
-    auto __first = ::cuda::std::ranges::begin(__range);
+    auto __first = ::cuda::std::ranges::__begin_cpo{}(__range);
     return insert(__cpos, __first, ::cuda::std::ranges::__unwrap_end(__range));
   }
 
@@ -1328,8 +1328,8 @@ public:
     !::cuda::std::ranges::forward_range<_Range>))
   _CCCL_API constexpr void append_range(_Range&& __range)
   {
-    auto __first = ::cuda::std::ranges::begin(__range);
-    auto __last  = ::cuda::std::ranges::end(__range);
+    auto __first = ::cuda::std::ranges::__begin_cpo{}(__range);
+    auto __last  = ::cuda::std::ranges::__end_cpo{}(__range);
     for (; __first != __last; ++__first)
     {
       emplace_back(*__first);
@@ -1341,7 +1341,7 @@ public:
     ::cuda::std::ranges::__container_compatible_range<_Range, _Tp> _CCCL_AND ::cuda::std::ranges::forward_range<_Range>)
   _CCCL_API constexpr void append_range(_Range&& __range)
   {
-    auto __first = ::cuda::std::ranges::begin(__range);
+    auto __first = ::cuda::std::ranges::__begin_cpo{}(__range);
     insert(this->end(), __first, ::cuda::std::ranges::__unwrap_end(__range));
   }
 
@@ -1442,8 +1442,8 @@ public:
   _CCCL_API constexpr ::cuda::std::ranges::iterator_t<_Range>
   try_append_range(_Range&& __range) noexcept(is_nothrow_move_constructible_v<_Tp>)
   {
-    auto __first = ::cuda::std::ranges::begin(__range);
-    auto __last  = ::cuda::std::ranges::end(__range);
+    auto __first = ::cuda::std::ranges::__begin_cpo{}(__range);
+    auto __last  = ::cuda::std::ranges::__end_cpo{}(__range);
     for (; this->size() != _Capacity && __first != __last; ++__first)
     {
       emplace_back(*__first);
@@ -1459,11 +1459,11 @@ public:
   try_append_range(_Range&& __range) noexcept(is_nothrow_move_constructible_v<_Tp>)
   {
     const auto __capacity = _Capacity - this->size();
-    const auto __size     = ::cuda::std::ranges::size(__range);
+    const auto __size     = ::cuda::std::ranges::__size_cpo{}(__range);
     const auto __diff     = __size < __capacity ? __size : __capacity;
 
-    auto __first  = ::cuda::std::ranges::begin(__range);
-    auto __middle = ::cuda::std::ranges::next(__first, __diff);
+    auto __first  = ::cuda::std::ranges::__begin_cpo{}(__range);
+    auto __middle = ::cuda::std::ranges::__next_cpo{}(__first, __diff);
     this->__uninitialized_move(__first, __middle, this->end());
     return __middle;
   }
@@ -1476,12 +1476,12 @@ public:
   try_append_range(_Range&& __range) noexcept(is_nothrow_move_constructible_v<_Tp>)
   {
     const auto __capacity = static_cast<ptrdiff_t>(_Capacity - this->size());
-    auto __first          = ::cuda::std::ranges::begin(__range);
-    const auto __size =
-      static_cast<ptrdiff_t>(::cuda::std::ranges::distance(__first, ::cuda::std::ranges::__unwrap_end(__range)));
+    auto __first          = ::cuda::std::ranges::__begin_cpo{}(__range);
+    const auto __size     = static_cast<ptrdiff_t>(
+      ::cuda::std::ranges::__distance_cpo{}(__first, ::cuda::std::ranges::__unwrap_end(__range)));
     const ptrdiff_t __diff = __size < __capacity ? __size : __capacity;
 
-    auto __middle = ::cuda::std::ranges::next(__first, __diff);
+    auto __middle = ::cuda::std::ranges::__next_cpo{}(__first, __diff);
     this->__uninitialized_move(__first, __middle, this->end());
     return __middle;
   }
@@ -1772,7 +1772,7 @@ public:
   _CCCL_API constexpr inplace_vector(from_range_t, _Range&& __range)
       : __base()
   {
-    if (::cuda::std::ranges::begin(__range) != ::cuda::std::ranges::end(__range))
+    if (::cuda::std::ranges::__begin_cpo{}(__range) != ::cuda::std::ranges::__end_cpo{}(__range))
     {
       _CCCL_THROW(::std::bad_alloc);
     }
@@ -1821,7 +1821,7 @@ public:
   _CCCL_REQUIRES(::cuda::std::ranges::__container_compatible_range<_Range, _Tp>)
   _CCCL_API constexpr void assign_range(_Range&& __range)
   {
-    if (::cuda::std::ranges::begin(__range) != ::cuda::std::ranges::end(__range))
+    if (::cuda::std::ranges::__begin_cpo{}(__range) != ::cuda::std::ranges::__end_cpo{}(__range))
     {
       _CCCL_THROW(::std::bad_alloc);
     }
@@ -1977,7 +1977,7 @@ public:
   _CCCL_REQUIRES(::cuda::std::ranges::__container_compatible_range<_Range, _Tp>)
   _CCCL_API constexpr iterator insert_range(const_iterator, _Range&& __range)
   {
-    if (::cuda::std::ranges::begin(__range) != ::cuda::std::ranges::end(__range))
+    if (::cuda::std::ranges::__begin_cpo{}(__range) != ::cuda::std::ranges::__end_cpo{}(__range))
     {
       _CCCL_THROW(::std::bad_alloc);
     }
@@ -1988,7 +1988,7 @@ public:
   _CCCL_REQUIRES(::cuda::std::ranges::__container_compatible_range<_Range, _Tp>)
   _CCCL_API constexpr void append_range(_Range&& __range)
   {
-    if (::cuda::std::ranges::begin(__range) != ::cuda::std::ranges::end(__range))
+    if (::cuda::std::ranges::__begin_cpo{}(__range) != ::cuda::std::ranges::__end_cpo{}(__range))
     {
       _CCCL_THROW(::std::bad_alloc);
     }
@@ -2036,7 +2036,7 @@ public:
   _CCCL_REQUIRES(::cuda::std::ranges::__container_compatible_range<_Range, _Tp>)
   _CCCL_API constexpr ::cuda::std::ranges::iterator_t<_Range> try_append_range(_Range&& __range) noexcept
   {
-    return ::cuda::std::ranges::begin(__range);
+    return ::cuda::std::ranges::__begin_cpo{}(__range);
   }
 
   using __base::unchecked_emplace_back;

--- a/libcudacxx/include/cuda/std/span
+++ b/libcudacxx/include/cuda/std/span
@@ -178,9 +178,9 @@ public:
   _CCCL_TEMPLATE(class _Range)
   _CCCL_REQUIRES(__span_compatible_range<_Range, element_type>)
   _CCCL_API constexpr explicit span(_Range&& __r)
-      : __data_{::cuda::std::ranges::data(__r)}
+      : __data_{::cuda::std::ranges::__data_cpo{}(__r)}
   {
-    _CCCL_ASSERT(::cuda::std::ranges::size(__r) == _Extent, "size mismatch in span's constructor (range)");
+    _CCCL_ASSERT(::cuda::std::ranges::__size_cpo{}(__r) == _Extent, "size mismatch in span's constructor (range)");
   }
 
   // Deviation from P4144R1 Hana Dusikova's proposed fix: uses initializer_list<_InitListValueType>
@@ -432,8 +432,8 @@ public:
   _CCCL_TEMPLATE(class _Range)
   _CCCL_REQUIRES(__span_compatible_range<_Range, element_type>)
   _CCCL_API constexpr span(_Range&& __r)
-      : __data_(::cuda::std::ranges::data(__r))
-      , __size_{::cuda::std::ranges::size(__r)}
+      : __data_(::cuda::std::ranges::__data_cpo{}(__r))
+      , __size_{::cuda::std::ranges::__size_cpo{}(__r)}
   {}
 
   // Deviation from P4144R1 Hana Dusikova's proposed fix: uses initializer_list<_InitListValueType>

--- a/libcudacxx/include/cuda/std/string_view
+++ b/libcudacxx/include/cuda/std/string_view
@@ -223,8 +223,8 @@ public:
   _CCCL_TEMPLATE(class _Range)
   _CCCL_REQUIRES(__cccl_basic_sv_compatible_range<_Range, _CharT, _Traits>)
   _CCCL_API explicit constexpr basic_string_view(_Range&& __r)
-      : __data_{::cuda::std::ranges::data(__r)}
-      , __size_{::cuda::std::ranges::size(__r)}
+      : __data_{::cuda::std::ranges::__data_cpo{}(__r)}
+      , __size_{::cuda::std::ranges::__size_cpo{}(__r)}
   {}
 
   // msvc has problems with constructing a string view from another string view using the from ranges constructor,


### PR DESCRIPTION
We cannot use CPOs in tile programs, because they live in device memory and its currently not possible to have `__device__ __tile__` variables

So avoid this by constructing the empty struct instead of accessing the global instance
