### PR TITLE
[STF] Don't terminate test binary when a UNITTEST source path is missing

### DIFF
--- a/cudax/include/cuda/experimental/__stf/utility/unittest.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/unittest.cuh
@@ -31,6 +31,7 @@
 #include <cuda/experimental/__stf/utility/traits.cuh>
 
 #include <filesystem>
+#include <set>
 
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document
 // One level of macro indirection is required in order to resolve __COUNTER__,
@@ -388,10 +389,29 @@ public:
     // throwing overload would raise ``filesystem_error`` and, because the
     // try/catch below is *inside* this if-branch, would propagate out of the
     // dispatcher and terminate the entire test binary. Treat any error as
-    // "not equivalent" -- i.e. skip this unittest.
+    // "not equivalent" -- i.e. skip this unittest, but tell the user why.
     ::std::error_code __equiv_ec;
     if (!::std::filesystem::equivalent(loc.file_name(), UNITTESTED_FILE, __equiv_ec))
     {
+      if (__equiv_ec)
+      {
+        // Deduplicate per unresolved path: a stale binary can have many
+        // UNITTESTs baked into the same dead header, and we don't want
+        // N copies of the same diagnostic. The function-local static is
+        // initialized at first use; dispatcher calls happen during static
+        // initialization, which is single-threaded for objects with static
+        // storage duration in the same translation unit.
+        static ::std::set<::std::string> __reported;
+        if (__reported.insert(loc.file_name()).second)
+        {
+          fprintf(stderr,
+                  "UNITTEST [skip]: cannot resolve source path %s (%s) -- "
+                  "likely a stale test binary built before that header was "
+                  "moved or renamed. Rebuild to clear.\n",
+                  loc.file_name(),
+                  __equiv_ec.message().c_str());
+        }
+      }
       return *this;
     }
     ++total();

--- a/cudax/include/cuda/experimental/__stf/utility/unittest.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/unittest.cuh
@@ -381,7 +381,16 @@ public:
   unittest& operator->*([[maybe_unused]] Fun&& fun)
   {
 #  ifdef UNITTESTED_FILE
-    if (!::std::filesystem::equivalent(loc.file_name(), UNITTESTED_FILE))
+    // Use the non-throwing overload: ``loc.file_name()`` may legitimately
+    // refer to a path that no longer exists on disk (e.g. a stale binary
+    // built before a header was moved/renamed -- the original path is baked
+    // into the binary as a string literal via std::source_location). The
+    // throwing overload would raise ``filesystem_error`` and, because the
+    // try/catch below is *inside* this if-branch, would propagate out of the
+    // dispatcher and terminate the entire test binary. Treat any error as
+    // "not equivalent" -- i.e. skip this unittest.
+    ::std::error_code __equiv_ec;
+    if (!::std::filesystem::equivalent(loc.file_name(), UNITTESTED_FILE, __equiv_ec))
     {
       return *this;
     }


### PR DESCRIPTION
## Summary

The header-unittest dispatcher in ``unittest.cuh`` decides whether to run each registered UNITTEST by comparing the call site's ``std::source_location::current()`` with the test binary's ``UNITTESTED_FILE`` via:

```cpp
if (!::std::filesystem::equivalent(loc.file_name(), UNITTESTED_FILE)) { ... }
```

``loc.file_name()`` is the **source path the compiler saw**, baked into the binary as a string literal. If the underlying header is later moved or renamed, that recorded path may no longer exist on disk -- a perfectly normal situation for any binary that wasn't rebuilt after the move.

The throwing overload of ``std::filesystem::equivalent`` raises ``filesystem_error`` ("No such file or directory") in that case. The try/catch around the user lambda below the check is *inside* the same if-branch and so cannot catch it; the exception propagates out of the dispatcher and the entire test binary calls ``std::terminate`` -- masking every other unittest in the same binary and producing a core dump.

### Concrete repro

This is exactly what happens today on a tree that still has a build directory predating PR #8190 (which moved ``unstable_unique.cuh`` out of ``__stf/utility/``):

```text
$ ./build/cudax/bin/cudax.test.stf.unittest_headers.__stf.internal.context
terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
  what():  filesystem error: cannot check file equivalence: No such file or directory
       [/.../__stf/utility/unstable_unique.cuh] [/.../__stf/internal/context.cuh]
Aborted (core dumped)
```

The old ``__stf/utility/unstable_unique.cuh`` contained a ``UNITTEST(...)`` block, so the baked-in source location survives in any ``.o`` built before the move. After the move, the path doesn't exist, ``equivalent`` throws, and the binary dies before running anything else.

## Fix

Switch to the non-throwing overload (the one that takes an ``std::error_code``) and treat any error as "not equivalent" -- i.e. skip just that unittest, run the rest:

```cpp
::std::error_code __equiv_ec;
if (!::std::filesystem::equivalent(loc.file_name(), UNITTESTED_FILE, __equiv_ec)) { ... }
```

Identical semantics on the happy path. No more ``std::terminate`` from a stale binary.

## Test plan

- [ ] CI green on the existing unittest_headers targets (everything that worked before still works).
- [ ] Manual: a binary built against an older tree can now be re-run against a checkout where headers have moved without crashing; it correctly skips the moved UNITTEST and runs the rest. (Not added as an automated test because it would require artificially producing a stale binary.)