### PR TITLE
Support `cub::DeviceReduce` without initial value

### DIFF
--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -707,11 +707,16 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_passes(
 
 // select the accumulator type using an overload set, so __accumulator_t and invoke_result_t are not instantiated when
 // an overriding accumulator type is present. This is needed by CCCL.C.
-template <typename InputIteratorT, typename InitValueT, typename ReductionOpT, typename TransformOpT>
-_CCCL_HOST_DEVICE_API auto select_accum_t(use_default*)
-  -> ::cuda::std::__accumulator_t<ReductionOpT,
-                                  ::cuda::std::invoke_result_t<TransformOpT, ::cuda::std::iter_value_t<InputIteratorT>>,
-                                  InitValueT>;
+template <typename InputIteratorT,
+          typename InitValueT,
+          typename ReductionOpT,
+          typename TransformOpT,
+          typename InputT = ::cuda::std::invoke_result_t<TransformOpT, ::cuda::std::iter_value_t<InputIteratorT>>>
+_CCCL_HOST_DEVICE_API auto select_accum_t(use_default*) -> ::cuda::std::__accumulator_t<
+  ReductionOpT,
+  InputT,
+  ::cuda::std::conditional_t<::cuda::std::is_same_v<InitValueT, no_init_t>, InputT, InitValueT>>;
+
 template <typename InputIteratorT,
           typename InitValueT,
           typename ReductionOpT,

--- a/cub/cub/device/dispatch/kernels/kernel_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_reduce.cuh
@@ -49,20 +49,20 @@ struct no_init_t
 inline constexpr auto no_init = no_init_t{};
 
 template <class OutputIteratorT, class InitValueT>
-_CCCL_HOST_DEVICE _CCCL_FORCEINLINE void handle_empty_problem(OutputIteratorT d_out, InitValueT init)
+_CCCL_HOST_DEVICE _CCCL_FORCEINLINE void handle_empty_problem(OutputIteratorT&& d_out, InitValueT init)
 {
   *d_out = init;
 }
 
 template <class OutputIteratorT, class InitValueT>
 _CCCL_HOST_DEVICE _CCCL_FORCEINLINE void
-handle_empty_problem(OutputIteratorT d_out, empty_problem_init_t<InitValueT> empty_problem_init)
+handle_empty_problem(OutputIteratorT&& d_out, empty_problem_init_t<InitValueT> empty_problem_init)
 {
   *d_out = empty_problem_init.init;
 }
 
 template <class OutputIteratorT>
-_CCCL_HOST_DEVICE _CCCL_FORCEINLINE void handle_empty_problem(OutputIteratorT, no_init_t)
+_CCCL_HOST_DEVICE _CCCL_FORCEINLINE void handle_empty_problem(OutputIteratorT&&, no_init_t)
 {}
 
 /**

--- a/cub/cub/device/dispatch/kernels/kernel_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_reduce.cuh
@@ -26,12 +26,10 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail::reduce
 {
-/**
- * All cub::DeviceReduce::* algorithms are using the same implementation. Some of them, however,
- * should use initial value only for empty problems. If this struct is used as initial value with
- * one of the `DeviceReduce` algorithms, the `init` value wrapped by this struct will only be used
- * for empty problems; it will not be incorporated into the aggregate of non-empty problems.
- */
+//! All cub::DeviceReduce::* algorithms are using the same implementation. Some of them, however,
+//! should use the initial value only for empty problems. If this struct is used as initial value with
+//! one of the `DeviceReduce` algorithms, the `init` value wrapped by this struct will only be used
+//! for empty problems; it will not be incorporated into the aggregate of non-empty problems.
 template <class T>
 struct empty_problem_init_t
 {
@@ -43,18 +41,29 @@ struct empty_problem_init_t
   }
 };
 
-template <class InitValueT>
-_CCCL_HOST_DEVICE _CCCL_FORCEINLINE InitValueT unwrap_empty_problem_init(InitValueT init)
+struct no_init_t
+{};
+
+//! If this value is passed as initial value to a `DeviceReduce` algorithm, no initial value will be incorporated into
+//! the total aggregate.
+inline constexpr auto no_init = no_init_t{};
+
+template <class OutputIteratorT, class InitValueT>
+_CCCL_HOST_DEVICE _CCCL_FORCEINLINE void handle_empty_problem(OutputIteratorT d_out, InitValueT init)
 {
-  return init;
+  *d_out = init;
 }
 
-template <class InitValueT>
-_CCCL_HOST_DEVICE _CCCL_FORCEINLINE InitValueT
-unwrap_empty_problem_init(empty_problem_init_t<InitValueT> empty_problem_init)
+template <class OutputIteratorT, class InitValueT>
+_CCCL_HOST_DEVICE _CCCL_FORCEINLINE void
+handle_empty_problem(OutputIteratorT d_out, empty_problem_init_t<InitValueT> empty_problem_init)
 {
-  return empty_problem_init.init;
+  *d_out = empty_problem_init.init;
 }
