### PR TITLE
`cuda::device::warp_match_any`

### DIFF
--- a/docs/libcudacxx/extended_api/warp.rst
+++ b/docs/libcudacxx/extended_api/warp.rst
@@ -9,6 +9,7 @@ Warp
 
    warp/warp_shuffle
    warp/warp_match_all
+   warp/warp_match_any
    warp/lane_mask
 
 .. list-table::
@@ -44,6 +45,11 @@ Warp
      - Check if all lanes have the same value
      - CCCL 3.1.0
      - CUDA 13.1
+
+   * - :ref:`warp_match_any <libcudacxx-extended-api-warp-warp-match-any>`
+     - Get the mask of lanes with the same value
+     - CCCL 3.5.0
+     - CUDA 13.5
 
    * - :ref:`lane_mask <libcudacxx-extended-api-warp-lane-mask>`
      - Class to represent a mask of lanes in a warp

--- a/docs/libcudacxx/extended_api/warp.rst
+++ b/docs/libcudacxx/extended_api/warp.rst
@@ -46,12 +46,12 @@ Warp
      - CCCL 3.1.0
      - CUDA 13.1
 
-   * - :ref:`warp_match_any <libcudacxx-extended-api-warp-warp-match-any>`
-     - Get the mask of lanes with the same value
-     - CCCL 3.5.0
-     - CUDA 13.5
-
    * - :ref:`lane_mask <libcudacxx-extended-api-warp-lane-mask>`
      - Class to represent a mask of lanes in a warp
      - CCCL 3.1.0
      - CUDA 13.1
+
+   * - :ref:`warp_match_any <libcudacxx-extended-api-warp-warp-match-any>`
+     - Get the mask of lanes with the same value
+     - CCCL 3.5.0
+     - CUDA 13.5

--- a/docs/libcudacxx/extended_api/warp/warp_match_all.rst
+++ b/docs/libcudacxx/extended_api/warp/warp_match_all.rst
@@ -50,6 +50,7 @@ The function allows bitwise comparison of any data size, including raw arrays, p
 
 - The function calls the PTX instruction ``match.sync`` :math:`ceil\left(\frac{sizeof(data)}{4}\right)` times.
 - The function is faster when called with a mask representing all active lanes in a warp (default value of the second parameter ``lane_mask``).
+- The function uses ``__ballot_sync`` when ``T`` is ``bool``.
 
 **References**
 

--- a/docs/libcudacxx/extended_api/warp/warp_match_all.rst
+++ b/docs/libcudacxx/extended_api/warp/warp_match_all.rst
@@ -50,6 +50,7 @@ The function allows bitwise comparison of any data size, including raw arrays, p
 
 - The function calls the PTX instruction ``match.sync`` :math:`ceil\left(\frac{sizeof(data)}{4}\right)` times.
 - The function is faster when called with a mask representing all active lanes in a warp (default value of the second parameter ``lane_mask``).
+- The function calls ``__all_sync`` when called with a boolean value.
 
 **References**
 

--- a/docs/libcudacxx/extended_api/warp/warp_match_all.rst
+++ b/docs/libcudacxx/extended_api/warp/warp_match_all.rst
@@ -50,7 +50,6 @@ The function allows bitwise comparison of any data size, including raw arrays, p
 
 - The function calls the PTX instruction ``match.sync`` :math:`ceil\left(\frac{sizeof(data)}{4}\right)` times.
 - The function is faster when called with a mask representing all active lanes in a warp (default value of the second parameter ``lane_mask``).
-- The function calls ``__all_sync`` when called with a boolean value.
 
 **References**
 

--- a/docs/libcudacxx/extended_api/warp/warp_match_any.rst
+++ b/docs/libcudacxx/extended_api/warp/warp_match_any.rst
@@ -50,6 +50,7 @@ The function allows bitwise comparison of any data size, including raw arrays, p
 
 - The function calls the PTX instruction ``match.sync`` :math:`ceil\left(\frac{sizeof(data)}{4}\right)` times.
 - The function is faster when called with a mask representing all active lanes in a warp (default value of the second parameter ``lane_mask``).
+- The function uses ``__ballot_sync`` when ``T`` is ``bool``.
 
 **References**
 

--- a/docs/libcudacxx/extended_api/warp/warp_match_any.rst
+++ b/docs/libcudacxx/extended_api/warp/warp_match_any.rst
@@ -1,6 +1,6 @@
-.. _libcudacxx-extended-api-warp-warp-match-all:
+.. _libcudacxx-extended-api-warp-warp-match-any:
 
-``cuda::device::warp_match_all``
+``cuda::device::warp_match_any``
 ================================
 
 Defined in ``<cuda/warp>`` header.
@@ -10,18 +10,18 @@ Defined in ``<cuda/warp>`` header.
     namespace cuda::device {
 
     template <typename T>
-    [[nodiscard]] __device__ bool
-    warp_match_all(const T& data, lane_mask = lane_mask::all());
+    [[nodiscard]] __device__ lane_mask
+    warp_match_any(const T& data, lane_mask = lane_mask::all());
 
     } // namespace cuda::device
 
-The functionality provides a generalized and safe alternative to CUDA warp match all intrinsic ``__match_all_sync``.
+The functionality provides a generalized and safe alternative to CUDA warp match any intrinsic ``__match_any_sync``.
 The function allows bitwise comparison of any data size, including raw arrays, pointers, and structs.
 
 .. note::
 
   The underlying CUDA intrinsic does not provide memory ordering.
