### PR TITLE
Use the new tuning API internally for `detail::segmented_scan::dispatch`

### DIFF
--- a/cub/benchmarks/bench/segmented_scan/base.cuh
+++ b/cub/benchmarks/bench/segmented_scan/base.cuh
@@ -64,16 +64,12 @@ struct to_offsets_functor
 template <size_t Wobble = 0, typename T, typename OffsetT>
 static void bench_impl(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 {
-  using init_t    = T;
-  using offset_t  = cub::detail::choose_offset_t<OffsetT>;
-  using offset_it = const offset_t*;
-
 #if !TUNE_BASE
   using policy_t = policy_selector_t<TUNE_THREADS, TUNE_ITEMS, TUNE_MAX_SEGMENTS_PER_BLOCK>;
 #endif
 
-  const auto elements     = static_cast<offset_t>(state.get_int64("Elements{io}"));
-  const auto segment_size = static_cast<offset_t>(state.get_int64("SegmentSize{io}"));
+  const auto elements     = static_cast<OffsetT>(state.get_int64("Elements{io}"));
+  const auto segment_size = static_cast<OffsetT>(state.get_int64("SegmentSize{io}"));
   const auto num_segments = cuda::ceil_div(elements, segment_size);
   auto& summary           = state.add_summary("user/derived/segment_count");
   summary.set_string("name", "#Segments");
@@ -82,16 +78,16 @@ static void bench_impl(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   thrust::device_vector<T> input = generate(elements);
   thrust::device_vector<T> output(elements, thrust::default_init);
 
-  thrust::device_vector<offset_t> offsets(num_segments + 1, thrust::no_init);
-  thrust::tabulate(offsets.begin(), offsets.end(), to_offsets_functor<offset_t>{elements, segment_size, Wobble});
+  thrust::device_vector<OffsetT> offsets(num_segments + 1, thrust::no_init);
+  thrust::tabulate(offsets.begin(), offsets.end(), to_offsets_functor<OffsetT>{elements, segment_size, Wobble});
 
-  const T* d_input    = thrust::raw_pointer_cast(input.data());
-  T* d_output         = thrust::raw_pointer_cast(output.data());
-  offset_it d_offsets = thrust::raw_pointer_cast(offsets.data());
+  const T* d_input         = thrust::raw_pointer_cast(input.data());
+  T* d_output              = thrust::raw_pointer_cast(output.data());
+  const OffsetT* d_offsets = thrust::raw_pointer_cast(offsets.data());
 
   state.add_element_count(elements, "Elements");
   state.add_global_memory_reads<T>(elements);
-  state.add_global_memory_reads<offset_t>(num_segments + 1);
+  state.add_global_memory_reads<OffsetT>(num_segments + 1);
   state.add_global_memory_writes<T>(elements);
 
   caching_allocator_t alloc;
@@ -114,7 +110,7 @@ static void bench_impl(nvbench::state& state, nvbench::type_list<T, OffsetT>)
       d_offsets,
       num_segments,
       op_t{},
-      init_t{},
+      T{},
       env);
   });
 }
