### PR TITLE
[STF] Add C API context wait helper

### DIFF
--- a/c/experimental/stf/include/cccl/c/experimental/stf/stf.h
+++ b/c/experimental/stf/include/cccl/c/experimental/stf/stf.h
@@ -419,6 +419,8 @@ cudaStream_t stf_fence(stf_ctx_handle ctx);
 //! \return 0 on success, non-zero on error
 //!
 //! \pre  ctx and ld must be valid handles; out must not be NULL
+//! \pre  The first min(size, data_size) bytes of out must not overlap the
+//!       logical data range associated with ld.
 //! \post The first min(size, data_size) bytes of the logical data are
 //!       written to out.
 //!

--- a/c/experimental/stf/include/cccl/c/experimental/stf/stf.h
+++ b/c/experimental/stf/include/cccl/c/experimental/stf/stf.h
@@ -403,6 +403,36 @@ stf_exec_place_resources_handle stf_ctx_get_place_resources(stf_ctx_handle ctx);
 
 cudaStream_t stf_fence(stf_ctx_handle ctx);
 
+//!
+//! \brief Synchronize and copy logical data contents to a host buffer
+//!
+//! Schedules a host callback that reads the logical data, synchronizes
+//! to ensure the callback completes, and copies the data into the
+//! caller-provided buffer. Unlike stf_ctx_finalize(), the context
+//! remains usable after this call, enabling iterative patterns such as
+//! convergence checks.
+//!
+//! \param ctx   Context handle
+//! \param ld    Logical data handle to read
+//! \param out   Destination host buffer
+//! \param size  Size of the destination buffer in bytes
+//! \return 0 on success, non-zero on error
+//!
+//! \pre  ctx and ld must be valid handles; out must not be NULL
+//! \post The first min(size, data_size) bytes of the logical data are
+//!       written to out.
+//!
+//! \par Example:
+//! \code
+//! int h_sum = 0;
+//! stf_ctx_wait(ctx, lSum, &h_sum, sizeof(h_sum));
+//! // h_sum now contains the result; context is still active
+//! \endcode
+//!
+//! \see stf_fence(), stf_ctx_finalize()
+
+int stf_ctx_wait(stf_ctx_handle ctx, stf_logical_data_handle ld, void* out, size_t size);
+
 //! \}
 
 //! \defgroup LogicalData Logical Data Management

--- a/c/experimental/stf/src/stf.cu
+++ b/c/experimental/stf/src/stf.cu
@@ -11,6 +11,7 @@
 #include <cuda/experimental/places.cuh>
 #include <cuda/experimental/stf.cuh>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdio>
 #include <cstring>
@@ -431,6 +432,39 @@ cudaStream_t stf_fence(stf_ctx_handle ctx)
   _CCCL_ASSERT(ctx != nullptr, "context handle must not be null");
   auto* context_ptr = from_opaque(ctx);
   return context_ptr->fence();
+}
+
+int stf_ctx_wait(stf_ctx_handle ctx, stf_logical_data_handle ld, void* out, size_t size)
+{
+  _CCCL_ASSERT(ctx != nullptr, "context handle must not be null");
+  _CCCL_ASSERT(ld != nullptr, "logical data handle must not be null");
+  _CCCL_ASSERT(out != nullptr, "output buffer must not be null");
+
+  try
+  {
+    auto* context_ptr = from_opaque(ctx);
+    auto* ld_ptr      = from_opaque(ld);
+
+    void* dst  = out;
+    size_t cap = size;
+
+    auto builder = context_ptr->host_launch();
+    builder.add_deps(task_dep_untyped(*ld_ptr, access_mode::read));
+    builder.set_symbol("wait");
+    builder->*[dst, cap](reserved::host_launch_deps& deps) {
+      auto data      = deps.get<slice<char>>(0);
+      size_t copy_sz = ::std::min(cap, static_cast<size_t>(data.extent(0)));
+      ::std::memcpy(dst, data.data_handle(), copy_sz);
+    };
+
+    cudaStream_t fence_stream = context_ptr->fence();
+    cuda_safe_call(cudaStreamSynchronize(fence_stream));
+    return 0;
+  }
+  catch (...)
+  {
+    return 1;
+  }
 }
 
 stf_logical_data_handle stf_logical_data(stf_ctx_handle ctx, void* addr, size_t sz)

