### PR TITLE
Use the new tuning API internally for `detail::batch_memcpy::dispatch`

### DIFF
--- a/cub/benchmarks/bench/copy/memcpy.cu
+++ b/cub/benchmarks/bench/copy/memcpy.cu
@@ -148,8 +148,6 @@ void copy(nvbench::state& state,
   using input_buffer_it_t  = it_t*;
   using output_buffer_it_t = it_t*;
   using buffer_size_it_t   = offset_t*;
-  using buffer_offset_t    = std::uint32_t;
-  using block_offset_t     = std::uint32_t;
 
   thrust::device_vector<T> input_buffer = generate(elements);
   thrust::device_vector<T> output_buffer(elements);
@@ -187,40 +185,25 @@ void copy(nvbench::state& state,
   state.add_global_memory_reads<it_t>(buffers);
   state.add_global_memory_reads<offset_t>(buffers);
 
-  std::size_t temp_storage_bytes{};
-  std::uint8_t* d_temp_storage{};
-  cub::detail::batch_memcpy::dispatch<cub::CopyAlg::Memcpy, block_offset_t>(
-    d_temp_storage,
-    temp_storage_bytes,
-    d_input_buffers,
-    d_output_buffers,
-    d_buffer_sizes,
-    buffers,
-    nullptr
-#if !TUNE_BASE
-    ,
-    policy_selector_t{}
-#endif
-  );
-
-  thrust::device_vector<nvbench::uint8_t> temp_storage(temp_storage_bytes);
-  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch) {
-               cub::detail::batch_memcpy::dispatch<cub::CopyAlg::Memcpy, block_offset_t>(
-                 d_temp_storage,
-                 temp_storage_bytes,
+               auto env = cub_bench_env(
+                 alloc,
+                 launch
+#if !TUNE_BASE
+                 ,
+                 cuda::execution::tune(policy_selector_t{})
+#endif
+               );
+               _CCCL_TRY_CUDA_API(
+                 cub::DeviceMemcpy::Batched,
+                 "Batched failed",
                  d_input_buffers,
                  d_output_buffers,
                  d_buffer_sizes,
-                 buffers,
-                 launch.get_stream()
-#if !TUNE_BASE
-                   ,
-                 policy_selector_t{}
-#endif
-               );
+                 static_cast<::cuda::std::int64_t>(buffers),
+                 env);
              });
 }
 

--- a/cub/benchmarks/bench/copy/memcpy.cu
+++ b/cub/benchmarks/bench/copy/memcpy.cu
@@ -202,7 +202,7 @@ void copy(nvbench::state& state,
                  d_input_buffers,
                  d_output_buffers,
                  d_buffer_sizes,
-                 static_cast<::cuda::std::int64_t>(buffers),
+                 static_cast<cuda::std::int64_t>(buffers),
                  env);
              });
 }

--- a/cub/cub/device/device_copy.cuh
+++ b/cub/cub/device/device_copy.cuh
@@ -230,12 +230,14 @@ struct DeviceCopy
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceCopy::Batched");
 
-    using BlockOffsetT = uint32_t;
+    using BlockOffsetT            = uint32_t;
+    using default_policy_selector = detail::batch_memcpy::policy_selector;
 
-    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::batch_memcpy::dispatch<CopyAlg::Copy, BlockOffsetT>(
-        storage, bytes, input_it, output_it, sizes, num_ranges, stream);
-    });
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::batch_memcpy::dispatch<CopyAlg::Copy, BlockOffsetT>(
+          storage, bytes, input_it, output_it, sizes, num_ranges, stream, policy_selector);
+      });
   }
 
   //! @rst

--- a/cub/cub/device/device_memcpy.cuh
+++ b/cub/cub/device/device_memcpy.cuh
@@ -252,12 +252,14 @@ struct DeviceMemcpy
                   "DeviceMemcpy::Batched only supports copying of memory buffers."
                   "Please consider using DeviceCopy::Batched instead.");
 
-    using BlockOffsetT = uint32_t;
+    using BlockOffsetT            = uint32_t;
+    using default_policy_selector = detail::batch_memcpy::policy_selector;
 
-    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      return detail::batch_memcpy::dispatch<CopyAlg::Memcpy, BlockOffsetT>(
-        storage, bytes, input_buffer_it, output_buffer_it, buffer_sizes, num_buffers, stream);
-    });
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::batch_memcpy::dispatch<CopyAlg::Memcpy, BlockOffsetT>(
+          storage, bytes, input_buffer_it, output_buffer_it, buffer_sizes, num_buffers, stream, policy_selector);
+      });
   }
 };
 

--- a/cub/test/catch2_test_device_copy_env.cu
+++ b/cub/test/catch2_test_device_copy_env.cu
@@ -12,10 +12,9 @@ struct stream_registry_factory_t;
 
 #include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/device_vector.h>
-#include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/transform_iterator.h>
 
 #include <cuda/__execution/tune.h>
+#include <cuda/iterator>
 
 #include "catch2_test_env_launch_helper.h"
 
@@ -163,8 +162,8 @@ C2H_TEST("DeviceCopy::Batched can be tuned", "[copy][device]", block_sizes)
   int num_ranges                = 3;
   constexpr int items_per_range = 2;
 