@@ -154,3 +150,5 @@ NVBENCH_BENCH_TYPES(varying_segment_size_bench, NVBENCH_TYPE_AXES(benched_value_
   .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(18, 26, 4))
   .add_int64_axis("SegmentSize{io}", {51, 123, 233, 513, 1337, 4417});
+// .add_int64_axis("SegmentsPerWorker{io}", {1}) // public API doesn' expose them (yet)
+// .add_string_axis("Worker{io}", {"block"});

--- a/cub/benchmarks/bench/segmented_scan/base.cuh
+++ b/cub/benchmarks/bench/segmented_scan/base.cuh
@@ -64,13 +64,9 @@ struct to_offsets_functor
 template <size_t Wobble = 0, typename T, typename OffsetT>
 static void bench_impl(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 {
-  using init_t         = T;
-  using wrapped_init_t = cub::detail::InputValue<init_t>;
-  using accum_t        = cuda::std::__accumulator_t<op_t, init_t, T>;
-  using input_it_t     = const T*;
-  using output_it_t    = T*;
-  using offset_t       = cub::detail::choose_offset_t<OffsetT>;
-  using offset_it      = const offset_t*;
+  using init_t    = T;
+  using offset_t  = cub::detail::choose_offset_t<OffsetT>;
+  using offset_it = const offset_t*;
 
 #if !TUNE_BASE
   using policy_t = policy_selector_t<TUNE_THREADS, TUNE_ITEMS, TUNE_MAX_SEGMENTS_PER_BLOCK>;
@@ -98,87 +94,28 @@ static void bench_impl(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   state.add_global_memory_reads<offset_t>(num_segments + 1);
   state.add_global_memory_writes<T>(elements);
 
-  int num_segments_per_worker = static_cast<int>(state.get_int64("SegmentsPerWorker{io}"));
-
-  if (num_segments_per_worker < 1)
-  {
-    state.skip("Number of segments parameter is not positive");
-    return;
-  }
-
-  auto worker_choice = [](auto token) -> cub::detail::segmented_scan::worker {
-    if (token == "block")
-    {
-      return cub::detail::segmented_scan::worker::block;
-    }
-    else
-    {
-      throw std::runtime_error("Unrecognized value of Worker{io} axis value. Expected 'block'");
-    }
-  }(state.get_string("Worker{io}"));
-
-  size_t tmp_size;
-  cub::detail::segmented_scan::dispatch<
-    cub::ForceInclusive::No,
-    input_it_t,
-    output_it_t,
-    offset_it,
-    offset_it,
-    offset_it,
-    op_t,
-    wrapped_init_t,
-    accum_t,
-    offset_t
+  caching_allocator_t alloc;
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
+    auto env = cub_bench_env(
+      alloc,
+      launch
 #if !TUNE_BASE
-    ,
-    policy_t
-#endif
-    >(nullptr,
-      tmp_size,
+      ,
+      cuda::execution::tune(policy_t{})
+#endif // !TUNE_BASE
+    );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceSegmentedScan::ExclusiveSegmentedScan,
+      "ExclusiveSegmentedScan failed",
       d_input,
       d_output,
-      num_segments,
       d_offsets,
       d_offsets + 1,
       d_offsets,
+      num_segments,
       op_t{},
-      wrapped_init_t{T{}},
-      num_segments_per_worker,
-      worker_choice,
-      nullptr /* stream */);
-
-  thrust::device_vector<nvbench::uint8_t> tmp(tmp_size, thrust::no_init);
-  nvbench::uint8_t* d_tmp = thrust::raw_pointer_cast(tmp.data());
-
-  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::segmented_scan::dispatch<
-      cub::ForceInclusive::No,
-      input_it_t,
-      output_it_t,
-      offset_it,
-      offset_it,
-      offset_it,
-      op_t,
-      wrapped_init_t,
-      accum_t,
-      offset_t
-#if !TUNE_BASE
-      ,
-      policy_t
-#endif
-      >(thrust::raw_pointer_cast(tmp.data()),
-        tmp_size,
-        d_input,
-        d_output,
-        num_segments,
-        d_offsets,
-        d_offsets + 1,
-        d_offsets,
-        op_t{},
-        wrapped_init_t{T{}},
-        num_segments_per_worker,
-        worker_choice,
-        launch.get_stream());
+      init_t{},
+      env);
   });
 }
 
@@ -210,14 +147,10 @@ NVBENCH_BENCH_TYPES(fixed_segment_size_bench, NVBENCH_TYPE_AXES(benched_value_ty
   .set_name("fixed_size_segments")
   .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(18, 26, 4))
-  .add_int64_axis("SegmentSize{io}", {51, 123, 233, 513, 1337, 4417})
-  .add_int64_axis("SegmentsPerWorker{io}", {1})
-  .add_string_axis("Worker{io}", {"block"});
+  .add_int64_axis("SegmentSize{io}", {51, 123, 233, 513, 1337, 4417});
 
 NVBENCH_BENCH_TYPES(varying_segment_size_bench, NVBENCH_TYPE_AXES(benched_value_types, offset_types))
   .set_name("varying_size_segments")
   .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(18, 26, 4))
-  .add_int64_axis("SegmentSize{io}", {51, 123, 233, 513, 1337, 4417})
-  .add_int64_axis("SegmentsPerWorker{io}", {1})
-  .add_string_axis("Worker{io}", {"block"});
+  .add_int64_axis("SegmentSize{io}", {51, 123, 233, 513, 1337, 4417});

