### PR TITLE
[cudax] Disable cuco hashers test for nvcc 12.0

### DIFF
--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -101,9 +101,15 @@ cudax_add_catch2_test(test_target copy
     copy/copy_shared_memory.cu
 )
 
-cudax_add_catch2_test(test_target cuco
-    cuco/utility/test_hashers.cu
+# nvcc 12.0 fails to compile cuco hashers test
+if (
+  NOT "${CMAKE_CUDA_COMPILER_ID}" STREQUAL "NVIDIA"
+  OR "${CMAKE_CUDA_COMPILER_VERSION}" VERSION_GREATER_EQUAL "12.1"
 )
+  cudax_add_catch2_test(test_target cuco
+    cuco/utility/test_hashers.cu
+  )
+endif()
 
 cudax_add_catch2_test(test_target cuco_hyperloglog ${cudax_target}
   cuco/hyperloglog/test_hyperloglog.cu

--- a/cudax/test/cuco/utility/test_hashers.cu
+++ b/cudax/test/cuco/utility/test_hashers.cu
@@ -224,12 +224,10 @@ TEST_CASE("Test Hasher's on host and device", "")
     test_xxhash32{}();
     test_xxhash64{}();
     test_murmurhash3_32{}();
-
-    // nvcc 12.0 crashes for int128 tests when using gcc as the host compiler
-#if _CCCL_HAS_INT128() && !(_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0) && _CCCL_COMPILER(GCC))
+#if _CCCL_HAS_INT128()
     test_murmurhash3_x86_128{}();
     test_murmurhash3_x64_128{}();
-#endif // _CCCL_HAS_INT128() && !(_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0) && _CCCL_COMPILER(GCC))
+#endif // _CCCL_HAS_INT128()
   }
 
   SECTION("device-generated hash values match the reference implementation.")
@@ -237,11 +235,9 @@ TEST_CASE("Test Hasher's on host and device", "")
     test_hasher_on_device(test_xxhash32{});
     test_hasher_on_device(test_xxhash64{});
     test_hasher_on_device(test_murmurhash3_32{});
-
-    // nvcc 12.0 crashes for int128 tests when using gcc as the host compiler
-#if _CCCL_HAS_INT128() && !(_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0) && _CCCL_COMPILER(GCC))
+#if _CCCL_HAS_INT128()
     test_hasher_on_device(test_murmurhash3_x86_128{});
     test_hasher_on_device(test_murmurhash3_x64_128{});
-#endif // _CCCL_HAS_INT128() && !(_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0) && _CCCL_COMPILER(GCC))
+#endif // _CCCL_HAS_INT128()
   }
 }


### PR DESCRIPTION
We've already tried to fix it once, but the problem re-occurs. When compiling int128 tests, `cicc` 12.0 dies. Let's just disable int128 completely for that test when compiling with nvcc 12.0. It's very possible that cuco will never see nvcc 12.0 in production code anyway.

Edit: This is not related to int128 probably, I've just disabled the test completely for 12.0.