### PR TITLE
Implement block TopK sieve and ranking API for handling multi-key workloads 

### DIFF
--- a/cub/cub/block/block_topk.cuh
+++ b/cub/cub/block/block_topk.cuh
@@ -27,19 +27,18 @@ class block_topk
 {
 private:
   using internal_block_topk_t = block_topk_air<KeyT, BlockDimX, ItemsPerThread, ValueT>;
+  using TempStorage_          = typename internal_block_topk_t::TempStorage;
 
 public:
-  struct TempStorage
-  {
-    typename internal_block_topk_t::TempStorage topk_storage;
-  };
+  struct TempStorage : Uninitialized<TempStorage_>
+  {};
 
 private:
-  TempStorage& storage;
+  TempStorage_& storage;
 
 public:
   _CCCL_DEVICE_API _CCCL_FORCEINLINE block_topk(TempStorage& storage)
-      : storage(storage)
+      : storage(storage.Alias())
   {}
 
   template <bool IsFullTile>
@@ -51,16 +50,16 @@ public:
     int begin_bit = 0,
     int end_bit   = sizeof(KeyT) * 8)
   {
-    internal_block_topk_t(storage.topk_storage)
-      .template select_pairs<detail::topk::select::max, IsFullTile>(keys, values, k, num_valid, begin_bit, end_bit);
+    internal_block_topk_t(storage).template select_pairs<detail::topk::select::max, IsFullTile>(
+      keys, values, k, num_valid, begin_bit, end_bit);
   }
 
   template <bool IsFullTile>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void
   max_keys(KeyT (&keys)[ItemsPerThread], int k, int num_valid, int begin_bit = 0, int end_bit = sizeof(KeyT) * 8)
   {
-    internal_block_topk_t(storage.topk_storage)
-      .template select_keys<detail::topk::select::max, IsFullTile>(keys, k, num_valid, begin_bit, end_bit);
+    internal_block_topk_t(storage).template select_keys<detail::topk::select::max, IsFullTile>(
+      keys, k, num_valid, begin_bit, end_bit);
   }
 
   template <bool IsFullTile>
@@ -72,16 +71,16 @@ public:
     int begin_bit = 0,
     int end_bit   = sizeof(KeyT) * 8)
   {
-    internal_block_topk_t(storage.topk_storage)
-      .template select_pairs<detail::topk::select::min, IsFullTile>(keys, values, k, num_valid, begin_bit, end_bit);
+    internal_block_topk_t(storage).template select_pairs<detail::topk::select::min, IsFullTile>(
+      keys, values, k, num_valid, begin_bit, end_bit);
   }
 
   template <bool IsFullTile>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void
   min_keys(KeyT (&keys)[ItemsPerThread], int k, int num_valid, int begin_bit = 0, int end_bit = sizeof(KeyT) * 8)
   {
-    internal_block_topk_t(storage.topk_storage)
-      .template select_keys<detail::topk::select::min, IsFullTile>(keys, k, num_valid, begin_bit, end_bit);
+    internal_block_topk_t(storage).template select_keys<detail::topk::select::min, IsFullTile>(
+      keys, k, num_valid, begin_bit, end_bit);
   }
 };
 } // namespace detail

--- a/cub/cub/block/block_topk_rank.cuh
+++ b/cub/cub/block/block_topk_rank.cuh
@@ -87,20 +87,20 @@ private:
   template <bool IsFullTile, int BlockDimX, bool IsBlockedInput = true>
   static _CCCL_DEVICE_API _CCCL_FORCEINLINE block_topk_key_states build(int k, int valid_items) noexcept
   {
-    if constexpr (IsFullTile)
+    [[maybe_unused]] constexpr int tile_items = BlockDimX * ItemsPerThread;
+    // Preconditions
+    _CCCL_ASSERT(k > 0 && k <= tile_items, "k must be in (0, tile_items]");
+    if constexpr (!IsFullTile)
     {
-      // Makes below code easier to read.
-      valid_items = BlockDimX * ItemsPerThread;
+      _CCCL_ASSERT(valid_items >= 0 && valid_items <= tile_items,
+                   "valid_items must be in [0, BlockDimX * ItemsPerThread]");
+      _CCCL_ASSERT(k <= valid_items, "k must be <= valid_items");
     }
-    const auto valid_initial_state =
-      k < valid_items ? (k > 0 ? class_value::candidate : class_value::rejected) : class_value::selected;
     block_topk_key_states states{};
-    states.k_ = ::cuda::std::max(k, 0);
-    // TODO (elstehle): Short-circuit if k is constrained to be positive
-    // TODO (elstehle): Short-circuit if k is greater than the number of items in the tile
-    states.num_candidates_                = (k < valid_items && k > 0) ? valid_items : 0;
-    states.num_selected_                  = k < valid_items ? 0 : valid_items;
-    states.num_valid_                     = valid_items;
+    states.k_                             = k;
+    states.num_candidates_                = IsFullTile ? tile_items : valid_items;
+    states.num_selected_                  = 0;
+    states.num_valid_                     = IsFullTile ? tile_items : valid_items;
     [[maybe_unused]] const int linear_tid = RowMajorTid(BlockDimX, 1, 1);
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < ItemsPerThread; ++i)
@@ -108,11 +108,11 @@ private:
       [[maybe_unused]] const int idx = IsBlockedInput ? linear_tid * ItemsPerThread + i : i * BlockDimX + linear_tid;
       if constexpr (IsFullTile)
       {
-        states.values_[i] = valid_initial_state;
+        states.values_[i] = class_value::candidate;
       }
       else
       {
-        states.values_[i] = idx < valid_items ? valid_initial_state : class_value::invalid;
+        states.values_[i] = idx < valid_items ? class_value::candidate : class_value::invalid;
       }
     }
     return states;
@@ -168,12 +168,14 @@ private:
 
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void set_selected(int i) noexcept
   {
-    _CCCL_ASSERT(values_[i] == class_value::candidate, "set_selected requires the item to be a candidate");
+    _CCCL_ASSERT(values_[i] == class_value::candidate || values_[i] == class_value::selected,
+                 "set_selected requires the item to be a candidate or already selected");
     values_[i] = class_value::selected;
   }
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void set_rejected(int i) noexcept
   {
-    _CCCL_ASSERT(values_[i] == class_value::candidate, "set_rejected requires the item to be a candidate");
+    _CCCL_ASSERT(values_[i] == class_value::candidate || values_[i] == class_value::rejected,
+                 "set_rejected requires the item to be a candidate or already rejected");
     values_[i] = class_value::rejected;
   }
 
@@ -185,10 +187,6 @@ private:
   friend class block_topk_rank;
   template <int>
   friend class block_topk_rank_atomic;
-  template <typename, int, int, typename>
-  friend class block_topk;
-  template <typename, int, int, typename, int>
-  friend class block_topk_air;
 
 public:
   //! `true` iff at least one item is still `candidate` and the candidate
@@ -228,35 +226,29 @@ template <typename KeyT, int BlockDimX>
 class block_topk_sieve
 {
 private:
-  using algorithm_t = block_topk_sieve_air<KeyT, BlockDimX>;
+  static constexpr int threads_per_block = BlockDimX;
+
+  using algorithm_t  = block_topk_sieve_air<KeyT, BlockDimX>;
+  using TempStorage_ = typename algorithm_t::TempStorage;
 
 public:
-  struct TempStorage
-  {
-    typename algorithm_t::TempStorage sieve_storage;
-  };
+  struct TempStorage : Uninitialized<TempStorage_>
+  {};
 
 private:
-  TempStorage& storage_;
+  TempStorage_& storage_;
 
 public:
   _CCCL_DEVICE_API _CCCL_FORCEINLINE explicit block_topk_sieve(TempStorage& storage)
-      : storage_(storage)
+      : storage_(storage.Alias())
   {}
 
 private:
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE void fix_bit_range(int& begin_bit, int& end_bit) const noexcept
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void check_preconditions(int begin_bit, int end_bit) const noexcept
   {
-    // TODO (elstehle): Short-circuit if begin_bit is constrained to be non-negative
-    begin_bit = (::cuda::std::max) (begin_bit, 0);
-
-    // TODO (elstehle): Short-circuit if end_bit is constrained to be less than the maximum number of bits in the key
-    // type
-    const int max_bit = int(sizeof(KeyT) * 8);
-    if (end_bit > max_bit)
-    {
-      end_bit = max_bit;
-    }
+    [[maybe_unused]] constexpr int max_bit = int(sizeof(KeyT) * 8);
+    _CCCL_ASSERT(begin_bit >= 0 && begin_bit < max_bit, "begin_bit must be in [0, max_bit)");
+    _CCCL_ASSERT(end_bit > begin_bit && end_bit <= max_bit, "end_bit must be in (begin_bit, max_bit]");
   }
 
 public:
@@ -302,18 +294,13 @@ public:
   [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE block_topk_key_states<ItemsPerThread>
   select_max(KeyT (&keys)[ItemsPerThread], int k, int valid_items, int begin_bit = 0, int end_bit = sizeof(KeyT) * 8)
   {
-    if constexpr (!IsFullTile)
-    {
-      _CCCL_ASSERT(valid_items > 0 && valid_items <= BlockDimX * ItemsPerThread,
-                   "valid_items must be in [1, BlockDimX * ItemsPerThread]");
-    }
-    fix_bit_range(begin_bit, end_bit);
+    check_preconditions(begin_bit, end_bit);
     auto states =
       block_topk_key_states<ItemsPerThread>::template build<IsFullTile, BlockDimX, BlockedInput>(k, valid_items);
     if (states.has_ties())
     {
-      algorithm_t(storage_.sieve_storage)
-        .template refine_keys<detail::topk::select::max, IsFullTile>(keys, states, begin_bit, end_bit);
+      algorithm_t(storage_).template refine_keys<detail::topk::select::max, IsFullTile>(
+        keys, states, begin_bit, end_bit);
     }
     return states;
   }
@@ -323,18 +310,13 @@ public:
   [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE block_topk_key_states<ItemsPerThread>
   select_min(KeyT (&keys)[ItemsPerThread], int k, int valid_items, int begin_bit = 0, int end_bit = sizeof(KeyT) * 8)
   {
-    if constexpr (!IsFullTile)
-    {
-      _CCCL_ASSERT(valid_items > 0 && valid_items <= BlockDimX * ItemsPerThread,
-                   "valid_items must be in [1, BlockDimX * ItemsPerThread]");
-    }
-    fix_bit_range(begin_bit, end_bit);
+    check_preconditions(begin_bit, end_bit);
     auto states =
       block_topk_key_states<ItemsPerThread>::template build<IsFullTile, BlockDimX, BlockedInput>(k, valid_items);
     if (states.has_ties())
     {
-      algorithm_t(storage_.sieve_storage)
-        .template refine_keys<detail::topk::select::min, IsFullTile, ItemsPerThread>(keys, states, begin_bit, end_bit);
+      algorithm_t(storage_).template refine_keys<detail::topk::select::min, IsFullTile, ItemsPerThread>(
+        keys, states, begin_bit, end_bit);
     }
     return states;
   }
@@ -370,11 +352,10 @@ public:
     int begin_bit = 0,
     int end_bit   = sizeof(KeyT) * 8)
   {
-    fix_bit_range(begin_bit, end_bit);
+    check_preconditions(begin_bit, end_bit);
     if (states.has_ties())
     {
-      algorithm_t(storage_.sieve_storage)
-        .template refine_keys<detail::topk::select::max, false>(keys, states, begin_bit, end_bit);
+      algorithm_t(storage_).template refine_keys<detail::topk::select::max, false>(keys, states, begin_bit, end_bit);
     }
   }
 
@@ -386,11 +367,10 @@ public:
     int begin_bit = 0,
     int end_bit   = sizeof(KeyT) * 8)
   {
-    fix_bit_range(begin_bit, end_bit);
+    check_preconditions(begin_bit, end_bit);
     if (states.has_ties())
     {
-      algorithm_t(storage_.sieve_storage)
-        .template refine_keys<detail::topk::select::min, false>(keys, states, begin_bit, end_bit);
+      algorithm_t(storage_).template refine_keys<detail::topk::select::min, false>(keys, states, begin_bit, end_bit);
     }
   }
 };
@@ -509,20 +489,19 @@ template <int BlockDimX>
 class block_topk_rank
 {
 private:
-  using algorithm_t = block_topk_rank_atomic<BlockDimX>;
+  using algorithm_t  = block_topk_rank_atomic<BlockDimX>;
+  using TempStorage_ = typename algorithm_t::TempStorage;
 
 public:
-  struct TempStorage
-  {
-    typename algorithm_t::TempStorage rank_storage;
-  };
+  struct TempStorage : Uninitialized<TempStorage_>
+  {};
 
 private:
-  TempStorage& storage_;
+  TempStorage_& storage_;
 
 public:
   _CCCL_DEVICE_API _CCCL_FORCEINLINE explicit block_topk_rank(TempStorage& storage)
-      : storage_(storage)
+      : storage_(storage.Alias())
   {}
 
   //! Final tie-break + scatter-rank emission.
@@ -549,7 +528,7 @@ public:
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void
   rank_key_states(block_topk_key_states<ItemsPerThread>& states, int (&scatter_ranks)[ItemsPerThread])
   {
-    algorithm_t(storage_.rank_storage).rank_key_states(states, scatter_ranks);
+    algorithm_t(storage_).rank_key_states(states, scatter_ranks);
   }
 };
 } // namespace detail

