### PR TITLE
[libcu++] Fix `ranges::subrange` use of `pair-like`

### DIFF
--- a/libcudacxx/include/cuda/std/__ranges/subrange.h
+++ b/libcudacxx/include/cuda/std/__ranges/subrange.h
@@ -38,6 +38,7 @@
 #include <cuda/std/__ranges/size.h>
 #include <cuda/std/__ranges/view_interface.h>
 #include <cuda/std/__tuple_dir/tuple_element.h>
+#include <cuda/std/__tuple_dir/tuple_like.h>
 #include <cuda/std/__tuple_dir/tuple_size.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/enable_if.h>
@@ -64,19 +65,9 @@ template <class _From, class _To>
 concept __convertible_to_non_slicing =
   convertible_to<_From, _To> && !__uses_nonqualification_pointer_conversion<decay_t<_From>, decay_t<_To>>;
 
-template <class _Tp>
-concept __pair_like = !is_reference_v<_Tp> && requires(_Tp __t) {
-  typename tuple_size<_Tp>::type; // Ensures `tuple_size<T>` is complete.
-  requires derived_from<tuple_size<_Tp>, integral_constant<size_t, 2>>;
-  typename tuple_element_t<0, remove_const_t<_Tp>>;
-  typename tuple_element_t<1, remove_const_t<_Tp>>;
-  { ::cuda::std::get<0>(__t) } -> convertible_to<const tuple_element_t<0, _Tp>&>;
-  { ::cuda::std::get<1>(__t) } -> convertible_to<const tuple_element_t<1, _Tp>&>;
-};
-
 template <class _Pair, class _Iter, class _Sent>
 concept __pair_like_convertible_from =
-  !range<_Pair> && __pair_like<_Pair> && constructible_from<_Pair, _Iter, _Sent>
+  __pair_like<_Pair> && !range<_Pair> && constructible_from<_Pair, _Iter, _Sent>
   && __convertible_to_non_slicing<_Iter, tuple_element_t<0, _Pair>> && convertible_to<_Sent, tuple_element_t<1, _Pair>>;
 
 // We have issues with MSVC and _StoreSize being unable to be properly determined in SFINAE, so we need to pull that out
@@ -95,10 +86,6 @@ template <class _Iter, class _Sent, subrange_kind _Kind, class _Range>
 concept __subrange_from_range_size =
   _Kind == subrange_kind::sized && borrowed_range<_Range> && __convertible_to_non_slicing<iterator_t<_Range>, _Iter>
   && convertible_to<sentinel_t<_Range>, _Sent>;