-
+  
 **Parameters**
 
 - ``data``: data to compare.
@@ -29,12 +29,12 @@ The function allows bitwise comparison of any data size, including raw arrays, p
 
 **Return value**
 
-- ``true`` if all lanes in the ``lane_mask`` have the same value for ``data``. ``false`` otherwise.
+- A ``lane_mask`` representing the non-exited lanes in ``lane_mask`` that have the same bitwise value for ``data`` as  the calling lane.
 
 **Constraints**
 
 - ``T`` shall be trivially copyable, see :ref:`cuda::is_trivially_copyable <libcudacxx-extended-api-type_traits-is_trivially_copyable>`.
-- ``T`` shall be bitwise comparable, see :ref:`cuda::is_bitwise_comparable <libcudacxx-extended-api-type_traits-is_bitwise_comparable>`, except when ``__builtin_clear_padding`` is supported. In the latter case, ``T`` can have padding bits.
+- When ``__builtin_clear_padding`` is not supported, ``T`` shall have no padding bits, that is, ``T``'s value representation shall be identical to its object representation.
 
 **Preconditions**
 
@@ -53,7 +53,7 @@ The function allows bitwise comparison of any data size, including raw arrays, p
 
 **References**
 
-- `CUDA match_all Intrinsics <https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/cpp-language-extensions.html#warp-match-functions>`_
+- `CUDA match_any Intrinsics <https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/cpp-language-extensions.html#warp-match-functions>`_
 - `PTX match.sync instruction <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-match-sync>`_
 
 Example
@@ -71,10 +71,22 @@ Example
     };            // 4 bytes of padding
 
     __global__ void warp_match_kernel() {
-        assert(cuda::device::warp_match_all(2));
-        assert(cuda::device::warp_match_all(2, cuda::device::lane_mask::all()));
-        assert(cuda::device::warp_match_all(MyStruct{1.0, 3})); // compile error, except when __builtin_clear_padding is supported
-        assert(!cuda::device::warp_match_all(threadIdx.x));
+        {
+            auto mask     = cuda::device::warp_match_any(threadIdx.x / 4);
+            auto expected = cuda::device::lane_mask{0b1111 << ((threadIdx.x / 4) * 4)};
+            assert(mask == expected);
+        }
+        {
+            auto mask     = cuda::device::warp_match_any(2);
+            auto expected = cuda::device::lane_mask{0xFFFFFFFF};
+            assert(mask == expected);
+        }
+        {
+            // compile error, except when __builtin_clear_padding is supported
+            auto mask     = cuda::device::warp_match_any(MyStruct{1.0, 3});
+            auto expected = cuda::device::lane_mask{0xFFFFFFFF};
+            assert(mask == expected);
+        }
     }
 
     int main() {
@@ -83,4 +95,4 @@ Example
         return 0;
     }
 
-`See it on Godbolt 🔗 <https://godbolt.org/z/x1sWbx14r>`_
+`See it on Godbolt 🔗 <https://godbolt.org/z/Ys1McG8nv>`_

--- a/docs/libcudacxx/extended_api/warp/warp_match_any.rst
+++ b/docs/libcudacxx/extended_api/warp/warp_match_any.rst
@@ -50,6 +50,7 @@ The function allows bitwise comparison of any data size, including raw arrays, p
 
 - The function calls the PTX instruction ``match.sync`` :math:`ceil\left(\frac{sizeof(data)}{4}\right)` times.
 - The function is faster when called with a mask representing all active lanes in a warp (default value of the second parameter ``lane_mask``).
+- The function calls ``__ballot_sync`` when called with a boolean value.
 
 **References**
 

--- a/docs/libcudacxx/extended_api/warp/warp_match_any.rst
+++ b/docs/libcudacxx/extended_api/warp/warp_match_any.rst
@@ -21,7 +21,7 @@ The function allows bitwise comparison of any data size, including raw arrays, p
 .. note::
 
   The underlying CUDA intrinsic does not provide memory ordering.
-  
+
 **Parameters**
 
 - ``data``: data to compare.

--- a/docs/libcudacxx/extended_api/warp/warp_match_any.rst
+++ b/docs/libcudacxx/extended_api/warp/warp_match_any.rst
@@ -50,7 +50,6 @@ The function allows bitwise comparison of any data size, including raw arrays, p
 
 - The function calls the PTX instruction ``match.sync`` :math:`ceil\left(\frac{sizeof(data)}{4}\right)` times.
 - The function is faster when called with a mask representing all active lanes in a warp (default value of the second parameter ``lane_mask``).
-- The function calls ``__ballot_sync`` when called with a boolean value.
 
 **References**
 

--- a/libcudacxx/include/cuda/__warp/warp_match_all.h
+++ b/libcudacxx/include/cuda/__warp/warp_match_all.h
@@ -29,6 +29,7 @@
 #  include <cuda/__warp/lane_mask.h>
 #  include <cuda/std/__cstring/memcpy.h>
 #  include <cuda/std/__memory/addressof.h>
+#  include <cuda/std/__type_traits/is_same.h>
 #  include <cuda/std/cstdint>
 
 #  include <cuda/std/__cccl/prologue.h>
