### PR TITLE
[FEA] Unify is_even functor

### DIFF
--- a/cub/test/catch2_test_device_select_api.cu
+++ b/cub/test/catch2_test_device_select_api.cu
@@ -9,19 +9,11 @@
 #include <thrust/equal.h>
 #include <thrust/memory.h>
 
+#include <cuda/functional>
+
 #include <cstddef>
 
 #include <c2h/catch2_test_helper.h>
-
-// example-begin segmented-select-iseven
-struct is_even_t
-{
-  __host__ __device__ bool operator()(int flag) const
-  {
-    return !(flag % 2);
-  }
-};
-// example-end segmented-select-iseven
 
 C2H_TEST("cub::DeviceSelect::FlaggedIf works with int data elements", "[select][device]")
 {
@@ -31,7 +23,7 @@ C2H_TEST("cub::DeviceSelect::FlaggedIf works with int data elements", "[select][
   c2h::device_vector<int> d_flags = {8, 6, 7, 5, 3, 0, 9, 3};
   c2h::device_vector<int> d_out(num_items);
   c2h::device_vector<int> d_num_selected_out(num_items);
-  is_even_t is_even{};
+  cuda::__is_even is_even{};
 
   // Determine temporary device storage requirements
   size_t temp_storage_bytes = 0;
@@ -74,7 +66,7 @@ C2H_TEST("cub::DeviceSelect::FlaggedIf in-place works with int data elements", "
   c2h::device_vector<int> d_data  = {0, 1, 2, 3, 4, 5, 6, 7};
   c2h::device_vector<int> d_flags = {8, 6, 7, 5, 3, 0, 9, 3};
   c2h::device_vector<int> d_num_selected_out(num_items);
-  is_even_t is_even{};
+  cuda::__is_even is_even{};
 
   // Determine temporary device storage requirements
   size_t temp_storage_bytes = 0;

--- a/cub/test/catch2_test_device_select_api.cu
+++ b/cub/test/catch2_test_device_select_api.cu
@@ -15,16 +15,6 @@
 
 #include "cub_test_macros.h"
 
-// example-begin segmented-select-iseven
-struct is_even_t
-{
-  __host__ __device__ bool operator()(int flag) const
-  {
-    return !(flag % 2);
-  }
-};
-// example-end segmented-select-iseven
-
 CUB_TEST("cub::DeviceSelect::FlaggedIf works with int data elements", "[select][device]", CUB_SMALL)
 {
   // example-begin segmented-select-flaggedif

--- a/cub/test/catch2_test_device_select_api.cu
+++ b/cub/test/catch2_test_device_select_api.cu
@@ -9,6 +9,8 @@
 #include <thrust/equal.h>
 #include <thrust/memory.h>
 
+#include <cuda/functional>
+
 #include <cstddef>
 
 #include "cub_test_macros.h"
@@ -31,7 +33,7 @@ CUB_TEST("cub::DeviceSelect::FlaggedIf works with int data elements", "[select][
   c2h::device_vector<int> d_flags = {8, 6, 7, 5, 3, 0, 9, 3};
   c2h::device_vector<int> d_out(num_items);
   c2h::device_vector<int> d_num_selected_out(num_items);
-  is_even_t is_even{};
+  cuda::__is_even is_even{};
 
   // Determine temporary device storage requirements
   size_t temp_storage_bytes = 0;
@@ -74,7 +76,7 @@ CUB_TEST("cub::DeviceSelect::FlaggedIf in-place works with int data elements", "
   c2h::device_vector<int> d_data  = {0, 1, 2, 3, 4, 5, 6, 7};
   c2h::device_vector<int> d_flags = {8, 6, 7, 5, 3, 0, 9, 3};
   c2h::device_vector<int> d_num_selected_out(num_items);
-  is_even_t is_even{};
+  cuda::__is_even is_even{};
 
   // Determine temporary device storage requirements
   size_t temp_storage_bytes = 0;

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -55,13 +55,9 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceSelect::FlaggedIf, select_flagged_if);
 
 using custom_t = c2h::custom_type_t<c2h::equal_comparable_t>;
 
-struct is_even_t
+struct is_even_t : cuda::__is_even
 {
-  template <typename T>
-  __host__ __device__ bool operator()(T const& elem) const
-  {
-    return cuda::__is_even{}(elem);
-  }
+  using __is_even::operator();
 
   template <template <typename> class... Policies>
   __host__ __device__ bool operator()(c2h::custom_type_t<Policies> elem) const

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -66,7 +66,7 @@ struct is_even_t
   template <template <typename> class... Policies>
   __host__ __device__ bool operator()(c2h::custom_type_t<Policies> elem) const
   {
-   return cuda::__is_even<int>{}(elem.key);
+    return cuda::__is_even<int>{}(elem.key);
   }
 };
 

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -10,6 +10,7 @@
 #include <thrust/logical.h>
 
 #include <cuda/devices>
+#include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/execution>
 
@@ -54,21 +55,18 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceSelect::FlaggedIf, select_flagged_if);
 
 using custom_t = c2h::custom_type_t<c2h::equal_comparable_t>;
 
-template <typename T>
 struct is_even_t
 {
+  template <typename T>
   __host__ __device__ bool operator()(T const& elem) const
   {
-    return !(elem % 2);
+    return cuda::__is_even<T>{}(elem);
   }
-};
 
-template <>
-struct is_even_t<custom_t>
-{
-  __host__ __device__ bool operator()(custom_t elem) const
+  template <template <typename> class... Policies>
+  __host__ __device__ bool operator()(c2h::custom_type_t<Policies> elem) const
   {
-    return !(elem.key % 2);
+   return cuda::__is_even<int>{}(elem.key);
   }
 };
 

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -60,13 +60,13 @@ struct is_even_t
   template <typename T>
   __host__ __device__ bool operator()(T const& elem) const
   {
-    return cuda::__is_even<T>{}(elem);
+    return cuda::__is_even{}(elem);
   }
 
   template <template <typename> class... Policies>
   __host__ __device__ bool operator()(c2h::custom_type_t<Policies> elem) const
   {
-    return cuda::__is_even<int>{}(elem.key);
+    return cuda::__is_even{}(elem.key);
   }
 };
 

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -170,7 +170,7 @@ C2H_TEST("DeviceSelect::FlaggedIf does not change input and is stable",
   c2h::device_vector<input_type> out(num_items);
   c2h::gen(C2H_SEED(2), in);
 
-  is_even_t<flag_type> is_even{};
+  is_even_t is_even{};
 
   c2h::device_vector<flag_type> flags(num_items);
   c2h::gen(C2H_SEED(1), flags);
@@ -211,7 +211,7 @@ C2H_TEST("DeviceSelect::FlaggedIf works with user provided memory and environmen
   c2h::device_vector<input_type> out(num_items, thrust::default_init);
   c2h::gen(C2H_SEED(2), in);
 
-  is_even_t<flag_type> is_even{};
+  is_even_t is_even{};
 
   c2h::device_vector<flag_type> flags(num_items, thrust::default_init);
   c2h::gen(C2H_SEED(1), flags);
@@ -322,7 +322,7 @@ C2H_TEST("DeviceSelect::FlaggedIf works in place with user provided memory and e
   c2h::device_vector<input_type> in(num_items, thrust::default_init);
   c2h::gen(C2H_SEED(2), in);
 
-  is_even_t<flag_type> is_even{};
+  is_even_t is_even{};
 
   c2h::device_vector<flag_type> flags(num_items, thrust::default_init);
   c2h::gen(C2H_SEED(1), flags);
@@ -430,7 +430,7 @@ C2H_TEST("DeviceSelect::FlaggedIf works with iterators", "[device][select_if]", 
   c2h::device_vector<input_type> out(num_items);
   c2h::gen(C2H_SEED(2), in);
 
-  is_even_t<flag_type> is_even{};
+  is_even_t is_even{};
 
   c2h::device_vector<flag_type> flags(num_items);
   c2h::gen(C2H_SEED(1), flags);
@@ -458,7 +458,7 @@ C2H_TEST("DeviceSelect::FlaggedIf works with pointers", "[device][select_flagged
   c2h::device_vector<input_type> out(num_items);
   c2h::gen(C2H_SEED(2), in);
 
-  is_even_t<flag_type> is_even{};
+  is_even_t is_even{};
 
   c2h::device_vector<flag_type> flags(num_items);
   c2h::gen(C2H_SEED(1), flags);

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -60,7 +60,7 @@ struct is_even_t : cuda::__is_even
   using __is_even::operator();
 
   template <template <typename> class... Policies>
-  __host__ __device__ bool operator()(c2h::custom_type_t<Policies> elem) const
+  __host__ __device__ bool operator()(c2h::custom_type_t<Policies...> elem) const
   {
     return cuda::__is_even{}(elem.key);
   }

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -457,7 +457,7 @@ CUB_TEST("DeviceSelect::FlaggedIf works with explicit prefetch policies",
   c2h::device_vector<int> flags(num_items);
   c2h::gen(C2H_SEED(1), flags);
 
-  const is_even_t<int> is_even{};
+  const is_even_t is_even{};
   const c2h::host_vector<int> reference = get_reference(in, flags, is_even);
   const int num_selected                = static_cast<int>(reference.size());
 

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -57,13 +57,9 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceSelect::FlaggedIf, select_flagged_if);
 
 using custom_t = c2h::custom_type_t<c2h::equal_comparable_t>;
 
-struct is_even_t
+struct is_even_t : cuda::__is_even
 {
-  template <typename T>
-  __host__ __device__ bool operator()(T const& elem) const
-  {
-    return cuda::__is_even{}(elem);
-  }
+  using __is_even::operator();
 
   template <template <typename> class... Policies>
   __host__ __device__ bool operator()(c2h::custom_type_t<Policies> elem) const

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -62,7 +62,7 @@ struct is_even_t : cuda::__is_even
   using __is_even::operator();
 
   template <template <typename> class... Policies>
-  __host__ __device__ bool operator()(c2h::custom_type_t<Policies> elem) const
+  __host__ __device__ bool operator()(c2h::custom_type_t<Policies...> elem) const
   {
     return cuda::__is_even{}(elem.key);
   }

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -68,7 +68,7 @@ struct is_even_t
   template <template <typename> class... Policies>
   __host__ __device__ bool operator()(c2h::custom_type_t<Policies> elem) const
   {
-   return cuda::__is_even<int>{}(elem.key);
+    return cuda::__is_even<int>{}(elem.key);
   }
 };
 

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -173,7 +173,7 @@ CUB_TEST("DeviceSelect::FlaggedIf does not change input and is stable",
   c2h::device_vector<input_type> out(num_items);
   c2h::gen(C2H_SEED(2), in);
 
-  is_even_t<flag_type> is_even{};
+  is_even_t is_even{};
 
   c2h::device_vector<flag_type> flags(num_items);
   c2h::gen(C2H_SEED(1), flags);
@@ -215,7 +215,7 @@ CUB_TEST("DeviceSelect::FlaggedIf works with user provided memory and environmen
   c2h::device_vector<input_type> out(num_items, thrust::default_init);
   c2h::gen(C2H_SEED(2), in);
 
-  is_even_t<flag_type> is_even{};
+  is_even_t is_even{};
 
   c2h::device_vector<flag_type> flags(num_items, thrust::default_init);
   c2h::gen(C2H_SEED(1), flags);
@@ -327,7 +327,7 @@ CUB_TEST("DeviceSelect::FlaggedIf works in place with user provided memory and e
   c2h::device_vector<input_type> in(num_items, thrust::default_init);
   c2h::gen(C2H_SEED(2), in);
 
-  is_even_t<flag_type> is_even{};
+  is_even_t is_even{};
 
   c2h::device_vector<flag_type> flags(num_items, thrust::default_init);
   c2h::gen(C2H_SEED(1), flags);
@@ -505,7 +505,7 @@ CUB_TEST("DeviceSelect::FlaggedIf works with iterators", "[device][select_if]", 
   c2h::device_vector<input_type> out(num_items);
   c2h::gen(C2H_SEED(2), in);
 
-  is_even_t<flag_type> is_even{};
+  is_even_t is_even{};
 
   c2h::device_vector<flag_type> flags(num_items);
   c2h::gen(C2H_SEED(1), flags);
@@ -533,7 +533,7 @@ CUB_TEST("DeviceSelect::FlaggedIf works with pointers", "[device][select_flagged
   c2h::device_vector<input_type> out(num_items);
   c2h::gen(C2H_SEED(2), in);
 
-  is_even_t<flag_type> is_even{};
+  is_even_t is_even{};
 
   c2h::device_vector<flag_type> flags(num_items);
   c2h::gen(C2H_SEED(1), flags);

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -62,13 +62,13 @@ struct is_even_t
   template <typename T>
   __host__ __device__ bool operator()(T const& elem) const
   {
-    return cuda::__is_even<T>{}(elem);
+    return cuda::__is_even{}(elem);
   }
 
   template <template <typename> class... Policies>
   __host__ __device__ bool operator()(c2h::custom_type_t<Policies> elem) const
   {
-    return cuda::__is_even<int>{}(elem.key);
+    return cuda::__is_even{}(elem.key);
   }
 };
 

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -12,6 +12,7 @@
 #include <thrust/logical.h>
 
 #include <cuda/devices>
+#include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/execution>
 
@@ -56,21 +57,18 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceSelect::FlaggedIf, select_flagged_if);
 
 using custom_t = c2h::custom_type_t<c2h::equal_comparable_t>;
 
-template <typename T>
 struct is_even_t
 {
+  template <typename T>
   __host__ __device__ bool operator()(T const& elem) const
   {
-    return !(elem % 2);
+    return cuda::__is_even<T>{}(elem);
   }
-};
 
-template <>
-struct is_even_t<custom_t>
-{
-  __host__ __device__ bool operator()(custom_t elem) const
+  template <template <typename> class... Policies>
+  __host__ __device__ bool operator()(c2h::custom_type_t<Policies> elem) const
   {
-    return !(elem.key % 2);
+   return cuda::__is_even<int>{}(elem.key);
   }
 };
 

--- a/cub/test/catch2_test_device_select_if_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_select_if_custom_policy_hub.cu
@@ -49,7 +49,7 @@ C2H_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]")
   expected.reserve(h_in.size());
   for (const auto value : h_in)
   {
-    if (cuda::__is_even<int>{}(value))
+    if (cuda::__is_even{}(value))
     {
       expected.push_back(value);
     }
@@ -61,7 +61,7 @@ C2H_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]")
                      NullType*,
                      value_t*,
                      offset_t*,
-                     cuda::__is_even<int>,
+                     cuda::__is_even,
                      NullType,
                      offset_t,
                      SelectImpl::Select,
@@ -75,7 +75,7 @@ C2H_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]")
     nullptr,
     thrust::raw_pointer_cast(d_out.data()),
     thrust::raw_pointer_cast(d_num_selected.data()),
-    cuda::__is_even<int>{},
+    cuda::__is_even{},
     NullType{},
     static_cast<offset_t>(h_in.size()),
     /* stream */ nullptr);
@@ -87,7 +87,7 @@ C2H_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]")
     nullptr,
     thrust::raw_pointer_cast(d_out.data()),
     thrust::raw_pointer_cast(d_num_selected.data()),
-    cuda::__is_even<int>{},
+    cuda::__is_even{},
     NullType{},
     static_cast<offset_t>(h_in.size()),
     /* stream */ nullptr);

--- a/cub/test/catch2_test_device_select_if_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_select_if_custom_policy_hub.cu
@@ -57,7 +57,15 @@ C2H_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]")
 
   using policy_hub_t = my_policy_hub<value_t>;
   using dispatch_t =
-    DispatchSelectIf<value_t*, NullType*, value_t*, offset_t*, cuda::__is_even<int>, NullType, offset_t, SelectImpl::Select, policy_hub_t>;
+    DispatchSelectIf<value_t*,
+                     NullType*,
+                     value_t*,
+                     offset_t*,
+                     cuda::__is_even<int>,
+                     NullType,
+                     offset_t,
+                     SelectImpl::Select,
+                     policy_hub_t>;
 
   size_t temp_size = 0;
   dispatch_t::Dispatch(

--- a/cub/test/catch2_test_device_select_if_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_select_if_custom_policy_hub.cu
@@ -11,7 +11,7 @@
 
 #include <thrust/detail/raw_pointer_cast.h>
 
-#include <cuda/std/functional>
+#include <cuda/functional>
 
 #include <c2h/catch2_test_helper.h>
 
@@ -35,14 +35,6 @@ struct my_policy_hub
   };
 };
 
-struct is_even_t
-{
-  __host__ __device__ bool operator()(int value) const
-  {
-    return (value & 1) == 0;
-  }
-};
-
 C2H_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]")
 {
   using value_t  = int;
@@ -57,7 +49,7 @@ C2H_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]")
   expected.reserve(h_in.size());
   for (const auto value : h_in)
   {
-    if (is_even_t{}(value))
+    if (cuda::__is_even<int>{}(value))
     {
       expected.push_back(value);
     }
@@ -65,7 +57,7 @@ C2H_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]")
 
   using policy_hub_t = my_policy_hub<value_t>;
   using dispatch_t =
-    DispatchSelectIf<value_t*, NullType*, value_t*, offset_t*, is_even_t, NullType, offset_t, SelectImpl::Select, policy_hub_t>;
+    DispatchSelectIf<value_t*, NullType*, value_t*, offset_t*, cuda::__is_even<int>, NullType, offset_t, SelectImpl::Select, policy_hub_t>;
 
   size_t temp_size = 0;
   dispatch_t::Dispatch(
@@ -75,7 +67,7 @@ C2H_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]")
     nullptr,
     thrust::raw_pointer_cast(d_out.data()),
     thrust::raw_pointer_cast(d_num_selected.data()),
-    is_even_t{},
+    cuda::__is_even<int>{},
     NullType{},
     static_cast<offset_t>(h_in.size()),
     /* stream */ nullptr);
@@ -87,7 +79,7 @@ C2H_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]")
     nullptr,
     thrust::raw_pointer_cast(d_out.data()),
     thrust::raw_pointer_cast(d_num_selected.data()),
-    is_even_t{},
+    cuda::__is_even<int>{},
     NullType{},
     static_cast<offset_t>(h_in.size()),
     /* stream */ nullptr);

--- a/cub/test/catch2_test_device_select_if_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_select_if_custom_policy_hub.cu
@@ -11,7 +11,7 @@
 
 #include <thrust/detail/raw_pointer_cast.h>
 
-#include <cuda/std/functional>
+#include <cuda/functional>
 
 #include "cub_test_macros.h"
 
@@ -57,7 +57,7 @@ CUB_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]",
   expected.reserve(h_in.size());
   for (const auto value : h_in)
   {
-    if (is_even_t{}(value))
+    if (cuda::__is_even<int>{}(value))
     {
       expected.push_back(value);
     }
@@ -65,7 +65,7 @@ CUB_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]",
 
   using policy_hub_t = my_policy_hub<value_t>;
   using dispatch_t =
-    DispatchSelectIf<value_t*, NullType*, value_t*, offset_t*, is_even_t, NullType, offset_t, SelectImpl::Select, policy_hub_t>;
+    DispatchSelectIf<value_t*, NullType*, value_t*, offset_t*, cuda::__is_even<int>, NullType, offset_t, SelectImpl::Select, policy_hub_t>;
 
   size_t temp_size = 0;
   dispatch_t::Dispatch(
@@ -75,7 +75,7 @@ CUB_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]",
     nullptr,
     thrust::raw_pointer_cast(d_out.data()),
     thrust::raw_pointer_cast(d_num_selected.data()),
-    is_even_t{},
+    cuda::__is_even<int>{},
     NullType{},
     static_cast<offset_t>(h_in.size()),
     /* stream */ nullptr);
@@ -87,7 +87,7 @@ CUB_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]",
     nullptr,
     thrust::raw_pointer_cast(d_out.data()),
     thrust::raw_pointer_cast(d_num_selected.data()),
-    is_even_t{},
+    cuda::__is_even<int>{},
     NullType{},
     static_cast<offset_t>(h_in.size()),
     /* stream */ nullptr);

--- a/cub/test/catch2_test_device_select_if_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_select_if_custom_policy_hub.cu
@@ -35,14 +35,6 @@ struct my_policy_hub
   };
 };
 
-struct is_even_t
-{
-  __host__ __device__ bool operator()(int value) const
-  {
-    return (value & 1) == 0;
-  }
-};
-
 CUB_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]", CUB_SMALL)
 {
   using value_t  = int;

--- a/cub/test/catch2_test_device_select_if_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_select_if_custom_policy_hub.cu
@@ -57,7 +57,7 @@ CUB_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]",
   expected.reserve(h_in.size());
   for (const auto value : h_in)
   {
-    if (cuda::__is_even<int>{}(value))
+    if (cuda::__is_even{}(value))
     {
       expected.push_back(value);
     }
@@ -69,7 +69,7 @@ CUB_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]",
                      NullType*,
                      value_t*,
                      offset_t*,
-                     cuda::__is_even<int>,
+                     cuda::__is_even,
                      NullType,
                      offset_t,
                      SelectImpl::Select,
@@ -83,7 +83,7 @@ CUB_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]",
     nullptr,
     thrust::raw_pointer_cast(d_out.data()),
     thrust::raw_pointer_cast(d_num_selected.data()),
-    cuda::__is_even<int>{},
+    cuda::__is_even{},
     NullType{},
     static_cast<offset_t>(h_in.size()),
     /* stream */ nullptr);
@@ -95,7 +95,7 @@ CUB_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]",
     nullptr,
     thrust::raw_pointer_cast(d_out.data()),
     thrust::raw_pointer_cast(d_num_selected.data()),
-    cuda::__is_even<int>{},
+    cuda::__is_even{},
     NullType{},
     static_cast<offset_t>(h_in.size()),
     /* stream */ nullptr);

--- a/cub/test/catch2_test_device_select_if_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_select_if_custom_policy_hub.cu
@@ -65,7 +65,15 @@ CUB_TEST("DispatchSelectIf::Dispatch: custom policy hub", "[select_if][device]",
 
   using policy_hub_t = my_policy_hub<value_t>;
   using dispatch_t =
-    DispatchSelectIf<value_t*, NullType*, value_t*, offset_t*, cuda::__is_even<int>, NullType, offset_t, SelectImpl::Select, policy_hub_t>;
+    DispatchSelectIf<value_t*,
+                     NullType*,
+                     value_t*,
+                     offset_t*,
+                     cuda::__is_even<int>,
+                     NullType,
+                     offset_t,
+                     SelectImpl::Select,
+                     policy_hub_t>;
 
   size_t temp_size = 0;
   dispatch_t::Dispatch(

--- a/libcudacxx/benchmarks/bench/copy_if/basic.cu
+++ b/libcudacxx/benchmarks/bench/copy_if/basic.cu
@@ -17,15 +17,6 @@
 
 #include "nvbench_helper.cuh"
 
-struct is_even
-{
-  template <class T>
-  __device__ constexpr bool operator()(const T& val) const noexcept
-  {
-    return static_cast<int>(val) % 2 == 0;
-  }
-};
-
 template <typename T>
 static void basic(nvbench::state& state, nvbench::type_list<T>)
 {

--- a/libcudacxx/benchmarks/bench/copy_if/basic.cu
+++ b/libcudacxx/benchmarks/bench/copy_if/basic.cu
@@ -31,11 +31,11 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
 
   caching_allocator_t alloc{};
 
-  state.exec(
-    nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-      do_not_optimize(
-        cuda::std::copy_if(cuda_policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even{}));
-    });
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               do_not_optimize(
+                 cuda::std::copy_if(cuda_policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even{}));
+             });
 }
 
 NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))

