### PR TITLE
Use public API in unique_by_key benchmark

### DIFF
--- a/cub/benchmarks/bench/select/unique_by_key.cu
+++ b/cub/benchmarks/bench/select/unique_by_key.cu
@@ -45,7 +45,7 @@ struct bench_unique_by_key_policy_selector
 template <class KeyT, class ValueT, class OffsetT>
 static void select(nvbench::state& state, nvbench::type_list<KeyT, ValueT, OffsetT>)
 {
-  using equality_op_t = ::cuda::std::equal_to<>;
+  using equality_op_t = cuda::std::equal_to<>;
 
   const auto elements                    = static_cast<std::size_t>(state.get_int64("Elements{io}"));
   constexpr std::size_t min_segment_size = 1;

--- a/cub/benchmarks/bench/select/unique_by_key.cu
+++ b/cub/benchmarks/bench/select/unique_by_key.cu
@@ -76,7 +76,7 @@ static void select(nvbench::state& state, nvbench::type_list<KeyT, ValueT, Offse
     d_num_runs_out,
     num_items,
     equality_op_t{});
-  cudaDeviceSynchronize();
+  _CCCL_TRY_CUDA_API(cudaDeviceSynchronize, "Sync failed");
   const OffsetT num_runs = num_runs_out[0];
 
   state.add_element_count(elements);

--- a/cub/benchmarks/bench/select/unique_by_key.cu
+++ b/cub/benchmarks/bench/select/unique_by_key.cu
@@ -46,7 +46,6 @@ template <class KeyT, class ValueT, class OffsetT>
 static void select(nvbench::state& state, nvbench::type_list<KeyT, ValueT, OffsetT>)
 {
   using equality_op_t = ::cuda::std::equal_to<>;
-  using offset_t      = ::cub::detail::choose_offset_t<OffsetT>;
 
   const auto elements                    = static_cast<std::size_t>(state.get_int64("Elements{io}"));
   constexpr std::size_t min_segment_size = 1;
@@ -64,35 +63,11 @@ static void select(nvbench::state& state, nvbench::type_list<KeyT, ValueT, Offse
   ValueT* d_out_vals      = thrust::raw_pointer_cast(out_vals.data());
   OffsetT* d_num_runs_out = thrust::raw_pointer_cast(num_runs_out.data());
 
-  std::uint8_t* d_temp_storage{};
-  std::size_t temp_storage_bytes{};
-  const offset_t num_items = static_cast<offset_t>(elements);
+  const auto num_items = static_cast<OffsetT>(elements);
 
-  auto dispatch_on_stream = [&](cudaStream_t stream) {
-    return cub::detail::unique_by_key::dispatch(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_in_keys,
-      d_in_vals,
-      d_out_keys,
-      d_out_vals,
-      d_num_runs_out,
-      equality_op_t{},
-      num_items,
-      stream
-#if !TUNE_BASE
-      ,
-      bench_unique_by_key_policy_selector{}
-#endif
-    );
-  };
-
-  dispatch_on_stream(nullptr);
-
-  thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
-  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
-
-  dispatch_on_stream(nullptr);
+  // Pre-computation to get num_runs for statistics
+  cub::DeviceSelect::UniqueByKey(
+    d_in_keys, d_in_vals, d_out_keys, d_out_vals, d_num_runs_out, num_items, equality_op_t{});
   cudaDeviceSynchronize();
   const OffsetT num_runs = num_runs_out[0];
 
@@ -103,8 +78,27 @@ static void select(nvbench::state& state, nvbench::type_list<KeyT, ValueT, Offse
   state.add_global_memory_writes<KeyT>(num_runs);
   state.add_global_memory_writes<OffsetT>(1);
 
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    dispatch_on_stream(launch.get_stream());
+    auto env = cub_bench_env(
+      alloc,
+      launch
+#if !TUNE_BASE
+      ,
+      cuda::execution::tune(bench_unique_by_key_policy_selector{})
+#endif // !TUNE_BASE
+    );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceSelect::UniqueByKey,
+      "UniqueByKey failed",
+      d_in_keys,
+      d_in_vals,
+      d_out_keys,
+      d_out_vals,
+      d_num_runs_out,
+      num_items,
+      equality_op_t{},
+      env);
   });
 }
 

--- a/cub/benchmarks/bench/select/unique_by_key.cu
+++ b/cub/benchmarks/bench/select/unique_by_key.cu
@@ -66,8 +66,16 @@ static void select(nvbench::state& state, nvbench::type_list<KeyT, ValueT, Offse
   const auto num_items = static_cast<OffsetT>(elements);
 
   // Pre-computation to get num_runs for statistics
-  cub::DeviceSelect::UniqueByKey(
-    d_in_keys, d_in_vals, d_out_keys, d_out_vals, d_num_runs_out, num_items, equality_op_t{});
+  _CCCL_TRY_CUDA_API(
+    cub::DeviceSelect::UniqueByKey,
+    "UniqueByKey failed",
+    d_in_keys,
+    d_in_vals,
+    d_out_keys,
+    d_out_vals,
+    d_num_runs_out,
+    num_items,
+    equality_op_t{});
   cudaDeviceSynchronize();
   const OffsetT num_runs = num_runs_out[0];
 


### PR DESCRIPTION
- [x] #9091
- [x] No SASS changes for `cub.bench.select.unique_by_key.base` on SM`75;80;86;90;100` (after #9091 is merged)

Fixes: #8480 