@@ -44,30 +45,38 @@ warp_match_all(const _Tp& __data, const lane_mask __lane_mask = lane_mask::all()
   static_assert(is_trivially_copyable_v<_Tp>, "data must be trivially copyable");
   _CCCL_ASSERT(__lane_mask != lane_mask::none(), "lane_mask must be non-zero");
 
-  constexpr int __ratio = ::cuda::ceil_div(sizeof(_Tp), sizeof(::cuda::std::uint32_t));
-  ::cuda::std::uint32_t __array[__ratio]{};
+  if constexpr (::cuda::std::is_same_v<_Tp, bool>)
+  {
+    const auto __mask = ::__ballot_sync(__lane_mask.value(), __data);
+    return (__mask == __lane_mask.value() || __mask == 0);
+  }
+  else
+  {
+    constexpr int __ratio = ::cuda::ceil_div(sizeof(_Tp), sizeof(::cuda::std::uint32_t));
+    ::cuda::std::uint32_t __array[__ratio]{};
 
 #  if defined(_CCCL_BUILTIN_CLEAR_PADDING)
-  auto __data_copy = __data;
-  _CCCL_BUILTIN_CLEAR_PADDING(&__data_copy);
-  const auto __data_ptr = ::cuda::std::addressof(__data_copy);
+    auto __data_copy = __data;
+    _CCCL_BUILTIN_CLEAR_PADDING(&__data_copy);
+    const auto __data_ptr = ::cuda::std::addressof(__data_copy);
 #  else // ^^^ _CCCL_BUILTIN_CLEAR_PADDING ^^^ / vvv !_CCCL_BUILTIN_CLEAR_PADDING vvv
-  static_assert(is_bitwise_comparable_v<_Tp>, "data must be bitwise comparable");
-  const auto __data_ptr = ::cuda::std::addressof(__data);
+    static_assert(is_bitwise_comparable_v<_Tp>, "data must be bitwise comparable");
+    const auto __data_ptr = ::cuda::std::addressof(__data);
 #  endif // _CCCL_BUILTIN_CLEAR_PADDING
-  ::cuda::std::memcpy(__array, __data_ptr, sizeof(_Tp));
+    ::cuda::std::memcpy(__array, __data_ptr, sizeof(_Tp));
 
-  bool __ret = true;
-  _CCCL_PRAGMA_UNROLL_FULL()
-  for (int i = 0; i < __ratio; ++i)
-  {
-    int __pred = false;
-    NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70,
-                      (::__match_all_sync(__lane_mask.value(), __array[i], &__pred);),
-                      (::cuda::device::__cuda__match_all_sync_is_not_supported_before_SM_70__();));
-    __ret = __ret && __pred;
+    bool __ret = true;
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < __ratio; ++i)
+    {
+      int __pred = false;
+      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70,
+                        (::__match_all_sync(__lane_mask.value(), __array[i], &__pred);),
+                        (::cuda::device::__cuda__match_all_sync_is_not_supported_before_SM_70__();));
+      __ret = __ret && __pred;
+    }
+    return __ret;
   }
-  return __ret;
 }
 
 _CCCL_END_NAMESPACE_CUDA_DEVICE

--- a/libcudacxx/include/cuda/__warp/warp_match_all.h
+++ b/libcudacxx/include/cuda/__warp/warp_match_all.h
@@ -44,30 +44,37 @@ warp_match_all(const _Tp& __data, const lane_mask __lane_mask = lane_mask::all()
   static_assert(is_trivially_copyable_v<_Tp>, "data must be trivially copyable");
   _CCCL_ASSERT(__lane_mask != lane_mask::none(), "lane_mask must be non-zero");
 
-  constexpr int __ratio = ::cuda::ceil_div(sizeof(_Tp), sizeof(::cuda::std::uint32_t));
-  ::cuda::std::uint32_t __array[__ratio]{};
+  if constexpr (::cuda::std::is_same_v<_Tp, bool>)
+  {
+    return ::__all_sync(__lane_mask.value(), __data);
+  }
+  else
+  {
+    constexpr int __ratio = ::cuda::ceil_div(sizeof(_Tp), sizeof(::cuda::std::uint32_t));
+    ::cuda::std::uint32_t __array[__ratio]{};
 
 #  if defined(_CCCL_BUILTIN_CLEAR_PADDING)
-  auto __data_copy = __data;
-  _CCCL_BUILTIN_CLEAR_PADDING(&__data_copy);
-  const auto __data_ptr = ::cuda::std::addressof(__data_copy);
+    auto __data_copy = __data;
+    _CCCL_BUILTIN_CLEAR_PADDING(&__data_copy);
+    const auto __data_ptr = ::cuda::std::addressof(__data_copy);
 #  else // ^^^ _CCCL_BUILTIN_CLEAR_PADDING ^^^ / vvv !_CCCL_BUILTIN_CLEAR_PADDING vvv
-  static_assert(is_bitwise_comparable_v<_Tp>, "data must be bitwise comparable");
-  const auto __data_ptr = ::cuda::std::addressof(__data);
+    static_assert(is_bitwise_comparable_v<_Tp>, "data must be bitwise comparable");
+    const auto __data_ptr = ::cuda::std::addressof(__data);
 #  endif // _CCCL_BUILTIN_CLEAR_PADDING
-  ::cuda::std::memcpy(__array, __data_ptr, sizeof(_Tp));
+    ::cuda::std::memcpy(__array, __data_ptr, sizeof(_Tp));
 
-  bool __ret = true;
-  _CCCL_PRAGMA_UNROLL_FULL()
-  for (int i = 0; i < __ratio; ++i)
-  {
-    int __pred = false;
-    NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70,
-                      (::__match_all_sync(__lane_mask.value(), __array[i], &__pred);),
-                      (::cuda::device::__cuda__match_all_sync_is_not_supported_before_SM_70__();));
-    __ret = __ret && __pred;
+    bool __ret = true;
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < __ratio; ++i)
+    {
+      int __pred = false;
+      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70,
+                        (::__match_all_sync(__lane_mask.value(), __array[i], &__pred);),
+                        (::cuda::device::__cuda__match_all_sync_is_not_supported_before_SM_70__();));
+      __ret = __ret && __pred;
+    }
+    return __ret;
   }
