### PR TITLE
[libcu++][doc] Fix Broken `cuda/functional` documentation

### DIFF
--- a/docs/libcudacxx/extended_api/functional.rst
+++ b/docs/libcudacxx/extended_api/functional.rst
@@ -24,10 +24,12 @@ Functional
    * - :ref:`cuda::always_true <libcudacxx-extended-api-functional-always-true-false>`
      - Function object that always returns ``true``
      - CCCL 3.4.0
+     - CUDA 13.4
 
    * - :ref:`cuda::always_false <libcudacxx-extended-api-functional-always-true-false>`
      - Function object that always returns ``false``
      - CCCL 3.4.0
+     - CUDA 13.4
 
    * - :ref:`cuda::maximum <libcudacxx-extended-api-functional-maximum-minimum>`
      - Returns the maximum of two values


### PR DESCRIPTION
## Description

https://nvidia.github.io/cccl/unstable/libcudacxx/extended_api/functional.html is empty. This PR fixes the problem.
