### PR TITLE
Add warp-aggregated CUB block histogram algorithms

### DIFF
--- a/cub/benchmarks/bench/block_histogram/algorithms.cu
+++ b/cub/benchmarks/bench/block_histogram/algorithms.cu
@@ -3,11 +3,14 @@
 
 #include <cub/block/block_histogram.cuh>
 
-#include <cstddef>
-#include <cstdint>
+#include <cuda/std/cstddef>
+#include <cuda/std/cstdint>
+
 #include <stdexcept>
 #include <string>
 
+#include <cuda_runtime_api.h>
+#include <device_side_benchmark.cuh>
 #include <nvbench_helper.cuh>
 
 enum class block_histogram_algorithm
@@ -15,6 +18,13 @@ enum class block_histogram_algorithm
   atomic,
   warp_aggregated,
   sort,
+};
+
+enum class sample_pattern
+{
+  single_bin,
+  skewed,
+  uniform,
 };
 
 block_histogram_algorithm parse_algorithm(const std::string& name)
@@ -35,88 +45,161 @@ block_histogram_algorithm parse_algorithm(const std::string& name)
   throw std::runtime_error("Unsupported Algorithm axis value");
 }
 
-template <typename SampleT,
-          typename CounterT,
-          int BlockThreads,
-          int ItemsPerThread,
-          int Bins,
-          cub::BlockHistogramAlgorithm Algorithm>
-__global__ void block_histogram_kernel(const SampleT* input, CounterT* histograms)
+sample_pattern parse_sample_pattern(const std::string& name)
 {
-  using block_histogram_t = cub::BlockHistogram<SampleT, BlockThreads, ItemsPerThread, Bins, Algorithm>;
-
-  __shared__ typename block_histogram_t::TempStorage temp_storage;
-
-  SampleT items[ItemsPerThread];
-  const auto tile_base = static_cast<std::size_t>(blockIdx.x) * BlockThreads * ItemsPerThread;
-
-  _CCCL_PRAGMA_UNROLL_FULL()
-  for (int item = 0; item < ItemsPerThread; ++item)
+  if (name == "single_bin")
   {
-    items[item] = input[tile_base + threadIdx.x + item * BlockThreads];
+    return sample_pattern::single_bin;
+  }
+  if (name == "skewed")
+  {
+    return sample_pattern::skewed;
+  }
+  if (name == "uniform")
+  {
+    return sample_pattern::uniform;
   }
 
-  CounterT* block_histogram = histograms + static_cast<std::size_t>(blockIdx.x) * Bins;
-  block_histogram_t(temp_storage).Histogram(items, block_histogram);
+  throw std::runtime_error("Unsupported SamplePattern axis value");
 }
+
+template <int BlockThreads, int Bins, sample_pattern Pattern, typename SampleT>
+_CCCL_DEVICE_API _CCCL_FORCEINLINE SampleT make_sample(int item)
+{
+  constexpr int warp_threads = cub::detail::warp_threads;
+  const int lane             = threadIdx.x % warp_threads;
+  const int striped_offset   = threadIdx.x + item * BlockThreads;
+
+  if constexpr (Pattern == sample_pattern::single_bin)
+  {
+    return SampleT{0};
+  }
+  else if constexpr (Pattern == sample_pattern::skewed)
+  {
+    return static_cast<SampleT>(lane < 24 ? 0 : striped_offset % Bins);
+  }
+  else
+  {
+    return static_cast<SampleT>(striped_offset % Bins);
+  }
+}
+
+template <typename CounterT,
+          int BlockThreads,
+          int ItemsPerThread,
+          int Bins,
+          cub::BlockHistogramAlgorithm Algorithm,
+          sample_pattern Pattern>
+struct benchmark_op_t
+{
+  template <typename SampleT>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE SampleT operator()(SampleT thread_data) const
+  {
+    using block_histogram_t = cub::BlockHistogram<SampleT, BlockThreads, ItemsPerThread, Bins, Algorithm>;
+
+    static_cast<void>(thread_data);
+
+    __shared__ typename block_histogram_t::TempStorage temp_storage;
+    __shared__ CounterT histogram[Bins];
+
+    SampleT items[ItemsPerThread];
+
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int item = 0; item < ItemsPerThread; ++item)
+    {
+      items[item] = make_sample<BlockThreads, Bins, Pattern, SampleT>(item);
+    }
+
+    block_histogram_t(temp_storage).Histogram(items, histogram);
+    __syncthreads();
+
+    const auto sink_bin = (threadIdx.x + blockIdx.x * blockDim.x) % Bins;
+    return static_cast<SampleT>(histogram[sink_bin]);
+  }
+};
 
 template <typename SampleT,
           typename CounterT,
           int BlockThreads,
           int ItemsPerThread,
           int Bins,
-          cub::BlockHistogramAlgorithm Algorithm>
-void run_algorithm(nvbench::state& state, const SampleT* input, CounterT* histograms, int num_blocks)
+          cub::BlockHistogramAlgorithm Algorithm,
+          sample_pattern Pattern>
+void run_algorithm(nvbench::state& state)
 {
-  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    block_histogram_kernel<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, Algorithm>
-      <<<num_blocks, BlockThreads, 0, launch.get_stream().get_stream()>>>(input, histograms);
+  constexpr int unroll_factor = 32;
+  using action_t              = benchmark_op_t<CounterT, BlockThreads, ItemsPerThread, Bins, Algorithm, Pattern>;
+  const auto& kernel          = benchmark_kernel<BlockThreads, unroll_factor, action_t, SampleT>;
+  const int num_sms           = state.get_device().value().get_number_of_sms();
+  int max_blocks_per_sm       = 0;
+
+  NVBENCH_CUDA_CALL_NOEXCEPT(
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_blocks_per_sm, kernel, BlockThreads, 0));
+
+  const int grid_size = max_blocks_per_sm * num_sms;
+  state.add_element_count(
+    static_cast<::cuda::std::size_t>(grid_size) * static_cast<::cuda::std::size_t>(BlockThreads)
+    * static_cast<::cuda::std::size_t>(ItemsPerThread) * static_cast<::cuda::std::size_t>(unroll_factor));
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch&) {
+    kernel<<<grid_size, BlockThreads>>>(action_t{});
   });
 }
 
+template <typename SampleT,
+          typename CounterT,
+          int BlockThreads,
+          int ItemsPerThread,
+          int Bins,
+          cub::BlockHistogramAlgorithm Algorithm>
+void dispatch_pattern(nvbench::state& state, sample_pattern pattern)
+{
+  switch (pattern)
+  {
+    case sample_pattern::single_bin:
+      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, Algorithm, sample_pattern::single_bin>(
+        state);
+      return;
+    case sample_pattern::skewed:
+      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, Algorithm, sample_pattern::skewed>(state);
+      return;
+    case sample_pattern::uniform:
+      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, Algorithm, sample_pattern::uniform>(state);
+      return;
+  }
+}
+
 template <typename SampleT, typename CounterT, int BlockThreads, int ItemsPerThread, int Bins>
-void dispatch_algorithm(
-  nvbench::state& state, block_histogram_algorithm algorithm, const SampleT* input, CounterT* histograms, int num_blocks)
+void dispatch_algorithm(nvbench::state& state, block_histogram_algorithm algorithm, sample_pattern pattern)
 {
   switch (algorithm)
   {
     case block_histogram_algorithm::atomic:
-      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_ATOMIC>(
-        state, input, histograms, num_blocks);
+      dispatch_pattern<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_ATOMIC>(state, pattern);
       return;
     case block_histogram_algorithm::warp_aggregated:
-      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED>(
-        state, input, histograms, num_blocks);
+      dispatch_pattern<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED>(
+        state, pattern);
       return;
     case block_histogram_algorithm::sort:
-      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_SORT>(
-        state, input, histograms, num_blocks);
+      dispatch_pattern<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_SORT>(state, pattern);
       return;
   }
 }
 
 template <typename SampleT, typename CounterT, int BlockThreads, int ItemsPerThread>