--- a/libcudacxx/benchmarks/bench/copy_if/basic.cu
+++ b/libcudacxx/benchmarks/bench/copy_if/basic.cu
@@ -42,7 +42,8 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
 
   state.exec(
     nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-      do_not_optimize(cuda::std::copy_if(cuda_policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even<T>{}));
+      do_not_optimize(
+        cuda::std::copy_if(cuda_policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even<T>{}));
     });
 }
 

--- a/libcudacxx/benchmarks/bench/copy_if/basic.cu
+++ b/libcudacxx/benchmarks/bench/copy_if/basic.cu
@@ -34,7 +34,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
   state.exec(
     nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
       do_not_optimize(
-        cuda::std::copy_if(cuda_policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even<T>{}));
+        cuda::std::copy_if(cuda_policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even{}));
     });
 }
 

--- a/libcudacxx/benchmarks/bench/copy_if/basic.cu
+++ b/libcudacxx/benchmarks/bench/copy_if/basic.cu
@@ -10,6 +10,7 @@
 
 #include <thrust/device_vector.h>
 
+#include <cuda/functional>
 #include <cuda/memory_pool>
 #include <cuda/std/execution>
 #include <cuda/stream>
@@ -41,7 +42,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
 
   state.exec(
     nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-      do_not_optimize(cuda::std::copy_if(cuda_policy(alloc, launch), in.begin(), in.end(), out.begin(), is_even{}));
+      do_not_optimize(cuda::std::copy_if(cuda_policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even<T>{}));
     });
 }
 

--- a/libcudacxx/benchmarks/bench/remove_copy_if/basic.cu
+++ b/libcudacxx/benchmarks/bench/remove_copy_if/basic.cu
@@ -17,15 +17,6 @@
 
 #include "nvbench_helper.cuh"
 
-struct is_even
-{
-  template <class T>
-  __device__ constexpr bool operator()(const T& val) const noexcept
-  {
-    return static_cast<int>(val) % 2 == 0;
-  }
-};
-
 template <typename T>
 static void basic(nvbench::state& state, nvbench::type_list<T>)
 {

--- a/libcudacxx/benchmarks/bench/remove_copy_if/basic.cu
+++ b/libcudacxx/benchmarks/bench/remove_copy_if/basic.cu
@@ -40,11 +40,11 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
 
   caching_allocator_t alloc{};
 
-  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
-             [&](nvbench::launch& launch) {
-               do_not_optimize(
-                 cuda::std::remove_copy_if(cuda_policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even<T>{}));
-             });
+  state.exec(
+    nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+      do_not_optimize(
+        cuda::std::remove_copy_if(cuda_policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even<T>{}));
+    });
 }
 
 NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))

--- a/libcudacxx/benchmarks/bench/remove_copy_if/basic.cu
+++ b/libcudacxx/benchmarks/bench/remove_copy_if/basic.cu
@@ -34,7 +34,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
   state.exec(
     nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
       do_not_optimize(
-        cuda::std::remove_copy_if(cuda_policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even<T>{}));
+        cuda::std::remove_copy_if(cuda_policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even{}));
     });
 }
 

--- a/libcudacxx/benchmarks/bench/remove_copy_if/basic.cu
+++ b/libcudacxx/benchmarks/bench/remove_copy_if/basic.cu
@@ -10,6 +10,7 @@
 
 #include <thrust/device_vector.h>
 
+#include <cuda/functional>
 #include <cuda/memory_pool>
 #include <cuda/std/execution>
 #include <cuda/stream>
@@ -42,7 +43,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch) {
                do_not_optimize(
-                 cuda::std::remove_copy_if(cuda_policy(alloc, launch), in.begin(), in.end(), out.begin(), is_even{}));
+                 cuda::std::remove_copy_if(cuda_policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even<T>{}));
              });
 }
 

--- a/libcudacxx/benchmarks/bench/remove_if/basic.cu
+++ b/libcudacxx/benchmarks/bench/remove_if/basic.cu
@@ -17,15 +17,6 @@
 
 #include "nvbench_helper.cuh"
 
-struct is_even
-{
-  template <class T>
-  __device__ constexpr bool operator()(const T& val) const noexcept
-  {
-    return static_cast<int>(val) % 2 == 0;
-  }
-};
-
 template <typename T>
 static void basic(nvbench::state& state, nvbench::type_list<T>)
 {

--- a/libcudacxx/benchmarks/bench/remove_if/basic.cu
+++ b/libcudacxx/benchmarks/bench/remove_if/basic.cu
@@ -10,6 +10,7 @@
 
 #include <thrust/device_vector.h>
 
+#include <cuda/functional>
 #include <cuda/memory_pool>
 #include <cuda/std/execution>
 #include <cuda/stream>
@@ -40,7 +41,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
 
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch) {
-               cuda::std::remove_if(cuda_policy(alloc, launch), in.begin(), in.end(), is_even{});
+               cuda::std::remove_if(cuda_policy(alloc, launch), in.begin(), in.end(), cuda::__is_even<T>{});
              });
 }
 

--- a/libcudacxx/benchmarks/bench/remove_if/basic.cu
+++ b/libcudacxx/benchmarks/bench/remove_if/basic.cu
@@ -32,7 +32,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
 
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch) {
-               cuda::std::remove_if(cuda_policy(alloc, launch), in.begin(), in.end(), cuda::__is_even<T>{});
+               cuda::std::remove_if(cuda_policy(alloc, launch), in.begin(), in.end(), cuda::__is_even{});
              });
 }
 

--- a/libcudacxx/include/cuda/__functional/is_even.h
+++ b/libcudacxx/include/cuda/__functional/is_even.h
@@ -4,12 +4,12 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_FUNCTIONAL_
-#define _CUDA_FUNCTIONAL_
+#ifndef _CUDA___FUNCTIONAL_IS_EVEN_H
+#define _CUDA___FUNCTIONAL_IS_EVEN_H
 
 #include <cuda/std/detail/__config>
 
@@ -21,16 +21,25 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__functional/address_stability.h>
-#include <cuda/__functional/always_true_false.h>
-#include <cuda/__functional/equal_to_value.h>
-#include <cuda/__functional/is_even.h>
-#include <cuda/__functional/maximum.h>
-#include <cuda/__functional/minimum.h>
-#include <cuda/__functional/operator_properties.h>
-#include <cuda/__functional/proclaim_return_type.h>
-#include <cuda/__iterator/zip_function.h>
-#include <cuda/__memory/get_device_address.h>
-#include <cuda/std/functional>
+#include <cuda/std/__type_traits/is_integral.h>
 
-#endif // _CUDA_FUNCTIONAL_
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+//! @brief `is_even` is a function object that checks if a value is even.
+struct __is_even
+{
+  _CCCL_TEMPLATE(class _Tp)
+  _CCCL_REQUIRES(::cuda::std::is_integral_v<_Tp>)
+  [[nodiscard]] _CCCL_API _CCCL_HOST_DEVICE constexpr bool operator()(const _Tp& __value) const noexcept
+  {
+    return (__value & 1) == 0;
+  }
+};
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___FUNCTIONAL_IS_EVEN_H

--- a/libcudacxx/include/cuda/__functional/is_even.h
+++ b/libcudacxx/include/cuda/__functional/is_even.h
@@ -21,9 +21,6 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__type_traits/is_integral.h>
-#include <cuda/std/__type_traits/remove_cvref.h>
-
 #include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA
@@ -31,12 +28,10 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 //! @brief `__is_even` is a function object that checks if an integral value is even.
 struct __is_even
 {
-  _CCCL_TEMPLATE(class _Tp)
-  _CCCL_REQUIRES(::cuda::std::is_integral_v<::cuda::std::remove_cvref_t<_Tp>>)
+  template <class _Tp>
   [[nodiscard]] _CCCL_API _CCCL_HOST_DEVICE constexpr bool operator()(const _Tp& __value) const noexcept
   {
-    using _Up = ::cuda::std::remove_cvref_t<_Tp>;
-    return (static_cast<_Up>(__value) & 1) == 0;
+    return (static_cast<long long>(__value) & 1) == 0;
   }
 };
 

--- a/libcudacxx/include/cuda/__functional/is_even.h
+++ b/libcudacxx/include/cuda/__functional/is_even.h
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/remove_cvref.h>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -31,10 +32,11 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 struct __is_even
 {
   _CCCL_TEMPLATE(class _Tp)
-  _CCCL_REQUIRES(::cuda::std::is_integral_v<_Tp>)
+  _CCCL_REQUIRES(::cuda::std::is_integral_v<::cuda::std::remove_cvref_t<_Tp>>)
   [[nodiscard]] _CCCL_API _CCCL_HOST_DEVICE constexpr bool operator()(const _Tp& __value) const noexcept
   {
-    return (__value & 1) == 0;
+    using _Up = ::cuda::std::remove_cvref_t<_Tp>;
+    return (static_cast<_Up>(__value) & 1) == 0;
   }
 };
 

