### PR TITLE
[libcu++] Fix issues with new tuple constructors

### DIFF
--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -211,6 +211,7 @@ public:
 
   template <class... _UTypes,
             enable_if_t<(sizeof...(_UTypes) < sizeof...(_Tp)), int> = 0,
+            enable_if_t<(sizeof...(_UTypes) != 0), int>             = 0,
             __select_constructor _Trait                             = _VariadicConstraintsLessRank<_UTypes...>::value,
             enable_if_t<__select_explicit<_Trait>, int>             = 0>
   _CCCL_API constexpr explicit tuple(_UTypes&&... __u)

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -275,6 +275,10 @@ __tuple_select_variadic_constructible_less_rank(__tuple_types<_Types...>, __tupl
   {
     return __select_constructor::__none;
   }
+  else if constexpr (sizeof...(_UTypes) == 0)
+  {
+    return __select_constructor::__none;
+  }
   else
   {
     using __arg_list       = __make_tuple_types_t<__tuple_types<_Types...>, sizeof...(_UTypes)>;

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -396,12 +396,31 @@ inline constexpr __select_constructor __tuple_select_tuple_like_constructible_v 
   ::cuda::std::__tuple_select_tuple_like_constructible<_UTuple>(_TupleTypes{}, _TupleIndices{});
 
 _CCCL_EXEC_CHECK_DISABLE
-template <class _UTuple, class... _Types, size_t... _Indices>
+template <class _UTuple, class _Type, class... _Types, size_t _Index, size_t... _Indices>
 [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL bool
-__tuple_nothrow_tuple_like_constructible(__tuple_types<_Types...>, __tuple_indices<_Indices...>) noexcept
+__tuple_nothrow_tuple_like_constructible(__tuple_types<_Type, _Types...>, __tuple_indices<_Index, _Indices...>) noexcept
 {
   using ::cuda::std::get;
-  return (is_nothrow_constructible_v<_Types, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...);
+  if constexpr (!is_nothrow_constructible_v<_Type, decltype(get<_Index>(::cuda::std::declval<_UTuple>()))>)
+  {
+    return false;
+  }
+  else if constexpr (sizeof...(_Types) != 0)
+  {
+    return ::cuda::std::__tuple_nothrow_tuple_like_constructible<_UTuple>(
+      __tuple_types<_Types...>{}, __tuple_indices<_Indices...>{});
+  }
+  else
+  {
+    return true;
+  }
+}
+
+template <class _UTuple>
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL bool
+__tuple_nothrow_tuple_like_constructible(__tuple_types<>, __tuple_indices<>) noexcept
+{
+  return true;
 }
 
 template <class _UTuple, class _TupleTypes, class _TupleIndices>

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -324,22 +324,6 @@ __tuple_select_tuple_like_constructible(__tuple_types<_Types...>, __tuple_indice
     // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
     return __select_constructor::__none;
   }
-  else if constexpr ((sizeof...(_Types) == 1) && __is_cuda_std_tuple<remove_cvref_t<_UTuple>>
-                     && (is_same_v<_Types, tuple_element_t<_Indices, remove_cvref_t<_UTuple>>> && ...))
-  { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1
-    // [tuple#cnstr]-21.3: is_same_v<T, U> is false
-    return __select_constructor::__none;
-  }
-  else if constexpr ((sizeof...(_Types) == 1) && (is_constructible_v<_Types, _UTuple> && ...))
-  { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1, or is_constructible_v<T, _UTuple> are false
-    // [tuple#cnstr]-29.5: either sizeof...(Types) is not 1, or is_constructible_v<T, _UTuple> are false
-    return __select_constructor::__none;
-  }
-  else if constexpr ((sizeof...(_Types) == 1) && (is_convertible_v<_UTuple, _Types> && ...))
-  { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1, or is_convertible_v<_UTuple, T> are false
-    // [tuple#cnstr]-29.5: either sizeof...(Types) is not 1, or is_convertible_v<_UTuple, T> are false
-    return __select_constructor::__none;
-  }
   else if constexpr (!(is_constructible_v<_Types, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...))
   { // [tuple.cnstr]-21.2: is_constructible<Types, decltype(get<I>(std​::​forward<UTuple>(u)))>... is true
     // [tuple.cnstr]-25.2: is_constructible<Types, decltype(get<I>(std​::​forward<UTuple>(u)))>... is true
@@ -351,6 +335,57 @@ __tuple_select_tuple_like_constructible(__tuple_types<_Types...>, __tuple_indice
     // [tuple.cnstr]-23: The expression inside explicit is equivalent to:
     // !(is_convertible_v<decltype(get<I>(FWD(u))), Types> && ...)
     return (is_convertible_v<decltype(get<_Indices>(::cuda::std::declval<_UTuple>())), _Types> && ...)
+           ? __select_constructor::__implicit
+           : __select_constructor::__explicit;
+  }
+}
+
+_CCCL_EXEC_CHECK_DISABLE
+template <class _UTuple, class _Type, size_t _Index>
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
+__tuple_select_tuple_like_constructible(__tuple_types<_Type>, __tuple_indices<_Index>) noexcept
+{
+  using ::cuda::std::get;
+  if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UTuple>>)
+  { // [tuple#cnstr]-29.2: remove_cvref_t<UTuple> is not a specialization of ranges​::​subrange,
+    return __select_constructor::__none;
+  }
+  else if constexpr (is_same_v<_UTuple, const tuple<_Type>&> || is_same_v<_UTuple, tuple<_Type>&&>)
+  { // Prefers the copy/move constructor
+    return __select_constructor::__none;
+  }
+  else if constexpr (!__tuple_like_with_size<_UTuple, 1>)
+  { // [tuple#cnstr]-21.1: sizeof...(Types) equals sizeof...(UTypes), and
+    // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
+    return __select_constructor::__none;
+  }
+  else if constexpr (__is_cuda_std_tuple<remove_cvref_t<_UTuple>>
+                     && is_same_v<_Type, tuple_element_t<_Index, remove_cvref_t<_UTuple>>>)
+  { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1
+    // [tuple#cnstr]-21.3: is_same_v<T, U> is false
+    return __select_constructor::__none;
+  }
+  else if constexpr (is_constructible_v<_Type, _UTuple>)
+  { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1, or is_constructible_v<T, _UTuple> are false
+    // [tuple#cnstr]-29.5: either sizeof...(Types) is not 1, or is_constructible_v<T, _UTuple> are false
+    return __select_constructor::__none;
+  }
+  else if constexpr (is_convertible_v<_UTuple, _Type>)
+  { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1, or is_convertible_v<_UTuple, T> are false
+    // [tuple#cnstr]-29.5: either sizeof...(Types) is not 1, or is_convertible_v<_UTuple, T> are false
+    return __select_constructor::__none;
+  }
+  else if constexpr (!is_constructible_v<_Type, decltype(get<_Index>(::cuda::std::declval<_UTuple>()))>)
+  { // [tuple.cnstr]-21.2: is_constructible<Types, decltype(get<I>(std​::​forward<UTuple>(u)))>... is true
+    // [tuple.cnstr]-25.2: is_constructible<Types, decltype(get<I>(std​::​forward<UTuple>(u)))>... is true
+    // [tuple.cnstr]-29.4: is_constructible<Types, decltype(get<I>(std​::​forward<UTuple>(u)))>... is true
+    return __select_constructor::__none;
+  }
+  else
+  { // [tuple.cnstr]-15: The expression inside explicit is equivalent to:
+    // [tuple.cnstr]-23: The expression inside explicit is equivalent to:
+    // !(is_convertible_v<decltype(get<I>(FWD(u))), Types> && ...)
+    return is_convertible_v<decltype(get<_Index>(::cuda::std::declval<_UTuple>())), _Type>
            ? __select_constructor::__implicit
            : __select_constructor::__explicit;
   }

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp
@@ -174,32 +174,29 @@ TEST_FUNC void test_empty_specialization()
   const auto AT = cuda::std::allocator_arg;
   unused(AT);
   { // Testing (1)
-    cuda::std::tuple t1{};
+    [[maybe_unused]] cuda::std::tuple t1{};
     static_assert(cuda::std::is_same_v<decltype(t1), cuda::std::tuple<>>);
-    unused(t1);
   }
   { // Testing (2)
-    cuda::std::tuple t1{AT, A};
+    [[maybe_unused]] cuda::std::tuple t1{AT, A};
     static_assert(cuda::std::is_same_v<decltype(t1), cuda::std::tuple<>>);
   }
   { // Testing (3)
     const cuda::std::tuple<> t{};
-    cuda::std::tuple t1(t);
+    [[maybe_unused]] cuda::std::tuple t1(t);
     static_assert(cuda::std::is_same_v<decltype(t1), cuda::std::tuple<>>);
-    unused(t1);
   }
   { // Testing (4)
-    cuda::std::tuple t1(cuda::std::tuple<>{});
+    [[maybe_unused]] cuda::std::tuple t1(cuda::std::tuple<>{});
     static_assert(cuda::std::is_same_v<decltype(t1), cuda::std::tuple<>>);
-    unused(t1);
   }
   { // Testing (5)
     const cuda::std::tuple<> t{};
-    cuda::std::tuple t1(AT, A, t);
+    [[maybe_unused]] cuda::std::tuple t1(AT, A, t);
     static_assert(cuda::std::is_same_v<decltype(t1), cuda::std::tuple<>>);
   }
   { // Testing (6)
-    cuda::std::tuple t1(AT, A, cuda::std::tuple<>{});
+    [[maybe_unused]] cuda::std::tuple t1(AT, A, cuda::std::tuple<>{});
     static_assert(cuda::std::is_same_v<decltype(t1), cuda::std::tuple<>>);
   }
 }

--- a/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
+++ b/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
@@ -18,6 +18,7 @@
 
 #include <cuda/std/__tuple_dir/tuple_element.h>
 #include <cuda/std/__tuple_dir/tuple_size.h>
+#include <cuda/std/__type_traits/common_reference.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__utility/move.h>
 #include <cuda/std/__utility/pair.h>
@@ -210,6 +211,30 @@ template <size_t Id, class... Ts>
 struct tuple_element<Id, THRUST_NS_QUALIFIER::detail::tuple_of_iterator_references<Ts...>>
     : tuple_element<Id, tuple<Ts...>>
 {};
+
+template <class... _TTypes, class... _UTypes, template <class> class _TQual, template <class> class _UQual>
+struct basic_common_reference<
+  THRUST_NS_QUALIFIER::detail::tuple_of_iterator_references<_TTypes...>,
+  tuple<_UTypes...>,
+  _TQual,
+  _UQual,
+  enable_if_t<
+    THRUST_NS_QUALIFIER::detail::is_compatible_tuple_v<::cuda::std::tuple<_TTypes...>, ::cuda::std::tuple<_UTypes...>>>>
+{
+  using type _CCCL_NODEBUG_ALIAS = tuple<_UTypes...>;
+};
+
+template <class... _TTypes, class... _UTypes, template <class> class _TQual, template <class> class _UQual>
+struct basic_common_reference<
+  tuple<_TTypes...>,
+  THRUST_NS_QUALIFIER::detail::tuple_of_iterator_references<_UTypes...>,
+  _TQual,
+  _UQual,
+  enable_if_t<
+    THRUST_NS_QUALIFIER::detail::is_compatible_tuple_v<::cuda::std::tuple<_TTypes...>, ::cuda::std::tuple<_UTypes...>>>>
+{
+  using type _CCCL_NODEBUG_ALIAS = tuple<_TTypes...>;
+};
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
+++ b/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
@@ -221,7 +221,7 @@ struct basic_common_reference<
   enable_if_t<
     THRUST_NS_QUALIFIER::detail::is_compatible_tuple_v<::cuda::std::tuple<_TTypes...>, ::cuda::std::tuple<_UTypes...>>>>
 {
-  using type _CCCL_NODEBUG_ALIAS = tuple<_UTypes...>;
+  using type _CCCL_NODEBUG_ALIAS = tuple<_UQual<_UTypes>...>;
 };
 
 template <class... _TTypes, class... _UTypes, template <class> class _TQual, template <class> class _UQual>
@@ -233,7 +233,7 @@ struct basic_common_reference<
   enable_if_t<
     THRUST_NS_QUALIFIER::detail::is_compatible_tuple_v<::cuda::std::tuple<_TTypes...>, ::cuda::std::tuple<_UTypes...>>>>
 {
-  using type _CCCL_NODEBUG_ALIAS = tuple<_TTypes...>;
+  using type _CCCL_NODEBUG_ALIAS = tuple<_TQual<_TTypes>...>;
 };
 
 _CCCL_END_NAMESPACE_CUDA_STD


### PR DESCRIPTION
This fixes corner cases that were identified by old or broken compilers

1. We need to disable the variadic constructor for less elements if the number of elements is zero 0

2. We need to ensure that we do not check the additional size-1 constraints for the tuple-like constructor if the size is not one

3. Probably unrelated GCC had issues with determining is_nothrow_constructible

4. tuple_of_iterator_references had issues, due to the new tuple like constructors. Needed to add a common_reference specialization for that