### PR TITLE
Add CUB WarpReduceBatchedBroadcast

### DIFF
--- a/cub/benchmarks/bench/reduce/warp_reduce_batched_broadcast.cu
+++ b/cub/benchmarks/bench/reduce/warp_reduce_batched_broadcast.cu
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/thread/thread_reduce.cuh>
+#include <cub/warp/warp_reduce.cuh>
+#include <cub/warp/warp_reduce_batched_broadcast.cuh>
+#include <cub/warp/warp_utils.cuh>
+
+#include <cuda/std/array>
+#include <cuda/std/functional>
+
+#include <cuda_runtime_api.h>
+#include <device_side_benchmark.cuh>
+#include <nvbench_helper.cuh>
+
+constexpr int block_size = 256;
+
+template <int Batches, int LogicalWarpThreads, bool SyncPhysicalWarp = false>
+struct manual_batched_broadcast_t
+{
+  template <typename T>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T operator()(T thread_data) const
+  {
+    const int lane_id        = cub::detail::logical_lane_id<LogicalWarpThreads>();
+    unsigned int member_mask = 0xFFFFFFFFu;
+    if constexpr (!SyncPhysicalWarp)
+    {
+      const int logical_warp_id = cub::detail::logical_warp_id<LogicalWarpThreads>();
+      member_mask               = cub::WarpMask<LogicalWarpThreads>(logical_warp_id);
+    }
+
+    ::cuda::std::array<T, Batches> outputs{};
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int batch = 0; batch < Batches; ++batch)
+    {
+      outputs[batch] = thread_data + static_cast<T>(batch);
+    }
+
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int offset = LogicalWarpThreads / 2; offset > 0; offset >>= 1)
+    {
+      _CCCL_PRAGMA_UNROLL_FULL()
+      for (int batch = 0; batch < Batches; ++batch)
+      {
+        outputs[batch] += cub::ShuffleIndex<LogicalWarpThreads>(outputs[batch], lane_id ^ offset, member_mask);
+      }
+    }
+
+    return cub::ThreadReduce(outputs, ::cuda::std::plus<>{});
+  }
+};
+
+template <int Batches, int LogicalWarpThreads, bool SyncPhysicalWarp = false>
+struct primitive_batched_broadcast_t
+{
+  template <typename T>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T operator()(T thread_data) const
+  {
+    using warp_reduce_t = cub::WarpReduceBatchedBroadcast<T, Batches, LogicalWarpThreads, SyncPhysicalWarp>;
+
+    typename warp_reduce_t::TempStorage temp_storage;
+
+    ::cuda::std::array<T, Batches> inputs{};
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int batch = 0; batch < Batches; ++batch)
+    {
+      inputs[batch] = thread_data + static_cast<T>(batch);
+    }
+
+    return cub::ThreadReduce(warp_reduce_t{temp_storage}.Sum(inputs), ::cuda::std::plus<>{});
+  }
+};
+
+template <int Batches, int LogicalWarpThreads>
+struct serial_warp_reduce_broadcast_t
+{
+  template <typename T>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T operator()(T thread_data) const
+  {
+    using warp_reduce_t = cub::WarpReduce<T, LogicalWarpThreads>;
+
+    // This baseline intentionally models the straightforward user spelling:
+    // invoke WarpReduce once per batch, then explicitly broadcast each owner-lane aggregate.
+    // Its shared-memory footprint is therefore the cost of the serial CUB composition, not the new primitive.
+    __shared__ typename warp_reduce_t::TempStorage temp_storage[block_size / LogicalWarpThreads];
+
+    const int logical_block_warp_id = static_cast<int>(threadIdx.x) / LogicalWarpThreads;
+    const int logical_warp_id       = cub::detail::logical_warp_id<LogicalWarpThreads>();
+    const auto member_mask          = cub::WarpMask<LogicalWarpThreads>(logical_warp_id);
+
+    T result{};
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int batch = 0; batch < Batches; ++batch)
+    {
+      const T aggregate = warp_reduce_t{temp_storage[logical_block_warp_id]}.Sum(thread_data + static_cast<T>(batch));
+      result += cub::ShuffleIndex<LogicalWarpThreads>(aggregate, 0, member_mask);
+    }
+    return result;
+  }
+};
+
+using broadcast_variants = nvbench::type_list<
+  serial_warp_reduce_broadcast_t<1, 4>,
+  manual_batched_broadcast_t<1, 4>,
+  manual_batched_broadcast_t<1, 4, true>,
+  primitive_batched_broadcast_t<1, 4>,
+  primitive_batched_broadcast_t<1, 4, true>,
+  serial_warp_reduce_broadcast_t<4, 4>,
+  manual_batched_broadcast_t<4, 4>,
+  manual_batched_broadcast_t<4, 4, true>,
+  primitive_batched_broadcast_t<4, 4>,
+  primitive_batched_broadcast_t<4, 4, true>,
+  serial_warp_reduce_broadcast_t<5, 4>,
+  manual_batched_broadcast_t<5, 4>,
+  manual_batched_broadcast_t<5, 4, true>,
+  primitive_batched_broadcast_t<5, 4>,
+  primitive_batched_broadcast_t<5, 4, true>,
+  serial_warp_reduce_broadcast_t<4, 8>,
+  manual_batched_broadcast_t<4, 8>,
+  manual_batched_broadcast_t<4, 8, true>,
+  primitive_batched_broadcast_t<4, 8>,
+  primitive_batched_broadcast_t<4, 8, true>,
+  serial_warp_reduce_broadcast_t<4, 16>,
+  manual_batched_broadcast_t<4, 16>,
+  manual_batched_broadcast_t<4, 16, true>,
+  primitive_batched_broadcast_t<4, 16>,
+  primitive_batched_broadcast_t<4, 16, true>>;
+using value_types = nvbench::type_list<int, float, double>;
+
+template <typename BroadcastVariant, typename T>
+void warp_reduce_batched_broadcast(nvbench::state& state, nvbench::type_list<BroadcastVariant, T>)
+{
+  constexpr int unroll_factor = 128; // compromise between compile time and noise
+  const auto& kernel          = benchmark_kernel<block_size, unroll_factor, BroadcastVariant, T>;
+  const int num_SMs           = state.get_device().value().get_number_of_sms();
+  const int device            = state.get_device().value().get_id();
+  int max_blocks_per_SM       = 0;
+
+  NVBENCH_CUDA_CALL_NOEXCEPT(cudaSetDevice(device));
+  NVBENCH_CUDA_CALL_NOEXCEPT(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_blocks_per_SM, kernel, block_size, 0));
+
+  const int grid_size = max_blocks_per_SM * num_SMs;
+  if (grid_size == 0)
+  {
+    state.skip("Skipping: no resident blocks for this benchmark configuration.");
+    return;
+  }
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
+    kernel<<<grid_size, block_size, 0, launch.get_stream()>>>(BroadcastVariant{});
+  });
+}
+
+NVBENCH_BENCH_TYPES(warp_reduce_batched_broadcast, NVBENCH_TYPE_AXES(broadcast_variants, value_types))
+  .set_name("base")
+  .set_type_axes_names({"Variant{ct}", "T{ct}"});