+
+template <class OutputIteratorT>
+_CCCL_HOST_DEVICE _CCCL_FORCEINLINE void handle_empty_problem(OutputIteratorT, no_init_t)
+{}
 
 /**
  * @brief Applies initial value to the block aggregate and stores the result to the output iterator.
@@ -80,6 +89,13 @@ finalize_and_store_aggregate(OutputIteratorT d_out, ReductionOpT reduction_op, I
 template <class OutputIteratorT, class ReductionOpT, class InitValueT, class AccumT>
 _CCCL_HOST_DEVICE void finalize_and_store_aggregate(
   OutputIteratorT d_out, ReductionOpT, empty_problem_init_t<InitValueT>, AccumT block_aggregate)
+{
+  *d_out = block_aggregate;
+}
+
+template <class OutputIteratorT, class ReductionOpT, class AccumT>
+_CCCL_HOST_DEVICE void
+finalize_and_store_aggregate(OutputIteratorT d_out, ReductionOpT, no_init_t, AccumT block_aggregate)
 {
   *d_out = block_aggregate;
 }
@@ -260,7 +276,7 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(
   {
     if (threadIdx.x == 0)
     {
-      *d_out = detail::reduce::unwrap_empty_problem_init(init);
+      detail::reduce::handle_empty_problem(d_out, init);
     }
 
     return;
@@ -314,7 +330,7 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(int(
   {
     if (threadIdx.x == 0)
     {
-      *d_out = detail::reduce::unwrap_empty_problem_init(init);
+      detail::reduce::handle_empty_problem(d_out, init);
     }
 
     return;

--- a/cub/cub/device/dispatch/kernels/kernel_segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_segmented_reduce.cuh
@@ -198,7 +198,7 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(current_policy<PolicySelector>().large
         {
           if (lane_id == 0)
           {
-            *(d_out + global_segment_id) = reduce::unwrap_empty_problem_init(init);
+            reduce::handle_empty_problem(d_out + global_segment_id, init);
           }
           return;
         }
@@ -240,7 +240,7 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(current_policy<PolicySelector>().large
     {
       if (tid == 0)
       {
-        *(d_out + bid) = reduce::unwrap_empty_problem_init(init);
+        reduce::handle_empty_problem(d_out + bid, init);
       }
       return;
     }
@@ -399,7 +399,7 @@ __launch_bounds__(current_policy<PolicySelector>().large_reduce.threads_per_bloc
       {
         if (lane_id == 0)
         {
-          *(d_out + global_segment_id) = detail::reduce::unwrap_empty_problem_init(init);
+          detail::reduce::handle_empty_problem(d_out + global_segment_id, init);
         }
         return;
       }

--- a/cub/test/catch2_test_device_reduce.cu
+++ b/cub/test/catch2_test_device_reduce.cu
@@ -404,7 +404,7 @@ struct checking_reduce
 
 struct faulting_reduce
 {
-  _CCCL_HOST_DEVICE_API auto operator()(int a, int b) const -> int
+  _CCCL_HOST_DEVICE_API auto operator()(int, int) const -> int
   {
     CHECK(false);
     return 0;

--- a/cub/test/catch2_test_device_reduce.cu
+++ b/cub/test/catch2_test_device_reduce.cu
@@ -389,4 +389,42 @@ C2H_TEST("Device reduce works with a non copy assignable reduction operator", "[
     REQUIRE(0 == output_index[0]);
   }
 }
+
+struct checking_reduce
+{
+  static constexpr auto sentinel = 42;
+
+  _CCCL_HOST_DEVICE_API auto operator()(int a, int b) const -> int
+  {
+    CHECK(a == sentinel);
+    CHECK(b == sentinel);
+    return sentinel;
+  }
+};
+
+struct faulting_reduce
+{
+  _CCCL_HOST_DEVICE_API auto operator()(int a, int b) const -> int
+  {
+    CHECK(false);
+    return 0;
+  }
+};
+
+C2H_TEST("Device reduce works without initial value", "[reduce][device]")
+{
+  constexpr int num_items = 1000;
+  c2h::device_vector<int> input(num_items, checking_reduce::sentinel);
+
+  SECTION("for some elements")
+  {
+    c2h::device_vector<int> output(1);
+    device_reduce(input.data(), output.data(), num_items, checking_reduce{}, cub::detail::reduce::no_init);
+    CHECK(output[0] == checking_reduce::sentinel);
+  }
+  SECTION("for no elements")
+  {
+    device_reduce(input.data(), static_cast<int*>(nullptr), 0, faulting_reduce{}, cub::detail::reduce::no_init);
+  }
+}
 #endif // TEST_TYPES == 0


### PR DESCRIPTION
This allows calling `cub::DeviceReduce::Reduce(..., cub::detail::reduce::no_init)`.

@Jacobfaib please test if this works for your use cases. If it does, we should consider making the feature public.

Fixes: #9080