### PR TITLE
[Tile] Avoid use of `in_place` global

### DIFF
--- a/libcudacxx/include/cuda/std/__expected/expected.h
+++ b/libcudacxx/include/cuda/std/__expected/expected.h
@@ -214,7 +214,7 @@ public:
                    _CCCL_AND(!__is_cuda_std_unexpected<remove_cvref_t<_Up>>)
                      _CCCL_AND is_constructible_v<_Tp, _Up> _CCCL_AND is_convertible_v<_Up, _Tp>)
   _CCCL_API constexpr expected(_Up&& __u) noexcept(is_nothrow_constructible_v<_Tp, _Up>) // strengthened
-      : __base(in_place, ::cuda::std::forward<_Up>(__u))
+      : __base(in_place_t{}, ::cuda::std::forward<_Up>(__u))
   {}
 
   _CCCL_TEMPLATE(class _Up = _Tp)
@@ -222,7 +222,7 @@ public:
                    _CCCL_AND(!__is_cuda_std_unexpected<remove_cvref_t<_Up>>)
                      _CCCL_AND is_constructible_v<_Tp, _Up> _CCCL_AND(!is_convertible_v<_Up, _Tp>))
   _CCCL_API constexpr explicit expected(_Up&& __u) noexcept(is_nothrow_constructible_v<_Tp, _Up>) // strengthened
-      : __base(in_place, ::cuda::std::forward<_Up>(__u))
+      : __base(in_place_t{}, ::cuda::std::forward<_Up>(__u))
   {}
 
   _CCCL_TEMPLATE(class _OtherErr)
@@ -257,14 +257,14 @@ public:
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr explicit expected(in_place_t, _Args&&... __args) noexcept(
     is_nothrow_constructible_v<_Tp, _Args...>) // strengthened