--- a/cub/cub/cub.cuh
+++ b/cub/cub/cub.cuh
@@ -79,6 +79,7 @@
 #include <cub/warp/warp_load.cuh>
 #include <cub/warp/warp_merge_sort.cuh>
 #include <cub/warp/warp_reduce.cuh>
+#include <cub/warp/warp_reduce_batched_broadcast.cuh>
 #include <cub/warp/warp_scan.cuh>
 #include <cub/warp/warp_store.cuh>
 

--- a/cub/cub/warp/warp_reduce_batched_broadcast.cuh
+++ b/cub/cub/warp/warp_reduce_batched_broadcast.cuh
@@ -1,0 +1,298 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//! @file
+//! @rst
+//! The ``cub::WarpReduceBatchedBroadcast`` class provides :ref:`collective <collective-primitives>` methods for
+//! computing batched warp-wide reductions whose aggregates are returned to every participating logical lane.
+//! @endrst
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/detail/type_traits.cuh>
+#include <cub/util_ptx.cuh>
+#include <cub/warp/warp_utils.cuh>
+
+#include <cuda/__cmath/pow2.h>
+#include <cuda/std/__functional/operations.h>
+#include <cuda/std/__iterator/readable_traits.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/array>
+
+CUB_NAMESPACE_BEGIN
+
+//! @rst
+//! The ``WarpReduceBatchedBroadcast`` class provides :ref:`collective <collective-primitives>` methods for computing
+//! batched warp-wide reductions whose aggregates are returned to every participating logical lane.
+//!
+//! Overview
+//! ++++++++
+//!
+//! - Supports "logical" warps smaller than the physical warp size (e.g., logical warps of 8 threads).
+//! - Computes one independent reduction per batch.
+//! - Returns every batch aggregate to every participating logical lane.
+//! - The reduction operator must be commutative and associative. Use ``cub::WarpReduceBatched`` when aggregates only
+//!   need to be returned to the owner lanes.
+//!
+//! Performance Characteristics
+//! +++++++++++++++++++++++++++
+//!
+//! - Uses warp shuffle instructions only, with no explicit synchronization between butterfly stages and no shared
+//!   memory storage.
+//! - Avoids sequentially invoking one warp-wide all-reduce per batch.
+//! - For smaller than physical warp size logical warps, using ``SyncPhysicalWarp = true`` should in general give better
+//!   performance than ``SyncPhysicalWarp = false``.
+//!   Note that it can cause a deadlock if not all non-exited logical warps from the same physical warp participate in
+//!   the reduction (due to branches).
+//!   It also requires complete physical warps at the call site, and is unsafe for tail warps.
+//!
+//! Simple Example
+//! ++++++++++++++
+//!
+//! @warpcollective{WarpReduceBatchedBroadcast}
+//!
+//! The code snippet below illustrates three batched sums across two 4-thread logical warps:
+//!
+//! .. literalinclude:: ../../../cub/test/warp/catch2_test_warp_reduce_batched_broadcast_api.cu
+//!     :language: c++
+//!     :dedent:
+//!     :start-after: example-begin warp-reduce-batched-broadcast-overview
+//!     :end-before: example-end warp-reduce-batched-broadcast-overview
+//!
+//! @endrst
+//!
+//! @tparam T
+//!   The reduction input/output element type.
+//!
+//! @tparam Batches
+//!   The number of independent batches to reduce. Also corresponds to the size of the input and output ranges for each
+//!   thread.
+//!
+//! @tparam LogicalWarpThreads
+//!   **[optional]** The number of threads per "logical" warp (may be less than the number of hardware warp threads but
+//!   has to be a power of two). Default is the warp size of the targeted CUDA compute-capability (e.g., 32 threads for
+//!   SM80).
+//!
+//! @tparam SyncPhysicalWarp
+//!   **[optional]** When true, synchronize the physical warp instead of only the logical warp. This requires complete
+//!   physical warps at the call site, and all non-exited logical warps in each physical warp must participate.
+template <typename T, int Batches, int LogicalWarpThreads = detail::warp_threads, bool SyncPhysicalWarp = false>
+class WarpReduceBatchedBroadcast
+{
+  static_assert(Batches >= 0, "Batches must be >= 0");
+  static_assert(LogicalWarpThreads > 0 && LogicalWarpThreads <= detail::warp_threads,
+                "LogicalWarpThreads must be in the range [1, 32]");
+  static_assert(::cuda::is_power_of_two(LogicalWarpThreads), "LogicalWarpThreads must be a power of two");
+
+  template <typename InputT, typename OutputT, typename ReductionOp>
+  static _CCCL_DEVICE _CCCL_FORCEINLINE void check_constraints()
+  {
+    static_assert(cub::detail::is_fixed_size_random_access_range_v<InputT>,
+                  "InputT must support operator[] and have a compile-time size");
+    static_assert(cub::detail::is_fixed_size_random_access_range_v<OutputT>,
+                  "OutputT must support operator[] and have a compile-time size");
+    static_assert(cub::detail::static_size_v<InputT> == Batches, "Input size must match Batches");
+    static_assert(cub::detail::static_size_v<OutputT> == Batches, "Output size must match Batches");
+    static_assert(::cuda::std::is_same_v<::cuda::std::iter_value_t<InputT>, T>, "Input element type must match T");
+    static_assert(::cuda::std::is_same_v<::cuda::std::iter_value_t<OutputT>, T>, "Output element type must match T");
+    static_assert(cub::detail::has_binary_call_operator<ReductionOp, T>::value,
+                  "ReductionOp must have the binary call operator: operator(T, T)");
+  }
+
+  template <typename OutputT, typename ReductionOp>
+  static _CCCL_DEVICE _CCCL_FORCEINLINE void commutative_all_reduce(OutputT& outputs, ReductionOp reduction_op)
+  {
+    if constexpr (Batches == 0)
+    {
+      static_cast<void>(outputs);
+      static_cast<void>(reduction_op);
+      return;
+    }
+
+    const auto lane_id       = cub::detail::logical_lane_id<LogicalWarpThreads>();
+    unsigned int member_mask = 0xFFFFFFFFu;
+    if constexpr (!SyncPhysicalWarp)
+    {
+      const auto logical_warp_id = cub::detail::logical_warp_id<LogicalWarpThreads>();
+      member_mask                = cub::WarpMask<LogicalWarpThreads>(logical_warp_id);
+    }
+
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int offset = LogicalWarpThreads / 2; offset > 0; offset >>= 1)
+    {
+      _CCCL_PRAGMA_UNROLL_FULL()
+      for (int batch = 0; batch < Batches; ++batch)
+      {
+        const T peer   = cub::ShuffleIndex<LogicalWarpThreads>(outputs[batch], lane_id ^ offset, member_mask);
+        outputs[batch] = reduction_op(outputs[batch], peer);
+      }
+    }
+  }
+
+public:
+  //! \smemstorage{WarpReduceBatchedBroadcast}
+  //!
+  //! WarpReduceBatchedBroadcast uses only warp shuffle instructions, so this storage is an empty marker preserved for
+  //! CUB collective constructor symmetry.
+  struct TempStorage
+  {};
+
+  //! @name Collective constructors
+  //! @{
+
+  //! @rst
+  //! Collective constructor using the specified memory allocation as temporary storage.
+  //! Logical warp and lane identifiers are constructed from ``threadIdx.x``.
+  //! The storage object is an empty marker and does not consume shared memory.
+  //! @endrst
+  //!
+  //! @param[in] temp_storage Reference to memory allocation having layout type TempStorage
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE WarpReduceBatchedBroadcast(TempStorage& temp_storage)
+  {
+    static_cast<void>(temp_storage);
+  }
+
+  //! @}
+  //! @name Commutative reductions
+  //! @{
+
+  //! @rst
+  //! Computes one warp-wide reduction per batch and returns every aggregate to every participating logical lane.
+  //! The reduction operator must be commutative and associative.
+  //!
+  //! .. versionadded:: 3.5.0
+  //!    First appears in CUDA Toolkit 13.5.
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputT
+  //!   **[inferred]** Fixed-size random access range type containing this lane's input items.
+  //!
+  //! @tparam OutputT
+  //!   **[inferred]** Fixed-size random access range type receiving the batch aggregates for this lane.
+  //!
+  //! @tparam ReductionOp
+  //!   **[inferred]** Commutative binary reduction operator type having member
+  //!   ``T operator()(const T &a, const T &b)``.
+  //!
+  //! @param[in] inputs
+  //!   Statically-sized input range holding ``Batches`` items.
+  //!
+  //! @param[out] outputs
+  //!   Statically-sized output range receiving ``Batches`` aggregate items.
+  //!
+  //! @param[in] reduction_op
+  //!   Commutative binary reduction operator.
+  template <typename InputT, typename OutputT, typename ReductionOp>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void
+  CommutativeReduce(const InputT& inputs, OutputT& outputs, ReductionOp reduction_op) const
+  {
+    check_constraints<InputT, OutputT, ReductionOp>();
+
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int batch = 0; batch < Batches; ++batch)
+    {
+      outputs[batch] = inputs[batch];
+    }
+
+    commutative_all_reduce(outputs, reduction_op);
+  }
+
+  //! @rst
+  //! Computes one warp-wide reduction per batch and returns every aggregate to every participating logical lane.
+  //! The reduction operator must be commutative and associative.
+  //!
+  //! .. versionadded:: 3.5.0
+  //!    First appears in CUDA Toolkit 13.5.
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputT
+  //!   **[inferred]** Fixed-size random access range type containing this lane's input items.
+  //!
+  //! @tparam ReductionOp
+  //!   **[inferred]** Commutative binary reduction operator type having member
+  //!   ``T operator()(const T &a, const T &b)``.
+  //!
+  //! @param[in] inputs
+  //!   Statically-sized input range holding ``Batches`` items.
+  //!
+  //! @param[in] reduction_op
+  //!   Commutative binary reduction operator.
+  //!
+  //! @return
+  //!   The ``Batches`` warp-wide reduction aggregates.
+  template <typename InputT, typename ReductionOp>
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE ::cuda::std::array<T, Batches>
+  CommutativeReduce(const InputT& inputs, ReductionOp reduction_op) const
+  {
+    ::cuda::std::array<T, Batches> outputs;
+    CommutativeReduce(inputs, outputs, reduction_op);
+    return outputs;
+  }
+
+  //! @}
+  //! @name Sum reductions
+  //! @{
+
+  //! @rst
+  //! Computes one warp-wide sum per batch and returns every aggregate to every participating logical lane.
+  //!
+  //! .. versionadded:: 3.5.0
+  //!    First appears in CUDA Toolkit 13.5.
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputT
+  //!   **[inferred]** Fixed-size random access range type containing this lane's input items.
+  //!
+  //! @tparam OutputT
+  //!   **[inferred]** Fixed-size random access range type receiving the batch aggregates for this lane.
+  //!
+  //! @param[in] inputs
+  //!   Statically-sized input range holding ``Batches`` items.
+  //!
+  //! @param[out] outputs
+  //!   Statically-sized output range receiving ``Batches`` aggregate items.
+  template <typename InputT, typename OutputT>
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE void Sum(const InputT& inputs, OutputT& outputs) const
+  {
+    CommutativeReduce(inputs, outputs, ::cuda::std::plus<>{});
+  }
+
+  //! @rst
+  //! Computes one warp-wide sum per batch and returns every aggregate to every participating logical lane.
+  //!
+  //! .. versionadded:: 3.5.0
+  //!    First appears in CUDA Toolkit 13.5.
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputT
+  //!   **[inferred]** Fixed-size random access range type containing this lane's input items.
+  //!
+  //! @param[in] inputs
+  //!   Statically-sized input range holding ``Batches`` items.
+  //!
+  //! @return
+  //!   The ``Batches`` warp-wide sum aggregates.
+  template <typename InputT>
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE ::cuda::std::array<T, Batches> Sum(const InputT& inputs) const
+  {
+    return CommutativeReduce(inputs, ::cuda::std::plus<>{});
+  }
+
+  //! @}
+};
+
+CUB_NAMESPACE_END