-
-template <class _Iter, class _Sent, subrange_kind _Kind, class _Pair>
-concept __subrange_to_pair = __different_from<_Pair, subrange<_Iter, _Sent, _Kind>>
-                          && __pair_like_convertible_from<_Pair, const _Iter&, const _Sent&>;
 
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 
@@ -121,27 +108,11 @@ _CCCL_CONCEPT_FRAGMENT(__convertible_to_non_slicing_,
 template <class _From, class _To>
 _CCCL_CONCEPT __convertible_to_non_slicing = _CCCL_FRAGMENT(__convertible_to_non_slicing_, _From, _To);
 
-// We relax the requirement on tuple_size due to a gcc issue
-template <class _Tp>
-_CCCL_CONCEPT_FRAGMENT(
-  __pair_like_,
-  requires(_Tp __t)(
-    requires(!is_reference_v<_Tp>),
-    typename(typename tuple_size<_Tp>::type),
-    requires(tuple_size<_Tp>::value == 2),
-    typename(tuple_element_t<0, remove_const_t<_Tp>>),
-    typename(tuple_element_t<1, remove_const_t<_Tp>>),
-    requires(convertible_to<decltype(::cuda::std::get<0>(__t)), const tuple_element_t<0, _Tp>&>),
-    requires(convertible_to<decltype(::cuda::std::get<1>(__t)), const tuple_element_t<1, _Tp>&>)));
-
-template <class _Tp>
-_CCCL_CONCEPT __pair_like = _CCCL_FRAGMENT(__pair_like_, _Tp);
-
 template <class _Pair, class _Iter, class _Sent>
 _CCCL_CONCEPT_FRAGMENT(
   __pair_like_convertible_from_,
-  requires()(requires(!range<_Pair>),
-             requires(__pair_like<_Pair>),
+  requires()(requires(__pair_like<_Pair>),
+             requires(!range<_Pair>),
              requires(constructible_from<_Pair, _Iter, _Sent>),
              requires(__convertible_to_non_slicing<_Iter, tuple_element_t<0, _Pair>>),
              requires(convertible_to<_Sent, tuple_element_t<1, _Pair>>)));
@@ -196,15 +167,6 @@ _CCCL_CONCEPT_FRAGMENT(
 template <class _Iter, class _Sent, subrange_kind _Kind, class _Range>
 _CCCL_CONCEPT __subrange_from_range_size =
   _CCCL_FRAGMENT(__subrange_from_range_size_, _Iter, _Sent, integral_constant<subrange_kind, _Kind>, _Range);
-
-template <class _Iter, class _Sent, class _Kind, class _Pair>
-_CCCL_CONCEPT_FRAGMENT(__subrange_to_pair_,
-                       requires()(requires(__different_from<_Pair, subrange<_Iter, _Sent, _Kind::value>>),
-                                  requires(__pair_like_convertible_from<_Pair, const _Iter&, const _Sent&>)));
-
-template <class _Iter, class _Sent, subrange_kind _Kind, class _Pair>
-_CCCL_CONCEPT __subrange_to_pair =
-  _CCCL_FRAGMENT(__subrange_to_pair_, _Iter, _Sent, integral_constant<subrange_kind, _Kind>, _Pair);
 #endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 
 #if _CCCL_HAS_CONCEPTS()
@@ -291,7 +253,8 @@ public:
   // This often ICEs all of clang and old gcc when it encounteres a rvalue subrange in a pipe
 #if _CCCL_HAS_CONCEPTS()
   _CCCL_TEMPLATE(class _Pair)
-  _CCCL_REQUIRES(__pair_like<_Pair> _CCCL_AND __subrange_to_pair<_Iter, _Sent, _Kind, _Pair>)
+  _CCCL_REQUIRES(__different_from<_Pair, subrange<_Iter, _Sent, _Kind>> _CCCL_AND
+                   __pair_like_convertible_from<_Pair, const _Iter&, const _Sent&>)
   _CCCL_API constexpr operator _Pair() const
   {
     return _Pair(__begin_, __end_);

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_like.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_like.h
@@ -89,7 +89,7 @@ _CCCL_CONCEPT __tuple_like = __tuple_like_impl<remove_cvref_t<_Tp>>;
 // Not on line 74 because of __COUNTER__ missing in NVRTC
 template <class _Tp>
 _CCCL_CONCEPT __pair_like = _CCCL_REQUIRES_EXPR((_Tp)) //
-  (requires(__tuple_like_impl<remove_cvref_t<_Tp>>), requires(tuple_size<remove_cvref_t<_Tp>>::value == 2));
+  (requires(__tuple_like<_Tp>), requires(tuple_size<remove_cvref_t<_Tp>>::value == 2));
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.utility/range.subrange/ctor.pair_like_conv.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.utility/range.subrange/ctor.pair_like_conv.pass.cpp
@@ -8,7 +8,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++17
-// UNSUPPORTED: msvc-19.16
 
 // class cuda::std::ranges::subrange;
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.utility/range.subrange/get.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.utility/range.subrange/get.pass.cpp
@@ -10,8 +10,12 @@
 // UNSUPPORTED: msvc-19.16
 
 // class cuda::std::ranges::subrange;
-
 #include <cuda/std/cassert>
+
+// NVHPC complains about the deprecated longlong4 types even if they are not used at all
+_CCCL_DIAG_SUPPRESS_NVHPC(deprecated_entity_with_custom_message)
+_CCCL_DIAG_SUPPRESS_NVHPC(deprecated_entity)
+
 #include <cuda/std/ranges>
 
 #include "test_iterators.h"

--- a/libcudacxx/test/libcudacxx/std/ranges/range.utility/range.subrange/structured_bindings.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.utility/range.subrange/structured_bindings.pass.cpp
@@ -12,6 +12,11 @@
 // class cuda::std::ranges::subrange;
 
 #include <cuda/std/cassert>
+
+// NVHPC complains about the deprecated longlong4 types even if they are not used at all
+_CCCL_DIAG_SUPPRESS_NVHPC(deprecated_entity_with_custom_message)
+_CCCL_DIAG_SUPPRESS_NVHPC(deprecated_entity)
+
 #include <cuda/std/ranges>
 #include <cuda/std/utility>
 


### PR DESCRIPTION
When I implemented `ranges::subrange` there was no proper `pair-like` concept. Since then the standard has added one and we also have that already internally.

This should ensure that we do not try to instantiate the world with subrange
