### PR TITLE
Env passthrough 4/4

### DIFF
--- a/cub/cub/device/device_histogram.cuh
+++ b/cub/cub/device/device_histogram.cuh
@@ -1690,6 +1690,7 @@ public:
   //!
   //! @param[in] num_levels
   //!   The number of boundaries (levels) for delineating histogram samples.
+  //!   Implies that the number of bins is `num_levels - 1`.
   //!
   //! @param[in] lower_level
   //!   The lower sample value bound (inclusive) for the lowest histogram bin.
@@ -1932,25 +1933,36 @@ public:
   //!   **[inferred]** Type for specifying boundaries (levels)
   //!
   //! @tparam OffsetT
-  //!   **[inferred]** Signed integer type for sequence offsets, list lengths, pointer differences, etc.
+  //!   **[inferred]** Signed integer type for sequence offsets, list lengths,
+  //!   pointer differences, etc. @offset_size1
   //!
   //! @tparam EnvT
   //!   **[inferred]** Environment type (e.g., `cuda::std::execution::env<...>`)
   //!
   //! @param[in] d_samples
-  //!   The pointer to the multi-channel input sequence of data samples.
+  //!   The pointer to the multi-channel input sequence of data samples. The
+  //!   samples from different channels are assumed to be interleaved (e.g.,
+  //!   an array of 32-bit pixels where each pixel consists of four
+  //!   *RGBA* 8-bit samples).
   //!
   //! @param[out] d_histogram
-  //!   Array of active channel histogram counter output arrays, each of length `num_levels[channel] - 1`.
+  //!   @rst
+  //!   The pointers to the histogram counter output arrays, one for each
+  //!   active channel. For channel\ :sub:`i`, the allocation length
+  //!   of ``d_histogram[i]`` should be ``num_levels[i] - 1``.
+  //!   @endrst
   //!
   //! @param[in] num_levels
-  //!   Array of the number of boundaries (levels) for each active channel.
+  //!   @rst
+  //!   The number of boundaries (levels) for delineating histogram samples in each active channel.
+  //!   Implies that the number of bins for channel\ :sub:`i` is ``num_levels[i] - 1``.
+  //!   @endrst
   //!
   //! @param[in] lower_level
-  //!   Array of the lower sample value bound (inclusive) for the lowest bin of each active channel.
+  //!   The lower sample value bound (inclusive) for the lowest histogram bin in each active channel.
   //!
   //! @param[in] upper_level
-  //!   Array of the upper sample value bound (exclusive) for the highest bin of each active channel.
+  //!   The upper sample value bound (exclusive) for the highest histogram bin in each active channel.
   //!
   //! @param[in] num_row_pixels
   //!   The number of multi-channel pixels per row in the region of interest
@@ -1959,7 +1971,8 @@ public:
   //!   The number of rows in the region of interest
   //!
   //! @param[in] row_stride_bytes
-  //!   The number of bytes between starts of consecutive rows in the region of interest
+  //!   The number of bytes between starts of consecutive rows in the region of
+  //!   interest
   //!
   //! @param[in] env
   //!   @rst
@@ -2088,7 +2101,9 @@ public:
   //!   Implies that the number of bins is `num_levels - 1`.
   //!
   //! @param[in] d_levels
-  //!   The pointer to the array of boundaries (levels). Bins are defined by consecutive pairs.
+  //!   The pointer to the array of boundaries (levels). Bin ranges are defined
+  //!   by consecutive boundary pairings: lower sample value boundaries are
+  //!   inclusive and upper sample value boundaries are exclusive.
   //!
   //! @param[in] num_samples
   //!   The number of input samples (i.e., the length of `d_samples`)
@@ -2181,9 +2196,12 @@ public:
   //!
   //! @param[in] num_levels
   //!   The number of boundaries (levels) for delineating histogram samples.
+  //!   Implies that the number of bins is `num_levels - 1`.
   //!
   //! @param[in] d_levels
-  //!   The pointer to the array of boundaries (levels). Bins are defined by consecutive pairs.
+  //!   The pointer to the array of boundaries (levels). Bin ranges are defined
+  //!   by consecutive boundary pairings: lower sample value boundaries are
+  //!   inclusive and upper sample value boundaries are exclusive.
   //!
   //! @param[in] num_row_samples
   //!   The number of data samples per row in the region of interest

--- a/cub/cub/device/device_merge_sort.cuh
+++ b/cub/cub/device/device_merge_sort.cuh
@@ -20,7 +20,6 @@
 
 #include <cuda/__execution/require.h>
 #include <cuda/std/__execution/env.h>