--- a/cub/test/warp/catch2_test_warp_reduce_batched_broadcast.cu
+++ b/cub/test/warp/catch2_test_warp_reduce_batched_broadcast.cu
@@ -1,0 +1,585 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/warp/warp_reduce_batched_broadcast.cuh>
+
+#include <cuda/functional>
+#include <cuda/std/__functional/operations.h>
+#include <cuda/std/__limits/numeric_limits.h>
+#include <cuda/std/__type_traits/is_floating_point.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/array>
+#include <cuda/std/cstdint>
+
+#include <test_util.h>
+
+#include <c2h/catch2_test_helper.h>
+#include <c2h/check_results.cuh>
+#include <c2h/custom_type.h>
+#include <c2h/operator.cuh>
+
+inline constexpr int warp_size  = 32;
+inline constexpr int block_size = 2 * warp_size;
+
+enum class WarpReduceBatchedBroadcastMode
+{
+  Sum,
+  SumOutput,
+  CommutativeReduce,
+  CommutativeReduceOutput
+};
+
+using custom_t =
+  c2h::custom_type_t<c2h::accumulateable_t, c2h::equal_comparable_t, c2h::lexicographical_less_comparable_t>;
+
+template <typename T>
+inline constexpr bool is_ulonglong4_test_type_v =
+#if _CCCL_CTK_AT_LEAST(13, 0)
+  ::cuda::std::is_same_v<T, ulonglong4_16a>;
+#else // _CCCL_CTK_AT_LEAST(13, 0)
+  ::cuda::std::is_same_v<T, ulonglong4>;
+#endif // _CCCL_CTK_AT_LEAST(13, 0)
+
+template <typename T>
+inline constexpr bool has_unwritten_output_sentinel_v =
+  ::cuda::std::is_floating_point_v<T> || ::cuda::std::is_integral_v<T>;
+
+template <typename T>
+_CCCL_HOST_DEVICE T unwritten_output_sentinel()
+{
+  static_assert(has_unwritten_output_sentinel_v<T>, "The output sentinel is only defined for arithmetic test types");
+  if constexpr (::cuda::std::is_floating_point_v<T>)
+  {
+    return T{-123.25};
+  }
+  else
+  {
+    return ::cuda::std::numeric_limits<T>::max();
+  }
+}
+
+template <WarpReduceBatchedBroadcastMode Mode,
+          bool SyncPhysicalWarp,
+          int Batches,
+          int LogicalWarpThreads,
+          typename T,
+          typename ReductionOp>
+__global__ void warp_reduce_batched_broadcast_kernel(const T* input, T* output, ReductionOp reduction_op)
+{
+  using warp_reduce_t = cub::WarpReduceBatchedBroadcast<T, Batches, LogicalWarpThreads, SyncPhysicalWarp>;
+
+  typename warp_reduce_t::TempStorage temp_storage;
+
+  const int tid = static_cast<int>(threadIdx.x);
+
+  auto inputs = ::cuda::std::array<T, Batches>{};
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (int batch = 0; batch < Batches; ++batch)
+  {
+    inputs[batch] = input[tid * Batches + batch];
+  }
+
+  auto outputs = ::cuda::std::array<T, Batches>{};
+  if constexpr (Mode == WarpReduceBatchedBroadcastMode::SumOutput
+                || Mode == WarpReduceBatchedBroadcastMode::CommutativeReduceOutput)
+  {
+    if constexpr (has_unwritten_output_sentinel_v<T>)
+    {
+      _CCCL_PRAGMA_UNROLL_FULL()
+      for (int batch = 0; batch < Batches; ++batch)
+      {
+        outputs[batch] = unwritten_output_sentinel<T>();
+      }
+    }
+  }
+
+  if constexpr (Mode == WarpReduceBatchedBroadcastMode::Sum)
+  {
+    outputs = warp_reduce_t{temp_storage}.Sum(inputs);
+  }
+  else if constexpr (Mode == WarpReduceBatchedBroadcastMode::SumOutput)
+  {
+    warp_reduce_t{temp_storage}.Sum(inputs, outputs);
+  }
+  else if constexpr (Mode == WarpReduceBatchedBroadcastMode::CommutativeReduce)
+  {
+    outputs = warp_reduce_t{temp_storage}.CommutativeReduce(inputs, reduction_op);
+  }
+  else
+  {
+    warp_reduce_t{temp_storage}.CommutativeReduce(inputs, outputs, reduction_op);
+  }
+
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (int batch = 0; batch < Batches; ++batch)
+  {
+    output[tid * Batches + batch] = outputs[batch];
+  }
+}
+
+template <WarpReduceBatchedBroadcastMode Mode,
+          bool SyncPhysicalWarp,
+          int Batches,
+          int LogicalWarpThreads,
+          typename T,
+          typename ReductionOp>
+__global__ void warp_reduce_batched_broadcast_cond_part_kernel(const T* input, T* output, ReductionOp reduction_op)
+{
+  static_assert(LogicalWarpThreads < warp_size, "Need at least 2 logical warps per physical warp for this test");
+  static_assert(!SyncPhysicalWarp, "Divergent participation is only valid without physical-warp synchronization");
+  using warp_reduce_t = cub::WarpReduceBatchedBroadcast<T, Batches, LogicalWarpThreads, SyncPhysicalWarp>;
+
+  typename warp_reduce_t::TempStorage temp_storage;
+
+  const int tid               = static_cast<int>(threadIdx.x);
+  const int logical_warp_id   = tid / LogicalWarpThreads;
+  const bool is_participating = logical_warp_id % 2 == 0;
+
+  if (is_participating)
+  {
+    auto inputs = ::cuda::std::array<T, Batches>{};
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int batch = 0; batch < Batches; ++batch)
+    {
+      inputs[batch] = input[tid * Batches + batch];
+    }
+
+    auto outputs = ::cuda::std::array<T, Batches>{};
+    if constexpr (Mode == WarpReduceBatchedBroadcastMode::SumOutput
+                  || Mode == WarpReduceBatchedBroadcastMode::CommutativeReduceOutput)
+    {
+      _CCCL_PRAGMA_UNROLL_FULL()
+      for (int batch = 0; batch < Batches; ++batch)
+      {
+        outputs[batch] = unwritten_output_sentinel<T>();
+      }
+    }
+
+    if constexpr (Mode == WarpReduceBatchedBroadcastMode::Sum)
+    {
+      outputs = warp_reduce_t{temp_storage}.Sum(inputs);
+    }
+    else if constexpr (Mode == WarpReduceBatchedBroadcastMode::SumOutput)
+    {
+      warp_reduce_t{temp_storage}.Sum(inputs, outputs);
+    }
+    else if constexpr (Mode == WarpReduceBatchedBroadcastMode::CommutativeReduce)
+    {
+      outputs = warp_reduce_t{temp_storage}.CommutativeReduce(inputs, reduction_op);
+    }
+    else
+    {
+      warp_reduce_t{temp_storage}.CommutativeReduce(inputs, outputs, reduction_op);
+    }
+
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int batch = 0; batch < Batches; ++batch)
+    {
+      output[tid * Batches + batch] = outputs[batch];
+    }
+  }
+
+  if constexpr (!SyncPhysicalWarp)
+  {
+    // Re-converge the full physical warp after the divergent region to surface unexpected deadlocks.
+    __syncwarp();
+  }
+}
+
+template <typename T, int Batches>
+__global__ void warp_reduce_batched_broadcast_default_logical_warp_kernel(const T* input, T* output)
+{
+  using warp_reduce_t = cub::WarpReduceBatchedBroadcast<T, Batches>;
+
+  typename warp_reduce_t::TempStorage temp_storage;
+
+  const int tid = static_cast<int>(threadIdx.x);
+
+  auto inputs = ::cuda::std::array<T, Batches>{};
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (int batch = 0; batch < Batches; ++batch)
+  {
+    inputs[batch] = input[tid * Batches + batch];
+  }
+
+  const auto outputs = warp_reduce_t{temp_storage}.Sum(inputs);
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (int batch = 0; batch < Batches; ++batch)
+  {
+    output[tid * Batches + batch] = outputs[batch];
+  }
+}
+
+template <typename T, int MaxReductionItems>
+void gen_bounded_input(c2h::seed_t seed, c2h::device_vector<T>& input)
+{
+  if constexpr (::cuda::std::is_floating_point_v<T>)
+  {
+    c2h::gen(seed, input, T(0.5), T(1.5));
+  }
+  else if constexpr (::cuda::std::is_integral_v<T> && ::cuda::std::is_signed_v<T>)
+  {
+    const T gen_max = ::cuda::std::numeric_limits<T>::max() / static_cast<T>(MaxReductionItems + 1);
+    c2h::gen(seed, input, -gen_max, gen_max);
+  }
+  else if constexpr (::cuda::std::is_integral_v<T>)
+  {
+    const T gen_max = ::cuda::std::numeric_limits<T>::max() / static_cast<T>(MaxReductionItems + 1);
+    c2h::gen(seed, input, T(0), gen_max);
+  }
+  else if constexpr (is_ulonglong4_test_type_v<T>)
+  {
+    using component_t             = decltype(T::x);
+    const component_t gen_max     = ::cuda::std::numeric_limits<component_t>::max() / MaxReductionItems;
+    constexpr component_t gen_min = 0;
+    c2h::gen(seed, input, T{gen_min, gen_min, gen_min, gen_min}, T{gen_max, gen_max, gen_max, gen_max});
+  }
+  else if constexpr (::cuda::std::is_same_v<T, custom_t>)
+  {
+    T min{};
+    T max{};
+    max.key = 64 / MaxReductionItems;
+    max.val = 96 / MaxReductionItems;
+    c2h::gen(seed, input, min, max);
+  }
+  else
+  {
+    c2h::gen(seed, input);
+  }
+}
+
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_MSVC(4244) // numeric(33): C: '=': conversion from 'int' to '_Ty', possible loss of data
+
+template <int Batches, int LogicalWarpThreads, typename T, typename ReductionOp>
+void compute_host_reference(const c2h::host_vector<T>& input, c2h::host_vector<T>& reference, ReductionOp reduction_op)
+{
+  constexpr int num_logical_warps = block_size / LogicalWarpThreads;
+
+  for (int logical_warp = 0; logical_warp < num_logical_warps; ++logical_warp)
+  {
+    for (int batch = 0; batch < Batches; ++batch)
+    {
+      auto aggregate = identity_v<ReductionOp, T>;
+      for (int lane = 0; lane < LogicalWarpThreads; ++lane)
+      {
+        aggregate = reduction_op(aggregate, input[(logical_warp * LogicalWarpThreads + lane) * Batches + batch]);
+      }
+
+      for (int lane = 0; lane < LogicalWarpThreads; ++lane)
+      {
+        reference[(logical_warp * LogicalWarpThreads + lane) * Batches + batch] = static_cast<T>(aggregate);
+      }
+    }
+  }
+}
+
+template <int Batches, int LogicalWarpThreads, typename T, typename ReductionOp>
+void compute_cond_part_host_reference(
+  const c2h::host_vector<T>& input, c2h::host_vector<T>& reference, ReductionOp reduction_op)
+{
+  constexpr int num_logical_warps = block_size / LogicalWarpThreads;
+
+  for (int logical_warp = 0; logical_warp < num_logical_warps; logical_warp += 2)
+  {
+    for (int batch = 0; batch < Batches; ++batch)
+    {
+      auto aggregate = identity_v<ReductionOp, T>;
+      for (int lane = 0; lane < LogicalWarpThreads; ++lane)
+      {
+        aggregate = reduction_op(aggregate, input[(logical_warp * LogicalWarpThreads + lane) * Batches + batch]);
+      }
+
+      for (int lane = 0; lane < LogicalWarpThreads; ++lane)
+      {
+        reference[(logical_warp * LogicalWarpThreads + lane) * Batches + batch] = static_cast<T>(aggregate);
+      }
+    }
+  }
+}
+
+_CCCL_DIAG_POP
+
+template <WarpReduceBatchedBroadcastMode Mode,
+          bool SyncPhysicalWarp,
+          int Batches,
+          int LogicalWarpThreads,
+          typename T,
+          typename ReductionOp>
+void test_warp_reduce_batched_broadcast(ReductionOp reduction_op = ReductionOp{})
+{
+  CAPTURE(c2h::type_name<T>(), c2h::type_name<ReductionOp>(), Batches, LogicalWarpThreads, SyncPhysicalWarp);
+
+  c2h::device_vector<T> d_input(block_size * Batches);
+  gen_bounded_input<T, LogicalWarpThreads>(C2H_SEED(10), d_input);
+
+  c2h::device_vector<T> d_output(block_size * Batches);
+  warp_reduce_batched_broadcast_kernel<Mode, SyncPhysicalWarp, Batches, LogicalWarpThreads><<<1, block_size>>>(
+    thrust::raw_pointer_cast(d_input.data()), thrust::raw_pointer_cast(d_output.data()), reduction_op);
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  c2h::host_vector<T> h_input  = d_input;
+  c2h::host_vector<T> h_output = d_output;
+  c2h::host_vector<T> h_reference(h_input.size());
+
+  if constexpr (Mode == WarpReduceBatchedBroadcastMode::SumOutput
+                || Mode == WarpReduceBatchedBroadcastMode::CommutativeReduceOutput)
+  {
+    if constexpr (has_unwritten_output_sentinel_v<T>)
+    {
+      const T sentinel = unwritten_output_sentinel<T>();
+      for (const auto& item : h_output)
+      {
+        REQUIRE(item != sentinel);
+      }
+    }
+  }
+
+  compute_host_reference<Batches, LogicalWarpThreads>(h_input, h_reference, reduction_op);
+  verify_results(h_reference, h_output);
+}
+
+template <WarpReduceBatchedBroadcastMode Mode,
+          bool SyncPhysicalWarp,
+          int Batches,
+          int LogicalWarpThreads,
+          typename T,
+          typename ReductionOp>
+void test_warp_reduce_batched_broadcast_cond_participation(ReductionOp reduction_op = ReductionOp{})
+{
+  CAPTURE(c2h::type_name<T>(), c2h::type_name<ReductionOp>(), Batches, LogicalWarpThreads, SyncPhysicalWarp);
+
+  c2h::device_vector<T> d_input(block_size * Batches);
+  gen_bounded_input<T, LogicalWarpThreads>(C2H_SEED(12), d_input);
+
+  const T sentinel = unwritten_output_sentinel<T>();
+  c2h::device_vector<T> d_output(block_size * Batches, sentinel);
+  warp_reduce_batched_broadcast_cond_part_kernel<Mode, SyncPhysicalWarp, Batches, LogicalWarpThreads>
+    <<<1, block_size>>>(
+      thrust::raw_pointer_cast(d_input.data()), thrust::raw_pointer_cast(d_output.data()), reduction_op);
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  c2h::host_vector<T> h_input  = d_input;
+  c2h::host_vector<T> h_output = d_output;
+  c2h::host_vector<T> h_reference(block_size * Batches, sentinel);
+
+  compute_cond_part_host_reference<Batches, LogicalWarpThreads>(h_input, h_reference, reduction_op);
+  verify_results(h_reference, h_output);
+}
+
+using value_types = c2h::type_list<::cuda::std::uint16_t, ::cuda::std::int32_t, ::cuda::std::int64_t, float>;
+#if _CCCL_CTK_AT_LEAST(13, 0)
+using shuffle_value_types = c2h::type_list<ulonglong4_16a, custom_t>;
+#else // _CCCL_CTK_AT_LEAST(13, 0)
+using shuffle_value_types = c2h::type_list<ulonglong4, custom_t>;
+#endif // _CCCL_CTK_AT_LEAST(13, 0)
+using logical_warp_threads = c2h::enum_type_list<int, 32, 16, 8, 4, 2, 1>;
+// Divergent-participation coverage excludes full-warp groups because SyncPhysicalWarp=false is the behavior under test.
+using sub_warp_threads      = c2h::enum_type_list<int, 16, 8, 4, 2, 1>;
+using batch_counts          = c2h::enum_type_list<int, 1, 5>;
+using cond_part_value_types = c2h::type_list<::cuda::std::int32_t, float>;
+using reduction_ops         = c2h::type_list<::cuda::std::plus<>, ::cuda::maximum<>, ::cuda::minimum<>>;
+
+C2H_TEST("WarpReduceBatchedBroadcast uses the default logical warp size", "[warp][reduce][batched][default]")
+{
+  constexpr int num_batches = 3;
+
+  c2h::device_vector<int> d_input(block_size * num_batches);
+  gen_bounded_input<int, warp_size>(C2H_SEED(10), d_input);
+
+  c2h::device_vector<int> d_output(block_size * num_batches);
+  warp_reduce_batched_broadcast_default_logical_warp_kernel<int, num_batches>
+    <<<1, block_size>>>(thrust::raw_pointer_cast(d_input.data()), thrust::raw_pointer_cast(d_output.data()));
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  c2h::host_vector<int> h_input     = d_input;
+  c2h::host_vector<int> h_output    = d_output;
+  c2h::host_vector<int> h_reference = d_output;
+
+  compute_host_reference<num_batches, warp_size>(h_input, h_reference, ::cuda::std::plus<>{});
+  verify_results(h_reference, h_output);
+}
+
+C2H_TEST("WarpReduceBatchedBroadcast::Sum returns every batch to every lane",
+         "[warp][reduce][batched]",
+         value_types,
+         logical_warp_threads,
+         batch_counts)
+{
+  using value_t                          = typename c2h::get<0, TestType>;
+  constexpr int logical_warp_num_threads = c2h::get<1, TestType>::value;
+  constexpr int num_batches              = c2h::get<2, TestType>::value;
+  constexpr bool sync_physical_warp      = false;
+
+  test_warp_reduce_batched_broadcast<WarpReduceBatchedBroadcastMode::Sum,
+                                     sync_physical_warp,
+                                     num_batches,
+                                     logical_warp_num_threads,
+                                     value_t,
+                                     ::cuda::std::plus<>>();
+  test_warp_reduce_batched_broadcast<WarpReduceBatchedBroadcastMode::SumOutput,
+                                     sync_physical_warp,
+                                     num_batches,
+                                     logical_warp_num_threads,
+                                     value_t,
+                                     ::cuda::std::plus<>>();
+
+  if constexpr (logical_warp_num_threads < warp_size)
+  {
+    constexpr bool sync_physical_warp_smoke = true;
+    test_warp_reduce_batched_broadcast<WarpReduceBatchedBroadcastMode::Sum,
+                                       sync_physical_warp_smoke,
+                                       num_batches,
+                                       logical_warp_num_threads,
+                                       value_t,
+                                       ::cuda::std::plus<>>();
+    test_warp_reduce_batched_broadcast<WarpReduceBatchedBroadcastMode::SumOutput,
+                                       sync_physical_warp_smoke,
+                                       num_batches,
+                                       logical_warp_num_threads,
+                                       value_t,
+                                       ::cuda::std::plus<>>();
+  }
+}
+
+C2H_TEST("WarpReduceBatchedBroadcast::CommutativeReduce returns every batch to every lane",
+         "[warp][reduce][batched]",
+         value_types,
+         logical_warp_threads,
+         batch_counts,
+         reduction_ops)
+{
+  using value_t                          = typename c2h::get<0, TestType>;
+  constexpr int logical_warp_num_threads = c2h::get<1, TestType>::value;
+  constexpr int num_batches              = c2h::get<2, TestType>::value;
+  using op_t                             = typename c2h::get<3, TestType>;
+
+  test_warp_reduce_batched_broadcast<WarpReduceBatchedBroadcastMode::CommutativeReduce,
+                                     false,
+                                     num_batches,
+                                     logical_warp_num_threads,
+                                     value_t,
+                                     op_t>();
+  test_warp_reduce_batched_broadcast<WarpReduceBatchedBroadcastMode::CommutativeReduceOutput,
+                                     false,
+                                     num_batches,
+                                     logical_warp_num_threads,
+                                     value_t,
+                                     op_t>();
+
+  if constexpr (logical_warp_num_threads < warp_size)
+  {
+    test_warp_reduce_batched_broadcast<WarpReduceBatchedBroadcastMode::CommutativeReduce,
+                                       true,
+                                       num_batches,
+                                       logical_warp_num_threads,
+                                       value_t,
+                                       op_t>();
+    test_warp_reduce_batched_broadcast<WarpReduceBatchedBroadcastMode::CommutativeReduceOutput,
+                                       true,
+                                       num_batches,
+                                       logical_warp_num_threads,
+                                       value_t,
+                                       op_t>();
+  }
+}
+
+C2H_TEST("WarpReduceBatchedBroadcast covers common batch counts", "[warp][reduce][batched]")
+{
+  test_warp_reduce_batched_broadcast<WarpReduceBatchedBroadcastMode::Sum,
+                                     false,
+                                     2,
+                                     4,
+                                     ::cuda::std::int32_t,
+                                     ::cuda::std::plus<>>();
+  test_warp_reduce_batched_broadcast<WarpReduceBatchedBroadcastMode::SumOutput,
+                                     false,
+                                     2,
+                                     4,
+                                     ::cuda::std::int32_t,
+                                     ::cuda::std::plus<>>();
+  test_warp_reduce_batched_broadcast<WarpReduceBatchedBroadcastMode::CommutativeReduce,
+                                     false,
+                                     4,
+                                     8,
+                                     float,
+                                     ::cuda::std::plus<>>();
+  test_warp_reduce_batched_broadcast<WarpReduceBatchedBroadcastMode::CommutativeReduceOutput,
+                                     false,
+                                     4,
+                                     8,
+                                     float,
+                                     ::cuda::std::plus<>>();
+}
+
+C2H_TEST("WarpReduceBatchedBroadcast handles divergent logical-warp participation",
+         "[warp][reduce][batched]",
+         cond_part_value_types,
+         sub_warp_threads,
+         batch_counts,
+         reduction_ops)
+{
+  using value_t                          = typename c2h::get<0, TestType>;
+  constexpr int logical_warp_num_threads = c2h::get<1, TestType>::value;
+  constexpr int num_batches              = c2h::get<2, TestType>::value;
+  using op_t                             = typename c2h::get<3, TestType>;
+
+  test_warp_reduce_batched_broadcast_cond_participation<
+    WarpReduceBatchedBroadcastMode::Sum,
+    false,
+    num_batches,
+    logical_warp_num_threads,
+    value_t,
+    ::cuda::std::plus<>>();
+  test_warp_reduce_batched_broadcast_cond_participation<
+    WarpReduceBatchedBroadcastMode::SumOutput,
+    false,
+    num_batches,
+    logical_warp_num_threads,
+    value_t,
+    ::cuda::std::plus<>>();
+  test_warp_reduce_batched_broadcast_cond_participation<
+    WarpReduceBatchedBroadcastMode::CommutativeReduce,
+    false,
+    num_batches,
+    logical_warp_num_threads,
+    value_t,
+    op_t>();
+  test_warp_reduce_batched_broadcast_cond_participation<
+    WarpReduceBatchedBroadcastMode::CommutativeReduceOutput,
+    false,
+    num_batches,
+    logical_warp_num_threads,
+    value_t,
+    op_t>();
+}
+
+C2H_TEST("WarpReduceBatchedBroadcast handles multi-word shuffled value types",
+         "[warp][reduce][batched]",
+         shuffle_value_types)
+{
+  using value_t = typename c2h::get<0, TestType>;
+
+  test_warp_reduce_batched_broadcast<WarpReduceBatchedBroadcastMode::Sum, false, 4, 4, value_t, ::cuda::std::plus<>>();
+  test_warp_reduce_batched_broadcast<WarpReduceBatchedBroadcastMode::SumOutput, false, 4, 4, value_t, ::cuda::std::plus<>>();
+  test_warp_reduce_batched_broadcast<WarpReduceBatchedBroadcastMode::CommutativeReduce,
+                                     false,
+                                     4,
+                                     4,
+                                     value_t,
+                                     ::cuda::std::plus<>>();
+  test_warp_reduce_batched_broadcast<WarpReduceBatchedBroadcastMode::CommutativeReduceOutput,
+                                     false,
+                                     4,
+                                     4,
+                                     value_t,
+                                     ::cuda::std::plus<>>();
+}

