### PR TITLE
Add tuning search based on CompileIQ

### DIFF
--- a/benchmarks/scripts/cccl/bench/bench.py
+++ b/benchmarks/scripts/cccl/bench/bench.py
@@ -529,8 +529,11 @@ class ProcessRunner:
 
     def __init__(self):
         self.process = None
-        signal.signal(signal.SIGINT, self.signal_handler)
-        signal.signal(signal.SIGTERM, self.signal_handler)
+        import threading
+
+        if threading.current_thread() is threading.main_thread():
+            signal.signal(signal.SIGINT, self.signal_handler)
+            signal.signal(signal.SIGTERM, self.signal_handler)
 
     def new_process(self, cmd):
         self.process = subprocess.Popen(

--- a/benchmarks/scripts/cccl/bench/bench.py
+++ b/benchmarks/scripts/cccl/bench/bench.py
@@ -553,6 +553,37 @@ class ProcessRunner:
             self.process.kill()
 
 
+def _filter_rt_values(speedups, rt_values):
+    """Filter rt_values to only include axis values present in speedup data.
+
+    The rt_values from JSON metadata may include values for benchmark states
+    that NVBench skips at runtime. If weight normalization includes these
+    missing states, the total weight for iterated states sums to < 1.0,
+    producing incorrect scores. This function filters rt_values to match the
+    actual data, preserving the original value ordering (important for
+    importance-ordered axes).
+    """
+    present = {}
+    for bench in speedups:
+        present[bench] = {}
+        for state in speedups[bench]:
+            for point in state_to_rt_workload(bench, state):
+                axis, value = point.split("=")
+                if axis not in present[bench]:
+                    present[bench][axis] = set()
+                present[bench][axis].add(value)
+
+    result = {}
+    for bench in speedups:
+        result[bench] = {}
+        for axis in rt_values.get(bench, {}):
+            if axis in present.get(bench, {}):
+                result[bench][axis] = [
+                    v for v in rt_values[bench][axis] if v in present[bench][axis]
+                ]
+    return result
+
+
 class Bench:
     def __init__(self, algorithm_name, variant, ct_workload):
         self.algname = algorithm_name
@@ -795,8 +826,11 @@ class Bench:
         if not speedups:
             return float("-inf")
 
-        rt_axes_ids = compute_axes_ids(rt_values)
-        weight_matrices = compute_weight_matrices(rt_values, rt_axes_ids)
+        # Filter rt_values to only include axis values present in the speedup data
+        actual_rt_values = _filter_rt_values(speedups, rt_values)
+
+        rt_axes_ids = compute_axes_ids(actual_rt_values)
+        weight_matrices = compute_weight_matrices(actual_rt_values, rt_axes_ids)
 
         score = 0
         for bench in speedups:
@@ -804,10 +838,13 @@ class Bench:
                 rt_workload = state_to_rt_workload(bench, state)
                 weights = weight_matrices[bench]
                 weight = get_workload_weight(
-                    rt_workload, rt_values[bench], rt_axes_ids[bench], weights
+                    rt_workload,
+                    actual_rt_values[bench],
+                    rt_axes_ids[bench],
+                    weights,
                 )
-                speedup = speedups[bench][state]
-                score = score + weight * speedup
+                speedup_val = speedups[bench][state]
+                score = score + weight * speedup_val
 
         return score
 

--- a/benchmarks/scripts/cccl/bench/bench.py
+++ b/benchmarks/scripts/cccl/bench/bench.py
@@ -553,37 +553,6 @@ class ProcessRunner:
             self.process.kill()
 
 
-def _filter_rt_values(speedups, rt_values):
-    """Filter rt_values to only include axis values present in speedup data.
-
-    The rt_values from JSON metadata may include values for benchmark states
-    that NVBench skips at runtime. If weight normalization includes these
-    missing states, the total weight for iterated states sums to < 1.0,
-    producing incorrect scores. This function filters rt_values to match the
-    actual data, preserving the original value ordering (important for
-    importance-ordered axes).
-    """
-    present = {}
-    for bench in speedups:
-        present[bench] = {}
-        for state in speedups[bench]:
-            for point in state_to_rt_workload(bench, state):
-                axis, value = point.split("=")
-                if axis not in present[bench]:
-                    present[bench][axis] = set()
-                present[bench][axis].add(value)
-
-    result = {}
-    for bench in speedups:
-        result[bench] = {}
-        for axis in rt_values.get(bench, {}):
-            if axis in present.get(bench, {}):
-                result[bench][axis] = [
-                    v for v in rt_values[bench][axis] if v in present[bench][axis]
-                ]
-    return result
-
-
 class Bench:
     def __init__(self, algorithm_name, variant, ct_workload):
         self.algname = algorithm_name
@@ -826,27 +795,47 @@ class Bench:
         if not speedups:
             return float("-inf")
 
-        # Filter rt_values to only include axis values present in the speedup data
-        actual_rt_values = _filter_rt_values(speedups, rt_values)
+        rt_axes_ids = compute_axes_ids(rt_values)
+        weight_matrices = compute_weight_matrices(rt_values, rt_axes_ids)
 
-        rt_axes_ids = compute_axes_ids(actual_rt_values)
-        weight_matrices = compute_weight_matrices(actual_rt_values, rt_axes_ids)
-
+        # For importance-ordered axis, score favors last speedups:
+        # score = 15% of S16 + 25% of S20 + 29% of S24 + 31% of S28
+        #
+        # Sometimes, list is incomplete. Say, if a workloads error out or skip.
+        # For simplicity, say we skipped 2^16 and 2^20 elements.
+        #
+        # In these cases, `rt_values` should still contain full list with 2^16
+        # and 2^20 included.
+        # Otherwise, we'd assume that 2^24 was the first value on the importance axis.
+        # In which case, we'd assign weights as 38% / 62% instead of 48% / 52%.
+        #
+        # If we do nothing, score computation would just skip S16 and S20 completely,
+        # while still scaling S24 and S28 components lower, as if S16 and S20 was there.
+        # score = 15% of 0 + 25% of 0 + 29% of S24 + 31% of S28
+        # Note how we end up with 29% of S24 + 31% of S28 all while 29 + 31 do
+        # not add to a 100%.
+        # This breaks "speedup" semantic of the score.
+        #
+        # To fix this, we just accumulate what new 100% mean and scale score by that:
+        # (29/100 of S24) / (60/100) + (31/100 of S28) / (60/100)
+        #     = 29/60 of S24 + 31/60 of S28
+        # which is: 48% of S24 + 52% of S28, maintaining the relative importance.
         score = 0
+        total_weight = 0
         for bench in speedups:
             for state in speedups[bench]:
                 rt_workload = state_to_rt_workload(bench, state)
                 weights = weight_matrices[bench]
                 weight = get_workload_weight(
-                    rt_workload,
-                    actual_rt_values[bench],
-                    rt_axes_ids[bench],
-                    weights,
+                    rt_workload, rt_values[bench], rt_axes_ids[bench], weights
                 )
-                speedup_val = speedups[bench][state]
-                score = score + weight * speedup_val
+                score = score + weight * speedups[bench][state]
+                total_weight = total_weight + weight
 
-        return score
+        if total_weight == 0:
+            return float("-inf")
+
+        return score / total_weight
 
 
 class BaseBench(Bench):

--- a/benchmarks/scripts/cccl/bench/storage.py
+++ b/benchmarks/scripts/cccl/bench/storage.py
@@ -75,8 +75,14 @@ class StorageBase:
 
 class SQLiteStorage(StorageBase):
     def __init__(self, db_path):
+        if sqlite3.threadsafety < 3:
+            raise RuntimeError(
+                "SQLite threadsafety level is {}, but serialized mode (3) is required".format(
+                    sqlite3.threadsafety
+                )
+            )
         self.db_path = db_path
-        self.conn = sqlite3.connect(db_path)
+        self.conn = sqlite3.connect(db_path, check_same_thread=False)
 
     def connection(self):
         return self.conn

--- a/benchmarks/scripts/search_iq.py
+++ b/benchmarks/scripts/search_iq.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+
+import cccl.bench as bench
+import compileiq.search_spaces.base as ss
+from compileiq.ciq import Search
+from compileiq.types import SearchConfiguration
+
+
+def pool_cull_sizes(num_genes, num_objectives, variant_space_size, cull=0.75):
+    min_pool_size = 128 if variant_space_size > 10000 else 32
+    target = (2 * num_objectives) + 1
+    poolsize = int(target / (1 - cull))
+    poolsize = max(max(poolsize, min_pool_size), 2 * num_genes)
+    poolsize = poolsize if poolsize % 2 == 0 else poolsize + 1
+    cullsize = int(poolsize * cull)
+    cullsize = cullsize if cullsize % 2 == 0 else cullsize - 1
+    return poolsize, cullsize
+
+
+def get_num_expected_runs(num_genes, num_objectives, variant_space_size):
+    poolsize, _ = pool_cull_sizes(num_genes, num_objectives, variant_space_size)
+    return poolsize * 5
+
+
+def build_search_space(parameter_space):
+    search_space = {}
+    for rng in parameter_space:
+        search_space[rng.label] = ss.range(
+            start=rng.low, end=rng.high - 1, step=rng.step
+        )
+    return search_space
+
+
+INVALID_SCORE = "*"
+
+
+def make_objective(algname, ct_workload, rt_workload_space, parameter_space):
+    center_estimator = bench.MedianCenterEstimator()
+
+    def objective(config):
+        print(f"Evaluating variant {config}: ", end="")
+
+        range_points = []
+        for rng in parameter_space:
+            value = int(config[rng.label])
+            range_points.append(bench.RangePoint(rng.definition, rng.label, value))
+
+        variant = bench.VariantPoint(range_points)
+        b = bench.Bench(algname, variant, list(ct_workload))
+
+        if not b.build():
+            print("Build failed")
+            return INVALID_SCORE
+
+        score = b.score(
+            ct_workload, rt_workload_space, center_estimator, center_estimator
+        )
+
+        if score == float("inf") or score == float("-inf"):
+            print("Infinite store")
+            return INVALID_SCORE
+
+        print(score)
+        return score
+
+    return objective
+
+
+class CompileIQSeeker:
+    def __init__(self):
+        self.base_center_estimator = bench.MedianCenterEstimator()
+        self.variant_center_estimator = bench.MedianCenterEstimator()
+        self.bruteforce_seeker = bench.BruteForceSeeker(
+            self.base_center_estimator, self.variant_center_estimator
+        )
+
+    def iq_search(self, algname, ct_workload_space, rt_workload_space):
+        config = bench.Config()
+        parameter_space = config.benchmarks[algname]
+        variant_space_size = config.variant_space_size(algname)
+
+        num_genes = len(parameter_space)
+        num_objectives = 1
+        poolsize, cullsize = pool_cull_sizes(
+            num_genes, num_objectives, variant_space_size
+        )
+        num_generations = 50 if variant_space_size > 10000 else 25
+
+        search_space = build_search_space(parameter_space)
+
+        search_config = SearchConfiguration(
+            problem_type="max",
+            num_objectives=num_objectives,
+            generations=num_generations,
+            pool_size=poolsize,
+            cull_size=cullsize,
+            mutate_rate=0.15,
+            init_with_true_random_threshold=0.90,
+        )
+
+        for ct_workload in ct_workload_space:
+            objective = make_objective(
+                algname, ct_workload, rt_workload_space, parameter_space
+            )
+
+            tuner = Search(
+                objective_function=objective,
+                search_space=search_space,
+                search_config=search_config,
+            )
+
+            results = tuner.start(num_workers=1)
+            best = results.get_best_result()
+            print("Best for {} {}: {}".format(algname, ct_workload, best))
+
+    def bf_search(self, algname, ct_workload_space, rt_workload_space):
+        self.bruteforce_seeker(algname, ct_workload_space, rt_workload_space)
+
+    def __call__(self, algname, ct_workload_space, rt_workload_space):
+        config = bench.Config()
+        num_genes = len(config.benchmarks[algname])
+        variant_space_size = config.variant_space_size(algname)
+        num_rt_workloads = len(rt_workload_space)
+        expected_runs = get_num_expected_runs(
+            num_genes, num_rt_workloads, variant_space_size
+        )
+
+        if expected_runs < 128:
+            self.bf_search(algname, ct_workload_space, rt_workload_space)
+        else:
+            self.iq_search(algname, ct_workload_space, rt_workload_space)
+
+
+def main():
+    bench.search(CompileIQSeeker())
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/scripts/search_iq.py
+++ b/benchmarks/scripts/search_iq.py
@@ -7,13 +7,15 @@ from compileiq.types import SearchConfiguration
 
 
 def pool_cull_sizes(num_genes, num_objectives, variant_space_size, cull=0.75):
+    if not (0.05 <= cull <= 0.95):
+        raise ValueError("cull must be between 0.05 and 0.95, got {}".format(cull))
     min_pool_size = 128 if variant_space_size > 10000 else 32
     target = (2 * num_objectives) + 1
     poolsize = int(target / (1 - cull))
     poolsize = max(max(poolsize, min_pool_size), 2 * num_genes)
-    poolsize = poolsize if poolsize % 2 == 0 else poolsize + 1
+    poolsize = poolsize + (poolsize % 2)
     cullsize = int(poolsize * cull)
-    cullsize = cullsize if cullsize % 2 == 0 else cullsize - 1
+    cullsize = cullsize - (cullsize % 2)
     return poolsize, cullsize
 
 
@@ -24,9 +26,9 @@ def get_num_expected_runs(num_genes, num_objectives, variant_space_size):
 
 def build_search_space(parameter_space):
     search_space = {}
-    for rng in parameter_space:
-        search_space[rng.label] = ss.range(
-            start=rng.low, end=rng.high - 1, step=rng.step
+    for search_range in parameter_space:
+        search_space[search_range.label] = ss.range(
+            start=search_range.low, end=search_range.high - 1, step=search_range.step
         )
     return search_space
 
@@ -41,9 +43,11 @@ def make_objective(algname, ct_workload, rt_workload_space, parameter_space):
         print(f"Evaluating variant {config}: ", end="")
 
         range_points = []
-        for rng in parameter_space:
-            value = int(config[rng.label])
-            range_points.append(bench.RangePoint(rng.definition, rng.label, value))
+        for search_range in parameter_space:
+            value = int(config[search_range.label])
+            range_points.append(
+                bench.RangePoint(search_range.definition, search_range.label, value)
+            )
 
         variant = bench.VariantPoint(range_points)
         b = bench.Bench(algname, variant, list(ct_workload))
@@ -57,7 +61,7 @@ def make_objective(algname, ct_workload, rt_workload_space, parameter_space):
         )
 
         if score == float("inf") or score == float("-inf"):
-            print("Infinite store")
+            print("Infinite score")
             return INVALID_SCORE
 
         print(score)

--- a/benchmarks/scripts/tests/conftest.py
+++ b/benchmarks/scripts/tests/conftest.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import os
+import sys
+
+# The benchmark scripts are not an installed package: `analyze.py`, `search.py`
+# and friends import `cccl.bench` by virtue of living next to it. Make the same
+# import work when the tests are collected from anywhere.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/benchmarks/scripts/tests/test_score.py
+++ b/benchmarks/scripts/tests/test_score.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Run with: `uvx --with numpy --with fpzip --with pandas --with pytest pytest -q benchmarks/scripts/tests/`
+
+"""Tests for the workload weighting in `Bench.score`."""
+
+import pytest
+from cccl.bench.bench import Bench
+from cccl.bench.config import RangePoint, VariantPoint
+from cccl.bench.score import compute_axes_ids, compute_weight_matrices
+
+ALGNAME = "cub.bench.reduce.sum"
+SUBBENCH = "base"
+CT_WORKLOAD = "T{ct}=I32 OffsetT{ct}=I64"
+ELEMENTS = "Elements{io}"
+
+# The runtime axis as declared by the benchmark, i.e. what `rt_axes_values()`
+# reports. NVBench may skip some of these states at runtime, in which case they
+# never reach `speedups`.
+DECLARED = {SUBBENCH: {ELEMENTS: ["16", "20", "24", "28"]}}
+
+
+class StubBench(Bench):
+    """A `Bench` whose measurements are supplied instead of benchmarked.
+
+    Everything up to `Bench.speedup()` needs a build directory, a GPU and a
+    database; the weighting `Bench.score()` applies on top of the speedups does
+    not, so it is tested against canned measurements.
+    """
+
+    def __init__(self, measured):
+        super().__init__(
+            ALGNAME, VariantPoint([RangePoint("TUNE_TPB", "tpb", 256)]), [CT_WORKLOAD]
+        )
+        self.measured = measured
+
+    def speedup(self, ct_workload_point, rt_values, base_estimator, variant_estimator):
+        return {
+            SUBBENCH: {
+                "{} {}={}".format(CT_WORKLOAD, ELEMENTS, value): s
+                for value, s in self.measured.items()
+            }
+        }
+
+
+def score_of(measured):
+    return StubBench(measured).score([CT_WORKLOAD], DECLARED, None, None)
+
+
+def declared_weight(value):
+    axes_ids = compute_axes_ids(DECLARED)
+    matrices = compute_weight_matrices(DECLARED, axes_ids)
+    return matrices[SUBBENCH][DECLARED[SUBBENCH][ELEMENTS].index(value)]
+
+
+def test_score_is_the_weighted_mean_of_the_speedups():
+    measured = {"16": 0.5, "20": 1.0, "24": 1.5, "28": 2.0}
+
+    assert score_of(measured) == pytest.approx(
+        sum(declared_weight(v) * s for v, s in measured.items())
+    )
+
+
+def test_score_of_a_failed_run_is_minus_infinity():
+    class FailedBench(StubBench):
+        def speedup(
+            self, ct_workload_point, rt_values, base_estimator, variant_estimator
+        ):
+            return {}
+
+    assert FailedBench({}).score([CT_WORKLOAD], DECLARED, None, None) == float("-inf")
+
+
+@pytest.mark.parametrize(
+    "measured", [["16", "20", "24", "28"], ["24", "28"], ["16", "28"], ["28"]]
+)
+def test_a_variant_on_par_with_base_scores_one_whatever_was_skipped(measured):
+    """Skipped states must not take their weight mass into the score.
+
+    If it stayed in, a variant that is exactly as fast as base would score below
+    1.0 and look like a regression.
+    """
+    assert score_of({value: 1.0 for value in measured}) == pytest.approx(1.0)
+
+
+def test_relative_importance_does_not_depend_on_what_was_skipped():
+    """The weight ratio of two workloads is fixed by the declared axis.
+
+    Importance is assigned by position on the axis (see `score.compute_weights`),
+    so deriving the weights from the states that ran would move the smallest
+    surviving value onto the least importance anchor -- 2^24 would stop being
+    nearly as important as 2^28 just because 2^16 was skipped.
+    """
+    measured = ["24", "28"]
+    total = sum(declared_weight(v) for v in measured)
+
+    for value in measured:
+        score = score_of({v: (2.0 if v == value else 1.0) for v in measured})
+
+        # Doubling the speedup of one workload raises the score by that
+        # workload's share of the declared weight of the measured set.
+        assert score - 1.0 == pytest.approx(declared_weight(value) / total)
+
+
+def test_a_uniformly_faster_variant_beats_one_that_trades_a_regression():
+    """2^24 and 2^28 carry almost the same weight in the declared axis.
+
+    Trading a 10% regression on 2^24 for a 20% gain on 2^28 is therefore not
+    worth it. Rebuilding the weights from the measured states would demote 2^24
+    to the least importance anchor and pick the regressing variant instead.
+    """
+    regressing = score_of({"24": 0.90, "28": 1.20})
+    uniform = score_of({"24": 1.05, "28": 1.08})
+
+    assert uniform > regressing


### PR DESCRIPTION
This is mostly done by `claude`, trying to migrate the internal `cub_tuning_evo` scripts. This PR adds a simplified version using a single worker, running benchmarks on a single GPU.

Running:
```
mkdir build_tune & cd build_tune
cmake .. --preset cub-tuning
CUDA_VISIBLE_DEVICES=0 ../benchmarks/scripts/search_iq.py -R 'cub.bench.transform.babelstream.*' -a 'T{ct}=F32'
 ctk:  13.3.33
cccl:  v3.5.0.dev-121-g575176ff50
🧬 Generation:  0/50|░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░| [elapsed: 00:00 · eta: ?] Evaluating variant {'alg': 3, 'bif': 4, 'pref': 2, 'tpb': 768, 'unrl': 1, 'vsp2': 6}: 0.7940340093966018
Evaluating variant {'alg': 2, 'bif': 0, 'pref': 3, 'tpb': 128, 'unrl': 2, 'vsp2': 1}: 0.7870774540476999
Evaluating variant {'alg': 0, 'bif': -8, 'pref': 1, 'tpb': 640, 'unrl': 3, 'vsp2': 5}: 0.7340502424429781
Evaluating variant {'alg': 1, 'bif': -16, 'pref': 1, 'tpb': 384, 'unrl': 4, 'vsp2': 3}: 0.6930208162203446
Evaluating variant {'alg': 4, 'bif': 12, 'pref': 3, 'tpb': 1024, 'unrl': 2, 'vsp2': 2}: Build failed
Evaluating variant {'alg': 1, 'bif': -12, 'pref': 2, 'tpb': 896, 'unrl': 4, 'vsp2': 5}: 0.19958390512595525
Evaluating variant {'alg': 3, 'bif': 0, 'pref': 2, 'tpb': 128, 'unrl': 1, 'vsp2': 4}: 0.7767127690888875
Evaluating variant {'alg': 2, 'bif': 8, 'pref': 3, 'tpb': 640, 'unrl': 3, 'vsp2': 6}: 0.7872272803730863
Evaluating variant {'alg': 4, 'bif': -4, 'pref': 1, 'tpb': 768, 'unrl': 3, 'vsp2': 2}: Build failed
Evaluating variant {'alg': 0, 'bif': 16, 'pref': 1, 'tpb': 384, 'unrl': 4, 'vsp2': 1}: 0.7388724658257656
...
```

It's still a bit confusing, because after running, the database shows different results, but it looks like the score reported by `analyze.py` is just computed differently than the score passed to compile-iq.
```
$ ../benchmarks/scripts/analyze.py --top=100 cccl_meta_bench.db
cub.bench.transform.babelstream[T{ct}=F32]:
                                          variant     score      mins     means      maxs
9    bif_16.alg_2.tpb_768.unrl_3.pref_1.vsp2_6 ()  1.026887  1.000000  1.025528  1.200000
11    bif_8.alg_2.tpb_640.unrl_3.pref_3.vsp2_6 ()  1.026887  1.000000  1.025528  1.200000
6     bif_0.alg_2.tpb_128.unrl_2.pref_3.vsp2_1 ()  1.026641  1.000000  1.025313  1.200000
10    bif_4.alg_3.tpb_768.unrl_1.pref_2.vsp2_6 ()  1.025089  1.000000  1.023932  1.200000
7     bif_0.alg_3.tpb_128.unrl_1.pref_2.vsp2_4 ()  1.013059  0.999988  1.012499  1.200000
5     bif_0.alg_1.tpb_640.unrl_2.pref_2.vsp2_1 ()  1.012436  1.000000  1.011788  1.166667
0                                         base ()  1.000000  1.000000  1.000000  1.000000
1   bif_-12.alg_0.tpb_384.unrl_1.pref_3.vsp2_2 ()  0.962345  0.600000  0.963987  1.012048
8    bif_16.alg_0.tpb_384.unrl_4.pref_1.vsp2_1 ()  0.962344  0.600000  0.963986  1.012048
4    bif_-8.alg_0.tpb_640.unrl_3.pref_1.vsp2_5 ()  0.953269  0.600000  0.955280  1.012048
3   bif_-16.alg_1.tpb_384.unrl_4.pref_1.vsp2_3 ()  0.885473  0.500000  0.859326  1.001472
2   bif_-12.alg_1.tpb_896.unrl_4.pref_2.vsp2_5 ()  0.256298  0.048387  0.249873  0.409063
```