### PR TITLE
[libcu++] Explicitly mark `__half` and `__nv_bfloat16` as trivially_copyable

### DIFF
--- a/libcudacxx/include/cuda/__type_traits/is_trivially_copyable.h
+++ b/libcudacxx/include/cuda/__type_traits/is_trivially_copyable.h
@@ -47,12 +47,17 @@ inline constexpr bool __is_trivially_copyable_v =
 #if _CCCL_HAS_NVFP16()
 
 template <>
+inline constexpr bool __is_trivially_copyable_v<::__half> = true;
+
+template <>
 inline constexpr bool __is_trivially_copyable_v<::__half2> = true;
 
 #endif // _CCCL_HAS_NVFP16()
 
 #if _CCCL_HAS_NVBF16()
 
+template <>
+inline constexpr bool __is_trivially_copyable_v<::__nv_bfloat16> = true;
 template <>
 inline constexpr bool __is_trivially_copyable_v<::__nv_bfloat162> = true;
 


### PR DESCRIPTION
Currently we only mark the vector types as trivially_copyable. However, for the machinery to work we actually need the type to be defined.

Rather than forcing internal headers to include `cuda_fp16.h` we should just specialize the trait directly
