### PR TITLE
[Backport] All tile fixes omnibus

### DIFF
--- a/ci/util/build_and_test_targets.sh
+++ b/ci/util/build_and_test_targets.sh
@@ -73,7 +73,7 @@ if [[ -n "${CONFIGURE_OVERRIDE}" ]]; then
   if [[ -n "${PRESET}" ]]; then
     echo "::warning:: --preset ignored due to --configure-override" >&2
   fi
-  if [[ "${#CMAKE_OPTIONS}" -gt 0 ]]; then
+  if [[ "${#CMAKE_OPTIONS[@]}" -gt 0 ]]; then
     echo "::warning:: --cmake-options ignored due to --configure-override" >&2
   fi
 fi
@@ -103,7 +103,7 @@ if [[ -z "${BUILD_DIR}" ]]; then
   exit 1
 fi
 
-if [[ "${#BUILD_TARGETS}" -gt 0 ]]; then
+if [[ "${#BUILD_TARGETS[@]}" -gt 0 ]]; then
   if ! (set -x; ninja -C "${BUILD_DIR}" "${BUILD_TARGETS[@]}"); then
     echo "::endgroup::"
     echo "🔴🛠️ Ninja build failed for targets ($(elapsed_time)): ${BUILD_TARGETS[*]@Q}"
@@ -111,7 +111,7 @@ if [[ "${#BUILD_TARGETS}" -gt 0 ]]; then
   fi
 fi
 
-if [[ "${#CTEST_TARGETS}" -gt 0 ]]; then
+if [[ "${#CTEST_TARGETS[@]}" -gt 0 ]]; then
   for t in "${CTEST_TARGETS[@]}"; do
     if ! (set -x; ctest --test-dir "${BUILD_DIR}" -R "$t" -V --output-on-failure); then
       echo "::endgroup::"
@@ -121,7 +121,7 @@ if [[ "${#CTEST_TARGETS}" -gt 0 ]]; then
   done
 fi
 
-if [[ "${#LIT_PRECOMPILE_TESTS}" -gt 0 || "${#LIT_TESTS}" -gt 0 ]]; then
+if [[ "${#LIT_PRECOMPILE_TESTS[@]}" -gt 0 || "${#LIT_TESTS[@]}" -gt 0 ]]; then
   lit_site_cfg="${BUILD_DIR}/libcudacxx/test/libcudacxx/lit.site.cfg"
   if [[ ! -f "${lit_site_cfg}" ]]; then
     echo "::endgroup::"
@@ -130,7 +130,7 @@ if [[ "${#LIT_PRECOMPILE_TESTS}" -gt 0 || "${#LIT_TESTS}" -gt 0 ]]; then
   fi
 fi
 
-if [[ "${#LIT_PRECOMPILE_TESTS}" -gt 0 ]]; then
+if [[ "${#LIT_PRECOMPILE_TESTS[@]}" -gt 0 ]]; then
   for t in "${LIT_PRECOMPILE_TESTS[@]}"; do
     t_path="libcudacxx/test/libcudacxx/${t}"
     if ! (set -x; LIBCUDACXX_SITE_CONFIG="${lit_site_cfg}" lit -v "-Dexecutor=NoopExecutor()" "${t_path}"); then
@@ -141,7 +141,7 @@ if [[ "${#LIT_PRECOMPILE_TESTS}" -gt 0 ]]; then
   done
 fi
 
-if [[ "${#LIT_TESTS}" -gt 0 ]]; then
+if [[ "${#LIT_TESTS[@]}" -gt 0 ]]; then
   for t in "${LIT_TESTS[@]}"; do
     t_path="libcudacxx/test/libcudacxx/${t}"
     if ! (set -x; LIBCUDACXX_SITE_CONFIG="${lit_site_cfg}" lit -v "${t_path}"); then

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -116,6 +116,8 @@ private:
 
       if constexpr (Determinism == ::cuda::execution::determinism::__determinism_t::__gpu_to_gpu)
       {
+        // Only instantiated with `plus<float|double>`; RFA hardcodes `deterministic_sum_t<accum_t>`.
+        (void) reduction_op;
         using default_policy_selector = detail::rfa::policy_selector_from_types<accum_t>;
         using policy_selector =
           ::cuda::std::execution::__query_result_or_t<tuning_env_t, detail::rfa::rfa_policy, default_policy_selector>;

--- a/docs/libcudacxx/tile.rst
+++ b/docs/libcudacxx/tile.rst
@@ -52,7 +52,7 @@ C++ mathematical operations
 
 We rely heavily on compiler builtins or cuda runtime functions to implement C++ standard math functions such
 as ``cuda::std::exp``. Those compiler builtins are not currently supported in tile mode, so the following headers
-are mostly unsupported:
+are mostly unsupported in a tile kernel:
 
     - <cuda/std/cmath>
     - <cuda/std/complex>
@@ -64,7 +64,26 @@ C++ customization point objects
 The standard library uses __ Customization Point Objects __ to enable user-customization of the behavior of many
 algorithms and ranges. We rely heavily on those for most of our iterator machinery such as e.g `cuda::std::begin`.
 
-Those CPOs are currently not accessible in a tile program.
+Those CPOs are currently not accessible in a tile kernel.
+
+C++ return statements in loops and switches
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tile currently does not support return statements inside of a ``switch`` or a loop. We can work around most places but
+not all. This mainly affects algorithms and arch traits.
+
+In ``<cuda/std/algorithm>`` the following algorithms are not supported in a tile kernel
+
+    - ``cuda::std::equal_range``
+    - ``cuda::std::find_end``
+    - ``cuda::std::find_first_of``
+    - ``cuda::std::partition``
+    - ``cuda::std::search``
+    - ``cuda::std::search_n``
+
+Besides that the content of the following headers is unsupported in a tile program
+
+    - ``<cuda/std/devices>``
 
 
 CUDA device intrinsics

--- a/docs/libcudacxx/tile.rst
+++ b/docs/libcudacxx/tile.rst
@@ -64,7 +64,8 @@ C++ customization point objects
 The standard library uses __ Customization Point Objects __ to enable user-customization of the behavior of many
 algorithms and ranges. We rely heavily on those for most of our iterator machinery such as e.g `cuda::std::begin`.
 
-Those CPOs are currently not accessible in a tile kernel.
+Those CPOs are currently not accessible in a tile kernel. A potential workaround is to construct an instance of the
+empty type, e.g. ``decltype(cuda::std::begin){}(container);``
 
 C++ return statements in loops and switches
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -328,7 +328,7 @@ public:
   buffer(::cuda::stream_ref __stream, _Resource&& __resource, _Range&& __range, [[maybe_unused]] const _Env& __env = {})
       : __buf_(::cuda::mr::__adapt_if_synchronous(::cuda::std::forward<_Resource>(__resource)),
                __stream,
-               static_cast<size_type>(::cuda::std::ranges::size(__range)),
+               static_cast<size_type>(::cuda::std::ranges::__size_cpo{}(__range)),
                __alignment_from_env(__env))
   {
     static_assert(::cuda::std::is_copy_constructible_v<::cuda::std::decay_t<_Resource>>,
@@ -336,7 +336,7 @@ public:
                   "cuda::mr::shared_resource can be used to attach shared ownership to a resource type.");
     using _Iter = ::cuda::std::ranges::iterator_t<_Range>;
     this->__copy_cross<_Iter>(
-      ::cuda::std::ranges::begin(__range),
+      ::cuda::std::ranges::__begin_cpo{}(__range),
       ::cuda::std::ranges::__unwrap_end(__range),
       __unwrapped_begin(),
       __buf_.size());
@@ -351,8 +351,8 @@ public:
   buffer(::cuda::stream_ref __stream, _Resource&& __resource, _Range&& __range, [[maybe_unused]] const _Env& __env = {})
       : __buf_(::cuda::mr::__adapt_if_synchronous(::cuda::std::forward<_Resource>(__resource)),
                __stream,
-               static_cast<size_type>(
-                 ::cuda::std::ranges::distance(::cuda::std::ranges::begin(__range), ::cuda::std::ranges::end(__range))),
+               static_cast<size_type>(::cuda::std::ranges::__distance_cpo{}(
+                 ::cuda::std::ranges::__begin_cpo{}(__range), ::cuda::std::ranges::__end_cpo{}(__range))),
                __alignment_from_env(__env))
   {
     static_assert(::cuda::std::is_copy_constructible_v<::cuda::std::decay_t<_Resource>>,
@@ -360,7 +360,7 @@ public:
                   "cuda::mr::shared_resource can be used to attach shared ownership to a resource type.");
     using _Iter = ::cuda::std::ranges::iterator_t<_Range>;
     this->__copy_cross<_Iter>(
-      ::cuda::std::ranges::begin(__range),
+      ::cuda::std::ranges::__begin_cpo{}(__range),
       ::cuda::std::ranges::__unwrap_end(__range),
       __unwrapped_begin(),
       __buf_.size());

--- a/libcudacxx/include/cuda/__device/arch_id.h
+++ b/libcudacxx/include/cuda/__device/arch_id.h
@@ -51,29 +51,29 @@ enum class arch_id : int
     _OP) " is deprecated and will be deleted in the next major release. Compare cuda::compute_capabilities of the " \
          "given "                                                                                                   \
          "cuda::arch_id instead.")
-[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(<) _CCCL_API constexpr bool
+[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(<) _CCCL_HOST_DEVICE_API constexpr bool
 operator<(arch_id __lhs, arch_id __rhs) noexcept
 {
   return ::cuda::std::to_underlying(__lhs) < ::cuda::std::to_underlying(__rhs);
 }
-[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(<=) _CCCL_API constexpr bool
+[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(<=) _CCCL_HOST_DEVICE_API constexpr bool
 operator<=(arch_id __lhs, arch_id __rhs) noexcept
 {
   return ::cuda::std::to_underlying(__lhs) <= ::cuda::std::to_underlying(__rhs);
 }
-[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(>) _CCCL_API constexpr bool
+[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(>) _CCCL_HOST_DEVICE_API constexpr bool
 operator>(arch_id __lhs, arch_id __rhs) noexcept
 {
   return ::cuda::std::to_underlying(__lhs) > ::cuda::std::to_underlying(__rhs);
 }
-[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(>=) _CCCL_API constexpr bool
+[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(>=) _CCCL_HOST_DEVICE_API constexpr bool
 operator>=(arch_id __lhs, arch_id __rhs) noexcept
 {
   return ::cuda::std::to_underlying(__lhs) >= ::cuda::std::to_underlying(__rhs);
 }
 #undef _CCCL_DEPRECATED_ARCH_ID_COMPARISONS
 
-[[nodiscard]] _CCCL_API constexpr auto __all_arch_ids() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto __all_arch_ids() noexcept
 {
   return ::cuda::std::array{
 #define _CCCL_MAKE_ARCH_ID(_CC)          arch_id::sm_##_CC,
@@ -85,12 +85,12 @@ operator>=(arch_id __lhs, arch_id __rhs) noexcept
   };
 }
 
-[[nodiscard]] _CCCL_API constexpr bool __is_specific_arch(arch_id __arch) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr bool __is_specific_arch(arch_id __arch) noexcept
 {
   return ::cuda::std::to_underlying(__arch) > __arch_specific_id_multiplier;
 }
 
-[[nodiscard]] _CCCL_API constexpr bool __has_known_arch(compute_capability __cc) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr bool __has_known_arch(compute_capability __cc) noexcept
 {
   switch (__cc.get())
   {
@@ -103,7 +103,7 @@ operator>=(arch_id __lhs, arch_id __rhs) noexcept
   }
 }
 
-[[nodiscard]] _CCCL_API constexpr bool __has_known_specific_arch(compute_capability __cc) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr bool __has_known_specific_arch(compute_capability __cc) noexcept
 {
   switch (__cc.get())
   {
@@ -121,7 +121,7 @@ operator>=(arch_id __lhs, arch_id __rhs) noexcept
 //! @param __cc The compute capability. Must have a corresponding architecture id.
 //!
 //! @returns The architecture id.
-[[nodiscard]] _CCCL_API constexpr arch_id to_arch_id(compute_capability __cc) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_id to_arch_id(compute_capability __cc) noexcept
 {
   _CCCL_ASSERT(::cuda::__has_known_arch(__cc), "this compute capability cannot be converted to arch id");
   return static_cast<arch_id>(__cc.get());
@@ -132,7 +132,7 @@ operator>=(arch_id __lhs, arch_id __rhs) noexcept
 //! @param __cc The compute capability. Must have a corresponding architecture specific id.
 //!
 //! @returns The architecture specific id.
-[[nodiscard]] _CCCL_API constexpr arch_id to_arch_specific_id(compute_capability __cc) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_id to_arch_specific_id(compute_capability __cc) noexcept
 {
   _CCCL_ASSERT(::cuda::__has_known_specific_arch(__cc),
                "this compute capability cannot be converted to arch specific id");

--- a/libcudacxx/include/cuda/__device/arch_traits.h
+++ b/libcudacxx/include/cuda/__device/arch_traits.h
@@ -155,7 +155,7 @@ struct arch_traits_t
   bool tma_supported;
 };
 
-[[nodiscard]] _CCCL_API constexpr arch_traits_t __common_arch_traits(arch_id __arch_id) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t __common_arch_traits(arch_id __arch_id) noexcept
 {
   const compute_capability __cc{__arch_id};
 
@@ -200,10 +200,10 @@ struct arch_traits_t
 
 //! @brief Gets the architecture traits for the given architecture id \c _Id.
 template <arch_id _Id>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits() noexcept;
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits() noexcept;
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_50>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_50>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_50);
   __traits.max_resident_grids                   = 32;
@@ -216,7 +216,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_52>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_52>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_52);
   __traits.max_resident_grids                   = 32;
@@ -229,7 +229,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_53>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_53>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_53);
   __traits.max_resident_grids                   = 32;
@@ -243,7 +243,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_60>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_60>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_60);
   __traits.max_shared_memory_per_multiprocessor = 64 * 1024;
@@ -255,7 +255,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_61>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_61>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_61);
   __traits.max_shared_memory_per_multiprocessor = 96 * 1024;
@@ -267,7 +267,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_62>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_62>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_62);
   __traits.max_shared_memory_per_multiprocessor = 64 * 1024;
@@ -281,7 +281,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_70>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_70>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_70);
   __traits.max_shared_memory_per_multiprocessor = 96 * 1024;
@@ -295,7 +295,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_75>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_75>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_75);
   __traits.max_shared_memory_per_multiprocessor = 64 * 1024;
@@ -308,7 +308,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_80>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_80>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_80);
   __traits.max_shared_memory_per_multiprocessor = 164 * 1024;
@@ -321,7 +321,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_86>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_86>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_86);
   __traits.max_shared_memory_per_multiprocessor = 100 * 1024;
@@ -334,7 +334,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_87>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_87>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_87);
   __traits.max_shared_memory_per_multiprocessor = 164 * 1024;
@@ -347,7 +347,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_88>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_88>() noexcept
 {
   auto __traits                     = ::cuda::arch_traits<arch_id::sm_86>();
   __traits.arch_id                  = arch_id::sm_88;
@@ -358,7 +358,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_89>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_89>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_89);
   __traits.max_shared_memory_per_multiprocessor = 100 * 1024;
@@ -371,7 +371,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_90>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_90>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_90);
   __traits.max_shared_memory_per_multiprocessor = 228 * 1024;
@@ -385,7 +385,7 @@ template <>
 
 // No sm_90a specific fields for now.
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_90a>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_90a>() noexcept
 {
   auto __traits    = ::cuda::arch_traits<arch_id::sm_90>();
   __traits.arch_id = arch_id::sm_90a;
@@ -393,7 +393,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_100>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_100>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_90);
   __traits.max_shared_memory_per_multiprocessor = 228 * 1024;
@@ -406,7 +406,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_100a>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_100a>() noexcept
 {
   auto __traits    = ::cuda::arch_traits<arch_id::sm_100>();
   __traits.arch_id = arch_id::sm_100a;
@@ -414,7 +414,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_103>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_103>() noexcept
 {
   auto __traits                     = ::cuda::arch_traits<arch_id::sm_100>();
   __traits.arch_id                  = arch_id::sm_103;
@@ -425,7 +425,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_103a>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_103a>() noexcept
 {
   auto __traits    = ::cuda::arch_traits<arch_id::sm_103>();
   __traits.arch_id = arch_id::sm_103a;
@@ -433,7 +433,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_110>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_110>() noexcept
 {
   auto __traits                           = ::cuda::arch_traits<arch_id::sm_100>();
   __traits.arch_id                        = arch_id::sm_110;
@@ -447,7 +447,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_110a>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_110a>() noexcept
 {
   auto __traits    = ::cuda::arch_traits<arch_id::sm_110>();
   __traits.arch_id = arch_id::sm_110a;
@@ -455,7 +455,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_120>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_120>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_120);
   __traits.max_shared_memory_per_multiprocessor = 100 * 1024;
@@ -468,7 +468,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_120a>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_120a>() noexcept
 {
   auto __traits    = ::cuda::arch_traits<arch_id::sm_120>();
   __traits.arch_id = arch_id::sm_120a;
@@ -476,7 +476,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_121>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_121>() noexcept
 {
   auto __traits                     = ::cuda::arch_traits<arch_id::sm_120>();
   __traits.arch_id                  = arch_id::sm_121;
@@ -487,7 +487,7 @@ template <>
 };
 
 template <>
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_121a>() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits<arch_id::sm_121a>() noexcept
 {
   auto __traits    = ::cuda::arch_traits<arch_id::sm_121>();
   __traits.arch_id = arch_id::sm_121a;
@@ -497,7 +497,7 @@ template <>
 //! @brief Gets the architecture traits for the given architecture id \c __id.
 //!
 //! @throws cuda::cuda_error if the \c __id is not a known architecture.
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits_for(arch_id __id)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits_for(arch_id __id)
 {
   switch (__id)
   {
@@ -523,7 +523,7 @@ template <>
 //! @brief Gets the architecture traits for the given compute capability \c __cc.
 //!
 //! @throws cuda::cuda_error if the \c __cc doesn't have a corresponding architecture id.
-[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits_for(compute_capability __cc)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr arch_traits_t arch_traits_for(compute_capability __cc)
 {
   return ::cuda::arch_traits_for(::cuda::to_arch_id(__cc));
 }

--- a/libcudacxx/include/cuda/__device/compute_capability.h
+++ b/libcudacxx/include/cuda/__device/compute_capability.h
@@ -42,7 +42,7 @@ public:
   //! @brief Constructs the object from compute capability \c __cc. The expected format is 10 * major + minor.
   //!
   //! @param __cc Compute capability.
-  _CCCL_API explicit constexpr compute_capability(int __cc) noexcept
+  _CCCL_HOST_DEVICE_API explicit constexpr compute_capability(int __cc) noexcept
       : __cc_{__cc}
   {}
 
@@ -50,7 +50,7 @@ public:
   //!
   //! @param __major The major compute capability.
   //! @param __minor The minor compute capability. Must be less than 10.
-  _CCCL_API constexpr compute_capability(int __major, int __minor) noexcept
+  _CCCL_HOST_DEVICE_API constexpr compute_capability(int __major, int __minor) noexcept
       : __cc_{10 * __major + __minor}
   {
     _CCCL_ASSERT(__minor < 10, "invalid minor compute capability");
@@ -59,7 +59,7 @@ public:
   //! @brief Constructs the object from the architecture id.
   //!
   //! @param __arch_id The architecture id.
-  _CCCL_API explicit constexpr compute_capability(arch_id __arch_id) noexcept
+  _CCCL_HOST_DEVICE_API explicit constexpr compute_capability(arch_id __arch_id) noexcept
   {
     const auto __val = ::cuda::std::to_underlying(__arch_id);
     if (__val > __arch_specific_id_multiplier)
@@ -79,7 +79,7 @@ public:
   //! @brief Gets the stored compute capability.
   //!
   //! @return The stored compute capability in format 10 * major + minor.
-  [[nodiscard]] _CCCL_API constexpr int get() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr int get() const noexcept
   {
     return __cc_;
   }
@@ -93,7 +93,7 @@ public:
   [[nodiscard]]
   CCCL_DEPRECATED_BECAUSE("This symbol is deprecated because it collides with major(...) macro defined in "
                           "<sys/sysmacros.h> and will be removed in next major release. Use cc.major_cap() instead.")
-  _CCCL_API constexpr int major() const noexcept
+  _CCCL_HOST_DEVICE_API constexpr int major() const noexcept
   {
     return major_cap();
   }
@@ -101,7 +101,7 @@ public:
   //! @brief Gets the major compute capability.
   //!
   //! @return Major compute capability.
-  [[nodiscard]] _CCCL_API constexpr int major_cap() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr int major_cap() const noexcept
   {
     return __cc_ / 10;
   }
@@ -115,7 +115,7 @@ public:
   [[nodiscard]]
   CCCL_DEPRECATED_BECAUSE("This symbol is deprecated because it collides with minor(...) macro defined in "
                           "<sys/sysmacros.h> and will be removed in next major release. Use cc.minor_cap() instead.")
-  _CCCL_API constexpr int minor() const noexcept
+  _CCCL_HOST_DEVICE_API constexpr int minor() const noexcept
   {
     return minor_cap();
   }
@@ -123,7 +123,7 @@ public:
   //! @brief Gets the minor compute capability.
   //!
   //! @return Minor compute capability. The value is always less than 10.
-  [[nodiscard]] _CCCL_API constexpr int minor_cap() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr int minor_cap() const noexcept
   {
     return __cc_ % 10;
   }
@@ -131,62 +131,68 @@ public:
   //! @brief Conversion operator to \c int.
   //!
   //! @return The stored compute capability in format 10 * major + minor.
-  _CCCL_API explicit constexpr operator int() const noexcept
+  _CCCL_HOST_DEVICE_API explicit constexpr operator int() const noexcept
   {
     return __cc_;
   }
 
   //! @brief Equality operator.
-  [[nodiscard]] _CCCL_API friend constexpr bool operator==(compute_capability __lhs, compute_capability __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator==(compute_capability __lhs, compute_capability __rhs) noexcept
   {
     return __lhs.__cc_ == __rhs.__cc_;
   }
 
   //! @brief Inequality operator.
-  [[nodiscard]] _CCCL_API friend constexpr bool operator!=(compute_capability __lhs, compute_capability __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator!=(compute_capability __lhs, compute_capability __rhs) noexcept
   {
     return __lhs.__cc_ != __rhs.__cc_;
   }
 
   //! @brief Less than operator.
-  [[nodiscard]] _CCCL_API friend constexpr bool operator<(compute_capability __lhs, compute_capability __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator<(compute_capability __lhs, compute_capability __rhs) noexcept
   {
     return __lhs.__cc_ < __rhs.__cc_;
   }
 
   //! @brief Less than or equal to operator.
-  [[nodiscard]] _CCCL_API friend constexpr bool operator<=(compute_capability __lhs, compute_capability __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator<=(compute_capability __lhs, compute_capability __rhs) noexcept
   {
     return __lhs.__cc_ <= __rhs.__cc_;
   }
 
   //! @brief Greater than operator.
-  [[nodiscard]] _CCCL_API friend constexpr bool operator>(compute_capability __lhs, compute_capability __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator>(compute_capability __lhs, compute_capability __rhs) noexcept
   {
     return __lhs.__cc_ > __rhs.__cc_;
   }
 
   //! @brief Greater than or equal to operator.
-  [[nodiscard]] _CCCL_API friend constexpr bool operator>=(compute_capability __lhs, compute_capability __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator>=(compute_capability __lhs, compute_capability __rhs) noexcept
   {
     return __lhs.__cc_ >= __rhs.__cc_;
   }
 };
 
 template <int... _Vs>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __make_all_compute_capabilities() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API _CCCL_CONSTEVAL auto __make_all_compute_capabilities() noexcept
 {
   return ::cuda::std::array{compute_capability{_Vs}...};
 }
 
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __all_compute_capabilities() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API _CCCL_CONSTEVAL auto __all_compute_capabilities() noexcept
 {
   return ::cuda::__make_all_compute_capabilities<_CCCL_KNOWN_CUDA_ARCH_LIST>();
 }
 
 #if _CCCL_CUDA_COMPILATION()
 template <int... _Vs>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __make_cc_list() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API _CCCL_CONSTEVAL auto __make_cc_list() noexcept
 {
 #  if defined(__CUDA_ARCH_LIST__)
   return ::cuda::std::array{compute_capability{_Vs / 10}...};
@@ -199,7 +205,7 @@ template <int... _Vs>
 #  endif // ^^^ no arch list ^^^
 }
 
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __target_compute_capabilities() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API _CCCL_CONSTEVAL auto __target_compute_capabilities() noexcept
 {
 #  if defined(__CUDA_ARCH_LIST__)
   return ::cuda::__make_cc_list<__CUDA_ARCH_LIST__>();

--- a/libcudacxx/include/cuda/__iterator/zip_common.h
+++ b/libcudacxx/include/cuda/__iterator/zip_common.h
@@ -57,7 +57,7 @@ struct __zip_iter_constraints
     (::cuda::std::sized_sentinel_for<_Iterators, _Iterators> && ...) || __all_random_access;
 
   static constexpr bool __all_nothrow_iter_movable =
-    (noexcept(::cuda::std::ranges::iter_move(::cuda::std::declval<const _Iterators&>())) && ...)
+    (noexcept(::cuda::std::ranges::__iter_move_cpo{}(::cuda::std::declval<const _Iterators&>())) && ...)
     && (::cuda::std::is_nothrow_move_constructible_v<::cuda::std::iter_rvalue_reference_t<_Iterators>> && ...);
 
   static constexpr bool __all_indirectly_swappable = (::cuda::std::indirectly_swappable<_Iterators> && ...);
@@ -138,9 +138,9 @@ struct __zip_iter_move
   _CCCL_EXEC_CHECK_DISABLE
   template <class... _Iterators>
   [[nodiscard]] _CCCL_API constexpr __iter_move_ret<_Iterators...> operator()(const _Iterators&... __iters) const
-    noexcept(noexcept(__iter_move_ret<_Iterators...>{::cuda::std::ranges::iter_move(__iters)...}))
+    noexcept(noexcept(__iter_move_ret<_Iterators...>{::cuda::std::ranges::__iter_move_cpo{}(__iters)...}))
   {
-    return __iter_move_ret<_Iterators...>{::cuda::std::ranges::iter_move(__iters)...};
+    return __iter_move_ret<_Iterators...>{::cuda::std::ranges::__iter_move_cpo{}(__iters)...};
   }
 };
 

--- a/libcudacxx/include/cuda/__iterator/zip_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_iterator.h
@@ -491,7 +491,9 @@ public:
                                         ::cuda::std::index_sequence<_Indices...>) const
       noexcept(__zip_iter_constraints<_Iterators...>::__all_noexcept_swappable)
     {
-      (::cuda::std::ranges::iter_swap(::cuda::std::get<_Indices>(__iters1), ::cuda::std::get<_Indices>(__iters2)), ...);
+      (::cuda::std::ranges::__iter_swap_cpo{}(
+         ::cuda::std::get<_Indices>(__iters1), ::cuda::std::get<_Indices>(__iters2)),
+       ...);
     }
   };
 

--- a/libcudacxx/include/cuda/__mdspan/host_device_accessor.h
+++ b/libcudacxx/include/cuda/__mdspan/host_device_accessor.h
@@ -196,7 +196,10 @@ public:
   _CCCL_API constexpr reference access(data_handle_type __p, ::cuda::std::size_t __i) const
     noexcept(__is_access_noexcept)
   {
-    NV_IF_TARGET(NV_IS_DEVICE, (_CCCL_VERIFY(false, "cuda::__host_accessor cannot be used in DEVICE code");))
+    _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+    {
+      NV_IF_TARGET(NV_IS_DEVICE, (_CCCL_VERIFY(false, "cuda::__host_accessor cannot be used in DEVICE code");))
+    }
     return _Accessor::access(__p, __i);
   }
 
@@ -217,7 +220,7 @@ public:
       _CCCL_ASSERT(__is_valid, "host_accessor (mdspan): data handle doesn't point to a valid host memory");
       return !__is_valid;
     }
-    return true;
+    return false;
   }
 #endif // !defined(_CCCL_DISABLE_MDSPAN_ACCESSOR_DETECT_INVALIDITY)
 };
@@ -352,7 +355,7 @@ public:
                    "device_accessor (mdspan): data handle doesn't point to a valid device or managed memory");
       return !__is_valid;
     }
-    return true;
+    return false;
   }
 #endif // !defined(_CCCL_DISABLE_MDSPAN_ACCESSOR_DETECT_INVALIDITY)
 };
@@ -472,7 +475,7 @@ public:
       _CCCL_ASSERT(__is_valid, "managed_accessor (mdspan): data handle doesn't point to a valid managed memory");
       return !__is_valid;
     }
-    return true;
+    return false;
   }
 #endif // !defined(_CCCL_DISABLE_MDSPAN_ACCESSOR_DETECT_INVALIDITY)
 };

--- a/libcudacxx/include/cuda/__mdspan/layout_stride_relaxed.h
+++ b/libcudacxx/include/cuda/__mdspan/layout_stride_relaxed.h
@@ -65,12 +65,18 @@ template <class _StridedMapping>
   using _RankType       = typename _StridedMapping::rank_type;
   constexpr auto __rank = _Extents::rank();
   // Check if any extent is zero - can't call mapping(0,...) in that case
+  bool __extent_is_zero = false;
   for (_RankType __r = 0; __r != __rank; ++__r)
   {
     if (__mapping.extents().extent(__r) == 0)
     {
-      return typename _StridedMapping::index_type{0};
+      __extent_is_zero = true;
+      break;
     }
+  }
+  if (__extent_is_zero)
+  {
+    return typename _StridedMapping::index_type{0};
   }
   return ::cuda::__layout_stride_relaxed_compute_offset(__mapping, ::cuda::std::make_index_sequence<__rank>{});
 }
@@ -141,14 +147,16 @@ private:
 
   [[nodiscard]] _CCCL_API constexpr bool __has_positive_strides() const noexcept
   {
+    bool __result = true;
     for (rank_type __r = 0; __r != __rank_; ++__r)
     {
       if (strides().stride(__r) <= 0)
       {
-        return false;
+        __result = false;
+        break;
       }
     }
-    return true;
+    return __result;
   }
 
 public:
@@ -265,12 +273,14 @@ public:
       // __min_dot tracks the total positive magnitude of the negative contributions
       index_type __dot{1};
       offset_type __min_dot{0};
+      bool __stride_is_negative = false;
       for (rank_type __r = 0; __r < __rank_; ++__r)
       {
         const auto __ext = extents().extent(__r);
         if (__ext == index_type{0})
         {
-          return index_type{0};
+          __stride_is_negative = true;
+          break;
         }
         const auto __stride_val = strides().stride(__r);
         _CCCL_ASSERT(::cuda::std::in_range<index_type>(::cuda::uabs(__stride_val)),
@@ -300,7 +310,7 @@ public:
                    "layout_stride_relaxed::mapping: offset is insufficient for negative strides");
       _CCCL_ASSERT(!::cuda::add_overflow<index_type>(__offset_val, __dot),
                    "layout_stride_relaxed::mapping: required_span_size is not representable as index_type");
-      return static_cast<index_type>(__offset_val + __dot);
+      return __stride_is_negative ? index_type{0} : static_cast<index_type>(__offset_val + __dot);
     }
   }
 

--- a/libcudacxx/include/cuda/__mdspan/strides.h
+++ b/libcudacxx/include/cuda/__mdspan/strides.h
@@ -229,14 +229,16 @@ public:
     }
     else
     {
+      bool __result = true;
       for (rank_type __r = 0; __r != __rank_; __r++)
       {
         if (::cuda::std::cmp_not_equal(__lhs.stride(__r), __rhs.stride(__r)))
         {
-          return false;
+          __result = false;
+          break;
         }
       }
-      return true;
+      return __result;
     }
   }
 

--- a/libcudacxx/include/cuda/std/__algorithm/adjacent_find.h
+++ b/libcudacxx/include/cuda/std/__algorithm/adjacent_find.h
@@ -38,7 +38,8 @@ adjacent_find(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicat
     {
       if (__pred(*__first, *__i))
       {
-        return __first;
+        __last = __first;
+        break;
       }
       __first = __i;
     }

--- a/libcudacxx/include/cuda/std/__algorithm/all_of.h
+++ b/libcudacxx/include/cuda/std/__algorithm/all_of.h
@@ -28,14 +28,16 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _Predicate>
 [[nodiscard]] _CCCL_API constexpr bool all_of(_InputIterator __first, _InputIterator __last, _Predicate __pred)
 {
+  bool __result = true;
   for (; __first != __last; ++__first)
   {
     if (!__pred(*__first))
     {
-      return false;
+      __result = false;
+      break;
     }
   }
-  return true;
+  return __result;
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__algorithm/any_of.h
+++ b/libcudacxx/include/cuda/std/__algorithm/any_of.h
@@ -28,14 +28,16 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _Predicate>
 [[nodiscard]] _CCCL_API constexpr bool any_of(_InputIterator __first, _InputIterator __last, _Predicate __pred)
 {
+  bool __result = false;
   for (; __first != __last; ++__first)
   {
     if (__pred(*__first))
     {
-      return true;
+      __result = true;
+      break;
     }
   }
-  return false;
+  return __result;
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy.h
@@ -86,13 +86,11 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
 _CCCL_API constexpr bool __constexpr_tail_overlap(_Tp* __first, _Up* __needle, [[maybe_unused]] _Tp* __last)
 {
-#if !_CCCL_TILE_COMPILATION() // pointer values cannot be compared
-  if (!::cuda::std::is_constant_evaluated())
+  if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
     return __first < __needle;
   }
   else
-#endif // !_CCCL_TILE_COMPILATION()
   {
 #if defined(_CCCL_BUILTIN_CONSTANT_P)
     NV_IF_ELSE_TARGET(NV_IS_HOST,

--- a/libcudacxx/include/cuda/std/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy.h
@@ -71,15 +71,17 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
 _CCCL_API constexpr bool __constexpr_tail_overlap_fallback(_Tp* __first, _Up* __needle, _Tp* __last)
 {
+  bool __result = false;
   while (__first != __last)
   {
     if (__first == __needle)
     {
-      return true;
+      __result = true;
+      break;
     }
     ++__first;
   }
-  return false;
+  return __result;
 }
 
 _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/std/__algorithm/equal.h
+++ b/libcudacxx/include/cuda/std/__algorithm/equal.h
@@ -34,14 +34,16 @@ template <class _InputIterator1, class _InputIterator2, class _BinaryPredicate>
 [[nodiscard]] _CCCL_API constexpr bool
 equal(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _BinaryPredicate __pred)
 {
+  bool __result = true;
   for (; __first1 != __last1; ++__first1, (void) ++__first2)
   {
     if (!__pred(*__first1, *__first2))
     {
-      return false;
+      __result = false;
+      break;
     }
   }
-  return true;
+  return __result;
 }
 
 template <class _InputIterator1, class _InputIterator2>
@@ -61,14 +63,16 @@ template <class _BinaryPredicate, class _InputIterator1, class _InputIterator2>
   input_iterator_tag,
   input_iterator_tag)
 {
+  bool __result = true;
   for (; __first1 != __last1 && __first2 != __last2; ++__first1, (void) ++__first2)
   {
     if (!__pred(*__first1, *__first2))
     {
-      return false;
+      __result = false;
+      break;
     }
   }
-  return __first1 == __last1 && __first2 == __last2;
+  return __result && __first1 == __last1 && __first2 == __last2;
 }
 
 template <class _BinaryPredicate, class _RandomAccessIterator1, class _RandomAccessIterator2>

--- a/libcudacxx/include/cuda/std/__algorithm/equal_range.h
+++ b/libcudacxx/include/cuda/std/__algorithm/equal_range.h
@@ -43,7 +43,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Compare, class _Iter, class _Sent, class _Tp, class _Proj>
-_CCCL_API constexpr pair<_Iter, _Iter>
+_CCCL_HOST_DEVICE_API constexpr pair<_Iter, _Iter>
 __equal_range(_Iter __first, _Sent __last, const _Tp& __value, _Compare&& __comp, _Proj&& __proj)
 {
   auto __len  = _IterOps<_AlgPolicy>::distance(__first, __last);
@@ -74,7 +74,7 @@ __equal_range(_Iter __first, _Sent __last, const _Tp& __value, _Compare&& __comp
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Tp, class _Compare>
-[[nodiscard]] _CCCL_API constexpr pair<_ForwardIterator, _ForwardIterator>
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr pair<_ForwardIterator, _ForwardIterator>
 equal_range(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, _Compare __comp)
 {
   static_assert(__is_callable<_Compare, decltype(*__first), const _Tp&>::value, "The comparator has to be callable");
@@ -88,7 +88,7 @@ equal_range(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __valu
 }
 
 template <class _ForwardIterator, class _Tp>
-[[nodiscard]] _CCCL_API constexpr pair<_ForwardIterator, _ForwardIterator>
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr pair<_ForwardIterator, _ForwardIterator>
 equal_range(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
 {
   return ::cuda::std::equal_range(::cuda::std::move(__first), ::cuda::std::move(__last), __value, __less{});

--- a/libcudacxx/include/cuda/std/__algorithm/find_end.h
+++ b/libcudacxx/include/cuda/std/__algorithm/find_end.h
@@ -45,13 +45,16 @@ template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterato
   {
     return __r;
   }
-  while (true)
+  bool __searching = true;
+  while (__searching)
   {
-    while (true)
+    while (__searching)
     {
       if (__first1 == __last1) // if source exhausted return last correct answer
       {
-        return __r; //    (or __last1 if never found)
+        // return __r; //    (or __last1 if never found)
+        __searching = false;
+        break;
       }
       if (__pred(*__first1, *__first2))
       {
@@ -62,7 +65,7 @@ template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterato
     // *__first1 matches *__first2, now match elements after here
     _ForwardIterator1 __m1 = __first1;
     _ForwardIterator2 __m2 = __first2;
-    while (true)
+    while (__searching)
     {
       if (++__m2 == __last2)
       { // Pattern exhausted, record answer and search for another one
@@ -72,7 +75,9 @@ template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterato
       }
       if (++__m1 == __last1) // Source exhausted, return last answer
       {
-        return __r;
+        // return __r;
+        __searching = false;
+        break;
       }
       if (!__pred(*__m1, *__m2)) // mismatch, restart with a new __first
       {
@@ -81,6 +86,7 @@ template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterato
       } // else there is a match, check next elements
     }
   }
+  return __r;
 }
 
 _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/std/__algorithm/find_end.h
+++ b/libcudacxx/include/cuda/std/__algorithm/find_end.h
@@ -30,7 +30,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterator2>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator1 __find_end(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator1 __find_end(
   _ForwardIterator1 __first1,
   _ForwardIterator1 __last1,
   _ForwardIterator2 __first2,
@@ -91,7 +91,7 @@ template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterato
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _BidirectionalIterator1, class _BidirectionalIterator2>
-[[nodiscard]] _CCCL_API constexpr _BidirectionalIterator1 __find_end(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _BidirectionalIterator1 __find_end(
   _BidirectionalIterator1 __first1,
   _BidirectionalIterator1 __last1,
   _BidirectionalIterator2 __first2,
@@ -145,7 +145,7 @@ template <class _BinaryPredicate, class _BidirectionalIterator1, class _Bidirect
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _RandomAccessIterator1, class _RandomAccessIterator2>
-[[nodiscard]] _CCCL_API constexpr _RandomAccessIterator1 __find_end(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _RandomAccessIterator1 __find_end(
   _RandomAccessIterator1 __first1,
   _RandomAccessIterator1 __last1,
   _RandomAccessIterator2 __first2,
@@ -200,7 +200,7 @@ template <class _BinaryPredicate, class _RandomAccessIterator1, class _RandomAcc
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator1 find_end(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator1 find_end(
   _ForwardIterator1 __first1,
   _ForwardIterator1 __last1,
   _ForwardIterator2 __first2,
@@ -218,7 +218,7 @@ template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredica
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator1
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator1
 find_end(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2)
 {
   return ::cuda::std::find_end(__first1, __last1, __first2, __last2, __equal_to{});

--- a/libcudacxx/include/cuda/std/__algorithm/find_first_of.h
+++ b/libcudacxx/include/cuda/std/__algorithm/find_first_of.h
@@ -28,7 +28,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator1 __find_first_of_ce(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator1 __find_first_of_ce(
   _ForwardIterator1 __first1,
   _ForwardIterator1 __last1,
   _ForwardIterator2 __first2,
@@ -49,7 +49,7 @@ template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredica
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator1 find_first_of(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator1 find_first_of(
   _ForwardIterator1 __first1,
   _ForwardIterator1 __last1,
   _ForwardIterator2 __first2,
@@ -60,7 +60,7 @@ template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredica
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator1 find_first_of(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator1 find_first_of(
   _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2)
 {
   return ::cuda::std::__find_first_of_ce(__first1, __last1, __first2, __last2, __equal_to{});

--- a/libcudacxx/include/cuda/std/__algorithm/includes.h
+++ b/libcudacxx/include/cuda/std/__algorithm/includes.h
@@ -37,19 +37,21 @@ template <class _Iter1, class _Sent1, class _Iter2, class _Sent2, class _Comp, c
 _CCCL_API constexpr bool __includes(
   _Iter1 __first1, _Sent1 __last1, _Iter2 __first2, _Sent2 __last2, _Comp&& __comp, _Proj1&& __proj1, _Proj2&& __proj2)
 {
+  bool __result = true;
   for (; __first2 != __last2; ++__first1)
   {
     if (__first1 == __last1
         || ::cuda::std::invoke(__comp, ::cuda::std::invoke(__proj2, *__first2), ::cuda::std::invoke(__proj1, *__first1)))
     {
-      return false;
+      __result = false;
+      break;
     }
     if (!::cuda::std::invoke(__comp, ::cuda::std::invoke(__proj1, *__first1), ::cuda::std::invoke(__proj2, *__first2)))
     {
       ++__first2;
     }
   }
-  return true;
+  return __result;
 }
 
 _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/std/__algorithm/is_heap_until.h
+++ b/libcudacxx/include/cuda/std/__algorithm/is_heap_until.h
@@ -43,17 +43,19 @@ __is_heap_until(_RandomAccessIterator __first, _RandomAccessIterator __last, _Co
     _RandomAccessIterator __cp = __first + __c;
     if (__comp(*__pp, *__cp))
     {
-      return __cp;
+      __last = __cp;
+      break;
     }
     ++__c;
     ++__cp;
     if (__c == __len)
     {
-      return __last;
+      break;
     }
     if (__comp(*__pp, *__cp))
     {
-      return __cp;
+      __last = __cp;
+      break;
     }
     ++__p;
     ++__pp;

--- a/libcudacxx/include/cuda/std/__algorithm/is_partitioned.h
+++ b/libcudacxx/include/cuda/std/__algorithm/is_partitioned.h
@@ -40,14 +40,16 @@ template <class _InputIterator, class _Predicate>
     return true;
   }
   ++__first;
+  bool __result = true;
   for (; __first != __last; ++__first)
   {
     if (__pred(*__first))
     {
-      return false;
+      __result = false;
+      break;
     }
   }
-  return true;
+  return __result;
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__algorithm/is_permutation.h
+++ b/libcudacxx/include/cuda/std/__algorithm/is_permutation.h
@@ -58,6 +58,7 @@ template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredica
   _ForwardIterator2 __last2 = ::cuda::std::next(__first2, __l1);
   // For each element in [f1, l1) see if there are the same number of
   //    equal elements in [f2, l2)
+  bool __result = true;
   for (_ForwardIterator1 __i = __first1; __i != __last1; ++__i)
   {
     //  Have we already counted the number of *__i in [f1, l1)?
@@ -82,7 +83,8 @@ template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredica
       }
       if (__c2 == 0)
       {
-        return false;
+        __result = false;
+        break;
       }
       // Count number of *__i in [__i, l1) (we can start with 1)
       _Diff1 __c1 = 1;
@@ -95,11 +97,12 @@ template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredica
       }
       if (__c1 != __c2)
       {
-        return false;
+        __result = false;
+        break;
       }
     }
   }
-  return true;
+  return __result;
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2>
@@ -149,6 +152,7 @@ template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterato
 
   // For each element in [f1, l1) see if there are the same number of
   //    equal elements in [f2, l2)
+  bool __result = true;
   for (_ForwardIterator1 __i = __first1; __i != __last1; ++__i)
   {
     //  Have we already counted the number of *__i in [f1, l1)?
@@ -173,7 +177,8 @@ template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterato
       }
       if (__c2 == 0)
       {
-        return false;
+        __result = false;
+        break;
       }
       // Count number of *__i in [__i, l1) (we can start with 1)
       _Diff1 __c1 = 1;
@@ -186,11 +191,12 @@ template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterato
       }
       if (__c1 != __c2)
       {
-        return false;
+        __result = false;
+        break;
       }
     }
   }
-  return true;
+  return __result;
 }
 
 _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/std/__algorithm/is_sorted_until.h
+++ b/libcudacxx/include/cuda/std/__algorithm/is_sorted_until.h
@@ -40,7 +40,8 @@ __is_sorted_until(_ForwardIterator __first, _ForwardIterator __last, _Compare __
     {
       if (__comp(*__i, *__first))
       {
-        return __i;
+        __last = __i;
+        break;
       }
       __first = __i;
     }

--- a/libcudacxx/include/cuda/std/__algorithm/iter_swap.h
+++ b/libcudacxx/include/cuda/std/__algorithm/iter_swap.h
@@ -73,6 +73,9 @@ inline namespace __cpo
 {
 // This is a global constant to avoid breaking types that pull in `::std::iter_swap` via ADL
 _CCCL_GLOBAL_CONSTANT auto iter_swap = __iter_swap::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __iter_swap_cpo = __iter_swap::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__algorithm/iterator_operations.h
+++ b/libcudacxx/include/cuda/std/__algorithm/iterator_operations.h
@@ -58,13 +58,13 @@ struct _IterOps<_RangeAlgPolicy>
   template <class _Iter>
   using __difference_type = iter_difference_t<_Iter>;
 
-  static constexpr auto advance      = ::cuda::std::ranges::advance;
-  static constexpr auto distance     = ::cuda::std::ranges::distance;
-  static constexpr auto __iter_move  = ::cuda::std::ranges::iter_move;
-  static constexpr auto iter_swap    = ::cuda::std::ranges::iter_swap;
-  static constexpr auto next         = ::cuda::std::ranges::next;
-  static constexpr auto prev         = ::cuda::std::ranges::prev;
-  static constexpr auto __advance_to = ::cuda::std::ranges::advance;
+  static constexpr auto advance      = ::cuda::std::ranges::__advance_cpo{};
+  static constexpr auto distance     = ::cuda::std::ranges::__distance_cpo{};
+  static constexpr auto __iter_move  = ::cuda::std::ranges::__iter_move_cpo{};
+  static constexpr auto iter_swap    = ::cuda::std::ranges::__iter_swap_cpo{};
+  static constexpr auto next         = ::cuda::std::ranges::__next_cpo{};
+  static constexpr auto prev         = ::cuda::std::ranges::__prev_cpo{};
+  static constexpr auto __advance_to = ::cuda::std::ranges::__advance_cpo{};
 };
 
 struct _ClassicAlgPolicy
@@ -141,7 +141,7 @@ struct _IterOps<_ClassicAlgPolicy>
   template <class _Iter1, class _Iter2>
   _CCCL_API constexpr static void iter_swap(_Iter1&& __a, _Iter2&& __b)
   {
-    ::cuda::std::iter_swap(::cuda::std::forward<_Iter1>(__a), ::cuda::std::forward<_Iter2>(__b));
+    ::cuda::std::__iter_swap_cpo{}(::cuda::std::forward<_Iter1>(__a), ::cuda::std::forward<_Iter2>(__b));
   }
 
   // next

--- a/libcudacxx/include/cuda/std/__algorithm/lexicographical_compare.h
+++ b/libcudacxx/include/cuda/std/__algorithm/lexicographical_compare.h
@@ -33,18 +33,20 @@ template <class _Compare, class _InputIterator1, class _InputIterator2>
 [[nodiscard]] _CCCL_API constexpr bool __lexicographical_compare(
   _InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _InputIterator2 __last2, _Compare __comp)
 {
+  bool __result = false;
   for (; __first2 != __last2; ++__first1, (void) ++__first2)
   {
     if (__first1 == __last1 || __comp(*__first1, *__first2))
     {
-      return true;
+      __result = true;
+      break;
     }
     if (__comp(*__first2, *__first1))
     {
-      return false;
+      break;
     }
   }
-  return false;
+  return __result;
 }
 
 template <class _InputIterator1, class _InputIterator2, class _Compare>

--- a/libcudacxx/include/cuda/std/__algorithm/merge.h
+++ b/libcudacxx/include/cuda/std/__algorithm/merge.h
@@ -39,11 +39,13 @@ _CCCL_API constexpr _OutputIterator __merge(
   _OutputIterator __result,
   _Compare __comp)
 {
+  bool __second_remains = true;
   for (; __first1 != __last1; ++__result)
   {
     if (__first2 == __last2)
     {
-      return ::cuda::std::copy(__first1, __last1, __result);
+      __second_remains = false;
+      break;
     }
     if (__comp(*__first2, *__first1))
     {
@@ -56,7 +58,14 @@ _CCCL_API constexpr _OutputIterator __merge(
       ++__first1;
     }
   }
-  return ::cuda::std::copy(__first2, __last2, __result);
+  if (__second_remains)
+  {
+    return ::cuda::std::copy(__first2, __last2, __result);
+  }
+  else
+  {
+    return ::cuda::std::copy(__first1, __last1, __result);
+  }
 }
 
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator, class _Compare>

--- a/libcudacxx/include/cuda/std/__algorithm/minmax_element.h
+++ b/libcudacxx/include/cuda/std/__algorithm/minmax_element.h
@@ -84,7 +84,7 @@ _CCCL_API constexpr pair<_Iter, _Iter> __minmax_element_impl(_Iter __first, _Sen
       {
         __result.second = __i;
       }
-      return __result;
+      break;
     }
 
     if (__less(__first, __i))

--- a/libcudacxx/include/cuda/std/__algorithm/next_permutation.h
+++ b/libcudacxx/include/cuda/std/__algorithm/next_permutation.h
@@ -46,6 +46,7 @@ __next_permutation(_BidirectionalIterator __first, _Sentinel __last, _Compare&& 
     return _Result(::cuda::std::move(__last_iter), false);
   }
 
+  bool __result = true;
   while (true)
   {
     _BidirectionalIterator __ip1 = __i;
@@ -56,14 +57,17 @@ __next_permutation(_BidirectionalIterator __first, _Sentinel __last, _Compare&& 
         ;
       _IterOps<_AlgPolicy>::iter_swap(__i, __j);
       ::cuda::std::__reverse<_AlgPolicy>(__ip1, __last_iter);
-      return _Result(::cuda::std::move(__last_iter), true);
+      __result = true;
+      break;
     }
     if (__i == __first)
     {
       ::cuda::std::__reverse<_AlgPolicy>(__first, __last_iter);
-      return _Result(::cuda::std::move(__last_iter), false);
+      __result = false;
+      break;
     }
   }
+  return _Result(::cuda::std::move(__last_iter), __result);
 }
 
 _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/std/__algorithm/none_of.h
+++ b/libcudacxx/include/cuda/std/__algorithm/none_of.h
@@ -28,14 +28,16 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _Predicate>
 [[nodiscard]] _CCCL_API constexpr bool none_of(_InputIterator __first, _InputIterator __last, _Predicate __pred)
 {
+  bool __result = true;
   for (; __first != __last; ++__first)
   {
     if (__pred(*__first))
     {
-      return false;
+      __result = false;
+      break;
     }
   }
-  return true;
+  return __result;
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__algorithm/partition.h
+++ b/libcudacxx/include/cuda/std/__algorithm/partition.h
@@ -32,7 +32,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Predicate, class _AlgPolicy, class _ForwardIterator, class _Sentinel>
-_CCCL_API constexpr pair<_ForwardIterator, _ForwardIterator>
+_CCCL_HOST_DEVICE_API constexpr pair<_ForwardIterator, _ForwardIterator>
 __partition_impl(_ForwardIterator __first, _Sentinel __last, _Predicate __pred, forward_iterator_tag)
 {
   while (true)
@@ -62,7 +62,7 @@ __partition_impl(_ForwardIterator __first, _Sentinel __last, _Predicate __pred, 
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Predicate, class _AlgPolicy, class _BidirectionalIterator, class _Sentinel>
-_CCCL_API constexpr pair<_BidirectionalIterator, _BidirectionalIterator>
+_CCCL_HOST_DEVICE_API constexpr pair<_BidirectionalIterator, _BidirectionalIterator>
 __partition_impl(_BidirectionalIterator __first, _Sentinel __sentinel, _Predicate __pred, bidirectional_iterator_tag)
 {
   _BidirectionalIterator __original_last = _IterOps<_AlgPolicy>::next(__first, __sentinel);
@@ -96,7 +96,7 @@ __partition_impl(_BidirectionalIterator __first, _Sentinel __sentinel, _Predicat
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _ForwardIterator, class _Sentinel, class _Predicate, class _IterCategory>
-_CCCL_API constexpr pair<_ForwardIterator, _ForwardIterator>
+_CCCL_HOST_DEVICE_API constexpr pair<_ForwardIterator, _ForwardIterator>
 __partition(_ForwardIterator __first, _Sentinel __last, _Predicate&& __pred, _IterCategory __iter_category)
 {
   return ::cuda::std::__partition_impl<remove_cvref_t<_Predicate>&, _AlgPolicy>(
@@ -105,7 +105,8 @@ __partition(_ForwardIterator __first, _Sentinel __last, _Predicate&& __pred, _It
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Predicate>
-_CCCL_API constexpr _ForwardIterator partition(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)
+_CCCL_HOST_DEVICE_API constexpr _ForwardIterator
+partition(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)
 {
   using _IterCategory = __iterator_traits_category_or_concept_t<_ForwardIterator>;
   auto __result       = ::cuda::std::__partition<_ClassicAlgPolicy>(

--- a/libcudacxx/include/cuda/std/__algorithm/prev_permutation.h
+++ b/libcudacxx/include/cuda/std/__algorithm/prev_permutation.h
@@ -46,6 +46,7 @@ __prev_permutation(_BidirectionalIterator __first, _Sentinel __last, _Compare&& 
     return _Result(::cuda::std::move(__last_iter), false);
   }
 
+  bool __result = true;
   while (true)
   {
     _BidirectionalIterator __ip1 = __i;
@@ -56,14 +57,17 @@ __prev_permutation(_BidirectionalIterator __first, _Sentinel __last, _Compare&& 
         ;
       _IterOps<_AlgPolicy>::iter_swap(__i, __j);
       ::cuda::std::__reverse<_AlgPolicy>(__ip1, __last_iter);
-      return _Result(::cuda::std::move(__last_iter), true);
+      __result = true;
+      break;
     }
     if (__i == __first)
     {
       ::cuda::std::__reverse<_AlgPolicy>(__first, __last_iter);
-      return _Result(::cuda::std::move(__last_iter), false);
+      __result = false;
+      break;
     }
   }
+  return _Result(::cuda::std::move(__last_iter), __result);
 }
 
 _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_find_if.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_find_if.h
@@ -62,7 +62,8 @@ struct __fn
   _CCCL_REQUIRES(input_range<_Rp> _CCCL_AND indirect_unary_predicate<_Pred, projected<iterator_t<_Rp>, _Proj>>)
   [[nodiscard]] _CCCL_API constexpr borrowed_iterator_t<_Rp> operator()(_Rp&& __r, _Pred __pred, _Proj __proj = {}) const
   {
-    return __find_if_impl(::cuda::std::ranges::begin(__r), ::cuda::std::ranges::end(__r), __pred, __proj);
+    return __find_if_impl(
+      ::cuda::std::ranges::__begin_cpo{}(__r), ::cuda::std::ranges::__end_cpo{}(__r), __pred, __proj);
   }
 };
 _CCCL_END_NAMESPACE_CPO

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_for_each.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_for_each.h
@@ -67,7 +67,8 @@ public:
   _CCCL_API constexpr for_each_result<borrowed_iterator_t<_Range>, _Func>
   operator()(_Range&& __range, _Func __func, _Proj __proj = {}) const
   {
-    return __for_each_impl(::cuda::std::ranges::begin(__range), ::cuda::std::ranges::end(__range), __func, __proj);
+    return __for_each_impl(
+      ::cuda::std::ranges::__begin_cpo{}(__range), ::cuda::std::ranges::__end_cpo{}(__range), __func, __proj);
   }
 };
 _CCCL_END_NAMESPACE_CPO

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_min.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_min.h
@@ -60,8 +60,8 @@ struct __fn
                    _CCCL_AND indirectly_copyable_storable<iterator_t<_Rp>, range_value_t<_Rp>*>)
   [[nodiscard]] _CCCL_API constexpr range_value_t<_Rp> operator()(_Rp&& __r, _Comp __comp = {}, _Proj __proj = {}) const
   {
-    auto __first = ::cuda::std::ranges::begin(__r);
-    auto __last  = ::cuda::std::ranges::end(__r);
+    auto __first = ::cuda::std::ranges::__begin_cpo{}(__r);
+    auto __last  = ::cuda::std::ranges::__end_cpo{}(__r);
 
     _CCCL_ASSERT(__first != __last, "range must contain at least one element");
 

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_min_element.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_min_element.h
@@ -51,7 +51,8 @@ struct __fn
   [[nodiscard]] _CCCL_API constexpr borrowed_iterator_t<_Rp>
   operator()(_Rp&& __r, _Comp __comp = {}, _Proj __proj = {}) const
   {
-    return ::cuda::std::__min_element(::cuda::std::ranges::begin(__r), ::cuda::std::ranges::end(__r), __comp, __proj);
+    return ::cuda::std::__min_element(
+      ::cuda::std::ranges::__begin_cpo{}(__r), ::cuda::std::ranges::__end_cpo{}(__r), __comp, __proj);
   }
 };
 _CCCL_END_NAMESPACE_CPO

--- a/libcudacxx/include/cuda/std/__algorithm/search.h
+++ b/libcudacxx/include/cuda/std/__algorithm/search.h
@@ -36,7 +36,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterator2>
-[[nodiscard]] _CCCL_API constexpr pair<_ForwardIterator1, _ForwardIterator1> __search(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr pair<_ForwardIterator1, _ForwardIterator1> __search(
   _ForwardIterator1 __first1,
   _ForwardIterator1 __last1,
   _ForwardIterator2 __first2,
@@ -88,7 +88,7 @@ template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterato
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _RandomAccessIterator1, class _RandomAccessIterator2>
-[[nodiscard]] _CCCL_API constexpr pair<_RandomAccessIterator1, _RandomAccessIterator1> __search(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr pair<_RandomAccessIterator1, _RandomAccessIterator1> __search(
   _RandomAccessIterator1 __first1,
   _RandomAccessIterator1 __last1,
   _RandomAccessIterator2 __first2,
@@ -146,7 +146,7 @@ template <class _BinaryPredicate, class _RandomAccessIterator1, class _RandomAcc
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator1
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator1
 search(_ForwardIterator1 __first1,
        _ForwardIterator1 __last1,
        _ForwardIterator2 __first2,
@@ -165,14 +165,14 @@ search(_ForwardIterator1 __first1,
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator1
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator1
 search(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2)
 {
   return ::cuda::std::search(__first1, __last1, __first2, __last2, __equal_to{});
 }
 
 template <class _ForwardIterator, class _Searcher>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator
 search(_ForwardIterator __f, _ForwardIterator __l, const _Searcher& __s)
 {
   return __s(__f, __l).first;

--- a/libcudacxx/include/cuda/std/__algorithm/search_n.h
+++ b/libcudacxx/include/cuda/std/__algorithm/search_n.h
@@ -31,7 +31,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _ForwardIterator, class _Size, class _Tp>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator __search_n(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator __search_n(
   _ForwardIterator __first,
   _ForwardIterator __last,
   _Size __count,
@@ -83,7 +83,7 @@ template <class _BinaryPredicate, class _ForwardIterator, class _Size, class _Tp
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _RandomAccessIterator, class _Size, class _Tp>
-[[nodiscard]] _CCCL_API constexpr _RandomAccessIterator __search_n(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _RandomAccessIterator __search_n(
   _RandomAccessIterator __first,
   _RandomAccessIterator __last,
   _Size __count,
@@ -137,7 +137,7 @@ template <class _BinaryPredicate, class _RandomAccessIterator, class _Size, clas
 }
 
 template <class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator
 search_n(_ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value_, _BinaryPredicate __pred)
 {
   return ::cuda::std::__search_n<add_lvalue_reference_t<_BinaryPredicate>>(
@@ -150,7 +150,7 @@ search_n(_ForwardIterator __first, _ForwardIterator __last, _Size __count, const
 }
 
 template <class _ForwardIterator, class _Size, class _Tp>
-[[nodiscard]] _CCCL_API constexpr _ForwardIterator
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _ForwardIterator
 search_n(_ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value_)
 {
   return ::cuda::std::search_n(__first, __last, __convert_to_integral(__count), __value_, __equal_to{});

--- a/libcudacxx/include/cuda/std/__algorithm/set_symmetric_difference.h
+++ b/libcudacxx/include/cuda/std/__algorithm/set_symmetric_difference.h
@@ -54,14 +54,13 @@ template <class _AlgPolicy, class _Compare, class _InIter1, class _Sent1, class 
 _CCCL_API constexpr __set_symmetric_difference_result<_InIter1, _InIter2, _OutIter> __set_symmetric_difference(
   _InIter1 __first1, _Sent1 __last1, _InIter2 __first2, _Sent2 __last2, _OutIter __result, _Compare&& __comp)
 {
+  bool __first_end_reached = true;
   while (__first1 != __last1)
   {
     if (__first2 == __last2)
     {
-      auto __ret1 = ::cuda::std::__copy<_AlgPolicy>(
-        ::cuda::std::move(__first1), ::cuda::std::move(__last1), ::cuda::std::move(__result));
-      return __set_symmetric_difference_result<_InIter1, _InIter2, _OutIter>(
-        ::cuda::std::move(__ret1.first), ::cuda::std::move(__first2), ::cuda::std::move((__ret1.second)));
+      __first_end_reached = false;
+      break;
     }
     if (__comp(*__first1, *__first2))
     {
@@ -83,10 +82,21 @@ _CCCL_API constexpr __set_symmetric_difference_result<_InIter1, _InIter2, _OutIt
       ++__first2;
     }
   }
-  auto __ret2 = ::cuda::std::__copy<_AlgPolicy>(
-    ::cuda::std::move(__first2), ::cuda::std::move(__last2), ::cuda::std::move(__result));
-  return __set_symmetric_difference_result<_InIter1, _InIter2, _OutIter>(
-    ::cuda::std::move(__first1), ::cuda::std::move(__ret2.first), ::cuda::std::move((__ret2.second)));
+
+  if (__first_end_reached)
+  {
+    auto __ret2 = ::cuda::std::__copy<_AlgPolicy>(
+      ::cuda::std::move(__first2), ::cuda::std::move(__last2), ::cuda::std::move(__result));
+    return __set_symmetric_difference_result<_InIter1, _InIter2, _OutIter>(
+      ::cuda::std::move(__first1), ::cuda::std::move(__ret2.first), ::cuda::std::move((__ret2.second)));
+  }
+  else
+  {
+    auto __ret1 = ::cuda::std::__copy<_AlgPolicy>(
+      ::cuda::std::move(__first1), ::cuda::std::move(__last1), ::cuda::std::move(__result));
+    return __set_symmetric_difference_result<_InIter1, _InIter2, _OutIter>(
+      ::cuda::std::move(__ret1.first), ::cuda::std::move(__first2), ::cuda::std::move((__ret1.second)));
+  }
 }
 
 _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/std/__algorithm/set_union.h
+++ b/libcudacxx/include/cuda/std/__algorithm/set_union.h
@@ -53,14 +53,13 @@ template <class _AlgPolicy, class _Compare, class _InIter1, class _Sent1, class 
 _CCCL_API constexpr __set_union_result<_InIter1, _InIter2, _OutIter>
 __set_union(_InIter1 __first1, _Sent1 __last1, _InIter2 __first2, _Sent2 __last2, _OutIter __result, _Compare&& __comp)
 {
+  bool __first_end_reached = true;
   for (; __first1 != __last1; ++__result)
   {
     if (__first2 == __last2)
     {
-      auto __ret1 = ::cuda::std::__copy<_AlgPolicy>(
-        ::cuda::std::move(__first1), ::cuda::std::move(__last1), ::cuda::std::move(__result));
-      return __set_union_result<_InIter1, _InIter2, _OutIter>(
-        ::cuda::std::move(__ret1.first), ::cuda::std::move(__first2), ::cuda::std::move((__ret1.second)));
+      __first_end_reached = false;
+      break;
     }
     if (__comp(*__first2, *__first1))
     {
@@ -77,10 +76,21 @@ __set_union(_InIter1 __first1, _Sent1 __last1, _InIter2 __first2, _Sent2 __last2
       ++__first1;
     }
   }
-  auto __ret2 = ::cuda::std::__copy<_AlgPolicy>(
-    ::cuda::std::move(__first2), ::cuda::std::move(__last2), ::cuda::std::move(__result));
-  return __set_union_result<_InIter1, _InIter2, _OutIter>(
-    ::cuda::std::move(__first1), ::cuda::std::move(__ret2.first), ::cuda::std::move((__ret2.second)));
+
+  if (__first_end_reached)
+  {
+    auto __ret2 = ::cuda::std::__copy<_AlgPolicy>(
+      ::cuda::std::move(__first2), ::cuda::std::move(__last2), ::cuda::std::move(__result));
+    return __set_union_result<_InIter1, _InIter2, _OutIter>(
+      ::cuda::std::move(__first1), ::cuda::std::move(__ret2.first), ::cuda::std::move((__ret2.second)));
+  }
+  else
+  {
+    auto __ret1 = ::cuda::std::__copy<_AlgPolicy>(
+      ::cuda::std::move(__first1), ::cuda::std::move(__last1), ::cuda::std::move(__result));
+    return __set_union_result<_InIter1, _InIter2, _OutIter>(
+      ::cuda::std::move(__ret1.first), ::cuda::std::move(__first2), ::cuda::std::move((__ret1.second)));
+  }
 }
 
 _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/std/__algorithm/sift_down.h
+++ b/libcudacxx/include/cuda/std/__algorithm/sift_down.h
@@ -127,9 +127,10 @@ _CCCL_API constexpr _RandomAccessIterator __floyd_sift_down(
     // if __hole is now a leaf, we're done
     if (__child > (__len - 2) / 2)
     {
-      return __hole;
+      break;
     }
   }
+  return __hole;
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__algorithm/unwrap_range.h
+++ b/libcudacxx/include/cuda/std/__algorithm/unwrap_range.h
@@ -45,7 +45,7 @@ struct __unwrap_range_impl
   _CCCL_API static constexpr auto __unwrap(_Iter __first, _Sent __sent)
     requires random_access_iterator<_Iter> && sized_sentinel_for<_Sent, _Iter>
   {
-    auto __last = ranges::next(__first, __sent);
+    auto __last = ::cuda::std::ranges::__next_cpo{}(__first, __sent);
     return pair{::cuda::std::__unwrap_iter(::cuda::std::move(__first)),
                 ::cuda::std::__unwrap_iter(::cuda::std::move(__last))};
   }

--- a/libcudacxx/include/cuda/std/__bit/bit_cast.h
+++ b/libcudacxx/include/cuda/std/__bit/bit_cast.h
@@ -51,10 +51,10 @@ _CCCL_DIAG_SUPPRESS_GCC("-Wclass-memaccess")
 template <class _To, class _From>
 [[nodiscard]] _CCCL_API inline _To __bit_cast_memcpy(const _From& __from) noexcept
 {
-#if !_CCCL_COMPILER(GCC, <=, 7)
+#if !_CCCL_COMPILER(GCC, <=, 8)
   static_assert(::cuda::std::default_initializable<_To>,
-                "bit_cast memcpy fallback requires the destination type to be default initializable");
-#endif // !_CCCL_COMPILER(GCC, <=, 7)
+                "bit_cast memcpy fallback requires the destination type to be default constructible");
+#endif // !_CCCL_COMPILER(GCC, <=, 8)
   _To __temp;
   ::cuda::std::memcpy(&__temp, &__from, sizeof(_To));
   return __temp;

--- a/libcudacxx/include/cuda/std/__bit/byteswap.h
+++ b/libcudacxx/include/cuda/std/__bit/byteswap.h
@@ -136,7 +136,9 @@ template <class _Tp>
 #  if _CCCL_COMPILER(MSVC)
     NV_IF_TARGET(NV_IS_HOST, return ::_byteswap_ushort(__val);)
 #  endif // _CCCL_COMPILER(MSVC)
+#  if !_CCCL_TILE_COMPILATION()
     NV_IF_TARGET(NV_IS_DEVICE, return ::cuda::std::__byteswap_impl_device(__val);)
+#  endif // !_CCCL_TILE_COMPILATION()
   }
   return ::cuda::std::__byteswap_impl_recursive(__val);
 #endif // !_CCCL_BUILTIN_BSWAP16
@@ -152,7 +154,9 @@ template <class _Tp>
 #  if _CCCL_COMPILER(MSVC)
     NV_IF_TARGET(NV_IS_HOST, return ::_byteswap_ulong(__val);)
 #  endif // _CCCL_COMPILER(MSVC)
+#  if !_CCCL_TILE_COMPILATION()
     NV_IF_TARGET(NV_IS_DEVICE, return ::cuda::std::__byteswap_impl_device(__val);)
+#  endif // !_CCCL_TILE_COMPILATION()
   }
   return ::cuda::std::__byteswap_impl_recursive(__val);
 #endif // !_CCCL_BUILTIN_BSWAP32
@@ -168,7 +172,9 @@ template <class _Tp>
 #  if _CCCL_COMPILER(MSVC)
     NV_IF_TARGET(NV_IS_HOST, return ::_byteswap_uint64(__val);)
 #  endif // _CCCL_COMPILER(MSVC)
+#  if !_CCCL_TILE_COMPILATION()
     NV_IF_TARGET(NV_IS_DEVICE, return ::cuda::std::__byteswap_impl_device(__val);)
+#  endif // !_CCCL_TILE_COMPILATION()
   }
   return ::cuda::std::__byteswap_impl_recursive(__val);
 #endif // !_CCCL_BUILTIN_BSWAP64

--- a/libcudacxx/include/cuda/std/__bit/reference.h
+++ b/libcudacxx/include/cuda/std/__bit/reference.h
@@ -933,19 +933,27 @@ _CCCL_API constexpr bool __equal_unaligned(
     // do middle words
     unsigned __clz_r   = __bits_per_word - __first2.__ctz_;
     __storage_type __m = ~__storage_type(0) << __first2.__ctz_;
+    bool __result      = true;
     for (; __n >= __bits_per_word; __n -= __bits_per_word, ++__first1.__seg_)
     {
       __storage_type __b = *__first1.__seg_;
       if ((*__first2.__seg_ & __m) != (__b << __first2.__ctz_))
       {
-        return false;
+        __result = false;
+        break;
       }
       ++__first2.__seg_;
       if ((*__first2.__seg_ & ~__m) != (__b >> __clz_r))
       {
-        return false;
+        __result = false;
+        break;
       }
     }
+    if (!__result)
+    {
+      return false;
+    }
+
     // do last word
     if (__n > 0)
     {
@@ -1004,13 +1012,20 @@ _CCCL_API constexpr bool __equal_aligned(
     // __first1.__ctz_ == 0;
     // __first2.__ctz_ == 0;
     // do middle words
+    bool __result = true;
     for (; __n >= __bits_per_word; __n -= __bits_per_word, ++__first1.__seg_, ++__first2.__seg_)
     {
       if (*__first2.__seg_ != *__first1.__seg_)
       {
-        return false;
+        __result = false;
+        break;
       }
     }
+    if (!__result)
+    {
+      return false;
+    }
+
     // do last word
     if (__n > 0)
     {

--- a/libcudacxx/include/cuda/std/__charconv/to_chars.h
+++ b/libcudacxx/include/cuda/std/__charconv/to_chars.h
@@ -62,26 +62,29 @@ template <class _Tp>
   {
     if (__uv < __ubase)
     {
-      return __r + 1;
+      __r += 1;
+      break;
     }
     else if (__uv < __ubase_2)
     {
-      return __r + 2;
+      __r += 2;
+      break;
     }
     else if (__uv < __ubase_3)
     {
-      return __r + 3;
+      __r += 3;
+      break;
     }
     else if (__uv < __ubase_4)
     {
-      return __r + 4;
+      __r += 4;
+      break;
     }
 
     __uv /= __ubase_4;
     __r += 4;
   }
-
-  _CCCL_UNREACHABLE();
+  return __r;
 }
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__cmath/logarithms.h
+++ b/libcudacxx/include/cuda/std/__cmath/logarithms.h
@@ -110,13 +110,9 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
                       __half_raw __ret_repr = ::__float2half_rn(__vf);
 
                       ::cuda::std::uint16_t __repr = ::cuda::std::__fp_get_storage(__x);
-                      switch (__repr)
+                      if (__repr == 7544)
                       {
-                        case 7544:
-                          __ret_repr.x -= 1;
-                          break;
-
-                        default:;
+                        __ret_repr.x -= 1;
                       }
 
                       return __ret_repr;
@@ -235,14 +231,18 @@ template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 template <class _Tp>
 [[nodiscard]] _CCCL_API inline constexpr int __ilogb_impl(_Tp __x) noexcept
 {
-  switch (::cuda::std::fpclassify(__x))
+  const auto __fp = ::cuda::std::fpclassify(__x);
+  if (__fp == FP_ZERO)
   {
-    case FP_ZERO:
-      return FP_ILOGB0;
-    case FP_NAN:
-      return FP_ILOGBNAN;
-    case FP_INFINITE:
-      return numeric_limits<int>::max();
+    return FP_ILOGB0;
+  }
+  else if (__fp == FP_NAN)
+  {
+    return FP_ILOGBNAN;
+  }
+  else if (__fp == FP_INFINITE)
+  {
+    return numeric_limits<int>::max();
   }
 
   constexpr auto __fmt = __fp_format_of_v<_Tp>;
@@ -465,17 +465,20 @@ template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 template <class _Tp>
 [[nodiscard]] _CCCL_API inline constexpr _Tp __logb_impl(_Tp __x) noexcept
 {
-  switch (::cuda::std::fpclassify(__x))
+  const auto __fp = ::cuda::std::fpclassify(__x);
+  if (__fp == FP_ZERO)
   {
-    case FP_ZERO:
-      return ::cuda::std::__fp_neg<_Tp>(::cuda::std::__fp_inf<_Tp>());
-    case FP_NAN:
-      return ::cuda::std::__fp_nan<_Tp>();
-    case FP_INFINITE:
-      return ::cuda::std::__fp_inf<_Tp>();
-    default:
-      break;
+    return ::cuda::std::__fp_neg<_Tp>(::cuda::std::__fp_inf<_Tp>());
   }
+  else if (__fp == FP_NAN)
+  {
+    return ::cuda::std::__fp_nan<_Tp>();
+  }
+  else if (__fp == FP_INFINITE)
+  {
+    return ::cuda::std::__fp_inf<_Tp>();
+  }
+
 #if _CCCL_HAS_CONSTEXPR_BIT_CAST()
   return static_cast<_Tp>(::cuda::std::__fp_get_exp(__x));
 #else // ^^^ _CCCL_HAS_CONSTEXPR_BIT_CAST() ^^^ / vvv !_CCCL_HAS_CONSTEXPR_BIT_CAST() vvv

--- a/libcudacxx/include/cuda/std/__concepts/swappable.h
+++ b/libcudacxx/include/cuda/std/__concepts/swappable.h
@@ -158,6 +158,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto swap = __swap::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __swap_cpo = __swap::__fn;
 } // namespace __cpo
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 
@@ -165,18 +168,18 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if _CCCL_HAS_CONCEPTS()
 template <class _Tp>
-concept swappable = requires(_Tp& __a, _Tp& __b) { ::cuda::std::ranges::swap(__a, __b); };
+concept swappable = requires(_Tp& __a, _Tp& __b) { ::cuda::std::ranges::__swap_cpo{}(__a, __b); };
 
 template <class _Tp, class _Up>
 concept swappable_with = common_reference_with<_Tp, _Up> && requires(_Tp&& __t, _Up&& __u) {
-  ::cuda::std::ranges::swap(::cuda::std::forward<_Tp>(__t), ::cuda::std::forward<_Tp>(__t));
-  ::cuda::std::ranges::swap(::cuda::std::forward<_Up>(__u), ::cuda::std::forward<_Up>(__u));
-  ::cuda::std::ranges::swap(::cuda::std::forward<_Tp>(__t), ::cuda::std::forward<_Up>(__u));
-  ::cuda::std::ranges::swap(::cuda::std::forward<_Up>(__u), ::cuda::std::forward<_Tp>(__t));
+  ::cuda::std::ranges::__swap_cpo{}(::cuda::std::forward<_Tp>(__t), ::cuda::std::forward<_Tp>(__t));
+  ::cuda::std::ranges::__swap_cpo{}(::cuda::std::forward<_Up>(__u), ::cuda::std::forward<_Up>(__u));
+  ::cuda::std::ranges::__swap_cpo{}(::cuda::std::forward<_Tp>(__t), ::cuda::std::forward<_Up>(__u));
+  ::cuda::std::ranges::__swap_cpo{}(::cuda::std::forward<_Up>(__u), ::cuda::std::forward<_Tp>(__t));
 };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Tp>
-_CCCL_CONCEPT_FRAGMENT(__swappable_, requires(_Tp& __a, _Tp& __b)((::cuda::std::ranges::swap(__a, __b))));
+_CCCL_CONCEPT_FRAGMENT(__swappable_, requires(_Tp& __a, _Tp& __b)((::cuda::std::ranges::__swap_cpo{}(__a, __b))));
 
 template <class _Tp>
 _CCCL_CONCEPT swappable = _CCCL_FRAGMENT(__swappable_, _Tp);
@@ -186,10 +189,10 @@ _CCCL_CONCEPT_FRAGMENT(
   __swappable_with_,
   requires(_Tp&& __t, _Up&& __u)(
     requires(common_reference_with<_Tp, _Up>),
-    (::cuda::std::ranges::swap(::cuda::std::forward<_Tp>(__t), ::cuda::std::forward<_Tp>(__t))),
-    (::cuda::std::ranges::swap(::cuda::std::forward<_Up>(__u), ::cuda::std::forward<_Up>(__u))),
-    (::cuda::std::ranges::swap(::cuda::std::forward<_Tp>(__t), ::cuda::std::forward<_Up>(__u))),
-    (::cuda::std::ranges::swap(::cuda::std::forward<_Up>(__u), ::cuda::std::forward<_Tp>(__t)))));
+    (::cuda::std::ranges::__swap_cpo{}(::cuda::std::forward<_Tp>(__t), ::cuda::std::forward<_Tp>(__t))),
+    (::cuda::std::ranges::__swap_cpo{}(::cuda::std::forward<_Up>(__u), ::cuda::std::forward<_Up>(__u))),
+    (::cuda::std::ranges::__swap_cpo{}(::cuda::std::forward<_Tp>(__t), ::cuda::std::forward<_Up>(__u))),
+    (::cuda::std::ranges::__swap_cpo{}(::cuda::std::forward<_Up>(__u), ::cuda::std::forward<_Tp>(__t)))));
 
 template <class _Tp, class _Up>
 _CCCL_CONCEPT swappable_with = _CCCL_FRAGMENT(__swappable_with_, _Tp, _Up);

--- a/libcudacxx/include/cuda/std/__execution/env.h
+++ b/libcudacxx/include/cuda/std/__execution/env.h
@@ -121,14 +121,16 @@ inline constexpr size_t __npos = static_cast<size_t>(-1);
 
 [[nodiscard]] _CCCL_API constexpr auto __find_pos(bool const* const __begin, bool const* const __end) noexcept -> size_t
 {
+  size_t __result = __npos;
   for (bool const* __where = __begin; __where != __end; ++__where)
   {
     if (*__where)
     {
-      return static_cast<size_t>(__where - __begin);
+      __result = static_cast<size_t>(__where - __begin);
+      break;
     }
   }
-  return __npos;
+  return __result;
 }
 } // namespace __detail
 

--- a/libcudacxx/include/cuda/std/__expected/expected.h
+++ b/libcudacxx/include/cuda/std/__expected/expected.h
@@ -214,7 +214,7 @@ public:
                    _CCCL_AND(!__is_cuda_std_unexpected<remove_cvref_t<_Up>>)
                      _CCCL_AND is_constructible_v<_Tp, _Up> _CCCL_AND is_convertible_v<_Up, _Tp>)
   _CCCL_API constexpr expected(_Up&& __u) noexcept(is_nothrow_constructible_v<_Tp, _Up>) // strengthened
-      : __base(in_place, ::cuda::std::forward<_Up>(__u))
+      : __base(in_place_t{}, ::cuda::std::forward<_Up>(__u))
   {}
 
   _CCCL_TEMPLATE(class _Up = _Tp)
@@ -222,7 +222,7 @@ public:
                    _CCCL_AND(!__is_cuda_std_unexpected<remove_cvref_t<_Up>>)
                      _CCCL_AND is_constructible_v<_Tp, _Up> _CCCL_AND(!is_convertible_v<_Up, _Tp>))
   _CCCL_API constexpr explicit expected(_Up&& __u) noexcept(is_nothrow_constructible_v<_Tp, _Up>) // strengthened
-      : __base(in_place, ::cuda::std::forward<_Up>(__u))
+      : __base(in_place_t{}, ::cuda::std::forward<_Up>(__u))
   {}
 
   _CCCL_TEMPLATE(class _OtherErr)
@@ -257,14 +257,14 @@ public:
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr explicit expected(in_place_t, _Args&&... __args) noexcept(
     is_nothrow_constructible_v<_Tp, _Args...>) // strengthened
-      : __base(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __base(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   _CCCL_TEMPLATE(class _Up, class... _Args)
   _CCCL_REQUIRES(is_constructible_v<_Tp, initializer_list<_Up>&, _Args...>)
   _CCCL_API constexpr explicit expected(in_place_t, initializer_list<_Up> __il, _Args&&... __args) noexcept(
     is_nothrow_constructible_v<_Tp, initializer_list<_Up>&, _Args...>) // strengthened
-      : __base(in_place, __il, ::cuda::std::forward<_Args>(__args)...)
+      : __base(in_place_t{}, __il, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   _CCCL_TEMPLATE(class... _Args)
@@ -289,7 +289,7 @@ private:
     _Fun&& __fun,
     _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, invoke_result_t<_Fun, _Args...>>)
       : __base(__expected_construct_from_invoke_tag{},
-               in_place,
+               in_place_t{},
                ::cuda::std::forward<_Fun>(__fun),
                ::cuda::std::forward<_Args>(__args)...)
   {}
@@ -672,7 +672,7 @@ public:
 
     if (this->__has_val_)
     {
-      return _Res{in_place, this->__union_.__val_};
+      return _Res{in_place_t{}, this->__union_.__val_};
     }
     else
     {
@@ -693,7 +693,7 @@ public:
 
     if (this->__has_val_)
     {
-      return _Res{in_place, this->__union_.__val_};
+      return _Res{in_place_t{}, this->__union_.__val_};
     }
     else
     {
@@ -714,7 +714,7 @@ public:
 
     if (this->__has_val_)
     {
-      return _Res{in_place, ::cuda::std::move(this->__union_.__val_)};
+      return _Res{in_place_t{}, ::cuda::std::move(this->__union_.__val_)};
     }
     else
     {
@@ -735,7 +735,7 @@ public:
 
     if (this->__has_val_)
     {
-      return _Res{in_place, ::cuda::std::move(this->__union_.__val_)};
+      return _Res{in_place_t{}, ::cuda::std::move(this->__union_.__val_)};
     }
     else
     {
@@ -779,7 +779,7 @@ public:
     if (this->__has_val_)
     {
       return expected<_Res, _Err>{
-        __expected_construct_from_invoke_tag{}, in_place, ::cuda::std::forward<_Fun>(__fun), this->__union_.__val_};
+        __expected_construct_from_invoke_tag{}, in_place_t{}, ::cuda::std::forward<_Fun>(__fun), this->__union_.__val_};
     }
     else
     {
@@ -824,7 +824,7 @@ public:
     if (this->__has_val_)
     {
       return expected<_Res, _Err>{
-        __expected_construct_from_invoke_tag{}, in_place, ::cuda::std::forward<_Fun>(__fun), this->__union_.__val_};
+        __expected_construct_from_invoke_tag{}, in_place_t{}, ::cuda::std::forward<_Fun>(__fun), this->__union_.__val_};
     }
     else
     {
@@ -867,7 +867,7 @@ public:
     {
       return expected<_Res, _Err>{
         __expected_construct_from_invoke_tag{},
-        in_place,
+        in_place_t{},
         ::cuda::std::forward<_Fun>(__fun),
         ::cuda::std::move(this->__union_.__val_)};
     }
@@ -915,7 +915,7 @@ public:
     {
       return expected<_Res, _Err>{
         __expected_construct_from_invoke_tag{},
-        in_place,
+        in_place_t{},
         ::cuda::std::forward<_Fun>(__fun),
         ::cuda::std::move(this->__union_.__val_)};
     }
@@ -941,7 +941,7 @@ public:
 
     if (this->__has_val_)
     {
-      return expected<_Tp, _Res>{in_place, this->__union_.__val_};
+      return expected<_Tp, _Res>{in_place_t{}, this->__union_.__val_};
     }
     else
     {
@@ -967,7 +967,7 @@ public:
 
     if (this->__has_val_)
     {
-      return expected<_Tp, _Res>{in_place, this->__union_.__val_};
+      return expected<_Tp, _Res>{in_place_t{}, this->__union_.__val_};
     }
     else
     {
@@ -992,7 +992,7 @@ public:
 
     if (this->__has_val_)
     {
-      return expected<_Tp, _Res>{in_place, ::cuda::std::move(this->__union_.__val_)};
+      return expected<_Tp, _Res>{in_place_t{}, ::cuda::std::move(this->__union_.__val_)};
     }
     else
     {
@@ -1021,7 +1021,7 @@ public:
 
     if (this->__has_val_)
     {
-      return expected<_Tp, _Res>{in_place, ::cuda::std::move(this->__union_.__val_)};
+      return expected<_Tp, _Res>{in_place_t{}, ::cuda::std::move(this->__union_.__val_)};
     }
     else
     {
@@ -1632,7 +1632,8 @@ public:
 
     if (this->__has_val_)
     {
-      return expected<_Res, _Err>{__expected_construct_from_invoke_tag{}, in_place, ::cuda::std::forward<_Fun>(__fun)};
+      return expected<_Res, _Err>{
+        __expected_construct_from_invoke_tag{}, in_place_t{}, ::cuda::std::forward<_Fun>(__fun)};
     }
     else
     {
@@ -1672,7 +1673,8 @@ public:
 
     if (this->__has_val_)
     {
-      return expected<_Res, _Err>{__expected_construct_from_invoke_tag{}, in_place, ::cuda::std::forward<_Fun>(__fun)};
+      return expected<_Res, _Err>{
+        __expected_construct_from_invoke_tag{}, in_place_t{}, ::cuda::std::forward<_Fun>(__fun)};
     }
     else
     {
@@ -1711,7 +1713,8 @@ public:
 
     if (this->__has_val_)
     {
-      return expected<_Res, _Err>{__expected_construct_from_invoke_tag{}, in_place, ::cuda::std::forward<_Fun>(__fun)};
+      return expected<_Res, _Err>{
+        __expected_construct_from_invoke_tag{}, in_place_t{}, ::cuda::std::forward<_Fun>(__fun)};
     }
     else
     {
@@ -1751,7 +1754,8 @@ public:
 
     if (this->__has_val_)
     {
-      return expected<_Res, _Err>{__expected_construct_from_invoke_tag{}, in_place, ::cuda::std::forward<_Fun>(__fun)};
+      return expected<_Res, _Err>{
+        __expected_construct_from_invoke_tag{}, in_place_t{}, ::cuda::std::forward<_Fun>(__fun)};
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__expected/expected_base.h
+++ b/libcudacxx/include/cuda/std/__expected/expected_base.h
@@ -200,7 +200,7 @@ struct __expected_destruct<_Tp, _Err, false, false>
   template <class... _Args>
   _CCCL_API constexpr __expected_destruct(in_place_t,
                                           _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
-      : __union_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __union_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   template <class... _Args>
@@ -217,7 +217,7 @@ struct __expected_destruct<_Tp, _Err, false, false>
     _Fun&& __fun,
     _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, invoke_result_t<_Fun, _Args...>>)
       : __union_(__expected_construct_from_invoke_tag{},
-                 in_place,
+                 in_place_t{},
                  ::cuda::std::forward<_Fun>(__fun),
                  ::cuda::std::forward<_Args>(__args)...)
   {}
@@ -264,7 +264,7 @@ struct __expected_destruct<_Tp, _Err, true, false>
   template <class... _Args>
   _CCCL_API constexpr __expected_destruct(in_place_t,
                                           _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
-      : __union_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __union_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   template <class... _Args>
@@ -281,7 +281,7 @@ struct __expected_destruct<_Tp, _Err, true, false>
     _Fun&& __fun,
     _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, invoke_result_t<_Fun, _Args...>>)
       : __union_(__expected_construct_from_invoke_tag{},
-                 in_place,
+                 in_place_t{},
                  ::cuda::std::forward<_Fun>(__fun),
                  ::cuda::std::forward<_Args>(__args)...)
   {}
@@ -324,7 +324,7 @@ struct __expected_destruct<_Tp, _Err, false, true>
   template <class... _Args>
   _CCCL_API constexpr __expected_destruct(in_place_t,
                                           _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
-      : __union_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __union_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   template <class... _Args>
@@ -341,7 +341,7 @@ struct __expected_destruct<_Tp, _Err, false, true>
     _Fun&& __fun,
     _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, invoke_result_t<_Fun, _Args...>>)
       : __union_(__expected_construct_from_invoke_tag{},
-                 in_place,
+                 in_place_t{},
                  ::cuda::std::forward<_Fun>(__fun),
                  ::cuda::std::forward<_Args>(__args)...)
   {}
@@ -385,7 +385,7 @@ struct __expected_destruct<_Tp, _Err, true, true>
   template <class... _Args>
   _CCCL_API constexpr __expected_destruct(in_place_t,
                                           _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
-      : __union_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __union_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   template <class... _Args>
@@ -402,7 +402,7 @@ struct __expected_destruct<_Tp, _Err, true, true>
     _Fun&& __fun,
     _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, invoke_result_t<_Fun, _Args...>>)
       : __union_(__expected_construct_from_invoke_tag{},
-                 in_place,
+                 in_place_t{},
                  ::cuda::std::forward<_Fun>(__fun),
                  ::cuda::std::forward<_Args>(__args)...)
   {}

--- a/libcudacxx/include/cuda/std/__expected/expected_base.h
+++ b/libcudacxx/include/cuda/std/__expected/expected_base.h
@@ -63,7 +63,7 @@ struct __expected_construct_from_invoke_tag
 template <class _Tp, class _Err, bool = is_trivially_destructible_v<_Tp> && is_trivially_destructible_v<_Err>>
 union __expected_union_t
 {
-  struct __empty_t
+  struct __empty_cpo
   {};
 
   _CCCL_EXEC_CHECK_DISABLE
@@ -118,7 +118,7 @@ union __expected_union_t
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 ~__expected_union_t() {}
 
-  _CCCL_NO_UNIQUE_ADDRESS __empty_t __empty_;
+  _CCCL_NO_UNIQUE_ADDRESS __empty_cpo __empty_;
   _CCCL_NO_UNIQUE_ADDRESS _Tp __val_;
   _CCCL_NO_UNIQUE_ADDRESS _Err __unex_;
 };
@@ -126,7 +126,7 @@ union __expected_union_t
 template <class _Tp, class _Err>
 union __expected_union_t<_Tp, _Err, true>
 {
-  struct __empty_t
+  struct __empty_cpo
   {};
 
   _CCCL_EXEC_CHECK_DISABLE
@@ -177,7 +177,7 @@ union __expected_union_t<_Tp, _Err, true>
       : __unex_(::cuda::std::invoke(::cuda::std::forward<_Fun>(__fun), ::cuda::std::forward<_Args>(__args)...))
   {}
 
-  _CCCL_NO_UNIQUE_ADDRESS __empty_t __empty_;
+  _CCCL_NO_UNIQUE_ADDRESS __empty_cpo __empty_;
   _CCCL_NO_UNIQUE_ADDRESS _Tp __val_;
   _CCCL_NO_UNIQUE_ADDRESS _Err __unex_;
 };
@@ -751,7 +751,7 @@ struct __expected_destruct<void, _Err, false, false>
 {
   _CCCL_NO_UNIQUE_ADDRESS union __expected_union_t
   {
-    struct __empty_t
+    struct __empty_cpo
     {};
 
     _CCCL_API constexpr __expected_union_t() noexcept
@@ -779,7 +779,7 @@ struct __expected_destruct<void, _Err, false, false>
     _CCCL_EXEC_CHECK_DISABLE
     _CCCL_API inline _CCCL_CONSTEXPR_CXX20 ~__expected_union_t() {}
 
-    _CCCL_NO_UNIQUE_ADDRESS __empty_t __empty_;
+    _CCCL_NO_UNIQUE_ADDRESS __empty_cpo __empty_;
     _CCCL_NO_UNIQUE_ADDRESS _Err __unex_;
   } __union_{};
   bool __has_val_{true};
@@ -828,7 +828,7 @@ struct __expected_destruct<void, _Err, false, true>
   // Using `_CCCL_NO_UNIQUE_ADDRESS` here crashes nvcc
   /* _CCCL_NO_UNIQUE_ADDRESS */ union __expected_union_t
   {
-    struct __empty_t
+    struct __empty_cpo
     {};
 
     _CCCL_API constexpr __expected_union_t() noexcept
@@ -852,7 +852,7 @@ struct __expected_destruct<void, _Err, false, true>
         : __unex_(::cuda::std::invoke(::cuda::std::forward<_Fun>(__fun), ::cuda::std::forward<_Args>(__args)...))
     {}
 
-    _CCCL_NO_UNIQUE_ADDRESS __empty_t __empty_;
+    _CCCL_NO_UNIQUE_ADDRESS __empty_cpo __empty_;
     _CCCL_NO_UNIQUE_ADDRESS _Err __unex_;
   } __union_{};
   bool __has_val_{true};

--- a/libcudacxx/include/cuda/std/__iterator/access.h
+++ b/libcudacxx/include/cuda/std/__iterator/access.h
@@ -54,6 +54,9 @@ struct __fn
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto begin = __begin::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __begin_cpo = __begin::__fn;
 } // namespace __cpo
 
 namespace __end
@@ -83,6 +86,9 @@ struct __fn
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto end = __end::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __end_cpo = __end::__fn;
 } // namespace __cpo
 
 namespace __cbegin
@@ -90,10 +96,10 @@ namespace __cbegin
 struct __fn
 {
   template <class _Cp>
-  _CCCL_API constexpr auto operator()(const _Cp& __c) const noexcept(noexcept(::cuda::std::begin(__c)))
-    -> decltype(::cuda::std::begin(__c))
+  _CCCL_API constexpr auto operator()(const _Cp& __c) const noexcept(noexcept(::cuda::std::__begin_cpo{}(__c)))
+    -> decltype(::cuda::std::__begin_cpo{}(__c))
   {
-    return ::cuda::std::begin(__c);
+    return ::cuda::std::__begin_cpo{}(__c);
   }
 };
 } // namespace __cbegin
@@ -101,6 +107,9 @@ struct __fn
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto cbegin = __cbegin::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __cbegin_cpo = __cbegin::__fn;
 } // namespace __cpo
 
 namespace __cend
@@ -108,10 +117,10 @@ namespace __cend
 struct __fn
 {
   template <class _Cp>
-  _CCCL_API constexpr auto operator()(const _Cp& __c) const noexcept(noexcept(::cuda::std::end(__c)))
-    -> decltype(::cuda::std::end(__c))
+  _CCCL_API constexpr auto operator()(const _Cp& __c) const noexcept(noexcept(::cuda::std::__end_cpo{}(__c)))
+    -> decltype(::cuda::std::__end_cpo{}(__c))
   {
-    return ::cuda::std::end(__c);
+    return ::cuda::std::__end_cpo{}(__c);
   }
 };
 } // namespace __cend
@@ -119,6 +128,9 @@ struct __fn
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto cend = __cend::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __cend_cpo = __cend::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__iterator/advance.h
+++ b/libcudacxx/include/cuda/std/__iterator/advance.h
@@ -218,6 +218,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto advance = __advance::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __advance_cpo = __advance::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__iterator/common_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/common_iterator.h
@@ -387,23 +387,24 @@ public:
 
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(input_iterator<_Iter2>)
-  _CCCL_API friend constexpr iter_rvalue_reference_t<_Iter2>
-  iter_move(const common_iterator& __i) noexcept(noexcept(::cuda::std::ranges::iter_move(declval<const _Iter&>())))
+  _CCCL_API friend constexpr iter_rvalue_reference_t<_Iter2> iter_move(const common_iterator& __i) noexcept(
+    noexcept(::cuda::std::ranges::__iter_move_cpo{}(declval<const _Iter&>())))
   {
     _CCCL_ASSERT(__i.__hold_.__holds_first(), "Attempted to iter_move a non-dereferenceable common_iterator");
-    return ::cuda::std::ranges::iter_move(__i.__hold_.__first_);
+    return ::cuda::std::ranges::__iter_move_cpo{}(__i.__hold_.__first_);
   }
 
   _CCCL_TEMPLATE(class _I2, class _S2)
   _CCCL_REQUIRES(indirectly_swappable<_I2, _Iter>)
-  _CCCL_API friend constexpr void iter_swap(const common_iterator& __x, const common_iterator<_I2, _S2>& __y) noexcept(
-    noexcept(::cuda::std::ranges::iter_swap(::cuda::std::declval<const _Iter&>(), ::cuda::std::declval<const _I2&>())))
+  _CCCL_API friend constexpr void
+  iter_swap(const common_iterator& __x, const common_iterator<_I2, _S2>& __y) noexcept(noexcept(
+    ::cuda::std::ranges::__iter_swap_cpo{}(::cuda::std::declval<const _Iter&>(), ::cuda::std::declval<const _I2&>())))
   {
     const auto& __y_hold = __y.__get_hold();
 
     _CCCL_ASSERT(__x.__hold_.__holds_first(), "Attempted to iter_swap a non-dereferenceable common_iterator");
     _CCCL_ASSERT(__y_hold.__holds_first(), "Attempted to iter_swap a non-dereferenceable common_iterator");
-    return ::cuda::std::ranges::iter_swap(__x.__hold_.__first_, __y_hold.__first_);
+    return ::cuda::std::ranges::__iter_swap_cpo{}(__x.__hold_.__first_, __y_hold.__first_);
   }
 
   [[nodiscard]] _CCCL_API constexpr __variant_like<_Iter, _Sent>& __get_hold() noexcept

--- a/libcudacxx/include/cuda/std/__iterator/concepts.h
+++ b/libcudacxx/include/cuda/std/__iterator/concepts.h
@@ -65,7 +65,7 @@ concept __indirectly_readable_impl =
     typename iter_reference_t<_In>;
     typename iter_rvalue_reference_t<_In>;
     { *__i } -> same_as<iter_reference_t<_In>>;
-    { ::cuda::std::ranges::iter_move(__i) } -> same_as<iter_rvalue_reference_t<_In>>;
+    { ::cuda::std::ranges::__iter_move_cpo{}(__i) } -> same_as<iter_rvalue_reference_t<_In>>;
   } && common_reference_with<iter_reference_t<_In>&&, iter_value_t<_In>&>
   && common_reference_with<iter_reference_t<_In>&&, iter_rvalue_reference_t<_In>&&>
   && common_reference_with<iter_rvalue_reference_t<_In>&&, const iter_value_t<_In>&>;
@@ -295,7 +295,7 @@ _CCCL_CONCEPT_FRAGMENT(
     typename(iter_reference_t<_In>),
     typename(iter_rvalue_reference_t<_In>),
     requires(same_as<iter_reference_t<_In>, decltype(*__i)>),
-    requires(same_as<iter_rvalue_reference_t<_In>, decltype(::cuda::std::ranges::iter_move(__i))>),
+    requires(same_as<iter_rvalue_reference_t<_In>, decltype(::cuda::std::ranges::__iter_move_cpo{}(__i))>),
     requires(common_reference_with<iter_reference_t<_In>&&, iter_value_t<_In>&>),
     requires(common_reference_with<iter_reference_t<_In>&&, iter_rvalue_reference_t<_In>&&>),
     requires(common_reference_with<iter_rvalue_reference_t<_In>&&, const iter_value_t<_In>&>)));

--- a/libcudacxx/include/cuda/std/__iterator/counted_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/counted_iterator.h
@@ -407,20 +407,20 @@ public:
 
   template <class _I2>
   _CCCL_API friend constexpr auto iter_swap(const counted_iterator& __x, const counted_iterator<_I2>& __y) noexcept(
-    noexcept(::cuda::std::ranges::iter_swap(__x.__current_, __y.__current_)))
+    noexcept(::cuda::std::ranges::__iter_swap_cpo{}(__x.__current_, __y.__current_)))
     _CCCL_TRAILING_REQUIRES(void)(indirectly_swappable<_I2, _Iter>)
   {
     _CCCL_ASSERT(__x.__count_ > 0 && __y.__count_ > 0, "Iterators must not be past end of range.");
-    return ::cuda::std::ranges::iter_swap(__x.__current_, __y.__current_);
+    return ::cuda::std::ranges::__iter_swap_cpo{}(__x.__current_, __y.__current_);
   }
 
   _CCCL_TEMPLATE(class _I2 = _Iter)
   _CCCL_REQUIRES(input_iterator<_I2>)
   [[nodiscard]] _CCCL_API friend constexpr decltype(auto)
-  iter_move(const counted_iterator& __i) noexcept(noexcept(::cuda::std::ranges::iter_move(__i.base())))
+  iter_move(const counted_iterator& __i) noexcept(noexcept(::cuda::std::ranges::__iter_move_cpo{}(__i.base())))
   {
     _CCCL_ASSERT(__i.count() > 0, "Iterator must not be past end of range.");
-    return ::cuda::std::ranges::iter_move(__i.base());
+    return ::cuda::std::ranges::__iter_move_cpo{}(__i.base());
   }
 };
 _CCCL_CTAD_SUPPORTED_FOR_TYPE(counted_iterator);

--- a/libcudacxx/include/cuda/std/__iterator/distance.h
+++ b/libcudacxx/include/cuda/std/__iterator/distance.h
@@ -102,11 +102,11 @@ struct __fn
   {
     if constexpr (sized_range<_Rp>)
     {
-      return static_cast<range_difference_t<_Rp>>(::cuda::std::ranges::size(__r));
+      return static_cast<range_difference_t<_Rp>>(::cuda::std::ranges::__size_cpo{}(__r));
     }
     else
     {
-      return operator()(::cuda::std::ranges::begin(__r), ::cuda::std::ranges::end(__r));
+      return operator()(::cuda::std::ranges::__begin_cpo{}(__r), ::cuda::std::ranges::__end_cpo{}(__r));
     }
   }
 };
@@ -115,6 +115,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto distance = __distance::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __distance_cpo = __distance::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__iterator/iter_move.h
+++ b/libcudacxx/include/cuda/std/__iterator/iter_move.h
@@ -123,6 +123,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto iter_move = __iter_move::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __iter_move_cpo = __iter_move::__fn;
 } // namespace __cpo
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 
@@ -131,22 +134,23 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 #if _CCCL_HAS_CONCEPTS()
 template <__dereferenceable _Tp>
   requires requires(_Tp& __t) {
-    { ::cuda::std::ranges::iter_move(__t) } -> __can_reference;
+    { ::cuda::std::ranges::__iter_move_cpo{}(__t) } -> __can_reference;
   }
-using iter_rvalue_reference_t = decltype(::cuda::std::ranges::iter_move(::cuda::std::declval<_Tp&>()));
+using iter_rvalue_reference_t = decltype(::cuda::std::ranges::__iter_move_cpo{}(::cuda::std::declval<_Tp&>()));
 
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 
 template <class _Tp>
-_CCCL_CONCEPT_FRAGMENT(__can_iter_rvalue_reference_t_,
-                       requires(_Tp& __t)(requires(__dereferenceable<_Tp>),
-                                          requires(__can_reference<decltype(::cuda::std::ranges::iter_move(__t))>)));
+_CCCL_CONCEPT_FRAGMENT(
+  __can_iter_rvalue_reference_t_,
+  requires(_Tp& __t)(requires(__dereferenceable<_Tp>),
+                     requires(__can_reference<decltype(::cuda::std::ranges::__iter_move_cpo{}(__t))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __can_iter_rvalue_reference_t = _CCCL_FRAGMENT(__can_iter_rvalue_reference_t_, _Tp);
 
 template <class _Tp>
-using __iter_rvalue_reference_t = decltype(::cuda::std::ranges::iter_move(::cuda::std::declval<_Tp&>()));
+using __iter_rvalue_reference_t = decltype(::cuda::std::ranges::__iter_move_cpo{}(::cuda::std::declval<_Tp&>()));
 
 template <class _Tp>
 using iter_rvalue_reference_t = enable_if_t<__can_iter_rvalue_reference_t<_Tp>, __iter_rvalue_reference_t<_Tp>>;

--- a/libcudacxx/include/cuda/std/__iterator/iter_swap.h
+++ b/libcudacxx/include/cuda/std/__iterator/iter_swap.h
@@ -71,14 +71,14 @@ _CCCL_CONCEPT __readable_swappable = _CCCL_REQUIRES_EXPR((_T1, _T2))(
 template <class _T1, class _T2>
 _CCCL_CONCEPT __noexcept_readable_swappable = _CCCL_REQUIRES_EXPR((_T1, _T2), _T1&& __x, _T2&& __y) //
   (requires(__readable_swappable<_T1, _T2>),
-   noexcept(::cuda::std::ranges::swap(*::cuda::std::forward<_T1>(__x), *::cuda::std::forward<_T2>(__y))));
+   noexcept(::cuda::std::ranges::__swap_cpo{}(*::cuda::std::forward<_T1>(__x), *::cuda::std::forward<_T2>(__y))));
 #else // ^^^ _CCCL_HAS_NOEXCEPT_MANGLING() ^^^ / vvv !_CCCL_HAS_NOEXCEPT_MANGLING() vvv
 template <class _T1, class _T2, bool = __readable_swappable<_T1, _T2>>
 inline constexpr bool __noexcept_readable_swappable = false;
 
 template <class _T1, class _T2>
 inline constexpr bool __noexcept_readable_swappable<_T1, _T2, true> =
-  noexcept(::cuda::std::ranges::swap(*::cuda::std::declval<_T1>(), *::cuda::std::declval<_T2>()));
+  noexcept(::cuda::std::ranges::__swap_cpo{}(*::cuda::std::declval<_T1>(), *::cuda::std::declval<_T2>()));
 #endif // !_CCCL_HAS_NOEXCEPT_MANGLING()
 
 template <class _T1, class _T2>
@@ -93,8 +93,8 @@ template <class _T1, class _T2>
 _CCCL_CONCEPT __noexcept_movable_storable =
   _CCCL_REQUIRES_EXPR((_T1, _T2), _T1&& __x, _T2&& __y, iter_value_t<_T2> __old)(
     requires(__movable_storable<_T1, _T2>),
-    noexcept(iter_value_t<_T2>(::cuda::std::ranges::iter_move(__y))),
-    noexcept(*__y = ::cuda::std::ranges::iter_move(__x)),
+    noexcept(iter_value_t<_T2>(::cuda::std::ranges::__iter_move_cpo{}(__y))),
+    noexcept(*__y = ::cuda::std::ranges::__iter_move_cpo{}(__x)),
     noexcept(*::cuda::std::forward<_T1>(__x) = ::cuda::std::move(__old)));
 #else // ^^^ _CCCL_HAS_NOEXCEPT_MANGLING() ^^^ / vvv !_CCCL_HAS_NOEXCEPT_MANGLING() vvv
 template <class _T1, class _T2, bool = __movable_storable<_T1, _T2>>
@@ -102,9 +102,10 @@ inline constexpr bool __noexcept_movable_storable = false;
 
 template <class _T1, class _T2>
 inline constexpr bool __noexcept_movable_storable<_T1, _T2, true> =
-  noexcept(iter_value_t<_T2>(::cuda::std::ranges::iter_move(::cuda::std::declval<add_lvalue_reference_t<_T2>>())))
+  noexcept(
+    iter_value_t<_T2>(::cuda::std::ranges::__iter_move_cpo{}(::cuda::std::declval<add_lvalue_reference_t<_T2>>())))
   && noexcept(*::cuda::std::declval<add_lvalue_reference_t<_T2>>() =
-                ::cuda::std::ranges::iter_move(::cuda::std::declval<add_lvalue_reference_t<_T1>>()))
+                ::cuda::std::ranges::__iter_move_cpo{}(::cuda::std::declval<add_lvalue_reference_t<_T1>>()))
   && noexcept(*::cuda::std::declval<_T1>() = ::cuda::std::declval<iter_value_t<_T2>>());
 #endif // !_CCCL_HAS_NOEXCEPT_MANGLING()
 
@@ -121,15 +122,15 @@ struct __fn
   _CCCL_REQUIRES(__readable_swappable<_T1, _T2>)
   _CCCL_API constexpr void operator()(_T1&& __x, _T2&& __y) const noexcept(__noexcept_readable_swappable<_T1, _T2>)
   {
-    ::cuda::std::ranges::swap(*::cuda::std::forward<_T1>(__x), *::cuda::std::forward<_T2>(__y));
+    ::cuda::std::ranges::__swap_cpo{}(*::cuda::std::forward<_T1>(__x), *::cuda::std::forward<_T2>(__y));
   }
 
   _CCCL_TEMPLATE(class _T1, class _T2)
   _CCCL_REQUIRES(__movable_storable<_T2, _T1>)
   _CCCL_API constexpr void operator()(_T1&& __x, _T2&& __y) const noexcept(__noexcept_movable_storable<_T1, _T2>)
   {
-    iter_value_t<_T2> __old(::cuda::std::ranges::iter_move(__y));
-    *__y                            = ::cuda::std::ranges::iter_move(__x);
+    iter_value_t<_T2> __old(::cuda::std::ranges::__iter_move_cpo{}(__y));
+    *__y                            = ::cuda::std::ranges::__iter_move_cpo{}(__x);
     *::cuda::std::forward<_T1>(__x) = ::cuda::std::move(__old);
   }
 };
@@ -138,6 +139,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto iter_swap = __iter_swap::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __iter_swap_cpo = __iter_swap::__fn;
 } // namespace __cpo
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 
@@ -146,10 +150,10 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 template <class _I1, class _I2 = _I1>
 concept indirectly_swappable =
   indirectly_readable<_I1> && indirectly_readable<_I2> && requires(const _I1 __i1, const _I2 __i2) {
-    ::cuda::std::ranges::iter_swap(__i1, __i1);
-    ::cuda::std::ranges::iter_swap(__i2, __i2);
-    ::cuda::std::ranges::iter_swap(__i1, __i2);
-    ::cuda::std::ranges::iter_swap(__i2, __i1);
+    ::cuda::std::ranges::__iter_swap_cpo{}(__i1, __i1);
+    ::cuda::std::ranges::__iter_swap_cpo{}(__i2, __i2);
+    ::cuda::std::ranges::__iter_swap_cpo{}(__i1, __i2);
+    ::cuda::std::ranges::__iter_swap_cpo{}(__i2, __i1);
   };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv _CCCL_HAS_CONCEPTS() vvv
 template <class _I1, class _I2>
@@ -158,10 +162,10 @@ _CCCL_CONCEPT_FRAGMENT(
   requires(const _I1 __i1, const _I2 __i2)(
     requires(indirectly_readable<_I1>),
     requires(indirectly_readable<_I2>),
-    (::cuda::std::ranges::iter_swap(__i1, __i1)),
-    (::cuda::std::ranges::iter_swap(__i2, __i2)),
-    (::cuda::std::ranges::iter_swap(__i1, __i2)),
-    (::cuda::std::ranges::iter_swap(__i2, __i1))));
+    (::cuda::std::ranges::__iter_swap_cpo{}(__i1, __i1)),
+    (::cuda::std::ranges::__iter_swap_cpo{}(__i2, __i2)),
+    (::cuda::std::ranges::__iter_swap_cpo{}(__i1, __i2)),
+    (::cuda::std::ranges::__iter_swap_cpo{}(__i2, __i1))));
 
 template <class _I1, class _I2 = _I1>
 _CCCL_CONCEPT indirectly_swappable = _CCCL_FRAGMENT(__indirectly_swappable_, _I1, _I2);
@@ -172,7 +176,7 @@ inline constexpr bool __noexcept_swappable = false;
 
 template <class _I1, class _I2>
 inline constexpr bool __noexcept_swappable<_I1, _I2, enable_if_t<indirectly_swappable<_I1, _I2>>> =
-  noexcept(::cuda::std::ranges::iter_swap(::cuda::std::declval<_I1&>(), ::cuda::std::declval<_I2&>()));
+  noexcept(::cuda::std::ranges::__iter_swap_cpo{}(::cuda::std::declval<_I1&>(), ::cuda::std::declval<_I2&>()));
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__iterator/move_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/move_iterator.h
@@ -75,7 +75,7 @@ concept __move_iter_comparable = requires {
 
 template <class _Iter>
 inline constexpr bool __noexcept_move_iter_iter_move =
-  noexcept(::cuda::std::ranges::iter_move(::cuda::std::declval<const _Iter&>()));
+  noexcept(::cuda::std::ranges::__iter_move_cpo{}(::cuda::std::declval<const _Iter&>()));
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Iter, class = void>
 struct __move_iter_category_base
@@ -100,7 +100,7 @@ _CCCL_CONCEPT __move_iter_comparable = _CCCL_FRAGMENT(__move_iter_comparable_, _
 
 template <class _Iter>
 inline constexpr bool __noexcept_move_iter_iter_move =
-  noexcept(::cuda::std::ranges::iter_move(::cuda::std::declval<const _Iter&>()));
+  noexcept(::cuda::std::ranges::__iter_move_cpo{}(::cuda::std::declval<const _Iter&>()));
 #endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 
 _LIBCUDACXX_BEGIN_HIDDEN_FRIEND_NAMESPACE
@@ -188,12 +188,12 @@ public:
 
   [[nodiscard]] _CCCL_API constexpr reference operator*() const
   {
-    return ::cuda::std::ranges::iter_move(__current_);
+    return ::cuda::std::ranges::__iter_move_cpo{}(__current_);
   }
 
   [[nodiscard]] _CCCL_API constexpr reference operator[](difference_type __n) const
   {
-    return ::cuda::std::ranges::iter_move(__current_ + __n);
+    return ::cuda::std::ranges::__iter_move_cpo{}(__current_ + __n);
   }
 
   _CCCL_EXEC_CHECK_DISABLE
@@ -396,7 +396,7 @@ public:
   [[nodiscard]] _CCCL_API friend constexpr iter_rvalue_reference_t<_Iter>
   iter_move(const move_iterator& __i) noexcept(__noexcept_move_iter_iter_move<_Iter>)
   {
-    return ::cuda::std::ranges::iter_move(__i.__current_);
+    return ::cuda::std::ranges::__iter_move_cpo{}(__i.__current_);
   }
 
   _CCCL_EXEC_CHECK_DISABLE
@@ -405,7 +405,7 @@ public:
   iter_swap(const move_iterator& __x, const move_iterator<_Iter2>& __y) noexcept(__noexcept_swappable<_Iter, _Iter2>)
     _CCCL_TRAILING_REQUIRES(void)(indirectly_swappable<_Iter2, _Iter>)
   {
-    return ::cuda::std::ranges::iter_swap(__x.__current_, __y.__current_);
+    return ::cuda::std::ranges::__iter_swap_cpo{}(__x.__current_, __y.__current_);
   }
 };
 _CCCL_CTAD_SUPPORTED_FOR_TYPE(move_iterator);

--- a/libcudacxx/include/cuda/std/__iterator/next.h
+++ b/libcudacxx/include/cuda/std/__iterator/next.h
@@ -65,7 +65,7 @@ struct __fn
   _CCCL_REQUIRES(input_or_output_iterator<_Ip>)
   [[nodiscard]] _CCCL_API constexpr _Ip operator()(_Ip __x, iter_difference_t<_Ip> __n) const
   {
-    ::cuda::std::ranges::advance(__x, __n);
+    ::cuda::std::ranges::__advance_cpo{}(__x, __n);
     return __x;
   }
 
@@ -74,7 +74,7 @@ struct __fn
   _CCCL_REQUIRES(input_or_output_iterator<_Ip>&& sentinel_for<_Sp, _Ip>)
   [[nodiscard]] _CCCL_API constexpr _Ip operator()(_Ip __x, _Sp __bound_sentinel) const
   {
-    ::cuda::std::ranges::advance(__x, __bound_sentinel);
+    ::cuda::std::ranges::__advance_cpo{}(__x, __bound_sentinel);
     return __x;
   }
 
@@ -83,7 +83,7 @@ struct __fn
   _CCCL_REQUIRES(input_or_output_iterator<_Ip>&& sentinel_for<_Sp, _Ip>)
   [[nodiscard]] _CCCL_API constexpr _Ip operator()(_Ip __x, iter_difference_t<_Ip> __n, _Sp __bound_sentinel) const
   {
-    ::cuda::std::ranges::advance(__x, __n, __bound_sentinel);
+    ::cuda::std::ranges::__advance_cpo{}(__x, __n, __bound_sentinel);
     return __x;
   }
 };
@@ -92,6 +92,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto next = __next::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __next_cpo = __next::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__iterator/prev.h
+++ b/libcudacxx/include/cuda/std/__iterator/prev.h
@@ -63,7 +63,7 @@ struct __fn
   _CCCL_REQUIRES(bidirectional_iterator<_Ip>)
   [[nodiscard]] _CCCL_API constexpr _Ip operator()(_Ip __x, iter_difference_t<_Ip> __n) const
   {
-    ::cuda::std::ranges::advance(__x, -__n);
+    ::cuda::std::ranges::__advance_cpo{}(__x, -__n);
     return __x;
   }
 
@@ -72,7 +72,7 @@ struct __fn
   _CCCL_REQUIRES(bidirectional_iterator<_Ip>)
   [[nodiscard]] _CCCL_API constexpr _Ip operator()(_Ip __x, iter_difference_t<_Ip> __n, _Ip __bound_iter) const
   {
-    ::cuda::std::ranges::advance(__x, -__n, __bound_iter);
+    ::cuda::std::ranges::__advance_cpo{}(__x, -__n, __bound_iter);
     return __x;
   }
 };
@@ -81,6 +81,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto prev = __prev::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __prev_cpo = __prev::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__iterator/reverse_access.h
+++ b/libcudacxx/include/cuda/std/__iterator/reverse_access.h
@@ -62,6 +62,9 @@ struct __fn
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto rbegin = __rbegin::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __rbegin_cpo = __rbegin::__fn;
 } // namespace __cpo
 
 namespace __rend
@@ -97,6 +100,9 @@ struct __fn
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto rend = __rend::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __rend_cpo = __rend::__fn;
 } // namespace __cpo
 
 namespace __crbegin
@@ -104,10 +110,10 @@ namespace __crbegin
 struct __fn
 {
   template <class _Cp>
-  _CCCL_API constexpr auto operator()(const _Cp& __c) const noexcept(noexcept(::cuda::std::rbegin(__c)))
-    -> decltype(::cuda::std::rbegin(__c))
+  _CCCL_API constexpr auto operator()(const _Cp& __c) const noexcept(noexcept(::cuda::std::__rbegin_cpo{}(__c)))
+    -> decltype(::cuda::std::__rbegin_cpo{}(__c))
   {
-    return ::cuda::std::rbegin(__c);
+    return ::cuda::std::__rbegin_cpo{}(__c);
   }
 };
 } // namespace __crbegin
@@ -115,6 +121,9 @@ struct __fn
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto crbegin = __crbegin::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __crbegin_cpo = __crbegin::__fn;
 } // namespace __cpo
 
 namespace __crend
@@ -122,10 +131,10 @@ namespace __crend
 struct __fn
 {
   template <class _Cp>
-  _CCCL_API constexpr auto operator()(const _Cp& __c) const noexcept(noexcept(::cuda::std::rend(__c)))
-    -> decltype(::cuda::std::rend(__c))
+  _CCCL_API constexpr auto operator()(const _Cp& __c) const noexcept(noexcept(::cuda::std::__rend_cpo{}(__c)))
+    -> decltype(::cuda::std::__rend_cpo{}(__c))
   {
-    return ::cuda::std::rend(__c);
+    return ::cuda::std::__rend_cpo{}(__c);
   }
 };
 } // namespace __crend
@@ -133,6 +142,9 @@ struct __fn
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto crend = __crend::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __crend_cpo = __crend::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__iterator/reverse_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/reverse_iterator.h
@@ -61,7 +61,8 @@ inline constexpr bool __noexcept_rev_iter_iter_move = false;
 
 template <class _Iter>
 inline constexpr bool __noexcept_rev_iter_iter_move<_Iter, void_t<decltype(--::cuda::std::declval<_Iter&>())>> =
-  is_nothrow_copy_constructible_v<_Iter> && noexcept(::cuda::std::ranges::iter_move(--::cuda::std::declval<_Iter&>()));
+  is_nothrow_copy_constructible_v<_Iter>
+  && noexcept(::cuda::std::ranges::__iter_move_cpo{}(--::cuda::std::declval<_Iter&>()));
 
 template <class _Iter, class _Iter2, class = void>
 inline constexpr bool __noexcept_rev_iter_iter_swap = false;
@@ -69,7 +70,7 @@ inline constexpr bool __noexcept_rev_iter_iter_swap = false;
 template <class _Iter, class _Iter2>
 inline constexpr bool __noexcept_rev_iter_iter_swap<_Iter, _Iter2, enable_if_t<indirectly_swappable<_Iter, _Iter2>>> =
   is_nothrow_copy_constructible_v<_Iter> && is_nothrow_copy_constructible_v<_Iter2>
-  && noexcept(::cuda::std::ranges::iter_swap(--declval<_Iter&>(), --declval<_Iter2&>()));
+  && noexcept(::cuda::std::ranges::__iter_swap_cpo{}(--declval<_Iter&>(), --declval<_Iter2&>()));
 
 // MSVC has issues with `is_nothrow_convertible_v` sometimes, so do the noexcept expression
 template <class _Iter, class _Iter2, class = void>
@@ -247,7 +248,7 @@ public:
   iter_move(const reverse_iterator& __i) noexcept(__noexcept_rev_iter_iter_move<_Iter2>)
   {
     auto __tmp = __i.base();
-    return ::cuda::std::ranges::iter_move(--__tmp);
+    return ::cuda::std::ranges::__iter_move_cpo{}(--__tmp);
   }
 
   _CCCL_EXEC_CHECK_DISABLE
@@ -257,7 +258,7 @@ public:
   {
     auto __xtmp = __x.base();
     auto __ytmp = __y.base();
-    return ::cuda::std::ranges::iter_swap(--__xtmp, --__ytmp);
+    return ::cuda::std::ranges::__iter_swap_cpo{}(--__xtmp, --__ytmp);
   }
 
   _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/std/__iterator/variant_like.h
+++ b/libcudacxx/include/cuda/std/__iterator/variant_like.h
@@ -364,13 +364,14 @@ public:
       {
         case __variant_like_state::__holds_first:
           this->__first_ = __other.__first_;
-          return *this;
+          break;
         case __variant_like_state::__holds_second:
           this->__second_ = __other.__second_;
-          return *this;
+          break;
         case __variant_like_state::__nothing:
-          return *this;
+          break;
       }
+      return *this;
     }
 
     this->__clear();

--- a/libcudacxx/include/cuda/std/__iterator/variant_like.h
+++ b/libcudacxx/include/cuda/std/__iterator/variant_like.h
@@ -405,10 +405,10 @@ public:
       switch (__x.__contains_)
       {
         case __variant_like_state::__holds_first:
-          ::cuda::std::ranges::swap(__x.__first_, __y.__first_);
+          ::cuda::std::ranges::__swap_cpo{}(__x.__first_, __y.__first_);
           break;
         case __variant_like_state::__holds_second:
-          ::cuda::std::ranges::swap(__x.__second_, __y.__second_);
+          ::cuda::std::ranges::__swap_cpo{}(__x.__second_, __y.__second_);
           break;
         case __variant_like_state::__nothing:
           break;

--- a/libcudacxx/include/cuda/std/__mdspan/extents.h
+++ b/libcudacxx/include/cuda/std/__mdspan/extents.h
@@ -362,14 +362,16 @@ _CCCL_TEMPLATE(class _To, class _From, size_t _Size)
 _CCCL_REQUIRES(__cccl_is_integer_v<_To>)
 [[nodiscard]] _CCCL_API constexpr bool __are_representable_as(span<_From, _Size> __values)
 {
+  bool __result = true;
   for (size_t __i = 0; __i != _Size; __i++)
   {
     if (!__mdspan_detail::__is_representable_as<_To>(__values[__i]))
     {
-      return false;
+      __result = false;
+      break;
     }
   }
-  return true;
+  return __result;
 }
 
 // ------------------------------------------------------------------
@@ -603,14 +605,16 @@ public:
     }
     else if constexpr (rank() != 0)
     {
+      bool __result = true;
       for (rank_type __r = 0; __r != __rank_; __r++)
       {
         if (::cuda::std::cmp_not_equal(__lhs.extent(__r), __rhs.extent(__r)))
         {
-          return false;
+          __result = false;
+          break;
         }
       }
-      return true;
+      return __result;
     }
     else // MSVC needs this or it complains about unreachable code in the first condition
     {
@@ -651,6 +655,7 @@ template <class _Extents>
 [[nodiscard]] _CCCL_API constexpr bool __required_span_size_is_representable(const _Extents& __ext) noexcept
 {
   using ::cuda::std::__mdspan_detail::__mul_overflow;
+  bool __result = true;
   if constexpr (_Extents::rank() != 0)
   {
     using __index_type  = typename _Extents::index_type;
@@ -660,11 +665,12 @@ template <class _Extents>
     {
       if (__mul_overflow(__prod, __ext.extent(__r), &__prod))
       {
-        return false;
+        __result = false;
+        break;
       }
     }
   }
-  return true;
+  return __result;
 }
 
 // Function to check whether a set of indices are a multidimensional

--- a/libcudacxx/include/cuda/std/__mdspan/layout_left.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_left.h
@@ -146,14 +146,16 @@ public:
   {
     // avoid warning when comparing signed and unsigner integers and pick the wider of two types
     using _CommonType = common_type_t<index_type, typename _OtherMappping::index_type>;
+    bool __result     = true;
     for (rank_type __r = 0; __r != extents_type::rank(); __r++)
     {
       if (static_cast<_CommonType>(stride(__r)) != static_cast<_CommonType>(__other.stride(__r)))
       {
-        return false;
+        __result = false;
+        break;
       }
     }
-    return true;
+    return __result;
   }
 
   _CCCL_TEMPLATE(class _OtherExtents)

--- a/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
@@ -122,6 +122,7 @@ private:
     const extents_type& __ext, [[maybe_unused]] span<_OtherIndexType, extents_type::rank()> __strides)
   {
     // nvcc believes strides is unused here
+    bool __result = true;
     if constexpr (extents_type::rank() != 0)
     {
       index_type __size = 1;
@@ -130,26 +131,30 @@ private:
         // We can only check correct conversion of _OtherIndexType if it is an integral
         if (__conversion_may_overflow(__strides[__r]))
         {
-          return false;
+          __result = false;
+          break;
         }
         if (__ext.extent(__r) == index_type{0})
         {
-          return true;
+          __result = true;
+          break;
         }
 
         index_type __prod = (__ext.extent(__r) - 1);
         if (::cuda::std::__mdspan_detail::__mul_overflow(__prod, static_cast<index_type>(__strides[__r]), &__prod))
         {
-          return false;
+          __result = false;
+          break;
         }
         if (__add_overflow(__size, __prod, &__size))
         {
-          return false;
+          __result = false;
+          break;
         }
       }
     }
 
-    return true;
+    return __result;
   }
 
   // compute offset of a strided layout mapping
@@ -258,15 +263,17 @@ public:
     __bubble_sort_by_strides(__permute);
 
     // check that this permutations represents a growing set
+    bool __result = true;
     for (rank_type __i = 1; __i < __rank_; __i++)
     {
       if (static_cast<index_type>(__strides()[__permute[__i]])
           < static_cast<index_type>(__strides()[__permute[__i - 1]]) * extents().extent(__permute[__i - 1]))
       {
-        return false;
+        __result = false;
+        break;
       }
     }
-    return true;
+    return __result;
   }
   [[nodiscard]] _CCCL_API constexpr bool __check_unique_mapping(index_sequence<>) const noexcept
   {
@@ -476,14 +483,17 @@ public:
               __r_largest = __r;
             }
           }
+
+          bool __result = true;
           for (rank_type __r = 0; __r != __rank_; __r++)
           {
             if (extents().extent(__r) == 0 && __r != __r_largest)
             {
-              return false;
+              __result = false;
+              break;
             }
           }
-          return true;
+          return __result;
         }
       }
       else

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -441,6 +441,7 @@ public:
   template <size_t... _Idxs>
   [[nodiscard]] _CCCL_API constexpr bool __check_size() const noexcept
   {
+    bool __result = true;
     if constexpr (extents_type::rank() > 0) // MSVC raises a warning even with __r != extents_type::rank()
     {
       size_t __prod = 1;
@@ -449,11 +450,12 @@ public:
         const auto __extent = static_cast<size_t>(mapping().extents().extent(__r));
         if (__mdspan_detail::__mul_overflow(__prod, __extent, &__prod))
         {
-          return false;
+          __result = false;
+          break;
         }
       }
     }
-    return true;
+    return __result;
   }
 
   template <size_t... _Idxs>

--- a/libcudacxx/include/cuda/std/__memory/construct_at.h
+++ b/libcudacxx/include/cuda/std/__memory/construct_at.h
@@ -166,7 +166,7 @@ _CCCL_API constexpr void __destroy_at([[maybe_unused]] _Tp* __loc)
   }
   else if constexpr (is_array_v<_Tp>)
   {
-    ::cuda::std::__destroy(::cuda::std::begin(*__loc), ::cuda::std::end(*__loc));
+    ::cuda::std::__destroy(::cuda::std::__begin_cpo{}(*__loc), ::cuda::std::__end_cpo{}(*__loc));
   }
   else
   {
@@ -209,7 +209,7 @@ _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void destroy_at([[maybe_unused]] _Tp* __l
   }
   else if constexpr (is_array_v<_Tp>)
   {
-    ::cuda::std::__destroy(::cuda::std::begin(*__loc), ::cuda::std::end(*__loc));
+    ::cuda::std::__destroy(::cuda::std::__begin_cpo{}(*__loc), ::cuda::std::__end_cpo{}(*__loc));
   }
   else
   {

--- a/libcudacxx/include/cuda/std/__memory/runtime_assume_aligned.h
+++ b/libcudacxx/include/cuda/std/__memory/runtime_assume_aligned.h
@@ -33,20 +33,29 @@ template <typename _Tp>
 {
 #if defined(_CCCL_BUILTIN_ASSUME_ALIGNED)
   using _Up = remove_volatile_t<_Tp>;
-  switch (__alignment)
+  if (__alignment == 1)
   {
-    case 1:
-      return static_cast<_Tp*>(_CCCL_BUILTIN_ASSUME_ALIGNED(const_cast<_Up*>(__ptr), 1));
-    case 2:
-      return static_cast<_Tp*>(_CCCL_BUILTIN_ASSUME_ALIGNED(const_cast<_Up*>(__ptr), 2));
-    case 4:
-      return static_cast<_Tp*>(_CCCL_BUILTIN_ASSUME_ALIGNED(const_cast<_Up*>(__ptr), 4));
-    case 8:
-      return static_cast<_Tp*>(_CCCL_BUILTIN_ASSUME_ALIGNED(const_cast<_Up*>(__ptr), 8));
-    case 16:
-      return static_cast<_Tp*>(_CCCL_BUILTIN_ASSUME_ALIGNED(const_cast<_Up*>(__ptr), 16));
-    default:
-      return static_cast<_Tp*>(_CCCL_BUILTIN_ASSUME_ALIGNED(const_cast<_Up*>(__ptr), 32));
+    return static_cast<_Tp*>(_CCCL_BUILTIN_ASSUME_ALIGNED(const_cast<_Up*>(__ptr), 1));
+  }
+  else if (__alignment == 2)
+  {
+    return static_cast<_Tp*>(_CCCL_BUILTIN_ASSUME_ALIGNED(const_cast<_Up*>(__ptr), 2));
+  }
+  else if (__alignment == 4)
+  {
+    return static_cast<_Tp*>(_CCCL_BUILTIN_ASSUME_ALIGNED(const_cast<_Up*>(__ptr), 4));
+  }
+  else if (__alignment == 8)
+  {
+    return static_cast<_Tp*>(_CCCL_BUILTIN_ASSUME_ALIGNED(const_cast<_Up*>(__ptr), 8));
+  }
+  else if (__alignment == 16)
+  {
+    return static_cast<_Tp*>(_CCCL_BUILTIN_ASSUME_ALIGNED(const_cast<_Up*>(__ptr), 16));
+  }
+  else
+  {
+    return static_cast<_Tp*>(_CCCL_BUILTIN_ASSUME_ALIGNED(const_cast<_Up*>(__ptr), 32));
   }
 #else
   _CCCL_ASSUME(reinterpret_cast<uintptr_t>(__ptr) % __alignment == 0);

--- a/libcudacxx/include/cuda/std/__memory/unique_ptr.h
+++ b/libcudacxx/include/cuda/std/__memory/unique_ptr.h
@@ -90,7 +90,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_delete<_Tp[]>
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Up>
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 enable_if_t<is_convertible_v<_Up (*)[], _Tp (*)[]>, void>
-  operator()(_Up* __ptr) const noexcept
+  operator()([[maybe_unused]] _Up* __ptr) const noexcept
   {
     static_assert(sizeof(_Up) >= 0, "cannot delete an incomplete type");
 #if _CCCL_TILE_COMPILATION()

--- a/libcudacxx/include/cuda/std/__optional/make_optional.h
+++ b/libcudacxx/include/cuda/std/__optional/make_optional.h
@@ -44,14 +44,14 @@ _CCCL_TEMPLATE(class _Tp, class... _Args)
 _CCCL_REQUIRES((!is_reference_v<_Tp>) )
 _CCCL_API constexpr optional<_Tp> make_optional(_Args&&... __args)
 {
-  return optional<_Tp>(in_place, ::cuda::std::forward<_Args>(__args)...);
+  return optional<_Tp>(in_place_t{}, ::cuda::std::forward<_Args>(__args)...);
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Up, class... _Args)
 _CCCL_REQUIRES((!is_reference_v<_Tp>) )
 _CCCL_API constexpr optional<_Tp> make_optional(initializer_list<_Up> __il, _Args&&... __args)
 {
-  return optional<_Tp>(in_place, __il, ::cuda::std::forward<_Args>(__args)...);
+  return optional<_Tp>(in_place_t{}, __il, ::cuda::std::forward<_Args>(__args)...);
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__optional/optional.h
+++ b/libcudacxx/include/cuda/std/__optional/optional.h
@@ -130,25 +130,25 @@ public:
   _CCCL_TEMPLATE(class _In_place_t, class... _Args)
   _CCCL_REQUIRES(is_same_v<_In_place_t, in_place_t> _CCCL_AND is_constructible_v<value_type, _Args...>)
   _CCCL_API constexpr explicit optional(_In_place_t, _Args&&... __args)
-      : __base(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __base(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   _CCCL_TEMPLATE(class _Up, class... _Args)
   _CCCL_REQUIRES(is_constructible_v<value_type, initializer_list<_Up>&, _Args...>)
   _CCCL_API constexpr explicit optional(in_place_t, initializer_list<_Up> __il, _Args&&... __args)
-      : __base(in_place, __il, ::cuda::std::forward<_Args>(__args)...)
+      : __base(in_place_t{}, __il, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   _CCCL_TEMPLATE(class _Up = value_type)
   _CCCL_REQUIRES(__opt_is_constructible_from_U<_Tp, _Up> _CCCL_AND __opt_is_implictly_constructible<_Tp, _Up>)
   _CCCL_API constexpr optional(_Up&& __v)
-      : __base(in_place, ::cuda::std::forward<_Up>(__v))
+      : __base(in_place_t{}, ::cuda::std::forward<_Up>(__v))
   {}
 
   _CCCL_TEMPLATE(class _Up)
   _CCCL_REQUIRES(__opt_is_constructible_from_U<_Tp, _Up> _CCCL_AND __opt_is_explictly_constructible<_Tp, _Up>)
   _CCCL_API constexpr explicit optional(_Up&& __v)
-      : __base(in_place, ::cuda::std::forward<_Up>(__v))
+      : __base(in_place_t{}, ::cuda::std::forward<_Up>(__v))
   {}
 
   _CCCL_TEMPLATE(class _Up)

--- a/libcudacxx/include/cuda/std/__optional/optional_base.h
+++ b/libcudacxx/include/cuda/std/__optional/optional_base.h
@@ -106,7 +106,7 @@ struct __optional_destruct_base<_Tp, false>
   template <class... _Args>
   _CCCL_API constexpr explicit __optional_destruct_base(in_place_t, _Args&&... __args) noexcept(
     is_nothrow_constructible_v<value_type, _Args...>)
-      : __storage_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __storage_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
       , __engaged_(true)
   {}
 
@@ -165,7 +165,7 @@ struct __optional_destruct_base<_Tp, true>
   template <class... _Args>
   _CCCL_API constexpr explicit __optional_destruct_base(in_place_t, _Args&&... __args) noexcept(
     is_nothrow_constructible_v<value_type, _Args...>)
-      : __storage_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __storage_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
       , __engaged_(true)
   {}
 

--- a/libcudacxx/include/cuda/std/__pstl/reverse.h
+++ b/libcudacxx/include/cuda/std/__pstl/reverse.h
@@ -64,7 +64,7 @@ struct __reverse_fn
 
   _CCCL_DEVICE_API constexpr void operator()(const iter_difference_t<_InputIterator> __index) const noexcept
   {
-    ::cuda::std::iter_swap(__first_ + __index, __last_ + __index);
+    ::cuda::std::__iter_swap_cpo{}(__first_ + __index, __last_ + __index);
   }
 };
 

--- a/libcudacxx/include/cuda/std/__pstl/swap_ranges.h
+++ b/libcudacxx/include/cuda/std/__pstl/swap_ranges.h
@@ -63,7 +63,8 @@ struct __swap_ranges_iter_swap_fn
   template <class _DifferenceType>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE constexpr void operator()(const _DifferenceType __index) const
   {
-    ::cuda::std::iter_swap(__first1 + __index, __first2 + static_cast<iter_difference_t<_InputIterator2>>(__index));
+    ::cuda::std::__iter_swap_cpo{}(
+      __first1 + __index, __first2 + static_cast<iter_difference_t<_InputIterator2>>(__index));
   }
 };
 

--- a/libcudacxx/include/cuda/std/__ranges/access.h
+++ b/libcudacxx/include/cuda/std/__ranges/access.h
@@ -134,12 +134,15 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto begin = __begin::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __begin_cpo = __begin::__fn;
 } // namespace __cpo
 
 // [range.range]
 
 template <class _Tp>
-using iterator_t = decltype(::cuda::std::ranges::begin(::cuda::std::declval<_Tp&>()));
+using iterator_t = decltype(::cuda::std::ranges::__begin_cpo{}(::cuda::std::declval<_Tp&>()));
 
 // [range.access.end]
 
@@ -230,6 +233,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto end = __end::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __end_cpo = __end::__fn;
 } // namespace __cpo
 
 // [range.access.cbegin]
@@ -241,20 +247,20 @@ struct __fn
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_lvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::begin(static_cast<const remove_reference_t<_Tp>&>(__t))))
-      -> decltype(::cuda::std::ranges::begin(static_cast<const remove_reference_t<_Tp>&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__begin_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t))))
+      -> decltype(::cuda::std::ranges::__begin_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t)))
   {
-    return ::cuda::std::ranges::begin(static_cast<const remove_reference_t<_Tp>&>(__t));
+    return ::cuda::std::ranges::__begin_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t));
   }
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_rvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::begin(static_cast<const _Tp&&>(__t))))
-      -> decltype(::cuda::std::ranges::begin(static_cast<const _Tp&&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__begin_cpo{}(static_cast<const _Tp&&>(__t))))
+      -> decltype(::cuda::std::ranges::__begin_cpo{}(static_cast<const _Tp&&>(__t)))
   {
-    return ::cuda::std::ranges::begin(static_cast<const _Tp&&>(__t));
+    return ::cuda::std::ranges::__begin_cpo{}(static_cast<const _Tp&&>(__t));
   }
 };
 _CCCL_END_NAMESPACE_CPO
@@ -262,6 +268,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto cbegin = __cbegin::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __cbegin_cpo = __cbegin::__fn;
 } // namespace __cpo
 
 // [range.access.cend]
@@ -273,20 +282,20 @@ struct __fn
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_lvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::end(static_cast<const remove_reference_t<_Tp>&>(__t))))
-      -> decltype(::cuda::std::ranges::end(static_cast<const remove_reference_t<_Tp>&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__end_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t))))
+      -> decltype(::cuda::std::ranges::__end_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t)))
   {
-    return ::cuda::std::ranges::end(static_cast<const remove_reference_t<_Tp>&>(__t));
+    return ::cuda::std::ranges::__end_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t));
   }
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_rvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::end(static_cast<const _Tp&&>(__t))))
-      -> decltype(::cuda::std::ranges::end(static_cast<const _Tp&&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__end_cpo{}(static_cast<const _Tp&&>(__t))))
+      -> decltype(::cuda::std::ranges::__end_cpo{}(static_cast<const _Tp&&>(__t)))
   {
-    return ::cuda::std::ranges::end(static_cast<const _Tp&&>(__t));
+    return ::cuda::std::ranges::__end_cpo{}(static_cast<const _Tp&&>(__t));
   }
 };
 _CCCL_END_NAMESPACE_CPO
@@ -294,6 +303,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto cend = __cend::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __cend_cpo = __cend::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__ranges/common_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/common_view.h
@@ -87,11 +87,11 @@ public:
   {
     if constexpr (random_access_range<_View> && sized_range<_View>)
     {
-      return ::cuda::std::ranges::begin(__base_);
+      return ::cuda::std::ranges::__begin_cpo{}(__base_);
     }
     else
     {
-      return common_iterator<iterator_t<_View>, sentinel_t<_View>>{::cuda::std::ranges::begin(__base_)};
+      return common_iterator<iterator_t<_View>, sentinel_t<_View>>{::cuda::std::ranges::__begin_cpo{}(__base_)};
     }
     _CCCL_UNREACHABLE();
   }
@@ -102,11 +102,12 @@ public:
   {
     if constexpr (random_access_range<const _View> && sized_range<const _View>)
     {
-      return ::cuda::std::ranges::begin(__base_);
+      return ::cuda::std::ranges::__begin_cpo{}(__base_);
     }
     else
     {
-      return common_iterator<iterator_t<const _View>, sentinel_t<const _View>>{::cuda::std::ranges::begin(__base_)};
+      return common_iterator<iterator_t<const _View>, sentinel_t<const _View>>{
+        ::cuda::std::ranges::__begin_cpo{}(__base_)};
     }
     _CCCL_UNREACHABLE();
   }
@@ -115,11 +116,11 @@ public:
   {
     if constexpr (random_access_range<_View> && sized_range<_View>)
     {
-      return ::cuda::std::ranges::begin(__base_) + ::cuda::std::ranges::size(__base_);
+      return ::cuda::std::ranges::__begin_cpo{}(__base_) + ::cuda::std::ranges::__size_cpo{}(__base_);
     }
     else
     {
-      return common_iterator<iterator_t<_View>, sentinel_t<_View>>{::cuda::std::ranges::end(__base_)};
+      return common_iterator<iterator_t<_View>, sentinel_t<_View>>{::cuda::std::ranges::__end_cpo{}(__base_)};
     }
     _CCCL_UNREACHABLE();
   }
@@ -130,11 +131,12 @@ public:
   {
     if constexpr (random_access_range<const _View> && sized_range<const _View>)
     {
-      return ::cuda::std::ranges::begin(__base_) + ::cuda::std::ranges::size(__base_);
+      return ::cuda::std::ranges::__begin_cpo{}(__base_) + ::cuda::std::ranges::__size_cpo{}(__base_);
     }
     else
     {
-      return common_iterator<iterator_t<const _View>, sentinel_t<const _View>>{::cuda::std::ranges::end(__base_)};
+      return common_iterator<iterator_t<const _View>, sentinel_t<const _View>>{
+        ::cuda::std::ranges::__end_cpo{}(__base_)};
     }
     _CCCL_UNREACHABLE();
   }
@@ -143,14 +145,14 @@ public:
   _CCCL_REQUIRES(sized_range<_View2>)
   [[nodiscard]] _CCCL_API constexpr auto size()
   {
-    return ::cuda::std::ranges::size(__base_);
+    return ::cuda::std::ranges::__size_cpo{}(__base_);
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(sized_range<const _View2>)
   [[nodiscard]] _CCCL_API constexpr auto size() const
   {
-    return ::cuda::std::ranges::size(__base_);
+    return ::cuda::std::ranges::__size_cpo{}(__base_);
   }
 };
 

--- a/libcudacxx/include/cuda/std/__ranges/compressed_movable_box.h
+++ b/libcudacxx/include/cuda/std/__ranges/compressed_movable_box.h
@@ -220,7 +220,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_storage
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
   _CCCL_REQUIRES(is_default_constructible_v<_Tp2>)
   _CCCL_API constexpr __compressed_box_storage() noexcept(is_nothrow_default_constructible_v<_Tp2>)
-      : __storage_(in_place)
+      : __storage_(in_place_t{})
       , __engaged_(true)
   {}
 
@@ -229,7 +229,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_storage
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr explicit __compressed_box_storage(in_place_t, _Args&&... __args) noexcept(
     is_nothrow_constructible_v<_Tp, _Args...>)
-      : __storage_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __storage_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
       , __engaged_(true)
   {}
 
@@ -273,7 +273,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_storage<_Index, _Tp, true>
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
   _CCCL_REQUIRES(is_default_constructible_v<_Tp2>)
   _CCCL_API constexpr __compressed_box_storage() noexcept(is_nothrow_default_constructible_v<_Tp2>)
-      : __storage_(in_place)
+      : __storage_(in_place_t{})
       , __engaged_(true)
   {}
 
@@ -282,7 +282,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_storage<_Index, _Tp, true>
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr explicit __compressed_box_storage(in_place_t, _Args&&... __args) noexcept(
     is_nothrow_constructible_v<_Tp, _Args...>)
-      : __storage_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __storage_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
       , __engaged_(true)
   {}
 };
@@ -302,7 +302,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_base<_Index, _Tp, __compresse
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
   _CCCL_REQUIRES(is_default_constructible_v<_Tp2>)
   _CCCL_API constexpr __compressed_box_base() noexcept(is_nothrow_default_constructible_v<_Tp2>)
-      : __base(in_place)
+      : __base(in_place_t{})
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
@@ -310,7 +310,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_base<_Index, _Tp, __compresse
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr __compressed_box_base(in_place_t,
                                             _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
-      : __base(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __base(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   [[nodiscard]] _CCCL_API constexpr _Tp& __get() noexcept
@@ -656,7 +656,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_movable_box<_Elem1> : __compresse
   _CCCL_TEMPLATE(class... _Args)
   _CCCL_REQUIRES((sizeof...(_Args) != 0) _CCCL_AND is_constructible_v<_Elem1, _Args...>)
   _CCCL_API constexpr __compressed_movable_box(_Args&&... __args) noexcept(is_nothrow_constructible_v<_Elem1, _Args...>)
-      : __base1(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __base1(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   _CCCL_TEMPLATE(size_t _Index)
@@ -710,7 +710,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_movable_box<_Elem1, _Elem2>
   _CCCL_TEMPLATE(class _Arg1)
   _CCCL_REQUIRES(__is_constructible_from_one_arg<_Arg1>)
   _CCCL_API constexpr __compressed_movable_box(_Arg1&& __arg1) noexcept(__is_nothrow_constructible_from_one_arg<_Arg1>)
-      : __base1(in_place, ::cuda::std::forward<_Arg1>(__arg1))
+      : __base1(in_place_t{}, ::cuda::std::forward<_Arg1>(__arg1))
       , __base2()
   {}
 
@@ -727,8 +727,8 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_movable_box<_Elem1, _Elem2>
   _CCCL_REQUIRES(__is_constructible_from_two_args<_Arg1, _Arg2>)
   _CCCL_API constexpr __compressed_movable_box(_Arg1&& __arg1, _Arg2&& __arg2) noexcept(
     __is_nothrow_constructible_from_two_args<_Arg1, _Arg2>)
-      : __base1(in_place, ::cuda::std::forward<_Arg1>(__arg1))
-      , __base2(in_place, ::cuda::std::forward<_Arg2>(__arg2))
+      : __base1(in_place_t{}, ::cuda::std::forward<_Arg1>(__arg1))
+      , __base2(in_place_t{}, ::cuda::std::forward<_Arg2>(__arg2))
   {}
 
   _CCCL_TEMPLATE(size_t _Index)
@@ -803,7 +803,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_movable_box<_Elem1, _Elem2, _Elem
   _CCCL_TEMPLATE(class _Arg1)
   _CCCL_REQUIRES(__is_constructible_from_one_arg<_Arg1>)
   _CCCL_API constexpr __compressed_movable_box(_Arg1&& __arg1) noexcept(__is_nothrow_constructible_from_one_arg<_Arg1>)
-      : __base1(in_place, ::cuda::std::forward<_Arg1>(__arg1))
+      : __base1(in_place_t{}, ::cuda::std::forward<_Arg1>(__arg1))
       , __base2()
       , __base3()
   {}
@@ -822,8 +822,8 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_movable_box<_Elem1, _Elem2, _Elem
   _CCCL_REQUIRES(__is_constructible_from_two_args<_Arg1, _Arg2>)
   _CCCL_API constexpr __compressed_movable_box(_Arg1&& __arg1, _Arg2&& __arg2) noexcept(
     __is_nothrow_constructible_from_two_args<_Arg1, _Arg2>)
-      : __base1(in_place, ::cuda::std::forward<_Arg1>(__arg1))
-      , __base2(in_place, ::cuda::std::forward<_Arg2>(__arg2))
+      : __base1(in_place_t{}, ::cuda::std::forward<_Arg1>(__arg1))
+      , __base2(in_place_t{}, ::cuda::std::forward<_Arg2>(__arg2))
       , __base3()
   {}
 
@@ -841,9 +841,9 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_movable_box<_Elem1, _Elem2, _Elem
   _CCCL_REQUIRES(__is_constructible_from_three_args<_Arg1, _Arg2, _Arg3>)
   _CCCL_API constexpr __compressed_movable_box(_Arg1&& __arg1, _Arg2&& __arg2, _Arg3&& __arg3) noexcept(
     __is_nothrow_constructible_from_three_args<_Arg1, _Arg2, _Arg3>)
-      : __base1(in_place, ::cuda::std::forward<_Arg1>(__arg1))
-      , __base2(in_place, ::cuda::std::forward<_Arg2>(__arg2))
-      , __base3(in_place, ::cuda::std::forward<_Arg3>(__arg3))
+      : __base1(in_place_t{}, ::cuda::std::forward<_Arg1>(__arg1))
+      , __base2(in_place_t{}, ::cuda::std::forward<_Arg2>(__arg2))
+      , __base3(in_place_t{}, ::cuda::std::forward<_Arg3>(__arg3))
   {}
 
   _CCCL_TEMPLATE(size_t _Index)

--- a/libcudacxx/include/cuda/std/__ranges/concepts.h
+++ b/libcudacxx/include/cuda/std/__ranges/concepts.h
@@ -52,8 +52,8 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
 template <class _Tp>
 concept range = requires(_Tp& __t) {
-  ::cuda::std::ranges::begin(__t); // sometimes equality-preserving
-  ::cuda::std::ranges::end(__t);
+  ::cuda::std::ranges::__begin_cpo{}(__t); // sometimes equality-preserving
+  ::cuda::std::ranges::__end_cpo{}(__t);
 };
 
 template <class _Tp>
@@ -66,7 +66,7 @@ concept borrowed_range =
 // `iterator_t` defined in <__ranges/access.h>
 
 template <range _Rp>
-using sentinel_t = decltype(::cuda::std::ranges::end(::cuda::std::declval<_Rp&>()));
+using sentinel_t = decltype(::cuda::std::ranges::__end_cpo{}(::cuda::std::declval<_Rp&>()));
 
 template <range _Rp>
 using range_difference_t = iter_difference_t<iterator_t<_Rp>>;
@@ -85,10 +85,10 @@ using range_common_reference_t = iter_common_reference_t<iterator_t<_Rp>>;
 
 // [range.sized]
 template <class _Tp>
-concept sized_range = range<_Tp> && requires(_Tp& __t) { ::cuda::std::ranges::size(__t); };
+concept sized_range = range<_Tp> && requires(_Tp& __t) { ::cuda::std::ranges::__size_cpo{}(__t); };
 
 template <sized_range _Rp>
-using range_size_t = decltype(::cuda::std::ranges::size(::cuda::std::declval<_Rp&>()));
+using range_size_t = decltype(::cuda::std::ranges::__size_cpo{}(::cuda::std::declval<_Rp&>()));
 
 // `disable_sized_range` defined in `<__ranges/size.h>`
 
@@ -119,7 +119,7 @@ concept random_access_range = bidirectional_range<_Tp> && random_access_iterator
 
 template <class _Tp>
 concept contiguous_range = random_access_range<_Tp> && contiguous_iterator<iterator_t<_Tp>> && requires(_Tp& __t) {
-  { ::cuda::std::ranges::data(__t) } -> same_as<add_pointer_t<range_reference_t<_Tp>>>;
+  { ::cuda::std::ranges::__data_cpo{}(__t) } -> same_as<add_pointer_t<range_reference_t<_Tp>>>;
 };
 
 template <class _Tp>
@@ -141,8 +141,8 @@ template <class _Tp>
 _CCCL_CONCEPT range =
   _CCCL_REQUIRES_EXPR((_Tp), _Tp& __t)
   (
-    void(::cuda::std::ranges::begin(__t)),
-    void(::cuda::std::ranges::end(__t))
+    void(::cuda::std::ranges::__begin_cpo{}(__t)),
+    void(::cuda::std::ranges::__end_cpo{}(__t))
   );
 
 template <class _Tp>
@@ -166,7 +166,7 @@ _CCCL_CONCEPT borrowed_range = _CCCL_FRAGMENT(__borrowed_range_, _Range);
 // `iterator_t` defined in <__ranges/access.h>
 
 template <class _Rp>
-using sentinel_t = enable_if_t<range<_Rp>, decltype(::cuda::std::ranges::end(::cuda::std::declval<_Rp&>()))>;
+using sentinel_t = enable_if_t<range<_Rp>, decltype(::cuda::std::ranges::__end_cpo{}(::cuda::std::declval<_Rp&>()))>;
 
 template <class _Rp>
 using range_difference_t = enable_if_t<range<_Rp>, iter_difference_t<iterator_t<_Rp>>>;
@@ -185,14 +185,15 @@ using range_common_reference_t = enable_if_t<range<_Rp>, iter_common_reference_t
 
 // [range.sized]
 template <class _Tp>
-_CCCL_CONCEPT_FRAGMENT(__sized_range_,
-                       requires(_Tp& __t)(requires(range<_Tp>), typename(decltype(::cuda::std::ranges::size(__t)))));
+_CCCL_CONCEPT_FRAGMENT(
+  __sized_range_, requires(_Tp& __t)(requires(range<_Tp>), typename(decltype(::cuda::std::ranges::__size_cpo{}(__t)))));
 
 template <class _Tp>
 _CCCL_CONCEPT sized_range = _CCCL_FRAGMENT(__sized_range_, _Tp);
 
 template <class _Rp>
-using range_size_t = enable_if_t<sized_range<_Rp>, decltype(::cuda::std::ranges::size(::cuda::std::declval<_Rp&>()))>;
+using range_size_t =
+  enable_if_t<sized_range<_Rp>, decltype(::cuda::std::ranges::__size_cpo{}(::cuda::std::declval<_Rp&>()))>;
 
 // `disable_sized_range` defined in `<__ranges/size.h>`
 
@@ -254,7 +255,7 @@ _CCCL_CONCEPT_FRAGMENT(
   requires(_Tp& __t)(
     requires(random_access_range<_Tp>),
     requires(contiguous_iterator<iterator_t<_Tp>>),
-    requires(same_as<decltype(::cuda::std::ranges::data(__t)), add_pointer_t<range_reference_t<_Tp>>>)));
+    requires(same_as<decltype(::cuda::std::ranges::__data_cpo{}(__t)), add_pointer_t<range_reference_t<_Tp>>>)));
 
 template <class _Tp>
 _CCCL_CONCEPT contiguous_range = _CCCL_FRAGMENT(__contiguous_range_, _Tp);

--- a/libcudacxx/include/cuda/std/__ranges/data.h
+++ b/libcudacxx/include/cuda/std/__ranges/data.h
@@ -51,7 +51,7 @@ concept __member_data = __can_borrow<_Tp> && __workaround_52970<_Tp> && requires
 
 template <class _Tp>
 concept __ranges_begin_invocable = !__member_data<_Tp> && __can_borrow<_Tp> && requires(_Tp&& __t) {
-  { ::cuda::std::ranges::begin(__t) } -> contiguous_iterator;
+  { ::cuda::std::ranges::__begin_cpo{}(__t) } -> contiguous_iterator;
 };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Tp>
@@ -64,10 +64,11 @@ template <class _Tp>
 _CCCL_CONCEPT __member_data = _CCCL_FRAGMENT(__member_data_, _Tp);
 
 template <class _Tp>
-_CCCL_CONCEPT_FRAGMENT(__ranges_begin_invocable_,
-                       requires(_Tp&& __t)(requires(!__member_data<_Tp>),
-                                           requires(__can_borrow<_Tp>),
-                                           requires(contiguous_iterator<decltype(::cuda::std::ranges::begin(__t))>)));
+_CCCL_CONCEPT_FRAGMENT(
+  __ranges_begin_invocable_,
+  requires(_Tp&& __t)(requires(!__member_data<_Tp>),
+                      requires(__can_borrow<_Tp>),
+                      requires(contiguous_iterator<decltype(::cuda::std::ranges::__begin_cpo{}(__t))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __ranges_begin_invocable = _CCCL_FRAGMENT(__ranges_begin_invocable_, _Tp);
@@ -87,9 +88,9 @@ struct __fn
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__ranges_begin_invocable<_Tp>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::to_address(::cuda::std::ranges::begin(__t))))
+    noexcept(noexcept(::cuda::std::to_address(::cuda::std::ranges::__begin_cpo{}(__t))))
   {
-    return ::cuda::std::to_address(::cuda::std::ranges::begin(__t));
+    return ::cuda::std::to_address(::cuda::std::ranges::__begin_cpo{}(__t));
   }
 };
 _CCCL_END_NAMESPACE_CPO
@@ -97,6 +98,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto data = __data::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __data_cpo = __data::__fn;
 } // namespace __cpo
 
 // [range.prim.cdata]
@@ -107,19 +111,19 @@ struct __fn
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_lvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::data(static_cast<const remove_reference_t<_Tp>&>(__t))))
-      -> decltype(::cuda::std::ranges::data(static_cast<const remove_reference_t<_Tp>&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__data_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t))))
+      -> decltype(::cuda::std::ranges::__data_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t)))
   {
-    return ::cuda::std::ranges::data(static_cast<const remove_reference_t<_Tp>&>(__t));
+    return ::cuda::std::ranges::__data_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t));
   }
 
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_rvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::data(static_cast<const _Tp&&>(__t))))
-      -> decltype(::cuda::std::ranges::data(static_cast<const _Tp&&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__data_cpo{}(static_cast<const _Tp&&>(__t))))
+      -> decltype(::cuda::std::ranges::__data_cpo{}(static_cast<const _Tp&&>(__t)))
   {
-    return ::cuda::std::ranges::data(static_cast<const _Tp&&>(__t));
+    return ::cuda::std::ranges::__data_cpo{}(static_cast<const _Tp&&>(__t));
   }
 };
 _CCCL_END_NAMESPACE_CPO
@@ -127,6 +131,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto cdata = __cdata::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __cdata_cpo = __cdata::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__ranges/drop_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/drop_view.h
@@ -64,7 +64,7 @@ template <class _View, enable_if_t<view<_View>, int> = 0>
 #endif // !_CCCL_HAS_CONCEPTS()
 class drop_view : public view_interface<drop_view<_View>>
 {
-  // We cache begin() whenever ::cuda::std::ranges::next is not guaranteed O(1) to provide an
+  // We cache begin() whenever ::cuda::std::ranges::__next_cpo{} is not guaranteed O(1) to provide an
   // amortized O(1) begin() method. If this is an input_range, then we cannot cache
   // begin because begin is not equality preserving.
   // Note: drop_view<input-range>::begin() is still trivially amortized O(1) because
@@ -115,21 +115,22 @@ public:
   {
     if constexpr (random_access_range<_View2> && sized_range<_View2>)
     {
-      const auto __dist = ::cuda::std::min(::cuda::std::ranges::distance(__base_), __count_);
-      return ::cuda::std::ranges::begin(__base_) + __dist;
+      const auto __dist = ::cuda::std::min(::cuda::std::ranges::__distance_cpo{}(__base_), __count_);
+      return ::cuda::std::ranges::__begin_cpo{}(__base_) + __dist;
     }
     else if constexpr (_UseCache)
     {
       if (!__cached_begin_.__has_value())
       {
-        __cached_begin_.__emplace(
-          ::cuda::std::ranges::next(::cuda::std::ranges::begin(__base_), __count_, ::cuda::std::ranges::end(__base_)));
+        __cached_begin_.__emplace(::cuda::std::ranges::__next_cpo{}(
+          ::cuda::std::ranges::__begin_cpo{}(__base_), __count_, ::cuda::std::ranges::__end_cpo{}(__base_)));
       }
       return *__cached_begin_;
     }
     else
     {
-      return ::cuda::std::ranges::next(::cuda::std::ranges::begin(__base_), __count_, ::cuda::std::ranges::end(__base_));
+      return ::cuda::std::ranges::__next_cpo{}(
+        ::cuda::std::ranges::__begin_cpo{}(__base_), __count_, ::cuda::std::ranges::__end_cpo{}(__base_));
     }
   }
 
@@ -137,28 +138,28 @@ public:
   _CCCL_REQUIRES(random_access_range<const _View2>&& sized_range<const _View2>)
   _CCCL_API constexpr auto begin() const
   {
-    const auto __dist = ::cuda::std::min(::cuda::std::ranges::distance(__base_), __count_);
-    return ::cuda::std::ranges::begin(__base_) + __dist;
+    const auto __dist = ::cuda::std::min(::cuda::std::ranges::__distance_cpo{}(__base_), __count_);
+    return ::cuda::std::ranges::__begin_cpo{}(__base_) + __dist;
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES((!__simple_view<_View2>) )
   _CCCL_API constexpr auto end()
   {
-    return ::cuda::std::ranges::end(__base_);
+    return ::cuda::std::ranges::__end_cpo{}(__base_);
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(range<const _View2>)
   _CCCL_API constexpr auto end() const
   {
-    return ::cuda::std::ranges::end(__base_);
+    return ::cuda::std::ranges::__end_cpo{}(__base_);
   }
 
   template <class _Self = drop_view>
   _CCCL_API static constexpr auto __size(_Self& __self)
   {
-    const auto __s = ::cuda::std::ranges::size(__self.__base_);
+    const auto __s = ::cuda::std::ranges::__size_cpo{}(__self.__base_);
     const auto __c = static_cast<decltype(__s)>(__self.__count_);
     return __s < __c ? 0 : __s - __c;
   }
@@ -294,14 +295,14 @@ struct __fn
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Range&& __rng, _Np&& __n) const
     // Note: deliberately not forwarding `__rng` to guard against double moves.
     noexcept(noexcept(__passthrough_type_t<_RawRange>(
-      ::cuda::std::ranges::begin(__rng)
-        + ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__rng), ::cuda::std::forward<_Np>(__n)),
-      ::cuda::std::ranges::end(__rng)))) -> __passthrough_type_t<_RawRange>
+      ::cuda::std::ranges::__begin_cpo{}(__rng)
+        + ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__rng), ::cuda::std::forward<_Np>(__n)),
+      ::cuda::std::ranges::__end_cpo{}(__rng)))) -> __passthrough_type_t<_RawRange>
   {
     return __passthrough_type_t<_RawRange>(
-      ::cuda::std::ranges::begin(__rng)
-        + ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__rng), ::cuda::std::forward<_Np>(__n)),
-      ::cuda::std::ranges::end(__rng));
+      ::cuda::std::ranges::__begin_cpo{}(__rng)
+        + ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__rng), ::cuda::std::forward<_Np>(__n)),
+      ::cuda::std::ranges::__end_cpo{}(__rng));
   }
 
   // [range.drop.overview]: the `subrange (StoreSize == true)` case.
@@ -311,19 +312,20 @@ struct __fn
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Range&& __rng, _Np&& __n) const
     // Note: deliberately not forwarding `__rng` to guard against double moves.
     noexcept(noexcept(_RawRange(
-      ::cuda::std::ranges::begin(__rng)
-        + ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__rng), ::cuda::std::forward<_Np>(__n)),
-      ::cuda::std::ranges::end(__rng),
+      ::cuda::std::ranges::__begin_cpo{}(__rng)
+        + ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__rng), ::cuda::std::forward<_Np>(__n)),
+      ::cuda::std::ranges::__end_cpo{}(__rng),
       ::cuda::std::__to_unsigned_like(
-        ::cuda::std::ranges::distance(__rng)
-        - ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__rng), ::cuda::std::forward<_Np>(__n)))))) -> _RawRange
+        ::cuda::std::ranges::__distance_cpo{}(__rng)
+        - ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__rng), ::cuda::std::forward<_Np>(__n))))))
+      -> _RawRange
   {
     // Introducing local variables avoids calculating `min` and `distance` twice (at the cost of diverging from the
     // expression used in the `noexcept` clause and the return statement).
-    auto dist    = ::cuda::std::ranges::distance(__rng);
+    auto dist    = ::cuda::std::ranges::__distance_cpo{}(__rng);
     auto clamped = ::cuda::std::min<_Dist>(dist, ::cuda::std::forward<_Np>(__n));
-    return _RawRange(::cuda::std::ranges::begin(__rng) + clamped,
-                     ::cuda::std::ranges::end(__rng),
+    return _RawRange(::cuda::std::ranges::__begin_cpo{}(__rng) + clamped,
+                     ::cuda::std::ranges::__end_cpo{}(__rng),
                      ::cuda::std::__to_unsigned_like(dist - clamped));
   }
 
@@ -335,14 +337,14 @@ struct __fn
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Range&& __range, _Np&& __n) const
     noexcept(noexcept(::cuda::std::ranges::views::repeat(
       ::cuda::std::forward_like<_Range>(*__range.__value_),
-      ::cuda::std::ranges::distance(__range)
-        - ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__range), ::cuda::std::forward<_Np>(__n)))))
+      ::cuda::std::ranges::__distance_cpo{}(__range)
+        - ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__range), ::cuda::std::forward<_Np>(__n)))))
       -> _RawRange
   {
     return ::cuda::std::ranges::views::repeat(
       ::cuda::std::forward_like<_Range>(*__range.__value_),
-      ::cuda::std::ranges::distance(__range)
-        - ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__range), ::cuda::std::forward<_Np>(__n)));
+      ::cuda::std::ranges::__distance_cpo{}(__range)
+        - ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__range), ::cuda::std::forward<_Np>(__n)));
   }
 
   // [range.take.overview]: the `repeat_view` "otherwise" case.

--- a/libcudacxx/include/cuda/std/__ranges/drop_while_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/drop_while_view.h
@@ -84,7 +84,7 @@ public:
 
   _CCCL_API constexpr explicit drop_while_view(_View __base, _Pred __pred)
       : __base_{::cuda::std::move(__base)}
-      , __pred_{::cuda::std::in_place, ::cuda::std::move(__pred)}
+      , __pred_{in_place_t{}, ::cuda::std::move(__pred)}
 
   {}
 

--- a/libcudacxx/include/cuda/std/__ranges/drop_while_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/drop_while_view.h
@@ -128,7 +128,7 @@ public:
 
   [[nodiscard]] _CCCL_API constexpr auto end()
   {
-    return ::cuda::std::ranges::end(__base_);
+    return ::cuda::std::ranges::__end_cpo{}(__base_);
   }
 };
 

--- a/libcudacxx/include/cuda/std/__ranges/empty.h
+++ b/libcudacxx/include/cuda/std/__ranges/empty.h
@@ -38,12 +38,12 @@ template <class _Tp>
 concept __member_empty = __workaround_52970<_Tp> && requires(_Tp&& __t) { bool(__t.empty()); };
 
 template <class _Tp>
-concept __can_invoke_size = !__member_empty<_Tp> && requires(_Tp&& __t) { ::cuda::std::ranges::size(__t); };
+concept __can_invoke_size = !__member_empty<_Tp> && requires(_Tp&& __t) { ::cuda::std::ranges::__size_cpo{}(__t); };
 
 template <class _Tp>
 concept __can_compare_begin_end = !__member_empty<_Tp> && !__can_invoke_size<_Tp> && requires(_Tp&& __t) {
-  bool(::cuda::std::ranges::begin(__t) == ::cuda::std::ranges::end(__t));
-  { ::cuda::std::ranges::begin(__t) } -> forward_iterator;
+  bool(::cuda::std::ranges::__begin_cpo{}(__t) == ::cuda::std::ranges::__end_cpo{}(__t));
+  { ::cuda::std::ranges::__begin_cpo{}(__t) } -> forward_iterator;
 };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Tp>
@@ -53,8 +53,9 @@ template <class _Tp>
 _CCCL_CONCEPT __member_empty = _CCCL_FRAGMENT(__member_empty_, _Tp);
 
 template <class _Tp>
-_CCCL_CONCEPT_FRAGMENT(__can_invoke_size_,
-                       requires(_Tp&& __t)(requires(!__member_empty<_Tp>), ((void) ::cuda::std::ranges::size(__t))));
+_CCCL_CONCEPT_FRAGMENT(
+  __can_invoke_size_,
+  requires(_Tp&& __t)(requires(!__member_empty<_Tp>), ((void) ::cuda::std::ranges::__size_cpo{}(__t))));
 
 template <class _Tp>
 _CCCL_CONCEPT __can_invoke_size = _CCCL_FRAGMENT(__can_invoke_size_, _Tp);
@@ -64,8 +65,8 @@ _CCCL_CONCEPT_FRAGMENT(
   __can_compare_begin_end_,
   requires(_Tp&& __t)(requires(!__member_empty<_Tp>),
                       requires(!__can_invoke_size<_Tp>),
-                      (bool(::cuda::std::ranges::begin(__t) == ::cuda::std::ranges::end(__t))),
-                      requires(forward_iterator<decltype(::cuda::std::ranges::begin(__t))>)));
+                      (bool(::cuda::std::ranges::__begin_cpo{}(__t) == ::cuda::std::ranges::__end_cpo{}(__t))),
+                      requires(forward_iterator<decltype(::cuda::std::ranges::__begin_cpo{}(__t))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __can_compare_begin_end = _CCCL_FRAGMENT(__can_compare_begin_end_, _Tp);
@@ -82,17 +83,18 @@ struct __fn
 
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__can_invoke_size<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr bool operator()(_Tp&& __t) const noexcept(noexcept(::cuda::std::ranges::size(__t)))
+  [[nodiscard]] _CCCL_API constexpr bool operator()(_Tp&& __t) const
+    noexcept(noexcept(::cuda::std::ranges::__size_cpo{}(__t)))
   {
-    return ::cuda::std::ranges::size(__t) == 0;
+    return ::cuda::std::ranges::__size_cpo{}(__t) == 0;
   }
 
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__can_compare_begin_end<_Tp>)
   [[nodiscard]] _CCCL_API constexpr bool operator()(_Tp&& __t) const
-    noexcept(noexcept(bool(::cuda::std::ranges::begin(__t) == ::cuda::std::ranges::end(__t))))
+    noexcept(noexcept(bool(::cuda::std::ranges::__begin_cpo{}(__t) == ::cuda::std::ranges::__end_cpo{}(__t))))
   {
-    return ::cuda::std::ranges::begin(__t) == ::cuda::std::ranges::end(__t);
+    return ::cuda::std::ranges::__begin_cpo{}(__t) == ::cuda::std::ranges::__end_cpo{}(__t);
   }
 };
 _CCCL_END_NAMESPACE_CPO
@@ -100,6 +102,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto empty = __empty::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __empty_cpo = __empty::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__ranges/filter_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/filter_view.h
@@ -299,7 +299,7 @@ public:
     is_nothrow_move_constructible_v<_View>
     && is_nothrow_constructible_v<__movable_box<_Pred>, in_place_t, add_rvalue_reference_t<_Pred>>)
       : __base_{::cuda::std::move(__base)}
-      , __pred_{in_place, ::cuda::std::move(__pred)}
+      , __pred_{in_place_t{}, ::cuda::std::move(__pred)}
   {}
 
   _CCCL_TEMPLATE(class _View2 = _View)

--- a/libcudacxx/include/cuda/std/__ranges/filter_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/filter_view.h
@@ -159,7 +159,7 @@ public:
     {
       __current_ = ::cuda::std::ranges::find_if(
         ::cuda::std::move(++__current_),
-        ::cuda::std::ranges::end(__parent_->__base_),
+        ::cuda::std::ranges::__end_cpo{}(__parent_->__base_),
         ::cuda::std::ref(*__parent_->__pred_));
       return *this;
     }
@@ -227,9 +227,9 @@ public:
 #endif // _LIBCUDACXX_HAS_NO_SPACESHIP_OPERATOR()
 
     [[nodiscard]] _CCCL_API friend constexpr range_rvalue_reference_t<_View>
-    iter_move(const __iterator& __it) noexcept(noexcept(::cuda::std::ranges::iter_move(__it.__current_)))
+    iter_move(const __iterator& __it) noexcept(noexcept(::cuda::std::ranges::__iter_move_cpo{}(__it.__current_)))
     {
-      return ::cuda::std::ranges::iter_move(__it.__current_);
+      return ::cuda::std::ranges::__iter_move_cpo{}(__it.__current_);
     }
 
     _CCCL_TEMPLATE(class _View2 = _View)
@@ -237,7 +237,7 @@ public:
     _CCCL_API friend constexpr void
     iter_swap(const __iterator& __x, const __iterator& __y) noexcept(__noexcept_swappable<iterator_t<_View2>>)
     {
-      ::cuda::std::ranges::iter_swap(__x.__current_, __y.__current_);
+      ::cuda::std::ranges::__iter_swap_cpo{}(__x.__current_, __y.__current_);
     }
   };
 
@@ -249,7 +249,7 @@ public:
     _CCCL_HIDE_FROM_ABI constexpr __sentinel() = default;
 
     _CCCL_API constexpr explicit __sentinel(filter_view& __parent)
-        : __end_{::cuda::std::ranges::end(__parent.__base_)}
+        : __end_{::cuda::std::ranges::__end_cpo{}(__parent.__base_)}
     {}
 
     [[nodiscard]] _CCCL_API constexpr sentinel_t<_View> base() const
@@ -343,7 +343,7 @@ public:
   {
     if constexpr (common_range<_View>)
     {
-      return __iterator{*this, ::cuda::std::ranges::end(__base_)};
+      return __iterator{*this, ::cuda::std::ranges::__end_cpo{}(__base_)};
     }
     else
     {

--- a/libcudacxx/include/cuda/std/__ranges/movable_box.h
+++ b/libcudacxx/include/cuda/std/__ranges/movable_box.h
@@ -116,7 +116,7 @@ struct __mb_optional_destruct_base
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr explicit __mb_optional_destruct_base(in_place_t, _Args&&... __args) noexcept(
     is_nothrow_constructible_v<_Tp, _Args...>)
-      : __val_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __val_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 };
 
@@ -126,14 +126,14 @@ struct __mb_optional_destruct_base<_Tp, true>
   _CCCL_NO_UNIQUE_ADDRESS optional<_Tp> __val_;
 
   _CCCL_API constexpr __mb_optional_destruct_base() noexcept(is_nothrow_default_constructible_v<_Tp>)
-      : __val_(in_place)
+      : __val_(in_place_t{})
   {}
 
   _CCCL_TEMPLATE(class... _Args)
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr explicit __mb_optional_destruct_base(in_place_t, _Args&&... __args) noexcept(
     is_nothrow_constructible_v<_Tp, _Args...>)
-      : __val_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __val_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 };
 
@@ -272,7 +272,7 @@ struct __mb_holder_base
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr explicit __mb_holder_base(in_place_t,
                                                 _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
-      : __holder_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __holder_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 };
 
@@ -282,14 +282,14 @@ struct __mb_holder_base<_Tp, true>
   _CCCL_NO_UNIQUE_ADDRESS __mb_holder<_Tp> __holder_;
 
   _CCCL_API constexpr __mb_holder_base() noexcept(is_nothrow_default_constructible_v<_Tp>)
-      : __holder_(in_place)
+      : __holder_(in_place_t{})
   {}
 
   _CCCL_TEMPLATE(class... _Args)
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr explicit __mb_holder_base(in_place_t,
                                                 _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
-      : __holder_(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __holder_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 };
 
@@ -396,7 +396,7 @@ struct __movable_box<_Tp, true> : __movable_box_base<_Tp>
   _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr explicit __movable_box(in_place_t,
                                              _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
-      : __base(in_place, ::cuda::std::forward<_Args>(__args)...)
+      : __base(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)
   {}
 
   _CCCL_HIDE_FROM_ABI constexpr __movable_box() noexcept(is_nothrow_default_constructible_v<_Tp>) = default;

--- a/libcudacxx/include/cuda/std/__ranges/owning_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/owning_view.h
@@ -92,63 +92,63 @@ public:
 
   [[nodiscard]] _CCCL_API constexpr iterator_t<_Rp> begin()
   {
-    return ::cuda::std::ranges::begin(__r_);
+    return ::cuda::std::ranges::__begin_cpo{}(__r_);
   }
   [[nodiscard]] _CCCL_API constexpr sentinel_t<_Rp> end()
   {
-    return ::cuda::std::ranges::end(__r_);
+    return ::cuda::std::ranges::__end_cpo{}(__r_);
   }
 
   _CCCL_TEMPLATE(class _Range = _Rp)
   _CCCL_REQUIRES(range<const _Range>)
   [[nodiscard]] _CCCL_API constexpr auto begin() const
   {
-    return ::cuda::std::ranges::begin(__r_);
+    return ::cuda::std::ranges::__begin_cpo{}(__r_);
   }
   _CCCL_TEMPLATE(class _Range = _Rp)
   _CCCL_REQUIRES(range<const _Range>)
   [[nodiscard]] _CCCL_API constexpr auto end() const
   {
-    return ::cuda::std::ranges::end(__r_);
+    return ::cuda::std::ranges::__end_cpo{}(__r_);
   }
 
   _CCCL_TEMPLATE(class _Range = _Rp)
   _CCCL_REQUIRES(invocable<::cuda::std::ranges::__empty::__fn, _Range&>)
   [[nodiscard]] _CCCL_API constexpr bool empty()
   {
-    return ::cuda::std::ranges::empty(__r_);
+    return ::cuda::std::ranges::__empty_cpo{}(__r_);
   }
   _CCCL_TEMPLATE(class _Range = _Rp)
   _CCCL_REQUIRES(invocable<::cuda::std::ranges::__empty::__fn, const _Range&>)
   [[nodiscard]] _CCCL_API constexpr bool empty() const
   {
-    return ::cuda::std::ranges::empty(__r_);
+    return ::cuda::std::ranges::__empty_cpo{}(__r_);
   }
 
   _CCCL_TEMPLATE(class _Range = _Rp)
   _CCCL_REQUIRES(sized_range<_Range>)
   [[nodiscard]] _CCCL_API constexpr auto size()
   {
-    return ::cuda::std::ranges::size(__r_);
+    return ::cuda::std::ranges::__size_cpo{}(__r_);
   }
   _CCCL_TEMPLATE(class _Range = _Rp)
   _CCCL_REQUIRES(sized_range<const _Range>)
   [[nodiscard]] _CCCL_API constexpr auto size() const
   {
-    return ::cuda::std::ranges::size(__r_);
+    return ::cuda::std::ranges::__size_cpo{}(__r_);
   }
 
   _CCCL_TEMPLATE(class _Range = _Rp)
   _CCCL_REQUIRES(contiguous_range<_Range>)
   [[nodiscard]] _CCCL_API constexpr auto data()
   {
-    return ::cuda::std::ranges::data(__r_);
+    return ::cuda::std::ranges::__data_cpo{}(__r_);
   }
   _CCCL_TEMPLATE(class _Range = _Rp)
   _CCCL_REQUIRES(contiguous_range<const _Range>)
   [[nodiscard]] _CCCL_API constexpr auto data() const
   {
-    return ::cuda::std::ranges::data(__r_);
+    return ::cuda::std::ranges::__data_cpo{}(__r_);
   }
 };
 _CCCL_CTAD_SUPPORTED_FOR_TYPE(owning_view);

--- a/libcudacxx/include/cuda/std/__ranges/rbegin.h
+++ b/libcudacxx/include/cuda/std/__ranges/rbegin.h
@@ -58,8 +58,8 @@ concept __unqualified_rbegin =
 template <class _Tp>
 concept __can_reverse =
   __can_borrow<_Tp> && !__member_rbegin<_Tp> && !__unqualified_rbegin<_Tp> && requires(_Tp&& __t) {
-    { ::cuda::std::ranges::begin(__t) } -> same_as<decltype(::cuda::std::ranges::end(__t))>;
-    { ::cuda::std::ranges::begin(__t) } -> bidirectional_iterator;
+    { ::cuda::std::ranges::__begin_cpo{}(__t) } -> same_as<decltype(::cuda::std::ranges::__end_cpo{}(__t))>;
+    { ::cuda::std::ranges::__begin_cpo{}(__t) } -> bidirectional_iterator;
   };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Tp>
@@ -90,8 +90,9 @@ _CCCL_CONCEPT_FRAGMENT(
     requires(__can_borrow<_Tp>),
     requires(!__member_rbegin<_Tp>),
     requires(!__unqualified_rbegin<_Tp>),
-    requires(same_as<decltype(::cuda::std::ranges::end(__t)), decltype(::cuda::std::ranges::begin(__t))>),
-    requires(bidirectional_iterator<decltype(::cuda::std::ranges::begin(__t))>)));
+    requires(
+      same_as<decltype(::cuda::std::ranges::__end_cpo{}(__t)), decltype(::cuda::std::ranges::__begin_cpo{}(__t))>),
+    requires(bidirectional_iterator<decltype(::cuda::std::ranges::__begin_cpo{}(__t))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __can_reverse = _CCCL_FRAGMENT(__can_reverse_, _Tp);
@@ -120,9 +121,10 @@ struct __fn
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__can_reverse<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(::cuda::std::ranges::end(__t)))
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
+    noexcept(noexcept(::cuda::std::ranges::__end_cpo{}(__t)))
   {
-    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::end(__t));
+    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::__end_cpo{}(__t));
   }
 
   _CCCL_TEMPLATE(class _Tp)
@@ -134,6 +136,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto rbegin = __rbegin::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __rbegin_cpo = __rbegin::__fn;
 } // namespace __cpo
 
 // [range.access.crbegin]
@@ -145,20 +150,20 @@ struct __fn
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_lvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::rbegin(static_cast<const remove_reference_t<_Tp>&>(__t))))
-      -> decltype(::cuda::std::ranges::rbegin(static_cast<const remove_reference_t<_Tp>&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__rbegin_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t))))
+      -> decltype(::cuda::std::ranges::__rbegin_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t)))
   {
-    return ::cuda::std::ranges::rbegin(static_cast<const remove_reference_t<_Tp>&>(__t));
+    return ::cuda::std::ranges::__rbegin_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t));
   }
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_rvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::rbegin(static_cast<const _Tp&&>(__t))))
-      -> decltype(::cuda::std::ranges::rbegin(static_cast<const _Tp&&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__rbegin_cpo{}(static_cast<const _Tp&&>(__t))))
+      -> decltype(::cuda::std::ranges::__rbegin_cpo{}(static_cast<const _Tp&&>(__t)))
   {
-    return ::cuda::std::ranges::rbegin(static_cast<const _Tp&&>(__t));
+    return ::cuda::std::ranges::__rbegin_cpo{}(static_cast<const _Tp&&>(__t));
   }
 };
 _CCCL_END_NAMESPACE_CPO
@@ -166,6 +171,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto crbegin = __crbegin::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __crbegin_cpo = __crbegin::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__ranges/ref_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/ref_view.h
@@ -79,32 +79,32 @@ public:
 
   _CCCL_API constexpr iterator_t<_Range> begin() const
   {
-    return ::cuda::std::ranges::begin(*__range_);
+    return ::cuda::std::ranges::__begin_cpo{}(*__range_);
   }
   _CCCL_API constexpr sentinel_t<_Range> end() const
   {
-    return ::cuda::std::ranges::end(*__range_);
+    return ::cuda::std::ranges::__end_cpo{}(*__range_);
   }
 
   _CCCL_TEMPLATE(class _Range2 = _Range)
   _CCCL_REQUIRES(invocable<::cuda::std::ranges::__empty::__fn, const _Range2&>)
   _CCCL_API constexpr bool empty() const
   {
-    return ::cuda::std::ranges::empty(*__range_);
+    return ::cuda::std::ranges::__empty_cpo{}(*__range_);
   }
 
   _CCCL_TEMPLATE(class _Range2 = _Range)
   _CCCL_REQUIRES(sized_range<_Range2>)
   _CCCL_API constexpr auto size() const
   {
-    return ::cuda::std::ranges::size(*__range_);
+    return ::cuda::std::ranges::__size_cpo{}(*__range_);
   }
 
   _CCCL_TEMPLATE(class _Range2 = _Range)
   _CCCL_REQUIRES(contiguous_range<_Range2>)
   _CCCL_API constexpr auto data() const
   {
-    return ::cuda::std::ranges::data(*__range_);
+    return ::cuda::std::ranges::__data_cpo{}(*__range_);
   }
 };
 

--- a/libcudacxx/include/cuda/std/__ranges/rend.h
+++ b/libcudacxx/include/cuda/std/__ranges/rend.h
@@ -47,21 +47,21 @@ void rend(const _Tp&) = delete;
 #if _CCCL_HAS_CONCEPTS()
 template <class _Tp>
 concept __member_rend = __can_borrow<_Tp> && __workaround_52970<_Tp> && requires(_Tp&& __t) {
-  ::cuda::std::ranges::rbegin(__t);
-  { _LIBCUDACXX_AUTO_CAST(__t.rend()) } -> sentinel_for<decltype(::cuda::std::ranges::rbegin(__t))>;
+  ::cuda::std::ranges::__rbegin_cpo{}(__t);
+  { _LIBCUDACXX_AUTO_CAST(__t.rend()) } -> sentinel_for<decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))>;
 };
 
 template <class _Tp>
 concept __unqualified_rend =
   !__member_rend<_Tp> && __can_borrow<_Tp> && __class_or_enum<remove_cvref_t<_Tp>> && requires(_Tp&& __t) {
-    ::cuda::std::ranges::rbegin(__t);
-    { _LIBCUDACXX_AUTO_CAST(rend(__t)) } -> sentinel_for<decltype(::cuda::std::ranges::rbegin(__t))>;
+    ::cuda::std::ranges::__rbegin_cpo{}(__t);
+    { _LIBCUDACXX_AUTO_CAST(rend(__t)) } -> sentinel_for<decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))>;
   };
 
 template <class _Tp>
 concept __can_reverse = __can_borrow<_Tp> && !__member_rend<_Tp> && !__unqualified_rend<_Tp> && requires(_Tp&& __t) {
-  { ::cuda::std::ranges::begin(__t) } -> same_as<decltype(::cuda::std::ranges::end(__t))>;
-  { ::cuda::std::ranges::begin(__t) } -> bidirectional_iterator;
+  { ::cuda::std::ranges::__begin_cpo{}(__t) } -> same_as<decltype(::cuda::std::ranges::__end_cpo{}(__t))>;
+  { ::cuda::std::ranges::__begin_cpo{}(__t) } -> bidirectional_iterator;
 };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Tp>
@@ -70,8 +70,9 @@ _CCCL_CONCEPT_FRAGMENT(
   requires(_Tp&& __t)(
     requires(__can_borrow<_Tp>),
     requires(__workaround_52970<_Tp>),
-    typename(decltype(::cuda::std::ranges::rbegin(__t))),
-    requires(sentinel_for<decltype(_LIBCUDACXX_AUTO_CAST(__t.rend())), decltype(::cuda::std::ranges::rbegin(__t))>)));
+    typename(decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))),
+    requires(
+      sentinel_for<decltype(_LIBCUDACXX_AUTO_CAST(__t.rend())), decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __member_rend = _CCCL_FRAGMENT(__member_rend_, _Tp);
@@ -83,8 +84,9 @@ _CCCL_CONCEPT_FRAGMENT(
     requires(!__member_rend<_Tp>),
     requires(__can_borrow<_Tp>),
     requires(__class_or_enum<remove_cvref_t<_Tp>>),
-    typename(decltype(::cuda::std::ranges::rbegin(__t))),
-    requires(sentinel_for<decltype(_LIBCUDACXX_AUTO_CAST(rend(__t))), decltype(::cuda::std::ranges::rbegin(__t))>)));
+    typename(decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))),
+    requires(
+      sentinel_for<decltype(_LIBCUDACXX_AUTO_CAST(rend(__t))), decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __unqualified_rend = _CCCL_FRAGMENT(__unqualified_rend_, _Tp);
@@ -96,8 +98,9 @@ _CCCL_CONCEPT_FRAGMENT(
     requires(!__member_rend<_Tp>),
     requires(!__unqualified_rend<_Tp>),
     requires(__can_borrow<_Tp>),
-    requires(same_as<decltype(::cuda::std::ranges::begin(__t)), decltype(::cuda::std::ranges::end(__t))>),
-    requires(bidirectional_iterator<decltype(::cuda::std::ranges::begin(__t))>)));
+    requires(
+      same_as<decltype(::cuda::std::ranges::__begin_cpo{}(__t)), decltype(::cuda::std::ranges::__end_cpo{}(__t))>),
+    requires(bidirectional_iterator<decltype(::cuda::std::ranges::__begin_cpo{}(__t))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __can_reverse = _CCCL_FRAGMENT(__can_reverse_, _Tp);
@@ -127,9 +130,10 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__can_reverse<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(::cuda::std::ranges::begin(__t)))
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
+    noexcept(noexcept(::cuda::std::ranges::__begin_cpo{}(__t)))
   {
-    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::begin(__t));
+    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::__begin_cpo{}(__t));
   }
 
   _CCCL_TEMPLATE(class _Tp)
@@ -141,6 +145,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto rend = __rend::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __rend_cpo = __rend::__fn;
 } // namespace __cpo
 
 // [range.access.crend]
@@ -152,20 +159,20 @@ struct __fn
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_lvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::rend(static_cast<const remove_reference_t<_Tp>&>(__t))))
-      -> decltype(::cuda::std::ranges::rend(static_cast<const remove_reference_t<_Tp>&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__rend_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t))))
+      -> decltype(::cuda::std::ranges::__rend_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t)))
   {
-    return ::cuda::std::ranges::rend(static_cast<const remove_reference_t<_Tp>&>(__t));
+    return ::cuda::std::ranges::__rend_cpo{}(static_cast<const remove_reference_t<_Tp>&>(__t));
   }
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(is_rvalue_reference_v<_Tp&&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::ranges::rend(static_cast<const _Tp&&>(__t))))
-      -> decltype(::cuda::std::ranges::rend(static_cast<const _Tp&&>(__t)))
+    noexcept(noexcept(::cuda::std::ranges::__rend_cpo{}(static_cast<const _Tp&&>(__t))))
+      -> decltype(::cuda::std::ranges::__rend_cpo{}(static_cast<const _Tp&&>(__t)))
   {
-    return ::cuda::std::ranges::rend(static_cast<const _Tp&&>(__t));
+    return ::cuda::std::ranges::__rend_cpo{}(static_cast<const _Tp&&>(__t));
   }
 };
 _CCCL_END_NAMESPACE_CPO
@@ -173,6 +180,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto crend = __crend::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __crend_cpo = __crend::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__ranges/repeat_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/repeat_view.h
@@ -238,7 +238,7 @@ public:
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
   _CCCL_REQUIRES((!same_as<_Tp2, repeat_view>) _CCCL_AND copy_constructible<_Tp2>)
   _CCCL_API constexpr explicit repeat_view(const _Tp2& __value, _Bound __bound_sentinel = _Bound())
-      : __value_(in_place, __value)
+      : __value_(in_place_t{}, __value)
       , __bound_(__bound_sentinel)
   {
     if constexpr (!same_as<_Bound, unreachable_sentinel_t> && is_signed_v<_Bound>)
@@ -248,7 +248,7 @@ public:
   }
 
   _CCCL_API constexpr explicit repeat_view(_Tp&& __value, _Bound __bound_sentinel = _Bound())
-      : __value_(in_place, ::cuda::std::move(__value))
+      : __value_(in_place_t{}, ::cuda::std::move(__value))
       , __bound_(__bound_sentinel)
   {
     if constexpr (!same_as<_Bound, unreachable_sentinel_t> && is_signed_v<_Bound>)
@@ -261,7 +261,7 @@ public:
   _CCCL_REQUIRES(constructible_from<_Tp, _TpArgs...> _CCCL_AND constructible_from<_Bound, _BoundArgs...>)
   _CCCL_API constexpr explicit repeat_view(
     piecewise_construct_t, tuple<_TpArgs...> __value_args, tuple<_BoundArgs...> __bound_args = tuple<>{})
-      : __value_(in_place, ::cuda::std::make_from_tuple<_Tp>(::cuda::std::move(__value_args)))
+      : __value_(in_place_t{}, ::cuda::std::make_from_tuple<_Tp>(::cuda::std::move(__value_args)))
       , __bound_(::cuda::std::make_from_tuple<_Bound>(::cuda::std::move(__bound_args)))
   {
     if constexpr (!same_as<_Bound, unreachable_sentinel_t> && is_signed_v<_Bound>)

--- a/libcudacxx/include/cuda/std/__ranges/reverse_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/reverse_view.h
@@ -102,8 +102,8 @@ public:
       }
     }
 
-    auto __tmp = ::cuda::std::make_reverse_iterator(
-      ::cuda::std::ranges::next(::cuda::std::ranges::begin(__base_), ::cuda::std::ranges::end(__base_)));
+    auto __tmp = ::cuda::std::make_reverse_iterator(::cuda::std::ranges::__next_cpo{}(
+      ::cuda::std::ranges::__begin_cpo{}(__base_), ::cuda::std::ranges::__end_cpo{}(__base_)));
     if constexpr (_UseCache)
     {
       __cached_begin_.__emplace(__tmp);
@@ -115,40 +115,40 @@ public:
   _CCCL_REQUIRES(common_range<_View2>)
   _CCCL_API constexpr reverse_iterator<iterator_t<_View2>> begin()
   {
-    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::end(__base_));
+    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::__end_cpo{}(__base_));
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(common_range<const _View2>)
   _CCCL_API constexpr auto begin() const
   {
-    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::end(__base_));
+    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::__end_cpo{}(__base_));
   }
 
   _CCCL_API constexpr reverse_iterator<iterator_t<_View>> end()
   {
-    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::begin(__base_));
+    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::__begin_cpo{}(__base_));
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(common_range<const _View2>)
   _CCCL_API constexpr auto end() const
   {
-    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::begin(__base_));
+    return ::cuda::std::make_reverse_iterator(::cuda::std::ranges::__begin_cpo{}(__base_));
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(sized_range<_View2>)
   _CCCL_API constexpr auto size()
   {
-    return ::cuda::std::ranges::size(__base_);
+    return ::cuda::std::ranges::__size_cpo{}(__base_);
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(sized_range<const _View2>)
   _CCCL_API constexpr auto size() const
   {
-    return ::cuda::std::ranges::size(__base_);
+    return ::cuda::std::ranges::__size_cpo{}(__base_);
   }
 };
 

--- a/libcudacxx/include/cuda/std/__ranges/single_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/single_view.h
@@ -68,12 +68,12 @@ public:
   _CCCL_REQUIRES((!is_same_v<remove_cvref_t<_Tp2>, single_view>) _CCCL_AND copy_constructible<_Tp2>)
   _CCCL_API constexpr explicit single_view(const _Tp2& __t) noexcept(is_nothrow_copy_constructible_v<_Tp2>)
       : view_interface<single_view<_Tp2>>()
-      , __value_(in_place, __t)
+      , __value_(in_place_t{}, __t)
   {}
 
   _CCCL_API constexpr explicit single_view(_Tp&& __t) noexcept(is_nothrow_move_constructible_v<_Tp>)
       : view_interface<single_view<_Tp>>()
-      , __value_(in_place, ::cuda::std::move(__t))
+      , __value_(in_place_t{}, ::cuda::std::move(__t))
   {}
 
   _CCCL_TEMPLATE(class... _Args)
@@ -81,7 +81,7 @@ public:
   _CCCL_API constexpr explicit single_view(in_place_t,
                                            _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
       : view_interface<single_view<_Tp>>()
-      , __value_{in_place, ::cuda::std::forward<_Args>(__args)...}
+      , __value_{in_place_t{}, ::cuda::std::forward<_Args>(__args)...}
   {}
 
   [[nodiscard]] _CCCL_API constexpr _Tp* begin() noexcept

--- a/libcudacxx/include/cuda/std/__ranges/size.h
+++ b/libcudacxx/include/cuda/std/__ranges/size.h
@@ -67,10 +67,10 @@ concept __unqualified_size =
 template <class _Tp>
 concept __difference =
   !__member_size<_Tp> && !__unqualified_size<_Tp> && __class_or_enum<remove_cvref_t<_Tp>> && requires(_Tp&& __t) {
-    { ::cuda::std::ranges::begin(__t) } -> forward_iterator;
+    { ::cuda::std::ranges::__begin_cpo{}(__t) } -> forward_iterator;
     {
-      ::cuda::std::ranges::end(__t)
-    } -> sized_sentinel_for<decltype(::cuda::std::ranges::begin(::cuda::std::declval<_Tp>()))>;
+      ::cuda::std::ranges::__end_cpo{}(__t)
+    } -> sized_sentinel_for<decltype(::cuda::std::ranges::__begin_cpo{}(::cuda::std::declval<_Tp>()))>;
   };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Tp>
@@ -96,12 +96,13 @@ _CCCL_CONCEPT __unqualified_size = _CCCL_FRAGMENT(__unqualified_size_, _Tp);
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(
   __difference_,
-  requires(_Tp&& __t)(requires(!__member_size<_Tp>),
-                      requires(!__unqualified_size<_Tp>),
-                      requires(__class_or_enum<remove_cvref_t<_Tp>>),
-                      requires(forward_iterator<decltype(::cuda::std::ranges::begin(__t))>),
-                      requires(sized_sentinel_for<decltype(::cuda::std::ranges::end(__t)),
-                                                  decltype(::cuda::std::ranges::begin(::cuda::std::declval<_Tp>()))>)));
+  requires(_Tp&& __t)(
+    requires(!__member_size<_Tp>),
+    requires(!__unqualified_size<_Tp>),
+    requires(__class_or_enum<remove_cvref_t<_Tp>>),
+    requires(forward_iterator<decltype(::cuda::std::ranges::__begin_cpo{}(__t))>),
+    requires(sized_sentinel_for<decltype(::cuda::std::ranges::__end_cpo{}(__t)),
+                                decltype(::cuda::std::ranges::__begin_cpo{}(::cuda::std::declval<_Tp>()))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __difference = _CCCL_FRAGMENT(__difference_, _Tp);
@@ -147,11 +148,13 @@ struct __fn
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__difference<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(::cuda::std::__to_unsigned_like(::cuda::std::ranges::end(__t) - ::cuda::std::ranges::begin(__t))))
-      -> decltype(::cuda::std::__to_unsigned_like(::cuda::std::ranges::end(__t) - ::cuda::std::ranges::begin(__t)))
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(
+    ::cuda::std::__to_unsigned_like(::cuda::std::ranges::__end_cpo{}(__t) - ::cuda::std::ranges::__begin_cpo{}(__t))))
+    -> decltype(::cuda::std::__to_unsigned_like(::cuda::std::ranges::__end_cpo{}(__t)
+                                                - ::cuda::std::ranges::__begin_cpo{}(__t)))
   {
-    return ::cuda::std::__to_unsigned_like(::cuda::std::ranges::end(__t) - ::cuda::std::ranges::begin(__t));
+    return ::cuda::std::__to_unsigned_like(
+      ::cuda::std::ranges::__end_cpo{}(__t) - ::cuda::std::ranges::__begin_cpo{}(__t));
   }
 };
 _CCCL_END_NAMESPACE_CPO
@@ -159,6 +162,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto size = __size::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __size_cpo = __size::__fn;
 } // namespace __cpo
 
 // [range.prim.ssize]
@@ -166,11 +172,12 @@ _CCCL_GLOBAL_CONSTANT auto size = __size::__fn{};
 _CCCL_BEGIN_NAMESPACE_CPO(__ssize)
 #if _CCCL_HAS_CONCEPTS()
 template <class _Tp>
-concept __can_ssize = requires(_Tp&& __t) { ::cuda::std::ranges::size(__t); };
+concept __can_ssize = requires(_Tp&& __t) { ::cuda::std::ranges::__size_cpo{}(__t); };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(
-  __can_ssize_, requires(_Tp&& __t)(requires(!is_unbounded_array_v<_Tp>), ((void) ::cuda::std::ranges::size(__t))));
+  __can_ssize_,
+  requires(_Tp&& __t)(requires(!is_unbounded_array_v<_Tp>), ((void) ::cuda::std::ranges::__size_cpo{}(__t))));
 
 template <class _Tp>
 _CCCL_CONCEPT __can_ssize = _CCCL_FRAGMENT(__can_ssize_, _Tp);
@@ -180,11 +187,12 @@ struct __fn
 {
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__can_ssize<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(::cuda::std::ranges::size(__t)))
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
+    noexcept(noexcept(::cuda::std::ranges::__size_cpo{}(__t)))
   {
-    using _Signed = make_signed_t<decltype(::cuda::std::ranges::size(__t))>;
+    using _Signed = make_signed_t<decltype(::cuda::std::ranges::__size_cpo{}(__t))>;
     using _Result = conditional_t<(sizeof(ptrdiff_t) > sizeof(_Signed)), ptrdiff_t, _Signed>;
-    return static_cast<_Result>(::cuda::std::ranges::size(__t));
+    return static_cast<_Result>(::cuda::std::ranges::__size_cpo{}(__t));
   }
 };
 _CCCL_END_NAMESPACE_CPO
@@ -192,6 +200,9 @@ _CCCL_END_NAMESPACE_CPO
 inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto ssize = __ssize::__fn{};
+
+// We want to avoid using the CPO internally because of __tile__ access
+using __ssize_cpo = __ssize::__fn;
 } // namespace __cpo
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES

--- a/libcudacxx/include/cuda/std/__ranges/subrange.h
+++ b/libcudacxx/include/cuda/std/__ranges/subrange.h
@@ -274,19 +274,19 @@ public:
   _CCCL_TEMPLATE(class _Range)
   _CCCL_REQUIRES(__subrange_from_range<_Iter, _Sent, _Kind, _Range, !_StoreSize>)
   _CCCL_API constexpr subrange(_Range&& __range)
-      : subrange(::cuda::std::ranges::begin(__range), ::cuda::std::ranges::end(__range))
+      : subrange(::cuda::std::ranges::__begin_cpo{}(__range), ::cuda::std::ranges::__end_cpo{}(__range))
   {}
 
   _CCCL_TEMPLATE(class _Range)
   _CCCL_REQUIRES(__subrange_from_range<_Iter, _Sent, _Kind, _Range, _StoreSize>)
   _CCCL_API constexpr subrange(_Range&& __range)
-      : subrange(__range, ::cuda::std::ranges::size(__range))
+      : subrange(__range, ::cuda::std::ranges::__size_cpo{}(__range))
   {}
 
   _CCCL_TEMPLATE(class _Range)
   _CCCL_REQUIRES(__subrange_from_range_size<_Iter, _Sent, _Kind, _Range>)
   _CCCL_API constexpr subrange(_Range&& __range, make_unsigned_t<iter_difference_t<_Iter>> __n)
-      : subrange(::cuda::std::ranges::begin(__range), ::cuda::std::ranges::end(__range), __n)
+      : subrange(::cuda::std::ranges::__begin_cpo{}(__range), ::cuda::std::ranges::__end_cpo{}(__range), __n)
   {}
 
   // This often ICEs all of clang and old gcc when it encounteres a rvalue subrange in a pipe
@@ -367,7 +367,7 @@ public:
     {
       if (__n < 0)
       {
-        ::cuda::std::ranges::advance(__begin_, __n);
+        ::cuda::std::ranges::__advance_cpo{}(__begin_, __n);
         if constexpr (_StoreSize)
         {
           __size_ += ::cuda::std::__to_unsigned_like(-__n);
@@ -376,7 +376,7 @@ public:
       }
     }
 
-    [[maybe_unused]] const auto __d = __n - ::cuda::std::ranges::advance(__begin_, __n, __end_);
+    [[maybe_unused]] const auto __d = __n - ::cuda::std::ranges::__advance_cpo{}(__begin_, __n, __end_);
     if constexpr (_StoreSize)
     {
       __size_ -= ::cuda::std::__to_unsigned_like(__d);

--- a/libcudacxx/include/cuda/std/__ranges/take_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/take_view.h
@@ -179,18 +179,18 @@ public:
     {
       if constexpr (random_access_range<_View>)
       {
-        return ::cuda::std::ranges::begin(__base_);
+        return ::cuda::std::ranges::__begin_cpo{}(__base_);
       }
       else
       {
         using _DifferenceT = range_difference_t<_View>;
         auto __size        = size();
-        return counted_iterator(::cuda::std::ranges::begin(__base_), static_cast<_DifferenceT>(__size));
+        return counted_iterator(::cuda::std::ranges::__begin_cpo{}(__base_), static_cast<_DifferenceT>(__size));
       }
     }
     else
     {
-      return counted_iterator(::cuda::std::ranges::begin(__base_), __count_);
+      return counted_iterator(::cuda::std::ranges::__begin_cpo{}(__base_), __count_);
     }
   }
 
@@ -202,18 +202,18 @@ public:
     {
       if constexpr (random_access_range<const _View>)
       {
-        return ::cuda::std::ranges::begin(__base_);
+        return ::cuda::std::ranges::__begin_cpo{}(__base_);
       }
       else
       {
         using _DifferenceT = range_difference_t<const _View>;
         auto __size        = size();
-        return counted_iterator(::cuda::std::ranges::begin(__base_), static_cast<_DifferenceT>(__size));
+        return counted_iterator(::cuda::std::ranges::__begin_cpo{}(__base_), static_cast<_DifferenceT>(__size));
       }
     }
     else
     {
-      return counted_iterator(::cuda::std::ranges::begin(__base_), __count_);
+      return counted_iterator(::cuda::std::ranges::__begin_cpo{}(__base_), __count_);
     }
   }
 
@@ -225,7 +225,7 @@ public:
     {
       if constexpr (random_access_range<_View>)
       {
-        return ::cuda::std::ranges::begin(__base_) + size();
+        return ::cuda::std::ranges::__begin_cpo{}(__base_) + size();
       }
       else
       {
@@ -234,7 +234,7 @@ public:
     }
     else
     {
-      return __sentinel<false>{::cuda::std::ranges::end(__base_)};
+      return __sentinel<false>{::cuda::std::ranges::__end_cpo{}(__base_)};
     }
   }
 
@@ -246,7 +246,7 @@ public:
     {
       if constexpr (random_access_range<const _View>)
       {
-        return ::cuda::std::ranges::begin(__base_) + size();
+        return ::cuda::std::ranges::__begin_cpo{}(__base_) + size();
       }
       else
       {
@@ -255,7 +255,7 @@ public:
     }
     else
     {
-      return __sentinel<true>{::cuda::std::ranges::end(__base_)};
+      return __sentinel<true>{::cuda::std::ranges::__end_cpo{}(__base_)};
     }
   }
 
@@ -263,7 +263,7 @@ public:
   _CCCL_REQUIRES(sized_range<_View2>)
   [[nodiscard]] _CCCL_API constexpr auto size()
   {
-    const auto __n = ::cuda::std::ranges::size(__base_);
+    const auto __n = ::cuda::std::ranges::__size_cpo{}(__base_);
     return (::cuda::std::ranges::min) (__n, static_cast<decltype(__n)>(__count_));
   }
 
@@ -271,7 +271,7 @@ public:
   _CCCL_REQUIRES(sized_range<const _View2>)
   [[nodiscard]] _CCCL_API constexpr auto size() const
   {
-    auto __n = ::cuda::std::ranges::size(__base_);
+    auto __n = ::cuda::std::ranges::__size_cpo{}(__base_);
     return (::cuda::std::ranges::min) (__n, static_cast<decltype(__n)>(__count_));
   }
 };
@@ -381,15 +381,15 @@ struct __fn
   _CCCL_REQUIRES(__use_passthrough<_Range, _Np>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Range&& __rng, _Np&& __n) const
     noexcept(noexcept(__passthrough_type_t<_RawRange>(
-      ::cuda::std::ranges::begin(__rng),
-      ::cuda::std::ranges::begin(__rng)
-        + ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__rng), ::cuda::std::forward<_Np>(__n)))))
+      ::cuda::std::ranges::__begin_cpo{}(__rng),
+      ::cuda::std::ranges::__begin_cpo{}(__rng)
+        + ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__rng), ::cuda::std::forward<_Np>(__n)))))
       -> __passthrough_type_t<_RawRange>
   {
     return __passthrough_type_t<_RawRange>(
-      ::cuda::std::ranges::begin(__rng),
-      ::cuda::std::ranges::begin(__rng)
-        + ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__rng), ::cuda::std::forward<_Np>(__n)));
+      ::cuda::std::ranges::__begin_cpo{}(__rng),
+      ::cuda::std::ranges::__begin_cpo{}(__rng)
+        + ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__rng), ::cuda::std::forward<_Np>(__n)));
   }
 
   // [range.take.overview]: the `repeat_view` "_RawRange models sized_range" case.
@@ -399,10 +399,12 @@ struct __fn
                    __is_repeat_specialization<_RawRange> _CCCL_AND sized_range<_RawRange>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Range&& __range, _Np&& __n) const noexcept(noexcept(views::repeat(
     ::cuda::std::forward_like<_Range>(*__range.__value_),
-    ::cuda::std::min<_Dist>(ranges::distance(__range), ::cuda::std::forward<_Np>(__n))))) -> _RawRange
+    ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__range), ::cuda::std::forward<_Np>(__n)))))
+    -> _RawRange
   {
-    return views::repeat(::cuda::std::forward_like<_Range>(*__range.__value_),
-                         ::cuda::std::min<_Dist>(ranges::distance(__range), ::cuda::std::forward<_Np>(__n)));
+    return views::repeat(
+      ::cuda::std::forward_like<_Range>(*__range.__value_),
+      ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__range), ::cuda::std::forward<_Np>(__n)));
   }
 
   // [range.take.overview]: the `repeat_view` "otherwise" case.
@@ -423,15 +425,15 @@ struct __fn
   _CCCL_REQUIRES(__use_iota<_Range, _Np>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Range&& __rng, _Np&& __n) const
     noexcept(noexcept(::cuda::std::ranges::iota_view(
-      *::cuda::std::ranges::begin(__rng),
-      *::cuda::std::ranges::begin(__rng)
-        + ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__rng), ::cuda::std::forward<_Np>(__n)))))
+      *::cuda::std::ranges::__begin_cpo{}(__rng),
+      *::cuda::std::ranges::__begin_cpo{}(__rng)
+        + ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__rng), ::cuda::std::forward<_Np>(__n)))))
       -> iota_view<range_value_t<_RawRange>, _Dist>
   {
     return ::cuda::std::ranges::iota_view(
-      *::cuda::std::ranges::begin(__rng),
-      *::cuda::std::ranges::begin(__rng)
-        + ::cuda::std::min<_Dist>(::cuda::std::ranges::distance(__rng), ::cuda::std::forward<_Np>(__n)));
+      *::cuda::std::ranges::__begin_cpo{}(__rng),
+      *::cuda::std::ranges::__begin_cpo{}(__rng)
+        + ::cuda::std::min<_Dist>(::cuda::std::ranges::__distance_cpo{}(__rng), ::cuda::std::forward<_Np>(__n)));
   }
 
   // [range.take.overview]: the "otherwise" case.

--- a/libcudacxx/include/cuda/std/__ranges/take_while_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/take_while_view.h
@@ -164,7 +164,7 @@ public:
 
   _CCCL_API constexpr take_while_view(_View __base, _Pred __pred)
       : view_interface<take_while_view<_View, _Pred>>()
-      , __pred_(::cuda::std::in_place, ::cuda::std::move(__pred))
+      , __pred_(in_place_t{}, ::cuda::std::move(__pred))
       , __base_(::cuda::std::move(__base))
   {}
 

--- a/libcudacxx/include/cuda/std/__ranges/take_while_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/take_while_view.h
@@ -189,28 +189,28 @@ public:
   _CCCL_REQUIRES((!__simple_view<_View2>) )
   [[nodiscard]] _CCCL_API constexpr auto begin()
   {
-    return ::cuda::std::ranges::begin(__base_);
+    return ::cuda::std::ranges::__begin_cpo{}(__base_);
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(__take_while_const_is_range<_View2, _Pred>)
   [[nodiscard]] _CCCL_API constexpr auto begin() const
   {
-    return ::cuda::std::ranges::begin(__base_);
+    return ::cuda::std::ranges::__begin_cpo{}(__base_);
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES((!__simple_view<_View2>) )
   [[nodiscard]] _CCCL_API constexpr auto end()
   {
-    return __sentinel</*_Const=*/false>(::cuda::std::ranges::end(__base_), ::cuda::std::addressof(*__pred_));
+    return __sentinel</*_Const=*/false>(::cuda::std::ranges::__end_cpo{}(__base_), ::cuda::std::addressof(*__pred_));
   }
 
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(__take_while_const_is_range<_View2, _Pred>)
   [[nodiscard]] _CCCL_API constexpr auto end() const
   {
-    return __sentinel</*_Const=*/true>(::cuda::std::ranges::end(__base_), ::cuda::std::addressof(*__pred_));
+    return __sentinel</*_Const=*/true>(::cuda::std::ranges::__end_cpo{}(__base_), ::cuda::std::addressof(*__pred_));
   }
 };
 

--- a/libcudacxx/include/cuda/std/__ranges/transform_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/transform_view.h
@@ -413,7 +413,7 @@ public:
   _CCCL_API constexpr transform_view(_View __base, _Fn __func)
       : view_interface<transform_view<_View, _Fn>>()
       , __base_(::cuda::std::move(__base))
-      , __func_(::cuda::std::in_place, ::cuda::std::move(__func))
+      , __func_(in_place_t{}, ::cuda::std::move(__func))
   {}
 
   _CCCL_TEMPLATE(class _View2 = _View)

--- a/libcudacxx/include/cuda/std/__ranges/transform_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/transform_view.h
@@ -429,24 +429,24 @@ public:
 
   [[nodiscard]] _CCCL_API constexpr __iterator<false> begin()
   {
-    return __iterator<false>{*this, ::cuda::std::ranges::begin(__base_)};
+    return __iterator<false>{*this, ::cuda::std::ranges::__begin_cpo{}(__base_)};
   }
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(range<const _View2> _CCCL_AND __regular_invocable_with_range_ref<const _Fn&, const _View2>)
   [[nodiscard]] _CCCL_API constexpr __iterator<true> begin() const
   {
-    return __iterator<true>(*this, ::cuda::std::ranges::begin(__base_));
+    return __iterator<true>(*this, ::cuda::std::ranges::__begin_cpo{}(__base_));
   }
 
   [[nodiscard]] _CCCL_API constexpr auto end()
   {
     if constexpr (common_range<_View>)
     {
-      return __iterator<false>(*this, ::cuda::std::ranges::end(__base_));
+      return __iterator<false>(*this, ::cuda::std::ranges::__end_cpo{}(__base_));
     }
     else
     {
-      return __sentinel<false>(::cuda::std::ranges::end(__base_));
+      return __sentinel<false>(::cuda::std::ranges::__end_cpo{}(__base_));
     }
   }
 
@@ -456,11 +456,11 @@ public:
   {
     if constexpr (common_range<const _View>)
     {
-      return __iterator<true>(*this, ::cuda::std::ranges::end(__base_));
+      return __iterator<true>(*this, ::cuda::std::ranges::__end_cpo{}(__base_));
     }
     else
     {
-      return __sentinel<true>(::cuda::std::ranges::end(__base_));
+      return __sentinel<true>(::cuda::std::ranges::__end_cpo{}(__base_));
     }
   }
 
@@ -468,13 +468,13 @@ public:
   _CCCL_REQUIRES(sized_range<_View2>)
   [[nodiscard]] _CCCL_API constexpr auto size()
   {
-    return ::cuda::std::ranges::size(__base_);
+    return ::cuda::std::ranges::__size_cpo{}(__base_);
   }
   _CCCL_TEMPLATE(class _View2 = _View)
   _CCCL_REQUIRES(sized_range<const _View2>)
   [[nodiscard]] _CCCL_API constexpr auto size() const
   {
-    return ::cuda::std::ranges::size(__base_);
+    return ::cuda::std::ranges::__size_cpo{}(__base_);
   }
 };
 

--- a/libcudacxx/include/cuda/std/__ranges/unwrap_end.h
+++ b/libcudacxx/include/cuda/std/__ranges/unwrap_end.h
@@ -35,12 +35,12 @@ _CCCL_REQUIRES(forward_range<_Range>)
 {
   if constexpr (common_range<_Range>)
   {
-    return ::cuda::std::ranges::end(__range);
+    return ::cuda::std::ranges::__end_cpo{}(__range);
   }
   else
   {
-    auto __ret = ::cuda::std::ranges::begin(__range);
-    ::cuda::std::ranges::advance(__ret, ::cuda::std::ranges::end(__range));
+    auto __ret = ::cuda::std::ranges::__begin_cpo{}(__range);
+    ::cuda::std::ranges::__advance_cpo{}(__ret, ::cuda::std::ranges::__end_cpo{}(__range));
     return __ret;
   }
 }

--- a/libcudacxx/include/cuda/std/__ranges/view_interface.h
+++ b/libcudacxx/include/cuda/std/__ranges/view_interface.h
@@ -41,10 +41,10 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 
 #if _CCCL_HAS_CONCEPTS()
 template <class _Tp>
-concept __can_empty = requires(_Tp& __t) { ::cuda::std::ranges::empty(__t); };
+concept __can_empty = requires(_Tp& __t) { ::cuda::std::ranges::__empty_cpo{}(__t); };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Tp>
-_CCCL_CONCEPT_FRAGMENT(__can_empty_, requires(_Tp& __t)(typename(decltype(::cuda::std::ranges::empty(__t)))));
+_CCCL_CONCEPT_FRAGMENT(__can_empty_, requires(_Tp& __t)(typename(decltype(::cuda::std::ranges::__empty_cpo{}(__t)))));
 
 template <class _Tp>
 _CCCL_CONCEPT __can_empty = _CCCL_FRAGMENT(__can_empty_, _Tp);
@@ -75,42 +75,42 @@ public:
   _CCCL_REQUIRES(forward_range<_D2>)
   [[nodiscard]] _CCCL_API constexpr bool empty()
   {
-    return ::cuda::std::ranges::begin(__derived()) == ::cuda::std::ranges::end(__derived());
+    return ::cuda::std::ranges::__begin_cpo{}(__derived()) == ::cuda::std::ranges::__end_cpo{}(__derived());
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
   _CCCL_REQUIRES(forward_range<const _D2>)
   [[nodiscard]] _CCCL_API constexpr bool empty() const
   {
-    return ::cuda::std::ranges::begin(__derived()) == ::cuda::std::ranges::end(__derived());
+    return ::cuda::std::ranges::__begin_cpo{}(__derived()) == ::cuda::std::ranges::__end_cpo{}(__derived());
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
   _CCCL_REQUIRES(__can_empty<_D2>)
   _CCCL_API constexpr explicit operator bool()
   {
-    return !::cuda::std::ranges::empty(__derived());
+    return !::cuda::std::ranges::__empty_cpo{}(__derived());
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
   _CCCL_REQUIRES(__can_empty<const _D2>)
   _CCCL_API constexpr explicit operator bool() const
   {
-    return !::cuda::std::ranges::empty(__derived());
+    return !::cuda::std::ranges::__empty_cpo{}(__derived());
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
   _CCCL_REQUIRES(contiguous_iterator<iterator_t<_D2>>)
   _CCCL_API constexpr auto data()
   {
-    return ::cuda::std::to_address(::cuda::std::ranges::begin(__derived()));
+    return ::cuda::std::to_address(::cuda::std::ranges::__begin_cpo{}(__derived()));
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
   _CCCL_REQUIRES(range<const _D2> _CCCL_AND contiguous_iterator<iterator_t<const _D2>>)
   _CCCL_API constexpr auto data() const
   {
-    return ::cuda::std::to_address(::cuda::std::ranges::begin(__derived()));
+    return ::cuda::std::to_address(::cuda::std::ranges::__begin_cpo{}(__derived()));
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
@@ -118,7 +118,7 @@ public:
   _CCCL_API constexpr auto size()
   {
     return ::cuda::std::__to_unsigned_like(
-      ::cuda::std::ranges::end(__derived()) - ::cuda::std::ranges::begin(__derived()));
+      ::cuda::std::ranges::__end_cpo{}(__derived()) - ::cuda::std::ranges::__begin_cpo{}(__derived()));
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
@@ -126,7 +126,7 @@ public:
   _CCCL_API constexpr auto size() const
   {
     return ::cuda::std::__to_unsigned_like(
-      ::cuda::std::ranges::end(__derived()) - ::cuda::std::ranges::begin(__derived()));
+      ::cuda::std::ranges::__end_cpo{}(__derived()) - ::cuda::std::ranges::__begin_cpo{}(__derived()));
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
@@ -134,7 +134,7 @@ public:
   _CCCL_API constexpr decltype(auto) front()
   {
     _CCCL_ASSERT(!empty(), "Precondition `!empty()` not satisfied. `.front()` called on an empty view.");
-    return *::cuda::std::ranges::begin(__derived());
+    return *::cuda::std::ranges::__begin_cpo{}(__derived());
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
@@ -142,7 +142,7 @@ public:
   _CCCL_API constexpr decltype(auto) front() const
   {
     _CCCL_ASSERT(!empty(), "Precondition `!empty()` not satisfied. `.front()` called on an empty view.");
-    return *::cuda::std::ranges::begin(__derived());
+    return *::cuda::std::ranges::__begin_cpo{}(__derived());
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
@@ -150,7 +150,7 @@ public:
   _CCCL_API constexpr decltype(auto) back()
   {
     _CCCL_ASSERT(!empty(), "Precondition `!empty()` not satisfied. `.back()` called on an empty view.");
-    return *::cuda::std::ranges::prev(::cuda::std::ranges::end(__derived()));
+    return *::cuda::std::ranges::__prev_cpo{}(::cuda::std::ranges::__end_cpo{}(__derived()));
   }
 
   _CCCL_TEMPLATE(class _D2 = _Derived)
@@ -158,21 +158,21 @@ public:
   _CCCL_API constexpr decltype(auto) back() const
   {
     _CCCL_ASSERT(!empty(), "Precondition `!empty()` not satisfied. `.back()` called on an empty view.");
-    return *::cuda::std::ranges::prev(::cuda::std::ranges::end(__derived()));
+    return *::cuda::std::ranges::__prev_cpo{}(::cuda::std::ranges::__end_cpo{}(__derived()));
   }
 
   _CCCL_TEMPLATE(class _RARange = _Derived)
   _CCCL_REQUIRES(random_access_range<_RARange>)
   _CCCL_API constexpr decltype(auto) operator[](range_difference_t<_RARange> __index)
   {
-    return ::cuda::std::ranges::begin(__derived())[__index];
+    return ::cuda::std::ranges::__begin_cpo{}(__derived())[__index];
   }
 
   _CCCL_TEMPLATE(class _RARange = const _Derived)
   _CCCL_REQUIRES(random_access_range<_RARange>)
   _CCCL_API constexpr decltype(auto) operator[](range_difference_t<_RARange> __index) const
   {
-    return ::cuda::std::ranges::begin(__derived())[__index];
+    return ::cuda::std::ranges::__begin_cpo{}(__derived())[__index];
   }
 };
 

--- a/libcudacxx/include/cuda/std/__simd/basic_mask.h
+++ b/libcudacxx/include/cuda/std/__simd/basic_mask.h
@@ -84,7 +84,7 @@ class basic_mask<_Bytes, _Abi, enable_if_t<__is_vectorizable_byte_size_v<_Bytes>
   {};
   static constexpr __storage_tag_t __storage_tag{};
 
-  _CCCL_API constexpr basic_mask(const _Storage __v, __storage_tag_t) noexcept
+  _CCCL_HOST_DEVICE_API constexpr basic_mask(const _Storage __v, __storage_tag_t) noexcept
       : __s_{__v}
   {}
 
@@ -95,27 +95,27 @@ public:
   using iterator       = __simd_iterator<basic_mask>;
   using const_iterator = __simd_iterator<const basic_mask>;
 
-  [[nodiscard]] _CCCL_API constexpr iterator begin() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr iterator begin() noexcept
   {
     return {*this, 0};
   }
 
-  [[nodiscard]] _CCCL_API constexpr const_iterator begin() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr const_iterator begin() const noexcept
   {
     return {*this, 0};
   }
 
-  [[nodiscard]] _CCCL_API constexpr const_iterator cbegin() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr const_iterator cbegin() const noexcept
   {
     return {*this, 0};
   }
 
-  [[nodiscard]] _CCCL_API constexpr default_sentinel_t end() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr default_sentinel_t end() const noexcept
   {
     return {};
   }
 
-  [[nodiscard]] _CCCL_API constexpr default_sentinel_t cend() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr default_sentinel_t cend() const noexcept
   {
     return {};
   }
@@ -131,13 +131,13 @@ public:
 
   _CCCL_TEMPLATE(typename _Up)
   _CCCL_REQUIRES(same_as<_Up, value_type>)
-  _CCCL_API constexpr explicit basic_mask(const _Up __v) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit basic_mask(const _Up __v) noexcept
       : __s_{_Impl::__broadcast(__v)}
   {}
 
   _CCCL_TEMPLATE(size_t _UBytes, typename _UAbi)
   _CCCL_REQUIRES((__simd_size_v<__integer_from<_UBytes>, _UAbi> == __size))
-  _CCCL_API constexpr explicit basic_mask(const basic_mask<_UBytes, _UAbi>& __x) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit basic_mask(const basic_mask<_UBytes, _UAbi>& __x) noexcept
   {
     _CCCL_PRAGMA_UNROLL_FULL()
     for (__simd_size_type __i = 0; __i < __size; ++__i)
@@ -148,13 +148,13 @@ public:
 
   _CCCL_TEMPLATE(typename _Generator)
   _CCCL_REQUIRES(__can_generate_v<bool, _Generator, __size>)
-  _CCCL_API constexpr explicit basic_mask(_Generator&& __g)
+  _CCCL_HOST_DEVICE_API constexpr explicit basic_mask(_Generator&& __g)
       : __s_{_Impl::__generate(__g)}
   {}
 
   _CCCL_TEMPLATE(typename _Tp)
   _CCCL_REQUIRES(same_as<_Tp, bitset<__usize>>)
-  _CCCL_API constexpr basic_mask(const _Tp& __b) noexcept
+  _CCCL_HOST_DEVICE_API constexpr basic_mask(const _Tp& __b) noexcept
       : __s_{_Impl::__broadcast(false)}
   {
     _CCCL_PRAGMA_UNROLL_FULL()
@@ -166,7 +166,7 @@ public:
 
   _CCCL_TEMPLATE(typename _Tp)
   _CCCL_REQUIRES(is_integral_v<_Tp> _CCCL_AND is_unsigned_v<_Tp> _CCCL_AND(!is_same_v<_Tp, value_type>))
-  _CCCL_API constexpr explicit basic_mask(const _Tp __val) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit basic_mask(const _Tp __val) noexcept
       : __s_{_Impl::__broadcast(false)}
   {
     constexpr auto __num_bits = __simd_size_type{__num_bits_v<_Tp>};
@@ -180,7 +180,7 @@ public:
 
   // [simd.mask.subscr], basic_mask subscript operators
 
-  [[nodiscard]] _CCCL_API constexpr value_type operator[](const __simd_size_type __i) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr value_type operator[](const __simd_size_type __i) const noexcept
   {
     _CCCL_ASSERT(::cuda::in_range(__i, __simd_size_type{0}, __size), "Index is out of bounds");
     return static_cast<bool>(__s_.__get(__i));
@@ -192,24 +192,24 @@ public:
 
   // [simd.mask.unary], basic_mask unary operators
 
-  [[nodiscard]] _CCCL_API constexpr basic_mask operator!() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr basic_mask operator!() const noexcept
   {
     return {_Impl::__bitwise_not(__s_), __storage_tag};
   }
 
   using __unary_return_t = basic_vec<__integer_from<_Bytes>, _Abi>;
 
-  [[nodiscard]] _CCCL_API constexpr __unary_return_t operator+() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __unary_return_t operator+() const noexcept
   {
     return static_cast<__unary_return_t>(*this);
   }
 
-  [[nodiscard]] _CCCL_API constexpr __unary_return_t operator-() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __unary_return_t operator-() const noexcept
   {
     return -static_cast<__unary_return_t>(*this);
   }
 
-  [[nodiscard]] _CCCL_API constexpr __unary_return_t operator~() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __unary_return_t operator~() const noexcept
   {
     return ~static_cast<__unary_return_t>(*this);
   }
@@ -218,7 +218,7 @@ public:
 
   _CCCL_TEMPLATE(typename _Up, typename _Ap)
   _CCCL_REQUIRES((sizeof(_Up) != _Bytes && __simd_size_v<_Up, _Ap> == __size))
-  _CCCL_API constexpr explicit operator basic_vec<_Up, _Ap>() const noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit operator basic_vec<_Up, _Ap>() const noexcept
   {
     basic_vec<_Up, _Ap> __result{};
     _CCCL_PRAGMA_UNROLL_FULL()
@@ -231,7 +231,7 @@ public:
 
   _CCCL_TEMPLATE(typename _Up, typename _Ap)
   _CCCL_REQUIRES((sizeof(_Up) == _Bytes && __simd_size_v<_Up, _Ap> == __size))
-  _CCCL_API constexpr operator basic_vec<_Up, _Ap>() const noexcept
+  _CCCL_HOST_DEVICE_API constexpr operator basic_vec<_Up, _Ap>() const noexcept
   {
     basic_vec<_Up, _Ap> __result{};
     _CCCL_PRAGMA_UNROLL_FULL()
@@ -242,7 +242,7 @@ public:
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API constexpr bitset<__usize> to_bitset() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr bitset<__usize> to_bitset() const noexcept
   {
     bitset<__usize> __result{};
     _CCCL_PRAGMA_UNROLL_FULL()
@@ -253,7 +253,7 @@ public:
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API constexpr unsigned long long to_ullong() const
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr unsigned long long to_ullong() const
   {
     constexpr __simd_size_type __nbits = __num_bits_v<unsigned long long>;
     if constexpr (__size > __nbits)
@@ -268,31 +268,31 @@ public:
 
   // [simd.mask.binary], basic_mask binary operators
 
-  [[nodiscard]] _CCCL_API friend constexpr basic_mask
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_mask
   operator&&(const basic_mask& __lhs, const basic_mask& __rhs) noexcept
   {
     return {_Impl::__logic_and(__lhs.__s_, __rhs.__s_), __storage_tag};
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr basic_mask
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_mask
   operator||(const basic_mask& __lhs, const basic_mask& __rhs) noexcept
   {
     return {_Impl::__logic_or(__lhs.__s_, __rhs.__s_), __storage_tag};
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr basic_mask
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_mask
   operator&(const basic_mask& __lhs, const basic_mask& __rhs) noexcept
   {
     return {_Impl::__bitwise_and(__lhs.__s_, __rhs.__s_), __storage_tag};
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr basic_mask
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_mask
   operator|(const basic_mask& __lhs, const basic_mask& __rhs) noexcept
   {
     return {_Impl::__bitwise_or(__lhs.__s_, __rhs.__s_), __storage_tag};
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr basic_mask
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_mask
   operator^(const basic_mask& __lhs, const basic_mask& __rhs) noexcept
   {
     return {_Impl::__bitwise_xor(__lhs.__s_, __rhs.__s_), __storage_tag};
@@ -300,54 +300,54 @@ public:
 
   // [simd.mask.cassign], basic_mask compound assignment
 
-  _CCCL_API friend constexpr basic_mask& operator&=(basic_mask& __lhs, const basic_mask& __rhs) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr basic_mask& operator&=(basic_mask& __lhs, const basic_mask& __rhs) noexcept
   {
     return __lhs = __lhs & __rhs;
   }
 
-  _CCCL_API friend constexpr basic_mask& operator|=(basic_mask& __lhs, const basic_mask& __rhs) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr basic_mask& operator|=(basic_mask& __lhs, const basic_mask& __rhs) noexcept
   {
     return __lhs = __lhs | __rhs;
   }
 
-  _CCCL_API friend constexpr basic_mask& operator^=(basic_mask& __lhs, const basic_mask& __rhs) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr basic_mask& operator^=(basic_mask& __lhs, const basic_mask& __rhs) noexcept
   {
     return __lhs = __lhs ^ __rhs;
   }
 
   // [simd.mask.comparison], basic_mask comparisons (element-wise)
 
-  [[nodiscard]] _CCCL_API friend constexpr basic_mask
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_mask
   operator==(const basic_mask& __lhs, const basic_mask& __rhs) noexcept
   {
     return !(__lhs ^ __rhs);
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr basic_mask
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_mask
   operator!=(const basic_mask& __lhs, const basic_mask& __rhs) noexcept
   {
     return __lhs ^ __rhs;
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr basic_mask
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_mask
   operator>=(const basic_mask& __lhs, const basic_mask& __rhs) noexcept
   {
     return __lhs || !__rhs;
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr basic_mask
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_mask
   operator<=(const basic_mask& __lhs, const basic_mask& __rhs) noexcept
   {
     return !__lhs || __rhs;
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr basic_mask
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_mask
   operator>(const basic_mask& __lhs, const basic_mask& __rhs) noexcept
   {
     return __lhs && !__rhs;
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr basic_mask
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_mask
   operator<(const basic_mask& __lhs, const basic_mask& __rhs) noexcept
   {
     return !__lhs && __rhs;

--- a/libcudacxx/include/cuda/std/__simd/basic_vec.h
+++ b/libcudacxx/include/cuda/std/__simd/basic_vec.h
@@ -82,19 +82,19 @@ private:
   {};
   static constexpr __storage_tag_t __storage_tag{};
 
-  _CCCL_API constexpr basic_vec(const _Storage __s, __storage_tag_t) noexcept
+  _CCCL_HOST_DEVICE_API constexpr basic_vec(const _Storage __s, __storage_tag_t) noexcept
       : __s_{__s}
   {}
 
   // Friend comparison operators (e.g. operator==) cannot access basic_mask's private constructor directly (friendship
   // is not transitive). This function is required to access the private constructor of basic_mask.
-  _CCCL_API static constexpr mask_type __make_mask(const typename mask_type::_Storage __s) noexcept
+  _CCCL_HOST_DEVICE_API static constexpr mask_type __make_mask(const typename mask_type::_Storage __s) noexcept
   {
     return mask_type{__s, mask_type::__storage_tag};
   }
 
   // operator[] is const only. We need this function to set values
-  _CCCL_API constexpr void __set(const __simd_size_type __i, const value_type __v) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void __set(const __simd_size_type __i, const value_type __v) noexcept
   {
     __s_.__set(__i, __v);
   }
@@ -105,27 +105,27 @@ public:
   using iterator       = __simd_iterator<basic_vec>;
   using const_iterator = __simd_iterator<const basic_vec>;
 
-  [[nodiscard]] _CCCL_API constexpr iterator begin() noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr iterator begin() noexcept
   {
     return {*this, 0};
   }
 
-  [[nodiscard]] _CCCL_API constexpr const_iterator begin() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr const_iterator begin() const noexcept
   {
     return {*this, 0};
   }
 
-  [[nodiscard]] _CCCL_API constexpr const_iterator cbegin() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr const_iterator cbegin() const noexcept
   {
     return {*this, 0};
   }
 
-  [[nodiscard]] _CCCL_API constexpr default_sentinel_t end() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr default_sentinel_t end() const noexcept
   {
     return {};
   }
 
-  [[nodiscard]] _CCCL_API constexpr default_sentinel_t cend() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr default_sentinel_t cend() const noexcept
   {
     return {};
   }
@@ -142,14 +142,14 @@ public:
   // [simd.ctor] value broadcast constructor (explicit overload)
   _CCCL_TEMPLATE(typename _Up)
   _CCCL_REQUIRES((__explicitly_convertible_to<_Up, value_type>) _CCCL_AND(!__is_value_ctor_implicit<_Up, value_type>))
-  _CCCL_API constexpr explicit basic_vec(_Up&& __v) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit basic_vec(_Up&& __v) noexcept
       : __s_{_Impl::__broadcast(static_cast<value_type>(__v))}
   {}
 
   // [simd.ctor] value broadcast constructor (implicit overload)
   _CCCL_TEMPLATE(typename _Up)
   _CCCL_REQUIRES((__explicitly_convertible_to<_Up, value_type>) _CCCL_AND(__is_value_ctor_implicit<_Up, value_type>))
-  _CCCL_API constexpr basic_vec(_Up&& __v) noexcept
+  _CCCL_HOST_DEVICE_API constexpr basic_vec(_Up&& __v) noexcept
       : __s_{_Impl::__broadcast(static_cast<value_type>(__v))}
   {}
 
@@ -157,7 +157,7 @@ public:
   _CCCL_TEMPLATE(typename _Up, typename _UAbi)
   _CCCL_REQUIRES((__simd_size_v<_Up, _UAbi> == __size) _CCCL_AND(__explicitly_convertible_to<_Up, value_type>)
                    _CCCL_AND(__is_vec_ctor_explicit<_Up, value_type>))
-  _CCCL_API constexpr explicit basic_vec(const basic_vec<_Up, _UAbi>& __v) noexcept
+  _CCCL_HOST_DEVICE_API constexpr explicit basic_vec(const basic_vec<_Up, _UAbi>& __v) noexcept
   {
     _CCCL_PRAGMA_UNROLL_FULL()
     for (__simd_size_type __i = 0; __i < __size; ++__i)
@@ -170,7 +170,7 @@ public:
   _CCCL_TEMPLATE(typename _Up, typename _UAbi)
   _CCCL_REQUIRES((__simd_size_v<_Up, _UAbi> == __size) _CCCL_AND(__explicitly_convertible_to<_Up, value_type>)
                    _CCCL_AND(!__is_vec_ctor_explicit<_Up, value_type>))
-  _CCCL_API constexpr basic_vec(const basic_vec<_Up, _UAbi>& __v) noexcept
+  _CCCL_HOST_DEVICE_API constexpr basic_vec(const basic_vec<_Up, _UAbi>& __v) noexcept
   {
     _CCCL_PRAGMA_UNROLL_FULL()
     for (__simd_size_type __i = 0; __i < __size; ++__i)
@@ -182,7 +182,7 @@ public:
   // [simd.ctor] generator constructor
   _CCCL_TEMPLATE(typename _Generator)
   _CCCL_REQUIRES(__can_generate_v<value_type, _Generator, __size>)
-  _CCCL_API constexpr explicit basic_vec(_Generator&& __g)
+  _CCCL_HOST_DEVICE_API constexpr explicit basic_vec(_Generator&& __g)
       : __s_{_Impl::__generate(__g)}
   {}
 
@@ -194,7 +194,7 @@ public:
   // [simd.ctor] range constructor
   _CCCL_TEMPLATE(typename _Range, typename... _Flags)
   _CCCL_REQUIRES(__is_compatible_range<_Range>)
-  _CCCL_API constexpr basic_vec(_Range&& __range, flags<_Flags...> = {})
+  _CCCL_HOST_DEVICE_API constexpr basic_vec(_Range&& __range, flags<_Flags...> = {})
   {
     static_assert(__has_convert_flag_v<_Flags...> || __is_value_preserving_v<ranges::range_value_t<_Range>, value_type>,
                   "Conversion from range_value_t<R> to value_type is not value-preserving; use flag_convert");
@@ -210,7 +210,7 @@ public:
   // [simd.ctor] masked range constructor
   _CCCL_TEMPLATE(typename _Range, typename... _Flags)
   _CCCL_REQUIRES(__is_compatible_range<_Range>)
-  _CCCL_API constexpr basic_vec(_Range&& __range, const mask_type& __mask, flags<_Flags...> = {})
+  _CCCL_HOST_DEVICE_API constexpr basic_vec(_Range&& __range, const mask_type& __mask, flags<_Flags...> = {})
   {
     static_assert(__has_convert_flag_v<_Flags...> || __is_value_preserving_v<ranges::range_value_t<_Range>, value_type>,
                   "Conversion from range_value_t<R> to value_type is not value-preserving; use flag_convert");
@@ -228,7 +228,7 @@ public:
 
   // [simd.subscr], basic_vec subscript operators
 
-  [[nodiscard]] _CCCL_API constexpr value_type operator[](const __simd_size_type __i) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr value_type operator[](const __simd_size_type __i) const noexcept
   {
     _CCCL_ASSERT(::cuda::in_range(__i, __simd_size_type{0}, __size), "Index is out of bounds");
     return __s_.__get(__i);
@@ -248,7 +248,7 @@ public:
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_pre_increment<_Up>)
-  _CCCL_API constexpr basic_vec& operator++() noexcept
+  _CCCL_HOST_DEVICE_API constexpr basic_vec& operator++() noexcept
   {
     _Impl::__increment(__s_);
     return *this;
@@ -256,7 +256,7 @@ public:
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_post_increment<_Up>)
-  [[nodiscard]] _CCCL_API constexpr basic_vec operator++(int) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr basic_vec operator++(int) noexcept
   {
     const basic_vec __r = *this;
     _Impl::__increment(__s_);
@@ -265,7 +265,7 @@ public:
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_pre_decrement<_Up>)
-  _CCCL_API constexpr basic_vec& operator--() noexcept
+  _CCCL_HOST_DEVICE_API constexpr basic_vec& operator--() noexcept
   {
     _Impl::__decrement(__s_);
     return *this;
@@ -273,7 +273,7 @@ public:
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_post_decrement<_Up>)
-  [[nodiscard]] _CCCL_API constexpr basic_vec operator--(int) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr basic_vec operator--(int) noexcept
   {
     const basic_vec __r = *this;
     _Impl::__decrement(__s_);
@@ -282,28 +282,28 @@ public:
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_negate<_Up>)
-  [[nodiscard]] _CCCL_API constexpr mask_type operator!() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr mask_type operator!() const noexcept
   {
     return mask_type{_Impl::__negate(__s_), mask_type::__storage_tag};
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_bitwise_not<_Up>)
-  [[nodiscard]] _CCCL_API constexpr basic_vec operator~() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr basic_vec operator~() const noexcept
   {
     return basic_vec{_Impl::__bitwise_not(__s_), __storage_tag};
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_unary_plus<_Up>)
-  [[nodiscard]] _CCCL_API constexpr basic_vec operator+() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr basic_vec operator+() const noexcept
   {
     return *this;
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_unary_minus<_Up>)
-  [[nodiscard]] _CCCL_API constexpr basic_vec operator-() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr basic_vec operator-() const noexcept
   {
     return basic_vec{_Impl::__unary_minus(__s_), __storage_tag};
   }
@@ -312,14 +312,16 @@ public:
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_binary_plus<_Up>)
-  [[nodiscard]] _CCCL_API friend constexpr basic_vec operator+(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_vec
+  operator+(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return basic_vec{_Impl::__plus(__lhs.__s_, __rhs.__s_), __storage_tag};
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_binary_minus<_Up>)
-  [[nodiscard]] _CCCL_API friend constexpr basic_vec operator-(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_vec
+  operator-(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return basic_vec{_Impl::__minus(__lhs.__s_, __rhs.__s_), __storage_tag};
   }
@@ -327,63 +329,70 @@ public:
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_multiplies<_Up>)
   [[nodiscard]]
-  _CCCL_API friend constexpr basic_vec operator*(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr basic_vec operator*(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return basic_vec{_Impl::__multiplies(__lhs.__s_, __rhs.__s_), __storage_tag};
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_divides<_Up>)
-  [[nodiscard]] _CCCL_API friend constexpr basic_vec operator/(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_vec
+  operator/(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return basic_vec{_Impl::__divides(__lhs.__s_, __rhs.__s_), __storage_tag};
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_modulo<_Up>)
-  [[nodiscard]] _CCCL_API friend constexpr basic_vec operator%(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_vec
+  operator%(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return basic_vec{_Impl::__modulo(__lhs.__s_, __rhs.__s_), __storage_tag};
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_bitwise_and<_Up>)
-  [[nodiscard]] _CCCL_API friend constexpr basic_vec operator&(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_vec
+  operator&(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return basic_vec{_Impl::__bitwise_and(__lhs.__s_, __rhs.__s_), __storage_tag};
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_bitwise_or<_Up>)
-  [[nodiscard]] _CCCL_API friend constexpr basic_vec operator|(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_vec
+  operator|(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return basic_vec{_Impl::__bitwise_or(__lhs.__s_, __rhs.__s_), __storage_tag};
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_bitwise_xor<_Up>)
-  [[nodiscard]] _CCCL_API friend constexpr basic_vec operator^(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_vec
+  operator^(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return basic_vec{_Impl::__bitwise_xor(__lhs.__s_, __rhs.__s_), __storage_tag};
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_shift_left<_Up>)
-  [[nodiscard]] _CCCL_API friend constexpr basic_vec operator<<(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_vec
+  operator<<(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return basic_vec{_Impl::__shift_left(__lhs.__s_, __rhs.__s_), __storage_tag};
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_shift_right<_Up>)
-  [[nodiscard]] _CCCL_API friend constexpr basic_vec operator>>(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_vec
+  operator>>(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return basic_vec{_Impl::__shift_right(__lhs.__s_, __rhs.__s_), __storage_tag};
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_shift_left_size<_Up>)
-  [[nodiscard]] _CCCL_API friend constexpr basic_vec
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_vec
   operator<<(const basic_vec& __lhs, const __simd_size_type __n) noexcept
   {
     return __lhs << basic_vec{__n};
@@ -391,7 +400,7 @@ public:
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_shift_right_size<_Up>)
-  [[nodiscard]] _CCCL_API friend constexpr basic_vec
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr basic_vec
   operator>>(const basic_vec& __lhs, const __simd_size_type __n) noexcept
   {
     return __lhs >> basic_vec{__n};
@@ -401,84 +410,84 @@ public:
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_binary_plus<_Up>)
-  _CCCL_API friend constexpr basic_vec& operator+=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr basic_vec& operator+=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return __lhs = __lhs + __rhs;
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_binary_minus<_Up>)
-  _CCCL_API friend constexpr basic_vec& operator-=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr basic_vec& operator-=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return __lhs = __lhs - __rhs;
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_multiplies<_Up>)
-  _CCCL_API friend constexpr basic_vec& operator*=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr basic_vec& operator*=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return __lhs = __lhs * __rhs;
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_divides<_Up>)
-  _CCCL_API friend constexpr basic_vec& operator/=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr basic_vec& operator/=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return __lhs = __lhs / __rhs;
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_modulo<_Up>)
-  _CCCL_API friend constexpr basic_vec& operator%=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr basic_vec& operator%=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return __lhs = __lhs % __rhs;
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_bitwise_and<_Up>)
-  _CCCL_API friend constexpr basic_vec& operator&=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr basic_vec& operator&=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return __lhs = __lhs & __rhs;
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_bitwise_or<_Up>)
-  _CCCL_API friend constexpr basic_vec& operator|=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr basic_vec& operator|=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return __lhs = __lhs | __rhs;
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_bitwise_xor<_Up>)
-  _CCCL_API friend constexpr basic_vec& operator^=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr basic_vec& operator^=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return __lhs = __lhs ^ __rhs;
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_shift_left<_Up>)
-  _CCCL_API friend constexpr basic_vec& operator<<=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr basic_vec& operator<<=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return __lhs = __lhs << __rhs;
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_shift_right<_Up>)
-  _CCCL_API friend constexpr basic_vec& operator>>=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr basic_vec& operator>>=(basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return __lhs = __lhs >> __rhs;
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_shift_left_size<_Up>)
-  _CCCL_API friend constexpr basic_vec& operator<<=(basic_vec& __lhs, const __simd_size_type __n) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr basic_vec& operator<<=(basic_vec& __lhs, const __simd_size_type __n) noexcept
   {
     return __lhs = __lhs << __n;
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_shift_right_size<_Up>)
-  _CCCL_API friend constexpr basic_vec& operator>>=(basic_vec& __lhs, const __simd_size_type __n) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr basic_vec& operator>>=(basic_vec& __lhs, const __simd_size_type __n) noexcept
   {
     return __lhs = __lhs >> __n;
   }
@@ -487,42 +496,48 @@ public:
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_equal_to<_Up>)
-  [[nodiscard]] _CCCL_API friend constexpr mask_type operator==(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr mask_type
+  operator==(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return __make_mask(_Impl::__equal_to(__lhs.__s_, __rhs.__s_));
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_not_equal_to<_Up>)
-  [[nodiscard]] _CCCL_API friend constexpr mask_type operator!=(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr mask_type
+  operator!=(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return __make_mask(_Impl::__not_equal_to(__lhs.__s_, __rhs.__s_));
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_greater_equal<_Up>)
-  [[nodiscard]] _CCCL_API friend constexpr mask_type operator>=(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr mask_type
+  operator>=(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return __make_mask(_Impl::__greater_equal(__lhs.__s_, __rhs.__s_));
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_less_equal<_Up>)
-  [[nodiscard]] _CCCL_API friend constexpr mask_type operator<=(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr mask_type
+  operator<=(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return __make_mask(_Impl::__less_equal(__lhs.__s_, __rhs.__s_));
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_greater<_Up>)
-  [[nodiscard]] _CCCL_API friend constexpr mask_type operator>(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr mask_type
+  operator>(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return __make_mask(_Impl::__greater(__lhs.__s_, __rhs.__s_));
   }
 
   _CCCL_TEMPLATE(typename _Up = _Tp)
   _CCCL_REQUIRES(__has_less<_Up>)
-  [[nodiscard]] _CCCL_API friend constexpr mask_type operator<(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr mask_type
+  operator<(const basic_vec& __lhs, const basic_vec& __rhs) noexcept
   {
     return __make_mask(_Impl::__less(__lhs.__s_, __rhs.__s_));
   }

--- a/libcudacxx/include/cuda/std/__simd/basic_vec.h
+++ b/libcudacxx/include/cuda/std/__simd/basic_vec.h
@@ -198,7 +198,7 @@ public:
   {
     static_assert(__has_convert_flag_v<_Flags...> || __is_value_preserving_v<ranges::range_value_t<_Range>, value_type>,
                   "Conversion from range_value_t<R> to value_type is not value-preserving; use flag_convert");
-    const auto __data = ::cuda::std::ranges::data(__range);
+    const auto __data = ::cuda::std::ranges::__data_cpo{}(__range);
     __assert_load_store_alignment<basic_vec, ranges::range_value_t<_Range>, _Flags...>(__data);
     _CCCL_PRAGMA_UNROLL_FULL()
     for (__simd_size_type __i = 0; __i < __size; ++__i)
@@ -214,7 +214,7 @@ public:
   {
     static_assert(__has_convert_flag_v<_Flags...> || __is_value_preserving_v<ranges::range_value_t<_Range>, value_type>,
                   "Conversion from range_value_t<R> to value_type is not value-preserving; use flag_convert");
-    const auto __data = ranges::data(__range);
+    const auto __data = ::cuda::std::ranges::__data_cpo{}(__range);
     __assert_load_store_alignment<basic_vec, ranges::range_value_t<_Range>, _Flags...>(__data);
     _CCCL_PRAGMA_UNROLL_FULL()
     for (__simd_size_type __i = 0; __i < __size; ++__i)

--- a/libcudacxx/include/cuda/std/__simd/flag.h
+++ b/libcudacxx/include/cuda/std/__simd/flag.h
@@ -78,7 +78,8 @@ struct flags
 
   // [simd.flags.oper], flags operators
   template <typename... _Other>
-  [[nodiscard]] _CCCL_API friend _CCCL_CONSTEVAL flags<_Flags..., _Other...> operator|(flags, flags<_Other...>) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend _CCCL_CONSTEVAL flags<_Flags..., _Other...>
+  operator|(flags, flags<_Other...>) noexcept
   {
     return {};
   }

--- a/libcudacxx/include/cuda/std/__simd/iterator.h
+++ b/libcudacxx/include/cuda/std/__simd/iterator.h
@@ -45,7 +45,7 @@ class __simd_iterator
   _Vp* __data_               = nullptr;
   __simd_size_type __offset_ = 0;
 
-  _CCCL_API constexpr __simd_iterator(_Vp& __data, const __simd_size_type __offset) noexcept
+  _CCCL_HOST_DEVICE_API constexpr __simd_iterator(_Vp& __data, const __simd_size_type __offset) noexcept
       : __data_{::cuda::std::addressof(__data)}
       , __offset_{__offset}
   {
@@ -79,18 +79,18 @@ public:
   // _Vp = T:        const T != T
   _CCCL_TEMPLATE(typename _Up = remove_const_t<_Vp>)
   _CCCL_REQUIRES(is_same_v<const _Up, _Vp>)
-  _CCCL_API constexpr __simd_iterator(const __simd_iterator<_Up>& __i) noexcept
+  _CCCL_HOST_DEVICE_API constexpr __simd_iterator(const __simd_iterator<_Up>& __i) noexcept
       : __data_{__i.__data_}
       , __offset_{__i.__offset_}
   {}
 
-  [[nodiscard]] _CCCL_API constexpr value_type operator*() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr value_type operator*() const noexcept
   {
     _CCCL_ASSERT(__data_ != nullptr, "cuda::std::simd::__simd_iterator: data is nullptr");
     return (*__data_)[__offset_];
   }
 
-  _CCCL_API constexpr __simd_iterator& operator++() noexcept
+  _CCCL_HOST_DEVICE_API constexpr __simd_iterator& operator++() noexcept
   {
     ++__offset_;
     _CCCL_ASSERT(::cuda::in_range(__offset_, __simd_size_type{0}, _Vp::__size),
@@ -98,7 +98,7 @@ public:
     return *this;
   }
 
-  _CCCL_API constexpr __simd_iterator operator++(int) noexcept
+  _CCCL_HOST_DEVICE_API constexpr __simd_iterator operator++(int) noexcept
   {
     const __simd_iterator __tmp = *this;
     ++__offset_;
@@ -107,7 +107,7 @@ public:
     return __tmp;
   }
 
-  _CCCL_API constexpr __simd_iterator& operator--() noexcept
+  _CCCL_HOST_DEVICE_API constexpr __simd_iterator& operator--() noexcept
   {
     --__offset_;
     _CCCL_ASSERT(::cuda::in_range(__offset_, __simd_size_type{0}, _Vp::__size),
@@ -115,7 +115,7 @@ public:
     return *this;
   }
 
-  _CCCL_API constexpr __simd_iterator operator--(int) noexcept
+  _CCCL_HOST_DEVICE_API constexpr __simd_iterator operator--(int) noexcept
   {
     const __simd_iterator __tmp = *this;
     --__offset_;
@@ -124,7 +124,7 @@ public:
     return __tmp;
   }
 
-  _CCCL_API constexpr __simd_iterator& operator+=(const difference_type __n) noexcept
+  _CCCL_HOST_DEVICE_API constexpr __simd_iterator& operator+=(const difference_type __n) noexcept
   {
     __offset_ += __n;
     _CCCL_ASSERT(::cuda::in_range(__offset_, __simd_size_type{0}, _Vp::__size),
@@ -132,7 +132,7 @@ public:
     return *this;
   }
 
-  _CCCL_API constexpr __simd_iterator& operator-=(const difference_type __n) noexcept
+  _CCCL_HOST_DEVICE_API constexpr __simd_iterator& operator-=(const difference_type __n) noexcept
   {
     __offset_ -= __n;
     _CCCL_ASSERT(::cuda::in_range(__offset_, __simd_size_type{0}, _Vp::__size),
@@ -140,7 +140,7 @@ public:
     return *this;
   }
 
-  [[nodiscard]] _CCCL_API constexpr value_type operator[](const difference_type __n) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr value_type operator[](const difference_type __n) const noexcept
   {
     _CCCL_ASSERT(__data_ != nullptr, "cuda::std::simd::__simd_iterator: data is nullptr");
     _CCCL_ASSERT(::cuda::in_range(__offset_ + __n, __simd_size_type{0}, _Vp::__size - 1),
@@ -150,36 +150,38 @@ public:
 
   // [simd.iterator] comparisons
 
-  [[nodiscard]] _CCCL_API friend constexpr bool operator==(const __simd_iterator __a, const __simd_iterator __b) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator==(const __simd_iterator __a, const __simd_iterator __b) noexcept
   {
     return __a.__data_ == __b.__data_ && __a.__offset_ == __b.__offset_;
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr bool operator==(const __simd_iterator __i, default_sentinel_t) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator==(const __simd_iterator __i, default_sentinel_t) noexcept
   {
     return __i.__offset_ == _Vp::__size;
   }
 
 #if _CCCL_STD_VER <= 2017
   [[nodiscard]]
-  _CCCL_API friend constexpr bool operator!=(const __simd_iterator __a, const __simd_iterator __b) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr bool operator!=(const __simd_iterator __a, const __simd_iterator __b) noexcept
   {
     return !(__a == __b);
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator!=(const __simd_iterator __i, const default_sentinel_t __s) noexcept
   {
     return !(__i == __s);
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator!=(const default_sentinel_t __s, const __simd_iterator __i) noexcept
   {
     return !(__i == __s);
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
   operator==(const default_sentinel_t __s, const __simd_iterator __i) noexcept
   {
     return __i == __s;
@@ -188,31 +190,34 @@ public:
 
 #if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
   [[nodiscard]]
-  _CCCL_API friend constexpr auto operator<=>(const __simd_iterator __a, const __simd_iterator __b) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr auto operator<=>(const __simd_iterator __a, const __simd_iterator __b) noexcept
   {
     _CCCL_ASSERT(__a.__data_ == __b.__data_, "cuda::std::simd::__simd_iterator: iterators refer to different objects");
     return __a.__offset_ <=> __b.__offset_;
   }
 #else // ^^^ _LIBCUDACXX_HAS_SPACESHIP_OPERATOR() ^^^ / vvv !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR() vvv
   [[nodiscard]]
-  _CCCL_API friend constexpr bool operator<(const __simd_iterator __a, const __simd_iterator __b) noexcept
+  _CCCL_HOST_DEVICE_API friend constexpr bool operator<(const __simd_iterator __a, const __simd_iterator __b) noexcept
   {
     _CCCL_ASSERT(__a.__data_ == __b.__data_, "cuda::std::simd::__simd_iterator: iterators refer to different objects");
     return __a.__offset_ < __b.__offset_;
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr bool operator>(const __simd_iterator __a, const __simd_iterator __b) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator>(const __simd_iterator __a, const __simd_iterator __b) noexcept
   {
     _CCCL_ASSERT(__a.__data_ == __b.__data_, "cuda::std::simd::__simd_iterator: iterators refer to different objects");
     return __b.__offset_ < __a.__offset_;
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr bool operator<=(const __simd_iterator __a, const __simd_iterator __b) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator<=(const __simd_iterator __a, const __simd_iterator __b) noexcept
   {
     return !(__b < __a);
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr bool operator>=(const __simd_iterator __a, const __simd_iterator __b) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator>=(const __simd_iterator __a, const __simd_iterator __b) noexcept
   {
     return !(__a < __b);
   }
@@ -220,38 +225,38 @@ public:
 
   // [simd.iterator] arithmetic
 
-  [[nodiscard]] _CCCL_API friend constexpr __simd_iterator
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr __simd_iterator
   operator+(__simd_iterator __i, const difference_type __n) noexcept
   {
     return __i += __n;
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr __simd_iterator
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr __simd_iterator
   operator+(const difference_type __n, __simd_iterator __i) noexcept
   {
     return __i += __n;
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr __simd_iterator
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr __simd_iterator
   operator-(__simd_iterator __i, const difference_type __n) noexcept
   {
     return __i -= __n;
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr difference_type
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr difference_type
   operator-(const __simd_iterator __a, const __simd_iterator __b) noexcept
   {
     _CCCL_ASSERT(__a.__data_ == __b.__data_, "cuda::std::simd::__simd_iterator: iterators refer to different objects");
     return __a.__offset_ - __b.__offset_;
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr difference_type
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr difference_type
   operator-(const __simd_iterator __i, default_sentinel_t) noexcept
   {
     return __i.__offset_ - _Vp::__size;
   }
 
-  [[nodiscard]] _CCCL_API friend constexpr difference_type
+  [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr difference_type
   operator-(default_sentinel_t, const __simd_iterator __i) noexcept
   {
     return _Vp::__size - __i.__offset_;

--- a/libcudacxx/include/cuda/std/__simd/reductions.h
+++ b/libcudacxx/include/cuda/std/__simd/reductions.h
@@ -62,7 +62,7 @@ inline constexpr bool __is_reduce_default_supported_operation_v =
   || __is_bit_xor_op_v<_BinaryOp>;
 
 template <typename _Tp, typename _BinaryOp>
-[[nodiscard]] _CCCL_API constexpr _Tp __default_identity_element() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _Tp __default_identity_element() noexcept
 {
   if constexpr (__is_plus_op_v<_BinaryOp> || __is_bit_or_op_v<_BinaryOp> || __is_bit_xor_op_v<_BinaryOp>)
   {
@@ -88,7 +88,7 @@ template <typename _Tp, typename _BinaryOp>
 
 _CCCL_TEMPLATE(typename _Tp, typename _Abi, typename _BinaryOperation = plus<>)
 _CCCL_REQUIRES(__reduction_binary_operation<_BinaryOperation, _Tp>)
-[[nodiscard]] _CCCL_API constexpr _Tp
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _Tp
 reduce(const basic_vec<_Tp, _Abi>& __x,
        _BinaryOperation __binary_op = {}) noexcept(__is_nothrow_reduction_binary_operation_v<_BinaryOperation, _Tp>)
 {
@@ -106,7 +106,7 @@ reduce(const basic_vec<_Tp, _Abi>& __x,
 // 2) unless BinaryOperation is one of plus<>, multiplies<>, bit_and<>, bit_or<>, or bit_xor<>
 _CCCL_TEMPLATE(typename _Tp, typename _Abi, typename _BinaryOperation)
 _CCCL_REQUIRES(__reduction_binary_operation<_BinaryOperation, _Tp>)
-[[nodiscard]] _CCCL_API constexpr _Tp
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _Tp
 reduce(const basic_vec<_Tp, _Abi>& __x,
        const typename basic_vec<_Tp, _Abi>::mask_type& __mask,
        _BinaryOperation __binary_op,
@@ -128,7 +128,7 @@ reduce(const basic_vec<_Tp, _Abi>& __x,
 _CCCL_TEMPLATE(typename _Tp, typename _Abi, typename _BinaryOperation = plus<>)
 _CCCL_REQUIRES(__reduction_binary_operation<_BinaryOperation, _Tp> _CCCL_AND
                  __is_reduce_default_supported_operation_v<_BinaryOperation>)
-[[nodiscard]] _CCCL_API constexpr _Tp reduce(
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _Tp reduce(
   const basic_vec<_Tp, _Abi>& __x,
   const typename basic_vec<_Tp, _Abi>::mask_type& __mask,
   const _BinaryOperation __binary_op = {}) noexcept(__is_nothrow_reduction_binary_operation_v<_BinaryOperation, _Tp>)
@@ -141,7 +141,7 @@ _CCCL_REQUIRES(__reduction_binary_operation<_BinaryOperation, _Tp> _CCCL_AND
 
 _CCCL_TEMPLATE(typename _Tp, typename _Abi)
 _CCCL_REQUIRES(totally_ordered<_Tp>)
-[[nodiscard]] _CCCL_API constexpr _Tp reduce_min(const basic_vec<_Tp, _Abi>& __x) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _Tp reduce_min(const basic_vec<_Tp, _Abi>& __x) noexcept
 {
   auto __result = __x[0];
   _CCCL_PRAGMA_UNROLL_FULL()
@@ -158,7 +158,7 @@ _CCCL_REQUIRES(totally_ordered<_Tp>)
 
 _CCCL_TEMPLATE(typename _Tp, typename _Abi)
 _CCCL_REQUIRES(totally_ordered<_Tp>)
-[[nodiscard]] _CCCL_API constexpr _Tp
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _Tp
 reduce_min(const basic_vec<_Tp, _Abi>& __x, const typename basic_vec<_Tp, _Abi>::mask_type& __mask) noexcept
 {
   auto __result = numeric_limits<_Tp>::max();
@@ -181,7 +181,7 @@ reduce_min(const basic_vec<_Tp, _Abi>& __x, const typename basic_vec<_Tp, _Abi>:
 
 _CCCL_TEMPLATE(typename _Tp, typename _Abi)
 _CCCL_REQUIRES(totally_ordered<_Tp>)
-[[nodiscard]] _CCCL_API constexpr _Tp reduce_max(const basic_vec<_Tp, _Abi>& __x) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _Tp reduce_max(const basic_vec<_Tp, _Abi>& __x) noexcept
 {
   auto __result = __x[0];
   _CCCL_PRAGMA_UNROLL_FULL()
@@ -198,7 +198,7 @@ _CCCL_REQUIRES(totally_ordered<_Tp>)
 
 _CCCL_TEMPLATE(typename _Tp, typename _Abi)
 _CCCL_REQUIRES(totally_ordered<_Tp>)
-[[nodiscard]] _CCCL_API constexpr _Tp
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _Tp
 reduce_max(const basic_vec<_Tp, _Abi>& __x, const typename basic_vec<_Tp, _Abi>::mask_type& __mask) noexcept
 {
   auto __result = numeric_limits<_Tp>::lowest();
@@ -220,7 +220,7 @@ reduce_max(const basic_vec<_Tp, _Abi>& __x, const typename basic_vec<_Tp, _Abi>:
 // [simd.mask.reductions], mask reductions
 
 template <size_t _Bytes, typename _Abi>
-[[nodiscard]] _CCCL_API constexpr bool all_of(const basic_mask<_Bytes, _Abi>& __k) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr bool all_of(const basic_mask<_Bytes, _Abi>& __k) noexcept
 {
   _CCCL_PRAGMA_UNROLL_FULL()
   for (__simd_size_type __i = 0; __i < __k.__size; ++__i)
@@ -234,7 +234,7 @@ template <size_t _Bytes, typename _Abi>
 }
 
 template <size_t _Bytes, typename _Abi>
-[[nodiscard]] _CCCL_API constexpr bool any_of(const basic_mask<_Bytes, _Abi>& __k) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr bool any_of(const basic_mask<_Bytes, _Abi>& __k) noexcept
 {
   _CCCL_PRAGMA_UNROLL_FULL()
   for (__simd_size_type __i = 0; __i < __k.__size; ++__i)
@@ -248,13 +248,13 @@ template <size_t _Bytes, typename _Abi>
 }
 
 template <size_t _Bytes, typename _Abi>
-[[nodiscard]] _CCCL_API constexpr bool none_of(const basic_mask<_Bytes, _Abi>& __k) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr bool none_of(const basic_mask<_Bytes, _Abi>& __k) noexcept
 {
   return !::cuda::std::simd::any_of(__k);
 }
 
 template <size_t _Bytes, typename _Abi>
-[[nodiscard]] _CCCL_API constexpr __simd_size_type reduce_count(const basic_mask<_Bytes, _Abi>& __k) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __simd_size_type reduce_count(const basic_mask<_Bytes, _Abi>& __k) noexcept
 {
   __simd_size_type __count = 0;
   _CCCL_PRAGMA_UNROLL_FULL()
@@ -266,7 +266,8 @@ template <size_t _Bytes, typename _Abi>
 }
 
 template <size_t _Bytes, typename _Abi>
-[[nodiscard]] _CCCL_API constexpr __simd_size_type reduce_min_index(const basic_mask<_Bytes, _Abi>& __k) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __simd_size_type
+reduce_min_index(const basic_mask<_Bytes, _Abi>& __k) noexcept
 {
   _CCCL_ASSERT(::cuda::std::simd::any_of(__k), "No bits are set");
   _CCCL_PRAGMA_UNROLL_FULL()
@@ -281,7 +282,8 @@ template <size_t _Bytes, typename _Abi>
 }
 
 template <size_t _Bytes, typename _Abi>
-[[nodiscard]] _CCCL_API constexpr __simd_size_type reduce_max_index(const basic_mask<_Bytes, _Abi>& __k) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __simd_size_type
+reduce_max_index(const basic_mask<_Bytes, _Abi>& __k) noexcept
 {
   _CCCL_ASSERT(::cuda::std::simd::any_of(__k), "No bits are set");
   _CCCL_PRAGMA_UNROLL_FULL()
@@ -299,35 +301,35 @@ template <size_t _Bytes, typename _Abi>
 
 _CCCL_TEMPLATE(typename _Tp)
 _CCCL_REQUIRES(same_as<_Tp, bool>)
-[[nodiscard]] _CCCL_API constexpr bool all_of(const _Tp __x) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr bool all_of(const _Tp __x) noexcept
 {
   return __x;
 }
 
 _CCCL_TEMPLATE(typename _Tp)
 _CCCL_REQUIRES(same_as<_Tp, bool>)
-[[nodiscard]] _CCCL_API constexpr bool any_of(const _Tp __x) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr bool any_of(const _Tp __x) noexcept
 {
   return __x;
 }
 
 _CCCL_TEMPLATE(typename _Tp)
 _CCCL_REQUIRES(same_as<_Tp, bool>)
-[[nodiscard]] _CCCL_API constexpr bool none_of(const _Tp __x) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr bool none_of(const _Tp __x) noexcept
 {
   return !__x;
 }
 
 _CCCL_TEMPLATE(typename _Tp)
 _CCCL_REQUIRES(same_as<_Tp, bool>)
-[[nodiscard]] _CCCL_API constexpr __simd_size_type reduce_count(const _Tp __x) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __simd_size_type reduce_count(const _Tp __x) noexcept
 {
   return __x;
 }
 
 _CCCL_TEMPLATE(typename _Tp)
 _CCCL_REQUIRES(same_as<_Tp, bool>)
-[[nodiscard]] _CCCL_API constexpr __simd_size_type reduce_min_index(const _Tp __x) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __simd_size_type reduce_min_index(const _Tp __x) noexcept
 {
   _CCCL_ASSERT(__x, "No bits are set");
   return 0;
@@ -335,7 +337,7 @@ _CCCL_REQUIRES(same_as<_Tp, bool>)
 
 _CCCL_TEMPLATE(typename _Tp)
 _CCCL_REQUIRES(same_as<_Tp, bool>)
-[[nodiscard]] _CCCL_API constexpr __simd_size_type reduce_max_index(const _Tp __x) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __simd_size_type reduce_max_index(const _Tp __x) noexcept
 {
   _CCCL_ASSERT(__x, "No bits are set");
   return 0;

--- a/libcudacxx/include/cuda/std/__simd/specializations/fixed_size_float_vec.h
+++ b/libcudacxx/include/cuda/std/__simd/specializations/fixed_size_float_vec.h
@@ -42,7 +42,7 @@ struct __simd_operations<float, __fixed_size<_Np>, __simd_operations_kind::__fix
   using __base       = __fixed_size_operations<float, _Np>;
   using _SimdStorage = __simd_storage<float, __fixed_size<_Np>>;
 
-  _CCCL_API static constexpr void __increment(_SimdStorage& __s) noexcept
+  _CCCL_HOST_DEVICE_API static constexpr void __increment(_SimdStorage& __s) noexcept
   {
     _CCCL_IF_NOT_CONSTEVAL_DEFAULT
     {
@@ -55,7 +55,7 @@ struct __simd_operations<float, __fixed_size<_Np>, __simd_operations_kind::__fix
     __base::__increment(__s);
   }
 
-  _CCCL_API static constexpr void __decrement(_SimdStorage& __s) noexcept
+  _CCCL_HOST_DEVICE_API static constexpr void __decrement(_SimdStorage& __s) noexcept
   {
     _CCCL_IF_NOT_CONSTEVAL_DEFAULT
     {
@@ -68,7 +68,7 @@ struct __simd_operations<float, __fixed_size<_Np>, __simd_operations_kind::__fix
     __base::__decrement(__s);
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _SimdStorage __unary_minus(const _SimdStorage& __s) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _SimdStorage __unary_minus(const _SimdStorage& __s) noexcept
   {
     _CCCL_IF_NOT_CONSTEVAL_DEFAULT
     {
@@ -80,7 +80,7 @@ struct __simd_operations<float, __fixed_size<_Np>, __simd_operations_kind::__fix
     return __base::__unary_minus(__s);
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _SimdStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _SimdStorage
   __plus(const _SimdStorage& __lhs, const _SimdStorage& __rhs) noexcept
   {
     _CCCL_IF_NOT_CONSTEVAL_DEFAULT
@@ -90,7 +90,7 @@ struct __simd_operations<float, __fixed_size<_Np>, __simd_operations_kind::__fix
     return __base::__plus(__lhs, __rhs);
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _SimdStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _SimdStorage
   __minus(const _SimdStorage& __lhs, const _SimdStorage& __rhs) noexcept
   {
     _CCCL_IF_NOT_CONSTEVAL_DEFAULT
@@ -100,7 +100,7 @@ struct __simd_operations<float, __fixed_size<_Np>, __simd_operations_kind::__fix
     return __base::__minus(__lhs, __rhs);
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _SimdStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _SimdStorage
   __multiplies(const _SimdStorage& __lhs, const _SimdStorage& __rhs) noexcept
   {
     _CCCL_IF_NOT_CONSTEVAL_DEFAULT

--- a/libcudacxx/include/cuda/std/__simd/specializations/fixed_size_mask.h
+++ b/libcudacxx/include/cuda/std/__simd/specializations/fixed_size_mask.h
@@ -44,13 +44,13 @@ struct __mask_storage<_Bytes, __fixed_size<_Np>>
   _CCCL_HIDE_FROM_ABI constexpr __mask_storage(const __mask_storage&) noexcept            = default;
   _CCCL_HIDE_FROM_ABI constexpr __mask_storage& operator=(const __mask_storage&) noexcept = default;
 
-  [[nodiscard]] _CCCL_API constexpr bool __get(const __simd_size_type __idx) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr bool __get(const __simd_size_type __idx) const noexcept
   {
     _CCCL_ASSERT(::cuda::in_range(__idx, __simd_size_type{0}, _Np), "Index is out of bounds");
     return __data[__idx];
   }
 
-  _CCCL_API constexpr void __set(const __simd_size_type __idx, const bool __v) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void __set(const __simd_size_type __idx, const bool __v) noexcept
   {
     _CCCL_ASSERT(::cuda::in_range(__idx, __simd_size_type{0}, _Np), "Index is out of bounds");
     __data[__idx] = __v;
@@ -63,7 +63,7 @@ struct __mask_operations<_Bytes, __fixed_size<_Np>>
 {
   using _MaskStorage = __mask_storage<_Bytes, __fixed_size<_Np>>;
 
-  [[nodiscard]] _CCCL_API static constexpr _MaskStorage __broadcast(const bool __v) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _MaskStorage __broadcast(const bool __v) noexcept
   {
     _MaskStorage __result;
     _CCCL_PRAGMA_UNROLL_FULL()
@@ -75,7 +75,7 @@ struct __mask_operations<_Bytes, __fixed_size<_Np>>
   }
 
   template <typename _Generator, __simd_size_type... _Is>
-  [[nodiscard]] _CCCL_API static constexpr _MaskStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _MaskStorage
   __generate_init(_Generator&& __g, integer_sequence<__simd_size_type, _Is...>)
   {
 #if _CCCL_STD_VER >= 2020
@@ -88,14 +88,14 @@ struct __mask_operations<_Bytes, __fixed_size<_Np>>
   }
 
   template <typename _Generator>
-  [[nodiscard]] _CCCL_API static constexpr _MaskStorage __generate(_Generator&& __g)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _MaskStorage __generate(_Generator&& __g)
   {
     return __generate_init(__g, make_integer_sequence<__simd_size_type, _Np>());
   }
 
   // Logical operators (for operator&& and operator||)
 
-  [[nodiscard]] _CCCL_API static constexpr _MaskStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _MaskStorage
   __logic_and(const _MaskStorage& __lhs, const _MaskStorage& __rhs) noexcept
   {
     _MaskStorage __result;
@@ -107,7 +107,7 @@ struct __mask_operations<_Bytes, __fixed_size<_Np>>
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _MaskStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _MaskStorage
   __logic_or(const _MaskStorage& __lhs, const _MaskStorage& __rhs) noexcept
   {
     _MaskStorage __result;
@@ -121,7 +121,7 @@ struct __mask_operations<_Bytes, __fixed_size<_Np>>
 
   // Bitwise operators (for operator&, operator|, operator^)
 
-  [[nodiscard]] _CCCL_API static constexpr _MaskStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _MaskStorage
   __bitwise_and(const _MaskStorage& __lhs, const _MaskStorage& __rhs) noexcept
   {
     _MaskStorage __result;
@@ -133,7 +133,7 @@ struct __mask_operations<_Bytes, __fixed_size<_Np>>
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _MaskStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _MaskStorage
   __bitwise_or(const _MaskStorage& __lhs, const _MaskStorage& __rhs) noexcept
   {
     _MaskStorage __result;
@@ -145,7 +145,7 @@ struct __mask_operations<_Bytes, __fixed_size<_Np>>
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _MaskStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _MaskStorage
   __bitwise_xor(const _MaskStorage& __lhs, const _MaskStorage& __rhs) noexcept
   {
     _MaskStorage __result;
@@ -157,7 +157,7 @@ struct __mask_operations<_Bytes, __fixed_size<_Np>>
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _MaskStorage __bitwise_not(const _MaskStorage& __s) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _MaskStorage __bitwise_not(const _MaskStorage& __s) noexcept
   {
     _MaskStorage __result;
     _CCCL_PRAGMA_UNROLL_FULL()

--- a/libcudacxx/include/cuda/std/__simd/specializations/fixed_size_storage.h
+++ b/libcudacxx/include/cuda/std/__simd/specializations/fixed_size_storage.h
@@ -44,13 +44,13 @@ struct __simd_storage<_Tp, __fixed_size<_Np>>
 
   _Tp __data[_Np]{};
 
-  [[nodiscard]] _CCCL_API constexpr _Tp __get(const __simd_size_type __idx) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _Tp __get(const __simd_size_type __idx) const noexcept
   {
     _CCCL_ASSERT(::cuda::in_range(__idx, __simd_size_type{0}, _Np), "Index is out of bounds");
     return __data[__idx];
   }
 
-  _CCCL_API constexpr void __set(const __simd_size_type __idx, const _Tp __v) noexcept
+  _CCCL_HOST_DEVICE_API constexpr void __set(const __simd_size_type __idx, const _Tp __v) noexcept
   {
     _CCCL_ASSERT(::cuda::in_range(__idx, __simd_size_type{0}, _Np), "Index is out of bounds");
     __data[__idx] = __v;

--- a/libcudacxx/include/cuda/std/__simd/specializations/fixed_size_vec.h
+++ b/libcudacxx/include/cuda/std/__simd/specializations/fixed_size_vec.h
@@ -39,7 +39,7 @@ struct __fixed_size_operations
   using _SimdStorage = __simd_storage<_Tp, __fixed_size<_Np>>;
   using _MaskStorage = __mask_storage<sizeof(_Tp), __fixed_size<_Np>>;
 
-  [[nodiscard]] _CCCL_API static constexpr _SimdStorage __broadcast(const _Tp __v) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _SimdStorage __broadcast(const _Tp __v) noexcept
   {
     _SimdStorage __result;
     _CCCL_PRAGMA_UNROLL_FULL()
@@ -51,7 +51,7 @@ struct __fixed_size_operations
   }
 
   template <typename _Generator, __simd_size_type... _Is>
-  [[nodiscard]] _CCCL_API static constexpr _SimdStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _SimdStorage
   __generate_init(_Generator&& __g, integer_sequence<__simd_size_type, _Is...>)
   {
 #if _CCCL_STD_VER >= 2020
@@ -64,14 +64,14 @@ struct __fixed_size_operations
   }
 
   template <typename _Generator>
-  [[nodiscard]] _CCCL_API static constexpr _SimdStorage __generate(_Generator&& __g)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _SimdStorage __generate(_Generator&& __g)
   {
     return __generate_init(__g, make_integer_sequence<__simd_size_type, _Np>());
   }
 
   // Unary operations
 
-  _CCCL_API static constexpr void __increment(_SimdStorage& __s) noexcept
+  _CCCL_HOST_DEVICE_API static constexpr void __increment(_SimdStorage& __s) noexcept
   {
     _CCCL_PRAGMA_UNROLL_FULL()
     for (__simd_size_type __i = 0; __i < _Np; ++__i)
@@ -80,7 +80,7 @@ struct __fixed_size_operations
     }
   }
 
-  _CCCL_API static constexpr void __decrement(_SimdStorage& __s) noexcept
+  _CCCL_HOST_DEVICE_API static constexpr void __decrement(_SimdStorage& __s) noexcept
   {
     _CCCL_PRAGMA_UNROLL_FULL()
     for (__simd_size_type __i = 0; __i < _Np; ++__i)
@@ -89,7 +89,7 @@ struct __fixed_size_operations
     }
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _MaskStorage __negate(const _SimdStorage& __s) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _MaskStorage __negate(const _SimdStorage& __s) noexcept
   {
     _MaskStorage __result;
     _CCCL_PRAGMA_UNROLL_FULL()
@@ -100,7 +100,7 @@ struct __fixed_size_operations
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _SimdStorage __bitwise_not(const _SimdStorage& __s) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _SimdStorage __bitwise_not(const _SimdStorage& __s) noexcept
   {
     _SimdStorage __result;
     _CCCL_PRAGMA_UNROLL_FULL()
@@ -113,7 +113,7 @@ struct __fixed_size_operations
 
   _CCCL_DIAG_PUSH
   _CCCL_DIAG_SUPPRESS_MSVC(4146) // unary minus applied to unsigned type
-  [[nodiscard]] _CCCL_API static constexpr _SimdStorage __unary_minus(const _SimdStorage& __s) noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _SimdStorage __unary_minus(const _SimdStorage& __s) noexcept
   {
     _SimdStorage __result;
     _CCCL_PRAGMA_UNROLL_FULL()
@@ -127,7 +127,7 @@ struct __fixed_size_operations
 
   // Binary arithmetic operations
 
-  [[nodiscard]] _CCCL_API static constexpr _SimdStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _SimdStorage
   __plus(const _SimdStorage& __lhs, const _SimdStorage& __rhs) noexcept
   {
     _SimdStorage __result;
@@ -139,7 +139,7 @@ struct __fixed_size_operations
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _SimdStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _SimdStorage
   __minus(const _SimdStorage& __lhs, const _SimdStorage& __rhs) noexcept
   {
     _SimdStorage __result;
@@ -151,7 +151,7 @@ struct __fixed_size_operations
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _SimdStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _SimdStorage
   __multiplies(const _SimdStorage& __lhs, const _SimdStorage& __rhs) noexcept
   {
     _SimdStorage __result;
@@ -163,7 +163,7 @@ struct __fixed_size_operations
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _SimdStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _SimdStorage
   __divides(const _SimdStorage& __lhs, const _SimdStorage& __rhs) noexcept
   {
     _SimdStorage __result;
@@ -175,7 +175,7 @@ struct __fixed_size_operations
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _SimdStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _SimdStorage
   __modulo(const _SimdStorage& __lhs, const _SimdStorage& __rhs) noexcept
   {
     _SimdStorage __result;
@@ -189,7 +189,7 @@ struct __fixed_size_operations
 
   // Comparison operations
 
-  [[nodiscard]] _CCCL_API static constexpr _MaskStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _MaskStorage
   __equal_to(const _SimdStorage& __lhs, const _SimdStorage& __rhs) noexcept
   {
     _MaskStorage __result;
@@ -201,7 +201,7 @@ struct __fixed_size_operations
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _MaskStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _MaskStorage
   __not_equal_to(const _SimdStorage& __lhs, const _SimdStorage& __rhs) noexcept
   {
     _MaskStorage __result;
@@ -213,7 +213,7 @@ struct __fixed_size_operations
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _MaskStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _MaskStorage
   __less(const _SimdStorage& __lhs, const _SimdStorage& __rhs) noexcept
   {
     _MaskStorage __result;
@@ -225,7 +225,7 @@ struct __fixed_size_operations
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _MaskStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _MaskStorage
   __less_equal(const _SimdStorage& __lhs, const _SimdStorage& __rhs) noexcept
   {
     _MaskStorage __result;
@@ -237,7 +237,7 @@ struct __fixed_size_operations
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _MaskStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _MaskStorage
   __greater(const _SimdStorage& __lhs, const _SimdStorage& __rhs) noexcept
   {
     _MaskStorage __result;
@@ -249,7 +249,7 @@ struct __fixed_size_operations
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _MaskStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _MaskStorage
   __greater_equal(const _SimdStorage& __lhs, const _SimdStorage& __rhs) noexcept
   {
     _MaskStorage __result;
@@ -263,7 +263,7 @@ struct __fixed_size_operations
 
   // Bitwise and shift operations
 
-  [[nodiscard]] _CCCL_API static constexpr _SimdStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _SimdStorage
   __bitwise_and(const _SimdStorage& __lhs, const _SimdStorage& __rhs) noexcept
   {
     _SimdStorage __result;
@@ -275,7 +275,7 @@ struct __fixed_size_operations
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _SimdStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _SimdStorage
   __bitwise_or(const _SimdStorage& __lhs, const _SimdStorage& __rhs) noexcept
   {
     _SimdStorage __result;
@@ -287,7 +287,7 @@ struct __fixed_size_operations
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _SimdStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _SimdStorage
   __bitwise_xor(const _SimdStorage& __lhs, const _SimdStorage& __rhs) noexcept
   {
     _SimdStorage __result;
@@ -299,7 +299,7 @@ struct __fixed_size_operations
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _SimdStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _SimdStorage
   __shift_left(const _SimdStorage& __lhs, const _SimdStorage& __rhs) noexcept
   {
     _SimdStorage __result;
@@ -311,7 +311,7 @@ struct __fixed_size_operations
     return __result;
   }
 
-  [[nodiscard]] _CCCL_API static constexpr _SimdStorage
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr _SimdStorage
   __shift_right(const _SimdStorage& __lhs, const _SimdStorage& __rhs) noexcept
   {
     _SimdStorage __result;

--- a/libcudacxx/include/cuda/std/__simd/utility.h
+++ b/libcudacxx/include/cuda/std/__simd/utility.h
@@ -65,7 +65,7 @@ inline constexpr bool
 
 template <typename _Tp, typename _Generator, __simd_size_type... _Indices>
 [[nodiscard]]
-_CCCL_API _CCCL_CONSTEVAL bool __can_generate(integer_sequence<__simd_size_type, _Indices...>) noexcept
+_CCCL_HOST_DEVICE_API _CCCL_CONSTEVAL bool __can_generate(integer_sequence<__simd_size_type, _Indices...>) noexcept
 {
   return (true && ... && __is_well_formed<_Tp, _Generator, _Indices>);
 }
@@ -95,7 +95,7 @@ template <typename _Range>
 _CCCL_CONCEPT __has_static_size = __has_tuple_size_v<_Range> || __has_static_extent_v<_Range>;
 
 template <typename _Range>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __simd_size_type __get_static_range_size() noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API _CCCL_CONSTEVAL __simd_size_type __get_static_range_size() noexcept
 {
   using __range_t = remove_cvref_t<_Range>;
   if constexpr (__has_tuple_size_v<_Range>)
@@ -136,7 +136,7 @@ inline constexpr bool __is_compatible_range_v<_Tp, _Size, _Range, true> =
 // [simd.flags] alignment assertion for load/store pointers
 
 template <typename _Vec, typename _Up, typename... _Flags>
-_CCCL_API constexpr void __assert_load_store_alignment([[maybe_unused]] const _Up* __data) noexcept
+_CCCL_HOST_DEVICE_API constexpr void __assert_load_store_alignment([[maybe_unused]] const _Up* __data) noexcept
 {
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {

--- a/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
+++ b/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
@@ -168,17 +168,19 @@ template <class _CharT>
 {
   using _UCharT = __make_nbit_uint_t<sizeof(_CharT) * CHAR_BIT>;
 
+  bool __reached_end = false;
   while (*__lhs == *__rhs)
   {
     if (*__lhs == _CharT('\0'))
     {
-      return 0;
+      __reached_end = true;
+      break;
     }
 
     ++__lhs;
     ++__rhs;
   }
-  return (static_cast<_UCharT>(*__lhs) < static_cast<_UCharT>(*__rhs)) ? -1 : 1;
+  return __reached_end ? 0 : (static_cast<_UCharT>(*__lhs) < static_cast<_UCharT>(*__rhs)) ? -1 : 1;
 }
 
 #if !_CCCL_COMPILER(NVRTC)
@@ -214,22 +216,24 @@ __cccl_strncmp_impl_constexpr(const _CharT* __lhs, const _CharT* __rhs, size_t _
 {
   using _UCharT = __make_nbit_uint_t<sizeof(_CharT) * CHAR_BIT>;
 
+  int __result = 0;
   while (__n--)
   {
     if (*__lhs != *__rhs)
     {
-      return (static_cast<_UCharT>(*__lhs) < static_cast<_UCharT>(*__rhs)) ? -1 : 1;
+      __result = (static_cast<_UCharT>(*__lhs) < static_cast<_UCharT>(*__rhs)) ? -1 : 1;
+      break;
     }
 
     if (*__lhs == _CharT('\0'))
     {
-      return 0;
+      break;
     }
 
     ++__lhs;
     ++__rhs;
   }
-  return 0;
+  return __result;
 }
 
 #if !_CCCL_COMPILER(NVRTC)
@@ -262,15 +266,17 @@ template <class _CharT>
 template <class _CharT>
 [[nodiscard]] _CCCL_API constexpr _CharT* __cccl_strchr_impl_constexpr(_CharT* __ptr, _CharT __c) noexcept
 {
+  bool __reached_end = false;
   while (*__ptr != __c)
   {
     if (*__ptr == _CharT('\0'))
     {
-      return nullptr;
+      __reached_end = true;
+      break;
     }
     ++__ptr;
   }
-  return __ptr;
+  return __reached_end ? nullptr : __ptr;
 }
 
 #if !_CCCL_COMPILER(NVRTC)
@@ -354,15 +360,17 @@ template <class _CharT>
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp* __cccl_memchr_impl_constexpr(_Tp* __ptr, _Tp __c, size_t __n) noexcept
 {
+  _Tp* __result = nullptr;
   while (__n--)
   {
     if (*__ptr == __c)
     {
-      return __ptr;
+      __result = __ptr;
+      break;
     }
     ++__ptr;
   }
-  return nullptr;
+  return __result;
 }
 
 #if !_CCCL_COMPILER(NVRTC)
@@ -450,16 +458,18 @@ __cccl_memcmp_impl_constexpr(const _Tp* __lhs, const _Tp* __rhs, size_t __n) noe
 {
   using _Up = __make_nbit_uint_t<sizeof(_Tp) * CHAR_BIT>;
 
+  int __result = 0;
   while (__n--)
   {
     if (*__lhs != *__rhs)
     {
-      return static_cast<_Up>(*__lhs) < static_cast<_Up>(*__rhs) ? -1 : 1;
+      __result = static_cast<_Up>(*__lhs) < static_cast<_Up>(*__rhs) ? -1 : 1;
+      break;
     }
     ++__lhs;
     ++__rhs;
   }
-  return 0;
+  return __result;
 }
 
 #if !_CCCL_COMPILER(NVRTC)

--- a/libcudacxx/include/cuda/std/__string/helper_functions.h
+++ b/libcudacxx/include/cuda/std/__string/helper_functions.h
@@ -73,14 +73,16 @@ __cccl_search_substring(const _CharT* __first1, const _CharT* __last1, const _Ch
     // Check whether __first1 still has at least __len2 bytes.
     if (__len1 < __len2)
     {
-      return __last1;
+      // return __last1;
+      break;
     }
 
     // Find __f2 the first byte matching in __first1.
     __first1 = _Traits::find(__first1, __len1 - __len2 + 1, __f2);
     if (__first1 == 0)
     {
-      return __last1;
+      // return __last1;
+      break;
     }
 
     // It is faster to compare from the first byte of __first1 even if we
@@ -90,11 +92,14 @@ __cccl_search_substring(const _CharT* __first1, const _CharT* __last1, const _Ch
     // the string.
     if (_Traits::compare(__first1, __first2, __len2) == 0)
     {
-      return __first1;
+      // return __first1;
+      __last1 = __first1;
+      break;
     }
 
     ++__first1;
   }
+  return __last1;
 }
 
 template <class _CharT, class _SizeT, class _Traits, _SizeT __npos>
@@ -135,14 +140,16 @@ _CCCL_API constexpr _SizeT __cccl_str_rfind(const _CharT* __p, _SizeT __sz, _Cha
   {
     __pos = __sz;
   }
+  _SizeT __result = __npos;
   for (const _CharT* __ps = __p + __pos; __ps != __p;)
   {
     if (_Traits::eq(*--__ps, __c))
     {
-      return static_cast<_SizeT>(__ps - __p);
+      __result = static_cast<_SizeT>(__ps - __p);
+      break;
     }
   }
-  return __npos;
+  return __result;
 }
 
 template <class _CharT, class _SizeT, class _Traits, _SizeT __npos>
@@ -199,14 +206,16 @@ __cccl_str_find_last_of(const _CharT* __p, _SizeT __sz, const _CharT* __s, _Size
   {
     __pos = __sz;
   }
+  _SizeT __result = __npos;
   for (const _CharT* __ps = __p + __pos; __ps != __p;)
   {
     if (_Traits::find(__s, __n, *--__ps) != nullptr)
     {
-      return static_cast<_SizeT>(__ps - __p);
+      __result = static_cast<_SizeT>(__ps - __p);
+      break;
     }
   }
-  return __npos;
+  return __result;
 }
 
 template <class _CharT, class _SizeT, class _Traits, _SizeT __npos>
@@ -218,20 +227,23 @@ __cccl_str_find_first_not_of(const _CharT* __p, _SizeT __sz, const _CharT* __s, 
     return __npos;
   }
   const _CharT* __pe = __p + __sz;
+  _SizeT __result    = __npos;
   for (const _CharT* __ps = __p + __pos; __ps != __pe; ++__ps)
   {
     if (_Traits::find(__s, __n, *__ps) == nullptr)
     {
-      return static_cast<_SizeT>(__ps - __p);
+      __result = static_cast<_SizeT>(__ps - __p);
+      break;
     }
   }
-  return __npos;
+  return __result;
 }
 
 template <class _CharT, class _SizeT, class _Traits, _SizeT __npos>
 _CCCL_API constexpr _SizeT
 __cccl_str_find_first_not_of(const _CharT* __p, _SizeT __sz, _CharT __c, _SizeT __pos) noexcept
 {
+  _SizeT __result = __npos;
   if (__pos < __sz)
   {
     const _CharT* __pe = __p + __sz;
@@ -239,11 +251,12 @@ __cccl_str_find_first_not_of(const _CharT* __p, _SizeT __sz, _CharT __c, _SizeT 
     {
       if (!_Traits::eq(*__ps, __c))
       {
-        return static_cast<_SizeT>(__ps - __p);
+        __result = static_cast<_SizeT>(__ps - __p);
+        break;
       }
     }
   }
-  return __npos;
+  return __result;
 }
 
 template <class _CharT, class _SizeT, class _Traits, _SizeT __npos>
@@ -258,14 +271,17 @@ __cccl_str_find_last_not_of(const _CharT* __p, _SizeT __sz, const _CharT* __s, _
   {
     __pos = __sz;
   }
+
+  _SizeT __result = __npos;
   for (const _CharT* __ps = __p + __pos; __ps != __p;)
   {
     if (_Traits::find(__s, __n, *--__ps) == nullptr)
     {
-      return static_cast<_SizeT>(__ps - __p);
+      __result = static_cast<_SizeT>(__ps - __p);
+      break;
     }
   }
-  return __npos;
+  return __result;
 }
 
 template <class _CharT, class _SizeT, class _Traits, _SizeT __npos>
@@ -279,14 +295,16 @@ _CCCL_API constexpr _SizeT __cccl_str_find_last_not_of(const _CharT* __p, _SizeT
   {
     __pos = __sz;
   }
+  _SizeT __result = __npos;
   for (const _CharT* __ps = __p + __pos; __ps != __p;)
   {
     if (!_Traits::eq(*--__ps, __c))
     {
-      return static_cast<_SizeT>(__ps - __p);
+      __result = static_cast<_SizeT>(__ps - __p);
+      break;
     }
   }
-  return __npos;
+  return __result;
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__string/string_view.h
+++ b/libcudacxx/include/cuda/std/__string/string_view.h
@@ -80,17 +80,20 @@ private:
   [[nodiscard]] _CCCL_API static constexpr int
   __compare_(char const* __s1, size_t __len1, char const* __s2, size_t __len2, size_t __n) noexcept
   {
+    int __result = int(__len1) - int(__len2);
     if (__n)
     {
       for (;; ++__s1, ++__s2)
       {
         if (*__s1 < *__s2)
         {
-          return -1;
+          __result = -1;
+          break;
         }
         if (*__s2 < *__s1)
         {
-          return 1;
+          __result = 1;
+          break;
         }
         if (0 == --__n)
         {
@@ -98,14 +101,15 @@ private:
         }
       }
     }
-    return int(__len1) - int(__len2);
+    return __result;
   }
 
   template <bool _Forward>
   [[nodiscard]] _CCCL_API static constexpr ptrdiff_t
   __find(const char* __needle, size_t __needle_size, const char* __haystack_begin, const char* __haystack_end) noexcept
   {
-    char const* __it = __haystack_begin;
+    ptrdiff_t __result = -1;
+    char const* __it   = __haystack_begin;
     for (; __it != __haystack_end; (_Forward ? ++__it : --__it))
     {
       size_t __i = 0;
@@ -118,10 +122,11 @@ private:
       }
       if (__i == __needle_size)
       {
-        return _Forward ? __it - __haystack_begin : __it - __haystack_end - 1;
+        __result = _Forward ? __it - __haystack_begin : __it - __haystack_end - 1;
+        break;
       }
     }
-    return -1;
+    return __result;
   }
 
 public:

--- a/libcudacxx/include/cuda/std/__thread/threading_support.h
+++ b/libcudacxx/include/cuda/std/__thread/threading_support.h
@@ -51,13 +51,13 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 #  define __LIBCUDACXX_ASM_THREAD_YIELD (;)
 #endif // ! _CCCL_ARCH(X86_64)
 
-_CCCL_API inline void __cccl_thread_yield_processor()
+_CCCL_HOST_DEVICE_API inline void __cccl_thread_yield_processor()
 {
   NV_IF_TARGET(NV_IS_HOST, __LIBCUDACXX_ASM_THREAD_YIELD)
 }
 
 template <class _Fn>
-_CCCL_API inline bool __cccl_thread_poll_with_backoff(
+_CCCL_HOST_DEVICE_API inline bool __cccl_thread_poll_with_backoff(
   _Fn&& __f, ::cuda::std::chrono::nanoseconds __max = ::cuda::std::chrono::nanoseconds::zero())
 {
   ::cuda::std::chrono::high_resolution_clock::time_point const __start =

--- a/libcudacxx/include/cuda/std/__thread/threading_support_cuda.h
+++ b/libcudacxx/include/cuda/std/__thread/threading_support_cuda.h
@@ -29,9 +29,9 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-_CCCL_API inline void __cccl_thread_yield() {}
+_CCCL_HOST_DEVICE_API inline void __cccl_thread_yield() {}
 
-_CCCL_API inline void __cccl_thread_sleep_for(::cuda::std::chrono::nanoseconds __ns){
+_CCCL_HOST_DEVICE_API inline void __cccl_thread_sleep_for(::cuda::std::chrono::nanoseconds __ns){
   NV_IF_TARGET(NV_PROVIDES_SM_70, ({
                  auto const __step = __ns.count();
                  _CCCL_ASSERT(__step < numeric_limits<unsigned>::max(), "invalid nanoseconds count");

--- a/libcudacxx/include/cuda/std/__thread/threading_support_external.h
+++ b/libcudacxx/include/cuda/std/__thread/threading_support_external.h
@@ -28,9 +28,9 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-_CCCL_API inline void __cccl_thread_yield();
+_CCCL_HOST_DEVICE_API inline void __cccl_thread_yield();
 
-_CCCL_API inline void __cccl_thread_sleep_for(::cuda::std::chrono::nanoseconds __ns);
+_CCCL_HOST_DEVICE_API inline void __cccl_thread_sleep_for(::cuda::std::chrono::nanoseconds __ns);
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__thread/threading_support_pthread.h
+++ b/libcudacxx/include/cuda/std/__thread/threading_support_pthread.h
@@ -73,7 +73,7 @@ using __cccl_tls_key = pthread_key_t;
 
 #  define _LIBCUDACXX_TLS_DESTRUCTOR_CC
 
-[[nodiscard]] _CCCL_API constexpr timespec __cccl_to_timespec(const ::cuda::std::chrono::nanoseconds& __ns)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr timespec __cccl_to_timespec(const ::cuda::std::chrono::nanoseconds& __ns)
 {
   constexpr auto __ts_sec_max = numeric_limits<time_t>::max();
 
@@ -95,39 +95,39 @@ using __cccl_tls_key = pthread_key_t;
 
 // Semaphore
 
-_CCCL_API inline bool __cccl_semaphore_init(__cccl_semaphore_t* __sem, int __init)
+_CCCL_HOST_DEVICE_API inline bool __cccl_semaphore_init(__cccl_semaphore_t* __sem, int __init)
 {
   return sem_init(__sem, 0, __init) == 0;
 }
 
-_CCCL_API inline bool __cccl_semaphore_destroy(__cccl_semaphore_t* __sem)
+_CCCL_HOST_DEVICE_API inline bool __cccl_semaphore_destroy(__cccl_semaphore_t* __sem)
 {
   return sem_destroy(__sem) == 0;
 }
 
-_CCCL_API inline bool __cccl_semaphore_post(__cccl_semaphore_t* __sem)
+_CCCL_HOST_DEVICE_API inline bool __cccl_semaphore_post(__cccl_semaphore_t* __sem)
 {
   return sem_post(__sem) == 0;
 }
 
-_CCCL_API inline bool __cccl_semaphore_wait(__cccl_semaphore_t* __sem)
+_CCCL_HOST_DEVICE_API inline bool __cccl_semaphore_wait(__cccl_semaphore_t* __sem)
 {
   return sem_wait(__sem) == 0;
 }
 
-_CCCL_API inline bool
+_CCCL_HOST_DEVICE_API inline bool
 __cccl_semaphore_wait_timed(__cccl_semaphore_t* __sem, ::cuda::std::chrono::nanoseconds const& __ns)
 {
   const auto __ts = __cccl_to_timespec(__ns);
   return sem_timedwait(__sem, &__ts) == 0;
 }
 
-_CCCL_API inline void __cccl_thread_yield()
+_CCCL_HOST_DEVICE_API inline void __cccl_thread_yield()
 {
   sched_yield();
 }
 
-_CCCL_API inline void __cccl_thread_sleep_for(::cuda::std::chrono::nanoseconds __ns)
+_CCCL_HOST_DEVICE_API inline void __cccl_thread_sleep_for(::cuda::std::chrono::nanoseconds __ns)
 {
   auto __ts = __cccl_to_timespec(__ns);
   while (nanosleep(&__ts, &__ts) == -1 && errno == EINTR)

--- a/libcudacxx/include/cuda/std/__thread/threading_support_win32.h
+++ b/libcudacxx/include/cuda/std/__thread/threading_support_win32.h
@@ -65,12 +65,12 @@ using __cccl_tls_key = long;
 
 #  define _LIBCUDACXX_TLS_DESTRUCTOR_CC __stdcall
 
-_CCCL_API inline void __cccl_thread_yield()
+_CCCL_HOST_DEVICE_API inline void __cccl_thread_yield()
 {
   SwitchToThread();
 }
 
-_CCCL_API inline void __cccl_thread_sleep_for(chrono::nanoseconds __ns)
+_CCCL_HOST_DEVICE_API inline void __cccl_thread_sleep_for(chrono::nanoseconds __ns)
 {
   using namespace chrono;
   // round-up to the nearest millisecond

--- a/libcudacxx/include/cuda/std/__type_traits/type_list.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_list.h
@@ -755,7 +755,7 @@ struct __type_concat_fn
 template <size_t _Count>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_maybe_concat_fn
 {
-  using __next_t _CCCL_NODEBUG_ALIAS = __type_maybe_concat_fn<(_Count < 8 ? 0 : _Count - 8)>;
+  using __next_cpo _CCCL_NODEBUG_ALIAS = __type_maybe_concat_fn<(_Count < 8 ? 0 : _Count - 8)>;
 
   template <class... _Ts,
             class... _As,
@@ -778,7 +778,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_maybe_concat_fn
     __type_list_ptr<_Gs...>, // 7
     __type_list_ptr<_Hs...>, // 8
     _Tail*... __tail) // rest
-    -> decltype(__next_t::__fn(
+    -> decltype(__next_cpo::__fn(
       __type_list_ptr<_Ts..., _As..., _Bs..., _Cs..., _Ds..., _Es..., _Fs..., _Gs..., _Hs...>{nullptr},
       __tail...,
       __type_list_ptr<>{nullptr},

--- a/libcudacxx/include/cuda/std/__variant/variant_base.h
+++ b/libcudacxx/include/cuda/std/__variant/variant_base.h
@@ -300,7 +300,7 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT __ctor : public __dtor<_Traits>
     {
       ::cuda::std::__construct_at(
         ::cuda::std::addressof(__access::__base::__get_alt<_CurrentIndex>(__lhs.__as_base())),
-        in_place,
+        in_place_t{},
         __access::__base::__get_alt<_CurrentIndex>(::cuda::std::forward<_Rhs>(__rhs).__as_base()).__value);
       return;
     }
@@ -316,7 +316,7 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT __ctor : public __dtor<_Traits>
     {
       ::cuda::std::__construct_at(
         ::cuda::std::addressof(__access::__base::__get_alt<0>(__lhs.__as_base())),
-        in_place,
+        in_place_t{},
         __access::__base::__get_alt<0>(::cuda::std::forward<_Rhs>(__rhs).__as_base()).__value);
       return;
     }
@@ -332,7 +332,7 @@ protected:
   template <size_t _Ip, class _Tp, class... _Args>
   _CCCL_API static _Tp& __construct_alt(__alt<_Ip, _Tp>& __a, _Args&&... __args)
   {
-    ::cuda::std::__construct_at(::cuda::std::addressof(__a), in_place, ::cuda::std::forward<_Args>(__args)...);
+    ::cuda::std::__construct_at(::cuda::std::addressof(__a), in_place_t{}, ::cuda::std::forward<_Args>(__args)...);
     return __a.__value;
   }
 

--- a/libcudacxx/include/cuda/std/__variant/variant_base.h
+++ b/libcudacxx/include/cuda/std/__variant/variant_base.h
@@ -91,7 +91,7 @@ public:                                                                         
                                                                                  \
   template <class... _Args>                                                      \
   _CCCL_API explicit constexpr __union(in_place_index_t<0>, _Args&&... __args)   \
-      : __head_(in_place, ::cuda::std::forward<_Args>(__args)...)                \
+      : __head_(in_place_t{}, ::cuda::std::forward<_Args>(__args)...)            \
   {}                                                                             \
                                                                                  \
   template <size_t _Ip, class... _Args>                                          \

--- a/libcudacxx/include/cuda/std/__variant/variant_constraints.h
+++ b/libcudacxx/include/cuda/std/__variant/variant_constraints.h
@@ -52,7 +52,8 @@ _CCCL_API constexpr size_t __find_index()
     {
       if (__result != __not_found)
       {
-        return __ambiguous;
+        __result = __ambiguous;
+        break;
       }
       __result = __i;
     }

--- a/libcudacxx/include/cuda/std/bitset
+++ b/libcudacxx/include/cuda/std/bitset
@@ -314,15 +314,17 @@ protected:
     // do middle whole words
     size_type __n               = _Size;
     __const_storage_pointer __p = __first_;
+    bool __result               = true;
     for (; __n >= __bits_per_word; ++__p, __n -= __bits_per_word)
     {
       if (~*__p)
       {
-        return false;
+        __result = false;
+        break;
       }
     }
     // do last partial word
-    if (__n > 0)
+    if (__n > 0 && __result)
     {
       __storage_type __m = ~__storage_type(0) >> (__bits_per_word - __n);
       if (~*__p & __m)
@@ -330,7 +332,7 @@ protected:
         return false;
       }
     }
-    return true;
+    return __result;
   }
 
   _CCCL_API constexpr bool any() const noexcept
@@ -338,15 +340,17 @@ protected:
     // do middle whole words
     size_type __n               = _Size;
     __const_storage_pointer __p = __first_;
+    bool __result               = false;
     for (; __n >= __bits_per_word; ++__p, __n -= __bits_per_word)
     {
       if (*__p)
       {
-        return true;
+        __result = true;
+        break;
       }
     }
     // do last partial word
-    if (__n > 0)
+    if (__n > 0 && !__result)
     {
       __storage_type __m = ~__storage_type(0) >> (__bits_per_word - __n);
       if (*__p & __m)
@@ -354,7 +358,7 @@ protected:
         return true;
       }
     }
-    return false;
+    return __result;
   }
 
   _CCCL_API inline size_t __hash_code() const noexcept

--- a/libcudacxx/include/cuda/std/inplace_vector
+++ b/libcudacxx/include/cuda/std/inplace_vector
@@ -313,7 +313,7 @@ protected:
     iterator __curr = __dest;
     for (; __first != __last; ++__curr, (void) ++__first)
     {
-      ::new (::cuda::std::__voidify(*__curr)) _Tp(::cuda::std::ranges::iter_move(__first));
+      ::new (::cuda::std::__voidify(*__curr)) _Tp(::cuda::std::ranges::__iter_move_cpo{}(__first));
     }
     this->__size_ += static_cast<__size_type>(__curr - __dest);
   }
@@ -326,7 +326,7 @@ protected:
     auto __guard    = __make_exception_guard(_Rollback_change_size<__inplace_vector_storage>{this, __dest, __curr});
     for (; __first != __last; ++__curr, (void) ++__first)
     {
-      ::new (::cuda::std::__voidify(*__curr)) _Tp(::cuda::std::ranges::iter_move(__first));
+      ::new (::cuda::std::__voidify(*__curr)) _Tp(::cuda::std::ranges::__iter_move_cpo{}(__first));
     }
     __guard.__complete();
     this->__size_ += static_cast<__size_type>(__curr - __dest);
@@ -577,14 +577,14 @@ protected:
   _CCCL_API constexpr void __uninitialized_copy(_Iter __first, _Iter __last, iterator __dest) noexcept
   {
     ::cuda::std::copy(__first, __last, __dest);
-    __size_ += static_cast<__size_type>(::cuda::std::ranges::distance(__first, __last));
+    __size_ += static_cast<__size_type>(::cuda::std::ranges::__distance_cpo{}(__first, __last));
   }
 
   template <class _Iter>
   _CCCL_API constexpr void __uninitialized_move(_Iter __first, _Iter __last, iterator __dest) noexcept
   {
     ::cuda::std::copy(__first, __last, __dest);
-    __size_ += static_cast<__size_type>(::cuda::std::ranges::distance(__first, __last));
+    __size_ += static_cast<__size_type>(::cuda::std::ranges::__distance_cpo{}(__first, __last));
   }
 };
 
@@ -785,11 +785,11 @@ public:
   _CCCL_API constexpr inplace_vector(from_range_t, _Range&& __range)
       : __base()
   {
-    auto __first = ::cuda::std::ranges::begin(__range);
-    auto __last  = ::cuda::std::ranges::end(__range);
+    auto __first = ::cuda::std::ranges::__begin_cpo{}(__range);
+    auto __last  = ::cuda::std::ranges::__end_cpo{}(__range);
     for (; __first != __last; ++__first)
     {
-      emplace_back(::cuda::std::ranges::iter_move(__first));
+      emplace_back(::cuda::std::ranges::__iter_move_cpo{}(__first));
     }
   }
 
@@ -800,7 +800,7 @@ public:
   _CCCL_API constexpr inplace_vector(from_range_t, _Range&& __range)
       : __base()
   {
-    const auto __size = ::cuda::std::ranges::size(__range);
+    const auto __size = ::cuda::std::ranges::__size_cpo{}(__range);
     if (__size > 0)
     {
       if (_Capacity < __size)
@@ -809,7 +809,7 @@ public:
       }
 
       this->__uninitialized_move(
-        ::cuda::std::ranges::begin(__range), ::cuda::std::ranges::__unwrap_end(__range), this->begin());
+        ::cuda::std::ranges::__begin_cpo{}(__range), ::cuda::std::ranges::__unwrap_end(__range), this->begin());
     }
   }
 
@@ -820,8 +820,8 @@ public:
   _CCCL_API constexpr inplace_vector(from_range_t, _Range&& __range)
       : __base()
   {
-    const auto __count = static_cast<size_t>(
-      ::cuda::std::ranges::distance(::cuda::std::ranges::begin(__range), ::cuda::std::ranges::end(__range)));
+    const auto __count = static_cast<size_t>(::cuda::std::ranges::__distance_cpo{}(
+      ::cuda::std::ranges::__begin_cpo{}(__range), ::cuda::std::ranges::__end_cpo{}(__range)));
     if (__count > 0)
     {
       if (_Capacity < __count)
@@ -830,7 +830,7 @@ public:
       }
 
       this->__uninitialized_move(
-        ::cuda::std::ranges::begin(__range), ::cuda::std::ranges::__unwrap_end(__range), this->begin());
+        ::cuda::std::ranges::__begin_cpo{}(__range), ::cuda::std::ranges::__unwrap_end(__range), this->begin());
     }
   }
 
@@ -947,8 +947,8 @@ public:
     !::cuda::std::ranges::forward_range<_Range>))
   _CCCL_API constexpr void assign_range(_Range&& __range)
   {
-    auto __first      = ::cuda::std::ranges::begin(__range);
-    const auto __last = ::cuda::std::ranges::end(__range);
+    auto __first      = ::cuda::std::ranges::__begin_cpo{}(__range);
+    const auto __last = ::cuda::std::ranges::__end_cpo{}(__range);
     iterator __end    = this->end();
     for (iterator __current = this->begin(); __current != __end; ++__current, (void) ++__first)
     {
@@ -972,13 +972,13 @@ public:
       _CCCL_AND ::cuda::std::ranges::sized_range<_Range>)
   _CCCL_API constexpr void assign_range(_Range&& __range)
   {
-    const auto __size = ::cuda::std::ranges::size(__range);
+    const auto __size = ::cuda::std::ranges::__size_cpo{}(__range);
     if (_Capacity < __size)
     {
       _CCCL_THROW(::std::bad_alloc);
     }
 
-    const auto __first = ::cuda::std::ranges::begin(__range);
+    const auto __first = ::cuda::std::ranges::__begin_cpo{}(__range);
     const auto __last  = ::cuda::std::ranges::__unwrap_end(__range);
     if (static_cast<size_type>(__size) < this->size())
     {
@@ -999,9 +999,9 @@ public:
       _CCCL_AND(!::cuda::std::ranges::sized_range<_Range>))
   _CCCL_API constexpr void assign_range(_Range&& __range)
   {
-    const auto __first = ::cuda::std::ranges::begin(__range);
+    const auto __first = ::cuda::std::ranges::__begin_cpo{}(__range);
     const auto __last  = ::cuda::std::ranges::__unwrap_end(__range);
-    const auto __size  = static_cast<size_type>(::cuda::std::ranges::distance(__first, __last));
+    const auto __size  = static_cast<size_type>(::cuda::std::ranges::__distance_cpo{}(__first, __last));
     if (_Capacity < __size)
     {
       _CCCL_THROW(::std::bad_alloc);
@@ -1301,8 +1301,8 @@ public:
   _CCCL_API constexpr iterator insert_range(const_iterator __cpos, _Range&& __range)
   {
     // add all new elements to the back then rotate
-    auto __first             = ::cuda::std::ranges::begin(__range);
-    auto __last              = ::cuda::std::ranges::end(__range);
+    auto __first             = ::cuda::std::ranges::__begin_cpo{}(__range);
+    auto __last              = ::cuda::std::ranges::__end_cpo{}(__range);
     const iterator __old_end = this->end();
     for (; __first != __last; ++__first)
     {
@@ -1319,7 +1319,7 @@ public:
     ::cuda::std::ranges::__container_compatible_range<_Range, _Tp> _CCCL_AND ::cuda::std::ranges::forward_range<_Range>)
   _CCCL_API constexpr iterator insert_range(const_iterator __cpos, _Range&& __range)
   {
-    auto __first = ::cuda::std::ranges::begin(__range);
+    auto __first = ::cuda::std::ranges::__begin_cpo{}(__range);
     return insert(__cpos, __first, ::cuda::std::ranges::__unwrap_end(__range));
   }
 
@@ -1328,8 +1328,8 @@ public:
     !::cuda::std::ranges::forward_range<_Range>))
   _CCCL_API constexpr void append_range(_Range&& __range)
   {
-    auto __first = ::cuda::std::ranges::begin(__range);
-    auto __last  = ::cuda::std::ranges::end(__range);
+    auto __first = ::cuda::std::ranges::__begin_cpo{}(__range);
+    auto __last  = ::cuda::std::ranges::__end_cpo{}(__range);
     for (; __first != __last; ++__first)
     {
       emplace_back(*__first);
@@ -1341,7 +1341,7 @@ public:
     ::cuda::std::ranges::__container_compatible_range<_Range, _Tp> _CCCL_AND ::cuda::std::ranges::forward_range<_Range>)
   _CCCL_API constexpr void append_range(_Range&& __range)
   {
-    auto __first = ::cuda::std::ranges::begin(__range);
+    auto __first = ::cuda::std::ranges::__begin_cpo{}(__range);
     insert(this->end(), __first, ::cuda::std::ranges::__unwrap_end(__range));
   }
 
@@ -1442,8 +1442,8 @@ public:
   _CCCL_API constexpr ::cuda::std::ranges::iterator_t<_Range>
   try_append_range(_Range&& __range) noexcept(is_nothrow_move_constructible_v<_Tp>)
   {
-    auto __first = ::cuda::std::ranges::begin(__range);
-    auto __last  = ::cuda::std::ranges::end(__range);
+    auto __first = ::cuda::std::ranges::__begin_cpo{}(__range);
+    auto __last  = ::cuda::std::ranges::__end_cpo{}(__range);
     for (; this->size() != _Capacity && __first != __last; ++__first)
     {
       emplace_back(*__first);
@@ -1459,11 +1459,11 @@ public:
   try_append_range(_Range&& __range) noexcept(is_nothrow_move_constructible_v<_Tp>)
   {
     const auto __capacity = _Capacity - this->size();
-    const auto __size     = ::cuda::std::ranges::size(__range);
+    const auto __size     = ::cuda::std::ranges::__size_cpo{}(__range);
     const auto __diff     = __size < __capacity ? __size : __capacity;
 
-    auto __first  = ::cuda::std::ranges::begin(__range);
-    auto __middle = ::cuda::std::ranges::next(__first, __diff);
+    auto __first  = ::cuda::std::ranges::__begin_cpo{}(__range);
+    auto __middle = ::cuda::std::ranges::__next_cpo{}(__first, __diff);
     this->__uninitialized_move(__first, __middle, this->end());
     return __middle;
   }
@@ -1476,12 +1476,12 @@ public:
   try_append_range(_Range&& __range) noexcept(is_nothrow_move_constructible_v<_Tp>)
   {
     const auto __capacity = static_cast<ptrdiff_t>(_Capacity - this->size());
-    auto __first          = ::cuda::std::ranges::begin(__range);
-    const auto __size =
-      static_cast<ptrdiff_t>(::cuda::std::ranges::distance(__first, ::cuda::std::ranges::__unwrap_end(__range)));
+    auto __first          = ::cuda::std::ranges::__begin_cpo{}(__range);
+    const auto __size     = static_cast<ptrdiff_t>(
+      ::cuda::std::ranges::__distance_cpo{}(__first, ::cuda::std::ranges::__unwrap_end(__range)));
     const ptrdiff_t __diff = __size < __capacity ? __size : __capacity;
 
-    auto __middle = ::cuda::std::ranges::next(__first, __diff);
+    auto __middle = ::cuda::std::ranges::__next_cpo{}(__first, __diff);
     this->__uninitialized_move(__first, __middle, this->end());
     return __middle;
   }
@@ -1772,7 +1772,7 @@ public:
   _CCCL_API constexpr inplace_vector(from_range_t, _Range&& __range)
       : __base()
   {
-    if (::cuda::std::ranges::begin(__range) != ::cuda::std::ranges::end(__range))
+    if (::cuda::std::ranges::__begin_cpo{}(__range) != ::cuda::std::ranges::__end_cpo{}(__range))
     {
       _CCCL_THROW(::std::bad_alloc);
     }
@@ -1821,7 +1821,7 @@ public:
   _CCCL_REQUIRES(::cuda::std::ranges::__container_compatible_range<_Range, _Tp>)
   _CCCL_API constexpr void assign_range(_Range&& __range)
   {
-    if (::cuda::std::ranges::begin(__range) != ::cuda::std::ranges::end(__range))
+    if (::cuda::std::ranges::__begin_cpo{}(__range) != ::cuda::std::ranges::__end_cpo{}(__range))
     {
       _CCCL_THROW(::std::bad_alloc);
     }
@@ -1977,7 +1977,7 @@ public:
   _CCCL_REQUIRES(::cuda::std::ranges::__container_compatible_range<_Range, _Tp>)
   _CCCL_API constexpr iterator insert_range(const_iterator, _Range&& __range)
   {
-    if (::cuda::std::ranges::begin(__range) != ::cuda::std::ranges::end(__range))
+    if (::cuda::std::ranges::__begin_cpo{}(__range) != ::cuda::std::ranges::__end_cpo{}(__range))
     {
       _CCCL_THROW(::std::bad_alloc);
     }
@@ -1988,7 +1988,7 @@ public:
   _CCCL_REQUIRES(::cuda::std::ranges::__container_compatible_range<_Range, _Tp>)
   _CCCL_API constexpr void append_range(_Range&& __range)
   {
-    if (::cuda::std::ranges::begin(__range) != ::cuda::std::ranges::end(__range))
+    if (::cuda::std::ranges::__begin_cpo{}(__range) != ::cuda::std::ranges::__end_cpo{}(__range))
     {
       _CCCL_THROW(::std::bad_alloc);
     }
@@ -2036,7 +2036,7 @@ public:
   _CCCL_REQUIRES(::cuda::std::ranges::__container_compatible_range<_Range, _Tp>)
   _CCCL_API constexpr ::cuda::std::ranges::iterator_t<_Range> try_append_range(_Range&& __range) noexcept
   {
-    return ::cuda::std::ranges::begin(__range);
+    return ::cuda::std::ranges::__begin_cpo{}(__range);
   }
 
   using __base::unchecked_emplace_back;

--- a/libcudacxx/include/cuda/std/span
+++ b/libcudacxx/include/cuda/std/span
@@ -247,10 +247,12 @@ public:
   _CCCL_API constexpr __subspan_t<_Offset, _Count> subspan() const noexcept
   {
     // ternary avoids "pointless comparison of unsigned integer with zero" warning
-    static_assert(_Offset == 0 ? true : _Offset <= _Extent,
-                  "span<T, N>::subspan<Offset, Count>(): Offset out of range");
-    static_assert(_Count == dynamic_extent || (_Count == 0 ? true : _Count <= _Extent - _Offset),
-                  "span<T, N>::subspan<Offset, Count>(): Offset + Count out of range");
+    if constexpr (_Offset != 0)
+    {
+      static_assert(_Offset <= _Extent, "span<T, N>::subspan<Offset, Count>(): Offset out of range");
+      static_assert(_Count == dynamic_extent || _Count <= _Extent - _Offset,
+                    "span<T, N>::subspan<Offset, Count>(): Offset + Count out of range");
+    }
     return __subspan_t<_Offset, _Count>{data() + _Offset, _Count == dynamic_extent ? size() - _Offset : _Count};
   }
 

--- a/libcudacxx/include/cuda/std/span
+++ b/libcudacxx/include/cuda/std/span
@@ -178,9 +178,9 @@ public:
   _CCCL_TEMPLATE(class _Range)
   _CCCL_REQUIRES(__span_compatible_range<_Range, element_type>)
   _CCCL_API constexpr explicit span(_Range&& __r)
-      : __data_{::cuda::std::ranges::data(__r)}
+      : __data_{::cuda::std::ranges::__data_cpo{}(__r)}
   {
-    _CCCL_ASSERT(::cuda::std::ranges::size(__r) == _Extent, "size mismatch in span's constructor (range)");
+    _CCCL_ASSERT(::cuda::std::ranges::__size_cpo{}(__r) == _Extent, "size mismatch in span's constructor (range)");
   }
 
   // Deviation from P4144R1 Hana Dusikova's proposed fix: uses initializer_list<_InitListValueType>
@@ -432,8 +432,8 @@ public:
   _CCCL_TEMPLATE(class _Range)
   _CCCL_REQUIRES(__span_compatible_range<_Range, element_type>)
   _CCCL_API constexpr span(_Range&& __r)
-      : __data_(::cuda::std::ranges::data(__r))
-      , __size_{::cuda::std::ranges::size(__r)}
+      : __data_(::cuda::std::ranges::__data_cpo{}(__r))
+      , __size_{::cuda::std::ranges::__size_cpo{}(__r)}
   {}
 
   // Deviation from P4144R1 Hana Dusikova's proposed fix: uses initializer_list<_InitListValueType>

--- a/libcudacxx/include/cuda/std/span
+++ b/libcudacxx/include/cuda/std/span
@@ -250,6 +250,9 @@ public:
     if constexpr (_Offset != 0)
     {
       static_assert(_Offset <= _Extent, "span<T, N>::subspan<Offset, Count>(): Offset out of range");
+    }
+    if constexpr (_Count != 0)
+    {
       static_assert(_Count == dynamic_extent || _Count <= _Extent - _Offset,
                     "span<T, N>::subspan<Offset, Count>(): Offset + Count out of range");
     }

--- a/libcudacxx/include/cuda/std/string_view
+++ b/libcudacxx/include/cuda/std/string_view
@@ -223,8 +223,8 @@ public:
   _CCCL_TEMPLATE(class _Range)
   _CCCL_REQUIRES(__cccl_basic_sv_compatible_range<_Range, _CharT, _Traits>)
   _CCCL_API explicit constexpr basic_string_view(_Range&& __r)
-      : __data_{::cuda::std::ranges::data(__r)}
-      , __size_{::cuda::std::ranges::size(__r)}
+      : __data_{::cuda::std::ranges::__data_cpo{}(__r)}
+      , __size_{::cuda::std::ranges::__size_cpo{}(__r)}
   {}
 
   // msvc has problems with constructing a string view from another string view using the from ranges constructor,

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/all_arch_ids.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/all_arch_ids.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: return in loop statement is not supported
+
 #include <cuda/devices>
 #include <cuda/std/array>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_id.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_id.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: return in loop statement is not supported
+
 #include <cuda/devices>
 #include <cuda/std/cassert>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_id_fmt.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_id_fmt.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: return in loop statement is not supported
+
 #include <cuda/devices>
 
 #if __cpp_lib_format >= 201907L

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/compute_capability.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/compute_capability.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: return in loop statement is not supported
+
 // ADDITIONAL_COMPILE_DEFINITIONS: CCCL_IGNORE_DEPRECATED_API
 
 #include <cuda/devices>

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/compute_capability_fmt.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/compute_capability_fmt.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: return in loop statement is not supported
+
 #include <cuda/devices>
 
 #if __cpp_lib_format >= 201907L

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/is_specific_arch.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/is_specific_arch.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: return in loop statement is not supported
+
 #include <cuda/devices>
 #include <cuda/std/array>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/target_compute_capabilities.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/target_compute_capabilities.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: return in loop statement is not supported
+
 #include <cuda/devices>
 #include <cuda/std/array>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/default_accessor/accessor.restrict.functional.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/default_accessor/accessor.restrict.functional.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/mdspan>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/default_accessor/accessor.restrict.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/default_accessor/accessor.restrict.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/mdspan>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/assign.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // constexpr mdspan& operator=(const mdspan& rhs) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/conversion.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // template<class OtherElementType, class OtherExtents,

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.copy.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // constexpr mdspan(const mdspan&) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.move.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // constexpr mdspan(mdspan&&) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/deduction.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/mdspan>
 
 //  template<class CArray>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/move.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // constexpr mdspan& operator=(mdspan&&) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/assign.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // constexpr mdspan& operator=(const mdspan& rhs) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/conversion.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // template<class OtherElementType, class OtherExtents,

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.copy.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // constexpr mdspan(const mdspan&) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.move.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // constexpr mdspan(mdspan&&) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/deduction.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/mdspan>
 
 //  template<class CArray>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/move.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // constexpr mdspan& operator=(mdspan&&) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/comparison.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/mdspan>
 
 // template<class OtherMapping>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/contant_offset.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/contant_offset.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/mdspan>
 
 // Test layout_stride_relaxed::mapping with integral_constant as _OffsetType:

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/conversion.layout_stride.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/conversion.layout_stride.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/mdspan>
 
 // Test conversion operator from layout_stride_relaxed::mapping to layout_stride::mapping:

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/ctor.default.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/mdspan>
 
 // Test default construction:

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/ctor.extents_strides.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/ctor.extents_strides.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/mdspan>
 
 // constexpr mapping(const extents_type& e, const strides_type& s, offset_type offset = 0) noexcept;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/ctor.strided_mapping.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/ctor.strided_mapping.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/mdspan>
 
 // Converting constructor from strided layout mappings:

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/index_operator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/index_operator.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/mdspan>
 
 // Test index operator:

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/negative_stride_unsigned_index.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/negative_stride_unsigned_index.pass.cpp
@@ -8,8 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// XFAIL: enable-tile && !c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
 
 // <cuda/__mdspan/layout_stride_relaxed.h>
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/offset.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/offset.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/mdspan>
 
 // Test offset functionality specific to layout_stride_relaxed:

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/properties.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/mdspan>
 
 // Test properties of layout_stride_relaxed::mapping:

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/required_span_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/required_span_size.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/mdspan>
 
 // constexpr index_type required_span_size() const noexcept;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/stride.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/stride.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/mdspan>
 
 // constexpr index_type stride(rank_type i) const noexcept;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/assign.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // constexpr mdspan& operator=(const mdspan& rhs) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/conversion.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // template<class OtherElementType, class OtherExtents,

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.copy.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // constexpr mdspan(const mdspan&) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.move.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // constexpr mdspan(mdspan&&) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/deduction.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/mdspan>
 
 //  template<class CArray>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/move.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // constexpr mdspan& operator=(mdspan&&) = default;

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/deduction.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/mdspan>
 
 //  template<class CArray>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/deduction.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <cuda/mdspan>
 
 //  template<class CArray>

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/swap.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // <mdspan>
 //
 // friend constexpr void swap(mdspan& x, mdspan& y) noexcept;

--- a/libcudacxx/test/libcudacxx/force_include.h
+++ b/libcudacxx/test/libcudacxx/force_include.h
@@ -62,8 +62,7 @@ __global__
   void
   fake_main_kernel(int* ret)
 {
-  // We need to use atomicCAS to make sure we don't overwrite previous non-zero value.
-  atomicCAS(ret, 0, fake_main(0, nullptr));
+  *ret = fake_main(0, nullptr);
 }
 
 #define CUDA_CALL(err, ...)                                                                              \

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/copy.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/std/algorithm.copy.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/copy_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/copy_n.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/std/algorithm.copy_n.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/equal_range.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/equal_range.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 #include <cuda/std/algorithm.equal_range.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_end.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 #include <cuda/std/algorithm.find_end.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_first_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_first_of.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 #include <cuda/std/algorithm.find_first_of.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/merge.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/merge.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/std/algorithm.merge.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 #include <cuda/std/algorithm.partition.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/rotate_copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/rotate_copy.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/std/algorithm.rotate_copy.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/search.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/search.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 #include <cuda/std/algorithm.search.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/search_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/search_n.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 #include <cuda/std/algorithm.search_n.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/set_symmetric_difference.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/set_symmetric_difference.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/std/algorithm.set_symmetric_difference.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/set_union.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/set_union.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/std/algorithm.set_union.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/cast.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/cast.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // clang-format off
 #include <disable_nvfp_conversions_and_operators.h>
 // clang-format on

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/device_fp128_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/device_fp128_functions.pass.cpp
@@ -57,8 +57,8 @@ TEST_DEVICE_FUNC void test()
   assert(__nv_fp128_fdim(1.q, 1.q) == 0.q);
   assert(__nv_fp128_fmod(1.q, 1.q) == 0.q);
   assert(__nv_fp128_remainder(1.q, 1.q) == 0.q);
-  assert(__nv_fp128_frexp(1.q, &dummy_int) == 1.q);
-  assert(__nv_fp128_modf(1.q, &dummy_f128) == 1.q);
+  assert(__nv_fp128_frexp(1.q, &dummy_int) == 0.5q);
+  assert(__nv_fp128_modf(1.q, &dummy_f128) == 0.q);
   assert(__nv_fp128_hypot(3.q, 4.q) == 5.q);
   assert(__nv_fp128_fma(1.q, 1.q, 1.q) == 2.q);
   assert(__nv_fp128_ldexp(1.q, 0) == 1.q);

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/overflow_handler/no_sat.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/overflow_handler/no_sat.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // ADDITIONAL_COMPILE_OPTIONS_HOST: -fext-numeric-literals
 // ADDITIONAL_COMPILE_DEFINITIONS: CCCL_GCC_HAS_EXTENDED_NUMERIC_LITERALS
 

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/overflow_handler/sat_finite.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/overflow_handler/sat_finite.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // ADDITIONAL_COMPILE_OPTIONS_HOST: -fext-numeric-literals
 // ADDITIONAL_COMPILE_DEFINITIONS: CCCL_GCC_HAS_EXTENDED_NUMERIC_LITERALS
 

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/storage.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/storage.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // clang-format off
 #include <disable_nvfp_conversions_and_operators.h>
 // clang-format on

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memchr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memchr.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/std/__string/constexpr_c_functions.h>
 #include <cuda/std/type_traits>
 

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memmove.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memmove.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/std/__string/constexpr_c_functions.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strchr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strchr.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/std/__string/constexpr_c_functions.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_bidir.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_bidir.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // <algorithm>
 
 // template<InputIterator InIter, OutputIterator<auto, InIter::reference> OutIter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_cpp17.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_cpp17.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // <algorithm>
 
 // template<InputIterator InIter, OutputIterator<auto, InIter::reference> OutIter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_fwd.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_fwd.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // <algorithm>
 
 // template<InputIterator InIter, OutputIterator<auto, InIter::reference> OutIter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_n.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // <algorithm>
 
 // template<InputIterator InIter, OutputIterator<auto, InIter::reference> OutIter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_ptr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_ptr.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // <algorithm>
 
 // template<InputIterator InIter, OutputIterator<auto, InIter::reference> OutIter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_rand.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_rand.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // <algorithm>
 
 // template<InputIterator InIter, OutputIterator<auto, InIter::reference> OutIter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.random.sample/sample.stable.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.random.sample/sample.stable.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a non-__tile__ variable cannot be used in tile code
-
 // <algorithm>
 
 // template <class PopulationIterator, class SampleIterator, class Distance,

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.random.shuffle/random_shuffle_urng.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.random.shuffle/random_shuffle_urng.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a non-__tile__ variable cannot be used in tile code
-
 // <algorithm>
 
 // template<class RandomAccessIterator, class UniformRandomNumberGenerator>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.all_of/all_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.all_of/all_of.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // <algorithm>
 
 // template <class InputIterator, class Predicate>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.any_of/any_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.any_of/any_of.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // <algorithm>
 
 // template <class InputIterator, class Predicate>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // <algorithm>
 
 // template<InputIterator Iter1, InputIterator Iter2>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.end/find_end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.end/find_end.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <algorithm>
 
 // template<ForwardIterator Iter1, ForwardIterator Iter2>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.end/find_end_pred.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.end/find_end_pred.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <algorithm>
 
 // template<ForwardIterator Iter1, ForwardIterator Iter2,

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.first.of/find_first_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.first.of/find_first_of.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <algorithm>
 
 // template<InputIterator Iter1, ForwardIterator Iter2>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.first.of/find_first_of_pred.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find.first.of/find_first_of_pred.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <algorithm>
 
 // template<InputIterator Iter1, ForwardIterator Iter2,

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.none_of/none_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.none_of/none_of.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // <algorithm>
 
 // template <class InputIterator, class Predicate>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <algorithm>
 
 // template<ForwardIterator Iter1, ForwardIterator Iter2>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search_n.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <algorithm>
 
 // template<class ForwardIterator, class Size, class T>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search_n_pred.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search_n_pred.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <algorithm>
 
 // template<class ForwardIterator, class Size, class T, class BinaryPredicate>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search_pred.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.search/search_pred.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // <algorithm>
 
 // template<ForwardIterator Iter1, ForwardIterator Iter2>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // CONSTEXPR_STEPS: 15000000
 
 // <algorithm>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range_comp.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: a return statement inside a loop is not currently supported in a tile function
+
 // CONSTEXPR_STEPS: 15000000
 
 // <algorithm>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/make.heap/make_heap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/make.heap/make_heap.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <algorithm>
 
 // template<RandomAccessIterator Iter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/make.heap/make_heap_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/make.heap/make_heap_comp.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <algorithm>
 
 // template<RandomAccessIterator Iter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/sort_heap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/sort_heap.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <algorithm>
 
 // template<RandomAccessIterator Iter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/sort_heap_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/sort_heap_comp.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <algorithm>
 
 // template<RandomAccessIterator Iter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/next_permutation.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/next_permutation.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <algorithm>
 
 // template<BidirectionalIterator Iter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/next_permutation_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/next_permutation_comp.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <algorithm>
 
 // template<BidirectionalIterator Iter, StrictWeakOrder<auto, Iter::value_type> Compare>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/prev_permutation.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/prev_permutation.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <algorithm>
 
 // template<BidirectionalIterator Iter>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/prev_permutation_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.permutation.generators/prev_permutation_comp.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <algorithm>
 
 // template<BidirectionalIterator Iter, StrictWeakOrder<auto, Iter::value_type> Compare>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.union/set_union_move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.set.operations/set.union/set_union_move.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // <algorithm>
 
 // template<InputIterator InIter1, InputIterator InIter2, typename OutIter,

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // CONSTEXPR_STEPS: 15000000
 
 // <algorithm>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort_comp.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // CONSTEXPR_STEPS: 15000000
 
 // <algorithm>

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.order/memory_order_new.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.order/memory_order_new.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: asm statement is unsupported in tile code
-
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 // UNSUPPORTED: c++17

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan.extents.dims/compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan.extents.dims/compare.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/std/cassert>
 #include <cuda/std/mdspan>
 

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/assign.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // constexpr mdspan& operator=(const mdspan& rhs) = default;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/conversion.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // template<class OtherElementType, class OtherExtents,

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.copy.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // constexpr mdspan(const mdspan&) = default;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.move.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // constexpr mdspan(mdspan&&) = default;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/deduction.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 //  template<class CArray>

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/move.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 // <mdspan>
 
 // constexpr mdspan& operator=(mdspan&&) = default;

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.container/data.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.container/data.pass.cpp
@@ -57,8 +57,6 @@ TEST_FUNC void test_const_array(const T (&array)[Sz])
   assert(cuda::std::data(array) == &array[0]);
 }
 
-TEST_GLOBAL_VARIABLE constexpr int arrA[]{1, 2, 3};
-
 int main(int, char**)
 {
   cuda::std::inplace_vector<int, 3> v;
@@ -79,9 +77,8 @@ int main(int, char**)
   test_container(sv);
   test_const_container(sv);
 
-#if !_CCCL_TILE_COMPILATION() // error: a non-__tile__ variable ("arrA") cannot be used in tile code
+  constexpr int arrA[]{1, 2, 3};
   test_const_array(arrA);
-#endif // !_CCCL_TILE_COMPILATION()
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.container/empty.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.container/empty.pass.cpp
@@ -58,8 +58,6 @@ TEST_FUNC void test_const_array(const T (&array)[Sz])
   assert(!cuda::std::empty(array));
 }
 
-TEST_GLOBAL_VARIABLE constexpr int arrA[]{1, 2, 3};
-
 int main(int, char**)
 {
   cuda::std::inplace_vector<int, 3> v;
@@ -90,9 +88,8 @@ int main(int, char**)
   test_container(sv);
   test_const_container(sv);
 
-#if !_CCCL_TILE_COMPILATION() // error: a non-__tile__ variable ("arrA") cannot be used in tile code
+  constexpr int arrA[]{1, 2, 3};
   test_const_array(arrA);
-#endif // !_CCCL_TILE_COMPILATION()
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.container/size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.container/size.pass.cpp
@@ -58,8 +58,6 @@ TEST_FUNC void test_const_array(const T (&array)[Sz])
   assert(cuda::std::size(array) == Sz);
 }
 
-TEST_GLOBAL_VARIABLE constexpr int arrA[]{1, 2, 3};
-
 int main(int, char**)
 {
   cuda::std::inplace_vector<int, 3> v;
@@ -89,9 +87,8 @@ int main(int, char**)
   test_container(sv);
   test_const_container(sv);
 
-#if !_CCCL_TILE_COMPILATION() // error: a non-__tile__ variable ("arrA") cannot be used in tile code
+  constexpr int arrA[]{1, 2, 3};
   test_const_array(arrA);
-#endif // !_CCCL_TILE_COMPILATION()
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/insert.iter.op_assign/lv_value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/insert.iter.op_assign/lv_value.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/iterator>
 
 // insert_iterator

--- a/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugate_transposed.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugate_transposed.pass.cpp
@@ -8,7 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 // XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
+// error: a non-__tile__ variable cannot be used in tile code
 
 #include <cuda/std/cassert>
 #include <cuda/std/complex>

--- a/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugated.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugated.pass.cpp
@@ -8,7 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 // XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
+// error: a non-__tile__ variable cannot be used in tile code
 
 #include <cuda/std/cassert>
 #include <cuda/std/complex>

--- a/libcudacxx/test/libcudacxx/std/linalg/accessors/scaled.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/accessors/scaled.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/std/cassert>
 #include <cuda/std/linalg>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/std/linalg/layouts/transposed.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/layouts/transposed.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/std/cassert>
 #include <cuda/std/cstddef>
 #include <cuda/std/linalg>

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bit.cast/bit_cast.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bit.cast/bit_cast.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6077498: ICE when validating tile MLIR
-
 // <cuda/std/bit>
 //
 // template<class To, class From>

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bit.cast/bit_cast.trivially_copyable.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bit.cast/bit_cast.trivially_copyable.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6077498: ICE when validating tile MLIR
-
 // <cuda/std/bit>
 //
 // template<class To, class From>

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.flags/flags.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.flags/flags.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.flags], load and store flags

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.flags/multiple_overaligned.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.flags/multiple_overaligned.fail.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // flags<Flags...> allows at most one overaligned_flag<N>.
 
 #include <cuda/std/__simd_>

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.flags/non_flag_type.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.flags/non_flag_type.fail.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // flags<Flags...> requires every type in the pack to be one of
 // convert_flag, aligned_flag, or overaligned_flag<N>.
 

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.flags/non_power_of_two_overaligned.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.flags/non_power_of_two_overaligned.fail.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // overaligned_flag<N> requires N to be a power of two.
 
 #include <cuda/std/__simd_>

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.iterator/arithmetic.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.iterator/arithmetic.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.iterator], iterator arithmetic for __simd_iterator

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.iterator/begin_end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.iterator/begin_end.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.iterator], begin/end on basic_vec and basic_mask

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.iterator/comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.iterator/comparison.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.iterator], iterator comparisons for __simd_iterator

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.iterator/concept.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.iterator/concept.compile.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.iterator], ranges iterator/sentinel concept conformance for

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.iterator/const_conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.iterator/const_conversion.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.iterator], non-const to const iterator conversion for __simd_iterator.

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.iterator/derefence.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.iterator/derefence.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.iterator], dereference and subscript for __simd_iterator.

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.iterator/host_stl.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.iterator/host_stl.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // UNSUPPORTED: nvrtc
 
 // <cuda/std/__simd_>

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.iterator/iterator_traits.compile.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.iterator], spec-mandated nested typedefs and iterator_traits

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/binary.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/binary.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.mask.binary], basic_mask binary operators

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/comparison.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.mask.comparison], basic_mask comparisons (element-wise)

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/compound_assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/compound_assign.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.mask.cassign], basic_mask compound assignment

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/conversion.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.mask.conv], basic_mask conversions

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/ctor.pass.cpp
@@ -123,7 +123,7 @@ template <int Bytes, int N>
 TEST_FUNC constexpr void test_generator()
 {
   using Mask = simd::basic_mask<Bytes, simd::fixed_size<N>>;
-#if _CCCL_COMPILER(GCC, !=, 7)
+#if _CCCL_COMPILER(GCC, >=, 9)
   static_assert(!noexcept(Mask(is_even{})));
 #endif
 

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/ctor.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.mask.ctor], basic_mask constructors

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/instantiation.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/instantiation.fail.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // basic_mask<Bytes, Abi> requires Bytes to map to a valid integer type (1, 2, 4, 8, or 16 with __int128).
 
 #include <cuda/std/__simd_>

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/subscript.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/subscript.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.mask.subscr], basic_mask subscript operators

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/unary.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.mask.class/unary.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.mask.unary], basic_mask unary operators

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.reductions/all_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.reductions/all_of.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.mask.reductions], all_of

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.reductions/any_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.reductions/any_of.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.mask.reductions], any_of

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.reductions/none_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.reductions/none_of.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.mask.reductions], none_of

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.reductions/reduce.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.reductions/reduce.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.reductions], reduce

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.reductions/reduce_count.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.reductions/reduce_count.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.mask.reductions], reduce_count

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.reductions/reduce_max.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.reductions/reduce_max.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.reductions], reduce_max

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.reductions/reduce_max_index.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.reductions/reduce_max_index.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.mask.reductions], reduce_max_index

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.reductions/reduce_min.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.reductions/reduce_min.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.reductions], reduce_min

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.reductions/reduce_min_index.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.reductions/reduce_min_index.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.mask.reductions], reduce_min_index

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.traits/aliases.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.traits/aliases.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // template<class T, simd-size-type N> using vec  = ...;

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.traits/alignment.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.traits/alignment.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // template<class T, class U = typename T::value_type>

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.traits/rebind.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.traits/rebind.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // template<class T, class V> struct rebind;

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.traits/resize.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.traits/resize.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // template<simd-size-type N, class V> struct resize;

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.traits/vectorizable.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.traits/vectorizable.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.expos] __is_vectorizable_v: true for all standard integer types,

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/binary.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/binary.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.binary], basic_vec binary operators

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/comparison.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/comparison.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.comparison], basic_vec compare operators

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/compound_assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/compound_assign.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.cassign], basic_vec compound assignment

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/ctor.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.ctor], basic_vec constructors

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/deduction.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // CTAD is unsupported on MSVC.
 
 // UNSUPPORTED: msvc

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/instantiation.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/instantiation.fail.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // basic_vec<T, Abi> requires T to be a vectorizable type.
 // bool is explicitly excluded by the standard.
 

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/subscript.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/subscript.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.subscr], basic_vec subscript operators

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/unary.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/unary.pass.cpp
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/__simd_>
 
 // [simd.unary], basic_vec unary operators

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.common.view/adaptor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.common.view/adaptor.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// error: a non-__tile__ variable cannot be used in tile code
-
 // cuda::std::views::common
 
 #include <cuda/std/array>

--- a/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/array_func/memchr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/array_func/memchr.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/std/cstring>
 #include <cuda/std/type_traits>
 

--- a/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/array_func/memcmp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/array_func/memcmp.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // int memcmp(const void* lhs, const void* rhs, size_t count);
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/array_func/memmove.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/array_func/memmove.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // void* memmove(void* dst, const void* src, size_t count);
 
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/string_exam/strchr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/c.strings/cstring.syn/string_exam/strchr.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/std/cassert>
 #include <cuda/std/cstddef>
 #include <cuda/std/cstring>

--- a/libcudacxx/test/libcudacxx/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/find.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/find.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/std/__string_>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/find.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/find.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/std/__string_>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/find.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/find.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/std/__string_>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char8_t/find.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char8_t/find.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 #include <cuda/std/__string_>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/common_type_specialization.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/common_type_specialization.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // During the review D130295 it was noticed libc++'s implementation uses
 // cuda::std::common_type. When users specialize this template for their own types the
 // comparisons would fail. This tests with a specialized cuda::std::common_type.

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/equal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/equal.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // template<class charT, class traits>

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/greater.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/greater.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // template<class charT, class traits>

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/greater_equal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/greater_equal.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // template<class charT, class traits>

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/less.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/less.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // template<class charT, class traits>

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/less_equal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/less_equal.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // template<class charT, class traits>

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/not_equal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.comparison/not_equal.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // template<class charT, class traits>

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.cons/from_range.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.cons/from_range.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 //  template <class Range>

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_char_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_char_size.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr size_type find(charT c, size_type pos = 0) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_not_of_char_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_not_of_char_size.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr size_type find_first_not_of(charT c, size_type pos = 0) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_not_of_pointer_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_not_of_pointer_size.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr size_type find_first_not_of(const charT* s, size_type pos = 0) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_not_of_pointer_size_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_not_of_pointer_size_size.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr size_type find_first_not_of(const charT* s, size_type pos, size_type n) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_not_of_string_view_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_not_of_string_view_size.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // size_type find_first_not_of(const basic_string& str, size_type pos = 0) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_of_char_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_first_of_char_size.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr size_type find_first_of(charT c, size_type pos = 0) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_not_of_char_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_not_of_char_size.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr size_type find_last_not_of(charT c, size_type pos = 0) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_not_of_pointer_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_not_of_pointer_size.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr size_type find_last_not_of(const charT* s, size_type pos = npos) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_not_of_pointer_size_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_not_of_pointer_size_size.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr size_type find_last_not_of(const charT* s, size_type pos, size_type n) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_not_of_string_view_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_not_of_string_view_size.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // size_type find_last_not_of(const basic_string& str, size_type pos = npos) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_of_char_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_of_char_size.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr size_type find_last_of(charT c, size_type pos = 0) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_of_pointer_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_of_pointer_size.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr size_type find_last_of(const charT* s, size_type pos = npos) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_of_pointer_size_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_of_pointer_size_size.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr size_type find_last_of(const charT* s, size_type pos, size_type n) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_of_string_view_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_last_of_string_view_size.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // size_type find_last_of(const basic_string& str, size_type pos = npos) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_pointer_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_pointer_size.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr size_type find(const charT* s, size_type pos = 0) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_pointer_size_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_pointer_size_size.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr size_type find(const charT* s, size_type pos, size_type n) const;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_string_view_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/find_string_view_size.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr size_type find(basic_string_view s, size_type pos = 0) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/rfind_char_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.find/rfind_char_size.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr size_type rfind(charT c, size_type pos = npos) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.literals/literal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.literals/literal.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr string_view operator""sv(const char* str, size_t len) noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.ops/compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.ops/compare.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr int compare(basic_string_view str) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.ops/contains.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.ops/contains.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr bool contains(basic_string_view x) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.ops/ends_with.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.ops/ends_with.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr bool ends_with(basic_string_view x) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.ops/starts_with.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/strings/string.view/string.view.ops/starts_with.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/string_view>
 
 // constexpr bool starts_with(basic_string_view x) const noexcept;

--- a/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int16.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int16.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 #include <cuda/std/array>
 #include <cuda/std/charconv>
 #include <cuda/std/cstddef>

--- a/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int32.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int32.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 #include <cuda/std/array>
 #include <cuda/std/charconv>
 #include <cuda/std/cstddef>

--- a/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int64.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int64.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 #include <cuda/std/array>
 #include <cuda/std/charconv>
 #include <cuda/std/cstddef>

--- a/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int8.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int8.pass.cpp
@@ -8,9 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6067464: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!
-
 #include <cuda/std/array>
 #include <cuda/std/charconv>
 #include <cuda/std/cstddef>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg.store/make_format_args.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg.store/make_format_args.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/ctor.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/operator_bool.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/operator_bool.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/visit_format_arg.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/visit_format_arg.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/ctor.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/get.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/get.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/advance_to.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/advance_to.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/arg.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/arg.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/ctor.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/out.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/out.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.bool.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.bool.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.c_string.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.c_string.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.char.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.char.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.char_array.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.char_array.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.handle.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.handle.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.pointer.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.pointer.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.signed_integral.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.signed_integral.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.string.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.string.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.unsigned_integral.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.unsigned_integral.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
+// UNSUPPORTED: enable-tile
 // error: bit field read/write is unsupported in tile code
 
 // <cuda/std/format>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/advance_to.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/advance_to.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // constexpr void advance_to(const_iterator it);

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/begin.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/begin.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // constexpr begin() const noexcept;

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/check_arg_id.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/check_arg_id.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // constexpr void check_arg_id(size_t id);

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/ctor.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // constexpr explicit

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/end.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // constexpr end() const noexcept;

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/next_arg_id.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/next_arg_id.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // constexpr size_t next_arg_id();

--- a/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.assign/emplace_initializer_list.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.assign/emplace_initializer_list.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/optional>
 
 // template <class U, class... Args>

--- a/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.ctor/initializer_list.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.ctor/initializer_list.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // <cuda/std/optional>
 
 // template <class U, class... Args>

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/count.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/count.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6141774: Internal compiler error: Dependency graph after simplification validation failed!
-
 // size_t count() const; // constexpr since C++23
 
 #include <cuda/std/bitset>

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/left_shift.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/left_shift.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // The CI "Apple back-deployment with assertions enabled" needs a higher value
 // CONSTEXPR_STEPS: 12712420
 

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/left_shift_eq.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/left_shift_eq.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // bitset<N>& operator<<=(size_t pos); // constexpr since C++23
 
 #include <cuda/std/bitset>

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/op_eq_eq.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/op_eq_eq.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile && !c++17
-// nvbug6076227: ICE when validating tile MLIR
-
 // test:
 
 // bool operator==(const bitset<N>& rhs) const; // constexpr since C++23

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/right_shift.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/right_shift.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // bitset<N> operator>>(size_t pos) const; // constexpr since C++23
 
 #include <cuda/std/bitset>

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/right_shift_eq.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/right_shift_eq.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // CONSTEXPR_STEPS: 15000000
 
 // bitset<N>& operator<<=(size_t pos); // constexpr since C++23

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.operators/op_and.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.operators/op_and.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // bitset<N> operator&(const bitset<N>& lhs, const bitset<N>& rhs); // constexpr since C++23
 
 #include <cuda/std/bitset>

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.operators/op_not.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.operators/op_not.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // bitset<N> operator^(const bitset<N>& lhs, const bitset<N>& rhs); // constexpr since C++23
 
 #include <cuda/std/bitset>

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.operators/op_or.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.operators/op_or.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: enable-tile
-// nvbug6076227: ICE when validating tile MLIR
-
 // bitset<N> operator|(const bitset<N>& lhs, const bitset<N>& rhs); // constexpr since C++23
 
 #include <cuda/std/bitset>

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.assign/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.assign/move.pass.cpp
@@ -37,8 +37,8 @@ struct MoveAssignable
   MoveAssignable& operator=(MoveAssignable&&)      = default;
 };
 
-TEST_GLOBAL_VARIABLE int copied = 0;
-TEST_GLOBAL_VARIABLE int moved  = 0;
+[[maybe_unused]] TEST_GLOBAL_VARIABLE int copied = 0;
+[[maybe_unused]] TEST_GLOBAL_VARIABLE int moved  = 0;
 
 struct CountAssign
 {

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.assign/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.assign/move.pass.cpp
@@ -58,7 +58,9 @@ struct CountAssign
   }
   TEST_FUNC CountAssign& operator=(CountAssign&&)
   {
+#if !_CCCL_TILE_COMPILATION() // error: a non-__tile__ variable cannot be used in tile code
     ++moved;
+#endif // !_CCCL_TILE_COMPILATION()
     return *this;
   }
 };


### PR DESCRIPTION
This backports the Tile fixes from last week

fecc3a3e64 [Tile] enable some more tests (#9034)
fc9b3dfe4b [Tile] Try to appease tile compiler (#9035)
8d999fb1dc [Tile] Avoid return in switch statements in `variant` (#9032)
6bcc90d228 [Tile] Mark format tests as unsupported (#9033)
150c6ccd45 [Tile] Avoid calling a device only function in tile mode (#9031)
b4bf1a523f [Tile] Avoid internal usage of CPOs (#9023)
b7d70546b4 [Tile] Do not access global in tile mode (#9026)
9bb822127b [Tile] Avoid loops in bitset (#9027)
fe97deb941 [Tile] Avoid returns in loops in some algorithms (#9025)
e686071898 [Tile] Avoid use of `in_place` global (#9024)
9c11be2846 Fix mdspan support in modernized CUB interfaces (#9020)
f81d38588e [Tile] Mark some algorithms as `_CCCL_HOST_DEVICE_API` (#9018)
9cad2d05f6 [Tile] Avoid unused variable warnings (#9017)
671dc8e0d5 [libcu++] avoid warning about pointless comparison (#9016)
d4fa73372a [Tile] Avoid returns in loops in string functions (#9008)
559405840e [Tile] Make `arch_id` `_CCCL_HOST_DEVICE_API` (#9005)
5ac3dac26c Revert "[libcu++] Fix concurent return value writes during device testing (#8957)" (#9003)
801137386c [libcu++] Fix device fp128 functions test (#9015)
b52e9b3a37 [Tile] Avoid returns in loops in various algorithms (#9014)
2d320e5413 [Tile] Avoid unused variable warning (#9009)
a987210ee9 [Tile] Mark threading support as `_CCCL_HOST_DEVICE_API` (#9006)
6e33782a67 [Tile] Avoid return in loop in `variant` (#9011)
902b63fdf1 [Tile] Mark `simd` as `_CCCL_HOST_DEVICE` (#9013)
4c95e3c9b7 [Tile] avoid use of CPO in variant (#9012)
53093b400c [Tile] Avoid return in loop in `charconv` (#9010)
e508c88d95 [Tile] Avoid returning in a loop in `env` (#9007)
c0c5b95873 [Tile] avoid return in switch statement in `assume_aligned` (#9002)
74925c2b3e [Tile] Avoid returns inside loops in `mdspan` (#9004)
c257379169 [Tile] avoid returns in switch statements in logarithm (#9001)
db93bd15f3 Fix nightly GCC8 build regressions in bit_cast and DeviceReduce (#8924)
011f7b52be [libcu++] Fix `__detectably_invalid` value returned during constant evaluations (#8987)
e15d87a092 Use signed offset type for DevicePartition (#8971)
