### PR TITLE
[STF] [TRIVIAL] Rename decorated_stream to augmented_stream

### DIFF
--- a/cudax/include/cuda/experimental/__places/exec/cuda_stream.cuh
+++ b/cudax/include/cuda/experimental/__places/exec/cuda_stream.cuh
@@ -35,7 +35,7 @@ namespace cuda::experimental::places
 class exec_place_cuda_stream_impl : public exec_place::impl
 {
 public:
-  exec_place_cuda_stream_impl(const decorated_stream& dstream)
+  exec_place_cuda_stream_impl(const augmented_stream& dstream)
       : exec_place::impl(data_place::device(dstream.dev_id))
       , dstream_(dstream)
       , dummy_pool_(dstream)
@@ -92,7 +92,7 @@ public:
   }
 
 private:
-  decorated_stream dstream_;
+  augmented_stream dstream_;
   mutable stream_pool dummy_pool_;
 };
 
@@ -100,10 +100,10 @@ inline exec_place exec_place::cuda_stream(cudaStream_t stream)
 {
   int devid = get_device_from_stream(stream);
   return exec_place{
-    ::std::make_shared<exec_place_cuda_stream_impl>(decorated_stream(stream, get_stream_id(stream), devid))};
+    ::std::make_shared<exec_place_cuda_stream_impl>(augmented_stream(stream, get_stream_id(stream), devid))};
 }
 
-inline exec_place exec_place::cuda_stream(const decorated_stream& dstream)
+inline exec_place exec_place::cuda_stream(const augmented_stream& dstream)
 {
   return exec_place{::std::make_shared<exec_place_cuda_stream_impl>(dstream)};
 }

--- a/cudax/include/cuda/experimental/__places/places.cuh
+++ b/cudax/include/cuda/experimental/__places/places.cuh
@@ -328,7 +328,7 @@ public:
     return pimpl_->hash();
   }
 
