### PR TITLE
`cudax::copy(mdspan)` Optimize shared memory cases

### DIFF
--- a/cudax/benchmarks/CMakeLists.txt
+++ b/cudax/benchmarks/CMakeLists.txt
@@ -53,7 +53,11 @@ function(add_bench_dir bench_dir)
     target_link_libraries(${bench_name} PRIVATE cudax.compiler_interface)
     target_compile_options(
       ${bench_name}
-      PRIVATE "$<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>"
+      PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>"
+        # cudax.compiler_interface enables assertions for tests/examples; benchmarks should measure release behavior.
+        "$<$<COMPILE_LANGUAGE:CUDA>:-UCCCL_ENABLE_ASSERTIONS>"
+        "$<$<COMPILE_LANGUAGE:CXX>:-UCCCL_ENABLE_ASSERTIONS>"
     )
   endforeach()
 endfunction()

--- a/cudax/benchmarks/bench/copy/copy_bench.cu
+++ b/cudax/benchmarks/bench/copy/copy_bench.cu
@@ -9,6 +9,8 @@
 
 #include <cuda/experimental/copy.cuh>
 
+#include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 
 #include <nvbench/nvbench.cuh>
@@ -157,25 +159,27 @@ void memcpy_neg(nvbench::state& state)
 }
 NVBENCH_BENCH(memcpy_neg).set_name("contiguous-negative-stride (5D, int, 4GB)");
 
-// src: (134217600, 32):(64, 1)
-// dst: (134217600, 32):(64, 1)
+// src: (134217600, 32):(128, 1), offset=32
+// dst: (134217600, 32):(128, 1), offset=32
+// Copies 4GB while allocating 16GB per tensor because of the padded outer stride.
 void vectorization(nvbench::state& state)
 {
   cuda::std::array<int64_t, 2> shape{134217600, 32};
   cuda::std::array<int64_t, 2> strides{128, 1};
   bench_copy<char, int64_t>(state, 32, shape, strides);
 }
-NVBENCH_BENCH(vectorization).set_name("vectorization (2D, char, 4GB)");
+NVBENCH_BENCH(vectorization).set_name("vectorization (2D, char, 4GB copy, 16GB alloc)");
 
-// src: (32 767, (128 * 1024) / sizeof(int)):(128 * 1024, 1)
-// dst: (32 767, (128 * 1024) / sizeof(int)):(128 * 1024, 1)
-void block_countiguous(nvbench::state& state)
+// src: (32767, (128 * 1024) / sizeof(int)):(128 * 1024, 1)
+// dst: (32767, (128 * 1024) / sizeof(int)):(128 * 1024, 1)
+// Copies 4GB while allocating 16GB per tensor because each row is padded to 128K elements.
+void block_contiguous(nvbench::state& state)
 {
   cuda::std::array<int, 2> shape{32767, (128 * 1024) / sizeof(int)};
   cuda::std::array<int, 2> strides{128 * 1024, 1};
   bench_copy(state, 0, shape, strides);
 }
-NVBENCH_BENCH(block_countiguous).set_name("block-countiguous (2D, int, 2GB)");
+NVBENCH_BENCH(block_contiguous).set_name("block-contiguous (2D, int, 4GB copy, 16GB alloc)");
 // (non-vectorizable)
 
 void several_dimensions(nvbench::state& state)

--- a/cudax/benchmarks/bench/copy/copy_bench.cu
+++ b/cudax/benchmarks/bench/copy/copy_bench.cu
@@ -16,15 +16,14 @@
 // GCC -Warray-bounds false positive for high-rank (20+) __raw_tensor instantiations
 _CCCL_DIAG_SUPPRESS_GCC("-Warray-bounds")
 