--- a/cub/cub/block/block_topk_rank.cuh
+++ b/cub/cub/block/block_topk_rank.cuh
@@ -1,0 +1,557 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/block/specializations/block_topk_rank_atomic.cuh>
+#include <cub/block/specializations/block_topk_sieve_air.cuh>
+#include <cub/device/dispatch/dispatch_common.cuh>
+
+#include <cuda/std/cstdint>
+
+CUB_NAMESPACE_BEGIN
+
+namespace detail
+{
+//! @brief Per-thread bundle of per-item selection states for top-k iterative
+//!        refinement. Opaque, k-locked, free-standing template with no public
+//!        constructors.
+//!
+//! Instances of this class are obtained exclusively via
+//! `block_topk_sieve::select_max` / `select_min`, which build the state and
+//! run the first radix sweep in one call. Subsequent `block_topk_sieve::refine_*`
+//! calls mutate the state in place; `block_topk_rank::rank_key_states`
+//! consumes it. Callers observe the state through the const predicate
+//! `has_ties()`.
+//!
+//! Each item held by the thread is in exactly one of three internal states:
+//!
+//!   - `candidate`: refinement has not yet ruled the item in or out of the
+//!                  top-k.
+//!   - `selected`:  the item is guaranteed to be in the top-k.
+//!   - `rejected`:  the item is guaranteed NOT to be in the top-k. Also used
+//!                  to mark invalid / padding items prior to the first refine
+//!                  step.
+//!
+//! The class also caches the block-wide counts of items currently in the
+//! `candidate` and `selected` states so the next refine call can short-circuit
+//! when no candidates remain and compute the effective k internally without a
+//! re-reduction.
+//!
+//! The internal representation is intentionally hidden so it can be replaced
+//! with a packed (e.g. 2-bits-per-item) layout without breaking the API.
+//!
+//! Decoupling from `KeyT` lets the same state instance flow through refines on
+//! different `block_topk_sieve` instantiations.
+//!
+//! @tparam ItemsPerThread Number of items each thread holds.
+template <int ItemsPerThread>
+class block_topk_key_states
+{
+private:
+  enum class class_value
+  {
+    candidate = 0,
+    selected  = 1,
+    rejected  = 2,
+    // Only needed for full ranking/permutation including not only rejected but also invalid items (they would need to
+    // be ordered after even the rejected items).
+    invalid = 3,
+  };
+
+  class_value values_[ItemsPerThread];
+  int k_;
+  int num_candidates_;
+  int num_selected_;
+  // Only needed for full ranking/permutation including not only rejected but also invalid items (they would need to be
+  // ordered after even the rejected items).
+  int num_valid_;
+
+  // Builder is private. The state is built only by
+  // `block_topk_sieve::select_*`, mutated by `block_topk_sieve::refine_*` and
+  // `block_topk_rank::rank_key_states`. Each of those goes through the
+  // friended specializations.
+  block_topk_key_states() = default;
+
+  //! @tparam BlockDimX     Number of threads in the (1D) block.
+  template <bool IsFullTile, int BlockDimX, bool IsBlockedInput = true>
+  static _CCCL_DEVICE_API _CCCL_FORCEINLINE block_topk_key_states build(int k, int valid_items) noexcept
+  {
+    if constexpr (IsFullTile)
+    {
+      // Makes below code easier to read.
+      valid_items = BlockDimX * ItemsPerThread;
+    }
+    const auto valid_initial_state =
+      k < valid_items ? (k > 0 ? class_value::candidate : class_value::rejected) : class_value::selected;
+    block_topk_key_states states{};
+    states.k_ = ::cuda::std::max(k, 0);
+    // TODO (elstehle): Short-circuit if k is constrained to be positive
+    // TODO (elstehle): Short-circuit if k is greater than the number of items in the tile
+    states.num_candidates_                = (k < valid_items && k > 0) ? valid_items : 0;
+    states.num_selected_                  = k < valid_items ? 0 : valid_items;
+    states.num_valid_                     = valid_items;
+    [[maybe_unused]] const int linear_tid = RowMajorTid(BlockDimX, 1, 1);
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < ItemsPerThread; ++i)
+    {
+      [[maybe_unused]] const int idx = IsBlockedInput ? linear_tid * ItemsPerThread + i : i * BlockDimX + linear_tid;
+      if constexpr (IsFullTile)
+      {
+        states.values_[i] = valid_initial_state;
+      }
+      else
+      {
+        states.values_[i] = idx < valid_items ? valid_initial_state : class_value::invalid;
+      }
+    }
+    return states;
+  }
+
+  // --- Storage-abstracting accessors / mutators ---
+  //
+  // Friends below never touch the storage directly; all reads and writes go
+  // through these. This lets the internal representation (currently a flat
+  // `class_value[ItemsPerThread]` plus a few `int` counters) change without
+  // touching the sieve / rank specializations.
+
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE int k() const noexcept
+  {
+    return k_;
+  }
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE int num_selected() const noexcept
+  {
+    return num_selected_;
+  }
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE int num_candidates() const noexcept
+  {
+    return num_candidates_;
+  }
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE int num_valid() const noexcept
+  {
+    return num_valid_;
+  }
+
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void set_num_selected(int new_num_selected) noexcept
+  {
+    _CCCL_ASSERT(new_num_selected <= num_valid_, "set_num_selected: new value must not exceed num_valid");
+    _CCCL_ASSERT(new_num_selected >= num_selected_, "set_num_selected: num_selected must monotonically grow");
+    num_selected_ = new_num_selected;
+  }
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void set_num_candidates(int new_num_candidates) noexcept
+  {
+    _CCCL_ASSERT(new_num_candidates >= 0, "set_num_candidates: new value must be non-negative");
+    _CCCL_ASSERT(new_num_candidates <= num_candidates_, "set_num_candidates: num_candidates must monotonically shrink");
+    num_candidates_ = new_num_candidates;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE bool is_candidate(int i) const noexcept
+  {
+    _CCCL_ASSERT(0 <= i && i < ItemsPerThread, "item index out of range");
+    return values_[i] == class_value::candidate;
+  }
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE bool is_selected(int i) const noexcept
+  {
+    _CCCL_ASSERT(0 <= i && i < ItemsPerThread, "item index out of range");
+    return values_[i] == class_value::selected;
+  }
+
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void set_selected(int i) noexcept
+  {
+    _CCCL_ASSERT(values_[i] == class_value::candidate, "set_selected requires the item to be a candidate");
+    values_[i] = class_value::selected;
+  }
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void set_rejected(int i) noexcept
+  {
+    _CCCL_ASSERT(values_[i] == class_value::candidate, "set_rejected requires the item to be a candidate");
+    values_[i] = class_value::rejected;
+  }
+
+  template <typename, int>
+  friend class block_topk_sieve;
+  template <typename, int, int>
+  friend class block_topk_sieve_air;
+  template <int>
+  friend class block_topk_rank;
+  template <int>
+  friend class block_topk_rank_atomic;
+  template <typename, int, int, typename>
+  friend class block_topk;
+  template <typename, int, int, typename, int>
+  friend class block_topk_air;
+
+public:
+  //! `true` iff at least one item is still `candidate` and the candidate
+  //! count exceeds the slots remaining to fill the top-k. Designed to be
+  //! used directly as an `if` / `while` predicate around subsequent
+  //! `block_topk_sieve::refine_*` calls. Uniform across the block.
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE bool has_ties() const noexcept
+  {
+    _CCCL_ASSERT(k_ >= 0, "negative k would report ties incorrectly");
+    return num_selected_ + num_candidates_ > k_;
+  }
+};
+
+//! @brief Block-level radix sieve that builds and updates per-item top-k
+//!        states without moving keys/values around.
+//!
+//! Instead of scattering selected items into shared memory, it writes
+//! per-item classifications back into a `block_topk_key_states` object.
+//! Suitable for iterative / multi-key refinement before a final tie-break +
+//! scatter via `block_topk_rank`.
+//!
+//! Two pairs of member functions are provided:
+//!
+//!   - `select_max` / `select_min` build a fresh `block_topk_key_states`
+//!     from a tile of keys and the target `k`, run the first radix-pass
+//!     sweep, and return the state. They carry an explicit @c IsFullTile
+//!     and a defaulted `BlockedInput = true` member-function template
+//!     parameter; this is the only step that benefits from those compile-
+//!     time information (the per-thread "is this index < num_valid?" check folds
+//!     into the rejection-mask seeding *and* into the radix histogram pass).
+//!   - `refine_max` / `refine_min` mutate an existing state in place`.
+//!
+//! @tparam KeyT     Key type for this sieve. May differ between sieves
+//!                  refining the same `block_topk_key_states`.
+//! @tparam BlockDimX Number of threads in the (1D) block.
+template <typename KeyT, int BlockDimX>
+class block_topk_sieve
+{
+private:
+  using algorithm_t = block_topk_sieve_air<KeyT, BlockDimX>;
+
+public:
+  struct TempStorage
+  {
+    typename algorithm_t::TempStorage sieve_storage;
+  };
+
+private:
+  TempStorage& storage_;
+
+public:
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE explicit block_topk_sieve(TempStorage& storage)
+      : storage_(storage)
+  {}
+
+private:
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void fix_bit_range(int& begin_bit, int& end_bit) const noexcept
+  {
+    // TODO (elstehle): Short-circuit if begin_bit is constrained to be non-negative
+    begin_bit = (::cuda::std::max) (begin_bit, 0);
+
+    // TODO (elstehle): Short-circuit if end_bit is constrained to be less than the maximum number of bits in the key
+    // type
+    const int max_bit = int(sizeof(KeyT) * 8);
+    if (end_bit > max_bit)
+    {
+      end_bit = max_bit;
+    }
+  }
+
+public:
+  //! Build a fresh `block_topk_key_states` selecting the largest @p k items
+  //! and run the first radix-pass sweep on @p keys. The returned state optionally
+  //! flows into subsequent `refine_*` calls and finally into
+  //! `block_topk_rank::rank_key_states`.
+  //!
+  //! Items whose key bits in `[begin_bit, end_bit)` are strictly larger than
+  //! the kth-key bits become `selected`; strictly smaller become `rejected`;
+  //! items tied with the kth key remain `candidate`. Items in
+  //! `[num_valid, BlockDimX * ItemsPerThread)` of the *logical* tile are
+  //! seeded directly as `rejected`.
+  //!
+  //! @tparam IsFullTile    If true, the caller guarantees @p num_valid ==
+  //!                       `BlockDimX * ItemsPerThread`. The implementation
+  //!                       skips per-item `idx < num_valid` checks both in
+  //!                       rejection-mask seeding and in the radix histogram
+  //!                       pass. When true, @p num_valid is unused.
+  //! @tparam BlockedInput  If true (the default), @p keys is in blocked
+  //!                       arrangement (thread `linear_tid` owns global
+  //!                       indices `[linear_tid * IPT, (linear_tid + 1) * IPT)`);
+  //!                       if false, striped (`linear_tid + i * BlockDimX`).
+  //!                       Has no effect when @c IsFullTile is true.
+  //! @tparam ItemsPerThread Number of items per thread; deduced from @p keys.
+  //!
+  //! @param[in] keys      Tile of keys held by this thread.
+  //! @param[in] k         Target number of top items in the block. Must be
+  //!                      in `[1, BlockDimX * ItemsPerThread]`. Locked into
+  //!                      the returned state.
+  //! @param[in] num_valid Number of valid items in the tile, in
+  //!                      `[0, BlockDimX * ItemsPerThread]`. Ignored when
+  //!                      @c IsFullTile is true.
+  //! @param[in] begin_bit Inclusive lower bit of the bit window to refine on
+  //!                      (default `0`).
+  //! @param[in] end_bit   Exclusive upper bit of the bit window to refine on
+  //!                      (default `sizeof(KeyT) * 8`).
+  //!
+  //! @return A `block_topk_key_states<ItemsPerThread>` reflecting the
+  //!         result of the first radix sweep. Use `has_ties()` to decide
+  //!         whether to run another refine.
+  template <bool IsFullTile, bool BlockedInput = true, int ItemsPerThread>
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE block_topk_key_states<ItemsPerThread>
+  select_max(KeyT (&keys)[ItemsPerThread], int k, int valid_items, int begin_bit = 0, int end_bit = sizeof(KeyT) * 8)
+  {
+    if constexpr (!IsFullTile)
+    {
+      _CCCL_ASSERT(valid_items > 0 && valid_items <= BlockDimX * ItemsPerThread,
+                   "valid_items must be in [1, BlockDimX * ItemsPerThread]");
+    }
+    fix_bit_range(begin_bit, end_bit);
+    auto states =
+      block_topk_key_states<ItemsPerThread>::template build<IsFullTile, BlockDimX, BlockedInput>(k, valid_items);
+    if (states.has_ties())
+    {
+      algorithm_t(storage_.sieve_storage)
+        .template refine_keys<detail::topk::select::max, IsFullTile>(keys, states, begin_bit, end_bit);
+    }
+    return states;
+  }
+
+  //! Same as `select_max` but selects the smallest @p k items.
+  template <bool IsFullTile, bool BlockedInput = true, int ItemsPerThread>
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE block_topk_key_states<ItemsPerThread>
+  select_min(KeyT (&keys)[ItemsPerThread], int k, int valid_items, int begin_bit = 0, int end_bit = sizeof(KeyT) * 8)
+  {
+    if constexpr (!IsFullTile)
+    {
+      _CCCL_ASSERT(valid_items > 0 && valid_items <= BlockDimX * ItemsPerThread,
+                   "valid_items must be in [1, BlockDimX * ItemsPerThread]");
+    }
+    fix_bit_range(begin_bit, end_bit);
+    auto states =
+      block_topk_key_states<ItemsPerThread>::template build<IsFullTile, BlockDimX, BlockedInput>(k, valid_items);
+    if (states.has_ties())
+    {
+      algorithm_t(storage_.sieve_storage)
+        .template refine_keys<detail::topk::select::min, IsFullTile, ItemsPerThread>(keys, states, begin_bit, end_bit);
+    }
+    return states;
+  }
+
+  //! Refine @p states for the largest k items (k locked at `select_*` time).
+  //!
+  //! Examines bit range `[begin_bit, end_bit)` of each candidate's key in
+  //! @p keys; items whose bits in that range are strictly larger than the
+  //! kth-key bits become `selected`, strictly smaller become `rejected`,
+  //! ties remain `candidate`. Items already `selected` / `rejected` on entry
+  //! are unchanged.
+  //!
+  //! May be called multiple times with disjoint bit ranges to progressively
+  //! narrow the candidate set. The same @p states may be passed to sieves
+  //! with different `KeyT` (provided `BlockDimX` matches and the per-call
+  //! `ItemsPerThread` deduction agrees).
+  //!
+  //! When `states.has_ties()` returns false on entry, this function performs
+  //! no shared-memory work and no `__syncthreads()`. Callers are still
+  //! encouraged to guard refines with `if (states.has_ties())` so they also
+  //! avoid loading / decoding the input keys.
+  //!
+  //! Internally the effective k for this pass is computed from the cached
+  //! state counts. On exit those counts (and therefore `has_ties()`) reflect
+  //! the new classification.
+  //!
+  //! @tparam ItemsPerThread Number of items per thread; deduced from @p keys
+  //!                       / @p states.
+  template <int ItemsPerThread>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void refine_max(
+    KeyT (&keys)[ItemsPerThread],
+    block_topk_key_states<ItemsPerThread>& states,
+    int begin_bit = 0,
+    int end_bit   = sizeof(KeyT) * 8)
+  {
+    fix_bit_range(begin_bit, end_bit);
+    if (states.has_ties())
+    {
+      algorithm_t(storage_.sieve_storage)
+        .template refine_keys<detail::topk::select::max, false>(keys, states, begin_bit, end_bit);
+    }
+  }
+
+  //! Same as `refine_max` but for a sieve that started with `select_min`.
+  template <int ItemsPerThread>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void refine_min(
+    KeyT (&keys)[ItemsPerThread],
+    block_topk_key_states<ItemsPerThread>& states,
+    int begin_bit = 0,
+    int end_bit   = sizeof(KeyT) * 8)
+  {
+    fix_bit_range(begin_bit, end_bit);
+    if (states.has_ties())
+    {
+      algorithm_t(storage_.sieve_storage)
+        .template refine_keys<detail::topk::select::min, false>(keys, states, begin_bit, end_bit);
+    }
+  }
+};
+
+//! @rst
+//! Block-level finalization: tie-breaks the candidates in a
+//! ``block_topk_key_states`` and emits per-item scatter ranks usable with
+//! ``cub::BlockExchange``.
+//!
+//! ``KeyT``-independent and ``ItemsPerThread``-independent at the class
+//! level: a single ``block_topk_rank`` instantiation can finalize a state
+//! object that was refined by any combination of
+//! ``block_topk_sieve<K, BlockDimX>`` instantiations (provided ``BlockDimX``
+//! matches).
+//!
+//! A Simple Example
+//! ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+//!
+//! The example below selects the largest ``k`` items by a primary float key,
+//! breaks ties using a secondary int key (lazily loaded only when ties
+//! actually remain), and then moves the selected items to the front of the
+//! block in striped arrangement using ``BlockExchange::ScatterToStripedGuarded``.
+//! The single ``__shared__`` union covers the full pipeline (sieves, rank,
+//! and exchange), separated by ``__syncthreads()`` between phases.
+//!
+//! .. code-block:: c++
+//!
+//!    #include <cub/block/block_exchange.cuh>
+//!    #include <cub/block/block_topk_rank.cuh>
+//!
+//!    constexpr int ThreadsPerBlock   = 128;
+//!    constexpr int ItemsPerThread = 4;
+//!    // Assume the caller knows it is operating on a full tile.
+//!    constexpr bool IsFullTile    = true;
+//!
+//!    using PrimarySieve   = cub::detail::block_topk_sieve<float, ThreadsPerBlock>;
+//!    using SecondarySieve = cub::detail::block_topk_sieve<int,   ThreadsPerBlock>;
+//!    using TopKRank       = cub::detail::block_topk_rank<ThreadsPerBlock>;
+//!    using Exchange       = cub::BlockExchange<float, ThreadsPerBlock, ItemsPerThread>;
+//!
+//!    __global__ void example_kernel(float* in, float* out, int k)
+//!    {
+//!      // Each phase (sieves / rank / exchange) is separated from the next
+//!      // by a __syncthreads(), so they share __shared__ bytes via a union.
+//!      // The block_topk_key_states itself is a per-thread object and does
+//!      // not (and cannot) live in __shared__.
+//!      __shared__ union {
+//!        typename PrimarySieve::TempStorage   primary_sieve;
+//!        typename SecondarySieve::TempStorage secondary_sieve;
+//!        typename TopKRank::TempStorage       topk_rank;
+//!        typename Exchange::TempStorage       exchange;
+//!      } smem;
+//!
+//!      float primary_keys[ItemsPerThread];
+//!      // ... load primary_keys (in blocked arrangement here) ...
+//!
+//!      // 1) Build the state object and run the first radix sweep on the
+//!      //    primary key. The state's k is locked here. For striped inputs,
+//!      //    pass `BlockedInput = false` as the second template argument.
+//!      auto states = PrimarySieve(smem.primary_sieve)
+//!                      .template select_max<IsFullTile>(primary_keys, k, ThreadsPerBlock * ItemsPerThread);
+//!      __syncthreads();
+//!
+//!      // 2) Break ties using the secondary key (different KeyT, same
+//!      //    BlockDimX and ItemsPerThread). Guarding on `has_ties()` lets
+//!      //    us skip loading the secondary key entirely when no ties
+//!      //    remained.
+//!      if (states.has_ties())
+//!      {
+//!        int secondary_keys[ItemsPerThread];
+//!        // ... load secondary_keys ...
+//!        SecondarySieve(smem.secondary_sieve).refine_max(secondary_keys, states);
+//!        __syncthreads();
+//!      }
+//!
+//!      // 3) Final tie-break + scatter ranks for BlockExchange.
+//!      int ranks[ItemsPerThread];
+//!      TopKRank(smem.topk_rank).rank_key_states(states, ranks);
+//!      __syncthreads();
+//!
+//!      // 4) Move the top-k items to the front of the logical tile. Non-top-k
+//!      //    items have rank == -1, which `ScatterToStripedGuarded`
+//!      //    interprets internally - no separate flags array is needed.
+//!      float out_keys[ItemsPerThread];
+//!      Exchange(smem.exchange).ScatterToStripedGuarded(primary_keys, out_keys, ranks);
+//!
+//!      // ... store the first k items of `out_keys` to `out` ...
+//!    }
+//!
+//! A while-loop variant (e.g. refining one byte at a time, MSB to LSB) is
+//! equally idiomatic. The first byte goes through ``select_max`` to build
+//! the state; subsequent bytes go through ``refine_max`` under a
+//! ``has_ties()`` predicate.
+//!
+//! .. code-block:: c++
+//!
+//!    auto sieve = PrimarySieve(smem.primary_sieve);
+//!
+//!    int hi      = sizeof(float) * 8;
+//!    auto states = sieve.template select_max<IsFullTile>(primary_keys, k, num_valid, hi - 8, hi);
+//!    hi -= 8;
+//!
+//!    while (hi > 0 && states.has_ties())
+//!    {
+//!      __syncthreads();
+//!      sieve.refine_max(primary_keys, states, hi - 8, hi);
+//!      hi -= 8;
+//!    }
+//!
+//! @endrst
+//!
+//! @tparam BlockDimX Number of threads in the (1D) block.
+// TODO(pauleonix): Add template parameters for deciding between deterministic and non-deterministic tie-breaking,
+//                  as well as returning ranks for a full permutation or topk including all ties.
+template <int BlockDimX>
+class block_topk_rank
+{
+private:
+  using algorithm_t = block_topk_rank_atomic<BlockDimX>;
+
+public:
+  struct TempStorage
+  {
+    typename algorithm_t::TempStorage rank_storage;
+  };
+
+private:
+  TempStorage& storage_;
+
+public:
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE explicit block_topk_rank(TempStorage& storage)
+      : storage_(storage)
+  {}
+
+  //! Final tie-break + scatter-rank emission.
+  //!
+  //! The target k is read from @p states (locked in
+  //! `block_topk_sieve::select_*`). Among items still `candidate` on entry,
+  //! an unspecified subset is promoted to `selected` to fill the top-k.
+  //!
+  //! On output:
+  //!
+  //!   - For each item promoted to `selected`: `scatter_ranks[i]` is in
+  //!     `[0, k)`. Selected items receive contiguous ranks starting at 0.
+  //!   - For each item left as `rejected`: `scatter_ranks[i] == -1`.
+  //!   - No item is left in the `candidate` state on return; `states`
+  //!     contains exactly `min(k, initial num_valid)` selected items, with
+  //!     `has_ties()` returning false.
+  //!
+  //! The ranks are designed for use with
+  //! `cub::BlockExchange::ScatterTo[Blocked|Striped]Guarded`.
+  //!
+  //! @tparam ItemsPerThread Number of items per thread; deduced from
+  //!                       @p states / @p scatter_ranks.
+  template <int ItemsPerThread>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
+  rank_key_states(block_topk_key_states<ItemsPerThread>& states, int (&scatter_ranks)[ItemsPerThread])
+  {
+    algorithm_t(storage_.rank_storage).rank_key_states(states, scatter_ranks);
+  }
+};
+} // namespace detail
+
+CUB_NAMESPACE_END

--- a/cub/cub/block/specializations/block_topk_air.cuh
+++ b/cub/cub/block/specializations/block_topk_air.cuh
@@ -41,7 +41,7 @@ namespace detail
 //! the histogram in shared memory is updated. (2) Partitioning scatters the top-k items (key
 //! prefix <= k-th prefix) into shared memory via atomic counters, then each thread reads back
 //! its portion. Supports key-only and key-value selection.
