### PR TITLE
[cudax] Implement `cudax::invoke_one`

### DIFF
--- a/cudax/include/cuda/experimental/__group/group.cuh
+++ b/cudax/include/cuda/experimental/__group/group.cuh
@@ -171,7 +171,7 @@ public:
 
   // todo(dabayer): Do we want to expose .arrive() and .wait()? Do we want to implement .sync() using them? Do we want
   //                aligned/unaligned variants?
-  _CCCL_DEVICE_API void sync() noexcept
+  _CCCL_DEVICE_API void sync() const noexcept
   {
     // Skip the synchronization for threads that are not part of this group.
     if constexpr (!_MappingResult::is_always_exhaustive())
@@ -184,7 +184,7 @@ public:
     __synchronizer_instance_.do_sync(__mapping_result_, __synchronizer_);
   }
 
-  _CCCL_DEVICE_API void sync_aligned() noexcept
+  _CCCL_DEVICE_API void sync_aligned() const noexcept
   {
     // Skip the synchronization for threads that are not part of this group.
     if constexpr (!_MappingResult::is_always_exhaustive())

--- a/cudax/include/cuda/experimental/__group/invoke_one.cuh
+++ b/cudax/include/cuda/experimental/__group/invoke_one.cuh
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_EXPERIMENTAL___GROUP_INVOKE_ONE_CUH
+#define _CUDA_EXPERIMENTAL___GROUP_INVOKE_ONE_CUH
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__ptx/instructions/elect_sync.h>
+#include <cuda/hierarchy>
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__functional/invoke.h>
+#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/is_reference.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/is_void.h>
+#include <cuda/std/__type_traits/remove_reference.h>
+#include <cuda/std/__utility/forward.h>
+#include <cuda/std/optional>
+
+#include <cuda/experimental/__group/concepts.cuh>
+#include <cuda/experimental/__group/fwd.cuh>
+
+#include <cuda/std/__cccl/prologue.h>
+
+#if !defined(_CCCL_DOXYGEN_INVOKED)
+
+namespace cuda::experimental
+{
+template <class _Group>
+[[nodiscard]] _CCCL_DEVICE_API bool __elect_one(const _Group& __group) noexcept
+{
+  if constexpr (__is_this_group_v<_Group> && ::cuda::std::is_same_v<typename _Group::level_type, warp_level>)
+  {
+    NV_IF_TARGET(NV_PROVIDES_SM_90, ({ return ::cuda::ptx::elect_sync(~0u); }))
+  }
+  else if constexpr (!::cuda::std::is_same_v<typename _Group::unit_type, thread_level>)
+  {
+    // For groups whose unit is >= warp_level, we want to still execute the elect.sync PTX instruction by the root warp
+    // to let the compiler enter the Uniform Data Path (UDP) when invoking the callable.
+    NV_IF_TARGET(NV_PROVIDES_SM_90, ({
+                   if (warp.is_root_rank(__group))
+                   {
+                     return ::cuda::ptx::elect_sync(~0u);
+                   }
+                   return false;
+                 }))
+  }
+  return gpu_thread.is_root_rank(__group);
+}
+
+_CCCL_TEMPLATE(class _Group, class _Callable, class... _Args)
+_CCCL_REQUIRES(is_group<_Group> _CCCL_AND ::cuda::std::is_invocable_v<_Callable, _Args...>
+                 _CCCL_AND ::cuda::std::is_void_v<::cuda::std::invoke_result_t<_Callable, _Args...>>)
+_CCCL_DEVICE_API void invoke_one(const _Group& __group, _Callable&& __callable, _Args&&... __args) noexcept(
+  ::cuda::std::is_nothrow_invocable_v<_Callable, _Args...>)
+{
+  if (::cuda::experimental::__elect_one(__group))
+  {
+    ::cuda::std::invoke(::cuda::std::forward<_Callable>(__callable), ::cuda::std::forward<_Args>(__args)...);
+  }
+}
+
+_CCCL_TEMPLATE(class _Group,
+               class _Callable,
+               class... _Args,
+               class _InvokeResult = ::cuda::std::invoke_result_t<_Callable, _Args...>)
+_CCCL_REQUIRES(is_group<_Group> _CCCL_AND ::cuda::std::is_invocable_v<_Callable, _Args...> _CCCL_AND(
+  !::cuda::std::is_void_v<_InvokeResult>))
+[[nodiscard]]
+_CCCL_DEVICE_API auto invoke_one(const _Group& __group, _Callable&& __callable, _Args&&... __args) noexcept(
+  ::cuda::std::is_nothrow_invocable_v<_Callable, _Args...>)
+{
+  using _Ret = ::cuda::std::optional<::cuda::std::conditional_t<::cuda::std::is_rvalue_reference_v<_InvokeResult>,
+                                                                ::cuda::std::remove_reference_t<_InvokeResult>,
+                                                                _InvokeResult>>;
+
+  _Ret __ret{};
+  if (::cuda::experimental::__elect_one(__group))
+  {
+    __ret = ::cuda::std::invoke(::cuda::std::forward<_Callable>(__callable), ::cuda::std::forward<_Args>(__args)...);
+  }
+  return __ret;
+}
+} // namespace cuda::experimental
+
+#endif // !_CCCL_DOXYGEN_INVOKED
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_EXPERIMENTAL___GROUP_INVOKE_ONE_CUH

--- a/cudax/include/cuda/experimental/group.cuh
+++ b/cudax/include/cuda/experimental/group.cuh
@@ -25,6 +25,7 @@
 #include <cuda/experimental/__group/fwd.cuh>
 #include <cuda/experimental/__group/group.cuh>
 #include <cuda/experimental/__group/implicit_hierarchy.cuh>
+#include <cuda/experimental/__group/invoke_one.cuh>
 #include <cuda/experimental/__group/mapping/binary_partition.cuh>
 #include <cuda/experimental/__group/mapping/composite_mapping.cuh>
 #include <cuda/experimental/__group/mapping/group_as.cuh>

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -172,6 +172,9 @@ cudax_add_catch2_test(test_target group.segmented_algorithm
 cudax_add_catch2_test(test_target group.this_group
     group/this_group.cu
 )
+cudax_add_catch2_test(test_target group.invoke_one
+    group/invoke_one.cu
+)
 
 cudax_add_catch2_test(test_target coop.reduce.this_thread
     coop/reduce/this_thread.cu

--- a/cudax/test/group/invoke_one.cu
+++ b/cudax/test/group/invoke_one.cu
@@ -1,0 +1,290 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/atomic>
+#include <cuda/devices>
+#include <cuda/hierarchy>
+#include <cuda/launch>
+#include <cuda/std/cstddef>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+#include <cuda/stream>
+
+#include <cuda/experimental/group.cuh>
+
+#include "group_testing.cuh"
+
+namespace
+{
+__device__ cuda::std::size_t invoke_count;
+__device__ int global_value = 1;
+
+__device__ void update_invoke_count() noexcept
+{
+  cuda::atomic_ref<cuda::std::size_t, cuda::thread_scope_device>
+  {
+    invoke_count
+  }
+  ++;
+}
+
+template <class Group>
+__device__ void check_and_reset_invoke_count(const Group& group)
+{
+  group.sync_aligned();
+  __threadfence();
+
+  REQUIRE(cuda::atomic_ref<cuda::std::size_t, cuda::thread_scope_device>{invoke_count} == 1);
+  __threadfence();
+
+  if (cuda::gpu_thread.is_root_rank(group))
+  {
+    cuda::atomic_ref<cuda::std::size_t, cuda::thread_scope_device>{invoke_count} = 0;
+  }
+  __threadfence();
+  group.sync_aligned();
+}
+
+template <class Group>
+__device__ void test_invoke_one(const Group& group)
+{
+  // We need only 1 group for these tests.
+  if (group.rank(cuda::grid) > 0)
+  {
+    return;
+  }
+
+  // invoke_one callable with void return type
+  {
+    auto callable = []() {
+      update_invoke_count();
+    };
+
+    static_assert(cuda::std::is_same_v<void, decltype(cudax::invoke_one(group, callable))>);
+    static_assert(!noexcept(cudax::invoke_one(group, callable)));
+
+    cudax::invoke_one(group, callable);
+
+    check_and_reset_invoke_count(group);
+  }
+
+  // invoke_one nothrow callable with void return type
+  {
+    auto callable = []() noexcept {
+      update_invoke_count();
+    };
+
+    static_assert(cuda::std::is_same_v<void, decltype(cudax::invoke_one(group, callable))>);
+    static_assert(noexcept(cudax::invoke_one(group, callable)));
+
+    cudax::invoke_one(group, callable);
+
+    check_and_reset_invoke_count(group);
+  }
+
+  // invoke_one callable with value return type
+  {
+    auto callable = []() -> int {
+      update_invoke_count();
+      return 1;
+    };
+
+    static_assert(cuda::std::is_same_v<cuda::std::optional<int>, decltype(cudax::invoke_one(group, callable))>);
+    static_assert(!noexcept(cudax::invoke_one(group, callable)));
+
+    const auto ret = cudax::invoke_one(group, callable);
+    REQUIRE(ret.has_value() == cudax::__elect_one(group));
+    if (ret.has_value())
+    {
+      REQUIRE(ret == 1);
+    }
+
+    check_and_reset_invoke_count(group);
+  }
+
+  // invoke_one nothrow callable with value return type
+  {
+    auto callable = []() noexcept -> int {
+      update_invoke_count();
+      return 1;
+    };
+
+    static_assert(cuda::std::is_same_v<cuda::std::optional<int>, decltype(cudax::invoke_one(group, callable))>);
+    static_assert(noexcept(cudax::invoke_one(group, callable)));
+
+    const auto ret = cudax::invoke_one(group, callable);
+    REQUIRE(ret.has_value() == cudax::__elect_one(group));
+    if (ret.has_value())
+    {
+      REQUIRE(ret == 1);
+    }
+
+    check_and_reset_invoke_count(group);
+  }
+
+  // invoke_one callable with l-value reference return type
+  {
+    auto callable = []() -> int& {
+      update_invoke_count();
+      return global_value;
+    };
+
+    static_assert(cuda::std::is_same_v<cuda::std::optional<int&>, decltype(cudax::invoke_one(group, callable))>);
+    static_assert(!noexcept(cudax::invoke_one(group, callable)));
+
+    const auto ret = cudax::invoke_one(group, callable);
+    REQUIRE(ret.has_value() == cudax::__elect_one(group));
+    if (ret.has_value())
+    {
+      REQUIRE(ret == 1);
+      REQUIRE(&ret.value() == &global_value);
+    }
+
+    check_and_reset_invoke_count(group);
+  }
+
+  // invoke_one callable with l-value reference return type
+  {
+    auto callable = []() noexcept -> int& {
+      update_invoke_count();
+      return global_value;
+    };
+
+    static_assert(cuda::std::is_same_v<cuda::std::optional<int&>, decltype(cudax::invoke_one(group, callable))>);
+    static_assert(noexcept(cudax::invoke_one(group, callable)));
+
+    const auto ret = cudax::invoke_one(group, callable);
+    REQUIRE(ret.has_value() == cudax::__elect_one(group));
+    if (ret.has_value())
+    {
+      REQUIRE(ret == 1);
+      REQUIRE(&ret.value() == &global_value);
+    }
+
+    check_and_reset_invoke_count(group);
+  }
+
+  // invoke_one callable with r-value reference return type
+  {
+    auto callable = []() -> int&& {
+      update_invoke_count();
+      return cuda::std::move(global_value);
+    };
+
+    static_assert(cuda::std::is_same_v<cuda::std::optional<int>, decltype(cudax::invoke_one(group, callable))>);
+    static_assert(!noexcept(cudax::invoke_one(group, callable)));
+
+    const auto ret = cudax::invoke_one(group, callable);
+    REQUIRE(ret.has_value() == cudax::__elect_one(group));
+    if (ret.has_value())
+    {
+      REQUIRE(ret == 1);
+    }
+
+    check_and_reset_invoke_count(group);
+  }
+
+  // invoke_one nothrow callable with r-value reference return type
+  {
+    auto callable = []() noexcept -> int&& {
+      update_invoke_count();
+      return cuda::std::move(global_value);
+    };
+
+    static_assert(cuda::std::is_same_v<cuda::std::optional<int>, decltype(cudax::invoke_one(group, callable))>);
+    static_assert(noexcept(cudax::invoke_one(group, callable)));
+
+    const auto ret = cudax::invoke_one(group, callable);
+    REQUIRE(ret.has_value() == cudax::__elect_one(group));
+    if (ret.has_value())
+    {
+      REQUIRE(ret == 1);
+    }
+
+    check_and_reset_invoke_count(group);
+  }
+
+  // Check that invoke_one correctly forwards the arguments for invocable with void return type.
+  {
+    auto callable = [](auto&& arg1, auto&& arg2) -> void {
+      static_assert(cuda::std::is_same_v<int&, decltype(arg1)>);
+      static_assert(cuda::std::is_same_v<unsigned&&, decltype(arg2)>);
+
+      REQUIRE(arg1 == 2);
+      REQUIRE(arg2 == 20u);
+    };
+
+    int arg1{2};
+    unsigned arg2{20};
+    cudax::invoke_one(group, callable, arg1, cuda::std::move(arg2));
+  }
+
+  // Check that invoke_one correctly forwards the arguments for invocable with non-void return type.
+  {
+    auto callable = [](auto&& arg1, auto&& arg2) -> int {
+      static_assert(cuda::std::is_same_v<int&, decltype(arg1)>);
+      static_assert(cuda::std::is_same_v<unsigned&&, decltype(arg2)>);
+
+      REQUIRE(arg1 == 2);
+      REQUIRE(arg2 == 20u);
+
+      return 1;
+    };
+
+    int arg1{2};
+    unsigned arg2{20};
+    const auto ret = cudax::invoke_one(group, callable, arg1, cuda::std::move(arg2));
+
+    REQUIRE(ret.has_value() == cudax::__elect_one(group));
+    if (ret.has_value())
+    {
+      REQUIRE(ret == 1);
+    }
+  }
+}
+
+struct TestKernel
+{
+  template <class Config>
+  __device__ void operator()(const Config& config)
+  {
+    // Test this groups.
+    test_invoke_one(cudax::this_thread{config});
+    test_invoke_one(cudax::this_warp{config});
+    test_invoke_one(cudax::this_block{config});
+    test_invoke_one(cudax::this_cluster{config});
+
+    // Test custom groups.
+    {
+      cudax::group group{cuda::gpu_thread, cudax::this_warp{config}, cudax::group_by<4>{}, cudax::lane_synchronizer{}};
+      test_invoke_one(group);
+    }
+  }
+};
+} // namespace
+
+C2H_TEST("Invoke one", "[group]")
+{
+  const auto device = cuda::devices[0];
+
+  const cuda::stream stream{device};
+
+  const auto config = cuda::make_config(cuda::grid_dims<2>(), cuda::block_dims<128>(), cuda::cooperative_launch{});
+  cuda::launch(stream, config, TestKernel{});
+
+  if (cuda::device_attributes::compute_capability(device) >= cuda::compute_capability{90})
+  {
+    const auto config_cluster = cuda::make_config(
+      cuda::grid_dims<2>(), cuda::cluster_dims<3>(), cuda::block_dims<128>(), cuda::cooperative_launch{});
+    cuda::launch(stream, config_cluster, TestKernel{});
+  }
+
+  stream.sync();
+}


### PR DESCRIPTION
Fixes #9229.

Cooperative groups always return `T` from the call. I don't think it's a good thing, because all threads except the one get an invalid value. That's why I went with `cuda::std::optional` for cases when the invoke result is non-`void`.

The return type of `cudax::invoke_one` is `cuda::std::optional<T>` for value and R-value references return types and `cuda::std::optional<T&>` for L-value references return types.