### PR TITLE
Add PDL to `cub::DeviceRadixSort`

### DIFF
--- a/c/parallel/include/cccl/c/radix_sort.h
+++ b/c/parallel/include/cccl/c/radix_sort.h
@@ -40,6 +40,8 @@ typedef struct cccl_device_radix_sort_build_result_t
   CUkernel alt_downsweep_kernel;
   CUkernel histogram_kernel;
   CUkernel exclusive_sum_kernel;
+  CUkernel init_bins_and_counters_kernel;
+  CUkernel init_lookback_kernel;
   CUkernel onesweep_kernel;
   cccl_sort_order_t order;
   void* runtime_policy;

--- a/c/parallel/src/radix_sort.cu
+++ b/c/parallel/src/radix_sort.cu
@@ -305,9 +305,8 @@ static_assert(device_radix_sort_policy()(current_tuning_cc()) == {6}, "Host gene
   std::string histogram_kernel_name =
     radix_sort::get_histogram_kernel_name(chained_policy_t, sort_order, key_cpp, offset_t);
   std::string exclusive_sum_kernel_name = radix_sort::get_exclusive_sum_kernel_name(chained_policy_t, offset_t);
-  std::string init_bins_and_counters_kernel_name =
-    radix_sort::get_init_kernel_name(chained_policy_t, "int", offset_t);
-  std::string init_lookback_kernel_name = radix_sort::get_init_kernel_name(chained_policy_t, "int", "int");
+  std::string init_bins_and_counters_kernel_name = radix_sort::get_init_kernel_name(chained_policy_t, "int", offset_t);
+  std::string init_lookback_kernel_name          = radix_sort::get_init_kernel_name(chained_policy_t, "int", "int");
   std::string onesweep_kernel_name =
     radix_sort::get_onesweep_kernel_name(chained_policy_t, sort_order, key_cpp, value_cpp, offset_t);
   std::string single_tile_kernel_lowered_name;

--- a/c/parallel/src/radix_sort.cu
+++ b/c/parallel/src/radix_sort.cu
@@ -105,6 +105,22 @@ std::string get_exclusive_sum_kernel_name(std::string_view chained_policy_t, std
   return std::format("cub::detail::radix_sort::DeviceRadixSortExclusiveSumKernel<{0}, {1}>", chained_policy_t, offset_t);
 }
 
+std::string get_init_kernel_name(
+  std::string_view chained_policy_t,
+  bool trigger_at_start,
+  bool fence_before_end_trigger,
+  std::string_view init_t0,
+  std::string_view init_t1)
+{
+  return std::format(
+    "cub::detail::radix_sort::DeviceRadixSortInitKernel<{0}, {1}, {2}, {3}, {4}>",
+    chained_policy_t,
+    trigger_at_start ? "true" : "false",
+    fence_before_end_trigger ? "true" : "false",
+    init_t0,
+    init_t1);
+}
+
 std::string get_onesweep_kernel_name(
   std::string_view chained_policy_t,
   cccl_sort_order_t sort_order,
@@ -164,6 +180,16 @@ struct radix_sort_kernel_source
   CUkernel RadixSortExclusiveSumKernel() const
   {
     return build.exclusive_sum_kernel;
+  }
+
+  CUkernel RadixSortInitBinsAndCountersKernel() const
+  {
+    return build.init_bins_and_counters_kernel;
+  }
+
+  CUkernel RadixSortInitLookbackKernel() const
+  {
+    return build.init_lookback_kernel;
   }
 
   CUkernel RadixSortOnesweepKernel() const
@@ -289,6 +315,9 @@ static_assert(device_radix_sort_policy()(current_tuning_cc()) == {6}, "Host gene
   std::string histogram_kernel_name =
     radix_sort::get_histogram_kernel_name(chained_policy_t, sort_order, key_cpp, offset_t);
   std::string exclusive_sum_kernel_name = radix_sort::get_exclusive_sum_kernel_name(chained_policy_t, offset_t);
+  std::string init_bins_and_counters_kernel_name =
+    radix_sort::get_init_kernel_name(chained_policy_t, true, false, "int", offset_t);
+  std::string init_lookback_kernel_name = radix_sort::get_init_kernel_name(chained_policy_t, false, true, "int", "int");
   std::string onesweep_kernel_name =
     radix_sort::get_onesweep_kernel_name(chained_policy_t, sort_order, key_cpp, value_cpp, offset_t);
   std::string single_tile_kernel_lowered_name;
@@ -299,6 +328,8 @@ static_assert(device_radix_sort_policy()(current_tuning_cc()) == {6}, "Host gene
   std::string alt_downsweep_kernel_lowered_name;
   std::string histogram_kernel_lowered_name;
   std::string exclusive_sum_kernel_lowered_name;
+  std::string init_bins_and_counters_kernel_lowered_name;
+  std::string init_lookback_kernel_lowered_name;
   std::string onesweep_kernel_lowered_name;
 
   const std::string arch = std::format("-arch=sm_{0}{1}", cc_major, cc_minor);
@@ -336,6 +367,8 @@ static_assert(device_radix_sort_policy()(current_tuning_cc()) == {6}, "Host gene
       ->add_expression({alt_downsweep_kernel_name})
       ->add_expression({histogram_kernel_name})
       ->add_expression({exclusive_sum_kernel_name})
+      ->add_expression({init_bins_and_counters_kernel_name})
+      ->add_expression({init_lookback_kernel_name})
       ->add_expression({onesweep_kernel_name})
       ->compile_program({args.data(), args.size()})
       ->get_name({single_tile_kernel_name, single_tile_kernel_lowered_name})
@@ -346,6 +379,8 @@ static_assert(device_radix_sort_policy()(current_tuning_cc()) == {6}, "Host gene
       ->get_name({alt_downsweep_kernel_name, alt_downsweep_kernel_lowered_name})
       ->get_name({histogram_kernel_name, histogram_kernel_lowered_name})
       ->get_name({exclusive_sum_kernel_name, exclusive_sum_kernel_lowered_name})
+      ->get_name({init_bins_and_counters_kernel_name, init_bins_and_counters_kernel_lowered_name})
+      ->get_name({init_lookback_kernel_name, init_lookback_kernel_lowered_name})
       ->get_name({onesweep_kernel_name, onesweep_kernel_lowered_name})
       ->link_program()
       ->add_link_list(linkable_list)
@@ -364,6 +399,10 @@ static_assert(device_radix_sort_policy()(current_tuning_cc()) == {6}, "Host gene
   check(cuLibraryGetKernel(&build_ptr->histogram_kernel, build_ptr->library, histogram_kernel_lowered_name.c_str()));
   check(cuLibraryGetKernel(
     &build_ptr->exclusive_sum_kernel, build_ptr->library, exclusive_sum_kernel_lowered_name.c_str()));
+  check(cuLibraryGetKernel(
+    &build_ptr->init_bins_and_counters_kernel, build_ptr->library, init_bins_and_counters_kernel_lowered_name.c_str()));
+  check(cuLibraryGetKernel(
+    &build_ptr->init_lookback_kernel, build_ptr->library, init_lookback_kernel_lowered_name.c_str()));
   check(cuLibraryGetKernel(&build_ptr->onesweep_kernel, build_ptr->library, onesweep_kernel_lowered_name.c_str()));
 
   build_ptr->cc             = cc_major * 10 + cc_minor;

--- a/c/parallel/src/radix_sort.cu
+++ b/c/parallel/src/radix_sort.cu
@@ -105,10 +105,9 @@ std::string get_exclusive_sum_kernel_name(std::string_view chained_policy_t, std
   return std::format("cub::detail::radix_sort::DeviceRadixSortExclusiveSumKernel<{0}, {1}>", chained_policy_t, offset_t);
 }
 
-std::string get_init_kernel_name(std::string_view chained_policy_t, std::string_view init_t0, std::string_view init_t1)
+std::string get_init_kernel_name(std::string_view init_t0, std::string_view init_t1)
 {
-  return std::format(
-    "cub::detail::radix_sort::DeviceRadixSortInitKernel<{0}, {1}, {2}>", chained_policy_t, init_t0, init_t1);
+  return std::format("cub::detail::radix_sort::DeviceRadixSortInitKernel<{0}, {1}>", init_t0, init_t1);
 }
 
 std::string get_onesweep_kernel_name(
@@ -305,8 +304,8 @@ static_assert(device_radix_sort_policy()(current_tuning_cc()) == {6}, "Host gene
   std::string histogram_kernel_name =
     radix_sort::get_histogram_kernel_name(chained_policy_t, sort_order, key_cpp, offset_t);
   std::string exclusive_sum_kernel_name = radix_sort::get_exclusive_sum_kernel_name(chained_policy_t, offset_t);
-  std::string init_bins_and_counters_kernel_name = radix_sort::get_init_kernel_name(chained_policy_t, "int", offset_t);
-  std::string init_lookback_kernel_name          = radix_sort::get_init_kernel_name(chained_policy_t, "int", "int");
+  std::string init_bins_and_counters_kernel_name = radix_sort::get_init_kernel_name("int", offset_t);
+  std::string init_lookback_kernel_name          = radix_sort::get_init_kernel_name("int", "int");
   std::string onesweep_kernel_name =
     radix_sort::get_onesweep_kernel_name(chained_policy_t, sort_order, key_cpp, value_cpp, offset_t);
   std::string single_tile_kernel_lowered_name;

--- a/c/parallel/src/radix_sort.cu
+++ b/c/parallel/src/radix_sort.cu
@@ -105,20 +105,10 @@ std::string get_exclusive_sum_kernel_name(std::string_view chained_policy_t, std
   return std::format("cub::detail::radix_sort::DeviceRadixSortExclusiveSumKernel<{0}, {1}>", chained_policy_t, offset_t);
 }
 
-std::string get_init_kernel_name(
-  std::string_view chained_policy_t,
-  bool trigger_at_start,
-  bool fence_before_end_trigger,
-  std::string_view init_t0,
-  std::string_view init_t1)
+std::string get_init_kernel_name(std::string_view chained_policy_t, std::string_view init_t0, std::string_view init_t1)
 {
   return std::format(
-    "cub::detail::radix_sort::DeviceRadixSortInitKernel<{0}, {1}, {2}, {3}, {4}>",
-    chained_policy_t,
-    trigger_at_start ? "true" : "false",
-    fence_before_end_trigger ? "true" : "false",
-    init_t0,
-    init_t1);
+    "cub::detail::radix_sort::DeviceRadixSortInitKernel<{0}, {1}, {2}>", chained_policy_t, init_t0, init_t1);
 }
 
 std::string get_onesweep_kernel_name(
@@ -316,8 +306,8 @@ static_assert(device_radix_sort_policy()(current_tuning_cc()) == {6}, "Host gene
     radix_sort::get_histogram_kernel_name(chained_policy_t, sort_order, key_cpp, offset_t);
   std::string exclusive_sum_kernel_name = radix_sort::get_exclusive_sum_kernel_name(chained_policy_t, offset_t);
   std::string init_bins_and_counters_kernel_name =
-    radix_sort::get_init_kernel_name(chained_policy_t, true, false, "int", offset_t);
-  std::string init_lookback_kernel_name = radix_sort::get_init_kernel_name(chained_policy_t, false, true, "int", "int");
+    radix_sort::get_init_kernel_name(chained_policy_t, "int", offset_t);
+  std::string init_lookback_kernel_name = radix_sort::get_init_kernel_name(chained_policy_t, "int", "int");
   std::string onesweep_kernel_name =
     radix_sort::get_onesweep_kernel_name(chained_policy_t, sort_order, key_cpp, value_cpp, offset_t);
   std::string single_tile_kernel_lowered_name;

--- a/c/parallel/src/radix_sort.cu
+++ b/c/parallel/src/radix_sort.cu
@@ -105,9 +105,10 @@ std::string get_exclusive_sum_kernel_name(std::string_view chained_policy_t, std
   return std::format("cub::detail::radix_sort::DeviceRadixSortExclusiveSumKernel<{0}, {1}>", chained_policy_t, offset_t);
 }
 
-std::string get_init_kernel_name(std::string_view init_t0, std::string_view init_t1)
+std::string get_init_kernel_name(std::string_view chained_policy_t, std::string_view init_t0, std::string_view init_t1)
 {
-  return std::format("cub::detail::radix_sort::DeviceRadixSortInitKernel<{0}, {1}>", init_t0, init_t1);
+  return std::format(
+    "cub::detail::radix_sort::DeviceRadixSortInitKernel<{0}, {1}, {2}>", chained_policy_t, init_t0, init_t1);
 }
 
 std::string get_onesweep_kernel_name(
@@ -304,8 +305,8 @@ static_assert(device_radix_sort_policy()(current_tuning_cc()) == {6}, "Host gene
   std::string histogram_kernel_name =
     radix_sort::get_histogram_kernel_name(chained_policy_t, sort_order, key_cpp, offset_t);
   std::string exclusive_sum_kernel_name = radix_sort::get_exclusive_sum_kernel_name(chained_policy_t, offset_t);
-  std::string init_bins_and_counters_kernel_name = radix_sort::get_init_kernel_name("int", offset_t);
-  std::string init_lookback_kernel_name          = radix_sort::get_init_kernel_name("int", "int");
+  std::string init_bins_and_counters_kernel_name = radix_sort::get_init_kernel_name(chained_policy_t, "int", offset_t);
+  std::string init_lookback_kernel_name          = radix_sort::get_init_kernel_name(chained_policy_t, "int", "int");
   std::string onesweep_kernel_name =
     radix_sort::get_onesweep_kernel_name(chained_policy_t, sort_order, key_cpp, value_cpp, offset_t);
   std::string single_tile_kernel_lowered_name;

--- a/cub/cub/agent/agent_radix_sort_histogram.cuh
+++ b/cub/cub/agent/agent_radix_sort_histogram.cuh
@@ -257,6 +257,7 @@ struct AgentRadixSortHistogram
       __syncthreads();
 
       // Accumulate the result in global memory.
+      // Wait for global histogram init
       _CCCL_PDL_GRID_DEPENDENCY_SYNC();
       AccumulateGlobalHistograms();
       __syncthreads();

--- a/cub/cub/agent/agent_radix_sort_histogram.cuh
+++ b/cub/cub/agent/agent_radix_sort_histogram.cuh
@@ -257,7 +257,6 @@ struct AgentRadixSortHistogram
       __syncthreads();
 
       // Accumulate the result in global memory.
-
       _CCCL_PDL_GRID_DEPENDENCY_SYNC();
       AccumulateGlobalHistograms();
       __syncthreads();

--- a/cub/cub/agent/agent_radix_sort_histogram.cuh
+++ b/cub/cub/agent/agent_radix_sort_histogram.cuh
@@ -257,6 +257,8 @@ struct AgentRadixSortHistogram
       __syncthreads();
 
       // Accumulate the result in global memory.
+
+      _CCCL_PDL_GRID_DEPENDENCY_SYNC();
       AccumulateGlobalHistograms();
       __syncthreads();
     }

--- a/cub/cub/agent/agent_radix_sort_histogram.cuh
+++ b/cub/cub/agent/agent_radix_sort_histogram.cuh
@@ -242,7 +242,6 @@ struct AgentRadixSortHistogram
     {
       // Reset the counters.
       Init();
-      __syncthreads();
 
       // Process the tiles.
       OffsetT portion_offset = portion * MAX_PORTION_SIZE;

--- a/cub/cub/agent/agent_radix_sort_histogram.cuh
+++ b/cub/cub/agent/agent_radix_sort_histogram.cuh
@@ -234,6 +234,7 @@ struct AgentRadixSortHistogram
 
   _CCCL_DEVICE _CCCL_FORCEINLINE void Process()
   {
+    _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
     // Within a portion, avoid overflowing (u)int32 counters.
     // Between portions, accumulate results in global memory.
     constexpr OffsetT MAX_PORTION_SIZE = 1 << 30;

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -180,7 +180,6 @@ struct AgentRadixSortOnesweep
   PortionOffsetT num_items;
   int current_bit;
   int num_bits;
-  bool use_pdl;
 
   // other thread variables
   int warp;
@@ -242,10 +241,8 @@ struct AgentRadixSortOnesweep
       {
         bins[u] = other_bins[u];
       }
-      if (agent.use_pdl)
-      {
-        _CCCL_PDL_GRID_DEPENDENCY_SYNC();
-      }
+
+      _CCCL_PDL_GRID_DEPENDENCY_SYNC();
       agent.LookbackPartial(bins);
 
       agent.TryShortCircuit(keys, bins);
@@ -659,7 +656,6 @@ struct AgentRadixSortOnesweep
     PortionOffsetT num_items,
     int current_bit,
     int num_bits,
-    bool use_pdl,
     DecomposerT decomposer = {})
       : s(temp_storage.Alias())
       , d_lookback(d_lookback)
@@ -673,7 +669,6 @@ struct AgentRadixSortOnesweep
       , num_items(num_items)
       , current_bit(current_bit)
       , num_bits(num_bits)
-      , use_pdl(use_pdl)
       , warp(threadIdx.x / WARP_THREADS)
       , lane(::cuda::ptx::get_sreg_laneid())
       , decomposer(decomposer)

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -610,13 +610,13 @@ struct AgentRadixSortOnesweep
 
   _CCCL_DEVICE _CCCL_FORCEINLINE void Process()
   {
-    _CCCL_PDL_GRID_DEPENDENCY_SYNC();
-
     // load keys
     // if warp1 < warp2, all elements of warp1 occur before those of warp2
     // in the source array
     bit_ordered_type keys[ITEMS_PER_THREAD];
     LoadKeys(block_idx * TILE_ITEMS, keys);
+
+    _CCCL_PDL_GRID_DEPENDENCY_SYNC();
 
     // rank keys
     int ranks[ITEMS_PER_THREAD];

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -610,8 +610,6 @@ struct AgentRadixSortOnesweep
 
   _CCCL_DEVICE _CCCL_FORCEINLINE void Process()
   {
-    _CCCL_PDL_GRID_DEPENDENCY_SYNC();
-
     // load keys
     // if warp1 < warp2, all elements of warp1 occur before those of warp2
     // in the source array

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -610,6 +610,8 @@ struct AgentRadixSortOnesweep
 
   _CCCL_DEVICE _CCCL_FORCEINLINE void Process()
   {
+    _CCCL_PDL_GRID_DEPENDENCY_SYNC();
+
     // load keys
     // if warp1 < warp2, all elements of warp1 occur before those of warp2
     // in the source array

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -284,6 +284,7 @@ struct AgentRadixSortOnesweep
         s.global_offsets[bin] += inc_sum - bins[u];
       }
     }
+    _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
   }
 
   _CCCL_DEVICE _CCCL_FORCEINLINE void LoadKeys(OffsetT tile_offset, bit_ordered_type (&keys)[ITEMS_PER_THREAD])

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -242,6 +242,10 @@ struct AgentRadixSortOnesweep
       {
         bins[u] = other_bins[u];
       }
+      if (agent.use_pdl)
+      {
+        _CCCL_PDL_GRID_DEPENDENCY_SYNC();
+      }
       agent.LookbackPartial(bins);
 
       agent.TryShortCircuit(keys, bins);
@@ -616,11 +620,6 @@ struct AgentRadixSortOnesweep
     // in the source array
     bit_ordered_type keys[ITEMS_PER_THREAD];
     LoadKeys(block_idx * TILE_ITEMS, keys);
-
-    if (use_pdl)
-    {
-      _CCCL_PDL_GRID_DEPENDENCY_SYNC();
-    }
 
     // rank keys
     int ranks[ITEMS_PER_THREAD];

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -242,6 +242,7 @@ struct AgentRadixSortOnesweep
         bins[u] = other_bins[u];
       }
 
+      // Wait for lookback init
       _CCCL_PDL_GRID_DEPENDENCY_SYNC();
       agent.LookbackPartial(bins);
 

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -180,6 +180,7 @@ struct AgentRadixSortOnesweep
   PortionOffsetT num_items;
   int current_bit;
   int num_bits;
+  bool use_pdl;
 
   // other thread variables
   int warp;
@@ -616,7 +617,10 @@ struct AgentRadixSortOnesweep
     bit_ordered_type keys[ITEMS_PER_THREAD];
     LoadKeys(block_idx * TILE_ITEMS, keys);
 
-    _CCCL_PDL_GRID_DEPENDENCY_SYNC();
+    if (use_pdl)
+    {
+      _CCCL_PDL_GRID_DEPENDENCY_SYNC();
+    }
 
     // rank keys
     int ranks[ITEMS_PER_THREAD];
@@ -656,6 +660,7 @@ struct AgentRadixSortOnesweep
     PortionOffsetT num_items,
     int current_bit,
     int num_bits,
+    bool use_pdl,
     DecomposerT decomposer = {})
       : s(temp_storage.Alias())
       , d_lookback(d_lookback)
@@ -669,6 +674,7 @@ struct AgentRadixSortOnesweep
       , num_items(num_items)
       , current_bit(current_bit)
       , num_bits(num_bits)
+      , use_pdl(use_pdl)
       , warp(threadIdx.x / WARP_THREADS)
       , lane(::cuda::ptx::get_sreg_laneid())
       , decomposer(decomposer)

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -75,9 +75,11 @@ struct DeviceRadixSortKernelSource
     DeviceRadixSortDownsweepKernel<PolicySelector, true, Order, KeyT, ValueT, OffsetT, DecomposerT>);
 
   CUB_DEFINE_KERNEL_GETTER(RadixSortHistogramKernel,
-                           DeviceRadixSortHistogramKernel<PolicySelector, Order, KeyT, OffsetT, DecomposerT>);
+                           DeviceRadixSortHistogramKernel<PolicySelector, Order, KeyT, OffsetT, int, DecomposerT>);
 
   CUB_DEFINE_KERNEL_GETTER(RadixSortExclusiveSumKernel, DeviceRadixSortExclusiveSumKernel<PolicySelector, OffsetT>);
+
+  CUB_DEFINE_KERNEL_GETTER(RadixSortInitLookbackKernel, DeviceRadixSortInitLookbackKernel<PolicySelector, int>);
 
   CUB_DEFINE_KERNEL_GETTER(
     RadixSortOnesweepKernel,
@@ -640,7 +642,15 @@ private:
 
     if (const auto error = CubDebug(
           launcher_factory(histo_blocks_per_sm * num_sms, HISTO_BLOCK_THREADS, 0, stream)
-            .doit(histogram_kernel, d_bins, d_keys.Current(), num_items, begin_bit, end_bit, decomposer)))
+            .doit(
+              histogram_kernel,
+              d_bins,
+              d_ctrs,
+              d_keys.Current(),
+              num_items,
+              begin_bit,
+              end_bit,
+              decomposer)))
     {
       return error;
     }
@@ -650,28 +660,6 @@ private:
       return error;
     }
 
-    // exclusive sums to determine starts
-    const int SCAN_BLOCK_THREADS = policy.exclusive_sum.threads_per_block;
-
-// log exclusive_sum_kernel configuration
-#ifdef CUB_DEBUG_LOG
-    _CubLog("Invoking exclusive_sum_kernel<<<%d, %d, 0, %lld>>>(), bit_grain %d\n",
-            num_passes,
-            SCAN_BLOCK_THREADS,
-            reinterpret_cast<long long>(stream),
-            policy.exclusive_sum.radix_bits);
-#endif
-
-    if (const auto error = CubDebug(launcher_factory(num_passes, SCAN_BLOCK_THREADS, 0, stream)
-                                      .doit(kernel_source.RadixSortExclusiveSumKernel(), d_bins)))
-    {
-      return error;
-    }
-
-    if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
-    {
-      return error;
-    }
     // use the other buffer if no overwrite is allowed
     KeyT* d_keys_tmp     = d_keys.Alternate();
     ValueT* d_values_tmp = d_values.Alternate();
@@ -690,9 +678,18 @@ private:
           ::cuda::std::min(num_items - portion * PORTION_SIZE, static_cast<OffsetT>(PORTION_SIZE)));
 
         PortionOffsetT num_blocks = ::cuda::ceil_div(portion_num_items, ONESWEEP_TILE_ITEMS);
+        const size_t num_lookback_items = static_cast<size_t>(num_blocks) * RADIX_DIGITS;
+        constexpr int INIT_LOOKBACK_THREADS = 256;
+        const int init_lookback_blocks      = static_cast<int>(
+          ::cuda::ceil_div(num_lookback_items, static_cast<size_t>(INIT_LOOKBACK_THREADS)));
 
-        if (const auto error =
-              CubDebug(cudaMemsetAsync(d_lookback, 0, num_blocks * RADIX_DIGITS * sizeof(AtomicOffsetT), stream)))
+        if (const auto error = CubDebug(launcher_factory(init_lookback_blocks, INIT_LOOKBACK_THREADS, 0, stream)
+                                          .doit(kernel_source.RadixSortInitLookbackKernel(), d_lookback, num_lookback_items)))
+        {
+          return error;
+        }
+
+        if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
         {
           return error;
         }

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -79,8 +79,6 @@ struct DeviceRadixSortKernelSource
 
   CUB_DEFINE_KERNEL_GETTER(RadixSortExclusiveSumKernel, DeviceRadixSortExclusiveSumKernel<PolicySelector, OffsetT>);
 
-  CUB_DEFINE_KERNEL_GETTER(RadixSortInitLookbackKernel, DeviceRadixSortInitLookbackKernel<PolicySelector, int>);
-
   CUB_DEFINE_KERNEL_GETTER(
     RadixSortOnesweepKernel,
     DeviceRadixSortOnesweepKernel<PolicySelector, Order, KeyT, ValueT, OffsetT, int, int, DecomposerT>);
@@ -678,18 +676,9 @@ private:
           ::cuda::std::min(num_items - portion * PORTION_SIZE, static_cast<OffsetT>(PORTION_SIZE)));
 
         PortionOffsetT num_blocks = ::cuda::ceil_div(portion_num_items, ONESWEEP_TILE_ITEMS);
-        const size_t num_lookback_items = static_cast<size_t>(num_blocks) * RADIX_DIGITS;
-        constexpr int INIT_LOOKBACK_THREADS = 256;
-        const int init_lookback_blocks      = static_cast<int>(
-          ::cuda::ceil_div(num_lookback_items, static_cast<size_t>(INIT_LOOKBACK_THREADS)));
 
-        if (const auto error = CubDebug(launcher_factory(init_lookback_blocks, INIT_LOOKBACK_THREADS, 0, stream)
-                                          .doit(kernel_source.RadixSortInitLookbackKernel(), d_lookback, num_lookback_items)))
-        {
-          return error;
-        }
-
-        if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+        if (const auto error =
+              CubDebug(cudaMemsetAsync(d_lookback, 0, num_blocks * RADIX_DIGITS * sizeof(AtomicOffsetT), stream)))
         {
           return error;
         }
@@ -711,7 +700,7 @@ private:
         auto onesweep_kernel = kernel_source.RadixSortOnesweepKernel();
 
         if (const auto error = CubDebug(
-              launcher_factory(num_blocks, ONESWEEP_BLOCK_THREADS, 0, stream, /* use_pdl */ true)
+              launcher_factory(num_blocks, ONESWEEP_BLOCK_THREADS, 0, stream)
                 .doit(
                   onesweep_kernel,
                   d_lookback,

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -80,10 +80,10 @@ struct DeviceRadixSortKernelSource
   CUB_DEFINE_KERNEL_GETTER(RadixSortExclusiveSumKernel, DeviceRadixSortExclusiveSumKernel<PolicySelector, OffsetT>);
 
   CUB_DEFINE_KERNEL_GETTER(RadixSortInitBinsAndCountersKernel,
-                           DeviceRadixSortInitKernel<PolicySelector, true, false, int, OffsetT>);
+                           DeviceRadixSortInitKernel<PolicySelector, int, OffsetT>);
 
   CUB_DEFINE_KERNEL_GETTER(RadixSortInitLookbackKernel,
-                           DeviceRadixSortInitKernel<PolicySelector, false, true, int, int>);
+                           DeviceRadixSortInitKernel<PolicySelector, int, int>);
 
   CUB_DEFINE_KERNEL_GETTER(
     RadixSortOnesweepKernel,

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -81,9 +81,10 @@ struct DeviceRadixSortKernelSource
 
   CUB_DEFINE_KERNEL_GETTER(
     RadixSortInitBinsAndCountersKernel,
-    DeviceRadixSortInitBinsAndCountersKernel<PolicySelector, OffsetT, int>);
+    DeviceRadixSortInitKernel<PolicySelector, true, false, int, OffsetT>);
 
-  CUB_DEFINE_KERNEL_GETTER(RadixSortInitLookbackKernel, DeviceRadixSortInitLookbackKernel<PolicySelector, int>);
+  CUB_DEFINE_KERNEL_GETTER(RadixSortInitLookbackKernel,
+                           DeviceRadixSortInitKernel<PolicySelector, false, true, int, int>);
 
   CUB_DEFINE_KERNEL_GETTER(
     RadixSortOnesweepKernel,
@@ -597,7 +598,8 @@ private:
     ValueT* d_values_tmp2     = (ValueT*) allocations[3];
     AtomicOffsetT* d_ctrs     = (AtomicOffsetT*) allocations[4];
 
-    const bool use_pdl = true;
+    constexpr OffsetT PDL_MAX_ITEMS = static_cast<OffsetT>(1) << 20;
+    const bool use_pdl              = num_items <= PDL_MAX_ITEMS;
 
     const size_t num_counter_items = static_cast<size_t>(num_portions) * num_passes;
     const size_t num_bin_items     = static_cast<size_t>(num_passes) * RADIX_DIGITS;
@@ -740,7 +742,12 @@ private:
 
           if (const auto error =
                 CubDebug(launcher_factory(init_lookback_blocks, INIT_LOOKBACK_THREADS, 0, stream, use_pdl)
-                           .doit(kernel_source.RadixSortInitLookbackKernel(), d_lookback, num_lookback_items)))
+                           .doit(
+                             kernel_source.RadixSortInitLookbackKernel(),
+                             d_lookback,
+                             num_lookback_items,
+                             d_lookback,
+                             size_t{0})))
           {
             return error;
           }

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -572,6 +572,8 @@ private:
       is_overwrite_okay || num_passes <= 1 ? 0 : num_items * value_size,
       // counters
       num_portions * num_passes * sizeof(AtomicOffsetT),
+      // histogram PDL completion counter
+      sizeof(int),
       // init-lookback PDL completion counters
       num_portions * num_passes * sizeof(int),
       // exclusive-sum PDL completion counter
@@ -596,12 +598,18 @@ private:
     KeyT* d_keys_tmp2         = (KeyT*) allocations[2];
     ValueT* d_values_tmp2     = (ValueT*) allocations[3];
     AtomicOffsetT* d_ctrs     = (AtomicOffsetT*) allocations[4];
-    int* d_init_lookback_ctrs = (int*) allocations[5];
-    int* d_exclusive_sum_ctr  = (int*) allocations[6];
+    int* d_histogram_ctr      = (int*) allocations[5];
+    int* d_init_lookback_ctrs = (int*) allocations[6];
+    int* d_exclusive_sum_ctr  = (int*) allocations[7];
 
     // initialization
     if (const auto error =
           CubDebug(cudaMemsetAsync(d_ctrs, 0, num_portions * num_passes * sizeof(AtomicOffsetT), stream)))
+    {
+      return error;
+    }
+
+    if (const auto error = CubDebug(cudaMemsetAsync(d_histogram_ctr, 0, sizeof(int), stream)))
     {
       return error;
     }
@@ -658,7 +666,7 @@ private:
 
     if (const auto error = CubDebug(
           launcher_factory(histo_blocks_per_sm * num_sms, HISTO_BLOCK_THREADS, 0, stream)
-            .doit(histogram_kernel, d_bins, d_keys.Current(), num_items, begin_bit, end_bit, decomposer)))
+            .doit(histogram_kernel, d_bins, d_keys.Current(), num_items, begin_bit, end_bit, d_histogram_ctr, decomposer)))
     {
       return error;
     }
@@ -680,8 +688,12 @@ private:
             policy.exclusive_sum.radix_bits);
 #endif
 
-    if (const auto error = CubDebug(launcher_factory(num_passes, SCAN_BLOCK_THREADS, 0, stream)
-                                      .doit(kernel_source.RadixSortExclusiveSumKernel(), d_bins, d_exclusive_sum_ctr)))
+    if (const auto error = CubDebug(launcher_factory(num_passes, SCAN_BLOCK_THREADS, 0, stream, /* use_pdl */ true)
+                                      .doit(
+                                        kernel_source.RadixSortExclusiveSumKernel(),
+                                        d_bins,
+                                        d_exclusive_sum_ctr,
+                                        /* wait_for_previous */ true)))
     {
       return error;
     }

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -75,9 +75,11 @@ struct DeviceRadixSortKernelSource
     DeviceRadixSortDownsweepKernel<PolicySelector, true, Order, KeyT, ValueT, OffsetT, DecomposerT>);
 
   CUB_DEFINE_KERNEL_GETTER(RadixSortHistogramKernel,
-                           DeviceRadixSortHistogramKernel<PolicySelector, Order, KeyT, OffsetT, int, DecomposerT>);
+                           DeviceRadixSortHistogramKernel<PolicySelector, Order, KeyT, OffsetT, DecomposerT>);
 
   CUB_DEFINE_KERNEL_GETTER(RadixSortExclusiveSumKernel, DeviceRadixSortExclusiveSumKernel<PolicySelector, OffsetT>);