--- a/cub/cub/device/device_segmented_scan.cuh
+++ b/cub/cub/device/device_segmented_scan.cuh
@@ -314,8 +314,13 @@ public:
     using init_value_t = cub::detail::it_value_t<InputIteratorT>;
     init_value_t init_value{};
 
-    return detail::dispatch_with_env(
-      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+    using accum_t = detail::segmented_scan::
+      deduced_accum_t<scan_op_t, detail::InputValue<init_value_t>, detail::it_value_t<InputIteratorT>>;
+
+    using default_policy_selector = detail::segmented_scan::policy_selector_from_types<accum_t>;
+
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return cub::detail::segmented_scan::dispatch(
           d_temp_storage,
           temp_storage_bytes,
@@ -329,7 +334,8 @@ public:
           detail::InputValue<init_value_t>(init_value),
           1,
           detail::segmented_scan::worker::block,
-          stream);
+          stream,
+          policy_selector);
       });
   }
 
@@ -570,8 +576,13 @@ public:
     using init_value_t = cub::detail::it_value_t<InputIteratorT>;
     init_value_t init_value{};
 
-    return detail::dispatch_with_env(
-      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+    using accum_t = detail::segmented_scan::
+      deduced_accum_t<scan_op_t, detail::InputValue<init_value_t>, detail::it_value_t<InputIteratorT>>;
+
+    using default_policy_selector = detail::segmented_scan::policy_selector_from_types<accum_t>;
+
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return cub::detail::segmented_scan::dispatch(
           d_temp_storage,
           temp_storage_bytes,
@@ -585,7 +596,8 @@ public:
           detail::InputValue<init_value_t>(init_value),
           1,
           detail::segmented_scan::worker::block,
-          stream);
+          stream,
+          policy_selector);
       });
   }
 
@@ -826,8 +838,13 @@ public:
 
     check_common_iterator_value_is_integral<BeginOffsetIteratorInputT, EndOffsetIteratorInputT>();
 
-    return detail::dispatch_with_env(
-      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+    using accum_t = detail::segmented_scan::
+      deduced_accum_t<ScanOpT, detail::InputValue<InitValueT>, detail::it_value_t<InputIteratorT>>;
+
+    using default_policy_selector = detail::segmented_scan::policy_selector_from_types<accum_t>;
+
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return cub::detail::segmented_scan::dispatch(
           d_temp_storage,
           temp_storage_bytes,
@@ -841,7 +858,8 @@ public:
           detail::InputValue<InitValueT>(init_value),
           1,
           detail::segmented_scan::worker::block,
-          stream);
+          stream,
+          policy_selector);
       });
   }
 
@@ -1099,8 +1117,13 @@ public:
                                             EndOffsetIteratorInputT,
                                             BeginOffsetIteratorOutputT>();
 
-    return detail::dispatch_with_env(
-      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+    using accum_t = detail::segmented_scan::
+      deduced_accum_t<ScanOpT, detail::InputValue<InitValueT>, detail::it_value_t<InputIteratorT>>;
+
+    using default_policy_selector = detail::segmented_scan::policy_selector_from_types<accum_t>;
+
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return cub::detail::segmented_scan::dispatch(
           d_temp_storage,
           temp_storage_bytes,
@@ -1114,7 +1137,8 @@ public:
           detail::InputValue<InitValueT>(init_value),
           1,
           detail::segmented_scan::worker::block,
-          stream);
+          stream,
+          policy_selector);
       });
   }
 
@@ -1323,8 +1347,12 @@ public:
     using scan_op_t = ::cuda::std::plus<>;
     scan_op_t scan_op{};
 
-    return detail::dispatch_with_env(
-      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+    using accum_t = detail::segmented_scan::deduced_accum_t<scan_op_t, NullType, detail::it_value_t<InputIteratorT>>;
+
+    using default_policy_selector = detail::segmented_scan::policy_selector_from_types<accum_t>;
+
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return cub::detail::segmented_scan::dispatch(
           d_temp_storage,
           temp_storage_bytes,
@@ -1338,7 +1366,8 @@ public:
           NullType(),
           1,
           detail::segmented_scan::worker::block,
-          stream);
+          stream,
+          policy_selector);
       });
   }
 
@@ -1578,8 +1607,12 @@ public:
     using scan_op_t = ::cuda::std::plus<>;
     scan_op_t scan_op{};
 
