### PR TITLE
[libcu++] Implement tuple protocol for `integer_sequence`

### DIFF
--- a/cudax/include/cuda/experimental/__execution/visit.cuh
+++ b/cudax/include/cuda/experimental/__execution/visit.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -40,13 +40,8 @@
 #  define _CCCL_BUILTIN_STRUCTURED_BINDING_SIZE(...) __builtin_structured_binding_size(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__builtin_structured_binding_size)
 
-#if __cpp_structured_bindings >= 202411L
-#  define _CCCL_STRUCTURED_BINDING_CAN_INTRODUCE_A_PACK
-#endif // __cpp_structured_bindings >= 202411L
-
 #if _CCCL_CUDA_COMPILER(NVCC)
 #  undef _CCCL_BUILTIN_STRUCTURED_BINDING_SIZE
-#  undef _CCCL_STRUCTURED_BINDING_CAN_INTRODUCE_A_PACK
 #endif // _CCCL_CUDA_COMPILER(NVCC)
 
 namespace cuda::experimental::execution
@@ -122,7 +117,7 @@ inline constexpr int structured_binding_size<_Sndr const&> = structured_binding_
 
 // If structured bindings can be used to introduce a pack, then `visit` has a very simple
 // implementation.
-#if defined(_CCCL_STRUCTURED_BINDING_CAN_INTRODUCE_A_PACK)
+#if _CCCL_HAS_STRUCTURED_BINDINGS_PACK()
 
 // C++26, structured binding can introduce a pack.
 struct _CCCL_TYPE_VISIBILITY_DEFAULT visit_t

--- a/libcudacxx/include/cuda/std/__cccl/dialect.h
+++ b/libcudacxx/include/cuda/std/__cccl/dialect.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -213,5 +213,18 @@
 #else // ^^^ has long double ^^^ / vvv no long double vvv
 #  define _CCCL_HAS_LONG_DOUBLE() 0
 #endif // ^^^ no long double ^^^
+
+// clang-21+ and gcc-16+ allow structured bindings to introduce a pack since C++17.
+#if __cpp_structured_bindings >= 202411L || _CCCL_COMPILER(CLANG, >=, 21) || _CCCL_COMPILER(GCC, >=, 16)
+#  define _CCCL_HAS_STRUCTURED_BINDINGS_PACK() 1
+#else // ^^^ has structured bindings with pack ^^^ / vvv no structured bindings with pack vvv
+#  define _CCCL_HAS_STRUCTURED_BINDINGS_PACK() 0
+#endif // ^^^ no structured bindings with pack ^^^
+
+// nvcc doesn't implement structured bindings pack yet.
+#if _CCCL_CUDA_COMPILER(NVCC)
+#  undef _CCCL_HAS_STRUCTURED_BINDINGS_PACK
+#  define _CCCL_HAS_STRUCTURED_BINDINGS_PACK() 0
+#endif // _CCCL_CUDA_COMPILER(NVCC)
 
 #endif // __CCCL_DIALECT_H

--- a/libcudacxx/include/cuda/std/__utility/integer_sequence.h
+++ b/libcudacxx/include/cuda/std/__utility/integer_sequence.h
@@ -3,7 +3,7 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -20,8 +20,11 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__tuple_dir/tuple_element.h>
+#include <cuda/std/__tuple_dir/tuple_size.h>
+#include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_integral.h>
-#include <cuda/std/cstddef>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -242,7 +245,63 @@ using make_index_sequence = make_integer_sequence<size_t, _Np>;
 template <class... _Tp>
 using index_sequence_for = make_index_sequence<sizeof...(_Tp)>;
 
+// specialize cuda::std::tuple_size and cuda::std::tuple_element for cuda::std::integer_sequence
+
+template <class _Tp, _Tp... _Indices>
+struct tuple_size<integer_sequence<_Tp, _Indices...>> : integral_constant<size_t, sizeof...(_Indices)>
+{};
+
+template <size_t _Ip, class _Tp, _Tp... _Indices>
+struct tuple_element<_Ip, integer_sequence<_Tp, _Indices...>>
+{
+  static_assert(_Ip < sizeof...(_Indices),
+                "Index out of bounds in cuda::std::tuple_element<> (cuda::std::integer_sequence)");
+  using type = _Tp;
+};
+
+template <size_t _Ip, class _Tp, _Tp... _Indices>
+struct tuple_element<_Ip, const integer_sequence<_Tp, _Indices...>>
+{
+  static_assert(_Ip < sizeof...(_Indices),
+                "Index out of bounds in cuda::std::tuple_element<> (const cuda::std::integer_sequence)");
+  using type = _Tp;
+};
+
+template <size_t _Ip, class _Tp, _Tp... _Indices>
+[[nodiscard]] _CCCL_API constexpr _Tp get(integer_sequence<_Tp, _Indices...>) noexcept
+{
+  static_assert(_Ip < sizeof...(_Indices), "Index out of bounds in cuda::std::get<> (cuda::std::integer_sequence)");
+  constexpr _Tp __indices[]{_Indices...};
+  return __indices[_Ip];
+}
+
 _CCCL_END_NAMESPACE_CUDA_STD