+
+  CUB_DEFINE_KERNEL_GETTER(RadixSortInitLookbackKernel, DeviceRadixSortInitLookbackKernel<PolicySelector, int>);
 
   CUB_DEFINE_KERNEL_GETTER(
     RadixSortOnesweepKernel,
@@ -640,15 +642,30 @@ private:
 
     if (const auto error = CubDebug(
           launcher_factory(histo_blocks_per_sm * num_sms, HISTO_BLOCK_THREADS, 0, stream)
-            .doit(
-              histogram_kernel,
-              d_bins,
-              d_ctrs,
-              d_keys.Current(),
-              num_items,
-              begin_bit,
-              end_bit,
-              decomposer)))
+            .doit(histogram_kernel, d_bins, d_keys.Current(), num_items, begin_bit, end_bit, decomposer)))
+    {
+      return error;
+    }
+
+    if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+    {
+      return error;
+    }
+
+    // exclusive sums to determine starts
+    const int SCAN_BLOCK_THREADS = policy.exclusive_sum.threads_per_block;
+
+// log exclusive_sum_kernel configuration
+#ifdef CUB_DEBUG_LOG
+    _CubLog("Invoking exclusive_sum_kernel<<<%d, %d, 0, %lld>>>(), bit_grain %d\n",
+            num_passes,
+            SCAN_BLOCK_THREADS,
+            reinterpret_cast<long long>(stream),
+            policy.exclusive_sum.radix_bits);
+#endif
+
+    if (const auto error = CubDebug(launcher_factory(num_passes, SCAN_BLOCK_THREADS, 0, stream)
+                                      .doit(kernel_source.RadixSortExclusiveSumKernel(), d_bins)))
     {
       return error;
     }
