### PR TITLE
Control unrolling in `cub::DeviceMerge[Sort]` via tuning 

### DIFF
--- a/cub/cub/agent/agent_merge.cuh
+++ b/cub/cub/agent/agent_merge.cuh
@@ -41,6 +41,7 @@ template <int ThreadsPerBlock,
           BlockStoreAlgorithm StoreAlgorithm,
           bool UseBl2ShForKeys,
           bool UseBl2ShForItems,
+          bool Unroll,
           typename KeysIt1,
           typename ItemsIt1,
           typename KeysIt2,
@@ -212,7 +213,7 @@ struct agent_t
 
     // perform serial merge
     int indices[ItemsPerThread];
-    cub::SerialMerge(
+    cub::detail::serial_merge<Unroll>(
       keys1_shared,
       keys1_beg_thread,
       keys2_offset + keys2_beg_thread,

--- a/cub/cub/agent/agent_merge_sort.cuh
+++ b/cub/cub/agent/agent_merge_sort.cuh
@@ -555,7 +555,7 @@ struct AgentMerge
     //
     int indices[ITEMS_PER_THREAD];
 
-    SerialMerge(
+    detail::serial_merge<policy.unroll>(
       &storage.keys_shared[0],
       keys1_beg_local,
       keys2_beg_local + num_keys1,

--- a/cub/cub/agent/agent_merge_sort.cuh
+++ b/cub/cub/agent/agent_merge_sort.cuh
@@ -48,7 +48,7 @@ struct AgentBlockSort
   static constexpr int ITEMS_PER_THREAD   = policy.items_per_thread;
   static constexpr int ITEMS_PER_TILE     = BLOCK_THREADS * ITEMS_PER_THREAD;
 
-  using BlockMergeSortT = BlockMergeSort<KeyT, BLOCK_THREADS, ITEMS_PER_THREAD, ValueT>;
+  using BlockMergeSortT = BlockMergeSort<KeyT, BLOCK_THREADS, ITEMS_PER_THREAD, ValueT, 1, 1, policy.unroll>;
 
   using KeysLoadIt  = try_make_cache_modified_iterator_t<policy.load_modifier, KeyInputIteratorT>;
   using ItemsLoadIt = try_make_cache_modified_iterator_t<policy.load_modifier, ValueInputIteratorT>;

--- a/cub/cub/block/block_merge_sort.cuh
+++ b/cub/cub/block/block_merge_sort.cuh
@@ -95,6 +95,21 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void serial_merge(
     }
   }
 }
+
+template <bool Unroll = true, typename KeyIt, typename KeyT, typename CompareOp, int ItemsPerThread>
+_CCCL_DEVICE _CCCL_FORCEINLINE void serial_merge(
+  KeyIt keys_shared,
+  int keys1_beg,
+  int keys2_beg,
+  int keys1_count,
+  int keys2_count,
+  KeyT (&output)[ItemsPerThread],
+  int (&indices)[ItemsPerThread],
+  CompareOp compare_op)
+{
+  serial_merge<Unroll>(
+    keys_shared, keys1_beg, keys2_beg, keys1_count, keys2_count, output, indices, compare_op, output[0]);
+}
 } // namespace detail
 
 //! Merges elements from two sorted sequences
@@ -120,7 +135,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void SerialMerge(
   CompareOp compare_op,
   KeyT oob_default)
 {
-  return detail::serial_merge(
+  detail::serial_merge(
     keys_shared, keys1_beg, keys2_beg, keys1_count, keys2_count, output, indices, compare_op, oob_default);
 }
 
@@ -135,7 +150,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void SerialMerge(
   int (&indices)[ItemsPerThread],
   CompareOp compare_op)
 {
-  SerialMerge(keys_shared, keys1_beg, keys2_beg, keys1_count, keys2_count, output, indices, compare_op, output[0]);
+  detail::serial_merge(keys_shared, keys1_beg, keys2_beg, keys1_count, keys2_count, output, indices, compare_op);
 }
 
 /**

--- a/cub/cub/block/block_merge_sort.cuh
+++ b/cub/cub/block/block_merge_sort.cuh
@@ -443,7 +443,7 @@ public:
     //
     if (!IS_LAST_TILE || ItemsPerThread * linear_tid < valid_items)
     {
-      StableOddEvenSort<_Unroll>(keys, items, compare_op);
+      detail::stable_odd_even_sort<_Unroll>(keys, items, compare_op);
     }
 
     // each thread has sorted keys
@@ -807,19 +807,21 @@ template <typename KeyT,
           int BlockDimZ   = 1,
           bool _Unroll    = true>
 class BlockMergeSort
-    : public BlockMergeSortStrategy<KeyT,
-                                    ValueT,
-                                    BlockDimX * BlockDimY * BlockDimZ,
-                                    ItemsPerThread,
-                                    BlockMergeSort<KeyT, BlockDimX, ItemsPerThread, ValueT, BlockDimY, BlockDimZ>,
-                                    _Unroll>
+    : public BlockMergeSortStrategy<
+        KeyT,
+        ValueT,
+        BlockDimX * BlockDimY * BlockDimZ,
+        ItemsPerThread,
+        BlockMergeSort<KeyT, BlockDimX, ItemsPerThread, ValueT, BlockDimY, BlockDimZ, _Unroll>,
+        _Unroll>
 {
 private:
   // The thread block size in threads
   static constexpr int BLOCK_THREADS  = BlockDimX * BlockDimY * BlockDimZ;
   static constexpr int ITEMS_PER_TILE = ItemsPerThread * BLOCK_THREADS;
 
-  using BlockMergeSortStrategyT = BlockMergeSortStrategy<KeyT, ValueT, BLOCK_THREADS, ItemsPerThread, BlockMergeSort>;
+  using BlockMergeSortStrategyT =
+    BlockMergeSortStrategy<KeyT, ValueT, BLOCK_THREADS, ItemsPerThread, BlockMergeSort, _Unroll>;
 
 public:
   _CCCL_DEVICE _CCCL_FORCEINLINE BlockMergeSort()

--- a/cub/cub/block/block_merge_sort.cuh
+++ b/cub/cub/block/block_merge_sort.cuh
@@ -59,6 +59,44 @@ MergePath(KeyIt1 keys1, KeyIt2 keys2, OffsetT keys1_count, OffsetT keys2_count, 
   return keys1_begin;
 }
 
+namespace detail
+{
+template <bool Unroll = true, typename KeyIt, typename KeyT, typename CompareOp, int ItemsPerThread>
+_CCCL_DEVICE _CCCL_FORCEINLINE void serial_merge(
+  KeyIt keys_shared,
+  int keys1_beg,
+  int keys2_beg,
+  int keys1_count,
+  int keys2_count,
+  KeyT (&output)[ItemsPerThread],
+  int (&indices)[ItemsPerThread],
+  CompareOp compare_op,
+  KeyT oob_default)
+{
+  const int keys1_end = keys1_beg + keys1_count;
+  const int keys2_end = keys2_beg + keys2_count;
+
+  KeyT key1 = keys1_count != 0 ? keys_shared[keys1_beg] : oob_default;
+  KeyT key2 = keys2_count != 0 ? keys_shared[keys2_beg] : oob_default;
+
+  _CCCL_PRAGMA_UNROLL(Unroll ? ItemsPerThread : 1)
+  for (int item = 0; item < ItemsPerThread; ++item)
+  {
+    const bool p  = (keys2_beg < keys2_end) && ((keys1_beg >= keys1_end) || compare_op(key2, key1));
+    output[item]  = p ? key2 : key1;
+    indices[item] = p ? keys2_beg++ : keys1_beg++;
+    if (p)
+    {
+      key2 = keys_shared[keys2_beg];
+    }
+    else
+    {
+      key1 = keys_shared[keys1_beg];
+    }
+  }
+}
+} // namespace detail
+
 //! Merges elements from two sorted sequences
 //! \tparam ItemsPerThread The number of elements to merge and write to \c output
 //! \param keys_shared An iterator to shared memory containing from which both sequences are reachable
@@ -82,27 +120,8 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void SerialMerge(
   CompareOp compare_op,
   KeyT oob_default)
 {
-  const int keys1_end = keys1_beg + keys1_count;
-  const int keys2_end = keys2_beg + keys2_count;
-
-  KeyT key1 = keys1_count != 0 ? keys_shared[keys1_beg] : oob_default;
-  KeyT key2 = keys2_count != 0 ? keys_shared[keys2_beg] : oob_default;
-
-  _CCCL_SORT_MAYBE_UNROLL()
-  for (int item = 0; item < ItemsPerThread; ++item)
-  {
-    const bool p  = (keys2_beg < keys2_end) && ((keys1_beg >= keys1_end) || compare_op(key2, key1));
-    output[item]  = p ? key2 : key1;
-    indices[item] = p ? keys2_beg++ : keys1_beg++;
-    if (p)
-    {
-      key2 = keys_shared[keys2_beg];
-    }
-    else
-    {
-      key1 = keys_shared[keys1_beg];
-    }
-  }
+  return detail::serial_merge(
+    keys_shared, keys1_beg, keys2_beg, keys1_count, keys2_count, output, indices, compare_op, oob_default);
 }
 
 template <typename KeyIt, typename KeyT, typename CompareOp, int ItemsPerThread>
@@ -171,7 +190,12 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void SerialMerge(
  *   Provides a way of synchronizing threads. Should be derived from
  *   `BlockMergeSortStrategy`.
  */
-template <typename KeyT, typename ValueT, int NumThreads, int ItemsPerThread, typename SynchronizationPolicy>
+template <typename KeyT,
+          typename ValueT,
+          int NumThreads,
+          int ItemsPerThread,
+          typename SynchronizationPolicy,
+          bool _Unroll = true>
 class BlockMergeSortStrategy
 {
   static_assert(::cuda::is_power_of_two(NumThreads), "NumThreads must be a power of two");
@@ -401,7 +425,7 @@ public:
       //
       KeyT max_key = oob_default;
 
-      _CCCL_SORT_MAYBE_UNROLL()
+      _CCCL_PRAGMA_UNROLL(_Unroll ? ItemsPerThread : 1)
       for (int item = 1; item < ItemsPerThread; ++item)
       {
         if (ItemsPerThread * linear_tid + item < valid_items)
@@ -419,7 +443,7 @@ public:
     //
     if (!IS_LAST_TILE || ItemsPerThread * linear_tid < valid_items)
     {
-      StableOddEvenSort(keys, items, compare_op);
+      StableOddEvenSort<_Unroll>(keys, items, compare_op);
     }
 
     // each thread has sorted keys
@@ -476,7 +500,7 @@ public:
       const int keys2_end_loc   = keys2_end;
       const int keys1_count_loc = keys1_end_loc - keys1_beg_loc;
       const int keys2_count_loc = keys2_end_loc - keys2_beg_loc;
-      SerialMerge(
+      detail::serial_merge<_Unroll>(
         &temp_storage.keys_shared[0],
         keys1_beg_loc,
         keys2_beg_loc,
@@ -775,13 +799,20 @@ private:
  *
  * This example can be easily adapted to the storage required by BlockMergeSort.
  */
-template <typename KeyT, int BlockDimX, int ItemsPerThread, typename ValueT = NullType, int BlockDimY = 1, int BlockDimZ = 1>
+template <typename KeyT,
+          int BlockDimX,
+          int ItemsPerThread,
+          typename ValueT = NullType,
+          int BlockDimY   = 1,
+          int BlockDimZ   = 1,
+          bool _Unroll    = true>
 class BlockMergeSort
     : public BlockMergeSortStrategy<KeyT,
                                     ValueT,
                                     BlockDimX * BlockDimY * BlockDimZ,
                                     ItemsPerThread,
-                                    BlockMergeSort<KeyT, BlockDimX, ItemsPerThread, ValueT, BlockDimY, BlockDimZ>>
+                                    BlockMergeSort<KeyT, BlockDimX, ItemsPerThread, ValueT, BlockDimY, BlockDimZ>,
+                                    _Unroll>
 {
 private:
   // The thread block size in threads

--- a/cub/cub/block/block_merge_sort.cuh
+++ b/cub/cub/block/block_merge_sort.cuh
@@ -104,8 +104,8 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void serial_merge(
 //! \param keys2_beg The index into \c keys_shared where the second sequence starts
 //! \param keys1_count The maximum number of keys to merge from the first sequence. One more item may be read but is not
 //! used.
-//! \param keys2_count The maximum number of keys to merge from the first sequence. One more item may be read but is not
-//! used.
+//! \param keys2_count The maximum number of keys to merge from the second sequence. One more item may be read but is
+//! not used.
 //! \param output The output array
 //! \param indices The shared memory indices relative to \c keys_shared of the elements written to \c output
 template <typename KeyIt, typename KeyT, typename CompareOp, int ItemsPerThread>

--- a/cub/cub/device/dispatch/dispatch_merge.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge.cuh
@@ -45,6 +45,7 @@ class choose_merge_agent
             active_policy.store_algorithm,
             active_policy.use_bulk_copy_for_keys,
             active_policy.use_bulk_copy_for_values,
+            active_policy.unroll,
             Args...>;
   using default_noload2sh_agent_t =
     agent_t<active_policy.threads_per_block,
@@ -53,6 +54,7 @@ class choose_merge_agent
             active_policy.store_algorithm,
             /* UseBl2ShForKeys */ false,
             /* UseBl2ShForItems */ false,
+            active_policy.unroll,
             Args...>;
 
   using fallback_agent_t =
@@ -62,6 +64,7 @@ class choose_merge_agent
             active_policy.store_algorithm,
             /* UseBl2ShForKeys */ false,
             /* UseBl2ShForItems */ false,
+            active_policy.unroll,
             Args...>;
 
   static constexpr bool use_default_load2sh =

--- a/cub/cub/device/dispatch/tuning/tuning_merge.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_merge.cuh
@@ -38,7 +38,7 @@ struct MergePolicy
   BlockStoreAlgorithm store_algorithm; //!< The @ref BlockStoreAlgorithm used for storing items to global memory
   bool use_bulk_copy_for_keys; //!< Whether to use bulk copy (cp.async.bulk) for loading keys into shared memory
   bool use_bulk_copy_for_values; //!< Whether to use bulk copy (cp.async.bulk) for loading values into shared memory
-  bool unroll = true;
+  bool unroll = true; //<! Whether to unroll the loops inside the block and serial merge implementation
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const MergePolicy& lhs, const MergePolicy& rhs) noexcept

--- a/cub/cub/device/dispatch/tuning/tuning_merge.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_merge.cuh
@@ -38,6 +38,7 @@ struct MergePolicy
   BlockStoreAlgorithm store_algorithm; //!< The @ref BlockStoreAlgorithm used for storing items to global memory
   bool use_bulk_copy_for_keys; //!< Whether to use bulk copy (cp.async.bulk) for loading keys into shared memory
   bool use_bulk_copy_for_values; //!< Whether to use bulk copy (cp.async.bulk) for loading values into shared memory
+  bool unroll = true;
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const MergePolicy& lhs, const MergePolicy& rhs) noexcept
@@ -45,7 +46,7 @@ struct MergePolicy
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
         && lhs.load_modifier == rhs.load_modifier && lhs.store_algorithm == rhs.store_algorithm
         && lhs.use_bulk_copy_for_keys == rhs.use_bulk_copy_for_keys
-        && lhs.use_bulk_copy_for_values == rhs.use_bulk_copy_for_values;
+        && lhs.use_bulk_copy_for_values == rhs.use_bulk_copy_for_values && lhs.unroll == rhs.unroll;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
@@ -61,7 +62,7 @@ struct MergePolicy
         << "MergePolicy { .threads_per_block = " << p.threads_per_block
         << ", .items_per_thread = " << p.items_per_thread << ", .load_modifier = " << p.load_modifier
         << ", .store_algorithm = " << p.store_algorithm << ", .use_bulk_copy_for_keys = " << p.use_bulk_copy_for_keys
-        << ", .use_bulk_copy_for_values = " << p.use_bulk_copy_for_values << " }";
+        << ", .use_bulk_copy_for_values = " << p.use_bulk_copy_for_values << ", .unroll = " << p.unroll << " }";
   }
 #endif // _CCCL_HOSTED()
 };

--- a/cub/cub/device/dispatch/tuning/tuning_merge.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_merge.cuh
@@ -38,7 +38,7 @@ struct MergePolicy
   BlockStoreAlgorithm store_algorithm; //!< The @ref BlockStoreAlgorithm used for storing items to global memory
   bool use_bulk_copy_for_keys; //!< Whether to use bulk copy (cp.async.bulk) for loading keys into shared memory
   bool use_bulk_copy_for_values; //!< Whether to use bulk copy (cp.async.bulk) for loading values into shared memory
-  bool unroll = true; //<! Whether to unroll the loops inside the block and serial merge implementation
+  bool unroll = true; //<! Whether to unroll the loops inside the serial merge implementation
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const MergePolicy& lhs, const MergePolicy& rhs) noexcept

--- a/cub/cub/device/dispatch/tuning/tuning_merge_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_merge_sort.cuh
@@ -61,6 +61,7 @@ struct MergeSortPolicy
   CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
   BlockStoreAlgorithm store_algorithm; //!< The @ref BlockStoreAlgorithm used for storing items to global memory
 
+  //! Whether to unroll the loops inside the block merge sort and serial merge implementation
   // RAPIDS cuDF needs to avoid unrolling some loops in sort to prevent compile time issues
 #if defined(CCCL_AVOID_SORT_UNROLL)
   bool unroll = false;

--- a/cub/cub/device/dispatch/tuning/tuning_merge_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_merge_sort.cuh
@@ -61,12 +61,19 @@ struct MergeSortPolicy
   CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
   BlockStoreAlgorithm store_algorithm; //!< The @ref BlockStoreAlgorithm used for storing items to global memory
 
+  // RAPIDS cuDF needs to avoid unrolling some loops in sort to prevent compile time issues
+#if defined(CCCL_AVOID_SORT_UNROLL)
+  bool unroll = false;
+#else // CCCL_AVOID_SORT_UNROLL
+  bool unroll = true;
+#endif // CCCL_AVOID_SORT_UNROLL
+
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const MergeSortPolicy& lhs, const MergeSortPolicy& rhs)
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
         && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
-        && lhs.store_algorithm == rhs.store_algorithm;
+        && lhs.store_algorithm == rhs.store_algorithm && lhs.unroll == rhs.unroll;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
@@ -78,9 +85,10 @@ struct MergeSortPolicy
 #if _CCCL_HOSTED()
   friend ::std::ostream& operator<<(::std::ostream& os, const MergeSortPolicy& p)
   {
-    return os << "MergeSortPolicy { .threads_per_block = " << p.threads_per_block
-              << ", .items_per_thread = " << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm
-              << ", .load_modifier = " << p.load_modifier << ", .store_algorithm = " << p.store_algorithm << " }";
+    return os
+        << "MergeSortPolicy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
+        << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm << ", .load_modifier = " << p.load_modifier
+        << ", .store_algorithm = " << p.store_algorithm << ", .unroll = " << p.unroll << " }";
   }
 #endif // _CCCL_HOSTED()
 };

--- a/cub/cub/thread/thread_sort.cuh
+++ b/cub/cub/thread/thread_sort.cuh
@@ -21,6 +21,34 @@
 
 CUB_NAMESPACE_BEGIN
 
+namespace detail
+{
+template <bool Unroll = true, typename KeyT, typename ValueT, typename CompareOp, int ITEMS_PER_THREAD>
+_CCCL_DEVICE _CCCL_FORCEINLINE void
+stable_odd_even_sort(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&items)[ITEMS_PER_THREAD], CompareOp compare_op)
+{
+  constexpr bool KEYS_ONLY = ::cuda::std::is_same_v<ValueT, NullType>;
+
+  _CCCL_PRAGMA_UNROLL(Unroll ? ItemsPerThread : 1)
+  for (int i = 0; i < ITEMS_PER_THREAD; ++i)
+  {
+    _CCCL_PRAGMA_UNROLL(Unroll ? ItemsPerThread : 1)
+    for (int j = 1 & i; j < ITEMS_PER_THREAD - 1; j += 2)
+    {
+      if (compare_op(keys[j + 1], keys[j]))
+      {
+        using ::cuda::std::swap;
+        swap(keys[j], keys[j + 1]);
+        if constexpr (!KEYS_ONLY)
+        {
+          swap(items[j], items[j + 1]);
+        }
+      }
+    } // inner loop
+  } // outer loop
+}
+} // namespace detail
+
 /**
  * @brief Sorts data using odd-even sort method
  *
@@ -50,29 +78,11 @@ CUB_NAMESPACE_BEGIN
  *   Comparison function object which returns true if the first argument is
  *   ordered before the second
  */
