### PR TITLE
Use the new tuning API internally for `detail::histogram::dispatch`

### DIFF
--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -17,31 +17,6 @@
 template <typename SampleT, typename CounterT, typename OffsetT>
 static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, OffsetT>)
 {
-  constexpr int num_channels        = 1;
-  constexpr int num_active_channels = 1;
-
-  using sample_iterator_t = SampleT*;
-
-#if !TUNE_BASE
-  using policy_t = policy_hub_t<key_t, num_channels, num_active_channels>;
-  using dispatch_t =
-    cub::DispatchHistogram<num_channels, //
-                           num_active_channels,
-                           sample_iterator_t,
-                           CounterT,
-                           SampleT,
-                           OffsetT,
-                           policy_t>;
-#else // TUNE_BASE
-  using dispatch_t =
-    cub::DispatchHistogram<num_channels, //
-                           num_active_channels,
-                           sample_iterator_t,
-                           CounterT,
-                           /* LevelT = */ SampleT,
-                           OffsetT>;
-#endif // TUNE_BASE
-
   const auto entropy   = str_to_entropy(state.get_string("Entropy"));
   const auto elements  = state.get_int64("Elements{io}");
   const auto num_bins  = state.get_int64("Bins");
@@ -66,49 +41,30 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   SampleT* d_input      = thrust::raw_pointer_cast(input.data());
   CounterT* d_histogram = thrust::raw_pointer_cast(hist.data());
 
-  std::uint8_t* d_temp_storage = nullptr;
-  std::size_t temp_storage_bytes{};
-
-  cuda::std::bool_constant<sizeof(SampleT) == 1> is_byte_sample;
-  OffsetT num_row_pixels     = static_cast<OffsetT>(elements);
-  OffsetT num_rows           = 1;
-  OffsetT row_stride_samples = num_row_pixels;
-
   state.add_element_count(elements);
   state.add_global_memory_reads<SampleT>(elements);
   state.add_global_memory_writes<CounterT>(num_bins);
 
-  dispatch_t::DispatchEven(
-    d_temp_storage,
-    temp_storage_bytes,
-    d_input,
-    {d_histogram},
-    {num_levels},
-    {lower_level},
-    {upper_level},
-    num_row_pixels,
-    num_rows,
-    row_stride_samples,
-    nullptr,
-    is_byte_sample);
-
-  thrust::device_vector<nvbench::uint8_t> tmp(temp_storage_bytes);
-  d_temp_storage = thrust::raw_pointer_cast(tmp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    dispatch_t::DispatchEven(
-      d_temp_storage,
-      temp_storage_bytes,
+    auto env = cub_bench_env(
+      alloc,
+      launch
+#if !TUNE_BASE
+      ,
+      cuda::execution::tune(bench_policy_selector<key_t, 1, 1>{})
+#endif // !TUNE_BASE
+    );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceHistogram::HistogramEven,
+      "HistogramEven failed",
       d_input,
-      {d_histogram},
-      {num_levels},
-      {lower_level},
-      {upper_level},
-      num_row_pixels,
-      num_rows,
-      row_stride_samples,
-      launch.get_stream(),
-      is_byte_sample);
+      d_histogram,
+      num_levels,
+      lower_level,
+      upper_level,
+      static_cast<OffsetT>(elements),
+      env);
   });
 }
 

--- a/cub/benchmarks/bench/histogram/histogram_common.cuh
+++ b/cub/benchmarks/bench/histogram/histogram_common.cuh
@@ -52,7 +52,8 @@ struct bench_policy_selector
             TUNE_RLE_COMPRESS,
             MEM_PREFERENCE,
             TUNE_WORK_STEALING,
-            TUNE_VEC_SIZE};
+            TUNE_VEC_SIZE,
+            2048}; // TODO(bgruber): make tunable
   }
 };
 #endif // !TUNE_BASE

--- a/cub/benchmarks/bench/histogram/histogram_common.cuh
+++ b/cub/benchmarks/bench/histogram/histogram_common.cuh
@@ -36,27 +36,24 @@ constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::BLEND;
 #  endif // TUNE_LOAD_ALGORITHM_ID
 
 template <typename SampleT, int NUM_CHANNELS, int NUM_ACTIVE_CHANNELS>