-  decorated_stream getDataStream(exec_place_resources& res) const;
+  augmented_stream getDataStream(exec_place_resources& res) const;
 
   /**
    * @brief Get the underlying interface pointer
@@ -669,11 +669,11 @@ public:
   /// inline in `__stf/internal/async_resources_handle.cuh`.
   inline stream_pool& get_stream_pool(bool for_computation, ::cuda::experimental::stf::async_resources_handle& h) const;
 
-  decorated_stream getStream(exec_place_resources& res, bool for_computation = true) const;
+  augmented_stream getStream(exec_place_resources& res, bool for_computation = true) const;
 
   /// @brief Convenience overload taking an `async_resources_handle`. Defined
   /// inline in `__stf/internal/async_resources_handle.cuh`.
-  inline decorated_stream getStream(::cuda::experimental::stf::async_resources_handle& h,
+  inline augmented_stream getStream(::cuda::experimental::stf::async_resources_handle& h,
                                     bool for_computation = true) const;
 
   cudaStream_t pick_stream(exec_place_resources& res, bool for_computation = true) const
@@ -765,7 +765,7 @@ public:
 #endif // _CCCL_CTK_AT_LEAST(12, 4)
 
   static exec_place cuda_stream(cudaStream_t stream);
-  static exec_place cuda_stream(const decorated_stream& dstream);
+  static exec_place cuda_stream(const augmented_stream& dstream);
 
   /**
    * @brief Returns the currently active device.
@@ -980,7 +980,7 @@ auto exec_place::operator->*(Fun&& fun) const
   return ::std::forward<Fun>(fun)();
 }
 
-inline decorated_stream stream_pool::next(const exec_place& place)
+inline augmented_stream stream_pool::next(const exec_place& place)
 {
   _CCCL_ASSERT(pimpl, "stream_pool::next called on empty pool");
   ::std::scoped_lock locker(pimpl->mtx);
@@ -1000,7 +1000,7 @@ inline decorated_stream stream_pool::next(const exec_place& place)
     if (stream_err == CUDA_ERROR_CONTEXT_IS_DESTROYED || stream_err == CUDA_ERROR_INVALID_CONTEXT
         || stream_err == CUDA_ERROR_INVALID_HANDLE || ctx == nullptr)
     {
-      result = decorated_stream(nullptr, k_no_stream_id, -1);
+      result = augmented_stream(nullptr, k_no_stream_id, -1);
     }
     else
     {
@@ -1026,7 +1026,7 @@ inline decorated_stream stream_pool::next(const exec_place& place)
   return result;
 }
 
-inline decorated_stream exec_place::getStream(exec_place_resources& res, bool for_computation) const
+inline augmented_stream exec_place::getStream(exec_place_resources& res, bool for_computation) const
 {
   return get_stream_pool(for_computation, res).next(*this);
 }
@@ -1743,7 +1743,7 @@ data_place data_place::composite(partitioner_t, const exec_place& g)
   return data_place::composite(&partitioner_t::get_executor, g);
 }
 
-inline decorated_stream data_place::getDataStream(exec_place_resources& res) const
+inline augmented_stream data_place::getDataStream(exec_place_resources& res) const
 {
   return affine_exec_place().getStream(res, false);
 }

--- a/cudax/include/cuda/experimental/__places/stream_pool.cuh
+++ b/cudax/include/cuda/experimental/__places/stream_pool.cuh
@@ -10,7 +10,7 @@
 
 /**
  * @file
- * @brief Stream pool and decorated stream types used by places.
+ * @brief Stream pool and augmented stream types used by places.
  *
  * Definitions of stream_pool::next() live in places.cuh (because we need to
  * activate the place to create a stream in the appropriate CUDA context).
@@ -109,25 +109,30 @@ inline unsigned long long get_stream_id(cudaStream_t stream)
 }
 
 /**
- * @brief A class to store a CUDA stream along with metadata
+ * @brief A CUDA stream augmented with its pre-resolved driver identity and home device.
  *
- * It contains
+ * Carries:
  *  - the stream itself,
- *  - the stream's unique ID from the CUDA driver (cuStreamGetId), or k_no_stream_id if no stream,
- *  - the device index in which the stream resides
+ *  - the stream's unique ID from the CUDA driver (cuStreamGetId), or k_no_stream_id when unknown,
+ *  - the device index on which the stream resides.
+ *
+ * The id and device are looked up at construction so downstream consumers
+ * (the stream-reuse logic in stream_task, the (src_id, dst_id)-keyed sync-skip
+ * cache in async_resources_handle, etc.) never have to re-pay the driver
+ * round-trip and can use the augmented stream as a cache key.
  */