--- a/libcudacxx/include/cuda/__functional/is_even.h
+++ b/libcudacxx/include/cuda/__functional/is_even.h
@@ -27,12 +27,23 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
-//! @brief `is_even` is a function object that checks if a value is even.
+//! @brief `is_even` is a function object that checks if a value is even (const).
 struct __is_even
 {
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(::cuda::std::is_integral_v<_Tp>)
   [[nodiscard]] _CCCL_API _CCCL_HOST_DEVICE constexpr bool operator()(const _Tp& __value) const noexcept
+  {
+    return (__value & 1) == 0;
+  }
+};
+
+//! @brief `is_even_no_const` is a function object that checks if a value is even (non-const).
+struct __is_even_no_const
+{
+  _CCCL_TEMPLATE(class _Tp)
+  _CCCL_REQUIRES(::cuda::std::is_integral_v<_Tp>)
+  [[nodiscard]] _CCCL_API _CCCL_HOST_DEVICE constexpr bool operator()(const _Tp& __value) /* no const */ noexcept
   {
     return (__value & 1) == 0;
   }

--- a/libcudacxx/include/cuda/__functional/is_even.h
+++ b/libcudacxx/include/cuda/__functional/is_even.h
@@ -27,23 +27,12 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
-//! @brief `is_even` is a function object that checks if a value is even (const).
+//! @brief `__is_even` is a function object that checks if an integral value is even.
 struct __is_even
 {
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(::cuda::std::is_integral_v<_Tp>)
   [[nodiscard]] _CCCL_API _CCCL_HOST_DEVICE constexpr bool operator()(const _Tp& __value) const noexcept
-  {
-    return (__value & 1) == 0;
-  }
-};
-
-//! @brief `is_even_no_const` is a function object that checks if a value is even (non-const).
-struct __is_even_no_const
-{
-  _CCCL_TEMPLATE(class _Tp)
-  _CCCL_REQUIRES(::cuda::std::is_integral_v<_Tp>)
-  [[nodiscard]] _CCCL_API _CCCL_HOST_DEVICE constexpr bool operator()(const _Tp& __value) /* no const */ noexcept
   {
     return (__value & 1) == 0;
   }

--- a/libcudacxx/include/cuda/__functional/is_even.h
+++ b/libcudacxx/include/cuda/__functional/is_even.h
@@ -31,7 +31,7 @@ struct __is_even
   template <class _Tp>
   [[nodiscard]] _CCCL_API constexpr bool operator()(const _Tp& __value) const noexcept
   {
-    return (static_cast<long long>(__value) & 1) == 0;
+    return __value % 2 == 0;
   }
 };
 

--- a/libcudacxx/include/cuda/__functional/is_even.h
+++ b/libcudacxx/include/cuda/__functional/is_even.h
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___FUNCTIONAL_IS_EVEN_H
+#define _CUDA___FUNCTIONAL_IS_EVEN_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__type_traits/is_integral.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+//! @brief `is_even` is a function object that checks if a value is even.
+struct __is_even
+{
+  _CCCL_TEMPLATE(class _Tp)
+  _CCCL_REQUIRES(::cuda::std::is_integral_v<_Tp>)
+  [[nodiscard]] _CCCL_API _CCCL_HOST_DEVICE constexpr bool operator()(const _Tp& __value) const noexcept
+  {
+    return (__value & 1) == 0;
+  }
+};
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___FUNCTIONAL_IS_EVEN_H

--- a/libcudacxx/include/cuda/__functional/is_even.h
+++ b/libcudacxx/include/cuda/__functional/is_even.h
@@ -29,7 +29,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 struct __is_even
 {
   template <class _Tp>
-  [[nodiscard]] _CCCL_API _CCCL_HOST_DEVICE constexpr bool operator()(const _Tp& __value) const noexcept
+  [[nodiscard]] _CCCL_API constexpr bool operator()(const _Tp& __value) const noexcept
   {
     return (static_cast<long long>(__value) & 1) == 0;
   }

--- a/libcudacxx/include/cuda/functional
+++ b/libcudacxx/include/cuda/functional
@@ -25,6 +25,7 @@
 #include <cuda/__functional/always_true_false.h>
 #include <cuda/__functional/equal_to_value.h>
 #include <cuda/__functional/hash.h>
+#include <cuda/__functional/is_even.h>
 #include <cuda/__functional/maximum.h>
 #include <cuda/__functional/minimum.h>
 #include <cuda/__functional/operator_properties.h>

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_if.pass.cpp
@@ -8,23 +8,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/functional>
 #include <cuda/std/algorithm.find_if.h>
 #include <cuda/std/cassert>
 
 #include "test_macros.h"
 
-struct find_if_is_even
-{
-  TEST_FUNC constexpr bool operator()(int x) const
-  {
-    return x % 2 == 0;
-  }
-};
-
 TEST_FUNC constexpr bool test()
 {
   constexpr int a[] = {1, 2, 3};
-  assert(*cuda::std::find_if(a, a + 3, find_if_is_even{}) == 2);
+  assert(*cuda::std::find_if(a, a + 3, cuda::__is_even<int>{}) == 2);
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_if.pass.cpp
@@ -17,7 +17,7 @@
 TEST_FUNC constexpr bool test()
 {
   constexpr int a[] = {1, 2, 3};
-  assert(*cuda::std::find_if(a, a + 3, cuda::__is_even<int>{}) == 2);
+  assert(*cuda::std::find_if(a, a + 3, cuda::__is_even{}) == 2);
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_if_not.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_if_not.pass.cpp
@@ -17,7 +17,7 @@
 TEST_FUNC constexpr bool test()
 {
   constexpr int a[] = {2, 4, 5};
-  assert(*cuda::std::find_if_not(a, a + 3, cuda::std::not_fn(cuda::__is_even<int>{})) == 5);
+  assert(*cuda::std::find_if_not(a, a + 3, cuda::std::not_fn(cuda::__is_even{})) == 5);
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_if_not.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_if_not.pass.cpp
@@ -8,23 +8,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/functional>
 #include <cuda/std/algorithm.find_if_not.h>
 #include <cuda/std/cassert>
 
 #include "test_macros.h"
 
-struct find_if_not_is_even
-{
-  TEST_FUNC constexpr bool operator()(int x) const
-  {
-    return x % 2 == 0;
-  }
-};
-
 TEST_FUNC constexpr bool test()
 {
   constexpr int a[] = {2, 4, 5};
-  assert(*cuda::std::find_if_not(a, a + 3, find_if_not_is_even{}) == 5);
+  assert(*cuda::std::find_if_not(a, a + 3, cuda::std::not_fn(cuda::__is_even<int>{})) == 5);
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_if_not.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_if_not.pass.cpp
@@ -17,7 +17,7 @@
 TEST_FUNC constexpr bool test()
 {
   constexpr int a[] = {2, 4, 5};
-  assert(*cuda::std::find_if_not(a, a + 3, cuda::std::not_fn(cuda::__is_even{})) == 5);
+  assert(*cuda::std::find_if_not(a, a + 3, cuda::__is_even{}) == 5);
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/is_partitioned.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/is_partitioned.pass.cpp
@@ -8,23 +8,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/functional>
 #include <cuda/std/algorithm.is_partitioned.h>
 #include <cuda/std/cassert>
 
 #include "test_macros.h"
 
-struct is_partitioned_is_even
-{
-  TEST_FUNC constexpr bool operator()(int x) const
-  {
-    return x % 2 == 0;
-  }
-};
-
 TEST_FUNC constexpr bool test()
 {
   constexpr int a[] = {2, 4, 1, 3};
-  assert(cuda::std::is_partitioned(a, a + 4, is_partitioned_is_even{}));
+  assert(cuda::std::is_partitioned(a, a + 4, cuda::__is_even<int>{}));
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/is_partitioned.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/is_partitioned.pass.cpp
@@ -17,7 +17,7 @@
 TEST_FUNC constexpr bool test()
 {
   constexpr int a[] = {2, 4, 1, 3};
-  assert(cuda::std::is_partitioned(a, a + 4, cuda::__is_even<int>{}));
+  assert(cuda::std::is_partitioned(a, a + 4, cuda::__is_even{}));
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition.pass.cpp
@@ -11,23 +11,16 @@
 // UNSUPPORTED: enable-tile
 // error: a return statement inside a loop is not currently supported in a tile function
 
+#include <cuda/functional>
 #include <cuda/std/algorithm.partition.h>
 #include <cuda/std/cassert>
 
 #include "test_macros.h"
 
-struct partition_is_even
-{
-  TEST_FUNC constexpr bool operator()(int x) const
-  {
-    return x % 2 == 0;
-  }
-};
-
 TEST_FUNC constexpr bool test()
 {
   int a[] = {1, 2, 3, 4};
-  auto p  = cuda::std::partition(a, a + 4, partition_is_even{});
+  auto p  = cuda::std::partition(a, a + 4, cuda::__is_even<int>{});
   assert(p == a + 2);
 
   return true;

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition.pass.cpp
@@ -20,7 +20,7 @@
 TEST_FUNC constexpr bool test()
 {
   int a[] = {1, 2, 3, 4};
-  auto p  = cuda::std::partition(a, a + 4, cuda::__is_even<int>{});
+  auto p  = cuda::std::partition(a, a + 4, cuda::__is_even{});
   assert(p == a + 2);
 
   return true;

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition.pass.cpp
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/functional>
 #include <cuda/std/algorithm.partition.h>
 #include <cuda/std/cassert>
 

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition.pass.cpp
@@ -13,18 +13,10 @@
 
 #include "test_macros.h"
 
-struct partition_is_even
-{
-  TEST_FUNC constexpr bool operator()(int x) const
-  {
-    return x % 2 == 0;
-  }
-};
-
 TEST_FUNC constexpr bool test()
 {
   int a[] = {1, 2, 3, 4};
-  auto p  = cuda::std::partition(a, a + 4, partition_is_even{});
+  auto p  = cuda::std::partition(a, a + 4, cuda::__is_even<int>{});
   assert(p == a + 2);
 
   return true;

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition.pass.cpp
@@ -16,7 +16,7 @@
 TEST_FUNC constexpr bool test()
 {
   int a[] = {1, 2, 3, 4};
-  auto p  = cuda::std::partition(a, a + 4, cuda::__is_even<int>{});
+  auto p  = cuda::std::partition(a, a + 4, cuda::__is_even{});
   assert(p == a + 2);
 
   return true;

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition_copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition_copy.pass.cpp
@@ -8,25 +8,18 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/functional>
 #include <cuda/std/algorithm.partition_copy.h>
 #include <cuda/std/cassert>
 
 #include "test_macros.h"
-
-struct partition_copy_is_even
-{
-  TEST_FUNC constexpr bool operator()(int x) const
-  {
-    return x % 2 == 0;
-  }
-};
 
 TEST_FUNC constexpr bool test()
 {
   constexpr int a[] = {1, 2, 3, 4};
   int t[4]          = {};
   int f[4]          = {};
-  auto p            = cuda::std::partition_copy(a, a + 4, t, f, partition_copy_is_even{});
+  auto p            = cuda::std::partition_copy(a, a + 4, t, f, cuda::__is_even<int>{});
   assert(p.first == t + 2 && p.second == f + 2);
 
   return true;

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition_copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition_copy.pass.cpp
@@ -19,7 +19,7 @@ TEST_FUNC constexpr bool test()
   constexpr int a[] = {1, 2, 3, 4};
   int t[4]          = {};
   int f[4]          = {};
-  auto p            = cuda::std::partition_copy(a, a + 4, t, f, cuda::__is_even<int>{});
+  auto p            = cuda::std::partition_copy(a, a + 4, t, f, cuda::__is_even{});
   assert(p.first == t + 2 && p.second == f + 2);
 
   return true;

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition_point.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition_point.pass.cpp
@@ -8,23 +8,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/functional>
 #include <cuda/std/algorithm.partition_point.h>
 #include <cuda/std/cassert>
 
 #include "test_macros.h"
 
-struct partition_point_is_even
-{
-  TEST_FUNC constexpr bool operator()(int x) const
-  {
-    return x % 2 == 0;
-  }
-};
-
 TEST_FUNC constexpr bool test()
 {
   constexpr int a[] = {2, 4, 5, 7};
-  auto p            = cuda::std::partition_point(a, a + 4, partition_point_is_even{});
+  auto p            = cuda::std::partition_point(a, a + 4, cuda::__is_even<int>{});
   assert(p == a + 2);
 
   return true;

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition_point.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition_point.pass.cpp
@@ -17,7 +17,7 @@
 TEST_FUNC constexpr bool test()
 {
   constexpr int a[] = {2, 4, 5, 7};
-  auto p            = cuda::std::partition_point(a, a + 4, cuda::__is_even<int>{});
+  auto p            = cuda::std::partition_point(a, a + 4, cuda::__is_even{});
   assert(p == a + 2);
 
   return true;

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_partition.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_partition.cu
@@ -42,13 +42,13 @@ void test_partition(const Policy& policy, c2h::device_vector<T>& input)
   const auto mid = size / 2;
 
   { // Empty does not access anything
-    auto res = cuda::std::partition(policy, static_cast<T*>(nullptr), static_cast<T*>(nullptr), cuda::__is_even<T>{});
+    auto res = cuda::std::partition(policy, static_cast<T*>(nullptr), static_cast<T*>(nullptr), cuda::__is_even{});
     CHECK(res == nullptr);
   }
 
   thrust::sequence(input.begin(), input.end(), static_cast<T>(0));
   { // contiguous
-    auto res = cuda::std::partition(policy, input.begin(), input.end(), cuda::__is_even<T>{});
+    auto res = cuda::std::partition(policy, input.begin(), input.end(), cuda::__is_even{});
     CHECK(res == cuda::std::next(input.begin(), mid));
     CHECK(cuda::std::equal(
       policy, input.begin(), res, cuda::strided_iterator{cuda::counting_iterator{static_cast<T>(0)}, 2}));
@@ -60,7 +60,7 @@ void test_partition(const Policy& policy, c2h::device_vector<T>& input)
   thrust::sequence(input.begin(), input.end(), static_cast<T>(0));
   { // random access
     auto res = cuda::std::partition(
-      policy, random_access_iterator{raw}, random_access_iterator{raw + size}, cuda::__is_even<T>{});
+      policy, random_access_iterator{raw}, random_access_iterator{raw + size}, cuda::__is_even{});
     CHECK(res == random_access_iterator{raw + mid});
     CHECK(cuda::std::equal(policy,
                            input.begin(),
@@ -75,7 +75,7 @@ void test_partition(const Policy& policy, c2h::device_vector<T>& input)
 
   thrust::sequence(input.begin(), input.end(), static_cast<T>(0));
   { // converting predicate
-    auto res = cuda::std::partition(policy, input.begin(), input.end(), cuda::__is_even<long>{});
+    auto res = cuda::std::partition(policy, input.begin(), input.end(), cuda::__is_even{});
     CHECK(res == cuda::std::next(input.begin(), mid));
     CHECK(cuda::std::equal(
       policy, input.begin(), res, cuda::strided_iterator{cuda::counting_iterator{static_cast<T>(0)}, 2}));

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_partition.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_partition.cu
@@ -59,8 +59,8 @@ void test_partition(const Policy& policy, c2h::device_vector<T>& input)
 
   thrust::sequence(input.begin(), input.end(), static_cast<T>(0));
   { // random access
-    auto res =
-      cuda::std::partition(policy, random_access_iterator{raw}, random_access_iterator{raw + size}, cuda::__is_even<T>{});
+    auto res = cuda::std::partition(
+      policy, random_access_iterator{raw}, random_access_iterator{raw + size}, cuda::__is_even<T>{});
     CHECK(res == random_access_iterator{raw + mid});
     CHECK(cuda::std::equal(policy,
                            input.begin(),

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_partition.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_partition.cu
@@ -59,8 +59,8 @@ void test_partition(const Policy& policy, c2h::device_vector<T>& input)
 
   thrust::sequence(input.begin(), input.end(), static_cast<T>(0));
   { // random access
-    auto res = cuda::std::partition(
-      policy, random_access_iterator{raw}, random_access_iterator{raw + size}, cuda::__is_even{});
+    auto res =
+      cuda::std::partition(policy, random_access_iterator{raw}, random_access_iterator{raw + size}, cuda::__is_even{});
     CHECK(res == random_access_iterator{raw + mid});
     CHECK(cuda::std::equal(policy,
                            input.begin(),

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_partition.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_partition.cu
@@ -19,6 +19,7 @@
 #include <thrust/sequence.h>
 
 #include <cuda/cmath>
+#include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/memory_pool>
 #include <cuda/std/algorithm>
@@ -34,15 +35,6 @@
 
 inline constexpr int size = 1000;
 
-template <class T>
-struct is_even
-{
-  [[nodiscard]] TEST_DEVICE_FUNC constexpr bool operator()(T value) const noexcept
-  {
-    return value % 2 == 0;
-  }
-};
-
 template <class Policy, class T>
 void test_partition(const Policy& policy, c2h::device_vector<T>& input)
 {
@@ -50,13 +42,13 @@ void test_partition(const Policy& policy, c2h::device_vector<T>& input)
   const auto mid = size / 2;
 
   { // Empty does not access anything
-    auto res = cuda::std::partition(policy, static_cast<T*>(nullptr), static_cast<T*>(nullptr), is_even<T>{});
+    auto res = cuda::std::partition(policy, static_cast<T*>(nullptr), static_cast<T*>(nullptr), cuda::__is_even<T>{});
     CHECK(res == nullptr);
   }
 
   thrust::sequence(input.begin(), input.end(), static_cast<T>(0));
   { // contiguous
-    auto res = cuda::std::partition(policy, input.begin(), input.end(), is_even<T>{});
+    auto res = cuda::std::partition(policy, input.begin(), input.end(), cuda::__is_even<T>{});
     CHECK(res == cuda::std::next(input.begin(), mid));
     CHECK(cuda::std::equal(
       policy, input.begin(), res, cuda::strided_iterator{cuda::counting_iterator{static_cast<T>(0)}, 2}));
@@ -68,7 +60,7 @@ void test_partition(const Policy& policy, c2h::device_vector<T>& input)
   thrust::sequence(input.begin(), input.end(), static_cast<T>(0));
   { // random access
     auto res =
-      cuda::std::partition(policy, random_access_iterator{raw}, random_access_iterator{raw + size}, is_even<T>{});
+      cuda::std::partition(policy, random_access_iterator{raw}, random_access_iterator{raw + size}, cuda::__is_even<T>{});
     CHECK(res == random_access_iterator{raw + mid});
     CHECK(cuda::std::equal(policy,
                            input.begin(),
@@ -83,7 +75,7 @@ void test_partition(const Policy& policy, c2h::device_vector<T>& input)
 
   thrust::sequence(input.begin(), input.end(), static_cast<T>(0));
   { // converting predicate
-    auto res = cuda::std::partition(policy, input.begin(), input.end(), is_even<long>{});
+    auto res = cuda::std::partition(policy, input.begin(), input.end(), cuda::__is_even<long>{});
     CHECK(res == cuda::std::next(input.begin(), mid));
     CHECK(cuda::std::equal(
       policy, input.begin(), res, cuda::strided_iterator{cuda::counting_iterator{static_cast<T>(0)}, 2}));

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_partition_copy.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_partition_copy.cu
@@ -21,6 +21,7 @@
 #include <thrust/sequence.h>
 
 #include <cuda/cmath>
+#include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/memory_pool>
 #include <cuda/std/execution>
@@ -36,15 +37,6 @@
 
 inline constexpr int size = 1000;
 
-template <class T>
-struct is_even
-{
-  [[nodiscard]] TEST_DEVICE_FUNC constexpr bool operator()(T value) const noexcept
-  {
-    return value % 2 == 0;
-  }
-};
-
 template <class Policy, class T>
 void test_partition_copy(const Policy& policy,
                          const c2h::device_vector<T>& input,
@@ -58,7 +50,7 @@ void test_partition_copy(const Policy& policy,
       static_cast<T*>(nullptr),
       static_cast<T*>(nullptr),
       static_cast<T*>(nullptr),
-      is_even<T>{});
+      cuda::__is_even<T>{});
     CHECK(res.first == nullptr);
     CHECK(res.second == nullptr);
   }
@@ -70,7 +62,7 @@ void test_partition_copy(const Policy& policy,
   cuda::std::fill(policy, output_false.begin(), output_false.end(), static_cast<T>(-1));
   { // contiguous iterators
     auto res = cuda::std::partition_copy(
-      policy, input.begin(), input.end(), output_true.begin(), output_false.begin(), is_even<T>{});
+      policy, input.begin(), input.end(), output_true.begin(), output_false.begin(), cuda::__is_even<T>{});
     CHECK(res == cuda::std::pair{output_true.end(), output_false.end()});
     CHECK(cuda::std::equal(policy, output_true.begin(), output_true.end(), expected_true));
     CHECK(cuda::std::equal(policy, output_false.begin(), output_false.end(), expected_false));
@@ -86,7 +78,7 @@ void test_partition_copy(const Policy& policy,
       random_access_iterator{raw_in + size},
       output_true.begin(),
       output_false.begin(),
-      is_even<T>{});
+      cuda::__is_even<T>{});
     CHECK(res == cuda::std::pair{output_true.end(), output_false.end()});
     CHECK(cuda::std::equal(policy, output_true.begin(), output_true.end(), expected_true));
     CHECK(cuda::std::equal(policy, output_false.begin(), output_false.end(), expected_false));
@@ -103,7 +95,7 @@ void test_partition_copy(const Policy& policy,
       input.end(),
       random_access_iterator{raw_true},
       random_access_iterator{raw_false},
-      is_even<T>{});
+      cuda::__is_even<T>{});
     CHECK(
       res
       == cuda::std::pair{random_access_iterator{raw_true + size / 2}, random_access_iterator{raw_false + size / 2}});
@@ -120,7 +112,7 @@ void test_partition_copy(const Policy& policy,
       cuda::counting_iterator<T>{static_cast<T>(size)},
       output_true.begin(),
       output_false.begin(),
-      is_even<T>{});
+      cuda::__is_even<T>{});
     CHECK(res == cuda::std::pair{output_true.end(), output_false.end()});
     CHECK(cuda::std::equal(policy, output_true.begin(), output_true.end(), expected_true));
     CHECK(cuda::std::equal(policy, output_false.begin(), output_false.end(), expected_false));
@@ -135,7 +127,7 @@ void test_partition_copy(const Policy& policy,
       cuda::counting_iterator<short>{static_cast<short>(size)},
       output_true.begin(),
       output_false.begin(),
-      is_even<short>{});
+      cuda::__is_even<short>{});
     CHECK(res == cuda::std::pair{output_true.end(), output_false.end()});
     CHECK(cuda::std::equal(policy, output_true.begin(), output_true.end(), expected_true));
     CHECK(cuda::std::equal(policy, output_false.begin(), output_false.end(), expected_false));
@@ -145,7 +137,7 @@ void test_partition_copy(const Policy& policy,
   cuda::std::fill(policy, output_false.begin(), output_false.end(), static_cast<T>(-1));
   { // contiguous input, converting predicate
     auto res = cuda::std::partition_copy(
-      policy, input.begin(), input.end(), output_true.begin(), output_false.begin(), is_even<long>{});
+      policy, input.begin(), input.end(), output_true.begin(), output_false.begin(), cuda::__is_even<long>{});
     CHECK(res == cuda::std::pair{output_true.end(), output_false.end()});
     CHECK(cuda::std::equal(policy, output_true.begin(), output_true.end(), expected_true));
     CHECK(cuda::std::equal(policy, output_false.begin(), output_false.end(), expected_false));
@@ -160,7 +152,7 @@ void test_partition_copy(const Policy& policy,
       cuda::counting_iterator<short>{static_cast<short>(size)},
       output_true.begin(),
       output_false.begin(),
-      is_even<long>{});
+      cuda::__is_even<long>{});
     CHECK(res == cuda::std::pair{output_true.end(), output_false.end()});
     CHECK(cuda::std::equal(policy, output_true.begin(), output_true.end(), expected_true));
     CHECK(cuda::std::equal(policy, output_false.begin(), output_false.end(), expected_false));

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_partition_copy.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_partition_copy.cu
@@ -50,7 +50,7 @@ void test_partition_copy(const Policy& policy,
       static_cast<T*>(nullptr),
       static_cast<T*>(nullptr),
       static_cast<T*>(nullptr),
-      cuda::__is_even<T>{});
+      cuda::__is_even{});
     CHECK(res.first == nullptr);
     CHECK(res.second == nullptr);
   }
@@ -62,7 +62,7 @@ void test_partition_copy(const Policy& policy,
   cuda::std::fill(policy, output_false.begin(), output_false.end(), static_cast<T>(-1));
   { // contiguous iterators
     auto res = cuda::std::partition_copy(
-      policy, input.begin(), input.end(), output_true.begin(), output_false.begin(), cuda::__is_even<T>{});
+      policy, input.begin(), input.end(), output_true.begin(), output_false.begin(), cuda::__is_even{});
     CHECK(res == cuda::std::pair{output_true.end(), output_false.end()});
     CHECK(cuda::std::equal(policy, output_true.begin(), output_true.end(), expected_true));
     CHECK(cuda::std::equal(policy, output_false.begin(), output_false.end(), expected_false));
@@ -78,7 +78,7 @@ void test_partition_copy(const Policy& policy,
       random_access_iterator{raw_in + size},
       output_true.begin(),
       output_false.begin(),
-      cuda::__is_even<T>{});
+      cuda::__is_even{});
     CHECK(res == cuda::std::pair{output_true.end(), output_false.end()});
     CHECK(cuda::std::equal(policy, output_true.begin(), output_true.end(), expected_true));
     CHECK(cuda::std::equal(policy, output_false.begin(), output_false.end(), expected_false));
@@ -95,7 +95,7 @@ void test_partition_copy(const Policy& policy,
       input.end(),
       random_access_iterator{raw_true},
       random_access_iterator{raw_false},
-      cuda::__is_even<T>{});
+      cuda::__is_even{});
     CHECK(
       res
       == cuda::std::pair{random_access_iterator{raw_true + size / 2}, random_access_iterator{raw_false + size / 2}});
@@ -112,7 +112,7 @@ void test_partition_copy(const Policy& policy,
       cuda::counting_iterator<T>{static_cast<T>(size)},
       output_true.begin(),
       output_false.begin(),
-      cuda::__is_even<T>{});
+      cuda::__is_even{});
     CHECK(res == cuda::std::pair{output_true.end(), output_false.end()});
     CHECK(cuda::std::equal(policy, output_true.begin(), output_true.end(), expected_true));
     CHECK(cuda::std::equal(policy, output_false.begin(), output_false.end(), expected_false));
@@ -127,7 +127,7 @@ void test_partition_copy(const Policy& policy,
       cuda::counting_iterator<short>{static_cast<short>(size)},
       output_true.begin(),
       output_false.begin(),
-      cuda::__is_even<short>{});
+      cuda::__is_even{});
     CHECK(res == cuda::std::pair{output_true.end(), output_false.end()});
     CHECK(cuda::std::equal(policy, output_true.begin(), output_true.end(), expected_true));
     CHECK(cuda::std::equal(policy, output_false.begin(), output_false.end(), expected_false));
@@ -137,7 +137,7 @@ void test_partition_copy(const Policy& policy,
   cuda::std::fill(policy, output_false.begin(), output_false.end(), static_cast<T>(-1));
   { // contiguous input, converting predicate
     auto res = cuda::std::partition_copy(
-      policy, input.begin(), input.end(), output_true.begin(), output_false.begin(), cuda::__is_even<long>{});
+      policy, input.begin(), input.end(), output_true.begin(), output_false.begin(), cuda::__is_even{});
     CHECK(res == cuda::std::pair{output_true.end(), output_false.end()});
     CHECK(cuda::std::equal(policy, output_true.begin(), output_true.end(), expected_true));
     CHECK(cuda::std::equal(policy, output_false.begin(), output_false.end(), expected_false));
@@ -152,7 +152,7 @@ void test_partition_copy(const Policy& policy,
       cuda::counting_iterator<short>{static_cast<short>(size)},
       output_true.begin(),
       output_false.begin(),
-      cuda::__is_even<long>{});
+      cuda::__is_even{});
     CHECK(res == cuda::std::pair{output_true.end(), output_false.end()});
     CHECK(cuda::std::equal(policy, output_true.begin(), output_true.end(), expected_true));
     CHECK(cuda::std::equal(policy, output_false.begin(), output_false.end(), expected_false));

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_stable_partition.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_stable_partition.cu
@@ -36,8 +36,8 @@ template <class Policy>
 void test_partition(const Policy& policy, thrust::device_vector<int>& input)
 {
   { // Empty does not access anything
-    auto res = cuda::std::stable_partition(
-      policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), cuda::__is_even{});
+    auto res =
+      cuda::std::stable_partition(policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), cuda::__is_even{});
     CHECK(res == nullptr);
   }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_stable_partition.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_stable_partition.cu
@@ -36,8 +36,8 @@ template <class Policy>
 void test_partition(const Policy& policy, thrust::device_vector<int>& input)
 {
   { // Empty does not access anything
-    auto res =
-      cuda::std::stable_partition(policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), cuda::__is_even<int>{});
+    auto res = cuda::std::stable_partition(
+      policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), cuda::__is_even<int>{});
     CHECK(res == nullptr);
   }
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_stable_partition.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_stable_partition.cu
@@ -19,6 +19,7 @@
 #include <thrust/sequence.h>
 
 #include <cuda/cmath>
+#include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/memory_pool>
 #include <cuda/std/execution>
@@ -31,28 +32,19 @@
 
 inline constexpr int size = 1000;
 
-template <class T>
-struct is_even
-{
-  [[nodiscard]] TEST_DEVICE_FUNC constexpr bool operator()(T value) const noexcept
-  {
-    return value % 2 == 0;
-  }
-};
-
 template <class Policy>
 void test_partition(const Policy& policy, thrust::device_vector<int>& input)
 {
   { // Empty does not access anything
     auto res =
-      cuda::std::stable_partition(policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), is_even<int>{});
+      cuda::std::stable_partition(policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), cuda::__is_even<int>{});
     CHECK(res == nullptr);
   }
 
   const auto mid = size / 2;
   thrust::sequence(input.begin(), input.end(), 0);
   { // With matching predicate
-    auto res = cuda::std::stable_partition(policy, input.begin(), input.end(), is_even<int>{});
+    auto res = cuda::std::stable_partition(policy, input.begin(), input.end(), cuda::__is_even<int>{});
     CHECK(res == cuda::std::next(input.begin(), mid));
     CHECK(cuda::std::equal(policy, input.begin(), res, cuda::strided_iterator{cuda::counting_iterator{0}, 2}));
     CHECK(cuda::std::equal(policy, res, input.end(), cuda::strided_iterator{cuda::counting_iterator{1}, 2}));
@@ -60,7 +52,7 @@ void test_partition(const Policy& policy, thrust::device_vector<int>& input)
 
   thrust::sequence(input.begin(), input.end(), 0);
   { // With converting predicate
-    auto res = cuda::std::stable_partition(policy, input.begin(), input.end(), is_even<long>{});
+    auto res = cuda::std::stable_partition(policy, input.begin(), input.end(), cuda::__is_even<long>{});
     CHECK(res == cuda::std::next(input.begin(), mid));
     CHECK(cuda::std::equal(policy, input.begin(), res, cuda::strided_iterator{cuda::counting_iterator{0}, 2}));
     CHECK(cuda::std::equal(policy, res, input.end(), cuda::strided_iterator{cuda::counting_iterator{1}, 2}));

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_stable_partition.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/pstl_stable_partition.cu
@@ -37,14 +37,14 @@ void test_partition(const Policy& policy, thrust::device_vector<int>& input)
 {
   { // Empty does not access anything
     auto res = cuda::std::stable_partition(
-      policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), cuda::__is_even<int>{});
+      policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), cuda::__is_even{});
     CHECK(res == nullptr);
   }
 
   const auto mid = size / 2;
   thrust::sequence(input.begin(), input.end(), 0);
   { // With matching predicate
-    auto res = cuda::std::stable_partition(policy, input.begin(), input.end(), cuda::__is_even<int>{});
+    auto res = cuda::std::stable_partition(policy, input.begin(), input.end(), cuda::__is_even{});
     CHECK(res == cuda::std::next(input.begin(), mid));
     CHECK(cuda::std::equal(policy, input.begin(), res, cuda::strided_iterator{cuda::counting_iterator{0}, 2}));
     CHECK(cuda::std::equal(policy, res, input.end(), cuda::strided_iterator{cuda::counting_iterator{1}, 2}));
@@ -52,7 +52,7 @@ void test_partition(const Policy& policy, thrust::device_vector<int>& input)
 
   thrust::sequence(input.begin(), input.end(), 0);
   { // With converting predicate
-    auto res = cuda::std::stable_partition(policy, input.begin(), input.end(), cuda::__is_even<long>{});
+    auto res = cuda::std::stable_partition(policy, input.begin(), input.end(), cuda::__is_even{});
     CHECK(res == cuda::std::next(input.begin(), mid));
     CHECK(cuda::std::equal(policy, input.begin(), res, cuda::strided_iterator{cuda::counting_iterator{0}, 2}));
     CHECK(cuda::std::equal(policy, res, input.end(), cuda::strided_iterator{cuda::counting_iterator{1}, 2}));

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd_test_utils.h
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd_test_utils.h
@@ -54,7 +54,7 @@ struct is_even
   template <typename I>
   TEST_FUNC constexpr bool operator()(I i) const noexcept
   {
-    return cuda::__is_even<T>(i);
+    return cuda::__is_even(i);
   }
 };
 

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd_test_utils.h
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd_test_utils.h
@@ -11,6 +11,7 @@
 #ifndef SIMD_TEST_UTILS_H
 #define SIMD_TEST_UTILS_H
 
+#include <cuda/functional>
 #include <cuda/std/__simd_>
 #include <cuda/std/array>
 #include <cuda/std/cmath>
@@ -53,7 +54,7 @@ struct is_even
   template <typename I>
   TEST_FUNC constexpr bool operator()(I i) const noexcept
   {
-    return i % 2 == 0;
+    return cuda::__is_even<T>(i);
   }
 };
 

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd_test_utils.h
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd_test_utils.h
@@ -54,7 +54,7 @@ struct is_even
   template <typename I>
   TEST_HOST_DEVICE_FUNC constexpr bool operator()(I i) const noexcept
   {
-    return cuda::__is_even(i);
+    return cuda::__is_even{}(i);
   }
 };
 

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd_test_utils.h
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd_test_utils.h
@@ -11,6 +11,7 @@
 #ifndef SIMD_TEST_UTILS_H
 #define SIMD_TEST_UTILS_H
 
+#include <cuda/functional>
 #include <cuda/std/__simd_>
 #include <cuda/std/array>
 #include <cuda/std/cmath>
@@ -53,7 +54,7 @@ struct is_even
   template <typename I>
   TEST_HOST_DEVICE_FUNC constexpr bool operator()(I i) const noexcept
   {
-    return i % 2 == 0;
+    return cuda::__is_even<T>(i);
   }
 };
 

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd_test_utils.h
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd_test_utils.h
@@ -54,7 +54,7 @@ struct is_even
   template <typename I>
   TEST_HOST_DEVICE_FUNC constexpr bool operator()(I i) const noexcept
   {
-    return cuda::__is_even<T>(i);
+    return cuda::__is_even(i);
   }
 };
 

--- a/thrust/benchmarks/bench/copy_if/basic.cu
+++ b/thrust/benchmarks/bench/copy_if/basic.cu
@@ -33,10 +33,10 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
 
   caching_allocator_t alloc{};
 
-  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
-             [&](nvbench::launch& launch) {
-               do_not_optimize(thrust::copy_if(policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even<T>{}));
-             });
+  state.exec(
+    nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+      do_not_optimize(thrust::copy_if(policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even<T>{}));
+    });
 }
 
 NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))

--- a/thrust/benchmarks/bench/copy_if/basic.cu
+++ b/thrust/benchmarks/bench/copy_if/basic.cu
@@ -10,15 +10,6 @@
 
 #include "nvbench_helper.cuh"
 
-struct is_even
-{
-  template <class T>
-  __device__ constexpr bool operator()(const T& val) const noexcept
-  {
-    return static_cast<int>(val) % 2 == 0;
-  }
-};
-
 template <typename T>
 static void basic(nvbench::state& state, nvbench::type_list<T>)
 {

--- a/thrust/benchmarks/bench/copy_if/basic.cu
+++ b/thrust/benchmarks/bench/copy_if/basic.cu
@@ -4,6 +4,7 @@
 #include <thrust/copy.h>
 #include <thrust/device_vector.h>
 
+#include <cuda/functional>
 #include <cuda/memory_pool>
 #include <cuda/stream>
 
@@ -34,7 +35,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
 
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch) {
-               do_not_optimize(thrust::copy_if(policy(alloc, launch), in.begin(), in.end(), out.begin(), is_even{}));
+               do_not_optimize(thrust::copy_if(policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even<T>{}));
              });
 }
 

--- a/thrust/benchmarks/bench/copy_if/basic.cu
+++ b/thrust/benchmarks/bench/copy_if/basic.cu
@@ -26,7 +26,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
 
   state.exec(
     nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-      do_not_optimize(thrust::copy_if(policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even<T>{}));
+      do_not_optimize(thrust::copy_if(policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even{}));
     });
 }
 

--- a/thrust/benchmarks/bench/remove_copy_if/basic.cu
+++ b/thrust/benchmarks/bench/remove_copy_if/basic.cu
@@ -27,7 +27,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
   state.exec(
     nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
       do_not_optimize(
-        thrust::remove_copy_if(policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even<T>{}));
+        thrust::remove_copy_if(policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even{}));
     });
 }
 

--- a/thrust/benchmarks/bench/remove_copy_if/basic.cu
+++ b/thrust/benchmarks/bench/remove_copy_if/basic.cu
@@ -35,7 +35,8 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
 
   state.exec(
     nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-      do_not_optimize(thrust::remove_copy_if(policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even<T>{}));
+      do_not_optimize(
+        thrust::remove_copy_if(policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even<T>{}));
     });
 }
 

--- a/thrust/benchmarks/bench/remove_copy_if/basic.cu
+++ b/thrust/benchmarks/bench/remove_copy_if/basic.cu
@@ -4,6 +4,7 @@
 #include <thrust/device_vector.h>
 #include <thrust/remove.h>
 
+#include <cuda/functional>
 #include <cuda/memory_pool>
 #include <cuda/stream>
 
@@ -34,7 +35,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
 
   state.exec(
     nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-      do_not_optimize(thrust::remove_copy_if(policy(alloc, launch), in.begin(), in.end(), out.begin(), is_even{}));
+      do_not_optimize(thrust::remove_copy_if(policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even<T>{}));
     });
 }
 

--- a/thrust/benchmarks/bench/remove_copy_if/basic.cu
+++ b/thrust/benchmarks/bench/remove_copy_if/basic.cu
@@ -10,15 +10,6 @@
 
 #include "nvbench_helper.cuh"
 
-struct is_even
-{
-  template <class T>
-  __device__ constexpr bool operator()(const T& val) const noexcept
-  {
-    return static_cast<int>(val) % 2 == 0;
-  }
-};
-
 template <typename T>
 static void basic(nvbench::state& state, nvbench::type_list<T>)
 {

--- a/thrust/benchmarks/bench/remove_copy_if/basic.cu
+++ b/thrust/benchmarks/bench/remove_copy_if/basic.cu
@@ -24,11 +24,11 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
 
   caching_allocator_t alloc{};
 
-  state.exec(
-    nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-      do_not_optimize(
-        thrust::remove_copy_if(policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even{}));
-    });
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               do_not_optimize(
+                 thrust::remove_copy_if(policy(alloc, launch), in.begin(), in.end(), out.begin(), cuda::__is_even{}));
+             });
 }
 
 NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))