-template <typename KeyT, typename ValueT, typename CompareOp, int ITEMS_PER_THREAD>
+template <typename KeyT, typename ValueT, typename CompareOp, int ITEMS_PER_THREAD, bool _Unroll = true>
 _CCCL_DEVICE _CCCL_FORCEINLINE void
 StableOddEvenSort(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&items)[ITEMS_PER_THREAD], CompareOp compare_op)
 {
-  constexpr bool KEYS_ONLY = ::cuda::std::is_same_v<ValueT, NullType>;
-
-  _CCCL_SORT_MAYBE_UNROLL()
-  for (int i = 0; i < ITEMS_PER_THREAD; ++i)
-  {
-    _CCCL_SORT_MAYBE_UNROLL()
-    for (int j = 1 & i; j < ITEMS_PER_THREAD - 1; j += 2)
-    {
-      if (compare_op(keys[j + 1], keys[j]))
-      {
-        using ::cuda::std::swap;
-        swap(keys[j], keys[j + 1]);
-        if constexpr (!KEYS_ONLY)
-        {
-          swap(items[j], items[j + 1]);
-        }
-      }
-    } // inner loop
-  } // outer loop
+  return stable_odd_even_sort(_Unroll, keys, items, compare_op);
 }
 
 CUB_NAMESPACE_END

