### PR TITLE
[cudax] Make `lane_mask` part of the mapping result

### DIFF
--- a/cudax/include/cuda/experimental/__group/concepts.cuh
+++ b/cudax/include/cuda/experimental/__group/concepts.cuh
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/__fwd/hierarchy.h>
+#include <cuda/__warp/lane_mask.h>
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__concepts/same_as.h>
 #include <cuda/std/__type_traits/is_copy_constructible.h>
@@ -55,6 +56,7 @@ _CCCL_CONCEPT __group_mapping_result = _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __v
   _Same_as(::cuda::std::size_t) _Tp::static_count(),
   _Same_as(unsigned) __v.count(),
   _Same_as(unsigned) __v.rank(),
+  _Same_as(::cuda::device::lane_mask) __v.lane_mask(),
   _Same_as(bool) _Tp::is_always_exhaustive(),
   _Same_as(bool) _Tp::is_always_contiguous());
 } // namespace cuda::experimental

--- a/cudax/include/cuda/experimental/__group/group.cuh
+++ b/cudax/include/cuda/experimental/__group/group.cuh
@@ -27,6 +27,7 @@
 #include <cuda/__hierarchy/queries/rank.h>
 #include <cuda/barrier>
 #include <cuda/hierarchy>
+#include <cuda/std/__bit/popcount.h>
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__limits/numeric_limits.h>
 #include <cuda/std/__type_traits/is_constructible.h>
@@ -71,7 +72,8 @@ class group
       1,
       0,
       ::cuda::experimental::__count_query_group<unsigned, _Unit>(__parent),
-      ::cuda::experimental::__rank_query_group<unsigned, _Unit>(__parent)};
+      ::cuda::experimental::__rank_query_group<unsigned, _Unit>(__parent),
+      __parent.__mapping_result().lane_mask()};
   }
 
   using _ParentMappingResult = typename _ParentGroup::__mapping_result_type;
@@ -96,6 +98,11 @@ class group
     {
       _CCCL_ASSERT(__mapping_result.group_rank() < __mapping_result.group_count(), "invalid group rank");
       _CCCL_ASSERT(__mapping_result.rank() < __mapping_result.count(), "invalid rank");
+      _CCCL_ASSERT(
+        (__mapping_result.lane_mask() & ::cuda::device::lane_mask::this_lane()) != ::cuda::device::lane_mask::none(),
+        "invalid lane mask - this lane must be contained in the lane mask");
+      _CCCL_ASSERT(::cuda::std::popcount(__mapping_result.lane_mask().value()) <= __mapping_result.count(),
+                   "invalid lane mask - too many lanes are set in the lane mask");
     }
     return __mapping_result;
   }
@@ -113,7 +120,7 @@ class group
     {
       if (!__parent.__mapping_result().is_valid())
       {
-        return _MappingResult::invalid();
+        return _SynchronizerInstance::invalid();
       }
     }
     return __synchronizer.make_instance(_Unit{}, __parent, __mapping, __mapping_result);

--- a/cudax/include/cuda/experimental/__group/mapping/group_as.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/group_as.cuh
@@ -159,8 +159,13 @@ public:
       const auto __i_count = count(__i);
       if (__prev_unit_rank < __sum + __i_count)
       {
-        return _MappingResult{
-          __ngroups, __prev_mapping_result.group_rank() * __curr_ngroups + __i, __i_count, __prev_unit_rank - __sum};
+        const auto __group_rank = __prev_mapping_result.group_rank() * __curr_ngroups + __i;
+        const auto __n          = __i_count;
+        const auto __rank       = __prev_unit_rank - __sum;
+        const auto __lane_mask =
+          ::cuda::experimental::__make_lane_mask_for_n<_PrevMappingResult::is_always_contiguous()>(
+            __prev_mapping_result.lane_mask(), __n, __rank);
+        return _MappingResult{__ngroups, __group_rank, __n, __rank, __lane_mask};
       }
       __sum += __i_count;
     }