--- a/thrust/benchmarks/bench/remove_if/basic.cu
+++ b/thrust/benchmarks/bench/remove_if/basic.cu
@@ -4,6 +4,7 @@
 #include <thrust/device_vector.h>
 #include <thrust/remove.h>
 
+#include <cuda/functional>
 #include <cuda/memory_pool>
 #include <cuda/stream>
 
@@ -33,7 +34,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
 
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch) {
-               thrust::remove_if(policy(alloc, launch), in.begin(), in.end(), is_even{});
+               thrust::remove_if(policy(alloc, launch), in.begin(), in.end(), cuda::__is_even<T>{});
              });
 }
 

--- a/thrust/benchmarks/bench/remove_if/basic.cu
+++ b/thrust/benchmarks/bench/remove_if/basic.cu
@@ -25,7 +25,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
 
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch) {
-               thrust::remove_if(policy(alloc, launch), in.begin(), in.end(), cuda::__is_even<T>{});
+               thrust::remove_if(policy(alloc, launch), in.begin(), in.end(), cuda::__is_even{});
              });
 }
 

--- a/thrust/benchmarks/bench/remove_if/basic.cu
+++ b/thrust/benchmarks/bench/remove_if/basic.cu
@@ -10,15 +10,6 @@
 
 #include "nvbench_helper.cuh"
 
-struct is_even
-{
-  template <class T>
-  __device__ constexpr bool operator()(const T& val) const noexcept
-  {
-    return static_cast<int>(val) % 2 == 0;
-  }
-};
-
 template <typename T>
 static void basic(nvbench::state& state, nvbench::type_list<T>)
 {

--- a/thrust/testing/copy.cu
+++ b/thrust/testing/copy.cu
@@ -284,8 +284,8 @@ void TestCopyIfIntegral(const size_t n)
     thrust::host_vector<T> h_result(n);
     thrust::device_vector<T> d_result(n);
 
-    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_result.begin(), cuda::__is_even<T>{});
-    d_new_end = thrust::copy_if(d_data.begin(), d_data.end(), d_result.begin(), cuda::__is_even<T>{});
+    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_result.begin(), cuda::__is_even{});
+    d_new_end = thrust::copy_if(d_data.begin(), d_data.end(), d_result.begin(), cuda::__is_even{});
 
     h_result.resize(h_new_end - h_result.begin());
     d_result.resize(d_new_end - d_result.begin());
@@ -325,8 +325,8 @@ void TestCopyIfSequence(const size_t n)
     thrust::host_vector<T> h_result(n);
     thrust::device_vector<T> d_result(n);
 
-    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_result.begin(), cuda::__is_even<T>{});
-    d_new_end = thrust::copy_if(d_data.begin(), d_data.end(), d_result.begin(), cuda::__is_even<T>{});
+    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_result.begin(), cuda::__is_even{});
+    d_new_end = thrust::copy_if(d_data.begin(), d_data.end(), d_result.begin(), cuda::__is_even{});
 
     h_result.resize(h_new_end - h_result.begin());
     d_result.resize(d_new_end - d_result.begin());
@@ -387,9 +387,9 @@ void TestCopyIfStencil(const size_t n)
     thrust::device_vector<T> d_result(n);
 
     h_new_end =
-      thrust::copy_if(h_data.begin(), h_data.end(), h_stencil.begin(), h_result.begin(), cuda::__is_even<T>{});
+      thrust::copy_if(h_data.begin(), h_data.end(), h_stencil.begin(), h_result.begin(), cuda::__is_even{});
     d_new_end =
-      thrust::copy_if(d_data.begin(), d_data.end(), d_stencil.begin(), d_result.begin(), cuda::__is_even<T>{});
+      thrust::copy_if(d_data.begin(), d_data.end(), d_stencil.begin(), d_result.begin(), cuda::__is_even{});
 
     h_result.resize(h_new_end - h_result.begin());
     d_result.resize(d_new_end - d_result.begin());

--- a/thrust/testing/copy.cu
+++ b/thrust/testing/copy.cu
@@ -386,8 +386,10 @@ void TestCopyIfStencil(const size_t n)
     thrust::host_vector<T> h_result(n);
     thrust::device_vector<T> d_result(n);
 
-    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_stencil.begin(), h_result.begin(), cuda::__is_even<T>{});
-    d_new_end = thrust::copy_if(d_data.begin(), d_data.end(), d_stencil.begin(), d_result.begin(), cuda::__is_even<T>{});
+    h_new_end =
+      thrust::copy_if(h_data.begin(), h_data.end(), h_stencil.begin(), h_result.begin(), cuda::__is_even<T>{});
+    d_new_end =
+      thrust::copy_if(d_data.begin(), d_data.end(), d_stencil.begin(), d_result.begin(), cuda::__is_even<T>{});
 
     h_result.resize(h_new_end - h_result.begin());
     d_result.resize(d_new_end - d_result.begin());

--- a/thrust/testing/copy.cu
+++ b/thrust/testing/copy.cu
@@ -9,6 +9,7 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/sequence.h>
 
+#include <cuda/functional>
 #include <cuda/iterator>
 
 #include <algorithm>
@@ -211,15 +212,6 @@ void TestCopyListTo()
 DECLARE_VECTOR_UNITTEST(TestCopyListTo);
 
 template <typename T>
-struct is_even
-{
-  _CCCL_HOST_DEVICE bool operator()(T x)
-  {
-    return (x & 1) == 0;
-  }
-};
-
-template <typename T>
 struct is_true
 {
   _CCCL_HOST_DEVICE bool operator()(T x)
@@ -292,8 +284,8 @@ void TestCopyIfIntegral(const size_t n)
     thrust::host_vector<T> h_result(n);
     thrust::device_vector<T> d_result(n);
 
-    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_result.begin(), is_even<T>());
-    d_new_end = thrust::copy_if(d_data.begin(), d_data.end(), d_result.begin(), is_even<T>());
+    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_result.begin(), cuda::__is_even<T>{});
+    d_new_end = thrust::copy_if(d_data.begin(), d_data.end(), d_result.begin(), cuda::__is_even<T>{});
 
     h_result.resize(h_new_end - h_result.begin());
     d_result.resize(d_new_end - d_result.begin());
@@ -333,8 +325,8 @@ void TestCopyIfSequence(const size_t n)
     thrust::host_vector<T> h_result(n);
     thrust::device_vector<T> d_result(n);
 
-    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_result.begin(), is_even<T>());
-    d_new_end = thrust::copy_if(d_data.begin(), d_data.end(), d_result.begin(), is_even<T>());
+    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_result.begin(), cuda::__is_even<T>{});
+    d_new_end = thrust::copy_if(d_data.begin(), d_data.end(), d_result.begin(), cuda::__is_even<T>{});
 
     h_result.resize(h_new_end - h_result.begin());
     d_result.resize(d_new_end - d_result.begin());
@@ -394,8 +386,8 @@ void TestCopyIfStencil(const size_t n)
     thrust::host_vector<T> h_result(n);
     thrust::device_vector<T> d_result(n);
 
-    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_stencil.begin(), h_result.begin(), is_even<T>());
-    d_new_end = thrust::copy_if(d_data.begin(), d_data.end(), d_stencil.begin(), d_result.begin(), is_even<T>());
+    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_stencil.begin(), h_result.begin(), cuda::__is_even<T>{});
+    d_new_end = thrust::copy_if(d_data.begin(), d_data.end(), d_stencil.begin(), d_result.begin(), cuda::__is_even<T>{});
 
     h_result.resize(h_new_end - h_result.begin());
     d_result.resize(d_new_end - d_result.begin());

--- a/thrust/testing/copy.cu
+++ b/thrust/testing/copy.cu
@@ -386,10 +386,8 @@ void TestCopyIfStencil(const size_t n)
     thrust::host_vector<T> h_result(n);
     thrust::device_vector<T> d_result(n);
 
-    h_new_end =
-      thrust::copy_if(h_data.begin(), h_data.end(), h_stencil.begin(), h_result.begin(), cuda::__is_even{});
-    d_new_end =
-      thrust::copy_if(d_data.begin(), d_data.end(), d_stencil.begin(), d_result.begin(), cuda::__is_even{});
+    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_stencil.begin(), h_result.begin(), cuda::__is_even{});
+    d_new_end = thrust::copy_if(d_data.begin(), d_data.end(), d_stencil.begin(), d_result.begin(), cuda::__is_even{});
 
     h_result.resize(h_new_end - h_result.begin());
     d_result.resize(d_new_end - d_result.begin());

--- a/thrust/testing/cuda/copy_if.cu
+++ b/thrust/testing/cuda/copy_if.cu
@@ -61,10 +61,10 @@ void TestCopyIfDevice(ExecutionPolicy exec)
     thrust::host_vector<int> h_result(n);
     thrust::device_vector<int> d_result(n);
 
-    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_result.begin(), cuda::__is_even<int>{});
+    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_result.begin(), cuda::__is_even{});
 
     copy_if_kernel<<<1, 1>>>(
-      exec, d_data.begin(), d_data.end(), d_result.begin(), cuda::__is_even<int>{}, d_new_end_vec.begin());
+      exec, d_data.begin(), d_data.end(), d_result.begin(), cuda::__is_even{}, d_new_end_vec.begin());
     cudaError_t const err = cudaDeviceSynchronize();
     ASSERT_EQUAL(cudaSuccess, err);
 
@@ -127,7 +127,7 @@ void TestCopyIfCudaStreams(ExecutionPolicy policy)
   cudaStreamCreate(&s);
 
   Vector::iterator end =
-    thrust::copy_if(policy.on(s), data.begin(), data.end(), result.begin(), cuda::__is_even<int>{});
+    thrust::copy_if(policy.on(s), data.begin(), data.end(), result.begin(), cuda::__is_even{});
 
   ASSERT_EQUAL(end - result.begin(), 2);
   result.resize(end - result.begin());
@@ -190,10 +190,10 @@ void TestCopyIfStencilDevice(ExecutionPolicy exec)
     thrust::host_vector<int> h_result(n);
     thrust::device_vector<int> d_result(n);
 
-    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_result.begin(), cuda::__is_even<int>{});
+    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_result.begin(), cuda::__is_even{});
 
     copy_if_kernel<<<1, 1>>>(
-      exec, d_data.begin(), d_data.end(), d_result.begin(), cuda::__is_even<int>{}, d_new_end_vec.begin());
+      exec, d_data.begin(), d_data.end(), d_result.begin(), cuda::__is_even{}, d_new_end_vec.begin());
     cudaError_t const err = cudaDeviceSynchronize();
     ASSERT_EQUAL(cudaSuccess, err);
 

--- a/thrust/testing/cuda/copy_if.cu
+++ b/thrust/testing/cuda/copy_if.cu
@@ -126,7 +126,8 @@ void TestCopyIfCudaStreams(ExecutionPolicy policy)
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  Vector::iterator end = thrust::copy_if(policy.on(s), data.begin(), data.end(), result.begin(), cuda::__is_even<int>{});
+  Vector::iterator end =
+    thrust::copy_if(policy.on(s), data.begin(), data.end(), result.begin(), cuda::__is_even<int>{});
 
   ASSERT_EQUAL(end - result.begin(), 2);
   result.resize(end - result.begin());

--- a/thrust/testing/cuda/copy_if.cu
+++ b/thrust/testing/cuda/copy_if.cu
@@ -2,17 +2,10 @@
 #include <thrust/execution_policy.h>
 #include <thrust/sequence.h>
 
+#include <cuda/functional>
+
 #include "thrust/iterator/transform_iterator.h"
 #include <unittest/unittest.h>
-
-template <typename T>
-struct is_even
-{
-  _CCCL_HOST_DEVICE bool operator()(T x)
-  {
-    return (static_cast<unsigned int>(x) & 1) == 0;
-  }
-};
 
 template <typename T>
 struct mod_3
@@ -68,10 +61,10 @@ void TestCopyIfDevice(ExecutionPolicy exec)
     thrust::host_vector<int> h_result(n);
     thrust::device_vector<int> d_result(n);
 
-    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_result.begin(), is_even<int>());
+    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_result.begin(), cuda::__is_even<int>{});
 
     copy_if_kernel<<<1, 1>>>(
-      exec, d_data.begin(), d_data.end(), d_result.begin(), is_even<int>(), d_new_end_vec.begin());
+      exec, d_data.begin(), d_data.end(), d_result.begin(), cuda::__is_even<int>{}, d_new_end_vec.begin());
     cudaError_t const err = cudaDeviceSynchronize();
     ASSERT_EQUAL(cudaSuccess, err);
 
@@ -133,7 +126,7 @@ void TestCopyIfCudaStreams(ExecutionPolicy policy)
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  Vector::iterator end = thrust::copy_if(policy.on(s), data.begin(), data.end(), result.begin(), is_even<int>());
+  Vector::iterator end = thrust::copy_if(policy.on(s), data.begin(), data.end(), result.begin(), cuda::__is_even<int>{});
 
   ASSERT_EQUAL(end - result.begin(), 2);
   result.resize(end - result.begin());
@@ -196,10 +189,10 @@ void TestCopyIfStencilDevice(ExecutionPolicy exec)
     thrust::host_vector<int> h_result(n);
     thrust::device_vector<int> d_result(n);
 
-    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_result.begin(), is_even<int>());
+    h_new_end = thrust::copy_if(h_data.begin(), h_data.end(), h_result.begin(), cuda::__is_even<int>{});
 
     copy_if_kernel<<<1, 1>>>(
-      exec, d_data.begin(), d_data.end(), d_result.begin(), is_even<int>(), d_new_end_vec.begin());
+      exec, d_data.begin(), d_data.end(), d_result.begin(), cuda::__is_even<int>{}, d_new_end_vec.begin());
     cudaError_t const err = cudaDeviceSynchronize();
     ASSERT_EQUAL(cudaSuccess, err);
 

--- a/thrust/testing/cuda/copy_if.cu
+++ b/thrust/testing/cuda/copy_if.cu
@@ -126,8 +126,7 @@ void TestCopyIfCudaStreams(ExecutionPolicy policy)
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  Vector::iterator end =
-    thrust::copy_if(policy.on(s), data.begin(), data.end(), result.begin(), cuda::__is_even{});
+  Vector::iterator end = thrust::copy_if(policy.on(s), data.begin(), data.end(), result.begin(), cuda::__is_even{});
 
   ASSERT_EQUAL(end - result.begin(), 2);
   result.resize(end - result.begin());

--- a/thrust/testing/cuda/gather.cu
+++ b/thrust/testing/cuda/gather.cu
@@ -1,6 +1,8 @@
 #include <thrust/execution_policy.h>
 #include <thrust/gather.h>
 
+#include <cuda/functional>
+
 #include <algorithm>
 
 #include <unittest/unittest.h>
@@ -100,15 +102,6 @@ __global__ void gather_if_kernel(
   thrust::gather_if(exec, map_first, map_last, stencil_first, elements_first, result, pred);
 }
 
-template <typename T>
-struct is_even_gather_if
-{
-  _CCCL_HOST_DEVICE bool operator()(const T i) const
-  {
-    return (i % 2) == 0;
-  }
-};
-
 template <typename T, typename ExecutionPolicy>
 void TestGatherIfDevice(ExecutionPolicy exec, const size_t n)
 {
@@ -143,12 +136,7 @@ void TestGatherIfDevice(ExecutionPolicy exec, const size_t n)
   thrust::device_vector<T> d_output(n);
 
   thrust::gather_if(
-    h_map.begin(),
-    h_map.end(),
-    h_stencil.begin(),
-    h_source.begin(),
-    h_output.begin(),
-    is_even_gather_if<unsigned int>());
+    h_map.begin(), h_map.end(), h_stencil.begin(), h_source.begin(), h_output.begin(), cuda::__is_even<unsigned int>());
 
   gather_if_kernel<<<1, 1>>>(
     exec,
@@ -157,7 +145,7 @@ void TestGatherIfDevice(ExecutionPolicy exec, const size_t n)
     d_stencil.begin(),
     d_source.begin(),
     d_output.begin(),
-    is_even_gather_if<unsigned int>());
+    cuda::__is_even<unsigned int>());
   {
     cudaError_t const err = cudaDeviceSynchronize();
     ASSERT_EQUAL(cudaSuccess, err);

--- a/thrust/testing/cuda/gather.cu
+++ b/thrust/testing/cuda/gather.cu
@@ -136,7 +136,7 @@ void TestGatherIfDevice(ExecutionPolicy exec, const size_t n)
   thrust::device_vector<T> d_output(n);
 
   thrust::gather_if(
-    h_map.begin(), h_map.end(), h_stencil.begin(), h_source.begin(), h_output.begin(), cuda::__is_even<unsigned int>());
+    h_map.begin(), h_map.end(), h_stencil.begin(), h_source.begin(), h_output.begin(), cuda::__is_even());
 
   gather_if_kernel<<<1, 1>>>(
     exec,
@@ -145,7 +145,7 @@ void TestGatherIfDevice(ExecutionPolicy exec, const size_t n)
     d_stencil.begin(),
     d_source.begin(),
     d_output.begin(),
-    cuda::__is_even<unsigned int>());
+    cuda::__is_even());
   {
     cudaError_t const err = cudaDeviceSynchronize();
     ASSERT_EQUAL(cudaSuccess, err);

--- a/thrust/testing/cuda/gather.cu
+++ b/thrust/testing/cuda/gather.cu
@@ -139,13 +139,7 @@ void TestGatherIfDevice(ExecutionPolicy exec, const size_t n)
     h_map.begin(), h_map.end(), h_stencil.begin(), h_source.begin(), h_output.begin(), cuda::__is_even());
 
   gather_if_kernel<<<1, 1>>>(
-    exec,
-    d_map.begin(),
-    d_map.end(),
-    d_stencil.begin(),
-    d_source.begin(),
-    d_output.begin(),
-    cuda::__is_even());
+    exec, d_map.begin(), d_map.end(), d_stencil.begin(), d_source.begin(), d_output.begin(), cuda::__is_even());
   {
     cudaError_t const err = cudaDeviceSynchronize();
     ASSERT_EQUAL(cudaSuccess, err);

--- a/thrust/testing/cuda/gather.cu
+++ b/thrust/testing/cuda/gather.cu
@@ -136,10 +136,10 @@ void TestGatherIfDevice(ExecutionPolicy exec, const size_t n)
   thrust::device_vector<T> d_output(n);
 
   thrust::gather_if(
-    h_map.begin(), h_map.end(), h_stencil.begin(), h_source.begin(), h_output.begin(), cuda::__is_even());
+    h_map.begin(), h_map.end(), h_stencil.begin(), h_source.begin(), h_output.begin(), cuda::__is_even{});
 
   gather_if_kernel<<<1, 1>>>(
-    exec, d_map.begin(), d_map.end(), d_stencil.begin(), d_source.begin(), d_output.begin(), cuda::__is_even());
+    exec, d_map.begin(), d_map.end(), d_stencil.begin(), d_source.begin(), d_output.begin(), cuda::__is_even{});
   {
     cudaError_t const err = cudaDeviceSynchronize();
     ASSERT_EQUAL(cudaSuccess, err);

--- a/thrust/testing/cuda/is_partitioned.cu
+++ b/thrust/testing/cuda/is_partitioned.cu
@@ -104,17 +104,23 @@ void TestIsPartitionedCudaStreams()
 }
 DECLARE_UNITTEST(TestIsPartitionedCudaStreams);
 
+struct is_even_no_const
+{
+  __host__ __device__ bool operator()(int x)
+  {
+    return (x & 1) == 0;
+  }
+};
+
 void TestIsPartitionedWithNonConstPredicate()
 {
   thrust::device_vector<int> partitioned   = {0, 2, 4, 1, 3, 5};
   thrust::device_vector<int> unpartitioned = {0, 1, 2, 3};
 
   ASSERT_EQUAL_QUIET(
-    true,
-    thrust::is_partitioned(thrust::cuda::par, partitioned.begin(), partitioned.end(), cuda::__is_even_no_const<int>{}));
+    true, thrust::is_partitioned(thrust::cuda::par, partitioned.begin(), partitioned.end(), is_even_no_const{}));
 
-  ASSERT_EQUAL_QUIET(false,
-                     thrust::is_partitioned(
-                       thrust::cuda::par, unpartitioned.begin(), unpartitioned.end(), cuda::__is_even_no_const<int>{}));
+  ASSERT_EQUAL_QUIET(
+    false, thrust::is_partitioned(thrust::cuda::par, unpartitioned.begin(), unpartitioned.end(), is_even_no_const{}));
 }
 DECLARE_UNITTEST(TestIsPartitionedWithNonConstPredicate);

--- a/thrust/testing/cuda/is_partitioned.cu
+++ b/thrust/testing/cuda/is_partitioned.cu
@@ -110,10 +110,11 @@ void TestIsPartitionedWithNonConstPredicate()
   thrust::device_vector<int> unpartitioned = {0, 1, 2, 3};
 
   ASSERT_EQUAL_QUIET(
-    true, thrust::is_partitioned(thrust::cuda::par, partitioned.begin(), partitioned.end(), cuda::__is_even_no_const<int>{}));
+    true,
+    thrust::is_partitioned(thrust::cuda::par, partitioned.begin(), partitioned.end(), cuda::__is_even_no_const<int>{}));
 
-  ASSERT_EQUAL_QUIET(
-    false,
-    thrust::is_partitioned(thrust::cuda::par, unpartitioned.begin(), unpartitioned.end(), cuda::__is_even_no_const<int>{}));
+  ASSERT_EQUAL_QUIET(false,
+                     thrust::is_partitioned(
+                       thrust::cuda::par, unpartitioned.begin(), unpartitioned.end(), cuda::__is_even_no_const<int>{}));
 }
 DECLARE_UNITTEST(TestIsPartitionedWithNonConstPredicate);

--- a/thrust/testing/cuda/is_partitioned.cu
+++ b/thrust/testing/cuda/is_partitioned.cu
@@ -28,7 +28,7 @@ void TestIsPartitionedDevice(ExecutionPolicy exec)
   v[0] = 1;
   v[1] = 0;
 
