### PR TITLE
[Tile] Avoid return statements in loops in `bitset`

### DIFF
--- a/libcudacxx/include/cuda/std/__bit/reference.h
+++ b/libcudacxx/include/cuda/std/__bit/reference.h
@@ -933,19 +933,27 @@ _CCCL_API constexpr bool __equal_unaligned(
     // do middle words
     unsigned __clz_r   = __bits_per_word - __first2.__ctz_;
     __storage_type __m = ~__storage_type(0) << __first2.__ctz_;
+    bool __result      = true;
     for (; __n >= __bits_per_word; __n -= __bits_per_word, ++__first1.__seg_)
     {
       __storage_type __b = *__first1.__seg_;
       if ((*__first2.__seg_ & __m) != (__b << __first2.__ctz_))
       {
-        return false;
+        __result = false;
+        break;
       }
       ++__first2.__seg_;
       if ((*__first2.__seg_ & ~__m) != (__b >> __clz_r))
       {
-        return false;
+        __result = false;
+        break;
       }
     }
+    if (!__result)
+    {
+      return false;
+    }
+
     // do last word
     if (__n > 0)
     {
@@ -1004,13 +1012,20 @@ _CCCL_API constexpr bool __equal_aligned(
     // __first1.__ctz_ == 0;
     // __first2.__ctz_ == 0;
     // do middle words
+    bool __result = true;
     for (; __n >= __bits_per_word; __n -= __bits_per_word, ++__first1.__seg_, ++__first2.__seg_)
     {
       if (*__first2.__seg_ != *__first1.__seg_)
       {
-        return false;
+        __result = false;
+        break;
       }
     }
+    if (!__result)
+    {
+      return false;
+    }
+
     // do last word
     if (__n > 0)
     {

--- a/libcudacxx/include/cuda/std/bitset
+++ b/libcudacxx/include/cuda/std/bitset
@@ -314,15 +314,17 @@ protected:
     // do middle whole words
     size_type __n               = _Size;
     __const_storage_pointer __p = __first_;
+    bool __result               = true;
     for (; __n >= __bits_per_word; ++__p, __n -= __bits_per_word)
     {
       if (~*__p)
       {
-        return false;
+        __result = false;
+        break;
       }
     }
     // do last partial word
-    if (__n > 0)
+    if (__n > 0 && __result)
     {
       __storage_type __m = ~__storage_type(0) >> (__bits_per_word - __n);
       if (~*__p & __m)
@@ -330,7 +332,7 @@ protected:
         return false;
       }
     }
-    return true;
+    return __result;
   }
 
   _CCCL_API constexpr bool any() const noexcept
@@ -338,15 +340,17 @@ protected:
     // do middle whole words
     size_type __n               = _Size;
     __const_storage_pointer __p = __first_;
+    bool __result               = false;
     for (; __n >= __bits_per_word; ++__p, __n -= __bits_per_word)
     {
       if (*__p)
       {
-        return true;
+        __result = true;
+        break;
       }
     }
     // do last partial word
-    if (__n > 0)
+    if (__n > 0 && !__result)
     {
       __storage_type __m = ~__storage_type(0) >> (__bits_per_word - __n);
       if (*__p & __m)
@@ -354,7 +358,7 @@ protected:
         return true;
       }
     }
-    return false;
+    return __result;
   }
 
   _CCCL_API inline size_t __hash_code() const noexcept


### PR DESCRIPTION
tile does not allow return statements in loops.