-template <typename KeyT, int ThreadsPerBlock, int ItemsPerThread, typename ValueT = NullType, int RadixBits = 8>
+template <typename KeyT, int ThreadsPerBlock, int ItemsPerThread, typename ValueT = NullType>
 class block_topk_air
 {
 private:
@@ -52,24 +52,32 @@ private:
   static constexpr int threads_per_block = ThreadsPerBlock;
   static constexpr int items_per_thread  = ItemsPerThread;
   static constexpr int tile_items        = threads_per_block * items_per_thread;
-  static constexpr int num_buckets       = int{1u << RadixBits};
 
   // Calculate number of buckets processed per thread
-  static constexpr int buckets_per_thread = ::cuda::ceil_div(num_buckets, threads_per_block);
-  static constexpr bool keys_only         = ::cuda::std::is_same_v<ValueT, NullType>;
+  static constexpr bool keys_only = ::cuda::std::is_same_v<ValueT, NullType>;
 
-  using block_sieve_t = block_topk_sieve_air<KeyT, threads_per_block>;
-  using block_rank_t  = block_topk_rank_atomic<threads_per_block>;
+  using block_sieve_t         = block_topk_sieve<KeyT, threads_per_block>;
+  using block_sieve_storage_t = typename block_sieve_t::TempStorage;
+  using block_rank_t          = block_topk_rank<threads_per_block>;
+  using block_rank_storage_t  = typename block_rank_t::TempStorage;
+
+  static_assert(
+    ::cuda::std::is_base_of_v<Uninitialized<typename block_topk_sieve_air<KeyT, threads_per_block>::TempStorage>,
+                              block_sieve_storage_t>,
+    "Wrong sieve specialization");
+  static_assert(::cuda::std::is_base_of_v<Uninitialized<typename block_topk_rank_atomic<threads_per_block>::TempStorage>,
+                                          block_rank_storage_t>,
+                "Wrong rank specialization");
 
   struct TempStorage_
   {
     union
     {
-      typename block_sieve_t::TempStorage sieve_storage;
+      block_sieve_storage_t sieve_storage;
 
       struct
       {
-        typename block_rank_t::TempStorage rank_storage;
+        block_rank_storage_t rank_storage;
         union
         {
           KeyT keys[tile_items];
@@ -110,14 +118,21 @@ private:
       end_bit = max_bit;
     }
 
-    auto states = block_topk_key_states<ItemsPerThread>::template build<IsFullTile, threads_per_block>(k, valid_items);
-    if (!states.has_ties())
-    {
-      // Short-circuit if k is <= 0 or k bigger than the number of (valid) items in the tile
-      return;
-    }
-    block_sieve_t(storage.stage.sieve_storage)
-      .template refine_keys<SelectDirection, IsFullTile>(keys, states, begin_bit, end_bit);
+    auto states = [&] {
+      if constexpr (SelectDirection == detail::topk::select::max)
+      {
+        return block_sieve_t(storage.stage.sieve_storage)
+          .template select_max<IsFullTile>(keys, k, valid_items, begin_bit, end_bit);
+      }
+      else
+      {
+        return block_sieve_t(storage.stage.sieve_storage)
+          .template select_min<IsFullTile>(keys, k, valid_items, begin_bit, end_bit);
+      }
+    }();
+    // Make sure smem can be reused by the rank stage
+    __syncthreads();
+
     int scatter_indices[items_per_thread];
     block_rank_t(storage.stage.select.rank_storage).rank_key_states(states, scatter_indices);
 

--- a/cub/cub/block/specializations/block_topk_air.cuh
+++ b/cub/cub/block/specializations/block_topk_air.cuh
@@ -14,7 +14,9 @@
 #endif // no system header
 
 #include <cub/block/block_scan.cuh>
-#include <cub/block/radix_rank_sort_operations.cuh>
+#include <cub/block/block_topk_rank.cuh>
+#include <cub/block/specializations/block_topk_rank_atomic.cuh>
+#include <cub/block/specializations/block_topk_sieve_air.cuh>
 #include <cub/device/dispatch/dispatch_common.cuh>
 #include <cub/util_ptx.cuh>
 #include <cub/util_type.cuh>
@@ -27,19 +29,6 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail
 {
-template <typename SortKeyT>
-struct compare_key_prefix_op
-{
-  static_assert(::cuda::std::is_unsigned_v<SortKeyT>, "SortKeyT must be an unsigned type");
-
-  SortKeyT prefix_mask;
-  SortKeyT key_prefix;
-  [[nodiscard]] _CCCL_HOST_DEVICE_API _CCCL_FORCEINLINE constexpr bool operator()(SortKeyT sort_key) const noexcept
-  {
-    return (sort_key & prefix_mask) == (key_prefix);
-  }
-};
-
 //! @brief Block-level top-k by radix selection.
 //!
 //! Selects the smallest (or largest) @p k keys from a tile of keys in registers, without
@@ -69,35 +58,18 @@ private:
   static constexpr int buckets_per_thread = ::cuda::ceil_div(num_buckets, threads_per_block);
   static constexpr bool keys_only         = ::cuda::std::is_same_v<ValueT, NullType>;
 
-  using histo_counter_t = ::cuda::std::uint32_t;
-  using block_scan_t    = BlockScan<histo_counter_t, threads_per_block, BLOCK_SCAN_WARP_SCANS>;
-
-  using traits                 = detail::radix::traits_t<KeyT>;
-  using bit_ordered_type       = typename traits::bit_ordered_type;
-  using bit_ordered_conversion = typename traits::bit_ordered_conversion_policy;
-  using bit_ordered_inversion  = typename traits::bit_ordered_inversion_policy;
-
-  using fundamental_digit_extractor_t = BFEDigitExtractor<KeyT>;
+  using block_sieve_t = block_topk_sieve_air<KeyT, threads_per_block>;
+  using block_rank_t  = block_topk_rank_atomic<threads_per_block>;
 
   struct TempStorage_
   {
     union
     {
-      struct
-      {
-        histo_counter_t histogram[num_buckets];
-        typename block_scan_t::TempStorage scan_temp_storage;
-        struct
-        {
-          histo_counter_t selected;
-          histo_counter_t candidates;
-          int bucket;
-        } pass_state;
-      } passes;
+      typename block_sieve_t::TempStorage sieve_storage;
 
       struct
       {
-        histo_counter_t selected_offset[2];
+        typename block_rank_t::TempStorage rank_storage;
         union
         {
           KeyT keys[tile_items];
@@ -113,180 +85,6 @@ private:
   /// Linear thread index
   int linear_tid;
 
-  // Initialize histogram bins to zero
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE void init_histograms()
-  {
-    // Initialize histogram bin counts to zeros
-    int histo_offset = 0;
-
-    // Loop unrolling is beneficial for performance here
-    _CCCL_PRAGMA_UNROLL_FULL()
-    for (; histo_offset + threads_per_block <= num_buckets; histo_offset += threads_per_block)
-    {
-      storage.stage.passes.histogram[histo_offset + threadIdx.x] = 0;
-    }
-    // Finish up with guarded initialization if necessary
-    if ((num_buckets % threads_per_block != 0) && (histo_offset + threadIdx.x < num_buckets))
-    {
-      storage.stage.passes.histogram[histo_offset + threadIdx.x] = 0;
-    }
-  }
-
-  // Compute histogram over keys
-  template <bool IsFullTile, typename DigitExtractorT, typename FilterOpT>
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE void compute_histograms(
-    const bit_ordered_type (&unsigned_keys)[items_per_thread],
-    int valid_items,
-    DigitExtractorT digit_extractor,
-    FilterOpT filter_op)
-  {
-    _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < items_per_thread; ++i)
-    {
-      const auto item_index      = linear_tid * items_per_thread + i;
-      const bit_ordered_type key = unsigned_keys[i];
-      if ((IsFullTile || item_index < valid_items) && filter_op(key))
-      {
-        const auto digit = digit_extractor.Digit(key);
-        atomicAdd(&storage.stage.passes.histogram[digit], histo_counter_t{1});
-      }
-    }
-  }
-
-  // Compute prefix sum over buckets
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE void compute_bin_offsets()
-  {
-    histo_counter_t thread_buckets[buckets_per_thread]{};
-    const int base = linear_tid * buckets_per_thread;
-
-    _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < buckets_per_thread; ++i)
-    {
-      const int bin_idx = base + i;
-      if (bin_idx < num_buckets)
-      {
-        thread_buckets[i] = storage.stage.passes.histogram[bin_idx];
-      }
-    }
-
-    block_scan_t(storage.stage.passes.scan_temp_storage).InclusiveSum(thread_buckets, thread_buckets);
-
-    _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < buckets_per_thread; ++i)
-    {
-      const int bin_idx = base + i;
-      if (bin_idx < num_buckets)
-      {
-        storage.stage.passes.histogram[bin_idx] = thread_buckets[i];
-      }
-    }
-  }
-
-  // Identify the bucket that the k-th item falls into
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE void choose_bucket(histo_counter_t k)
-  {
-    const int base = linear_tid * buckets_per_thread;
-
-    _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < buckets_per_thread; ++i)
-    {
-      const int bin_idx = base + i;
-      if (bin_idx < num_buckets)
-      {
-        const histo_counter_t prev = (bin_idx == 0) ? 0 : storage.stage.passes.histogram[bin_idx - 1];
-        const histo_counter_t cur  = storage.stage.passes.histogram[bin_idx];
-
-        if (prev < k && cur >= k)
-        {
-          storage.stage.passes.pass_state.bucket     = bin_idx;
-          storage.stage.passes.pass_state.candidates = cur - prev;
-          storage.stage.passes.pass_state.selected   = prev;
-        }
-      }
-    }
-  }
-
-  template <typename detail::topk::select SelectDirection, bool IsFullTile, typename DecomposerT>
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE void get_kth_key_prefix(
-    bit_ordered_type (&unsigned_keys)[items_per_thread],
-    int k,
-    int valid_items,
-    int begin_bit,
-    int end_bit,
-    int& total_selected,
-    int& num_candidates,
-    bit_ordered_type& kth_key_prefix,
-    bit_ordered_type& prefix_mask,
-    DecomposerT decomposer = DecomposerT{})
-  {
-    // Preconditions
-    [[maybe_unused]] constexpr int max_bit = int(sizeof(KeyT) * 8);
-    _CCCL_ASSERT(k > 0 && k <= tile_items, "k must be in (0, tile_items]");
-    if constexpr (!IsFullTile)
-    {
-      _CCCL_ASSERT(valid_items > 0 && valid_items <= tile_items, "valid_items must be in [1, tile_items]");
-    }
-    _CCCL_ASSERT(begin_bit >= 0 && begin_bit < max_bit, "begin_bit must be in [0, max_bit)");
-    _CCCL_ASSERT(end_bit > begin_bit && end_bit <= max_bit, "end_bit must be in (begin_bit, max_bit]");
-
-    // We only consider candidates identified in the previous pass, i.e., ((sortkey & prefix_mask) == kth_prefix)
-    // With each pass, we identify a wider prefix of the splitter key
-    kth_key_prefix = 0;
-    prefix_mask    = 0;
-
-    // The total number of selected items
-    total_selected = 0;
-
-    const int total_bits = (::cuda::std::max) (end_bit - begin_bit, 0);
-    const int num_passes = ::cuda::ceil_div(total_bits, RadixBits);
-    for (int pass = 0; pass < num_passes; ++pass)
-    {
-      // Bit-range & mask of the current pass
-      const int pass_end_bit           = end_bit - pass * RadixBits;
-      const int pass_begin_bit         = (::cuda::std::max) (pass_end_bit - RadixBits, begin_bit);
-      const int pass_bits              = pass_end_bit - pass_begin_bit;
-      const bit_ordered_type pass_mask = ::cuda::bitmask<bit_ordered_type>(pass_begin_bit, pass_bits);
-
-      // Zero-initialize histograms for the current pass
-      init_histograms();
-      __syncthreads();
-
-      // Compute histogram over the current pass's, bits pre-filtered for keys matching the previous pass's prefix mask
-      auto filter_op = compare_key_prefix_op<bit_ordered_type>{prefix_mask, kth_key_prefix};
-      auto digit_extractor =
-        traits::template digit_extractor<fundamental_digit_extractor_t>(pass_begin_bit, pass_bits, decomposer);
-      compute_histograms<IsFullTile>(unsigned_keys, valid_items, digit_extractor, filter_op);
-      __syncthreads();
-
-      // Compute prefix sum over buckets
-      compute_bin_offsets();
-      __syncthreads();
-
-      // Identify the bucket that the k-th item falls into
-      choose_bucket(k);
-      __syncthreads();
-
-      // Update the current k and length for the next pass
-      k -= storage.stage.passes.pass_state.selected;
-      num_candidates = storage.stage.passes.pass_state.candidates;
-      total_selected += storage.stage.passes.pass_state.selected;
-
-      // Update the kth_key_prefix and prefix_mask for the next pass
-      // Basically, we will have valid_items candidates with the prefix kth_key_prefix
-      kth_key_prefix |= bit_ordered_type(storage.stage.passes.pass_state.bucket) << pass_begin_bit;
-      prefix_mask |= pass_mask;
-
-      // Short-circuit if all candidates are amongst the top-k
-      if (num_candidates == k)
-      {
-        break;
-      }
-    }
-
-    // Ensure we can repurpose shared memory after the multi-pass stage
-    __syncthreads();
-  }
-
   template <detail::topk::select SelectDirection, bool IsFullTile>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void select_topk(
     KeyT (&keys)[items_per_thread],
@@ -301,12 +99,6 @@ private:
       _CCCL_ASSERT(valid_items > 0 && valid_items <= tile_items, "valid_items must be in [1, tile_items]");
     }
 
-    // TODO (elstehle): Short-circuit if k is constrained to be positive
-    if (k <= 0)
-    {
-      return;
-    }
-
     // TODO (elstehle): Short-circuit if begin_bit is constrained to be non-negative
     begin_bit = (::cuda::std::max) (begin_bit, 0);
 
@@ -318,138 +110,23 @@ private:
       end_bit = max_bit;
     }
 
-    // TODO (elstehle): Short-circuit if k is greater than the number of items in the tile
-    if ((!IsFullTile && k >= valid_items) || k >= tile_items)
+    auto states = block_topk_key_states<ItemsPerThread>::template build<IsFullTile, threads_per_block>(k, valid_items);
+    if (!states.has_ties())
     {
+      // Short-circuit if k is <= 0 or k bigger than the number of (valid) items in the tile
       return;
     }
-
-    // TODO (elstehle): Add support for custom decomposers
-    identity_decomposer_t decomposer;
-
-    // Get bit-twiddled sortkeys. For float keys, track which were -0.0 (normalized to +0.0 for ranking) so we can
-    // restore -0.0 in the output via a bitvector; no extra key buffer.
-    bit_ordered_type(&unsigned_keys)[ItemsPerThread] = reinterpret_cast<bit_ordered_type(&)[ItemsPerThread]>(keys);
-    constexpr int flip_back_num_words                = ::cuda::ceil_div(items_per_thread, 32);
-    [[maybe_unused]] ::cuda::std::uint32_t flip_back_bits[flip_back_num_words] = {};
-    if constexpr (::cuda::is_floating_point_v<KeyT>)
-    {
-      const bit_ordered_type twiddled_minus_zero =
-        Traits<KeyT>::TwiddleIn(bit_ordered_type(1) << (8 * sizeof(bit_ordered_type) - 1));
-      const bit_ordered_type twiddled_zero = Traits<KeyT>::TwiddleIn(0);
-      _CCCL_PRAGMA_UNROLL_FULL()
-      for (int i = 0; i < items_per_thread; ++i)
-      {
-        unsigned_keys[i] = bit_ordered_conversion::to_bit_ordered(decomposer, unsigned_keys[i]);
-        if (unsigned_keys[i] == twiddled_minus_zero)
-        {
-          flip_back_bits[i / 32] |= (1u << (i % 32));
-          unsigned_keys[i] = twiddled_zero;
-        }
-        if constexpr (SelectDirection == detail::topk::select::max)
-        {
-          unsigned_keys[i] = bit_ordered_inversion::inverse(decomposer, unsigned_keys[i]);
-        }
-      }
-    }
-    else
-    {
-      _CCCL_PRAGMA_UNROLL_FULL()
-      for (int i = 0; i < items_per_thread; ++i)
-      {
-        unsigned_keys[i] = bit_ordered_conversion::to_bit_ordered(decomposer, unsigned_keys[i]);
-        if constexpr (SelectDirection == detail::topk::select::max)
-        {
-          unsigned_keys[i] = bit_ordered_inversion::inverse(decomposer, unsigned_keys[i]);
-        }
-      }
-    }
-
-    // The prefix (i.e., the most significant bits) of the k-th key
-    bit_ordered_type kth_prefix{};
-    // The prefix mask (i.e., the bit mask with the most significant bits populated) of the k-th key
-    bit_ordered_type prefix_mask{};
-    // The total number of items that compare strictly less than the k-th key's prefix (i.e., the number of items that
-    // are guaranteed to be selected)
-    int total_selected{};
-    // The number of candidates that compare equal to the k-th key's prefix
-    auto num_candidates = IsFullTile ? tile_items : valid_items;
-
-    // Identify the prefix of the k-th key
-    get_kth_key_prefix<SelectDirection, IsFullTile>(
-      unsigned_keys,
-      k,
-      valid_items,
-      begin_bit,
-      end_bit,
-      total_selected,
-      num_candidates,
-      kth_prefix,
-      prefix_mask,
-      decomposer);
-
-    // Scatter indices of selected items into shared memory (only for selecting key-value pairs, using a two-phase
-    // approach to lower shared memory requirements).
-    [[maybe_unused]] int scatter_indices[items_per_thread];
-    if constexpr (!keys_only)
-    {
-      for (int i = 0; i < items_per_thread; ++i)
-      {
-        scatter_indices[i] = -1;
-      }
-    }
-
-    // If all candidates are amongst the remaining top-k, we can simply select all items that compare less than or equal
-    // to the splitter prefix. Otherwise, we have to make sure that *all* candidates that compare strictly less than the
-    // splitter prefix are selected, and then select amongst candidates that compare equal to the splitter prefix to
-    // fill up the remaining slots up to k.
-    const bool select_all_candidates = expand_k_to_include_ties || num_candidates + total_selected == k;
-
-    if (linear_tid == 0)
-    {
-      // Write offsets for selected items with key_prefix < kth_prefix
-      storage.stage.select.selected_offset[0] = 0;
-      // Write offsets for tied items across the k-th position, i.e., key_prefix == kth_prefix
-      storage.stage.select.selected_offset[1] = total_selected;
-    }
-    // Ensure atomic selection counter has been reset
-    __syncthreads();
+    block_sieve_t(storage.stage.sieve_storage)
+      .template refine_keys<SelectDirection, IsFullTile>(keys, states, begin_bit, end_bit);
+    int scatter_indices[items_per_thread];
+    block_rank_t(storage.stage.select.rank_storage).rank_key_states(states, scatter_indices);
 
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < items_per_thread; ++i)
     {
-      const bit_ordered_type key_prefix = unsigned_keys[i] & prefix_mask;
-
-      const bool is_valid     = (IsFullTile || linear_tid * items_per_thread + i < valid_items);
-      const bool is_selected  = key_prefix < kth_prefix;
-      const bool is_candidate = key_prefix == kth_prefix;
-
-      // We differentiate between candidates and selected only if not all candidates make it into the top-k items.
-      int item_class = (!select_all_candidates) && is_candidate ? 1 : 0;
-
-      // Untwiddle the key before storing in shared memory
-      if constexpr (SelectDirection == detail::topk::select::max)
+      if (scatter_indices[i] >= 0)
       {
-        unsigned_keys[i] = bit_ordered_inversion::inverse(decomposer, unsigned_keys[i]);
-      }
-      unsigned_keys[i] = bit_ordered_conversion::from_bit_ordered(decomposer, unsigned_keys[i]);
-
-      if (is_valid && (is_selected || is_candidate))
-      {
-        const histo_counter_t selected_offset = atomicAdd(&storage.stage.select.selected_offset[item_class], 1);
-        if constexpr (::cuda::is_floating_point_v<KeyT>)
-        {
-          storage.stage.select.exchange.keys[selected_offset] =
-            (flip_back_bits[i / 32] & (1u << (i % 32))) ? KeyT(-0.0) : ::cuda::std::bit_cast<KeyT>(unsigned_keys[i]);
-        }
-        else
-        {
-          storage.stage.select.exchange.keys[selected_offset] = ::cuda::std::bit_cast<KeyT>(unsigned_keys[i]);
-        }
-        if constexpr (!keys_only)
-        {
-          scatter_indices[i] = selected_offset;
-        }
+        storage.stage.select.exchange.keys[scatter_indices[i]] = keys[i];
       }
     }
 

--- a/cub/cub/block/specializations/block_topk_air.cuh
+++ b/cub/cub/block/specializations/block_topk_air.cuh
@@ -25,7 +25,6 @@
 #include <cuda/std/__type_traits/is_base_of.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/cstdint>
-#include <cuda/std/optional>
 
 CUB_NAMESPACE_BEGIN
 
@@ -95,6 +94,25 @@ private:
   /// Linear thread index
   int linear_tid;
 
+  template <detail::topk::select Dir, bool Full>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE static block_topk_key_states<items_per_thread> sieve_select(
+    block_sieve_storage_t& sieve_storage,
+    KeyT (&keys)[items_per_thread],
+    int k,
+    int valid_items,
+    int begin_bit,
+    int end_bit)
+  {
+    if constexpr (Dir == detail::topk::select::max)
+    {
+      return block_sieve_t(sieve_storage).template select_max<Full>(keys, k, valid_items, begin_bit, end_bit);
+    }
+    else
+    {
+      return block_sieve_t(sieve_storage).template select_min<Full>(keys, k, valid_items, begin_bit, end_bit);
+    }
+  }
+
   template <detail::topk::select SelectDirection, bool IsFullTile>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void select_topk(
     KeyT (&keys)[items_per_thread],
@@ -120,22 +138,13 @@ private:
       end_bit = max_bit;
     }
 
-    ::cuda::std::optional<block_topk_key_states<items_per_thread>> states;
-    if constexpr (SelectDirection == detail::topk::select::max)
-    {
-      states = block_sieve_t(storage.stage.sieve_storage)
-                 .template select_max<IsFullTile>(keys, k, valid_items, begin_bit, end_bit);
-    }
-    else
-    {
-      states = block_sieve_t(storage.stage.sieve_storage)
-                 .template select_min<IsFullTile>(keys, k, valid_items, begin_bit, end_bit);
-    }
+    auto states =
+      sieve_select<SelectDirection, IsFullTile>(storage.stage.sieve_storage, keys, k, valid_items, begin_bit, end_bit);
     // Make sure smem can be reused by the rank stage
     __syncthreads();
 
     int scatter_indices[items_per_thread];
-    block_rank_t(storage.stage.select.rank_storage).rank_key_states(states.value(), scatter_indices);
+    block_rank_t(storage.stage.select.rank_storage).rank_key_states(states, scatter_indices);
 
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < items_per_thread; ++i)

--- a/cub/cub/block/specializations/block_topk_air.cuh
+++ b/cub/cub/block/specializations/block_topk_air.cuh
@@ -22,8 +22,10 @@
 #include <cub/util_type.cuh>
 
 #include <cuda/std/__bit/bit_cast.h>
-#include <cuda/std/__type_traits/is_unsigned.h>
+#include <cuda/std/__type_traits/is_base_of.h>
+#include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/cstdint>
+#include <cuda/std/optional>
 
 CUB_NAMESPACE_BEGIN
 
@@ -118,23 +120,22 @@ private:
       end_bit = max_bit;
     }
 
-    auto states = [&] {
-      if constexpr (SelectDirection == detail::topk::select::max)
-      {
-        return block_sieve_t(storage.stage.sieve_storage)
-          .template select_max<IsFullTile>(keys, k, valid_items, begin_bit, end_bit);
-      }
-      else
-      {
-        return block_sieve_t(storage.stage.sieve_storage)
-          .template select_min<IsFullTile>(keys, k, valid_items, begin_bit, end_bit);
-      }
-    }();
+    ::cuda::std::optional<block_topk_key_states<items_per_thread>> states;
+    if constexpr (SelectDirection == detail::topk::select::max)
+    {
+      states = block_sieve_t(storage.stage.sieve_storage)
+                 .template select_max<IsFullTile>(keys, k, valid_items, begin_bit, end_bit);
+    }
+    else
+    {
+      states = block_sieve_t(storage.stage.sieve_storage)
+                 .template select_min<IsFullTile>(keys, k, valid_items, begin_bit, end_bit);
+    }
     // Make sure smem can be reused by the rank stage
     __syncthreads();
 
     int scatter_indices[items_per_thread];
-    block_rank_t(storage.stage.select.rank_storage).rank_key_states(states, scatter_indices);
+    block_rank_t(storage.stage.select.rank_storage).rank_key_states(states.value(), scatter_indices);
 
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < items_per_thread; ++i)