-  is_partitioned_kernel<<<1, 1>>>(exec, v.begin(), v.end(), cuda::__is_even<int>(), result.begin());
+  is_partitioned_kernel<<<1, 1>>>(exec, v.begin(), v.end(), cuda::__is_even(), result.begin());
   {
     cudaError_t const err = cudaDeviceSynchronize();
     ASSERT_EQUAL(cudaSuccess, err);
@@ -36,9 +36,9 @@ void TestIsPartitionedDevice(ExecutionPolicy exec)
 
   ASSERT_EQUAL(false, result[0]);
 
-  thrust::partition(v.begin(), v.end(), cuda::__is_even<int>());
+  thrust::partition(v.begin(), v.end(), cuda::__is_even());
 
-  is_partitioned_kernel<<<1, 1>>>(exec, v.begin(), v.end(), cuda::__is_even<int>(), result.begin());
+  is_partitioned_kernel<<<1, 1>>>(exec, v.begin(), v.end(), cuda::__is_even(), result.begin());
   {
     cudaError_t const err = cudaDeviceSynchronize();
     ASSERT_EQUAL(cudaSuccess, err);

--- a/thrust/testing/cuda/is_partitioned.cu
+++ b/thrust/testing/cuda/is_partitioned.cu
@@ -2,6 +2,8 @@
 #include <thrust/functional.h>
 #include <thrust/partition.h>
 
+#include <cuda/functional>
+
 #include <unittest/unittest.h>
 
 #ifdef THRUST_TEST_DEVICE_SIDE
@@ -11,15 +13,6 @@ is_partitioned_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Predi
 {
   *result = thrust::is_partitioned(exec, first, last, pred);
 }
-
-template <typename T>
-struct is_even
-{
-  _CCCL_HOST_DEVICE bool operator()(T x) const
-  {
-    return ((int) x % 2) == 0;
-  }
-};
 
 template <typename ExecutionPolicy>
 void TestIsPartitionedDevice(ExecutionPolicy exec)
@@ -35,7 +28,7 @@ void TestIsPartitionedDevice(ExecutionPolicy exec)
   v[0] = 1;
   v[1] = 0;
 
-  is_partitioned_kernel<<<1, 1>>>(exec, v.begin(), v.end(), is_even<int>(), result.begin());
+  is_partitioned_kernel<<<1, 1>>>(exec, v.begin(), v.end(), cuda::__is_even<int>(), result.begin());
   {
     cudaError_t const err = cudaDeviceSynchronize();
     ASSERT_EQUAL(cudaSuccess, err);
@@ -43,9 +36,9 @@ void TestIsPartitionedDevice(ExecutionPolicy exec)
 
   ASSERT_EQUAL(false, result[0]);
 
-  thrust::partition(v.begin(), v.end(), is_even<int>());
+  thrust::partition(v.begin(), v.end(), cuda::__is_even<int>());
 
-  is_partitioned_kernel<<<1, 1>>>(exec, v.begin(), v.end(), is_even<int>(), result.begin());
+  is_partitioned_kernel<<<1, 1>>>(exec, v.begin(), v.end(), cuda::__is_even<int>(), result.begin());
   {
     cudaError_t const err = cudaDeviceSynchronize();
     ASSERT_EQUAL(cudaSuccess, err);
@@ -111,25 +104,16 @@ void TestIsPartitionedCudaStreams()
 }
 DECLARE_UNITTEST(TestIsPartitionedCudaStreams);
 
-template <typename T>
-struct is_even_non_const
-{
-  _CCCL_HOST_DEVICE bool operator()(T x) // no const
-  {
-    return ((int) x % 2) == 0;
-  }
-};
-
 void TestIsPartitionedWithNonConstPredicate()
 {
   thrust::device_vector<int> partitioned   = {0, 2, 4, 1, 3, 5};
   thrust::device_vector<int> unpartitioned = {0, 1, 2, 3};
 
   ASSERT_EQUAL_QUIET(
-    true, thrust::is_partitioned(thrust::cuda::par, partitioned.begin(), partitioned.end(), is_even_non_const<int>{}));
+    true, thrust::is_partitioned(thrust::cuda::par, partitioned.begin(), partitioned.end(), cuda::__is_even_no_const<int>{}));
 
   ASSERT_EQUAL_QUIET(
     false,
-    thrust::is_partitioned(thrust::cuda::par, unpartitioned.begin(), unpartitioned.end(), is_even_non_const<int>{}));
+    thrust::is_partitioned(thrust::cuda::par, unpartitioned.begin(), unpartitioned.end(), cuda::__is_even_no_const<int>{}));
 }
 DECLARE_UNITTEST(TestIsPartitionedWithNonConstPredicate);

--- a/thrust/testing/cuda/is_partitioned.cu
+++ b/thrust/testing/cuda/is_partitioned.cu
@@ -108,7 +108,7 @@ struct is_even_no_const
 {
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr bool operator()(const int x) noexcept
   {
-    return (x & 1) == 0;
+    return x % 2 == 0;
   }
 };
 

--- a/thrust/testing/cuda/is_partitioned.cu
+++ b/thrust/testing/cuda/is_partitioned.cu
@@ -28,7 +28,7 @@ void TestIsPartitionedDevice(ExecutionPolicy exec)
   v[0] = 1;
   v[1] = 0;
 
-  is_partitioned_kernel<<<1, 1>>>(exec, v.begin(), v.end(), cuda::__is_even(), result.begin());
+  is_partitioned_kernel<<<1, 1>>>(exec, v.begin(), v.end(), cuda::__is_even{}, result.begin());
   {
     cudaError_t const err = cudaDeviceSynchronize();
     ASSERT_EQUAL(cudaSuccess, err);
@@ -36,9 +36,9 @@ void TestIsPartitionedDevice(ExecutionPolicy exec)
 
   ASSERT_EQUAL(false, result[0]);
 
-  thrust::partition(v.begin(), v.end(), cuda::__is_even());
+  thrust::partition(v.begin(), v.end(), cuda::__is_even{});
 
-  is_partitioned_kernel<<<1, 1>>>(exec, v.begin(), v.end(), cuda::__is_even(), result.begin());
+  is_partitioned_kernel<<<1, 1>>>(exec, v.begin(), v.end(), cuda::__is_even{}, result.begin());
   {
     cudaError_t const err = cudaDeviceSynchronize();
     ASSERT_EQUAL(cudaSuccess, err);
@@ -106,7 +106,7 @@ DECLARE_UNITTEST(TestIsPartitionedCudaStreams);
 
 struct is_even_no_const
 {
-  __host__ __device__ bool operator()(int x)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr bool operator()(const int x) noexcept
   {
     return (x & 1) == 0;
   }

--- a/thrust/testing/cuda/partition.cu
+++ b/thrust/testing/cuda/partition.cu
@@ -184,7 +184,13 @@ void TestPartitionCopyDevice(ExecutionPolicy exec)
   thrust::device_vector<pair_type> iterators(1);
 
   partition_copy_kernel<<<1, 1>>>(
-    exec, data.begin(), data.end(), true_results.begin(), false_results.begin(), cuda::__is_even<T>{}, iterators.begin());
+    exec,
+    data.begin(),
+    data.end(),
+    true_results.begin(),
+    false_results.begin(),
+    cuda::__is_even<T>{},
+    iterators.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
@@ -400,7 +406,8 @@ void TestStablePartitionStencilDevice(ExecutionPolicy exec)
 
   thrust::device_vector<iterator> result(1);
 
-  stable_partition_kernel<<<1, 1>>>(exec, data.begin(), data.end(), stencil.begin(), cuda::__is_even<T>{}, result.begin());
+  stable_partition_kernel<<<1, 1>>>(
+    exec, data.begin(), data.end(), stencil.begin(), cuda::__is_even<T>{}, result.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
@@ -471,7 +478,13 @@ void TestStablePartitionCopyDevice(ExecutionPolicy exec)
   thrust::device_vector<pair_type> iterators(1);
 
   stable_partition_copy_kernel<<<1, 1>>>(
-    exec, data.begin(), data.end(), true_results.begin(), false_results.begin(), cuda::__is_even<T>{}, iterators.begin());
+    exec,
+    data.begin(),
+    data.end(),
+    true_results.begin(),
+    false_results.begin(),
+    cuda::__is_even<T>{},
+    iterators.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 

--- a/thrust/testing/cuda/partition.cu
+++ b/thrust/testing/cuda/partition.cu
@@ -3,17 +3,10 @@
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/partition.h>
 
+#include <cuda/functional>
+
 #include "thrust/detail/raw_pointer_cast.h"
 #include <unittest/unittest.h>
-
-template <typename T>
-struct is_even
-{
-  _CCCL_HOST_DEVICE bool operator()(T x) const
-  {
-    return ((int) x % 2) == 0;
-  }
-};
 
 template <typename T>
 struct mod_n
@@ -58,7 +51,7 @@ void TestPartitionDevice(ExecutionPolicy exec)
 
   thrust::device_vector<iterator> result(1);
 
-  partition_kernel<<<1, 1>>>(exec, data.begin(), data.end(), is_even<T>(), result.begin());
+  partition_kernel<<<1, 1>>>(exec, data.begin(), data.end(), cuda::__is_even<T>{}, result.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
@@ -120,7 +113,7 @@ void TestPartitionStencilDevice(ExecutionPolicy exec)
 
   thrust::device_vector<iterator> result(1);
 
-  partition_kernel<<<1, 1>>>(exec, data.begin(), data.end(), stencil.begin(), is_even<T>(), result.begin());
+  partition_kernel<<<1, 1>>>(exec, data.begin(), data.end(), stencil.begin(), cuda::__is_even<T>{}, result.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
@@ -191,7 +184,7 @@ void TestPartitionCopyDevice(ExecutionPolicy exec)
   thrust::device_vector<pair_type> iterators(1);
 
   partition_copy_kernel<<<1, 1>>>(
-    exec, data.begin(), data.end(), true_results.begin(), false_results.begin(), is_even<T>(), iterators.begin());
+    exec, data.begin(), data.end(), true_results.begin(), false_results.begin(), cuda::__is_even<T>{}, iterators.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
@@ -283,7 +276,7 @@ void TestPartitionCopyStencilDevice(ExecutionPolicy exec)
     stencil.begin(),
     true_results.begin(),
     false_results.begin(),
-    is_even<T>(),
+    cuda::__is_even<T>{},
     iterators.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
@@ -345,7 +338,7 @@ void TestStablePartitionDevice(ExecutionPolicy exec)
 
   thrust::device_vector<iterator> result(1);
 
-  stable_partition_kernel<<<1, 1>>>(exec, data.begin(), data.end(), is_even<T>(), result.begin());
+  stable_partition_kernel<<<1, 1>>>(exec, data.begin(), data.end(), cuda::__is_even<T>{}, result.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
@@ -407,7 +400,7 @@ void TestStablePartitionStencilDevice(ExecutionPolicy exec)
 
   thrust::device_vector<iterator> result(1);
 
-  stable_partition_kernel<<<1, 1>>>(exec, data.begin(), data.end(), stencil.begin(), is_even<T>(), result.begin());
+  stable_partition_kernel<<<1, 1>>>(exec, data.begin(), data.end(), stencil.begin(), cuda::__is_even<T>{}, result.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
@@ -478,7 +471,7 @@ void TestStablePartitionCopyDevice(ExecutionPolicy exec)
   thrust::device_vector<pair_type> iterators(1);
 
   stable_partition_copy_kernel<<<1, 1>>>(
-    exec, data.begin(), data.end(), true_results.begin(), false_results.begin(), is_even<T>(), iterators.begin());
+    exec, data.begin(), data.end(), true_results.begin(), false_results.begin(), cuda::__is_even<T>{}, iterators.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
@@ -570,7 +563,7 @@ void TestStablePartitionCopyStencilDevice(ExecutionPolicy exec)
     stencil.begin(),
     true_results.begin(),
     false_results.begin(),
-    is_even<T>(),
+    cuda::__is_even<T>{},
     iterators.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
@@ -706,7 +699,7 @@ void TestPartitionCudaStreams(ExecutionPolicy policy)
 
   auto streampolicy = policy.on(s);
 
-  Iterator iter = thrust::partition(streampolicy, data.begin(), data.end(), is_even<T>());
+  Iterator iter = thrust::partition(streampolicy, data.begin(), data.end(), cuda::__is_even<T>{});
 
   Vector ref(5);
   ref[0] = 2;

--- a/thrust/testing/cuda/partition.cu
+++ b/thrust/testing/cuda/partition.cu
@@ -51,7 +51,7 @@ void TestPartitionDevice(ExecutionPolicy exec)
 
   thrust::device_vector<iterator> result(1);
 
-  partition_kernel<<<1, 1>>>(exec, data.begin(), data.end(), cuda::__is_even<T>{}, result.begin());
+  partition_kernel<<<1, 1>>>(exec, data.begin(), data.end(), cuda::__is_even{}, result.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
@@ -113,7 +113,7 @@ void TestPartitionStencilDevice(ExecutionPolicy exec)
 
   thrust::device_vector<iterator> result(1);
 
-  partition_kernel<<<1, 1>>>(exec, data.begin(), data.end(), stencil.begin(), cuda::__is_even<T>{}, result.begin());
+  partition_kernel<<<1, 1>>>(exec, data.begin(), data.end(), stencil.begin(), cuda::__is_even{}, result.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
@@ -189,7 +189,7 @@ void TestPartitionCopyDevice(ExecutionPolicy exec)
     data.end(),
     true_results.begin(),
     false_results.begin(),
-    cuda::__is_even<T>{},
+    cuda::__is_even{},
     iterators.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
@@ -282,7 +282,7 @@ void TestPartitionCopyStencilDevice(ExecutionPolicy exec)
     stencil.begin(),
     true_results.begin(),
     false_results.begin(),
-    cuda::__is_even<T>{},
+    cuda::__is_even{},
     iterators.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
@@ -344,7 +344,7 @@ void TestStablePartitionDevice(ExecutionPolicy exec)
 
   thrust::device_vector<iterator> result(1);
 
-  stable_partition_kernel<<<1, 1>>>(exec, data.begin(), data.end(), cuda::__is_even<T>{}, result.begin());
+  stable_partition_kernel<<<1, 1>>>(exec, data.begin(), data.end(), cuda::__is_even{}, result.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
@@ -407,7 +407,7 @@ void TestStablePartitionStencilDevice(ExecutionPolicy exec)
   thrust::device_vector<iterator> result(1);
 
   stable_partition_kernel<<<1, 1>>>(
-    exec, data.begin(), data.end(), stencil.begin(), cuda::__is_even<T>{}, result.begin());
+    exec, data.begin(), data.end(), stencil.begin(), cuda::__is_even{}, result.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
@@ -483,7 +483,7 @@ void TestStablePartitionCopyDevice(ExecutionPolicy exec)
     data.end(),
     true_results.begin(),
     false_results.begin(),
-    cuda::__is_even<T>{},
+    cuda::__is_even{},
     iterators.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
@@ -576,7 +576,7 @@ void TestStablePartitionCopyStencilDevice(ExecutionPolicy exec)
     stencil.begin(),
     true_results.begin(),
     false_results.begin(),
-    cuda::__is_even<T>{},
+    cuda::__is_even{},
     iterators.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
@@ -712,7 +712,7 @@ void TestPartitionCudaStreams(ExecutionPolicy policy)
 
   auto streampolicy = policy.on(s);
 
-  Iterator iter = thrust::partition(streampolicy, data.begin(), data.end(), cuda::__is_even<T>{});
+  Iterator iter = thrust::partition(streampolicy, data.begin(), data.end(), cuda::__is_even{});
 
   Vector ref(5);
   ref[0] = 2;

--- a/thrust/testing/cuda/partition.cu
+++ b/thrust/testing/cuda/partition.cu
@@ -184,13 +184,7 @@ void TestPartitionCopyDevice(ExecutionPolicy exec)
   thrust::device_vector<pair_type> iterators(1);
 
   partition_copy_kernel<<<1, 1>>>(
-    exec,
-    data.begin(),
-    data.end(),
-    true_results.begin(),
-    false_results.begin(),
-    cuda::__is_even{},
-    iterators.begin());
+    exec, data.begin(), data.end(), true_results.begin(), false_results.begin(), cuda::__is_even{}, iterators.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
@@ -406,8 +400,7 @@ void TestStablePartitionStencilDevice(ExecutionPolicy exec)
 
   thrust::device_vector<iterator> result(1);
 
-  stable_partition_kernel<<<1, 1>>>(
-    exec, data.begin(), data.end(), stencil.begin(), cuda::__is_even{}, result.begin());
+  stable_partition_kernel<<<1, 1>>>(exec, data.begin(), data.end(), stencil.begin(), cuda::__is_even{}, result.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
@@ -478,13 +471,7 @@ void TestStablePartitionCopyDevice(ExecutionPolicy exec)
   thrust::device_vector<pair_type> iterators(1);
 
   stable_partition_copy_kernel<<<1, 1>>>(
-    exec,
-    data.begin(),
-    data.end(),
-    true_results.begin(),
-    false_results.begin(),
-    cuda::__is_even{},
-    iterators.begin());
+    exec, data.begin(), data.end(), true_results.begin(), false_results.begin(), cuda::__is_even{}, iterators.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 

--- a/thrust/testing/cuda/partition_point.cu
+++ b/thrust/testing/cuda/partition_point.cu
@@ -2,6 +2,8 @@
 #include <thrust/functional.h>
 #include <thrust/partition.h>
 
+#include <cuda/functional>
+
 #include <unittest/unittest.h>
 
 #ifdef THRUST_TEST_DEVICE_SIDE
@@ -12,15 +14,6 @@ partition_point_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Pr
   *result = thrust::partition_point(exec, first, last, pred);
 }
 
-template <typename T>
-struct is_even
-{
-  _CCCL_HOST_DEVICE bool operator()(T x) const
-  {
-    return ((int) x % 2) == 0;
-  }
-};
-
 template <typename ExecutionPolicy>
 void TestPartitionPointDevice(ExecutionPolicy exec)
 {
@@ -28,10 +21,10 @@ void TestPartitionPointDevice(ExecutionPolicy exec)
   thrust::device_vector<int> v = unittest::random_integers<int>(n);
   using iterator               = typename thrust::device_vector<int>::iterator;
 
-  iterator ref = thrust::stable_partition(v.begin(), v.end(), is_even<int>());
+  iterator ref = thrust::stable_partition(v.begin(), v.end(), cuda::__is_even<int>{});
 
   thrust::device_vector<iterator> result(1);
-  partition_point_kernel<<<1, 1>>>(exec, v.begin(), v.end(), is_even<int>(), result.begin());
+  partition_point_kernel<<<1, 1>>>(exec, v.begin(), v.end(), cuda::__is_even<int>{}, result.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 

--- a/thrust/testing/cuda/partition_point.cu
+++ b/thrust/testing/cuda/partition_point.cu
@@ -21,10 +21,10 @@ void TestPartitionPointDevice(ExecutionPolicy exec)
   thrust::device_vector<int> v = unittest::random_integers<int>(n);
   using iterator               = typename thrust::device_vector<int>::iterator;
 
-  iterator ref = thrust::stable_partition(v.begin(), v.end(), cuda::__is_even<int>{});
+  iterator ref = thrust::stable_partition(v.begin(), v.end(), cuda::__is_even{});
 
   thrust::device_vector<iterator> result(1);
-  partition_point_kernel<<<1, 1>>>(exec, v.begin(), v.end(), cuda::__is_even<int>{}, result.begin());
+  partition_point_kernel<<<1, 1>>>(exec, v.begin(), v.end(), cuda::__is_even{}, result.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 

--- a/thrust/testing/cuda/partition_point.cu
+++ b/thrust/testing/cuda/partition_point.cu
@@ -47,7 +47,6 @@ DECLARE_UNITTEST(TestPartitionPointDeviceDevice);
 void TestPartitionPointCudaStreams()
 {
   using Vector   = thrust::device_vector<int>;
-  using T        = Vector::value_type;
   using Iterator = Vector::iterator;
 
   Vector v(4);

--- a/thrust/testing/cuda/remove.cu
+++ b/thrust/testing/cuda/remove.cu
@@ -373,7 +373,7 @@ void TestRemoveIfCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  Vector::iterator end = thrust::remove_if(thrust::cuda::par.on(s), data.begin(), data.end(), cuda::__is_even<T>{});
+  Vector::iterator end = thrust::remove_if(thrust::cuda::par.on(s), data.begin(), data.end(), cuda::__is_even{});
 
   ASSERT_EQUAL(end - data.begin(), 3);
   data.erase(end, data.end());
@@ -423,7 +423,7 @@ void TestRemoveCopyIfCudaStreams()
   cudaStreamCreate(&s);
 
   Vector::iterator end =
-    thrust::remove_copy_if(thrust::cuda::par.on(s), data.begin(), data.end(), result.begin(), cuda::__is_even<T>{});
+    thrust::remove_copy_if(thrust::cuda::par.on(s), data.begin(), data.end(), result.begin(), cuda::__is_even{});
 
   ASSERT_EQUAL(end - result.begin(), 3);
   result.erase(end, result.end());

--- a/thrust/testing/cuda/remove.cu
+++ b/thrust/testing/cuda/remove.cu
@@ -1,6 +1,8 @@
 #include <thrust/execution_policy.h>
 #include <thrust/remove.h>
 
+#include <cuda/functional>
+
 #include <unittest/unittest.h>
 
 #ifdef THRUST_TEST_DEVICE_SIDE
@@ -55,15 +57,6 @@ __global__ void remove_copy_if_kernel(
   *result_end = thrust::remove_copy_if(exec, first, last, stencil_first, result, pred);
 }
 #endif
-
-template <typename T>
-struct is_even
-{
-  _CCCL_HOST_DEVICE bool operator()(T x)
-  {
-    return (static_cast<unsigned int>(x) & 1) == 0;
-  }
-};
 
 template <typename T>
 struct is_true
@@ -380,7 +373,7 @@ void TestRemoveIfCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  Vector::iterator end = thrust::remove_if(thrust::cuda::par.on(s), data.begin(), data.end(), is_even<T>());
+  Vector::iterator end = thrust::remove_if(thrust::cuda::par.on(s), data.begin(), data.end(), cuda::__is_even<T>{});
 
   ASSERT_EQUAL(end - data.begin(), 3);
   data.erase(end, data.end());
@@ -430,7 +423,7 @@ void TestRemoveCopyIfCudaStreams()
   cudaStreamCreate(&s);
 
   Vector::iterator end =
-    thrust::remove_copy_if(thrust::cuda::par.on(s), data.begin(), data.end(), result.begin(), is_even<T>());
+    thrust::remove_copy_if(thrust::cuda::par.on(s), data.begin(), data.end(), result.begin(), cuda::__is_even<T>{});
 
   ASSERT_EQUAL(end - result.begin(), 3);
   result.erase(end, result.end());

--- a/thrust/testing/cuda/remove.cu
+++ b/thrust/testing/cuda/remove.cu
@@ -366,7 +366,6 @@ DECLARE_UNITTEST(TestRemoveCopyCudaStreams);
 void TestRemoveIfCudaStreams()
 {
   using Vector = thrust::device_vector<int>;
-  using T      = Vector::value_type;
 
   Vector data{1, 2, 1, 3, 2};
 
@@ -413,7 +412,6 @@ DECLARE_UNITTEST(TestRemoveIfStencilCudaStreams);
 void TestRemoveCopyIfCudaStreams()
 {
   using Vector = thrust::device_vector<int>;
-  using T      = Vector::value_type;
 
   Vector data{1, 2, 1, 3, 2};
 

--- a/thrust/testing/cuda/scatter.cu
+++ b/thrust/testing/cuda/scatter.cu
@@ -96,17 +96,10 @@ void TestScatterIfDevice(ExecutionPolicy exec)
   thrust::host_vector<int> h_output(output_size, 0);
   thrust::device_vector<int> d_output(output_size, 0);
 
-  thrust::scatter_if(
-    h_input.begin(), h_input.end(), h_map.begin(), h_map.begin(), h_output.begin(), cuda::__is_even());
+  thrust::scatter_if(h_input.begin(), h_input.end(), h_map.begin(), h_map.begin(), h_output.begin(), cuda::__is_even());
 
   scatter_if_kernel<<<1, 1>>>(
-    exec,
-    d_input.begin(),
-    d_input.end(),
-    d_map.begin(),
-    d_map.begin(),
-    d_output.begin(),
-    cuda::__is_even());
+    exec, d_input.begin(), d_input.end(), d_map.begin(), d_map.begin(), d_output.begin(), cuda::__is_even());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 

--- a/thrust/testing/cuda/scatter.cu
+++ b/thrust/testing/cuda/scatter.cu
@@ -97,7 +97,7 @@ void TestScatterIfDevice(ExecutionPolicy exec)
   thrust::device_vector<int> d_output(output_size, 0);
 
   thrust::scatter_if(
-    h_input.begin(), h_input.end(), h_map.begin(), h_map.begin(), h_output.begin(), cuda::__is_even<unsigned int>());
+    h_input.begin(), h_input.end(), h_map.begin(), h_map.begin(), h_output.begin(), cuda::__is_even());
 
   scatter_if_kernel<<<1, 1>>>(
     exec,
@@ -106,7 +106,7 @@ void TestScatterIfDevice(ExecutionPolicy exec)
     d_map.begin(),
     d_map.begin(),
     d_output.begin(),
-    cuda::__is_even<unsigned int>());
+    cuda::__is_even());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 

--- a/thrust/testing/cuda/scatter.cu
+++ b/thrust/testing/cuda/scatter.cu
@@ -1,6 +1,8 @@
 #include <thrust/execution_policy.h>
 #include <thrust/scatter.h>
 
+#include <cuda/functional>
+
 #include <algorithm>
 
 #include <unittest/unittest.h>
@@ -73,15 +75,6 @@ __global__ void scatter_if_kernel(
   thrust::scatter_if(exec, first, last, map_first, stencil_first, result, f);
 }
 
-template <typename T>
-struct is_even_scatter_if
-{
-  _CCCL_HOST_DEVICE bool operator()(const T i) const
-  {
-    return (i % 2) == 0;
-  }
-};
-
 template <typename ExecutionPolicy>
 void TestScatterIfDevice(ExecutionPolicy exec)
 {
@@ -104,7 +97,7 @@ void TestScatterIfDevice(ExecutionPolicy exec)
   thrust::device_vector<int> d_output(output_size, 0);
 
   thrust::scatter_if(
-    h_input.begin(), h_input.end(), h_map.begin(), h_map.begin(), h_output.begin(), is_even_scatter_if<unsigned int>());
+    h_input.begin(), h_input.end(), h_map.begin(), h_map.begin(), h_output.begin(), cuda::__is_even<unsigned int>());
 
   scatter_if_kernel<<<1, 1>>>(
     exec,
@@ -113,7 +106,7 @@ void TestScatterIfDevice(ExecutionPolicy exec)
     d_map.begin(),
     d_map.begin(),
     d_output.begin(),
-    is_even_scatter_if<unsigned int>());
+    cuda::__is_even<unsigned int>());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 

--- a/thrust/testing/cuda/scatter.cu
+++ b/thrust/testing/cuda/scatter.cu
@@ -96,10 +96,10 @@ void TestScatterIfDevice(ExecutionPolicy exec)
   thrust::host_vector<int> h_output(output_size, 0);
   thrust::device_vector<int> d_output(output_size, 0);
 
-  thrust::scatter_if(h_input.begin(), h_input.end(), h_map.begin(), h_map.begin(), h_output.begin(), cuda::__is_even());
+  thrust::scatter_if(h_input.begin(), h_input.end(), h_map.begin(), h_map.begin(), h_output.begin(), cuda::__is_even{});
 
   scatter_if_kernel<<<1, 1>>>(
-    exec, d_input.begin(), d_input.end(), d_map.begin(), d_map.begin(), d_output.begin(), cuda::__is_even());
+    exec, d_input.begin(), d_input.end(), d_map.begin(), d_map.begin(), d_output.begin(), cuda::__is_even{});
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 

--- a/thrust/testing/gather.cu
+++ b/thrust/testing/gather.cu
@@ -5,6 +5,8 @@
 #include <thrust/iterator/retag.h>
 #include <thrust/sequence.h>
 
+#include <cuda/functional>
+
 #include <algorithm>
 
 #include <unittest/unittest.h>
@@ -149,15 +151,6 @@ void TestGatherIfSimple()
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestGatherIfSimple);
 
-template <typename T>
-struct is_even_gather_if
-{
-  _CCCL_HOST_DEVICE bool operator()(const T i) const
-  {
-    return (i % 2) == 0;
-  }
-};
-
 template <typename InputIterator1, typename InputIterator2, typename RandomAccessIterator, typename OutputIterator>
 OutputIterator gather_if(
   my_system& system,
@@ -244,19 +237,9 @@ void TestGatherIf(const size_t n)
   thrust::device_vector<T> d_output(n);
 
   thrust::gather_if(
-    h_map.begin(),
-    h_map.end(),
-    h_stencil.begin(),
-    h_source.begin(),
-    h_output.begin(),
-    is_even_gather_if<unsigned int>());
+    h_map.begin(), h_map.end(), h_stencil.begin(), h_source.begin(), h_output.begin(), cuda::__is_even<unsigned int>());
   thrust::gather_if(
-    d_map.begin(),
-    d_map.end(),
-    d_stencil.begin(),
-    d_source.begin(),
-    d_output.begin(),
-    is_even_gather_if<unsigned int>());
+    d_map.begin(), d_map.end(), d_stencil.begin(), d_source.begin(), d_output.begin(), cuda::__is_even<unsigned int>());
 
   ASSERT_EQUAL(h_output, d_output);
 }
@@ -297,7 +280,7 @@ void TestGatherIfToDiscardIterator(const size_t n)
     h_stencil.begin(),
     h_source.begin(),
     thrust::make_discard_iterator(),
-    is_even_gather_if<unsigned int>());
+    cuda::__is_even<unsigned int>());
 
   thrust::discard_iterator<> d_result = thrust::gather_if(
     d_map.begin(),
@@ -305,7 +288,7 @@ void TestGatherIfToDiscardIterator(const size_t n)
     d_stencil.begin(),
     d_source.begin(),
     thrust::make_discard_iterator(),
-    is_even_gather_if<unsigned int>());
+    cuda::__is_even<unsigned int>());
 
   thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 

--- a/thrust/testing/gather.cu
+++ b/thrust/testing/gather.cu
@@ -237,9 +237,9 @@ void TestGatherIf(const size_t n)
   thrust::device_vector<T> d_output(n);
 
   thrust::gather_if(
-    h_map.begin(), h_map.end(), h_stencil.begin(), h_source.begin(), h_output.begin(), cuda::__is_even<unsigned int>());
+    h_map.begin(), h_map.end(), h_stencil.begin(), h_source.begin(), h_output.begin(), cuda::__is_even());
   thrust::gather_if(
-    d_map.begin(), d_map.end(), d_stencil.begin(), d_source.begin(), d_output.begin(), cuda::__is_even<unsigned int>());
+    d_map.begin(), d_map.end(), d_stencil.begin(), d_source.begin(), d_output.begin(), cuda::__is_even());
 
   ASSERT_EQUAL(h_output, d_output);
 }
@@ -280,7 +280,7 @@ void TestGatherIfToDiscardIterator(const size_t n)
     h_stencil.begin(),
     h_source.begin(),
     thrust::make_discard_iterator(),
-    cuda::__is_even<unsigned int>());
+    cuda::__is_even());
 
   thrust::discard_iterator<> d_result = thrust::gather_if(
     d_map.begin(),
@@ -288,7 +288,7 @@ void TestGatherIfToDiscardIterator(const size_t n)
     d_stencil.begin(),
     d_source.begin(),
     thrust::make_discard_iterator(),
-    cuda::__is_even<unsigned int>());
+    cuda::__is_even());
 
   thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 

--- a/thrust/testing/gather.cu
+++ b/thrust/testing/gather.cu
@@ -275,20 +275,10 @@ void TestGatherIfToDiscardIterator(const size_t n)
   thrust::device_vector<unsigned int> d_stencil = h_stencil;
 
   thrust::discard_iterator<> h_result = thrust::gather_if(
-    h_map.begin(),
-    h_map.end(),
-    h_stencil.begin(),
-    h_source.begin(),
-    thrust::make_discard_iterator(),
-    cuda::__is_even());
+    h_map.begin(), h_map.end(), h_stencil.begin(), h_source.begin(), thrust::make_discard_iterator(), cuda::__is_even());
 
   thrust::discard_iterator<> d_result = thrust::gather_if(
-    d_map.begin(),
-    d_map.end(),
-    d_stencil.begin(),
-    d_source.begin(),
-    thrust::make_discard_iterator(),
-    cuda::__is_even());
+    d_map.begin(), d_map.end(), d_stencil.begin(), d_source.begin(), thrust::make_discard_iterator(), cuda::__is_even());
 
   thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 