-  return __ret;
 }
 
 _CCCL_END_NAMESPACE_CUDA_DEVICE

--- a/libcudacxx/include/cuda/__warp/warp_match_all.h
+++ b/libcudacxx/include/cuda/__warp/warp_match_all.h
@@ -44,37 +44,30 @@ warp_match_all(const _Tp& __data, const lane_mask __lane_mask = lane_mask::all()
   static_assert(is_trivially_copyable_v<_Tp>, "data must be trivially copyable");
   _CCCL_ASSERT(__lane_mask != lane_mask::none(), "lane_mask must be non-zero");
 
-  if constexpr (::cuda::std::is_same_v<_Tp, bool>)
-  {
-    return ::__all_sync(__lane_mask.value(), __data);
-  }
-  else
-  {
-    constexpr int __ratio = ::cuda::ceil_div(sizeof(_Tp), sizeof(::cuda::std::uint32_t));
-    ::cuda::std::uint32_t __array[__ratio]{};
+  constexpr int __ratio = ::cuda::ceil_div(sizeof(_Tp), sizeof(::cuda::std::uint32_t));
+  ::cuda::std::uint32_t __array[__ratio]{};
 
 #  if defined(_CCCL_BUILTIN_CLEAR_PADDING)
-    auto __data_copy = __data;
-    _CCCL_BUILTIN_CLEAR_PADDING(&__data_copy);
-    const auto __data_ptr = ::cuda::std::addressof(__data_copy);
+  auto __data_copy = __data;
+  _CCCL_BUILTIN_CLEAR_PADDING(&__data_copy);
+  const auto __data_ptr = ::cuda::std::addressof(__data_copy);
 #  else // ^^^ _CCCL_BUILTIN_CLEAR_PADDING ^^^ / vvv !_CCCL_BUILTIN_CLEAR_PADDING vvv
-    static_assert(is_bitwise_comparable_v<_Tp>, "data must be bitwise comparable");
-    const auto __data_ptr = ::cuda::std::addressof(__data);
+  static_assert(is_bitwise_comparable_v<_Tp>, "data must be bitwise comparable");
+  const auto __data_ptr = ::cuda::std::addressof(__data);
 #  endif // _CCCL_BUILTIN_CLEAR_PADDING
-    ::cuda::std::memcpy(__array, __data_ptr, sizeof(_Tp));
+  ::cuda::std::memcpy(__array, __data_ptr, sizeof(_Tp));
 
-    bool __ret = true;
-    _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < __ratio; ++i)
-    {
-      int __pred = false;
-      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70,
-                        (::__match_all_sync(__lane_mask.value(), __array[i], &__pred);),
-                        (::cuda::device::__cuda__match_all_sync_is_not_supported_before_SM_70__();));
-      __ret = __ret && __pred;
-    }
-    return __ret;
+  bool __ret = true;
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (int i = 0; i < __ratio; ++i)
+  {
+    int __pred = false;
+    NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70,
+                      (::__match_all_sync(__lane_mask.value(), __array[i], &__pred);),
+                      (::cuda::device::__cuda__match_all_sync_is_not_supported_before_SM_70__();));
+    __ret = __ret && __pred;
   }
+  return __ret;
 }
 
 _CCCL_END_NAMESPACE_CUDA_DEVICE

--- a/libcudacxx/include/cuda/__warp/warp_match_any.h
+++ b/libcudacxx/include/cuda/__warp/warp_match_any.h
@@ -29,6 +29,7 @@
 #  include <cuda/__warp/lane_mask.h>
 #  include <cuda/std/__cstring/memcpy.h>
 #  include <cuda/std/__memory/addressof.h>
+#  include <cuda/std/__type_traits/is_same.h>
 #  include <cuda/std/cstdint>
 
 #  include <cuda/std/__cccl/prologue.h>
