### PR TITLE
Use the new tuning API internally for `detail::batched_topk::dispatch`

### DIFF
--- a/cub/benchmarks/bench/segmented_topk/fixed/keys.cu
+++ b/cub/benchmarks/bench/segmented_topk/fixed/keys.cu
@@ -107,6 +107,7 @@ void fixed_seg_size_topk_keys(
       cuda::execution::tune(tuned_policy_selector{})
 #endif // !TUNE_BASE
     );
+    // TODO(bgruber): call the public API once available
     _CCCL_TRY_CUDA_API(
       cub::detail::batched_topk::dispatch_with_env,
       "batched topk failed",

--- a/cub/benchmarks/bench/segmented_topk/fixed/keys.cu
+++ b/cub/benchmarks/bench/segmented_topk/fixed/keys.cu
@@ -97,35 +97,19 @@ void fixed_seg_size_topk_keys(
   state.add_global_memory_reads<KeyT>(elements, "InputKeys");
   state.add_global_memory_writes<KeyT>(selected_elements * num_segments, "OutputKeys");
 
-  // allocate temporary storage
-  size_t temp_size;
-  cub::detail::batched_topk::dispatch(
-    nullptr,
-    temp_size,
-    d_keys_in,
-    d_keys_out,
-    static_cast<cub::NullType**>(nullptr),
-    static_cast<cub::NullType**>(nullptr),
-    segment_sizes,
-    k,
-    select_directions,
-    num_segments_uniform_t{static_cast<::cuda::std::int64_t>(num_segments)},
-    total_num_items,
-    nullptr
-#if !TUNE_BASE
-    ,
-    tuned_policy_selector{}
-#endif // !TUNE_BASE
-  );
-
-  thrust::device_vector<nvbench::uint8_t> temp(temp_size, thrust::no_init);
-  auto* temp_storage = thrust::raw_pointer_cast(temp.data());
-
-  // run the algorithm
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::batched_topk::dispatch(
-      temp_storage,
-      temp_size,
+    auto env = cub_bench_env(
+      alloc,
+      launch
+#if !TUNE_BASE
+      ,
+      cuda::execution::tune(tuned_policy_selector{})
+#endif // !TUNE_BASE
+    );
+    _CCCL_TRY_CUDA_API(
+      cub::detail::batched_topk::dispatch_with_env,
+      "batched topk failed",
       d_keys_in,
       d_keys_out,
       static_cast<cub::NullType**>(nullptr),
@@ -135,12 +119,7 @@ void fixed_seg_size_topk_keys(
       select_directions,
       num_segments_uniform_t{static_cast<::cuda::std::int64_t>(num_segments)},
       total_num_items,
-      launch.get_stream()
-#if !TUNE_BASE
-        ,
-      tuned_policy_selector{}
-#endif // !TUNE_BASE
-    );
+      env);
   });
 }
 

--- a/cub/benchmarks/bench/segmented_topk/variable/keys.cu
+++ b/cub/benchmarks/bench/segmented_topk/variable/keys.cu
@@ -197,28 +197,12 @@ void variable_seg_size_topk_keys(nvbench::state& state,
   state.add_global_memory_reads<KeyT>(input_elements, "InputKeys");
   state.add_global_memory_writes<KeyT>(output_elements, "OutputKeys");
 
-  size_t temp_size{};
-  cub::detail::batched_topk::dispatch(
-    nullptr,
-    temp_size,
-    d_keys_in,
-    d_keys_out,
-    static_cast<cub::NullType**>(nullptr),
-    static_cast<cub::NullType**>(nullptr),
-    segment_sizes_param,
-    k_param,
-    select_directions,
-    num_segments_uniform_param,
-    total_num_items,
-    nullptr);
-
-  thrust::device_vector<nvbench::uint8_t> temp(temp_size, thrust::no_init);
-  auto* temp_storage = thrust::raw_pointer_cast(temp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::batched_topk::dispatch(
-      temp_storage,
-      temp_size,
+    auto env = cub_bench_env(alloc, launch);
+    _CCCL_TRY_CUDA_API(
+      cub::detail::batched_topk::dispatch_with_env,
+      "batched topk failed",
       d_keys_in,
       d_keys_out,
       static_cast<cub::NullType**>(nullptr),
@@ -228,7 +212,7 @@ void variable_seg_size_topk_keys(nvbench::state& state,
       select_directions,
       num_segments_uniform_param,
       total_num_items,
-      launch.get_stream());
+      env);
   });
 }
 

--- a/cub/benchmarks/bench/segmented_topk/variable/keys.cu
+++ b/cub/benchmarks/bench/segmented_topk/variable/keys.cu
@@ -200,6 +200,7 @@ void variable_seg_size_topk_keys(nvbench::state& state,
   caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
     auto env = cub_bench_env(alloc, launch);
+    // TODO(bgruber): call the public API once available
     _CCCL_TRY_CUDA_API(
       cub::detail::batched_topk::dispatch_with_env,
       "batched topk failed",

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -18,6 +18,7 @@
 #endif // no system header
 
 #include <cub/detail/choose_offset.cuh>
+#include <cub/detail/env_dispatch.cuh>
 #include <cub/detail/segmented_params.cuh>
 #include <cub/device/dispatch/dispatch_common.cuh>
 #include <cub/device/dispatch/dispatch_scan.cuh>
@@ -375,6 +376,53 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
     // - Directly take the segment parameters since all segments are large
   }
   return CubDebug(detail::DebugSyncStream(stream));
+}
+// Env-based dispatch function handling memory allocation as well. This is usually done by the device-layer, but there
+// is no public API for segmented topk yet.
+template <typename KeyInputItItT,
+          typename KeyOutputItItT,
+          typename ValueInputItItT,
+          typename ValueOutputItItT,
+          typename SegmentSizeParameterT,
+          typename KParameterT,
+          typename SelectDirectionParameterT,
+          typename NumSegmentsParameterT,
+          typename TotalNumItemsGuaranteeT,
+          typename EnvT = ::cuda::std::execution::env<>>
+[[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_with_env(
+  KeyInputItItT d_key_segments_it,
+  KeyOutputItItT d_key_segments_out_it,
+  ValueInputItItT d_value_segments_it,
+  ValueOutputItItT d_value_segments_out_it,
+  SegmentSizeParameterT segment_sizes,
+  KParameterT k,
+  SelectDirectionParameterT select_directions,
+  NumSegmentsParameterT num_segments,
+  TotalNumItemsGuaranteeT total_num_items_guarantee,
+  EnvT env = {})
+{
+  using default_policy_selector =
+    policy_selector_from_types<it_value_t<it_value_t<KeyInputItItT>>,
+                               it_value_t<it_value_t<ValueInputItItT>>,
+                               ::cuda::std::int64_t,
+                               params::static_max_value_v<KParameterT>>;
+  return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+    env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+      return dispatch(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_key_segments_it,
+        d_key_segments_out_it,
+        d_value_segments_it,
+        d_value_segments_out_it,
+        segment_sizes,
+        k,
+        select_directions,
+        num_segments,
+        total_num_items_guarantee,
+        stream,
+        policy_selector);
+    });
 }
 } // namespace detail::batched_topk
 


### PR DESCRIPTION
- [x] No SASS changes for `cub.bench.segmented_topk.fixed.base` on SM120
- [x] No SASS changes for `cub.bench.segmented_topk.variable.base` on SM120

Fixes: #8482