### PR TITLE
[cub] Harden histogram benchmarks and add bin-by-bin verification

### DIFF
--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -46,10 +46,14 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   state.add_global_memory_writes<CounterT>(num_bins);
 
   caching_allocator_t alloc;
-  // Demote persisting L2 lines outside the timed window so that no
-  // cudaAccessPolicyWindow set by the dispatcher can carry across iterations.
+  // Force the persisting-L2 reservation back to 0 and demote any persisting
+  // lines outside the timed window, so neither cudaAccessPolicyWindow nor a
+  // bumped cudaLimitPersistingL2CacheSize can carry across iterations. The
+  // default reservation is 0; hardcoding 0 also clears any pollution left by
+  // a prior benchmark in the same nvbench process.
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::timer,
              [&](nvbench::launch& launch, auto& timer) {
+               cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, 0);
                cudaCtxResetPersistingL2Cache();
                timer.start();
                auto env = cub_bench_env(

--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -46,26 +46,32 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   state.add_global_memory_writes<CounterT>(num_bins);
 
   caching_allocator_t alloc;
-  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    auto env = cub_bench_env(
-      alloc,
-      launch
+  // Demote persisting L2 lines outside the timed window so that no
+  // cudaAccessPolicyWindow set by the dispatcher can carry across iterations.
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::timer,
+             [&](nvbench::launch& launch, auto& timer) {
+               cudaCtxResetPersistingL2Cache();
+               timer.start();
+               auto env = cub_bench_env(
+                 alloc,
+                 launch
 #if !TUNE_BASE
-      ,
-      cuda::execution::tune(bench_policy_selector<key_t, 1, 1>{})
+                 ,
+                 cuda::execution::tune(bench_policy_selector<key_t, 1, 1>{})
 #endif // !TUNE_BASE
-    );
-    _CCCL_TRY_CUDA_API(
-      cub::DeviceHistogram::HistogramEven,
-      "HistogramEven failed",
-      d_input,
-      d_histogram,
-      num_levels,
-      lower_level,
-      upper_level,
-      static_cast<OffsetT>(elements),
-      env);
-  });
+               );
+               _CCCL_TRY_CUDA_API(
+                 cub::DeviceHistogram::HistogramEven,
+                 "HistogramEven failed",
+                 d_input,
+                 d_histogram,
+                 num_levels,
+                 lower_level,
+                 upper_level,
+                 static_cast<OffsetT>(elements),
+                 env);
+               timer.stop();
+             });
 }
 
 using counter_types     = nvbench::type_list<int32_t>;