-struct policy_hub_t
+struct bench_policy_selector
 {
-  struct policy_t : cub::ChainedPolicy<500, policy_t, policy_t>
+  _CCCL_API constexpr auto operator()(::cuda::compute_capability) const -> cub::detail::histogram::histogram_policy
   {
-    static constexpr cub::BlockLoadAlgorithm load_algorithm =
+    constexpr cub::BlockLoadAlgorithm load_algorithm =
       (TUNE_LOAD_ALGORITHM == cub::BLOCK_LOAD_STRIPED)
         ? (NUM_CHANNELS == 1 ? cub::BLOCK_LOAD_STRIPED : cub::BLOCK_LOAD_DIRECT)
         : TUNE_LOAD_ALGORITHM;
 
-    using AgentHistogramPolicyT = cub::AgentHistogramPolicy<
-      TUNE_THREADS,
-      TUNE_ITEMS,
-      load_algorithm,
-      TUNE_LOAD_MODIFIER,
-      TUNE_RLE_COMPRESS,
-      MEM_PREFERENCE,
-      TUNE_WORK_STEALING,
-      TUNE_VEC_SIZE>;
-  };
-
-  using MaxPolicy = policy_t;
+    return {TUNE_THREADS,
+            TUNE_ITEMS,
+            load_algorithm,
+            TUNE_LOAD_MODIFIER,
+            TUNE_RLE_COMPRESS,
+            MEM_PREFERENCE,
+            TUNE_WORK_STEALING,
+            TUNE_VEC_SIZE};
+  }
 };
 #endif // !TUNE_BASE
 

--- a/cub/benchmarks/bench/histogram/multi/even.cu
+++ b/cub/benchmarks/bench/histogram/multi/even.cu
@@ -20,28 +20,6 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   constexpr int num_channels        = 4;
   constexpr int num_active_channels = 3;
 
-  using sample_iterator_t = SampleT*;
-
-#if !TUNE_BASE
-  using policy_t = policy_hub_t<key_t, num_channels, num_active_channels>;
-  using dispatch_t =
-    cub::DispatchHistogram<num_channels, //
-                           num_active_channels,
-                           sample_iterator_t,
-                           CounterT,
-                           SampleT,
-                           OffsetT,
-                           policy_t>;
-#else // TUNE_BASE
-  using dispatch_t =
-    cub::DispatchHistogram<num_channels, //
-                           num_active_channels,
-                           sample_iterator_t,
-                           CounterT,
-                           /* LevelT = */ SampleT,
-                           OffsetT>;
-#endif // TUNE_BASE
-
   const auto entropy     = str_to_entropy(state.get_string("Entropy"));
   const auto elements    = state.get_int64("Elements{io}");
   const auto num_bins    = state.get_int64("Bins");
@@ -76,49 +54,30 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   CounterT* d_histogram_g = thrust::raw_pointer_cast(hist_g.data());
   CounterT* d_histogram_b = thrust::raw_pointer_cast(hist_b.data());
 
-  std::uint8_t* d_temp_storage = nullptr;
-  std::size_t temp_storage_bytes{};
-
-  cuda::std::bool_constant<sizeof(SampleT) == 1> is_byte_sample;
-  OffsetT num_row_pixels     = static_cast<OffsetT>(elements);
-  OffsetT num_rows           = 1;
-  OffsetT row_stride_samples = num_row_pixels;
-
   state.add_element_count(elements);
   state.add_global_memory_reads<SampleT>(elements * num_active_channels);
   state.add_global_memory_writes<CounterT>(num_bins * num_active_channels);
 