@@ -278,8 +283,13 @@ public:
       const auto __i_count = count(__i);
       if (__prev_unit_rank < __sum + __i_count)
       {
-        return _MappingResult{
-          __ngroups, __prev_mapping_result.group_rank() * __curr_ngroups + __i, __i_count, __prev_unit_rank - __sum};
+        const auto __group_rank = __prev_mapping_result.group_rank() * __curr_ngroups + __i;
+        const auto __n          = __i_count;
+        const auto __rank       = __prev_unit_rank - __sum;
+        const auto __lane_mask =
+          ::cuda::experimental::__make_lane_mask_for_n<_PrevMappingResult::is_always_contiguous()>(
+            __prev_mapping_result.lane_mask(), __n, __rank);
+        return _MappingResult{__ngroups, __group_rank, __n, __rank, __lane_mask};
       }
       __sum += __i_count;
     }

--- a/cudax/include/cuda/experimental/__group/mapping/group_by.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/group_by.cuh
@@ -130,11 +130,13 @@ public:
         return _MappingResult::invalid_with_group_count(__ngroups);
       }
     }
-    return _MappingResult{
-      __ngroups,
-      __prev_mapping_result.group_rank() * __curr_ngroups + __curr_group_rank,
-      count(),
-      __prev_unit_rank % count()};
+
+    const auto __group_rank = __prev_mapping_result.group_rank() * __curr_ngroups + __curr_group_rank;
+    const auto __n          = count();
+    const auto __rank       = __prev_unit_rank % __n;
+    const auto __lane_mask  = ::cuda::experimental::__make_lane_mask_for_n<_PrevMappingResult::is_always_contiguous()>(
+      __prev_mapping_result.lane_mask(), __n, __rank);
+    return _MappingResult{__ngroups, __group_rank, __n, __rank, __lane_mask};
   }
 };
 
@@ -206,11 +208,13 @@ public:
         return _MappingResult::invalid_with_group_count(__ngroups);
       }
     }
-    return _MappingResult{
-      __ngroups,
-      __prev_mapping_result.group_rank() * __curr_ngroups + __curr_group_rank,
-      __count_,
-      __prev_unit_rank % __count_};
+
+    const auto __group_rank = __prev_mapping_result.group_rank() * __curr_ngroups + __curr_group_rank;
+    const auto __n          = __count_;
+    const auto __rank       = __prev_unit_rank % __count_;
+    const auto __lane_mask  = ::cuda::experimental::__make_lane_mask_for_n<_PrevMappingResult::is_always_contiguous()>(
+      __prev_mapping_result.lane_mask(), __n, __rank);
+    return _MappingResult{__ngroups, __group_rank, __n, __rank, __lane_mask};
   }
 };
 

--- a/cudax/include/cuda/experimental/__group/mapping/mapping_result.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/mapping_result.cuh
@@ -21,6 +21,8 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/__warp/lane_mask.h>
+#include <cuda/std/__bit/popcount.h>
 #include <cuda/std/__cstddef/types.h>
 #include <cuda/std/__fwd/span.h>
 
@@ -41,16 +43,25 @@ struct __mapping_result
   unsigned __group_rank_;
   unsigned __count_;
   unsigned __rank_;
+  ::cuda::device::lane_mask __lane_mask_;
 
   [[nodiscard]] _CCCL_DEVICE_API static constexpr __mapping_result invalid() noexcept
   {
-    return {__invalid_count_or_rank, __invalid_count_or_rank, __invalid_count_or_rank, __invalid_count_or_rank};
+    return {__invalid_count_or_rank,
+            __invalid_count_or_rank,
+            __invalid_count_or_rank,
+            __invalid_count_or_rank,
+            ::cuda::device::lane_mask::none()};
   }
 
   [[nodiscard]] _CCCL_DEVICE_API static constexpr __mapping_result
   invalid_with_group_count(unsigned __group_count) noexcept
   {
-    return {__group_count, __invalid_count_or_rank, __invalid_count_or_rank, __invalid_count_or_rank};
+    return {__group_count,
+            __invalid_count_or_rank,
+            __invalid_count_or_rank,
+            __invalid_count_or_rank,
+            ::cuda::device::lane_mask::none()};
   }
 
   [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_group_count() noexcept
@@ -114,6 +125,15 @@ struct __mapping_result
     return __rank_;
   }
 
+  [[nodiscard]] _CCCL_DEVICE_API ::cuda::device::lane_mask lane_mask() const noexcept
+  {
+    if constexpr (!_IsExhaustive)
+    {
+      _CCCL_ASSERT(is_valid(), "getting lane mask of thread that is not part of the group is UB");
+    }
+    return __lane_mask_;
+  }
+
   [[nodiscard]] _CCCL_DEVICE_API bool is_valid() const noexcept
   {
     if constexpr (_IsExhaustive)
@@ -136,6 +156,58 @@ struct __mapping_result
     return _IsContiguous;
   }
 };