@@ -50,30 +51,42 @@ warp_match_any(const _Tp& __data, const lane_mask __lane_mask = lane_mask::all()
   static_assert(is_trivially_copyable_v<_Tp>, "data must be trivially copyable");
   _CCCL_ASSERT(__lane_mask != lane_mask::none(), "lane_mask must be non-zero");
 
-  constexpr int __ratio = ::cuda::ceil_div(sizeof(_Tp), sizeof(::cuda::std::uint32_t));
-  ::cuda::std::uint32_t __array[__ratio]{};
+  if constexpr (::cuda::std::is_same_v<_Tp, bool>)
+  {
+    auto __mask = ::__ballot_sync(__lane_mask.value(), __data);
+    if (!__data)
+    {
+      __mask = (~__mask) & __lane_mask.value();
+    }
+    return lane_mask{__mask};
+  }
+  else
+  {
+    constexpr int __ratio = ::cuda::ceil_div(sizeof(_Tp), sizeof(::cuda::std::uint32_t));
+    ::cuda::std::uint32_t __array[__ratio]{};
 
 #  if defined(_CCCL_BUILTIN_CLEAR_PADDING)
-  auto __data_copy = __data;
-  _CCCL_BUILTIN_CLEAR_PADDING(&__data_copy);
-  const auto __data_ptr = ::cuda::std::addressof(__data_copy);
+    auto __data_copy = __data;
+    _CCCL_BUILTIN_CLEAR_PADDING(&__data_copy);
+    const auto __data_ptr = ::cuda::std::addressof(__data_copy);
 #  else // ^^^ _CCCL_BUILTIN_CLEAR_PADDING ^^^ / vvv !_CCCL_BUILTIN_CLEAR_PADDING vvv
-  static_assert(is_bitwise_comparable_v<_Tp>, "data must be bitwise comparable");
-  const auto __data_ptr = ::cuda::std::addressof(__data);
+    static_assert(is_bitwise_comparable_v<_Tp>, "data must be bitwise comparable");
+    const auto __data_ptr = ::cuda::std::addressof(__data);
 #  endif // _CCCL_BUILTIN_CLEAR_PADDING
-  ::cuda::std::memcpy(__array, __data_ptr, sizeof(_Tp));
+    ::cuda::std::memcpy(__array, __data_ptr, sizeof(_Tp));
 
-  lane_mask __ret = __lane_mask;
-  _CCCL_PRAGMA_UNROLL_FULL()
-  for (int i = 0; i < __ratio; ++i)
-  {
-    ::cuda::std::uint32_t __match_any_result = 0;
-    NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70,
-                      (__match_any_result = ::__match_any_sync(__lane_mask.value(), __array[i]);),
-                      (::cuda::device::__cuda__match_any_sync_is_not_supported_before_SM_70__();));
-    __ret &= lane_mask{__match_any_result};
+    lane_mask __ret = __lane_mask;
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < __ratio; ++i)
+    {
+      ::cuda::std::uint32_t __match_any_result = 0;
+      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70,
+                        (__match_any_result = ::__match_any_sync(__lane_mask.value(), __array[i]);),
+                        (::cuda::device::__cuda__match_any_sync_is_not_supported_before_SM_70__();));
+      __ret &= lane_mask{__match_any_result};
+    }
+    return __ret;
   }
-  return __ret;
 }
 
 _CCCL_END_NAMESPACE_CUDA_DEVICE

--- a/libcudacxx/include/cuda/__warp/warp_match_any.h
+++ b/libcudacxx/include/cuda/__warp/warp_match_any.h
@@ -50,30 +50,37 @@ warp_match_any(const _Tp& __data, const lane_mask __lane_mask = lane_mask::all()
   static_assert(is_trivially_copyable_v<_Tp>, "data must be trivially copyable");
   _CCCL_ASSERT(__lane_mask != lane_mask::none(), "lane_mask must be non-zero");
 
-  constexpr int __ratio = ::cuda::ceil_div(sizeof(_Tp), sizeof(::cuda::std::uint32_t));
-  ::cuda::std::uint32_t __array[__ratio]{};
+  if constexpr (::cuda::std::is_same_v<_Tp, bool>)
+  {
+    return ::__ballot_sync(__lane_mask.value(), __data);
+  }
+  else
+  {
+    constexpr int __ratio = ::cuda::ceil_div(sizeof(_Tp), sizeof(::cuda::std::uint32_t));
+    ::cuda::std::uint32_t __array[__ratio]{};
 
 #  if defined(_CCCL_BUILTIN_CLEAR_PADDING)
-  auto __data_copy = __data;
-  _CCCL_BUILTIN_CLEAR_PADDING(&__data_copy);
-  const auto __data_ptr = ::cuda::std::addressof(__data_copy);
+    auto __data_copy = __data;
+    _CCCL_BUILTIN_CLEAR_PADDING(&__data_copy);
+    const auto __data_ptr = ::cuda::std::addressof(__data_copy);
 #  else // ^^^ _CCCL_BUILTIN_CLEAR_PADDING ^^^ / vvv !_CCCL_BUILTIN_CLEAR_PADDING vvv
-  static_assert(is_bitwise_comparable_v<_Tp>, "data must be bitwise comparable");
-  const auto __data_ptr = ::cuda::std::addressof(__data);
+    static_assert(is_bitwise_comparable_v<_Tp>, "data must be bitwise comparable");
+    const auto __data_ptr = ::cuda::std::addressof(__data);
 #  endif // _CCCL_BUILTIN_CLEAR_PADDING
-  ::cuda::std::memcpy(__array, __data_ptr, sizeof(_Tp));
+    ::cuda::std::memcpy(__array, __data_ptr, sizeof(_Tp));
 
-  lane_mask __ret = __lane_mask;
-  _CCCL_PRAGMA_UNROLL_FULL()
-  for (int i = 0; i < __ratio; ++i)
-  {
-    ::cuda::std::uint32_t __match_any_result = 0;
-    NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70,
-                      (__match_any_result = ::__match_any_sync(__lane_mask.value(), __array[i]);),
-                      (::cuda::device::__cuda__match_any_sync_is_not_supported_before_SM_70__();));
-    __ret &= lane_mask{__match_any_result};
+    lane_mask __ret = __lane_mask;
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < __ratio; ++i)
+    {
+      ::cuda::std::uint32_t __match_any_result = 0;
+      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70,
+                        (__match_any_result = ::__match_any_sync(__lane_mask.value(), __array[i]);),
+                        (::cuda::device::__cuda__match_any_sync_is_not_supported_before_SM_70__();));
+      __ret &= lane_mask{__match_any_result};
+    }
+    return __ret;
   }
