### PR TITLE
CUB DeviceRotate

### DIFF
--- a/cub/benchmarks/bench/rotate/bfs_visit_order.cu
+++ b/cub/benchmarks/bench/rotate/bfs_visit_order.cu
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/device/device_rotate.cuh>
+
+#include <cstddef>
+#include <cstdint>
+
+#include <nvbench_helper.cuh>
+
+template <typename T>
+void bfs_visit_order_benchmark(nvbench::state& state, nvbench::type_list<T>)
+{
+  using namespace cub::detail::rotate;
+
+  const auto num_bytes    = static_cast<size_t>(state.get_int64("Bytes{io}"));
+  const auto num_elements = num_bytes / sizeof(T);
+  const auto rot_pct      = state.get_float64("RotatePercentage");
+  const auto rot_dist     = rot_pct == 0.0 ? size_t{1} : static_cast<size_t>(rot_pct * num_elements);
+  const auto head_size    = static_cast<uint32_t>(state.get_int64("HeadSize"));
+
+  if (rot_dist >= num_elements)
+  {
+    state.skip("Skipped: rotate distance >= array size");
+    return;
+  }
+
+  constexpr auto sector_elements = BYTES_PER_SECTOR / sizeof(T);
+  if (head_size >= sector_elements)
+  {
+    state.skip("Skipped: head size exceeds sector size.");
+    return;
+  }
+
+  cuda::compute_capability cc{};
+  NVBENCH_CUDA_CALL(cub::detail::ptx_compute_cap(cc));
+  const auto long_policy = policy_selector{}(cc).long_algorithm;
+
+  state.add_element_count(num_elements);
+  state.exec(nvbench::exec_tag::no_gpu, [&](nvbench::launch&) {
+    do_not_optimize(bfs_visit_order<T>(num_elements, rot_dist, head_size, long_policy));
+  });
+}
+
+using TypeList = nvbench::type_list<uint8_t>;
+
+NVBENCH_BENCH_TYPES(bfs_visit_order_benchmark, NVBENCH_TYPE_AXES(TypeList))
+  .set_name("bfs_visit_order")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Bytes{io}", nvbench::range(30, 32, 2))
+  .add_float64_axis("RotatePercentage", // Random nums to force dependency chains
+                    {0.03366275, 0.05408525, 0.07465742, 0.17368588,
+                     0.22188703, 0.24204597, 0.25078173, 0.29280947,
+                     0.41545696, 0.43265761, 0.45944469, 0.49439498})
+  .add_int64_axis("HeadSize", {0LL, 1LL})
+  .set_is_cpu_only(true);

--- a/cub/benchmarks/bench/rotate/rotate.cu
+++ b/cub/benchmarks/bench/rotate/rotate.cu
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/device/device_rotate.cuh>
+
+#include <nvbench_helper.cuh>
+
+template <typename T>
+void rotate_benchmark(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto num_bytes           = static_cast<size_t>(state.get_int64("Bytes{io}"));
+  const auto num_elements        = num_bytes / sizeof(T);
+  const auto rot_pct             = state.get_float64("RotatePercentage");
+  const size_t rot_dist          = rot_pct == 0.0 ? size_t{1} : static_cast<size_t>(rot_pct * num_elements);
+  const auto num_unaligned_elems = static_cast<int>(state.get_int64("NumUnalignedElems"));
+
+  if (rot_dist >= num_elements)
+  {
+    state.skip("Skipped: rotate distance >= array size");
+    return;
+  }
+  if (num_unaligned_elems * sizeof(T) >= cub::detail::rotate::BYTES_PER_SECTOR)
+  {
+    state.skip("Skipped: unaligned elems exceed sector size.");
+    return;
+  }
+
+  // Allocate with extra room for unaligned offset
+  thrust::device_vector<T> data = generate(num_elements + num_unaligned_elems);
+  T* d_data                     = thrust::raw_pointer_cast(data.data()) + num_unaligned_elems;
+
+  // Query pass
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+  cub::RotateState_t rotate_state;
+  cub::DeviceRotate::Rotate(d_temp_storage, temp_storage_bytes, rotate_state, d_data, num_elements, rot_dist);
+
+  thrust::device_vector<nvbench::uint8_t> temp(temp_storage_bytes, thrust::no_init);
+  d_temp_storage = thrust::raw_pointer_cast(temp.data());
+
+  state.add_element_count(num_elements);
+  state.add_global_memory_reads<T>(num_elements);
+  state.add_global_memory_writes<T>(num_elements);
+
+  const auto algo    = cub::detail::rotate::get_algorithm_to_use<T>(rot_dist, rotate_state.max_distance_, nullptr);
+  auto& algo_summary = state.add_summary("Algorithm");
+  algo_summary.set_string("name", "Algorithm");
+  algo_summary.set_string(
+    "value",
+    algo == cub::detail::rotate::RotateAlgo::Short ? "short"
+    : algo == cub::detail::rotate::RotateAlgo::Long
+      ? "long"
+      : "naive");
+
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
+    cub::DeviceRotate::Rotate(
+      d_temp_storage, temp_storage_bytes, rotate_state, d_data, num_elements, rot_dist, launch.get_stream());
+  });
+}
+
+using TypeList = nvbench::type_list<uint8_t, uint16_t, uint32_t, uint64_t>;
+
+NVBENCH_BENCH_TYPES(rotate_benchmark, NVBENCH_TYPE_AXES(TypeList))
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Bytes{io}", nvbench::range(16, 32, 4))
+  .add_float64_axis("RotatePercentage", {0.0, 0.01, 0.3, 0.6, 0.9})
+  .add_int64_axis("NumUnalignedElems", {0LL, 1LL});

--- a/cub/benchmarks/bench/rotate/rotate.cu
+++ b/cub/benchmarks/bench/rotate/rotate.cu
@@ -5,13 +5,22 @@
 
 #include <nvbench_helper.cuh>
 
-template <typename T>
+template <bool AsPercentage, typename T>
 void rotate_benchmark(nvbench::state& state, nvbench::type_list<T>)
 {
-  const auto num_bytes           = static_cast<size_t>(state.get_int64("Bytes{io}"));
-  const auto num_elements        = num_bytes / sizeof(T);
-  const auto rot_pct             = state.get_float64("RotatePercentage");
-  const size_t rot_dist          = rot_pct == 0.0 ? size_t{1} : static_cast<size_t>(rot_pct * num_elements);
+  const auto num_bytes    = static_cast<size_t>(state.get_int64("Bytes{io}"));
+  const auto num_elements = num_bytes / sizeof(T);
+
+  size_t rot_dist;
+  if constexpr (AsPercentage)
+  {
+    const auto rot_pct = state.get_float64("RotatePercentage");
+    rot_dist           = rot_pct == 0.0 ? size_t{1} : static_cast<size_t>(rot_pct * num_elements);
+  }
+  else
+  {
+    rot_dist = cuda::ceil_div(static_cast<size_t>(state.get_int64("RotateDistanceBytes")), sizeof(T));
+  }
   const auto num_unaligned_elems = static_cast<int>(state.get_int64("NumUnalignedElems"));
 
   if (rot_dist >= num_elements)
@@ -58,10 +67,34 @@ void rotate_benchmark(nvbench::state& state, nvbench::type_list<T>)
   });
 }
 
+// NVBENCH_BENCH_TYPES instantiates its callable from the type axis alone, so wrap each distance
+// mode in a single-type-parameter entry point that pins the `AsPercentage` template argument.
+template <typename T>
+void rotate_benchmark_distance(nvbench::state& state, nvbench::type_list<T> types)
+{
+  rotate_benchmark<false, T>(state, types);
+}
+
+template <typename T>
+void rotate_benchmark_percentage(nvbench::state& state, nvbench::type_list<T> types)
+{
+  rotate_benchmark<true, T>(state, types);
+}
+
 using TypeList = nvbench::type_list<uint8_t, uint16_t, uint32_t, uint64_t>;
 
-NVBENCH_BENCH_TYPES(rotate_benchmark, NVBENCH_TYPE_AXES(TypeList))
+// Short kernel: absolute rotate distances that stay within the short-path tile threshold.
+NVBENCH_BENCH_TYPES(rotate_benchmark_distance, NVBENCH_TYPE_AXES(TypeList))
+  .set_name("rotate_short")
   .set_type_axes_names({"T{ct}"})
-  .add_int64_power_of_two_axis("Bytes{io}", nvbench::range(16, 32, 4))
-  .add_float64_axis("RotatePercentage", {0.0, 0.01, 0.3, 0.6, 0.9})
+  .add_int64_power_of_two_axis("Bytes{io}", nvbench::range(26, 32, 2))
+  .add_int64_axis("RotateDistanceBytes", {1, 100, 500, 5000, 10000, 20000, 30000, 32700})
+  .add_int64_axis("NumUnalignedElems", {0LL, 1LL});
+
+// Long/naive algorithm: rotate distance as a fraction of the array size.
+NVBENCH_BENCH_TYPES(rotate_benchmark_percentage, NVBENCH_TYPE_AXES(TypeList))
+  .set_name("rotate_long")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Bytes{io}", nvbench::range(26, 32, 2))
+  .add_float64_axis("RotatePercentage", {0.01, 0.3, 0.6, 0.9})
   .add_int64_axis("NumUnalignedElems", {0LL, 1LL});

--- a/cub/benchmarks/bench/rotate/rotate.cu
+++ b/cub/benchmarks/bench/rotate/rotate.cu
@@ -3,6 +3,8 @@
 
 #include <cub/device/device_rotate.cuh>
 
+#include <algorithm>
+
 #include <nvbench_helper.cuh>
 
 template <bool AsPercentage, typename T>
@@ -33,6 +35,13 @@ void rotate_benchmark(nvbench::state& state, nvbench::type_list<T>)
     state.skip("Skipped: unaligned elems exceed sector size.");
     return;
   }
+  if constexpr (!AsPercentage)
+  {
+    if (state.get_string("Direction") == "Right")
+    {
+      rot_dist = num_elements - rot_dist;
+    }
+  }
 
   // Allocate with extra room for unaligned offset
   thrust::device_vector<T> data = generate(num_elements + num_unaligned_elems);
@@ -51,7 +60,9 @@ void rotate_benchmark(nvbench::state& state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(num_elements);
   state.add_global_memory_writes<T>(num_elements);
 
-  const auto algo    = cub::detail::rotate::get_algorithm_to_use<T>(rot_dist, rotate_state.max_distance_, nullptr);
+  auto const normalized_rot_dist = std::min(rot_dist, num_elements - rot_dist);
+  const auto algo =
+    cub::detail::rotate::get_algorithm_to_use<T>(normalized_rot_dist, rotate_state.max_distance_, nullptr);
   auto& algo_summary = state.add_summary("Algorithm");
   algo_summary.set_string("name", "Algorithm");
   algo_summary.set_string(
@@ -83,12 +94,14 @@ void rotate_benchmark_percentage(nvbench::state& state, nvbench::type_list<T> ty
 
 using TypeList = nvbench::type_list<uint8_t, uint16_t, uint32_t, uint64_t>;
 
-// Short kernel: absolute rotate distances that stay within the short-path tile threshold.
+// Short kernel: absolute rotate-distance magnitudes that stay within the short-path tile threshold.
+// Direction selects which side of the array is rotated by that magnitude.
 NVBENCH_BENCH_TYPES(rotate_benchmark_distance, NVBENCH_TYPE_AXES(TypeList))
   .set_name("rotate_short")
   .set_type_axes_names({"T{ct}"})
   .add_int64_power_of_two_axis("Bytes{io}", nvbench::range(26, 32, 2))
   .add_int64_axis("RotateDistanceBytes", {1, 100, 500, 5000, 10000, 20000, 30000, 32700})
+  .add_string_axis("Direction", {"Left", "Right"})
   .add_int64_axis("NumUnalignedElems", {0LL, 1LL});
 
 // Long/naive algorithm: rotate distance as a fraction of the array size.
@@ -96,5 +109,5 @@ NVBENCH_BENCH_TYPES(rotate_benchmark_percentage, NVBENCH_TYPE_AXES(TypeList))
   .set_name("rotate_long")
   .set_type_axes_names({"T{ct}"})
   .add_int64_power_of_two_axis("Bytes{io}", nvbench::range(26, 32, 2))
-  .add_float64_axis("RotatePercentage", {0.01, 0.3, 0.6, 0.9})
+  .add_float64_axis("RotatePercentage", {0.01, 0.3, 0.6, 0.9, 0.99})
   .add_int64_axis("NumUnalignedElems", {0LL, 1LL});

--- a/cub/benchmarks/bench/rotate/rotate.cu
+++ b/cub/benchmarks/bench/rotate/rotate.cu
@@ -62,7 +62,7 @@ void rotate_benchmark(nvbench::state& state, nvbench::type_list<T>)
 
   auto const normalized_rot_dist = std::min(rot_dist, num_elements - rot_dist);
   const auto algo =
-    cub::detail::rotate::get_algorithm_to_use<T>(normalized_rot_dist, rotate_state.max_distance_, nullptr);
+    cub::detail::rotate::get_algorithm_to_use<T>(num_elements, normalized_rot_dist, rotate_state.max_distance_, nullptr);
   auto& algo_summary = state.add_summary("Algorithm");
   algo_summary.set_string("name", "Algorithm");
   algo_summary.set_string(

--- a/cub/benchmarks/bench/rotate/rotate.cu
+++ b/cub/benchmarks/bench/rotate/rotate.cu
@@ -97,7 +97,7 @@ void rotate_benchmark_percentage(nvbench::state& state, nvbench::type_list<T> ty
   rotate_benchmark<true, T>(state, types);
 }
 
-using TypeList = nvbench::type_list<uint8_t, uint16_t, uint32_t, uint64_t>;
+using TypeList = nvbench::type_list<uint8_t, uint32_t>;
 
 // Short kernel: absolute rotate-distance magnitudes that stay within the short-path tile threshold.
 // Direction selects which side of the array is rotated by that magnitude.
@@ -105,7 +105,7 @@ NVBENCH_BENCH_TYPES(rotate_benchmark_distance, NVBENCH_TYPE_AXES(TypeList))
   .set_name("rotate_short")
   .set_type_axes_names({"T{ct}"})
   .add_int64_power_of_two_axis("Bytes{io}", nvbench::range(26, 32, 2))
-  .add_int64_axis("RotateDistanceBytes", {1, 100, 500, 5000, 10000, 20000, 30000, 32700})
+  .add_int64_axis("RotateDistanceBytes", {1, 2000, 10000})
   .add_string_axis("Direction", {"Left", "Right"})
   .add_int64_axis("NumUnalignedElems", {0LL, 1LL});
 
@@ -114,5 +114,5 @@ NVBENCH_BENCH_TYPES(rotate_benchmark_percentage, NVBENCH_TYPE_AXES(TypeList))
   .set_name("rotate_long")
   .set_type_axes_names({"T{ct}"})
   .add_int64_power_of_two_axis("Bytes{io}", nvbench::range(26, 32, 2))
-  .add_float64_axis("RotatePercentage", {0.01, 0.3, 0.6, 0.9, 0.99})
+  .add_float64_axis("RotatePercentage", {0.01, 0.3, 0.6, 0.99})
   .add_int64_axis("NumUnalignedElems", {0LL, 1LL});

--- a/cub/benchmarks/bench/rotate/rotate.cu
+++ b/cub/benchmarks/bench/rotate/rotate.cu
@@ -61,8 +61,13 @@ void rotate_benchmark(nvbench::state& state, nvbench::type_list<T>)
   state.add_global_memory_writes<T>(num_elements);
 
   auto const normalized_rot_dist = std::min(rot_dist, num_elements - rot_dist);
-  const auto algo =
-    cub::detail::rotate::get_algorithm_to_use<T>(num_elements, normalized_rot_dist, rotate_state.max_distance_, nullptr);
+  cuda::compute_capability cc{};
+  NVBENCH_CUDA_CALL(cub::detail::ptx_compute_cap(cc));
+  const auto policy = cub::detail::rotate::policy_selector{}(cc);
+  int num_sms;
+  NVBENCH_CUDA_CALL(cub::detail::rotate::get_num_sms(nullptr, num_sms));
+  const auto algo = cub::detail::rotate::get_algorithm_to_use<T>(
+    num_elements, normalized_rot_dist, rotate_state.max_distance_, num_sms, policy);
   auto& algo_summary = state.add_summary("Algorithm");
   algo_summary.set_string("name", "Algorithm");
   algo_summary.set_string(

--- a/cub/cub/device/device_rotate.cuh
+++ b/cub/cub/device/device_rotate.cuh
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/device/dispatch/dispatch_rotate.cuh>
+
+CUB_NAMESPACE_BEGIN
+
+using RotateState_t = detail::rotate::RotateState_t;
+
+struct DeviceRotate
+{
+  template <typename T>
+  CUB_RUNTIME_FUNCTION static cudaError_t Rotate(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    RotateState_t& state,
+    T* d_array,
+    size_t num_items,
+    size_t rotate_distance,
+    cudaStream_t stream = nullptr)
+  {
+    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceRotate::Rotate");
+
+    return detail::rotate::dispatch(
+      d_temp_storage, temp_storage_bytes, state, d_array, num_items, rotate_distance, stream);
+  }
+};
+
+CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/dispatch_rotate.cuh
+++ b/cub/cub/device/dispatch/dispatch_rotate.cuh
@@ -1,0 +1,502 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/device/device_transform.cuh>
+#include <cub/device/dispatch/kernels/kernel_rotate.cuh>
+#include <cub/util_debug.cuh>
+
+#include <cuda/std/functional>
+
+#include <algorithm>
+#include <climits>
+#include <queue>
+#include <stdexcept>
+#include <unordered_map>
+#include <vector>
+
+CUB_NAMESPACE_BEGIN
+namespace detail
+{
+namespace rotate
+{
+// ============================================================================
+// Error propagation macro (wraps CubDebug for consistent logging)
+// ============================================================================
+
+#define CUB_ROTATE_CHECK(call)         \
+  do                                   \
+  {                                    \
+    cudaError_t _err = CubDebug(call); \
+    if (_err != cudaSuccess)           \
+    {                                  \
+      return _err;                     \
+    }                                  \
+  } while (0)
+
+// ============================================================================
+// Runtime device queries
+// ============================================================================
+
+// Get number of SMs in stream's GPU.
+inline cudaError_t get_num_sms(cudaStream_t stream, int& num_sms)
+{
+  int device;
+  CUB_ROTATE_CHECK(cudaStreamGetDevice(stream, &device));
+  CUB_ROTATE_CHECK(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, device));
+  return cudaSuccess;
+}
+
+inline cudaError_t get_launch_config(cudaStream_t stream, const int tile_bytes, int& block_size_out, int& grid_size_out)
+{
+  int device;
+  CUB_ROTATE_CHECK(cudaStreamGetDevice(stream, &device));
+
+  int num_sms;
+  CUB_ROTATE_CHECK(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, device));
+  int max_threads_per_sm;
+  CUB_ROTATE_CHECK(cudaDeviceGetAttribute(&max_threads_per_sm, cudaDevAttrMaxThreadsPerMultiProcessor, device));
+  int shmem_per_sm;
+  CUB_ROTATE_CHECK(cudaDeviceGetAttribute(&shmem_per_sm, cudaDevAttrMaxSharedMemoryPerMultiprocessor, device));
+  const auto [block_size, blocks_per_sm] = get_launch_bounds(tile_bytes, shmem_per_sm, max_threads_per_sm);
+  block_size_out                         = block_size;
+  grid_size_out                          = blocks_per_sm * num_sms;
+  return cudaSuccess;
+}
+
+// ============================================================================
+// Algorithm state (persisted between query and execution passes)
+// ============================================================================
+
+struct RotateState_t
+{
+  std::vector<int32_t> ordering_;
+  uint32_t max_distance_ = 0;
+};
+
+// ============================================================================
+// Algorithm selection
+// ============================================================================
+
+// Max dependency distance for which the long algorithm is faster than the naive one.
+// Derived dynamically from the cooperative grid size.
+inline size_t get_max_dependency_distance(cudaStream_t stream)
+{
+  int block_size, grid_size;
+  get_launch_config(stream, rotate_long::TILE_BYTES, block_size, grid_size);
+  return static_cast<size_t>(grid_size - 50); // TODO: could be a tuning parameter
+}
+
+constexpr int SHORT_TILE_BYTES = USE_SHORT_PIPELINE ? rotate_short::TILE_BYTES : rotate_short_no_pipeline::TILE_BYTES;
+
+enum class RotateAlgo
+{
+  Short,
+  Long,
+  Naive
+};
+
+template <typename T>
+RotateAlgo get_algorithm_to_use(size_t rotate_distance, size_t max_distance, cudaStream_t stream)
+{
+  if (rotate_distance <= SHORT_TILE_BYTES / sizeof(T))
+  {
+    return RotateAlgo::Short;
+  }
+  else if (max_distance < get_max_dependency_distance(stream))
+  {
+    return RotateAlgo::Long;
+  }
+  else
+  {
+    return RotateAlgo::Naive;
+  }
+}
+
+template <typename T>
+uint32_t compute_head_size(T const* d_array, size_t const size, size_t const rotate_distance)
+{
+  uint32_t const arr_misalignment = reinterpret_cast<uintptr_t>(d_array) % BYTES_PER_SECTOR;
+  uint32_t head_size              = arr_misalignment == 0 ? 0U : (BYTES_PER_SECTOR - arr_misalignment) / sizeof(T);
+  head_size                       = std::min(static_cast<size_t>(head_size), size - rotate_distance);
+  assert(head_size < BYTES_PER_SECTOR);
+  return head_size;
+}
+
+// ============================================================================
+// BFS tile ordering (host-side)
+// ============================================================================
+
+// pos[node] = index in order
+// TODO: could use vector instead
+template <typename T>
+uint32_t max_dependency_distance(
+  const std::vector<Dependencies>& adj,
+  const std::vector<int32_t>& order,
+  size_t const arr_size,
+  size_t const tile_size,
+  size_t const rot_dist,
+  uint32_t const head_size)
+{
+  std::unordered_map<int32_t, uint32_t> pos;
+  for (uint32_t i = 0; i < order.size(); i++)
+  {
+    int32_t v = order[i];
+    pos[v]    = i;
+  }
+
+  std::vector<int64_t> distances(order.size(), 0);
+
+  auto const neg_head_size      = tile_detail::get_neg_head_size<T>(arr_size, rot_dist, head_size);
+  auto const num_negative_tiles = tile_detail::get_num_negative_tiles(rot_dist, tile_size, neg_head_size);
+
+  for (auto const node : order)
+  {
+    uint32_t node_ix  = pos[node];
+    auto const adj_ix = tile_detail::tile_ix_to_arr_ix(node, num_negative_tiles);
+    for (int i = 0; i < adj[adj_ix].num_dependencies_; ++i)
+    {
+      auto const dep    = adj[adj_ix].deps_[i];
+      auto const dep_ix = pos[dep];
+      int64_t distance  = static_cast<int64_t>(dep_ix) - static_cast<int64_t>(node_ix);
+      distances[adj_ix] = std::max(distances[adj_ix], distance);
+    }
+  }
+
+  auto max_elem = std::max_element(distances.begin(), distances.end());
+  return *max_elem;
+}
+
+// TODO optimize, takes around the same time than the rotate itself
+template <typename T>
+RotateState_t
+bfs_visit_order(size_t const arr_size, size_t const rot_dist, size_t const tile_size, uint32_t const head_size)
+{
+  auto const neg_head_size      = tile_detail::get_neg_head_size<T>(arr_size, rot_dist, head_size);
+  const auto num_negative_tiles = tile_detail::get_num_negative_tiles(rot_dist, tile_size, neg_head_size);
+  const auto num_positive_tiles = tile_detail::get_num_positive_tiles(arr_size, rot_dist, tile_size, head_size);
+  const auto num_nodes          = num_negative_tiles + num_positive_tiles;
+  std::vector<Dependencies> adj(num_nodes);
+
+  for (uint32_t i = 0; i < num_negative_tiles; i++)
+  {
+    adj[i] = tile_detail::get_dependencies<T>(arr_size, rot_dist, tile_size, -(i + 1), num_nodes, head_size);
+  }
+  for (uint32_t i = 0; i < num_positive_tiles; i++)
+  {
+    adj[num_negative_tiles + i] =
+      tile_detail::get_dependencies<T>(arr_size, rot_dist, tile_size, i, num_nodes, head_size);
+  }
+
+  std::vector<uint8_t> visited(num_nodes, 0);
+
+  RotateState_t state;
+  state.ordering_.reserve(num_nodes);
+
+  std::vector<uint32_t> q;
+  q.reserve(num_nodes);
+
+  auto bfs_from = [&](uint32_t s) {
+    assert(!visited[s]);
+    visited[s] = 1;
+
+    q.clear();
+    q.push_back(s);
+    size_t head = 0;
+
+    while (head < q.size())
+    {
+      uint32_t u = q[head++];
+      state.ordering_.push_back(tile_detail::arr_ix_to_tile_ix(u, num_negative_tiles));
+
+      for (int i = 0; i < adj[u].num_dependencies_; ++i)
+      {
+        auto const v = tile_detail::tile_ix_to_arr_ix(adj[u].deps_[i], num_negative_tiles);
+        if (!visited[v])
+        {
+          visited[v] = 1;
+          q.push_back(v);
+        }
+      }
+    }
+  };
+
+  // TODO: play with start position
+  bfs_from(0);
+  for (uint32_t s = 0; s < static_cast<uint32_t>(num_nodes); ++s)
+  {
+    if (!visited[s])
+    {
+      bfs_from(s);
+    }
+  }
+
+  assert(state.ordering_.size() == num_nodes);
+
+  state.max_distance_ = max_dependency_distance<T>(adj, state.ordering_, arr_size, tile_size, rot_dist, head_size);
+  return state;
+}
+
+// ============================================================================
+// Compute temp storage size and algorithm state for a given configuration.
+// Pure host-side logic, no device memory access.
+// ============================================================================
+
+template <typename T>
+void compute_temp_size_and_state(
+  T* d_array, size_t size, size_t rotate_distance, cudaStream_t stream, size_t& temp_storage_bytes, RotateState_t& state)
+{
+  int num_sms;
+  get_num_sms(stream, num_sms);
+
+  if (rotate_distance <= SHORT_TILE_BYTES / sizeof(T))
+  {
+    if constexpr (USE_SHORT_PIPELINE)
+    {
+      temp_storage_bytes = sizeof(device_flag_t) * num_sms;
+    }
+    else
+    {
+      uint32_t const head_size_short = compute_head_size(d_array, size, rotate_distance);
+      size_t const num_main_tiles =
+        cuda::ceil_div((size - rotate_distance - head_size_short) * sizeof(T), static_cast<size_t>(SHORT_TILE_BYTES));
+      temp_storage_bytes = sizeof(int) + sizeof(device_flag_t) * num_main_tiles;
+    }
+    state = RotateState_t{};
+    return;
+  }
+
+  uint32_t const head_size = compute_head_size(d_array, size, rotate_distance);
+
+  // Edge case where head_size consumes the entire positive region, so fall back to naive algorithm.
+  if (size - rotate_distance <= static_cast<size_t>(head_size))
+  {
+    state.max_distance_ = std::numeric_limits<uint32_t>::max();
+    temp_storage_bytes  = rotate_distance * sizeof(T);
+    return;
+  }
+
+  state = bfs_visit_order<T>(size, rotate_distance, rotate_long::TILE_BYTES / sizeof(T), head_size);
+  const auto algorithm_to_use = get_algorithm_to_use<T>(rotate_distance, state.max_distance_, stream);
+
+  if (algorithm_to_use == RotateAlgo::Long)
+  {
+    auto const num_tiles = state.ordering_.size();
+    // Tile counter + ordering + flags
+    temp_storage_bytes = sizeof(uint32_t) + (sizeof(int32_t) + sizeof(device_flag_t)) * num_tiles;
+  }
+  else
+  {
+    // Naive algorithm: temp buffer to save the first rotate_distance elements,
+    // plus whatever DeviceTransform requires for its own temp storage.
+    size_t transform_temp_bytes = 0;
+    T* dummy_out                = nullptr;
+    cuda::std::identity id{};
+    cub::DeviceTransform::Transform(
+      nullptr, transform_temp_bytes, ::cuda::std::make_tuple(d_array), dummy_out, rotate_distance, id, stream);
+    temp_storage_bytes = rotate_distance * sizeof(T) + transform_temp_bytes;
+  }
+}
+
+// ============================================================================
+// Unified dispatch: query pass (d_temp_storage == nullptr) or execution pass
+//
+// When d_temp_storage is nullptr (query pass):
+//   - temp_storage_bytes is filled with the required allocation size
+//   - state is filled with the precomputed BFS ordering
+//   - No device work is performed
+//
+// When d_temp_storage is non-null (execution pass):
+//   - state must contain the values written by a prior query pass
+//   - The rotation is executed using the precomputed state
+// ============================================================================
+
+template <typename T>
+CUB_RUNTIME_FUNCTION cudaError_t dispatch(
+  void* d_temp_storage,
+  size_t& temp_storage_bytes,
+  RotateState_t& state,
+  T* d_array,
+  size_t size,
+  size_t rotate_distance,
+  cudaStream_t stream)
+{
+  if constexpr (sizeof(T) != alignof(T))
+  {
+    return dispatch(
+      d_temp_storage,
+      temp_storage_bytes,
+      state,
+      reinterpret_cast<uint8_t*>(d_array),
+      size * sizeof(T),
+      rotate_distance * sizeof(T),
+      stream);
+  }
+  else
+  {
+    if (size <= 1 || rotate_distance == 0)
+    {
+      temp_storage_bytes = 0;
+      return cudaSuccess;
+    }
+    if (rotate_distance >= size)
+    {
+      rotate_distance %= size;
+    }
+    if (rotate_distance == 0)
+    {
+      temp_storage_bytes = 0;
+      return cudaSuccess;
+    }
+
+    // Query pass: compute temp storage requirements and fill state
+    if (d_temp_storage == nullptr)
+    {
+      compute_temp_size_and_state(d_array, size, rotate_distance, stream, temp_storage_bytes, state);
+      return cudaSuccess;
+    }
+
+    int num_sms;
+    CUB_ROTATE_CHECK(get_num_sms(stream, num_sms));
+
+    // Execution pass: use the precomputed state
+    const auto algo_to_use = get_algorithm_to_use<T>(rotate_distance, state.max_distance_, stream);
+
+    if (algo_to_use == RotateAlgo::Short)
+    {
+      constexpr size_t TILE_SIZE = SHORT_TILE_BYTES / sizeof(T);
+      bool const is_tiny         = (2 * rotate_distance > size) || (size <= TILE_SIZE);
+
+      if (is_tiny)
+      {
+        const int shmem = static_cast<int>(size * sizeof(T));
+        CUB_ROTATE_CHECK(cudaFuncSetAttribute(
+          rotate_short_no_pipeline::rotate_tiny_kernel<T>, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem));
+        rotate_short_no_pipeline::rotate_tiny_kernel<T><<<1, 512, shmem, stream>>>(d_array, size, rotate_distance);
+        CUB_ROTATE_CHECK(cudaGetLastError());
+      }
+      else
+      {
+        if constexpr (USE_SHORT_PIPELINE)
+        {
+          auto const head_size = compute_head_size(d_array, size, rotate_distance);
+          size_t const num_main_tiles =
+            cuda::ceil_div((size - rotate_distance - head_size) * sizeof(T), static_cast<size_t>(SHORT_TILE_BYTES));
+          assert(reinterpret_cast<uintptr_t>(d_array + head_size) % BYTES_PER_SECTOR == 0 || num_main_tiles == 0);
+
+          rotate_short::setup_kernel<<<1, 512, 0, stream>>>(d_temp_storage, temp_storage_bytes, num_sms);
+          CUB_ROTATE_CHECK(cudaGetLastError());
+
+          const auto dynamic_shmem = rotate_short::get_shmem_usage<T>(stream);
+          CUB_ROTATE_CHECK(cudaFuncSetAttribute(
+            rotate_short::rotate_short_kernel<T>, cudaFuncAttributeMaxDynamicSharedMemorySize, dynamic_shmem));
+          rotate_short::rotate_short_kernel<T><<<num_sms, rotate_short::BLOCK_SIZE, dynamic_shmem, stream>>>(
+            d_array, size, d_temp_storage, temp_storage_bytes, rotate_distance, num_main_tiles, head_size);
+          CUB_ROTATE_CHECK(cudaGetLastError());
+        }
+        else
+        {
+          auto const head_size = compute_head_size(d_array, size, rotate_distance);
+          size_t const num_main_tiles =
+            cuda::ceil_div((size - rotate_distance - head_size) * sizeof(T), static_cast<size_t>(SHORT_TILE_BYTES));
+
+          int block_size, grid_size;
+          CUB_ROTATE_CHECK(get_launch_config(stream, rotate_short_no_pipeline::TILE_BYTES, block_size, grid_size));
+
+          rotate_short_no_pipeline::setup_kernel<<<1, 512, 0, stream>>>(
+            d_temp_storage, temp_storage_bytes, num_main_tiles);
+          CUB_ROTATE_CHECK(cudaGetLastError());
+
+          rotate_short_no_pipeline::rotate_short_kernel_no_pipeline<T><<<grid_size, block_size, 0, stream>>>(
+            d_array, size, d_temp_storage, temp_storage_bytes, rotate_distance, num_main_tiles, head_size);
+          CUB_ROTATE_CHECK(cudaGetLastError());
+        }
+      }
+    }
+    else if (algo_to_use == RotateAlgo::Long)
+    {
+      size_t const num_tiles = state.ordering_.size();
+      if (num_tiles == 0)
+      {
+        return cudaErrorInvalidValue;
+      }
+      uint32_t const head_size = compute_head_size(d_array, size, rotate_distance);
+
+      rotate_long::setup_kernel<<<num_sms, 512, 0, stream>>>(d_temp_storage, temp_storage_bytes, num_tiles);
+      CUB_ROTATE_CHECK(cudaGetLastError());
+      CUB_ROTATE_CHECK(cudaMemcpyAsync(
+        reinterpret_cast<uint32_t*>(d_temp_storage) + 1,
+        state.ordering_.data(),
+        num_tiles * sizeof(int32_t),
+        cudaMemcpyHostToDevice,
+        stream));
+
+      // Launch rotate_long_kernel using cooperative kernel launch
+      int block_size, grid_size;
+      CUB_ROTATE_CHECK(get_launch_config(stream, rotate_long::TILE_BYTES, block_size, grid_size));
+      dim3 grid_dim(grid_size);
+      dim3 block_dim(block_size);
+      //! Make sure the variable types are exactly the same that the kernel takes
+      void* kernelArgs[] = {
+        (void*) &d_array,
+        (void*) &size,
+        (void*) &d_temp_storage,
+        (void*) &temp_storage_bytes,
+        (void*) &rotate_distance,
+        const_cast<void*>(static_cast<const void*>(&num_tiles)),
+        const_cast<void*>(static_cast<const void*>(&head_size))};
+      CUB_ROTATE_CHECK(cudaLaunchCooperativeKernel(
+        (void*) rotate_long::rotate_long_kernel<T>, grid_dim, block_dim, kernelArgs, 0, stream));
+    }
+    else
+    {
+      T* d_save_buf = reinterpret_cast<T*>(d_temp_storage);
+      cuda::std::identity id{};
+      ::cuda::stream_ref env{stream};
+
+      // Copy first elems into tmp buffer
+      CUB_ROTATE_CHECK(cub::DeviceTransform::__transform_internal(
+        ::cuda::std::make_tuple(d_array), d_save_buf, rotate_distance, ::cuda::always_true{}, id, env));
+
+      // Copy last elems chunk-wise into the start of the array
+      for (size_t offset = rotate_distance; offset < size; offset += rotate_distance)
+      {
+        size_t const elems_to_copy = std::min(rotate_distance, size - offset);
+        CUB_ROTATE_CHECK(cub::DeviceTransform::__transform_internal(
+          ::cuda::std::make_tuple(d_array + offset),
+          d_array + offset - rotate_distance,
+          elems_to_copy,
+          ::cuda::always_true{},
+          id,
+          env));
+      }
+
+      // Copy saved elems into end of the array
+      CUB_ROTATE_CHECK(cub::DeviceTransform::__transform_internal(
+        ::cuda::std::make_tuple(d_save_buf),
+        d_array + size - rotate_distance,
+        rotate_distance,
+        ::cuda::always_true{},
+        id,
+        env));
+    }
+
+    return cudaSuccess;
+  } // else (aligned type)
+}
+
+#undef CUB_ROTATE_CHECK
+} // namespace rotate
+} // namespace detail
+CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/dispatch_rotate.cuh
+++ b/cub/cub/device/dispatch/dispatch_rotate.cuh
@@ -20,10 +20,10 @@
 #include <cuda/std/functional>
 
 #include <algorithm>
-#include <climits>
-#include <queue>
-#include <stdexcept>
-#include <unordered_map>
+#include <limits>
+#include <memory>
+#include <new>
+#include <utility>
 #include <vector>
 
 CUB_NAMESPACE_BEGIN
@@ -79,9 +79,54 @@ inline cudaError_t get_launch_config(cudaStream_t stream, const int tile_bytes, 
 // Algorithm state (persisted between query and execution passes)
 // ============================================================================
 
+// Avoid initializing all members of std::vector
+template <typename T>
+struct UninitializedAllocator : std::allocator<T>
+{
+  using value_type = T;
+
+  template <typename U>
+  struct rebind
+  {
+    using other = UninitializedAllocator<U>;
+  };
+
+  template <typename U>
+  UninitializedAllocator(UninitializedAllocator<U> const&) noexcept
+  {}
+
+  UninitializedAllocator() noexcept = default;
+
+  template <typename U>
+  void construct(U* ptr)
+  {
+    ::new (static_cast<void*>(ptr)) U;
+  }
+
+  template <typename U, typename Arg, typename... Args>
+  void construct(U* ptr, Arg&& arg, Args&&... args)
+  {
+    ::new (static_cast<void*>(ptr)) U(std::forward<Arg>(arg), std::forward<Args>(args)...);
+  }
+};
+
+template <typename T, typename U>
+bool operator==(UninitializedAllocator<T> const&, UninitializedAllocator<U> const&)
+{
+  return true;
+}
+
+template <typename T, typename U>
+bool operator!=(UninitializedAllocator<T> const&, UninitializedAllocator<U> const&)
+{
+  return false;
+}
+
 struct RotateState_t
 {
-  std::vector<int32_t> ordering_;
+  // Dense tile indices in [0, ordering_.size()). The long kernel maps each
+  // claimed index to the signed tile coordinate used by the copy helpers.
+  std::vector<uint32_t, UninitializedAllocator<uint32_t>> ordering_;
   uint32_t max_distance_ = 0;
 };
 
@@ -137,115 +182,453 @@ uint32_t compute_head_size(T const* d_array, size_t const size, size_t const rot
 // ============================================================================
 // BFS tile ordering (host-side)
 // ============================================================================
-
-// pos[node] = index in order
-// TODO: could use vector instead
-template <typename T>
-uint32_t max_dependency_distance(
-  const std::vector<Dependencies>& adj,
-  const std::vector<int32_t>& order,
-  size_t const arr_size,
-  size_t const tile_size,
-  size_t const rot_dist,
-  uint32_t const head_size)
+// Clang 14 rejects templating the function
+#if defined(__x86_64__) && defined(__GNUC__)
+__attribute__((target_clones("avx2", "default"))) inline void
+fill_arithmetic_sequence(uint32_t* output, uint32_t const count, uint32_t const first)
 {
-  std::unordered_map<int32_t, uint32_t> pos;
-  for (uint32_t i = 0; i < order.size(); i++)
+#  if defined(__clang__)
+#    pragma clang loop vectorize_width(8) interleave_count(1)
+  for (uint32_t i = 0; i < count; ++i)
   {
-    int32_t v = order[i];
-    pos[v]    = i;
+    output[i] = first + i;
   }
-
-  std::vector<int64_t> distances(order.size(), 0);
-
-  auto const neg_head_size      = tile_detail::get_neg_head_size<T>(arr_size, rot_dist, head_size);
-  auto const num_negative_tiles = tile_detail::get_num_negative_tiles(rot_dist, tile_size, neg_head_size);
-
-  for (auto const node : order)
+#  else
+#    pragma GCC ivdep
+  for (uint32_t i = 0; i < count; ++i)
   {
-    uint32_t node_ix  = pos[node];
-    auto const adj_ix = tile_detail::tile_ix_to_arr_ix(node, num_negative_tiles);
-    for (int i = 0; i < adj[adj_ix].num_dependencies_; ++i)
-    {
-      auto const dep    = adj[adj_ix].deps_[i];
-      auto const dep_ix = pos[dep];
-      int64_t distance  = static_cast<int64_t>(dep_ix) - static_cast<int64_t>(node_ix);
-      distances[adj_ix] = std::max(distances[adj_ix], distance);
-    }
+    output[i] = first + i;
   }
-
-  auto max_elem = std::max_element(distances.begin(), distances.end());
-  return *max_elem;
+#  endif
 }
 
-// TODO optimize, takes around the same time than the rotate itself
-template <typename T>
-RotateState_t
-bfs_visit_order(size_t const arr_size, size_t const rot_dist, size_t const tile_size, uint32_t const head_size)
+__attribute__((target_clones("avx2", "default"))) inline void
+fill_arithmetic_sequence(int32_t* output, uint32_t const count, int32_t const first)
 {
-  auto const neg_head_size      = tile_detail::get_neg_head_size<T>(arr_size, rot_dist, head_size);
-  const auto num_negative_tiles = tile_detail::get_num_negative_tiles(rot_dist, tile_size, neg_head_size);
-  const auto num_positive_tiles = tile_detail::get_num_positive_tiles(arr_size, rot_dist, tile_size, head_size);
-  const auto num_nodes          = num_negative_tiles + num_positive_tiles;
-  std::vector<Dependencies> adj(num_nodes);
-
-  for (uint32_t i = 0; i < num_negative_tiles; i++)
+#  if defined(__clang__)
+#    pragma clang loop vectorize_width(8) interleave_count(1)
+  for (uint32_t i = 0; i < count; ++i)
   {
-    adj[i] = tile_detail::get_dependencies<T>(arr_size, rot_dist, tile_size, -(i + 1), num_nodes, head_size);
+    output[i] = first + static_cast<int32_t>(i);
   }
-  for (uint32_t i = 0; i < num_positive_tiles; i++)
+#  else
+#    pragma GCC ivdep
+  for (uint32_t i = 0; i < count; ++i)
   {
-    adj[num_negative_tiles + i] =
-      tile_detail::get_dependencies<T>(arr_size, rot_dist, tile_size, i, num_nodes, head_size);
+    output[i] = first + static_cast<int32_t>(i);
   }
+#  endif
+}
+#endif
 
-  std::vector<uint8_t> visited(num_nodes, 0);
+enum class SmallSide
+{
+  Negative,
+  Positive
+};
 
-  RotateState_t state;
-  state.ordering_.reserve(num_nodes);
+// Half-open interval of tile indices that a given tile depends on.
+struct DependencySegment
+{
+  uint32_t begin_;
+  uint32_t end_;
+  uint8_t offsets_;
+};
 
-  std::vector<uint32_t> q;
-  q.reserve(num_nodes);
+struct DependencySegments
+{
+  DependencySegment segments_[19]; // Since there can be at most 20 boundaries. See `get_dependency_segments` for an
+                                   // explanation.
+  uint32_t size_ = 0;
+};
 
-  auto bfs_from = [&](uint32_t s) {
-    assert(!visited[s]);
-    visited[s] = 1;
+// Given a certain rotate configuration, compute the offset of the dependency of a tile of a given candidate.
+uint32_t dependency_offset(uint32_t const num_positive_tiles, uint32_t const num_tiles, uint32_t const candidate)
+{
+  return (num_positive_tiles + num_tiles - 2 + candidate) % num_tiles;
+}
 
-    q.clear();
-    q.push_back(s);
-    size_t head = 0;
-
-    while (head < q.size())
+// For the dependencies of a given tile, compute the bitmask of which of the five possible offsets are present: {P-2,
+// P-1, P, P+1, P+2}.
+template <typename T>
+uint8_t dependency_offsets_at(
+  uint32_t const index,
+  size_t const arr_size,
+  size_t const rot_dist,
+  uint32_t const head_size,
+  uint32_t const neg_head_size,
+  uint32_t const num_negative_tiles,
+  uint32_t const num_positive_tiles)
+{
+  constexpr uint32_t TILE_SIZE = rotate_long::TILE_BYTES / sizeof(T);
+  uint32_t const num_nodes     = num_negative_tiles + num_positive_tiles;
+  uint8_t mask                 = 0;
+  int32_t const tile           = tile_detail::arr_ix_to_tile_ix(index, num_negative_tiles);
+  auto const dependencies =
+    tile_detail::get_dependencies(arr_size, rot_dist, TILE_SIZE, tile, head_size, neg_head_size, num_negative_tiles);
+  for (uint32_t dependency = dependencies.begin_; dependency < dependencies.end_; ++dependency)
+  {
+    uint32_t const offset = dependency >= index ? dependency - index : dependency + num_nodes - index;
+    bool matched          = false;
+    for (uint32_t candidate = 0; candidate < 5; ++candidate)
     {
-      uint32_t u = q[head++];
-      state.ordering_.push_back(tile_detail::arr_ix_to_tile_ix(u, num_negative_tiles));
-
-      for (int i = 0; i < adj[u].num_dependencies_; ++i)
+      if (offset == dependency_offset(num_positive_tiles, num_nodes, candidate))
       {
-        auto const v = tile_detail::tile_ix_to_arr_ix(adj[u].deps_[i], num_negative_tiles);
-        if (!visited[v])
-        {
-          visited[v] = 1;
-          q.push_back(v);
-        }
+        mask |= static_cast<uint8_t>(1u << candidate);
+        matched = true;
       }
+    }
+    (void) matched;
+    assert(matched);
+  }
+  assert(mask != 0);
+  return mask;
+}
+
+template <typename T>
+DependencySegments get_dependency_segments(
+  size_t const arr_size,
+  size_t const rot_dist,
+  uint32_t const head_size,
+  uint32_t const neg_head_size,
+  uint32_t const num_negative_tiles,
+  uint32_t const num_positive_tiles)
+{
+  uint32_t const num_nodes = num_negative_tiles + num_positive_tiles;
+  // Places in the array where the dependency pattern changes.
+  // Inside of a boundary all nodes have the dependency pattern: (i + {X}) % N, where X is a subset of {P-2, P-1, P,
+  // P+1, P+2}.
+  // There are at most 20 boundaries, since the dependency pattern can change only at 0, M, 2M mod N, or N, and each of
+  // those can be +/- 2. So 4 * 5 = 20. M = num_negative_tiles, N = num_nodes.
+  // 0 -> Possible partial tile at the start of the array.
+  // M -> Possible partial tile at the end of the negative region and partial tile at the start of the positive region.
+  //      Also where the tiles that depend on the first possible partial negative tile are.
+  // 2M mod N -> where the tiles that depend on the last possible partial negative tile and the first possible partial
+  // positive tile are.
+  // N -> Possible partial tile at the end of the array.
+  uint32_t boundaries[20];
+  uint32_t num_boundaries = 0;
+  auto add_boundary       = [&](int64_t const boundary) {
+    if (boundary >= 0 && boundary <= num_nodes)
+    {
+      boundaries[num_boundaries++] = static_cast<uint32_t>(boundary);
     }
   };
 
-  // TODO: play with start position
-  bfs_from(0);
-  for (uint32_t s = 0; s < static_cast<uint32_t>(num_nodes); ++s)
+  // Add all possible boundaries
+  for (uint32_t const center : {0u, num_negative_tiles, (2u * num_negative_tiles) % num_nodes, num_nodes})
   {
-    if (!visited[s])
+    for (int64_t delta = -2; delta <= 2; ++delta)
     {
-      bfs_from(s);
+      add_boundary(static_cast<int64_t>(center) + delta);
     }
   }
 
-  assert(state.ordering_.size() == num_nodes);
+  std::sort(boundaries, boundaries + num_boundaries);
+  auto const unique_end = std::unique(boundaries, boundaries + num_boundaries);
+  num_boundaries        = static_cast<uint32_t>(unique_end - boundaries);
 
-  state.max_distance_ = max_dependency_distance<T>(adj, state.ordering_, arr_size, tile_size, rot_dist, head_size);
+  DependencySegments result;
+  for (uint32_t i = 0; i + 1 < num_boundaries; ++i)
+  {
+    uint32_t const begin = boundaries[i];
+    uint32_t const end   = boundaries[i + 1];
+    if (begin == end)
+    {
+      continue;
+    }
+    uint8_t const offsets = dependency_offsets_at<T>(
+      begin, arr_size, rot_dist, head_size, neg_head_size, num_negative_tiles, num_positive_tiles);
+    // If the last segment has the same offsets, merge them into one segment.
+    if (result.size_ > 0 && result.segments_[result.size_ - 1].offsets_ == offsets)
+    {
+      result.segments_[result.size_ - 1].end_ = end;
+    }
+    else
+    {
+      result.segments_[result.size_++] = {begin, end, offsets};
+    }
+  }
+  assert(result.size_ > 0 && result.segments_[0].begin_ == 0 && result.segments_[result.size_ - 1].end_ == num_nodes);
+  return result;
+}
+
+// Take advantage of the extreme rotate distance to simplify the dependency ordering creation.
+template <SmallSide Side>
+RotateState_t small_side_visit_order(
+  uint32_t const num_negative_tiles, uint32_t const num_positive_tiles, DependencySegments const& dependency_segments)
+{
+  uint32_t const num_nodes = num_negative_tiles + num_positive_tiles;
+
+  RotateState_t state;
+  state.ordering_.resize(num_nodes);
+  uint32_t* output = state.ordering_.data();
+
+  if constexpr (Side == SmallSide::Negative)
+  {
+    // In dense node coordinates, every real dependency advances by one of the
+    // five offsets from -(num_negative_tiles + 2) through
+    // -(num_negative_tiles - 2). Visiting node zero followed by all other nodes
+    // in descending order therefore gives a tight dependency bound.
+    output[0] = 0;
+  }
+
+  constexpr uint32_t first = Side == SmallSide::Negative ? 1 : 0;
+  for (uint32_t i = first; i < num_nodes; ++i)
+  {
+    if constexpr (Side == SmallSide::Negative)
+    {
+      output[i] = num_nodes - i;
+    }
+    else
+    {
+      // Ascending dense coordinates make each P-2/.../P+2 dependency advance by
+      // at most P+2 positions; modular wraparound dependencies point backward.
+      output[i] = i;
+    }
+  }
+
+  for (uint32_t segment_index = 0; segment_index < dependency_segments.size_; ++segment_index)
+  {
+    auto const segment = dependency_segments.segments_[segment_index];
+    for (uint32_t candidate = 0; candidate < 5; ++candidate)
+    {
+      if ((segment.offsets_ & (1u << candidate)) == 0)
+      {
+        continue;
+      }
+      uint32_t const offset = dependency_offset(num_positive_tiles, num_nodes, candidate);
+      if constexpr (Side == SmallSide::Positive)
+      {
+        if (offset > 0 && segment.begin_ < std::min(segment.end_, num_nodes - offset))
+        {
+          state.max_distance_ = std::max(state.max_distance_, offset);
+        }
+      }
+      else if (offset > 0)
+      {
+        bool const contains_zero        = segment.begin_ == 0;
+        bool const contains_wrap_source = segment.end_ > num_nodes - offset + 1;
+        if (contains_zero || contains_wrap_source)
+        {
+          state.max_distance_ = std::max(state.max_distance_, num_nodes - offset);
+        }
+      }
+    }
+  }
   return state;
+}
+
+struct VisitInterval
+{
+  uint32_t begin_;
+  uint32_t end_;
+};
+
+#if defined(__x86_64__) && defined(__GNUC__)
+__attribute__((target_clones("avx2", "default")))
+#endif
+uint32_t
+max_position_distance(int32_t const* source, int32_t const* target, uint32_t const count)
+{
+  int32_t result = 0;
+#if defined(__clang__)
+#  pragma clang loop vectorize(enable) interleave(enable)
+#elif defined(__GNUC__)
+#  pragma GCC ivdep
+#endif
+  for (uint32_t i = 0; i < count; ++i)
+  {
+    result = std::max(result, target[i] - source[i]);
+  }
+  return static_cast<uint32_t>(result);
+}
+
+void set_exact_max_dependency_distance(
+  RotateState_t& state,
+  uint32_t const num_positive_tiles,
+  DependencySegments const& dependency_segments,
+  int32_t const* positions)
+{
+  uint32_t const num_nodes = static_cast<uint32_t>(state.ordering_.size());
+  state.max_distance_      = 0;
+  for (uint32_t segment_index = 0; segment_index < dependency_segments.size_; ++segment_index)
+  {
+    auto const segment = dependency_segments.segments_[segment_index];
+    for (uint32_t candidate = 0; candidate < 5; ++candidate)
+    {
+      if ((segment.offsets_ & (1u << candidate)) == 0)
+      {
+        continue;
+      }
+      uint32_t const offset     = dependency_offset(num_positive_tiles, num_nodes, candidate);
+      uint32_t const wrap       = num_nodes - offset;
+      uint32_t const linear_end = std::min(segment.end_, wrap);
+      if (segment.begin_ < linear_end)
+      {
+        state.max_distance_ =
+          std::max(state.max_distance_,
+                   max_position_distance(
+                     positions + segment.begin_, positions + segment.begin_ + offset, linear_end - segment.begin_));
+      }
+      uint32_t const wrap_begin = std::max(segment.begin_, wrap);
+      if (wrap_begin < segment.end_)
+      {
+        state.max_distance_ =
+          std::max(state.max_distance_,
+                   max_position_distance(
+                     positions + wrap_begin, positions + wrap_begin - (num_nodes - offset), segment.end_ - wrap_begin));
+      }
+    }
+  }
+}
+
+// Given a range of nodes, append the subranges that have not yet been visited to the output ordering and mark them as
+// visited.
+template <typename AppendRange>
+_CCCL_FORCEINLINE void append_unvisited_linear(
+  std::vector<VisitInterval>& visited, uint32_t const begin, uint32_t const end, AppendRange& append_range)
+{
+  if (begin == end)
+  {
+    return;
+  }
+
+  // TODO: Clang 14 lowers this search to a serial cmov chain that is slower than GCC's branchy implementation on x86.
+  auto first =
+    std::lower_bound(visited.begin(), visited.end(), begin, [](VisitInterval const interval, uint32_t point) {
+      return interval.end_ < point;
+    });
+  auto last             = first;
+  uint32_t cursor       = begin;
+  uint32_t merged_begin = begin;
+  uint32_t merged_end   = end;
+  while (last != visited.end() && last->begin_ <= end)
+  {
+    uint32_t const gap_end = std::min(end, last->begin_);
+    if (cursor < gap_end)
+    {
+      append_range(cursor, gap_end - cursor);
+    }
+    cursor       = std::min(end, std::max(cursor, last->end_));
+    merged_begin = std::min(merged_begin, last->begin_);
+    merged_end   = std::max(merged_end, last->end_);
+    ++last;
+  }
+  if (cursor < end)
+  {
+    append_range(cursor, end - cursor);
+  }
+
+  if (first == last)
+  {
+    visited.insert(first, {merged_begin, merged_end});
+  }
+  else
+  {
+    first->begin_ = merged_begin;
+    first->end_   = merged_end;
+    visited.erase(first + 1, last);
+  }
+}
+
+// Create the dependency order by using dependency ranges. Starting from tile 0, recursively get the dependency range of
+// a range of nodes, and add ones that are not yet in the ordering. That dependency range becomes the range of nodes in
+// the next iteration.
+// TODO: performance can be improved for certain degenerate cases.
+RotateState_t circulant_interval_visit_order(
+  uint32_t const num_negative_tiles, uint32_t const num_positive_tiles, DependencySegments const& dependency_segments)
+{
+  uint32_t const num_nodes = num_negative_tiles + num_positive_tiles;
+
+  RotateState_t state;
+  state.ordering_.resize(num_nodes);
+  uint32_t* output     = state.ordering_.data();
+  uint32_t output_size = 0;
+
+  std::vector<int32_t, UninitializedAllocator<int32_t>> position_storage(num_nodes);
+  int32_t* positions = position_storage.data();
+
+  std::vector<VisitInterval> visited;
+  // Reserve a small amount of space to avoid repeated reallocations in the common case of a small number of nodes.
+  visited.reserve(std::min(num_nodes, 512u));
+
+  // This function is in the hot path, so the specific compiler and arch optimizations make a difference.
+  auto append_range = [&](uint32_t start, uint32_t length) {
+    while (length > 0)
+    {
+      uint32_t const count = std::min(length, num_nodes - start);
+      uint32_t const first = start;
+#if defined(__x86_64__) && defined(__GNUC__)
+      fill_arithmetic_sequence(output + output_size, count, first);
+      fill_arithmetic_sequence(positions + start, count, static_cast<int32_t>(output_size));
+      output_size += count;
+#else
+      uint32_t* const range_output = output + output_size;
+#  if defined(__GNUC__)
+#    pragma GCC ivdep
+#  endif
+      for (uint32_t i = 0; i < count; ++i)
+      {
+        range_output[i]      = first + i;
+        positions[start + i] = static_cast<int32_t>(output_size + i);
+      }
+      output_size += count;
+#endif
+      start += count;
+      length -= count;
+    }
+  };
+  auto append_unvisited = [&](uint32_t const start, uint32_t const length) {
+    uint32_t const first_length = std::min(length, num_nodes - start);
+    append_unvisited_linear(visited, start, start + first_length, append_range);
+    append_unvisited_linear(visited, 0, length - first_length, append_range);
+  };
+
+  uint32_t layer_start = 0;
+  uint32_t layer       = 0;
+  while (output_size < num_nodes)
+  {
+    uint32_t const layer_length = layer >= num_nodes / 2 ? num_nodes : 2 * layer + 1;
+    append_unvisited(layer_start, layer_length);
+    ++layer;
+    layer_start += num_positive_tiles - 1;
+    if (layer_start >= num_nodes)
+    {
+      layer_start -= num_nodes;
+    }
+  }
+
+  set_exact_max_dependency_distance(state, num_positive_tiles, dependency_segments, positions);
+
+  return state;
+}
+
+// Build a dependency-safe tile order and its maximum forward dependency distance.
+template <typename T>
+RotateState_t bfs_visit_order(size_t const arr_size, size_t const rot_dist, uint32_t const head_size)
+{
+  constexpr size_t TILE_SIZE    = rotate_long::TILE_BYTES / sizeof(T);
+  auto const neg_head_size      = tile_detail::get_neg_head_size<T>(arr_size, rot_dist, head_size);
+  const auto num_negative_tiles = tile_detail::get_num_negative_tiles(rot_dist, TILE_SIZE, neg_head_size);
+  const auto num_positive_tiles = tile_detail::get_num_positive_tiles(arr_size, rot_dist, TILE_SIZE, head_size);
+  auto const dependency_segments =
+    get_dependency_segments<T>(arr_size, rot_dist, head_size, neg_head_size, num_negative_tiles, num_positive_tiles);
+
+  // A descending order is both cheap to generate and has a tight dependency
+  // bound while the negative side is small.
+  constexpr uint32_t max_direct_dependency_distance = 256;
+  if (num_negative_tiles + 1 <= max_direct_dependency_distance)
+  {
+    return small_side_visit_order<SmallSide::Negative>(num_negative_tiles, num_positive_tiles, dependency_segments);
+  }
+  // TODO: remove once rotate right implemented
+  if (num_positive_tiles + 1 <= max_direct_dependency_distance)
+  {
+    return small_side_visit_order<SmallSide::Positive>(num_negative_tiles, num_positive_tiles, dependency_segments);
+  }
+
+  return circulant_interval_visit_order(num_negative_tiles, num_positive_tiles, dependency_segments);
 }
 
 // ============================================================================
@@ -277,14 +660,14 @@ void compute_temp_size_and_state(
     return;
   }
 
-  state = bfs_visit_order<T>(size, rotate_distance, rotate_long::TILE_BYTES / sizeof(T), head_size);
+  state                       = bfs_visit_order<T>(size, rotate_distance, head_size);
   const auto algorithm_to_use = get_algorithm_to_use<T>(rotate_distance, state.max_distance_, stream);
 
   if (algorithm_to_use == RotateAlgo::Long)
   {
     auto const num_tiles = state.ordering_.size();
     // Tile counter + ordering + flags
-    temp_storage_bytes = sizeof(uint32_t) + (sizeof(int32_t) + sizeof(device_flag_t)) * num_tiles;
+    temp_storage_bytes = sizeof(uint32_t) + (sizeof(uint32_t) + sizeof(device_flag_t)) * num_tiles;
   }
   else
   {
@@ -386,8 +769,8 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch(
         // Reuse get_launch_config by scaling the tile footprint by the stage count: each block
         // stages PIPELINE_STAGES shmem tiles, so its per-block shmem cost is PIPELINE_STAGES *
         // TILE_BYTES (reproduces the device-side rotate_short::LAUNCH_BOUNDS on the real device).
-        CUB_ROTATE_CHECK(get_launch_config(
-          stream, rotate_short::TILE_BYTES * rotate_short::PIPELINE_STAGES, block_size, grid_size));
+        CUB_ROTATE_CHECK(
+          get_launch_config(stream, rotate_short::TILE_BYTES * rotate_short::PIPELINE_STAGES, block_size, grid_size));
 
         // Zero-initialize the temp buffer ([int counter][device_flag_t flags...]) with a plain
         // async memset instead of a separate setup_kernel launch. The kernel's tile counter now
@@ -400,9 +783,7 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch(
         // Multi-stage pipeline holds PIPELINE_STAGES tile buffers in dynamic shared memory.
         constexpr int dynamic_shmem = rotate_short::get_shmem_usage<T>();
         CUB_ROTATE_CHECK(cudaFuncSetAttribute(
-          rotate_short::rotate_short_kernel<T>,
-          cudaFuncAttributeMaxDynamicSharedMemorySize,
-          dynamic_shmem));
+          rotate_short::rotate_short_kernel<T>, cudaFuncAttributeMaxDynamicSharedMemorySize, dynamic_shmem));
         rotate_short::rotate_short_kernel<T><<<grid_size, block_size, dynamic_shmem, stream>>>(
           d_array, size, d_temp_storage, temp_storage_bytes, rotate_distance, num_main_tiles, head_size);
         CUB_ROTATE_CHECK(cudaGetLastError());
@@ -422,7 +803,7 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch(
       CUB_ROTATE_CHECK(cudaMemcpyAsync(
         reinterpret_cast<uint32_t*>(d_temp_storage) + 1,
         state.ordering_.data(),
-        num_tiles * sizeof(int32_t),
+        num_tiles * sizeof(uint32_t),
         cudaMemcpyHostToDevice,
         stream));
 

--- a/cub/cub/device/dispatch/dispatch_rotate.cuh
+++ b/cub/cub/device/dispatch/dispatch_rotate.cuh
@@ -98,7 +98,7 @@ inline size_t get_max_dependency_distance(cudaStream_t stream)
   return static_cast<size_t>(grid_size - 50); // TODO: could be a tuning parameter
 }
 
-constexpr int SHORT_TILE_BYTES = USE_SHORT_PIPELINE ? rotate_short::TILE_BYTES : rotate_short_no_pipeline::TILE_BYTES;
+constexpr int SHORT_TILE_BYTES = rotate_short::TILE_BYTES;
 
 enum class RotateAlgo
 {
@@ -257,23 +257,13 @@ template <typename T>
 void compute_temp_size_and_state(
   T* d_array, size_t size, size_t rotate_distance, cudaStream_t stream, size_t& temp_storage_bytes, RotateState_t& state)
 {
-  int num_sms;
-  get_num_sms(stream, num_sms);
-
   if (rotate_distance <= SHORT_TILE_BYTES / sizeof(T))
   {
-    if constexpr (USE_SHORT_PIPELINE)
-    {
-      temp_storage_bytes = sizeof(device_flag_t) * num_sms;
-    }
-    else
-    {
-      uint32_t const head_size_short = compute_head_size(d_array, size, rotate_distance);
-      size_t const num_main_tiles =
-        cuda::ceil_div((size - rotate_distance - head_size_short) * sizeof(T), static_cast<size_t>(SHORT_TILE_BYTES));
-      temp_storage_bytes = sizeof(int) + sizeof(device_flag_t) * num_main_tiles;
-    }
-    state = RotateState_t{};
+    uint32_t const head_size_short = compute_head_size(d_array, size, rotate_distance);
+    size_t const num_main_tiles =
+      cuda::ceil_div((size - rotate_distance - head_size_short) * sizeof(T), static_cast<size_t>(SHORT_TILE_BYTES));
+    temp_storage_bytes = sizeof(int) + sizeof(device_flag_t) * num_main_tiles;
+    state              = RotateState_t{};
     return;
   }
 
@@ -382,46 +372,40 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch(
       {
         const int shmem = static_cast<int>(size * sizeof(T));
         CUB_ROTATE_CHECK(cudaFuncSetAttribute(
-          rotate_short_no_pipeline::rotate_tiny_kernel<T>, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem));
-        rotate_short_no_pipeline::rotate_tiny_kernel<T><<<1, 512, shmem, stream>>>(d_array, size, rotate_distance);
+          rotate_short::rotate_tiny_kernel<T>, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem));
+        rotate_short::rotate_tiny_kernel<T><<<1, 512, shmem, stream>>>(d_array, size, rotate_distance);
         CUB_ROTATE_CHECK(cudaGetLastError());
       }
       else
       {
-        if constexpr (USE_SHORT_PIPELINE)
-        {
-          auto const head_size = compute_head_size(d_array, size, rotate_distance);
-          size_t const num_main_tiles =
-            cuda::ceil_div((size - rotate_distance - head_size) * sizeof(T), static_cast<size_t>(SHORT_TILE_BYTES));
-          assert(reinterpret_cast<uintptr_t>(d_array + head_size) % BYTES_PER_SECTOR == 0 || num_main_tiles == 0);
+        auto const head_size = compute_head_size(d_array, size, rotate_distance);
+        size_t const num_main_tiles =
+          cuda::ceil_div((size - rotate_distance - head_size) * sizeof(T), static_cast<size_t>(SHORT_TILE_BYTES));
 
-          rotate_short::setup_kernel<<<1, 512, 0, stream>>>(d_temp_storage, temp_storage_bytes, num_sms);
-          CUB_ROTATE_CHECK(cudaGetLastError());
+        int block_size, grid_size;
+        // Reuse get_launch_config by scaling the tile footprint by the stage count: each block
+        // stages PIPELINE_STAGES shmem tiles, so its per-block shmem cost is PIPELINE_STAGES *
+        // TILE_BYTES (reproduces the device-side rotate_short::LAUNCH_BOUNDS on the real device).
+        CUB_ROTATE_CHECK(get_launch_config(
+          stream, rotate_short::TILE_BYTES * rotate_short::PIPELINE_STAGES, block_size, grid_size));
 
-          const auto dynamic_shmem = rotate_short::get_shmem_usage<T>(stream);
-          CUB_ROTATE_CHECK(cudaFuncSetAttribute(
-            rotate_short::rotate_short_kernel<T>, cudaFuncAttributeMaxDynamicSharedMemorySize, dynamic_shmem));
-          rotate_short::rotate_short_kernel<T><<<num_sms, rotate_short::BLOCK_SIZE, dynamic_shmem, stream>>>(
-            d_array, size, d_temp_storage, temp_storage_bytes, rotate_distance, num_main_tiles, head_size);
-          CUB_ROTATE_CHECK(cudaGetLastError());
-        }
-        else
-        {
-          auto const head_size = compute_head_size(d_array, size, rotate_distance);
-          size_t const num_main_tiles =
-            cuda::ceil_div((size - rotate_distance - head_size) * sizeof(T), static_cast<size_t>(SHORT_TILE_BYTES));
+        // Zero-initialize the temp buffer ([int counter][device_flag_t flags...]) with a plain
+        // async memset instead of a separate setup_kernel launch. The kernel's tile counter now
+        // counts UP from 0 (fetch_add) and maps each ascending claim to a descending run top, so
+        // 0 is the correct counter start and the flags start at 0 -- memset suffices. This removes
+        // a kernel launch + its host launch latency from the critical path, a large fixed-cost
+        // fraction for the small 256MiB arrays (~16x fewer tiles than the 4GiB arrays).
+        CUB_ROTATE_CHECK(cudaMemsetAsync(d_temp_storage, 0, temp_storage_bytes, stream));
 
-          int block_size, grid_size;
-          CUB_ROTATE_CHECK(get_launch_config(stream, rotate_short_no_pipeline::TILE_BYTES, block_size, grid_size));
-
-          rotate_short_no_pipeline::setup_kernel<<<1, 512, 0, stream>>>(
-            d_temp_storage, temp_storage_bytes, num_main_tiles);
-          CUB_ROTATE_CHECK(cudaGetLastError());
-
-          rotate_short_no_pipeline::rotate_short_kernel_no_pipeline<T><<<grid_size, block_size, 0, stream>>>(
-            d_array, size, d_temp_storage, temp_storage_bytes, rotate_distance, num_main_tiles, head_size);
-          CUB_ROTATE_CHECK(cudaGetLastError());
-        }
+        // Multi-stage pipeline holds PIPELINE_STAGES tile buffers in dynamic shared memory.
+        constexpr int dynamic_shmem = rotate_short::get_shmem_usage<T>();
+        CUB_ROTATE_CHECK(cudaFuncSetAttribute(
+          rotate_short::rotate_short_kernel<T>,
+          cudaFuncAttributeMaxDynamicSharedMemorySize,
+          dynamic_shmem));
+        rotate_short::rotate_short_kernel<T><<<grid_size, block_size, dynamic_shmem, stream>>>(
+          d_array, size, d_temp_storage, temp_storage_bytes, rotate_distance, num_main_tiles, head_size);
+        CUB_ROTATE_CHECK(cudaGetLastError());
       }
     }
     else if (algo_to_use == RotateAlgo::Long)

--- a/cub/cub/device/dispatch/dispatch_rotate.cuh
+++ b/cub/cub/device/dispatch/dispatch_rotate.cuh
@@ -20,7 +20,6 @@
 #include <cuda/std/functional>
 
 #include <algorithm>
-#include <limits>
 #include <memory>
 #include <new>
 #include <utility>
@@ -169,12 +168,14 @@ RotateAlgo get_algorithm_to_use(size_t rotate_distance, size_t max_distance, cud
   }
 }
 
-template <typename T>
+template <RotDir Dir, typename T>
 uint32_t compute_head_size(T const* d_array, size_t const size, size_t const rotate_distance)
 {
-  uint32_t const arr_misalignment = reinterpret_cast<uintptr_t>(d_array) % BYTES_PER_SECTOR;
-  uint32_t head_size              = arr_misalignment == 0 ? 0U : (BYTES_PER_SECTOR - arr_misalignment) / sizeof(T);
-  head_size                       = std::min(static_cast<size_t>(head_size), size - rotate_distance);
+  uintptr_t const boundary_address     = reinterpret_cast<uintptr_t>(d_array + (Dir == RotDir::Right ? size : 0));
+  uint32_t const boundary_misalignment = boundary_address % BYTES_PER_SECTOR;
+  uint32_t head_size = Dir == RotDir::Left ? ((BYTES_PER_SECTOR - boundary_misalignment) % BYTES_PER_SECTOR) / sizeof(T)
+                                           : boundary_misalignment / sizeof(T);
+  head_size          = std::min(static_cast<size_t>(head_size), size - rotate_distance);
   assert(head_size < BYTES_PER_SECTOR);
   return head_size;
 }
@@ -428,8 +429,7 @@ struct VisitInterval
 #if defined(__x86_64__) && defined(__GNUC__)
 __attribute__((target_clones("avx2", "default")))
 #endif
-uint32_t
-max_position_distance(int32_t const* source, int32_t const* target, uint32_t const count)
+uint32_t max_position_distance(int32_t const* source, int32_t const* target, uint32_t const count)
 {
   int32_t result = 0;
 #if defined(__clang__)
@@ -622,7 +622,7 @@ RotateState_t bfs_visit_order(size_t const arr_size, size_t const rot_dist, uint
   {
     return small_side_visit_order<SmallSide::Negative>(num_negative_tiles, num_positive_tiles, dependency_segments);
   }
-  // TODO: remove once rotate right implemented
+  // At an exact-half rotation, alignment rounding can make the positive side one tile smaller than the negative side.
   if (num_positive_tiles + 1 <= max_direct_dependency_distance)
   {
     return small_side_visit_order<SmallSide::Positive>(num_negative_tiles, num_positive_tiles, dependency_segments);
@@ -636,29 +636,22 @@ RotateState_t bfs_visit_order(size_t const arr_size, size_t const rot_dist, uint
 // Pure host-side logic, no device memory access.
 // ============================================================================
 
-template <typename T>
+template <RotDir Dir, typename T>
 void compute_temp_size_and_state(
   T* d_array, size_t size, size_t rotate_distance, cudaStream_t stream, size_t& temp_storage_bytes, RotateState_t& state)
 {
+  assert(rotate_distance > 0 && rotate_distance <= size / 2);
+  uint32_t const head_size = compute_head_size<Dir>(d_array, size, rotate_distance);
   if (rotate_distance <= SHORT_TILE_BYTES / sizeof(T))
   {
-    uint32_t const head_size_short = compute_head_size(d_array, size, rotate_distance);
     size_t const num_main_tiles =
-      cuda::ceil_div((size - rotate_distance - head_size_short) * sizeof(T), static_cast<size_t>(SHORT_TILE_BYTES));
+      cuda::ceil_div((size - rotate_distance - head_size) * sizeof(T), static_cast<size_t>(SHORT_TILE_BYTES));
     temp_storage_bytes = sizeof(int) + sizeof(device_flag_t) * num_main_tiles;
     state              = RotateState_t{};
     return;
   }
 
-  uint32_t const head_size = compute_head_size(d_array, size, rotate_distance);
-
-  // Edge case where head_size consumes the entire positive region, so fall back to naive algorithm.
-  if (size - rotate_distance <= static_cast<size_t>(head_size))
-  {
-    state.max_distance_ = std::numeric_limits<uint32_t>::max();
-    temp_storage_bytes  = rotate_distance * sizeof(T);
-    return;
-  }
+  assert(static_cast<size_t>(head_size) < size - rotate_distance);
 
   state                       = bfs_visit_order<T>(size, rotate_distance, head_size);
   const auto algorithm_to_use = get_algorithm_to_use<T>(rotate_distance, state.max_distance_, stream);
@@ -671,7 +664,7 @@ void compute_temp_size_and_state(
   }
   else
   {
-    // Naive algorithm: temp buffer to save the first rotate_distance elements,
+    // Naive algorithm: temp buffer to save the wrapped rotate_distance elements,
     // plus whatever DeviceTransform requires for its own temp storage.
     size_t transform_temp_bytes = 0;
     T* dummy_out                = nullptr;
@@ -695,7 +688,7 @@ void compute_temp_size_and_state(
 //   - The rotation is executed using the precomputed state
 // ============================================================================
 
-template <typename T>
+template <typename T, RotDir Dir = RotDir::Left>
 CUB_RUNTIME_FUNCTION cudaError_t dispatch(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
@@ -707,7 +700,7 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch(
 {
   if constexpr (sizeof(T) != alignof(T))
   {
-    return dispatch(
+    return dispatch<uint8_t, Dir>(
       d_temp_storage,
       temp_storage_bytes,
       state,
@@ -732,16 +725,19 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch(
       temp_storage_bytes = 0;
       return cudaSuccess;
     }
+    if (rotate_distance > size / 2 && Dir == RotDir::Left)
+    {
+      return dispatch<T, RotDir::Right>(
+        d_temp_storage, temp_storage_bytes, state, d_array, size, size - rotate_distance, stream);
+    }
+    assert(rotate_distance <= size / 2);
 
     // Query pass: compute temp storage requirements and fill state
     if (d_temp_storage == nullptr)
     {
-      compute_temp_size_and_state(d_array, size, rotate_distance, stream, temp_storage_bytes, state);
+      compute_temp_size_and_state<Dir>(d_array, size, rotate_distance, stream, temp_storage_bytes, state);
       return cudaSuccess;
     }
-
-    int num_sms;
-    CUB_ROTATE_CHECK(get_num_sms(stream, num_sms));
 
     // Execution pass: use the precomputed state
     const auto algo_to_use = get_algorithm_to_use<T>(rotate_distance, state.max_distance_, stream);
@@ -749,19 +745,19 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch(
     if (algo_to_use == RotateAlgo::Short)
     {
       constexpr size_t TILE_SIZE = SHORT_TILE_BYTES / sizeof(T);
-      bool const is_tiny         = (2 * rotate_distance > size) || (size <= TILE_SIZE);
+      bool const is_tiny         = size <= TILE_SIZE;
 
       if (is_tiny)
       {
         const int shmem = static_cast<int>(size * sizeof(T));
         CUB_ROTATE_CHECK(cudaFuncSetAttribute(
-          rotate_short::rotate_tiny_kernel<T>, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem));
-        rotate_short::rotate_tiny_kernel<T><<<1, 512, shmem, stream>>>(d_array, size, rotate_distance);
+          rotate_short::rotate_tiny_kernel<Dir, T>, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem));
+        rotate_short::rotate_tiny_kernel<Dir, T><<<1, 512, shmem, stream>>>(d_array, size, rotate_distance);
         CUB_ROTATE_CHECK(cudaGetLastError());
       }
       else
       {
-        auto const head_size = compute_head_size(d_array, size, rotate_distance);
+        auto const head_size = compute_head_size<Dir>(d_array, size, rotate_distance);
         size_t const num_main_tiles =
           cuda::ceil_div((size - rotate_distance - head_size) * sizeof(T), static_cast<size_t>(SHORT_TILE_BYTES));
 
@@ -772,20 +768,14 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch(
         CUB_ROTATE_CHECK(
           get_launch_config(stream, rotate_short::TILE_BYTES * rotate_short::PIPELINE_STAGES, block_size, grid_size));
 
-        // Zero-initialize the temp buffer ([int counter][device_flag_t flags...]) with a plain
-        // async memset instead of a separate setup_kernel launch. The kernel's tile counter now
-        // counts UP from 0 (fetch_add) and maps each ascending claim to a descending run top, so
-        // 0 is the correct counter start and the flags start at 0 -- memset suffices. This removes
-        // a kernel launch + its host launch latency from the critical path, a large fixed-cost
-        // fraction for the small 256MiB arrays (~16x fewer tiles than the 4GiB arrays).
         CUB_ROTATE_CHECK(cudaMemsetAsync(d_temp_storage, 0, temp_storage_bytes, stream));
 
         // Multi-stage pipeline holds PIPELINE_STAGES tile buffers in dynamic shared memory.
         constexpr int dynamic_shmem = rotate_short::get_shmem_usage<T>();
         CUB_ROTATE_CHECK(cudaFuncSetAttribute(
-          rotate_short::rotate_short_kernel<T>, cudaFuncAttributeMaxDynamicSharedMemorySize, dynamic_shmem));
-        rotate_short::rotate_short_kernel<T><<<grid_size, block_size, dynamic_shmem, stream>>>(
-          d_array, size, d_temp_storage, temp_storage_bytes, rotate_distance, num_main_tiles, head_size);
+          rotate_short::rotate_short_kernel<Dir, T>, cudaFuncAttributeMaxDynamicSharedMemorySize, dynamic_shmem));
+        rotate_short::rotate_short_kernel<Dir, T><<<grid_size, block_size, dynamic_shmem, stream>>>(
+          d_array, size, d_temp_storage, rotate_distance, num_main_tiles, head_size);
         CUB_ROTATE_CHECK(cudaGetLastError());
       }
     }
@@ -796,9 +786,11 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch(
       {
         return cudaErrorInvalidValue;
       }
-      uint32_t const head_size = compute_head_size(d_array, size, rotate_distance);
+      uint32_t const head_size = compute_head_size<Dir>(d_array, size, rotate_distance);
+      int num_sms;
+      CUB_ROTATE_CHECK(get_num_sms(stream, num_sms));
 
-      rotate_long::setup_kernel<<<num_sms, 512, 0, stream>>>(d_temp_storage, temp_storage_bytes, num_tiles);
+      rotate_long::setup_kernel<<<num_sms, 512, 0, stream>>>(d_temp_storage, num_tiles);
       CUB_ROTATE_CHECK(cudaGetLastError());
       CUB_ROTATE_CHECK(cudaMemcpyAsync(
         reinterpret_cast<uint32_t*>(d_temp_storage) + 1,
@@ -817,12 +809,11 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch(
         (void*) &d_array,
         (void*) &size,
         (void*) &d_temp_storage,
-        (void*) &temp_storage_bytes,
         (void*) &rotate_distance,
         const_cast<void*>(static_cast<const void*>(&num_tiles)),
         const_cast<void*>(static_cast<const void*>(&head_size))};
       CUB_ROTATE_CHECK(cudaLaunchCooperativeKernel(
-        (void*) rotate_long::rotate_long_kernel<T>, grid_dim, block_dim, kernelArgs, 0, stream));
+        (void*) rotate_long::rotate_long_kernel<Dir, T>, grid_dim, block_dim, kernelArgs, 0, stream));
     }
     else
     {
@@ -830,31 +821,27 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch(
       cuda::std::identity id{};
       ::cuda::stream_ref env{stream};
 
-      // Copy first elems into tmp buffer
+      // Save the wrapped elements
+      auto* src = Dir == RotDir::Left ? d_array : d_array + size - rotate_distance;
       CUB_ROTATE_CHECK(cub::DeviceTransform::__transform_internal(
-        ::cuda::std::make_tuple(d_array), d_save_buf, rotate_distance, ::cuda::always_true{}, id, env));
+        ::cuda::std::make_tuple(src), d_save_buf, rotate_distance, ::cuda::always_true{}, id, env));
 
-      // Copy last elems chunk-wise into the start of the array
-      for (size_t offset = rotate_distance; offset < size; offset += rotate_distance)
+      // Shift the remaining region in chunks
+      size_t remaining = size - rotate_distance;
+      while (remaining > 0)
       {
-        size_t const elems_to_copy = std::min(rotate_distance, size - offset);
+        size_t const elems_to_copy = std::min(rotate_distance, remaining);
+        size_t const src_ix        = Dir == RotDir::Left ? size - remaining : remaining - elems_to_copy;
+        size_t const dst_ix        = Dir == RotDir::Left ? src_ix - rotate_distance : src_ix + rotate_distance;
         CUB_ROTATE_CHECK(cub::DeviceTransform::__transform_internal(
-          ::cuda::std::make_tuple(d_array + offset),
-          d_array + offset - rotate_distance,
-          elems_to_copy,
-          ::cuda::always_true{},
-          id,
-          env));
+          ::cuda::std::make_tuple(d_array + src_ix), d_array + dst_ix, elems_to_copy, ::cuda::always_true{}, id, env));
+        remaining -= elems_to_copy;
       }
 
-      // Copy saved elems into end of the array
+      // Restore the saved elements
+      auto* dst = Dir == RotDir::Left ? d_array + size - rotate_distance : d_array;
       CUB_ROTATE_CHECK(cub::DeviceTransform::__transform_internal(
-        ::cuda::std::make_tuple(d_save_buf),
-        d_array + size - rotate_distance,
-        rotate_distance,
-        ::cuda::always_true{},
-        id,
-        env));
+        ::cuda::std::make_tuple(d_save_buf), dst, rotate_distance, ::cuda::always_true{}, id, env));
     }
 
     return cudaSuccess;

--- a/cub/cub/device/dispatch/dispatch_rotate.cuh
+++ b/cub/cub/device/dispatch/dispatch_rotate.cuh
@@ -15,8 +15,10 @@
 
 #include <cub/device/device_transform.cuh>
 #include <cub/device/dispatch/kernels/kernel_rotate.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_debug.cuh>
 
+#include <cuda/std/__host_stdlib/sstream>
 #include <cuda/std/functional>
 
 #include <algorithm>
@@ -48,20 +50,12 @@ namespace rotate
 // Runtime device queries
 // ============================================================================
 
-inline cudaError_t get_launch_config(cudaStream_t stream, const int tile_bytes, int& block_size_out, int& grid_size_out)
+inline cudaError_t get_num_sms(cudaStream_t stream, int& num_sms)
 {
   int device;
   CUB_ROTATE_CHECK(cudaStreamGetDevice(stream, &device));
 
-  int num_sms;
   CUB_ROTATE_CHECK(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, device));
-  int max_threads_per_sm;
-  CUB_ROTATE_CHECK(cudaDeviceGetAttribute(&max_threads_per_sm, cudaDevAttrMaxThreadsPerMultiProcessor, device));
-  int shmem_per_sm;
-  CUB_ROTATE_CHECK(cudaDeviceGetAttribute(&shmem_per_sm, cudaDevAttrMaxSharedMemoryPerMultiprocessor, device));
-  const auto [block_size, blocks_per_sm] = get_launch_bounds(tile_bytes, shmem_per_sm, max_threads_per_sm);
-  block_size_out                         = block_size;
-  grid_size_out                          = blocks_per_sm * num_sms;
   return cudaSuccess;
 }
 
@@ -132,19 +126,21 @@ struct RotateState_t
 
 // Max dependency distance for which the long algorithm is faster than the naive one.
 // Derived dynamically from the cooperative grid size.
-inline size_t get_max_supported_dependency_distance(cudaStream_t stream)
+inline size_t get_max_supported_dependency_distance(int num_sms, const long_algorithm_policy& long_policy)
 {
-  int block_size, grid_size;
-  get_launch_config(stream, long_algorithm::tile_bytes * long_algorithm::pipeline_stages, block_size, grid_size);
-  return grid_size > long_algorithm::cooperative_grid_safety_margin
-         ? grid_size - long_algorithm::cooperative_grid_safety_margin
+  const int grid_size = long_policy.kernel.blocks_per_sm * num_sms;
+  return grid_size > long_policy.cooperative_grid_safety_margin
+         ? grid_size - long_policy.cooperative_grid_safety_margin
          : 0;
 }
 
 template <typename T>
-inline bool fall_back_to_naive(const size_t arr_size, const size_t rotate_distance)
+inline bool
+fall_back_to_naive(const size_t arr_size, const size_t rotate_distance, const long_algorithm_policy& long_policy)
 {
-  return arr_size > long_algorithm::naive_fallback_min_size && static_cast<double>(rotate_distance) / arr_size < long_algorithm::naive_fallback_max_fraction && rotate_distance * sizeof(T) > long_algorithm::naive_fallback_min_distance_bytes;
+  return arr_size > long_policy.naive_fallback_min_size
+      && static_cast<double>(rotate_distance) / arr_size < long_policy.naive_fallback_max_fraction
+      && rotate_distance * sizeof(T) > long_policy.naive_fallback_min_distance_bytes;
 }
 
 enum class RotateAlgo
@@ -155,20 +151,17 @@ enum class RotateAlgo
 };
 
 template <typename T>
-RotateAlgo get_algorithm_to_use(size_t arr_size, size_t rotate_distance, size_t max_distance, cudaStream_t stream)
+RotateAlgo get_algorithm_to_use(
+  size_t arr_size, size_t rotate_distance, size_t max_distance, int num_sms, const rotate_policy& policy)
 {
-  if (rotate_distance <= short_algorithm::tile_bytes / sizeof(T))
+  if (rotate_distance <= policy.short_algorithm.kernel.tile_bytes / sizeof(T))
   {
     return RotateAlgo::Short;
   }
-  else if (max_distance < get_max_supported_dependency_distance(stream) && !fall_back_to_naive<T>(arr_size, rotate_distance))
-  {
-    return RotateAlgo::Long;
-  }
-  else
-  {
-    return RotateAlgo::Naive;
-  }
+  return max_distance < get_max_supported_dependency_distance(num_sms, policy.long_algorithm)
+          && !fall_back_to_naive<T>(arr_size, rotate_distance, policy.long_algorithm)
+         ? RotateAlgo::Long
+         : RotateAlgo::Naive;
 }
 
 template <RotDir Dir, typename T>
@@ -259,17 +252,17 @@ uint8_t dependency_offsets_at(
   uint32_t const index,
   size_t const arr_size,
   size_t const rot_dist,
+  uint32_t const tile_size,
   uint32_t const head_size,
   uint32_t const neg_head_size,
   uint32_t const num_negative_tiles,
   uint32_t const num_positive_tiles)
 {
-  constexpr uint32_t TILE_SIZE = long_algorithm::tile_bytes / sizeof(T);
-  uint32_t const num_nodes     = num_negative_tiles + num_positive_tiles;
-  uint8_t mask                 = 0;
-  int32_t const tile           = tile_detail::arr_ix_to_tile_ix(index, num_negative_tiles);
+  uint32_t const num_nodes = num_negative_tiles + num_positive_tiles;
+  uint8_t mask             = 0;
+  int32_t const tile       = tile_detail::arr_ix_to_tile_ix(index, num_negative_tiles);
   auto const dependencies =
-    tile_detail::get_dependencies(arr_size, rot_dist, TILE_SIZE, tile, head_size, neg_head_size, num_negative_tiles);
+    tile_detail::get_dependencies(arr_size, rot_dist, tile_size, tile, head_size, neg_head_size, num_negative_tiles);
   for (uint32_t dependency = dependencies.begin_; dependency < dependencies.end_; ++dependency)
   {
     uint32_t const offset = dependency >= index ? dependency - index : dependency + num_nodes - index;
@@ -293,6 +286,7 @@ template <typename T>
 DependencySegments get_dependency_segments(
   size_t const arr_size,
   size_t const rot_dist,
+  uint32_t const tile_size,
   uint32_t const head_size,
   uint32_t const neg_head_size,
   uint32_t const num_negative_tiles,
@@ -342,7 +336,7 @@ DependencySegments get_dependency_segments(
       continue;
     }
     uint8_t const offsets = dependency_offsets_at<T>(
-      begin, arr_size, rot_dist, head_size, neg_head_size, num_negative_tiles, num_positive_tiles);
+      begin, arr_size, rot_dist, tile_size, head_size, neg_head_size, num_negative_tiles, num_positive_tiles);
     // If the last segment has the same offsets, merge them into one segment.
     if (result.size_ > 0 && result.segments_[result.size_ - 1].offsets_ == offsets)
     {
@@ -611,23 +605,24 @@ RotateState_t circulant_interval_visit_order(
 
 // Build a dependency-safe tile order and its maximum forward dependency distance.
 template <typename T>
-RotateState_t bfs_visit_order(size_t const arr_size, size_t const rot_dist, uint32_t const head_size)
+RotateState_t bfs_visit_order(
+  size_t const arr_size, size_t const rot_dist, uint32_t const head_size, const long_algorithm_policy& long_policy)
 {
-  constexpr size_t TILE_SIZE    = long_algorithm::tile_bytes / sizeof(T);
-  auto const neg_head_size      = tile_detail::get_neg_head_size<T>(arr_size, rot_dist, head_size);
-  const auto num_negative_tiles = tile_detail::get_num_negative_tiles(rot_dist, TILE_SIZE, neg_head_size);
-  const auto num_positive_tiles = tile_detail::get_num_positive_tiles(arr_size, rot_dist, TILE_SIZE, head_size);
-  auto const dependency_segments =
-    get_dependency_segments<T>(arr_size, rot_dist, head_size, neg_head_size, num_negative_tiles, num_positive_tiles);
+  const auto tile_size           = static_cast<uint32_t>(long_policy.kernel.tile_bytes / sizeof(T));
+  auto const neg_head_size       = tile_detail::get_neg_head_size<T>(arr_size, rot_dist, head_size);
+  const auto num_negative_tiles  = tile_detail::get_num_negative_tiles(rot_dist, tile_size, neg_head_size);
+  const auto num_positive_tiles  = tile_detail::get_num_positive_tiles(arr_size, rot_dist, tile_size, head_size);
+  auto const dependency_segments = get_dependency_segments<T>(
+    arr_size, rot_dist, tile_size, head_size, neg_head_size, num_negative_tiles, num_positive_tiles);
 
   // A descending order is both cheap to generate and has a tight dependency
   // bound while the negative side is small.
-  if (num_negative_tiles + 1 <= long_algorithm::max_direct_dependency_distance)
+  if (num_negative_tiles + 1 <= long_policy.max_direct_dependency_distance)
   {
     return small_side_visit_order<SmallSide::Negative>(num_negative_tiles, num_positive_tiles, dependency_segments);
   }
   // At an exact-half rotation, alignment rounding can make the positive side one tile smaller than the negative side.
-  if (num_positive_tiles + 1 <= long_algorithm::max_direct_dependency_distance)
+  if (num_positive_tiles + 1 <= long_policy.max_direct_dependency_distance)
   {
     return small_side_visit_order<SmallSide::Positive>(num_negative_tiles, num_positive_tiles, dependency_segments);
   }
@@ -641,24 +636,31 @@ RotateState_t bfs_visit_order(size_t const arr_size, size_t const rot_dist, uint
 // ============================================================================
 
 template <RotDir Dir, typename T>
-void compute_temp_size_and_state(
-  T* d_array, size_t size, size_t rotate_distance, cudaStream_t stream, size_t& temp_storage_bytes, RotateState_t& state)
+cudaError_t compute_temp_size_and_state(
+  T* d_array,
+  size_t size,
+  size_t rotate_distance,
+  cudaStream_t stream,
+  int num_sms,
+  size_t& temp_storage_bytes,
+  RotateState_t& state,
+  const rotate_policy& policy)
 {
   assert(rotate_distance > 0 && rotate_distance <= size / 2);
   uint32_t const head_size = compute_head_size<Dir>(d_array, size, rotate_distance);
-  if (rotate_distance <= short_algorithm::tile_bytes / sizeof(T))
+  if (rotate_distance <= policy.short_algorithm.kernel.tile_bytes / sizeof(T))
   {
     size_t const num_main_tiles =
-      cuda::ceil_div((size - rotate_distance - head_size) * sizeof(T), short_algorithm::tile_bytes);
+      cuda::ceil_div((size - rotate_distance - head_size) * sizeof(T), policy.short_algorithm.kernel.tile_bytes);
     temp_storage_bytes = sizeof(int) + sizeof(device_flag_t) * num_main_tiles;
     state              = RotateState_t{};
-    return;
+    return cudaSuccess;
   }
 
   assert(head_size < size - rotate_distance);
 
-  state                       = bfs_visit_order<T>(size, rotate_distance, head_size);
-  const auto algorithm_to_use = get_algorithm_to_use<T>(size, rotate_distance, state.max_distance_, stream);
+  state                       = bfs_visit_order<T>(size, rotate_distance, head_size, policy.long_algorithm);
+  const auto algorithm_to_use = get_algorithm_to_use<T>(size, rotate_distance, state.max_distance_, num_sms, policy);
 
   if (algorithm_to_use == RotateAlgo::Long)
   {
@@ -673,10 +675,11 @@ void compute_temp_size_and_state(
     size_t transform_temp_bytes = 0;
     T* dummy_out                = nullptr;
     cuda::std::identity id{};
-    cub::DeviceTransform::Transform(
-      nullptr, transform_temp_bytes, ::cuda::std::make_tuple(d_array), dummy_out, rotate_distance, id, stream);
+    CUB_ROTATE_CHECK(cub::DeviceTransform::Transform(
+      nullptr, transform_temp_bytes, ::cuda::std::make_tuple(d_array), dummy_out, rotate_distance, id, stream));
     temp_storage_bytes = rotate_distance * sizeof(T) + transform_temp_bytes;
   }
+  return cudaSuccess;
 }
 
 // ============================================================================
@@ -692,7 +695,10 @@ void compute_temp_size_and_state(
 //   - The rotation is executed using the precomputed state
 // ============================================================================
 
-template <typename T, RotDir Dir = RotDir::Left>
+template <typename T, RotDir Dir = RotDir::Left, typename PolicySelector = policy_selector>
+#if _CCCL_HAS_CONCEPTS()
+  requires rotate_policy_selector<PolicySelector>
+#endif // _CCCL_HAS_CONCEPTS()
 CUB_RUNTIME_FUNCTION cudaError_t dispatch(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
@@ -700,18 +706,20 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch(
   T* d_array,
   size_t size,
   size_t rotate_distance,
-  cudaStream_t stream)
+  cudaStream_t stream,
+  PolicySelector policy_selector = {})
 {
   if constexpr (sizeof(T) != alignof(T))
   {
-    return dispatch<uint8_t, Dir>(
+    return dispatch<uint8_t, Dir, PolicySelector>(
       d_temp_storage,
       temp_storage_bytes,
       state,
       reinterpret_cast<uint8_t*>(d_array),
       size * sizeof(T),
       rotate_distance * sizeof(T),
-      stream);
+      stream,
+      policy_selector);
   }
   else
   {
@@ -731,57 +739,80 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch(
     }
     if (rotate_distance > size / 2 && Dir == RotDir::Left)
     {
-      return dispatch<T, RotDir::Right>(
-        d_temp_storage, temp_storage_bytes, state, d_array, size, size - rotate_distance, stream);
+      return dispatch<T, RotDir::Right, PolicySelector>(
+        d_temp_storage, temp_storage_bytes, state, d_array, size, size - rotate_distance, stream, policy_selector);
     }
     assert(rotate_distance <= size / 2);
+
+    ::cuda::compute_capability cc{};
+    CUB_ROTATE_CHECK(ptx_compute_cap(cc));
+    const rotate_policy active_policy = policy_selector(cc);
+    int num_sms;
+    CUB_ROTATE_CHECK(get_num_sms(stream, num_sms));
+
+#if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
+    NV_IF_TARGET(NV_IS_HOST, ({
+                   ::std::stringstream ss;
+                   ss << active_policy;
+                   _CubLog("Dispatching DeviceRotate to compute capability %d.%d with tuning: %s\n",
+                           cc.major_cap(),
+                           cc.minor_cap(),
+                           ss.str().c_str());
+                 }))
+#endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
 
     // Query pass: compute temp storage requirements and fill state
     if (d_temp_storage == nullptr)
     {
-      compute_temp_size_and_state<Dir>(d_array, size, rotate_distance, stream, temp_storage_bytes, state);
+      CUB_ROTATE_CHECK(compute_temp_size_and_state<Dir>(
+        d_array, size, rotate_distance, stream, num_sms, temp_storage_bytes, state, active_policy));
       return cudaSuccess;
     }
 
     // Execution pass: use the precomputed state
-    const auto algo_to_use = get_algorithm_to_use<T>(size, rotate_distance, state.max_distance_, stream);
+    const auto algo_to_use =
+      get_algorithm_to_use<T>(size, rotate_distance, state.max_distance_, num_sms, active_policy);
 
     if (algo_to_use == RotateAlgo::Short)
     {
-      constexpr size_t TILE_SIZE = short_algorithm::tile_bytes / sizeof(T);
-      bool const is_tiny         = size <= TILE_SIZE;
+      const auto& kernel     = active_policy.short_algorithm.kernel;
+      const size_t tile_size = kernel.tile_bytes / sizeof(T);
+      bool const is_tiny     = size <= tile_size;
 
       if (is_tiny)
       {
         const int shmem = static_cast<int>(size * sizeof(T));
         CUB_ROTATE_CHECK(cudaFuncSetAttribute(
-          rotate_tiny::rotate_tiny_kernel<Dir, T>, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem));
-        rotate_tiny::rotate_tiny_kernel<Dir, T><<<1, 512, shmem, stream>>>(d_array, size, rotate_distance);
+          rotate_tiny::rotate_tiny_kernel<Dir, T, PolicySelector>, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem));
+        rotate_tiny::rotate_tiny_kernel<Dir, T, PolicySelector>
+          <<<1, 512, shmem, stream>>>(d_array, size, rotate_distance);
         CUB_ROTATE_CHECK(cudaGetLastError());
       }
       else
       {
         auto const head_size = compute_head_size<Dir>(d_array, size, rotate_distance);
         size_t const num_main_tiles =
-          cuda::ceil_div((size - rotate_distance - head_size) * sizeof(T), short_algorithm::tile_bytes);
+          cuda::ceil_div((size - rotate_distance - head_size) * sizeof(T), kernel.tile_bytes);
 
-        int block_size, grid_size;
-        CUB_ROTATE_CHECK(get_launch_config(
-          stream, short_algorithm::tile_bytes * short_algorithm::pipeline_stages, block_size, grid_size));
+        const int grid_size = kernel.blocks_per_sm * num_sms;
 
         CUB_ROTATE_CHECK(cudaMemsetAsync(d_temp_storage, 0, temp_storage_bytes, stream));
 
         // Multi-stage pipeline holds PIPELINE_STAGES tile buffers in dynamic shared memory.
-        constexpr int dynamic_shmem = get_shmem_usage<short_algorithm, T>();
+        const int dynamic_shmem = get_shmem_usage<T>(kernel);
         CUB_ROTATE_CHECK(cudaFuncSetAttribute(
-          rotate_kernel<short_algorithm, Dir, T>, cudaFuncAttributeMaxDynamicSharedMemorySize, dynamic_shmem));
-        rotate_kernel<short_algorithm, Dir, T><<<grid_size, block_size, dynamic_shmem, stream>>>(
-          d_array, size, d_temp_storage, rotate_distance, num_main_tiles, head_size, OrderMode::Circulant);
+          rotate_kernel<short_algorithm, Dir, T, PolicySelector>,
+          cudaFuncAttributeMaxDynamicSharedMemorySize,
+          dynamic_shmem));
+        rotate_kernel<short_algorithm, Dir, T, PolicySelector>
+          <<<grid_size, kernel.threads_per_block, dynamic_shmem, stream>>>(
+            d_array, size, d_temp_storage, rotate_distance, num_main_tiles, head_size, OrderMode::Circulant);
         CUB_ROTATE_CHECK(cudaGetLastError());
       }
     }
     else if (algo_to_use == RotateAlgo::Long)
     {
+      const auto& kernel     = active_policy.long_algorithm.kernel;
       size_t const num_tiles = state.ordering_.size();
       if (num_tiles == 0)
       {
@@ -803,16 +834,16 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch(
       }
 
       // The long variant requires a cooperative launch to keep every dependency producer resident.
-      int block_size, grid_size;
-      CUB_ROTATE_CHECK(
-        get_launch_config(stream, long_algorithm::tile_bytes * long_algorithm::pipeline_stages, block_size, grid_size));
+      const int grid_size = kernel.blocks_per_sm * num_sms;
       dim3 grid_dim(grid_size);
-      dim3 block_dim(block_size);
+      dim3 block_dim(kernel.threads_per_block);
 
       // Multi-stage pipeline holds PIPELINE_STAGES tile buffers in dynamic shared memory.
-      constexpr int dynamic_shmem = get_shmem_usage<long_algorithm, T>();
+      const int dynamic_shmem = get_shmem_usage<T>(kernel);
       CUB_ROTATE_CHECK(cudaFuncSetAttribute(
-        rotate_kernel<long_algorithm, Dir, T>, cudaFuncAttributeMaxDynamicSharedMemorySize, dynamic_shmem));
+        rotate_kernel<long_algorithm, Dir, T, PolicySelector>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize,
+        dynamic_shmem));
 
       OrderMode const order_mode = state.order_mode_;
 
@@ -826,7 +857,12 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch(
         const_cast<void*>(static_cast<const void*>(&head_size)),
         const_cast<void*>(static_cast<const void*>(&order_mode))};
       CUB_ROTATE_CHECK(cudaLaunchCooperativeKernel(
-        (void*) rotate_kernel<long_algorithm, Dir, T>, grid_dim, block_dim, kernelArgs, dynamic_shmem, stream));
+        (void*) rotate_kernel<long_algorithm, Dir, T, PolicySelector>,
+        grid_dim,
+        block_dim,
+        kernelArgs,
+        dynamic_shmem,
+        stream));
     }
     else
     {

--- a/cub/cub/device/dispatch/dispatch_rotate.cuh
+++ b/cub/cub/device/dispatch/dispatch_rotate.cuh
@@ -127,6 +127,12 @@ struct RotateState_t
   // claimed index to the signed tile coordinate used by the copy helpers.
   std::vector<uint32_t, UninitializedAllocator<uint32_t>> ordering_;
   uint32_t max_distance_ = 0;
+  // Which visit-order algorithm bfs_visit_order chose.  The two small-side orderings are trivial
+  // closed forms of the claim position -- the long kernel recomputes each tile index inline from
+  // its counter ticket, so NO processing_order host->device copy is needed for them (a device-side
+  // memset of the counter+flags is all the init required, removing the pageable H2D->kernel stream
+  // dependency that dominates small long rotations).  Only the circulant order (0) is host-staged.
+  OrderMode order_mode_ = OrderMode::Circulant;
 };
 
 // ============================================================================
@@ -138,11 +144,11 @@ struct RotateState_t
 inline size_t get_max_dependency_distance(cudaStream_t stream)
 {
   int block_size, grid_size;
-  get_launch_config(stream, rotate_long::TILE_BYTES, block_size, grid_size);
+  get_launch_config(stream, long_algorithm::tile_bytes * long_algorithm::pipeline_stages, block_size, grid_size);
   return static_cast<size_t>(grid_size - 50); // TODO: could be a tuning parameter
 }
 
-constexpr int SHORT_TILE_BYTES = rotate_short::TILE_BYTES;
+// TODO add a tuning parameter that figures out from when on it's better to move to naive (K, N)
 
 enum class RotateAlgo
 {
@@ -154,7 +160,7 @@ enum class RotateAlgo
 template <typename T>
 RotateAlgo get_algorithm_to_use(size_t rotate_distance, size_t max_distance, cudaStream_t stream)
 {
-  if (rotate_distance <= SHORT_TILE_BYTES / sizeof(T))
+  if (rotate_distance <= short_algorithm::tile_bytes / sizeof(T))
   {
     return RotateAlgo::Short;
   }
@@ -261,7 +267,7 @@ uint8_t dependency_offsets_at(
   uint32_t const num_negative_tiles,
   uint32_t const num_positive_tiles)
 {
-  constexpr uint32_t TILE_SIZE = rotate_long::TILE_BYTES / sizeof(T);
+  constexpr uint32_t TILE_SIZE = long_algorithm::tile_bytes / sizeof(T);
   uint32_t const num_nodes     = num_negative_tiles + num_positive_tiles;
   uint8_t mask                 = 0;
   int32_t const tile           = tile_detail::arr_ix_to_tile_ix(index, num_negative_tiles);
@@ -362,6 +368,7 @@ RotateState_t small_side_visit_order(
   uint32_t const num_nodes = num_negative_tiles + num_positive_tiles;
 
   RotateState_t state;
+  state.order_mode_ = (Side == SmallSide::Negative) ? OrderMode::Negative : OrderMode::Positive;
   state.ordering_.resize(num_nodes);
   uint32_t* output = state.ordering_.data();
 
@@ -429,7 +436,8 @@ struct VisitInterval
 #if defined(__x86_64__) && defined(__GNUC__)
 __attribute__((target_clones("avx2", "default")))
 #endif
-uint32_t max_position_distance(int32_t const* source, int32_t const* target, uint32_t const count)
+uint32_t
+max_position_distance(int32_t const* source, int32_t const* target, uint32_t const count)
 {
   int32_t result = 0;
 #if defined(__clang__)
@@ -608,7 +616,7 @@ RotateState_t circulant_interval_visit_order(
 template <typename T>
 RotateState_t bfs_visit_order(size_t const arr_size, size_t const rot_dist, uint32_t const head_size)
 {
-  constexpr size_t TILE_SIZE    = rotate_long::TILE_BYTES / sizeof(T);
+  constexpr size_t TILE_SIZE    = long_algorithm::tile_bytes / sizeof(T);
   auto const neg_head_size      = tile_detail::get_neg_head_size<T>(arr_size, rot_dist, head_size);
   const auto num_negative_tiles = tile_detail::get_num_negative_tiles(rot_dist, TILE_SIZE, neg_head_size);
   const auto num_positive_tiles = tile_detail::get_num_positive_tiles(arr_size, rot_dist, TILE_SIZE, head_size);
@@ -642,16 +650,16 @@ void compute_temp_size_and_state(
 {
   assert(rotate_distance > 0 && rotate_distance <= size / 2);
   uint32_t const head_size = compute_head_size<Dir>(d_array, size, rotate_distance);
-  if (rotate_distance <= SHORT_TILE_BYTES / sizeof(T))
+  if (rotate_distance <= short_algorithm::tile_bytes / sizeof(T))
   {
     size_t const num_main_tiles =
-      cuda::ceil_div((size - rotate_distance - head_size) * sizeof(T), static_cast<size_t>(SHORT_TILE_BYTES));
+      cuda::ceil_div((size - rotate_distance - head_size) * sizeof(T), short_algorithm::tile_bytes);
     temp_storage_bytes = sizeof(int) + sizeof(device_flag_t) * num_main_tiles;
     state              = RotateState_t{};
     return;
   }
 
-  assert(static_cast<size_t>(head_size) < size - rotate_distance);
+  assert(head_size < size - rotate_distance);
 
   state                       = bfs_visit_order<T>(size, rotate_distance, head_size);
   const auto algorithm_to_use = get_algorithm_to_use<T>(rotate_distance, state.max_distance_, stream);
@@ -659,7 +667,7 @@ void compute_temp_size_and_state(
   if (algorithm_to_use == RotateAlgo::Long)
   {
     auto const num_tiles = state.ordering_.size();
-    // Tile counter + ordering + flags
+    // Tile counter + flags + ordering
     temp_storage_bytes = sizeof(uint32_t) + (sizeof(uint32_t) + sizeof(device_flag_t)) * num_tiles;
   }
   else
@@ -744,38 +752,35 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch(
 
     if (algo_to_use == RotateAlgo::Short)
     {
-      constexpr size_t TILE_SIZE = SHORT_TILE_BYTES / sizeof(T);
+      constexpr size_t TILE_SIZE = short_algorithm::tile_bytes / sizeof(T);
       bool const is_tiny         = size <= TILE_SIZE;
 
       if (is_tiny)
       {
         const int shmem = static_cast<int>(size * sizeof(T));
         CUB_ROTATE_CHECK(cudaFuncSetAttribute(
-          rotate_short::rotate_tiny_kernel<Dir, T>, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem));
-        rotate_short::rotate_tiny_kernel<Dir, T><<<1, 512, shmem, stream>>>(d_array, size, rotate_distance);
+          rotate_tiny::rotate_tiny_kernel<Dir, T>, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem));
+        rotate_tiny::rotate_tiny_kernel<Dir, T><<<1, 512, shmem, stream>>>(d_array, size, rotate_distance);
         CUB_ROTATE_CHECK(cudaGetLastError());
       }
       else
       {
         auto const head_size = compute_head_size<Dir>(d_array, size, rotate_distance);
         size_t const num_main_tiles =
-          cuda::ceil_div((size - rotate_distance - head_size) * sizeof(T), static_cast<size_t>(SHORT_TILE_BYTES));
+          cuda::ceil_div((size - rotate_distance - head_size) * sizeof(T), short_algorithm::tile_bytes);
 
         int block_size, grid_size;
-        // Reuse get_launch_config by scaling the tile footprint by the stage count: each block
-        // stages PIPELINE_STAGES shmem tiles, so its per-block shmem cost is PIPELINE_STAGES *
-        // TILE_BYTES (reproduces the device-side rotate_short::LAUNCH_BOUNDS on the real device).
-        CUB_ROTATE_CHECK(
-          get_launch_config(stream, rotate_short::TILE_BYTES * rotate_short::PIPELINE_STAGES, block_size, grid_size));
+        CUB_ROTATE_CHECK(get_launch_config(
+          stream, short_algorithm::tile_bytes * short_algorithm::pipeline_stages, block_size, grid_size));
 
         CUB_ROTATE_CHECK(cudaMemsetAsync(d_temp_storage, 0, temp_storage_bytes, stream));
 
         // Multi-stage pipeline holds PIPELINE_STAGES tile buffers in dynamic shared memory.
-        constexpr int dynamic_shmem = rotate_short::get_shmem_usage<T>();
+        constexpr int dynamic_shmem = get_shmem_usage<short_algorithm, T>();
         CUB_ROTATE_CHECK(cudaFuncSetAttribute(
-          rotate_short::rotate_short_kernel<Dir, T>, cudaFuncAttributeMaxDynamicSharedMemorySize, dynamic_shmem));
-        rotate_short::rotate_short_kernel<Dir, T><<<grid_size, block_size, dynamic_shmem, stream>>>(
-          d_array, size, d_temp_storage, rotate_distance, num_main_tiles, head_size);
+          rotate_kernel<short_algorithm, Dir, T>, cudaFuncAttributeMaxDynamicSharedMemorySize, dynamic_shmem));
+        rotate_kernel<short_algorithm, Dir, T><<<grid_size, block_size, dynamic_shmem, stream>>>(
+          d_array, size, d_temp_storage, rotate_distance, num_main_tiles, head_size, OrderMode::Circulant);
         CUB_ROTATE_CHECK(cudaGetLastError());
       }
     }
@@ -787,23 +792,34 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch(
         return cudaErrorInvalidValue;
       }
       uint32_t const head_size = compute_head_size<Dir>(d_array, size, rotate_distance);
-      int num_sms;
-      CUB_ROTATE_CHECK(get_num_sms(stream, num_sms));
 
-      rotate_long::setup_kernel<<<num_sms, 512, 0, stream>>>(d_temp_storage, num_tiles);
-      CUB_ROTATE_CHECK(cudaGetLastError());
-      CUB_ROTATE_CHECK(cudaMemcpyAsync(
-        reinterpret_cast<uint32_t*>(d_temp_storage) + 1,
-        state.ordering_.data(),
-        num_tiles * sizeof(uint32_t),
-        cudaMemcpyHostToDevice,
-        stream));
+      // The counter and flags are adjacent, so one memset initializes every mutable scratch value.
+      size_t const initialized_bytes = sizeof(uint32_t) + num_tiles * sizeof(device_flag_t);
+      CUB_ROTATE_CHECK(cudaMemsetAsync(d_temp_storage, 0, initialized_bytes, stream));
+      if (state.order_mode_ == OrderMode::Circulant)
+      {
+        CUB_ROTATE_CHECK(cudaMemcpyAsync(
+          get_long_processing_order(d_temp_storage, num_tiles),
+          state.ordering_.data(),
+          num_tiles * sizeof(uint32_t),
+          cudaMemcpyHostToDevice,
+          stream));
+      }
 
-      // Launch rotate_long_kernel using cooperative kernel launch
+      // The long variant requires a cooperative launch to keep every dependency producer resident.
       int block_size, grid_size;
-      CUB_ROTATE_CHECK(get_launch_config(stream, rotate_long::TILE_BYTES, block_size, grid_size));
+      CUB_ROTATE_CHECK(
+        get_launch_config(stream, long_algorithm::tile_bytes * long_algorithm::pipeline_stages, block_size, grid_size));
       dim3 grid_dim(grid_size);
       dim3 block_dim(block_size);
+
+      // Multi-stage pipeline holds PIPELINE_STAGES tile buffers in dynamic shared memory.
+      constexpr int dynamic_shmem = get_shmem_usage<long_algorithm, T>();
+      CUB_ROTATE_CHECK(cudaFuncSetAttribute(
+        rotate_kernel<long_algorithm, Dir, T>, cudaFuncAttributeMaxDynamicSharedMemorySize, dynamic_shmem));
+
+      OrderMode const order_mode = state.order_mode_;
+
       //! Make sure the variable types are exactly the same that the kernel takes
       void* kernelArgs[] = {
         (void*) &d_array,
@@ -811,9 +827,10 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch(
         (void*) &d_temp_storage,
         (void*) &rotate_distance,
         const_cast<void*>(static_cast<const void*>(&num_tiles)),
-        const_cast<void*>(static_cast<const void*>(&head_size))};
+        const_cast<void*>(static_cast<const void*>(&head_size)),
+        const_cast<void*>(static_cast<const void*>(&order_mode))};
       CUB_ROTATE_CHECK(cudaLaunchCooperativeKernel(
-        (void*) rotate_long::rotate_long_kernel<Dir, T>, grid_dim, block_dim, kernelArgs, 0, stream));
+        (void*) rotate_kernel<long_algorithm, Dir, T>, grid_dim, block_dim, kernelArgs, dynamic_shmem, stream));
     }
     else
     {

--- a/cub/cub/device/dispatch/dispatch_rotate.cuh
+++ b/cub/cub/device/dispatch/dispatch_rotate.cuh
@@ -48,15 +48,6 @@ namespace rotate
 // Runtime device queries
 // ============================================================================
 
-// Get number of SMs in stream's GPU.
-inline cudaError_t get_num_sms(cudaStream_t stream, int& num_sms)
-{
-  int device;
-  CUB_ROTATE_CHECK(cudaStreamGetDevice(stream, &device));
-  CUB_ROTATE_CHECK(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, device));
-  return cudaSuccess;
-}
-
 inline cudaError_t get_launch_config(cudaStream_t stream, const int tile_bytes, int& block_size_out, int& grid_size_out)
 {
   int device;
@@ -141,14 +132,20 @@ struct RotateState_t
 
 // Max dependency distance for which the long algorithm is faster than the naive one.
 // Derived dynamically from the cooperative grid size.
-inline size_t get_max_dependency_distance(cudaStream_t stream)
+inline size_t get_max_supported_dependency_distance(cudaStream_t stream)
 {
   int block_size, grid_size;
   get_launch_config(stream, long_algorithm::tile_bytes * long_algorithm::pipeline_stages, block_size, grid_size);
-  return static_cast<size_t>(grid_size - 50); // TODO: could be a tuning parameter
+  return grid_size > long_algorithm::cooperative_grid_safety_margin
+         ? grid_size - long_algorithm::cooperative_grid_safety_margin
+         : 0;
 }
 
-// TODO add a tuning parameter that figures out from when on it's better to move to naive (K, N)
+template <typename T>
+inline bool fall_back_to_naive(const size_t arr_size, const size_t rotate_distance)
+{
+  return arr_size > long_algorithm::naive_fallback_min_size && static_cast<double>(rotate_distance) / arr_size < long_algorithm::naive_fallback_max_fraction && rotate_distance * sizeof(T) > long_algorithm::naive_fallback_min_distance_bytes;
+}
 
 enum class RotateAlgo
 {
@@ -158,13 +155,13 @@ enum class RotateAlgo
 };
 
 template <typename T>
-RotateAlgo get_algorithm_to_use(size_t rotate_distance, size_t max_distance, cudaStream_t stream)
+RotateAlgo get_algorithm_to_use(size_t arr_size, size_t rotate_distance, size_t max_distance, cudaStream_t stream)
 {
   if (rotate_distance <= short_algorithm::tile_bytes / sizeof(T))
   {
     return RotateAlgo::Short;
   }
-  else if (max_distance < get_max_dependency_distance(stream))
+  else if (max_distance < get_max_supported_dependency_distance(stream) && !fall_back_to_naive<T>(arr_size, rotate_distance))
   {
     return RotateAlgo::Long;
   }
@@ -625,13 +622,12 @@ RotateState_t bfs_visit_order(size_t const arr_size, size_t const rot_dist, uint
 
   // A descending order is both cheap to generate and has a tight dependency
   // bound while the negative side is small.
-  constexpr uint32_t max_direct_dependency_distance = 256;
-  if (num_negative_tiles + 1 <= max_direct_dependency_distance)
+  if (num_negative_tiles + 1 <= long_algorithm::max_direct_dependency_distance)
   {
     return small_side_visit_order<SmallSide::Negative>(num_negative_tiles, num_positive_tiles, dependency_segments);
   }
   // At an exact-half rotation, alignment rounding can make the positive side one tile smaller than the negative side.
-  if (num_positive_tiles + 1 <= max_direct_dependency_distance)
+  if (num_positive_tiles + 1 <= long_algorithm::max_direct_dependency_distance)
   {
     return small_side_visit_order<SmallSide::Positive>(num_negative_tiles, num_positive_tiles, dependency_segments);
   }
@@ -662,7 +658,7 @@ void compute_temp_size_and_state(
   assert(head_size < size - rotate_distance);
 
   state                       = bfs_visit_order<T>(size, rotate_distance, head_size);
-  const auto algorithm_to_use = get_algorithm_to_use<T>(rotate_distance, state.max_distance_, stream);
+  const auto algorithm_to_use = get_algorithm_to_use<T>(size, rotate_distance, state.max_distance_, stream);
 
   if (algorithm_to_use == RotateAlgo::Long)
   {
@@ -748,7 +744,7 @@ CUB_RUNTIME_FUNCTION cudaError_t dispatch(
     }
 
     // Execution pass: use the precomputed state
-    const auto algo_to_use = get_algorithm_to_use<T>(rotate_distance, state.max_distance_, stream);
+    const auto algo_to_use = get_algorithm_to_use<T>(size, rotate_distance, state.max_distance_, stream);
 
     if (algo_to_use == RotateAlgo::Short)
     {

--- a/cub/cub/device/dispatch/kernels/kernel_rotate.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_rotate.cuh
@@ -1,0 +1,1038 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/cub.cuh>
+#include <cub/device/dispatch/tuning/tuning_rotate.cuh>
+
+#include <cuda/atomic>
+#include <cuda/barrier>
+#include <cuda/cmath>
+#include <cuda/std/utility>
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <span>
+#include <stdexcept>
+#include <unordered_map>
+#include <vector>
+
+#include <cooperative_groups.h>
+
+CUB_NAMESPACE_BEGIN
+namespace detail
+{
+namespace rotate
+{
+// ============================================================================
+// Device-side utility functions
+// ============================================================================
+
+__device__ __forceinline__ void bar_sync(int barrier_id, int num_threads)
+{
+  asm volatile("bar.sync %0, %1;" ::"r"(barrier_id), "r"(num_threads));
+}
+
+struct named_barrier_sync
+{
+  int barrier_id_;
+  int num_threads_;
+  uint32_t tid_;
+  __device__ uint32_t thread_rank() const
+  {
+    return tid_;
+  }
+  __device__ void sync()
+  {
+    bar_sync(barrier_id_, num_threads_);
+  }
+};
+
+template <typename T, int BLOCK_SIZE, class CG>
+__device__ inline void overcopy_memcpy_async(
+  T* shmem_dst,
+  T* src,
+  const int size,
+  const int num_elems_past_alignment,
+  CG& group,
+  cuda::barrier<cuda::thread_scope_block>& bar)
+{
+  constexpr auto ELEMS_PER_SECTOR = BYTES_PER_SECTOR / sizeof(T);
+  assert(reinterpret_cast<uintptr_t>(shmem_dst) % BYTES_PER_SECTOR == 0);
+  // Round up to multiple of sector size
+  const uint32_t overcopy_tail_elems = cuda::round_up((size + num_elems_past_alignment), ELEMS_PER_SECTOR) - size;
+
+  T* aligned_src = src - num_elems_past_alignment;
+
+  assert(reinterpret_cast<uintptr_t>(aligned_src) % BYTES_PER_SECTOR == 0
+         && (size + overcopy_tail_elems) % ELEMS_PER_SECTOR == 0);
+  cuda::memcpy_async(
+    group,
+    shmem_dst,
+    aligned_src,
+    cuda::aligned_size_t<BYTES_PER_SECTOR>((size + overcopy_tail_elems) * sizeof(T)),
+    bar);
+}
+
+// Copies a tile from shared memory to global memory through registers.
+// Buffers up to MAX_REGS_PER_THREAD uint32_t registers worth of data from shmem
+// BEFORE calling sync_op.sync(), then writes to gmem AFTER.  Any remaining
+// iterations that do not fit in the register budget are processed post-sync.
+// sync_op must provide sync() and thread_rank().
+//
+// MAX_REGS_PER_THREAD should be set to REGS_PER_SM / (BLOCKS_PER_SM * BLOCK_SIZE)
+// so that the register buffering does not reduce occupancy.
+template <typename T, int NUM_THREADS, int TILE_BYTES, int MAX_REGS_PER_THREAD, typename SyncOp>
+__device__ inline void shared_to_global_through_regs(T* dst, T* src, uint32_t const bytes_to_load, SyncOp& sync_op)
+{
+  static_assert(TILE_BYTES % (NUM_THREADS * static_cast<int>(sizeof(uint32_t))) == 0);
+  constexpr int REGS_PER_T     = TILE_BYTES / (NUM_THREADS * static_cast<int>(sizeof(uint32_t)));
+  constexpr int ITERS          = REGS_PER_T / 4; // each uint4 = 4 regs
+  constexpr int CHUNK_REGS     = cuda::std::min(MAX_REGS_PER_THREAD, REGS_PER_T);
+  constexpr int BUFFERED_ITERS = CHUNK_REGS / 4;
+  static_assert(BUFFERED_ITERS >= 1 && BUFFERED_ITERS <= ITERS);
+
+  auto const tid = sync_op.thread_rank();
+
+  if (bytes_to_load < TILE_BYTES)
+  {
+    uint32_t const elems_to_load = bytes_to_load / sizeof(T);
+    sync_op.sync();
+    for (uint32_t i = tid; i < elems_to_load; i += NUM_THREADS)
+    {
+      dst[i] = src[i];
+    }
+  }
+  else
+  {
+    assert((reinterpret_cast<uintptr_t>(dst) % BYTES_PER_SECTOR) == 0);
+    if ((reinterpret_cast<uintptr_t>(src) % sizeof(uint4)) == 0)
+    {
+      uint4* new_src = reinterpret_cast<uint4*>(src);
+      uint4* new_dst = reinterpret_cast<uint4*>(dst);
+
+      uint4 regs[BUFFERED_ITERS];
+#pragma unroll
+      for (int k = 0; k < BUFFERED_ITERS; ++k)
+      {
+        regs[k] = new_src[tid + k * NUM_THREADS];
+      }
+      sync_op.sync();
+#pragma unroll
+      for (int k = 0; k < BUFFERED_ITERS; ++k)
+      {
+        new_dst[tid + k * NUM_THREADS] = regs[k];
+      }
+#pragma unroll
+      for (int k = BUFFERED_ITERS; k < ITERS; ++k)
+      {
+        new_dst[tid + k * NUM_THREADS] = new_src[tid + k * NUM_THREADS];
+      }
+    }
+    else if constexpr (sizeof(T) >= 4)
+    {
+      uint32_t* new_src = reinterpret_cast<uint32_t*>(src);
+      uint4* new_dst    = reinterpret_cast<uint4*>(dst);
+
+      uint32_t const group = (tid >> 3) & 3;
+
+      auto load_swizzled = [&](int k) {
+        int const i         = tid + k * NUM_THREADS;
+        uint32_t const base = i * 4;
+        uint32_t w[4];
+#pragma unroll
+        for (int r = 0; r < 4; ++r)
+        {
+          w[r] = new_src[base + ((r + group) & 3)];
+        }
+        switch (group)
+        {
+          case 0:
+            return make_uint4(w[0], w[1], w[2], w[3]);
+          case 1:
+            return make_uint4(w[3], w[0], w[1], w[2]);
+          case 2:
+            return make_uint4(w[2], w[3], w[0], w[1]);
+          default:
+            return make_uint4(w[1], w[2], w[3], w[0]);
+        }
+      };
+
+      uint4 regs[BUFFERED_ITERS];
+#pragma unroll
+      for (int k = 0; k < BUFFERED_ITERS; ++k)
+      {
+        regs[k] = load_swizzled(k);
+      }
+      sync_op.sync();
+#pragma unroll
+      for (int k = 0; k < BUFFERED_ITERS; ++k)
+      {
+        new_dst[tid + k * NUM_THREADS] = regs[k];
+      }
+#pragma unroll
+      for (int k = BUFFERED_ITERS; k < ITERS; ++k)
+      {
+        new_dst[tid + k * NUM_THREADS] = load_swizzled(k);
+      }
+    }
+    else
+    {
+      int const bytes_to_word_end = sizeof(uint32_t) - (reinterpret_cast<uintptr_t>(src) % sizeof(uint32_t));
+      uint32_t* new_src =
+        reinterpret_cast<uint32_t*>(reinterpret_cast<uintptr_t>(src) - (sizeof(uint32_t) - bytes_to_word_end));
+      assert(reinterpret_cast<uintptr_t>(new_src) % sizeof(uint32_t) == 0);
+
+      const int shift_len = 8 * (sizeof(uint32_t) - bytes_to_word_end);
+
+      uint4* new_dst = reinterpret_cast<uint4*>(dst);
+
+      uint32_t const group = (tid >> 3) & 3;
+
+      auto load_funnel_shifted = [&](int k) {
+        int const i         = tid + k * NUM_THREADS;
+        uint32_t const base = i * 4;
+        uint32_t w[5];
+#pragma unroll
+        for (int r = 0; r < 5; ++r)
+        {
+          int col = r + group;
+          w[r]    = new_src[base + (col >= 5 ? col - 5 : col)];
+        }
+#define FS(a, b) __funnelshift_rc(w[a], w[b], shift_len)
+        uint4 val;
+        switch (group)
+        {
+          case 0:
+            val = make_uint4(FS(0, 1), FS(1, 2), FS(2, 3), FS(3, 4));
+            break;
+          case 1:
+            val = make_uint4(FS(4, 0), FS(0, 1), FS(1, 2), FS(2, 3));
+            break;
+          case 2:
+            val = make_uint4(FS(3, 4), FS(4, 0), FS(0, 1), FS(1, 2));
+            break;
+          default:
+            val = make_uint4(FS(2, 3), FS(3, 4), FS(4, 0), FS(0, 1));
+            break;
+        }
+#undef FS
+        return val;
+      };
+
+      uint4 regs[BUFFERED_ITERS];
+#pragma unroll
+      for (int k = 0; k < BUFFERED_ITERS; ++k)
+      {
+        regs[k] = load_funnel_shifted(k);
+      }
+      sync_op.sync();
+#pragma unroll
+      for (int k = 0; k < BUFFERED_ITERS; ++k)
+      {
+        new_dst[tid + k * NUM_THREADS] = regs[k];
+      }
+#pragma unroll
+      for (int k = BUFFERED_ITERS; k < ITERS; ++k)
+      {
+        new_dst[tid + k * NUM_THREADS] = load_funnel_shifted(k);
+      }
+    }
+  }
+}
+
+// ============================================================================
+// Tile coordinate helpers (host + device)
+// ============================================================================
+
+struct Dependencies
+{
+  int32_t deps_[3];
+  uint8_t num_dependencies_;
+};
+
+namespace tile_detail
+{
+template <typename T>
+__host__ __device__ uint32_t get_neg_head_size(size_t const arr_size, size_t const rot_dist, uint32_t const head_size)
+{
+  constexpr auto ELEMS_PER_SECTOR = BYTES_PER_SECTOR / sizeof(T);
+  // Sector offset of the negative region's start (= arr + arr_size - rot_dist).
+  uint32_t const arr_offset = head_size == 0u ? 0u : (ELEMS_PER_SECTOR - head_size);
+  uint32_t const dst_offset = static_cast<uint32_t>((arr_offset + (arr_size - rot_dist)) % ELEMS_PER_SECTOR);
+  // 0 when the region's start is already sector-aligned; otherwise the slack to the
+  // next sector boundary, in [1, ELEMS_PER_SECTOR - 1].
+  return dst_offset == 0u ? 0u : (ELEMS_PER_SECTOR - dst_offset);
+}
+
+__host__ __device__ size_t get_overwrite_start(
+  size_t const arr_size,
+  size_t const rot_dist,
+  uint32_t const nominal_tile_size,
+  int32_t const tile_ix,
+  uint32_t const head_size,
+  uint32_t const neg_head_size)
+{
+  if (tile_ix >= 0)
+  {
+    return static_cast<size_t>(head_size) + static_cast<size_t>(tile_ix) * nominal_tile_size;
+  }
+  else
+  {
+    return (arr_size - rot_dist) + neg_head_size + static_cast<size_t>(-tile_ix - 1) * nominal_tile_size;
+  }
+}
+
+__host__ __device__ uint32_t get_tile_size(
+  size_t const arr_size,
+  size_t const rot_dist,
+  uint32_t const nominal_tile_size,
+  int32_t const tile_ix,
+  size_t const start,
+  uint32_t const head_size,
+  uint32_t const neg_head_size)
+{
+  if (tile_ix >= 0)
+  {
+    if (start + nominal_tile_size >= arr_size)
+    {
+      size_t const main_size   = arr_size - rot_dist - head_size;
+      uint32_t const remainder = static_cast<uint32_t>(main_size % nominal_tile_size);
+      return remainder == 0u ? nominal_tile_size : remainder;
+    }
+    else
+    {
+      return nominal_tile_size;
+    }
+  }
+  else if (start + nominal_tile_size >= rot_dist)
+  {
+    size_t const main_size   = rot_dist - neg_head_size;
+    uint32_t const remainder = static_cast<uint32_t>(main_size % nominal_tile_size);
+    return remainder == 0u ? nominal_tile_size : remainder;
+  }
+  else
+  {
+    return nominal_tile_size;
+  }
+}
+
+__host__ __device__ size_t get_tile_start(
+  size_t const rot_dist,
+  uint32_t const nominal_tile_size,
+  int32_t const tile_ix,
+  uint32_t const head_size,
+  uint32_t const neg_head_size)
+{
+  if (tile_ix >= 0)
+  {
+    return rot_dist + static_cast<size_t>(head_size) + static_cast<size_t>(tile_ix) * nominal_tile_size;
+  }
+  else
+  {
+    return neg_head_size + static_cast<size_t>(-tile_ix - 1) * nominal_tile_size;
+  }
+}
+
+__host__ __device__ uint32_t
+get_num_negative_tiles(size_t const rot_dist, uint32_t const nominal_tile_size, uint32_t const neg_head_size)
+{
+  return cuda::ceil_div(rot_dist - neg_head_size, nominal_tile_size);
+}
+
+__host__ __device__ uint32_t get_num_positive_tiles(
+  size_t const arr_size, size_t const rot_dist, uint32_t const nominal_tile_size, uint32_t const head_size)
+{
+  return cuda::ceil_div(arr_size - rot_dist - head_size, nominal_tile_size);
+}
+
+template <typename T>
+__host__ __device__ Dependencies get_dependencies(
+  size_t const arr_size,
+  size_t const rot_dist,
+  uint32_t const nominal_tile_size,
+  int32_t const tile_ix,
+  uint32_t const /*num_tiles*/,
+  uint32_t const head_size)
+{
+  Dependencies item_deps{{0, 0, 0}, 0};
+
+  uint32_t const neg_head_size = get_neg_head_size<T>(arr_size, rot_dist, head_size);
+  uint32_t const num_neg       = get_num_negative_tiles(rot_dist, nominal_tile_size, neg_head_size);
+
+  size_t overwrite_start =
+    get_overwrite_start(arr_size, rot_dist, nominal_tile_size, tile_ix, head_size, neg_head_size);
+  uint32_t const tile_size = get_tile_size(
+    arr_size,
+    rot_dist,
+    nominal_tile_size,
+    tile_ix,
+    get_tile_start(rot_dist, nominal_tile_size, tile_ix, head_size, neg_head_size),
+    head_size,
+    neg_head_size);
+  size_t const overwrite_end = overwrite_start + tile_size - 1;
+  // Extend the overwrite start to cover the head destination owned by this tile so that
+  // any tile whose source overlaps the head dst is picked up as a dependency.
+  if (tile_ix == 0 && head_size > 0u)
+  {
+    overwrite_start = 0;
+  }
+  else if (tile_ix == -1 && neg_head_size > 0u)
+  {
+    overwrite_start = arr_size - rot_dist;
+  }
+
+  auto snap = [&](size_t pos) -> int32_t {
+    if (pos < neg_head_size)
+    {
+      return -1; // pos head src -> tile -1
+    }
+    if (pos < rot_dist)
+    {
+      return -static_cast<int32_t>((pos - neg_head_size) / nominal_tile_size + 1);
+    }
+    if (pos < rot_dist + head_size)
+    {
+      return 0; // pos head src -> tile 0
+    }
+    return static_cast<int32_t>((pos - rot_dist - head_size) / nominal_tile_size);
+  };
+
+  int32_t cur        = snap(overwrite_start);
+  int32_t const last = snap(overwrite_end);
+
+  auto advance = [&]() {
+    if (cur < 0)
+    {
+      cur--;
+      if (static_cast<uint32_t>(cuda::std::abs(cur)) > num_neg)
+      {
+        cur = 0; // jump from -num_neg past pos head to BFS pos 0
+      }
+    }
+    else
+    {
+      cur++;
+    }
+  };
+  auto should_continue = [&]() {
+    return ((cuda::std::abs(cur) <= cuda::std::abs(last)) || ((cur < 0) && (last >= 0))) && !(last < 0 && cur >= 0);
+  };
+
+  item_deps.deps_[0]          = cur;
+  item_deps.num_dependencies_ = 1;
+  advance();
+  if (should_continue())
+  {
+    item_deps.deps_[1]          = cur;
+    item_deps.num_dependencies_ = 2;
+    advance();
+    if (should_continue())
+    {
+      item_deps.deps_[2]          = cur;
+      item_deps.num_dependencies_ = 3;
+    }
+  }
+  return item_deps;
+}
+
+__host__ __device__ int32_t arr_ix_to_tile_ix(size_t const arr_ix, uint32_t const num_negative_tiles)
+{
+  return arr_ix < num_negative_tiles
+         ? -static_cast<int32_t>(arr_ix + 1)
+         : (static_cast<int32_t>(arr_ix - num_negative_tiles));
+};
+
+__host__ __device__ size_t tile_ix_to_arr_ix(int32_t const tile_ix, uint32_t const num_negative_tiles)
+{
+  return tile_ix < 0 ? cuda::std::abs(tile_ix + 1) : static_cast<size_t>(tile_ix + num_negative_tiles);
+};
+} // namespace tile_detail
+
+// ============================================================================
+// Short-distance rotate kernel
+// ============================================================================
+
+namespace rotate_short
+{
+template <typename T>
+int get_shmem_usage(cudaStream_t stream)
+{
+  int device;
+  cudaStreamGetDevice(stream, &device);
+
+  int shmem_per_sm;
+  cudaDeviceGetAttribute(&shmem_per_sm, cudaDevAttrMaxSharedMemoryPerMultiprocessor, device);
+
+  const auto pipeline_depth = get_pipeline_depth(TILE_BYTES, shmem_per_sm);
+  return pipeline_depth * (TILE_BYTES + BYTES_PER_SECTOR);
+}
+
+__global__ void setup_kernel(void* d_temp_storage, size_t const temp_bytes, size_t const num_sms)
+{
+  auto* flags       = reinterpret_cast<device_flag_t*>(d_temp_storage);
+  auto const tid    = blockIdx.x * blockDim.x + threadIdx.x;
+  auto const stride = blockDim.x * gridDim.x;
+  for (int i = tid; i < num_sms; i += stride)
+  {
+    // Initialize as blocked
+    flags[i].store(0, cuda::memory_order_relaxed);
+  }
+}
+
+template <typename T>
+CUB_ROTATE_LB(BLOCK_SIZE, BLOCKS_PER_SM)
+__global__ void rotate_short_kernel(
+  T* arr,
+  size_t const size,
+  void* d_temp_storage,
+  size_t const temp_size,
+  size_t const rotate_distance,
+  size_t const num_tiles,
+  uint32_t const head_size)
+{
+  assert(blockDim.x == BLOCK_SIZE);
+  constexpr int TILE_SIZE         = TILE_BYTES / sizeof(T);
+  constexpr auto ELEMS_PER_SECTOR = BYTES_PER_SECTOR / sizeof(T);
+
+  assert(rotate_distance <= TILE_SIZE);
+  assert(head_size < ELEMS_PER_SECTOR);
+
+  constexpr int P = get_pipeline_depth(TILE_BYTES, SHMEM_PER_SM);
+
+  alignas(BYTES_PER_SECTOR) extern __shared__ unsigned char smem_raw[];
+  T(*cache)[TILE_SIZE + ELEMS_PER_SECTOR] = reinterpret_cast<T(*)[TILE_SIZE + ELEMS_PER_SECTOR]>(smem_raw);
+
+  // Space in shared memory for the first chunk's head tile used for alignment of the others
+  __shared__ T head_tile[ELEMS_PER_SECTOR];
+
+#pragma nv_diag_suppress static_var_with_dynamic_init
+  __shared__ cuda::barrier<cuda::thread_scope_block> bars[P];
+
+  __shared__ cuda::atomic<uint32_t, cuda::thread_scope_block> num_loaded;
+  __shared__ cuda::atomic<uint32_t, cuda::thread_scope_block> num_consumed;
+
+  auto* flags = reinterpret_cast<device_flag_t*>(d_temp_storage);
+
+  auto const tid         = threadIdx.x;
+  bool const is_producer = tid < WS;
+
+  if (tid < P)
+  {
+    init(&bars[tid], NUM_CONSUMER_THREADS);
+  }
+  if (tid == 0)
+  {
+    num_loaded   = 0;
+    num_consumed = 0;
+  }
+  __syncthreads();
+
+  assert(2 * rotate_distance <= size);
+  assert(size > TILE_SIZE);
+
+  const auto nominal_tiles_per_chunk = num_tiles / gridDim.x;
+  const uint32_t tiles_to_process =
+    blockIdx.x == gridDim.x - 1 ? nominal_tiles_per_chunk + num_tiles % gridDim.x : nominal_tiles_per_chunk;
+  assert(tiles_to_process > 0 || nominal_tiles_per_chunk == 0);
+
+  // Blocks with no tiles to process must still set their flag
+  // to prevent deadlocks in subsequent blocks waiting on them
+  if (tiles_to_process == 0)
+  {
+    if (tid == 0)
+    {
+      flags[blockIdx.x].store(1, cuda::memory_order_release);
+      flags[blockIdx.x].notify_all();
+    }
+    return;
+  }
+
+  const auto chunk_start_ix = rotate_distance + head_size + blockIdx.x * nominal_tiles_per_chunk * TILE_SIZE;
+  uint32_t const overcopy_extra_head_elems = static_cast<uint32_t>(rotate_distance % ELEMS_PER_SECTOR);
+  bool const is_first_chunk                = chunk_start_ix == rotate_distance + head_size;
+
+  auto get_tile_load_index = [&](uint32_t tile_num) -> size_t {
+    // We load from the back forwards
+    return chunk_start_ix + (tiles_to_process - 1 - tile_num) * TILE_SIZE;
+  };
+
+  auto get_bytes_to_load = [&](uint32_t tile_num) -> uint32_t {
+    bool const is_last_chunks_first_tile = blockIdx.x == gridDim.x - 1 && tile_num == 0;
+    if (!is_last_chunks_first_tile)
+    {
+      return TILE_SIZE * sizeof(T);
+    }
+    uint32_t const remainder = (size - rotate_distance - head_size) % TILE_SIZE;
+    return (remainder == 0u ? TILE_SIZE : remainder) * sizeof(T);
+  };
+
+  // ========================= PRODUCER (warp 0) =========================
+  if (is_producer)
+  {
+    auto warp = cooperative_groups::tiled_partition<WS>(cooperative_groups::this_thread_block());
+
+    auto producer_load = [&](uint32_t tile_num) {
+      int const slot       = tile_num % P;
+      T* src               = arr + get_tile_load_index(tile_num);
+      uint32_t const bytes = get_bytes_to_load(tile_num);
+      while (tile_num >= num_consumed.load(cuda::memory_order_acquire) + P)
+      {
+        __nanosleep(0);
+      }
+      if constexpr (hasTMA())
+      {
+        cooperative_groups::invoke_one(warp, [&] {
+          overcopy_memcpy_async<T, WS>(cache[slot], src, bytes / sizeof(T), overcopy_extra_head_elems, warp, bars[slot]);
+        });
+      }
+      else
+      {
+        overcopy_memcpy_async<T, WS>(cache[slot], src, bytes / sizeof(T), overcopy_extra_head_elems, warp, bars[slot]);
+      }
+      if (tid == 0)
+      {
+        num_loaded++;
+      }
+    };
+
+    // Load head tile
+    if (is_first_chunk)
+    {
+      for (uint32_t i = tid; i < head_size; i += WS)
+      {
+        head_tile[i] = arr[rotate_distance + i];
+      }
+    }
+
+    // Main loop
+    for (int i = 0; i < static_cast<int>(tiles_to_process); i++)
+    {
+      producer_load(i);
+    }
+  }
+  // ======================== CONSUMERS (warps 1+) ========================
+  else
+  {
+    uint32_t const consumer_tid = tid - WS;
+
+    // wait on the first tile and set global flag
+    if (consumer_tid == 0)
+    {
+      while (num_loaded.load(cuda::memory_order_acquire) == 0)
+      {
+        __nanosleep(0);
+      }
+    }
+    bars[0].arrive_and_wait();
+    if (consumer_tid == 0)
+    {
+      flags[blockIdx.x].store(1, cuda::memory_order_release);
+      flags[blockIdx.x].notify_all();
+    }
+
+    for (int i = 0; i < static_cast<int>(tiles_to_process); i++)
+    {
+      int const slot = i % P;
+
+      // Handle inter-block dependencies on the last tile
+      if (i == static_cast<int>(tiles_to_process) - 1)
+      {
+        if (is_first_chunk)
+        {
+          assert(blockIdx.x == 0 || blockIdx.x == gridDim.x - 1);
+          if (consumer_tid == 0)
+          {
+            flags[gridDim.x - 1].wait(0, cuda::memory_order_acquire);
+            flags[gridDim.x - 2].wait(0, cuda::memory_order_acquire);
+          }
+          bar_sync(1, NUM_CONSUMER_THREADS);
+          for (uint32_t j = consumer_tid; j < rotate_distance; j += NUM_CONSUMER_THREADS)
+          {
+            arr[size - rotate_distance + j] = arr[j];
+          }
+          bar_sync(1, NUM_CONSUMER_THREADS);
+        }
+        else
+        {
+          if (consumer_tid == 0)
+          {
+            flags[blockIdx.x - 1].wait(0, cuda::memory_order_acquire);
+          }
+          bar_sync(1, NUM_CONSUMER_THREADS);
+        }
+      }
+
+      // Store tile from shmem to gmem
+      auto const load_index = get_tile_load_index(i);
+      T* src                = cache[slot] + overcopy_extra_head_elems;
+      T* dst                = arr + load_index - rotate_distance;
+      assert(load_index > rotate_distance || head_size == 0);
+
+      // wait on next tile to finish loading (all consumers participate)
+      if (i < static_cast<int>(tiles_to_process) - 1)
+      {
+        if (consumer_tid == 0)
+        {
+          while (num_loaded.load(cuda::memory_order_acquire) <= static_cast<uint32_t>(i + 1))
+          {
+            __nanosleep(0);
+          }
+        }
+        bars[(slot + 1) % P].arrive_and_wait();
+      }
+      named_barrier_sync nbs{1, NUM_CONSUMER_THREADS, consumer_tid};
+      constexpr int MAX_REGS = REGS_PER_SM / (BLOCKS_PER_SM * BLOCK_SIZE);
+      shared_to_global_through_regs<T, NUM_CONSUMER_THREADS, TILE_BYTES, MAX_REGS>(dst, src, get_bytes_to_load(i), nbs);
+      bar_sync(1, NUM_CONSUMER_THREADS);
+      if (consumer_tid == 0)
+      {
+        num_consumed++;
+      }
+    }
+  }
+
+  __syncthreads();
+
+  if (is_first_chunk && tid < WS)
+  {
+    for (uint32_t i = tid; i < head_size; i += WS)
+    {
+      arr[i] = head_tile[i];
+    }
+  }
+}
+} // namespace rotate_short
+
+// ============================================================================
+// Short-distance rotate kernel (no pipelining)
+// ============================================================================
+
+namespace rotate_short_no_pipeline
+{
+__global__ void setup_kernel(void* d_temp_storage, size_t const temp_bytes, size_t const num_tiles)
+{
+  auto* counter     = reinterpret_cast<int*>(d_temp_storage);
+  auto const tid    = blockIdx.x * blockDim.x + threadIdx.x;
+  auto const stride = blockDim.x * gridDim.x;
+  if (tid == 0)
+  {
+    counter[0] = num_tiles - 1;
+  }
+  auto* flags = reinterpret_cast<device_flag_t*>(counter + 1);
+  for (int i = tid; i < num_tiles; i += stride)
+  {
+    flags[i].store(0, cuda::memory_order_relaxed);
+  }
+}
+
+template <typename T>
+__global__ void rotate_tiny_kernel(T* arr, size_t const size, size_t const rotate_distance)
+{
+  extern __shared__ unsigned char smem_raw[];
+  T* smem = reinterpret_cast<T*>(smem_raw);
+
+  assert(2 * rotate_distance > size || size <= TILE_BYTES / sizeof(T));
+  assert(rotate_distance > 0 && rotate_distance < size);
+
+  if (blockIdx.x == 0)
+  {
+    for (size_t i = threadIdx.x; i < size; i += blockDim.x)
+    {
+      smem[i] = arr[i];
+    }
+    __syncthreads();
+
+    size_t const tail = size - rotate_distance;
+    for (size_t i = threadIdx.x; i < tail; i += blockDim.x)
+    {
+      arr[i] = smem[i + rotate_distance];
+    }
+    for (size_t i = threadIdx.x; i < rotate_distance; i += blockDim.x)
+    {
+      arr[tail + i] = smem[i];
+    }
+  }
+}
+
+template <typename T>
+CUB_ROTATE_LB(BLOCK_SIZE, BLOCKS_PER_SM)
+__global__ void rotate_short_kernel_no_pipeline(
+  T* arr,
+  size_t const size,
+  void* d_temp_storage,
+  size_t const temp_size,
+  size_t const rotate_distance,
+  size_t const num_tiles,
+  uint32_t const head_size)
+{
+  assert(blockDim.x == BLOCK_SIZE);
+  constexpr int TILE_SIZE         = TILE_BYTES / sizeof(T);
+  constexpr auto ELEMS_PER_SECTOR = BYTES_PER_SECTOR / sizeof(T);
+
+  assert(rotate_distance <= TILE_SIZE);
+  assert(head_size < ELEMS_PER_SECTOR);
+  assert(2 * rotate_distance <= size);
+  assert(size > TILE_SIZE);
+
+  alignas(BYTES_PER_SECTOR) __shared__ T cache[TILE_SIZE + ELEMS_PER_SECTOR];
+  __shared__ int tile_ix;
+  __shared__ T head_tile_cache[ELEMS_PER_SECTOR];
+#pragma nv_diag_suppress static_var_with_dynamic_init
+  __shared__ cuda::barrier<cuda::thread_scope_block> bar;
+
+  auto* tile_counter = reinterpret_cast<cuda::atomic<int, cuda::thread_scope_device>*>(d_temp_storage);
+  auto* flags        = reinterpret_cast<device_flag_t*>(reinterpret_cast<int*>(d_temp_storage) + 1);
+
+  auto const tid = threadIdx.x;
+  auto cta       = cooperative_groups::this_thread_block();
+
+  if (tid == 0)
+  {
+    init(&bar, BLOCK_SIZE);
+  }
+
+  uint32_t const overcopy_extra_head_elems = static_cast<uint32_t>(rotate_distance % ELEMS_PER_SECTOR);
+
+  bool first_iteration = true;
+  while (true)
+  {
+    if (tid == 0)
+    {
+      tile_ix = tile_counter->fetch_sub(1, cuda::memory_order_relaxed);
+    }
+    __syncthreads();
+    int const curr_tile = tile_ix;
+    if (curr_tile < 0)
+    {
+      if (!first_iteration)
+      {
+        bar.arrive_and_wait();
+      }
+      return;
+    }
+
+    bool const is_first_tile = static_cast<size_t>(curr_tile) == num_tiles - 1;
+    uint32_t bytes_to_load   = TILE_SIZE * sizeof(T);
+    if (is_first_tile)
+    {
+      uint32_t const remainder = (size - rotate_distance - head_size) % TILE_SIZE;
+      bytes_to_load            = (remainder == 0u ? TILE_SIZE : remainder) * sizeof(T);
+    }
+
+    size_t const load_index = rotate_distance + head_size + static_cast<size_t>(curr_tile) * TILE_SIZE;
+    T* src                  = arr + load_index;
+
+    if (!first_iteration)
+    {
+      bar.arrive_and_wait();
+    }
+    else
+    {
+      first_iteration = false;
+    }
+    overcopy_memcpy_async<T, BLOCK_SIZE>(cache, src, bytes_to_load / sizeof(T), overcopy_extra_head_elems, cta, bar);
+    bar.arrive_and_wait();
+
+    bool const is_last_tile = curr_tile == 0;
+    if (tid == 0)
+    {
+      flags[curr_tile].store(1, cuda::memory_order_release);
+      flags[curr_tile].notify_all();
+      auto const ix = is_last_tile ? num_tiles - 1 : curr_tile - 1;
+      flags[ix].wait(0, cuda::memory_order_acquire);
+    }
+
+    if (is_last_tile)
+    {
+      // Save head data before it gets overwritten by our tile store
+      if (head_size > 0u)
+      {
+        for (uint32_t i = tid; i < head_size; i += BLOCK_SIZE)
+        {
+          head_tile_cache[i] = arr[rotate_distance + i];
+        }
+      }
+
+      // Copy first rotate_distance elements to end of array
+      flags[num_tiles - 1].wait(0, cuda::memory_order_acquire);
+      __syncthreads();
+      for (size_t i = tid; i < rotate_distance; i += BLOCK_SIZE)
+      {
+        arr[size - rotate_distance + i] = arr[i];
+      }
+      __syncthreads();
+    }
+
+    T* dst                 = arr + load_index - rotate_distance;
+    constexpr int MAX_REGS = REGS_PER_SM / (BLOCKS_PER_SM * BLOCK_SIZE);
+    shared_to_global_through_regs<T, BLOCK_SIZE, TILE_BYTES, MAX_REGS>(
+      dst, cache + overcopy_extra_head_elems, bytes_to_load, cta);
+
+    // Tile 0 owns the head: write it after storing the main tile
+    if (is_last_tile && head_size > 0u)
+    {
+      __syncthreads();
+      for (uint32_t i = tid; i < head_size; i += BLOCK_SIZE)
+      {
+        arr[i] = head_tile_cache[i];
+      }
+    }
+  }
+}
+} // namespace rotate_short_no_pipeline
+
+// ============================================================================
+// Long-distance rotate kernel
+// ============================================================================
+
+namespace rotate_long
+{
+__global__ void setup_kernel(void* d_temp_storage, size_t const temp_bytes, size_t const num_tiles)
+{
+  auto* counter     = reinterpret_cast<uint32_t*>(d_temp_storage);
+  auto const tid    = blockIdx.x * blockDim.x + threadIdx.x;
+  auto const stride = blockDim.x * gridDim.x;
+  if (tid == 0)
+  {
+    counter[0] = 0;
+  }
+  auto* flags = reinterpret_cast<device_flag_t*>(counter + 1 + num_tiles); // skip ordering array
+  for (int i = tid; i < num_tiles; i += stride)
+  {
+    // Initialize as blocked
+    flags[i].store(0, cuda::memory_order_relaxed);
+  }
+}
+
+template <typename T>
+CUB_ROTATE_LB(BLOCK_SIZE, BLOCKS_PER_SM)
+__global__ void rotate_long_kernel(
+  T* arr,
+  size_t const size,
+  void* d_temp_storage,
+  size_t const temp_size,
+  size_t const rotate_distance,
+  size_t const num_tiles,
+  uint32_t const head_size)
+{
+  assert(blockDim.x == BLOCK_SIZE);
+  constexpr int TILE_SIZE         = TILE_BYTES / sizeof(T);
+  constexpr auto ELEMS_PER_SECTOR = BYTES_PER_SECTOR / sizeof(T);
+  alignas(BYTES_PER_SECTOR) __shared__ T cache[TILE_SIZE + ELEMS_PER_SECTOR]; // +ELEMS_PER_SECTOR to avoid shmem bank
+                                                                              // conflicts when writing back to global
+                                                                              // memory
+  __shared__ int tile_ordering_ix;
+  // Tile -1 owns the negative head used for sector alignment of the negative tiles destinations.
+  // Tile 0 owns the positive head used for sector alignment of the positive tiles destinations.
+  __shared__ T head_tile_cache[ELEMS_PER_SECTOR];
+#pragma nv_diag_suppress static_var_with_dynamic_init
+  __shared__ cuda::barrier<cuda::thread_scope_block> bar;
+
+  auto* tiles_processed  = reinterpret_cast<cuda::atomic<uint32_t, cuda::thread_scope_device>*>(d_temp_storage);
+  auto* processing_order = reinterpret_cast<int32_t*>(tiles_processed + 1); // first uint32_t is the counter of
+                                                                            // processed items
+  auto* flags = reinterpret_cast<device_flag_t*>(processing_order + num_tiles);
+
+  uint32_t const neg_head_size = tile_detail::get_neg_head_size<T>(size, rotate_distance, head_size);
+
+  auto const tid = threadIdx.x;
+  auto cta       = cooperative_groups::this_thread_block();
+
+  if (tid == 0)
+  {
+    init(&bar, BLOCK_SIZE);
+  }
+  while (true)
+  {
+    if (tid == 0)
+    {
+      tile_ordering_ix = tiles_processed->fetch_add(1, cuda::memory_order_seq_cst);
+    }
+    __syncthreads();
+    auto const curr_tile_ordering_ix = tile_ordering_ix;
+    if (curr_tile_ordering_ix >= num_tiles)
+    {
+      return;
+    }
+    auto const curr_tile = processing_order[curr_tile_ordering_ix];
+    auto const curr_tile_start =
+      tile_detail::get_tile_start(rotate_distance, TILE_SIZE, curr_tile, head_size, neg_head_size);
+    auto const curr_tile_size = tile_detail::get_tile_size(
+      size, rotate_distance, TILE_SIZE, curr_tile, curr_tile_start, head_size, neg_head_size);
+    assert(curr_tile_size <= TILE_SIZE);
+
+    bool const owns_pos_head      = (curr_tile == 0) && (head_size > 0u);
+    bool const owns_neg_head      = (curr_tile == -1) && (neg_head_size > 0u);
+    uint32_t const head_load_size = owns_pos_head ? head_size : (owns_neg_head ? neg_head_size : 0u);
+    size_t const head_src_off     = owns_pos_head ? rotate_distance : 0;
+    size_t const head_dst_off     = owns_pos_head ? 0 : (size - rotate_distance);
+
+    if (head_load_size > 0u && tid < WS)
+    {
+      for (uint32_t i = tid; i < head_load_size; i += WS)
+      {
+        head_tile_cache[i] = arr[head_src_off + i];
+      }
+    }
+
+    // Regular tile load via the standard memcpy_async pipeline.
+    T* src                         = arr + curr_tile_start;
+    uint32_t const unaligned_elems = (reinterpret_cast<uintptr_t>(src) % BYTES_PER_SECTOR) / sizeof(T);
+
+    overcopy_memcpy_async<T, BLOCK_SIZE>(cache, src, curr_tile_size, unaligned_elems, cta, bar);
+    bar.arrive_and_wait();
+
+    if (tid == 0)
+    {
+      auto const num_negative_tiles = tile_detail::get_num_negative_tiles(rotate_distance, TILE_SIZE, neg_head_size);
+      flags[tile_detail::tile_ix_to_arr_ix(curr_tile, num_negative_tiles)].store(1, cuda::memory_order_release);
+      flags[tile_detail::tile_ix_to_arr_ix(curr_tile, num_negative_tiles)].notify_all();
+      // Poll dependencies
+      auto const deps =
+        tile_detail::get_dependencies<T>(size, rotate_distance, TILE_SIZE, curr_tile, num_tiles, head_size);
+      // static loop to keep deps in registers
+      for (int i = 0; i < 3; ++i)
+      {
+        if (i < deps.num_dependencies_)
+        {
+          flags[tile_detail::tile_ix_to_arr_ix(deps.deps_[i], num_negative_tiles)].wait(0, cuda::memory_order_acquire);
+        }
+      }
+    }
+
+    // Copy cached tile to destination
+    T* dst = arr
+           + tile_detail::get_overwrite_start(size, rotate_distance, TILE_SIZE, curr_tile, head_size, neg_head_size);
+    src                    = cache + unaligned_elems;
+    constexpr int MAX_REGS = REGS_PER_SM / (BLOCKS_PER_SM * BLOCK_SIZE);
+    shared_to_global_through_regs<T, BLOCK_SIZE, TILE_BYTES, MAX_REGS>(dst, src, curr_tile_size * sizeof(T), cta);
+
+    if (head_load_size > 0u && tid < WS)
+    {
+      for (uint32_t i = tid; i < head_load_size; i += WS)
+      {
+        arr[head_dst_off + i] = head_tile_cache[i];
+      }
+    }
+  }
+}
+} // namespace rotate_long
+} // namespace rotate
+} // namespace detail
+CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/kernels/kernel_rotate.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_rotate.cuh
@@ -91,7 +91,7 @@ __device__ inline void overcopy_memcpy_async(
 
 // Copies a tile from shared memory to global memory through registers.
 // Buffers up to MAX_REGS_PER_THREAD uint32_t registers worth of data from shmem
-// BEFORE calling sync_op.sync(), then writes to gmem AFTER.  Any remaining
+// BEFORE calling sync_op.sync(), to maximally overlap the atomic polling with other work, then writes to gmem AFTER.  Any remaining
 // iterations that do not fit in the register budget are processed post-sync.
 // sync_op must provide sync() and thread_rank().
 //
@@ -106,6 +106,8 @@ __device__ inline void shared_to_global_through_regs(T* dst, T* src, uint32_t co
   constexpr int CHUNK_REGS     = cuda::std::min(MAX_REGS_PER_THREAD, REGS_PER_T);
   constexpr int BUFFERED_ITERS = CHUNK_REGS / 4;
   static_assert(BUFFERED_ITERS >= 1 && BUFFERED_ITERS <= ITERS);
+
+  constexpr int VEC_TILE_BYTES = ITERS * 4 * NUM_THREADS * static_cast<int>(sizeof(uint32_t));
 
   auto const tid = sync_op.thread_rank();
 
@@ -136,40 +138,48 @@ __device__ inline void shared_to_global_through_regs(T* dst, T* src, uint32_t co
 #pragma unroll
       for (int k = 0; k < BUFFERED_ITERS; ++k)
       {
-        new_dst[tid + k * NUM_THREADS] = regs[k];
+        // Write-through store to not pollute L2
+        cub::ThreadStore<cub::STORE_WT>(new_dst + tid + k * NUM_THREADS, regs[k]);
       }
 #pragma unroll
       for (int k = BUFFERED_ITERS; k < ITERS; ++k)
       {
-        new_dst[tid + k * NUM_THREADS] = new_src[tid + k * NUM_THREADS];
+        cub::ThreadStore<cub::STORE_WT>(new_dst + tid + k * NUM_THREADS, new_src[tid + k * NUM_THREADS]);
       }
     }
-    else if constexpr (sizeof(T) >= 4)
+    else if ((reinterpret_cast<uintptr_t>(src) % sizeof(uint32_t)) == 0)
     {
       uint32_t* new_src = reinterpret_cast<uint32_t*>(src);
       uint4* new_dst    = reinterpret_cast<uint4*>(dst);
 
-      uint32_t const group = (tid >> 3) & 3;
+      // s = words `src` is above the 16B boundary; in {1,2,3} in this branch.
+      uint32_t const s         = (static_cast<uint32_t>(reinterpret_cast<uintptr_t>(src)) % sizeof(uint4)) / sizeof(uint32_t);
+      uint4 const* aligned_src = reinterpret_cast<uint4 const*>(new_src - s);
+      bool const is_top_lane      = (tid % WS) == (WS - 1);
 
-      auto load_swizzled = [&](int k) {
-        int const i         = tid + k * NUM_THREADS;
-        uint32_t const base = i * 4;
-        uint32_t w[4];
-#pragma unroll
-        for (int r = 0; r < 4; ++r)
+      auto load_funnel = [&](int k) -> uint4 {
+        int const j   = tid + k * NUM_THREADS;
+        uint4 const A = aligned_src[j];
+        // Boundary words = the first `s` words of B = aligned_src[j+1] = the neighbor lane's A.
+        // Shuffle them from lane+1; the top lane has no in-warp neighbor, so load B directly.
+        uint32_t bx = __shfl_down_sync(0xffffffffu, A.x, 1);
+        uint32_t by = (s >= 2u) ? __shfl_down_sync(0xffffffffu, A.y, 1) : 0u;
+        uint32_t bz = (s >= 3u) ? __shfl_down_sync(0xffffffffu, A.z, 1) : 0u;
+        if (is_top_lane)
         {
-          w[r] = new_src[base + ((r + group) & 3)];
+          uint4 const B = aligned_src[j + 1];
+          bx            = B.x;
+          by            = B.y;
+          bz            = B.z;
         }
-        switch (group)
+        switch (s)
         {
-          case 0:
-            return make_uint4(w[0], w[1], w[2], w[3]);
           case 1:
-            return make_uint4(w[3], w[0], w[1], w[2]);
+            return make_uint4(A.y, A.z, A.w, bx);
           case 2:
-            return make_uint4(w[2], w[3], w[0], w[1]);
-          default:
-            return make_uint4(w[1], w[2], w[3], w[0]);
+            return make_uint4(A.z, A.w, bx, by);
+          default: // s == 3
+            return make_uint4(A.w, bx, by, bz);
         }
       };
 
@@ -177,18 +187,18 @@ __device__ inline void shared_to_global_through_regs(T* dst, T* src, uint32_t co
 #pragma unroll
       for (int k = 0; k < BUFFERED_ITERS; ++k)
       {
-        regs[k] = load_swizzled(k);
+        regs[k] = load_funnel(k);
       }
       sync_op.sync();
 #pragma unroll
       for (int k = 0; k < BUFFERED_ITERS; ++k)
       {
-        new_dst[tid + k * NUM_THREADS] = regs[k];
+        cub::ThreadStore<cub::STORE_WT>(new_dst + tid + k * NUM_THREADS, regs[k]);
       }
 #pragma unroll
       for (int k = BUFFERED_ITERS; k < ITERS; ++k)
       {
-        new_dst[tid + k * NUM_THREADS] = load_swizzled(k);
+        cub::ThreadStore<cub::STORE_WT>(new_dst + tid + k * NUM_THREADS, load_funnel(k));
       }
     }
     else
@@ -245,16 +255,31 @@ __device__ inline void shared_to_global_through_regs(T* dst, T* src, uint32_t co
 #pragma unroll
       for (int k = 0; k < BUFFERED_ITERS; ++k)
       {
-        new_dst[tid + k * NUM_THREADS] = regs[k];
+        cub::ThreadStore<cub::STORE_WT>(new_dst + tid + k * NUM_THREADS, regs[k]);
       }
 #pragma unroll
       for (int k = BUFFERED_ITERS; k < ITERS; ++k)
       {
-        new_dst[tid + k * NUM_THREADS] = load_funnel_shifted(k);
+        cub::ThreadStore<cub::STORE_WT>(new_dst + tid + k * NUM_THREADS, load_funnel_shifted(k));
+      }
+    }
+
+    // TODO: see if adapting the tile size to remove the tail improves perf
+    if constexpr (VEC_TILE_BYTES < TILE_BYTES)
+    {
+      // The uncovered tail [VEC_TILE_BYTES, TILE_BYTES) is a contiguous src->dst block copy: the
+      // rotation lives entirely in dst's gmem offset, so a plain element copy is byte-identical for
+      // all three realignment branches above.
+      uint32_t const elems_to_load  = bytes_to_load / sizeof(T);
+      constexpr uint32_t tail_begin = VEC_TILE_BYTES / static_cast<int>(sizeof(T));
+      for (uint32_t i = tail_begin + tid; i < elems_to_load; i += NUM_THREADS)
+      {
+        dst[i] = src[i];
       }
     }
   }
 }
+
 
 // ============================================================================
 // Tile coordinate helpers (host + device)
@@ -465,261 +490,23 @@ __host__ __device__ size_t tile_ix_to_arr_ix(int32_t const tile_ix, uint32_t con
 } // namespace tile_detail
 
 // ============================================================================
-// Short-distance rotate kernel
+// Short-distance rotate kernel (no pipelining)
 // ============================================================================
 
 namespace rotate_short
 {
+// Dynamic shared-memory bytes for the multi-stage short kernel: PIPELINE_STAGES tile
+// buffers, each TILE_BYTES + BYTES_PER_SECTOR (overcopy / bank-conflict slack).
 template <typename T>
-int get_shmem_usage(cudaStream_t stream)
+constexpr int get_shmem_usage()
 {
-  int device;
-  cudaStreamGetDevice(stream, &device);
-
-  int shmem_per_sm;
-  cudaDeviceGetAttribute(&shmem_per_sm, cudaDevAttrMaxSharedMemoryPerMultiprocessor, device);
-
-  const auto pipeline_depth = get_pipeline_depth(TILE_BYTES, shmem_per_sm);
-  return pipeline_depth * (TILE_BYTES + BYTES_PER_SECTOR);
+  constexpr auto ELEMS_PER_SECTOR = BYTES_PER_SECTOR / static_cast<int>(sizeof(T));
+  constexpr int TILE_SIZE         = TILE_BYTES / static_cast<int>(sizeof(T));
+  // Must match SLOT_BYTES inside the kernel (each slot rounded up to 128B for TMA alignment).
+  constexpr int SLOT_BYTES = cuda::round_up((TILE_SIZE + ELEMS_PER_SECTOR) * static_cast<int>(sizeof(T)), 128);
+  return PIPELINE_STAGES * SLOT_BYTES;
 }
 
-__global__ void setup_kernel(void* d_temp_storage, size_t const temp_bytes, size_t const num_sms)
-{
-  auto* flags       = reinterpret_cast<device_flag_t*>(d_temp_storage);
-  auto const tid    = blockIdx.x * blockDim.x + threadIdx.x;
-  auto const stride = blockDim.x * gridDim.x;
-  for (int i = tid; i < num_sms; i += stride)
-  {
-    // Initialize as blocked
-    flags[i].store(0, cuda::memory_order_relaxed);
-  }
-}
-
-template <typename T>
-CUB_ROTATE_LB(BLOCK_SIZE, BLOCKS_PER_SM)
-__global__ void rotate_short_kernel(
-  T* arr,
-  size_t const size,
-  void* d_temp_storage,
-  size_t const temp_size,
-  size_t const rotate_distance,
-  size_t const num_tiles,
-  uint32_t const head_size)
-{
-  assert(blockDim.x == BLOCK_SIZE);
-  constexpr int TILE_SIZE         = TILE_BYTES / sizeof(T);
-  constexpr auto ELEMS_PER_SECTOR = BYTES_PER_SECTOR / sizeof(T);
-
-  assert(rotate_distance <= TILE_SIZE);
-  assert(head_size < ELEMS_PER_SECTOR);
-
-  constexpr int P = get_pipeline_depth(TILE_BYTES, SHMEM_PER_SM);
-
-  alignas(BYTES_PER_SECTOR) extern __shared__ unsigned char smem_raw[];
-  T(*cache)[TILE_SIZE + ELEMS_PER_SECTOR] = reinterpret_cast<T(*)[TILE_SIZE + ELEMS_PER_SECTOR]>(smem_raw);
-
-  // Space in shared memory for the first chunk's head tile used for alignment of the others
-  __shared__ T head_tile[ELEMS_PER_SECTOR];
-
-#pragma nv_diag_suppress static_var_with_dynamic_init
-  __shared__ cuda::barrier<cuda::thread_scope_block> bars[P];
-
-  __shared__ cuda::atomic<uint32_t, cuda::thread_scope_block> num_loaded;
-  __shared__ cuda::atomic<uint32_t, cuda::thread_scope_block> num_consumed;
-
-  auto* flags = reinterpret_cast<device_flag_t*>(d_temp_storage);
-
-  auto const tid         = threadIdx.x;
-  bool const is_producer = tid < WS;
-
-  if (tid < P)
-  {
-    init(&bars[tid], NUM_CONSUMER_THREADS);
-  }
-  if (tid == 0)
-  {
-    num_loaded   = 0;
-    num_consumed = 0;
-  }
-  __syncthreads();
-
-  assert(2 * rotate_distance <= size);
-  assert(size > TILE_SIZE);
-
-  const auto nominal_tiles_per_chunk = num_tiles / gridDim.x;
-  const uint32_t tiles_to_process =
-    blockIdx.x == gridDim.x - 1 ? nominal_tiles_per_chunk + num_tiles % gridDim.x : nominal_tiles_per_chunk;
-  assert(tiles_to_process > 0 || nominal_tiles_per_chunk == 0);
-
-  // Blocks with no tiles to process must still set their flag
-  // to prevent deadlocks in subsequent blocks waiting on them
-  if (tiles_to_process == 0)
-  {
-    if (tid == 0)
-    {
-      flags[blockIdx.x].store(1, cuda::memory_order_release);
-      flags[blockIdx.x].notify_all();
-    }
-    return;
-  }
-
-  const auto chunk_start_ix = rotate_distance + head_size + blockIdx.x * nominal_tiles_per_chunk * TILE_SIZE;
-  uint32_t const overcopy_extra_head_elems = static_cast<uint32_t>(rotate_distance % ELEMS_PER_SECTOR);
-  bool const is_first_chunk                = chunk_start_ix == rotate_distance + head_size;
-
-  auto get_tile_load_index = [&](uint32_t tile_num) -> size_t {
-    // We load from the back forwards
-    return chunk_start_ix + (tiles_to_process - 1 - tile_num) * TILE_SIZE;
-  };
-
-  auto get_bytes_to_load = [&](uint32_t tile_num) -> uint32_t {
-    bool const is_last_chunks_first_tile = blockIdx.x == gridDim.x - 1 && tile_num == 0;
-    if (!is_last_chunks_first_tile)
-    {
-      return TILE_SIZE * sizeof(T);
-    }
-    uint32_t const remainder = (size - rotate_distance - head_size) % TILE_SIZE;
-    return (remainder == 0u ? TILE_SIZE : remainder) * sizeof(T);
-  };
-
-  // ========================= PRODUCER (warp 0) =========================
-  if (is_producer)
-  {
-    auto warp = cooperative_groups::tiled_partition<WS>(cooperative_groups::this_thread_block());
-
-    auto producer_load = [&](uint32_t tile_num) {
-      int const slot       = tile_num % P;
-      T* src               = arr + get_tile_load_index(tile_num);
-      uint32_t const bytes = get_bytes_to_load(tile_num);
-      while (tile_num >= num_consumed.load(cuda::memory_order_acquire) + P)
-      {
-        __nanosleep(0);
-      }
-      // cuda::memcpy_async(warp, ...) is a warp-collective op: every lane of the producer warp must
-      // call it together (the library elects a single thread internally to issue the TMA bulk-copy
-      // instruction). Wrapping it in cooperative_groups::invoke_one ran it on one lane only, leaving
-      // the collective's internal warp sync waiting on the 31 lanes that skipped it -> warp deadlock.
-      overcopy_memcpy_async<T, WS>(cache[slot], src, bytes / sizeof(T), overcopy_extra_head_elems, warp, bars[slot]);
-      if (tid == 0)
-      {
-        num_loaded++;
-      }
-    };
-
-    // Load head tile
-    if (is_first_chunk)
-    {
-      for (uint32_t i = tid; i < head_size; i += WS)
-      {
-        head_tile[i] = arr[rotate_distance + i];
-      }
-    }
-
-    // Main loop
-    for (int i = 0; i < static_cast<int>(tiles_to_process); i++)
-    {
-      producer_load(i);
-    }
-  }
-  // ======================== CONSUMERS (warps 1+) ========================
-  else
-  {
-    uint32_t const consumer_tid = tid - WS;
-
-    // wait on the first tile and set global flag
-    if (consumer_tid == 0)
-    {
-      while (num_loaded.load(cuda::memory_order_acquire) == 0)
-      {
-        __nanosleep(0);
-      }
-    }
-    bars[0].arrive_and_wait();
-    if (consumer_tid == 0)
-    {
-      flags[blockIdx.x].store(1, cuda::memory_order_release);
-      flags[blockIdx.x].notify_all();
-    }
-
-    for (int i = 0; i < static_cast<int>(tiles_to_process); i++)
-    {
-      int const slot = i % P;
-
-      // Handle inter-block dependencies on the last tile
-      if (i == static_cast<int>(tiles_to_process) - 1)
-      {
-        if (is_first_chunk)
-        {
-          assert(blockIdx.x == 0 || blockIdx.x == gridDim.x - 1);
-          if (consumer_tid == 0)
-          {
-            flags[gridDim.x - 1].wait(0, cuda::memory_order_acquire);
-            flags[gridDim.x - 2].wait(0, cuda::memory_order_acquire);
-          }
-          bar_sync(1, NUM_CONSUMER_THREADS);
-          for (uint32_t j = consumer_tid; j < rotate_distance; j += NUM_CONSUMER_THREADS)
-          {
-            arr[size - rotate_distance + j] = arr[j];
-          }
-          bar_sync(1, NUM_CONSUMER_THREADS);
-        }
-        else
-        {
-          if (consumer_tid == 0)
-          {
-            flags[blockIdx.x - 1].wait(0, cuda::memory_order_acquire);
-          }
-          bar_sync(1, NUM_CONSUMER_THREADS);
-        }
-      }
-
-      // Store tile from shmem to gmem
-      auto const load_index = get_tile_load_index(i);
-      T* src                = cache[slot] + overcopy_extra_head_elems;
-      T* dst                = arr + load_index - rotate_distance;
-      assert(load_index > rotate_distance || head_size == 0);
-
-      // wait on next tile to finish loading (all consumers participate)
-      if (i < static_cast<int>(tiles_to_process) - 1)
-      {
-        if (consumer_tid == 0)
-        {
-          while (num_loaded.load(cuda::memory_order_acquire) <= static_cast<uint32_t>(i + 1))
-          {
-            __nanosleep(0);
-          }
-        }
-        bars[(slot + 1) % P].arrive_and_wait();
-      }
-      named_barrier_sync nbs{1, NUM_CONSUMER_THREADS, consumer_tid};
-      constexpr int MAX_REGS = REGS_PER_SM / (BLOCKS_PER_SM * BLOCK_SIZE);
-      shared_to_global_through_regs<T, NUM_CONSUMER_THREADS, TILE_BYTES, MAX_REGS>(dst, src, get_bytes_to_load(i), nbs);
-      bar_sync(1, NUM_CONSUMER_THREADS);
-      if (consumer_tid == 0)
-      {
-        num_consumed++;
-      }
-    }
-  }
-
-  __syncthreads();
-
-  if (is_first_chunk && tid < WS)
-  {
-    for (uint32_t i = tid; i < head_size; i += WS)
-    {
-      arr[i] = head_tile[i];
-    }
-  }
-}
-} // namespace rotate_short
-
-// ============================================================================
-// Short-distance rotate kernel (no pipelining)
-// ============================================================================
-
-namespace rotate_short_no_pipeline
-{
 __global__ void setup_kernel(void* d_temp_storage, size_t const temp_bytes, size_t const num_tiles)
 {
   auto* counter     = reinterpret_cast<int*>(d_temp_storage);
@@ -767,7 +554,7 @@ __global__ void rotate_tiny_kernel(T* arr, size_t const size, size_t const rotat
 
 template <typename T>
 CUB_ROTATE_LB(BLOCK_SIZE, BLOCKS_PER_SM)
-__global__ void rotate_short_kernel_no_pipeline(
+__global__ void rotate_short_kernel(
   T* arr,
   size_t const size,
   void* d_temp_storage,
@@ -779,78 +566,137 @@ __global__ void rotate_short_kernel_no_pipeline(
   assert(blockDim.x == BLOCK_SIZE);
   constexpr int TILE_SIZE         = TILE_BYTES / sizeof(T);
   constexpr auto ELEMS_PER_SECTOR = BYTES_PER_SECTOR / sizeof(T);
+  constexpr int P                 = PIPELINE_STAGES;
 
   assert(rotate_distance <= TILE_SIZE);
   assert(head_size < ELEMS_PER_SECTOR);
   assert(2 * rotate_distance <= size);
   assert(size > TILE_SIZE);
 
-  alignas(BYTES_PER_SECTOR) __shared__ T cache[TILE_SIZE + ELEMS_PER_SECTOR];
-  __shared__ int tile_ix;
+  constexpr int SLOT_BYTES = cuda::round_up((TILE_SIZE + ELEMS_PER_SECTOR) * static_cast<int>(sizeof(T)), BYTES_PER_SECTOR);
+  constexpr int SLOT_ELEMS = SLOT_BYTES / static_cast<int>(sizeof(T));
+  alignas(BYTES_PER_SECTOR) extern __shared__ unsigned char smem_raw[];
+  T(*cache)[SLOT_ELEMS] = reinterpret_cast<T(*)[SLOT_ELEMS]>(smem_raw);
+
+  constexpr int B = TILES_PER_GRAB;
+
+  __shared__ int tile_ix_buf[P];
+  __shared__ bool is_top_buf[P]; // tile is the highest of its contiguous grab-run
+  __shared__ bool is_bot_buf[P]; // tile is the lowest of its contiguous grab-run
+  __shared__ int batch_next; // next (descending) tile to issue within the current run
+  __shared__ int batch_lo; // lowest tile index in the current run
   __shared__ T head_tile_cache[ELEMS_PER_SECTOR];
 #pragma nv_diag_suppress static_var_with_dynamic_init
-  __shared__ cuda::barrier<cuda::thread_scope_block> bar;
+  __shared__ cuda::barrier<cuda::thread_scope_block> bars[P];
 
   auto* tile_counter = reinterpret_cast<cuda::atomic<int, cuda::thread_scope_device>*>(d_temp_storage);
   auto* flags        = reinterpret_cast<device_flag_t*>(reinterpret_cast<int*>(d_temp_storage) + 1);
 
-  auto const tid = threadIdx.x;
   auto cta       = cooperative_groups::this_thread_block();
+  auto const tid = cta.thread_rank();
 
+  if (tid < P)
+  {
+    init(&bars[tid], BLOCK_SIZE);
+  }
   if (tid == 0)
   {
-    init(&bar, BLOCK_SIZE);
+    batch_next = -1; // no run claimed yet -> force a fetch on the first grab
+    batch_lo   = 0;
   }
+  __syncthreads();
 
   uint32_t const overcopy_extra_head_elems = static_cast<uint32_t>(rotate_distance % ELEMS_PER_SECTOR);
+  constexpr int MAX_REGS_OCCUPANCY         = REGS_PER_SM / (BLOCKS_PER_SM * BLOCK_SIZE);
+  constexpr int MAX_REGS = MAX_REGS_PER_THREAD_OVERRIDE > 0 ? MAX_REGS_PER_THREAD_OVERRIDE : MAX_REGS_OCCUPANCY;
 
-  bool first_iteration = true;
-  while (true)
-  {
+  auto bytes_to_load_for = [&](int curr_tile) -> uint32_t {
+    bool const is_first_tile = static_cast<size_t>(curr_tile) == num_tiles - 1;
+    if (!is_first_tile)
+    {
+      return TILE_SIZE * sizeof(T);
+    }
+    uint32_t const remainder = (size - rotate_distance - head_size) % TILE_SIZE;
+    return (remainder == 0u ? TILE_SIZE : remainder) * sizeof(T);
+  };
+
+  // Claim the next tile (descending) from this CTA's current contiguous run, refilling the run
+  // from the global counter via a single fetch_sub(B) when it is exhausted, issue the tile's
+  // async load into slot `slot`, and record the tile index plus whether it is the top/bottom
+  // of its run.  Returns the grabbed tile index (negative => no more work).
+  auto grab_and_load = [&](int slot) -> int {
     if (tid == 0)
     {
-      tile_ix = tile_counter->fetch_sub(1, cuda::memory_order_relaxed);
+      bool new_run = false;
+      if (batch_next < batch_lo)
+      {
+        // Claim a new contiguous run, top tile first (descending), exactly as the original
+        // descending counter did -- but the global counter counts UP from 0 (fetch_add) so the
+        // temp buffer can be zero-initialized with a plain cudaMemsetAsync (no separate
+        // setup_kernel launch, a large fixed-cost fraction for the small 256MiB arrays). The
+        // ascending claim value is mapped to a descending run top, reproducing the proven
+        // high->low tile claim order and run partition; only the counter *storage* changed.
+        int const claim = tile_counter->fetch_add(B, cuda::memory_order_relaxed);
+        int const hi    = static_cast<int>(num_tiles) - 1 - claim; // descending run top
+        batch_next      = hi; // negative once past the end
+        batch_lo        = (hi - (B - 1) < 0) ? 0 : hi - (B - 1);
+        new_run         = true;
+      }
+      int const t       = batch_next; // negative once the counter is past the end
+      tile_ix_buf[slot] = t;
+      // The first tile issued of a run is its top; the tile equal to batch_lo is its bottom.
+      is_top_buf[slot] = new_run && (t >= 0);
+      is_bot_buf[slot] = (t == batch_lo);
+      --batch_next;
     }
     __syncthreads();
-    int const curr_tile = tile_ix;
+    int const curr_tile = tile_ix_buf[slot];
     if (curr_tile < 0)
     {
-      if (!first_iteration)
-      {
-        bar.arrive_and_wait();
-      }
-      return;
+      return curr_tile;
     }
-
-    bool const is_first_tile = static_cast<size_t>(curr_tile) == num_tiles - 1;
-    uint32_t bytes_to_load   = TILE_SIZE * sizeof(T);
-    if (is_first_tile)
-    {
-      uint32_t const remainder = (size - rotate_distance - head_size) % TILE_SIZE;
-      bytes_to_load            = (remainder == 0u ? TILE_SIZE : remainder) * sizeof(T);
-    }
-
     size_t const load_index = rotate_distance + head_size + static_cast<size_t>(curr_tile) * TILE_SIZE;
-    T* src                  = arr + load_index;
+    overcopy_memcpy_async<T, BLOCK_SIZE>(
+      cache[slot],
+      arr + load_index,
+      bytes_to_load_for(curr_tile) / sizeof(T),
+      overcopy_extra_head_elems,
+      cta,
+      bars[slot]);
+    return curr_tile;
+  };
 
-    if (!first_iteration)
-    {
-      bar.arrive_and_wait();
-    }
-    else
-    {
-      first_iteration = false;
-    }
-    overcopy_memcpy_async<T, BLOCK_SIZE>(cache, src, bytes_to_load / sizeof(T), overcopy_extra_head_elems, cta, bar);
-    bar.arrive_and_wait();
-
-    bool const is_last_tile = curr_tile == 0;
-    if (tid == 0)
+  // Wait until slot's load has landed in shmem, then publish this tile's load-complete flag.
+  // Splitting flag publication from the store is what keeps the per-CTA pipeline deadlock-free:
+  // tiles are grabbed in descending order, but a tile's store waits on its *predecessor's* flag,
+  // so every in-flight tile must publish its flag (when its data is in shmem) before any
+  // dependent store can proceed.
+  auto await_and_publish = [&](int slot) {
+    int const curr_tile = tile_ix_buf[slot];
+    bars[slot].arrive_and_wait();
+    // Only the top tile of a run is ever waited on by another CTA (whose run-bottom predecessor
+    // is exactly this tile), so only run tops publish a device-scope flag.
+    if (tid == 0 && is_top_buf[slot])
     {
       flags[curr_tile].store(1, cuda::memory_order_release);
       flags[curr_tile].notify_all();
-      auto const ix = is_last_tile ? num_tiles - 1 : curr_tile - 1;
-      flags[ix].wait(0, cuda::memory_order_acquire);
+    }
+  };
+
+  // Store the tile held in slot back to gmem, shifted left by rotate_distance.  Waits on the
+  // predecessor tile's load-complete flag first (the in-place RAW ordering).
+  auto store_tile = [&](int slot) {
+    int const curr_tile          = tile_ix_buf[slot];
+    bool const is_last_tile      = curr_tile == 0;
+    bool const is_bot            = is_bot_buf[slot];
+    uint32_t const bytes_to_load = bytes_to_load_for(curr_tile);
+    size_t const load_index      = rotate_distance + head_size + static_cast<size_t>(curr_tile) * TILE_SIZE;
+
+    // Only a run-bottom tile's predecessor lives in another CTA; interior tiles rely on the
+    // in-CTA pipeline (predecessor loaded before this tile is stored), so they skip the flag.
+    if (tid == 0 && is_bot && !is_last_tile)
+    {
+      flags[curr_tile - 1].wait(0, cuda::memory_order_acquire);
     }
 
     if (is_last_tile)
@@ -874,10 +720,9 @@ __global__ void rotate_short_kernel_no_pipeline(
       __syncthreads();
     }
 
-    T* dst                 = arr + load_index - rotate_distance;
-    constexpr int MAX_REGS = REGS_PER_SM / (BLOCKS_PER_SM * BLOCK_SIZE);
-    shared_to_global_through_regs<T, BLOCK_SIZE, TILE_BYTES, MAX_REGS>(
-      dst, cache + overcopy_extra_head_elems, bytes_to_load, cta);
+    T* dst       = arr + load_index - rotate_distance;
+    T* store_src = cache[slot] + overcopy_extra_head_elems;
+    shared_to_global_through_regs<T, BLOCK_SIZE, TILE_BYTES, MAX_REGS>(dst, store_src, bytes_to_load, cta);
 
     // Tile 0 owns the head: write it after storing the main tile
     if (is_last_tile && head_size > 0u)
@@ -888,9 +733,64 @@ __global__ void rotate_short_kernel_no_pipeline(
         arr[i] = head_tile_cache[i];
       }
     }
+  };
+
+  // Software pipeline keeping up to P cp.async tile loads in flight, tracked by three monotone
+  // grab-order cursors (grab-order index g maps to ring slot g % P):
+  //   issued    : loads issued (cp.async in flight)
+  //   published : loads awaited + flags[tile] published (load-complete signalled to other CTAs)
+  //   stored    : tiles written back
+  // with the ring invariant   stored <= published <= issued <= stored + P.
+  int issued     = 0;
+  int published  = 0;
+  int stored     = 0;
+  bool exhausted = false;
+
+  auto try_issue = [&]() {
+    if (!exhausted && (issued - stored) < P)
+    {
+      if (grab_and_load(issued % P) < 0)
+      {
+        exhausted = true;
+      }
+      else
+      {
+        ++issued;
+      }
+    }
+  };
+
+  // Prime the pipeline: issue up to P loads.
+  while (!exhausted && (issued - stored) < P)
+  {
+    try_issue();
   }
+  if (issued == 0)
+  {
+    return; // no tiles for this CTA
+  }
+
+  while (stored < issued)
+  {
+    // Eagerly await + publish every issued-but-unpublished load.  The awaited load for the
+    // oldest slot was issued up to P iterations ago, so this rarely stalls; publishing it now
+    // (before the dependent store) keeps every CTA's flags visible and the chain unblocked.
+    while (published < issued)
+    {
+      await_and_publish(published % P);
+      ++published;
+    }
+
+    // Store the oldest tile; the next load (issued below) overlaps this store.
+    store_tile(stored % P);
+    ++stored;
+
+    // Refill the freed slot, keeping a load in flight to overlap the next store.
+    try_issue();
+  }
+
 }
-} // namespace rotate_short_no_pipeline
+} // namespace rotate_short
 
 // ============================================================================
 // Long-distance rotate kernel

--- a/cub/cub/device/dispatch/kernels/kernel_rotate.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_rotate.cuh
@@ -21,16 +21,8 @@
 #include <cuda/cmath>
 #include <cuda/std/utility>
 
-#include <algorithm>
-#include <array>
 #include <cassert>
 #include <cstdint>
-#include <cstdlib>
-#include <exception>
-#include <span>
-#include <stdexcept>
-#include <unordered_map>
-#include <vector>
 
 #include <cooperative_groups.h>
 
@@ -39,29 +31,15 @@ namespace detail
 {
 namespace rotate
 {
+enum class RotDir
+{
+  Left,
+  Right
+};
+
 // ============================================================================
 // Device-side utility functions
 // ============================================================================
-
-__device__ __forceinline__ void bar_sync(int barrier_id, int num_threads)
-{
-  asm volatile("bar.sync %0, %1;" ::"r"(barrier_id), "r"(num_threads));
-}
-
-struct named_barrier_sync
-{
-  int barrier_id_;
-  int num_threads_;
-  uint32_t tid_;
-  __device__ uint32_t thread_rank() const
-  {
-    return tid_;
-  }
-  __device__ void sync()
-  {
-    bar_sync(barrier_id_, num_threads_);
-  }
-};
 
 template <typename T, int BLOCK_SIZE, class CG>
 __device__ inline void overcopy_memcpy_async(
@@ -291,6 +269,20 @@ struct DependencyRange
 
 namespace tile_detail
 {
+template <RotDir Dir>
+__host__ __device__ size_t
+physical_interval_start(size_t const array_size, size_t const logical_start, size_t const interval_size)
+{
+  if constexpr (Dir == RotDir::Left)
+  {
+    return logical_start;
+  }
+  else
+  {
+    return array_size - logical_start - interval_size;
+  }
+}
+
 template <typename T>
 __host__ __device__ uint32_t get_neg_head_size(size_t const arr_size, size_t const rot_dist, uint32_t const head_size)
 {
@@ -446,7 +438,7 @@ __host__ __device__ int32_t arr_ix_to_tile_ix(uint32_t const arr_ix, uint32_t co
 } // namespace tile_detail
 
 // ============================================================================
-// Short-distance rotate kernel (no pipelining)
+// Short-distance rotate kernels
 // ============================================================================
 
 namespace rotate_short
@@ -463,30 +455,14 @@ constexpr int get_shmem_usage()
   return PIPELINE_STAGES * SLOT_BYTES;
 }
 
-__global__ void setup_kernel(void* d_temp_storage, size_t const temp_bytes, size_t const num_tiles)
-{
-  auto* counter     = reinterpret_cast<int*>(d_temp_storage);
-  auto const tid    = blockIdx.x * blockDim.x + threadIdx.x;
-  auto const stride = blockDim.x * gridDim.x;
-  if (tid == 0)
-  {
-    counter[0] = num_tiles - 1;
-  }
-  auto* flags = reinterpret_cast<device_flag_t*>(counter + 1);
-  for (int i = tid; i < num_tiles; i += stride)
-  {
-    flags[i].store(0, cuda::memory_order_relaxed);
-  }
-}
-
-template <typename T>
+template <RotDir Dir, typename T>
 __global__ void rotate_tiny_kernel(T* arr, size_t const size, size_t const rotate_distance)
 {
   extern __shared__ unsigned char smem_raw[];
   T* smem = reinterpret_cast<T*>(smem_raw);
 
-  assert(2 * rotate_distance > size || size <= TILE_BYTES / sizeof(T));
-  assert(rotate_distance > 0 && rotate_distance < size);
+  assert(size <= TILE_BYTES / sizeof(T));
+  assert(rotate_distance > 0 && rotate_distance <= size / 2);
 
   if (blockIdx.x == 0)
   {
@@ -496,25 +472,24 @@ __global__ void rotate_tiny_kernel(T* arr, size_t const size, size_t const rotat
     }
     __syncthreads();
 
-    size_t const tail = size - rotate_distance;
-    for (size_t i = threadIdx.x; i < tail; i += blockDim.x)
-    {
-      arr[i] = smem[i + rotate_distance];
-    }
+    size_t const main_size = size - rotate_distance;
     for (size_t i = threadIdx.x; i < rotate_distance; i += blockDim.x)
     {
-      arr[tail + i] = smem[i];
+      arr[(Dir == RotDir::Left ? main_size : 0) + i] = smem[(Dir == RotDir::Left ? 0 : main_size) + i];
+    }
+    for (size_t i = threadIdx.x; i < main_size; i += blockDim.x)
+    {
+      arr[(Dir == RotDir::Left ? 0 : rotate_distance) + i] = smem[(Dir == RotDir::Left ? rotate_distance : 0) + i];
     }
   }
 }
 
-template <typename T>
+template <RotDir Dir, typename T>
 CUB_ROTATE_LB(BLOCK_SIZE, BLOCKS_PER_SM)
 __global__ void rotate_short_kernel(
   T* arr,
   size_t const size,
   void* d_temp_storage,
-  size_t const temp_size,
   size_t const rotate_distance,
   size_t const num_tiles,
   uint32_t const head_size)
@@ -563,8 +538,7 @@ __global__ void rotate_short_kernel(
   }
   __syncthreads();
 
-  uint32_t const overcopy_extra_head_elems = static_cast<uint32_t>(rotate_distance % ELEMS_PER_SECTOR);
-  constexpr int MAX_REGS_OCCUPANCY         = REGS_PER_SM / (BLOCKS_PER_SM * BLOCK_SIZE);
+  constexpr int MAX_REGS_OCCUPANCY = REGS_PER_SM / (BLOCKS_PER_SM * BLOCK_SIZE);
   constexpr int MAX_REGS = MAX_REGS_PER_THREAD_OVERRIDE > 0 ? MAX_REGS_PER_THREAD_OVERRIDE : MAX_REGS_OCCUPANCY;
 
   auto bytes_to_load_for = [&](int curr_tile) -> uint32_t {
@@ -612,14 +586,16 @@ __global__ void rotate_short_kernel(
     {
       return curr_tile;
     }
-    size_t const load_index = rotate_distance + head_size + static_cast<size_t>(curr_tile) * TILE_SIZE;
+    uint32_t const elements_to_load = bytes_to_load_for(curr_tile) / sizeof(T);
+    size_t const logical_load_index = rotate_distance + head_size + static_cast<size_t>(curr_tile) * TILE_SIZE;
+    size_t const load_index = tile_detail::physical_interval_start<Dir>(size, logical_load_index, elements_to_load);
+    uint32_t overcopy_extra_head_elems = static_cast<uint32_t>(rotate_distance % ELEMS_PER_SECTOR);
+    if constexpr (Dir == RotDir::Right)
+    {
+      overcopy_extra_head_elems = (reinterpret_cast<uintptr_t>(arr + load_index) % BYTES_PER_SECTOR) / sizeof(T);
+    }
     overcopy_memcpy_async<T, BLOCK_SIZE>(
-      cache[slot],
-      arr + load_index,
-      bytes_to_load_for(curr_tile) / sizeof(T),
-      overcopy_extra_head_elems,
-      cta,
-      bars[slot]);
+      cache[slot], arr + load_index, elements_to_load, overcopy_extra_head_elems, cta, bars[slot]);
     return curr_tile;
   };
 
@@ -640,14 +616,17 @@ __global__ void rotate_short_kernel(
     }
   };
 
-  // Store the tile held in slot back to gmem, shifted left by rotate_distance.  Waits on the
-  // predecessor tile's load-complete flag first (the in-place RAW ordering).
+  // Store the tile held in slot at its logical rotation destination. Wait on the predecessor
+  // tile's load-complete flag first (the in-place RAW ordering).
   auto store_tile = [&](int slot) {
-    int const curr_tile          = tile_ix_buf[slot];
-    bool const is_last_tile      = curr_tile == 0;
-    bool const is_bot            = is_bot_buf[slot];
-    uint32_t const bytes_to_load = bytes_to_load_for(curr_tile);
-    size_t const load_index      = rotate_distance + head_size + static_cast<size_t>(curr_tile) * TILE_SIZE;
+    int const curr_tile             = tile_ix_buf[slot];
+    bool const is_last_tile         = curr_tile == 0;
+    bool const is_bot               = is_bot_buf[slot];
+    uint32_t const bytes_to_load    = bytes_to_load_for(curr_tile);
+    uint32_t const elements_to_load = bytes_to_load / sizeof(T);
+    size_t const logical_load_index = rotate_distance + head_size + static_cast<size_t>(curr_tile) * TILE_SIZE;
+    size_t const logical_dst_index  = logical_load_index - rotate_distance;
+    size_t const dst_index = tile_detail::physical_interval_start<Dir>(size, logical_dst_index, elements_to_load);
 
     // Only a run-bottom tile's predecessor lives in another CTA; interior tiles rely on the
     // in-CTA pipeline (predecessor loaded before this tile is stored), so they skip the flag.
@@ -658,36 +637,46 @@ __global__ void rotate_short_kernel(
 
     if (is_last_tile)
     {
-      // Save head data before it gets overwritten by our tile store
+      // Save the logical positive head before it gets overwritten by our tile store.
       if (head_size > 0u)
       {
+        size_t const head_src = tile_detail::physical_interval_start<Dir>(size, rotate_distance, head_size);
         for (uint32_t i = tid; i < head_size; i += BLOCK_SIZE)
         {
-          head_tile_cache[i] = arr[rotate_distance + i];
+          head_tile_cache[i] = arr[head_src + i];
         }
       }
 
-      // Copy first rotate_distance elements to end of array
+      // Copy the logical negative region to its wrapped destination.
       flags[num_tiles - 1].wait(0, cuda::memory_order_acquire);
       __syncthreads();
+      size_t const wrap_src = tile_detail::physical_interval_start<Dir>(size, 0, rotate_distance);
+      size_t const wrap_dst = tile_detail::physical_interval_start<Dir>(size, size - rotate_distance, rotate_distance);
       for (size_t i = tid; i < rotate_distance; i += BLOCK_SIZE)
       {
-        arr[size - rotate_distance + i] = arr[i];
+        arr[wrap_dst + i] = arr[wrap_src + i];
       }
       __syncthreads();
     }
 
-    T* dst       = arr + load_index - rotate_distance;
+    size_t const load_index = tile_detail::physical_interval_start<Dir>(size, logical_load_index, elements_to_load);
+    uint32_t overcopy_extra_head_elems = static_cast<uint32_t>(rotate_distance % ELEMS_PER_SECTOR);
+    if constexpr (Dir == RotDir::Right)
+    {
+      overcopy_extra_head_elems = (reinterpret_cast<uintptr_t>(arr + load_index) % BYTES_PER_SECTOR) / sizeof(T);
+    }
+    T* dst       = arr + dst_index;
     T* store_src = cache[slot] + overcopy_extra_head_elems;
     shared_to_global_through_regs<T, BLOCK_SIZE, TILE_BYTES, MAX_REGS>(dst, store_src, bytes_to_load, cta);
 
-    // Tile 0 owns the head: write it after storing the main tile
+    // Logical tile 0 owns the positive head: write it after storing the main tile.
     if (is_last_tile && head_size > 0u)
     {
       __syncthreads();
+      size_t const head_dst = tile_detail::physical_interval_start<Dir>(size, 0, head_size);
       for (uint32_t i = tid; i < head_size; i += BLOCK_SIZE)
       {
-        arr[i] = head_tile_cache[i];
+        arr[head_dst + i] = head_tile_cache[i];
       }
     }
   };
@@ -754,7 +743,7 @@ __global__ void rotate_short_kernel(
 
 namespace rotate_long
 {
-__global__ void setup_kernel(void* d_temp_storage, size_t const temp_bytes, size_t const num_tiles)
+__global__ void setup_kernel(void* d_temp_storage, size_t const num_tiles)
 {
   auto* counter     = reinterpret_cast<uint32_t*>(d_temp_storage);
   auto const tid    = blockIdx.x * blockDim.x + threadIdx.x;
@@ -771,13 +760,12 @@ __global__ void setup_kernel(void* d_temp_storage, size_t const temp_bytes, size
   }
 }
 
-template <typename T>
+template <RotDir Dir, typename T>
 CUB_ROTATE_LB(BLOCK_SIZE, BLOCKS_PER_SM)
 __global__ void rotate_long_kernel(
   T* arr,
   size_t const size,
   void* d_temp_storage,
-  size_t const temp_size,
   size_t const rotate_distance,
   size_t const num_tiles,
   uint32_t const head_size)
@@ -824,17 +812,19 @@ __global__ void rotate_long_kernel(
     }
     auto const curr_tile_index = processing_order[curr_tile_ordering_ix];
     auto const curr_tile       = tile_detail::arr_ix_to_tile_ix(curr_tile_index, num_negative_tiles);
-    auto const curr_tile_start =
+    auto const logical_tile_start =
       tile_detail::get_tile_start(rotate_distance, TILE_SIZE, curr_tile, head_size, neg_head_size);
     auto const curr_tile_size = tile_detail::get_tile_size(
-      size, rotate_distance, TILE_SIZE, curr_tile, curr_tile_start, head_size, neg_head_size);
+      size, rotate_distance, TILE_SIZE, curr_tile, logical_tile_start, head_size, neg_head_size);
     assert(curr_tile_size <= TILE_SIZE);
 
-    bool const owns_pos_head      = (curr_tile == 0) && (head_size > 0u);
-    bool const owns_neg_head      = (curr_tile == -1) && (neg_head_size > 0u);
-    uint32_t const head_load_size = owns_pos_head ? head_size : (owns_neg_head ? neg_head_size : 0u);
-    size_t const head_src_off     = owns_pos_head ? rotate_distance : 0;
-    size_t const head_dst_off     = owns_pos_head ? 0 : (size - rotate_distance);
+    bool const owns_pos_head          = (curr_tile == 0) && (head_size > 0u);
+    bool const owns_neg_head          = (curr_tile == -1) && (neg_head_size > 0u);
+    uint32_t const head_load_size     = owns_pos_head ? head_size : (owns_neg_head ? neg_head_size : 0u);
+    size_t const logical_head_src_off = owns_pos_head ? rotate_distance : 0;
+    size_t const logical_head_dst_off = owns_pos_head ? 0 : (size - rotate_distance);
+    size_t const head_src_off = tile_detail::physical_interval_start<Dir>(size, logical_head_src_off, head_load_size);
+    size_t const head_dst_off = tile_detail::physical_interval_start<Dir>(size, logical_head_dst_off, head_load_size);
 
     if (head_load_size > 0u && tid < WS)
     {
@@ -845,7 +835,8 @@ __global__ void rotate_long_kernel(
     }
 
     // Regular tile load via the standard memcpy_async pipeline.
-    T* src                         = arr + curr_tile_start;
+    size_t const curr_tile_start = tile_detail::physical_interval_start<Dir>(size, logical_tile_start, curr_tile_size);
+    T* src                       = arr + curr_tile_start;
     uint32_t const unaligned_elems = (reinterpret_cast<uintptr_t>(src) % BYTES_PER_SECTOR) / sizeof(T);
 
     overcopy_memcpy_async<T, BLOCK_SIZE>(cache, src, curr_tile_size, unaligned_elems, cta, bar);
@@ -865,8 +856,10 @@ __global__ void rotate_long_kernel(
     }
 
     // Copy cached tile to destination
-    T* dst = arr
-           + tile_detail::get_overwrite_start(size, rotate_distance, TILE_SIZE, curr_tile, head_size, neg_head_size);
+    size_t const logical_dst_start =
+      tile_detail::get_overwrite_start(size, rotate_distance, TILE_SIZE, curr_tile, head_size, neg_head_size);
+    size_t const dst_start = tile_detail::physical_interval_start<Dir>(size, logical_dst_start, curr_tile_size);
+    T* dst                 = arr + dst_start;
     src                    = cache + unaligned_elems;
     constexpr int MAX_REGS = REGS_PER_SM / (BLOCKS_PER_SM * BLOCK_SIZE);
     shared_to_global_through_regs<T, BLOCK_SIZE, TILE_BYTES, MAX_REGS>(dst, src, curr_tile_size * sizeof(T), cta);

--- a/cub/cub/device/dispatch/kernels/kernel_rotate.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_rotate.cuh
@@ -595,16 +595,11 @@ __global__ void rotate_short_kernel(
       {
         __nanosleep(0);
       }
-      if constexpr (hasTMA())
-      {
-        cooperative_groups::invoke_one(warp, [&] {
-          overcopy_memcpy_async<T, WS>(cache[slot], src, bytes / sizeof(T), overcopy_extra_head_elems, warp, bars[slot]);
-        });
-      }
-      else
-      {
-        overcopy_memcpy_async<T, WS>(cache[slot], src, bytes / sizeof(T), overcopy_extra_head_elems, warp, bars[slot]);
-      }
+      // cuda::memcpy_async(warp, ...) is a warp-collective op: every lane of the producer warp must
+      // call it together (the library elects a single thread internally to issue the TMA bulk-copy
+      // instruction). Wrapping it in cooperative_groups::invoke_one ran it on one lane only, leaving
+      // the collective's internal warp sync waiting on the 31 lanes that skipped it -> warp deadlock.
+      overcopy_memcpy_async<T, WS>(cache[slot], src, bytes / sizeof(T), overcopy_extra_head_elems, warp, bars[slot]);
       if (tid == 0)
       {
         num_loaded++;

--- a/cub/cub/device/dispatch/kernels/kernel_rotate.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_rotate.cuh
@@ -91,16 +91,15 @@ __device__ inline void overcopy_memcpy_async(
 
 // Copies a tile from shared memory to global memory through registers.
 // Buffers up to MAX_REGS_PER_THREAD uint32_t registers worth of data from shmem
-// BEFORE calling sync_op.sync(), to maximally overlap the atomic polling with other work, then writes to gmem AFTER.  Any remaining
-// iterations that do not fit in the register budget are processed post-sync.
-// sync_op must provide sync() and thread_rank().
+// BEFORE calling sync_op.sync(), to maximally overlap the atomic polling with other work, then writes to gmem AFTER.
+// Any remaining iterations that do not fit in the register budget are processed post-sync. sync_op must provide sync()
+// and thread_rank().
 //
 // MAX_REGS_PER_THREAD should be set to REGS_PER_SM / (BLOCKS_PER_SM * BLOCK_SIZE)
 // so that the register buffering does not reduce occupancy.
 template <typename T, int NUM_THREADS, int TILE_BYTES, int MAX_REGS_PER_THREAD, typename SyncOp>
 __device__ inline void shared_to_global_through_regs(T* dst, T* src, uint32_t const bytes_to_load, SyncOp& sync_op)
 {
-  static_assert(TILE_BYTES % (NUM_THREADS * static_cast<int>(sizeof(uint32_t))) == 0);
   constexpr int REGS_PER_T     = TILE_BYTES / (NUM_THREADS * static_cast<int>(sizeof(uint32_t)));
   constexpr int ITERS          = REGS_PER_T / 4; // each uint4 = 4 regs
   constexpr int CHUNK_REGS     = cuda::std::min(MAX_REGS_PER_THREAD, REGS_PER_T);
@@ -153,9 +152,9 @@ __device__ inline void shared_to_global_through_regs(T* dst, T* src, uint32_t co
       uint4* new_dst    = reinterpret_cast<uint4*>(dst);
 
       // s = words `src` is above the 16B boundary; in {1,2,3} in this branch.
-      uint32_t const s         = (static_cast<uint32_t>(reinterpret_cast<uintptr_t>(src)) % sizeof(uint4)) / sizeof(uint32_t);
+      uint32_t const s = (static_cast<uint32_t>(reinterpret_cast<uintptr_t>(src)) % sizeof(uint4)) / sizeof(uint32_t);
       uint4 const* aligned_src = reinterpret_cast<uint4 const*>(new_src - s);
-      bool const is_top_lane      = (tid % WS) == (WS - 1);
+      bool const is_top_lane   = (tid % WS) == (WS - 1);
 
       auto load_funnel = [&](int k) -> uint4 {
         int const j   = tid + k * NUM_THREADS;
@@ -280,15 +279,14 @@ __device__ inline void shared_to_global_through_regs(T* dst, T* src, uint32_t co
   }
 }
 
-
 // ============================================================================
 // Tile coordinate helpers (host + device)
 // ============================================================================
 
-struct Dependencies
+struct DependencyRange
 {
-  int32_t deps_[3];
-  uint8_t num_dependencies_;
+  uint32_t begin_;
+  uint32_t end_;
 };
 
 namespace tile_detail
@@ -380,26 +378,21 @@ get_num_negative_tiles(size_t const rot_dist, uint32_t const nominal_tile_size, 
   return cuda::ceil_div(rot_dist - neg_head_size, nominal_tile_size);
 }
 
-__host__ __device__ uint32_t get_num_positive_tiles(
+uint32_t get_num_positive_tiles(
   size_t const arr_size, size_t const rot_dist, uint32_t const nominal_tile_size, uint32_t const head_size)
 {
   return cuda::ceil_div(arr_size - rot_dist - head_size, nominal_tile_size);
 }
 
-template <typename T>
-__host__ __device__ Dependencies get_dependencies(
+_CCCL_HOST_DEVICE _CCCL_FORCEINLINE DependencyRange get_dependencies(
   size_t const arr_size,
   size_t const rot_dist,
   uint32_t const nominal_tile_size,
   int32_t const tile_ix,
-  uint32_t const /*num_tiles*/,
-  uint32_t const head_size)
+  uint32_t const head_size,
+  uint32_t const neg_head_size,
+  uint32_t const num_negative_tiles)
 {
-  Dependencies item_deps{{0, 0, 0}, 0};
-
-  uint32_t const neg_head_size = get_neg_head_size<T>(arr_size, rot_dist, head_size);
-  uint32_t const num_neg       = get_num_negative_tiles(rot_dist, nominal_tile_size, neg_head_size);
-
   size_t overwrite_start =
     get_overwrite_start(arr_size, rot_dist, nominal_tile_size, tile_ix, head_size, neg_head_size);
   uint32_t const tile_size = get_tile_size(
@@ -422,70 +415,33 @@ __host__ __device__ Dependencies get_dependencies(
     overwrite_start = arr_size - rot_dist;
   }
 
-  auto snap = [&](size_t pos) -> int32_t {
+  auto snap_to_order = [&](size_t pos) -> uint32_t {
     if (pos < neg_head_size)
     {
-      return -1; // pos head src -> tile -1
+      return 0;
     }
     if (pos < rot_dist)
     {
-      return -static_cast<int32_t>((pos - neg_head_size) / nominal_tile_size + 1);
+      return static_cast<uint32_t>((pos - neg_head_size) / nominal_tile_size);
     }
     if (pos < rot_dist + head_size)
     {
-      return 0; // pos head src -> tile 0
+      return num_negative_tiles;
     }
-    return static_cast<int32_t>((pos - rot_dist - head_size) / nominal_tile_size);
+    return num_negative_tiles + static_cast<uint32_t>((pos - rot_dist - head_size) / nominal_tile_size);
   };
 
-  int32_t cur        = snap(overwrite_start);
-  int32_t const last = snap(overwrite_end);
-
-  auto advance = [&]() {
-    if (cur < 0)
-    {
-      cur--;
-      if (static_cast<uint32_t>(cuda::std::abs(cur)) > num_neg)
-      {
-        cur = 0; // jump from -num_neg past pos head to BFS pos 0
-      }
-    }
-    else
-    {
-      cur++;
-    }
-  };
-  auto should_continue = [&]() {
-    return ((cuda::std::abs(cur) <= cuda::std::abs(last)) || ((cur < 0) && (last >= 0))) && !(last < 0 && cur >= 0);
-  };
-
-  item_deps.deps_[0]          = cur;
-  item_deps.num_dependencies_ = 1;
-  advance();
-  if (should_continue())
-  {
-    item_deps.deps_[1]          = cur;
-    item_deps.num_dependencies_ = 2;
-    advance();
-    if (should_continue())
-    {
-      item_deps.deps_[2]          = cur;
-      item_deps.num_dependencies_ = 3;
-    }
-  }
-  return item_deps;
+  uint32_t const first_order = snap_to_order(overwrite_start);
+  uint32_t const last_order  = snap_to_order(overwrite_end);
+  assert(first_order <= last_order && last_order - first_order < 3);
+  return {first_order, last_order + 1};
 }
 
-__host__ __device__ int32_t arr_ix_to_tile_ix(size_t const arr_ix, uint32_t const num_negative_tiles)
+__host__ __device__ int32_t arr_ix_to_tile_ix(uint32_t const arr_ix, uint32_t const num_negative_tiles)
 {
   return arr_ix < num_negative_tiles
          ? -static_cast<int32_t>(arr_ix + 1)
          : (static_cast<int32_t>(arr_ix - num_negative_tiles));
-};
-
-__host__ __device__ size_t tile_ix_to_arr_ix(int32_t const tile_ix, uint32_t const num_negative_tiles)
-{
-  return tile_ix < 0 ? cuda::std::abs(tile_ix + 1) : static_cast<size_t>(tile_ix + num_negative_tiles);
 };
 } // namespace tile_detail
 
@@ -573,7 +529,8 @@ __global__ void rotate_short_kernel(
   assert(2 * rotate_distance <= size);
   assert(size > TILE_SIZE);
 
-  constexpr int SLOT_BYTES = cuda::round_up((TILE_SIZE + ELEMS_PER_SECTOR) * static_cast<int>(sizeof(T)), BYTES_PER_SECTOR);
+  constexpr int SLOT_BYTES =
+    cuda::round_up((TILE_SIZE + ELEMS_PER_SECTOR) * static_cast<int>(sizeof(T)), BYTES_PER_SECTOR);
   constexpr int SLOT_ELEMS = SLOT_BYTES / static_cast<int>(sizeof(T));
   alignas(BYTES_PER_SECTOR) extern __shared__ unsigned char smem_raw[];
   T(*cache)[SLOT_ELEMS] = reinterpret_cast<T(*)[SLOT_ELEMS]>(smem_raw);
@@ -788,7 +745,6 @@ __global__ void rotate_short_kernel(
     // Refill the freed slot, keeping a load in flight to overlap the next store.
     try_issue();
   }
-
 }
 } // namespace rotate_short
 
@@ -832,7 +788,7 @@ __global__ void rotate_long_kernel(
   alignas(BYTES_PER_SECTOR) __shared__ T cache[TILE_SIZE + ELEMS_PER_SECTOR]; // +ELEMS_PER_SECTOR to avoid shmem bank
                                                                               // conflicts when writing back to global
                                                                               // memory
-  __shared__ int tile_ordering_ix;
+  __shared__ uint32_t tile_ordering_ix;
   // Tile -1 owns the negative head used for sector alignment of the negative tiles destinations.
   // Tile 0 owns the positive head used for sector alignment of the positive tiles destinations.
   __shared__ T head_tile_cache[ELEMS_PER_SECTOR];
@@ -840,11 +796,12 @@ __global__ void rotate_long_kernel(
   __shared__ cuda::barrier<cuda::thread_scope_block> bar;
 
   auto* tiles_processed  = reinterpret_cast<cuda::atomic<uint32_t, cuda::thread_scope_device>*>(d_temp_storage);
-  auto* processing_order = reinterpret_cast<int32_t*>(tiles_processed + 1); // first uint32_t is the counter of
-                                                                            // processed items
+  auto* processing_order = reinterpret_cast<uint32_t*>(tiles_processed + 1); // first uint32_t is the counter of
+                                                                             // processed items
   auto* flags = reinterpret_cast<device_flag_t*>(processing_order + num_tiles);
 
-  uint32_t const neg_head_size = tile_detail::get_neg_head_size<T>(size, rotate_distance, head_size);
+  uint32_t const neg_head_size      = tile_detail::get_neg_head_size<T>(size, rotate_distance, head_size);
+  uint32_t const num_negative_tiles = tile_detail::get_num_negative_tiles(rotate_distance, TILE_SIZE, neg_head_size);
 
   auto const tid = threadIdx.x;
   auto cta       = cooperative_groups::this_thread_block();
@@ -865,7 +822,8 @@ __global__ void rotate_long_kernel(
     {
       return;
     }
-    auto const curr_tile = processing_order[curr_tile_ordering_ix];
+    auto const curr_tile_index = processing_order[curr_tile_ordering_ix];
+    auto const curr_tile       = tile_detail::arr_ix_to_tile_ix(curr_tile_index, num_negative_tiles);
     auto const curr_tile_start =
       tile_detail::get_tile_start(rotate_distance, TILE_SIZE, curr_tile, head_size, neg_head_size);
     auto const curr_tile_size = tile_detail::get_tile_size(
@@ -895,19 +853,14 @@ __global__ void rotate_long_kernel(
 
     if (tid == 0)
     {
-      auto const num_negative_tiles = tile_detail::get_num_negative_tiles(rotate_distance, TILE_SIZE, neg_head_size);
-      flags[tile_detail::tile_ix_to_arr_ix(curr_tile, num_negative_tiles)].store(1, cuda::memory_order_release);
-      flags[tile_detail::tile_ix_to_arr_ix(curr_tile, num_negative_tiles)].notify_all();
+      flags[curr_tile_index].store(1, cuda::memory_order_release);
+      flags[curr_tile_index].notify_all();
       // Poll dependencies
-      auto const deps =
-        tile_detail::get_dependencies<T>(size, rotate_distance, TILE_SIZE, curr_tile, num_tiles, head_size);
-      // static loop to keep deps in registers
-      for (int i = 0; i < 3; ++i)
+      auto const dependencies = tile_detail::get_dependencies(
+        size, rotate_distance, TILE_SIZE, curr_tile, head_size, neg_head_size, num_negative_tiles);
+      for (uint32_t dependency = dependencies.begin_; dependency < dependencies.end_; ++dependency)
       {
-        if (i < deps.num_dependencies_)
-        {
-          flags[tile_detail::tile_ix_to_arr_ix(deps.deps_[i], num_negative_tiles)].wait(0, cuda::memory_order_acquire);
-        }
+        flags[dependency].wait(0, cuda::memory_order_acquire);
       }
     }
 

--- a/cub/cub/device/dispatch/kernels/kernel_rotate.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_rotate.cuh
@@ -19,6 +19,7 @@
 #include <cuda/atomic>
 #include <cuda/barrier>
 #include <cuda/cmath>
+#include <cuda/std/type_traits>
 #include <cuda/std/utility>
 
 #include <cassert>
@@ -37,12 +38,32 @@ enum class RotDir
   Right
 };
 
+// Which visit-order the long kernel uses to claim tiles.  Circulant is host-staged in
+// processing_order[]; the two small-side orders are trivial closed forms of the claim ticket that
+// the kernel evaluates inline, so they need no host->device ordering copy.
+enum class OrderMode : uint32_t
+{
+  Circulant = 0, // host-staged processing_order[]
+  Negative  = 1, // small-side negative closed form: pos == 0 ? 0 : num_tiles - pos
+  Positive  = 2, // small-side positive closed form: pos
+};
+
+_CCCL_HOST_DEVICE _CCCL_FORCEINLINE device_flag_t* get_long_flags(void* temp_storage)
+{
+  return reinterpret_cast<device_flag_t*>(reinterpret_cast<uint32_t*>(temp_storage) + 1);
+}
+
+_CCCL_HOST_DEVICE _CCCL_FORCEINLINE uint32_t* get_long_processing_order(void* temp_storage, size_t num_tiles)
+{
+  return reinterpret_cast<uint32_t*>(get_long_flags(temp_storage) + num_tiles);
+}
+
 // ============================================================================
 // Device-side utility functions
 // ============================================================================
 
-template <typename T, int BLOCK_SIZE, class CG>
-__device__ inline void overcopy_memcpy_async(
+template <typename T, class CG>
+_CCCL_DEVICE void overcopy_memcpy_async(
   T* shmem_dst,
   T* src,
   const int size,
@@ -70,23 +91,22 @@ __device__ inline void overcopy_memcpy_async(
 // Copies a tile from shared memory to global memory through registers.
 // Buffers up to MAX_REGS_PER_THREAD uint32_t registers worth of data from shmem
 // BEFORE calling sync_op.sync(), to maximally overlap the atomic polling with other work, then writes to gmem AFTER.
-// Any remaining iterations that do not fit in the register budget are processed post-sync. sync_op must provide sync()
-// and thread_rank().
+// Any remaining iterations that do not fit in the register budget are processed post-sync. sync_op must provide sync().
 //
 // MAX_REGS_PER_THREAD should be set to REGS_PER_SM / (BLOCKS_PER_SM * BLOCK_SIZE)
 // so that the register buffering does not reduce occupancy.
 template <typename T, int NUM_THREADS, int TILE_BYTES, int MAX_REGS_PER_THREAD, typename SyncOp>
-__device__ inline void shared_to_global_through_regs(T* dst, T* src, uint32_t const bytes_to_load, SyncOp& sync_op)
+_CCCL_DEVICE void shared_to_global_through_regs(T* dst, T* src, uint32_t const bytes_to_load, SyncOp& sync_op)
 {
-  constexpr int REGS_PER_T     = TILE_BYTES / (NUM_THREADS * static_cast<int>(sizeof(uint32_t)));
+  constexpr int REGS_PER_T     = TILE_BYTES / (NUM_THREADS * sizeof(uint32_t));
   constexpr int ITERS          = REGS_PER_T / 4; // each uint4 = 4 regs
   constexpr int CHUNK_REGS     = cuda::std::min(MAX_REGS_PER_THREAD, REGS_PER_T);
   constexpr int BUFFERED_ITERS = CHUNK_REGS / 4;
   static_assert(BUFFERED_ITERS >= 1 && BUFFERED_ITERS <= ITERS);
 
-  constexpr int VEC_TILE_BYTES = ITERS * 4 * NUM_THREADS * static_cast<int>(sizeof(uint32_t));
+  constexpr int VEC_TILE_BYTES = ITERS * 4 * NUM_THREADS * sizeof(uint32_t);
 
-  auto const tid = sync_op.thread_rank();
+  auto const tid = threadIdx.x;
 
   if (bytes_to_load < TILE_BYTES)
   {
@@ -130,33 +150,21 @@ __device__ inline void shared_to_global_through_regs(T* dst, T* src, uint32_t co
       uint4* new_dst    = reinterpret_cast<uint4*>(dst);
 
       // s = words `src` is above the 16B boundary; in {1,2,3} in this branch.
-      uint32_t const s = (static_cast<uint32_t>(reinterpret_cast<uintptr_t>(src)) % sizeof(uint4)) / sizeof(uint32_t);
+      uint32_t const s         = (reinterpret_cast<uintptr_t>(src) % sizeof(uint4)) / sizeof(uint32_t);
       uint4 const* aligned_src = reinterpret_cast<uint4 const*>(new_src - s);
-      bool const is_top_lane   = (tid % WS) == (WS - 1);
 
       auto load_funnel = [&](int k) -> uint4 {
         int const j   = tid + k * NUM_THREADS;
         uint4 const A = aligned_src[j];
-        // Boundary words = the first `s` words of B = aligned_src[j+1] = the neighbor lane's A.
-        // Shuffle them from lane+1; the top lane has no in-warp neighbor, so load B directly.
-        uint32_t bx = __shfl_down_sync(0xffffffffu, A.x, 1);
-        uint32_t by = (s >= 2u) ? __shfl_down_sync(0xffffffffu, A.y, 1) : 0u;
-        uint32_t bz = (s >= 3u) ? __shfl_down_sync(0xffffffffu, A.z, 1) : 0u;
-        if (is_top_lane)
-        {
-          uint4 const B = aligned_src[j + 1];
-          bx            = B.x;
-          by            = B.y;
-          bz            = B.z;
-        }
+        uint4 const B = aligned_src[j + 1];
         switch (s)
         {
           case 1:
-            return make_uint4(A.y, A.z, A.w, bx);
+            return make_uint4(A.y, A.z, A.w, B.x);
           case 2:
-            return make_uint4(A.z, A.w, bx, by);
+            return make_uint4(A.z, A.w, B.x, B.y);
           default: // s == 3
-            return make_uint4(A.w, bx, by, bz);
+            return make_uint4(A.w, B.x, B.y, B.z);
         }
       };
 
@@ -180,42 +188,33 @@ __device__ inline void shared_to_global_through_regs(T* dst, T* src, uint32_t co
     }
     else
     {
-      int const bytes_to_word_end = sizeof(uint32_t) - (reinterpret_cast<uintptr_t>(src) % sizeof(uint32_t));
-      uint32_t* new_src =
-        reinterpret_cast<uint32_t*>(reinterpret_cast<uintptr_t>(src) - (sizeof(uint32_t) - bytes_to_word_end));
-      assert(reinterpret_cast<uintptr_t>(new_src) % sizeof(uint32_t) == 0);
-
-      const int shift_len = 8 * (sizeof(uint32_t) - bytes_to_word_end);
+      uintptr_t const src_addr = reinterpret_cast<uintptr_t>(src);
+      uint4 const* aligned16   = reinterpret_cast<uint4 const*>(src_addr & ~uintptr_t{15});
+      uint32_t const boff      = src_addr & uintptr_t{15}; // in [1,15], boff % 4 != 0
+      uint32_t const bw        = boff >> 2; // whole 32-bit words src is above the 16B boundary: 0..3
+      uint32_t const shift_len = (boff & 3u) * 8u; // sub-word bit shift: 8, 16 or 24
 
       uint4* new_dst = reinterpret_cast<uint4*>(dst);
 
-      uint32_t const group = (tid >> 3) & 3;
-
       auto load_funnel_shifted = [&](int k) {
-        int const i         = tid + k * NUM_THREADS;
-        uint32_t const base = i * 4;
-        uint32_t w[5];
-#pragma unroll
-        for (int r = 0; r < 5; ++r)
-        {
-          int col = r + group;
-          w[r]    = new_src[base + (col >= 5 ? col - 5 : col)];
-        }
-#define FS(a, b) __funnelshift_rc(w[a], w[b], shift_len)
+        int const i    = tid + k * NUM_THREADS;
+        uint4 const Lo = aligned16[i];
+        uint4 const Hi = aligned16[i + 1];
+#define FS(a, b) __funnelshift_rc(a, b, shift_len)
         uint4 val;
-        switch (group)
+        switch (bw)
         {
           case 0:
-            val = make_uint4(FS(0, 1), FS(1, 2), FS(2, 3), FS(3, 4));
+            val = make_uint4(FS(Lo.x, Lo.y), FS(Lo.y, Lo.z), FS(Lo.z, Lo.w), FS(Lo.w, Hi.x));
             break;
           case 1:
-            val = make_uint4(FS(4, 0), FS(0, 1), FS(1, 2), FS(2, 3));
+            val = make_uint4(FS(Lo.y, Lo.z), FS(Lo.z, Lo.w), FS(Lo.w, Hi.x), FS(Hi.x, Hi.y));
             break;
           case 2:
-            val = make_uint4(FS(3, 4), FS(4, 0), FS(0, 1), FS(1, 2));
+            val = make_uint4(FS(Lo.z, Lo.w), FS(Lo.w, Hi.x), FS(Hi.x, Hi.y), FS(Hi.y, Hi.z));
             break;
-          default:
-            val = make_uint4(FS(2, 3), FS(3, 4), FS(4, 0), FS(0, 1));
+          default: // bw == 3
+            val = make_uint4(FS(Lo.w, Hi.x), FS(Hi.x, Hi.y), FS(Hi.y, Hi.z), FS(Hi.z, Hi.w));
             break;
         }
 #undef FS
@@ -248,7 +247,7 @@ __device__ inline void shared_to_global_through_regs(T* dst, T* src, uint32_t co
       // rotation lives entirely in dst's gmem offset, so a plain element copy is byte-identical for
       // all three realignment branches above.
       uint32_t const elems_to_load  = bytes_to_load / sizeof(T);
-      constexpr uint32_t tail_begin = VEC_TILE_BYTES / static_cast<int>(sizeof(T));
+      constexpr uint32_t tail_begin = VEC_TILE_BYTES / sizeof(T);
       for (uint32_t i = tail_begin + tid; i < elems_to_load; i += NUM_THREADS)
       {
         dst[i] = src[i];
@@ -270,7 +269,7 @@ struct DependencyRange
 namespace tile_detail
 {
 template <RotDir Dir>
-__host__ __device__ size_t
+_CCCL_DEVICE size_t
 physical_interval_start(size_t const array_size, size_t const logical_start, size_t const interval_size)
 {
   if constexpr (Dir == RotDir::Left)
@@ -284,18 +283,18 @@ physical_interval_start(size_t const array_size, size_t const logical_start, siz
 }
 
 template <typename T>
-__host__ __device__ uint32_t get_neg_head_size(size_t const arr_size, size_t const rot_dist, uint32_t const head_size)
+_CCCL_HOST_DEVICE uint32_t get_neg_head_size(size_t const arr_size, size_t const rot_dist, uint32_t const head_size)
 {
   constexpr auto ELEMS_PER_SECTOR = BYTES_PER_SECTOR / sizeof(T);
   // Sector offset of the negative region's start (= arr + arr_size - rot_dist).
   uint32_t const arr_offset = head_size == 0u ? 0u : (ELEMS_PER_SECTOR - head_size);
-  uint32_t const dst_offset = static_cast<uint32_t>((arr_offset + (arr_size - rot_dist)) % ELEMS_PER_SECTOR);
+  uint32_t const dst_offset = (arr_offset + (arr_size - rot_dist)) % ELEMS_PER_SECTOR;
   // 0 when the region's start is already sector-aligned; otherwise the slack to the
   // next sector boundary, in [1, ELEMS_PER_SECTOR - 1].
   return dst_offset == 0u ? 0u : (ELEMS_PER_SECTOR - dst_offset);
 }
 
-__host__ __device__ size_t get_overwrite_start(
+_CCCL_HOST_DEVICE size_t get_overwrite_start(
   size_t const arr_size,
   size_t const rot_dist,
   uint32_t const nominal_tile_size,
@@ -313,7 +312,7 @@ __host__ __device__ size_t get_overwrite_start(
   }
 }
 
-__host__ __device__ uint32_t get_tile_size(
+_CCCL_HOST_DEVICE uint32_t get_tile_size(
   size_t const arr_size,
   size_t const rot_dist,
   uint32_t const nominal_tile_size,
@@ -327,7 +326,7 @@ __host__ __device__ uint32_t get_tile_size(
     if (start + nominal_tile_size >= arr_size)
     {
       size_t const main_size   = arr_size - rot_dist - head_size;
-      uint32_t const remainder = static_cast<uint32_t>(main_size % nominal_tile_size);
+      uint32_t const remainder = main_size % nominal_tile_size;
       return remainder == 0u ? nominal_tile_size : remainder;
     }
     else
@@ -338,7 +337,7 @@ __host__ __device__ uint32_t get_tile_size(
   else if (start + nominal_tile_size >= rot_dist)
   {
     size_t const main_size   = rot_dist - neg_head_size;
-    uint32_t const remainder = static_cast<uint32_t>(main_size % nominal_tile_size);
+    uint32_t const remainder = main_size % nominal_tile_size;
     return remainder == 0u ? nominal_tile_size : remainder;
   }
   else
@@ -347,7 +346,7 @@ __host__ __device__ uint32_t get_tile_size(
   }
 }
 
-__host__ __device__ size_t get_tile_start(
+_CCCL_HOST_DEVICE size_t get_tile_start(
   size_t const rot_dist,
   uint32_t const nominal_tile_size,
   int32_t const tile_ix,
@@ -364,7 +363,7 @@ __host__ __device__ size_t get_tile_start(
   }
 }
 
-__host__ __device__ uint32_t
+_CCCL_HOST_DEVICE uint32_t
 get_num_negative_tiles(size_t const rot_dist, uint32_t const nominal_tile_size, uint32_t const neg_head_size)
 {
   return cuda::ceil_div(rot_dist - neg_head_size, nominal_tile_size);
@@ -376,25 +375,17 @@ uint32_t get_num_positive_tiles(
   return cuda::ceil_div(arr_size - rot_dist - head_size, nominal_tile_size);
 }
 
-_CCCL_HOST_DEVICE _CCCL_FORCEINLINE DependencyRange get_dependencies(
+_CCCL_HOST_DEVICE _CCCL_FORCEINLINE DependencyRange get_dependencies_from(
   size_t const arr_size,
   size_t const rot_dist,
   uint32_t const nominal_tile_size,
   int32_t const tile_ix,
   uint32_t const head_size,
   uint32_t const neg_head_size,
-  uint32_t const num_negative_tiles)
+  uint32_t const num_negative_tiles,
+  size_t overwrite_start,
+  uint32_t const tile_size)
 {
-  size_t overwrite_start =
-    get_overwrite_start(arr_size, rot_dist, nominal_tile_size, tile_ix, head_size, neg_head_size);
-  uint32_t const tile_size = get_tile_size(
-    arr_size,
-    rot_dist,
-    nominal_tile_size,
-    tile_ix,
-    get_tile_start(rot_dist, nominal_tile_size, tile_ix, head_size, neg_head_size),
-    head_size,
-    neg_head_size);
   size_t const overwrite_end = overwrite_start + tile_size - 1;
   // Extend the overwrite start to cover the head destination owned by this tile so that
   // any tile whose source overlaps the head dst is picked up as a dependency.
@@ -429,7 +420,38 @@ _CCCL_HOST_DEVICE _CCCL_FORCEINLINE DependencyRange get_dependencies(
   return {first_order, last_order + 1};
 }
 
-__host__ __device__ int32_t arr_ix_to_tile_ix(uint32_t const arr_ix, uint32_t const num_negative_tiles)
+DependencyRange get_dependencies(
+  size_t const arr_size,
+  size_t const rot_dist,
+  uint32_t const nominal_tile_size,
+  int32_t const tile_ix,
+  uint32_t const head_size,
+  uint32_t const neg_head_size,
+  uint32_t const num_negative_tiles)
+{
+  size_t const overwrite_start =
+    get_overwrite_start(arr_size, rot_dist, nominal_tile_size, tile_ix, head_size, neg_head_size);
+  uint32_t const tile_size = get_tile_size(
+    arr_size,
+    rot_dist,
+    nominal_tile_size,
+    tile_ix,
+    get_tile_start(rot_dist, nominal_tile_size, tile_ix, head_size, neg_head_size),
+    head_size,
+    neg_head_size);
+  return get_dependencies_from(
+    arr_size,
+    rot_dist,
+    nominal_tile_size,
+    tile_ix,
+    head_size,
+    neg_head_size,
+    num_negative_tiles,
+    overwrite_start,
+    tile_size);
+}
+
+_CCCL_HOST_DEVICE int32_t arr_ix_to_tile_ix(uint32_t const arr_ix, uint32_t const num_negative_tiles)
 {
   return arr_ix < num_negative_tiles
          ? -static_cast<int32_t>(arr_ix + 1)
@@ -437,31 +459,141 @@ __host__ __device__ int32_t arr_ix_to_tile_ix(uint32_t const arr_ix, uint32_t co
 };
 } // namespace tile_detail
 
-// ============================================================================
-// Short-distance rotate kernels
-// ============================================================================
-
-namespace rotate_short
-{
-// Dynamic shared-memory bytes for the multi-stage short kernel: PIPELINE_STAGES tile
-// buffers, each TILE_BYTES + BYTES_PER_SECTOR (overcopy / bank-conflict slack).
-template <typename T>
+template <typename Algorithm, typename T>
 constexpr int get_shmem_usage()
 {
-  constexpr auto ELEMS_PER_SECTOR = BYTES_PER_SECTOR / static_cast<int>(sizeof(T));
-  constexpr int TILE_SIZE         = TILE_BYTES / static_cast<int>(sizeof(T));
-  // Must match SLOT_BYTES inside the kernel (each slot rounded up to 128B for TMA alignment).
-  constexpr int SLOT_BYTES = cuda::round_up((TILE_SIZE + ELEMS_PER_SECTOR) * static_cast<int>(sizeof(T)), 128);
-  return PIPELINE_STAGES * SLOT_BYTES;
+  constexpr int tile_size        = Algorithm::tile_bytes / sizeof(T);
+  constexpr int elems_per_sector = BYTES_PER_SECTOR / sizeof(T);
+  constexpr int slot_bytes       = cuda::round_up((tile_size + elems_per_sector) * sizeof(T), BYTES_PER_SECTOR);
+  return Algorithm::pipeline_stages * slot_bytes;
 }
 
+template <typename Algorithm, typename T>
+struct pipeline_shared_storage;
+
+template <typename T>
+struct pipeline_shared_storage<short_algorithm, T>
+{
+  static constexpr int pipeline_stages  = short_algorithm::pipeline_stages;
+  static constexpr int elems_per_sector = BYTES_PER_SECTOR / sizeof(T);
+
+  struct tile
+  {
+    int index;
+    bool is_run_first;
+    bool is_run_last;
+
+    _CCCL_DEVICE bool should_publish() const
+    {
+      return is_run_first;
+    }
+  };
+
+  tile tiles[pipeline_stages];
+  int next_tile;
+  int run_last;
+  T head_cache[elems_per_sector];
+  cuda::barrier<cuda::thread_scope_block> bars[pipeline_stages];
+};
+
+template <typename T>
+struct pipeline_shared_storage<long_algorithm, T>
+{
+  static constexpr int pipeline_stages  = long_algorithm::pipeline_stages;
+  static constexpr int elems_per_sector = BYTES_PER_SECTOR / sizeof(T);
+
+  struct tile
+  {
+    uint32_t work_index;
+    uint32_t index;
+    uint32_t size;
+    uint32_t unaligned_elems;
+    size_t src_offset;
+    size_t dst_offset;
+    DependencyRange dependencies;
+    uint32_t head_size;
+    size_t head_src_offset;
+    size_t head_dst_offset;
+
+    _CCCL_DEVICE bool should_publish() const
+    {
+      return true;
+    }
+  };
+
+  tile tiles[pipeline_stages];
+  // The positive and negative head tiles can be in flight in different stages at the same time.
+  T head_cache[pipeline_stages][elems_per_sector];
+  cuda::barrier<cuda::thread_scope_block> bars[pipeline_stages];
+};
+
+
+// TODO: this may cause unnecessary register usage
+template <typename Algorithm, RotDir Dir, typename T>
+struct pipeline_context
+{
+  using policy         = Algorithm;
+  using shared_storage = pipeline_shared_storage<Algorithm, T>;
+
+  static constexpr int block_size       = policy::block_size;
+  static constexpr int tile_bytes       = policy::tile_bytes;
+  static constexpr int tiles_per_grab   = policy::tiles_per_grab;
+  static constexpr int pipeline_stages  = policy::pipeline_stages;
+  static constexpr int tile_size        = tile_bytes / sizeof(T);
+  static constexpr int elems_per_sector = BYTES_PER_SECTOR / sizeof(T);
+  static constexpr int slot_bytes       = cuda::round_up((tile_size + elems_per_sector) * sizeof(T), BYTES_PER_SECTOR);
+  static constexpr int slot_elems       = slot_bytes / sizeof(T);
+  static constexpr int max_regs_occupancy = REGS_PER_SM / (policy::blocks_per_sm * block_size);
+  static constexpr int max_regs =
+    policy::max_regs_per_thread_override > 0 ? policy::max_regs_per_thread_override : max_regs_occupancy;
+
+  T* array;
+  size_t size;
+  void* temp_storage;
+  size_t rotate_distance;
+  size_t num_tiles;
+  uint32_t head_size;
+  OrderMode order_mode;
+  T* cache;
+  shared_storage& shared;
+
+  _CCCL_DEVICE T* tile_cache(int slot) const
+  {
+    return cache + slot * slot_elems;
+  }
+};
+
+template <RotDir Dir, typename T>
+_CCCL_DEVICE device_flag_t* get_flags(pipeline_context<short_algorithm, Dir, T> const& context)
+{
+  return reinterpret_cast<device_flag_t*>(reinterpret_cast<int*>(context.temp_storage) + 1);
+}
+
+template <RotDir Dir, typename T>
+_CCCL_DEVICE device_flag_t* get_flags(pipeline_context<long_algorithm, Dir, T> const& context)
+{
+  return get_long_flags(context.temp_storage);
+}
+
+template <RotDir Dir, typename T>
+_CCCL_DEVICE uint32_t* get_processing_order(pipeline_context<long_algorithm, Dir, T> const& context)
+{
+  return get_long_processing_order(context.temp_storage, context.num_tiles);
+}
+
+// ============================================================================
+// Short-distance rotate operations
+// ============================================================================
+
+namespace rotate_tiny
+{
 template <RotDir Dir, typename T>
 __global__ void rotate_tiny_kernel(T* arr, size_t const size, size_t const rotate_distance)
 {
   extern __shared__ unsigned char smem_raw[];
   T* smem = reinterpret_cast<T*>(smem_raw);
 
-  assert(size <= TILE_BYTES / sizeof(T));
+  assert(size <= short_algorithm::tile_bytes / sizeof(T));
   assert(rotate_distance > 0 && rotate_distance <= size / 2);
 
   if (blockIdx.x == 0)
@@ -483,397 +615,393 @@ __global__ void rotate_tiny_kernel(T* arr, size_t const size, size_t const rotat
     }
   }
 }
+} // namespace rotate_tiny
+
+template <typename Algorithm, RotDir Dir, typename T>
+_CCCL_DEVICE void initialize_pipeline(pipeline_context<Algorithm, Dir, T>& context)
+{
+  using context_t = pipeline_context<Algorithm, Dir, T>;
+  auto const tid  = threadIdx.x;
+
+  if (tid < context_t::pipeline_stages)
+  {
+    init(&context.shared.bars[tid], context_t::block_size);
+  }
+
+  if constexpr (cuda::std::is_same_v<Algorithm, short_algorithm>)
+  {
+    assert(context.rotate_distance <= context_t::tile_size);
+    assert(context.head_size < context_t::elems_per_sector);
+    assert(2 * context.rotate_distance <= context.size);
+    assert(context.size > context_t::tile_size);
+
+    if (tid == 0)
+    {
+      context.shared.next_tile = -1;
+      context.shared.run_last  = 0;
+    }
+  }
+  __syncthreads();
+}
 
 template <RotDir Dir, typename T>
-CUB_ROTATE_LB(BLOCK_SIZE, BLOCKS_PER_SM)
-__global__ void rotate_short_kernel(
-  T* arr,
-  size_t const size,
-  void* d_temp_storage,
-  size_t const rotate_distance,
-  size_t const num_tiles,
-  uint32_t const head_size)
+_CCCL_DEVICE uint32_t get_tile_size(pipeline_context<short_algorithm, Dir, T> const& context, uint32_t tile_index)
 {
-  assert(blockDim.x == BLOCK_SIZE);
-  constexpr int TILE_SIZE         = TILE_BYTES / sizeof(T);
-  constexpr auto ELEMS_PER_SECTOR = BYTES_PER_SECTOR / sizeof(T);
-  constexpr int P                 = PIPELINE_STAGES;
-
-  assert(rotate_distance <= TILE_SIZE);
-  assert(head_size < ELEMS_PER_SECTOR);
-  assert(2 * rotate_distance <= size);
-  assert(size > TILE_SIZE);
-
-  constexpr int SLOT_BYTES =
-    cuda::round_up((TILE_SIZE + ELEMS_PER_SECTOR) * static_cast<int>(sizeof(T)), BYTES_PER_SECTOR);
-  constexpr int SLOT_ELEMS = SLOT_BYTES / static_cast<int>(sizeof(T));
-  alignas(BYTES_PER_SECTOR) extern __shared__ unsigned char smem_raw[];
-  T(*cache)[SLOT_ELEMS] = reinterpret_cast<T(*)[SLOT_ELEMS]>(smem_raw);
-
-  constexpr int B = TILES_PER_GRAB;
-
-  __shared__ int tile_ix_buf[P];
-  __shared__ bool is_top_buf[P]; // tile is the highest of its contiguous grab-run
-  __shared__ bool is_bot_buf[P]; // tile is the lowest of its contiguous grab-run
-  __shared__ int batch_next; // next (descending) tile to issue within the current run
-  __shared__ int batch_lo; // lowest tile index in the current run
-  __shared__ T head_tile_cache[ELEMS_PER_SECTOR];
-#pragma nv_diag_suppress static_var_with_dynamic_init
-  __shared__ cuda::barrier<cuda::thread_scope_block> bars[P];
-
-  auto* tile_counter = reinterpret_cast<cuda::atomic<int, cuda::thread_scope_device>*>(d_temp_storage);
-  auto* flags        = reinterpret_cast<device_flag_t*>(reinterpret_cast<int*>(d_temp_storage) + 1);
-
-  auto cta       = cooperative_groups::this_thread_block();
-  auto const tid = cta.thread_rank();
-
-  if (tid < P)
+  using context_t = pipeline_context<short_algorithm, Dir, T>;
+  if (tile_index != context.num_tiles - 1)
   {
-    init(&bars[tid], BLOCK_SIZE);
+    return context_t::tile_size;
   }
+
+  uint32_t const remainder = (context.size - context.rotate_distance - context.head_size) % context_t::tile_size;
+  return remainder == 0u ? context_t::tile_size : remainder;
+}
+
+// Claim the next tile from this CTA's descending run and issue its asynchronous load.
+template <RotDir Dir, typename T>
+_CCCL_DEVICE bool claim_and_load(pipeline_context<short_algorithm, Dir, T>& context, int slot)
+{
+  using context_t              = pipeline_context<short_algorithm, Dir, T>;
+  constexpr int tiles_per_grab = context_t::tiles_per_grab;
+  auto* tile_counter           = reinterpret_cast<cuda::atomic<int, cuda::thread_scope_device>*>(context.temp_storage);
+  auto cta                     = cooperative_groups::this_thread_block();
+  auto const tid               = threadIdx.x;
+  auto& tile                   = context.shared.tiles[slot];
+
   if (tid == 0)
   {
-    batch_next = -1; // no run claimed yet -> force a fetch on the first grab
-    batch_lo   = 0;
+    bool is_run_first = false;
+    if (context.shared.next_tile < context.shared.run_last)
+    {
+      int const claim          = tile_counter->fetch_add(tiles_per_grab, cuda::memory_order_relaxed);
+      int const first          = static_cast<int>(context.num_tiles) - 1 - claim;
+      context.shared.next_tile = first;
+      context.shared.run_last  = (first < tiles_per_grab - 1) ? 0 : first - (tiles_per_grab - 1);
+      is_run_first             = first >= 0;
+    }
+
+    tile.index        = context.shared.next_tile;
+    tile.is_run_first = is_run_first;
+    tile.is_run_last  = tile.index == context.shared.run_last;
+    --context.shared.next_tile;
   }
   __syncthreads();
 
-  constexpr int MAX_REGS_OCCUPANCY = REGS_PER_SM / (BLOCKS_PER_SM * BLOCK_SIZE);
-  constexpr int MAX_REGS = MAX_REGS_PER_THREAD_OVERRIDE > 0 ? MAX_REGS_PER_THREAD_OVERRIDE : MAX_REGS_OCCUPANCY;
+  if (tile.index < 0)
+  {
+    return false;
+  }
 
-  auto bytes_to_load_for = [&](int curr_tile) -> uint32_t {
-    bool const is_first_tile = static_cast<size_t>(curr_tile) == num_tiles - 1;
-    if (!is_first_tile)
-    {
-      return TILE_SIZE * sizeof(T);
-    }
-    uint32_t const remainder = (size - rotate_distance - head_size) % TILE_SIZE;
-    return (remainder == 0u ? TILE_SIZE : remainder) * sizeof(T);
-  };
+  uint32_t const tile_size = get_tile_size(context, tile.index);
+  size_t const logical_src =
+    context.rotate_distance + context.head_size + static_cast<size_t>(tile.index) * context_t::tile_size;
+  size_t const src_offset  = tile_detail::physical_interval_start<Dir>(context.size, logical_src, tile_size);
+  uint32_t unaligned_elems = context.rotate_distance % context_t::elems_per_sector;
+  if constexpr (Dir == RotDir::Right)
+  {
+    unaligned_elems = (reinterpret_cast<uintptr_t>(context.array + src_offset) % BYTES_PER_SECTOR) / sizeof(T);
+  }
 
-  // Claim the next tile (descending) from this CTA's current contiguous run, refilling the run
-  // from the global counter via a single fetch_sub(B) when it is exhausted, issue the tile's
-  // async load into slot `slot`, and record the tile index plus whether it is the top/bottom
-  // of its run.  Returns the grabbed tile index (negative => no more work).
-  auto grab_and_load = [&](int slot) -> int {
-    if (tid == 0)
+  overcopy_memcpy_async<T>(
+    context.tile_cache(slot), context.array + src_offset, tile_size, unaligned_elems, cta, context.shared.bars[slot]);
+  return true;
+}
+
+template <typename Algorithm, RotDir Dir, typename T>
+_CCCL_DEVICE void publish_tile(pipeline_context<Algorithm, Dir, T>& context, int slot)
+{
+  auto* flags      = get_flags(context);
+  auto const& tile = context.shared.tiles[slot];
+  context.shared.bars[slot].arrive_and_wait();
+
+  if (threadIdx.x == 0 && tile.should_publish())
+  {
+    flags[tile.index].store(1, cuda::memory_order_release);
+    flags[tile.index].notify_all();
+  }
+}
+
+template <RotDir Dir, typename T>
+_CCCL_DEVICE void wait_for_dependencies(pipeline_context<short_algorithm, Dir, T>& context, int slot)
+{
+  auto* flags             = get_flags(context);
+  auto const& tile        = context.shared.tiles[slot];
+  bool const is_last_tile = tile.index == 0;
+
+  if (threadIdx.x == 0 && tile.is_run_last && !is_last_tile)
+  {
+    flags[tile.index - 1].wait(0, cuda::memory_order_acquire);
+  }
+
+  if (is_last_tile)
+  {
+    flags[context.num_tiles - 1].wait(0, cuda::memory_order_acquire);
+    __syncthreads();
+  }
+}
+
+template <RotDir Dir, typename T>
+_CCCL_DEVICE void store_tile(pipeline_context<short_algorithm, Dir, T>& context, int slot)
+{
+  using context_t          = pipeline_context<short_algorithm, Dir, T>;
+  auto cta                 = cooperative_groups::this_thread_block();
+  auto const tid           = threadIdx.x;
+  int const tile_index     = context.shared.tiles[slot].index;
+  bool const is_last_tile  = tile_index == 0;
+  uint32_t const tile_size = get_tile_size(context, tile_index);
+  size_t const logical_src =
+    context.rotate_distance + context.head_size + static_cast<size_t>(tile_index) * context_t::tile_size;
+  size_t const logical_dst = logical_src - context.rotate_distance;
+  size_t const dst_offset  = tile_detail::physical_interval_start<Dir>(context.size, logical_dst, tile_size);
+
+  if (is_last_tile)
+  {
+    if (context.head_size > 0u)
     {
-      bool new_run = false;
-      if (batch_next < batch_lo)
+      size_t const head_src =
+        tile_detail::physical_interval_start<Dir>(context.size, context.rotate_distance, context.head_size);
+      for (uint32_t i = tid; i < context.head_size; i += context_t::block_size)
       {
-        // Claim a new contiguous run, top tile first (descending), exactly as the original
-        // descending counter did -- but the global counter counts UP from 0 (fetch_add) so the
-        // temp buffer can be zero-initialized with a plain cudaMemsetAsync (no separate
-        // setup_kernel launch, a large fixed-cost fraction for the small 256MiB arrays). The
-        // ascending claim value is mapped to a descending run top, reproducing the proven
-        // high->low tile claim order and run partition; only the counter *storage* changed.
-        int const claim = tile_counter->fetch_add(B, cuda::memory_order_relaxed);
-        int const hi    = static_cast<int>(num_tiles) - 1 - claim; // descending run top
-        batch_next      = hi; // negative once past the end
-        batch_lo        = (hi - (B - 1) < 0) ? 0 : hi - (B - 1);
-        new_run         = true;
+        context.shared.head_cache[i] = context.array[head_src + i];
       }
-      int const t       = batch_next; // negative once the counter is past the end
-      tile_ix_buf[slot] = t;
-      // The first tile issued of a run is its top; the tile equal to batch_lo is its bottom.
-      is_top_buf[slot] = new_run && (t >= 0);
-      is_bot_buf[slot] = (t == batch_lo);
-      --batch_next;
+    }
+
+    size_t const wrap_src = tile_detail::physical_interval_start<Dir>(context.size, 0, context.rotate_distance);
+    size_t const wrap_dst = tile_detail::physical_interval_start<Dir>(
+      context.size, context.size - context.rotate_distance, context.rotate_distance);
+    for (size_t i = tid; i < context.rotate_distance; i += context_t::block_size)
+    {
+      context.array[wrap_dst + i] = context.array[wrap_src + i];
     }
     __syncthreads();
-    int const curr_tile = tile_ix_buf[slot];
-    if (curr_tile < 0)
-    {
-      return curr_tile;
-    }
-    uint32_t const elements_to_load = bytes_to_load_for(curr_tile) / sizeof(T);
-    size_t const logical_load_index = rotate_distance + head_size + static_cast<size_t>(curr_tile) * TILE_SIZE;
-    size_t const load_index = tile_detail::physical_interval_start<Dir>(size, logical_load_index, elements_to_load);
-    uint32_t overcopy_extra_head_elems = static_cast<uint32_t>(rotate_distance % ELEMS_PER_SECTOR);
-    if constexpr (Dir == RotDir::Right)
-    {
-      overcopy_extra_head_elems = (reinterpret_cast<uintptr_t>(arr + load_index) % BYTES_PER_SECTOR) / sizeof(T);
-    }
-    overcopy_memcpy_async<T, BLOCK_SIZE>(
-      cache[slot], arr + load_index, elements_to_load, overcopy_extra_head_elems, cta, bars[slot]);
-    return curr_tile;
-  };
 
-  // Wait until slot's load has landed in shmem, then publish this tile's load-complete flag.
-  // Splitting flag publication from the store is what keeps the per-CTA pipeline deadlock-free:
-  // tiles are grabbed in descending order, but a tile's store waits on its *predecessor's* flag,
-  // so every in-flight tile must publish its flag (when its data is in shmem) before any
-  // dependent store can proceed.
-  auto await_and_publish = [&](int slot) {
-    int const curr_tile = tile_ix_buf[slot];
-    bars[slot].arrive_and_wait();
-    // Only the top tile of a run is ever waited on by another CTA (whose run-bottom predecessor
-    // is exactly this tile), so only run tops publish a device-scope flag.
-    if (tid == 0 && is_top_buf[slot])
+    if (context.head_size > 0u)
     {
-      flags[curr_tile].store(1, cuda::memory_order_release);
-      flags[curr_tile].notify_all();
-    }
-  };
-
-  // Store the tile held in slot at its logical rotation destination. Wait on the predecessor
-  // tile's load-complete flag first (the in-place RAW ordering).
-  auto store_tile = [&](int slot) {
-    int const curr_tile             = tile_ix_buf[slot];
-    bool const is_last_tile         = curr_tile == 0;
-    bool const is_bot               = is_bot_buf[slot];
-    uint32_t const bytes_to_load    = bytes_to_load_for(curr_tile);
-    uint32_t const elements_to_load = bytes_to_load / sizeof(T);
-    size_t const logical_load_index = rotate_distance + head_size + static_cast<size_t>(curr_tile) * TILE_SIZE;
-    size_t const logical_dst_index  = logical_load_index - rotate_distance;
-    size_t const dst_index = tile_detail::physical_interval_start<Dir>(size, logical_dst_index, elements_to_load);
-
-    // Only a run-bottom tile's predecessor lives in another CTA; interior tiles rely on the
-    // in-CTA pipeline (predecessor loaded before this tile is stored), so they skip the flag.
-    if (tid == 0 && is_bot && !is_last_tile)
-    {
-      flags[curr_tile - 1].wait(0, cuda::memory_order_acquire);
-    }
-
-    if (is_last_tile)
-    {
-      // Save the logical positive head before it gets overwritten by our tile store.
-      if (head_size > 0u)
+      size_t const head_dst = tile_detail::physical_interval_start<Dir>(context.size, 0, context.head_size);
+      for (uint32_t i = tid; i < context.head_size; i += context_t::block_size)
       {
-        size_t const head_src = tile_detail::physical_interval_start<Dir>(size, rotate_distance, head_size);
-        for (uint32_t i = tid; i < head_size; i += BLOCK_SIZE)
-        {
-          head_tile_cache[i] = arr[head_src + i];
-        }
-      }
-
-      // Copy the logical negative region to its wrapped destination.
-      flags[num_tiles - 1].wait(0, cuda::memory_order_acquire);
-      __syncthreads();
-      size_t const wrap_src = tile_detail::physical_interval_start<Dir>(size, 0, rotate_distance);
-      size_t const wrap_dst = tile_detail::physical_interval_start<Dir>(size, size - rotate_distance, rotate_distance);
-      for (size_t i = tid; i < rotate_distance; i += BLOCK_SIZE)
-      {
-        arr[wrap_dst + i] = arr[wrap_src + i];
-      }
-      __syncthreads();
-    }
-
-    size_t const load_index = tile_detail::physical_interval_start<Dir>(size, logical_load_index, elements_to_load);
-    uint32_t overcopy_extra_head_elems = static_cast<uint32_t>(rotate_distance % ELEMS_PER_SECTOR);
-    if constexpr (Dir == RotDir::Right)
-    {
-      overcopy_extra_head_elems = (reinterpret_cast<uintptr_t>(arr + load_index) % BYTES_PER_SECTOR) / sizeof(T);
-    }
-    T* dst       = arr + dst_index;
-    T* store_src = cache[slot] + overcopy_extra_head_elems;
-    shared_to_global_through_regs<T, BLOCK_SIZE, TILE_BYTES, MAX_REGS>(dst, store_src, bytes_to_load, cta);
-
-    // Logical tile 0 owns the positive head: write it after storing the main tile.
-    if (is_last_tile && head_size > 0u)
-    {
-      __syncthreads();
-      size_t const head_dst = tile_detail::physical_interval_start<Dir>(size, 0, head_size);
-      for (uint32_t i = tid; i < head_size; i += BLOCK_SIZE)
-      {
-        arr[head_dst + i] = head_tile_cache[i];
+        context.array[head_dst + i] = context.shared.head_cache[i];
       }
     }
-  };
-
-  // Software pipeline keeping up to P cp.async tile loads in flight, tracked by three monotone
-  // grab-order cursors (grab-order index g maps to ring slot g % P):
-  //   issued    : loads issued (cp.async in flight)
-  //   published : loads awaited + flags[tile] published (load-complete signalled to other CTAs)
-  //   stored    : tiles written back
-  // with the ring invariant   stored <= published <= issued <= stored + P.
-  int issued     = 0;
-  int published  = 0;
-  int stored     = 0;
-  bool exhausted = false;
-
-  auto try_issue = [&]() {
-    if (!exhausted && (issued - stored) < P)
-    {
-      if (grab_and_load(issued % P) < 0)
-      {
-        exhausted = true;
-      }
-      else
-      {
-        ++issued;
-      }
-    }
-  };
-
-  // Prime the pipeline: issue up to P loads.
-  while (!exhausted && (issued - stored) < P)
-  {
-    try_issue();
   }
-  if (issued == 0)
+
+  size_t const src_offset  = tile_detail::physical_interval_start<Dir>(context.size, logical_src, tile_size);
+  uint32_t unaligned_elems = context.rotate_distance % context_t::elems_per_sector;
+  if constexpr (Dir == RotDir::Right)
   {
-    return; // no tiles for this CTA
+    unaligned_elems = (reinterpret_cast<uintptr_t>(context.array + src_offset) % BYTES_PER_SECTOR) / sizeof(T);
+  }
+  shared_to_global_through_regs<T, context_t::block_size, context_t::tile_bytes, context_t::max_regs>(
+    context.array + dst_offset, context.tile_cache(slot) + unaligned_elems, tile_size * sizeof(T), cta);
+}
+
+// ============================================================================
+// Long-distance rotate operations
+// ============================================================================
+
+template <RotDir Dir, typename T>
+_CCCL_DEVICE bool claim_and_load(pipeline_context<long_algorithm, Dir, T>& context, int slot)
+{
+  using context_t        = pipeline_context<long_algorithm, Dir, T>;
+  auto* counter          = reinterpret_cast<cuda::atomic<uint32_t, cuda::thread_scope_device>*>(context.temp_storage);
+  auto* processing_order = get_processing_order(context);
+  auto cta               = cooperative_groups::this_thread_block();
+  auto const tid         = threadIdx.x;
+  auto& tile             = context.shared.tiles[slot];
+  uint32_t const neg_head_size =
+    tile_detail::get_neg_head_size<T>(context.size, context.rotate_distance, context.head_size);
+  uint32_t const num_negative_tiles =
+    tile_detail::get_num_negative_tiles(context.rotate_distance, context_t::tile_size, neg_head_size);
+
+  if (tid == 0)
+  {
+    tile.work_index = counter->fetch_add(context_t::tiles_per_grab, cuda::memory_order_relaxed);
+    if (tile.work_index < context.num_tiles)
+    {
+      tile.index =
+        context.order_mode == OrderMode::Circulant
+          ? processing_order[tile.work_index]
+          : (context.order_mode == OrderMode::Negative
+               ? (tile.work_index == 0u ? 0u : static_cast<uint32_t>(context.num_tiles) - tile.work_index)
+               : tile.work_index);
+
+      int32_t const tile_index = tile_detail::arr_ix_to_tile_ix(tile.index, num_negative_tiles);
+      size_t const logical_src = tile_detail::get_tile_start(
+        context.rotate_distance, context_t::tile_size, tile_index, context.head_size, neg_head_size);
+      tile.size = tile_detail::get_tile_size(
+        context.size,
+        context.rotate_distance,
+        context_t::tile_size,
+        tile_index,
+        logical_src,
+        context.head_size,
+        neg_head_size);
+      assert(tile.size <= context_t::tile_size);
+      tile.src_offset = tile_detail::physical_interval_start<Dir>(context.size, logical_src, tile.size);
+      tile.unaligned_elems =
+        (reinterpret_cast<uintptr_t>(context.array + tile.src_offset) % BYTES_PER_SECTOR) / sizeof(T);
+
+      bool const owns_pos_head      = tile_index == 0 && context.head_size > 0u;
+      bool const owns_neg_head      = tile_index == -1 && neg_head_size > 0u;
+      tile.head_size                = owns_pos_head ? context.head_size : (owns_neg_head ? neg_head_size : 0u);
+      size_t const logical_head_src = owns_pos_head ? context.rotate_distance : 0;
+      tile.head_src_offset = tile_detail::physical_interval_start<Dir>(context.size, logical_head_src, tile.head_size);
+    }
+  }
+  __syncthreads();
+
+  if (tile.work_index >= context.num_tiles)
+  {
+    return false;
+  }
+
+  overcopy_memcpy_async<T>(
+    context.tile_cache(slot),
+    context.array + tile.src_offset,
+    tile.size,
+    tile.unaligned_elems,
+    cta,
+    context.shared.bars[slot]);
+
+  if (tile.head_size > 0u && tid < WS)
+  {
+    for (uint32_t i = tid; i < tile.head_size; i += WS)
+    {
+      context.shared.head_cache[slot][i] = context.array[tile.head_src_offset + i];
+    }
+  }
+
+  // Compute store-side state while the asynchronous tile copy is in flight.
+  if (tid == 0)
+  {
+    int32_t const tile_index = tile_detail::arr_ix_to_tile_ix(tile.index, num_negative_tiles);
+    size_t const logical_dst = tile_detail::get_overwrite_start(
+      context.size, context.rotate_distance, context_t::tile_size, tile_index, context.head_size, neg_head_size);
+    tile.dependencies = tile_detail::get_dependencies_from(
+      context.size,
+      context.rotate_distance,
+      context_t::tile_size,
+      tile_index,
+      context.head_size,
+      neg_head_size,
+      num_negative_tiles,
+      logical_dst,
+      tile.size);
+    tile.dst_offset = tile_detail::physical_interval_start<Dir>(context.size, logical_dst, tile.size);
+
+    bool const owns_pos_head      = tile_index == 0 && context.head_size > 0u;
+    size_t const logical_head_dst = owns_pos_head ? 0 : (context.size - context.rotate_distance);
+    tile.head_dst_offset = tile_detail::physical_interval_start<Dir>(context.size, logical_head_dst, tile.head_size);
+  }
+  return true;
+}
+
+template <RotDir Dir, typename T>
+_CCCL_DEVICE void wait_for_dependencies(pipeline_context<long_algorithm, Dir, T>& context, int slot)
+{
+  auto* flags = get_flags(context);
+
+  if (threadIdx.x == 0)
+  {
+    auto const dependencies = context.shared.tiles[slot].dependencies;
+    for (uint32_t dependency = dependencies.begin_; dependency < dependencies.end_; ++dependency)
+    {
+      flags[dependency].wait(0, cuda::memory_order_acquire);
+    }
+  }
+}
+
+template <RotDir Dir, typename T>
+_CCCL_DEVICE void store_tile(pipeline_context<long_algorithm, Dir, T>& context, int slot)
+{
+  using context_t  = pipeline_context<long_algorithm, Dir, T>;
+  auto cta         = cooperative_groups::this_thread_block();
+  auto const tid   = threadIdx.x;
+  auto const& tile = context.shared.tiles[slot];
+
+  shared_to_global_through_regs<T, context_t::block_size, context_t::tile_bytes, context_t::max_regs>(
+    context.array + tile.dst_offset, context.tile_cache(slot) + tile.unaligned_elems, tile.size * sizeof(T), cta);
+
+  if (tile.head_size > 0u && tid < WS)
+  {
+    for (uint32_t i = tid; i < tile.head_size; i += WS)
+    {
+      context.array[tile.head_dst_offset + i] = context.shared.head_cache[slot][i];
+    }
+  }
+}
+
+// ============================================================================
+// Pipeline execution
+// ============================================================================
+template <typename Context>
+_CCCL_DEVICE void run_tile_pipeline(Context& context)
+{
+  constexpr int pipeline_stages = Context::pipeline_stages;
+  int issued                    = 0;
+  int published                 = 0;
+  int stored                    = 0;
+  bool exhausted                = false;
+
+  // Fill the pipeline. A claim that reports exhaustion does not occupy a slot.
+  while (!exhausted && issued - stored < pipeline_stages)
+  {
+    exhausted = !claim_and_load(context, issued % pipeline_stages);
+    if (!exhausted)
+    {
+      ++issued;
+    }
   }
 
   while (stored < issued)
   {
-    // Eagerly await + publish every issued-but-unpublished load.  The awaited load for the
-    // oldest slot was issued up to P iterations ago, so this rarely stalls; publishing it now
-    // (before the dependent store) keeps every CTA's flags visible and the chain unblocked.
+    // Publish every in-flight load before waiting: a tile may depend on another tile
+    // currently owned by this CTA.
     while (published < issued)
     {
-      await_and_publish(published % P);
+      publish_tile(context, published % pipeline_stages);
       ++published;
     }
 
-    // Store the oldest tile; the next load (issued below) overlaps this store.
-    store_tile(stored % P);
+    wait_for_dependencies(context, stored % pipeline_stages);
+    store_tile(context, stored % pipeline_stages);
     ++stored;
 
-    // Refill the freed slot, keeping a load in flight to overlap the next store.
-    try_issue();
-  }
-}
-} // namespace rotate_short
-
-// ============================================================================
-// Long-distance rotate kernel
-// ============================================================================
-
-namespace rotate_long
-{
-__global__ void setup_kernel(void* d_temp_storage, size_t const num_tiles)
-{
-  auto* counter     = reinterpret_cast<uint32_t*>(d_temp_storage);
-  auto const tid    = blockIdx.x * blockDim.x + threadIdx.x;
-  auto const stride = blockDim.x * gridDim.x;
-  if (tid == 0)
-  {
-    counter[0] = 0;
-  }
-  auto* flags = reinterpret_cast<device_flag_t*>(counter + 1 + num_tiles); // skip ordering array
-  for (int i = tid; i < num_tiles; i += stride)
-  {
-    // Initialize as blocked
-    flags[i].store(0, cuda::memory_order_relaxed);
+    // The store freed one slot, so issue at most one replacement load.
+    if (!exhausted)
+    {
+      exhausted = !claim_and_load(context, issued % pipeline_stages);
+      if (!exhausted)
+      {
+        ++issued;
+      }
+    }
   }
 }
 
-template <RotDir Dir, typename T>
-CUB_ROTATE_LB(BLOCK_SIZE, BLOCKS_PER_SM)
-__global__ void rotate_long_kernel(
+template <typename Algorithm, RotDir Dir, typename T>
+CUB_ROTATE_LB(Algorithm::block_size, Algorithm::blocks_per_sm)
+__global__ void rotate_kernel(
   T* arr,
   size_t const size,
-  void* d_temp_storage,
+  void* temp_storage,
   size_t const rotate_distance,
   size_t const num_tiles,
-  uint32_t const head_size)
+  uint32_t const head_size,
+  OrderMode const order_mode)
 {
-  assert(blockDim.x == BLOCK_SIZE);
-  constexpr int TILE_SIZE         = TILE_BYTES / sizeof(T);
-  constexpr auto ELEMS_PER_SECTOR = BYTES_PER_SECTOR / sizeof(T);
-  alignas(BYTES_PER_SECTOR) __shared__ T cache[TILE_SIZE + ELEMS_PER_SECTOR]; // +ELEMS_PER_SECTOR to avoid shmem bank
-                                                                              // conflicts when writing back to global
-                                                                              // memory
-  __shared__ uint32_t tile_ordering_ix;
-  // Tile -1 owns the negative head used for sector alignment of the negative tiles destinations.
-  // Tile 0 owns the positive head used for sector alignment of the positive tiles destinations.
-  __shared__ T head_tile_cache[ELEMS_PER_SECTOR];
+  using context_t = pipeline_context<Algorithm, Dir, T>;
+  assert(blockDim.x == Algorithm::block_size);
+
+  alignas(BYTES_PER_SECTOR) extern __shared__ unsigned char smem_raw[];
 #pragma nv_diag_suppress static_var_with_dynamic_init
-  __shared__ cuda::barrier<cuda::thread_scope_block> bar;
+  __shared__ typename context_t::shared_storage shared;
 
-  auto* tiles_processed  = reinterpret_cast<cuda::atomic<uint32_t, cuda::thread_scope_device>*>(d_temp_storage);
-  auto* processing_order = reinterpret_cast<uint32_t*>(tiles_processed + 1); // first uint32_t is the counter of
-                                                                             // processed items
-  auto* flags = reinterpret_cast<device_flag_t*>(processing_order + num_tiles);
-
-  uint32_t const neg_head_size      = tile_detail::get_neg_head_size<T>(size, rotate_distance, head_size);
-  uint32_t const num_negative_tiles = tile_detail::get_num_negative_tiles(rotate_distance, TILE_SIZE, neg_head_size);
-
-  auto const tid = threadIdx.x;
-  auto cta       = cooperative_groups::this_thread_block();
-
-  if (tid == 0)
-  {
-    init(&bar, BLOCK_SIZE);
-  }
-  while (true)
-  {
-    if (tid == 0)
-    {
-      tile_ordering_ix = tiles_processed->fetch_add(1, cuda::memory_order_seq_cst);
-    }
-    __syncthreads();
-    auto const curr_tile_ordering_ix = tile_ordering_ix;
-    if (curr_tile_ordering_ix >= num_tiles)
-    {
-      return;
-    }
-    auto const curr_tile_index = processing_order[curr_tile_ordering_ix];
-    auto const curr_tile       = tile_detail::arr_ix_to_tile_ix(curr_tile_index, num_negative_tiles);
-    auto const logical_tile_start =
-      tile_detail::get_tile_start(rotate_distance, TILE_SIZE, curr_tile, head_size, neg_head_size);
-    auto const curr_tile_size = tile_detail::get_tile_size(
-      size, rotate_distance, TILE_SIZE, curr_tile, logical_tile_start, head_size, neg_head_size);
-    assert(curr_tile_size <= TILE_SIZE);
-
-    bool const owns_pos_head          = (curr_tile == 0) && (head_size > 0u);
-    bool const owns_neg_head          = (curr_tile == -1) && (neg_head_size > 0u);
-    uint32_t const head_load_size     = owns_pos_head ? head_size : (owns_neg_head ? neg_head_size : 0u);
-    size_t const logical_head_src_off = owns_pos_head ? rotate_distance : 0;
-    size_t const logical_head_dst_off = owns_pos_head ? 0 : (size - rotate_distance);
-    size_t const head_src_off = tile_detail::physical_interval_start<Dir>(size, logical_head_src_off, head_load_size);
-    size_t const head_dst_off = tile_detail::physical_interval_start<Dir>(size, logical_head_dst_off, head_load_size);
-
-    if (head_load_size > 0u && tid < WS)
-    {
-      for (uint32_t i = tid; i < head_load_size; i += WS)
-      {
-        head_tile_cache[i] = arr[head_src_off + i];
-      }
-    }
-
-    // Regular tile load via the standard memcpy_async pipeline.
-    size_t const curr_tile_start = tile_detail::physical_interval_start<Dir>(size, logical_tile_start, curr_tile_size);
-    T* src                       = arr + curr_tile_start;
-    uint32_t const unaligned_elems = (reinterpret_cast<uintptr_t>(src) % BYTES_PER_SECTOR) / sizeof(T);
-
-    overcopy_memcpy_async<T, BLOCK_SIZE>(cache, src, curr_tile_size, unaligned_elems, cta, bar);
-    bar.arrive_and_wait();
-
-    if (tid == 0)
-    {
-      flags[curr_tile_index].store(1, cuda::memory_order_release);
-      flags[curr_tile_index].notify_all();
-      // Poll dependencies
-      auto const dependencies = tile_detail::get_dependencies(
-        size, rotate_distance, TILE_SIZE, curr_tile, head_size, neg_head_size, num_negative_tiles);
-      for (uint32_t dependency = dependencies.begin_; dependency < dependencies.end_; ++dependency)
-      {
-        flags[dependency].wait(0, cuda::memory_order_acquire);
-      }
-    }
-
-    // Copy cached tile to destination
-    size_t const logical_dst_start =
-      tile_detail::get_overwrite_start(size, rotate_distance, TILE_SIZE, curr_tile, head_size, neg_head_size);
-    size_t const dst_start = tile_detail::physical_interval_start<Dir>(size, logical_dst_start, curr_tile_size);
-    T* dst                 = arr + dst_start;
-    src                    = cache + unaligned_elems;
-    constexpr int MAX_REGS = REGS_PER_SM / (BLOCKS_PER_SM * BLOCK_SIZE);
-    shared_to_global_through_regs<T, BLOCK_SIZE, TILE_BYTES, MAX_REGS>(dst, src, curr_tile_size * sizeof(T), cta);
-
-    if (head_load_size > 0u && tid < WS)
-    {
-      for (uint32_t i = tid; i < head_load_size; i += WS)
-      {
-        arr[head_dst_off + i] = head_tile_cache[i];
-      }
-    }
-  }
+  context_t context{
+    arr, size, temp_storage, rotate_distance, num_tiles, head_size, order_mode, reinterpret_cast<T*>(smem_raw), shared};
+  initialize_pipeline(context);
+  run_tile_pipeline(context);
 }
-} // namespace rotate_long
 } // namespace rotate
 } // namespace detail
 CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/kernels/kernel_rotate.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_rotate.cuh
@@ -240,7 +240,6 @@ _CCCL_DEVICE void shared_to_global_through_regs(T* dst, T* src, uint32_t const b
       }
     }
 
-    // TODO: see if adapting the tile size to remove the tail improves perf
     if constexpr (VEC_TILE_BYTES < TILE_BYTES)
     {
       // The uncovered tail [VEC_TILE_BYTES, TILE_BYTES) is a contiguous src->dst block copy: the
@@ -537,7 +536,6 @@ struct pipeline_context
 
   static constexpr int block_size       = policy::block_size;
   static constexpr int tile_bytes       = policy::tile_bytes;
-  static constexpr int tiles_per_grab   = policy::tiles_per_grab;
   static constexpr int pipeline_stages  = policy::pipeline_stages;
   static constexpr int tile_size        = tile_bytes / sizeof(T);
   static constexpr int elems_per_sector = BYTES_PER_SECTOR / sizeof(T);
@@ -662,7 +660,7 @@ template <RotDir Dir, typename T>
 _CCCL_DEVICE bool claim_and_load(pipeline_context<short_algorithm, Dir, T>& context, int slot)
 {
   using context_t              = pipeline_context<short_algorithm, Dir, T>;
-  constexpr int tiles_per_grab = context_t::tiles_per_grab;
+  constexpr int tiles_per_grab = short_algorithm::tiles_per_grab;
   auto* tile_counter           = reinterpret_cast<cuda::atomic<int, cuda::thread_scope_device>*>(context.temp_storage);
   auto cta                     = cooperative_groups::this_thread_block();
   auto const tid               = threadIdx.x;
@@ -815,7 +813,7 @@ _CCCL_DEVICE bool claim_and_load(pipeline_context<long_algorithm, Dir, T>& conte
 
   if (tid == 0)
   {
-    tile.work_index = counter->fetch_add(context_t::tiles_per_grab, cuda::memory_order_relaxed);
+    tile.work_index = counter->fetch_add(1, cuda::memory_order_relaxed);
     if (tile.work_index < context.num_tiles)
     {
       tile.index =

--- a/cub/cub/device/dispatch/kernels/kernel_rotate.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_rotate.cuh
@@ -15,6 +15,7 @@
 
 #include <cub/cub.cuh>
 #include <cub/device/dispatch/tuning/tuning_rotate.cuh>
+#include <cub/util_arch.cuh>
 
 #include <cuda/atomic>
 #include <cuda/barrier>
@@ -32,6 +33,9 @@ namespace detail
 {
 namespace rotate
 {
+inline constexpr int BYTES_PER_SECTOR = 32;
+using device_flag_t                   = cuda::atomic<int, cuda::thread_scope_device>;
+
 enum class RotDir
 {
   Left,
@@ -47,6 +51,26 @@ enum class OrderMode : uint32_t
   Negative  = 1, // small-side negative closed form: pos == 0 ? 0 : num_tiles - pos
   Positive  = 2, // small-side positive closed form: pos
 };
+
+struct short_algorithm
+{};
+
+struct long_algorithm
+{};
+
+template <typename Algorithm>
+[[nodiscard]] _CCCL_API constexpr auto get_algorithm_policy(const rotate_policy& policy)
+{
+  if constexpr (::cuda::std::is_same_v<Algorithm, short_algorithm>)
+  {
+    return policy.short_algorithm;
+  }
+  else
+  {
+    static_assert(::cuda::std::is_same_v<Algorithm, long_algorithm>);
+    return policy.long_algorithm;
+  }
+}
 
 _CCCL_HOST_DEVICE _CCCL_FORCEINLINE device_flag_t* get_long_flags(void* temp_storage)
 {
@@ -93,8 +117,7 @@ _CCCL_DEVICE void overcopy_memcpy_async(
 // BEFORE calling sync_op.sync(), to maximally overlap the atomic polling with other work, then writes to gmem AFTER.
 // Any remaining iterations that do not fit in the register budget are processed post-sync. sync_op must provide sync().
 //
-// MAX_REGS_PER_THREAD should be set to REGS_PER_SM / (BLOCKS_PER_SM * BLOCK_SIZE)
-// so that the register buffering does not reduce occupancy.
+// MAX_REGS_PER_THREAD is a tuning parameter and must leave room for at least one uint4.
 template <typename T, int NUM_THREADS, int TILE_BYTES, int MAX_REGS_PER_THREAD, typename SyncOp>
 _CCCL_DEVICE void shared_to_global_through_regs(T* dst, T* src, uint32_t const bytes_to_load, SyncOp& sync_op)
 {
@@ -458,22 +481,22 @@ _CCCL_HOST_DEVICE int32_t arr_ix_to_tile_ix(uint32_t const arr_ix, uint32_t cons
 };
 } // namespace tile_detail
 
-template <typename Algorithm, typename T>
-constexpr int get_shmem_usage()
+template <typename T>
+constexpr int get_shmem_usage(const kernel_policy& policy)
 {
-  constexpr int tile_size        = Algorithm::tile_bytes / sizeof(T);
+  const int tile_size            = policy.tile_bytes / sizeof(T);
   constexpr int elems_per_sector = BYTES_PER_SECTOR / sizeof(T);
-  constexpr int slot_bytes       = cuda::round_up((tile_size + elems_per_sector) * sizeof(T), BYTES_PER_SECTOR);
-  return Algorithm::pipeline_stages * slot_bytes;
+  const int slot_bytes           = cuda::round_up((tile_size + elems_per_sector) * sizeof(T), BYTES_PER_SECTOR);
+  return policy.pipeline_stages * slot_bytes;
 }
 
-template <typename Algorithm, typename T>
+template <typename Algorithm, typename T, typename PolicySelector = policy_selector>
 struct pipeline_shared_storage;
 
-template <typename T>
-struct pipeline_shared_storage<short_algorithm, T>
+template <typename T, typename PolicySelector>
+struct pipeline_shared_storage<short_algorithm, T, PolicySelector>
 {
-  static constexpr int pipeline_stages  = short_algorithm::pipeline_stages;
+  static constexpr int pipeline_stages  = current_policy<PolicySelector>().short_algorithm.kernel.pipeline_stages;
   static constexpr int elems_per_sector = BYTES_PER_SECTOR / sizeof(T);
 
   struct tile
@@ -495,10 +518,10 @@ struct pipeline_shared_storage<short_algorithm, T>
   cuda::barrier<cuda::thread_scope_block> bars[pipeline_stages];
 };
 
-template <typename T>
-struct pipeline_shared_storage<long_algorithm, T>
+template <typename T, typename PolicySelector>
+struct pipeline_shared_storage<long_algorithm, T, PolicySelector>
 {
-  static constexpr int pipeline_stages  = long_algorithm::pipeline_stages;
+  static constexpr int pipeline_stages  = current_policy<PolicySelector>().long_algorithm.kernel.pipeline_stages;
   static constexpr int elems_per_sector = BYTES_PER_SECTOR / sizeof(T);
 
   struct tile
@@ -526,24 +549,11 @@ struct pipeline_shared_storage<long_algorithm, T>
   cuda::barrier<cuda::thread_scope_block> bars[pipeline_stages];
 };
 
-
 // TODO: this may cause unnecessary register usage
-template <typename Algorithm, RotDir Dir, typename T>
+template <typename Algorithm, RotDir Dir, typename T, typename PolicySelector = policy_selector>
 struct pipeline_context
 {
-  using policy         = Algorithm;
-  using shared_storage = pipeline_shared_storage<Algorithm, T>;
-
-  static constexpr int block_size       = policy::block_size;
-  static constexpr int tile_bytes       = policy::tile_bytes;
-  static constexpr int pipeline_stages  = policy::pipeline_stages;
-  static constexpr int tile_size        = tile_bytes / sizeof(T);
-  static constexpr int elems_per_sector = BYTES_PER_SECTOR / sizeof(T);
-  static constexpr int slot_bytes       = cuda::round_up((tile_size + elems_per_sector) * sizeof(T), BYTES_PER_SECTOR);
-  static constexpr int slot_elems       = slot_bytes / sizeof(T);
-  static constexpr int max_regs_occupancy = REGS_PER_SM / (policy::blocks_per_sm * block_size);
-  static constexpr int max_regs =
-    policy::max_regs_per_thread_override > 0 ? policy::max_regs_per_thread_override : max_regs_occupancy;
+  using shared_storage = pipeline_shared_storage<Algorithm, T, PolicySelector>;
 
   T* array;
   size_t size;
@@ -557,24 +567,29 @@ struct pipeline_context
 
   _CCCL_DEVICE T* tile_cache(int slot) const
   {
+    constexpr auto kernel          = get_algorithm_policy<Algorithm>(current_policy<PolicySelector>()).kernel;
+    constexpr int tile_size        = kernel.tile_bytes / sizeof(T);
+    constexpr int elems_per_sector = BYTES_PER_SECTOR / sizeof(T);
+    constexpr int slot_bytes       = cuda::round_up((tile_size + elems_per_sector) * sizeof(T), BYTES_PER_SECTOR);
+    constexpr int slot_elems       = slot_bytes / sizeof(T);
     return cache + slot * slot_elems;
   }
 };
 
-template <RotDir Dir, typename T>
-_CCCL_DEVICE device_flag_t* get_flags(pipeline_context<short_algorithm, Dir, T> const& context)
+template <RotDir Dir, typename T, typename PolicySelector>
+_CCCL_DEVICE device_flag_t* get_flags(pipeline_context<short_algorithm, Dir, T, PolicySelector> const& context)
 {
   return reinterpret_cast<device_flag_t*>(reinterpret_cast<int*>(context.temp_storage) + 1);
 }
 
-template <RotDir Dir, typename T>
-_CCCL_DEVICE device_flag_t* get_flags(pipeline_context<long_algorithm, Dir, T> const& context)
+template <RotDir Dir, typename T, typename PolicySelector>
+_CCCL_DEVICE device_flag_t* get_flags(pipeline_context<long_algorithm, Dir, T, PolicySelector> const& context)
 {
   return get_long_flags(context.temp_storage);
 }
 
-template <RotDir Dir, typename T>
-_CCCL_DEVICE uint32_t* get_processing_order(pipeline_context<long_algorithm, Dir, T> const& context)
+template <RotDir Dir, typename T, typename PolicySelector>
+_CCCL_DEVICE uint32_t* get_processing_order(pipeline_context<long_algorithm, Dir, T, PolicySelector> const& context)
 {
   return get_long_processing_order(context.temp_storage, context.num_tiles);
 }
@@ -585,13 +600,14 @@ _CCCL_DEVICE uint32_t* get_processing_order(pipeline_context<long_algorithm, Dir
 
 namespace rotate_tiny
 {
-template <RotDir Dir, typename T>
-__global__ void rotate_tiny_kernel(T* arr, size_t const size, size_t const rotate_distance)
+template <RotDir Dir, typename T, typename PolicySelector = policy_selector>
+_CCCL_KERNEL_ATTRIBUTES void rotate_tiny_kernel(T* arr, size_t const size, size_t const rotate_distance)
 {
+  constexpr auto policy = current_policy<PolicySelector>().short_algorithm;
   extern __shared__ unsigned char smem_raw[];
   T* smem = reinterpret_cast<T*>(smem_raw);
 
-  assert(size <= short_algorithm::tile_bytes / sizeof(T));
+  assert(size <= policy.kernel.tile_bytes / sizeof(T));
   assert(rotate_distance > 0 && rotate_distance <= size / 2);
 
   if (blockIdx.x == 0)
@@ -615,23 +631,25 @@ __global__ void rotate_tiny_kernel(T* arr, size_t const size, size_t const rotat
 }
 } // namespace rotate_tiny
 
-template <typename Algorithm, RotDir Dir, typename T>
-_CCCL_DEVICE void initialize_pipeline(pipeline_context<Algorithm, Dir, T>& context)
+template <typename Algorithm, RotDir Dir, typename T, typename PolicySelector>
+_CCCL_DEVICE void initialize_pipeline(pipeline_context<Algorithm, Dir, T, PolicySelector>& context)
 {
-  using context_t = pipeline_context<Algorithm, Dir, T>;
-  auto const tid  = threadIdx.x;
+  constexpr auto kernel          = get_algorithm_policy<Algorithm>(current_policy<PolicySelector>()).kernel;
+  constexpr int tile_size        = kernel.tile_bytes / sizeof(T);
+  constexpr int elems_per_sector = BYTES_PER_SECTOR / sizeof(T);
+  auto const tid                 = threadIdx.x;
 
-  if (tid < context_t::pipeline_stages)
+  if (tid < kernel.pipeline_stages)
   {
-    init(&context.shared.bars[tid], context_t::block_size);
+    init(&context.shared.bars[tid], kernel.threads_per_block);
   }
 
   if constexpr (cuda::std::is_same_v<Algorithm, short_algorithm>)
   {
-    assert(context.rotate_distance <= context_t::tile_size);
-    assert(context.head_size < context_t::elems_per_sector);
+    assert(context.rotate_distance <= tile_size);
+    assert(context.head_size < elems_per_sector);
     assert(2 * context.rotate_distance <= context.size);
-    assert(context.size > context_t::tile_size);
+    assert(context.size > tile_size);
 
     if (tid == 0)
     {
@@ -642,29 +660,33 @@ _CCCL_DEVICE void initialize_pipeline(pipeline_context<Algorithm, Dir, T>& conte
   __syncthreads();
 }
 
-template <RotDir Dir, typename T>
-_CCCL_DEVICE uint32_t get_tile_size(pipeline_context<short_algorithm, Dir, T> const& context, uint32_t tile_index)
+template <RotDir Dir, typename T, typename PolicySelector>
+_CCCL_DEVICE uint32_t get_tile_size(pipeline_context<short_algorithm, Dir, T, PolicySelector> const& context,
+                                    uint32_t tile_index)
 {
-  using context_t = pipeline_context<short_algorithm, Dir, T>;
+  constexpr auto kernel   = current_policy<PolicySelector>().short_algorithm.kernel;
+  constexpr int tile_size = kernel.tile_bytes / sizeof(T);
   if (tile_index != context.num_tiles - 1)
   {
-    return context_t::tile_size;
+    return tile_size;
   }
 
-  uint32_t const remainder = (context.size - context.rotate_distance - context.head_size) % context_t::tile_size;
-  return remainder == 0u ? context_t::tile_size : remainder;
+  uint32_t const remainder = (context.size - context.rotate_distance - context.head_size) % tile_size;
+  return remainder == 0u ? tile_size : remainder;
 }
 
 // Claim the next tile from this CTA's descending run and issue its asynchronous load.
-template <RotDir Dir, typename T>
-_CCCL_DEVICE bool claim_and_load(pipeline_context<short_algorithm, Dir, T>& context, int slot)
+template <RotDir Dir, typename T, typename PolicySelector>
+_CCCL_DEVICE bool claim_and_load(pipeline_context<short_algorithm, Dir, T, PolicySelector>& context, int slot)
 {
-  using context_t              = pipeline_context<short_algorithm, Dir, T>;
-  constexpr int tiles_per_grab = short_algorithm::tiles_per_grab;
-  auto* tile_counter           = reinterpret_cast<cuda::atomic<int, cuda::thread_scope_device>*>(context.temp_storage);
-  auto cta                     = cooperative_groups::this_thread_block();
-  auto const tid               = threadIdx.x;
-  auto& tile                   = context.shared.tiles[slot];
+  constexpr auto policy          = current_policy<PolicySelector>().short_algorithm;
+  constexpr int full_tile_size   = policy.kernel.tile_bytes / sizeof(T);
+  constexpr int elems_per_sector = BYTES_PER_SECTOR / sizeof(T);
+  constexpr int tiles_per_grab   = policy.tiles_per_grab;
+  auto* tile_counter = reinterpret_cast<cuda::atomic<int, cuda::thread_scope_device>*>(context.temp_storage);
+  auto cta           = cooperative_groups::this_thread_block();
+  auto const tid     = threadIdx.x;
+  auto& tile         = context.shared.tiles[slot];
 
   if (tid == 0)
   {
@@ -692,9 +714,9 @@ _CCCL_DEVICE bool claim_and_load(pipeline_context<short_algorithm, Dir, T>& cont
 
   uint32_t const tile_size = get_tile_size(context, tile.index);
   size_t const logical_src =
-    context.rotate_distance + context.head_size + static_cast<size_t>(tile.index) * context_t::tile_size;
+    context.rotate_distance + context.head_size + static_cast<size_t>(tile.index) * full_tile_size;
   size_t const src_offset  = tile_detail::physical_interval_start<Dir>(context.size, logical_src, tile_size);
-  uint32_t unaligned_elems = context.rotate_distance % context_t::elems_per_sector;
+  uint32_t unaligned_elems = context.rotate_distance % elems_per_sector;
   if constexpr (Dir == RotDir::Right)
   {
     unaligned_elems = (reinterpret_cast<uintptr_t>(context.array + src_offset) % BYTES_PER_SECTOR) / sizeof(T);
@@ -705,8 +727,8 @@ _CCCL_DEVICE bool claim_and_load(pipeline_context<short_algorithm, Dir, T>& cont
   return true;
 }
 
-template <typename Algorithm, RotDir Dir, typename T>
-_CCCL_DEVICE void publish_tile(pipeline_context<Algorithm, Dir, T>& context, int slot)
+template <typename Algorithm, RotDir Dir, typename T, typename PolicySelector>
+_CCCL_DEVICE void publish_tile(pipeline_context<Algorithm, Dir, T, PolicySelector>& context, int slot)
 {
   auto* flags      = get_flags(context);
   auto const& tile = context.shared.tiles[slot];
@@ -719,8 +741,8 @@ _CCCL_DEVICE void publish_tile(pipeline_context<Algorithm, Dir, T>& context, int
   }
 }
 
-template <RotDir Dir, typename T>
-_CCCL_DEVICE void wait_for_dependencies(pipeline_context<short_algorithm, Dir, T>& context, int slot)
+template <RotDir Dir, typename T, typename PolicySelector>
+_CCCL_DEVICE void wait_for_dependencies(pipeline_context<short_algorithm, Dir, T, PolicySelector>& context, int slot)
 {
   auto* flags             = get_flags(context);
   auto const& tile        = context.shared.tiles[slot];
@@ -738,17 +760,19 @@ _CCCL_DEVICE void wait_for_dependencies(pipeline_context<short_algorithm, Dir, T
   }
 }
 
-template <RotDir Dir, typename T>
-_CCCL_DEVICE void store_tile(pipeline_context<short_algorithm, Dir, T>& context, int slot)
+template <RotDir Dir, typename T, typename PolicySelector>
+_CCCL_DEVICE void store_tile(pipeline_context<short_algorithm, Dir, T, PolicySelector>& context, int slot)
 {
-  using context_t          = pipeline_context<short_algorithm, Dir, T>;
-  auto cta                 = cooperative_groups::this_thread_block();
-  auto const tid           = threadIdx.x;
-  int const tile_index     = context.shared.tiles[slot].index;
-  bool const is_last_tile  = tile_index == 0;
-  uint32_t const tile_size = get_tile_size(context, tile_index);
+  constexpr auto kernel          = current_policy<PolicySelector>().short_algorithm.kernel;
+  constexpr int full_tile_size   = kernel.tile_bytes / sizeof(T);
+  constexpr int elems_per_sector = BYTES_PER_SECTOR / sizeof(T);
+  auto cta                       = cooperative_groups::this_thread_block();
+  auto const tid                 = threadIdx.x;
+  int const tile_index           = context.shared.tiles[slot].index;
+  bool const is_last_tile        = tile_index == 0;
+  uint32_t const tile_size       = get_tile_size(context, tile_index);
   size_t const logical_src =
-    context.rotate_distance + context.head_size + static_cast<size_t>(tile_index) * context_t::tile_size;
+    context.rotate_distance + context.head_size + static_cast<size_t>(tile_index) * full_tile_size;
   size_t const logical_dst = logical_src - context.rotate_distance;
   size_t const dst_offset  = tile_detail::physical_interval_start<Dir>(context.size, logical_dst, tile_size);
 
@@ -758,7 +782,7 @@ _CCCL_DEVICE void store_tile(pipeline_context<short_algorithm, Dir, T>& context,
     {
       size_t const head_src =
         tile_detail::physical_interval_start<Dir>(context.size, context.rotate_distance, context.head_size);
-      for (uint32_t i = tid; i < context.head_size; i += context_t::block_size)
+      for (uint32_t i = tid; i < context.head_size; i += kernel.threads_per_block)
       {
         context.shared.head_cache[i] = context.array[head_src + i];
       }
@@ -767,7 +791,7 @@ _CCCL_DEVICE void store_tile(pipeline_context<short_algorithm, Dir, T>& context,
     size_t const wrap_src = tile_detail::physical_interval_start<Dir>(context.size, 0, context.rotate_distance);
     size_t const wrap_dst = tile_detail::physical_interval_start<Dir>(
       context.size, context.size - context.rotate_distance, context.rotate_distance);
-    for (size_t i = tid; i < context.rotate_distance; i += context_t::block_size)
+    for (size_t i = tid; i < context.rotate_distance; i += kernel.threads_per_block)
     {
       context.array[wrap_dst + i] = context.array[wrap_src + i];
     }
@@ -776,7 +800,7 @@ _CCCL_DEVICE void store_tile(pipeline_context<short_algorithm, Dir, T>& context,
     if (context.head_size > 0u)
     {
       size_t const head_dst = tile_detail::physical_interval_start<Dir>(context.size, 0, context.head_size);
-      for (uint32_t i = tid; i < context.head_size; i += context_t::block_size)
+      for (uint32_t i = tid; i < context.head_size; i += kernel.threads_per_block)
       {
         context.array[head_dst + i] = context.shared.head_cache[i];
       }
@@ -784,12 +808,12 @@ _CCCL_DEVICE void store_tile(pipeline_context<short_algorithm, Dir, T>& context,
   }
 
   size_t const src_offset  = tile_detail::physical_interval_start<Dir>(context.size, logical_src, tile_size);
-  uint32_t unaligned_elems = context.rotate_distance % context_t::elems_per_sector;
+  uint32_t unaligned_elems = context.rotate_distance % elems_per_sector;
   if constexpr (Dir == RotDir::Right)
   {
     unaligned_elems = (reinterpret_cast<uintptr_t>(context.array + src_offset) % BYTES_PER_SECTOR) / sizeof(T);
   }
-  shared_to_global_through_regs<T, context_t::block_size, context_t::tile_bytes, context_t::max_regs>(
+  shared_to_global_through_regs<T, kernel.threads_per_block, kernel.tile_bytes, kernel.max_regs_per_thread>(
     context.array + dst_offset, context.tile_cache(slot) + unaligned_elems, tile_size * sizeof(T), cta);
 }
 
@@ -797,19 +821,20 @@ _CCCL_DEVICE void store_tile(pipeline_context<short_algorithm, Dir, T>& context,
 // Long-distance rotate operations
 // ============================================================================
 
-template <RotDir Dir, typename T>
-_CCCL_DEVICE bool claim_and_load(pipeline_context<long_algorithm, Dir, T>& context, int slot)
+template <RotDir Dir, typename T, typename PolicySelector>
+_CCCL_DEVICE bool claim_and_load(pipeline_context<long_algorithm, Dir, T, PolicySelector>& context, int slot)
 {
-  using context_t        = pipeline_context<long_algorithm, Dir, T>;
-  auto* counter          = reinterpret_cast<cuda::atomic<uint32_t, cuda::thread_scope_device>*>(context.temp_storage);
-  auto* processing_order = get_processing_order(context);
-  auto cta               = cooperative_groups::this_thread_block();
-  auto const tid         = threadIdx.x;
-  auto& tile             = context.shared.tiles[slot];
+  constexpr auto kernel   = current_policy<PolicySelector>().long_algorithm.kernel;
+  constexpr int tile_size = kernel.tile_bytes / sizeof(T);
+  auto* counter           = reinterpret_cast<cuda::atomic<uint32_t, cuda::thread_scope_device>*>(context.temp_storage);
+  auto* processing_order  = get_processing_order(context);
+  auto cta                = cooperative_groups::this_thread_block();
+  auto const tid          = threadIdx.x;
+  auto& tile              = context.shared.tiles[slot];
   uint32_t const neg_head_size =
     tile_detail::get_neg_head_size<T>(context.size, context.rotate_distance, context.head_size);
   uint32_t const num_negative_tiles =
-    tile_detail::get_num_negative_tiles(context.rotate_distance, context_t::tile_size, neg_head_size);
+    tile_detail::get_num_negative_tiles(context.rotate_distance, tile_size, neg_head_size);
 
   if (tid == 0)
   {
@@ -824,17 +849,11 @@ _CCCL_DEVICE bool claim_and_load(pipeline_context<long_algorithm, Dir, T>& conte
                : tile.work_index);
 
       int32_t const tile_index = tile_detail::arr_ix_to_tile_ix(tile.index, num_negative_tiles);
-      size_t const logical_src = tile_detail::get_tile_start(
-        context.rotate_distance, context_t::tile_size, tile_index, context.head_size, neg_head_size);
+      size_t const logical_src =
+        tile_detail::get_tile_start(context.rotate_distance, tile_size, tile_index, context.head_size, neg_head_size);
       tile.size = tile_detail::get_tile_size(
-        context.size,
-        context.rotate_distance,
-        context_t::tile_size,
-        tile_index,
-        logical_src,
-        context.head_size,
-        neg_head_size);
-      assert(tile.size <= context_t::tile_size);
+        context.size, context.rotate_distance, tile_size, tile_index, logical_src, context.head_size, neg_head_size);
+      assert(tile.size <= tile_size);
       tile.src_offset = tile_detail::physical_interval_start<Dir>(context.size, logical_src, tile.size);
       tile.unaligned_elems =
         (reinterpret_cast<uintptr_t>(context.array + tile.src_offset) % BYTES_PER_SECTOR) / sizeof(T);
@@ -861,9 +880,9 @@ _CCCL_DEVICE bool claim_and_load(pipeline_context<long_algorithm, Dir, T>& conte
     cta,
     context.shared.bars[slot]);
 
-  if (tile.head_size > 0u && tid < WS)
+  if (tile.head_size > 0u && tid < warp_threads)
   {
-    for (uint32_t i = tid; i < tile.head_size; i += WS)
+    for (uint32_t i = tid; i < tile.head_size; i += warp_threads)
     {
       context.shared.head_cache[slot][i] = context.array[tile.head_src_offset + i];
     }
@@ -874,11 +893,11 @@ _CCCL_DEVICE bool claim_and_load(pipeline_context<long_algorithm, Dir, T>& conte
   {
     int32_t const tile_index = tile_detail::arr_ix_to_tile_ix(tile.index, num_negative_tiles);
     size_t const logical_dst = tile_detail::get_overwrite_start(
-      context.size, context.rotate_distance, context_t::tile_size, tile_index, context.head_size, neg_head_size);
+      context.size, context.rotate_distance, tile_size, tile_index, context.head_size, neg_head_size);
     tile.dependencies = tile_detail::get_dependencies_from(
       context.size,
       context.rotate_distance,
-      context_t::tile_size,
+      tile_size,
       tile_index,
       context.head_size,
       neg_head_size,
@@ -894,8 +913,8 @@ _CCCL_DEVICE bool claim_and_load(pipeline_context<long_algorithm, Dir, T>& conte
   return true;
 }
 
-template <RotDir Dir, typename T>
-_CCCL_DEVICE void wait_for_dependencies(pipeline_context<long_algorithm, Dir, T>& context, int slot)
+template <RotDir Dir, typename T, typename PolicySelector>
+_CCCL_DEVICE void wait_for_dependencies(pipeline_context<long_algorithm, Dir, T, PolicySelector>& context, int slot)
 {
   auto* flags = get_flags(context);
 
@@ -909,20 +928,20 @@ _CCCL_DEVICE void wait_for_dependencies(pipeline_context<long_algorithm, Dir, T>
   }
 }
 
-template <RotDir Dir, typename T>
-_CCCL_DEVICE void store_tile(pipeline_context<long_algorithm, Dir, T>& context, int slot)
+template <RotDir Dir, typename T, typename PolicySelector>
+_CCCL_DEVICE void store_tile(pipeline_context<long_algorithm, Dir, T, PolicySelector>& context, int slot)
 {
-  using context_t  = pipeline_context<long_algorithm, Dir, T>;
-  auto cta         = cooperative_groups::this_thread_block();
-  auto const tid   = threadIdx.x;
-  auto const& tile = context.shared.tiles[slot];
+  constexpr auto kernel = current_policy<PolicySelector>().long_algorithm.kernel;
+  auto cta              = cooperative_groups::this_thread_block();
+  auto const tid        = threadIdx.x;
+  auto const& tile      = context.shared.tiles[slot];
 
-  shared_to_global_through_regs<T, context_t::block_size, context_t::tile_bytes, context_t::max_regs>(
+  shared_to_global_through_regs<T, kernel.threads_per_block, kernel.tile_bytes, kernel.max_regs_per_thread>(
     context.array + tile.dst_offset, context.tile_cache(slot) + tile.unaligned_elems, tile.size * sizeof(T), cta);
 
-  if (tile.head_size > 0u && tid < WS)
+  if (tile.head_size > 0u && tid < warp_threads)
   {
-    for (uint32_t i = tid; i < tile.head_size; i += WS)
+    for (uint32_t i = tid; i < tile.head_size; i += warp_threads)
     {
       context.array[tile.head_dst_offset + i] = context.shared.head_cache[slot][i];
     }
@@ -932,10 +951,11 @@ _CCCL_DEVICE void store_tile(pipeline_context<long_algorithm, Dir, T>& context, 
 // ============================================================================
 // Pipeline execution
 // ============================================================================
-template <typename Context>
-_CCCL_DEVICE void run_tile_pipeline(Context& context)
+template <typename Algorithm, RotDir Dir, typename T, typename PolicySelector>
+_CCCL_DEVICE void run_tile_pipeline(pipeline_context<Algorithm, Dir, T, PolicySelector>& context)
 {
-  constexpr int pipeline_stages = Context::pipeline_stages;
+  constexpr auto kernel         = get_algorithm_policy<Algorithm>(current_policy<PolicySelector>()).kernel;
+  constexpr int pipeline_stages = kernel.pipeline_stages;
   int issued                    = 0;
   int published                 = 0;
   int stored                    = 0;
@@ -977,25 +997,27 @@ _CCCL_DEVICE void run_tile_pipeline(Context& context)
   }
 }
 
-template <typename Algorithm, RotDir Dir, typename T>
-CUB_ROTATE_LB(Algorithm::block_size, Algorithm::blocks_per_sm)
-__global__ void rotate_kernel(
-  T* arr,
-  size_t const size,
-  void* temp_storage,
-  size_t const rotate_distance,
-  size_t const num_tiles,
-  uint32_t const head_size,
-  OrderMode const order_mode)
+template <typename Algorithm, RotDir Dir, typename T, typename PolicySelector = policy_selector>
+__launch_bounds__(get_algorithm_policy<Algorithm>(current_policy<PolicySelector>()).kernel.threads_per_block,
+                  get_algorithm_policy<Algorithm>(current_policy<PolicySelector>()).kernel.blocks_per_sm)
+  _CCCL_KERNEL_ATTRIBUTES void rotate_kernel(
+    T* arr,
+    size_t const size,
+    void* temp_storage,
+    size_t const rotate_distance,
+    size_t const num_tiles,
+    uint32_t const head_size,
+    OrderMode const order_mode)
 {
-  using context_t = pipeline_context<Algorithm, Dir, T>;
-  assert(blockDim.x == Algorithm::block_size);
+  constexpr auto policy = current_policy<PolicySelector>();
+  constexpr auto kernel = get_algorithm_policy<Algorithm>(policy).kernel;
+  assert(blockDim.x == kernel.threads_per_block);
 
   alignas(BYTES_PER_SECTOR) extern __shared__ unsigned char smem_raw[];
 #pragma nv_diag_suppress static_var_with_dynamic_init
-  __shared__ typename context_t::shared_storage shared;
+  __shared__ pipeline_shared_storage<Algorithm, T, PolicySelector> shared;
 
-  context_t context{
+  pipeline_context<Algorithm, Dir, T, PolicySelector> context{
     arr, size, temp_storage, rotate_distance, num_tiles, head_size, order_mode, reinterpret_cast<T*>(smem_raw), shared};
   initialize_pipeline(context);
   run_tile_pipeline(context);

--- a/cub/cub/device/dispatch/tuning/tuning_rotate.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_rotate.cuh
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/atomic>
+#include <cuda/cmath>
+
+#include <algorithm>
+
+CUB_NAMESPACE_BEGIN
+namespace detail
+{
+namespace rotate
+{
+constexpr int WS               = 32; // warp size
+constexpr int BYTES_PER_SECTOR = 32; // cache sector size
+constexpr int REGS_PER_SM      = 65536;
+
+using device_flag_t = cuda::atomic<int, cuda::thread_scope_device>;
+
+#ifdef __CUDA_ARCH__
+#  if (__CUDA_ARCH__ > 800 && __CUDA_ARCH__ < 900) || __CUDA_ARCH__ >= 1100
+constexpr size_t MAX_TPSM = 1536;
+#  elif __CUDA_ARCH__ == 750
+constexpr size_t MAX_TPSM = 1024;
+#  else
+constexpr size_t MAX_TPSM = 2048;
+#  endif
+
+#  if __CUDA_ARCH__ == 750
+constexpr int SHMEM_PER_SM = 64 * 1024;
+#  elif __CUDA_ARCH__ == 800 || __CUDA_ARCH__ == 870
+constexpr int SHMEM_PER_SM = 164 * 1024;
+#  elif __CUDA_ARCH__ == 860 || __CUDA_ARCH__ == 890 || __CUDA_ARCH__ >= 1200
+constexpr int SHMEM_PER_SM = 100 * 1024;
+#  elif __CUDA_ARCH__ >= 900 && __CUDA_ARCH__ <= 1100
+constexpr int SHMEM_PER_SM = 228 * 1024;
+#  else
+#    error "Unknown device architecture, please define SHMEM_PER_SM for __CUDA_ARCH__"
+#  endif
+
+#  define CUB_ROTATE_LB(x, y) __launch_bounds__(x, y)
+#else
+constexpr int SHMEM_PER_SM = 1;
+constexpr int MAX_TPSM     = 1;
+#  define CUB_ROTATE_LB(x, y)
+#endif // __CUDA_ARCH__
+
+__device__ constexpr bool hasTMA()
+{
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  return true;
+#else
+  return false;
+#endif
+}
+
+constexpr int get_pipeline_depth(const int tile_bytes, const int shmem_per_sm)
+{
+  const int depth = shmem_per_sm / (tile_bytes + 1'000); // extra bytes to ensure no spilling
+  return depth > 0 ? depth : 1;
+}
+
+constexpr std::pair<int, int> get_launch_bounds(const int tile_bytes, const int shmem_per_sm, const int max_tpsm)
+{
+  const int BLOCKS_PER_SM = shmem_per_sm / (tile_bytes + 1'000); // extra bytes to ensure no spilling
+  if (BLOCKS_PER_SM <= 0)
+  {
+    return {1, 1}; // shmem too small (e.g. host-side fallback); return safe defaults
+  }
+
+  const int BLOCK_SIZE = cuda::prev_power_of_two(max_tpsm / BLOCKS_PER_SM);
+  return {BLOCK_SIZE, BLOCKS_PER_SM};
+}
+
+constexpr bool USE_SHORT_PIPELINE = false;
+
+namespace rotate_short
+{
+constexpr int TILE_BYTES                  = 32 * 1024;
+inline constexpr int NUM_CONSUMER_THREADS = 512;
+inline constexpr int BLOCK_SIZE           = NUM_CONSUMER_THREADS + WS;
+inline constexpr int BLOCKS_PER_SM        = 1;
+} // namespace rotate_short
+
+namespace rotate_short_no_pipeline
+{
+constexpr int TILE_BYTES            = 32 * 1024;
+constexpr auto LAUNCH_BOUNDS        = get_launch_bounds(TILE_BYTES, SHMEM_PER_SM, MAX_TPSM);
+inline constexpr auto BLOCK_SIZE    = LAUNCH_BOUNDS.first;
+inline constexpr auto BLOCKS_PER_SM = LAUNCH_BOUNDS.second;
+} // namespace rotate_short_no_pipeline
+
+namespace rotate_long
+{
+constexpr int TILE_BYTES            = 32 * 1024;
+constexpr auto LAUNCH_BOUNDS        = get_launch_bounds(TILE_BYTES, SHMEM_PER_SM, MAX_TPSM);
+inline constexpr auto BLOCK_SIZE    = LAUNCH_BOUNDS.first;
+inline constexpr auto BLOCKS_PER_SM = LAUNCH_BOUNDS.second;
+} // namespace rotate_long
+} // namespace rotate
+} // namespace detail
+CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/tuning/tuning_rotate.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_rotate.cuh
@@ -66,12 +66,6 @@ __device__ constexpr bool hasTMA()
 #endif
 }
 
-constexpr int get_pipeline_depth(const int tile_bytes, const int shmem_per_sm)
-{
-  const int depth = shmem_per_sm / (tile_bytes + 1'000); // extra bytes to ensure no spilling
-  return depth > 0 ? depth : 1;
-}
-
 constexpr std::pair<int, int> get_launch_bounds(const int tile_bytes, const int shmem_per_sm, const int max_tpsm)
 {
   const int BLOCKS_PER_SM = shmem_per_sm / (tile_bytes + 1'000); // extra bytes to ensure no spilling
@@ -84,23 +78,27 @@ constexpr std::pair<int, int> get_launch_bounds(const int tile_bytes, const int 
   return {BLOCK_SIZE, BLOCKS_PER_SM};
 }
 
-constexpr bool USE_SHORT_PIPELINE = false;
-
 namespace rotate_short
 {
-constexpr int TILE_BYTES                  = 32 * 1024;
-inline constexpr int NUM_CONSUMER_THREADS = 512;
-inline constexpr int BLOCK_SIZE           = NUM_CONSUMER_THREADS + WS;
-inline constexpr int BLOCKS_PER_SM        = 1;
-} // namespace rotate_short
+// Short-path tile size.  The test suite also keys its per-case sizes to `rotate_short::TILE_BYTES`.
+constexpr int TILE_BYTES = 18 * 1024;
 
-namespace rotate_short_no_pipeline
-{
-constexpr int TILE_BYTES            = 32 * 1024;
-constexpr auto LAUNCH_BOUNDS        = get_launch_bounds(TILE_BYTES, SHMEM_PER_SM, MAX_TPSM);
+// How many contiguous tiles a CTA grabs at once.
+constexpr int TILES_PER_GRAB = 6;
+
+// Number of shmem tile buffers per block (double-buffer for staging contiguous runs of tiles).
+constexpr int PIPELINE_STAGES = 2;
+
+// Each block stages PIPELINE_STAGES shmem tile buffers, so its effective per-block shmem footprint
+// is PIPELINE_STAGES * TILE_BYTES.  Feeding that product to get_launch_bounds divides occupancy by
+// the stage count exactly as a bespoke helper would, keeping the register-buffering budget in
+// shared_to_global_through_regs correctly sized -- no separate launch-bounds function needed.
+constexpr auto LAUNCH_BOUNDS        = get_launch_bounds(TILE_BYTES * PIPELINE_STAGES, SHMEM_PER_SM, MAX_TPSM);
 inline constexpr auto BLOCK_SIZE    = LAUNCH_BOUNDS.first;
 inline constexpr auto BLOCKS_PER_SM = LAUNCH_BOUNDS.second;
-} // namespace rotate_short_no_pipeline
+// Limit the number of registers per thread when copying from shared to global.
+constexpr int MAX_REGS_PER_THREAD_OVERRIDE = 4;
+} // namespace rotate_short
 
 namespace rotate_long
 {

--- a/cub/cub/device/dispatch/tuning/tuning_rotate.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_rotate.cuh
@@ -57,15 +57,6 @@ constexpr int MAX_TPSM     = 1;
 #  define CUB_ROTATE_LB(x, y)
 #endif // __CUDA_ARCH__
 
-__device__ constexpr bool hasTMA()
-{
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
-  return true;
-#else
-  return false;
-#endif
-}
-
 constexpr std::pair<int, int> get_launch_bounds(const int tile_bytes, const int shmem_per_sm, const int max_tpsm)
 {
   const int BLOCKS_PER_SM = shmem_per_sm / (tile_bytes + 1'000); // extra bytes to ensure no spilling
@@ -78,35 +69,43 @@ constexpr std::pair<int, int> get_launch_bounds(const int tile_bytes, const int 
   return {BLOCK_SIZE, BLOCKS_PER_SM};
 }
 
-namespace rotate_short
+struct short_algorithm
 {
-// Short-path tile size.  The test suite also keys its per-case sizes to `rotate_short::TILE_BYTES`.
-constexpr int TILE_BYTES = 18 * 1024;
+  static constexpr int tile_bytes = 18 * 1024;
 
-// How many contiguous tiles a CTA grabs at once.
-constexpr int TILES_PER_GRAB = 6;
+  // How many contiguous tiles a CTA grabs at once.
+  static constexpr int tiles_per_grab = 6;
 
-// Number of shmem tile buffers per block (double-buffer for staging contiguous runs of tiles).
-constexpr int PIPELINE_STAGES = 2;
+  // Number of shared-memory tile buffers per block.
+  static constexpr int pipeline_stages = 2;
 
-// Each block stages PIPELINE_STAGES shmem tile buffers, so its effective per-block shmem footprint
-// is PIPELINE_STAGES * TILE_BYTES.  Feeding that product to get_launch_bounds divides occupancy by
-// the stage count exactly as a bespoke helper would, keeping the register-buffering budget in
-// shared_to_global_through_regs correctly sized -- no separate launch-bounds function needed.
-constexpr auto LAUNCH_BOUNDS        = get_launch_bounds(TILE_BYTES * PIPELINE_STAGES, SHMEM_PER_SM, MAX_TPSM);
-inline constexpr auto BLOCK_SIZE    = LAUNCH_BOUNDS.first;
-inline constexpr auto BLOCKS_PER_SM = LAUNCH_BOUNDS.second;
-// Limit the number of registers per thread when copying from shared to global.
-constexpr int MAX_REGS_PER_THREAD_OVERRIDE = 4;
-} // namespace rotate_short
+  static constexpr auto launch_bounds = get_launch_bounds(tile_bytes * pipeline_stages, SHMEM_PER_SM, MAX_TPSM);
+  static constexpr int block_size     = launch_bounds.first;
+  static constexpr int blocks_per_sm  = launch_bounds.second;
 
-namespace rotate_long
+  // Limit the number of registers per thread when copying from shared to global.
+  static constexpr int max_regs_per_thread_override = 4;
+};
+
+struct long_algorithm
 {
-constexpr int TILE_BYTES            = 32 * 1024;
-constexpr auto LAUNCH_BOUNDS        = get_launch_bounds(TILE_BYTES, SHMEM_PER_SM, MAX_TPSM);
-inline constexpr auto BLOCK_SIZE    = LAUNCH_BOUNDS.first;
-inline constexpr auto BLOCKS_PER_SM = LAUNCH_BOUNDS.second;
-} // namespace rotate_long
+  static constexpr int tile_bytes = 32 * 1024;
+
+  // TODO: ensure multiple tiles per grab works
+  static constexpr int tiles_per_grab = 1;
+
+  static constexpr int pipeline_stages = 2;
+
+  static constexpr auto launch_bounds = get_launch_bounds(tile_bytes * pipeline_stages, SHMEM_PER_SM, MAX_TPSM);
+  static constexpr int block_size     = launch_bounds.first;
+  static constexpr int blocks_per_sm  = launch_bounds.second;
+
+  // Cap the shared->global store register buffer at the BUFFERED_ITERS=1 floor (= min(4, REGS_PER_T)/4)
+  // so the store loop interleaves each per-uint4 shmem load with its write-through gmem store (higher
+  // store-side memory-level parallelism / DRAM utilization) instead of buffering the whole tile in
+  // registers before storing. Swept 4/8/16 under the pipeline -- 4 is the tuned winner.
+  static constexpr int max_regs_per_thread_override = 4;
+};
 } // namespace rotate
 } // namespace detail
 CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/tuning/tuning_rotate.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_rotate.cuh
@@ -91,8 +91,15 @@ struct long_algorithm
 {
   static constexpr int tile_bytes = 32 * 1024;
 
-  // TODO: ensure multiple tiles per grab works
-  static constexpr int tiles_per_grab = 1;
+  // Keep dependency chains below the cooperative grid size by this many CTAs.
+  static constexpr int cooperative_grid_safety_margin = 50;
+
+  // Use a closed-form processing order while either side fits within this many tiles.
+  static constexpr int max_direct_dependency_distance = 256;
+
+  static constexpr size_t naive_fallback_min_size     = 1'000'000'000;
+  static constexpr double naive_fallback_max_fraction = 0.3;
+  static constexpr size_t naive_fallback_min_distance_bytes = 500'000'000;
 
   static constexpr int pipeline_stages = 2;
 

--- a/cub/cub/device/dispatch/tuning/tuning_rotate.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_rotate.cuh
@@ -13,106 +13,186 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/atomic>
-#include <cuda/cmath>
+#include <cub/util_device.cuh>
 
-#include <algorithm>
+#include <cuda/__device/arch_traits.h>
+#include <cuda/__device/compute_capability.h>
+#include <cuda/cmath>
+#include <cuda/std/__host_stdlib/ostream>
+#include <cuda/std/algorithm>
+#include <cuda/std/concepts>
+#include <cuda/std/cstddef>
+#include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
-namespace detail
+namespace detail::rotate
 {
-namespace rotate
+struct kernel_policy
 {
-constexpr int WS               = 32; // warp size
-constexpr int BYTES_PER_SECTOR = 32; // cache sector size
-constexpr int REGS_PER_SM      = 65536;
+  int threads_per_block;
+  int blocks_per_sm;
+  int tile_bytes;
+  int pipeline_stages;
+  int max_regs_per_thread;
 
-using device_flag_t = cuda::atomic<int, cuda::thread_scope_device>;
-
-#ifdef __CUDA_ARCH__
-#  if (__CUDA_ARCH__ > 800 && __CUDA_ARCH__ < 900) || __CUDA_ARCH__ >= 1100
-constexpr size_t MAX_TPSM = 1536;
-#  elif __CUDA_ARCH__ == 750
-constexpr size_t MAX_TPSM = 1024;
-#  else
-constexpr size_t MAX_TPSM = 2048;
-#  endif
-
-#  if __CUDA_ARCH__ == 750
-constexpr int SHMEM_PER_SM = 64 * 1024;
-#  elif __CUDA_ARCH__ == 800 || __CUDA_ARCH__ == 870
-constexpr int SHMEM_PER_SM = 164 * 1024;
-#  elif __CUDA_ARCH__ == 860 || __CUDA_ARCH__ == 890 || __CUDA_ARCH__ >= 1200
-constexpr int SHMEM_PER_SM = 100 * 1024;
-#  elif __CUDA_ARCH__ >= 900 && __CUDA_ARCH__ <= 1100
-constexpr int SHMEM_PER_SM = 228 * 1024;
-#  else
-#    error "Unknown device architecture, please define SHMEM_PER_SM for __CUDA_ARCH__"
-#  endif
-
-#  define CUB_ROTATE_LB(x, y) __launch_bounds__(x, y)
-#else
-constexpr int SHMEM_PER_SM = 1;
-constexpr int MAX_TPSM     = 1;
-#  define CUB_ROTATE_LB(x, y)
-#endif // __CUDA_ARCH__
-
-constexpr std::pair<int, int> get_launch_bounds(const int tile_bytes, const int shmem_per_sm, const int max_tpsm)
-{
-  const int BLOCKS_PER_SM = shmem_per_sm / (tile_bytes + 1'000); // extra bytes to ensure no spilling
-  if (BLOCKS_PER_SM <= 0)
+  [[nodiscard]] _CCCL_API constexpr friend bool operator==(const kernel_policy& lhs, const kernel_policy& rhs)
   {
-    return {1, 1}; // shmem too small (e.g. host-side fallback); return safe defaults
+    return lhs.threads_per_block == rhs.threads_per_block && lhs.blocks_per_sm == rhs.blocks_per_sm
+        && lhs.tile_bytes == rhs.tile_bytes && lhs.pipeline_stages == rhs.pipeline_stages
+        && lhs.max_regs_per_thread == rhs.max_regs_per_thread;
   }
 
-  const int BLOCK_SIZE = cuda::prev_power_of_two(max_tpsm / BLOCKS_PER_SM);
-  return {BLOCK_SIZE, BLOCKS_PER_SM};
+  [[nodiscard]] _CCCL_API constexpr friend bool operator!=(const kernel_policy& lhs, const kernel_policy& rhs)
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const kernel_policy& policy)
+  {
+    return os
+        << "kernel_policy { .threads_per_block = " << policy.threads_per_block
+        << ", .blocks_per_sm = " << policy.blocks_per_sm << ", .tile_bytes = " << policy.tile_bytes
+        << ", .pipeline_stages = " << policy.pipeline_stages
+        << ", .max_regs_per_thread = " << policy.max_regs_per_thread << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
+struct short_algorithm_policy
+{
+  kernel_policy kernel;
+  int tiles_per_grab;
+
+  [[nodiscard]] _CCCL_API constexpr friend bool
+  operator==(const short_algorithm_policy& lhs, const short_algorithm_policy& rhs)
+  {
+    return lhs.kernel == rhs.kernel && lhs.tiles_per_grab == rhs.tiles_per_grab;
+  }
+
+  [[nodiscard]] _CCCL_API constexpr friend bool
+  operator!=(const short_algorithm_policy& lhs, const short_algorithm_policy& rhs)
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const short_algorithm_policy& policy)
+  {
+    return os << "short_algorithm_policy { .kernel = " << policy.kernel
+              << ", .tiles_per_grab = " << policy.tiles_per_grab << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
+struct long_algorithm_policy
+{
+  kernel_policy kernel;
+  int cooperative_grid_safety_margin;
+  ::cuda::std::uint32_t max_direct_dependency_distance;
+  ::cuda::std::size_t naive_fallback_min_size;
+  double naive_fallback_max_fraction;
+  ::cuda::std::size_t naive_fallback_min_distance_bytes;
+
+  [[nodiscard]] _CCCL_API constexpr friend bool
+  operator==(const long_algorithm_policy& lhs, const long_algorithm_policy& rhs)
+  {
+    return lhs.kernel == rhs.kernel && lhs.cooperative_grid_safety_margin == rhs.cooperative_grid_safety_margin
+        && lhs.max_direct_dependency_distance == rhs.max_direct_dependency_distance
+        && lhs.naive_fallback_min_size == rhs.naive_fallback_min_size
+        && lhs.naive_fallback_max_fraction == rhs.naive_fallback_max_fraction
+        && lhs.naive_fallback_min_distance_bytes == rhs.naive_fallback_min_distance_bytes;
+  }
+
+  [[nodiscard]] _CCCL_API constexpr friend bool
+  operator!=(const long_algorithm_policy& lhs, const long_algorithm_policy& rhs)
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const long_algorithm_policy& policy)
+  {
+    return os
+        << "long_algorithm_policy { .kernel = " << policy.kernel
+        << ", .cooperative_grid_safety_margin = " << policy.cooperative_grid_safety_margin
+        << ", .max_direct_dependency_distance = " << policy.max_direct_dependency_distance
+        << ", .naive_fallback_min_size = " << policy.naive_fallback_min_size
+        << ", .naive_fallback_max_fraction = " << policy.naive_fallback_max_fraction
+        << ", .naive_fallback_min_distance_bytes = " << policy.naive_fallback_min_distance_bytes << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
+struct rotate_policy
+{
+  short_algorithm_policy short_algorithm;
+  long_algorithm_policy long_algorithm;
+
+  [[nodiscard]] _CCCL_API constexpr friend bool operator==(const rotate_policy& lhs, const rotate_policy& rhs)
+  {
+    return lhs.short_algorithm == rhs.short_algorithm && lhs.long_algorithm == rhs.long_algorithm;
+  }
+
+  [[nodiscard]] _CCCL_API constexpr friend bool operator!=(const rotate_policy& lhs, const rotate_policy& rhs)
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const rotate_policy& policy)
+  {
+    return os << "rotate_policy { .short_algorithm = " << policy.short_algorithm
+              << ", .long_algorithm = " << policy.long_algorithm << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
+#if _CCCL_HAS_CONCEPTS()
+template <typename T>
+concept rotate_policy_selector = policy_selector<T, rotate_policy>;
+#endif // _CCCL_HAS_CONCEPTS()
+
+[[nodiscard]] _CCCL_API constexpr auto make_kernel_policy(
+  ::cuda::compute_capability cc, int tile_bytes, int pipeline_stages, int max_regs_per_thread) -> kernel_policy
+{
+  const auto arch         = ::cuda::arch_traits_for(cc);
+  const int blocks_per_sm = ::cuda::std::max(
+    static_cast<int>(arch.max_shared_memory_per_multiprocessor) / (tile_bytes * pipeline_stages + 1'000), 1);
+  const int threads_per_block = ::cuda::prev_power_of_two(
+    ::cuda::std::min(arch.max_threads_per_multiprocessor / blocks_per_sm, arch.max_threads_per_block));
+  return {threads_per_block, blocks_per_sm, tile_bytes, pipeline_stages, max_regs_per_thread};
 }
 
-struct short_algorithm
+struct policy_selector
 {
-  static constexpr int tile_bytes = 18 * 1024;
+  [[nodiscard]] _CCCL_API constexpr auto operator()(::cuda::compute_capability cc) const -> rotate_policy
+  {
+    constexpr int short_tile_bytes = 18 * 1024;
+    constexpr int long_tile_bytes  = 32 * 1024;
+    static_assert(short_tile_bytes < long_tile_bytes,
+                  "The short rotate tile must be smaller than the long rotate tile");
 
-  // How many contiguous tiles a CTA grabs at once.
-  static constexpr int tiles_per_grab = 6;
-
-  // Number of shared-memory tile buffers per block.
-  static constexpr int pipeline_stages = 2;
-
-  static constexpr auto launch_bounds = get_launch_bounds(tile_bytes * pipeline_stages, SHMEM_PER_SM, MAX_TPSM);
-  static constexpr int block_size     = launch_bounds.first;
-  static constexpr int blocks_per_sm  = launch_bounds.second;
-
-  // Limit the number of registers per thread when copying from shared to global.
-  static constexpr int max_regs_per_thread_override = 4;
+    return rotate_policy{
+      short_algorithm_policy{
+        /* .kernel = */ make_kernel_policy(
+          cc, /* tile_bytes = */ short_tile_bytes, /* pipeline_stages = */ 2, /* max_regs_per_thread = */ 4),
+        /* .tiles_per_grab = */ 6,
+      },
+      long_algorithm_policy{
+        /* .kernel = */ make_kernel_policy(
+          cc, /* tile_bytes = */ long_tile_bytes, /* pipeline_stages = */ 2, /* max_regs_per_thread = */ 4),
+        /* .cooperative_grid_safety_margin = */ 50,
+        /* .max_direct_dependency_distance = */ 256,
+        /* .naive_fallback_min_size = */ 1'000'000'000,
+        /* .naive_fallback_max_fraction = */ 0.3,
+        /* .naive_fallback_min_distance_bytes = */ 500'000'000,
+      }};
+  }
 };
 
-struct long_algorithm
-{
-  static constexpr int tile_bytes = 32 * 1024;
-
-  // Keep dependency chains below the cooperative grid size by this many CTAs.
-  static constexpr int cooperative_grid_safety_margin = 50;
-
-  // Use a closed-form processing order while either side fits within this many tiles.
-  static constexpr int max_direct_dependency_distance = 256;
-
-  static constexpr size_t naive_fallback_min_size     = 1'000'000'000;
-  static constexpr double naive_fallback_max_fraction = 0.3;
-  static constexpr size_t naive_fallback_min_distance_bytes = 500'000'000;
-
-  static constexpr int pipeline_stages = 2;
-
-  static constexpr auto launch_bounds = get_launch_bounds(tile_bytes * pipeline_stages, SHMEM_PER_SM, MAX_TPSM);
-  static constexpr int block_size     = launch_bounds.first;
-  static constexpr int blocks_per_sm  = launch_bounds.second;
-
-  // Cap the shared->global store register buffer at the BUFFERED_ITERS=1 floor (= min(4, REGS_PER_T)/4)
-  // so the store loop interleaves each per-uint4 shmem load with its write-through gmem store (higher
-  // store-side memory-level parallelism / DRAM utilization) instead of buffering the whole tile in
-  // registers before storing. Swept 4/8/16 under the pipeline -- 4 is the tuned winner.
-  static constexpr int max_regs_per_thread_override = 4;
-};
-} // namespace rotate
-} // namespace detail
+#if _CCCL_HAS_CONCEPTS()
+static_assert(rotate_policy_selector<policy_selector>);
+#endif // _CCCL_HAS_CONCEPTS()
+} // namespace detail::rotate
 CUB_NAMESPACE_END

--- a/cub/test/catch2_test_device_rotate.cu
+++ b/cub/test/catch2_test_device_rotate.cu
@@ -1,0 +1,949 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "insert_nested_NVTX_range_guard.h"
+
+#include <cub/device/device_rotate.cuh>
+
+#include <thrust/equal.h>
+#include <thrust/execution_policy.h>
+
+#include <cuda/cmath>
+
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include <curand.h>
+
+#include <c2h/catch2_test_helper.h>
+
+using namespace cub::detail::rotate;
+
+// ============================================================================
+// Device-side test harness
+// ============================================================================
+
+template <typename T>
+class RotateTestHarness
+{
+public:
+  static constexpr unsigned long long kNoMismatch = ULLONG_MAX;
+
+  RotateTestHarness()
+  {
+    cudaStreamCreate(&stream_);
+    curandCreateGenerator(&gen_, CURAND_RNG_PSEUDO_DEFAULT);
+    curandSetPseudoRandomGeneratorSeed(gen_, 12345ull);
+    curandSetStream(gen_, stream_);
+  }
+
+  ~RotateTestHarness()
+  {
+    if (d_reference_)
+    {
+      cudaFreeAsync(d_reference_, stream_);
+    }
+    if (d_workspace_)
+    {
+      cudaFreeAsync(d_workspace_, stream_);
+    }
+    if (d_tmp_storage_)
+    {
+      cudaFreeAsync(d_tmp_storage_, stream_);
+    }
+    curandDestroyGenerator(gen_);
+    cudaStreamDestroy(stream_);
+  }
+
+  RotateTestHarness(RotateTestHarness const&)            = delete;
+  RotateTestHarness& operator=(RotateTestHarness const&) = delete;
+
+  void prepare(size_t size, size_t rot_dist, int unaligned_elems)
+  {
+    if (rot_dist >= size)
+    {
+      rot_dist %= size;
+    }
+    size_            = size;
+    rot_dist_        = rot_dist;
+    unaligned_elems_ = unaligned_elems;
+
+    constexpr size_t kAlignT =
+      sizeof(T) >= sizeof(uint32_t)
+        ? 1
+        : (sizeof(uint32_t) % sizeof(T) == 0 ? sizeof(uint32_t) / sizeof(T) : sizeof(uint32_t));
+    size_t const buf_count = cuda::round_up(size + BYTES_PER_SECTOR, kAlignT);
+    realloc_async(reinterpret_cast<void**>(&d_reference_), buf_count * sizeof(T));
+    realloc_async(reinterpret_cast<void**>(&d_workspace_), buf_count * sizeof(T));
+
+    // Query pass: determine temp storage size and fill state
+    tmp_storage_bytes_ = 0;
+    cub::DeviceRotate::Rotate(nullptr, tmp_storage_bytes_, state_, workspace_ptr(), size, rot_dist, stream_);
+    realloc_async(reinterpret_cast<void**>(&d_tmp_storage_), tmp_storage_bytes_);
+
+    size_t const count_u32 = buf_count * sizeof(T) / sizeof(uint32_t);
+    curandGenerate(gen_, reinterpret_cast<uint32_t*>(d_reference_), count_u32);
+  }
+
+  T* reference_ptr() const
+  {
+    return d_reference_ + unaligned_elems_;
+  }
+  T* workspace_ptr() const
+  {
+    return d_workspace_ + unaligned_elems_;
+  }
+
+  void reset_workspace()
+  {
+    cudaMemcpyAsync(workspace_ptr(), reference_ptr(), size_ * sizeof(T), cudaMemcpyDeviceToDevice, stream_);
+  }
+
+  void rotate(cudaStream_t stream)
+  {
+    cub::DeviceRotate::Rotate(d_tmp_storage_, tmp_storage_bytes_, state_, workspace_ptr(), size_, rot_dist_, stream);
+  }
+
+  unsigned long long verify()
+  {
+    auto policy        = thrust::cuda::par.on(stream_);
+    T* ws              = workspace_ptr();
+    T* ref             = reference_ptr();
+    size_t const tail  = size_ - rot_dist_;
+    bool const eq_head = thrust::equal(policy, ws, ws + tail, ref + rot_dist_);
+    bool const eq_tail = thrust::equal(policy, ws + tail, ws + size_, ref);
+    if (eq_head && eq_tail)
+    {
+      return kNoMismatch;
+    }
+    else
+    {
+      std::vector<T> h_ws(size_), h_ref(size_);
+      cudaMemcpyAsync(h_ws.data(), ws, size_ * sizeof(T), cudaMemcpyDeviceToHost, stream_);
+      cudaMemcpyAsync(h_ref.data(), ref, size_ * sizeof(T), cudaMemcpyDeviceToHost, stream_);
+      cudaStreamSynchronize(stream_);
+      for (size_t i = 0; i < size_; ++i)
+      {
+        size_t const expected = (i + rot_dist_) % size_;
+        if (h_ws[i] != h_ref[expected])
+        {
+          return i;
+        }
+      }
+      throw std::runtime_error("Thrust found a mismatch, but manual verification did not!");
+    }
+  }
+
+  unsigned long long run_and_verify()
+  {
+    reset_workspace();
+    rotate(stream_);
+    return verify();
+  }
+
+private:
+  void realloc_async(void** ptr, size_t bytes)
+  {
+    if (*ptr)
+    {
+      cudaFreeAsync(*ptr, stream_);
+      cudaStreamSynchronize(stream_);
+      cudaMemPool_t pool;
+      cudaDeviceGetDefaultMemPool(&pool, 0);
+      cudaMemPoolTrimTo(pool, 0);
+    }
+    cudaMallocAsync(ptr, bytes, stream_);
+  }
+
+  cudaStream_t stream_;
+  curandGenerator_t gen_;
+  T* d_reference_           = nullptr;
+  T* d_workspace_           = nullptr;
+  void* d_tmp_storage_      = nullptr;
+  int unaligned_elems_      = 0;
+  size_t size_              = 0;
+  size_t rot_dist_          = 0;
+  size_t tmp_storage_bytes_ = 0;
+  cub::RotateState_t state_;
+};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+struct EdgeCase
+{
+  size_t arr_size;
+  size_t rot_dist;
+  int unaligned_elems;
+};
+
+template <typename T>
+void check_edge_case(RotateTestHarness<T>& harness, EdgeCase const& tc)
+{
+  harness.prepare(tc.arr_size, tc.rot_dist, tc.unaligned_elems);
+  auto const mismatch = harness.run_and_verify();
+  REQUIRE(mismatch == harness.kNoMismatch);
+}
+
+template <typename T>
+void run_random_tests(
+  RotateTestHarness<T>& harness, size_t min_size, size_t max_size, size_t min_rot, size_t max_rot, size_t num_tests)
+{
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<size_t> size_dist(min_size, max_size);
+  std::uniform_int_distribution<size_t> rot_dist(min_rot, max_rot);
+  std::uniform_int_distribution<int> unaligned_dist(0, static_cast<int>(BYTES_PER_SECTOR / sizeof(T)) - 1);
+
+  for (size_t i = 0; i < num_tests; ++i)
+  {
+    harness.prepare(size_dist(gen), rot_dist(gen), unaligned_dist(gen));
+    auto const mismatch = harness.run_and_verify();
+    REQUIRE(mismatch == harness.kNoMismatch);
+  }
+}
+
+// ============================================================================
+// Edge case tests
+// ============================================================================
+
+using rotate_types = c2h::type_list<uint8_t, uint16_t, uint32_t, uint64_t, uchar3>;
+
+C2H_TEST("DeviceRotate trivial and degenerate cases", "[device][rotate]", rotate_types)
+{
+  using T            = c2h::get<0, TestType>;
+  constexpr size_t S = BYTES_PER_SECTOR / sizeof(T);
+
+  RotateTestHarness<T> harness;
+
+  std::vector<EdgeCase> cases = {
+    {2, 1, 0},
+    {2, 1, 1},
+    {3, 1, 0},
+    {3, 2, 0},
+    {S, 1, 0},
+    {S, S - 1, 0},
+    {S + 1, 1, 0},
+    {S + 1, S, 0},
+  };
+
+  for (auto const& tc : cases)
+  {
+    check_edge_case(harness, tc);
+  }
+}
+
+C2H_TEST("DeviceRotate no-op and modular reduction", "[device][rotate]", rotate_types)
+{
+  using T = c2h::get<0, TestType>;
+
+  RotateTestHarness<T> harness;
+
+  std::vector<EdgeCase> cases = {
+    {100, 0, 0},
+    {100, 100, 0},
+    {100, 250, 0},
+    {100, 200, 0},
+    {100, 300, 0},
+    {100, 101, 0},
+    {100, 99, 0},
+  };
+
+  for (auto const& tc : cases)
+  {
+    check_edge_case(harness, tc);
+  }
+}
+
+C2H_TEST("DeviceRotate short algorithm boundary", "[device][rotate]", rotate_types)
+{
+  using T             = c2h::get<0, TestType>;
+  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+
+  RotateTestHarness<T> harness;
+
+  std::vector<EdgeCase> cases = {
+    {TS + 1, TS, 0},
+    {TS + 1, TS, 1},
+    {TS + 1, TS, 31},
+    {2 * TS, TS, 0},
+    {2 * TS, TS - 1, 0},
+    {2 * TS, TS + 1, 0},
+    {2 * TS, TS + 1, 1},
+    {2 * TS, TS + 1, 16},
+    {2 * TS, TS + 1, 31},
+  };
+
+  for (auto const& tc : cases)
+  {
+    check_edge_case(harness, tc);
+  }
+}
+
+C2H_TEST("DeviceRotate short rotate_tiny path", "[device][rotate]", rotate_types)
+{
+  using T             = c2h::get<0, TestType>;
+  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+
+  RotateTestHarness<T> harness;
+
+  std::vector<EdgeCase> cases = {
+    {TS, 1, 0},
+    {TS, TS - 1, 0},
+    {TS, TS / 2, 0},
+    {2 * TS - 1, TS, 0},
+    {2 * TS, TS, 0},
+    {2 * TS + 1, TS, 0},
+    {TS + 1, TS / 2 + 1, 0},
+    {TS + 1, TS / 2, 0},
+  };
+
+  for (auto const& tc : cases)
+  {
+    check_edge_case(harness, tc);
+  }
+}
+
+C2H_TEST("DeviceRotate short head_size alignments", "[device][rotate]", rotate_types)
+{
+  using T             = c2h::get<0, TestType>;
+  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+
+  RotateTestHarness<T> harness;
+
+  std::vector<EdgeCase> cases = {
+    {2 * TS, 100, 0},
+    {2 * TS, 100, 1},
+    {2 * TS, 100, 8},
+    {2 * TS, 100, 15},
+    {2 * TS, 100, 16},
+    {2 * TS, 100, 24},
+    {2 * TS, 100, 31},
+  };
+
+  for (auto const& tc : cases)
+  {
+    check_edge_case(harness, tc);
+  }
+}
+
+C2H_TEST("DeviceRotate short overcopy and tile distribution", "[device][rotate]", rotate_types)
+{
+  using T             = c2h::get<0, TestType>;
+  constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
+  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+
+  RotateTestHarness<T> harness;
+
+  std::vector<EdgeCase> cases = {
+    // overcopy alignment
+    {2 * TS, S, 0},
+    {2 * TS, S + 1, 0},
+    {2 * TS, 2 * S - 1, 0},
+    {2 * TS, S / 2, 0},
+    // get_bytes_to_load remainder
+    {TS + 1, 1, 0},
+    {2 * TS + 1, 1, 0},
+    {3 * TS + 1, 1, 0},
+    {2 * TS + 100, 100, 0},
+    {TS + 32, 1, 1},
+    {2 * TS + 32, 1, 1},
+    // tile distribution across SMs
+    {TS + S + 1, 1, 0},
+    {2 * TS + S + 1, 1, 0},
+    // last tile remainder sizes
+    {TS + S + 2, 1, 0},
+    {TS + S + S, 1, 0},
+    {2 * TS, 1, 0},
+    {2 * TS + 1, 1, 0},
+  };
+
+  for (auto const& tc : cases)
+  {
+    check_edge_case(harness, tc);
+  }
+}
+
+C2H_TEST("DeviceRotate long algorithm cases", "[device][rotate]", rotate_types)
+{
+  using T             = c2h::get<0, TestType>;
+  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+
+  RotateTestHarness<T> harness;
+
+  std::vector<EdgeCase> cases = {
+    // minimum cases
+    {2 * TS + 1, TS + 1, 0},
+    {2 * TS + 1, TS + 1, 1},
+    {2 * TS + 1, TS + 1, 16},
+    {2 * TS + 1, TS + 1, 31},
+    {3 * TS, TS + 1, 0},
+    {3 * TS, 2 * TS - 1, 0},
+    // exactly 1 positive tile
+    {2 * TS + 1, TS + 1, 0},
+    {2 * TS + 2, TS + 1, 0},
+    // tile remainder cases
+    {3 * TS + 1, TS + 1, 0},
+    {3 * TS + 2, TS + 1, 0},
+    {3 * TS, 2 * TS + 1, 0},
+    {3 * TS, 2 * TS, 0},
+    // neg_head_size variations
+    {10 * TS, 5 * TS + 1, 0},
+    {10 * TS, 5 * TS + 16, 0},
+    {10 * TS + 1, 5 * TS + 1, 0},
+    {10 * TS + 17, 5 * TS + 1, 1},
+    // exact multiples of TILE_SIZE
+    {2 * TS, TS + 1, 0},
+    {3 * TS, TS, 0},
+    {3 * TS, 2 * TS, 0},
+    {4 * TS, 2 * TS + 1, 0},
+    {4 * TS, 2 * TS + 1, 1},
+  };
+
+  for (auto const& tc : cases)
+  {
+    check_edge_case(harness, tc);
+  }
+}
+
+C2H_TEST("DeviceRotate long all alignments at medium scale", "[device][rotate]", rotate_types)
+{
+  using T = c2h::get<0, TestType>;
+
+  RotateTestHarness<T> harness;
+
+  std::vector<EdgeCase> cases = {
+    {100'000, 50'000, 0},
+    {100'000, 50'000, 1},
+    {100'000, 50'000, 8},
+    {100'000, 50'000, 15},
+    {100'000, 50'000, 16},
+    {100'000, 50'000, 24},
+    {100'000, 50'000, 31},
+  };
+
+  for (auto const& tc : cases)
+  {
+    check_edge_case(harness, tc);
+  }
+}
+
+C2H_TEST("DeviceRotate head consumes positive region fallback", "[device][rotate]", rotate_types)
+{
+  using T = c2h::get<0, TestType>;
+
+  RotateTestHarness<T> harness;
+
+  std::vector<EdgeCase> cases = {
+    {100'000, 99'999, 1},
+    {100'000, 99'999, 15},
+    {100'000, 99'999, 31},
+    {100'000, 99'970, 1},
+    {100'000, 99'969, 1},
+    {100'000, 99'968, 1},
+    {100'000, 99'999, 0},
+  };
+
+  for (auto const& tc : cases)
+  {
+    check_edge_case(harness, tc);
+  }
+}
+
+C2H_TEST("DeviceRotate maximal and near-boundary rotations", "[device][rotate]", rotate_types)
+{
+  using T             = c2h::get<0, TestType>;
+  constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
+  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+
+  RotateTestHarness<T> harness;
+
+  std::vector<EdgeCase> cases = {
+    {1'000, 999, 0},
+    {1'000, 999, 1},
+    {10 * TS, 10 * TS - 1, 0},
+    {10 * TS, 10 * TS - 1, 1},
+    {100'000, 60'000, 0},
+    {100'000, 60'000, 1},
+    {100'000, 60'000, 31},
+    {200'000, 200'000 - 1, 1},
+    {200'000, 200'000 - S, 1},
+    {200'000, 200'000 - S + 1, 1},
+    {200'000, 200'000 - S - 1, 1},
+    // naive algorithm path
+    {100'000, 99'000, 0},
+    {100'000, 99'000, 1},
+    // sizes near BYTES_PER_SECTOR
+    {S - 1, 1, 0},
+    {S - 1, S - 2, 0},
+    {S, S / 2, 0},
+    {S + 1, S / 2, 0},
+    {2 * S, S, 0},
+    {2 * S + 1, S, 0},
+    {2 * S, 1, 0},
+  };
+
+  for (auto const& tc : cases)
+  {
+    check_edge_case(harness, tc);
+  }
+}
+
+C2H_TEST("DeviceRotate large-scale tests", "[device][rotate]", rotate_types)
+{
+  using T             = c2h::get<0, TestType>;
+  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+
+  RotateTestHarness<T> harness;
+
+  std::vector<EdgeCase> cases = {
+    {1'000'000, TS + 1, 0},
+    {1'000'000, TS + 1, 1},
+    {1'000'000, 500'000, 0},
+    {1'000'000, 500'000, 1},
+    {1'000'000, 999'999, 0},
+    {1'000'000, 999'999, 1},
+  };
+
+  for (auto const& tc : cases)
+  {
+    check_edge_case(harness, tc);
+  }
+}
+
+// ============================================================================
+// size == 0 and size == 1 (bypass harness which has its own % size)
+// ============================================================================
+
+C2H_TEST("DeviceRotate size zero and one", "[device][rotate]", rotate_types)
+{
+  using T = c2h::get<0, TestType>;
+
+  cudaStream_t stream;
+  cudaStreamCreate(&stream);
+
+  size_t temp_bytes = 42;
+  cub::RotateState_t state{};
+
+  // size == 0, rotate_distance == 0
+  REQUIRE(cub::DeviceRotate::Rotate(nullptr, temp_bytes, state, static_cast<T*>(nullptr), 0, 0, stream) == cudaSuccess);
+  REQUIRE(temp_bytes == 0);
+
+  // size == 0, rotate_distance > 0 (was UB before fix)
+  temp_bytes = 42;
+  REQUIRE(cub::DeviceRotate::Rotate(nullptr, temp_bytes, state, static_cast<T*>(nullptr), 0, 5, stream) == cudaSuccess);
+  REQUIRE(temp_bytes == 0);
+
+  // size == 0, rotate_distance very large
+  temp_bytes = 42;
+  REQUIRE(
+    cub::DeviceRotate::Rotate(nullptr, temp_bytes, state, static_cast<T*>(nullptr), 0, 999, stream) == cudaSuccess);
+  REQUIRE(temp_bytes == 0);
+
+  // size == 1 — rotation of a single element is always a no-op
+  T* d_buf = nullptr;
+  cudaMallocAsync(&d_buf, sizeof(T), stream);
+  T val = {};
+  cudaMemcpyAsync(d_buf, &val, sizeof(T), cudaMemcpyHostToDevice, stream);
+
+  temp_bytes = 42;
+  REQUIRE(cub::DeviceRotate::Rotate(nullptr, temp_bytes, state, d_buf, 1, 0, stream) == cudaSuccess);
+  REQUIRE(temp_bytes == 0);
+
+  temp_bytes = 42;
+  REQUIRE(cub::DeviceRotate::Rotate(nullptr, temp_bytes, state, d_buf, 1, 1, stream) == cudaSuccess);
+  REQUIRE(temp_bytes == 0);
+
+  temp_bytes = 42;
+  REQUIRE(cub::DeviceRotate::Rotate(nullptr, temp_bytes, state, d_buf, 1, 100, stream) == cudaSuccess);
+  REQUIRE(temp_bytes == 0);
+
+  cudaFreeAsync(d_buf, stream);
+  cudaStreamSynchronize(stream);
+  cudaStreamDestroy(stream);
+}
+
+// ============================================================================
+// Long algorithm: 1-element positive region (no naive fallback)
+// ============================================================================
+
+C2H_TEST("DeviceRotate long single-element positive region", "[device][rotate]", rotate_types)
+{
+  using T             = c2h::get<0, TestType>;
+  constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
+  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+
+  RotateTestHarness<T> harness;
+
+  std::vector<EdgeCase> cases = {
+    // pos region = 1 element, head_size = 0 (aligned) — 1 pos tile with 1 elem
+    {TS + 2, TS + 1, 0},
+    // pos region = 2 elements
+    {TS + 3, TS + 1, 0},
+    // pos region = S elements (one sector worth)
+    {TS + 1 + S, TS + 1, 0},
+    // with alignment offsets
+    {TS + 2, TS + 1, 1},
+    {TS + 3, TS + 1, 1},
+  };
+
+  for (auto const& tc : cases)
+  {
+    check_edge_case(harness, tc);
+  }
+}
+
+// ============================================================================
+// Short: zero overcopy combined with non-zero head_size
+// ============================================================================
+
+C2H_TEST("DeviceRotate short zero overcopy with head", "[device][rotate]", rotate_types)
+{
+  using T             = c2h::get<0, TestType>;
+  constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
+  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+
+  RotateTestHarness<T> harness;
+
+  // rot_dist is an exact multiple of ELEMS_PER_SECTOR → overcopy = 0
+  // combined with various non-zero head_size values
+  std::vector<EdgeCase> cases = {
+    {2 * TS, S, 1},
+    {2 * TS, S, 8},
+    {2 * TS, S, 15},
+    {2 * TS, S, 16},
+    {2 * TS, S, 31},
+    {2 * TS, 2 * S, 1},
+    {2 * TS, 2 * S, 31},
+    {3 * TS, S, 1},
+    {3 * TS, S, 31},
+  };
+
+  for (auto const& tc : cases)
+  {
+    check_edge_case(harness, tc);
+  }
+}
+
+// ============================================================================
+// Long: both head_size > 0 and neg_head_size > 0 simultaneously
+// ============================================================================
+
+C2H_TEST("DeviceRotate long dual head alignment", "[device][rotate]", rotate_types)
+{
+  using T             = c2h::get<0, TestType>;
+  constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
+  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+
+  RotateTestHarness<T> harness;
+
+  // Sweep alignment offsets that produce non-zero pos head, checking that
+  // neg_head is also exercised (depends on array size and rot_dist alignment).
+  std::vector<EdgeCase> cases = {
+    {5 * TS, 2 * TS + 1, 1},
+    {5 * TS, 2 * TS + 1, 3},
+    {5 * TS, 2 * TS + 1, 7},
+    {5 * TS, 2 * TS + 1, 15},
+    {5 * TS, 2 * TS + 1, 31},
+    {5 * TS + 1, 2 * TS + 3, 1},
+    {5 * TS + 1, 2 * TS + 3, 7},
+    {5 * TS + 1, 2 * TS + 3, 15},
+    {5 * TS + 1, 2 * TS + 3, 31},
+    // odd sizes that stress both heads
+    {7 * TS + 13, 3 * TS + 7, 5},
+    {7 * TS + 13, 3 * TS + 7, 11},
+    {7 * TS + 13, 3 * TS + 7, 29},
+  };
+
+  for (auto const& tc : cases)
+  {
+    check_edge_case(harness, tc);
+  }
+}
+
+// ============================================================================
+// Short: single main tile (num_main_tiles == 1)
+// ============================================================================
+
+C2H_TEST("DeviceRotate short single tile with alignments", "[device][rotate]", rotate_types)
+{
+  using T             = c2h::get<0, TestType>;
+  constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
+  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+
+  RotateTestHarness<T> harness;
+
+  std::vector<EdgeCase> cases = {
+    // minimal: positive region = 1 element beyond head → 1 tile
+    {TS + S + 1, S, 0},
+    {TS + S + 2, S, 0},
+    {TS + S + S, S, 0},
+    // with head_size via alignment offset
+    {TS + S + 1, S, 1},
+    {TS + S + 1, S, 15},
+    {TS + S + 1, S, 31},
+    // rot_dist = 1, various sizes producing exactly 1 tile
+    {TS + 1, 1, 0},
+    {TS + 1, 1, 1},
+    {TS + 1, 1, 15},
+    {TS + 1, 1, 31},
+  };
+
+  for (auto const& tc : cases)
+  {
+    check_edge_case(harness, tc);
+  }
+}
+
+// ============================================================================
+// Naive algorithm: explicit coverage of cases that produce high dep distance
+// ============================================================================
+
+C2H_TEST("DeviceRotate naive algorithm fallback", "[device][rotate]", rotate_types)
+{
+  using T             = c2h::get<0, TestType>;
+  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+
+  RotateTestHarness<T> harness;
+
+  // rot_dist close to size/2 or large relative to size → high dep distance
+  std::vector<EdgeCase> cases = {
+    {100'000, 99'000, 0},
+    {100'000, 99'000, 1},
+    {100'000, 99'000, 15},
+    {100'000, 99'000, 31},
+    {50'000, 49'000, 0},
+    {50'000, 49'000, 1},
+    // rot_dist near size — always naive via head-consumes-positive fallback
+    {200'000, 199'999, 1},
+    {200'000, 199'999, 15},
+    {200'000, 199'990, 1},
+  };
+
+  for (auto const& tc : cases)
+  {
+    check_edge_case(harness, tc);
+  }
+}
+
+// ============================================================================
+// Short: rot_dist = 1 with large arrays and non-zero alignment
+// ============================================================================
+
+C2H_TEST("DeviceRotate short rot_dist one large array", "[device][rotate]", rotate_types)
+{
+  using T             = c2h::get<0, TestType>;
+  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+
+  RotateTestHarness<T> harness;
+
+  std::vector<EdgeCase> cases = {
+    {1'000'000, 1, 0},
+    {1'000'000, 1, 1},
+    {1'000'000, 1, 15},
+    {1'000'000, 1, 31},
+    {500'000, 1, 0},
+    {500'000, 1, 7},
+  };
+
+  for (auto const& tc : cases)
+  {
+    check_edge_case(harness, tc);
+  }
+}
+
+// ============================================================================
+// Long: rot_dist just over TILE_SIZE boundary with all alignment offsets
+// ============================================================================
+
+C2H_TEST("DeviceRotate long boundary sweep alignments", "[device][rotate]", rotate_types)
+{
+  using T             = c2h::get<0, TestType>;
+  constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
+  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+
+  RotateTestHarness<T> harness;
+
+  std::vector<EdgeCase> cases = {
+    // rot_dist = TS + 1 (minimal long) with every alignment
+    {3 * TS, TS + 1, 0},
+    {3 * TS, TS + 1, 1},
+    {3 * TS, TS + 1, 3},
+    {3 * TS, TS + 1, 7},
+    {3 * TS, TS + 1, 8},
+    {3 * TS, TS + 1, 15},
+    {3 * TS, TS + 1, 16},
+    {3 * TS, TS + 1, 24},
+    {3 * TS, TS + 1, 31},
+    // rot_dist = TS + 2
+    {3 * TS, TS + 2, 0},
+    {3 * TS, TS + 2, 1},
+    {3 * TS, TS + 2, 31},
+    // rot_dist = TS + S (sector-aligned long distance)
+    {4 * TS, TS + S, 0},
+    {4 * TS, TS + S, 1},
+    {4 * TS, TS + S, 31},
+  };
+
+  for (auto const& tc : cases)
+  {
+    check_edge_case(harness, tc);
+  }
+}
+
+// ============================================================================
+// Long: exact tile-multiple regions (no remainder tiles)
+// ============================================================================
+
+C2H_TEST("DeviceRotate long exact tile multiples", "[device][rotate]", rotate_types)
+{
+  using T             = c2h::get<0, TestType>;
+  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+
+  RotateTestHarness<T> harness;
+
+  std::vector<EdgeCase> cases = {
+    // Both regions exact multiples of TILE_SIZE (no partial tiles)
+    {4 * TS, 2 * TS, 0},
+    {6 * TS, 2 * TS, 0},
+    {6 * TS, 3 * TS, 0},
+    {6 * TS, 4 * TS, 0},
+    // With alignment
+    {4 * TS, 2 * TS, 1},
+    {4 * TS, 2 * TS, 31},
+    {6 * TS, 3 * TS, 1},
+    {6 * TS, 3 * TS, 15},
+  };
+
+  for (auto const& tc : cases)
+  {
+    check_edge_case(harness, tc);
+  }
+}
+
+// ============================================================================
+// Sizes near and beyond UINT32_MAX — stress uint32_t tile counts, BFS
+// ordering, and size_t arithmetic throughout the pipeline.
+//
+// The harness needs ~3× the array size in GPU memory (reference + workspace +
+// temp).  We query free memory and skip individual cases that would exceed
+// one-third of the available pool.
+// ============================================================================
+
+inline size_t get_free_bytes()
+{
+  size_t free_bytes = 0, total_bytes = 0;
+  cudaMemGetInfo(&free_bytes, &total_bytes);
+  return free_bytes;
+}
+
+TEST_CASE("DeviceRotate sizes near UINT32_MAX", "[device][rotate]")
+{
+  using T             = uint8_t;
+  constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
+  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+
+  constexpr size_t U32MAX = static_cast<size_t>(std::numeric_limits<uint32_t>::max());
+
+  // Each test case needs ~3 * size * sizeof(T) bytes of GPU memory.
+  size_t const max_elems = get_free_bytes() / (3 * sizeof(T));
+
+  RotateTestHarness<T> harness;
+
+  std::vector<EdgeCase> cases = {
+    // --- Just below UINT32_MAX ---
+    {U32MAX - 1, 1, 0},
+    {U32MAX - 1, 1, 1},
+    {U32MAX - 1, TS, 0},
+    {U32MAX - 1, TS - 1, 0},
+    {U32MAX - 1, TS + 1, 0},
+    {U32MAX - 1, TS + 1, 1},
+    {U32MAX - 1, U32MAX / 2, 0},
+    {U32MAX - 1, U32MAX / 2, 1},
+
+    // --- Exactly UINT32_MAX ---
+    {U32MAX, 1, 0},
+    {U32MAX, 1, 1},
+    {U32MAX, TS, 0},
+    {U32MAX, TS + 1, 0},
+    {U32MAX, TS + 1, 1},
+    {U32MAX, U32MAX - 1, 0},
+    {U32MAX, U32MAX - 1, 1},
+
+    // --- Just above UINT32_MAX ---
+    {U32MAX + 1, 1, 0},
+    {U32MAX + 1, 1, 1},
+    {U32MAX + 1, TS, 0},
+    {U32MAX + 1, TS + 1, 0},
+    {U32MAX + 1, TS + 1, 1},
+    {U32MAX + 1, U32MAX, 0},
+    {U32MAX + 1, U32MAX, 1},
+
+    // --- Modular reduction with size > UINT32_MAX ---
+    {U32MAX + 1, U32MAX + 2, 0}, // rot > size → rot %= size = 1
+    {U32MAX + 100, U32MAX + 200, 0}, // rot > size → rot %= size = 100
+
+    // --- rot_dist near UINT32_MAX with moderate size ---
+    {U32MAX, U32MAX / 2 + 1, 0},
+    {U32MAX, U32MAX / 2 + 1, 1},
+
+    // --- Size exactly 2 * UINT32_MAX (if memory allows) ---
+    {2 * U32MAX, 1, 0},
+    {2 * U32MAX, TS + 1, 0},
+    {2 * U32MAX, U32MAX, 0},
+  };
+
+  for (auto const& tc : cases)
+  {
+    if (tc.arr_size > max_elems)
+    {
+      continue;
+    }
+    check_edge_case(harness, tc);
+  }
+}
+
+inline size_t get_max_test_bytes()
+{
+  size_t free_bytes, total_bytes;
+  cudaMemGetInfo(&free_bytes, &total_bytes);
+  return std::min(free_bytes / 3, static_cast<size_t>(1) * 1024 * 1024 * 1024);
+}
+
+// TODO currently trimmed to take less than 2 minutes in total
+C2H_TEST("DeviceRotate random short tests", "[device][rotate]", rotate_types)
+{
+  using T                = c2h::get<0, TestType>;
+  constexpr size_t TS    = rotate_short::TILE_BYTES / sizeof(T);
+  size_t const max_elems = get_max_test_bytes() / sizeof(T);
+
+  RotateTestHarness<T> harness;
+
+  for (size_t n = 1; n < max_elems; n *= 10)
+  {
+    size_t const max_size = std::min(10 * n, max_elems);
+    run_random_tests(harness, n, max_size, 1, 1'000, 5);
+    run_random_tests(harness, n, max_size, 1'000, TS, 5);
+  }
+}
+
+C2H_TEST("DeviceRotate random long tests", "[device][rotate]", rotate_types)
+{
+  using T                = c2h::get<0, TestType>;
+  constexpr size_t TS    = rotate_short::TILE_BYTES / sizeof(T);
+  size_t const max_elems = get_max_test_bytes() / sizeof(T);
+
+  RotateTestHarness<T> harness;
+
+  for (size_t n = TS; n < max_elems; n *= 10)
+  {
+    for (size_t k = TS; k < n; k *= 10)
+    {
+      run_random_tests(harness, n, std::min(10 * n, max_elems), k, 10 * k, 5);
+    }
+  }
+}
+

--- a/cub/test/catch2_test_device_rotate.cu
+++ b/cub/test/catch2_test_device_rotate.cu
@@ -184,8 +184,12 @@ template <typename T>
 void check_edge_case(RotateTestHarness<T>& harness, EdgeCase const& tc)
 {
   harness.prepare(tc.arr_size, tc.rot_dist, tc.unaligned_elems);
-  auto const mismatch = harness.run_and_verify();
-  REQUIRE(mismatch == harness.kNoMismatch);
+  auto const mismatch_left = harness.run_and_verify();
+  REQUIRE(mismatch_left == harness.kNoMismatch);
+
+  harness.prepare(tc.arr_size, tc.arr_size - (tc.rot_dist % tc.arr_size), tc.unaligned_elems);
+  auto const mismatch_right = harness.run_and_verify();
+  REQUIRE(mismatch_right == harness.kNoMismatch);
 }
 
 template <typename T>
@@ -200,9 +204,7 @@ void run_random_tests(
 
   for (size_t i = 0; i < num_tests; ++i)
   {
-    harness.prepare(size_dist(gen), rot_dist(gen), unaligned_dist(gen));
-    auto const mismatch = harness.run_and_verify();
-    REQUIRE(mismatch == harness.kNoMismatch);
+    check_edge_case(harness, {size_dist(gen), rot_dist(gen), unaligned_dist(gen)});
   }
 }
 
@@ -431,7 +433,24 @@ C2H_TEST("DeviceRotate long all alignments at medium scale", "[device][rotate]",
   }
 }
 
-C2H_TEST("DeviceRotate head consumes positive region fallback", "[device][rotate]", rotate_types)
+TEST_CASE("DeviceRotate positive-small ordering alignment boundary", "[device][rotate]")
+{
+  constexpr size_t size            = 16'711'682;
+  constexpr size_t rotate_distance = size / 2;
+  constexpr uint32_t head_size     = 1;
+
+  auto const state = bfs_visit_order<uint8_t>(size, rotate_distance, head_size);
+  REQUIRE(state.ordering_.size() == 511);
+  REQUIRE(state.ordering_[0] == 0);
+  REQUIRE(state.ordering_[1] == 1);
+  REQUIRE(state.ordering_[2] == 2);
+  REQUIRE(state.max_distance_ == 256);
+
+  RotateTestHarness<uint8_t> harness;
+  check_edge_case(harness, {size, rotate_distance, 31});
+}
+
+C2H_TEST("DeviceRotate right short near-end alignments", "[device][rotate]", rotate_types)
 {
   using T = c2h::get<0, TestType>;
 
@@ -473,7 +492,6 @@ C2H_TEST("DeviceRotate maximal and near-boundary rotations", "[device][rotate]",
     {200'000, 200'000 - S, 1},
     {200'000, 200'000 - S + 1, 1},
     {200'000, 200'000 - S - 1, 1},
-    // naive algorithm path
     {100'000, 99'000, 0},
     {100'000, 99'000, 1},
     // sizes near BYTES_PER_SECTOR
@@ -567,10 +585,10 @@ C2H_TEST("DeviceRotate size zero and one", "[device][rotate]", rotate_types)
 }
 
 // ============================================================================
-// Long algorithm: 1-element positive region (no naive fallback)
+// Right short rotations just above the tiny-kernel size boundary
 // ============================================================================
 
-C2H_TEST("DeviceRotate long single-element positive region", "[device][rotate]", rotate_types)
+C2H_TEST("DeviceRotate right short just above tiny boundary", "[device][rotate]", rotate_types)
 {
   using T             = c2h::get<0, TestType>;
   constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
@@ -579,11 +597,11 @@ C2H_TEST("DeviceRotate long single-element positive region", "[device][rotate]",
   RotateTestHarness<T> harness;
 
   std::vector<EdgeCase> cases = {
-    // pos region = 1 element, head_size = 0 (aligned) — 1 pos tile with 1 elem
+    // Normalizes to a one-element right rotation.
     {TS + 2, TS + 1, 0},
-    // pos region = 2 elements
+    // Normalizes to a two-element right rotation.
     {TS + 3, TS + 1, 0},
-    // pos region = S elements (one sector worth)
+    // Normalizes to a one-sector right rotation.
     {TS + 1 + S, TS + 1, 0},
     // with alignment offsets
     {TS + 2, TS + 1, 1},
@@ -699,17 +717,17 @@ C2H_TEST("DeviceRotate short single tile with alignments", "[device][rotate]", r
 }
 
 // ============================================================================
-// Naive algorithm: explicit coverage of cases that produce high dep distance
+// Right short rotations at medium array sizes
 // ============================================================================
 
-C2H_TEST("DeviceRotate naive algorithm fallback", "[device][rotate]", rotate_types)
+C2H_TEST("DeviceRotate right short medium near-end distances", "[device][rotate]", rotate_types)
 {
   using T             = c2h::get<0, TestType>;
   constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
 
   RotateTestHarness<T> harness;
 
-  // rot_dist close to size/2 or large relative to size → high dep distance
+  // Each near-end left distance normalizes to a small right distance.
   std::vector<EdgeCase> cases = {
     {100'000, 99'000, 0},
     {100'000, 99'000, 1},
@@ -717,7 +735,7 @@ C2H_TEST("DeviceRotate naive algorithm fallback", "[device][rotate]", rotate_typ
     {100'000, 99'000, 31},
     {50'000, 49'000, 0},
     {50'000, 49'000, 1},
-    // rot_dist near size — always naive via head-consumes-positive fallback
+    // Very small normalized right distances.
     {200'000, 199'999, 1},
     {200'000, 199'999, 15},
     {200'000, 199'990, 1},
@@ -946,4 +964,3 @@ C2H_TEST("DeviceRotate random long tests", "[device][rotate]", rotate_types)
     }
   }
 }
-

--- a/cub/test/catch2_test_device_rotate.cu
+++ b/cub/test/catch2_test_device_rotate.cu
@@ -263,7 +263,7 @@ C2H_TEST("DeviceRotate no-op and modular reduction", "[device][rotate]", rotate_
 C2H_TEST("DeviceRotate short algorithm boundary", "[device][rotate]", rotate_types)
 {
   using T             = c2h::get<0, TestType>;
-  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
 
   RotateTestHarness<T> harness;
 
@@ -288,7 +288,7 @@ C2H_TEST("DeviceRotate short algorithm boundary", "[device][rotate]", rotate_typ
 C2H_TEST("DeviceRotate short rotate_tiny path", "[device][rotate]", rotate_types)
 {
   using T             = c2h::get<0, TestType>;
-  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
 
   RotateTestHarness<T> harness;
 
@@ -312,7 +312,7 @@ C2H_TEST("DeviceRotate short rotate_tiny path", "[device][rotate]", rotate_types
 C2H_TEST("DeviceRotate short head_size alignments", "[device][rotate]", rotate_types)
 {
   using T             = c2h::get<0, TestType>;
-  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
 
   RotateTestHarness<T> harness;
 
@@ -336,7 +336,7 @@ C2H_TEST("DeviceRotate short overcopy and tile distribution", "[device][rotate]"
 {
   using T             = c2h::get<0, TestType>;
   constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
-  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
 
   RotateTestHarness<T> harness;
 
@@ -372,7 +372,7 @@ C2H_TEST("DeviceRotate short overcopy and tile distribution", "[device][rotate]"
 C2H_TEST("DeviceRotate long algorithm cases", "[device][rotate]", rotate_types)
 {
   using T             = c2h::get<0, TestType>;
-  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
 
   RotateTestHarness<T> harness;
 
@@ -476,7 +476,7 @@ C2H_TEST("DeviceRotate maximal and near-boundary rotations", "[device][rotate]",
 {
   using T             = c2h::get<0, TestType>;
   constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
-  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
 
   RotateTestHarness<T> harness;
 
@@ -513,7 +513,7 @@ C2H_TEST("DeviceRotate maximal and near-boundary rotations", "[device][rotate]",
 C2H_TEST("DeviceRotate large-scale tests", "[device][rotate]", rotate_types)
 {
   using T             = c2h::get<0, TestType>;
-  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
 
   RotateTestHarness<T> harness;
 
@@ -592,7 +592,7 @@ C2H_TEST("DeviceRotate right short just above tiny boundary", "[device][rotate]"
 {
   using T             = c2h::get<0, TestType>;
   constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
-  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
 
   RotateTestHarness<T> harness;
 
@@ -622,7 +622,7 @@ C2H_TEST("DeviceRotate short zero overcopy with head", "[device][rotate]", rotat
 {
   using T             = c2h::get<0, TestType>;
   constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
-  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
 
   RotateTestHarness<T> harness;
 
@@ -654,7 +654,7 @@ C2H_TEST("DeviceRotate long dual head alignment", "[device][rotate]", rotate_typ
 {
   using T             = c2h::get<0, TestType>;
   constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
-  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
 
   RotateTestHarness<T> harness;
 
@@ -690,7 +690,7 @@ C2H_TEST("DeviceRotate short single tile with alignments", "[device][rotate]", r
 {
   using T             = c2h::get<0, TestType>;
   constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
-  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
 
   RotateTestHarness<T> harness;
 
@@ -723,7 +723,7 @@ C2H_TEST("DeviceRotate short single tile with alignments", "[device][rotate]", r
 C2H_TEST("DeviceRotate right short medium near-end distances", "[device][rotate]", rotate_types)
 {
   using T             = c2h::get<0, TestType>;
-  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
 
   RotateTestHarness<T> harness;
 
@@ -754,7 +754,7 @@ C2H_TEST("DeviceRotate right short medium near-end distances", "[device][rotate]
 C2H_TEST("DeviceRotate short rot_dist one large array", "[device][rotate]", rotate_types)
 {
   using T             = c2h::get<0, TestType>;
-  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
 
   RotateTestHarness<T> harness;
 
@@ -781,7 +781,7 @@ C2H_TEST("DeviceRotate long boundary sweep alignments", "[device][rotate]", rota
 {
   using T             = c2h::get<0, TestType>;
   constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
-  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
 
   RotateTestHarness<T> harness;
 
@@ -819,7 +819,7 @@ C2H_TEST("DeviceRotate long boundary sweep alignments", "[device][rotate]", rota
 C2H_TEST("DeviceRotate long exact tile multiples", "[device][rotate]", rotate_types)
 {
   using T             = c2h::get<0, TestType>;
-  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
 
   RotateTestHarness<T> harness;
 
@@ -862,7 +862,7 @@ TEST_CASE("DeviceRotate sizes near UINT32_MAX", "[device][rotate]")
 {
   using T             = uint8_t;
   constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
-  constexpr size_t TS = rotate_short::TILE_BYTES / sizeof(T);
+  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
 
   constexpr size_t U32MAX = static_cast<size_t>(std::numeric_limits<uint32_t>::max());
 
@@ -935,7 +935,7 @@ inline size_t get_max_test_bytes()
 C2H_TEST("DeviceRotate random short tests", "[device][rotate]", rotate_types)
 {
   using T                = c2h::get<0, TestType>;
-  constexpr size_t TS    = rotate_short::TILE_BYTES / sizeof(T);
+  constexpr size_t TS    = short_algorithm::tile_bytes / sizeof(T);
   size_t const max_elems = get_max_test_bytes() / sizeof(T);
 
   RotateTestHarness<T> harness;
@@ -951,7 +951,7 @@ C2H_TEST("DeviceRotate random short tests", "[device][rotate]", rotate_types)
 C2H_TEST("DeviceRotate random long tests", "[device][rotate]", rotate_types)
 {
   using T                = c2h::get<0, TestType>;
-  constexpr size_t TS    = rotate_short::TILE_BYTES / sizeof(T);
+  constexpr size_t TS    = short_algorithm::tile_bytes / sizeof(T);
   size_t const max_elems = get_max_test_bytes() / sizeof(T);
 
   RotateTestHarness<T> harness;

--- a/cub/test/catch2_test_device_rotate.cu
+++ b/cub/test/catch2_test_device_rotate.cu
@@ -183,6 +183,7 @@ struct EdgeCase
 template <typename T>
 void check_edge_case(RotateTestHarness<T>& harness, EdgeCase const& tc)
 {
+  CAPTURE(tc.arr_size, tc.rot_dist, tc.unaligned_elems);
   harness.prepare(tc.arr_size, tc.rot_dist, tc.unaligned_elems);
   auto const mismatch_left = harness.run_and_verify();
   REQUIRE(mismatch_left == harness.kNoMismatch);

--- a/cub/test/catch2_test_device_rotate.cu
+++ b/cub/test/catch2_test_device_rotate.cu
@@ -4,6 +4,7 @@
 #include "insert_nested_NVTX_range_guard.h"
 
 #include <cub/device/device_rotate.cuh>
+#include <cub/util_arch.cuh>
 
 #include <thrust/equal.h>
 #include <thrust/execution_policy.h>
@@ -20,6 +21,22 @@
 #include <c2h/catch2_test_helper.h>
 
 using namespace cub::detail::rotate;
+
+rotate_policy get_test_policy()
+{
+  int current_device;
+  REQUIRE(cudaSuccess == cudaGetDevice(&current_device));
+
+  cuda::compute_capability cc{};
+  REQUIRE(cudaSuccess == cub::detail::ptx_compute_cap(cc, current_device));
+  return policy_selector{}(cc);
+}
+
+template <typename T>
+size_t test_short_tile_size()
+{
+  return get_test_policy().short_algorithm.kernel.tile_bytes / sizeof(T);
+}
 
 // ============================================================================
 // Device-side test harness
@@ -263,8 +280,8 @@ C2H_TEST("DeviceRotate no-op and modular reduction", "[device][rotate]", rotate_
 
 C2H_TEST("DeviceRotate short algorithm boundary", "[device][rotate]", rotate_types)
 {
-  using T             = c2h::get<0, TestType>;
-  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
+  using T         = c2h::get<0, TestType>;
+  const size_t TS = test_short_tile_size<T>();
 
   RotateTestHarness<T> harness;
 
@@ -288,8 +305,8 @@ C2H_TEST("DeviceRotate short algorithm boundary", "[device][rotate]", rotate_typ
 
 C2H_TEST("DeviceRotate short rotate_tiny path", "[device][rotate]", rotate_types)
 {
-  using T             = c2h::get<0, TestType>;
-  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
+  using T         = c2h::get<0, TestType>;
+  const size_t TS = test_short_tile_size<T>();
 
   RotateTestHarness<T> harness;
 
@@ -312,8 +329,8 @@ C2H_TEST("DeviceRotate short rotate_tiny path", "[device][rotate]", rotate_types
 
 C2H_TEST("DeviceRotate short head_size alignments", "[device][rotate]", rotate_types)
 {
-  using T             = c2h::get<0, TestType>;
-  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
+  using T         = c2h::get<0, TestType>;
+  const size_t TS = test_short_tile_size<T>();
 
   RotateTestHarness<T> harness;
 
@@ -335,9 +352,9 @@ C2H_TEST("DeviceRotate short head_size alignments", "[device][rotate]", rotate_t
 
 C2H_TEST("DeviceRotate short overcopy and tile distribution", "[device][rotate]", rotate_types)
 {
-  using T             = c2h::get<0, TestType>;
-  constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
-  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
+  using T            = c2h::get<0, TestType>;
+  constexpr size_t S = BYTES_PER_SECTOR / sizeof(T);
+  const size_t TS    = test_short_tile_size<T>();
 
   RotateTestHarness<T> harness;
 
@@ -372,8 +389,8 @@ C2H_TEST("DeviceRotate short overcopy and tile distribution", "[device][rotate]"
 
 C2H_TEST("DeviceRotate long algorithm cases", "[device][rotate]", rotate_types)
 {
-  using T             = c2h::get<0, TestType>;
-  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
+  using T         = c2h::get<0, TestType>;
+  const size_t TS = test_short_tile_size<T>();
 
   RotateTestHarness<T> harness;
 
@@ -436,16 +453,20 @@ C2H_TEST("DeviceRotate long all alignments at medium scale", "[device][rotate]",
 
 TEST_CASE("DeviceRotate positive-small ordering alignment boundary", "[device][rotate]")
 {
-  constexpr size_t size            = 16'711'682;
-  constexpr size_t rotate_distance = size / 2;
-  constexpr uint32_t head_size     = 1;
+  constexpr uint32_t head_size = 1;
 
-  auto const state = bfs_visit_order<uint8_t>(size, rotate_distance, head_size);
-  REQUIRE(state.ordering_.size() == 511);
+  auto const policy          = get_test_policy().long_algorithm;
+  auto const tile_size       = static_cast<size_t>(policy.kernel.tile_bytes);
+  auto const max_distance    = policy.max_direct_dependency_distance;
+  auto const size            = 2 * tile_size * (max_distance - 1) + 2;
+  auto const rotate_distance = size / 2;
+
+  auto const state = bfs_visit_order<uint8_t>(size, rotate_distance, head_size, policy);
+  REQUIRE(state.ordering_.size() == 2 * max_distance - 1);
   REQUIRE(state.ordering_[0] == 0);
   REQUIRE(state.ordering_[1] == 1);
   REQUIRE(state.ordering_[2] == 2);
-  REQUIRE(state.max_distance_ == 256);
+  REQUIRE(state.max_distance_ == max_distance);
 
   RotateTestHarness<uint8_t> harness;
   check_edge_case(harness, {size, rotate_distance, 31});
@@ -475,9 +496,9 @@ C2H_TEST("DeviceRotate right short near-end alignments", "[device][rotate]", rot
 
 C2H_TEST("DeviceRotate maximal and near-boundary rotations", "[device][rotate]", rotate_types)
 {
-  using T             = c2h::get<0, TestType>;
-  constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
-  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
+  using T            = c2h::get<0, TestType>;
+  constexpr size_t S = BYTES_PER_SECTOR / sizeof(T);
+  const size_t TS    = test_short_tile_size<T>();
 
   RotateTestHarness<T> harness;
 
@@ -513,8 +534,8 @@ C2H_TEST("DeviceRotate maximal and near-boundary rotations", "[device][rotate]",
 
 C2H_TEST("DeviceRotate large-scale tests", "[device][rotate]", rotate_types)
 {
-  using T             = c2h::get<0, TestType>;
-  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
+  using T         = c2h::get<0, TestType>;
+  const size_t TS = test_short_tile_size<T>();
 
   RotateTestHarness<T> harness;
 
@@ -591,9 +612,9 @@ C2H_TEST("DeviceRotate size zero and one", "[device][rotate]", rotate_types)
 
 C2H_TEST("DeviceRotate right short just above tiny boundary", "[device][rotate]", rotate_types)
 {
-  using T             = c2h::get<0, TestType>;
-  constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
-  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
+  using T            = c2h::get<0, TestType>;
+  constexpr size_t S = BYTES_PER_SECTOR / sizeof(T);
+  const size_t TS    = test_short_tile_size<T>();
 
   RotateTestHarness<T> harness;
 
@@ -621,9 +642,9 @@ C2H_TEST("DeviceRotate right short just above tiny boundary", "[device][rotate]"
 
 C2H_TEST("DeviceRotate short zero overcopy with head", "[device][rotate]", rotate_types)
 {
-  using T             = c2h::get<0, TestType>;
-  constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
-  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
+  using T            = c2h::get<0, TestType>;
+  constexpr size_t S = BYTES_PER_SECTOR / sizeof(T);
+  const size_t TS    = test_short_tile_size<T>();
 
   RotateTestHarness<T> harness;
 
@@ -653,9 +674,9 @@ C2H_TEST("DeviceRotate short zero overcopy with head", "[device][rotate]", rotat
 
 C2H_TEST("DeviceRotate long dual head alignment", "[device][rotate]", rotate_types)
 {
-  using T             = c2h::get<0, TestType>;
-  constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
-  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
+  using T            = c2h::get<0, TestType>;
+  constexpr size_t S = BYTES_PER_SECTOR / sizeof(T);
+  const size_t TS    = test_short_tile_size<T>();
 
   RotateTestHarness<T> harness;
 
@@ -689,9 +710,9 @@ C2H_TEST("DeviceRotate long dual head alignment", "[device][rotate]", rotate_typ
 
 C2H_TEST("DeviceRotate short single tile with alignments", "[device][rotate]", rotate_types)
 {
-  using T             = c2h::get<0, TestType>;
-  constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
-  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
+  using T            = c2h::get<0, TestType>;
+  constexpr size_t S = BYTES_PER_SECTOR / sizeof(T);
+  const size_t TS    = test_short_tile_size<T>();
 
   RotateTestHarness<T> harness;
 
@@ -723,8 +744,8 @@ C2H_TEST("DeviceRotate short single tile with alignments", "[device][rotate]", r
 
 C2H_TEST("DeviceRotate right short medium near-end distances", "[device][rotate]", rotate_types)
 {
-  using T             = c2h::get<0, TestType>;
-  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
+  using T         = c2h::get<0, TestType>;
+  const size_t TS = test_short_tile_size<T>();
 
   RotateTestHarness<T> harness;
 
@@ -754,8 +775,8 @@ C2H_TEST("DeviceRotate right short medium near-end distances", "[device][rotate]
 
 C2H_TEST("DeviceRotate short rot_dist one large array", "[device][rotate]", rotate_types)
 {
-  using T             = c2h::get<0, TestType>;
-  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
+  using T         = c2h::get<0, TestType>;
+  const size_t TS = test_short_tile_size<T>();
 
   RotateTestHarness<T> harness;
 
@@ -780,9 +801,9 @@ C2H_TEST("DeviceRotate short rot_dist one large array", "[device][rotate]", rota
 
 C2H_TEST("DeviceRotate long boundary sweep alignments", "[device][rotate]", rotate_types)
 {
-  using T             = c2h::get<0, TestType>;
-  constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
-  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
+  using T            = c2h::get<0, TestType>;
+  constexpr size_t S = BYTES_PER_SECTOR / sizeof(T);
+  const size_t TS    = test_short_tile_size<T>();
 
   RotateTestHarness<T> harness;
 
@@ -819,8 +840,8 @@ C2H_TEST("DeviceRotate long boundary sweep alignments", "[device][rotate]", rota
 
 C2H_TEST("DeviceRotate long exact tile multiples", "[device][rotate]", rotate_types)
 {
-  using T             = c2h::get<0, TestType>;
-  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
+  using T         = c2h::get<0, TestType>;
+  const size_t TS = test_short_tile_size<T>();
 
   RotateTestHarness<T> harness;
 
@@ -861,9 +882,9 @@ inline size_t get_free_bytes()
 
 TEST_CASE("DeviceRotate sizes near UINT32_MAX", "[device][rotate]")
 {
-  using T             = uint8_t;
-  constexpr size_t S  = BYTES_PER_SECTOR / sizeof(T);
-  constexpr size_t TS = short_algorithm::tile_bytes / sizeof(T);
+  using T            = uint8_t;
+  constexpr size_t S = BYTES_PER_SECTOR / sizeof(T);
+  const size_t TS    = test_short_tile_size<T>();
 
   constexpr size_t U32MAX = static_cast<size_t>(std::numeric_limits<uint32_t>::max());
 
@@ -936,7 +957,7 @@ inline size_t get_max_test_bytes()
 C2H_TEST("DeviceRotate random short tests", "[device][rotate]", rotate_types)
 {
   using T                = c2h::get<0, TestType>;
-  constexpr size_t TS    = short_algorithm::tile_bytes / sizeof(T);
+  const size_t TS        = test_short_tile_size<T>();
   size_t const max_elems = get_max_test_bytes() / sizeof(T);
 
   RotateTestHarness<T> harness;
@@ -952,7 +973,7 @@ C2H_TEST("DeviceRotate random short tests", "[device][rotate]", rotate_types)
 C2H_TEST("DeviceRotate random long tests", "[device][rotate]", rotate_types)
 {
   using T                = c2h::get<0, TestType>;
-  constexpr size_t TS    = short_algorithm::tile_bytes / sizeof(T);
+  const size_t TS        = test_short_tile_size<T>();
   size_t const max_elems = get_max_test_bytes() / sizeof(T);
 
   RotateTestHarness<T> harness;


### PR DESCRIPTION
## Description

This MR adds a device-wide implementation of the in-place rotate algorithm for CUB. The changes contain three implementations (`short`, `long`, and `naive`), since the first two (which are truly in-place) can only be used when the rotate distance satisfies some specific criteria. For more information about the algorithms, please take a look at these (NVIDIA internal) [slides](https://nvidia-my.sharepoint.com/:p:/g/personal/mfranzrebsal_nvidia_com1/IQBbldAZrsE6QbGSzGJs3iwUAR1sPld-K5SoOFwoTvH-G0w).

For the `short` algorithm, I have added two implementations: one that launches as many CTAs per SM as possible, and another that instead uses pipelining combined with a different version of the algorithm. The motivation behind the pipelined version was to try to achieve SOL on H100, but when comparing profiles ([link](https://drive.google.com/drive/folders/1iIoWJjSJZseXthxTGVBsBsTgN7-q-1Oc?usp=sharing)) on H100 PCIe (attached), the pipelined version is 15% slower, while the (to me) relevant metrics compare as follows:

1. 13% lower mem throughput.
2. 5% less shared loads, 10% less wavefronts.
3. No shared stores.
4. 4KB global loads instead of 5MB
5. No global atomics.
6. 70% less stalls:
    a. ⅓ long scoreboard.
    b. 18x less barrier.
7. 13% more instructions:
8. 12% more branch instructions.

I would like to understand how/why the pipelined version performs worse, since theoretically the algorithm seems superior, and the metrics mostly look better. And what optimizations would be necessary to reach SOL on H100 and even B100? I'd be very interested to discuss this! Which version to use can be modulated by changing the variable `constexpr bool USE_SHORT_PIPELINE`.

The way the `long` algorithm works is also a bit unusual since, when querying the scratch space, there is a `RotateState_t` struct that also gets filled and must be passed to the following function call unchanged, in order to avoid repeating the dependency graph creation. Would this be acceptable to have in CUB? Alternatively, if we allow copying of the first K (= rotate distance) elements to a scratch buffer we would know longer need that dependency graph. The downside of this, is that the memory movement is now `2N + 2K` instead of `2N`, which would substantially reduce the theoretically achievable performance when `K ~ N/2`.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


# Benchmark Results
`RotatePercentage = 0` means a rotate distance of 1. Interesting here is how the performance does not really change between 1B and 8B data types, indicating that the extra work needed for the 1B type is "free".

## rotate_benchmark

### [0] NVIDIA H100 80GB HBM3

### [0] NVIDIA H100 80GB HBM3

```
| T{ct} |    Bytes{io}     | RotatePercentage | NumUnalignedElems | Algorithm |  Samples |  CPU Time  |  Noise  |  GPU Time  | Noise |  Elem/s  | GlobalMem BW | BWUtil |
|-------|------------------|------------------|-------------------|-----------|- --------|------------|---------|------------|-------|----------|--------------|- -------|
|    U8 |     2^16 = 65536 |                0 |                 1 |     short |  46144x |  33.894 us | 111.06% |  10.837 us | 4.76% |   6.048G |  12.095 GB/s | 0.36% |
|    U8 |   2^20 = 1048576 |                0 |                 1 |     short |  41824x |  35.414 us |   4.60% |  11.958 us | 4.89% |  87.686G | 175.371 GB/s | 5.23% |
|    U8 |  2^24 = 16777216 |                0 |                 1 |     short |  20480x |  47.657 us |   4.18% |  24.419 us | 3.58% | 687.056G |   1.374 TB/s | 40.99% |
|    U8 | 2^28 = 268435456 |                0 |                 1 |     short |  2128x | 259.734 us |   0.92% | 236.669 us | 0.88% |   1.134T |   2.268 TB/s | 67.67% |
|    U8 |     2^16 = 65536 |             0.01 |                 1 |     short |  41776x |  35.682 us |   4.45% |  11.970 us | 3.58% |   5.475G |  10.950 GB/s | 0.33% |
|    U8 |   2^20 = 1048576 |             0.01 |                 1 |     short |  18272x |  51.031 us |   3.57% |  27.371 us | 2.40% |  38.310G |  76.620 GB/s | 2.29% |
|    U8 |  2^24 = 16777216 |             0.01 |                 1 |      long |  18384x |  53.162 us |   3.66% |  27.200 us | 4.25% | 616.801G |   1.234 TB/s | 36.80% |
|    U8 | 2^28 = 268435456 |             0.01 |                 1 |      long |  2000x | 279.249 us |   1.36% | 251.571 us | 0.81% |   1.067T |   2.134 TB/s | 63.66% |
|    U8 |     2^16 = 65536 |              0.3 |                 1 |     short |  12592x |  62.828 us |   2.74% |  39.736 us | 2.18% |   1.649G |   3.299 GB/s | 0.10% |
|    U8 |   2^20 = 1048576 |              0.3 |                 1 |      long |  37472x |  39.239 us |   3.98% |  13.343 us | 2.46% |  78.583G | 157.167 GB/s | 4.69% |
|    U8 |  2^24 = 16777216 |              0.3 |                 1 |      long |  18688x |  52.944 us |   3.46% |  26.766 us | 3.14% | 626.800G |   1.254 TB/s | 37.39% |
|    U8 | 2^28 = 268435456 |              0.3 |                 1 |      long |  2048x | 275.229 us |   0.88% | 247.331 us | 0.78% |   1.085T |   2.171 TB/s | 64.75% |
|    U8 |     2^16 = 65536 |              0.6 |                 1 |      long |  39472x |  38.926 us |   4.96% |  12.672 us | 1.56% |   5.172G |  10.343 GB/s | 0.31% |
|    U8 |   2^20 = 1048576 |              0.6 |                 1 |      long |  37360x |  39.747 us |   4.57% |  13.387 us | 2.52% |  78.330G | 156.659 GB/s | 4.67% |
|    U8 |  2^24 = 16777216 |              0.6 |                 1 |      long |  18368x |  53.530 us |   3.86% |  27.241 us | 4.10% | 615.890G |   1.232 TB/s | 36.74% |
|    U8 | 2^28 = 268435456 |              0.6 |                 1 |      long |  2000x | 279.710 us |   0.96% | 251.934 us | 0.81% |   1.066T |   2.131 TB/s | 63.57% |
|    U8 |     2^16 = 65536 |              0.9 |                 1 |      long |  40128x |  38.666 us |   4.83% |  12.460 us | 1.72% |   5.260G |  10.519 GB/s | 0.31% |
|    U8 |   2^20 = 1048576 |              0.9 |                 1 |      long |  37520x |  39.373 us |   4.41% |  13.329 us | 2.60% |  78.669G | 157.338 GB/s | 4.69% |
|    U8 |  2^24 = 16777216 |              0.9 |                 1 |      long |  19136x |  52.303 us |   3.54% |  26.132 us | 2.24% | 642.026G |   1.284 TB/s | 38.30% |
|    U8 | 2^28 = 268435456 |              0.9 |                 1 |      long |  2032x | 274.788 us |   0.93% | 246.708 us | 0.82% |   1.088T |   2.176 TB/s | 64.91% |
|   U16 |     2^16 = 65536 |                0 |                 1 |     short |  45040x |  34.610 us |   4.59% |  11.103 us | 4.86% |   2.951G |  11.805 GB/s | 0.35% |
|   U16 |   2^20 = 1048576 |                0 |                 1 |     short |  42528x |  35.665 us |   4.62% |  11.759 us | 4.38% |  44.584G | 178.337 GB/s | 5.32% |
|   U16 |  2^24 = 16777216 |                0 |                 1 |     short |  20672x |  48.036 us |   3.72% |  24.206 us | 3.00% | 346.557G |   1.386 TB/s | 41.35% |
|   U16 | 2^28 = 268435456 |                0 |                 1 |     short |  2080x | 265.741 us |   0.79% | 241.706 us | 0.61% | 555.293G |   2.221 TB/s | 66.26% |
|   U16 |     2^16 = 65536 |             0.01 |                 1 |     short |  42752x |  35.099 us |   4.64% |  11.698 us | 4.42% |   2.801G |  11.204 GB/s | 0.33% |
|   U16 |   2^20 = 1048576 |             0.01 |                 1 |     short |  24736x |  44.359 us |   3.69% |  20.221 us | 2.55% |  25.928G | 103.711 GB/s | 3.09% |
|   U16 |  2^24 = 16777216 |             0.01 |                 1 |      long |  17808x |  54.677 us |   3.95% |  28.102 us | 5.42% | 298.508G |   1.194 TB/s | 35.62% |
|   U16 | 2^28 = 268435456 |             0.01 |                 1 |      long |  2000x | 278.872 us |   0.97% | 250.929 us | 0.56% | 534.882G |   2.140 TB/s | 63.82% |
|   U16 |     2^16 = 65536 |              0.3 |                 1 |     short |  19136x |  49.925 us |   2.96% |  26.145 us | 2.12% |   1.253G |   5.013 GB/s | 0.15% |
|   U16 |   2^20 = 1048576 |              0.3 |                 1 |      long |  36640x |  40.262 us |   4.28% |  13.650 us | 2.64% |  38.408G | 153.632 GB/s | 4.58% |
|   U16 |  2^24 = 16777216 |              0.3 |                 1 |      long |  18256x |  53.619 us |   4.82% |  27.402 us | 4.39% | 306.135G |   1.225 TB/s | 36.53% |
|   U16 | 2^28 = 268435456 |              0.3 |                 1 |      long |  2022x | 275.156 us |   0.64% | 247.289 us | 0.48% | 542.757G |   2.171 TB/s | 64.76% |
|   U16 |     2^16 = 65536 |              0.6 |                 1 |      long |  39120x |  39.397 us |   4.61% |  12.782 us | 1.70% |   2.564G |  10.255 GB/s | 0.31% |
|   U16 |   2^20 = 1048576 |              0.6 |                 1 |      long |  36800x |  39.899 us |   4.38% |  13.589 us | 2.41% |  38.581G | 154.322 GB/s | 4.60% |
|   U16 |  2^24 = 16777216 |              0.6 |                 1 |      long |  18368x |  53.623 us |   3.58% |  27.239 us | 4.70% | 307.960G |   1.232 TB/s | 36.75% |
|   U16 | 2^28 = 268435456 |              0.6 |                 1 |      long |  1984x | 279.861 us |   0.67% | 252.231 us | 0.55% | 532.123G |   2.128 TB/s | 63.49% |
|   U16 |     2^16 = 65536 |              0.9 |                 1 |      long |  39472x |  39.065 us |   3.93% |  12.668 us | 1.82% |   2.587G |  10.347 GB/s | 0.31% |
|   U16 |   2^20 = 1048576 |              0.9 |                 1 |      long |  36752x |  39.642 us |   3.39% |  13.609 us | 2.70% |  38.525G | 154.099 GB/s | 4.60% |
|   U16 |  2^24 = 16777216 |              0.9 |                 1 |      long |  18992x |  52.456 us |   2.97% |  26.339 us | 2.57% | 318.487G |   1.274 TB/s | 38.00% |
|   U16 | 2^28 = 268435456 |              0.9 |                 1 |      long |  2032x | 274.679 us |   0.65% | 247.064 us | 0.56% | 543.252G |   2.173 TB/s | 64.82% |
|   U32 |     2^16 = 65536 |                0 |                 1 |     short |  46976x |  34.282 us |   4.74% |  10.645 us | 3.98% |   1.539G |  12.312 GB/s | 0.37% |
|   U32 |   2^20 = 1048576 |                0 |                 1 |     short |  41792x |  35.660 us |   4.27% |  11.968 us | 3.43% |  21.903G | 175.224 GB/s | 5.23% |
|   U32 |  2^24 = 16777216 |                0 |                 1 |     short |  21680x |  47.134 us |   3.67% |  23.070 us | 2.96% | 181.811G |   1.454 TB/s | 43.39% |
|   U32 | 2^28 = 268435456 |                0 |                 1 |     short |  2272x | 243.951 us |   0.81% | 220.410 us | 0.67% | 304.473G |   2.436 TB/s | 72.66% |
|   U32 |     2^16 = 65536 |             0.01 |                 1 |     short |  45856x |  34.771 us |   4.38% |  10.907 us | 3.03% |   1.502G |  12.017 GB/s | 0.36% |
|   U32 |   2^20 = 1048576 |             0.01 |                 1 |     short |  32080x |  39.290 us |   4.39% |  15.591 us | 3.40% |  16.814G | 134.513 GB/s | 4.01% |
|   U32 |  2^24 = 16777216 |             0.01 |                 1 |      long |  19760x |  51.343 us |   9.95% |  25.304 us | 3.75% | 165.754G |   1.326 TB/s | 39.56% |
|   U32 | 2^28 = 268435456 |             0.01 |                 1 |      long |  2304x | 245.343 us |   0.81% | 217.462 us | 0.57% | 308.601G |   2.469 TB/s | 73.64% |
|   U32 |     2^16 = 65536 |              0.3 |                 1 |     short |  27712x |  41.685 us |   4.08% |  18.045 us | 2.35% | 907.931M |   7.263 GB/s | 0.22% |
|   U32 |   2^20 = 1048576 |              0.3 |                 1 |      long |  39024x |  39.199 us |   4.80% |  12.813 us | 2.57% |  20.459G | 163.675 GB/s | 4.88% |
|   U32 |  2^24 = 16777216 |              0.3 |                 1 |      long |  20272x |  51.157 us |   3.03% |  24.680 us | 1.74% | 169.949G |   1.360 TB/s | 40.56% |
|   U32 | 2^28 = 268435456 |              0.3 |                 1 |      long |  2258x | 249.763 us |   0.90% | 221.527 us | 0.49% | 302.937G |   2.423 TB/s | 72.29% |
|   U32 |     2^16 = 65536 |              0.6 |                 1 |      long |  40800x |  38.655 us |  14.24% |  12.258 us | 1.62% |   1.337G |  10.692 GB/s | 0.32% |
|   U32 |   2^20 = 1048576 |              0.6 |                 1 |      long |  39168x |  39.400 us |   5.05% |  12.766 us | 2.21% |  20.535G | 164.277 GB/s | 4.90% |
|   U32 |  2^24 = 16777216 |              0.6 |                 1 |      long |  20240x |  50.858 us |   3.02% |  24.712 us | 1.70% | 169.726G |   1.358 TB/s | 40.50% |
|   U32 | 2^28 = 268435456 |              0.6 |                 1 |      long |  2208x | 254.819 us |   0.70% | 226.636 us | 0.60% | 296.108G |   2.369 TB/s | 70.66% |
|   U32 |     2^16 = 65536 |              0.9 |                 1 |      long |  43136x |  38.048 us |   4.46% |  11.594 us | 2.58% |   1.413G |  11.305 GB/s | 0.34% |
|   U32 |   2^20 = 1048576 |              0.9 |                 1 |      long |  39760x |  38.981 us |   4.31% |  12.579 us | 2.08% |  20.840G | 166.723 GB/s | 4.97% |
|   U32 |  2^24 = 16777216 |              0.9 |                 1 |      long |  20560x |  50.189 us |   2.40% |  24.324 us | 1.22% | 172.438G |   1.380 TB/s | 41.15% |
|   U32 | 2^28 = 268435456 |              0.9 |                 1 |      long |  2272x | 248.510 us |   0.60% | 220.833 us | 0.54% | 303.890G |   2.431 TB/s | 72.52% |
|   U64 |     2^16 = 65536 |                0 |                 1 |     short |  47648x |  34.180 us |   4.90% |  10.494 us | 5.95% | 780.643M |  12.490 GB/s | 0.37% |
|   U64 |   2^20 = 1048576 |                0 |                 1 |     short |  41760x |  35.918 us |   4.55% |  11.975 us | 4.92% |  10.946G | 175.128 GB/s | 5.22% |
|   U64 |  2^24 = 16777216 |                0 |                 1 |     short |  22064x |  46.016 us |   2.96% |  22.674 us | 2.30% |  92.493G |   1.480 TB/s | 44.15% |
|   U64 | 2^28 = 268435456 |                0 |                 1 |     short |  2288x | 244.486 us |   0.68% | 219.435 us | 0.62% | 152.913G |   2.447 TB/s | 72.98% |
|   U64 |     2^16 = 65536 |             0.01 |                 1 |     short |  46928x |  34.014 us |   4.72% |  10.656 us | 3.89% | 768.753M |  12.300 GB/s | 0.37% |
|   U64 |   2^20 = 1048576 |             0.01 |                 1 |     short |  38496x |  36.333 us |  11.93% |  12.989 us | 5.22% |  10.091G | 161.454 GB/s | 4.82% |
|   U64 |  2^24 = 16777216 |             0.01 |                 1 |      long |  19952x |  51.008 us |   3.20% |  25.065 us | 3.34% |  83.669G |   1.339 TB/s | 39.93% |
|   U64 | 2^28 = 268435456 |             0.01 |                 1 |      long |  2304x | 245.746 us |   1.24% | 217.854 us | 0.59% | 154.022G |   2.464 TB/s | 73.51% |
|   U64 |     2^16 = 65536 |              0.3 |                 1 |     short |  35184x |  37.422 us |   4.01% |  14.211 us | 2.44% | 576.437M |   9.223 GB/s | 0.28% |
|   U64 |   2^20 = 1048576 |              0.3 |                 1 |      long |  39632x |  38.600 us |   3.96% |  12.619 us | 2.57% |  10.387G | 166.184 GB/s | 4.96% |
|   U64 |  2^24 = 16777216 |              0.3 |                 1 |      long |  20480x |  50.823 us |   3.38% |  24.418 us | 1.65% |  85.887G |   1.374 TB/s | 40.99% |
|   U64 | 2^28 = 268435456 |              0.3 |                 1 |      long |  2258x | 249.375 us |   0.81% | 221.495 us | 0.49% | 151.491G |   2.424 TB/s | 72.30% |
|   U64 |     2^16 = 65536 |              0.6 |                 1 |      long |  41136x |  38.147 us |   4.69% |  12.158 us | 1.45% | 673.799M |  10.781 GB/s | 0.32% |
|   U64 |   2^20 = 1048576 |              0.6 |                 1 |      long |  39904x |  38.746 us |   4.62% |  12.530 us | 2.63% |  10.461G | 167.369 GB/s | 4.99% |
|   U64 |  2^24 = 16777216 |              0.6 |                 1 |      long |  20352x |  50.128 us |   2.68% |  24.574 us | 2.06% |  85.339G |   1.365 TB/s | 40.73% |
|   U64 | 2^28 = 268435456 |              0.6 |                 1 |      long |  2208x | 253.839 us |   0.77% | 226.465 us | 0.61% | 148.166G |   2.371 TB/s | 70.72% |
|   U64 |     2^16 = 65536 |              0.9 |                 1 |      long |  44288x |  37.328 us |   4.24% |  11.292 us | 1.76% | 725.465M |  11.607 GB/s | 0.35% |
|   U64 |   2^20 = 1048576 |              0.9 |                 1 |      long |  41792x |  38.166 us |   4.32% |  11.968 us | 2.64% |  10.952G | 175.235 GB/s | 5.23% |
|   U64 |  2^24 = 16777216 |              0.9 |                 1 |      long |  20912x |  49.680 us |   3.29% |  23.926 us | 1.71% |  87.651G |   1.402 TB/s | 41.83% |
|   U64 | 2^28 = 268435456 |              0.9 |                 1 |      long |  2304x | 245.565 us |   0.88% | 217.764 us | 0.53% | 154.086G |   2.465 TB/s | 73.54% |
```