### PR TITLE
[Backport to 3.4] Avoid passing OOB data to scan operator in warpspeed scan

### DIFF
--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -640,8 +640,16 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void kernelBody(
               {
                 // Add the sums of preceding CTAs to the cumulative sum.
                 AccumT regSumExclusiveCta = refSumExclusiveCtaR.data();
-                // sumExclusive is invalid in warp_0/thread_0, so only include it in other threads/warps
-                sumExclusive = squad.threadRank() == 0 ? regSumExclusiveCta : scan_op(regSumExclusiveCta, sumExclusive);
+                // sumExclusive is invalid in warp_0/thread_0, so only include it in other threads/warps. Skip it, when
+                // this thread has no valid items to process in the last tile.
+                if (squad.threadRank() == 0 || (is_last_tile_ic && valid_items_this_thread == 0))
+                {
+                  sumExclusive = regSumExclusiveCta;
+                }
+                else
+                {
+                  sumExclusive = scan_op(regSumExclusiveCta, sumExclusive);
+                }
               }
             }
 
@@ -649,8 +657,10 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void kernelBody(
             {
               if (is_first_tile)
               {
-                // The first thread cannot use scan_op because sumExclusive holds garbage data
-                if (squad.threadRank() == 0)
+                // The first thread cannot use scan_op because sumExclusive holds garbage data. Also skip sumExclusive
+                // when
+                // this thread has no valid items to process in the last tile.
+                if (squad.threadRank() == 0 || (is_last_tile_ic && valid_items_this_thread == 0))
                 {
                   sumExclusive = static_cast<AccumT>(real_init_value);
                 }

--- a/thrust/testing/scan.cu
+++ b/thrust/testing/scan.cu
@@ -796,31 +796,38 @@ struct checking_identity
 
   _CCCL_HOST_DEVICE unsigned operator()([[maybe_unused]] unsigned a, [[maybe_unused]] unsigned b) const
   {
-    // only the SM100 tuning will pick the warpspeed implementation currently, so only verify on that architecture.
-    // < SM100 and SM120 will use the old scan implementation for this scan operator, which passes invalid data.
-    NV_DISPATCH_TARGET(
-      NV_PROVIDES_SM_120,
-      (), //
-      NV_PROVIDES_SM_100,
-      ({
-        _CCCL_ASSERT(a == sentinel, "Unexpected value in scan operator. Reading invalid data?");
-        _CCCL_ASSERT(b == sentinel, "Unexpected value in scan operator. Reading invalid data?");
-      }));
-
+    _CCCL_ASSERT(a == sentinel, "Unexpected value in scan operator. Reading invalid data?");
+    _CCCL_ASSERT(b == sentinel, "Unexpected value in scan operator. Reading invalid data?");
     return sentinel;
   }
 };
 
 void TestInclusiveScanForInvalidValues()
 {
-  const thrust::device_vector<unsigned> input(10'000, checking_identity::sentinel);
-  thrust::device_vector<unsigned> output(10'000, thrust::no_init);
+  using value_t = unsigned;
 
-  thrust::inclusive_scan(input.begin(), input.end(), output.begin(), checking_identity{});
-  ASSERT_EQUAL(input, output);
+#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+  // for the CUDA backend, only the warpspeed implementation does not call the scan operator on out-of-bounds data
+  cuda::compute_capability cc;
+  ASSERT_EQUAL(cub::detail::ptx_compute_cap(cc), cudaSuccess);
+  using policy_selector_t = cub::detail::scan::
+    policy_selector_from_types<const value_t*, value_t*, value_t, unsigned long long, checking_identity>;
+  if (policy_selector_t{}(cc).algorithm == cub::detail::scan::scan_algorithm::warpspeed)
+#endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+  {
+    for (int n : {1, 100, 10'000})
+    {
+      const thrust::device_vector<value_t> input(n, checking_identity::sentinel);
+      thrust::device_vector<value_t> output(n, thrust::no_init);
 
-  thrust::exclusive_scan(input.begin(), input.end(), output.begin(), checking_identity::sentinel, checking_identity{});
-  ASSERT_EQUAL(input, output);
+      thrust::inclusive_scan(input.begin(), input.end(), output.begin(), checking_identity{});
+      ASSERT_EQUAL(input, output);
+
+      thrust::exclusive_scan(
+        input.begin(), input.end(), output.begin(), checking_identity::sentinel, checking_identity{});
+      ASSERT_EQUAL(input, output);
+    }
+  }
 }
 DECLARE_UNITTEST(TestInclusiveScanForInvalidValues);
 


### PR DESCRIPTION
cherry-picked from c3873febab82aafb913d2091a9d694bd6336c8e0