-  return __ret;
 }
 
 _CCCL_END_NAMESPACE_CUDA_DEVICE

--- a/libcudacxx/include/cuda/__warp/warp_match_any.h
+++ b/libcudacxx/include/cuda/__warp/warp_match_any.h
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___WARP_WARP_MATCH_ANY_H
+#define _CUDA___WARP_WARP_MATCH_ANY_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_CUDA_COMPILATION()
+
+#  include <cuda/__cmath/ceil_div.h>
+#  include <cuda/__type_traits/is_bitwise_comparable.h>
+#  include <cuda/__type_traits/is_trivially_copyable.h>
+#  include <cuda/__warp/lane_mask.h>
+#  include <cuda/std/__cstring/memcpy.h>
+#  include <cuda/std/__memory/addressof.h>
+#  include <cuda/std/cstdint>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
+
+extern "C" _CCCL_DEVICE void __cuda__match_any_sync_is_not_supported_before_SM_70__();
+
+//! @brief Returns the mask of lanes with the same bitwise value as the calling lane.
+//!
+//! @param[in] __data The data to compare across lanes.
+//! @param[in] __lane_mask The mask of participating lanes.
+//!
+//! @return A lane mask containing lanes in `__lane_mask` whose `__data` matches the calling lane's data.
+template <class _Tp>
+[[nodiscard]] _CCCL_DEVICE_API lane_mask
+warp_match_any(const _Tp& __data, const lane_mask __lane_mask = lane_mask::all()) noexcept
+{
+  static_assert(is_trivially_copyable_v<_Tp>, "data must be trivially copyable");
+  _CCCL_ASSERT(__lane_mask != lane_mask::none(), "lane_mask must be non-zero");
+
+  constexpr int __ratio = ::cuda::ceil_div(sizeof(_Tp), sizeof(::cuda::std::uint32_t));
+  ::cuda::std::uint32_t __array[__ratio]{};
+
+#  if defined(_CCCL_BUILTIN_CLEAR_PADDING)
+  auto __data_copy = __data;
+  _CCCL_BUILTIN_CLEAR_PADDING(&__data_copy);
+  const auto __data_ptr = ::cuda::std::addressof(__data_copy);
+#  else // ^^^ _CCCL_BUILTIN_CLEAR_PADDING ^^^ / vvv !_CCCL_BUILTIN_CLEAR_PADDING vvv
+  static_assert(is_bitwise_comparable_v<_Tp>, "data must be bitwise comparable");
+  const auto __data_ptr = ::cuda::std::addressof(__data);
+#  endif // _CCCL_BUILTIN_CLEAR_PADDING
+  ::cuda::std::memcpy(__array, __data_ptr, sizeof(_Tp));
+
+  lane_mask __ret = __lane_mask;
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (int i = 0; i < __ratio; ++i)
+  {
+    ::cuda::std::uint32_t __match_any_result = 0;
+    NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70,
+                      (__match_any_result = ::__match_any_sync(__lane_mask.value(), __array[i]);),
+                      (::cuda::device::__cuda__match_any_sync_is_not_supported_before_SM_70__();));
+    __ret &= lane_mask{__match_any_result};
+  }
+  return __ret;
+}
+
+_CCCL_END_NAMESPACE_CUDA_DEVICE
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CCCL_CUDA_COMPILATION()
+#endif // _CUDA___WARP_WARP_MATCH_ANY_H