+
+template <bool _IsContiguous>
+[[nodiscard]] _CCCL_DEVICE_API inline ::cuda::device::lane_mask
+__make_lane_mask_for_n(::cuda::device::lane_mask __prev_lane_mask, unsigned __n, unsigned __rank) noexcept
+{
+  if constexpr (_IsContiguous)
+  {
+    auto __lane_mask  = __prev_lane_mask;
+    const auto __lane = ::cuda::ptx::get_sreg_laneid();
+
+    if (__lane > __rank)
+    {
+      __lane_mask &= ::cuda::device::lane_mask::all() << (__lane - __rank);
+    }
+    if (__lane + (__n - __rank) < 32)
+    {
+      __lane_mask &= ::cuda::device::lane_mask::all() >> (32 - __lane - (__n - __rank));
+    }
+    return __lane_mask;
+  }
+  else
+  {
+    auto __lane_mask = ::cuda::device::lane_mask::this_lane();
+
+    const auto __less_mask = __prev_lane_mask & ::cuda::device::lane_mask::all_less();
+    const auto __nless     = ::cuda::std::popcount(__less_mask.value());
+    if (__nless > __rank)
+    {
+      const auto __nless_to_remove = __nless - __rank;
+      const auto __last_to_remove  = ::__fns(__less_mask.value(), 0, __nless_to_remove);
+      __lane_mask |= ::cuda::device::lane_mask{__less_mask.value() & (~0u << (__last_to_remove + 1))};
+    }
+    else
+    {
+      __lane_mask |= __less_mask;
+    }
+
+    const auto __greater_mask = __prev_lane_mask & ::cuda::device::lane_mask::all_greater();
+    const auto __ngreater     = ::cuda::std::popcount(__greater_mask.value());
+    if (__rank + __ngreater >= __n)
+    {
+      const auto __ngreater_to_keep = __n - __rank;
+      const auto __first_to_remove  = ::__fns(__greater_mask.value(), 0, __ngreater_to_keep);
+      __lane_mask |= ::cuda::device::lane_mask{__greater_mask.value() & ((1u << __first_to_remove) - 1u)};
+    }
+    else
+    {
+      __lane_mask |= __greater_mask;
+    }
+    return __lane_mask;
+  }
+}
 } // namespace cuda::experimental
 
 #endif // !_CCCL_DOXYGEN_INVOKED

--- a/cudax/include/cuda/experimental/__group/synchronizer/lane_synchronizer.cuh
+++ b/cudax/include/cuda/experimental/__group/synchronizer/lane_synchronizer.cuh
@@ -23,6 +23,7 @@
 
 #include <cuda/__cmath/pow2.h>
 #include <cuda/hierarchy>
+#include <cuda/std/__bit/popcount.h>
 #include <cuda/std/__cstddef/types.h>
 #include <cuda/std/__fwd/span.h>
 #include <cuda/std/__type_traits/is_same.h>
@@ -48,60 +49,36 @@ class lane_synchronizer
 public:
   struct __synchronizer_instance
   {
-    unsigned __lane_mask_;
-
     [[nodiscard]] _CCCL_DEVICE_API static __synchronizer_instance invalid() noexcept
     {
-      return {0u};
+      return {};
     }
 
     template <class _MappingResult>
-    _CCCL_DEVICE_API void do_sync(const _MappingResult&, const lane_synchronizer&) const noexcept
+    _CCCL_DEVICE_API void do_sync(const _MappingResult& __mapping_result, const lane_synchronizer&) const noexcept
     {
-      ::__syncwarp(__lane_mask_);
+      ::__syncwarp(__mapping_result.lane_mask().value());
     }
 
     template <class _MappingResult>
-    _CCCL_DEVICE_API void do_sync_aligned(const _MappingResult&, const lane_synchronizer&) const noexcept
+    _CCCL_DEVICE_API void
+    do_sync_aligned(const _MappingResult& __mapping_result, const lane_synchronizer&) const noexcept
     {
-      ::__syncwarp(__lane_mask_);
+      ::__syncwarp(__mapping_result.lane_mask().value());
     }
   };
 
   _CCCL_HIDE_FROM_ABI explicit lane_synchronizer() = default;
 
