### PR TITLE
Fix/Improve `warp_match_all`

### DIFF
--- a/docs/libcudacxx/extended_api/warp/warp_match_all.rst
+++ b/docs/libcudacxx/extended_api/warp/warp_match_all.rst
@@ -27,11 +27,15 @@ The function allows bitwise comparison of any data size, including raw arrays, p
 
 - ``true`` if all lanes in the ``lane_mask`` have the same value for ``data``. ``false`` otherwise.
 
+**Constraints**
+
+- ``T`` shall be trivially copyable, see :ref:`cuda::is_trivially_copyable <libcudacxx-extended-api-type_traits-is_trivially_copyable>`.
+- When ``__builtin_clear_padding`` is not supported, ``T`` shall have no padding bits, that is, ``T``'s value representation shall be identical to its object representation.
+
 **Preconditions**
 
 - The functionality is only supported on ``SM >= 70``.
 - ``lane_mask`` must be non-zero.
-- ``T`` shall have no padding bits, that is, ``T``'s value representation shall be identical to its object representation.
 
 **Undefined Behavior**
 

--- a/libcudacxx/include/cuda/__warp/warp_match_all.h
+++ b/libcudacxx/include/cuda/__warp/warp_match_all.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -24,10 +24,14 @@
 #if _CCCL_CUDA_COMPILATION()
 
 #  include <cuda/__cmath/ceil_div.h>
+#  include <cuda/__type_traits/is_trivially_copyable.h>
 #  include <cuda/__warp/lane_mask.h>
 #  include <cuda/std/__cstring/memcpy.h>
 #  include <cuda/std/__memory/addressof.h>
 #  include <cuda/std/cstdint>
+#  if !defined(_CCCL_BUILTIN_CLEAR_PADDING)
+#    include <cuda/__type_traits/is_bitwise_comparable.h>
+#  endif // _CCCL_BUILTIN_CLEAR_PADDING
 
 #  include <cuda/std/__cccl/prologue.h>
 
@@ -36,13 +40,24 @@ _CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
 extern "C" _CCCL_DEVICE void __cuda__match_all_sync_is_not_supported_before_SM_70__();
 
 template <class _Tp>
