### PR TITLE
[Tile] Mark format tests as unsupported

### DIFF
--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg.store/make_format_args.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg.store/make_format_args.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/ctor.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/operator_bool.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/operator_bool.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/visit_format_arg.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/visit_format_arg.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/ctor.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/get.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/get.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/advance_to.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/advance_to.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/arg.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/arg.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/ctor.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/out.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/out.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.bool.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.bool.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.c_string.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.c_string.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.char.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.char.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.char_array.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.char_array.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.handle.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.handle.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.pointer.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.pointer.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.signed_integral.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.signed_integral.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.string.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.string.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.unsigned_integral.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.unsigned_integral.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/advance_to.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/advance_to.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // constexpr void advance_to(const_iterator it);

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/begin.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/begin.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // constexpr begin() const noexcept;

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/check_arg_id.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/check_arg_id.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // constexpr void check_arg_id(size_t id);

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/ctor.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // constexpr explicit

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/end.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // constexpr end() const noexcept;

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/next_arg_id.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/next_arg_id.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // constexpr size_t next_arg_id();


### PR DESCRIPTION
tile does not allow bit fields
