### PR TITLE
Allow public tuning of `cub::DeviceSelect` (without `UniqueByKey`) and `cub::DevicePartition` (without three-way)

### DIFF
--- a/cub/benchmarks/bench/partition/flagged.cu
+++ b/cub/benchmarks/bench/partition/flagged.cu
@@ -35,8 +35,7 @@
 template <typename InputT>
 struct policy_selector
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::select::select_if_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::SelectPolicy
   {
     return {TUNE_THREADS_PER_BLOCK,
             TUNE_ITEMS_PER_THREAD,

--- a/cub/benchmarks/bench/partition/flagged.cu
+++ b/cub/benchmarks/bench/partition/flagged.cu
@@ -35,7 +35,7 @@
 template <typename InputT>
 struct policy_selector
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::SelectPolicy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::PartitionPolicy
   {
     return {TUNE_THREADS_PER_BLOCK,
             TUNE_ITEMS_PER_THREAD,

--- a/cub/benchmarks/bench/partition/if.cu
+++ b/cub/benchmarks/bench/partition/if.cu
@@ -35,8 +35,7 @@
 template <typename InputT>
 struct policy_selector
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::select::select_if_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::SelectPolicy
   {
     return {TUNE_THREADS_PER_BLOCK,
             TUNE_ITEMS_PER_THREAD,

--- a/cub/benchmarks/bench/partition/if.cu
+++ b/cub/benchmarks/bench/partition/if.cu
@@ -35,7 +35,7 @@
 template <typename InputT>
 struct policy_selector
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::SelectPolicy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::PartitionPolicy
   {
     return {TUNE_THREADS_PER_BLOCK,
             TUNE_ITEMS_PER_THREAD,

--- a/cub/benchmarks/bench/select/flagged.cu
+++ b/cub/benchmarks/bench/select/flagged.cu
@@ -22,8 +22,7 @@
 template <typename InputT>
 struct bench_policy_selector
 {
-  [[nodiscard]] _CCCL_API constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::select::select_if_policy
+  [[nodiscard]] _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::SelectPolicy
   {
     return {TUNE_THREADS_PER_BLOCK,
             TUNE_ITEMS_PER_THREAD,

--- a/cub/benchmarks/bench/select/if.cu
+++ b/cub/benchmarks/bench/select/if.cu
@@ -24,8 +24,7 @@
 template <typename InputT>
 struct bench_policy_selector
 {
-  [[nodiscard]] _CCCL_API constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::select::select_if_policy
+  [[nodiscard]] _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::SelectPolicy
   {
     return {TUNE_THREADS_PER_BLOCK,
             TUNE_ITEMS_PER_THREAD,

--- a/cub/benchmarks/bench/select/unique.cu
+++ b/cub/benchmarks/bench/select/unique.cu
@@ -22,8 +22,7 @@
 template <typename InputT>
 struct bench_policy_selector
 {
-  [[nodiscard]] _CCCL_API constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::select::select_if_policy
+  [[nodiscard]] _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::SelectPolicy
   {
     return {TUNE_THREADS_PER_BLOCK,
             TUNE_ITEMS_PER_THREAD,

--- a/cub/cub/agent/agent_select_if.cuh
+++ b/cub/cub/agent/agent_select_if.cuh
@@ -44,49 +44,21 @@ CUB_NAMESPACE_BEGIN
  * Tuning policy types
  ******************************************************************************/
 
-/**
- * Parameterizable tuning policy type for AgentSelectIf
- *
- * @tparam ThreadsPerBlock
- *   Threads per thread block
- *
- * @tparam ItemsPerThread
- *   Items per thread (per tile of input)
- *
- * @tparam LoadAlgorithm
- *   The BlockLoad algorithm to use
- *
- * @tparam LoadModifier
- *   Cache load modifier for reading input elements
- *
- * @tparam ScanAlgorithm
- *   The BlockScan algorithm to use
- *
- * @tparam DelayConstructorT
- *   Implementation detail, do not specify directly, requirements on the
- *   content of this type are subject to breaking change.
- */
+namespace detail
+{
+// TODO(bgruber): remove this when C++20 is the minimum, since then we can pass policy values as NTTP
 template <int ThreadsPerBlock,
           int ItemsPerThread,
           BlockLoadAlgorithm LoadAlgorithm,
           CacheLoadModifier LoadModifier,
           BlockScanAlgorithm ScanAlgorithm,
           typename DelayConstructorT = detail::fixed_delay_constructor_t<350, 450>>
-struct AgentSelectIfPolicy
+struct agent_select_if_policy
 {
-  /// Threads per thread block
-  static constexpr int BLOCK_THREADS = ThreadsPerBlock;
-
-  /// Items per thread (per tile of input)
-  static constexpr int ITEMS_PER_THREAD = ItemsPerThread;
-
-  /// The BlockLoad algorithm to use
+  static constexpr int BLOCK_THREADS                 = ThreadsPerBlock;
+  static constexpr int ITEMS_PER_THREAD              = ItemsPerThread;
   static constexpr BlockLoadAlgorithm LOAD_ALGORITHM = LoadAlgorithm;
-
-  /// Cache load modifier for reading input elements
-  static constexpr CacheLoadModifier LOAD_MODIFIER = LoadModifier;
-
-  /// The BlockScan algorithm to use
+  static constexpr CacheLoadModifier LOAD_MODIFIER   = LoadModifier;
   static constexpr BlockScanAlgorithm SCAN_ALGORITHM = ScanAlgorithm;
 
   struct detail
@@ -94,6 +66,16 @@ struct AgentSelectIfPolicy
     using delay_constructor_t = DelayConstructorT;
   };
 };
+} // namespace detail
+
+template <int ThreadsPerBlock,
+          int ItemsPerThread,
+          BlockLoadAlgorithm LoadAlgorithm,
+          CacheLoadModifier LoadModifier,
+          BlockScanAlgorithm ScanAlgorithm,
+          typename DelayConstructorT = detail::fixed_delay_constructor_t<350, 450>>
+using AgentSelectIfPolicy CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceSelect/DevicePartition") = detail::
+  agent_select_if_policy<ThreadsPerBlock, ItemsPerThread, LoadAlgorithm, LoadModifier, ScanAlgorithm, DelayConstructorT>;
 
 /******************************************************************************
  * Thread block abstractions

--- a/cub/cub/device/device_partition.cuh
+++ b/cub/cub/device/device_partition.cuh
@@ -30,6 +30,9 @@
 
 CUB_NAMESPACE_BEGIN
 
+//! The tuning policy for all non-three-way algorithms of @ref DevicePartition
+using PartitionPolicy = SelectPolicy;
+
 //! @rst
 //! DevicePartition provides device-wide, parallel operations for
 //! partitioning sequences of data items residing within device-accessible memory.
@@ -53,7 +56,7 @@ CUB_NAMESPACE_BEGIN
 //!
 //! @par Tuning
 //! All algorithms in DevicePartition, except @p If with three partitions, that accept an environment can be tuned by
-//! passing a custom :ref:`policy selector <cub-policy-selectors>` that returns a @ref SelectPolicy, as shown in the
+//! passing a custom :ref:`policy selector <cub-policy-selectors>` that returns a @ref PartitionPolicy, as shown in the
 //! example below:
 //!
 //!  .. literalinclude:: ../../../cub/test/catch2_test_device_partition_env_api.cu

--- a/cub/cub/device/device_partition.cuh
+++ b/cub/cub/device/device_partition.cuh
@@ -31,7 +31,39 @@
 CUB_NAMESPACE_BEGIN
 
 //! The tuning policy for all non-three-way algorithms of @ref DevicePartition
-using PartitionPolicy = SelectPolicy;
+struct PartitionPolicy
+{
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int items_per_thread; //!< Number of items processed per thread
+  BlockLoadAlgorithm load_algorithm; //!< The @ref BlockLoadAlgorithm used for loading items from global memory
+  CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
+  BlockScanAlgorithm scan_algorithm; //!< The @ref BlockScanAlgorithm used for scanning
+  LookbackDelayPolicy lookback_delay; //!< The policy configuring the delay used in decoupled lookback
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const PartitionPolicy& lhs, const PartitionPolicy& rhs) noexcept
+  {
+    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
+        && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
+        && lhs.scan_algorithm == rhs.scan_algorithm && lhs.lookback_delay == rhs.lookback_delay;
+  }
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const PartitionPolicy& lhs, const PartitionPolicy& rhs) noexcept
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const PartitionPolicy& p)
+  {
+    return os
+        << "PartitionPolicy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
+        << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm << ", .load_modifier = " << p.load_modifier
+        << ", .scan_algorithm = " << p.scan_algorithm << ", .lookback_delay = " << p.lookback_delay << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
 
 //! @rst
 //! DevicePartition provides device-wide, parallel operations for
@@ -74,6 +106,29 @@ using PartitionPolicy = SelectPolicy;
 //! @endrst
 struct DevicePartition
 {
+#ifndef _CCCL_DOXYGEN_INVOKED // Do not document
+  // Several algorithms dispatch to DeviceSelect, but we want to have a dedicated PartitionPolicy, so we need to adapt
+  // the policy selector to convert the tuning policy
+  template <typename PolicySelector>
+  struct __policy_selector_adapter
+  {
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> SelectPolicy
+    {
+      // the user-provided policy selector returns a PartitionPolicy, the default one a SelectPolicy
+      const auto policy = PolicySelector{}(cc);
+      static_assert(::cuda::std::is_same_v<decltype(policy), PartitionPolicy>
+                    || ::cuda::std::is_same_v<decltype(policy), SelectPolicy>);
+      return SelectPolicy{
+        policy.threads_per_block,
+        policy.items_per_thread,
+        policy.load_algorithm,
+        policy.load_modifier,
+        policy.scan_algorithm,
+        policy.lookback_delay};
+    }
+  };
+#endif // _CCCL_DOXYGEN_INVOKED
+
   //! @rst
   //! Uses the ``d_flags`` sequence to split the corresponding items from
   //! ``d_in`` into a partitioned sequence ``d_out``.
@@ -310,7 +365,7 @@ struct DevicePartition
     }
 
     return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+      env, [&]([[maybe_unused]] auto policy_selector, void* storage, size_t& bytes, auto stream) {
         return detail::select::dispatch<SelectImpl::Partition>(
           storage,
           bytes,
@@ -322,7 +377,7 @@ struct DevicePartition
           NullType{},
           static_cast<offset_t>(num_items),
           stream,
-          policy_selector);
+          __policy_selector_adapter<decltype(policy_selector)>{});
       });
   }
 
@@ -571,7 +626,7 @@ struct DevicePartition
     }
 
     return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+      env, [&]([[maybe_unused]] auto policy_selector, void* storage, size_t& bytes, auto stream) {
         return detail::select::dispatch<SelectImpl::Partition>(
           storage,
           bytes,
@@ -583,7 +638,7 @@ struct DevicePartition
           NullType{},
           static_cast<offset_t>(num_items),
           stream,
-          policy_selector);
+          __policy_selector_adapter<decltype(policy_selector)>{});
       });
   }
 

--- a/cub/cub/device/device_partition.cuh
+++ b/cub/cub/device/device_partition.cuh
@@ -30,41 +30,6 @@
 
 CUB_NAMESPACE_BEGIN
 
-//! The tuning policy for all non-three-way algorithms of @ref DevicePartition
-struct PartitionPolicy
-{
-  int threads_per_block; //!< Number of threads in a CUDA block
-  int items_per_thread; //!< Number of items processed per thread
-  BlockLoadAlgorithm load_algorithm; //!< The @ref BlockLoadAlgorithm used for loading items from global memory
-  CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
-  BlockScanAlgorithm scan_algorithm; //!< The @ref BlockScanAlgorithm used for scanning
-  LookbackDelayPolicy lookback_delay; //!< The policy configuring the delay used in decoupled lookback
-
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const PartitionPolicy& lhs, const PartitionPolicy& rhs) noexcept
-  {
-    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
-        && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
-        && lhs.scan_algorithm == rhs.scan_algorithm && lhs.lookback_delay == rhs.lookback_delay;
-  }
-
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const PartitionPolicy& lhs, const PartitionPolicy& rhs) noexcept
-  {
-    return !(lhs == rhs);
-  }
-
-#if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const PartitionPolicy& p)
-  {
-    return os
-        << "PartitionPolicy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
-        << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm << ", .load_modifier = " << p.load_modifier
-        << ", .scan_algorithm = " << p.scan_algorithm << ", .lookback_delay = " << p.lookback_delay << " }";
-  }
-#endif // _CCCL_HOSTED()
-};
-
 //! @rst
 //! DevicePartition provides device-wide, parallel operations for
 //! partitioning sequences of data items residing within device-accessible memory.

--- a/cub/cub/device/device_partition.cuh
+++ b/cub/cub/device/device_partition.cuh
@@ -354,10 +354,8 @@ struct DevicePartition
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DevicePartition::Flagged");
 
-    using choose_offset_t         = detail::choose_signed_offset<NumItemsT>;
-    using offset_t                = typename choose_offset_t::type;
-    using default_policy_selector = detail::select::
-      policy_selector_from_types<InputIteratorT, FlagIterator, OutputIteratorT, offset_t, SelectImpl::Partition>;
+    using choose_offset_t = detail::choose_signed_offset<NumItemsT>;
+    using offset_t        = typename choose_offset_t::type;
 
     // Check if the number of items exceeds the range covered by the selected signed offset type
     if (const auto error = choose_offset_t::is_exceeding_offset_type(num_items))
@@ -365,8 +363,13 @@ struct DevicePartition
       return error;
     }
 
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&]([[maybe_unused]] auto policy_selector, void* storage, size_t& bytes, auto stream) {
+    // we can't use dispatch_with_env_and_tuning, since default_policy_selector uses SelectPolicy, not PartitionPolicy
+    return detail::dispatch_with_env(
+      env, [&]([[maybe_unused]] auto tuning_env, void* storage, size_t& bytes, cudaStream_t stream) {
+        using default_policy_selector = detail::select::
+          policy_selector_from_types<InputIteratorT, FlagIterator, OutputIteratorT, offset_t, SelectImpl::Partition>;
+        using policy_selector_t =
+          ::cuda::std::execution::__query_result_or_t<decltype(tuning_env), PartitionPolicy, default_policy_selector>;
         return detail::select::dispatch<SelectImpl::Partition>(
           storage,
           bytes,
@@ -378,7 +381,7 @@ struct DevicePartition
           NullType{},
           static_cast<offset_t>(num_items),
           stream,
-          __policy_selector_adapter<decltype(policy_selector)>{});
+          __policy_selector_adapter<policy_selector_t>{});
       });
   }
 
@@ -615,10 +618,8 @@ struct DevicePartition
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DevicePartition::If");
 
-    using choose_offset_t         = detail::choose_signed_offset<NumItemsT>;
-    using offset_t                = typename choose_offset_t::type;
-    using default_policy_selector = detail::select::
-      policy_selector_from_types<InputIteratorT, NullType*, OutputIteratorT, offset_t, SelectImpl::Partition>;
+    using choose_offset_t = detail::choose_signed_offset<NumItemsT>;
+    using offset_t        = typename choose_offset_t::type;
 
     // Check if the number of items exceeds the range covered by the selected signed offset type
     if (const auto error = choose_offset_t::is_exceeding_offset_type(num_items))
@@ -626,8 +627,13 @@ struct DevicePartition
       return error;
     }
 
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&]([[maybe_unused]] auto policy_selector, void* storage, size_t& bytes, auto stream) {
+    // we can't use dispatch_with_env_and_tuning, since default_policy_selector uses SelectPolicy, not PartitionPolicy
+    return detail::dispatch_with_env(
+      env, [&]([[maybe_unused]] auto tuning_env, void* storage, size_t& bytes, cudaStream_t stream) {
+        using default_policy_selector = detail::select::
+          policy_selector_from_types<InputIteratorT, NullType*, OutputIteratorT, offset_t, SelectImpl::Partition>;
+        using policy_selector_t =
+          ::cuda::std::execution::__query_result_or_t<decltype(tuning_env), PartitionPolicy, default_policy_selector>;
         return detail::select::dispatch<SelectImpl::Partition>(
           storage,
           bytes,
@@ -639,7 +645,7 @@ struct DevicePartition
           NullType{},
           static_cast<offset_t>(num_items),
           stream,
-          __policy_selector_adapter<decltype(policy_selector)>{});
+          __policy_selector_adapter<policy_selector_t>{});
       });
   }
 

--- a/cub/cub/device/device_partition.cuh
+++ b/cub/cub/device/device_partition.cuh
@@ -115,9 +115,10 @@ struct DevicePartition
     [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> SelectPolicy
     {
       // the user-provided policy selector returns a PartitionPolicy, the default one a SelectPolicy
+      using policy_t = ::cuda::std::remove_cvref_t<decltype(PolicySelector{}(cc))>;
+      static_assert(
+        ::cuda::std::is_same_v<policy_t, PartitionPolicy> || ::cuda::std::is_same_v<policy_t, SelectPolicy>);
       const auto policy = PolicySelector{}(cc);
-      static_assert(::cuda::std::is_same_v<decltype(policy), PartitionPolicy>
-                    || ::cuda::std::is_same_v<decltype(policy), SelectPolicy>);
       return SelectPolicy{
         policy.threads_per_block,
         policy.items_per_thread,

--- a/cub/cub/device/device_partition.cuh
+++ b/cub/cub/device/device_partition.cuh
@@ -51,10 +51,26 @@ CUB_NAMESPACE_BEGIN
 //!
 //! @linear_performance{partition}
 //!
+//! @par Tuning
+//! All algorithms in DevicePartition, except @p If with three partitions, that accept an environment can be tuned by
+//! passing a custom :ref:`policy selector <cub-policy-selectors>` that returns a @ref SelectPolicy, as shown in the
+//! example below:
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_partition_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin partition-if-policy-selector
+//!      :end-before: example-end partition-if-policy-selector
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_partition_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin partition-if-tuning
+//!      :end-before: example-end partition-if-tuning
+//!
 //! @endrst
 struct DevicePartition
 {
-public:
   //! @rst
   //! Uses the ``d_flags`` sequence to split the corresponding items from
   //! ``d_in`` into a partitioned sequence ``d_out``.

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -56,6 +56,23 @@ CUB_NAMESPACE_BEGIN
 //!
 //! @linear_performance{select-flagged, select-if, and select-unique}
 //!
+//! @par Tuning
+//! All non-ByKey algorithms in DeviceSelect that accept an environment can be tuned by passing a custom
+//! :ref:`policy selector <cub-policy-selectors>` that returns a @ref SelectPolicy, as shown in the
+//! example below:
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_select_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin select-if-policy-selector
+//!      :end-before: example-end select-if-policy-selector
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_select_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin select-if-tuning
+//!      :end-before: example-end select-if-tuning
+//!
 //! @endrst
 struct DeviceSelect
 {

--- a/cub/cub/device/dispatch/dispatch_select_if.cuh
+++ b/cub/cub/device/dispatch/dispatch_select_if.cuh
@@ -214,16 +214,16 @@ template <typename DefaultPolicyGetter,
           typename StreamingContextT>
 struct make_vsmem_helper
 {
-  static constexpr select_if_policy active_policy = DefaultPolicyGetter{}();
-  using agent_policy_t =
-    AgentSelectIfPolicy<active_policy.threads_per_block,
-                        active_policy.items_per_thread,
-                        active_policy.load_algorithm,
-                        active_policy.load_modifier,
-                        active_policy.scan_algorithm,
-                        delay_constructor_t<active_policy.delay_constructor.kind,
-                                            active_policy.delay_constructor.delay,
-                                            active_policy.delay_constructor.l2_write_latency>>;
+  static constexpr SelectPolicy active_policy = DefaultPolicyGetter{}();
+  using agent_policy_t                        = detail::agent_select_if_policy<
+                           active_policy.threads_per_block,
+                           active_policy.items_per_thread,
+                           active_policy.load_algorithm,
+                           active_policy.load_modifier,
+                           active_policy.scan_algorithm,
+                           delay_constructor_t<active_policy.lookback_delay.kind,
+                                               active_policy.lookback_delay.delay,
+                                               active_policy.lookback_delay.l2_write_latency>>;
   using type = vsmem_helper_default_fallback_policy_t<
     agent_policy_t,
     bind_selection_opt<SelectionOpt>::template agent_t,
@@ -391,10 +391,10 @@ template <typename PolicyHub>
 struct policy_selector_from_hub
 {
   // this is only called in device code
-  [[nodiscard]] _CCCL_DEVICE_API constexpr auto operator()(::cuda::compute_capability /*cc*/) const -> select_if_policy
+  [[nodiscard]] _CCCL_DEVICE_API constexpr auto operator()(::cuda::compute_capability /*cc*/) const -> SelectPolicy
   {
     using active_policy = typename PolicyHub::MaxPolicy::ActivePolicy::SelectIfPolicyT;
-    return select_if_policy{
+    return SelectPolicy{
       active_policy::BLOCK_THREADS,
       active_policy::ITEMS_PER_THREAD,
       active_policy::LOAD_ALGORITHM,
@@ -454,7 +454,7 @@ template <
     ::cuda::std::conditional_t<SelectionOpt == SelectImpl::Partition, OffsetT, detail::select::per_partition_offset_t>,
     detail::select::is_partition_distinct_output_t<SelectedOutputIteratorT>::value,
     SelectionOpt>>
-struct DispatchSelectIf
+struct CCCL_DEPRECATED_BECAUSE("Please use DeviceSelect or DevicePartition") DispatchSelectIf
 {
   /******************************************************************************
    * Types and constants

--- a/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
@@ -69,6 +69,43 @@ struct SelectPolicy
 #endif // _CCCL_HOSTED()
 };
 
+// We have a dedicated policy for partition, since it's also a dedicated public API. However, we will convert this
+// policy to a SelectPolicy at the device layer so the dispatch and kernel can just use a SelectPolicy.
+//! The tuning policy for all non-three-way algorithms of @ref DevicePartition
+struct PartitionPolicy
+{
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int items_per_thread; //!< Number of items processed per thread
+  BlockLoadAlgorithm load_algorithm; //!< The @ref BlockLoadAlgorithm used for loading items from global memory
+  CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
+  BlockScanAlgorithm scan_algorithm; //!< The @ref BlockScanAlgorithm used for scanning
+  LookbackDelayPolicy lookback_delay; //!< The policy configuring the delay used in decoupled lookback
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const PartitionPolicy& lhs, const PartitionPolicy& rhs) noexcept
+  {
+    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
+        && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
+        && lhs.scan_algorithm == rhs.scan_algorithm && lhs.lookback_delay == rhs.lookback_delay;
+  }
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const PartitionPolicy& lhs, const PartitionPolicy& rhs) noexcept
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const PartitionPolicy& p)
+  {
+    return os
+        << "PartitionPolicy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
+        << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm << ", .load_modifier = " << p.load_modifier
+        << ", .scan_algorithm = " << p.scan_algorithm << ", .lookback_delay = " << p.lookback_delay << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
 namespace detail::select
 {
 // TODO(bgruber): drop in CCCL 4.0

--- a/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
@@ -34,6 +34,41 @@
 
 CUB_NAMESPACE_BEGIN
 
+//! The tuning policy for all non-ByKey algorithms in @ref DeviceSelect and @ref DevicePartition (two-way).
+struct SelectPolicy
+{
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int items_per_thread; //!< Number of items processed per thread
+  BlockLoadAlgorithm load_algorithm; //!< The @ref BlockLoadAlgorithm used for loading items from global memory
+  CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
+  BlockScanAlgorithm scan_algorithm; //!< The @ref BlockScanAlgorithm used for scanning
+  LookbackDelayPolicy lookback_delay; //!< The policy configuring the delay used in decoupled lookback
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const SelectPolicy& lhs, const SelectPolicy& rhs) noexcept
+  {
+    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
+        && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
+        && lhs.scan_algorithm == rhs.scan_algorithm && lhs.lookback_delay == rhs.lookback_delay;
+  }
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const SelectPolicy& lhs, const SelectPolicy& rhs) noexcept
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const SelectPolicy& p)
+  {
+    return os
+        << "SelectPolicy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
+        << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm << ", .load_modifier = " << p.load_modifier
+        << ", .scan_algorithm = " << p.scan_algorithm << ", .lookback_delay = " << p.lookback_delay << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
 namespace detail::select
 {
 // TODO(bgruber): drop in CCCL 4.0
@@ -1505,12 +1540,12 @@ struct policy_hub
     static constexpr int items_per_thread =
       ::cuda::std::clamp(nominal_4B_items_per_thread * 4 / int{sizeof(InputT)}, 1, nominal_4B_items_per_thread);
     using SelectIfPolicyT =
-      AgentSelectIfPolicy<128,
-                          items_per_thread,
-                          BLOCK_LOAD_DIRECT,
-                          LoadModifier,
-                          BLOCK_SCAN_WARP_SCANS,
-                          detail::fixed_delay_constructor_t<350, 450>>;
+      agent_select_if_policy<128,
+                             items_per_thread,
+                             BLOCK_LOAD_DIRECT,
+                             LoadModifier,
+                             BLOCK_SCAN_WARP_SCANS,
+                             detail::fixed_delay_constructor_t<350, 450>>;
   };
 
   // nvbug5935129: GCC-11.2 cannot directly use DefaultPolicy inside Policy500
@@ -1524,12 +1559,12 @@ struct policy_hub
   // Use values from tuning if a specialization exists, otherwise pick the default
   template <typename Tuning>
   static auto select_agent_policy(int)
-    -> AgentSelectIfPolicy<Tuning::threads,
-                           Tuning::items,
-                           Tuning::load_algorithm,
-                           LOAD_DEFAULT,
-                           BLOCK_SCAN_WARP_SCANS,
-                           typename Tuning::delay_constructor>;
+    -> agent_select_if_policy<Tuning::threads,
+                              Tuning::items,
+                              Tuning::load_algorithm,
+                              LOAD_DEFAULT,
+                              BLOCK_SCAN_WARP_SCANS,
+                              typename Tuning::delay_constructor>;
   template <typename Tuning>
   static auto select_agent_policy(long) -> typename DefaultPolicy<LOAD_DEFAULT>::SelectIfPolicyT;
 
@@ -1568,12 +1603,12 @@ struct policy_hub
     // Use values from tuning if a specialization exists, otherwise pick Policy900
     template <typename Tuning>
     static auto select_agent_policy100(int)
-      -> AgentSelectIfPolicy<Tuning::threads,
-                             Nominal4BItemsToItems<InputT>(Tuning::nominal_4b_items),
-                             Tuning::load_algorithm,
-                             Tuning::load_modifier,
-                             BLOCK_SCAN_WARP_SCANS,
-                             typename Tuning::delay_constructor>;
+      -> agent_select_if_policy<Tuning::threads,
+                                Nominal4BItemsToItems<InputT>(Tuning::nominal_4b_items),
+                                Tuning::load_algorithm,
+                                Tuning::load_modifier,
+                                BLOCK_SCAN_WARP_SCANS,
+                                typename Tuning::delay_constructor>;
     template <typename Tuning>
     static auto select_agent_policy100(long) -> typename Policy900::SelectIfPolicyT;
 
@@ -1591,43 +1626,9 @@ struct policy_hub
   using MaxPolicy = Policy1000;
 };
 
-struct select_if_policy
-{
-  int threads_per_block;
-  int items_per_thread;
-  BlockLoadAlgorithm load_algorithm;
-  CacheLoadModifier load_modifier;
-  BlockScanAlgorithm scan_algorithm;
-  LookbackDelayPolicy delay_constructor;
-
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const select_if_policy& lhs, const select_if_policy& rhs)
-  {
-    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
-        && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
-        && lhs.scan_algorithm == rhs.scan_algorithm && lhs.delay_constructor == rhs.delay_constructor;
-  }
-
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const select_if_policy& lhs, const select_if_policy& rhs)
-  {
-    return !(lhs == rhs);
-  }
-
-#if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const select_if_policy& p)
-  {
-    return os
-        << "select_if_policy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
-        << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm << ", .load_modifier = " << p.load_modifier
-        << ", .scan_algorithm = " << p.scan_algorithm << ", .delay_constructor = " << p.delay_constructor << " }";
-  }
-#endif // _CCCL_HOSTED()
-};
-
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>
-concept select_if_policy_selector = policy_selector<T, select_if_policy>;
+concept select_if_policy_selector = policy_selector<T, SelectPolicy>;
 #endif // _CCCL_HAS_CONCEPTS()
 
 struct policy_selector
@@ -1642,12 +1643,12 @@ struct policy_selector
 
 private:
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto default_policy(CacheLoadModifier load_modifier) const
-    -> select_if_policy
+    -> SelectPolicy
   {
     constexpr int nominal_4B_items_per_thread = 10;
     const int items_per_thread =
       ::cuda::std::clamp(nominal_4B_items_per_thread * 4 / input_size_bytes, 1, nominal_4B_items_per_thread);
-    return select_if_policy{
+    return SelectPolicy{
       128,
       items_per_thread,
       BLOCK_LOAD_DIRECT,
@@ -1661,14 +1662,14 @@ private:
     int nominal_4b_items,
     BlockLoadAlgorithm load_alg,
     CacheLoadModifier load_mod,
-    LookbackDelayPolicy delay) const -> select_if_policy
+    LookbackDelayPolicy delay) const -> SelectPolicy
   {
     const int items_per_thread = nominal_4B_items_to_items(nominal_4b_items, input_size_bytes);
-    return select_if_policy{threads_per_block, items_per_thread, load_alg, load_mod, BLOCK_SCAN_WARP_SCANS, delay};
+    return SelectPolicy{threads_per_block, items_per_thread, load_alg, load_mod, BLOCK_SCAN_WARP_SCANS, delay};
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto get_sm80_tuning(bool has_flags, bool keep_rejects) const
-    -> select_if_policy
+    -> SelectPolicy
   {
     // before SM100, we only tuned for int32, but we always take these tunings independently of the offset type size
 
@@ -1676,7 +1677,7 @@ private:
     {
       if (not has_flags && not keep_rejects)
       {
-        return select_if_policy{
+        return SelectPolicy{
           384,
           4,
           BLOCK_LOAD_DIRECT,
@@ -1686,7 +1687,7 @@ private:
       }
       if (has_flags && not keep_rejects)
       {
-        return select_if_policy{
+        return SelectPolicy{
           256,
           5,
           BLOCK_LOAD_DIRECT,
@@ -1696,7 +1697,7 @@ private:
       }
       if (not has_flags && keep_rejects)
       {
-        return select_if_policy{
+        return SelectPolicy{
           256,
           5,
           BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1706,7 +1707,7 @@ private:
       }
       if (has_flags && keep_rejects)
       {
-        return select_if_policy{
+        return SelectPolicy{
           256,
           5,
           BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1726,7 +1727,7 @@ private:
       switch (input_size_bytes)
       {
         case 1:
-          return select_if_policy{
+          return SelectPolicy{
             992,
             20,
             BLOCK_LOAD_DIRECT,
@@ -1734,7 +1735,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 395}};
         case 2:
-          return select_if_policy{
+          return SelectPolicy{
             576,
             14,
             BLOCK_LOAD_DIRECT,
@@ -1742,7 +1743,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 870}};
         case 4:
-          return select_if_policy{
+          return SelectPolicy{
             256,
             18,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1750,7 +1751,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1130}};
         case 8:
-          return select_if_policy{
+          return SelectPolicy{
             192,
             10,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1766,7 +1767,7 @@ private:
       switch (input_size_bytes)
       {
         case 1:
-          return select_if_policy{
+          return SelectPolicy{
             224,
             20,
             BLOCK_LOAD_DIRECT,
@@ -1774,7 +1775,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 735}};
         case 2:
-          return select_if_policy{
+          return SelectPolicy{
             256,
             20,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1782,7 +1783,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1155}};
         case 4:
-          return select_if_policy{
+          return SelectPolicy{
             320,
             10,
             BLOCK_LOAD_DIRECT,
@@ -1790,7 +1791,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 124, 1115}};
         case 8:
-          return select_if_policy{
+          return SelectPolicy{
             384,
             6,
             BLOCK_LOAD_DIRECT,
@@ -1806,7 +1807,7 @@ private:
       switch (input_size_bytes)
       {
         case 1:
-          return select_if_policy{
+          return SelectPolicy{
             512,
             20,
             BLOCK_LOAD_DIRECT,
@@ -1814,7 +1815,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 510}};
         case 2:
-          return select_if_policy{
+          return SelectPolicy{
             224,
             18,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1822,7 +1823,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1045}};
         case 4:
-          return select_if_policy{
+          return SelectPolicy{
             192,
             15,
             BLOCK_LOAD_DIRECT,
@@ -1830,7 +1831,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1040}};
         case 8:
-          return select_if_policy{
+          return SelectPolicy{
             192,
             10,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1846,7 +1847,7 @@ private:
       switch (input_size_bytes)
       {
         case 1:
-          return select_if_policy{
+          return SelectPolicy{
             512,
             20,
             BLOCK_LOAD_DIRECT,
@@ -1854,7 +1855,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 595}};
         case 2:
-          return select_if_policy{
+          return SelectPolicy{
             224,
             18,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1862,7 +1863,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1105}};
         case 4:
-          return select_if_policy{
+          return SelectPolicy{
             192,
             12,
             BLOCK_LOAD_DIRECT,
@@ -1870,7 +1871,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 912, 1025}};
         case 8:
-          return select_if_policy{
+          return SelectPolicy{
             192,
             12,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1885,7 +1886,7 @@ private:
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto get_sm90_tuning(bool has_flags, bool keep_rejects) const
-    -> select_if_policy
+    -> SelectPolicy
   {
     // before SM100, we only tuned for int32, but we always take these tunings independently of the offset type size
 
@@ -1893,7 +1894,7 @@ private:
     {
       if (not has_flags && not keep_rejects)
       {
-        return select_if_policy{
+        return SelectPolicy{
           512,
           5,
           BLOCK_LOAD_DIRECT,
@@ -1903,7 +1904,7 @@ private:
       }
       if (has_flags && not keep_rejects)
       {
-        return select_if_policy{
+        return SelectPolicy{
           512,
           3,
           BLOCK_LOAD_DIRECT,
@@ -1913,7 +1914,7 @@ private:
       }
       if (not has_flags && keep_rejects)
       {
-        return select_if_policy{
+        return SelectPolicy{
           192,
           5,
           BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1923,7 +1924,7 @@ private:
       }
       if (has_flags && keep_rejects)
       {
-        return select_if_policy{
+        return SelectPolicy{
           160,
           5,
           BLOCK_LOAD_DIRECT,
@@ -1943,7 +1944,7 @@ private:
       switch (input_size_bytes)
       {
         case 1:
-          return select_if_policy{
+          return SelectPolicy{
             256,
             22,
             BLOCK_LOAD_DIRECT,
@@ -1951,7 +1952,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 580}};
         case 2:
-          return select_if_policy{
+          return SelectPolicy{
             256,
             22,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1959,7 +1960,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 320, 605}};
         case 4:
-          return select_if_policy{
+          return SelectPolicy{
             384,
             17,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1967,7 +1968,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 76, 1150}};
         case 8:
-          return select_if_policy{
+          return SelectPolicy{
             384,
             11,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1983,7 +1984,7 @@ private:
       switch (input_size_bytes)
       {
         case 1:
-          return select_if_policy{
+          return SelectPolicy{
             448,
             20,
             BLOCK_LOAD_DIRECT,
@@ -1991,7 +1992,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 715}};
         case 2:
-          return select_if_policy{
+          return SelectPolicy{
             448,
             20,
             BLOCK_LOAD_DIRECT,
@@ -1999,7 +2000,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 504, 765}};
         case 4:
-          return select_if_policy{
+          return SelectPolicy{
             384,
             15,
             BLOCK_LOAD_DIRECT,
@@ -2007,7 +2008,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 415, 1125}};
         case 8:
-          return select_if_policy{
+          return SelectPolicy{
             384,
             11,
             BLOCK_LOAD_DIRECT,
@@ -2023,7 +2024,7 @@ private:
       switch (input_size_bytes)
       {
         case 1:
-          return select_if_policy{
+          return SelectPolicy{
             384,
             20,
             BLOCK_LOAD_DIRECT,
@@ -2031,7 +2032,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 908, 995}};
         case 2:
-          return select_if_policy{
+          return SelectPolicy{
             320,
             14,
             BLOCK_LOAD_DIRECT,
@@ -2039,7 +2040,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 500, 560}};
         case 4:
-          return select_if_policy{
+          return SelectPolicy{
             256,
             14,
             BLOCK_LOAD_DIRECT,
@@ -2047,7 +2048,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 536, 1055}};
         case 8:
-          return select_if_policy{
+          return SelectPolicy{
             128,
             12,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -2063,7 +2064,7 @@ private:
       switch (input_size_bytes)
       {
         case 1:
-          return select_if_policy{
+          return SelectPolicy{
             256,
             20,
             BLOCK_LOAD_DIRECT,
@@ -2071,7 +2072,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 580, 850}};
         case 2:
-          return select_if_policy{
+          return SelectPolicy{
             512,
             20,
             BLOCK_LOAD_DIRECT,
@@ -2079,7 +2080,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 388, 1055}};
         case 4:
-          return select_if_policy{
+          return SelectPolicy{
             256,
             20,
             BLOCK_LOAD_DIRECT,
@@ -2087,7 +2088,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 72, 1165}};
         case 8:
-          return select_if_policy{
+          return SelectPolicy{
             224,
             6,
             BLOCK_LOAD_DIRECT,
@@ -2102,7 +2103,7 @@ private:
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto
-  get_sm100_tuning(bool has_flags, bool keep_rejects, bool may_alias) const -> ::cuda::std::optional<select_if_policy>
+  get_sm100_tuning(bool has_flags, bool keep_rejects, bool may_alias) const -> ::cuda::std::optional<SelectPolicy>
   {
     if (not input_is_primitive)
     {
@@ -2516,7 +2517,7 @@ private:
   }
 
 public:
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> select_if_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> SelectPolicy
   {
     const bool has_flags    = flag_size_bytes != 0;
     const bool keep_rejects = selection_impl == SelectImpl::Partition;
@@ -2557,7 +2558,7 @@ template <typename InputIteratorT,
           SelectImpl SelectionOpt>
 struct policy_selector_from_types
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> select_if_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> SelectPolicy
   {
     using input_t = it_value_t<InputIteratorT>;
     using flag_t  = it_value_t<FlagsInputIteratorT>;

--- a/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
@@ -34,7 +34,7 @@
 
 CUB_NAMESPACE_BEGIN
 
-//! The tuning policy for all non-ByKey algorithms in @ref DeviceSelect and @ref DevicePartition (two-way).
+//! The tuning policy for all non-ByKey algorithms in @ref DeviceSelect
 struct SelectPolicy
 {
   int threads_per_block; //!< Number of threads in a CUDA block

--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -184,6 +184,7 @@ function(
       "${test_src}" MATCHES "test_device_segmented_scan_api\\.cu$"
       OR "${test_src}" MATCHES "test_device_find_env_api\\.cu$"
       OR "${test_src}" MATCHES "test_device_partition_env_api\\.cu$"
+      OR "${test_src}" MATCHES "test_device_select_env_api\\.cu$"
     )
       if (
         "Clang" STREQUAL "${CMAKE_CXX_COMPILER_ID}"

--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -183,6 +183,7 @@ function(
     if (
       "${test_src}" MATCHES "test_device_segmented_scan_api\\.cu$"
       OR "${test_src}" MATCHES "test_device_find_env_api\\.cu$"
+      OR "${test_src}" MATCHES "test_device_partition_env_api\\.cu$"
     )
       if (
         "Clang" STREQUAL "${CMAKE_CXX_COMPILER_ID}"

--- a/cub/test/catch2_test_device_partition_env.cu
+++ b/cub/test/catch2_test_device_partition_env.cu
@@ -285,7 +285,7 @@ struct less_than_5_t
 template <unsigned int BlockThreads>
 struct partition_policy_selector
 {
-  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::SelectPolicy
+  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::PartitionPolicy
   {
     return {static_cast<int>(BlockThreads),
             10,

--- a/cub/test/catch2_test_device_partition_env.cu
+++ b/cub/test/catch2_test_device_partition_env.cu
@@ -285,7 +285,7 @@ struct less_than_5_t
 template <unsigned int BlockThreads>
 struct partition_policy_selector
 {
-  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::detail::select::select_if_policy
+  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::SelectPolicy
   {
     return {static_cast<int>(BlockThreads),
             10,

--- a/cub/test/catch2_test_device_partition_env_api.cu
+++ b/cub/test/catch2_test_device_partition_env_api.cu
@@ -134,7 +134,7 @@ C2H_TEST("cub::DevicePartition::If three-way accepts env with stream", "[partiti
 // example-begin partition-if-policy-selector
 struct PartitionPolicySelector
 {
-  __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::SelectPolicy
+  __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::PartitionPolicy
   {
     return {.threads_per_block = 128,
             .items_per_thread  = cc > cuda::compute_capability{9, 0} ? 16 : 10,

--- a/cub/test/catch2_test_device_partition_env_api.cu
+++ b/cub/test/catch2_test_device_partition_env_api.cu
@@ -7,6 +7,7 @@
 
 #include <thrust/device_vector.h>
 
+#include <cuda/__execution/tune.h>
 #include <cuda/devices>
 #include <cuda/stream>
 
@@ -127,3 +128,53 @@ C2H_TEST("cub::DevicePartition::If three-way accepts env with stream", "[partiti
   REQUIRE(small_out == expected_small);
   REQUIRE(large_out == expected_large);
 }
+
+#if _CCCL_STD_VER >= 2020
+
+// example-begin partition-if-policy-selector
+struct PartitionPolicySelector
+{
+  __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::SelectPolicy
+  {
+    return {.threads_per_block = 128,
+            .items_per_thread  = cc > cuda::compute_capability{9, 0} ? 16 : 10,
+            .load_algorithm    = cub::BLOCK_LOAD_DIRECT,
+            .load_modifier     = cub::LOAD_DEFAULT,
+            .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
+            .lookback_delay    = {cub::LookbackDelayAlgorithm::fixed_delay, 350, 450}};
+  }
+};
+// example-end partition-if-policy-selector
+
+C2H_TEST("cub::DevicePartition::If env-based API with tuning", "[partition][env]")
+{
+  // example-begin partition-if-tuning
+  auto d_in           = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto d_out          = thrust::device_vector<int>(8, thrust::no_init);
+  auto d_num_selected = thrust::device_vector<int>(1, thrust::no_init);
+
+  const auto error = cub::DevicePartition::If(
+    d_in.begin(),
+    d_out.begin(),
+    d_num_selected.begin(),
+    d_in.size(),
+    [] __host__ __device__(int v) {
+      return v < 5;
+    },
+    cuda::execution::tune(PartitionPolicySelector{}));
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DevicePartition::If failed with status: " << error << '\n';
+  }
+
+  // Selected items (< 5) at front, unselected items (>= 5) at back in reverse order
+  thrust::device_vector<int> expected_output{1, 2, 3, 4, 8, 7, 6, 5};
+  int expected_num_selected = 4;
+  // example-end partition-if-tuning
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_out == expected_output);
+  REQUIRE(d_num_selected[0] == expected_num_selected);
+}
+
+#endif // _CCCL_STD_VER >= 2020

--- a/cub/test/catch2_test_device_select_env.cu
+++ b/cub/test/catch2_test_device_select_env.cu
@@ -1097,7 +1097,7 @@ struct even_flag_t
 template <unsigned int BlockThreads>
 struct select_tuning
 {
-  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::detail::select::select_if_policy
+  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::SelectPolicy
   {
     return {static_cast<int>(BlockThreads),
             10,
@@ -1275,3 +1275,37 @@ C2H_TEST("DeviceSelect::UniqueByKey can be tuned", "[select][device]", block_siz
 }
 
 #endif // TEST_LAUNCH != 1
+
+#if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
+C2H_TEST("SelectPolicy", "[select][device]")
+{
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::SelectPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::SelectPolicy>);
+
+  // aggregate init
+  constexpr auto p1 = cub::SelectPolicy{
+    128,
+    10,
+    cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+    cub::CacheLoadModifier::LOAD_DEFAULT,
+    cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_SCANS,
+    cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 350, 450}};
+
+#  if _CCCL_STD_VER >= 2020
+  // designated init
+  constexpr auto p2 = cub::SelectPolicy{
+    .threads_per_block = 128,
+    .items_per_thread  = 10,
+    .load_algorithm    = cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+    .load_modifier     = cub::CacheLoadModifier::LOAD_DEFAULT,
+    .scan_algorithm    = cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_SCANS,
+    .lookback_delay    = cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 350, 450}};
+#  else // _CCCL_STD_VER >= 2020
+  constexpr auto p2 = p1;
+#  endif // _CCCL_STD_VER >= 2020
+
+  // comparison
+  STATIC_REQUIRE(p1 == p2);
+  STATIC_REQUIRE_FALSE(p1 != p2);
+}
+#endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_select_env_api.cu
+++ b/cub/test/catch2_test_device_select_env_api.cu
@@ -7,6 +7,7 @@
 
 #include <thrust/device_vector.h>
 
+#include <cuda/__execution/tune.h>
 #include <cuda/devices>
 #include <cuda/stream>
 
@@ -401,3 +402,52 @@ C2H_TEST("cub::DeviceSelect::UniqueByKey accepts default env without equality_op
   REQUIRE(values_out == expected_values);
   REQUIRE(num_selected == expected_num_selected);
 }
+
+#if _CCCL_STD_VER >= 2020
+
+// example-begin select-if-policy-selector
+struct SelectPolicySelector
+{
+  __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::SelectPolicy
+  {
+    return {.threads_per_block = 128,
+            .items_per_thread  = cc > cuda::compute_capability{9, 0} ? 16 : 10,
+            .load_algorithm    = cub::BLOCK_LOAD_DIRECT,
+            .load_modifier     = cub::LOAD_DEFAULT,
+            .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
+            .lookback_delay    = {cub::LookbackDelayAlgorithm::fixed_delay, 350, 450}};
+  }
+};
+// example-end select-if-policy-selector
+
+C2H_TEST("cub::DeviceSelect::If env-based API with tuning", "[select][env]")
+{
+  // example-begin select-if-tuning
+  auto d_in           = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto d_out          = thrust::device_vector<int>(4, thrust::no_init);
+  auto d_num_selected = thrust::device_vector<int>(1, thrust::no_init);
+
+  const auto error = cub::DeviceSelect::If(
+    d_in.begin(),
+    d_out.begin(),
+    d_num_selected.begin(),
+    d_in.size(),
+    [] __host__ __device__(int v) {
+      return v < 5;
+    },
+    cuda::execution::tune(SelectPolicySelector{}));
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceSelect::If failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected_output{1, 2, 3, 4};
+  int expected_num_selected = 4;
+  // example-end select-if-tuning
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_out == expected_output);
+  REQUIRE(d_num_selected[0] == expected_num_selected);
+}
+
+#endif // _CCCL_STD_VER >= 2020

--- a/cub/test/catch2_test_device_select_if_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_select_if_custom_policy_hub.cu
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// TODO(bgruber): drop this test with CCCL 4.0 when we drop the select if dispatcher
+
+#define CCCL_IGNORE_DEPRECATED_API
+
 #include "insert_nested_NVTX_range_guard.h"
 
 #include <cub/device/dispatch/dispatch_select_if.cuh>
@@ -12,8 +16,6 @@
 #include <c2h/catch2_test_helper.h>
 
 using namespace cub;
-
-// TODO(bgruber): drop this test with CCCL 4.0 when we drop the select if dispatcher after publishing the tuning API
 
 template <class InputT>
 struct my_policy_hub

--- a/libcudacxx/include/cuda/std/__pstl/cuda/unique.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/unique.h
@@ -79,23 +79,13 @@ struct __pstl_dispatch<__pstl_algorithm::__unique, __execution_backend::__cuda>
     const auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
     const auto __ctx    = ::cuda::std::execution::__pstl_ensure_current_ctx_for(__policy);
 
-    using _OffsetType    = iter_difference_t<_InputIterator>;
-    using DispatchUnique = CUB_NS_QUALIFIER::DispatchSelectIf<
-      _InputIterator,
-      CUB_NS_QUALIFIER::NullType*,
-      _InputIterator,
-      _OffsetType*,
-      CUB_NS_QUALIFIER::NullType,
-      _BinaryPredicate,
-      _OffsetType,
-      Select>;
-
+    using _OffsetType          = iter_difference_t<_InputIterator>;
     const auto __count         = ::cuda::std::distance(__first, __last);
     _OffsetType __num_selected = 0;
     size_t __num_bytes         = 0;
 
     _CCCL_TRY_CUDA_API(
-      DispatchUnique::Dispatch,
+      CUB_NS_QUALIFIER::detail::select::dispatch<Select>,
       "__pstl_cuda_unique: determination of device storage for cub::DispatchSelectIf::Dispatch failed",
       static_cast<void*>(nullptr),
       __num_bytes,
@@ -106,13 +96,13 @@ struct __pstl_dispatch<__pstl_algorithm::__unique, __execution_backend::__cuda>
       CUB_NS_QUALIFIER::NullType{},
       __pred,
       __count,
-      nullptr);
+      __stream.get());
 
     { // Create temporary storage for the return value as well as a copy of the input sequence as Unique is not inplace
       __temporary_storage<_OffsetType> __storage{__policy, __num_bytes, 1};
 
       _CCCL_TRY_CUDA_API(
-        DispatchUnique::Dispatch,
+        CUB_NS_QUALIFIER::detail::select::dispatch<Select>,
         "__pstl_cuda_unique: kernel launch of cub::DispatchSelectIf::Dispatch failed",
         __storage.__get_temp_storage(),
         __num_bytes,


### PR DESCRIPTION
Fixes: #8583
Fixes: #8575 
