### PR TITLE
Avoid copyable-argument transform path in tabulate

### DIFF
--- a/thrust/thrust/system/cuda/detail/tabulate.h
+++ b/thrust/thrust/system/cuda/detail/tabulate.h
@@ -32,8 +32,7 @@ void _CCCL_HOST_DEVICE tabulate(execution_policy<Derived>& policy, Iterator firs
 {
   using size_type  = ::cuda::std::iter_difference_t<Iterator>;
   const auto count = ::cuda::std::distance(first, last);
-  cuda_cub::transform_n(
-    policy, ::cuda::counting_iterator<size_type>{}, count, first, ::cuda::proclaim_copyable_arguments(tabulate_op));
+  cuda_cub::transform_n(policy, ::cuda::counting_iterator<size_type>{}, count, first, tabulate_op);
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END


### PR DESCRIPTION
## Summary

- Removes `cuda::proclaim_copyable_arguments` from the CUDA `thrust::tabulate` backend.
- Keeps `tabulate` implemented through `cuda_cub::transform_n`, but lets transform dispatch choose the stable-address path for user functors.
- Fixes a large slowdown found in wide row-wise tabulate workloads.

## Details

In #6012, CUDA `tabulate` was ported from a custom `parallel_for` implementation to `transform_n` and the functor was wrapped with `cuda::proclaim_copyable_arguments`.

A standalone CCCL + NVBench reproducer in #9070 showed that the wrapper is the source of the slowdown. Applying `proclaim_copyable_arguments` manually to an otherwise fast `transform_n` reproduces the slow `tabulate` behavior.

Representative results on NVIDIA GB10, CUDA 13.2, CCCL main `fcd4ff4ea1`:

| rows | cols | tabulate | transform_n_ptrdiff | transform_n_proclaim |
|---:|---:|---:|---:|---:|
| 1,048,576 | 32 | 4.197 ms | 1.185 ms | 4.277 ms |
| 1,048,576 | 128 | 18.337 ms | 4.679 ms | 18.361 ms |

With this patch:

| rows | cols | patched tabulate | transform_n_ptrdiff | for_each | cub_for | direct_kernel |
|---:|---:|---:|---:|---:|---:|---:|
| 1,048,576 | 32 | 1.199 ms | 1.182 ms | 1.172 ms | 1.191 ms | 1.198 ms |
| 1,048,576 | 128 | 4.733 ms | 4.657 ms | 4.558 ms | 4.641 ms | 4.573 ms |
| 1,048,576 | 256 | 9.249 ms | 9.312 ms | 9.192 ms | 9.148 ms | 9.198 ms |

Fixes #9070.