### PR TITLE
[places] Guard empty tiled mdspan shape size

### DIFF
--- a/cudax/include/cuda/experimental/__places/partitions/tiled_partition.cuh
+++ b/cudax/include/cuda/experimental/__places/partitions/tiled_partition.cuh
@@ -51,6 +51,10 @@ public:
     _CCCL_ASSERT(mdspan_shape_t::rank() == 1, "Tiled mdspan shape only implemented in 1D yet");
 
     const size_t n = original_shape.size();
+    if (n == 0)
+    {
+      return 0;
+    }
 
     // 0000 1111 2222 0000 11xx xxxx xxxx
     // S=4, n=18
@@ -182,6 +186,32 @@ UNITTEST("tiled partition with large 1D data")
   tiled_partition<tile_size>::get_executor(&tile_pos, large_coords, data_dims, grid_dims);
 
   EXPECT(tile_pos.x == (test_coord / tile_size) % grid_dims.x);
+};
+
+UNITTEST("tiled mdspan shape empty size is zero")
+{
+  struct mock_shape
+  {
+    using coords_t = pos4;
+
+    _CCCL_HOST_DEVICE static constexpr size_t rank()
+    {
+      return 1;
+    }
+
+    _CCCL_HOST_DEVICE size_t size() const
+    {
+      return 0;
+    }
+
+    _CCCL_HOST_DEVICE coords_t index_to_coords(size_t index) const
+    {
+      return pos4(index);
+    }
+  };
+
+  auto shape = reserved::tiled_mdspan_shape<4, mock_shape>(mock_shape{}, 0, 3);
+  EXPECT(shape.size() == 0);
 };
 
 #endif // UNITTESTED_FILE

--- a/cudax/include/cuda/experimental/__places/partitions/tiled_partition.cuh
+++ b/cudax/include/cuda/experimental/__places/partitions/tiled_partition.cuh
@@ -149,6 +149,26 @@ public:
 };
 
 #ifdef UNITTESTED_FILE
+struct empty_tiled_mdspan_mock_shape
+{
+  using coords_t = pos4;
+
+  _CCCL_HOST_DEVICE static constexpr size_t rank()
+  {
+    return 1;
+  }
+
+  _CCCL_HOST_DEVICE size_t size() const
+  {
+    return 0;
+  }
+
+  _CCCL_HOST_DEVICE coords_t index_to_coords(size_t index) const
+  {
+    return pos4(index);
+  }
+};
+
 UNITTEST("Composite data place equality")
 {
   auto all           = exec_place::all_devices();
@@ -190,27 +210,7 @@ UNITTEST("tiled partition with large 1D data")
 
 UNITTEST("tiled mdspan shape empty size is zero")
 {
-  struct mock_shape
-  {
-    using coords_t = pos4;
-
-    _CCCL_HOST_DEVICE static constexpr size_t rank()
-    {
-      return 1;
-    }
-
-    _CCCL_HOST_DEVICE size_t size() const
-    {
-      return 0;
-    }
-
-    _CCCL_HOST_DEVICE coords_t index_to_coords(size_t index) const
-    {
-      return pos4(index);
-    }
-  };
-
-  auto shape = reserved::tiled_mdspan_shape<4, mock_shape>(mock_shape{}, 0, 3);
+  auto shape = reserved::tiled_mdspan_shape<4, empty_tiled_mdspan_mock_shape>(empty_tiled_mdspan_mock_shape{}, 0, 3);
   EXPECT(shape.size() == 0);
 };
 


### PR DESCRIPTION
## What changed
- return `0` early from `tiled_mdspan_shape::size()` when the original shape is empty
- add a regression test covering the empty-shape case

## Why
`tiled_mdspan_shape::size()` computes `tile_per_part` and then uses `(tile_per_part - 1)` in unsigned arithmetic.

For empty input, `original_shape.size()` is `0`, so `ntiles == 0` and `tile_per_part == 0`. That makes `(tile_per_part - 1)` underflow and can turn an empty shape into a huge nonzero size.

## Impact
Empty tiled mdspan shapes now report `0` elements instead of underflowing.

## Validation
- added a focused header unittest for the empty-shape case
- attempted `cmake --preset cudax-cpp17`, but validation is blocked in this environment because `nvcc` / `CUDAToolkit` is not available