--- a/thrust/testing/gather.cu
+++ b/thrust/testing/gather.cu
@@ -237,9 +237,9 @@ void TestGatherIf(const size_t n)
   thrust::device_vector<T> d_output(n);
 
   thrust::gather_if(
-    h_map.begin(), h_map.end(), h_stencil.begin(), h_source.begin(), h_output.begin(), cuda::__is_even());
+    h_map.begin(), h_map.end(), h_stencil.begin(), h_source.begin(), h_output.begin(), cuda::__is_even{});
   thrust::gather_if(
-    d_map.begin(), d_map.end(), d_stencil.begin(), d_source.begin(), d_output.begin(), cuda::__is_even());
+    d_map.begin(), d_map.end(), d_stencil.begin(), d_source.begin(), d_output.begin(), cuda::__is_even{});
 
   ASSERT_EQUAL(h_output, d_output);
 }
@@ -275,10 +275,10 @@ void TestGatherIfToDiscardIterator(const size_t n)
   thrust::device_vector<unsigned int> d_stencil = h_stencil;
 
   thrust::discard_iterator<> h_result = thrust::gather_if(
-    h_map.begin(), h_map.end(), h_stencil.begin(), h_source.begin(), thrust::make_discard_iterator(), cuda::__is_even());
+    h_map.begin(), h_map.end(), h_stencil.begin(), h_source.begin(), thrust::make_discard_iterator(), cuda::__is_even{});
 
   thrust::discard_iterator<> d_result = thrust::gather_if(
-    d_map.begin(), d_map.end(), d_stencil.begin(), d_source.begin(), thrust::make_discard_iterator(), cuda::__is_even());
+    d_map.begin(), d_map.end(), d_stencil.begin(), d_source.begin(), thrust::make_discard_iterator(), cuda::__is_even{});
 
   thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 

--- a/thrust/testing/is_partitioned.cu
+++ b/thrust/testing/is_partitioned.cu
@@ -45,11 +45,11 @@ void TestIsPartitioned()
   v[0] = 1;
   v[1] = 0;
 
-  ASSERT_EQUAL(false, thrust::is_partitioned(v.begin(), v.end(), cuda::__is_even<T>{}));
+  ASSERT_EQUAL(false, thrust::is_partitioned(v.begin(), v.end(), cuda::__is_even{}));
 
-  thrust::partition(v.begin(), v.end(), cuda::__is_even<T>{});
+  thrust::partition(v.begin(), v.end(), cuda::__is_even{});
 
-  ASSERT_EQUAL(true, thrust::is_partitioned(v.begin(), v.end(), cuda::__is_even<T>{}));
+  ASSERT_EQUAL(true, thrust::is_partitioned(v.begin(), v.end(), cuda::__is_even{}));
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestIsPartitioned);
 

--- a/thrust/testing/is_partitioned.cu
+++ b/thrust/testing/is_partitioned.cu
@@ -2,16 +2,9 @@
 #include <thrust/iterator/retag.h>
 #include <thrust/partition.h>
 
-#include <unittest/unittest.h>
+#include <cuda/functional>
 
-template <typename T>
-struct is_even
-{
-  _CCCL_HOST_DEVICE bool operator()(T x) const
-  {
-    return ((int) x % 2) == 0;
-  }
-};
+#include <unittest/unittest.h>
 
 template <typename Vector>
 void TestIsPartitionedSimple()
@@ -52,11 +45,11 @@ void TestIsPartitioned()
   v[0] = 1;
   v[1] = 0;
 
-  ASSERT_EQUAL(false, thrust::is_partitioned(v.begin(), v.end(), is_even<T>()));
+  ASSERT_EQUAL(false, thrust::is_partitioned(v.begin(), v.end(), cuda::__is_even<T>{}));
 
-  thrust::partition(v.begin(), v.end(), is_even<T>());
+  thrust::partition(v.begin(), v.end(), cuda::__is_even<T>{});
 
-  ASSERT_EQUAL(true, thrust::is_partitioned(v.begin(), v.end(), is_even<T>()));
+  ASSERT_EQUAL(true, thrust::is_partitioned(v.begin(), v.end(), cuda::__is_even<T>{}));
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestIsPartitioned);
 

--- a/thrust/testing/partition.cu
+++ b/thrust/testing/partition.cu
@@ -157,8 +157,8 @@ void TestStablePartitionCopySimple()
   Vector true_results(2);
   Vector false_results(3);
 
-  cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends =
-    thrust::stable_partition_copy(data.begin(), data.end(), true_results.begin(), false_results.begin(), cuda::__is_even<T>{});
+  cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends = thrust::stable_partition_copy(
+    data.begin(), data.end(), true_results.begin(), false_results.begin(), cuda::__is_even<T>{});
 
   Vector true_ref(2, 2);
 
@@ -203,8 +203,10 @@ struct TestPartition
     thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_data = h_data;
 
-    typename thrust::host_vector<T>::iterator h_iter   = thrust::partition(h_data.begin(), h_data.end(), cuda::__is_even<T>{});
-    typename thrust::device_vector<T>::iterator d_iter = thrust::partition(d_data.begin(), d_data.end(), cuda::__is_even<T>{});
+    typename thrust::host_vector<T>::iterator h_iter =
+      thrust::partition(h_data.begin(), h_data.end(), cuda::__is_even<T>{});
+    typename thrust::device_vector<T>::iterator d_iter =
+      thrust::partition(d_data.begin(), d_data.end(), cuda::__is_even<T>{});
 
     thrust::sort(h_data.begin(), h_iter);
     thrust::sort(h_iter, h_data.end());
@@ -320,11 +322,21 @@ struct TestPartitionCopyStencil
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
       thrust::partition_copy(
-        h_data.begin(), h_data.end(), h_stencil.begin(), h_true_results.begin(), h_false_results.begin(), cuda::__is_even<T>{});
+        h_data.begin(),
+        h_data.end(),
+        h_stencil.begin(),
+        h_true_results.begin(),
+        h_false_results.begin(),
+        cuda::__is_even<T>{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
       thrust::partition_copy(
-        d_data.begin(), d_data.end(), d_stencil.begin(), d_true_results.begin(), d_false_results.begin(), cuda::__is_even<T>{});
+        d_data.begin(),
+        d_data.end(),
+        d_stencil.begin(),
+        d_true_results.begin(),
+        d_false_results.begin(),
+        cuda::__is_even<T>{});
 
     // check true output
     ASSERT_EQUAL(h_ends.first - h_true_results.begin(), n_true);
@@ -365,11 +377,21 @@ struct TestStablePartitionCopyStencil
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
       thrust::stable_partition_copy(
-        h_data.begin(), h_data.end(), h_stencil.begin(), h_true_results.begin(), h_false_results.begin(), cuda::__is_even<T>{});
+        h_data.begin(),
+        h_data.end(),
+        h_stencil.begin(),
+        h_true_results.begin(),
+        h_false_results.begin(),
+        cuda::__is_even<T>{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
       thrust::stable_partition_copy(
-        d_data.begin(), d_data.end(), d_stencil.begin(), d_true_results.begin(), d_false_results.begin(), cuda::__is_even<T>{});
+        d_data.begin(),
+        d_data.end(),
+        d_stencil.begin(),
+        d_true_results.begin(),
+        d_false_results.begin(),
+        cuda::__is_even<T>{});
 
     // check true output
     ASSERT_EQUAL(h_ends.first - h_true_results.begin(), n_true);
@@ -402,10 +424,18 @@ struct TestPartitionCopyToDiscardIterator
 
     // mask both ranges
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::partition_copy(
-      h_data.begin(), h_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
+      h_data.begin(),
+      h_data.end(),
+      thrust::make_discard_iterator(),
+      thrust::make_discard_iterator(),
+      cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::partition_copy(
-      d_data.begin(), d_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
+      d_data.begin(),
+      d_data.end(),
+      thrust::make_discard_iterator(),
+      thrust::make_discard_iterator(),
+      cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
@@ -503,11 +533,21 @@ struct TestPartitionCopyStencilToDiscardIterator
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
       thrust::partition_copy(
-        h_data.begin(), h_data.end(), h_stencil.begin(), h_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
+        h_data.begin(),
+        h_data.end(),
+        h_stencil.begin(),
+        h_trues.begin(),
+        thrust::make_discard_iterator(),
+        cuda::__is_even<T>{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::partition_copy(
-        d_data.begin(), d_data.end(), d_stencil.begin(), d_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
+        d_data.begin(),
+        d_data.end(),
+        d_stencil.begin(),
+        d_trues.begin(),
+        thrust::make_discard_iterator(),
+        cuda::__is_even<T>{});
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
       cuda::std::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
@@ -660,10 +700,18 @@ struct TestStablePartitionCopyToDiscardIterator
 
     // mask both ranges
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::stable_partition_copy(
-      h_data.begin(), h_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
+      h_data.begin(),
+      h_data.end(),
+      thrust::make_discard_iterator(),
+      thrust::make_discard_iterator(),
+      cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::stable_partition_copy(
-      d_data.begin(), d_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
+      d_data.begin(),
+      d_data.end(),
+      thrust::make_discard_iterator(),
+      thrust::make_discard_iterator(),
+      cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
@@ -762,11 +810,21 @@ struct TestStablePartitionCopyStencilToDiscardIterator
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
       thrust::stable_partition_copy(
-        h_data.begin(), h_data.end(), h_stencil.begin(), h_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
+        h_data.begin(),
+        h_data.end(),
+        h_stencil.begin(),
+        h_trues.begin(),
+        thrust::make_discard_iterator(),
+        cuda::__is_even<T>{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::stable_partition_copy(
-        d_data.begin(), d_data.end(), d_stencil.begin(), d_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
+        d_data.begin(),
+        d_data.end(),
+        d_stencil.begin(),
+        d_trues.begin(),
+        thrust::make_discard_iterator(),
+        cuda::__is_even<T>{});
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
       cuda::std::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));

--- a/thrust/testing/partition.cu
+++ b/thrust/testing/partition.cu
@@ -34,7 +34,7 @@ void TestPartitionSimple()
 
   Vector data{1, 2, 1, 1, 2};
 
-  Iterator iter = thrust::partition(data.begin(), data.end(), cuda::__is_even<T>{});
+  Iterator iter = thrust::partition(data.begin(), data.end(), cuda::__is_even{});
 
   Vector ref{2, 2, 1, 1, 1};
 
@@ -53,7 +53,7 @@ void TestPartitionStencilSimple()
 
   Vector stencil{1, 2, 1, 1, 2};
 
-  Iterator iter = thrust::partition(data.begin(), data.end(), stencil.begin(), cuda::__is_even<T>{});
+  Iterator iter = thrust::partition(data.begin(), data.end(), stencil.begin(), cuda::__is_even{});
 
   Vector ref{1, 1, 0, 0, 0};
 
@@ -73,7 +73,7 @@ void TestPartitionCopySimple()
   Vector false_results(3);
 
   cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends =
-    thrust::partition_copy(data.begin(), data.end(), true_results.begin(), false_results.begin(), cuda::__is_even<T>{});
+    thrust::partition_copy(data.begin(), data.end(), true_results.begin(), false_results.begin(), cuda::__is_even{});
 
   Vector true_ref(2, 2);
 
@@ -99,7 +99,7 @@ void TestPartitionCopyStencilSimple()
   Vector false_results(3);
 
   cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends = thrust::partition_copy(
-    data.begin(), data.end(), stencil.begin(), true_results.begin(), false_results.begin(), cuda::__is_even<T>{});
+    data.begin(), data.end(), stencil.begin(), true_results.begin(), false_results.begin(), cuda::__is_even{});
 
   Vector true_ref(2, 1);
 
@@ -120,7 +120,7 @@ void TestStablePartitionSimple()
 
   Vector data{1, 2, 1, 3, 2};
 
-  Iterator iter = thrust::stable_partition(data.begin(), data.end(), cuda::__is_even<T>{});
+  Iterator iter = thrust::stable_partition(data.begin(), data.end(), cuda::__is_even{});
 
   Vector ref{2, 2, 1, 1, 3};
 
@@ -158,7 +158,7 @@ void TestStablePartitionCopySimple()
   Vector false_results(3);
 
   cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends = thrust::stable_partition_copy(
-    data.begin(), data.end(), true_results.begin(), false_results.begin(), cuda::__is_even<T>{});
+    data.begin(), data.end(), true_results.begin(), false_results.begin(), cuda::__is_even{});
 
   Vector true_ref(2, 2);
 
@@ -204,9 +204,9 @@ struct TestPartition
     thrust::device_vector<T> d_data = h_data;
 
     typename thrust::host_vector<T>::iterator h_iter =
-      thrust::partition(h_data.begin(), h_data.end(), cuda::__is_even<T>{});
+      thrust::partition(h_data.begin(), h_data.end(), cuda::__is_even{});
     typename thrust::device_vector<T>::iterator d_iter =
-      thrust::partition(d_data.begin(), d_data.end(), cuda::__is_even<T>{});
+      thrust::partition(d_data.begin(), d_data.end(), cuda::__is_even{});
 
     thrust::sort(h_data.begin(), h_iter);
     thrust::sort(h_iter, h_data.end());
@@ -242,9 +242,9 @@ struct TestPartitionStencil
     thrust::device_vector<T> d_stencil = h_stencil;
 
     typename thrust::host_vector<T>::iterator h_iter =
-      thrust::partition(h_data.begin(), h_data.end(), h_stencil.begin(), cuda::__is_even<T>{});
+      thrust::partition(h_data.begin(), h_data.end(), h_stencil.begin(), cuda::__is_even{});
     typename thrust::device_vector<T>::iterator d_iter =
-      thrust::partition(d_data.begin(), d_data.end(), d_stencil.begin(), cuda::__is_even<T>{});
+      thrust::partition(d_data.begin(), d_data.end(), d_stencil.begin(), cuda::__is_even{});
 
     thrust::sort(h_data.begin(), h_iter);
     thrust::sort(h_iter, h_data.end());
@@ -266,7 +266,7 @@ struct TestPartitionCopy
     thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_data = h_data;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), cuda::__is_even<T>{});
+    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), cuda::__is_even{});
     std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // setup output ranges
