### PR TITLE
[libcu++] Implement `cuda::device::warp_broadcast`

### DIFF
--- a/docs/libcudacxx/extended_api/warp.rst
+++ b/docs/libcudacxx/extended_api/warp.rst
@@ -7,9 +7,10 @@ Warp
    :hidden:
    :maxdepth: 1
 
-   warp/warp_shuffle
-   warp/warp_match_all
    warp/lane_mask
+   warp/warp_broadcast
+   warp/warp_match_all
+   warp/warp_shuffle
 
 .. list-table::
    :widths: 25 45 30 30
@@ -49,3 +50,8 @@ Warp
      - Class to represent a mask of lanes in a warp
      - CCCL 3.1.0
      - CUDA 13.1
+
+   * - :ref:`warp_broadcast <libcudacxx-extended-api-warp-warp-broadcast>`
+     - Broadcast a value within a warp
+     - CCCL 3.5.0
+     - CUDA 13.5

--- a/docs/libcudacxx/extended_api/warp/warp_broadcast.rst
+++ b/docs/libcudacxx/extended_api/warp/warp_broadcast.rst
@@ -1,0 +1,97 @@
+.. _libcudacxx-extended-api-warp-warp-broadcast:
+
+``cuda::device::warp_broadcast``
+==============================================
+
+Defined in ``<cuda/warp>`` header.
+
+.. code:: cuda
+
+    namespace cuda::device {
+
+    template <typename T>
+    [[nodiscard]] __device__ T
+    warp_broadcast(const T& value,
+                   cuda::std::uint32_t src_lane,
+                   lane_mask lane_mask = lane_mask::all())
+
+    } // namespace cuda::device
+
+Broadcasts a ``value`` from ``src_lane`` to all lanes whose lane bit is set in ``lane_mask``.
+
+**Parameters**
+
+- ``value``: The value to broadcast.
+- ``src_lane``: The source lane.
+- ``lane_mask``: The lane mask of threads participating in the broadcast.
+
+**Return value**
+
+Returns ``T`` of the broadcasted value.
+
+**Constrains**
+
+- ``T`` must be trivially copyable.
+- ``T`` must be default constructible.
+
+**Preconditions**
+
+- ``src_lane`` must be less than ``32``.
+- ``src_lane``'s lane bit must be set in the ``lane_mask``.
+- The calling thread have its lane bit set in the ``lane_mask``.
+
+**Performance considerations**
+
+- The function calls the PTX instruction ``shfl.sync`` :math:`ceil\left(\frac{sizeof(value)}{4}\right)` times.
+
+**References**
+
+- `PTX shfl.sync instruction <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-shfl-sync>`_
+
+Example
+-------
+
+.. code:: cuda
+
+    #include <cuda/warp>
+    #include <cuda/ptx>
+
+    __global__ void warp_broadcast_kernel()
+    {
+        const auto lane = cuda::ptx::get_sreg_laneid();
+
+        // Set the secret value only on lane 0.
+        unsigned secret;
+        if (lane == 0)
+        {
+            secret = 0xDEAD'BEEF;
+        }
+
+        // Broadcast the secret and verify all threads got the same value.
+        secret = cuda::device::warp_broadcast(secret, 0);
+        assert(secret == 0xDEAD'BEEF);
+
+        // Set the odd_secret value only on lane 1.
+        unsigned odd_secret = 0;
+        if (lane == 1)
+        {
+            odd_secret = 0xA'BAD'CAFE;
+        }
+
+        // Broadcast the odd_secret only among odd lanes.
+        if (lane % 2 == 1)
+        {
+            odd_secret = cuda::device::warp_broadcast(odd_secret, 1, cuda::device::lane_mask{0xaaaa'aaaau});
+        }
+
+        // Verify that only the odd lanes got the result.
+        assert(odd_secret == ((lane % 2 == 1) ? 0xA'BAD'CAFE : 0));
+    }
+
+    int main()
+    {
+        warp_broadcast_kernel<<<1, 32>>>();
+        assert(cudaDeviceSynchronize() == cudaSuccess);
+    }
+
+`See it on Godbolt 🔗 <https://godbolt.org/z/cv6hY5nPK>`_

--- a/libcudacxx/include/cuda/__warp/warp_broadcast.h
+++ b/libcudacxx/include/cuda/__warp/warp_broadcast.h
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___WARP_WARP_BROADCAST_H
+#define _CUDA___WARP_WARP_BROADCAST_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_CUDA_COMPILATION()
+
+#  include <cuda/__warp/lane_mask.h>
+#  include <cuda/__warp/warp_shuffle.h>
+#  include <cuda/std/cstdint>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
+
+template <class _Tp>
+[[nodiscard]] _CCCL_DEVICE_API _Tp
+warp_broadcast(const _Tp& __value, ::cuda::std::uint32_t __src_lane, lane_mask __lane_mask = lane_mask::all())
+{
+  return ::cuda::device::warp_shuffle_idx(__value, static_cast<int>(__src_lane), __lane_mask.value()).data;
+}
+
+_CCCL_END_NAMESPACE_CUDA_DEVICE
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CCCL_CUDA_COMPILATION()
+
+#endif // _CUDA___WARP_WARP_BROADCAST_H

--- a/libcudacxx/include/cuda/warp
+++ b/libcudacxx/include/cuda/warp
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/__warp/lane_mask.h>
+#include <cuda/__warp/warp_broadcast.h>
 #include <cuda/__warp/warp_match_all.h>
 #include <cuda/__warp/warp_shuffle.h>
 

--- a/libcudacxx/test/libcudacxx/cuda/warp/warp_broadcast.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/warp/warp_broadcast.pass.cpp
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+// UNSUPPORTED: pre-sm-70
+
+// UNSUPPORTED: enable-tile
+// error: asm statement is unsupported in tile code
+
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
+#include <cuda/std/type_traits>
+#include <cuda/warp>
+
+#if _CCCL_HAS_NVFP16()
+#  include <cuda_fp16.h>
+#endif // _CCCL_HAS_NVFP16()
+
+#include "test_macros.h"
+
+template <class T>
+TEST_DEVICE_FUNC void test(T bcasted, T invalid, unsigned src_lane, cuda::device::lane_mask lane_mask)
+{
+  if ((lane_mask & cuda::device::lane_mask::this_lane()) == cuda::device::lane_mask::none())
+  {
+    return;
+  }
+
+  const auto lane = cuda::ptx::get_sreg_laneid();
+  auto result     = cuda::device::warp_broadcast((src_lane == lane) ? bcasted : invalid, src_lane, lane_mask);
+
+  static_assert(cuda::std::is_same_v<T, decltype(result)>);
+  assert(cuda::std::memcmp(&result, &bcasted, sizeof(T)) == 0);
+}
+
+template <class T>
+TEST_DEVICE_FUNC void test(T bcasted, T invalid, unsigned src_lane)
+{
+  const auto lane = cuda::ptx::get_sreg_laneid();
+  auto result     = cuda::device::warp_broadcast((src_lane == lane) ? bcasted : invalid, src_lane);
+
+  static_assert(cuda::std::is_same_v<T, decltype(result)>);
+  assert(cuda::std::memcmp(&result, &bcasted, sizeof(T)) == 0);
+
+  test(bcasted, invalid, src_lane, cuda::device::lane_mask::all());
+}
+
+template <class T>
+TEST_DEVICE_FUNC void test(T bcasted, T invalid)
+{
+  test(bcasted, invalid, 0u);
+  test(bcasted, invalid, 6u);
+  test(bcasted, invalid, 17u);
+  test(bcasted, invalid, 31u);
+
+  test(bcasted, invalid, 0u, cuda::device::lane_mask{0x1});
+  test(bcasted, invalid, 31u, cuda::device::lane_mask{0x8000'0001});
+  test(bcasted, invalid, 7u, cuda::device::lane_mask{0x8ff0'0ff1});
+}
+
+TEST_DEVICE_FUNC void test()
+{
+  test<uint8_t>(127, 23);
+  test<int16_t>(8098, -12309);
+  test<uint32_t>(0xffff'ffff, 0xa0a0'f2f2);
+  test<int64_t>(0x70f0'f0f0'f0f0, 0x0f0f'0f0f'0f0f'0f0f);
+#if _CCCL_HAS_INT128()
+  test(__uint128_t{0}, ~__uint128_t{0});
+#endif // _CCCL_HAS_INT128()
+
+  test(1.f, 2.f);
+  test(123908.0, -123098.0);
+#if _CCCL_HAS_NVFP16()
+  test(__float2half(1.f), __float2half(2.f));
+#endif // _CCCL_HAS_NVFP16()
+
+  test<char3>({0x1, 0x20, 0x50}, {0x26, 0x12, 0x15});
+  test<uint4>({0x1, 0x125, 0x1908, 0x4898}, {0x2098, 0x1290380, 0x0918, 0x2222});
+  test<float2>({1.f, 2.f}, {2.f, 1.f});
+}
+
+int main(int, char**)
+{
+  NV_IF_ELSE_TARGET(NV_IS_HOST, (cuda_thread_count = 32;), (test();))
+  return 0;
+}


### PR DESCRIPTION
When implementing cooperative reduce for groups, I realized we are missing a simple API to do value broadcast within a warp. This PR fixes that.