--- a/cub/test/warp/catch2_test_warp_reduce_batched_broadcast_api.cu
+++ b/cub/test/warp/catch2_test_warp_reduce_batched_broadcast_api.cu
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/warp/warp_reduce_batched_broadcast.cuh>
+
+#include <thrust/detail/raw_pointer_cast.h>
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+#include <cuda/std/array>
+
+#include <c2h/catch2_test_helper.h>
+
+__global__ __launch_bounds__(8) void WarpReduceBatchedBroadcastOverviewKernel(int* out)
+{
+  // example-begin warp-reduce-batched-broadcast-overview
+  constexpr int num_batches          = 3;
+  constexpr int logical_warp_threads = 4;
+  using WarpReduceBatchedBroadcast   = cub::WarpReduceBatchedBroadcast<int, num_batches, logical_warp_threads>;
+
+  typename WarpReduceBatchedBroadcast::TempStorage temp_storage;
+
+  const int tid = static_cast<int>(threadIdx.x);
+
+  const cuda::std::array<int, num_batches> inputs{tid - 1, tid, tid + 1};
+  cuda::std::array<int, num_batches> results = WarpReduceBatchedBroadcast{temp_storage}.Sum(inputs);
+  // results across threads:
+  // [{2, 6, 10}, {2, 6, 10}, {2, 6, 10}, {2, 6, 10},
+  //  {18, 22, 26}, {18, 22, 26}, {18, 22, 26}, {18, 22, 26}]
+  // example-end warp-reduce-batched-broadcast-overview
+
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (int batch = 0; batch < num_batches; ++batch)
+  {
+    out[tid * num_batches + batch] = results[batch];
+  }
+}
+
+C2H_TEST("WarpReduceBatchedBroadcast overview documentation kernel", "[warp][reduce][batched]")
+{
+  constexpr int num_threads = 8;
+  constexpr int num_batches = 3;
+  c2h::device_vector<int> d_out(num_threads * num_batches);
+
+  WarpReduceBatchedBroadcastOverviewKernel<<<1, num_threads>>>(thrust::raw_pointer_cast(d_out.data()));
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  c2h::host_vector<int> expected(num_threads * num_batches);
+  for (int tid = 0; tid < num_threads; ++tid)
+  {
+    const int logical_warp_id       = tid / 4;
+    expected[tid * num_batches]     = 2 + logical_warp_id * 16;
+    expected[tid * num_batches + 1] = 6 + logical_warp_id * 16;
+    expected[tid * num_batches + 2] = 10 + logical_warp_id * 16;
+  }
+  REQUIRE(expected == d_out);
+}
+
+__global__ __launch_bounds__(8) void WarpReduceBatchedBroadcastCArraysKernel(int* out)
+{
+  constexpr int num_batches          = 3;
+  constexpr int logical_warp_threads = 4;
+  using WarpReduceBatchedBroadcast   = cub::WarpReduceBatchedBroadcast<int, num_batches, logical_warp_threads>;
+
+  typename WarpReduceBatchedBroadcast::TempStorage temp_storage;
+
+  const int tid = static_cast<int>(threadIdx.x);
+
+  const int inputs[num_batches] = {tid - 1, tid, tid + 1};
+  int results[num_batches];
+  WarpReduceBatchedBroadcast{temp_storage}.Sum(inputs, results);
+
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (int batch = 0; batch < num_batches; ++batch)
+  {
+    out[tid * num_batches + batch] = results[batch];
+  }
+}
+
+C2H_TEST("WarpReduceBatchedBroadcast accepts C arrays", "[warp][reduce][batched]")
+{
+  constexpr int num_threads = 8;
+  constexpr int num_batches = 3;
+  c2h::device_vector<int> d_out(num_threads * num_batches);
+
+  WarpReduceBatchedBroadcastCArraysKernel<<<1, num_threads>>>(thrust::raw_pointer_cast(d_out.data()));
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  c2h::host_vector<int> expected(num_threads * num_batches);
+  for (int tid = 0; tid < num_threads; ++tid)
+  {
+    const int logical_warp_id       = tid / 4;
+    expected[tid * num_batches]     = 2 + logical_warp_id * 16;
+    expected[tid * num_batches + 1] = 6 + logical_warp_id * 16;
+    expected[tid * num_batches + 2] = 10 + logical_warp_id * 16;
+  }
+  REQUIRE(expected == d_out);
+}
+
+__global__ __launch_bounds__(4) void WarpReduceBatchedBroadcastZeroBatchesKernel(int* out)
+{
+  constexpr int num_batches          = 0;
+  constexpr int logical_warp_threads = 4;
+  using WarpReduceBatchedBroadcast   = cub::WarpReduceBatchedBroadcast<int, num_batches, logical_warp_threads>;
+
+  typename WarpReduceBatchedBroadcast::TempStorage temp_storage;
+
+  cuda::std::array<int, num_batches> inputs{};
+  cuda::std::array<int, num_batches> results = WarpReduceBatchedBroadcast{temp_storage}.Sum(inputs);
+  WarpReduceBatchedBroadcast{temp_storage}.Sum(inputs, results);
+
+  if (threadIdx.x == 0)
+  {
+    out[0] = static_cast<int>(results.size());
+  }
+}
+
+C2H_TEST("WarpReduceBatchedBroadcast accepts zero batches", "[warp][reduce][batched]")
+{
+  c2h::device_vector<int> d_out(1, -1);
+
+  WarpReduceBatchedBroadcastZeroBatchesKernel<<<1, 4>>>(thrust::raw_pointer_cast(d_out.data()));
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  REQUIRE(d_out[0] == 0);
+}

