### PR TITLE
Fix CMake configure error on Windows in thrust benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build*/
 .aws
 .config
 _deps/catch2-src/
+.vs/
 .vscode/
 _site/
 .devcontainer/local*

--- a/thrust/benchmarks/CMakeLists.txt
+++ b/thrust/benchmarks/CMakeLists.txt
@@ -38,8 +38,9 @@ endfunction()
 
 function(thrust_wrap_bench_in_cpp cpp_file_var cu_file thrust_target)
   thrust_get_target_property(prefix ${thrust_target} PREFIX)
+  file(RELATIVE_PATH rel_cu_file "${CMAKE_CURRENT_LIST_DIR}" "${cu_file}")
   set(wrapped_source_file "${cu_file}")
-  set(cpp_file "${CMAKE_CURRENT_BINARY_DIR}/${prefix}/${cu_file}.cpp")
+  set(cpp_file "${CMAKE_CURRENT_BINARY_DIR}/${prefix}/${rel_cu_file}.cpp")
   configure_file(
     "${Thrust_SOURCE_DIR}/cmake/wrap_source_file.cpp.in"
     "${cpp_file}"


### PR DESCRIPTION
## Description
I used vs2026 to configure cccl with `all-dev` preset and found these errors:
```
1> [CMake] CMake Error: Could not open file for write in copy operation D:/github/miyanyan/cccl/build/all-dev/thrust/benchmarks/thrust.cpp.cpp/D:/github/miyanyan/cccl/thrust/benchmarks/bench/adjacent_difference/basic.cu.cpp.tmp
1> [CMake] CMake Error: : System Error: Invalid argument
1> [CMake] CMake Error at thrust/benchmarks/CMakeLists.txt:43 (configure_file):
1> [CMake]   configure_file Problem configuring file
1> [CMake] Call Stack (most recent call first):
1> [CMake]   thrust/benchmarks/CMakeLists.txt:65 (thrust_wrap_bench_in_cpp)
1> [CMake]   thrust/benchmarks/CMakeLists.txt:90 (add_bench_dir)
1> [CMake] CMake Error: Could not open file for write in copy operation D:/github/miyanyan/cccl/build/all-dev/thrust/benchmarks/thrust.cpp.omp/D:/github/miyanyan/cccl/thrust/benchmarks/bench/adjacent_difference/basic.cu.cpp.tmp
1> [CMake] CMake Error: : System Error: Invalid argument
1> [CMake] CMake Error at thrust/benchmarks/CMakeLists.txt:43 (configure_file):
1> [CMake]   configure_file Problem configuring file
1> [CMake] Call Stack (most recent call first):
1> [CMake]   thrust/benchmarks/CMakeLists.txt:65 (thrust_wrap_bench_in_cpp)
1> [CMake]   thrust/benchmarks/CMakeLists.txt:90 (add_bench_dir)
1> [CMake] CMake Error: Could not open file for write in copy operation D:/github/miyanyan/cccl/build/all-dev/thrust/benchmarks/thrust.cpp.tbb/D:/github/miyanyan/cccl/thrust/benchmarks/bench/adjacent_difference/basic.cu.cpp.tmp
1> [CMake] CMake Error: : System Error: Invalid argument
1> [CMake] CMake Error at thrust/benchmarks/CMakeLists.txt:43 (configure_file):
1> [CMake]   configure_file Problem configuring file
1> [CMake] Call Stack (most recent call first):
1> [CMake]   thrust/benchmarks/CMakeLists.txt:65 (thrust_wrap_bench_in_cpp)
1> [CMake]   thrust/benchmarks/CMakeLists.txt:90 (add_bench_dir)
1> [CMake] CMake Error: Could not open file for write in copy operation D:/github/miyanyan/cccl/build/all-dev/thrust/benchmarks/thrust.omp.omp/D:/github/miyanyan/cccl/thrust/benchmarks/bench/adjacent_difference/basic.cu.cpp.tmp
1> [CMake] CMake Error: : System Error: Invalid argument
```
Non-CUDA benchmark targets wrap `.cu` files into generated `.cpp` files. The wrapper output path was built from an absolute benchmark source path, which produces an invalid build-tree path on Windows because it embeds the drive prefix.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