-      : __base(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __base(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   _CCCL_TEMPLATE(class _Up, class... _Args)
   _CCCL_REQUIRES(is_constructible_v<_Tp, initializer_list<_Up>&, _Args...>)
   _CCCL_API constexpr explicit expected(in_place_t, initializer_list<_Up> __il, _Args&&... __args) noexcept(
     is_nothrow_constructible_v<_Tp, initializer_list<_Up>&, _Args...>) // strengthened
-      : __base(in_place, __il, ::cuda::std::forward<_Args>(__args)...)
+      : __base(in_place_t{}, __il, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   _CCCL_TEMPLATE(class... _Args)
@@ -289,7 +289,7 @@ private:
     _Fun&& __fun,
     _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, invoke_result_t<_Fun, _Args...>>)
       : __base(__expected_construct_from_invoke_tag{},
-               in_place,
+               in_place_t{},
                ::cuda::std::forward<_Fun>(__fun),
                ::cuda::std::forward<_Args>(__args)...)
   {}
@@ -672,7 +672,7 @@ public:
 
     if (this->__has_val_)
     {
-      return _Res{in_place, this->__union_.__val_};
+      return _Res{in_place_t{}, this->__union_.__val_};
     }
     else
     {
@@ -693,7 +693,7 @@ public:
 
     if (this->__has_val_)
     {
-      return _Res{in_place, this->__union_.__val_};
+      return _Res{in_place_t{}, this->__union_.__val_};
     }
     else
     {
@@ -714,7 +714,7 @@ public:
 
     if (this->__has_val_)
     {
-      return _Res{in_place, ::cuda::std::move(this->__union_.__val_)};
+      return _Res{in_place_t{}, ::cuda::std::move(this->__union_.__val_)};
     }
     else
     {
@@ -735,7 +735,7 @@ public:
 
     if (this->__has_val_)
     {
-      return _Res{in_place, ::cuda::std::move(this->__union_.__val_)};
+      return _Res{in_place_t{}, ::cuda::std::move(this->__union_.__val_)};
     }
     else
     {
@@ -779,7 +779,7 @@ public:
     if (this->__has_val_)
     {
       return expected<_Res, _Err>{
-        __expected_construct_from_invoke_tag{}, in_place, ::cuda::std::forward<_Fun>(__fun), this->__union_.__val_};
+        __expected_construct_from_invoke_tag{}, in_place_t{}, ::cuda::std::forward<_Fun>(__fun), this->__union_.__val_};
     }
     else
     {
@@ -824,7 +824,7 @@ public:
     if (this->__has_val_)
     {
       return expected<_Res, _Err>{
-        __expected_construct_from_invoke_tag{}, in_place, ::cuda::std::forward<_Fun>(__fun), this->__union_.__val_};
+        __expected_construct_from_invoke_tag{}, in_place_t{}, ::cuda::std::forward<_Fun>(__fun), this->__union_.__val_};
     }
     else
     {
@@ -867,7 +867,7 @@ public:
     {
       return expected<_Res, _Err>{
         __expected_construct_from_invoke_tag{},
-        in_place,
+        in_place_t{},
         ::cuda::std::forward<_Fun>(__fun),
         ::cuda::std::move(this->__union_.__val_)};
     }
@@ -915,7 +915,7 @@ public:
     {
       return expected<_Res, _Err>{
         __expected_construct_from_invoke_tag{},
-        in_place,
+        in_place_t{},
         ::cuda::std::forward<_Fun>(__fun),
         ::cuda::std::move(this->__union_.__val_)};
     }
@@ -941,7 +941,7 @@ public:
 
     if (this->__has_val_)
     {
-      return expected<_Tp, _Res>{in_place, this->__union_.__val_};
+      return expected<_Tp, _Res>{in_place_t{}, this->__union_.__val_};
     }
     else
     {
@@ -967,7 +967,7 @@ public:
 
     if (this->__has_val_)
     {
-      return expected<_Tp, _Res>{in_place, this->__union_.__val_};
+      return expected<_Tp, _Res>{in_place_t{}, this->__union_.__val_};
     }
     else
     {
@@ -992,7 +992,7 @@ public:
 
     if (this->__has_val_)
     {
-      return expected<_Tp, _Res>{in_place, ::cuda::std::move(this->__union_.__val_)};
+      return expected<_Tp, _Res>{in_place_t{}, ::cuda::std::move(this->__union_.__val_)};
     }
     else
     {
@@ -1021,7 +1021,7 @@ public:
 
     if (this->__has_val_)
     {
-      return expected<_Tp, _Res>{in_place, ::cuda::std::move(this->__union_.__val_)};
+      return expected<_Tp, _Res>{in_place_t{}, ::cuda::std::move(this->__union_.__val_)};
     }
     else
     {
@@ -1632,7 +1632,8 @@ public:
 
     if (this->__has_val_)
     {
-      return expected<_Res, _Err>{__expected_construct_from_invoke_tag{}, in_place, ::cuda::std::forward<_Fun>(__fun)};
+      return expected<_Res, _Err>{
+        __expected_construct_from_invoke_tag{}, in_place_t{}, ::cuda::std::forward<_Fun>(__fun)};
     }
     else
     {
@@ -1672,7 +1673,8 @@ public:
 
     if (this->__has_val_)
     {
-      return expected<_Res, _Err>{__expected_construct_from_invoke_tag{}, in_place, ::cuda::std::forward<_Fun>(__fun)};
+      return expected<_Res, _Err>{
+        __expected_construct_from_invoke_tag{}, in_place_t{}, ::cuda::std::forward<_Fun>(__fun)};
     }
     else
     {
@@ -1711,7 +1713,8 @@ public:
 
     if (this->__has_val_)
     {
-      return expected<_Res, _Err>{__expected_construct_from_invoke_tag{}, in_place, ::cuda::std::forward<_Fun>(__fun)};
+      return expected<_Res, _Err>{
+        __expected_construct_from_invoke_tag{}, in_place_t{}, ::cuda::std::forward<_Fun>(__fun)};
     }
     else
     {
@@ -1751,7 +1754,8 @@ public:
 
     if (this->__has_val_)
     {
-      return expected<_Res, _Err>{__expected_construct_from_invoke_tag{}, in_place, ::cuda::std::forward<_Fun>(__fun)};
+      return expected<_Res, _Err>{
+        __expected_construct_from_invoke_tag{}, in_place_t{}, ::cuda::std::forward<_Fun>(__fun)};
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__expected/expected_base.h
+++ b/libcudacxx/include/cuda/std/__expected/expected_base.h
@@ -200,7 +200,7 @@ struct __expected_destruct<_Tp, _Err, false, false>
   template <class... _Args>
   _CCCL_API constexpr __expected_destruct(in_place_t,
                                           _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
-      : __union_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __union_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   template <class... _Args>
@@ -217,7 +217,7 @@ struct __expected_destruct<_Tp, _Err, false, false>
     _Fun&& __fun,
     _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, invoke_result_t<_Fun, _Args...>>)
       : __union_(__expected_construct_from_invoke_tag{},
-                 in_place,
+                 in_place_t{},
                  ::cuda::std::forward<_Fun>(__fun),
                  ::cuda::std::forward<_Args>(__args)...)
   {}
@@ -264,7 +264,7 @@ struct __expected_destruct<_Tp, _Err, true, false>
   template <class... _Args>
   _CCCL_API constexpr __expected_destruct(in_place_t,
                                           _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
-      : __union_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __union_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   template <class... _Args>
@@ -281,7 +281,7 @@ struct __expected_destruct<_Tp, _Err, true, false>
     _Fun&& __fun,
     _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, invoke_result_t<_Fun, _Args...>>)
       : __union_(__expected_construct_from_invoke_tag{},
-                 in_place,
+                 in_place_t{},
                  ::cuda::std::forward<_Fun>(__fun),
                  ::cuda::std::forward<_Args>(__args)...)
   {}
@@ -324,7 +324,7 @@ struct __expected_destruct<_Tp, _Err, false, true>
   template <class... _Args>
   _CCCL_API constexpr __expected_destruct(in_place_t,
                                           _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
-      : __union_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __union_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   template <class... _Args>
@@ -341,7 +341,7 @@ struct __expected_destruct<_Tp, _Err, false, true>
     _Fun&& __fun,
     _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, invoke_result_t<_Fun, _Args...>>)
       : __union_(__expected_construct_from_invoke_tag{},
-                 in_place,
+                 in_place_t{},
                  ::cuda::std::forward<_Fun>(__fun),
                  ::cuda::std::forward<_Args>(__args)...)
   {}
@@ -385,7 +385,7 @@ struct __expected_destruct<_Tp, _Err, true, true>
   template <class... _Args>
   _CCCL_API constexpr __expected_destruct(in_place_t,
                                           _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
-      : __union_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __union_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   template <class... _Args>
@@ -402,7 +402,7 @@ struct __expected_destruct<_Tp, _Err, true, true>
     _Fun&& __fun,
     _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, invoke_result_t<_Fun, _Args...>>)
       : __union_(__expected_construct_from_invoke_tag{},
-                 in_place,
+                 in_place_t{},
                  ::cuda::std::forward<_Fun>(__fun),
                  ::cuda::std::forward<_Args>(__args)...)
   {}

--- a/libcudacxx/include/cuda/std/__optional/make_optional.h
+++ b/libcudacxx/include/cuda/std/__optional/make_optional.h
@@ -44,14 +44,14 @@ _CCCL_TEMPLATE(class _Tp, class... _Args)
 _CCCL_REQUIRES((!is_reference_v<_Tp>) )
 _CCCL_API constexpr optional<_Tp> make_optional(_Args&&... __args)
 {
-  return optional<_Tp>(in_place, ::cuda::std::forward<_Args>(__args)...);
+  return optional<_Tp>(in_place_t{}, ::cuda::std::forward<_Args>(__args)...);
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Up, class... _Args)
 _CCCL_REQUIRES((!is_reference_v<_Tp>) )
 _CCCL_API constexpr optional<_Tp> make_optional(initializer_list<_Up> __il, _Args&&... __args)
 {
-  return optional<_Tp>(in_place, __il, ::cuda::std::forward<_Args>(__args)...);
+  return optional<_Tp>(in_place_t{}, __il, ::cuda::std::forward<_Args>(__args)...);
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__optional/optional.h
+++ b/libcudacxx/include/cuda/std/__optional/optional.h
@@ -130,25 +130,25 @@ public:
   _CCCL_TEMPLATE(class _In_place_t, class... _Args)
   _CCCL_REQUIRES(is_same_v<_In_place_t, in_place_t> _CCCL_AND is_constructible_v<value_type, _Args...>)
   _CCCL_API constexpr explicit optional(_In_place_t, _Args&&... __args)
-      : __base(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __base(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   _CCCL_TEMPLATE(class _Up, class... _Args)
   _CCCL_REQUIRES(is_constructible_v<value_type, initializer_list<_Up>&, _Args...>)
   _CCCL_API constexpr explicit optional(in_place_t, initializer_list<_Up> __il, _Args&&... __args)
-      : __base(in_place, __il, ::cuda::std::forward<_Args>(__args)...)
+      : __base(in_place_t{}, __il, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   _CCCL_TEMPLATE(class _Up = value_type)
   _CCCL_REQUIRES(__opt_is_constructible_from_U<_Tp, _Up> _CCCL_AND __opt_is_implictly_constructible<_Tp, _Up>)
   _CCCL_API constexpr optional(_Up&& __v)
-      : __base(in_place, ::cuda::std::forward<_Up>(__v))
+      : __base(in_place_t{}, ::cuda::std::forward<_Up>(__v))
   {}
 
   _CCCL_TEMPLATE(class _Up)
   _CCCL_REQUIRES(__opt_is_constructible_from_U<_Tp, _Up> _CCCL_AND __opt_is_explictly_constructible<_Tp, _Up>)
   _CCCL_API constexpr explicit optional(_Up&& __v)
-      : __base(in_place, ::cuda::std::forward<_Up>(__v))
+      : __base(in_place_t{}, ::cuda::std::forward<_Up>(__v))
   {}
 
   _CCCL_TEMPLATE(class _Up)

--- a/libcudacxx/include/cuda/std/__optional/optional_base.h
+++ b/libcudacxx/include/cuda/std/__optional/optional_base.h
@@ -106,7 +106,7 @@ struct __optional_destruct_base<_Tp, false>
   template <class... _Args>
   _CCCL_API constexpr explicit __optional_destruct_base(in_place_t, _Args&&... __args) noexcept(
     is_nothrow_constructible_v<value_type, _Args...>)
-      : __storage_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __storage_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
       , __engaged_(true)
   {}
 
@@ -165,7 +165,7 @@ struct __optional_destruct_base<_Tp, true>
   template <class... _Args>
   _CCCL_API constexpr explicit __optional_destruct_base(in_place_t, _Args&&... __args) noexcept(
     is_nothrow_constructible_v<value_type, _Args...>)
-      : __storage_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __storage_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
       , __engaged_(true)
   {}
 

--- a/libcudacxx/include/cuda/std/__ranges/compressed_movable_box.h
+++ b/libcudacxx/include/cuda/std/__ranges/compressed_movable_box.h
@@ -220,7 +220,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_storage
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
   _CCCL_REQUIRES(is_default_constructible_v<_Tp2>)
   _CCCL_API constexpr __compressed_box_storage() noexcept(is_nothrow_default_constructible_v<_Tp2>)
-      : __storage_(in_place)
+      : __storage_(in_place_t{})
       , __engaged_(true)
   {}
 
@@ -229,7 +229,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_storage
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr explicit __compressed_box_storage(in_place_t, _Args&&... __args) noexcept(
     is_nothrow_constructible_v<_Tp, _Args...>)
-      : __storage_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __storage_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
       , __engaged_(true)
   {}
 
@@ -273,7 +273,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_storage<_Index, _Tp, true>
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
   _CCCL_REQUIRES(is_default_constructible_v<_Tp2>)
   _CCCL_API constexpr __compressed_box_storage() noexcept(is_nothrow_default_constructible_v<_Tp2>)
-      : __storage_(in_place)
+      : __storage_(in_place_t{})
       , __engaged_(true)
   {}
 
@@ -282,7 +282,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_storage<_Index, _Tp, true>
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr explicit __compressed_box_storage(in_place_t, _Args&&... __args) noexcept(
     is_nothrow_constructible_v<_Tp, _Args...>)
-      : __storage_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __storage_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
       , __engaged_(true)
   {}
 };
@@ -302,7 +302,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_base<_Index, _Tp, __compresse
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
   _CCCL_REQUIRES(is_default_constructible_v<_Tp2>)
   _CCCL_API constexpr __compressed_box_base() noexcept(is_nothrow_default_constructible_v<_Tp2>)
-      : __base(in_place)
+      : __base(in_place_t{})
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
@@ -310,7 +310,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_base<_Index, _Tp, __compresse
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr __compressed_box_base(in_place_t,
                                             _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
-      : __base(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __base(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   [[nodiscard]] _CCCL_API constexpr _Tp& __get() noexcept
@@ -656,7 +656,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_movable_box<_Elem1> : __compresse
   _CCCL_TEMPLATE(class... _Args)
   _CCCL_REQUIRES((sizeof...(_Args) != 0) _CCCL_AND is_constructible_v<_Elem1, _Args...>)
   _CCCL_API constexpr __compressed_movable_box(_Args&&... __args) noexcept(is_nothrow_constructible_v<_Elem1, _Args...>)
-      : __base1(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __base1(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   _CCCL_TEMPLATE(size_t _Index)
@@ -710,7 +710,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_movable_box<_Elem1, _Elem2>
   _CCCL_TEMPLATE(class _Arg1)
   _CCCL_REQUIRES(__is_constructible_from_one_arg<_Arg1>)
   _CCCL_API constexpr __compressed_movable_box(_Arg1&& __arg1) noexcept(__is_nothrow_constructible_from_one_arg<_Arg1>)
-      : __base1(in_place, ::cuda::std::forward<_Arg1>(__arg1))
+      : __base1(in_place_t{}, ::cuda::std::forward<_Arg1>(__arg1))
       , __base2()
   {}
 
@@ -727,8 +727,8 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_movable_box<_Elem1, _Elem2>
   _CCCL_REQUIRES(__is_constructible_from_two_args<_Arg1, _Arg2>)
   _CCCL_API constexpr __compressed_movable_box(_Arg1&& __arg1, _Arg2&& __arg2) noexcept(
     __is_nothrow_constructible_from_two_args<_Arg1, _Arg2>)
-      : __base1(in_place, ::cuda::std::forward<_Arg1>(__arg1))
-      , __base2(in_place, ::cuda::std::forward<_Arg2>(__arg2))
+      : __base1(in_place_t{}, ::cuda::std::forward<_Arg1>(__arg1))
+      , __base2(in_place_t{}, ::cuda::std::forward<_Arg2>(__arg2))
   {}
 
   _CCCL_TEMPLATE(size_t _Index)
@@ -803,7 +803,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_movable_box<_Elem1, _Elem2, _Elem
   _CCCL_TEMPLATE(class _Arg1)
   _CCCL_REQUIRES(__is_constructible_from_one_arg<_Arg1>)
   _CCCL_API constexpr __compressed_movable_box(_Arg1&& __arg1) noexcept(__is_nothrow_constructible_from_one_arg<_Arg1>)
-      : __base1(in_place, ::cuda::std::forward<_Arg1>(__arg1))
+      : __base1(in_place_t{}, ::cuda::std::forward<_Arg1>(__arg1))
       , __base2()
       , __base3()
   {}
@@ -822,8 +822,8 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_movable_box<_Elem1, _Elem2, _Elem
   _CCCL_REQUIRES(__is_constructible_from_two_args<_Arg1, _Arg2>)
   _CCCL_API constexpr __compressed_movable_box(_Arg1&& __arg1, _Arg2&& __arg2) noexcept(
     __is_nothrow_constructible_from_two_args<_Arg1, _Arg2>)
-      : __base1(in_place, ::cuda::std::forward<_Arg1>(__arg1))
-      , __base2(in_place, ::cuda::std::forward<_Arg2>(__arg2))
+      : __base1(in_place_t{}, ::cuda::std::forward<_Arg1>(__arg1))
+      , __base2(in_place_t{}, ::cuda::std::forward<_Arg2>(__arg2))
       , __base3()
   {}
 
@@ -841,9 +841,9 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_movable_box<_Elem1, _Elem2, _Elem
   _CCCL_REQUIRES(__is_constructible_from_three_args<_Arg1, _Arg2, _Arg3>)
   _CCCL_API constexpr __compressed_movable_box(_Arg1&& __arg1, _Arg2&& __arg2, _Arg3&& __arg3) noexcept(
     __is_nothrow_constructible_from_three_args<_Arg1, _Arg2, _Arg3>)
-      : __base1(in_place, ::cuda::std::forward<_Arg1>(__arg1))
-      , __base2(in_place, ::cuda::std::forward<_Arg2>(__arg2))
-      , __base3(in_place, ::cuda::std::forward<_Arg3>(__arg3))
+      : __base1(in_place_t{}, ::cuda::std::forward<_Arg1>(__arg1))
+      , __base2(in_place_t{}, ::cuda::std::forward<_Arg2>(__arg2))
+      , __base3(in_place_t{}, ::cuda::std::forward<_Arg3>(__arg3))
   {}
 
   _CCCL_TEMPLATE(size_t _Index)

--- a/libcudacxx/include/cuda/std/__ranges/drop_while_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/drop_while_view.h
@@ -84,7 +84,7 @@ public:
 
   _CCCL_API constexpr explicit drop_while_view(_View __base, _Pred __pred)
       : __base_{::cuda::std::move(__base)}
-      , __pred_{::cuda::std::in_place, ::cuda::std::move(__pred)}
+      , __pred_{in_place_t{}, ::cuda::std::move(__pred)}
 
   {}
 

--- a/libcudacxx/include/cuda/std/__ranges/filter_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/filter_view.h
@@ -299,7 +299,7 @@ public:
     is_nothrow_move_constructible_v<_View>
     && is_nothrow_constructible_v<__movable_box<_Pred>, in_place_t, add_rvalue_reference_t<_Pred>>)
       : __base_{::cuda::std::move(__base)}
-      , __pred_{in_place, ::cuda::std::move(__pred)}
+      , __pred_{in_place_t{}, ::cuda::std::move(__pred)}
   {}
 
   _CCCL_TEMPLATE(class _View2 = _View)

--- a/libcudacxx/include/cuda/std/__ranges/movable_box.h
+++ b/libcudacxx/include/cuda/std/__ranges/movable_box.h
@@ -116,7 +116,7 @@ struct __mb_optional_destruct_base
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr explicit __mb_optional_destruct_base(in_place_t, _Args&&... __args) noexcept(
     is_nothrow_constructible_v<_Tp, _Args...>)
-      : __val_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __val_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 };
 
@@ -126,14 +126,14 @@ struct __mb_optional_destruct_base<_Tp, true>
   _CCCL_NO_UNIQUE_ADDRESS optional<_Tp> __val_;
 
   _CCCL_API constexpr __mb_optional_destruct_base() noexcept(is_nothrow_default_constructible_v<_Tp>)
-      : __val_(in_place)
+      : __val_(in_place_t{})
   {}
 
   _CCCL_TEMPLATE(class... _Args)
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr explicit __mb_optional_destruct_base(in_place_t, _Args&&... __args) noexcept(
     is_nothrow_constructible_v<_Tp, _Args...>)
-      : __val_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __val_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 };
 
@@ -272,7 +272,7 @@ struct __mb_holder_base
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr explicit __mb_holder_base(in_place_t,
                                                 _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
-      : __holder_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __holder_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 };
 
@@ -282,14 +282,14 @@ struct __mb_holder_base<_Tp, true>
   _CCCL_NO_UNIQUE_ADDRESS __mb_holder<_Tp> __holder_;
 
   _CCCL_API constexpr __mb_holder_base() noexcept(is_nothrow_default_constructible_v<_Tp>)
-      : __holder_(in_place)
+      : __holder_(in_place_t{})
   {}
 
   _CCCL_TEMPLATE(class... _Args)
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr explicit __mb_holder_base(in_place_t,
                                                 _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
-      : __holder_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __holder_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 };
 
@@ -396,7 +396,7 @@ struct __movable_box<_Tp, true> : __movable_box_base<_Tp>
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr explicit __movable_box(in_place_t,
                                              _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
-      : __base(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __base(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   _CCCL_HIDE_FROM_ABI constexpr __movable_box() noexcept(is_nothrow_default_constructible_v<_Tp>) = default;

--- a/libcudacxx/include/cuda/std/__ranges/repeat_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/repeat_view.h
@@ -238,7 +238,7 @@ public:
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
   _CCCL_REQUIRES((!same_as<_Tp2, repeat_view>) _CCCL_AND copy_constructible<_Tp2>)
   _CCCL_API constexpr explicit repeat_view(const _Tp2& __value, _Bound __bound_sentinel = _Bound())
-      : __value_(in_place, __value)
+      : __value_(in_place_t{}, __value)
       , __bound_(__bound_sentinel)
   {
     if constexpr (!same_as<_Bound, unreachable_sentinel_t> && is_signed_v<_Bound>)
@@ -248,7 +248,7 @@ public:
   }
 
   _CCCL_API constexpr explicit repeat_view(_Tp&& __value, _Bound __bound_sentinel = _Bound())
-      : __value_(in_place, ::cuda::std::move(__value))
+      : __value_(in_place_t{}, ::cuda::std::move(__value))
       , __bound_(__bound_sentinel)
   {
     if constexpr (!same_as<_Bound, unreachable_sentinel_t> && is_signed_v<_Bound>)
@@ -261,7 +261,7 @@ public:
   _CCCL_REQUIRES(constructible_from<_Tp, _TpArgs...> _CCCL_AND constructible_from<_Bound, _BoundArgs...>)
   _CCCL_API constexpr explicit repeat_view(
     piecewise_construct_t, tuple<_TpArgs...> __value_args, tuple<_BoundArgs...> __bound_args = tuple<>{})
-      : __value_(in_place, ::cuda::std::make_from_tuple<_Tp>(::cuda::std::move(__value_args)))
+      : __value_(in_place_t{}, ::cuda::std::make_from_tuple<_Tp>(::cuda::std::move(__value_args)))
       , __bound_(::cuda::std::make_from_tuple<_Bound>(::cuda::std::move(__bound_args)))
   {
     if constexpr (!same_as<_Bound, unreachable_sentinel_t> && is_signed_v<_Bound>)

--- a/libcudacxx/include/cuda/std/__ranges/single_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/single_view.h
@@ -68,12 +68,12 @@ public:
   _CCCL_REQUIRES((!is_same_v<remove_cvref_t<_Tp2>, single_view>) _CCCL_AND copy_constructible<_Tp2>)
   _CCCL_API constexpr explicit single_view(const _Tp2& __t) noexcept(is_nothrow_copy_constructible_v<_Tp2>)
       : view_interface<single_view<_Tp2>>()
-      , __value_(in_place, __t)
+      , __value_(in_place_t{}, __t)
   {}
 
   _CCCL_API constexpr explicit single_view(_Tp&& __t) noexcept(is_nothrow_move_constructible_v<_Tp>)
       : view_interface<single_view<_Tp>>()
-      , __value_(in_place, ::cuda::std::move(__t))
+      , __value_(in_place_t{}, ::cuda::std::move(__t))
   {}
 
   _CCCL_TEMPLATE(class... _Args)
@@ -81,7 +81,7 @@ public:
   _CCCL_API constexpr explicit single_view(in_place_t,
                                            _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
       : view_interface<single_view<_Tp>>()
-      , __value_{in_place, ::cuda::std::forward<_Args>(__args)...}
+      , __value_{in_place_t{}, ::cuda::std::forward<_Args>(__args)...}
   {}
 
   [[nodiscard]] _CCCL_API constexpr _Tp* begin() noexcept

--- a/libcudacxx/include/cuda/std/__ranges/take_while_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/take_while_view.h
@@ -164,7 +164,7 @@ public:
 
   _CCCL_API constexpr take_while_view(_View __base, _Pred __pred)
       : view_interface<take_while_view<_View, _Pred>>()
-      , __pred_(::cuda::std::in_place, ::cuda::std::move(__pred))
+      , __pred_(in_place_t{}, ::cuda::std::move(__pred))
       , __base_(::cuda::std::move(__base))
   {}
 

--- a/libcudacxx/include/cuda/std/__ranges/transform_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/transform_view.h
@@ -413,7 +413,7 @@ public:
   _CCCL_API constexpr transform_view(_View __base, _Fn __func)
       : view_interface<transform_view<_View, _Fn>>()
       , __base_(::cuda::std::move(__base))
-      , __func_(::cuda::std::in_place, ::cuda::std::move(__func))
+      , __func_(in_place_t{}, ::cuda::std::move(__func))
   {}
 
   _CCCL_TEMPLATE(class _View2 = _View)

--- a/libcudacxx/include/cuda/std/__variant/variant_base.h
+++ b/libcudacxx/include/cuda/std/__variant/variant_base.h
@@ -91,7 +91,7 @@ public:                                                                         
                                                                                  \
   template <class... _Args>                                                      \
   _CCCL_API explicit constexpr __union(in_place_index_t<0>, _Args&&... __args)   \
-      : __head_(in_place, ::cuda::std::forward<_Args>(__args)...)                \
+      : __head_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)            \
   {}                                                                             \
                                                                                  \
   template <size_t _Ip, class... _Args>                                          \


### PR DESCRIPTION
tile does not allow access to `__device__` variables, so construct an instance via `in_place_t{}`
