### PR TITLE
[libcu++] Fix use of exception keywords

### DIFF
--- a/libcudacxx/include/cuda/std/__pstl/cuda/copy_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/copy_if.h
@@ -144,7 +144,7 @@ struct __pstl_dispatch<__pstl_algorithm::__copy_if, __execution_backend::__cuda>
         }
         else
         {
-          throw;
+          _CCCL_RETHROW;
         }
       }
       _CCCL_CATCH_FALLTHROUGH

--- a/libcudacxx/include/cuda/std/__pstl/cuda/sort.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/sort.h
@@ -169,7 +169,7 @@ struct __pstl_dispatch<__pstl_algorithm::__sort, __execution_backend::__cuda>
   {
     if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>)
     {
-      try
+      _CCCL_TRY
       {
         if constexpr (CUB_NS_QUALIFIER::__can_use_radix_sort<_InputIterator, _BinaryPredicate> //
                       && __can_to_address<_InputIterator>)
@@ -182,7 +182,7 @@ struct __pstl_dispatch<__pstl_algorithm::__sort, __execution_backend::__cuda>
           __merge_sort_impl(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
         }
       }
-      catch (const ::cuda::cuda_error& __err)
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
         if (__err.status() == cudaErrorMemoryAllocation)
         {
@@ -190,9 +190,10 @@ struct __pstl_dispatch<__pstl_algorithm::__sort, __execution_backend::__cuda>
         }
         else
         {
-          throw __err;
+          _CCCL_RETHROW;
         }
       }
+      _CCCL_CATCH_FALLTHROUGH
     }
     else
     {


### PR DESCRIPTION
Replace them with our exception macros instead.