### PR TITLE
cuda.cccl: Fix header discovery under pip build isolation

### DIFF
--- a/python/cuda_cccl/cuda/cccl/headers/include_paths.py
+++ b/python/cuda_cccl/cuda/cccl/headers/include_paths.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import site
 import sys
 from dataclasses import dataclass
 from functools import lru_cache
@@ -11,6 +12,35 @@ from typing import Optional
 
 # type: ignore[import-not-found]
 from cuda.pathfinder import find_nvidia_header_directory
+
+
+def iter_site_roots():
+    """Yield unique candidate roots under which an installed ``cuda`` package
+    may live.
+
+    Scans ``sys.path`` plus the interpreter's site directories. The site
+    directories are required for pip build isolation, which strips the venv
+    site-packages from ``sys.path`` while cuda-cccl remains installed there
+    (``sys.prefix`` still points at the venv, so ``site.getsitepackages()``
+    recovers it). ``getsitepackages`` is missing in some virtualenv setups, so
+    it is probed defensively.
+    """
+    try:
+        site_dirs = site.getsitepackages()
+    except AttributeError:
+        site_dirs = []
+    try:
+        site_dirs = [*site_dirs, site.getusersitepackages()]
+    except AttributeError:
+        pass
+
+    seen: set[Path] = set()
+    for sp in [*sys.path, *site_dirs]:
+        root = Path(sp).resolve()
+        if root in seen:
+            continue
+        seen.add(root)
+        yield root
 
 
 @dataclass
@@ -36,8 +66,8 @@ def get_include_paths(probe_file: str = "cub/version.cuh") -> IncludePaths:
 
     probe_file_path = Path(probe_file)
     if not (cccl_incl / probe_file_path).exists():
-        for sp in sys.path:
-            cccl_incl = Path(sp).resolve() / "cuda" / "cccl" / "headers" / "include"
+        for root in iter_site_roots():
+            cccl_incl = root / "cuda" / "cccl" / "headers" / "include"
             if (cccl_incl / probe_file_path).exists():
                 break
         else:

--- a/python/cuda_cccl/cuda/cccl/headers/include_paths.py
+++ b/python/cuda_cccl/cuda/cccl/headers/include_paths.py
@@ -36,6 +36,10 @@ def iter_site_roots():
 
     seen: set[Path] = set()
     for sp in [*sys.path, *site_dirs]:
+        # getsitepackages()/getusersitepackages() can return None when user
+        # site is disabled (e.g. ``python -s`` / ``PYTHONNOUSERSITE``).
+        if sp is None:
+            continue
         root = Path(sp).resolve()
         if root in seen:
             continue

--- a/python/cuda_cccl/tests/headers/test_include_paths_build_isolation.py
+++ b/python/cuda_cccl/tests/headers/test_include_paths_build_isolation.py
@@ -59,6 +59,23 @@ def test_iter_site_roots_is_deduplicated(monkeypatch):
     assert roots.count(Path(shared).resolve()) == 1
 
 
+def test_iter_site_roots_tolerates_none_user_site(monkeypatch):
+    """``getusersitepackages()`` can return ``None`` when user site is disabled
+    (``python -s`` / ``PYTHONNOUSERSITE``); it must not raise."""
+    monkeypatch.setattr("cuda.cccl.headers.include_paths.sys.path", ["/some/path"])
+    monkeypatch.setattr(
+        "cuda.cccl.headers.include_paths.site.getsitepackages", lambda: [None]
+    )
+    monkeypatch.setattr(
+        "cuda.cccl.headers.include_paths.site.getusersitepackages", lambda: None
+    )
+
+    roots = list(iter_site_roots())
+
+    assert Path("/some/path").resolve() in roots
+    assert None not in roots
+
+
 def test_iter_site_roots_tolerates_missing_getsitepackages(monkeypatch):
     """Some virtualenv setups lack ``getsitepackages``; it must be probed
     defensively rather than raising."""

