### PR TITLE
[libcu++] Fix redefinition errors in `cuda::std::simd` test utilities

### DIFF
--- a/libcudacxx/include/cuda/__device/arch_traits.h
+++ b/libcudacxx/include/cuda/__device/arch_traits.h
@@ -556,4 +556,5 @@ _CCCL_END_NAMESPACE_CUDA_DEVICE
 
 #include <cuda/std/__cccl/epilogue.h>
 
+// a comment to trigger CI
 #endif // _CUDA___DEVICE_ARCH_TRAITS_H

--- a/libcudacxx/include/cuda/__device/arch_traits.h
+++ b/libcudacxx/include/cuda/__device/arch_traits.h
@@ -556,5 +556,4 @@ _CCCL_END_NAMESPACE_CUDA_DEVICE
 
 #include <cuda/std/__cccl/epilogue.h>
 
-// a comment to trigger CI
 #endif // _CUDA___DEVICE_ARCH_TRAITS_H

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd_test_utils.h
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd_test_utils.h
@@ -228,31 +228,6 @@ TEST_FUNC constexpr bool operator==(const simd::basic_vec<T, Abi>& vec, const cu
 }
 
 template <typename T, int N>
-TEST_FUNC constexpr cuda::std::array<T, N> make_iota_array(int __offset = 1)
-{
-  cuda::std::array<T, N> arr{};
-  for (int i = 0; i < N; ++i)
-  {
-    arr[i] = static_cast<T>(i + __offset);
-  }
-  return arr;
-}
-
-template <typename T, typename Abi, typename U, size_t N>
-TEST_FUNC constexpr bool operator==(const simd::basic_vec<T, Abi>& vec, const cuda::std::array<U, N>& arr)
-{
-  static_assert(simd::basic_vec<T, Abi>::size() == static_cast<int>(N));
-  for (int i = 0; i < static_cast<int>(N); ++i)
-  {
-    if (vec[i] != arr[i])
-    {
-      return false;
-    }
-  }
-  return true;
-}
-
-template <typename T, int N>
 TEST_FUNC constexpr simd::basic_vec<T, simd::fixed_size<N>> make_iota_vec()
 {
   cuda::std::array<T, N> arr{};


### PR DESCRIPTION
## Description

I found unrelated libcudacxx CI failures in https://github.com/NVIDIA/cccl/pull/8985/. Asked Claude to do some digging and this is what it came up with:

## What this changes

Deletes 25 lines from `libcudacxx/test/libcudacxx/std/numerics/simd/simd_test_utils.h` that were a verbatim duplicate of declarations already in the same file:

- `make_iota_array<T, N>(int __offset = 1)`
- `operator==(const simd::basic_vec<T, Abi>&, const cuda::std::array<U, N>&)`

Both declarations appeared at lines 205-228 and again at lines 230-253. The two blocks were byte-identical — same template parameters, same default argument, same body — so the second copy is a pure deduplication.

## Why the build was failing

Any test that includes `simd_test_utils.h` and is compiled with `-Werror=all-warnings` (the default on the CTK 12.0 + gcc12 matrix) fails with:

```
error #802-D: specifying a default argument when redeclaring an unreferenced function template is nonstandard
error #307-D: redefinition of default argument
error: function template "make_iota_array" has already been defined
error: function template "operator==(...)" has already been defined
```

This blocks `simd.iterator/*.pass.cpp`, `simd.loadstore/*.pass.cpp`, and any other `simd` test that includes the header.

## Where the duplicate came from

The redundant block was added by **PR #8252** (`cuda::std::simd` load and store functionalities), commit `c47f1404e8`, merged 2026-05-22. The commit's diff shows `+25 lines` to this file — those 25 lines are exactly the duplicated functions. Almost certainly a botched merge or copy-paste: the intent was to extend the file with new utilities for the load/store tests, but t\
he additions overlap declarations that already existed.

## Why CI on #8252 didn't catch it

PR #8472 (`cuda::std::simd` Iterators) merged on **2026-04-29** and added `simd.iterator/arithmetic.pass.cpp` (along with the rest of `simd.iterator/`), which includes `simd_test_utils.h` and is the test that surfaces the redefinition error.

PR #8252 merged **2026-05-22** — three weeks later. The most likely sequence:

1. PR #8252 ran CI green at some point *before* April 29, when `simd.iterator/` did not yet exist in the tree, so the duplicate definitions were never compiled into anything that included the header in a flagged context.
2. After #8472 landed, #8252 was rebased onto the new main but merged *without re-running CI* against the rebased base. GitHub's merge flow doesn't force a fresh CI run after a rebase, so the stale green check carried over.
3. The duplicate landed silently on `main`. From that point on, any PR that triggers a full CTK 12.0 + gcc12 libcudacxx build hits the failure.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
