### PR TITLE
[STF] Use direct C++ linkage guards in C API header

### DIFF
--- a/c/experimental/stf/CMakeLists.txt
+++ b/c/experimental/stf/CMakeLists.txt
@@ -70,7 +70,11 @@ target_compile_options(
 
 target_include_directories(
   cccl.c.experimental.stf
-  PUBLIC "include"
+  PUBLIC #
+    "include"
+    # Pulls in cccl/c/extern_c.h, the canonical CCCL_C_EXTERN_C_BEGIN/_END macros
+    # shared with cccl.c.parallel.
+    "${CCCL_SOURCE_DIR}/c/parallel/include"
   PRIVATE "src"
 )
 

--- a/c/experimental/stf/CMakeLists.txt
+++ b/c/experimental/stf/CMakeLists.txt
@@ -70,8 +70,7 @@ target_compile_options(
 
 target_include_directories(
   cccl.c.experimental.stf
-  PUBLIC #
-    "include"
+  PUBLIC "include"
   PRIVATE "src"
 )
 

--- a/c/experimental/stf/CMakeLists.txt
+++ b/c/experimental/stf/CMakeLists.txt
@@ -72,9 +72,6 @@ target_include_directories(
   cccl.c.experimental.stf
   PUBLIC #
     "include"
-    # Pulls in cccl/c/extern_c.h, the canonical CCCL_C_EXTERN_C_BEGIN/_END macros
-    # shared with cccl.c.parallel.
-    "${CCCL_SOURCE_DIR}/c/parallel/include"
   PRIVATE "src"
 )
 

--- a/c/experimental/stf/include/cccl/c/experimental/stf/stf.h
+++ b/c/experimental/stf/include/cccl/c/experimental/stf/stf.h
@@ -72,9 +72,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <cccl/c/extern_c.h>
-
-CCCL_C_EXTERN_C_BEGIN
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
 
 //! \defgroup AccessMode Data Access Modes
 //! \brief Specifies how tasks access logical data
@@ -1215,5 +1215,7 @@ void* stf_host_launch_deps_get_user_data(stf_host_launch_deps_handle deps);
 
 //! \}
 
-CCCL_C_EXTERN_C_END
+#ifdef __cplusplus
+}
+#endif // __cplusplus
 // NOLINTEND(modernize-use-using)

--- a/c/experimental/stf/include/cccl/c/experimental/stf/stf.h
+++ b/c/experimental/stf/include/cccl/c/experimental/stf/stf.h
@@ -72,9 +72,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <cccl/c/extern_c.h>
+
+CCCL_C_EXTERN_C_BEGIN
 
 //! \defgroup AccessMode Data Access Modes
 //! \brief Specifies how tasks access logical data
@@ -1213,7 +1213,5 @@ void* stf_host_launch_deps_get_user_data(stf_host_launch_deps_handle deps);
 
 //! \}
 
-#ifdef __cplusplus
-}
-#endif
+CCCL_C_EXTERN_C_END
 // NOLINTEND(modernize-use-using)


### PR DESCRIPTION
## Description

Simplify the STF C API header by using a local `#ifdef __cplusplus` / `extern "C"` wrapper directly in `stf.h`.

This avoids pulling in `cccl/c/extern_c.h` from the C parallel API solely for the linkage macros, so the STF C API does not need a new dependency on `cccl.c.parallel`.

## Testing

Not run; this is a header-only include/linkage cleanup.