-struct decorated_stream
+struct augmented_stream
 {
-  decorated_stream() = default;
+  augmented_stream() = default;
 
-  decorated_stream(cudaStream_t stream, unsigned long long id, int dev_id = -1)
+  augmented_stream(cudaStream_t stream, unsigned long long id, int dev_id = -1)
       : stream(stream)
       , id(id)
       , dev_id(dev_id)
   {}
 
   /** Construct from stream only; id is from cuStreamGetId, dev_id is -1 (filled lazily when needed). */
-  explicit decorated_stream(cudaStream_t stream)
+  explicit augmented_stream(cudaStream_t stream)
       : stream(stream)
       , id(get_stream_id(stream))
       , dev_id(-1)
@@ -153,11 +158,11 @@ class stream_pool
   struct impl
   {
     explicit impl(size_t n)
-        : payload(n, decorated_stream(nullptr, k_no_stream_id, -1))
+        : payload(n, augmented_stream(nullptr, k_no_stream_id, -1))
     {}
 
-    // Construct from a decorated stream, this is used to create a stream pool with a single stream.
-    explicit impl(decorated_stream ds)
+    // Construct from an augmented stream, this is used to create a stream pool with a single stream.
+    explicit impl(augmented_stream ds)
         : payload(1, mv(ds))
         , externally_owned(true)
     {}
@@ -187,7 +192,7 @@ class stream_pool
     impl& operator=(const impl&) = delete;
 
     mutable ::std::mutex mtx;
-    ::std::vector<decorated_stream> payload;
+    ::std::vector<augmented_stream> payload;
     size_t index          = 0;
     bool externally_owned = false;
   };
@@ -201,8 +206,8 @@ public:
       : pimpl(::std::make_shared<impl>(n))
   {}
 
-  // Construct from a decorated stream, this is used to create a stream pool with a single stream.
-  explicit stream_pool(decorated_stream ds)
+  // Construct from an augmented stream, this is used to create a stream pool with a single stream.
+  explicit stream_pool(augmented_stream ds)
       : pimpl(::std::make_shared<impl>(mv(ds)))
   {}
 
@@ -215,9 +220,9 @@ public:
    * @brief Get the next stream in the pool; when a slot is empty, activate the place (RAII guard) and call
    * place.create_stream(). Defined in places.cuh so the pool can use exec_place_scope and exec_place::create_stream().
    */
-  decorated_stream next(const exec_place& place);
+  augmented_stream next(const exec_place& place);
 
-  using iterator = ::std::vector<decorated_stream>::iterator;
+  using iterator = ::std::vector<augmented_stream>::iterator;
   iterator begin()
   {
     return pimpl->payload.begin();

--- a/cudax/include/cuda/experimental/__stf/internal/async_resources_handle.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/async_resources_handle.cuh
@@ -319,7 +319,7 @@ exec_place::get_stream_pool(bool for_computation, ::cuda::experimental::stf::asy
   return get_stream_pool(for_computation, h.get_place_resources());
 }
 
-[[nodiscard]] inline decorated_stream
+[[nodiscard]] inline augmented_stream
 exec_place::getStream(::cuda::experimental::stf::async_resources_handle& h, bool for_computation) const
 {
   return getStream(h.get_place_resources(), for_computation);

--- a/cudax/include/cuda/experimental/__stf/internal/parallel_for_scope.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/parallel_for_scope.cuh
@@ -813,7 +813,7 @@ public:
     if constexpr (::std::is_same_v<context, stream_ctx>)
     {
       // Synchronize stream with allocation events
-      reserved::join_with_stream(ctx, decorated_stream(stream), alloc_events, "alloc_sync", false);
+      reserved::join_with_stream(ctx, augmented_stream(stream), alloc_events, "alloc_sync", false);
 
       // TODO optimize the case where there was a single block to write to result ??
       reserved::loop_redux<Fun_no_ref, sub_shape_t, deps_tup_t, ops_and_inits>
@@ -824,7 +824,7 @@ public:
         <<<1, finalize_block_size, dynamic_shared_mem_finalize, stream>>>(arg_instances, d_redux_buffer, blocks);
 
       // Stream context: create event from stream to represent kernel completion
-      completion_event = event_list(reserved::record_event_in_stream(decorated_stream(stream)));
+      completion_event = event_list(reserved::record_event_in_stream(augmented_stream(stream)));
     }
     else
     {
@@ -878,7 +878,7 @@ public:
 
     if constexpr (::std::is_same_v<context, stream_ctx>)
     {
-      reserved::join_with_stream(ctx, decorated_stream(stream), completion_event, "dealloc_sync", false);
+      reserved::join_with_stream(ctx, augmented_stream(stream), completion_event, "dealloc_sync", false);
     }
     else
     {

--- a/cudax/include/cuda/experimental/__stf/internal/stf_places_into_stf_core.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/stf_places_into_stf_core.cuh
@@ -25,8 +25,8 @@
 
 namespace cuda::experimental::stf
 {
+using ::cuda::experimental::places::augmented_stream;
 using ::cuda::experimental::places::data_place;
-using ::cuda::experimental::places::decorated_stream;
 using ::cuda::experimental::places::device_ordinal;
 using ::cuda::experimental::places::exec_place;
 using ::cuda::experimental::places::exec_place_scope;

--- a/cudax/include/cuda/experimental/__stf/stream/interfaces/slice.cuh
+++ b/cudax/include/cuda/experimental/__stf/stream/interfaces/slice.cuh
@@ -202,8 +202,8 @@ public:
     // static_assert(dimensions <= 2, "unsupported yet.");
     //_CCCL_ASSERT(dimensions <= 2, "unsupported yet.");
 
-    auto decorated_s = dst_memory_node.getDataStream(bctx.async_resources().get_place_resources());
-    auto op          = stream_async_op(bctx, decorated_s, prereqs);
+    auto augmented_s = dst_memory_node.getDataStream(bctx.async_resources().get_place_resources());
+    auto op          = stream_async_op(bctx, augmented_s, prereqs);
 
     if (bctx.generate_event_symbols())
     {
@@ -211,7 +211,7 @@ public:
       op.set_symbol("slice copy " + src_memory_node.to_string() + "->" + dst_memory_node.to_string());
     }
 
-    cudaStream_t s = decorated_s.stream;
+    cudaStream_t s = augmented_s.stream;
 
     // Let CUDA figure out from pointers
     cudaMemcpyKind kind = cudaMemcpyDefault;

--- a/cudax/include/cuda/experimental/__stf/stream/internal/event_types.cuh
+++ b/cudax/include/cuda/experimental/__stf/stream/internal/event_types.cuh
@@ -35,7 +35,7 @@ namespace reserved
 {
 inline event join_with_stream(
   const backend_ctx_untyped& bctx,
-  decorated_stream dstream,
+  augmented_stream dstream,
   event_list& prereq_in,
   ::std::string string,
   bool record_event);
@@ -67,7 +67,7 @@ protected:
     }
   }
 
-  stream_and_event(const decorated_stream& dstream, bool do_insert_event)
+  stream_and_event(const augmented_stream& dstream, bool do_insert_event)
       : dstream(dstream)
   {
     // fprintf(stderr, "stream_and_event %s (ID %d)\n", this->get_symbol().c_str(), int(this->unique_prereq_id));
@@ -241,7 +241,7 @@ public:
 
   void sync_with_stream(const backend_ctx_untyped& bctx, event_list& prereqs, cudaStream_t stream) const override
   {
-    reserved::join_with_stream(bctx, decorated_stream(stream), prereqs, "sync", false);
+    reserved::join_with_stream(bctx, augmented_stream(stream), prereqs, "sync", false);
   }
 
   cudaStream_t get_stream() const
@@ -249,7 +249,7 @@ public:
     return dstream.stream;
   }
 
-  decorated_stream get_decorated_stream() const
+  augmented_stream get_augmented_stream() const
   {
     return dstream;
   }
@@ -265,7 +265,7 @@ public:
   }
 
 private:
-  decorated_stream dstream;
+  augmented_stream dstream;
   cudaEvent_t cudaEvent = nullptr;
 };
 
@@ -277,7 +277,7 @@ class stream_async_op
 public:
   stream_async_op() = default;
 
-  stream_async_op(backend_ctx_untyped& bctx, decorated_stream dstream, event_list& prereq_in)
+  stream_async_op(backend_ctx_untyped& bctx, augmented_stream dstream, event_list& prereq_in)
       : dstream(mv(dstream))
   {
     setup(bctx, prereq_in);
@@ -302,7 +302,7 @@ public:
     }
 
     // Note that if we had stream_dev_id = -1 (eg. host memory), the device
-    // id of this decorated stream will disagree, as we have taken one
+    // id of this augmented stream will disagree, as we have taken one
     // stream from any device (current device, in particular)
     assert(dstream.stream);
 
@@ -386,7 +386,7 @@ private:
 
   /* Find is there is already a stream associated to that device in the
    * prereq list */
-  static decorated_stream device_lookup_in_event_list(backend_ctx_untyped& /* bctx */, event_list& prereq_in, int devid)
+  static augmented_stream device_lookup_in_event_list(backend_ctx_untyped& /* bctx */, event_list& prereq_in, int devid)
   {
     static const bool no_lookup = [] {
       const char* env = ::std::getenv("CUDASTF_NO_LOOKUP");
@@ -394,7 +394,7 @@ private:
     }();
     if (no_lookup)
     {
-      return decorated_stream(nullptr);
+      return augmented_stream(nullptr);
     }
 
     for (const auto& e : prereq_in)
@@ -418,14 +418,14 @@ private:
       if (stream_dev == devid)
       {
         //    fprintf(stderr, "Found matching device %d with stream %p\n", devid, stream);
-        return decorated_stream(stream, stream_id, static_cast<int>(stream_dev));
+        return augmented_stream(stream, stream_id, static_cast<int>(stream_dev));
       }
     }
 
-    return decorated_stream();
+    return augmented_stream();
   }
 
-  decorated_stream dstream;
+  augmented_stream dstream;
   ::std::string symbol;
 
   // Used to display dependencies in DOT
@@ -437,7 +437,7 @@ namespace reserved
 /* This creates a synchronization point between all entries of the prereq_in list, and a CUDA stream */
 inline event join_with_stream(
   const backend_ctx_untyped& bctx,
-  decorated_stream dstream,
+  augmented_stream dstream,
   event_list& prereq_in,
   ::std::string string,
   bool record_event)
@@ -453,13 +453,13 @@ inline event join_with_stream(
 }
 
 /* Create a simple event in a CUDA stream */
-inline event record_event_in_stream(const decorated_stream& dstream)
+inline event record_event_in_stream(const augmented_stream& dstream)
 {
   return reserved::handle<stream_and_event>(dstream, true);
 }
 
 /* Overload to provide a symbol */
-inline event record_event_in_stream(const decorated_stream& dstream, reserved::per_ctx_dot& dot, ::std::string symbol)
+inline event record_event_in_stream(const augmented_stream& dstream, reserved::per_ctx_dot& dot, ::std::string symbol)
 {
   event res = record_event_in_stream(dstream);
   res->set_symbol_with_dot(dot, mv(symbol));

--- a/cudax/include/cuda/experimental/__stf/stream/stream_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/stream/stream_ctx.cuh
@@ -189,7 +189,7 @@ public:
   void set_user_stream(cudaStream_t user_stream)
   {
     // TODO first introduce the user stream in our pool
-    auto dstream = decorated_stream(user_stream);
+    auto dstream = augmented_stream(user_stream);
 
     this->state().user_dstream = dstream;
 
@@ -251,7 +251,7 @@ public:
   {
     const auto& user_dstream = state().user_dstream;
     // We either use the user-provided stream, or we get one stream from the pool
-    decorated_stream dstream =
+    augmented_stream dstream =
       (user_dstream.has_value())
         ? user_dstream.value()
         : exec_place::current_device().getStream(
@@ -629,7 +629,7 @@ private:
 
     event_list stream_to_event_list(cudaStream_t stream, ::std::string symbol) const override
     {
-      auto e = reserved::record_event_in_stream(decorated_stream(stream), *get_dot(), mv(symbol));
+      auto e = reserved::record_event_in_stream(augmented_stream(stream), *get_dot(), mv(symbol));
       return event_list(mv(e));
     }
 
@@ -652,7 +652,7 @@ private:
 
     // If the context is attached to a user stream, we should use it for
     // finalize() or fence()
-    ::std::optional<decorated_stream> user_dstream;
+    ::std::optional<augmented_stream> user_dstream;
 
     /* By default, the finalize operation is blocking, unless user provided
      * a stream when creating the context */

--- a/cudax/include/cuda/experimental/__stf/stream/stream_task.cuh
+++ b/cudax/include/cuda/experimental/__stf/stream/stream_task.cuh
@@ -107,7 +107,7 @@ public:
     // We don't need to find a stream from the pool in this case
     automatic_stream = false;
     // -1 identifies streams which are not from our internal pool
-    dstream = decorated_stream(s);
+    dstream = augmented_stream(s);
     return *this;
   }
 
@@ -154,11 +154,11 @@ public:
             if (e->outbound_deps == 0)
             {
               auto se                    = reserved::handle<stream_and_event>(e, reserved::use_static_cast);
-              decorated_stream candidate = se->get_decorated_stream();
+              augmented_stream candidate = se->get_augmented_stream();
 
               if (candidate.id != k_no_stream_id)
               {
-                for (const decorated_stream& pool_s : pool)
+                for (const augmented_stream& pool_s : pool)
                 {
                   if (candidate.id == pool_s.id)
                   {
@@ -385,7 +385,7 @@ public:
 
 private:
   // Make all streams depend on streams[0]
-  static void insert_dependencies(::std::vector<decorated_stream>& streams)
+  static void insert_dependencies(::std::vector<augmented_stream>& streams)
   {
     if (streams.size() < 2)
     {
@@ -443,8 +443,8 @@ private:
   bool automatic_stream = true; // `true` if the stream is automatically fetched from the internal pool
 
   // Stream and their unique id (if applicable)
-  decorated_stream dstream;
-  ::std::vector<decorated_stream> stream_grid;
+  augmented_stream dstream;
+  ::std::vector<augmented_stream> stream_grid;
 
   // TODO rename to submitted_ops
   stream_async_op submitted_events;

--- a/cudax/test/stf/cpp/test_pick_stream.cu
+++ b/cudax/test/stf/cpp/test_pick_stream.cu
@@ -50,13 +50,13 @@ int main()
   }
 
   // ==========================================================================
-  // Test exec_place::getStream() - returns decorated_stream with metadata
+  // Test exec_place::getStream() - returns augmented_stream with metadata
   // ==========================================================================
   {
     exec_place place = exec_place::current_device();
 
-    // getStream() returns a decorated_stream with additional metadata
-    decorated_stream dstream = place.getStream(resources, true);
+    // getStream() returns a augmented_stream with additional metadata
+    augmented_stream dstream = place.getStream(resources, true);
     EXPECT(dstream.stream != nullptr);
     EXPECT(dstream.dev_id == current_device);
     EXPECT(get_device_from_stream(dstream.stream) == current_device);
@@ -100,7 +100,7 @@ int main()
       EXPECT(get_device_from_stream(stream) == test_device);
 
       // getStream returns more metadata
-      decorated_stream dstream = dev_place.getStream(resources, true);
+      augmented_stream dstream = dev_place.getStream(resources, true);
       EXPECT(dstream.stream != nullptr);
       EXPECT(dstream.dev_id == test_device);
     }

--- a/cudax/test/stf/cpp/test_pick_stream_green_context.cu
+++ b/cudax/test/stf/cpp/test_pick_stream_green_context.cu
@@ -111,7 +111,7 @@ int main()
     }
 
     // getStream() provides additional metadata if needed
-    decorated_stream dstream = gc_place0.getStream(resources, true);
+    augmented_stream dstream = gc_place0.getStream(resources, true);
     EXPECT(dstream.stream != nullptr);
     EXPECT(dstream.dev_id == current_device);
   }


### PR DESCRIPTION
## Summary

Pure rename: ``decorated_stream`` → ``augmented_stream`` across cudax/STF (12 files, 58 type uses + the ``get_decorated_stream`` accessor).

The struct bundles a ``cudaStream_t`` with its pre-resolved driver identity (``cuStreamGetId``) and its home device, so downstream STF -- the stream-reuse logic in ``stream_task``, the ``(src_id, dst_id)``-keyed sync-skip cache in ``async_resources_handle``, the stream event helpers -- can use it as a value type and as a cache key without re-paying the driver round-trip every time.

"Decorated" is technically accurate (decorator pattern) but uninformative: it doesn't tell the reader *what* the decoration is for. "Augmented" -- same family as "augmented data" / "augmented reality" -- makes the central fact explicit: this is a stream that has been *augmented* with extra, pre-computed information so it can stand in for the bare ``cudaStream_t`` in places where the bare handle alone would not be enough. The doc comment on the struct now spells this out.

### Scope

- Type: ``decorated_stream`` → ``augmented_stream``
- Accessor: ``get_decorated_stream`` → ``get_augmented_stream``
- One local variable (``decorated_s`` in ``slice.cuh``) renamed because it explicitly mirrored the type name
- Doc-comment mentions of "decorated stream" updated to match
- The ``dstream`` local-variable abbreviation used throughout STF is **left untouched on purpose**: it's a project-wide convention orthogonal to the type name, and renaming it would balloon the diff for no clarity gain

### Test plan

- [ ] CI green -- pure rename, no behavior change; if it builds, it works