-    return detail::dispatch_with_env(
-      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+    using accum_t = detail::segmented_scan::deduced_accum_t<scan_op_t, NullType, detail::it_value_t<InputIteratorT>>;
+
+    using default_policy_selector = detail::segmented_scan::policy_selector_from_types<accum_t>;
+
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return cub::detail::segmented_scan::dispatch(
           d_temp_storage,
           temp_storage_bytes,
@@ -1593,7 +1626,8 @@ public:
           NullType(),
           1,
           detail::segmented_scan::worker::block,
-          stream);
+          stream,
+          policy_selector);
       });
   }
 
@@ -1801,8 +1835,12 @@ public:
 
     check_common_iterator_value_is_integral<BeginOffsetIteratorInputT, EndOffsetIteratorInputT>();
 
-    return detail::dispatch_with_env(
-      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+    using accum_t = detail::segmented_scan::deduced_accum_t<ScanOpT, NullType, detail::it_value_t<InputIteratorT>>;
+
+    using default_policy_selector = detail::segmented_scan::policy_selector_from_types<accum_t>;
+
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return cub::detail::segmented_scan::dispatch(
           d_temp_storage,
           temp_storage_bytes,
@@ -1816,7 +1854,8 @@ public:
           NullType(),
           1,
           detail::segmented_scan::worker::block,
-          stream);
+          stream,
+          policy_selector);
       });
   }
 
@@ -2068,8 +2107,12 @@ public:
                                             EndOffsetIteratorInputT,
                                             BeginOffsetIteratorOutputT>();
 
-    return detail::dispatch_with_env(
-      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+    using accum_t = detail::segmented_scan::deduced_accum_t<ScanOpT, NullType, detail::it_value_t<InputIteratorT>>;
+
+    using default_policy_selector = detail::segmented_scan::policy_selector_from_types<accum_t>;
+
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return cub::detail::segmented_scan::dispatch(
           d_temp_storage,
           temp_storage_bytes,
@@ -2083,7 +2126,8 @@ public:
           NullType(),
           1,
           detail::segmented_scan::worker::block,
-          stream);
+          stream,
+          policy_selector);
       });
   }
 
@@ -2327,8 +2371,13 @@ public:
     check_common_iterator_value_is_integral<BeginOffsetIteratorInputT, EndOffsetIteratorInputT>();
     static_assert(!::cuda::std::is_same_v<InitValueT, NullType>);
 
-    return detail::dispatch_with_env(
-      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+    using accum_t = detail::segmented_scan::
+      deduced_accum_t<ScanOpT, detail::InputValue<InitValueT>, detail::it_value_t<InputIteratorT>>;
+
+    using default_policy_selector = detail::segmented_scan::policy_selector_from_types<accum_t>;
+
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return cub::detail::segmented_scan::dispatch<ForceInclusive::Yes>(
           d_temp_storage,
           temp_storage_bytes,
@@ -2342,7 +2391,8 @@ public:
           detail::InputValue<InitValueT>(init_value),
           1,
           detail::segmented_scan::worker::block,
-          stream);
+          stream,
+          policy_selector);
       });
   }
 
@@ -2604,10 +2654,13 @@ public:
                                             BeginOffsetIteratorOutputT>();
     static_assert(!::cuda::std::is_same_v<InitValueT, NullType>);
 
-    using accum_t = ::cuda::std::__accumulator_t<ScanOpT, cub::detail::it_value_t<InputIteratorT>, InitValueT>;
+    using accum_t = detail::segmented_scan::
+      deduced_accum_t<ScanOpT, detail::InputValue<InitValueT>, detail::it_value_t<InputIteratorT>>;
 
-    return detail::dispatch_with_env(
-      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+    using default_policy_selector = detail::segmented_scan::policy_selector_from_types<accum_t>;
+
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return cub::detail::segmented_scan::dispatch<ForceInclusive::Yes>(
           d_temp_storage,
           temp_storage_bytes,
@@ -2621,7 +2674,8 @@ public:
           detail::InputValue<InitValueT>(init_value),
           1,
           detail::segmented_scan::worker::block,
-          stream);
+          stream,
+          policy_selector);
       });
   }
 };

