### PR TITLE
Only enabled PDL for PTX/SASS supporting it

### DIFF
--- a/cub/cub/detail/launcher/cuda_driver.cuh
+++ b/cub/cub/detail/launcher/cuda_driver.cuh
@@ -79,8 +79,9 @@ struct CudaDriverLauncherFactory
   {
     if (dependent_launch)
     {
+      // note: assumes that cc_ holds the current device's AND the PTX's compute capability
       _CCCL_ASSERT((::cuda::compute_capability{cc_} >= ::cuda::compute_capability{9, 0}),
-                   "Enabling PDL for a kernel launch requires SM90+ PTX/SASS");
+                   "Enabling PDL for a kernel launch requires CC 9.0+ PTX/SASS when running on SM90+");
     }
   }
 

--- a/cub/cub/detail/launcher/cuda_driver.cuh
+++ b/cub/cub/detail/launcher/cuda_driver.cuh
@@ -75,7 +75,7 @@ struct CudaDriverLauncher
 
 struct CudaDriverLauncherFactory
 {
-  CUB_RUNTIME_FUNCTION void __assert_pdl_allowed(bool dependent_launch) const
+  CUB_RUNTIME_FUNCTION inline void __assert_pdl_allowed(bool dependent_launch) const
   {
     if (dependent_launch)
     {

--- a/cub/cub/detail/launcher/cuda_driver.cuh
+++ b/cub/cub/detail/launcher/cuda_driver.cuh
@@ -75,9 +75,19 @@ struct CudaDriverLauncher
 
 struct CudaDriverLauncherFactory
 {
+  CUB_RUNTIME_FUNCTION void __assert_pdl_allowed(bool dependent_launch) const
+  {
+    if (dependent_launch)
+    {
+      _CCCL_ASSERT((::cuda::compute_capability{cc_} >= ::cuda::compute_capability{9, 0}),
+                   "Enabling PDL for a kernel launch requires SM90+ PTX/SASS");
+    }
+  }
+
   CudaDriverLauncher
   operator()(dim3 grid, dim3 block, unsigned int shared_mem, ::CUstream stream, bool dependent_launch = false) const
   {
+    __assert_pdl_allowed(dependent_launch);
     return CudaDriverLauncher{grid, block, shared_mem, stream, dependent_launch};
   }
 

--- a/cub/cub/detail/launcher/cuda_driver.cuh
+++ b/cub/cub/detail/launcher/cuda_driver.cuh
@@ -75,7 +75,7 @@ struct CudaDriverLauncher
 
 struct CudaDriverLauncherFactory
 {
-  CUB_RUNTIME_FUNCTION inline void __assert_pdl_allowed(bool dependent_launch) const
+  CUB_RUNTIME_FUNCTION void __assert_pdl_allowed(bool dependent_launch) const
   {
     if (dependent_launch)
     {

--- a/cub/cub/detail/launcher/cuda_runtime.cuh
+++ b/cub/cub/detail/launcher/cuda_runtime.cuh
@@ -29,10 +29,15 @@ struct TripleChevronFactory
   {
     if (dependent_launch)
     {
-      [[maybe_unused]] ::cuda::compute_capability cc;
-      _CCCL_ASSERT(PtxComputeCap(cc) == cudaSuccess, "Failed to query PTX compute capability");
-      _CCCL_ASSERT((cc >= ::cuda::compute_capability{9, 0}),
-                   "Enabling PDL for a kernel launch requires SM90+ PTX/SASS");
+      [[maybe_unused]] int sm_version = 0;
+      _CCCL_ASSERT(SmVersion(sm_version) == cudaSuccess, "Failed to query SM compute capability");
+      if (sm_version >= 900)
+      {
+        [[maybe_unused]] ::cuda::compute_capability cc;
+        _CCCL_ASSERT(PtxComputeCap(cc) == cudaSuccess, "Failed to query PTX compute capability");
+        _CCCL_ASSERT((cc >= ::cuda::compute_capability{9, 0}),
+                     "Enabling PDL for a kernel launch requires CC 9.0+ PTX/SASS when running on SM90+");
+      }
     }
   }
 

--- a/cub/cub/detail/launcher/cuda_runtime.cuh
+++ b/cub/cub/detail/launcher/cuda_runtime.cuh
@@ -29,7 +29,7 @@ struct TripleChevronFactory
   {
     if (dependent_launch)
     {
-      ::cuda::compute_capability cc;
+      [[maybe_unused]] ::cuda::compute_capability cc;
       _CCCL_ASSERT(PtxComputeCap(cc) == cudaSuccess, "");
       _CCCL_ASSERT((cc >= ::cuda::compute_capability{9, 0}),
                    "Enabling PDL for a kernel launch requires SM90+ PTX/SASS");

--- a/cub/cub/detail/launcher/cuda_runtime.cuh
+++ b/cub/cub/detail/launcher/cuda_runtime.cuh
@@ -25,9 +25,21 @@ namespace detail
 {
 struct TripleChevronFactory
 {
+  CUB_RUNTIME_FUNCTION void __assert_pdl_allowed(bool dependent_launch) const
+  {
+    if (dependent_launch)
+    {
+      ::cuda::compute_capability cc;
+      _CCCL_ASSERT(PtxComputeCap(cc) == cudaSuccess, "");
+      _CCCL_ASSERT((cc >= ::cuda::compute_capability{9, 0}),
+                   "Enabling PDL for a kernel launch requires SM90+ PTX/SASS");
+    }
+  }
+
   CUB_RUNTIME_FUNCTION THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron operator()(
     dim3 grid, dim3 block, ::cuda::std::size_t shared_mem, ::cudaStream_t stream, bool dependent_launch = false) const
   {
+    __assert_pdl_allowed(dependent_launch);
     return THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(grid, block, shared_mem, stream, dependent_launch);
   }
 

--- a/cub/cub/detail/launcher/cuda_runtime.cuh
+++ b/cub/cub/detail/launcher/cuda_runtime.cuh
@@ -25,7 +25,7 @@ namespace detail
 {
 struct TripleChevronFactory
 {
-  CUB_RUNTIME_FUNCTION inline void __assert_pdl_allowed(bool dependent_launch) const
+  CUB_RUNTIME_FUNCTION void __assert_pdl_allowed(bool dependent_launch) const
   {
     if (dependent_launch)
     {

--- a/cub/cub/detail/launcher/cuda_runtime.cuh
+++ b/cub/cub/detail/launcher/cuda_runtime.cuh
@@ -30,7 +30,7 @@ struct TripleChevronFactory
     if (dependent_launch)
     {
       [[maybe_unused]] ::cuda::compute_capability cc;
-      _CCCL_ASSERT(PtxComputeCap(cc) == cudaSuccess, "");
+      _CCCL_ASSERT(PtxComputeCap(cc) == cudaSuccess, "Failed to query PTX compute capability");
       _CCCL_ASSERT((cc >= ::cuda::compute_capability{9, 0}),
                    "Enabling PDL for a kernel launch requires SM90+ PTX/SASS");
     }

--- a/cub/cub/detail/launcher/cuda_runtime.cuh
+++ b/cub/cub/detail/launcher/cuda_runtime.cuh
@@ -25,7 +25,7 @@ namespace detail
 {
 struct TripleChevronFactory
 {
-  CUB_RUNTIME_FUNCTION void __assert_pdl_allowed(bool dependent_launch) const
+  CUB_RUNTIME_FUNCTION inline void __assert_pdl_allowed(bool dependent_launch) const
   {
     if (dependent_launch)
     {

--- a/cub/cub/device/dispatch/dispatch_find.cuh
+++ b/cub/cub/device/dispatch/dispatch_find.cuh
@@ -181,7 +181,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
 
   // use d_temp_storage as the intermediate device result to read and write from. Then store the final result in the
   // output iterator.
-  if (const auto error = CubDebug(THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(1, 1, 0, stream, true)
+  if (const auto error = CubDebug(THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
+                                    1, 1, 0, stream, /* dependent_launch */ cc >= ::cuda::compute_capability{9, 0})
                                     .doit(init_found_pos_pointer<OffsetT, OffsetT>, found_pos_ptr, num_items)))
   {
     return error;
@@ -190,9 +191,14 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   // Unwrap the input iterator to convert device_ptr<T> to T* (raw pointer). This ensures that dereferencing yields T&
   // instead of device_reference<T>, which is necessary for predicates that don't accept proxy types.
   auto d_in_unwrapped = THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_in);
-  if (const auto error = CubDebug(THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
-                                    findif_grid_size, active_policy.threads_per_block, 0, stream, true)
-                                    .doit(kernel_ptr, d_in_unwrapped, num_items, found_pos_ptr, predicate)))
+  if (const auto error = CubDebug(
+        THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
+          findif_grid_size,
+          active_policy.threads_per_block,
+          0,
+          stream,
+          /* dependent_launch */ cc >= ::cuda::compute_capability{9, 0})
+          .doit(kernel_ptr, d_in_unwrapped, num_items, found_pos_ptr, predicate)))
   {
     return error;
   }
@@ -200,7 +206,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   if constexpr (!can_write_to_output_directly)
   {
     if (const auto error = CubDebug(
-          THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(1, 1, 0, stream, true)
+          THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
+            1, 1, 0, stream, /* dependent_launch */ cc >= ::cuda::compute_capability{9, 0})
             .doit(copy_final_result_to_output_iterator<OffsetT, OutputIteratorT>, found_pos_ptr, d_out)))
     {
       return error;

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -335,7 +335,11 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto dispatch(
 
   // Invoke histogram_init_kernel
   if (const auto error = CubDebug(
-        launcher_factory(histogram_init_grid_dims, histogram_init_threads_per_block, 0, stream, true)
+        launcher_factory(histogram_init_grid_dims,
+                         histogram_init_threads_per_block,
+                         0,
+                         stream,
+                         /* dependent_launch */ cc >= ::cuda::compute_capability{9, 0})
           .doit(init_kernel, num_output_bins_wrapper, d_output_histograms, tile_queue)))
   {
     return error;
@@ -361,7 +365,8 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto dispatch(
 #endif // CUB_DEBUG_LOG
 
   if (const auto error = CubDebug(
-        launcher_factory(sweep_grid_dims, threads_per_block, 0, stream, true)
+        launcher_factory(
+          sweep_grid_dims, threads_per_block, 0, stream, /* dependent_launch */ cc >= ::cuda::compute_capability{9, 0})
           .doit(sweep_kernel,
                 d_samples,
                 num_output_bins_wrapper,

--- a/cub/cub/device/dispatch/dispatch_merge_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge_sort.cuh
@@ -292,7 +292,8 @@ public:
         ValueT>::policy.threads_per_block;
 
     // Invoke DeviceMergeSortBlockSortKernel
-    launcher_factory(static_cast<int>(num_tiles), threads_per_block, 0, stream, true)
+    launcher_factory(
+      static_cast<int>(num_tiles), threads_per_block, 0, stream, /* dependent launch */ ptx_version >= 900)
       .doit(kernel_source.MergeSortBlockSortKernel(),
             ping,
             d_input_keys,
@@ -336,7 +337,8 @@ public:
       const OffsetT target_merged_tiles_number = OffsetT(2) << pass;
 
       // Partition
-      launcher_factory(partition_grid_size, threads_per_partition_block, 0, stream, true)
+      launcher_factory(
+        partition_grid_size, threads_per_partition_block, 0, stream, /* dependent launch */ ptx_version >= 900)
         .doit(kernel_source.MergeSortPartitionKernel(),
               ping,
               d_output_keys,
@@ -360,7 +362,8 @@ public:
       }
 
       // Merge
-      launcher_factory(static_cast<int>(num_tiles), threads_per_block, 0, stream, true)
+      launcher_factory(
+        static_cast<int>(num_tiles), threads_per_block, 0, stream, /* dependent launch */ ptx_version >= 900)
         .doit(kernel_source.MergeSortMergeKernel(),
               ping,
               d_output_keys,
@@ -558,7 +561,11 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
     auto items_buffer     = static_cast<ValueT*>(allocations[2]);
 
     if (const auto error = CubDebug(
-          launcher_factory(static_cast<int>(num_tiles), active_policy.threads_per_block, 0, stream, true)
+          launcher_factory(static_cast<int>(num_tiles),
+                           active_policy.threads_per_block,
+                           0,
+                           stream,
+                           /* dependent launch */ cc >= ::cuda::compute_capability{9, 0})
             .doit(kernel_source.MergeSortBlockSortKernel(),
                   ping,
                   d_input_keys,
@@ -600,7 +607,11 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
       const OffsetT target_merged_tiles_number = OffsetT(2) << pass;
 
       if (const auto error = CubDebug(
-            launcher_factory(partition_grid_size, threads_per_partition_block, 0, stream, true)
+            launcher_factory(partition_grid_size,
+                             threads_per_partition_block,
+                             0,
+                             stream,
+                             /* dependent launch */ cc >= ::cuda::compute_capability{9, 0})
               .doit(kernel_source.MergeSortPartitionKernel(),
                     ping,
                     d_output_keys,
@@ -623,7 +634,11 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
         return error;
       }
       if (const auto error = CubDebug(
-            launcher_factory(static_cast<int>(num_tiles), active_policy.threads_per_block, 0, stream, true)
+            launcher_factory(static_cast<int>(num_tiles),
+                             active_policy.threads_per_block,
+                             0,
+                             stream,
+                             /* dependent launch */ cc >= ::cuda::compute_capability{9, 0})
               .doit(kernel_source.MergeSortMergeKernel(),
                     ping,
                     d_output_keys,

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -386,7 +386,7 @@ struct DispatchScan
 
     // Invoke init_kernel to initialize tile descriptors
     if (const auto error = CubDebug(
-          launcher_factory(init_grid_size, INIT_KERNEL_THREADS, 0, stream, /* use_pdl */ true)
+          launcher_factory(init_grid_size, INIT_KERNEL_THREADS, 0, stream, /* dependent_launch */ ptx_version >= 900)
             .doit(init_kernel, kernel_source.make_tile_state_kernel_arg(tile_state), num_tiles)))
     {
       return error;
@@ -437,7 +437,8 @@ struct DispatchScan
 
       // Invoke scan_kernel
       if (const auto error = CubDebug(
-            launcher_factory(scan_grid_size, policy.Scan().ThreadsPerBlock(), 0, stream, /* use_pdl */ true)
+            launcher_factory(
+              scan_grid_size, policy.Scan().ThreadsPerBlock(), 0, stream, /* dependent_launch */ ptx_version >= 900)
               .doit(scan_kernel,
                     THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_in),
                     THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_out),
@@ -584,7 +585,11 @@ struct DispatchScan
 #  endif // CUB_DEBUG_LOG
 
       if (const auto error = CubDebug(
-            launcher_factory(init_grid_size, init_kernel_threads, 0, stream, /* use_pdl */ true)
+            launcher_factory(init_grid_size,
+                             init_kernel_threads,
+                             0,
+                             stream,
+                             /* dependent_launch */ ptx_version >= 900)
               .doit(kernel_source.InitKernel(),
                     kernel_source.look_ahead_make_tile_state_kernel_arg(d_temp_storage),
                     grid_dim)))
@@ -614,7 +619,7 @@ struct DispatchScan
 #  endif // CUB_DEBUG_LOG
 
       if (const auto error = CubDebug(
-            launcher_factory(grid_dim, block_dim, smem_size, stream, /* use_pdl */ true)
+            launcher_factory(grid_dim, block_dim, smem_size, stream, /* dependent_launch */ ptx_version >= 900)
               .doit(scan_kernel,
                     THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_in),
                     THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_out),
@@ -699,7 +704,7 @@ struct DispatchScan
 
     // Invoke init_kernel to initialize tile descriptors
     if (const auto error = CubDebug(
-          launcher_factory(init_grid_size, init_kernel_threads, 0, stream, /* use_pdl */ true)
+          launcher_factory(init_grid_size, init_kernel_threads, 0, stream, /* dependent_launch */ ptx_version >= 900)
             .doit(kernel_source.InitKernel(), kernel_source.make_tile_state_kernel_arg(tile_state), num_tiles)))
     {
       return error;
@@ -750,7 +755,8 @@ struct DispatchScan
 
       // Invoke scan_kernel
       if (const auto error = CubDebug(
-            launcher_factory(scan_grid_size, active_policy.threads_per_block, 0, stream, /* use_pdl */ true)
+            launcher_factory(
+              scan_grid_size, active_policy.threads_per_block, 0, stream, /* dependent_launch */ ptx_version >= 900)
               .doit(kernel_source.ScanKernel(),
                     THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_in),
                     THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_out),

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -195,7 +195,8 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto configure_as
   cudaStream_t stream,
   PolicyGetter policy_getter,
   KernelSource kernel_source,
-  KernelLauncherFactory launcher_factory)
+  KernelLauncherFactory launcher_factory,
+  ::cuda::compute_capability cc)
   -> cuda_expected<
     ::cuda::std::tuple<decltype(launcher_factory(0, 0, 0, nullptr)), decltype(kernel_source.TransformKernel()), int>>
 {
@@ -273,7 +274,10 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto configure_as
   // config->smem_size is 16 bytes larger than needed for UBLKCP because it's the total SMEM size, but 16 bytes are
   // occupied by static shared memory and padding. But let's not complicate things.
   return ::cuda::std::make_tuple(
-    launcher_factory(grid_dim, threads_per_block, dyn_smem_size, stream, true), kernel_source.TransformKernel(), ipt);
+    launcher_factory(
+      grid_dim, threads_per_block, dyn_smem_size, stream, /* dependent_launch */ cc >= ::cuda::compute_capability{9, 0}),
+    kernel_source.TransformKernel(),
+    ipt);
 }
 
 template <typename Offset,
@@ -298,10 +302,11 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_async_algorithm(
   cuda::std::index_sequence<Is...>,
   PolicyGetter policy_getter,
   KernelSource kernel_source,
-  KernelLauncherFactory launcher_factory)
+  KernelLauncherFactory launcher_factory,
+  ::cuda::compute_capability cc)
 {
   auto ret = configure_async_kernel<(sizeof...(RandomAccessIteratorsIn) == 0)>(
-    num_items, alignment, dyn_smem_for_tile_size, stream, policy_getter, kernel_source, launcher_factory);
+    num_items, alignment, dyn_smem_for_tile_size, stream, policy_getter, kernel_source, launcher_factory, cc);
   if (!ret)
   {
     return ret.error();
@@ -339,7 +344,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_prefetch_or_vectorized
   ::cuda::std::index_sequence<Is...>,
   PolicyGetter policy_getter,
   KernelSource kernel_source,
-  KernelLauncherFactory launcher_factory)
+  KernelLauncherFactory launcher_factory,
+  ::cuda::compute_capability cc)
 {
   CUB_DETAIL_CONSTEXPR_ISH const transform_policy policy = policy_getter();
   CUB_DETAIL_CONSTEXPR_ISH const int threads_per_block =
@@ -409,7 +415,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_prefetch_or_vectorized
   const int tile_size = threads_per_block * ipt.value();
   const auto grid_dim = static_cast<unsigned int>(::cuda::ceil_div(num_items, static_cast<Offset>(tile_size)));
   return CubDebug(
-    launcher_factory(grid_dim, threads_per_block, 0, stream, true)
+    launcher_factory(
+      grid_dim, threads_per_block, 0, stream, /* dependent_launch */ cc >= ::cuda::compute_capability{9, 0})
       .doit(kernel_source.TransformKernel(),
             num_items,
             ipt.value(),
@@ -490,7 +497,8 @@ struct invoke_for_cc<::cuda::std::tuple<RandomAccessIteratorsIn...>,
         seq,
         policy_getter,
         kernel_source,
-        launcher_factory);
+        launcher_factory,
+        cc);
     }
     else if CUB_DETAIL_CONSTEXPR_ISH (Algorithm::memcpy_async == active_policy.algorithm)
     {
@@ -509,7 +517,8 @@ struct invoke_for_cc<::cuda::std::tuple<RandomAccessIteratorsIn...>,
         seq,
         policy_getter,
         kernel_source,
-        launcher_factory);
+        launcher_factory,
+        cc);
     }
     else
     {
@@ -523,7 +532,8 @@ struct invoke_for_cc<::cuda::std::tuple<RandomAccessIteratorsIn...>,
         seq,
         policy_getter,
         kernel_source,
-        launcher_factory);
+        launcher_factory,
+        cc);
     }
   }
 };


### PR DESCRIPTION
The changes in this PR assert that PDL is only enabled with PTX/SASS supporting it. The assertions are not triggered by any CI run, but I can hit them locally by e.g. compiling for SM80 and running on SM120 (e.g. `cub.test.device.transform.lid_0`).

Then, a fix is proposed by guarding any PDL use by the compute capability of the PTX used to launch.

Fixes: #9134