### PR TITLE
[thrust] Fix missing qualifiers for basic_common_reference

### DIFF
--- a/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
+++ b/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
@@ -212,6 +212,8 @@ struct tuple_element<Id, THRUST_NS_QUALIFIER::detail::tuple_of_iterator_referenc
     : tuple_element<Id, tuple<Ts...>>
 {};
 
+// tuple_of_iterator_references<_TTypes...> implicitly converts to tuple<_UTypes...> if is_compatible_tuple_v holds
+// So make sure that basic_common_reference in that case is the same as that of tuple<_UTypes...> with qualifiers
 template <class... _TTypes, class... _UTypes, template <class> class _TQual, template <class> class _UQual>
 struct basic_common_reference<
   THRUST_NS_QUALIFIER::detail::tuple_of_iterator_references<_TTypes...>,
@@ -219,9 +221,8 @@ struct basic_common_reference<
   _TQual,
   _UQual,
   enable_if_t<THRUST_NS_QUALIFIER::detail::is_compatible_tuple_v<tuple<_TTypes...>, tuple<_UTypes...>>>>
-{
-  using type _CCCL_NODEBUG_ALIAS = tuple<common_reference_t<_TQual<_UTypes>, _UQual<_UTypes>>...>;
-};
+    : basic_common_reference<tuple<_UTypes...>, tuple<_UTypes...>, _TQual, _UQual>
+{};
 
 template <class... _TTypes, class... _UTypes, template <class> class _TQual, template <class> class _UQual>
 struct basic_common_reference<
@@ -230,9 +231,8 @@ struct basic_common_reference<
   _TQual,
   _UQual,
   enable_if_t<THRUST_NS_QUALIFIER::detail::is_compatible_tuple_v<tuple<_TTypes...>, tuple<_UTypes...>>>>
-{
-  using type _CCCL_NODEBUG_ALIAS = tuple<common_reference_t<_TQual<_TTypes>, _UQual<_TTypes>>...>;
-};
+    : basic_common_reference<tuple<_TTypes...>, tuple<_TTypes...>, _TQual, _UQual>
+{};
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
+++ b/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
@@ -218,10 +218,9 @@ struct basic_common_reference<
   tuple<_UTypes...>,
   _TQual,
   _UQual,
-  enable_if_t<
-    THRUST_NS_QUALIFIER::detail::is_compatible_tuple_v<::cuda::std::tuple<_TTypes...>, ::cuda::std::tuple<_UTypes...>>>>
+  enable_if_t<THRUST_NS_QUALIFIER::detail::is_compatible_tuple_v<tuple<_TTypes...>, tuple<_UTypes...>>>>
 {
-  using type _CCCL_NODEBUG_ALIAS = tuple<_UQual<_UTypes>...>;
+  using type _CCCL_NODEBUG_ALIAS = tuple<common_reference_t<_TQual<_UTypes>, _UQual<_UTypes>>...>;
 };
 
 template <class... _TTypes, class... _UTypes, template <class> class _TQual, template <class> class _UQual>
@@ -230,10 +229,9 @@ struct basic_common_reference<
   THRUST_NS_QUALIFIER::detail::tuple_of_iterator_references<_UTypes...>,
   _TQual,
   _UQual,
-  enable_if_t<
-    THRUST_NS_QUALIFIER::detail::is_compatible_tuple_v<::cuda::std::tuple<_TTypes...>, ::cuda::std::tuple<_UTypes...>>>>
+  enable_if_t<THRUST_NS_QUALIFIER::detail::is_compatible_tuple_v<tuple<_TTypes...>, tuple<_UTypes...>>>>
 {
-  using type _CCCL_NODEBUG_ALIAS = tuple<_TQual<_TTypes>...>;
+  using type _CCCL_NODEBUG_ALIAS = tuple<common_reference_t<_TQual<_TTypes>, _UQual<_TTypes>>...>;
 };
 
 _CCCL_END_NAMESPACE_CUDA_STD


### PR DESCRIPTION
If a tuple is compatible with `tuple_of_iterator_references` we want to treat it as if it had the same types as the `tuple`

However, we need to also consider the qualifiers