-void dispatch_bins(
-  nvbench::state& state,
-  block_histogram_algorithm algorithm,
-  int bins,
-  const SampleT* input,
-  CounterT* histograms,
-  int num_blocks)
+void dispatch_bins(nvbench::state& state, block_histogram_algorithm algorithm, sample_pattern pattern, int bins)
 {
   switch (bins)
   {
     case 32:
-      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 32>(
-        state, algorithm, input, histograms, num_blocks);
+      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 32>(state, algorithm, pattern);
       return;
     case 128:
-      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 128>(
-        state, algorithm, input, histograms, num_blocks);
+      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 128>(state, algorithm, pattern);
       return;
     case 2048:
-      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 2048>(
-        state, algorithm, input, histograms, num_blocks);
+      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 2048>(state, algorithm, pattern);
       return;
   }
 
@@ -125,24 +208,18 @@ void dispatch_bins(
 
 template <typename SampleT, typename CounterT, int BlockThreads>
 void dispatch_items(
-  nvbench::state& state,
-  int items_per_thread,
-  int bins,
-  block_histogram_algorithm algorithm,
-  const SampleT* input,
-  CounterT* histograms,
-  int num_blocks)
+  nvbench::state& state, block_histogram_algorithm algorithm, sample_pattern pattern, int bins, int items_per_thread)
 {
   switch (items_per_thread)
   {
     case 1:
-      dispatch_bins<SampleT, CounterT, BlockThreads, 1>(state, algorithm, bins, input, histograms, num_blocks);
+      dispatch_bins<SampleT, CounterT, BlockThreads, 1>(state, algorithm, pattern, bins);
       return;
     case 4:
-      dispatch_bins<SampleT, CounterT, BlockThreads, 4>(state, algorithm, bins, input, histograms, num_blocks);
+      dispatch_bins<SampleT, CounterT, BlockThreads, 4>(state, algorithm, pattern, bins);
       return;
     case 8:
-      dispatch_bins<SampleT, CounterT, BlockThreads, 8>(state, algorithm, bins, input, histograms, num_blocks);
+      dispatch_bins<SampleT, CounterT, BlockThreads, 8>(state, algorithm, pattern, bins);
       return;
   }
 
@@ -155,30 +232,15 @@ void block_histogram_algorithms(nvbench::state& state, nvbench::type_list<Sample
   constexpr int block_threads = 256;
 
   const auto algorithm       = parse_algorithm(state.get_string("Algorithm"));
-  const auto entropy         = str_to_entropy(state.get_string("Entropy"));
+  const auto pattern         = parse_sample_pattern(state.get_string("SamplePattern"));
   const int bins             = static_cast<int>(state.get_int64("Bins"));
   const int items_per_thread = static_cast<int>(state.get_int64("ItemsPerThread{io}"));
-  const int num_blocks       = static_cast<int>(state.get_int64("Blocks"));
-  const auto items_per_block = block_threads * items_per_thread;
-  const auto elements        = static_cast<std::size_t>(num_blocks) * static_cast<std::size_t>(items_per_block);
-  const auto histogram_items = static_cast<std::size_t>(num_blocks) * static_cast<std::size_t>(bins);
 
-  thrust::device_vector<SampleT> input = generate(elements, entropy, SampleT{0}, static_cast<SampleT>(bins - 1));
-  thrust::device_vector<CounterT> histograms(histogram_items);
-
-  const SampleT* d_input = thrust::raw_pointer_cast(input.data());
-  CounterT* d_histograms = thrust::raw_pointer_cast(histograms.data());
-
-  state.add_element_count(elements);
-  state.add_global_memory_reads<SampleT>(elements, "InputSize");
-  state.add_global_memory_writes<CounterT>(histogram_items, "HistogramSize");
-
-  dispatch_items<SampleT, CounterT, block_threads>(
-    state, items_per_thread, bins, algorithm, d_input, d_histograms, num_blocks);
+  dispatch_items<SampleT, CounterT, block_threads>(state, algorithm, pattern, bins, items_per_thread);
 }
 
-using sample_types  = nvbench::type_list<std::int32_t>;
-using counter_types = nvbench::type_list<std::int32_t>;
+using sample_types  = nvbench::type_list<::cuda::std::int32_t>;
+using counter_types = nvbench::type_list<::cuda::std::int32_t>;
 
 NVBENCH_BENCH_TYPES(block_histogram_algorithms, NVBENCH_TYPE_AXES(sample_types, counter_types))
   .set_name("base")
@@ -186,5 +248,4 @@ NVBENCH_BENCH_TYPES(block_histogram_algorithms, NVBENCH_TYPE_AXES(sample_types, 
   .add_string_axis("Algorithm", {"atomic", "warp_aggregated", "sort"})
   .add_int64_axis("ItemsPerThread{io}", {1, 4, 8})
   .add_int64_axis("Bins", {32, 128, 2048})
-  .add_int64_axis("Blocks", {4096, 16384})
-  .add_string_axis("Entropy", {"0.000", "0.201", "1.000"});
+  .add_string_axis("SamplePattern", {"single_bin", "skewed", "uniform"});

--- a/cub/benchmarks/bench/block_histogram/algorithms.cu
+++ b/cub/benchmarks/bench/block_histogram/algorithms.cu
@@ -30,6 +30,7 @@ enum class benchmark_mode
 {
   occupancy,
   fixed,
+  // Used by the separate latency benchmark, not by the BenchmarkMode axis.
   latency,
   full_bounds,
 };
@@ -194,8 +195,9 @@ void run_algorithm(nvbench::state& state)
 
     if constexpr (Mode == benchmark_mode::full_bounds)
     {
-      constexpr int max_sm_warps              = 48;
-      constexpr int full_bounds_max_sm_blocks = (max_sm_warps * cub::detail::warp_threads) / BlockThreads;
+      // Use a launch-bound target that is valid for the oldest SMs in the benchmark matrix.
+      constexpr int resident_threads_per_sm   = 1024;
+      constexpr int full_bounds_max_sm_blocks = resident_threads_per_sm / BlockThreads;
       const auto& full_bounds_kernel =
         kernel_full_bounds<BlockThreads, full_bounds_max_sm_blocks, unroll_factor, action_t, SampleT>;
 
@@ -373,6 +375,7 @@ void dispatch_mode(
         state, algorithm, pattern, bins, items_per_thread, block_threads);
       return;
     case benchmark_mode::latency:
+      // The latency benchmark bypasses dispatch_mode and dispatches this mode directly with one warp.
       break;
   }
 

--- a/cub/benchmarks/bench/block_histogram/algorithms.cu
+++ b/cub/benchmarks/bench/block_histogram/algorithms.cu
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/block/block_histogram.cuh>
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#include <nvbench_helper.cuh>
+
+enum class block_histogram_algorithm
+{
+  atomic,
+  warp_aggregated,
+  warp_aggregated_cg,
+  sort,
+};
+
+block_histogram_algorithm parse_algorithm(const std::string& name)
+{
+  if (name == "atomic")
+  {
+    return block_histogram_algorithm::atomic;
+  }
+  if (name == "warp_aggregated")
+  {
+    return block_histogram_algorithm::warp_aggregated;
+  }
+  if (name == "warp_aggregated_cg")
+  {
+    return block_histogram_algorithm::warp_aggregated_cg;
+  }
+  if (name == "sort")
+  {
+    return block_histogram_algorithm::sort;
+  }
+
+  throw std::runtime_error("Unsupported Algorithm axis value");
+}
+
+template <typename SampleT,
+          typename CounterT,
+          int BlockThreads,
+          int ItemsPerThread,
+          int Bins,
+          cub::BlockHistogramAlgorithm Algorithm>
+__global__ void block_histogram_kernel(const SampleT* input, CounterT* histograms)
+{
+  using block_histogram_t = cub::BlockHistogram<SampleT, BlockThreads, ItemsPerThread, Bins, Algorithm>;
+
+  __shared__ typename block_histogram_t::TempStorage temp_storage;
+
+  SampleT items[ItemsPerThread];
+  const int tile_base = static_cast<int>(blockIdx.x) * BlockThreads * ItemsPerThread;
+
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (int item = 0; item < ItemsPerThread; ++item)
+  {
+    items[item] = input[tile_base + threadIdx.x + item * BlockThreads];
+  }
+
+  CounterT* block_histogram = histograms + static_cast<std::size_t>(blockIdx.x) * Bins;
+  block_histogram_t(temp_storage).Histogram(items, block_histogram);
+}
+
+template <typename SampleT,
+          typename CounterT,
+          int BlockThreads,
+          int ItemsPerThread,
+          int Bins,
+          cub::BlockHistogramAlgorithm Algorithm>
+void run_algorithm(nvbench::state& state, const SampleT* input, CounterT* histograms, int num_blocks)
+{
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
+    block_histogram_kernel<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, Algorithm>
+      <<<num_blocks, BlockThreads, 0, launch.get_stream().get_stream()>>>(input, histograms);
+  });
+}
+
+template <typename SampleT, typename CounterT, int BlockThreads, int ItemsPerThread, int Bins>
+void dispatch_algorithm(
+  nvbench::state& state, block_histogram_algorithm algorithm, const SampleT* input, CounterT* histograms, int num_blocks)
+{
+  switch (algorithm)
+  {
+    case block_histogram_algorithm::atomic:
+      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_ATOMIC>(
+        state, input, histograms, num_blocks);
+      return;
+    case block_histogram_algorithm::warp_aggregated:
+      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED>(
+        state, input, histograms, num_blocks);
+      return;
+    case block_histogram_algorithm::warp_aggregated_cg:
+      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED_CG>(
+        state, input, histograms, num_blocks);
+      return;
+    case block_histogram_algorithm::sort:
+      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_SORT>(
+        state, input, histograms, num_blocks);
+      return;
+  }
+}
+
+template <typename SampleT, typename CounterT, int BlockThreads, int ItemsPerThread>
+void dispatch_bins(
+  nvbench::state& state,
+  block_histogram_algorithm algorithm,
+  int bins,
+  const SampleT* input,
+  CounterT* histograms,
+  int num_blocks)
+{
+  switch (bins)
+  {
+    case 32:
+      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 32>(
+        state, algorithm, input, histograms, num_blocks);
+      return;
+    case 128:
+      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 128>(
+        state, algorithm, input, histograms, num_blocks);
+      return;
+    case 2048:
+      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 2048>(
+        state, algorithm, input, histograms, num_blocks);
+      return;
+  }
+
+  throw std::runtime_error("Unsupported Bins axis value");
+}
+
+template <typename SampleT, typename CounterT, int BlockThreads>
+void dispatch_items(
+  nvbench::state& state,
+  int items_per_thread,
+  int bins,
+  block_histogram_algorithm algorithm,
+  const SampleT* input,
+  CounterT* histograms,
+  int num_blocks)
+{
+  switch (items_per_thread)
+  {
+    case 1:
+      dispatch_bins<SampleT, CounterT, BlockThreads, 1>(state, algorithm, bins, input, histograms, num_blocks);
+      return;
+    case 4:
+      dispatch_bins<SampleT, CounterT, BlockThreads, 4>(state, algorithm, bins, input, histograms, num_blocks);
+      return;
+    case 8:
+      dispatch_bins<SampleT, CounterT, BlockThreads, 8>(state, algorithm, bins, input, histograms, num_blocks);
+      return;
+  }
+
+  throw std::runtime_error("Unsupported ItemsPerThread axis value");
+}
+
+template <typename SampleT, typename CounterT>
+void block_histogram_algorithms(nvbench::state& state, nvbench::type_list<SampleT, CounterT>)
+{
+  constexpr int block_threads = 256;
+
+  const auto algorithm       = parse_algorithm(state.get_string("Algorithm"));
+  const auto entropy         = str_to_entropy(state.get_string("Entropy"));
+  const int bins             = static_cast<int>(state.get_int64("Bins"));
+  const int items_per_thread = static_cast<int>(state.get_int64("ItemsPerThread{io}"));
+  const int num_blocks       = static_cast<int>(state.get_int64("Blocks"));
+  const auto items_per_block = block_threads * items_per_thread;
+  const auto elements        = static_cast<std::size_t>(num_blocks) * static_cast<std::size_t>(items_per_block);
+  const auto histogram_items = static_cast<std::size_t>(num_blocks) * static_cast<std::size_t>(bins);
+
+  thrust::device_vector<SampleT> input = generate(elements, entropy, SampleT{0}, static_cast<SampleT>(bins - 1));
+  thrust::device_vector<CounterT> histograms(histogram_items);
+
+  const SampleT* d_input = thrust::raw_pointer_cast(input.data());
+  CounterT* d_histograms = thrust::raw_pointer_cast(histograms.data());
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<SampleT>(elements, "InputSize");
+  state.add_global_memory_writes<CounterT>(histogram_items, "HistogramSize");
+
+  dispatch_items<SampleT, CounterT, block_threads>(
+    state, items_per_thread, bins, algorithm, d_input, d_histograms, num_blocks);
+}
+
+using sample_types  = nvbench::type_list<std::int32_t>;
+using counter_types = nvbench::type_list<std::int32_t>;
+
+NVBENCH_BENCH_TYPES(block_histogram_algorithms, NVBENCH_TYPE_AXES(sample_types, counter_types))
+  .set_name("base")
+  .set_type_axes_names({"SampleT{ct}", "CounterT{ct}"})
+  .add_string_axis("Algorithm", {"atomic", "warp_aggregated", "warp_aggregated_cg", "sort"})
+  .add_int64_axis("ItemsPerThread{io}", {1, 4, 8})
+  .add_int64_axis("Bins", {32, 128, 2048})
+  .add_int64_axis("Blocks", {4096, 16384})
+  .add_string_axis("Entropy", {"0.000", "0.201", "1.000"});

--- a/cub/benchmarks/bench/block_histogram/algorithms.cu
+++ b/cub/benchmarks/bench/block_histogram/algorithms.cu
@@ -3,9 +3,7 @@
 
 #include <cub/block/block_histogram.cuh>
 
-#include <cuda/std/cstddef>
-#include <cuda/std/cstdint>
-
+#include <cstddef>
 #include <stdexcept>
 #include <string>
 
@@ -26,6 +24,14 @@ enum class sample_pattern
   lane_pairs,
   skewed,
   uniform,
+};
+
+enum class benchmark_mode
+{
+  occupancy,
+  fixed,
+  latency,
+  full_bounds,
 };
 
 block_histogram_algorithm parse_algorithm(const std::string& name)
@@ -68,6 +74,24 @@ sample_pattern parse_sample_pattern(const std::string& name)
   throw std::runtime_error("Unsupported SamplePattern axis value");
 }
 
+benchmark_mode parse_benchmark_mode(const std::string& name)
+{
+  if (name == "occupancy")
+  {
+    return benchmark_mode::occupancy;
+  }
+  if (name == "fixed")
+  {
+    return benchmark_mode::fixed;
+  }
+  if (name == "full_bounds")
+  {
+    return benchmark_mode::full_bounds;
+  }
+
+  throw std::runtime_error("Unsupported BenchmarkMode axis value");
+}
+
 template <int BlockThreads, int Bins, sample_pattern Pattern, typename SampleT>
 _CCCL_DEVICE_API _CCCL_FORCEINLINE SampleT make_sample(int item)
 {
@@ -102,11 +126,9 @@ template <typename CounterT,
 struct benchmark_op_t
 {
   template <typename SampleT>
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE SampleT operator()(SampleT thread_data) const
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE SampleT operator()(SampleT) const
   {
     using block_histogram_t = cub::BlockHistogram<SampleT, BlockThreads, ItemsPerThread, Bins, Algorithm>;
-
-    static_cast<void>(thread_data);
 
     __shared__ typename block_histogram_t::TempStorage temp_storage;
     __shared__ CounterT histogram[Bins];
@@ -127,32 +149,83 @@ struct benchmark_op_t
   }
 };
 
+template <std::size_t Numerator, std::size_t Denominator>
+inline constexpr std::size_t static_ceil_div = (Numerator + Denominator - 1) / Denominator;
+
+template <int BlockThreads, int SmBlocks, int UnrollFactor, typename ActionT, typename T>
+__launch_bounds__(BlockThreads, SmBlocks) __global__
+  static void kernel_full_bounds(_CCCL_GRID_CONSTANT const ActionT action)
+{
+  auto data = generate_random_data<T>();
+  cuda::static_for<UnrollFactor>([&]([[maybe_unused]] auto _) {
+    data = action(data);
+  });
+  sink(data);
+}
+
 template <typename SampleT,
           typename CounterT,
           int BlockThreads,
           int ItemsPerThread,
           int Bins,
           cub::BlockHistogramAlgorithm Algorithm,
-          sample_pattern Pattern>
+          sample_pattern Pattern,
+          benchmark_mode Mode>
 void run_algorithm(nvbench::state& state)
 {
   constexpr int unroll_factor = 32;
   using action_t              = benchmark_op_t<CounterT, BlockThreads, ItemsPerThread, Bins, Algorithm, Pattern>;
   const auto& kernel          = benchmark_kernel<BlockThreads, unroll_factor, action_t, SampleT>;
-  const int num_sms           = state.get_device().value().get_number_of_sms();
-  int max_blocks_per_sm       = 0;
 
-  NVBENCH_CUDA_CALL_NOEXCEPT(
-    cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_blocks_per_sm, kernel, BlockThreads, 0));
+  if constexpr (Mode == benchmark_mode::latency)
+  {
+    constexpr int grid_size = 1;
+    state.add_element_count(static_cast<std::size_t>(grid_size) * BlockThreads * ItemsPerThread * unroll_factor);
+    state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
+      kernel<<<grid_size, BlockThreads, 0, launch.get_stream()>>>(action_t{});
+    });
+    return;
+  }
+  else
+  {
+    constexpr std::size_t fixed_work_items = std::size_t{1} << 28;
+    constexpr std::size_t items_per_block  = BlockThreads * ItemsPerThread * unroll_factor;
+    constexpr int fixed_grid_size          = static_cast<int>(static_ceil_div<fixed_work_items, items_per_block>);
 
-  const int grid_size = max_blocks_per_sm * num_sms;
-  state.add_element_count(
-    static_cast<::cuda::std::size_t>(grid_size) * static_cast<::cuda::std::size_t>(BlockThreads)
-    * static_cast<::cuda::std::size_t>(ItemsPerThread) * static_cast<::cuda::std::size_t>(unroll_factor));
+    if constexpr (Mode == benchmark_mode::full_bounds)
+    {
+      constexpr int max_sm_warps              = 48;
+      constexpr int full_bounds_max_sm_blocks = (max_sm_warps * cub::detail::warp_threads) / BlockThreads;
+      const auto& full_bounds_kernel =
+        kernel_full_bounds<BlockThreads, full_bounds_max_sm_blocks, unroll_factor, action_t, SampleT>;
 
-  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch&) {
-    kernel<<<grid_size, BlockThreads>>>(action_t{});
-  });
+      state.add_element_count(
+        static_cast<std::size_t>(fixed_grid_size) * BlockThreads * ItemsPerThread * unroll_factor);
+      state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
+        full_bounds_kernel<<<fixed_grid_size, BlockThreads, 0, launch.get_stream()>>>(action_t{});
+      });
+      return;
+    }
+
+    int grid_size = fixed_grid_size;
+
+    if constexpr (Mode == benchmark_mode::occupancy)
+    {
+      const int num_sms     = state.get_device().value().get_number_of_sms();
+      int max_blocks_per_sm = 0;
+
+      NVBENCH_CUDA_CALL_NOEXCEPT(
+        cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_blocks_per_sm, kernel, BlockThreads, 0));
+
+      grid_size = max_blocks_per_sm * num_sms;
+    }
+
+    state.add_element_count(static_cast<std::size_t>(grid_size) * BlockThreads * ItemsPerThread * unroll_factor);
+
+    state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
+      kernel<<<grid_size, BlockThreads, 0, launch.get_stream()>>>(action_t{});
+    });
+  }
 }
 
 template <typename SampleT,
