### PR TITLE
[STF] Migrate __stf/allocators/ from cuda_safe_call to cuda_try

### DIFF
--- a/cudax/include/cuda/experimental/__stf/allocators/adapters.cuh
+++ b/cudax/include/cuda/experimental/__stf/allocators/adapters.cuh
@@ -26,6 +26,7 @@
 #endif // no system header
 
 #include <cuda/experimental/__stf/allocators/block_allocator.cuh>
+#include <cuda/experimental/__stf/utility/scope_guard.cuh>
 
 namespace cuda::experimental::stf
 {
@@ -170,6 +171,16 @@ public:
     _CCCL_ASSERT(adapter_state, "Invalid state");
     _CCCL_ASSERT(!cleared_or_moved, "clear() was already called, or the object was moved.");
 
+    // Flip the bool up-front so the destructor's "clear() was not called"
+    // sanity assertion still holds even if a CUDA call below throws and the
+    // caller catches the exception. From the user's contract perspective,
+    // ``clear()`` *was* called; whether every individual deallocation
+    // succeeded is communicated via the thrown ``cuda_exception``.
+    SCOPE(exit)
+    {
+      cleared_or_moved = true;
+    };
+
     cudaStream_t stream = adapter_state->stream;
 
     // Deallocate all buffers, synchronizing lazily on the first blocking deallocation.
@@ -181,15 +192,13 @@ public:
       // Sync stream once before the first blocking deallocation
       if (!b.memory_node.allocation_is_stream_ordered() && !stream_synchronized)
       {
-        cuda_safe_call(cudaStreamSynchronize(stream));
+        cuda_try(cudaStreamSynchronize(stream));
         stream_synchronized = true;
       }
       b.memory_node.deallocate(b.ptr, b.sz, stream);
     }
 
     adapter_state->to_free.clear();
-
-    cleared_or_moved = true;
   }
 
   /**

--- a/cudax/include/cuda/experimental/__stf/allocators/pooled_allocator.cuh
+++ b/cudax/include/cuda/experimental/__stf/allocators/pooled_allocator.cuh
@@ -74,7 +74,7 @@ public:
       const int dev = device_ordinal(this->place);
       assert(dev >= 0);
       cudaDeviceProp prop;
-      cuda_safe_call(cudaGetDeviceProperties(&prop, dev));
+      cuda_try(cudaGetDeviceProperties(&prop, dev));
 
       size_t max_mem = prop.totalGlobalMem;
 


### PR DESCRIPTION
## Summary

First PR in a series migrating production STF headers off the abort-on-failure `cuda_safe_call` and onto the throw-on-failure `cuda_try`, so callers (including Python wrappers and any wider exception-aware control flow) have the option to recover from CUDA errors instead of having the process aborted underneath them.

Scope here is intentionally tiny -- the entire `cudax/include/cuda/experimental/__stf/allocators/` subtree, two call sites -- so the migration pattern can be reviewed before it scales up.

## Changes

### `pooled_allocator.cuh`
Plain `cudaGetDeviceProperties` query inside the constructor. No CUDA state in flight, no rollback needed -- straight `cuda_safe_call` -> `cuda_try` substitution.

### `adapters.cuh`
`stream_adapter::clear()` synchronizes the stream before any blocking deallocations. With `cuda_try`, that path can now throw. The existing `~stream_adapter()` sanity assertion (`cleared_or_moved` must be true at destruction) would then fire spuriously and report *"clear() was not called"* -- which is misleading: `clear()` *was* called, it just failed mid-way.

Guarded the bool flip with `SCOPE(exit)` at the top of `clear()` so the destructor's contract holds whether or not the synchronization throws. Explicit `scope_guard.cuh` include added rather than relying on transitive inclusion.

```cpp
void clear()
{
  _CCCL_ASSERT(adapter_state, "Invalid state");
  _CCCL_ASSERT(!cleared_or_moved, "clear() was already called, or the object was moved.");

  SCOPE(exit) { cleared_or_moved = true; };

  // ... cuda_try(cudaStreamSynchronize(stream)); ...
}
```

The `SCOPE(exit)` body only writes a `bool`, which is `noexcept` -- no risk of `std::terminate` during unwinding.

## Migration pattern notes (for the follow-ups)

- **SAFE**: pure queries with no in-flight CUDA state -> direct `cuda_try` substitution.
- **GUARDED**: operations that need an undo step on failure -> `cuda_try` + `SCOPE(fail)` for the rollback. **Inside the `SCOPE(fail)` body, use `cuda_safe_call`, not `cuda_try`** -- guard destructors are `noexcept`, so a thrown exception during unwinding would `std::terminate`.
- **KEEP**: destructors and CUDA host callbacks remain `cuda_safe_call`. Same rationale -- those contexts are `noexcept`.

## Test plan

- [ ] CI green (`/ok to test` once branch is pushed -- see comment below)
- [ ] No behavioral change for the success path
- [ ] Confirmed no `@code` doxygen blocks in either file reference `cuda_safe_call`, so docs do not drift