### PR TITLE
Fix segmented radix sort benchmark segment size type

### DIFF
--- a/cub/benchmarks/bench/segmented_radix_sort/keys.cu
+++ b/cub/benchmarks/bench/segmented_radix_sort/keys.cu
@@ -18,7 +18,7 @@ void seg_radix_sort(nvbench::state& state,
   using offset_t          = OffsetT;
   using begin_offset_it_t = const offset_t*;
   using end_offset_it_t   = const offset_t*;
-  using segment_size_t    = offset_t;
+  using segment_size_t    = cuda::std::int32_t; // same as CUB public API
   using key_t             = T;
   using value_t           = cub::NullType;
 


### PR DESCRIPTION
It should be the same as CUB's public API uses.

- [x] Benchmark `cub.bench.segmented_radix_sort.keys.base`

This is the expected change coming from the redefinition of the benchmark:
```
# power

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |  Segments{io}  |  Entropy  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|----------------|-----------|------------|-------------|------------|-------------|------------|---------|----------|
|   I32   |      I32      |      2^22      |      2^12      |     1     | 571.396 us |       0.34% | 573.217 us |       0.32% |   1.822 us |   0.32% |  🔴 SLOW  |
|   I32   |      I32      |      2^26      |      2^12      |     1     |   3.427 ms |       1.06% |   3.429 ms |       1.03% |   1.768 us |   0.05% |  🔵 SAME  |
|   I32   |      I32      |      2^30      |      2^12      |     1     |  51.546 ms |       1.16% |  51.488 ms |       0.96% | -57.835 us |  -0.11% |  🔵 SAME  |
|   I32   |      I32      |      2^22      |      2^16      |     1     |   6.693 ms |       0.04% |   6.692 ms |       0.04% |  -0.156 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^26      |      2^16      |     1     |   8.483 ms |       0.02% |   8.483 ms |       0.02% |  -0.280 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^30      |      2^16      |     1     |  36.489 ms |       0.06% |  36.489 ms |       0.07% |  -0.412 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^22      |      2^20      |     1     |  81.404 ms |       0.01% |  81.404 ms |       0.01% |   0.148 us |   0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^26      |      2^20      |     1     | 108.602 ms |       0.01% | 108.600 ms |       0.00% |  -2.145 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^30      |      2^20      |     1     | 134.873 ms |       0.00% | 134.853 ms |       0.00% | -19.668 us |  -0.01% |  🟢 FAST  |
|   I32   |      I32      |      2^22      |      2^12      |   0.201   | 573.109 us |       0.32% | 572.891 us |       0.33% |  -0.218 us |  -0.04% |  🔵 SAME  |
|   I32   |      I32      |      2^26      |      2^12      |   0.201   |   3.414 ms |       1.06% |   3.413 ms |       1.02% |  -0.974 us |  -0.03% |  🔵 SAME  |
|   I32   |      I32      |      2^30      |      2^12      |   0.201   |  51.181 ms |       1.01% |  51.153 ms |       0.93% | -28.058 us |  -0.05% |  🔵 SAME  |
|   I32   |      I32      |      2^22      |      2^16      |   0.201   |   6.421 ms |       0.04% |   6.421 ms |       0.04% |  -0.272 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^26      |      2^16      |   0.201   |   8.489 ms |       0.02% |   8.489 ms |       0.03% |  -0.085 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^30      |      2^16      |   0.201   |  36.307 ms |       0.07% |  36.306 ms |       0.07% |  -1.258 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^22      |      2^20      |   0.201   |  66.550 ms |       0.01% |  66.548 ms |       0.01% |  -2.950 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^26      |      2^20      |   0.201   | 105.377 ms |       0.00% | 105.347 ms |       0.00% | -29.765 us |  -0.03% |  🟢 FAST  |
|   I32   |      I32      |      2^30      |      2^20      |   0.201   | 134.981 ms |       0.00% | 134.962 ms |       0.01% | -18.769 us |  -0.01% |  🟢 FAST  |

# small

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |  MaxSegmentSize  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |         Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------------|------------|-------------|------------|-------------|--------------|---------|----------|
|   I32   |      I32      |      2^22      |       2^1        | 219.484 ms |       0.00% | 219.464 ms |       0.02% |   -19.836 us |  -0.01% |  🟢 FAST  |
|   I32   |      I32      |      2^26      |       2^1        |    3.514 s |       0.00% |    3.513 s |       0.00% | -1253.320 us |  -0.04% |  🟢 FAST  |
|   I32   |      I32      |      2^30      |       2^1        |   56.206 s |        inf% |   56.209 s |        inf% |     2.840 ms |   0.01% |  🔵 SAME  |
|   I32   |      I32      |      2^22      |       2^2        | 141.816 ms |       0.00% | 141.816 ms |       0.01% |     0.146 us |   0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^26      |       2^2        |    2.284 s |       0.00% |    2.284 s |       0.00% |  -894.810 us |  -0.04% |  🟢 FAST  |
|   I32   |      I32      |      2^30      |       2^2        |   36.546 s |        inf% |   36.545 s |        inf% | -1210.937 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^22      |       2^3        |  71.057 ms |       0.01% |  71.056 ms |       0.01% |    -1.681 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^26      |       2^3        |    1.150 s |       0.00% |    1.150 s |       0.00% |   -44.939 us |  -0.00% |  🟢 FAST  |
|   I32   |      I32      |      2^30      |       2^3        |   18.395 s |        inf% |   18.394 s |        inf% |  -333.984 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^22      |       2^4        |  35.515 ms |       0.01% |  35.515 ms |       0.02% |    -0.568 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^26      |       2^4        | 576.302 ms |       0.00% | 576.289 ms |       0.00% |   -12.906 us |  -0.00% |  🟢 FAST  |
|   I32   |      I32      |      2^30      |       2^4        |    9.221 s |        inf% |    9.221 s |        inf% |   -23.437 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^22      |       2^5        |  17.792 ms |       0.01% |  17.792 ms |       0.01% |    -0.161 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^26      |       2^5        | 288.963 ms |       0.02% | 289.011 ms |       0.00% |    48.664 us |   0.02% |  🔴 SLOW  |
|   I32   |      I32      |      2^30      |       2^5        |    4.622 s |        inf% |    4.623 s |        inf% |     1.632 ms |   0.04% |  🔵 SAME  |
|   I32   |      I32      |      2^22      |       2^6        |   8.909 ms |       0.01% |   8.913 ms |       0.01% |     3.500 us |   0.04% |  🔴 SLOW  |
|   I32   |      I32      |      2^26      |       2^6        | 144.634 ms |       0.00% | 144.630 ms |       0.00% |    -3.632 us |  -0.00% |  🟢 FAST  |
|   I32   |      I32      |      2^30      |       2^6        |    2.314 s |       0.00% |    2.314 s |       0.00% |   -59.187 us |  -0.00% |  🟢 FAST  |
|   I32   |      I32      |      2^22      |       2^7        |   4.501 ms |       0.02% |   4.501 ms |       0.02% |    -0.104 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^26      |       2^7        |  72.797 ms |       0.01% |  72.796 ms |       0.01% |    -1.156 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^30      |       2^7        |    1.164 s |       0.00% |    1.164 s |       0.00% |   -30.940 us |  -0.00% |  🟢 FAST  |
|   I32   |      I32      |      2^22      |       2^8        |   2.290 ms |       0.03% |   2.290 ms |       0.03% |     0.115 us |   0.01% |  🔵 SAME  |
|   I32   |      I32      |      2^26      |       2^8        |  37.131 ms |       0.01% |  37.131 ms |       0.01% |    -0.868 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^30      |       2^8        | 593.652 ms |       0.00% | 593.638 ms |       0.00% |   -14.259 us |  -0.00% |  🟢 FAST  |

# large

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |  MaxSegmentSize  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I32   |      I32      |      2^22      |       2^10       | 652.292 us |       0.14% | 652.085 us |       0.15% | -0.206 us |  -0.03% |  🔵 SAME  |
|   I32   |      I32      |      2^26      |       2^10       |  10.683 ms |       0.02% |  10.683 ms |       0.02% | -0.168 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^30      |       2^10       | 170.252 ms |       0.00% | 170.255 ms |       0.00% |  3.163 us |   0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^22      |       2^12       | 236.718 us |       0.43% | 236.515 us |       0.40% | -0.203 us |  -0.09% |  🔵 SAME  |
|   I32   |      I32      |      2^26      |       2^12       |   3.635 ms |       0.04% |   3.635 ms |       0.04% | -0.068 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^30      |       2^12       |  57.366 ms |       0.01% |  57.363 ms |       0.01% | -2.451 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^22      |       2^14       | 203.716 us |       1.04% | 203.553 us |       1.04% | -0.163 us |  -0.08% |  🔵 SAME  |
|   I32   |      I32      |      2^26      |       2^14       |   2.163 ms |       0.09% |   2.163 ms |       0.09% | -0.011 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^30      |       2^14       |  33.245 ms |       0.01% |  33.245 ms |       0.01% | -0.176 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^22      |       2^16       | 279.785 us |       0.39% | 279.735 us |       0.38% | -0.049 us |  -0.02% |  🔵 SAME  |
|   I32   |      I32      |      2^26      |       2^16       |   2.137 ms |       0.34% |   2.136 ms |       0.35% | -0.663 us |  -0.03% |  🔵 SAME  |
|   I32   |      I32      |      2^30      |       2^16       |  30.318 ms |       0.04% |  30.318 ms |       0.04% | -0.096 us |  -0.00% |  🔵 SAME  |
|   I32   |      I32      |      2^22      |       2^18       | 967.923 us |       0.20% | 968.271 us |       0.23% |  0.347 us |   0.04% |  🔵 SAME  |
|   I32   |      I32      |      2^26      |       2^18       |   2.853 ms |       0.83% |   2.853 ms |       0.84% |  0.581 us |   0.02% |  🔵 SAME  |
|   I32   |      I32      |      2^30      |       2^18       |  29.544 ms |       0.08% |  29.541 ms |       0.08% | -2.456 us |  -0.01% |  🔵 SAME  |
```