### PR TITLE
Refactor warpspeed scan 2/2 

### DIFF
--- a/cub/cub/detail/warpspeed/look_ahead.cuh
+++ b/cub/cub/detail/warpspeed/look_ahead.cuh
@@ -123,7 +123,7 @@ _CCCL_DEVICE_API tile_state_t<AccumT> loadTileAggregate(tile_state_t<AccumT>* pt
   return res;
 }
 
-// warpLoadLookback loads tmp states:
+// warpLoadLookahead loads tmp states:
 //   idxTileCur + [0; 32 * numTileStatesPerThread[
 //
 // The states are loaded in laneId order and warp-strided:
@@ -142,7 +142,7 @@ _CCCL_DEVICE_API tile_state_t<AccumT> loadTileAggregate(tile_state_t<AccumT>* pt
 // If the index idxTileCur + ii of the loaded state is equal to or exceeds idxTileNext, i.e., idxTileCur + ii >=
 // idxTileNext, then the state is not loaded from memory and set to empty.
 template <int numTileStatesPerThread, typename AccumT>
-_CCCL_DEVICE_API void warpLoadLookback(
+_CCCL_DEVICE_API void warpLoadLookahead(
   int laneIdx,
   tile_state_t<AccumT> (&outTileStates)[numTileStatesPerThread],
   tile_state_t<AccumT>* ptrTileStates,
@@ -151,10 +151,10 @@ _CCCL_DEVICE_API void warpLoadLookback(
 {
   for (int i = 0; i < numTileStatesPerThread; ++i)
   {
-    const int idxTileLookback = idxTileCur + 32 * i + laneIdx;
-    if (idxTileLookback < idxTileNext)
+    const int idxTileLookahead = idxTileCur + 32 * i + laneIdx;
+    if (idxTileLookahead < idxTileNext)
     {
-      outTileStates[i] = loadTileAggregate(ptrTileStates, idxTileLookback);
+      outTileStates[i] = loadTileAggregate(ptrTileStates, idxTileLookahead);
     }
     else
     {
@@ -164,7 +164,7 @@ _CCCL_DEVICE_API void warpLoadLookback(
   }
 }
 
-// warpIncrementalLookback takes the latest known aggrExclusiveCtaPrev and its tile index, idxTilePrev (which's
+// warpIncrementalLookahead takes the latest known aggrExclusiveCtaPrev and its tile index, idxTilePrev (which's
 // aggregate is NOT included in aggrExclusiveCtaPrev), and computes the aggrExclusiveCta for the next tile of interest,
 // idxTileNext (where the returned value will NOT include the aggregate of idxTileNext).
 //
@@ -174,7 +174,7 @@ _CCCL_DEVICE_API void warpLoadLookback(
 //
 // The function must be called from a single warp. All passed arguments must be warp-uniform.
 template <int numTileStatesPerThread, typename AccumT, typename ScanOpT>
-[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE AccumT warpIncrementalLookback(
+[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE AccumT warpIncrementalLookahead(
   SpecialRegisters specialRegisters,
   tile_state_t<AccumT>* ptrTileStates,
   const int idxTilePrev,
@@ -201,7 +201,7 @@ template <int numTileStatesPerThread, typename AccumT, typename ScanOpT>
   while (idxTileCur < idxTileNext)
   {
     tile_state_t<AccumT> regTmpStates[numTileStatesPerThread];
-    warpLoadLookback(laneIdx, regTmpStates, ptrTileStates, idxTileCur, idxTileNext);
+    warpLoadLookahead(laneIdx, regTmpStates, ptrTileStates, idxTileCur, idxTileNext);
 
     for (int idx = 0; idx < numTileStatesPerThread; ++idx)
     {

--- a/cub/cub/detail/warpspeed/look_ahead.cuh
+++ b/cub/cub/detail/warpspeed/look_ahead.cuh
@@ -70,7 +70,7 @@ struct alignas(_Alignment) tile_state_t : tile_state_unaligned_t<AccumT>
 
 template <typename AccumT>
 _CCCL_DEVICE_API void
-storeTileAggregate(tile_state_t<AccumT>* ptrTileStates, scan_state scanState, AccumT sum, int index)
+storeTileAggregate(tile_state_t<AccumT>* ptrTileStates, scan_state scanState, AccumT aggr, int index)
 {
   _CCCL_ASSERT(::cuda::is_aligned(ptrTileStates, alignof(tile_state_t<AccumT>)), "");
   _CCCL_ASSERT(index >= 0 && index < gridDim.x, "Reading out of bounds tile state");
@@ -79,7 +79,7 @@ storeTileAggregate(tile_state_t<AccumT>* ptrTileStates, scan_state scanState, Ac
                 && ::cuda::is_trivially_copyable_v<tile_state_t<AccumT>>)
   {
     static_assert(::cuda::is_power_of_two(sizeof(tile_state_t<AccumT>)));
-    tile_state_t<AccumT> tmp{scanState, sum};
+    tile_state_t<AccumT> tmp{scanState, aggr};
 
 #  if _CCCL_HAS_NV_ATOMIC_BUILTINS()
     __nv_atomic_store(ptrTileStates + index, &tmp, __NV_ATOMIC_RELAXED, __NV_THREAD_SCOPE_DEVICE);
@@ -90,7 +90,7 @@ storeTileAggregate(tile_state_t<AccumT>* ptrTileStates, scan_state scanState, Ac
   }
   else
   {
-    ThreadStore<STORE_CG>(&ptrTileStates[index].value, sum);
+    ThreadStore<STORE_CG>(&ptrTileStates[index].value, aggr);
     using state_int = ::cuda::std::underlying_type_t<scan_state>;
     store_release(reinterpret_cast<state_int*>(&ptrTileStates[index].state), scanState);
   }
@@ -164,33 +164,29 @@ _CCCL_DEVICE_API void warpLoadLookback(
   }
 }
 
-// warpIncrementalLookback takes the latest known sumExclusiveCtaPrev and its tile index, idxTilePrev (which's sum is
-// NOT included in sumExclusiveCtaPrev), and computes the sumExclusiveCta for the next tile of interest, idxTileNext
-// (where the returned value will NOT include the sum of idxTileNext).
+// warpIncrementalLookback takes the latest known aggrExclusiveCtaPrev and its tile index, idxTilePrev (which's
+// aggregate is NOT included in aggrExclusiveCtaPrev), and computes the aggrExclusiveCta for the next tile of interest,
+// idxTileNext (where the returned value will NOT include the aggregate of idxTileNext).
 //
-// It does so by loading states in chunks of 32 * numTileStatesPerThread
-// elements, starting from idxTilePrev + 1. From the chunk of states, it tries
-// to advance its knowledge of sumExclusiveCta as much as possible. It loops
-// until it can calculate the value of sumExclusiveCta from the preceding
-// states.
+// It does so by loading states in chunks of 32 * numTileStatesPerThread elements, starting from idxTilePrev + 1. From
+// the chunk of states, it tries to advance its knowledge of aggrExclusiveCta as much as possible. It loops until it can
+// calculate the value of aggrExclusiveCta from the preceding states.
 //
-// The function must be called from a single warp. All passed arguments must be
-// warp-uniform.
-//
+// The function must be called from a single warp. All passed arguments must be warp-uniform.
 template <int numTileStatesPerThread, typename AccumT, typename ScanOpT>
 [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE AccumT warpIncrementalLookback(
   SpecialRegisters specialRegisters,
   tile_state_t<AccumT>* ptrTileStates,
   const int idxTilePrev,
-  const AccumT sumExclusiveCtaPrev,
+  const AccumT aggrExclusiveCtaPrev,
   const int idxTileNext,
   ScanOpT& scan_op)
 {
   const int laneIdx                      = specialRegisters.laneIdx;
   const ::cuda::std::uint32_t lanemaskEq = ::cuda::ptx::get_sreg_lanemask_eq();
 
-  int idxTileCur            = idxTilePrev;
-  AccumT sumExclusiveCtaCur = sumExclusiveCtaPrev;
+  int idxTileCur             = idxTilePrev;
+  AccumT aggrExclusiveCtaCur = aggrExclusiveCtaPrev;
 
   using warp_reduce_t = WarpReduce<AccumT>;
   static_assert(sizeof(typename warp_reduce_t::TempStorage) <= 4,
@@ -228,7 +224,7 @@ template <int numTileStatesPerThread, typename AccumT, typename ScanOpT>
       const ::cuda::std::uint32_t warp_right_aggregates_count = ::cuda::std::popcount(warp_right_aggregates_mask);
 
       // Accumulate the rightmost tile aggregates
-      AccumT local_sum;
+      AccumT local_aggr;
       NV_IF_ELSE_TARGET(
         NV_PROVIDES_SM_80,
         ({ // NOTE: Inlined from warp_reduce_shfl
@@ -238,19 +234,20 @@ template <int numTileStatesPerThread, typename AccumT, typename ScanOpT>
           {
             const bool use_value = lanemaskEq & warp_right_aggregates_mask;
             const AccumT value   = use_value ? regTmpStates[idx].value : cuda::identity_element<ScanOpT, AccumT>();
-            local_sum            = reduce_op_sync(value, ~0, scan_op);
+            local_aggr           = reduce_op_sync(value, ~0, scan_op);
           }
           else
           {
             // TODO(bgruber): this generates a LOT of SASS. I think it can do better.
-            local_sum =
+            local_aggr =
               warp_reduce_t{temp_storage}.Reduce(regTmpStates[idx].value, scan_op, warp_right_aggregates_count);
           }
         }),
-        (local_sum = warp_reduce_t{temp_storage}.Reduce(regTmpStates[idx].value, scan_op, warp_right_aggregates_count);))
+        (local_aggr =
+           warp_reduce_t{temp_storage}.Reduce(regTmpStates[idx].value, scan_op, warp_right_aggregates_count);))
 
-      // We never initialized sumExclusiveCtaCur when starting look ahead at tile 0
-      sumExclusiveCtaCur = idxTileCur == 0 ? local_sum : scan_op(sumExclusiveCtaCur, local_sum);
+      // We never initialized aggrExclusiveCtaCur when starting look ahead at tile 0
+      aggrExclusiveCtaCur = idxTileCur == 0 ? local_aggr : scan_op(aggrExclusiveCtaCur, local_aggr);
       idxTileCur += warp_right_aggregates_count;
 
       // we can only continue on the next 32 tile states, if we consumed all 32 of this iteration
@@ -261,7 +258,7 @@ template <int numTileStatesPerThread, typename AccumT, typename ScanOpT>
     }
   }
 
-  return sumExclusiveCtaCur; // must only be valid in lane_0
+  return aggrExclusiveCtaCur; // must only be valid in lane_0
 }
 
 #endif // __cccl_ptx_isa >= 860

--- a/cub/cub/detail/warpspeed/squad/squad.cuh
+++ b/cub/cub/detail/warpspeed/squad/squad.cuh
@@ -17,6 +17,11 @@
 
 #include <cuda/__ptx/instructions/elect_sync.h>
 
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+template <class _Tp, size_t _Size>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT array;
+_CCCL_END_NAMESPACE_CUDA_STD
+
 CUB_NAMESPACE_BEGIN
 
 namespace detail::warpspeed
@@ -145,6 +150,13 @@ squadDispatch(SpecialRegisters sr, const SquadDesc (&squads)[numSquads], F f, in
       squadDispatch(sr, squadsRight, f, warpIdxStartMid);
     }
   }
+}
+
+template <::cuda::std::size_t numSquads, typename F>
+_CCCL_DEVICE_API _CCCL_FORCEINLINE void
+squadDispatch(SpecialRegisters sr, ::cuda::std::array<SquadDesc, numSquads> squads, F f, int warpIdxStart = 0)
+{
+  squadDispatch<numSquads>(sr, squads.__elems_, f, warpIdxStart);
 }
 } // namespace detail::warpspeed
 

--- a/cub/cub/detail/warpspeed/squad/squad.cuh
+++ b/cub/cub/detail/warpspeed/squad/squad.cuh
@@ -16,11 +16,7 @@
 #include <cub/detail/warpspeed/squad/squad_desc.cuh>
 
 #include <cuda/__ptx/instructions/elect_sync.h>
-
-_CCCL_BEGIN_NAMESPACE_CUDA_STD
-template <class _Tp, size_t _Size>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT array;
-_CCCL_END_NAMESPACE_CUDA_STD
+#include <cuda/std/array>
 
 CUB_NAMESPACE_BEGIN
 

--- a/cub/cub/device/dispatch/kernels/kernel_scan.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan.cuh
@@ -191,7 +191,7 @@ __launch_bounds__(device_scan_launch_bounds<PolicySelector>, 1) _CCCL_KERNEL_ATT
   _CCCL_GRID_CONSTANT const OutputIteratorT d_out,
   tile_state_kernel_arg_t<ScanTileState, AccumT> tile_state,
   _CCCL_GRID_CONSTANT const int start_tile,
-  ScanOpT scan_op,
+  _CCCL_GRID_CONSTANT const ScanOpT scan_op,
 // nvcc 12.0 gets stuck compiling some TUs like `cub.bench.scan.exclusive.sum.base`, so only enable for newer versions
 #if _CCCL_CUDACC_AT_LEAST(12, 8)
   _CCCL_GRID_CONSTANT

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -298,8 +298,8 @@ struct warpspeed_scan_closure
   const RealInitValueT real_init_value;
   scan_resources_t& res;
 
-  template <typename PhaseT>
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE void load_next_tile_index(const warpspeed::Squad& squad, PhaseT& phaseNextBlockIdxW)
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
+  load_next_tile_index(const warpspeed::Squad& squad, warpspeed::SmemPhase<uint4>& phaseNextBlockIdxW)
   {
     warpspeed::SmemRef refNextBlockIdxW = phaseNextBlockIdxW.acquireRef();
     squadGetNextBlockIdx(squad, refNextBlockIdxW);

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -203,14 +203,13 @@ warpScanExclusivePartial(Tp regInput, ScanOpT& scan_op, const int num_items, boo
   }
 }
 
-template <bool is_last_tile, typename ScanOpT, typename Tp, size_t elemPerThread>
-_CCCL_DEVICE_API _CCCL_FORCEINLINE void fillWithIdentity(Tp (&regAggrInclusive)[elemPerThread], int valid_items)
+template <typename ScanOpT, typename Tp, size_t ElemPerThread>
+_CCCL_DEVICE_API _CCCL_FORCEINLINE void fillWithIdentity(Tp (&regAggrInclusive)[ElemPerThread], int valid_items)
 {
   // if we are in the last tile and have an identity, fill the invalid array items with it
-  constexpr bool have_identity = ::cuda::has_identity_element_v<ScanOpT, Tp>;
-  if constexpr (is_last_tile && have_identity)
+  if constexpr (::cuda::has_identity_element_v<ScanOpT, Tp>)
   {
-    for (int i = 0; i < elemPerThread; ++i)
+    for (int i = 0; i < ElemPerThread; ++i)
     {
       if (i >= valid_items)
       {
@@ -220,15 +219,14 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void fillWithIdentity(Tp (&regAggrInclusive)[
   }
 }
 
-template <bool isInclusive, bool is_last_tile, typename Tp, size_t elemPerThread, typename ScanOpT>
+template <bool IsInclusive, bool IsLastTile, typename Tp, size_t ElemPerThread, typename ScanOpT>
 _CCCL_DEVICE_API _CCCL_FORCEINLINE void
-threadScanPartial(Tp (&regAggrInclusive)[elemPerThread], ScanOpT& scan_op, Tp prefix, bool use_prefix, int valid_items)
+threadScanPartial(Tp (&regAggrInclusive)[ElemPerThread], ScanOpT& scan_op, Tp prefix, bool use_prefix, int valid_items)
 {
   // skip the partial scan if we have an identity
-  constexpr bool have_identity = ::cuda::has_identity_element_v<ScanOpT, Tp>;
-  if constexpr (is_last_tile && !have_identity)
+  if constexpr (IsLastTile && !::cuda::has_identity_element_v<ScanOpT, Tp>)
   {
-    if constexpr (isInclusive)
+    if constexpr (IsInclusive)
     {
       __cub_detail::ThreadScanInclusivePartial(
         regAggrInclusive, regAggrInclusive, scan_op, valid_items, prefix, use_prefix);
@@ -241,7 +239,7 @@ threadScanPartial(Tp (&regAggrInclusive)[elemPerThread], ScanOpT& scan_op, Tp pr
   }
   else
   {
-    if constexpr (isInclusive)
+    if constexpr (IsInclusive)
     {
       __cub_detail::ThreadScanInclusive(regAggrInclusive, regAggrInclusive, scan_op, prefix, use_prefix);
     }
@@ -465,7 +463,10 @@ struct warpspeed_scan_closure
 
     // Fill the registers with the scan identity, if there is one, before acquiring/waiting on any resources
     AccumT regAggrInclusive[elemPerThread];
-    fillWithIdentity<IsLastTile, ScanOpT>(regAggrInclusive, valid_items_this_thread);
+    if constexpr (IsLastTile)
+    {
+      fillWithIdentity<ScanOpT>(regAggrInclusive, valid_items_this_thread);
+    }
 
     // Aggregate of all threads up to but not including this one
     AccumT aggrExclusive;

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -295,7 +295,7 @@ struct warpspeed_scan_closure
 
   const warpspeed::SpecialRegisters specialRegisters;
   const scanKernelParams<InputT, OutputT, AccumT> params;
-  ScanOpT scan_op;
+  mutable ScanOpT scan_op; // mutable, so we can support non-const operator()
   const RealInitValueT real_init_value;
   scan_resources_t& res; // this is the only shared mutable state
 

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -100,7 +100,7 @@ allocResources(warpspeed::SyncHandler& syncHandler, warpspeed::SmemAllocator& sm
   const int num_block_idx_stages =
     policy.block_idx_stages > 0 ? policy.block_idx_stages : ::cuda::std::max(1, numStages + policy.block_idx_stages);
   const int num_aggr_exclusive_cta_stages =
-    policy.lookback_stages > 0 ? policy.lookback_stages : ::cuda::std::max(1, numStages + policy.lookback_stages);
+    policy.lookahead_stages > 0 ? policy.lookahead_stages : ::cuda::std::max(1, numStages + policy.lookahead_stages);
 
   ScanResourcesT res = {
     warpspeed::SmemResource<in_out_t>(syncHandler, smemAllocator, warpspeed::Stages{numStages}),
@@ -267,14 +267,14 @@ struct warpspeed_scan_closure
   static constexpr warpspeed::SquadDesc squadScanStore = squad_scan_store(policy);
   static constexpr warpspeed::SquadDesc squadLoad      = squad_load(policy);
   static constexpr warpspeed::SquadDesc squadSched     = squad_sched(policy);
-  static constexpr warpspeed::SquadDesc squadLookback  = squad_lookback(policy);
+  static constexpr warpspeed::SquadDesc squadLookahead = squad_lookahead(policy);
 
   static constexpr ::cuda::std::array<warpspeed::SquadDesc, 5> scanSquads = {
     squad_reduce(policy),
     squad_scan_store(policy),
     squad_load(policy),
     squad_sched(policy),
-    squad_lookback(policy),
+    squad_lookahead(policy),
   };
 
   static constexpr int tile_size                   = policy.tile_size();
@@ -314,7 +314,7 @@ struct warpspeed_scan_closure
     warpspeed::squadLoadBulk(squad, refInOutW, loadInfo);
   }
 
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE void lookback(
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void lookahead(
     const warpspeed::Squad& squad,
     warpspeed::SmemPhase<AccumT>& phaseAggrExclusiveCtaW,
     bool is_first_tile,
@@ -326,7 +326,7 @@ struct warpspeed_scan_closure
 
     if (!is_first_tile)
     {
-      AccumT regAggrExclusiveCta = warpspeed::warpIncrementalLookback<look_ahead_items_per_thread>(
+      AccumT regAggrExclusiveCta = warpspeed::warpIncrementalLookahead<look_ahead_items_per_thread>(
         specialRegisters, params.ptrTileStates, idxTilePrev, AggrExclusiveCtaPrev, idxTile, scan_op);
       if (squad.isLeaderThread())
       {
@@ -427,7 +427,7 @@ struct warpspeed_scan_closure
       }
     }
 
-    // Store tile aggregate for lookback
+    // Store tile aggregate for lookahead
     if (squad.isLeaderThread())
     {
       warpspeed::storeTileAggregate(params.ptrTileStates, warpspeed::scan_state::tile_aggregate, regSquadAggr, idxTile);
@@ -700,9 +700,9 @@ struct warpspeed_scan_closure
   {
     // Start with the tile indicated by blockIdx.x
     int idxTile = specialRegisters.blockIdxX;
-    // Lookback-specific variables:
+    // Lookahead-specific variables:
     int idxTilePrev = 0;
-    AccumT AggrExclusiveCtaPrev; // only valid in squadLookback lane_0
+    AccumT AggrExclusiveCtaPrev; // only valid in squadLookahead lane_0
 
     _CCCL_PDL_GRID_DEPENDENCY_SYNC();
 
@@ -760,9 +760,9 @@ struct warpspeed_scan_closure
           squad, phaseInOutRW, phaseThreadAndWarpAggrW, valid_items, is_first_tile, is_last_tile, loadInfo, idxTile);
       }
 
-      if (squad == squadLookback)
+      if (squad == squadLookahead)
       {
-        lookback(squad, phaseAggrExclusiveCtaW, is_first_tile, idxTilePrev, AggrExclusiveCtaPrev, idxTile);
+        lookahead(squad, phaseAggrExclusiveCtaW, is_first_tile, idxTilePrev, AggrExclusiveCtaPrev, idxTile);
       }
 
       if (squad == squadScanStore)

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -52,12 +52,6 @@ _CCCL_HOST_DEVICE_API constexpr int num_total_threads(const scan_warpspeed_polic
   return num_total_warps * warp_threads;
 }
 
-template <typename PolicySelector>
-_CCCL_DEVICE_API constexpr scan_warpspeed_policy get_warpspeed_policy() noexcept
-{
-  return current_policy<PolicySelector>().warpspeed;
-}
-
 template <typename InputT, typename OutputT, typename AccumT>
 struct scanKernelParams
 {
@@ -72,7 +66,7 @@ struct scanKernelParams
 template <typename PolicySelector, typename InputT, typename OutputT, typename AccumT>
 struct ScanResources
 {
-  static constexpr scan_warpspeed_policy policy = get_warpspeed_policy<PolicySelector>();
+  static constexpr scan_warpspeed_policy policy = current_policy<PolicySelector>().warpspeed;
 
   // align to at least 16 bytes (InputT/OutputT may be aligned higher) so each stage starts correctly aligned
   struct alignas(::cuda::std::max({::cuda::std::size_t{16}, alignof(InputT), alignof(OutputT)})) InOutT
@@ -103,7 +97,7 @@ allocResources(warpspeed::SyncHandler& syncHandler, warpspeed::SmemAllocator& sm
   using InOutT            = typename ScanResourcesT::InOutT;
   using SumThreadAndWarpT = typename ScanResourcesT::SumThreadAndWarpT;
 
-  constexpr auto policy = get_warpspeed_policy<PolicySelector>();
+  constexpr auto policy = current_policy<PolicySelector>().warpspeed;
 
   const int num_block_idx_stages =
     policy.block_idx_stages > 0 ? policy.block_idx_stages : ::cuda::std::max(1, numStages + policy.block_idx_stages);
@@ -271,7 +265,7 @@ template <typename PolicySelector,
           bool ForceInclusive>
 struct warpspeed_scan_closure
 {
-  static constexpr scan_warpspeed_policy policy = get_warpspeed_policy<PolicySelector>();
+  static constexpr scan_warpspeed_policy policy = current_policy<PolicySelector>().warpspeed;
 
   static constexpr warpspeed::SquadDesc squadReduce    = squad_reduce(policy);
   static constexpr warpspeed::SquadDesc squadScanStore = squad_scan_store(policy);
@@ -859,7 +853,7 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void device_scan_warpspeed_body(
   // Cache special registers at the start of kernel, since getting them takes a few cycles
   warpspeed::SpecialRegisters specialRegisters = warpspeed::getSpecialRegisters();
 
-  static constexpr scan_warpspeed_policy policy = get_warpspeed_policy<PolicySelector>();
+  static constexpr scan_warpspeed_policy policy = current_policy<PolicySelector>().warpspeed;
 
   // Set up the shared memory resources
   ScanResources<PolicySelector, InputT, OutputT, AccumT> res = [&] {

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -250,8 +250,9 @@ threadScanPartial(Tp (&regAggrInclusive)[ElemPerThread], ScanOpT& scan_op, Tp pr
   }
 }
 
-// Similar to CUB agents, this closure just aggregates common variables and constants so the device functions
-// implementing the warpspeed scan kernel can have lighter signatures
+// Similar to CUB agents, this closure just aggregates common constants so the device functions implementing the
+// warpspeed scan kernel can have lighter signatures. Each squad uses an instance of this to provide its context. In
+// principle, it does not hold any mutable state. But it refers to the shared scan resources (SMEM + barriers etc.).
 template <typename PolicySelector,
           typename InputT,
           typename OutputT,
@@ -296,10 +297,10 @@ struct warpspeed_scan_closure
   const scanKernelParams<InputT, OutputT, AccumT> params;
   ScanOpT scan_op;
   const RealInitValueT real_init_value;
-  scan_resources_t& res;
+  scan_resources_t& res; // this is the only shared mutable state
 
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void
-  load_next_tile_index(const warpspeed::Squad& squad, warpspeed::SmemPhase<uint4>& phaseNextBlockIdxW)
+  load_next_tile_index(const warpspeed::Squad& squad, warpspeed::SmemPhase<uint4>& phaseNextBlockIdxW) const
   {
     warpspeed::SmemRef refNextBlockIdxW = phaseNextBlockIdxW.acquireRef();
     squadGetNextBlockIdx(squad, refNextBlockIdxW);
@@ -308,7 +309,7 @@ struct warpspeed_scan_closure
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void load_current_tile(
     const warpspeed::Squad& squad,
     warpspeed::SmemPhase<in_out_t>& phaseInOutW,
-    const warpspeed::CpAsyncOobInfo<InputT>& loadInfo)
+    const warpspeed::CpAsyncOobInfo<InputT>& loadInfo) const
   {
     warpspeed::SmemRef refInOutW = phaseInOutW.acquireRef();
     warpspeed::squadLoadBulk(squad, refInOutW, loadInfo);
@@ -320,7 +321,7 @@ struct warpspeed_scan_closure
     bool is_first_tile,
     int& idxTilePrev,
     AccumT& AggrExclusiveCtaPrev,
-    int idxTile)
+    int idxTile) /*const*/ // FIXME(bgruber): this const causes a large SASS diff
   {
     warpspeed::SmemRef refAggrExclusiveCtaW = phaseAggrExclusiveCtaW.acquireRef();
 
@@ -345,7 +346,7 @@ struct warpspeed_scan_closure
     bool is_first_tile,
     bool is_last_tile, // TODO(bgruber): should we dispatch on is_last_tile outside this function and compile it twice?
     const warpspeed::CpAsyncOobInfo<InputT>& loadInfo,
-    int idxTile)
+    int idxTile) const
   {
     const int valid_items_this_thread =
       cuda::std::clamp(valid_items - squad.threadRank() * elemPerThread, 0, +elemPerThread);
@@ -446,7 +447,7 @@ struct warpspeed_scan_closure
     bool is_first_tile,
     int valid_items,
     const warpspeed::CpAsyncOobInfo<InputT>& loadInfo,
-    ::cuda::std::size_t idxTileBase)
+    ::cuda::std::size_t idxTileBase) /*const*/ // FIXME(bgruber): this const causes a large SASS diff
   {
     // need to init these to silence nvcc warning about reading uninitialized data
     [[maybe_unused]] int valid_items_this_thread = 0;
@@ -696,7 +697,7 @@ struct warpspeed_scan_closure
   // Using this structure, all code that is not executed by the current squad is DCE (dead-code-eliminated) by the
   // compiler and all warp-specialization dispatch is performed once at the start of the kernel and not in any of the
   // hot loops (even if that may seem the case from a first glance at the code).
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE void dispatch_squad(warpspeed::Squad squad)
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void dispatch_squad(warpspeed::Squad squad) // const // TODO(bgruber): enable const
   {
     // Start with the tile indicated by blockIdx.x
     int idxTile = specialRegisters.blockIdxX;

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -62,14 +62,14 @@ struct scanKernelParams
   int numStages;
 };
 
-// Struct holding all scan kernel resources
+// holds all scan kernel resources
 template <typename PolicySelector, typename InputT, typename OutputT, typename AccumT>
 struct ScanResources
 {
   static constexpr scan_warpspeed_policy policy = current_policy<PolicySelector>().warpspeed;
 
   // align to at least 16 bytes (InputT/OutputT may be aligned higher) so each stage starts correctly aligned
-  struct alignas(::cuda::std::max({::cuda::std::size_t{16}, alignof(InputT), alignof(OutputT)})) InOutT
+  struct alignas(::cuda::std::max({::cuda::std::size_t{16}, alignof(InputT), alignof(OutputT)})) in_out_t
   {
     // the tile_size size is a multiple of the warp size, and thus for sure a multiple of 16
     static_assert(policy.tile_size() % 16 == 0, "tile_size must be multiple of 16");
@@ -77,21 +77,20 @@ struct ScanResources
     // therefore, unaligned inputs need exactly 16 bytes extra for overcopying (tail padding = 16 - head padding)
     ::cuda::std::byte inout[policy.tile_size() * sizeof(InputT) + 16];
   };
-  static_assert(alignof(InOutT) >= alignof(InputT));
-  static_assert(alignof(InOutT) >= alignof(OutputT));
-  using SumThreadAndWarpT = AccumT[squad_reduce(policy).threadCount() + squad_reduce(policy).warpCount()];
+  static_assert(alignof(in_out_t) >= alignof(InputT));
+  static_assert(alignof(in_out_t) >= alignof(OutputT));
+  using thread_and_warp_aggr_t = AccumT[squad_reduce(policy).threadCount() + squad_reduce(policy).warpCount()];
 
-  warpspeed::SmemResource<InOutT> smemInOut; // will also be used to stage the output (as OutputT) for the bulk copy
+  warpspeed::SmemResource<in_out_t> smemInOut; // will also be used to stage the output (as OutputT) for the bulk copy
   warpspeed::SmemResource<uint4> smemNextBlockIdx;
   warpspeed::SmemResource<AccumT> smemSumExclusiveCta;
-  warpspeed::SmemResource<SumThreadAndWarpT> smemSumThreadAndWarp;
+  warpspeed::SmemResource<thread_and_warp_aggr_t> smemSumThreadAndWarp;
 };
 
-// Function to allocate resources.
-
 template <typename PolicySelector, typename InputT, typename OutputT, typename AccumT>
-[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr ScanResources<PolicySelector, InputT, OutputT, AccumT>
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto
 allocResources(warpspeed::SyncHandler& syncHandler, warpspeed::SmemAllocator& smemAllocator, int numStages)
+  -> ScanResources<PolicySelector, InputT, OutputT, AccumT>
 {
   using ScanResourcesT    = ScanResources<PolicySelector, InputT, OutputT, AccumT>;
   using InOutT            = typename ScanResourcesT::InOutT;
@@ -292,11 +291,15 @@ struct warpspeed_scan_closure
   static constexpr bool hasInit     = !::cuda::std::is_same_v<RealInitValueT, NullType>;
   static constexpr bool isInclusive = ForceInclusive || !hasInit;
 
+  using scan_resources_t       = ScanResources<PolicySelector, InputT, OutputT, AccumT>;
+  using in_out_t               = typename scan_resources_t::InOutT;
+  using thread_and_warp_aggr_t = typename scan_resources_t::SumThreadAndWarpT;
+
   const warpspeed::SpecialRegisters specialRegisters;
   const scanKernelParams<InputT, OutputT, AccumT> params;
   ScanOpT scan_op;
   const RealInitValueT real_init_value;
-  ScanResources<PolicySelector, InputT, OutputT, AccumT>& res;
+  scan_resources_t& res;
 
   template <typename PhaseT>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void load_next_tile_index(const warpspeed::Squad& squad, PhaseT& phaseNextBlockIdxW)
@@ -305,20 +308,18 @@ struct warpspeed_scan_closure
     squadGetNextBlockIdx(squad, refNextBlockIdxW);
   }
 
-  template <typename InOutT>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void load_current_tile(
     const warpspeed::Squad& squad,
-    warpspeed::SmemPhase<InOutT>& phaseInOutW,
+    warpspeed::SmemPhase<in_out_t>& phaseInOutW,
     const warpspeed::CpAsyncOobInfo<InputT>& loadInfo)
   {
     warpspeed::SmemRef refInOutW = phaseInOutW.acquireRef();
     warpspeed::squadLoadBulk(squad, refInOutW, loadInfo);
   }
 
-  template <typename PhaseT>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void lookback(
     const warpspeed::Squad& squad,
-    PhaseT& phaseSumExclusiveCtaW,
+    warpspeed::SmemPhase<AccumT>& phaseSumExclusiveCtaW,
     bool is_first_tile,
     int& idxTilePrev,
     AccumT& sumExclusiveCtaPrev,
@@ -339,11 +340,10 @@ struct warpspeed_scan_closure
     }
   }
 
-  template <typename PhaseInOutT, typename PhaseSumT>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void reduce_tile(
     const warpspeed::Squad& squad,
-    PhaseInOutT& phaseInOutRW,
-    PhaseSumT& phaseSumThreadAndWarpW,
+    warpspeed::SmemPhase<in_out_t>& phaseInOutRW,
+    warpspeed::SmemPhase<thread_and_warp_aggr_t>& phaseSumThreadAndWarpW,
     int valid_items,
     bool is_first_tile,
     bool is_last_tile, // TODO(bgruber): should we dispatch on is_last_tile outside this function and compile it twice?
@@ -453,12 +453,12 @@ struct warpspeed_scan_closure
     refSumThreadAndWarpW.data()[squad.threadRank()] = regThreadSum;
   }
 
-  template <bool IsLastTile, typename PhaseSumR, typename PhaseSumExR, typename PhaseInOutT>
+  template <bool IsLastTile>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void scan_and_store_tile(
     const warpspeed::Squad& squad,
-    PhaseSumR& phaseSumThreadAndWarpR,
-    PhaseSumExR& phaseSumExclusiveCtaR,
-    PhaseInOutT& phaseInOutRW,
+    warpspeed::SmemPhase<thread_and_warp_aggr_t>& phaseSumThreadAndWarpR,
+    warpspeed::SmemPhase<AccumT>& phaseSumExclusiveCtaR,
+    warpspeed::SmemPhase<in_out_t>& phaseInOutRW,
     bool is_first_tile,
     int valid_items,
     const warpspeed::CpAsyncOobInfo<InputT>& loadInfo,
@@ -856,7 +856,7 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void device_scan_warpspeed_body(
   static constexpr scan_warpspeed_policy policy = current_policy<PolicySelector>().warpspeed;
 
   // Set up the shared memory resources
-  ScanResources<PolicySelector, InputT, OutputT, AccumT> res = [&] {
+  auto res = [&] {
     warpspeed::SyncHandler syncHandler{};
     warpspeed::SmemAllocator smemAllocator{};
     auto r = allocResources<PolicySelector, InputT, OutputT, AccumT>(syncHandler, smemAllocator, params.numStages);
@@ -869,6 +869,7 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void device_scan_warpspeed_body(
     warpspeed_scan_closure<PolicySelector, InputT, OutputT, AccumT, ScanOpT, RealInitValueT, ForceInclusive>;
   warpspeed::squadDispatch(
     specialRegisters, closure_t::scanSquads, [&](warpspeed::Squad squad) _CCCL_FORCEINLINE_LAMBDA {
+      // we load the initial value after the squad dispatch, so only the squads needing it emit an LDG
       closure_t{specialRegisters, params, scan_op, static_cast<RealInitValueT>(init_value), res}.dispatch_squad(squad);
     });
 #endif // __cccl_ptx_isa >= 860

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -36,6 +36,7 @@
 #include <cuda/std/__cccl/cuda_capabilities.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__utility/move.h>
+#include <cuda/std/array>
 
 CUB_NAMESPACE_BEGIN
 
@@ -259,6 +260,8 @@ threadScanPartial(Tp (&regSumInclusive)[elemPerThread], ScanOpT& scan_op, Tp pre
   }
 }
 
+// Similar to CUB agents, this closure just aggregates common variables and constants so the device functions
+// implementing the warpspeed scan kernel can have lighter signatures
 template <typename PolicySelector,
           typename InputT,
           typename OutputT,
@@ -266,14 +269,23 @@ template <typename PolicySelector,
           typename ScanOpT,
           typename RealInitValueT,
           bool ForceInclusive>
-struct agent_warpspeed_scan
+struct warpspeed_scan_closure
 {
-  static constexpr scan_warpspeed_policy policy        = get_warpspeed_policy<PolicySelector>();
+  static constexpr scan_warpspeed_policy policy = get_warpspeed_policy<PolicySelector>();
+
   static constexpr warpspeed::SquadDesc squadReduce    = squad_reduce(policy);
   static constexpr warpspeed::SquadDesc squadScanStore = squad_scan_store(policy);
   static constexpr warpspeed::SquadDesc squadLoad      = squad_load(policy);
   static constexpr warpspeed::SquadDesc squadSched     = squad_sched(policy);
   static constexpr warpspeed::SquadDesc squadLookback  = squad_lookback(policy);
+
+  static constexpr ::cuda::std::array<warpspeed::SquadDesc, 5> scanSquads = {
+    squad_reduce(policy),
+    squad_scan_store(policy),
+    squad_load(policy),
+    squad_sched(policy),
+    squad_lookback(policy),
+  };
 
   static constexpr int tile_size                   = policy.tile_size();
   static constexpr int look_ahead_items_per_thread = policy.look_ahead_items_per_thread;
@@ -841,23 +853,15 @@ template <typename PolicySelector,
           typename ScanOpT,
           typename InitValueT>
 _CCCL_DEVICE_API _CCCL_FORCEINLINE void device_scan_warpspeed_body(
-  const scanKernelParams<InputT, OutputT, AccumT> params, ScanOpT scan_op, const InitValueT& init_value)
+  const scanKernelParams<InputT, OutputT, AccumT>& params, const ScanOpT& scan_op, const InitValueT& init_value)
 {
 #if __cccl_ptx_isa >= 860
-  // Cache special registers at start of kernel
+  // Cache special registers at the start of kernel, since getting them takes a few cycles
   warpspeed::SpecialRegisters specialRegisters = warpspeed::getSpecialRegisters();
 
   static constexpr scan_warpspeed_policy policy = get_warpspeed_policy<PolicySelector>();
 
-  // Dispatch for warp-specialization
-  static constexpr warpspeed::SquadDesc scanSquads[] = {
-    squad_reduce(policy),
-    squad_scan_store(policy),
-    squad_load(policy),
-    squad_sched(policy),
-    squad_lookback(policy),
-  };
-
+  // Set up the shared memory resources
   ScanResources<PolicySelector, InputT, OutputT, AccumT> res = [&] {
     warpspeed::SyncHandler syncHandler{};
     warpspeed::SmemAllocator smemAllocator{};
@@ -866,11 +870,13 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void device_scan_warpspeed_body(
     return r;
   }();
 
-  warpspeed::squadDispatch(specialRegisters, scanSquads, [&](warpspeed::Squad squad) _CCCL_FORCEINLINE_LAMBDA {
-    agent_warpspeed_scan<PolicySelector, InputT, OutputT, AccumT, ScanOpT, RealInitValueT, ForceInclusive>{
-      specialRegisters, params, ::cuda::std::move(scan_op), static_cast<RealInitValueT>(init_value), res}
-      .dispatch_squad(squad);
-  });
+  // Dispatch each warp to its respective squad
+  using closure_t =
+    warpspeed_scan_closure<PolicySelector, InputT, OutputT, AccumT, ScanOpT, RealInitValueT, ForceInclusive>;
+  warpspeed::squadDispatch(
+    specialRegisters, closure_t::scanSquads, [&](warpspeed::Squad squad) _CCCL_FORCEINLINE_LAMBDA {
+      closure_t{specialRegisters, params, scan_op, static_cast<RealInitValueT>(init_value), res}.dispatch_squad(squad);
+    });
 #endif // __cccl_ptx_isa >= 860
 }
 

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -35,7 +35,6 @@
 #include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__cccl/cuda_capabilities.h>
 #include <cuda/std/__type_traits/is_same.h>
-#include <cuda/std/__utility/move.h>
 #include <cuda/std/array>
 
 CUB_NAMESPACE_BEGIN
@@ -83,8 +82,8 @@ struct ScanResources
 
   warpspeed::SmemResource<in_out_t> smemInOut; // will also be used to stage the output (as OutputT) for the bulk copy
   warpspeed::SmemResource<uint4> smemNextBlockIdx;
-  warpspeed::SmemResource<AccumT> smemSumExclusiveCta;
-  warpspeed::SmemResource<thread_and_warp_aggr_t> smemSumThreadAndWarp;
+  warpspeed::SmemResource<AccumT> smemAggrExclusiveCta;
+  warpspeed::SmemResource<thread_and_warp_aggr_t> smemThreadAndWarpAggr;
 };
 
 template <typename PolicySelector, typename InputT, typename OutputT, typename AccumT>
@@ -92,22 +91,22 @@ template <typename PolicySelector, typename InputT, typename OutputT, typename A
 allocResources(warpspeed::SyncHandler& syncHandler, warpspeed::SmemAllocator& smemAllocator, int numStages)
   -> ScanResources<PolicySelector, InputT, OutputT, AccumT>
 {
-  using ScanResourcesT    = ScanResources<PolicySelector, InputT, OutputT, AccumT>;
-  using InOutT            = typename ScanResourcesT::InOutT;
-  using SumThreadAndWarpT = typename ScanResourcesT::SumThreadAndWarpT;
+  using ScanResourcesT         = ScanResources<PolicySelector, InputT, OutputT, AccumT>;
+  using in_out_t               = typename ScanResourcesT::in_out_t;
+  using thread_and_warp_aggr_t = typename ScanResourcesT::thread_and_warp_aggr_t;
 
   constexpr auto policy = current_policy<PolicySelector>().warpspeed;
 
   const int num_block_idx_stages =
     policy.block_idx_stages > 0 ? policy.block_idx_stages : ::cuda::std::max(1, numStages + policy.block_idx_stages);
-  const int num_sum_exclusive_cta_stages =
+  const int num_aggr_exclusive_cta_stages =
     policy.lookback_stages > 0 ? policy.lookback_stages : ::cuda::std::max(1, numStages + policy.lookback_stages);
 
   ScanResourcesT res = {
-    warpspeed::SmemResource<InOutT>(syncHandler, smemAllocator, warpspeed::Stages{numStages}),
+    warpspeed::SmemResource<in_out_t>(syncHandler, smemAllocator, warpspeed::Stages{numStages}),
     warpspeed::SmemResource<uint4>(syncHandler, smemAllocator, warpspeed::Stages{num_block_idx_stages}),
-    warpspeed::SmemResource<AccumT>(syncHandler, smemAllocator, warpspeed::Stages{num_sum_exclusive_cta_stages}),
-    warpspeed::SmemResource<SumThreadAndWarpT>(syncHandler, smemAllocator, warpspeed::Stages{numStages}),
+    warpspeed::SmemResource<AccumT>(syncHandler, smemAllocator, warpspeed::Stages{num_aggr_exclusive_cta_stages}),
+    warpspeed::SmemResource<thread_and_warp_aggr_t>(syncHandler, smemAllocator, warpspeed::Stages{numStages}),
   };
 
   setup_scan_resources(
@@ -116,8 +115,8 @@ allocResources(warpspeed::SyncHandler& syncHandler, warpspeed::SmemAllocator& sm
     smemAllocator,
     res.smemInOut,
     res.smemNextBlockIdx,
-    res.smemSumExclusiveCta,
-    res.smemSumThreadAndWarp);
+    res.smemAggrExclusiveCta,
+    res.smemThreadAndWarpAggr);
 
   return res;
 }
@@ -205,7 +204,7 @@ warpScanExclusivePartial(Tp regInput, ScanOpT& scan_op, const int num_items, boo
 }
 
 template <bool is_last_tile, typename ScanOpT, typename Tp, size_t elemPerThread>
-_CCCL_DEVICE_API _CCCL_FORCEINLINE void fillWithIdentity(Tp (&regSumInclusive)[elemPerThread], int valid_items)
+_CCCL_DEVICE_API _CCCL_FORCEINLINE void fillWithIdentity(Tp (&regAggrInclusive)[elemPerThread], int valid_items)
 {
   // if we are in the last tile and have an identity, fill the invalid array items with it
   constexpr bool have_identity = ::cuda::has_identity_element_v<ScanOpT, Tp>;
@@ -215,7 +214,7 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void fillWithIdentity(Tp (&regSumInclusive)[e
     {
       if (i >= valid_items)
       {
-        regSumInclusive[i] = ::cuda::identity_element<ScanOpT, Tp>();
+        regAggrInclusive[i] = ::cuda::identity_element<ScanOpT, Tp>();
       }
     }
   }
@@ -223,7 +222,7 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void fillWithIdentity(Tp (&regSumInclusive)[e
 
 template <bool isInclusive, bool is_last_tile, typename Tp, size_t elemPerThread, typename ScanOpT>
 _CCCL_DEVICE_API _CCCL_FORCEINLINE void
-threadScanPartial(Tp (&regSumInclusive)[elemPerThread], ScanOpT& scan_op, Tp prefix, bool use_prefix, int valid_items)
+threadScanPartial(Tp (&regAggrInclusive)[elemPerThread], ScanOpT& scan_op, Tp prefix, bool use_prefix, int valid_items)
 {
   // skip the partial scan if we have an identity
   constexpr bool have_identity = ::cuda::has_identity_element_v<ScanOpT, Tp>;
@@ -232,23 +231,23 @@ threadScanPartial(Tp (&regSumInclusive)[elemPerThread], ScanOpT& scan_op, Tp pre
     if constexpr (isInclusive)
     {
       __cub_detail::ThreadScanInclusivePartial(
-        regSumInclusive, regSumInclusive, scan_op, valid_items, prefix, use_prefix);
+        regAggrInclusive, regAggrInclusive, scan_op, valid_items, prefix, use_prefix);
     }
     else
     {
       __cub_detail::ThreadScanExclusivePartial(
-        regSumInclusive, regSumInclusive, scan_op, valid_items, prefix, use_prefix);
+        regAggrInclusive, regAggrInclusive, scan_op, valid_items, prefix, use_prefix);
     }
   }
   else
   {
     if constexpr (isInclusive)
     {
-      __cub_detail::ThreadScanInclusive(regSumInclusive, regSumInclusive, scan_op, prefix, use_prefix);
+      __cub_detail::ThreadScanInclusive(regAggrInclusive, regAggrInclusive, scan_op, prefix, use_prefix);
     }
     else
     {
-      __cub_detail::ThreadScanExclusive(regSumInclusive, regSumInclusive, scan_op, prefix, use_prefix);
+      __cub_detail::ThreadScanExclusive(regAggrInclusive, regAggrInclusive, scan_op, prefix, use_prefix);
     }
   }
 }
@@ -292,8 +291,8 @@ struct warpspeed_scan_closure
   static constexpr bool isInclusive = ForceInclusive || !hasInit;
 
   using scan_resources_t       = ScanResources<PolicySelector, InputT, OutputT, AccumT>;
-  using in_out_t               = typename scan_resources_t::InOutT;
-  using thread_and_warp_aggr_t = typename scan_resources_t::SumThreadAndWarpT;
+  using in_out_t               = typename scan_resources_t::in_out_t;
+  using thread_and_warp_aggr_t = typename scan_resources_t::thread_and_warp_aggr_t;
 
   const warpspeed::SpecialRegisters specialRegisters;
   const scanKernelParams<InputT, OutputT, AccumT> params;
@@ -319,31 +318,31 @@ struct warpspeed_scan_closure
 
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void lookback(
     const warpspeed::Squad& squad,
-    warpspeed::SmemPhase<AccumT>& phaseSumExclusiveCtaW,
+    warpspeed::SmemPhase<AccumT>& phaseAggrExclusiveCtaW,
     bool is_first_tile,
     int& idxTilePrev,
-    AccumT& sumExclusiveCtaPrev,
+    AccumT& AggrExclusiveCtaPrev,
     int idxTile)
   {
-    warpspeed::SmemRef refSumExclusiveCtaW = phaseSumExclusiveCtaW.acquireRef();
+    warpspeed::SmemRef refAggrExclusiveCtaW = phaseAggrExclusiveCtaW.acquireRef();
 
     if (!is_first_tile)
     {
-      AccumT regSumExclusiveCta = warpspeed::warpIncrementalLookback<look_ahead_items_per_thread>(
-        specialRegisters, params.ptrTileStates, idxTilePrev, sumExclusiveCtaPrev, idxTile, scan_op);
+      AccumT regAggrExclusiveCta = warpspeed::warpIncrementalLookback<look_ahead_items_per_thread>(
+        specialRegisters, params.ptrTileStates, idxTilePrev, AggrExclusiveCtaPrev, idxTile, scan_op);
       if (squad.isLeaderThread())
       {
-        refSumExclusiveCtaW.data() = regSumExclusiveCta;
+        refAggrExclusiveCtaW.data() = regAggrExclusiveCta;
       }
-      sumExclusiveCtaPrev = regSumExclusiveCta;
-      idxTilePrev         = idxTile;
+      AggrExclusiveCtaPrev = regAggrExclusiveCta;
+      idxTilePrev          = idxTile;
     }
   }
 
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void reduce_tile(
     const warpspeed::Squad& squad,
     warpspeed::SmemPhase<in_out_t>& phaseInOutRW,
-    warpspeed::SmemPhase<thread_and_warp_aggr_t>& phaseSumThreadAndWarpW,
+    warpspeed::SmemPhase<thread_and_warp_aggr_t>& phaseThreadAndWarpAggrW,
     int valid_items,
     bool is_first_tile,
     bool is_last_tile, // TODO(bgruber): should we dispatch on is_last_tile outside this function and compile it twice?
@@ -357,67 +356,57 @@ struct warpspeed_scan_closure
     const int valid_warps = ::cuda::ceil_div(valid_items, elemPerThread * 32);
     _CCCL_ASSERT(0 < valid_warps && valid_warps <= squad.warpCount(), "");
 
-    ////////////////////////////////////////////////////////////////////////////////
-    // Load tile from shared memory
-    ////////////////////////////////////////////////////////////////////////////////
-    AccumT regThreadSum;
-    AccumT regWarpSum;
+    // Load tile from shared memory and reduce across thread and warp
+    AccumT regThreadAggr;
+    AccumT regWarpAggr;
     {
-      // Acquire phaseInOutRW in this short scope
+      // Acquire phaseInOutRW only in this short scope
       warpspeed::SmemRef refInOutRW = phaseInOutRW.acquireRef();
-      // Load data
       AccumT regInput[elemPerThread];
-      // refInOutRW.data() + loadInfo.smemStartSkipBytes points to the first element of the tile.
+      const auto* smem_data_start =
+        reinterpret_cast<const InputT*>(&refInOutRW.data().inout[0] + loadInfo.smemStartSkipBytes);
       // in the last tile, we load some invalid elements, but don't process them later
-      warpspeed::squadLoadSmem(
-        squad, regInput, reinterpret_cast<const InputT*>(&refInOutRW.data().inout[0] + loadInfo.smemStartSkipBytes));
+      warpspeed::squadLoadSmem(squad, regInput, smem_data_start);
 
-      ////////////////////////////////////////////////////////////////////////////////
       // Reduce across thread and warp
-      ////////////////////////////////////////////////////////////////////////////////
       if (is_last_tile)
       {
-        // TODO(bgruber): for operators where we know the identity we can probably optimize further here
-        regThreadSum = __cub_detail::ThreadReducePartial(regInput, scan_op, valid_items_this_thread);
-        regWarpSum   = __scan_detail::warpReducePartial(regThreadSum, scan_op, valid_threads_this_warp);
+        // TODO(bgruber): for operators where we know the identity we can probably optimize this better
+        regThreadAggr = __cub_detail::ThreadReducePartial(regInput, scan_op, valid_items_this_thread);
+        regWarpAggr   = __scan_detail::warpReducePartial(regThreadAggr, scan_op, valid_threads_this_warp);
       }
       else
       {
-        regThreadSum = CUB_NS_QUALIFIER::ThreadReduce(regInput, scan_op);
-        regWarpSum   = __scan_detail::warpReduce(regThreadSum, scan_op);
+        regThreadAggr = CUB_NS_QUALIFIER::ThreadReduce(regInput, scan_op);
+        regWarpAggr   = __scan_detail::warpReduce(regThreadAggr, scan_op);
       }
     }
 
-    ////////////////////////////////////////////////////////////////////////////////
-    // Store warp sum to shared memory
-    ////////////////////////////////////////////////////////////////////////////////
-    warpspeed::SmemRef refSumThreadAndWarpW = phaseSumThreadAndWarpW.acquireRef();
-
+    // Store warp aggregate to shared memory
+    warpspeed::SmemRef refThreadAndWarpAggrW = phaseThreadAndWarpAggrW.acquireRef();
     if (squad.isLeaderThreadOfWarp())
     {
-      refSumThreadAndWarpW.data()[squadReduce.threadCount() + squad.warpRank()] = regWarpSum;
+      refThreadAndWarpAggrW.data()[squadReduce.threadCount() + squad.warpRank()] = regWarpAggr;
     }
     squad.syncThreads();
 
-    ////////////////////////////////////////////////////////////////////////////////
     // Reduce across squad
-    ////////////////////////////////////////////////////////////////////////////////
     // We need to accumulate the first element by hand because of the potential initial element and partial tiles
-    AccumT regSquadSum;
+    AccumT regSquadAggr;
     if constexpr (hasInit)
     {
       if (is_first_tile)
       {
-        regSquadSum = scan_op(real_init_value, refSumThreadAndWarpW.data()[squadReduce.threadCount()]);
+        regSquadAggr = scan_op(real_init_value, refThreadAndWarpAggrW.data()[squadReduce.threadCount()]);
       }
       else
       {
-        regSquadSum = refSumThreadAndWarpW.data()[squadReduce.threadCount()];
+        regSquadAggr = refThreadAndWarpAggrW.data()[squadReduce.threadCount()];
       }
     }
     else
     {
-      regSquadSum = refSumThreadAndWarpW.data()[squadReduce.threadCount()];
+      regSquadAggr = refThreadAndWarpAggrW.data()[squadReduce.threadCount()];
     }
 
     if (is_last_tile)
@@ -427,7 +416,7 @@ struct warpspeed_scan_closure
       {
         if (i < valid_warps)
         {
-          regSquadSum = scan_op(regSquadSum, refSumThreadAndWarpW.data()[squadReduce.threadCount() + i]);
+          regSquadAggr = scan_op(regSquadAggr, refThreadAndWarpAggrW.data()[squadReduce.threadCount() + i]);
         }
       }
     }
@@ -436,28 +425,25 @@ struct warpspeed_scan_closure
       _CCCL_PRAGMA_UNROLL_FULL()
       for (int i = 1; i < squadReduce.warpCount(); ++i)
       {
-        regSquadSum = scan_op(regSquadSum, refSumThreadAndWarpW.data()[squadReduce.threadCount() + i]);
+        regSquadAggr = scan_op(regSquadAggr, refThreadAndWarpAggrW.data()[squadReduce.threadCount() + i]);
       }
     }
 
-    ////////////////////////////////////////////////////////////////////////////////
-    // Store private sum for lookback
-    ////////////////////////////////////////////////////////////////////////////////
+    // Store tile aggregate for lookback
     if (squad.isLeaderThread())
     {
-      warpspeed::storeTileAggregate(params.ptrTileStates, warpspeed::scan_state::tile_aggregate, regSquadSum, idxTile);
+      warpspeed::storeTileAggregate(params.ptrTileStates, warpspeed::scan_state::tile_aggregate, regSquadAggr, idxTile);
     }
-    ////////////////////////////////////////////////////////////////////////////////
-    // Store thread sum
-    ////////////////////////////////////////////////////////////////////////////////
-    refSumThreadAndWarpW.data()[squad.threadRank()] = regThreadSum;
+
+    // Store thread aggregate
+    refThreadAndWarpAggrW.data()[squad.threadRank()] = regThreadAggr;
   }
 
   template <bool IsLastTile>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void scan_and_store_tile(
     const warpspeed::Squad& squad,
-    warpspeed::SmemPhase<thread_and_warp_aggr_t>& phaseSumThreadAndWarpR,
-    warpspeed::SmemPhase<AccumT>& phaseSumExclusiveCtaR,
+    warpspeed::SmemPhase<thread_and_warp_aggr_t>& phaseThreadAndWarpAggrR,
+    warpspeed::SmemPhase<AccumT>& phaseAggrExclusiveCtaR,
     warpspeed::SmemPhase<in_out_t>& phaseInOutRW,
     bool is_first_tile,
     int valid_items,
@@ -478,24 +464,21 @@ struct warpspeed_scan_closure
     }
 
     // Fill the registers with the scan identity, if there is one, before acquiring/waiting on any resources
-    AccumT regSumInclusive[elemPerThread];
-    fillWithIdentity<IsLastTile, ScanOpT>(regSumInclusive, valid_items_this_thread);
+    AccumT regAggrInclusive[elemPerThread];
+    fillWithIdentity<IsLastTile, ScanOpT>(regAggrInclusive, valid_items_this_thread);
 
-    // Sum of all threads up to but not including this one
-    AccumT sumExclusive;
+    // Aggregate of all threads up to but not including this one
+    AccumT aggrExclusive;
 
-    ////////////////////////////////////////////////////////////////////////////////
-    // Include warp and thread sum of current tile
-    ////////////////////////////////////////////////////////////////////////////////
+    // Include warp and thread aggregates of current tile
     {
-      // Acquire refSumThread briefly
-      warpspeed::SmemRef refSumThreadAndWarpR = phaseSumThreadAndWarpR.acquireRef();
-      // Add the sums of the preceding warps in this CTA to the cumulative
-      // sum. These sums have been calculated in reduce squad. We need
-      // the reduce and scan squads to be the same size to do this.
+      // acquire the thread and warp aggregates only for as long as we need them
+      warpspeed::SmemRef refThreadAndWarpAggrR = phaseThreadAndWarpAggrR.acquireRef();
+      // Add the aggregates of the preceding warps in this CTA to the cumulative aggregate. These have been calculated
+      // in reduce squad. We need the reduce and scan squads to be the same size to do this.
       static_assert(squadReduce.warpCount() == squadScanStore.warpCount());
 
-      // Include warp sums
+      // Include warp aggregates
       _CCCL_PRAGMA_UNROLL_FULL()
       for (int i = 0; i < squadScanStore.warpCount(); ++i)
       {
@@ -509,98 +492,96 @@ struct warpspeed_scan_closure
         {
           if (i == 0)
           {
-            // The first iteration initializes sumExclusive
-            sumExclusive = refSumThreadAndWarpR.data()[squadReduce.threadCount()];
+            // The first iteration initializes aggrExclusive
+            aggrExclusive = refThreadAndWarpAggrR.data()[squadReduce.threadCount()];
           }
           else
           {
-            // If loaded value belongs to previous warp, include it in sumExclusive.
-            sumExclusive = scan_op(sumExclusive, refSumThreadAndWarpR.data()[squadReduce.threadCount() + i]);
+            // If loaded value belongs to previous warp, include it in aggrExclusive.
+            aggrExclusive = scan_op(aggrExclusive, refThreadAndWarpAggrR.data()[squadReduce.threadCount() + i]);
           }
         }
       }
-      // sumExclusive contains the sum of previous warps.
+      // aggrExclusive contains the aggregates of previous warps.
       // It has a valid value in
-      // - tile*::warp{1,2, ..}      (sum of previous warps)
+      // - tile*::warp{1,2, ..}      (aggregate of previous warps)
       //
       // It is not yet initialized in
       // - tile*::warp0
 
-      // Add the sums of preceding threads in this warp to the cumulative sum.
+      // Add the aggregates of preceding threads in this warp to the cumulative aggregate.
       // We perform an exclusive scan of:
       //
-      //   {sumT0, sumT1, ..., sumT30, sumT31 }
+      //   {aggrT0, aggrT1, ..., aggrT30, aggrT31 }
       //
       // As a result:
       // - lane0 has undefined value
-      // - lane1 has sumT0
+      // - lane1 has aggrT0
       // - ...
-      // - lane31 has sumT0 + ... + sumT30
+      // - lane31 has aggrT0 + ... + aggrT30
       //
-      // For lane1, ..., 31, we add the result to sumExclusive.
+      // For lane1, ..., 31, we add the result to aggrExclusive.
       //
       // If the warp contains partial data, we pass invalid elements to
-      // scan_op, and sumExclusiveIntraWarp is invalid when the inputs were
+      // scan_op, and aggrExclusiveIntraWarp is invalid when the inputs were
       // invalid.
-      AccumT regSumThread = refSumThreadAndWarpR.data()[squad.threadRank()];
-      AccumT sumExclusiveIntraWarp;
+      AccumT regAggrThread = refThreadAndWarpAggrR.data()[squad.threadRank()];
+      AccumT aggrExclusiveIntraWarp;
       if constexpr (IsLastTile) // this branch would cost up to 4% BW for I8 and I16 if it were at
                                 // runtime
       {
-        sumExclusiveIntraWarp = __scan_detail::warpScanExclusivePartial(
-          regSumThread,
+        aggrExclusiveIntraWarp = __scan_detail::warpScanExclusivePartial(
+          regAggrThread,
           scan_op,
           valid_threads_this_warp,
           specialRegisters.laneIdx < static_cast<uint32_t>(valid_threads_this_warp));
       }
       else
       {
-        sumExclusiveIntraWarp = __scan_detail::warpScanExclusive(regSumThread, scan_op);
+        aggrExclusiveIntraWarp = __scan_detail::warpScanExclusive(regAggrThread, scan_op);
       }
 
       if (squad.warpRank() == 0)
       {
-        // Warp0 does not yet have a valid value for sumExclusive. We set it
+        // Warp0 does not yet have a valid value for aggrExclusive. We set it
         // here. This ensures that lane1,..,31 of tile0::warp0 have a valid
-        // value for sumExclusive.
-        sumExclusive = sumExclusiveIntraWarp;
+        // value for aggrExclusive.
+        aggrExclusive = aggrExclusiveIntraWarp;
       }
       else
       {
-        // lane0 has an undefined value for sumExclusiveIntraWarp, so skip it
-        bool includeIntraWarpSum = specialRegisters.laneIdx != 0;
+        // lane0 has an undefined value for aggrExclusiveIntraWarp, so skip it
+        bool includeIntraWarpAggr = specialRegisters.laneIdx != 0;
         if constexpr (IsLastTile)
         {
-          includeIntraWarpSum &= specialRegisters.laneIdx < static_cast<uint32_t>(valid_threads_this_warp);
+          includeIntraWarpAggr &= specialRegisters.laneIdx < static_cast<uint32_t>(valid_threads_this_warp);
         }
 
-        if (includeIntraWarpSum)
+        if (includeIntraWarpAggr)
         {
-          sumExclusive = scan_op(sumExclusive, sumExclusiveIntraWarp);
+          aggrExclusive = scan_op(aggrExclusive, aggrExclusiveIntraWarp);
         }
       }
     }
-    // sumExclusive contains the sum of previous warps and sum of previous threads.
+    // aggrExclusive contains the aggregates of previous warps and threads.
     //
-    // - tile*::warp0::lane{1, .., 31}  (sum of previous threads)
-    // - tile*::warp{1,2, ..}           (sum of previous warps + sum of previous threads)
+    // - tile*::warp0::lane{1, .., 31}  (aggr of previous threads)
+    // - tile*::warp{1,2, ..}           (aggr of previous warps + aggr of previous threads)
     //
     // It has an undefined value in
     // - tile*::warp0::lane0
 
-    ////////////////////////////////////////////////////////////////////////////////
-    // Include sum of previous tiles
-    ////////////////////////////////////////////////////////////////////////////////
+    // Include aggregate of previous tiles
     {
-      // Briefly acquire refSumExclusiveCtaR (we have to do this for the first tile as well to prevent a hang)
-      warpspeed::SmemRef refSumExclusiveCtaR = phaseSumExclusiveCtaR.acquireRef();
+      // important: we have to acquire the resource for the first tile as well to prevent a hang
+      warpspeed::SmemRef refAggrExclusiveCtaR = phaseAggrExclusiveCtaR.acquireRef();
 
       if (!is_first_tile)
       {
-        // Add the sums of preceding CTAs to the cumulative sum.
-        AccumT regSumExclusiveCta = refSumExclusiveCtaR.data();
-        // sumExclusive is invalid in warp_0/thread_0, so only include it in other threads/warps
-        sumExclusive = squad.threadRank() == 0 ? regSumExclusiveCta : scan_op(regSumExclusiveCta, sumExclusive);
+        // Add the aggregates of preceding CTAs to the cumulative aggregate.
+        AccumT regAggrExclusiveCta = refAggrExclusiveCtaR.data();
+        // aggrExclusive is invalid in warp_0/thread_0, so only include it in other threads/warps
+        aggrExclusive = squad.threadRank() == 0 ? regAggrExclusiveCta : scan_op(regAggrExclusiveCta, aggrExclusive);
       }
     }
 
@@ -608,33 +589,31 @@ struct warpspeed_scan_closure
     {
       if (is_first_tile)
       {
-        // The first thread cannot use scan_op because sumExclusive holds garbage data
+        // The first thread cannot use scan_op because aggrExclusive holds garbage data
         if (squad.threadRank() == 0)
         {
-          sumExclusive = static_cast<AccumT>(real_init_value);
+          aggrExclusive = static_cast<AccumT>(real_init_value);
         }
         else
         {
-          sumExclusive = scan_op(static_cast<AccumT>(real_init_value), sumExclusive);
+          aggrExclusive = scan_op(static_cast<AccumT>(real_init_value), aggrExclusive);
         }
       }
     }
-    // sumExclusive contains the following values:
+    // aggrExclusive contains the following values:
     //
     // - tile0::warp0::lane0            (init_value)
-    // - tile0::warp0::lane{1, .., 31}  (init_value + sum of previous threads)
-    // - tile0::warp{1,2, ..}           (init_value + sum of previous warps + sum of previous threads)
-    // - tile*::warp0::lane0            (sum of previous CTAs)
-    // - tile*::warp0::lane{1, .., 31}  (sum of previous CTAs + sum of previous threads)
-    // - tile*::warp{1,2, ..}           (sum of previous CTAs + sum of previous warps + sum of previous
+    // - tile0::warp0::lane{1, .., 31}  (init_value + aggr of previous threads)
+    // - tile0::warp{1,2, ..}           (init_value + aggr of previous warps + aggr of previous threads)
+    // - tile*::warp0::lane0            (aggr of previous CTAs)
+    // - tile*::warp0::lane{1, .., 31}  (aggr of previous CTAs + aggr of previous threads)
+    // - tile*::warp{1,2, ..}           (aggr of previous CTAs + aggr of previous warps + aggr of previous
     // threads)
     //
-    // If no init value is provided, then sumExclusive has an undefined value in
+    // If no init value is provided, then aggrExclusive has an undefined value in
     // - tile0::warp0::lane0
 
-    ////////////////////////////////////////////////////////////////////////////////
     // Scan across elements allocated to this thread
-    ////////////////////////////////////////////////////////////////////////////////
 
     // Acquire refInOut for remainder of scope.
     warpspeed::SmemRef refInOutRW = phaseInOutRW.acquireRef();
@@ -642,36 +621,32 @@ struct warpspeed_scan_closure
     // We are always loading a full tile even for the last tile, so we are loading invalid data
     warpspeed::squadLoadSmem(
       squad,
-      regSumInclusive,
+      regAggrInclusive,
       reinterpret_cast<const InputT*>(&refInOutRW.data().inout[0] + loadInfo.smemStartSkipBytes));
 
     // Perform inclusive scan of register array in current thread.
-    // warp_0/thread_0 in the first tile when there is no initial value, we MUST NOT use sumExclusive
+    // warp_0/thread_0 in the first tile when there is no initial value, we MUST NOT use aggrExclusive
     const bool use_prefix = hasInit ? true : !(is_first_tile && squad.threadRank() == 0);
     threadScanPartial<isInclusive, IsLastTile>(
-      regSumInclusive, scan_op, sumExclusive, use_prefix, valid_items_this_thread);
+      regAggrInclusive, scan_op, aggrExclusive, use_prefix, valid_items_this_thread);
 
-    ////////////////////////////////////////////////////////////////////////////////
-    // Store result to shared memory
-    ////////////////////////////////////////////////////////////////////////////////
     // Sync before storing to avoid data races on SMEM
     squad.syncThreads();
 
+    // Store result to shared memory
     ::cuda::std::byte* smem_output_tile = refInOutRW.data().inout;
     if constexpr (sizeof(OutputT) <= sizeof(InputT))
     {
       warpspeed::CpAsyncOobInfo storeInfo = warpspeed::prepareCpAsyncOob(params.ptrOut + idxTileBase, valid_items);
 
       warpspeed::squadStoreSmem(
-        squad, reinterpret_cast<OutputT*>(smem_output_tile + storeInfo.smemStartSkipBytes), regSumInclusive);
+        squad, reinterpret_cast<OutputT*>(smem_output_tile + storeInfo.smemStartSkipBytes), regAggrInclusive);
       // We do *not* release refSmemInOut here, because we will issue a TMA
       // instruction below. Instead, we issue a squad-local syncthreads +
       // fence.proxy.async to sync the shared memory writes with the TMA store.
       squad.syncThreads();
 
-      ////////////////////////////////////////////////////////////////////////////////
       // Store result to global memory using TMA
-      ////////////////////////////////////////////////////////////////////////////////
       warpspeed::squadStoreBulkSync(squad, storeInfo, smem_output_tile);
     }
     else
@@ -692,7 +667,7 @@ struct warpspeed_scan_closure
           squad,
           reinterpret_cast<OutputT*>(smem_output_tile + storeInfo.smemStartSkipBytes), // different in each
                                                                                        // iteration
-          regSumInclusive,
+          regAggrInclusive,
           chunk_offset,
           chunk_offset + chunk_size);
 
@@ -701,9 +676,7 @@ struct warpspeed_scan_closure
         // fence.proxy.async to sync the shared memory writes with the TMA store.
         squad.syncThreads();
 
-        ////////////////////////////////////////////////////////////////////////////////
         // Store result to global memory using TMA
-        ////////////////////////////////////////////////////////////////////////////////
         warpspeed::squadStoreBulkSync(squad, storeInfo, smem_output_tile);
 
         squad.syncThreads();
@@ -728,7 +701,7 @@ struct warpspeed_scan_closure
     int idxTile = specialRegisters.blockIdxX;
     // Lookback-specific variables:
     int idxTilePrev = 0;
-    AccumT sumExclusiveCtaPrev; // only valid in squadLookback lane_0
+    AccumT AggrExclusiveCtaPrev; // only valid in squadLookback lane_0
 
     _CCCL_PDL_GRID_DEPENDENCY_SYNC();
 
@@ -737,18 +710,18 @@ struct warpspeed_scan_closure
     while (true)
     {
       // Get stages. When these objects go out of scope, the stage of the resource is automatically incremented.
-      warpspeed::SmemStage stageNextBlockIdx     = res.smemNextBlockIdx.nextStage();
-      warpspeed::SmemStage stageInOut            = res.smemInOut.nextStage();
-      warpspeed::SmemStage stageSumThreadAndWarp = res.smemSumThreadAndWarp.nextStage();
-      warpspeed::SmemStage stageSumExclusiveCta  = res.smemSumExclusiveCta.nextStage();
+      warpspeed::SmemStage stageNextBlockIdx      = res.smemNextBlockIdx.nextStage();
+      warpspeed::SmemStage stageInOut             = res.smemInOut.nextStage();
+      warpspeed::SmemStage stageThreadAndWarpAggr = res.smemThreadAndWarpAggr.nextStage();
+      warpspeed::SmemStage stageAggrExclusiveCta  = res.smemAggrExclusiveCta.nextStage();
 
       // Split the stages into phases. Each resource goes through phases where it is writeable by a set of threads and
       // readable by a set of threads. To acquire and release a phase, we need to arrive and wait on certain barriers.
       // The selection of the barriers is handled under the hood.
-      auto [phaseNextBlockIdxW, phaseNextBlockIdxR]         = warpspeed::bindPhases<2>(stageNextBlockIdx);
-      auto [phaseInOutW, phaseInOutRW]                      = warpspeed::bindPhases<2>(stageInOut);
-      auto [phaseSumThreadAndWarpW, phaseSumThreadAndWarpR] = warpspeed::bindPhases<2>(stageSumThreadAndWarp);
-      auto [phaseSumExclusiveCtaW, phaseSumExclusiveCtaR]   = warpspeed::bindPhases<2>(stageSumExclusiveCta);
+      auto [phaseNextBlockIdxW, phaseNextBlockIdxR]           = warpspeed::bindPhases<2>(stageNextBlockIdx);
+      auto [phaseInOutW, phaseInOutRW]                        = warpspeed::bindPhases<2>(stageInOut);
+      auto [phaseThreadAndWarpAggrW, phaseThreadAndWarpAggrR] = warpspeed::bindPhases<2>(stageThreadAndWarpAggr);
+      auto [phaseAggrExclusiveCtaW, phaseAggrExclusiveCtaR]   = warpspeed::bindPhases<2>(stageAggrExclusiveCta);
 
       // We need to handle the first and the last -partial- tile differently
       const bool is_first_tile = idxTile == 0;
@@ -783,12 +756,12 @@ struct warpspeed_scan_closure
       if (squad == squadReduce)
       {
         reduce_tile(
-          squad, phaseInOutRW, phaseSumThreadAndWarpW, valid_items, is_first_tile, is_last_tile, loadInfo, idxTile);
+          squad, phaseInOutRW, phaseThreadAndWarpAggrW, valid_items, is_first_tile, is_last_tile, loadInfo, idxTile);
       }
 
       if (squad == squadLookback)
       {
-        lookback(squad, phaseSumExclusiveCtaW, is_first_tile, idxTilePrev, sumExclusiveCtaPrev, idxTile);
+        lookback(squad, phaseAggrExclusiveCtaW, is_first_tile, idxTilePrev, AggrExclusiveCtaPrev, idxTile);
       }
 
       if (squad == squadScanStore)
@@ -798,8 +771,8 @@ struct warpspeed_scan_closure
         {
           scan_and_store_tile<true>(
             squad,
-            phaseSumThreadAndWarpR,
-            phaseSumExclusiveCtaR,
+            phaseThreadAndWarpAggrR,
+            phaseAggrExclusiveCtaR,
             phaseInOutRW,
             is_first_tile,
             valid_items,
@@ -810,8 +783,8 @@ struct warpspeed_scan_closure
         {
           scan_and_store_tile<false>(
             squad,
-            phaseSumThreadAndWarpR,
-            phaseSumExclusiveCtaR,
+            phaseThreadAndWarpAggrR,
+            phaseAggrExclusiveCtaR,
             phaseInOutRW,
             is_first_tile,
             valid_items,

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -595,9 +595,9 @@ struct scan_warpspeed_policy
   // Therefore, a value of 0 just takes the number of stages.
   // TODO(bgruber): should we rather have two values? A stage bias (additive) and a stage scale (multiplicative)?
 
-  // We do not need too many stages for lookback since the lookback warp is the bottleneck. As soon as it produces a new
-  // value, it will be consumed by the scanStore squad, releasing the stage. So just always use 2 stages.
-  int lookback_stages = 2;
+  // We do not need too many stages for lookahead since the lookahead warp is the bottleneck. As soon as it produces a
+  // new value, it will be consumed by the scanStore squad, releasing the stage. So just always use 2 stages.
+  int lookahead_stages = 2;
 
   // If one less than the number of stages, we find a small speedup compared to setting it equal to num_stages. Not sure
   // why.
@@ -613,7 +613,7 @@ struct scan_warpspeed_policy
   {
     return lhs.num_reduce_and_scan_warps == rhs.num_reduce_and_scan_warps
         && lhs.look_ahead_items_per_thread == rhs.look_ahead_items_per_thread
-        && lhs.items_per_thread == rhs.items_per_thread && lhs.lookback_stages == rhs.lookback_stages
+        && lhs.items_per_thread == rhs.items_per_thread && lhs.lookahead_stages == rhs.lookahead_stages
         && lhs.block_idx_stages == rhs.block_idx_stages;
   }
 
@@ -629,7 +629,7 @@ struct scan_warpspeed_policy
     return os
         << "scan_warpspeed_policy { .num_reduce_and_scan_warps = " << p.num_reduce_and_scan_warps
         << ", .look_ahead_items_per_thread = " << p.look_ahead_items_per_thread
-        << ", .items_per_thread = " << p.items_per_thread << ", .lookback_stages = " << p.lookback_stages
+        << ", .items_per_thread = " << p.items_per_thread << ", .lookahead_stages = " << p.lookahead_stages
         << ", .block_idx_stages = " << p.block_idx_stages << " }";
   }
 #endif // _CCCL_HOSTED()
@@ -730,7 +730,7 @@ _CCCL_HOST_DEVICE_API constexpr warpspeed::SquadDesc squad_sched(const scan_warp
   return warpspeed::SquadDesc{3, 1}; // no point in being more than 1 warp
 }
 
-_CCCL_HOST_DEVICE_API constexpr warpspeed::SquadDesc squad_lookback(const scan_warpspeed_policy&)
+_CCCL_HOST_DEVICE_API constexpr warpspeed::SquadDesc squad_lookahead(const scan_warpspeed_policy&)
 {
   return warpspeed::SquadDesc{4, 1}; // must have 1 warp
 }
@@ -784,7 +784,7 @@ _CCCL_HOST_DEVICE_API constexpr void setup_scan_resources(
     squad_scan_store(policy),
     squad_load(policy),
     squad_sched(policy),
-    squad_lookback(policy),
+    squad_lookahead(policy),
   };
 
   smemInOut.addPhase(syncHandler, smemAllocator, squad_load(policy));
@@ -793,7 +793,7 @@ _CCCL_HOST_DEVICE_API constexpr void setup_scan_resources(
   smemNextBlockIdx.addPhase(syncHandler, smemAllocator, squad_sched(policy));
   smemNextBlockIdx.addPhase(syncHandler, smemAllocator, scanSquads);
 
-  smemSumExclusiveCta.addPhase(syncHandler, smemAllocator, squad_lookback(policy));
+  smemSumExclusiveCta.addPhase(syncHandler, smemAllocator, squad_lookahead(policy));
   smemSumExclusiveCta.addPhase(syncHandler, smemAllocator, squad_scan_store(policy));
 
   smemSumThreadAndWarp.addPhase(syncHandler, smemAllocator, squad_reduce(policy));
@@ -822,7 +822,7 @@ _CCCL_HOST_DEVICE_API constexpr auto smem_for_stages(
   const int num_block_idx_stages =
     policy.block_idx_stages > 0 ? policy.block_idx_stages : ::cuda::std::max(1, num_stages + policy.block_idx_stages);
   const int num_sum_exclusive_cta_stages =
-    policy.lookback_stages > 0 ? policy.lookback_stages : ::cuda::std::max(1, num_stages + policy.lookback_stages);
+    policy.lookahead_stages > 0 ? policy.lookahead_stages : ::cuda::std::max(1, num_stages + policy.lookahead_stages);
 
   void* inout_base = smemAllocator.alloc(static_cast<::cuda::std::uint32_t>(inout_stride * num_stages), align_inout);
   void* next_block_idx_base =


### PR DESCRIPTION
This is the second part of a few cleanup commits that should improve the readability of the warpspeed scan implementation.

This PR causes no SASS changes for the warpspeed scan benchmark on SM120.

- [x] Merge first: #9168