-  dispatch_t::DispatchEven(
-    d_temp_storage,
-    temp_storage_bytes,
-    d_input,
-    {d_histogram_r, d_histogram_g, d_histogram_b},
-    {num_levels_r, num_levels_g, num_levels_b},
-    {lower_level_r, lower_level_g, lower_level_b},
-    {upper_level_r, upper_level_g, upper_level_b},
-    num_row_pixels,
-    num_rows,
-    row_stride_samples,
-    nullptr,
-    is_byte_sample);
-
-  thrust::device_vector<nvbench::uint8_t> tmp(temp_storage_bytes);
-  d_temp_storage = thrust::raw_pointer_cast(tmp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    dispatch_t::DispatchEven(
-      d_temp_storage,
-      temp_storage_bytes,
+    auto env = cub_bench_env(
+      alloc,
+      launch
+#if !TUNE_BASE
+      ,
+      cuda::execution::tune(bench_policy_selector<key_t, num_channels, num_active_channels>{})
+#endif // !TUNE_BASE
+    );
+    _CCCL_TRY_CUDA_API(
+      (cub::DeviceHistogram::MultiHistogramEven<num_channels, num_active_channels>),
+      "MultiHistogramEven failed",
       d_input,
-      {d_histogram_r, d_histogram_g, d_histogram_b},
-      {num_levels_r, num_levels_g, num_levels_b},
-      {lower_level_r, lower_level_g, lower_level_b},
-      {upper_level_r, upper_level_g, upper_level_b},
-      num_row_pixels,
-      num_rows,
-      row_stride_samples,
-      launch.get_stream(),
-      is_byte_sample);
+      cuda::std::array<CounterT*, num_active_channels>{d_histogram_r, d_histogram_g, d_histogram_b},
+      cuda::std::array<int, num_active_channels>{num_levels_r, num_levels_g, num_levels_b},
+      cuda::std::array<SampleT, num_active_channels>{lower_level_r, lower_level_g, lower_level_b},
+      cuda::std::array<SampleT, num_active_channels>{upper_level_r, upper_level_g, upper_level_b},
+      static_cast<OffsetT>(elements),
+      env);
   });
 }
 

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -22,28 +22,6 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   constexpr int num_channels        = 4;
   constexpr int num_active_channels = 3;
 
-  using sample_iterator_t = SampleT*;
-
-#if !TUNE_BASE
-  using policy_t = policy_hub_t<key_t, num_channels, num_active_channels>;
-  using dispatch_t =
-    cub::DispatchHistogram<num_channels, //
-                           num_active_channels,
-                           sample_iterator_t,
-                           CounterT,
-                           SampleT,
-                           OffsetT,
-                           policy_t>;
-#else // TUNE_BASE
-  using dispatch_t =
-    cub::DispatchHistogram<num_channels, //
-                           num_active_channels,
-                           sample_iterator_t,
-                           CounterT,
-                           /* LevelT = */ SampleT,
-                           OffsetT>;
-#endif // TUNE_BASE
-
   const auto entropy     = str_to_entropy(state.get_string("Entropy"));
   const auto elements    = state.get_int64("Elements{io}");
   const auto num_bins    = state.get_int64("Bins");
@@ -76,47 +54,29 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   CounterT* d_histogram_g = thrust::raw_pointer_cast(hist_g.data());
   CounterT* d_histogram_b = thrust::raw_pointer_cast(hist_b.data());
 
-  std::uint8_t* d_temp_storage = nullptr;
-  std::size_t temp_storage_bytes{};
-
-  cuda::std::bool_constant<sizeof(SampleT) == 1> is_byte_sample;
-  OffsetT num_row_pixels     = static_cast<OffsetT>(elements);
-  OffsetT num_rows           = 1;
-  OffsetT row_stride_samples = num_row_pixels;
-
   state.add_element_count(elements);
   state.add_global_memory_reads<SampleT>(elements * num_active_channels);
   state.add_global_memory_writes<CounterT>(num_bins * num_active_channels);
 