@@ -676,9 +693,13 @@ private:
           ::cuda::std::min(num_items - portion * PORTION_SIZE, static_cast<OffsetT>(PORTION_SIZE)));
 
         PortionOffsetT num_blocks = ::cuda::ceil_div(portion_num_items, ONESWEEP_TILE_ITEMS);
+        const size_t num_lookback_items = static_cast<size_t>(num_blocks) * RADIX_DIGITS;
+        constexpr int INIT_LOOKBACK_THREADS = 256;
+        const int init_lookback_blocks      = static_cast<int>(
+          ::cuda::ceil_div(num_lookback_items, static_cast<size_t>(INIT_LOOKBACK_THREADS)));
 
-        if (const auto error =
-              CubDebug(cudaMemsetAsync(d_lookback, 0, num_blocks * RADIX_DIGITS * sizeof(AtomicOffsetT), stream)))
+        if (const auto error = CubDebug(launcher_factory(init_lookback_blocks, INIT_LOOKBACK_THREADS, 0, stream)
+                                          .doit(kernel_source.RadixSortInitLookbackKernel(), d_lookback, num_lookback_items)))
         {
           return error;
         }
@@ -700,7 +721,7 @@ private:
         auto onesweep_kernel = kernel_source.RadixSortOnesweepKernel();
 
         if (const auto error = CubDebug(
-              launcher_factory(num_blocks, ONESWEEP_BLOCK_THREADS, 0, stream)
+              launcher_factory(num_blocks, ONESWEEP_BLOCK_THREADS, 0, stream, /* use_pdl */ true)
                 .doit(
                   onesweep_kernel,
                   d_lookback,

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -79,9 +79,8 @@ struct DeviceRadixSortKernelSource
 
   CUB_DEFINE_KERNEL_GETTER(RadixSortExclusiveSumKernel, DeviceRadixSortExclusiveSumKernel<PolicySelector, OffsetT>);
 
-  CUB_DEFINE_KERNEL_GETTER(
-    RadixSortInitBinsAndCountersKernel,
-    DeviceRadixSortInitKernel<PolicySelector, true, false, int, OffsetT>);
+  CUB_DEFINE_KERNEL_GETTER(RadixSortInitBinsAndCountersKernel,
+                           DeviceRadixSortInitKernel<PolicySelector, true, false, int, OffsetT>);
 
   CUB_DEFINE_KERNEL_GETTER(RadixSortInitLookbackKernel,
                            DeviceRadixSortInitKernel<PolicySelector, false, true, int, int>);
@@ -603,8 +602,8 @@ private:
 
     const size_t num_counter_items = static_cast<size_t>(num_portions) * num_passes;
     const size_t num_bin_items     = static_cast<size_t>(num_passes) * RADIX_DIGITS;
-    int device  = -1;
-    int num_sms = 0;
+    int device                     = -1;
+    int num_sms                    = 0;
 
     if (const auto error = CubDebug(cudaGetDevice(&device)))
     {
@@ -731,30 +730,27 @@ private:
         PortionOffsetT portion_num_items = static_cast<PortionOffsetT>(
           ::cuda::std::min(num_items - portion * PORTION_SIZE, static_cast<OffsetT>(PORTION_SIZE)));
 
-        PortionOffsetT num_blocks = ::cuda::ceil_div(portion_num_items, ONESWEEP_TILE_ITEMS);
+        PortionOffsetT num_blocks       = ::cuda::ceil_div(portion_num_items, ONESWEEP_TILE_ITEMS);
         const size_t num_lookback_items = static_cast<size_t>(num_blocks) * RADIX_DIGITS;
 
         if (use_pdl)
         {
           constexpr int INIT_LOOKBACK_THREADS = 256;
-          const int init_lookback_blocks      = static_cast<int>(
-            ::cuda::ceil_div(num_lookback_items, static_cast<size_t>(INIT_LOOKBACK_THREADS)));
+          const int init_lookback_blocks =
+            static_cast<int>(::cuda::ceil_div(num_lookback_items, static_cast<size_t>(INIT_LOOKBACK_THREADS)));
 
-          if (const auto error =
-                CubDebug(launcher_factory(init_lookback_blocks, INIT_LOOKBACK_THREADS, 0, stream, use_pdl)
-                           .doit(
-                             kernel_source.RadixSortInitLookbackKernel(),
-                             d_lookback,
-                             num_lookback_items,
-                             d_lookback,
-                             size_t{0})))
+          if (const auto error = CubDebug(
+                launcher_factory(init_lookback_blocks, INIT_LOOKBACK_THREADS, 0, stream, use_pdl)
+                  .doit(
+                    kernel_source.RadixSortInitLookbackKernel(), d_lookback, num_lookback_items, d_lookback, size_t{0})))
           {
             return error;
           }
         }
         else
         {
-          if (const auto error = CubDebug(cudaMemsetAsync(d_lookback, 0, num_lookback_items * sizeof(AtomicOffsetT), stream)))
+          if (const auto error =
+                CubDebug(cudaMemsetAsync(d_lookback, 0, num_lookback_items * sizeof(AtomicOffsetT), stream)))
           {
             return error;
           }

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -79,9 +79,9 @@ struct DeviceRadixSortKernelSource
 
   CUB_DEFINE_KERNEL_GETTER(RadixSortExclusiveSumKernel, DeviceRadixSortExclusiveSumKernel<PolicySelector, OffsetT>);
 
-  CUB_DEFINE_KERNEL_GETTER(RadixSortInitBinsAndCountersKernel, DeviceRadixSortInitKernel<int, OffsetT>);
+  CUB_DEFINE_KERNEL_GETTER(RadixSortInitBinsAndCountersKernel, DeviceRadixSortInitKernel<PolicySelector, int, OffsetT>);
 
-  CUB_DEFINE_KERNEL_GETTER(RadixSortInitLookbackKernel, DeviceRadixSortInitKernel<int, int>);
+  CUB_DEFINE_KERNEL_GETTER(RadixSortInitLookbackKernel, DeviceRadixSortInitKernel<PolicySelector, int, int>);
 
   CUB_DEFINE_KERNEL_GETTER(
     RadixSortOnesweepKernel,

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -600,8 +600,7 @@ private:
     {
       return error;
     }
-    constexpr OffsetT pdl_max_items = static_cast<OffsetT>(1) << 20;
-    const bool use_pdl              = num_items <= pdl_max_items && cc >= ::cuda::compute_capability{9, 0};
+    const bool use_pdl = cc >= ::cuda::compute_capability{9, 0};
 
     const size_t num_counter_items = static_cast<size_t>(num_portions) * num_passes;
     const size_t num_bin_items     = static_cast<size_t>(num_passes) * RADIX_DIGITS;
@@ -654,7 +653,6 @@ private:
 
     // Initialization is intentionally adjacent to the histogram launch. For the PDL path, this avoids consuming the
     // short init kernel's runtime in host-side launch setup work before the dependent histogram is submitted.
-    if (use_pdl)
     {
       constexpr int init_startup_threads = 256;
       const size_t num_init_items        = ::cuda::std::max(num_counter_items, num_bin_items);
@@ -676,33 +674,12 @@ private:
         return error;
       }
     }
-    else
-    {
-      if (const auto error = CubDebug(cudaMemsetAsync(d_ctrs, 0, num_counter_items * sizeof(AtomicOffsetT), stream)))
-      {
-        return error;
-      }
-
-      // compute num_passes histograms with RADIX_DIGITS bins each
-      if (const auto error = CubDebug(cudaMemsetAsync(d_bins, 0, num_bin_items * sizeof(OffsetT), stream)))
-      {
-        return error;
-      }
-    }
 
     if (const auto error = CubDebug(
           launcher_factory(histo_blocks_per_sm * num_sms, HISTO_BLOCK_THREADS, 0, stream, use_pdl)
             .doit(histogram_kernel, d_bins, d_keys.Current(), num_items, begin_bit, end_bit, decomposer)))
     {
       return error;
-    }
-
-    if (!use_pdl)
-    {
-      if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
-      {
-        return error;
-      }
     }
 
     if (const auto error = CubDebug(launcher_factory(num_passes, SCAN_BLOCK_THREADS, 0, stream, use_pdl)

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -684,6 +684,8 @@ private:
       d_values.d_buffers[1] = d_values_tmp2;
     }
 
+    const bool use_pdl = num_items <= static_cast<OffsetT>(1 << 20);
+
     for (int current_bit = begin_bit, pass = 0; current_bit < end_bit; current_bit += RADIX_BITS, ++pass)
     {
       int num_bits = ::cuda::std::min(end_bit - current_bit, RADIX_BITS);
@@ -694,14 +696,26 @@ private:
 
         PortionOffsetT num_blocks = ::cuda::ceil_div(portion_num_items, ONESWEEP_TILE_ITEMS);
         const size_t num_lookback_items = static_cast<size_t>(num_blocks) * RADIX_DIGITS;
-        constexpr int INIT_LOOKBACK_THREADS = 256;
-        const int init_lookback_blocks      = static_cast<int>(
-          ::cuda::ceil_div(num_lookback_items, static_cast<size_t>(INIT_LOOKBACK_THREADS)));
 
-        if (const auto error = CubDebug(launcher_factory(init_lookback_blocks, INIT_LOOKBACK_THREADS, 0, stream)
-                                          .doit(kernel_source.RadixSortInitLookbackKernel(), d_lookback, num_lookback_items)))
+        if (use_pdl)
         {
-          return error;
+          constexpr int INIT_LOOKBACK_THREADS = 256;
+          const int init_lookback_blocks      = static_cast<int>(
+            ::cuda::ceil_div(num_lookback_items, static_cast<size_t>(INIT_LOOKBACK_THREADS)));
+
+          if (const auto error =
+                CubDebug(launcher_factory(init_lookback_blocks, INIT_LOOKBACK_THREADS, 0, stream, use_pdl)
+                           .doit(kernel_source.RadixSortInitLookbackKernel(), d_lookback, num_lookback_items)))
+          {
+            return error;
+          }
+        }
+        else
+        {
+          if (const auto error = CubDebug(cudaMemsetAsync(d_lookback, 0, num_lookback_items * sizeof(AtomicOffsetT), stream)))
+          {
+            return error;
+          }
         }
 
 // log onesweep_kernel configuration
@@ -721,7 +735,7 @@ private:
         auto onesweep_kernel = kernel_source.RadixSortOnesweepKernel();
 
         if (const auto error = CubDebug(
-              launcher_factory(num_blocks, ONESWEEP_BLOCK_THREADS, 0, stream, /* use_pdl */ true)
+              launcher_factory(num_blocks, ONESWEEP_BLOCK_THREADS, 0, stream, use_pdl)
                 .doit(
                   onesweep_kernel,
                   d_lookback,
@@ -735,6 +749,7 @@ private:
                   portion_num_items,
                   current_bit,
                   num_bits,
+                  use_pdl,
                   decomposer)))
         {
           return error;

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -636,6 +636,18 @@ private:
             policy.histogram.radix_bits);
 #endif
 
+    // exclusive sums to determine starts
+    const int SCAN_BLOCK_THREADS = policy.exclusive_sum.threads_per_block;
+
+// log exclusive_sum_kernel configuration
+#ifdef CUB_DEBUG_LOG
+    _CubLog("Invoking exclusive_sum_kernel<<<%d, %d, 0, %lld>>>(), bit_grain %d\n",
+            num_passes,
+            SCAN_BLOCK_THREADS,
+            reinterpret_cast<long long>(stream),
+            policy.exclusive_sum.radix_bits);
+#endif
+
     // Initialization is intentionally adjacent to the histogram launch. For the PDL path, this avoids consuming the
     // short init kernel's runtime in host-side launch setup work before the dependent histogram is submitted.
     if (use_pdl)
@@ -681,24 +693,15 @@ private:
       return error;
     }
 
-    if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+    if (!use_pdl)
     {
-      return error;
+      if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+      {
+        return error;
+      }
     }
 
-    // exclusive sums to determine starts
-    const int SCAN_BLOCK_THREADS = policy.exclusive_sum.threads_per_block;
-
-// log exclusive_sum_kernel configuration
-#ifdef CUB_DEBUG_LOG
-    _CubLog("Invoking exclusive_sum_kernel<<<%d, %d, 0, %lld>>>(), bit_grain %d\n",
-            num_passes,
-            SCAN_BLOCK_THREADS,
-            reinterpret_cast<long long>(stream),
-            policy.exclusive_sum.radix_bits);
-#endif
-
-    if (const auto error = CubDebug(launcher_factory(num_passes, SCAN_BLOCK_THREADS, 0, stream)
+    if (const auto error = CubDebug(launcher_factory(num_passes, SCAN_BLOCK_THREADS, 0, stream, use_pdl)
                                       .doit(kernel_source.RadixSortExclusiveSumKernel(), d_bins)))
     {
       return error;

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -572,12 +572,6 @@ private:
       is_overwrite_okay || num_passes <= 1 ? 0 : num_items * value_size,
       // counters
       num_portions * num_passes * sizeof(AtomicOffsetT),
-      // histogram PDL completion counter
-      sizeof(int),
-      // init-lookback PDL completion counters
-      num_portions * num_passes * sizeof(int),
-      // exclusive-sum PDL completion counter
-      sizeof(int),
     };
     constexpr int NUM_ALLOCATIONS      = sizeof(allocation_sizes) / sizeof(allocation_sizes[0]);
     void* allocations[NUM_ALLOCATIONS] = {};
@@ -598,28 +592,10 @@ private:
     KeyT* d_keys_tmp2         = (KeyT*) allocations[2];
     ValueT* d_values_tmp2     = (ValueT*) allocations[3];
     AtomicOffsetT* d_ctrs     = (AtomicOffsetT*) allocations[4];
-    int* d_histogram_ctr      = (int*) allocations[5];
-    int* d_init_lookback_ctrs = (int*) allocations[6];
-    int* d_exclusive_sum_ctr  = (int*) allocations[7];
 
     // initialization
     if (const auto error =
           CubDebug(cudaMemsetAsync(d_ctrs, 0, num_portions * num_passes * sizeof(AtomicOffsetT), stream)))
-    {
-      return error;
-    }
-
-    if (const auto error = CubDebug(cudaMemsetAsync(d_histogram_ctr, 0, sizeof(int), stream)))
-    {
-      return error;
-    }
-
-    if (const auto error = CubDebug(cudaMemsetAsync(d_init_lookback_ctrs, 0, num_portions * num_passes * sizeof(int), stream)))
-    {
-      return error;
-    }
-
-    if (const auto error = CubDebug(cudaMemsetAsync(d_exclusive_sum_ctr, 0, sizeof(int), stream)))
     {
       return error;
     }
@@ -666,7 +642,7 @@ private:
 
     if (const auto error = CubDebug(
           launcher_factory(histo_blocks_per_sm * num_sms, HISTO_BLOCK_THREADS, 0, stream)
-            .doit(histogram_kernel, d_bins, d_keys.Current(), num_items, begin_bit, end_bit, d_histogram_ctr, decomposer)))
+            .doit(histogram_kernel, d_bins, d_keys.Current(), num_items, begin_bit, end_bit, decomposer)))
     {
       return error;
     }
@@ -688,12 +664,8 @@ private:
             policy.exclusive_sum.radix_bits);
 #endif
 
-    if (const auto error = CubDebug(launcher_factory(num_passes, SCAN_BLOCK_THREADS, 0, stream, /* use_pdl */ true)
-                                      .doit(
-                                        kernel_source.RadixSortExclusiveSumKernel(),
-                                        d_bins,
-                                        d_exclusive_sum_ctr,
-                                        /* wait_for_previous */ true)))
+    if (const auto error = CubDebug(launcher_factory(num_passes, SCAN_BLOCK_THREADS, 0, stream)
+                                      .doit(kernel_source.RadixSortExclusiveSumKernel(), d_bins)))
     {
       return error;
     }
@@ -725,16 +697,9 @@ private:
         constexpr int INIT_LOOKBACK_THREADS = 256;
         const int init_lookback_blocks      = static_cast<int>(
           ::cuda::ceil_div(num_lookback_items, static_cast<size_t>(INIT_LOOKBACK_THREADS)));
-        const bool wait_for_exclusive_sum = pass == 0 && portion == 0;
 
-        if (const auto error = CubDebug(
-              launcher_factory(init_lookback_blocks, INIT_LOOKBACK_THREADS, 0, stream, wait_for_exclusive_sum)
-                .doit(
-                  kernel_source.RadixSortInitLookbackKernel(),
-                  d_lookback,
-                  num_lookback_items,
-                  d_init_lookback_ctrs + portion * num_passes + pass,
-                  wait_for_exclusive_sum)))
+        if (const auto error = CubDebug(launcher_factory(init_lookback_blocks, INIT_LOOKBACK_THREADS, 0, stream)
+                                          .doit(kernel_source.RadixSortInitLookbackKernel(), d_lookback, num_lookback_items)))
         {
           return error;
         }

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -79,11 +79,9 @@ struct DeviceRadixSortKernelSource
 
   CUB_DEFINE_KERNEL_GETTER(RadixSortExclusiveSumKernel, DeviceRadixSortExclusiveSumKernel<PolicySelector, OffsetT>);
 
-  CUB_DEFINE_KERNEL_GETTER(RadixSortInitBinsAndCountersKernel,
-                           DeviceRadixSortInitKernel<PolicySelector, int, OffsetT>);
+  CUB_DEFINE_KERNEL_GETTER(RadixSortInitBinsAndCountersKernel, DeviceRadixSortInitKernel<PolicySelector, int, OffsetT>);
 
-  CUB_DEFINE_KERNEL_GETTER(RadixSortInitLookbackKernel,
-                           DeviceRadixSortInitKernel<PolicySelector, int, int>);
+  CUB_DEFINE_KERNEL_GETTER(RadixSortInitLookbackKernel, DeviceRadixSortInitKernel<PolicySelector, int, int>);
 
   CUB_DEFINE_KERNEL_GETTER(
     RadixSortOnesweepKernel,

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -597,7 +597,7 @@ private:
     ValueT* d_values_tmp2     = (ValueT*) allocations[3];
     AtomicOffsetT* d_ctrs     = (AtomicOffsetT*) allocations[4];
 
-    const bool use_pdl = num_items <= static_cast<OffsetT>(1 << 20);
+    const bool use_pdl = true;
 
     const size_t num_counter_items = static_cast<size_t>(num_portions) * num_passes;
     const size_t num_bin_items     = static_cast<size_t>(num_passes) * RADIX_DIGITS;

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -79,9 +79,9 @@ struct DeviceRadixSortKernelSource
 
   CUB_DEFINE_KERNEL_GETTER(RadixSortExclusiveSumKernel, DeviceRadixSortExclusiveSumKernel<PolicySelector, OffsetT>);
 
-  CUB_DEFINE_KERNEL_GETTER(RadixSortInitBinsAndCountersKernel, DeviceRadixSortInitKernel<PolicySelector, int, OffsetT>);
+  CUB_DEFINE_KERNEL_GETTER(RadixSortInitBinsAndCountersKernel, DeviceRadixSortInitKernel<int, OffsetT>);
 
-  CUB_DEFINE_KERNEL_GETTER(RadixSortInitLookbackKernel, DeviceRadixSortInitKernel<PolicySelector, int, int>);
+  CUB_DEFINE_KERNEL_GETTER(RadixSortInitLookbackKernel, DeviceRadixSortInitKernel<int, int>);
 
   CUB_DEFINE_KERNEL_GETTER(
     RadixSortOnesweepKernel,
@@ -651,20 +651,20 @@ private:
     // short init kernel's runtime in host-side launch setup work before the dependent histogram is submitted.
     if (use_pdl)
     {
-      constexpr int INIT_STARTUP_THREADS = 256;
+      constexpr int init_startup_threads = 256;
       const size_t num_init_items        = ::cuda::std::max(num_counter_items, num_bin_items);
       const int init_startup_blocks =
-        static_cast<int>(::cuda::ceil_div(num_init_items, static_cast<size_t>(INIT_STARTUP_THREADS)));
+        static_cast<int>(::cuda::ceil_div(num_init_items, static_cast<size_t>(init_startup_threads)));
 
 #ifdef CUB_DEBUG_LOG
       _CubLog("Invoking init_bins_and_counters_kernel<<<%d, %d, 0, %lld>>>()\n",
               init_startup_blocks,
-              INIT_STARTUP_THREADS,
+              init_startup_threads,
               reinterpret_cast<long long>(stream));
 #endif
 
       if (const auto error = CubDebug(
-            launcher_factory(init_startup_blocks, INIT_STARTUP_THREADS, 0, stream, use_pdl)
+            launcher_factory(init_startup_blocks, init_startup_threads, 0, stream, use_pdl)
               .doit(
                 kernel_source.RadixSortInitBinsAndCountersKernel(), d_ctrs, num_counter_items, d_bins, num_bin_items)))
       {
@@ -733,12 +733,12 @@ private:
 
         if (use_pdl)
         {
-          constexpr int INIT_LOOKBACK_THREADS = 256;
+          constexpr int init_lookback_threads = 256;
           const int init_lookback_blocks =
-            static_cast<int>(::cuda::ceil_div(num_lookback_items, static_cast<size_t>(INIT_LOOKBACK_THREADS)));
+            static_cast<int>(::cuda::ceil_div(num_lookback_items, static_cast<size_t>(init_lookback_threads)));
 
           if (const auto error = CubDebug(
-                launcher_factory(init_lookback_blocks, INIT_LOOKBACK_THREADS, 0, stream, use_pdl)
+                launcher_factory(init_lookback_blocks, init_lookback_threads, 0, stream, use_pdl)
                   .doit(
                     kernel_source.RadixSortInitLookbackKernel(), d_lookback, num_lookback_items, d_lookback, size_t{0})))
           {

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -595,8 +595,13 @@ private:
     ValueT* d_values_tmp2     = (ValueT*) allocations[3];
     AtomicOffsetT* d_ctrs     = (AtomicOffsetT*) allocations[4];
 
-    constexpr OffsetT PDL_MAX_ITEMS = static_cast<OffsetT>(1) << 20;
-    const bool use_pdl              = num_items <= PDL_MAX_ITEMS;
+    ::cuda::compute_capability cc{};
+    if (const auto error = CubDebug(launcher_factory.PtxComputeCap(cc)))
+    {
+      return error;
+    }
+    constexpr OffsetT pdl_max_items = static_cast<OffsetT>(1) << 20;
+    const bool use_pdl              = num_items <= pdl_max_items && cc >= ::cuda::compute_capability{9, 0};
 
     const size_t num_counter_items = static_cast<size_t>(num_portions) * num_passes;
     const size_t num_bin_items     = static_cast<size_t>(num_passes) * RADIX_DIGITS;

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -572,6 +572,10 @@ private:
       is_overwrite_okay || num_passes <= 1 ? 0 : num_items * value_size,
       // counters
       num_portions * num_passes * sizeof(AtomicOffsetT),
+      // init-lookback PDL completion counters
+      num_portions * num_passes * sizeof(int),
+      // exclusive-sum PDL completion counter
+      sizeof(int),
     };
     constexpr int NUM_ALLOCATIONS      = sizeof(allocation_sizes) / sizeof(allocation_sizes[0]);
     void* allocations[NUM_ALLOCATIONS] = {};
@@ -592,10 +596,22 @@ private:
     KeyT* d_keys_tmp2         = (KeyT*) allocations[2];
     ValueT* d_values_tmp2     = (ValueT*) allocations[3];
     AtomicOffsetT* d_ctrs     = (AtomicOffsetT*) allocations[4];
+    int* d_init_lookback_ctrs = (int*) allocations[5];
+    int* d_exclusive_sum_ctr  = (int*) allocations[6];
 
     // initialization
     if (const auto error =
           CubDebug(cudaMemsetAsync(d_ctrs, 0, num_portions * num_passes * sizeof(AtomicOffsetT), stream)))
+    {
+      return error;
+    }
+
+    if (const auto error = CubDebug(cudaMemsetAsync(d_init_lookback_ctrs, 0, num_portions * num_passes * sizeof(int), stream)))
+    {
+      return error;
+    }
+
+    if (const auto error = CubDebug(cudaMemsetAsync(d_exclusive_sum_ctr, 0, sizeof(int), stream)))
     {
       return error;
     }
@@ -665,7 +681,7 @@ private:
 #endif
 
     if (const auto error = CubDebug(launcher_factory(num_passes, SCAN_BLOCK_THREADS, 0, stream)
-                                      .doit(kernel_source.RadixSortExclusiveSumKernel(), d_bins)))
+                                      .doit(kernel_source.RadixSortExclusiveSumKernel(), d_bins, d_exclusive_sum_ctr)))
     {
       return error;
     }
@@ -697,9 +713,16 @@ private:
         constexpr int INIT_LOOKBACK_THREADS = 256;
         const int init_lookback_blocks      = static_cast<int>(
           ::cuda::ceil_div(num_lookback_items, static_cast<size_t>(INIT_LOOKBACK_THREADS)));
+        const bool wait_for_exclusive_sum = pass == 0 && portion == 0;
 
-        if (const auto error = CubDebug(launcher_factory(init_lookback_blocks, INIT_LOOKBACK_THREADS, 0, stream)
-                                          .doit(kernel_source.RadixSortInitLookbackKernel(), d_lookback, num_lookback_items)))
+        if (const auto error = CubDebug(
+              launcher_factory(init_lookback_blocks, INIT_LOOKBACK_THREADS, 0, stream, wait_for_exclusive_sum)
+                .doit(
+                  kernel_source.RadixSortInitLookbackKernel(),
+                  d_lookback,
+                  num_lookback_items,
+                  d_init_lookback_ctrs + portion * num_passes + pass,
+                  wait_for_exclusive_sum)))
         {
           return error;
         }

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -711,7 +711,7 @@ private:
         auto onesweep_kernel = kernel_source.RadixSortOnesweepKernel();
 
         if (const auto error = CubDebug(
-              launcher_factory(num_blocks, ONESWEEP_BLOCK_THREADS, 0, stream)
+              launcher_factory(num_blocks, ONESWEEP_BLOCK_THREADS, 0, stream, /* use_pdl */ true)
                 .doit(
                   onesweep_kernel,
                   d_lookback,

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -79,6 +79,10 @@ struct DeviceRadixSortKernelSource
 
   CUB_DEFINE_KERNEL_GETTER(RadixSortExclusiveSumKernel, DeviceRadixSortExclusiveSumKernel<PolicySelector, OffsetT>);
 
+  CUB_DEFINE_KERNEL_GETTER(
+    RadixSortInitBinsAndCountersKernel,
+    DeviceRadixSortInitBinsAndCountersKernel<PolicySelector, OffsetT, int>);
+
   CUB_DEFINE_KERNEL_GETTER(RadixSortInitLookbackKernel, DeviceRadixSortInitLookbackKernel<PolicySelector, int>);
 
   CUB_DEFINE_KERNEL_GETTER(
@@ -593,18 +597,10 @@ private:
     ValueT* d_values_tmp2     = (ValueT*) allocations[3];
     AtomicOffsetT* d_ctrs     = (AtomicOffsetT*) allocations[4];
 
-    // initialization
-    if (const auto error =
-          CubDebug(cudaMemsetAsync(d_ctrs, 0, num_portions * num_passes * sizeof(AtomicOffsetT), stream)))
-    {
-      return error;
-    }
+    const bool use_pdl = num_items <= static_cast<OffsetT>(1 << 20);
 
-    // compute num_passes histograms with RADIX_DIGITS bins each
-    if (const auto error = CubDebug(cudaMemsetAsync(d_bins, 0, num_passes * RADIX_DIGITS * sizeof(OffsetT), stream)))
-    {
-      return error;
-    }
+    const size_t num_counter_items = static_cast<size_t>(num_portions) * num_passes;
+    const size_t num_bin_items     = static_cast<size_t>(num_passes) * RADIX_DIGITS;
     int device  = -1;
     int num_sms = 0;
 
@@ -640,8 +636,46 @@ private:
             policy.histogram.radix_bits);
 #endif
 
+    // Initialization is intentionally adjacent to the histogram launch. For the PDL path, this avoids consuming the
+    // short init kernel's runtime in host-side launch setup work before the dependent histogram is submitted.
+    if (use_pdl)
+    {
+      constexpr int INIT_STARTUP_THREADS = 256;
+      const size_t num_init_items        = ::cuda::std::max(num_counter_items, num_bin_items);
+      const int init_startup_blocks =
+        static_cast<int>(::cuda::ceil_div(num_init_items, static_cast<size_t>(INIT_STARTUP_THREADS)));
+
+#ifdef CUB_DEBUG_LOG
+      _CubLog("Invoking init_bins_and_counters_kernel<<<%d, %d, 0, %lld>>>()\n",
+              init_startup_blocks,
+              INIT_STARTUP_THREADS,
+              reinterpret_cast<long long>(stream));
+#endif
+
+      if (const auto error = CubDebug(
+            launcher_factory(init_startup_blocks, INIT_STARTUP_THREADS, 0, stream, use_pdl)
+              .doit(
+                kernel_source.RadixSortInitBinsAndCountersKernel(), d_ctrs, num_counter_items, d_bins, num_bin_items)))
+      {
+        return error;
+      }
+    }
+    else
+    {
+      if (const auto error = CubDebug(cudaMemsetAsync(d_ctrs, 0, num_counter_items * sizeof(AtomicOffsetT), stream)))
+      {
+        return error;
+      }
+
+      // compute num_passes histograms with RADIX_DIGITS bins each
+      if (const auto error = CubDebug(cudaMemsetAsync(d_bins, 0, num_bin_items * sizeof(OffsetT), stream)))
+      {
+        return error;
+      }
+    }
+
     if (const auto error = CubDebug(
-          launcher_factory(histo_blocks_per_sm * num_sms, HISTO_BLOCK_THREADS, 0, stream)
+          launcher_factory(histo_blocks_per_sm * num_sms, HISTO_BLOCK_THREADS, 0, stream, use_pdl)
             .doit(histogram_kernel, d_bins, d_keys.Current(), num_items, begin_bit, end_bit, decomposer)))
     {
       return error;
@@ -683,8 +717,6 @@ private:
       d_keys.d_buffers[1]   = d_keys_tmp2;
       d_values.d_buffers[1] = d_values_tmp2;
     }
-
-    const bool use_pdl = num_items <= static_cast<OffsetT>(1 << 20);
 
     for (int current_bit = begin_bit, pass = 0; current_bit < end_bit; current_bit += RADIX_BITS, ++pass)
     {
@@ -749,7 +781,6 @@ private:
                   portion_num_items,
                   current_bit,
                   num_bits,
-                  use_pdl,
                   decomposer)))
         {
           return error;

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -475,18 +475,15 @@ __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) 
   agent.Process();
 }
 
-template <typename PolicySelector, bool TRIGGER_AT_START, bool FENCE_BEFORE_END_TRIGGER, typename InitT0, typename InitT1>
+template <typename PolicySelector, typename InitT0, typename InitT1>
 _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortInitKernel(
   _CCCL_GRID_CONSTANT InitT0* const d_items0,
   _CCCL_GRID_CONSTANT const size_t num_items0,
   _CCCL_GRID_CONSTANT InitT1* const d_items1,
   _CCCL_GRID_CONSTANT const size_t num_items1)
 {
-  if constexpr (TRIGGER_AT_START)
-  {
-    _CCCL_PDL_GRID_DEPENDENCY_SYNC();
-    _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
-  }
+  _CCCL_PDL_GRID_DEPENDENCY_SYNC();
+  _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
 
   const size_t stride = static_cast<size_t>(blockDim.x) * gridDim.x;
   for (size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
@@ -501,17 +498,6 @@ _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortInitKernel(
     {
       d_items1[idx] = 0;
     }
-  }
-
-  if constexpr (FENCE_BEFORE_END_TRIGGER)
-  {
-    __threadfence();
-  }
-
-  if constexpr (!TRIGGER_AT_START)
-  {
-    _CCCL_PDL_GRID_DEPENDENCY_SYNC();
-    _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
   }
 }
 

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -544,6 +544,8 @@ _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortInitLookbackKernel(
   {
     d_lookback[idx] = 0;
   }
+  __threadfence();
+  _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
 }
 
 template <typename PolicySelector,

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -589,6 +589,8 @@ _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortExclusiveSumKernel(_CCCL_GRID_CONSTA
   using BlockScan                                         = cub::BlockScan<OffsetT, BLOCK_THREADS>;
   __shared__ typename BlockScan::TempStorage temp_storage;
 
+  _CCCL_PDL_GRID_DEPENDENCY_SYNC();
+
   // load the bins
   OffsetT bins[BINS_PER_THREAD];
   int bin_start = blockIdx.x * RADIX_DIGITS;

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -451,10 +451,12 @@ template <typename PolicySelector,
           SortOrder Order,
           typename KeyT,
           typename OffsetT,
+          typename AtomicOffsetT = int,
           typename DecomposerT = identity_decomposer_t>
 _CCCL_KERNEL_ATTRIBUTES
 __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) void DeviceRadixSortHistogramKernel(
   _CCCL_GRID_CONSTANT OffsetT* const d_bins_out,
+  _CCCL_GRID_CONSTANT AtomicOffsetT* const d_ctrs,
   _CCCL_GRID_CONSTANT const KeyT* const d_keys_in,
   _CCCL_GRID_CONSTANT const OffsetT num_items,
   _CCCL_GRID_CONSTANT const int start_bit,
@@ -462,6 +464,10 @@ __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) 
   _CCCL_GRID_CONSTANT const DecomposerT decomposer = {})
 {
   static constexpr radix_sort_histogram_policy policy = current_policy<PolicySelector>().histogram;
+  constexpr int RADIX_BITS                            = policy.radix_bits;
+  constexpr int RADIX_DIGITS                          = 1 << RADIX_BITS;
+  constexpr int BLOCK_THREADS                         = policy.threads_per_block;
+  constexpr int BINS_PER_THREAD                       = (RADIX_DIGITS + BLOCK_THREADS - 1) / BLOCK_THREADS;
 
   using HistogramPolicyT =
     AgentRadixSortHistogramPolicy<policy.threads_per_block,
@@ -470,9 +476,74 @@ __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) 
                                   void,
                                   policy.radix_bits>;
   using AgentT = AgentRadixSortHistogram<HistogramPolicyT, Order == SortOrder::Descending, KeyT, OffsetT, DecomposerT>;
+  using BlockScan = cub::BlockScan<OffsetT, BLOCK_THREADS>;
   __shared__ typename AgentT::TempStorage temp_storage;
+  __shared__ typename BlockScan::TempStorage scan_temp_storage;
+  __shared__ bool is_last_block;
   AgentT agent(temp_storage, d_bins_out, d_keys_in, num_items, start_bit, end_bit, decomposer);
   agent.Process();
+
+  __threadfence();
+  __syncthreads();
+  if (threadIdx.x == 0)
+  {
+    is_last_block = atomicAdd(d_ctrs, 1) == static_cast<AtomicOffsetT>(gridDim.x - 1);
+  }
+  __syncthreads();
+
+  if (is_last_block)
+  {
+    const int num_passes = ::cuda::ceil_div(end_bit - start_bit, RADIX_BITS);
+    for (int pass = 0; pass < num_passes; ++pass)
+    {
+      OffsetT bins[BINS_PER_THREAD];
+      const int bin_start = pass * RADIX_DIGITS;
+
+      _CCCL_PRAGMA_UNROLL_FULL()
+      for (int u = 0; u < BINS_PER_THREAD; ++u)
+      {
+        const int bin = threadIdx.x * BINS_PER_THREAD + u;
+        if (bin >= RADIX_DIGITS)
+        {
+          break;
+        }
+        bins[u] = d_bins_out[bin_start + bin];
+      }
+
+      BlockScan(scan_temp_storage).ExclusiveSum(bins, bins);
+
+      _CCCL_PRAGMA_UNROLL_FULL()
+      for (int u = 0; u < BINS_PER_THREAD; ++u)
+      {
+        const int bin = threadIdx.x * BINS_PER_THREAD + u;
+        if (bin >= RADIX_DIGITS)
+        {
+          break;
+        }
+        d_bins_out[bin_start + bin] = bins[u];
+      }
+      __syncthreads();
+    }
+
+    __threadfence();
+    __syncthreads();
+    if (threadIdx.x == 0)
+    {
+      d_ctrs[0] = 0;
+    }
+  }
+}
+
+template <typename PolicySelector, typename AtomicOffsetT>
+_CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortInitLookbackKernel(
+  _CCCL_GRID_CONSTANT AtomicOffsetT* const d_lookback,
+  _CCCL_GRID_CONSTANT const size_t num_lookback_items)
+{
+  const size_t stride = static_cast<size_t>(blockDim.x) * gridDim.x;
+  for (size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x; idx < num_lookback_items; idx += stride)
+  {
+    d_lookback[idx] = 0;
+  }
 }
 
 template <typename PolicySelector,

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -510,6 +510,7 @@ _CCCL_KERNEL_ATTRIBUTES void __launch_bounds__(current_policy<PolicySelector>().
     _CCCL_GRID_CONSTANT const PortionOffsetT num_items,
     _CCCL_GRID_CONSTANT const int current_bit,
     _CCCL_GRID_CONSTANT const int num_bits,
+    _CCCL_GRID_CONSTANT const bool use_pdl,
     _CCCL_GRID_CONSTANT const DecomposerT decomposer = {})
 {
   static constexpr radix_sort_onesweep_policy policy = current_policy<PolicySelector>().onesweep;
@@ -547,6 +548,7 @@ _CCCL_KERNEL_ATTRIBUTES void __launch_bounds__(current_policy<PolicySelector>().
     num_items,
     current_bit,
     num_bits,
+    use_pdl,
     decomposer);
   agent.Process();
 }

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -459,7 +459,6 @@ __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) 
   _CCCL_GRID_CONSTANT const OffsetT num_items,
   _CCCL_GRID_CONSTANT const int start_bit,
   _CCCL_GRID_CONSTANT const int end_bit,
-  _CCCL_GRID_CONSTANT int* const d_completion_counter,
   _CCCL_GRID_CONSTANT const DecomposerT decomposer = {})
 {
   static constexpr radix_sort_histogram_policy policy = current_policy<PolicySelector>().histogram;
@@ -474,47 +473,20 @@ __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) 
   __shared__ typename AgentT::TempStorage temp_storage;
   AgentT agent(temp_storage, d_bins_out, d_keys_in, num_items, start_bit, end_bit, decomposer);
   agent.Process();
-
-  __syncthreads();
-
-  if (threadIdx.x == 0)
-  {
-    const int finished = atomicAdd(d_completion_counter, 1);
-    if (finished == static_cast<int>(gridDim.x) - 1)
-    {
-      _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
-    }
-  }
 }
 
 template <typename PolicySelector, typename AtomicOffsetT>
 _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortInitLookbackKernel(
   _CCCL_GRID_CONSTANT AtomicOffsetT* const d_lookback,
-  _CCCL_GRID_CONSTANT const size_t num_lookback_items,
-  _CCCL_GRID_CONSTANT int* const d_completion_counter,
-  _CCCL_GRID_CONSTANT const bool wait_for_previous)
+  _CCCL_GRID_CONSTANT const size_t num_lookback_items)
 {
-  if (wait_for_previous)
-  {
-    _CCCL_PDL_GRID_DEPENDENCY_SYNC();
-  }
-
   const size_t stride = static_cast<size_t>(blockDim.x) * gridDim.x;
   for (size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x; idx < num_lookback_items; idx += stride)
   {
     d_lookback[idx] = 0;
   }
-
-  __syncthreads();
-
-  if (threadIdx.x == 0)
-  {
-    const int finished = atomicAdd(d_completion_counter, 1);
-    if (finished == static_cast<int>(gridDim.x) - 1)
-    {
-      _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
-    }
-  }
+  __threadfence();
+  _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
 }
 
 template <typename PolicySelector,
@@ -583,16 +555,8 @@ _CCCL_KERNEL_ATTRIBUTES void __launch_bounds__(current_policy<PolicySelector>().
  * Exclusive sum kernel
  */
 template <typename PolicySelector, typename OffsetT>
-_CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortExclusiveSumKernel(
-  _CCCL_GRID_CONSTANT OffsetT* const d_bins,
-  _CCCL_GRID_CONSTANT int* const d_completion_counter,
-  _CCCL_GRID_CONSTANT const bool wait_for_previous)
+_CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortExclusiveSumKernel(_CCCL_GRID_CONSTANT OffsetT* const d_bins)
 {
-  if (wait_for_previous)
-  {
-    _CCCL_PDL_GRID_DEPENDENCY_SYNC();
-  }
-
   static constexpr radix_sort_exclusive_sum_policy policy = current_policy<PolicySelector>().exclusive_sum;
   constexpr int RADIX_BITS                                = policy.radix_bits;
   constexpr int RADIX_DIGITS                              = 1 << RADIX_BITS;
@@ -629,17 +593,6 @@ _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortExclusiveSumKernel(
       break;
     }
     d_bins[bin_start + bin] = bins[u];
-  }
-
-  __syncthreads();
-
-  if (threadIdx.x == 0)
-  {
-    const int finished = atomicAdd(d_completion_counter, 1);
-    if (finished == static_cast<int>(gridDim.x) - 1)
-    {
-      _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
-    }
   }
 }
 } // namespace detail::radix_sort

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -475,7 +475,7 @@ __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) 
   agent.Process();
 }
 
