### PR TITLE
Deprecate `DispatchScan` and `AgentScanPolicy`

### DIFF
--- a/cub/cub/agent/agent_scan.cuh
+++ b/cub/cub/agent/agent_scan.cuh
@@ -36,6 +36,7 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail
 {
+// TODO(bgruber): remove when C++20 is the minimum, since then we can pass policy values as NTTPs
 template <int NominalThreadsPerBlock4B,
           int NominalItemsPerThread4B,
           typename ComputeT,

--- a/cub/cub/agent/agent_scan.cuh
+++ b/cub/cub/agent/agent_scan.cuh
@@ -34,6 +34,31 @@
 
 CUB_NAMESPACE_BEGIN
 
+namespace detail
+{
+template <int NominalThreadsPerBlock4B,
+          int NominalItemsPerThread4B,
+          typename ComputeT,
+          BlockLoadAlgorithm LoadAlgorithm,
+          CacheLoadModifier LoadModifier,
+          BlockStoreAlgorithm StoreAlgorithm,
+          BlockScanAlgorithm ScanAlgorithm,
+          typename ScalingType = detail::MemBoundScaling<NominalThreadsPerBlock4B, NominalItemsPerThread4B, ComputeT>,
+          typename DelayConstructorT = detail::default_delay_constructor_t<ComputeT>>
+struct agent_scan_policy : ScalingType
+{
+  static constexpr BlockLoadAlgorithm LOAD_ALGORITHM   = LoadAlgorithm;
+  static constexpr CacheLoadModifier LOAD_MODIFIER     = LoadModifier;
+  static constexpr BlockStoreAlgorithm STORE_ALGORITHM = StoreAlgorithm;
+  static constexpr BlockScanAlgorithm SCAN_ALGORITHM   = ScanAlgorithm;
+
+  struct detail
+  {
+    using delay_constructor_t = DelayConstructorT;
+  };
+};
+} // namespace detail
+
 /******************************************************************************
  * Tuning policy types
  ******************************************************************************/
@@ -75,18 +100,16 @@ template <int NominalThreadsPerBlock4B,
           BlockScanAlgorithm ScanAlgorithm,
           typename ScalingType = detail::MemBoundScaling<NominalThreadsPerBlock4B, NominalItemsPerThread4B, ComputeT>,
           typename DelayConstructorT = detail::default_delay_constructor_t<ComputeT>>
-struct AgentScanPolicy : ScalingType
-{
-  static constexpr BlockLoadAlgorithm LOAD_ALGORITHM   = LoadAlgorithm;
-  static constexpr CacheLoadModifier LOAD_MODIFIER     = LoadModifier;
-  static constexpr BlockStoreAlgorithm STORE_ALGORITHM = StoreAlgorithm;
-  static constexpr BlockScanAlgorithm SCAN_ALGORITHM   = ScanAlgorithm;
-
-  struct detail
-  {
-    using delay_constructor_t = DelayConstructorT;
-  };
-};
+using AgentScanPolicy CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceScan") = detail::agent_scan_policy<
+  NominalThreadsPerBlock4B,
+  NominalItemsPerThread4B,
+  ComputeT,
+  LoadAlgorithm,
+  LoadModifier,
+  StoreAlgorithm,
+  ScanAlgorithm,
+  ScalingType,
+  DelayConstructorT>;
 
 /******************************************************************************
  * Thread block abstractions

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -1129,7 +1129,7 @@ CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t invoke_warpspeed(
   }
 
   // TODO(bgruber): we probably need to ensure alignment of d_temp_storage
-  _CCCL_ASSERT(::cuda::is_aligned(d_temp_storage, kernel_source.look_ahead_tile_state_alignment()), "");
+  _CCCL_ASSERT(::cuda::is_aligned(d_temp_storage, kernel_source.lookahead_tile_state_alignment()), "");
 
   auto scan_kernel                 = kernel_source.ScanKernel();
   [[maybe_unused]] auto kernel_src = kernel_source; // need to pull a copy to not access `this` during const. eval.

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -932,7 +932,10 @@ CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t invoke_lookback(
   KernelLauncherFactory launcher_factory)
 {
   CUB_DETAIL_CONSTEXPR_ISH const ScanLookbackPolicy active_policy = policy_getter().lookback;
-
+  CUB_DETAIL_STATIC_ISH_ASSERT(
+    active_policy.threads_per_block >= 1, "Lookback scan policy must have at least 1 thread per block");
+  CUB_DETAIL_STATIC_ISH_ASSERT(
+    active_policy.items_per_thread >= 1, "Lookback scan policy must have at least 1 item per thread");
   CUB_DETAIL_STATIC_ISH_ASSERT(active_policy.load_modifier != CacheLoadModifier::LOAD_LDG,
                                "The memory consistency model does not apply to texture accesses");
 
@@ -1091,6 +1094,12 @@ CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t invoke_warpspeed(
   }
 
   CUB_DETAIL_CONSTEXPR_ISH const ScanWarpspeedPolicy warpspeed_policy = policy_getter().warpspeed;
+  CUB_DETAIL_STATIC_ISH_ASSERT(warpspeed_policy.reduce_and_scan_warps >= 1,
+                               "Warpspeed scan policy have at least 1 warp for reducing and scanning");
+  CUB_DETAIL_STATIC_ISH_ASSERT(
+    warpspeed_policy.items_per_thread >= 1, "Warpspeed scan policy must have at least 1 item per thread");
+  CUB_DETAIL_STATIC_ISH_ASSERT(warpspeed_policy.lookahead_items_per_thread >= 1,
+                               "Warpspeed scan policy must look ahead at least 1 item per thread");
 
   const int grid_dim =
     static_cast<int>(::cuda::ceil_div(num_items, static_cast<OffsetT>(warpspeed_policy.tile_size())));

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -1097,7 +1097,7 @@ CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t invoke_warpspeed(
 
   if (d_temp_storage == nullptr)
   {
-    temp_storage_bytes = static_cast<size_t>(grid_dim) * kernel_source.look_ahead_tile_state_size();
+    temp_storage_bytes = static_cast<size_t>(grid_dim) * kernel_source.lookahead_tile_state_size();
     return cudaSuccess;
   }
 

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -809,7 +809,7 @@ struct CCCL_DEPRECATED_BECAUSE("Please use DeviceScan") DispatchScan
       }
     };
 
-    if CUB_DETAIL_CONSTEXPR_ISH (policy_getter().algorithm == ScanAlgorithm::warpspeed)
+    if CUB_DETAIL_CONSTEXPR_ISH (policy_getter{}().algorithm == ScanAlgorithm::warpspeed)
     {
       return __invoke_warpspeed_algorithm(policy_getter{});
     }

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -844,7 +844,6 @@ struct CCCL_DEPRECATED_BECAUSE("Please use DeviceScan") DispatchScan
    *
    * @param[in] num_items
    *   Total number of input items (i.e., the length of `d_in`)
-   *   Total number of input items (i.e., the length of `d_in`)
    *
    * @param[in] stream
    *   **[optional]** CUDA stream to launch kernels within.

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -233,7 +233,7 @@ template <
     AccumT,
     EnforceInclusive>,
   typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
-struct DispatchScan
+struct CCCL_DEPRECATED_BECAUSE("Please use DeviceScan") DispatchScan
 {
   static_assert(::cuda::std::is_unsigned_v<OffsetT> && sizeof(OffsetT) >= 4,
                 "DispatchScan only supports unsigned offset types of at least 4-bytes");
@@ -797,19 +797,6 @@ struct DispatchScan
     return cudaSuccess;
   }
 
-  template <typename PolicyGetter>
-  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t __invoke(PolicyGetter policy_getter)
-  {
-    if CUB_DETAIL_CONSTEXPR_ISH (policy_getter().algorithm == ScanAlgorithm::warpspeed)
-    {
-      return __invoke_warpspeed_algorithm(policy_getter);
-    }
-    else
-    {
-      return __invoke_lookback_algorithm(policy_getter);
-    }
-  }
-
   template <typename ActivePolicyT>
   CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t Invoke(ActivePolicyT = {})
   {
@@ -822,7 +809,14 @@ struct DispatchScan
       }
     };
 
-    return __invoke(policy_getter{});
+    if CUB_DETAIL_CONSTEXPR_ISH (policy_getter().algorithm == ScanAlgorithm::warpspeed)
+    {
+      return __invoke_warpspeed_algorithm(policy_getter{});
+    }
+    else
+    {
+      return __invoke_lookback_algorithm(policy_getter{});
+    }
   }
 
   /**
@@ -849,6 +843,7 @@ struct DispatchScan
    *   Initial value to seed the exclusive scan
    *
    * @param[in] num_items
+   *   Total number of input items (i.e., the length of `d_in`)
    *   Total number of input items (i.e., the length of `d_in`)
    *
    * @param[in] stream
@@ -907,6 +902,414 @@ struct DispatchScan
 
 namespace detail::scan
 {
+// do check in separate function, so error message contains the required SMEM in the error novel
+template <int SMemSizeForSingleStage>
+CUB_RUNTIME_FUNCTION void check_warpspeed_smem()
+{
+  static_assert(SMemSizeForSingleStage <= detail::max_smem_per_block,
+                "Single-stage warpspeed scan exceeds architecture independent SMEM (48KiB)");
+}
+
+template <typename PolicyGetter,
+          typename InputIteratorT,
+          typename OutputIteratorT,
+          typename ScanOpT,
+          typename InitValueT,
+          typename OffsetT,
+          typename KernelSource,
+          typename KernelLauncherFactory>
+CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t invoke_lookback(
+  PolicyGetter policy_getter,
+  void* d_temp_storage,
+  size_t& temp_storage_bytes,
+  InputIteratorT d_in,
+  OutputIteratorT d_out,
+  ScanOpT scan_op,
+  InitValueT init_value,
+  OffsetT num_items,
+  cudaStream_t stream,
+  bool dependent_launch,
+  KernelSource kernel_source,
+  KernelLauncherFactory launcher_factory)
+{
+  CUB_DETAIL_CONSTEXPR_ISH const ScanLookbackPolicy active_policy = policy_getter().lookback;
+
+  CUB_DETAIL_STATIC_ISH_ASSERT(active_policy.load_modifier != CacheLoadModifier::LOAD_LDG,
+                               "The memory consistency model does not apply to texture accesses");
+
+  // Number of input tiles
+  const int tile_size = active_policy.threads_per_block * active_policy.items_per_thread;
+  const int num_tiles = static_cast<int>(::cuda::ceil_div(num_items, tile_size));
+
+  auto tile_state = kernel_source.TileState();
+
+  // Specify temporary storage allocation requirements
+  size_t allocation_sizes[1];
+  if (const auto error = CubDebug(tile_state.AllocationSize(num_tiles, allocation_sizes[0])))
+  {
+    return error; // bytes needed for tile status descriptors
+  }
+
+  // Compute allocation pointers into the single storage blob (or compute
+  // the necessary size of the blob)
+  void* allocations[1] = {};
+  if (const auto error =
+        CubDebug(detail::alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))
+  {
+    return error;
+  }
+
+  // Return if the caller is simply requesting the size of the storage allocation, or the problem is empty
+  if (d_temp_storage == nullptr || num_items == 0)
+  {
+    return cudaSuccess;
+  }
+
+  // Construct the tile status interface
+  if (const auto error = CubDebug(tile_state.Init(num_tiles, allocations[0], allocation_sizes[0])))
+  {
+    return error;
+  }
+
+  // Log init_kernel configuration
+  constexpr int init_kernel_threads = 128;
+  const int init_grid_size          = ::cuda::ceil_div(num_tiles, init_kernel_threads);
+
+#ifdef CUB_DEBUG_LOG
+  _CubLog("Invoking init_kernel<<<%d, %d, 0, %lld>>>()\n", init_grid_size, init_kernel_threads, (long long) stream);
+#endif // CUB_DEBUG_LOG
+
+  // Invoke init_kernel to initialize tile descriptors
+  if (const auto error = CubDebug(
+        launcher_factory(init_grid_size, init_kernel_threads, 0, stream, dependent_launch)
+          .doit(kernel_source.InitKernel(), kernel_source.make_tile_state_kernel_arg(tile_state), num_tiles)))
+  {
+    return error;
+  }
+
+  // Check for failure to launch
+  if (const auto error = CubDebug(cudaPeekAtLastError()))
+  {
+    return error;
+  }
+
+  // Sync the stream if specified to flush runtime errors
+  if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+  {
+    return error;
+  }
+
+  // Get SM occupancy for scan_kernel
+  int scan_sm_occupancy;
+  if (const auto error = CubDebug(launcher_factory.MaxSmOccupancy(
+        scan_sm_occupancy, kernel_source.ScanKernel(), active_policy.threads_per_block)))
+  {
+    return error;
+  }
+
+  // Get max x-dimension of grid
+  int max_dim_x;
+  if (const auto error = CubDebug(launcher_factory.MaxGridDimX(max_dim_x)))
+  {
+    return error;
+  }
+
+  // Run grids in epochs (in case number of tiles exceeds max x-dimension
+  const int scan_grid_size = ::cuda::std::min(num_tiles, max_dim_x);
+  for (int start_tile = 0; start_tile < num_tiles; start_tile += scan_grid_size)
+  {
+// Log scan_kernel configuration
+#ifdef CUB_DEBUG_LOG
+    _CubLog("Invoking %d scan_kernel<<<%d, %d, 0, %lld>>>(), %d items "
+            "per thread, %d SM occupancy\n",
+            start_tile,
+            scan_grid_size,
+            active_policy.threads_per_block,
+            (long long) stream,
+            active_policy.items_per_thread,
+            scan_sm_occupancy);
+#endif // CUB_DEBUG_LOG
+
+    // Invoke scan_kernel
+    if (const auto error = CubDebug(
+          launcher_factory(scan_grid_size, active_policy.threads_per_block, 0, stream, dependent_launch)
+            .doit(kernel_source.ScanKernel(),
+                  THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_in),
+                  THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_out),
+                  kernel_source.make_tile_state_kernel_arg(tile_state),
+                  start_tile,
+                  scan_op,
+                  init_value,
+                  num_items,
+                  /* num_stages, unused */ 1)))
+    {
+      return error;
+    }
+
+    // Check for failure to launch
+    if (const auto error = CubDebug(cudaPeekAtLastError()))
+    {
+      return error;
+    }
+
+    // Sync the stream if specified to flush runtime errors
+    if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+    {
+      return error;
+    }
+  }
+
+  return cudaSuccess;
+}
+
+template <typename PolicyGetter,
+          typename InputIteratorT,
+          typename OutputIteratorT,
+          typename ScanOpT,
+          typename InitValueT,
+          typename OffsetT,
+          typename KernelSource,
+          typename KernelLauncherFactory>
+CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t invoke_warpspeed(
+  PolicyGetter policy_getter,
+  void* d_temp_storage,
+  size_t& temp_storage_bytes,
+  InputIteratorT d_in,
+  OutputIteratorT d_out,
+  ScanOpT scan_op,
+  InitValueT init_value,
+  OffsetT num_items,
+  cudaStream_t stream,
+  bool dependent_launch,
+  KernelSource kernel_source,
+  KernelLauncherFactory launcher_factory)
+{
+#if __cccl_ptx_isa >= 860
+  if (num_items == 0)
+  {
+    temp_storage_bytes = 1; // just fulfill the contract that CUB always requires some temporary storage
+    return cudaSuccess;
+  }
+
+  CUB_DETAIL_CONSTEXPR_ISH const ScanWarpspeedPolicy warpspeed_policy = policy_getter().warpspeed;
+
+  const int grid_dim =
+    static_cast<int>(::cuda::ceil_div(num_items, static_cast<OffsetT>(warpspeed_policy.tile_size())));
+
+  if (d_temp_storage == nullptr)
+  {
+    temp_storage_bytes = static_cast<size_t>(grid_dim) * kernel_source.look_ahead_tile_state_size();
+    return cudaSuccess;
+  }
+
+  if (num_items == 0)
+  {
+    return cudaSuccess;
+  }
+
+  int sm_count = 0;
+  if (const auto error = CubDebug(launcher_factory.MultiProcessorCount(sm_count)))
+  {
+    return error;
+  }
+  // Maximum dynamic shared memory size that we can use for temporary storage.
+  int max_dynamic_smem_size{};
+  if (const auto error =
+        CubDebug(launcher_factory.max_dynamic_smem_size_for(max_dynamic_smem_size, kernel_source.ScanKernel())))
+  {
+    return error;
+  }
+
+  // TODO(bgruber): we probably need to ensure alignment of d_temp_storage
+  _CCCL_ASSERT(::cuda::is_aligned(d_temp_storage, kernel_source.look_ahead_tile_state_alignment()), "");
+
+  auto scan_kernel                 = kernel_source.ScanKernel();
+  [[maybe_unused]] auto kernel_src = kernel_source; // need to pull a copy to not access `this` during const. eval.
+  CUB_DETAIL_CONSTEXPR_ISH int smem_size_1_stage = detail::scan::smem_for_stages(
+    warpspeed_policy,
+    1,
+    static_cast<int>(kernel_src.InputSize()),
+    static_cast<int>(kernel_src.InputAlign()),
+    static_cast<int>(kernel_src.OutputAlign()),
+    static_cast<int>(kernel_src.AccumSize()),
+    static_cast<int>(kernel_src.AccumAlign()));
+#  if defined(CUB_DEFINE_RUNTIME_POLICIES)
+  _CCCL_ASSERT(smem_size_1_stage <= int{detail::max_smem_per_block},
+               "Single-stage warpspeed scan exceeds architecture independent SMEM (48KiB)");
+#  else // defined(CUB_DEFINE_RUNTIME_POLICIES)
+  check_warpspeed_smem<smem_size_1_stage>();
+#  endif // defined(CUB_DEFINE_RUNTIME_POLICIES)
+
+  int num_stages = 1;
+  int smem_size  = smem_size_1_stage;
+
+  // When launched from the host, maximize the number of stages that we can fit inside the shared memory.
+  NV_IF_TARGET(NV_IS_HOST, ({
+                 // number of stages to have an even workload across all SMs (improves small problem sizes), assuming
+                 // 1 CTA per SM +1 since it tends to improve performance
+                 // TODO(bgruber): make the +1 a tuning parameter
+                 const int max_stages_for_even_workload = static_cast<int>(
+                   ::cuda::ceil_div(num_items, static_cast<OffsetT>(sm_count * warpspeed_policy.tile_size())) + 1);
+
+                 while (num_stages <= max_stages_for_even_workload)
+                 {
+                   const int next_smem_size = detail::scan::smem_for_stages(
+                     warpspeed_policy,
+                     num_stages + 1,
+                     static_cast<int>(kernel_source.InputSize()),
+                     static_cast<int>(kernel_source.InputAlign()),
+                     static_cast<int>(kernel_source.OutputAlign()),
+                     static_cast<int>(kernel_source.AccumSize()),
+                     static_cast<int>(kernel_source.AccumAlign()));
+                   if (next_smem_size > max_dynamic_smem_size)
+                   {
+                     // This number of stages failed, so stay at the current settings
+                     break;
+                   }
+
+                   smem_size = next_smem_size;
+                   ++num_stages;
+                 }
+
+                 if (const auto error = launcher_factory.set_max_dynamic_smem_size_for(scan_kernel, smem_size))
+                 {
+                   return error;
+                 }
+               }))
+
+  // Invoke init kernel
+  {
+    constexpr auto init_kernel_threads = 128;
+    const auto init_grid_size          = ::cuda::ceil_div(grid_dim, init_kernel_threads);
+
+#  ifdef CUB_DEBUG_LOG
+    _CubLog("Invoking DeviceScanInitKernel<<<%d, %d, 0, %lld>>>()\n",
+            init_grid_size,
+            init_kernel_threads,
+            (long long) stream);
+#  endif // CUB_DEBUG_LOG
+
+    if (const auto error = CubDebug(
+          launcher_factory(init_grid_size, init_kernel_threads, 0, stream, dependent_launch)
+            .doit(kernel_source.InitKernel(),
+                  kernel_source.look_ahead_make_tile_state_kernel_arg(d_temp_storage),
+                  grid_dim)))
+    {
+      return error;
+    }
+
+    // Check for failure to launch
+    if (const auto error = CubDebug(cudaPeekAtLastError()))
+    {
+      return error;
+    }
+
+    // Sync the stream if specified to flush runtime errors
+    if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+    {
+      return error;
+    }
+  }
+
+  // Invoke scan kernel
+  {
+    const int block_dim = detail::scan::num_total_threads(warpspeed_policy);
+
+#  ifdef CUB_DEBUG_LOG
+    _CubLog("Invoking DeviceScanKernel<<<%d, %d, %d, %lld>>>()\n", grid_dim, block_dim, smem_size, (long long) stream);
+#  endif // CUB_DEBUG_LOG
+
+    if (const auto error = CubDebug(
+          launcher_factory(grid_dim, block_dim, smem_size, stream, dependent_launch)
+            .doit(scan_kernel,
+                  THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_in),
+                  THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_out),
+                  kernel_source.look_ahead_make_tile_state_kernel_arg(d_temp_storage),
+                  /* start_tile, unused */ 0,
+                  ::cuda::std::move(scan_op),
+                  init_value,
+                  num_items,
+                  num_stages)))
+    {
+      return error;
+    }
+
+    // Check for failure to launch
+    if (const auto error = CubDebug(cudaPeekAtLastError()))
+    {
+      return error;
+    }
+
+    // Sync the stream if specified to flush runtime errors
+    if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+    {
+      return error;
+    }
+  }
+#else // __cccl_ptx_isa >= 860
+  static_assert(sizeof(policy_getter) == 0,
+                "Implementation bug: Tuning policy selected warpspeed, but supported PTX ISA is too low");
+#endif // __cccl_ptx_isa >= 860
+  return cudaSuccess;
+}
+
+template <typename PolicyGetter,
+          typename InputIteratorT,
+          typename OutputIteratorT,
+          typename ScanOpT,
+          typename InitValueT,
+          typename OffsetT,
+          typename KernelSource,
+          typename KernelLauncherFactory>
+CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke(
+  PolicyGetter policy_getter,
+  void* d_temp_storage,
+  size_t& temp_storage_bytes,
+  InputIteratorT d_in,
+  OutputIteratorT d_out,
+  ScanOpT scan_op,
+  InitValueT init_value,
+  OffsetT num_items,
+  cudaStream_t stream,
+  ::cuda::compute_capability cc,
+  KernelSource kernel_source,
+  KernelLauncherFactory launcher_factory)
+{
+  const bool dependent_launch = cc >= ::cuda::compute_capability{9, 0};
+  if CUB_DETAIL_CONSTEXPR_ISH (policy_getter().algorithm == ScanAlgorithm::warpspeed)
+  {
+    return invoke_warpspeed(
+      policy_getter,
+      d_temp_storage,
+      temp_storage_bytes,
+      d_in,
+      d_out,
+      scan_op,
+      init_value,
+      num_items,
+      stream,
+      dependent_launch,
+      kernel_source,
+      launcher_factory);
+  }
+  else
+  {
+    return invoke_lookback(
+      policy_getter,
+      d_temp_storage,
+      temp_storage_bytes,
+      d_in,
+      d_out,
+      scan_op,
+      init_value,
+      num_items,
+      stream,
+      dependent_launch,
+      kernel_source,
+      launcher_factory);
+  }
+}
+
 template <
   ForceInclusive EnforceInclusive = ForceInclusive::No,
   bool StableReductionOrder       = false,
