### PR TITLE
Internal `__has_no_floating_point_v`

### DIFF
--- a/libcudacxx/include/cuda/__type_traits/has_no_floating_point.h
+++ b/libcudacxx/include/cuda/__type_traits/has_no_floating_point.h
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDA__TYPE_TRAITS_HAS_NO_FLOATING_POINT_H
+#define __CUDA__TYPE_TRAITS_HAS_NO_FLOATING_POINT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__fwd/complex.h>
+#include <cuda/__type_traits/is_floating_point.h>
+#include <cuda/__type_traits/is_vector_type.h>
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__fwd/array.h>
+#include <cuda/std/__fwd/complex.h>
+#include <cuda/std/__fwd/pair.h>
+#include <cuda/std/__fwd/tuple.h>
+#include <cuda/std/__type_traits/aggregate_members_all_of.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/integral_constant.h>
+#include <cuda/std/__type_traits/is_aggregate.h>
+#include <cuda/std/__type_traits/remove_cv.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+template <typename _Tp, typename = void>
+inline constexpr bool __has_no_floating_point_aggregate_v = true;
+
+template <typename _Tp>
+inline constexpr bool __has_no_floating_point_cv_v =
+  !::cuda::is_floating_point_v<_Tp>
+#if _CCCL_HAS_CTK()
+  && !is_extended_fp_vector_type_v<_Tp>
+#endif // _CCCL_HAS_CTK()
+  && __has_no_floating_point_aggregate_v<_Tp>;
+
+template <typename _Tp>
+inline constexpr bool __has_no_floating_point_v = __has_no_floating_point_cv_v<::cuda::std::remove_cv_t<_Tp>>;
+
+//----------------------------------------------------------------------------------------------------------------------
+// specializations for array, pair, tuple, and complex types
+
+template <typename _Tp>
+inline constexpr bool __has_no_floating_point_cv_v<_Tp[]> = __has_no_floating_point_v<_Tp>;
+
+template <typename _Tp, ::cuda::std::size_t _Size>
+inline constexpr bool __has_no_floating_point_cv_v<_Tp[_Size]> = __has_no_floating_point_v<_Tp>;
+
+template <typename _Tp, ::cuda::std::size_t _Size>
+inline constexpr bool __has_no_floating_point_cv_v<::cuda::std::array<_Tp, _Size>> = __has_no_floating_point_v<_Tp>;
+
+template <typename _T1, typename _T2>
+inline constexpr bool __has_no_floating_point_cv_v<::cuda::std::pair<_T1, _T2>> =
+  __has_no_floating_point_v<_T1> && __has_no_floating_point_v<_T2>;
+
+template <typename... _Ts>
+inline constexpr bool __has_no_floating_point_cv_v<::cuda::std::tuple<_Ts...>> =
+  (__has_no_floating_point_v<_Ts> && ...);
+
+template <typename _Tp>
+inline constexpr bool __has_no_floating_point_cv_v<::cuda::std::complex<_Tp>> = __has_no_floating_point_v<_Tp>;
+
+template <typename _Tp>
+inline constexpr bool __has_no_floating_point_cv_v<complex<_Tp>> = __has_no_floating_point_v<_Tp>;
+
+//----------------------------------------------------------------------------------------------------------------------
+// if all the previous conditions fail, check if the type is an aggregate and none of its members are floating-point
+
+template <typename _Tp>
+using __has_no_floating_point_callable = ::cuda::std::bool_constant<__has_no_floating_point_v<_Tp>>;
+
+template <typename _Tp>
+inline constexpr bool
+  __has_no_floating_point_aggregate_v<_Tp, ::cuda::std::enable_if_t<::cuda::std::is_aggregate_v<_Tp>>> =
+    ::cuda::std::__aggregate_all_of_v<__has_no_floating_point_callable, _Tp>;
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // __CUDA__TYPE_TRAITS_HAS_NO_FLOATING_POINT_H