-template <typename PolicySelector, typename InitT0, typename InitT1>
+template <typename InitT0, typename InitT1>
 _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortInitKernel(
   _CCCL_GRID_CONSTANT InitT0* const d_items0,
   _CCCL_GRID_CONSTANT const size_t num_items0,
@@ -577,6 +577,7 @@ _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortExclusiveSumKernel(_CCCL_GRID_CONSTA
   using BlockScan                                         = cub::BlockScan<OffsetT, BLOCK_THREADS>;
   __shared__ typename BlockScan::TempStorage temp_storage;
 
+  // Make sure the histograms are done
   _CCCL_PDL_GRID_DEPENDENCY_SYNC();
 
   // load the bins

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -459,6 +459,7 @@ __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) 
   _CCCL_GRID_CONSTANT const OffsetT num_items,
   _CCCL_GRID_CONSTANT const int start_bit,
   _CCCL_GRID_CONSTANT const int end_bit,
+  _CCCL_GRID_CONSTANT int* const d_completion_counter,
   _CCCL_GRID_CONSTANT const DecomposerT decomposer = {})
 {
   static constexpr radix_sort_histogram_policy policy = current_policy<PolicySelector>().histogram;
@@ -473,6 +474,17 @@ __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) 
   __shared__ typename AgentT::TempStorage temp_storage;
   AgentT agent(temp_storage, d_bins_out, d_keys_in, num_items, start_bit, end_bit, decomposer);
   agent.Process();