--- a/c/experimental/stf/src/stf.cu
+++ b/c/experimental/stf/src/stf.cu
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <exception>
@@ -455,6 +456,17 @@ int stf_ctx_wait(stf_ctx_handle ctx, stf_logical_data_handle ld, void* out, size
     builder->*[dst, cap](reserved::host_launch_deps& deps) {
       auto data      = deps.get<slice<char>>(0);
       size_t copy_sz = ::std::min(cap, static_cast<size_t>(data.extent(0)));
+      // The destination must not overlap the logical data range: in practice the
+      // logical data is backed by storage that is allocated independently from the
+      // caller's readback buffer, so use uintptr_t comparisons (relational pointer
+      // comparison across unrelated allocations is unspecified) to encode that
+      // contract.
+      const auto src_begin = reinterpret_cast<::std::uintptr_t>(data.data_handle());
+      const auto src_end   = src_begin + copy_sz;
+      const auto dst_begin = reinterpret_cast<::std::uintptr_t>(dst);
+      const auto dst_end   = dst_begin + copy_sz;
+      _CCCL_ASSERT(copy_sz == 0 || dst_end <= src_begin || src_end <= dst_begin,
+                   "stf_ctx_wait destination buffer must not overlap the logical data range");
       ::std::memcpy(dst, data.data_handle(), copy_sz);
     };
 

--- a/c/experimental/stf/src/stf.cu
+++ b/c/experimental/stf/src/stf.cu
@@ -436,9 +436,10 @@ cudaStream_t stf_fence(stf_ctx_handle ctx)
 
 int stf_ctx_wait(stf_ctx_handle ctx, stf_logical_data_handle ld, void* out, size_t size)
 {
-  _CCCL_ASSERT(ctx != nullptr, "context handle must not be null");
-  _CCCL_ASSERT(ld != nullptr, "logical data handle must not be null");
-  _CCCL_ASSERT(out != nullptr, "output buffer must not be null");
+  if (ctx == nullptr || ld == nullptr || out == nullptr)
+  {
+    return 1;
+  }
 
   try
   {

--- a/c/experimental/stf/test/test_ctx.cpp
+++ b/c/experimental/stf/test/test_ctx.cpp
@@ -19,3 +19,56 @@ C2H_TEST("basic stf context", "[context]")
   REQUIRE(ctx != nullptr);
   stf_ctx_finalize(ctx);
 }
+
+C2H_TEST("stf_ctx_wait reads data without finalizing", "[context]")
+{
+  stf_ctx_handle ctx = stf_ctx_create();
+  REQUIRE(ctx != nullptr);
+
+  int h_value                  = 0;
+  stf_logical_data_handle lVal = stf_logical_data(ctx, &h_value, sizeof(int));
+  REQUIRE(lVal != nullptr);
+  stf_logical_data_set_symbol(lVal, "val");
+
+  int src_val = 42;
+
+  stf_host_launch_handle h = stf_host_launch_create(ctx);
+  REQUIRE(h != nullptr);
+  stf_host_launch_set_symbol(h, "set42");
+  stf_host_launch_add_dep(h, lVal, STF_WRITE);
+  stf_host_launch_set_user_data(h, &src_val, sizeof(int), nullptr);
+  stf_host_launch_submit(h, [](stf_host_launch_deps_handle deps) {
+    int* data = (int*) stf_host_launch_deps_get(deps, 0);
+    int* src  = (int*) stf_host_launch_deps_get_user_data(deps);
+    data[0]   = *src;
+  });
+  stf_host_launch_destroy(h);
+
+  int result = 0;
+  int rc     = stf_ctx_wait(ctx, lVal, &result, sizeof(int));
+  REQUIRE(rc == 0);
+  REQUIRE(result == 42);
+
+  // The context remains usable after waiting.
+  src_val = 99;
+
+  stf_host_launch_handle h2 = stf_host_launch_create(ctx);
+  REQUIRE(h2 != nullptr);
+  stf_host_launch_set_symbol(h2, "set99");
+  stf_host_launch_add_dep(h2, lVal, STF_WRITE);
+  stf_host_launch_set_user_data(h2, &src_val, sizeof(int), nullptr);
+  stf_host_launch_submit(h2, [](stf_host_launch_deps_handle deps) {
+    int* data = (int*) stf_host_launch_deps_get(deps, 0);
+    int* src  = (int*) stf_host_launch_deps_get_user_data(deps);
+    data[0]   = *src;
+  });
+  stf_host_launch_destroy(h2);
+
+  result = 0;
+  rc     = stf_ctx_wait(ctx, lVal, &result, sizeof(int));
+  REQUIRE(rc == 0);
+  REQUIRE(result == 99);
+
+  stf_logical_data_destroy(lVal);
+  stf_ctx_finalize(ctx);
+}

--- a/c/experimental/stf/test/test_ctx.cpp
+++ b/c/experimental/stf/test/test_ctx.cpp
@@ -72,3 +72,21 @@ C2H_TEST("stf_ctx_wait reads data without finalizing", "[context]")
   stf_logical_data_destroy(lVal);
   stf_ctx_finalize(ctx);
 }
+
+C2H_TEST("stf_ctx_wait rejects invalid arguments", "[context]")
+{
+  stf_ctx_handle ctx = stf_ctx_create();
+  REQUIRE(ctx != nullptr);
+
+  int h_value                  = 0;
+  stf_logical_data_handle lVal = stf_logical_data(ctx, &h_value, sizeof(int));
+  REQUIRE(lVal != nullptr);
+
+  int result = 0;
+  REQUIRE(stf_ctx_wait(nullptr, lVal, &result, sizeof(int)) != 0);
+  REQUIRE(stf_ctx_wait(ctx, nullptr, &result, sizeof(int)) != 0);
+  REQUIRE(stf_ctx_wait(ctx, lVal, nullptr, sizeof(int)) != 0);
+
+  stf_logical_data_destroy(lVal);
+  stf_ctx_finalize(ctx);
+}


### PR DESCRIPTION
Expose a blocking readback helper so C callers can observe logical data without finalizing the context.

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