+
+// tuple protocol for cuda::std::integer_sequence
+
+_CCCL_BEGIN_NAMESPACE_STD
+
+template <class _Tp, _Tp... _Indices>
+struct tuple_size<::cuda::std::integer_sequence<_Tp, _Indices...>>
+    : ::cuda::std::integral_constant<::cuda::std::size_t, sizeof...(_Indices)>
+{};
+
+template <::cuda::std::size_t _Ip, class _Tp, _Tp... _Indices>
+struct tuple_element<_Ip, ::cuda::std::integer_sequence<_Tp, _Indices...>>
+{
+  static_assert(_Ip < sizeof...(_Indices), "Index out of bounds in std::tuple_element<> (cuda::std::integer_sequence)");
+  using type = _Tp;
+};
+
+template <::cuda::std::size_t _Ip, class _Tp, _Tp... _Indices>
+struct tuple_element<_Ip, const ::cuda::std::integer_sequence<_Tp, _Indices...>>
+{
+  static_assert(_Ip < sizeof...(_Indices),
+                "Index out of bounds in std::tuple_element<> (const cuda::std::integer_sequence)");
+  using type = _Tp;
+};
+
+_CCCL_END_NAMESPACE_STD
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/std/version
+++ b/libcudacxx/include/cuda/std/version
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -39,7 +39,7 @@
 #define __cccl_lib_forward_like                 202207L
 #define __cccl_lib_gcd_lcm                      201606L
 #define __cccl_lib_integer_comparison_functions 202002L
-#define __cccl_lib_integer_sequence             201304L
+#define __cccl_lib_integer_sequence             202511L
 #define __cccl_lib_integral_constant_callable   201304L
 #define __cccl_lib_is_final                     201402L
 #define __cccl_lib_is_nothrow_convertible       201806L