-[[nodiscard]] _CCCL_DEVICE_API bool warp_match_all(const _Tp& __data, lane_mask __lane_mask = lane_mask::all()) noexcept
+[[nodiscard]] _CCCL_DEVICE_API bool
+warp_match_all(const _Tp& __data, const lane_mask __lane_mask = lane_mask::all()) noexcept
 {
+  static_assert(is_trivially_copyable_v<_Tp>, "data must be trivially copyable");
   _CCCL_ASSERT(__lane_mask != lane_mask::none(), "lane_mask must be non-zero");
 
-  constexpr int __ratio = ::cuda::ceil_div(sizeof(_Tp), sizeof(uint32_t));
-  uint32_t __array[__ratio]{};
-  ::cuda::std::memcpy(__array, ::cuda::std::addressof(__data), sizeof(_Tp));
+  constexpr int __ratio = ::cuda::ceil_div(sizeof(_Tp), sizeof(::cuda::std::uint32_t));
+  ::cuda::std::uint32_t __array[__ratio]{};
+
+#  if defined(_CCCL_BUILTIN_CLEAR_PADDING)
+  auto __data_copy = __data;
+  _CCCL_BUILTIN_CLEAR_PADDING(&__data_copy);
+  const auto __data_ptr = ::cuda::std::addressof(__data_copy);
+#  else // ^^^ _CCCL_BUILTIN_CLEAR_PADDING ^^^ / vvv !_CCCL_BUILTIN_CLEAR_PADDING vvv
+  static_assert(is_bitwise_comparable_v<_Tp>, "data must be bitwise comparable");
+  const auto __data_ptr = ::cuda::std::addressof(__data);
+#  endif // _CCCL_BUILTIN_CLEAR_PADDING
+  ::cuda::std::memcpy(__array, __data_ptr, sizeof(_Tp));
 
   bool __ret = true;
   _CCCL_PRAGMA_UNROLL_FULL()

--- a/libcudacxx/include/cuda/__warp/warp_match_all.h
+++ b/libcudacxx/include/cuda/__warp/warp_match_all.h
@@ -24,14 +24,12 @@
 #if _CCCL_CUDA_COMPILATION()
 
 #  include <cuda/__cmath/ceil_div.h>
+#  include <cuda/__type_traits/is_bitwise_comparable.h>
 #  include <cuda/__type_traits/is_trivially_copyable.h>
 #  include <cuda/__warp/lane_mask.h>
 #  include <cuda/std/__cstring/memcpy.h>
 #  include <cuda/std/__memory/addressof.h>
 #  include <cuda/std/cstdint>
-#  if !defined(_CCCL_BUILTIN_CLEAR_PADDING)
-#    include <cuda/__type_traits/is_bitwise_comparable.h>
-#  endif // _CCCL_BUILTIN_CLEAR_PADDING
 
 #  include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -427,6 +427,10 @@
 #  define _CCCL_BUILTIN_IS_COMPLETE_TYPE(...) __is_complete_type(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__is_complete_type)
 
+#if _CCCL_HAS_BUILTIN(__builtin_clear_padding) && !_CCCL_DEVICE_COMPILATION()
+#  define _CCCL_BUILTIN_CLEAR_PADDING(...) __builtin_clear_padding(__VA_ARGS__)
+#endif // _CCCL_HAS_BUILTIN(__builtin_clear_padding) && !_CCCL_DEVICE_COMPILATION()
+
 // NVCC prior to 12.2 have trouble with pack expansion into __type_pack_element in an alias template
 #if _CCCL_CUDACC_BELOW(12, 2)
 #  undef _CCCL_BUILTIN_TYPE_PACK_ELEMENT

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -427,9 +427,11 @@
 #  define _CCCL_BUILTIN_IS_COMPLETE_TYPE(...) __is_complete_type(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__is_complete_type)
 
-#if _CCCL_HAS_BUILTIN(__builtin_clear_padding) && !_CCCL_DEVICE_COMPILATION()
+#if _CCCL_HAS_BUILTIN(__builtin_clear_padding) \
+  && (_CCCL_HOST_COMPILATION() || !(_CCCL_COMPILER(GCC) || _CCCL_COMPILER(NVHPC)))
 #  define _CCCL_BUILTIN_CLEAR_PADDING(...) __builtin_clear_padding(__VA_ARGS__)
-#endif // _CCCL_HAS_BUILTIN(__builtin_clear_padding) && !_CCCL_DEVICE_COMPILATION()
+#endif // _CCCL_HAS_BUILTIN(__builtin_clear_padding) && (_CCCL_HOST_COMPILATION() || !(_CCCL_COMPILER(GCC) ||
+       // _CCCL_COMPILER(NVHPC)))
 
 // NVCC prior to 12.2 have trouble with pack expansion into __type_pack_element in an alias template
 #if _CCCL_CUDACC_BELOW(12, 2)

--- a/libcudacxx/test/libcudacxx/cuda/warp/warp_match.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/warp/warp_match.pass.cpp
@@ -34,6 +34,12 @@ TEST_DEVICE_FUNC void test_types(T valueA = T{}, T valueB = T{1})
   }
 }
 
+struct WithPadding
+{
+  int a;
+  char b;
+};
+
 __global__ void test_kernel()
 {
   test_types<uint8_t>();
@@ -46,6 +52,9 @@ __global__ void test_kernel()
   test_types(char3{0, 0, 0}, char3{1, 1, 1});
   using array_t = cuda::std::array<char, 6>;
   test_types(array_t{0, 0, 0, 0, 0, 0}, array_t{1, 1, 1, 1, 1, 1});
+#if defined(_CCCL_BUILTIN_BUILTIN_CLEAR_PADDING)
+  test_types<WithPadding>();
+#endif
 }
 
 int main(int, char**)


### PR DESCRIPTION
closes https://github.com/NVIDIA/cccl/issues/6085 

## Description

`cuda::device::warp_match_all` requires types that bitwise copyable, UB otherwise.
The PR adds a compile-time check with the recently introduced trait and uses `__builtin_clear_padding` (clang-cuda 23) to support more types.