+
+  __syncthreads();
+
+  if (threadIdx.x == 0)
+  {
+    const int finished = atomicAdd(d_completion_counter, 1);
+    if (finished == static_cast<int>(gridDim.x) - 1)
+    {
+      _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
+    }
+  }
 }
 
 template <typename PolicySelector, typename AtomicOffsetT>
@@ -573,8 +585,14 @@ _CCCL_KERNEL_ATTRIBUTES void __launch_bounds__(current_policy<PolicySelector>().
 template <typename PolicySelector, typename OffsetT>
 _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortExclusiveSumKernel(
   _CCCL_GRID_CONSTANT OffsetT* const d_bins,
-  _CCCL_GRID_CONSTANT int* const d_completion_counter)
+  _CCCL_GRID_CONSTANT int* const d_completion_counter,
+  _CCCL_GRID_CONSTANT const bool wait_for_previous)
 {
+  if (wait_for_previous)
+  {
+    _CCCL_PDL_GRID_DEPENDENCY_SYNC();
+  }
+
   static constexpr radix_sort_exclusive_sum_policy policy = current_policy<PolicySelector>().exclusive_sum;
   constexpr int RADIX_BITS                                = policy.radix_bits;
   constexpr int RADIX_DIGITS                              = 1 << RADIX_BITS;

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -475,11 +475,7 @@ __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) 
   agent.Process();
 }
 