--- a/docs/cub/api_docs/warp_wide.rst
+++ b/docs/cub/api_docs/warp_wide.rst
@@ -18,5 +18,7 @@ These algorithms may only be invoked by ``1 <= n <= 32`` *consecutive* threads i
 * :cpp:class:`cub::WarpMergeSort` sorts items partitioned across a CUDA warp
 * :cpp:struct:`cub::WarpReduce` computes reduction of items partitioned across a CUDA warp
 * :cpp:struct:`cub::WarpReduceBatched` computes reduction of multiple batches of items partitioned across a CUDA warp
+* :cpp:class:`cub::WarpReduceBatchedBroadcast` computes batched reductions and returns every batch aggregate to every
+  participating logical lane
 * :cpp:struct:`cub::WarpScan` computes a prefix scan of items partitioned across a CUDA warp
 * :cpp:class:`cub::WarpStore` stores items partitioned across a CUDA warp to a linear segment of memory


### PR DESCRIPTION
## Summary

Adds `cub::WarpReduceBatchedBroadcast`, a batched warp collective that reduces multiple independent values per lane and returns each aggregate to every lane in the logical warp.

This captures the common norm-style pattern of several same-shape warp reductions followed by explicit broadcasts, without requiring each caller to hand-write the lane exchange code.

