### PR TITLE
Properly forward declare `allocator_arg_t`

### DIFF
--- a/libcudacxx/include/cuda/std/__fwd/allocator_arg_t.h
+++ b/libcudacxx/include/cuda/std/__fwd/allocator_arg_t.h
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___FWD_ALLOCATOR_ARG_T_H
+#define _CUDA_STD___FWD_ALLOCATOR_ARG_T_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_arg_t;
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD___FWD_ALLOCATOR_ARG_T_H

--- a/libcudacxx/include/cuda/std/__memory/allocator_arg_t.h
+++ b/libcudacxx/include/cuda/std/__memory/allocator_arg_t.h
@@ -22,6 +22,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__fwd/allocator_arg_t.h>
 #include <cuda/std/__memory/uses_allocator.h>
 #include <cuda/std/__new/device_new.h>
 #include <cuda/std/__type_traits/integral_constant.h>

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -20,9 +20,9 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__fwd/allocator_arg_t.h>
 #include <cuda/std/__fwd/get.h>
 #include <cuda/std/__fwd/tuple.h>
-#include <cuda/std/__memory/allocator_arg_t.h>
 #include <cuda/std/__tuple_dir/tuple_constraints.h>
 #include <cuda/std/__tuple_dir/tuple_element.h>
 #include <cuda/std/__tuple_dir/tuple_indices.h>

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -20,6 +20,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__fwd/allocator_arg_t.h>
 #include <cuda/std/__fwd/tuple.h>
 #include <cuda/std/__tuple_dir/make_tuple_types.h>
 #include <cuda/std/__tuple_dir/tuple_element.h>

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_leaf.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_leaf.h
@@ -20,9 +20,9 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__fwd/allocator_arg_t.h>
 #include <cuda/std/__fwd/get.h>
 #include <cuda/std/__fwd/tuple.h>
-#include <cuda/std/__memory/allocator_arg_t.h>
 #include <cuda/std/__tuple_dir/make_tuple_types.h>
 #include <cuda/std/__tuple_dir/sfinae_helpers.h>
 #include <cuda/std/__tuple_dir/tuple_constraints.h>


### PR DESCRIPTION
We do not need to include all of the header for just a struct