--- a/libcudacxx/include/cuda/__warp/warp_match_any.h
+++ b/libcudacxx/include/cuda/__warp/warp_match_any.h
@@ -50,37 +50,30 @@ warp_match_any(const _Tp& __data, const lane_mask __lane_mask = lane_mask::all()
   static_assert(is_trivially_copyable_v<_Tp>, "data must be trivially copyable");
   _CCCL_ASSERT(__lane_mask != lane_mask::none(), "lane_mask must be non-zero");
 
-  if constexpr (::cuda::std::is_same_v<_Tp, bool>)
-  {
-    return ::__ballot_sync(__lane_mask.value(), __data);
-  }
-  else
-  {
-    constexpr int __ratio = ::cuda::ceil_div(sizeof(_Tp), sizeof(::cuda::std::uint32_t));
-    ::cuda::std::uint32_t __array[__ratio]{};
+  constexpr int __ratio = ::cuda::ceil_div(sizeof(_Tp), sizeof(::cuda::std::uint32_t));
+  ::cuda::std::uint32_t __array[__ratio]{};
 
 #  if defined(_CCCL_BUILTIN_CLEAR_PADDING)
-    auto __data_copy = __data;
-    _CCCL_BUILTIN_CLEAR_PADDING(&__data_copy);
-    const auto __data_ptr = ::cuda::std::addressof(__data_copy);
+  auto __data_copy = __data;
+  _CCCL_BUILTIN_CLEAR_PADDING(&__data_copy);
+  const auto __data_ptr = ::cuda::std::addressof(__data_copy);
 #  else // ^^^ _CCCL_BUILTIN_CLEAR_PADDING ^^^ / vvv !_CCCL_BUILTIN_CLEAR_PADDING vvv
-    static_assert(is_bitwise_comparable_v<_Tp>, "data must be bitwise comparable");
-    const auto __data_ptr = ::cuda::std::addressof(__data);
+  static_assert(is_bitwise_comparable_v<_Tp>, "data must be bitwise comparable");
+  const auto __data_ptr = ::cuda::std::addressof(__data);
 #  endif // _CCCL_BUILTIN_CLEAR_PADDING
-    ::cuda::std::memcpy(__array, __data_ptr, sizeof(_Tp));
+  ::cuda::std::memcpy(__array, __data_ptr, sizeof(_Tp));
 
-    lane_mask __ret = __lane_mask;
-    _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < __ratio; ++i)
-    {
-      ::cuda::std::uint32_t __match_any_result = 0;
-      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70,
-                        (__match_any_result = ::__match_any_sync(__lane_mask.value(), __array[i]);),
-                        (::cuda::device::__cuda__match_any_sync_is_not_supported_before_SM_70__();));
-      __ret &= lane_mask{__match_any_result};
-    }
-    return __ret;
+  lane_mask __ret = __lane_mask;
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (int i = 0; i < __ratio; ++i)
+  {
+    ::cuda::std::uint32_t __match_any_result = 0;
+    NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70,
+                      (__match_any_result = ::__match_any_sync(__lane_mask.value(), __array[i]);),
+                      (::cuda::device::__cuda__match_any_sync_is_not_supported_before_SM_70__();));
+    __ret &= lane_mask{__match_any_result};
   }
+  return __ret;
 }
 
 _CCCL_END_NAMESPACE_CUDA_DEVICE

--- a/libcudacxx/include/cuda/warp
+++ b/libcudacxx/include/cuda/warp
@@ -23,6 +23,7 @@
 
 #include <cuda/__warp/lane_mask.h>
 #include <cuda/__warp/warp_match_all.h>
+#include <cuda/__warp/warp_match_any.h>
 #include <cuda/__warp/warp_shuffle.h>
 
 #endif // _CUDA_WARP

--- a/libcudacxx/test/libcudacxx/cuda/warp/warp_match.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/warp/warp_match.pass.cpp
@@ -34,6 +34,26 @@ TEST_DEVICE_FUNC void test_types(T valueA = T{}, T valueB = T{1})
   }
 }
 
+TEST_DEVICE_FUNC uint32_t make_low_mask(unsigned count)
+{
+  return count == 32 ? 0xFFFFFFFF : ((1u << count) - 1);
+}
+
+TEST_DEVICE_FUNC void test_bool()
+{
+  for (unsigned i = 1; i <= 32; ++i)
+  {
+    auto mask = cuda::device::lane_mask{make_low_mask(i)};
+    if (threadIdx.x < i)
+    {
+      assert(cuda::device::warp_match_all(false, mask));
+      assert(cuda::device::warp_match_all(true, mask));
+      auto value = threadIdx.x == 0;
+      assert(cuda::device::warp_match_all(value, mask) == (i == 1));
+    }
+  }
+}
+
 struct WithPadding
 {
   int a;
@@ -42,6 +62,7 @@ struct WithPadding
 
 __global__ void test_kernel()
 {
+  test_bool();
   test_types<uint8_t>();
   test_types<uint16_t>();
   test_types<uint32_t>();

--- a/libcudacxx/test/libcudacxx/cuda/warp/warp_match_any.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/warp/warp_match_any.pass.cpp
@@ -65,9 +65,28 @@ TEST_DEVICE_FUNC void test_grouped(T valueA = T{}, T valueB = T{1})
   }
 }
 
+TEST_DEVICE_FUNC void test_bool()
+{
+  for (unsigned i = 1; i <= 32; ++i)
+  {
+    if (threadIdx.x < i)
+    {
+      auto mask = cuda::device::lane_mask{make_low_mask(i)};
+      assert(cuda::device::warp_match_any(false, mask) == mask);
+      assert(cuda::device::warp_match_any(true, mask) == mask);
+
+      auto value    = threadIdx.x % 2 == 0;
+      auto expected = cuda::device::lane_mask{make_stride_mask(i, 2, threadIdx.x % 2)};
+      assert(cuda::device::warp_match_any(value, mask) == expected);
+    }
+  }
+}
+
 TEST_DEVICE_FUNC void test()
 {
   using array_t = cuda::std::array<char, 6>;
+  test_bool();
+
   test_all_equal<uint8_t>();
   test_all_equal<uint16_t>();
   test_all_equal<uint32_t>();

--- a/libcudacxx/test/libcudacxx/cuda/warp/warp_match_any.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/warp/warp_match_any.pass.cpp
@@ -75,7 +75,7 @@ __global__ void test_kernel()
   test_all_equal<uint64_t>();
 #if _CCCL_HAS_INT128()
   test_all_equal<__uint128_t>();
-#endif
+#endif // _CCCL_HAS_INT128()
   test_all_equal(char3{0, 0, 0});
   test_all_equal(array_t{0, 0, 0, 0, 0, 0});
 

--- a/libcudacxx/test/libcudacxx/cuda/warp/warp_match_any.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/warp/warp_match_any.pass.cpp
@@ -85,7 +85,7 @@ __global__ void test_kernel()
   test_grouped<uint64_t>();
 #if _CCCL_HAS_INT128()
   test_grouped<__uint128_t>();
-#endif
+#endif // _CCCL_HAS_INT128() 
   test_grouped(char3{0, 0, 0}, char3{1, 1, 1});
   test_grouped(array_t{0, 0, 0, 0, 0, 0}, array_t{1, 1, 1, 1, 1, 1});
 }