--- a/cub/cub/block/specializations/block_topk_air.cuh
+++ b/cub/cub/block/specializations/block_topk_air.cuh
@@ -138,6 +138,12 @@ private:
       end_bit = max_bit;
     }
 
+    // TODO (elstehle): Short-circuit if k is greater than the number of items in the tile
+    if ((!IsFullTile && k >= valid_items) || k >= tile_items)
+    {
+      return;
+    }
+
     auto states =
       sieve_select<SelectDirection, IsFullTile>(storage.stage.sieve_storage, keys, k, valid_items, begin_bit, end_bit);
     // Make sure smem can be reused by the rank stage

--- a/cub/cub/block/specializations/block_topk_rank_atomic.cuh
+++ b/cub/cub/block/specializations/block_topk_rank_atomic.cuh
@@ -96,9 +96,20 @@ public:
       if (is_selected || is_candidate)
       {
         const auto selected_offset = static_cast<int>(atomicAdd(&storage.selected_offset[item_class], counter_t{1}));
-        scatter_ranks[i]           = selected_offset < states.k() ? selected_offset : -1;
+        if (selected_offset < states.k())
+        {
+          scatter_ranks[i] = selected_offset;
+          states.set_selected(i);
+        }
+        else
+        {
+          scatter_ranks[i] = -1;
+          states.set_rejected(i);
+        }
       }
     }
+    states.set_num_selected(states.k());
+    states.set_num_candidates(0);
   }
 };
 } // namespace detail

--- a/cub/cub/block/specializations/block_topk_rank_atomic.cuh
+++ b/cub/cub/block/specializations/block_topk_rank_atomic.cuh
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/util_ptx.cuh>
+#include <cub/util_type.cuh>
+
+CUB_NAMESPACE_BEGIN
+
+namespace detail
+{
+template <int ItemsPerThread>
+class block_topk_key_states;
+
+//! @brief Block-level rank specialization that uses atomic counters for the
+//!        final tie-break.
+//!
+//! The implementation is non-deterministic across launches because the tie-breaking subset is
+//! chosen by `atomicAdd` ordering.
+template <int BlockDimX>
+class block_topk_rank_atomic
+{
+private:
+  // TODO (elstehle): Make this configurable
+  // Whether to include all items tied with the k-th key when selecting top-k
+  static constexpr bool expand_k_to_include_ties = false;
+
+  static constexpr int threads_per_block = BlockDimX;
+
+  using counter_t = ::cuda::std::uint32_t;
+
+  struct TempStorage_
+  {
+    counter_t selected_offset[2];
+  };
+
+  TempStorage_& storage;
+  int linear_tid;
+
+public:
+  struct TempStorage : Uninitialized<TempStorage_>
+  {};
+
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE explicit block_topk_rank_atomic(TempStorage& storage)
+      : storage(storage.Alias())
+      , linear_tid(RowMajorTid(threads_per_block, 1, 1))
+  {}
+
+  //! Final tie-break + scatter-rank emission. See `block_topk_rank::rank_key_states`.
+  template <int ItemsPerThread>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
+  rank_key_states(block_topk_key_states<ItemsPerThread>& states, int (&scatter_ranks)[ItemsPerThread])
+  {
+    // Scatter indices of selected items into shared memory (only for selecting key-value pairs, using a two-phase
+    // approach to lower shared memory requirements).
+    for (int i = 0; i < ItemsPerThread; ++i)
+    {
+      scatter_ranks[i] = -1;
+    }
+
+    // If all candidates are amongst the remaining top-k, we can simply select all non-rejected/non-invalid candidates.
+    // Otherwise, we have to make sure that *all* selected candidates come first, and then select amongst tied
+    // candidates to fill up the remaining slots up to k.
+    const bool select_all_candidates = expand_k_to_include_ties || !states.has_ties();
+
+    if (linear_tid == 0)
+    {
+      // Write offsets for selected items with key_prefix < kth_prefix
+      storage.selected_offset[0] = counter_t{0};
+      // Write offsets for tied items across the k-th position, i.e., key_prefix == kth_prefix
+      storage.selected_offset[1] = static_cast<counter_t>(states.num_selected());
+    }
+    // Ensure atomic selection counter has been reset
+    __syncthreads();
+
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < ItemsPerThread; ++i)
+    {
+      const bool is_selected  = states.is_selected(i);
+      const bool is_candidate = states.is_candidate(i);
+
+      // We differentiate between candidates and selected only if not all candidates make it into the top-k items.
+      int item_class = (!select_all_candidates) && is_candidate ? 1 : 0;
+
+      if (is_selected || is_candidate)
+      {
+        const auto selected_offset = static_cast<int>(atomicAdd(&storage.selected_offset[item_class], counter_t{1}));
+        scatter_ranks[i]           = selected_offset < states.k() ? selected_offset : -1;
+      }
+    }
+  }
+};
+} // namespace detail
+
+CUB_NAMESPACE_END

--- a/cub/cub/block/specializations/block_topk_sieve_air.cuh
+++ b/cub/cub/block/specializations/block_topk_sieve_air.cuh
@@ -1,0 +1,379 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/block/block_scan.cuh>
+#include <cub/block/radix_rank_sort_operations.cuh>
+#include <cub/device/dispatch/dispatch_common.cuh>
+#include <cub/util_ptx.cuh>
+#include <cub/util_type.cuh>
+
+#include <cuda/__cmath/ceil_div.h>
+#include <cuda/std/cstdint>
+
+CUB_NAMESPACE_BEGIN
+
+namespace detail
+{
+template <int ItemsPerThread>
+class block_topk_key_states;
+
+template <typename SortKeyT>
+struct compare_key_prefix_op
+{
+  static_assert(::cuda::std::is_unsigned_v<SortKeyT>, "SortKeyT must be an unsigned type");
+
+  SortKeyT prefix_mask;
+  SortKeyT key_prefix;
+  [[nodiscard]] _CCCL_HOST_DEVICE_API _CCCL_FORCEINLINE constexpr bool operator()(SortKeyT sort_key) const noexcept
+  {
+    return (sort_key & prefix_mask) == (key_prefix);
+  }
+};
+
+//! @brief Block-level radix sieve specialization (state-classification only).
+//!
+template <typename KeyT, int BlockDimX, int RadixBits = 8>
+class block_topk_sieve_air
+{
+private:
+  static constexpr int threads_per_block  = BlockDimX;
+  static constexpr int num_buckets        = int{1u << RadixBits};
+  static constexpr int buckets_per_thread = ::cuda::ceil_div(num_buckets, threads_per_block);
+
+  using histo_counter_t = ::cuda::std::uint32_t;
+  using block_scan_t    = BlockScan<histo_counter_t, threads_per_block, BLOCK_SCAN_WARP_SCANS>;
+
+  using traits                 = detail::radix::traits_t<KeyT>;
+  using bit_ordered_type       = typename traits::bit_ordered_type;
+  using bit_ordered_conversion = typename traits::bit_ordered_conversion_policy;
+  using bit_ordered_inversion  = typename traits::bit_ordered_inversion_policy;
+
+  using fundamental_digit_extractor_t = BFEDigitExtractor<KeyT>;
+
+  struct TempStorage_
+  {
+    histo_counter_t histogram[num_buckets];
+    typename block_scan_t::TempStorage scan_temp_storage;
+    struct
+    {
+      histo_counter_t selected;
+      histo_counter_t candidates;
+      int bucket;
+    } pass_state;
+  };
+
+  TempStorage_& storage;
+  int linear_tid;
+
+  // Initialize histogram bins to zero
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void init_histograms()
+  {
+    // Initialize histogram bin counts to zeros
+    int histo_offset = 0;
+
+    // Loop unrolling is beneficial for performance here
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (; histo_offset + threads_per_block <= num_buckets; histo_offset += threads_per_block)
+    {
+      storage.histogram[histo_offset + linear_tid] = 0;
+    }
+    // Finish up with guarded initialization if necessary
+    if ((num_buckets % threads_per_block != 0) && (histo_offset + linear_tid < num_buckets))
+    {
+      storage.histogram[histo_offset + linear_tid] = 0;
+    }
+  }
+
+  // Compute histogram over keys
+  template <detail::topk::select SelectDirection,
+            bool IsFullTile,
+            int ItemsPerThread,
+            typename DigitExtractorT,
+            typename FilterOpT>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void compute_histograms(
+    const bit_ordered_type (&unsigned_keys)[ItemsPerThread],
+    block_topk_key_states<ItemsPerThread>& states,
+    DigitExtractorT digit_extractor,
+    FilterOpT filter_op)
+  {
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < ItemsPerThread; ++i)
+    {
+      const bit_ordered_type key = unsigned_keys[i];
+      if ((IsFullTile || states.is_candidate(i)) && filter_op(key))
+      {
+        const auto digit  = static_cast<int>(digit_extractor.Digit(key));
+        const auto bucket = (SelectDirection == detail::topk::select::min) ? digit : (num_buckets - 1 - digit);
+        atomicAdd(&storage.histogram[bucket], histo_counter_t{1});
+      }
+    }
+  }
+
+  // Compute prefix sum over buckets
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void compute_bin_offsets()
+  {
+    // TODO: If we ever have a block-scan with smem input (vs. rmem), use it here.
+    histo_counter_t thread_buckets[buckets_per_thread]{};
+    const int base = linear_tid * buckets_per_thread;
+
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < buckets_per_thread; ++i)
+    {
+      const int bin_idx = base + i;
+      if (bin_idx < num_buckets)
+      {
+        thread_buckets[i] = storage.histogram[bin_idx];
+      }
+    }
+
+    block_scan_t(storage.scan_temp_storage).InclusiveSum(thread_buckets, thread_buckets);
+
+    // TODO(pauleonix): There is no need to write and read the scanned histogram to/from smem:
+    // Keep thread_buckets[0] of each thread from before the scan and compute prev[0] = cur[0] - thread_buckets[0].
+    // Alternatively, compute the exclusive scan out-of-place and manually compute the inclusive scan from it and
+    // thread_buckets.
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < buckets_per_thread; ++i)
+    {
+      const int bin_idx = base + i;
+      if (bin_idx < num_buckets)
+      {
+        storage.histogram[bin_idx] = thread_buckets[i];
+      }
+    }
+  }
+
+  // Identify the bucket that the k-th item falls into
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void choose_bucket(histo_counter_t k)
+  {
+    const int base = linear_tid * buckets_per_thread;
+
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < buckets_per_thread; ++i)
+    {
+      const int bin_idx = base + i;
+      if (bin_idx < num_buckets)
+      {
+        const histo_counter_t prev = (bin_idx == 0) ? 0 : storage.histogram[bin_idx - 1];
+        const histo_counter_t cur  = storage.histogram[bin_idx];
+        _CCCL_ASSERT(cur >= prev, "Histogram bin count is not monotonically increasing");
+        // If a bug causes less than k candidates in the histogram, the previous pass' pass_state will persist making
+        // debugging harder. This assert should catch such bugs. Should there ever be a valid use case for less than k
+        // candidates, the pass_state needs to be reset unconditionally (e.g. in init_histograms()).
+        _CCCL_ASSERT((bin_idx != num_buckets - 1) || (cur >= k),
+                     "Less than k candidates have participated in the histogram");
+
+        if (prev < k && cur >= k)
+        {
+          storage.pass_state.bucket     = bin_idx;
+          storage.pass_state.candidates = cur - prev;
+          storage.pass_state.selected   = prev;
+        }
+      }
+    }
+  }
+
+  template <detail::topk::select SelectDirection, bool IsFullTile, int ItemsPerThread, typename DecomposerT>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void get_kth_key_prefix(
+    bit_ordered_type (&unsigned_keys)[ItemsPerThread],
+    int k,
+    block_topk_key_states<ItemsPerThread>& states,
+    int begin_bit,
+    int end_bit,
+    int& total_selected,
+    int& num_candidates,
+    bit_ordered_type& kth_key_prefix,
+    bit_ordered_type& prefix_mask,
+    DecomposerT decomposer = DecomposerT{})
+  {
+    // Preconditions
+    [[maybe_unused]] constexpr int tile_items = threads_per_block * ItemsPerThread;
+    _CCCL_ASSERT(k > 0 && k <= tile_items, "k must be in (0, tile_items]");
+    [[maybe_unused]] constexpr int max_bit = int(sizeof(KeyT) * 8);
+    _CCCL_ASSERT(begin_bit >= 0 && begin_bit < max_bit, "begin_bit must be in [0, max_bit)");
+    _CCCL_ASSERT(end_bit > begin_bit && end_bit <= max_bit, "end_bit must be in (begin_bit, max_bit]");
+
+    // We only consider candidates identified in the previous pass, i.e., ((sortkey & prefix_mask) == kth_prefix)
+    // With each pass, we identify a wider prefix of the splitter key
+    kth_key_prefix = 0;
+    prefix_mask    = 0;
+
+    const int total_bits = (::cuda::std::max) (end_bit - begin_bit, 0);
+    const int num_passes = ::cuda::ceil_div(total_bits, RadixBits);
+    for (int pass = 0; pass < num_passes; ++pass)
+    {
+      // Bit-range & mask of the current pass
+      const int pass_end_bit           = end_bit - pass * RadixBits;
+      const int pass_begin_bit         = (::cuda::std::max) (pass_end_bit - RadixBits, begin_bit);
+      const int pass_bits              = pass_end_bit - pass_begin_bit;
+      const bit_ordered_type pass_mask = ::cuda::bitmask<bit_ordered_type>(pass_begin_bit, pass_bits);
+
+      // Zero-initialize histograms for the current pass
+      init_histograms();
+      __syncthreads();
+
+      // Compute histogram over the current pass's, bits pre-filtered for keys matching the previous pass's prefix mask
+      auto filter_op = compare_key_prefix_op<bit_ordered_type>{prefix_mask, kth_key_prefix};
+      auto digit_extractor =
+        traits::template digit_extractor<fundamental_digit_extractor_t>(pass_begin_bit, pass_bits, decomposer);
+      compute_histograms<SelectDirection, IsFullTile>(unsigned_keys, states, digit_extractor, filter_op);
+      __syncthreads();
+
+      // Compute prefix sum over buckets
+      compute_bin_offsets();
+      __syncthreads();
+
+      // Identify the bucket that the k-th item falls into
+      choose_bucket(k);
+      __syncthreads();
+
+      // Update the current k and length for the next pass
+      k -= storage.pass_state.selected;
+      num_candidates = storage.pass_state.candidates;
+      total_selected += storage.pass_state.selected;
+
+      // Update the kth_key_prefix and prefix_mask for the next pass
+      // Basically, we will have valid_items candidates with the prefix kth_key_prefix
+      const auto kth_key_digit =
+        (SelectDirection == detail::topk::select::min)
+          ? storage.pass_state.bucket
+          : (num_buckets - 1 - storage.pass_state.bucket);
+      kth_key_prefix |= bit_ordered_type(kth_key_digit) << pass_begin_bit;
+      prefix_mask |= pass_mask;
+
+      // Short-circuit if all candidates are amongst the top-k
+      if (num_candidates == k)
+      {
+        break;
+      }
+    }
+
+    // Ensure we can repurpose shared memory after the multi-pass stage
+    __syncthreads();
+  }
+
+  template <detail::topk::select SelectDirection, bool IsFullTile, int ItemsPerThread>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
+  select_topk(KeyT (&keys)[ItemsPerThread], block_topk_key_states<ItemsPerThread>& states, int begin_bit, int end_bit)
+  {
+    // TODO (elstehle): Add support for custom decomposers
+    identity_decomposer_t decomposer;
+
+    // Get bit-twiddled sortkeys. For float keys, track which were -0.0 (normalized to +0.0 for ranking) so we can
+    // restore -0.0 in the output via a bitvector; no extra key buffer.
+    bit_ordered_type(&unsigned_keys)[ItemsPerThread] = reinterpret_cast<bit_ordered_type(&)[ItemsPerThread]>(keys);
+    constexpr int flip_back_num_words                = ::cuda::ceil_div(ItemsPerThread, 32);
+    [[maybe_unused]] ::cuda::std::uint32_t flip_back_bits[flip_back_num_words] = {};
+    if constexpr (::cuda::is_floating_point_v<KeyT>)
+    {
+      const bit_ordered_type twiddled_minus_zero =
+        Traits<KeyT>::TwiddleIn(bit_ordered_type(1) << (8 * sizeof(bit_ordered_type) - 1));
+      const bit_ordered_type twiddled_zero = Traits<KeyT>::TwiddleIn(0);
+      _CCCL_PRAGMA_UNROLL_FULL()
+      for (int i = 0; i < ItemsPerThread; ++i)
+      {
+        unsigned_keys[i] = bit_ordered_conversion::to_bit_ordered(decomposer, unsigned_keys[i]);
+        if (unsigned_keys[i] == twiddled_minus_zero)
+        {
+          flip_back_bits[i / 32] |= (1u << (i % 32));
+          unsigned_keys[i] = twiddled_zero;
+        }
+      }
+    }
+    else
+    {
+      _CCCL_PRAGMA_UNROLL_FULL()
+      for (int i = 0; i < ItemsPerThread; ++i)
+      {
+        unsigned_keys[i] = bit_ordered_conversion::to_bit_ordered(decomposer, unsigned_keys[i]);
+      }
+    }
+
+    // The prefix (i.e., the most significant bits) of the k-th key
+    bit_ordered_type kth_prefix{};
+    // The prefix mask (i.e., the bit mask with the most significant bits populated) of the k-th key
+    bit_ordered_type prefix_mask{};
+    // The total number of items that compare strictly less than the k-th key's prefix (i.e., the number of items that
+    // are guaranteed to be selected)
+    auto total_selected = IsFullTile ? 0 : states.num_selected();
+    // The number of candidates that compare equal to the k-th key's prefix
+    auto num_candidates = IsFullTile ? BlockDimX * ItemsPerThread : states.num_candidates();
+
+    // Identify the prefix of the k-th key
+    get_kth_key_prefix<SelectDirection, IsFullTile>(
+      unsigned_keys,
+      states.k() - states.num_selected(),
+      states,
+      begin_bit,
+      end_bit,
+      total_selected,
+      num_candidates,
+      kth_prefix,
+      prefix_mask,
+      decomposer);
+
+    // Update the states before untwiddling the key
+    states.set_num_selected(total_selected);
+    states.set_num_candidates(num_candidates);
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < ItemsPerThread; ++i)
+    {
+      if (states.is_candidate(i))
+      {
+        using comparison_t = ::cuda::std::
+          conditional_t<SelectDirection == detail::topk::select::min, ::cuda::std::less<>, ::cuda::std::greater<>>;
+        const bit_ordered_type key_prefix = unsigned_keys[i] & prefix_mask;
+        if (comparison_t{}(key_prefix, kth_prefix))
+        {
+          states.set_selected(i);
+        }
+        else if (comparison_t{}(kth_prefix, key_prefix))
+        {
+          states.set_rejected(i);
+        }
+      }
+      // Un-twiddle the key
+      if constexpr (::cuda::is_floating_point_v<KeyT>)
+      {
+        const bit_ordered_type twiddled_minus_zero =
+          Traits<KeyT>::TwiddleIn(bit_ordered_type(1) << (8 * sizeof(bit_ordered_type) - 1));
+        unsigned_keys[i] = (flip_back_bits[i / 32] & (1u << (i % 32))) ? twiddled_minus_zero : unsigned_keys[i];
+      }
+      unsigned_keys[i] = bit_ordered_conversion::from_bit_ordered(decomposer, unsigned_keys[i]);
+    }
+  }
+
+public:
+  struct TempStorage : Uninitialized<TempStorage_>
+  {};
+
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE explicit block_topk_sieve_air(TempStorage& storage)
+      : storage(storage.Alias())
+      , linear_tid(RowMajorTid(threads_per_block, 1, 1))
+  {}
+
+  template <detail::topk::select SelectDirection, bool IsFullTile, int ItemsPerThread>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void refine_keys(
+    KeyT (&keys)[ItemsPerThread],
+    block_topk_key_states<ItemsPerThread>& states,
+    int begin_bit = 0,
+    int end_bit   = sizeof(KeyT) * 8)
+  {
+    select_topk<SelectDirection, IsFullTile>(keys, states, begin_bit, end_bit);
+  }
+};
+} // namespace detail
+
+CUB_NAMESPACE_END