-using data_t = int;
-
-template <size_t Rank>
-int compute_alloc(int offset, const cuda::std::array<int, Rank>& shape, const cuda::std::array<int, Rank>& strides)
+template <size_t Rank, typename idx_t>
+size_t
+compute_alloc(size_t offset, const cuda::std::array<idx_t, Rank>& shape, const cuda::std::array<idx_t, Rank>& strides)
 {
-  int max_pos = offset;
+  int64_t max_pos = offset;
   for (size_t i = 0; i < Rank; ++i)
   {
-    int delta = (shape[i] - 1) * strides[i];
+    auto delta = static_cast<ptrdiff_t>(shape[i] - 1) * strides[i];
     if (delta > 0)
     {
       max_pos += delta;
@@ -33,21 +32,21 @@ int compute_alloc(int offset, const cuda::std::array<int, Rank>& shape, const cu
   return max_pos + 1;
 }
 
-template <size_t Rank>
+template <typename data_t = int, typename idx_t = int, size_t Rank>
 void bench_copy(nvbench::state& state,
-                int src_offset,
-                const cuda::std::array<int, Rank>& shape,
-                const cuda::std::array<int, Rank>& src_strides,
-                int dst_offset,
-                const cuda::std::array<int, Rank>& dst_strides)
+                size_t src_offset,
+                const cuda::std::array<idx_t, Rank>& shape,
+                const cuda::std::array<idx_t, Rank>& src_strides,
+                size_t dst_offset,
+                const cuda::std::array<idx_t, Rank>& dst_strides)
 {
-  const int src_alloc = compute_alloc(src_offset, shape, src_strides);
-  const int dst_alloc = compute_alloc(dst_offset, shape, dst_strides);
+  const auto src_alloc = compute_alloc(src_offset, shape, src_strides);
+  const auto dst_alloc = compute_alloc(dst_offset, shape, dst_strides);
 
   thrust::device_vector<data_t> d_src(src_alloc);
   thrust::device_vector<data_t> d_dst(dst_alloc);
 
-  int num_items = 1;
+  size_t num_items = 1;
   for (size_t i = 0; i < Rank; ++i)
   {
     num_items *= shape[i];
@@ -56,8 +55,8 @@ void bench_copy(nvbench::state& state,
   state.add_global_memory_reads<data_t>(num_items);
   state.add_global_memory_writes<data_t>(num_items);
 
-  using extents_t = cuda::std::dextents<int, Rank>;
-  using strides_t = cuda::dstrides<int, Rank>;
+  using extents_t = cuda::std::dextents<idx_t, Rank>;
+  using strides_t = cuda::dstrides<idx_t, Rank>;
   using mapping_t = cuda::layout_stride_relaxed::mapping<extents_t>;
 
   extents_t ext(shape);
@@ -75,179 +74,125 @@ void bench_copy(nvbench::state& state,
   });
 }
 
-template <size_t Rank>
+template <typename data_t = int, typename idx_t = int, size_t Rank>
 void bench_copy(nvbench::state& state,
-                int offset,
-                const cuda::std::array<int, Rank>& shape,
-                const cuda::std::array<int, Rank>& strides)
+                size_t offset,
+                const cuda::std::array<idx_t, Rank>& shape,
+                const cuda::std::array<idx_t, Rank>& strides)
 {
-  bench_copy(state, offset, shape, strides, offset, strides);
+  bench_copy<data_t>(state, offset, shape, strides, offset, strides);
 }
 
 /***********************************************************************************************************************
  * Memcpy benchmarks
  **********************************************************************************************************************/
 
-// src: (70,90,80,80):(576000,6400,80,1)
-// dst: (70,90,80,80):(576000,6400,80,1)
+// src: (25, 70, 90, 80, 80):(40320000, 576000, 6400, 80, 1)
+// dst: (25, 70, 90, 80, 80):(40320000, 576000, 6400, 80, 1)
 void memcpy_layout_0(nvbench::state& state)
 {
-  bench_copy(state, 0, cuda::std::array<int, 4>{70, 90, 80, 80}, cuda::std::array<int, 4>{576000, 6400, 80, 1});
+  cuda::std::array<int, 5> shape{25, 70, 90, 80, 80};
+  cuda::std::array<int, 5> strides{40320000, 576000, 6400, 80, 1};
+  bench_copy(state, 0, shape, strides);
 }
-NVBENCH_BENCH(memcpy_layout_0).set_name("memcpy_layout_0");
+NVBENCH_BENCH(memcpy_layout_0).set_name("contiguous (5D, int, 4GB)");
 
-// src: (70,90,80,80):(90,1,6300,504000)
-// dst: (70,90,80,80):(90,1,6300,504000)
+// src: (25, 80, 70, 80, 90):(40320000, 1, 576000, 80, 6400)
+// dst: (25, 80, 70, 80, 90):(40320000, 1, 576000, 80, 6400)
 void memcpy_layout_1(nvbench::state& state)
 {
-  bench_copy(state, 0, cuda::std::array<int, 4>{70, 90, 80, 80}, cuda::std::array<int, 4>{90, 1, 6300, 504000});
+  cuda::std::array<int, 5> shape{25, 80, 70, 80, 90};
+  cuda::std::array<int, 5> strides{40320000, 1, 576000, 80, 6400};
+  bench_copy(state, 0, shape, strides);
 }
-NVBENCH_BENCH(memcpy_layout_1).set_name("memcpy_layout_1");
+NVBENCH_BENCH(memcpy_layout_1).set_name("contiguous-perm (5D, int, 4GB)");
 
-// src: (1001,1007,3,31):(31217,1,31248217,1007), offset=0
-// dst: (1001,1007,3,31):(31217,1,31248217,1007), offset=31248217
+// src: (1, 25, 1, 80, 1, 70, 1, 80, 1, 90):(1, 40320000, 1, 1, 1, 576000, 1, 80, 1, 6400)
+// dst: (1, 25, 1, 80, 1, 70, 1, 80, 1, 90):(1, 40320000, 1, 1, 1, 576000, 1, 80, 1, 6400)
+void memcpy_layout_1b(nvbench::state& state)
+{
+  cuda::std::array<int, 10> shape{1, 25, 1, 80, 1, 70, 1, 80, 1, 90};
+  cuda::std::array<int, 10> strides{1, 40320000, 1, 1, 1, 576000, 1, 80, 1, 6400};
+  bench_copy(state, 0, shape, strides);
+}
+NVBENCH_BENCH(memcpy_layout_1b).set_name("contiguous-1-sized (10D, int, 4GB)");
+
+// src: (25, 70, 90, 80, 80):(40320000, 576000, 6400, 80, 1)
+// dst: (25, 70, 90, 80, 80):(40320000, 576000, 6400, 80, 1)
 void memcpy_layout_2(nvbench::state& state)
 {
-  cuda::std::array<int, 4> shape{1001, 1007, 3, 31};
-  cuda::std::array<int, 4> strides{31217, 1, 31248217, 1007};
-  bench_copy(state, 0, shape, strides, 31248217, strides);
+  cuda::std::array<int, 5> shape{25, 70, 90, 80, 80};
+  cuda::std::array<int, 5> strides{40320000, 576000, 6400, 80, 1};
+  bench_copy(state, 1, shape, strides);
 }
-NVBENCH_BENCH(memcpy_layout_2).set_name("memcpy_layout_2");
+NVBENCH_BENCH(memcpy_layout_2).set_name("contiguous-not-aligned (5D, int, 4GB)");
 
-// src: (57,71,1,1007,1):(71497,1,12225987,71,4075329), offset=12225987+4075329
-// dst: (57,71,1,1007,1):(71497,1,4075329,71,20376645), offset=3*4075329
+// src: (100, 70, 90, 80, 80):(40320000, 576000, 6400, 80, 1)
+// dst: (100, 70, 90, 80, 80):(40320000, 576000, 6400, 80, 1)
 void memcpy_layout_3(nvbench::state& state)
 {
-  cuda::std::array<int, 5> shape{57, 71, 1, 1007, 1};
-  cuda::std::array<int, 5> src_strides{71497, 1, 12225987, 71, 4075329};
-  cuda::std::array<int, 5> dst_strides{71497, 1, 4075329, 71, 20376645};
-  bench_copy(state, 12225987 + 4075329, shape, src_strides, 3 * 4075329, dst_strides);
+  cuda::std::array<long long, 5> shape{100, 70, 90, 80, 80};
+  cuda::std::array<long long, 5> strides{40320000, 576000, 6400, 80, 1};
+  bench_copy<char, long long>(state, 0, shape, strides);
 }
-NVBENCH_BENCH(memcpy_layout_3).set_name("memcpy_layout_3");
+NVBENCH_BENCH(memcpy_layout_3).set_name("contiguous-small (5D, char, 4GB)");
 
-// src: (63,70,1001):(1001,63063,-1), offset=1000
-// dst: (63,70,1001):(1001,63063,-1), offset=1000
+// src: (100, 70, 90, 80, 80):(40320000, 576000, 6400, 80, 1)
+// dst: (100, 70, 90, 80, 80):(40320000, 576000, 6400, 80, 1)
+void memcpy_layout_4(nvbench::state& state)
+{
+  cuda::std::array<long long, 5> shape{100, 70, 90, 80, 80};
+  cuda::std::array<long long, 5> strides{40320000, 576000, 6400, 80, 1};
+  bench_copy<char, long long>(state, 1, shape, strides);
+}
+NVBENCH_BENCH(memcpy_layout_4).set_name("contiguous-small-not-aligned (5D, char, 4GB)");
+
+// src: (25, 70, 90, 80, 80):(40320000, 576000, 6400, 80, -1), offset=80
+// dst: (25, 70, 90, 80, 80):(40320000, 576000, 6400, 80, -1), offset=80
 void memcpy_neg(nvbench::state& state)
 {
-  bench_copy(state, 1000, cuda::std::array<int, 3>{63, 70, 1001}, cuda::std::array<int, 3>{1001, 63063, -1});
+  cuda::std::array<int, 5> shape{25, 70, 90, 80, 80};
+  cuda::std::array<int, 5> strides{40320000, 576000, 6400, 80, -1};
+  bench_copy(state, 80, shape, strides);
 }
-NVBENCH_BENCH(memcpy_neg).set_name("memcpy_neg");
+NVBENCH_BENCH(memcpy_neg).set_name("contiguous-negative-stride (5D, int, 4GB)");
 
-/***********************************************************************************************************************
- * Reorder strides benchmark
- **********************************************************************************************************************/
-
-// src: (8,100019,4):(1100209,11,3)
-// dst: (8,100019,4):(1,8,800152)
-void reorder_strides(nvbench::state& state)
+// src: (134217600, 32):(64, 1)
+// dst: (134217600, 32):(64, 1)
+void vectorization(nvbench::state& state)
 {
-  cuda::std::array<int, 3> shape{8, 100019, 4};
-  bench_copy(state, 0, shape, cuda::std::array<int, 3>{1100209, 11, 3}, 0, cuda::std::array<int, 3>{1, 8, 800152});
+  cuda::std::array<long long, 2> shape{134217600, 32};
+  cuda::std::array<long long, 2> strides{128, 1};
+  bench_copy<char, long long>(state, 32, shape, strides);
 }
-NVBENCH_BENCH(reorder_strides).set_name("reorder_strides");
+NVBENCH_BENCH(vectorization).set_name("vectorization (2D, char, 4GB)");
 
-/***********************************************************************************************************************
- * Negative strides benchmarks
- **********************************************************************************************************************/
-
-// src: (70,90,80,80):(-576000,-6400,-80,-1), offset=alloc-1
-// dst: (70,90,80,80):(-576000,-6400,-80,-1), offset=alloc-1
-void negative_strides_0(nvbench::state& state)
+// src: (32 767, (128 * 1024) / sizeof(int)):(128 * 1024, 1)
+// dst: (32 767, (128 * 1024) / sizeof(int)):(128 * 1024, 1)
+void block_countiguous(nvbench::state& state)
 {
-  constexpr int offset = 70 * 90 * 80 * 80 - 1;
-  bench_copy(state, offset, cuda::std::array<int, 4>{70, 90, 80, 80}, cuda::std::array<int, 4>{-576000, -6400, -80, -1});
+  cuda::std::array<int, 2> shape{32767, (128 * 1024) / sizeof(int)};
+  cuda::std::array<int, 2> strides{128 * 1024, 1};
+  bench_copy(state, 0, shape, strides);
 }
-NVBENCH_BENCH(negative_strides_0).set_name("Negative Strides (optimized)");
+NVBENCH_BENCH(block_countiguous).set_name("block-countiguous (2D, int, 2GB)");
+// (non-vectorizable)
 
-// src: (63,70,1001):(-1001,-63063,-1), offset=alloc-1
-// dst: (63,70,1001):(70070,1001,1), offset=0
-void src_neg_stride(nvbench::state& state)
+void several_dimensions(nvbench::state& state)
 {
-  constexpr int src_offset = 63 * 70 * 1001 - 1;
-  cuda::std::array<int, 3> shape{63, 70, 1001};
-  bench_copy(
-    state, src_offset, shape, cuda::std::array<int, 3>{-1001, -63063, -1}, 0, cuda::std::array<int, 3>{70070, 1001, 1});
+  cuda::std::array<int, 5> shape{64, 64, 64, 64, 64};
+  cuda::std::array<int, 5> strides{17043520 + 1, 266304 + 1, 4160 + 1, 64 + 1, 1};
+  bench_copy(state, 0, shape, strides);
 }
-NVBENCH_BENCH(src_neg_stride).set_name("src_neg_stride");
+NVBENCH_BENCH(several_dimensions).set_name("several_dimensions (5D, int, 4GB)");
 
-/***********************************************************************************************************************
- * Squeezing and flattening benchmarks
- **********************************************************************************************************************/
-
-// src: (2,)^23, bit-permuted strides
-// dst: (2,)^23, different bit-permuted strides (dims 20-22 differ)
-void flatten_common(nvbench::state& state)
+void several_dimensions_non_square(nvbench::state& state)
 {
-  cuda::std::array<int, 23> shape{};
-  for (auto& s : shape)
-  {
-    s = 2;
-  }
-  // clang-format off
-  cuda::std::array<int, 23> src_strides{
-    1 << 15, 1 << 16, 1 << 17, 1 << 18, 1 << 19, 1 << 20, 1 << 21, 1 << 22,
-    1 << 14, 1 << 13, 1 << 12, 1 << 11, 1 << 10, 1 <<  9, 1 <<  8, 1 <<  7,
-    1 <<  6, 1 <<  5, 1 <<  4, 1 <<  3, 1 <<  2, 1 <<  0, 1 <<  1};
-  cuda::std::array<int, 23> dst_strides{
-    1 << 15, 1 << 16, 1 << 17, 1 << 18, 1 << 19, 1 << 20, 1 << 21, 1 << 22,
-    1 << 14, 1 << 13, 1 << 12, 1 << 11, 1 << 10, 1 <<  9, 1 <<  8, 1 <<  7,
-    1 <<  6, 1 <<  5, 1 <<  4, 1 <<  3, 1 <<  1, 1 <<  2, 1 <<  0};
-  // clang-format on
-  bench_copy(state, 0, shape, src_strides, 0, dst_strides);
+  cuda::std::array<int, 5> shape{63, 65, 67, 69, 57};
+  cuda::std::array<int, 5> strides{17433131, 268202, 4003, 58, 1};
+  bench_copy(state, 0, shape, strides);
 }
-NVBENCH_BENCH(flatten_common).set_name("flatten_common");
-
-// src: (4,2,...,2):(5,2^4,...,2^22), alloc=2^23
-// dst: (4,2,...,2):(2^19,2^18,...,2^0), alloc=2^21
-void flatten_one(nvbench::state& state)
-{
-  // clang-format off
-  cuda::std::array<int, 20> shape{4, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
-  cuda::std::array<int, 20> src_strides{
-    5,       1 << 4,  1 << 5,  1 << 6,  1 << 7,  1 << 8,  1 << 9,  1 << 10,
-    1 << 11, 1 << 12, 1 << 13, 1 << 14, 1 << 15, 1 << 16, 1 << 17, 1 << 18,
-    1 << 19, 1 << 20, 1 << 21, 1 << 22};
-  cuda::std::array<int, 20> dst_strides{
-    1 << 19, 1 << 18, 1 << 17, 1 << 16, 1 << 15, 1 << 14, 1 << 13, 1 << 12,
-    1 << 11, 1 << 10, 1 <<  9, 1 <<  8, 1 <<  7, 1 <<  6, 1 <<  5, 1 <<  4,
-    1 <<  3, 1 <<  2, 1 <<  1, 1 <<  0};
-  // clang-format on
-  bench_copy(state, 0, shape, src_strides, 0, dst_strides);
-}
-NVBENCH_BENCH(flatten_one).set_name("flatten_one");
-
-/***********************************************************************************************************************
- * Vectorize benchmarks
- **********************************************************************************************************************/
-
-// src: (35,255,10,24):(61440,240,24,1), offset=240
-// dst: (35,255,10,24):(61200,240,24,1), offset=0
-void sliced_vec(nvbench::state& state)
-{
-  cuda::std::array<int, 4> shape{35, 255, 10, 24};
-  bench_copy(
-    state, 240, shape, cuda::std::array<int, 4>{61440, 240, 24, 1}, 0, cuda::std::array<int, 4>{61200, 240, 24, 1});
-}
-NVBENCH_BENCH(sliced_vec).set_name("sliced_vec");
-
-// src: (355,255,4,3):(3072,12,3,1), offset=12
-// dst: (355,255,4,3):(3060,12,3,1), offset=0
-void sliced_vec_2(nvbench::state& state)
-{
-  cuda::std::array<int, 4> shape{355, 255, 4, 3};
-  bench_copy(state, 12, shape, cuda::std::array<int, 4>{3072, 12, 3, 1}, 0, cuda::std::array<int, 4>{3060, 12, 3, 1});
-}
-NVBENCH_BENCH(sliced_vec_2).set_name("sliced_vec_2");
-
-// src: (35,255,5,10):(153000,600,20,1), offset=205
-// dst: (35,255,5,10):(12750,50,10,1), offset=0
-void sliced_unaligned_ptr(nvbench::state& state)
-{
-  cuda::std::array<int, 4> shape{35, 255, 5, 10};
-  bench_copy(
-    state, 205, shape, cuda::std::array<int, 4>{153000, 600, 20, 1}, 0, cuda::std::array<int, 4>{12750, 50, 10, 1});
-}
-NVBENCH_BENCH(sliced_unaligned_ptr).set_name("sliced_unaligned_ptr");
+NVBENCH_BENCH(several_dimensions_non_square).set_name("several_dimensions_non_square (5D, int, 4GB)");
 
 /***********************************************************************************************************************
  * Transpose benchmark
@@ -255,9 +200,128 @@ NVBENCH_BENCH(sliced_unaligned_ptr).set_name("sliced_unaligned_ptr");
 
 // src: (8192,8192):(8192,1)
 // dst: (8192,8192):(1,8192)
-void transpose(nvbench::state& state)
+void transpose_2D_col_row(nvbench::state& state)
 {
-  cuda::std::array<int, 2> shape{8192, 8192};
-  bench_copy(state, 0, shape, cuda::std::array<int, 2>{8192, 1}, 0, cuda::std::array<int, 2>{1, 8192});
+  cuda::std::array<int, 2> shape{32768, 32768};
+  cuda::std::array<int, 2> src_strides{1, 32768};
+  cuda::std::array<int, 2> dst_strides{32768, 1};
+  bench_copy(state, 0, shape, src_strides, 0, dst_strides);
 }
-NVBENCH_BENCH(transpose).set_name("transpose");
+NVBENCH_BENCH(transpose_2D_col_row).set_name("transpose_2D_col_row (2D, int, 4GB)");
+
+void transpose_2D_row_col(nvbench::state& state)
+{
+  cuda::std::array<int, 2> shape{32768, 32768};
+  cuda::std::array<int, 2> src_strides{32768, 1};
+  cuda::std::array<int, 2> dst_strides{1, 32768};
+  bench_copy(state, 0, shape, src_strides, 0, dst_strides);
+}
+NVBENCH_BENCH(transpose_2D_row_col).set_name("transpose_2D_row_col (2D, int, 4GB)");
+
+void transpose_2D_char(nvbench::state& state)
+{
+  cuda::std::array<long long, 2> shape{65536, 65536};
+  cuda::std::array<long long, 2> src_strides{1, 65536};
+  cuda::std::array<long long, 2> dst_strides{65536, 1};
+  bench_copy<char, long long>(state, 0, shape, src_strides, 0, dst_strides);
+}
+NVBENCH_BENCH(transpose_2D_char).set_name("transpose_2D_char (2D, char, 4GB)");
+
+void transpose_2D_short(nvbench::state& state)
+{
+  cuda::std::array<int, 2> shape{32760, 32768 * 2};
+  cuda::std::array<int, 2> src_strides{1, 32760};
+  cuda::std::array<int, 2> dst_strides{32768 * 2, 1};
+  bench_copy<short>(state, 0, shape, src_strides, 0, dst_strides);
+}
+NVBENCH_BENCH(transpose_2D_short).set_name("transpose_2D_short (2D, short, 4GB)");
+
+void transpose_2D_double(nvbench::state& state)
+{
+  cuda::std::array<long long, 2> shape{32768, 16384};
+  cuda::std::array<long long, 2> src_strides{1, 32768};
+  cuda::std::array<long long, 2> dst_strides{16384, 1};
+  bench_copy<double, long long>(state, 0, shape, src_strides, 0, dst_strides);
+}
+NVBENCH_BENCH(transpose_2D_double).set_name("transpose_2D_double (2D, double, 4GB)");
+
+void transpose_2D_odd_both(nvbench::state& state)
+{
+  cuda::std::array<int, 2> shape{32767, 32769};
+  cuda::std::array<int, 2> src_strides{1, 32767};
+  cuda::std::array<int, 2> dst_strides{32769, 1};
+  bench_copy(state, 0, shape, src_strides, 0, dst_strides);
+}
+NVBENCH_BENCH(transpose_2D_odd_both).set_name("transpose_2D_odd_both (2D, int, 4GB)");
+
+void transpose_3D(nvbench::state& state)
+{
+  cuda::std::array<int, 3> shape{1024, 1024, 1024};
+  cuda::std::array<int, 3> src_strides{1, 1024, 1024 * 1024};
+  cuda::std::array<int, 3> dst_strides{1024 * 1024, 1024, 1};
+  bench_copy(state, 0, shape, src_strides, 0, dst_strides);
+}
+NVBENCH_BENCH(transpose_3D).set_name("transpose_3D (3D, int, 4GB)");
+
+void transpose_3D_odd_edges(nvbench::state& state)
+{
+  cuda::std::array<int, 3> shape{1023, 1025, 1024};
+  cuda::std::array<int, 3> src_strides{1, 1023, 1023 * 1025};
+  cuda::std::array<int, 3> dst_strides{1025 * 1024, 1024, 1};
+  bench_copy(state, 0, shape, src_strides, 0, dst_strides);
+}
+NVBENCH_BENCH(transpose_3D_odd_edges).set_name("transpose_3D_odd_edges (3D, int, 4GB)");
+
+void transpose_src_small_15(nvbench::state& state)
+{
+  cuda::std::array<int, 3> shape{15, 2236962, 32};
+  cuda::std::array<int, 3> src_strides{1, 15 * 32, 15};
+  cuda::std::array<int, 3> dst_strides{2236962 * 32, 32, 1};
+  bench_copy(state, 0, shape, src_strides, 0, dst_strides);
+}
+NVBENCH_BENCH(transpose_src_small_15).set_name("transpose_src_small_15 (3D, int, 4GB)");
+
+void transpose_src_small_16(nvbench::state& state)
+{
+  cuda::std::array<int, 3> shape{16, 2097152, 32};
+  cuda::std::array<int, 3> src_strides{1, 16 * 32, 16};
+  cuda::std::array<int, 3> dst_strides{2097152 * 32, 32, 1};
+  bench_copy(state, 0, shape, src_strides, 0, dst_strides);
+}
+NVBENCH_BENCH(transpose_src_small_16).set_name("transpose_src_small_16 (3D, int, 4GB)");
+
+void transpose_src_small_17(nvbench::state& state)
+{
+  cuda::std::array<int, 3> shape{17, 1973790, 32};
+  cuda::std::array<int, 3> src_strides{1, 17 * 32, 17};
+  cuda::std::array<int, 3> dst_strides{1973790 * 32, 32, 1};
+  bench_copy(state, 0, shape, src_strides, 0, dst_strides);
+}
+NVBENCH_BENCH(transpose_src_small_17).set_name("transpose_src_small_17 (3D, int, 4GB)");
+
+void transpose_dst_small_8_padded(nvbench::state& state)
+{
+  cuda::std::array<long long, 3> shape{32, 4194304, 8};
+  cuda::std::array<long long, 3> src_strides{1, 32 * 8, 32};
+  cuda::std::array<long long, 3> dst_strides{4194304 * 16, 16, 1};
+  bench_copy<int, long long>(state, 0, shape, src_strides, 0, dst_strides);
+}
+NVBENCH_BENCH(transpose_dst_small_8_padded).set_name("transpose_dst_small_8_padded (3D, int, 4GB)");
+
+void transpose_dst_small_16_padded(nvbench::state& state)
+{
+  cuda::std::array<long long, 3> shape{32, 2097152, 16};
+  cuda::std::array<long long, 3> src_strides{1, 32 * 16, 32};
+  cuda::std::array<long long, 3> dst_strides{2097152 * 32, 32, 1};
+  bench_copy<int, long long>(state, 0, shape, src_strides, 0, dst_strides);
+}
+NVBENCH_BENCH(transpose_dst_small_16_padded).set_name("transpose_dst_small_16_padded (3D, int, 4GB)");
+
+void transpose_src_small_16_4D(nvbench::state& state)
+{
+  cuda::std::array<int, 4> shape{16, 1024, 2048, 32};
+  cuda::std::array<int, 4> src_strides{1, 16 * 32, 16 * 32 * 1024, 16};
+  cuda::std::array<int, 4> dst_strides{1024 * 2048 * 32, 32, 1024 * 32, 1};
+  bench_copy(state, 0, shape, src_strides, 0, dst_strides);
+}
+NVBENCH_BENCH(transpose_src_small_16_4D).set_name("transpose_src_small_16_4D (4D, int, 4GB)");

--- a/cudax/benchmarks/bench/copy/copy_bench.cu
+++ b/cudax/benchmarks/bench/copy/copy_bench.cu
@@ -202,8 +202,8 @@ NVBENCH_BENCH(several_dimensions_non_square).set_name("several_dimensions_non_sq
  * Transpose benchmark
  **********************************************************************************************************************/
 
-// src: (32768,32768):(32768,1)
-// dst: (32768,32768):(1,32768)
+// src: (32768,32768):(1,32768)
+// dst: (32768,32768):(32768,1)
 void transpose_2D_col_row(nvbench::state& state)
 {
   cuda::std::array<int, 2> shape{32768, 32768};

--- a/cudax/benchmarks/bench/copy/copy_bench.cu
+++ b/cudax/benchmarks/bench/copy/copy_bench.cu
@@ -131,9 +131,9 @@ NVBENCH_BENCH(memcpy_layout_2).set_name("contiguous-not-aligned (5D, int, 4GB)")
 // dst: (100, 70, 90, 80, 80):(40320000, 576000, 6400, 80, 1)
 void memcpy_layout_3(nvbench::state& state)
 {
-  cuda::std::array<long long, 5> shape{100, 70, 90, 80, 80};
-  cuda::std::array<long long, 5> strides{40320000, 576000, 6400, 80, 1};
-  bench_copy<char, long long>(state, 0, shape, strides);
+  cuda::std::array<int64_t, 5> shape{100, 70, 90, 80, 80};
+  cuda::std::array<int64_t, 5> strides{40320000, 576000, 6400, 80, 1};
+  bench_copy<char, int64_t>(state, 0, shape, strides);
 }
 NVBENCH_BENCH(memcpy_layout_3).set_name("contiguous-small (5D, char, 4GB)");
 
@@ -141,9 +141,9 @@ NVBENCH_BENCH(memcpy_layout_3).set_name("contiguous-small (5D, char, 4GB)");
 // dst: (100, 70, 90, 80, 80):(40320000, 576000, 6400, 80, 1)
 void memcpy_layout_4(nvbench::state& state)
 {
-  cuda::std::array<long long, 5> shape{100, 70, 90, 80, 80};
-  cuda::std::array<long long, 5> strides{40320000, 576000, 6400, 80, 1};
-  bench_copy<char, long long>(state, 1, shape, strides);
+  cuda::std::array<int64_t, 5> shape{100, 70, 90, 80, 80};
+  cuda::std::array<int64_t, 5> strides{40320000, 576000, 6400, 80, 1};
+  bench_copy<char, int64_t>(state, 1, shape, strides);
 }
 NVBENCH_BENCH(memcpy_layout_4).set_name("contiguous-small-not-aligned (5D, char, 4GB)");
 
@@ -161,9 +161,9 @@ NVBENCH_BENCH(memcpy_neg).set_name("contiguous-negative-stride (5D, int, 4GB)");
 // dst: (134217600, 32):(64, 1)
 void vectorization(nvbench::state& state)
 {
-  cuda::std::array<long long, 2> shape{134217600, 32};
-  cuda::std::array<long long, 2> strides{128, 1};
-  bench_copy<char, long long>(state, 32, shape, strides);
+  cuda::std::array<int64_t, 2> shape{134217600, 32};
+  cuda::std::array<int64_t, 2> strides{128, 1};
+  bench_copy<char, int64_t>(state, 32, shape, strides);
 }
 NVBENCH_BENCH(vectorization).set_name("vectorization (2D, char, 4GB)");
 
@@ -220,10 +220,10 @@ NVBENCH_BENCH(transpose_2D_row_col).set_name("transpose_2D_row_col (2D, int, 4GB
 
 void transpose_2D_char(nvbench::state& state)
 {
-  cuda::std::array<long long, 2> shape{65536, 65536};
-  cuda::std::array<long long, 2> src_strides{1, 65536};
-  cuda::std::array<long long, 2> dst_strides{65536, 1};
-  bench_copy<char, long long>(state, 0, shape, src_strides, 0, dst_strides);
+  cuda::std::array<int64_t, 2> shape{65536, 65536};
+  cuda::std::array<int64_t, 2> src_strides{1, 65536};
+  cuda::std::array<int64_t, 2> dst_strides{65536, 1};
+  bench_copy<char, int64_t>(state, 0, shape, src_strides, 0, dst_strides);
 }
 NVBENCH_BENCH(transpose_2D_char).set_name("transpose_2D_char (2D, char, 4GB)");
 
@@ -238,10 +238,10 @@ NVBENCH_BENCH(transpose_2D_short).set_name("transpose_2D_short (2D, short, 4GB)"
 
 void transpose_2D_double(nvbench::state& state)
 {
-  cuda::std::array<long long, 2> shape{32768, 16384};
-  cuda::std::array<long long, 2> src_strides{1, 32768};
-  cuda::std::array<long long, 2> dst_strides{16384, 1};
-  bench_copy<double, long long>(state, 0, shape, src_strides, 0, dst_strides);
+  cuda::std::array<int64_t, 2> shape{32768, 16384};
+  cuda::std::array<int64_t, 2> src_strides{1, 32768};
+  cuda::std::array<int64_t, 2> dst_strides{16384, 1};
+  bench_copy<double, int64_t>(state, 0, shape, src_strides, 0, dst_strides);
 }
 NVBENCH_BENCH(transpose_2D_double).set_name("transpose_2D_double (2D, double, 4GB)");
 
@@ -301,19 +301,19 @@ NVBENCH_BENCH(transpose_src_small_17).set_name("transpose_src_small_17 (3D, int,
 
 void transpose_dst_small_8_padded(nvbench::state& state)
 {
-  cuda::std::array<long long, 3> shape{32, 4194304, 8};
-  cuda::std::array<long long, 3> src_strides{1, 32 * 8, 32};
-  cuda::std::array<long long, 3> dst_strides{4194304 * 16, 16, 1};
-  bench_copy<int, long long>(state, 0, shape, src_strides, 0, dst_strides);
+  cuda::std::array<int64_t, 3> shape{32, 4194304, 8};
+  cuda::std::array<int64_t, 3> src_strides{1, 32 * 8, 32};
+  cuda::std::array<int64_t, 3> dst_strides{4194304 * 16, 16, 1};
+  bench_copy<int, int64_t>(state, 0, shape, src_strides, 0, dst_strides);
 }
 NVBENCH_BENCH(transpose_dst_small_8_padded).set_name("transpose_dst_small_8_padded (3D, int, 4GB)");
 
 void transpose_dst_small_16_padded(nvbench::state& state)
 {
-  cuda::std::array<long long, 3> shape{32, 2097152, 16};
-  cuda::std::array<long long, 3> src_strides{1, 32 * 16, 32};
-  cuda::std::array<long long, 3> dst_strides{2097152 * 32, 32, 1};
-  bench_copy<int, long long>(state, 0, shape, src_strides, 0, dst_strides);
+  cuda::std::array<int64_t, 3> shape{32, 2097152, 16};
+  cuda::std::array<int64_t, 3> src_strides{1, 32 * 16, 32};
+  cuda::std::array<int64_t, 3> dst_strides{2097152 * 32, 32, 1};
+  bench_copy<int, int64_t>(state, 0, shape, src_strides, 0, dst_strides);
 }
 NVBENCH_BENCH(transpose_dst_small_16_padded).set_name("transpose_dst_small_16_padded (3D, int, 4GB)");
 

--- a/cudax/benchmarks/bench/copy/copy_bench.cu
+++ b/cudax/benchmarks/bench/copy/copy_bench.cu
@@ -202,8 +202,8 @@ NVBENCH_BENCH(several_dimensions_non_square).set_name("several_dimensions_non_sq
  * Transpose benchmark
  **********************************************************************************************************************/
 
-// src: (8192,8192):(8192,1)
-// dst: (8192,8192):(1,8192)
+// src: (32768,32768):(32768,1)
+// dst: (32768,32768):(1,32768)
 void transpose_2D_col_row(nvbench::state& state)
 {
   cuda::std::array<int, 2> shape{32768, 32768};

--- a/cudax/include/cuda/experimental/__copy/copy_optimized.cuh
+++ b/cudax/include/cuda/experimental/__copy/copy_optimized.cuh
@@ -80,6 +80,10 @@ __global__ void __copy_optimized_kernel(
   {
     const auto __coord = __coord_iter(__i);
     __dst(__coord)     = __src(__coord);
+    if constexpr (sizeof(_ExtentT) <= 4)
+    {
+      return;
+    }
   }
 }
 

--- a/cudax/include/cuda/experimental/__copy/copy_shared_memory.cuh
+++ b/cudax/include/cuda/experimental/__copy/copy_shared_memory.cuh
@@ -71,10 +71,12 @@ template <bool _UseXorSwizzle>
     static_assert(__max_tile_size == 32, "XOR shared-memory swizzle assumes 32 banks and 32-element tile modes");
     constexpr __tile_extent_t __swizzle_tile_size = __max_tile_size * __max_tile_size;
     const auto __outer                            = __offset / __swizzle_tile_size;
-    const auto __inner                            = __offset - (__outer * __swizzle_tile_size);
+    const auto __offset_tile_rounded              = __outer * __swizzle_tile_size;
+    const auto __inner                            = __offset - __offset_tile_rounded;
     const auto __row                              = __inner / __max_tile_size;
-    const auto __col                              = __inner - (__row * __max_tile_size);
-    return __outer * __swizzle_tile_size + __row * __max_tile_size + (__col ^ __row);
+    const auto __row_tile_rounded                 = __row * __max_tile_size;
+    const auto __col                              = __inner - __row_tile_rounded;
+    return __offset_tile_rounded + __row_tile_rounded + (__col ^ __row);
   }
   return __offset;
 }

--- a/cudax/include/cuda/experimental/__copy/copy_shared_memory.cuh
+++ b/cudax/include/cuda/experimental/__copy/copy_shared_memory.cuh
@@ -25,7 +25,6 @@
 #include <cuda/__launch/configuration.h>
 #include <cuda/__launch/launch.h>
 #include <cuda/__stream/stream_ref.h>
-#include <cuda/std/__algorithm/stable_sort.h>
 #include <cuda/std/__cstddef/types.h>
 #include <cuda/std/__mdspan/default_accessor.h>
 #include <cuda/std/__type_traits/make_unsigned.h>
@@ -34,7 +33,6 @@
 
 #include <cuda/experimental/__copy/copy_shared_memory_utils.cuh>
 #include <cuda/experimental/__copy/tensor_iterator.cuh>
-#include <cuda/experimental/__copy_bytes/tensor_query.cuh>
 #include <cuda/experimental/__copy_bytes/types.cuh>
 
 #include <cuda/std/__cccl/prologue.h>
@@ -43,7 +41,7 @@
 //!
 //! The overall idea is to decompose the tensors into tiles that can fit in shared memory.
 //! Each tile is assigned to a thread block. A tile can entirely represent a dimension or split the respective extent.
-//! The algorithm creates tiles only for contiguous dimensions in the destination tensor.
+//! The algorithm creates tiles over dimensions that provide coalesced accesses in the source and destination tensors.
 //!
 //! (1) Grid decomposition
 //! The tensor is partitioned into tiles whose per-dimension sizes are capped by warp size and shared-memory capacity.
@@ -54,18 +52,38 @@
 //!   1. *Load*: threads cooperatively read source elements into shared memory.
 //!      This requires additional logic to "transpose" the source tensor into a row-major order.
 //!      The mapping is determined by using the source-tile permutation obtained by sorting by |src stride|.
-//!   2. *Store*: after a barrier, threads read shared memory in the destination-natural
-//!      (row-major) order and write to global memory, achieving coalesced destination writes.
+//!   2. *Store*: after a barrier, threads read shared memory in destination-coalesced order by using the
+//!      destination-tile permutation obtained by sorting by |dst stride|.
 //!
 //! Boundary tiles that extend past the tensor extents fall back to a direct element-wise copy without shared memory.
 
 namespace cuda::experimental
 {
+//! @brief Compute the shared-memory offset for the XOR swizzle.
+//!
+//! @param[in] __offset The offset in the shared-memory tile.
+//! @return The offset in the shared-memory tile with the XOR swizzle applied.
+template <bool _UseXorSwizzle>
+[[nodiscard]] _CCCL_DEVICE_API __tile_extent_t __smem_offset(__tile_extent_t __offset) noexcept
+{
+  if constexpr (_UseXorSwizzle)
+  {
+    static_assert(__max_tile_size == 32, "XOR shared-memory swizzle assumes 32 banks and 32-element tile modes");
+    constexpr __tile_extent_t __swizzle_tile_size = __max_tile_size * __max_tile_size;
+    const auto __outer                            = __offset / __swizzle_tile_size;
+    const auto __inner                            = __offset - (__outer * __swizzle_tile_size);
+    const auto __row                              = __inner / __max_tile_size;
+    const auto __col                              = __inner - (__row * __max_tile_size);
+    return __outer * __swizzle_tile_size + __row * __max_tile_size + (__col ^ __row);
+  }
+  return __offset;
+}
+
 //! @brief Shared-memory tiled transpose kernel for arbitrary-rank tensors.
 //!
 //! Each block processes one tile. Threads cooperatively iterate over tile elements with a stride loop. Full (interior)
 //! tiles use a two-phase shared-memory transpose: load source data into shared memory using source-coalesced ordering,
-//! then store from shared memory to destination using destination-natural ordering. Partial (boundary) tiles copy
+//! then store from shared memory to destination using destination-coalesced ordering. Partial (boundary) tiles copy
 //! elements directly without shared memory.
 //!
 //! @param[in]  __config                 Kernel launch configuration
@@ -78,14 +96,17 @@ namespace cuda::experimental
 //! @param[in]  __grid_tile_dst_strides  Per-dimension destination strides scaled by tile sizes
 //! @param[in]  __tile_perm_iter         Coordinate iterator for src-permuted tile decomposition
 //! @param[in]  __src_perm_src_strides   Src-permuted source strides for loading
-//! @param[in]  __tile_perm_smem_strides Src-permuted shared memory strides for loading
-//! @param[in]  __tile_natural_iter      Coordinate iterator for dst-natural tile decomposition
-//! @param[in]  __dst_strides            Per-dimension destination strides for storing
+//! @param[in]  __tile_src_perm_smem_strides Src-permuted shared memory strides for loading
+//! @param[in]  __tile_dst_perm_iter     Coordinate iterator for dst-permuted tile decomposition
+//! @param[in]  __dst_perm_dst_strides   Dst-permuted destination strides for storing
+//! @param[in]  __tile_dst_smem_strides  Dst-permuted shared memory strides for storing
+//! @param[in]  __dst_strides            Per-dimension destination strides for partial tiles
 //! @param[in]  __tile_total_size        Total number of elements in one tile
 //! @param[in]  __tile_sizes             Per-dimension tile extents
 //! @param[in]  __extents                Per-dimension tensor extents (for partial-tile bounds)
 //! @param[in]  __src_strides            Per-dimension source strides (for partial-tile access)
-template <typename _Config,
+template <bool _UseXorSwizzle,
+          typename _Config,
           ::cuda::std::size_t _MaxRankUZ,
           typename _TpSrc,
           typename _TpDst,
@@ -105,8 +126,10 @@ __global__ void __copy_shared_mem_kernel(
   _CCCL_GRID_CONSTANT const ::cuda::std::array<_StrideTOut, _MaxRankUZ> __grid_tile_dst_strides,
   _CCCL_GRID_CONSTANT const __tensor_coord_iterator<__tile_extent_t, _MaxRankUZ> __tile_perm_iter,
   _CCCL_GRID_CONSTANT const ::cuda::std::array<_StrideTIn, _MaxRankUZ> __src_perm_src_strides,
-  _CCCL_GRID_CONSTANT const ::cuda::std::array<__tile_extent_t, _MaxRankUZ> __tile_perm_smem_strides,
-  _CCCL_GRID_CONSTANT const __tensor_coord_iterator<__tile_extent_t, _MaxRankUZ> __tile_natural_iter,
+  _CCCL_GRID_CONSTANT const ::cuda::std::array<__tile_extent_t, _MaxRankUZ> __tile_src_perm_smem_strides,
+  _CCCL_GRID_CONSTANT const __tensor_coord_iterator<__tile_extent_t, _MaxRankUZ> __tile_dst_perm_iter,
+  _CCCL_GRID_CONSTANT const ::cuda::std::array<_StrideTOut, _MaxRankUZ> __dst_perm_dst_strides,
+  _CCCL_GRID_CONSTANT const ::cuda::std::array<__tile_extent_t, _MaxRankUZ> __tile_dst_perm_smem_strides,
   _CCCL_GRID_CONSTANT const ::cuda::std::array<_StrideTOut, _MaxRankUZ> __dst_strides,
   _CCCL_GRID_CONSTANT const int __tile_total_size,
   _CCCL_GRID_CONSTANT const ::cuda::std::array<__tile_extent_t, _MaxRankUZ> __tile_sizes,
@@ -164,22 +187,29 @@ __global__ void __copy_shared_mem_kernel(
 
     // (1) load src to shared memory by using the src/tile-permuted ordering
     const __partial_tensor_src __src_tensor{__src_ptr, __src_perm_src_strides, __src_accessor};
-    const __partial_tensor_smem __smem_tensor{__smem, __tile_perm_smem_strides, ::cuda::std::default_accessor<_Tp>{}};
+    const __partial_tensor_smem __smem_tensor{
+      __smem, __tile_src_perm_smem_strides, ::cuda::std::default_accessor<_Tp>{}};
 
     for (auto __i = __tid; __i < __tile_total_size; __i += __block_stride)
     {
-      const auto __coords     = __tile_perm_iter(__i);
-      __smem_tensor(__coords) = __src_tensor(__coords);
+      const auto __coords          = __tile_perm_iter(__i);
+      const auto __raw_offset      = __smem_tensor.__offset(__coords);
+      const auto __swizzled_offset = ::cuda::experimental::__smem_offset<_UseXorSwizzle>(__raw_offset);
+      __smem[__swizzled_offset]    = __src_tensor(__coords);
     }
     __syncthreads();
 
-    // (2) store from shared memory to destination by using the dst-natural ordering (row-major)
-    const __partial_tensor_dst __dst_tensor{__dst_ptr, __dst_strides, __dst_accessor};
+    // (2) store from shared memory to destination by using the dst/tile-permuted ordering
+    const __partial_tensor_dst __dst_tensor{__dst_ptr, __dst_perm_dst_strides, __dst_accessor};
+    const __partial_tensor_smem __smem_dst_tensor{
+      __smem, __tile_dst_perm_smem_strides, ::cuda::std::default_accessor<_Tp>{}};
 
     for (auto __i = __tid; __i < __tile_total_size; __i += __block_stride)
     {
-      const auto __coords    = __tile_natural_iter(__i);
-      __dst_tensor(__coords) = __smem[__i];
+      const auto __coords          = __tile_dst_perm_iter(__i);
+      const auto __raw_offset      = __smem_dst_tensor.__offset(__coords);
+      const auto __swizzled_offset = ::cuda::experimental::__smem_offset<_UseXorSwizzle>(__raw_offset);
+      __dst_tensor(__coords)       = __smem[__swizzled_offset];
     }
   }
 
@@ -223,12 +253,10 @@ __global__ void __copy_shared_mem_kernel(
 
 //! @brief Launch the shared-memory tiled transpose kernel.
 //!
-//! Precomputes the src-coalesced permutation and tile shapes, constructs coordinate iterators, then launches one
-//! block per tile.
+//! Precomputes the source/destination-coalesced permutations and tile shapes, constructs coordinate iterators, then
+//! launches one block per tile.
 //!
 //! @pre `__src.__rank >= 2`
-//! @pre `__dst.__strides[0] == 1`
-//! @pre `__src.__strides[0] != 1`
 //!
 //! @param[in]  __src          Source raw tensor descriptor
 //! @param[out] __dst          Destination raw tensor descriptor
@@ -253,12 +281,11 @@ _CCCL_HOST_API void __launch_copy_shared_mem_kernel(
   namespace cudax = ::cuda::experimental;
   using ::cuda::std::size_t;
   _CCCL_ASSERT(__src.__rank >= 2, "Rank must be at least 2 for shared memory transpose");
-  _CCCL_ASSERT(__src.__strides[0] != 1, "Source must not have stride-1 in mode 0");
-  _CCCL_ASSERT(__dst.__strides[0] == 1, "Destination must have stride-1 in mode 0");
 
-  size_t __tile_total_size = 0;
-  const auto __tile_sizes  = cudax::__find_shared_mem_tiling<_TpIn>(__dst, __tile_total_size);
-  const auto __rank        = __src.__rank;
+  const auto __tiling          = cudax::__find_shared_mem_tiling<_TpIn>(__src, __dst);
+  const auto __tile_sizes      = __tiling.__tile_sizes;
+  const auto __rank            = __src.__rank;
+  const auto __tile_total_size = __tiling.__tile_total_size;
 
   //--------------------------------------------------------------------------------------------------------------------
   // Find the grid size (number of blocks) and strides for block index decomposition
@@ -279,20 +306,13 @@ _CCCL_HOST_API void __launch_copy_shared_mem_kernel(
   }
 
   //--------------------------------------------------------------------------------------------------------------------
-  // source-coalesced permutation: sort modes by ascending |src_stride|
-  ::cuda::std::array<size_t, _MaxRank> __src_perm{};
-  for (size_t __i = 0; __i < _MaxRank; ++__i)
-  {
-    __src_perm[__i] = __i;
-  }
-  ::cuda::std::stable_sort(
-    __src_perm.begin(), __src_perm.begin() + __rank, __stride_compare<_StrideTIn, _MaxRank>{__src.__strides});
-
-  //--------------------------------------------------------------------------------------------------------------------
-  // Reordered arrays for loading src to shared memory based on the source-coalesced permutation
+  // Reordered arrays for loading src and storing dst based on coalesced permutations
   ::cuda::std::array<_StrideTIn, _MaxRank> __src_perm_src_strides{};
-  ::cuda::std::array<__tile_extent_t, _MaxRank> __tile_perm_sizes{};
-  ::cuda::std::array<__tile_extent_t, _MaxRank> __tile_perm_smem_strides{};
+  ::cuda::std::array<_StrideTOut, _MaxRank> __dst_perm_dst_strides{};
+  ::cuda::std::array<__tile_extent_t, _MaxRank> __tile_src_perm_sizes{};
+  ::cuda::std::array<__tile_extent_t, _MaxRank> __tile_dst_perm_sizes{};
+  ::cuda::std::array<__tile_extent_t, _MaxRank> __tile_src_perm_smem_strides{};
+  ::cuda::std::array<__tile_extent_t, _MaxRank> __tile_dst_perm_smem_strides{};
   ::cuda::std::array<__tile_extent_t, _MaxRank> __canonical_strides{};
   __canonical_strides[0] = 1;
   for (size_t __i = 1; __i < __rank; ++__i)
@@ -301,22 +321,30 @@ _CCCL_HOST_API void __launch_copy_shared_mem_kernel(
   }
   for (size_t __i = 0; __i < __rank; ++__i)
   {
-    const auto __p                = __src_perm[__i];
-    __tile_perm_sizes[__i]        = __tile_sizes[__p];
-    __src_perm_src_strides[__i]   = __src.__strides[__p];
-    __tile_perm_smem_strides[__i] = __canonical_strides[__p];
+    const auto __p                    = __tiling.__src_perm[__i];
+    __tile_src_perm_sizes[__i]        = __tile_sizes[__p];
+    __src_perm_src_strides[__i]       = __src.__strides[__p];
+    __tile_src_perm_smem_strides[__i] = __canonical_strides[__p];
+
+    const auto __q                    = __tiling.__dst_perm[__i];
+    __tile_dst_perm_sizes[__i]        = __tile_sizes[__q];
+    __dst_perm_dst_strides[__i]       = __dst.__strides[__q];
+    __tile_dst_perm_smem_strides[__i] = __canonical_strides[__q];
   }
   for (size_t __i = __rank; __i < _MaxRank; ++__i)
   {
-    __tile_perm_sizes[__i] = 1;
+    __tile_src_perm_sizes[__i] = 1;
+    __tile_dst_perm_sizes[__i] = 1;
   }
 
   //--------------------------------------------------------------------------------------------------------------------
   // Construct coordinate iterators on the host (precomputed fast modulo/division)
   // namely, given a linear index, compute the multi-dimensional coordinates
   const __tensor_coord_iterator<_ExtentT, _MaxRank> __grid_iter{__grid_tile_sizes}; // grid tile index
-  const __tensor_coord_iterator<__tile_extent_t, _MaxRank> __tile_perm_iter{__tile_perm_sizes}; // src -> shared memory
-  const __tensor_coord_iterator<__tile_extent_t, _MaxRank> __tile_natural_iter{__tile_sizes}; // shared memory -> dst
+  const __tensor_coord_iterator<__tile_extent_t, _MaxRank> __tile_perm_iter{__tile_src_perm_sizes}; // src -> shared
+                                                                                                    // memory
+  const __tensor_coord_iterator<__tile_extent_t, _MaxRank> __tile_dst_perm_iter{__tile_dst_perm_sizes}; // shared memory
+                                                                                                        // -> dst
 
   //--------------------------------------------------------------------------------------------------------------------
   // Launch the kernel
@@ -327,37 +355,81 @@ _CCCL_HOST_API void __launch_copy_shared_mem_kernel(
     ::cuda::block_dims(__thread_block_size),
     ::cuda::grid_dims(__grid_size),
     ::cuda::dynamic_shared_memory<__value_type[]>(__tile_total_size));
-  const auto __kernel = cudax::__copy_shared_mem_kernel<
-    decltype(__config),
-    _MaxRank,
-    _TpIn,
-    _TpOut,
-    _SrcAccessor,
-    _DstAccessor,
-    _ExtentT,
-    _StrideTIn,
-    _StrideTOut>;
 
-  ::cuda::launch(
-    __stream,
-    __config,
-    __kernel,
-    __src.__data,
-    __src_accessor,
-    __dst.__data,
-    __dst_accessor,
-    __grid_iter,
-    __grid_tile_src_strides,
-    __grid_tile_dst_strides,
-    __tile_perm_iter,
-    __src_perm_src_strides,
-    __tile_perm_smem_strides,
-    __tile_natural_iter,
-    __dst.__strides,
-    static_cast<int>(__tile_total_size),
-    __tile_sizes,
-    __dst.__extents,
-    __src.__strides);
+  if (__tiling.__use_xor_swizzle)
+  {
+    const auto __kernel = cudax::__copy_shared_mem_kernel<
+      true,
+      decltype(__config),
+      _MaxRank,
+      _TpIn,
+      _TpOut,
+      _SrcAccessor,
+      _DstAccessor,
+      _ExtentT,
+      _StrideTIn,
+      _StrideTOut>;
+
+    ::cuda::launch(
+      __stream,
+      __config,
+      __kernel,
+      __src.__data,
+      __src_accessor,
+      __dst.__data,
+      __dst_accessor,
+      __grid_iter,
+      __grid_tile_src_strides,
+      __grid_tile_dst_strides,
+      __tile_perm_iter,
+      __src_perm_src_strides,
+      __tile_src_perm_smem_strides,
+      __tile_dst_perm_iter,
+      __dst_perm_dst_strides,
+      __tile_dst_perm_smem_strides,
+      __dst.__strides,
+      static_cast<int>(__tile_total_size),
+      __tile_sizes,
+      __dst.__extents,
+      __src.__strides);
+  }
+  else
+  {
+    const auto __kernel = cudax::__copy_shared_mem_kernel<
+      false,
+      decltype(__config),
+      _MaxRank,
+      _TpIn,
+      _TpOut,
+      _SrcAccessor,
+      _DstAccessor,
+      _ExtentT,
+      _StrideTIn,
+      _StrideTOut>;
+
+    ::cuda::launch(
+      __stream,
+      __config,
+      __kernel,
+      __src.__data,
+      __src_accessor,
+      __dst.__data,
+      __dst_accessor,
+      __grid_iter,
+      __grid_tile_src_strides,
+      __grid_tile_dst_strides,
+      __tile_perm_iter,
+      __src_perm_src_strides,
+      __tile_src_perm_smem_strides,
+      __tile_dst_perm_iter,
+      __dst_perm_dst_strides,
+      __tile_dst_perm_smem_strides,
+      __dst.__strides,
+      static_cast<int>(__tile_total_size),
+      __tile_sizes,
+      __dst.__extents,
+      __src.__strides);
+  }
 }
 
 #endif // !_CCCL_COMPILER(NVRTC)

--- a/cudax/include/cuda/experimental/__copy/copy_shared_memory_utils.cuh
+++ b/cudax/include/cuda/experimental/__copy/copy_shared_memory_utils.cuh
@@ -33,6 +33,7 @@
 #  include <cuda/std/__cstddef/types.h>
 #  include <cuda/std/array>
 
+#  include <cuda/experimental/__copy_bytes/tensor_query.cuh>
 #  include <cuda/experimental/__copy_bytes/types.cuh>
 
 #  include <cuda/std/__cccl/prologue.h>
@@ -107,11 +108,147 @@ __num_contiguous_dimensions(const __raw_tensor<_ExtentT, _StrideT, _Tp, _MaxRank
 //! full warp of coalesced accesses.
 inline constexpr size_t __max_tile_size = 32;
 
-//! @brief Decide whether the shared-memory tiled transpose kernel is profitable.
+// The structure holds the tiling information to optimize the transpose (shared-memory) kernel.
+// - __tile_sizes: the size of each tile dimension in shared-memory
+// - __src_perm: the permutation of the source dimensions (copy to shared-memory)
+// - __dst_perm: the permutation of the destination dimensions (copy from shared-memory)
+// - __tile_total_size: the total size of the tile in shared-memory
+// - __active_tile_dims: the number of dimensions covered by the tile
+// - __active_32_dims: the number of tile dimensions with extent __max_tile_size
+// - __is_valid: true if the tiling is valid
+// - __use_xor_swizzle: true if the XOR swizzle is used
+template <::cuda::std::size_t _MaxRank>
+struct __shared_mem_tiling_result
+{
+  ::cuda::std::array<__tile_extent_t, _MaxRank> __tile_sizes{};
+  ::cuda::std::array<::cuda::std::size_t, _MaxRank> __src_perm{};
+  ::cuda::std::array<::cuda::std::size_t, _MaxRank> __dst_perm{};
+  ::cuda::std::size_t __tile_total_size  = 1;
+  ::cuda::std::size_t __active_tile_dims = 0;
+  ::cuda::std::size_t __active_32_dims   = 0;
+  bool __is_valid                        = false;
+  bool __use_xor_swizzle                 = false;
+};
+
+//! @brief Adds a contiguous stride-1 run from one tensor to the shared-memory tile.
 //!
-//! Returns true when the destination has stride-1 in mode 0, the source does not, there are at least two contiguous
-//! destination dimensions, the resulting tile is large enough to amortize the shared-memory overhead, and the total
-//! number of tiles is sufficient to utilize the GPU (at least one full wave across all SMs).
+//! @param[in]     __tensor                 Raw tensor descriptor used to find coalesced modes
+//! @param[in]     __perm                   Mode order to scan
+//! @param[in,out] __result                 Shared-memory tiling result updated with selected tile sizes
+//! @param[in]     __max_shared_mem_bytes   Maximum shared-memory capacity for one tile
+//! @return Number of coalesced elements covered by this tensor's selected tile run
+template <typename _ExtentT, typename _StrideT, typename _Tp, ::cuda::std::size_t _MaxRank>
+[[nodiscard]] _CCCL_HOST_API ::cuda::std::size_t __add_coalesced_tile_run(
+  const __raw_tensor<_ExtentT, _StrideT, _Tp, _MaxRank>& __tensor,
+  const ::cuda::std::array<::cuda::std::size_t, _MaxRank>& __perm,
+  __shared_mem_tiling_result<_MaxRank>& __result,
+  ::cuda::std::size_t __max_shared_mem_bytes) noexcept
+{
+  using ::cuda::std::size_t;
+  size_t __coalesced_tile_size = 1;
+  _StrideT __expected_stride   = 1;
+
+  for (size_t __i = 0; __i < __tensor.__rank; ++__i)
+  {
+    const auto __perm_i = __perm[__i];
+    const auto __extent = static_cast<size_t>(__tensor.__extents[__perm_i]);
+    const auto __stride = ::cuda::experimental::__abs_integer(__tensor.__strides[__perm_i]);
+    if (__stride != __expected_stride) // input tensor not contiguous
+    {
+      break;
+    }
+
+    if (__result.__tile_sizes[__perm_i] == 1) // first time we see this dimension
+    {
+      const auto __tile_size             = ::cuda::std::min(__extent, __max_tile_size);
+      const auto __tile_total_size_bytes = __result.__tile_total_size * __tile_size * sizeof(_Tp);
+      if (__tile_total_size_bytes > __max_shared_mem_bytes)
+      {
+        break;
+      }
+      // if the tile fits in shared-memory, update the result
+      __result.__tile_sizes[__perm_i] = static_cast<__tile_extent_t>(__tile_size);
+      __result.__tile_total_size *= __tile_size;
+      ++__result.__active_tile_dims;
+      if (__tile_size == __max_tile_size)
+      {
+        ++__result.__active_32_dims;
+      }
+    }
+    __coalesced_tile_size *= __result.__tile_sizes[__perm_i];
+    __expected_stride *= static_cast<_StrideT>(__extent);
+  }
+  return __coalesced_tile_size;
+}
+
+//! @brief Compute a source/destination-aware shared-memory tile.
+//!
+//! The selected tile spans coalesced dimensions from both layouts. This keeps the load phase ordered by source stride
+//! and the store phase ordered by destination stride, without requiring either coalesced dimension to be mode 0.
+//!
+//! @param[in] __src Source raw tensor descriptor
+//! @param[in] __dst Destination raw tensor descriptor
+//! @return Shared-memory tiling decision and layout permutations
+template <typename _TpIn,
+          typename _ExtentT,
+          typename _StrideTIn,
+          typename _TpSrc,
+          typename _StrideTOut,
+          typename _TpDst,
+          ::cuda::std::size_t _MaxRank>
+[[nodiscard]] _CCCL_HOST_API __shared_mem_tiling_result<_MaxRank>
+__find_shared_mem_tiling(const __raw_tensor<_ExtentT, _StrideTIn, _TpSrc, _MaxRank>& __src,
+                         const __raw_tensor<_ExtentT, _StrideTOut, _TpDst, _MaxRank>& __dst) noexcept
+{
+  using ::cuda::std::size_t;
+  __shared_mem_tiling_result<_MaxRank> __result{};
+  // initialize the source and destination permutations and sort them by stride
+  for (size_t __i = 0; __i < _MaxRank; ++__i)
+  {
+    __result.__tile_sizes[__i] = 1;
+    __result.__src_perm[__i]   = __i;
+    __result.__dst_perm[__i]   = __i;
+  }
+  __result.__src_perm = ::cuda::experimental::__stride_order(__src);
+  __result.__dst_perm = ::cuda::experimental::__stride_order(__dst);
+
+  const auto __current_dev            = ::cuda::experimental::__current_device();
+  const size_t __max_shared_mem_bytes = __current_dev.attribute<::cudaDevAttrMaxSharedMemoryPerBlock>();
+  const auto __src_coalesced_tile_size =
+    ::cuda::experimental::__add_coalesced_tile_run(__src, __result.__src_perm, __result, __max_shared_mem_bytes);
+  const auto __dst_coalesced_tile_size =
+    ::cuda::experimental::__add_coalesced_tile_run(__dst, __result.__dst_perm, __result, __max_shared_mem_bytes);
+
+  // If the tile total size is too small, or the coalescing is not useful on both sides, or the number of active tile
+  // dimensions is less than 2, return the result.
+  if (__result.__tile_total_size < __max_tile_size * 8 || __src_coalesced_tile_size < 2 || __dst_coalesced_tile_size < 2
+      || __result.__active_tile_dims < 2)
+  {
+    return __result;
+  }
+
+  // There must be enough blocks to keep the GPU busy (at least one full wave across all SMs).
+  const size_t __num_sms = __current_dev.attribute<::cudaDevAttrMultiProcessorCount>();
+  size_t __num_tiles     = 1;
+  for (size_t __r = 0; __r < __dst.__rank; ++__r)
+  {
+    const auto __extent    = static_cast<size_t>(__dst.__extents[__r]);
+    const auto __tile_size = static_cast<size_t>(__result.__tile_sizes[__r]);
+    __num_tiles *= ::cuda::ceil_div(__extent, __tile_size);
+  }
+  if (__num_tiles < __num_sms)
+  {
+    return __result;
+  }
+
+  __result.__is_valid = true;
+  // Shared memory swizzle makes sense only for 32-bit and 64-bit types.
+  __result.__use_xor_swizzle = (sizeof(_TpIn) == 4 || sizeof(_TpIn) == 8) //
+                            && __result.__active_32_dims == 2;
+  return __result;
+}
+
+//! @brief Decide whether the shared-memory tiled transpose kernel is profitable.
 //!
 //! @param[in] __src Source raw tensor descriptor
 //! @param[in] __dst Destination raw tensor descriptor
@@ -126,88 +263,7 @@ template <typename _ExtentT,
 __use_shared_mem_kernel(const __raw_tensor<_ExtentT, _StrideTIn, _TpIn, _MaxRank>& __src,
                         const __raw_tensor<_ExtentT, _StrideTOut, _TpOut, _MaxRank>& __dst) noexcept
 {
-  using ::cuda::std::size_t;
-  using __rank_t                    = typename __raw_tensor<_ExtentT, _StrideTOut, _TpOut, _MaxRank>::__rank_t;
-  const size_t __num_contiguous_dst = ::cuda::experimental::__num_contiguous_dimensions(__dst);
-  // * destination is contiguous (in dimension 0) -> coalesced destination writes
-  // * source is not contiguous (already excluded by vectorized/contiguous copy)
-  // * there are at least two contiguous destination dimensions -> otherwise, direct copy is better
-  if (__src.__strides[0] == 1 || __dst.__strides[0] != 1 || __num_contiguous_dst < 2)
-  {
-    return false;
-  }
-
-  // * the tile is large enough to benefits from coalesced memory accesses.
-  // algorithm:
-  // - accumulate the product of the tile sizes until the shared memory limit is reached
-  // - the tile size (which is at block level) is capped at the warp size to get coalesced accesses
-  const auto __current_dev            = ::cuda::experimental::__current_device();
-  const size_t __max_shared_mem_bytes = __current_dev.attribute<::cudaDevAttrMaxSharedMemoryPerBlock>();
-  size_t __size_product               = 1;
-  int __tile_rank                     = 0;
-  for (size_t __r = 0; __r < __num_contiguous_dst; ++__r, ++__tile_rank)
-  {
-    const auto __tile_size_r = ::cuda::std::min(static_cast<size_t>(__dst.__extents[__r]), __max_tile_size);
-    if (__size_product * __tile_size_r * sizeof(_TpIn) > __max_shared_mem_bytes)
-    {
-      break;
-    }
-    __size_product *= __tile_size_r;
-  }
-  // if the final tile size is too small, exit
-  // 8 means each warp performs (block size / warp size) iterations >= 8
-  if (__tile_rank < 2 || __size_product < __max_tile_size * 8)
-  {
-    return false;
-  }
-
-  // * there are enough tiles to keep the GPU busy (at least one full wave across all SMs)
-  size_t __num_tiles = 1; // __num_tiles == number of blocks
-  for (__rank_t __r = 0; __r < __dst.__rank; ++__r)
-  {
-    const auto __extent    = static_cast<size_t>(__dst.__extents[__r]);
-    const auto __tile_size = (__r < __tile_rank) ? ::cuda::std::min(__extent, __max_tile_size) : size_t{1};
-    __num_tiles *= ::cuda::ceil_div(__extent, __tile_size);
-  }
-  const size_t __num_sms = __current_dev.attribute<::cudaDevAttrMultiProcessorCount>();
-  return __num_tiles >= __num_sms;
-}
-
-//! @brief Compute the shared-memory tile sizes for a destination tensor.
-//!
-//! Greedily expands the tile across contiguous dimensions up to the warp-size cap per dimension and the device
-//! shared-memory limit. Dimensions beyond the tile rank are set to extent 1.
-//!
-//! @param[in]  __tensor          Destination raw tensor descriptor
-//! @param[out] __tile_total_size Total number of elements in one tile (output)
-//! @return Per-dimension tile sizes (unused dimensions are 1)
-template <typename _TpIn, typename _ExtentT, typename _StrideT, typename _TpOut, ::cuda::std::size_t _MaxRank>
-[[nodiscard]] _CCCL_HOST_API ::cuda::std::array<__tile_extent_t, _MaxRank> __find_shared_mem_tiling(
-  const __raw_tensor<_ExtentT, _StrideT, _TpOut, _MaxRank>& __tensor, ::cuda::std::size_t& __tile_total_size) noexcept
-{
-  using ::cuda::std::size_t;
-  const auto __current_dev            = ::cuda::experimental::__current_device();
-  const size_t __max_shared_mem_bytes = __current_dev.attribute<::cudaDevAttrMaxSharedMemoryPerBlock>();
-  const size_t __num_contiguous_dst   = ::cuda::experimental::__num_contiguous_dimensions(__tensor);
-
-  ::cuda::std::array<__tile_extent_t, _MaxRank> __tile_sizes{};
-  __tile_total_size  = 1;
-  size_t __tile_rank = 0;
-  for (size_t __r = 0; __r < __num_contiguous_dst; ++__r, ++__tile_rank)
-  {
-    const auto __tile_size_r = ::cuda::std::min(static_cast<size_t>(__tensor.__extents[__r]), __max_tile_size);
-    if (__tile_total_size * __tile_size_r * sizeof(_TpIn) > __max_shared_mem_bytes)
-    {
-      break;
-    }
-    __tile_sizes[__r] = static_cast<__tile_extent_t>(__tile_size_r);
-    __tile_total_size *= __tile_size_r;
-  }
-  for (size_t __r = __tile_rank; __r < _MaxRank; ++__r)
-  {
-    __tile_sizes[__r] = 1;
-  }
-  return __tile_sizes;
+  return ::cuda::experimental::__find_shared_mem_tiling<_TpIn>(__src, __dst).__is_valid;
 }
 
 //! @brief Compute the thread block size for the shared-memory kernel.

--- a/cudax/include/cuda/experimental/__copy/copy_shared_memory_utils.cuh
+++ b/cudax/include/cuda/experimental/__copy/copy_shared_memory_utils.cuh
@@ -46,6 +46,24 @@ inline constexpr ::cuda::std::size_t __max_shared_mem_kernel_rank = 8;
 //! A tile size is always representable by an unsigned integer.
 using __tile_extent_t = unsigned;
 
+//! @brief Copy a raw tensor descriptor into one with a narrower static maximum rank.
+//!
+//! @param[in] __tensor Raw tensor descriptor with dynamic rank matching _RankOut
+//! @return Raw tensor descriptor with _RankOut as its static maximum rank
+template <::cuda::std::size_t _RankOut, typename _ExtentT, typename _StrideT, typename _Tp, ::cuda::std::size_t _MaxRank>
+[[nodiscard]] _CCCL_HOST_API __raw_tensor<_ExtentT, _StrideT, _Tp, _RankOut>
+__narrow_raw_tensor_rank(const __raw_tensor<_ExtentT, _StrideT, _Tp, _MaxRank>& __tensor) noexcept
+{
+  _CCCL_ASSERT(__tensor.__rank == _RankOut, "tensor rank must match the narrowed static rank");
+  __raw_tensor<_ExtentT, _StrideT, _Tp, _RankOut> __result{__tensor.__data, _RankOut, {}, {}};
+  for (::cuda::std::size_t __i = 0; __i < _RankOut; ++__i)
+  {
+    __result.__extents[__i] = __tensor.__extents[__i];
+    __result.__strides[__i] = __tensor.__strides[__i];
+  }
+  return __result;
+}
+
 //! @brief Count the number of leading contiguous dimensions in a raw tensor.
 //!
 //! Starting from dimension 0, counts consecutive dimensions where `stride[0] == 1` and `stride[i] == stride[i-1] *

--- a/cudax/include/cuda/experimental/__copy/copy_shared_memory_utils.cuh
+++ b/cudax/include/cuda/experimental/__copy/copy_shared_memory_utils.cuh
@@ -137,7 +137,7 @@ struct __shared_mem_tiling_result
 //! @param[in,out] __result                 Shared-memory tiling result updated with selected tile sizes
 //! @param[in]     __max_shared_mem_bytes   Maximum shared-memory capacity for one tile
 //! @return Number of coalesced elements covered by this tensor's selected tile run
-template <typename _ExtentT, typename _StrideT, typename _Tp, ::cuda::std::size_t _MaxRank>
+template <typename _SmemTp, typename _ExtentT, typename _StrideT, typename _Tp, ::cuda::std::size_t _MaxRank>
 [[nodiscard]] _CCCL_HOST_API ::cuda::std::size_t __add_coalesced_tile_run(
   const __raw_tensor<_ExtentT, _StrideT, _Tp, _MaxRank>& __tensor,
   const ::cuda::std::array<::cuda::std::size_t, _MaxRank>& __perm,
@@ -161,7 +161,7 @@ template <typename _ExtentT, typename _StrideT, typename _Tp, ::cuda::std::size_
     if (__result.__tile_sizes[__perm_i] == 1) // first time we see this dimension
     {
       const auto __tile_size             = ::cuda::std::min(__extent, __max_tile_size);
-      const auto __tile_total_size_bytes = __result.__tile_total_size * __tile_size * sizeof(_Tp);
+      const auto __tile_total_size_bytes = __result.__tile_total_size * __tile_size * sizeof(_SmemTp);
       if (__tile_total_size_bytes > __max_shared_mem_bytes)
       {
         break;
@@ -215,9 +215,9 @@ __find_shared_mem_tiling(const __raw_tensor<_ExtentT, _StrideTIn, _TpSrc, _MaxRa
   const auto __current_dev            = ::cuda::experimental::__current_device();
   const size_t __max_shared_mem_bytes = __current_dev.attribute<::cudaDevAttrMaxSharedMemoryPerBlock>();
   const auto __src_coalesced_tile_size =
-    ::cuda::experimental::__add_coalesced_tile_run(__src, __result.__src_perm, __result, __max_shared_mem_bytes);
+    ::cuda::experimental::__add_coalesced_tile_run<_TpIn>(__src, __result.__src_perm, __result, __max_shared_mem_bytes);
   const auto __dst_coalesced_tile_size =
-    ::cuda::experimental::__add_coalesced_tile_run(__dst, __result.__dst_perm, __result, __max_shared_mem_bytes);
+    ::cuda::experimental::__add_coalesced_tile_run<_TpIn>(__dst, __result.__dst_perm, __result, __max_shared_mem_bytes);
 
   // If the tile total size is too small, or the coalescing is not useful on both sides, or the number of active tile
   // dimensions is less than 2, return the result.

--- a/cudax/include/cuda/experimental/__copy/mdspan_d2d.cuh
+++ b/cudax/include/cuda/experimental/__copy/mdspan_d2d.cuh
@@ -44,7 +44,6 @@
 #  include <cuda/std/__type_traits/is_const.h>
 #  include <cuda/std/__type_traits/is_convertible.h>
 #  include <cuda/std/__type_traits/is_same.h>
-#  include <cuda/std/__type_traits/remove_cvref.h>
 
 #  include <cuda/experimental/__copy/copy_contiguous.cuh>
 #  include <cuda/experimental/__copy/copy_optimized.cuh>

--- a/cudax/include/cuda/experimental/__copy/mdspan_d2d.cuh
+++ b/cudax/include/cuda/experimental/__copy/mdspan_d2d.cuh
@@ -230,12 +230,22 @@ _CCCL_HOST_API void copy(::cuda::device_mdspan<_TpIn, _ExtentsIn, _LayoutPolicyI
       }
     }
     // (4) transpose case (rank capped to avoid excessive register pressure in the kernel)
-    if constexpr (__max_rank <= cudax::__max_shared_mem_kernel_rank)
+    if constexpr (__max_rank >= 2 && __max_rank <= cudax::__max_shared_mem_kernel_rank)
     {
-      if (cudax::__use_shared_mem_kernel(__src_normalized, __dst_normalized))
+      if (__src_simplified.__rank == 2) // Optimize when the actual rank is 2
+      {
+        const auto __src_rank2 = cudax::__narrow_raw_tensor_rank<2>(__src_simplified);
+        const auto __dst_rank2 = cudax::__narrow_raw_tensor_rank<2>(__dst_simplified);
+        if (cudax::__use_shared_mem_kernel(__src_rank2, __dst_rank2))
+        {
+          cudax::__launch_copy_shared_mem_kernel(__src_rank2, __dst_rank2, __stream, __src.accessor(), __dst.accessor());
+          return;
+        }
+      }
+      if (cudax::__use_shared_mem_kernel(__src_simplified, __dst_simplified))
       {
         cudax::__launch_copy_shared_mem_kernel(
-          __src_normalized, __dst_normalized, __stream, __src.accessor(), __dst.accessor());
+          __src_simplified, __dst_simplified, __stream, __src.accessor(), __dst.accessor());
         return;
       }
     }

--- a/cudax/include/cuda/experimental/__copy/tensor_copy_utils.cuh
+++ b/cudax/include/cuda/experimental/__copy/tensor_copy_utils.cuh
@@ -23,7 +23,6 @@
 
 #if !_CCCL_COMPILER(NVRTC)
 
-#  include <cuda/__mdspan/traits.h>
 #  include <cuda/__memory/ptr_alignment.h>
 #  include <cuda/__memory/ranges_overlap.h>
 #  include <cuda/__utility/in_range.h>

--- a/cudax/include/cuda/experimental/__copy/tensor_iterator.cuh
+++ b/cudax/include/cuda/experimental/__copy/tensor_iterator.cuh
@@ -22,8 +22,8 @@
 #endif // no system header
 
 #include <cuda/__cmath/fast_modulo_division.h>
-#include <cuda/__utility/in_range.h>
 #include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__type_traits/make_unsigned.h>
 #include <cuda/std/__type_traits/remove_const.h>
 #include <cuda/std/__utility/integer_sequence.h>
 #include <cuda/std/array>
@@ -58,49 +58,6 @@ __extents_fast_div_mod(const ::cuda::std::array<_ExtentT, _Size>& __extents) noe
   return ::cuda::experimental::__extents_fast_div_mod_impl(__extents, __seq_t{});
 }
 
-//! @brief Compute the product of extents in the range [__start, __end).
-//!
-//! @param[in] __extents Array of extents
-//! @param[in] __start   Start index of the range (inclusive)
-//! @param[in] __end     End index of the range (exclusive)
-//! @return Fast modulo/division object wrapping the product
-template <typename _ExtentT, ::cuda::std::size_t _Size>
-[[nodiscard]] _CCCL_HOST_DEVICE_API ::cuda::fast_mod_div<_ExtentT> __extent_product_in_range(
-  const ::cuda::std::array<_ExtentT, _Size>& __extents, ::cuda::std::size_t __start, ::cuda::std::size_t __end) noexcept
-{
-  using __fast_mod_div_t = ::cuda::fast_mod_div<_ExtentT>;
-  _CCCL_ASSERT(::cuda::in_range(__start, ::cuda::std::size_t{0}, _Size), "invalid __start");
-  _CCCL_ASSERT(::cuda::in_range(__end, ::cuda::std::size_t{0}, _Size), "invalid __end");
-  _ExtentT __size = 1;
-  for (auto __i = __start; __i < __end; __i++)
-  {
-    __size *= __extents[__i];
-  }
-  return __fast_mod_div_t(__size);
-}
-
-template <typename _ExtentT, ::cuda::std::size_t _Size, ::cuda::std::size_t... _Rp>
-[[nodiscard]] _CCCL_HOST_DEVICE_API ::cuda::std::array<::cuda::fast_mod_div<_ExtentT>, sizeof...(_Rp)>
-__extents_product_fast_div_mod_impl(const ::cuda::std::array<_ExtentT, _Size>& __extents,
-                                    ::cuda::std::index_sequence<_Rp...> = {}) noexcept
-{
-  using __fast_mod_div_t = ::cuda::fast_mod_div<_ExtentT>;
-  using __array_t        = ::cuda::std::array<__fast_mod_div_t, sizeof...(_Rp)>;
-  return __array_t{::cuda::experimental::__extent_product_in_range(__extents, 0, _Rp)...};
-}
-
-//! @brief Precompute cumulative extent products as fast modulo/division objects.
-//!
-//! @param[in] __extents Array of extents
-//! @return Array of fast modulo/division objects for each cumulative product
-template <typename _ExtentT, ::cuda::std::size_t _Size>
-[[nodiscard]] _CCCL_HOST_DEVICE_API ::cuda::std::array<::cuda::fast_mod_div<_ExtentT>, _Size>
-__extents_product_fast_div_mod(const ::cuda::std::array<_ExtentT, _Size>& __extents) noexcept
-{
-  using __seq_t = ::cuda::std::make_index_sequence<_Size>;
-  return ::cuda::experimental::__extents_product_fast_div_mod_impl(__extents, __seq_t{});
-}
-
 /***********************************************************************************************************************
  * Tensor Coordinate Iterator and Partial Tensor
  **********************************************************************************************************************/
@@ -109,24 +66,24 @@ __extents_product_fast_div_mod(const ::cuda::std::array<_ExtentT, _Size>& __exte
 template <typename _ExtentT, ::cuda::std::size_t _Rank>
 struct __tensor_coord_iterator
 {
-  using __fast_mod_div_t = ::cuda::fast_mod_div<_ExtentT>;
-  using __array_t        = ::cuda::std::array<__fast_mod_div_t, _Rank>;
+  using __unsigned_extent_t = ::cuda::std::make_unsigned_t<_ExtentT>;
+  using __fast_mod_div_t    = ::cuda::fast_mod_div<__unsigned_extent_t>;
+  using __array_t           = ::cuda::std::array<__fast_mod_div_t, _Rank>;
 
   __array_t __extents_;
-  __array_t __extent_products_;
 
   //! @brief Convert an array of _UExtentT elements to an array of _ExtentT elements.
   //!
   //! @param[in] __in_array Source array with elements of type _UExtentT
   //! @return Array with elements statically cast to _ExtentT
   template <typename _UExtentT>
-  [[nodiscard]] static _CCCL_HOST_API ::cuda::std::array<_ExtentT, _Rank>
+  [[nodiscard]] static _CCCL_HOST_API ::cuda::std::array<__unsigned_extent_t, _Rank>
   __to_extent_array(const ::cuda::std::array<_UExtentT, _Rank>& __in_array) noexcept
   {
-    ::cuda::std::array<_ExtentT, _Rank> __out_array{};
+    ::cuda::std::array<__unsigned_extent_t, _Rank> __out_array{};
     for (::cuda::std::size_t __i = 0; __i < _Rank; ++__i)
     {
-      __out_array[__i] = static_cast<_ExtentT>(__in_array[__i]);
+      __out_array[__i] = static_cast<__unsigned_extent_t>(__in_array[__i]);
     }
     return __out_array;
   }
@@ -137,29 +94,32 @@ struct __tensor_coord_iterator
   template <typename _UExtentT>
   _CCCL_HOST_API explicit __tensor_coord_iterator(const ::cuda::std::array<_UExtentT, _Rank>& __extents) noexcept
       : __extents_{::cuda::experimental::__extents_fast_div_mod(__to_extent_array(__extents))}
-      , __extent_products_{::cuda::experimental::__extents_product_fast_div_mod(__to_extent_array(__extents))}
   {}
 
   //! @brief Returns the multi-dimensional coordinates for the given linear index.
   //!
-  //! @param[in] __in_arraydex Linear tile index
+  //! @param[in] __index Linear tile index
   //! @return Array of coordinates into the tensor
-  [[nodiscard]] _CCCL_HOST_DEVICE_API ::cuda::std::array<_ExtentT, _Rank>
-  operator()(_ExtentT __in_arraydex) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API ::cuda::std::array<_ExtentT, _Rank> operator()(_ExtentT __index) const noexcept
   {
     if constexpr (_Rank == 1)
     {
-      return ::cuda::std::array<_ExtentT, _Rank>{{__in_arraydex}};
+      return ::cuda::std::array<_ExtentT, _Rank>{{__index}};
     }
     else
     {
+      // instead of computing the coordinate in parallel (index / prod(extent_i) % extent_i), we use a simpler and
+      // slower approach. This saves registers and makes the overall computation faster.
       ::cuda::std::array<_ExtentT, _Rank> __coords{};
-      __coords[0] = __in_arraydex % __extents_[0]; // __extent_products_[0] == 1
+      auto __quotient = static_cast<__unsigned_extent_t>(__index);
       _CCCL_PRAGMA_UNROLL_FULL()
-      for (int __i = 1; __i < _Rank; ++__i)
+      for (int __i = 0; __i < int{_Rank} - 1; ++__i)
       {
-        __coords[__i] = (__in_arraydex / __extent_products_[__i]) % __extents_[__i];
+        const auto __div_result = ::cuda::div(__quotient, __extents_[__i]);
+        __quotient              = __div_result.first;
+        __coords[__i]           = static_cast<_ExtentT>(__div_result.second);
       }
+      __coords[_Rank - 1] = static_cast<_ExtentT>(__quotient % __extents_[_Rank - 1]);
       return __coords;
     }
   }
@@ -176,6 +136,22 @@ struct __partial_tensor
   ::cuda::std::array<_StrideT, _Rank> __strides;
   _Accessor __accessor;
 
+  //! @brief Compute the linear offset for the given multi-dimensional coordinates.
+  //!
+  //! @param[in] __coords Array of per-dimension coordinates
+  //! @return Linear offset into the tensor storage
+  template <typename _CoordT>
+  [[nodiscard]] _CCCL_DEVICE_API _StrideT __offset(const ::cuda::std::array<_CoordT, _Rank>& __coords) const noexcept
+  {
+    _StrideT __offset = 0;
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int __i = 0; __i < int{_Rank}; ++__i)
+    {
+      __offset += static_cast<_StrideT>(__coords[__i]) * __strides[__i];
+    }
+    return __offset;
+  }
+
   //! @brief Access the element at the given multi-dimensional coordinates.
   //!
   //! @param[in] __coords Array of per-dimension coordinates
@@ -184,13 +160,7 @@ struct __partial_tensor
   [[nodiscard]] _CCCL_DEVICE_API decltype(auto)
   operator()(const ::cuda::std::array<_CoordT, _Rank>& __coords) const noexcept
   {
-    _StrideT __offset = 0;
-    _CCCL_PRAGMA_UNROLL_FULL()
-    for (int __i = 0; __i < int{_Rank}; ++__i)
-    {
-      __offset += static_cast<_StrideT>(__coords[__i]) * __strides[__i];
-    }
-    return __accessor.access(const_cast<::cuda::std::remove_const_t<_Tp>*>(__ptr), __offset);
+    return __accessor.access(const_cast<::cuda::std::remove_const_t<_Tp>*>(__ptr), __offset(__coords));
   }
 };
 } // namespace cuda::experimental

--- a/cudax/include/cuda/experimental/__copy_bytes/tensor_query.cuh
+++ b/cudax/include/cuda/experimental/__copy_bytes/tensor_query.cuh
@@ -114,7 +114,7 @@ __sort_by_stride(const __raw_tensor<_ExtentT, _StrideT, _Tp, _MaxRank>& __tensor
   using __raw_tensor_t = __raw_tensor<_ExtentT, _StrideT, _Tp, _MaxRank>;
   using __rank_t       = typename __raw_tensor_t::__rank_t;
   const auto __rank    = __tensor.__rank;
-  const auto __perm = ::cuda::experimental::__stride_order(__tensor);
+  const auto __perm    = ::cuda::experimental::__stride_order(__tensor);
 
   __raw_tensor<_ExtentT, _StrideT, _Tp, _MaxRank> __result{__tensor.__data, __rank};
   for (__rank_t __i = 0; __i < __rank; ++__i)

--- a/cudax/include/cuda/experimental/__copy_bytes/tensor_query.cuh
+++ b/cudax/include/cuda/experimental/__copy_bytes/tensor_query.cuh
@@ -83,6 +83,24 @@ struct __stride_compare
   }
 };
 
+//! @brief Computes the mode permutation that orders a tensor by ascending absolute stride.
+//!
+//! @param[in] __tensor Raw tensor whose stride order is inspected
+//! @return Mode permutation sorted by ascending absolute stride
+template <typename _ExtentT, typename _StrideT, typename _Tp, ::cuda::std::size_t _MaxRank>
+[[nodiscard]] _CCCL_HOST_API constexpr ::cuda::std::array<::cuda::std::size_t, _MaxRank>
+__stride_order(const __raw_tensor<_ExtentT, _StrideT, _Tp, _MaxRank>& __tensor) noexcept
+{
+  ::cuda::std::array<::cuda::std::size_t, _MaxRank> __perm{};
+  for (::cuda::std::size_t __i = 0; __i < _MaxRank; ++__i)
+  {
+    __perm[__i] = __i;
+  }
+  ::cuda::std::stable_sort(
+    __perm.begin(), __perm.begin() + __tensor.__rank, __stride_compare<_StrideT, _MaxRank>{__tensor.__strides});
+  return __perm;
+}
+
 //! @brief Reorders tensor modes by ascending absolute stride.
 //!
 //! After sorting, mode 0 has the smallest absolute stride (innermost) and mode rank-1 has the largest (outermost).
@@ -96,13 +114,7 @@ __sort_by_stride(const __raw_tensor<_ExtentT, _StrideT, _Tp, _MaxRank>& __tensor
   using __raw_tensor_t = __raw_tensor<_ExtentT, _StrideT, _Tp, _MaxRank>;
   using __rank_t       = typename __raw_tensor_t::__rank_t;
   const auto __rank    = __tensor.__rank;
-  ::cuda::std::array<__rank_t, _MaxRank> __perm{};
-  for (__rank_t __i = 0; __i < __rank; ++__i)
-  {
-    __perm[__i] = __i;
-  }
-  ::cuda::std::stable_sort(
-    __perm.begin(), __perm.begin() + __rank, __stride_compare<_StrideT, _MaxRank>{__tensor.__strides});
+  const auto __perm = ::cuda::experimental::__stride_order(__tensor);
 
   __raw_tensor<_ExtentT, _StrideT, _Tp, _MaxRank> __result{__tensor.__data, __rank};
   for (__rank_t __i = 0; __i < __rank; ++__i)

--- a/cudax/test/copy/copy_shared_memory.cu
+++ b/cudax/test/copy/copy_shared_memory.cu
@@ -16,32 +16,78 @@ using data_t = int;
  * Shared-memory tiled transpose test cases (device-to-device)
  **********************************************************************************************************************/
 
-// src: (32,32):(1,32), column-major
-// dst: (32,32):(32,1), row-major
-// Shape (32,32) ensures tile sizes (32,32) evenly divide and the tile product (1024) exceeds the
-// shared-memory kernel threshold (256). After sort_by_stride_paired, dst is stride-1 at mode 0
-// while src is not, triggering the shared-memory transpose path.
+// src: (8192,32):(1,8192), column-major
+// dst: (8192,32):(32,1), row-major
+// Shape (8192,32) creates enough 32x32 tiles to satisfy the one-wave occupancy heuristic.
 TEST_CASE("copy d2d shared_memory 2D transpose", "[copy][d2d][shared_memory][transpose]")
 {
+  constexpr int M     = 8192;
   constexpr int N     = 32;
-  constexpr int alloc = N * N;
-  cuda::std::array<int, 2> shape{N, N};
-  cuda::std::array<int, 2> src_strides{1, N};
+  constexpr int alloc = M * N;
+  cuda::std::array<int, 2> shape{M, N};
+  cuda::std::array<int, 2> src_strides{1, M};
   cuda::std::array<int, 2> dst_strides{N, 1};
   test_copy_stride_relaxed<data_t>(alloc, 0, shape, src_strides, alloc, 0, dst_strides);
 }
 
-// src: (50,37):(1,50), column-major
-// dst: (50,37):(37,1), row-major
-// Extents (50,37) are not divisible by tile size 32.
-// Full-tile blocks cover [0,32)x[0,32). Boundary blocks handle the remainder.
+// src: (8193,37):(1,8193), column-major
+// dst: (8193,37):(37,1), row-major
+// Extents (8193,37) are not divisible by tile size 32.
+// Boundary blocks handle the remainder.
 TEST_CASE("copy d2d shared_memory 2D partial tiles", "[copy][d2d][shared_memory][transpose][partial]")
 {
-  constexpr int M     = 50;
+  constexpr int M     = 8193;
   constexpr int N     = 37;
   constexpr int alloc = M * N;
   cuda::std::array<int, 2> shape{M, N};
   cuda::std::array<int, 2> src_strides{1, M};
   cuda::std::array<int, 2> dst_strides{N, 1};
   test_copy_stride_relaxed<data_t>(alloc, 0, shape, src_strides, alloc, 0, dst_strides);
+}
+
+// src: (8192,16,16):(1,8192,131072), column-major
+// dst: (8192,16,16):(256,16,1), row-major
+// The simplified tensor rank remains 3, covering the generic shared-memory launch.
+TEST_CASE("copy d2d shared_memory 3D transpose", "[copy][d2d][shared_memory][transpose][3d]")
+{
+  constexpr int D0    = 8192;
+  constexpr int D1    = 16;
+  constexpr int D2    = 16;
+  constexpr int alloc = D0 * D1 * D2;
+  cuda::std::array<int, 3> shape{D0, D1, D2};
+  cuda::std::array<int, 3> src_strides{1, D0, D0 * D1};
+  cuda::std::array<int, 3> dst_strides{D1 * D2, D2, 1};
+  test_copy_stride_relaxed<data_t>(alloc, 0, shape, src_strides, alloc, 0, dst_strides);
+}
+
+// src: (8193,16,16):(1,8193,131088), column-major
+// dst: (8193,16,16):(256,16,1), row-major
+// The first dimension is not tile-aligned, so rank-3 boundary tiles use the direct-copy fallback.
+TEST_CASE("copy d2d shared_memory 3D partial tiles", "[copy][d2d][shared_memory][transpose][3d][partial]")
+{
+  constexpr int D0    = 8193;
+  constexpr int D1    = 16;
+  constexpr int D2    = 16;
+  constexpr int alloc = D0 * D1 * D2;
+  cuda::std::array<int, 3> shape{D0, D1, D2};
+  cuda::std::array<int, 3> src_strides{1, D0, D0 * D1};
+  cuda::std::array<int, 3> dst_strides{D1 * D2, D2, 1};
+  test_copy_stride_relaxed<data_t>(alloc, 0, shape, src_strides, alloc, 0, dst_strides);
+}
+
+// src: (16,8192,8):(1,128,16)
+// dst: (16,8192,8):(131072,16,1), padded in the middle dimension.
+// This mirrors the padded small-dimension benchmark shape at unit-test scale.
+TEST_CASE("copy d2d shared_memory 3D padded small dimension", "[copy][d2d][shared_memory][transpose][3d][padded]")
+{
+  constexpr int D0        = 16;
+  constexpr int D1        = 8192;
+  constexpr int D2        = 8;
+  constexpr int dst_pitch = 16;
+  constexpr int src_alloc = D0 * D1 * D2;
+  constexpr int dst_alloc = D0 * D1 * dst_pitch;
+  cuda::std::array<int, 3> shape{D0, D1, D2};
+  cuda::std::array<int, 3> src_strides{1, D0 * D2, D0};
+  cuda::std::array<int, 3> dst_strides{D1 * dst_pitch, dst_pitch, 1};
+  test_copy_stride_relaxed<data_t>(src_alloc, 0, shape, src_strides, dst_alloc, 0, dst_strides);
 }


### PR DESCRIPTION
## Description

The PR optimizes `cudax::copy(mdspan)` for the following cases:

- Extend permutation of the destination tensor to exploit coalesced memory accesses on a wider set of cases. Previously, the shared memory path was enabled only when the destination tensor is contiguous.
- Add Xor swizzle for 2D cases.
- Simplified `fast_mod_div` code to use less registers.
