### PR TITLE
[Tile] Avoid return in switch statements in `variant`

### DIFF
--- a/libcudacxx/include/cuda/std/__iterator/variant_like.h
+++ b/libcudacxx/include/cuda/std/__iterator/variant_like.h
@@ -364,13 +364,14 @@ public:
       {
         case __variant_like_state::__holds_first:
           this->__first_ = __other.__first_;
-          return *this;
+          break;
         case __variant_like_state::__holds_second:
           this->__second_ = __other.__second_;
-          return *this;
+          break;
         case __variant_like_state::__nothing:
-          return *this;
+          break;
       }
+      return *this;
     }
 
     this->__clear();


### PR DESCRIPTION
tile does not allow a return statement inside a switch
