### PR TITLE
[libcu++] Change `inplace_vector` return type for `try_meow` methods

### DIFF
--- a/libcudacxx/include/cuda/std/inplace_vector
+++ b/libcudacxx/include/cuda/std/inplace_vector
@@ -44,6 +44,7 @@
 #include <cuda/std/__memory/uninitialized_algorithms.h>
 #include <cuda/std/__new/device_new.h>
 #include <cuda/std/__new/launder.h>
+#include <cuda/std/__optional/optional_ref.h>
 #include <cuda/std/__ranges/access.h>
 #include <cuda/std/__ranges/concepts.h>
 #include <cuda/std/__ranges/from_range.h>
@@ -1406,34 +1407,33 @@ public:
   }
 
   template <class... _Args>
-  _CCCL_API constexpr pointer try_emplace_back(_Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
+  _CCCL_API constexpr optional<reference>
+  try_emplace_back(_Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
   {
     if (this->size() == _Capacity)
     {
-      return nullptr;
+      return {};
     }
-
-    return ::cuda::std::addressof(this->unchecked_emplace_back(::cuda::std::forward<_Args>(__args)...));
+    return optional<reference>{in_place, this->unchecked_emplace_back(::cuda::std::forward<_Args>(__args)...)};
   }
 
-  _CCCL_API constexpr pointer try_push_back(const _Tp& __value) noexcept(is_nothrow_copy_constructible_v<_Tp>)
+  _CCCL_API constexpr optional<reference>
+  try_push_back(const _Tp& __value) noexcept(is_nothrow_copy_constructible_v<_Tp>)
   {
     if (this->size() == _Capacity)
     {
-      return nullptr;
+      return {};
     }
-
-    return ::cuda::std::addressof(this->unchecked_emplace_back(__value));
+    return optional<reference>{in_place, this->unchecked_emplace_back(__value)};
   }
 
-  _CCCL_API constexpr pointer try_push_back(_Tp&& __value) noexcept(is_nothrow_move_constructible_v<_Tp>)
+  _CCCL_API constexpr optional<reference> try_push_back(_Tp&& __value) noexcept(is_nothrow_move_constructible_v<_Tp>)
   {
     if (this->size() == _Capacity)
     {
-      return nullptr;
+      return {};
     }
-
-    return ::cuda::std::addressof(this->unchecked_emplace_back(::cuda::std::move(__value)));
+    return optional<reference>{in_place, this->unchecked_emplace_back(::cuda::std::move(__value))};
   }
 
   _CCCL_TEMPLATE(class _Range)
@@ -2017,19 +2017,19 @@ public:
   }
 
   template <class... _Args>
-  _CCCL_API constexpr pointer try_emplace_back(_Args&&...) noexcept
+  _CCCL_API constexpr optional<reference> try_emplace_back(_Args&&...) noexcept
   {
-    return nullptr;
+    return {};
   }
 
-  _CCCL_API constexpr pointer try_push_back(const _Tp&) noexcept
+  _CCCL_API constexpr optional<reference> try_push_back(const _Tp&) noexcept
   {
-    return nullptr;
+    return {};
   }
 
-  _CCCL_API constexpr pointer try_push_back(_Tp&&) noexcept
+  _CCCL_API constexpr optional<reference> try_push_back(_Tp&&) noexcept
   {
-    return nullptr;
+    return {};
   }
 
   _CCCL_TEMPLATE(class _Range)

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/emplace.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/emplace.pass.cpp
@@ -15,6 +15,7 @@
 #include <cuda/std/cassert>
 #include <cuda/std/initializer_list>
 #include <cuda/std/inplace_vector>
+#include <cuda/std/optional>
 #include <cuda/std/type_traits>
 
 #include "test_iterators.h"
@@ -82,82 +83,82 @@ TEST_FUNC constexpr void test()
   { // inplace_vector<T, 0>::try_emplace_back(args...)
     cuda::std::inplace_vector<T, 0> vec{};
     auto res = vec.try_emplace_back(5);
-    static_assert(cuda::std::is_same<decltype(res), typename inplace_vector::pointer>::value);
+    static_assert(cuda::std::is_same<decltype(res), cuda::std::optional<typename inplace_vector::reference>>::value);
     assert(vec.empty());
-    assert(res == nullptr);
+    assert(!res);
   }
 
   { // inplace_vector<T, N>::try_emplace_back(args...)
     inplace_vector vec = {T(0), T(1), T(2), T(3), T(4)};
     auto res           = vec.try_emplace_back(5);
-    static_assert(cuda::std::is_same<decltype(res), typename inplace_vector::pointer>::value);
+    static_assert(cuda::std::is_same<decltype(res), cuda::std::optional<typename inplace_vector::reference>>::value);
     assert(equal_range(vec, expected));
-    assert(*res == T(5));
-    *res = T(6);
-    assert(*res == T(6));
+    assert(res.value() == T(5));
+    res.value() = T(6);
+    assert(res.value() == T(6));
   }
 
   { // inplace_vector<T, N>::try_emplace_back(args...), at capacity
     inplace_vector vec = {T(0), T(1), T(2), T(3), T(4), T(5)};
     auto res           = vec.try_emplace_back(6);
-    static_assert(cuda::std::is_same<decltype(res), typename inplace_vector::pointer>::value);
+    static_assert(cuda::std::is_same<decltype(res), cuda::std::optional<typename inplace_vector::reference>>::value);
     assert(equal_range(vec, expected));
-    assert(res == nullptr);
+    assert(!res);
   }
 
   { // inplace_vector<T, 0>::try_push_back(const T&)
     const T to_be_pushed = 5;
     cuda::std::inplace_vector<T, 0> vec{};
     auto res = vec.try_push_back(to_be_pushed);
-    static_assert(cuda::std::is_same<decltype(res), typename inplace_vector::pointer>::value);
+    static_assert(cuda::std::is_same<decltype(res), cuda::std::optional<typename inplace_vector::reference>>::value);
     assert(vec.empty());
-    assert(res == nullptr);
+    assert(!res);
   }
 
   { // inplace_vector<T, N>::try_push_back(const T&)
     const T to_be_pushed = 5;
     inplace_vector vec   = {T(0), T(1), T(2), T(3), T(4)};
     auto res             = vec.try_push_back(to_be_pushed);
-    static_assert(cuda::std::is_same<decltype(res), typename inplace_vector::pointer>::value);
+    static_assert(cuda::std::is_same<decltype(res), cuda::std::optional<typename inplace_vector::reference>>::value);
     assert(equal_range(vec, expected));
-    assert(*res == T(5));
-    *res = T(6);
-    assert(*res == T(6));
+    assert(res.value() == T(5));
+    res.value() = T(6);
+    assert(res.value() == T(6));
   }
 
   { // inplace_vector<T, N>::try_push_back(const T&), at capacity
     const T to_be_pushed = 6;
     inplace_vector vec   = {T(0), T(1), T(2), T(3), T(4), T(5)};
     auto res             = vec.try_push_back(to_be_pushed);
-    static_assert(cuda::std::is_same<decltype(res), typename inplace_vector::pointer>::value);
+    static_assert(cuda::std::is_same<decltype(res), cuda::std::optional<typename inplace_vector::reference>>::value);
     assert(equal_range(vec, expected));
-    assert(res == nullptr);
+    assert(!res);
   }
 
   { // inplace_vector<T, 0>::try_push_back(T&&)
     cuda::std::inplace_vector<T, 0> vec{};
     auto res = vec.try_push_back(5);
-    static_assert(cuda::std::is_same<decltype(res), typename inplace_vector::pointer>::value);
+    static_assert(cuda::std::is_same<decltype(res), cuda::std::optional<typename inplace_vector::reference>>::value);
     assert(vec.empty());
-    assert(res == nullptr);
+    assert(!res);
   }
 
   { // inplace_vector<T, N>::try_push_back(T&&)
     inplace_vector vec = {T(0), T(1), T(2), T(3), T(4)};
     auto res           = vec.try_push_back(T(5));
-    static_assert(cuda::std::is_same<decltype(res), typename inplace_vector::pointer>::value);
+    static_assert(cuda::std::is_same<decltype(res), cuda::std::optional<typename inplace_vector::reference>>::value);
     assert(equal_range(vec, expected));
-    assert(*res == T(5));
-    *res = T(6);
-    assert(*res == T(6));
+    assert(res.value() == T(5));
+    res.value() = T(6);
+    assert(res.value() == T(6));
   }
 
   { // inplace_vector<T, N>::try_push_back(T&&), at capacity
     inplace_vector vec = {T(0), T(1), T(2), T(3), T(4), T(5)};
     auto res           = vec.try_push_back(T(6));
-    static_assert(cuda::std::is_same<decltype(res), typename inplace_vector::pointer>::value);
+    static_assert(cuda::std::is_same<decltype(res), cuda::std::optional<typename inplace_vector::reference>>::value);
     assert(equal_range(vec, expected));
-    assert(res == nullptr);
+    assert(!res);
   }
 
   { // inplace_vector<T, N>::unchecked_emplace_back(args...)


### PR DESCRIPTION
This PR implements part of [P3981R2](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3981r2.html) that changes `inplace_vector` return types for `try_meow` methods.

I've not updated the feature testing macro value, because there is another paper that we don't currently implement and they share the same macro value.

This is a source breaking change, but it's consistent what other standard libraries do when a feature is changed before the standard release.