--- a/libcudacxx/test/libcudacxx/cuda/type_traits/has_no_floating_point.basic_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/type_traits/has_no_floating_point.basic_types.pass.cpp
@@ -1,0 +1,83 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/__type_traits/has_no_floating_point.h>
+
+#include "cuda_fp_types.h"
+#include "test_macros.h"
+
+template <class T>
+TEST_FUNC void test_has_no_floating_point()
+{
+  static_assert(cuda::__has_no_floating_point_v<T>);
+  static_assert(cuda::__has_no_floating_point_v<const T>);
+  static_assert(cuda::__has_no_floating_point_v<volatile T>);
+  static_assert(cuda::__has_no_floating_point_v<const volatile T>);
+}
+
+template <class T>
+TEST_FUNC void test_has_floating_point()
+{
+  static_assert(!cuda::__has_no_floating_point_v<T>);
+  static_assert(!cuda::__has_no_floating_point_v<const T>);
+  static_assert(!cuda::__has_no_floating_point_v<volatile T>);
+  static_assert(!cuda::__has_no_floating_point_v<const volatile T>);
+}
+
+TEST_FUNC void test_basic_types()
+{
+  test_has_no_floating_point<bool>();
+  test_has_no_floating_point<int>();
+  test_has_no_floating_point<unsigned>();
+  test_has_no_floating_point<char>();
+  test_has_no_floating_point<unsigned char>();
+  test_has_no_floating_point<short>();
+  test_has_no_floating_point<long long>();
+
+  test_has_floating_point<float>();
+  test_has_floating_point<double>();
+  NV_IF_TARGET(NV_IS_HOST, (test_has_floating_point<long double>();))
+
+  // arrays
+  static_assert(cuda::__has_no_floating_point_v<int[]>);
+  static_assert(cuda::__has_no_floating_point_v<const int[]>);
+  static_assert(cuda::__has_no_floating_point_v<int[4]>);
+  static_assert(cuda::__has_no_floating_point_v<const int[4]>);
+  static_assert(!cuda::__has_no_floating_point_v<float[]>);
+  static_assert(!cuda::__has_no_floating_point_v<const float[]>);
+  static_assert(!cuda::__has_no_floating_point_v<float[4]>);
+  static_assert(!cuda::__has_no_floating_point_v<const float[4]>);
+
+#if _CCCL_HAS_CTK()
+  test_has_no_floating_point<int4>();
+  test_has_no_floating_point<uint2>();
+  test_has_floating_point<float2>();
+  test_has_floating_point<double2>();
+#endif // _CCCL_HAS_CTK()
+
+  // extended floating-point scalar and vector types
+#if _CCCL_HAS_NVFP16()
+  test_has_floating_point<__half>();
+  test_has_floating_point<__half2>();
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
+  test_has_floating_point<__nv_bfloat16>();
+  test_has_floating_point<__nv_bfloat162>();
+#endif // _CCCL_HAS_NVBF16()
+#if _CCCL_HAS_NVFP8_E4M3()
+  test_has_floating_point<__nv_fp8_e4m3>();
+  test_has_floating_point<__nv_fp8x2_e4m3>();
+#endif // _CCCL_HAS_NVFP8_E4M3()
+}
+
+int main(int, char**)
+{
+  test_basic_types();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/type_traits/has_no_floating_point.composite_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/type_traits/has_no_floating_point.composite_types.pass.cpp
@@ -1,0 +1,140 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/__complex_>
+#include <cuda/__type_traits/has_no_floating_point.h>
+#include <cuda/std/array>
+#include <cuda/std/complex>
+#include <cuda/std/tuple>
+#include <cuda/std/utility>
+
+#include "cuda_fp_types.h"
+#include "test_macros.h"
+
+template <class T>
+TEST_FUNC void test_has_no_floating_point()
+{
+  static_assert(cuda::__has_no_floating_point_v<T>);
+  static_assert(cuda::__has_no_floating_point_v<const T>);
+  static_assert(cuda::__has_no_floating_point_v<volatile T>);
+  static_assert(cuda::__has_no_floating_point_v<const volatile T>);
+}
+
+template <class T>
+TEST_FUNC void test_has_floating_point()
+{
+  static_assert(!cuda::__has_no_floating_point_v<T>);
+  static_assert(!cuda::__has_no_floating_point_v<const T>);
+  static_assert(!cuda::__has_no_floating_point_v<volatile T>);
+  static_assert(!cuda::__has_no_floating_point_v<const volatile T>);
+}
+
+struct WithNoPadding
+{
+  int x;
+  int y;
+};
+
+struct WithPadding
+{
+  int x;
+  char y;
+};
+
+struct WithFloatingPoint
+{
+  int x;
+  float y;
+};
+
+struct NestedWithoutFloatingPoint
+{
+  WithPadding x;
+  cuda::std::array<int, 4> y;
+};
+
+struct UserFloatingPoint
+{};
+
+template <>
+constexpr bool cuda::is_floating_point_v<UserFloatingPoint> = true;
+
+struct ContainsUserFloatingPoint
+{
+  UserFloatingPoint value;
+};
+
+TEST_FUNC void test_composite_types()
+{
+  // padding does not affect whether a type contains floating-point members
+  test_has_no_floating_point<WithNoPadding>();
+  test_has_no_floating_point<WithPadding>();
+  test_has_no_floating_point<NestedWithoutFloatingPoint>();
+
+  test_has_floating_point<WithFloatingPoint>();
+
+  // cuda::std::array, pair, and tuple compositions
+  test_has_no_floating_point<cuda::std::array<int, 4>>();
+  test_has_no_floating_point<cuda::std::pair<int, char>>();
+  test_has_no_floating_point<cuda::std::tuple<int, unsigned, char>>();
+  test_has_no_floating_point<cuda::std::tuple<>>();
+
+  test_has_floating_point<cuda::std::array<float, 4>>();
+  test_has_floating_point<cuda::std::pair<int, float>>();
+  test_has_floating_point<cuda::std::tuple<int, double, char>>();
+  test_has_floating_point<cuda::std::tuple<cuda::std::array<float, 4>, int>>();
+
+  test_has_floating_point<cuda::std::complex<float>>();
+  test_has_floating_point<cuda::complex<double>>();
+
+  // cuda::is_floating_point_v user specializations are respected
+  test_has_floating_point<UserFloatingPoint>();
+  test_has_floating_point<ContainsUserFloatingPoint>();
+}
+
+#if _CCCL_HAS_NVFP16()
+
+struct NoPaddingExtendedFloatingPoint
+{
+  unsigned short x;
+  __half y;
+};
+
+#endif // _CCCL_HAS_NVFP16()
+
+TEST_FUNC void test_extended_floating_point_types()
+{
+#if _CCCL_HAS_NVFP16()
+  test_has_floating_point<__half[4]>();
+  test_has_floating_point<cuda::std::array<__half, 4>>();
+  test_has_floating_point<cuda::std::pair<__half, int>>();
+  test_has_floating_point<cuda::std::tuple<__half, float>>();
+  test_has_floating_point<cuda::std::array<cuda::std::pair<__half, int>, 2>>();
+  test_has_floating_point<cuda::std::tuple<cuda::std::array<__half, 4>, int>>();
+  test_has_floating_point<NoPaddingExtendedFloatingPoint>();
+#endif // _CCCL_HAS_NVFP16()
+
+#if _CCCL_HAS_NVBF16()
+  test_has_floating_point<cuda::std::array<__nv_bfloat16, 2>>();
+  test_has_floating_point<cuda::std::pair<__nv_bfloat16, int>>();
+#endif // _CCCL_HAS_NVBF16()
+
+#if _CCCL_HAS_CTK()
+  test_has_no_floating_point<int2>();
+  test_has_floating_point<float2>();
+  test_has_floating_point<cuda::std::array<double2, 2>>();
+#endif // _CCCL_HAS_CTK()
+}
+
+int main(int, char**)
+{
+  test_composite_types();
+  test_extended_floating_point_types();
+  return 0;
+}


### PR DESCRIPTION
## Description

Related to `warp_match_all`/ `warp_match_any` (https://github.com/NVIDIA/cccl/pull/9243), we need a trait to check if a data type is bitwise comparable, but excluding the padding issue. For this reason, we cannot use `has_unique_representation`.

The PR introduces an _internal_ trait to check if a data type is or contains an (extended/vectorized) floating-point type, similarly to `is_bitwise_comparable`.

- Open to modify the name of the traits, currently `__has_no_floating_point_v`.
- I would not expose the internal trait in `<cuda/type_trait>`