--- a/libcudacxx/test/libcudacxx/std/utilities/intseq/intseq.binding/get.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/intseq/intseq.binding/get.pass.cpp
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/utility>
+
+// template<size_t I, class T, T... Values>
+//   constexpr T get(integer_sequence<T, Values...>) noexcept;
+
+#include <cuda/std/cstddef>
+#include <cuda/std/type_traits>
+#include <cuda/utility>
+
+#include "test_macros.h"
+
+template <class Seq, cuda::std::size_t I>
+TEST_FUNC constexpr void test(typename Seq::value_type ref_val)
+{
+  // Test Seq.
+  {
+    Seq seq{};
+    static_assert(cuda::std::is_same_v<cuda::std::tuple_element_t<I, Seq>, decltype(cuda::std::get<I>(seq))>);
+    static_assert(noexcept(cuda::std::get<I>(seq)));
+
+    const auto v1 = cuda::std::get<I>(seq);
+    assert(v1 == ref_val);
+
+    // Test ADL.
+#if TEST_STD_VER >= 2020
+    const auto v2 = get<I>(seq);
+    assert(v2 == ref_val);
+#endif // TEST_STD_VER >= 2020
+  }
+
+  // Test const Seq.
+  {
+    const Seq seq{};
+    static_assert(cuda::std::is_same_v<cuda::std::tuple_element_t<I, Seq>, decltype(cuda::std::get<I>(seq))>);
+    static_assert(noexcept(cuda::std::get<I>(seq)));
+
+    const auto v1 = cuda::std::get<I>(seq);
+    assert(v1 == ref_val);
+
+    // Test ADL.
+#if TEST_STD_VER >= 2020
+    const auto v2 = get<I>(seq);
+    assert(v2 == ref_val);
+#endif // TEST_STD_VER >= 2020
+  }
+}
+
+template <class T, T... Vs>
+TEST_FUNC constexpr void test()
+{
+  cuda::static_for<sizeof...(Vs)>([](auto i) {
+    constexpr T values[]{Vs...};
+    test<cuda::std::integer_sequence<T, Vs...>, i()>(values[i()]);
+  });
+}
+
+TEST_FUNC constexpr bool test()
+{
+  test<cuda::std::integer_sequence<signed char, -1>>();
+  test<cuda::std::integer_sequence<unsigned, 1, 2, 3>>();
+  test<cuda::std::integer_sequence<unsigned long long, 1, 2, 3, 8098098>>();
+
+  const auto [v1, v2, v3] = cuda::std::integer_sequence<unsigned, 1, 2, 3>{};
+  assert(v1 == 1);
+  assert(v2 == 2);
+  assert(v3 == 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/intseq/intseq.binding/get.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/intseq/intseq.binding/get.pass.cpp
@@ -58,7 +58,7 @@ template <class T, T... Vs>
 TEST_FUNC constexpr void test()
 {
   cuda::static_for<sizeof...(Vs)>([](auto i) {
-    constexpr T values[]{Vs...};
+    constexpr T values[(sizeof...(Vs) > 0) ? sizeof...(Vs) : 1]{Vs...};
     test<cuda::std::integer_sequence<T, Vs...>, i()>(values[i()]);
   });
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/intseq/intseq.binding/tuple_element.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/intseq/intseq.binding/tuple_element.compile.pass.cpp
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/utility>
+
+// template<size_t I, class T, T... Values>
+//   struct tuple_element<I, integer_sequence<T, Values...>>;
+// template<size_t I, class T, T... Values>
+//   struct tuple_element<I, const integer_sequence<T, Values...>>;
+
+#include <cuda/std/type_traits>
+#include <cuda/utility>
+
+#include "test_macros.h"
+
+template <class T, T... Vs>
+TEST_FUNC constexpr bool test_tuple_element()
+{
+  using Seq = cuda::std::integer_sequence<T, Vs...>;
+
+  cuda::static_for<sizeof...(Vs)>([](auto i) {
+    // Test std::tuple_element.
+    static_assert(cuda::std::is_same_v<T, typename std::tuple_element<i(), Seq>::type>);
+    static_assert(cuda::std::is_same_v<T, typename std::tuple_element<i(), const Seq>::type>);
+
+    // Test cuda::std::tuple_element.
+    static_assert(cuda::std::is_same_v<T, typename cuda::std::tuple_element<i(), Seq>::type>);
+    static_assert(cuda::std::is_same_v<T, typename cuda::std::tuple_element<i(), const Seq>::type>);
+
+    // Test cuda::std::tuple_element_t.
+    static_assert(cuda::std::is_same_v<T, cuda::std::tuple_element_t<i(), Seq>>);
+    static_assert(cuda::std::is_same_v<T, cuda::std::tuple_element_t<i(), const Seq>>);
+  });
+
+  return true;
+}
+
+static_assert(test_tuple_element<signed char, -1>());
+static_assert(test_tuple_element<unsigned, 1, 2, 3>());
+static_assert(test_tuple_element<unsigned long long, 1, 2, 3, 8098098>());
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/intseq/intseq.binding/tuple_size.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/intseq/intseq.binding/tuple_size.compile.pass.cpp
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/utility>
+
+// template<class T, T... Values>
+//   struct tuple_size<integer_sequence<T, Values...>>;
+
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+#include "test_macros.h"
+
+template <class T, T... Vs>
+TEST_FUNC constexpr bool test_tuple_size()
+{
+  using Seq               = cuda::std::integer_sequence<T, Vs...>;
+  constexpr auto ref_size = sizeof...(Vs);
+
+  // Test std::tuple_size.
+  static_assert(std::tuple_size<Seq>::value == ref_size);
+  static_assert(std::tuple_size<const Seq>::value == ref_size);
+
+  // Test cuda::std::tuple_size.
+  static_assert(cuda::std::tuple_size<Seq>::value == ref_size);
+  static_assert(cuda::std::tuple_size<const Seq>::value == ref_size);
+
+  // Test cuda::std::tuple_size_v.
+  static_assert(cuda::std::tuple_size_v<Seq> == ref_size);
+  static_assert(cuda::std::tuple_size_v<const Seq> == ref_size);
+
+  return true;
+}
+
+static_assert(test_tuple_size<int>());
+static_assert(test_tuple_size<signed char, -1>());
+static_assert(test_tuple_size<unsigned, 1, 2, 3>());
+static_assert(test_tuple_size<unsigned long long, 1, 2, 3, 8098098>());
+
+int main(int, char**)
+{
+  return 0;
+}


### PR DESCRIPTION
This PR implements tuple protocol for `integer_sequence` ([P1789R3](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p1789r3.pdf)) from C++26