-  // todo(dabayer): Rewrite this function to support groups made from groups. Might need to change the compile-time
-  // parameters.
-  template <class _Unit, class _ParentGroup, ::cuda::std::size_t _Np, class _MappingResult>
+  template <class _Unit, class _ParentGroup, class _Mapping, class _MappingResult>
   [[nodiscard]] _CCCL_DEVICE_API __synchronizer_instance make_instance(
-    const _Unit&, const _ParentGroup&, const group_by<_Np>&, const _MappingResult& __mapping_result) const noexcept
+    const _Unit&, const _ParentGroup&, const _Mapping&, const _MappingResult& __mapping_result) const noexcept
   {
     static_assert(::cuda::std::is_same_v<_Unit, thread_level>, "_Unit must be cuda::thread_level");
     static_assert(__group_mapping_result<_MappingResult>);
-
-    // If the thread is not part of the newly created group, return an invalid instance.
-    if constexpr (!_MappingResult::is_always_exhaustive())
-    {
-      if (!__mapping_result.is_valid())
-      {
-        return __synchronizer_instance::invalid();
-      }
-    }
-
-    if constexpr (_MappingResult::static_count() != ::cuda::std::dynamic_extent)
-    {
-      static_assert(__is_supported_count<typename _ParentGroup::level_type>(_MappingResult::static_count()),
-                    "unsupported count for cuda::lane_synchronizer");
-    }
-    else
-    {
-      _CCCL_ASSERT(__is_supported_count<typename _ParentGroup::level_type>(__mapping_result.count()),
-                   "unsupported count for cuda::lane_synchronizer");
-    }
-
-    const auto __mask  = (1u << __mapping_result.count()) - 1;
-    const auto __shift = (__mapping_result.group_rank() * __mapping_result.count()) % 32;
-    return {__mask << __shift};
+    _CCCL_ASSERT(::cuda::std::popcount(__mapping_result.lane_mask().value()) == __mapping_result.count(),
+                 "lane_synchronizer can only synchronize units within the same warp");
+    return {};
   }
 };
 } // namespace cuda::experimental

--- a/cudax/include/cuda/experimental/__group/this_group.cuh
+++ b/cudax/include/cuda/experimental/__group/this_group.cuh
@@ -21,6 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/__warp/lane_mask.h>
 #include <cuda/hierarchy>
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__limits/numeric_limits.h>
@@ -78,6 +79,7 @@ _CCCL_DEVICE_API void __cluster_sync() noexcept
 }
 #  endif // _CCCL_CUDA_COMPILATION()
 
