### PR TITLE
Allow public tuning of `cub::DeviceScan::*ByKey`

### DIFF
--- a/cub/benchmarks/bench/scan/exclusive/by_key.cu
+++ b/cub/benchmarks/bench/scan/exclusive/by_key.cu
@@ -17,8 +17,7 @@
 #if !TUNE_BASE
 struct bench_scan_by_key_policy_selector
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::scan_by_key::scan_by_key_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::ScanByKeyPolicy
   {
     return {TUNE_THREADS,
             TUNE_ITEMS,

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -101,6 +101,21 @@ CUB_NAMESPACE_BEGIN
 //!      :start-after: example-begin exclusive-sum-tuning
 //!      :end-before: example-end exclusive-sum-tuning
 //!
+//! All ByKey algorithms in DeviceScan that accept an environment can be tuned by passing a custom :ref:`policy
+//! selector <cub-policy-selectors>` that returns a @ref ScanByKeyPolicy, as shown in the example below:
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_scan_by_key_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin exclusive-sum-by-key-policy-selector
+//!      :end-before: example-end exclusive-sum-by-key-policy-selector
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_scan_by_key_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin exclusive-sum-by-key-tuning
+//!      :end-before: example-end exclusive-sum-by-key-tuning
+//!
 //! @endrst
 struct DeviceScan
 {
@@ -231,8 +246,8 @@ struct DeviceScan
                                                       cub::detail::it_value_t<ValuesInputIteratorT>,
                                                       ScanOpT>;
 
-    using policy_selector_t = ::cuda::std::execution::
-      __query_result_or_t<TuningEnvT, detail::scan_by_key::scan_by_key_policy, default_policy_selector_t>;
+    using policy_selector_t =
+      ::cuda::std::execution::__query_result_or_t<TuningEnvT, ScanByKeyPolicy, default_policy_selector_t>;
 
     // we would not need to override the accumulator type, but we must ensure it's the same as for the policy here
     return detail::scan_by_key::dispatch</* OverrideAccumT = */ accum_t>(

--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -136,7 +136,7 @@ __launch_bounds__(int(current_policy<PolicySelector>().threads_per_block))
     _CCCL_GRID_CONSTANT const InitValueT init_value,
     _CCCL_GRID_CONSTANT const OffsetT num_items)
 {
-  static constexpr scan_by_key_policy policy = current_policy<PolicySelector>();
+  static constexpr ScanByKeyPolicy policy = current_policy<PolicySelector>();
 
   using scan_by_key_policy_t = AgentScanByKeyPolicy<
     policy.threads_per_block,
@@ -145,9 +145,7 @@ __launch_bounds__(int(current_policy<PolicySelector>().threads_per_block))
     policy.load_modifier,
     policy.scan_algorithm,
     policy.store_algorithm,
-    delay_constructor_t<policy.delay_constructor.kind,
-                        policy.delay_constructor.delay,
-                        policy.delay_constructor.l2_write_latency>>;
+    delay_constructor_t<policy.lookback_delay.kind, policy.lookback_delay.delay, policy.lookback_delay.l2_write_latency>>;
 
   // Thread block type for scanning input tiles
   using AgentScanByKeyT = detail::scan_by_key::AgentScanByKey<
@@ -408,7 +406,7 @@ struct DispatchScanByKey
       , launcher_factory(launcher_factory)
   {}
 
-  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t __invoke(detail::scan_by_key::scan_by_key_policy active_policy)
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t __invoke(ScanByKeyPolicy active_policy)
   {
     // Get device ordinal
     int device_ordinal;
@@ -653,7 +651,7 @@ struct DispatchScanByKey
                  }))
 #endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
 
-    const detail::scan_by_key::scan_by_key_policy active_policy = policy_selector(cc);
+    const ScanByKeyPolicy active_policy = policy_selector(cc);
 
     return DispatchScanByKey<KeysInputIteratorT,
                              ValuesInputIteratorT,
@@ -718,6 +716,9 @@ template <
       OffsetT,
       AccumT>,
   typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
+#if _CCCL_HAS_CONCEPTS()
+  requires scan_by_key_policy_selector<PolicySelector>
+#endif // _CCCL_HAS_CONCEPTS()
 CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
@@ -758,7 +759,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
     using MaxPolicy = void;
   };
 
-  const detail::scan_by_key::scan_by_key_policy active_policy = policy_selector(cc);
+  const ScanByKeyPolicy active_policy = policy_selector(cc);
 
   return DispatchScanByKey<KeysInputIteratorT,
                            ValuesInputIteratorT,

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -1059,7 +1059,7 @@ struct policy_selector_from_hub
 
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>
-concept scan_by_key_policy_selector = ::cub::detail::policy_selector<T, ScanByKeyPolicy>;
+concept scan_by_key_policy_selector = detail::policy_selector<T, ScanByKeyPolicy>;
 #endif // _CCCL_HAS_CONCEPTS()
 
 struct policy_selector

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -32,42 +32,46 @@
 
 CUB_NAMESPACE_BEGIN
 
-namespace detail::scan_by_key
+//! The tuning policy for all algorithms in @ref DeviceScan scan-by-key.
+struct ScanByKeyPolicy
 {
-struct scan_by_key_policy
-{
-  int threads_per_block;
-  int items_per_thread;
-  BlockLoadAlgorithm load_algorithm;
-  CacheLoadModifier load_modifier;
-  BlockStoreAlgorithm store_algorithm;
-  BlockScanAlgorithm scan_algorithm;
-  LookbackDelayPolicy delay_constructor;
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int items_per_thread; //!< Number of items processed per thread
+  BlockLoadAlgorithm load_algorithm; //!< The @ref BlockLoadAlgorithm used for loading items from global memory
+  CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
+  BlockStoreAlgorithm store_algorithm; //!< The @ref BlockStoreAlgorithm used for storing items to global memory
+  BlockScanAlgorithm scan_algorithm; //!< The @ref BlockScanAlgorithm used for scanning within a thread block
+  LookbackDelayPolicy lookback_delay; //!< The policy configuring the delay used in decoupled lookback
 
-  _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const scan_by_key_policy& lhs, const scan_by_key_policy& rhs)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const ScanByKeyPolicy& lhs, const ScanByKeyPolicy& rhs)
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
         && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
         && lhs.store_algorithm == rhs.store_algorithm && lhs.scan_algorithm == rhs.scan_algorithm
-        && lhs.delay_constructor == rhs.delay_constructor;
+        && lhs.lookback_delay == rhs.lookback_delay;
   }
 