-  thrust::counting_iterator<int> iota(0);
-  auto input_it = thrust::make_transform_iterator(
+  cuda::counting_iterator<int> iota(0);
+  auto input_it = cuda::make_transform_iterator(
     iota, index_to_ptr<const int>{thrust::raw_pointer_cast(d_src.data()), thrust::raw_pointer_cast(d_offsets.data())});
   auto output_it = thrust::make_transform_iterator(
     iota, index_to_ptr<int>{thrust::raw_pointer_cast(d_dst.data()), thrust::raw_pointer_cast(d_offsets.data())});

--- a/cub/test/catch2_test_device_copy_env.cu
+++ b/cub/test/catch2_test_device_copy_env.cu
@@ -8,10 +8,14 @@ struct stream_registry_factory_t;
 #include "insert_nested_NVTX_range_guard.h"
 
 #include <cub/device/device_copy.cuh>
+#include <cub/device/dispatch/tuning/tuning_batch_memcpy.cuh>
 
+#include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/device_vector.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
+
+#include <cuda/__execution/tune.h>
 
 #include "catch2_test_env_launch_helper.h"
 
@@ -129,3 +133,51 @@ TEST_CASE("DeviceCopy::Batched uses custom stream", "[copy][device]")
   REQUIRE(d_dst == d_src);
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
+
+template <int BlockThreads>
+struct batch_copy_tuning
+{
+  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::detail::batch_memcpy::batch_memcpy_policy
+  {
+    return {
+      {BlockThreads, 4, 8, false, 256 * 32, 128, 8 * 1024, {}, {}},
+      {256, 32},
+    };
+  }
+};
+
+using block_sizes =
+  c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
+
+#if TEST_LAUNCH != 1
+
+C2H_TEST("DeviceCopy::Batched can be tuned", "[copy][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+
+  // 3 ranges of 2 ints each
+  auto d_src     = c2h::device_vector<int>{10, 20, 30, 40, 50, 60};
+  auto d_dst     = c2h::device_vector<int>(6, 0);
+  auto d_offsets = c2h::device_vector<int>{0, 2, 4, 6};
+
+  int num_ranges                = 3;
+  constexpr int items_per_range = 2;
+
+  thrust::counting_iterator<int> iota(0);
+  auto input_it = thrust::make_transform_iterator(
+    iota, index_to_ptr<const int>{thrust::raw_pointer_cast(d_src.data()), thrust::raw_pointer_cast(d_offsets.data())});
+  auto output_it = thrust::make_transform_iterator(
+    iota, index_to_ptr<int>{thrust::raw_pointer_cast(d_dst.data()), thrust::raw_pointer_cast(d_offsets.data())});
+
+  c2h::device_vector<unsigned int> d_block_size(1);
+  block_size_extracting_constant_iterator sizes(items_per_range, thrust::raw_pointer_cast(d_block_size.data()));
+
+  auto env = cuda::execution::tune(batch_copy_tuning<target_block_size>{});
+
+  device_copy_batched(input_it, output_it, sizes, num_ranges, env);
+
+  REQUIRE(d_dst == d_src);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+#endif // TEST_LAUNCH != 1

--- a/cub/test/catch2_test_device_memcpy_env.cu
+++ b/cub/test/catch2_test_device_memcpy_env.cu
@@ -8,9 +8,12 @@ struct stream_registry_factory_t;
 #include "insert_nested_NVTX_range_guard.h"
 
 #include <cub/device/device_memcpy.cuh>
+#include <cub/device/dispatch/tuning/tuning_batch_memcpy.cuh>
 
+#include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/device_vector.h>
 
+#include <cuda/__execution/tune.h>
 #include <cuda/iterator>
 #include <cuda/stream>
 
@@ -128,3 +131,52 @@ TEST_CASE("DeviceMemcpy::Batched uses custom stream", "[memcpy][device]")
   custom_stream.sync();
   REQUIRE(d_dst == d_src);
 }
+
+template <int BlockThreads>
+struct batch_memcpy_tuning
+{
+  _CCCL_API constexpr auto operator()(cuda::compute_capability /*cc*/) const
+    -> cub::detail::batch_memcpy::batch_memcpy_policy
+  {
+    return {
+      {BlockThreads, 4, 8, false, 256 * 32, 128, 8 * 1024, {}, {}},
+      {256, 32},
+    };
+  }
+};
+
+using block_sizes =
+  c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
+
+#if TEST_LAUNCH != 1
+
+C2H_TEST("DeviceMemcpy::Batched can be tuned", "[memcpy][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+
+  // 3 buffers of 2 ints each (8 bytes)
+  auto d_src     = c2h::device_vector<int>{10, 20, 30, 40, 50, 60};
+  auto d_dst     = c2h::device_vector<int>(6, 0);
+  auto d_offsets = c2h::device_vector<int>{0, 2, 4, 6};
+
+  int num_buffers                = 3;
+  constexpr int bytes_per_buffer = 2 * static_cast<int>(sizeof(int));
+
+  cuda::counting_iterator<int> iota(0);
+  auto input_it = cuda::transform_iterator(
+    iota, index_to_ptr<const int>{thrust::raw_pointer_cast(d_src.data()), thrust::raw_pointer_cast(d_offsets.data())});
+  auto output_it = cuda::transform_iterator(
+    iota, index_to_ptr<int>{thrust::raw_pointer_cast(d_dst.data()), thrust::raw_pointer_cast(d_offsets.data())});
+
+  c2h::device_vector<unsigned int> d_block_size(1);
+  block_size_extracting_constant_iterator sizes(bytes_per_buffer, thrust::raw_pointer_cast(d_block_size.data()));
+
+  auto env = cuda::execution::tune(batch_memcpy_tuning<target_block_size>{});
+
+  device_memcpy_batched(input_it, output_it, sizes, num_buffers, env);
+
+  REQUIRE(d_dst == d_src);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+#endif // TEST_LAUNCH != 1


### PR DESCRIPTION
- [x] No SASS changes for `cub.bench.copy.memcpy.base` on SM120

Fixes: #8374