--- a/cub/examples/device/example_device_scan.cu
+++ b/cub/examples/device/example_device_scan.cu
@@ -1,166 +1,23 @@
-// SPDX-FileCopyrightText: Copyright (c) 2011, Duane Merrill. All rights reserved.
-// SPDX-FileCopyrightText: Copyright (c) 2011-2018, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: BSD-3
-
-/******************************************************************************
- * Simple example of DeviceScan::ExclusiveSum().
- *
- * Computes an exclusive sum of int keys.
- *
- * To compile using the command line:
- *   nvcc -arch=sm_XX example_device_scan.cu -I../.. -lcudart -O3
- *
- ******************************************************************************/
-
-// Ensure printing of CUDA runtime errors to console
-#define CUB_STDERR
-
 #include <cub/device/device_scan.cuh>
 #include <cub/util_allocator.cuh>
 
+#include <thrust/binary_search.h>
+#include <thrust/device_vector.h>
+
 #include <cstdio>
 
-#include "../../test/test_util.h"
-
-using namespace cub;
-
-//---------------------------------------------------------------------
-// Globals, constants and aliases
-//---------------------------------------------------------------------
-
-bool g_verbose = false; // Whether to display input/output to console
-CachingDeviceAllocator g_allocator(true); // Caching allocator for device memory
-
-//---------------------------------------------------------------------
-// Test generation
-//---------------------------------------------------------------------
-
-/**
- * Initialize problem
- */
-void Initialize(int* h_in, int num_items)
+int main()
 {
-  for (int i = 0; i < num_items; ++i)
+  thrust::device_vector<int> a{0, 2, 5, 7, 8};
+
+  thrust::device_vector<int> b{0, 1, 2, 3, 8, 9};
+
+  thrust::device_vector<int> out(6);
+  thrust::lower_bound(a.begin(), a.end(), b.begin(), b.end(), out.begin());
+
+  for (int a : out)
   {
-    h_in[i] = i;
+    printf("%d\n", (int) a);
   }
-
-  if (g_verbose)
-  {
-    printf("Input:\n");
-    DisplayResults(h_in, num_items);
-    printf("\n\n");
-  }
-}
-
-/**
- * Solve exclusive-scan problem
- */
-int Solve(int* h_in, int* h_reference, int num_items)
-{
-  int inclusive = 0;
-  int aggregate = 0;
-
-  for (int i = 0; i < num_items; ++i)
-  {
-    h_reference[i] = inclusive;
-    inclusive += h_in[i];
-    aggregate += h_in[i];
-  }
-
-  return aggregate;
-}
-
-//---------------------------------------------------------------------
-// Main
-//---------------------------------------------------------------------
-
-/**
- * Main
- */
-int main(int argc, char** argv)
-{
-  int num_items = 150;
-
-  // Initialize command line
-  CommandLineArgs args(argc, argv);
-  g_verbose = args.CheckCmdLineFlag("v");
-  args.GetCmdLineArgument("n", num_items);
-
-  // Print usage
-  if (args.CheckCmdLineFlag("help"))
-  {
-    printf("%s "
-           "[--n=<input items> "
-           "[--device=<device-id>] "
-           "[--v] "
-           "\n",
-           argv[0]);
-    exit(0);
-  }
-
-  // Initialize device
-  CubDebugExit(args.DeviceInit());
-
-  printf("cub::DeviceScan::ExclusiveSum %d items (%d-byte elements)\n", num_items, (int) sizeof(int));
-  fflush(stdout);
-
-  // Allocate host arrays
-  int* h_in        = new int[num_items];
-  int* h_reference = new int[num_items];
-
-  // Initialize problem and solution
-  Initialize(h_in, num_items);
-  Solve(h_in, h_reference, num_items);
-
-  // Allocate problem device arrays
-  int* d_in = nullptr;
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_in, sizeof(int) * num_items));
-
-  // Initialize device input
-  CubDebugExit(cudaMemcpy(d_in, h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
-
-  // Allocate device output array
-  int* d_out = nullptr;
-  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_out, sizeof(int) * num_items));
-
-  // Allocate temporary storage
-  void* d_temp_storage      = nullptr;
-  size_t temp_storage_bytes = 0;
-  CubDebugExit(DeviceScan::ExclusiveSum(d_temp_storage, temp_storage_bytes, d_in, d_out, num_items));
-  CubDebugExit(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
-
-  // Run
-  CubDebugExit(DeviceScan::ExclusiveSum(d_temp_storage, temp_storage_bytes, d_in, d_out, num_items));
-
-  // Check for correctness (and display results, if specified)
-  int compare = CompareDeviceResults(h_reference, d_out, num_items, true, g_verbose);
-  printf("\t%s", compare ? "FAIL" : "PASS");
-  AssertEquals(0, compare);
-
-  // Cleanup
-  if (h_in)
-  {
-    delete[] h_in;
-  }
-  if (h_reference)
-  {
-    delete[] h_reference;
-  }
-  if (d_in)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_in));
-  }
-  if (d_out)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_out));
-  }
-  if (d_temp_storage)
-  {
-    CubDebugExit(g_allocator.DeviceFree(d_temp_storage));
-  }
-
-  printf("\n\n");
-
   return 0;
 }

