### PR TITLE
Hardcode `DeviceTransform` `OffsetT` to `int64`

### DIFF
--- a/cub/benchmarks/bench/transform/babelstream.cu
+++ b/cub/benchmarks/bench/transform/babelstream.cu
@@ -55,16 +55,11 @@ inline constexpr auto startScalar = -2; // BabelStream: 0.4
 
 static_assert(startA == (startA + startB + startScalar * startC), "nstream must have a consistent workload");
 
-template <typename T, typename OffsetT>
-static void mul(nvbench::state& state, nvbench::type_list<T, OffsetT>)
+template <typename T>
+static void mul(nvbench::state& state, nvbench::type_list<T>)
 try
 {
   const auto n = state.get_int64("Elements{io}");
-  if (sizeof(OffsetT) == 4 && n > std::numeric_limits<OffsetT>::max())
-  {
-    state.skip("Skipping: input size exceeds 32-bit offset type capacity.");
-    return;
-  }
 
   thrust::device_vector<T> b(n, startB);
   thrust::device_vector<T> c(n, startC);
@@ -74,31 +69,25 @@ try
   state.add_global_memory_writes<T>(n);
 
   const T scalar = startScalar;
-  bench_transform(
-    state, ::cuda::std::tuple{c.begin()}, b.begin(), static_cast<OffsetT>(n), [=] _CCCL_DEVICE(const T& ci) {
-      return ci * scalar;
-    });
+  bench_transform(state, ::cuda::std::tuple{c.begin()}, b.begin(), n, [=] _CCCL_DEVICE(const T& ci) {
+    return ci * scalar;
+  });
 }
 catch (const std::bad_alloc&)
 {
   state.skip("Skipping: out of memory.");
 }
 
-NVBENCH_BENCH_TYPES(mul, NVBENCH_TYPE_AXES(element_types, offset_types))
+NVBENCH_BENCH_TYPES(mul, NVBENCH_TYPE_AXES(element_types))
   .set_name("mul")
