### PR TITLE
[cub] Add WarpBitonicTopK

### DIFF
--- a/cub/benchmarks/bench/bitonic_sort/bitonic_common.cuh
+++ b/cub/benchmarks/bench/bitonic_sort/bitonic_common.cuh
@@ -7,6 +7,7 @@
 
 #include <cuda/std/limits>
 
+#include <cstddef>
 #include <string>
 
 #include <device_side_benchmark.cuh>
@@ -45,33 +46,74 @@ NVBENCH_DECLARE_ENUM_TYPE_STRINGS(
     return std::string{};
   })
 
-template <typename ActionT, Mode mode, typename KeyT, typename ValueT, int Len>
+struct RunParams
+{
+  int block_dim;
+  int grid_dim;
+  int num_iterations;
+};
+
+template <Mode BenchMode>
+[[nodiscard]] constexpr RunParams get_run_params()
+{
+  if constexpr (BenchMode == Mode::Latency)
+  {
+    return {warp_threads, 1, num_iterations_for_latency_mode};
+  }
+  else
+  {
+    return {block_dim_for_throughput_mode,
+            grid_threads_for_throughput_mode / block_dim_for_throughput_mode,
+            num_iterations_for_throughput_mode};
+  }
+}
+
+[[nodiscard]] constexpr std::size_t count_items(const RunParams& run_params, int items_per_warp)
+{
+  return static_cast<std::size_t>(run_params.grid_dim) * (run_params.block_dim / warp_threads) * items_per_warp
+       * run_params.num_iterations;
+}
+
+template <typename ActionT, Mode BenchMode, typename KeyT, typename ValueT, int Len>
 void run_bench(nvbench::state& state)
 {
   constexpr int items_per_thread = Len / warp_threads;
   const auto kernel              = benchmark_kernel<items_per_thread, KeyT, ValueT, ActionT, int>;
+  constexpr RunParams run_params = get_run_params<BenchMode>();
 
-  int block_dim;
-  int grid_dim;
-  int num_iterations;
-  if (mode == Mode::Latency)
+  state.add_element_count(count_items(run_params, Len));
+
+  state.exec([kernel, &run_params](nvbench::launch& launch) {
+    kernel<<<run_params.grid_dim, run_params.block_dim, 0, launch.get_stream()>>>(
+      run_params.num_iterations, ActionT{}, Len);
+  });
+}
+
+template <typename ActionT, Mode BenchMode, typename KeyT, typename ValueT, int Len, int MaxK>
+void run_topk(nvbench::state& state)
+{
+  static_assert(MaxK >= 1);
+  if constexpr (MaxK > Len)
   {
-    block_dim      = warp_threads;
-    grid_dim       = 1;
-    num_iterations = num_iterations_for_latency_mode;
+    state.skip("Skipping workload where max_k > len.");
   }
   else
   {
-    block_dim      = block_dim_for_throughput_mode;
-    grid_dim       = grid_threads_for_throughput_mode / block_dim;
-    num_iterations = num_iterations_for_throughput_mode;
+    constexpr int items_per_thread = Len / warp_threads;
+    const auto kernel              = benchmark_kernel<items_per_thread, KeyT, ValueT, ActionT>;
+    RunParams run_params           = get_run_params<BenchMode>();
+    if (BenchMode == Mode::Throughput)
+    {
+      // scale grid_dim because throughout mode is slow
+      run_params.grid_dim /= Len / warp_threads;
+    }
+
+    state.add_element_count(count_items(run_params, Len));
+
+    state.exec([=](nvbench::launch& launch) {
+      kernel<<<run_params.grid_dim, run_params.block_dim, 0, launch.get_stream()>>>(run_params.num_iterations, ActionT{});
+    });
   }
-
-  state.add_element_count(static_cast<size_t>(grid_dim) * (block_dim / warp_threads) * Len * num_iterations);
-
-  state.exec([grid_dim, block_dim, kernel, num_iterations](nvbench::launch& launch) {
-    kernel<<<grid_dim, block_dim, 0, launch.get_stream()>>>(num_iterations, ActionT{}, Len);
-  });
 }
 
 struct CustomLess

--- a/cub/benchmarks/bench/bitonic_sort/warp_topk_pairs.cu
+++ b/cub/benchmarks/bench/bitonic_sort/warp_topk_pairs.cu
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/warp/warp_bitonic_topk.cuh>
+
+#include <thrust/device_vector.h>
+
+#include <cuda/std/limits>
+
+#include <vector>
+
+#include <device_side_benchmark.cuh>
+#include <nvbench_helper.cuh>
+
+using key_types    = fundamental_types;
+using value_types  = offset_types;
+using len_values   = nvbench::enum_type_list<32, 64, 96, 128, 160, 192>;
+using max_k_values = nvbench::enum_type_list<32, 64, 96>;
+// the perf is mostly determined by max_k values, so just use k=1
+const std::vector<nvbench::int64_t> k_values{1};
+
+constexpr int WARP_THREADS                  = 32;
+constexpr int NUM_ITERATIONS                = 100;
+constexpr int BLOCK_DIM_FOR_THROUGHPUT_MODE = 128;
+
+enum class Mode
+{
+  // launch single warp
+  Latency,
+  // launch one full wave of thread blocks. Measure Elem/s.
+  Throughput
+};
+using modes = nvbench::enum_type_list<Mode::Latency, Mode::Throughput>;
+
+NVBENCH_DECLARE_ENUM_TYPE_STRINGS(
+  Mode,
+  // Callable to generate input strings:
+  [](Mode value) {
+    switch (value)
+    {
+      case Mode::Latency:
+        return "latency";
+      case Mode::Throughput:
+        return "throughput";
+      default:
+        return "Unknown";
+    }
+  },
+  // Callable to generate descriptions:
+  [](auto) {
+    return std::string{};
+  })
+
+struct CustomLess
+{
+  template <typename T>
+  __device__ bool operator()(const T& lhs, const T& rhs) const
+  {
+    return lhs < rhs;
+  }
+
+  template <typename T>
+  static constexpr T oob = cuda::std::numeric_limits<T>::max();
+};
+
+template <Mode mode>
+constexpr int calc_block_dim()
+{
+  if constexpr (mode == Mode::Latency)
+  {
+    return WARP_THREADS;
+  }
+  else
+  {
+    return BLOCK_DIM_FOR_THROUGHPUT_MODE;
+  }
+}
+
+template <Mode mode, typename Kernel>
+int calc_grid_dim(int num_SMs, int block_dim, Kernel kernel)
+{
+  if constexpr (mode == Mode::Latency)
+  {
+    return 1;
+  }
+  else
+  {
+    int max_blocks_per_SM = 0;
+    NVBENCH_CUDA_CALL_NOEXCEPT(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_blocks_per_SM, kernel, block_dim, 0));
+    return max_blocks_per_SM * num_SMs;
+  }
+}
+
+template <typename ActionT, Mode mode, typename KeyT, typename ValueT, int LEN, int MAX_K>
+void run_topk(nvbench::state& state, int num_items)
+{
+  if constexpr (MAX_K > LEN)
+  {
+    state.skip("Skipping workload where max_k > len.");
+  }
+  else
+  {
+    const int k = static_cast<int>(state.get_int64("k"));
+    if (k > MAX_K || k > num_items)
+    {
+      state.skip("Skipping workload where k > max_k or k > num_items.");
+      return;
+    }
+
+    constexpr int items_per_thread = LEN / WARP_THREADS;
+    const auto kernel              = benchmark_kernel<items_per_thread, KeyT, ValueT, ActionT, int, int>;
+
+    const int num_SMs       = state.get_device().value().get_number_of_sms();
+    constexpr int block_dim = calc_block_dim<mode>();
+    const int grid_dim      = calc_grid_dim<mode>(num_SMs, block_dim, kernel);
+    state.add_element_count(grid_dim * (block_dim / WARP_THREADS) * num_items * NUM_ITERATIONS);
+
+    state.exec([grid_dim, block_dim, kernel, k, num_items](nvbench::launch& launch) {
+      kernel<<<grid_dim, block_dim, 0, launch.get_stream()>>>(NUM_ITERATIONS, ActionT{}, k, num_items);
+    });
+  }
+}
+
+template <int MAX_K, int ITEMS_PER_THREAD>
+struct full_op_t
+{
+  template <typename KeyT, typename ValueT>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void
+  operator()(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], int k, int) const
+  {
+    cub::detail::WarpBitonicTopK<MAX_K, KeyT, ValueT>{}.TopK(keys, values, CustomLess{}, k);
+  }
+};
+
+template <Mode mode, typename KeyT, typename ValueT, int LEN, int MAX_K>
+void full(nvbench::state& state,
+          nvbench::type_list<nvbench::enum_type<mode>, KeyT, ValueT, nvbench::enum_type<LEN>, nvbench::enum_type<MAX_K>>)
+{
+  run_topk<full_op_t<MAX_K, LEN / WARP_THREADS>, mode, KeyT, ValueT, LEN, MAX_K>(state, LEN);
+}
+
+NVBENCH_BENCH_TYPES(full, NVBENCH_TYPE_AXES(modes, key_types, value_types, len_values, max_k_values))
+  .set_type_axes_names({"mode", "KeyT", "ValueT", "len", "max_k"})
+  .add_int64_axis("k", k_values);
+
+template <int MAX_K, int ITEMS_PER_THREAD>
+struct partial_oob_op_t
+{
+  template <typename KeyT, typename ValueT>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void
+  operator()(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], int k, int len) const
+  {
+    cub::detail::WarpBitonicTopK<MAX_K, KeyT, ValueT>{}.TopK(keys, values, CustomLess{}, k, len, CustomLess::oob<KeyT>);
+  }
+};
+
+template <Mode mode, typename KeyT, typename ValueT, int LEN, int MAX_K>
+void partial_oob(
+  nvbench::state& state,
+  nvbench::type_list<nvbench::enum_type<mode>, KeyT, ValueT, nvbench::enum_type<LEN>, nvbench::enum_type<MAX_K>>)
+{
+  constexpr int num_items = LEN;
+  run_topk<partial_oob_op_t<MAX_K, LEN / WARP_THREADS>, mode, KeyT, ValueT, LEN, MAX_K>(state, num_items);
+}
+
+NVBENCH_BENCH_TYPES(partial_oob, NVBENCH_TYPE_AXES(modes, key_types, value_types, len_values, max_k_values))
+  .set_type_axes_names({"mode", "KeyT", "ValueT", "len", "max_k"})
+  .add_int64_axis("k", k_values);
+
+template <int MAX_K, int ITEMS_PER_THREAD>
+struct partial_op_t
+{
+  template <typename KeyT, typename ValueT>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void
+  operator()(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], int k, int len) const
+  {
+    cub::detail::WarpBitonicTopK<MAX_K, KeyT, ValueT>{}.TopK(keys, values, CustomLess{}, k, len);
+  }
+};
+
+template <Mode mode, typename KeyT, typename ValueT, int LEN, int MAX_K>
+void partial(
+  nvbench::state& state,
+  nvbench::type_list<nvbench::enum_type<mode>, KeyT, ValueT, nvbench::enum_type<LEN>, nvbench::enum_type<MAX_K>>)
+{
+  constexpr int num_items = LEN;
+  run_topk<partial_op_t<MAX_K, LEN / WARP_THREADS>, mode, KeyT, ValueT, LEN, MAX_K>(state, num_items);
+}
+
+NVBENCH_BENCH_TYPES(partial, NVBENCH_TYPE_AXES(modes, key_types, value_types, len_values, max_k_values))
+  .set_type_axes_names({"mode", "KeyT", "ValueT", "len", "max_k"})
+  .add_int64_axis("k", k_values);
+
+template <int THREADS_PER_BLOCK, int MAX_K, typename KeyT, typename ValueT>
+__global__ void iterator_topk_kernel(int num_iterations, KeyT* keys_in, ValueT* values_in, int k, int num_items)
+{
+  using warp_topk_t = cub::detail::WarpBitonicTopK<MAX_K, KeyT, ValueT>;
+  static_assert(THREADS_PER_BLOCK % WARP_THREADS == 0);
+  constexpr int warps_per_block = THREADS_PER_BLOCK / WARP_THREADS;
+
+  __shared__ typename warp_topk_t::TempStorage temp_storage[warps_per_block];
+
+  const int warp_id      = blockIdx.x * warps_per_block + threadIdx.x / WARP_THREADS;
+  const int input_offset = warp_id * num_items * num_iterations;
+
+  KeyT keys_out[MAX_K / WARP_THREADS];
+  ValueT values_out[MAX_K / WARP_THREADS];
+
+  warp_topk_t warp_topk(temp_storage[threadIdx.x / WARP_THREADS]);
+  for (int i = 0; i < num_iterations; ++i)
+  {
+    const int offset = input_offset + i * num_items;
+    warp_topk.TopK(keys_in + offset, values_in + offset, CustomLess{}, k, num_items, keys_out, values_out);
+    sink(keys_out);
+    sink(values_out);
+  }
+}
+
+template <Mode mode, typename KeyT, typename ValueT, int MAX_K>
+void iterator(nvbench::state& state,
+              nvbench::type_list<nvbench::enum_type<mode>, KeyT, ValueT, nvbench::enum_type<MAX_K>>)
+{
+  const int num_items = static_cast<int>(state.get_int64("len"));
+  const int k         = static_cast<int>(state.get_int64("k"));
+
+  if (MAX_K > num_items || k > MAX_K || k > num_items)
+  {
+    state.skip("Skipping workload where max_k > len, k > max_k, or k > len.");
+    return;
+  }
+
+  constexpr int block_dim = calc_block_dim<mode>();
+  const auto kernel       = iterator_topk_kernel<block_dim, MAX_K, KeyT, ValueT>;
+
+  const int num_SMs  = state.get_device().value().get_number_of_sms();
+  const int grid_dim = calc_grid_dim<mode>(num_SMs, block_dim, kernel);
+
+  const size_t input_items_per_iteration = grid_dim * (block_dim / WARP_THREADS) * num_items;
+  const size_t input_items               = input_items_per_iteration * NUM_ITERATIONS;
+
+  thrust::device_vector<KeyT> keys_in     = generate(input_items);
+  thrust::device_vector<ValueT> values_in = generate(input_items);
+
+  state.add_element_count(input_items);
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
+    kernel<<<grid_dim, block_dim, 0, launch.get_stream()>>>(
+      NUM_ITERATIONS,
+      thrust::raw_pointer_cast(keys_in.data()),
+      thrust::raw_pointer_cast(values_in.data()),
+      k,
+      num_items);
+  });
+}
+
+NVBENCH_BENCH_TYPES(iterator, NVBENCH_TYPE_AXES(modes, key_types, value_types, max_k_values))
+  .set_type_axes_names({"mode", "KeyT", "ValueT", "max_k"})
+  .add_int64_axis("len", {32, 64, 96, 128, 256, 512, 1024, 2048})
+  .add_int64_axis("k", {32});

--- a/cub/benchmarks/bench/bitonic_sort/warp_topk_pairs.cu
+++ b/cub/benchmarks/bench/bitonic_sort/warp_topk_pairs.cu
@@ -36,9 +36,8 @@ NVBENCH_DECLARE_ENUM_TYPE_STRINGS(
 
 using modes        = nvbench::enum_type_list<Mode::Latency, Mode::Throughput>;
 using algos        = nvbench::enum_type_list<WarpBitonicTopKAlgorithm::eager, WarpBitonicTopKAlgorithm::buffered>;
-using eager_algos  = nvbench::enum_type_list<WarpBitonicTopKAlgorithm::eager>;
 using key_types    = nvbench::type_list<std::int16_t, float>;
-using value_types  = offset_types;
+using value_types  = nvbench::type_list<int32_t>;
 using len_values   = nvbench::enum_type_list<32, 64, 96, 128, 160>;
 using max_k_values = nvbench::enum_type_list<32, 64, 96>;
 
@@ -47,6 +46,7 @@ using max_k_values = nvbench::enum_type_list<32, 64, 96>;
 // (2) num_items is always set to len (ItemsPerThread * 32), though partial variants accept smaller values.
 //     Because adding a num_items axis would bloat the benchmark combinations, and using a len much larger than
 //     num_items is inefficient for these APIs.
+// (3) the perf of the partial (with oob_default) API is nearly the same as the full API, so not benchmark it
 
 template <WarpBitonicTopKAlgorithm Algo, int WarpsPerBlock, int MaxK>
 struct full_op_t
@@ -54,7 +54,7 @@ struct full_op_t
   template <typename KeyT, typename ValueT, int ItemsPerThread>
   __device__ __forceinline__ void operator()(KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread]) const
   {
-    using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT, Algo>;
+    using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, warp_threads, ValueT, Algo>;
     __shared__ typename warp_topk_t::TempStorage temp_storage[WarpsPerBlock];
     warp_topk_t{temp_storage[threadIdx.x / warp_threads]}.TopK(keys, values, CustomLess{}, 1);
   }
@@ -77,43 +77,12 @@ NVBENCH_BENCH_TYPES(full, NVBENCH_TYPE_AXES(modes, algos, key_types, value_types
   .set_type_axes_names({"mode", "algo", "KeyT", "ValueT", "len", "max_k"});
 
 template <WarpBitonicTopKAlgorithm Algo, int WarpsPerBlock, int MaxK>
-struct partial_oob_op_t
-{
-  template <typename KeyT, typename ValueT, int ItemsPerThread>
-  __device__ __forceinline__ void operator()(KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread]) const
-  {
-    using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT, Algo>;
-    __shared__ typename warp_topk_t::TempStorage temp_storage[WarpsPerBlock];
-    warp_topk_t{temp_storage[threadIdx.x / warp_threads]}.TopK(
-      keys, values, CustomLess{}, 1, ItemsPerThread * warp_threads, CustomLess::oob_default<KeyT>);
-  }
-};
-
-template <Mode BenchMode, WarpBitonicTopKAlgorithm Algo, typename KeyT, typename ValueT, int Len, int MaxK>
-void partial_oob(
-  nvbench::state& state,
-  nvbench::type_list<nvbench::enum_type<BenchMode>,
-                     nvbench::enum_type<Algo>,
-                     KeyT,
-                     ValueT,
-                     nvbench::enum_type<Len>,
-                     nvbench::enum_type<MaxK>>)
-{
-  constexpr int warps_per_block = get_run_params<BenchMode>().block_dim / warp_threads;
-  run_topk<partial_oob_op_t<Algo, warps_per_block, MaxK>, BenchMode, KeyT, ValueT, Len, MaxK>(state);
-}
-
-NVBENCH_BENCH_TYPES(partial_oob,
-                    NVBENCH_TYPE_AXES(modes, eager_algos, key_types, value_types, len_values, max_k_values))
-  .set_type_axes_names({"mode", "algo", "KeyT", "ValueT", "len", "max_k"});
-
-template <WarpBitonicTopKAlgorithm Algo, int WarpsPerBlock, int MaxK>
 struct partial_op_t
 {
   template <typename KeyT, typename ValueT, int ItemsPerThread>
   __device__ __forceinline__ void operator()(KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread]) const
   {
-    using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT, Algo>;
+    using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, warp_threads, ValueT, Algo>;
     __shared__ typename warp_topk_t::TempStorage temp_storage[WarpsPerBlock];
     warp_topk_t{temp_storage[threadIdx.x / warp_threads]}.TopK(
       keys, values, CustomLess{}, 1, ItemsPerThread * warp_threads);
@@ -139,7 +108,7 @@ NVBENCH_BENCH_TYPES(partial, NVBENCH_TYPE_AXES(modes, algos, key_types, value_ty
 template <WarpBitonicTopKAlgorithm Algo, int WarpsPerBlock, int MaxK, typename KeyT, typename ValueT>
 __global__ void iterator_topk_kernel(int num_iterations, KeyT* keys_in, ValueT* values_in, int k, int num_items)
 {
-  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT, Algo>;
+  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, warp_threads, ValueT, Algo>;
 
   __shared__ typename warp_topk_t::TempStorage temp_storage[WarpsPerBlock];
 
@@ -199,7 +168,10 @@ void iterator(
   });
 }
 
-NVBENCH_BENCH_TYPES(iterator, NVBENCH_TYPE_AXES(modes, algos, key_types, value_types, max_k_values))
+NVBENCH_BENCH_TYPES(
+  iterator,
+  NVBENCH_TYPE_AXES(
+    modes, nvbench::enum_type_list<WarpBitonicTopKAlgorithm::buffered>, key_types, value_types, max_k_values))
   .set_type_axes_names({"mode", "algo", "KeyT", "ValueT", "max_k"})
   .add_int64_axis("len", {32, 64, 96, 128, 256, 512, 1024, 2048})
   .add_int64_axis("k", {32});

--- a/cub/benchmarks/bench/bitonic_sort/warp_topk_pairs.cu
+++ b/cub/benchmarks/bench/bitonic_sort/warp_topk_pairs.cu
@@ -8,13 +8,35 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 
 #include <device_side_benchmark.cuh>
 #include <nvbench_helper.cuh>
 
 #include "bitonic_common.cuh"
 
+using cub::detail::WarpBitonicTopKAlgorithm;
+
+NVBENCH_DECLARE_ENUM_TYPE_STRINGS(
+  WarpBitonicTopKAlgorithm,
+  [](WarpBitonicTopKAlgorithm value) {
+    switch (value)
+    {
+      case WarpBitonicTopKAlgorithm::eager:
+        return "eager";
+      case WarpBitonicTopKAlgorithm::buffered:
+        return "buffered";
+      default:
+        return "Unknown";
+    }
+  },
+  [](auto) {
+    return std::string{};
+  })
+
 using modes        = nvbench::enum_type_list<Mode::Latency, Mode::Throughput>;
+using algos        = nvbench::enum_type_list<WarpBitonicTopKAlgorithm::eager, WarpBitonicTopKAlgorithm::buffered>;
+using eager_algos  = nvbench::enum_type_list<WarpBitonicTopKAlgorithm::eager>;
 using key_types    = nvbench::type_list<std::int16_t, float>;
 using value_types  = offset_types;
 using len_values   = nvbench::enum_type_list<32, 64, 96, 128, 160>;
@@ -26,90 +48,108 @@ using max_k_values = nvbench::enum_type_list<32, 64, 96>;
 //     Because adding a num_items axis would bloat the benchmark combinations, and using a len much larger than
 //     num_items is inefficient for these APIs.
 
-template <int MaxK>
+template <WarpBitonicTopKAlgorithm Algo, int WarpsPerBlock, int MaxK>
 struct full_op_t
 {
   template <typename KeyT, typename ValueT, int ItemsPerThread>
-  __device__ __forceinline__ void
-  operator()(KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread]) const
+  __device__ __forceinline__ void operator()(KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread]) const
   {
-    cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT>{}.TopK(keys, values, CustomLess{}, 1);
+    using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT, Algo>;
+    __shared__ typename warp_topk_t::TempStorage temp_storage[WarpsPerBlock];
+    warp_topk_t{temp_storage[threadIdx.x / warp_threads]}.TopK(keys, values, CustomLess{}, 1);
   }
 };
 
-template <Mode BenchMode, typename KeyT, typename ValueT, int Len, int MaxK>
-void full(
-  nvbench::state& state,
-  nvbench::type_list<nvbench::enum_type<BenchMode>, KeyT, ValueT, nvbench::enum_type<Len>, nvbench::enum_type<MaxK>>)
+template <Mode BenchMode, WarpBitonicTopKAlgorithm Algo, typename KeyT, typename ValueT, int Len, int MaxK>
+void full(nvbench::state& state,
+          nvbench::type_list<nvbench::enum_type<BenchMode>,
+                             nvbench::enum_type<Algo>,
+                             KeyT,
+                             ValueT,
+                             nvbench::enum_type<Len>,
+                             nvbench::enum_type<MaxK>>)
 {
-  run_topk<full_op_t<MaxK>, BenchMode, KeyT, ValueT, Len, MaxK>(state);
+  constexpr int warps_per_block = get_run_params<BenchMode>().block_dim / warp_threads;
+  run_topk<full_op_t<Algo, warps_per_block, MaxK>, BenchMode, KeyT, ValueT, Len, MaxK>(state);
 }
 
-NVBENCH_BENCH_TYPES(full, NVBENCH_TYPE_AXES(modes, key_types, value_types, len_values, max_k_values))
-  .set_type_axes_names({"mode", "KeyT", "ValueT", "len", "max_k"});
+NVBENCH_BENCH_TYPES(full, NVBENCH_TYPE_AXES(modes, algos, key_types, value_types, len_values, max_k_values))
+  .set_type_axes_names({"mode", "algo", "KeyT", "ValueT", "len", "max_k"});
 
-template <int MaxK>
+template <WarpBitonicTopKAlgorithm Algo, int WarpsPerBlock, int MaxK>
 struct partial_oob_op_t
 {
   template <typename KeyT, typename ValueT, int ItemsPerThread>
-  __device__ __forceinline__ void
-  operator()(KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread]) const
+  __device__ __forceinline__ void operator()(KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread]) const
   {
-    cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT>{}.TopK(
+    using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT, Algo>;
+    __shared__ typename warp_topk_t::TempStorage temp_storage[WarpsPerBlock];
+    warp_topk_t{temp_storage[threadIdx.x / warp_threads]}.TopK(
       keys, values, CustomLess{}, 1, ItemsPerThread * warp_threads, CustomLess::oob_default<KeyT>);
   }
 };
 
-template <Mode BenchMode, typename KeyT, typename ValueT, int Len, int MaxK>
+template <Mode BenchMode, WarpBitonicTopKAlgorithm Algo, typename KeyT, typename ValueT, int Len, int MaxK>
 void partial_oob(
   nvbench::state& state,
-  nvbench::type_list<nvbench::enum_type<BenchMode>, KeyT, ValueT, nvbench::enum_type<Len>, nvbench::enum_type<MaxK>>)
+  nvbench::type_list<nvbench::enum_type<BenchMode>,
+                     nvbench::enum_type<Algo>,
+                     KeyT,
+                     ValueT,
+                     nvbench::enum_type<Len>,
+                     nvbench::enum_type<MaxK>>)
 {
-  run_topk<partial_oob_op_t<MaxK>, BenchMode, KeyT, ValueT, Len, MaxK>(state);
+  constexpr int warps_per_block = get_run_params<BenchMode>().block_dim / warp_threads;
+  run_topk<partial_oob_op_t<Algo, warps_per_block, MaxK>, BenchMode, KeyT, ValueT, Len, MaxK>(state);
 }
 
-NVBENCH_BENCH_TYPES(partial_oob, NVBENCH_TYPE_AXES(modes, key_types, value_types, len_values, max_k_values))
-  .set_type_axes_names({"mode", "KeyT", "ValueT", "len", "max_k"});
+NVBENCH_BENCH_TYPES(partial_oob,
+                    NVBENCH_TYPE_AXES(modes, eager_algos, key_types, value_types, len_values, max_k_values))
+  .set_type_axes_names({"mode", "algo", "KeyT", "ValueT", "len", "max_k"});
 
-template <int MaxK>
+template <WarpBitonicTopKAlgorithm Algo, int WarpsPerBlock, int MaxK>
 struct partial_op_t
 {
   template <typename KeyT, typename ValueT, int ItemsPerThread>
-  __device__ __forceinline__ void
-  operator()(KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread]) const
+  __device__ __forceinline__ void operator()(KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread]) const
   {
-    cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT>{}.TopK(
+    using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT, Algo>;
+    __shared__ typename warp_topk_t::TempStorage temp_storage[WarpsPerBlock];
+    warp_topk_t{temp_storage[threadIdx.x / warp_threads]}.TopK(
       keys, values, CustomLess{}, 1, ItemsPerThread * warp_threads);
   }
 };
 
-template <Mode BenchMode, typename KeyT, typename ValueT, int Len, int MaxK>
-void partial(
-  nvbench::state& state,
-  nvbench::type_list<nvbench::enum_type<BenchMode>, KeyT, ValueT, nvbench::enum_type<Len>, nvbench::enum_type<MaxK>>)
+template <Mode BenchMode, WarpBitonicTopKAlgorithm Algo, typename KeyT, typename ValueT, int Len, int MaxK>
+void partial(nvbench::state& state,
+             nvbench::type_list<nvbench::enum_type<BenchMode>,
+                                nvbench::enum_type<Algo>,
+                                KeyT,
+                                ValueT,
+                                nvbench::enum_type<Len>,
+                                nvbench::enum_type<MaxK>>)
 {
-  run_topk<partial_op_t<MaxK>, BenchMode, KeyT, ValueT, Len, MaxK>(state);
+  constexpr int warps_per_block = get_run_params<BenchMode>().block_dim / warp_threads;
+  run_topk<partial_op_t<Algo, warps_per_block, MaxK>, BenchMode, KeyT, ValueT, Len, MaxK>(state);
 }
 
-NVBENCH_BENCH_TYPES(partial, NVBENCH_TYPE_AXES(modes, key_types, value_types, len_values, max_k_values))
-  .set_type_axes_names({"mode", "KeyT", "ValueT", "len", "max_k"});
+NVBENCH_BENCH_TYPES(partial, NVBENCH_TYPE_AXES(modes, algos, key_types, value_types, len_values, max_k_values))
+  .set_type_axes_names({"mode", "algo", "KeyT", "ValueT", "len", "max_k"});
 
-template <int ThreadsPerBlock, int MaxK, typename KeyT, typename ValueT>
+template <WarpBitonicTopKAlgorithm Algo, int WarpsPerBlock, int MaxK, typename KeyT, typename ValueT>
 __global__ void iterator_topk_kernel(int num_iterations, KeyT* keys_in, ValueT* values_in, int k, int num_items)
 {
-  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT>;
-  static_assert(ThreadsPerBlock % warp_threads == 0);
-  constexpr int warps_per_block = ThreadsPerBlock / warp_threads;
+  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT, Algo>;
 
-  __shared__ typename warp_topk_t::TempStorage temp_storage[warps_per_block];
+  __shared__ typename warp_topk_t::TempStorage temp_storage[WarpsPerBlock];
 
-  const std::size_t warp_id      = static_cast<std::size_t>(blockIdx.x) * warps_per_block + threadIdx.x / warp_threads;
+  const std::size_t warp_id      = static_cast<std::size_t>(blockIdx.x) * WarpsPerBlock + threadIdx.x / warp_threads;
   const std::size_t input_offset = warp_id * num_items * num_iterations;
 
   KeyT keys_out[MaxK / warp_threads];
   ValueT values_out[MaxK / warp_threads];
 
-  warp_topk_t warp_topk(temp_storage[threadIdx.x / warp_threads]);
+  warp_topk_t warp_topk{temp_storage[threadIdx.x / warp_threads]};
   for (int i = 0; i < num_iterations; ++i)
   {
     const std::size_t offset = input_offset + i * num_items;
@@ -119,9 +159,10 @@ __global__ void iterator_topk_kernel(int num_iterations, KeyT* keys_in, ValueT* 
   }
 }
 
-template <Mode BenchMode, typename KeyT, typename ValueT, int MaxK>
-void iterator(nvbench::state& state,
-              nvbench::type_list<nvbench::enum_type<BenchMode>, KeyT, ValueT, nvbench::enum_type<MaxK>>)
+template <Mode BenchMode, WarpBitonicTopKAlgorithm Algo, typename KeyT, typename ValueT, int MaxK>
+void iterator(
+  nvbench::state& state,
+  nvbench::type_list<nvbench::enum_type<BenchMode>, nvbench::enum_type<Algo>, KeyT, ValueT, nvbench::enum_type<MaxK>>)
 {
   const int num_items = static_cast<int>(state.get_int64("len"));
   const int k         = static_cast<int>(state.get_int64("k"));
@@ -132,7 +173,8 @@ void iterator(nvbench::state& state,
     return;
   }
 
-  const auto kernel = iterator_topk_kernel<get_run_params<BenchMode>().block_dim, MaxK, KeyT, ValueT>;
+  constexpr int warps_per_block = get_run_params<BenchMode>().block_dim / warp_threads;
+  const auto kernel             = iterator_topk_kernel<Algo, warps_per_block, MaxK, KeyT, ValueT>;
 
   RunParams run_params = get_run_params<BenchMode>();
   if (BenchMode == Mode::Throughput)
@@ -157,7 +199,7 @@ void iterator(nvbench::state& state,
   });
 }
 
-NVBENCH_BENCH_TYPES(iterator, NVBENCH_TYPE_AXES(modes, key_types, value_types, max_k_values))
-  .set_type_axes_names({"mode", "KeyT", "ValueT", "max_k"})
+NVBENCH_BENCH_TYPES(iterator, NVBENCH_TYPE_AXES(modes, algos, key_types, value_types, max_k_values))
+  .set_type_axes_names({"mode", "algo", "KeyT", "ValueT", "max_k"})
   .add_int64_axis("len", {32, 64, 96, 128, 256, 512, 1024, 2048})
   .add_int64_axis("k", {32});

--- a/cub/benchmarks/bench/bitonic_sort/warp_topk_pairs.cu
+++ b/cub/benchmarks/bench/bitonic_sort/warp_topk_pairs.cu
@@ -4,239 +4,143 @@
 #include <cub/warp/warp_bitonic_topk.cuh>
 
 #include <thrust/device_vector.h>
+#include <thrust/memory.h>
 
-#include <cuda/std/limits>
-
-#include <vector>
+#include <cstddef>
+#include <cstdint>
 
 #include <device_side_benchmark.cuh>
 #include <nvbench_helper.cuh>
 
-using key_types    = fundamental_types;
+#include "bitonic_common.cuh"
+
+using modes        = nvbench::enum_type_list<Mode::Latency, Mode::Throughput>;
+using key_types    = nvbench::type_list<std::int16_t, float>;
 using value_types  = offset_types;
-using len_values   = nvbench::enum_type_list<32, 64, 96, 128, 160, 192>;
+using len_values   = nvbench::enum_type_list<32, 64, 96, 128, 160>;
 using max_k_values = nvbench::enum_type_list<32, 64, 96>;
-// the perf is mostly determined by max_k values, so just use k=1
-const std::vector<nvbench::int64_t> k_values{1};
 
-constexpr int WARP_THREADS                  = 32;
-constexpr int NUM_ITERATIONS                = 100;
-constexpr int BLOCK_DIM_FOR_THROUGHPUT_MODE = 128;
+// For array API:
+// (1) k is set to 1 because performance is mostly determined by max_k not k
+// (2) num_items is always set to len (ItemsPerThread * 32), though partial variants accept smaller values.
+//     Because adding a num_items axis would bloat the benchmark combinations, and using a len much larger than
+//     num_items is inefficient for these APIs.
 
-enum class Mode
-{
-  // launch single warp
-  Latency,
-  // launch one full wave of thread blocks. Measure Elem/s.
-  Throughput
-};
-using modes = nvbench::enum_type_list<Mode::Latency, Mode::Throughput>;
-
-NVBENCH_DECLARE_ENUM_TYPE_STRINGS(
-  Mode,
-  // Callable to generate input strings:
-  [](Mode value) {
-    switch (value)
-    {
-      case Mode::Latency:
-        return "latency";
-      case Mode::Throughput:
-        return "throughput";
-      default:
-        return "Unknown";
-    }
-  },
-  // Callable to generate descriptions:
-  [](auto) {
-    return std::string{};
-  })
-
-struct CustomLess
-{
-  template <typename T>
-  __device__ bool operator()(const T& lhs, const T& rhs) const
-  {
-    return lhs < rhs;
-  }
-
-  template <typename T>
-  static constexpr T oob = cuda::std::numeric_limits<T>::max();
-};
-
-template <Mode mode>
-constexpr int calc_block_dim()
-{
-  if constexpr (mode == Mode::Latency)
-  {
-    return WARP_THREADS;
-  }
-  else
-  {
-    return BLOCK_DIM_FOR_THROUGHPUT_MODE;
-  }
-}
-
-template <Mode mode, typename Kernel>
-int calc_grid_dim(int num_SMs, int block_dim, Kernel kernel)
-{
-  if constexpr (mode == Mode::Latency)
-  {
-    return 1;
-  }
-  else
-  {
-    int max_blocks_per_SM = 0;
-    NVBENCH_CUDA_CALL_NOEXCEPT(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_blocks_per_SM, kernel, block_dim, 0));
-    return max_blocks_per_SM * num_SMs;
-  }
-}
-
-template <typename ActionT, Mode mode, typename KeyT, typename ValueT, int LEN, int MAX_K>
-void run_topk(nvbench::state& state, int num_items)
-{
-  if constexpr (MAX_K > LEN)
-  {
-    state.skip("Skipping workload where max_k > len.");
-  }
-  else
-  {
-    const int k = static_cast<int>(state.get_int64("k"));
-    if (k > MAX_K || k > num_items)
-    {
-      state.skip("Skipping workload where k > max_k or k > num_items.");
-      return;
-    }
-
-    constexpr int items_per_thread = LEN / WARP_THREADS;
-    const auto kernel              = benchmark_kernel<items_per_thread, KeyT, ValueT, ActionT, int, int>;
-
-    const int num_SMs       = state.get_device().value().get_number_of_sms();
-    constexpr int block_dim = calc_block_dim<mode>();
-    const int grid_dim      = calc_grid_dim<mode>(num_SMs, block_dim, kernel);
-    state.add_element_count(grid_dim * (block_dim / WARP_THREADS) * num_items * NUM_ITERATIONS);
-
-    state.exec([grid_dim, block_dim, kernel, k, num_items](nvbench::launch& launch) {
-      kernel<<<grid_dim, block_dim, 0, launch.get_stream()>>>(NUM_ITERATIONS, ActionT{}, k, num_items);
-    });
-  }
-}
-
-template <int MAX_K, int ITEMS_PER_THREAD>
+template <int MaxK>
 struct full_op_t
 {
-  template <typename KeyT, typename ValueT>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void
-  operator()(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], int k, int) const
+  template <typename KeyT, typename ValueT, int ItemsPerThread>
+  __device__ __forceinline__ void
+  operator()(KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread]) const
   {
-    cub::detail::WarpBitonicTopK<MAX_K, KeyT, ValueT>{}.TopK(keys, values, CustomLess{}, k);
+    cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT>{}.TopK(keys, values, CustomLess{}, 1);
   }
 };
 
-template <Mode mode, typename KeyT, typename ValueT, int LEN, int MAX_K>
-void full(nvbench::state& state,
-          nvbench::type_list<nvbench::enum_type<mode>, KeyT, ValueT, nvbench::enum_type<LEN>, nvbench::enum_type<MAX_K>>)
+template <Mode BenchMode, typename KeyT, typename ValueT, int Len, int MaxK>
+void full(
+  nvbench::state& state,
+  nvbench::type_list<nvbench::enum_type<BenchMode>, KeyT, ValueT, nvbench::enum_type<Len>, nvbench::enum_type<MaxK>>)
 {
-  run_topk<full_op_t<MAX_K, LEN / WARP_THREADS>, mode, KeyT, ValueT, LEN, MAX_K>(state, LEN);
+  run_topk<full_op_t<MaxK>, BenchMode, KeyT, ValueT, Len, MaxK>(state);
 }
 
 NVBENCH_BENCH_TYPES(full, NVBENCH_TYPE_AXES(modes, key_types, value_types, len_values, max_k_values))
-  .set_type_axes_names({"mode", "KeyT", "ValueT", "len", "max_k"})
-  .add_int64_axis("k", k_values);
+  .set_type_axes_names({"mode", "KeyT", "ValueT", "len", "max_k"});
 
-template <int MAX_K, int ITEMS_PER_THREAD>
+template <int MaxK>
 struct partial_oob_op_t
 {
-  template <typename KeyT, typename ValueT>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void
-  operator()(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], int k, int len) const
+  template <typename KeyT, typename ValueT, int ItemsPerThread>
+  __device__ __forceinline__ void
+  operator()(KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread]) const
   {
-    cub::detail::WarpBitonicTopK<MAX_K, KeyT, ValueT>{}.TopK(keys, values, CustomLess{}, k, len, CustomLess::oob<KeyT>);
+    cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT>{}.TopK(
+      keys, values, CustomLess{}, 1, ItemsPerThread * warp_threads, CustomLess::oob_default<KeyT>);
   }
 };
 
-template <Mode mode, typename KeyT, typename ValueT, int LEN, int MAX_K>
+template <Mode BenchMode, typename KeyT, typename ValueT, int Len, int MaxK>
 void partial_oob(
   nvbench::state& state,
-  nvbench::type_list<nvbench::enum_type<mode>, KeyT, ValueT, nvbench::enum_type<LEN>, nvbench::enum_type<MAX_K>>)
+  nvbench::type_list<nvbench::enum_type<BenchMode>, KeyT, ValueT, nvbench::enum_type<Len>, nvbench::enum_type<MaxK>>)
 {
-  constexpr int num_items = LEN;
-  run_topk<partial_oob_op_t<MAX_K, LEN / WARP_THREADS>, mode, KeyT, ValueT, LEN, MAX_K>(state, num_items);
+  run_topk<partial_oob_op_t<MaxK>, BenchMode, KeyT, ValueT, Len, MaxK>(state);
 }
 
 NVBENCH_BENCH_TYPES(partial_oob, NVBENCH_TYPE_AXES(modes, key_types, value_types, len_values, max_k_values))
-  .set_type_axes_names({"mode", "KeyT", "ValueT", "len", "max_k"})
-  .add_int64_axis("k", k_values);
+  .set_type_axes_names({"mode", "KeyT", "ValueT", "len", "max_k"});
 
-template <int MAX_K, int ITEMS_PER_THREAD>
+template <int MaxK>
 struct partial_op_t
 {
-  template <typename KeyT, typename ValueT>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void
-  operator()(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], int k, int len) const
+  template <typename KeyT, typename ValueT, int ItemsPerThread>
+  __device__ __forceinline__ void
+  operator()(KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread]) const
   {
-    cub::detail::WarpBitonicTopK<MAX_K, KeyT, ValueT>{}.TopK(keys, values, CustomLess{}, k, len);
+    cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT>{}.TopK(
+      keys, values, CustomLess{}, 1, ItemsPerThread * warp_threads);
   }
 };
 
-template <Mode mode, typename KeyT, typename ValueT, int LEN, int MAX_K>
+template <Mode BenchMode, typename KeyT, typename ValueT, int Len, int MaxK>
 void partial(
   nvbench::state& state,
-  nvbench::type_list<nvbench::enum_type<mode>, KeyT, ValueT, nvbench::enum_type<LEN>, nvbench::enum_type<MAX_K>>)
+  nvbench::type_list<nvbench::enum_type<BenchMode>, KeyT, ValueT, nvbench::enum_type<Len>, nvbench::enum_type<MaxK>>)
 {
-  constexpr int num_items = LEN;
-  run_topk<partial_op_t<MAX_K, LEN / WARP_THREADS>, mode, KeyT, ValueT, LEN, MAX_K>(state, num_items);
+  run_topk<partial_op_t<MaxK>, BenchMode, KeyT, ValueT, Len, MaxK>(state);
 }
 
 NVBENCH_BENCH_TYPES(partial, NVBENCH_TYPE_AXES(modes, key_types, value_types, len_values, max_k_values))
-  .set_type_axes_names({"mode", "KeyT", "ValueT", "len", "max_k"})
-  .add_int64_axis("k", k_values);
+  .set_type_axes_names({"mode", "KeyT", "ValueT", "len", "max_k"});
 
-template <int THREADS_PER_BLOCK, int MAX_K, typename KeyT, typename ValueT>
+template <int ThreadsPerBlock, int MaxK, typename KeyT, typename ValueT>
 __global__ void iterator_topk_kernel(int num_iterations, KeyT* keys_in, ValueT* values_in, int k, int num_items)
 {
-  using warp_topk_t = cub::detail::WarpBitonicTopK<MAX_K, KeyT, ValueT>;
-  static_assert(THREADS_PER_BLOCK % WARP_THREADS == 0);
-  constexpr int warps_per_block = THREADS_PER_BLOCK / WARP_THREADS;
+  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT>;
+  static_assert(ThreadsPerBlock % warp_threads == 0);
+  constexpr int warps_per_block = ThreadsPerBlock / warp_threads;
 
   __shared__ typename warp_topk_t::TempStorage temp_storage[warps_per_block];
 
-  const int warp_id      = blockIdx.x * warps_per_block + threadIdx.x / WARP_THREADS;
-  const int input_offset = warp_id * num_items * num_iterations;
+  const std::size_t warp_id      = static_cast<std::size_t>(blockIdx.x) * warps_per_block + threadIdx.x / warp_threads;
+  const std::size_t input_offset = warp_id * num_items * num_iterations;
 
-  KeyT keys_out[MAX_K / WARP_THREADS];
-  ValueT values_out[MAX_K / WARP_THREADS];
+  KeyT keys_out[MaxK / warp_threads];
+  ValueT values_out[MaxK / warp_threads];
 
-  warp_topk_t warp_topk(temp_storage[threadIdx.x / WARP_THREADS]);
+  warp_topk_t warp_topk(temp_storage[threadIdx.x / warp_threads]);
   for (int i = 0; i < num_iterations; ++i)
   {
-    const int offset = input_offset + i * num_items;
+    const std::size_t offset = input_offset + i * num_items;
     warp_topk.TopK(keys_in + offset, values_in + offset, CustomLess{}, k, num_items, keys_out, values_out);
     sink(keys_out);
     sink(values_out);
   }
 }
 
-template <Mode mode, typename KeyT, typename ValueT, int MAX_K>
+template <Mode BenchMode, typename KeyT, typename ValueT, int MaxK>
 void iterator(nvbench::state& state,
-              nvbench::type_list<nvbench::enum_type<mode>, KeyT, ValueT, nvbench::enum_type<MAX_K>>)
+              nvbench::type_list<nvbench::enum_type<BenchMode>, KeyT, ValueT, nvbench::enum_type<MaxK>>)
 {
   const int num_items = static_cast<int>(state.get_int64("len"));
   const int k         = static_cast<int>(state.get_int64("k"));
 
-  if (MAX_K > num_items || k > MAX_K || k > num_items)
+  if (MaxK > num_items || k > MaxK || k > num_items)
   {
     state.skip("Skipping workload where max_k > len, k > max_k, or k > len.");
     return;
   }
 
-  constexpr int block_dim = calc_block_dim<mode>();
-  const auto kernel       = iterator_topk_kernel<block_dim, MAX_K, KeyT, ValueT>;
+  const auto kernel = iterator_topk_kernel<get_run_params<BenchMode>().block_dim, MaxK, KeyT, ValueT>;
 
-  const int num_SMs  = state.get_device().value().get_number_of_sms();
-  const int grid_dim = calc_grid_dim<mode>(num_SMs, block_dim, kernel);
-
-  const size_t input_items_per_iteration = grid_dim * (block_dim / WARP_THREADS) * num_items;
-  const size_t input_items               = input_items_per_iteration * NUM_ITERATIONS;
+  RunParams run_params = get_run_params<BenchMode>();
+  if (BenchMode == Mode::Throughput)
+  {
+    // scale grid_dim because throughout mode is slow
+    run_params.grid_dim /= num_items / warp_threads;
+  }
+  const std::size_t input_items = count_items(run_params, num_items);
 
   thrust::device_vector<KeyT> keys_in     = generate(input_items);
   thrust::device_vector<ValueT> values_in = generate(input_items);
@@ -244,8 +148,8 @@ void iterator(nvbench::state& state,
   state.add_element_count(input_items);
 
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    kernel<<<grid_dim, block_dim, 0, launch.get_stream()>>>(
-      NUM_ITERATIONS,
+    kernel<<<run_params.grid_dim, run_params.block_dim, 0, launch.get_stream()>>>(
+      run_params.num_iterations,
       thrust::raw_pointer_cast(keys_in.data()),
       thrust::raw_pointer_cast(values_in.data()),
       k,

--- a/cub/cub/cub.cuh
+++ b/cub/cub/cub.cuh
@@ -77,6 +77,7 @@
 
 // Warp
 #include <cub/warp/warp_bitonic_sort.cuh>
+#include <cub/warp/warp_bitonic_topk.cuh>
 #include <cub/warp/warp_exchange.cuh>
 #include <cub/warp/warp_load.cuh>
 #include <cub/warp/warp_merge_sort.cuh>

--- a/cub/cub/warp/warp_bitonic_sort.cuh
+++ b/cub/cub/warp/warp_bitonic_sort.cuh
@@ -304,6 +304,8 @@ public:
 private:
   template <typename, int, int, typename>
   friend class WarpBitonicSort;
+  template <int, typename, typename>
+  friend class WarpBitonicTopK;
 
   static constexpr bool keys_only = ::cuda::std::is_same_v<ValueT, NullType>;
 
@@ -516,6 +518,8 @@ public:
 private:
   template <typename, int, int, typename>
   friend class WarpBitonicSort;
+  template <int, typename, typename>
+  friend class WarpBitonicTopK;
 
   static constexpr bool keys_only = ::cuda::std::is_same_v<ValueT, NullType>;
 

--- a/cub/cub/warp/warp_bitonic_sort.cuh
+++ b/cub/cub/warp/warp_bitonic_sort.cuh
@@ -286,6 +286,8 @@ public:
 private:
   template <typename, int, int, typename>
   friend class WarpBitonicSort;
+  template <int, typename, typename>
+  friend class WarpBitonicTopK;
 
   static constexpr int warp_threads = detail::warp_threads;
   static constexpr bool keys_only   = ::cuda::std::is_same_v<ValueT, NullType>;
@@ -496,6 +498,8 @@ public:
 private:
   template <typename, int, int, typename>
   friend class WarpBitonicSort;
+  template <int, typename, typename>
+  friend class WarpBitonicTopK;
 
   static constexpr int warp_threads            = detail::warp_threads;
   static constexpr unsigned int full_warp_mask = 0xFFFFFFFFu;

--- a/cub/cub/warp/warp_bitonic_sort.cuh
+++ b/cub/cub/warp/warp_bitonic_sort.cuh
@@ -33,6 +33,8 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail
 {
+enum class WarpBitonicTopKAlgorithm;
+
 //! @rst
 //! The WarpBitonicSort class provides methods for sorting items partitioned across a CUDA warp
 //! using a bitonic sorting network.
@@ -304,7 +306,7 @@ public:
 private:
   template <typename, int, int, typename>
   friend class WarpBitonicSort;
-  template <int, typename, typename>
+  template <int, typename, typename, WarpBitonicTopKAlgorithm>
   friend class WarpBitonicTopK;
 
   static constexpr bool keys_only = ::cuda::std::is_same_v<ValueT, NullType>;
@@ -518,7 +520,7 @@ public:
 private:
   template <typename, int, int, typename>
   friend class WarpBitonicSort;
-  template <int, typename, typename>
+  template <int, typename, typename, WarpBitonicTopKAlgorithm>
   friend class WarpBitonicTopK;
 
   static constexpr bool keys_only = ::cuda::std::is_same_v<ValueT, NullType>;

--- a/cub/cub/warp/warp_bitonic_sort.cuh
+++ b/cub/cub/warp/warp_bitonic_sort.cuh
@@ -306,7 +306,7 @@ public:
 private:
   template <typename, int, int, typename>
   friend class WarpBitonicSort;
-  template <int, typename, typename, WarpBitonicTopKAlgorithm, int>
+  template <int, typename, int, typename, WarpBitonicTopKAlgorithm>
   friend class WarpBitonicTopK;
 
   static constexpr bool keys_only = ::cuda::std::is_same_v<ValueT, NullType>;
@@ -520,7 +520,7 @@ public:
 private:
   template <typename, int, int, typename>
   friend class WarpBitonicSort;
-  template <int, typename, typename, WarpBitonicTopKAlgorithm, int>
+  template <int, typename, int, typename, WarpBitonicTopKAlgorithm>
   friend class WarpBitonicTopK;
 
   static constexpr bool keys_only = ::cuda::std::is_same_v<ValueT, NullType>;

--- a/cub/cub/warp/warp_bitonic_sort.cuh
+++ b/cub/cub/warp/warp_bitonic_sort.cuh
@@ -306,7 +306,7 @@ public:
 private:
   template <typename, int, int, typename>
   friend class WarpBitonicSort;
-  template <int, typename, typename, WarpBitonicTopKAlgorithm>
+  template <int, typename, typename, WarpBitonicTopKAlgorithm, int>
   friend class WarpBitonicTopK;
 
   static constexpr bool keys_only = ::cuda::std::is_same_v<ValueT, NullType>;
@@ -520,7 +520,7 @@ public:
 private:
   template <typename, int, int, typename>
   friend class WarpBitonicSort;
-  template <int, typename, typename, WarpBitonicTopKAlgorithm>
+  template <int, typename, typename, WarpBitonicTopKAlgorithm, int>
   friend class WarpBitonicTopK;
 
   static constexpr bool keys_only = ::cuda::std::is_same_v<ValueT, NullType>;

--- a/cub/cub/warp/warp_bitonic_topk.cuh
+++ b/cub/cub/warp/warp_bitonic_topk.cuh
@@ -1,0 +1,683 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/util_arch.cuh>
+#include <cub/util_type.cuh>
+#include <cub/warp/warp_bitonic_sort.cuh>
+
+#include <cuda/__cmath/pow2.h>
+#include <cuda/__warp/warp_shuffle.h>
+#include <cuda/std/__type_traits/is_same.h>
+
+CUB_NAMESPACE_BEGIN
+
+namespace detail
+{
+//! @rst
+//! The WarpBitonicTopK class provides methods for selecting top-k items from data partitioned across a CUDA warp.
+//!
+//! Overview
+//! ++++++++++++++++
+//!
+//!   WarpBitonicTopK selects the ``k`` items ordered first by a comparison functor with less-than semantics.
+//!
+//!   Two kinds of TopK functions are provided:
+//!   Array overloads operate on items already held by each lane. Input and output items use a striped arrangement
+//!   across warp lanes. Iterator overloads read arbitrary-length input from memory and require ``TempStorage`` to
+//!   buffer candidates while merging them into the retained top-k set. Output items also use a striped arrangement
+//!   across warp lanes.
+//!
+//! Simple Examples
+//! ++++++++++++++++
+//!
+//! The code snippet below illustrates the array overload. The input contains 64 integer keys partitioned across
+//! 32 threads, with each thread owning 2 items in a striped arrangement. The top 30 items are selected.
+//!
+//! .. code-block:: c++
+//!
+//!    #include <cub/cub.cuh>  // or equivalently <cub/warp/warp_bitonic_topk.cuh>
+//!
+//!    struct CustomLess
+//!    {
+//!      template <typename DataType>
+//!      __device__ bool operator()(const DataType &lhs, const DataType &rhs) const
+//!      {
+//!        return lhs < rhs;
+//!      }
+//!    };
+//!
+//!    __global__ void ArrayExampleKernel(...)
+//!    {
+//!        constexpr int max_k            = 32;
+//!        constexpr int items_per_thread = 2;
+//!
+//!        using WarpBitonicTopKT = cub::detail::WarpBitonicTopK<max_k, int>;
+//!
+//!        int thread_keys[items_per_thread];
+//!        // ...
+//!
+//!        WarpBitonicTopKT{}.TopK(thread_keys, CustomLess{}, 30);
+//!    }
+//!
+//! Suppose the set of input ``thread_keys`` across a warp of threads is
+//! ``{ [0,63], [1,62], [2,61], ..., [31,32] }``.
+//! The corresponding output ``thread_keys`` in those threads will be
+//! ``{ [0,?], [1,?], [2,?], ..., [29,?], [?,?], [?,?] }``.
+//! Note keys are in a :ref:`striped arrangement <flexible-data-arrangement>` across warp lanes.
+//!
+//! The code snippet below illustrates the iterator overload. The input ``keys_in`` points to ``num_items`` items.
+//! The top 30 items are selected.
+//!
+//! .. code-block:: c++
+//!
+//!    #include <cub/cub.cuh>  // or equivalently <cub/warp/warp_bitonic_topk.cuh>
+//!
+//!    __global__ void IteratorExampleKernel(const int* keys_in, int num_items)
+//!    {
+//!        constexpr int max_k = 32;
+//!
+//!        using WarpBitonicTopKT = cub::detail::WarpBitonicTopK<max_k, int>;
+//!        __shared__ typename WarpBitonicTopKT::TempStorage temp_storage;
+//!
+//!        int keys_out[max_k / 32];
+//!
+//!        WarpBitonicTopKT{temp_storage}.TopK(keys_in, CustomLess{}, 30, num_items, keys_out);
+//!    }
+//!
+//! Suppose the input ``keys_in`` is [0, 1, ..., 63],
+//! The output ``keys_out`` in a warp of threads will be
+//! ``{ [0,?], [1,?], [2,?], ..., [29,?], [?,?], [?,?] }``.
+//! Note keys are in a :ref:`striped arrangement <flexible-data-arrangement>` across warp lanes.
+//!
+//! @endrst
+//!
+//! @tparam MAX_K
+//!   The maximum number of selected items. Must be a multiple of the warp size.
+//!
+//! @tparam KeyT
+//!   Key type.
+//!
+//! @tparam ValueT
+//!   <b>[optional]</b> Value type (default: cub::NullType, which indicates keys-only top-k).
+template <int MAX_K, typename KeyT, typename ValueT = NullType>
+class WarpBitonicTopK
+{
+private:
+  static constexpr unsigned int FULL_WARP_MASK_ = 0xFFFFFFFFu;
+  static constexpr int WARP_THREADS_            = detail::warp_threads;
+  static_assert(MAX_K % WARP_THREADS_ == 0);
+  static constexpr int max_k_per_thread_ = MAX_K / WARP_THREADS_;
+  static constexpr bool KEYS_ONLY_       = ::cuda::std::is_same_v<ValueT, NullType>;
+
+  struct TempStorage_
+  {
+    KeyT keys[WARP_THREADS_];
+    ValueT values[WARP_THREADS_];
+  };
+
+public:
+  struct TempStorage : Uninitialized<TempStorage_>
+  {};
+
+  //! @brief Constructs a WarpBitonicTopK object without temporary storage.
+  //!
+  //! This constructor is intended for array overloads. Iterator overloads require temporary storage and must
+  //! use the constructor that accepts ``TempStorage``.
+  _CCCL_DEVICE _CCCL_FORCEINLINE WarpBitonicTopK()
+      : storage_(nullptr)
+  {}
+
+  //! @brief Constructs a WarpBitonicTopK object with temporary storage for iterator overloads.
+  //!
+  //! @param[in] temp_storage Warp-private temporary storage used to buffer candidates while processing iterator input.
+  explicit _CCCL_DEVICE _CCCL_FORCEINLINE WarpBitonicTopK(TempStorage& temp_storage)
+      : storage_(&temp_storage.Alias())
+  {}
+
+  //! @brief Selects top-k keys from per-thread arrays across a warp.
+  //!
+  //! @tparam ITEMS_PER_THREAD Number of keys per thread.
+  //! @tparam CompareOp Comparison functor type.
+  //!
+  //! @param[in,out] keys Keys in striped arrangement. On return, the first ``k`` striped positions contain the selected
+  //! top-k keys.
+  //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
+  //! @param[in] k Number of keys to select. Must not exceed ``MAX_K``.
+  template <int ITEMS_PER_THREAD, typename CompareOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void TopK(KeyT (&keys)[ITEMS_PER_THREAD], CompareOp compare_op, int k)
+  {
+    static_assert(KEYS_ONLY_);
+    ValueT values[ITEMS_PER_THREAD];
+    TopK(keys, values, compare_op, k);
+  }
+
+  //! @brief Selects top-k keys from partially valid per-thread arrays across a warp. An out-of-bound key ordered after
+  //! any valid key must be provided.
+  //!
+  //! @tparam ITEMS_PER_THREAD Number of keys per thread.
+  //! @tparam CompareOp Comparison functor type.
+  //!
+  //! @param[in,out] keys Keys in striped arrangement. On return, the first ``k`` striped positions contain the selected
+  //! top-k keys.
+  //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
+  //! @param[in] k Number of keys to select. Must not exceed ``MAX_K`` or ``num_items``.
+  //! @param[in] num_items Total number of valid keys across the warp.
+  //! @param[in] oob_default Default value for out-of-bound key.
+  template <int ITEMS_PER_THREAD, typename CompareOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void
+  TopK(KeyT (&keys)[ITEMS_PER_THREAD], CompareOp compare_op, int k, int num_items, KeyT oob_default)
+  {
+    static_assert(KEYS_ONLY_);
+    ValueT values[ITEMS_PER_THREAD];
+    TopK(keys, values, compare_op, k, num_items, oob_default);
+  }
+
+  //! @brief Selects top-k keys from partially valid per-thread arrays across a warp.
+  //!
+  //! @tparam ITEMS_PER_THREAD Number of keys per thread.
+  //! @tparam CompareOp Comparison functor type.
+  //!
+  //! @param[in,out] keys Keys in striped arrangement. On return, the first ``k`` striped positions contain the selected
+  //! top-k keys.
+  //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
+  //! @param[in] k Number of keys to select. Must not exceed ``MAX_K`` or ``num_items``.
+  //! @param[in] num_items Total number of valid keys across the warp.
+  template <int ITEMS_PER_THREAD, typename CompareOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void TopK(KeyT (&keys)[ITEMS_PER_THREAD], CompareOp compare_op, int k, int num_items)
+  {
+    static_assert(KEYS_ONLY_);
+    ValueT values[ITEMS_PER_THREAD];
+    TopK(keys, values, compare_op, k, num_items);
+  }
+
+  //! @brief Selects top-k key-value pairs from per-thread arrays across a warp.
+  //!
+  //! @tparam ITEMS_PER_THREAD Number of key-value pairs per thread.
+  //! @tparam CompareOp Comparison functor type.
+  //!
+  //! @param[in,out] keys Keys in striped arrangement. On return, the first ``k`` striped positions contain the selected
+  //! top-k keys.
+  //! @param[in,out] values Values selected together with their corresponding keys.
+  //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
+  //! @param[in] k Number of pairs to select. Must not exceed ``MAX_K``.
+  template <int ITEMS_PER_THREAD, typename CompareOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void
+  TopK(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], CompareOp compare_op, [[maybe_unused]] int k)
+  {
+    static_assert(ITEMS_PER_THREAD * WARP_THREADS_ >= MAX_K);
+
+    if constexpr (ITEMS_PER_THREAD * WARP_THREADS_ == MAX_K)
+    {
+      WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Sort_<CompareOp, false>(keys, values, compare_op);
+    }
+    else
+    {
+      // Due to a limitation of WarpBitonicSort::Merge_, when MAX_K is not a power of 2, the result must be
+      // reverse-sorted while merging incoming data, then reversed again at the end.
+      constexpr bool reverse = !::cuda::is_power_of_two(MAX_K);
+      WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Sort_<CompareOp, reverse>(keys, values, compare_op);
+
+      _CCCL_PRAGMA_UNROLL_FULL()
+      for (int i = 1; i < ITEMS_PER_THREAD / max_k_per_thread_; ++i)
+      {
+        int offset = max_k_per_thread_ * i;
+        WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Sort_<CompareOp, !reverse>(
+          keys + offset, values + offset, compare_op);
+        compare_and_replace_<max_k_per_thread_>(keys, values, keys + offset, values + offset, compare_op);
+        WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Merge_<CompareOp, reverse>(keys, values, compare_op);
+      }
+
+      if constexpr (constexpr int remain = ITEMS_PER_THREAD % max_k_per_thread_; remain != 0)
+      {
+        constexpr int offset = ITEMS_PER_THREAD / max_k_per_thread_ * max_k_per_thread_;
+        WarpBitonicSort<remain, KeyT, ValueT>::template Sort_<CompareOp, !reverse>(
+          keys + offset, values + offset, compare_op);
+        if constexpr (reverse)
+        {
+          compare_and_replace_<remain>(keys, values, keys + offset, values + offset, compare_op);
+        }
+        else
+        {
+          compare_and_replace_<remain>(
+            keys + max_k_per_thread_ - remain,
+            values + max_k_per_thread_ - remain,
+            keys + offset,
+            values + offset,
+            compare_op);
+        }
+        WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Merge_<CompareOp, reverse>(keys, values, compare_op);
+      }
+
+      if constexpr (reverse)
+      {
+        reverse_<max_k_per_thread_>(keys, values);
+      }
+    }
+  }
+
+  //! @brief Selects top-k key-value pairs from partially valid per-thread arrays across a warp. An out-of-bound key
+  //! ordered after any valid key must be provided.
+  //!
+  //! @tparam ITEMS_PER_THREAD Number of key-value pairs per thread.
+  //! @tparam CompareOp Comparison functor type.
+  //!
+  //! @param[in,out] keys Keys in striped arrangement. On return, the first ``k`` striped positions contain the selected
+  //! top-k keys.
+  //! @param[in,out] values Values selected together with their corresponding keys.
+  //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
+  //! @param[in] k Number of pairs to select. Must not exceed ``MAX_K`` or ``num_items``.
+  //! @param[in] num_items Total number of valid pairs across the warp.
+  //! @param[in] oob_default Default value for out-of-bound key.
+  template <int ITEMS_PER_THREAD, typename CompareOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void
+  TopK(KeyT (&keys)[ITEMS_PER_THREAD],
+       ValueT (&values)[ITEMS_PER_THREAD],
+       CompareOp compare_op,
+       int k,
+       int num_items,
+       KeyT oob_default)
+  {
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < ITEMS_PER_THREAD; ++i)
+    {
+      if (i * WARP_THREADS_ + lane_ >= num_items)
+      {
+        keys[i] = oob_default;
+      }
+    }
+    TopK(keys, values, compare_op, k);
+  }
+
+  //! @brief Selects top-k key-value pairs from partially valid arrays across a warp of threads.
+  //!
+  //! @tparam ITEMS_PER_THREAD Number of key-value pairs per thread.
+  //! @tparam CompareOp Comparison functor type.
+  //!
+  //! @param[in,out] keys Keys in striped arrangement. On return, the first ``k`` striped positions contain the selected
+  //! top-k keys.
+  //! @param[in,out] values Values selected together with their corresponding keys.
+  //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
+  //! @param[in] k Number of pairs to select. Must not exceed ``MAX_K`` or ``num_items``.
+  //! @param[in] num_items Total number of valid pairs across the warp.
+  template <int ITEMS_PER_THREAD, typename CompareOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void
+  TopK(KeyT (&keys)[ITEMS_PER_THREAD],
+       ValueT (&values)[ITEMS_PER_THREAD],
+       CompareOp compare_op,
+       [[maybe_unused]] int k,
+       int num_items)
+  {
+    static_assert(ITEMS_PER_THREAD * WARP_THREADS_ >= MAX_K);
+
+    if (num_items < MAX_K) // using "<=" is slower
+    {
+      WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Sort_<CompareOp, false>(
+        keys, values, compare_op, num_items);
+      return;
+    }
+
+    WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Sort_<CompareOp, true>(keys, values, compare_op);
+
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = max_k_per_thread_; i <= ITEMS_PER_THREAD - max_k_per_thread_; i += max_k_per_thread_)
+    {
+      const int remain_items = num_items - i * WARP_THREADS_;
+      if (remain_items >= MAX_K)
+      {
+        WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Sort_<CompareOp, false>(
+          keys + i, values + i, compare_op);
+        compare_and_replace_<max_k_per_thread_>(keys, values, keys + i, values + i, compare_op);
+        WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Merge_<CompareOp, true>(keys, values, compare_op);
+      }
+      else if (remain_items > 0)
+      {
+        WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Sort_<CompareOp, false>(
+          keys + i, values + i, compare_op, remain_items);
+        compare_and_replace_<max_k_per_thread_>(keys, values, keys + i, values + i, compare_op, remain_items);
+        WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Merge_<CompareOp, true>(keys, values, compare_op);
+        reverse_<max_k_per_thread_>(keys, values);
+        return;
+      }
+    }
+
+    if constexpr (constexpr int remain = ITEMS_PER_THREAD % max_k_per_thread_; remain != 0)
+    {
+      constexpr int offset   = ITEMS_PER_THREAD / max_k_per_thread_ * max_k_per_thread_;
+      const int remain_items = num_items - offset * WARP_THREADS_;
+      if (remain_items > 0)
+      {
+        WarpBitonicSort<remain, KeyT, ValueT>::template Sort_<CompareOp, false>(
+          keys + offset, values + offset, compare_op, remain_items);
+        compare_and_replace_<remain>(keys, values, keys + offset, values + offset, compare_op, remain_items);
+        WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Merge_<CompareOp, true>(keys, values, compare_op);
+      }
+    }
+
+    reverse_<max_k_per_thread_>(keys, values);
+  }
+
+  //! @brief Selects top-k key-value pairs from iterator input.
+  //!
+  //! This overload can process arbitrary-length input and requires the object to be constructed with ``TempStorage``.
+  //!
+  //! @tparam KeyInputIteratorT Random-access iterator type for input keys.
+  //! @tparam ValueInputIteratorT Random-access iterator type for input values.
+  //! @tparam CompareOp Comparison functor type.
+  //!
+  //! @param[in] keys_in Iterator pointing to the first input key.
+  //! @param[in] values_in Iterator pointing to the first input value.
+  //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
+  //! @param[in] k Number of pairs to select. Must not exceed ``MAX_K`` or ``num_items``.
+  //! @param[in] num_items Number of input pairs.
+  //! @param[out] keys_out Selected keys in striped arrangement.
+  //! @param[out] values_out Values selected together with their corresponding keys.
+  template <typename KeyInputIteratorT, typename ValueInputIteratorT, typename CompareOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void
+  TopK(KeyInputIteratorT keys_in,
+       ValueInputIteratorT values_in,
+       CompareOp compare_op,
+       int k,
+       int num_items,
+       KeyT (&keys_out)[MAX_K / detail::warp_threads],
+       ValueT (&values_out)[MAX_K / detail::warp_threads])
+  {
+    const int k_th_pos  = MAX_K - k;
+    const int k_th_item = k_th_pos / WARP_THREADS_;
+    const int k_th_lane = k_th_pos % WARP_THREADS_;
+
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < max_k_per_thread_; ++i)
+    {
+      int pos = i * WARP_THREADS_ + lane_;
+      if (pos < num_items)
+      {
+        keys_out[i] = keys_in[pos];
+        if constexpr (!KEYS_ONLY_)
+        {
+          values_out[i] = values_in[pos];
+        }
+      }
+    }
+
+    if (num_items <= MAX_K)
+    {
+      WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Sort_<CompareOp, false>(
+        keys_out, values_out, compare_op, num_items);
+      return;
+    }
+
+    WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Sort_<CompareOp, true>(keys_out, values_out, compare_op);
+    KeyT k_th          = get_key_threshold_(keys_out, k_th_item, k_th_lane);
+    int num_candidates = 0;
+
+    const int num_items_per_thread = (num_items + WARP_THREADS_ - 1) / WARP_THREADS_;
+    for (int i = max_k_per_thread_; i < num_items_per_thread; ++i)
+    {
+      int pos = i * WARP_THREADS_ + lane_;
+      KeyT key;
+      ValueT value;
+      bool is_candidate = false;
+      if (pos < num_items)
+      {
+        key = keys_in[pos];
+        if constexpr (!KEYS_ONLY_)
+        {
+          value = values_in[pos];
+        }
+        is_candidate = true;
+      }
+      process_candidate_(
+        keys_out, values_out, key, value, compare_op, is_candidate, k_th_item, k_th_lane, k_th, num_candidates);
+    }
+    flush_candidates_(keys_out, values_out, compare_op, num_candidates);
+    reverse_<max_k_per_thread_>(keys_out, values_out);
+  }
+
+  //! @brief Selects top-k keys from iterator input.
+  //!
+  //! This overload can process arbitrary-length input and requires the object to be constructed with ``TempStorage``.
+  //!
+  //! @tparam KeyInputIteratorT Random-access iterator type for input keys.
+  //! @tparam CompareOp Comparison functor type.
+  //!
+  //! @param[in] keys_in Iterator pointing to the first input key.
+  //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
+  //! @param[in] k Number of keys to select. Must not exceed ``MAX_K`` or ``num_items``.
+  //! @param[in] num_items Number of input keys.
+  //! @param[out] keys_out Selected keys in striped arrangement.
+  template <typename KeyInputIteratorT, typename CompareOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void
+  TopK(KeyInputIteratorT keys_in,
+       CompareOp compare_op,
+       int k,
+       int num_items,
+       KeyT (&keys_out)[MAX_K / detail::warp_threads])
+  {
+    static_assert(KEYS_ONLY_);
+    ValueT values_out[max_k_per_thread_];
+    TopK(keys_in, nullptr, compare_op, k, num_items, keys_out, values_out);
+  }
+
+private:
+  template <int LEN, typename CompareOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void compare_and_replace_(
+    KeyT* __restrict__ keys1,
+    ValueT* __restrict__ values1,
+    const KeyT* __restrict__ keys2,
+    const ValueT* __restrict__ values2,
+    CompareOp compare_op)
+  {
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < LEN; ++i)
+    {
+      if (compare_op(keys2[i], keys1[i]))
+      {
+        keys1[i] = keys2[i];
+        if constexpr (!KEYS_ONLY_)
+        {
+          values1[i] = values2[i];
+        }
+      }
+    }
+  }
+
+  template <int LEN, typename CompareOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void compare_and_replace_(
+    KeyT* __restrict__ keys1,
+    ValueT* __restrict__ values1,
+    const KeyT* __restrict__ keys2,
+    const ValueT* __restrict__ values2,
+    CompareOp compare_op,
+    int num_items2)
+  {
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < LEN; ++i)
+    {
+      if (i * WARP_THREADS_ + lane_ < num_items2 && compare_op(keys2[i], keys1[i]))
+      {
+        keys1[i] = keys2[i];
+        if constexpr (!KEYS_ONLY_)
+        {
+          values1[i] = values2[i];
+        }
+      }
+    }
+  }
+
+  template <int LEN>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void reverse_(KeyT* __restrict__ keys, ValueT* __restrict__ values)
+  {
+    const int src_lane = WARP_THREADS_ - lane_ - 1;
+
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < LEN / 2; ++i)
+    {
+      const int other_i = LEN - i - 1;
+
+      KeyT key      = keys[i];
+      keys[i]       = keys[other_i];
+      keys[other_i] = key;
+
+      if constexpr (!KEYS_ONLY_)
+      {
+        ValueT value    = values[i];
+        values[i]       = values[other_i];
+        values[other_i] = value;
+      }
+    }
+
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < LEN; ++i)
+    {
+      keys[i] = shuffle_idx_(keys[i], src_lane);
+      if constexpr (!KEYS_ONLY_)
+      {
+        values[i] = shuffle_idx_(values[i], src_lane);
+      }
+    }
+  }
+
+  template <typename T>
+  _CCCL_DEVICE _CCCL_FORCEINLINE static T shuffle_idx_(const T& value, int src_lane)
+  {
+    if constexpr (has_native_shfl_v<T>)
+    {
+      return __shfl_sync(FULL_WARP_MASK_, value, src_lane);
+    }
+    else
+    {
+      return ::cuda::device::warp_shuffle_idx(value, src_lane);
+    }
+  }
+
+  template <typename CompareOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void process_candidate_(
+    KeyT (&keys_out)[MAX_K / detail::warp_threads],
+    ValueT (&values_out)[MAX_K / detail::warp_threads],
+    const KeyT& key,
+    const ValueT& value,
+    CompareOp compare_op,
+    bool is_candidate,
+    int k_th_item,
+    int k_th_lane,
+    KeyT& k_th,
+    int& num_candidates)
+  {
+    TempStorage_& storage = *storage_;
+    is_candidate          = is_candidate && compare_op(key, k_th);
+    uint32_t mask         = __ballot_sync(FULL_WARP_MASK_, is_candidate);
+    if (mask == 0)
+    {
+      return;
+    }
+
+    int pos = num_candidates + __popc(mask & ((0x1u << lane_) - 1));
+    if (is_candidate && pos < WARP_THREADS_)
+    {
+      storage.keys[pos] = key;
+      if constexpr (!KEYS_ONLY_)
+      {
+        storage.values[pos] = value;
+      }
+      is_candidate = false;
+    }
+    num_candidates += __popc(mask);
+    if (num_candidates >= WARP_THREADS_)
+    {
+      __syncwarp();
+      ValueT value;
+      if constexpr (!KEYS_ONLY_)
+      {
+        value = storage.values[lane_];
+      }
+      merge_candidates_(keys_out, values_out, storage.keys[lane_], value, compare_op);
+      k_th = get_key_threshold_(keys_out, k_th_item, k_th_lane);
+      num_candidates -= WARP_THREADS_;
+    }
+    if (is_candidate)
+    {
+      pos -= WARP_THREADS_;
+      storage.keys[pos] = key;
+      if constexpr (!KEYS_ONLY_)
+      {
+        storage.values[pos] = value;
+      }
+    }
+    __syncwarp();
+  }
+
+  template <typename CompareOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void flush_candidates_(
+    KeyT (&keys_out)[MAX_K / detail::warp_threads],
+    ValueT (&values_out)[MAX_K / detail::warp_threads],
+    CompareOp compare_op,
+    int num_candidates)
+  {
+    if (num_candidates)
+    {
+      TempStorage_& storage = *storage_;
+      KeyT key              = (lane_ < num_candidates) ? storage.keys[lane_] : KeyT{};
+      ValueT value{};
+      if constexpr (!KEYS_ONLY_)
+      {
+        value = (lane_ < num_candidates) ? storage.values[lane_] : ValueT{};
+      }
+      merge_candidates_(keys_out, values_out, key, value, compare_op, num_candidates);
+    }
+  }
+
+  template <typename CompareOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void merge_candidates_(
+    KeyT (&keys_out)[MAX_K / detail::warp_threads],
+    ValueT (&values_out)[MAX_K / detail::warp_threads],
+    KeyT key,
+    ValueT value,
+    CompareOp compare_op)
+  {
+    WarpBitonicSort<1, KeyT, ValueT>::template Sort_<CompareOp, false>(&key, &value, compare_op);
+
+    compare_and_replace_<1>(keys_out, values_out, &key, &value, compare_op);
+
+    WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Merge_<CompareOp, true>(keys_out, values_out, compare_op);
+  }
+
+  template <typename CompareOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void merge_candidates_(
+    KeyT (&keys_out)[MAX_K / detail::warp_threads],
+    ValueT (&values_out)[MAX_K / detail::warp_threads],
+    KeyT key,
+    ValueT value,
+    CompareOp compare_op,
+    int len)
+  {
+    WarpBitonicSort<1, KeyT, ValueT>::template Sort_<CompareOp, false>(&key, &value, compare_op, len);
+
+    compare_and_replace_<1>(keys_out, values_out, &key, &value, compare_op, len);
+
+    WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Merge_<CompareOp, true>(keys_out, values_out, compare_op);
+  }
+
+  _CCCL_DEVICE _CCCL_FORCEINLINE KeyT
+  get_key_threshold_(KeyT (&keys_out)[MAX_K / detail::warp_threads], int k_th_item, int k_th_lane)
+  {
+    return shuffle_idx_(keys_out[k_th_item], k_th_lane);
+  }
+
+  TempStorage_* storage_;
+  int lane_ = threadIdx.x % WARP_THREADS_;
+};
+} // namespace detail
+
+CUB_NAMESPACE_END

--- a/cub/cub/warp/warp_bitonic_topk.cuh
+++ b/cub/cub/warp/warp_bitonic_topk.cuh
@@ -14,8 +14,10 @@
 #endif // no system header
 
 #include <cub/util_arch.cuh>
+#include <cub/util_ptx.cuh>
 #include <cub/util_type.cuh>
 #include <cub/warp/warp_bitonic_sort.cuh>
+#include <cub/warp/warp_utils.cuh>
 
 #include <cuda/__cmath/pow2.h>
 #include <cuda/__warp/warp_shuffle.h>
@@ -28,8 +30,6 @@ namespace detail
 {
 namespace warp_bitonic_topk
 {
-inline constexpr unsigned int full_warp_mask = 0xFFFFFFFFu;
-
 template <int Len, typename KeyT, typename ValueT, typename CompareOp>
 _CCCL_DEVICE _CCCL_FORCEINLINE void
 compare_and_replace(KeyT* keys1, ValueT* values1, const KeyT* keys2, const ValueT* values2, CompareOp compare_op)
@@ -48,14 +48,14 @@ compare_and_replace(KeyT* keys1, ValueT* values1, const KeyT* keys2, const Value
   }
 }
 
-template <int Len, typename KeyT, typename ValueT, typename CompareOp>
+template <int Len, int LogicalWarpThreads, typename KeyT, typename ValueT, typename CompareOp>
 _CCCL_DEVICE _CCCL_FORCEINLINE void compare_and_replace(
   KeyT* keys1, ValueT* values1, const KeyT* keys2, const ValueT* values2, CompareOp compare_op, int num_items2, int lane)
 {
   _CCCL_PRAGMA_UNROLL_FULL()
   for (int i = 0; i < Len; ++i)
   {
-    if (i * detail::warp_threads + lane < num_items2 && compare_op(keys2[i], keys1[i]))
+    if (i * LogicalWarpThreads + lane < num_items2 && compare_op(keys2[i], keys1[i]))
     {
       keys1[i] = keys2[i];
       if constexpr (!::cuda::std::is_same_v<ValueT, NullType>)
@@ -66,23 +66,10 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void compare_and_replace(
   }
 }
 
-template <typename T>
-[[nodiscard]] _CCCL_DEVICE _CCCL_FORCEINLINE T shuffle_idx(const T& value, int src_lane)
+template <int Len, int LogicalWarpThreads, typename KeyT, typename ValueT>
+_CCCL_DEVICE _CCCL_FORCEINLINE void reverse_items(KeyT* keys, ValueT* values, int lane, unsigned int member_mask)
 {
-  if constexpr (has_native_shfl_v<T>)
-  {
-    return __shfl_sync(full_warp_mask, value, src_lane);
-  }
-  else
-  {
-    return ::cuda::device::warp_shuffle_idx(value, src_lane);
-  }
-}
-
-template <int Len, typename KeyT, typename ValueT>
-_CCCL_DEVICE _CCCL_FORCEINLINE void reverse_items(KeyT* keys, ValueT* values, int lane)
-{
-  const int src_lane = detail::warp_threads - lane - 1;
+  const int src_lane = LogicalWarpThreads - lane - 1;
 
   _CCCL_PRAGMA_UNROLL_FULL()
   for (int i = 0; i < Len / 2; ++i)
@@ -104,10 +91,10 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void reverse_items(KeyT* keys, ValueT* values, in
   _CCCL_PRAGMA_UNROLL_FULL()
   for (int i = 0; i < Len; ++i)
   {
-    keys[i] = shuffle_idx(keys[i], src_lane);
+    keys[i] = ::cuda::device::warp_shuffle_idx<LogicalWarpThreads>(keys[i], src_lane, member_mask);
     if constexpr (!::cuda::std::is_same_v<ValueT, NullType>)
     {
-      values[i] = shuffle_idx(values[i], src_lane);
+      values[i] = ::cuda::device::warp_shuffle_idx<LogicalWarpThreads>(values[i], src_lane, member_mask);
     }
   }
 }
@@ -125,11 +112,12 @@ enum class WarpBitonicTopKAlgorithm
 template <int MaxK,
           typename KeyT,
           typename ValueT                    = NullType,
-          WarpBitonicTopKAlgorithm Algorithm = WarpBitonicTopKAlgorithm::eager>
+          WarpBitonicTopKAlgorithm Algorithm = WarpBitonicTopKAlgorithm::eager,
+          int LogicalWarpThreads             = detail::warp_threads>
 class WarpBitonicTopK;
 
 //! @rst
-//! The WarpBitonicTopK class provides methods for selecting top-k items from data partitioned across a CUDA warp.
+//! The WarpBitonicTopK class provides methods for selecting top-k items from data partitioned across a logical warp.
 //!
 //! Overview
 //! ++++++++++++++++
@@ -137,7 +125,7 @@ class WarpBitonicTopK;
 //!   WarpBitonicTopK selects the ``k`` items ordered first by a comparison functor with less-than semantics.
 //!
 //!   The TopK functions operate on items already held by each lane or read arbitrary-length input through random-access
-//!   iterators in array-sized tiles. Output items use a striped arrangement across warp lanes.
+//!   iterators in array-sized tiles. Output items use a striped arrangement across logical warp lanes.
 //!
 //! Simple Examples
 //! ++++++++++++++++
@@ -172,33 +160,39 @@ class WarpBitonicTopK;
 //!        WarpBitonicTopKT{temp_storage}.TopK(thread_keys, CustomLess{}, 30);
 //!    }
 //!
-//! Suppose the set of input ``thread_keys`` across a warp of threads is
+//! Suppose the set of input ``thread_keys`` across a logical warp of threads is
 //! ``{ [0,63], [1,62], [2,61], ..., [31,32] }``.
 //! The corresponding output ``thread_keys`` in those threads will be
 //! ``{ [0,?], [1,?], [2,?], ..., [29,?], [?,?], [?,?] }``.
-//! Note keys are in a :ref:`striped arrangement <flexible-data-arrangement>` across warp lanes.
+//! Note keys are in a :ref:`striped arrangement <flexible-data-arrangement>` across logical warp lanes.
 //!
 //! @endrst
 //!
 //! @tparam MaxK
-//!   The maximum number of selected items. Must be a multiple of the warp size.
+//!   The maximum number of selected items. Must be a multiple of the logical warp size.
 //!
 //! @tparam KeyT
 //!   Key type.
 //!
 //! @tparam ValueT
 //!   <b>[optional]</b> Value type (default: cub::NullType, which indicates keys-only top-k).
-template <int MaxK, typename KeyT, typename ValueT>
-class WarpBitonicTopK<MaxK, KeyT, ValueT, WarpBitonicTopKAlgorithm::eager>
+//!
+//! @tparam LogicalWarpThreads
+//!   <b>[optional]</b> Number of threads per logical warp. Must be a power of two no greater than the architectural
+//!   warp size.
+template <int MaxK, typename KeyT, typename ValueT, int LogicalWarpThreads>
+class WarpBitonicTopK<MaxK, KeyT, ValueT, WarpBitonicTopKAlgorithm::eager, LogicalWarpThreads>
 {
 private:
-  static constexpr int warp_threads = detail::warp_threads;
-  static_assert(MaxK % warp_threads == 0);
-  static constexpr int max_k_per_thread = MaxK / warp_threads;
+  static_assert(detail::is_valid_logical_warp_size_v<LogicalWarpThreads>,
+                "LogicalWarpThreads must not exceed the architectural warp size");
+  static_assert(::cuda::is_power_of_two(LogicalWarpThreads), "LogicalWarpThreads must be a power of two");
+  static_assert(MaxK % LogicalWarpThreads == 0, "MaxK must be a multiple of LogicalWarpThreads");
+  static constexpr int max_k_per_thread = MaxK / LogicalWarpThreads;
   static constexpr bool keys_only       = ::cuda::std::is_same_v<ValueT, NullType>;
 
   template <int ItemsPerThread>
-  using WarpBitonicSortT = WarpBitonicSort<KeyT, ItemsPerThread, warp_threads, ValueT>;
+  using WarpBitonicSortT = WarpBitonicSort<KeyT, ItemsPerThread, LogicalWarpThreads, ValueT>;
 
   using MaxKSortT    = WarpBitonicSortT<max_k_per_thread>;
   using _TempStorage = cub::NullType;
@@ -212,7 +206,7 @@ public:
   //! @param[in] temp_storage Temporary storage.
   explicit _CCCL_DEVICE_API _CCCL_FORCEINLINE WarpBitonicTopK(TempStorage&) {}
 
-  //! @brief Selects top-k keys from per-thread arrays across a warp.
+  //! @brief Selects top-k keys from per-thread arrays across a logical warp.
   //!
   //! @tparam ItemsPerThread Number of keys per thread.
   //! @tparam CompareOp Comparison functor type.
@@ -229,8 +223,8 @@ public:
     TopK(keys, values, compare_op, k);
   }
 
-  //! @brief Selects top-k keys from partially valid per-thread arrays across a warp. An out-of-bound key ordered after
-  //! any valid key must be provided.
+  //! @brief Selects top-k keys from partially valid per-thread arrays across a logical warp. An out-of-bound key
+  //! ordered after any valid key must be provided.
   //!
   //! @tparam ItemsPerThread Number of keys per thread.
   //! @tparam CompareOp Comparison functor type.
@@ -239,7 +233,7 @@ public:
   //! top-k keys.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
   //! @param[in] k Number of keys to select. Must not exceed ``MaxK`` or ``num_items``.
-  //! @param[in] num_items Total number of valid keys across the warp.
+  //! @param[in] num_items Total number of valid keys across the logical warp.
   //! @param[in] oob_default Default value for out-of-bound key.
   template <int ItemsPerThread, typename CompareOp>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void
@@ -250,7 +244,7 @@ public:
     TopK(keys, values, compare_op, k, num_items, oob_default);
   }
 
-  //! @brief Selects top-k keys from partially valid per-thread arrays across a warp.
+  //! @brief Selects top-k keys from partially valid per-thread arrays across a logical warp.
   //!
   //! @tparam ItemsPerThread Number of keys per thread.
   //! @tparam CompareOp Comparison functor type.
@@ -259,7 +253,7 @@ public:
   //! top-k keys.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
   //! @param[in] k Number of keys to select. Must not exceed ``MaxK`` or ``num_items``.
-  //! @param[in] num_items Total number of valid keys across the warp.
+  //! @param[in] num_items Total number of valid keys across the logical warp.
   template <int ItemsPerThread, typename CompareOp>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void
   TopK(KeyT (&keys)[ItemsPerThread], CompareOp compare_op, int k, int num_items) const
@@ -269,7 +263,7 @@ public:
     TopK(keys, values, compare_op, k, num_items);
   }
 
-  //! @brief Selects top-k key-value pairs from per-thread arrays across a warp.
+  //! @brief Selects top-k key-value pairs from per-thread arrays across a logical warp.
   //!
   //! @tparam ItemsPerThread Number of key-value pairs per thread.
   //! @tparam CompareOp Comparison functor type.
@@ -283,9 +277,9 @@ public:
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void TopK(
     KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread], CompareOp compare_op, [[maybe_unused]] int k) const
   {
-    static_assert(ItemsPerThread * warp_threads >= MaxK);
+    static_assert(ItemsPerThread * LogicalWarpThreads >= MaxK);
 
-    if constexpr (ItemsPerThread * warp_threads == MaxK)
+    if constexpr (ItemsPerThread * LogicalWarpThreads == MaxK)
     {
       MaxKSortT{}.template sort<CompareOp, false>(keys, values, compare_op);
     }
@@ -328,13 +322,13 @@ public:
 
       if constexpr (reverse)
       {
-        warp_bitonic_topk::reverse_items<max_k_per_thread>(keys, values, lane);
+        warp_bitonic_topk::reverse_items<max_k_per_thread, LogicalWarpThreads>(keys, values, lane, member_mask);
       }
     }
   }
 
-  //! @brief Selects top-k key-value pairs from partially valid per-thread arrays across a warp. An out-of-bound key
-  //! ordered after any valid key must be provided.
+  //! @brief Selects top-k key-value pairs from partially valid per-thread arrays across a logical warp. An out-of-bound
+  //! key ordered after any valid key must be provided.
   //!
   //! @tparam ItemsPerThread Number of key-value pairs per thread.
   //! @tparam CompareOp Comparison functor type.
@@ -344,7 +338,7 @@ public:
   //! @param[in,out] values Values selected together with their corresponding keys.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
   //! @param[in] k Number of pairs to select. Must not exceed ``MaxK`` or ``num_items``.
-  //! @param[in] num_items Total number of valid pairs across the warp.
+  //! @param[in] num_items Total number of valid pairs across the logical warp.
   //! @param[in] oob_default Default value for out-of-bound key.
   template <int ItemsPerThread, typename CompareOp>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void
@@ -358,7 +352,7 @@ public:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < ItemsPerThread; ++i)
     {
-      if (i * warp_threads + lane >= num_items)
+      if (i * LogicalWarpThreads + lane >= num_items)
       {
         keys[i] = oob_default;
       }
@@ -366,7 +360,7 @@ public:
     TopK(keys, values, compare_op, k);
   }
 
-  //! @brief Selects top-k key-value pairs from partially valid arrays across a warp of threads.
+  //! @brief Selects top-k key-value pairs from partially valid arrays across a logical warp of threads.
   //!
   //! @tparam ItemsPerThread Number of key-value pairs per thread.
   //! @tparam CompareOp Comparison functor type.
@@ -376,7 +370,7 @@ public:
   //! @param[in,out] values Values selected together with their corresponding keys.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
   //! @param[in] k Number of pairs to select. Must not exceed ``MaxK`` or ``num_items``.
-  //! @param[in] num_items Total number of valid pairs across the warp.
+  //! @param[in] num_items Total number of valid pairs across the logical warp.
   template <int ItemsPerThread, typename CompareOp>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void
   TopK(KeyT (&keys)[ItemsPerThread],
@@ -385,7 +379,7 @@ public:
        [[maybe_unused]] int k,
        int num_items) const
   {
-    static_assert(ItemsPerThread * warp_threads >= MaxK);
+    static_assert(ItemsPerThread * LogicalWarpThreads >= MaxK);
 
     if (num_items < MaxK) // using "<=" is slower
     {
@@ -398,7 +392,7 @@ public:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = max_k_per_thread; i <= ItemsPerThread - max_k_per_thread; i += max_k_per_thread)
     {
-      const int remain_items = num_items - i * warp_threads;
+      const int remain_items = num_items - i * LogicalWarpThreads;
       if (remain_items >= MaxK)
       {
         MaxKSortT{}.template sort<CompareOp, false>(keys + i, values + i, compare_op);
@@ -408,10 +402,10 @@ public:
       else if (remain_items > 0)
       {
         MaxKSortT{}.template sort<CompareOp, false>(keys + i, values + i, compare_op, remain_items);
-        warp_bitonic_topk::compare_and_replace<max_k_per_thread>(
+        warp_bitonic_topk::compare_and_replace<max_k_per_thread, LogicalWarpThreads>(
           keys, values, keys + i, values + i, compare_op, remain_items, lane);
         MaxKSortT{}.template merge<CompareOp, true>(keys, values, compare_op);
-        warp_bitonic_topk::reverse_items<max_k_per_thread>(keys, values, lane);
+        warp_bitonic_topk::reverse_items<max_k_per_thread, LogicalWarpThreads>(keys, values, lane, member_mask);
         return;
       }
     }
@@ -419,18 +413,18 @@ public:
     if constexpr (constexpr int remain = ItemsPerThread % max_k_per_thread; remain != 0)
     {
       constexpr int offset   = ItemsPerThread / max_k_per_thread * max_k_per_thread;
-      const int remain_items = num_items - offset * warp_threads;
+      const int remain_items = num_items - offset * LogicalWarpThreads;
       if (remain_items > 0)
       {
         WarpBitonicSortT<remain>{}.template sort<CompareOp, false>(
           keys + offset, values + offset, compare_op, remain_items);
-        warp_bitonic_topk::compare_and_replace<remain>(
+        warp_bitonic_topk::compare_and_replace<remain, LogicalWarpThreads>(
           keys, values, keys + offset, values + offset, compare_op, remain_items, lane);
         MaxKSortT{}.template merge<CompareOp, true>(keys, values, compare_op);
       }
     }
 
-    warp_bitonic_topk::reverse_items<max_k_per_thread>(keys, values, lane);
+    warp_bitonic_topk::reverse_items<max_k_per_thread, LogicalWarpThreads>(keys, values, lane, member_mask);
   }
 
   //! @brief Selects top-k key-value pairs from arbitrary-length iterator input using array tiles.
@@ -439,8 +433,10 @@ public:
   //! @tparam ValueInputIteratorT Random-access iterator type for input values.
   //! @tparam CompareOp Comparison functor type.
   //!
-  //! @param[in] keys_in Iterator pointing to the first input key.
-  //! @param[in] values_in Iterator pointing to the first input value.
+  //! @param[in] keys_in Iterator pointing to the first input key of a logical warp. All lanes in a logical warp should
+  //! pass the same iterator.
+  //! @param[in] values_in Iterator pointing to the first input value of a logical warp. All lanes in a logical warp
+  //! should pass the same iterator.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
   //! @param[in] k Number of pairs to select. Must not exceed ``MaxK`` or ``num_items``.
   //! @param[in] num_items Number of input pairs.
@@ -453,11 +449,11 @@ public:
        CompareOp compare_op,
        int k,
        int num_items,
-       KeyT (&keys_out)[MaxK / detail::warp_threads],
-       ValueT (&values_out)[MaxK / detail::warp_threads]) const
+       KeyT (&keys_out)[MaxK / LogicalWarpThreads],
+       ValueT (&values_out)[MaxK / LogicalWarpThreads]) const
   {
     constexpr int tile_items_per_thread = 2 * max_k_per_thread;
-    constexpr int tile_items            = tile_items_per_thread * warp_threads;
+    constexpr int tile_items            = tile_items_per_thread * LogicalWarpThreads;
     KeyT keys[tile_items_per_thread];
     ValueT values[tile_items_per_thread];
 
@@ -465,7 +461,7 @@ public:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < tile_items_per_thread; ++i)
     {
-      const int pos = i * warp_threads + lane;
+      const int pos = i * LogicalWarpThreads + lane;
       if (pos < first_tile_items)
       {
         keys[i] = keys_in[pos];
@@ -483,7 +479,7 @@ public:
       _CCCL_PRAGMA_UNROLL_FULL()
       for (int i = 0; i < max_k_per_thread; ++i)
       {
-        const int pos = i * warp_threads + lane;
+        const int pos = i * LogicalWarpThreads + lane;
         if (pos < incoming_items)
         {
           keys[max_k_per_thread + i] = keys_in[offset + pos];
@@ -500,7 +496,7 @@ public:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < max_k_per_thread; ++i)
     {
-      if (i * warp_threads + lane < output_items)
+      if (i * LogicalWarpThreads + lane < output_items)
       {
         keys_out[i] = keys[i];
         if constexpr (!keys_only)
@@ -516,18 +512,19 @@ public:
   //! @tparam KeyInputIteratorT Random-access iterator type for input keys.
   //! @tparam CompareOp Comparison functor type.
   //!
-  //! @param[in] keys_in Iterator pointing to the first input key.
+  //! @param[in] keys_in Iterator pointing to the first input key of a logical warp. All lanes in a logical warp should
+  //! pass the same iterator.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
   //! @param[in] k Number of keys to select. Must not exceed ``MaxK`` or ``num_items``.
   //! @param[in] num_items Number of input keys.
   //! @param[out] keys_out Selected keys in striped arrangement.
   template <typename KeyInputIteratorT, typename CompareOp>
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE void TopK(
-    KeyInputIteratorT keys_in,
-    CompareOp compare_op,
-    int k,
-    int num_items,
-    KeyT (&keys_out)[MaxK / detail::warp_threads]) const
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
+  TopK(KeyInputIteratorT keys_in,
+       CompareOp compare_op,
+       int k,
+       int num_items,
+       KeyT (&keys_out)[MaxK / LogicalWarpThreads]) const
   {
     static_assert(keys_only);
     ValueT values_out[max_k_per_thread];
@@ -535,19 +532,20 @@ public:
   }
 
 private:
-  int lane = static_cast<int>(::cuda::ptx::get_sreg_laneid());
+  int lane                 = detail::logical_lane_id<LogicalWarpThreads>();
+  unsigned int member_mask = WarpMask<LogicalWarpThreads>(detail::logical_warp_id<LogicalWarpThreads>());
 };
 
 //! @rst
-//! The buffered WarpBitonicTopK specialization selects top-k items from arrays or arbitrary-length iterator input across
-//! a CUDA warp.
+//! The buffered WarpBitonicTopK specialization selects top-k items from arrays or arbitrary-length iterator input
+//! across a logical warp.
 //!
 //! Overview
 //! ++++++++++++++++
 //!
 //!   The buffered WarpBitonicTopK specialization initializes a retained top-k set from per-thread arrays or
 //!   random-access iterators, buffers candidates that pass the current key threshold, and merges them into the retained
-//!   set. Input and output items use a striped arrangement across warp lanes.
+//!   set. Input and output items use a striped arrangement across logical warp lanes.
 //!
 //! Simple Example
 //! ++++++++++++++
@@ -571,39 +569,45 @@ private:
 //!        WarpBitonicTopKT{temp_storage}.TopK(keys_in, CustomLess{}, 30, num_items, keys_out);
 //!    }
 //!
-//! Suppose the input ``keys_in`` is [0, 1, ..., 63]. The output ``keys_out`` in a warp of threads will be
+//! Suppose the input ``keys_in`` is [0, 1, ..., 63]. The output ``keys_out`` in a logical warp of threads will be
 //! ``{ [0,?], [1,?], [2,?], ..., [29,?], [?,?], [?,?] }``.
-//! Note keys are in a :ref:`striped arrangement <flexible-data-arrangement>` across warp lanes.
+//! Note keys are in a :ref:`striped arrangement <flexible-data-arrangement>` across logical warp lanes.
 //!
 //! @endrst
 //!
 //! @tparam MaxK
-//!   The maximum number of selected items. Must be a multiple of the warp size.
+//!   The maximum number of selected items. Must be a multiple of the logical warp size.
 //!
 //! @tparam KeyT
 //!   Key type.
 //!
 //! @tparam ValueT
 //!   <b>[optional]</b> Value type (default: cub::NullType, which indicates keys-only top-k).
-template <int MaxK, typename KeyT, typename ValueT>
-class WarpBitonicTopK<MaxK, KeyT, ValueT, WarpBitonicTopKAlgorithm::buffered>
+//!
+//! @tparam LogicalWarpThreads
+//!   <b>[optional]</b> Number of threads per logical warp. Must be a power of two no greater than the architectural
+//!   warp size.
+template <int MaxK, typename KeyT, typename ValueT, int LogicalWarpThreads>
+class WarpBitonicTopK<MaxK, KeyT, ValueT, WarpBitonicTopKAlgorithm::buffered, LogicalWarpThreads>
 {
 private:
-  static constexpr int warp_threads = detail::warp_threads;
-  static_assert(MaxK % warp_threads == 0);
-  static constexpr int max_k_per_thread = MaxK / warp_threads;
+  static_assert(detail::is_valid_logical_warp_size_v<LogicalWarpThreads>,
+                "LogicalWarpThreads must not exceed the architectural warp size");
+  static_assert(::cuda::is_power_of_two(LogicalWarpThreads), "LogicalWarpThreads must be a power of two");
+  static_assert(MaxK % LogicalWarpThreads == 0, "MaxK must be a multiple of LogicalWarpThreads");
+  static constexpr int max_k_per_thread = MaxK / LogicalWarpThreads;
   static constexpr bool keys_only       = ::cuda::std::is_same_v<ValueT, NullType>;
 
   template <int ItemsPerThread>
-  using WarpBitonicSortT = WarpBitonicSort<KeyT, ItemsPerThread, warp_threads, ValueT>;
+  using WarpBitonicSortT = WarpBitonicSort<KeyT, ItemsPerThread, LogicalWarpThreads, ValueT>;
 
   using MaxKSortT      = WarpBitonicSortT<max_k_per_thread>;
   using CandidateSortT = WarpBitonicSortT<1>;
 
   struct _TempStorage
   {
-    KeyT keys[warp_threads];
-    ValueT values[warp_threads];
+    KeyT keys[LogicalWarpThreads];
+    ValueT values[LogicalWarpThreads];
   };
 
 public:
@@ -612,7 +616,7 @@ public:
 
   //! @brief Constructs a WarpBitonicTopK object.
   //!
-  //! @param[in] temp_storage Warp-private temporary storage used to buffer candidates while processing iterator input.
+  //! @param[in] temp_storage Logical-warp-private temporary storage used to buffer candidates.
   explicit _CCCL_DEVICE_API _CCCL_FORCEINLINE WarpBitonicTopK(TempStorage& temp_storage)
       : storage(&temp_storage.Alias())
   {}
@@ -643,10 +647,9 @@ public:
   //! top-k keys.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
   //! @param[in] k Number of keys to select. Must not exceed ``MaxK`` or ``num_items``.
-  //! @param[in] num_items Total number of valid keys across the warp.
+  //! @param[in] num_items Total number of valid keys across the logical warp.
   template <int ItemsPerThread, typename CompareOp>
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
-  TopK(KeyT (&keys)[ItemsPerThread], CompareOp compare_op, int k, int num_items)
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void TopK(KeyT (&keys)[ItemsPerThread], CompareOp compare_op, int k, int num_items)
   {
     static_assert(keys_only);
     ValueT values[ItemsPerThread];
@@ -667,7 +670,7 @@ public:
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void
   TopK(KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread], CompareOp compare_op, int k)
   {
-    TopK(keys, values, compare_op, k, ItemsPerThread * warp_threads);
+    TopK(keys, values, compare_op, k, ItemsPerThread * LogicalWarpThreads);
   }
 
   //! @brief Selects top-k key-value pairs from partially valid per-thread arrays using a candidate buffer.
@@ -680,16 +683,12 @@ public:
   //! @param[in,out] values Values selected together with their corresponding keys.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
   //! @param[in] k Number of pairs to select. Must not exceed ``MaxK`` or ``num_items``.
-  //! @param[in] num_items Total number of valid pairs across the warp.
+  //! @param[in] num_items Total number of valid pairs across the logical warp.
   template <int ItemsPerThread, typename CompareOp>
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE void TopK(
-    KeyT (&keys)[ItemsPerThread],
-    ValueT (&values)[ItemsPerThread],
-    CompareOp compare_op,
-    int k,
-    int num_items)
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
+  TopK(KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread], CompareOp compare_op, int k, int num_items)
   {
-    static_assert(ItemsPerThread * warp_threads >= MaxK);
+    static_assert(ItemsPerThread * LogicalWarpThreads >= MaxK);
 
     if (num_items <= MaxK)
     {
@@ -698,8 +697,8 @@ public:
     }
 
     const int k_th_pos  = MaxK - k;
-    const int k_th_item = k_th_pos / warp_threads;
-    const int k_th_lane = k_th_pos % warp_threads;
+    const int k_th_item = k_th_pos / LogicalWarpThreads;
+    const int k_th_lane = k_th_pos % LogicalWarpThreads;
 
     MaxKSortT{}.template sort<CompareOp, true>(keys, values, compare_op);
     KeyT k_th          = get_key_threshold(keys, k_th_item, k_th_lane);
@@ -708,12 +707,12 @@ public:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = max_k_per_thread; i < ItemsPerThread; ++i)
     {
-      const bool is_candidate = i * warp_threads + lane < num_items;
+      const bool is_candidate = i * LogicalWarpThreads + lane < num_items;
       process_candidate(
         keys, values, keys[i], values[i], compare_op, is_candidate, k_th_item, k_th_lane, k_th, num_candidates);
     }
     flush_candidates(keys, values, compare_op, num_candidates);
-    warp_bitonic_topk::reverse_items<max_k_per_thread>(keys, values, lane);
+    warp_bitonic_topk::reverse_items<max_k_per_thread, LogicalWarpThreads>(keys, values, lane, member_mask);
   }
 
   //! @brief Selects top-k key-value pairs from iterator input.
@@ -722,8 +721,10 @@ public:
   //! @tparam ValueInputIteratorT Random-access iterator type for input values.
   //! @tparam CompareOp Comparison functor type.
   //!
-  //! @param[in] keys_in Iterator pointing to the first input key.
-  //! @param[in] values_in Iterator pointing to the first input value.
+  //! @param[in] keys_in Iterator pointing to the first input key of a logical warp. All lanes in a logical warp should
+  //! pass the same iterator.
+  //! @param[in] values_in Iterator pointing to the first input value of a logical warp. All lanes in a logical warp
+  //! should pass the same iterator.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
   //! @param[in] k Number of pairs to select. Must not exceed ``MaxK`` or ``num_items``.
   //! @param[in] num_items Number of input pairs.
@@ -736,17 +737,17 @@ public:
        CompareOp compare_op,
        int k,
        int num_items,
-       KeyT (&keys_out)[MaxK / detail::warp_threads],
-       ValueT (&values_out)[MaxK / detail::warp_threads])
+       KeyT (&keys_out)[MaxK / LogicalWarpThreads],
+       ValueT (&values_out)[MaxK / LogicalWarpThreads])
   {
     const int k_th_pos  = MaxK - k;
-    const int k_th_item = k_th_pos / warp_threads;
-    const int k_th_lane = k_th_pos % warp_threads;
+    const int k_th_item = k_th_pos / LogicalWarpThreads;
+    const int k_th_lane = k_th_pos % LogicalWarpThreads;
 
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < max_k_per_thread; ++i)
     {
-      const int pos = i * warp_threads + lane;
+      const int pos = i * LogicalWarpThreads + lane;
       if (pos < num_items)
       {
         keys_out[i] = keys_in[pos];
@@ -767,10 +768,10 @@ public:
     KeyT k_th          = get_key_threshold(keys_out, k_th_item, k_th_lane);
     int num_candidates = 0;
 
-    const int num_items_per_thread = (num_items + warp_threads - 1) / warp_threads;
+    const int num_items_per_thread = (num_items + LogicalWarpThreads - 1) / LogicalWarpThreads;
     for (int i = max_k_per_thread; i < num_items_per_thread; ++i)
     {
-      const int pos = i * warp_threads + lane;
+      const int pos = i * LogicalWarpThreads + lane;
       KeyT key;
       ValueT value;
       bool is_candidate = false;
@@ -787,7 +788,7 @@ public:
         keys_out, values_out, key, value, compare_op, is_candidate, k_th_item, k_th_lane, k_th, num_candidates);
     }
     flush_candidates(keys_out, values_out, compare_op, num_candidates);
-    warp_bitonic_topk::reverse_items<max_k_per_thread>(keys_out, values_out, lane);
+    warp_bitonic_topk::reverse_items<max_k_per_thread, LogicalWarpThreads>(keys_out, values_out, lane, member_mask);
   }
 
   //! @brief Selects top-k keys from iterator input.
@@ -795,14 +796,15 @@ public:
   //! @tparam KeyInputIteratorT Random-access iterator type for input keys.
   //! @tparam CompareOp Comparison functor type.
   //!
-  //! @param[in] keys_in Iterator pointing to the first input key.
+  //! @param[in] keys_in Iterator pointing to the first input key of a logical warp. All lanes in a logical warp should
+  //! pass the same iterator.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
   //! @param[in] k Number of keys to select. Must not exceed ``MaxK`` or ``num_items``.
   //! @param[in] num_items Number of input keys.
   //! @param[out] keys_out Selected keys in striped arrangement.
   template <typename KeyInputIteratorT, typename CompareOp>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void TopK(
-    KeyInputIteratorT keys_in, CompareOp compare_op, int k, int num_items, KeyT (&keys_out)[MaxK / detail::warp_threads])
+    KeyInputIteratorT keys_in, CompareOp compare_op, int k, int num_items, KeyT (&keys_out)[MaxK / LogicalWarpThreads])
   {
     static_assert(keys_only);
     ValueT values_out[max_k_per_thread];
@@ -825,14 +827,24 @@ private:
   {
     _TempStorage& temp_storage = *storage;
     is_candidate               = is_candidate && compare_op(key, k_th);
-    const unsigned int mask    = __ballot_sync(warp_bitonic_topk::full_warp_mask, is_candidate);
+    unsigned int mask;
+    if constexpr (LogicalWarpThreads == detail::warp_threads)
+    {
+      constexpr unsigned int full_warp_mask = 0xFFFFFFFFu;
+      mask                                  = __ballot_sync(full_warp_mask, is_candidate);
+    }
+    else
+    {
+      mask = __ballot_sync(member_mask, is_candidate);
+      mask >>= logical_warp_id * LogicalWarpThreads;
+    }
     if (mask == 0)
     {
       return;
     }
 
     int pos = num_candidates + ::cuda::std::popcount(mask & ((0x1u << lane) - 1));
-    if (is_candidate && pos < warp_threads)
+    if (is_candidate && pos < LogicalWarpThreads)
     {
       temp_storage.keys[pos] = key;
       if constexpr (!keys_only)
@@ -842,9 +854,9 @@ private:
       is_candidate = false;
     }
     num_candidates += ::cuda::std::popcount(mask);
-    if (num_candidates >= warp_threads)
+    if (num_candidates >= LogicalWarpThreads)
     {
-      __syncwarp();
+      __syncwarp(member_mask);
       ValueT value;
       if constexpr (!keys_only)
       {
@@ -852,26 +864,23 @@ private:
       }
       merge_candidates(keys_out, values_out, temp_storage.keys[lane], value, compare_op);
       k_th = get_key_threshold(keys_out, k_th_item, k_th_lane);
-      num_candidates -= warp_threads;
+      num_candidates -= LogicalWarpThreads;
     }
     if (is_candidate)
     {
-      pos -= warp_threads;
+      pos -= LogicalWarpThreads;
       temp_storage.keys[pos] = key;
       if constexpr (!keys_only)
       {
         temp_storage.values[pos] = value;
       }
     }
-    __syncwarp();
+    __syncwarp(member_mask);
   }
 
   template <typename CompareOp>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void flush_candidates(
-    KeyT* keys_out,
-    ValueT* values_out,
-    CompareOp compare_op,
-    int num_candidates) const
+  _CCCL_DEVICE _CCCL_FORCEINLINE void
+  flush_candidates(KeyT* keys_out, ValueT* values_out, CompareOp compare_op, int num_candidates) const
   {
     if (num_candidates)
     {
@@ -887,12 +896,8 @@ private:
   }
 
   template <typename CompareOp>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void merge_candidates(
-    KeyT* keys_out,
-    ValueT* values_out,
-    KeyT key,
-    ValueT value,
-    CompareOp compare_op) const
+  _CCCL_DEVICE _CCCL_FORCEINLINE void
+  merge_candidates(KeyT* keys_out, ValueT* values_out, KeyT key, ValueT value, CompareOp compare_op) const
   {
     CandidateSortT{}.template sort<CompareOp, false>(&key, &value, compare_op);
 
@@ -902,17 +907,13 @@ private:
   }
 
   template <typename CompareOp>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void merge_candidates(
-    KeyT* keys_out,
-    ValueT* values_out,
-    KeyT key,
-    ValueT value,
-    CompareOp compare_op,
-    int len) const
+  _CCCL_DEVICE _CCCL_FORCEINLINE void
+  merge_candidates(KeyT* keys_out, ValueT* values_out, KeyT key, ValueT value, CompareOp compare_op, int len) const
   {
     CandidateSortT{}.template sort<CompareOp, false>(&key, &value, compare_op, len);
 
-    warp_bitonic_topk::compare_and_replace<1>(keys_out, values_out, &key, &value, compare_op, len, lane);
+    warp_bitonic_topk::compare_and_replace<1, LogicalWarpThreads>(
+      keys_out, values_out, &key, &value, compare_op, len, lane);
 
     MaxKSortT{}.template merge<CompareOp, true>(keys_out, values_out, compare_op);
   }
@@ -920,11 +921,13 @@ private:
   [[nodiscard]] _CCCL_DEVICE _CCCL_FORCEINLINE KeyT
   get_key_threshold(const KeyT* keys_out, int k_th_item, int k_th_lane) const
   {
-    return warp_bitonic_topk::shuffle_idx(keys_out[k_th_item], k_th_lane);
+    return ::cuda::device::warp_shuffle_idx<LogicalWarpThreads>(keys_out[k_th_item], k_th_lane, member_mask);
   }
 
   _TempStorage* storage;
-  int lane = static_cast<int>(::cuda::ptx::get_sreg_laneid());
+  int logical_warp_id      = detail::logical_warp_id<LogicalWarpThreads>();
+  int lane                 = detail::logical_lane_id<LogicalWarpThreads>();
+  unsigned int member_mask = WarpMask<LogicalWarpThreads>(logical_warp_id);
 };
 } // namespace detail
 

--- a/cub/cub/warp/warp_bitonic_topk.cuh
+++ b/cub/cub/warp/warp_bitonic_topk.cuh
@@ -23,6 +23,7 @@
 #include <cuda/__warp/warp_shuffle.h>
 #include <cuda/std/__bit/popcount.h>
 #include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__utility/swap.h>
 
 CUB_NAMESPACE_BEGIN
 
@@ -69,24 +70,21 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void compare_and_replace(
 template <int Len, int LogicalWarpThreads, typename KeyT, typename ValueT>
 _CCCL_DEVICE _CCCL_FORCEINLINE void reverse_items(KeyT* keys, ValueT* values, int lane, unsigned int member_mask)
 {
-  const int src_lane = LogicalWarpThreads - lane - 1;
-
   _CCCL_PRAGMA_UNROLL_FULL()
   for (int i = 0; i < Len / 2; ++i)
   {
     const int other_i = Len - i - 1;
 
-    const KeyT key = keys[i];
-    keys[i]        = keys[other_i];
-    keys[other_i]  = key;
+    using ::cuda::std::swap;
+    swap(keys[i], keys[other_i]);
 
     if constexpr (!::cuda::std::is_same_v<ValueT, NullType>)
     {
-      const ValueT value = values[i];
-      values[i]          = values[other_i];
-      values[other_i]    = value;
+      swap(values[i], values[other_i]);
     }
   }
+
+  const int src_lane = LogicalWarpThreads - lane - 1;
 
   _CCCL_PRAGMA_UNROLL_FULL()
   for (int i = 0; i < Len; ++i)
@@ -100,21 +98,13 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void reverse_items(KeyT* keys, ValueT* values, in
 }
 } // namespace warp_bitonic_topk
 
-//! @brief Algorithms used by WarpBitonicTopK.
 enum class WarpBitonicTopKAlgorithm
 {
-  //! Eagerly sort and merge each input tile.
+  //! Eagerly sort and merge every MaxK items.
   eager,
   //! Buffer candidates that pass the current key threshold before merging them.
   buffered,
 };
-
-template <int MaxK,
-          typename KeyT,
-          typename ValueT                    = NullType,
-          WarpBitonicTopKAlgorithm Algorithm = WarpBitonicTopKAlgorithm::eager,
-          int LogicalWarpThreads             = detail::warp_threads>
-class WarpBitonicTopK;
 
 //! @rst
 //! The WarpBitonicTopK class provides methods for selecting top-k items from data partitioned across a logical warp.
@@ -124,13 +114,16 @@ class WarpBitonicTopK;
 //!
 //!   WarpBitonicTopK selects the ``k`` items ordered first by a comparison functor with less-than semantics.
 //!
-//!   The TopK functions operate on items already held by each lane or read arbitrary-length input through random-access
-//!   iterators in array-sized tiles. Output items use a striped arrangement across logical warp lanes.
+//!   Two kinds of TopK functions are provided:
+//!   (1) Array overloads operate on items already held by each lane. Input and
+//!       output items use a striped arrangement across logical warp lanes.
+//!   (2) Iterator overloads read arbitrary-length input through random-access iterators. Output items use a striped
+//!       arrangement across logical warp lanes. Supported only by the buffered algorithm.
 //!
 //! Simple Examples
 //! ++++++++++++++++
 //!
-//! The code snippet below illustrates the array API. The input contains 64 integer keys partitioned across
+//! The code snippet below illustrates the array overload. The input contains 64 integer keys partitioned across
 //! 32 threads, with each thread owning 2 items in a striped arrangement. The top 30 items are selected.
 //!
 //! .. code-block:: c++
@@ -160,11 +153,35 @@ class WarpBitonicTopK;
 //!        WarpBitonicTopKT{temp_storage}.TopK(thread_keys, CustomLess{}, 30);
 //!    }
 //!
-//! Suppose the set of input ``thread_keys`` across a logical warp of threads is
+//! Suppose the set of input ``thread_keys`` across a warp of threads is
 //! ``{ [0,63], [1,62], [2,61], ..., [31,32] }``.
 //! The corresponding output ``thread_keys`` in those threads will be
 //! ``{ [0,?], [1,?], [2,?], ..., [29,?], [?,?], [?,?] }``.
-//! Note keys are in a :ref:`striped arrangement <flexible-data-arrangement>` across logical warp lanes.
+//! (``?`` represents an undetermined value.)
+//! Note keys are in a :ref:`striped arrangement <flexible-data-arrangement>` across warp lanes.
+//!
+//! The code snippet below illustrates the iterator overload. The input ``keys_in`` points to ``num_items`` items. The
+//! top 30 keys are selected.
+//!
+//! .. code-block:: c++
+//!
+//!    __global__ void IteratorExampleKernel(const int* keys_in, int num_items)
+//!    {
+//!        constexpr int max_k = 32;
+//!        constexpr int warp_threads = 32;
+//!
+//!        using WarpBitonicTopKT = cub::detail::WarpBitonicTopK<
+//!          max_k, int, warp_threads, cub::NullType, cub::detail::WarpBitonicTopKAlgorithm::buffered>;
+//!        __shared__ typename WarpBitonicTopKT::TempStorage temp_storage;
+//!
+//!        int keys_out[max_k / warp_threads];
+//!
+//!        WarpBitonicTopKT{temp_storage}.TopK(keys_in, CustomLess{}, 30, num_items, keys_out);
+//!    }
+//!
+//! Suppose the input ``keys_in`` is [0, 1, ..., 63]. The output ``keys_out`` in a warp of threads will be
+//! ``{ [0,?], [1,?], [2,?], ..., [29,?], [?,?], [?,?] }``.
+//! Note keys in ``keys_out`` are in a :ref:`striped arrangement <flexible-data-arrangement>` across warp lanes.
 //!
 //! @endrst
 //!
@@ -174,14 +191,24 @@ class WarpBitonicTopK;
 //! @tparam KeyT
 //!   Key type.
 //!
-//! @tparam ValueT
-//!   <b>[optional]</b> Value type (default: cub::NullType, which indicates keys-only top-k).
-//!
 //! @tparam LogicalWarpThreads
 //!   <b>[optional]</b> Number of threads per logical warp. Must be a power of two no greater than the architectural
 //!   warp size.
-template <int MaxK, typename KeyT, typename ValueT, int LogicalWarpThreads>
-class WarpBitonicTopK<MaxK, KeyT, ValueT, WarpBitonicTopKAlgorithm::eager, LogicalWarpThreads>
+//!
+//! @tparam ValueT
+//!   <b>[optional]</b> Value type (default: cub::NullType, which indicates keys-only top-k).
+//!
+//! @tparam Algorithm
+//!   <b>[optional]</b> WarpBitonicTopKAlgorithm to use (default: WarpBitonicTopKAlgorithm::buffered).
+template <int MaxK,
+          typename KeyT,
+          int LogicalWarpThreads             = detail::warp_threads,
+          typename ValueT                    = NullType,
+          WarpBitonicTopKAlgorithm Algorithm = WarpBitonicTopKAlgorithm::buffered>
+class WarpBitonicTopK;
+
+template <int MaxK, typename KeyT, int LogicalWarpThreads, typename ValueT>
+class WarpBitonicTopK<MaxK, KeyT, LogicalWarpThreads, ValueT, WarpBitonicTopKAlgorithm::eager>
 {
 private:
   static_assert(detail::is_valid_logical_warp_size_v<LogicalWarpThreads>,
@@ -193,8 +220,8 @@ private:
 
   template <int ItemsPerThread>
   using WarpBitonicSortT = WarpBitonicSort<KeyT, ItemsPerThread, LogicalWarpThreads, ValueT>;
+  using MaxKSortT        = WarpBitonicSortT<max_k_per_thread>;
 
-  using MaxKSortT    = WarpBitonicSortT<max_k_per_thread>;
   using _TempStorage = cub::NullType;
 
 public:
@@ -232,16 +259,16 @@ public:
   //! @param[in,out] keys Keys in striped arrangement. On return, the first ``k`` striped positions contain the selected
   //! top-k keys.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
-  //! @param[in] k Number of keys to select. Must not exceed ``MaxK`` or ``num_items``.
-  //! @param[in] num_items Total number of valid keys across the logical warp.
+  //! @param[in] k Number of keys to select. Must not exceed ``MaxK`` or ``valid_items``.
+  //! @param[in] valid_items Total number of valid keys across the logical warp.
   //! @param[in] oob_default Default value for out-of-bound key.
   template <int ItemsPerThread, typename CompareOp>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void
-  TopK(KeyT (&keys)[ItemsPerThread], CompareOp compare_op, int k, int num_items, KeyT oob_default) const
+  TopK(KeyT (&keys)[ItemsPerThread], CompareOp compare_op, int k, int valid_items, KeyT oob_default) const
   {
     static_assert(keys_only);
     ValueT values[ItemsPerThread];
-    TopK(keys, values, compare_op, k, num_items, oob_default);
+    TopK(keys, values, compare_op, k, valid_items, oob_default);
   }
 
   //! @brief Selects top-k keys from partially valid per-thread arrays across a logical warp.
@@ -252,15 +279,15 @@ public:
   //! @param[in,out] keys Keys in striped arrangement. On return, the first ``k`` striped positions contain the selected
   //! top-k keys.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
-  //! @param[in] k Number of keys to select. Must not exceed ``MaxK`` or ``num_items``.
-  //! @param[in] num_items Total number of valid keys across the logical warp.
+  //! @param[in] k Number of keys to select. Must not exceed ``MaxK`` or ``valid_items``.
+  //! @param[in] valid_items Total number of valid keys across the logical warp.
   template <int ItemsPerThread, typename CompareOp>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void
-  TopK(KeyT (&keys)[ItemsPerThread], CompareOp compare_op, int k, int num_items) const
+  TopK(KeyT (&keys)[ItemsPerThread], CompareOp compare_op, int k, int valid_items) const
   {
     static_assert(keys_only);
     ValueT values[ItemsPerThread];
-    TopK(keys, values, compare_op, k, num_items);
+    TopK(keys, values, compare_op, k, valid_items);
   }
 
   //! @brief Selects top-k key-value pairs from per-thread arrays across a logical warp.
@@ -337,8 +364,8 @@ public:
   //! top-k keys.
   //! @param[in,out] values Values selected together with their corresponding keys.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
-  //! @param[in] k Number of pairs to select. Must not exceed ``MaxK`` or ``num_items``.
-  //! @param[in] num_items Total number of valid pairs across the logical warp.
+  //! @param[in] k Number of pairs to select. Must not exceed ``MaxK`` or ``valid_items``.
+  //! @param[in] valid_items Total number of valid pairs across the logical warp.
   //! @param[in] oob_default Default value for out-of-bound key.
   template <int ItemsPerThread, typename CompareOp>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void
@@ -346,13 +373,13 @@ public:
        ValueT (&values)[ItemsPerThread],
        CompareOp compare_op,
        int k,
-       int num_items,
+       int valid_items,
        KeyT oob_default) const
   {
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < ItemsPerThread; ++i)
     {
-      if (i * LogicalWarpThreads + lane >= num_items)
+      if (i * LogicalWarpThreads + lane >= valid_items)
       {
         keys[i] = oob_default;
       }
@@ -360,7 +387,7 @@ public:
     TopK(keys, values, compare_op, k);
   }
 
-  //! @brief Selects top-k key-value pairs from partially valid arrays across a logical warp of threads.
+  //! @brief Selects top-k key-value pairs from partially valid per-thread arrays across a logical warp of threads.
   //!
   //! @tparam ItemsPerThread Number of key-value pairs per thread.
   //! @tparam CompareOp Comparison functor type.
@@ -369,21 +396,21 @@ public:
   //! top-k keys.
   //! @param[in,out] values Values selected together with their corresponding keys.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
-  //! @param[in] k Number of pairs to select. Must not exceed ``MaxK`` or ``num_items``.
-  //! @param[in] num_items Total number of valid pairs across the logical warp.
+  //! @param[in] k Number of pairs to select. Must not exceed ``MaxK`` or ``valid_items``.
+  //! @param[in] valid_items Total number of valid pairs across the logical warp.
   template <int ItemsPerThread, typename CompareOp>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void
   TopK(KeyT (&keys)[ItemsPerThread],
        ValueT (&values)[ItemsPerThread],
        CompareOp compare_op,
        [[maybe_unused]] int k,
-       int num_items) const
+       int valid_items) const
   {
     static_assert(ItemsPerThread * LogicalWarpThreads >= MaxK);
 
-    if (num_items < MaxK) // using "<=" is slower
+    if (valid_items < MaxK) // using "<=" is slower
     {
-      MaxKSortT{}.template sort<CompareOp, false>(keys, values, compare_op, num_items);
+      MaxKSortT{}.template sort<CompareOp, false>(keys, values, compare_op, valid_items);
       return;
     }
 
@@ -392,7 +419,7 @@ public:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = max_k_per_thread; i <= ItemsPerThread - max_k_per_thread; i += max_k_per_thread)
     {
-      const int remain_items = num_items - i * LogicalWarpThreads;
+      const int remain_items = valid_items - i * LogicalWarpThreads;
       if (remain_items >= MaxK)
       {
         MaxKSortT{}.template sort<CompareOp, false>(keys + i, values + i, compare_op);
@@ -413,7 +440,7 @@ public:
     if constexpr (constexpr int remain = ItemsPerThread % max_k_per_thread; remain != 0)
     {
       constexpr int offset   = ItemsPerThread / max_k_per_thread * max_k_per_thread;
-      const int remain_items = num_items - offset * LogicalWarpThreads;
+      const int remain_items = valid_items - offset * LogicalWarpThreads;
       if (remain_items > 0)
       {
         WarpBitonicSortT<remain>{}.template sort<CompareOp, false>(
@@ -427,168 +454,16 @@ public:
     warp_bitonic_topk::reverse_items<max_k_per_thread, LogicalWarpThreads>(keys, values, lane, member_mask);
   }
 
-  //! @brief Selects top-k key-value pairs from arbitrary-length iterator input using array tiles.
-  //!
-  //! @tparam KeyInputIteratorT Random-access iterator type for input keys.
-  //! @tparam ValueInputIteratorT Random-access iterator type for input values.
-  //! @tparam CompareOp Comparison functor type.
-  //!
-  //! @param[in] keys_in Iterator pointing to the first input key of a logical warp. All lanes in a logical warp should
-  //! pass the same iterator.
-  //! @param[in] values_in Iterator pointing to the first input value of a logical warp. All lanes in a logical warp
-  //! should pass the same iterator.
-  //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
-  //! @param[in] k Number of pairs to select. Must not exceed ``MaxK`` or ``num_items``.
-  //! @param[in] num_items Number of input pairs.
-  //! @param[out] keys_out Selected keys in striped arrangement.
-  //! @param[out] values_out Values selected together with their corresponding keys.
-  template <typename KeyInputIteratorT, typename ValueInputIteratorT, typename CompareOp>
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
-  TopK(KeyInputIteratorT keys_in,
-       ValueInputIteratorT values_in,
-       CompareOp compare_op,
-       int k,
-       int num_items,
-       KeyT (&keys_out)[MaxK / LogicalWarpThreads],
-       ValueT (&values_out)[MaxK / LogicalWarpThreads]) const
-  {
-    constexpr int tile_items_per_thread = 2 * max_k_per_thread;
-    constexpr int tile_items            = tile_items_per_thread * LogicalWarpThreads;
-    KeyT keys[tile_items_per_thread];
-    ValueT values[tile_items_per_thread];
-
-    const int first_tile_items = num_items < tile_items ? num_items : tile_items;
-    _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < tile_items_per_thread; ++i)
-    {
-      const int pos = i * LogicalWarpThreads + lane;
-      if (pos < first_tile_items)
-      {
-        keys[i] = keys_in[pos];
-        if constexpr (!keys_only)
-        {
-          values[i] = values_in[pos];
-        }
-      }
-    }
-    TopK(keys, values, compare_op, k, first_tile_items);
-
-    for (int offset = first_tile_items; offset < num_items; offset += MaxK)
-    {
-      const int incoming_items = num_items - offset < MaxK ? num_items - offset : MaxK;
-      _CCCL_PRAGMA_UNROLL_FULL()
-      for (int i = 0; i < max_k_per_thread; ++i)
-      {
-        const int pos = i * LogicalWarpThreads + lane;
-        if (pos < incoming_items)
-        {
-          keys[max_k_per_thread + i] = keys_in[offset + pos];
-          if constexpr (!keys_only)
-          {
-            values[max_k_per_thread + i] = values_in[offset + pos];
-          }
-        }
-      }
-      TopK(keys, values, compare_op, k, MaxK + incoming_items);
-    }
-
-    const int output_items = num_items < MaxK ? num_items : MaxK;
-    _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < max_k_per_thread; ++i)
-    {
-      if (i * LogicalWarpThreads + lane < output_items)
-      {
-        keys_out[i] = keys[i];
-        if constexpr (!keys_only)
-        {
-          values_out[i] = values[i];
-        }
-      }
-    }
-  }
-
-  //! @brief Selects top-k keys from arbitrary-length iterator input using array tiles.
-  //!
-  //! @tparam KeyInputIteratorT Random-access iterator type for input keys.
-  //! @tparam CompareOp Comparison functor type.
-  //!
-  //! @param[in] keys_in Iterator pointing to the first input key of a logical warp. All lanes in a logical warp should
-  //! pass the same iterator.
-  //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
-  //! @param[in] k Number of keys to select. Must not exceed ``MaxK`` or ``num_items``.
-  //! @param[in] num_items Number of input keys.
-  //! @param[out] keys_out Selected keys in striped arrangement.
-  template <typename KeyInputIteratorT, typename CompareOp>
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
-  TopK(KeyInputIteratorT keys_in,
-       CompareOp compare_op,
-       int k,
-       int num_items,
-       KeyT (&keys_out)[MaxK / LogicalWarpThreads]) const
-  {
-    static_assert(keys_only);
-    ValueT values_out[max_k_per_thread];
-    TopK(keys_in, nullptr, compare_op, k, num_items, keys_out, values_out);
-  }
-
 private:
   int lane                 = detail::logical_lane_id<LogicalWarpThreads>();
   unsigned int member_mask = WarpMask<LogicalWarpThreads>(detail::logical_warp_id<LogicalWarpThreads>());
 };
 
-//! @rst
-//! The buffered WarpBitonicTopK specialization selects top-k items from arrays or arbitrary-length iterator input
-//! across a logical warp.
-//!
-//! Overview
-//! ++++++++++++++++
-//!
-//!   The buffered WarpBitonicTopK specialization initializes a retained top-k set from per-thread arrays or
-//!   random-access iterators, buffers candidates that pass the current key threshold, and merges them into the retained
-//!   set. Input and output items use a striped arrangement across logical warp lanes.
-//!
-//! Simple Example
-//! ++++++++++++++
-//!
-//! The code snippet below selects the top 30 keys from ``num_items`` integer keys.
-//!
-//! .. code-block:: c++
-//!
-//!    #include <cub/cub.cuh>  // or equivalently <cub/warp/warp_bitonic_topk.cuh>
-//!
-//!    __global__ void IteratorExampleKernel(const int* keys_in, int num_items)
-//!    {
-//!        constexpr int max_k = 32;
-//!
-//!        using WarpBitonicTopKT = cub::detail::WarpBitonicTopK<
-//!          max_k, int, cub::NullType, cub::detail::WarpBitonicTopKAlgorithm::buffered>;
-//!        __shared__ typename WarpBitonicTopKT::TempStorage temp_storage;
-//!
-//!        int keys_out[max_k / 32];
-//!
-//!        WarpBitonicTopKT{temp_storage}.TopK(keys_in, CustomLess{}, 30, num_items, keys_out);
-//!    }
-//!
-//! Suppose the input ``keys_in`` is [0, 1, ..., 63]. The output ``keys_out`` in a logical warp of threads will be
-//! ``{ [0,?], [1,?], [2,?], ..., [29,?], [?,?], [?,?] }``.
-//! Note keys are in a :ref:`striped arrangement <flexible-data-arrangement>` across logical warp lanes.
-//!
-//! @endrst
-//!
-//! @tparam MaxK
-//!   The maximum number of selected items. Must be a multiple of the logical warp size.
-//!
-//! @tparam KeyT
-//!   Key type.
-//!
-//! @tparam ValueT
-//!   <b>[optional]</b> Value type (default: cub::NullType, which indicates keys-only top-k).
-//!
-//! @tparam LogicalWarpThreads
-//!   <b>[optional]</b> Number of threads per logical warp. Must be a power of two no greater than the architectural
-//!   warp size.
-template <int MaxK, typename KeyT, typename ValueT, int LogicalWarpThreads>
-class WarpBitonicTopK<MaxK, KeyT, ValueT, WarpBitonicTopKAlgorithm::buffered, LogicalWarpThreads>
+// The buffered WarpBitonicTopK specialization initializes a retained top-k set from per-thread arrays or
+// random-access iterators, buffers candidates that pass the current key threshold, and merges them into the retained
+// set. Input and output items use a striped arrangement across logical warp lanes.
+template <int MaxK, typename KeyT, int LogicalWarpThreads, typename ValueT>
+class WarpBitonicTopK<MaxK, KeyT, LogicalWarpThreads, ValueT, WarpBitonicTopKAlgorithm::buffered>
 {
 private:
   static_assert(detail::is_valid_logical_warp_size_v<LogicalWarpThreads>,
@@ -600,9 +475,8 @@ private:
 
   template <int ItemsPerThread>
   using WarpBitonicSortT = WarpBitonicSort<KeyT, ItemsPerThread, LogicalWarpThreads, ValueT>;
-
-  using MaxKSortT      = WarpBitonicSortT<max_k_per_thread>;
-  using CandidateSortT = WarpBitonicSortT<1>;
+  using MaxKSortT        = WarpBitonicSortT<max_k_per_thread>;
+  using CandidateSortT   = WarpBitonicSortT<1>;
 
   struct _TempStorage
   {
@@ -616,12 +490,12 @@ public:
 
   //! @brief Constructs a WarpBitonicTopK object.
   //!
-  //! @param[in] temp_storage Logical-warp-private temporary storage used to buffer candidates.
+  //! @param[in] temp_storage Temporary storage.
   explicit _CCCL_DEVICE_API _CCCL_FORCEINLINE WarpBitonicTopK(TempStorage& temp_storage)
       : storage(&temp_storage.Alias())
   {}
 
-  //! @brief Selects top-k keys from per-thread arrays using a candidate buffer.
+  //! @brief Selects top-k keys from per-thread arrays across a logical warp.
   //!
   //! @tparam ItemsPerThread Number of keys per thread.
   //! @tparam CompareOp Comparison functor type.
@@ -638,7 +512,7 @@ public:
     TopK(keys, values, compare_op, k);
   }
 
-  //! @brief Selects top-k keys from partially valid per-thread arrays using a candidate buffer.
+  //! @brief Selects top-k keys from partially valid per-thread arrays across a logical warp.
   //!
   //! @tparam ItemsPerThread Number of keys per thread.
   //! @tparam CompareOp Comparison functor type.
@@ -646,17 +520,18 @@ public:
   //! @param[in,out] keys Keys in striped arrangement. On return, the first ``k`` striped positions contain the selected
   //! top-k keys.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
-  //! @param[in] k Number of keys to select. Must not exceed ``MaxK`` or ``num_items``.
-  //! @param[in] num_items Total number of valid keys across the logical warp.
+  //! @param[in] k Number of keys to select. Must not exceed ``MaxK`` or ``valid_items``.
+  //! @param[in] valid_items Total number of valid keys across the logical warp.
   template <int ItemsPerThread, typename CompareOp>
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE void TopK(KeyT (&keys)[ItemsPerThread], CompareOp compare_op, int k, int num_items)
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
+  TopK(KeyT (&keys)[ItemsPerThread], CompareOp compare_op, int k, int valid_items)
   {
     static_assert(keys_only);
     ValueT values[ItemsPerThread];
-    TopK(keys, values, compare_op, k, num_items);
+    TopK(keys, values, compare_op, k, valid_items);
   }
 
-  //! @brief Selects top-k key-value pairs from per-thread arrays using a candidate buffer.
+  //! @brief Selects top-k key-value pairs from per-thread arrays across a logical warp.
   //!
   //! @tparam ItemsPerThread Number of key-value pairs per thread.
   //! @tparam CompareOp Comparison functor type.
@@ -673,7 +548,7 @@ public:
     TopK(keys, values, compare_op, k, ItemsPerThread * LogicalWarpThreads);
   }
 
-  //! @brief Selects top-k key-value pairs from partially valid per-thread arrays using a candidate buffer.
+  //! @brief Selects top-k key-value pairs from partially valid per-thread arrays across a logical warp.
   //!
   //! @tparam ItemsPerThread Number of key-value pairs per thread.
   //! @tparam CompareOp Comparison functor type.
@@ -682,17 +557,17 @@ public:
   //! top-k keys.
   //! @param[in,out] values Values selected together with their corresponding keys.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
-  //! @param[in] k Number of pairs to select. Must not exceed ``MaxK`` or ``num_items``.
-  //! @param[in] num_items Total number of valid pairs across the logical warp.
+  //! @param[in] k Number of pairs to select. Must not exceed ``MaxK`` or ``valid_items``.
+  //! @param[in] valid_items Total number of valid pairs across the logical warp.
   template <int ItemsPerThread, typename CompareOp>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void
-  TopK(KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread], CompareOp compare_op, int k, int num_items)
+  TopK(KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread], CompareOp compare_op, int k, int valid_items)
   {
     static_assert(ItemsPerThread * LogicalWarpThreads >= MaxK);
 
-    if (num_items <= MaxK)
+    if (valid_items <= MaxK)
     {
-      MaxKSortT{}.template sort<CompareOp, false>(keys, values, compare_op, num_items);
+      MaxKSortT{}.template sort<CompareOp, false>(keys, values, compare_op, valid_items);
       return;
     }
 
@@ -707,12 +582,32 @@ public:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = max_k_per_thread; i < ItemsPerThread; ++i)
     {
-      const bool is_candidate = i * LogicalWarpThreads + lane < num_items;
+      const bool is_candidate = i * LogicalWarpThreads + lane < valid_items;
       process_candidate(
         keys, values, keys[i], values[i], compare_op, is_candidate, k_th_item, k_th_lane, k_th, num_candidates);
     }
     flush_candidates(keys, values, compare_op, num_candidates);
     warp_bitonic_topk::reverse_items<max_k_per_thread, LogicalWarpThreads>(keys, values, lane, member_mask);
+  }
+
+  //! @brief Selects top-k keys from iterator input.
+  //!
+  //! @tparam KeyInputIteratorT Random-access iterator type for input keys.
+  //! @tparam CompareOp Comparison functor type.
+  //!
+  //! @param[in] keys_in Iterator pointing to the first input key of a logical warp. All lanes in a logical warp should
+  //! pass the same iterator.
+  //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
+  //! @param[in] k Number of keys to select. Must not exceed ``MaxK`` or ``num_items``.
+  //! @param[in] num_items Number of input keys.
+  //! @param[out] keys_out Selected keys in striped arrangement.
+  template <typename KeyInputIteratorT, typename CompareOp>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void TopK(
+    KeyInputIteratorT keys_in, CompareOp compare_op, int k, int num_items, KeyT (&keys_out)[MaxK / LogicalWarpThreads])
+  {
+    static_assert(keys_only);
+    ValueT values_out[max_k_per_thread];
+    TopK(keys_in, nullptr, compare_op, k, num_items, keys_out, values_out);
   }
 
   //! @brief Selects top-k key-value pairs from iterator input.
@@ -791,26 +686,6 @@ public:
     warp_bitonic_topk::reverse_items<max_k_per_thread, LogicalWarpThreads>(keys_out, values_out, lane, member_mask);
   }
 
-  //! @brief Selects top-k keys from iterator input.
-  //!
-  //! @tparam KeyInputIteratorT Random-access iterator type for input keys.
-  //! @tparam CompareOp Comparison functor type.
-  //!
-  //! @param[in] keys_in Iterator pointing to the first input key of a logical warp. All lanes in a logical warp should
-  //! pass the same iterator.
-  //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
-  //! @param[in] k Number of keys to select. Must not exceed ``MaxK`` or ``num_items``.
-  //! @param[in] num_items Number of input keys.
-  //! @param[out] keys_out Selected keys in striped arrangement.
-  template <typename KeyInputIteratorT, typename CompareOp>
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE void TopK(
-    KeyInputIteratorT keys_in, CompareOp compare_op, int k, int num_items, KeyT (&keys_out)[MaxK / LogicalWarpThreads])
-  {
-    static_assert(keys_only);
-    ValueT values_out[max_k_per_thread];
-    TopK(keys_in, nullptr, compare_op, k, num_items, keys_out, values_out);
-  }
-
 private:
   template <typename CompareOp>
   _CCCL_DEVICE _CCCL_FORCEINLINE void process_candidate(
@@ -875,7 +750,6 @@ private:
         temp_storage.values[pos] = value;
       }
     }
-    __syncwarp(member_mask);
   }
 
   template <typename CompareOp>
@@ -884,6 +758,7 @@ private:
   {
     if (num_candidates)
     {
+      __syncwarp(member_mask);
       const _TempStorage& temp_storage = *storage;
       KeyT key                         = (lane < num_candidates) ? temp_storage.keys[lane] : KeyT{};
       ValueT value{};

--- a/cub/cub/warp/warp_bitonic_topk.cuh
+++ b/cub/cub/warp/warp_bitonic_topk.cuh
@@ -26,6 +26,108 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail
 {
+namespace warp_bitonic_topk
+{
+inline constexpr unsigned int full_warp_mask = 0xFFFFFFFFu;
+
+template <int Len, typename KeyT, typename ValueT, typename CompareOp>
+_CCCL_DEVICE _CCCL_FORCEINLINE void
+compare_and_replace(KeyT* keys1, ValueT* values1, const KeyT* keys2, const ValueT* values2, CompareOp compare_op)
+{
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (int i = 0; i < Len; ++i)
+  {
+    if (compare_op(keys2[i], keys1[i]))
+    {
+      keys1[i] = keys2[i];
+      if constexpr (!::cuda::std::is_same_v<ValueT, NullType>)
+      {
+        values1[i] = values2[i];
+      }
+    }
+  }
+}
+
+template <int Len, typename KeyT, typename ValueT, typename CompareOp>
+_CCCL_DEVICE _CCCL_FORCEINLINE void compare_and_replace(
+  KeyT* keys1, ValueT* values1, const KeyT* keys2, const ValueT* values2, CompareOp compare_op, int num_items2, int lane)
+{
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (int i = 0; i < Len; ++i)
+  {
+    if (i * detail::warp_threads + lane < num_items2 && compare_op(keys2[i], keys1[i]))
+    {
+      keys1[i] = keys2[i];
+      if constexpr (!::cuda::std::is_same_v<ValueT, NullType>)
+      {
+        values1[i] = values2[i];
+      }
+    }
+  }
+}
+
+template <typename T>
+[[nodiscard]] _CCCL_DEVICE _CCCL_FORCEINLINE T shuffle_idx(const T& value, int src_lane)
+{
+  if constexpr (has_native_shfl_v<T>)
+  {
+    return __shfl_sync(full_warp_mask, value, src_lane);
+  }
+  else
+  {
+    return ::cuda::device::warp_shuffle_idx(value, src_lane);
+  }
+}
+
+template <int Len, typename KeyT, typename ValueT>
+_CCCL_DEVICE _CCCL_FORCEINLINE void reverse_items(KeyT* keys, ValueT* values, int lane)
+{
+  const int src_lane = detail::warp_threads - lane - 1;
+
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (int i = 0; i < Len / 2; ++i)
+  {
+    const int other_i = Len - i - 1;
+
+    const KeyT key = keys[i];
+    keys[i]        = keys[other_i];
+    keys[other_i]  = key;
+
+    if constexpr (!::cuda::std::is_same_v<ValueT, NullType>)
+    {
+      const ValueT value = values[i];
+      values[i]          = values[other_i];
+      values[other_i]    = value;
+    }
+  }
+
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (int i = 0; i < Len; ++i)
+  {
+    keys[i] = shuffle_idx(keys[i], src_lane);
+    if constexpr (!::cuda::std::is_same_v<ValueT, NullType>)
+    {
+      values[i] = shuffle_idx(values[i], src_lane);
+    }
+  }
+}
+} // namespace warp_bitonic_topk
+
+//! @brief Algorithms used by WarpBitonicTopK.
+enum class WarpBitonicTopKAlgorithm
+{
+  //! Eagerly sort and merge each input tile.
+  eager,
+  //! Buffer candidates that pass the current key threshold before merging them.
+  buffered,
+};
+
+template <int MaxK,
+          typename KeyT,
+          typename ValueT                    = NullType,
+          WarpBitonicTopKAlgorithm Algorithm = WarpBitonicTopKAlgorithm::eager>
+class WarpBitonicTopK;
+
 //! @rst
 //! The WarpBitonicTopK class provides methods for selecting top-k items from data partitioned across a CUDA warp.
 //!
@@ -34,16 +136,13 @@ namespace detail
 //!
 //!   WarpBitonicTopK selects the ``k`` items ordered first by a comparison functor with less-than semantics.
 //!
-//!   Two kinds of TopK functions are provided:
-//!   Array overloads operate on items already held by each lane. Input and output items use a striped arrangement
-//!   across warp lanes. Iterator overloads read arbitrary-length input from memory and require ``TempStorage`` to
-//!   buffer candidates while merging them into the retained top-k set. Output items also use a striped arrangement
-//!   across warp lanes.
+//!   The TopK functions operate on items already held by each lane or read arbitrary-length input through random-access
+//!   iterators in array-sized tiles. Output items use a striped arrangement across warp lanes.
 //!
 //! Simple Examples
 //! ++++++++++++++++
 //!
-//! The code snippet below illustrates the array overload. The input contains 64 integer keys partitioned across
+//! The code snippet below illustrates the array API. The input contains 64 integer keys partitioned across
 //! 32 threads, with each thread owning 2 items in a striped arrangement. The top 30 items are selected.
 //!
 //! .. code-block:: c++
@@ -65,40 +164,17 @@ namespace detail
 //!        constexpr int items_per_thread = 2;
 //!
 //!        using WarpBitonicTopKT = cub::detail::WarpBitonicTopK<max_k, int>;
+//!        __shared__ typename WarpBitonicTopKT::TempStorage temp_storage;
 //!
 //!        int thread_keys[items_per_thread];
 //!        // ...
 //!
-//!        WarpBitonicTopKT{}.TopK(thread_keys, CustomLess{}, 30);
+//!        WarpBitonicTopKT{temp_storage}.TopK(thread_keys, CustomLess{}, 30);
 //!    }
 //!
 //! Suppose the set of input ``thread_keys`` across a warp of threads is
 //! ``{ [0,63], [1,62], [2,61], ..., [31,32] }``.
 //! The corresponding output ``thread_keys`` in those threads will be
-//! ``{ [0,?], [1,?], [2,?], ..., [29,?], [?,?], [?,?] }``.
-//! Note keys are in a :ref:`striped arrangement <flexible-data-arrangement>` across warp lanes.
-//!
-//! The code snippet below illustrates the iterator overload. The input ``keys_in`` points to ``num_items`` items.
-//! The top 30 items are selected.
-//!
-//! .. code-block:: c++
-//!
-//!    #include <cub/cub.cuh>  // or equivalently <cub/warp/warp_bitonic_topk.cuh>
-//!
-//!    __global__ void IteratorExampleKernel(const int* keys_in, int num_items)
-//!    {
-//!        constexpr int max_k = 32;
-//!
-//!        using WarpBitonicTopKT = cub::detail::WarpBitonicTopK<max_k, int>;
-//!        __shared__ typename WarpBitonicTopKT::TempStorage temp_storage;
-//!
-//!        int keys_out[max_k / 32];
-//!
-//!        WarpBitonicTopKT{temp_storage}.TopK(keys_in, CustomLess{}, 30, num_items, keys_out);
-//!    }
-//!
-//! Suppose the input ``keys_in`` is [0, 1, ..., 63],
-//! The output ``keys_out`` in a warp of threads will be
 //! ``{ [0,?], [1,?], [2,?], ..., [29,?], [?,?], [?,?] }``.
 //! Note keys are in a :ref:`striped arrangement <flexible-data-arrangement>` across warp lanes.
 //!
@@ -112,12 +188,11 @@ namespace detail
 //!
 //! @tparam ValueT
 //!   <b>[optional]</b> Value type (default: cub::NullType, which indicates keys-only top-k).
-template <int MaxK, typename KeyT, typename ValueT = NullType>
-class WarpBitonicTopK
+template <int MaxK, typename KeyT, typename ValueT>
+class WarpBitonicTopK<MaxK, KeyT, ValueT, WarpBitonicTopKAlgorithm::eager>
 {
 private:
-  static constexpr unsigned int full_warp_mask = 0xFFFFFFFFu;
-  static constexpr int warp_threads            = detail::warp_threads;
+  static constexpr int warp_threads = detail::warp_threads;
   static_assert(MaxK % warp_threads == 0);
   static constexpr int max_k_per_thread = MaxK / warp_threads;
   static constexpr bool keys_only       = ::cuda::std::is_same_v<ValueT, NullType>;
@@ -125,33 +200,17 @@ private:
   template <int ItemsPerThread>
   using WarpBitonicSortT = WarpBitonicSort<KeyT, ItemsPerThread, warp_threads, ValueT>;
 
-  using MaxKSortT      = WarpBitonicSortT<max_k_per_thread>;
-  using CandidateSortT = WarpBitonicSortT<1>;
-
-  struct _TempStorage
-  {
-    KeyT keys[warp_threads];
-    ValueT values[warp_threads];
-  };
+  using MaxKSortT    = WarpBitonicSortT<max_k_per_thread>;
+  using _TempStorage = cub::NullType;
 
 public:
   struct TempStorage : Uninitialized<_TempStorage>
   {};
 
-  //! @brief Constructs a WarpBitonicTopK object without temporary storage.
+  //! @brief Constructs a WarpBitonicTopK object.
   //!
-  //! This constructor is intended for array overloads. Iterator overloads require temporary storage and must
-  //! use the constructor that accepts ``TempStorage``.
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE WarpBitonicTopK()
-      : storage(nullptr)
-  {}
-
-  //! @brief Constructs a WarpBitonicTopK object with temporary storage for iterator overloads.
-  //!
-  //! @param[in] temp_storage Warp-private temporary storage used to buffer candidates while processing iterator input.
-  explicit _CCCL_DEVICE_API _CCCL_FORCEINLINE WarpBitonicTopK(TempStorage& temp_storage)
-      : storage(&temp_storage.Alias())
-  {}
+  //! @param[in] temp_storage Temporary storage.
+  explicit _CCCL_DEVICE_API _CCCL_FORCEINLINE WarpBitonicTopK(TempStorage&) {}
 
   //! @brief Selects top-k keys from per-thread arrays across a warp.
   //!
@@ -242,7 +301,8 @@ public:
       {
         const int offset = max_k_per_thread * i;
         MaxKSortT{}.template sort<CompareOp, !reverse>(keys + offset, values + offset, compare_op);
-        compare_and_replace<max_k_per_thread>(keys, values, keys + offset, values + offset, compare_op);
+        warp_bitonic_topk::compare_and_replace<max_k_per_thread>(
+          keys, values, keys + offset, values + offset, compare_op);
         MaxKSortT{}.template merge<CompareOp, reverse>(keys, values, compare_op);
       }
 
@@ -252,11 +312,11 @@ public:
         WarpBitonicSortT<remain>{}.template sort<CompareOp, !reverse>(keys + offset, values + offset, compare_op);
         if constexpr (reverse)
         {
-          compare_and_replace<remain>(keys, values, keys + offset, values + offset, compare_op);
+          warp_bitonic_topk::compare_and_replace<remain>(keys, values, keys + offset, values + offset, compare_op);
         }
         else
         {
-          compare_and_replace<remain>(
+          warp_bitonic_topk::compare_and_replace<remain>(
             keys + max_k_per_thread - remain,
             values + max_k_per_thread - remain,
             keys + offset,
@@ -268,7 +328,7 @@ public:
 
       if constexpr (reverse)
       {
-        reverse_items<max_k_per_thread>(keys, values);
+        warp_bitonic_topk::reverse_items<max_k_per_thread>(keys, values, lane);
       }
     }
   }
@@ -342,15 +402,16 @@ public:
       if (remain_items >= MaxK)
       {
         MaxKSortT{}.template sort<CompareOp, false>(keys + i, values + i, compare_op);
-        compare_and_replace<max_k_per_thread>(keys, values, keys + i, values + i, compare_op);
+        warp_bitonic_topk::compare_and_replace<max_k_per_thread>(keys, values, keys + i, values + i, compare_op);
         MaxKSortT{}.template merge<CompareOp, true>(keys, values, compare_op);
       }
       else if (remain_items > 0)
       {
         MaxKSortT{}.template sort<CompareOp, false>(keys + i, values + i, compare_op, remain_items);
-        compare_and_replace<max_k_per_thread>(keys, values, keys + i, values + i, compare_op, remain_items);
+        warp_bitonic_topk::compare_and_replace<max_k_per_thread>(
+          keys, values, keys + i, values + i, compare_op, remain_items, lane);
         MaxKSortT{}.template merge<CompareOp, true>(keys, values, compare_op);
-        reverse_items<max_k_per_thread>(keys, values);
+        warp_bitonic_topk::reverse_items<max_k_per_thread>(keys, values, lane);
         return;
       }
     }
@@ -363,17 +424,299 @@ public:
       {
         WarpBitonicSortT<remain>{}.template sort<CompareOp, false>(
           keys + offset, values + offset, compare_op, remain_items);
-        compare_and_replace<remain>(keys, values, keys + offset, values + offset, compare_op, remain_items);
+        warp_bitonic_topk::compare_and_replace<remain>(
+          keys, values, keys + offset, values + offset, compare_op, remain_items, lane);
         MaxKSortT{}.template merge<CompareOp, true>(keys, values, compare_op);
       }
     }
 
-    reverse_items<max_k_per_thread>(keys, values);
+    warp_bitonic_topk::reverse_items<max_k_per_thread>(keys, values, lane);
+  }
+
+  //! @brief Selects top-k key-value pairs from arbitrary-length iterator input using array tiles.
+  //!
+  //! @tparam KeyInputIteratorT Random-access iterator type for input keys.
+  //! @tparam ValueInputIteratorT Random-access iterator type for input values.
+  //! @tparam CompareOp Comparison functor type.
+  //!
+  //! @param[in] keys_in Iterator pointing to the first input key.
+  //! @param[in] values_in Iterator pointing to the first input value.
+  //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
+  //! @param[in] k Number of pairs to select. Must not exceed ``MaxK`` or ``num_items``.
+  //! @param[in] num_items Number of input pairs.
+  //! @param[out] keys_out Selected keys in striped arrangement.
+  //! @param[out] values_out Values selected together with their corresponding keys.
+  template <typename KeyInputIteratorT, typename ValueInputIteratorT, typename CompareOp>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
+  TopK(KeyInputIteratorT keys_in,
+       ValueInputIteratorT values_in,
+       CompareOp compare_op,
+       int k,
+       int num_items,
+       KeyT (&keys_out)[MaxK / detail::warp_threads],
+       ValueT (&values_out)[MaxK / detail::warp_threads]) const
+  {
+    constexpr int tile_items_per_thread = 2 * max_k_per_thread;
+    constexpr int tile_items            = tile_items_per_thread * warp_threads;
+    KeyT keys[tile_items_per_thread];
+    ValueT values[tile_items_per_thread];
+
+    const int first_tile_items = num_items < tile_items ? num_items : tile_items;
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < tile_items_per_thread; ++i)
+    {
+      const int pos = i * warp_threads + lane;
+      if (pos < first_tile_items)
+      {
+        keys[i] = keys_in[pos];
+        if constexpr (!keys_only)
+        {
+          values[i] = values_in[pos];
+        }
+      }
+    }
+    TopK(keys, values, compare_op, k, first_tile_items);
+
+    for (int offset = first_tile_items; offset < num_items; offset += MaxK)
+    {
+      const int incoming_items = num_items - offset < MaxK ? num_items - offset : MaxK;
+      _CCCL_PRAGMA_UNROLL_FULL()
+      for (int i = 0; i < max_k_per_thread; ++i)
+      {
+        const int pos = i * warp_threads + lane;
+        if (pos < incoming_items)
+        {
+          keys[max_k_per_thread + i] = keys_in[offset + pos];
+          if constexpr (!keys_only)
+          {
+            values[max_k_per_thread + i] = values_in[offset + pos];
+          }
+        }
+      }
+      TopK(keys, values, compare_op, k, MaxK + incoming_items);
+    }
+
+    const int output_items = num_items < MaxK ? num_items : MaxK;
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < max_k_per_thread; ++i)
+    {
+      if (i * warp_threads + lane < output_items)
+      {
+        keys_out[i] = keys[i];
+        if constexpr (!keys_only)
+        {
+          values_out[i] = values[i];
+        }
+      }
+    }
+  }
+
+  //! @brief Selects top-k keys from arbitrary-length iterator input using array tiles.
+  //!
+  //! @tparam KeyInputIteratorT Random-access iterator type for input keys.
+  //! @tparam CompareOp Comparison functor type.
+  //!
+  //! @param[in] keys_in Iterator pointing to the first input key.
+  //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
+  //! @param[in] k Number of keys to select. Must not exceed ``MaxK`` or ``num_items``.
+  //! @param[in] num_items Number of input keys.
+  //! @param[out] keys_out Selected keys in striped arrangement.
+  template <typename KeyInputIteratorT, typename CompareOp>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void TopK(
+    KeyInputIteratorT keys_in,
+    CompareOp compare_op,
+    int k,
+    int num_items,
+    KeyT (&keys_out)[MaxK / detail::warp_threads]) const
+  {
+    static_assert(keys_only);
+    ValueT values_out[max_k_per_thread];
+    TopK(keys_in, nullptr, compare_op, k, num_items, keys_out, values_out);
+  }
+
+private:
+  int lane = static_cast<int>(::cuda::ptx::get_sreg_laneid());
+};
+
+//! @rst
+//! The buffered WarpBitonicTopK specialization selects top-k items from arrays or arbitrary-length iterator input across
+//! a CUDA warp.
+//!
+//! Overview
+//! ++++++++++++++++
+//!
+//!   The buffered WarpBitonicTopK specialization initializes a retained top-k set from per-thread arrays or
+//!   random-access iterators, buffers candidates that pass the current key threshold, and merges them into the retained
+//!   set. Input and output items use a striped arrangement across warp lanes.
+//!
+//! Simple Example
+//! ++++++++++++++
+//!
+//! The code snippet below selects the top 30 keys from ``num_items`` integer keys.
+//!
+//! .. code-block:: c++
+//!
+//!    #include <cub/cub.cuh>  // or equivalently <cub/warp/warp_bitonic_topk.cuh>
+//!
+//!    __global__ void IteratorExampleKernel(const int* keys_in, int num_items)
+//!    {
+//!        constexpr int max_k = 32;
+//!
+//!        using WarpBitonicTopKT = cub::detail::WarpBitonicTopK<
+//!          max_k, int, cub::NullType, cub::detail::WarpBitonicTopKAlgorithm::buffered>;
+//!        __shared__ typename WarpBitonicTopKT::TempStorage temp_storage;
+//!
+//!        int keys_out[max_k / 32];
+//!
+//!        WarpBitonicTopKT{temp_storage}.TopK(keys_in, CustomLess{}, 30, num_items, keys_out);
+//!    }
+//!
+//! Suppose the input ``keys_in`` is [0, 1, ..., 63]. The output ``keys_out`` in a warp of threads will be
+//! ``{ [0,?], [1,?], [2,?], ..., [29,?], [?,?], [?,?] }``.
+//! Note keys are in a :ref:`striped arrangement <flexible-data-arrangement>` across warp lanes.
+//!
+//! @endrst
+//!
+//! @tparam MaxK
+//!   The maximum number of selected items. Must be a multiple of the warp size.
+//!
+//! @tparam KeyT
+//!   Key type.
+//!
+//! @tparam ValueT
+//!   <b>[optional]</b> Value type (default: cub::NullType, which indicates keys-only top-k).
+template <int MaxK, typename KeyT, typename ValueT>
+class WarpBitonicTopK<MaxK, KeyT, ValueT, WarpBitonicTopKAlgorithm::buffered>
+{
+private:
+  static constexpr int warp_threads = detail::warp_threads;
+  static_assert(MaxK % warp_threads == 0);
+  static constexpr int max_k_per_thread = MaxK / warp_threads;
+  static constexpr bool keys_only       = ::cuda::std::is_same_v<ValueT, NullType>;
+
+  template <int ItemsPerThread>
+  using WarpBitonicSortT = WarpBitonicSort<KeyT, ItemsPerThread, warp_threads, ValueT>;
+
+  using MaxKSortT      = WarpBitonicSortT<max_k_per_thread>;
+  using CandidateSortT = WarpBitonicSortT<1>;
+
+  struct _TempStorage
+  {
+    KeyT keys[warp_threads];
+    ValueT values[warp_threads];
+  };
+
+public:
+  struct TempStorage : Uninitialized<_TempStorage>
+  {};
+
+  //! @brief Constructs a WarpBitonicTopK object.
+  //!
+  //! @param[in] temp_storage Warp-private temporary storage used to buffer candidates while processing iterator input.
+  explicit _CCCL_DEVICE_API _CCCL_FORCEINLINE WarpBitonicTopK(TempStorage& temp_storage)
+      : storage(&temp_storage.Alias())
+  {}
+
+  //! @brief Selects top-k keys from per-thread arrays using a candidate buffer.
+  //!
+  //! @tparam ItemsPerThread Number of keys per thread.
+  //! @tparam CompareOp Comparison functor type.
+  //!
+  //! @param[in,out] keys Keys in striped arrangement. On return, the first ``k`` striped positions contain the selected
+  //! top-k keys.
+  //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
+  //! @param[in] k Number of keys to select. Must not exceed ``MaxK``.
+  template <int ItemsPerThread, typename CompareOp>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void TopK(KeyT (&keys)[ItemsPerThread], CompareOp compare_op, int k)
+  {
+    static_assert(keys_only);
+    ValueT values[ItemsPerThread];
+    TopK(keys, values, compare_op, k);
+  }
+
+  //! @brief Selects top-k keys from partially valid per-thread arrays using a candidate buffer.
+  //!
+  //! @tparam ItemsPerThread Number of keys per thread.
+  //! @tparam CompareOp Comparison functor type.
+  //!
+  //! @param[in,out] keys Keys in striped arrangement. On return, the first ``k`` striped positions contain the selected
+  //! top-k keys.
+  //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
+  //! @param[in] k Number of keys to select. Must not exceed ``MaxK`` or ``num_items``.
+  //! @param[in] num_items Total number of valid keys across the warp.
+  template <int ItemsPerThread, typename CompareOp>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
+  TopK(KeyT (&keys)[ItemsPerThread], CompareOp compare_op, int k, int num_items)
+  {
+    static_assert(keys_only);
+    ValueT values[ItemsPerThread];
+    TopK(keys, values, compare_op, k, num_items);
+  }
+
+  //! @brief Selects top-k key-value pairs from per-thread arrays using a candidate buffer.
+  //!
+  //! @tparam ItemsPerThread Number of key-value pairs per thread.
+  //! @tparam CompareOp Comparison functor type.
+  //!
+  //! @param[in,out] keys Keys in striped arrangement. On return, the first ``k`` striped positions contain the selected
+  //! top-k keys.
+  //! @param[in,out] values Values selected together with their corresponding keys.
+  //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
+  //! @param[in] k Number of pairs to select. Must not exceed ``MaxK``.
+  template <int ItemsPerThread, typename CompareOp>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
+  TopK(KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread], CompareOp compare_op, int k)
+  {
+    TopK(keys, values, compare_op, k, ItemsPerThread * warp_threads);
+  }
+
+  //! @brief Selects top-k key-value pairs from partially valid per-thread arrays using a candidate buffer.
+  //!
+  //! @tparam ItemsPerThread Number of key-value pairs per thread.
+  //! @tparam CompareOp Comparison functor type.
+  //!
+  //! @param[in,out] keys Keys in striped arrangement. On return, the first ``k`` striped positions contain the selected
+  //! top-k keys.
+  //! @param[in,out] values Values selected together with their corresponding keys.
+  //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
+  //! @param[in] k Number of pairs to select. Must not exceed ``MaxK`` or ``num_items``.
+  //! @param[in] num_items Total number of valid pairs across the warp.
+  template <int ItemsPerThread, typename CompareOp>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void TopK(
+    KeyT (&keys)[ItemsPerThread],
+    ValueT (&values)[ItemsPerThread],
+    CompareOp compare_op,
+    int k,
+    int num_items)
+  {
+    static_assert(ItemsPerThread * warp_threads >= MaxK);
+
+    if (num_items <= MaxK)
+    {
+      MaxKSortT{}.template sort<CompareOp, false>(keys, values, compare_op, num_items);
+      return;
+    }
+
+    const int k_th_pos  = MaxK - k;
+    const int k_th_item = k_th_pos / warp_threads;
+    const int k_th_lane = k_th_pos % warp_threads;
+
+    MaxKSortT{}.template sort<CompareOp, true>(keys, values, compare_op);
+    KeyT k_th          = get_key_threshold(keys, k_th_item, k_th_lane);
+    int num_candidates = 0;
+
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = max_k_per_thread; i < ItemsPerThread; ++i)
+    {
+      const bool is_candidate = i * warp_threads + lane < num_items;
+      process_candidate(
+        keys, values, keys[i], values[i], compare_op, is_candidate, k_th_item, k_th_lane, k_th, num_candidates);
+    }
+    flush_candidates(keys, values, compare_op, num_candidates);
+    warp_bitonic_topk::reverse_items<max_k_per_thread>(keys, values, lane);
   }
 
   //! @brief Selects top-k key-value pairs from iterator input.
-  //!
-  //! This overload can process arbitrary-length input and requires the object to be constructed with ``TempStorage``.
   //!
   //! @tparam KeyInputIteratorT Random-access iterator type for input keys.
   //! @tparam ValueInputIteratorT Random-access iterator type for input values.
@@ -444,12 +787,10 @@ public:
         keys_out, values_out, key, value, compare_op, is_candidate, k_th_item, k_th_lane, k_th, num_candidates);
     }
     flush_candidates(keys_out, values_out, compare_op, num_candidates);
-    reverse_items<max_k_per_thread>(keys_out, values_out);
+    warp_bitonic_topk::reverse_items<max_k_per_thread>(keys_out, values_out, lane);
   }
 
   //! @brief Selects top-k keys from iterator input.
-  //!
-  //! This overload can process arbitrary-length input and requires the object to be constructed with ``TempStorage``.
   //!
   //! @tparam KeyInputIteratorT Random-access iterator type for input keys.
   //! @tparam CompareOp Comparison functor type.
@@ -469,92 +810,10 @@ public:
   }
 
 private:
-  template <int Len, typename CompareOp>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void compare_and_replace(
-    KeyT* keys1, ValueT* values1, const KeyT* keys2, const ValueT* values2, CompareOp compare_op) const
-  {
-    _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < Len; ++i)
-    {
-      if (compare_op(keys2[i], keys1[i]))
-      {
-        keys1[i] = keys2[i];
-        if constexpr (!keys_only)
-        {
-          values1[i] = values2[i];
-        }
-      }
-    }
-  }
-
-  template <int Len, typename CompareOp>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void compare_and_replace(
-    KeyT* keys1, ValueT* values1, const KeyT* keys2, const ValueT* values2, CompareOp compare_op, int num_items2) const
-  {
-    _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < Len; ++i)
-    {
-      if (i * warp_threads + lane < num_items2 && compare_op(keys2[i], keys1[i]))
-      {
-        keys1[i] = keys2[i];
-        if constexpr (!keys_only)
-        {
-          values1[i] = values2[i];
-        }
-      }
-    }
-  }
-
-  template <int Len>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void reverse_items(KeyT* keys, ValueT* values) const
-  {
-    const int src_lane = warp_threads - lane - 1;
-
-    _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < Len / 2; ++i)
-    {
-      const int other_i = Len - i - 1;
-
-      const KeyT key = keys[i];
-      keys[i]        = keys[other_i];
-      keys[other_i]  = key;
-
-      if constexpr (!keys_only)
-      {
-        const ValueT value = values[i];
-        values[i]          = values[other_i];
-        values[other_i]    = value;
-      }
-    }
-
-    _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < Len; ++i)
-    {
-      keys[i] = shuffle_idx(keys[i], src_lane);
-      if constexpr (!keys_only)
-      {
-        values[i] = shuffle_idx(values[i], src_lane);
-      }
-    }
-  }
-
-  template <typename T>
-  [[nodiscard]] _CCCL_DEVICE _CCCL_FORCEINLINE static T shuffle_idx(const T& value, int src_lane)
-  {
-    if constexpr (has_native_shfl_v<T>)
-    {
-      return __shfl_sync(full_warp_mask, value, src_lane);
-    }
-    else
-    {
-      return ::cuda::device::warp_shuffle_idx(value, src_lane);
-    }
-  }
-
   template <typename CompareOp>
   _CCCL_DEVICE _CCCL_FORCEINLINE void process_candidate(
-    KeyT (&keys_out)[MaxK / detail::warp_threads],
-    ValueT (&values_out)[MaxK / detail::warp_threads],
+    KeyT* keys_out,
+    ValueT* values_out,
     const KeyT& key,
     const ValueT& value,
     CompareOp compare_op,
@@ -566,7 +825,7 @@ private:
   {
     _TempStorage& temp_storage = *storage;
     is_candidate               = is_candidate && compare_op(key, k_th);
-    const unsigned int mask    = __ballot_sync(full_warp_mask, is_candidate);
+    const unsigned int mask    = __ballot_sync(warp_bitonic_topk::full_warp_mask, is_candidate);
     if (mask == 0)
     {
       return;
@@ -609,8 +868,8 @@ private:
 
   template <typename CompareOp>
   _CCCL_DEVICE _CCCL_FORCEINLINE void flush_candidates(
-    KeyT (&keys_out)[MaxK / detail::warp_threads],
-    ValueT (&values_out)[MaxK / detail::warp_threads],
+    KeyT* keys_out,
+    ValueT* values_out,
     CompareOp compare_op,
     int num_candidates) const
   {
@@ -629,23 +888,23 @@ private:
 
   template <typename CompareOp>
   _CCCL_DEVICE _CCCL_FORCEINLINE void merge_candidates(
-    KeyT (&keys_out)[MaxK / detail::warp_threads],
-    ValueT (&values_out)[MaxK / detail::warp_threads],
+    KeyT* keys_out,
+    ValueT* values_out,
     KeyT key,
     ValueT value,
     CompareOp compare_op) const
   {
     CandidateSortT{}.template sort<CompareOp, false>(&key, &value, compare_op);
 
-    compare_and_replace<1>(keys_out, values_out, &key, &value, compare_op);
+    warp_bitonic_topk::compare_and_replace<1>(keys_out, values_out, &key, &value, compare_op);
 
     MaxKSortT{}.template merge<CompareOp, true>(keys_out, values_out, compare_op);
   }
 
   template <typename CompareOp>
   _CCCL_DEVICE _CCCL_FORCEINLINE void merge_candidates(
-    KeyT (&keys_out)[MaxK / detail::warp_threads],
-    ValueT (&values_out)[MaxK / detail::warp_threads],
+    KeyT* keys_out,
+    ValueT* values_out,
     KeyT key,
     ValueT value,
     CompareOp compare_op,
@@ -653,15 +912,15 @@ private:
   {
     CandidateSortT{}.template sort<CompareOp, false>(&key, &value, compare_op, len);
 
-    compare_and_replace<1>(keys_out, values_out, &key, &value, compare_op, len);
+    warp_bitonic_topk::compare_and_replace<1>(keys_out, values_out, &key, &value, compare_op, len, lane);
 
     MaxKSortT{}.template merge<CompareOp, true>(keys_out, values_out, compare_op);
   }
 
   [[nodiscard]] _CCCL_DEVICE _CCCL_FORCEINLINE KeyT
-  get_key_threshold(const KeyT (&keys_out)[MaxK / detail::warp_threads], int k_th_item, int k_th_lane) const
+  get_key_threshold(const KeyT* keys_out, int k_th_item, int k_th_lane) const
   {
-    return shuffle_idx(keys_out[k_th_item], k_th_lane);
+    return warp_bitonic_topk::shuffle_idx(keys_out[k_th_item], k_th_lane);
   }
 
   _TempStorage* storage;

--- a/cub/cub/warp/warp_bitonic_topk.cuh
+++ b/cub/cub/warp/warp_bitonic_topk.cuh
@@ -19,6 +19,7 @@
 
 #include <cuda/__cmath/pow2.h>
 #include <cuda/__warp/warp_shuffle.h>
+#include <cuda/std/__bit/popcount.h>
 #include <cuda/std/__type_traits/is_same.h>
 
 CUB_NAMESPACE_BEGIN
@@ -103,7 +104,7 @@ namespace detail
 //!
 //! @endrst
 //!
-//! @tparam MAX_K
+//! @tparam MaxK
 //!   The maximum number of selected items. Must be a multiple of the warp size.
 //!
 //! @tparam KeyT
@@ -111,158 +112,163 @@ namespace detail
 //!
 //! @tparam ValueT
 //!   <b>[optional]</b> Value type (default: cub::NullType, which indicates keys-only top-k).
-template <int MAX_K, typename KeyT, typename ValueT = NullType>
+template <int MaxK, typename KeyT, typename ValueT = NullType>
 class WarpBitonicTopK
 {
 private:
-  static constexpr unsigned int FULL_WARP_MASK_ = 0xFFFFFFFFu;
-  static constexpr int WARP_THREADS_            = detail::warp_threads;
-  static_assert(MAX_K % WARP_THREADS_ == 0);
-  static constexpr int max_k_per_thread_ = MAX_K / WARP_THREADS_;
-  static constexpr bool KEYS_ONLY_       = ::cuda::std::is_same_v<ValueT, NullType>;
+  static constexpr unsigned int full_warp_mask = 0xFFFFFFFFu;
+  static constexpr int warp_threads            = detail::warp_threads;
+  static_assert(MaxK % warp_threads == 0);
+  static constexpr int max_k_per_thread = MaxK / warp_threads;
+  static constexpr bool keys_only       = ::cuda::std::is_same_v<ValueT, NullType>;
 
-  struct TempStorage_
+  template <int ItemsPerThread>
+  using WarpBitonicSortT = WarpBitonicSort<KeyT, ItemsPerThread, warp_threads, ValueT>;
+
+  using MaxKSortT      = WarpBitonicSortT<max_k_per_thread>;
+  using CandidateSortT = WarpBitonicSortT<1>;
+
+  struct _TempStorage
   {
-    KeyT keys[WARP_THREADS_];
-    ValueT values[WARP_THREADS_];
+    KeyT keys[warp_threads];
+    ValueT values[warp_threads];
   };
 
 public:
-  struct TempStorage : Uninitialized<TempStorage_>
+  struct TempStorage : Uninitialized<_TempStorage>
   {};
 
   //! @brief Constructs a WarpBitonicTopK object without temporary storage.
   //!
   //! This constructor is intended for array overloads. Iterator overloads require temporary storage and must
   //! use the constructor that accepts ``TempStorage``.
-  _CCCL_DEVICE _CCCL_FORCEINLINE WarpBitonicTopK()
-      : storage_(nullptr)
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE WarpBitonicTopK()
+      : storage(nullptr)
   {}
 
   //! @brief Constructs a WarpBitonicTopK object with temporary storage for iterator overloads.
   //!
   //! @param[in] temp_storage Warp-private temporary storage used to buffer candidates while processing iterator input.
-  explicit _CCCL_DEVICE _CCCL_FORCEINLINE WarpBitonicTopK(TempStorage& temp_storage)
-      : storage_(&temp_storage.Alias())
+  explicit _CCCL_DEVICE_API _CCCL_FORCEINLINE WarpBitonicTopK(TempStorage& temp_storage)
+      : storage(&temp_storage.Alias())
   {}
 
   //! @brief Selects top-k keys from per-thread arrays across a warp.
   //!
-  //! @tparam ITEMS_PER_THREAD Number of keys per thread.
+  //! @tparam ItemsPerThread Number of keys per thread.
   //! @tparam CompareOp Comparison functor type.
   //!
   //! @param[in,out] keys Keys in striped arrangement. On return, the first ``k`` striped positions contain the selected
   //! top-k keys.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
-  //! @param[in] k Number of keys to select. Must not exceed ``MAX_K``.
-  template <int ITEMS_PER_THREAD, typename CompareOp>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void TopK(KeyT (&keys)[ITEMS_PER_THREAD], CompareOp compare_op, int k)
+  //! @param[in] k Number of keys to select. Must not exceed ``MaxK``.
+  template <int ItemsPerThread, typename CompareOp>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void TopK(KeyT (&keys)[ItemsPerThread], CompareOp compare_op, int k) const
   {
-    static_assert(KEYS_ONLY_);
-    ValueT values[ITEMS_PER_THREAD];
+    static_assert(keys_only);
+    ValueT values[ItemsPerThread];
     TopK(keys, values, compare_op, k);
   }
 
   //! @brief Selects top-k keys from partially valid per-thread arrays across a warp. An out-of-bound key ordered after
   //! any valid key must be provided.
   //!
-  //! @tparam ITEMS_PER_THREAD Number of keys per thread.
+  //! @tparam ItemsPerThread Number of keys per thread.
   //! @tparam CompareOp Comparison functor type.
   //!
   //! @param[in,out] keys Keys in striped arrangement. On return, the first ``k`` striped positions contain the selected
   //! top-k keys.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
-  //! @param[in] k Number of keys to select. Must not exceed ``MAX_K`` or ``num_items``.
+  //! @param[in] k Number of keys to select. Must not exceed ``MaxK`` or ``num_items``.
   //! @param[in] num_items Total number of valid keys across the warp.
   //! @param[in] oob_default Default value for out-of-bound key.
-  template <int ITEMS_PER_THREAD, typename CompareOp>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void
-  TopK(KeyT (&keys)[ITEMS_PER_THREAD], CompareOp compare_op, int k, int num_items, KeyT oob_default)
+  template <int ItemsPerThread, typename CompareOp>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
+  TopK(KeyT (&keys)[ItemsPerThread], CompareOp compare_op, int k, int num_items, KeyT oob_default) const
   {
-    static_assert(KEYS_ONLY_);
-    ValueT values[ITEMS_PER_THREAD];
+    static_assert(keys_only);
+    ValueT values[ItemsPerThread];
     TopK(keys, values, compare_op, k, num_items, oob_default);
   }
 
   //! @brief Selects top-k keys from partially valid per-thread arrays across a warp.
   //!
-  //! @tparam ITEMS_PER_THREAD Number of keys per thread.
+  //! @tparam ItemsPerThread Number of keys per thread.
   //! @tparam CompareOp Comparison functor type.
   //!
   //! @param[in,out] keys Keys in striped arrangement. On return, the first ``k`` striped positions contain the selected
   //! top-k keys.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
-  //! @param[in] k Number of keys to select. Must not exceed ``MAX_K`` or ``num_items``.
+  //! @param[in] k Number of keys to select. Must not exceed ``MaxK`` or ``num_items``.
   //! @param[in] num_items Total number of valid keys across the warp.
-  template <int ITEMS_PER_THREAD, typename CompareOp>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void TopK(KeyT (&keys)[ITEMS_PER_THREAD], CompareOp compare_op, int k, int num_items)
+  template <int ItemsPerThread, typename CompareOp>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
+  TopK(KeyT (&keys)[ItemsPerThread], CompareOp compare_op, int k, int num_items) const
   {
-    static_assert(KEYS_ONLY_);
-    ValueT values[ITEMS_PER_THREAD];
+    static_assert(keys_only);
+    ValueT values[ItemsPerThread];
     TopK(keys, values, compare_op, k, num_items);
   }
 
   //! @brief Selects top-k key-value pairs from per-thread arrays across a warp.
   //!
-  //! @tparam ITEMS_PER_THREAD Number of key-value pairs per thread.
+  //! @tparam ItemsPerThread Number of key-value pairs per thread.
   //! @tparam CompareOp Comparison functor type.
   //!
   //! @param[in,out] keys Keys in striped arrangement. On return, the first ``k`` striped positions contain the selected
   //! top-k keys.
   //! @param[in,out] values Values selected together with their corresponding keys.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
-  //! @param[in] k Number of pairs to select. Must not exceed ``MAX_K``.
-  template <int ITEMS_PER_THREAD, typename CompareOp>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void
-  TopK(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], CompareOp compare_op, [[maybe_unused]] int k)
+  //! @param[in] k Number of pairs to select. Must not exceed ``MaxK``.
+  template <int ItemsPerThread, typename CompareOp>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void TopK(
+    KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread], CompareOp compare_op, [[maybe_unused]] int k) const
   {
-    static_assert(ITEMS_PER_THREAD * WARP_THREADS_ >= MAX_K);
+    static_assert(ItemsPerThread * warp_threads >= MaxK);
 
-    if constexpr (ITEMS_PER_THREAD * WARP_THREADS_ == MAX_K)
+    if constexpr (ItemsPerThread * warp_threads == MaxK)
     {
-      WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Sort_<CompareOp, false>(keys, values, compare_op);
+      MaxKSortT{}.template sort<CompareOp, false>(keys, values, compare_op);
     }
     else
     {
-      // Due to a limitation of WarpBitonicSort::Merge_, when MAX_K is not a power of 2, the result must be
+      // Due to the requirement of WarpBitonicSort::merge, when MaxK is not a power of 2, the result must be
       // reverse-sorted while merging incoming data, then reversed again at the end.
-      constexpr bool reverse = !::cuda::is_power_of_two(MAX_K);
-      WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Sort_<CompareOp, reverse>(keys, values, compare_op);
+      constexpr bool reverse = !::cuda::is_power_of_two(MaxK);
+      MaxKSortT{}.template sort<CompareOp, reverse>(keys, values, compare_op);
 
       _CCCL_PRAGMA_UNROLL_FULL()
-      for (int i = 1; i < ITEMS_PER_THREAD / max_k_per_thread_; ++i)
+      for (int i = 1; i < ItemsPerThread / max_k_per_thread; ++i)
       {
-        int offset = max_k_per_thread_ * i;
-        WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Sort_<CompareOp, !reverse>(
-          keys + offset, values + offset, compare_op);
-        compare_and_replace_<max_k_per_thread_>(keys, values, keys + offset, values + offset, compare_op);
-        WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Merge_<CompareOp, reverse>(keys, values, compare_op);
+        const int offset = max_k_per_thread * i;
+        MaxKSortT{}.template sort<CompareOp, !reverse>(keys + offset, values + offset, compare_op);
+        compare_and_replace<max_k_per_thread>(keys, values, keys + offset, values + offset, compare_op);
+        MaxKSortT{}.template merge<CompareOp, reverse>(keys, values, compare_op);
       }
 
-      if constexpr (constexpr int remain = ITEMS_PER_THREAD % max_k_per_thread_; remain != 0)
+      if constexpr (constexpr int remain = ItemsPerThread % max_k_per_thread; remain != 0)
       {
-        constexpr int offset = ITEMS_PER_THREAD / max_k_per_thread_ * max_k_per_thread_;
-        WarpBitonicSort<remain, KeyT, ValueT>::template Sort_<CompareOp, !reverse>(
-          keys + offset, values + offset, compare_op);
+        constexpr int offset = ItemsPerThread / max_k_per_thread * max_k_per_thread;
+        WarpBitonicSortT<remain>{}.template sort<CompareOp, !reverse>(keys + offset, values + offset, compare_op);
         if constexpr (reverse)
         {
-          compare_and_replace_<remain>(keys, values, keys + offset, values + offset, compare_op);
+          compare_and_replace<remain>(keys, values, keys + offset, values + offset, compare_op);
         }
         else
         {
-          compare_and_replace_<remain>(
-            keys + max_k_per_thread_ - remain,
-            values + max_k_per_thread_ - remain,
+          compare_and_replace<remain>(
+            keys + max_k_per_thread - remain,
+            values + max_k_per_thread - remain,
             keys + offset,
             values + offset,
             compare_op);
         }
-        WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Merge_<CompareOp, reverse>(keys, values, compare_op);
+        MaxKSortT{}.template merge<CompareOp, reverse>(keys, values, compare_op);
       }
 
       if constexpr (reverse)
       {
-        reverse_<max_k_per_thread_>(keys, values);
+        reverse_items<max_k_per_thread>(keys, values);
       }
     }
   }
@@ -270,29 +276,29 @@ public:
   //! @brief Selects top-k key-value pairs from partially valid per-thread arrays across a warp. An out-of-bound key
   //! ordered after any valid key must be provided.
   //!
-  //! @tparam ITEMS_PER_THREAD Number of key-value pairs per thread.
+  //! @tparam ItemsPerThread Number of key-value pairs per thread.
   //! @tparam CompareOp Comparison functor type.
   //!
   //! @param[in,out] keys Keys in striped arrangement. On return, the first ``k`` striped positions contain the selected
   //! top-k keys.
   //! @param[in,out] values Values selected together with their corresponding keys.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
-  //! @param[in] k Number of pairs to select. Must not exceed ``MAX_K`` or ``num_items``.
+  //! @param[in] k Number of pairs to select. Must not exceed ``MaxK`` or ``num_items``.
   //! @param[in] num_items Total number of valid pairs across the warp.
   //! @param[in] oob_default Default value for out-of-bound key.
-  template <int ITEMS_PER_THREAD, typename CompareOp>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void
-  TopK(KeyT (&keys)[ITEMS_PER_THREAD],
-       ValueT (&values)[ITEMS_PER_THREAD],
+  template <int ItemsPerThread, typename CompareOp>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
+  TopK(KeyT (&keys)[ItemsPerThread],
+       ValueT (&values)[ItemsPerThread],
        CompareOp compare_op,
        int k,
        int num_items,
-       KeyT oob_default)
+       KeyT oob_default) const
   {
     _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < ITEMS_PER_THREAD; ++i)
+    for (int i = 0; i < ItemsPerThread; ++i)
     {
-      if (i * WARP_THREADS_ + lane_ >= num_items)
+      if (i * warp_threads + lane >= num_items)
       {
         keys[i] = oob_default;
       }
@@ -302,70 +308,67 @@ public:
 
   //! @brief Selects top-k key-value pairs from partially valid arrays across a warp of threads.
   //!
-  //! @tparam ITEMS_PER_THREAD Number of key-value pairs per thread.
+  //! @tparam ItemsPerThread Number of key-value pairs per thread.
   //! @tparam CompareOp Comparison functor type.
   //!
   //! @param[in,out] keys Keys in striped arrangement. On return, the first ``k`` striped positions contain the selected
   //! top-k keys.
   //! @param[in,out] values Values selected together with their corresponding keys.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
-  //! @param[in] k Number of pairs to select. Must not exceed ``MAX_K`` or ``num_items``.
+  //! @param[in] k Number of pairs to select. Must not exceed ``MaxK`` or ``num_items``.
   //! @param[in] num_items Total number of valid pairs across the warp.
-  template <int ITEMS_PER_THREAD, typename CompareOp>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void
-  TopK(KeyT (&keys)[ITEMS_PER_THREAD],
-       ValueT (&values)[ITEMS_PER_THREAD],
+  template <int ItemsPerThread, typename CompareOp>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
+  TopK(KeyT (&keys)[ItemsPerThread],
+       ValueT (&values)[ItemsPerThread],
        CompareOp compare_op,
        [[maybe_unused]] int k,
-       int num_items)
+       int num_items) const
   {
-    static_assert(ITEMS_PER_THREAD * WARP_THREADS_ >= MAX_K);
+    static_assert(ItemsPerThread * warp_threads >= MaxK);
 
-    if (num_items < MAX_K) // using "<=" is slower
+    if (num_items < MaxK) // using "<=" is slower
     {
-      WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Sort_<CompareOp, false>(
-        keys, values, compare_op, num_items);
+      MaxKSortT{}.template sort<CompareOp, false>(keys, values, compare_op, num_items);
       return;
     }
 
-    WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Sort_<CompareOp, true>(keys, values, compare_op);
+    MaxKSortT{}.template sort<CompareOp, true>(keys, values, compare_op);
 
     _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = max_k_per_thread_; i <= ITEMS_PER_THREAD - max_k_per_thread_; i += max_k_per_thread_)
+    for (int i = max_k_per_thread; i <= ItemsPerThread - max_k_per_thread; i += max_k_per_thread)
     {
-      const int remain_items = num_items - i * WARP_THREADS_;
-      if (remain_items >= MAX_K)
+      const int remain_items = num_items - i * warp_threads;
+      if (remain_items >= MaxK)
       {
-        WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Sort_<CompareOp, false>(
-          keys + i, values + i, compare_op);
-        compare_and_replace_<max_k_per_thread_>(keys, values, keys + i, values + i, compare_op);
-        WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Merge_<CompareOp, true>(keys, values, compare_op);
+        MaxKSortT{}.template sort<CompareOp, false>(keys + i, values + i, compare_op);
+        compare_and_replace<max_k_per_thread>(keys, values, keys + i, values + i, compare_op);
+        MaxKSortT{}.template merge<CompareOp, true>(keys, values, compare_op);
       }
       else if (remain_items > 0)
       {
-        WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Sort_<CompareOp, false>(
-          keys + i, values + i, compare_op, remain_items);
-        compare_and_replace_<max_k_per_thread_>(keys, values, keys + i, values + i, compare_op, remain_items);
-        WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Merge_<CompareOp, true>(keys, values, compare_op);
-        reverse_<max_k_per_thread_>(keys, values);
+        MaxKSortT{}.template sort<CompareOp, false>(keys + i, values + i, compare_op, remain_items);
+        compare_and_replace<max_k_per_thread>(keys, values, keys + i, values + i, compare_op, remain_items);
+        MaxKSortT{}.template merge<CompareOp, true>(keys, values, compare_op);
+        reverse_items<max_k_per_thread>(keys, values);
         return;
       }
     }
 
-    if constexpr (constexpr int remain = ITEMS_PER_THREAD % max_k_per_thread_; remain != 0)
+    if constexpr (constexpr int remain = ItemsPerThread % max_k_per_thread; remain != 0)
     {
-      constexpr int offset   = ITEMS_PER_THREAD / max_k_per_thread_ * max_k_per_thread_;
-      const int remain_items = num_items - offset * WARP_THREADS_;
+      constexpr int offset   = ItemsPerThread / max_k_per_thread * max_k_per_thread;
+      const int remain_items = num_items - offset * warp_threads;
       if (remain_items > 0)
       {
-        WarpBitonicSort<remain, KeyT, ValueT>::template Sort_<CompareOp, false>(
+        WarpBitonicSortT<remain>{}.template sort<CompareOp, false>(
           keys + offset, values + offset, compare_op, remain_items);
-        compare_and_replace_<remain>(keys, values, keys + offset, values + offset, compare_op, remain_items);
-        WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Merge_<CompareOp, true>(keys, values, compare_op);
+        compare_and_replace<remain>(keys, values, keys + offset, values + offset, compare_op, remain_items);
+        MaxKSortT{}.template merge<CompareOp, true>(keys, values, compare_op);
       }
     }
 
-    reverse_<max_k_per_thread_>(keys, values);
+    reverse_items<max_k_per_thread>(keys, values);
   }
 
   //! @brief Selects top-k key-value pairs from iterator input.
@@ -379,70 +382,69 @@ public:
   //! @param[in] keys_in Iterator pointing to the first input key.
   //! @param[in] values_in Iterator pointing to the first input value.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
-  //! @param[in] k Number of pairs to select. Must not exceed ``MAX_K`` or ``num_items``.
+  //! @param[in] k Number of pairs to select. Must not exceed ``MaxK`` or ``num_items``.
   //! @param[in] num_items Number of input pairs.
   //! @param[out] keys_out Selected keys in striped arrangement.
   //! @param[out] values_out Values selected together with their corresponding keys.
   template <typename KeyInputIteratorT, typename ValueInputIteratorT, typename CompareOp>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
   TopK(KeyInputIteratorT keys_in,
        ValueInputIteratorT values_in,
        CompareOp compare_op,
        int k,
        int num_items,
-       KeyT (&keys_out)[MAX_K / detail::warp_threads],
-       ValueT (&values_out)[MAX_K / detail::warp_threads])
+       KeyT (&keys_out)[MaxK / detail::warp_threads],
+       ValueT (&values_out)[MaxK / detail::warp_threads])
   {
-    const int k_th_pos  = MAX_K - k;
-    const int k_th_item = k_th_pos / WARP_THREADS_;
-    const int k_th_lane = k_th_pos % WARP_THREADS_;
+    const int k_th_pos  = MaxK - k;
+    const int k_th_item = k_th_pos / warp_threads;
+    const int k_th_lane = k_th_pos % warp_threads;
 
     _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < max_k_per_thread_; ++i)
+    for (int i = 0; i < max_k_per_thread; ++i)
     {
-      int pos = i * WARP_THREADS_ + lane_;
+      const int pos = i * warp_threads + lane;
       if (pos < num_items)
       {
         keys_out[i] = keys_in[pos];
-        if constexpr (!KEYS_ONLY_)
+        if constexpr (!keys_only)
         {
           values_out[i] = values_in[pos];
         }
       }
     }
 
-    if (num_items <= MAX_K)
+    if (num_items <= MaxK)
     {
-      WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Sort_<CompareOp, false>(
-        keys_out, values_out, compare_op, num_items);
+      MaxKSortT{}.template sort<CompareOp, false>(keys_out, values_out, compare_op, num_items);
       return;
     }
 
-    WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Sort_<CompareOp, true>(keys_out, values_out, compare_op);
-    KeyT k_th          = get_key_threshold_(keys_out, k_th_item, k_th_lane);
+    MaxKSortT{}.template sort<CompareOp, true>(keys_out, values_out, compare_op);
+    KeyT k_th          = get_key_threshold(keys_out, k_th_item, k_th_lane);
     int num_candidates = 0;
 
-    const int num_items_per_thread = (num_items + WARP_THREADS_ - 1) / WARP_THREADS_;
-    for (int i = max_k_per_thread_; i < num_items_per_thread; ++i)
+    const int num_items_per_thread = (num_items + warp_threads - 1) / warp_threads;
+    for (int i = max_k_per_thread; i < num_items_per_thread; ++i)
     {
-      int pos = i * WARP_THREADS_ + lane_;
+      const int pos = i * warp_threads + lane;
       KeyT key;
       ValueT value;
       bool is_candidate = false;
       if (pos < num_items)
       {
         key = keys_in[pos];
-        if constexpr (!KEYS_ONLY_)
+        if constexpr (!keys_only)
         {
           value = values_in[pos];
         }
         is_candidate = true;
       }
-      process_candidate_(
+      process_candidate(
         keys_out, values_out, key, value, compare_op, is_candidate, k_th_item, k_th_lane, k_th, num_candidates);
     }
-    flush_candidates_(keys_out, values_out, compare_op, num_candidates);
-    reverse_<max_k_per_thread_>(keys_out, values_out);
+    flush_candidates(keys_out, values_out, compare_op, num_candidates);
+    reverse_items<max_k_per_thread>(keys_out, values_out);
   }
 
   //! @brief Selects top-k keys from iterator input.
@@ -454,38 +456,30 @@ public:
   //!
   //! @param[in] keys_in Iterator pointing to the first input key.
   //! @param[in] compare_op Comparison functor which returns true if the first argument is ordered before the second.
-  //! @param[in] k Number of keys to select. Must not exceed ``MAX_K`` or ``num_items``.
+  //! @param[in] k Number of keys to select. Must not exceed ``MaxK`` or ``num_items``.
   //! @param[in] num_items Number of input keys.
   //! @param[out] keys_out Selected keys in striped arrangement.
   template <typename KeyInputIteratorT, typename CompareOp>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void
-  TopK(KeyInputIteratorT keys_in,
-       CompareOp compare_op,
-       int k,
-       int num_items,
-       KeyT (&keys_out)[MAX_K / detail::warp_threads])
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void TopK(
+    KeyInputIteratorT keys_in, CompareOp compare_op, int k, int num_items, KeyT (&keys_out)[MaxK / detail::warp_threads])
   {
-    static_assert(KEYS_ONLY_);
-    ValueT values_out[max_k_per_thread_];
+    static_assert(keys_only);
+    ValueT values_out[max_k_per_thread];
     TopK(keys_in, nullptr, compare_op, k, num_items, keys_out, values_out);
   }
 
 private:
-  template <int LEN, typename CompareOp>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void compare_and_replace_(
-    KeyT* __restrict__ keys1,
-    ValueT* __restrict__ values1,
-    const KeyT* __restrict__ keys2,
-    const ValueT* __restrict__ values2,
-    CompareOp compare_op)
+  template <int Len, typename CompareOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void compare_and_replace(
+    KeyT* keys1, ValueT* values1, const KeyT* keys2, const ValueT* values2, CompareOp compare_op) const
   {
     _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < LEN; ++i)
+    for (int i = 0; i < Len; ++i)
     {
       if (compare_op(keys2[i], keys1[i]))
       {
         keys1[i] = keys2[i];
-        if constexpr (!KEYS_ONLY_)
+        if constexpr (!keys_only)
         {
           values1[i] = values2[i];
         }
@@ -493,22 +487,17 @@ private:
     }
   }
 
-  template <int LEN, typename CompareOp>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void compare_and_replace_(
-    KeyT* __restrict__ keys1,
-    ValueT* __restrict__ values1,
-    const KeyT* __restrict__ keys2,
-    const ValueT* __restrict__ values2,
-    CompareOp compare_op,
-    int num_items2)
+  template <int Len, typename CompareOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void compare_and_replace(
+    KeyT* keys1, ValueT* values1, const KeyT* keys2, const ValueT* values2, CompareOp compare_op, int num_items2) const
   {
     _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < LEN; ++i)
+    for (int i = 0; i < Len; ++i)
     {
-      if (i * WARP_THREADS_ + lane_ < num_items2 && compare_op(keys2[i], keys1[i]))
+      if (i * warp_threads + lane < num_items2 && compare_op(keys2[i], keys1[i]))
       {
         keys1[i] = keys2[i];
-        if constexpr (!KEYS_ONLY_)
+        if constexpr (!keys_only)
         {
           values1[i] = values2[i];
         }
@@ -516,45 +505,45 @@ private:
     }
   }
 
-  template <int LEN>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void reverse_(KeyT* __restrict__ keys, ValueT* __restrict__ values)
+  template <int Len>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void reverse_items(KeyT* keys, ValueT* values) const
   {
-    const int src_lane = WARP_THREADS_ - lane_ - 1;
+    const int src_lane = warp_threads - lane - 1;
 
     _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < LEN / 2; ++i)
+    for (int i = 0; i < Len / 2; ++i)
     {
-      const int other_i = LEN - i - 1;
+      const int other_i = Len - i - 1;
 
-      KeyT key      = keys[i];
-      keys[i]       = keys[other_i];
-      keys[other_i] = key;
+      const KeyT key = keys[i];
+      keys[i]        = keys[other_i];
+      keys[other_i]  = key;
 
-      if constexpr (!KEYS_ONLY_)
+      if constexpr (!keys_only)
       {
-        ValueT value    = values[i];
-        values[i]       = values[other_i];
-        values[other_i] = value;
+        const ValueT value = values[i];
+        values[i]          = values[other_i];
+        values[other_i]    = value;
       }
     }
 
     _CCCL_PRAGMA_UNROLL_FULL()
-    for (int i = 0; i < LEN; ++i)
+    for (int i = 0; i < Len; ++i)
     {
-      keys[i] = shuffle_idx_(keys[i], src_lane);
-      if constexpr (!KEYS_ONLY_)
+      keys[i] = shuffle_idx(keys[i], src_lane);
+      if constexpr (!keys_only)
       {
-        values[i] = shuffle_idx_(values[i], src_lane);
+        values[i] = shuffle_idx(values[i], src_lane);
       }
     }
   }
 
   template <typename T>
-  _CCCL_DEVICE _CCCL_FORCEINLINE static T shuffle_idx_(const T& value, int src_lane)
+  [[nodiscard]] _CCCL_DEVICE _CCCL_FORCEINLINE static T shuffle_idx(const T& value, int src_lane)
   {
     if constexpr (has_native_shfl_v<T>)
     {
-      return __shfl_sync(FULL_WARP_MASK_, value, src_lane);
+      return __shfl_sync(full_warp_mask, value, src_lane);
     }
     else
     {
@@ -563,9 +552,9 @@ private:
   }
 
   template <typename CompareOp>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void process_candidate_(
-    KeyT (&keys_out)[MAX_K / detail::warp_threads],
-    ValueT (&values_out)[MAX_K / detail::warp_threads],
+  _CCCL_DEVICE _CCCL_FORCEINLINE void process_candidate(
+    KeyT (&keys_out)[MaxK / detail::warp_threads],
+    ValueT (&values_out)[MaxK / detail::warp_threads],
     const KeyT& key,
     const ValueT& value,
     CompareOp compare_op,
@@ -575,108 +564,108 @@ private:
     KeyT& k_th,
     int& num_candidates)
   {
-    TempStorage_& storage = *storage_;
-    is_candidate          = is_candidate && compare_op(key, k_th);
-    uint32_t mask         = __ballot_sync(FULL_WARP_MASK_, is_candidate);
+    _TempStorage& temp_storage = *storage;
+    is_candidate               = is_candidate && compare_op(key, k_th);
+    const unsigned int mask    = __ballot_sync(full_warp_mask, is_candidate);
     if (mask == 0)
     {
       return;
     }
 
-    int pos = num_candidates + __popc(mask & ((0x1u << lane_) - 1));
-    if (is_candidate && pos < WARP_THREADS_)
+    int pos = num_candidates + ::cuda::std::popcount(mask & ((0x1u << lane) - 1));
+    if (is_candidate && pos < warp_threads)
     {
-      storage.keys[pos] = key;
-      if constexpr (!KEYS_ONLY_)
+      temp_storage.keys[pos] = key;
+      if constexpr (!keys_only)
       {
-        storage.values[pos] = value;
+        temp_storage.values[pos] = value;
       }
       is_candidate = false;
     }
-    num_candidates += __popc(mask);
-    if (num_candidates >= WARP_THREADS_)
+    num_candidates += ::cuda::std::popcount(mask);
+    if (num_candidates >= warp_threads)
     {
       __syncwarp();
       ValueT value;
-      if constexpr (!KEYS_ONLY_)
+      if constexpr (!keys_only)
       {
-        value = storage.values[lane_];
+        value = temp_storage.values[lane];
       }
-      merge_candidates_(keys_out, values_out, storage.keys[lane_], value, compare_op);
-      k_th = get_key_threshold_(keys_out, k_th_item, k_th_lane);
-      num_candidates -= WARP_THREADS_;
+      merge_candidates(keys_out, values_out, temp_storage.keys[lane], value, compare_op);
+      k_th = get_key_threshold(keys_out, k_th_item, k_th_lane);
+      num_candidates -= warp_threads;
     }
     if (is_candidate)
     {
-      pos -= WARP_THREADS_;
-      storage.keys[pos] = key;
-      if constexpr (!KEYS_ONLY_)
+      pos -= warp_threads;
+      temp_storage.keys[pos] = key;
+      if constexpr (!keys_only)
       {
-        storage.values[pos] = value;
+        temp_storage.values[pos] = value;
       }
     }
     __syncwarp();
   }
 
   template <typename CompareOp>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void flush_candidates_(
-    KeyT (&keys_out)[MAX_K / detail::warp_threads],
-    ValueT (&values_out)[MAX_K / detail::warp_threads],
+  _CCCL_DEVICE _CCCL_FORCEINLINE void flush_candidates(
+    KeyT (&keys_out)[MaxK / detail::warp_threads],
+    ValueT (&values_out)[MaxK / detail::warp_threads],
     CompareOp compare_op,
-    int num_candidates)
+    int num_candidates) const
   {
     if (num_candidates)
     {
-      TempStorage_& storage = *storage_;
-      KeyT key              = (lane_ < num_candidates) ? storage.keys[lane_] : KeyT{};
+      const _TempStorage& temp_storage = *storage;
+      KeyT key                         = (lane < num_candidates) ? temp_storage.keys[lane] : KeyT{};
       ValueT value{};
-      if constexpr (!KEYS_ONLY_)
+      if constexpr (!keys_only)
       {
-        value = (lane_ < num_candidates) ? storage.values[lane_] : ValueT{};
+        value = (lane < num_candidates) ? temp_storage.values[lane] : ValueT{};
       }
-      merge_candidates_(keys_out, values_out, key, value, compare_op, num_candidates);
+      merge_candidates(keys_out, values_out, key, value, compare_op, num_candidates);
     }
   }
 
   template <typename CompareOp>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void merge_candidates_(
-    KeyT (&keys_out)[MAX_K / detail::warp_threads],
-    ValueT (&values_out)[MAX_K / detail::warp_threads],
+  _CCCL_DEVICE _CCCL_FORCEINLINE void merge_candidates(
+    KeyT (&keys_out)[MaxK / detail::warp_threads],
+    ValueT (&values_out)[MaxK / detail::warp_threads],
     KeyT key,
     ValueT value,
-    CompareOp compare_op)
+    CompareOp compare_op) const
   {
-    WarpBitonicSort<1, KeyT, ValueT>::template Sort_<CompareOp, false>(&key, &value, compare_op);
+    CandidateSortT{}.template sort<CompareOp, false>(&key, &value, compare_op);
 
-    compare_and_replace_<1>(keys_out, values_out, &key, &value, compare_op);
+    compare_and_replace<1>(keys_out, values_out, &key, &value, compare_op);
 
-    WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Merge_<CompareOp, true>(keys_out, values_out, compare_op);
+    MaxKSortT{}.template merge<CompareOp, true>(keys_out, values_out, compare_op);
   }
 
   template <typename CompareOp>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void merge_candidates_(
-    KeyT (&keys_out)[MAX_K / detail::warp_threads],
-    ValueT (&values_out)[MAX_K / detail::warp_threads],
+  _CCCL_DEVICE _CCCL_FORCEINLINE void merge_candidates(
+    KeyT (&keys_out)[MaxK / detail::warp_threads],
+    ValueT (&values_out)[MaxK / detail::warp_threads],
     KeyT key,
     ValueT value,
     CompareOp compare_op,
-    int len)
+    int len) const
   {
-    WarpBitonicSort<1, KeyT, ValueT>::template Sort_<CompareOp, false>(&key, &value, compare_op, len);
+    CandidateSortT{}.template sort<CompareOp, false>(&key, &value, compare_op, len);
 
-    compare_and_replace_<1>(keys_out, values_out, &key, &value, compare_op, len);
+    compare_and_replace<1>(keys_out, values_out, &key, &value, compare_op, len);
 
-    WarpBitonicSort<max_k_per_thread_, KeyT, ValueT>::template Merge_<CompareOp, true>(keys_out, values_out, compare_op);
+    MaxKSortT{}.template merge<CompareOp, true>(keys_out, values_out, compare_op);
   }
 
-  _CCCL_DEVICE _CCCL_FORCEINLINE KeyT
-  get_key_threshold_(KeyT (&keys_out)[MAX_K / detail::warp_threads], int k_th_item, int k_th_lane)
+  [[nodiscard]] _CCCL_DEVICE _CCCL_FORCEINLINE KeyT
+  get_key_threshold(const KeyT (&keys_out)[MaxK / detail::warp_threads], int k_th_item, int k_th_lane) const
   {
-    return shuffle_idx_(keys_out[k_th_item], k_th_lane);
+    return shuffle_idx(keys_out[k_th_item], k_th_lane);
   }
 
-  TempStorage_* storage_;
-  int lane_ = threadIdx.x % WARP_THREADS_;
+  _TempStorage* storage;
+  int lane = static_cast<int>(::cuda::ptx::get_sreg_laneid());
 };
 } // namespace detail
 

--- a/cub/test/catch2_test_warp_bitonic_topk.cu
+++ b/cub/test/catch2_test_warp_bitonic_topk.cu
@@ -1,0 +1,610 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/warp/warp_bitonic_topk.cuh>
+
+#include <thrust/iterator/zip_iterator.h>
+
+#include <cuda/iterator>
+#include <cuda/std/type_traits>
+
+#include <algorithm>
+
+#include <c2h/catch2_test_helper.h>
+
+struct CustomLess
+{
+  template <typename T>
+  __device__ __host__ bool operator()(const T& lhs, const T& rhs) const
+  {
+    return lhs < rhs;
+  }
+};
+
+constexpr int WARP_THREADS = cub::detail::warp_threads;
+
+/**
+ * @brief Kernel to dispatch to the appropriate WarpBitonicTopK member function, for keys-only.
+ */
+template <int MAX_K, int ITEMS_PER_THREAD, int TOTAL_WARPS, typename KeyT, typename ActionT>
+__global__ void warp_bitonic_topk_kernel(KeyT* keys_in, KeyT* keys_out, int k, int num_items, ActionT action)
+{
+  using warp_bitonic_topk_t = cub::detail::WarpBitonicTopK<MAX_K, KeyT>;
+
+  // Get linear thread and warp index
+  const int tid     = threadIdx.x;
+  const int warp_id = tid / WARP_THREADS;
+  const int lane    = tid % WARP_THREADS;
+
+  // Test case of partially finished CTA
+  if (warp_id >= TOTAL_WARPS)
+  {
+    return;
+  }
+
+  // Thread-local storage
+  KeyT keys[ITEMS_PER_THREAD];
+
+  // Instantiate warp-scope algorithm
+  warp_bitonic_topk_t warp_topk;
+
+  // Load data
+  for (int i = 0; i < ITEMS_PER_THREAD; ++i)
+  {
+    const int idx = i * WARP_THREADS + lane;
+    if (idx < num_items)
+    {
+      keys[i] = keys_in[num_items * warp_id + idx];
+    }
+  }
+
+  // Run bitonic topk
+  action(warp_topk, keys, k, num_items);
+
+  // Store data
+  for (int i = 0; i < ITEMS_PER_THREAD; ++i)
+  {
+    const int idx = i * WARP_THREADS + lane;
+    if (idx < k)
+    {
+      keys_out[k * warp_id + idx] = keys[i];
+    }
+  }
+}
+
+template <int MAX_K, int ITEMS_PER_THREAD, int TOTAL_WARPS, typename KeyT, typename ActionT>
+__global__ void warp_bitonic_topk_iterator_kernel(KeyT* keys_in, KeyT* keys_out, int k, int num_items, ActionT action)
+{
+  using warp_bitonic_topk_t = cub::detail::WarpBitonicTopK<MAX_K, KeyT>;
+
+  // Get linear thread and warp index
+  const int tid     = threadIdx.x;
+  const int warp_id = tid / WARP_THREADS;
+  const int lane    = tid % WARP_THREADS;
+
+  // Test case of partially finished CTA
+  if (warp_id >= TOTAL_WARPS)
+  {
+    return;
+  }
+
+  // Thread-local storage
+  KeyT keys[MAX_K / WARP_THREADS];
+
+  // Instantiate warp-scope algorithm
+  __shared__ typename warp_bitonic_topk_t::TempStorage temp_storage[TOTAL_WARPS];
+  warp_bitonic_topk_t warp_topk(temp_storage[warp_id]);
+
+  // Run bitonic topk
+  const int in_offset = num_items * warp_id;
+  action(warp_topk, keys_in + in_offset, k, num_items, keys);
+
+  // Store data
+  for (int i = 0; i < MAX_K / WARP_THREADS; ++i)
+  {
+    const int idx = i * WARP_THREADS + lane;
+    if (idx < k)
+    {
+      keys_out[k * warp_id + idx] = keys[i];
+    }
+  }
+}
+
+/**
+ * @brief Kernel to dispatch to the appropriate WarpBitonicTopK member function, for key-value
+ * pairs.
+ */
+template <int MAX_K, int ITEMS_PER_THREAD, int TOTAL_WARPS, typename KeyT, typename ValueT, typename ActionT>
+__global__ void warp_bitonic_topk_kernel(
+  KeyT* keys_in, KeyT* keys_out, ValueT* values_in, ValueT* values_out, int k, int num_items, ActionT action)
+{
+  using warp_bitonic_topk_t = cub::detail::WarpBitonicTopK<MAX_K, KeyT, ValueT>;
+
+  // Get linear thread and warp index
+  const int tid     = threadIdx.x;
+  const int warp_id = tid / WARP_THREADS;
+  const int lane    = tid % WARP_THREADS;
+
+  // Test case of partially finished CTA
+  if (warp_id >= TOTAL_WARPS)
+  {
+    return;
+  }
+
+  // Thread-local storage
+  KeyT keys[ITEMS_PER_THREAD];
+  ValueT values[ITEMS_PER_THREAD];
+
+  // Instantiate warp-scope algorithm
+  warp_bitonic_topk_t warp_topk;
+
+  // Load data
+  for (int i = 0; i < ITEMS_PER_THREAD; ++i)
+  {
+    const int idx = i * WARP_THREADS + lane;
+    if (idx < num_items)
+    {
+      keys[i]   = keys_in[num_items * warp_id + idx];
+      values[i] = values_in[num_items * warp_id + idx];
+    }
+  }
+
+  // Run bitonic topk
+  action(warp_topk, keys, values, k, num_items);
+
+  // Store data
+  for (int i = 0; i < ITEMS_PER_THREAD; ++i)
+  {
+    const int idx = i * WARP_THREADS + lane;
+    if (idx < k)
+    {
+      keys_out[k * warp_id + idx]   = keys[i];
+      values_out[k * warp_id + idx] = values[i];
+    }
+  }
+}
+
+template <int MAX_K, int ITEMS_PER_THREAD, int TOTAL_WARPS, typename KeyT, typename ValueT, typename ActionT>
+__global__ void warp_bitonic_topk_iterator_kernel(
+  KeyT* keys_in, KeyT* keys_out, ValueT* values_in, ValueT* values_out, int k, int num_items, ActionT action)
+{
+  using warp_bitonic_topk_t = cub::detail::WarpBitonicTopK<MAX_K, KeyT, ValueT>;
+
+  // Get linear thread and warp index
+  const int tid     = threadIdx.x;
+  const int warp_id = tid / WARP_THREADS;
+  const int lane    = tid % WARP_THREADS;
+
+  // Test case of partially finished CTA
+  if (warp_id >= TOTAL_WARPS)
+  {
+    return;
+  }
+
+  // Thread-local storage
+  KeyT keys[MAX_K / WARP_THREADS];
+  ValueT values[MAX_K / WARP_THREADS];
+
+  // Instantiate warp-scope algorithm
+  __shared__ typename warp_bitonic_topk_t::TempStorage temp_storage[TOTAL_WARPS];
+  warp_bitonic_topk_t warp_topk(temp_storage[warp_id]);
+
+  // Run bitonic topk
+  const int in_offset = num_items * warp_id;
+  action(warp_topk, keys_in + in_offset, values_in + in_offset, k, num_items, keys, values);
+
+  // Store data
+  for (int i = 0; i < MAX_K / WARP_THREADS; ++i)
+  {
+    const int idx = i * WARP_THREADS + lane;
+    if (idx < k)
+    {
+      keys_out[k * warp_id + idx]   = keys[i];
+      values_out[k * warp_id + idx] = values[i];
+    }
+  }
+}
+
+// -----------------------------------------------------------
+// Dimensions being instantiated:
+// {full,partial,partial-iterator} x {keys, kv-pairs}
+// -----------------------------------------------------------
+
+/**
+ * @brief Delegate wrapper for WarpBitonicTopK::TopK on keys-only
+ */
+struct topk_keys_t
+{
+  template <int ITEMS_PER_THREAD, typename KeyT, typename WarpTopKT>
+  __device__ void operator()(WarpTopKT& warp_topk, KeyT (&thread_data)[ITEMS_PER_THREAD], int k, int /*num_items*/) const
+  {
+    warp_topk.TopK(thread_data, CustomLess{}, k);
+  }
+
+  static constexpr bool use_iterator{false};
+};
+
+/**
+ * @brief Delegate wrapper for partial WarpBitonicTopK::TopK on keys-only
+ */
+struct partial_topk_keys_t
+{
+  template <int ITEMS_PER_THREAD, typename KeyT, typename WarpTopKT>
+  __device__ void operator()(WarpTopKT& warp_topk, KeyT (&thread_data)[ITEMS_PER_THREAD], int k, int num_items) const
+  {
+    warp_topk.TopK(thread_data, CustomLess{}, k, num_items);
+  }
+
+  static constexpr bool use_iterator{false};
+};
+
+struct partial_topk_keys_iterator_t
+{
+  template <int MAX_K_PER_THREAD, typename KeyInputIteratorT, typename KeyT, typename WarpTopKT>
+  __device__ void operator()(
+    WarpTopKT& warp_topk, KeyInputIteratorT keys_in, int k, int num_items, KeyT (&keys_out)[MAX_K_PER_THREAD]) const
+  {
+    warp_topk.TopK(keys_in, CustomLess{}, k, num_items, keys_out);
+  }
+
+  static constexpr bool use_iterator{true};
+};
+
+/**
+ * @brief Delegate wrapper for WarpBitonicTopK::TopK on key-value pairs
+ */
+struct topk_pairs_t
+{
+  template <int ITEMS_PER_THREAD, typename KeyT, typename ValueT, typename WarpTopKT>
+  __device__ void operator()(
+    WarpTopKT& warp_topk, KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], int k, int /*num_items*/
+  ) const
+  {
+    warp_topk.TopK(keys, values, CustomLess{}, k);
+  }
+
+  static constexpr bool use_iterator{false};
+};
+
+/**
+ * @brief Delegate wrapper for partial WarpBitonicTopK::TopK on key-value pairs
+ */
+struct partial_topk_pairs_t
+{
+  template <int ITEMS_PER_THREAD, typename KeyT, typename ValueT, typename WarpTopKT>
+  __device__ void operator()(
+    WarpTopKT& warp_topk, KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], int k, int num_items) const
+  {
+    warp_topk.TopK(keys, values, CustomLess{}, k, num_items);
+  }
+
+  static constexpr bool use_iterator{false};
+};
+
+struct partial_topk_pairs_iterator_t
+{
+  template <int MAX_K_PER_THREAD,
+            typename KeyInputIteratorT,
+            typename ValueInputIteratorT,
+            typename KeyT,
+            typename ValueT,
+            typename WarpTopKT>
+  __device__ void operator()(
+    WarpTopKT& warp_topk,
+    KeyInputIteratorT keys_in,
+    ValueInputIteratorT values_in,
+    int k,
+    int num_items,
+    KeyT (&keys_out)[MAX_K_PER_THREAD],
+    ValueT (&values_out)[MAX_K_PER_THREAD]) const
+  {
+    warp_topk.TopK(keys_in, values_in, CustomLess{}, k, num_items, keys_out, values_out);
+  }
+
+  static constexpr bool use_iterator{true};
+};
+
+/**
+ * @brief Dispatch helper function for keys
+ */
+template <int MAX_K, int ITEMS_PER_THREAD, int TOTAL_WARPS, typename KeyT, typename ActionT>
+void warp_bitonic_topk(c2h::device_vector<KeyT>& in, c2h::device_vector<KeyT>& out, int k, int num_items, ActionT action)
+{
+  using Kernel = void (*)(KeyT*, KeyT*, int, int, ActionT);
+  Kernel kernel;
+  if constexpr (ActionT::use_iterator)
+  {
+    kernel = warp_bitonic_topk_iterator_kernel<MAX_K, ITEMS_PER_THREAD, TOTAL_WARPS, KeyT, ActionT>;
+  }
+  else
+  {
+    kernel = warp_bitonic_topk_kernel<MAX_K, ITEMS_PER_THREAD, TOTAL_WARPS, KeyT, ActionT>;
+  }
+
+  kernel<<<1, WARP_THREADS * TOTAL_WARPS>>>(
+    thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), k, num_items, action);
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+}
+
+/**
+ * @brief Dispatch helper function for key-value pairs
+ */
+template <int MAX_K, int ITEMS_PER_THREAD, int TOTAL_WARPS, typename KeyT, typename ValueT, typename ActionT>
+void warp_bitonic_topk(
+  c2h::device_vector<KeyT>& keys_in,
+  c2h::device_vector<KeyT>& keys_out,
+  c2h::device_vector<ValueT>& values_in,
+  c2h::device_vector<ValueT>& values_out,
+  int k,
+  int num_items,
+  ActionT action)
+{
+  using Kernel = void (*)(KeyT*, KeyT*, ValueT*, ValueT*, int, int, ActionT);
+  Kernel kernel;
+  if constexpr (ActionT::use_iterator)
+  {
+    kernel = warp_bitonic_topk_iterator_kernel<MAX_K, ITEMS_PER_THREAD, TOTAL_WARPS, KeyT, ValueT, ActionT>;
+  }
+  else
+  {
+    kernel = warp_bitonic_topk_kernel<MAX_K, ITEMS_PER_THREAD, TOTAL_WARPS, KeyT, ValueT, ActionT>;
+  }
+
+  kernel<<<1, WARP_THREADS * TOTAL_WARPS>>>(
+    thrust::raw_pointer_cast(keys_in.data()),
+    thrust::raw_pointer_cast(keys_out.data()),
+    thrust::raw_pointer_cast(values_in.data()),
+    thrust::raw_pointer_cast(values_out.data()),
+    k,
+    num_items,
+    action);
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+}
+
+template <typename KeyT>
+void verify_topk_result(
+  const c2h::device_vector<KeyT>& d_keys_in, const c2h::device_vector<KeyT>& d_keys_out, int total_warps)
+{
+  c2h::host_vector<KeyT> keys_in  = d_keys_in;
+  c2h::host_vector<KeyT> keys_out = d_keys_out;
+
+  const int num_items = keys_in.size() / total_warps;
+  const int k         = keys_out.size() / total_warps;
+
+  for (int warp_id = 0; warp_id < total_warps; ++warp_id)
+  {
+    const int in_offset  = warp_id * num_items;
+    const int out_offset = warp_id * k;
+
+    // the keys of WarpBitonicTopK result are sorted, so we check it using std::sort
+    std::sort(keys_in.begin() + in_offset, keys_in.begin() + in_offset + num_items);
+    REQUIRE(c2h::host_vector<KeyT>(keys_in.begin() + in_offset, keys_in.begin() + in_offset + k)
+            == c2h::host_vector<KeyT>(keys_out.begin() + out_offset, keys_out.begin() + out_offset + k));
+  }
+}
+
+template <typename KeyT, typename ValueT>
+void verify_topk_result(
+  const c2h::device_vector<KeyT>& d_keys_in,
+  const c2h::device_vector<ValueT>& d_values_in,
+  const c2h::device_vector<KeyT>& d_keys_out,
+  const c2h::device_vector<ValueT>& d_values_out,
+  int total_warps)
+{
+  c2h::host_vector<KeyT> keys_in      = d_keys_in;
+  c2h::host_vector<ValueT> values_in  = d_values_in;
+  c2h::host_vector<KeyT> keys_out     = d_keys_out;
+  c2h::host_vector<ValueT> values_out = d_values_out;
+
+  const int num_items = keys_in.size() / total_warps;
+  const int k         = keys_out.size() / total_warps;
+
+  for (int warp_id = 0; warp_id < total_warps; ++warp_id)
+  {
+    const int in_offset  = warp_id * num_items;
+    const int out_offset = warp_id * k;
+
+    auto pair_in_begin  = thrust::make_zip_iterator(keys_in.begin() + in_offset, values_in.begin() + in_offset);
+    auto pair_in_end    = pair_in_begin + num_items;
+    auto pair_begin_end = thrust::make_zip_iterator(keys_out.begin() + out_offset, values_out.begin() + out_offset);
+    auto pair_out_end   = pair_begin_end + k;
+
+    std::sort(pair_in_begin, pair_in_end);
+    // the keys of WarpBitonicTopK result are sorted, so we check it before std::sort(pair_begin_end, pair_out_end)
+    REQUIRE(c2h::host_vector<KeyT>(keys_in.begin() + in_offset, keys_in.begin() + in_offset + k)
+            == c2h::host_vector<KeyT>(keys_out.begin() + out_offset, keys_out.begin() + out_offset + k));
+
+    // Top-k results are not unique when ties exist at the k-th key, so further check that each output (key, value) pair
+    // appears in the input
+    std::sort(pair_begin_end, pair_out_end);
+    REQUIRE(std::includes(pair_in_begin, pair_in_end, pair_begin_end, pair_out_end));
+  }
+}
+
+// List of key types to test
+using key_types = c2h::type_list<std::uint8_t, std::int32_t, std::int64_t>;
+
+// List of value types
+using value_types = c2h::type_list<std::int32_t>;
+
+using max_k_list                  = c2h::enum_type_list<int, WARP_THREADS, WARP_THREADS * 2, WARP_THREADS * 3>;
+using extra_items_per_thread_list = c2h::enum_type_list<int, 0, 1, 2, 3, 4, 5, 6, 7>;
+
+template <typename TestType>
+struct params_t
+{
+  using type = typename c2h::get<0, TestType>;
+
+  static constexpr int max_k                  = c2h::get<1, TestType>::value;
+  static constexpr int extra_items_per_thread = c2h::get<2, TestType>::value;
+  static constexpr int items_per_thread       = max_k / WARP_THREADS + extra_items_per_thread;
+  static constexpr int total_warps            = 2;
+};
+
+C2H_TEST("Warp topk on keys works", "[topk][warp]", key_types, max_k_list, extra_items_per_thread_list)
+{
+  using params                   = params_t<TestType>;
+  using key_type                 = typename params::type;
+  constexpr int max_k            = params::max_k;
+  constexpr int items_per_thread = params::items_per_thread;
+  constexpr int total_warps      = params::total_warps;
+
+  // Prepare test data
+  const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
+  const int num_items = items_per_thread * WARP_THREADS;
+  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
+  c2h::device_vector<key_type> d_keys_out(total_warps * k);
+  c2h::gen(C2H_SEED(10), d_keys_in);
+
+  // Run test
+  warp_bitonic_topk<max_k, items_per_thread, total_warps>(d_keys_in, d_keys_out, k, num_items, topk_keys_t{});
+
+  // Verify results
+  verify_topk_result(d_keys_in, d_keys_out, total_warps);
+}
+
+C2H_TEST(
+  "Warp topk on keys of a partial warp-tile works", "[topk][warp]", key_types, max_k_list, extra_items_per_thread_list)
+{
+  using params                   = params_t<TestType>;
+  using key_type                 = typename params::type;
+  constexpr int max_k            = params::max_k;
+  constexpr int items_per_thread = params::items_per_thread;
+  constexpr int total_warps      = params::total_warps;
+
+  // Prepare test data
+  const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
+  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * WARP_THREADS)));
+  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
+  c2h::device_vector<key_type> d_keys_out(total_warps * k);
+  c2h::gen(C2H_SEED(5), d_keys_in);
+
+  // Run test
+  warp_bitonic_topk<max_k, items_per_thread, total_warps>(d_keys_in, d_keys_out, k, num_items, partial_topk_keys_t{});
+
+  // Verify results
+  verify_topk_result(d_keys_in, d_keys_out, total_warps);
+}
+
+C2H_TEST("Warp topk iterator on keys of a partial warp-tile works",
+         "[topk][warp]",
+         key_types,
+         max_k_list,
+         c2h::enum_type_list<int, 0>)
+{
+  using params                   = params_t<TestType>;
+  using key_type                 = typename params::type;
+  constexpr int max_k            = params::max_k;
+  constexpr int items_per_thread = params::items_per_thread;
+  constexpr int total_warps      = params::total_warps;
+
+  // Prepare test data
+  const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
+  const int num_items = GENERATE_COPY(k, k + 1, take(5, random(k + 2, k + 100)), take(5, random(k + 100, k + 1000)));
+  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
+  c2h::device_vector<key_type> d_keys_out(total_warps * k);
+  c2h::gen(C2H_SEED(5), d_keys_in);
+
+  // Run test
+  warp_bitonic_topk<max_k, items_per_thread, total_warps>(
+    d_keys_in, d_keys_out, k, num_items, partial_topk_keys_iterator_t{});
+
+  // Verify results
+  verify_topk_result(d_keys_in, d_keys_out, total_warps);
+}
+
+C2H_TEST(
+  "Warp topk on keys-value pairs works", "[topk][warp]", key_types, max_k_list, extra_items_per_thread_list, value_types)
+{
+  using params                   = params_t<TestType>;
+  using key_type                 = typename params::type;
+  using value_type               = typename c2h::get<3, TestType>;
+  constexpr int max_k            = params::max_k;
+  constexpr int items_per_thread = params::items_per_thread;
+  constexpr int total_warps      = params::total_warps;
+
+  // Prepare test data
+  const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
+  const int num_items = items_per_thread * WARP_THREADS;
+  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
+  c2h::device_vector<value_type> d_values_in(total_warps * num_items);
+  c2h::device_vector<key_type> d_keys_out(total_warps * k);
+  c2h::device_vector<value_type> d_values_out(total_warps * k);
+  c2h::gen(C2H_SEED(10), d_keys_in);
+  c2h::gen(C2H_SEED(1), d_values_in);
+
+  // Run test
+  warp_bitonic_topk<max_k, items_per_thread, total_warps>(
+    d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, topk_pairs_t{});
+
+  // Verify results
+  verify_topk_result(d_keys_in, d_values_in, d_keys_out, d_values_out, total_warps);
+}
+
+C2H_TEST("Warp topk on key-value pairs of a partial warp-tile works",
+         "[topk][warp]",
+         key_types,
+         max_k_list,
+         extra_items_per_thread_list,
+         value_types)
+{
+  using params                   = params_t<TestType>;
+  using key_type                 = typename params::type;
+  using value_type               = typename c2h::get<3, TestType>;
+  constexpr int max_k            = params::max_k;
+  constexpr int items_per_thread = params::items_per_thread;
+  constexpr int total_warps      = params::total_warps;
+
+  // Prepare test data
+  const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
+  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * WARP_THREADS)));
+  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
+  c2h::device_vector<value_type> d_values_in(total_warps * num_items);
+  c2h::device_vector<key_type> d_keys_out(total_warps * k);
+  c2h::device_vector<value_type> d_values_out(total_warps * k);
+  c2h::gen(C2H_SEED(5), d_keys_in);
+  c2h::gen(C2H_SEED(1), d_values_in);
+
+  // Run test
+  warp_bitonic_topk<max_k, items_per_thread, total_warps>(
+    d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, partial_topk_pairs_t{});
+
+  // Verify results
+  verify_topk_result(d_keys_in, d_values_in, d_keys_out, d_values_out, total_warps);
+}
+
+C2H_TEST("Warp topk iterator on key-value pairs of a partial warp-tile works",
+         "[topk][warp]",
+         key_types,
+         max_k_list,
+         c2h::enum_type_list<int, 0>, // unused
+         value_types)
+{
+  using params                   = params_t<TestType>;
+  using key_type                 = typename params::type;
+  using value_type               = typename c2h::get<3, TestType>;
+  constexpr int max_k            = params::max_k;
+  constexpr int items_per_thread = params::items_per_thread;
+  constexpr int total_warps      = params::total_warps;
+
+  // Prepare test data
+  const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
+  const int num_items = GENERATE_COPY(k, k + 1, take(5, random(k + 2, k + 100)), take(5, random(k + 100, k + 1000)));
+  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
+  c2h::device_vector<value_type> d_values_in(total_warps * num_items);
+  c2h::device_vector<key_type> d_keys_out(total_warps * k);
+  c2h::device_vector<value_type> d_values_out(total_warps * k);
+  c2h::gen(C2H_SEED(5), d_keys_in);
+  c2h::gen(C2H_SEED(1), d_values_in);
+
+  // Run test
+  warp_bitonic_topk<max_k, items_per_thread, total_warps>(
+    d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, partial_topk_pairs_iterator_t{});
+
+  // Verify results
+  verify_topk_result(d_keys_in, d_values_in, d_keys_out, d_values_out, total_warps);
+}

--- a/cub/test/catch2_test_warp_bitonic_topk.cu
+++ b/cub/test/catch2_test_warp_bitonic_topk.cu
@@ -18,6 +18,7 @@
 
 #include "cub_test_macros.h"
 #include <c2h/catch2_test_helper.h>
+#include <c2h/custom_type.h>
 
 struct CustomLess
 {
@@ -56,7 +57,7 @@ template <WarpBitonicTopKAlgorithm Algo,
           typename ActionT>
 __global__ void array_kernel(KeyT* keys_in, KeyT* keys_out, int k, int num_items, ActionT action)
 {
-  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, cub::NullType, Algo, LogicalWarpThreads>;
+  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, LogicalWarpThreads, cub::NullType, Algo>;
 
   // Get linear thread and warp index
   const int tid     = threadIdx.x;
@@ -109,7 +110,7 @@ template <WarpBitonicTopKAlgorithm Algo,
           typename ActionT>
 __global__ void iterator_kernel(KeyT* keys_in, KeyT* keys_out, int k, int num_items, ActionT action)
 {
-  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, cub::NullType, Algo, LogicalWarpThreads>;
+  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, LogicalWarpThreads, cub::NullType, Algo>;
 
   // Get linear thread and warp index
   const int tid     = threadIdx.x;
@@ -159,7 +160,7 @@ template <WarpBitonicTopKAlgorithm Algo,
 __global__ void
 array_kernel(KeyT* keys_in, KeyT* keys_out, ValueT* values_in, ValueT* values_out, int k, int num_items, ActionT action)
 {
-  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT, Algo, LogicalWarpThreads>;
+  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, LogicalWarpThreads, ValueT, Algo>;
 
   // Get linear thread and warp index
   const int tid     = threadIdx.x;
@@ -217,7 +218,7 @@ template <WarpBitonicTopKAlgorithm Algo,
 __global__ void iterator_kernel(
   KeyT* keys_in, KeyT* keys_out, ValueT* values_in, ValueT* values_out, int k, int num_items, ActionT action)
 {
-  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT, Algo, LogicalWarpThreads>;
+  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, LogicalWarpThreads, ValueT, Algo>;
 
   // Get linear thread and warp index
   const int tid     = threadIdx.x;
@@ -256,7 +257,7 @@ __global__ void iterator_kernel(
 
 // -----------------------------------------------------------
 // Dimensions being instantiated:
-// {full,partial-oob,partial,partial-iterator} x {keys, kv-pairs}
+// {full,partial-oob,partial,iterator} x {keys, kv-pairs}
 // -----------------------------------------------------------
 
 /**
@@ -509,7 +510,6 @@ using value_types = c2h::type_list<std::int32_t>;
 
 using algo_list =
   c2h::enum_type_list<WarpBitonicTopKAlgorithm, WarpBitonicTopKAlgorithm::eager, WarpBitonicTopKAlgorithm::buffered>;
-using eager_algo_list             = c2h::enum_type_list<WarpBitonicTopKAlgorithm, WarpBitonicTopKAlgorithm::eager>;
 using logical_warp_threads_list   = c2h::enum_type_list<int, 1, 4, warp_threads>;
 using max_k_per_thread_list       = c2h::enum_type_list<int, 1, 2, 3>;
 using extra_items_per_thread_list = c2h::enum_type_list<int, 0, 1, 2, 3, 4>;
@@ -530,6 +530,58 @@ struct params_t
     (logical_warp_threads == warp_threads) ? 2 : (2 * warp_threads / logical_warp_threads - 1);
 };
 
+template <typename TestType, typename ActionT>
+void test_topk_keys(int k, int num_items)
+{
+  using params                       = params_t<TestType>;
+  using key_type                     = typename params::type;
+  constexpr auto algo                = params::algo;
+  constexpr int logical_warp_threads = params::logical_warp_threads;
+  constexpr int max_k                = params::max_k;
+  constexpr int items_per_thread     = params::items_per_thread;
+  constexpr int total_warps          = params::total_warps;
+
+  // Prepare test data
+  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
+  c2h::device_vector<key_type> d_keys_out(total_warps * k);
+  c2h::gen(C2H_SEED(5), d_keys_in);
+
+  // Run test
+  warp_bitonic_topk<algo, logical_warp_threads, max_k, items_per_thread, total_warps>(
+    d_keys_in, d_keys_out, k, num_items, ActionT{});
+
+  // Verify results
+  verify_topk_result(d_keys_in, d_keys_out, total_warps);
+}
+
+template <typename TestType, typename ActionT>
+void test_topk_pairs(int k, int num_items)
+{
+  using params                       = params_t<TestType>;
+  using key_type                     = typename params::type;
+  using value_type                   = typename c2h::get<5, TestType>;
+  constexpr auto algo                = params::algo;
+  constexpr int logical_warp_threads = params::logical_warp_threads;
+  constexpr int max_k                = params::max_k;
+  constexpr int items_per_thread     = params::items_per_thread;
+  constexpr int total_warps          = params::total_warps;
+
+  // Prepare test data
+  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
+  c2h::device_vector<value_type> d_values_in(total_warps * num_items);
+  c2h::device_vector<key_type> d_keys_out(total_warps * k);
+  c2h::device_vector<value_type> d_values_out(total_warps * k);
+  c2h::gen(C2H_SEED(5), d_keys_in);
+  c2h::gen(C2H_SEED(1), d_values_in);
+
+  // Run test
+  warp_bitonic_topk<algo, logical_warp_threads, max_k, items_per_thread, total_warps>(
+    d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, ActionT{});
+
+  // Verify results
+  verify_topk_result(d_keys_in, d_values_in, d_keys_out, d_values_out, total_warps);
+}
+
 CUB_TEST("Warp top-k on keys works",
          "[topk][warp]",
          CUB_SMALL,
@@ -539,59 +591,31 @@ CUB_TEST("Warp top-k on keys works",
          max_k_per_thread_list,
          extra_items_per_thread_list)
 {
-  using params                       = params_t<TestType>;
-  using key_type                     = typename params::type;
-  constexpr auto algo                = params::algo;
-  constexpr int logical_warp_threads = params::logical_warp_threads;
-  constexpr int max_k                = params::max_k;
-  constexpr int items_per_thread     = params::items_per_thread;
-  constexpr int total_warps          = params::total_warps;
+  using params        = params_t<TestType>;
+  constexpr int max_k = params::max_k;
 
-  // Prepare test data
-  const int k         = GENERATE_COPY(1, max_k > 1 ? max_k - 1 : max_k, max_k, take(5, random(1, max_k)));
-  const int num_items = items_per_thread * logical_warp_threads;
-  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
-  c2h::device_vector<key_type> d_keys_out(total_warps * k);
-  c2h::gen(C2H_SEED(10), d_keys_in);
+  const int k         = GENERATE_COPY(1, max_k, take(5, random(1, max_k)));
+  const int num_items = params::items_per_thread * params::logical_warp_threads;
 
-  // Run test
-  warp_bitonic_topk<algo, logical_warp_threads, max_k, items_per_thread, total_warps>(
-    d_keys_in, d_keys_out, k, num_items, topk_keys_full_t{});
-
-  // Verify results
-  verify_topk_result(d_keys_in, d_keys_out, total_warps);
+  test_topk_keys<TestType, topk_keys_full_t>(k, num_items);
 }
 
 CUB_TEST("Warp top-k on keys of a partial warp-tile with an OOB default works",
          "[topk][warp]",
          CUB_SMALL,
          key_types,
-         eager_algo_list,
+         c2h::enum_type_list<WarpBitonicTopKAlgorithm, WarpBitonicTopKAlgorithm::eager>,
          logical_warp_threads_list,
          max_k_per_thread_list,
          extra_items_per_thread_list)
 {
-  using params                       = params_t<TestType>;
-  using key_type                     = typename params::type;
-  constexpr auto algo                = params::algo;
-  constexpr int logical_warp_threads = params::logical_warp_threads;
-  constexpr int max_k                = params::max_k;
-  constexpr int items_per_thread     = params::items_per_thread;
-  constexpr int total_warps          = params::total_warps;
+  using params        = params_t<TestType>;
+  constexpr int max_k = params::max_k;
 
-  // Prepare test data
-  const int k         = GENERATE_COPY(1, max_k > 1 ? max_k - 1 : max_k, max_k, take(5, random(1, max_k)));
-  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * logical_warp_threads)));
-  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
-  c2h::device_vector<key_type> d_keys_out(total_warps * k);
-  c2h::gen(C2H_SEED(5), d_keys_in);
+  const int k         = GENERATE_COPY(1, max_k, take(5, random(1, max_k)));
+  const int num_items = GENERATE_COPY(k, take(5, random(k, params::items_per_thread * params::logical_warp_threads)));
 
-  // Run test
-  warp_bitonic_topk<algo, logical_warp_threads, max_k, items_per_thread, total_warps>(
-    d_keys_in, d_keys_out, k, num_items, topk_keys_partial_oob_t{});
-
-  // Verify results
-  verify_topk_result(d_keys_in, d_keys_out, total_warps);
+  test_topk_keys<TestType, topk_keys_partial_oob_t>(k, num_items);
 }
 
 CUB_TEST("Warp top-k on keys of a partial warp-tile works",
@@ -603,59 +627,31 @@ CUB_TEST("Warp top-k on keys of a partial warp-tile works",
          max_k_per_thread_list,
          extra_items_per_thread_list)
 {
-  using params                       = params_t<TestType>;
-  using key_type                     = typename params::type;
-  constexpr auto algo                = params::algo;
-  constexpr int logical_warp_threads = params::logical_warp_threads;
-  constexpr int max_k                = params::max_k;
-  constexpr int items_per_thread     = params::items_per_thread;
-  constexpr int total_warps          = params::total_warps;
+  using params        = params_t<TestType>;
+  constexpr int max_k = params::max_k;
 
-  // Prepare test data
-  const int k         = GENERATE_COPY(1, max_k > 1 ? max_k - 1 : max_k, max_k, take(5, random(1, max_k)));
-  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * logical_warp_threads)));
-  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
-  c2h::device_vector<key_type> d_keys_out(total_warps * k);
-  c2h::gen(C2H_SEED(5), d_keys_in);
+  const int k         = GENERATE_COPY(1, max_k, take(5, random(1, max_k)));
+  const int num_items = GENERATE_COPY(k, take(5, random(k, params::items_per_thread * params::logical_warp_threads)));
 
-  // Run test
-  warp_bitonic_topk<algo, logical_warp_threads, max_k, items_per_thread, total_warps>(
-    d_keys_in, d_keys_out, k, num_items, topk_keys_partial_t{});
-
-  // Verify results
-  verify_topk_result(d_keys_in, d_keys_out, total_warps);
+  test_topk_keys<TestType, topk_keys_partial_t>(k, num_items);
 }
 
 CUB_TEST("Warp top-k iterator on keys of a partial warp-tile works",
          "[topk][warp]",
          CUB_SMALL,
          key_types,
-         algo_list,
+         c2h::enum_type_list<WarpBitonicTopKAlgorithm, WarpBitonicTopKAlgorithm::buffered>,
          logical_warp_threads_list,
          max_k_per_thread_list,
          c2h::enum_type_list<int, 0>)
 {
-  using params                       = params_t<TestType>;
-  using key_type                     = typename params::type;
-  constexpr auto algo                = params::algo;
-  constexpr int logical_warp_threads = params::logical_warp_threads;
-  constexpr int max_k                = params::max_k;
-  constexpr int items_per_thread     = params::items_per_thread;
-  constexpr int total_warps          = params::total_warps;
+  using params        = params_t<TestType>;
+  constexpr int max_k = params::max_k;
 
-  // Prepare test data
-  const int k         = GENERATE_COPY(1, max_k > 1 ? max_k - 1 : max_k, max_k, take(5, random(1, max_k)));
+  const int k         = GENERATE_COPY(1, max_k, take(5, random(1, max_k)));
   const int num_items = GENERATE_COPY(k, k + 1, take(5, random(k + 2, k + 100)), take(5, random(k + 100, k + 1000)));
-  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
-  c2h::device_vector<key_type> d_keys_out(total_warps * k);
-  c2h::gen(C2H_SEED(5), d_keys_in);
 
-  // Run test
-  warp_bitonic_topk<algo, logical_warp_threads, max_k, items_per_thread, total_warps>(
-    d_keys_in, d_keys_out, k, num_items, topk_keys_iterator_t{});
-
-  // Verify results
-  verify_topk_result(d_keys_in, d_keys_out, total_warps);
+  test_topk_keys<TestType, topk_keys_iterator_t>(k, num_items);
 }
 
 CUB_TEST("Warp top-k on key-value pairs works",
@@ -668,68 +664,32 @@ CUB_TEST("Warp top-k on key-value pairs works",
          extra_items_per_thread_list,
          value_types)
 {
-  using params                       = params_t<TestType>;
-  using key_type                     = typename params::type;
-  using value_type                   = typename c2h::get<5, TestType>;
-  constexpr auto algo                = params::algo;
-  constexpr int logical_warp_threads = params::logical_warp_threads;
-  constexpr int max_k                = params::max_k;
-  constexpr int items_per_thread     = params::items_per_thread;
-  constexpr int total_warps          = params::total_warps;
+  using params        = params_t<TestType>;
+  constexpr int max_k = params::max_k;
 
-  // Prepare test data
-  const int k         = GENERATE_COPY(1, max_k > 1 ? max_k - 1 : max_k, max_k, take(5, random(1, max_k)));
-  const int num_items = items_per_thread * logical_warp_threads;
-  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
-  c2h::device_vector<value_type> d_values_in(total_warps * num_items);
-  c2h::device_vector<key_type> d_keys_out(total_warps * k);
-  c2h::device_vector<value_type> d_values_out(total_warps * k);
-  c2h::gen(C2H_SEED(10), d_keys_in);
-  c2h::gen(C2H_SEED(1), d_values_in);
+  const int k         = GENERATE_COPY(1, max_k, take(5, random(1, max_k)));
+  const int num_items = params::items_per_thread * params::logical_warp_threads;
 
-  // Run test
-  warp_bitonic_topk<algo, logical_warp_threads, max_k, items_per_thread, total_warps>(
-    d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, topk_pairs_full_t{});
-
-  // Verify results
-  verify_topk_result(d_keys_in, d_values_in, d_keys_out, d_values_out, total_warps);
+  test_topk_pairs<TestType, topk_pairs_full_t>(k, num_items);
 }
 
 CUB_TEST("Warp top-k on key-value pairs of a partial warp-tile with an OOB default works",
          "[topk][warp]",
          CUB_SMALL,
          key_types,
-         eager_algo_list,
+         c2h::enum_type_list<WarpBitonicTopKAlgorithm, WarpBitonicTopKAlgorithm::eager>,
          logical_warp_threads_list,
          max_k_per_thread_list,
          extra_items_per_thread_list,
          value_types)
 {
-  using params                       = params_t<TestType>;
-  using key_type                     = typename params::type;
-  using value_type                   = typename c2h::get<5, TestType>;
-  constexpr auto algo                = params::algo;
-  constexpr int logical_warp_threads = params::logical_warp_threads;
-  constexpr int max_k                = params::max_k;
-  constexpr int items_per_thread     = params::items_per_thread;
-  constexpr int total_warps          = params::total_warps;
+  using params        = params_t<TestType>;
+  constexpr int max_k = params::max_k;
 
-  // Prepare test data
-  const int k         = GENERATE_COPY(1, max_k > 1 ? max_k - 1 : max_k, max_k, take(5, random(1, max_k)));
-  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * logical_warp_threads)));
-  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
-  c2h::device_vector<value_type> d_values_in(total_warps * num_items);
-  c2h::device_vector<key_type> d_keys_out(total_warps * k);
-  c2h::device_vector<value_type> d_values_out(total_warps * k);
-  c2h::gen(C2H_SEED(5), d_keys_in);
-  c2h::gen(C2H_SEED(1), d_values_in);
+  const int k         = GENERATE_COPY(1, max_k, take(5, random(1, max_k)));
+  const int num_items = GENERATE_COPY(k, take(5, random(k, params::items_per_thread * params::logical_warp_threads)));
 
-  // Run test
-  warp_bitonic_topk<algo, logical_warp_threads, max_k, items_per_thread, total_warps>(
-    d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, topk_pairs_partial_oob_t{});
-
-  // Verify results
-  verify_topk_result(d_keys_in, d_values_in, d_keys_out, d_values_out, total_warps);
+  test_topk_pairs<TestType, topk_pairs_partial_oob_t>(k, num_items);
 }
 
 CUB_TEST("Warp top-k on key-value pairs of a partial warp-tile works",
@@ -742,66 +702,53 @@ CUB_TEST("Warp top-k on key-value pairs of a partial warp-tile works",
          extra_items_per_thread_list,
          value_types)
 {
-  using params                       = params_t<TestType>;
-  using key_type                     = typename params::type;
-  using value_type                   = typename c2h::get<5, TestType>;
-  constexpr auto algo                = params::algo;
-  constexpr int logical_warp_threads = params::logical_warp_threads;
-  constexpr int max_k                = params::max_k;
-  constexpr int items_per_thread     = params::items_per_thread;
-  constexpr int total_warps          = params::total_warps;
+  using params        = params_t<TestType>;
+  constexpr int max_k = params::max_k;
 
-  // Prepare test data
-  const int k         = GENERATE_COPY(1, max_k > 1 ? max_k - 1 : max_k, max_k, take(5, random(1, max_k)));
-  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * logical_warp_threads)));
-  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
-  c2h::device_vector<value_type> d_values_in(total_warps * num_items);
-  c2h::device_vector<key_type> d_keys_out(total_warps * k);
-  c2h::device_vector<value_type> d_values_out(total_warps * k);
-  c2h::gen(C2H_SEED(5), d_keys_in);
-  c2h::gen(C2H_SEED(1), d_values_in);
+  const int k         = GENERATE_COPY(1, max_k, take(5, random(1, max_k)));
+  const int num_items = GENERATE_COPY(k, take(5, random(k, params::items_per_thread * params::logical_warp_threads)));
 
-  // Run test
-  warp_bitonic_topk<algo, logical_warp_threads, max_k, items_per_thread, total_warps>(
-    d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, topk_pairs_partial_t{});
-
-  // Verify results
-  verify_topk_result(d_keys_in, d_values_in, d_keys_out, d_values_out, total_warps);
+  test_topk_pairs<TestType, topk_pairs_partial_t>(k, num_items);
 }
 
 CUB_TEST("Warp top-k iterator on key-value pairs of a partial warp-tile works",
          "[topk][warp]",
          CUB_SMALL,
          key_types,
-         algo_list,
+         c2h::enum_type_list<WarpBitonicTopKAlgorithm, WarpBitonicTopKAlgorithm::buffered>,
          logical_warp_threads_list,
          max_k_per_thread_list,
          c2h::enum_type_list<int, 0>, // unused
          value_types)
 {
-  using params                       = params_t<TestType>;
-  using key_type                     = typename params::type;
-  using value_type                   = typename c2h::get<5, TestType>;
-  constexpr auto algo                = params::algo;
-  constexpr int logical_warp_threads = params::logical_warp_threads;
-  constexpr int max_k                = params::max_k;
-  constexpr int items_per_thread     = params::items_per_thread;
-  constexpr int total_warps          = params::total_warps;
+  using params        = params_t<TestType>;
+  constexpr int max_k = params::max_k;
 
-  // Prepare test data
-  const int k         = GENERATE_COPY(1, max_k > 1 ? max_k - 1 : max_k, max_k, take(5, random(1, max_k)));
+  const int k         = GENERATE_COPY(1, max_k, take(5, random(1, max_k)));
   const int num_items = GENERATE_COPY(k, k + 1, take(5, random(k + 2, k + 100)), take(5, random(k + 100, k + 1000)));
-  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
-  c2h::device_vector<value_type> d_values_in(total_warps * num_items);
-  c2h::device_vector<key_type> d_keys_out(total_warps * k);
-  c2h::device_vector<value_type> d_values_out(total_warps * k);
-  c2h::gen(C2H_SEED(5), d_keys_in);
-  c2h::gen(C2H_SEED(1), d_values_in);
 
-  // Run test
-  warp_bitonic_topk<algo, logical_warp_threads, max_k, items_per_thread, total_warps>(
-    d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, topk_pairs_iterator_t{});
+  test_topk_pairs<TestType, topk_pairs_iterator_t>(k, num_items);
+}
 
-  // Verify results
-  verify_topk_result(d_keys_in, d_values_in, d_keys_out, d_values_out, total_warps);
+// Keep custom_t coverage narrow because it is expensive to instantiate.
+using custom_t = c2h::custom_type_t<c2h::equal_comparable_t, c2h::lexicographical_less_comparable_t>;
+
+CUB_TEST("Warp top-k on custom key-value pairs works",
+         "[topk][warp]",
+         CUB_SMALL,
+         c2h::type_list<custom_t>, // key_types,
+         algo_list,
+         c2h::enum_type_list<int, 4, warp_threads>, // logical_warp_threads
+         c2h::enum_type_list<int, 2>, // max_k
+         c2h::enum_type_list<int, 1>, // extra_items_per_thread
+         c2h::type_list<custom_t>, // value_types,
+         c2h::type_list<topk_pairs_partial_oob_t, topk_pairs_partial_t, topk_pairs_iterator_t>)
+{
+  using params        = params_t<TestType>;
+  constexpr int max_k = params::max_k;
+
+  const int k         = GENERATE_COPY(1, max_k, take(5, random(1, max_k)));
+  const int num_items = GENERATE_COPY(k, take(5, random(k, params::items_per_thread * params::logical_warp_threads)));
+
+  test_topk_pairs<TestType, topk_pairs_partial_t>(k, num_items);
 }

--- a/cub/test/catch2_test_warp_bitonic_topk.cu
+++ b/cub/test/catch2_test_warp_bitonic_topk.cu
@@ -7,6 +7,7 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/memory.h>
 
+#include <cuda/cmath>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
@@ -46,15 +47,21 @@ using cub::detail::WarpBitonicTopKAlgorithm;
 /**
  * @brief Kernel to dispatch to the appropriate WarpBitonicTopK member function, for keys-only.
  */
-template <WarpBitonicTopKAlgorithm Algo, int MaxK, int ItemsPerThread, int TotalWarps, typename KeyT, typename ActionT>
+template <WarpBitonicTopKAlgorithm Algo,
+          int LogicalWarpThreads,
+          int MaxK,
+          int ItemsPerThread,
+          int TotalWarps,
+          typename KeyT,
+          typename ActionT>
 __global__ void array_kernel(KeyT* keys_in, KeyT* keys_out, int k, int num_items, ActionT action)
 {
-  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, cub::NullType, Algo>;
+  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, cub::NullType, Algo, LogicalWarpThreads>;
 
   // Get linear thread and warp index
   const int tid     = threadIdx.x;
-  const int warp_id = tid / warp_threads;
-  const int lane    = tid % warp_threads;
+  const int warp_id = tid / LogicalWarpThreads;
+  const int lane    = tid % LogicalWarpThreads;
 
   // Test case of partially finished CTA
   if (warp_id >= TotalWarps)
@@ -72,7 +79,7 @@ __global__ void array_kernel(KeyT* keys_in, KeyT* keys_out, int k, int num_items
   // Load data
   for (int i = 0; i < ItemsPerThread; ++i)
   {
-    const int idx = i * warp_threads + lane;
+    const int idx = i * LogicalWarpThreads + lane;
     if (idx < num_items)
     {
       keys[i] = keys_in[num_items * warp_id + idx];
@@ -85,7 +92,7 @@ __global__ void array_kernel(KeyT* keys_in, KeyT* keys_out, int k, int num_items
   // Store data
   for (int i = 0; i < ItemsPerThread; ++i)
   {
-    const int idx = i * warp_threads + lane;
+    const int idx = i * LogicalWarpThreads + lane;
     if (idx < k)
     {
       keys_out[k * warp_id + idx] = keys[i];
@@ -93,15 +100,21 @@ __global__ void array_kernel(KeyT* keys_in, KeyT* keys_out, int k, int num_items
   }
 }
 
-template <WarpBitonicTopKAlgorithm Algo, int MaxK, int ItemsPerThread, int TotalWarps, typename KeyT, typename ActionT>
+template <WarpBitonicTopKAlgorithm Algo,
+          int LogicalWarpThreads,
+          int MaxK,
+          int ItemsPerThread,
+          int TotalWarps,
+          typename KeyT,
+          typename ActionT>
 __global__ void iterator_kernel(KeyT* keys_in, KeyT* keys_out, int k, int num_items, ActionT action)
 {
-  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, cub::NullType, Algo>;
+  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, cub::NullType, Algo, LogicalWarpThreads>;
 
   // Get linear thread and warp index
   const int tid     = threadIdx.x;
-  const int warp_id = tid / warp_threads;
-  const int lane    = tid % warp_threads;
+  const int warp_id = tid / LogicalWarpThreads;
+  const int lane    = tid % LogicalWarpThreads;
 
   // Test case of partially finished CTA
   if (warp_id >= TotalWarps)
@@ -110,7 +123,7 @@ __global__ void iterator_kernel(KeyT* keys_in, KeyT* keys_out, int k, int num_it
   }
 
   // Thread-local storage
-  KeyT keys[MaxK / warp_threads];
+  KeyT keys[MaxK / LogicalWarpThreads];
 
   // Instantiate warp-scope algorithm
   __shared__ typename warp_topk_t::TempStorage temp_storage[TotalWarps];
@@ -121,9 +134,9 @@ __global__ void iterator_kernel(KeyT* keys_in, KeyT* keys_out, int k, int num_it
   action(warp_topk, keys_in + in_offset, k, num_items, keys);
 
   // Store data
-  for (int i = 0; i < MaxK / warp_threads; ++i)
+  for (int i = 0; i < MaxK / LogicalWarpThreads; ++i)
   {
-    const int idx = i * warp_threads + lane;
+    const int idx = i * LogicalWarpThreads + lane;
     if (idx < k)
     {
       keys_out[k * warp_id + idx] = keys[i];
@@ -136,6 +149,7 @@ __global__ void iterator_kernel(KeyT* keys_in, KeyT* keys_out, int k, int num_it
  * pairs.
  */
 template <WarpBitonicTopKAlgorithm Algo,
+          int LogicalWarpThreads,
           int MaxK,
           int ItemsPerThread,
           int TotalWarps,
@@ -145,12 +159,12 @@ template <WarpBitonicTopKAlgorithm Algo,
 __global__ void
 array_kernel(KeyT* keys_in, KeyT* keys_out, ValueT* values_in, ValueT* values_out, int k, int num_items, ActionT action)
 {
-  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT, Algo>;
+  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT, Algo, LogicalWarpThreads>;
 
   // Get linear thread and warp index
   const int tid     = threadIdx.x;
-  const int warp_id = tid / warp_threads;
-  const int lane    = tid % warp_threads;
+  const int warp_id = tid / LogicalWarpThreads;
+  const int lane    = tid % LogicalWarpThreads;
 
   // Test case of partially finished CTA
   if (warp_id >= TotalWarps)
@@ -169,7 +183,7 @@ array_kernel(KeyT* keys_in, KeyT* keys_out, ValueT* values_in, ValueT* values_ou
   // Load data
   for (int i = 0; i < ItemsPerThread; ++i)
   {
-    const int idx = i * warp_threads + lane;
+    const int idx = i * LogicalWarpThreads + lane;
     if (idx < num_items)
     {
       keys[i]   = keys_in[num_items * warp_id + idx];
@@ -183,7 +197,7 @@ array_kernel(KeyT* keys_in, KeyT* keys_out, ValueT* values_in, ValueT* values_ou
   // Store data
   for (int i = 0; i < ItemsPerThread; ++i)
   {
-    const int idx = i * warp_threads + lane;
+    const int idx = i * LogicalWarpThreads + lane;
     if (idx < k)
     {
       keys_out[k * warp_id + idx]   = keys[i];
@@ -193,6 +207,7 @@ array_kernel(KeyT* keys_in, KeyT* keys_out, ValueT* values_in, ValueT* values_ou
 }
 
 template <WarpBitonicTopKAlgorithm Algo,
+          int LogicalWarpThreads,
           int MaxK,
           int ItemsPerThread,
           int TotalWarps,
@@ -202,12 +217,12 @@ template <WarpBitonicTopKAlgorithm Algo,
 __global__ void iterator_kernel(
   KeyT* keys_in, KeyT* keys_out, ValueT* values_in, ValueT* values_out, int k, int num_items, ActionT action)
 {
-  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT, Algo>;
+  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT, Algo, LogicalWarpThreads>;
 
   // Get linear thread and warp index
   const int tid     = threadIdx.x;
-  const int warp_id = tid / warp_threads;
-  const int lane    = tid % warp_threads;
+  const int warp_id = tid / LogicalWarpThreads;
+  const int lane    = tid % LogicalWarpThreads;
 
   // Test case of partially finished CTA
   if (warp_id >= TotalWarps)
@@ -216,8 +231,8 @@ __global__ void iterator_kernel(
   }
 
   // Thread-local storage
-  KeyT keys[MaxK / warp_threads];
-  ValueT values[MaxK / warp_threads];
+  KeyT keys[MaxK / LogicalWarpThreads];
+  ValueT values[MaxK / LogicalWarpThreads];
 
   // Instantiate warp-scope algorithm
   __shared__ typename warp_topk_t::TempStorage temp_storage[TotalWarps];
@@ -228,9 +243,9 @@ __global__ void iterator_kernel(
   action(warp_topk, keys_in + in_offset, values_in + in_offset, k, num_items, keys, values);
 
   // Store data
-  for (int i = 0; i < MaxK / warp_threads; ++i)
+  for (int i = 0; i < MaxK / LogicalWarpThreads; ++i)
   {
-    const int idx = i * warp_threads + lane;
+    const int idx = i * LogicalWarpThreads + lane;
     if (idx < k)
     {
       keys_out[k * warp_id + idx]   = keys[i];
@@ -353,21 +368,28 @@ struct topk_pairs_iterator_t
 /**
  * @brief Dispatch helper function for keys
  */
-template <WarpBitonicTopKAlgorithm Algo, int MaxK, int ItemsPerThread, int TotalWarps, typename KeyT, typename ActionT>
+template <WarpBitonicTopKAlgorithm Algo,
+          int LogicalWarpThreads,
+          int MaxK,
+          int ItemsPerThread,
+          int TotalWarps,
+          typename KeyT,
+          typename ActionT>
 void warp_bitonic_topk(c2h::device_vector<KeyT>& in, c2h::device_vector<KeyT>& out, int k, int num_items, ActionT action)
 {
   const auto kernel = [] {
     if constexpr (cuda::std::is_same_v<ActionT, topk_keys_iterator_t>)
     {
-      return &iterator_kernel<Algo, MaxK, ItemsPerThread, TotalWarps, KeyT, ActionT>;
+      return &iterator_kernel<Algo, LogicalWarpThreads, MaxK, ItemsPerThread, TotalWarps, KeyT, ActionT>;
     }
     else
     {
-      return &array_kernel<Algo, MaxK, ItemsPerThread, TotalWarps, KeyT, ActionT>;
+      return &array_kernel<Algo, LogicalWarpThreads, MaxK, ItemsPerThread, TotalWarps, KeyT, ActionT>;
     }
   }();
 
-  kernel<<<1, warp_threads * TotalWarps>>>(
+  // deliberately round up block dim to architectural warp size
+  kernel<<<1, ::cuda::round_up(LogicalWarpThreads * TotalWarps, warp_threads)>>>(
     thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), k, num_items, action);
 
   REQUIRE(cudaSuccess == cudaPeekAtLastError());
@@ -378,6 +400,7 @@ void warp_bitonic_topk(c2h::device_vector<KeyT>& in, c2h::device_vector<KeyT>& o
  * @brief Dispatch helper function for key-value pairs
  */
 template <WarpBitonicTopKAlgorithm Algo,
+          int LogicalWarpThreads,
           int MaxK,
           int ItemsPerThread,
           int TotalWarps,
@@ -396,15 +419,16 @@ void warp_bitonic_topk(
   const auto kernel = [] {
     if constexpr (cuda::std::is_same_v<ActionT, topk_pairs_iterator_t>)
     {
-      return &iterator_kernel<Algo, MaxK, ItemsPerThread, TotalWarps, KeyT, ValueT, ActionT>;
+      return &iterator_kernel<Algo, LogicalWarpThreads, MaxK, ItemsPerThread, TotalWarps, KeyT, ValueT, ActionT>;
     }
     else
     {
-      return &array_kernel<Algo, MaxK, ItemsPerThread, TotalWarps, KeyT, ValueT, ActionT>;
+      return &array_kernel<Algo, LogicalWarpThreads, MaxK, ItemsPerThread, TotalWarps, KeyT, ValueT, ActionT>;
     }
   }();
 
-  kernel<<<1, warp_threads * TotalWarps>>>(
+  // deliberately round up block dim to architectural warp size
+  kernel<<<1, ::cuda::round_up(LogicalWarpThreads * TotalWarps, warp_threads)>>>(
     thrust::raw_pointer_cast(keys_in.data()),
     thrust::raw_pointer_cast(keys_out.data()),
     thrust::raw_pointer_cast(values_in.data()),
@@ -478,7 +502,7 @@ void verify_topk_result(
 }
 
 // List of key types to test
-using key_types = c2h::type_list<std::uint8_t, std::int32_t, std::int64_t, float>;
+using key_types = c2h::type_list<std::uint8_t, float>;
 
 // List of value types
 using value_types = c2h::type_list<std::int32_t>;
@@ -486,8 +510,9 @@ using value_types = c2h::type_list<std::int32_t>;
 using algo_list =
   c2h::enum_type_list<WarpBitonicTopKAlgorithm, WarpBitonicTopKAlgorithm::eager, WarpBitonicTopKAlgorithm::buffered>;
 using eager_algo_list             = c2h::enum_type_list<WarpBitonicTopKAlgorithm, WarpBitonicTopKAlgorithm::eager>;
-using max_k_list                  = c2h::enum_type_list<int, warp_threads, warp_threads * 2, warp_threads * 3>;
-using extra_items_per_thread_list = c2h::enum_type_list<int, 0, 1, 2, 3, 4, 5, 6, 7>;
+using logical_warp_threads_list   = c2h::enum_type_list<int, 1, 4, warp_threads>;
+using max_k_per_thread_list       = c2h::enum_type_list<int, 1, 2, 3>;
+using extra_items_per_thread_list = c2h::enum_type_list<int, 0, 1, 2, 3, 4>;
 
 template <typename TestType>
 struct params_t
@@ -495,31 +520,43 @@ struct params_t
   using type = typename c2h::get<0, TestType>;
 
   static constexpr WarpBitonicTopKAlgorithm algo = c2h::get<1, TestType>::value;
-  static constexpr int max_k                     = c2h::get<2, TestType>::value;
-  static constexpr int extra_items_per_thread    = c2h::get<3, TestType>::value;
-  static constexpr int items_per_thread          = max_k / warp_threads + extra_items_per_thread;
-  static constexpr int total_warps               = 2;
+  static constexpr int logical_warp_threads      = c2h::get<2, TestType>::value;
+  static constexpr int max_k                     = logical_warp_threads * c2h::get<3, TestType>::value;
+  static constexpr int extra_items_per_thread    = c2h::get<4, TestType>::value;
+  static constexpr int items_per_thread          = max_k / logical_warp_threads + extra_items_per_thread;
+  // When the logical warp is smaller than the architectural warp, deliberately leaves the last architectural warp
+  // partially occupied
+  static constexpr int total_warps =
+    (logical_warp_threads == warp_threads) ? 2 : (2 * warp_threads / logical_warp_threads - 1);
 };
 
-CUB_TEST(
-  "Warp top-k on keys works", "[topk][warp]", CUB_SMALL, key_types, algo_list, max_k_list, extra_items_per_thread_list)
+CUB_TEST("Warp top-k on keys works",
+         "[topk][warp]",
+         CUB_SMALL,
+         key_types,
+         algo_list,
+         logical_warp_threads_list,
+         max_k_per_thread_list,
+         extra_items_per_thread_list)
 {
-  using params                   = params_t<TestType>;
-  using key_type                 = typename params::type;
-  constexpr auto algo            = params::algo;
-  constexpr int max_k            = params::max_k;
-  constexpr int items_per_thread = params::items_per_thread;
-  constexpr int total_warps      = params::total_warps;
+  using params                       = params_t<TestType>;
+  using key_type                     = typename params::type;
+  constexpr auto algo                = params::algo;
+  constexpr int logical_warp_threads = params::logical_warp_threads;
+  constexpr int max_k                = params::max_k;
+  constexpr int items_per_thread     = params::items_per_thread;
+  constexpr int total_warps          = params::total_warps;
 
   // Prepare test data
-  const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
-  const int num_items = items_per_thread * warp_threads;
+  const int k         = GENERATE_COPY(1, max_k > 1 ? max_k - 1 : max_k, max_k, take(5, random(1, max_k)));
+  const int num_items = items_per_thread * logical_warp_threads;
   c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
   c2h::device_vector<key_type> d_keys_out(total_warps * k);
   c2h::gen(C2H_SEED(10), d_keys_in);
 
   // Run test
-  warp_bitonic_topk<algo, max_k, items_per_thread, total_warps>(d_keys_in, d_keys_out, k, num_items, topk_keys_full_t{});
+  warp_bitonic_topk<algo, logical_warp_threads, max_k, items_per_thread, total_warps>(
+    d_keys_in, d_keys_out, k, num_items, topk_keys_full_t{});
 
   // Verify results
   verify_topk_result(d_keys_in, d_keys_out, total_warps);
@@ -530,25 +567,27 @@ CUB_TEST("Warp top-k on keys of a partial warp-tile with an OOB default works",
          CUB_SMALL,
          key_types,
          eager_algo_list,
-         max_k_list,
+         logical_warp_threads_list,
+         max_k_per_thread_list,
          extra_items_per_thread_list)
 {
-  using params                   = params_t<TestType>;
-  using key_type                 = typename params::type;
-  constexpr auto algo            = params::algo;
-  constexpr int max_k            = params::max_k;
-  constexpr int items_per_thread = params::items_per_thread;
-  constexpr int total_warps      = params::total_warps;
+  using params                       = params_t<TestType>;
+  using key_type                     = typename params::type;
+  constexpr auto algo                = params::algo;
+  constexpr int logical_warp_threads = params::logical_warp_threads;
+  constexpr int max_k                = params::max_k;
+  constexpr int items_per_thread     = params::items_per_thread;
+  constexpr int total_warps          = params::total_warps;
 
   // Prepare test data
-  const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
-  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * warp_threads)));
+  const int k         = GENERATE_COPY(1, max_k > 1 ? max_k - 1 : max_k, max_k, take(5, random(1, max_k)));
+  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * logical_warp_threads)));
   c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
   c2h::device_vector<key_type> d_keys_out(total_warps * k);
   c2h::gen(C2H_SEED(5), d_keys_in);
 
   // Run test
-  warp_bitonic_topk<algo, max_k, items_per_thread, total_warps>(
+  warp_bitonic_topk<algo, logical_warp_threads, max_k, items_per_thread, total_warps>(
     d_keys_in, d_keys_out, k, num_items, topk_keys_partial_oob_t{});
 
   // Verify results
@@ -560,25 +599,27 @@ CUB_TEST("Warp top-k on keys of a partial warp-tile works",
          CUB_SMALL,
          key_types,
          algo_list,
-         max_k_list,
+         logical_warp_threads_list,
+         max_k_per_thread_list,
          extra_items_per_thread_list)
 {
-  using params                   = params_t<TestType>;
-  using key_type                 = typename params::type;
-  constexpr auto algo            = params::algo;
-  constexpr int max_k            = params::max_k;
-  constexpr int items_per_thread = params::items_per_thread;
-  constexpr int total_warps      = params::total_warps;
+  using params                       = params_t<TestType>;
+  using key_type                     = typename params::type;
+  constexpr auto algo                = params::algo;
+  constexpr int logical_warp_threads = params::logical_warp_threads;
+  constexpr int max_k                = params::max_k;
+  constexpr int items_per_thread     = params::items_per_thread;
+  constexpr int total_warps          = params::total_warps;
 
   // Prepare test data
-  const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
-  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * warp_threads)));
+  const int k         = GENERATE_COPY(1, max_k > 1 ? max_k - 1 : max_k, max_k, take(5, random(1, max_k)));
+  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * logical_warp_threads)));
   c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
   c2h::device_vector<key_type> d_keys_out(total_warps * k);
   c2h::gen(C2H_SEED(5), d_keys_in);
 
   // Run test
-  warp_bitonic_topk<algo, max_k, items_per_thread, total_warps>(
+  warp_bitonic_topk<algo, logical_warp_threads, max_k, items_per_thread, total_warps>(
     d_keys_in, d_keys_out, k, num_items, topk_keys_partial_t{});
 
   // Verify results
@@ -590,25 +631,27 @@ CUB_TEST("Warp top-k iterator on keys of a partial warp-tile works",
          CUB_SMALL,
          key_types,
          algo_list,
-         max_k_list,
+         logical_warp_threads_list,
+         max_k_per_thread_list,
          c2h::enum_type_list<int, 0>)
 {
-  using params                   = params_t<TestType>;
-  using key_type                 = typename params::type;
-  constexpr auto algo            = params::algo;
-  constexpr int max_k            = params::max_k;
-  constexpr int items_per_thread = params::items_per_thread;
-  constexpr int total_warps      = params::total_warps;
+  using params                       = params_t<TestType>;
+  using key_type                     = typename params::type;
+  constexpr auto algo                = params::algo;
+  constexpr int logical_warp_threads = params::logical_warp_threads;
+  constexpr int max_k                = params::max_k;
+  constexpr int items_per_thread     = params::items_per_thread;
+  constexpr int total_warps          = params::total_warps;
 
   // Prepare test data
-  const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
+  const int k         = GENERATE_COPY(1, max_k > 1 ? max_k - 1 : max_k, max_k, take(5, random(1, max_k)));
   const int num_items = GENERATE_COPY(k, k + 1, take(5, random(k + 2, k + 100)), take(5, random(k + 100, k + 1000)));
   c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
   c2h::device_vector<key_type> d_keys_out(total_warps * k);
   c2h::gen(C2H_SEED(5), d_keys_in);
 
   // Run test
-  warp_bitonic_topk<algo, max_k, items_per_thread, total_warps>(
+  warp_bitonic_topk<algo, logical_warp_threads, max_k, items_per_thread, total_warps>(
     d_keys_in, d_keys_out, k, num_items, topk_keys_iterator_t{});
 
   // Verify results
@@ -620,21 +663,23 @@ CUB_TEST("Warp top-k on key-value pairs works",
          CUB_SMALL,
          key_types,
          algo_list,
-         max_k_list,
+         logical_warp_threads_list,
+         max_k_per_thread_list,
          extra_items_per_thread_list,
          value_types)
 {
-  using params                   = params_t<TestType>;
-  using key_type                 = typename params::type;
-  using value_type               = typename c2h::get<4, TestType>;
-  constexpr auto algo            = params::algo;
-  constexpr int max_k            = params::max_k;
-  constexpr int items_per_thread = params::items_per_thread;
-  constexpr int total_warps      = params::total_warps;
+  using params                       = params_t<TestType>;
+  using key_type                     = typename params::type;
+  using value_type                   = typename c2h::get<5, TestType>;
+  constexpr auto algo                = params::algo;
+  constexpr int logical_warp_threads = params::logical_warp_threads;
+  constexpr int max_k                = params::max_k;
+  constexpr int items_per_thread     = params::items_per_thread;
+  constexpr int total_warps          = params::total_warps;
 
   // Prepare test data
-  const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
-  const int num_items = items_per_thread * warp_threads;
+  const int k         = GENERATE_COPY(1, max_k > 1 ? max_k - 1 : max_k, max_k, take(5, random(1, max_k)));
+  const int num_items = items_per_thread * logical_warp_threads;
   c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
   c2h::device_vector<value_type> d_values_in(total_warps * num_items);
   c2h::device_vector<key_type> d_keys_out(total_warps * k);
@@ -643,7 +688,7 @@ CUB_TEST("Warp top-k on key-value pairs works",
   c2h::gen(C2H_SEED(1), d_values_in);
 
   // Run test
-  warp_bitonic_topk<algo, max_k, items_per_thread, total_warps>(
+  warp_bitonic_topk<algo, logical_warp_threads, max_k, items_per_thread, total_warps>(
     d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, topk_pairs_full_t{});
 
   // Verify results
@@ -655,21 +700,23 @@ CUB_TEST("Warp top-k on key-value pairs of a partial warp-tile with an OOB defau
          CUB_SMALL,
          key_types,
          eager_algo_list,
-         max_k_list,
+         logical_warp_threads_list,
+         max_k_per_thread_list,
          extra_items_per_thread_list,
          value_types)
 {
-  using params                   = params_t<TestType>;
-  using key_type                 = typename params::type;
-  using value_type               = typename c2h::get<4, TestType>;
-  constexpr auto algo            = params::algo;
-  constexpr int max_k            = params::max_k;
-  constexpr int items_per_thread = params::items_per_thread;
-  constexpr int total_warps      = params::total_warps;
+  using params                       = params_t<TestType>;
+  using key_type                     = typename params::type;
+  using value_type                   = typename c2h::get<5, TestType>;
+  constexpr auto algo                = params::algo;
+  constexpr int logical_warp_threads = params::logical_warp_threads;
+  constexpr int max_k                = params::max_k;
+  constexpr int items_per_thread     = params::items_per_thread;
+  constexpr int total_warps          = params::total_warps;
 
   // Prepare test data
-  const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
-  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * warp_threads)));
+  const int k         = GENERATE_COPY(1, max_k > 1 ? max_k - 1 : max_k, max_k, take(5, random(1, max_k)));
+  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * logical_warp_threads)));
   c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
   c2h::device_vector<value_type> d_values_in(total_warps * num_items);
   c2h::device_vector<key_type> d_keys_out(total_warps * k);
@@ -678,7 +725,7 @@ CUB_TEST("Warp top-k on key-value pairs of a partial warp-tile with an OOB defau
   c2h::gen(C2H_SEED(1), d_values_in);
 
   // Run test
-  warp_bitonic_topk<algo, max_k, items_per_thread, total_warps>(
+  warp_bitonic_topk<algo, logical_warp_threads, max_k, items_per_thread, total_warps>(
     d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, topk_pairs_partial_oob_t{});
 
   // Verify results
@@ -690,21 +737,23 @@ CUB_TEST("Warp top-k on key-value pairs of a partial warp-tile works",
          CUB_SMALL,
          key_types,
          algo_list,
-         max_k_list,
+         logical_warp_threads_list,
+         max_k_per_thread_list,
          extra_items_per_thread_list,
          value_types)
 {
-  using params                   = params_t<TestType>;
-  using key_type                 = typename params::type;
-  using value_type               = typename c2h::get<4, TestType>;
-  constexpr auto algo            = params::algo;
-  constexpr int max_k            = params::max_k;
-  constexpr int items_per_thread = params::items_per_thread;
-  constexpr int total_warps      = params::total_warps;
+  using params                       = params_t<TestType>;
+  using key_type                     = typename params::type;
+  using value_type                   = typename c2h::get<5, TestType>;
+  constexpr auto algo                = params::algo;
+  constexpr int logical_warp_threads = params::logical_warp_threads;
+  constexpr int max_k                = params::max_k;
+  constexpr int items_per_thread     = params::items_per_thread;
+  constexpr int total_warps          = params::total_warps;
 
   // Prepare test data
-  const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
-  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * warp_threads)));
+  const int k         = GENERATE_COPY(1, max_k > 1 ? max_k - 1 : max_k, max_k, take(5, random(1, max_k)));
+  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * logical_warp_threads)));
   c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
   c2h::device_vector<value_type> d_values_in(total_warps * num_items);
   c2h::device_vector<key_type> d_keys_out(total_warps * k);
@@ -713,7 +762,7 @@ CUB_TEST("Warp top-k on key-value pairs of a partial warp-tile works",
   c2h::gen(C2H_SEED(1), d_values_in);
 
   // Run test
-  warp_bitonic_topk<algo, max_k, items_per_thread, total_warps>(
+  warp_bitonic_topk<algo, logical_warp_threads, max_k, items_per_thread, total_warps>(
     d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, topk_pairs_partial_t{});
 
   // Verify results
@@ -725,20 +774,22 @@ CUB_TEST("Warp top-k iterator on key-value pairs of a partial warp-tile works",
          CUB_SMALL,
          key_types,
          algo_list,
-         max_k_list,
+         logical_warp_threads_list,
+         max_k_per_thread_list,
          c2h::enum_type_list<int, 0>, // unused
          value_types)
 {
-  using params                   = params_t<TestType>;
-  using key_type                 = typename params::type;
-  using value_type               = typename c2h::get<4, TestType>;
-  constexpr auto algo            = params::algo;
-  constexpr int max_k            = params::max_k;
-  constexpr int items_per_thread = params::items_per_thread;
-  constexpr int total_warps      = params::total_warps;
+  using params                       = params_t<TestType>;
+  using key_type                     = typename params::type;
+  using value_type                   = typename c2h::get<5, TestType>;
+  constexpr auto algo                = params::algo;
+  constexpr int logical_warp_threads = params::logical_warp_threads;
+  constexpr int max_k                = params::max_k;
+  constexpr int items_per_thread     = params::items_per_thread;
+  constexpr int total_warps          = params::total_warps;
 
   // Prepare test data
-  const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
+  const int k         = GENERATE_COPY(1, max_k > 1 ? max_k - 1 : max_k, max_k, take(5, random(1, max_k)));
   const int num_items = GENERATE_COPY(k, k + 1, take(5, random(k + 2, k + 100)), take(5, random(k + 100, k + 1000)));
   c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
   c2h::device_vector<value_type> d_values_in(total_warps * num_items);
@@ -748,7 +799,7 @@ CUB_TEST("Warp top-k iterator on key-value pairs of a partial warp-tile works",
   c2h::gen(C2H_SEED(1), d_values_in);
 
   // Run test
-  warp_bitonic_topk<algo, max_k, items_per_thread, total_warps>(
+  warp_bitonic_topk<algo, logical_warp_threads, max_k, items_per_thread, total_warps>(
     d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, topk_pairs_iterator_t{});
 
   // Verify results

--- a/cub/test/catch2_test_warp_bitonic_topk.cu
+++ b/cub/test/catch2_test_warp_bitonic_topk.cu
@@ -1,70 +1,88 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <cub/util_arch.cuh>
 #include <cub/warp/warp_bitonic_topk.cuh>
 
 #include <thrust/iterator/zip_iterator.h>
+#include <thrust/memory.h>
 
-#include <cuda/iterator>
-#include <cuda/std/type_traits>
+#include <cuda/std/limits>
 
 #include <algorithm>
+#include <cstdint>
 
+#include <cuda_runtime_api.h>
+
+#include "cub_test_macros.h"
 #include <c2h/catch2_test_helper.h>
 
 struct CustomLess
 {
   template <typename T>
-  __device__ __host__ bool operator()(const T& lhs, const T& rhs) const
+  [[nodiscard]] __device__ __host__ bool operator()(const T& lhs, const T& rhs) const
   {
     return lhs < rhs;
   }
+
+  template <typename T>
+  [[nodiscard]] static __device__ __host__ T get_oob_default()
+  {
+    if constexpr (cuda::std::is_same_v<T, float>)
+    {
+      return cuda::std::numeric_limits<T>::infinity();
+    }
+    else
+    {
+      return cuda::std::numeric_limits<T>::max();
+    }
+  };
 };
 
-constexpr int WARP_THREADS = cub::detail::warp_threads;
+using cub::detail::warp_threads;
 
 /**
  * @brief Kernel to dispatch to the appropriate WarpBitonicTopK member function, for keys-only.
  */
-template <int MAX_K, int ITEMS_PER_THREAD, int TOTAL_WARPS, typename KeyT, typename ActionT>
+template <int MaxK, int ItemsPerThread, int TotalWarps, typename KeyT, typename ActionT>
 __global__ void warp_bitonic_topk_kernel(KeyT* keys_in, KeyT* keys_out, int k, int num_items, ActionT action)
 {
-  using warp_bitonic_topk_t = cub::detail::WarpBitonicTopK<MAX_K, KeyT>;
+  using warp_bitonic_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT>;
 
   // Get linear thread and warp index
   const int tid     = threadIdx.x;
-  const int warp_id = tid / WARP_THREADS;
-  const int lane    = tid % WARP_THREADS;
+  const int warp_id = tid / warp_threads;
+  const int lane    = tid % warp_threads;
 
   // Test case of partially finished CTA
-  if (warp_id >= TOTAL_WARPS)
+  if (warp_id >= TotalWarps)
   {
     return;
   }
 
   // Thread-local storage
-  KeyT keys[ITEMS_PER_THREAD];
+  KeyT keys[ItemsPerThread];
 
   // Instantiate warp-scope algorithm
   warp_bitonic_topk_t warp_topk;
 
   // Load data
-  for (int i = 0; i < ITEMS_PER_THREAD; ++i)
+  for (int i = 0; i < ItemsPerThread; ++i)
   {
-    const int idx = i * WARP_THREADS + lane;
+    const int idx = i * warp_threads + lane;
     if (idx < num_items)
     {
       keys[i] = keys_in[num_items * warp_id + idx];
     }
   }
 
-  // Run bitonic topk
+  // Run bitonic top-k
   action(warp_topk, keys, k, num_items);
 
   // Store data
-  for (int i = 0; i < ITEMS_PER_THREAD; ++i)
+  for (int i = 0; i < ItemsPerThread; ++i)
   {
-    const int idx = i * WARP_THREADS + lane;
+    const int idx = i * warp_threads + lane;
     if (idx < k)
     {
       keys_out[k * warp_id + idx] = keys[i];
@@ -72,37 +90,37 @@ __global__ void warp_bitonic_topk_kernel(KeyT* keys_in, KeyT* keys_out, int k, i
   }
 }
 
-template <int MAX_K, int ITEMS_PER_THREAD, int TOTAL_WARPS, typename KeyT, typename ActionT>
+template <int MaxK, int ItemsPerThread, int TotalWarps, typename KeyT, typename ActionT>
 __global__ void warp_bitonic_topk_iterator_kernel(KeyT* keys_in, KeyT* keys_out, int k, int num_items, ActionT action)
 {
-  using warp_bitonic_topk_t = cub::detail::WarpBitonicTopK<MAX_K, KeyT>;
+  using warp_bitonic_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT>;
 
   // Get linear thread and warp index
   const int tid     = threadIdx.x;
-  const int warp_id = tid / WARP_THREADS;
-  const int lane    = tid % WARP_THREADS;
+  const int warp_id = tid / warp_threads;
+  const int lane    = tid % warp_threads;
 
   // Test case of partially finished CTA
-  if (warp_id >= TOTAL_WARPS)
+  if (warp_id >= TotalWarps)
   {
     return;
   }
 
   // Thread-local storage
-  KeyT keys[MAX_K / WARP_THREADS];
+  KeyT keys[MaxK / warp_threads];
 
   // Instantiate warp-scope algorithm
-  __shared__ typename warp_bitonic_topk_t::TempStorage temp_storage[TOTAL_WARPS];
+  __shared__ typename warp_bitonic_topk_t::TempStorage temp_storage[TotalWarps];
   warp_bitonic_topk_t warp_topk(temp_storage[warp_id]);
 
-  // Run bitonic topk
+  // Run bitonic top-k
   const int in_offset = num_items * warp_id;
   action(warp_topk, keys_in + in_offset, k, num_items, keys);
 
   // Store data
-  for (int i = 0; i < MAX_K / WARP_THREADS; ++i)
+  for (int i = 0; i < MaxK / warp_threads; ++i)
   {
-    const int idx = i * WARP_THREADS + lane;
+    const int idx = i * warp_threads + lane;
     if (idx < k)
     {
       keys_out[k * warp_id + idx] = keys[i];
@@ -114,34 +132,34 @@ __global__ void warp_bitonic_topk_iterator_kernel(KeyT* keys_in, KeyT* keys_out,
  * @brief Kernel to dispatch to the appropriate WarpBitonicTopK member function, for key-value
  * pairs.
  */
-template <int MAX_K, int ITEMS_PER_THREAD, int TOTAL_WARPS, typename KeyT, typename ValueT, typename ActionT>
+template <int MaxK, int ItemsPerThread, int TotalWarps, typename KeyT, typename ValueT, typename ActionT>
 __global__ void warp_bitonic_topk_kernel(
   KeyT* keys_in, KeyT* keys_out, ValueT* values_in, ValueT* values_out, int k, int num_items, ActionT action)
 {
-  using warp_bitonic_topk_t = cub::detail::WarpBitonicTopK<MAX_K, KeyT, ValueT>;
+  using warp_bitonic_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT>;
 
   // Get linear thread and warp index
   const int tid     = threadIdx.x;
-  const int warp_id = tid / WARP_THREADS;
-  const int lane    = tid % WARP_THREADS;
+  const int warp_id = tid / warp_threads;
+  const int lane    = tid % warp_threads;
 
   // Test case of partially finished CTA
-  if (warp_id >= TOTAL_WARPS)
+  if (warp_id >= TotalWarps)
   {
     return;
   }
 
   // Thread-local storage
-  KeyT keys[ITEMS_PER_THREAD];
-  ValueT values[ITEMS_PER_THREAD];
+  KeyT keys[ItemsPerThread];
+  ValueT values[ItemsPerThread];
 
   // Instantiate warp-scope algorithm
   warp_bitonic_topk_t warp_topk;
 
   // Load data
-  for (int i = 0; i < ITEMS_PER_THREAD; ++i)
+  for (int i = 0; i < ItemsPerThread; ++i)
   {
-    const int idx = i * WARP_THREADS + lane;
+    const int idx = i * warp_threads + lane;
     if (idx < num_items)
     {
       keys[i]   = keys_in[num_items * warp_id + idx];
@@ -149,13 +167,13 @@ __global__ void warp_bitonic_topk_kernel(
     }
   }
 
-  // Run bitonic topk
+  // Run bitonic top-k
   action(warp_topk, keys, values, k, num_items);
 
   // Store data
-  for (int i = 0; i < ITEMS_PER_THREAD; ++i)
+  for (int i = 0; i < ItemsPerThread; ++i)
   {
-    const int idx = i * WARP_THREADS + lane;
+    const int idx = i * warp_threads + lane;
     if (idx < k)
     {
       keys_out[k * warp_id + idx]   = keys[i];
@@ -164,39 +182,39 @@ __global__ void warp_bitonic_topk_kernel(
   }
 }
 
-template <int MAX_K, int ITEMS_PER_THREAD, int TOTAL_WARPS, typename KeyT, typename ValueT, typename ActionT>
+template <int MaxK, int ItemsPerThread, int TotalWarps, typename KeyT, typename ValueT, typename ActionT>
 __global__ void warp_bitonic_topk_iterator_kernel(
   KeyT* keys_in, KeyT* keys_out, ValueT* values_in, ValueT* values_out, int k, int num_items, ActionT action)
 {
-  using warp_bitonic_topk_t = cub::detail::WarpBitonicTopK<MAX_K, KeyT, ValueT>;
+  using warp_bitonic_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT>;
 
   // Get linear thread and warp index
   const int tid     = threadIdx.x;
-  const int warp_id = tid / WARP_THREADS;
-  const int lane    = tid % WARP_THREADS;
+  const int warp_id = tid / warp_threads;
+  const int lane    = tid % warp_threads;
 
   // Test case of partially finished CTA
-  if (warp_id >= TOTAL_WARPS)
+  if (warp_id >= TotalWarps)
   {
     return;
   }
 
   // Thread-local storage
-  KeyT keys[MAX_K / WARP_THREADS];
-  ValueT values[MAX_K / WARP_THREADS];
+  KeyT keys[MaxK / warp_threads];
+  ValueT values[MaxK / warp_threads];
 
   // Instantiate warp-scope algorithm
-  __shared__ typename warp_bitonic_topk_t::TempStorage temp_storage[TOTAL_WARPS];
+  __shared__ typename warp_bitonic_topk_t::TempStorage temp_storage[TotalWarps];
   warp_bitonic_topk_t warp_topk(temp_storage[warp_id]);
 
-  // Run bitonic topk
+  // Run bitonic top-k
   const int in_offset = num_items * warp_id;
   action(warp_topk, keys_in + in_offset, values_in + in_offset, k, num_items, keys, values);
 
   // Store data
-  for (int i = 0; i < MAX_K / WARP_THREADS; ++i)
+  for (int i = 0; i < MaxK / warp_threads; ++i)
   {
-    const int idx = i * WARP_THREADS + lane;
+    const int idx = i * warp_threads + lane;
     if (idx < k)
     {
       keys_out[k * warp_id + idx]   = keys[i];
@@ -207,16 +225,16 @@ __global__ void warp_bitonic_topk_iterator_kernel(
 
 // -----------------------------------------------------------
 // Dimensions being instantiated:
-// {full,partial,partial-iterator} x {keys, kv-pairs}
+// {full,partial-oob,partial,partial-iterator} x {keys, kv-pairs}
 // -----------------------------------------------------------
 
 /**
  * @brief Delegate wrapper for WarpBitonicTopK::TopK on keys-only
  */
-struct topk_keys_t
+struct topk_keys_full_t
 {
-  template <int ITEMS_PER_THREAD, typename KeyT, typename WarpTopKT>
-  __device__ void operator()(WarpTopKT& warp_topk, KeyT (&thread_data)[ITEMS_PER_THREAD], int k, int /*num_items*/) const
+  template <int ItemsPerThread, typename KeyT, typename WarpTopKT>
+  __device__ void operator()(WarpTopKT& warp_topk, KeyT (&thread_data)[ItemsPerThread], int k, int /*num_items*/) const
   {
     warp_topk.TopK(thread_data, CustomLess{}, k);
   }
@@ -225,12 +243,26 @@ struct topk_keys_t
 };
 
 /**
+ * @brief Delegate wrapper for partial WarpBitonicTopK::TopK on keys-only with oob_default
+ */
+struct topk_keys_partial_oob_t
+{
+  template <int ItemsPerThread, typename KeyT, typename WarpTopKT>
+  __device__ void operator()(WarpTopKT& warp_topk, KeyT (&thread_data)[ItemsPerThread], int k, int num_items) const
+  {
+    warp_topk.TopK(thread_data, CustomLess{}, k, num_items, CustomLess::get_oob_default<KeyT>());
+  }
+
+  static constexpr bool use_iterator{false};
+};
+
+/**
  * @brief Delegate wrapper for partial WarpBitonicTopK::TopK on keys-only
  */
-struct partial_topk_keys_t
+struct topk_keys_partial_t
 {
-  template <int ITEMS_PER_THREAD, typename KeyT, typename WarpTopKT>
-  __device__ void operator()(WarpTopKT& warp_topk, KeyT (&thread_data)[ITEMS_PER_THREAD], int k, int num_items) const
+  template <int ItemsPerThread, typename KeyT, typename WarpTopKT>
+  __device__ void operator()(WarpTopKT& warp_topk, KeyT (&thread_data)[ItemsPerThread], int k, int num_items) const
   {
     warp_topk.TopK(thread_data, CustomLess{}, k, num_items);
   }
@@ -238,11 +270,11 @@ struct partial_topk_keys_t
   static constexpr bool use_iterator{false};
 };
 
-struct partial_topk_keys_iterator_t
+struct topk_keys_iterator_t
 {
-  template <int MAX_K_PER_THREAD, typename KeyInputIteratorT, typename KeyT, typename WarpTopKT>
+  template <int MaxKPerThread, typename KeyInputIteratorT, typename KeyT, typename WarpTopKT>
   __device__ void operator()(
-    WarpTopKT& warp_topk, KeyInputIteratorT keys_in, int k, int num_items, KeyT (&keys_out)[MAX_K_PER_THREAD]) const
+    WarpTopKT& warp_topk, KeyInputIteratorT keys_in, int k, int num_items, KeyT (&keys_out)[MaxKPerThread]) const
   {
     warp_topk.TopK(keys_in, CustomLess{}, k, num_items, keys_out);
   }
@@ -253,12 +285,11 @@ struct partial_topk_keys_iterator_t
 /**
  * @brief Delegate wrapper for WarpBitonicTopK::TopK on key-value pairs
  */
-struct topk_pairs_t
+struct topk_pairs_full_t
 {
-  template <int ITEMS_PER_THREAD, typename KeyT, typename ValueT, typename WarpTopKT>
+  template <int ItemsPerThread, typename KeyT, typename ValueT, typename WarpTopKT>
   __device__ void operator()(
-    WarpTopKT& warp_topk, KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], int k, int /*num_items*/
-  ) const
+    WarpTopKT& warp_topk, KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread], int k, int /*num_items*/) const
   {
     warp_topk.TopK(keys, values, CustomLess{}, k);
   }
@@ -267,13 +298,28 @@ struct topk_pairs_t
 };
 
 /**
+ * @brief Delegate wrapper for partial WarpBitonicTopK::TopK on key-value pairs with oob_default
+ */
+struct topk_pairs_partial_oob_t
+{
+  template <int ItemsPerThread, typename KeyT, typename ValueT, typename WarpTopKT>
+  __device__ void operator()(
+    WarpTopKT& warp_topk, KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread], int k, int num_items) const
+  {
+    warp_topk.TopK(keys, values, CustomLess{}, k, num_items, CustomLess::get_oob_default<KeyT>());
+  }
+
+  static constexpr bool use_iterator{false};
+};
+
+/**
  * @brief Delegate wrapper for partial WarpBitonicTopK::TopK on key-value pairs
  */
-struct partial_topk_pairs_t
+struct topk_pairs_partial_t
 {
-  template <int ITEMS_PER_THREAD, typename KeyT, typename ValueT, typename WarpTopKT>
+  template <int ItemsPerThread, typename KeyT, typename ValueT, typename WarpTopKT>
   __device__ void operator()(
-    WarpTopKT& warp_topk, KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], int k, int num_items) const
+    WarpTopKT& warp_topk, KeyT (&keys)[ItemsPerThread], ValueT (&values)[ItemsPerThread], int k, int num_items) const
   {
     warp_topk.TopK(keys, values, CustomLess{}, k, num_items);
   }
@@ -281,9 +327,9 @@ struct partial_topk_pairs_t
   static constexpr bool use_iterator{false};
 };
 
-struct partial_topk_pairs_iterator_t
+struct topk_pairs_iterator_t
 {
-  template <int MAX_K_PER_THREAD,
+  template <int MaxKPerThread,
             typename KeyInputIteratorT,
             typename ValueInputIteratorT,
             typename KeyT,
@@ -295,8 +341,8 @@ struct partial_topk_pairs_iterator_t
     ValueInputIteratorT values_in,
     int k,
     int num_items,
-    KeyT (&keys_out)[MAX_K_PER_THREAD],
-    ValueT (&values_out)[MAX_K_PER_THREAD]) const
+    KeyT (&keys_out)[MaxKPerThread],
+    ValueT (&values_out)[MaxKPerThread]) const
   {
     warp_topk.TopK(keys_in, values_in, CustomLess{}, k, num_items, keys_out, values_out);
   }
@@ -307,21 +353,21 @@ struct partial_topk_pairs_iterator_t
 /**
  * @brief Dispatch helper function for keys
  */
-template <int MAX_K, int ITEMS_PER_THREAD, int TOTAL_WARPS, typename KeyT, typename ActionT>
+template <int MaxK, int ItemsPerThread, int TotalWarps, typename KeyT, typename ActionT>
 void warp_bitonic_topk(c2h::device_vector<KeyT>& in, c2h::device_vector<KeyT>& out, int k, int num_items, ActionT action)
 {
-  using Kernel = void (*)(KeyT*, KeyT*, int, int, ActionT);
-  Kernel kernel;
-  if constexpr (ActionT::use_iterator)
-  {
-    kernel = warp_bitonic_topk_iterator_kernel<MAX_K, ITEMS_PER_THREAD, TOTAL_WARPS, KeyT, ActionT>;
-  }
-  else
-  {
-    kernel = warp_bitonic_topk_kernel<MAX_K, ITEMS_PER_THREAD, TOTAL_WARPS, KeyT, ActionT>;
-  }
+  const auto kernel = [] {
+    if constexpr (ActionT::use_iterator)
+    {
+      return &warp_bitonic_topk_iterator_kernel<MaxK, ItemsPerThread, TotalWarps, KeyT, ActionT>;
+    }
+    else
+    {
+      return &warp_bitonic_topk_kernel<MaxK, ItemsPerThread, TotalWarps, KeyT, ActionT>;
+    }
+  }();
 
-  kernel<<<1, WARP_THREADS * TOTAL_WARPS>>>(
+  kernel<<<1, warp_threads * TotalWarps>>>(
     thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), k, num_items, action);
 
   REQUIRE(cudaSuccess == cudaPeekAtLastError());
@@ -331,7 +377,7 @@ void warp_bitonic_topk(c2h::device_vector<KeyT>& in, c2h::device_vector<KeyT>& o
 /**
  * @brief Dispatch helper function for key-value pairs
  */
-template <int MAX_K, int ITEMS_PER_THREAD, int TOTAL_WARPS, typename KeyT, typename ValueT, typename ActionT>
+template <int MaxK, int ItemsPerThread, int TotalWarps, typename KeyT, typename ValueT, typename ActionT>
 void warp_bitonic_topk(
   c2h::device_vector<KeyT>& keys_in,
   c2h::device_vector<KeyT>& keys_out,
@@ -341,18 +387,18 @@ void warp_bitonic_topk(
   int num_items,
   ActionT action)
 {
-  using Kernel = void (*)(KeyT*, KeyT*, ValueT*, ValueT*, int, int, ActionT);
-  Kernel kernel;
-  if constexpr (ActionT::use_iterator)
-  {
-    kernel = warp_bitonic_topk_iterator_kernel<MAX_K, ITEMS_PER_THREAD, TOTAL_WARPS, KeyT, ValueT, ActionT>;
-  }
-  else
-  {
-    kernel = warp_bitonic_topk_kernel<MAX_K, ITEMS_PER_THREAD, TOTAL_WARPS, KeyT, ValueT, ActionT>;
-  }
+  const auto kernel = [] {
+    if constexpr (ActionT::use_iterator)
+    {
+      return &warp_bitonic_topk_iterator_kernel<MaxK, ItemsPerThread, TotalWarps, KeyT, ValueT, ActionT>;
+    }
+    else
+    {
+      return &warp_bitonic_topk_kernel<MaxK, ItemsPerThread, TotalWarps, KeyT, ValueT, ActionT>;
+    }
+  }();
 
-  kernel<<<1, WARP_THREADS * TOTAL_WARPS>>>(
+  kernel<<<1, warp_threads * TotalWarps>>>(
     thrust::raw_pointer_cast(keys_in.data()),
     thrust::raw_pointer_cast(keys_out.data()),
     thrust::raw_pointer_cast(values_in.data()),
@@ -380,7 +426,7 @@ void verify_topk_result(
     const int in_offset  = warp_id * num_items;
     const int out_offset = warp_id * k;
 
-    // the keys of WarpBitonicTopK result are sorted, so we check it using std::sort
+    // The keys of the WarpBitonicTopK result are sorted, so check them using std::sort.
     std::sort(keys_in.begin() + in_offset, keys_in.begin() + in_offset + num_items);
     REQUIRE(c2h::host_vector<KeyT>(keys_in.begin() + in_offset, keys_in.begin() + in_offset + k)
             == c2h::host_vector<KeyT>(keys_out.begin() + out_offset, keys_out.begin() + out_offset + k));
@@ -410,28 +456,28 @@ void verify_topk_result(
 
     auto pair_in_begin  = thrust::make_zip_iterator(keys_in.begin() + in_offset, values_in.begin() + in_offset);
     auto pair_in_end    = pair_in_begin + num_items;
-    auto pair_begin_end = thrust::make_zip_iterator(keys_out.begin() + out_offset, values_out.begin() + out_offset);
-    auto pair_out_end   = pair_begin_end + k;
+    auto pair_out_begin = thrust::make_zip_iterator(keys_out.begin() + out_offset, values_out.begin() + out_offset);
+    auto pair_out_end   = pair_out_begin + k;
 
     std::sort(pair_in_begin, pair_in_end);
-    // the keys of WarpBitonicTopK result are sorted, so we check it before std::sort(pair_begin_end, pair_out_end)
+    // The keys of the WarpBitonicTopK result are sorted, so check them are sorted before sorting the output pairs
     REQUIRE(c2h::host_vector<KeyT>(keys_in.begin() + in_offset, keys_in.begin() + in_offset + k)
             == c2h::host_vector<KeyT>(keys_out.begin() + out_offset, keys_out.begin() + out_offset + k));
 
     // Top-k results are not unique when ties exist at the k-th key, so further check that each output (key, value) pair
     // appears in the input
-    std::sort(pair_begin_end, pair_out_end);
-    REQUIRE(std::includes(pair_in_begin, pair_in_end, pair_begin_end, pair_out_end));
+    std::sort(pair_out_begin, pair_out_end);
+    REQUIRE(std::includes(pair_in_begin, pair_in_end, pair_out_begin, pair_out_end));
   }
 }
 
 // List of key types to test
-using key_types = c2h::type_list<std::uint8_t, std::int32_t, std::int64_t>;
+using key_types = c2h::type_list<std::uint8_t, std::int32_t, std::int64_t, float>;
 
 // List of value types
 using value_types = c2h::type_list<std::int32_t>;
 
-using max_k_list                  = c2h::enum_type_list<int, WARP_THREADS, WARP_THREADS * 2, WARP_THREADS * 3>;
+using max_k_list                  = c2h::enum_type_list<int, warp_threads, warp_threads * 2, warp_threads * 3>;
 using extra_items_per_thread_list = c2h::enum_type_list<int, 0, 1, 2, 3, 4, 5, 6, 7>;
 
 template <typename TestType>
@@ -441,11 +487,11 @@ struct params_t
 
   static constexpr int max_k                  = c2h::get<1, TestType>::value;
   static constexpr int extra_items_per_thread = c2h::get<2, TestType>::value;
-  static constexpr int items_per_thread       = max_k / WARP_THREADS + extra_items_per_thread;
+  static constexpr int items_per_thread       = max_k / warp_threads + extra_items_per_thread;
   static constexpr int total_warps            = 2;
 };
 
-C2H_TEST("Warp topk on keys works", "[topk][warp]", key_types, max_k_list, extra_items_per_thread_list)
+CUB_TEST("Warp top-k on keys works", "[topk][warp]", CUB_SMALL, key_types, max_k_list, extra_items_per_thread_list)
 {
   using params                   = params_t<TestType>;
   using key_type                 = typename params::type;
@@ -455,43 +501,50 @@ C2H_TEST("Warp topk on keys works", "[topk][warp]", key_types, max_k_list, extra
 
   // Prepare test data
   const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
-  const int num_items = items_per_thread * WARP_THREADS;
+  const int num_items = items_per_thread * warp_threads;
   c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
   c2h::device_vector<key_type> d_keys_out(total_warps * k);
   c2h::gen(C2H_SEED(10), d_keys_in);
 
   // Run test
-  warp_bitonic_topk<max_k, items_per_thread, total_warps>(d_keys_in, d_keys_out, k, num_items, topk_keys_t{});
+  warp_bitonic_topk<max_k, items_per_thread, total_warps>(d_keys_in, d_keys_out, k, num_items, topk_keys_full_t{});
 
   // Verify results
   verify_topk_result(d_keys_in, d_keys_out, total_warps);
 }
 
-C2H_TEST(
-  "Warp topk on keys of a partial warp-tile works", "[topk][warp]", key_types, max_k_list, extra_items_per_thread_list)
+CUB_TEST("Warp top-k on keys of a partial warp-tile works",
+         "[topk][warp]",
+         CUB_SMALL,
+         key_types,
+         max_k_list,
+         extra_items_per_thread_list,
+         c2h::type_list<topk_keys_partial_oob_t, topk_keys_partial_t>)
 {
   using params                   = params_t<TestType>;
   using key_type                 = typename params::type;
+  using action_t                 = typename c2h::get<3, TestType>;
   constexpr int max_k            = params::max_k;
   constexpr int items_per_thread = params::items_per_thread;
   constexpr int total_warps      = params::total_warps;
 
   // Prepare test data
   const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
-  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * WARP_THREADS)));
+  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * warp_threads)));
   c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
   c2h::device_vector<key_type> d_keys_out(total_warps * k);
   c2h::gen(C2H_SEED(5), d_keys_in);
 
   // Run test
-  warp_bitonic_topk<max_k, items_per_thread, total_warps>(d_keys_in, d_keys_out, k, num_items, partial_topk_keys_t{});
+  warp_bitonic_topk<max_k, items_per_thread, total_warps>(d_keys_in, d_keys_out, k, num_items, action_t{});
 
   // Verify results
   verify_topk_result(d_keys_in, d_keys_out, total_warps);
 }
 
-C2H_TEST("Warp topk iterator on keys of a partial warp-tile works",
+CUB_TEST("Warp top-k iterator on keys of a partial warp-tile works",
          "[topk][warp]",
+         CUB_SMALL,
          key_types,
          max_k_list,
          c2h::enum_type_list<int, 0>)
@@ -510,43 +563,15 @@ C2H_TEST("Warp topk iterator on keys of a partial warp-tile works",
   c2h::gen(C2H_SEED(5), d_keys_in);
 
   // Run test
-  warp_bitonic_topk<max_k, items_per_thread, total_warps>(
-    d_keys_in, d_keys_out, k, num_items, partial_topk_keys_iterator_t{});
+  warp_bitonic_topk<max_k, items_per_thread, total_warps>(d_keys_in, d_keys_out, k, num_items, topk_keys_iterator_t{});
 
   // Verify results
   verify_topk_result(d_keys_in, d_keys_out, total_warps);
 }
 
-C2H_TEST(
-  "Warp topk on keys-value pairs works", "[topk][warp]", key_types, max_k_list, extra_items_per_thread_list, value_types)
-{
-  using params                   = params_t<TestType>;
-  using key_type                 = typename params::type;
-  using value_type               = typename c2h::get<3, TestType>;
-  constexpr int max_k            = params::max_k;
-  constexpr int items_per_thread = params::items_per_thread;
-  constexpr int total_warps      = params::total_warps;
-
-  // Prepare test data
-  const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
-  const int num_items = items_per_thread * WARP_THREADS;
-  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
-  c2h::device_vector<value_type> d_values_in(total_warps * num_items);
-  c2h::device_vector<key_type> d_keys_out(total_warps * k);
-  c2h::device_vector<value_type> d_values_out(total_warps * k);
-  c2h::gen(C2H_SEED(10), d_keys_in);
-  c2h::gen(C2H_SEED(1), d_values_in);
-
-  // Run test
-  warp_bitonic_topk<max_k, items_per_thread, total_warps>(
-    d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, topk_pairs_t{});
-
-  // Verify results
-  verify_topk_result(d_keys_in, d_values_in, d_keys_out, d_values_out, total_warps);
-}
-
-C2H_TEST("Warp topk on key-value pairs of a partial warp-tile works",
+CUB_TEST("Warp top-k on key-value pairs works",
          "[topk][warp]",
+         CUB_SMALL,
          key_types,
          max_k_list,
          extra_items_per_thread_list,
@@ -561,7 +586,42 @@ C2H_TEST("Warp topk on key-value pairs of a partial warp-tile works",
 
   // Prepare test data
   const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
-  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * WARP_THREADS)));
+  const int num_items = items_per_thread * warp_threads;
+  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
+  c2h::device_vector<value_type> d_values_in(total_warps * num_items);
+  c2h::device_vector<key_type> d_keys_out(total_warps * k);
+  c2h::device_vector<value_type> d_values_out(total_warps * k);
+  c2h::gen(C2H_SEED(10), d_keys_in);
+  c2h::gen(C2H_SEED(1), d_values_in);
+
+  // Run test
+  warp_bitonic_topk<max_k, items_per_thread, total_warps>(
+    d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, topk_pairs_full_t{});
+
+  // Verify results
+  verify_topk_result(d_keys_in, d_values_in, d_keys_out, d_values_out, total_warps);
+}
+
+CUB_TEST("Warp top-k on key-value pairs of a partial warp-tile works",
+         "[topk][warp]",
+         CUB_SMALL,
+         key_types,
+         max_k_list,
+         extra_items_per_thread_list,
+         value_types,
+         c2h::type_list<topk_pairs_partial_oob_t, topk_pairs_partial_t>)
+{
+  using params                   = params_t<TestType>;
+  using key_type                 = typename params::type;
+  using value_type               = typename c2h::get<3, TestType>;
+  using action_t                 = typename c2h::get<4, TestType>;
+  constexpr int max_k            = params::max_k;
+  constexpr int items_per_thread = params::items_per_thread;
+  constexpr int total_warps      = params::total_warps;
+
+  // Prepare test data
+  const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
+  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * warp_threads)));
   c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
   c2h::device_vector<value_type> d_values_in(total_warps * num_items);
   c2h::device_vector<key_type> d_keys_out(total_warps * k);
@@ -571,14 +631,15 @@ C2H_TEST("Warp topk on key-value pairs of a partial warp-tile works",
 
   // Run test
   warp_bitonic_topk<max_k, items_per_thread, total_warps>(
-    d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, partial_topk_pairs_t{});
+    d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, action_t{});
 
   // Verify results
   verify_topk_result(d_keys_in, d_values_in, d_keys_out, d_values_out, total_warps);
 }
 
-C2H_TEST("Warp topk iterator on key-value pairs of a partial warp-tile works",
+CUB_TEST("Warp top-k iterator on key-value pairs of a partial warp-tile works",
          "[topk][warp]",
+         CUB_SMALL,
          key_types,
          max_k_list,
          c2h::enum_type_list<int, 0>, // unused
@@ -603,7 +664,7 @@ C2H_TEST("Warp topk iterator on key-value pairs of a partial warp-tile works",
 
   // Run test
   warp_bitonic_topk<max_k, items_per_thread, total_warps>(
-    d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, partial_topk_pairs_iterator_t{});
+    d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, topk_pairs_iterator_t{});
 
   // Verify results
   verify_topk_result(d_keys_in, d_values_in, d_keys_out, d_values_out, total_warps);

--- a/cub/test/catch2_test_warp_bitonic_topk.cu
+++ b/cub/test/catch2_test_warp_bitonic_topk.cu
@@ -8,6 +8,7 @@
 #include <thrust/memory.h>
 
 #include <cuda/std/limits>
+#include <cuda/std/type_traits>
 
 #include <algorithm>
 #include <cstdint>
@@ -40,14 +41,15 @@ struct CustomLess
 };
 
 using cub::detail::warp_threads;
+using cub::detail::WarpBitonicTopKAlgorithm;
 
 /**
  * @brief Kernel to dispatch to the appropriate WarpBitonicTopK member function, for keys-only.
  */
-template <int MaxK, int ItemsPerThread, int TotalWarps, typename KeyT, typename ActionT>
-__global__ void warp_bitonic_topk_kernel(KeyT* keys_in, KeyT* keys_out, int k, int num_items, ActionT action)
+template <WarpBitonicTopKAlgorithm Algo, int MaxK, int ItemsPerThread, int TotalWarps, typename KeyT, typename ActionT>
+__global__ void array_kernel(KeyT* keys_in, KeyT* keys_out, int k, int num_items, ActionT action)
 {
-  using warp_bitonic_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT>;
+  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, cub::NullType, Algo>;
 
   // Get linear thread and warp index
   const int tid     = threadIdx.x;
@@ -64,7 +66,8 @@ __global__ void warp_bitonic_topk_kernel(KeyT* keys_in, KeyT* keys_out, int k, i
   KeyT keys[ItemsPerThread];
 
   // Instantiate warp-scope algorithm
-  warp_bitonic_topk_t warp_topk;
+  __shared__ typename warp_topk_t::TempStorage temp_storage[TotalWarps];
+  warp_topk_t warp_topk{temp_storage[warp_id]};
 
   // Load data
   for (int i = 0; i < ItemsPerThread; ++i)
@@ -90,10 +93,10 @@ __global__ void warp_bitonic_topk_kernel(KeyT* keys_in, KeyT* keys_out, int k, i
   }
 }
 
-template <int MaxK, int ItemsPerThread, int TotalWarps, typename KeyT, typename ActionT>
-__global__ void warp_bitonic_topk_iterator_kernel(KeyT* keys_in, KeyT* keys_out, int k, int num_items, ActionT action)
+template <WarpBitonicTopKAlgorithm Algo, int MaxK, int ItemsPerThread, int TotalWarps, typename KeyT, typename ActionT>
+__global__ void iterator_kernel(KeyT* keys_in, KeyT* keys_out, int k, int num_items, ActionT action)
 {
-  using warp_bitonic_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT>;
+  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, cub::NullType, Algo>;
 
   // Get linear thread and warp index
   const int tid     = threadIdx.x;
@@ -110,8 +113,8 @@ __global__ void warp_bitonic_topk_iterator_kernel(KeyT* keys_in, KeyT* keys_out,
   KeyT keys[MaxK / warp_threads];
 
   // Instantiate warp-scope algorithm
-  __shared__ typename warp_bitonic_topk_t::TempStorage temp_storage[TotalWarps];
-  warp_bitonic_topk_t warp_topk(temp_storage[warp_id]);
+  __shared__ typename warp_topk_t::TempStorage temp_storage[TotalWarps];
+  warp_topk_t warp_topk{temp_storage[warp_id]};
 
   // Run bitonic top-k
   const int in_offset = num_items * warp_id;
@@ -132,11 +135,17 @@ __global__ void warp_bitonic_topk_iterator_kernel(KeyT* keys_in, KeyT* keys_out,
  * @brief Kernel to dispatch to the appropriate WarpBitonicTopK member function, for key-value
  * pairs.
  */
-template <int MaxK, int ItemsPerThread, int TotalWarps, typename KeyT, typename ValueT, typename ActionT>
-__global__ void warp_bitonic_topk_kernel(
-  KeyT* keys_in, KeyT* keys_out, ValueT* values_in, ValueT* values_out, int k, int num_items, ActionT action)
+template <WarpBitonicTopKAlgorithm Algo,
+          int MaxK,
+          int ItemsPerThread,
+          int TotalWarps,
+          typename KeyT,
+          typename ValueT,
+          typename ActionT>
+__global__ void
+array_kernel(KeyT* keys_in, KeyT* keys_out, ValueT* values_in, ValueT* values_out, int k, int num_items, ActionT action)
 {
-  using warp_bitonic_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT>;
+  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT, Algo>;
 
   // Get linear thread and warp index
   const int tid     = threadIdx.x;
@@ -154,7 +163,8 @@ __global__ void warp_bitonic_topk_kernel(
   ValueT values[ItemsPerThread];
 
   // Instantiate warp-scope algorithm
-  warp_bitonic_topk_t warp_topk;
+  __shared__ typename warp_topk_t::TempStorage temp_storage[TotalWarps];
+  warp_topk_t warp_topk{temp_storage[warp_id]};
 
   // Load data
   for (int i = 0; i < ItemsPerThread; ++i)
@@ -182,11 +192,17 @@ __global__ void warp_bitonic_topk_kernel(
   }
 }
 
-template <int MaxK, int ItemsPerThread, int TotalWarps, typename KeyT, typename ValueT, typename ActionT>
-__global__ void warp_bitonic_topk_iterator_kernel(
+template <WarpBitonicTopKAlgorithm Algo,
+          int MaxK,
+          int ItemsPerThread,
+          int TotalWarps,
+          typename KeyT,
+          typename ValueT,
+          typename ActionT>
+__global__ void iterator_kernel(
   KeyT* keys_in, KeyT* keys_out, ValueT* values_in, ValueT* values_out, int k, int num_items, ActionT action)
 {
-  using warp_bitonic_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT>;
+  using warp_topk_t = cub::detail::WarpBitonicTopK<MaxK, KeyT, ValueT, Algo>;
 
   // Get linear thread and warp index
   const int tid     = threadIdx.x;
@@ -204,8 +220,8 @@ __global__ void warp_bitonic_topk_iterator_kernel(
   ValueT values[MaxK / warp_threads];
 
   // Instantiate warp-scope algorithm
-  __shared__ typename warp_bitonic_topk_t::TempStorage temp_storage[TotalWarps];
-  warp_bitonic_topk_t warp_topk(temp_storage[warp_id]);
+  __shared__ typename warp_topk_t::TempStorage temp_storage[TotalWarps];
+  warp_topk_t warp_topk{temp_storage[warp_id]};
 
   // Run bitonic top-k
   const int in_offset = num_items * warp_id;
@@ -238,8 +254,6 @@ struct topk_keys_full_t
   {
     warp_topk.TopK(thread_data, CustomLess{}, k);
   }
-
-  static constexpr bool use_iterator{false};
 };
 
 /**
@@ -252,8 +266,6 @@ struct topk_keys_partial_oob_t
   {
     warp_topk.TopK(thread_data, CustomLess{}, k, num_items, CustomLess::get_oob_default<KeyT>());
   }
-
-  static constexpr bool use_iterator{false};
 };
 
 /**
@@ -266,8 +278,6 @@ struct topk_keys_partial_t
   {
     warp_topk.TopK(thread_data, CustomLess{}, k, num_items);
   }
-
-  static constexpr bool use_iterator{false};
 };
 
 struct topk_keys_iterator_t
@@ -278,8 +288,6 @@ struct topk_keys_iterator_t
   {
     warp_topk.TopK(keys_in, CustomLess{}, k, num_items, keys_out);
   }
-
-  static constexpr bool use_iterator{true};
 };
 
 /**
@@ -293,8 +301,6 @@ struct topk_pairs_full_t
   {
     warp_topk.TopK(keys, values, CustomLess{}, k);
   }
-
-  static constexpr bool use_iterator{false};
 };
 
 /**
@@ -308,8 +314,6 @@ struct topk_pairs_partial_oob_t
   {
     warp_topk.TopK(keys, values, CustomLess{}, k, num_items, CustomLess::get_oob_default<KeyT>());
   }
-
-  static constexpr bool use_iterator{false};
 };
 
 /**
@@ -323,8 +327,6 @@ struct topk_pairs_partial_t
   {
     warp_topk.TopK(keys, values, CustomLess{}, k, num_items);
   }
-
-  static constexpr bool use_iterator{false};
 };
 
 struct topk_pairs_iterator_t
@@ -346,24 +348,22 @@ struct topk_pairs_iterator_t
   {
     warp_topk.TopK(keys_in, values_in, CustomLess{}, k, num_items, keys_out, values_out);
   }
-
-  static constexpr bool use_iterator{true};
 };
 
 /**
  * @brief Dispatch helper function for keys
  */
-template <int MaxK, int ItemsPerThread, int TotalWarps, typename KeyT, typename ActionT>
+template <WarpBitonicTopKAlgorithm Algo, int MaxK, int ItemsPerThread, int TotalWarps, typename KeyT, typename ActionT>
 void warp_bitonic_topk(c2h::device_vector<KeyT>& in, c2h::device_vector<KeyT>& out, int k, int num_items, ActionT action)
 {
   const auto kernel = [] {
-    if constexpr (ActionT::use_iterator)
+    if constexpr (cuda::std::is_same_v<ActionT, topk_keys_iterator_t>)
     {
-      return &warp_bitonic_topk_iterator_kernel<MaxK, ItemsPerThread, TotalWarps, KeyT, ActionT>;
+      return &iterator_kernel<Algo, MaxK, ItemsPerThread, TotalWarps, KeyT, ActionT>;
     }
     else
     {
-      return &warp_bitonic_topk_kernel<MaxK, ItemsPerThread, TotalWarps, KeyT, ActionT>;
+      return &array_kernel<Algo, MaxK, ItemsPerThread, TotalWarps, KeyT, ActionT>;
     }
   }();
 
@@ -377,7 +377,13 @@ void warp_bitonic_topk(c2h::device_vector<KeyT>& in, c2h::device_vector<KeyT>& o
 /**
  * @brief Dispatch helper function for key-value pairs
  */
-template <int MaxK, int ItemsPerThread, int TotalWarps, typename KeyT, typename ValueT, typename ActionT>
+template <WarpBitonicTopKAlgorithm Algo,
+          int MaxK,
+          int ItemsPerThread,
+          int TotalWarps,
+          typename KeyT,
+          typename ValueT,
+          typename ActionT>
 void warp_bitonic_topk(
   c2h::device_vector<KeyT>& keys_in,
   c2h::device_vector<KeyT>& keys_out,
@@ -388,13 +394,13 @@ void warp_bitonic_topk(
   ActionT action)
 {
   const auto kernel = [] {
-    if constexpr (ActionT::use_iterator)
+    if constexpr (cuda::std::is_same_v<ActionT, topk_pairs_iterator_t>)
     {
-      return &warp_bitonic_topk_iterator_kernel<MaxK, ItemsPerThread, TotalWarps, KeyT, ValueT, ActionT>;
+      return &iterator_kernel<Algo, MaxK, ItemsPerThread, TotalWarps, KeyT, ValueT, ActionT>;
     }
     else
     {
-      return &warp_bitonic_topk_kernel<MaxK, ItemsPerThread, TotalWarps, KeyT, ValueT, ActionT>;
+      return &array_kernel<Algo, MaxK, ItemsPerThread, TotalWarps, KeyT, ValueT, ActionT>;
     }
   }();
 
@@ -477,6 +483,9 @@ using key_types = c2h::type_list<std::uint8_t, std::int32_t, std::int64_t, float
 // List of value types
 using value_types = c2h::type_list<std::int32_t>;
 
+using algo_list =
+  c2h::enum_type_list<WarpBitonicTopKAlgorithm, WarpBitonicTopKAlgorithm::eager, WarpBitonicTopKAlgorithm::buffered>;
+using eager_algo_list             = c2h::enum_type_list<WarpBitonicTopKAlgorithm, WarpBitonicTopKAlgorithm::eager>;
 using max_k_list                  = c2h::enum_type_list<int, warp_threads, warp_threads * 2, warp_threads * 3>;
 using extra_items_per_thread_list = c2h::enum_type_list<int, 0, 1, 2, 3, 4, 5, 6, 7>;
 
@@ -485,16 +494,19 @@ struct params_t
 {
   using type = typename c2h::get<0, TestType>;
 
-  static constexpr int max_k                  = c2h::get<1, TestType>::value;
-  static constexpr int extra_items_per_thread = c2h::get<2, TestType>::value;
-  static constexpr int items_per_thread       = max_k / warp_threads + extra_items_per_thread;
-  static constexpr int total_warps            = 2;
+  static constexpr WarpBitonicTopKAlgorithm algo = c2h::get<1, TestType>::value;
+  static constexpr int max_k                     = c2h::get<2, TestType>::value;
+  static constexpr int extra_items_per_thread    = c2h::get<3, TestType>::value;
+  static constexpr int items_per_thread          = max_k / warp_threads + extra_items_per_thread;
+  static constexpr int total_warps               = 2;
 };
 
-CUB_TEST("Warp top-k on keys works", "[topk][warp]", CUB_SMALL, key_types, max_k_list, extra_items_per_thread_list)
+CUB_TEST(
+  "Warp top-k on keys works", "[topk][warp]", CUB_SMALL, key_types, algo_list, max_k_list, extra_items_per_thread_list)
 {
   using params                   = params_t<TestType>;
   using key_type                 = typename params::type;
+  constexpr auto algo            = params::algo;
   constexpr int max_k            = params::max_k;
   constexpr int items_per_thread = params::items_per_thread;
   constexpr int total_warps      = params::total_warps;
@@ -507,7 +519,37 @@ CUB_TEST("Warp top-k on keys works", "[topk][warp]", CUB_SMALL, key_types, max_k
   c2h::gen(C2H_SEED(10), d_keys_in);
 
   // Run test
-  warp_bitonic_topk<max_k, items_per_thread, total_warps>(d_keys_in, d_keys_out, k, num_items, topk_keys_full_t{});
+  warp_bitonic_topk<algo, max_k, items_per_thread, total_warps>(d_keys_in, d_keys_out, k, num_items, topk_keys_full_t{});
+
+  // Verify results
+  verify_topk_result(d_keys_in, d_keys_out, total_warps);
+}
+
+CUB_TEST("Warp top-k on keys of a partial warp-tile with an OOB default works",
+         "[topk][warp]",
+         CUB_SMALL,
+         key_types,
+         eager_algo_list,
+         max_k_list,
+         extra_items_per_thread_list)
+{
+  using params                   = params_t<TestType>;
+  using key_type                 = typename params::type;
+  constexpr auto algo            = params::algo;
+  constexpr int max_k            = params::max_k;
+  constexpr int items_per_thread = params::items_per_thread;
+  constexpr int total_warps      = params::total_warps;
+
+  // Prepare test data
+  const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
+  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * warp_threads)));
+  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
+  c2h::device_vector<key_type> d_keys_out(total_warps * k);
+  c2h::gen(C2H_SEED(5), d_keys_in);
+
+  // Run test
+  warp_bitonic_topk<algo, max_k, items_per_thread, total_warps>(
+    d_keys_in, d_keys_out, k, num_items, topk_keys_partial_oob_t{});
 
   // Verify results
   verify_topk_result(d_keys_in, d_keys_out, total_warps);
@@ -517,13 +559,13 @@ CUB_TEST("Warp top-k on keys of a partial warp-tile works",
          "[topk][warp]",
          CUB_SMALL,
          key_types,
+         algo_list,
          max_k_list,
-         extra_items_per_thread_list,
-         c2h::type_list<topk_keys_partial_oob_t, topk_keys_partial_t>)
+         extra_items_per_thread_list)
 {
   using params                   = params_t<TestType>;
   using key_type                 = typename params::type;
-  using action_t                 = typename c2h::get<3, TestType>;
+  constexpr auto algo            = params::algo;
   constexpr int max_k            = params::max_k;
   constexpr int items_per_thread = params::items_per_thread;
   constexpr int total_warps      = params::total_warps;
@@ -536,7 +578,8 @@ CUB_TEST("Warp top-k on keys of a partial warp-tile works",
   c2h::gen(C2H_SEED(5), d_keys_in);
 
   // Run test
-  warp_bitonic_topk<max_k, items_per_thread, total_warps>(d_keys_in, d_keys_out, k, num_items, action_t{});
+  warp_bitonic_topk<algo, max_k, items_per_thread, total_warps>(
+    d_keys_in, d_keys_out, k, num_items, topk_keys_partial_t{});
 
   // Verify results
   verify_topk_result(d_keys_in, d_keys_out, total_warps);
@@ -546,11 +589,13 @@ CUB_TEST("Warp top-k iterator on keys of a partial warp-tile works",
          "[topk][warp]",
          CUB_SMALL,
          key_types,
+         algo_list,
          max_k_list,
          c2h::enum_type_list<int, 0>)
 {
   using params                   = params_t<TestType>;
   using key_type                 = typename params::type;
+  constexpr auto algo            = params::algo;
   constexpr int max_k            = params::max_k;
   constexpr int items_per_thread = params::items_per_thread;
   constexpr int total_warps      = params::total_warps;
@@ -563,7 +608,8 @@ CUB_TEST("Warp top-k iterator on keys of a partial warp-tile works",
   c2h::gen(C2H_SEED(5), d_keys_in);
 
   // Run test
-  warp_bitonic_topk<max_k, items_per_thread, total_warps>(d_keys_in, d_keys_out, k, num_items, topk_keys_iterator_t{});
+  warp_bitonic_topk<algo, max_k, items_per_thread, total_warps>(
+    d_keys_in, d_keys_out, k, num_items, topk_keys_iterator_t{});
 
   // Verify results
   verify_topk_result(d_keys_in, d_keys_out, total_warps);
@@ -573,13 +619,15 @@ CUB_TEST("Warp top-k on key-value pairs works",
          "[topk][warp]",
          CUB_SMALL,
          key_types,
+         algo_list,
          max_k_list,
          extra_items_per_thread_list,
          value_types)
 {
   using params                   = params_t<TestType>;
   using key_type                 = typename params::type;
-  using value_type               = typename c2h::get<3, TestType>;
+  using value_type               = typename c2h::get<4, TestType>;
+  constexpr auto algo            = params::algo;
   constexpr int max_k            = params::max_k;
   constexpr int items_per_thread = params::items_per_thread;
   constexpr int total_warps      = params::total_warps;
@@ -595,26 +643,26 @@ CUB_TEST("Warp top-k on key-value pairs works",
   c2h::gen(C2H_SEED(1), d_values_in);
 
   // Run test
-  warp_bitonic_topk<max_k, items_per_thread, total_warps>(
+  warp_bitonic_topk<algo, max_k, items_per_thread, total_warps>(
     d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, topk_pairs_full_t{});
 
   // Verify results
   verify_topk_result(d_keys_in, d_values_in, d_keys_out, d_values_out, total_warps);
 }
 
-CUB_TEST("Warp top-k on key-value pairs of a partial warp-tile works",
+CUB_TEST("Warp top-k on key-value pairs of a partial warp-tile with an OOB default works",
          "[topk][warp]",
          CUB_SMALL,
          key_types,
+         eager_algo_list,
          max_k_list,
          extra_items_per_thread_list,
-         value_types,
-         c2h::type_list<topk_pairs_partial_oob_t, topk_pairs_partial_t>)
+         value_types)
 {
   using params                   = params_t<TestType>;
   using key_type                 = typename params::type;
-  using value_type               = typename c2h::get<3, TestType>;
-  using action_t                 = typename c2h::get<4, TestType>;
+  using value_type               = typename c2h::get<4, TestType>;
+  constexpr auto algo            = params::algo;
   constexpr int max_k            = params::max_k;
   constexpr int items_per_thread = params::items_per_thread;
   constexpr int total_warps      = params::total_warps;
@@ -630,8 +678,43 @@ CUB_TEST("Warp top-k on key-value pairs of a partial warp-tile works",
   c2h::gen(C2H_SEED(1), d_values_in);
 
   // Run test
-  warp_bitonic_topk<max_k, items_per_thread, total_warps>(
-    d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, action_t{});
+  warp_bitonic_topk<algo, max_k, items_per_thread, total_warps>(
+    d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, topk_pairs_partial_oob_t{});
+
+  // Verify results
+  verify_topk_result(d_keys_in, d_values_in, d_keys_out, d_values_out, total_warps);
+}
+
+CUB_TEST("Warp top-k on key-value pairs of a partial warp-tile works",
+         "[topk][warp]",
+         CUB_SMALL,
+         key_types,
+         algo_list,
+         max_k_list,
+         extra_items_per_thread_list,
+         value_types)
+{
+  using params                   = params_t<TestType>;
+  using key_type                 = typename params::type;
+  using value_type               = typename c2h::get<4, TestType>;
+  constexpr auto algo            = params::algo;
+  constexpr int max_k            = params::max_k;
+  constexpr int items_per_thread = params::items_per_thread;
+  constexpr int total_warps      = params::total_warps;
+
+  // Prepare test data
+  const int k         = GENERATE_COPY(1, max_k - 1, max_k, take(5, random(2, max_k - 2)));
+  const int num_items = GENERATE_COPY(k, take(5, random(k, items_per_thread * warp_threads)));
+  c2h::device_vector<key_type> d_keys_in(total_warps * num_items);
+  c2h::device_vector<value_type> d_values_in(total_warps * num_items);
+  c2h::device_vector<key_type> d_keys_out(total_warps * k);
+  c2h::device_vector<value_type> d_values_out(total_warps * k);
+  c2h::gen(C2H_SEED(5), d_keys_in);
+  c2h::gen(C2H_SEED(1), d_values_in);
+
+  // Run test
+  warp_bitonic_topk<algo, max_k, items_per_thread, total_warps>(
+    d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, topk_pairs_partial_t{});
 
   // Verify results
   verify_topk_result(d_keys_in, d_values_in, d_keys_out, d_values_out, total_warps);
@@ -641,13 +724,15 @@ CUB_TEST("Warp top-k iterator on key-value pairs of a partial warp-tile works",
          "[topk][warp]",
          CUB_SMALL,
          key_types,
+         algo_list,
          max_k_list,
          c2h::enum_type_list<int, 0>, // unused
          value_types)
 {
   using params                   = params_t<TestType>;
   using key_type                 = typename params::type;
-  using value_type               = typename c2h::get<3, TestType>;
+  using value_type               = typename c2h::get<4, TestType>;
+  constexpr auto algo            = params::algo;
   constexpr int max_k            = params::max_k;
   constexpr int items_per_thread = params::items_per_thread;
   constexpr int total_warps      = params::total_warps;
@@ -663,7 +748,7 @@ CUB_TEST("Warp top-k iterator on key-value pairs of a partial warp-tile works",
   c2h::gen(C2H_SEED(1), d_values_in);
 
   // Run test
-  warp_bitonic_topk<max_k, items_per_thread, total_warps>(
+  warp_bitonic_topk<algo, max_k, items_per_thread, total_warps>(
     d_keys_in, d_keys_out, d_values_in, d_values_out, k, num_items, topk_pairs_iterator_t{});
 
   // Verify results


### PR DESCRIPTION
## Description

Add `WarpBitonicTopK` which is a warp-wide top-k (WarpTopK), a feature listed in in #5673

It is based on `WarpBitonicSort` from #8391.

The output guarantees are (1) deterministic (2) unstable sorted.

Tests and benchmarks are also added.