## Why this primitive

A lot of modern kernels reduce a small fixed bundle of values under the same warp topology: multiple tokens, vector lanes, scale candidates, or independent statistics. Implementations usually write a loop around a scalar warp reduction, which duplicates shuffle control flow and makes it harder for DSL frontends to express the operation as one reusable primitive.

Concrete OSS patterns this can replace or simplify:

- vLLM's MiniMax RMS kernel has `warpReduceSumV2<T, NUM>` and `local_warp_reduce_sum_array<..., ArraySize = 4>`, both of which manually repeat the same `__shfl_xor_sync` reduction for each independent value: https://github.com/vllm-project/vllm/blob/2ee51063722c9e6d28f71340966942394f330c0e/csrc/libtorch_stable/minimax_reduce_rms_kernel.cu#L132-L182
- The same vLLM float4 path reduces four token rows at once through a `float warp_sum_variance[4]` bundle before publishing per-row totals: https://github.com/vllm-project/vllm/blob/2ee51063722c9e6d28f71340966942394f330c0e/csrc/libtorch_stable/minimax_reduce_rms_kernel.cu#L420-L469
- FlashInfer's CuTe helper handles tensor-valued warp reductions by looping over elements and recursively reducing each one: https://github.com/flashinfer-ai/flashinfer/blob/97b7de6846e72a9f5cbb536ac8eff04d2e9535bb/flashinfer/norm/utils.py#L399-L407

