### PR TITLE
Improve argument names in cub/util_math

### DIFF
--- a/cub/cub/util_math.cuh
+++ b/cub/cub/util_math.cuh
@@ -51,38 +51,38 @@ _CCCL_HOST_DEVICE _CCCL_FORCEINLINE OffsetT safe_add_bound_to_max(OffsetT lhs, O
   return lhs + capped_operand_rhs;
 }
 
-constexpr _CCCL_HOST_DEVICE int nominal_4B_items_to_items(int nominal_4b_items_per_thread, int item_size)
+constexpr _CCCL_HOST_DEVICE int nominal_4B_items_to_items(int nominal_items_per_thread, int item_size)
 {
-  return ::cuda::std::clamp(nominal_4b_items_per_thread * 4 / item_size, 1, nominal_4b_items_per_thread);
+  return ::cuda::std::clamp(nominal_items_per_thread * 4 / item_size, 1, nominal_items_per_thread);
 }
 
-constexpr _CCCL_HOST_DEVICE int nominal_8B_items_to_items(int nominal_8b_items_per_thread, int item_size)
+constexpr _CCCL_HOST_DEVICE int nominal_8B_items_to_items(int nominal_items_per_thread, int item_size)
 {
   if (item_size <= 8)
   {
-    return nominal_8b_items_per_thread;
+    return nominal_items_per_thread;
   }
   return ::cuda::std::clamp(
-    ::cuda::ceil_div(nominal_8b_items_per_thread * 8, item_size), 1, nominal_8b_items_per_thread);
+    ::cuda::ceil_div(nominal_items_per_thread * 8, item_size), 1, nominal_items_per_thread);
 }
 } // namespace detail
 
-constexpr _CCCL_HOST_DEVICE int Nominal4BItemsToItemsCombined(int nominal_4b_items_per_thread, int combined_bytes)
+constexpr _CCCL_HOST_DEVICE int Nominal4BItemsToItemsCombined(int nominal_items_per_thread, int combined_bytes)
 {
-  return (::cuda::std::min) (nominal_4b_items_per_thread,
-                             (::cuda::std::max) (1, nominal_4b_items_per_thread * 8 / combined_bytes));
+  return (::cuda::std::min) (nominal_items_per_thread,
+                             (::cuda::std::max) (1, nominal_items_per_thread * 8 / combined_bytes));
 }
 
 template <typename T>
-constexpr _CCCL_HOST_DEVICE int Nominal4BItemsToItems(int nominal_4b_items_per_thread)
+constexpr _CCCL_HOST_DEVICE int Nominal4BItemsToItems(int nominal_items_per_thread)
 {
-  return detail::nominal_4B_items_to_items(nominal_4b_items_per_thread, int{sizeof(T)});
+  return detail::nominal_4B_items_to_items(nominal_items_per_thread, int{sizeof(T)});
 }
 
 template <typename ItemT>
-constexpr _CCCL_HOST_DEVICE int Nominal8BItemsToItems(int nominal_8b_items_per_thread)
+constexpr _CCCL_HOST_DEVICE int Nominal8BItemsToItems(int nominal_items_per_thread)
 {
-  return detail::nominal_8B_items_to_items(nominal_8b_items_per_thread, int{sizeof(ItemT)});
+  return detail::nominal_8B_items_to_items(nominal_items_per_thread, int{sizeof(ItemT)});
 }
 
 /**

--- a/cub/cub/util_math.cuh
+++ b/cub/cub/util_math.cuh
@@ -62,15 +62,14 @@ constexpr _CCCL_HOST_DEVICE int nominal_8B_items_to_items(int nominal_items_per_
   {
     return nominal_items_per_thread;
   }
-  return ::cuda::std::clamp(
-    ::cuda::ceil_div(nominal_items_per_thread * 8, item_size), 1, nominal_items_per_thread);
+  return ::cuda::std::clamp(::cuda::ceil_div(nominal_items_per_thread * 8, item_size), 1, nominal_items_per_thread);
 }
 } // namespace detail
 
 constexpr _CCCL_HOST_DEVICE int Nominal4BItemsToItemsCombined(int nominal_items_per_thread, int combined_bytes)
 {
-  return (::cuda::std::min) (nominal_items_per_thread,
-                             (::cuda::std::max) (1, nominal_items_per_thread * 8 / combined_bytes));
+  return (
+    ::cuda::std::min) (nominal_items_per_thread, (::cuda::std::max) (1, nominal_items_per_thread * 8 / combined_bytes));
 }
 
 template <typename T>


### PR DESCRIPTION
## Description
The size in bytes is part of the function names already and does not need to be repeated in the argument name. Especially not with differing capitalization which can cause confusion due to the regular interpretation of "B" = bytes and "b" = bits.

Since this PR only modifies argument names, there is no need to change call sites/this is a non-breaking change even for the public functions.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
<!-- closes Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines]().
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