@@ -160,92 +233,97 @@ template <typename SampleT,
           int BlockThreads,
           int ItemsPerThread,
           int Bins,
-          cub::BlockHistogramAlgorithm Algorithm>
+          cub::BlockHistogramAlgorithm Algorithm,
+          benchmark_mode Mode>
 void dispatch_pattern(nvbench::state& state, sample_pattern pattern)
 {
   switch (pattern)
   {
     case sample_pattern::single_bin:
-      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, Algorithm, sample_pattern::single_bin>(
+      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, Algorithm, sample_pattern::single_bin, Mode>(
         state);
       return;
     case sample_pattern::lane_pairs:
-      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, Algorithm, sample_pattern::lane_pairs>(
+      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, Algorithm, sample_pattern::lane_pairs, Mode>(
         state);
       return;
     case sample_pattern::skewed:
-      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, Algorithm, sample_pattern::skewed>(state);
+      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, Algorithm, sample_pattern::skewed, Mode>(
+        state);
       return;
     case sample_pattern::uniform:
-      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, Algorithm, sample_pattern::uniform>(state);
+      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, Algorithm, sample_pattern::uniform, Mode>(
+        state);
       return;
   }
 }
 
-template <typename SampleT, typename CounterT, int BlockThreads, int ItemsPerThread, int Bins>
+template <typename SampleT, typename CounterT, int BlockThreads, int ItemsPerThread, int Bins, benchmark_mode Mode>
 void dispatch_algorithm(nvbench::state& state, block_histogram_algorithm algorithm, sample_pattern pattern)
 {
   switch (algorithm)
   {
     case block_histogram_algorithm::atomic:
-      dispatch_pattern<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_ATOMIC>(state, pattern);
+      dispatch_pattern<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_ATOMIC, Mode>(
+        state, pattern);
       return;
     case block_histogram_algorithm::warp_aggregated:
-      dispatch_pattern<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED>(
+      dispatch_pattern<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED, Mode>(
         state, pattern);
       return;
     case block_histogram_algorithm::sort:
-      dispatch_pattern<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_SORT>(state, pattern);
+      dispatch_pattern<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_SORT, Mode>(
+        state, pattern);
       return;
   }
 }
 
-template <typename SampleT, typename CounterT, int BlockThreads, int ItemsPerThread>
+template <typename SampleT, typename CounterT, int BlockThreads, int ItemsPerThread, benchmark_mode Mode>
 void dispatch_bins(nvbench::state& state, block_histogram_algorithm algorithm, sample_pattern pattern, int bins)
 {
   switch (bins)
   {
     case 32:
-      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 32>(state, algorithm, pattern);
+      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 32, Mode>(state, algorithm, pattern);
       return;
     case 64:
-      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 64>(state, algorithm, pattern);
+      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 64, Mode>(state, algorithm, pattern);
       return;
     case 128:
-      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 128>(state, algorithm, pattern);
+      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 128, Mode>(state, algorithm, pattern);
       return;
     case 512:
-      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 512>(state, algorithm, pattern);
+      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 512, Mode>(state, algorithm, pattern);
       return;
     case 2048:
-      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 2048>(state, algorithm, pattern);
+      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 2048, Mode>(state, algorithm, pattern);
       return;
   }
 
   throw std::runtime_error("Unsupported Bins axis value");
 }
 
-template <typename SampleT, typename CounterT, int BlockThreads>
+template <typename SampleT, typename CounterT, int BlockThreads, benchmark_mode Mode>
 void dispatch_items(
   nvbench::state& state, block_histogram_algorithm algorithm, sample_pattern pattern, int bins, int items_per_thread)
 {
   switch (items_per_thread)
   {
     case 1:
-      dispatch_bins<SampleT, CounterT, BlockThreads, 1>(state, algorithm, pattern, bins);
+      dispatch_bins<SampleT, CounterT, BlockThreads, 1, Mode>(state, algorithm, pattern, bins);
       return;
     case 4:
-      dispatch_bins<SampleT, CounterT, BlockThreads, 4>(state, algorithm, pattern, bins);
+      dispatch_bins<SampleT, CounterT, BlockThreads, 4, Mode>(state, algorithm, pattern, bins);
       return;
     case 8:
-      dispatch_bins<SampleT, CounterT, BlockThreads, 8>(state, algorithm, pattern, bins);
+      dispatch_bins<SampleT, CounterT, BlockThreads, 8, Mode>(state, algorithm, pattern, bins);
       return;
   }
 
   throw std::runtime_error("Unsupported ItemsPerThread axis value");
 }
 
-template <typename SampleT, typename CounterT>
+template <typename SampleT, typename CounterT, benchmark_mode Mode>
 void dispatch_block_threads(
   nvbench::state& state,
   block_histogram_algorithm algorithm,
@@ -257,13 +335,13 @@ void dispatch_block_threads(
   switch (block_threads)
   {
     case 128:
-      dispatch_items<SampleT, CounterT, 128>(state, algorithm, pattern, bins, items_per_thread);
+      dispatch_items<SampleT, CounterT, 128, Mode>(state, algorithm, pattern, bins, items_per_thread);
       return;
     case 256:
-      dispatch_items<SampleT, CounterT, 256>(state, algorithm, pattern, bins, items_per_thread);
+      dispatch_items<SampleT, CounterT, 256, Mode>(state, algorithm, pattern, bins, items_per_thread);
       return;
     case 512:
-      dispatch_items<SampleT, CounterT, 512>(state, algorithm, pattern, bins, items_per_thread);
+      dispatch_items<SampleT, CounterT, 512, Mode>(state, algorithm, pattern, bins, items_per_thread);
       return;
   }
 
@@ -271,25 +349,78 @@ void dispatch_block_threads(
 }
 
 template <typename SampleT, typename CounterT>
+void dispatch_mode(
+  nvbench::state& state,
+  block_histogram_algorithm algorithm,
+  sample_pattern pattern,
+  benchmark_mode mode,
+  int bins,
+  int items_per_thread,
+  int block_threads)
+{
+  switch (mode)
+  {
+    case benchmark_mode::occupancy:
+      dispatch_block_threads<SampleT, CounterT, benchmark_mode::occupancy>(
+        state, algorithm, pattern, bins, items_per_thread, block_threads);
+      return;
+    case benchmark_mode::fixed:
+      dispatch_block_threads<SampleT, CounterT, benchmark_mode::fixed>(
+        state, algorithm, pattern, bins, items_per_thread, block_threads);
+      return;
+    case benchmark_mode::full_bounds:
+      dispatch_block_threads<SampleT, CounterT, benchmark_mode::full_bounds>(
+        state, algorithm, pattern, bins, items_per_thread, block_threads);
+      return;
+    case benchmark_mode::latency:
+      break;
+  }
+
+  throw std::runtime_error("Unsupported BenchmarkMode axis value");
+}
+
+template <typename SampleT, typename CounterT>
 void block_histogram_algorithms(nvbench::state& state, nvbench::type_list<SampleT, CounterT>)
+{
+  const auto algorithm       = parse_algorithm(state.get_string("Algorithm"));
+  const auto pattern         = parse_sample_pattern(state.get_string("SamplePattern"));
+  const auto mode            = parse_benchmark_mode(state.get_string("BenchmarkMode"));
+  const int bins             = static_cast<int>(state.get_int64("Bins"));
+  const int items_per_thread = static_cast<int>(state.get_int64("ItemsPerThread{io}"));
+  const int block_threads    = static_cast<int>(state.get_int64("BlockThreads"));
+
+  dispatch_mode<SampleT, CounterT>(state, algorithm, pattern, mode, bins, items_per_thread, block_threads);
+}
+
+template <typename SampleT, typename CounterT>
+void block_histogram_algorithms_latency(nvbench::state& state, nvbench::type_list<SampleT, CounterT>)
 {
   const auto algorithm       = parse_algorithm(state.get_string("Algorithm"));
   const auto pattern         = parse_sample_pattern(state.get_string("SamplePattern"));
   const int bins             = static_cast<int>(state.get_int64("Bins"));
   const int items_per_thread = static_cast<int>(state.get_int64("ItemsPerThread{io}"));
-  const int block_threads    = static_cast<int>(state.get_int64("BlockThreads"));
 
-  dispatch_block_threads<SampleT, CounterT>(state, algorithm, pattern, bins, items_per_thread, block_threads);
+  dispatch_items<SampleT, CounterT, cub::detail::warp_threads, benchmark_mode::latency>(
+    state, algorithm, pattern, bins, items_per_thread);
 }
 
-using sample_types  = nvbench::type_list<::cuda::std::int32_t>;
-using counter_types = nvbench::type_list<::cuda::std::int32_t>;
+using sample_types  = nvbench::type_list<int>;
+using counter_types = nvbench::type_list<int>;
 
 NVBENCH_BENCH_TYPES(block_histogram_algorithms, NVBENCH_TYPE_AXES(sample_types, counter_types))
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}"})
   .add_string_axis("Algorithm", {"atomic", "warp_aggregated", "sort"})
+  .add_string_axis("BenchmarkMode", {"occupancy", "fixed", "full_bounds"})
   .add_int64_axis("BlockThreads", {128, 256, 512})
+  .add_int64_axis("ItemsPerThread{io}", {1, 4, 8})
+  .add_int64_axis("Bins", {32, 64, 128, 512, 2048})
+  .add_string_axis("SamplePattern", {"single_bin", "lane_pairs", "skewed", "uniform"});
+
+NVBENCH_BENCH_TYPES(block_histogram_algorithms_latency, NVBENCH_TYPE_AXES(sample_types, counter_types))
+  .set_name("latency")
+  .set_type_axes_names({"SampleT{ct}", "CounterT{ct}"})
+  .add_string_axis("Algorithm", {"atomic", "warp_aggregated", "sort"})
   .add_int64_axis("ItemsPerThread{io}", {1, 4, 8})
   .add_int64_axis("Bins", {32, 64, 128, 512, 2048})
   .add_string_axis("SamplePattern", {"single_bin", "lane_pairs", "skewed", "uniform"});

--- a/cub/benchmarks/bench/block_histogram/algorithms.cu
+++ b/cub/benchmarks/bench/block_histogram/algorithms.cu
@@ -23,6 +23,7 @@ enum class block_histogram_algorithm
 enum class sample_pattern
 {
   single_bin,
+  lane_pairs,
   skewed,
   uniform,
 };
@@ -51,6 +52,10 @@ sample_pattern parse_sample_pattern(const std::string& name)
   {
     return sample_pattern::single_bin;
   }
+  if (name == "lane_pairs")
+  {
+    return sample_pattern::lane_pairs;
+  }
   if (name == "skewed")
   {
     return sample_pattern::skewed;
@@ -73,6 +78,10 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE SampleT make_sample(int item)
   if constexpr (Pattern == sample_pattern::single_bin)
   {
     return SampleT{0};
+  }
+  else if constexpr (Pattern == sample_pattern::lane_pairs)
+  {
+    return static_cast<SampleT>((lane / 2) % Bins);
   }
   else if constexpr (Pattern == sample_pattern::skewed)
   {
@@ -160,6 +169,10 @@ void dispatch_pattern(nvbench::state& state, sample_pattern pattern)
       run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, Algorithm, sample_pattern::single_bin>(
         state);
       return;
+    case sample_pattern::lane_pairs:
+      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, Algorithm, sample_pattern::lane_pairs>(
+        state);
+      return;
     case sample_pattern::skewed:
       run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, Algorithm, sample_pattern::skewed>(state);
       return;
@@ -195,8 +208,14 @@ void dispatch_bins(nvbench::state& state, block_histogram_algorithm algorithm, s
     case 32:
       dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 32>(state, algorithm, pattern);
       return;
+    case 64:
+      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 64>(state, algorithm, pattern);
+      return;
     case 128:
       dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 128>(state, algorithm, pattern);
+      return;
+    case 512:
+      dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 512>(state, algorithm, pattern);
       return;
     case 2048:
       dispatch_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, 2048>(state, algorithm, pattern);
@@ -227,16 +246,40 @@ void dispatch_items(
 }
 
 template <typename SampleT, typename CounterT>
+void dispatch_block_threads(
+  nvbench::state& state,
+  block_histogram_algorithm algorithm,
+  sample_pattern pattern,
+  int bins,
+  int items_per_thread,
+  int block_threads)
+{
+  switch (block_threads)
+  {
+    case 128:
+      dispatch_items<SampleT, CounterT, 128>(state, algorithm, pattern, bins, items_per_thread);
+      return;
+    case 256:
+      dispatch_items<SampleT, CounterT, 256>(state, algorithm, pattern, bins, items_per_thread);
+      return;
+    case 512:
+      dispatch_items<SampleT, CounterT, 512>(state, algorithm, pattern, bins, items_per_thread);
+      return;
+  }
+
+  throw std::runtime_error("Unsupported BlockThreads axis value");
+}
+
+template <typename SampleT, typename CounterT>
 void block_histogram_algorithms(nvbench::state& state, nvbench::type_list<SampleT, CounterT>)
 {
-  constexpr int block_threads = 256;
-
   const auto algorithm       = parse_algorithm(state.get_string("Algorithm"));
   const auto pattern         = parse_sample_pattern(state.get_string("SamplePattern"));
   const int bins             = static_cast<int>(state.get_int64("Bins"));
   const int items_per_thread = static_cast<int>(state.get_int64("ItemsPerThread{io}"));
+  const int block_threads    = static_cast<int>(state.get_int64("BlockThreads"));
 
-  dispatch_items<SampleT, CounterT, block_threads>(state, algorithm, pattern, bins, items_per_thread);
+  dispatch_block_threads<SampleT, CounterT>(state, algorithm, pattern, bins, items_per_thread, block_threads);
 }
 
 using sample_types  = nvbench::type_list<::cuda::std::int32_t>;
@@ -246,6 +289,7 @@ NVBENCH_BENCH_TYPES(block_histogram_algorithms, NVBENCH_TYPE_AXES(sample_types, 
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}"})
   .add_string_axis("Algorithm", {"atomic", "warp_aggregated", "sort"})
+  .add_int64_axis("BlockThreads", {128, 256, 512})
   .add_int64_axis("ItemsPerThread{io}", {1, 4, 8})
-  .add_int64_axis("Bins", {32, 128, 2048})
-  .add_string_axis("SamplePattern", {"single_bin", "skewed", "uniform"});
+  .add_int64_axis("Bins", {32, 64, 128, 512, 2048})
+  .add_string_axis("SamplePattern", {"single_bin", "lane_pairs", "skewed", "uniform"});

--- a/cub/benchmarks/bench/block_histogram/algorithms.cu
+++ b/cub/benchmarks/bench/block_histogram/algorithms.cu
@@ -14,7 +14,6 @@ enum class block_histogram_algorithm
 {
   atomic,
   warp_aggregated,
-  warp_aggregated_cg,
   sort,
 };
 
@@ -27,10 +26,6 @@ block_histogram_algorithm parse_algorithm(const std::string& name)
   if (name == "warp_aggregated")
   {
     return block_histogram_algorithm::warp_aggregated;
-  }
-  if (name == "warp_aggregated_cg")
-  {
-    return block_histogram_algorithm::warp_aggregated_cg;
   }
   if (name == "sort")
   {
@@ -53,7 +48,7 @@ __global__ void block_histogram_kernel(const SampleT* input, CounterT* histogram
   __shared__ typename block_histogram_t::TempStorage temp_storage;
 
   SampleT items[ItemsPerThread];
-  const int tile_base = static_cast<int>(blockIdx.x) * BlockThreads * ItemsPerThread;
+  const auto tile_base = static_cast<std::size_t>(blockIdx.x) * BlockThreads * ItemsPerThread;
 
   _CCCL_PRAGMA_UNROLL_FULL()
   for (int item = 0; item < ItemsPerThread; ++item)
@@ -91,10 +86,6 @@ void dispatch_algorithm(
       return;
     case block_histogram_algorithm::warp_aggregated:
       run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED>(
-        state, input, histograms, num_blocks);
-      return;
-    case block_histogram_algorithm::warp_aggregated_cg:
-      run_algorithm<SampleT, CounterT, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED_CG>(
         state, input, histograms, num_blocks);
       return;
     case block_histogram_algorithm::sort:
@@ -192,7 +183,7 @@ using counter_types = nvbench::type_list<std::int32_t>;
 NVBENCH_BENCH_TYPES(block_histogram_algorithms, NVBENCH_TYPE_AXES(sample_types, counter_types))
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "CounterT{ct}"})
-  .add_string_axis("Algorithm", {"atomic", "warp_aggregated", "warp_aggregated_cg", "sort"})
+  .add_string_axis("Algorithm", {"atomic", "warp_aggregated", "sort"})
   .add_int64_axis("ItemsPerThread{io}", {1, 4, 8})
   .add_int64_axis("Bins", {32, 128, 2048})
   .add_int64_axis("Blocks", {4096, 16384})

--- a/cub/cub/block/block_histogram.cuh
+++ b/cub/cub/block/block_histogram.cuh
@@ -85,6 +85,10 @@ enum BlockHistogramAlgorithm
   //! relatively few bins. In that case, reducing multiple contended atomic updates to one update can reduce
   //! global-memory atomic pressure.
   //!
+  //! Like :cpp:enumerator:`cub::BLOCK_HISTO_ATOMIC`, this algorithm updates histogram counters with CUDA
+  //! ``atomicAdd``. The counter type must be supported by ``atomicAdd`` for the target memory space and
+  //! architecture.
+  //!
   //! The extra warp-level peer-mask, leader-election, and population-count work adds instruction overhead. If the
   //! counters are in shared memory, prefer cub::BLOCK_HISTO_ATOMIC. If most lanes update different bins, the direct
   //! atomic algorithm is also the better starting point. In the most contended case, where every lane in a warp

--- a/cub/cub/block/block_histogram.cuh
+++ b/cub/cub/block/block_histogram.cuh
@@ -21,6 +21,7 @@
 #endif // no system header
 
 #include <cub/block/specializations/block_histogram_atomic.cuh>
+#include <cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh>
 #include <cub/block/specializations/block_histogram_sort.cuh>
 #include <cub/util_ptx.cuh>
 
@@ -68,6 +69,43 @@ enum BlockHistogramAlgorithm
   //!
   //! @endrst
   BLOCK_HISTO_ATOMIC,
+
+  //! @rst
+  //!
+  //! Overview
+  //! ++++++++++++++++++++++++++
+  //!
+  //! Use warp-level match primitives in conjunction with warp-aggregated
+  //! atomic addition to update counts directly.
+  //!
+  //! Performance Considerations
+  //! ++++++++++++++++++++++++++
+  //!
+  //! This algorithm reduces per-warp contention when multiple lanes update
+  //! the same bin counter. In the most extreme case, where each lane in a
+  //! warp updates the same bin, it reduces the number of atomic operations
+  //! from 32 to 1.
+  //!
+  //! @endrst
+  BLOCK_HISTO_ATOMIC_WARP_AGGREGATED,
+
+  //! @rst
+  //!
+  //! Overview
+  //! ++++++++++++++++++++++++++
+  //!
+  //! Use cooperative groups in conjunction with warp-aggregated atomic
+  //! addition to update counts directly.
+  //!
+  //! Performance Considerations
+  //! ++++++++++++++++++++++++++
+  //!
+  //! This algorithm performs the same aggregation as
+  //! :cpp:enumerator:`cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED`, but uses
+  //! cooperative groups instead of raw warp-level intrinsics.
+  //!
+  //! @endrst
+  BLOCK_HISTO_ATOMIC_WARP_AGGREGATED_CG,
 };
 
 //! @rst
@@ -86,6 +124,10 @@ enum BlockHistogramAlgorithm
 //!
 //!   #. :cpp:enumerator:`cub::BLOCK_HISTO_SORT`: Sorting followed by differentiation.
 //!   #. :cpp:enumerator:`cub::BLOCK_HISTO_ATOMIC`: Use atomic addition to update byte counts directly.
+//!   #. :cpp:enumerator:`cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED`: Use raw warp primitives to aggregate
+//!      atomic updates by bin.
+//!   #. :cpp:enumerator:`cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED_CG`: Use cooperative groups to aggregate
+//!      atomic updates by bin.
 //!
 //! A Simple Example
 //! +++++++++++++++++++++++++++++++++++++++++++++
@@ -173,7 +215,11 @@ private:
   using InternalBlockHistogram =
     ::cuda::std::_If<Algorithm == BLOCK_HISTO_SORT,
                      detail::BlockHistogramSort<T, BlockDimX, ItemsPerThread, Bins, BlockDimY, BlockDimZ>,
-                     detail::BlockHistogramAtomic<Bins>>;
+                     ::cuda::std::_If<Algorithm == BLOCK_HISTO_ATOMIC,
+                                      detail::BlockHistogramAtomic<Bins>,
+                                      ::cuda::std::_If<Algorithm == BLOCK_HISTO_ATOMIC_WARP_AGGREGATED_CG,
+                                                       detail::BlockHistogramAtomicWarpAggregatedCg<Bins>,
+                                                       detail::BlockHistogramAtomicWarpAggregated<Bins>>>>;
 
   /// Shared memory storage layout type for BlockHistogram
   using _TempStorage = typename InternalBlockHistogram::TempStorage;

--- a/cub/cub/block/block_histogram.cuh
+++ b/cub/cub/block/block_histogram.cuh
@@ -88,24 +88,6 @@ enum BlockHistogramAlgorithm
   //!
   //! @endrst
   BLOCK_HISTO_ATOMIC_WARP_AGGREGATED,
-
-  //! @rst
-  //!
-  //! Overview
-  //! ++++++++++++++++++++++++++
-  //!
-  //! Use cooperative groups in conjunction with warp-aggregated atomic
-  //! addition to update counts directly.
-  //!
-  //! Performance Considerations
-  //! ++++++++++++++++++++++++++
-  //!
-  //! This algorithm performs the same aggregation as
-  //! :cpp:enumerator:`cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED`, but uses
-  //! cooperative groups instead of raw warp-level intrinsics.
-  //!
-  //! @endrst
-  BLOCK_HISTO_ATOMIC_WARP_AGGREGATED_CG,
 };
 
 //! @rst
@@ -125,8 +107,6 @@ enum BlockHistogramAlgorithm
 //!   #. :cpp:enumerator:`cub::BLOCK_HISTO_SORT`: Sorting followed by differentiation.
 //!   #. :cpp:enumerator:`cub::BLOCK_HISTO_ATOMIC`: Use atomic addition to update byte counts directly.
 //!   #. :cpp:enumerator:`cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED`: Use raw warp primitives to aggregate
-//!      atomic updates by bin.
-//!   #. :cpp:enumerator:`cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED_CG`: Use cooperative groups to aggregate
 //!      atomic updates by bin.
 //!
 //! A Simple Example
@@ -217,9 +197,7 @@ private:
                      detail::BlockHistogramSort<T, BlockDimX, ItemsPerThread, Bins, BlockDimY, BlockDimZ>,
                      ::cuda::std::_If<Algorithm == BLOCK_HISTO_ATOMIC,
                                       detail::BlockHistogramAtomic<Bins>,
-                                      ::cuda::std::_If<Algorithm == BLOCK_HISTO_ATOMIC_WARP_AGGREGATED_CG,
-                                                       detail::BlockHistogramAtomicWarpAggregatedCg<Bins>,
-                                                       detail::BlockHistogramAtomicWarpAggregated<Bins>>>>;
+                                      detail::BlockHistogramAtomicWarpAggregated<Bins>>>;
 
   /// Shared memory storage layout type for BlockHistogram
   using _TempStorage = typename InternalBlockHistogram::TempStorage;

--- a/cub/cub/block/block_histogram.cuh
+++ b/cub/cub/block/block_histogram.cuh
@@ -75,16 +75,13 @@ enum BlockHistogramAlgorithm
   //! Overview
   //! ++++++++++++++++++++++++++
   //!
-  //! Use warp-level match primitives in conjunction with warp-aggregated
-  //! atomic addition to update counts directly.
+  //! Use warp-level match primitives with warp-aggregated atomic addition to update counts directly.
   //!
   //! Performance Considerations
   //! ++++++++++++++++++++++++++
   //!
-  //! This algorithm reduces per-warp contention when multiple lanes update
-  //! the same bin counter. In the most extreme case, where each lane in a
-  //! warp updates the same bin, it reduces the number of atomic operations
-  //! from 32 to 1.
+  //! This algorithm reduces per-warp contention when multiple lanes update the same bin counter. In the most
+  //! extreme case, where each lane in a warp updates the same bin, it reduces atomic operations from 32 to 1.
   //!
   //! @endrst
   BLOCK_HISTO_ATOMIC_WARP_AGGREGATED,

--- a/cub/cub/block/block_histogram.cuh
+++ b/cub/cub/block/block_histogram.cuh
@@ -192,12 +192,12 @@ private:
   static constexpr int BLOCK_THREADS = BlockDimX * BlockDimY * BlockDimZ;
 
   /// Internal specialization.
-  using InternalBlockHistogram =
-    ::cuda::std::_If<Algorithm == BLOCK_HISTO_SORT,
-                     detail::BlockHistogramSort<T, BlockDimX, ItemsPerThread, Bins, BlockDimY, BlockDimZ>,
-                     ::cuda::std::_If<Algorithm == BLOCK_HISTO_ATOMIC,
-                                      detail::BlockHistogramAtomic<Bins>,
-                                      detail::BlockHistogramAtomicWarpAggregated<Bins>>>;
+  using InternalBlockHistogram = ::cuda::std::_If<
+    Algorithm == BLOCK_HISTO_SORT,
+    detail::BlockHistogramSort<T, BlockDimX, ItemsPerThread, Bins, BlockDimY, BlockDimZ>,
+    ::cuda::std::_If<Algorithm == BLOCK_HISTO_ATOMIC,
+                     detail::BlockHistogramAtomic<Bins>,
+                     detail::BlockHistogramAtomicWarpAggregated<Bins, BlockDimX, BlockDimY, BlockDimZ>>>;
 
   /// Shared memory storage layout type for BlockHistogram
   using _TempStorage = typename InternalBlockHistogram::TempStorage;

--- a/cub/cub/block/block_histogram.cuh
+++ b/cub/cub/block/block_histogram.cuh
@@ -75,13 +75,20 @@ enum BlockHistogramAlgorithm
   //! Overview
   //! ++++++++++++++++++++++++++
   //!
-  //! Use warp-level match primitives with warp-aggregated atomic addition to update counts directly.
+  //! Use warp-level match primitives to combine updates to the same bin within each warp. One elected lane
+  //! performs an atomic add with the number of matching lanes.
   //!
   //! Performance Considerations
   //! ++++++++++++++++++++++++++
   //!
-  //! This algorithm reduces per-warp contention when multiple lanes update the same bin counter. In the most
-  //! extreme case, where each lane in a warp updates the same bin, it reduces atomic operations from 32 to 1.
+  //! This algorithm targets histograms whose counters are in global memory and whose samples are concentrated into
+  //! relatively few bins. In that case, reducing multiple contended atomic updates to one update can reduce
+  //! global-memory atomic pressure.
+  //!
+  //! The extra warp-level peer-mask, leader-election, and population-count work adds instruction overhead. If the
+  //! counters are in shared memory, prefer cub::BLOCK_HISTO_ATOMIC. If most lanes update different bins, the direct
+  //! atomic algorithm is also the better starting point. In the most contended case, where every lane in a warp
+  //! updates the same bin, this algorithm reduces atomic operations from one per lane to one per warp.
   //!
   //! @endrst
   BLOCK_HISTO_ATOMIC_WARP_AGGREGATED,
@@ -142,8 +149,11 @@ enum BlockHistogramAlgorithm
 //!
 //! - @granularity
 //! - All input values must fall between ``[0, Bins)``, or behavior is undefined.
-//! - The histogram output can be constructed in shared or device-accessible memory
+//! - The histogram output can be constructed in shared or global memory
 //! - See ``cub::BlockHistogramAlgorithm`` for performance details regarding algorithmic alternatives
+//! - ``cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED`` is primarily useful when the histogram output is in global memory
+//!   and many lanes in a warp update the same bins. For shared-memory histograms, prefer
+//!   ``cub::BLOCK_HISTO_ATOMIC``.
 //!
 //! Re-using dynamically allocating shared memory
 //! +++++++++++++++++++++++++++++++++++++++++++++
@@ -316,7 +326,7 @@ public:
   }
 
   //! @rst
-  //! Constructs a block-wide histogram in shared/device-accessible memory.
+  //! Constructs a block-wide histogram in shared or global memory.
   //! Each thread contributes an array of input elements.
   //!
   //! .. versionadded:: 2.2.0
@@ -362,7 +372,7 @@ public:
   //!   Calling thread's input values to histogram
   //!
   //! @param[out] histogram
-  //!   Reference to shared/device-accessible memory histogram
+  //!   Reference to shared or global memory histogram
   template <typename CounterT>
   _CCCL_DEVICE _CCCL_FORCEINLINE void Histogram(T (&items)[ItemsPerThread], CounterT histogram[Bins])
   {
@@ -376,7 +386,7 @@ public:
   }
 
   //! @rst
-  //! Updates an existing block-wide histogram in shared/device-accessible memory.
+  //! Updates an existing block-wide histogram in shared or global memory.
   //! Each thread composites an array of input elements.
   //!
   //! .. versionadded:: 2.2.0
@@ -426,7 +436,7 @@ public:
   //!   Calling thread's input values to histogram
   //!
   //! @param[out] histogram
-  //!   Reference to shared/device-accessible memory histogram
+  //!   Reference to shared or global memory histogram
   template <typename CounterT>
   _CCCL_DEVICE _CCCL_FORCEINLINE void Composite(T (&items)[ItemsPerThread], CounterT histogram[Bins])
   {

--- a/cub/cub/block/block_histogram.cuh
+++ b/cub/cub/block/block_histogram.cuh
@@ -191,13 +191,17 @@ private:
   /// The thread block size in threads
   static constexpr int BLOCK_THREADS = BlockDimX * BlockDimY * BlockDimZ;
 
+  static_assert(Algorithm == BLOCK_HISTO_SORT || Algorithm == BLOCK_HISTO_ATOMIC
+                  || Algorithm == BLOCK_HISTO_ATOMIC_WARP_AGGREGATED,
+                "Unsupported BlockHistogramAlgorithm");
+
   /// Internal specialization.
-  using InternalBlockHistogram = ::cuda::std::_If<
+  using InternalBlockHistogram = ::cuda::std::conditional_t<
     Algorithm == BLOCK_HISTO_SORT,
     detail::BlockHistogramSort<T, BlockDimX, ItemsPerThread, Bins, BlockDimY, BlockDimZ>,
-    ::cuda::std::_If<Algorithm == BLOCK_HISTO_ATOMIC,
-                     detail::BlockHistogramAtomic<Bins>,
-                     detail::BlockHistogramAtomicWarpAggregated<Bins, BlockDimX, BlockDimY, BlockDimZ>>>;
+    ::cuda::std::conditional_t<Algorithm == BLOCK_HISTO_ATOMIC,
+                               detail::BlockHistogramAtomic<Bins>,
+                               detail::BlockHistogramAtomicWarpAggregated<Bins, BlockDimX, BlockDimY, BlockDimZ>>>;
 
   /// Shared memory storage layout type for BlockHistogram
   using _TempStorage = typename InternalBlockHistogram::TempStorage;

--- a/cub/cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh
+++ b/cub/cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh
@@ -49,69 +49,40 @@ struct BlockHistogramAtomicWarpAggregated
   struct TempStorage
   {};
 
-  int linear_tid;
   int warp_id;
 
   //! Constructor
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE BlockHistogramAtomicWarpAggregated(TempStorage& temp_storage)
-      : linear_tid(cub::RowMajorTid(BlockDimX, BlockDimY, BlockDimZ))
-      , warp_id(linear_tid / warp_threads)
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE BlockHistogramAtomicWarpAggregated(TempStorage&)
+      : warp_id(cub::RowMajorTid(BlockDimX, BlockDimY, BlockDimZ) / warp_threads)
   {}
 
   [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE ::cuda::std::uint32_t NativePeerMaskImpl(unsigned bin) const
   {
-    if constexpr (full_warps)
-    {
-      return ::__match_any_sync(full_warp_mask, bin);
-    }
-    else
-    {
-      if (warp_id == partial_warp_id)
-      {
-        const ::cuda::std::uint32_t active_mask = ::__activemask();
-        return ::__match_any_sync(active_mask, bin);
-      }
-
-      return ::__match_any_sync(full_warp_mask, bin);
-    }
+    const auto active_mask = (full_warps || warp_id != partial_warp_id) ? full_warp_mask : ::__activemask();
+    return ::__match_any_sync(active_mask, bin);
   }
 
   [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE ::cuda::std::uint32_t NativePeerMask(unsigned bin) const
   {
-    ::cuda::std::uint32_t peer_mask;
-    NV_IF_ELSE_TARGET(
-      NV_PROVIDES_SM_70, (peer_mask = this->NativePeerMaskImpl(bin);), (peer_mask = this->BallotPeerMask(bin);));
-
-    return peer_mask;
+    NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70, (return NativePeerMaskImpl(bin);), (return BallotPeerMask(bin);));
   }
 
   [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE ::cuda::std::uint32_t BallotPeerMask(unsigned bin) const
   {
-    if constexpr (full_warps)
-    {
-      return cub::MatchAny<bin_bits>(bin);
-    }
-    else
-    {
-      if (warp_id == partial_warp_id)
-      {
-        constexpr auto partial_warp_mask = (::cuda::std::uint32_t{1} << partial_warp_threads) - 1;
-        return cub::MatchAny<bin_bits>(bin) & partial_warp_mask;
-      }
-
-      return cub::MatchAny<bin_bits>(bin);
-    }
+    constexpr auto partial_warp_mask = (::cuda::std::uint32_t{1} << partial_warp_threads) - 1;
+    const auto warp_mask             = (full_warps || warp_id != partial_warp_id) ? full_warp_mask : partial_warp_mask;
+    return cub::MatchAny<bin_bits>(bin) & warp_mask;
   }
 
   [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE ::cuda::std::uint32_t PeerMask(unsigned bin) const
   {
     if constexpr (use_ballot_peer_mask)
     {
-      return this->BallotPeerMask(bin);
+      return BallotPeerMask(bin);
     }
     else
     {
-      return this->NativePeerMask(bin);
+      return NativePeerMask(bin);
     }
   }
 
@@ -150,7 +121,7 @@ struct BlockHistogramAtomicWarpAggregated
       if (::cuda::ptx::get_sreg_laneid() == leader)
       {
         const auto count = static_cast<CounterT>(::cuda::std::popcount(peer_mask));
-        this->Add(histogram[bin], count);
+        Add(histogram[bin], count);
       }
     }
   }

--- a/cub/cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh
+++ b/cub/cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh
@@ -19,6 +19,8 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cub/util_ptx.cuh>
+
 #include <cuda/__ptx/instructions/get_sreg.h>
 
 CUB_NAMESPACE_BEGIN
@@ -28,15 +30,37 @@ namespace detail
  * @brief The BlockHistogramAtomicWarpAggregated class provides raw warp intrinsic based methods for constructing
  *        block-wide histograms from data samples partitioned across a CUDA thread block.
  */
-template <int Bins>
+template <int Bins, int BlockDimX, int BlockDimY, int BlockDimZ>
 struct BlockHistogramAtomicWarpAggregated
 {
+  static constexpr int BLOCK_THREADS        = BlockDimX * BlockDimY * BlockDimZ;
+  static constexpr int PARTIAL_WARP_THREADS = BLOCK_THREADS % detail::warp_threads;
+  static constexpr int PARTIAL_WARP_ID      = BLOCK_THREADS / detail::warp_threads;
+
   /// Shared memory storage layout type
   struct TempStorage
   {};
 
+  unsigned int linear_tid;
+
   /// Constructor
-  _CCCL_DEVICE _CCCL_FORCEINLINE BlockHistogramAtomicWarpAggregated(TempStorage& temp_storage) {}
+  _CCCL_DEVICE _CCCL_FORCEINLINE BlockHistogramAtomicWarpAggregated(TempStorage& temp_storage)
+      : linear_tid(RowMajorTid(BlockDimX, BlockDimY, BlockDimZ))
+  {}
+
+  template <int BIN_BITS>
+  _CCCL_DEVICE _CCCL_FORCEINLINE unsigned int FallbackPeerMask(unsigned int bin) const
+  {
+    if constexpr (PARTIAL_WARP_THREADS == 0)
+    {
+      return MatchAny<BIN_BITS>(bin);
+    }
+    else
+    {
+      const unsigned int warp_id = linear_tid / detail::warp_threads;
+      return (warp_id == PARTIAL_WARP_ID) ? MatchAny<BIN_BITS, PARTIAL_WARP_THREADS>(bin) : MatchAny<BIN_BITS>(bin);
+    }
+  }
 
   /**
    * @brief Composite data onto an existing histogram
@@ -50,12 +74,17 @@ struct BlockHistogramAtomicWarpAggregated
   template <typename T, typename CounterT, int ITEMS_PER_THREAD>
   _CCCL_DEVICE _CCCL_FORCEINLINE void Composite(T (&items)[ITEMS_PER_THREAD], CounterT histogram[Bins])
   {
+    constexpr int BIN_BITS = (Bins <= 1) ? 1 : Log2<Bins>::VALUE;
+
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < ITEMS_PER_THREAD; ++i)
     {
-      const unsigned int bin       = static_cast<unsigned int>(items[i]);
-      const unsigned int peer_mask = __match_any_sync(__activemask(), bin);
-      const int leader             = __ffs(static_cast<int>(peer_mask)) - 1;
+      const unsigned int bin = static_cast<unsigned int>(items[i]);
+      unsigned int peer_mask;
+      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70,
+                        (peer_mask = __match_any_sync(__activemask(), bin);),
+                        (peer_mask = FallbackPeerMask<BIN_BITS>(bin);));
+      const int leader = __ffs(static_cast<int>(peer_mask)) - 1;
 
       if (static_cast<int>(::cuda::ptx::get_sreg_laneid()) == leader)
       {

--- a/cub/cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh
+++ b/cub/cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh
@@ -21,15 +21,9 @@
 
 #include <cuda/__ptx/instructions/get_sreg.h>
 
-#include <cooperative_groups.h>
-
-#include <cooperative_groups/reduce.h>
-
 CUB_NAMESPACE_BEGIN
 namespace detail
 {
-namespace cg = cooperative_groups;
-
 /**
  * @brief The BlockHistogramAtomicWarpAggregated class provides raw warp intrinsic based methods for constructing
  *        block-wide histograms from data samples partitioned across a CUDA thread block.
@@ -66,48 +60,6 @@ struct BlockHistogramAtomicWarpAggregated
       if (static_cast<int>(::cuda::ptx::get_sreg_laneid()) == leader)
       {
         atomicAdd(histogram + bin, static_cast<CounterT>(__popc(peer_mask)));
-      }
-    }
-  }
-};
-
-/**
- * @brief The BlockHistogramAtomicWarpAggregatedCg class provides cooperative-groups based methods for constructing
- *        block-wide histograms from data samples partitioned across a CUDA thread block.
- */
-template <int Bins>
-struct BlockHistogramAtomicWarpAggregatedCg
-{
-  /// Shared memory storage layout type
-  struct TempStorage
-  {};
-
-  /// Constructor
-  _CCCL_DEVICE _CCCL_FORCEINLINE BlockHistogramAtomicWarpAggregatedCg(TempStorage& temp_storage) {}
-
-  /**
-   * @brief Composite data onto an existing histogram
-   *
-   * @param[in] items
-   *   Calling thread's input values to histogram
-   *
-   * @param[out] histogram
-   *   Reference to shared/device-accessible memory histogram
-   */
-  template <typename T, typename CounterT, int ITEMS_PER_THREAD>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void Composite(T (&items)[ITEMS_PER_THREAD], CounterT histogram[Bins])
-  {
-    _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < ITEMS_PER_THREAD; ++i)
-    {
-      cg::coalesced_group active = cg::coalesced_threads();
-      const T bin                = items[i];
-      auto bin_group             = cg::labeled_partition(active, bin);
-      const CounterT votes       = cg::reduce(bin_group, CounterT{1}, cg::plus<CounterT>());
-
-      if (bin_group.thread_rank() == 0)
-      {
-        atomicAdd(histogram + bin, votes);
       }
     }
   }

--- a/cub/cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh
+++ b/cub/cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh
@@ -20,11 +20,9 @@
 #include <cub/util_ptx.cuh>
 
 #include <cuda/__cmath/ilog.h>
-#include <cuda/__memory/address_space.h>
 #include <cuda/__ptx/instructions/bfind.h>
 #include <cuda/__ptx/instructions/elect_sync.h>
 #include <cuda/__ptx/instructions/get_sreg.h>
-#include <cuda/atomic>
 #include <cuda/std/__bit/popcount.h>
 #include <cuda/std/cstdint>
 
@@ -97,16 +95,7 @@ struct BlockHistogramAtomicWarpAggregated
   template <typename CounterT>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void Add(CounterT& counter_ref, CounterT count) const
   {
-    if (::cuda::device::is_address_from(&counter_ref, ::cuda::device::address_space::shared))
-    {
-      ::cuda::atomic_ref<CounterT, ::cuda::thread_scope_block> counter(counter_ref);
-      counter.fetch_add(count, ::cuda::memory_order_relaxed);
-    }
-    else
-    {
-      ::cuda::atomic_ref<CounterT, ::cuda::thread_scope_device> counter(counter_ref);
-      counter.fetch_add(count, ::cuda::memory_order_relaxed);
-    }
+    atomicAdd(&counter_ref, count);
   }
 
   //! @brief Composite data onto an existing histogram
@@ -117,12 +106,15 @@ struct BlockHistogramAtomicWarpAggregated
   //! @param[out] histogram
   //!   Reference to shared or global memory histogram
   template <typename T, typename CounterT, int ItemsPerThread>
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE void Composite(T (&items)[ItemsPerThread], CounterT histogram[Bins]) const
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void Composite(const T (&items)[ItemsPerThread], CounterT histogram[Bins]) const
   {
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < ItemsPerThread; ++i)
     {
-      const auto bin       = static_cast<unsigned>(items[i]);
+      const auto bin_value = static_cast<::cuda::std::uint64_t>(items[i]);
+      _CCCL_ASSERT(bin_value < static_cast<::cuda::std::uint64_t>(Bins), "sample value must be in [0, Bins)");
+
+      const auto bin       = static_cast<unsigned>(bin_value);
       const auto peer_mask = this->PeerMask(bin);
 
       if (IsLeader(peer_mask))

--- a/cub/cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh
+++ b/cub/cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh
@@ -41,15 +41,15 @@ struct BlockHistogramAtomicWarpAggregated
   struct TempStorage
   {};
 
-  unsigned int linear_tid;
+  unsigned int linear_tid_;
 
   /// Constructor
   _CCCL_DEVICE _CCCL_FORCEINLINE BlockHistogramAtomicWarpAggregated(TempStorage& temp_storage)
-      : linear_tid(RowMajorTid(BlockDimX, BlockDimY, BlockDimZ))
+      : linear_tid_(RowMajorTid(BlockDimX, BlockDimY, BlockDimZ))
   {}
 
   template <int BIN_BITS>
-  _CCCL_DEVICE _CCCL_FORCEINLINE unsigned int FallbackPeerMask(unsigned int bin) const
+  [[nodiscard]] _CCCL_DEVICE _CCCL_FORCEINLINE unsigned int FallbackPeerMask(unsigned int bin) const
   {
     if constexpr (PARTIAL_WARP_THREADS == 0)
     {
@@ -57,7 +57,7 @@ struct BlockHistogramAtomicWarpAggregated
     }
     else
     {
-      const unsigned int warp_id = linear_tid / detail::warp_threads;
+      const unsigned int warp_id = linear_tid_ / detail::warp_threads;
       return (warp_id == PARTIAL_WARP_ID) ? MatchAny<BIN_BITS, PARTIAL_WARP_THREADS>(bin) : MatchAny<BIN_BITS>(bin);
     }
   }

--- a/cub/cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh
+++ b/cub/cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh
@@ -1,11 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-// SPDX-License-Identifier: BSD-3
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-/**
- * @file
- * The cub::BlockHistogramAtomicWarpAggregated class provides warp-aggregated atomic methods for
- * constructing block-wide histograms from data samples partitioned across a CUDA thread block.
- */
+//! @file
+//! The cub::BlockHistogramAtomicWarpAggregated class provides warp-aggregated atomic methods for
+//! constructing block-wide histograms from data samples partitioned across a CUDA thread block.
 
 #pragma once
 
@@ -21,74 +19,138 @@
 
 #include <cub/util_ptx.cuh>
 
+#include <cuda/__atomic/atomic.h>
+#include <cuda/__cmath/ilog.h>
+#include <cuda/__memory/address_space.h>
+#include <cuda/__ptx/instructions/bfind.h>
 #include <cuda/__ptx/instructions/get_sreg.h>
+#include <cuda/std/__bit/popcount.h>
+#include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
 namespace detail
 {
-/**
- * @brief The BlockHistogramAtomicWarpAggregated class provides raw warp intrinsic based methods for constructing
- *        block-wide histograms from data samples partitioned across a CUDA thread block.
- */
+//! @brief The BlockHistogramAtomicWarpAggregated class provides raw warp intrinsic based methods for constructing
+//!        block-wide histograms from data samples partitioned across a CUDA thread block.
 template <int Bins, int BlockDimX, int BlockDimY, int BlockDimZ>
 struct BlockHistogramAtomicWarpAggregated
 {
-  static constexpr int BLOCK_THREADS        = BlockDimX * BlockDimY * BlockDimZ;
-  static constexpr int PARTIAL_WARP_THREADS = BLOCK_THREADS % detail::warp_threads;
-  static constexpr int PARTIAL_WARP_ID      = BLOCK_THREADS / detail::warp_threads;
+  static constexpr int warp_threads                     = detail::warp_threads;
+  static constexpr int block_threads                    = BlockDimX * BlockDimY * BlockDimZ;
+  static constexpr int partial_warp_threads             = block_threads % warp_threads;
+  static constexpr int partial_warp_id                  = block_threads / warp_threads;
+  static constexpr bool full_warps                      = partial_warp_threads == 0;
+  static constexpr int bin_bits                         = (Bins <= 1) ? 1 : ::cuda::ceil_ilog2(Bins);
+  static constexpr int ballot_peer_mask_max_bits        = ::cuda::ceil_ilog2(warp_threads);
+  static constexpr bool use_ballot_peer_mask            = bin_bits <= ballot_peer_mask_max_bits;
+  static constexpr ::cuda::std::uint32_t full_warp_mask = 0xFFFFFFFFu;
 
-  /// Shared memory storage layout type
+  //! Shared memory storage layout type
   struct TempStorage
   {};
 
-  unsigned int linear_tid_;
+  int linear_tid;
+  int warp_id;
 
-  /// Constructor
-  _CCCL_DEVICE _CCCL_FORCEINLINE BlockHistogramAtomicWarpAggregated(TempStorage& temp_storage)
-      : linear_tid_(RowMajorTid(BlockDimX, BlockDimY, BlockDimZ))
+  //! Constructor
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE BlockHistogramAtomicWarpAggregated(TempStorage& temp_storage)
+      : linear_tid(cub::RowMajorTid(BlockDimX, BlockDimY, BlockDimZ))
+      , warp_id(linear_tid / warp_threads)
   {}
 
-  template <int BIN_BITS>
-  [[nodiscard]] _CCCL_DEVICE _CCCL_FORCEINLINE unsigned int FallbackPeerMask(unsigned int bin) const
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE ::cuda::std::uint32_t NativePeerMaskImpl(unsigned bin) const
   {
-    if constexpr (PARTIAL_WARP_THREADS == 0)
+    if constexpr (full_warps)
     {
-      return MatchAny<BIN_BITS>(bin);
+      return ::__match_any_sync(full_warp_mask, bin);
     }
     else
     {
-      const unsigned int warp_id = linear_tid_ / detail::warp_threads;
-      return (warp_id == PARTIAL_WARP_ID) ? MatchAny<BIN_BITS, PARTIAL_WARP_THREADS>(bin) : MatchAny<BIN_BITS>(bin);
+      if (warp_id == partial_warp_id)
+      {
+        const ::cuda::std::uint32_t active_mask = ::__activemask();
+        return ::__match_any_sync(active_mask, bin);
+      }
+
+      return ::__match_any_sync(full_warp_mask, bin);
     }
   }
 
-  /**
-   * @brief Composite data onto an existing histogram
-   *
-   * @param[in] items
-   *   Calling thread's input values to histogram
-   *
-   * @param[out] histogram
-   *   Reference to shared/device-accessible memory histogram
-   */
-  template <typename T, typename CounterT, int ITEMS_PER_THREAD>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void Composite(T (&items)[ITEMS_PER_THREAD], CounterT histogram[Bins])
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE ::cuda::std::uint32_t NativePeerMask(unsigned bin) const
   {
-    constexpr int BIN_BITS = (Bins <= 1) ? 1 : Log2<Bins>::VALUE;
+    ::cuda::std::uint32_t peer_mask;
+    NV_IF_ELSE_TARGET(
+      NV_PROVIDES_SM_70, (peer_mask = this->NativePeerMaskImpl(bin);), (peer_mask = this->BallotPeerMask(bin);));
 
-    _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < ITEMS_PER_THREAD; ++i)
+    return peer_mask;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE ::cuda::std::uint32_t BallotPeerMask(unsigned bin) const
+  {
+    if constexpr (full_warps)
     {
-      const unsigned int bin = static_cast<unsigned int>(items[i]);
-      unsigned int peer_mask;
-      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70,
-                        (peer_mask = __match_any_sync(__activemask(), bin);),
-                        (peer_mask = FallbackPeerMask<BIN_BITS>(bin);));
-      const int leader = __ffs(static_cast<int>(peer_mask)) - 1;
-
-      if (static_cast<int>(::cuda::ptx::get_sreg_laneid()) == leader)
+      return cub::MatchAny<bin_bits>(bin);
+    }
+    else
+    {
+      if (warp_id == partial_warp_id)
       {
-        atomicAdd(histogram + bin, static_cast<CounterT>(__popc(peer_mask)));
+        constexpr auto partial_warp_mask = (::cuda::std::uint32_t{1} << partial_warp_threads) - 1;
+        return cub::MatchAny<bin_bits>(bin) & partial_warp_mask;
+      }
+
+      return cub::MatchAny<bin_bits>(bin);
+    }
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE ::cuda::std::uint32_t PeerMask(unsigned bin) const
+  {
+    if constexpr (use_ballot_peer_mask)
+    {
+      return this->BallotPeerMask(bin);
+    }
+    else
+    {
+      return this->NativePeerMask(bin);
+    }
+  }
+
+  template <typename CounterT>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void Add(CounterT& counter_ref, CounterT count) const
+  {
+    if (::cuda::device::is_address_from(&counter_ref, ::cuda::device::address_space::shared))
+    {
+      ::cuda::atomic_ref<CounterT, ::cuda::thread_scope_block> counter(counter_ref);
+      counter.fetch_add(count, ::cuda::memory_order_relaxed);
+    }
+    else
+    {
+      ::cuda::atomic_ref<CounterT, ::cuda::thread_scope_device> counter(counter_ref);
+      counter.fetch_add(count, ::cuda::memory_order_relaxed);
+    }
+  }
+
+  //! @brief Composite data onto an existing histogram
+  //!
+  //! @param[in] items
+  //!   Calling thread's input values to histogram
+  //!
+  //! @param[out] histogram
+  //!   Reference to shared/device-accessible memory histogram
+  template <typename T, typename CounterT, int ItemsPerThread>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void Composite(T (&items)[ItemsPerThread], CounterT histogram[Bins]) const
+  {
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < ItemsPerThread; ++i)
+    {
+      const auto bin       = static_cast<unsigned>(items[i]);
+      const auto peer_mask = this->PeerMask(bin);
+      const auto leader    = ::cuda::ptx::bfind(peer_mask);
+
+      if (::cuda::ptx::get_sreg_laneid() == leader)
+      {
+        const auto count = static_cast<CounterT>(::cuda::std::popcount(peer_mask));
+        this->Add(histogram[bin], count);
       }
     }
   }

--- a/cub/cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh
+++ b/cub/cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh
@@ -105,6 +105,9 @@ struct BlockHistogramAtomicWarpAggregated
   //!
   //! @param[out] histogram
   //!   Reference to shared or global memory histogram
+  //!
+  //! @tparam CounterT
+  //!   Counter type accepted by CUDA atomicAdd
   template <typename T, typename CounterT, int ItemsPerThread>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void Composite(const T (&items)[ItemsPerThread], CounterT histogram[Bins]) const
   {

--- a/cub/cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh
+++ b/cub/cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3
+
+/**
+ * @file
+ * The cub::BlockHistogramAtomicWarpAggregated class provides warp-aggregated atomic methods for
+ * constructing block-wide histograms from data samples partitioned across a CUDA thread block.
+ */
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__ptx/instructions/get_sreg.h>
+
+#include <cooperative_groups.h>
+
+#include <cooperative_groups/reduce.h>
+
+CUB_NAMESPACE_BEGIN
+namespace detail
+{
+namespace cg = cooperative_groups;
+
+/**
+ * @brief The BlockHistogramAtomicWarpAggregated class provides raw warp intrinsic based methods for constructing
+ *        block-wide histograms from data samples partitioned across a CUDA thread block.
+ */
+template <int Bins>
+struct BlockHistogramAtomicWarpAggregated
+{
+  /// Shared memory storage layout type
+  struct TempStorage
+  {};
+
+  /// Constructor
+  _CCCL_DEVICE _CCCL_FORCEINLINE BlockHistogramAtomicWarpAggregated(TempStorage& temp_storage) {}
+
+  /**
+   * @brief Composite data onto an existing histogram
+   *
+   * @param[in] items
+   *   Calling thread's input values to histogram
+   *
+   * @param[out] histogram
+   *   Reference to shared/device-accessible memory histogram
+   */
+  template <typename T, typename CounterT, int ITEMS_PER_THREAD>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void Composite(T (&items)[ITEMS_PER_THREAD], CounterT histogram[Bins])
+  {
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < ITEMS_PER_THREAD; ++i)
+    {
+      const unsigned int bin       = static_cast<unsigned int>(items[i]);
+      const unsigned int peer_mask = __match_any_sync(__activemask(), bin);
+      const int leader             = __ffs(static_cast<int>(peer_mask)) - 1;
+
+      if (static_cast<int>(::cuda::ptx::get_sreg_laneid()) == leader)
+      {
+        atomicAdd(histogram + bin, static_cast<CounterT>(__popc(peer_mask)));
+      }
+    }
+  }
+};
+
+/**
+ * @brief The BlockHistogramAtomicWarpAggregatedCg class provides cooperative-groups based methods for constructing
+ *        block-wide histograms from data samples partitioned across a CUDA thread block.
+ */
+template <int Bins>
+struct BlockHistogramAtomicWarpAggregatedCg
+{
+  /// Shared memory storage layout type
+  struct TempStorage
+  {};
+
+  /// Constructor
+  _CCCL_DEVICE _CCCL_FORCEINLINE BlockHistogramAtomicWarpAggregatedCg(TempStorage& temp_storage) {}
+
+  /**
+   * @brief Composite data onto an existing histogram
+   *
+   * @param[in] items
+   *   Calling thread's input values to histogram
+   *
+   * @param[out] histogram
+   *   Reference to shared/device-accessible memory histogram
+   */
+  template <typename T, typename CounterT, int ITEMS_PER_THREAD>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void Composite(T (&items)[ITEMS_PER_THREAD], CounterT histogram[Bins])
+  {
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < ITEMS_PER_THREAD; ++i)
+    {
+      cg::coalesced_group active = cg::coalesced_threads();
+      const T bin                = items[i];
+      auto bin_group             = cg::labeled_partition(active, bin);
+      const CounterT votes       = cg::reduce(bin_group, CounterT{1}, cg::plus<CounterT>());
+
+      if (bin_group.thread_rank() == 0)
+      {
+        atomicAdd(histogram + bin, votes);
+      }
+    }
+  }
+};
+} // namespace detail
+
+CUB_NAMESPACE_END

--- a/cub/cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh
+++ b/cub/cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh
@@ -19,11 +19,12 @@
 
 #include <cub/util_ptx.cuh>
 
-#include <cuda/__atomic/atomic.h>
 #include <cuda/__cmath/ilog.h>
 #include <cuda/__memory/address_space.h>
 #include <cuda/__ptx/instructions/bfind.h>
+#include <cuda/__ptx/instructions/elect_sync.h>
 #include <cuda/__ptx/instructions/get_sreg.h>
+#include <cuda/atomic>
 #include <cuda/std/__bit/popcount.h>
 #include <cuda/std/cstdint>
 
@@ -86,6 +87,13 @@ struct BlockHistogramAtomicWarpAggregated
     }
   }
 
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE bool IsLeader(::cuda::std::uint32_t peer_mask) const
+  {
+    NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,
+                      (return ::cuda::ptx::elect_sync(peer_mask);),
+                      (return ::cuda::ptx::get_sreg_laneid() == ::cuda::ptx::bfind(peer_mask);));
+  }
+
   template <typename CounterT>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void Add(CounterT& counter_ref, CounterT count) const
   {
@@ -107,7 +115,7 @@ struct BlockHistogramAtomicWarpAggregated
   //!   Calling thread's input values to histogram
   //!
   //! @param[out] histogram
-  //!   Reference to shared/device-accessible memory histogram
+  //!   Reference to shared or global memory histogram
   template <typename T, typename CounterT, int ItemsPerThread>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void Composite(T (&items)[ItemsPerThread], CounterT histogram[Bins]) const
   {
@@ -116,9 +124,8 @@ struct BlockHistogramAtomicWarpAggregated
     {
       const auto bin       = static_cast<unsigned>(items[i]);
       const auto peer_mask = this->PeerMask(bin);
-      const auto leader    = ::cuda::ptx::bfind(peer_mask);
 
-      if (::cuda::ptx::get_sreg_laneid() == leader)
+      if (IsLeader(peer_mask))
       {
         const auto count = static_cast<CounterT>(::cuda::std::popcount(peer_mask));
         Add(histogram[bin], count);

--- a/cub/test/catch2_test_block_histogram.cu
+++ b/cub/test/catch2_test_block_histogram.cu
@@ -123,6 +123,11 @@ using algorithms =
                       cub::BLOCK_HISTO_SORT,
                       cub::BLOCK_HISTO_ATOMIC,
                       cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED>;
+using warp_aggregated_algorithm =
+  c2h::enum_type_list<cub::BlockHistogramAlgorithm, cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED>;
+using composite_items_per_thread        = c2h::enum_type_list<int, 3>;
+using global_composite_threads_in_block = c2h::enum_type_list<int, 64>;
+using shared_composite_threads_in_block = c2h::enum_type_list<int, 33>;
 
 template <class TestType>
 struct params_t
@@ -235,55 +240,63 @@ C2H_TEST("Block histogram can be computed with random input",
   REQUIRE(h_reference == d_histogram);
 }
 
-TEST_CASE("Block histogram warp-aggregated composite updates a global histogram from multiple blocks",
-          "[histogram][block]")
+C2H_TEST("Block histogram warp-aggregated composite updates a global histogram from multiple blocks",
+         "[histogram][block]",
+         types,
+         composite_items_per_thread,
+         global_composite_threads_in_block,
+         bins,
+         warp_aggregated_algorithm)
 {
-  using sample_t = std::uint16_t;
+  using params   = params_t<TestType>;
+  using sample_t = typename params::sample_t;
 
-  static constexpr int items_per_thread = 3;
-  static constexpr int threads_in_block = 64;
-  static constexpr int num_blocks       = 5;
-  static constexpr int num_bins         = TEST_BINS;
-  static constexpr int num_samples      = num_blocks * threads_in_block * items_per_thread;
+  static constexpr int num_blocks  = 5;
+  static constexpr int num_samples = num_blocks * params::num_samples;
 
   c2h::host_vector<sample_t> h_samples(num_samples);
   for (int i = 0; i < num_samples; ++i)
   {
-    h_samples[static_cast<std::size_t>(i)] = static_cast<sample_t>(i % num_bins);
+    h_samples[static_cast<std::size_t>(i)] = static_cast<sample_t>(i % params::bins);
   }
 
-  auto h_reference = compute_host_reference(num_bins, h_samples);
+  auto h_reference = compute_host_reference(params::bins, h_samples);
 
   c2h::device_vector<sample_t> d_samples = h_samples;
-  c2h::device_vector<int> d_histogram(num_bins, 0);
+  c2h::device_vector<int> d_histogram(params::bins, 0);
 
-  block_histogram_composite<items_per_thread, threads_in_block, num_bins>(d_samples, d_histogram, num_blocks);
+  block_histogram_composite<params::items_per_thread, params::threads_in_block, params::bins>(
+    d_samples, d_histogram, num_blocks);
 
   REQUIRE(h_reference == d_histogram);
 }
 
-TEST_CASE("Block histogram warp-aggregated composite updates a shared histogram from a partial warp block",
-          "[histogram][block]")
+C2H_TEST("Block histogram warp-aggregated composite updates a shared histogram from a partial warp block",
+         "[histogram][block]",
+         types,
+         composite_items_per_thread,
+         shared_composite_threads_in_block,
+         bins,
+         warp_aggregated_algorithm)
 {
-  using sample_t = std::uint16_t;
+  using params   = params_t<TestType>;
+  using sample_t = typename params::sample_t;
 
-  static constexpr int items_per_thread = 3;
-  static constexpr int threads_in_block = 33;
-  static constexpr int num_bins         = TEST_BINS;
-  static constexpr int num_samples      = threads_in_block * items_per_thread;
+  static constexpr int num_samples = params::num_samples;
 
   c2h::host_vector<sample_t> h_samples(num_samples);
   for (int i = 0; i < num_samples; ++i)
   {
-    h_samples[static_cast<std::size_t>(i)] = static_cast<sample_t>(i % num_bins);
+    h_samples[static_cast<std::size_t>(i)] = static_cast<sample_t>(i % params::bins);
   }
 
-  auto h_reference = compute_host_reference(num_bins, h_samples);
+  auto h_reference = compute_host_reference(params::bins, h_samples);
 
   c2h::device_vector<sample_t> d_samples = h_samples;
-  c2h::device_vector<int> d_histogram(num_bins, 0);
+  c2h::device_vector<int> d_histogram(params::bins, 0);
 
-  block_histogram_composite_shared<items_per_thread, threads_in_block, num_bins>(d_samples, d_histogram);
+  block_histogram_composite_shared<params::items_per_thread, params::threads_in_block, params::bins>(
+    d_samples, d_histogram);
 
   REQUIRE(h_reference == d_histogram);
 }

--- a/cub/test/catch2_test_block_histogram.cu
+++ b/cub/test/catch2_test_block_histogram.cu
@@ -56,7 +56,7 @@ __global__ void block_histogram_composite_kernel(T* d_samples, HistoCounter* d_h
   __shared__ typename block_histogram_t::TempStorage temp_storage;
 
   T data[ItemsPerThread];
-  const int block_offset = blockIdx.x * BlockThreads * ItemsPerThread;
+  int block_offset = blockIdx.x * BlockThreads * ItemsPerThread;
   cub::LoadDirectStriped<BlockThreads>(threadIdx.x, d_samples + block_offset, data);
 
   block_histogram_t(temp_storage).Composite(data, d_histogram);
@@ -257,7 +257,7 @@ C2H_TEST("Block histogram warp-aggregated composite updates a global histogram f
   c2h::host_vector<sample_t> h_samples(num_samples);
   for (int i = 0; i < num_samples; ++i)
   {
-    h_samples[static_cast<std::size_t>(i)] = static_cast<sample_t>(i % params::bins);
+    h_samples[i] = static_cast<sample_t>(i % params::bins);
   }
 
   auto h_reference = compute_host_reference(params::bins, h_samples);
@@ -287,7 +287,7 @@ C2H_TEST("Block histogram warp-aggregated composite updates a shared histogram f
   c2h::host_vector<sample_t> h_samples(num_samples);
   for (int i = 0; i < num_samples; ++i)
   {
-    h_samples[static_cast<std::size_t>(i)] = static_cast<sample_t>(i % params::bins);
+    h_samples[i] = static_cast<sample_t>(i % params::bins);
   }
 
   auto h_reference = compute_host_reference(params::bins, h_samples);

--- a/cub/test/catch2_test_block_histogram.cu
+++ b/cub/test/catch2_test_block_histogram.cu
@@ -57,8 +57,7 @@ using algorithms =
   c2h::enum_type_list<cub::BlockHistogramAlgorithm,
                       cub::BLOCK_HISTO_SORT,
                       cub::BLOCK_HISTO_ATOMIC,
-                      cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED,
-                      cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED_CG>;
+                      cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED>;
 
 template <class TestType>
 struct params_t

--- a/cub/test/catch2_test_block_histogram.cu
+++ b/cub/test/catch2_test_block_histogram.cu
@@ -15,23 +15,23 @@
 
 #include <c2h/catch2_test_helper.h>
 
-template <int BINS,
-          int BLOCK_THREADS,
-          int ITEMS_PER_THREAD,
-          cub::BlockHistogramAlgorithm ALGORITHM,
+template <int Bins,
+          int BlockThreads,
+          int ItemsPerThread,
+          cub::BlockHistogramAlgorithm Algorithm,
           typename T,
           typename HistoCounter>
 __global__ void block_histogram_kernel(T* d_samples, HistoCounter* d_histogram)
 {
   // Parameterize BlockHistogram type for our thread block
-  using block_histogram_t = cub::BlockHistogram<T, BLOCK_THREADS, ITEMS_PER_THREAD, BINS, ALGORITHM>;
+  using block_histogram_t = cub::BlockHistogram<T, BlockThreads, ItemsPerThread, Bins, Algorithm>;
 
   // Allocate temp storage in shared memory
   __shared__ typename block_histogram_t::TempStorage temp_storage;
 
   // Per-thread tile data
-  T data[ITEMS_PER_THREAD];
-  cub::LoadDirectStriped<BLOCK_THREADS>(threadIdx.x, d_samples, data);
+  T data[ItemsPerThread];
+  cub::LoadDirectStriped<BlockThreads>(threadIdx.x, d_samples, data);
 
   // Test histo (writing directly to histogram buffer in global)
   block_histogram_t(temp_storage).Histogram(data, d_histogram);
@@ -41,6 +41,71 @@ template <int ItemsPerThread, int ThreadsInBlock, int Bins, cub::BlockHistogramA
 void block_histogram(c2h::device_vector<SampleT>& d_samples, c2h::device_vector<int>& d_histogram)
 {
   block_histogram_kernel<Bins, ThreadsInBlock, ItemsPerThread, Algorithm>
+    <<<1, ThreadsInBlock>>>(thrust::raw_pointer_cast(d_samples.data()), thrust::raw_pointer_cast(d_histogram.data()));
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+}
+
+template <int Bins, int BlockThreads, int ItemsPerThread, typename T, typename HistoCounter>
+__global__ void block_histogram_composite_kernel(T* d_samples, HistoCounter* d_histogram)
+{
+  using block_histogram_t =
+    cub::BlockHistogram<T, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED>;
+
+  __shared__ typename block_histogram_t::TempStorage temp_storage;
+
+  T data[ItemsPerThread];
+  const int block_offset = blockIdx.x * BlockThreads * ItemsPerThread;
+  cub::LoadDirectStriped<BlockThreads>(threadIdx.x, d_samples + block_offset, data);
+
+  block_histogram_t(temp_storage).Composite(data, d_histogram);
+}
+
+template <int ItemsPerThread, int ThreadsInBlock, int Bins, typename SampleT>
+void block_histogram_composite(
+  c2h::device_vector<SampleT>& d_samples, c2h::device_vector<int>& d_histogram, int num_blocks)
+{
+  block_histogram_composite_kernel<Bins, ThreadsInBlock, ItemsPerThread><<<num_blocks, ThreadsInBlock>>>(
+    thrust::raw_pointer_cast(d_samples.data()), thrust::raw_pointer_cast(d_histogram.data()));
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+}
+
+template <int Bins, int BlockThreads, int ItemsPerThread, typename T, typename HistoCounter>
+__global__ void block_histogram_composite_shared_kernel(T* d_samples, HistoCounter* d_histogram)
+{
+  using block_histogram_t =
+    cub::BlockHistogram<T, BlockThreads, ItemsPerThread, Bins, cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED>;
+
+  __shared__ typename block_histogram_t::TempStorage temp_storage;
+  __shared__ HistoCounter s_histogram[Bins];
+
+  for (int bin = threadIdx.x; bin < Bins; bin += BlockThreads)
+  {
+    s_histogram[bin] = 0;
+  }
+
+  __syncthreads();
+
+  T data[ItemsPerThread];
+  cub::LoadDirectStriped<BlockThreads>(threadIdx.x, d_samples, data);
+
+  block_histogram_t(temp_storage).Composite(data, s_histogram);
+
+  __syncthreads();
+
+  for (int bin = threadIdx.x; bin < Bins; bin += BlockThreads)
+  {
+    d_histogram[bin] = s_histogram[bin];
+  }
+}
+
+template <int ItemsPerThread, int ThreadsInBlock, int Bins, typename SampleT>
+void block_histogram_composite_shared(c2h::device_vector<SampleT>& d_samples, c2h::device_vector<int>& d_histogram)
+{
+  block_histogram_composite_shared_kernel<Bins, ThreadsInBlock, ItemsPerThread>
     <<<1, ThreadsInBlock>>>(thrust::raw_pointer_cast(d_samples.data()), thrust::raw_pointer_cast(d_histogram.data()));
 
   REQUIRE(cudaSuccess == cudaPeekAtLastError());
@@ -166,6 +231,59 @@ C2H_TEST("Block histogram can be computed with random input",
   // Run kernel
   block_histogram<params::items_per_thread, params::threads_in_block, params::bins, params::algorithm>(
     d_samples, d_histogram);
+
+  REQUIRE(h_reference == d_histogram);
+}
+
+TEST_CASE("Block histogram warp-aggregated composite updates a global histogram from multiple blocks",
+          "[histogram][block]")
+{
+  using sample_t = std::uint16_t;
+
+  static constexpr int items_per_thread = 3;
+  static constexpr int threads_in_block = 64;
+  static constexpr int num_blocks       = 5;
+  static constexpr int num_bins         = TEST_BINS;
+  static constexpr int num_samples      = num_blocks * threads_in_block * items_per_thread;
+
+  c2h::host_vector<sample_t> h_samples(num_samples);
+  for (int i = 0; i < num_samples; ++i)
+  {
+    h_samples[static_cast<std::size_t>(i)] = static_cast<sample_t>(i % num_bins);
+  }
+
+  auto h_reference = compute_host_reference(num_bins, h_samples);
+
+  c2h::device_vector<sample_t> d_samples = h_samples;
+  c2h::device_vector<int> d_histogram(num_bins, 0);
+
+  block_histogram_composite<items_per_thread, threads_in_block, num_bins>(d_samples, d_histogram, num_blocks);
+
+  REQUIRE(h_reference == d_histogram);
+}
+
+TEST_CASE("Block histogram warp-aggregated composite updates a shared histogram from a partial warp block",
+          "[histogram][block]")
+{
+  using sample_t = std::uint16_t;
+
+  static constexpr int items_per_thread = 3;
+  static constexpr int threads_in_block = 33;
+  static constexpr int num_bins         = TEST_BINS;
+  static constexpr int num_samples      = threads_in_block * items_per_thread;
+
+  c2h::host_vector<sample_t> h_samples(num_samples);
+  for (int i = 0; i < num_samples; ++i)
+  {
+    h_samples[static_cast<std::size_t>(i)] = static_cast<sample_t>(i % num_bins);
+  }
+
+  auto h_reference = compute_host_reference(num_bins, h_samples);
+
+  c2h::device_vector<sample_t> d_samples = h_samples;
+  c2h::device_vector<int> d_histogram(num_bins, 0);
+
+  block_histogram_composite_shared<items_per_thread, threads_in_block, num_bins>(d_samples, d_histogram);
 
   REQUIRE(h_reference == d_histogram);
 }

--- a/cub/test/catch2_test_block_histogram.cu
+++ b/cub/test/catch2_test_block_histogram.cu
@@ -53,7 +53,12 @@ using types            = c2h::type_list<std::uint8_t, std::uint16_t>;
 using threads_in_block = c2h::enum_type_list<int, 32, 96, 128>;
 using items_per_thread = c2h::enum_type_list<int, 1, 5>;
 using bins             = c2h::enum_type_list<int, TEST_BINS>;
-using algorithms = c2h::enum_type_list<cub::BlockHistogramAlgorithm, cub::BLOCK_HISTO_SORT, cub::BLOCK_HISTO_ATOMIC>;
+using algorithms =
+  c2h::enum_type_list<cub::BlockHistogramAlgorithm,
+                      cub::BLOCK_HISTO_SORT,
+                      cub::BLOCK_HISTO_ATOMIC,
+                      cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED,
+                      cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED_CG>;
 
 template <class TestType>
 struct params_t

--- a/cub/test/catch2_test_block_histogram.cu
+++ b/cub/test/catch2_test_block_histogram.cu
@@ -50,7 +50,7 @@ void block_histogram(c2h::device_vector<SampleT>& d_samples, c2h::device_vector<
 // %PARAM% TEST_BINS bins 32:256:1024
 
 using types            = c2h::type_list<std::uint8_t, std::uint16_t>;
-using threads_in_block = c2h::enum_type_list<int, 32, 96, 128>;
+using threads_in_block = c2h::enum_type_list<int, 32, 33, 96, 128>;
 using items_per_thread = c2h::enum_type_list<int, 1, 5>;
 using bins             = c2h::enum_type_list<int, TEST_BINS>;
 using algorithms =

--- a/docs/cub/index.rst
+++ b/docs/cub/index.rst
@@ -206,9 +206,10 @@ library and software abstraction layer, CUB provides:
      change grain sizes (threads per block, items per thread, etc.) to best match
      the processor resources of their target architecture
    * **Variant tuning**.  Most CUB primitives support alternative algorithmic
-     strategies. For example, ``cub::BlockHistogram`` is parameterized to implement either
-     an atomic-based approach or a sorting-based approach. (The latter provides uniform
-     performance regardless of input distribution.)
+     strategies. For example, ``cub::BlockHistogram`` is parameterized to implement
+     atomic-based, warp-aggregated atomic, or sorting-based approaches. The sorting-based
+     approach provides uniform performance regardless of input distribution. The
+     warp-aggregated atomic approach targets contended counters in global memory.
    * **Co-optimization**.  When the enclosing kernel
      is similarly parameterizable, a tuning configuration can be found that optimally
      accommodates their combined register and shared memory pressure.
@@ -398,10 +399,10 @@ Static tuning and co-tuning
 
 This style of flexible interface simplifies performance tuning. Most CUB
 primitives support alternative algorithmic strategies that can be
-statically targeted by a compiler-based or JIT-based autotuner. (For
-example, ``cub::BlockHistogram`` is parameterized to implement either an
-atomic-based approach or a sorting-based approach.) Algorithms are also
-tunable over parameters such as thread count and grain size as well.
+statically targeted by a compiler-based or JIT-based autotuner. For
+example, ``cub::BlockHistogram`` is parameterized to implement atomic-based,
+warp-aggregated atomic, or sorting-based approaches. Algorithms are also
+tunable over parameters such as thread count and grain size.
 Taken together, each of the CUB algorithms provides a fairly rich tuning
 space.
 


### PR DESCRIPTION
## Summary

Adds a new `cub::BlockHistogram` algorithm that reduces same-bin atomic contention within each warp before updating the histogram:

- `cub::BLOCK_HISTO_ATOMIC_WARP_AGGREGATED`: uses warp match primitives and a leader lane to issue one atomic add per distinct bin value in the warp.

The implementation uses native `__match_any_sync` on SM70+ targets and falls back to CUB's `MatchAny` helper below SM70, including the partial-final-warp form when the block size is not a multiple of the hardware warp size.

This extends the existing block histogram Catch2 coverage to exercise the new algorithm, including a 33-thread partial-warp block case, and adds an nvbench benchmark for comparing `atomic`, `warp_aggregated`, and `sort` across item count, bin count, block count, and entropy.

## Benchmark Summary

I ran the full benchmark matrix from `cub.bench.block_histogram.algorithms.base` on:

- GPU: NVIDIA RTX PRO 6000 Blackwell Workstation Edition
- CMake build: Release
- CUDA architecture: `sm_120`
- Benchmark matrix: `ItemsPerThread={1,4,8}`, `Bins={32,128,2048}`, `Blocks={4096,16384}`, `Entropy={0.000,0.201,1.000}`

The benchmark data below is filtered to the remaining algorithms after dropping the cooperative-groups variant in PR feedback. The later SM70 guard keeps the benchmarked SM120 path on native match-any and adds the lower-target fallback path.

Across the 54 non-algorithm configurations:

- Fastest algorithm counts: `warp_aggregated` 48, `atomic` 6.
- `warp_aggregated` vs plain `atomic`: 42 wins, 8 near-neutral cases, 4 losses, geometric mean speedup 1.51x.
- Best speedup: 3.77x for `ItemsPerThread=8, Bins=32, Blocks=16384, Entropy=0.000`.
- The wins are largest when bin collisions are common. High-entropy / large-bin cases become neutral or slightly negative because the grouping overhead has fewer duplicate bin updates to amortize.

Representative `ItemsPerThread=8, Blocks=16384` GPU times:

| Bins | Entropy | atomic | warp_aggregated | Speedup | sort |
| ---: | ------: | -----: | ---------------: | ------: | ---: |
| 32 | 0.000 | 415.516 us | 110.345 us | 3.77x | 335.275 us |
| 128 | 0.000 | 379.250 us | 112.657 us | 3.37x | 335.871 us |
| 2048 | 0.000 | 398.879 us | 202.859 us | 1.97x | 362.679 us |
| 32 | 0.201 | 374.142 us | 110.545 us | 3.38x | 341.186 us |
| 128 | 0.201 | 338.694 us | 111.421 us | 3.04x | 339.838 us |
| 2048 | 0.201 | 357.340 us | 203.199 us | 1.76x | 368.558 us |
| 32 | 1.000 | 127.035 us | 111.175 us | 1.14x | 339.936 us |
| 128 | 1.000 | 173.452 us | 141.329 us | 1.23x | 339.978 us |
| 2048 | 1.000 | 288.329 us | 285.490 us | 1.01x | 371.171 us |

## Codegen Notes

I also inspected representative `sm_120` SASS for `ItemsPerThread=8, Bins=32`:

| Algorithm | Instructions | MATCH | VOTE | POPC | REDG.ADD |
| --- | ---: | ---: | ---: | ---: | ---: |
| `atomic` | 56 | 0 | 0 | 0 | 8 |
| `warp_aggregated` | 120 | 8 | 8 | 8 | 8 |

The plain atomic path does not appear to get compiler-generated histogram-style warp aggregation: it emits one `REDG.E.ADD` per item and no `MATCH`, `VOTE`, or `POPC` grouping sequence. The raw warp-aggregated path has one grouping sequence per item and guards the add so only the elected leader lane updates each same-bin peer group. That explains the large low-entropy wins.

## Validation

- `pre-commit run --files cub/cub/block/block_histogram.cuh cub/cub/block/specializations/block_histogram_atomic_warp_aggregated.cuh cub/test/catch2_test_block_histogram.cu cub/benchmarks/bench/block_histogram/algorithms.cu`
- `cmake --build build/cub-cpp20 --target cub.test.block.histogram`
- `ctest --test-dir build/cub-cpp20 -R '^cub\\.test\\.block\\.histogram' --output-on-failure` passed 3/3 tests
- `cmake --build build/cub-benchmark --target cub.bench.block_histogram.algorithms.base`
- `build/cub-benchmark/bin/cub.bench.block_histogram.algorithms.base --list` reports 162 configurations and algorithms `atomic`, `warp_aggregated`, and `sort`
- Full `cub.bench.block_histogram.algorithms.base` benchmark matrix on GPU 0
- `git diff --check`
- Local RoboRev branch code review against `origin/main`: no issues found
- Local RoboRev branch design review against `origin/main`: pass

Local CUDA 13 tooling only advertises `compute_75` and newer, so I could not run an actual pre-SM70 compile here. The lower-target path is guarded through `NV_IF_ELSE_TARGET` and uses CUB's existing `MatchAny` fallback.
