### PR TITLE
Drop obsolete function

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_merge.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_merge.cuh
@@ -16,6 +16,7 @@
 #include <cub/block/block_store.cuh>
 #include <cub/device/dispatch/tuning/common.cuh>
 #include <cub/thread/thread_load.cuh>
+#include <cub/util_math.cuh>
 
 #include <cuda/__device/compute_capability.h>
 #include <cuda/std/__algorithm/clamp.h>
@@ -63,11 +64,6 @@ template <typename T>
 concept merge_policy_selector = policy_selector<T, merge_policy>;
 #endif // _CCCL_HAS_CONCEPTS()
 
-_CCCL_HOST_DEVICE constexpr int nominal_4b_items_to_items(int nominal_4b_items_per_thread, int type_size)
-{
-  return ::cuda::std::clamp(nominal_4b_items_per_thread * 4 / type_size, 1, nominal_4b_items_per_thread);
-}
-
 struct policy_selector
 {
   int key_size;
@@ -77,7 +73,7 @@ struct policy_selector
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> merge_policy
   {
     const int tune_type_size = key_size + value_size;
-    const int ipt_800_plus   = nominal_4b_items_to_items(15, tune_type_size);
+    const int ipt_800_plus   = nominal_4B_items_to_items(15, tune_type_size);
 
     if (cc >= ::cuda::compute_capability{10, 0})
     {
@@ -106,12 +102,12 @@ struct policy_selector
 
     if (cc >= ::cuda::compute_capability{6, 0})
     {
-      const int ipt_600 = nominal_4b_items_to_items(15, tune_type_size);
+      const int ipt_600 = nominal_4B_items_to_items(15, tune_type_size);
       return merge_policy{512, ipt_600, LOAD_DEFAULT, BLOCK_STORE_WARP_TRANSPOSE, false};
     }
 
     // default is SM52
-    const int ipt_520 = nominal_4b_items_to_items(13, tune_type_size);
+    const int ipt_520 = nominal_4B_items_to_items(13, tune_type_size);
     return merge_policy{512, ipt_520, LOAD_LDG, BLOCK_STORE_WARP_TRANSPOSE, false};
   }
 };


### PR DESCRIPTION
We have the same function already in `<cub/util_math.cuh>`