-  dispatch_t::DispatchRange(
-    d_temp_storage,
-    temp_storage_bytes,
-    d_input,
-    {d_histogram_r, d_histogram_g, d_histogram_b},
-    {num_levels_r, num_levels_g, num_levels_b},
-    {d_levels_r, d_levels_g, d_levels_b},
-    num_row_pixels,
-    num_rows,
-    row_stride_samples,
-    nullptr,
-    is_byte_sample);
-
-  thrust::device_vector<nvbench::uint8_t> tmp(temp_storage_bytes);
-  d_temp_storage = thrust::raw_pointer_cast(tmp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    dispatch_t::DispatchRange(
-      d_temp_storage,
-      temp_storage_bytes,
+    auto env = cub_bench_env(
+      alloc,
+      launch
+#if !TUNE_BASE
+      ,
+      cuda::execution::tune(bench_policy_selector<key_t, num_channels, num_active_channels>{})
+#endif // !TUNE_BASE
+    );
+    _CCCL_TRY_CUDA_API(
+      (cub::DeviceHistogram::MultiHistogramRange<num_channels, num_active_channels>),
+      "MultiHistogramRange failed",
       d_input,
-      {d_histogram_r, d_histogram_g, d_histogram_b},
-      {num_levels_r, num_levels_g, num_levels_b},
-      {d_levels_r, d_levels_g, d_levels_b},
-      num_row_pixels,
-      num_rows,
-      row_stride_samples,
-      launch.get_stream(),
-      is_byte_sample);
+      cuda::std::array<CounterT*, num_active_channels>{d_histogram_r, d_histogram_g, d_histogram_b},
+      cuda::std::array<int, num_active_channels>{num_levels_r, num_levels_g, num_levels_b},
+      cuda::std::array<const SampleT*, num_active_channels>{d_levels_r, d_levels_g, d_levels_b},
+      static_cast<OffsetT>(elements),
+      env);
   });
 }
 

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -19,31 +19,6 @@
 template <typename SampleT, typename CounterT, typename OffsetT>
 static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, OffsetT>)
 {
-  constexpr int num_channels        = 1;
-  constexpr int num_active_channels = 1;
-
-  using sample_iterator_t = SampleT*;
-
-#if !TUNE_BASE
-  using policy_t = policy_hub_t<key_t, num_channels, num_active_channels>;
-  using dispatch_t =
-    cub::DispatchHistogram<num_channels, //
-                           num_active_channels,
-                           sample_iterator_t,
-                           CounterT,
-                           SampleT,
-                           OffsetT,
-                           policy_t>;
-#else // TUNE_BASE
-  using dispatch_t =
-    cub::DispatchHistogram<num_channels, //
-                           num_active_channels,
-                           sample_iterator_t,
-                           CounterT,
-                           /* LevelT = */ SampleT,
-                           OffsetT>;
-#endif // TUNE_BASE
-
   const auto entropy   = str_to_entropy(state.get_string("Entropy"));
   const auto elements  = state.get_int64("Elements{io}");
   const auto num_bins  = state.get_int64("Bins");
@@ -65,47 +40,29 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   SampleT* d_input      = thrust::raw_pointer_cast(input.data());
   CounterT* d_histogram = thrust::raw_pointer_cast(hist.data());
 
-  std::uint8_t* d_temp_storage = nullptr;
-  std::size_t temp_storage_bytes{};
-
-  cuda::std::bool_constant<sizeof(SampleT) == 1> is_byte_sample;
-  OffsetT num_row_pixels     = static_cast<OffsetT>(elements);
-  OffsetT num_rows           = 1;
-  OffsetT row_stride_samples = num_row_pixels;
-
   state.add_element_count(elements);
   state.add_global_memory_reads<SampleT>(elements);
   state.add_global_memory_writes<CounterT>(num_bins);
 
-  dispatch_t::DispatchRange(
-    d_temp_storage,
-    temp_storage_bytes,
-    d_input,
-    {d_histogram},
-    {num_levels},
-    {d_levels},
-    num_row_pixels,
-    num_rows,
-    row_stride_samples,
-    nullptr,
-    is_byte_sample);
-
-  thrust::device_vector<nvbench::uint8_t> tmp(temp_storage_bytes);
-  d_temp_storage = thrust::raw_pointer_cast(tmp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    dispatch_t::DispatchRange(
-      d_temp_storage,
-      temp_storage_bytes,
+    auto env = cub_bench_env(
+      alloc,
+      launch
+#if !TUNE_BASE
+      ,
+      cuda::execution::tune(bench_policy_selector<key_t, 1, 1>{})
+#endif // !TUNE_BASE
+    );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceHistogram::HistogramRange,
+      "HistogramRange failed",
       d_input,
-      {d_histogram},
-      {num_levels},
-      {d_levels},
-      num_row_pixels,
-      num_rows,
-      row_stride_samples,
-      launch.get_stream(),
-      is_byte_sample);
+      d_histogram,
+      num_levels,
+      d_levels,
+      static_cast<OffsetT>(elements),
+      env);
   });
 }
 