--- a/cub/examples/device/example_device_scan.cu
+++ b/cub/examples/device/example_device_scan.cu
@@ -1,23 +1,166 @@
+// SPDX-FileCopyrightText: Copyright (c) 2011, Duane Merrill. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2011-2018, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3
+
+/******************************************************************************
+ * Simple example of DeviceScan::ExclusiveSum().
+ *
+ * Computes an exclusive sum of int keys.
+ *
+ * To compile using the command line:
+ *   nvcc -arch=sm_XX example_device_scan.cu -I../.. -lcudart -O3
+ *
+ ******************************************************************************/
+
+// Ensure printing of CUDA runtime errors to console
+#define CUB_STDERR
+
 #include <cub/device/device_scan.cuh>
 #include <cub/util_allocator.cuh>
 
-#include <thrust/binary_search.h>
-#include <thrust/device_vector.h>
-
 #include <cstdio>
 
-int main()
+#include "../../test/test_util.h"
+
+using namespace cub;
+
+//---------------------------------------------------------------------
+// Globals, constants and aliases
+//---------------------------------------------------------------------
+
+bool g_verbose = false; // Whether to display input/output to console
+CachingDeviceAllocator g_allocator(true); // Caching allocator for device memory
+
+//---------------------------------------------------------------------
+// Test generation
+//---------------------------------------------------------------------
+
+/**
+ * Initialize problem
+ */
+void Initialize(int* h_in, int num_items)
 {
-  thrust::device_vector<int> a{0, 2, 5, 7, 8};
-
-  thrust::device_vector<int> b{0, 1, 2, 3, 8, 9};
-
-  thrust::device_vector<int> out(6);
-  thrust::lower_bound(a.begin(), a.end(), b.begin(), b.end(), out.begin());
-
-  for (int a : out)
+  for (int i = 0; i < num_items; ++i)
   {
-    printf("%d\n", (int) a);
+    h_in[i] = i;
   }
+
+  if (g_verbose)
+  {
+    printf("Input:\n");
+    DisplayResults(h_in, num_items);
+    printf("\n\n");
+  }
+}
+
+/**
+ * Solve exclusive-scan problem
+ */
+int Solve(int* h_in, int* h_reference, int num_items)
+{
+  int inclusive = 0;
+  int aggregate = 0;
+
+  for (int i = 0; i < num_items; ++i)
+  {
+    h_reference[i] = inclusive;
+    inclusive += h_in[i];
+    aggregate += h_in[i];
+  }
+
+  return aggregate;
+}
+
+//---------------------------------------------------------------------
+// Main
+//---------------------------------------------------------------------
+
+/**
+ * Main
+ */
+int main(int argc, char** argv)
+{
+  int num_items = 150;
+
+  // Initialize command line
+  CommandLineArgs args(argc, argv);
+  g_verbose = args.CheckCmdLineFlag("v");
+  args.GetCmdLineArgument("n", num_items);
+
+  // Print usage
+  if (args.CheckCmdLineFlag("help"))
+  {
+    printf("%s "
+           "[--n=<input items> "
+           "[--device=<device-id>] "
+           "[--v] "
+           "\n",
+           argv[0]);
+    exit(0);
+  }
+
+  // Initialize device
+  CubDebugExit(args.DeviceInit());
+
+  printf("cub::DeviceScan::ExclusiveSum %d items (%d-byte elements)\n", num_items, (int) sizeof(int));
+  fflush(stdout);
+
+  // Allocate host arrays
+  int* h_in        = new int[num_items];
+  int* h_reference = new int[num_items];
+
+  // Initialize problem and solution
+  Initialize(h_in, num_items);
+  Solve(h_in, h_reference, num_items);
+
+  // Allocate problem device arrays
+  int* d_in = nullptr;
+  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_in, sizeof(int) * num_items));
+
+  // Initialize device input
+  CubDebugExit(cudaMemcpy(d_in, h_in, sizeof(int) * num_items, cudaMemcpyHostToDevice));
+
+  // Allocate device output array
+  int* d_out = nullptr;
+  CubDebugExit(g_allocator.DeviceAllocate((void**) &d_out, sizeof(int) * num_items));
+
+  // Allocate temporary storage
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+  CubDebugExit(DeviceScan::ExclusiveSum(d_temp_storage, temp_storage_bytes, d_in, d_out, num_items));
+  CubDebugExit(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+
+  // Run
+  CubDebugExit(DeviceScan::ExclusiveSum(d_temp_storage, temp_storage_bytes, d_in, d_out, num_items));
+
+  // Check for correctness (and display results, if specified)
+  int compare = CompareDeviceResults(h_reference, d_out, num_items, true, g_verbose);
+  printf("\t%s", compare ? "FAIL" : "PASS");
+  AssertEquals(0, compare);
+
+  // Cleanup
+  if (h_in)
+  {
+    delete[] h_in;
+  }
+  if (h_reference)
+  {
+    delete[] h_reference;
+  }
+  if (d_in)
+  {
+    CubDebugExit(g_allocator.DeviceFree(d_in));
+  }
+  if (d_out)
+  {
+    CubDebugExit(g_allocator.DeviceFree(d_out));
+  }
+  if (d_temp_storage)
+  {
+    CubDebugExit(g_allocator.DeviceFree(d_temp_storage));
+  }
+
+  printf("\n\n");
+
   return 0;
 }