--- a/cub/cub/block/specializations/block_topk_sieve_air.cuh
+++ b/cub/cub/block/specializations/block_topk_sieve_air.cuh
@@ -20,6 +20,7 @@
 #include <cub/util_type.cuh>
 
 #include <cuda/__cmath/ceil_div.h>
+#include <cuda/std/__type_traits/is_unsigned.h>
 #include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN

--- a/cub/test/catch2_test_block_topk_common.cuh
+++ b/cub/test/catch2_test_block_topk_common.cuh
@@ -1,0 +1,356 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Shared helpers for block-level top-k API tests: deterministic and
+// random key generation (incl. fine control over the top-k boundary),
+// host-side top-k references, and small CUDA-test glue.
+
+#pragma once
+
+#include <thrust/random.h>
+#include <thrust/shuffle.h>
+
+#include <cuda/std/__algorithm/max.h>
+#include <cuda/std/__algorithm/min.h>
+#include <cuda/std/__bit/bit_cast.h>
+#include <cuda/std/__cmath/isfinite.h>
+#include <cuda/std/__cmath/rounding_functions.h>
+#include <cuda/std/__functional/operations.h>
+#include <cuda/std/__memory/pointer_traits.h>
+#include <cuda/std/cstddef>
+#include <cuda/std/cstdint>
+#include <cuda/std/limits>
+#include <cuda/std/optional>
+#include <cuda/std/span>
+#include <cuda/type_traits>
+
+#include <algorithm>
+#include <initializer_list>
+
+#include <c2h/catch2_test_helper.h>
+
+// --- RNG and data generation ---
+
+// Shared RNG type; each test constructs one and threads it through every
+// helper that consumes randomness.
+using rng_t = thrust::default_random_engine;
+
+// `n` distinct, shuffled values of `T` centered at `0` (or `max() / 2` for unsigned).
+template <typename T>
+c2h::host_vector<T> distinct_keys(cuda::std::size_t n, rng_t& rng)
+{
+  constexpr T mean = cuda::std::is_signed_v<T> ? T{0} : (cuda::std::numeric_limits<T>::max() / T{2});
+  const T start    = static_cast<T>(mean - static_cast<T>(n / 2));
+  c2h::host_vector<T> v(n);
+  for (cuda::std::size_t i = 0; i < n; ++i)
+  {
+    v[i] = static_cast<T>(start + static_cast<T>(i));
+  }
+  thrust::shuffle(v.begin(), v.end(), rng);
+  return v;
+}
+
+// `n` keys from a centered distribution: standard normal for FP, uniform
+// over a width-`n` window for integers (centered at `0` for signed,
+// `max() / 2` for unsigned). The narrow window gives `~n/2` expected
+// collision pairs by birthday paradox, exercising the tie-break path
+// without engineering ties.
+template <typename KeyT>
+c2h::host_vector<KeyT> random_keys_centered(int n, rng_t& rng)
+{
+  c2h::host_vector<KeyT> v(n);
+  auto fill_keys = [&](auto& dist) {
+    for (auto& x : v)
+    {
+      x = dist(rng);
+    }
+  };
+  if constexpr (cuda::is_floating_point_v<KeyT>)
+  {
+    constexpr KeyT mean   = KeyT{0};
+    constexpr KeyT stddev = KeyT{1};
+    thrust::random::normal_distribution<KeyT> dist(mean, stddev);
+    fill_keys(dist);
+  }
+  else
+  {
+    constexpr KeyT mean = cuda::std::is_signed_v<KeyT> ? KeyT{0} : (cuda::std::numeric_limits<KeyT>::max() / KeyT{2});
+    const KeyT half     = static_cast<KeyT>(n / 2);
+    thrust::random::uniform_int_distribution<KeyT> dist(static_cast<KeyT>(mean - half), static_cast<KeyT>(mean + half));
+    fill_keys(dist);
+  }
+  return v;
+}
+
+// Random `boundary_key` valid for `gen_keys_from_boundary_key<KeyT>`
+// (strictly inside the representable range; FP halves the span to satisfy
+// `uniform_real_distribution`'s `b - a <= max()` precondition).
+template <typename KeyT>
+KeyT random_boundary_key(rng_t& rng)
+{
+  if constexpr (cuda::std::is_integral_v<KeyT>)
+  {
+    constexpr KeyT type_lo = cuda::std::numeric_limits<KeyT>::lowest();
+    constexpr KeyT type_hi = cuda::std::numeric_limits<KeyT>::max();
+    thrust::random::uniform_int_distribution<KeyT> dist(
+      static_cast<KeyT>(type_lo + KeyT{1}), static_cast<KeyT>(type_hi - KeyT{1}));
+    return dist(rng);
+  }
+  else
+  {
+    // FP: half-span to satisfy `uniform_real_distribution`'s `b - a <= max()` precondition.
+    constexpr KeyT type_hi = cuda::std::numeric_limits<KeyT>::max() / KeyT{2};
+    constexpr KeyT type_lo = -type_hi;
+    thrust::random::uniform_real_distribution<KeyT> dist(
+      cuda::std::nextafter(type_lo, KeyT{0}), cuda::std::nextafter(type_hi, KeyT{0}));
+    return dist(rng);
+  }
+}
+
+// Generates `n` keys with knobs for top-k boundary behavior: the boundary
+// value (`boundary_key`), the number of boundary ties (`num_tied >=
+// overhang + 1`), and built-in coverage of near-boundary values
+// (`boundary_succ` / `boundary_pred`) and FP specials (`+/-inf`, and a
+// `+0.0` / `-0.0` mix when `boundary_key == 0.0`). Remaining slots are
+// random above-/below-k fillers.
+//
+// `overhang > 0` forces ranking to pick a `num_tied - overhang` subset of
+// boundary copies; `overhang == 0` only fixes the *order* of selected
+// items. Requires `effective_k + overhang <= num_items` (with
+// `effective_k = min(k, num_items)`). `boundary_key` must be strictly
+// inside the integer range, or finite for FP (`lowest()` / `max()`
+// collapse the corresponding above-/below-k slots to `+/-inf`).
+template <bool SelectMax, typename KeyT>
+c2h::host_vector<KeyT> gen_keys_from_boundary_key(int num_items, int k, int overhang, KeyT boundary_key, rng_t& rng)
+{
+  REQUIRE(0 < k);
+  REQUIRE(0 <= overhang);
+  const int effective_k = cuda::std::min(k, num_items);
+  REQUIRE(effective_k + overhang <= num_items);
+
+  // overhang only specifies the lower bound of the number of tied keys.
+  thrust::random::uniform_int_distribution<int> num_tied_dist(overhang + 1, effective_k + overhang);
+  const int num_tied        = num_tied_dist(rng);
+  const int num_after_sieve = effective_k + overhang;
+  const int num_winners     = num_after_sieve - num_tied;
+  const int num_losers      = num_items - num_after_sieve;
+
+  // Map selection direction onto the two sides of `boundary_key` once;
+  // rest is direction-agnostic.
+  const int num_above_k = SelectMax ? num_winners : num_losers;
+  const int num_below_k = SelectMax ? num_losers : num_winners;
+  REQUIRE(num_above_k + num_tied + num_below_k == num_items);
+
+  c2h::host_vector<KeyT> keys(num_items);
+
+  // Slot 0 of each non-empty side is pinned to `boundary_succ` /
+  // `boundary_pred` so the sieve discriminates adjacent bit patterns.
+  auto fill_keys = [&](auto above_gen, auto below_gen, auto boundary_key_gen) {
+    int idx = 0;
+    for (int i = 0; i < num_above_k; ++i, ++idx)
+    {
+      keys[idx] = above_gen(i);
+    }
+    for (int i = 0; i < num_below_k; ++i, ++idx)
+    {
+      keys[idx] = below_gen(i);
+    }
+    for (int i = 0; i < num_tied; ++i, ++idx)
+    {
+      keys[idx] = boundary_key_gen(i);
+    }
+  };
+
+  if constexpr (cuda::std::is_integral_v<KeyT>)
+  {
+    constexpr KeyT type_lo = cuda::std::numeric_limits<KeyT>::lowest();
+    constexpr KeyT type_hi = cuda::std::numeric_limits<KeyT>::max();
+
+    // Strict inequality so `boundary_key +/- 1` stay representable.
+    REQUIRE(type_lo < boundary_key);
+    REQUIRE(boundary_key < type_hi);
+    const KeyT boundary_succ = static_cast<KeyT>(boundary_key + KeyT{1});
+    const KeyT boundary_pred = static_cast<KeyT>(boundary_key - KeyT{1});
+
+    thrust::random::uniform_int_distribution<KeyT> above_dist(boundary_succ, type_hi);
+    thrust::random::uniform_int_distribution<KeyT> below_dist(type_lo, boundary_pred);
+
+    // First slot of each side is pinned to `boundary_succ` / `boundary_pred` so the sieve discriminates adjacent bit
+    // patterns.
+    fill_keys(
+      [&](int i) {
+        return (i == 0) ? boundary_succ : above_dist(rng);
+      },
+      [&](int i) {
+        return (i == 0) ? boundary_pred : below_dist(rng);
+      },
+      [&](int) {
+        return boundary_key;
+      });
+  }
+  else
+  {
+    constexpr KeyT inf      = cuda::std::numeric_limits<KeyT>::infinity();
+    constexpr KeyT type_max = cuda::std::numeric_limits<KeyT>::max();
+    constexpr KeyT type_min = -type_max;
+
+    REQUIRE(cuda::std::isfinite(boundary_key));
+
+    // `boundary_key == max()` / `lowest()` saturates `nextafter` to
+    // `+/-inf` (slot 0 then carries `+/-inf` for free); the non-edge side
+    // uses the optional, clamped to `max()` to satisfy
+    // `uniform_real_distribution`'s `b - a <= max()` precondition.
+    const KeyT boundary_succ = cuda::std::nextafter(boundary_key, +inf);
+    const KeyT boundary_pred = cuda::std::nextafter(boundary_key, -inf);
+
+    // Make sure the distributions are valid.
+    cuda::std::optional<thrust::random::uniform_real_distribution<KeyT>> above_dist;
+    cuda::std::optional<thrust::random::uniform_real_distribution<KeyT>> below_dist;
+    if (boundary_key != type_max)
+    {
+      above_dist.emplace(boundary_succ, cuda::std::min(boundary_succ + type_max, type_max));
+    }
+    if (boundary_key != type_min)
+    {
+      below_dist.emplace(cuda::std::max(boundary_pred - type_max, type_min), boundary_pred);
+    }
+
+    fill_keys(
+      [&](int i) -> KeyT {
+        if (i == 0)
+        {
+          return boundary_succ;
+        }
+        else if (i == 1)
+        {
+          return inf;
+        }
+        else
+        {
+          return above_dist ? (*above_dist)(rng) : inf;
+        }
+      },
+      [&](int i) -> KeyT {
+        if (i == 0)
+        {
+          return boundary_pred;
+        }
+        else if (i == 1)
+        {
+          return -inf;
+        }
+        else
+        {
+          return below_dist ? (*below_dist)(rng) : -inf;
+        }
+      },
+      // For `boundary_key == +/-0.0`, alternate signs to mix `+0.0` and
+      // `-0.0` ties; otherwise every tied slot is identical.
+      [&](int i) -> KeyT {
+        if ((i % 2 == 0) || (boundary_key != KeyT{0.0}))
+        {
+          return boundary_key;
+        }
+        return -boundary_key;
+      });
+  }
+
+  thrust::shuffle(keys.begin(), keys.end(), rng);
+  return keys;
+}
+
+// Catch2 generator over type-specific deterministic `boundary_key` values:
+// FP gets `0.0`, the smallest positive/negative values, the subnormal/
+// normal boundary on each side, and `max()` / `lowest()`. Signed integers
+// get just `0`; unsigned integers get `max() / 2` (the top-bit transition).
+template <typename KeyT>
+auto boundary_key_generator()
+{
+  using namespace Catch::Generators;
+  if constexpr (cuda::is_floating_point_v<KeyT>)
+  {
+    constexpr KeyT inf     = cuda::std::numeric_limits<KeyT>::infinity();
+    constexpr KeyT pos_min = cuda::std::numeric_limits<KeyT>::min();
+    return values<KeyT>({
+      KeyT{0}, // -0.0 is automatically generated by the FP branch of gen_keys_from_boundary_key
+      cuda::std::nextafter(KeyT{0}, +inf), // smallest finite positive value (possibly subnormal)
+      cuda::std::nextafter(KeyT{0}, -inf), // largest finite negative value (possibly subnormal)
+      // Subnormal/normal boundary on each side -- the bit-cast unsigned representation jumps when the exponent flips
+      // from all-zeros to a leading 1.
+      cuda::std::nextafter(pos_min, KeyT{0}), // largest positive subnormal
+      pos_min, // smallest positive normal
+      -pos_min, // largest negative normal (closest to 0)
+      cuda::std::nextafter(-pos_min, KeyT{0}), // largest-magnitude negative subnormal
+      cuda::std::numeric_limits<KeyT>::max(), // largest finite -- collapses above-k slots to +inf
+      cuda::std::numeric_limits<KeyT>::lowest(), // smallest finite (== -max()) -- collapses below-k slots to -inf
+    });
+  }
+  else
+  {
+    constexpr KeyT fixed = cuda::std::is_signed_v<KeyT> ? KeyT{0} : (cuda::std::numeric_limits<KeyT>::max() / KeyT{2});
+    return values<KeyT>({fixed});
+  }
+}
+
+// Catch2 generator over `options`, narrowed to the leading entry when
+// `narrow` (callers must list the always-applicable value first).
+inline auto overhang_generator(bool narrow, std::initializer_list<int> options)
+{
+  using namespace Catch::Generators;
+  return narrow ? take(1, values<int>(options)) : values<int>(options);
+}
+
+// --- Host top-k reference ---
+
+// Winner-first ordering: largest for SelectMax, smallest for SelectMin.
+template <bool SelectMax>
+using comparator_t = cuda::std::conditional_t<SelectMax, cuda::std::greater<>, cuda::std::less<>>;
+
+// Up to `min(k, in.size())` items so callers can pass a `k` exceeding the input length.
+template <bool SelectMax, typename T>
+c2h::host_vector<T> sorted_top_k(const c2h::host_vector<T>& in, int k)
+{
+  c2h::host_vector<T> ref = in;
+  const auto out_size     = cuda::std::min(static_cast<cuda::std::size_t>(k), ref.size());
+  std::partial_sort(ref.begin(), ref.begin() + out_size, ref.end(), comparator_t<SelectMax>{});
+  ref.resize(out_size);
+  return ref;
+}
+
+// --- Kernel-launch glue ---
+
+// Wraps a thrust-compatible contiguous container as a dynamic-extent
+// `cuda::std::span` (static-extent spans are built manually at call sites).
+template <typename Container>
+auto to_span(Container&& v)
+{
+  return cuda::std::span{cuda::std::to_address(v.data()), v.size()};
+}
+
+// --- Post-processing / comparison ---
+
+// For FP `T`, returns each element's same-sized unsigned-int bit pattern
+// (no-op for non-FP `T`) so the round-trip compare catches subnormal /
+// sign-bit-only diffs that FP `==` would equate.
+template <typename T>
+auto bit_repr(const c2h::host_vector<T>& v)
+{
+  if constexpr (cuda::is_floating_point_v<T>)
+  {
+    using U = cuda::std::conditional_t<
+      sizeof(T) == sizeof(cuda::std::uint64_t),
+      cuda::std::uint64_t,
+      cuda::std::conditional_t<sizeof(T) == sizeof(cuda::std::uint32_t), cuda::std::uint32_t, cuda::std::uint16_t>>;
+    static_assert(sizeof(U) == sizeof(T), "bit_repr: no matching unsigned-int width for T");
+    c2h::host_vector<U> out(v.size());
+    for (cuda::std::size_t i = 0; i < v.size(); ++i)
+    {
+      out[i] = cuda::std::bit_cast<U>(v[i]);
+    }
+    return out;
+  }
+  else
+  {
+    return v;
+  }
+}

--- a/cub/test/catch2_test_block_topk_common.cuh
+++ b/cub/test/catch2_test_block_topk_common.cuh
@@ -17,6 +17,7 @@
 #include <cuda/std/__cmath/rounding_functions.h>
 #include <cuda/std/__functional/operations.h>
 #include <cuda/std/__memory/pointer_traits.h>
+#include <cuda/std/__type_traits/remove_pointer.h>
 #include <cuda/std/cstddef>
 #include <cuda/std/cstdint>
 #include <cuda/std/limits>
@@ -324,7 +325,8 @@ c2h::host_vector<T> sorted_top_k(const c2h::host_vector<T>& in, int k)
 template <typename Container>
 auto to_span(Container&& v)
 {
-  return cuda::std::span{cuda::std::to_address(v.data()), v.size()};
+  using element_t = cuda::std::remove_pointer_t<decltype(cuda::std::to_address(v.data()))>;
+  return cuda::std::span<element_t>{cuda::std::to_address(v.data()), v.size()};
 }
 
 // --- Post-processing / comparison ---

