### PR TITLE
cudax/stf: cuda_try migration — graph misc (PR6)

### DIFF
--- a/cudax/include/cuda/experimental/__stf/graph/interfaces/slice.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/interfaces/slice.cuh
@@ -262,10 +262,7 @@ public:
         .kind     = kind};
     }
 
-    cudaGraphNode_t result;
-    cuda_safe_call(cudaGraphAddMemcpyNode(&result, graph, input_nodes, input_cnt, &cpy_params));
-
-    return result;
+    return cuda_try<cudaGraphAddMemcpyNode>(graph, input_nodes, input_cnt, &cpy_params);
   }
 
   /// @brief Implementation of interface primitive

--- a/cudax/include/cuda/experimental/__stf/graph/interfaces/slice.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/interfaces/slice.cuh
@@ -27,6 +27,7 @@
 
 #include <cuda/experimental/__stf/graph/graph_data_interface.cuh>
 #include <cuda/experimental/__stf/localization/composite_slice.cuh>
+#include <cuda/experimental/__stf/utility/cuda_safe_call.cuh>
 
 namespace cuda::experimental::stf
 {

--- a/cudax/include/cuda/experimental/__stf/graph/interfaces/void_interface.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/interfaces/void_interface.cuh
@@ -76,9 +76,7 @@ public:
     const cudaGraphNode_t* input_nodes,
     size_t input_cnt) override
   {
-    cudaGraphNode_t dummy;
-    cuda_safe_call(cudaGraphAddEmptyNode(&dummy, graph, input_nodes, input_cnt));
-    return dummy;
+    return cuda_try<cudaGraphAddEmptyNode>(graph, input_nodes, input_cnt);
   }
 
   bool pin_host_memory(instance_id_t) override

--- a/cudax/include/cuda/experimental/__stf/graph/interfaces/void_interface.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/interfaces/void_interface.cuh
@@ -28,6 +28,7 @@
 
 #include <cuda/experimental/__stf/graph/graph_data_interface.cuh>
 #include <cuda/experimental/__stf/internal/void_interface.cuh>
+#include <cuda/experimental/__stf/utility/cuda_safe_call.cuh>
 
 namespace cuda::experimental::stf
 {

--- a/cudax/include/cuda/experimental/__stf/graph/internal/event_types.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/internal/event_types.cuh
@@ -22,6 +22,7 @@
 
 #include <cuda/experimental/__stf/internal/async_prereq.cuh>
 #include <cuda/experimental/__stf/internal/backend_ctx.cuh>
+#include <cuda/experimental/__stf/utility/cuda_safe_call.cuh>
 
 #include <vector>
 

--- a/cudax/include/cuda/experimental/__stf/graph/internal/event_types.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/internal/event_types.cuh
@@ -87,7 +87,7 @@ protected:
     // graph events by making them depend on a single node instead
     if (events.size() > 16)
     {
-      cudaGraphNode_t n;
+      cudaGraphNode_t n = nullptr;
 
       ::std::vector<cudaGraphNode_t> nodes;
 

--- a/cudax/include/cuda/experimental/__stf/graph/internal/event_types.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/internal/event_types.cuh
@@ -123,7 +123,7 @@ protected:
 
         // Create a new empty graph node which depends on the previous ones,
         // empty the list of events and replace it with this single "empty" event
-        cuda_safe_call(cudaGraphAddEmptyNode(&n, bctx_graph, nodes.data(), nodes.size()));
+        n = cuda_try<cudaGraphAddEmptyNode>(bctx_graph, nodes.data(), nodes.size());
       }
 
       events.clear();


### PR DESCRIPTION
## Summary

- Migrate the three leaf `graph/` headers from `cuda_safe_call` to templated `cuda_try<>`:
  - `graph/internal/event_types.cuh` — `cudaGraphAddEmptyNode`
  - `graph/interfaces/void_interface.cuh` — `cudaGraphAddEmptyNode`
  - `graph/interfaces/slice.cuh` — `cudaGraphAddMemcpyNode`
- Part of the staged STF `cuda_safe_call` → `cuda_try` migration (PR6 of 11).

## Test plan

- [x] Local build: `ninja -j 12 -C build/cudax-cpp20 cudax.test.stf.graph.explicit_graph cudax.test.stf.interface.graph_use_device_data`
- [ ] CI