### PR TITLE
Avoid passing OOB data to scan operator in warpspeed scan

### DIFF
--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -599,8 +599,8 @@ struct warpspeed_scan_closure
     {
       if (is_first_tile)
       {
-        // The first thread cannot use scan_op because aggrExclusive holds garbage data. Also skip sumExclusive when this
-        // thread has no valid items to process in the last tile.
+        // The first thread cannot use scan_op because aggrExclusive holds garbage data. Also skip sumExclusive when
+        // this thread has no valid items to process in the last tile.
         if (squad.threadRank() == 0 || (IsLastTile && valid_items_this_thread == 0))
         {
           aggrExclusive = static_cast<AccumT>(real_init_value);

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -582,8 +582,8 @@ struct warpspeed_scan_closure
       {
         // Add the aggregates of preceding CTAs to the cumulative aggregate.
         AccumT regAggrExclusiveCta = refAggrExclusiveCtaR.data();
-        // aggrExclusive is invalid in warp_0/thread_0 and also for out-of-bounds threads in the last tile's last valid
-        // warp (where the partial warp scan produced garbage). Only combine with sumExclusive when it's valid.
+        // aggrExclusive is invalid in warp_0/thread_0, so only include it in other threads/warps. Skip it, when this
+        // thread has no valid items to process in the last tile.
         if (squad.threadRank() == 0 || (IsLastTile && valid_items_this_thread == 0))
         {
           aggrExclusive = regAggrExclusiveCta;
@@ -599,8 +599,8 @@ struct warpspeed_scan_closure
     {
       if (is_first_tile)
       {
-        // The first thread cannot use scan_op because aggrExclusive holds garbage data.
-        // Similarly, out-of-bounds threads in the last tile's last valid warp have garbage from the partial warp scan.
+        // The first thread cannot use scan_op because aggrExclusive holds garbage data. Also skip sumExclusive when this
+        // thread has no valid items to process in the last tile.
         if (squad.threadRank() == 0 || (IsLastTile && valid_items_this_thread == 0))
         {
           aggrExclusive = static_cast<AccumT>(real_init_value);

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -582,8 +582,16 @@ struct warpspeed_scan_closure
       {
         // Add the aggregates of preceding CTAs to the cumulative aggregate.
         AccumT regAggrExclusiveCta = refAggrExclusiveCtaR.data();
-        // aggrExclusive is invalid in warp_0/thread_0, so only include it in other threads/warps
-        aggrExclusive = squad.threadRank() == 0 ? regAggrExclusiveCta : scan_op(regAggrExclusiveCta, aggrExclusive);
+        // aggrExclusive is invalid in warp_0/thread_0 and also for out-of-bounds threads in the last tile's last valid
+        // warp (where the partial warp scan produced garbage). Only combine with sumExclusive when it's valid.
+        if (squad.threadRank() == 0 || (IsLastTile && valid_items_this_thread == 0))
+        {
+          aggrExclusive = regAggrExclusiveCta;
+        }
+        else
+        {
+          aggrExclusive = scan_op(regAggrExclusiveCta, aggrExclusive);
+        }
       }
     }
 
@@ -591,8 +599,9 @@ struct warpspeed_scan_closure
     {
       if (is_first_tile)
       {
-        // The first thread cannot use scan_op because aggrExclusive holds garbage data
-        if (squad.threadRank() == 0)
+        // The first thread cannot use scan_op because aggrExclusive holds garbage data.
+        // Similarly, out-of-bounds threads in the last tile's last valid warp have garbage from the partial warp scan.
+        if (squad.threadRank() == 0 || (IsLastTile && valid_items_this_thread == 0))
         {
           aggrExclusive = static_cast<AccumT>(real_init_value);
         }

--- a/thrust/testing/scan.cu
+++ b/thrust/testing/scan.cu
@@ -796,31 +796,38 @@ struct checking_identity
 
   _CCCL_HOST_DEVICE unsigned operator()([[maybe_unused]] unsigned a, [[maybe_unused]] unsigned b) const
   {
-    // only the SM100 tuning will pick the warpspeed implementation currently, so only verify on that architecture.
-    // < SM100 and SM120 will use the old scan implementation for this scan operator, which passes invalid data.
-    NV_DISPATCH_TARGET(
-      NV_PROVIDES_SM_120,
-      (), //
-      NV_PROVIDES_SM_100,
-      ({
-        _CCCL_ASSERT(a == sentinel, "Unexpected value in scan operator. Reading invalid data?");
-        _CCCL_ASSERT(b == sentinel, "Unexpected value in scan operator. Reading invalid data?");
-      }));
-
+    _CCCL_ASSERT(a == sentinel, "Unexpected value in scan operator. Reading invalid data?");
+    _CCCL_ASSERT(b == sentinel, "Unexpected value in scan operator. Reading invalid data?");
     return sentinel;
   }
 };
 
 void TestInclusiveScanForInvalidValues()
 {
-  const thrust::device_vector<unsigned> input(10'000, checking_identity::sentinel);
-  thrust::device_vector<unsigned> output(10'000, thrust::no_init);
+  using value_t = unsigned;
 
-  thrust::inclusive_scan(input.begin(), input.end(), output.begin(), checking_identity{});
-  ASSERT_EQUAL(input, output);
+#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+  // for the CUDA backend, only the warpspeed implementation does not call the scan operator on out-of-bounds data
+  cuda::compute_capability cc;
+  ASSERT_EQUAL(cub::detail::ptx_compute_cap(cc), cudaSuccess);
+  using policy_selector_t = cub::detail::scan::
+    policy_selector_from_types<const value_t*, value_t*, value_t, unsigned long long, checking_identity>;
+  if (policy_selector_t{}(cc).algorithm == cub::detail::scan::scan_algorithm::warpspeed)
+#endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+  {
+    for (int n : {1, 100, 10'000})
+    {
+      const thrust::device_vector<value_t> input(n, checking_identity::sentinel);
+      thrust::device_vector<value_t> output(n, thrust::no_init);
 
-  thrust::exclusive_scan(input.begin(), input.end(), output.begin(), checking_identity::sentinel, checking_identity{});
-  ASSERT_EQUAL(input, output);
+      thrust::inclusive_scan(input.begin(), input.end(), output.begin(), checking_identity{});
+      ASSERT_EQUAL(input, output);
+
+      thrust::exclusive_scan(
+        input.begin(), input.end(), output.begin(), checking_identity::sentinel, checking_identity{});
+      ASSERT_EQUAL(input, output);
+    }
+  }
 }
 DECLARE_UNITTEST(TestInclusiveScanForInvalidValues);
 


### PR DESCRIPTION
This was supposedly fixed in #8184, but QA filed NVBug 6156669, since they saw a failure. I could reproduce it.

This was not caught by CI because we don't have a CI that runs on SM100. The test was disabled on SM120, because of codegen issues with warpspeed scan for nvcc < 13.4.

This PR reformulates the unit test to we active whenever warpspeed scan is used as scan implementation (which also covers SM120 for nvcc >= 13.4)

The fix is that the scanAndStore warp at the last tile could have entirely empty warps not processing any valid items. The first thread of this warp should not try to include the lookback prefix or the initial value.

The fix was proposed by claude in a few minutes, I was surprised! It looks legit to me.

- [x] Benchmark
- [x] Fixes `thrust.test.scan` compiled for SM100 (running on SM120)
- [x] Fixes `thrust.test.scan` compiled for SM120 (running on SM120)

No pref regression of `cub.bench.scan.exclusive.sum.warpspeed.base` on B200:
```
## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |      I64      |      2^16      |  11.266 us |       1.01% |  11.268 us |       1.00% |   0.002 us |   0.02% |  🔵 SAME  |
|   I8    |      I64      |      2^20      |  13.031 us |       4.34% |  13.025 us |       4.41% |  -0.006 us |  -0.05% |  🔵 SAME  |
|   I8    |      I64      |      2^24      |  27.879 us |       2.38% |  27.881 us |       2.37% |   0.002 us |   0.01% |  🔵 SAME  |
|   I8    |      I64      |      2^28      | 213.789 us |       0.62% | 213.555 us |       0.60% |  -0.234 us |  -0.11% |  🔵 SAME  |
|   I8    |      I64      |      2^32      |   3.227 ms |       0.41% |   3.223 ms |       0.32% |  -3.947 us |  -0.12% |  🔵 SAME  |
|   I16   |      I64      |      2^16      |  11.154 us |       1.08% |  10.966 us |       4.43% |  -0.189 us |  -1.69% |  🟢 FAST  |
|   I16   |      I64      |      2^20      |  13.514 us |       4.72% |  13.437 us |       4.01% |  -0.077 us |  -0.57% |  🔵 SAME  |
|   I16   |      I64      |      2^24      |  27.695 us |       3.37% |  27.571 us |       3.64% |  -0.124 us |  -0.45% |  🔵 SAME  |
|   I16   |      I64      |      2^28      | 209.561 us |       0.57% | 209.896 us |       0.52% |   0.335 us |   0.16% |  🔵 SAME  |
|   I16   |      I64      |      2^32      |   3.227 ms |       1.44% |   3.230 ms |       1.32% |   2.683 us |   0.08% |  🔵 SAME  |
|   I32   |      I64      |      2^16      |  10.434 us |       9.55% |  10.144 us |       9.14% |  -0.290 us |  -2.78% |  🔵 SAME  |
|   I32   |      I64      |      2^20      |  13.859 us |       6.65% |  13.693 us |       6.85% |  -0.165 us |  -1.19% |  🔵 SAME  |
|   I32   |      I64      |      2^24      |  34.655 us |       3.79% |  34.441 us |       3.46% |  -0.214 us |  -0.62% |  🔵 SAME  |
|   I32   |      I64      |      2^28      | 318.133 us |       0.54% | 317.975 us |       0.52% |  -0.157 us |  -0.05% |  🔵 SAME  |
|   I32   |      I64      |      2^32      |   4.941 ms |       0.72% |   4.931 ms |       0.76% | -10.489 us |  -0.21% |  🔵 SAME  |
|   I64   |      I64      |      2^16      |  11.703 us |       7.30% |  11.585 us |       6.40% |  -0.118 us |  -1.01% |  🔵 SAME  |
|   I64   |      I64      |      2^20      |  16.985 us |       4.96% |  16.760 us |       5.76% |  -0.225 us |  -1.32% |  🔵 SAME  |
|   I64   |      I64      |      2^24      |  55.243 us |       2.26% |  55.042 us |       2.36% |  -0.201 us |  -0.36% |  🔵 SAME  |
|   I64   |      I64      |      2^28      | 620.181 us |       0.21% | 620.212 us |       0.23% |   0.031 us |   0.01% |  🔵 SAME  |
|   I64   |      I64      |      2^32      |  10.229 ms |       0.72% |  10.226 ms |       0.65% |  -2.681 us |  -0.03% |  🔵 SAME  |
|  I128   |      I64      |      2^16      |  13.323 us |       4.62% |  13.338 us |       4.44% |   0.014 us |   0.11% |  🔵 SAME  |
|  I128   |      I64      |      2^20      |  21.359 us |       2.20% |  21.512 us |       0.78% |   0.153 us |   0.72% |  🔵 SAME  |
|  I128   |      I64      |      2^24      | 145.284 us |       0.81% | 145.734 us |       0.79% |   0.450 us |   0.31% |  🔵 SAME  |
|  I128   |      I64      |      2^28      |   2.017 ms |       0.23% |   2.016 ms |       0.23% |  -0.742 us |  -0.04% |  🔵 SAME  |
|  I128   |      I64      |      2^32      |  31.738 ms |       0.04% |  31.742 ms |       0.04% |   3.821 us |   0.01% |  🔵 SAME  |
|   F32   |      I64      |      2^16      |  10.906 us |       7.14% |  10.810 us |       7.06% |  -0.095 us |  -0.87% |  🔵 SAME  |
|   F32   |      I64      |      2^20      |  14.390 us |       7.12% |  14.202 us |       7.21% |  -0.188 us |  -1.30% |  🔵 SAME  |
|   F32   |      I64      |      2^24      |  36.126 us |       2.88% |  35.883 us |       2.92% |  -0.242 us |  -0.67% |  🔵 SAME  |
|   F32   |      I64      |      2^28      | 317.072 us |       0.64% | 316.770 us |       0.64% |  -0.303 us |  -0.10% |  🔵 SAME  |
|   F32   |      I64      |      2^32      |   4.859 ms |       0.66% |   4.856 ms |       0.71% |  -2.787 us |  -0.06% |  🔵 SAME  |
|   F64   |      I64      |      2^16      |  11.307 us |       2.87% |  11.267 us |       1.79% |  -0.040 us |  -0.36% |  🔵 SAME  |
|   F64   |      I64      |      2^20      |  15.448 us |       2.75% |  15.386 us |       4.45% |  -0.062 us |  -0.40% |  🔵 SAME  |
|   F64   |      I64      |      2^24      |  58.312 us |       1.53% |  58.209 us |       1.76% |  -0.103 us |  -0.18% |  🔵 SAME  |
|   F64   |      I64      |      2^28      | 640.246 us |       0.24% | 640.147 us |       0.23% |  -0.099 us |  -0.02% |  🔵 SAME  |
|   F64   |      I64      |      2^32      |  10.019 ms |       0.18% |  10.016 ms |       0.19% |  -2.515 us |  -0.03% |  🔵 SAME  |
|   C32   |      I64      |      2^16      |  11.546 us |       6.19% |  11.568 us |       6.30% |   0.022 us |   0.19% |  🔵 SAME  |
|   C32   |      I64      |      2^20      |  15.168 us |       3.92% |  14.937 us |       3.87% |  -0.231 us |  -1.52% |  🔵 SAME  |
|   C32   |      I64      |      2^24      |  56.029 us |       1.81% |  56.026 us |       1.66% |  -0.002 us |  -0.00% |  🔵 SAME  |
|   C32   |      I64      |      2^28      | 625.004 us |       0.19% | 624.267 us |       0.17% |  -0.737 us |  -0.12% |  🔵 SAME  |
|   C32   |      I64      |      2^32      |   9.768 ms |       0.09% |   9.758 ms |       0.09% |  -9.578 us |  -0.10% |  🟢 FAST  |
```

Fixes: NVBug 6156669