--- a/cub/test/catch2_test_block_topk_rank.cu
+++ b/cub/test/catch2_test_block_topk_rank.cu
@@ -476,7 +476,7 @@ C2H_TEST("block_topk_sieve::select_* selects the right top-k on a full tile",
   const int k = GENERATE_COPY(values<int>({1, 13, items_per_thread, threads_per_block, tile_size - 1, tile_size}));
   // 0 (order only) -> `tile_size - k` (every boundary copy overflows);
   // trailing entries go negative when `k > tile_size` but get narrowed off.
-  const int overhang = GENERATE_COPY(overhang_generator(k >= tile_size, {0, 1, (tile_size - k) / 2, tile_size - k}));
+  const int overhang = GENERATE_COPY(overhang_generator(k == tile_size, {0, 1, (tile_size - k) / 2, tile_size - k}));
 
   auto run_check = [&](rng_t& rng, key_t boundary_key) {
     CAPTURE(c2h::type_name<key_t>(), select_max, k, overhang, boundary_key);
@@ -519,7 +519,7 @@ C2H_TEST("block_topk_sieve handles partial tiles correctly", "[block][topk][rank
   const int num_valid = GENERATE_COPY(values<int>({threads_per_block, tile_size - items_per_thread, tile_size}));
   const int k =
     GENERATE_COPY(values<int>({1, 5, items_per_thread, threads_per_block, num_valid / 2, num_valid - 1, num_valid}));
-  const int overhang = GENERATE_COPY(overhang_generator(k >= num_valid, {0, 1, (num_valid - k) / 2, num_valid - k}));
+  const int overhang = GENERATE_COPY(overhang_generator(k == num_valid, {0, 1, (num_valid - k) / 2, num_valid - k}));
   const bool blocked_input = GENERATE_COPY(true, false);
 
   // Same shape assertion as test 3: `has_ties == (overhang > 0)`.
@@ -556,32 +556,40 @@ C2H_TEST("block_topk_sieve handles partial tiles correctly", "[block][topk][rank
 
 // ---------------------------------------------------------------------------
 // 5) Multi-key tie-break: many primary ties, unique secondary breaks them.
+//    Sweeps `select_max`/`select_min` and full / partial tiles.
 // ---------------------------------------------------------------------------
 
-C2H_TEST("block_topk_sieve resolves primary ties via a secondary refine", "[block][topk][rank][multi-key]")
+C2H_TEST("block_topk_sieve resolves primary ties via a secondary refine",
+         "[block][topk][rank][multi-key]",
+         select_direction_max)
 {
-  using primary_t   = float;
-  using secondary_t = cuda::std::uint32_t;
+  using primary_t                  = float;
+  using secondary_t                = cuda::std::uint32_t;
+  static constexpr bool select_max = c2h::get<0, TestType>::value;
   // Odd items-per-thread (3) to verify nothing assumes power-of-two strides.
   static constexpr int threads_per_block = 128;
   static constexpr int items_per_thread  = 3;
   static constexpr int tile_size         = threads_per_block * items_per_thread;
-  static constexpr bool is_full_tile     = true;
-  static constexpr bool select_max       = true;
+
+  // `num_valid == tile_size` exercises the `IsFullTile=true` instantiation;
+  // smaller values exercise `IsFullTile=false`.
+  const int num_valid =
+    GENERATE_COPY(values<int>({threads_per_block - 1, threads_per_block, tile_size - items_per_thread, tile_size}));
 
   // Primary: bit-equal boundary copies + strict above/below fillers ->
-  // ties iff `overhang > 0`. Secondary: shuffled `[0, tile_size)` ->
+  // ties iff `overhang > 0`. Secondary: shuffled `[0, num_valid)` ->
   // refine collapses every tied primary class to a unique representative,
   // so post-refine `has_ties()` is always `false`.
-  const int k        = GENERATE_COPY(values<int>({1, 7, tile_size / 4, tile_size - 1}));
-  const int overhang = GENERATE_COPY(overhang_generator(k >= tile_size, {0, 1, (tile_size - k) / 2}));
+  const int k        = GENERATE_COPY(values<int>({1, 7, num_valid / 4, num_valid - 1}));
+  const int overhang = GENERATE_COPY(overhang_generator(k == num_valid, {0, 1, (num_valid - k) / 2}));
 
   auto run_check = [&](rng_t& rng, primary_t boundary_key) {
-    CAPTURE(k, overhang, boundary_key);
+    const bool is_full_tile = (num_valid == tile_size);
+    CAPTURE(select_max, is_full_tile, num_valid, k, overhang, boundary_key);
 
     c2h::host_vector<primary_t> h_primary =
-      gen_keys_from_boundary_key<select_max>(tile_size, k, overhang, boundary_key, rng);
-    c2h::host_vector<secondary_t> h_secondary = distinct_keys<secondary_t>(tile_size, rng);
+      gen_keys_from_boundary_key<select_max>(num_valid, k, overhang, boundary_key, rng);
+    c2h::host_vector<secondary_t> h_secondary = distinct_keys<secondary_t>(num_valid, rng);
 
     c2h::device_vector<primary_t> d_primary(h_primary);
     c2h::device_vector<secondary_t> d_secondary(h_secondary);
@@ -589,13 +597,26 @@ C2H_TEST("block_topk_sieve resolves primary ties via a secondary refine", "[bloc
     c2h::device_vector<secondary_t> d_top_secondary(k, secondary_t{});
     c2h::device_vector<bool> d_has_ties(2, false);
 
-    multi_key_kernel<primary_t, secondary_t, threads_per_block, items_per_thread, is_full_tile, select_max>
-      <<<1, threads_per_block>>>(
-        to_span(d_primary),
-        to_span(d_secondary),
-        to_span(d_top_primary),
-        to_span(d_top_secondary),
-        cuda::std::span<bool, 2>{cuda::std::to_address(d_has_ties.data()), 2});
+    // Generic lambda dispatches on the runtime `is_full_tile` flag to one of
+    // the two compile-time `IsFullTile` kernel instantiations.
+    auto launch_kernel = [&](auto is_full_tile_const) {
+      static constexpr bool ift = decltype(is_full_tile_const)::value;
+      multi_key_kernel<primary_t, secondary_t, threads_per_block, items_per_thread, ift, select_max>
+        <<<1, threads_per_block>>>(
+          to_span(d_primary),
+          to_span(d_secondary),
+          to_span(d_top_primary),
+          to_span(d_top_secondary),
+          cuda::std::span<bool, 2>{cuda::std::to_address(d_has_ties.data()), 2});
+    };
+    if (is_full_tile)
+    {
+      launch_kernel(cuda::std::true_type{});
+    }
+    else
+    {
+      launch_kernel(cuda::std::false_type{});
+    }
     REQUIRE(cudaSuccess == cudaPeekAtLastError());
     REQUIRE(cudaSuccess == cudaDeviceSynchronize());
 
@@ -605,7 +626,7 @@ C2H_TEST("block_topk_sieve resolves primary ties via a secondary refine", "[bloc
     REQUIRE_FALSE(h_has_ties[1]);
 
     auto zip_ref = thrust::make_zip_iterator(h_primary.begin(), h_secondary.begin());
-    thrust::sort(zip_ref, zip_ref + tile_size, comparator_t<select_max>{});
+    thrust::sort(zip_ref, zip_ref + num_valid, comparator_t<select_max>{});
     h_primary.resize(k);
     h_secondary.resize(k);
 
@@ -693,7 +714,7 @@ C2H_TEST("block_topk_sieve produces the same selection across bit-window splits"
     const int k = GENERATE_COPY(values<int>({1, 11, tile_size / 4, tile_size - 1}));
     // `overhang == 0` excluded: would let the early exit fire non-
     // deterministically. `> 0` keeps `has_ties()` true to `hi == 0`.
-    const int overhang = GENERATE_COPY(overhang_generator(k >= tile_size, {1, (tile_size - k) / 2}));
+    const int overhang = GENERATE_COPY(overhang_generator(k == tile_size, {1, (tile_size - k) / 2}));
     // `key_t` is unsigned -- only the random draw applies.
     rng_t rng(static_cast<cuda::std::uint32_t>(C2H_SEED(1).get()));
     const key_t boundary_key = random_boundary_key<key_t>(rng);

--- a/cub/test/catch2_test_block_topk_rank.cu
+++ b/cub/test/catch2_test_block_topk_rank.cu
@@ -83,6 +83,11 @@ __global__ void single_key_kernel(
   }();
   __syncthreads();
 
+  if (threadIdx.x == 0)
+  {
+    g_has_ties[0] = states.has_ties();
+  }
+
   int ranks[ItemsPerThread];
   rank_t(smem.rank).rank_key_states(states, ranks);
 
@@ -92,11 +97,6 @@ __global__ void single_key_kernel(
     {
       g_top[ranks[i]] = keys[i];
     }
-  }
-
-  if (threadIdx.x == 0)
-  {
-    g_has_ties[0] = states.has_ties();
   }
 
   // Round-trip the keys: bit-identical to the input. Bounded store skips OOB.
@@ -409,8 +409,7 @@ C2H_TEST("block_topk_sieve preserves keys bit-faithfully across FP edge cases",
 
   CAPTURE(c2h::type_name<key_t>(), select_max);
 
-  // Partial-tile sections use a `num_valid` prefix; each section also
-  // exercises `k > valid_items`. All-distinct bit patterns ->
+  // Partial-tile sections use a `num_valid` prefix. All-distinct bit patterns ->
   // `has_ties()` must end false.
   const int num_valid = tile_size / 2 + 7;
   c2h::host_vector<key_t> h_in_partial(h_in.begin(), h_in.begin() + num_valid);
@@ -419,7 +418,7 @@ C2H_TEST("block_topk_sieve preserves keys bit-faithfully across FP edge cases",
   {
     static constexpr bool is_full_tile  = true;
     static constexpr bool blocked_input = true;
-    const int k                         = GENERATE_COPY(values<int>({1, tile_size / 4, tile_size - 1, tile_size + 5}));
+    const int k                         = GENERATE_COPY(values<int>({1, tile_size / 4, tile_size - 1}));
     CAPTURE(k);
     const auto h_ref = sorted_top_k<select_max>(h_in, k);
     const bool has_ties =
@@ -432,7 +431,7 @@ C2H_TEST("block_topk_sieve preserves keys bit-faithfully across FP edge cases",
   {
     static constexpr bool is_full_tile  = false;
     static constexpr bool blocked_input = true;
-    const int k                         = GENERATE_COPY(values<int>({1, num_valid / 4, num_valid - 1, num_valid + 5}));
+    const int k                         = GENERATE_COPY(values<int>({1, num_valid / 4, num_valid - 1}));
     CAPTURE(num_valid, k);
     const auto h_ref = sorted_top_k<select_max>(h_in_partial, k);
     const bool has_ties =
@@ -445,7 +444,7 @@ C2H_TEST("block_topk_sieve preserves keys bit-faithfully across FP edge cases",
   {
     static constexpr bool is_full_tile  = false;
     static constexpr bool blocked_input = false;
-    const int k                         = GENERATE_COPY(values<int>({1, num_valid / 4, num_valid - 1, num_valid + 5}));
+    const int k                         = GENERATE_COPY(values<int>({1, num_valid / 4, num_valid - 1}));
     CAPTURE(num_valid, k);
     const auto h_ref = sorted_top_k<select_max>(h_in_partial, k);
     const bool has_ties =
@@ -474,8 +473,7 @@ C2H_TEST("block_topk_sieve::select_* selects the right top-k on a full tile",
   static constexpr bool is_full_tile     = true;
   static constexpr bool blocked_input    = true;
 
-  const int k =
-    GENERATE_COPY(values<int>({1, 13, items_per_thread, threads_per_block, tile_size - 1, tile_size, tile_size + 1}));
+  const int k = GENERATE_COPY(values<int>({1, 13, items_per_thread, threads_per_block, tile_size - 1, tile_size}));
   // 0 (order only) -> `tile_size - k` (every boundary copy overflows);
   // trailing entries go negative when `k > tile_size` but get narrowed off.
   const int overhang = GENERATE_COPY(overhang_generator(k >= tile_size, {0, 1, (tile_size - k) / 2, tile_size - k}));
@@ -518,15 +516,10 @@ C2H_TEST("block_topk_sieve handles partial tiles correctly", "[block][topk][rank
   static constexpr int items_per_thread  = 2;
   static constexpr int tile_size         = threads_per_block * items_per_thread;
 
-  const int num_valid =
-    GENERATE_COPY(values<int>({threads_per_block - 1, threads_per_block, tile_size - items_per_thread, tile_size}));
-  const int k = GENERATE_COPY(
-    values<int>({1, 5, items_per_thread, threads_per_block, num_valid / 2, num_valid - 1, num_valid, num_valid + 1}));
+  const int num_valid = GENERATE_COPY(values<int>({threads_per_block, tile_size - items_per_thread, tile_size}));
+  const int k =
+    GENERATE_COPY(values<int>({1, 5, items_per_thread, threads_per_block, num_valid / 2, num_valid - 1, num_valid}));
   const int overhang = GENERATE_COPY(overhang_generator(k >= num_valid, {0, 1, (num_valid - k) / 2, num_valid - k}));
-  // GENERATE_COPY (not nested SECTIONs) so the boundary_key SECTIONs below
-  // aren't reached through multiple paths -- Catch2's tracker can't handle
-  // that. Variadic form wraps each arg in a SingleValueGenerator (avoiding
-  // the `std::vector<bool>`-backed FixedValuesGenerator).
   const bool blocked_input = GENERATE_COPY(true, false);
 
   // Same shape assertion as test 3: `has_ties == (overhang > 0)`.
@@ -611,13 +604,6 @@ C2H_TEST("block_topk_sieve resolves primary ties via a secondary refine", "[bloc
     REQUIRE(h_has_ties[0] == (overhang > 0));
     REQUIRE_FALSE(h_has_ties[1]);
 
-    // Reference: zip-sort the full input by lex desc so the first k pairs
-    // are the winners; same canonical sort on the kernel output. Unique
-    // secondaries pin both lex sorts, and FP `==` already excuses the
-    // sieve's `+/-0.0` ambiguity on the primary. `thrust::make_zip_iterator`
-    // (not `cuda::`): proxy-ref iterators only sort correctly via thrust's
-    // host backend; `std::sort` and `cuda::zip_iterator` don't compose
-    // until C++20 `std::ranges::sort` (not yet ported to `cuda::std`).
     auto zip_ref = thrust::make_zip_iterator(h_primary.begin(), h_secondary.begin());
     thrust::sort(zip_ref, zip_ref + tile_size, comparator_t<select_max>{});
     h_primary.resize(k);
@@ -736,41 +722,4 @@ C2H_TEST("block_topk_sieve produces the same selection across bit-window splits"
     constexpr int expected_last_hi = key_bits - 2 * window_bits;
     run_compare(h_in, k, expected_last_hi);
   }
-}
-
-// ---------------------------------------------------------------------------
-// 7) `k == 0`: nothing selected, no writes to the output span.
-// ---------------------------------------------------------------------------
-
-C2H_TEST("block_topk_sieve handles k == 0", "[block][topk][rank][edge]")
-{
-  using key_t                            = int;
-  static constexpr int threads_per_block = 32;
-  static constexpr int items_per_thread  = 16;
-  static constexpr int tile_size         = threads_per_block * items_per_thread;
-  static constexpr bool is_full_tile     = true;
-  static constexpr bool blocked_input    = true;
-  static constexpr bool select_max       = true;
-
-  rng_t rng(static_cast<cuda::std::uint32_t>(C2H_SEED(1).get()));
-  c2h::host_vector<key_t> h_in = distinct_keys<key_t>(tile_size, rng);
-  c2h::device_vector<key_t> d_in(h_in);
-  c2h::device_vector<key_t> d_keys_out(tile_size, key_t{});
-  // Real (size-1) backing for the zero-length output span -- gives the kernel
-  // a valid `data()` to consume even though it must never dereference.
-  c2h::device_vector<key_t> d_top(1, cuda::std::numeric_limits<key_t>::min());
-  c2h::device_vector<bool> d_has_ties(1, false);
-
-  single_key_kernel<key_t, threads_per_block, items_per_thread, is_full_tile, blocked_input, select_max>
-    <<<1, threads_per_block>>>(
-      to_span(d_in),
-      to_span(d_keys_out),
-      cuda::std::span<key_t>{cuda::std::to_address(d_top.data()), 0},
-      cuda::std::span<bool, 1>{cuda::std::to_address(d_has_ties.data()), 1});
-  REQUIRE(cudaSuccess == cudaPeekAtLastError());
-  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
-  const bool has_ties = c2h::host_vector<bool>(d_has_ties)[0];
-  REQUIRE_FALSE(has_ties);
-  c2h::host_vector<key_t> h_keys_out(d_keys_out);
-  REQUIRE(bit_repr(h_in) == bit_repr(h_keys_out));
 }

--- a/cub/test/catch2_test_block_topk_rank.cu
+++ b/cub/test/catch2_test_block_topk_rank.cu
@@ -221,7 +221,7 @@ bit_window_kernel(cuda::std::span<const KeyT> g_in, cuda::std::span<KeyT> g_top,
   using sieve_t = cub::detail::block_topk_sieve<KeyT, BlockDim>;
   using rank_t  = cub::detail::block_topk_rank<BlockDim>;
 
-  static_assert(int(sizeof(KeyT) * 8) % WindowBits == 0, "test currently requires window-aligned key width");
+  static_assert(int{sizeof(KeyT) * 8} % WindowBits == 0, "test currently requires window-aligned key width");
 
   constexpr int tile_size = BlockDim * ItemsPerThread;
   const int k             = static_cast<int>(g_top.size());
@@ -238,7 +238,7 @@ bit_window_kernel(cuda::std::span<const KeyT> g_in, cuda::std::span<KeyT> g_top,
   sieve_t sieve(smem.sieve);
 
   constexpr bool is_full_tile = true;
-  int hi                      = int(sizeof(KeyT) * 8);
+  int hi                      = int{sizeof(KeyT) * 8};
   auto states                 = sieve.template select_max<is_full_tile>(keys, k, tile_size, hi - WindowBits, hi);
   hi -= WindowBits;
 

--- a/cub/test/catch2_test_block_topk_rank.cu
+++ b/cub/test/catch2_test_block_topk_rank.cu
@@ -360,8 +360,7 @@ C2H_TEST("block_topk_sieve correctly selects on plain random inputs",
   static constexpr int items_per_thread  = 5;
   static constexpr int tile_size         = threads_per_block * items_per_thread;
 
-  const c2h::seed_t seed = C2H_SEED(2);
-  rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+  rng_t rng(static_cast<cuda::std::uint32_t>(C2H_SEED(2).get()));
 
   c2h::host_vector<key_t> h_in = random_keys_centered<key_t>(tile_size, rng);
 
@@ -400,8 +399,7 @@ C2H_TEST("block_topk_sieve preserves keys bit-faithfully across FP edge cases",
   static constexpr int tile_size         = threads_per_block * items_per_thread;
   static_assert(tile_size >= 4, "FP edge-case poke needs at least 4 slots in h_in");
 
-  const c2h::seed_t seed = C2H_SEED(1);
-  rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+  rng_t rng(static_cast<cuda::std::uint32_t>(C2H_SEED(1).get()));
   c2h::host_vector<key_t> h_in = distinct_keys<key_t>(tile_size, rng);
   h_in[0]                      = static_cast<key_t>(-0.0);
   h_in[1]                      = static_cast<key_t>(+0.0);
@@ -495,15 +493,13 @@ C2H_TEST("block_topk_sieve::select_* selects the right top-k on a full tile",
   // Split fixed/random so the seed loop only fans out on the random draw.
   SECTION("fixed boundary_key")
   {
-    const c2h::seed_t seed = C2H_SEED(1);
-    rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+    rng_t rng(static_cast<cuda::std::uint32_t>(C2H_SEED(1).get()));
     const key_t boundary_key = GENERATE_COPY(boundary_key_generator<key_t>());
     run_check(rng, boundary_key);
   }
   SECTION("random boundary_key")
   {
-    const c2h::seed_t seed = C2H_SEED(2);
-    rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+    rng_t rng(static_cast<cuda::std::uint32_t>(C2H_SEED(2).get()));
     const key_t boundary_key = random_boundary_key<key_t>(rng);
     run_check(rng, boundary_key);
   }
@@ -553,15 +549,13 @@ C2H_TEST("block_topk_sieve handles partial tiles correctly", "[block][topk][rank
   // Split the boundary_key loop, see test 3.
   SECTION("fixed boundary_key")
   {
-    const c2h::seed_t seed = C2H_SEED(1);
-    rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+    rng_t rng(static_cast<cuda::std::uint32_t>(C2H_SEED(1).get()));
     const key_t boundary_key = GENERATE_COPY(boundary_key_generator<key_t>());
     run_check(rng, boundary_key);
   }
   SECTION("random boundary_key")
   {
-    const c2h::seed_t seed = C2H_SEED(2);
-    rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+    rng_t rng(static_cast<cuda::std::uint32_t>(C2H_SEED(2).get()));
     const key_t boundary_key = random_boundary_key<key_t>(rng);
     run_check(rng, boundary_key);
   }
@@ -641,15 +635,13 @@ C2H_TEST("block_topk_sieve resolves primary ties via a secondary refine", "[bloc
   // Split the boundary_key loop, see test 3.
   SECTION("fixed boundary_key")
   {
-    const c2h::seed_t seed = C2H_SEED(1);
-    rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+    rng_t rng(static_cast<cuda::std::uint32_t>(C2H_SEED(1).get()));
     const primary_t boundary_key = GENERATE_COPY(boundary_key_generator<primary_t>());
     run_check(rng, boundary_key);
   }
   SECTION("random boundary_key")
   {
-    const c2h::seed_t seed = C2H_SEED(2);
-    rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+    rng_t rng(static_cast<cuda::std::uint32_t>(C2H_SEED(2).get()));
     const primary_t boundary_key = random_boundary_key<primary_t>(rng);
     run_check(rng, boundary_key);
   }
@@ -717,8 +709,7 @@ C2H_TEST("block_topk_sieve produces the same selection across bit-window splits"
     // deterministically. `> 0` keeps `has_ties()` true to `hi == 0`.
     const int overhang = GENERATE_COPY(overhang_generator(k >= tile_size, {1, (tile_size - k) / 2}));
     // `key_t` is unsigned -- only the random draw applies.
-    const c2h::seed_t seed = C2H_SEED(1);
-    rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+    rng_t rng(static_cast<cuda::std::uint32_t>(C2H_SEED(1).get()));
     const key_t boundary_key = random_boundary_key<key_t>(rng);
     CAPTURE(k, overhang, boundary_key);
 
@@ -733,9 +724,8 @@ C2H_TEST("block_topk_sieve produces the same selection across bit-window splits"
     // byte still ties after the first `select_max`, but the next refine
     // over [16, 24) fully orders them, firing the iter-2 `!has_ties()`
     // break and skipping windows [8, 16) and [0, 8).
-    const int k            = GENERATE_COPY(values<int>({1, 11, tile_size / 4, tile_size - 1}));
-    const c2h::seed_t seed = C2H_SEED(1);
-    rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+    const int k = GENERATE_COPY(values<int>({1, 11, tile_size / 4, tile_size - 1}));
+    rng_t rng(static_cast<cuda::std::uint32_t>(C2H_SEED(1).get()));
     CAPTURE(k);
 
     c2h::host_vector<key_t> h_in = distinct_keys<key_t>(tile_size, rng);
@@ -762,8 +752,7 @@ C2H_TEST("block_topk_sieve handles k == 0", "[block][topk][rank][edge]")
   static constexpr bool blocked_input    = true;
   static constexpr bool select_max       = true;
 
-  const c2h::seed_t seed = C2H_SEED(1);
-  rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+  rng_t rng(static_cast<cuda::std::uint32_t>(C2H_SEED(1).get()));
   c2h::host_vector<key_t> h_in = distinct_keys<key_t>(tile_size, rng);
   c2h::device_vector<key_t> d_in(h_in);
   c2h::device_vector<key_t> d_keys_out(tile_size, key_t{});

--- a/cub/test/catch2_test_block_topk_rank.cu
+++ b/cub/test/catch2_test_block_topk_rank.cu
@@ -1,0 +1,787 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Tests for the low-level top-k rank API in `cub/cub/block/block_topk_rank.cuh`
+// (`block_topk_sieve::select_max/min`, `refine_max/min`, and
+// `block_topk_rank::rank_key_states`).
+//
+// `rank_key_states` is non-deterministic in both selected-subset and output
+// order when ties remain. All checks compare the scattered output as a
+// value-multiset against a host reference; the fixtures are shaped so that
+// multiset is uniquely determined regardless of how the ranker resolves the
+// boundary ties (see `gen_keys_from_boundary_key` and the multi-key test).
+
+#include <cub/block/block_load.cuh>
+#include <cub/block/block_store.cuh>
+#include <cub/block/block_topk_rank.cuh>
+
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/sort.h>
+
+#include <cuda/std/__memory/pointer_traits.h>
+#include <cuda/std/cstdint>
+#include <cuda/std/limits>
+#include <cuda/std/span>
+#include <cuda/type_traits>
+
+#include <algorithm>
+
+#include "catch2_test_block_topk_common.cuh"
+#include <c2h/catch2_test_helper.h>
+
+namespace
+{
+// --- Kernels under test ---
+
+// `select_*` + `rank_key_states`, then both round-trip the per-thread keys
+// back to `g_keys_out` (must be byte-identical to `g_in`) and scatter the
+// selected keys to `g_top[0, k)`. `k` is the size of `g_top`.
+template <typename KeyT, int BlockDim, int ItemsPerThread, bool IsFullTile, bool BlockedInput, bool SelectMax>
+__global__ void single_key_kernel(
+  cuda::std::span<const KeyT> g_in,
+  cuda::std::span<KeyT> g_keys_out,
+  cuda::std::span<KeyT> g_top,
+  cuda::std::span<bool, 1> g_has_ties)
+{
+  using sieve_t = cub::detail::block_topk_sieve<KeyT, BlockDim>;
+  using rank_t  = cub::detail::block_topk_rank<BlockDim>;
+
+  const int k = static_cast<int>(g_top.size());
+
+  __shared__ union
+  {
+    typename sieve_t::TempStorage sieve;
+    typename rank_t::TempStorage rank;
+  } smem;
+
+  // OOB lanes seeded with the most-attractive value so any escape into
+  // the candidate set displaces a real winner and the compare flags it.
+  KeyT keys[ItemsPerThread];
+  constexpr KeyT oob_sentinel =
+    SelectMax ? cuda::std::numeric_limits<KeyT>::max() : cuda::std::numeric_limits<KeyT>::lowest();
+  if constexpr (BlockedInput)
+  {
+    cub::LoadDirectBlocked(
+      static_cast<int>(threadIdx.x), g_in.data(), keys, static_cast<int>(g_in.size()), oob_sentinel);
+  }
+  else
+  {
+    cub::LoadDirectStriped<BlockDim>(
+      static_cast<int>(threadIdx.x), g_in.data(), keys, static_cast<int>(g_in.size()), oob_sentinel);
+  }
+
+  sieve_t sieve(smem.sieve);
+  auto states = [&] {
+    if constexpr (SelectMax)
+    {
+      return sieve.template select_max<IsFullTile, BlockedInput>(keys, k, static_cast<int>(g_in.size()));
+    }
+    else
+    {
+      return sieve.template select_min<IsFullTile, BlockedInput>(keys, k, static_cast<int>(g_in.size()));
+    }
+  }();
+  __syncthreads();
+
+  int ranks[ItemsPerThread];
+  rank_t(smem.rank).rank_key_states(states, ranks);
+
+  for (int i = 0; i < ItemsPerThread; ++i)
+  {
+    if (ranks[i] >= 0)
+    {
+      g_top[ranks[i]] = keys[i];
+    }
+  }
+
+  if (threadIdx.x == 0)
+  {
+    g_has_ties[0] = states.has_ties();
+  }
+
+  // Round-trip the keys: bit-identical to the input. Bounded store skips OOB.
+  if constexpr (BlockedInput)
+  {
+    cub::StoreDirectBlocked(static_cast<int>(threadIdx.x), g_keys_out.data(), keys, static_cast<int>(g_keys_out.size()));
+  }
+  else
+  {
+    cub::StoreDirectStriped<BlockDim>(
+      static_cast<int>(threadIdx.x), g_keys_out.data(), keys, static_cast<int>(g_keys_out.size()));
+  }
+}
+
+// Primary `select_max` + (if ties) secondary `refine_max`, then
+// `rank_key_states`. `g_has_ties[0]` / `g_has_ties[1]` snapshot
+// `has_ties()` before and after the (possibly skipped) refine.
+template <typename PrimaryT, typename SecondaryT, int BlockDim, int ItemsPerThread, bool IsFullTile, bool SelectMax>
+__global__ void multi_key_kernel(
+  cuda::std::span<const PrimaryT> g_primary,
+  cuda::std::span<const SecondaryT> g_secondary,
+  cuda::std::span<PrimaryT> g_top_primary,
+  cuda::std::span<SecondaryT> g_top_secondary,
+  cuda::std::span<bool, 2> g_has_ties)
+{
+  using primary_sieve_t   = cub::detail::block_topk_sieve<PrimaryT, BlockDim>;
+  using secondary_sieve_t = cub::detail::block_topk_sieve<SecondaryT, BlockDim>;
+  using rank_t            = cub::detail::block_topk_rank<BlockDim>;
+
+  const int k = static_cast<int>(g_top_primary.size());
+
+  __shared__ union
+  {
+    typename primary_sieve_t::TempStorage primary_sieve;
+    typename secondary_sieve_t::TempStorage secondary_sieve;
+    typename rank_t::TempStorage rank;
+  } smem;
+
+  // OOB sentinels: same convention as `single_key_kernel`.
+  constexpr PrimaryT primary_oob_sentinel =
+    SelectMax ? cuda::std::numeric_limits<PrimaryT>::max() : cuda::std::numeric_limits<PrimaryT>::lowest();
+  constexpr SecondaryT secondary_oob_sentinel =
+    SelectMax ? cuda::std::numeric_limits<SecondaryT>::max() : cuda::std::numeric_limits<SecondaryT>::lowest();
+  PrimaryT primary_keys[ItemsPerThread];
+  cub::LoadDirectBlocked(
+    static_cast<int>(threadIdx.x),
+    g_primary.data(),
+    primary_keys,
+    static_cast<int>(g_primary.size()),
+    primary_oob_sentinel);
+  // Loaded unconditionally so they're in scope for the final scatter.
+  SecondaryT secondary_keys[ItemsPerThread];
+  cub::LoadDirectBlocked(
+    static_cast<int>(threadIdx.x),
+    g_secondary.data(),
+    secondary_keys,
+    static_cast<int>(g_secondary.size()),
+    secondary_oob_sentinel);
+
+  primary_sieve_t primary_sieve(smem.primary_sieve);
+  constexpr bool blocked_input = true;
+  auto states                  = [&] {
+    if constexpr (SelectMax)
+    {
+      return primary_sieve.template select_max<IsFullTile, blocked_input>(
+        primary_keys, k, static_cast<int>(g_primary.size()));
+    }
+    else
+    {
+      return primary_sieve.template select_min<IsFullTile, blocked_input>(
+        primary_keys, k, static_cast<int>(g_primary.size()));
+    }
+  }();
+  __syncthreads();
+
+  if (threadIdx.x == 0)
+  {
+    g_has_ties[0] = states.has_ties();
+  }
+
+  if (states.has_ties())
+  {
+    secondary_sieve_t secondary_sieve(smem.secondary_sieve);
+    if constexpr (SelectMax)
+    {
+      secondary_sieve.refine_max(secondary_keys, states, 0, int(sizeof(SecondaryT) * 8));
+    }
+    else
+    {
+      secondary_sieve.refine_min(secondary_keys, states, 0, int(sizeof(SecondaryT) * 8));
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0)
+  {
+    g_has_ties[1] = states.has_ties();
+  }
+
+  int ranks[ItemsPerThread];
+  rank_t(smem.rank).rank_key_states(states, ranks);
+
+  for (int i = 0; i < ItemsPerThread; ++i)
+  {
+    if (ranks[i] >= 0)
+    {
+      g_top_primary[ranks[i]]   = primary_keys[i];
+      g_top_secondary[ranks[i]] = secondary_keys[i];
+    }
+  }
+}
+
+// `select_max` over a high bit window, then `refine_max` down through
+// the lower windows. `g_last_hi` is the loop's `hi` cursor after
+// termination -- `0` if every window ran, otherwise the lower bound of
+// the last window before the `!has_ties()` early exit.
+template <typename KeyT, int BlockDim, int ItemsPerThread, int WindowBits>
+__global__ void
+bit_window_kernel(cuda::std::span<const KeyT> g_in, cuda::std::span<KeyT> g_top, cuda::std::span<int, 1> g_last_hi)
+{
+  using sieve_t = cub::detail::block_topk_sieve<KeyT, BlockDim>;
+  using rank_t  = cub::detail::block_topk_rank<BlockDim>;
+
+  static_assert(int(sizeof(KeyT) * 8) % WindowBits == 0, "test currently requires window-aligned key width");
+
+  constexpr int tile_size = BlockDim * ItemsPerThread;
+  const int k             = static_cast<int>(g_top.size());
+
+  __shared__ union
+  {
+    typename sieve_t::TempStorage sieve;
+    typename rank_t::TempStorage rank;
+  } smem;
+
+  KeyT keys[ItemsPerThread];
+  cub::LoadDirectBlocked(static_cast<int>(threadIdx.x), g_in.data(), keys);
+
+  sieve_t sieve(smem.sieve);
+
+  constexpr bool is_full_tile = true;
+  int hi                      = int(sizeof(KeyT) * 8);
+  auto states                 = sieve.template select_max<is_full_tile>(keys, k, tile_size, hi - WindowBits, hi);
+  hi -= WindowBits;
+
+  while (hi > 0)
+  {
+    __syncthreads();
+    if (!states.has_ties())
+    {
+      break;
+    }
+    sieve.refine_max(keys, states, hi - WindowBits, hi);
+    hi -= WindowBits;
+  }
+  __syncthreads();
+
+  if (threadIdx.x == 0)
+  {
+    g_last_hi[0] = hi;
+  }
+
+  int ranks[ItemsPerThread];
+  rank_t(smem.rank).rank_key_states(states, ranks);
+
+  for (int i = 0; i < ItemsPerThread; ++i)
+  {
+    if (ranks[i] >= 0)
+    {
+      g_top[ranks[i]] = keys[i];
+    }
+  }
+}
+} // namespace
+
+// --- Type-list axes for the parameterized tests ---
+
+// Direction axis: `false_type` = select_min, `true_type` = select_max.
+using select_direction_max = c2h::type_list<cuda::std::false_type, cuda::std::true_type>;
+
+using key_types = c2h::type_list<cuda::std::uint16_t, cuda::std::int32_t, cuda::std::uint64_t, float, double>;
+
+using fp_key_types = c2h::type_list<float, double>;
+
+// (BlockDim, ItemsPerThread) shape pair, used as a Catch2 type-list axis.
+template <int BlockDim, int ItemsPerThread>
+struct block_shape
+{
+  static constexpr int threads_per_block = BlockDim;
+  static constexpr int items_per_thread  = ItemsPerThread;
+};
+
+// Four full-tile shapes sharing `tile_size == 512` so the per-shape `k`
+// sweep is comparable across them.
+using block_shapes_full_tile =
+  c2h::type_list<block_shape<64, 8>, block_shape<256, 2>, block_shape<32, 16>, block_shape<128, 4>>;
+
+// --- Test driver ---
+
+// Runs `single_key_kernel` over `h_in` and checks bit-identity (round-trip
+// output equals input) and selection correctness (first `min(k, num_valid)`
+// slots of `g_top` match `h_ref` as a multiset). `k > num_valid` is
+// supported. `h_ref` must be sized `min(k, num_valid)` (see
+// `sorted_top_k`). Returns the kernel's `has_ties`.
+template <typename KeyT, int BlockDim, int ItemsPerThread, bool IsFullTile, bool BlockedInput, bool SelectMax>
+bool check_single_key(const c2h::host_vector<KeyT>& h_in, cuda::std::span<const KeyT> h_ref, int k)
+{
+  constexpr int tile  = BlockDim * ItemsPerThread;
+  const int num_valid = static_cast<int>(h_in.size());
+  REQUIRE(0 < k);
+  REQUIRE(num_valid <= tile);
+  REQUIRE((!IsFullTile || num_valid == tile));
+
+  const int top_size = cuda::std::min(k, num_valid);
+  REQUIRE(static_cast<int>(h_ref.size()) == top_size);
+
+  c2h::device_vector<KeyT> d_in(h_in);
+  c2h::device_vector<KeyT> d_keys_out(num_valid, KeyT{});
+  // Tail (when `k > num_valid`) unused by the kernel, dropped pre-compare.
+  c2h::device_vector<KeyT> d_top(k, KeyT{});
+  c2h::device_vector<bool> d_has_ties(1, false);
+
+  single_key_kernel<KeyT, BlockDim, ItemsPerThread, IsFullTile, BlockedInput, SelectMax><<<1, BlockDim>>>(
+    to_span(d_in),
+    to_span(d_keys_out),
+    to_span(d_top),
+    cuda::std::span<bool, 1>{cuda::std::to_address(d_has_ties.data()), 1});
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  c2h::host_vector<KeyT> h_keys_out(d_keys_out);
+  REQUIRE(bit_repr(h_in) == bit_repr(h_keys_out));
+
+  const bool has_ties = c2h::host_vector<bool>(d_has_ties)[0];
+
+  c2h::host_vector<KeyT> h_top(d_top);
+  h_top.resize(top_size);
+  std::sort(h_top.begin(), h_top.end(), comparator_t<SelectMax>{});
+  c2h::host_vector<KeyT> h_ref_vec(h_ref.begin(), h_ref.end());
+  // FP `==` already excuses the sieve's `+/-0.0` ambiguity; CAPTURE bit
+  // patterns since the default printer rounds floats.
+  CAPTURE(bit_repr(h_top), bit_repr(h_ref_vec));
+  REQUIRE(h_top == h_ref_vec);
+
+  return has_ties;
+}
+
+// ---------------------------------------------------------------------------
+// 1) Random-data smoke test using `random_keys_centered`. Non-power-of-two
+//    `(96, 5)` shape distinct from the other tests. Expected `has_ties` is
+//    read off the sorted reference (`sorted[k-1] == sorted[k]`).
+// ---------------------------------------------------------------------------
+
+C2H_TEST("block_topk_sieve correctly selects on plain random inputs",
+         "[block][topk][rank][smoke]",
+         key_types,
+         select_direction_max)
+{
+  using key_t                            = c2h::get<0, TestType>;
+  static constexpr bool select_max       = c2h::get<1, TestType>::value;
+  static constexpr int threads_per_block = 96;
+  static constexpr int items_per_thread  = 5;
+  static constexpr int tile_size         = threads_per_block * items_per_thread;
+
+  const c2h::seed_t seed = C2H_SEED(2);
+  rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+
+  c2h::host_vector<key_t> h_in = random_keys_centered<key_t>(tile_size, rng);
+
+  const int k = GENERATE_COPY(values<int>({1, tile_size / 4, tile_size / 2, tile_size - 1}));
+  CAPTURE(c2h::type_name<key_t>(), select_max, k);
+
+  static constexpr bool is_full_tile  = true;
+  static constexpr bool blocked_input = true;
+  // Partial-sort to `k + 1` so one vector serves both the top-k check
+  // (first `k`) and the boundary tie check below.
+  const auto h_ref_kp1 = sorted_top_k<select_max>(h_in, k + 1);
+  const bool has_ties =
+    check_single_key<key_t, threads_per_block, items_per_thread, is_full_tile, blocked_input, select_max>(
+      h_in, to_span(h_ref_kp1).first(k), k);
+
+  const bool expected_has_ties = (static_cast<int>(h_ref_kp1.size()) > k) && (h_ref_kp1[k - 1] == h_ref_kp1[k]);
+  CAPTURE(expected_has_ties);
+  REQUIRE(has_ties == expected_has_ties);
+}
+
+// ---------------------------------------------------------------------------
+// 2) Round-trip + selection on FP edge-case inputs. Only test pinning
+//    `+0.0`, `-0.0`, `+/-inf` together in one input; non-FP coverage of
+//    the "bit-distinct + has_ties == false" property lives in test 6.
+// ---------------------------------------------------------------------------
+
+C2H_TEST("block_topk_sieve preserves keys bit-faithfully across FP edge cases",
+         "[block][topk][rank]",
+         fp_key_types,
+         select_direction_max)
+{
+  using key_t                            = c2h::get<0, TestType>;
+  static constexpr bool select_max       = c2h::get<1, TestType>::value;
+  static constexpr int threads_per_block = 128;
+  static constexpr int items_per_thread  = 4;
+  static constexpr int tile_size         = threads_per_block * items_per_thread;
+  static_assert(tile_size >= 4, "FP edge-case poke needs at least 4 slots in h_in");
+
+  const c2h::seed_t seed = C2H_SEED(1);
+  rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+  c2h::host_vector<key_t> h_in = distinct_keys<key_t>(tile_size, rng);
+  h_in[0]                      = static_cast<key_t>(-0.0);
+  h_in[1]                      = static_cast<key_t>(+0.0);
+  h_in[2]                      = cuda::std::numeric_limits<key_t>::infinity();
+  h_in[3]                      = -cuda::std::numeric_limits<key_t>::infinity();
+  thrust::shuffle(h_in.begin(), h_in.end(), rng);
+
+  CAPTURE(c2h::type_name<key_t>(), select_max);
+
+  // Partial-tile sections use a `num_valid` prefix; each section also
+  // exercises `k > valid_items`. All-distinct bit patterns ->
+  // `has_ties()` must end false.
+  const int num_valid = tile_size / 2 + 7;
+  c2h::host_vector<key_t> h_in_partial(h_in.begin(), h_in.begin() + num_valid);
+
+  SECTION("full tile, blocked input")
+  {
+    static constexpr bool is_full_tile  = true;
+    static constexpr bool blocked_input = true;
+    const int k                         = GENERATE_COPY(values<int>({1, tile_size / 4, tile_size - 1, tile_size + 5}));
+    CAPTURE(k);
+    const auto h_ref = sorted_top_k<select_max>(h_in, k);
+    const bool has_ties =
+      check_single_key<key_t, threads_per_block, items_per_thread, is_full_tile, blocked_input, select_max>(
+        h_in, to_span(h_ref), k);
+    REQUIRE_FALSE(has_ties);
+  }
+
+  SECTION("partial tile, blocked input")
+  {
+    static constexpr bool is_full_tile  = false;
+    static constexpr bool blocked_input = true;
+    const int k                         = GENERATE_COPY(values<int>({1, num_valid / 4, num_valid - 1, num_valid + 5}));
+    CAPTURE(num_valid, k);
+    const auto h_ref = sorted_top_k<select_max>(h_in_partial, k);
+    const bool has_ties =
+      check_single_key<key_t, threads_per_block, items_per_thread, is_full_tile, blocked_input, select_max>(
+        h_in_partial, to_span(h_ref), k);
+    REQUIRE_FALSE(has_ties);
+  }
+
+  SECTION("partial tile, striped input")
+  {
+    static constexpr bool is_full_tile  = false;
+    static constexpr bool blocked_input = false;
+    const int k                         = GENERATE_COPY(values<int>({1, num_valid / 4, num_valid - 1, num_valid + 5}));
+    CAPTURE(num_valid, k);
+    const auto h_ref = sorted_top_k<select_max>(h_in_partial, k);
+    const bool has_ties =
+      check_single_key<key_t, threads_per_block, items_per_thread, is_full_tile, blocked_input, select_max>(
+        h_in_partial, to_span(h_ref), k);
+    REQUIRE_FALSE(has_ties);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3) Single-key correctness on a full tile, swept over `block_shapes_full_tile`.
+// ---------------------------------------------------------------------------
+
+C2H_TEST("block_topk_sieve::select_* selects the right top-k on a full tile",
+         "[block][topk][rank]",
+         key_types,
+         select_direction_max,
+         block_shapes_full_tile)
+{
+  using key_t                            = c2h::get<0, TestType>;
+  static constexpr bool select_max       = c2h::get<1, TestType>::value;
+  using shape_t                          = c2h::get<2, TestType>;
+  static constexpr int threads_per_block = shape_t::threads_per_block;
+  static constexpr int items_per_thread  = shape_t::items_per_thread;
+  static constexpr int tile_size         = threads_per_block * items_per_thread;
+  static constexpr bool is_full_tile     = true;
+  static constexpr bool blocked_input    = true;
+
+  const int k =
+    GENERATE_COPY(values<int>({1, 13, items_per_thread, threads_per_block, tile_size - 1, tile_size, tile_size + 1}));
+  // 0 (order only) -> `tile_size - k` (every boundary copy overflows);
+  // trailing entries go negative when `k > tile_size` but get narrowed off.
+  const int overhang = GENERATE_COPY(overhang_generator(k >= tile_size, {0, 1, (tile_size - k) / 2, tile_size - k}));
+
+  auto run_check = [&](rng_t& rng, key_t boundary_key) {
+    CAPTURE(c2h::type_name<key_t>(), select_max, k, overhang, boundary_key);
+    c2h::host_vector<key_t> h_in = gen_keys_from_boundary_key<select_max>(tile_size, k, overhang, boundary_key, rng);
+    const auto h_ref             = sorted_top_k<select_max>(h_in, k);
+    const bool has_ties =
+      check_single_key<key_t, threads_per_block, items_per_thread, is_full_tile, blocked_input, select_max>(
+        h_in, to_span(h_ref), k);
+    REQUIRE(has_ties == (overhang > 0));
+  };
+
+  // Split fixed/random so the seed loop only fans out on the random draw.
+  SECTION("fixed boundary_key")
+  {
+    const c2h::seed_t seed = C2H_SEED(1);
+    rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+    const key_t boundary_key = GENERATE_COPY(boundary_key_generator<key_t>());
+    run_check(rng, boundary_key);
+  }
+  SECTION("random boundary_key")
+  {
+    const c2h::seed_t seed = C2H_SEED(2);
+    rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+    const key_t boundary_key = random_boundary_key<key_t>(rng);
+    run_check(rng, boundary_key);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4) Single-key correctness on partial tiles, blocked and striped inputs.
+// ---------------------------------------------------------------------------
+
+C2H_TEST("block_topk_sieve handles partial tiles correctly", "[block][topk][rank]", key_types, select_direction_max)
+{
+  using key_t                      = c2h::get<0, TestType>;
+  static constexpr bool select_max = c2h::get<1, TestType>::value;
+  // Larger block, fewer items-per-thread than tests 2 and 3.
+  static constexpr int threads_per_block = 256;
+  static constexpr int items_per_thread  = 2;
+  static constexpr int tile_size         = threads_per_block * items_per_thread;
+
+  const int num_valid =
+    GENERATE_COPY(values<int>({threads_per_block - 1, threads_per_block, tile_size - items_per_thread, tile_size}));
+  const int k = GENERATE_COPY(
+    values<int>({1, 5, items_per_thread, threads_per_block, num_valid / 2, num_valid - 1, num_valid, num_valid + 1}));
+  const int overhang = GENERATE_COPY(overhang_generator(k >= num_valid, {0, 1, (num_valid - k) / 2, num_valid - k}));
+  // GENERATE_COPY (not nested SECTIONs) so the boundary_key SECTIONs below
+  // aren't reached through multiple paths -- Catch2's tracker can't handle
+  // that. Variadic form wraps each arg in a SingleValueGenerator (avoiding
+  // the `std::vector<bool>`-backed FixedValuesGenerator).
+  const bool blocked_input = GENERATE_COPY(true, false);
+
+  // Same shape assertion as test 3: `has_ties == (overhang > 0)`.
+  auto run_check = [&](rng_t& rng, key_t boundary_key) {
+    CAPTURE(c2h::type_name<key_t>(), select_max, num_valid, k, overhang, blocked_input, boundary_key);
+    static constexpr bool is_full_tile = false;
+    static constexpr bool blocked      = true;
+    static constexpr bool striped      = false;
+    c2h::host_vector<key_t> h_in = gen_keys_from_boundary_key<select_max>(num_valid, k, overhang, boundary_key, rng);
+    const auto h_ref             = sorted_top_k<select_max>(h_in, k);
+    const bool has_ties =
+      blocked_input
+        ? check_single_key<key_t, threads_per_block, items_per_thread, is_full_tile, blocked, select_max>(
+            h_in, to_span(h_ref), k)
+        : check_single_key<key_t, threads_per_block, items_per_thread, is_full_tile, striped, select_max>(
+            h_in, to_span(h_ref), k);
+    REQUIRE(has_ties == (overhang > 0));
+  };
+
+  // Split the boundary_key loop, see test 3.
+  SECTION("fixed boundary_key")
+  {
+    const c2h::seed_t seed = C2H_SEED(1);
+    rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+    const key_t boundary_key = GENERATE_COPY(boundary_key_generator<key_t>());
+    run_check(rng, boundary_key);
+  }
+  SECTION("random boundary_key")
+  {
+    const c2h::seed_t seed = C2H_SEED(2);
+    rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+    const key_t boundary_key = random_boundary_key<key_t>(rng);
+    run_check(rng, boundary_key);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5) Multi-key tie-break: many primary ties, unique secondary breaks them.
+// ---------------------------------------------------------------------------
+
+C2H_TEST("block_topk_sieve resolves primary ties via a secondary refine", "[block][topk][rank][multi-key]")
+{
+  using primary_t   = float;
+  using secondary_t = cuda::std::uint32_t;
+  // Odd items-per-thread (3) to verify nothing assumes power-of-two strides.
+  static constexpr int threads_per_block = 128;
+  static constexpr int items_per_thread  = 3;
+  static constexpr int tile_size         = threads_per_block * items_per_thread;
+  static constexpr bool is_full_tile     = true;
+  static constexpr bool select_max       = true;
+
+  // Primary: bit-equal boundary copies + strict above/below fillers ->
+  // ties iff `overhang > 0`. Secondary: shuffled `[0, tile_size)` ->
+  // refine collapses every tied primary class to a unique representative,
+  // so post-refine `has_ties()` is always `false`.
+  const int k        = GENERATE_COPY(values<int>({1, 7, tile_size / 4, tile_size - 1}));
+  const int overhang = GENERATE_COPY(overhang_generator(k >= tile_size, {0, 1, (tile_size - k) / 2}));
+
+  auto run_check = [&](rng_t& rng, primary_t boundary_key) {
+    CAPTURE(k, overhang, boundary_key);
+
+    c2h::host_vector<primary_t> h_primary =
+      gen_keys_from_boundary_key<select_max>(tile_size, k, overhang, boundary_key, rng);
+    c2h::host_vector<secondary_t> h_secondary = distinct_keys<secondary_t>(tile_size, rng);
+
+    c2h::device_vector<primary_t> d_primary(h_primary);
+    c2h::device_vector<secondary_t> d_secondary(h_secondary);
+    c2h::device_vector<primary_t> d_top_primary(k, primary_t{});
+    c2h::device_vector<secondary_t> d_top_secondary(k, secondary_t{});
+    c2h::device_vector<bool> d_has_ties(2, false);
+
+    multi_key_kernel<primary_t, secondary_t, threads_per_block, items_per_thread, is_full_tile, select_max>
+      <<<1, threads_per_block>>>(
+        to_span(d_primary),
+        to_span(d_secondary),
+        to_span(d_top_primary),
+        to_span(d_top_secondary),
+        cuda::std::span<bool, 2>{cuda::std::to_address(d_has_ties.data()), 2});
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    const c2h::host_vector<bool> h_has_ties(d_has_ties);
+    CAPTURE(h_has_ties[0], h_has_ties[1]);
+    REQUIRE(h_has_ties[0] == (overhang > 0));
+    REQUIRE_FALSE(h_has_ties[1]);
+
+    // Reference: zip-sort the full input by lex desc so the first k pairs
+    // are the winners; same canonical sort on the kernel output. Unique
+    // secondaries pin both lex sorts, and FP `==` already excuses the
+    // sieve's `+/-0.0` ambiguity on the primary. `thrust::make_zip_iterator`
+    // (not `cuda::`): proxy-ref iterators only sort correctly via thrust's
+    // host backend; `std::sort` and `cuda::zip_iterator` don't compose
+    // until C++20 `std::ranges::sort` (not yet ported to `cuda::std`).
+    auto zip_ref = thrust::make_zip_iterator(h_primary.begin(), h_secondary.begin());
+    thrust::sort(zip_ref, zip_ref + tile_size, comparator_t<select_max>{});
+    h_primary.resize(k);
+    h_secondary.resize(k);
+
+    c2h::host_vector<primary_t> h_top_primary(d_top_primary);
+    c2h::host_vector<secondary_t> h_top_secondary(d_top_secondary);
+    auto zip_got = thrust::make_zip_iterator(h_top_primary.begin(), h_top_secondary.begin());
+    thrust::sort(zip_got, zip_got + k, comparator_t<select_max>{});
+
+    REQUIRE(h_primary == h_top_primary);
+    REQUIRE(h_secondary == h_top_secondary);
+  };
+
+  // Split the boundary_key loop, see test 3.
+  SECTION("fixed boundary_key")
+  {
+    const c2h::seed_t seed = C2H_SEED(1);
+    rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+    const primary_t boundary_key = GENERATE_COPY(boundary_key_generator<primary_t>());
+    run_check(rng, boundary_key);
+  }
+  SECTION("random boundary_key")
+  {
+    const c2h::seed_t seed = C2H_SEED(2);
+    rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+    const primary_t boundary_key = random_boundary_key<primary_t>(rng);
+    run_check(rng, boundary_key);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 6) Bit-window split: chained `refine_max`'es over disjoint windows must
+//    match a one-shot `select_max`. SECTIONs cover the two ends of
+//    `bit_window_kernel`'s loop, pinned via `g_last_hi`.
+// ---------------------------------------------------------------------------
+
+C2H_TEST("block_topk_sieve produces the same selection across bit-window splits", "[block][topk][rank][bit-window]")
+{
+  using key_t                            = cuda::std::uint32_t;
+  static constexpr int threads_per_block = 64;
+  static constexpr int items_per_thread  = 6;
+  static constexpr int tile_size         = threads_per_block * items_per_thread;
+  static constexpr int window_bits       = 8;
+  static constexpr int key_bits          = static_cast<int>(sizeof(key_t) * 8);
+  static constexpr bool is_full_tile     = true;
+  static constexpr bool blocked_input    = true;
+  static constexpr bool select_max       = true;
+
+  // Compares `bit_window_kernel` vs. one-shot `single_key_kernel`, pinning
+  // post-loop `hi` to `expected_last_hi` (`0` = full chain ran).
+  auto run_compare = [&](const c2h::host_vector<key_t>& h_in, int k, int expected_last_hi) {
+    c2h::device_vector<key_t> d_in(h_in);
+    c2h::device_vector<key_t> d_top_split(k, key_t{});
+    c2h::device_vector<key_t> d_top_oneshot(k, key_t{});
+    // `single_key_kernel`'s round-trip output is unused; scratch.
+    c2h::device_vector<key_t> d_keys_out(tile_size, key_t{});
+    c2h::device_vector<bool> d_has_ties(1, false);
+    c2h::device_vector<int> d_last_hi(1, -1);
+
+    // One-shot reference.
+    single_key_kernel<key_t, threads_per_block, items_per_thread, is_full_tile, blocked_input, select_max>
+      <<<1, threads_per_block>>>(
+        to_span(d_in),
+        to_span(d_keys_out),
+        to_span(d_top_oneshot),
+        cuda::std::span<bool, 1>{cuda::std::to_address(d_has_ties.data()), 1});
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    bit_window_kernel<key_t, threads_per_block, items_per_thread, window_bits><<<1, threads_per_block>>>(
+      to_span(d_in), to_span(d_top_split), cuda::std::span<int, 1>{cuda::std::to_address(d_last_hi.data()), 1});
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    const int last_hi = c2h::host_vector<int>(d_last_hi)[0];
+    CAPTURE(last_hi, expected_last_hi);
+    REQUIRE(last_hi == expected_last_hi);
+
+    c2h::host_vector<key_t> h_top_oneshot(d_top_oneshot);
+    c2h::host_vector<key_t> h_top_split(d_top_split);
+    std::sort(h_top_oneshot.begin(), h_top_oneshot.end());
+    std::sort(h_top_split.begin(), h_top_split.end());
+    REQUIRE(h_top_oneshot == h_top_split);
+  };
+
+  SECTION("ties to the last window")
+  {
+    const int k = GENERATE_COPY(values<int>({1, 11, tile_size / 4, tile_size - 1}));
+    // `overhang == 0` excluded: would let the early exit fire non-
+    // deterministically. `> 0` keeps `has_ties()` true to `hi == 0`.
+    const int overhang = GENERATE_COPY(overhang_generator(k >= tile_size, {1, (tile_size - k) / 2}));
+    // `key_t` is unsigned -- only the random draw applies.
+    const c2h::seed_t seed = C2H_SEED(1);
+    rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+    const key_t boundary_key = random_boundary_key<key_t>(rng);
+    CAPTURE(k, overhang, boundary_key);
+
+    c2h::host_vector<key_t> h_in   = gen_keys_from_boundary_key<select_max>(tile_size, k, overhang, boundary_key, rng);
+    constexpr int expected_last_hi = 0;
+    run_compare(h_in, k, expected_last_hi);
+  }
+
+  SECTION("early exit before last window")
+  {
+    // Distinct keys with non-zero bits only in window [16, 24): the top
+    // byte still ties after the first `select_max`, but the next refine
+    // over [16, 24) fully orders them, firing the iter-2 `!has_ties()`
+    // break and skipping windows [8, 16) and [0, 8).
+    const int k            = GENERATE_COPY(values<int>({1, 11, tile_size / 4, tile_size - 1}));
+    const c2h::seed_t seed = C2H_SEED(1);
+    rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+    CAPTURE(k);
+
+    c2h::host_vector<key_t> h_in = distinct_keys<key_t>(tile_size, rng);
+    for (auto& x : h_in)
+    {
+      x = static_cast<key_t>(x << (2 * window_bits));
+    }
+    constexpr int expected_last_hi = key_bits - 2 * window_bits;
+    run_compare(h_in, k, expected_last_hi);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 7) `k == 0`: nothing selected, no writes to the output span.
+// ---------------------------------------------------------------------------
+
+C2H_TEST("block_topk_sieve handles k == 0", "[block][topk][rank][edge]")
+{
+  using key_t                            = int;
+  static constexpr int threads_per_block = 32;
+  static constexpr int items_per_thread  = 16;
+  static constexpr int tile_size         = threads_per_block * items_per_thread;
+  static constexpr bool is_full_tile     = true;
+  static constexpr bool blocked_input    = true;
+  static constexpr bool select_max       = true;
+
+  const c2h::seed_t seed = C2H_SEED(1);
+  rng_t rng(static_cast<cuda::std::uint32_t>(seed.get()));
+  c2h::host_vector<key_t> h_in = distinct_keys<key_t>(tile_size, rng);
+  c2h::device_vector<key_t> d_in(h_in);
+  c2h::device_vector<key_t> d_keys_out(tile_size, key_t{});
+  // Real (size-1) backing for the zero-length output span -- gives the kernel
+  // a valid `data()` to consume even though it must never dereference.
+  c2h::device_vector<key_t> d_top(1, cuda::std::numeric_limits<key_t>::min());
+  c2h::device_vector<bool> d_has_ties(1, false);
+
+  single_key_kernel<key_t, threads_per_block, items_per_thread, is_full_tile, blocked_input, select_max>
+    <<<1, threads_per_block>>>(
+      to_span(d_in),
+      to_span(d_keys_out),
+      cuda::std::span<key_t>{cuda::std::to_address(d_top.data()), 0},
+      cuda::std::span<bool, 1>{cuda::std::to_address(d_has_ties.data()), 1});
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  const bool has_ties = c2h::host_vector<bool>(d_has_ties)[0];
+  REQUIRE_FALSE(has_ties);
+  c2h::host_vector<key_t> h_keys_out(d_keys_out);
+  REQUIRE(bit_repr(h_in) == bit_repr(h_keys_out));
+}

--- a/cub/test/catch2_test_block_topk_rank.cu
+++ b/cub/test/catch2_test_block_topk_rank.cu
@@ -16,6 +16,7 @@
 #include <cub/block/block_topk_rank.cuh>
 
 #include <thrust/iterator/zip_iterator.h>
+#include <thrust/shuffle.h>
 #include <thrust/sort.h>
 
 #include <cuda/std/__memory/pointer_traits.h>
@@ -182,11 +183,11 @@ __global__ void multi_key_kernel(
     secondary_sieve_t secondary_sieve(smem.secondary_sieve);
     if constexpr (SelectMax)
     {
-      secondary_sieve.refine_max(secondary_keys, states, 0, int(sizeof(SecondaryT) * 8));
+      secondary_sieve.refine_max(secondary_keys, states);
     }
     else
     {
-      secondary_sieve.refine_min(secondary_keys, states, 0, int(sizeof(SecondaryT) * 8));
+      secondary_sieve.refine_min(secondary_keys, states);
     }
     __syncthreads();
   }
@@ -727,19 +728,22 @@ C2H_TEST("block_topk_sieve produces the same selection across bit-window splits"
 
   SECTION("early exit before last window")
   {
-    // Distinct keys with non-zero bits only in window [16, 24): the top
-    // byte still ties after the first `select_max`, but the next refine
-    // over [16, 24) fully orders them, firing the iter-2 `!has_ties()`
-    // break and skipping windows [8, 16) and [0, 8).
+    // Distinct values `i in [0, tile_size)` shifted left by `2 * window_bits`,
+    // confining entropy to bits [16, 25). `select_max` over [24, 32) at most
+    // partitions candidates on bit 24; within each partition, `[16, 24)`
+    // bits are still distinct, so the iter-1 refine over [16, 24) fully
+    // orders the top-k. The iter-2 `!has_ties()` break then fires before
+    // visiting windows [8, 16) and [0, 8).
     const int k = GENERATE_COPY(values<int>({1, 11, tile_size / 4, tile_size - 1}));
     rng_t rng(static_cast<cuda::std::uint32_t>(C2H_SEED(1).get()));
     CAPTURE(k);
 
-    c2h::host_vector<key_t> h_in = distinct_keys<key_t>(tile_size, rng);
-    for (auto& x : h_in)
+    c2h::host_vector<key_t> h_in(tile_size);
+    for (int i = 0; i < tile_size; ++i)
     {
-      x = static_cast<key_t>(x << (2 * window_bits));
+      h_in[i] = static_cast<key_t>(i << (2 * window_bits));
     }
+    thrust::shuffle(h_in.begin(), h_in.end(), rng);
     constexpr int expected_last_hi = key_bits - 2 * window_bits;
     run_compare(h_in, k, expected_last_hi);
   }


### PR DESCRIPTION
## Description
During testing I found and fixed a bug in the previous block TopK AIR implementation regarding bit-twiddling-inversion and 0.0/-0.0 handling. 

TODO:
- [x] Compare performance to old implementation (no pessimization of segmented device TopK)
- [ ] ~~Add simple optimization of integer scan+adjacent difference~~ (No perf improvement with current segmented topk tuning)

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #8368<!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines]().
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes. (non-public API)
