### PR TITLE
Constrain tuple_of_iterator_references -> tuple conversion on element convertibility (fixes GCC 9 build break)

### DIFF
--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -47,6 +47,22 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+// Determines whether each element of a tuple_of_iterator_references can actually construct the
+// corresponding tuple element. The tuple_of_iterator_references converting constructor below is
+// otherwise unconstrained on element convertibility, so is_constructible would report true even for
+// ill-formed conversions (e.g. tuple_of_iterator_references<const int&> -> tuple<int&>) and then
+// hard-error when the delegating constructor body is instantiated -- which happens during a
+// contiguous_iterator concept check on a thrust zip_iterator under GCC 9.
+template <class _TupleTypes, class _TupleOfIteratorReferences, class _Indices>
+inline constexpr bool __tuple_of_iterator_references_constructible_v = false;
+
+template <class... _Tp, class _TupleOfIteratorReferences, size_t... _Indices>
+inline constexpr bool __tuple_of_iterator_references_constructible_v<__tuple_types<_Tp...>,
+                                                                     _TupleOfIteratorReferences,
+                                                                     __tuple_indices<_Indices...>> =
+  (is_constructible_v<_Tp, decltype(::cuda::std::get<_Indices>(::cuda::std::declval<_TupleOfIteratorReferences>()))>
+   && ...);
+
 template <class... _Tp>
 class _CCCL_TYPE_VISIBILITY_DEFAULT tuple
 {
@@ -225,7 +241,11 @@ public:
             // NOLINTBEGIN(modernize-type-traits)
             enable_if_t<__is_tuple_of_iterator_references_v<_TupleOfIteratorReferences>, int> = 0,
             // NOLINTEND(modernize-type-traits)
-            enable_if_t<(tuple_size<_TupleOfIteratorReferences>::value == sizeof...(_Tp)), int> = 0>
+            enable_if_t<(tuple_size<_TupleOfIteratorReferences>::value == sizeof...(_Tp)), int> = 0,
+            enable_if_t<__tuple_of_iterator_references_constructible_v<__tuple_types<_Tp...>,
+                                                                       _TupleOfIteratorReferences,
+                                                                       __make_tuple_indices_t<sizeof...(_Tp)>>,
+                        int>                                                                    = 0>
   _CCCL_API constexpr tuple(_TupleOfIteratorReferences&& __t)
       : tuple(::cuda::std::forward<_TupleOfIteratorReferences>(__t), __make_tuple_indices_t<sizeof...(_Tp)>{})
   {}

--- a/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
+++ b/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
@@ -168,7 +168,12 @@ public:
 
   template <
     class... Us,
-    ::cuda::std::enable_if_t<is_compatible_tuple_v<::cuda::std::tuple<Us...>, ::cuda::std::tuple<Ts...>>, int> = 0>
+    ::cuda::std::enable_if_t<is_compatible_tuple_v<::cuda::std::tuple<Us...>, ::cuda::std::tuple<Ts...>>, int> = 0,
+    // Structure compatibility alone is not enough: each held reference must actually convert to the
+    // requested element, otherwise this operator is selected for ill-formed conversions such as
+    // tuple_of_iterator_references<const int&> -> tuple<int&>, which then hard-errors in the body
+    // (e.g. during a contiguous_iterator concept check on a zip_iterator under GCC 9).
+    ::cuda::std::enable_if_t<(::cuda::std::is_convertible_v<Ts, Us> && ...), int> = 0>
   _CCCL_HOST_DEVICE constexpr operator ::cuda::std::tuple<Us...>() const
   {
     return __to_tuple<Us...>(typename ::cuda::std::__make_tuple_indices<sizeof...(Ts)>::type{});


### PR DESCRIPTION
## Summary

Converting thrust's `tuple_of_iterator_references<Us...>` to `cuda::std::tuple<Ts...>` was selectable whenever the tuple *structures* matched, without checking that each held reference can actually construct the target element. So `is_constructible` reports `true` for ill-formed conversions such as `tuple_of_iterator_references<const int&> -> tuple<int&>`, which then **hard-error** when the constructor body is instantiated.

This surfaces as a build break: under **GCC 9 / C++17** the `contiguous_iterator` concept check on a thrust `zip_iterator` instantiates that conversion and fails to compile (e.g. `cudax/examples/stf/thrust_zip_iterator.cu`). GCC 11+ happen not to instantiate it, so they pass. The conversion machinery here was last touched by #9059.

## Root cause

Two entry points report the ill-formed conversion as viable:

1. `thrust/iterator/detail/tuple_of_iterator_references.h` — `operator cuda::std::tuple<Us...>()` is gated only by `is_compatible_tuple_v`, which checks tuple structure/size (it normalizes `T&` -> `T`), not element convertibility.
2. `libcudacxx/.../__tuple_dir/tuple.h` — the `tuple_of_iterator_references` converting constructor ("Horrible hack") is constrained only on `__is_tuple_of_iterator_references_v` + size, not element convertibility.

`is_constructible<tuple<int&,char&>, tuple_of_iterator_references<const int&,const char&>>` therefore wrongly evaluates to `true`.

## Fix

Constrain both entry points on per-element convertibility:

- thrust: additionally require `(is_convertible_v<Ts, Us> && ...)` on the conversion operator.
- libcu++: require each `_Tp` be constructible from the corresponding `get<>()` result of the incoming `tuple_of_iterator_references`.

Both are required — either one alone still leaves `is_constructible` reporting `true`.

## Test plan

Minimal trait check (compiler-independent), before -> after:

| conversion | before | after |
| --- | --- | --- |
| `tuple_of_iterator_references<const int&,const char&>` -> `tuple<int&,char&>` (ill-formed) | `true` | **`false`** |
| `...<int&,char&>` -> `tuple<int&,char&>` | `true` | `true` |
| `...<int&,char&>` -> `tuple<int,char>` | `true` | `true` |
| `...<const int&,const char&>` -> `tuple<int,char>` | `true` | `true` |

- No success-path change; valid ref->ref, ref->value, and const-ref->value conversions still work.
- `cudax/examples/stf/thrust_zip_iterator.cu` still builds (verified locally on GCC 14).
- I do not have a GCC 9 toolchain locally, so the GCC 9 / C++17 jobs need CI to confirm the build break is resolved.

This unblocks the cudax GCC 9 / C++17 jobs that are currently red across cudax PRs (e.g. #9248, #9249, #9265).