### PR TITLE
Better asserts for warp primitives without temp storage

### DIFF
--- a/cub/cub/detail/warpspeed/look_ahead.cuh
+++ b/cub/cub/detail/warpspeed/look_ahead.cuh
@@ -189,8 +189,8 @@ template <int numTileStatesPerThread, typename AccumT, typename ScanOpT>
   AccumT aggrExclusiveCtaCur = aggrExclusiveCtaPrev;
 
   using warp_reduce_t = WarpReduce<AccumT>;
-  static_assert(sizeof(typename warp_reduce_t::TempStorage) <= 4,
-                "WarpReduce with non-trivial temporary storage is not supported yet in this kernel.");
+  static_assert(::cuda::std::is_same_v<typename warp_reduce_t::TempStorage, Uninitialized<NullType>>,
+                "WarpReduce for a full warp must not require temporary storage");
   [[maybe_unused]] typename warp_reduce_t::TempStorage temp_storage;
 
   using warp_reduce_or_t = WarpReduce<::cuda::std::uint32_t>;

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -136,11 +136,8 @@ template <typename Tp, typename ScanOpT>
 _CCCL_DEVICE_API Tp warpReduce(const Tp input, ScanOpT& scan_op)
 {
   using warp_reduce_t = WarpReduce<Tp>;
-
-  // TODO (elstehle): Do proper temporary storage allocation in case WarpReduce may rely on it
-  static_assert(sizeof(typename warp_reduce_t::TempStorage) <= 4,
-                "WarpReduce with non-trivial temporary storage is not supported yet in this kernel.");
-
+  static_assert(::cuda::std::is_same_v<typename warp_reduce_t::TempStorage, Uninitialized<NullType>>,
+                "WarpReduce for a full warp must not require temporary storage");
   typename warp_reduce_t::TempStorage temp_storage;
   return warp_reduce_t{temp_storage}.Reduce(input, scan_op);
 }
@@ -149,11 +146,8 @@ template <typename Tp, typename ScanOpT>
 _CCCL_DEVICE_API Tp warpReducePartial(const Tp input, ScanOpT& scan_op, const int num_items)
 {
   using warp_reduce_t = WarpReduce<Tp>;
-
-  // TODO (elstehle): Do proper temporary storage allocation in case WarpReduce may rely on it
-  static_assert(sizeof(typename warp_reduce_t::TempStorage) <= 4,
-                "WarpReduce with non-trivial temporary storage is not supported yet in this kernel.");
-
+  static_assert(::cuda::std::is_same_v<typename warp_reduce_t::TempStorage, Uninitialized<NullType>>,
+                "WarpReduce for a full warp must not require temporary storage");
   typename warp_reduce_t::TempStorage temp_storage;
   return warp_reduce_t{temp_storage}.Reduce(input, scan_op, num_items);
 }
@@ -162,16 +156,11 @@ template <typename Tp, typename ScanOpT>
 _CCCL_DEVICE_API Tp warpScanExclusive(const Tp regInput, ScanOpT& scan_op)
 {
   using warp_scan_t = WarpScan<Tp>;
-
-  // TODO (elstehle): Do proper temporary storage allocation in case WarpReduce may rely on it
-  static_assert(sizeof(typename warp_scan_t::TempStorage) <= 4,
-                "WarpScan with non-trivial temporary storage is not supported yet in this kernel.");
-
-  Tp result;
+  static_assert(::cuda::std::is_same_v<typename warp_scan_t::TempStorage, Uninitialized<NullType>>,
+                "WarpScan for a full warp must not require temporary storage");
   typename warp_scan_t::TempStorage temp_storage;
-
+  Tp result;
   warp_scan_t{temp_storage}.ExclusiveScan(regInput, result, scan_op);
-
   return result;
 }
 
@@ -191,11 +180,8 @@ warpScanExclusivePartial(Tp regInput, ScanOpT& scan_op, const int num_items, boo
   else
   {
     using warp_scan_t = WarpScan<Tp>;
-
-    // TODO (elstehle): Do proper temporary storage allocation in case WarpReduce may rely on it
-    static_assert(sizeof(typename warp_scan_t::TempStorage) <= 4,
-                  "WarpScan with non-trivial temporary storage is not supported yet in this kernel.");
-
+    static_assert(::cuda::std::is_same_v<typename warp_scan_t::TempStorage, Uninitialized<NullType>>,
+                  "WarpScan for a full warp must not require temporary storage");
     Tp result;
     typename warp_scan_t::TempStorage temp_storage;
     warp_scan_t{temp_storage}.ExclusiveScanPartial(regInput, result, scan_op, num_items);

--- a/cub/cub/warp/specializations/warp_scan_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_scan_shfl.cuh
@@ -73,8 +73,7 @@ struct WarpScanShfl
   };
 
   /// Shared memory storage layout type
-  struct TempStorage
-  {};
+  using TempStorage = NullType;
 
   //---------------------------------------------------------------------
   // Thread fields

--- a/cub/cub/warp/warp_reduce.cuh
+++ b/cub/cub/warp/warp_reduce.cuh
@@ -155,8 +155,7 @@ private:
 
 public:
   /// \smemstorage{WarpReduce}
-  struct TempStorage : Uninitialized<_TempStorage>
-  {};
+  using TempStorage = Uninitialized<_TempStorage>;
 
   //! @name Collective constructors
   //! @{

--- a/cub/cub/warp/warp_scan.cuh
+++ b/cub/cub/warp/warp_scan.cuh
@@ -175,8 +175,7 @@ private:
 
 public:
   /// @smemstorage{WarpScan}
-  struct TempStorage : Uninitialized<_TempStorage>
-  {};
+  using TempStorage = Uninitialized<_TempStorage>;
 
   //! @name Collective constructors
   //! @{


### PR DESCRIPTION
Let's use a better assertion that the warp primitives used in warpspeed scan don't require any temporary storage.