### PR TITLE
Use `U32` in `by_key` benchmark

### DIFF
--- a/cub/benchmarks/bench/reduce/by_key.cu
+++ b/cub/benchmarks/bench/reduce/by_key.cu
@@ -37,27 +37,27 @@ static void reduce(nvbench::state& state, nvbench::type_list<KeyT, ValueT, Offse
 {
   using equality_op_t  = ::cuda::std::equal_to<>;
   using reduction_op_t = ::cuda::std::plus<>;
-  using offset_t       = OffsetT;
+  using offset_t       = cub::detail::choose_offset_t<OffsetT>;
 
   const auto elements                    = static_cast<std::size_t>(state.get_int64("Elements{io}"));
   constexpr std::size_t min_segment_size = 1;
   const std::size_t max_segment_size     = static_cast<std::size_t>(state.get_int64("MaxSegSize"));
 
-  thrust::device_vector<OffsetT> num_runs_out(1);
+  thrust::device_vector<offset_t> num_runs_out(1);
   thrust::device_vector<ValueT> in_vals(elements);
   thrust::device_vector<ValueT> out_vals(elements);
   thrust::device_vector<KeyT> out_keys(elements);
   thrust::device_vector<KeyT> in_keys = generate.uniform.key_segments(elements, min_segment_size, max_segment_size);
 
-  const KeyT* d_in_keys   = thrust::raw_pointer_cast(in_keys.data());
-  KeyT* d_out_keys        = thrust::raw_pointer_cast(out_keys.data());
-  const ValueT* d_in_vals = thrust::raw_pointer_cast(in_vals.data());
-  ValueT* d_out_vals      = thrust::raw_pointer_cast(out_vals.data());
-  OffsetT* d_num_runs_out = thrust::raw_pointer_cast(num_runs_out.data());
+  const KeyT* d_in_keys    = thrust::raw_pointer_cast(in_keys.data());
+  KeyT* d_out_keys         = thrust::raw_pointer_cast(out_keys.data());
+  const ValueT* d_in_vals  = thrust::raw_pointer_cast(in_vals.data());
+  ValueT* d_out_vals       = thrust::raw_pointer_cast(out_vals.data());
+  offset_t* d_num_runs_out = thrust::raw_pointer_cast(num_runs_out.data());
 
   std::uint8_t* d_temp_storage{};
   std::size_t temp_storage_bytes{};
-  const offset_t num_items = static_cast<offset_t>(elements);
+  const auto num_items = static_cast<offset_t>(elements);
 
   auto dispatch_on_stream = [&](cudaStream_t stream) {
     return cub::detail::reduce_by_key::dispatch(


### PR DESCRIPTION
To align with `cub::DeviceReduce::ReduceByKey`. This redefines the benchmark and probably impacts the reported performance.

Here is a benchmark showing how the baseline reported by this benchmark changes (on my local GPU, cluster is currently unavailable):
```
## [0] NVIDIA GeForce RTX 5090

|  KeyT{ct}  |  ValueT{ct}  |  OffsetT{ct}  |  Elements{io}  |  MaxSegSize  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|------------|--------------|---------------|----------------|--------------|------------|-------------|------------|-------------|------------|---------|----------|
|     I8     |      I8      |      I32      |      2^16      |     2^1      |   6.780 us |      14.01% |   6.738 us |      13.83% |  -0.042 us |  -0.61% |  🔵 SAME  |
|     I8     |      I8      |      I32      |      2^20      |     2^1      |  10.131 us |       4.49% |  10.173 us |       3.50% |   0.042 us |   0.41% |  🔵 SAME  |
|     I8     |      I8      |      I32      |      2^24      |     2^1      |  54.666 us |       1.74% |  55.285 us |       0.22% |   0.619 us |   1.13% |  🔴 SLOW  |
|     I8     |      I8      |      I32      |      2^28      |     2^1      | 741.349 us |       5.23% | 749.094 us |       5.64% |   7.745 us |   1.04% |  🔵 SAME  |
|     I8     |      I8      |      I32      |      2^16      |     2^4      |   6.158 us |       3.01% |   6.144 us |       0.00% |  -0.014 us |  -0.23% |  🟡 ????  |
|     I8     |      I8      |      I32      |      2^20      |     2^4      |  10.239 us |       0.07% |  10.240 us |       0.00% |   0.001 us |   0.01% |  🔴 SLOW  |
|     I8     |      I8      |      I32      |      2^24      |     2^4      |  51.200 us |       0.00% |  51.196 us |       0.02% |  -0.004 us |  -0.01% |  🟢 FAST  |
|     I8     |      I8      |      I32      |      2^28      |     2^4      | 640.029 us |       0.19% | 642.187 us |       0.16% |   2.157 us |   0.34% |  🔴 SLOW  |
|     I8     |      I8      |      I32      |      2^16      |     2^8      |   6.144 us |       0.25% |   6.143 us |       0.18% |  -0.001 us |  -0.02% |  🔵 SAME  |
|     I8     |      I8      |      I32      |      2^20      |     2^8      |  10.238 us |       0.14% |  10.237 us |       0.10% |  -0.002 us |  -0.02% |  🔵 SAME  |
|     I8     |      I8      |      I32      |      2^24      |     2^8      |  49.148 us |       0.02% |  49.221 us |       0.77% |   0.073 us |   0.15% |  🔴 SLOW  |
|     I8     |      I8      |      I32      |      2^28      |     2^8      | 624.399 us |       0.11% | 625.882 us |       0.16% |   1.483 us |   0.24% |  🔴 SLOW  |
|     I8     |     I16      |      I32      |      2^16      |     2^1      |   6.206 us |       5.71% |   6.274 us |       8.03% |   0.068 us |   1.09% |  🔵 SAME  |
|     I8     |     I16      |      I32      |      2^20      |     2^1      |  10.482 us |       6.30% |  10.537 us |       6.84% |   0.055 us |   0.53% |  🔵 SAME  |
|     I8     |     I16      |      I32      |      2^24      |     2^1      |  63.758 us |       1.09% |  63.909 us |       1.32% |   0.151 us |   0.24% |  🔵 SAME  |
|     I8     |     I16      |      I32      |      2^28      |     2^1      | 921.366 us |       6.45% | 920.684 us |       6.25% |  -0.682 us |  -0.07% |  🔵 SAME  |
|     I8     |     I16      |      I32      |      2^16      |     2^4      |   6.174 us |       4.09% |   6.190 us |       5.00% |   0.016 us |   0.26% |  🔵 SAME  |
|     I8     |     I16      |      I32      |      2^20      |     2^4      |  10.240 us |       0.00% |  10.297 us |       3.39% |   0.057 us |   0.56% |  🔴 SLOW  |
|     I8     |     I16      |      I32      |      2^24      |     2^4      |  53.253 us |       0.26% |  53.637 us |       1.51% |   0.384 us |   0.72% |  🔴 SLOW  |
|     I8     |     I16      |      I32      |      2^28      |     2^4      | 682.087 us |       0.17% | 685.555 us |       0.17% |   3.468 us |   0.51% |  🔴 SLOW  |
|     I8     |     I16      |      I32      |      2^16      |     2^8      |   6.145 us |       0.26% |   6.142 us |       0.18% |  -0.003 us |  -0.05% |  🔵 SAME  |
|     I8     |     I16      |      I32      |      2^20      |     2^8      |  10.218 us |       2.01% |  10.237 us |       0.09% |   0.019 us |   0.19% |  🔴 SLOW  |
|     I8     |     I16      |      I32      |      2^24      |     2^8      |  53.245 us |       0.02% |  53.248 us |       0.18% |   0.003 us |   0.01% |  🔵 SAME  |
|     I8     |     I16      |      I32      |      2^28      |     2^8      | 646.109 us |       0.16% | 649.310 us |       0.11% |   3.201 us |   0.50% |  🔴 SLOW  |
|     I8     |     I32      |      I32      |      2^16      |     2^1      |   7.876 us |       9.35% |   8.031 us |       6.79% |   0.156 us |   1.98% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^20      |     2^1      |  12.355 us |       2.97% |  12.288 us |       0.00% |  -0.067 us |  -0.54% |  🟡 ????  |
|     I8     |     I32      |      I32      |      2^24      |     2^1      |  96.223 us |       1.26% |  96.404 us |       1.33% |   0.180 us |   0.19% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^28      |     2^1      |   1.457 ms |       4.31% |   1.457 ms |       4.33% |  -0.191 us |  -0.01% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^16      |     2^4      |   6.251 us |       7.41% |   6.230 us |       6.69% |  -0.022 us |  -0.35% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^20      |     2^4      |  10.745 us |       8.22% |  10.945 us |       9.01% |   0.200 us |   1.86% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^24      |     2^4      |  75.420 us |       1.29% |  75.612 us |       1.13% |   0.192 us |   0.25% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^28      |     2^4      | 962.887 us |       0.17% | 963.149 us |       0.17% |   0.262 us |   0.03% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^16      |     2^8      |   6.144 us |       0.00% |   6.143 us |       0.11% |  -0.001 us |  -0.02% |  🟡 ????  |
|     I8     |     I32      |      I32      |      2^20      |     2^8      |  12.547 us |       5.45% |  12.514 us |       5.14% |  -0.033 us |  -0.26% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^24      |     2^8      |  72.635 us |       1.46% |  72.734 us |       1.50% |   0.099 us |   0.14% |  🔵 SAME  |
|     I8     |     I32      |      I32      |      2^28      |     2^8      | 860.195 us |       0.26% | 861.443 us |       0.27% |   1.248 us |   0.15% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^16      |     2^1      |   7.130 us |      14.33% |   6.976 us |      14.38% |  -0.155 us |  -2.17% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^20      |     2^1      |  16.525 us |       3.15% |  16.540 us |       3.29% |   0.015 us |   0.09% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^24      |     2^1      | 169.786 us |       0.53% | 169.826 us |       0.56% |   0.039 us |   0.02% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^28      |     2^1      |   2.609 ms |       1.95% |   2.609 ms |       2.27% |   0.265 us |   0.01% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^16      |     2^4      |   6.524 us |      12.19% |   6.560 us |      12.60% |   0.036 us |   0.56% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^20      |     2^4      |  14.765 us |       5.65% |  14.783 us |       5.73% |   0.018 us |   0.12% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^24      |     2^4      | 120.875 us |       0.52% | 120.885 us |       0.55% |   0.009 us |   0.01% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^28      |     2^4      |   1.709 ms |       0.14% |   1.711 ms |       0.14% |   1.686 us |   0.10% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^16      |     2^8      |   6.461 us |      11.48% |   6.517 us |      12.18% |   0.056 us |   0.87% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^20      |     2^8      |  15.753 us |       6.01% |  15.926 us |       5.34% |   0.173 us |   1.10% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^24      |     2^8      | 115.190 us |       0.82% | 115.469 us |       0.88% |   0.278 us |   0.24% |  🔵 SAME  |
|     I8     |     I64      |      I32      |      2^28      |     2^8      |   1.592 ms |       0.20% |   1.597 ms |       0.22% |   5.075 us |   0.32% |  🔴 SLOW  |
|     I8     |     I128     |      I32      |      2^16      |     2^1      |  10.239 us |       0.13% |  10.240 us |       0.00% |   0.001 us |   0.01% |  🔴 SLOW  |
|     I8     |     I128     |      I32      |      2^20      |     2^1      |  29.480 us |       3.40% |  29.580 us |       3.44% |   0.100 us |   0.34% |  🔵 SAME  |
|     I8     |     I128     |      I32      |      2^24      |     2^1      | 322.608 us |       0.46% | 322.807 us |       0.47% |   0.199 us |   0.06% |  🔵 SAME  |
|     I8     |     I128     |      I32      |      2^28      |     2^1      |   4.880 ms |       0.11% |   4.880 ms |       0.07% |  -0.150 us |  -0.00% |  🔵 SAME  |
|     I8     |     I128     |      I32      |      2^16      |     2^4      |  10.240 us |       0.00% |  10.240 us |       0.00% |   0.000 us |   0.00% |  🔵 SAME  |
|     I8     |     I128     |      I32      |      2^20      |     2^4      |  26.231 us |       3.08% |  26.302 us |       3.01% |   0.071 us |   0.27% |  🔵 SAME  |
|     I8     |     I128     |      I32      |      2^24      |     2^4      | 244.496 us |       0.47% | 246.064 us |       0.50% |   1.567 us |   0.64% |  🔴 SLOW  |
|     I8     |     I128     |      I32      |      2^28      |     2^4      |   3.575 ms |       0.14% |   3.598 ms |       0.12% |  23.148 us |   0.65% |  🔴 SLOW  |
|     I8     |     I128     |      I32      |      2^16      |     2^8      |   8.192 us |       0.19% |   8.188 us |       0.17% |  -0.004 us |  -0.05% |  🔵 SAME  |
|     I8     |     I128     |      I32      |      2^20      |     2^8      |  25.485 us |       4.00% |  25.575 us |       4.02% |   0.090 us |   0.35% |  🔵 SAME  |
|     I8     |     I128     |      I32      |      2^24      |     2^8      | 233.443 us |       0.43% | 235.358 us |       0.38% |   1.915 us |   0.82% |  🔴 SLOW  |
|     I8     |     I128     |      I32      |      2^28      |     2^8      |   3.356 ms |       0.36% |   3.394 ms |       0.09% |  38.592 us |   1.15% |  🔴 SLOW  |
|     I8     |     F32      |      I32      |      2^16      |     2^1      |   6.169 us |       3.69% |   6.222 us |       6.37% |   0.053 us |   0.85% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^20      |     2^1      |  12.842 us |       7.09% |  12.766 us |       6.80% |  -0.075 us |  -0.59% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^24      |     2^1      |  96.661 us |       1.21% |  96.585 us |       1.24% |  -0.075 us |  -0.08% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^28      |     2^1      |   1.456 ms |       4.38% |   1.455 ms |       3.85% |  -0.838 us |  -0.06% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^16      |     2^4      |   6.141 us |       0.22% |   6.142 us |       0.17% |   0.001 us |   0.02% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^20      |     2^4      |  12.603 us |       5.89% |  12.697 us |       6.45% |   0.094 us |   0.75% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^24      |     2^4      |  75.776 us |       0.00% |  75.874 us |       0.63% |   0.098 us |   0.13% |  🔴 SLOW  |
|     I8     |     F32      |      I32      |      2^28      |     2^4      | 970.514 us |       0.17% | 970.669 us |       0.18% |   0.155 us |   0.02% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^16      |     2^8      |   6.142 us |       0.20% |   6.140 us |       0.22% |  -0.002 us |  -0.03% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^20      |     2^8      |  12.555 us |       5.51% |  12.513 us |       5.15% |  -0.042 us |  -0.33% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^24      |     2^8      |  72.310 us |       1.34% |  72.183 us |       1.27% |  -0.127 us |  -0.18% |  🔵 SAME  |
|     I8     |     F32      |      I32      |      2^28      |     2^8      | 870.656 us |       0.28% | 871.039 us |       0.27% |   0.383 us |   0.04% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^16      |     2^1      |  10.170 us |       3.56% |  10.202 us |       2.54% |   0.032 us |   0.32% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^20      |     2^1      |  20.472 us |       0.48% |  20.496 us |       0.96% |   0.024 us |   0.12% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^24      |     2^1      | 173.791 us |       0.72% | 174.638 us |       0.67% |   0.848 us |   0.49% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^28      |     2^1      |   2.599 ms |       1.31% |   2.606 ms |       1.68% |   6.586 us |   0.25% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^16      |     2^4      |   8.782 us |      10.57% |   9.131 us |      11.17% |   0.349 us |   3.97% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^20      |     2^4      |  18.447 us |       1.07% |  18.609 us |       3.14% |   0.162 us |   0.88% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^24      |     2^4      | 142.226 us |       0.81% | 145.230 us |       0.68% |   3.004 us |   2.11% |  🔴 SLOW  |
|     I8     |     F64      |      I32      |      2^28      |     2^4      |   1.880 ms |       0.13% |   1.926 ms |       0.12% |  46.744 us |   2.49% |  🔴 SLOW  |
|     I8     |     F64      |      I32      |      2^16      |     2^8      |   8.190 us |       0.10% |   8.192 us |       0.00% |   0.002 us |   0.03% |  🔴 SLOW  |
|     I8     |     F64      |      I32      |      2^20      |     2^8      |  18.558 us |       2.69% |  18.902 us |       4.58% |   0.344 us |   1.85% |  🔵 SAME  |
|     I8     |     F64      |      I32      |      2^24      |     2^8      | 138.490 us |       0.78% | 141.176 us |       0.56% |   2.686 us |   1.94% |  🔴 SLOW  |
|     I8     |     F64      |      I32      |      2^28      |     2^8      |   1.778 ms |       0.13% |   1.839 ms |       0.11% |  60.561 us |   3.41% |  🔴 SLOW  |
|     I8     |     C32      |      I32      |      2^16      |     2^1      |   6.144 us |       0.00% |   6.144 us |       0.00% |   0.000 us |   0.00% |  🟡 ????  |
|     I8     |     C32      |      I32      |      2^20      |     2^1      |  16.384 us |       0.00% |  16.383 us |       0.04% |  -0.001 us |  -0.01% |  🟢 FAST  |
|     I8     |     C32      |      I32      |      2^24      |     2^1      | 172.550 us |       0.81% | 172.695 us |       0.78% |   0.145 us |   0.08% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^28      |     2^1      |   2.607 ms |       2.42% |   2.606 ms |       2.23% |  -0.672 us |  -0.03% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^16      |     2^4      |   6.637 us |      13.19% |   6.931 us |      14.38% |   0.295 us |   4.44% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^20      |     2^4      |  14.566 us |       4.46% |  14.705 us |       5.38% |   0.139 us |   0.95% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^24      |     2^4      | 120.983 us |       0.82% | 120.970 us |       0.76% |  -0.013 us |  -0.01% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^28      |     2^4      |   1.741 ms |       0.20% |   1.742 ms |       0.20% |   1.028 us |   0.06% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^16      |     2^8      |   6.254 us |       7.44% |   6.278 us |       8.14% |   0.024 us |   0.38% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^20      |     2^8      |  15.996 us |       5.01% |  16.048 us |       4.71% |   0.052 us |   0.32% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^24      |     2^8      | 112.976 us |       0.86% | 112.927 us |       0.92% |  -0.049 us |  -0.04% |  🔵 SAME  |
|     I8     |     C32      |      I32      |      2^28      |     2^8      |   1.569 ms |       0.25% |   1.569 ms |       0.24% |   0.653 us |   0.04% |  🔵 SAME  |
|    I16     |      I8      |      I32      |      2^16      |     2^1      |   6.178 us |       4.47% |   6.198 us |       5.46% |   0.019 us |   0.32% |  🔵 SAME  |
|    I16     |      I8      |      I32      |      2^20      |     2^1      |  10.345 us |       4.42% |  10.284 us |       3.01% |  -0.061 us |  -0.59% |  🔵 SAME  |
|    I16     |      I8      |      I32      |      2^24      |     2^1      |  61.116 us |       1.27% |  61.099 us |       1.27% |  -0.017 us |  -0.03% |  🔵 SAME  |
|    I16     |      I8      |      I32      |      2^28      |     2^1      | 892.496 us |       6.73% | 893.005 us |       6.95% |   0.509 us |   0.06% |  🔵 SAME  |
|    I16     |      I8      |      I32      |      2^16      |     2^4      |   6.144 us |       0.00% |   6.255 us |       7.69% |   0.111 us |   1.81% |  🟡 ????  |
|    I16     |      I8      |      I32      |      2^20      |     2^4      |  10.240 us |       0.00% |  10.240 us |       0.00% |   0.000 us |   0.00% |  🔵 SAME  |
|    I16     |      I8      |      I32      |      2^24      |     2^4      |  50.646 us |       1.79% |  50.791 us |       1.61% |   0.144 us |   0.29% |  🔵 SAME  |
|    I16     |      I8      |      I32      |      2^28      |     2^4      | 637.825 us |       0.17% | 639.113 us |       0.17% |   1.288 us |   0.20% |  🔴 SLOW  |
|    I16     |      I8      |      I32      |      2^16      |     2^8      |   6.204 us |       5.72% |   6.144 us |       0.00% |  -0.060 us |  -0.97% |  🟡 ????  |
|    I16     |      I8      |      I32      |      2^20      |     2^8      |  10.240 us |       0.00% |  10.235 us |       0.12% |  -0.005 us |  -0.04% |  🟢 FAST  |
|    I16     |      I8      |      I32      |      2^24      |     2^8      |  49.181 us |       0.53% |  49.267 us |       0.97% |   0.086 us |   0.17% |  🔵 SAME  |
|    I16     |      I8      |      I32      |      2^28      |     2^8      | 608.336 us |       0.07% | 610.247 us |       0.06% |   1.911 us |   0.31% |  🔴 SLOW  |
|    I16     |     I16      |      I32      |      2^16      |     2^1      |   6.588 us |      12.83% |   6.538 us |      12.38% |  -0.050 us |  -0.76% |  🔵 SAME  |
|    I16     |     I16      |      I32      |      2^20      |     2^1      |  12.288 us |       0.00% |  12.236 us |       2.56% |  -0.052 us |  -0.43% |  🟡 ????  |
|    I16     |     I16      |      I32      |      2^24      |     2^1      |  79.367 us |       1.21% |  79.361 us |       1.19% |  -0.005 us |  -0.01% |  🔵 SAME  |
|    I16     |     I16      |      I32      |      2^28      |     2^1      |   1.172 ms |       5.65% |   1.172 ms |       5.65% |  -0.020 us |  -0.00% |  🔵 SAME  |
|    I16     |     I16      |      I32      |      2^16      |     2^4      |   6.144 us |       0.00% |   6.143 us |       0.10% |  -0.001 us |  -0.02% |  🟡 ????  |
|    I16     |     I16      |      I32      |      2^20      |     2^4      |  10.439 us |       6.08% |  10.413 us |       5.54% |  -0.026 us |  -0.25% |  🔵 SAME  |
|    I16     |     I16      |      I32      |      2^24      |     2^4      |  59.395 us |       0.59% |  59.401 us |       0.26% |   0.006 us |   0.01% |  🔵 SAME  |
|    I16     |     I16      |      I32      |      2^28      |     2^4      | 774.588 us |       0.19% | 774.695 us |       0.19% |   0.107 us |   0.01% |  🔵 SAME  |
|    I16     |     I16      |      I32      |      2^16      |     2^8      |   6.412 us |      10.84% |   6.388 us |      10.47% |  -0.024 us |  -0.37% |  🔵 SAME  |
|    I16     |     I16      |      I32      |      2^20      |     2^8      |  10.515 us |       6.81% |  10.743 us |       8.22% |   0.228 us |   2.17% |  🔵 SAME  |
|    I16     |     I16      |      I32      |      2^24      |     2^8      |  55.804 us |       1.61% |  55.860 us |       1.65% |   0.056 us |   0.10% |  🔵 SAME  |
|    I16     |     I16      |      I32      |      2^28      |     2^8      | 690.222 us |       0.15% | 690.465 us |       0.15% |   0.242 us |   0.04% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^16      |     2^1      |   6.198 us |       5.31% |   6.144 us |       0.00% |  -0.054 us |  -0.87% |  🟡 ????  |
|    I16     |     I32      |      I32      |      2^20      |     2^1      |  13.265 us |       7.71% |  13.387 us |       7.63% |   0.122 us |   0.92% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^24      |     2^1      | 113.676 us |       1.15% | 113.800 us |       1.16% |   0.125 us |   0.11% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^28      |     2^1      |   1.743 ms |       3.81% |   1.743 ms |       3.88% |   0.052 us |   0.00% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^16      |     2^4      |   7.711 us |      11.25% |   7.810 us |      10.18% |   0.100 us |   1.29% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^20      |     2^4      |  12.288 us |       0.00% |  12.398 us |       3.76% |   0.110 us |   0.90% |  🟡 ????  |
|    I16     |     I32      |      I32      |      2^24      |     2^4      |  84.538 us |       1.15% |  84.433 us |       1.04% |  -0.105 us |  -0.12% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^28      |     2^4      |   1.130 ms |       0.14% |   1.129 ms |       0.14% |  -0.174 us |  -0.02% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^16      |     2^8      |   7.789 us |      10.44% |   7.762 us |      10.73% |  -0.026 us |  -0.34% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^20      |     2^8      |  12.288 us |       0.00% |  12.288 us |       0.00% |   0.000 us |   0.00% |  🟡 ????  |
|    I16     |     I32      |      I32      |      2^24      |     2^8      |  82.827 us |       1.61% |  82.791 us |       1.39% |  -0.036 us |  -0.04% |  🔵 SAME  |
|    I16     |     I32      |      I32      |      2^28      |     2^8      |   1.009 ms |       0.15% |   1.009 ms |       0.14% |   0.084 us |   0.01% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^16      |     2^1      |   6.141 us |       0.16% |   6.147 us |       1.91% |   0.007 us |   0.11% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^20      |     2^1      |  18.432 us |       0.00% |  18.432 us |       0.00% |   0.000 us |   0.00% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^24      |     2^1      | 187.000 us |       0.53% | 186.847 us |       0.52% |  -0.153 us |  -0.08% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^28      |     2^1      |   2.893 ms |       1.43% |   2.892 ms |       1.25% |  -0.490 us |  -0.02% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^16      |     2^4      |   6.353 us |       9.83% |   6.274 us |       8.02% |  -0.079 us |  -1.24% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^20      |     2^4      |  16.416 us |       1.62% |  16.412 us |       1.52% |  -0.004 us |  -0.02% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^24      |     2^4      | 131.545 us |       0.68% | 131.389 us |       0.58% |  -0.155 us |  -0.12% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^28      |     2^4      |   1.862 ms |       0.09% |   1.862 ms |       0.09% |  -0.170 us |  -0.01% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^16      |     2^8      |   6.875 us |      14.27% |   6.147 us |       1.74% |  -0.728 us | -10.59% |  🟢 FAST  |
|    I16     |     I64      |      I32      |      2^20      |     2^8      |  16.388 us |       0.70% |  16.416 us |       1.62% |   0.028 us |   0.17% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^24      |     2^8      | 123.403 us |       0.77% | 123.362 us |       0.71% |  -0.041 us |  -0.03% |  🔵 SAME  |
|    I16     |     I64      |      I32      |      2^28      |     2^8      |   1.663 ms |       0.10% |   1.665 ms |       0.11% |   2.411 us |   0.15% |  🔴 SLOW  |
|    I16     |     I128     |      I32      |      2^16      |     2^1      |  10.237 us |       0.12% |  10.240 us |       0.00% |   0.003 us |   0.03% |  🔴 SLOW  |
|    I16     |     I128     |      I32      |      2^20      |     2^1      |  30.585 us |       1.72% |  30.487 us |       2.13% |  -0.099 us |  -0.32% |  🔵 SAME  |
|    I16     |     I128     |      I32      |      2^24      |     2^1      | 339.432 us |       0.49% | 338.461 us |       0.46% |  -0.971 us |  -0.29% |  🔵 SAME  |
|    I16     |     I128     |      I32      |      2^28      |     2^1      |   5.193 ms |       0.23% |   5.194 ms |       0.23% |   1.542 us |   0.03% |  🔵 SAME  |
|    I16     |     I128     |      I32      |      2^16      |     2^4      |  10.240 us |       0.00% |   8.374 us |       7.03% |  -1.866 us | -18.22% |  🟢 FAST  |
|    I16     |     I128     |      I32      |      2^20      |     2^4      |  26.917 us |       2.68% |  27.136 us |       3.28% |   0.219 us |   0.81% |  🔵 SAME  |
|    I16     |     I128     |      I32      |      2^24      |     2^4      | 250.491 us |       0.43% | 251.032 us |       0.47% |   0.541 us |   0.22% |  🔵 SAME  |
|    I16     |     I128     |      I32      |      2^28      |     2^4      |   3.658 ms |       0.13% |   3.678 ms |       0.14% |  20.153 us |   0.55% |  🔴 SLOW  |
|    I16     |     I128     |      I32      |      2^16      |     2^8      |   8.344 us |       6.50% |   9.469 us |      10.48% |   1.125 us |  13.48% |  🔴 SLOW  |
|    I16     |     I128     |      I32      |      2^20      |     2^8      |  25.694 us |       3.97% |  25.760 us |       3.93% |   0.066 us |   0.26% |  🔵 SAME  |
|    I16     |     I128     |      I32      |      2^24      |     2^8      | 235.520 us |       0.00% | 238.285 us |       0.46% |   2.765 us |   1.17% |  🔴 SLOW  |
|    I16     |     I128     |      I32      |      2^28      |     2^8      |   3.390 ms |       0.07% |   3.418 ms |       0.07% |  27.221 us |   0.80% |  🔴 SLOW  |
|    I16     |     F32      |      I32      |      2^16      |     2^1      |   7.503 us |      12.84% |   7.451 us |      13.18% |  -0.053 us |  -0.70% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^20      |     2^1      |  12.288 us |       0.00% |  12.288 us |       0.00% |   0.000 us |   0.00% |  🟡 ????  |
|    I16     |     F32      |      I32      |      2^24      |     2^1      | 110.777 us |       0.62% | 111.043 us |       0.79% |   0.265 us |   0.24% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^28      |     2^1      |   1.742 ms |       3.66% |   1.740 ms |       3.26% |  -1.367 us |  -0.08% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^16      |     2^4      |   6.174 us |       4.18% |   6.191 us |       5.14% |   0.017 us |   0.27% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^20      |     2^4      |  10.989 us |       8.98% |  11.056 us |       9.08% |   0.067 us |   0.61% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^24      |     2^4      |  84.513 us |       1.09% |  84.407 us |       1.01% |  -0.105 us |  -0.12% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^28      |     2^4      |   1.118 ms |       0.46% |   1.117 ms |       0.50% |  -1.192 us |  -0.11% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^16      |     2^8      |   6.195 us |       5.37% |   6.161 us |       3.26% |  -0.035 us |  -0.56% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^20      |     2^8      |  10.718 us |       8.09% |  10.778 us |       8.36% |   0.059 us |   0.55% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^24      |     2^8      |  79.918 us |       0.69% |  79.864 us |       0.66% |  -0.054 us |  -0.07% |  🔵 SAME  |
|    I16     |     F32      |      I32      |      2^28      |     2^8      |   1.005 ms |       0.28% |   1.005 ms |       0.28% |   0.164 us |   0.02% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^16      |     2^1      |   8.189 us |       0.14% |   8.189 us |       0.14% |   0.000 us |   0.00% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^20      |     2^1      |  20.424 us |       1.58% |  20.432 us |       1.52% |   0.008 us |   0.04% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^24      |     2^1      | 188.534 us |       0.62% | 188.457 us |       0.62% |  -0.077 us |  -0.04% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^28      |     2^1      |   2.892 ms |       0.85% |   2.892 ms |       1.05% |   0.040 us |   0.00% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^16      |     2^4      |   8.190 us |       0.14% |   8.192 us |       0.00% |   0.002 us |   0.03% |  🔴 SLOW  |
|    I16     |     F64      |      I32      |      2^20      |     2^4      |  19.086 us |       5.02% |  19.128 us |       5.09% |   0.042 us |   0.22% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^24      |     2^4      | 137.544 us |       0.57% | 138.003 us |       0.74% |   0.458 us |   0.33% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^28      |     2^4      |   1.948 ms |       0.11% |   1.955 ms |       0.11% |   6.942 us |   0.36% |  🔴 SLOW  |
|    I16     |     F64      |      I32      |      2^16      |     2^8      |   8.188 us |       0.14% |   8.189 us |       0.14% |   0.000 us |   0.00% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^20      |     2^8      |  18.553 us |       2.64% |  18.571 us |       2.81% |   0.018 us |   0.10% |  🔵 SAME  |
|    I16     |     F64      |      I32      |      2^24      |     2^8      | 133.165 us |       0.59% | 133.972 us |       0.77% |   0.807 us |   0.61% |  🔴 SLOW  |
|    I16     |     F64      |      I32      |      2^28      |     2^8      |   1.806 ms |       0.08% |   1.820 ms |       0.09% |  14.162 us |   0.78% |  🔴 SLOW  |
|    I16     |     C32      |      I32      |      2^16      |     2^1      |   6.675 us |      13.55% |   6.578 us |      12.73% |  -0.097 us |  -1.45% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^20      |     2^1      |  16.491 us |       2.79% |  16.533 us |       3.27% |   0.043 us |   0.26% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^24      |     2^1      | 187.462 us |       0.64% | 187.461 us |       0.64% |  -0.000 us |  -0.00% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^28      |     2^1      |   2.895 ms |       2.25% |   2.894 ms |       2.15% |  -0.376 us |  -0.01% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^16      |     2^4      |   6.804 us |      14.09% |   6.792 us |      14.04% |  -0.013 us |  -0.19% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^20      |     2^4      |  16.354 us |       1.43% |  16.384 us |       0.00% |   0.030 us |   0.18% |  🔴 SLOW  |
|    I16     |     C32      |      I32      |      2^24      |     2^4      | 134.569 us |       1.21% | 134.704 us |       1.21% |   0.134 us |   0.10% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^28      |     2^4      |   1.897 ms |       0.15% |   1.899 ms |       0.16% |   1.669 us |   0.09% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^16      |     2^8      |   6.144 us |       0.15% |   6.974 us |      14.43% |   0.830 us |  13.52% |  🔴 SLOW  |
|    I16     |     C32      |      I32      |      2^20      |     2^8      |  15.504 us |       6.56% |  15.205 us |       6.66% |  -0.299 us |  -1.93% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^24      |     2^8      | 122.764 us |       0.90% | 122.715 us |       0.88% |  -0.049 us |  -0.04% |  🔵 SAME  |
|    I16     |     C32      |      I32      |      2^28      |     2^8      |   1.709 ms |       0.18% |   1.710 ms |       0.20% |   0.953 us |   0.06% |  🔵 SAME  |
|    I32     |      I8      |      I32      |      2^16      |     2^1      |   8.192 us |       0.00% |   8.155 us |       3.17% |  -0.037 us |  -0.45% |  🟢 FAST  |
|    I32     |      I8      |      I32      |      2^20      |     2^1      |  12.245 us |       2.32% |  12.286 us |       0.07% |   0.041 us |   0.33% |  🔴 SLOW  |
|    I32     |      I8      |      I32      |      2^24      |     2^1      |  95.316 us |       1.18% |  95.020 us |       1.10% |  -0.297 us |  -0.31% |  🔵 SAME  |
|    I32     |      I8      |      I32      |      2^28      |     2^1      |   1.456 ms |       4.22% |   1.455 ms |       4.11% |  -1.428 us |  -0.10% |  🔵 SAME  |
|    I32     |      I8      |      I32      |      2^16      |     2^4      |   7.129 us |      17.36% |   7.104 us |      14.44% |  -0.024 us |  -0.34% |  🔵 SAME  |
|    I32     |      I8      |      I32      |      2^20      |     2^4      |  10.901 us |       8.80% |  11.010 us |       9.01% |   0.108 us |   0.99% |  🔵 SAME  |
|    I32     |      I8      |      I32      |      2^24      |     2^4      |  72.442 us |       1.40% |  72.579 us |       1.42% |   0.137 us |   0.19% |  🔵 SAME  |
|    I32     |      I8      |      I32      |      2^28      |     2^4      | 975.117 us |       0.35% | 975.656 us |       0.35% |   0.539 us |   0.06% |  🔵 SAME  |
|    I32     |      I8      |      I32      |      2^16      |     2^8      |   8.192 us |       0.00% |   8.191 us |       0.06% |  -0.001 us |  -0.01% |  🟢 FAST  |
|    I32     |      I8      |      I32      |      2^20      |     2^8      |  10.238 us |       0.07% |  10.245 us |       1.05% |   0.007 us |   0.07% |  🔵 SAME  |
|    I32     |      I8      |      I32      |      2^24      |     2^8      |  69.850 us |       0.91% |  70.133 us |       1.26% |   0.283 us |   0.41% |  🔵 SAME  |
|    I32     |      I8      |      I32      |      2^28      |     2^8      | 880.860 us |       0.34% | 888.420 us |       0.52% |   7.561 us |   0.86% |  🔴 SLOW  |
|    I32     |     I16      |      I32      |      2^16      |     2^1      |   8.184 us |       0.68% |   8.190 us |       0.24% |   0.005 us |   0.06% |  🔵 SAME  |
|    I32     |     I16      |      I32      |      2^20      |     2^1      |  12.287 us |       0.04% |  12.288 us |       0.00% |   0.001 us |   0.01% |  🟡 ????  |
|    I32     |     I16      |      I32      |      2^24      |     2^1      | 112.881 us |       0.67% | 112.630 us |       0.66% |  -0.251 us |  -0.22% |  🔵 SAME  |
|    I32     |     I16      |      I32      |      2^28      |     2^1      |   1.741 ms |       3.71% |   1.740 ms |       3.77% |  -0.877 us |  -0.05% |  🔵 SAME  |
|    I32     |     I16      |      I32      |      2^16      |     2^4      |   7.969 us |       7.95% |   8.192 us |       0.00% |   0.223 us |   2.79% |  🔴 SLOW  |
|    I32     |     I16      |      I32      |      2^20      |     2^4      |  10.351 us |       4.50% |  10.368 us |       4.80% |   0.017 us |   0.17% |  🔵 SAME  |
|    I32     |     I16      |      I32      |      2^24      |     2^4      |  82.021 us |       0.62% |  82.001 us |       0.57% |  -0.020 us |  -0.02% |  🔵 SAME  |
|    I32     |     I16      |      I32      |      2^28      |     2^4      |   1.137 ms |       0.18% |   1.138 ms |       0.17% |   0.479 us |   0.04% |  🔵 SAME  |
|    I32     |     I16      |      I32      |      2^16      |     2^8      |   8.190 us |       0.09% |   6.144 us |       0.00% |  -2.046 us | -24.98% |  🟡 ????  |
|    I32     |     I16      |      I32      |      2^20      |     2^8      |  10.615 us |       7.45% |  11.052 us |       9.07% |   0.437 us |   4.12% |  🔵 SAME  |
|    I32     |     I16      |      I32      |      2^24      |     2^8      |  78.811 us |       1.30% |  79.133 us |       1.26% |   0.323 us |   0.41% |  🔵 SAME  |
|    I32     |     I16      |      I32      |      2^28      |     2^8      |   1.016 ms |       0.23% |   1.017 ms |       0.41% |   0.929 us |   0.09% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^16      |     2^1      |   8.188 us |       0.13% |   8.188 us |       0.13% |   0.000 us |   0.00% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^20      |     2^1      |  12.600 us |       5.85% |  12.589 us |       5.77% |  -0.011 us |  -0.09% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^24      |     2^1      | 147.122 us |       0.58% | 147.112 us |       0.61% |  -0.010 us |  -0.01% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^28      |     2^1      |   2.314 ms |       2.85% |   2.314 ms |       2.96% |   0.332 us |   0.01% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^16      |     2^4      |   6.568 us |      12.71% |   6.506 us |      12.04% |  -0.062 us |  -0.94% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^20      |     2^4      |  12.288 us |       0.00% |  12.288 us |       0.00% |   0.000 us |   0.00% |  🟡 ????  |
|    I32     |     I32      |      I32      |      2^24      |     2^4      | 104.288 us |       0.90% | 104.266 us |       0.84% |  -0.022 us |  -0.02% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^28      |     2^4      |   1.504 ms |       1.20% |   1.505 ms |       1.13% |   0.705 us |   0.05% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^16      |     2^8      |   8.188 us |       0.14% |   8.189 us |       0.11% |   0.001 us |   0.01% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^20      |     2^8      |  12.287 us |       0.06% |  12.288 us |       0.00% |   0.001 us |   0.01% |  🟡 ????  |
|    I32     |     I32      |      I32      |      2^24      |     2^8      | 100.086 us |       0.75% | 100.215 us |       0.65% |   0.129 us |   0.13% |  🔵 SAME  |
|    I32     |     I32      |      I32      |      2^28      |     2^8      |   1.335 ms |       0.32% |   1.335 ms |       0.30% |   0.368 us |   0.03% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^16      |     2^1      |   8.192 us |       0.00% |   8.190 us |       0.10% |  -0.002 us |  -0.03% |  🟢 FAST  |
|    I32     |     I64      |      I32      |      2^20      |     2^1      |  19.177 us |       5.16% |  19.071 us |       5.20% |  -0.107 us |  -0.56% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^24      |     2^1      | 220.253 us |       0.49% | 220.350 us |       0.50% |   0.098 us |   0.04% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^28      |     2^1      |   3.466 ms |       1.63% |   3.466 ms |       1.67% |   0.002 us |   0.00% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^16      |     2^4      |   8.190 us |       0.16% |   8.192 us |       0.00% |   0.002 us |   0.02% |  🔴 SLOW  |
|    I32     |     I64      |      I32      |      2^20      |     2^4      |  17.619 us |       5.70% |  17.788 us |       5.35% |   0.169 us |   0.96% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^24      |     2^4      | 151.396 us |       0.56% | 151.459 us |       0.55% |   0.064 us |   0.04% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^28      |     2^4      |   2.221 ms |       0.55% |   2.225 ms |       0.71% |   3.935 us |   0.18% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^16      |     2^8      |   8.191 us |       0.08% |   8.192 us |       0.00% |   0.001 us |   0.02% |  🔴 SLOW  |
|    I32     |     I64      |      I32      |      2^20      |     2^8      |  17.033 us |       5.61% |  17.024 us |       5.61% |  -0.009 us |  -0.05% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^24      |     2^8      | 144.025 us |       0.72% | 144.097 us |       0.78% |   0.073 us |   0.05% |  🔵 SAME  |
|    I32     |     I64      |      I32      |      2^28      |     2^8      |   1.971 ms |       0.11% |   1.971 ms |       0.10% |   0.316 us |   0.02% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^16      |     2^1      |  10.240 us |       0.00% |  10.240 us |       0.00% |   0.000 us |   0.00% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^20      |     2^1      |  32.225 us |       3.14% |  32.241 us |       3.11% |   0.016 us |   0.05% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^24      |     2^1      | 371.404 us |       0.39% | 371.450 us |       0.39% |   0.047 us |   0.01% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^28      |     2^1      |   5.776 ms |       0.05% |   5.776 ms |       0.05% |  -0.737 us |  -0.01% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^16      |     2^4      |  10.230 us |       1.14% |  10.209 us |       2.37% |  -0.021 us |  -0.21% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^20      |     2^4      |  27.683 us |       3.70% |  27.666 us |       3.71% |  -0.017 us |  -0.06% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^24      |     2^4      | 249.880 us |       0.51% | 250.839 us |       0.55% |   0.959 us |   0.38% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^28      |     2^4      |   3.834 ms |       0.29% |   3.844 ms |       0.13% |  10.731 us |   0.28% |  🔴 SLOW  |
|    I32     |     I128     |      I32      |      2^16      |     2^8      |  10.146 us |       4.18% |  10.170 us |       3.59% |   0.023 us |   0.23% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^20      |     2^8      |  26.327 us |       2.73% |  26.418 us |       2.31% |   0.091 us |   0.35% |  🔵 SAME  |
|    I32     |     I128     |      I32      |      2^24      |     2^8      | 240.454 us |       0.80% | 242.319 us |       0.68% |   1.865 us |   0.78% |  🔴 SLOW  |
|    I32     |     I128     |      I32      |      2^28      |     2^8      |   3.481 ms |       0.10% |   3.501 ms |       0.28% |  19.986 us |   0.57% |  🔴 SLOW  |
|    I32     |     F32      |      I32      |      2^16      |     2^1      |   8.189 us |       0.18% |   8.188 us |       0.33% |  -0.001 us |  -0.02% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^20      |     2^1      |  12.728 us |       6.61% |  12.705 us |       6.50% |  -0.023 us |  -0.18% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^24      |     2^1      | 147.978 us |       0.64% | 148.008 us |       0.67% |   0.030 us |   0.02% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^28      |     2^1      |   2.315 ms |       3.11% |   2.315 ms |       3.09% |   0.125 us |   0.01% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^16      |     2^4      |   8.189 us |       0.15% |   8.188 us |       0.13% |  -0.001 us |  -0.01% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^20      |     2^4      |  12.286 us |       0.06% |  12.287 us |       0.04% |   0.001 us |   0.01% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^24      |     2^4      | 102.815 us |       0.82% | 102.709 us |       0.76% |  -0.106 us |  -0.10% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^28      |     2^4      |   1.501 ms |       1.26% |   1.504 ms |       1.35% |   3.176 us |   0.21% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^16      |     2^8      |   8.189 us |       0.14% |   8.189 us |       0.12% |  -0.000 us |  -0.00% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^20      |     2^8      |  12.285 us |       0.08% |  12.288 us |       0.00% |   0.003 us |   0.03% |  🟡 ????  |
|    I32     |     F32      |      I32      |      2^24      |     2^8      | 100.316 us |       0.60% | 100.242 us |       0.70% |  -0.075 us |  -0.07% |  🔵 SAME  |
|    I32     |     F32      |      I32      |      2^28      |     2^8      |   1.337 ms |       0.30% |   1.338 ms |       0.30% |   0.383 us |   0.03% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^16      |     2^1      |  10.236 us |       0.10% |  10.238 us |       0.07% |   0.002 us |   0.02% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^20      |     2^1      |  22.239 us |       3.32% |  22.264 us |       3.31% |   0.026 us |   0.11% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^24      |     2^1      | 223.316 us |       0.44% | 223.317 us |       0.42% |   0.001 us |   0.00% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^28      |     2^1      |   3.466 ms |       1.20% |   3.465 ms |       0.86% |  -0.965 us |  -0.03% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^16      |     2^4      |   8.192 us |       0.00% |   8.192 us |       0.00% |   0.000 us |   0.00% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^20      |     2^4      |  20.515 us |       3.35% |  20.537 us |       3.01% |   0.022 us |   0.11% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^24      |     2^4      | 156.431 us |       0.84% | 156.094 us |       0.73% |  -0.337 us |  -0.22% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^28      |     2^4      |   2.231 ms |       0.12% |   2.237 ms |       0.11% |   6.517 us |   0.29% |  🔴 SLOW  |
|    I32     |     F64      |      I32      |      2^16      |     2^8      |   8.392 us |       7.29% |   8.192 us |       0.00% |  -0.200 us |  -2.39% |  🟢 FAST  |
|    I32     |     F64      |      I32      |      2^20      |     2^8      |  20.480 us |       0.00% |  19.353 us |       5.47% |  -1.127 us |  -5.50% |  🟢 FAST  |
|    I32     |     F64      |      I32      |      2^24      |     2^8      | 149.680 us |       1.24% | 149.908 us |       0.96% |   0.228 us |   0.15% |  🔵 SAME  |
|    I32     |     F64      |      I32      |      2^28      |     2^8      |   2.035 ms |       0.24% |   2.057 ms |       0.21% |  21.250 us |   1.04% |  🔴 SLOW  |
|    I32     |     C32      |      I32      |      2^16      |     2^1      |   8.188 us |       0.13% |   7.127 us |      14.35% |  -1.061 us | -12.96% |  🟢 FAST  |
|    I32     |     C32      |      I32      |      2^20      |     2^1      |  18.192 us |       3.62% |  18.335 us |       2.53% |   0.143 us |   0.79% |  🔵 SAME  |
|    I32     |     C32      |      I32      |      2^24      |     2^1      | 221.184 us |       0.00% | 222.409 us |       0.50% |   1.225 us |   0.55% |  🔴 SLOW  |
|    I32     |     C32      |      I32      |      2^28      |     2^1      |   3.469 ms |       1.91% |   3.469 ms |       1.73% |  -0.597 us |  -0.02% |  🔵 SAME  |
|    I32     |     C32      |      I32      |      2^16      |     2^4      |   6.578 us |      12.74% |   6.311 us |       8.99% |  -0.266 us |  -4.05% |  🔵 SAME  |
|    I32     |     C32      |      I32      |      2^20      |     2^4      |  16.399 us |       1.15% |  16.384 us |       0.00% |  -0.015 us |  -0.09% |  🟢 FAST  |
|    I32     |     C32      |      I32      |      2^24      |     2^4      | 158.526 us |       0.94% | 158.439 us |       0.98% |  -0.087 us |  -0.06% |  🔵 SAME  |
|    I32     |     C32      |      I32      |      2^28      |     2^4      |   2.241 ms |       0.10% |   2.242 ms |       0.11% |   0.995 us |   0.04% |  🔵 SAME  |
|    I32     |     C32      |      I32      |      2^16      |     2^8      |   6.670 us |      13.45% |   7.271 us |      13.99% |   0.601 us |   9.00% |  🔵 SAME  |
|    I32     |     C32      |      I32      |      2^20      |     2^8      |  16.384 us |       0.00% |  16.390 us |       0.88% |   0.006 us |   0.04% |  🔴 SLOW  |
|    I32     |     C32      |      I32      |      2^24      |     2^8      | 143.787 us |       0.88% | 143.173 us |       0.90% |  -0.613 us |  -0.43% |  🔵 SAME  |
|    I32     |     C32      |      I32      |      2^28      |     2^8      |   2.011 ms |       0.16% |   2.015 ms |       0.14% |   3.544 us |   0.18% |  🔴 SLOW  |
|    I64     |      I8      |      I32      |      2^16      |     2^1      |   6.141 us |       0.17% |   8.188 us |       0.14% |   2.047 us |  33.34% |  🔴 SLOW  |
|    I64     |      I8      |      I32      |      2^20      |     2^1      |  16.302 us |       2.43% |  16.171 us |       3.84% |  -0.130 us |  -0.80% |  🔵 SAME  |
|    I64     |      I8      |      I32      |      2^24      |     2^1      | 168.715 us |       0.81% | 168.672 us |       0.67% |  -0.044 us |  -0.03% |  🔵 SAME  |
|    I64     |      I8      |      I32      |      2^28      |     2^1      |   2.604 ms |       2.58% |   2.605 ms |       2.53% |   0.252 us |   0.01% |  🔵 SAME  |
|    I64     |      I8      |      I32      |      2^16      |     2^4      |   6.423 us |      11.02% |   6.362 us |      10.02% |  -0.061 us |  -0.95% |  🔵 SAME  |
|    I64     |      I8      |      I32      |      2^20      |     2^4      |  14.421 us |       2.86% |  14.431 us |       3.00% |   0.009 us |   0.06% |  🔵 SAME  |
|    I64     |      I8      |      I32      |      2^24      |     2^4      | 121.769 us |       1.02% | 121.958 us |       0.96% |   0.189 us |   0.16% |  🔵 SAME  |
|    I64     |      I8      |      I32      |      2^28      |     2^4      |   1.732 ms |       0.34% |   1.731 ms |       0.35% |  -0.640 us |  -0.04% |  🔵 SAME  |
|    I64     |      I8      |      I32      |      2^16      |     2^8      |   6.151 us |       2.13% |   6.144 us |       0.00% |  -0.007 us |  -0.11% |  🟡 ????  |
|    I64     |      I8      |      I32      |      2^20      |     2^8      |  14.336 us |       0.00% |  14.352 us |       1.25% |   0.016 us |   0.11% |  🟡 ????  |
|    I64     |      I8      |      I32      |      2^24      |     2^8      | 115.656 us |       1.00% | 115.640 us |       1.01% |  -0.015 us |  -0.01% |  🔵 SAME  |
|    I64     |      I8      |      I32      |      2^28      |     2^8      |   1.588 ms |       0.34% |   1.590 ms |       0.31% |   2.134 us |   0.13% |  🔵 SAME  |
|    I64     |     I16      |      I32      |      2^16      |     2^1      |   6.437 us |      11.15% |   6.144 us |       0.00% |  -0.293 us |  -4.55% |  🟡 ????  |
|    I64     |     I16      |      I32      |      2^20      |     2^1      |  16.384 us |       0.00% |  16.326 us |       2.09% |  -0.058 us |  -0.36% |  🟢 FAST  |
|    I64     |     I16      |      I32      |      2^24      |     2^1      | 186.622 us |       0.65% | 186.702 us |       0.67% |   0.080 us |   0.04% |  🔵 SAME  |
|    I64     |     I16      |      I32      |      2^28      |     2^1      |   2.889 ms |       2.25% |   2.888 ms |       2.09% |  -1.046 us |  -0.04% |  🔵 SAME  |
|    I64     |     I16      |      I32      |      2^16      |     2^4      |   6.601 us |      12.94% |   6.629 us |      13.15% |   0.028 us |   0.43% |  🔵 SAME  |
|    I64     |     I16      |      I32      |      2^20      |     2^4      |  14.429 us |       3.03% |  14.336 us |       0.00% |  -0.093 us |  -0.65% |  🟡 ????  |
|    I64     |     I16      |      I32      |      2^24      |     2^4      | 131.013 us |       0.86% | 131.031 us |       0.64% |   0.017 us |   0.01% |  🔵 SAME  |
|    I64     |     I16      |      I32      |      2^28      |     2^4      |   1.876 ms |       0.21% |   1.876 ms |       0.22% |   0.289 us |   0.02% |  🔵 SAME  |
|    I64     |     I16      |      I32      |      2^16      |     2^8      |   6.148 us |       1.76% |   6.148 us |       1.92% |  -0.000 us |  -0.00% |  🔵 SAME  |
|    I64     |     I16      |      I32      |      2^20      |     2^8      |  14.319 us |       1.16% |  14.332 us |       0.09% |   0.013 us |   0.09% |  🔴 SLOW  |
|    I64     |     I16      |      I32      |      2^24      |     2^8      | 126.208 us |       1.00% | 126.258 us |       0.91% |   0.050 us |   0.04% |  🔵 SAME  |
|    I64     |     I16      |      I32      |      2^28      |     2^8      |   1.695 ms |       0.30% |   1.699 ms |       0.31% |   3.640 us |   0.21% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^16      |     2^1      |   8.189 us |       0.12% |   8.192 us |       0.00% |   0.003 us |   0.04% |  🔴 SLOW  |
|    I64     |     I32      |      I32      |      2^20      |     2^1      |  16.384 us |       0.00% |  16.474 us |       2.64% |   0.090 us |   0.55% |  🔴 SLOW  |
|    I64     |     I32      |      I32      |      2^24      |     2^1      | 218.420 us |       0.62% | 218.691 us |       0.61% |   0.271 us |   0.12% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^28      |     2^1      |   3.462 ms |       1.70% |   3.460 ms |       1.30% |  -1.452 us |  -0.04% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^16      |     2^4      |   6.140 us |       0.18% |   6.142 us |       0.17% |   0.002 us |   0.03% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^20      |     2^4      |  16.340 us |       1.75% |  16.339 us |       1.75% |  -0.001 us |  -0.01% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^24      |     2^4      | 151.489 us |       0.67% | 151.452 us |       0.59% |  -0.037 us |  -0.02% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^28      |     2^4      |   2.211 ms |       0.27% |   2.211 ms |       0.26% |   0.374 us |   0.02% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^16      |     2^8      |   6.231 us |       6.79% |   6.152 us |       2.34% |  -0.079 us |  -1.27% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^20      |     2^8      |  16.161 us |       4.07% |  16.281 us |       2.70% |   0.121 us |   0.75% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^24      |     2^8      | 147.865 us |       1.04% | 148.303 us |       1.05% |   0.439 us |   0.30% |  🔵 SAME  |
|    I64     |     I32      |      I32      |      2^28      |     2^8      |   1.984 ms |       0.15% |   1.984 ms |       0.15% |   0.189 us |   0.01% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^16      |     2^1      |   8.190 us |       0.10% |   8.189 us |       0.12% |  -0.001 us |  -0.01% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^20      |     2^1      |  19.625 us |       5.22% |  19.762 us |       5.06% |   0.138 us |   0.70% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^24      |     2^1      | 291.171 us |       0.61% | 291.267 us |       0.59% |   0.096 us |   0.03% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^28      |     2^1      |   4.615 ms |       1.45% |   4.612 ms |       0.76% |  -3.133 us |  -0.07% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^16      |     2^4      |   8.188 us |       0.13% |   8.195 us |       1.45% |   0.007 us |   0.09% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^20      |     2^4      |  18.586 us |       2.91% |  18.565 us |       2.76% |  -0.021 us |  -0.11% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^24      |     2^4      | 197.108 us |       0.59% | 197.300 us |       0.67% |   0.193 us |   0.10% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^28      |     2^4      |   2.957 ms |       0.39% |   2.956 ms |       0.36% |  -0.607 us |  -0.02% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^16      |     2^8      |   6.462 us |      11.55% |   6.435 us |      11.20% |  -0.027 us |  -0.43% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^20      |     2^8      |  18.542 us |       2.49% |  18.504 us |       2.09% |  -0.038 us |  -0.20% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^24      |     2^8      | 189.144 us |       1.30% | 188.770 us |       1.10% |  -0.374 us |  -0.20% |  🔵 SAME  |
|    I64     |     I64      |      I32      |      2^28      |     2^8      |   2.619 ms |       0.10% |   2.619 ms |       0.10% |   0.209 us |   0.01% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^16      |     2^1      |  10.237 us |       0.34% |  10.237 us |       0.10% |  -0.000 us |  -0.00% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^20      |     2^1      |  33.298 us |       2.70% |  33.080 us |       2.24% |  -0.218 us |  -0.66% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^24      |     2^1      | 439.997 us |       0.31% | 439.943 us |       0.31% |  -0.054 us |  -0.01% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^28      |     2^1      |   6.921 ms |       0.03% |   6.922 ms |       0.16% |   0.304 us |   0.00% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^16      |     2^4      |   9.819 us |       8.38% |   9.867 us |       7.97% |   0.048 us |   0.49% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^20      |     2^4      |  29.858 us |       3.43% |  29.886 us |       3.41% |   0.028 us |   0.09% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^24      |     2^4      | 297.438 us |       1.07% | 297.272 us |       1.10% |  -0.166 us |  -0.06% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^28      |     2^4      |   4.417 ms |       0.27% |   4.416 ms |       0.12% |  -1.369 us |  -0.03% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^16      |     2^8      |   9.184 us |      11.14% |   9.433 us |      10.59% |   0.250 us |   2.72% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^20      |     2^8      |  28.049 us |       3.40% |  28.170 us |       3.15% |   0.120 us |   0.43% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^24      |     2^8      | 266.770 us |       0.37% | 266.989 us |       0.39% |   0.219 us |   0.08% |  🔵 SAME  |
|    I64     |     I128     |      I32      |      2^28      |     2^8      |   3.969 ms |       0.13% |   3.971 ms |       0.12% |   2.050 us |   0.05% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^16      |     2^1      |   8.189 us |       0.13% |   8.192 us |       0.00% |   0.003 us |   0.04% |  🔴 SLOW  |
|    I64     |     F32      |      I32      |      2^20      |     2^1      |  16.509 us |       3.01% |  16.474 us |       2.59% |  -0.036 us |  -0.22% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^24      |     2^1      | 221.251 us |       0.68% | 221.128 us |       0.57% |  -0.123 us |  -0.06% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^28      |     2^1      |   3.459 ms |       1.49% |   3.460 ms |       1.70% |   0.681 us |   0.02% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^16      |     2^4      |   6.944 us |      14.41% |   6.856 us |      14.26% |  -0.088 us |  -1.27% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^20      |     2^4      |  16.375 us |       1.88% |  16.332 us |       2.43% |  -0.044 us |  -0.27% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^24      |     2^4      | 151.016 us |       0.74% | 150.817 us |       0.75% |  -0.199 us |  -0.13% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^28      |     2^4      |   2.208 ms |       0.24% |   2.208 ms |       0.69% |   0.772 us |   0.03% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^16      |     2^8      |   6.853 us |      14.25% |   6.755 us |      13.93% |  -0.099 us |  -1.44% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^20      |     2^8      |  16.315 us |       2.64% |  16.271 us |       3.04% |  -0.044 us |  -0.27% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^24      |     2^8      | 145.998 us |       0.93% | 145.884 us |       0.86% |  -0.114 us |  -0.08% |  🔵 SAME  |
|    I64     |     F32      |      I32      |      2^28      |     2^8      |   1.986 ms |       0.18% |   1.986 ms |       0.16% |  -0.076 us |  -0.00% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^16      |     2^1      |   8.332 us |       6.23% |   8.301 us |       5.55% |  -0.031 us |  -0.37% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^20      |     2^1      |  21.631 us |       4.70% |  21.750 us |       4.58% |   0.119 us |   0.55% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^24      |     2^1      | 292.511 us |       0.66% | 292.381 us |       0.61% |  -0.130 us |  -0.04% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^28      |     2^1      |   4.612 ms |       0.66% |   4.612 ms |       1.03% |   0.329 us |   0.01% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^16      |     2^4      |   8.192 us |       0.00% |   8.192 us |       0.00% |   0.000 us |   0.00% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^20      |     2^4      |  20.639 us |       2.76% |  20.609 us |       2.55% |  -0.031 us |  -0.15% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^24      |     2^4      | 200.122 us |       0.84% | 200.421 us |       1.01% |   0.299 us |   0.15% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^28      |     2^4      |   2.937 ms |       0.15% |   2.936 ms |       0.16% |  -0.766 us |  -0.03% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^16      |     2^8      |   8.192 us |       0.00% |   8.192 us |       0.00% |   0.000 us |   0.00% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^20      |     2^8      |  20.602 us |       2.75% |  20.595 us |       2.71% |  -0.007 us |  -0.03% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^24      |     2^8      | 189.850 us |       0.94% | 189.662 us |       0.92% |  -0.187 us |  -0.10% |  🔵 SAME  |
|    I64     |     F64      |      I32      |      2^28      |     2^8      |   2.627 ms |       0.15% |   2.627 ms |       0.17% |   0.183 us |   0.01% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^16      |     2^1      |   7.060 us |      14.42% |   7.372 us |      13.58% |   0.311 us |   4.41% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^20      |     2^1      |  20.551 us |       2.04% |  20.586 us |       2.22% |   0.035 us |   0.17% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^24      |     2^1      | 291.372 us |       0.32% | 291.585 us |       0.36% |   0.213 us |   0.07% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^28      |     2^1      |   4.613 ms |       0.86% |   4.614 ms |       0.54% |   0.221 us |   0.00% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^16      |     2^4      |   7.601 us |      12.19% |   6.150 us |       2.25% |  -1.451 us | -19.09% |  🟢 FAST  |
|    I64     |     C32      |      I32      |      2^20      |     2^4      |  18.529 us |       2.38% |  18.676 us |       3.62% |   0.147 us |   0.80% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^24      |     2^4      | 203.712 us |       0.95% | 203.939 us |       0.89% |   0.227 us |   0.11% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^28      |     2^4      |   2.940 ms |       0.64% |   2.939 ms |       0.08% |  -0.817 us |  -0.03% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^16      |     2^8      |   7.754 us |      10.80% |   6.177 us |       4.36% |  -1.578 us | -20.34% |  🟢 FAST  |
|    I64     |     C32      |      I32      |      2^20      |     2^8      |  18.432 us |       0.00% |  18.465 us |       1.48% |   0.033 us |   0.18% |  🔴 SLOW  |
|    I64     |     C32      |      I32      |      2^24      |     2^8      | 185.031 us |       0.62% | 185.596 us |       0.68% |   0.566 us |   0.31% |  🔵 SAME  |
|    I64     |     C32      |      I32      |      2^28      |     2^8      |   2.641 ms |       0.10% |   2.640 ms |       0.10% |  -0.742 us |  -0.03% |  🔵 SAME  |
|    I128    |      I8      |      I32      |      2^16      |     2^1      |   8.192 us |       0.00% |   8.190 us |       0.11% |  -0.002 us |  -0.03% |  🟢 FAST  |
|    I128    |      I8      |      I32      |      2^20      |     2^1      |  27.167 us |       3.59% |  27.287 us |       3.58% |   0.120 us |   0.44% |  🔵 SAME  |
|    I128    |      I8      |      I32      |      2^24      |     2^1      | 313.991 us |       0.34% | 314.231 us |       0.38% |   0.240 us |   0.08% |  🔵 SAME  |
|    I128    |      I8      |      I32      |      2^28      |     2^1      |   4.892 ms |       1.53% |   4.892 ms |       1.50% |   0.108 us |   0.00% |  🔵 SAME  |
|    I128    |      I8      |      I32      |      2^16      |     2^4      |   8.192 us |       0.00% |   7.621 us |      12.01% |  -0.571 us |  -6.97% |  🟢 FAST  |
|    I128    |      I8      |      I32      |      2^20      |     2^4      |  24.657 us |       2.92% |  24.626 us |       3.24% |  -0.031 us |  -0.13% |  🔵 SAME  |
|    I128    |      I8      |      I32      |      2^24      |     2^4      | 239.264 us |       1.07% | 238.650 us |       1.01% |  -0.614 us |  -0.26% |  🔵 SAME  |
|    I128    |      I8      |      I32      |      2^28      |     2^4      |   3.556 ms |       0.27% |   3.544 ms |       0.26% | -12.017 us |  -0.34% |  🟢 FAST  |
|    I128    |      I8      |      I32      |      2^16      |     2^8      |   8.188 us |       0.12% |   8.188 us |       0.12% |  -0.000 us |  -0.00% |  🔵 SAME  |
|    I128    |      I8      |      I32      |      2^20      |     2^8      |  24.457 us |       3.38% |  24.343 us |       3.95% |  -0.114 us |  -0.46% |  🔵 SAME  |
|    I128    |      I8      |      I32      |      2^24      |     2^8      | 232.251 us |       0.92% | 232.156 us |       0.87% |  -0.096 us |  -0.04% |  🔵 SAME  |
|    I128    |      I8      |      I32      |      2^28      |     2^8      |   3.434 ms |       0.38% |   3.439 ms |       0.23% |   5.446 us |   0.16% |  🔵 SAME  |
|    I128    |     I16      |      I32      |      2^16      |     2^1      |   8.188 us |       0.13% |   8.192 us |       0.00% |   0.004 us |   0.04% |  🔴 SLOW  |
|    I128    |     I16      |      I32      |      2^20      |     2^1      |  28.347 us |       3.05% |  28.237 us |       3.18% |  -0.110 us |  -0.39% |  🔵 SAME  |
|    I128    |     I16      |      I32      |      2^24      |     2^1      | 328.674 us |       0.34% | 328.504 us |       0.31% |  -0.170 us |  -0.05% |  🔵 SAME  |
|    I128    |     I16      |      I32      |      2^28      |     2^1      |   5.177 ms |       0.53% |   5.180 ms |       1.13% |   2.688 us |   0.05% |  🔵 SAME  |
|    I128    |     I16      |      I32      |      2^16      |     2^4      |   8.190 us |       0.11% |   8.188 us |       0.13% |  -0.002 us |  -0.02% |  🔵 SAME  |
|    I128    |     I16      |      I32      |      2^20      |     2^4      |  24.557 us |       4.04% |  24.571 us |       3.82% |   0.014 us |   0.06% |  🔵 SAME  |
|    I128    |     I16      |      I32      |      2^24      |     2^4      | 244.393 us |       1.75% | 242.525 us |       1.64% |  -1.868 us |  -0.76% |  🔵 SAME  |
|    I128    |     I16      |      I32      |      2^28      |     2^4      |   3.589 ms |       0.44% |   3.575 ms |       0.44% | -14.147 us |  -0.39% |  🔵 SAME  |
|    I128    |     I16      |      I32      |      2^16      |     2^8      |   8.192 us |       0.00% |   8.189 us |       0.11% |  -0.003 us |  -0.03% |  🟢 FAST  |
|    I128    |     I16      |      I32      |      2^20      |     2^8      |  24.312 us |       4.05% |  24.144 us |       4.63% |  -0.168 us |  -0.69% |  🔵 SAME  |
|    I128    |     I16      |      I32      |      2^24      |     2^8      | 236.403 us |       1.34% | 236.503 us |       1.36% |   0.100 us |   0.04% |  🔵 SAME  |
|    I128    |     I16      |      I32      |      2^28      |     2^8      |   3.504 ms |       0.25% |   3.510 ms |       0.35% |   6.405 us |   0.18% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^16      |     2^1      |   8.188 us |       0.14% |   8.192 us |       0.00% |   0.004 us |   0.04% |  🔴 SLOW  |
|    I128    |     I32      |      I32      |      2^20      |     2^1      |  28.457 us |       2.59% |  28.439 us |       2.62% |  -0.017 us |  -0.06% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^24      |     2^1      | 364.407 us |       0.24% | 364.463 us |       0.26% |   0.056 us |   0.02% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^28      |     2^1      |   5.756 ms |       0.73% |   5.757 ms |       1.26% |   1.535 us |   0.03% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^16      |     2^4      |   8.192 us |       0.00% |   8.189 us |       0.13% |  -0.003 us |  -0.03% |  🟢 FAST  |
|    I128    |     I32      |      I32      |      2^20      |     2^4      |  24.990 us |       5.02% |  25.097 us |       5.00% |   0.107 us |   0.43% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^24      |     2^4      | 252.446 us |       1.03% | 251.698 us |       1.14% |  -0.749 us |  -0.30% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^28      |     2^4      |   3.648 ms |       0.15% |   3.649 ms |       0.15% |   0.988 us |   0.03% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^16      |     2^8      |   8.188 us |       0.13% |   8.192 us |       0.00% |   0.004 us |   0.05% |  🔴 SLOW  |
|    I128    |     I32      |      I32      |      2^20      |     2^8      |  24.299 us |       4.97% |  24.445 us |       4.71% |   0.146 us |   0.60% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^24      |     2^8      | 237.612 us |       0.87% | 237.492 us |       0.88% |  -0.120 us |  -0.05% |  🔵 SAME  |
|    I128    |     I32      |      I32      |      2^28      |     2^8      |   3.389 ms |       0.20% |   3.388 ms |       0.20% |  -0.331 us |  -0.01% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^16      |     2^1      |   8.202 us |       2.04% |   8.201 us |       1.92% |  -0.001 us |  -0.01% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^20      |     2^1      |  30.565 us |       2.28% |  30.502 us |       2.06% |  -0.063 us |  -0.21% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^24      |     2^1      | 437.639 us |       0.26% | 437.578 us |       0.26% |  -0.061 us |  -0.01% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^28      |     2^1      |   6.918 ms |       0.94% |   6.919 ms |       1.15% |   1.468 us |   0.02% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^16      |     2^4      |   7.608 us |      12.13% |   7.765 us |      10.67% |   0.158 us |   2.07% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^20      |     2^4      |  26.575 us |       1.69% |  26.620 us |       1.30% |   0.045 us |   0.17% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^24      |     2^4      | 296.897 us |       0.97% | 297.130 us |       1.00% |   0.233 us |   0.08% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^28      |     2^4      |   4.425 ms |       0.40% |   4.423 ms |       0.40% |  -2.418 us |  -0.05% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^16      |     2^8      |   8.188 us |       0.13% |   8.188 us |       0.14% |  -0.001 us |  -0.01% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^20      |     2^8      |  26.026 us |       3.96% |  26.033 us |       3.67% |   0.007 us |   0.03% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^24      |     2^8      | 272.253 us |       0.94% | 272.161 us |       0.94% |  -0.092 us |  -0.03% |  🔵 SAME  |
|    I128    |     I64      |      I32      |      2^28      |     2^8      |   3.904 ms |       0.08% |   3.904 ms |       0.08% |  -0.375 us |  -0.01% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^16      |     2^1      |  11.550 us |       8.50% |  11.657 us |       8.08% |   0.107 us |   0.93% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^20      |     2^1      |  39.926 us |       2.57% |  40.163 us |       2.49% |   0.237 us |   0.59% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^24      |     2^1      | 582.105 us |       0.20% | 582.089 us |       0.18% |  -0.017 us |  -0.00% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^28      |     2^1      |   9.219 ms |       0.02% |   9.219 ms |       0.13% |   0.075 us |   0.00% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^16      |     2^4      |  10.246 us |       1.15% |  10.249 us |       1.18% |   0.003 us |   0.03% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^20      |     2^4      |  34.599 us |       1.89% |  34.634 us |       1.67% |   0.035 us |   0.10% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^24      |     2^4      | 396.606 us |       1.10% | 396.380 us |       1.10% |  -0.226 us |  -0.06% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^28      |     2^4      |   5.862 ms |       0.39% |   5.863 ms |       0.38% |   0.867 us |   0.01% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^16      |     2^8      |  10.240 us |       0.00% |   8.967 us |      11.11% |  -1.273 us | -12.44% |  🟢 FAST  |
|    I128    |     I128     |      I32      |      2^20      |     2^8      |  32.321 us |       2.62% |  32.424 us |       2.45% |   0.103 us |   0.32% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^24      |     2^8      | 350.776 us |       0.72% | 350.765 us |       0.64% |  -0.011 us |  -0.00% |  🔵 SAME  |
|    I128    |     I128     |      I32      |      2^28      |     2^8      |   5.246 ms |       0.13% |   5.246 ms |       0.26% |   0.363 us |   0.01% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^16      |     2^1      |   8.195 us |       1.35% |   8.201 us |       2.08% |   0.006 us |   0.07% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^20      |     2^1      |  28.246 us |       3.13% |  28.308 us |       2.77% |   0.062 us |   0.22% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^24      |     2^1      | 364.704 us |       0.28% | 364.723 us |       0.31% |   0.019 us |   0.01% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^28      |     2^1      |   5.757 ms |       0.67% |   5.758 ms |       1.14% |   1.182 us |   0.02% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^16      |     2^4      |   8.189 us |       0.11% |   8.192 us |       0.00% |   0.003 us |   0.03% |  🔴 SLOW  |
|    I128    |     F32      |      I32      |      2^20      |     2^4      |  24.709 us |       3.96% |  24.791 us |       4.52% |   0.082 us |   0.33% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^24      |     2^4      | 250.821 us |       0.95% | 250.696 us |       0.86% |  -0.125 us |  -0.05% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^28      |     2^4      |   3.647 ms |       0.16% |   3.647 ms |       0.17% |   0.289 us |   0.01% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^16      |     2^8      |   8.188 us |       0.13% |   8.192 us |       0.00% |   0.004 us |   0.05% |  🔴 SLOW  |
|    I128    |     F32      |      I32      |      2^20      |     2^8      |  24.348 us |       4.80% |  24.390 us |       4.97% |   0.042 us |   0.17% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^24      |     2^8      | 237.349 us |       0.95% | 237.731 us |       0.97% |   0.382 us |   0.16% |  🔵 SAME  |
|    I128    |     F32      |      I32      |      2^28      |     2^8      |   3.388 ms |       0.39% |   3.395 ms |       0.20% |   6.495 us |   0.19% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^16      |     2^1      |  10.117 us |       4.73% |  10.239 us |       0.07% |   0.122 us |   1.20% |  🔴 SLOW  |
|    I128    |     F64      |      I32      |      2^20      |     2^1      |  32.768 us |       0.00% |  32.640 us |       1.62% |  -0.128 us |  -0.39% |  🟢 FAST  |
|    I128    |     F64      |      I32      |      2^24      |     2^1      | 438.868 us |       0.28% | 438.999 us |       0.27% |   0.131 us |   0.03% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^28      |     2^1      |   6.913 ms |       0.76% |   6.912 ms |       0.63% |  -0.890 us |  -0.01% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^16      |     2^4      |   9.341 us |      10.87% |  10.176 us |       3.41% |   0.836 us |   8.95% |  🔴 SLOW  |
|    I128    |     F64      |      I32      |      2^20      |     2^4      |  29.160 us |       5.70% |  29.376 us |       5.48% |   0.216 us |   0.74% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^24      |     2^4      | 295.834 us |       1.20% | 297.374 us |       1.00% |   1.540 us |   0.52% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^28      |     2^4      |   4.381 ms |       0.14% |   4.390 ms |       0.15% |   8.429 us |   0.19% |  🔴 SLOW  |
|    I128    |     F64      |      I32      |      2^16      |     2^8      |   8.229 us |       3.51% |   8.236 us |       3.73% |   0.006 us |   0.08% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^20      |     2^8      |  29.444 us |       4.68% |  29.274 us |       5.37% |  -0.169 us |  -0.58% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^24      |     2^8      | 274.940 us |       1.16% | 275.380 us |       1.17% |   0.439 us |   0.16% |  🔵 SAME  |
|    I128    |     F64      |      I32      |      2^28      |     2^8      |   3.971 ms |       0.37% |   3.968 ms |       0.23% |  -3.519 us |  -0.09% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^16      |     2^1      |   8.188 us |       0.13% |   8.192 us |       0.00% |   0.004 us |   0.05% |  🔴 SLOW  |
|    I128    |     C32      |      I32      |      2^20      |     2^1      |  29.466 us |       3.39% |  29.699 us |       3.45% |   0.233 us |   0.79% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^24      |     2^1      | 438.790 us |       0.22% | 438.893 us |       0.23% |   0.104 us |   0.02% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^28      |     2^1      |   6.944 ms |       1.11% |   6.944 ms |       1.11% |   0.712 us |   0.01% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^16      |     2^4      |   8.188 us |       0.39% |   8.192 us |       0.00% |   0.004 us |   0.04% |  🔴 SLOW  |
|    I128    |     C32      |      I32      |      2^20      |     2^4      |  26.624 us |       0.00% |  26.603 us |       0.75% |  -0.021 us |  -0.08% |  🟢 FAST  |
|    I128    |     C32      |      I32      |      2^24      |     2^4      | 306.789 us |       1.50% | 306.718 us |       1.49% |  -0.071 us |  -0.02% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^28      |     2^4      |   4.725 ms |       0.21% |   4.733 ms |       0.20% |   7.840 us |   0.17% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^16      |     2^8      |   8.189 us |       0.12% |   8.188 us |       0.13% |  -0.001 us |  -0.01% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^20      |     2^8      |  24.892 us |       3.01% |  24.875 us |       2.92% |  -0.017 us |  -0.07% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^24      |     2^8      | 267.116 us |       0.57% | 267.081 us |       0.53% |  -0.035 us |  -0.01% |  🔵 SAME  |
|    I128    |     C32      |      I32      |      2^28      |     2^8      |   4.326 ms |       0.52% |   4.332 ms |       0.50% |   5.877 us |   0.14% |  🔵 SAME  |

```