-  .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
+  .set_type_axes_names({"T{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", array_size_powers);
 
-template <typename T, typename OffsetT>
-static void add(nvbench::state& state, nvbench::type_list<T, OffsetT>)
+template <typename T>
+static void add(nvbench::state& state, nvbench::type_list<T>)
 try
 {
   const auto n = state.get_int64("Elements{io}");
-  if (sizeof(OffsetT) == 4 && n > std::numeric_limits<OffsetT>::max())
-  {
-    state.skip("Skipping: input size exceeds 32-bit offset type capacity.");
-    return;
-  }
 
   thrust::device_vector<T> a(n, startA);
   thrust::device_vector<T> b(n, startB);
@@ -108,11 +97,7 @@ try
   state.add_global_memory_reads<T>(2 * n);
   state.add_global_memory_writes<T>(n);
   bench_transform(
-    state,
-    ::cuda::std::tuple{a.begin(), b.begin()},
-    c.begin(),
-    static_cast<OffsetT>(n),
-    [] _CCCL_DEVICE(const T& ai, const T& bi) -> T {
+    state, ::cuda::std::tuple{a.begin(), b.begin()}, c.begin(), n, [] _CCCL_DEVICE(const T& ai, const T& bi) -> T {
       return ai + bi;
     });
 }
@@ -121,21 +106,16 @@ catch (const std::bad_alloc&)
   state.skip("Skipping: out of memory.");
 }
 
-NVBENCH_BENCH_TYPES(add, NVBENCH_TYPE_AXES(element_types, offset_types))
+NVBENCH_BENCH_TYPES(add, NVBENCH_TYPE_AXES(element_types))
   .set_name("add")
-  .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
+  .set_type_axes_names({"T{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", array_size_powers);
 
-template <typename T, typename OffsetT>
-static void triad(nvbench::state& state, nvbench::type_list<T, OffsetT>)
+template <typename T>
+static void triad(nvbench::state& state, nvbench::type_list<T>)
 try
 {
   const auto n = state.get_int64("Elements{io}");
-  if (sizeof(OffsetT) == 4 && n > std::numeric_limits<OffsetT>::max())
-  {
-    state.skip("Skipping: input size exceeds 32-bit offset type capacity.");
-    return;
-  }
 
   thrust::device_vector<T> a(n, startA);
   thrust::device_vector<T> b(n, startB);
@@ -146,11 +126,7 @@ try
   state.add_global_memory_writes<T>(n);
   const T scalar = startScalar;
   bench_transform(
-    state,
-    ::cuda::std::tuple{b.begin(), c.begin()},
-    a.begin(),
-    static_cast<OffsetT>(n),
-    [=] _CCCL_DEVICE(const T& bi, const T& ci) {
+    state, ::cuda::std::tuple{b.begin(), c.begin()}, a.begin(), n, [=] _CCCL_DEVICE(const T& bi, const T& ci) {
       return bi + scalar * ci;
     });
 }
@@ -159,21 +135,16 @@ catch (const std::bad_alloc&)
   state.skip("Skipping: out of memory.");
 }
 
-NVBENCH_BENCH_TYPES(triad, NVBENCH_TYPE_AXES(element_types, offset_types))
+NVBENCH_BENCH_TYPES(triad, NVBENCH_TYPE_AXES(element_types))
   .set_name("triad")
-  .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
+  .set_type_axes_names({"T{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", array_size_powers);
 
-template <typename T, typename OffsetT>
-static void nstream(nvbench::state& state, nvbench::type_list<T, OffsetT>)
+template <typename T>
+static void nstream(nvbench::state& state, nvbench::type_list<T>)
 try
 {
   const auto n = state.get_int64("Elements{io}");
-  if (sizeof(OffsetT) == 4 && n > std::numeric_limits<OffsetT>::max())
-  {
-    state.skip("Skipping: input size exceeds 32-bit offset type capacity.");
-    return;
-  }
 
   thrust::device_vector<T> a(n, startA);
   thrust::device_vector<T> b(n, startB);
@@ -187,7 +158,7 @@ try
     state,
     ::cuda::std::tuple{a.begin(), b.begin(), c.begin()},
     a.begin(),
-    static_cast<OffsetT>(n),
+    n,
     [=] _CCCL_DEVICE(const T& ai, const T& bi, const T& ci) {
       return ai + bi + scalar * ci;
     });
@@ -197,7 +168,7 @@ catch (const std::bad_alloc&)
   state.skip("Skipping: out of memory.");
 }
 
-NVBENCH_BENCH_TYPES(nstream, NVBENCH_TYPE_AXES(element_types, offset_types))
+NVBENCH_BENCH_TYPES(nstream, NVBENCH_TYPE_AXES(element_types))
   .set_name("nstream")
-  .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
+  .set_type_axes_names({"T{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", array_size_powers);

--- a/cub/benchmarks/bench/transform/babelstream.cu
+++ b/cub/benchmarks/bench/transform/babelstream.cu
@@ -69,7 +69,7 @@ try
   state.add_global_memory_writes<T>(n);
 
   const T scalar = startScalar;
-  bench_transform(state, ::cuda::std::tuple{c.begin()}, b.begin(), n, [=] _CCCL_DEVICE(const T& ci) {
+  bench_transform(state, cuda::std::tuple{c.begin()}, b.begin(), n, [=] _CCCL_DEVICE(const T& ci) {
     return ci * scalar;
   });
 }
@@ -97,7 +97,7 @@ try
   state.add_global_memory_reads<T>(2 * n);
   state.add_global_memory_writes<T>(n);
   bench_transform(
-    state, ::cuda::std::tuple{a.begin(), b.begin()}, c.begin(), n, [] _CCCL_DEVICE(const T& ai, const T& bi) -> T {
+    state, cuda::std::tuple{a.begin(), b.begin()}, c.begin(), n, [] _CCCL_DEVICE(const T& ai, const T& bi) -> T {
       return ai + bi;
     });
 }
@@ -126,7 +126,7 @@ try
   state.add_global_memory_writes<T>(n);
   const T scalar = startScalar;
   bench_transform(
-    state, ::cuda::std::tuple{b.begin(), c.begin()}, a.begin(), n, [=] _CCCL_DEVICE(const T& bi, const T& ci) {
+    state, cuda::std::tuple{b.begin(), c.begin()}, a.begin(), n, [=] _CCCL_DEVICE(const T& bi, const T& ci) {
       return bi + scalar * ci;
     });
 }
@@ -156,7 +156,7 @@ try
   const T scalar = startScalar;
   bench_transform(
     state,
-    ::cuda::std::tuple{a.begin(), b.begin(), c.begin()},
+    cuda::std::tuple{a.begin(), b.begin(), c.begin()},
     a.begin(),
     n,
     [=] _CCCL_DEVICE(const T& ai, const T& bi, const T& ci) {

--- a/cub/benchmarks/bench/transform/common.h
+++ b/cub/benchmarks/bench/transform/common.h
@@ -78,7 +78,7 @@ struct policy_selector
 
 template <typename... RandomAccessIteratorsIn, typename RandomAccessIteratorOut, typename TransformOp>
 void bench_transform(nvbench::state& state,
-                     ::cuda::std::tuple<RandomAccessIteratorsIn...> inputs,
+                     cuda::std::tuple<RandomAccessIteratorsIn...> inputs,
                      RandomAccessIteratorOut output,
                      ::cuda::std::int64_t num_items,
                      TransformOp transform_op)

--- a/cub/benchmarks/bench/transform/common.h
+++ b/cub/benchmarks/bench/transform/common.h
@@ -79,7 +79,7 @@ template <typename... RandomAccessIteratorsIn, typename RandomAccessIteratorOut,
 void bench_transform(nvbench::state& state,
                      ::cuda::std::tuple<RandomAccessIteratorsIn...> inputs,
                      RandomAccessIteratorOut output,
-                     ::cuda::std::size_t num_items,
+                     ::cuda::std::int64_t num_items,
                      TransformOp transform_op)
 {
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](const nvbench::launch& launch) {

--- a/cub/benchmarks/bench/transform/common.h
+++ b/cub/benchmarks/bench/transform/common.h
@@ -75,11 +75,11 @@ struct policy_selector
 };
 #endif // !TUNE_BASE
 
-template <typename OffsetT, typename... RandomAccessIteratorsIn, typename RandomAccessIteratorOut, typename TransformOp>
+template <typename... RandomAccessIteratorsIn, typename RandomAccessIteratorOut, typename TransformOp>
 void bench_transform(nvbench::state& state,
                      ::cuda::std::tuple<RandomAccessIteratorsIn...> inputs,
                      RandomAccessIteratorOut output,
-                     OffsetT num_items,
+                     ::cuda::std::size_t num_items,
                      TransformOp transform_op)
 {
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](const nvbench::launch& launch) {

--- a/cub/benchmarks/bench/transform/common.h
+++ b/cub/benchmarks/bench/transform/common.h
@@ -19,6 +19,7 @@
 #include <cub/util_namespace.cuh>
 
 #include <cuda/__numeric/narrow.h>
+#include <cuda/std/cstdint>
 #include <cuda/std/type_traits>
 
 #include <stdexcept>

--- a/cub/benchmarks/bench/transform/complex_cmp.cu
+++ b/cub/benchmarks/bench/transform/complex_cmp.cu
@@ -26,17 +26,10 @@
 
 // This benchmark tests overlapping memory regions for reading and is compute intensive
 
-template <typename OffsetT>
-static void compare_complex(nvbench::state& state, nvbench::type_list<OffsetT>)
+static void compare_complex(nvbench::state& state)
 try
 {
-  const auto n = state.get_int64("Elements{io}");
-  if (sizeof(OffsetT) == 4 && n > std::numeric_limits<OffsetT>::max())
-  {
-    state.skip("Skipping: input size exceeds 32-bit offset type capacity.");
-    return;
-  }
-
+  const auto n                        = state.get_int64("Elements{io}");
   thrust::device_vector<complex32> in = generate(n);
   thrust::device_vector<bool> out(n - 1);
 
@@ -46,16 +39,13 @@ try
 
   // the complex comparison needs lots of compute and transform reads from overlapping input
   using compare_op = less_t;
-  bench_transform(
-    state, ::cuda::std::tuple{in.begin(), in.begin() + 1}, out.begin(), static_cast<OffsetT>(n) - 1, compare_op{});
+  bench_transform(state, ::cuda::std::tuple{in.begin(), in.begin() + 1}, out.begin(), n - 1, compare_op{});
 }
 catch (const std::bad_alloc&)
 {
   state.skip("Skipping: out of memory.");
 }
 
-// TODO(bgruber): hardcode OffsetT?
-NVBENCH_BENCH_TYPES(compare_complex, NVBENCH_TYPE_AXES(offset_types))
+NVBENCH_BENCH(compare_complex)
   .set_name("compare_complex")
-  .set_type_axes_names({"OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 32, 4));

--- a/cub/benchmarks/bench/transform/complex_cmp.cu
+++ b/cub/benchmarks/bench/transform/complex_cmp.cu
@@ -39,7 +39,7 @@ try
 
   // the complex comparison needs lots of compute and transform reads from overlapping input
   using compare_op = less_t;
-  bench_transform(state, ::cuda::std::tuple{in.begin(), in.begin() + 1}, out.begin(), n - 1, compare_op{});
+  bench_transform(state, cuda::std::tuple{in.begin(), in.begin() + 1}, out.begin(), n - 1, compare_op{});
 }
 catch (const std::bad_alloc&)
 {

--- a/cub/benchmarks/bench/transform/fib.cu
+++ b/cub/benchmarks/bench/transform/fib.cu
@@ -68,7 +68,7 @@ try
   state.add_global_memory_reads<index_t>(n);
   state.add_global_memory_writes<output_t>(n);
 
-  bench_transform(state, ::cuda::std::tuple{in.begin()}, out.begin(), n, fib_t<index_t, output_t>{});
+  bench_transform(state, cuda::std::tuple{in.begin()}, out.begin(), n, fib_t<index_t, output_t>{});
 }
 catch (const std::bad_alloc&)
 {

--- a/cub/benchmarks/bench/transform/fib.cu
+++ b/cub/benchmarks/bench/transform/fib.cu
@@ -55,19 +55,12 @@ struct fib_t
     return t2;
   }
 };
-template <typename OffsetT>
-static void fibonacci(nvbench::state& state, nvbench::type_list<OffsetT>)
+static void fibonacci(nvbench::state& state)
 try
 {
-  using index_t  = int64_t;
-  using output_t = uint32_t;
-  const auto n   = state.get_int64("Elements{io}");
-  if (sizeof(OffsetT) == 4 && n > std::numeric_limits<OffsetT>::max())
-  {
-    state.skip("Skipping: input size exceeds 32-bit offset type capacity.");
-    return;
-  }
-
+  using index_t                     = int64_t;
+  using output_t                    = uint32_t;
+  const auto n                      = state.get_int64("Elements{io}");
   thrust::device_vector<index_t> in = generate(n, bit_entropy::_1_000, index_t{0}, index_t{42});
   thrust::device_vector<output_t> out(n);
 
@@ -75,15 +68,11 @@ try
   state.add_global_memory_reads<index_t>(n);
   state.add_global_memory_writes<output_t>(n);
 
-  bench_transform(
-    state, ::cuda::std::tuple{in.begin()}, out.begin(), static_cast<OffsetT>(n), fib_t<index_t, output_t>{});
+  bench_transform(state, ::cuda::std::tuple{in.begin()}, out.begin(), n, fib_t<index_t, output_t>{});
 }
 catch (const std::bad_alloc&)
 {
   state.skip("Skipping: out of memory.");
 }
 
-NVBENCH_BENCH_TYPES(fibonacci, NVBENCH_TYPE_AXES(offset_types))
-  .set_name("fibonacci")
-  .set_type_axes_names({"OffsetT{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 32, 4));
+NVBENCH_BENCH(fibonacci).set_name("fibonacci").add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 32, 4));

--- a/cub/benchmarks/bench/transform/fill.cu
+++ b/cub/benchmarks/bench/transform/fill.cu
@@ -41,7 +41,6 @@ static void fill(nvbench::state& state, nvbench::type_list<T>)
 try
 {
   // A 32-bit offset type or the value 0 or 0xFF... have <1% performance impact
-  using offset_t   = int64_t;
   const auto value = T{42};
   const auto n     = state.get_int64("Elements{io}");
   thrust::device_vector<T> out(n);
@@ -50,7 +49,7 @@ try
   state.add_global_memory_reads<T>(0);
   state.add_global_memory_writes<T>(n);
 
-  bench_transform(state, ::cuda::std::tuple{}, out.begin(), cuda::narrow<offset_t>(n), return_constant<T>{value});
+  bench_transform(state, ::cuda::std::tuple{}, out.begin(), n, return_constant<T>{value});
 }
 catch (const std::bad_alloc&)
 {

--- a/cub/benchmarks/bench/transform/fill.cu
+++ b/cub/benchmarks/bench/transform/fill.cu
@@ -49,7 +49,7 @@ try
   state.add_global_memory_reads<T>(0);
   state.add_global_memory_writes<T>(n);
 
-  bench_transform(state, ::cuda::std::tuple{}, out.begin(), n, return_constant<T>{value});
+  bench_transform(state, cuda::std::tuple{}, out.begin(), n, return_constant<T>{value});
 }
 catch (const std::bad_alloc&)
 {

--- a/cub/benchmarks/bench/transform/grayscale.cu
+++ b/cub/benchmarks/bench/transform/grayscale.cu
@@ -50,17 +50,12 @@ struct transform_op_t
   }
 };
 
-template <typename T, typename OffsetT>
-static void grayscale(nvbench::state& state, nvbench::type_list<T, OffsetT>)
+template <typename T>
+static void grayscale(nvbench::state& state, nvbench::type_list<T>)
 try
 {
   using pixel_t = rgb_t<T>;
   const auto n  = state.get_int64("Elements{io}");
-  if (sizeof(OffsetT) == 4 && n > std::numeric_limits<OffsetT>::max())
-  {
-    state.skip("Skipping: input size exceeds 32-bit offset type capacity.");
-    return;
-  }
 
   // Generate random RGB data by creating separate R, G, B vectors and combining them
   thrust::device_vector<T> r_data = generate(n);
@@ -82,7 +77,7 @@ try
   state.add_global_memory_reads<pixel_t>(n);
   state.add_global_memory_writes<T>(n);
 
-  bench_transform(state, cuda::std::tuple{input.begin()}, output.begin(), static_cast<OffsetT>(n), transform_op_t<T>{});
+  bench_transform(state, cuda::std::tuple{input.begin()}, output.begin(), n, transform_op_t<T>{});
 }
 catch (const std::bad_alloc&)
 {
@@ -95,7 +90,7 @@ using value_types = nvbench::type_list<TUNE_T>;
 using value_types = nvbench::type_list<float, double>;
 #endif
 
-NVBENCH_BENCH_TYPES(grayscale, NVBENCH_TYPE_AXES(value_types, offset_types))
+NVBENCH_BENCH_TYPES(grayscale, NVBENCH_TYPE_AXES(value_types))
   .set_name("grayscale")
-  .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
+  .set_type_axes_names({"T{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 32, 4));

--- a/cub/benchmarks/bench/transform/heavy.cu
+++ b/cub/benchmarks/bench/transform/heavy.cu
@@ -69,7 +69,7 @@ try
   state.add_global_memory_reads<value_t>(n);
   state.add_global_memory_writes<value_t>(n);
 
-  bench_transform(state, ::cuda::std::tuple{in.begin()}, out.begin(), n, heavy_functor<Heaviness::value>{});
+  bench_transform(state, cuda::std::tuple{in.begin()}, out.begin(), n, heavy_functor<Heaviness::value>{});
 }
 catch (const std::bad_alloc&)
 {

--- a/cub/benchmarks/bench/transform/heavy.cu
+++ b/cub/benchmarks/bench/transform/heavy.cu
@@ -59,9 +59,8 @@ template <typename Heaviness>
 static void heavy(nvbench::state& state, nvbench::type_list<Heaviness>)
 try
 {
-  using value_t  = std::uint32_t;
-  using offset_t = int64_t;
-  const auto n   = state.get_int64("Elements{io}");
+  using value_t = std::uint32_t;
+  const auto n  = state.get_int64("Elements{io}");
 
   thrust::device_vector<value_t> in = generate(n);
   thrust::device_vector<value_t> out(n);
@@ -70,8 +69,7 @@ try
   state.add_global_memory_reads<value_t>(n);
   state.add_global_memory_writes<value_t>(n);
 
-  bench_transform(
-    state, ::cuda::std::tuple{in.begin()}, out.begin(), cuda::narrow<offset_t>(n), heavy_functor<Heaviness::value>{});
+  bench_transform(state, ::cuda::std::tuple{in.begin()}, out.begin(), n, heavy_functor<Heaviness::value>{});
 }
 catch (const std::bad_alloc&)
 {

--- a/cub/benchmarks/bench/transform/pytorch.cu
+++ b/cub/benchmarks/bench/transform/pytorch.cu
@@ -49,7 +49,7 @@ try
   state.add_global_memory_reads<T>(n);
   state.add_global_memory_writes<T>(n);
 
-  bench_transform(state, ::cuda::std::tuple{in.begin()}, out.begin(), n, Op{});
+  bench_transform(state, cuda::std::tuple{in.begin()}, out.begin(), n, Op{});
 }
 catch (const std::bad_alloc&)
 {
@@ -151,7 +151,7 @@ try
   state.add_global_memory_reads<T>(2 * n);
   state.add_global_memory_writes<T>(n);
 
-  bench_transform(state, ::cuda::std::tuple{in1.begin(), in2.begin()}, out.begin(), n, Op{});
+  bench_transform(state, cuda::std::tuple{in1.begin(), in2.begin()}, out.begin(), n, Op{});
 }
 catch (const std::bad_alloc&)
 {

--- a/cub/benchmarks/bench/transform/pytorch.cu
+++ b/cub/benchmarks/bench/transform/pytorch.cu
@@ -41,8 +41,6 @@ template <typename Op, typename T>
 static void unary(nvbench::state& state, nvbench::type_list<T>)
 try
 {
-  using OffsetT = int64_t;
-
   const auto n = state.get_int64("Elements{io}");
   thrust::device_vector<T> in(n, 1337);
   thrust::device_vector<T> out(n, thrust::no_init);
@@ -51,7 +49,7 @@ try
   state.add_global_memory_reads<T>(n);
   state.add_global_memory_writes<T>(n);
 
-  bench_transform(state, ::cuda::std::tuple{in.begin()}, out.begin(), static_cast<OffsetT>(n), Op{});
+  bench_transform(state, ::cuda::std::tuple{in.begin()}, out.begin(), n, Op{});
 }
 catch (const std::bad_alloc&)
 {
@@ -144,8 +142,6 @@ template <typename Op, typename T>
 static void binary(nvbench::state& state, nvbench::type_list<T>)
 try
 {
-  using OffsetT = int64_t;
-
   const auto n = state.get_int64("Elements{io}");
   thrust::device_vector<T> in1(n, 1337);
   thrust::device_vector<T> in2(n, 42);
@@ -155,7 +151,7 @@ try
   state.add_global_memory_reads<T>(2 * n);
   state.add_global_memory_writes<T>(n);
 
-  bench_transform(state, ::cuda::std::tuple{in1.begin(), in2.begin()}, out.begin(), static_cast<OffsetT>(n), Op{});
+  bench_transform(state, ::cuda::std::tuple{in1.begin(), in2.begin()}, out.begin(), n, Op{});
 }
 catch (const std::bad_alloc&)
 {

--- a/cub/cub/device/device_transform.cuh
+++ b/cub/cub/device/device_transform.cuh
@@ -71,16 +71,13 @@ struct DeviceTransform
     Env env)
   {
     // We use int64_t internally, since it's faster than uint64_t and similar to a 32-bit offset type. See
-    // https://github.com/NVIDIA/cccl/issues/8805 for data. We need to check if it can hold the value passed by the
-    // user.
+    // https://github.com/NVIDIA/cccl/issues/8805 for data. We use choose_signed_offset to just check if it can hold the
+    // value passed by the user, but otherwise ignore the chosen signed offset type.
     using offset_t = ::cuda::std::int64_t;
-    _CCCL_DIAG_PUSH
-    _CCCL_DIAG_SUPPRESS_MSVC(4127) // conditional expression is constant
-    if (sizeof(NumItemsT) >= 8 && num_items > static_cast<NumItemsT>(::cuda::std::numeric_limits<offset_t>::max()))
+    if (const cudaError_t error = detail::choose_signed_offset<NumItemsT>::is_exceeding_offset_type(num_items))
     {
-      return cudaErrorInvalidValue;
+      return error;
     }
-    _CCCL_DIAG_POP
 
     const auto stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, env).get();
 

--- a/cub/cub/device/device_transform.cuh
+++ b/cub/cub/device/device_transform.cuh
@@ -70,14 +70,17 @@ struct DeviceTransform
     TransformOp transform_op,
     Env env)
   {
-    using choose_offset_t = detail::choose_signed_offset<NumItemsT>;
-    using offset_t        = typename choose_offset_t::type;
-
-    // Check if the number of items exceeds the range covered by the selected signed offset type
-    if (const cudaError_t error = choose_offset_t::is_exceeding_offset_type(num_items); error != cudaSuccess)
+    // We use int64_t internally, since it's faster than uint64_t and similar to a 32-bit offset type. See
+    // https://github.com/NVIDIA/cccl/issues/8805 for data. We need to check if it can hold the value passed by the
+    // user.
+    using offset_t = ::cuda::std::int64_t;
+    _CCCL_DIAG_PUSH
+    _CCCL_DIAG_SUPPRESS_MSVC(4127) // conditional expression is constant
+    if (sizeof(NumItemsT) >= 8 && num_items > static_cast<NumItemsT>(::cuda::std::numeric_limits<offset_t>::max()))
     {
-      return error;
+      return cudaErrorInvalidValue;
     }
+    _CCCL_DIAG_POP
 
     const auto stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, env).get();
 

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -175,7 +175,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE int
 spread_out_items_per_thread(Offset num_items, Policy policy, int items_per_thread, int sm_count, int max_occupancy)
 {
   const int items_per_thread_evenly_spread = static_cast<int>(
-    (::cuda::std::min) (Offset{items_per_thread},
+    (::cuda::std::min) (static_cast<Offset>(items_per_thread),
                         ::cuda::ceil_div(num_items, sm_count * policy.threads_per_block * max_occupancy)));
   const int items_per_thread_clamped =
     ::cuda::std::clamp(items_per_thread_evenly_spread, policy.min_items_per_thread, policy.max_items_per_thread);
@@ -269,7 +269,7 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto configure_as
   const int dyn_smem_size = dyn_smem_for_tile_size(tile_size, alignment);
   _CCCL_ASSERT(NoInputs != (dyn_smem_size != 0), ""); // logical xor
 
-  const auto grid_dim = static_cast<unsigned int>(::cuda::ceil_div(num_items, Offset{tile_size}));
+  const auto grid_dim = static_cast<unsigned int>(::cuda::ceil_div(num_items, static_cast<Offset>(tile_size)));
   // config->smem_size is 16 bytes larger than needed for UBLKCP because it's the total SMEM size, but 16 bytes are
   // occupied by static shared memory and padding. But let's not complicate things.
   return ::cuda::std::make_tuple(
@@ -407,7 +407,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_prefetch_or_vectorized
   }
   _CCCL_ASSERT(ipt, "");
   const int tile_size = threads_per_block * ipt.value();
-  const auto grid_dim = static_cast<unsigned int>(::cuda::ceil_div(num_items, Offset{tile_size}));
+  const auto grid_dim = static_cast<unsigned int>(::cuda::ceil_div(num_items, static_cast<Offset>(tile_size)));
   return CubDebug(
     launcher_factory(grid_dim, threads_per_block, 0, stream, true)
       .doit(kernel_source.TransformKernel(),
@@ -556,9 +556,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch(
   KernelSource kernel_source             = {},
   KernelLauncherFactory launcher_factory = {})
 {
-  static_assert(
-    ::cuda::std::is_same_v<Offset, ::cuda::std::int32_t> || ::cuda::std::is_same_v<Offset, ::cuda::std::int64_t>,
-    "cub::DeviceTransform is only tested and tuned for 32-bit or 64-bit signed offset types");
+  static_assert(::cuda::std::is_same_v<Offset, ::cuda::std::int64_t>,
+                "cub::DeviceTransform is only tested and tuned for int64_t");
 
   if (num_items == 0)
   {

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -134,7 +134,7 @@ _CCCL_DEVICE void transform_kernel_prefetch(
 {
   const int tile_size   = ThreadsPerBlock * num_elem_per_thread;
   const Offset offset   = static_cast<Offset>(blockIdx.x) * tile_size;
-  const int valid_items = static_cast<int>((::cuda::std::min) (num_items - offset, Offset{tile_size}));
+  const int valid_items = static_cast<int>((::cuda::std::min) (num_items - offset, static_cast<Offset>(tile_size)));
 
   // move index and iterator domain to the block/thread index, to reduce arithmetic in the loops below
   {
@@ -246,7 +246,7 @@ _CCCL_DEVICE void transform_kernel_vectorized(
   _CCCL_ASSERT(!can_vectorize || (items_per_thread == num_elem_per_thread_prefetch), "");
   constexpr int tile_size = threads_per_block * items_per_thread;
   const Offset offset     = static_cast<Offset>(blockIdx.x) * tile_size;
-  const int valid_items   = static_cast<int>((::cuda::std::min) (num_items - offset, Offset{tile_size}));
+  const int valid_items   = static_cast<int>((::cuda::std::min) (num_items - offset, static_cast<Offset>(tile_size)));
 
   // if we cannot vectorize or don't have a full tile, fall back to prefetch kernel
   if (!can_vectorize || valid_items != tile_size)
@@ -597,7 +597,7 @@ _CCCL_DEVICE void transform_kernel_ldgsts(
   // constexpr int threads_per_block = Policy.async_copy.threads_per_block;
   const int tile_size   = threads_per_block * num_elem_per_thread;
   const Offset offset   = static_cast<Offset>(blockIdx.x) * tile_size;
-  const int valid_items = static_cast<int>(::cuda::std::min(num_items - offset, Offset{tile_size}));
+  const int valid_items = static_cast<int>(::cuda::std::min(num_items - offset, static_cast<Offset>(tile_size)));
 
   [[maybe_unused]] int smem_offset = 0;
   // TODO(bgruber): drop checking first block, since gmem buffers are always sufficiently aligned. But this would not
@@ -792,7 +792,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
 
   const int tile_size   = threads_per_block * num_elem_per_thread;
   const Offset offset   = static_cast<Offset>(blockIdx.x) * tile_size;
-  const int valid_items = (::cuda::std::min) (num_items - offset, Offset{tile_size});
+  const int valid_items = (::cuda::std::min) (num_items - offset, static_cast<Offset>(tile_size));
 
   const bool inner_blocks = 0 < blockIdx.x && blockIdx.x + 2 < gridDim.x;
   if (inner_blocks)

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -29,15 +29,12 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceTransform::TransformStableArgumentAddresses, t
 DECLARE_LAUNCH_WRAPPER(cub::DeviceTransform::Generate, generate);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceTransform::Fill, fill);
 
-using offset_types = c2h::type_list<std::int32_t, std::int64_t>;
-
 C2H_TEST("DeviceTransform::Transform BabelStream add",
          "[device][transform]",
-         c2h::type_list<std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t, uchar3>,
-         offset_types)
+         c2h::type_list<std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t, uchar3>)
 {
   using type     = c2h::get<0, TestType>;
-  using offset_t = c2h::get<1, TestType>;
+  using offset_t = ::cuda::std::int64_t;
 
   // test edge cases around 16, 128, page size, and full tile
   const offset_t num_items = GENERATE(0, 1, 15, 16, 17, 127, 128, 129, 4095, 4096, 4097, 100'000);
@@ -61,10 +58,9 @@ C2H_TEST("DeviceTransform::Transform BabelStream add",
 
 // note: because this uses a fancy iterator type, it will only test the fallback kernel
 C2H_TEST("DeviceTransform::Transform works for large number of items",
-         "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
-         offset_types)
+         "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
 {
-  using offset_t = c2h::get<0, TestType>;
+  using offset_t = ::cuda::std::int64_t;
   CAPTURE(c2h::type_name<offset_t>());
   const auto num_items = detail::make_large_offset<offset_t>();
 
@@ -81,10 +77,9 @@ C2H_TEST("DeviceTransform::Transform works for large number of items",
 }
 
 C2H_TEST("DeviceTransform::Transform with multiple inputs works for large number of items",
-         "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
-         offset_types)
+         "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
 {
-  using offset_t = c2h::get<0, TestType>;
+  using offset_t = ::cuda::std::int64_t;
   CAPTURE(c2h::type_name<offset_t>());
   const offset_t num_items = detail::make_large_offset<offset_t>();
 
@@ -115,12 +110,11 @@ struct times_seven
 // straddles 4 GiB (negative delta -> just under, positive -> just over). Both deltas fit in I32
 // and I64 offset types.
 C2H_TEST("DeviceTransform::Transform works with large input",
-         "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
-         offset_types)
+         "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
 try
 {
   using type     = std::uint32_t;
-  using offset_t = c2h::get<0, TestType>;
+  using offset_t = ::cuda::std::int64_t;
 
   const auto delta         = GENERATE(-123456, 123456);
   const offset_t num_items = static_cast<offset_t>((offset_t{1} << 30) + delta);
@@ -298,11 +292,10 @@ struct nstream_kernel
 // overwrites one input stream
 C2H_TEST("DeviceTransform::Transform BabelStream nstream",
          "[device][transform]",
-         c2h::type_list<std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t>,
-         offset_types)
+         c2h::type_list<std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t>)
 {
   using type     = c2h::get<0, TestType>;
-  using offset_t = c2h::get<1, TestType>;
+  using offset_t = ::cuda::std::int64_t;
 
   const offset_t num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
   c2h::device_vector<type> a(num_items, thrust::no_init);

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -34,7 +34,7 @@ C2H_TEST("DeviceTransform::Transform BabelStream add",
          c2h::type_list<std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t, uchar3>)
 {
   using type     = c2h::get<0, TestType>;
-  using offset_t = ::cuda::std::int64_t;
+  using offset_t = cuda::std::int64_t;
 
   // test edge cases around 16, 128, page size, and full tile
   const offset_t num_items = GENERATE(0, 1, 15, 16, 17, 127, 128, 129, 4095, 4096, 4097, 100'000);
@@ -60,7 +60,7 @@ C2H_TEST("DeviceTransform::Transform BabelStream add",
 C2H_TEST("DeviceTransform::Transform works for large number of items",
          "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
 {
-  using offset_t = ::cuda::std::int64_t;
+  using offset_t = cuda::std::int64_t;
   CAPTURE(c2h::type_name<offset_t>());
   const auto num_items = detail::make_large_offset<offset_t>();
 
@@ -79,7 +79,7 @@ C2H_TEST("DeviceTransform::Transform works for large number of items",
 C2H_TEST("DeviceTransform::Transform with multiple inputs works for large number of items",
          "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
 {
-  using offset_t = ::cuda::std::int64_t;
+  using offset_t = cuda::std::int64_t;
   CAPTURE(c2h::type_name<offset_t>());
   const offset_t num_items = detail::make_large_offset<offset_t>();
 
@@ -114,7 +114,7 @@ C2H_TEST("DeviceTransform::Transform works with large input",
 try
 {
   using type     = std::uint32_t;
-  using offset_t = ::cuda::std::int64_t;
+  using offset_t = cuda::std::int64_t;
 
   const auto delta         = GENERATE(-123456, 123456);
   const offset_t num_items = static_cast<offset_t>((offset_t{1} << 30) + delta);
@@ -295,7 +295,7 @@ C2H_TEST("DeviceTransform::Transform BabelStream nstream",
          c2h::type_list<std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t>)
 {
   using type     = c2h::get<0, TestType>;
-  using offset_t = ::cuda::std::int64_t;
+  using offset_t = cuda::std::int64_t;
 
   const offset_t num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
   c2h::device_vector<type> a(num_items, thrust::no_init);
@@ -784,10 +784,10 @@ C2H_TEST("DeviceTransform::Transform PDL overlap check", "[device][transform]")
   // completely async work of filling, 2x transforming and 1x reduction. we also avoid using the launch wrapper, since
   // it would synchronize
   fill_pdl(thrust::raw_pointer_cast(data.data()), num_items, 42);
-  cub::DeviceTransform::Transform(::cuda::std::make_tuple(data.begin()), data.begin(), num_items, cuda::std::negate{});
-  cub::DeviceTransform::Transform(::cuda::std::make_tuple(data.begin()), flags.begin(), num_items, _1 == -42);
+  cub::DeviceTransform::Transform(cuda::std::make_tuple(data.begin()), data.begin(), num_items, cuda::std::negate{});
+  cub::DeviceTransform::Transform(cuda::std::make_tuple(data.begin()), flags.begin(), num_items, _1 == -42);
   thrust::reduce_into(
-    thrust::cuda::par_nosync, flags.begin(), flags.end(), result.begin(), true, ::cuda::std::logical_and{});
+    thrust::cuda::par_nosync, flags.begin(), flags.end(), result.begin(), true, cuda::std::logical_and{});
   REQUIRE(result[0]); // access finally synchronize
 }
 #endif

--- a/cub/test/catch2_test_device_transform_if.cu
+++ b/cub/test/catch2_test_device_transform_if.cu
@@ -13,15 +13,12 @@
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceTransform::TransformIf, transform_if);
 
-using offset_types = c2h::type_list<std::int32_t, std::int64_t>;
-
 C2H_TEST("DeviceTransform::TransformIf conditional BabelStream add",
          "[device][transform_if]",
-         c2h::type_list<std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t>,
-         offset_types)
+         c2h::type_list<std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t>)
 {
   using type     = c2h::get<0, TestType>;
-  using offset_t = c2h::get<1, TestType>;
+  using offset_t = ::cuda::std::int64_t;
 
   // test edge cases around 16, 128, page size, and full tile
   const offset_t num_items = GENERATE(0, 1, 15, 16, 17, 127, 128, 129, 4095, 4096, 4097, 100'000);

--- a/thrust/thrust/system/cuda/detail/transform.h
+++ b/thrust/thrust/system/cuda/detail/transform.h
@@ -148,19 +148,13 @@ OutputIt _CCCL_HOST_DEVICE_API _CCCL_FORCEINLINE cub_transform_many(
   if constexpr (::cuda::proclaims_copyable_arguments<Predicate>::value
                 && ::cuda::proclaims_copyable_arguments<TransformOp>::value)
   {
-    THRUST_INDEX_TYPE_DISPATCH(
-      status,
-      (CUB_NS_QUALIFIER::DeviceTransform::TransformIf),
-      num_items,
-      (firsts, result, num_items_fixed, pred, transform_op, cuda_cub::stream(policy)));
+    status = CUB_NS_QUALIFIER::DeviceTransform::TransformIf(
+      firsts, result, num_items, pred, transform_op, cuda_cub::stream(policy));
   }
   else
   {
-    THRUST_INDEX_TYPE_DISPATCH(
-      status,
-      (CUB_NS_QUALIFIER::DeviceTransform::__transform_if_stable_argument_addresses),
-      num_items,
-      (firsts, result, num_items_fixed, pred, transform_op, cuda_cub::stream(policy)));
+    status = CUB_NS_QUALIFIER::DeviceTransform::__transform_if_stable_argument_addresses(
+      firsts, result, num_items, pred, transform_op, cuda_cub::stream(policy));
   }
   throw_on_error(status, "transform: failed inside CUB");
 

--- a/thrust/thrust/system/cuda/detail/transform.h
+++ b/thrust/thrust/system/cuda/detail/transform.h
@@ -144,6 +144,9 @@ OutputIt _CCCL_HOST_DEVICE_API _CCCL_FORCEINLINE cub_transform_many(
     return result;
   }
 
+  // throw exception in case num_items is negative. Should never happen since last - first iterator must be positive.
+  _THRUST_INDEX_TYPE_DISPATCH_GUARD_UNDERFLOW(num_items);
+
   cudaError_t status;
   if constexpr (::cuda::proclaims_copyable_arguments<Predicate>::value
                 && ::cuda::proclaims_copyable_arguments<TransformOp>::value)


### PR DESCRIPTION
This change is going to cause a tiny regression (benchmarks in #8805, important ones repeated below). However, it:

* halfs compilation time for `thrust::transform` (and any other Thrust call using `DeviceTransform`, because we got rid of the index type dispatch
* halfs compilation time of all `DeviceTransform` tests
* halfs benchmark time for `DeviceTransform`
* doubles tuning throughput for `DeviceTransform`

I am gladly eating a small regression for these benefits. Here are the regressions:

A100 (1/200 workloads regressed):
```
# triad

## [0] NVIDIA A100-SXM4-80GB

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |     Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|----------|---------|----------|
|   F64   |      I64      |      2^24      | 243.144 us |       1.02% | 245.588 us |       0.38% | 2.444 us |   1.01% |  🔴 SLOW  |
```

H200 (1/200 workloads regressed):
```
# nstream

## [0] NVIDIA H200 NVL

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   F32   |      I64      |      2^20      |   9.963 us |       1.47% |  10.443 us |       6.24% |  0.480 us |   4.82% |  🔴 SLOW  |
```

B200 (4/200 workloads regressed):
```
# mul

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^28      | 116.430 us |       0.54% | 117.871 us |       0.70% |  1.442 us |   1.24% |  🔴 SLOW  |

# triad

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |     Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|----------|---------|----------|
|   I8    |      I32      |      2^28      | 153.406 us |       0.32% | 155.685 us |       0.25% | 2.280 us |   1.49% |  🔴 SLOW  |

# nstream

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |     Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|----------|---------|----------|
|   I8    |      I32      |      2^28      | 208.966 us |       0.18% | 212.496 us |       0.36% | 3.531 us |   1.69% |  🔴 SLOW  |
|   I16   |      I32      |      2^28      | 317.133 us |       0.23% | 322.522 us |       0.29% | 5.389 us |   1.70% |  🔴 SLOW  |
```

Let me know if we need more benchmarks, like on non-data-center-grade GPUs.

Fixes: #8805