-template <typename PolicySelector,
-          bool TRIGGER_AT_START,
-          bool FENCE_BEFORE_END_TRIGGER,
-          typename InitT0,
-          typename InitT1>
+template <typename PolicySelector, bool TRIGGER_AT_START, bool FENCE_BEFORE_END_TRIGGER, typename InitT0, typename InitT1>
 _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortInitKernel(
   _CCCL_GRID_CONSTANT InitT0* const d_items0,
   _CCCL_GRID_CONSTANT const size_t num_items0,

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -416,7 +416,7 @@ __launch_bounds__(current_policy<PolicySelector>().single_tile.threads_per_block
       values,
       current_bit,
       end_bit,
-      bool_constant_v<Order == SortOrder::Descending>,
+      bool_constant_v < Order == SortOrder::Descending >,
       bool_constant_v<KEYS_ONLY>,
       decomposer);
 
@@ -488,6 +488,7 @@ _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortInitKernel(
 {
   if constexpr (TRIGGER_AT_START)
   {
+    _CCCL_PDL_GRID_DEPENDENCY_SYNC();
     _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
   }
 
@@ -513,6 +514,7 @@ _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortInitKernel(
 
   if constexpr (!TRIGGER_AT_START)
   {
+    _CCCL_PDL_GRID_DEPENDENCY_SYNC();
     _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
   }
 }

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -478,15 +478,31 @@ __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) 
 template <typename PolicySelector, typename AtomicOffsetT>
 _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortInitLookbackKernel(
   _CCCL_GRID_CONSTANT AtomicOffsetT* const d_lookback,
-  _CCCL_GRID_CONSTANT const size_t num_lookback_items)
+  _CCCL_GRID_CONSTANT const size_t num_lookback_items,
+  _CCCL_GRID_CONSTANT int* const d_completion_counter,
+  _CCCL_GRID_CONSTANT const bool wait_for_previous)
 {
+  if (wait_for_previous)
+  {
+    _CCCL_PDL_GRID_DEPENDENCY_SYNC();
+  }
+
   const size_t stride = static_cast<size_t>(blockDim.x) * gridDim.x;
   for (size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x; idx < num_lookback_items; idx += stride)
   {
     d_lookback[idx] = 0;
   }
-  __threadfence();
-  _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
+
+  __syncthreads();
+
+  if (threadIdx.x == 0)
+  {
+    const int finished = atomicAdd(d_completion_counter, 1);
+    if (finished == static_cast<int>(gridDim.x) - 1)
+    {
+      _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
+    }
+  }
 }
 
 template <typename PolicySelector,
@@ -555,7 +571,9 @@ _CCCL_KERNEL_ATTRIBUTES void __launch_bounds__(current_policy<PolicySelector>().
  * Exclusive sum kernel
  */
 template <typename PolicySelector, typename OffsetT>
-_CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortExclusiveSumKernel(_CCCL_GRID_CONSTANT OffsetT* const d_bins)
+_CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortExclusiveSumKernel(
+  _CCCL_GRID_CONSTANT OffsetT* const d_bins,
+  _CCCL_GRID_CONSTANT int* const d_completion_counter)
 {
   static constexpr radix_sort_exclusive_sum_policy policy = current_policy<PolicySelector>().exclusive_sum;
   constexpr int RADIX_BITS                                = policy.radix_bits;
@@ -593,6 +611,17 @@ _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortExclusiveSumKernel(_CCCL_GRID_CONSTA
       break;
     }
     d_bins[bin_start + bin] = bins[u];
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x == 0)
+  {
+    const int finished = atomicAdd(d_completion_counter, 1);
+    if (finished == static_cast<int>(gridDim.x) - 1)
+    {
+      _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
+    }
   }
 }
 } // namespace detail::radix_sort

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -475,7 +475,7 @@ __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) 
   agent.Process();
 }
 