@@ -277,11 +277,11 @@ struct TestPartitionCopy
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
       thrust::partition_copy(
-        h_data.begin(), h_data.end(), h_true_results.begin(), h_false_results.begin(), cuda::__is_even<T>{});
+        h_data.begin(), h_data.end(), h_true_results.begin(), h_false_results.begin(), cuda::__is_even{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
       thrust::partition_copy(
-        d_data.begin(), d_data.end(), d_true_results.begin(), d_false_results.begin(), cuda::__is_even<T>{});
+        d_data.begin(), d_data.end(), d_true_results.begin(), d_false_results.begin(), cuda::__is_even{});
 
     // check true output
     ASSERT_EQUAL(h_ends.first - h_true_results.begin(), n_true);
@@ -311,7 +311,7 @@ struct TestPartitionCopyStencil
     thrust::device_vector<T> d_data    = h_data;
     thrust::device_vector<T> d_stencil = h_stencil;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), cuda::__is_even<T>{});
+    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), cuda::__is_even{});
     std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // setup output ranges
@@ -327,7 +327,7 @@ struct TestPartitionCopyStencil
         h_stencil.begin(),
         h_true_results.begin(),
         h_false_results.begin(),
-        cuda::__is_even<T>{});
+        cuda::__is_even{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
       thrust::partition_copy(
@@ -336,7 +336,7 @@ struct TestPartitionCopyStencil
         d_stencil.begin(),
         d_true_results.begin(),
         d_false_results.begin(),
-        cuda::__is_even<T>{});
+        cuda::__is_even{});
 
     // check true output
     ASSERT_EQUAL(h_ends.first - h_true_results.begin(), n_true);
@@ -366,7 +366,7 @@ struct TestStablePartitionCopyStencil
     thrust::device_vector<T> d_data    = h_data;
     thrust::device_vector<T> d_stencil = h_stencil;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), cuda::__is_even<T>{});
+    std::ptrdiff_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), cuda::__is_even{});
     std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // setup output ranges
@@ -382,7 +382,7 @@ struct TestStablePartitionCopyStencil
         h_stencil.begin(),
         h_true_results.begin(),
         h_false_results.begin(),
-        cuda::__is_even<T>{});
+        cuda::__is_even{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
       thrust::stable_partition_copy(
@@ -391,7 +391,7 @@ struct TestStablePartitionCopyStencil
         d_stencil.begin(),
         d_true_results.begin(),
         d_false_results.begin(),
-        cuda::__is_even<T>{});
+        cuda::__is_even{});
 
     // check true output
     ASSERT_EQUAL(h_ends.first - h_true_results.begin(), n_true);
@@ -419,7 +419,7 @@ struct TestPartitionCopyToDiscardIterator
     thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_data = h_data;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), cuda::__is_even<T>{});
+    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), cuda::__is_even{});
     std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // mask both ranges
@@ -428,14 +428,14 @@ struct TestPartitionCopyToDiscardIterator
       h_data.end(),
       thrust::make_discard_iterator(),
       thrust::make_discard_iterator(),
-      cuda::__is_even<T>{});
+      cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::partition_copy(
       d_data.begin(),
       d_data.end(),
       thrust::make_discard_iterator(),
       thrust::make_discard_iterator(),
-      cuda::__is_even<T>{});
+      cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
@@ -449,11 +449,11 @@ struct TestPartitionCopyToDiscardIterator
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
       thrust::partition_copy(
-        h_data.begin(), h_data.end(), h_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
+        h_data.begin(), h_data.end(), h_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::partition_copy(
-        d_data.begin(), d_data.end(), d_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
+        d_data.begin(), d_data.end(), d_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even{});
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
       cuda::std::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
@@ -471,11 +471,11 @@ struct TestPartitionCopyToDiscardIterator
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
       thrust::partition_copy(
-        h_data.begin(), h_data.end(), thrust::make_discard_iterator(), h_falses.begin(), cuda::__is_even<T>{});
+        h_data.begin(), h_data.end(), thrust::make_discard_iterator(), h_falses.begin(), cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
       thrust::partition_copy(
-        d_data.begin(), d_data.end(), thrust::make_discard_iterator(), d_falses.begin(), cuda::__is_even<T>{});
+        d_data.begin(), d_data.end(), thrust::make_discard_iterator(), d_falses.begin(), cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);
@@ -501,7 +501,7 @@ struct TestPartitionCopyStencilToDiscardIterator
     thrust::device_vector<T> d_data    = h_data;
     thrust::device_vector<T> d_stencil = h_stencil;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), cuda::__is_even<T>{});
+    std::ptrdiff_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), cuda::__is_even{});
     std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // mask both ranges
@@ -511,7 +511,7 @@ struct TestPartitionCopyStencilToDiscardIterator
       h_stencil.begin(),
       thrust::make_discard_iterator(),
       thrust::make_discard_iterator(),
-      cuda::__is_even<T>{});
+      cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::partition_copy(
       d_data.begin(),
@@ -519,7 +519,7 @@ struct TestPartitionCopyStencilToDiscardIterator
       d_stencil.begin(),
       thrust::make_discard_iterator(),
       thrust::make_discard_iterator(),
-      cuda::__is_even<T>{});
+      cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
@@ -538,7 +538,7 @@ struct TestPartitionCopyStencilToDiscardIterator
         h_stencil.begin(),
         h_trues.begin(),
         thrust::make_discard_iterator(),
-        cuda::__is_even<T>{});
+        cuda::__is_even{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::partition_copy(
@@ -547,7 +547,7 @@ struct TestPartitionCopyStencilToDiscardIterator
         d_stencil.begin(),
         d_trues.begin(),
         thrust::make_discard_iterator(),
-        cuda::__is_even<T>{});
+        cuda::__is_even{});
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
       cuda::std::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
@@ -570,7 +570,7 @@ struct TestPartitionCopyStencilToDiscardIterator
         h_stencil.begin(),
         thrust::make_discard_iterator(),
         h_falses.begin(),
-        cuda::__is_even<T>{});
+        cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
       thrust::partition_copy(
@@ -579,7 +579,7 @@ struct TestPartitionCopyStencilToDiscardIterator
         d_stencil.begin(),
         thrust::make_discard_iterator(),
         d_falses.begin(),
-        cuda::__is_even<T>{});
+        cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);
@@ -608,9 +608,9 @@ struct TestStablePartition
     thrust::device_vector<T> d_data = h_data;
 
     typename thrust::host_vector<T>::iterator h_iter =
-      thrust::stable_partition(h_data.begin(), h_data.end(), cuda::__is_even<T>{});
+      thrust::stable_partition(h_data.begin(), h_data.end(), cuda::__is_even{});
     typename thrust::device_vector<T>::iterator d_iter =
-      thrust::stable_partition(d_data.begin(), d_data.end(), cuda::__is_even<T>{});
+      thrust::stable_partition(d_data.begin(), d_data.end(), cuda::__is_even{});
 
     ASSERT_EQUAL(h_data, d_data);
     ASSERT_EQUAL(h_iter - h_data.begin(), d_iter - d_data.begin());
@@ -635,9 +635,9 @@ struct TestStablePartitionStencil
     thrust::device_vector<T> d_stencil = h_stencil;
 
     typename thrust::host_vector<T>::iterator h_iter =
-      thrust::stable_partition(h_data.begin(), h_data.end(), h_stencil.begin(), cuda::__is_even<T>{});
+      thrust::stable_partition(h_data.begin(), h_data.end(), h_stencil.begin(), cuda::__is_even{});
     typename thrust::device_vector<T>::iterator d_iter =
-      thrust::stable_partition(d_data.begin(), d_data.end(), d_stencil.begin(), cuda::__is_even<T>{});
+      thrust::stable_partition(d_data.begin(), d_data.end(), d_stencil.begin(), cuda::__is_even{});
 
     ASSERT_EQUAL(h_data, d_data);
     ASSERT_EQUAL(h_iter - h_data.begin(), d_iter - d_data.begin());
@@ -656,7 +656,7 @@ struct TestStablePartitionCopy
     thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_data = h_data;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), cuda::__is_even<T>{});
+    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), cuda::__is_even{});
     std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // setup output ranges
@@ -667,11 +667,11 @@ struct TestStablePartitionCopy
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
       thrust::stable_partition_copy(
-        h_data.begin(), h_data.end(), h_true_results.begin(), h_false_results.begin(), cuda::__is_even<T>{});
+        h_data.begin(), h_data.end(), h_true_results.begin(), h_false_results.begin(), cuda::__is_even{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
       thrust::stable_partition_copy(
-        d_data.begin(), d_data.end(), d_true_results.begin(), d_false_results.begin(), cuda::__is_even<T>{});
+        d_data.begin(), d_data.end(), d_true_results.begin(), d_false_results.begin(), cuda::__is_even{});
 
     // check true output
     ASSERT_EQUAL(h_ends.first - h_true_results.begin(), n_true);
@@ -695,7 +695,7 @@ struct TestStablePartitionCopyToDiscardIterator
     thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_data = h_data;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), cuda::__is_even<T>{});
+    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), cuda::__is_even{});
     std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // mask both ranges
@@ -704,14 +704,14 @@ struct TestStablePartitionCopyToDiscardIterator
       h_data.end(),
       thrust::make_discard_iterator(),
       thrust::make_discard_iterator(),
-      cuda::__is_even<T>{});
+      cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::stable_partition_copy(
       d_data.begin(),
       d_data.end(),
       thrust::make_discard_iterator(),
       thrust::make_discard_iterator(),
-      cuda::__is_even<T>{});
+      cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
@@ -725,11 +725,11 @@ struct TestStablePartitionCopyToDiscardIterator
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
       thrust::stable_partition_copy(
-        h_data.begin(), h_data.end(), h_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
+        h_data.begin(), h_data.end(), h_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::stable_partition_copy(
-        d_data.begin(), d_data.end(), d_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
+        d_data.begin(), d_data.end(), d_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even{});
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
       cuda::std::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
@@ -747,11 +747,11 @@ struct TestStablePartitionCopyToDiscardIterator
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
       thrust::stable_partition_copy(
-        h_data.begin(), h_data.end(), thrust::make_discard_iterator(), h_falses.begin(), cuda::__is_even<T>{});
+        h_data.begin(), h_data.end(), thrust::make_discard_iterator(), h_falses.begin(), cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
       thrust::stable_partition_copy(
-        d_data.begin(), d_data.end(), thrust::make_discard_iterator(), d_falses.begin(), cuda::__is_even<T>{});
+        d_data.begin(), d_data.end(), thrust::make_discard_iterator(), d_falses.begin(), cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);
@@ -778,7 +778,7 @@ struct TestStablePartitionCopyStencilToDiscardIterator
     thrust::device_vector<T> d_data    = h_data;
     thrust::device_vector<T> d_stencil = h_stencil;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), cuda::__is_even<T>{});
+    std::ptrdiff_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), cuda::__is_even{});
     std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // mask both ranges
@@ -788,7 +788,7 @@ struct TestStablePartitionCopyStencilToDiscardIterator
       h_stencil.begin(),
       thrust::make_discard_iterator(),
       thrust::make_discard_iterator(),
-      cuda::__is_even<T>{});
+      cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::stable_partition_copy(
       d_data.begin(),
@@ -796,7 +796,7 @@ struct TestStablePartitionCopyStencilToDiscardIterator
       d_stencil.begin(),
       thrust::make_discard_iterator(),
       thrust::make_discard_iterator(),
-      cuda::__is_even<T>{});
+      cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
@@ -815,7 +815,7 @@ struct TestStablePartitionCopyStencilToDiscardIterator
         h_stencil.begin(),
         h_trues.begin(),
         thrust::make_discard_iterator(),
-        cuda::__is_even<T>{});
+        cuda::__is_even{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::stable_partition_copy(
@@ -824,7 +824,7 @@ struct TestStablePartitionCopyStencilToDiscardIterator
         d_stencil.begin(),
         d_trues.begin(),
         thrust::make_discard_iterator(),
-        cuda::__is_even<T>{});
+        cuda::__is_even{});
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
       cuda::std::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
@@ -847,7 +847,7 @@ struct TestStablePartitionCopyStencilToDiscardIterator
         h_stencil.begin(),
         thrust::make_discard_iterator(),
         h_falses.begin(),
-        cuda::__is_even<T>{});
+        cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
       thrust::stable_partition_copy(
@@ -856,7 +856,7 @@ struct TestStablePartitionCopyStencilToDiscardIterator
         d_stencil.begin(),
         thrust::make_discard_iterator(),
         d_falses.begin(),
-        cuda::__is_even<T>{});
+        cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);

--- a/thrust/testing/partition.cu
+++ b/thrust/testing/partition.cu
@@ -424,18 +424,10 @@ struct TestPartitionCopyToDiscardIterator
 
     // mask both ranges
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::partition_copy(
-      h_data.begin(),
-      h_data.end(),
-      thrust::make_discard_iterator(),
-      thrust::make_discard_iterator(),
-      cuda::__is_even{});
+      h_data.begin(), h_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::partition_copy(
-      d_data.begin(),
-      d_data.end(),
-      thrust::make_discard_iterator(),
-      thrust::make_discard_iterator(),
-      cuda::__is_even{});
+      d_data.begin(), d_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
@@ -700,18 +692,10 @@ struct TestStablePartitionCopyToDiscardIterator
 
     // mask both ranges
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::stable_partition_copy(
-      h_data.begin(),
-      h_data.end(),
-      thrust::make_discard_iterator(),
-      thrust::make_discard_iterator(),
-      cuda::__is_even{});
+      h_data.begin(), h_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::stable_partition_copy(
-      d_data.begin(),
-      d_data.end(),
-      thrust::make_discard_iterator(),
-      thrust::make_discard_iterator(),
-      cuda::__is_even{});
+      d_data.begin(), d_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), cuda::__is_even{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));

--- a/thrust/testing/partition.cu
+++ b/thrust/testing/partition.cu
@@ -5,20 +5,13 @@
 #include <thrust/partition.h>
 #include <thrust/sort.h>
 
+#include <cuda/functional>
+
 #include <unittest/unittest.h>
 
 #if _CCCL_COMPILER(GCC, >=, 11) && _CCCL_COMPILER(GCC, <, 12)
 #  define WAIVE_GCC11_FAILURES
 #endif
-
-template <typename T>
-struct is_even
-{
-  _CCCL_HOST_DEVICE bool operator()(T x) const
-  {
-    return ((int) x % 2) == 0;
-  }
-};
 
 using PartitionTypes = unittest::type_list<unittest::int8_t, unittest::int16_t, unittest::int32_t>;
 
@@ -41,7 +34,7 @@ void TestPartitionSimple()
 
   Vector data{1, 2, 1, 1, 2};
 
-  Iterator iter = thrust::partition(data.begin(), data.end(), is_even<T>());
+  Iterator iter = thrust::partition(data.begin(), data.end(), cuda::__is_even<T>{});
 
   Vector ref{2, 2, 1, 1, 1};
 
@@ -60,7 +53,7 @@ void TestPartitionStencilSimple()
 
   Vector stencil{1, 2, 1, 1, 2};
 
-  Iterator iter = thrust::partition(data.begin(), data.end(), stencil.begin(), is_even<T>());
+  Iterator iter = thrust::partition(data.begin(), data.end(), stencil.begin(), cuda::__is_even<T>{});
 
   Vector ref{1, 1, 0, 0, 0};
 
@@ -80,7 +73,7 @@ void TestPartitionCopySimple()
   Vector false_results(3);
 
   cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends =
-    thrust::partition_copy(data.begin(), data.end(), true_results.begin(), false_results.begin(), is_even<T>());
+    thrust::partition_copy(data.begin(), data.end(), true_results.begin(), false_results.begin(), cuda::__is_even<T>{});
 
   Vector true_ref(2, 2);
 
@@ -106,7 +99,7 @@ void TestPartitionCopyStencilSimple()
   Vector false_results(3);
 
   cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends = thrust::partition_copy(
-    data.begin(), data.end(), stencil.begin(), true_results.begin(), false_results.begin(), is_even<T>());
+    data.begin(), data.end(), stencil.begin(), true_results.begin(), false_results.begin(), cuda::__is_even<T>{});
 
   Vector true_ref(2, 1);
 
@@ -127,7 +120,7 @@ void TestStablePartitionSimple()
 
   Vector data{1, 2, 1, 3, 2};
 
-  Iterator iter = thrust::stable_partition(data.begin(), data.end(), is_even<T>());
+  Iterator iter = thrust::stable_partition(data.begin(), data.end(), cuda::__is_even<T>{});
 
   Vector ref{2, 2, 1, 1, 3};
 
@@ -165,7 +158,7 @@ void TestStablePartitionCopySimple()
   Vector false_results(3);
 
   cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends =
-    thrust::stable_partition_copy(data.begin(), data.end(), true_results.begin(), false_results.begin(), is_even<T>());
+    thrust::stable_partition_copy(data.begin(), data.end(), true_results.begin(), false_results.begin(), cuda::__is_even<T>{});
 
   Vector true_ref(2, 2);
 
@@ -210,8 +203,8 @@ struct TestPartition
     thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_data = h_data;
 
-    typename thrust::host_vector<T>::iterator h_iter   = thrust::partition(h_data.begin(), h_data.end(), is_even<T>());
-    typename thrust::device_vector<T>::iterator d_iter = thrust::partition(d_data.begin(), d_data.end(), is_even<T>());
+    typename thrust::host_vector<T>::iterator h_iter   = thrust::partition(h_data.begin(), h_data.end(), cuda::__is_even<T>{});
+    typename thrust::device_vector<T>::iterator d_iter = thrust::partition(d_data.begin(), d_data.end(), cuda::__is_even<T>{});
 
     thrust::sort(h_data.begin(), h_iter);
     thrust::sort(h_iter, h_data.end());
@@ -247,9 +240,9 @@ struct TestPartitionStencil
     thrust::device_vector<T> d_stencil = h_stencil;
 
     typename thrust::host_vector<T>::iterator h_iter =
-      thrust::partition(h_data.begin(), h_data.end(), h_stencil.begin(), is_even<T>());
+      thrust::partition(h_data.begin(), h_data.end(), h_stencil.begin(), cuda::__is_even<T>{});
     typename thrust::device_vector<T>::iterator d_iter =
-      thrust::partition(d_data.begin(), d_data.end(), d_stencil.begin(), is_even<T>());
+      thrust::partition(d_data.begin(), d_data.end(), d_stencil.begin(), cuda::__is_even<T>{});
 
     thrust::sort(h_data.begin(), h_iter);
     thrust::sort(h_iter, h_data.end());
@@ -271,7 +264,7 @@ struct TestPartitionCopy
     thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_data = h_data;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), is_even<T>());
+    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), cuda::__is_even<T>{});
     std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // setup output ranges
@@ -282,11 +275,11 @@ struct TestPartitionCopy
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
       thrust::partition_copy(
-        h_data.begin(), h_data.end(), h_true_results.begin(), h_false_results.begin(), is_even<T>());
+        h_data.begin(), h_data.end(), h_true_results.begin(), h_false_results.begin(), cuda::__is_even<T>{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
       thrust::partition_copy(
-        d_data.begin(), d_data.end(), d_true_results.begin(), d_false_results.begin(), is_even<T>());
+        d_data.begin(), d_data.end(), d_true_results.begin(), d_false_results.begin(), cuda::__is_even<T>{});
 
     // check true output
     ASSERT_EQUAL(h_ends.first - h_true_results.begin(), n_true);
@@ -316,7 +309,7 @@ struct TestPartitionCopyStencil
     thrust::device_vector<T> d_data    = h_data;
     thrust::device_vector<T> d_stencil = h_stencil;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), is_even<T>());
+    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), cuda::__is_even<T>{});
     std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // setup output ranges
@@ -327,11 +320,11 @@ struct TestPartitionCopyStencil
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
       thrust::partition_copy(
-        h_data.begin(), h_data.end(), h_stencil.begin(), h_true_results.begin(), h_false_results.begin(), is_even<T>());
+        h_data.begin(), h_data.end(), h_stencil.begin(), h_true_results.begin(), h_false_results.begin(), cuda::__is_even<T>{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
       thrust::partition_copy(
-        d_data.begin(), d_data.end(), d_stencil.begin(), d_true_results.begin(), d_false_results.begin(), is_even<T>());
+        d_data.begin(), d_data.end(), d_stencil.begin(), d_true_results.begin(), d_false_results.begin(), cuda::__is_even<T>{});
 
     // check true output
     ASSERT_EQUAL(h_ends.first - h_true_results.begin(), n_true);
@@ -361,7 +354,7 @@ struct TestStablePartitionCopyStencil
     thrust::device_vector<T> d_data    = h_data;
     thrust::device_vector<T> d_stencil = h_stencil;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), is_even<T>());
+    std::ptrdiff_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), cuda::__is_even<T>{});
     std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // setup output ranges
@@ -372,11 +365,11 @@ struct TestStablePartitionCopyStencil
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
       thrust::stable_partition_copy(
-        h_data.begin(), h_data.end(), h_stencil.begin(), h_true_results.begin(), h_false_results.begin(), is_even<T>());
+        h_data.begin(), h_data.end(), h_stencil.begin(), h_true_results.begin(), h_false_results.begin(), cuda::__is_even<T>{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
       thrust::stable_partition_copy(
-        d_data.begin(), d_data.end(), d_stencil.begin(), d_true_results.begin(), d_false_results.begin(), is_even<T>());
+        d_data.begin(), d_data.end(), d_stencil.begin(), d_true_results.begin(), d_false_results.begin(), cuda::__is_even<T>{});
 
     // check true output
     ASSERT_EQUAL(h_ends.first - h_true_results.begin(), n_true);
@@ -404,15 +397,15 @@ struct TestPartitionCopyToDiscardIterator
     thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_data = h_data;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), is_even<T>());
+    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), cuda::__is_even<T>{});
     std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // mask both ranges
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::partition_copy(
-      h_data.begin(), h_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), is_even<T>());
+      h_data.begin(), h_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::partition_copy(
-      d_data.begin(), d_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), is_even<T>());
+      d_data.begin(), d_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
@@ -426,11 +419,11 @@ struct TestPartitionCopyToDiscardIterator
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
       thrust::partition_copy(
-        h_data.begin(), h_data.end(), h_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
+        h_data.begin(), h_data.end(), h_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::partition_copy(
-        d_data.begin(), d_data.end(), d_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
+        d_data.begin(), d_data.end(), d_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
       cuda::std::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
@@ -448,11 +441,11 @@ struct TestPartitionCopyToDiscardIterator
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
       thrust::partition_copy(
-        h_data.begin(), h_data.end(), thrust::make_discard_iterator(), h_falses.begin(), is_even<T>());
+        h_data.begin(), h_data.end(), thrust::make_discard_iterator(), h_falses.begin(), cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
       thrust::partition_copy(
-        d_data.begin(), d_data.end(), thrust::make_discard_iterator(), d_falses.begin(), is_even<T>());
+        d_data.begin(), d_data.end(), thrust::make_discard_iterator(), d_falses.begin(), cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);
@@ -478,7 +471,7 @@ struct TestPartitionCopyStencilToDiscardIterator
     thrust::device_vector<T> d_data    = h_data;
     thrust::device_vector<T> d_stencil = h_stencil;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), is_even<T>());
+    std::ptrdiff_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), cuda::__is_even<T>{});
     std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // mask both ranges
@@ -488,7 +481,7 @@ struct TestPartitionCopyStencilToDiscardIterator
       h_stencil.begin(),
       thrust::make_discard_iterator(),
       thrust::make_discard_iterator(),