+template <class _Level>
 struct __this_mapping_result
 {
   [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_group_count() noexcept
@@ -110,6 +112,18 @@ struct __this_mapping_result
     return 0;
   }
 
+  [[nodiscard]] _CCCL_DEVICE_API ::cuda::device::lane_mask lane_mask() const noexcept
+  {
+    if constexpr (::cuda::std::is_same_v<_Level, thread_level>)
+    {
+      return ::cuda::device::lane_mask::this_lane();
+    }
+    else
+    {
+      return ::cuda::device::lane_mask::all();
+    }
+  }
+
   [[nodiscard]] _CCCL_DEVICE_API bool is_valid() const noexcept
   {
     return true;
@@ -136,7 +150,7 @@ class __this_group_base
   static_assert(__is_hierarchy_v<_Hierarchy>);
 
 protected:
-  using __mapping_result_type = __this_mapping_result;
+  using __mapping_result_type = __this_mapping_result<_Level>;
 
   _Hierarchy __hier_;
 

--- a/cudax/test/common/group_testing.cuh
+++ b/cudax/test/common/group_testing.cuh
@@ -14,6 +14,7 @@
 #include <cuda/barrier>
 #include <cuda/std/cstddef>
 #include <cuda/std/type_traits>
+#include <cuda/warp>
 
 #include <cuda/experimental/group.cuh>
 
@@ -75,6 +76,11 @@ struct ThreadsInWarpMappingResult
   __device__ unsigned rank() const
   {
     return cuda::gpu_thread.rank_as<unsigned>(cuda::warp);
+  }
+
+  __device__ cuda::device::lane_mask lane_mask() const noexcept
+  {
+    return cuda::device::lane_mask::all();
   }
 
   __device__ bool is_valid() const

--- a/cudax/test/group/mapping/composite_mapping.cu
+++ b/cudax/test/group/mapping/composite_mapping.cu
@@ -17,6 +17,7 @@
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
 #include <cuda/stream>
+#include <cuda/warp>
 
 #include <cuda/experimental/group.cuh>
 
@@ -80,6 +81,9 @@ __device__ void test_composite_mapping(const Mapping1& mapping1, const Mapping2&
     static_assert(Result::static_count() == cuda::std::dynamic_extent);
     CHECK(result.count() == ((rank_in_warp % 4 > 0) ? 3 : 1));
     CHECK(result.rank() == ((rank_in_warp % 4 > 0) ? (rank_in_warp % 4 - 1) : 0));
+
+    const auto lane_mask_ref = ((rank_in_warp % 4 > 0) ? 0b1110u : 0b0001u) << ((rank_in_warp / 4) * 4);
+    CHECK(result.lane_mask() == cuda::device::lane_mask{lane_mask_ref});
 
     CHECK(result.is_valid());
     static_assert(Result::is_always_exhaustive());

--- a/cudax/test/group/mapping/group_as.cu
+++ b/cudax/test/group/mapping/group_as.cu
@@ -16,6 +16,7 @@
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
 #include <cuda/stream>
+#include <cuda/warp>
 
 #include <cuda/experimental/group.cuh>
 
@@ -133,6 +134,10 @@ __device__ void test_group_as(Config config)
       CHECK(result.count() == ns[group_rank_ref]);
       CHECK(result.rank() == rank_ref);
 
+      const auto lane_mask_ref =
+        (ns[group_rank_ref] < 32) ? ((1u << ns[group_rank_ref]) - 1) << group_starts[group_rank_ref] : ~0;
+      CHECK(result.lane_mask() == cuda::device::lane_mask{lane_mask_ref});
+
       CHECK(result.is_valid());
       static_assert(Result::is_always_exhaustive());
       static_assert(Result::is_always_contiguous());
@@ -229,6 +234,10 @@ __device__ void test_group_as(Config config)
       static_assert(Result::static_count() == cuda::std::dynamic_extent);
       CHECK(result.count() == ns[group_rank_ref]);
       CHECK(result.rank() == rank_ref);
+
+      const auto lane_mask_ref =
+        (ns[group_rank_ref] < 32) ? ((1u << ns[group_rank_ref]) - 1) << group_starts[group_rank_ref] : ~0;
+      CHECK(result.lane_mask() == cuda::device::lane_mask{lane_mask_ref});
 
       CHECK(result.is_valid());
       static_assert(Result::is_always_exhaustive());
@@ -356,6 +365,10 @@ __device__ void test_group_as_non_exhaustive(Config config)
 
         CHECK(result.count() == ns[group_rank_ref]);
         CHECK(result.rank() == rank_ref);
+
+        const auto lane_mask_ref =
+          (ns[group_rank_ref] < 32) ? ((1u << ns[group_rank_ref]) - 1) << group_starts[group_rank_ref] : ~0;
+        CHECK(result.lane_mask() == cuda::device::lane_mask{lane_mask_ref});
       }
     }
   }
@@ -458,6 +471,10 @@ __device__ void test_group_as_non_exhaustive(Config config)
 
         CHECK(result.count() == ns[group_rank_ref]);
         CHECK(result.rank() == rank_ref);
+
+        const auto lane_mask_ref =
+          (ns[group_rank_ref] < 32) ? ((1u << ns[group_rank_ref]) - 1) << group_starts[group_rank_ref] : ~0;
+        CHECK(result.lane_mask() == cuda::device::lane_mask{lane_mask_ref});
       }
     }
   }

--- a/cudax/test/group/mapping/group_by.cu
+++ b/cudax/test/group/mapping/group_by.cu
@@ -15,6 +15,7 @@
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
 #include <cuda/stream>
+#include <cuda/warp>
 
 #include <cuda/experimental/group.cuh>
 
@@ -88,6 +89,9 @@ __device__ void test_group_by(Config config)
       CHECK(result.count() == N);
       CHECK(result.rank() == cuda::gpu_thread.rank(cuda::warp) % N);
 
+      const auto lane_mask_ref = ((N < 32) ? ((1u << N) - 1) : ~0u) << ((cuda::gpu_thread.rank(cuda::warp) / N) * N);
+      CHECK(result.lane_mask() == cuda::device::lane_mask{lane_mask_ref});
+
       CHECK(result.is_valid());
       static_assert(Result::is_always_exhaustive());
       static_assert(Result::is_always_contiguous());
