### PR TITLE
Use the public API for the `transform_reduce` benchmark

### DIFF
--- a/cub/benchmarks/bench/transform_reduce/sum.cu
+++ b/cub/benchmarks/bench/transform_reduce/sum.cu
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2011-2023, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: BSD-3
 
-#include <nvbench_helper.cuh>
+#include <cub/device/device_reduce.cuh>
 
-#include "thrust/iterator/transform_iterator.h"
+#include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_ITEMS_PER_THREAD ipt 7:24:1
 // %RANGE% TUNE_THREADS_PER_BLOCK tpb 128:1024:32
@@ -18,9 +18,9 @@ struct policy_selector
   {
     const auto [items, threads] =
       cub::detail::scale_mem_bound(TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, int{sizeof(AccumT)});
-    const auto policy = cub::agent_reduce_policy{
+    const auto policy = cub::detail::reduce::agent_reduce_policy{
       threads, items, 1 << TUNE_ITEMS_PER_VEC_LOAD_POW2, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_DEFAULT};
-    return {policy, policy, policy, policy};
+    return {policy, policy};
   }
 };
 #endif // !TUNE_BASE
@@ -37,15 +37,15 @@ struct square_t
 template <typename T, typename OffsetT>
 void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 {
-  using offset_t       = cub::detail::choose_offset_t<OffsetT>;
   using init_t         = T;
   using reduction_op_t = ::cuda::std::plus<>;
   using transform_op_t = square_t<T>;
 
   // Retrieve axis parameters
-  const auto elements         = static_cast<offset_t>(state.get_int64("Elements{io}"));
+  const auto elements = state.get_int64("Elements{io}");
+
   thrust::device_vector<T> in = generate(elements);
-  thrust::device_vector<T> out(1);
+  thrust::device_vector<T> out(1, thrust::default_init);
 
   auto d_in  = thrust::raw_pointer_cast(in.data());
   auto d_out = thrust::raw_pointer_cast(out.data());
@@ -55,43 +55,26 @@ void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   state.add_global_memory_reads<T>(elements, "Size");
   state.add_global_memory_writes<T>(1);
 
-  // Allocate temporary storage:
-  std::size_t temp_size;
-  cub::detail::reduce::dispatch(
-    nullptr,
-    temp_size,
-    d_in,
-    d_out,
-    elements,
-    reduction_op_t{},
-    init_t{},
-    nullptr /* stream */,
-    transform_op_t{}
-#if !TUNE_BASE
-    ,
-    policy_selector<T>{}
-#endif
-  );
-
-  thrust::device_vector<nvbench::uint8_t> temp(temp_size, thrust::no_init);
-  auto* temp_storage = thrust::raw_pointer_cast(temp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::reduce::dispatch(
-      temp_storage,
-      temp_size,
-      d_in,
-      d_out,
-      elements,
-      reduction_op_t{},
-      init_t{},
-      nullptr /* stream */,
-      transform_op_t{}
+    auto env = cub_bench_env(
+      alloc,
+      launch
 #if !TUNE_BASE
       ,
-      policy_selector<T>{}
-#endif
+      cuda::execution::tune(policy_selector<cuda::std::__accumulator_t<reduction_op_t, T, init_t>>{})
+#endif // !TUNE_BASE
     );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceReduce::TransformReduce,
+      "TransformReduce failed",
+      d_in,
+      d_out,
+      static_cast<OffsetT>(elements),
+      reduction_op_t{},
+      transform_op_t{},
+      init_t{},
+      env);
   });
 }
 


### PR DESCRIPTION
This was left over from #7464 

- [x] No SASS changes on `cub.bench.transform_reduce.sum.base` for SM`75;100`