This gives CUB and cuda.coop frontends a natural target for those fixed-size bundles instead of forcing every project to rebuild the same batched shuffle loop.

## Validation

- `git diff --check`
- `pre-commit run --files cub/cub/warp/warp_reduce_batched_broadcast.cuh cub/test/catch2_test_warp_reduce_batched_broadcast.cu cub/test/catch2_test_warp_reduce_batched_broadcast_api.cu cub/benchmarks/bench/reduce/warp_reduce_batched_broadcast.cu`
- `bash ci/util/build_and_test_targets.sh --preset cub-cpp20 --build-targets "cub.headers.base cub.test.warp.reduce_batched_broadcast cub.test.warp.reduce_batched_broadcast_api" --ctest-targets "'^cub\\.test\\.warp\\.reduce_batched_broadcast$' '^cub\\.test\\.warp\\.reduce_batched_broadcast_api$'"`
  - Passed: 709,710 assertions in 256 test cases for the main test, plus 6 assertions in 2 API test cases.
- Benchmark smoke on NVIDIA RTX PRO 6000 Blackwell Workstation Edition:
  - `cmake --build build/cub-benchmark --target cub.bench.reduce.warp_reduce_batched_broadcast.base -j "$(nproc)" && ./build/cub-benchmark/bin/cub.bench.reduce.warp_reduce_batched_broadcast.base --devices 0 --profile --timeout 5 --min-samples 1 --min-time 0.001`
  - Passed 75/75 cases.

## Local Review

- Local roborev branch reviews with Gemini, Codex, and Claude: no issues found.