-template <typename InitT0, typename InitT1>
+template <typename PolicySelector, typename InitT0, typename InitT1>
 _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortInitKernel(
   _CCCL_GRID_CONSTANT InitT0* const d_items0,
   _CCCL_GRID_CONSTANT const size_t num_items0,

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -475,42 +475,46 @@ __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) 
   agent.Process();
 }
 
-template <typename PolicySelector, typename OffsetT, typename AtomicOffsetT>
-_CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortInitBinsAndCountersKernel(
-  _CCCL_GRID_CONSTANT AtomicOffsetT* const d_ctrs,
-  _CCCL_GRID_CONSTANT const size_t num_counter_items,
-  _CCCL_GRID_CONSTANT OffsetT* const d_bins,
-  _CCCL_GRID_CONSTANT const size_t num_bin_items)
+template <typename PolicySelector,
+          bool TRIGGER_AT_START,
+          bool FENCE_BEFORE_END_TRIGGER,
+          typename InitT0,
+          typename InitT1>
+_CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortInitKernel(
+  _CCCL_GRID_CONSTANT InitT0* const d_items0,
+  _CCCL_GRID_CONSTANT const size_t num_items0,
+  _CCCL_GRID_CONSTANT InitT1* const d_items1,
+  _CCCL_GRID_CONSTANT const size_t num_items1)
 {
-  _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
+  if constexpr (TRIGGER_AT_START)
+  {
+    _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
+  }
 
   const size_t stride = static_cast<size_t>(blockDim.x) * gridDim.x;
   for (size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-       idx < ::cuda::std::max(num_counter_items, num_bin_items);
+       idx < ::cuda::std::max(num_items0, num_items1);
        idx += stride)
   {
-    if (idx < num_counter_items)
+    if (idx < num_items0)
     {
-      d_ctrs[idx] = 0;
+      d_items0[idx] = 0;
     }
-    if (idx < num_bin_items)
+    if (idx < num_items1)
     {
-      d_bins[idx] = 0;
+      d_items1[idx] = 0;
     }
   }
-}
 
