### PR TITLE
[Tile] Avoid calling a device only function in tile mode

### DIFF
--- a/libcudacxx/include/cuda/std/__bit/byteswap.h
+++ b/libcudacxx/include/cuda/std/__bit/byteswap.h
@@ -136,7 +136,9 @@ template <class _Tp>
 #  if _CCCL_COMPILER(MSVC)
     NV_IF_TARGET(NV_IS_HOST, return ::_byteswap_ushort(__val);)
 #  endif // _CCCL_COMPILER(MSVC)
+#  if !_CCCL_TILE_COMPILATION()
     NV_IF_TARGET(NV_IS_DEVICE, return ::cuda::std::__byteswap_impl_device(__val);)
+#  endif // !_CCCL_TILE_COMPILATION()
   }
   return ::cuda::std::__byteswap_impl_recursive(__val);
 #endif // !_CCCL_BUILTIN_BSWAP16
@@ -152,7 +154,9 @@ template <class _Tp>
 #  if _CCCL_COMPILER(MSVC)
     NV_IF_TARGET(NV_IS_HOST, return ::_byteswap_ulong(__val);)
 #  endif // _CCCL_COMPILER(MSVC)
+#  if !_CCCL_TILE_COMPILATION()
     NV_IF_TARGET(NV_IS_DEVICE, return ::cuda::std::__byteswap_impl_device(__val);)
+#  endif // !_CCCL_TILE_COMPILATION()
   }
   return ::cuda::std::__byteswap_impl_recursive(__val);
 #endif // !_CCCL_BUILTIN_BSWAP32
@@ -168,7 +172,9 @@ template <class _Tp>
 #  if _CCCL_COMPILER(MSVC)
     NV_IF_TARGET(NV_IS_HOST, return ::_byteswap_uint64(__val);)
 #  endif // _CCCL_COMPILER(MSVC)
+#  if !_CCCL_TILE_COMPILATION()
     NV_IF_TARGET(NV_IS_DEVICE, return ::cuda::std::__byteswap_impl_device(__val);)
+#  endif // !_CCCL_TILE_COMPILATION()
   }
   return ::cuda::std::__byteswap_impl_recursive(__val);
 #endif // !_CCCL_BUILTIN_BSWAP64


### PR DESCRIPTION
We cannot call device only builtins