--- a/python/cuda_cccl/tests/headers/test_include_paths_build_isolation.py
+++ b/python/cuda_cccl/tests/headers/test_include_paths_build_isolation.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Regression tests for header discovery under pip build isolation.
+
+Pip build isolation strips the active venv's ``site-packages`` from
+``sys.path`` even though ``cuda-cccl`` is still installed there. A discovery
+fallback that scans only ``sys.path`` therefore fails to find the shipped
+headers. ``iter_site_roots()`` must also consult the interpreter site
+directories (``site.getsitepackages()`` / ``site.getusersitepackages()``) so
+discovery still succeeds.
+"""
+
+from pathlib import Path
+
+from cuda.cccl.headers.include_paths import iter_site_roots
+
+
+def test_iter_site_roots_includes_site_packages_when_absent_from_sys_path(
+    monkeypatch,
+):
+    """The venv site-packages must be discoverable via site dirs even when it
+    has been stripped from ``sys.path`` (the pip build-isolation scenario)."""
+    isolated_sys_path = ["/tmp/pip-build-env/overlay/lib/python3.x/site-packages"]
+    venv_site_packages = "/venv/lib/python3.x/site-packages"
+
+    monkeypatch.setattr("cuda.cccl.headers.include_paths.sys.path", isolated_sys_path)
+    monkeypatch.setattr(
+        "cuda.cccl.headers.include_paths.site.getsitepackages",
+        lambda: [venv_site_packages],
+    )
+    monkeypatch.setattr(
+        "cuda.cccl.headers.include_paths.site.getusersitepackages",
+        lambda: "/home/user/.local/lib/python3.x/site-packages",
+    )
+
+    roots = list(iter_site_roots())
+
+    assert Path(venv_site_packages).resolve() in roots
+    # The sys.path entries are still scanned too.
+    assert Path(isolated_sys_path[0]).resolve() in roots
+
+
+def test_iter_site_roots_is_deduplicated(monkeypatch):
+    """Roots present in both ``sys.path`` and the site dirs are yielded once."""
+    shared = "/venv/lib/python3.x/site-packages"
+
+    monkeypatch.setattr("cuda.cccl.headers.include_paths.sys.path", [shared])
+    monkeypatch.setattr(
+        "cuda.cccl.headers.include_paths.site.getsitepackages", lambda: [shared]
+    )
+    monkeypatch.setattr(
+        "cuda.cccl.headers.include_paths.site.getusersitepackages", lambda: shared
+    )
+
+    roots = list(iter_site_roots())
+
+    assert roots.count(Path(shared).resolve()) == 1
+
+
+def test_iter_site_roots_tolerates_missing_getsitepackages(monkeypatch):
+    """Some virtualenv setups lack ``getsitepackages``; it must be probed
+    defensively rather than raising."""
+
+    def _raise():
+        raise AttributeError("getsitepackages is unavailable")
+
+    monkeypatch.setattr("cuda.cccl.headers.include_paths.sys.path", ["/some/path"])
+    monkeypatch.setattr("cuda.cccl.headers.include_paths.site.getsitepackages", _raise)
+    monkeypatch.setattr(
+        "cuda.cccl.headers.include_paths.site.getusersitepackages",
+        lambda: "/home/user/.local/lib/python3.x/site-packages",
+    )
+
+    roots = list(iter_site_roots())
+
+    assert Path("/some/path").resolve() in roots


### PR DESCRIPTION
## Summary

`cuda.cccl.headers.get_include_paths()` falls back to scanning candidate roots when the primary `importlib.resources` lookup does not contain the probe header. That fallback scanned only `sys.path`.

Under **pip build isolation**, pip strips the active venv's `site-packages` from `sys.path` even though `cuda-cccl` is still installed there, so discovery failed with `Unable to locate CCCL include directory.`. `sys.prefix` still points at the venv, so the directory is recoverable via `site.getsitepackages()`.

This centralizes the candidate-root scan in a new `iter_site_roots()` helper that also consults the interpreter site directories (guarding `getsitepackages`/`getusersitepackages` for virtualenv setups that lack them, and de-duplicating roots).

This is a generic fix in the shared header-discovery module, so it benefits **every** consumer of `get_include_paths()` — `cuda.compute` (`_cpp_compile.py`, `_cccl_interop.py`) and `cuda.coop._experimental` (`_nvrtc.py`) — not just one package. It was originally found and fixed while packaging `cuda.stf`, but is intentionally extracted here as a standalone, easy-to-review change.

## Changes

- Add `iter_site_roots()` scanning `sys.path` + `site.getsitepackages()` / `site.getusersitepackages()`, with defensive guards and de-duplication.
- Use it in the `get_include_paths()` fallback instead of a `sys.path`-only scan.
- Add regression tests for the build-isolation scenario, root de-duplication, and the missing-`getsitepackages` fallback.

## Test plan

- [x] `pytest python/cuda_cccl/tests/headers/test_include_paths_build_isolation.py` (3 passed)
- [x] `pre-commit run --files ...` (ruff, ruff-format, mypy, codespell all pass)
- [ ] CI on `cuda.cccl` / `cuda.compute` / `cuda.coop` Python jobs