--- a/cub/cub/device/device_histogram.cuh
+++ b/cub/cub/device/device_histogram.cuh
@@ -2001,11 +2001,10 @@ public:
     using SampleT = cub::detail::it_value_t<SampleIteratorT>;
     ::cuda::std::bool_constant<sizeof(SampleT) == 1> is_byte_sample;
 
-    return detail::dispatch_with_env(
-      env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) -> cudaError_t {
-        auto policy_selector =
-          detail::histogram::policy_selector_from_types<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, true>{};
-
+    using default_policy_selector =
+      detail::histogram::policy_selector_from_types<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, true>;
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) -> cudaError_t {
         if constexpr (sizeof(OffsetT) > sizeof(int))
         {
           if ((unsigned long long) (num_rows * row_stride_bytes) < (unsigned long long) INT_MAX)
@@ -2465,11 +2464,10 @@ public:
     using SampleT = cub::detail::it_value_t<SampleIteratorT>;
     ::cuda::std::bool_constant<sizeof(SampleT) == 1> is_byte_sample;
 
-    return detail::dispatch_with_env(
-      env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) -> cudaError_t {
-        auto policy_selector =
-          detail::histogram::policy_selector_from_types<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, false>{};
-
+    using default_policy_selector =
+      detail::histogram::policy_selector_from_types<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, false>;
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) -> cudaError_t {
         if constexpr (sizeof(OffsetT) > sizeof(int))
         {
           if ((unsigned long long) (num_rows * row_stride_bytes) < (unsigned long long) INT_MAX)

--- a/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
@@ -239,7 +239,7 @@ struct histogram_policy
   BlockHistogramMemoryPreference mem_preference;
   bool work_stealing;
   int vec_size;
-  int pdl_trigger_next_launch_in_init_kernel_max_bin_count;
+  int pdl_trigger_next_launch_in_init_kernel_max_bin_count = 2048;
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const histogram_policy& lhs, const histogram_policy& rhs)

--- a/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
@@ -239,7 +239,7 @@ struct histogram_policy
   BlockHistogramMemoryPreference mem_preference;
   bool work_stealing;
   int vec_size;
-  int pdl_trigger_next_launch_in_init_kernel_max_bin_count = 2048;
+  int pdl_trigger_next_launch_in_init_kernel_max_bin_count;
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const histogram_policy& lhs, const histogram_policy& rhs)

--- a/cub/test/catch2_test_device_histogram_env.cu
+++ b/cub/test/catch2_test_device_histogram_env.cu
@@ -31,6 +31,7 @@ DECLARE_TMPL_LAUNCH_WRAPPER(cub::DeviceHistogram::MultiHistogramRange,
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
 #include <cuda/__execution/require.h>
+#include <cuda/__execution/tune.h>
 
 #include <c2h/catch2_test_helper.h>
 
@@ -1142,3 +1143,126 @@ TEST_CASE("DeviceHistogram::MultiHistogramRange 2D uses custom stream", "[histog
 
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
+
+#if TEST_LAUNCH != 1
+
+template <int BlockThreads>
+struct histogram_tuning
+{
+  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::detail::histogram::histogram_policy
+  {
+    return {BlockThreads, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, false, cub::SMEM, false, 1, 0};
+  }
+};
+
+using block_sizes =
+  c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
+
+C2H_TEST("DeviceHistogram::HistogramEven can be tuned", "[histogram][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<unsigned int> d_block_size(1);
+  block_size_extracting_constant_iterator d_samples(0, thrust::raw_pointer_cast(d_block_size.data()));
+  int num_samples  = 256;
+  int num_levels   = 257;
+  int lower_level  = 0;
+  int upper_level  = 256;
+  auto d_histogram = c2h::device_vector<int>(num_levels - 1, 0);
+
+  auto env = cuda::execution::tune(histogram_tuning<target_block_size>{});
+
+  histogram_even(
+    d_samples, thrust::raw_pointer_cast(d_histogram.data()), num_levels, lower_level, upper_level, num_samples, env);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceHistogram::HistogramRange can be tuned", "[histogram][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  c2h::device_vector<unsigned int> d_block_size(1);
+  block_size_extracting_constant_iterator d_samples(0, thrust::raw_pointer_cast(d_block_size.data()));
+  int num_samples  = 256;
+  auto d_levels    = c2h::device_vector<int>{0, 128, 256};
+  int num_levels   = static_cast<int>(d_levels.size());
+  auto d_histogram = c2h::device_vector<int>(num_levels - 1, 0);
+
+  auto env = cuda::execution::tune(histogram_tuning<target_block_size>{});
+
+  histogram_range(
+    d_samples,
+    thrust::raw_pointer_cast(d_histogram.data()),
+    num_levels,
+    thrust::raw_pointer_cast(d_levels.data()),
+    num_samples,
+    env);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceHistogram::MultiHistogramEven can be tuned", "[histogram][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  constexpr int NUM_CHANNELS               = 4;
+  constexpr int NUM_ACTIVE_CHANNELS        = 3;
+
+  c2h::device_vector<unsigned int> d_block_size(1);
+  block_size_extracting_constant_iterator d_samples(0, thrust::raw_pointer_cast(d_block_size.data()));
+  int num_pixels = 64;
+
+  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels  = {5, 5, 5};
+  cuda::std::array<int, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
+  cuda::std::array<int, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
+
+  auto d_histogram_r = c2h::device_vector<int>(4, 0);
+  auto d_histogram_g = c2h::device_vector<int>(4, 0);
+  auto d_histogram_b = c2h::device_vector<int>(4, 0);
+
+  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+    thrust::raw_pointer_cast(d_histogram_r.data()),
+    thrust::raw_pointer_cast(d_histogram_g.data()),
+    thrust::raw_pointer_cast(d_histogram_b.data())};
+
+  auto env = cuda::execution::tune(histogram_tuning<target_block_size>{});
+
+  multi_histogram_even<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
+    d_samples, d_histogram, num_levels, lower_level, upper_level, num_pixels, env);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceHistogram::MultiHistogramRange can be tuned", "[histogram][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  constexpr int NUM_CHANNELS               = 4;
+  constexpr int NUM_ACTIVE_CHANNELS        = 3;
+
+  c2h::device_vector<unsigned int> d_block_size(1);
+  block_size_extracting_constant_iterator d_samples(0, thrust::raw_pointer_cast(d_block_size.data()));
+  int num_pixels = 64;
+
+  auto d_levels_r = c2h::device_vector<int>{0, 2, 4};
+  auto d_levels_g = c2h::device_vector<int>{0, 2, 4};
+  auto d_levels_b = c2h::device_vector<int>{0, 2, 4};
+
+  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels = {3, 3, 3};
+
+  cuda::std::array<const int*, NUM_ACTIVE_CHANNELS> d_levels = {
+    thrust::raw_pointer_cast(d_levels_r.data()),
+    thrust::raw_pointer_cast(d_levels_g.data()),
+    thrust::raw_pointer_cast(d_levels_b.data())};
+
+  auto d_histogram_r = c2h::device_vector<int>(2, 0);
+  auto d_histogram_g = c2h::device_vector<int>(2, 0);
+  auto d_histogram_b = c2h::device_vector<int>(2, 0);
+
+  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+    thrust::raw_pointer_cast(d_histogram_r.data()),
+    thrust::raw_pointer_cast(d_histogram_g.data()),
+    thrust::raw_pointer_cast(d_histogram_b.data())};
+
+  auto env = cuda::execution::tune(histogram_tuning<target_block_size>{});
+
+  multi_histogram_range<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
+    d_samples, d_histogram, num_levels, d_levels, num_pixels, env);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+#endif // TEST_LAUNCH != 1


### PR DESCRIPTION
- [x] Tiny SASS changes for `cub.bench.histogram.even.base` for SM`80;90;100`
- [x] Tiny SASS changes for `cub.bench.histogram.range.base` for SM`80;90;100`
- [x] Tiny SASS changes for `cub.bench.histogram.multi.even.base` for SM`80;90;100`
- [x] Tiny SASS changes for `cub.bench.histogram.multi.range.base` for SM`80;90;100`

All SASS diffs are caused by changing the PDL trigger value from 0 to 2028 and only affect how a predicate is computed in `DeviceHistogramInitKernel`.

Fixes: #8375