@@ -157,6 +161,9 @@ __device__ void test_group_by(Config config)
       static_assert(Result::static_count() == cuda::std::dynamic_extent);
       CHECK(result.count() == N);
       CHECK(result.rank() == cuda::gpu_thread.rank(cuda::warp) % N);
+
+      const auto lane_mask_ref = ((N < 32) ? ((1u << N) - 1) : ~0u) << ((cuda::gpu_thread.rank(cuda::warp) / N) * N);
+      CHECK(result.lane_mask() == cuda::device::lane_mask{lane_mask_ref});
 
       CHECK(result.is_valid());
       static_assert(Result::is_always_exhaustive());
@@ -238,6 +245,9 @@ __device__ void test_group_by_non_exhaustive(Config config)
 
         CHECK(result.count() == N);
         CHECK(result.rank() == cuda::gpu_thread.rank(cuda::warp) % N);
+
+        const auto lane_mask_ref = ((N < 32) ? ((1u << N) - 1) : ~0u) << ((cuda::gpu_thread.rank(cuda::warp) / N) * N);
+        CHECK(result.lane_mask() == cuda::device::lane_mask{lane_mask_ref});
       }
     }
   }
@@ -313,6 +323,9 @@ __device__ void test_group_by_non_exhaustive(Config config)
 
         CHECK(result.count() == N);
         CHECK(result.rank() == cuda::gpu_thread.rank(cuda::warp) % N);
+
+        const auto lane_mask_ref = ((N < 32) ? ((1u << N) - 1) : ~0u) << ((cuda::gpu_thread.rank(cuda::warp) / N) * N);
+        CHECK(result.lane_mask() == cuda::device::lane_mask{lane_mask_ref});
       }
     }
   }

--- a/cudax/test/group/mapping/identity_mapping.cu
+++ b/cudax/test/group/mapping/identity_mapping.cu
@@ -15,6 +15,7 @@
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
 #include <cuda/stream>
+#include <cuda/warp>
 
 #include <cuda/experimental/group.cuh>
 
@@ -57,6 +58,8 @@ __device__ void test_identity_mapping(Config config)
     static_assert(Result::static_count() == ThreadsInWarpMappingResult::static_count());
     CHECK(result.count() == prev_mapping_result.count());
     CHECK(result.rank() == prev_mapping_result.rank());
+
+    CHECK(result.lane_mask() == prev_mapping_result.lane_mask());
 
     CHECK(result.is_valid() == prev_mapping_result.is_valid());
     static_assert(Result::is_always_exhaustive() == ThreadsInWarpMappingResult::is_always_exhaustive());

--- a/cudax/test/group/synchronizer/lane_synchronizer.cu
+++ b/cudax/test/group/synchronizer/lane_synchronizer.cu
@@ -42,11 +42,6 @@ __device__ void test_lane_synchronizer(const Level& level, Config config)
     const auto synchronizer_instance =
       synchronizer.make_instance(cuda::gpu_thread, parent_group, mapping, mapping_result);
 
-    const auto this_lane_mask = cuda::ptx::get_sreg_lanemask_eq();
-    const auto another_lane_mask =
-      cuda::std::rotl(this_lane_mask, (cuda::std::countr_zero(this_lane_mask) % 2 == 0) ? 1 : -1);
-    CHECK(synchronizer_instance.__lane_mask_ == (this_lane_mask | another_lane_mask));
-
     // Test do_sync(...).
     static_assert(cuda::std::is_same_v<void, decltype(synchronizer_instance.do_sync(mapping_result, synchronizer))>);
     static_assert(noexcept(synchronizer_instance.do_sync(mapping_result, synchronizer)));


### PR DESCRIPTION
Storing lane mask only inside `lane_synchronizer` instance had several problems:
1. If threads were grouped and synchronized using `barrier_synchronizer`, there was no way to create a sub-group that would use `lane_synchronizer`, because we couldn't retrieve the lane mask.
2. There was no good way to pass lane mask computed inside the mapping to the `lane_synchronzier` instance, which made us duplicate the operations.

I solved both problems by moving the lane mask into the mapping result. Now, just from the mapping result, the threads are aware which threads from the same group are inside the same warp. I believe it will be useful for some other collective operations even when using `barrier_synchronizer`