--- a/libcudacxx/test/libcudacxx/cuda/warp/warp_match_any.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/warp/warp_match_any.pass.cpp
@@ -1,0 +1,97 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+// UNSUPPORTED: pre-sm-70
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
+#include <cuda/warp>
+
+#include "test_macros.h"
+
+TEST_DEVICE_FUNC uint32_t make_low_mask(unsigned count)
+{
+  return count == 32 ? 0xFFFFFFFF : ((1u << count) - 1);
+}
+
+TEST_DEVICE_FUNC uint32_t make_stride_mask(unsigned count, unsigned step, unsigned remainder)
+{
+  uint32_t mask = 0;
+  for (unsigned lane = 0; lane < count; ++lane)
+  {
+    if ((lane % step) == remainder)
+    {
+      mask |= uint32_t{1} << lane;
+    }
+  }
+  return mask;
+}
+
+template <typename T>
+TEST_DEVICE_FUNC void test_all_equal(T value = T{})
+{
+  for (unsigned i = 1; i <= 32; ++i)
+  {
+    auto mask = cuda::device::lane_mask{make_low_mask(i)};
+    if (threadIdx.x < i)
+    {
+      assert(cuda::device::warp_match_any(value, mask) == mask);
+    }
+  }
+}
+
+// two different groups of lanes
+template <typename T>
+TEST_DEVICE_FUNC void test_grouped(T valueA = T{}, T valueB = T{1})
+{
+  for (unsigned i = 2; i <= 32; ++i)
+  {
+    auto mask = cuda::device::lane_mask{make_low_mask(i)};
+    if (threadIdx.x < i)
+    {
+      auto value    = threadIdx.x % 2 == 0 ? valueA : valueB;
+      auto expected = cuda::device::lane_mask{make_stride_mask(i, 2, threadIdx.x % 2)};
+      assert(cuda::device::warp_match_any(value, mask) == expected);
+    }
+  }
+}
+
+__global__ void test_kernel()
+{
+  using array_t = cuda::std::array<char, 6>;
+
+  test_all_equal<uint8_t>();
+  test_all_equal<uint16_t>();
+  test_all_equal<uint32_t>();
+  test_all_equal<uint64_t>();
+#if _CCCL_HAS_INT128()
+  test_all_equal<__uint128_t>();
+#endif
+  test_all_equal(char3{0, 0, 0});
+  test_all_equal(array_t{0, 0, 0, 0, 0, 0});
+
+  test_grouped<uint8_t>();
+  test_grouped<uint16_t>();
+  test_grouped<uint32_t>();
+  test_grouped<uint64_t>();
+#if _CCCL_HAS_INT128()
+  test_grouped<__uint128_t>();
+#endif
+  test_grouped(char3{0, 0, 0}, char3{1, 1, 1});
+  test_grouped(array_t{0, 0, 0, 0, 0, 0}, array_t{1, 1, 1, 1, 1, 1});
+}
+
+int main(int, char**)
+{
+  NV_IF_TARGET(NV_IS_HOST, (test_kernel<<<1, 32>>>();))
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/warp/warp_match_any.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/warp/warp_match_any.pass.cpp
@@ -65,10 +65,9 @@ TEST_DEVICE_FUNC void test_grouped(T valueA = T{}, T valueB = T{1})
   }
 }
 
-__global__ void test_kernel()
+TEST_DEVICE_FUNC void test()
 {
   using array_t = cuda::std::array<char, 6>;
-
   test_all_equal<uint8_t>();
   test_all_equal<uint16_t>();
   test_all_equal<uint32_t>();
@@ -85,13 +84,13 @@ __global__ void test_kernel()
   test_grouped<uint64_t>();
 #if _CCCL_HAS_INT128()
   test_grouped<__uint128_t>();
-#endif // _CCCL_HAS_INT128() 
+#endif // _CCCL_HAS_INT128()
   test_grouped(char3{0, 0, 0}, char3{1, 1, 1});
   test_grouped(array_t{0, 0, 0, 0, 0, 0}, array_t{1, 1, 1, 1, 1, 1});
 }
 
 int main(int, char**)
 {
-  NV_IF_TARGET(NV_IS_HOST, (test_kernel<<<1, 32>>>();))
+  NV_DISPATCH_TARGET(NV_IS_HOST, (cuda_thread_count = 32;), NV_IS_DEVICE, (test();))
   return 0;
 }


### PR DESCRIPTION
## Description

The PR provides `cuda::device::warp_match_any` in a similar way of [cuda::device::warp_match_all](https://nvidia.github.io/cccl/unstable/libcudacxx/extended_api/warp/warp_match_all.html#libcudacxx-extended-api-warp-warp-match-all) for completeness.
The main difference is that `warp_match_any` returns a `mask` instead of a bool value.