### PR TITLE
Update NVBench

### DIFF
--- a/cmake/CCCLGetDependencies.cmake
+++ b/cmake/CCCLGetDependencies.cmake
@@ -77,7 +77,7 @@ endmacro()
 
 set(
   CCCL_NVBENCH_SHA
-  "ee4b9f0963387334db194663134dc6ef714004c4"
+  "56d552687e6a462a812d6f046f5a85a07f13c9f3"
   CACHE STRING
   "SHA/tag to use for CCCL's NVBench."
 )

--- a/cmake/CCCLGetDependencies.cmake
+++ b/cmake/CCCLGetDependencies.cmake
@@ -77,7 +77,7 @@ endmacro()
 
 set(
   CCCL_NVBENCH_SHA
-  "373970323f3e2a3995761ea682ca64dfcbdd1e26"
+  "ee4b9f0963387334db194663134dc6ef714004c4"
   CACHE STRING
   "SHA/tag to use for CCCL's NVBench."
 )


### PR DESCRIPTION
every now and then we update the SHA in NVBench. Not sure if there is a criterion but newest NVBench introduces ` --stopping-criterion sample-count` which is very useful for my PDL work so why not update again. 