--- a/cub/cub/thread/thread_sort.cuh
+++ b/cub/cub/thread/thread_sort.cuh
@@ -32,7 +32,7 @@ stable_odd_even_sort(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&items)[ITEMS_PER_T
   _CCCL_PRAGMA_UNROLL(Unroll ? ITEMS_PER_THREAD : 1)
   for (int i = 0; i < ITEMS_PER_THREAD; ++i)
   {
-    _CCCL_PRAGMA_UNROLL(Unroll ? ITEMS_PER_THREAD : 1)
+    _CCCL_PRAGMA_UNROLL(Unroll ? ITEMS_PER_THREAD : 1) // unroll count is higher than loop count, but that's fine
     for (int j = 1 & i; j < ITEMS_PER_THREAD - 1; j += 2)
     {
       if (compare_op(keys[j + 1], keys[j]))

--- a/cub/cub/thread/thread_sort.cuh
+++ b/cub/cub/thread/thread_sort.cuh
@@ -29,10 +29,10 @@ stable_odd_even_sort(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&items)[ITEMS_PER_T
 {
   constexpr bool KEYS_ONLY = ::cuda::std::is_same_v<ValueT, NullType>;
 
-  _CCCL_PRAGMA_UNROLL(Unroll ? ItemsPerThread : 1)
+  _CCCL_PRAGMA_UNROLL(Unroll ? ITEMS_PER_THREAD : 1)
   for (int i = 0; i < ITEMS_PER_THREAD; ++i)
   {
-    _CCCL_PRAGMA_UNROLL(Unroll ? ItemsPerThread : 1)
+    _CCCL_PRAGMA_UNROLL(Unroll ? ITEMS_PER_THREAD : 1)
     for (int j = 1 & i; j < ITEMS_PER_THREAD - 1; j += 2)
     {
       if (compare_op(keys[j + 1], keys[j]))
@@ -78,11 +78,11 @@ stable_odd_even_sort(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&items)[ITEMS_PER_T
  *   Comparison function object which returns true if the first argument is
  *   ordered before the second
  */
-template <typename KeyT, typename ValueT, typename CompareOp, int ITEMS_PER_THREAD, bool _Unroll = true>
+template <typename KeyT, typename ValueT, typename CompareOp, int ITEMS_PER_THREAD>
 _CCCL_DEVICE _CCCL_FORCEINLINE void
 StableOddEvenSort(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&items)[ITEMS_PER_THREAD], CompareOp compare_op)
 {
-  return stable_odd_even_sort(_Unroll, keys, items, compare_op);
+  return detail::stable_odd_even_sort(keys, items, compare_op);
 }
 
 CUB_NAMESPACE_END

--- a/cub/cub/util_macro.cuh
+++ b/cub/cub/util_macro.cuh
@@ -56,13 +56,6 @@ _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
     }
 #endif
 
-// RAPIDS cuDF needs to avoid unrolling some loops in sort to prevent compile time issues
-#if defined(CCCL_AVOID_SORT_UNROLL)
-#  define _CCCL_SORT_MAYBE_UNROLL() _CCCL_PRAGMA_NOUNROLL()
-#else // ^^^ CCCL_AVOID_SORT_UNROLL ^^^ / vvv !CCCL_AVOID_SORT_UNROLL vvv
-#  define _CCCL_SORT_MAYBE_UNROLL() _CCCL_PRAGMA_UNROLL_FULL()
-#endif // !CCCL_AVOID_SORT_UNROLL
-
 #if defined(CUB_DEFINE_RUNTIME_POLICIES)
 #  define CUB_DETAIL_STATIC_ISH_ASSERT(expr, msg) _CCCL_ASSERT(expr, msg)
 #  define CUB_DETAIL_CONSTEXPR_ISH

--- a/cub/test/catch2_test_device_merge_env.cu
+++ b/cub/test/catch2_test_device_merge_env.cu
@@ -319,6 +319,67 @@ TEST_CASE("DeviceMerge::MergePairs uses custom stream", "[merge][device]")
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
+struct no_unroll_tuning
+{
+  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::MergePolicy
+  {
+    return {256, 7, cub::LOAD_DEFAULT, cub::BLOCK_STORE_WARP_TRANSPOSE, false, false, false};
+  }
+};
+
+TEST_CASE("DeviceMerge::MergeKeys works with unroll disabled", "[merge][device]")
+{
+  auto keys1  = c2h::device_vector<int>{0, 2, 5};
+  auto keys2  = c2h::device_vector<int>{0, 3, 3, 4};
+  auto result = c2h::device_vector<int>(7);
+  auto env    = cuda::execution::tune(no_unroll_tuning{});
+
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceMerge::MergeKeys(
+      keys1.begin(),
+      static_cast<int>(keys1.size()),
+      keys2.begin(),
+      static_cast<int>(keys2.size()),
+      result.begin(),
+      cuda::std::less<>{},
+      env));
+
+  c2h::device_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
+  REQUIRE(result == expected);
+}
+
+TEST_CASE("DeviceMerge::MergePairs works with unroll disabled", "[merge][device]")
+{
+  auto keys1   = c2h::device_vector<int>{0, 2, 5};
+  auto values1 = c2h::device_vector<char>{'a', 'b', 'c'};
+  auto keys2   = c2h::device_vector<int>{0, 3, 3, 4};
+  auto values2 = c2h::device_vector<char>{'A', 'B', 'C', 'D'};
+
+  auto result_keys   = c2h::device_vector<int>(7);
+  auto result_values = c2h::device_vector<char>(7);
+  auto env           = cuda::execution::tune(no_unroll_tuning{});
+
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceMerge::MergePairs(
+      keys1.begin(),
+      values1.begin(),
+      static_cast<int>(keys1.size()),
+      keys2.begin(),
+      values2.begin(),
+      static_cast<int>(keys2.size()),
+      result_keys.begin(),
+      result_values.begin(),
+      cuda::std::less<>{},
+      env));
+
+  c2h::device_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
+  c2h::device_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
+  REQUIRE(result_keys == expected_keys);
+  REQUIRE(result_values == expected_values);
+}
+
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
 C2H_TEST("MergePolicy", "[merge][device]")
 {
@@ -327,7 +388,7 @@ C2H_TEST("MergePolicy", "[merge][device]")
 
   // aggregate init
   constexpr auto p1 = cub::MergePolicy{
-    128, 7, cub::CacheLoadModifier::LOAD_LDG, cub::BlockStoreAlgorithm::BLOCK_STORE_WARP_TRANSPOSE, true, false};
+    128, 7, cub::CacheLoadModifier::LOAD_LDG, cub::BlockStoreAlgorithm::BLOCK_STORE_WARP_TRANSPOSE, true, false, false};
 
 #  if _CCCL_STD_VER >= 2020
   // designated init
@@ -337,7 +398,8 @@ C2H_TEST("MergePolicy", "[merge][device]")
     .load_modifier            = cub::CacheLoadModifier::LOAD_LDG,
     .store_algorithm          = cub::BlockStoreAlgorithm::BLOCK_STORE_WARP_TRANSPOSE,
     .use_bulk_copy_for_keys   = true,
-    .use_bulk_copy_for_values = false};
+    .use_bulk_copy_for_values = false,
+    .unroll                   = false};
 #  else // _CCCL_STD_VER >= 2020
   constexpr auto p2 = p1;
 #  endif // _CCCL_STD_VER >= 2020

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -556,6 +556,26 @@ C2H_TEST("DeviceMergeSort::StableSortKeysCopy can be tuned", "[merge_sort][devic
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
+TEST_CASE("DeviceMergeSort::SortKeys works with unroll disabled", "[merge_sort][device]")
+{
+  struct no_unroll_tuning
+  {
+    _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const
+      -> cub::detail::merge_sort::merge_sort_policy
+    {
+      return {256, 7, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_STORE_DIRECT, false};
+    }
+  };
+
+  auto d_keys = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
+  auto env    = cuda::execution::tune(no_unroll_tuning{});
+
+  device_merge_sort_keys(d_keys.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}, env);
+
+  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  REQUIRE(d_keys == expected_keys);
+}
+
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -558,8 +558,7 @@ C2H_TEST("DeviceMergeSort::StableSortKeysCopy can be tuned", "[merge_sort][devic
 
 struct no_unroll_tuning
 {
-  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::merge_sort::merge_sort_policy
+  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::MergeSortPolicy
   {
     return {256, 7, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_STORE_DIRECT, false};
   }

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -556,17 +556,17 @@ C2H_TEST("DeviceMergeSort::StableSortKeysCopy can be tuned", "[merge_sort][devic
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
+struct no_unroll_tuning
+{
+  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const
+    -> cub::detail::merge_sort::merge_sort_policy
+  {
+    return {256, 7, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_STORE_DIRECT, false};
+  }
+};
+
 TEST_CASE("DeviceMergeSort::SortKeys works with unroll disabled", "[merge_sort][device]")
 {
-  struct no_unroll_tuning
-  {
-    _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const
-      -> cub::detail::merge_sort::merge_sort_policy
-    {
-      return {256, 7, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_STORE_DIRECT, false};
-    }
-  };
-
   auto d_keys = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto env    = cuda::execution::tune(no_unroll_tuning{});
 


### PR DESCRIPTION
- [x] Test locally that setting different unroll values actually has an effect

```c++
#include <cub/device/device_merge_sort.cuh>
#include <thrust/device_vector.h>
#include <cuda/__execution/tune.h>
#include <cuda/std/functional>
#include <cstdio>


struct MyMergeSortPolicySelector
{
  __host__ __device__ constexpr auto operator()(cuda::compute_capability) const -> cub::MergeSortPolicy
  {
    return {.threads_per_block = 256,
            .items_per_thread  = 17,
            .load_algorithm    = cub::BLOCK_LOAD_WARP_TRANSPOSE,
            .load_modifier     = cub::LOAD_DEFAULT,
            .store_algorithm   = cub::BLOCK_STORE_WARP_TRANSPOSE,
            .unroll            = true}; // or false
  }
};

int main()
{
  thrust::device_vector<int> keys = {8, 6, 7, 5, 3, 0, 9, 1};
  (void) cub::DeviceMergeSort::SortKeys(
    keys.begin(),
    static_cast<int>(keys.size()),
    ::cuda::std::less<int>{},
    cuda::execution::tune(MyMergeSortPolicySelector{}));
  for (int k : keys)
    printf("%d ", k);
  printf("\n");
}
```
compiled with:
```
nvcc -Icub -Ithrust -Ilibcudacxx/include ./merge_sort_example.cu && ./a.out && cuobjdump -sass ./a.out >> unroll_true.sass
```
Then did the same with `.unroll = false`. SASS is vastly different. The `unroll = false` version produces lots of `STL` instructions, as expected.

Fixes: #9052