--- a/cub/test/catch2_test_device_segmented_scan_env.cu
+++ b/cub/test/catch2_test_device_segmented_scan_env.cu
@@ -24,6 +24,7 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedScan::InclusiveSegmentedScanInit, dev
 
 #include <cuda/__execution/determinism.h>
 #include <cuda/__execution/require.h>
+#include <cuda/__execution/tune.h>
 
 #include <c2h/catch2_test_helper.h>
 
@@ -541,3 +542,123 @@ C2H_TEST("Device segmented inclusive scan init with separate offsets uses enviro
   thrust::device_vector<int> expected{101, 103, 106, sentinel, 104, 109, sentinel, 106, 113, 121};
   REQUIRE(d_out == expected);
 }
+
+#if TEST_LAUNCH != 1
+
+// A policy selector that forces a specific block size. We deliberately use direct block load/store so that the chosen
+// block size is valid for any of the values exercised below.
+template <unsigned int BlockThreads>
+struct segmented_scan_tuning
+{
+  _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const
+    -> cub::detail::segmented_scan::segmented_scan_policy
+  {
+    return cub::detail::segmented_scan::segmented_scan_policy{cub::detail::segmented_scan::block_segmented_scan_policy{
+      static_cast<int>(BlockThreads),
+      1,
+      cub::BLOCK_LOAD_DIRECT,
+      cub::LOAD_DEFAULT,
+      cub::BLOCK_STORE_DIRECT,
+      cub::BLOCK_SCAN_WARP_SCANS,
+      512}};
+  }
+};
+
+using block_sizes =
+  c2h::type_list<cuda::std::integral_constant<unsigned int, 64>, cuda::std::integral_constant<unsigned int, 128>>;
+
+// The "Sum" APIs do not take a user operator, so we extract the launched block size through a custom input iterator
+// (block_size_extracting_constant_iterator). The "Scan" APIs take a user scan operator, so we wrap a plus<> in
+// block_size_extracting_op which both records the block size and computes the expected result.
+
+C2H_TEST("Device segmented exclusive sum can be tuned", "[segmented_scan][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  ::cuda::std::int64_t num_segments        = 3;
+  thrust::device_vector<int> d_offsets     = {0, 4, 7, 9};
+  auto d_offsets_it                        = thrust::raw_pointer_cast(d_offsets.data());
+  thrust::device_vector<int> d_out(9);
+  c2h::device_vector<unsigned int> d_block_size(1);
+  auto d_in = block_size_extracting_constant_iterator(1, thrust::raw_pointer_cast(d_block_size.data()));
+  auto env  = cuda::execution::tune(segmented_scan_tuning<target_block_size>{});
+
+  device_segmented_exclusive_sum(d_in, d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, env);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("Device segmented inclusive sum can be tuned", "[segmented_scan][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  ::cuda::std::int64_t num_segments        = 3;
+  thrust::device_vector<int> d_offsets     = {0, 4, 7, 9};
+  auto d_offsets_it                        = thrust::raw_pointer_cast(d_offsets.data());
+  thrust::device_vector<int> d_out(9);
+  c2h::device_vector<unsigned int> d_block_size(1);
+  auto d_in = block_size_extracting_constant_iterator(1, thrust::raw_pointer_cast(d_block_size.data()));
+  auto env  = cuda::execution::tune(segmented_scan_tuning<target_block_size>{});
+
+  device_segmented_inclusive_sum(d_in, d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, env);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("Device segmented exclusive scan can be tuned", "[segmented_scan][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  ::cuda::std::int64_t num_segments        = 3;
+  thrust::device_vector<int> d_offsets     = {0, 4, 7, 9};
+  auto d_offsets_it                        = thrust::raw_pointer_cast(d_offsets.data());
+  thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
+  thrust::device_vector<int> d_out(d_in.size());
+  c2h::device_vector<unsigned int> d_block_size(1);
+  block_size_extracting_op<::cuda::std::plus<>> scan_op{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env = cuda::execution::tune(segmented_scan_tuning<target_block_size>{});
+
+  device_segmented_exclusive_scan(
+    d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, scan_op, 100, env);
+
+  thrust::device_vector<int> expected{100, 108, 114, 121, 100, 103, 103, 100, 101};
+  REQUIRE(d_out == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("Device segmented inclusive scan can be tuned", "[segmented_scan][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  ::cuda::std::int64_t num_segments        = 3;
+  thrust::device_vector<int> d_offsets     = {0, 4, 7, 9};
+  auto d_offsets_it                        = thrust::raw_pointer_cast(d_offsets.data());
+  thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
+  thrust::device_vector<int> d_out(d_in.size());
+  c2h::device_vector<unsigned int> d_block_size(1);
+  block_size_extracting_op<::cuda::std::plus<>> scan_op{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env = cuda::execution::tune(segmented_scan_tuning<target_block_size>{});
+
+  device_segmented_inclusive_scan(
+    d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, scan_op, env);
+
+  thrust::device_vector<int> expected{8, 14, 21, 26, 3, 3, 12, 1, 3};
+  REQUIRE(d_out == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("Device segmented inclusive scan init can be tuned", "[segmented_scan][device]", block_sizes)
+{
+  constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
+  ::cuda::std::int64_t num_segments        = 3;
+  thrust::device_vector<int> d_offsets     = {0, 4, 7, 9};
+  auto d_offsets_it                        = thrust::raw_pointer_cast(d_offsets.data());
+  thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
+  thrust::device_vector<int> d_out(d_in.size());
+  c2h::device_vector<unsigned int> d_block_size(1);
+  block_size_extracting_op<::cuda::std::plus<>> scan_op{thrust::raw_pointer_cast(d_block_size.data())};
+  auto env = cuda::execution::tune(segmented_scan_tuning<target_block_size>{});
+
+  device_segmented_inclusive_scan_init(
+    d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, scan_op, 100, env);
+
+  thrust::device_vector<int> expected{108, 114, 121, 126, 103, 103, 112, 101, 103};
+  REQUIRE(d_out == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+#endif // TEST_LAUNCH != 1


### PR DESCRIPTION
fixes https://github.com/NVIDIA/cccl/issues/7464?issue=NVIDIA%7Ccccl%7C8481

@bernhardmgruber  I am curious since I see no old tunings in `cub/cub/device/dispatch/tuning/tuning_segmented_scan.cuh` which sass diffs should I be checking?

No SASS diffs found at all in both:

  - cub.bench.segmented_scan.sum.base
  - cub.bench.segmented_scan.custom.base

for sm90
 