-  _CCCL_HOST_DEVICE_API constexpr friend bool operator!=(const scan_by_key_policy& lhs, const scan_by_key_policy& rhs)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const ScanByKeyPolicy& lhs, const ScanByKeyPolicy& rhs)
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const scan_by_key_policy& p)
+  friend ::std::ostream& operator<<(::std::ostream& os, const ScanByKeyPolicy& p)
   {
     return os
-        << "scan_by_key_policy { .threads_per_block = " << p.threads_per_block
+        << "ScanByKeyPolicy { .threads_per_block = " << p.threads_per_block
         << ", .items_per_thread = " << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm
         << ", .load_modifier = " << p.load_modifier << ", .store_algorithm = " << p.store_algorithm
-        << ", .scan_algorithm = " << p.scan_algorithm << ", .delay_constructor = " << p.delay_constructor << " }";
+        << ", .scan_algorithm = " << p.scan_algorithm << ", .lookback_delay = " << p.lookback_delay << " }";
   }
 #endif // _CCCL_HOSTED()
 };
+
+namespace detail::scan_by_key
+{
 enum class primitive_accum
 {
   no,
@@ -1031,7 +1035,7 @@ struct policy_hub
 
 // TODO(griwes): remove in CCCL 4.0 when we drop the scan dispatcher after publishing the tuning API
 template <typename ActivePolicyT>
-_CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> scan_by_key_policy
+_CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> ScanByKeyPolicy
 {
   using policy_t = typename ActivePolicyT::ScanByKeyPolicyT;
   return {policy_t::BLOCK_THREADS,
@@ -1047,12 +1051,16 @@ _CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> scan_by_key_policy
 template <typename PolicyHub>
 struct policy_selector_from_hub
 {
-  [[nodiscard]] _CCCL_DEVICE_API constexpr auto operator()(::cuda::compute_capability /*cc*/) const
-    -> scan_by_key_policy
+  [[nodiscard]] _CCCL_DEVICE_API constexpr auto operator()(::cuda::compute_capability /*cc*/) const -> ScanByKeyPolicy
   {
     return convert_policy<typename PolicyHub::MaxPolicy::ActivePolicy>();
   }
 };
+
+#if _CCCL_HAS_CONCEPTS()
+template <typename T>
+concept scan_by_key_policy_selector = ::cub::detail::policy_selector<T, ScanByKeyPolicy>;
+#endif // _CCCL_HAS_CONCEPTS()
 
 struct policy_selector
 {
@@ -1068,8 +1076,7 @@ struct policy_selector
   type_t accum_type;
   op_kind_t operation_t;
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
-    -> scan_by_key_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> ScanByKeyPolicy
   {
     const bool value_is_primitive_or_trivially_copyable = value_is_primitive || value_is_trivially_copyable;
     const bool accum_is_primitive_or_trivially_copyable = accum_is_primitive || accum_is_trivially_copyable;
@@ -1081,7 +1088,7 @@ struct policy_selector
     auto default_policy =
       [&](CacheLoadModifier load_modifier,
           int delay_ctor_key_size,
-          bool delay_ctor_key_is_primitive_or_trivially_copyable) -> scan_by_key_policy {
+          bool delay_ctor_key_is_primitive_or_trivially_copyable) -> ScanByKeyPolicy {
       const auto items_per_thread =
         max_input_bytes <= 8
           ? 9
@@ -1914,8 +1921,7 @@ struct policy_selector
 template <typename KeyT, typename AccumT, typename ValueT, typename ScanOpT>
 struct policy_selector_from_types
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
-    -> scan_by_key_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> ScanByKeyPolicy
   {
     return policy_selector{
       static_cast<int>(sizeof(KeyT)),
@@ -1931,6 +1937,10 @@ struct policy_selector_from_types
       classify_op<ScanOpT>}(cc);
   }
 };
+
+#if _CCCL_HAS_CONCEPTS()
+static_assert(scan_by_key_policy_selector<policy_selector>);
+#endif // _CCCL_HAS_CONCEPTS()
 } // namespace detail::scan_by_key
 
 CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -44,7 +44,7 @@ struct ScanByKeyPolicy
   LookbackDelayPolicy lookback_delay; //!< The policy configuring the delay used in decoupled lookback
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const ScanByKeyPolicy& lhs, const ScanByKeyPolicy& rhs)
+  operator==(const ScanByKeyPolicy& lhs, const ScanByKeyPolicy& rhs) noexcept
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
         && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
@@ -53,7 +53,7 @@ struct ScanByKeyPolicy
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const ScanByKeyPolicy& lhs, const ScanByKeyPolicy& rhs)
+  operator!=(const ScanByKeyPolicy& lhs, const ScanByKeyPolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -32,7 +32,7 @@
 
 CUB_NAMESPACE_BEGIN
 
-//! The tuning policy for all algorithms in @ref DeviceScan scan-by-key.
+//! The tuning policy for all ByKey algorithms in @ref DeviceScan.
 struct ScanByKeyPolicy
 {
   int threads_per_block; //!< Number of threads in a CUDA block

--- a/cub/test/catch2_test_device_scan_by_key_env.cu
+++ b/cub/test/catch2_test_device_scan_by_key_env.cu
@@ -131,7 +131,7 @@ TEST_CASE("Device scan inclusive-scan-by-key works with default environment", "[
 template <int BlockThreads>
 struct scan_by_key_tuning
 {
-  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::detail::scan_by_key::scan_by_key_policy
+  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::ScanByKeyPolicy
   {
     return {BlockThreads,
             1,
@@ -347,3 +347,39 @@ C2H_TEST("Device scan inclusive-scan-by-key uses environment", "[scan][by_key][d
   thrust::device_vector<float> expected{8.0f, 14.0f, 7.0f, 12.0f, 15.0f, 0.0f, 9.0f};
   REQUIRE(d_out == expected);
 }
+
+#if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
+C2H_TEST("ScanByKeyPolicy", "[scan][by_key][device]")
+{
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::ScanByKeyPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ScanByKeyPolicy>);
+
+  // aggregate init
+  constexpr auto p1 = cub::ScanByKeyPolicy{
+    256,
+    11,
+    cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+    cub::CacheLoadModifier::LOAD_DEFAULT,
+    cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+    cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING,
+    cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 832, 1165}};
+
+#  if _CCCL_STD_VER >= 2020
+  // designated init
+  constexpr auto p2 = cub::ScanByKeyPolicy{
+    .threads_per_block = 256,
+    .items_per_thread  = 11,
+    .load_algorithm    = cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+    .load_modifier     = cub::CacheLoadModifier::LOAD_DEFAULT,
+    .store_algorithm   = cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+    .scan_algorithm    = cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING,
+    .lookback_delay    = cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 832, 1165}};
+#  else // _CCCL_STD_VER >= 2020
+  constexpr auto p2 = p1;
+#  endif // _CCCL_STD_VER >= 2020
+
+  // comparison
+  STATIC_REQUIRE(p1 == p2);
+  STATIC_REQUIRE_FALSE(p1 != p2);
+}
+#endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_scan_by_key_env_api.cu
+++ b/cub/test/catch2_test_device_scan_by_key_env_api.cu
@@ -129,3 +129,49 @@ C2H_TEST("cub::DeviceScan::InclusiveScanByKey accepts stream environment", "[sca
   REQUIRE(error == cudaSuccess);
   REQUIRE(output == expected);
 }
+
+#if _CCCL_STD_VER >= 2020
+
+// example-begin exclusive-sum-by-key-policy-selector
+struct ScanByKeyPolicySelector
+{
+  __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::ScanByKeyPolicy
+  {
+    return {.threads_per_block = 256,
+            .items_per_thread  = cc > cuda::compute_capability{9, 0} ? 15 : 12,
+            .load_algorithm    = cub::BLOCK_LOAD_WARP_TRANSPOSE,
+            .load_modifier     = cub::LOAD_DEFAULT,
+            .store_algorithm   = cub::BLOCK_STORE_WARP_TRANSPOSE,
+            .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
+            .lookback_delay    = cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 832, 1165}};
+  }
+};
+// example-end exclusive-sum-by-key-policy-selector
+
+C2H_TEST("cub::DeviceScan::ExclusiveSumByKey env-based API with tuning", "[scan][by_key][env]")
+{
+  // example-begin exclusive-sum-by-key-tuning
+  auto keys   = thrust::device_vector<int>{0, 0, 1, 1, 1, 2, 2};
+  auto input  = thrust::device_vector<float>{8.0f, 6.0f, 7.0f, 5.0f, 3.0f, 0.0f, 9.0f};
+  auto output = thrust::device_vector<float>(7, thrust::no_init);
+
+  const auto error = cub::DeviceScan::ExclusiveSumByKey(
+    keys.begin(),
+    input.begin(),
+    output.begin(),
+    static_cast<int>(input.size()),
+    cuda::std::equal_to<>{},
+    cuda::execution::tune(ScanByKeyPolicySelector{}));
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceScan::ExclusiveSumByKey failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<float> expected{0.0f, 8.0f, 0.0f, 7.0f, 12.0f, 0.0f, 0.0f};
+  // example-end exclusive-sum-by-key-tuning
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(output == expected);
+}
+
+#endif // _CCCL_STD_VER >= 2020


### PR DESCRIPTION
- [x] Merge before: #8853
- [x] Bikeshedding

Fixes: #8852

### New public entities

 | Entity | Members |                                                                                                                                                                                               
  |--------|---------|                                                                                                                                                                                               
  | `cub::ScanByKeyPolicy` | `threads_per_block`, `items_per_thread`, `load_algorithm`, `load_modifier`, `store_algorithm`, `scan_algorithm`, `lookback_delay` |    