-      is_even<T>());
+      cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::partition_copy(
       d_data.begin(),
@@ -496,7 +489,7 @@ struct TestPartitionCopyStencilToDiscardIterator
       d_stencil.begin(),
       thrust::make_discard_iterator(),
       thrust::make_discard_iterator(),
-      is_even<T>());
+      cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
@@ -510,11 +503,11 @@ struct TestPartitionCopyStencilToDiscardIterator
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
       thrust::partition_copy(
-        h_data.begin(), h_data.end(), h_stencil.begin(), h_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
+        h_data.begin(), h_data.end(), h_stencil.begin(), h_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::partition_copy(
-        d_data.begin(), d_data.end(), d_stencil.begin(), d_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
+        d_data.begin(), d_data.end(), d_stencil.begin(), d_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
       cuda::std::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
@@ -537,7 +530,7 @@ struct TestPartitionCopyStencilToDiscardIterator
         h_stencil.begin(),
         thrust::make_discard_iterator(),
         h_falses.begin(),
-        is_even<T>());
+        cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
       thrust::partition_copy(
@@ -546,7 +539,7 @@ struct TestPartitionCopyStencilToDiscardIterator
         d_stencil.begin(),
         thrust::make_discard_iterator(),
         d_falses.begin(),
-        is_even<T>());
+        cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);
@@ -575,9 +568,9 @@ struct TestStablePartition
     thrust::device_vector<T> d_data = h_data;
 
     typename thrust::host_vector<T>::iterator h_iter =
-      thrust::stable_partition(h_data.begin(), h_data.end(), is_even<T>());
+      thrust::stable_partition(h_data.begin(), h_data.end(), cuda::__is_even<T>{});
     typename thrust::device_vector<T>::iterator d_iter =
-      thrust::stable_partition(d_data.begin(), d_data.end(), is_even<T>());
+      thrust::stable_partition(d_data.begin(), d_data.end(), cuda::__is_even<T>{});
 
     ASSERT_EQUAL(h_data, d_data);
     ASSERT_EQUAL(h_iter - h_data.begin(), d_iter - d_data.begin());
@@ -602,9 +595,9 @@ struct TestStablePartitionStencil
     thrust::device_vector<T> d_stencil = h_stencil;
 
     typename thrust::host_vector<T>::iterator h_iter =
-      thrust::stable_partition(h_data.begin(), h_data.end(), h_stencil.begin(), is_even<T>());
+      thrust::stable_partition(h_data.begin(), h_data.end(), h_stencil.begin(), cuda::__is_even<T>{});
     typename thrust::device_vector<T>::iterator d_iter =
-      thrust::stable_partition(d_data.begin(), d_data.end(), d_stencil.begin(), is_even<T>());
+      thrust::stable_partition(d_data.begin(), d_data.end(), d_stencil.begin(), cuda::__is_even<T>{});
 
     ASSERT_EQUAL(h_data, d_data);
     ASSERT_EQUAL(h_iter - h_data.begin(), d_iter - d_data.begin());
@@ -623,7 +616,7 @@ struct TestStablePartitionCopy
     thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_data = h_data;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), is_even<T>());
+    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), cuda::__is_even<T>{});
     std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // setup output ranges
@@ -634,11 +627,11 @@ struct TestStablePartitionCopy
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
       thrust::stable_partition_copy(
-        h_data.begin(), h_data.end(), h_true_results.begin(), h_false_results.begin(), is_even<T>());
+        h_data.begin(), h_data.end(), h_true_results.begin(), h_false_results.begin(), cuda::__is_even<T>{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
       thrust::stable_partition_copy(
-        d_data.begin(), d_data.end(), d_true_results.begin(), d_false_results.begin(), is_even<T>());
+        d_data.begin(), d_data.end(), d_true_results.begin(), d_false_results.begin(), cuda::__is_even<T>{});
 
     // check true output
     ASSERT_EQUAL(h_ends.first - h_true_results.begin(), n_true);
@@ -662,15 +655,15 @@ struct TestStablePartitionCopyToDiscardIterator
     thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_data = h_data;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), is_even<T>());
+    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), cuda::__is_even<T>{});
     std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // mask both ranges
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::stable_partition_copy(
-      h_data.begin(), h_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), is_even<T>());
+      h_data.begin(), h_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::stable_partition_copy(
-      d_data.begin(), d_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), is_even<T>());
+      d_data.begin(), d_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
@@ -684,11 +677,11 @@ struct TestStablePartitionCopyToDiscardIterator
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
       thrust::stable_partition_copy(
-        h_data.begin(), h_data.end(), h_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
+        h_data.begin(), h_data.end(), h_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::stable_partition_copy(
-        d_data.begin(), d_data.end(), d_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
+        d_data.begin(), d_data.end(), d_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
       cuda::std::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
@@ -706,11 +699,11 @@ struct TestStablePartitionCopyToDiscardIterator
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
       thrust::stable_partition_copy(
-        h_data.begin(), h_data.end(), thrust::make_discard_iterator(), h_falses.begin(), is_even<T>());
+        h_data.begin(), h_data.end(), thrust::make_discard_iterator(), h_falses.begin(), cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
       thrust::stable_partition_copy(
-        d_data.begin(), d_data.end(), thrust::make_discard_iterator(), d_falses.begin(), is_even<T>());
+        d_data.begin(), d_data.end(), thrust::make_discard_iterator(), d_falses.begin(), cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);
@@ -737,7 +730,7 @@ struct TestStablePartitionCopyStencilToDiscardIterator
     thrust::device_vector<T> d_data    = h_data;
     thrust::device_vector<T> d_stencil = h_stencil;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), is_even<T>());
+    std::ptrdiff_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), cuda::__is_even<T>{});
     std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // mask both ranges
@@ -747,7 +740,7 @@ struct TestStablePartitionCopyStencilToDiscardIterator
       h_stencil.begin(),
       thrust::make_discard_iterator(),
       thrust::make_discard_iterator(),
-      is_even<T>());
+      cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::stable_partition_copy(
       d_data.begin(),
@@ -755,7 +748,7 @@ struct TestStablePartitionCopyStencilToDiscardIterator
       d_stencil.begin(),
       thrust::make_discard_iterator(),
       thrust::make_discard_iterator(),
-      is_even<T>());
+      cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
@@ -769,11 +762,11 @@ struct TestStablePartitionCopyStencilToDiscardIterator
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
       thrust::stable_partition_copy(
-        h_data.begin(), h_data.end(), h_stencil.begin(), h_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
+        h_data.begin(), h_data.end(), h_stencil.begin(), h_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
 
     cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::stable_partition_copy(
-        d_data.begin(), d_data.end(), d_stencil.begin(), d_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
+        d_data.begin(), d_data.end(), d_stencil.begin(), d_trues.begin(), thrust::make_discard_iterator(), cuda::__is_even<T>{});
 
     cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
       cuda::std::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
@@ -796,7 +789,7 @@ struct TestStablePartitionCopyStencilToDiscardIterator
         h_stencil.begin(),
         thrust::make_discard_iterator(),
         h_falses.begin(),
-        is_even<T>());
+        cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
       thrust::stable_partition_copy(
@@ -805,7 +798,7 @@ struct TestStablePartitionCopyStencilToDiscardIterator
         d_stencil.begin(),
         thrust::make_discard_iterator(),
         d_falses.begin(),
-        is_even<T>());
+        cuda::__is_even<T>{});
 
     cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);

--- a/thrust/testing/partition.cu
+++ b/thrust/testing/partition.cu
@@ -18,19 +18,7 @@ using PartitionTypes = unittest::type_list<unittest::int8_t, unittest::int16_t, 
 template <typename Vector>
 void TestPartitionSimple()
 {
-  using T        = typename Vector::value_type;
   using Iterator = typename Vector::iterator;
-
-  // GCC 11 miscompiles and segfaults for certain versions of this test.
-  // It's not reproducible on other compilers, and the test passes when
-  // optimizations are disabled. It only affects 32-bit value types, and
-  // impacts all CPU host/device combinations tested.
-#ifdef WAIVE_GCC11_FAILURES
-  if (sizeof(T) == 4)
-  {
-    return;
-  }
-#endif
 
   Vector data{1, 2, 1, 1, 2};
 
@@ -46,7 +34,6 @@ DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPartitionSimple);
 template <typename Vector>
 void TestPartitionStencilSimple()
 {
-  using T        = typename Vector::value_type;
   using Iterator = typename Vector::iterator;
 
   Vector data{0, 1, 0, 0, 1};
@@ -65,8 +52,6 @@ DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPartitionStencilSimple);
 template <typename Vector>
 void TestPartitionCopySimple()
 {
-  using T = typename Vector::value_type;
-
   Vector data{1, 2, 1, 1, 2};
 
   Vector true_results(2);
@@ -89,8 +74,6 @@ DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPartitionCopySimple);
 template <typename Vector>
 void TestPartitionCopyStencilSimple()
 {
-  using T = typename Vector::value_type;
-
   Vector data{0, 1, 0, 0, 1};
 
   Vector stencil{1, 2, 1, 1, 2};
@@ -115,7 +98,6 @@ DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPartitionCopyStencilSimple);
 template <typename Vector>
 void TestStablePartitionSimple()
 {
-  using T        = typename Vector::value_type;
   using Iterator = typename Vector::iterator;
 
   Vector data{1, 2, 1, 3, 2};
@@ -150,8 +132,6 @@ DECLARE_VECTOR_UNITTEST(TestStablePartitionStencilSimple);
 template <typename Vector>
 void TestStablePartitionCopySimple()
 {
-  using T = typename Vector::value_type;
-
   Vector data{1, 2, 1, 1, 2};
 
   Vector true_results(2);

--- a/thrust/testing/partition_point.cu
+++ b/thrust/testing/partition_point.cu
@@ -35,9 +35,9 @@ void TestPartitionPoint()
 
   Vector v = unittest::random_integers<T>(n);
 
-  Iterator ref = thrust::stable_partition(v.begin(), v.end(), cuda::__is_even<T>{});
+  Iterator ref = thrust::stable_partition(v.begin(), v.end(), cuda::__is_even{});
 
-  ASSERT_EQUAL(ref - v.begin(), thrust::partition_point(v.begin(), v.end(), cuda::__is_even<T>{}) - v.begin());
+  ASSERT_EQUAL(ref - v.begin(), thrust::partition_point(v.begin(), v.end(), cuda::__is_even{}) - v.begin());
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPartitionPoint);
 

--- a/thrust/testing/partition_point.cu
+++ b/thrust/testing/partition_point.cu
@@ -2,16 +2,9 @@
 #include <thrust/iterator/retag.h>
 #include <thrust/partition.h>
 
-#include <unittest/unittest.h>
+#include <cuda/functional>
 
-template <typename T>
-struct is_even
-{
-  _CCCL_HOST_DEVICE bool operator()(T x) const
-  {
-    return ((int) x % 2) == 0;
-  }
-};
+#include <unittest/unittest.h>
 
 template <typename Vector>
 void TestPartitionPointSimple()
@@ -42,9 +35,9 @@ void TestPartitionPoint()
 
   Vector v = unittest::random_integers<T>(n);
 
-  Iterator ref = thrust::stable_partition(v.begin(), v.end(), is_even<T>());
+  Iterator ref = thrust::stable_partition(v.begin(), v.end(), cuda::__is_even<T>{});
 
-  ASSERT_EQUAL(ref - v.begin(), thrust::partition_point(v.begin(), v.end(), is_even<T>()) - v.begin());
+  ASSERT_EQUAL(ref - v.begin(), thrust::partition_point(v.begin(), v.end(), cuda::__is_even<T>{}) - v.begin());
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPartitionPoint);
 

--- a/thrust/testing/remove.cu
+++ b/thrust/testing/remove.cu
@@ -240,8 +240,7 @@ void TestRemoveCopyIfSimple()
 
   Vector result(5);
 
-  typename Vector::iterator end =
-    thrust::remove_copy_if(data.begin(), data.end(), result.begin(), cuda::__is_even{});
+  typename Vector::iterator end = thrust::remove_copy_if(data.begin(), data.end(), result.begin(), cuda::__is_even{});
 
   ASSERT_EQUAL(end - result.begin(), 3);
   result.resize(end - result.begin());

--- a/thrust/testing/remove.cu
+++ b/thrust/testing/remove.cu
@@ -240,7 +240,8 @@ void TestRemoveCopyIfSimple()
 
   Vector result(5);
 
-  typename Vector::iterator end = thrust::remove_copy_if(data.begin(), data.end(), result.begin(), cuda::__is_even<T>{});
+  typename Vector::iterator end =
+    thrust::remove_copy_if(data.begin(), data.end(), result.begin(), cuda::__is_even<T>{});
 
   ASSERT_EQUAL(end - result.begin(), 3);
   result.resize(end - result.begin());

--- a/thrust/testing/remove.cu
+++ b/thrust/testing/remove.cu
@@ -134,7 +134,7 @@ void TestRemoveIfSimple()
 
   Vector data{1, 2, 1, 3, 2};
 
-  typename Vector::iterator end = thrust::remove_if(data.begin(), data.end(), cuda::__is_even<T>{});
+  typename Vector::iterator end = thrust::remove_if(data.begin(), data.end(), cuda::__is_even{});
 
   ASSERT_EQUAL(end - data.begin(), 3);
   data.resize(end - data.begin());
@@ -241,7 +241,7 @@ void TestRemoveCopyIfSimple()
   Vector result(5);
 
   typename Vector::iterator end =
-    thrust::remove_copy_if(data.begin(), data.end(), result.begin(), cuda::__is_even<T>{});
+    thrust::remove_copy_if(data.begin(), data.end(), result.begin(), cuda::__is_even{});
 
   ASSERT_EQUAL(end - result.begin(), 3);
   result.resize(end - result.begin());

--- a/thrust/testing/remove.cu
+++ b/thrust/testing/remove.cu
@@ -5,18 +5,11 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/remove.h>
 
+#include <cuda/functional>
+
 #include <stdexcept>
 
 #include <unittest/unittest.h>
-
-template <typename T>
-struct is_even
-{
-  _CCCL_HOST_DEVICE bool operator()(T x)
-  {
-    return (static_cast<unsigned int>(x) & 1) == 0;
-  }
-};
 
 template <typename T>
 struct is_true
@@ -141,7 +134,7 @@ void TestRemoveIfSimple()
 
   Vector data{1, 2, 1, 3, 2};
 
-  typename Vector::iterator end = thrust::remove_if(data.begin(), data.end(), is_even<T>());
+  typename Vector::iterator end = thrust::remove_if(data.begin(), data.end(), cuda::__is_even<T>{});
 
   ASSERT_EQUAL(end - data.begin(), 3);
   data.resize(end - data.begin());
@@ -247,7 +240,7 @@ void TestRemoveCopyIfSimple()
 
   Vector result(5);
 
-  typename Vector::iterator end = thrust::remove_copy_if(data.begin(), data.end(), result.begin(), is_even<T>());
+  typename Vector::iterator end = thrust::remove_copy_if(data.begin(), data.end(), result.begin(), cuda::__is_even<T>{});
 
   ASSERT_EQUAL(end - result.begin(), 3);
   result.resize(end - result.begin());

--- a/thrust/testing/remove.cu
+++ b/thrust/testing/remove.cu
@@ -130,8 +130,6 @@ DECLARE_UNITTEST(TestRemoveCopyDispatchImplicit);
 template <typename Vector>
 void TestRemoveIfSimple()
 {
-  using T = typename Vector::value_type;
-
   Vector data{1, 2, 1, 3, 2};
 
   typename Vector::iterator end = thrust::remove_if(data.begin(), data.end(), cuda::__is_even{});
@@ -234,8 +232,6 @@ DECLARE_UNITTEST(TestRemoveIfStencilDispatchImplicit);
 template <typename Vector>
 void TestRemoveCopyIfSimple()
 {
-  using T = typename Vector::value_type;
-
   Vector data{1, 2, 1, 3, 2};
 
   Vector result(5);

--- a/thrust/testing/scatter.cu
+++ b/thrust/testing/scatter.cu
@@ -5,6 +5,8 @@
 #include <thrust/scatter.h>
 #include <thrust/sequence.h>
 
+#include <cuda/functional>
+
 #include <algorithm>
 
 #include <unittest/unittest.h>
@@ -164,16 +166,6 @@ void TestScatterIfDispatchImplicit()
 DECLARE_UNITTEST(TestScatterIfDispatchImplicit);
 
 template <typename T>
-class is_even_scatter_if
-{
-public:
-  _CCCL_HOST_DEVICE bool operator()(const T i) const
-  {
-    return (i % 2) == 0;
-  }
-};
-
-template <typename T>
 void TestScatterIf(const size_t n)
 {
   const size_t output_size = std::min((size_t) 10, 2 * n);
@@ -194,9 +186,9 @@ void TestScatterIf(const size_t n)
   thrust::device_vector<T> d_output(output_size, (T) 0);
 
   thrust::scatter_if(
-    h_input.begin(), h_input.end(), h_map.begin(), h_map.begin(), h_output.begin(), is_even_scatter_if<unsigned int>());
+    h_input.begin(), h_input.end(), h_map.begin(), h_map.begin(), h_output.begin(), cuda::__is_even<unsigned int>());
   thrust::scatter_if(
-    d_input.begin(), d_input.end(), d_map.begin(), d_map.begin(), d_output.begin(), is_even_scatter_if<unsigned int>());
+    d_input.begin(), d_input.end(), d_map.begin(), d_map.begin(), d_output.begin(), cuda::__is_even<unsigned int>());
 
   ASSERT_EQUAL(h_output, d_output);
 }
@@ -225,14 +217,14 @@ void TestScatterIfToDiscardIterator(const size_t n)
     h_map.begin(),
     h_map.begin(),
     thrust::make_discard_iterator(),
-    is_even_scatter_if<unsigned int>());
+    cuda::__is_even<unsigned int>());
   thrust::scatter_if(
     d_input.begin(),
     d_input.end(),
     d_map.begin(),
     d_map.begin(),
     thrust::make_discard_iterator(),
-    is_even_scatter_if<unsigned int>());
+    cuda::__is_even<unsigned int>());
 }
 DECLARE_VARIABLE_UNITTEST(TestScatterIfToDiscardIterator);
 

--- a/thrust/testing/scatter.cu
+++ b/thrust/testing/scatter.cu
@@ -186,9 +186,9 @@ void TestScatterIf(const size_t n)
   thrust::device_vector<T> d_output(output_size, (T) 0);
 
   thrust::scatter_if(
-    h_input.begin(), h_input.end(), h_map.begin(), h_map.begin(), h_output.begin(), cuda::__is_even<unsigned int>());
+    h_input.begin(), h_input.end(), h_map.begin(), h_map.begin(), h_output.begin(), cuda::__is_even());
   thrust::scatter_if(
-    d_input.begin(), d_input.end(), d_map.begin(), d_map.begin(), d_output.begin(), cuda::__is_even<unsigned int>());
+    d_input.begin(), d_input.end(), d_map.begin(), d_map.begin(), d_output.begin(), cuda::__is_even());
 
   ASSERT_EQUAL(h_output, d_output);
 }
@@ -217,14 +217,14 @@ void TestScatterIfToDiscardIterator(const size_t n)
     h_map.begin(),
     h_map.begin(),
     thrust::make_discard_iterator(),
-    cuda::__is_even<unsigned int>());
+    cuda::__is_even());
   thrust::scatter_if(
     d_input.begin(),
     d_input.end(),
     d_map.begin(),
     d_map.begin(),
     thrust::make_discard_iterator(),
-    cuda::__is_even<unsigned int>());
+    cuda::__is_even());
 }
 DECLARE_VARIABLE_UNITTEST(TestScatterIfToDiscardIterator);
 

--- a/thrust/testing/scatter.cu
+++ b/thrust/testing/scatter.cu
@@ -185,10 +185,8 @@ void TestScatterIf(const size_t n)
   thrust::host_vector<T> h_output(output_size, (T) 0);
   thrust::device_vector<T> d_output(output_size, (T) 0);
 
-  thrust::scatter_if(
-    h_input.begin(), h_input.end(), h_map.begin(), h_map.begin(), h_output.begin(), cuda::__is_even());
-  thrust::scatter_if(
-    d_input.begin(), d_input.end(), d_map.begin(), d_map.begin(), d_output.begin(), cuda::__is_even());
+  thrust::scatter_if(h_input.begin(), h_input.end(), h_map.begin(), h_map.begin(), h_output.begin(), cuda::__is_even());
+  thrust::scatter_if(d_input.begin(), d_input.end(), d_map.begin(), d_map.begin(), d_output.begin(), cuda::__is_even());
 
   ASSERT_EQUAL(h_output, d_output);
 }
@@ -212,19 +210,9 @@ void TestScatterIfToDiscardIterator(const size_t n)
   thrust::device_vector<unsigned int> d_map = h_map;
 
   thrust::scatter_if(
-    h_input.begin(),
-    h_input.end(),
-    h_map.begin(),
-    h_map.begin(),
-    thrust::make_discard_iterator(),
-    cuda::__is_even());
+    h_input.begin(), h_input.end(), h_map.begin(), h_map.begin(), thrust::make_discard_iterator(), cuda::__is_even());
   thrust::scatter_if(
-    d_input.begin(),
-    d_input.end(),
-    d_map.begin(),
-    d_map.begin(),
-    thrust::make_discard_iterator(),
-    cuda::__is_even());
+    d_input.begin(), d_input.end(), d_map.begin(), d_map.begin(), thrust::make_discard_iterator(), cuda::__is_even());
 }
 DECLARE_VARIABLE_UNITTEST(TestScatterIfToDiscardIterator);
 

--- a/thrust/testing/scatter.cu
+++ b/thrust/testing/scatter.cu
@@ -185,8 +185,8 @@ void TestScatterIf(const size_t n)
   thrust::host_vector<T> h_output(output_size, (T) 0);
   thrust::device_vector<T> d_output(output_size, (T) 0);
 
-  thrust::scatter_if(h_input.begin(), h_input.end(), h_map.begin(), h_map.begin(), h_output.begin(), cuda::__is_even());
-  thrust::scatter_if(d_input.begin(), d_input.end(), d_map.begin(), d_map.begin(), d_output.begin(), cuda::__is_even());
+  thrust::scatter_if(h_input.begin(), h_input.end(), h_map.begin(), h_map.begin(), h_output.begin(), cuda::__is_even{});
+  thrust::scatter_if(d_input.begin(), d_input.end(), d_map.begin(), d_map.begin(), d_output.begin(), cuda::__is_even{});
 
   ASSERT_EQUAL(h_output, d_output);
 }
@@ -210,9 +210,9 @@ void TestScatterIfToDiscardIterator(const size_t n)
   thrust::device_vector<unsigned int> d_map = h_map;
 
   thrust::scatter_if(
-    h_input.begin(), h_input.end(), h_map.begin(), h_map.begin(), thrust::make_discard_iterator(), cuda::__is_even());
+    h_input.begin(), h_input.end(), h_map.begin(), h_map.begin(), thrust::make_discard_iterator(), cuda::__is_even{});
   thrust::scatter_if(
-    d_input.begin(), d_input.end(), d_map.begin(), d_map.begin(), thrust::make_discard_iterator(), cuda::__is_even());
+    d_input.begin(), d_input.end(), d_map.begin(), d_map.begin(), thrust::make_discard_iterator(), cuda::__is_even{});
 }
 DECLARE_VARIABLE_UNITTEST(TestScatterIfToDiscardIterator);
 


### PR DESCRIPTION
This is a continuation of #7455.

This PR focuses on unifying `is_even` functor across CCCL testing and benchmarking environment.

## Quick Summary of Changed
- Moved `is_even` logic to `c2h/include/c2h/operator.cuh` and enclosed it in c2h namespace.
- changed scattered functors to utilize unified one.

## Note
This does not unify `cub/*` files, because they uses `custom_type`. If we have to unify them, then I'll.

(Comment from @bernhardmgruber in #7455 specified duplicates in cub/*)

Also, this is an issue from my end, my system has integrated M2 chip and testing CCCL on it, is either impossible or painfully slow. So, changes can contain few errors.

Fixes: #9638