@@ -80,6 +86,6 @@ using sample_types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t, float
 NVBENCH_BENCH_TYPES(even, NVBENCH_TYPE_AXES(sample_types, counter_types, some_offset_types))
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
+  .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
   .add_int64_axis("Bins", {32, 128, 2048, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -22,17 +22,18 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   const auto num_bins  = state.get_int64("Bins");
   const int num_levels = static_cast<int>(num_bins) + 1;
 
-  // Skip invalid configurations where LevelT (= SampleT) cannot represent the number of bins
-  if constexpr (cuda::std::is_integral_v<SampleT>)
+  // Skip invalid configurations where the SampleT range can't hold enough
+  // strictly-monotonic levels: bins + 1 levels require bins + 1 distinct
+  // SampleT values, and the bench's `[get_lower_level, get_upper_level]`
+  // range spans at most `max_representable_bins<SampleT>() + 1` distinct
+  // values.
+  if (num_bins > max_representable_bins<SampleT>())
   {
-    if (num_bins > static_cast<int64_t>(cuda::std::numeric_limits<SampleT>::max()))
-    {
-      state.skip("Number of bins exceeds what LevelT (= SampleT) can represent");
-      return;
-    }
+    state.skip("Number of bins exceeds what SampleT can represent");
+    return;
   }
 
-  const SampleT lower_level = 0;
+  const SampleT lower_level = get_lower_level<SampleT>();
   const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
 
   thrust::device_vector<SampleT> input = generate(elements, entropy, lower_level, upper_level);

--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -87,5 +87,5 @@ NVBENCH_BENCH_TYPES(even, NVBENCH_TYPE_AXES(sample_types, counter_types, some_of
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
-  .add_int64_axis("Bins", {32, 128, 2048, 2097152})
+  .add_int64_axis("Bins", {32, 100, 2000, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -4,6 +4,7 @@
 #include <nvbench_helper.cuh>
 
 #include "histogram_common.cuh"
+#include "histogram_inputs.cuh"
 
 // %RANGE% TUNE_ITEMS ipt 4:28:1
 // %RANGE% TUNE_THREADS tpb 128:1024:32
@@ -17,7 +18,7 @@
 template <typename SampleT, typename CounterT, typename OffsetT>
 static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, OffsetT>)
 {
-  const auto entropy   = str_to_entropy(state.get_string("Entropy"));
+  const auto shape     = parse_input_shape(state.get_string("InputShape"));
   const auto elements  = state.get_int64("Elements{io}");
   const auto num_bins  = state.get_int64("Bins");
   const int num_levels = static_cast<int>(num_bins) + 1;
@@ -36,7 +37,8 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   const SampleT lower_level = get_lower_level<SampleT>();
   const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
 
-  thrust::device_vector<SampleT> input = generate(elements, entropy, lower_level, upper_level);
+  thrust::device_vector<SampleT> input =
+    generate_histogram_input_even<SampleT>(shape, elements, static_cast<int>(num_bins), lower_level, upper_level);
   thrust::device_vector<CounterT> hist(num_bins);
 
   SampleT* d_input      = thrust::raw_pointer_cast(input.data());
@@ -145,4 +147,18 @@ NVBENCH_BENCH_TYPES(even, NVBENCH_TYPE_AXES(sample_types, counter_types, some_of
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
   .add_int64_axis("Bins", {32, 100, 2000, 16384, 60000, 2097152})
-  .add_string_axis("Entropy", {"0.201", "1.000"});
+  // One `concentrated` shape swept across entropy (1.0=uniform, 0.5=spike,
+  // 0.0=constant) plus the multi-hot and cache-adversarial shapes. Each value
+  // may carry an inline knob as "name:value"; see histogram_inputs.cuh.
+  .add_string_axis(
+    "InputShape",
+    {"concentrated:1.0",
+     "concentrated:0.5",
+     "concentrated:0.0",
+     "powerlaw:0.5",
+     "zipf:1.0",
+     "hash_synonym",
+     "capacity_cliff",
+     "stale_resident",
+     "temporal_phases",
+     "strided_sweep"});

--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -91,5 +91,5 @@ NVBENCH_BENCH_TYPES(even, NVBENCH_TYPE_AXES(sample_types, counter_types, some_of
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
-  .add_int64_axis("Bins", {32, 100, 2000, 2097152})
+  .add_int64_axis("Bins", {32, 100, 2000, 16384, 60000, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -45,7 +45,59 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   state.add_global_memory_reads<SampleT>(elements);
   state.add_global_memory_writes<CounterT>(num_bins);
 
+  // Warmup + correctness check: run HistogramEven once outside `state.exec`,
+  // checking the dispatch return code, then verify the produced histogram
+  // bin-by-bin against an independent reference. A failure here throws
+  // before any timed iteration runs, so a silent dispatch failure or a
+  // sample-loss bug can't inflate the measured bandwidth. Skipped when
+  // CUB_BENCH_HISTOGRAM_VERIFY=0|false|no|off.
+  if (bench_correctness_checks_enabled())
+  {
+    thrust::fill(hist.begin(), hist.end(), CounterT{0});
+    void* d_temp_storage      = nullptr;
+    size_t temp_storage_bytes = 0;
+    bench_check_cuda(
+      cub::DeviceHistogram::HistogramEven(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_input,
+        d_histogram,
+        num_levels,
+        lower_level,
+        upper_level,
+        static_cast<OffsetT>(elements)),
+      "warmup HistogramEven temp-size");
+    thrust::device_vector<unsigned char> warmup_tmp(temp_storage_bytes);
+    d_temp_storage = thrust::raw_pointer_cast(warmup_tmp.data());
+    bench_check_cuda(
+      cub::DeviceHistogram::HistogramEven(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_input,
+        d_histogram,
+        num_levels,
+        lower_level,
+        upper_level,
+        static_cast<OffsetT>(elements)),
+      "warmup HistogramEven");
+    bench_check_cuda(cudaDeviceSynchronize(), "warmup sync");
+
+    std::vector<thrust::device_vector<CounterT>> opt_hists_d;
+    opt_hists_d.emplace_back(std::move(hist));
+    bench_verify_histogram_even<1, 1, SampleT, CounterT, OffsetT>(
+      input,
+      opt_hists_d,
+      static_cast<OffsetT>(elements),
+      static_cast<int>(num_bins),
+      lower_level,
+      upper_level,
+      "even");
+    hist        = std::move(opt_hists_d[0]);
+    d_histogram = thrust::raw_pointer_cast(hist.data());
+  }
+
   caching_allocator_t alloc;
+
   // Force the persisting-L2 reservation back to 0 and demote any persisting
   // lines outside the timed window, so neither cudaAccessPolicyWindow nor a
   // bumped cudaLimitPersistingL2CacheSize can carry across iterations. The

--- a/cub/benchmarks/bench/histogram/histogram_common.cuh
+++ b/cub/benchmarks/bench/histogram/histogram_common.cuh
@@ -76,15 +76,20 @@ SampleT get_upper_level(OffsetT bins, OffsetT elements)
 {
   if constexpr (cuda::std::is_integral_v<SampleT>)
   {
-    if constexpr (sizeof(SampleT) < sizeof(OffsetT))
-    {
-      const SampleT max_key = ::cuda::std::numeric_limits<SampleT>::max();
-      return static_cast<SampleT>(std::min(bins, static_cast<OffsetT>(max_key)));
-    }
-    else
-    {
-      return static_cast<SampleT>(bins);
-    }
+    // Widen the upper level to ~4 * num_bins so the range bench's
+    // jittered-uniform level construction (jitter amplitude is step / 4)
+    // produces genuinely non-uniform integer levels. With the previous
+    // upper_level == num_bins, step was exactly 1 for `int32_t` / `int64_t`,
+    // the integer cast in the level loop annihilated the jitter, and the
+    // dedup-by-1 step forced the array back to perfect uniform stride —
+    // which `DispatchHistogram`'s uniform-range detection (when present)
+    // would route through the fast EVEN classify path, defeating the
+    // purpose of the range bench. Clamp to the type max when 4 * bins
+    // overflows `SampleT`; those axes already have step < 1 and the level
+    // array is degenerate regardless of jitter.
+    const int64_t max_v = static_cast<int64_t>(::cuda::std::numeric_limits<SampleT>::max());
+    const int64_t want  = static_cast<int64_t>(bins) * int64_t{4};
+    return static_cast<SampleT>(std::min(want, max_v));
   }
 
   return static_cast<SampleT>(elements);

--- a/cub/benchmarks/bench/histogram/histogram_common.cuh
+++ b/cub/benchmarks/bench/histogram/histogram_common.cuh
@@ -4,8 +4,21 @@
 #pragma once
 
 #include <cub/device/device_histogram.cuh>
+#include <cub/thread/thread_search.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/for_each.h>
+#include <thrust/host_vector.h>
+#include <thrust/iterator/counting_iterator.h>
 
 #include <cuda/std/type_traits>
+
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 #if !TUNE_BASE
 
@@ -75,4 +88,268 @@ SampleT get_upper_level(OffsetT bins, OffsetT elements)
   }
 
   return static_cast<SampleT>(elements);
+}
+
+// Bench-side correctness checks that compare the CUB histogram result
+// bin-by-bin against an independent on-device reference computed with
+// `thrust::for_each` + global `atomicAdd`. The verifier is invoked once per
+// benchmark cell, outside NVBench's timed region, so it does not contribute
+// to the reported bandwidth. The reference does not share any kernels with
+// `cub::DeviceHistogram`, so a bug that leaves the optimized histogram
+// shaped correctly but counted incorrectly is still caught.
+//
+// Verification is on by default. To skip it (e.g. during a tuning sweep where
+// only relative throughput matters), set the environment variable
+// CUB_BENCH_HISTOGRAM_VERIFY to one of: 0, false, no, off (case-insensitive).
+
+inline bool bench_correctness_checks_enabled()
+{
+  static const bool enabled = []() {
+    const char* v = std::getenv("CUB_BENCH_HISTOGRAM_VERIFY");
+    if (v == nullptr)
+    {
+      return true;
+    }
+    std::string s(v);
+    for (char& c : s)
+    {
+      c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+    return !(s == "0" || s == "false" || s == "no" || s == "off");
+  }();
+  return enabled;
+}
+
+inline void bench_check_cuda(cudaError_t e, const char* what)
+{
+  if (e != cudaSuccess)
+  {
+    throw std::runtime_error(std::string{"bench correctness check: "} + what + " -> " + cudaGetErrorString(e));
+  }
+}
+
+// EVEN reference: closed-form bin index `(sample - lo) * num_bins / (hi - lo)`
+// computed in double precision, then a global `atomicAdd` per pixel per active
+// channel.
+template <int NumChannels, int NumActiveChannels, typename SampleT, typename CounterT, typename OffsetT>
+struct bench_ref_even_op
+{
+  const SampleT* d_input;
+  CounterT* d_hist[NumActiveChannels];
+  OffsetT num_pixels;
+  int num_bins;
+  SampleT lower_level;
+  SampleT upper_level;
+
+  __device__ void operator()(OffsetT pixel) const
+  {
+    if (pixel >= num_pixels)
+    {
+      return;
+    }
+
+    const double L     = static_cast<double>(lower_level);
+    const double U     = static_cast<double>(upper_level);
+    const double scale = static_cast<double>(num_bins) / (U - L);
+
+    const SampleT* px = d_input + static_cast<std::size_t>(pixel) * NumChannels;
+#pragma unroll
+    for (int c = 0; c < NumActiveChannels; ++c)
+    {
+      const SampleT s = px[c];
+      if (s < lower_level || s >= upper_level)
+      {
+        continue;
+      }
+      int bin = static_cast<int>((static_cast<double>(s) - L) * scale);
+      if (bin >= num_bins)
+      {
+        bin = num_bins - 1;
+      }
+      if (bin >= 0)
+      {
+        atomicAdd(d_hist[c] + bin, CounterT{1});
+      }
+    }
+  }
+};
+
+// RANGE reference: per-pixel `cub::UpperBound` on the per-channel level array,
+// then a global `atomicAdd`. Levels are arbitrary monotonic boundaries so the
+// closed-form EVEN index does not apply.
+template <int NumChannels, int NumActiveChannels, typename SampleT, typename CounterT, typename OffsetT>
+struct bench_ref_range_op
+{
+  const SampleT* d_input;
+  CounterT* d_hist[NumActiveChannels];
+  const SampleT* d_levels[NumActiveChannels];
+  OffsetT num_pixels;
+  int num_levels;
+
+  __device__ void operator()(OffsetT pixel) const
+  {
+    if (pixel >= num_pixels)
+    {
+      return;
+    }
+
+    const int num_bins = num_levels - 1;
+    const SampleT* px  = d_input + static_cast<std::size_t>(pixel) * NumChannels;
+
+#pragma unroll
+    for (int c = 0; c < NumActiveChannels; ++c)
+    {
+      const SampleT s = px[c];
+      const int idx   = cub::UpperBound(d_levels[c], num_levels, s);
+      const int bin   = idx - 1;
+      if (bin >= 0 && bin < num_bins)
+      {
+        atomicAdd(d_hist[c] + bin, CounterT{1});
+      }
+    }
+  }
+};
+
+template <typename CounterT>
+void bench_compare_histograms(
+  const std::vector<thrust::host_vector<CounterT>>& opt_hists,
+  const std::vector<thrust::host_vector<CounterT>>& ref_hists,
+  const char* bench_label,
+  int num_channels)
+{
+  for (int c = 0; c < num_channels; ++c)
+  {
+    const auto& opt = opt_hists[c];
+    const auto& ref = ref_hists[c];
+    if (opt.size() != ref.size())
+    {
+      throw std::runtime_error(std::string{"bench correctness check ["} + bench_label + "]: channel "
+                               + std::to_string(c) + " size mismatch: opt=" + std::to_string(opt.size())
+                               + " ref=" + std::to_string(ref.size()));
+    }
+    long long opt_total = 0;
+    long long ref_total = 0;
+    int first_mismatch  = -1;
+    for (std::size_t b = 0; b < opt.size(); ++b)
+    {
+      opt_total += static_cast<long long>(opt[b]);
+      ref_total += static_cast<long long>(ref[b]);
+      if (first_mismatch < 0 && opt[b] != ref[b])
+      {
+        first_mismatch = static_cast<int>(b);
+      }
+    }
+    if (opt_total != ref_total || first_mismatch >= 0)
+    {
+      char msg[512];
+      std::snprintf(
+        msg,
+        sizeof(msg),
+        "bench correctness check [%s]: channel=%d total opt=%lld ref=%lld; first mismatched bin=%d "
+        "(opt=%lld ref=%lld)",
+        bench_label,
+        c,
+        opt_total,
+        ref_total,
+        first_mismatch,
+        first_mismatch >= 0 ? static_cast<long long>(opt[first_mismatch]) : -1LL,
+        first_mismatch >= 0 ? static_cast<long long>(ref[first_mismatch]) : -1LL);
+      throw std::runtime_error(msg);
+    }
+  }
+}
+
+template <typename CounterT>
+std::vector<thrust::host_vector<CounterT>>
+bench_snapshot_histograms(const std::vector<thrust::device_vector<CounterT>>& d_hists)
+{
+  std::vector<thrust::host_vector<CounterT>> out;
+  out.reserve(d_hists.size());
+  for (const auto& d : d_hists)
+  {
+    out.emplace_back(d);
+  }
+  return out;
+}
+
+// Verifier entry point for EVEN benches. Caller passes the strided pixel-
+// major sample buffer and the per-channel optimized histograms it has
+// already produced; this function builds a per-channel reference and
+// compares bin-by-bin.
+template <int NumChannels,
+          int NumActiveChannels,
+          typename SampleT,
+          typename CounterT,
+          typename OffsetT>
+void bench_verify_histogram_even(
+  const thrust::device_vector<SampleT>& d_input,
+  const std::vector<thrust::device_vector<CounterT>>& opt_hists_d,
+  OffsetT num_pixels,
+  int num_bins,
+  SampleT lower_level,
+  SampleT upper_level,
+  const char* bench_label)
+{
+  static_assert(NumActiveChannels >= 1 && NumActiveChannels <= NumChannels);
+
+  std::vector<thrust::device_vector<CounterT>> ref_hists_d(NumActiveChannels);
+  bench_ref_even_op<NumChannels, NumActiveChannels, SampleT, CounterT, OffsetT> op{};
+  op.d_input     = thrust::raw_pointer_cast(d_input.data());
+  op.num_pixels  = num_pixels;
+  op.num_bins    = num_bins;
+  op.lower_level = lower_level;
+  op.upper_level = upper_level;
+  for (int c = 0; c < NumActiveChannels; ++c)
+  {
+    ref_hists_d[c].assign(num_bins, CounterT{0});
+    op.d_hist[c] = thrust::raw_pointer_cast(ref_hists_d[c].data());
+  }
+
+  thrust::for_each(
+    thrust::counting_iterator<OffsetT>(0), thrust::counting_iterator<OffsetT>(num_pixels), op);
+  bench_check_cuda(cudaGetLastError(), "ref-even launch");
+  bench_check_cuda(cudaDeviceSynchronize(), "ref-even sync");
+
+  const auto opt_hists = bench_snapshot_histograms(opt_hists_d);
+  const auto ref_hists = bench_snapshot_histograms(ref_hists_d);
+  bench_compare_histograms(opt_hists, ref_hists, bench_label, NumActiveChannels);
+}
+
+template <int NumChannels,
+          int NumActiveChannels,
+          typename SampleT,
+          typename CounterT,
+          typename OffsetT>
+void bench_verify_histogram_range(
+  const thrust::device_vector<SampleT>& d_input,
+  const std::vector<thrust::device_vector<CounterT>>& opt_hists_d,
+  const std::vector<thrust::device_vector<SampleT>>& d_levels_per_channel,
+  OffsetT num_pixels,
+  const char* bench_label)
+{
+  static_assert(NumActiveChannels >= 1 && NumActiveChannels <= NumChannels);
+
+  const int num_levels = static_cast<int>(d_levels_per_channel[0].size());
+  const int num_bins   = num_levels - 1;
+
+  std::vector<thrust::device_vector<CounterT>> ref_hists_d(NumActiveChannels);
+  bench_ref_range_op<NumChannels, NumActiveChannels, SampleT, CounterT, OffsetT> op{};
+  op.d_input    = thrust::raw_pointer_cast(d_input.data());
+  op.num_pixels = num_pixels;
+  op.num_levels = num_levels;
+  for (int c = 0; c < NumActiveChannels; ++c)
+  {
+    ref_hists_d[c].assign(num_bins, CounterT{0});
+    op.d_hist[c]   = thrust::raw_pointer_cast(ref_hists_d[c].data());
+    op.d_levels[c] = thrust::raw_pointer_cast(d_levels_per_channel[c].data());
+  }
+
+  thrust::for_each(
+    thrust::counting_iterator<OffsetT>(0), thrust::counting_iterator<OffsetT>(num_pixels), op);
+  bench_check_cuda(cudaGetLastError(), "ref-range launch");
+  bench_check_cuda(cudaDeviceSynchronize(), "ref-range sync");
+
+  const auto opt_hists = bench_snapshot_histograms(opt_hists_d);
+  const auto ref_hists = bench_snapshot_histograms(ref_hists_d);
+  bench_compare_histograms(opt_hists, ref_hists, bench_label, NumActiveChannels);
 }

--- a/cub/benchmarks/bench/histogram/histogram_common.cuh
+++ b/cub/benchmarks/bench/histogram/histogram_common.cuh
@@ -161,11 +161,26 @@ inline bool bench_correctness_checks_enabled()
   return enabled;
 }
 
+// A correctness-check failure MUST end the trial in a hard runtime failure, not
+// a silent skip. nvbench catches a thrown std::exception from the benchmark body
+// and merely marks the measurement `Skipped: Yes`, then exits 0 -- which lets an
+// incorrect kernel "pass" by having its failing cells silently dropped from any
+// downstream aggregation. To make a wrong result unambiguously fatal, we print
+// the diagnostic to stderr and `std::abort()`, which terminates the process with
+// a non-zero status that nvbench cannot swallow. Legitimate, expected skips
+// (e.g. row-stride overflow) use `state.skip(...)` instead and are unaffected.
+[[noreturn]] inline void bench_fatal(const std::string& msg)
+{
+  std::fprintf(stderr, "FATAL %s\n", msg.c_str());
+  std::fflush(stderr);
+  std::abort();
+}
+
 inline void bench_check_cuda(cudaError_t e, const char* what)
 {
   if (e != cudaSuccess)
   {
-    throw std::runtime_error(std::string{"bench correctness check: "} + what + " -> " + cudaGetErrorString(e));
+    bench_fatal(std::string{"bench correctness check: "} + what + " -> " + cudaGetErrorString(e));
   }
 }
 
@@ -264,9 +279,9 @@ void bench_compare_histograms(
     const auto& ref = ref_hists[c];
     if (opt.size() != ref.size())
     {
-      throw std::runtime_error(std::string{"bench correctness check ["} + bench_label + "]: channel "
-                               + std::to_string(c) + " size mismatch: opt=" + std::to_string(opt.size())
-                               + " ref=" + std::to_string(ref.size()));
+      bench_fatal(std::string{"bench correctness check ["} + bench_label + "]: channel "
+                  + std::to_string(c) + " size mismatch: opt=" + std::to_string(opt.size())
+                  + " ref=" + std::to_string(ref.size()));
     }
     long long opt_total = 0;
     long long ref_total = 0;
@@ -295,7 +310,7 @@ void bench_compare_histograms(
         first_mismatch,
         first_mismatch >= 0 ? static_cast<long long>(opt[first_mismatch]) : -1LL,
         first_mismatch >= 0 ? static_cast<long long>(ref[first_mismatch]) : -1LL);
-      throw std::runtime_error(msg);
+      bench_fatal(msg);
     }
   }
 }

--- a/cub/benchmarks/bench/histogram/histogram_common.cuh
+++ b/cub/benchmarks/bench/histogram/histogram_common.cuh
@@ -71,6 +71,22 @@ struct bench_policy_selector
 };
 #endif // !TUNE_BASE
 
+// Lower bound of the bench's level range. For signed integer SampleT we use
+// `numeric_limits<SampleT>::min()` so the level range spans the full type;
+// previously `lower_level = 0` clipped half the range, forcing a skip on
+// configurations like int8_t with bins > 127 even though the type can hold
+// 256 distinct values. For unsigned integer and floating-point SampleT,
+// `lower_level = 0` is the natural choice.
+template <class SampleT>
+SampleT get_lower_level()
+{
+  if constexpr (cuda::std::is_integral_v<SampleT> && cuda::std::is_signed_v<SampleT>)
+  {
+    return ::cuda::std::numeric_limits<SampleT>::min();
+  }
+  return SampleT{0};
+}
+
 template <class SampleT, class OffsetT>
 SampleT get_upper_level(OffsetT bins, OffsetT elements)
 {
@@ -93,6 +109,26 @@ SampleT get_upper_level(OffsetT bins, OffsetT elements)
   }
 
   return static_cast<SampleT>(elements);
+}
+
+// Maximum number of bins that can be represented by SampleT levels in this
+// bench's `[get_lower_level<SampleT>(), get_upper_level<SampleT>(...)]` range.
+// For integer SampleT this caps at the count of distinct values the type can
+// hold (`max - min`); strict-monotonic level construction needs `bins + 1`
+// distinct values. For floating-point SampleT it's effectively unbounded.
+template <class SampleT>
+int64_t max_representable_bins()
+{
+  if constexpr (cuda::std::is_integral_v<SampleT> && sizeof(SampleT) < sizeof(int64_t))
+  {
+    return static_cast<int64_t>(::cuda::std::numeric_limits<SampleT>::max())
+         - static_cast<int64_t>(::cuda::std::numeric_limits<SampleT>::min());
+  }
+  // For int64_t (and any wider type that we may add later) the bins axis tops
+  // out at ~10^6, which is many orders of magnitude below the type's range, so
+  // the skip never triggers. Avoid the int64_t overflow that
+  // `max() - min() = 2^64 - 1` would produce.
+  return ::cuda::std::numeric_limits<int64_t>::max();
 }
 
 // Bench-side correctness checks that compare the CUB histogram result

--- a/cub/benchmarks/bench/histogram/histogram_inputs.cuh
+++ b/cub/benchmarks/bench/histogram/histogram_inputs.cuh
@@ -1,0 +1,678 @@
+// SPDX-FileCopyrightText: Copyright (c) 2011-2023, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3
+
+#pragma once
+
+// Input-shape generators for the CUB histogram benchmarks.
+//
+// The legacy `generate(elements, entropy, lower, upper)` knob (bitwise-AND
+// "entropy") is non-linear, bunched at the extremes, always pins the hot bin to
+// the zero value, and cannot express multi-hot or cache-adversarial inputs.
+// This header replaces it with a set of named INPUT SHAPES that control the
+// *bin* distribution directly.
+//
+// Mechanism: every shape decides a per-element BIN index in [0, num_bins), then
+// emits a SampleT value that lands inside that bin's value interval. CUB then
+// re-derives the bin from the value, so the in-bench verifier
+// (`bench_verify_histogram_*` in histogram_common.cuh) validates the mapping
+// automatically -- we feed the verifier, never bypass it.
+//
+//   * EVEN  path: bin b owns [lower + b*w, lower + (b+1)*w), w=(upper-lower)/B.
+//                 emit the bin midpoint -> CUB's (s-lower)*B/(upper-lower) == b.
+//   * RANGE path: bin b owns [levels[b], levels[b+1]).
+//                 emit that interval's midpoint -> UpperBound(levels, s)-1 == b.
+//
+// Shapes split into i.i.d. DISTRIBUTION shapes (only the pmf differs; positions
+// are independent) and ORDERING shapes (the pathology lives in the sequence
+// order, so they are generated positionally).
+
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+#include <thrust/tabulate.h>
+
+#include <cuda/std/type_traits>
+
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Shape catalog
+// ---------------------------------------------------------------------------
+
+enum class InputShape
+{
+  concentrated,   // spike-slab family. KNOB = target normalized entropy in
+                  // [0,1]: 1.0 = uniform, 0.0 = constant (single bin), in
+                  // between = one hot bin over a uniform floor. Sweeping the
+                  // knob reproduces (and generalizes) the old Entropy sweep --
+                  // continuously, and with the hot bin scattered off zero.
+  powerlaw,       // decaying warm set (many hot bins). KNOB = target normalized
+                  // entropy in [0,1]; the rank exponent is solved to hit it.
+                  // Independent of the concentrated knob.
+  zipf,           // decaying warm set with a classic exponent. KNOB = exponent
+                  // s >= 0 (default 1.0).
+  hash_synonym,   // hot bins all collide on one cache slot. KNOB = hot share
+                  // in [0,1] (default 0.9).
+  capacity_cliff, // equiprobable active set sized around cache capacity. KNOB =
+                  // active set as a multiple of cache slots (default => slots+1,
+                  // the just-over-capacity cliff).
+  stale_resident, // cold prefix claims slots, then a hot bulk (attacks
+                  // no-evict). KNOB = prefix coverage as a multiple of cache
+                  // slots (default 1.0 => claim `slots` bins).
+  temporal_phases,// the hot bin steps to a new location across phases. KNOB =
+                  // number of phases (default 8).
+  strided_sweep,  // bin = stride*i % B (minimal temporal locality). KNOB =
+                  // stride (default a large prime).
+};
+
+// A shape plus an optional knob value. `has_knob == false` means "use the
+// shape's default". The knob's meaning is shape-specific (see the enum).
+struct ShapeSpec
+{
+  InputShape shape;
+  double knob    = 0.0;
+  bool has_knob  = false;
+};
+
+// kAdversarialCacheSlots mirrors the SMEM cuckoo-cache capacity in
+// tuning_histogram.cuh; it is a benchmark *probe* and never affects
+// correctness. TODO: wire to the policy's actual slot count rather than
+// hardcoding, so the adversarial shapes track the cache as it is tuned.
+constexpr int kAdversarialCacheSlots = 4096;
+constexpr int kHashSynonymCount      = 32; // number of colliding bins
+
+// Parse an InputShape axis value of the form "name" or "name:knob".
+//   "concentrated:1.0"    -> uniform (entropy 1.0)
+//   "concentrated:0.5"    -> a single hot bin over a floor (was "spike")
+//   "concentrated:0.0"    -> a single bin gets 100% (was "constant")
+//   "powerlaw:0.3"        -> power law at target entropy 0.3
+//   "capacity_cliff"      -> default (slots+1) cliff
+// There is deliberately ONE concentrated shape spanning uniform<->constant via
+// its entropy knob -- no separate uniform/constant/spike names.
+inline ShapeSpec parse_input_shape(const std::string& spec)
+{
+  std::string name = spec;
+  ShapeSpec out{};
+  const auto colon = spec.find(':');
+  if (colon != std::string::npos)
+  {
+    name        = spec.substr(0, colon);
+    out.knob    = std::stod(spec.substr(colon + 1));
+    out.has_knob = true;
+  }
+
+  if (name == "concentrated") { out.shape = InputShape::concentrated; }
+  else if (name == "powerlaw") { out.shape = InputShape::powerlaw; }
+  else if (name == "zipf")     { out.shape = InputShape::zipf; }
+  else if (name == "hash_synonym")    { out.shape = InputShape::hash_synonym; }
+  else if (name == "capacity_cliff")  { out.shape = InputShape::capacity_cliff; }
+  else if (name == "stale_resident")  { out.shape = InputShape::stale_resident; }
+  else if (name == "temporal_phases") { out.shape = InputShape::temporal_phases; }
+  else if (name == "strided_sweep")   { out.shape = InputShape::strided_sweep; }
+  else { throw std::runtime_error("Unknown InputShape: " + spec); }
+  return out;
+}
+
+// Resolve a knob to a concrete value, applying the shape's default when the
+// axis value did not specify one.
+inline double knob_or(const ShapeSpec& s, double default_value)
+{
+  return s.has_knob ? s.knob : default_value;
+}
+
+// A large prime > every bins-axis value; multiplying bin ranks by it modulo
+// num_bins is a bijection (a cheap fixed permutation), used to SCATTER hot bins
+// across the array so the mode is never forced to bin 0.
+constexpr uint64_t kScatterPrime = 2147483647ull; // 2^31 - 1, prime
+
+// ---------------------------------------------------------------------------
+// Per-element uniform draw: splitmix64 finalizer on a decorrelated key, mapped
+// to [0, 1). Higher quality per index than seeding a thrust engine per element.
+// ---------------------------------------------------------------------------
+__host__ __device__ inline double u01_from_hash(uint64_t x)
+{
+  x += 0x9E3779B97F4A7C15ull;
+  x = (x ^ (x >> 30)) * 0xBF58476D1CE4E5B9ull;
+  x = (x ^ (x >> 27)) * 0x94D049BB133111EBull;
+  x = x ^ (x >> 31);
+  return static_cast<double>(x >> 11) * (1.0 / 9007199254740992.0); // 2^53
+}
+
+__host__ __device__ inline uint64_t element_key(uint64_t i, uint64_t seed)
+{
+  return i * 6364136223846793005ull + 1442695040888963407ull + seed * 0x9E3779B97F4A7C15ull;
+}
+
+__host__ __device__ inline int scatter_bin(uint64_t rank, int num_bins, uint64_t offset)
+{
+  return static_cast<int>((rank * kScatterPrime + offset) % static_cast<uint64_t>(num_bins));
+}
+
+// First index `i` in [0, n) with `val < cdf[i]` (upper-bound binary search).
+// Local host/device implementation so this header has no device-only deps
+// (cub::UpperBound is _CCCL_DEVICE only and we need a host path for tests).
+__host__ __device__ inline int upper_bound_cdf(const double* cdf, int n, double val)
+{
+  int lo = 0;
+  int len = n;
+  while (len > 0)
+  {
+    const int half = len >> 1;
+    if (val < cdf[lo + half])
+    {
+      len = half;
+    }
+    else
+    {
+      lo  = lo + half + 1;
+      len = len - (half + 1);
+    }
+  }
+  return lo;
+}
+
+// ---------------------------------------------------------------------------
+// Bin -> sample value mappers (one per histogram path). Both emit a value in
+// the *interior* of bin `b` so CUB re-derives exactly `b`.
+// ---------------------------------------------------------------------------
+template <class SampleT>
+struct even_bin_to_value
+{
+  double L;
+  double w; // (upper - lower) / num_bins
+  SampleT lower;
+  SampleT upper;
+
+  __host__ __device__ SampleT operator()(int bin) const
+  {
+    double v = L + (static_cast<double>(bin) + 0.5) * w;
+    if constexpr (::cuda::std::is_integral_v<SampleT>)
+    {
+      double f = ::floor(v);
+      if (f < static_cast<double>(lower))
+      {
+        f = static_cast<double>(lower);
+      }
+      if (f > static_cast<double>(upper) - 1.0)
+      {
+        f = static_cast<double>(upper) - 1.0;
+      }
+      return static_cast<SampleT>(f);
+    }
+    else
+    {
+      if (v < static_cast<double>(lower))
+      {
+        v = static_cast<double>(lower);
+      }
+      return static_cast<SampleT>(v);
+    }
+  }
+};
+
+template <class SampleT>
+struct range_bin_to_value
+{
+  const SampleT* levels; // num_bins + 1 strictly increasing levels
+  int num_bins;
+
+  __host__ __device__ SampleT operator()(int bin) const
+  {
+    if (bin < 0)
+    {
+      bin = 0;
+    }
+    if (bin > num_bins - 1)
+    {
+      bin = num_bins - 1;
+    }
+    const double lo = static_cast<double>(levels[bin]);
+    const double hi = static_cast<double>(levels[bin + 1]);
+    double v        = 0.5 * (lo + hi);
+    SampleT s;
+    if constexpr (::cuda::std::is_integral_v<SampleT>)
+    {
+      s = static_cast<SampleT>(::floor(v));
+    }
+    else
+    {
+      s = static_cast<SampleT>(v);
+    }
+    // Guarantee s lands in [levels[bin], levels[bin+1]).
+    if (s < levels[bin])
+    {
+      s = levels[bin];
+    }
+    if (s >= levels[bin + 1])
+    {
+      s = levels[bin];
+    }
+    return s;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Device functors.
+// ---------------------------------------------------------------------------
+
+// Inverse-CDF sampler for the i.i.d. distribution shapes.
+template <class SampleT, class Mapper>
+struct cdf_sample_functor
+{
+  const double* cdf; // inclusive prefix sum over bins, cdf[num_bins-1] == 1
+  int num_bins;
+  uint64_t seed;
+  Mapper mapper;
+
+  template <class I>
+  __host__ __device__ SampleT operator()(I i) const
+  {
+    const double u = u01_from_hash(element_key(static_cast<uint64_t>(i), seed));
+    int bin        = upper_bound_cdf(cdf, num_bins, u);
+    if (bin >= num_bins)
+    {
+      bin = num_bins - 1;
+    }
+    return mapper(bin);
+  }
+};
+
+// strided_sweep: bin = stride*i % num_bins.
+template <class SampleT, class Mapper>
+struct strided_functor
+{
+  int num_bins;
+  uint64_t stride;
+  Mapper mapper;
+
+  template <class I>
+  __host__ __device__ SampleT operator()(I i) const
+  {
+    int bin = static_cast<int>((static_cast<uint64_t>(i) * stride) % static_cast<uint64_t>(num_bins));
+    return mapper(bin);
+  }
+};
+
+// temporal_phases: contiguous phases, each hammering one scattered bin.
+template <class SampleT, class Mapper>
+struct phases_functor
+{
+  int num_bins;
+  int num_phases;
+  uint64_t n;
+  uint64_t offset;
+  Mapper mapper;
+
+  template <class I>
+  __host__ __device__ SampleT operator()(I i) const
+  {
+    uint64_t phase = (static_cast<uint64_t>(i) * static_cast<uint64_t>(num_phases)) / n;
+    if (phase >= static_cast<uint64_t>(num_phases))
+    {
+      phase = static_cast<uint64_t>(num_phases) - 1;
+    }
+    // Spread phases across the bin array, scattered off zero.
+    int bin = scatter_bin(phase * (static_cast<uint64_t>(num_bins) / static_cast<uint64_t>(num_phases) + 1), num_bins, offset);
+    return mapper(bin);
+  }
+};
+
+// Exact uniform: round-robin tiling bin(i) = i % num_bins. Every bin receives
+// exactly floor(n/num_bins) or +1 samples -- ACTUALLY uniform (zero count
+// variance), unlike i.i.d. sampling of a uniform pmf which leaves multinomial
+// noise and ~37% empty bins when bins ~= elements. This is the canonical
+// entropy=1.0 endpoint. Access is sequential (a benign, low-contention
+// baseline); contrast strided_sweep, which uses a large coprime stride to
+// destroy locality on purpose.
+template <class SampleT, class Mapper>
+struct uniform_tiling_functor
+{
+  int num_bins;
+  Mapper mapper;
+
+  template <class I>
+  __host__ __device__ SampleT operator()(I i) const
+  {
+    return mapper(static_cast<int>(static_cast<uint64_t>(i) % static_cast<uint64_t>(num_bins)));
+  }
+};
+
+// stale_resident: a cold prefix sweeps `n_cold` distinct bins once (claiming
+// every cache slot), then the hot bulk hammers a single bin disjoint from the
+// prefix.
+template <class SampleT, class Mapper>
+struct stale_functor
+{
+  int num_bins;
+  uint64_t n_cold;
+  int hot_bin;
+  Mapper mapper;
+
+  template <class I>
+  __host__ __device__ SampleT operator()(I i) const
+  {
+    uint64_t idx = static_cast<uint64_t>(i);
+    int bin      = (idx < n_cold) ? static_cast<int>(idx % static_cast<uint64_t>(num_bins)) : hot_bin;
+    return mapper(bin);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Host pmf construction for the distribution shapes.
+// ---------------------------------------------------------------------------
+
+inline double normalized_entropy(const std::vector<double>& pmf)
+{
+  if (pmf.size() <= 1)
+  {
+    return 0.0;
+  }
+  double h = 0.0;
+  for (double p : pmf)
+  {
+    if (p > 0.0)
+    {
+      h -= p * std::log2(p);
+    }
+  }
+  return h / std::log2(static_cast<double>(pmf.size()));
+}
+
+// Ranked weights w[r] ~ (r+1)^(-s), normalized.
+inline std::vector<double> ranked_powerlaw(int num_bins, double s)
+{
+  std::vector<double> w(num_bins);
+  double sum = 0.0;
+  for (int r = 0; r < num_bins; ++r)
+  {
+    w[r] = std::pow(static_cast<double>(r + 1), -s);
+    sum += w[r];
+  }
+  for (double& x : w)
+  {
+    x /= sum;
+  }
+  return w;
+}
+
+// Solve the power-law exponent so normalized entropy ~= target (monotone
+// decreasing in s -> bisection).
+inline double solve_powerlaw_exponent(int num_bins, double target)
+{
+  double lo = 0.0, hi = 60.0;
+  for (int it = 0; it < 60; ++it)
+  {
+    const double mid = 0.5 * (lo + hi);
+    const double h   = normalized_entropy(ranked_powerlaw(num_bins, mid));
+    // entropy decreases as s grows
+    if (h < target)
+    {
+      hi = mid;
+    }
+    else
+    {
+      lo = mid;
+    }
+  }
+  return 0.5 * (lo + hi);
+}
+
+// Spike-slab pmf: probability `p` on one hot bin, `(1-p)` spread uniformly over
+// all bins. Normalized entropy decreases monotonically from 1.0 (p=0, uniform)
+// to 0.0 (p=1, single bin), so we bisect `p` to hit a target entropy.
+inline double spike_slab_entropy(int num_bins, double p)
+{
+  const double base = (1.0 - p) / num_bins;
+  std::vector<double> pmf(num_bins, base);
+  pmf[0] += p;
+  return normalized_entropy(pmf);
+}
+
+inline double solve_spike_share(int num_bins, double target)
+{
+  double lo = 0.0, hi = 1.0;
+  for (int it = 0; it < 60; ++it)
+  {
+    const double mid = 0.5 * (lo + hi);
+    const double h   = spike_slab_entropy(num_bins, mid);
+    if (h < target)
+    {
+      hi = mid; // too concentrated -> reduce p
+    }
+    else
+    {
+      lo = mid;
+    }
+  }
+  return 0.5 * (lo + hi);
+}
+
+// Defaults applied when the axis value supplies no knob.
+constexpr double kDefaultConcentratedEntropy = 0.5; // bare "concentrated"
+constexpr double kDefaultPowerlawEntropy     = 0.5; // bare "powerlaw"
+constexpr double kDefaultZipfExponent        = 1.0; // bare "zipf"
+constexpr double kDefaultHashSynonymHotShare = 0.9; // bare "hash_synonym"
+constexpr int kDefaultTemporalPhases         = 8;   // bare "temporal_phases"
+constexpr uint64_t kDefaultStridedStride     = 9973ull; // bare "strided_sweep"
+
+// Build the per-bin pmf for an i.i.d. distribution shape, honoring the spec's
+// knob. Hot ranks are scattered across bins via scatter_bin() so the mode is
+// not forced to bin 0.
+inline std::vector<double> build_pmf(const ShapeSpec& spec, int num_bins, uint64_t seed)
+{
+  std::vector<double> pmf(num_bins, 0.0);
+  const uint64_t offset = seed % static_cast<uint64_t>(num_bins);
+
+  switch (spec.shape)
+  {
+    case InputShape::concentrated: {
+      // KNOB = target normalized entropy. Exact endpoints, solver in between.
+      const double target = knob_or(spec, kDefaultConcentratedEntropy);
+      if (target >= 1.0)
+      {
+        const double p = 1.0 / num_bins; // exact uniform
+        for (int b = 0; b < num_bins; ++b)
+        {
+          pmf[b] = p;
+        }
+      }
+      else if (target <= 0.0)
+      {
+        pmf[scatter_bin(0, num_bins, offset)] = 1.0; // exact single bin
+      }
+      else
+      {
+        const double p       = solve_spike_share(num_bins, target);
+        const double floor_p = (1.0 - p) / num_bins;
+        for (int b = 0; b < num_bins; ++b)
+        {
+          pmf[b] = floor_p;
+        }
+        pmf[scatter_bin(0, num_bins, offset)] += p;
+      }
+      break;
+    }
+    case InputShape::powerlaw: {
+      const double target         = knob_or(spec, kDefaultPowerlawEntropy);
+      const double s              = solve_powerlaw_exponent(num_bins, target);
+      const std::vector<double> w = ranked_powerlaw(num_bins, s);
+      for (int r = 0; r < num_bins; ++r)
+      {
+        pmf[scatter_bin(static_cast<uint64_t>(r), num_bins, offset)] = w[r];
+      }
+      break;
+    }
+    case InputShape::zipf: {
+      const double s              = knob_or(spec, kDefaultZipfExponent);
+      const std::vector<double> w = ranked_powerlaw(num_bins, s);
+      for (int r = 0; r < num_bins; ++r)
+      {
+        pmf[scatter_bin(static_cast<uint64_t>(r), num_bins, offset)] = w[r];
+      }
+      break;
+    }
+    case InputShape::hash_synonym: {
+      // KNOB = hot share. kHashSynonymCount bins that all collide on one cache
+      // slot share the hot traffic; the rest is uniform background.
+      const double hot_share = knob_or(spec, kDefaultHashSynonymHotShare);
+      const int slot         = static_cast<int>(offset % static_cast<uint64_t>(kAdversarialCacheSlots));
+      std::vector<int> syn;
+      for (int k = 0; k < kHashSynonymCount; ++k)
+      {
+        const int b = slot + k * kAdversarialCacheSlots;
+        if (b < num_bins)
+        {
+          syn.push_back(b);
+        }
+      }
+      const double bg = (1.0 - hot_share) / num_bins;
+      for (int b = 0; b < num_bins; ++b)
+      {
+        pmf[b] = bg;
+      }
+      if (!syn.empty())
+      {
+        const double per = hot_share / syn.size();
+        for (int b : syn)
+        {
+          pmf[b] += per;
+        }
+      }
+      else
+      {
+        pmf[scatter_bin(0, num_bins, offset)] += hot_share; // degenerate fallback
+      }
+      break;
+    }
+    case InputShape::capacity_cliff: {
+      // KNOB = active set as a multiple of cache slots. Default => slots+1
+      // (the just-over-capacity cliff). Equiprobable bins, spread across the
+      // array so they do not trivially share slots.
+      int k;
+      if (spec.has_knob)
+      {
+        k = static_cast<int>(std::lround(spec.knob * kAdversarialCacheSlots));
+      }
+      else
+      {
+        k = kAdversarialCacheSlots + 1;
+      }
+      k = std::max(1, std::min(k, num_bins));
+      const double p = 1.0 / k;
+      for (int j = 0; j < k; ++j)
+      {
+        const int b = static_cast<int>((static_cast<uint64_t>(j) * num_bins) / static_cast<uint64_t>(k));
+        pmf[b] = p;
+      }
+      break;
+    }
+    default:
+      throw std::runtime_error("build_pmf called with a non-distribution shape");
+  }
+  return pmf;
+}
+
+inline bool is_ordering_shape(InputShape shape)
+{
+  return shape == InputShape::stale_resident || shape == InputShape::temporal_phases
+      || shape == InputShape::strided_sweep;
+}
+
+// ---------------------------------------------------------------------------
+// Core generation: given a bin->value mapper, fill an output device vector of
+// `n` samples according to `spec`.
+// ---------------------------------------------------------------------------
+template <class SampleT, class OffsetT, class Mapper>
+thrust::device_vector<SampleT>
+generate_shape_impl(const ShapeSpec& spec, OffsetT n, int num_bins, Mapper mapper, uint64_t seed)
+{
+  thrust::device_vector<SampleT> out(static_cast<std::size_t>(n));
+  const uint64_t offset = seed % static_cast<uint64_t>(num_bins);
+
+  // Exact-uniform endpoint: emitted as equal-count tiling rather than i.i.d.
+  // sampling, so every bin gets exactly n/num_bins (+-1) -- truly uniform.
+  if (spec.shape == InputShape::concentrated && spec.has_knob && spec.knob >= 1.0)
+  {
+    uniform_tiling_functor<SampleT, Mapper> fn{num_bins, mapper};
+    thrust::tabulate(out.begin(), out.end(), fn);
+    return out;
+  }
+
+  if (!is_ordering_shape(spec.shape))
+  {
+    // Distribution shape: host pmf -> inclusive CDF -> device -> inverse-CDF sample.
+    std::vector<double> pmf = build_pmf(spec, num_bins, seed);
+    thrust::host_vector<double> h_cdf(num_bins);
+    double acc = 0.0;
+    for (int b = 0; b < num_bins; ++b)
+    {
+      acc += pmf[b];
+      h_cdf[b] = acc;
+    }
+    h_cdf[num_bins - 1] = 1.0; // guard against fp drift on the last bin
+    thrust::device_vector<double> d_cdf = h_cdf;
+    cdf_sample_functor<SampleT, Mapper> fn{thrust::raw_pointer_cast(d_cdf.data()), num_bins, seed, mapper};
+    thrust::tabulate(out.begin(), out.end(), fn);
+    return out;
+  }
+
+  switch (spec.shape)
+  {
+    case InputShape::strided_sweep: {
+      // KNOB = stride.
+      const uint64_t stride =
+        spec.has_knob ? static_cast<uint64_t>(std::llround(spec.knob)) : kDefaultStridedStride;
+      strided_functor<SampleT, Mapper> fn{num_bins, stride, mapper};
+      thrust::tabulate(out.begin(), out.end(), fn);
+      break;
+    }
+    case InputShape::temporal_phases: {
+      // KNOB = number of phases.
+      const int requested = spec.has_knob ? static_cast<int>(std::llround(spec.knob)) : kDefaultTemporalPhases;
+      const int phases    = std::max(1, std::min(requested, num_bins));
+      phases_functor<SampleT, Mapper> fn{num_bins, phases, static_cast<uint64_t>(n), offset, mapper};
+      thrust::tabulate(out.begin(), out.end(), fn);
+      break;
+    }
+    case InputShape::stale_resident: {
+      // KNOB = prefix coverage as a multiple of cache slots (default 1.0).
+      const double cover    = knob_or(spec, 1.0);
+      const int64_t want    = static_cast<int64_t>(std::llround(cover * kAdversarialCacheSlots));
+      const uint64_t n_cold = static_cast<uint64_t>(std::max<int64_t>(1, std::min<int64_t>(want, num_bins)));
+      // hot bin disjoint from the cold prefix [0, n_cold) when possible.
+      const int hot_bin =
+        (num_bins > static_cast<int>(n_cold))
+          ? static_cast<int>(n_cold + (offset % (static_cast<uint64_t>(num_bins) - n_cold)))
+          : num_bins / 2;
+      stale_functor<SampleT, Mapper> fn{num_bins, n_cold, hot_bin, mapper};
+      thrust::tabulate(out.begin(), out.end(), fn);
+      break;
+    }
+    default:
+      throw std::runtime_error("unreachable ordering shape");
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Public entry points -- drop-in replacements for the legacy generate() call.
+// ---------------------------------------------------------------------------
+template <class SampleT, class OffsetT>
+thrust::device_vector<SampleT> generate_histogram_input_even(
+  const ShapeSpec& spec, OffsetT n, int num_bins, SampleT lower, SampleT upper, uint64_t seed = 42)
+{
+  const double w = (static_cast<double>(upper) - static_cast<double>(lower)) / static_cast<double>(num_bins);
+  even_bin_to_value<SampleT> mapper{static_cast<double>(lower), w, lower, upper};
+  return generate_shape_impl<SampleT, OffsetT>(spec, n, num_bins, mapper, seed);
+}
+
+template <class SampleT, class OffsetT>
+thrust::device_vector<SampleT> generate_histogram_input_range(
+  const ShapeSpec& spec, OffsetT n, int num_bins, const SampleT* d_levels, uint64_t seed = 42)
+{
+  range_bin_to_value<SampleT> mapper{d_levels, num_bins};
+  return generate_shape_impl<SampleT, OffsetT>(spec, n, num_bins, mapper, seed);
+}

--- a/cub/benchmarks/bench/histogram/multi/even.cu
+++ b/cub/benchmarks/bench/histogram/multi/even.cu
@@ -58,6 +58,63 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   state.add_global_memory_reads<SampleT>(elements * num_active_channels);
   state.add_global_memory_writes<CounterT>(num_bins * num_active_channels);
 
+  // Warmup + correctness check: run MultiHistogramEven once outside
+  // `state.exec`, checking the dispatch return code, then verify each
+  // channel's histogram bin-by-bin against an independent reference.
+  // Skipped when CUB_BENCH_HISTOGRAM_VERIFY=0|false|no|off.
+  if (bench_correctness_checks_enabled())
+  {
+    thrust::fill(hist_r.begin(), hist_r.end(), CounterT{0});
+    thrust::fill(hist_g.begin(), hist_g.end(), CounterT{0});
+    thrust::fill(hist_b.begin(), hist_b.end(), CounterT{0});
+    void* d_temp_storage      = nullptr;
+    size_t temp_storage_bytes = 0;
+    bench_check_cuda(
+      (cub::DeviceHistogram::MultiHistogramEven<num_channels, num_active_channels>(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_input,
+        cuda::std::array<CounterT*, num_active_channels>{d_histogram_r, d_histogram_g, d_histogram_b},
+        cuda::std::array<int, num_active_channels>{num_levels_r, num_levels_g, num_levels_b},
+        cuda::std::array<SampleT, num_active_channels>{lower_level_r, lower_level_g, lower_level_b},
+        cuda::std::array<SampleT, num_active_channels>{upper_level_r, upper_level_g, upper_level_b},
+        static_cast<OffsetT>(elements))),
+      "warmup MultiHistogramEven temp-size");
+    thrust::device_vector<unsigned char> warmup_tmp(temp_storage_bytes);
+    d_temp_storage = thrust::raw_pointer_cast(warmup_tmp.data());
+    bench_check_cuda(
+      (cub::DeviceHistogram::MultiHistogramEven<num_channels, num_active_channels>(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_input,
+        cuda::std::array<CounterT*, num_active_channels>{d_histogram_r, d_histogram_g, d_histogram_b},
+        cuda::std::array<int, num_active_channels>{num_levels_r, num_levels_g, num_levels_b},
+        cuda::std::array<SampleT, num_active_channels>{lower_level_r, lower_level_g, lower_level_b},
+        cuda::std::array<SampleT, num_active_channels>{upper_level_r, upper_level_g, upper_level_b},
+        static_cast<OffsetT>(elements))),
+      "warmup MultiHistogramEven");
+    bench_check_cuda(cudaDeviceSynchronize(), "warmup sync");
+
+    std::vector<thrust::device_vector<CounterT>> opt_hists_d;
+    opt_hists_d.emplace_back(std::move(hist_r));
+    opt_hists_d.emplace_back(std::move(hist_g));
+    opt_hists_d.emplace_back(std::move(hist_b));
+    bench_verify_histogram_even<num_channels, num_active_channels, SampleT, CounterT, OffsetT>(
+      input,
+      opt_hists_d,
+      static_cast<OffsetT>(elements),
+      static_cast<int>(num_bins),
+      lower_level_r,
+      upper_level_r,
+      "multi.even");
+    hist_r        = std::move(opt_hists_d[0]);
+    hist_g        = std::move(opt_hists_d[1]);
+    hist_b        = std::move(opt_hists_d[2]);
+    d_histogram_r = thrust::raw_pointer_cast(hist_r.data());
+    d_histogram_g = thrust::raw_pointer_cast(hist_g.data());
+    d_histogram_b = thrust::raw_pointer_cast(hist_b.data());
+  }
+
   caching_allocator_t alloc;
   // Force the persisting-L2 reservation back to 0 and demote any persisting
   // lines outside the timed window, so neither cudaAccessPolicyWindow nor a

--- a/cub/benchmarks/bench/histogram/multi/even.cu
+++ b/cub/benchmarks/bench/histogram/multi/even.cu
@@ -4,6 +4,7 @@
 #include <nvbench_helper.cuh>
 
 #include "../histogram_common.cuh"
+#include "../histogram_inputs.cuh"
 
 // %RANGE% TUNE_ITEMS ipt 7:24:1
 // %RANGE% TUNE_THREADS tpb 128:1024:32
@@ -20,7 +21,7 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   constexpr int num_channels        = 4;
   constexpr int num_active_channels = 3;
 
-  const auto entropy     = str_to_entropy(state.get_string("Entropy"));
+  const auto shape       = parse_input_shape(state.get_string("InputShape"));
   const auto elements    = state.get_int64("Elements{io}");
   const auto num_bins    = state.get_int64("Bins");
   const int num_levels_r = static_cast<int>(num_bins) + 1;
@@ -58,7 +59,8 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   thrust::device_vector<CounterT> hist_r(num_bins);
   thrust::device_vector<CounterT> hist_g(num_bins);
   thrust::device_vector<CounterT> hist_b(num_bins);
-  thrust::device_vector<SampleT> input = generate(elements * num_channels, entropy, lower_level_r, upper_level_r);
+  thrust::device_vector<SampleT> input = generate_histogram_input_even<SampleT>(
+    shape, elements * num_channels, static_cast<int>(num_bins), lower_level_r, upper_level_r);
 
   SampleT* d_input        = thrust::raw_pointer_cast(input.data());
   CounterT* d_histogram_r = thrust::raw_pointer_cast(hist_r.data());
@@ -173,4 +175,18 @@ NVBENCH_BENCH_TYPES(even, NVBENCH_TYPE_AXES(sample_types, counter_types, some_of
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
   .add_int64_axis("Bins", {32, 100, 2000, 16384, 60000, 2097152})
-  .add_string_axis("Entropy", {"0.201", "1.000"});
+  // One `concentrated` shape swept across entropy (1.0=uniform, 0.5=spike,
+  // 0.0=constant) plus the multi-hot and cache-adversarial shapes. Each value
+  // may carry an inline knob as "name:value"; see histogram_inputs.cuh.
+  .add_string_axis(
+    "InputShape",
+    {"concentrated:1.0",
+     "concentrated:0.5",
+     "concentrated:0.0",
+     "powerlaw:0.5",
+     "zipf:1.0",
+     "hash_synonym",
+     "capacity_cliff",
+     "stale_resident",
+     "temporal_phases",
+     "strided_sweep"});

--- a/cub/benchmarks/bench/histogram/multi/even.cu
+++ b/cub/benchmarks/bench/histogram/multi/even.cu
@@ -35,6 +35,19 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
     return;
   }
 
+  // Skip configurations whose row stride in samples (= elements * num_channels)
+  // overflows OffsetT. The MultiHistogramEven<NUM_CHANNELS> single-row
+  // overload internally computes `row_stride_samples = elements * num_channels`
+  // and stores it as OffsetT; the rectangular overload does the same. For
+  // OffsetT = int32_t and num_channels = 4 this caps at elements <= INT_MAX/4
+  // (~536M); above that the cast wraps to a negative value and the kernel
+  // produces zero output. Reported by autocuda matrix runs at elements=1G.
+  if (static_cast<int64_t>(elements) * num_channels > static_cast<int64_t>(::cuda::std::numeric_limits<OffsetT>::max()))
+  {
+    state.skip("Row stride samples (elements * num_channels) overflows OffsetT");
+    return;
+  }
+
   const SampleT lower_level_r = get_lower_level<SampleT>();
   const SampleT upper_level_r = get_upper_level<SampleT>(num_bins, elements);
   const SampleT lower_level_g = lower_level_r;

--- a/cub/benchmarks/bench/histogram/multi/even.cu
+++ b/cub/benchmarks/bench/histogram/multi/even.cu
@@ -27,17 +27,15 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   const int num_levels_g = num_levels_r;
   const int num_levels_b = num_levels_g;
 
-  // Skip invalid configurations where LevelT (= SampleT) cannot represent the number of bins
-  if constexpr (cuda::std::is_integral_v<SampleT>)
+  // Skip invalid configurations where the SampleT range can't hold enough
+  // strictly-monotonic levels.
+  if (num_bins > max_representable_bins<SampleT>())
   {
-    if (num_bins > static_cast<int64_t>(cuda::std::numeric_limits<SampleT>::max()))
-    {
-      state.skip("Number of bins exceeds what LevelT (= SampleT) can represent");
-      return;
-    }
+    state.skip("Number of bins exceeds what SampleT can represent");
+    return;
   }
 
-  const SampleT lower_level_r = 0;
+  const SampleT lower_level_r = get_lower_level<SampleT>();
   const SampleT upper_level_r = get_upper_level<SampleT>(num_bins, elements);
   const SampleT lower_level_g = lower_level_r;
   const SampleT upper_level_g = upper_level_r;

--- a/cub/benchmarks/bench/histogram/multi/even.cu
+++ b/cub/benchmarks/bench/histogram/multi/even.cu
@@ -59,26 +59,32 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   state.add_global_memory_writes<CounterT>(num_bins * num_active_channels);
 
   caching_allocator_t alloc;
-  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    auto env = cub_bench_env(
-      alloc,
-      launch
+  // Demote persisting L2 lines outside the timed window so that no
+  // cudaAccessPolicyWindow set by the dispatcher can carry across iterations.
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::timer,
+             [&](nvbench::launch& launch, auto& timer) {
+               cudaCtxResetPersistingL2Cache();
+               timer.start();
+               auto env = cub_bench_env(
+                 alloc,
+                 launch
 #if !TUNE_BASE
-      ,
-      cuda::execution::tune(bench_policy_selector<key_t, num_channels, num_active_channels>{})
+                 ,
+                 cuda::execution::tune(bench_policy_selector<key_t, num_channels, num_active_channels>{})
 #endif // !TUNE_BASE
-    );
-    _CCCL_TRY_CUDA_API(
-      (cub::DeviceHistogram::MultiHistogramEven<num_channels, num_active_channels>),
-      "MultiHistogramEven failed",
-      d_input,
-      cuda::std::array<CounterT*, num_active_channels>{d_histogram_r, d_histogram_g, d_histogram_b},
-      cuda::std::array<int, num_active_channels>{num_levels_r, num_levels_g, num_levels_b},
-      cuda::std::array<SampleT, num_active_channels>{lower_level_r, lower_level_g, lower_level_b},
-      cuda::std::array<SampleT, num_active_channels>{upper_level_r, upper_level_g, upper_level_b},
-      static_cast<OffsetT>(elements),
-      env);
-  });
+               );
+               _CCCL_TRY_CUDA_API(
+                 (cub::DeviceHistogram::MultiHistogramEven<num_channels, num_active_channels>),
+                 "MultiHistogramEven failed",
+                 d_input,
+                 cuda::std::array<CounterT*, num_active_channels>{d_histogram_r, d_histogram_g, d_histogram_b},
+                 cuda::std::array<int, num_active_channels>{num_levels_r, num_levels_g, num_levels_b},
+                 cuda::std::array<SampleT, num_active_channels>{lower_level_r, lower_level_g, lower_level_b},
+                 cuda::std::array<SampleT, num_active_channels>{upper_level_r, upper_level_g, upper_level_b},
+                 static_cast<OffsetT>(elements),
+                 env);
+               timer.stop();
+             });
 }
 
 using counter_types     = nvbench::type_list<int32_t>;
@@ -93,6 +99,6 @@ using sample_types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t, float
 NVBENCH_BENCH_TYPES(even, NVBENCH_TYPE_AXES(sample_types, counter_types, some_offset_types))
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
-  .add_int64_axis("Bins", {32, 128, 2048, 2097152})
+  .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
+  .add_int64_axis("Bins", {32, 100, 2000, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/multi/even.cu
+++ b/cub/benchmarks/bench/histogram/multi/even.cu
@@ -59,10 +59,14 @@ static void even(nvbench::state& state, nvbench::type_list<SampleT, CounterT, Of
   state.add_global_memory_writes<CounterT>(num_bins * num_active_channels);
 
   caching_allocator_t alloc;
-  // Demote persisting L2 lines outside the timed window so that no
-  // cudaAccessPolicyWindow set by the dispatcher can carry across iterations.
+  // Force the persisting-L2 reservation back to 0 and demote any persisting
+  // lines outside the timed window, so neither cudaAccessPolicyWindow nor a
+  // bumped cudaLimitPersistingL2CacheSize can carry across iterations. The
+  // default reservation is 0; hardcoding 0 also clears any pollution left by
+  // a prior benchmark in the same nvbench process.
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::timer,
              [&](nvbench::launch& launch, auto& timer) {
+               cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, 0);
                cudaCtxResetPersistingL2Cache();
                timer.start();
                auto env = cub_bench_env(

--- a/cub/benchmarks/bench/histogram/multi/even.cu
+++ b/cub/benchmarks/bench/histogram/multi/even.cu
@@ -104,5 +104,5 @@ NVBENCH_BENCH_TYPES(even, NVBENCH_TYPE_AXES(sample_types, counter_types, some_of
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
-  .add_int64_axis("Bins", {32, 100, 2000, 2097152})
+  .add_int64_axis("Bins", {32, 100, 2000, 16384, 60000, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -31,7 +31,14 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   const int num_levels_g = num_levels_r;
   const int num_levels_b = num_levels_g;
 
-  const SampleT lower_level = 0;
+  // Skip invalid configurations; see range.cu for rationale.
+  if (num_bins > max_representable_bins<SampleT>())
+  {
+    state.skip("Number of bins exceeds what SampleT can represent");
+    return;
+  }
+
+  const SampleT lower_level = get_lower_level<SampleT>();
   const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
 
   // Jittered uniform spacing keeps DispatchRange on the SearchTransform path

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -125,5 +125,5 @@ NVBENCH_BENCH_TYPES(range, NVBENCH_TYPE_AXES(sample_types, counter_types, some_o
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
-  .add_int64_axis("Bins", {32, 100, 2000, 2097152})
+  .add_int64_axis("Bins", {32, 100, 2000, 16384, 60000, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2011-2023, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: BSD-3
 
-#include <thrust/sequence.h>
+#include <thrust/host_vector.h>
 
 #include <nvbench_helper.cuh>
 
@@ -32,11 +32,23 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   const SampleT lower_level = 0;
   const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
 
-  SampleT step = (upper_level - lower_level) / num_bins;
-  thrust::device_vector<SampleT> levels_r(num_bins + 1);
-
-  // TODO Extract sequence to the helper TU
-  thrust::sequence(levels_r.begin(), levels_r.end(), lower_level, step);
+  // Quadratic spacing keeps DispatchRange on the SearchTransform path.
+  thrust::host_vector<SampleT> h_levels(num_bins + 1);
+  h_levels[0]    = lower_level;
+  const double L = static_cast<double>(lower_level);
+  const double U = static_cast<double>(upper_level);
+  const double n = static_cast<double>(num_bins);
+  for (int i = 1; i <= num_bins; ++i)
+  {
+    const double t = static_cast<double>(i) / n;
+    SampleT lvl    = static_cast<SampleT>(L + (U - L) * t * t);
+    if (lvl <= h_levels[i - 1])
+    {
+      lvl = static_cast<SampleT>(h_levels[i - 1] + SampleT{1});
+    }
+    h_levels[i] = lvl;
+  }
+  thrust::device_vector<SampleT> levels_r = h_levels;
   thrust::device_vector<SampleT> levels_g = levels_r;
   thrust::device_vector<SampleT> levels_b = levels_g;
 
@@ -59,25 +71,31 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   state.add_global_memory_writes<CounterT>(num_bins * num_active_channels);
 
   caching_allocator_t alloc;
-  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    auto env = cub_bench_env(
-      alloc,
-      launch
+  // Demote persisting L2 lines outside the timed window so that no
+  // cudaAccessPolicyWindow set by the dispatcher can carry across iterations.
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::timer,
+             [&](nvbench::launch& launch, auto& timer) {
+               cudaCtxResetPersistingL2Cache();
+               timer.start();
+               auto env = cub_bench_env(
+                 alloc,
+                 launch
 #if !TUNE_BASE
-      ,
-      cuda::execution::tune(bench_policy_selector<key_t, num_channels, num_active_channels>{})
+                 ,
+                 cuda::execution::tune(bench_policy_selector<key_t, num_channels, num_active_channels>{})
 #endif // !TUNE_BASE
-    );
-    _CCCL_TRY_CUDA_API(
-      (cub::DeviceHistogram::MultiHistogramRange<num_channels, num_active_channels>),
-      "MultiHistogramRange failed",
-      d_input,
-      cuda::std::array<CounterT*, num_active_channels>{d_histogram_r, d_histogram_g, d_histogram_b},
-      cuda::std::array<int, num_active_channels>{num_levels_r, num_levels_g, num_levels_b},
-      cuda::std::array<const SampleT*, num_active_channels>{d_levels_r, d_levels_g, d_levels_b},
-      static_cast<OffsetT>(elements),
-      env);
-  });
+               );
+               _CCCL_TRY_CUDA_API(
+                 (cub::DeviceHistogram::MultiHistogramRange<num_channels, num_active_channels>),
+                 "MultiHistogramRange failed",
+                 d_input,
+                 cuda::std::array<CounterT*, num_active_channels>{d_histogram_r, d_histogram_g, d_histogram_b},
+                 cuda::std::array<int, num_active_channels>{num_levels_r, num_levels_g, num_levels_b},
+                 cuda::std::array<const SampleT*, num_active_channels>{d_levels_r, d_levels_g, d_levels_b},
+                 static_cast<OffsetT>(elements),
+                 env);
+               timer.stop();
+             });
 }
 
 using counter_types     = nvbench::type_list<int32_t>;
@@ -92,6 +110,6 @@ using sample_types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t, float
 NVBENCH_BENCH_TYPES(range, NVBENCH_TYPE_AXES(sample_types, counter_types, some_offset_types))
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
-  .add_int64_axis("Bins", {32, 128, 2048, 2097152})
+  .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
+  .add_int64_axis("Bins", {32, 100, 2000, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -38,6 +38,14 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
     return;
   }
 
+  // Skip when row_stride_samples (= elements * num_channels) would overflow
+  // OffsetT. See multi/even.cu for the rationale.
+  if (static_cast<int64_t>(elements) * num_channels > static_cast<int64_t>(::cuda::std::numeric_limits<OffsetT>::max()))
+  {
+    state.skip("Row stride samples (elements * num_channels) overflows OffsetT");
+    return;
+  }
+
   const SampleT lower_level = get_lower_level<SampleT>();
   const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
 

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -80,6 +80,65 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   state.add_global_memory_reads<SampleT>(elements * num_active_channels);
   state.add_global_memory_writes<CounterT>(num_bins * num_active_channels);
 
+  // Warmup + correctness check: run MultiHistogramRange once outside
+  // `state.exec`, checking the dispatch return code, then verify each
+  // channel's histogram bin-by-bin against an independent reference.
+  // Skipped when CUB_BENCH_HISTOGRAM_VERIFY=0|false|no|off.
+  if (bench_correctness_checks_enabled())
+  {
+    thrust::fill(hist_r.begin(), hist_r.end(), CounterT{0});
+    thrust::fill(hist_g.begin(), hist_g.end(), CounterT{0});
+    thrust::fill(hist_b.begin(), hist_b.end(), CounterT{0});
+    void* d_temp_storage      = nullptr;
+    size_t temp_storage_bytes = 0;
+    bench_check_cuda(
+      (cub::DeviceHistogram::MultiHistogramRange<num_channels, num_active_channels>(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_input,
+        cuda::std::array<CounterT*, num_active_channels>{d_histogram_r, d_histogram_g, d_histogram_b},
+        cuda::std::array<int, num_active_channels>{num_levels_r, num_levels_g, num_levels_b},
+        cuda::std::array<const SampleT*, num_active_channels>{d_levels_r, d_levels_g, d_levels_b},
+        static_cast<OffsetT>(elements))),
+      "warmup MultiHistogramRange temp-size");
+    thrust::device_vector<unsigned char> warmup_tmp(temp_storage_bytes);
+    d_temp_storage = thrust::raw_pointer_cast(warmup_tmp.data());
+    bench_check_cuda(
+      (cub::DeviceHistogram::MultiHistogramRange<num_channels, num_active_channels>(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_input,
+        cuda::std::array<CounterT*, num_active_channels>{d_histogram_r, d_histogram_g, d_histogram_b},
+        cuda::std::array<int, num_active_channels>{num_levels_r, num_levels_g, num_levels_b},
+        cuda::std::array<const SampleT*, num_active_channels>{d_levels_r, d_levels_g, d_levels_b},
+        static_cast<OffsetT>(elements))),
+      "warmup MultiHistogramRange");
+    bench_check_cuda(cudaDeviceSynchronize(), "warmup sync");
+
+    std::vector<thrust::device_vector<CounterT>> opt_hists_d;
+    opt_hists_d.emplace_back(std::move(hist_r));
+    opt_hists_d.emplace_back(std::move(hist_g));
+    opt_hists_d.emplace_back(std::move(hist_b));
+    std::vector<thrust::device_vector<SampleT>> d_levels_per_channel;
+    d_levels_per_channel.emplace_back(std::move(levels_r));
+    d_levels_per_channel.emplace_back(std::move(levels_g));
+    d_levels_per_channel.emplace_back(std::move(levels_b));
+    bench_verify_histogram_range<num_channels, num_active_channels, SampleT, CounterT, OffsetT>(
+      input, opt_hists_d, d_levels_per_channel, static_cast<OffsetT>(elements), "multi.range");
+    hist_r        = std::move(opt_hists_d[0]);
+    hist_g        = std::move(opt_hists_d[1]);
+    hist_b        = std::move(opt_hists_d[2]);
+    d_histogram_r = thrust::raw_pointer_cast(hist_r.data());
+    d_histogram_g = thrust::raw_pointer_cast(hist_g.data());
+    d_histogram_b = thrust::raw_pointer_cast(hist_b.data());
+    levels_r      = std::move(d_levels_per_channel[0]);
+    levels_g      = std::move(d_levels_per_channel[1]);
+    levels_b      = std::move(d_levels_per_channel[2]);
+    d_levels_r    = thrust::raw_pointer_cast(levels_r.data());
+    d_levels_g    = thrust::raw_pointer_cast(levels_g.data());
+    d_levels_b    = thrust::raw_pointer_cast(levels_b.data());
+  }
+
   caching_allocator_t alloc;
   // Force the persisting-L2 reservation back to 0 and demote any persisting
   // lines outside the timed window, so neither cudaAccessPolicyWindow nor a

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -8,6 +8,7 @@
 #include <nvbench_helper.cuh>
 
 #include "../histogram_common.cuh"
+#include "../histogram_inputs.cuh"
 
 // %RANGE% TUNE_ITEMS ipt 7:24:1
 // %RANGE% TUNE_THREADS tpb 128:1024:32
@@ -24,7 +25,7 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   constexpr int num_channels        = 4;
   constexpr int num_active_channels = 3;
 
-  const auto entropy     = str_to_entropy(state.get_string("Entropy"));
+  const auto shape       = parse_input_shape(state.get_string("InputShape"));
   const auto elements    = state.get_int64("Elements{io}");
   const auto num_bins    = state.get_int64("Bins");
   const int num_levels_r = static_cast<int>(num_bins) + 1;
@@ -84,7 +85,8 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   thrust::device_vector<CounterT> hist_r(num_bins);
   thrust::device_vector<CounterT> hist_g(num_bins);
   thrust::device_vector<CounterT> hist_b(num_bins);
-  thrust::device_vector<SampleT> input = generate(elements * num_channels, entropy, lower_level, upper_level);
+  thrust::device_vector<SampleT> input = generate_histogram_input_range<SampleT>(
+    shape, elements * num_channels, static_cast<int>(num_bins), d_levels_r);
 
   SampleT* d_input        = thrust::raw_pointer_cast(input.data());
   CounterT* d_histogram_r = thrust::raw_pointer_cast(hist_r.data());
@@ -200,4 +202,18 @@ NVBENCH_BENCH_TYPES(range, NVBENCH_TYPE_AXES(sample_types, counter_types, some_o
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
   .add_int64_axis("Bins", {32, 100, 2000, 16384, 60000, 2097152})
-  .add_string_axis("Entropy", {"0.201", "1.000"});
+  // One `concentrated` shape swept across entropy (1.0=uniform, 0.5=spike,
+  // 0.0=constant) plus the multi-hot and cache-adversarial shapes. Each value
+  // may carry an inline knob as "name:value"; see histogram_inputs.cuh.
+  .add_string_axis(
+    "InputShape",
+    {"concentrated:1.0",
+     "concentrated:0.5",
+     "concentrated:0.0",
+     "powerlaw:0.5",
+     "zipf:1.0",
+     "hash_synonym",
+     "capacity_cliff",
+     "stale_resident",
+     "temporal_phases",
+     "strided_sweep"});

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -71,10 +71,14 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   state.add_global_memory_writes<CounterT>(num_bins * num_active_channels);
 
   caching_allocator_t alloc;
-  // Demote persisting L2 lines outside the timed window so that no
-  // cudaAccessPolicyWindow set by the dispatcher can carry across iterations.
+  // Force the persisting-L2 reservation back to 0 and demote any persisting
+  // lines outside the timed window, so neither cudaAccessPolicyWindow nor a
+  // bumped cudaLimitPersistingL2CacheSize can carry across iterations. The
+  // default reservation is 0; hardcoding 0 also clears any pollution left by
+  // a prior benchmark in the same nvbench process.
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::timer,
              [&](nvbench::launch& launch, auto& timer) {
+               cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, 0);
                cudaCtxResetPersistingL2Cache();
                timer.start();
                auto env = cub_bench_env(

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -3,6 +3,8 @@
 
 #include <thrust/host_vector.h>
 
+#include <random>
+
 #include <nvbench_helper.cuh>
 
 #include "../histogram_common.cuh"
@@ -32,21 +34,29 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   const SampleT lower_level = 0;
   const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
 
-  // Quadratic spacing keeps DispatchRange on the SearchTransform path.
+  // Jittered uniform spacing keeps DispatchRange on the SearchTransform path
+  // while keeping bin widths within ~2x of each other. Fixed seed makes the
+  // levels reproducible across runs.
   thrust::host_vector<SampleT> h_levels(num_bins + 1);
-  h_levels[0]    = lower_level;
-  const double L = static_cast<double>(lower_level);
-  const double U = static_cast<double>(upper_level);
-  const double n = static_cast<double>(num_bins);
-  for (int i = 1; i <= num_bins; ++i)
+  const double L    = static_cast<double>(lower_level);
+  const double U    = static_cast<double>(upper_level);
+  const double step = (U - L) / static_cast<double>(num_bins);
+  std::mt19937 rng(0xC0FFEE);
+  std::uniform_real_distribution<double> jitter(-0.25, 0.25);
+  h_levels[0]        = lower_level;
+  h_levels[num_bins] = upper_level;
+  for (int i = 1; i < num_bins; ++i)
   {
-    const double t = static_cast<double>(i) / n;
-    SampleT lvl    = static_cast<SampleT>(L + (U - L) * t * t);
+    SampleT lvl = static_cast<SampleT>(L + i * step + step * jitter(rng));
     if (lvl <= h_levels[i - 1])
     {
       lvl = static_cast<SampleT>(h_levels[i - 1] + SampleT{1});
     }
     h_levels[i] = lvl;
+  }
+  if (h_levels[num_bins] <= h_levels[num_bins - 1])
+  {
+    h_levels[num_bins] = static_cast<SampleT>(h_levels[num_bins - 1] + SampleT{1});
   }
   thrust::device_vector<SampleT> levels_r = h_levels;
   thrust::device_vector<SampleT> levels_g = levels_r;

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -26,7 +26,18 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   const auto num_bins  = state.get_int64("Bins");
   const int num_levels = static_cast<int>(num_bins) + 1;
 
-  const SampleT lower_level = 0;
+  // Skip invalid configurations where the SampleT range can't hold enough
+  // strictly-monotonic levels. The level-construction loop below uses
+  // `h_levels[i-1] + SampleT{1}` to enforce strict monotonicity; for narrow
+  // integer SampleT this overflows once bins exceed the count of distinct
+  // SampleT values, leaving a non-monotonic level array.
+  if (num_bins > max_representable_bins<SampleT>())
+  {
+    state.skip("Number of bins exceeds what SampleT can represent");
+    return;
+  }
+
+  const SampleT lower_level = get_lower_level<SampleT>();
   const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
 
   // Jittered uniform spacing keeps DispatchRange on the SearchTransform path

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -66,7 +66,53 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   state.add_global_memory_reads<SampleT>(elements);
   state.add_global_memory_writes<CounterT>(num_bins);
 
+  // Warmup + correctness check: run HistogramRange once outside
+  // `state.exec`, checking the dispatch return code, then verify the
+  // produced histogram bin-by-bin against an independent reference.
+  // Skipped when CUB_BENCH_HISTOGRAM_VERIFY=0|false|no|off.
+  if (bench_correctness_checks_enabled())
+  {
+    thrust::fill(hist.begin(), hist.end(), CounterT{0});
+    void* d_temp_storage      = nullptr;
+    size_t temp_storage_bytes = 0;
+    bench_check_cuda(
+      cub::DeviceHistogram::HistogramRange(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_input,
+        d_histogram,
+        num_levels,
+        d_levels,
+        static_cast<OffsetT>(elements)),
+      "warmup HistogramRange temp-size");
+    thrust::device_vector<unsigned char> warmup_tmp(temp_storage_bytes);
+    d_temp_storage = thrust::raw_pointer_cast(warmup_tmp.data());
+    bench_check_cuda(
+      cub::DeviceHistogram::HistogramRange(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_input,
+        d_histogram,
+        num_levels,
+        d_levels,
+        static_cast<OffsetT>(elements)),
+      "warmup HistogramRange");
+    bench_check_cuda(cudaDeviceSynchronize(), "warmup sync");
+
+    std::vector<thrust::device_vector<CounterT>> opt_hists_d;
+    opt_hists_d.emplace_back(std::move(hist));
+    std::vector<thrust::device_vector<SampleT>> d_levels_per_channel;
+    d_levels_per_channel.emplace_back(std::move(levels));
+    bench_verify_histogram_range<1, 1, SampleT, CounterT, OffsetT>(
+      input, opt_hists_d, d_levels_per_channel, static_cast<OffsetT>(elements), "range");
+    hist        = std::move(opt_hists_d[0]);
+    d_histogram = thrust::raw_pointer_cast(hist.data());
+    levels      = std::move(d_levels_per_channel[0]);
+    d_levels    = thrust::raw_pointer_cast(levels.data());
+  }
+
   caching_allocator_t alloc;
+
   // Force the persisting-L2 reservation back to 0 and demote any persisting
   // lines outside the timed window, so neither cudaAccessPolicyWindow nor a
   // bumped cudaLimitPersistingL2CacheSize can carry across iterations. The

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -8,6 +8,7 @@
 #include <nvbench_helper.cuh>
 
 #include "histogram_common.cuh"
+#include "histogram_inputs.cuh"
 
 // %RANGE% TUNE_ITEMS ipt 7:24:1
 // %RANGE% TUNE_THREADS tpb 128:1024:32
@@ -21,7 +22,7 @@
 template <typename SampleT, typename CounterT, typename OffsetT>
 static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, OffsetT>)
 {
-  const auto entropy   = str_to_entropy(state.get_string("Entropy"));
+  const auto shape     = parse_input_shape(state.get_string("InputShape"));
   const auto elements  = state.get_int64("Elements{io}");
   const auto num_bins  = state.get_int64("Bins");
   const int num_levels = static_cast<int>(num_bins) + 1;
@@ -67,7 +68,8 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   thrust::device_vector<SampleT> levels = h_levels;
   SampleT* d_levels                     = thrust::raw_pointer_cast(levels.data());
 
-  thrust::device_vector<SampleT> input = generate(elements, entropy, lower_level, upper_level);
+  thrust::device_vector<SampleT> input =
+    generate_histogram_input_range<SampleT>(shape, elements, static_cast<int>(num_bins), d_levels);
   thrust::device_vector<CounterT> hist(num_bins);
 
   SampleT* d_input      = thrust::raw_pointer_cast(input.data());
@@ -169,4 +171,18 @@ NVBENCH_BENCH_TYPES(range, NVBENCH_TYPE_AXES(sample_types, counter_types, some_o
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
   .add_int64_axis("Bins", {32, 100, 2000, 16384, 60000, 2097152})
-  .add_string_axis("Entropy", {"0.201", "1.000"});
+  // One `concentrated` shape swept across entropy (1.0=uniform, 0.5=spike,
+  // 0.0=constant) plus the multi-hot and cache-adversarial shapes. Each value
+  // may carry an inline knob as "name:value"; see histogram_inputs.cuh.
+  .add_string_axis(
+    "InputShape",
+    {"concentrated:1.0",
+     "concentrated:0.5",
+     "concentrated:0.0",
+     "powerlaw:0.5",
+     "zipf:1.0",
+     "hash_synonym",
+     "capacity_cliff",
+     "stale_resident",
+     "temporal_phases",
+     "strided_sweep"});

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2011-2023, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: BSD-3
 
-#include <thrust/sequence.h>
+#include <thrust/host_vector.h>
 
 #include <nvbench_helper.cuh>
 
@@ -27,12 +27,24 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   const SampleT lower_level = 0;
   const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
 
-  SampleT step = (upper_level - lower_level) / num_bins;
-  thrust::device_vector<SampleT> levels(num_bins + 1);
-
-  // TODO Extract sequence to the helper TU
-  thrust::sequence(levels.begin(), levels.end(), lower_level, step);
-  SampleT* d_levels = thrust::raw_pointer_cast(levels.data());
+  // Quadratic spacing keeps DispatchRange on the SearchTransform path.
+  thrust::host_vector<SampleT> h_levels(num_bins + 1);
+  h_levels[0]    = lower_level;
+  const double L = static_cast<double>(lower_level);
+  const double U = static_cast<double>(upper_level);
+  const double n = static_cast<double>(num_bins);
+  for (int i = 1; i <= num_bins; ++i)
+  {
+    const double t = static_cast<double>(i) / n;
+    SampleT lvl    = static_cast<SampleT>(L + (U - L) * t * t);
+    if (lvl <= h_levels[i - 1])
+    {
+      lvl = static_cast<SampleT>(h_levels[i - 1] + SampleT{1});
+    }
+    h_levels[i] = lvl;
+  }
+  thrust::device_vector<SampleT> levels = h_levels;
+  SampleT* d_levels                     = thrust::raw_pointer_cast(levels.data());
 
   thrust::device_vector<SampleT> input = generate(elements, entropy, lower_level, upper_level);
   thrust::device_vector<CounterT> hist(num_bins);
@@ -45,25 +57,31 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   state.add_global_memory_writes<CounterT>(num_bins);
 
   caching_allocator_t alloc;
-  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    auto env = cub_bench_env(
-      alloc,
-      launch
+  // Demote persisting L2 lines outside the timed window so that no
+  // cudaAccessPolicyWindow set by the dispatcher can carry across iterations.
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::timer,
+             [&](nvbench::launch& launch, auto& timer) {
+               cudaCtxResetPersistingL2Cache();
+               timer.start();
+               auto env = cub_bench_env(
+                 alloc,
+                 launch
 #if !TUNE_BASE
-      ,
-      cuda::execution::tune(bench_policy_selector<key_t, 1, 1>{})
+                 ,
+                 cuda::execution::tune(bench_policy_selector<key_t, 1, 1>{})
 #endif // !TUNE_BASE
-    );
-    _CCCL_TRY_CUDA_API(
-      cub::DeviceHistogram::HistogramRange,
-      "HistogramRange failed",
-      d_input,
-      d_histogram,
-      num_levels,
-      d_levels,
-      static_cast<OffsetT>(elements),
-      env);
-  });
+               );
+               _CCCL_TRY_CUDA_API(
+                 cub::DeviceHistogram::HistogramRange,
+                 "HistogramRange failed",
+                 d_input,
+                 d_histogram,
+                 num_levels,
+                 d_levels,
+                 static_cast<OffsetT>(elements),
+                 env);
+               timer.stop();
+             });
 }
 
 using counter_types     = nvbench::type_list<int32_t>;
@@ -78,6 +96,6 @@ using sample_types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t, float
 NVBENCH_BENCH_TYPES(range, NVBENCH_TYPE_AXES(sample_types, counter_types, some_offset_types))
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
+  .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
   .add_int64_axis("Bins", {32, 128, 2048, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -97,5 +97,5 @@ NVBENCH_BENCH_TYPES(range, NVBENCH_TYPE_AXES(sample_types, counter_types, some_o
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
-  .add_int64_axis("Bins", {32, 128, 2048, 2097152})
+  .add_int64_axis("Bins", {32, 100, 2000, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -57,10 +57,14 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   state.add_global_memory_writes<CounterT>(num_bins);
 
   caching_allocator_t alloc;
-  // Demote persisting L2 lines outside the timed window so that no
-  // cudaAccessPolicyWindow set by the dispatcher can carry across iterations.
+  // Force the persisting-L2 reservation back to 0 and demote any persisting
+  // lines outside the timed window, so neither cudaAccessPolicyWindow nor a
+  // bumped cudaLimitPersistingL2CacheSize can carry across iterations. The
+  // default reservation is 0; hardcoding 0 also clears any pollution left by
+  // a prior benchmark in the same nvbench process.
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::timer,
              [&](nvbench::launch& launch, auto& timer) {
+               cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, 0);
                cudaCtxResetPersistingL2Cache();
                timer.start();
                auto env = cub_bench_env(

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -111,5 +111,5 @@ NVBENCH_BENCH_TYPES(range, NVBENCH_TYPE_AXES(sample_types, counter_types, some_o
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}", "OffsetT{ct}"})
   .add_int64_axis("Elements{io}", {100'000, 1 << 20, 20'000'000, 1 << 28})
-  .add_int64_axis("Bins", {32, 100, 2000, 2097152})
+  .add_int64_axis("Bins", {32, 100, 2000, 16384, 60000, 2097152})
   .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -3,6 +3,8 @@
 
 #include <thrust/host_vector.h>
 
+#include <random>
+
 #include <nvbench_helper.cuh>
 
 #include "histogram_common.cuh"
@@ -27,21 +29,29 @@ static void range(nvbench::state& state, nvbench::type_list<SampleT, CounterT, O
   const SampleT lower_level = 0;
   const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
 
-  // Quadratic spacing keeps DispatchRange on the SearchTransform path.
+  // Jittered uniform spacing keeps DispatchRange on the SearchTransform path
+  // while keeping bin widths within ~2x of each other. Fixed seed makes the
+  // levels reproducible across runs.
   thrust::host_vector<SampleT> h_levels(num_bins + 1);
-  h_levels[0]    = lower_level;
-  const double L = static_cast<double>(lower_level);
-  const double U = static_cast<double>(upper_level);
-  const double n = static_cast<double>(num_bins);
-  for (int i = 1; i <= num_bins; ++i)
+  const double L    = static_cast<double>(lower_level);
+  const double U    = static_cast<double>(upper_level);
+  const double step = (U - L) / static_cast<double>(num_bins);
+  std::mt19937 rng(0xC0FFEE);
+  std::uniform_real_distribution<double> jitter(-0.25, 0.25);
+  h_levels[0]        = lower_level;
+  h_levels[num_bins] = upper_level;
+  for (int i = 1; i < num_bins; ++i)
   {
-    const double t = static_cast<double>(i) / n;
-    SampleT lvl    = static_cast<SampleT>(L + (U - L) * t * t);
+    SampleT lvl = static_cast<SampleT>(L + i * step + step * jitter(rng));
     if (lvl <= h_levels[i - 1])
     {
       lvl = static_cast<SampleT>(h_levels[i - 1] + SampleT{1});
     }
     h_levels[i] = lvl;
+  }
+  if (h_levels[num_bins] <= h_levels[num_bins - 1])
+  {
+    h_levels[num_bins] = static_cast<SampleT>(h_levels[num_bins - 1] + SampleT{1});
   }
   thrust::device_vector<SampleT> levels = h_levels;
   SampleT* d_levels                     = thrust::raw_pointer_cast(levels.data());

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -147,8 +147,36 @@ struct DeviceHistogramKernelSource
     if constexpr (::cuda::std::is_integral_v<CommonT>)
     {
       using IntArithmeticT = typename TransformsT::ScaleTransform::IntArithmeticT;
-      return static_cast<IntArithmeticT>(upper_level[channel] - lower_level[channel])
-           > (::cuda::std::numeric_limits<IntArithmeticT>::max() / static_cast<IntArithmeticT>(num_bins));
+      // Compute `upper - lower` without overflowing the level type. For
+      // signed integer level types with full range (e.g. int32_t with
+      // [INT_MIN, INT_MAX/4]), the signed difference overflows.
+      // Reinterpret-cast each operand through its unsigned counterpart and
+      // subtract in unsigned arithmetic; modular wrap-around produces the
+      // correct (non-negative) difference.
+      // Compute `upper - lower` without overflow. For signed integer
+      // level types, the signed difference can overflow (e.g. int32_t
+      // with [INT_MIN, INT_MAX]) and even narrow types are subject to
+      // C++ integer promotion to `int`, which then converts back to
+      // unsigned through sign-extension. We:
+      //   1. Cast each operand to its unsigned counterpart of the same
+      //      width (`make_unsigned_t<LevelT>`). This reinterprets the
+      //      bit pattern: int8_t(-128..127) -> uint8_t(128..255, 0..127).
+      //   2. Subtract through an unsigned-wraparound assignment. C++
+      //      integer promotion forces the operands up to `int` for the
+      //      subtraction, but assigning the result back to ULevelT
+      //      truncates via unsigned modular wrap-around, producing the
+      //      correct difference in [0, 2^N - 1]. Pre-promoting to the
+      //      destination integer arithmetic type before subtraction would
+      //      sign-extend the int promotion's negative result into the
+      //      wider type and yield a giant garbage value.
+      //   3. Widen the truncated unsigned difference to `IntArithmeticT`,
+      //      which holds it without overflow.
+      using ArrayLevelT = typename UpperLevelArrayT::value_type;
+      using ULevelT     = ::cuda::std::make_unsigned_t<ArrayLevelT>;
+      const ULevelT diff = static_cast<ULevelT>(static_cast<ULevelT>(upper_level[channel])
+                                                - static_cast<ULevelT>(lower_level[channel]));
+      const IntArithmeticT range = static_cast<IntArithmeticT>(diff);
+      return range > (::cuda::std::numeric_limits<IntArithmeticT>::max() / static_cast<IntArithmeticT>(num_bins));
     }
     else
     {
@@ -1014,7 +1042,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch_even(
       num_privatized_levels[channel] = 257;
 
       int num_levels = num_output_levels[channel];
-      if (kernel_source.MayOverflow(static_cast<CommonT>(num_levels - 1), upper_level, lower_level, channel))
+      if (kernel_source.MayOverflow(num_levels - 1, upper_level, lower_level, channel))
       {
         if (!d_temp_storage)
         {
@@ -1075,7 +1103,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch_even(
     for (int channel = 0; channel < NUM_ACTIVE_CHANNELS; ++channel)
     {
       int num_levels = num_output_levels[channel];
-      if (kernel_source.MayOverflow(static_cast<CommonT>(num_levels - 1), upper_level, lower_level, channel))
+      if (kernel_source.MayOverflow(num_levels - 1, upper_level, lower_level, channel))
       {
         if (!d_temp_storage)
         {

--- a/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
@@ -117,14 +117,24 @@ struct Transforms
       ::cuda::std::is_integral<T>;
 #endif // !_CCCL_HAS_INT128()
 
+    // Storage type for the precomputed `range = max_level - min_level` and
+    // `bins = num_levels - 1` used by the integer ComputeBin path. For
+    // narrow integer CommonT (e.g. int8_t with full range), `max - min`
+    // overflows CommonT and would silently produce wrong bins; widening to
+    // `IntArithmeticT` (uint32_t / uint64_t) holds the difference without
+    // overflow. For 128-bit and non-integer types, IntArithmeticT == CommonT
+    // (or wider), so this is also correct.
+    using FractionStorageT =
+      ::cuda::std::_If<is_integral_excl_int128<CommonT>::value, IntArithmeticT, CommonT>;
+
     union ScaleT
     {
       // Used when CommonT is not floating-point to avoid intermediate
       // rounding errors (see NVIDIA/cub#489).
       struct FractionT
       {
-        CommonT bins;
-        CommonT range;
+        FractionStorageT bins;
+        FractionStorageT range;
       } fraction;
 
       // Used when CommonT is floating-point as an optimization.
@@ -149,8 +159,30 @@ struct Transforms
     ComputeScale(int num_levels, T max_level, T min_level, ::cuda::std::false_type /* is_fp */)
     {
       ScaleT result;
-      result.fraction.bins  = static_cast<T>(num_levels - 1);
-      result.fraction.range = static_cast<T>(max_level - min_level);
+      result.fraction.bins = static_cast<FractionStorageT>(num_levels - 1);
+      // Compute `max - min` without overflowing T. For signed integer T
+      // with full range (e.g. int8_t with [-128, 127]), the signed
+      // difference `127 - (-128) = 255` overflows int8_t. Cast each
+      // operand to its unsigned counterpart of the same width and
+      // subtract, then assign back to that unsigned type to truncate via
+      // modular wrap-around: e.g. for int8_t with max=127, min=-128, the
+      // unsigned reinterpretations are uint8_t(127)=127 and
+      // uint8_t(-128)=128 (two's complement bit pattern). C++ integer
+      // promotion lifts the subtraction to int (127 - 128 = -1), and
+      // truncating that back to uint8_t yields 255 — the correct
+      // difference in [0, 2^N - 1]. The intermediate ULevelT is required
+      // because casting the int result directly to FractionStorageT (a
+      // wider unsigned type) would sign-extend -1 into a giant value.
+      if constexpr (::cuda::std::is_integral_v<T>)
+      {
+        using UT          = ::cuda::std::make_unsigned_t<T>;
+        const UT diff     = static_cast<UT>(static_cast<UT>(max_level) - static_cast<UT>(min_level));
+        result.fraction.range = static_cast<FractionStorageT>(diff);
+      }
+      else
+      {
+        result.fraction.range = static_cast<FractionStorageT>(max_level - min_level);
+      }
       return result;
     }
 
@@ -303,7 +335,20 @@ struct Transforms
     {
       if (valid)
       {
-        bin = static_cast<int>(sample);
+        // The byte-sample privatized histogram has 256 bins indexed by the
+        // sample's unsigned byte value. For signed integer samples this
+        // reinterprets the bit pattern: int8_t(-128..127) -> uint8_t(128..255, 0..127).
+        // Without this reinterpretation, negative samples cast directly to
+        // `int` produce negative bin indices and are silently dropped.
+        if constexpr (::cuda::std::is_integral_v<_SampleT>)
+        {
+          using UT = ::cuda::std::make_unsigned_t<_SampleT>;
+          bin      = static_cast<int>(static_cast<UT>(sample));
+        }
+        else
+        {
+          bin = static_cast<int>(sample);
+        }
       }
     }
   };

--- a/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
@@ -262,13 +262,25 @@ struct Transforms
       return static_cast<int>(((sample - min_level) * scale.fraction.bins) / scale.fraction.range);
     }
 
-    //! @brief Bin computation for integral types of up to 64-bit types
+    //! @brief Bin computation for integral types of up to 64-bit types.
+    //!
+    //! Compute `sample - min_level` via the unsigned representation of T,
+    //! mirroring `ComputeScale`. For signed integer T with negative
+    //! `min_level` (e.g. `min_level = INT_MIN`), the signed difference
+    //! `sample - min_level` overflows T and is undefined behaviour; the
+    //! resulting numerator on two's complement is a wildly wrong magnitude
+    //! and produces an incorrect bin (the sample is dropped from the output
+    //! histogram). The unsigned subtraction wraps modularly and yields the
+    //! correct non-negative difference exactly the way `ComputeScale`
+    //! computes `max_level - min_level`.
     template <typename T, ::cuda::std::enable_if_t<is_integral_excl_int128<T>::value, int> = 0>
     _CCCL_HOST_DEVICE _CCCL_FORCEINLINE int ComputeBin(T sample, T min_level, ScaleT scale) const
     {
+      using UT                  = ::cuda::std::make_unsigned_t<T>;
+      const IntArithmeticT diff = static_cast<IntArithmeticT>(
+        static_cast<UT>(static_cast<UT>(sample) - static_cast<UT>(min_level)));
       return static_cast<int>(
-        (static_cast<IntArithmeticT>(sample - min_level) * static_cast<IntArithmeticT>(scale.fraction.bins))
-        / static_cast<IntArithmeticT>(scale.fraction.range));
+        (diff * static_cast<IntArithmeticT>(scale.fraction.bins)) / static_cast<IntArithmeticT>(scale.fraction.range));
     }
 
     template <typename T, ::cuda::std::enable_if_t<!is_integral_excl_int128<T>::value, int> = 0>

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -716,8 +716,15 @@ C2H_TEST_LIST("DeviceHistogram::HistogramEven bin computation does not overflow"
   CHECK(error2 == (num_bins == 1 || sizeof(sample_t) <= 4UL ? cudaSuccess : cudaErrorInvalidValue));
 }
 
-// When the number of bins exceeds what LevelT can represent, the bin computation will overflow
-// during the cast to CommonT. We expect cudaErrorInvalidValue to be returned.
+// `num_bins` may exceed what `LevelT` can represent without an error: bin
+// width can be fractional (smaller than one LevelT distinct value), and the
+// integer ComputeBin path promotes through `IntArithmeticT` (uint32_t /
+// uint64_t) so the multiplication and division do not overflow even when
+// `num_bins > numeric_limits<LevelT>::max()`. The previous implementation
+// returned `cudaErrorInvalidValue` in this regime because both the
+// `MayOverflow` precondition and `ScaleTransform`'s `range = max - min`
+// storage truncated `num_bins` and the level difference back to `LevelT`
+// before checking; once those casts are removed, the dispatch succeeds.
 C2H_TEST_LIST(
   "DeviceHistogram::HistogramEven num_bins exceeds LevelT range", "[histogram_even][device]", int8_t, int16_t)
 {
@@ -733,13 +740,13 @@ C2H_TEST_LIST(
   auto d_samples   = cuda::counting_iterator<sample_t>{0};
   auto d_histo_out = c2h::device_vector<counter_t>(4096);
 
-  // Test with num_bins that exceeds what LevelT can represent
-  // int8_t max = 127, so 128 bins will overflow
-  // int16_t max = 32767, so 32768 bins will overflow
+  // num_bins that previously overflowed LevelT-typed storage:
+  //   int8_t  max = 127, so 128 bins triggered the bug
+  //   int16_t max = 32767, so 32768 bins triggered the bug
   const int num_bins_overflow = static_cast<int>(cs::numeric_limits<level_t>::max()) + 1;
   const int num_levels        = num_bins_overflow + 1;
 
-  // Verify temp_storage_bytes is always initialized even on error
+  // Verify temp_storage_bytes is always initialized.
   constexpr size_t canary_bytes = 3;
   size_t temp_storage_bytes     = canary_bytes;
 
@@ -753,12 +760,12 @@ C2H_TEST_LIST(
     upper_level,
     num_samples);
 
-  // Should return error because num_bins overflows LevelT
-  CHECK(error1 == cudaErrorInvalidValue);
-  // Should still initialize temp_storage_bytes to a valid value
+  // Now succeeds: bin width is fractional but the integer ComputeBin path
+  // handles it correctly.
+  CHECK(error1 == cudaSuccess);
   CHECK(temp_storage_bytes != canary_bytes);
 
-  // Also verify that valid num_bins works
+  // Also verify that num_bins == numeric_limits<LevelT>::max() still works.
   const int valid_num_bins   = static_cast<int>(cs::numeric_limits<level_t>::max());
   const int valid_num_levels = valid_num_bins + 1;
 

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -202,6 +202,12 @@ auto setup_bin_levels_for_range(const array<int, ActiveChannels>& num_levels, Le
   const auto min_bin_width = max_level / (max_level_count - 1);
   REQUIRE(min_bin_width > 0);
 
+  // Perturb interior levels to defeat uniform-spacing detection so the
+  // SearchTransform path is exercised. Endpoints stay anchored. When
+  // min_bin_width is too small for a strictly monotonic shift (e.g. byte-sample
+  // tests with 256 levels), levels stay uniform.
+  const auto perturbation_step = min_bin_width / 4;
+
   array<c2h::host_vector<LevelT>, ActiveChannels> levels;
   for (size_t c = 0; c < ActiveChannels; ++c)
   {
@@ -211,7 +217,12 @@ auto setup_bin_levels_for_range(const array<int, ActiveChannels>& num_levels, Le
     const auto lower_level    = (max_level / 2 - min_hist_width / 2);
     for (int l = 0; l < num_levels[c]; ++l)
     {
-      levels[c][l] = static_cast<LevelT>(lower_level + l * min_bin_width);
+      auto level = static_cast<LevelT>(lower_level + l * min_bin_width);
+      if (l > 0 && l < num_levels[c] - 1 && perturbation_step > LevelT{0})
+      {
+        level = static_cast<LevelT>(level + (l % 2 == 0 ? perturbation_step : -perturbation_step));
+      }
+      levels[c][l] = level;
       if (l > 0)
       {
         REQUIRE(levels[c][l - 1] < levels[c][l]);

--- a/cub/test/catch2_test_device_histogram_input_shapes.cu
+++ b/cub/test/catch2_test_device_histogram_input_shapes.cu
@@ -1,0 +1,292 @@
+// SPDX-FileCopyrightText: Copyright (c) 2011-2023, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3
+
+// Validates the histogram-benchmark input-shape generators in
+// cub/benchmarks/bench/histogram/histogram_inputs.cuh: that each named shape
+// produces the bin distribution / ordering structure it claims, and that the
+// entropy and per-shape knobs behave monotonically. This is the shape contract;
+// per-bin *counting* correctness is separately enforced by the in-bench
+// verifier (bench_verify_histogram_*).
+
+#include <thrust/copy.h>
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <vector>
+
+// The generator header lives in the benchmarks tree; include it by relative
+// path. It is self-contained (thrust + cuda/std only), so this is safe.
+#include "../benchmarks/bench/histogram/histogram_inputs.cuh"
+
+#include <c2h/catch2_test_helper.h>
+
+namespace
+{
+
+// Generate an EVEN input for `spec` and return the per-bin counts, recomputed
+// from the sample values with the same formula CUB uses.
+template <class SampleT>
+std::vector<long long>
+bin_counts_even(const ShapeSpec& spec, int64_t n, int num_bins, SampleT lower, SampleT upper, uint64_t seed = 42)
+{
+  thrust::device_vector<SampleT> d_input =
+    generate_histogram_input_even<SampleT>(spec, n, num_bins, lower, upper, seed);
+  thrust::host_vector<SampleT> h_input = d_input;
+
+  std::vector<long long> counts(num_bins, 0);
+  const double L     = static_cast<double>(lower);
+  const double U     = static_cast<double>(upper);
+  const double scale = static_cast<double>(num_bins) / (U - L);
+  for (SampleT s : h_input)
+  {
+    if (s < lower || s >= upper)
+    {
+      continue; // out-of-range samples are not counted by CUB either
+    }
+    int bin = static_cast<int>((static_cast<double>(s) - L) * scale);
+    if (bin >= num_bins)
+    {
+      bin = num_bins - 1;
+    }
+    if (bin >= 0)
+    {
+      ++counts[bin];
+    }
+  }
+  return counts;
+}
+
+double normalized_entropy_counts(const std::vector<long long>& counts, int64_t n)
+{
+  if (counts.size() <= 1 || n == 0)
+  {
+    return 0.0;
+  }
+  double h = 0.0;
+  for (long long c : counts)
+  {
+    if (c > 0)
+    {
+      const double p = static_cast<double>(c) / static_cast<double>(n);
+      h -= p * std::log2(p);
+    }
+  }
+  return h / std::log2(static_cast<double>(counts.size()));
+}
+
+int nonzero_bins(const std::vector<long long>& counts)
+{
+  return static_cast<int>(std::count_if(counts.begin(), counts.end(), [](long long c) {
+    return c > 0;
+  }));
+}
+
+long long top_count(const std::vector<long long>& counts)
+{
+  return *std::max_element(counts.begin(), counts.end());
+}
+
+constexpr int64_t N = 200000;
+constexpr int32_t LO = 0;
+constexpr int32_t HI = 4096; // bin width 1 at B=4096; >1 below that
+
+} // namespace
+
+C2H_TEST("histogram input: concentrated endpoints are exact", "[histogram][input_shapes]")
+{
+  const int num_bins = 64;
+
+  // entropy 1.0 -> uniform: every bin within a few % of N/num_bins.
+  {
+    auto counts        = bin_counts_even<int32_t>(parse_input_shape("concentrated:1.0"), N, num_bins, LO, HI);
+    const double mean  = static_cast<double>(N) / num_bins;
+    REQUIRE(nonzero_bins(counts) == num_bins);
+    for (long long c : counts)
+    {
+      REQUIRE(std::abs(c - mean) < 0.15 * mean);
+    }
+    REQUIRE(normalized_entropy_counts(counts, N) > 0.99);
+  }
+
+  // entropy 0.0 -> constant: exactly one nonzero bin holding everything.
+  {
+    auto counts = bin_counts_even<int32_t>(parse_input_shape("concentrated:0.0"), N, num_bins, LO, HI);
+    REQUIRE(nonzero_bins(counts) == 1);
+    REQUIRE(top_count(counts) == N);
+  }
+}
+
+C2H_TEST("histogram input: concentrated entropy knob is monotone", "[histogram][input_shapes]")
+{
+  const int num_bins = 64;
+  // As the entropy knob falls, the top-bin share must rise monotonically.
+  double prev_share = -1.0;
+  for (double e : {1.0, 0.75, 0.5, 0.25, 0.0})
+  {
+    auto counts        = bin_counts_even<int32_t>(parse_input_shape("concentrated:" + std::to_string(e)), N, num_bins, LO, HI);
+    const double share = static_cast<double>(top_count(counts)) / N;
+    if (prev_share >= 0.0)
+    {
+      REQUIRE(share >= prev_share - 0.02); // non-decreasing (small tolerance)
+    }
+    prev_share = share;
+  }
+  REQUIRE(prev_share > 0.99); // entropy 0 ends at ~100% top share
+}
+
+C2H_TEST("histogram input: hot bin is not pinned to zero", "[histogram][input_shapes]")
+{
+  const int num_bins = 64;
+  // Different seeds should move the hot bin (spike-slab at entropy 0.3).
+  std::map<int, int> argmax_seen;
+  for (uint64_t seed : {1ull, 2ull, 3ull, 4ull, 5ull})
+  {
+    auto counts   = bin_counts_even<int32_t>(parse_input_shape("concentrated:0.3"), N, num_bins, LO, HI, seed);
+    const int arg = static_cast<int>(std::max_element(counts.begin(), counts.end()) - counts.begin());
+    ++argmax_seen[arg];
+  }
+  // The mode is not always bin 0, and varies across seeds.
+  REQUIRE(argmax_seen.count(0) < 5);
+  REQUIRE(argmax_seen.size() >= 2);
+}
+
+C2H_TEST("histogram input: powerlaw is a decaying warm set", "[histogram][input_shapes]")
+{
+  const int num_bins = 256;
+  auto counts        = bin_counts_even<int32_t>(parse_input_shape("powerlaw:0.4"), N, num_bins, LO, HI);
+  // Many hot bins (more than a single spike), with a heavy head: the top bin
+  // holds a large share and the warm set (top-K) dominates.
+  REQUIRE(nonzero_bins(counts) > 5);
+  std::vector<long long> sorted(counts);
+  std::sort(sorted.rbegin(), sorted.rend());
+  const double top1 = static_cast<double>(sorted[0]) / N;
+  double top8       = 0.0;
+  for (int i = 0; i < 8 && i < static_cast<int>(sorted.size()); ++i)
+  {
+    top8 += static_cast<double>(sorted[i]) / N;
+  }
+  REQUIRE(top1 > 0.05);
+  REQUIRE(top8 > 0.5); // a small warm set carries most of the mass
+  REQUIRE(top1 < 0.99); // but not a single spike
+}
+
+C2H_TEST("histogram input: powerlaw knob is monotone in entropy", "[histogram][input_shapes]")
+{
+  const int num_bins = 256;
+  // Entropy decreases across the loop, so the top-bin share must RISE
+  // (non-decreasing): lower target entropy -> higher concentration.
+  double prev_top = -1.0;
+  for (double e : {0.8, 0.6, 0.4, 0.2})
+  {
+    auto counts        = bin_counts_even<int32_t>(parse_input_shape("powerlaw:" + std::to_string(e)), N, num_bins, LO, HI);
+    std::vector<long long> sorted(counts);
+    std::sort(sorted.rbegin(), sorted.rend());
+    const double top1 = static_cast<double>(sorted[0]) / N;
+    REQUIRE(top1 >= prev_top - 0.02); // non-decreasing as entropy falls
+    prev_top = top1;
+  }
+}
+
+C2H_TEST("histogram input: capacity_cliff active set tracks the knob", "[histogram][input_shapes]")
+{
+  // num_bins large enough that the active set fits below it.
+  const int num_bins = 16384;
+  // Default => kAdversarialCacheSlots + 1 distinct equiprobable bins.
+  {
+    auto counts = bin_counts_even<int32_t>(parse_input_shape("capacity_cliff"), N * 4, num_bins, LO, 16384);
+    // Sampling N*4 over slots+1 bins: expect ~ all of them populated.
+    const int nz = nonzero_bins(counts);
+    REQUIRE(nz > kAdversarialCacheSlots / 2); // a large active set, near capacity
+    REQUIRE(nz <= kAdversarialCacheSlots + 1);
+  }
+  // Knob 0.25 => ~1024 active bins (a quarter of capacity).
+  {
+    const int num_bins2 = 4096;
+    auto counts = bin_counts_even<int32_t>(parse_input_shape("capacity_cliff:0.25"), N * 4, num_bins2, LO, 4096);
+    const int nz = nonzero_bins(counts);
+    REQUIRE(nz > 256);
+    REQUIRE(nz <= 1100);
+  }
+}
+
+C2H_TEST("histogram input: stale_resident has a cold prefix and a dominant hot bin", "[histogram][input_shapes]")
+{
+  const int num_bins = 16384;
+  // n must exceed the cold prefix (kAdversarialCacheSlots) so a hot bulk exists.
+  auto counts = bin_counts_even<int32_t>(parse_input_shape("stale_resident"), N, num_bins, LO, 16384);
+  // Cold prefix touches ~kAdversarialCacheSlots distinct bins once each.
+  REQUIRE(nonzero_bins(counts) > kAdversarialCacheSlots / 2);
+  // One hot bin dominates (the bulk), far above the single-visit cold bins.
+  const double top = static_cast<double>(top_count(counts)) / N;
+  REQUIRE(top > 0.5);
+}
+
+C2H_TEST("histogram input: temporal_phases changes the hot bin across phases", "[histogram][input_shapes]")
+{
+  const int num_bins = 256;
+  const int phases   = 4;
+  thrust::device_vector<int32_t> d_input =
+    generate_histogram_input_even<int32_t>(parse_input_shape("temporal_phases:" + std::to_string(phases)), N, num_bins, LO, HI);
+  thrust::host_vector<int32_t> h = d_input;
+
+  const double scale = static_cast<double>(num_bins) / (static_cast<double>(HI) - static_cast<double>(LO));
+  std::vector<int> phase_mode;
+  const int64_t per = N / phases;
+  for (int p = 0; p < phases; ++p)
+  {
+    std::map<int, long long> c;
+    for (int64_t i = p * per; i < (p + 1) * per; ++i)
+    {
+      int bin = static_cast<int>(static_cast<double>(h[i]) * scale);
+      if (bin >= num_bins) bin = num_bins - 1;
+      ++c[bin];
+    }
+    int best = -1; long long bestc = -1;
+    for (auto& kv : c) { if (kv.second > bestc) { bestc = kv.second; best = kv.first; } }
+    phase_mode.push_back(best);
+  }
+  // Adjacent phases must have different hot bins.
+  for (int p = 1; p < phases; ++p)
+  {
+    REQUIRE(phase_mode[p] != phase_mode[p - 1]);
+  }
+}
+
+C2H_TEST("histogram input: strided_sweep is flat in distribution but ordered", "[histogram][input_shapes]")
+{
+  const int num_bins = 256;
+  auto counts        = bin_counts_even<int32_t>(parse_input_shape("strided_sweep"), N, num_bins, LO, HI);
+  // A stride coprime to num_bins visits every bin near-equally.
+  REQUIRE(nonzero_bins(counts) == num_bins);
+  REQUIRE(normalized_entropy_counts(counts, N) > 0.98);
+}
+
+C2H_TEST("histogram input: RANGE path maps bins into level intervals", "[histogram][input_shapes]")
+{
+  // Build a simple strictly-increasing level array and check that a constant
+  // (entropy 0) input lands every sample inside one [levels[b], levels[b+1]).
+  const int num_bins = 32;
+  thrust::host_vector<int32_t> h_levels(num_bins + 1);
+  for (int i = 0; i <= num_bins; ++i)
+  {
+    h_levels[i] = i * 10; // levels 0,10,20,...,320
+  }
+  thrust::device_vector<int32_t> d_levels = h_levels;
+
+  thrust::device_vector<int32_t> d_input = generate_histogram_input_range<int32_t>(
+    parse_input_shape("concentrated:0.0"), N, num_bins, thrust::raw_pointer_cast(d_levels.data()));
+  thrust::host_vector<int32_t> h = d_input;
+
+  // All samples equal (constant) and inside the same level interval.
+  const int32_t v0 = h[0];
+  for (int32_t v : h)
+  {
+    REQUIRE(v == v0);
+  }
+  // v0 must sit within some [levels[b], levels[b+1]).
+  REQUIRE(v0 >= h_levels[0]);
+  REQUIRE(v0 < h_levels[num_bins]);
+}

--- a/cub/test/catch2_test_device_histogram_thread_local_cache.cu
+++ b/cub/test/catch2_test_device_histogram_thread_local_cache.cu
@@ -1,0 +1,251 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Exercises the thread_local detection-stream / detection-buffer cache used by
+// dispatch_range's uniform-levels detection path: sequential calls on multiple
+// user streams, concurrent calls from multiple threads, and the cross-device
+// hazard where the cache is bound to the device current at first call.
+
+#include <cub/device/device_histogram.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+#include <algorithm>
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include <c2h/catch2_test_helper.h>
+
+namespace
+{
+
+using sample_t  = int;
+using counter_t = int;
+
+// Non-uniform spacing keeps DispatchRange on the SearchTransform path, which is
+// where the thread_local detection cache is exercised.
+auto make_levels(int num_bins) -> thrust::host_vector<sample_t>
+{
+  thrust::host_vector<sample_t> levels(num_bins + 1);
+  levels[0] = 0;
+  for (int i = 1; i <= num_bins; ++i)
+  {
+    const double t = static_cast<double>(i) / num_bins;
+    sample_t v     = static_cast<sample_t>(t * t * 1024.0);
+    if (v <= levels[i - 1])
+    {
+      v = static_cast<sample_t>(levels[i - 1] + 1);
+    }
+    levels[i] = v;
+  }
+  return levels;
+}
+
+auto reference_histogram(const thrust::host_vector<sample_t>& samples, const thrust::host_vector<sample_t>& levels)
+  -> thrust::host_vector<counter_t>
+{
+  const int num_bins = static_cast<int>(levels.size()) - 1;
+  thrust::host_vector<counter_t> ref(num_bins, 0);
+  for (sample_t s : samples)
+  {
+    auto ub = std::upper_bound(levels.begin(), levels.end(), s);
+    if (ub == levels.begin() || ub == levels.end())
+    {
+      continue;
+    }
+    ++ref[std::distance(levels.begin(), ub) - 1];
+  }
+  return ref;
+}
+
+void run_histogram_range(
+  cudaStream_t stream,
+  const thrust::device_vector<sample_t>& d_samples,
+  const thrust::device_vector<sample_t>& d_levels,
+  thrust::device_vector<counter_t>& d_histogram)
+{
+  const int num_levels = static_cast<int>(d_levels.size());
+  size_t temp_bytes    = 0;
+  REQUIRE(cudaSuccess
+          == cub::DeviceHistogram::HistogramRange(
+            nullptr,
+            temp_bytes,
+            thrust::raw_pointer_cast(d_samples.data()),
+            thrust::raw_pointer_cast(d_histogram.data()),
+            num_levels,
+            thrust::raw_pointer_cast(d_levels.data()),
+            static_cast<int>(d_samples.size()),
+            stream));
+  thrust::device_vector<unsigned char> temp(temp_bytes);
+  REQUIRE(cudaSuccess
+          == cub::DeviceHistogram::HistogramRange(
+            thrust::raw_pointer_cast(temp.data()),
+            temp_bytes,
+            thrust::raw_pointer_cast(d_samples.data()),
+            thrust::raw_pointer_cast(d_histogram.data()),
+            num_levels,
+            thrust::raw_pointer_cast(d_levels.data()),
+            static_cast<int>(d_samples.size()),
+            stream));
+}
+
+} // namespace
+
+C2H_TEST("DeviceHistogram::HistogramRange thread_local cache: sequential calls on multiple user streams",
+         "[histogram][device]")
+{
+  constexpr int num_bins    = 32;
+  constexpr int num_samples = 4096;
+
+  const auto h_levels = make_levels(num_bins);
+  thrust::host_vector<sample_t> h_samples(num_samples);
+  for (int i = 0; i < num_samples; ++i)
+  {
+    h_samples[i] = static_cast<sample_t>((i * 31) % 1024);
+  }
+  const auto h_ref = reference_histogram(h_samples, h_levels);
+
+  thrust::device_vector<sample_t> d_samples = h_samples;
+  thrust::device_vector<sample_t> d_levels  = h_levels;
+
+  cudaStream_t stream_a;
+  cudaStream_t stream_b;
+  REQUIRE(cudaSuccess == cudaStreamCreate(&stream_a));
+  REQUIRE(cudaSuccess == cudaStreamCreate(&stream_b));
+
+  for (cudaStream_t s : {stream_a, stream_b, stream_a})
+  {
+    thrust::device_vector<counter_t> d_histogram(num_bins, 0);
+    run_histogram_range(s, d_samples, d_levels, d_histogram);
+    REQUIRE(cudaSuccess == cudaStreamSynchronize(s));
+    thrust::host_vector<counter_t> h_got = d_histogram;
+    CHECK(h_got == h_ref);
+  }
+
+  REQUIRE(cudaSuccess == cudaStreamDestroy(stream_a));
+  REQUIRE(cudaSuccess == cudaStreamDestroy(stream_b));
+}
+
+C2H_TEST("DeviceHistogram::HistogramRange thread_local cache: concurrent threads on the same device",
+         "[histogram][device]")
+{
+  constexpr int num_bins    = 64;
+  constexpr int num_samples = 8192;
+  constexpr int num_threads = 4;
+
+  const auto h_levels = make_levels(num_bins);
+  thrust::host_vector<sample_t> h_samples(num_samples);
+  for (int i = 0; i < num_samples; ++i)
+  {
+    h_samples[i] = static_cast<sample_t>((i * 13 + 7) % 1024);
+  }
+  const auto h_ref = reference_histogram(h_samples, h_levels);
+
+  thrust::device_vector<sample_t> d_samples = h_samples;
+  thrust::device_vector<sample_t> d_levels  = h_levels;
+
+  std::atomic<int> failures{0};
+  std::vector<std::thread> threads;
+  threads.reserve(num_threads);
+
+  for (int t = 0; t < num_threads; ++t)
+  {
+    threads.emplace_back([&]() {
+      cudaStream_t stream;
+      if (cudaStreamCreate(&stream) != cudaSuccess)
+      {
+        failures.fetch_add(1);
+        return;
+      }
+      for (int it = 0; it < 2; ++it)
+      {
+        thrust::device_vector<counter_t> d_histogram(num_bins, 0);
+        const int num_levels = static_cast<int>(d_levels.size());
+        size_t temp_bytes    = 0;
+        if (cub::DeviceHistogram::HistogramRange(
+              nullptr,
+              temp_bytes,
+              thrust::raw_pointer_cast(d_samples.data()),
+              thrust::raw_pointer_cast(d_histogram.data()),
+              num_levels,
+              thrust::raw_pointer_cast(d_levels.data()),
+              static_cast<int>(d_samples.size()),
+              stream)
+            != cudaSuccess)
+        {
+          failures.fetch_add(1);
+          continue;
+        }
+        thrust::device_vector<unsigned char> temp(temp_bytes);
+        if (cub::DeviceHistogram::HistogramRange(
+              thrust::raw_pointer_cast(temp.data()),
+              temp_bytes,
+              thrust::raw_pointer_cast(d_samples.data()),
+              thrust::raw_pointer_cast(d_histogram.data()),
+              num_levels,
+              thrust::raw_pointer_cast(d_levels.data()),
+              static_cast<int>(d_samples.size()),
+              stream)
+            != cudaSuccess)
+        {
+          failures.fetch_add(1);
+          continue;
+        }
+        if (cudaStreamSynchronize(stream) != cudaSuccess)
+        {
+          failures.fetch_add(1);
+          continue;
+        }
+        thrust::host_vector<counter_t> h_got = d_histogram;
+        if (h_got != h_ref)
+        {
+          failures.fetch_add(1);
+        }
+      }
+      cudaStreamDestroy(stream);
+    });
+  }
+  for (auto& th : threads)
+  {
+    th.join();
+  }
+  CHECK(failures.load() == 0);
+}
+
+C2H_TEST("DeviceHistogram::HistogramRange thread_local cache: same thread switches devices between calls",
+         "[histogram][device]")
+{
+  int num_devices = 0;
+  REQUIRE(cudaSuccess == cudaGetDeviceCount(&num_devices));
+  if (num_devices < 2)
+  {
+    SKIP("Requires >= 2 CUDA devices");
+  }
+
+  constexpr int num_bins    = 32;
+  constexpr int num_samples = 4096;
+
+  const auto h_levels = make_levels(num_bins);
+  thrust::host_vector<sample_t> h_samples(num_samples);
+  for (int i = 0; i < num_samples; ++i)
+  {
+    h_samples[i] = static_cast<sample_t>((i * 17) % 1024);
+  }
+  const auto h_ref = reference_histogram(h_samples, h_levels);
+
+  for (int dev : {0, 1, 0})
+  {
+    REQUIRE(cudaSuccess == cudaSetDevice(dev));
+    thrust::device_vector<sample_t> d_samples = h_samples;
+    thrust::device_vector<sample_t> d_levels  = h_levels;
+    thrust::device_vector<counter_t> d_histogram(num_bins, 0);
+    run_histogram_range(/*stream=*/0, d_samples, d_levels, d_histogram);
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+    thrust::host_vector<counter_t> h_got = d_histogram;
+    INFO("device " << dev);
+    CHECK(h_got == h_ref);
+  }
+  REQUIRE(cudaSuccess == cudaSetDevice(0));
+}

--- a/cub/test/catch2_test_device_histogram_thread_local_cache.cu
+++ b/cub/test/catch2_test_device_histogram_thread_local_cache.cu
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <random>
 #include <thread>
 #include <vector>
 
@@ -24,21 +25,30 @@ namespace
 using sample_t  = int;
 using counter_t = int;
 
-// Non-uniform spacing keeps DispatchRange on the SearchTransform path, which is
-// where the thread_local detection cache is exercised.
+// Jittered uniform spacing keeps DispatchRange on the SearchTransform path,
+// which is where the thread_local detection cache is exercised. Fixed seed
+// makes the levels reproducible across runs.
 auto make_levels(int num_bins) -> thrust::host_vector<sample_t>
 {
+  constexpr double upper = 1024.0;
+  const double step      = upper / static_cast<double>(num_bins);
   thrust::host_vector<sample_t> levels(num_bins + 1);
-  levels[0] = 0;
-  for (int i = 1; i <= num_bins; ++i)
+  std::mt19937 rng(0xC0FFEE);
+  std::uniform_real_distribution<double> jitter(-0.25, 0.25);
+  levels[0]        = 0;
+  levels[num_bins] = static_cast<sample_t>(upper);
+  for (int i = 1; i < num_bins; ++i)
   {
-    const double t = static_cast<double>(i) / num_bins;
-    sample_t v     = static_cast<sample_t>(t * t * 1024.0);
+    sample_t v = static_cast<sample_t>(i * step + step * jitter(rng));
     if (v <= levels[i - 1])
     {
       v = static_cast<sample_t>(levels[i - 1] + 1);
     }
     levels[i] = v;
+  }
+  if (levels[num_bins] <= levels[num_bins - 1])
+  {
+    levels[num_bins] = static_cast<sample_t>(levels[num_bins - 1] + 1);
   }
   return levels;
 }


### PR DESCRIPTION
## Summary

Hardens the four `cub.bench.histogram.{even,range,multi.even,multi.range}.base` NVBench benchmarks (under `cub/benchmarks/bench/histogram/`) against pattern-matching tunings and silent dispatch failures, and adds an opt-out bin-by-bin correctness verifier that runs outside the timed region. Also extends and adds CTest coverage in `cub/test/`.

The four benchmarks each call into `cub::DeviceHistogram::HistogramEven` / `HistogramRange` (single-channel) or `MultiHistogramEven` / `MultiHistogramRange` (3-active-channel of 4) over a sweep of input sizes, bin counts, sample types, and entropy values, and report a bandwidth in bytes/sec via NVBench's `GlobalMem BW` column.

## Why

When you tune CUB's histogram code paths, NVBench measures elapsed time inside `state.exec` and reports bandwidth as `bytes_processed / elapsed`. Two failure modes can quietly inflate the reported bandwidth:

1. **The dispatch returns a non-`cudaSuccess` error code**, but the benchmark drops the return value on the floor. The kernel never launched, so the elapsed time is small, so the reported bandwidth is large.
2. **The kernel completes with `cudaSuccess` but writes wrong counts** into the output histogram. For example, a partition mask that drops samples that should have landed in another partition's write set produces a non-empty histogram with the right shape but the wrong values. CTest cases that aggregate to a sum-of-counts check pass; the bench reports inflated bandwidth because effectively only a fraction of the input was processed.

There is also a third class — uniform-spacing detection fast paths and tunings that key off power-of-two element/bin counts — where the bench measures a code path real users do not exercise, so the reported bandwidth overstates production behavior.

## What changed

### Six commits, each scoped narrowly

1. **`[cub] Harden histogram benchmarks against pattern-matching tunings`** — single-channel `even.cu` / `range.cu`. Quadratic-spaced range levels (still strictly monotonic across `[lower_level, upper_level]`) so `DispatchRange` stays on the `SearchTransform` path instead of collapsing to the uniform-detection fast path. Replaces the power-of-two `Elements{io}` axis with non-power-of-two sizes. Switches to NVBench's manual-timer `exec_tag` and calls `cudaCtxResetPersistingL2Cache()` outside the timed window, since cold-cache eviction does not demote persistence-marked addresses set via `cudaStreamSetAttribute` / `cudaAccessPolicyWindow`.

2. **`[cub] Extend histogram bench/test hardening to multi-channel and add cache coverage`** — same three changes for `multi/even.cu` and `multi/range.cu`. Replaces 128/2048 with 100/2000 in the `Bins` axis on all four benches so tunings that hard-code on power-of-two bin counts cannot use those shortcuts. In `cub/test/catch2_test_device_histogram.cu`, `setup_bin_levels_for_range` now perturbs interior levels by ±`min_bin_width/4` (alternating sign), falling back to uniform when the type is too tight (e.g. byte-sample with 256 levels). Adds a new `cub/test/catch2_test_device_histogram_thread_local_cache.cu` with three Catch2 cases targeting the `thread_local` detection-stream / detection-buffer cache in `dispatch_range`: sequential calls across multiple user streams, four-thread concurrent calls on the same device, and a single-thread cross-device case that skips when fewer than two GPUs are present.

3. **`[cub] Force histogram bench persisting-L2 reservation to zero each iteration`** — adds `cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, 0)` immediately before every timed iteration, so a prior bench in the same NVBench process can't leave the reservation bumped. The default is 0; this hardcodes 0 instead of relying on the default.

4. **`[cub] Use jittered-uniform histogram bench levels instead of quadratic`** — quadratic spacing produced bin widths spanning ~2n× (last bin vs first), which is not representative of typical workloads. Jittered uniform spacing (±25% of step, fixed `mt19937` seed for reproducibility) keeps consecutive widths within ~3× while still defeating the uniform-spacing detection fast path.

5. **`[cub] Add 16384 and 60000 bin sizes to histogram benchmarks`** — covers the 10k–65k bin tier between 2000 and 2097152 across all four benches.

6. **`[cub] Verify histogram benchmark output bin-by-bin against a reference`** — the verifier described below.

### How the verifier works

Each benchmark cell builds the strided pixel-major sample buffer and the output histograms exactly as before. Then, before `state.exec`:

1. The dispatch (`HistogramEven` / `HistogramRange` / `MultiHistogramEven` / `MultiHistogramRange`) is called once with explicit return-code checking. A non-`cudaSuccess` return throws `std::runtime_error` and the cell is reported as failed; NVBench prints the message in the per-cell log and emits no bandwidth row for that cell.

2. The produced histogram(s) are compared bin-by-bin against an independent reference. The reference is computed on the same device, but with `thrust::for_each` + a global `atomicAdd` per pixel per active channel — the EVEN reference uses the closed-form bin index `(sample - lo) * num_bins / (hi - lo)` (in double); the RANGE reference uses `cub::UpperBound` on the per-channel level array. Neither reference shares any kernel with `cub::DeviceHistogram`, so a bug that produces a wrong-but-plausible histogram from the optimized path is caught.

3. The compare reports both the total count (`opt_total` vs `ref_total`) and the first mismatched bin index with both values, so a failure log identifies the channel and bin to investigate.

The warmup, the reference build, and the comparison all run outside `state.exec`, so the timed region only contains the dispatch under test.

### Disabling the verifier at run time

The verifier is on by default. To skip it (e.g. during a tuning sweep where only relative throughput matters and the verifier's wall-clock cost is undesirable), set `CUB_BENCH_HISTOGRAM_VERIFY` to `0`, `false`, `no`, or `off` (case-insensitive) in the environment when invoking the benchmark binary. The flag is read once per process via a function-local static, so toggling has no per-cell overhead.

## Cost

The verifier's cost on the timed region (NVBench's reported `histogram` metric — geometric mean across all four binaries' `GlobalMem BW (bytes/sec)` rows, in `GiB/s`) is zero within measurement noise. Wall-clock benchmark runtime grows by ~14% (median ~7 s on a ~52 s baseline run) because the on-device reference loops over every sample once per cell.

Hardware: NVIDIA B200, CUDA driver 580.126.09, CUDA toolkit 12.8.93, host Linux 6.8 with 30 CPUs / 180 GiB RAM. Five interleaved runs of `cub/benchmarks/bench/histogram/run_histogram_benchmark.py` each (interleaved to factor out NVBench-iteration-count run-to-run variance):

| | Mean `histogram` (GiB/s) | Median wall-clock (s) |
|---|---|---|
| baseline (no verifier) | 210.87 | 52.0 |
| verifier on (default) | 210.88 | 59.4 |
| verifier off (`CUB_BENCH_HISTOGRAM_VERIFY=0`) | 210.78 | 52.8 |

The timed-region metric is unchanged across all three modes within ±0.05% (well inside the bench's natural noise of ±0.05–0.10%). The wall-clock overhead from running the verifier is ~7 s; with the verifier disabled, wall-clock is statistically indistinguishable from baseline.

## Validation

Built and ran the full sweep on the B200 host. With the verifier on the unmodified branch, all 160 benchmark cells (40 cells × 4 binaries) pass; the reported `histogram` metric is unchanged within noise.

To confirm the verifier triggers when the optimized output is actually wrong, I rebased a known-bad change onto this branch — a CUB optimization attempt that introduced a partition-mask bug that silently dropped most input samples on multi-channel `Bins=60000` configurations. With the verifier in place, that change is rejected: 44 cells across the four binaries fail, with messages like

```
Run:  [1/1] base [Device=0 SampleT{ct}=I32 CounterT{ct}=I32 OffsetT{ct}=I32 Elements{io}=268435456 Bins=60000 Entropy=0.201]
Fail: Unexpected error: bench correctness check [multi.range]: channel=0 total opt=1209247 ref=268435456;
      first mismatched bin=0 (opt=763903 ref=169668305)
```

The message reports both the total-count mismatch (`1.2M` vs `268M` — only ~0.45% of samples landed in the optimized histogram) and the first mismatched bin's per-bin counts. Without the verifier (`CUB_BENCH_HISTOGRAM_VERIFY=0`), the same change reports `histogram=893.25` GiB/s — a ~4.2× bandwidth speedup that is entirely an artifact of the dropped samples — exactly the failure mode this PR is intended to prevent.

## Test plan

- [x] `ci/util/build_and_test_targets.sh --preset cub-cpp20 --build-targets "cub.bench.histogram.even.base cub.bench.histogram.range.base cub.bench.histogram.multi.even.base cub.bench.histogram.multi.range.base"` builds clean.
- [x] `ctest -R 'cub\.test\.device\.histogram(\.lid_0|_api\.lid_0|_env\.lid_0|_thread_local_cache\.lid_0)$'` passes (including the new `cub.test.device.histogram_thread_local_cache.lid_0`).
- [x] All 160 benchmark cells (40 cells × 4 binaries) pass the bin-by-bin verifier on the unmodified branch; reported `histogram` metric is unchanged within noise.
- [x] `CUB_BENCH_HISTOGRAM_VERIFY=0` skips the verifier; reported `histogram` metric is unchanged within noise; wall-clock is statistically indistinguishable from baseline.
- [x] Cherry-picking a known-bad change onto this branch causes 44 cells to fail with explicit bin-by-bin mismatch messages when the verifier is on, and "passes" with an inflated `histogram` value when the verifier is off (demonstrating the failure mode the verifier exists to prevent).