-
 CUB_NAMESPACE_BEGIN
 
 /**

--- a/cub/cub/device/device_merge_sort.cuh
+++ b/cub/cub/device/device_merge_sort.cuh
@@ -20,6 +20,7 @@
 
 #include <cuda/__execution/require.h>
 #include <cuda/std/__execution/env.h>
+
 CUB_NAMESPACE_BEGIN
 
 /**

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -769,13 +769,15 @@ struct DeviceScan
   //!   @rst
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
-  template <typename InputIteratorT,
-            typename OutputIteratorT,
-            typename ScanOpT,
-            typename InitValueT,
-            typename NumItemsT,
-            typename EnvT                                                        = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
+  template <
+    typename InputIteratorT,
+    typename OutputIteratorT,
+    typename ScanOpT,
+    typename InitValueT,
+    typename NumItemsT,
+    typename EnvT                 = ::cuda::std::execution::env<>,
+    ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<OutputIteratorT, size_t>,
+                             int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t ExclusiveScan(
     InputIteratorT d_in,
     OutputIteratorT d_out,
@@ -1393,14 +1395,16 @@ struct DeviceScan
   //!   @rst
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
-  template <typename InputIteratorT,
-            typename OutputIteratorT,
-            typename ScanOpT,
-            typename InitValueT,
-            typename InitValueIterT                                              = InitValueT*,
-            typename NumItemsT                                                   = int,
-            typename EnvT                                                        = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
+  template <
+    typename InputIteratorT,
+    typename OutputIteratorT,
+    typename ScanOpT,
+    typename InitValueT,
+    typename InitValueIterT       = InitValueT*,
+    typename NumItemsT            = int,
+    typename EnvT                 = ::cuda::std::execution::env<>,
+    ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<OutputIteratorT, size_t>,
+                             int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t ExclusiveScan(
     InputIteratorT d_in,
     OutputIteratorT d_out,
@@ -2271,7 +2275,8 @@ struct DeviceScan
             typename ScanOpT,
             typename InitValueT,
             typename NumItemsT,
-            typename EnvT = ::cuda::std::execution::env<>>
+            typename EnvT                                                        = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t InclusiveScanInit(
     InputIteratorT d_in,
     OutputIteratorT d_out,

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -1397,8 +1397,8 @@ struct DeviceScan
             typename OutputIteratorT,
             typename ScanOpT,
             typename InitValueT,
-            typename InitValueIterT,
-            typename NumItemsT,
+            typename InitValueIterT                                              = InitValueT*,
+            typename NumItemsT                                                   = int,
             typename EnvT                                                        = ::cuda::std::execution::env<>,
             ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t ExclusiveScan(
@@ -2903,6 +2903,7 @@ struct DeviceScan
   //!   ``[d_values_out, d_values_out + num_items)`` shall not overlap otherwise.
   //!
   //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
   //! The code snippet below illustrates the exclusive prefix sum-by-key of an ``int`` device vector.
   //!
@@ -3035,6 +3036,7 @@ struct DeviceScan
   //!   ``[d_values_out, d_values_out + num_items)`` shall not overlap otherwise.
   //!
   //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
   //! The code snippet below illustrates the exclusive prefix scan-by-key of an ``int`` device vector.
   //!
@@ -3149,6 +3151,7 @@ struct DeviceScan
   //!   ``[d_values_out, d_values_out + num_items)`` shall not overlap otherwise.
   //!
   //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
   //! The code snippet below illustrates the inclusive prefix sum-by-key of an ``int`` device vector.
   //!
@@ -3256,6 +3259,7 @@ struct DeviceScan
   //!   ``[d_values_out, d_values_out + num_items)`` shall not overlap otherwise.
   //!
   //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
   //! The code snippet below illustrates the inclusive prefix scan-by-key of an ``int`` device vector.
   //!

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -769,15 +769,14 @@ struct DeviceScan
   //!   @rst
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
-  template <
-    typename InputIteratorT,
-    typename OutputIteratorT,
-    typename ScanOpT,
-    typename InitValueT,
-    typename NumItemsT,
-    typename EnvT                 = ::cuda::std::execution::env<>,
-    ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<OutputIteratorT, size_t>,
-                             int> = 0>
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename ScanOpT,
+            typename InitValueT,
+            typename NumItemsT,
+            typename EnvT                                                        = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0,
+            ::cuda::std::enable_if_t<!::cuda::std::is_same_v<OutputIteratorT, size_t>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t ExclusiveScan(
     InputIteratorT d_in,
     OutputIteratorT d_out,
@@ -1395,16 +1394,15 @@ struct DeviceScan
   //!   @rst
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
-  template <
-    typename InputIteratorT,
-    typename OutputIteratorT,
-    typename ScanOpT,
-    typename InitValueT,
-    typename InitValueIterT       = InitValueT*,
-    typename NumItemsT            = int,
-    typename EnvT                 = ::cuda::std::execution::env<>,
-    ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_same_v<OutputIteratorT, size_t>,
-                             int> = 0>
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename ScanOpT,
+            typename InitValueT,
+            typename InitValueIterT                                              = InitValueT*,
+            typename NumItemsT                                                   = int,
+            typename EnvT                                                        = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0,
+            ::cuda::std::enable_if_t<!::cuda::std::is_same_v<OutputIteratorT, size_t>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t ExclusiveScan(
     InputIteratorT d_in,
     OutputIteratorT d_out,

--- a/cub/cub/device/device_segmented_scan.cuh
+++ b/cub/cub/device/device_segmented_scan.cuh
@@ -224,6 +224,14 @@ public:
   //!   shall not overlap in any other way.
   //! - Can use a specific stream or cuda memory resource through the ``env`` parameter.
   //!
+  //! Preconditions
+  //! +++++++++++++
+  //!
+  //! - When ``d_in`` and ``d_out`` are equal, the segmented scan is performed in-place.
+  //!   The range ``[d_in, d_in + num_items_in)`` and ``[d_out, d_out + num_items_out)``
+  //!   shall not overlap in any other way.
+  //! - ``d_in`` and ``d_out`` must not be null pointers
+  //!
   //! Snippet
   //! +++++++++++++++++++++++++++++++++++++++++++++
   //!
@@ -506,13 +514,27 @@ public:
   //!   Random-access iterator to the output sequence of data items
   //!
   //! @param[in] d_in_begin_offsets
-  //!   Random-access input iterator to the sequence of beginning offsets in the input data of length ``num_segments``
+  //!   @rst
+  //!   Random-access input iterator to the sequence of beginning offsets of
+  //!   length ``num_segments``, such that ``d_in_begin_offsets[i]`` is the first
+  //!   element of the \ *i*\ :sup:`th` data segment in ``d_in``
+  //!   @endrst
   //!
   //! @param[in] d_in_end_offsets
-  //!   Random-access input iterator to the sequence of ending offsets in the input data of length ``num_segments``
+  //!   @rst
+  //!   Random-access input iterator to the sequence of ending offsets of length
+  //!   ``num_segments``, such that ``d_in_end_offsets[i] - 1`` is the last element of
+  //!   the \ *i*\ :sup:`th` data segment in ``d_in``.
+  //!   If ``d_in_end_offsets[i] - 1 <= d_in_begin_offsets[i]``, the \ *i*\ :sup:`th`
+  //!   is considered empty.
+  //!   @endrst
   //!
   //! @param[in] d_out_begin_offsets
-  //!   Random-access input iterator to the sequence of beginning offsets in the output data of length ``num_segments``
+  //!   @rst
+  //!   Random-access input iterator to the sequence of beginning offsets of
+  //!   length ``num_segments``, such that ``d_out_begin_offsets[i]`` is the first
+  //!   element of the \ *i*\ :sup:`th` data segment in ``d_out``
+  //!   @endrst
   //!
   //! @param[in] num_segments
   //!   The number of segments that comprise the segmented prefix scan data.
@@ -707,7 +729,8 @@ public:
   //! - Results are not deterministic for pseudo-associative operators (e.g.,
   //!   addition of floating-point types). Results for pseudo-associative
   //!   operators may vary from run to run.
-  //! - When ``d_in`` and ``d_out`` are equal, the scan is performed in-place.
+  //! - When ``d_in`` and ``d_out`` are equal, the scan is performed in-place. The input and output sequences
+  //!   shall not overlap in any other way.
   //! - Can use a specific stream or cuda memory resource through the ``env`` parameter.
   //!
   //! Snippet
@@ -964,6 +987,8 @@ public:
   //! - Results are not deterministic for pseudo-associative operators (e.g.,
   //!   addition of floating-point types). Results for pseudo-associative
   //!   operators may vary from run to run.
+  //! - When ``d_in`` and ``d_out`` are equal, the scan is performed in-place. The input and output sequences
+  //!   shall not overlap in any other way.
   //! - Can use a specific stream or cuda memory resource through the ``env`` parameter.
   //!
   //! Snippet
@@ -1014,13 +1039,27 @@ public:
   //!   Random-access iterator to the output sequence of data items
   //!
   //! @param[in] d_in_begin_offsets
-  //!   Random-access input iterator to the sequence of beginning offsets in the input data of length ``num_segments``
+  //!   @rst
+  //!   Random-access input iterator to the sequence of beginning offsets of
+  //!   length ``num_segments``, such that ``d_in_begin_offsets[i]`` is the first
+  //!   element of the \ *i*\ :sup:`th` data segment in ``d_in``
+  //!   @endrst
   //!
   //! @param[in] d_in_end_offsets
-  //!   Random-access input iterator to the sequence of ending offsets in the input data of length ``num_segments``
+  //!   @rst
+  //!   Random-access input iterator to the sequence of ending offsets of length
+  //!   ``num_segments``, such that ``d_in_end_offsets[i] - 1`` is the last element of
+  //!   the \ *i*\ :sup:`th` data segment in ``d_in``.
+  //!   If ``d_in_end_offsets[i] - 1 <= d_in_begin_offsets[i]``, the \ *i*\ :sup:`th`
+  //!   is considered empty.
+  //!   @endrst
   //!
   //! @param[in] d_out_begin_offsets
-  //!   Random-access input iterator to the sequence of beginning offsets in the output data of length ``num_segments``
+  //!   @rst
+  //!   Random-access input iterator to the sequence of beginning offsets of
+  //!   length ``num_segments``, such that ``d_out_begin_offsets[i]`` is the first
+  //!   element of the \ *i*\ :sup:`th` data segment in ``d_out``
+  //!   @endrst
   //!
   //! @param[in] num_segments
   //!   The number of segments that comprise the segmented prefix scan data.
@@ -1440,6 +1479,8 @@ public:
   //!
   //! - Results are not deterministic for computation of prefix sum on floating-point types
   //!   and may vary from run to run.
+  //! - When ``d_in`` and ``d_out`` are equal, the scan is performed in-place. The input and output sequences
+  //!   shall not overlap in any other way.
   //! - Can use a specific stream or cuda memory resource through the ``env`` parameter.
   //!
   //! Snippet
@@ -1484,13 +1525,27 @@ public:
   //!   Random-access iterator to the output sequence of data items
   //!
   //! @param[in] d_in_begin_offsets
-  //!   Random-access input iterator to the sequence of beginning offsets in the input data of length ``num_segments``
+  //!   @rst
+  //!   Random-access input iterator to the sequence of beginning offsets of
+  //!   length ``num_segments``, such that ``d_in_begin_offsets[i]`` is the first
+  //!   element of the \ *i*\ :sup:`th` data segment in ``d_in``
+  //!   @endrst
   //!
   //! @param[in] d_in_end_offsets
-  //!   Random-access input iterator to the sequence of ending offsets in the input data of length ``num_segments``
+  //!   @rst
+  //!   Random-access input iterator to the sequence of ending offsets of length
+  //!   ``num_segments``, such that ``d_in_end_offsets[i] - 1`` is the last element of
+  //!   the \ *i*\ :sup:`th` data segment in ``d_in``.
+  //!   If ``d_in_end_offsets[i] - 1 <= d_in_begin_offsets[i]``, the \ *i*\ :sup:`th`
+  //!   is considered empty.
+  //!   @endrst
   //!
   //! @param[in] d_out_begin_offsets
-  //!   Random-access input iterator to the sequence of beginning offsets in the output data of length ``num_segments``
+  //!   @rst
+  //!   Random-access input iterator to the sequence of beginning offsets of
+  //!   length ``num_segments``, such that ``d_out_begin_offsets[i]`` is the first
+  //!   element of the \ *i*\ :sup:`th` data segment in ``d_out``
+  //!   @endrst
   //!
   //! @param[in] num_segments
   //!   The number of segments that comprise the segmented prefix scan data.
@@ -1657,7 +1712,8 @@ public:
   //! - Results are not deterministic for pseudo-associative operators (e.g.,
   //!   addition of floating-point types). Results for pseudo-associative
   //!   operators may vary from run to run.
-  //! - When ``d_in`` and ``d_out`` are equal, the scan is performed in-place.
+  //! - When ``d_in`` and ``d_out`` are equal, the scan is performed in-place. The input and output sequences
+  //!   shall not overlap in any other way.
   //! - Can use a specific stream or cuda memory resource through the ``env`` parameter.
   //!
   //! Snippet
@@ -1908,6 +1964,8 @@ public:
   //! - Results are not deterministic for pseudo-associative operators (e.g.,
   //!   addition of floating-point types). Results for pseudo-associative
   //!   operators may vary from run to run.
+  //! - When ``d_in`` and ``d_out`` are equal, the scan is performed in-place. The input and output sequences
+  //!   shall not overlap in any other way.
   //! - Can use a specific stream or cuda memory resource through the ``env`` parameter.
   //!
   //! Snippet
@@ -1955,13 +2013,27 @@ public:
   //!   Random-access iterator to the output sequence of data items
   //!
   //! @param[in] d_in_begin_offsets
-  //!   Random-access input iterator to the sequence of beginning offsets in the input data of length ``num_segments``
+  //!   @rst
+  //!   Random-access input iterator to the sequence of beginning offsets of
+  //!   length ``num_segments``, such that ``d_in_begin_offsets[i]`` is the first
+  //!   element of the \ *i*\ :sup:`th` data segment in ``d_in``
+  //!   @endrst
   //!
   //! @param[in] d_in_end_offsets
-  //!   Random-access input iterator to the sequence of ending offsets in the input data of length ``num_segments``
+  //!   @rst
+  //!   Random-access input iterator to the sequence of ending offsets of length
+  //!   ``num_segments``, such that ``d_in_end_offsets[i] - 1`` is the last element of
+  //!   the \ *i*\ :sup:`th` data segment in ``d_in``.
+  //!   If ``d_in_end_offsets[i] - 1 <= d_in_begin_offsets[i]``, the \ *i*\ :sup:`th`
+  //!   is considered empty.
+  //!   @endrst
   //!
   //! @param[in] d_out_begin_offsets
-  //!   Random-access input iterator to the sequence of beginning offsets in the output data of length ``num_segments``
+  //!   @rst
+  //!   Random-access input iterator to the sequence of beginning offsets of
+  //!   length ``num_segments``, such that ``d_out_begin_offsets[i]`` is the first
+  //!   element of the \ *i*\ :sup:`th` data segment in ``d_out``
+  //!   @endrst
   //!
   //! @param[in] num_segments
   //!   The number of segments that comprise the segmented prefix scan data.
@@ -2157,7 +2229,8 @@ public:
   //! - Results are not deterministic for pseudo-associative operators (e.g.,
   //!   addition of floating-point types). Results for pseudo-associative
   //!   operators may vary from run to run.
-  //! - When ``d_in`` and ``d_out`` are equal, the scan is performed in-place.
+  //! - When ``d_in`` and ``d_out`` are equal, the scan is performed in-place. The input and output sequences
+  //!   shall not overlap in any other way.
   //! - Can use a specific stream or cuda memory resource through the ``env`` parameter.
   //!
   //! Snippet
@@ -2204,10 +2277,20 @@ public:
   //!   Random-access iterator to the output sequence of data items
   //!
   //! @param[in] d_in_begin_offsets
-  //!   Random-access input iterator to the sequence of beginning offsets of length ``num_segments``
+  //!   @rst
+  //!   Random-access input iterator to the sequence of beginning offsets of
+  //!   length ``num_segments``, such that ``d_in_begin_offsets[i]`` is the first
+  //!   element of the \ *i*\ :sup:`th` data segment in ``d_in`` and in ``d_out``
+  //!   @endrst
   //!
   //! @param[in] d_in_end_offsets
-  //!   Random-access input iterator to the sequence of ending offsets of length ``num_segments``
+  //!   @rst
+  //!   Random-access input iterator to the sequence of ending offsets of length
+  //!   ``num_segments``, such that ``d_in_end_offsets[i] - 1`` is the last element of
+  //!   the \ *i*\ :sup:`th` data segment in ``d_in``.
+  //!   If ``d_in_end_offsets[i] - 1 <= d_in_begin_offsets[i]``, the \ *i*\ :sup:`th`
+  //!   is considered empty.
+  //!   @endrst
   //!
   //! @param[in] num_segments
   //!   The number of segments that comprise the segmented prefix scan data.
@@ -2408,6 +2491,8 @@ public:
   //! - Results are not deterministic for pseudo-associative operators (e.g.,
   //!   addition of floating-point types). Results for pseudo-associative
   //!   operators may vary from run to run.
+  //! - When ``d_in`` and ``d_out`` are equal, the scan is performed in-place. The input and output sequences
+  //!   shall not overlap in any other way.
   //! - Can use a specific stream or cuda memory resource through the ``env`` parameter.
   //!
   //! Snippet
@@ -2458,13 +2543,27 @@ public:
   //!   Random-access iterator to the output sequence of data items
   //!
   //! @param[in] d_in_begin_offsets
-  //!   Random-access input iterator to the sequence of beginning offsets in the input data of length ``num_segments``
+  //!   @rst
+  //!   Random-access input iterator to the sequence of beginning offsets of
+  //!   length ``num_segments``, such that ``d_in_begin_offsets[i]`` is the first
+  //!   element of the \ *i*\ :sup:`th` data segment in ``d_in``
+  //!   @endrst
   //!
   //! @param[in] d_in_end_offsets
-  //!   Random-access input iterator to the sequence of ending offsets in the input data of length ``num_segments``
+  //!   @rst
+  //!   Random-access input iterator to the sequence of ending offsets of length
+  //!   ``num_segments``, such that ``d_in_end_offsets[i] - 1`` is the last element of
+  //!   the \ *i*\ :sup:`th` data segment in ``d_in``.
+  //!   If ``d_in_end_offsets[i] - 1 <= d_in_begin_offsets[i]``, the \ *i*\ :sup:`th`
+  //!   is considered empty.
+  //!   @endrst
   //!
   //! @param[in] d_out_begin_offsets
-  //!   Random-access input iterator to the sequence of beginning offsets in the output data of length ``num_segments``
+  //!   @rst
+  //!   Random-access input iterator to the sequence of beginning offsets of
+  //!   length ``num_segments``, such that ``d_out_begin_offsets[i]`` is the first
+  //!   element of the \ *i*\ :sup:`th` data segment in ``d_out``
+  //!   @endrst
   //!
   //! @param[in] num_segments
   //!   The number of segments that comprise the segmented prefix scan data.

--- a/cub/test/catch2_test_device_histogram_api.cu
+++ b/cub/test/catch2_test_device_histogram_api.cu
@@ -9,7 +9,7 @@
 
 #include <c2h/catch2_test_helper.h>
 
-C2H_TEST("cub::DeviceHistogram::HistogramEven non-env API", "[histogram][device]")
+C2H_TEST("cub::DeviceHistogram::HistogramEven non-env overload is not ambiguous", "[histogram][device]")
 {
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);
@@ -18,7 +18,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramEven non-env API", "[histogram][device]
     nullptr, temp_storage_bytes, samples.begin(), thrust::raw_pointer_cast(histogram.data()), 2, 0, 10, 1);
 }
 
-C2H_TEST("cub::DeviceHistogram::HistogramEven 2D non-env API", "[histogram][device]")
+C2H_TEST("cub::DeviceHistogram::HistogramEven 2D non-env overload is not ambiguous", "[histogram][device]")
 {
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);
@@ -36,7 +36,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramEven 2D non-env API", "[histogram][devi
     sizeof(int));
 }
 
-C2H_TEST("cub::DeviceHistogram::MultiHistogramEven non-env API", "[histogram][device]")
+C2H_TEST("cub::DeviceHistogram::MultiHistogramEven non-env overload is not ambiguous", "[histogram][device]")
 {
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);
@@ -49,7 +49,7 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramEven non-env API", "[histogram][de
     nullptr, temp_storage_bytes, samples.begin(), d_histogram, num_levels, lower_level, upper_level, 1);
 }
 
-C2H_TEST("cub::DeviceHistogram::MultiHistogramEven 2D non-env API", "[histogram][device]")
+C2H_TEST("cub::DeviceHistogram::MultiHistogramEven 2D non-env overload is not ambiguous", "[histogram][device]")
 {
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);
@@ -62,7 +62,7 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramEven 2D non-env API", "[histogram]
     nullptr, temp_storage_bytes, samples.begin(), d_histogram, num_levels, lower_level, upper_level, 1, 1, sizeof(int));
 }
 
-C2H_TEST("cub::DeviceHistogram::HistogramRange non-env API", "[histogram][device]")
+C2H_TEST("cub::DeviceHistogram::HistogramRange non-env overload is not ambiguous", "[histogram][device]")
 {
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);
@@ -78,7 +78,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramRange non-env API", "[histogram][device
     1);
 }
 
-C2H_TEST("cub::DeviceHistogram::HistogramRange 2D non-env API", "[histogram][device]")
+C2H_TEST("cub::DeviceHistogram::HistogramRange 2D non-env overload is not ambiguous", "[histogram][device]")
 {
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);
@@ -96,7 +96,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramRange 2D non-env API", "[histogram][dev
     sizeof(int));
 }
 
-C2H_TEST("cub::DeviceHistogram::MultiHistogramRange non-env API", "[histogram][device]")
+C2H_TEST("cub::DeviceHistogram::MultiHistogramRange non-env overload is not ambiguous", "[histogram][device]")
 {
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);
@@ -109,7 +109,7 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramRange non-env API", "[histogram][d
     nullptr, temp_storage_bytes, samples.begin(), d_histogram, num_levels, d_levels, 1);
 }
 
-C2H_TEST("cub::DeviceHistogram::MultiHistogramRange 2D non-env API", "[histogram][device]")
+C2H_TEST("cub::DeviceHistogram::MultiHistogramRange 2D non-env overload is not ambiguous", "[histogram][device]")
 {
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);

--- a/cub/test/catch2_test_device_histogram_api.cu
+++ b/cub/test/catch2_test_device_histogram_api.cu
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/device/device_histogram.cuh>
+
+#include <thrust/device_vector.h>
+
+#include <cuda/std/array>
+
+#include <c2h/catch2_test_helper.h>
+
+C2H_TEST("cub::DeviceHistogram::HistogramEven non-env API", "[histogram][device]")
+{
+  thrust::device_vector<int> samples(1);
+  thrust::device_vector<int> histogram(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceHistogram::HistogramEven(
+    nullptr, temp_storage_bytes, samples.begin(), thrust::raw_pointer_cast(histogram.data()), 2, 0, 10, 1);
+}
+
+C2H_TEST("cub::DeviceHistogram::HistogramEven 2D non-env API", "[histogram][device]")
+{
+  thrust::device_vector<int> samples(1);
+  thrust::device_vector<int> histogram(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceHistogram::HistogramEven(
+    nullptr,
+    temp_storage_bytes,
+    samples.begin(),
+    thrust::raw_pointer_cast(histogram.data()),
+    2,
+    0,
+    10,
+    1,
+    1,
+    sizeof(int));
+}
+
+C2H_TEST("cub::DeviceHistogram::MultiHistogramEven non-env API", "[histogram][device]")
+{
+  thrust::device_vector<int> samples(1);
+  thrust::device_vector<int> histogram(1);
+  ::cuda::std::array<int*, 1> d_histogram{thrust::raw_pointer_cast(histogram.data())};
+  ::cuda::std::array<int, 1> num_levels{2};
+  ::cuda::std::array<int, 1> lower_level{0};
+  ::cuda::std::array<int, 1> upper_level{10};
+  size_t temp_storage_bytes = 0;
+  cub::DeviceHistogram::MultiHistogramEven<1, 1>(
+    nullptr, temp_storage_bytes, samples.begin(), d_histogram, num_levels, lower_level, upper_level, 1);
+}
+
+C2H_TEST("cub::DeviceHistogram::MultiHistogramEven 2D non-env API", "[histogram][device]")
+{
+  thrust::device_vector<int> samples(1);
+  thrust::device_vector<int> histogram(1);
+  ::cuda::std::array<int*, 1> d_histogram{thrust::raw_pointer_cast(histogram.data())};
+  ::cuda::std::array<int, 1> num_levels{2};
+  ::cuda::std::array<int, 1> lower_level{0};
+  ::cuda::std::array<int, 1> upper_level{10};
+  size_t temp_storage_bytes = 0;
+  cub::DeviceHistogram::MultiHistogramEven<1, 1>(
+    nullptr, temp_storage_bytes, samples.begin(), d_histogram, num_levels, lower_level, upper_level, 1, 1, sizeof(int));
+}
+
+C2H_TEST("cub::DeviceHistogram::HistogramRange non-env API", "[histogram][device]")
+{
+  thrust::device_vector<int> samples(1);
+  thrust::device_vector<int> histogram(1);
+  thrust::device_vector<int> levels{0, 5, 10};
+  size_t temp_storage_bytes = 0;
+  cub::DeviceHistogram::HistogramRange(
+    nullptr,
+    temp_storage_bytes,
+    samples.begin(),
+    thrust::raw_pointer_cast(histogram.data()),
+    3,
+    thrust::raw_pointer_cast(levels.data()),
+    1);
+}
+
+C2H_TEST("cub::DeviceHistogram::HistogramRange 2D non-env API", "[histogram][device]")
+{
+  thrust::device_vector<int> samples(1);
+  thrust::device_vector<int> histogram(1);
+  thrust::device_vector<int> levels{0, 5, 10};
+  size_t temp_storage_bytes = 0;
+  cub::DeviceHistogram::HistogramRange(
+    nullptr,
+    temp_storage_bytes,
+    samples.begin(),
+    thrust::raw_pointer_cast(histogram.data()),
+    3,
+    thrust::raw_pointer_cast(levels.data()),
+    1,
+    1,
+    sizeof(int));
+}
+
+C2H_TEST("cub::DeviceHistogram::MultiHistogramRange non-env API", "[histogram][device]")
+{
+  thrust::device_vector<int> samples(1);
+  thrust::device_vector<int> histogram(1);
+  thrust::device_vector<int> levels{0, 5, 10};
+  ::cuda::std::array<int*, 1> d_histogram{thrust::raw_pointer_cast(histogram.data())};
+  ::cuda::std::array<int, 1> num_levels{3};
+  ::cuda::std::array<const int*, 1> d_levels{thrust::raw_pointer_cast(levels.data())};
+  size_t temp_storage_bytes = 0;
+  cub::DeviceHistogram::MultiHistogramRange<1, 1>(
+    nullptr, temp_storage_bytes, samples.begin(), d_histogram, num_levels, d_levels, 1);
+}
+
+C2H_TEST("cub::DeviceHistogram::MultiHistogramRange 2D non-env API", "[histogram][device]")
+{
+  thrust::device_vector<int> samples(1);
+  thrust::device_vector<int> histogram(1);
+  thrust::device_vector<int> levels{0, 5, 10};
+  ::cuda::std::array<int*, 1> d_histogram{thrust::raw_pointer_cast(histogram.data())};
+  ::cuda::std::array<int, 1> num_levels{3};
+  ::cuda::std::array<const int*, 1> d_levels{thrust::raw_pointer_cast(levels.data())};
+  size_t temp_storage_bytes = 0;
+  cub::DeviceHistogram::MultiHistogramRange<1, 1>(
+    nullptr, temp_storage_bytes, samples.begin(), d_histogram, num_levels, d_levels, 1, 1, sizeof(int));
+}

--- a/cub/test/catch2_test_device_histogram_env_api.cu
+++ b/cub/test/catch2_test_device_histogram_env_api.cu
@@ -27,7 +27,6 @@ C2H_TEST("cub::DeviceHistogram::HistogramEven accepts env with stream", "[histog
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceHistogram::HistogramEven(
     thrust::raw_pointer_cast(d_samples.data()),
@@ -36,7 +35,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramEven accepts env with stream", "[histog
     lower_level,
     upper_level,
     num_samples,
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceHistogram::HistogramEven failed with status: " << error << '\n';
@@ -67,7 +66,6 @@ C2H_TEST("cub::DeviceHistogram::HistogramEven accepts env with stream (2D)", "[h
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceHistogram::HistogramEven(
     thrust::raw_pointer_cast(d_samples.data()),
@@ -78,7 +76,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramEven accepts env with stream (2D)", "[h
     num_row_samples,
     num_rows,
     row_stride_bytes,
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceHistogram::HistogramEven (2D) failed with status: " << error << '\n';
@@ -104,7 +102,6 @@ C2H_TEST("cub::DeviceHistogram::HistogramRange accepts env with stream", "[histo
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceHistogram::HistogramRange(
     thrust::raw_pointer_cast(d_samples.data()),
@@ -112,7 +109,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramRange accepts env with stream", "[histo
     num_levels,
     thrust::raw_pointer_cast(d_levels.data()),
     num_samples,
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceHistogram::HistogramRange failed with status: " << error << '\n';
@@ -142,7 +139,6 @@ C2H_TEST("cub::DeviceHistogram::HistogramRange accepts env with stream (2D)", "[
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceHistogram::HistogramRange(
     thrust::raw_pointer_cast(d_samples.data()),
@@ -152,7 +148,7 @@ C2H_TEST("cub::DeviceHistogram::HistogramRange accepts env with stream (2D)", "[
     num_row_samples,
     num_rows,
     row_stride_bytes,
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceHistogram::HistogramRange (2D) failed with status: " << error << '\n';
@@ -196,10 +192,15 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramEven accepts env with stream (1D)"
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-    thrust::raw_pointer_cast(d_samples.data()), d_histogram, num_levels, lower_level, upper_level, num_pixels, env);
+    thrust::raw_pointer_cast(d_samples.data()),
+    d_histogram,
+    num_levels,
+    lower_level,
+    upper_level,
+    num_pixels,
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceHistogram::MultiHistogramEven failed with status: " << error << '\n';
@@ -252,7 +253,6 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramEven accepts env with stream (2D)"
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
     thrust::raw_pointer_cast(d_samples.data()),
@@ -263,7 +263,7 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramEven accepts env with stream (2D)"
     num_row_pixels,
     num_rows,
     row_stride_bytes,
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceHistogram::MultiHistogramEven (2D) failed with status: " << error << '\n';
@@ -318,10 +318,9 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramRange accepts env with stream (1D)
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-    thrust::raw_pointer_cast(d_samples.data()), d_histogram, num_levels, d_levels, num_pixels, env);
+    thrust::raw_pointer_cast(d_samples.data()), d_histogram, num_levels, d_levels, num_pixels, stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceHistogram::MultiHistogramRange failed with status: " << error << '\n';
@@ -381,7 +380,6 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramRange accepts env with stream (2D)
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
     thrust::raw_pointer_cast(d_samples.data()),
@@ -391,7 +389,7 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramRange accepts env with stream (2D)
     num_row_pixels,
     num_rows,
     row_stride_bytes,
-    env);
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceHistogram::MultiHistogramRange (2D) failed with status: " << error << '\n';

--- a/cub/test/catch2_test_device_merge_sort_api.cu
+++ b/cub/test/catch2_test_device_merge_sort_api.cu
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/device/device_merge_sort.cuh>
+
+#include <thrust/device_vector.h>
+
+#include <c2h/catch2_test_helper.h>
+
+C2H_TEST("cub::DeviceMergeSort::SortPairs non-env API", "[merge_sort][device]")
+{
+  thrust::device_vector<int> keys(1);
+  thrust::device_vector<int> values(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceMergeSort::SortPairs(nullptr, temp_storage_bytes, keys.begin(), values.begin(), 1, cuda::std::less<>{});
+}
+
+C2H_TEST("cub::DeviceMergeSort::SortPairsCopy non-env API", "[merge_sort][device]")
+{
+  thrust::device_vector<int> keys_in(1);
+  thrust::device_vector<int> values_in(1);
+  thrust::device_vector<int> keys_out(1);
+  thrust::device_vector<int> values_out(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceMergeSort::SortPairsCopy(
+    nullptr,
+    temp_storage_bytes,
+    keys_in.begin(),
+    values_in.begin(),
+    keys_out.begin(),
+    values_out.begin(),
+    1,
+    cuda::std::less<>{});
+}
+
+C2H_TEST("cub::DeviceMergeSort::SortKeys non-env API", "[merge_sort][device]")
+{
+  thrust::device_vector<int> keys(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceMergeSort::SortKeys(nullptr, temp_storage_bytes, keys.begin(), 1, cuda::std::less<>{});
+}
+
+C2H_TEST("cub::DeviceMergeSort::SortKeysCopy non-env API", "[merge_sort][device]")
+{
+  thrust::device_vector<int> keys_in(1);
+  thrust::device_vector<int> keys_out(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceMergeSort::SortKeysCopy(
+    nullptr, temp_storage_bytes, keys_in.begin(), keys_out.begin(), 1, cuda::std::less<>{});
+}
+
+C2H_TEST("cub::DeviceMergeSort::StableSortPairs non-env API", "[merge_sort][device]")
+{
+  thrust::device_vector<int> keys(1);
+  thrust::device_vector<int> values(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceMergeSort::StableSortPairs(
+    nullptr, temp_storage_bytes, keys.begin(), values.begin(), 1, cuda::std::less<>{});
+}
+
+C2H_TEST("cub::DeviceMergeSort::StableSortKeys non-env API", "[merge_sort][device]")
+{
+  thrust::device_vector<int> keys(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceMergeSort::StableSortKeys(nullptr, temp_storage_bytes, keys.begin(), 1, cuda::std::less<>{});
+}
+
+C2H_TEST("cub::DeviceMergeSort::StableSortKeysCopy non-env API", "[merge_sort][device]")
+{
+  thrust::device_vector<int> keys_in(1);
+  thrust::device_vector<int> keys_out(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceMergeSort::StableSortKeysCopy(
+    nullptr, temp_storage_bytes, keys_in.begin(), keys_out.begin(), 1, cuda::std::less<>{});
+}

--- a/cub/test/catch2_test_device_merge_sort_api.cu
+++ b/cub/test/catch2_test_device_merge_sort_api.cu
@@ -7,7 +7,7 @@
 
 #include <c2h/catch2_test_helper.h>
 
-C2H_TEST("cub::DeviceMergeSort::SortPairs non-env API", "[merge_sort][device]")
+C2H_TEST("cub::DeviceMergeSort::SortPairs non-env overload is not ambiguous", "[merge_sort][device]")
 {
   thrust::device_vector<int> keys(1);
   thrust::device_vector<int> values(1);
@@ -15,7 +15,7 @@ C2H_TEST("cub::DeviceMergeSort::SortPairs non-env API", "[merge_sort][device]")
   cub::DeviceMergeSort::SortPairs(nullptr, temp_storage_bytes, keys.begin(), values.begin(), 1, cuda::std::less<>{});
 }
 
-C2H_TEST("cub::DeviceMergeSort::SortPairsCopy non-env API", "[merge_sort][device]")
+C2H_TEST("cub::DeviceMergeSort::SortPairsCopy non-env overload is not ambiguous", "[merge_sort][device]")
 {
   thrust::device_vector<int> keys_in(1);
   thrust::device_vector<int> values_in(1);
@@ -33,14 +33,14 @@ C2H_TEST("cub::DeviceMergeSort::SortPairsCopy non-env API", "[merge_sort][device
     cuda::std::less<>{});
 }
 
-C2H_TEST("cub::DeviceMergeSort::SortKeys non-env API", "[merge_sort][device]")
+C2H_TEST("cub::DeviceMergeSort::SortKeys non-env overload is not ambiguous", "[merge_sort][device]")
 {
   thrust::device_vector<int> keys(1);
   size_t temp_storage_bytes = 0;
   cub::DeviceMergeSort::SortKeys(nullptr, temp_storage_bytes, keys.begin(), 1, cuda::std::less<>{});
 }
 
-C2H_TEST("cub::DeviceMergeSort::SortKeysCopy non-env API", "[merge_sort][device]")
+C2H_TEST("cub::DeviceMergeSort::SortKeysCopy non-env overload is not ambiguous", "[merge_sort][device]")
 {
   thrust::device_vector<int> keys_in(1);
   thrust::device_vector<int> keys_out(1);
@@ -49,7 +49,7 @@ C2H_TEST("cub::DeviceMergeSort::SortKeysCopy non-env API", "[merge_sort][device]
     nullptr, temp_storage_bytes, keys_in.begin(), keys_out.begin(), 1, cuda::std::less<>{});
 }
 
-C2H_TEST("cub::DeviceMergeSort::StableSortPairs non-env API", "[merge_sort][device]")
+C2H_TEST("cub::DeviceMergeSort::StableSortPairs non-env overload is not ambiguous", "[merge_sort][device]")
 {
   thrust::device_vector<int> keys(1);
   thrust::device_vector<int> values(1);
@@ -58,14 +58,14 @@ C2H_TEST("cub::DeviceMergeSort::StableSortPairs non-env API", "[merge_sort][devi
     nullptr, temp_storage_bytes, keys.begin(), values.begin(), 1, cuda::std::less<>{});
 }
 
-C2H_TEST("cub::DeviceMergeSort::StableSortKeys non-env API", "[merge_sort][device]")
+C2H_TEST("cub::DeviceMergeSort::StableSortKeys non-env overload is not ambiguous", "[merge_sort][device]")
 {
   thrust::device_vector<int> keys(1);
   size_t temp_storage_bytes = 0;
   cub::DeviceMergeSort::StableSortKeys(nullptr, temp_storage_bytes, keys.begin(), 1, cuda::std::less<>{});
 }
 
-C2H_TEST("cub::DeviceMergeSort::StableSortKeysCopy non-env API", "[merge_sort][device]")
+C2H_TEST("cub::DeviceMergeSort::StableSortKeysCopy non-env overload is not ambiguous", "[merge_sort][device]")
 {
   thrust::device_vector<int> keys_in(1);
   thrust::device_vector<int> keys_out(1);

--- a/cub/test/catch2_test_device_merge_sort_env_api.cu
+++ b/cub/test/catch2_test_device_merge_sort_env_api.cu
@@ -123,6 +123,7 @@ C2H_TEST("cub::DeviceMergeSort::SortPairsCopy env-based API", "[merge_sort][env]
   thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   thrust::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   // example-end sort-pairs-copy-env
+  stream.sync();
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(d_keys_out == expected_keys);
@@ -151,6 +152,7 @@ C2H_TEST("cub::DeviceMergeSort::SortKeysCopy env-based API", "[merge_sort][env]"
 
   thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   // example-end sort-keys-copy-env
+  stream.sync();
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(d_keys_out == expected_keys);
@@ -178,6 +180,7 @@ C2H_TEST("cub::DeviceMergeSort::StableSortKeysCopy env-based API", "[merge_sort]
 
   thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   // example-end stable-sort-keys-copy-env
+  stream.sync();
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(d_keys_out == expected_keys);

--- a/cub/test/catch2_test_device_merge_sort_env_api.cu
+++ b/cub/test/catch2_test_device_merge_sort_env_api.cu
@@ -80,7 +80,7 @@ C2H_TEST("cub::DeviceMergeSort::StableSortPairs env-based API", "[merge_sort][en
 C2H_TEST("cub::DeviceMergeSort::StableSortKeys env-based API", "[merge_sort][env]")
 {
   // example-begin stable-sort-keys-env
-  auto d_keys = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
+  auto d_keys = thrust::device_vector<int>{8, 6, 7, 5, 5, 3, 0, 9};
 
   auto error =
     cub::DeviceMergeSort::StableSortKeys(d_keys.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{});
@@ -89,7 +89,7 @@ C2H_TEST("cub::DeviceMergeSort::StableSortKeys env-based API", "[merge_sort][env
     std::cerr << "cub::DeviceMergeSort::StableSortKeys failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  thrust::device_vector<int> expected_keys{0, 3, 5, 5, 6, 7, 8, 9};
   // example-end stable-sort-keys-env
 
   REQUIRE(error == cudaSuccess);
@@ -161,8 +161,8 @@ C2H_TEST("cub::DeviceMergeSort::SortKeysCopy env-based API", "[merge_sort][env]"
 C2H_TEST("cub::DeviceMergeSort::StableSortKeysCopy env-based API", "[merge_sort][env]")
 {
   // example-begin stable-sort-keys-copy-env
-  auto d_keys_in  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
-  auto d_keys_out = thrust::device_vector<int>(7);
+  auto d_keys_in  = thrust::device_vector<int>{8, 6, 7, 5, 5, 3, 0, 9};
+  auto d_keys_out = thrust::device_vector<int>(8);
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
@@ -178,10 +178,30 @@ C2H_TEST("cub::DeviceMergeSort::StableSortKeysCopy env-based API", "[merge_sort]
     std::cerr << "cub::DeviceMergeSort::StableSortKeysCopy failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  thrust::device_vector<int> expected_keys{0, 3, 5, 5, 6, 7, 8, 9};
   // example-end stable-sort-keys-copy-env
   stream.sync();
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(d_keys_out == expected_keys);
+}
+
+C2H_TEST("cub::DeviceMergeSort::SortPairs env-based API with greater comparator", "[merge_sort][env]")
+{
+  auto d_keys   = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
+  auto d_values = thrust::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
+
+  auto error = cub::DeviceMergeSort::SortPairs(
+    d_keys.data().get(), d_values.data().get(), static_cast<int>(d_keys.size()), cuda::std::greater<int>{});
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceMergeSort::SortPairs (greater) failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
+  thrust::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_keys == expected_keys);
+  REQUIRE(d_values == expected_values);
 }

--- a/cub/test/catch2_test_device_scan_api.cu
+++ b/cub/test/catch2_test_device_scan_api.cu
@@ -39,7 +39,7 @@ C2H_TEST("Device inclusive scan works", "[scan][device]")
   REQUIRE(expected == out);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveSum non-env API", "[scan][device]")
+C2H_TEST("cub::DeviceScan::ExclusiveSum non-env overload is not ambiguous", "[scan][device]")
 {
   thrust::device_vector<int> input(1);
   thrust::device_vector<int> out(1);
@@ -47,14 +47,14 @@ C2H_TEST("cub::DeviceScan::ExclusiveSum non-env API", "[scan][device]")
   cub::DeviceScan::ExclusiveSum(nullptr, temp_storage_bytes, input.begin(), out.begin(), 1);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveSum non-env in-place API", "[scan][device]")
+C2H_TEST("cub::DeviceScan::ExclusiveSum non-env in-place overload is not ambiguous", "[scan][device]")
 {
   thrust::device_vector<int> data(1);
   size_t temp_storage_bytes = 0;
   cub::DeviceScan::ExclusiveSum(nullptr, temp_storage_bytes, data.begin(), 1);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveScan non-env API", "[scan][device]")
+C2H_TEST("cub::DeviceScan::ExclusiveScan non-env overload is not ambiguous", "[scan][device]")
 {
   thrust::device_vector<int> input(1);
   thrust::device_vector<int> out(1);
@@ -62,14 +62,14 @@ C2H_TEST("cub::DeviceScan::ExclusiveScan non-env API", "[scan][device]")
   cub::DeviceScan::ExclusiveScan(nullptr, temp_storage_bytes, input.begin(), out.begin(), cuda::std::plus<>{}, 5, 1);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveScan non-env in-place API", "[scan][device]")
+C2H_TEST("cub::DeviceScan::ExclusiveScan non-env in-place overload is not ambiguous", "[scan][device]")
 {
   thrust::device_vector<int> data(1);
   size_t temp_storage_bytes = 0;
   cub::DeviceScan::ExclusiveScan(nullptr, temp_storage_bytes, data.begin(), cuda::std::plus<>{}, 5, 1);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveScan FutureValue non-env API", "[scan][device]")
+C2H_TEST("cub::DeviceScan::ExclusiveScan FutureValue non-env overload is not ambiguous", "[scan][device]")
 {
   thrust::device_vector<int> input(1);
   thrust::device_vector<int> out(1);
@@ -80,7 +80,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScan FutureValue non-env API", "[scan][devic
     nullptr, temp_storage_bytes, input.begin(), out.begin(), cuda::std::plus<>{}, future_init, 1);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveScan FutureValue non-env in-place API", "[scan][device]")
+C2H_TEST("cub::DeviceScan::ExclusiveScan FutureValue non-env in-place overload is not ambiguous", "[scan][device]")
 {
   thrust::device_vector<int> data(1);
   thrust::device_vector<int> init_storage(1, 5);
@@ -89,7 +89,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScan FutureValue non-env in-place API", "[sc
   cub::DeviceScan::ExclusiveScan(nullptr, temp_storage_bytes, data.begin(), cuda::std::plus<>{}, future_init, 1);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveSum non-env API", "[scan][device]")
+C2H_TEST("cub::DeviceScan::InclusiveSum non-env overload is not ambiguous", "[scan][device]")
 {
   thrust::device_vector<int> input(1);
   thrust::device_vector<int> out(1);
@@ -97,14 +97,14 @@ C2H_TEST("cub::DeviceScan::InclusiveSum non-env API", "[scan][device]")
   cub::DeviceScan::InclusiveSum(nullptr, temp_storage_bytes, input.begin(), out.begin(), 1);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveSum non-env in-place API", "[scan][device]")
+C2H_TEST("cub::DeviceScan::InclusiveSum non-env in-place overload is not ambiguous", "[scan][device]")
 {
   thrust::device_vector<int> data(1);
   size_t temp_storage_bytes = 0;
   cub::DeviceScan::InclusiveSum(nullptr, temp_storage_bytes, data.begin(), 1);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveScan non-env API", "[scan][device]")
+C2H_TEST("cub::DeviceScan::InclusiveScan non-env overload is not ambiguous", "[scan][device]")
 {
   thrust::device_vector<int> input(1);
   thrust::device_vector<int> out(1);
@@ -112,14 +112,14 @@ C2H_TEST("cub::DeviceScan::InclusiveScan non-env API", "[scan][device]")
   cub::DeviceScan::InclusiveScan(nullptr, temp_storage_bytes, input.begin(), out.begin(), cuda::std::plus<>{}, 1);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveScan non-env in-place API", "[scan][device]")
+C2H_TEST("cub::DeviceScan::InclusiveScan non-env in-place overload is not ambiguous", "[scan][device]")
 {
   thrust::device_vector<int> data(1);
   size_t temp_storage_bytes = 0;
   cub::DeviceScan::InclusiveScan(nullptr, temp_storage_bytes, data.begin(), cuda::std::plus<>{}, 1);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveScanInit non-env API", "[scan][device]")
+C2H_TEST("cub::DeviceScan::InclusiveScanInit non-env overload is not ambiguous", "[scan][device]")
 {
   thrust::device_vector<int> input(1);
   thrust::device_vector<int> out(1);
@@ -127,7 +127,7 @@ C2H_TEST("cub::DeviceScan::InclusiveScanInit non-env API", "[scan][device]")
   cub::DeviceScan::InclusiveScanInit(nullptr, temp_storage_bytes, input.begin(), out.begin(), cuda::std::plus<>{}, 5, 1);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveSumByKey non-env API", "[scan][device]")
+C2H_TEST("cub::DeviceScan::ExclusiveSumByKey non-env overload is not ambiguous", "[scan][device]")
 {
   thrust::device_vector<int> keys(1);
   thrust::device_vector<int> values_in(1);
@@ -137,7 +137,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveSumByKey non-env API", "[scan][device]")
     nullptr, temp_storage_bytes, keys.begin(), values_in.begin(), values_out.begin(), 1);
 }
 
-C2H_TEST("cub::DeviceScan::ExclusiveScanByKey non-env API", "[scan][device]")
+C2H_TEST("cub::DeviceScan::ExclusiveScanByKey non-env overload is not ambiguous", "[scan][device]")
 {
   thrust::device_vector<int> keys(1);
   thrust::device_vector<int> values_in(1);
@@ -147,7 +147,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScanByKey non-env API", "[scan][device]")
     nullptr, temp_storage_bytes, keys.begin(), values_in.begin(), values_out.begin(), cuda::std::plus<>{}, 5, 1);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveSumByKey non-env API", "[scan][device]")
+C2H_TEST("cub::DeviceScan::InclusiveSumByKey non-env overload is not ambiguous", "[scan][device]")
 {
   thrust::device_vector<int> keys(1);
   thrust::device_vector<int> values_in(1);
@@ -157,7 +157,7 @@ C2H_TEST("cub::DeviceScan::InclusiveSumByKey non-env API", "[scan][device]")
     nullptr, temp_storage_bytes, keys.begin(), values_in.begin(), values_out.begin(), 1);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveScanByKey non-env API", "[scan][device]")
+C2H_TEST("cub::DeviceScan::InclusiveScanByKey non-env overload is not ambiguous", "[scan][device]")
 {
   thrust::device_vector<int> keys(1);
   thrust::device_vector<int> values_in(1);

--- a/cub/test/catch2_test_device_scan_api.cu
+++ b/cub/test/catch2_test_device_scan_api.cu
@@ -38,3 +38,131 @@ C2H_TEST("Device inclusive scan works", "[scan][device]")
 
   REQUIRE(expected == out);
 }
+
+C2H_TEST("cub::DeviceScan::ExclusiveSum non-env API", "[scan][device]")
+{
+  thrust::device_vector<int> input(1);
+  thrust::device_vector<int> out(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceScan::ExclusiveSum(nullptr, temp_storage_bytes, input.begin(), out.begin(), 1);
+}
+
+C2H_TEST("cub::DeviceScan::ExclusiveSum non-env in-place API", "[scan][device]")
+{
+  thrust::device_vector<int> data(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceScan::ExclusiveSum(nullptr, temp_storage_bytes, data.begin(), 1);
+}
+
+C2H_TEST("cub::DeviceScan::ExclusiveScan non-env API", "[scan][device]")
+{
+  thrust::device_vector<int> input(1);
+  thrust::device_vector<int> out(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceScan::ExclusiveScan(nullptr, temp_storage_bytes, input.begin(), out.begin(), cuda::std::plus<>{}, 5, 1);
+}
+
+C2H_TEST("cub::DeviceScan::ExclusiveScan non-env in-place API", "[scan][device]")
+{
+  thrust::device_vector<int> data(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceScan::ExclusiveScan(nullptr, temp_storage_bytes, data.begin(), cuda::std::plus<>{}, 5, 1);
+}
+
+C2H_TEST("cub::DeviceScan::ExclusiveScan FutureValue non-env API", "[scan][device]")
+{
+  thrust::device_vector<int> input(1);
+  thrust::device_vector<int> out(1);
+  thrust::device_vector<int> init_storage(1, 5);
+  auto future_init          = cub::FutureValue<int>(thrust::raw_pointer_cast(init_storage.data()));
+  size_t temp_storage_bytes = 0;
+  cub::DeviceScan::ExclusiveScan(
+    nullptr, temp_storage_bytes, input.begin(), out.begin(), cuda::std::plus<>{}, future_init, 1);
+}
+
+C2H_TEST("cub::DeviceScan::ExclusiveScan FutureValue non-env in-place API", "[scan][device]")
+{
+  thrust::device_vector<int> data(1);
+  thrust::device_vector<int> init_storage(1, 5);
+  auto future_init          = cub::FutureValue<int>(thrust::raw_pointer_cast(init_storage.data()));
+  size_t temp_storage_bytes = 0;
+  cub::DeviceScan::ExclusiveScan(nullptr, temp_storage_bytes, data.begin(), cuda::std::plus<>{}, future_init, 1);
+}
+
+C2H_TEST("cub::DeviceScan::InclusiveSum non-env API", "[scan][device]")
+{
+  thrust::device_vector<int> input(1);
+  thrust::device_vector<int> out(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceScan::InclusiveSum(nullptr, temp_storage_bytes, input.begin(), out.begin(), 1);
+}
+
+C2H_TEST("cub::DeviceScan::InclusiveSum non-env in-place API", "[scan][device]")
+{
+  thrust::device_vector<int> data(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceScan::InclusiveSum(nullptr, temp_storage_bytes, data.begin(), 1);
+}
+
+C2H_TEST("cub::DeviceScan::InclusiveScan non-env API", "[scan][device]")
+{
+  thrust::device_vector<int> input(1);
+  thrust::device_vector<int> out(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceScan::InclusiveScan(nullptr, temp_storage_bytes, input.begin(), out.begin(), cuda::std::plus<>{}, 1);
+}
+
+C2H_TEST("cub::DeviceScan::InclusiveScan non-env in-place API", "[scan][device]")
+{
+  thrust::device_vector<int> data(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceScan::InclusiveScan(nullptr, temp_storage_bytes, data.begin(), cuda::std::plus<>{}, 1);
+}
+
+C2H_TEST("cub::DeviceScan::InclusiveScanInit non-env API", "[scan][device]")
+{
+  thrust::device_vector<int> input(1);
+  thrust::device_vector<int> out(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceScan::InclusiveScanInit(nullptr, temp_storage_bytes, input.begin(), out.begin(), cuda::std::plus<>{}, 5, 1);
+}
+
+C2H_TEST("cub::DeviceScan::ExclusiveSumByKey non-env API", "[scan][device]")
+{
+  thrust::device_vector<int> keys(1);
+  thrust::device_vector<int> values_in(1);
+  thrust::device_vector<int> values_out(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceScan::ExclusiveSumByKey(
+    nullptr, temp_storage_bytes, keys.begin(), values_in.begin(), values_out.begin(), 1);
+}
+
+C2H_TEST("cub::DeviceScan::ExclusiveScanByKey non-env API", "[scan][device]")
+{
+  thrust::device_vector<int> keys(1);
+  thrust::device_vector<int> values_in(1);
+  thrust::device_vector<int> values_out(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceScan::ExclusiveScanByKey(
+    nullptr, temp_storage_bytes, keys.begin(), values_in.begin(), values_out.begin(), cuda::std::plus<>{}, 5, 1);
+}
+
+C2H_TEST("cub::DeviceScan::InclusiveSumByKey non-env API", "[scan][device]")
+{
+  thrust::device_vector<int> keys(1);
+  thrust::device_vector<int> values_in(1);
+  thrust::device_vector<int> values_out(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceScan::InclusiveSumByKey(
+    nullptr, temp_storage_bytes, keys.begin(), values_in.begin(), values_out.begin(), 1);
+}
+
+C2H_TEST("cub::DeviceScan::InclusiveScanByKey non-env API", "[scan][device]")
+{
+  thrust::device_vector<int> keys(1);
+  thrust::device_vector<int> values_in(1);
+  thrust::device_vector<int> values_out(1);
+  size_t temp_storage_bytes = 0;
+  cub::DeviceScan::InclusiveScanByKey(
+    nullptr, temp_storage_bytes, keys.begin(), values_in.begin(), values_out.begin(), cuda::std::plus<>{}, 1);
+}

--- a/cub/test/catch2_test_device_scan_by_key_env_api.cu
+++ b/cub/test/catch2_test_device_scan_by_key_env_api.cu
@@ -23,10 +23,9 @@ C2H_TEST("cub::DeviceScan::ExclusiveSumByKey accepts stream environment", "[scan
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceScan::ExclusiveSumByKey(
-    keys.begin(), input.begin(), output.begin(), static_cast<int>(input.size()), cuda::std::equal_to<>{}, env);
+    keys.begin(), input.begin(), output.begin(), static_cast<int>(input.size()), cuda::std::equal_to<>{}, stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceScan::ExclusiveSumByKey failed with status: " << error << '\n';
@@ -35,6 +34,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveSumByKey accepts stream environment", "[scan
   thrust::device_vector<float> expected{0.0f, 8.0f, 0.0f, 7.0f, 12.0f, 0.0f, 0.0f};
   // example-end exclusive-sum-by-key-env
 
+  stream.sync();
   REQUIRE(error == cudaSuccess);
   REQUIRE(output == expected);
 }
@@ -50,10 +50,16 @@ C2H_TEST("cub::DeviceScan::ExclusiveScanByKey accepts stream environment", "[sca
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceScan::ExclusiveScanByKey(
-    keys.begin(), input.begin(), output.begin(), op, init, static_cast<int>(input.size()), cuda::std::equal_to<>{}, env);
+    keys.begin(),
+    input.begin(),
+    output.begin(),
+    op,
+    init,
+    static_cast<int>(input.size()),
+    cuda::std::equal_to<>{},
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceScan::ExclusiveScanByKey failed with status: " << error << '\n';
@@ -62,6 +68,7 @@ C2H_TEST("cub::DeviceScan::ExclusiveScanByKey accepts stream environment", "[sca
   thrust::device_vector<float> expected{0.0f, 8.0f, 0.0f, 7.0f, 12.0f, 0.0f, 0.0f};
   // example-end exclusive-scan-by-key-env
 
+  stream.sync();
   REQUIRE(error == cudaSuccess);
   REQUIRE(output == expected);
 }
@@ -75,10 +82,9 @@ C2H_TEST("cub::DeviceScan::InclusiveSumByKey accepts stream environment", "[scan
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceScan::InclusiveSumByKey(
-    keys.begin(), input.begin(), output.begin(), static_cast<int>(input.size()), cuda::std::equal_to<>{}, env);
+    keys.begin(), input.begin(), output.begin(), static_cast<int>(input.size()), cuda::std::equal_to<>{}, stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceScan::InclusiveSumByKey failed with status: " << error << '\n';
@@ -87,6 +93,7 @@ C2H_TEST("cub::DeviceScan::InclusiveSumByKey accepts stream environment", "[scan
   thrust::device_vector<float> expected{8.0f, 14.0f, 7.0f, 12.0f, 15.0f, 0.0f, 9.0f};
   // example-end inclusive-sum-by-key-env
 
+  stream.sync();
   REQUIRE(error == cudaSuccess);
   REQUIRE(output == expected);
 }
@@ -101,10 +108,15 @@ C2H_TEST("cub::DeviceScan::InclusiveScanByKey accepts stream environment", "[sca
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
   auto error = cub::DeviceScan::InclusiveScanByKey(
-    keys.begin(), input.begin(), output.begin(), op, static_cast<int>(input.size()), cuda::std::equal_to<>{}, env);
+    keys.begin(),
+    input.begin(),
+    output.begin(),
+    op,
+    static_cast<int>(input.size()),
+    cuda::std::equal_to<>{},
+    stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceScan::InclusiveScanByKey failed with status: " << error << '\n';
@@ -113,6 +125,7 @@ C2H_TEST("cub::DeviceScan::InclusiveScanByKey accepts stream environment", "[sca
   thrust::device_vector<float> expected{8.0f, 14.0f, 7.0f, 12.0f, 15.0f, 0.0f, 9.0f};
   // example-end inclusive-scan-by-key-env
 
+  stream.sync();
   REQUIRE(error == cudaSuccess);
   REQUIRE(output == expected);
 }

--- a/cub/test/catch2_test_device_scan_env_api.cu
+++ b/cub/test/catch2_test_device_scan_env_api.cu
@@ -194,10 +194,9 @@ C2H_TEST("cub::DeviceScan::ExclusiveScan with FutureValue accepts stream environ
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
-  auto error =
-    cub::DeviceScan::ExclusiveScan(input.begin(), output.begin(), cuda::std::plus{}, future_init, input.size(), env);
+  auto error = cub::DeviceScan::ExclusiveScan(
+    input.begin(), output.begin(), cuda::std::plus{}, future_init, input.size(), stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceScan::ExclusiveScan (FutureValue) failed with status: " << error << '\n';
@@ -240,9 +239,8 @@ C2H_TEST("cub::DeviceScan::InclusiveScan accepts stream environment", "[scan][en
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
-  auto error = cub::DeviceScan::InclusiveScan(input.begin(), output.begin(), op, input.size(), env);
+  auto error = cub::DeviceScan::InclusiveScan(input.begin(), output.begin(), op, input.size(), stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceScan::InclusiveScan failed with status: " << error << '\n';
@@ -287,9 +285,8 @@ C2H_TEST("cub::DeviceScan::InclusiveScanInit accepts stream environment", "[scan
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
-  auto env = cuda::std::execution::env{stream_ref};
 
-  auto error = cub::DeviceScan::InclusiveScanInit(input.begin(), output.begin(), op, init, input.size(), env);
+  auto error = cub::DeviceScan::InclusiveScanInit(input.begin(), output.begin(), op, init, input.size(), stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceScan::InclusiveScanInit failed with status: " << error << '\n';

--- a/cub/test/catch2_test_device_segmented_scan_api.cu
+++ b/cub/test/catch2_test_device_segmented_scan_api.cu
@@ -414,7 +414,8 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan API with three offset
   REQUIRE(status == cudaSuccess);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum non-env API (2 offsets)", "[segmented_scan][device]")
+C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum non-env overload is not ambiguous (2 offsets)",
+         "[segmented_scan][device]")
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);
@@ -424,7 +425,8 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum non-env API (2 offsets
     nullptr, temp_storage_bytes, in.begin(), out.begin(), offsets.begin(), offsets.begin() + 1, 1);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum non-env API (3 offsets)", "[segmented_scan][device]")
+C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum non-env overload is not ambiguous (3 offsets)",
+         "[segmented_scan][device]")
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);
@@ -442,7 +444,8 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum non-env API (3 offsets
     1);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan non-env API (2 offsets)", "[segmented_scan][device]")
+C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan non-env overload is not ambiguous (2 offsets)",
+         "[segmented_scan][device]")
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);
@@ -460,7 +463,8 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan non-env API (2 offset
     5);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan non-env API (3 offsets)", "[segmented_scan][device]")
+C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan non-env overload is not ambiguous (3 offsets)",
+         "[segmented_scan][device]")
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);
@@ -480,7 +484,8 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan non-env API (3 offset
     5);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum non-env API (2 offsets)", "[segmented_scan][device]")
+C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum non-env overload is not ambiguous (2 offsets)",
+         "[segmented_scan][device]")
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);
@@ -490,7 +495,8 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum non-env API (2 offsets
     nullptr, temp_storage_bytes, in.begin(), out.begin(), offsets.begin(), offsets.begin() + 1, 1);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum non-env API (3 offsets)", "[segmented_scan][device]")
+C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum non-env overload is not ambiguous (3 offsets)",
+         "[segmented_scan][device]")
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);
@@ -508,7 +514,8 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum non-env API (3 offsets
     1);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan non-env API (2 offsets)", "[segmented_scan][device]")
+C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan non-env overload is not ambiguous (2 offsets)",
+         "[segmented_scan][device]")
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);
@@ -518,7 +525,8 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan non-env API (2 offset
     nullptr, temp_storage_bytes, in.begin(), out.begin(), offsets.begin(), offsets.begin() + 1, 1, cuda::std::plus<>{});
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan non-env API (3 offsets)", "[segmented_scan][device]")
+C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan non-env overload is not ambiguous (3 offsets)",
+         "[segmented_scan][device]")
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);
@@ -537,7 +545,8 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan non-env API (3 offset
     cuda::std::plus<>{});
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit non-env API (2 offsets)", "[segmented_scan][device]")
+C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit non-env overload is not ambiguous (2 offsets)",
+         "[segmented_scan][device]")
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);
@@ -555,7 +564,8 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit non-env API (2 of
     5);
 }
 
-C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit non-env API (3 offsets)", "[segmented_scan][device]")
+C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit non-env overload is not ambiguous (3 offsets)",
+         "[segmented_scan][device]")
 {
   thrust::device_vector<int> in(1);
   thrust::device_vector<int> out(1);

--- a/cub/test/catch2_test_device_segmented_scan_api.cu
+++ b/cub/test/catch2_test_device_segmented_scan_api.cu
@@ -11,6 +11,7 @@
 
 #include <cuda/cmath>
 #include <cuda/iterator>
+#include <cuda/std/functional>
 
 #include <iostream> // std::cerr
 #include <string>
@@ -411,4 +412,165 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan API with three offset
   // example-end inclusive-segmented-scan-three-offsets
   REQUIRE(output == expected);
   REQUIRE(status == cudaSuccess);
+}
+
+C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum non-env API (2 offsets)", "[segmented_scan][device]")
+{
+  thrust::device_vector<int> in(1);
+  thrust::device_vector<int> out(1);
+  thrust::device_vector<int> offsets{0, 1};
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedScan::ExclusiveSegmentedSum(
+    nullptr, temp_storage_bytes, in.begin(), out.begin(), offsets.begin(), offsets.begin() + 1, 1);
+}
+
+C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum non-env API (3 offsets)", "[segmented_scan][device]")
+{
+  thrust::device_vector<int> in(1);
+  thrust::device_vector<int> out(1);
+  thrust::device_vector<int> in_offsets{0, 1};
+  thrust::device_vector<int> out_offsets{0};
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedScan::ExclusiveSegmentedSum(
+    nullptr,
+    temp_storage_bytes,
+    in.begin(),
+    out.begin(),
+    in_offsets.begin(),
+    in_offsets.begin() + 1,
+    out_offsets.begin(),
+    1);
+}
+
+C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan non-env API (2 offsets)", "[segmented_scan][device]")
+{
+  thrust::device_vector<int> in(1);
+  thrust::device_vector<int> out(1);
+  thrust::device_vector<int> offsets{0, 1};
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
+    nullptr,
+    temp_storage_bytes,
+    in.begin(),
+    out.begin(),
+    offsets.begin(),
+    offsets.begin() + 1,
+    1,
+    cuda::std::plus<>{},
+    5);
+}
+
+C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan non-env API (3 offsets)", "[segmented_scan][device]")
+{
+  thrust::device_vector<int> in(1);
+  thrust::device_vector<int> out(1);
+  thrust::device_vector<int> in_offsets{0, 1};
+  thrust::device_vector<int> out_offsets{0};
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
+    nullptr,
+    temp_storage_bytes,
+    in.begin(),
+    out.begin(),
+    in_offsets.begin(),
+    in_offsets.begin() + 1,
+    out_offsets.begin(),
+    1,
+    cuda::std::plus<>{},
+    5);
+}
+
+C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum non-env API (2 offsets)", "[segmented_scan][device]")
+{
+  thrust::device_vector<int> in(1);
+  thrust::device_vector<int> out(1);
+  thrust::device_vector<int> offsets{0, 1};
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedScan::InclusiveSegmentedSum(
+    nullptr, temp_storage_bytes, in.begin(), out.begin(), offsets.begin(), offsets.begin() + 1, 1);
+}
+
+C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum non-env API (3 offsets)", "[segmented_scan][device]")
+{
+  thrust::device_vector<int> in(1);
+  thrust::device_vector<int> out(1);
+  thrust::device_vector<int> in_offsets{0, 1};
+  thrust::device_vector<int> out_offsets{0};
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedScan::InclusiveSegmentedSum(
+    nullptr,
+    temp_storage_bytes,
+    in.begin(),
+    out.begin(),
+    in_offsets.begin(),
+    in_offsets.begin() + 1,
+    out_offsets.begin(),
+    1);
+}
+
+C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan non-env API (2 offsets)", "[segmented_scan][device]")
+{
+  thrust::device_vector<int> in(1);
+  thrust::device_vector<int> out(1);
+  thrust::device_vector<int> offsets{0, 1};
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedScan::InclusiveSegmentedScan(
+    nullptr, temp_storage_bytes, in.begin(), out.begin(), offsets.begin(), offsets.begin() + 1, 1, cuda::std::plus<>{});
+}
+
+C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan non-env API (3 offsets)", "[segmented_scan][device]")
+{
+  thrust::device_vector<int> in(1);
+  thrust::device_vector<int> out(1);
+  thrust::device_vector<int> in_offsets{0, 1};
+  thrust::device_vector<int> out_offsets{0};
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedScan::InclusiveSegmentedScan(
+    nullptr,
+    temp_storage_bytes,
+    in.begin(),
+    out.begin(),
+    in_offsets.begin(),
+    in_offsets.begin() + 1,
+    out_offsets.begin(),
+    1,
+    cuda::std::plus<>{});
+}
+
+C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit non-env API (2 offsets)", "[segmented_scan][device]")
+{
+  thrust::device_vector<int> in(1);
+  thrust::device_vector<int> out(1);
+  thrust::device_vector<int> offsets{0, 1};
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
+    nullptr,
+    temp_storage_bytes,
+    in.begin(),
+    out.begin(),
+    offsets.begin(),
+    offsets.begin() + 1,
+    1,
+    cuda::std::plus<>{},
+    5);
+}
+
+C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit non-env API (3 offsets)", "[segmented_scan][device]")
+{
+  thrust::device_vector<int> in(1);
+  thrust::device_vector<int> out(1);
+  thrust::device_vector<int> in_offsets{0, 1};
+  thrust::device_vector<int> out_offsets{0};
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
+    nullptr,
+    temp_storage_bytes,
+    in.begin(),
+    out.begin(),
+    in_offsets.begin(),
+    in_offsets.begin() + 1,
+    out_offsets.begin(),
+    1,
+    cuda::std::plus<>{},
+    5);
 }

--- a/cub/test/catch2_test_device_segmented_scan_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_scan_env_api.cu
@@ -8,6 +8,7 @@
 #include <thrust/device_vector.h>
 
 #include <cuda/devices>
+#include <cuda/functional>
 #include <cuda/stream>
 
 #include <iostream>
@@ -54,13 +55,13 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan accepts stream", "[se
   cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
-    d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, ::cuda::std::plus<>{}, 100, stream_ref);
+    d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, cuda::maximum<>{}, 4, stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceSegmentedScan::ExclusiveSegmentedScan failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{100, 108, 114, 121, 100, 103, 103, 100, 101};
+  thrust::device_vector<int> expected{4, 8, 8, 8, 4, 4, 4, 4, 4};
   // example-end exclusive-segmented-scan-env
   stream.sync();
 
@@ -108,13 +109,13 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan accepts stream", "[se
   cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedScan::InclusiveSegmentedScan(
-    d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, ::cuda::std::plus<>{}, stream_ref);
+    d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, cuda::maximum<>{}, stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceSegmentedScan::InclusiveSegmentedScan failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{8, 14, 21, 26, 3, 3, 12, 1, 3};
+  thrust::device_vector<int> expected{8, 8, 8, 8, 3, 3, 9, 1, 2};
   // example-end inclusive-segmented-scan-env
   stream.sync();
 
@@ -135,13 +136,13 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit accepts stream", 
   cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
-    d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, ::cuda::std::plus<>{}, 100, stream_ref);
+    d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, cuda::maximum<>{}, 4, stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceSegmentedScan::InclusiveSegmentedScanInit failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{108, 114, 121, 126, 103, 103, 112, 101, 103};
+  thrust::device_vector<int> expected{8, 8, 8, 8, 4, 4, 9, 4, 4};
   // example-end inclusive-segmented-scan-init-env
   stream.sync();
 
@@ -188,7 +189,7 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan (separate offsets) ac
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
   auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
   auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
-  thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<int> d_in{3, 1, 4, 1, 5, 9, 2, 6};
   thrust::device_vector<int> d_out(10, sentinel);
 
   cuda::stream stream{cuda::devices[0]};
@@ -201,15 +202,15 @@ C2H_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan (separate offsets) ac
     d_in_off_it + 1,
     d_out_off_it,
     num_segments,
-    ::cuda::std::plus<>{},
-    100,
+    cuda::maximum<>{},
+    2,
     stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceSegmentedScan::ExclusiveSegmentedScan failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{100, 101, 103, sentinel, 100, 104, sentinel, 100, 106, 113};
+  thrust::device_vector<int> expected{2, 3, 3, sentinel, 2, 2, sentinel, 2, 9, 9};
   // example-end exclusive-segmented-scan-separate-env
   stream.sync();
 
@@ -256,27 +257,20 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan (separate offsets) ac
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
   auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
   auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
-  thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<int> d_in{3, 1, 4, 1, 5, 9, 2, 6};
   thrust::device_vector<int> d_out(10, sentinel);
 
   cuda::stream stream{cuda::devices[0]};
   cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedScan::InclusiveSegmentedScan(
-    d_in.begin(),
-    d_out.begin(),
-    d_in_off_it,
-    d_in_off_it + 1,
-    d_out_off_it,
-    num_segments,
-    ::cuda::std::plus<>{},
-    stream_ref);
+    d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, cuda::maximum<>{}, stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceSegmentedScan::InclusiveSegmentedScan failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{1, 3, 6, sentinel, 4, 9, sentinel, 6, 13, 21};
+  thrust::device_vector<int> expected{3, 3, 4, sentinel, 1, 5, sentinel, 9, 9, 9};
   // example-end inclusive-segmented-scan-separate-env
   stream.sync();
 
@@ -294,7 +288,7 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit (separate offsets
   thrust::device_vector<int> d_out_offsets{0, 4, 7};
   auto d_in_off_it  = thrust::raw_pointer_cast(d_in_offsets.data());
   auto d_out_off_it = thrust::raw_pointer_cast(d_out_offsets.data());
-  thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<int> d_in{3, 1, 4, 1, 5, 9, 2, 6};
   thrust::device_vector<int> d_out(10, sentinel);
 
   cuda::stream stream{cuda::devices[0]};
@@ -307,15 +301,15 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit (separate offsets
     d_in_off_it + 1,
     d_out_off_it,
     num_segments,
-    ::cuda::std::plus<>{},
-    100,
+    cuda::maximum<>{},
+    7,
     stream_ref);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceSegmentedScan::InclusiveSegmentedScanInit failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{101, 103, 106, sentinel, 104, 109, sentinel, 106, 113, 121};
+  thrust::device_vector<int> expected{7, 7, 7, sentinel, 7, 7, sentinel, 9, 9, 9};
   // example-end inclusive-segmented-scan-init-separate-env
   stream.sync();
 


### PR DESCRIPTION
closes #8175 

examines 

- `DeviceMergeSort`
- `DeviceHistogram`
- `DeviceScan`
- `DeviceSegmentedScan`

ambiguities found. important to backport.

`DeviceTopK` is still open so we cannot examine it here in order not to create conflicts.