### PR TITLE
`cudax::fill_bytes(mdspan)`

### DIFF
--- a/cudax/include/cuda/experimental/__fill_bytes/fill_bytes_mdspan.cuh
+++ b/cudax/include/cuda/experimental/__fill_bytes/fill_bytes_mdspan.cuh
@@ -87,7 +87,7 @@ _CCCL_HOST_API void __fill_bytes_tile(
 //! -----------------------------
 //!
 //! ``fill_bytes`` asynchronously fills the mapped elements of a device ``mdspan`` with a repeated byte pattern on the
-//! given CUDA stream. The pattern is the object representation of a 1-, 2-, or 4-byte fill value. This is a byte
+//! given CUDA stream. The pattern is the object representation of a 1-, 2-, or 4-byte value. This is a byte
 //! operation: it does not assign ``__byte_value`` as an object of the destination element type. For strided layouts,
 //! only bytes belonging to mapped destination elements are filled; padding bytes outside the mapping are left
 //! unchanged.
@@ -110,13 +110,11 @@ _CCCL_HOST_API void __fill_bytes_tile(
 //! ``cuda::std::uint8_t{0}`` or ``cuda::std::byte{0}`` for a byte pattern fill. The implementation is optimized to
 //! maximize the contiguous memory regions to fill.
 //!
-//! .. code-block:: c++
-//!
-//!    #include <cuda/experimental/fill_bytes.cuh>
-//!
-//!    using extents_t = cuda::std::dims<2>;
-//!    cuda::device_mdspan<int, extents_t> dst(dst_ptr, extents);
-//!    cuda::experimental::fill_bytes(dst, cuda::std::uint32_t{0xFF00FF00}, stream);
+//! .. literalinclude:: ../../../../test/fill_bytes/fill_bytes_mdspan_example.cu
+//!     :language: c++
+//!     :dedent:
+//!     :start-after: example-begin fill-bytes-mdspan
+//!     :end-before: example-end fill-bytes-mdspan
 //!
 //! @endrst
 //! @brief Asynchronously fills a device mdspan with a 1-, 2-, or 4-byte pattern.

--- a/cudax/include/cuda/experimental/__fill_bytes/fill_bytes_mdspan.cuh
+++ b/cudax/include/cuda/experimental/__fill_bytes/fill_bytes_mdspan.cuh
@@ -86,16 +86,25 @@ _CCCL_HOST_API void __fill_bytes_tile(
 //! Asynchronous mdspan byte fill
 //! -----------------------------
 //!
-//! ``fill_bytes`` asynchronously fills the elements of a device ``mdspan`` with the object representation of
-//! a 1-, 2-, or 4-byte fill value on the given CUDA stream.
+//! ``fill_bytes`` asynchronously fills the mapped elements of a device ``mdspan`` with a repeated byte pattern on the
+//! given CUDA stream. The pattern is the object representation of a 1-, 2-, or 4-byte fill value. This is a byte
+//! operation: it does not assign ``__byte_value`` as an object of the destination element type. For strided layouts,
+//! only bytes belonging to mapped destination elements are filled; padding bytes outside the mapping are left
+//! unchanged.
+//!
+//! The operation is enqueued on ``__stream`` and may complete after ``fill_bytes`` returns. Synchronize the stream, or
+//! otherwise order dependent work on the same stream, before observing the filled data.
 //!
 //! - Destination element and fill value types must be trivially copyable.
 //! - The fill value type must have unique object representations and size 1, 2, or 4.
-//! - The destination element size and alignment must support the fill value size.
+//! - The destination element type must not be ``const``.
+//! - The destination element size must be a multiple of the fill value size.
+//! - The destination element alignment must be at least the fill value size.
 //! - Layout policies must be one of the predefined ``cuda::std`` layout policies
 //!   (``layout_right``, ``layout_left``, ``layout_stride``) or ``cuda::layout_stride_relaxed``.
 //! - Accessor policies must be convertible to ``cuda::std::default_accessor``.
 //! - The destination must not have an interleaved stride order.
+//! - Zero-size mdspans are no-ops and do not require a non-null data handle.
 //!
 //! Integer literals use their usual type. For example, ``0`` is an ``int`` and requests a 4-byte pattern fill; use
 //! ``cuda::std::uint8_t{0}`` or ``cuda::std::byte{0}`` for a byte pattern fill. The implementation is optimized to
@@ -105,19 +114,21 @@ _CCCL_HOST_API void __fill_bytes_tile(
 //!
 //!    #include <cuda/experimental/fill_bytes.cuh>
 //!
-//!      using extents_t = cuda::std::dims<2>;
-//!      cuda::device_mdspan<int, extents_t> dst(dst_ptr, extents);
-//!      cuda::experimental::fill_bytes(dst, cuda::std::uint32_t{0xFF00FF00}, stream);
+//!    using extents_t = cuda::std::dims<2>;
+//!    cuda::device_mdspan<int, extents_t> dst(dst_ptr, extents);
+//!    cuda::experimental::fill_bytes(dst, cuda::std::uint32_t{0xFF00FF00}, stream);
 //!
 //! @endrst
 //! @brief Asynchronously fills a device mdspan with a 1-, 2-, or 4-byte pattern.
 //!
-//! Validates preconditions, converts the mdspan to a raw tensor descriptor, simplifies the layout
-//! (sort, flip negative strides, coalesce), then dispatches asynchronous memset operations.
+//! Validates the public preconditions, then dispatches asynchronous memset operations over the mapped destination
+//! elements.
 //!
 //! @param[out] __mdspan Destination device mdspan
 //! @param[in] __byte_value Value pattern to fill into the destination
 //! @param[in] __stream CUDA stream for the asynchronous fill
+//! @throws std::invalid_argument if ``__stream`` is the null stream, or if a non-empty destination has a null data
+//! handle, is insufficiently aligned, or has interleaved stride order.
 template <typename _Tp, typename _Extents, typename _Layout, typename _Accessor, typename _ByteT>
 _CCCL_HOST_API void fill_bytes(::cuda::device_mdspan<_Tp, _Extents, _Layout, _Accessor> __mdspan,
                                const _ByteT __byte_value,

--- a/cudax/include/cuda/experimental/__fill_bytes/fill_bytes_mdspan.cuh
+++ b/cudax/include/cuda/experimental/__fill_bytes/fill_bytes_mdspan.cuh
@@ -1,0 +1,207 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX___FILL_BYTES_FILL_BYTES_MDSPAN_H
+#define __CUDAX___FILL_BYTES_FILL_BYTES_MDSPAN_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/__driver/driver_api.h>
+#  include <cuda/__mdspan/host_device_mdspan.h>
+#  include <cuda/__mdspan/traits.h>
+#  include <cuda/__stream/stream_ref.h>
+#  include <cuda/__type_traits/is_trivially_copyable.h>
+#  include <cuda/std/__cstddef/types.h>
+#  include <cuda/std/__exception/exception_macros.h>
+#  include <cuda/std/__host_stdlib/stdexcept>
+#  include <cuda/std/__mdspan/default_accessor.h>
+#  include <cuda/std/__mdspan/mdspan.h>
+#  include <cuda/std/__memory/is_sufficiently_aligned.h>
+#  include <cuda/std/__type_traits/has_unique_object_representation.h>
+#  include <cuda/std/__type_traits/is_const.h>
+#  include <cuda/std/__type_traits/is_convertible.h>
+#  include <cuda/std/__type_traits/remove_cvref.h>
+
+#  include <cuda/experimental/__copy_bytes/mdspan_to_raw_tensor.cuh>
+#  include <cuda/experimental/__copy_bytes/memcpy_batch_tiles.cuh>
+#  include <cuda/experimental/__copy_bytes/simplify_paired.cuh>
+#  include <cuda/experimental/__copy_bytes/tensor_query.cuh>
+#  include <cuda/experimental/__fill_bytes/fill_bytes_mdspan_utils.cuh>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+namespace cuda::experimental
+{
+template <typename _ByteT>
+inline constexpr bool __is_fill_bytes_value_v =
+  ::cuda::std::is_trivially_copyable_v<_ByteT> && ::cuda::std::has_unique_object_representations_v<_ByteT>
+  && (sizeof(_ByteT) == 1 || sizeof(_ByteT) == 2 || sizeof(_ByteT) == 4);
+
+// __half, __nv_bfloat16 don't have a unique object representation
+#  if _CCCL_HAS_NVFP16()
+template <>
+inline constexpr bool __is_fill_bytes_value_v<::__half> = true;
+#  endif // _CCCL_HAS_NVFP16()
+
+#  if _CCCL_HAS_NVBF16()
+template <>
+inline constexpr bool __is_fill_bytes_value_v<::__nv_bfloat16> = true;
+#  endif // _CCCL_HAS_NVBF16()
+
+template <typename _Tp, typename _ByteT>
+_CCCL_HOST_API void __fill_bytes_tile(
+  _Tp* __ptr, const ::cuda::std::size_t __tile_bytes, const _ByteT __byte_value, const ::cuda::stream_ref __stream)
+{
+  _CCCL_ASSERT(__tile_bytes % sizeof(_ByteT) == 0,
+               "cudax::fill_bytes: destination byte size must be a multiple of the fill value size");
+  _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<sizeof(_ByteT)>(static_cast<void*>(__ptr)),
+               "cudax::fill_bytes: destination tile must be sufficiently aligned");
+  ::cuda::__driver::__memsetAsync(__ptr, __byte_value, __tile_bytes / sizeof(_ByteT), __stream.get());
+}
+
+/***********************************************************************************************************************
+ * Public API
+ **********************************************************************************************************************/
+
+//! @rst
+//! .. _cudax-fill-bytes:
+//!
+//! Asynchronous mdspan byte fill
+//! -----------------------------
+//!
+//! ``fill_bytes`` asynchronously fills the elements of a device ``mdspan`` with the object representation of
+//! a 1-, 2-, or 4-byte fill value on the given CUDA stream.
+//!
+//! - Destination element and fill value types must be trivially copyable.
+//! - The fill value type must have unique object representations and size 1, 2, or 4.
+//! - The destination element size and alignment must support the fill value size.
+//! - Layout policies must be one of the predefined ``cuda::std`` layout policies
+//!   (``layout_right``, ``layout_left``, ``layout_stride``) or ``cuda::layout_stride_relaxed``.
+//! - Accessor policies must be convertible to ``cuda::std::default_accessor``.
+//! - The destination must not have an interleaved stride order.
+//!
+//! Integer literals use their usual type. For example, ``0`` is an ``int`` and requests a 4-byte pattern fill; use
+//! ``cuda::std::uint8_t{0}`` or ``cuda::std::byte{0}`` for a byte pattern fill.
+//!
+//! .. code-block:: c++
+//!
+//!    #include <cuda/experimental/fill_bytes.cuh>
+//!
+//!      using extents_t = cuda::std::dims<2>;
+//!      cuda::device_mdspan<int, extents_t> dst(dst_ptr, extents);
+//!      cuda::experimental::fill_bytes(dst, cuda::std::uint32_t{0xff00ff00}, stream);
+//!
+//! @endrst
+//! @brief Asynchronously fills a device mdspan with a 1-, 2-, or 4-byte pattern.
+//!
+//! Validates preconditions, converts the mdspan to a raw tensor descriptor, simplifies the layout
+//! (sort, flip negative strides, coalesce), then dispatches asynchronous memset operations.
+//!
+//! @param[out] __mdspan Destination device mdspan
+//! @param[in] __byte_value Value pattern to fill into the destination
+//! @param[in] __stream CUDA stream for the asynchronous fill
+template <typename _Tp, typename _Extents, typename _Layout, typename _Accessor, typename _ByteT>
+_CCCL_HOST_API void fill_bytes(::cuda::device_mdspan<_Tp, _Extents, _Layout, _Accessor> __mdspan,
+                               const _ByteT __byte_value,
+                               const ::cuda::stream_ref __stream)
+{
+  using __mdspan_t   = ::cuda::std::mdspan<_Tp, _Extents, _Layout, _Accessor>;
+  using __value_t    = ::cuda::std::remove_cvref_t<_ByteT>;
+  using __accessor_t = ::cuda::std::default_accessor<_Tp>;
+  using __extent_t   = typename _Extents::index_type;
+  using __stride_t   = __mdspan_stride_t<_Layout, typename __mdspan_t::mapping_type>;
+
+  static_assert(!::cuda::std::is_const_v<_Tp>, "cudax::fill_bytes: element type must not be const");
+  static_assert(::cuda::is_trivially_copyable_v<_Tp>, "cudax::fill_bytes: element type must be trivially copyable");
+  static_assert(__is_fill_bytes_value_v<__value_t>,
+                "cudax::fill_bytes: fill value type must be trivially copyable with unique object representations and "
+                "have size 1, 2, or 4");
+  static_assert(sizeof(_Tp) % sizeof(__value_t) == 0,
+                "cudax::fill_bytes: element size must be a multiple of the fill value size");
+  static_assert(alignof(_Tp) >= sizeof(__value_t),
+                "cudax::fill_bytes: element alignment must be at least the fill value size");
+  static_assert(::cuda::__is_cuda_mdspan_layout_v<_Layout>,
+                "cudax::fill_bytes: LayoutPolicy must be a predefined layout policy");
+  static_assert(::cuda::std::is_convertible_v<_Accessor, __accessor_t>,
+                "cudax::fill_bytes: AccessorPolicy must be convertible to cuda::std::default_accessor");
+
+  if (__stream.get() == nullptr)
+  {
+    _CCCL_THROW(::std::invalid_argument, "cudax::fill_bytes: stream must not be nullptr");
+  }
+
+  const auto __tensor_size = __mdspan.size();
+  if (__tensor_size == 0)
+  {
+    return;
+  }
+  if (__mdspan.data_handle() == nullptr)
+  {
+    _CCCL_THROW(::std::invalid_argument, "cudax::fill_bytes: mdspan data handle must not be nullptr");
+  }
+  if (!::cuda::std::is_sufficiently_aligned<alignof(_Tp)>(__mdspan.data_handle()))
+  {
+    _CCCL_THROW(::std::invalid_argument, "cudax::fill_bytes: destination mdspan must be sufficiently aligned");
+  }
+  if (::cuda::experimental::__has_interleaved_stride_order(__mdspan))
+  {
+    _CCCL_THROW(::std::invalid_argument,
+                "cudax::fill_bytes: destination mdspan must not have interleaved stride order");
+  }
+  if (__tensor_size == 1) // rank == 0 also falls into this case
+  {
+    auto* __data_ptr = __mdspan.data_handle();
+    if constexpr (::cuda::__is_layout_stride_relaxed_v<_Layout>)
+    {
+      __data_ptr += __mdspan.mapping().offset();
+    }
+    ::cuda::experimental::__fill_bytes_tile(__data_ptr, sizeof(_Tp), __byte_value, __stream);
+    return;
+  }
+
+  constexpr auto __rank = _Extents::rank();
+  if constexpr (__rank > 0)
+  {
+    const auto __raw_tensor = ::cuda::experimental::__to_raw_tensor<__extent_t, __stride_t, __rank>(__mdspan);
+    auto __simplified       = ::cuda::experimental::__sort_by_stride(__raw_tensor);
+    ::cuda::experimental::__flip_negative_strides_single(__simplified);
+    ::cuda::experimental::__coalesce_single(__simplified);
+
+    const bool __stride1      = (__simplified.__strides[0] == 1);
+    const auto __tile_size    = __stride1 ? __simplified.__extents[0] : __extent_t{1};
+    const auto __final_tensor = (__tile_size > 1) ? __simplified : ::cuda::experimental::__reverse_modes(__simplified);
+    const auto __num_tiles    = static_cast<::cuda::std::size_t>(__tensor_size / __tile_size);
+    const auto __tile_bytes   = static_cast<::cuda::std::size_t>(__tile_size) * sizeof(_Tp);
+    _CCCL_ASSERT(__tensor_size % __tile_size == 0, "cudax::fill_bytes: tensor size must be divisible by tile size");
+
+    __tile_iterator_linearized<__extent_t, __stride_t, _Tp, __rank> __tiles_iterator(__final_tensor, __tile_size);
+    for (::cuda::std::size_t __tile_idx = 0; __tile_idx < __num_tiles; ++__tile_idx)
+    {
+      auto* const __tile_ptr = __tiles_iterator(static_cast<__extent_t>(__tile_idx));
+      ::cuda::experimental::__fill_bytes_tile(__tile_ptr, __tile_bytes, __byte_value, __stream);
+    }
+  }
+}
+} // namespace cuda::experimental
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+#endif // __CUDAX___FILL_BYTES_FILL_BYTES_MDSPAN_H

--- a/cudax/include/cuda/experimental/__fill_bytes/fill_bytes_mdspan.cuh
+++ b/cudax/include/cuda/experimental/__fill_bytes/fill_bytes_mdspan.cuh
@@ -27,7 +27,6 @@
 #  include <cuda/__mdspan/host_device_mdspan.h>
 #  include <cuda/__mdspan/traits.h>
 #  include <cuda/__stream/stream_ref.h>
-#  include <cuda/__type_traits/is_trivially_copyable.h>
 #  include <cuda/std/__cstddef/types.h>
 #  include <cuda/std/__exception/exception_macros.h>
 #  include <cuda/std/__host_stdlib/stdexcept>
@@ -37,6 +36,7 @@
 #  include <cuda/std/__type_traits/has_unique_object_representation.h>
 #  include <cuda/std/__type_traits/is_const.h>
 #  include <cuda/std/__type_traits/is_convertible.h>
+#  include <cuda/std/__type_traits/is_trivially_copyable.h>
 #  include <cuda/std/__type_traits/remove_cvref.h>
 
 #  include <cuda/experimental/__copy_bytes/mdspan_to_raw_tensor.cuh>
@@ -50,19 +50,19 @@
 namespace cuda::experimental
 {
 template <typename _ByteT>
-inline constexpr bool __is_fill_bytes_value_v =
+inline constexpr bool __can_fill_bytes_value_v =
   ::cuda::std::is_trivially_copyable_v<_ByteT> && ::cuda::std::has_unique_object_representations_v<_ByteT>
   && (sizeof(_ByteT) == 1 || sizeof(_ByteT) == 2 || sizeof(_ByteT) == 4);
 
 // __half, __nv_bfloat16 don't have a unique object representation
 #  if _CCCL_HAS_NVFP16()
 template <>
-inline constexpr bool __is_fill_bytes_value_v<::__half> = true;
+inline constexpr bool __can_fill_bytes_value_v<::__half> = false;
 #  endif // _CCCL_HAS_NVFP16()
 
 #  if _CCCL_HAS_NVBF16()
 template <>
-inline constexpr bool __is_fill_bytes_value_v<::__nv_bfloat16> = true;
+inline constexpr bool __can_fill_bytes_value_v<::__nv_bfloat16> = false;
 #  endif // _CCCL_HAS_NVBF16()
 
 template <typename _Tp, typename _ByteT>
@@ -98,7 +98,8 @@ _CCCL_HOST_API void __fill_bytes_tile(
 //! - The destination must not have an interleaved stride order.
 //!
 //! Integer literals use their usual type. For example, ``0`` is an ``int`` and requests a 4-byte pattern fill; use
-//! ``cuda::std::uint8_t{0}`` or ``cuda::std::byte{0}`` for a byte pattern fill.
+//! ``cuda::std::uint8_t{0}`` or ``cuda::std::byte{0}`` for a byte pattern fill. The implementation is optimized to
+//! maximize the contiguous memory regions to fill.
 //!
 //! .. code-block:: c++
 //!
@@ -106,7 +107,7 @@ _CCCL_HOST_API void __fill_bytes_tile(
 //!
 //!      using extents_t = cuda::std::dims<2>;
 //!      cuda::device_mdspan<int, extents_t> dst(dst_ptr, extents);
-//!      cuda::experimental::fill_bytes(dst, cuda::std::uint32_t{0xff00ff00}, stream);
+//!      cuda::experimental::fill_bytes(dst, cuda::std::uint32_t{0xFF00FF00}, stream);
 //!
 //! @endrst
 //! @brief Asynchronously fills a device mdspan with a 1-, 2-, or 4-byte pattern.
@@ -129,8 +130,9 @@ _CCCL_HOST_API void fill_bytes(::cuda::device_mdspan<_Tp, _Extents, _Layout, _Ac
   using __stride_t   = __mdspan_stride_t<_Layout, typename __mdspan_t::mapping_type>;
 
   static_assert(!::cuda::std::is_const_v<_Tp>, "cudax::fill_bytes: element type must not be const");
-  static_assert(::cuda::is_trivially_copyable_v<_Tp>, "cudax::fill_bytes: element type must be trivially copyable");
-  static_assert(__is_fill_bytes_value_v<__value_t>,
+  static_assert(::cuda::std::is_trivially_copyable_v<_Tp>,
+                "cudax::fill_bytes: element type must be trivially copyable");
+  static_assert(__can_fill_bytes_value_v<__value_t>,
                 "cudax::fill_bytes: fill value type must be trivially copyable with unique object representations and "
                 "have size 1, 2, or 4");
   static_assert(sizeof(_Tp) % sizeof(__value_t) == 0,

--- a/cudax/include/cuda/experimental/__fill_bytes/fill_bytes_mdspan_utils.cuh
+++ b/cudax/include/cuda/experimental/__fill_bytes/fill_bytes_mdspan_utils.cuh
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX___FILL_BYTES_FILL_BYTES_MDSPAN_UTILS_H
+#define __CUDAX___FILL_BYTES_FILL_BYTES_MDSPAN_UTILS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/std/__cstddef/types.h>
+#  include <cuda/std/__type_traits/is_signed.h>
+
+#  include <cuda/experimental/__copy_bytes/types.cuh>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+namespace cuda::experimental
+{
+//! @brief Flips negative-stride modes to equivalent positive-stride modes.
+//!
+//! @param[in,out] __tensor Raw tensor to flip negative strides for
+template <typename _ExtentT, typename _StrideT, typename _Tp, ::cuda::std::size_t _MaxRank>
+_CCCL_HOST_API void
+__flip_negative_strides_single([[maybe_unused]] __raw_tensor<_ExtentT, _StrideT, _Tp, _MaxRank>& __tensor) noexcept
+{
+  if constexpr (::cuda::std::is_signed_v<_StrideT>)
+  {
+    using __raw_tensor_t = __raw_tensor<_ExtentT, _StrideT, _Tp, _MaxRank>;
+    using __rank_t       = typename __raw_tensor_t::__rank_t;
+    for (__rank_t __i = 0; __i < __tensor.__rank; ++__i)
+    {
+      if (__tensor.__strides[__i] < 0)
+      {
+        const auto __extent = static_cast<_StrideT>(__tensor.__extents[__i] - 1);
+        __tensor.__data += __extent * __tensor.__strides[__i];
+        _CCCL_ASSERT(__tensor.__strides[__i] != ::cuda::std::numeric_limits<_StrideT>::min(),
+                     "cudax::flip_negative_strides_single: stride is at min value");
+        __tensor.__strides[__i] = -__tensor.__strides[__i];
+      }
+    }
+  }
+}
+
+//! @brief Merges adjacent modes that are contiguous in the destination tensor.
+//!
+//! @param[in,out] __tensor Raw tensor to coalesce modes for
+template <typename _ExtentT, typename _StrideT, typename _Tp, ::cuda::std::size_t _MaxRank>
+_CCCL_HOST_API void __coalesce_single(__raw_tensor<_ExtentT, _StrideT, _Tp, _MaxRank>& __tensor) noexcept
+{
+  if (__tensor.__rank <= 1)
+  {
+    return;
+  }
+  using __raw_tensor_t = __raw_tensor<_ExtentT, _StrideT, _Tp, _MaxRank>;
+  using __rank_t       = typename __raw_tensor_t::__rank_t;
+  __rank_t __out_rank  = 1;
+  for (__rank_t __i = 1; __i < __tensor.__rank; ++__i)
+  {
+    const auto __prev_extent = static_cast<_StrideT>(__tensor.__extents[__out_rank - 1]);
+    if (__prev_extent * __tensor.__strides[__out_rank - 1] == __tensor.__strides[__i])
+    {
+      __tensor.__extents[__out_rank - 1] *= __tensor.__extents[__i];
+      continue;
+    }
+    __tensor.__extents[__out_rank] = __tensor.__extents[__i];
+    __tensor.__strides[__out_rank] = __tensor.__strides[__i];
+    ++__out_rank;
+  }
+  for (__rank_t __i = __out_rank; __i < _MaxRank; ++__i)
+  {
+    __tensor.__extents[__i] = _ExtentT{1};
+  }
+  __tensor.__rank = __out_rank;
+}
+} // namespace cuda::experimental
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+#endif // __CUDAX___FILL_BYTES_FILL_BYTES_MDSPAN_UTILS_H

--- a/cudax/include/cuda/experimental/fill_bytes.cuh
+++ b/cudax/include/cuda/experimental/fill_bytes.cuh
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_FILL_BYTES_CUH
+#define __CUDAX_FILL_BYTES_CUH
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/experimental/__fill_bytes/fill_bytes_mdspan.cuh>
+
+#endif // __CUDAX_FILL_BYTES_CUH

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -92,6 +92,7 @@ cudax_add_catch2_test(test_target copy_bytes
 
 cudax_add_catch2_test(test_target fill_bytes
     fill_bytes/fill_bytes_mdspan.cu
+    fill_bytes/fill_bytes_mdspan_example.cu
 )
 
 cudax_add_catch2_test(test_target copy

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -90,6 +90,10 @@ cudax_add_catch2_test(test_target copy_bytes
     copy_bytes/mdspan_d2h_h2d_relaxed.cu
 )
 
+cudax_add_catch2_test(test_target fill_bytes
+    fill_bytes/fill_bytes_mdspan.cu
+)
+
 cudax_add_catch2_test(test_target copy
     copy/copy.cu
     copy/copy_edge_cases.cu

--- a/cudax/test/fill_bytes/fill_bytes_mdspan.cu
+++ b/cudax/test/fill_bytes/fill_bytes_mdspan.cu
@@ -1,0 +1,280 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+#include <cuda/mdspan>
+#include <cuda/std/array>
+#include <cuda/std/cstddef>
+#include <cuda/std/cstdint>
+#include <cuda/std/span>
+#include <cuda/stream>
+
+#include <cuda/experimental/fill_bytes.cuh>
+
+#include <cstring>
+
+#include "testing.cuh"
+
+static const cuda::stream stream{cuda::device_ref{0}};
+
+using host_vector_bytes_t = thrust::host_vector<cuda::std::byte>;
+using span_bytes_t        = cuda::std::span<const cuda::std::byte>;
+
+// create a host vector of bytes with a repeated pattern
+template <typename Value>
+host_vector_bytes_t repeated_bytes_vector(size_t num_bytes, const Value& value)
+{
+  cuda::std::byte pattern[sizeof(Value)];
+  std::memcpy(pattern, &value, sizeof(Value));
+
+  host_vector_bytes_t expected(num_bytes);
+  for (size_t i = 0; i < num_bytes; ++i)
+  {
+    expected[i] = pattern[i % sizeof(Value)];
+  }
+  return expected;
+}
+
+template <typename Tp>
+span_bytes_t to_byte_span(const thrust::host_vector<Tp>& data)
+{
+  return cuda::std::as_bytes(cuda::std::span<const Tp>{data.data(), data.size()});
+}
+
+// create a copy of the input as a host vector of bytes
+template <typename Tp>
+host_vector_bytes_t to_byte_vector(const thrust::host_vector<Tp>& data)
+{
+  auto data_bytes = to_byte_span(data);
+  host_vector_bytes_t bytes(data_bytes.size());
+  for (size_t i = 0; i < data_bytes.size(); ++i)
+  {
+    bytes[i] = data_bytes[i];
+  }
+  return bytes;
+}
+
+bool equal_bytes(span_bytes_t lhs, span_bytes_t rhs)
+{
+  if (lhs.size() != rhs.size())
+  {
+    return false;
+  }
+  for (size_t i = 0; i < lhs.size(); ++i)
+  {
+    if (lhs[i] != rhs[i])
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename Tp>
+thrust::host_vector<Tp> make_host_data(size_t size, uint8_t byte)
+{
+  thrust::host_vector<Tp> data(size);
+  ::std::memset(data.data(), byte, data.size() * sizeof(Tp));
+  return data;
+}
+
+template <typename Tp, typename Value>
+host_vector_bytes_t contiguous_fill_bytes(size_t num_elements, Value value)
+{
+  return repeated_bytes_vector(num_elements * sizeof(Tp), value);
+}
+
+template <typename _Layout = cuda::std::layout_right, typename Tp, typename Value, typename Index, size_t... Extents>
+void test_impl(const thrust::host_vector<Tp>& input,
+               const host_vector_bytes_t& expected,
+               cuda::std::extents<Index, Extents...> extents,
+               Value value)
+{
+  using extents_t = cuda::std::extents<Index, Extents...>;
+  using mapping_t = typename _Layout::template mapping<extents_t>;
+  thrust::device_vector<Tp> device_data(input.begin(), input.end());
+  cuda::device_mdspan<Tp, extents_t, _Layout> dst(thrust::raw_pointer_cast(device_data.data()), mapping_t(extents));
+
+  cuda::experimental::fill_bytes(dst, value, stream);
+  stream.sync();
+
+  const thrust::host_vector<Tp> actual(device_data);
+  REQUIRE(equal_bytes(to_byte_span(actual), to_byte_span(expected)));
+}
+
+template <typename Tp, typename Value, typename Index, size_t... Extents>
+void test_impl_stride(
+  const thrust::host_vector<Tp>& input,
+  const host_vector_bytes_t& expected,
+  cuda::std::extents<Index, Extents...> extents,
+  const cuda::std::array<Index, sizeof...(Extents)>& strides,
+  Value value)
+{
+  using extents_t = cuda::std::extents<Index, Extents...>;
+  using mapping_t = cuda::std::layout_stride::mapping<extents_t>;
+  thrust::device_vector<Tp> device_data(input.begin(), input.end());
+  cuda::device_mdspan<Tp, extents_t, cuda::std::layout_stride> dst(
+    thrust::raw_pointer_cast(device_data.data()), mapping_t(extents, strides));
+
+  cuda::experimental::fill_bytes(dst, value, stream);
+  stream.sync();
+
+  const thrust::host_vector<Tp> actual(device_data);
+  REQUIRE(equal_bytes(to_byte_span(actual), to_byte_span(expected)));
+}
+
+template <typename Tp, typename Value, typename Index, size_t... Extents>
+void test_impl_relaxed(
+  const thrust::host_vector<Tp>& input,
+  const host_vector_bytes_t& expected,
+  cuda::std::extents<Index, Extents...> extents,
+  const cuda::dstrides<Index, sizeof...(Extents)>& strides,
+  Index offset,
+  Value value)
+{
+  using extents_t = cuda::std::extents<Index, Extents...>;
+  using mapping_t = cuda::layout_stride_relaxed::mapping<extents_t>;
+  thrust::device_vector<Tp> device_data(input.begin(), input.end());
+  cuda::device_mdspan<Tp, extents_t, cuda::layout_stride_relaxed> dst(
+    thrust::raw_pointer_cast(device_data.data()), mapping_t(extents, strides, offset));
+
+  cuda::experimental::fill_bytes(dst, value, stream);
+  stream.sync();
+
+  const thrust::host_vector<Tp> actual(device_data);
+  REQUIRE(equal_bytes(to_byte_span(actual), to_byte_span(expected)));
+}
+
+/***********************************************************************************************************************
+ * 1D Tests
+ **********************************************************************************************************************/
+
+enum class pattern32 : uint32_t
+{
+  value = 0xff00ff00u,
+};
+
+TEST_CASE("fill_bytes device mdspan accepts generic fill values", "[fill_bytes][device]")
+{
+  constexpr int n = 16427;
+  using extents_t = cuda::std::extents<int, n>;
+  // int16_t
+  {
+    auto input              = make_host_data<int16_t>(n, 0xCD);
+    constexpr int16_t value = -0x1234;
+    test_impl(input, contiguous_fill_bytes<int16_t>(n, value), extents_t{}, value);
+  }
+  // std::byte
+  {
+    auto input           = make_host_data<uint8_t>(n, 0xCD);
+    constexpr auto value = cuda::std::byte{0xAB};
+    test_impl(input, contiguous_fill_bytes<uint8_t>(n, value), extents_t{}, value);
+  }
+  // int
+  {
+    auto input           = make_host_data<int>(n, 0xCD);
+    constexpr auto value = pattern32::value;
+    test_impl(input, contiguous_fill_bytes<int>(n, value), extents_t{}, value);
+  }
+  // float
+  {
+    auto input          = make_host_data<float>(n, 0xCD);
+    constexpr int value = 0xAB;
+    test_impl(input, contiguous_fill_bytes<float>(n, value), extents_t{}, value);
+  }
+}
+
+TEST_CASE("fill_bytes handles layout_stride_relaxed negative strides and offsets", "[fill_bytes][relaxed]")
+{
+  constexpr int n = 8455;
+  using extents_t = cuda::std::extents<int, n>;
+  using mapping_t = cuda::layout_stride_relaxed::mapping<extents_t>;
+
+  // int8_t
+  {
+    auto input = make_host_data<uint8_t>(n, 0xCD);
+    const mapping_t mapping(extents_t{}, cuda::dstrides<int, 1>(-1), n - 1);
+    const uint8_t value = 0x5A;
+    test_impl_relaxed(input, contiguous_fill_bytes<uint8_t>(n, value), extents_t{}, mapping.strides(), n - 1, value);
+  }
+  // uint32_t pattern into int64_t elements
+  {
+    auto input = make_host_data<int64_t>(n, 0xCD);
+    const mapping_t mapping(extents_t{}, cuda::dstrides<int, 1>(-1), n - 1);
+    const uint32_t value = 0x12345678;
+    test_impl_relaxed(input, contiguous_fill_bytes<int64_t>(n, value), extents_t{}, mapping.strides(), n - 1, value);
+  }
+}
+
+/***********************************************************************************************************************
+ * 2D Tests
+ **********************************************************************************************************************/
+
+TEST_CASE("fill_bytes handles layout_left device mdspan", "[fill_bytes][layout_left]")
+{
+  constexpr int rows = 265;
+  constexpr int cols = 456;
+  using extents_t    = cuda::std::extents<int, rows, cols>;
+
+  auto input           = make_host_data<uint16_t>(rows * cols, 0xCD);
+  const uint16_t value = 0x1234;
+  test_impl<cuda::std::layout_left>(input, contiguous_fill_bytes<uint16_t>(rows * cols, value), extents_t{}, value);
+}
+
+TEST_CASE("fill_bytes preserves padding bytes in strided destination layouts", "[fill_bytes][stride]")
+{
+  constexpr int rows = 367;
+  constexpr int cols = 456;
+  constexpr int ld   = 657;
+  using extents_t    = cuda::std::extents<int, rows, cols>;
+  using mapping_t    = cuda::std::layout_stride::mapping<extents_t>;
+
+  cuda::std::array<int, 2> strides{ld, 1};
+  mapping_t mapping(extents_t{}, strides);
+  auto input     = make_host_data<uint16_t>(mapping.required_span_size(), 0xCD);
+  uint16_t value = 0x1234;
+
+  auto expected = to_byte_vector(input);
+  auto pattern  = repeated_bytes_vector(sizeof(value), value);
+  for (int row = 0; row < rows; ++row)
+  {
+    for (int col = 0; col < cols; ++col)
+    {
+      auto element_offset = (row * ld + col) * sizeof(value);
+      for (size_t byte_idx = 0; byte_idx < sizeof(value); ++byte_idx)
+      {
+        expected[element_offset + byte_idx] = pattern[byte_idx];
+      }
+    }
+  }
+  test_impl_stride(input, expected, extents_t{}, strides, value);
+}
+
+/***********************************************************************************************************************
+ * Edge Cases
+ **********************************************************************************************************************/
+
+TEST_CASE("fill_bytes handles rank-zero and zero-size mdspans", "[fill_bytes][edge]")
+{
+  // rank-zero
+  {
+    using extents_t = cuda::std::extents<int>;
+    auto input      = make_host_data<uint32_t>(1, 0xCD);
+    auto value      = pattern32::value;
+    test_impl(input, contiguous_fill_bytes<uint32_t>(1, value), extents_t{}, value);
+  }
+  // zero-size
+  {
+    auto input = make_host_data<uint32_t>(1, 0xCD);
+    test_impl(input, to_byte_vector(input), cuda::std::dims<1>{0}, uint32_t{0xdeadbeef});
+  }
+}

--- a/cudax/test/fill_bytes/fill_bytes_mdspan.cu
+++ b/cudax/test/fill_bytes/fill_bytes_mdspan.cu
@@ -21,6 +21,7 @@
 #include <cuda/experimental/fill_bytes.cuh>
 
 #include <cstring>
+#include <stdexcept>
 
 #include "testing.cuh"
 
@@ -29,18 +30,24 @@ static const cuda::stream stream{cuda::device_ref{0}};
 using host_vector_bytes_t = thrust::host_vector<cuda::std::byte>;
 using span_bytes_t        = cuda::std::span<const cuda::std::byte>;
 
-// create a host vector of bytes with a repeated pattern
 template <typename Value>
-host_vector_bytes_t repeated_bytes_vector(size_t num_bytes, const Value& value)
+void fill_expected_bytes(host_vector_bytes_t& expected, size_t byte_offset, size_t num_bytes, const Value& value)
 {
   cuda::std::byte pattern[sizeof(Value)];
   std::memcpy(pattern, &value, sizeof(Value));
 
-  host_vector_bytes_t expected(num_bytes);
   for (size_t i = 0; i < num_bytes; ++i)
   {
-    expected[i] = pattern[i % sizeof(Value)];
+    expected[byte_offset + i] = pattern[i % sizeof(Value)];
   }
+}
+
+// create a host vector of bytes with a repeated pattern
+template <typename Value>
+host_vector_bytes_t repeated_bytes_vector(size_t num_bytes, const Value& value)
+{
+  host_vector_bytes_t expected(num_bytes);
+  fill_expected_bytes(expected, 0, num_bytes, value);
   return expected;
 }
 
@@ -93,6 +100,13 @@ host_vector_bytes_t contiguous_fill_bytes(size_t num_elements, Value value)
   return repeated_bytes_vector(num_elements * sizeof(Tp), value);
 }
 
+template <typename Tp, typename Value>
+void fill_expected_element(host_vector_bytes_t& expected, size_t element_offset, Value value)
+{
+  fill_expected_bytes(expected, element_offset * sizeof(Tp), sizeof(Tp), value);
+}
+
+// contiguous layout tests
 template <typename _Layout = cuda::std::layout_right, typename Tp, typename Value, typename Index, size_t... Extents>
 void test_impl(const thrust::host_vector<Tp>& input,
                const host_vector_bytes_t& expected,
@@ -111,19 +125,22 @@ void test_impl(const thrust::host_vector<Tp>& input,
   REQUIRE(equal_bytes(to_byte_span(actual), to_byte_span(expected)));
 }
 
+// layout_stride tests
 template <typename Tp, typename Value, typename Index, size_t... Extents>
 void test_impl_stride(
   const thrust::host_vector<Tp>& input,
   const host_vector_bytes_t& expected,
-  cuda::std::extents<Index, Extents...> extents,
+  const cuda::std::extents<Index, Extents...>& extents,
   const cuda::std::array<Index, sizeof...(Extents)>& strides,
-  Value value)
+  Value value,
+  size_t offset = 0)
 {
   using extents_t = cuda::std::extents<Index, Extents...>;
   using mapping_t = cuda::std::layout_stride::mapping<extents_t>;
+
   thrust::device_vector<Tp> device_data(input.begin(), input.end());
   cuda::device_mdspan<Tp, extents_t, cuda::std::layout_stride> dst(
-    thrust::raw_pointer_cast(device_data.data()), mapping_t(extents, strides));
+    thrust::raw_pointer_cast(device_data.data()) + offset, mapping_t(extents, strides));
 
   cuda::experimental::fill_bytes(dst, value, stream);
   stream.sync();
@@ -132,17 +149,19 @@ void test_impl_stride(
   REQUIRE(equal_bytes(to_byte_span(actual), to_byte_span(expected)));
 }
 
+// layout_stride_relaxed tests
 template <typename Tp, typename Value, typename Index, size_t... Extents>
 void test_impl_relaxed(
   const thrust::host_vector<Tp>& input,
   const host_vector_bytes_t& expected,
-  cuda::std::extents<Index, Extents...> extents,
+  const cuda::std::extents<Index, Extents...>& extents,
   const cuda::dstrides<Index, sizeof...(Extents)>& strides,
   Index offset,
   Value value)
 {
   using extents_t = cuda::std::extents<Index, Extents...>;
   using mapping_t = cuda::layout_stride_relaxed::mapping<extents_t>;
+
   thrust::device_vector<Tp> device_data(input.begin(), input.end());
   cuda::device_mdspan<Tp, extents_t, cuda::layout_stride_relaxed> dst(
     thrust::raw_pointer_cast(device_data.data()), mapping_t(extents, strides, offset));
@@ -230,7 +249,19 @@ TEST_CASE("fill_bytes handles layout_left device mdspan", "[fill_bytes][layout_l
   test_impl<cuda::std::layout_left>(input, contiguous_fill_bytes<uint16_t>(rows * cols, value), extents_t{}, value);
 }
 
-TEST_CASE("fill_bytes preserves padding bytes in strided destination layouts", "[fill_bytes][stride]")
+TEST_CASE("fill_bytes handles singleton dimensions", "[fill_bytes][singleton]")
+{
+  constexpr int rows = 2;
+  constexpr int cols = 4;
+  using extents_t    = cuda::std::extents<int, rows, 1, cols>;
+
+  auto input           = make_host_data<uint16_t>(rows * cols, 0xCD);
+  constexpr auto value = uint16_t{0x1234};
+  test_impl(input, contiguous_fill_bytes<uint16_t>(rows * cols, value), extents_t{}, value);
+  test_impl<cuda::std::layout_left>(input, contiguous_fill_bytes<uint16_t>(rows * cols, value), extents_t{}, value);
+}
+
+TEST_CASE("fill_bytes preserves padding bytes in strided row-major destination layouts", "[fill_bytes][stride]")
 {
   constexpr int rows = 367;
   constexpr int cols = 456;
@@ -244,19 +275,136 @@ TEST_CASE("fill_bytes preserves padding bytes in strided destination layouts", "
   uint16_t value = 0x1234;
 
   auto expected = to_byte_vector(input);
-  auto pattern  = repeated_bytes_vector(sizeof(value), value);
   for (int row = 0; row < rows; ++row)
   {
     for (int col = 0; col < cols; ++col)
     {
-      auto element_offset = (row * ld + col) * sizeof(value);
-      for (size_t byte_idx = 0; byte_idx < sizeof(value); ++byte_idx)
+      fill_expected_element<uint16_t>(expected, row * ld + col, value);
+    }
+  }
+  test_impl_stride(input, expected, extents_t{}, strides, value);
+}
+
+TEST_CASE("fill_bytes preserves padding bytes in strided column-major destination layouts", "[fill_bytes][stride]")
+{
+  constexpr int rows = 127;
+  constexpr int cols = 79;
+  constexpr int ld   = 191;
+  using extents_t    = cuda::std::extents<int, rows, cols>;
+  using mapping_t    = cuda::std::layout_stride::mapping<extents_t>;
+
+  cuda::std::array<int, 2> strides{1, ld};
+  mapping_t mapping(extents_t{}, strides);
+  auto input     = make_host_data<uint16_t>(mapping.required_span_size(), 0xCD);
+  uint16_t value = 0x1234;
+
+  auto expected = to_byte_vector(input);
+  for (int row = 0; row < rows; ++row)
+  {
+    for (int col = 0; col < cols; ++col)
+    {
+      fill_expected_element<uint16_t>(expected, row + col * ld, value);
+    }
+  }
+  test_impl_stride(input, expected, extents_t{}, strides, value);
+}
+
+/***********************************************************************************************************************
+ * 3D Tests
+ **********************************************************************************************************************/
+
+TEST_CASE("fill_bytes handles 3D mdspans", "[fill_bytes][3d]")
+{
+  constexpr int dim0  = 2;
+  constexpr int dim1  = 3;
+  constexpr int dim2  = 4;
+  constexpr int total = dim0 * dim1 * dim2;
+  using extents_t     = cuda::std::extents<int, dim0, dim1, dim2>;
+
+  auto input           = make_host_data<uint32_t>(total, 0xCD);
+  constexpr auto value = pattern32::value;
+  test_impl(input, contiguous_fill_bytes<uint32_t>(total, value), extents_t{}, value);
+  test_impl<cuda::std::layout_left>(input, contiguous_fill_bytes<uint32_t>(total, value), extents_t{}, value);
+}
+
+TEST_CASE("fill_bytes handles 3D strided permutation layouts", "[fill_bytes][3d][stride][permutation]")
+{
+  constexpr int dim0 = 25;
+  constexpr int dim1 = 37;
+  constexpr int dim2 = 41;
+  using extents_t    = cuda::std::extents<int, dim0, dim1, dim2>;
+  constexpr int span = (dim0 - 1) + (dim1 - 1) * dim2 * dim0 + (dim2 - 1) * dim0 + 1;
+
+  cuda::std::array<int, 3> strides{1, dim2 * dim0, dim0};
+  auto input           = make_host_data<uint32_t>(span, 0xCD);
+  constexpr auto value = pattern32::value;
+
+  auto expected = to_byte_vector(input);
+  for (int i = 0; i < dim0; ++i)
+  {
+    for (int j = 0; j < dim1; ++j)
+    {
+      for (int k = 0; k < dim2; ++k)
       {
-        expected[element_offset + byte_idx] = pattern[byte_idx];
+        int offset = i + j * dim2 * dim0 + k * dim0;
+        fill_expected_element<uint32_t>(expected, offset, value);
       }
     }
   }
   test_impl_stride(input, expected, extents_t{}, strides, value);
+}
+
+TEST_CASE("fill_bytes handles 3D strided tile_size greater than one", "[fill_bytes][3d][stride][tile]")
+{
+  constexpr int dim0      = 27;
+  constexpr int dim1      = 39;
+  constexpr int dim2      = 47;
+  using extents_t         = cuda::std::extents<int, dim0, dim1, dim2>;
+  constexpr int stride0   = 64;
+  constexpr int stride1   = 2048;
+  constexpr int span_size = (dim0 - 1) * stride0 + (dim1 - 1) * stride1 + dim2;
+
+  cuda::std::array<int, 3> strides{stride0, stride1, 1};
+  auto input           = make_host_data<uint32_t>(span_size, 0xCD);
+  constexpr auto value = pattern32::value;
+
+  auto expected = to_byte_vector(input);
+  for (int i = 0; i < dim0; ++i)
+  {
+    for (int j = 0; j < dim1; ++j)
+    {
+      for (int k = 0; k < dim2; ++k)
+      {
+        int offset = i * stride0 + j * stride1 + k;
+        fill_expected_element<uint32_t>(expected, offset, value);
+      }
+    }
+  }
+  test_impl_stride(input, expected, extents_t{}, strides, value);
+}
+
+TEST_CASE("fill_bytes preserves surrounding bytes in strided subviews with offsets", "[fill_bytes][stride][offset]")
+{
+  constexpr int rows   = 2;
+  constexpr int cols   = 3;
+  constexpr int ld     = 4;
+  constexpr int offset = 3;
+  constexpr int alloc  = 16;
+  using extents_t      = cuda::std::extents<int, rows, cols>;
+
+  cuda::std::array<int, 2> strides{1, ld};
+  auto input           = make_host_data<uint32_t>(alloc, 0xCD);
+  constexpr auto value = uint32_t{0x12345678};
+
+  auto expected = to_byte_vector(input);
+  for (int row = 0; row < rows; ++row)
+  {
+    for (int col = 0; col < cols; ++col)
+    {
+      fill_expected_element<uint32_t>(expected, offset + row + col * ld, value);
+    }
+  }
+  test_impl_stride(input, expected, extents_t{}, strides, value, offset);
 }
 
 /***********************************************************************************************************************
@@ -277,4 +425,17 @@ TEST_CASE("fill_bytes handles rank-zero and zero-size mdspans", "[fill_bytes][ed
     auto input = make_host_data<uint32_t>(1, 0xCD);
     test_impl(input, to_byte_vector(input), cuda::std::dims<1>{0}, uint32_t{0xdeadbeef});
   }
+}
+
+TEST_CASE("fill_bytes rejects interleaved layout", "[fill_bytes][throw]")
+{
+  using extents_t = cuda::std::extents<int, 2, 2>;
+  using mapping_t = cuda::layout_stride_relaxed::mapping<extents_t>;
+  auto input      = make_host_data<uint32_t>(6, 0xCD);
+
+  thrust::device_vector<uint32_t> device_data(input.begin(), input.end());
+  cuda::device_mdspan<uint32_t, extents_t, cuda::layout_stride_relaxed> dst(
+    thrust::raw_pointer_cast(device_data.data()), mapping_t(extents_t{}, cuda::dstrides<int, 2>(2, 3)));
+
+  REQUIRE_THROWS_AS(cuda::experimental::fill_bytes(dst, uint32_t{0x12345678}, stream), std::invalid_argument);
 }

--- a/cudax/test/fill_bytes/fill_bytes_mdspan_example.cu
+++ b/cudax/test/fill_bytes/fill_bytes_mdspan_example.cu
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+#include <cuda/mdspan>
+#include <cuda/std/cstdint>
+#include <cuda/stream>
+
+#include <cuda/experimental/fill_bytes.cuh>
+
+#include <cstring>
+
+#include "testing.cuh"
+
+TEST_CASE("fill_bytes mdspan documentation example", "[fill_bytes][example]")
+{
+  // example-begin fill-bytes-mdspan
+  using extents_t = cuda::std::dims<2>;
+  extents_t extents{2, 3};
+
+  thrust::device_vector<int> device_data(extents.extent(0) * extents.extent(1));
+  int* dst_ptr = thrust::raw_pointer_cast(device_data.data());
+  cuda::device_mdspan<int, extents_t> dst(dst_ptr, extents);
+
+  cuda::stream stream{cuda::device_ref{0}};
+  cuda::experimental::fill_bytes(dst, uint32_t{0xFF00FF00}, stream);
+  // example-end fill-bytes-mdspan
+
+  stream.sync();
+
+  const thrust::host_vector<int> actual(device_data);
+  for (const int value : actual)
+  {
+    uint32_t value_bits{};
+    std::memcpy(&value_bits, &value, sizeof(value_bits));
+    REQUIRE(value_bits == uint32_t{0xFF00FF00});
+  }
+}

--- a/docs/cudax/Doxyfile
+++ b/docs/cudax/Doxyfile
@@ -11,6 +11,7 @@ XML_PROGRAMLISTING     = YES
 
 # Input directory - specific paths for cudax
 INPUT                  = ../../cudax/include/cuda/experimental/__copy_bytes \
+                         ../../cudax/include/cuda/experimental/__fill_bytes \
                          ../../cudax/include/cuda/experimental/__container \
                          ../../cudax/include/cuda/experimental/__device \
                          ../../cudax/include/cuda/experimental/graph.cuh \

--- a/docs/cudax/index.rst
+++ b/docs/cudax/index.rst
@@ -20,6 +20,7 @@ However, any feature within this library has important use cases and we encourag
 
 Specifically, ``cudax`` provides:
    - :ref:`asynchronous host from/to device byte-wise mdspan copy <cudax-copy-bytes>`
+   - :ref:`mdspan byte fill <cudax-fill-bytes>`
    - :ref:`uninitialized storage <libcudacxx-containers-uninitialized-async-buffer>`
    - :ref:`an owning type erased memory resource <libcudacxx-memory-resource-any-async-resource>`
    - :ref:`stream-ordered memory resources <libcudacxx-memory-resource-async>`


### PR DESCRIPTION
## Description

Very similar to `cudax::copy_bytes` H2D, D2H and complementary to it.

also taking into account most comments of https://github.com/NVIDIA/cccl/pull/8333