### PR TITLE
Rename `block_scan_algorithm` to `scan_algorithm`

### DIFF
--- a/cub/cub/device/dispatch/kernels/kernel_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_three_way_partition.cuh
@@ -137,7 +137,7 @@ __launch_bounds__(current_policy<PolicySelector>().threads_per_block)
     active_policy.items_per_thread,
     active_policy.load_algorithm,
     active_policy.load_modifier,
-    active_policy.block_scan_algorithm,
+    active_policy.scan_algorithm,
     delay_constructor_t<active_policy.delay_constructor.kind,
                         active_policy.delay_constructor.delay,
                         active_policy.delay_constructor.l2_write_latency>>;

--- a/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
@@ -422,7 +422,7 @@ struct three_way_partition_policy
   int items_per_thread;
   BlockLoadAlgorithm load_algorithm;
   CacheLoadModifier load_modifier;
-  BlockScanAlgorithm block_scan_algorithm;
+  BlockScanAlgorithm scan_algorithm;
   delay_constructor_policy delay_constructor;
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
@@ -430,7 +430,7 @@ struct three_way_partition_policy
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
         && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
-        && lhs.block_scan_algorithm == rhs.block_scan_algorithm && lhs.delay_constructor == rhs.delay_constructor;
+        && lhs.scan_algorithm == rhs.scan_algorithm && lhs.delay_constructor == rhs.delay_constructor;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
@@ -445,7 +445,7 @@ struct three_way_partition_policy
     return os
         << "three_way_partition_policy { .threads_per_block = " << policy.threads_per_block
         << ", .items_per_thread = " << policy.items_per_thread << ", .load_algorithm = " << policy.load_algorithm
-        << ", .load_modifier = " << policy.load_modifier << ", .block_scan_algorithm = " << policy.block_scan_algorithm
+        << ", .load_modifier = " << policy.load_modifier << ", .scan_algorithm = " << policy.scan_algorithm
         << ", .delay_constructor = " << policy.delay_constructor << " }";
   }
 #endif // _CCCL_HOSTED()


### PR DESCRIPTION
This member of `three_way_partition_policy` was the only tuning policy member of for a `BlockScanAlgorithm` that was not spelled `scan_algorithm`. Renaming for consistency. See also: https://docs.google.com/spreadsheets/d/1EUdwvmv2n7-WRp30-lt7CQxyu8r6atdfJJx3O6Pf1Ag