### PR TITLE
[codex] libcudacxx: relax bit_cast fallback construction check

### DIFF
--- a/libcudacxx/include/cuda/std/__bit/bit_cast.h
+++ b/libcudacxx/include/cuda/std/__bit/bit_cast.h
@@ -23,7 +23,7 @@
 
 #include <cuda/__type_traits/is_trivially_copyable.h>
 #include <cuda/std/__concepts/concept_macros.h>
-#include <cuda/std/__concepts/constructible.h>
+#include <cuda/std/__type_traits/is_default_constructible.h>
 #include <cuda/std/cstring>
 
 #include <cuda/std/__cccl/prologue.h>
@@ -52,7 +52,7 @@ template <class _To, class _From>
 [[nodiscard]] _CCCL_API inline _To __bit_cast_memcpy(const _From& __from) noexcept
 {
 #if !_CCCL_COMPILER(GCC, <=, 8)
-  static_assert(::cuda::std::default_initializable<_To>,
+  static_assert(::cuda::std::is_default_constructible_v<_To>,
                 "bit_cast memcpy fallback requires the destination type to be default constructible");
 #endif // !_CCCL_COMPILER(GCC, <=, 8)
   _To __temp;

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bit.cast/bit_cast.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bit.cast/bit_cast.pass.cpp
@@ -285,6 +285,18 @@ TEST_FUNC bool tests()
     test_roundtrip_through<long long>(i);
   }
 
+#if _CCCL_HAS_FLOAT128()
+  {
+    constexpr __uint128_t one_bits = __uint128_t{0x3fff'0000'0000'0000} << 64;
+    __float128 one                 = cuda::std::bit_cast<__float128>(one_bits);
+    __float128 fallback_one        = cuda::std::__bit_cast_memcpy<__float128>(one_bits);
+    assert(one == fallback_one);
+    test_roundtrip_through_nested_T(one);
+    test_roundtrip_through_buffer(one);
+    test_roundtrip_through<__uint128_t>(one);
+  }
+#endif // _CCCL_HAS_FLOAT128()
+
 #if _LIBCUDACXX_HAS_NVFP16()
   // Extended floating point type __half
   for (__half i :


### PR DESCRIPTION
## Summary
- replace the `cuda::std::bit_cast` memcpy fallback assertion from `default_initializable<_To>` to `is_default_constructible_v<_To>`
- add `__float128` / `__uint128_t` coverage to the existing `bit_cast` roundtrip test

## Root Cause
The memcpy fallback only needs to default-construct a temporary destination object before copying bytes into it. `default_initializable` is stricter than that and can reject compiler extended floating-point types such as `__float128`, causing the fallback path to fail even though the destination type is default constructible.

## Validation
- `g++ -std=gnu++20 -Ilibcudacxx/include -Ilibcudacxx/test/support libcudacxx/test/libcudacxx/std/numerics/bit/bit.cast/bit_cast.pass.cpp -o /tmp/cccl-bit-cast-pass-gcc && /tmp/cccl-bit-cast-pass-gcc`
- `clang++ -std=gnu++20 -Ilibcudacxx/include -Ilibcudacxx/test/support libcudacxx/test/libcudacxx/std/numerics/bit/bit.cast/bit_cast.pass.cpp -o /tmp/cccl-bit-cast-pass-clang && /tmp/cccl-bit-cast-pass-clang`
- `nvcc -std=c++20 -Ilibcudacxx/include -Ilibcudacxx/test/support -x cu libcudacxx/test/libcudacxx/std/numerics/bit/bit.cast/bit_cast.pass.cpp -o /tmp/cccl-bit-cast-pass-nvcc && /tmp/cccl-bit-cast-pass-nvcc`
- commit hook suite, including `clang-format` and `codespell`