@@ -969,34 +1372,20 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
                }))
 #endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
 
-  struct fake_policy
-  {
-    using MaxPolicy = void;
-  };
-
   return dispatch_compute_cap(policy_selector, cc, [&](auto policy_getter) {
-    return DispatchScan<InputIteratorT,
-                        OutputIteratorT,
-                        ScanOpT,
-                        InitValueT,
-                        OffsetT,
-                        AccumT,
-                        EnforceInclusive,
-                        fake_policy,
-                        KernelSource,
-                        KernelLauncherFactory>{
+    return invoke(
+      policy_getter,
       d_temp_storage,
       temp_storage_bytes,
       d_in,
       d_out,
-      num_items,
       scan_op,
       init_value,
+      num_items,
       stream,
-      -1 /* ptx_version, not used actually */,
+      cc,
       kernel_source,
-      launcher_factory}
-      .__invoke(policy_getter);
+      launcher_factory);
   });
 }
 

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -1191,7 +1191,7 @@ CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t invoke_warpspeed(
     if (const auto error = CubDebug(
           launcher_factory(init_grid_size, init_kernel_threads, 0, stream, dependent_launch)
             .doit(kernel_source.InitKernel(),
-                  kernel_source.look_ahead_make_tile_state_kernel_arg(d_temp_storage),
+                  kernel_source.lookahead_make_tile_state_kernel_arg(d_temp_storage),
                   grid_dim)))
     {
       return error;
@@ -1213,7 +1213,6 @@ CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t invoke_warpspeed(
   // Invoke scan kernel
   {
     const int block_dim = detail::scan::num_total_threads(warpspeed_policy);
-
 #  ifdef CUB_DEBUG_LOG
     _CubLog("Invoking DeviceScanKernel<<<%d, %d, %d, %lld>>>()\n", grid_dim, block_dim, smem_size, (long long) stream);
 #  endif // CUB_DEBUG_LOG
@@ -1223,7 +1222,7 @@ CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t invoke_warpspeed(
             .doit(scan_kernel,
                   THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_in),
                   THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(d_out),
-                  kernel_source.look_ahead_make_tile_state_kernel_arg(d_temp_storage),
+                  kernel_source.lookahead_make_tile_state_kernel_arg(d_temp_storage),
                   /* start_tile, unused */ 0,
                   ::cuda::std::move(scan_op),
                   init_value,

--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -284,7 +284,7 @@ template <
 struct DispatchScanByKey
 {
   static_assert(::cuda::std::is_unsigned_v<OffsetT> && sizeof(OffsetT) >= 4,
-                "DispatchScan only supports unsigned offset types of at least 4-bytes");
+                "DispatchScanByKey only supports unsigned offset types of at least 4-bytes");
 
   //---------------------------------------------------------------------
   // Constants and Types
@@ -734,7 +734,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
   KernelLauncherFactory launcher_factory = {}) -> cudaError_t
 {
   static_assert(::cuda::std::is_unsigned_v<OffsetT> && sizeof(OffsetT) >= 4,
-                "DispatchScan only supports unsigned offset types of at least 4-bytes");
+                "scan_by_key::dispatch only supports unsigned offset types of at least 4-bytes");
 
   ::cuda::compute_capability cc{};
   if (const auto error = CubDebug(launcher_factory.PtxComputeCap(cc)))

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -151,7 +151,7 @@ __launch_bounds__(current_policy<PolicySelector>().scan.lookback.threads_per_blo
   static constexpr ScanPolicy active_policy = current_policy<PolicySelector>().scan;
   static_assert(active_policy.algorithm == ScanAlgorithm::lookback);
   static constexpr ScanLookbackPolicy policy = active_policy.lookback;
-  using ScanPolicy                           = AgentScanPolicy<
+  using ScanPolicy                           = agent_scan_policy<
                               0,
                               0,
                               void,

--- a/cub/cub/device/dispatch/kernels/kernel_scan.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan.cuh
@@ -221,7 +221,7 @@ __launch_bounds__(device_scan_launch_bounds<PolicySelector>, 1) _CCCL_KERNEL_ATT
     static constexpr ScanLookbackPolicy policy = active_policy.lookback;
     static_assert(policy.load_modifier != CacheLoadModifier::LOAD_LDG,
                   "The memory consistency model does not apply to texture accesses");
-    using ScanPolicyT = AgentScanPolicy<
+    using ScanPolicyT = agent_scan_policy<
       0,
       0,
       void,

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -1000,13 +1000,13 @@ struct policy_hub
 
     // ScanPolicy
     using ScanPolicy =
-      AgentScanPolicy<512,
-                      23,
-                      OffsetT,
-                      BLOCK_LOAD_WARP_TRANSPOSE,
-                      LOAD_DEFAULT,
-                      BLOCK_STORE_WARP_TRANSPOSE,
-                      BLOCK_SCAN_RAKING_MEMOIZE>;
+      agent_scan_policy<512,
+                        23,
+                        OffsetT,
+                        BLOCK_LOAD_WARP_TRANSPOSE,
+                        LOAD_DEFAULT,
+                        BLOCK_STORE_WARP_TRANSPOSE,
+                        BLOCK_SCAN_RAKING_MEMOIZE>;
 
     // Downsweep policies
     using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
@@ -1093,13 +1093,13 @@ struct policy_hub
 
     // ScanPolicy
     using ScanPolicy =
-      AgentScanPolicy<512,
-                      23,
-                      OffsetT,
-                      BLOCK_LOAD_WARP_TRANSPOSE,
-                      LOAD_DEFAULT,
-                      BLOCK_STORE_WARP_TRANSPOSE,
-                      BLOCK_SCAN_RAKING_MEMOIZE>;
+      agent_scan_policy<512,
+                        23,
+                        OffsetT,
+                        BLOCK_LOAD_WARP_TRANSPOSE,
+                        LOAD_DEFAULT,
+                        BLOCK_STORE_WARP_TRANSPOSE,
+                        BLOCK_SCAN_RAKING_MEMOIZE>;
 
     // Downsweep policies
     using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
@@ -1185,13 +1185,13 @@ struct policy_hub
 
     // ScanPolicy
     using ScanPolicy =
-      AgentScanPolicy<512,
-                      23,
-                      OffsetT,
-                      BLOCK_LOAD_WARP_TRANSPOSE,
-                      LOAD_DEFAULT,
-                      BLOCK_STORE_WARP_TRANSPOSE,
-                      BLOCK_SCAN_RAKING_MEMOIZE>;
+      agent_scan_policy<512,
+                        23,
+                        OffsetT,
+                        BLOCK_LOAD_WARP_TRANSPOSE,
+                        LOAD_DEFAULT,
+                        BLOCK_STORE_WARP_TRANSPOSE,
+                        BLOCK_SCAN_RAKING_MEMOIZE>;
 
     // Downsweep policies
     using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
@@ -1276,13 +1276,13 @@ struct policy_hub
 
     // ScanPolicy
     using ScanPolicy =
-      AgentScanPolicy<512,
-                      23,
-                      OffsetT,
-                      BLOCK_LOAD_WARP_TRANSPOSE,
-                      LOAD_DEFAULT,
-                      BLOCK_STORE_WARP_TRANSPOSE,
-                      BLOCK_SCAN_RAKING_MEMOIZE>;
+      agent_scan_policy<512,
+                        23,
+                        OffsetT,
+                        BLOCK_LOAD_WARP_TRANSPOSE,
+                        LOAD_DEFAULT,
+                        BLOCK_STORE_WARP_TRANSPOSE,
+                        BLOCK_SCAN_RAKING_MEMOIZE>;
 
     // Downsweep policies
     using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
@@ -1353,13 +1353,13 @@ struct policy_hub
 
     // ScanPolicy
     using ScanPolicy =
-      AgentScanPolicy<512,
-                      23,
-                      OffsetT,
-                      BLOCK_LOAD_WARP_TRANSPOSE,
-                      LOAD_DEFAULT,
-                      BLOCK_STORE_WARP_TRANSPOSE,
-                      BLOCK_SCAN_RAKING_MEMOIZE>;
+      agent_scan_policy<512,
+                        23,
+                        OffsetT,
+                        BLOCK_LOAD_WARP_TRANSPOSE,
+                        LOAD_DEFAULT,
+                        BLOCK_STORE_WARP_TRANSPOSE,
+                        BLOCK_SCAN_RAKING_MEMOIZE>;
 
     // Downsweep policies
     using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
@@ -1447,13 +1447,13 @@ struct policy_hub
 
     // ScanPolicy
     using ScanPolicy =
-      AgentScanPolicy<512,
-                      23,
-                      OffsetT,
-                      BLOCK_LOAD_WARP_TRANSPOSE,
-                      LOAD_DEFAULT,
-                      BLOCK_STORE_WARP_TRANSPOSE,
-                      BLOCK_SCAN_RAKING_MEMOIZE>;
+      agent_scan_policy<512,
+                        23,
+                        OffsetT,
+                        BLOCK_LOAD_WARP_TRANSPOSE,
+                        LOAD_DEFAULT,
+                        BLOCK_STORE_WARP_TRANSPOSE,
+                        BLOCK_SCAN_RAKING_MEMOIZE>;
 
     // Downsweep policies
     using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
@@ -1569,13 +1569,13 @@ struct policy_hub
     // below to set the launch bounds. The device compiler pass will also compile all kernels for SM70 **and** SM90,
     // even though only the Onesweep kernel is used on SM90.
     using ScanPolicy =
-      AgentScanPolicy<512,
-                      23,
-                      OffsetT,
-                      BLOCK_LOAD_WARP_TRANSPOSE,
-                      LOAD_DEFAULT,
-                      BLOCK_STORE_WARP_TRANSPOSE,
-                      BLOCK_SCAN_RAKING_MEMOIZE>;
+      agent_scan_policy<512,
+                        23,
+                        OffsetT,
+                        BLOCK_LOAD_WARP_TRANSPOSE,
+                        LOAD_DEFAULT,
+                        BLOCK_STORE_WARP_TRANSPOSE,
+                        BLOCK_SCAN_RAKING_MEMOIZE>;
 
     using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
       512,

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -563,19 +563,19 @@ struct policy_hub
   {
     // GTX Titan: 29.5B items/s (232.4 GB/s) @ 48M 32-bit T
     using ScanPolicyT =
-      AgentScanPolicy<128, 12, AccumT, BLOCK_LOAD_DIRECT, LOAD_CA, BLOCK_STORE_WARP_TRANSPOSE_TIMESLICED, BLOCK_SCAN_RAKING>;
+      agent_scan_policy<128, 12, AccumT, BLOCK_LOAD_DIRECT, LOAD_CA, BLOCK_STORE_WARP_TRANSPOSE_TIMESLICED, BLOCK_SCAN_RAKING>;
   };
   struct Policy520 : ChainedPolicy<520, Policy520, Policy500>
   {
     // Titan X: 32.47B items/s @ 48M 32-bit T
     using ScanPolicyT =
-      AgentScanPolicy<128, 12, AccumT, BLOCK_LOAD_DIRECT, LOAD_CA, scan_transposed_store, BLOCK_SCAN_WARP_SCANS>;
+      agent_scan_policy<128, 12, AccumT, BLOCK_LOAD_DIRECT, LOAD_CA, scan_transposed_store, BLOCK_SCAN_WARP_SCANS>;
   };
 
   struct DefaultPolicy
   {
     using ScanPolicyT =
-      AgentScanPolicy<128, 15, AccumT, scan_transposed_load, LOAD_DEFAULT, scan_transposed_store, BLOCK_SCAN_WARP_SCANS>;
+      agent_scan_policy<128, 15, AccumT, scan_transposed_load, LOAD_DEFAULT, scan_transposed_store, BLOCK_SCAN_WARP_SCANS>;
   };
 
   struct Policy600
@@ -586,15 +586,15 @@ struct policy_hub
   // Use values from tuning if a specialization exists, otherwise pick DefaultPolicy
   template <typename Tuning>
   _CCCL_HOST_DEVICE static auto select_agent_policy(int)
-    -> AgentScanPolicy<Tuning::threads,
-                       Tuning::items,
-                       AccumT,
-                       Tuning::load_algorithm,
-                       LOAD_DEFAULT,
-                       Tuning::store_algorithm,
-                       BLOCK_SCAN_WARP_SCANS,
-                       cub::detail::MemBoundScaling<Tuning::threads, Tuning::items, AccumT>,
-                       typename Tuning::delay_constructor>;
+    -> agent_scan_policy<Tuning::threads,
+                         Tuning::items,
+                         AccumT,
+                         Tuning::load_algorithm,
+                         LOAD_DEFAULT,
+                         Tuning::store_algorithm,
+                         BLOCK_SCAN_WARP_SCANS,
+                         cub::detail::MemBoundScaling<Tuning::threads, Tuning::items, AccumT>,
+                         typename Tuning::delay_constructor>;
   template <typename Tuning>
   _CCCL_HOST_DEVICE static auto select_agent_policy(long) -> typename DefaultPolicy::ScanPolicyT;
 
@@ -612,15 +612,15 @@ struct policy_hub
                                          && sizeof(IVT) == sizeof(OutputValueT),
                                        int> = 0>
     _CCCL_HOST_DEVICE static auto select_agent_policy750(int)
-      -> AgentScanPolicy<Tuning::threads,
-                         Tuning::items,
-                         AccumT,
-                         Tuning::load_algorithm,
-                         Tuning::load_modifier,
-                         Tuning::store_algorithm,
-                         BLOCK_SCAN_WARP_SCANS,
-                         MemBoundScaling<Tuning::threads, Tuning::items, AccumT>,
-                         typename Tuning::delay_constructor>;
+      -> agent_scan_policy<Tuning::threads,
+                           Tuning::items,
+                           AccumT,
+                           Tuning::load_algorithm,
+                           Tuning::load_modifier,
+                           Tuning::store_algorithm,
+                           BLOCK_SCAN_WARP_SCANS,
+                           MemBoundScaling<Tuning::threads, Tuning::items, AccumT>,
+                           typename Tuning::delay_constructor>;
     template <typename Tuning, typename IVT>
     _CCCL_HOST_DEVICE static auto select_agent_policy750(long) -> typename Policy600::ScanPolicyT;
 
@@ -661,15 +661,15 @@ struct policy_hub
                                          && sizeof(IVT) == sizeof(OutputValueT),
                                        int> = 0>
     _CCCL_HOST_DEVICE static auto select_agent_policy100(int)
-      -> AgentScanPolicy<Tuning::threads,
-                         Tuning::items,
-                         AccumT,
-                         Tuning::load_algorithm,
-                         Tuning::load_modifier,
-                         Tuning::store_algorithm,
-                         BLOCK_SCAN_WARP_SCANS,
-                         MemBoundScaling<Tuning::threads, Tuning::items, AccumT>,
-                         typename Tuning::delay_constructor>;
+      -> agent_scan_policy<Tuning::threads,
+                           Tuning::items,
+                           AccumT,
+                           Tuning::load_algorithm,
+                           Tuning::load_modifier,
+                           Tuning::store_algorithm,
+                           BLOCK_SCAN_WARP_SCANS,
+                           MemBoundScaling<Tuning::threads, Tuning::items, AccumT>,
+                           typename Tuning::delay_constructor>;
     template <typename Tuning, typename IVT>
     _CCCL_HOST_DEVICE static auto select_agent_policy100(long) -> typename Policy900::ScanPolicyT;
 

--- a/cub/test/catch2_test_device_radix_sort_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_radix_sort_custom_policy_hub.cu
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// TODO(bgruber): drop this test with CCCL 4.0 when we drop the radix sort dispatcher
+
+// disable deprecation warnings for DispatchScan
+#define CCCL_IGNORE_DEPRECATED_API
+
 #include "insert_nested_NVTX_range_guard.h"
 
 #include <cub/device/device_radix_sort.cuh>
@@ -8,8 +13,6 @@
 #include "catch2_radix_sort_helper.cuh"
 
 using namespace cub;
-
-// TODO(bgruber): drop this test with CCCL 4.0 when we drop the radix sort dispatcher after publishing the tuning API
 
 template <typename KeyT, typename OffsetT>
 struct my_policy_hub

--- a/cub/test/catch2_test_device_scan_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_scan_custom_policy_hub.cu
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// TODO(bgruber): drop this test with CCCL 4.0 when we drop the scan dispatcher
+
+// disable deprecation warnings for DispatchScan
+#define CCCL_IGNORE_DEPRECATED_API
+
 #include "insert_nested_NVTX_range_guard.h"
 
 #include <cub/device/device_scan.cuh>
@@ -13,8 +18,6 @@
 #include <c2h/catch2_test_helper.h>
 
 using namespace cub;
-
-// TODO(bgruber): drop this test with CCCL 4.0 when we drop the scan dispatcher after publishing the tuning API
 
 template <typename InputValueT, typename OutputValueT, typename AccumT, typename OffsetT, typename ScanOpT>
 struct my_policy_hub

--- a/cub/test/catch2_test_device_segmented_radix_sort_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_custom_policy_hub.cu
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// TODO(bgruber): drop this test with CCCL 4.0 when we drop the segmented radix sort dispatcher
+
+// disable deprecation warnings for DispatchScan
+#define CCCL_IGNORE_DEPRECATED_API
+
 #include "insert_nested_NVTX_range_guard.h"
 
 #include <cub/device/dispatch/dispatch_segmented_radix_sort.cuh>
@@ -11,9 +16,6 @@
 #include <c2h/catch2_test_helper.h>
 
 using namespace cub;
-
-// TODO(bgruber): drop this test with CCCL 4.0 when we drop the segmented radix sort dispatcher after publishing the
-// tuning API
 
 template <typename KeyT, typename OffsetT>
 struct my_policy_hub


### PR DESCRIPTION
This is a follow-up to #8853 to keep that PR a bit shorter.

- [x] Merge before: #8853