-template <typename PolicySelector, typename AtomicOffsetT>
-_CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortInitLookbackKernel(
-  _CCCL_GRID_CONSTANT AtomicOffsetT* const d_lookback, _CCCL_GRID_CONSTANT const size_t num_lookback_items)
-{
-  const size_t stride = static_cast<size_t>(blockDim.x) * gridDim.x;
-  for (size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x; idx < num_lookback_items; idx += stride)
+  if constexpr (FENCE_BEFORE_END_TRIGGER)
   {
-    d_lookback[idx] = 0;
+    __threadfence();
   }
-  __threadfence();
-  _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
+
+  if constexpr (!TRIGGER_AT_START)
+  {
+    _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
+  }
 }
 
 template <typename PolicySelector,

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -534,20 +534,6 @@ __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) 
   }
 }
 
-template <typename PolicySelector, typename AtomicOffsetT>
-_CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortInitLookbackKernel(
-  _CCCL_GRID_CONSTANT AtomicOffsetT* const d_lookback,
-  _CCCL_GRID_CONSTANT const size_t num_lookback_items)
-{
-  const size_t stride = static_cast<size_t>(blockDim.x) * gridDim.x;
-  for (size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x; idx < num_lookback_items; idx += stride)
-  {
-    d_lookback[idx] = 0;
-  }
-  __threadfence();
-  _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
-}
-
 template <typename PolicySelector,
           SortOrder Order,
           typename KeyT,

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -416,7 +416,7 @@ __launch_bounds__(current_policy<PolicySelector>().single_tile.threads_per_block
       values,
       current_bit,
       end_bit,
-      bool_constant_v < Order == SortOrder::Descending >,
+      bool_constant_v<Order == SortOrder::Descending>,
       bool_constant_v<KEYS_ONLY>,
       decomposer);
 
@@ -475,10 +475,34 @@ __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) 
   agent.Process();
 }
 
+template <typename PolicySelector, typename OffsetT, typename AtomicOffsetT>
+_CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortInitBinsAndCountersKernel(
+  _CCCL_GRID_CONSTANT AtomicOffsetT* const d_ctrs,
+  _CCCL_GRID_CONSTANT const size_t num_counter_items,
+  _CCCL_GRID_CONSTANT OffsetT* const d_bins,
+  _CCCL_GRID_CONSTANT const size_t num_bin_items)
+{
+  _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
+
+  const size_t stride = static_cast<size_t>(blockDim.x) * gridDim.x;
+  for (size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       idx < ::cuda::std::max(num_counter_items, num_bin_items);
+       idx += stride)
+  {
+    if (idx < num_counter_items)
+    {
+      d_ctrs[idx] = 0;
+    }
+    if (idx < num_bin_items)
+    {
+      d_bins[idx] = 0;
+    }
+  }
+}
+
 template <typename PolicySelector, typename AtomicOffsetT>
 _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortInitLookbackKernel(
-  _CCCL_GRID_CONSTANT AtomicOffsetT* const d_lookback,
-  _CCCL_GRID_CONSTANT const size_t num_lookback_items)
+  _CCCL_GRID_CONSTANT AtomicOffsetT* const d_lookback, _CCCL_GRID_CONSTANT const size_t num_lookback_items)
 {
   const size_t stride = static_cast<size_t>(blockDim.x) * gridDim.x;
   for (size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x; idx < num_lookback_items; idx += stride)
@@ -510,7 +534,6 @@ _CCCL_KERNEL_ATTRIBUTES void __launch_bounds__(current_policy<PolicySelector>().
     _CCCL_GRID_CONSTANT const PortionOffsetT num_items,
     _CCCL_GRID_CONSTANT const int current_bit,
     _CCCL_GRID_CONSTANT const int num_bits,
-    _CCCL_GRID_CONSTANT const bool use_pdl,
     _CCCL_GRID_CONSTANT const DecomposerT decomposer = {})
 {
   static constexpr radix_sort_onesweep_policy policy = current_policy<PolicySelector>().onesweep;
@@ -548,7 +571,6 @@ _CCCL_KERNEL_ATTRIBUTES void __launch_bounds__(current_policy<PolicySelector>().
     num_items,
     current_bit,
     num_bits,
-    use_pdl,
     decomposer);
   agent.Process();
 }

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -451,12 +451,10 @@ template <typename PolicySelector,
           SortOrder Order,
           typename KeyT,
           typename OffsetT,
-          typename AtomicOffsetT = int,
           typename DecomposerT = identity_decomposer_t>
 _CCCL_KERNEL_ATTRIBUTES
 __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) void DeviceRadixSortHistogramKernel(
   _CCCL_GRID_CONSTANT OffsetT* const d_bins_out,
-  _CCCL_GRID_CONSTANT AtomicOffsetT* const d_ctrs,
   _CCCL_GRID_CONSTANT const KeyT* const d_keys_in,
   _CCCL_GRID_CONSTANT const OffsetT num_items,
   _CCCL_GRID_CONSTANT const int start_bit,
@@ -464,10 +462,6 @@ __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) 
   _CCCL_GRID_CONSTANT const DecomposerT decomposer = {})
 {
   static constexpr radix_sort_histogram_policy policy = current_policy<PolicySelector>().histogram;
-  constexpr int RADIX_BITS                            = policy.radix_bits;
-  constexpr int RADIX_DIGITS                          = 1 << RADIX_BITS;
-  constexpr int BLOCK_THREADS                         = policy.threads_per_block;
-  constexpr int BINS_PER_THREAD                       = (RADIX_DIGITS + BLOCK_THREADS - 1) / BLOCK_THREADS;
 
   using HistogramPolicyT =
     AgentRadixSortHistogramPolicy<policy.threads_per_block,
@@ -476,62 +470,23 @@ __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) 
                                   void,
                                   policy.radix_bits>;
   using AgentT = AgentRadixSortHistogram<HistogramPolicyT, Order == SortOrder::Descending, KeyT, OffsetT, DecomposerT>;
-  using BlockScan = cub::BlockScan<OffsetT, BLOCK_THREADS>;
   __shared__ typename AgentT::TempStorage temp_storage;
-  __shared__ typename BlockScan::TempStorage scan_temp_storage;
-  __shared__ bool is_last_block;
   AgentT agent(temp_storage, d_bins_out, d_keys_in, num_items, start_bit, end_bit, decomposer);
   agent.Process();
+}
 
+template <typename PolicySelector, typename AtomicOffsetT>
+_CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortInitLookbackKernel(
+  _CCCL_GRID_CONSTANT AtomicOffsetT* const d_lookback,
+  _CCCL_GRID_CONSTANT const size_t num_lookback_items)
+{
+  const size_t stride = static_cast<size_t>(blockDim.x) * gridDim.x;
+  for (size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x; idx < num_lookback_items; idx += stride)
+  {
+    d_lookback[idx] = 0;
+  }
   __threadfence();
-  __syncthreads();
-  if (threadIdx.x == 0)
-  {
-    is_last_block = atomicAdd(d_ctrs, 1) == static_cast<AtomicOffsetT>(gridDim.x - 1);
-  }
-  __syncthreads();
-
-  if (is_last_block)
-  {
-    const int num_passes = ::cuda::ceil_div(end_bit - start_bit, RADIX_BITS);
-    for (int pass = 0; pass < num_passes; ++pass)
-    {
-      OffsetT bins[BINS_PER_THREAD];
-      const int bin_start = pass * RADIX_DIGITS;
-
-      _CCCL_PRAGMA_UNROLL_FULL()
-      for (int u = 0; u < BINS_PER_THREAD; ++u)
-      {
-        const int bin = threadIdx.x * BINS_PER_THREAD + u;
-        if (bin >= RADIX_DIGITS)
-        {
-          break;
-        }
-        bins[u] = d_bins_out[bin_start + bin];
-      }
-
-      BlockScan(scan_temp_storage).ExclusiveSum(bins, bins);
-
-      _CCCL_PRAGMA_UNROLL_FULL()
-      for (int u = 0; u < BINS_PER_THREAD; ++u)
-      {
-        const int bin = threadIdx.x * BINS_PER_THREAD + u;
-        if (bin >= RADIX_DIGITS)
-        {
-          break;
-        }
-        d_bins_out[bin_start + bin] = bins[u];
-      }
-      __syncthreads();
-    }
-
-    __threadfence();
-    __syncthreads();
-    if (threadIdx.x == 0)
-    {
-      d_ctrs[0] = 0;
-    }
-  }
+  _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
 }
 
 template <typename PolicySelector,


### PR DESCRIPTION
fixes #8765 

**BEFORE**

<img width="1462" height="581" alt="image" src="https://github.com/user-attachments/assets/c8095d7d-f4a4-40f2-8428-942556a8ff2f" />

**AFTER**

<img width="1307" height="554" alt="image" src="https://github.com/user-attachments/assets/6ba1054d-4d84-4241-bb0f-f69b3d814032" />

zoomed in:

<img width="1414" height="675" alt="image" src="https://github.com/user-attachments/assets/268a1130-28c0-4286-a293-d82b2f00bd4e" />
