### PR TITLE
[STF] Deduplicate cudaStreamIsCapturing helper

### DIFF
--- a/cudax/include/cuda/experimental/__places/stream_pool.cuh
+++ b/cudax/include/cuda/experimental/__places/stream_pool.cuh
@@ -45,6 +45,21 @@ using ::cuda::experimental::stf::mv;
 class exec_place;
 
 /**
+ * @brief Is @p stream currently participating in a CUDA graph capture?
+ *
+ * Returns `false` for `nullptr` (the legacy default stream is never
+ * capturing). `cudaStreamIsCapturing` is itself capture-safe, so this can be
+ * called from contexts where most other driver queries (`cuStreamGetId`,
+ * `cudaStreamGetDevice`, ...) would be rejected with
+ * `cudaErrorStreamCaptureUnsupported` and would *invalidate* the in-flight
+ * capture.
+ */
+[[nodiscard]] inline bool is_stream_capturing(cudaStream_t stream)
+{
+  return cuda_try<cudaStreamIsCapturing>(stream) != cudaStreamCaptureStatusNone;
+}
+
+/**
  * @brief Computes the CUDA device in which the stream was created
  */
 inline int get_device_from_stream(cudaStream_t stream)
@@ -54,12 +69,11 @@ inline int get_device_from_stream(cudaStream_t stream)
     return cuda_try<cudaGetDevice>();
   }
 
-  auto capture_status = cudaStreamCaptureStatusNone;
-  if (cudaStreamIsCapturing(stream, &capture_status) == cudaSuccess && capture_status != cudaStreamCaptureStatusNone)
+  // cudaStreamGetDevice/cuStreamGetCtx are not permitted while the stream is
+  // participating in capture. Use the active device, which is the device on
+  // which the capture is being constructed.
+  if (is_stream_capturing(stream))
   {
-    // cudaStreamGetDevice/cuStreamGetCtx are not permitted while the stream is
-    // participating in capture. Use the active device, which is the device on
-    // which the capture is being constructed.
     return cuda_try<cudaGetDevice>();
   }
 
@@ -97,9 +111,7 @@ inline unsigned long long get_stream_id(cudaStream_t stream)
   {
     return k_no_stream_id;
   }
-  cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
-  const cudaError_t cap_err              = cudaStreamIsCapturing(stream, &capture_status);
-  if (cap_err == cudaSuccess && capture_status != cudaStreamCaptureStatusNone)
+  if (is_stream_capturing(stream))
   {
     return k_no_stream_id;
   }

--- a/cudax/include/cuda/experimental/__stf/internal/stf_places_extended_exports.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/stf_places_extended_exports.cuh
@@ -46,6 +46,7 @@ using ::cuda::experimental::places::green_ctx_view;
 #endif // _CCCL_CTK_AT_LEAST(12, 4)
 using ::cuda::experimental::places::exec_place_resources;
 using ::cuda::experimental::places::get_device_from_stream;
+using ::cuda::experimental::places::is_stream_capturing;
 using ::cuda::experimental::places::k_no_stream_id;
 using ::cuda::experimental::places::localized_array;
 using ::cuda::experimental::places::partition_fn_t;

--- a/cudax/include/cuda/experimental/__stf/stream/stream_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/stream/stream_ctx.cuh
@@ -142,12 +142,15 @@ public:
       : backend_ctx<stream_ctx>(::std::make_shared<impl>(mv(handle)))
   {}
   stream_ctx(cudaStream_t user_stream, async_resources_handle handle = async_resources_handle(nullptr))
-      : backend_ctx<stream_ctx>(::std::make_shared<impl>(mv(handle), !is_capturing(user_stream)))
+      : backend_ctx<stream_ctx>(::std::make_shared<impl>(mv(handle), !is_stream_capturing(user_stream)))
   {
-    // A valid user stream means the CUDA runtime has already been initialized.
-    // If that stream is currently capturing, avoid making the backend
-    // constructor issue any additional runtime initialization calls that could
-    // be incompatible with the capture.
+    // If ``user_stream`` is currently capturing a CUDA graph, avoid issuing
+    // any CUDA runtime initialization calls in the backend constructor: under
+    // ``cudaStreamCaptureModeThreadLocal`` / ``Global`` such calls are
+    // rejected with ``cudaErrorStreamCaptureUnsupported`` and invalidate the
+    // in-progress capture. (The null/default stream is treated as
+    // ``not-capturing`` by ``cudaStreamIsCapturing``, so it goes through the
+    // normal init path.)
 
     // When the caller supplies their own ``async_resources_handle``, its
     // stream pool is very likely already populated with streams that carry
@@ -159,7 +162,7 @@ public:
     // the supported in-capture configuration.
     if (state().user_provided_handle)
     {
-      EXPECT(!is_capturing(user_stream),
+      EXPECT(!is_stream_capturing(user_stream),
              "stream_ctx(user_stream, handle): user_stream is in a CUDA graph "
              "capture but a caller-provided async_resources_handle was "
              "supplied. The handle's stream pool may carry uncaptured work "
@@ -177,15 +180,6 @@ public:
 
   ///@}
 
-private:
-  [[nodiscard]] static bool is_capturing(cudaStream_t user_stream)
-  {
-    cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
-    cuda_safe_call(cudaStreamIsCapturing(user_stream, &capture_status));
-    return capture_status != cudaStreamCaptureStatusNone;
-  }
-
-public:
   void set_user_stream(cudaStream_t user_stream)
   {
     // TODO first introduce the user stream in our pool


### PR DESCRIPTION
## Summary

Follow-up on top of #8919 that came out of a post-merge review.

Three independent copies of the `cudaStreamIsCapturing(stream, &s); s != None` pattern had grown across cudax: two inline in `places.cuh` (`get_device_from_stream`, `get_stream_id`) and one as a private `stream_ctx::is_capturing` helper. They all do the same thing -- ask "is this stream currently part of a CUDA graph capture?" -- which is the *only* driver query that is itself capture-safe and so deserves a single named, documented home.

Introduce `cuda::experimental::places::is_stream_capturing(cudaStream_t)` in `__places/stream_pool.cuh`, document why it is the one query you can safely call mid-capture, and re-export it into the `stf` namespace via `stf_places_extended_exports.cuh`. Replace the three call sites. No behavior change; the new helper does **not** silently swallow the `cudaStreamIsCapturing` return value the way the old `cap_err == cudaSuccess` paths did, because that error is always fatal in practice and the existing `cuda_try` machinery already gives the right diagnostic.

### History

Originally this PR also wrapped `cudaFree(0)` in a process-wide gate to skip redundant runtime-init calls on the hot path. Dropped per @caugonnet's review: CUDA contexts can be torn down and recreated (some Python stacks do this), and a process-wide `static bool` would lie about that, potentially leaving subsequent contexts uninitialized. The micro-optimization isn't worth that risk.

## Test plan

- [ ] CI green -- pure refactor of the capture-query, exercised by the existing in-capture coverage (`legacy_to_stf_in_capture.cu` etc.).