### PR TITLE
Add CUB BlockReduceBroadcast

### DIFF
--- a/cub/benchmarks/bench/reduce/block_reduce_broadcast.cu
+++ b/cub/benchmarks/bench/reduce/block_reduce_broadcast.cu
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// The manual baseline intentionally uses BlockReduce directly.
+#include <cub/block/block_reduce.cuh>
+#include <cub/block/block_reduce_broadcast.cuh>
+#include <cub/detail/uninitialized_copy.cuh>
+#include <cub/util_type.cuh>
+
+#include <cuda/std/type_traits>
+
+#include <cuda_runtime_api.h>
+#include <device_side_benchmark.cuh>
+#include <nvbench_helper.cuh>
+
+struct manual_broadcast_t
+{
+  template <int BlockThreads, cub::BlockReduceAlgorithm Algorithm, typename T>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T operator()(T thread_data) const
+  {
+    using block_reduce_t = cub::BlockReduce<T, BlockThreads, Algorithm>;
+
+    struct temp_storage_t
+    {
+      typename block_reduce_t::TempStorage reduce;
+      cub::Uninitialized<T> aggregate;
+    };
+
+    __shared__ temp_storage_t temp_storage;
+
+    const T aggregate = block_reduce_t{temp_storage.reduce}.Sum(thread_data);
+    if (cub::RowMajorTid(BlockThreads, 1, 1) == 0)
+    {
+      cub::detail::uninitialized_copy_single(&temp_storage.aggregate.Alias(), aggregate);
+    }
+    __syncthreads();
+
+    const T result = temp_storage.aggregate.Alias();
+    __syncthreads();
+    return result;
+  }
+};
+
+struct primitive_broadcast_t
+{
+  template <int BlockThreads, cub::BlockReduceAlgorithm Algorithm, typename T>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T operator()(T thread_data) const
+  {
+    using block_reduce_t = cub::BlockReduceBroadcast<T, BlockThreads, Algorithm>;
+
+    __shared__ typename block_reduce_t::TempStorage temp_storage;
+
+    return block_reduce_t{temp_storage}.Sum(thread_data);
+  }
+};
+
+template <typename BroadcastVariant, int BlockThreads, cub::BlockReduceAlgorithm Algorithm>
+struct broadcast_action_t
+{
+  template <typename T>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T operator()(T thread_data) const
+  {
+    return BroadcastVariant{}.template operator()<BlockThreads, Algorithm>(thread_data);
+  }
+};
+
+template <int BlockThreads>
+using block_size_t = ::cuda::std::integral_constant<int, BlockThreads>;
+
+template <cub::BlockReduceAlgorithm Algorithm>
+using algorithm_t = ::cuda::std::integral_constant<cub::BlockReduceAlgorithm, Algorithm>;
+
+using broadcast_variants = nvbench::type_list<manual_broadcast_t, primitive_broadcast_t>;
+using value_types        = nvbench::type_list<int, float, double>;
+using block_sizes        = nvbench::type_list<block_size_t<128>, block_size_t<256>, block_size_t<512>>;
+using algorithms =
+  nvbench::type_list<algorithm_t<cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING>,
+                     algorithm_t<cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY>,
+                     algorithm_t<cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS>,
+                     algorithm_t<cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC>>;
+
+template <typename BroadcastVariant, typename T, typename BlockThreadsT, typename AlgorithmT>
+void block_reduce_broadcast(nvbench::state& state, nvbench::type_list<BroadcastVariant, T, BlockThreadsT, AlgorithmT>)
+{
+  constexpr int block_size    = BlockThreadsT::value;
+  constexpr auto algorithm    = AlgorithmT::value;
+  constexpr int unroll_factor = 64; // compromise between compile time and noise
+  using action_t              = broadcast_action_t<BroadcastVariant, block_size, algorithm>;
+  const auto& kernel          = benchmark_kernel<block_size, unroll_factor, action_t, T>;
+  const int num_sms           = state.get_device().value().get_number_of_sms();
+  int max_blocks_per_sm       = 0;
+
+  NVBENCH_CUDA_CALL_NOEXCEPT(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_blocks_per_sm, kernel, block_size, 0));
+  if (max_blocks_per_sm <= 0)
+  {
+    state.skip("Skipping: benchmark kernel does not fit on the selected device.");
+    return;
+  }
+
+  const int grid_size = max_blocks_per_sm * num_sms;
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
+    kernel<<<grid_size, block_size, 0, launch.get_stream()>>>(action_t{});
+  });
+}
+
+NVBENCH_BENCH_TYPES(block_reduce_broadcast, NVBENCH_TYPE_AXES(broadcast_variants, value_types, block_sizes, algorithms))
+  .set_name("block_reduce_broadcast")
+  .set_type_axes_names({"Variant{ct}", "T{ct}", "BlockThreads{ct}", "Algorithm{ct}"});

--- a/cub/cub/block/block_reduce_broadcast.cuh
+++ b/cub/cub/block/block_reduce_broadcast.cuh
@@ -1,0 +1,322 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//! @file
+//! @rst
+//! The ``cub::BlockReduceBroadcast`` class provides :ref:`collective <collective-primitives>` methods for computing
+//! block-wide reductions whose aggregate is returned to every thread in the block.
+//! @endrst
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/block/block_reduce.cuh>
+#include <cub/detail/uninitialized_copy.cuh>
+#include <cub/util_ptx.cuh>
+#include <cub/util_type.cuh>
+
+#include <cuda/std/__type_traits/is_trivially_destructible.h>
+
+CUB_NAMESPACE_BEGIN
+
+//! @rst
+//! The ``BlockReduceBroadcast`` class provides :ref:`collective <collective-primitives>` methods for computing
+//! block-wide reductions whose aggregate is returned to every thread in the block.
+//!
+//! .. versionadded:: 3.5.0
+//!    First appears in CUDA Toolkit 13.5.
+//!
+//! Overview
+//! ++++++++
+//!
+//! - Supports all ``cub::BlockReduce`` algorithms; ``BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC`` is restricted to
+//!   the ``Sum(input)`` and ``Sum(inputs)`` overloads.
+//! - Preserves ``BlockReduce`` reduction ordering for the selected algorithm.
+//! - Broadcasts the aggregate through temporary storage so every thread receives the same return value.
+//! - This primitive is useful for kernels that need the aggregate in every thread and would otherwise call
+//!   ``BlockReduce`` followed by an explicit shared-memory broadcast.
+//! - The broadcast aggregate uses placement construction in shared storage and requires trivially destructible ``T``.
+//!
+//! Performance Characteristics
+//! +++++++++++++++++++++++++++
+//!
+//! - Reuses ``BlockReduce`` for the reduction phase.
+//! - Adds one shared-memory store and two block barriers to make the aggregate available to all threads.
+//! - Requires the same reduction temporary storage as ``BlockReduce`` plus one aggregate item.
+//!
+//! @blockcollective{BlockReduceBroadcast}
+//!
+//! Simple Example
+//! ++++++++++++++
+//!
+//! .. code-block:: c++
+//!
+//!    using BlockReduceBroadcast = cub::BlockReduceBroadcast<int, 128>;
+//!    __shared__ typename BlockReduceBroadcast::TempStorage temp_storage;
+//!
+//!    int thread_data = ...;
+//!    int block_sum = BlockReduceBroadcast(temp_storage).Sum(thread_data);
+//!    // block_sum is valid in every thread in the block.
+//!
+//! @endrst
+//!
+//! @tparam T
+//!   The reduction input/output element type. Must be trivially destructible because the broadcast aggregate is
+//!   placement-constructed in temporary shared storage that may be reused by later collective calls.
+//!
+//! @tparam BlockDimX
+//!   The thread block length in threads along the X dimension.
+//!
+//! @tparam Algorithm
+//!   **[optional]** The ``cub::BlockReduceAlgorithm`` specialization to use
+//!   (default: ``cub::BLOCK_REDUCE_WARP_REDUCTIONS``).
+//!
+//! @tparam BlockDimY
+//!   **[optional]** The thread block length in threads along the Y dimension (default: 1).
+//!
+//! @tparam BlockDimZ
+//!   **[optional]** The thread block length in threads along the Z dimension (default: 1).
+template <typename T,
+          int BlockDimX,
+          BlockReduceAlgorithm Algorithm = BLOCK_REDUCE_WARP_REDUCTIONS,
+          int BlockDimY                  = 1,
+          int BlockDimZ                  = 1>
+class BlockReduceBroadcast
+{
+  using BlockReduceT                        = BlockReduce<T, BlockDimX, Algorithm, BlockDimY, BlockDimZ>;
+  static constexpr bool IS_NONDETERMINISTIC = Algorithm == BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC;
+
+  static_assert(::cuda::std::is_trivially_destructible_v<T>,
+                "BlockReduceBroadcast requires a trivially destructible value type because it reuses shared "
+                "TempStorage without destroying previous broadcast aggregates");
+
+  template <bool IsSupported>
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE static constexpr void AssertAlgorithmSupportsOverload()
+  {
+    static_assert(IsSupported,
+                  "BlockReduceBroadcast supports BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC only for Sum(input) "
+                  "and Sum(inputs) overloads; Reduce and partial Sum overloads are unsupported");
+  }
+
+  struct _TempStorage
+  {
+    typename BlockReduceT::TempStorage reduce;
+    Uninitialized<T> aggregate;
+  };
+
+  //! Shared storage reference.
+  _TempStorage& temp_storage;
+
+  //! Linear thread id in row-major order.
+  unsigned int linear_tid;
+
+  //! Internal storage allocator.
+  _CCCL_DEVICE _CCCL_FORCEINLINE _TempStorage& PrivateStorage()
+  {
+    __shared__ _TempStorage private_storage;
+    return private_storage;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE _CCCL_FORCEINLINE T BroadcastAggregate(T aggregate)
+  {
+    if (linear_tid == 0)
+    {
+      detail::uninitialized_copy_single(&temp_storage.aggregate.Alias(), aggregate);
+    }
+    __syncthreads();
+
+    const T result = temp_storage.aggregate.Alias();
+    __syncthreads();
+    return result;
+  }
+
+public:
+  //! @smemstorage{BlockReduceBroadcast}
+  struct TempStorage : Uninitialized<_TempStorage>
+  {};
+
+  //! @name Collective constructors
+  //! @{
+
+  //! @rst
+  //! Collective constructor using a private static allocation of shared memory as temporary storage.
+  //! @endrst
+  _CCCL_DEVICE _CCCL_FORCEINLINE BlockReduceBroadcast()
+      : temp_storage(PrivateStorage())
+      , linear_tid(RowMajorTid(BlockDimX, BlockDimY, BlockDimZ))
+  {}
+
+  //! @rst
+  //! Collective constructor using the specified memory allocation as temporary storage.
+  //! @endrst
+  //!
+  //! @param[in] temp_storage Reference to memory allocation having layout type TempStorage
+  _CCCL_DEVICE _CCCL_FORCEINLINE BlockReduceBroadcast(TempStorage& temp_storage)
+      : temp_storage(temp_storage.Alias())
+      , linear_tid(RowMajorTid(BlockDimX, BlockDimY, BlockDimZ))
+  {}
+
+  //! @}
+  //! @name Generic reductions
+  //! @{
+
+  //! @rst
+  //! Computes a block-wide reduction using the specified binary reduction functor and returns the aggregate to every
+  //! thread in the block.
+  //!
+  //! @smemreuse
+  //! @endrst
+  //!
+  //! @tparam ReductionOp
+  //!   **[inferred]** Binary reduction operator type having member ``T operator()(const T &a, const T &b)``.
+  //!
+  //! @param[in] input
+  //!   Calling thread's input item.
+  //!
+  //! @param[in] reduction_op
+  //!   Binary reduction operator.
+  //!
+  //! @return
+  //!   The block-wide reduction aggregate, returned in every thread in the block.
+  template <typename ReductionOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T Reduce(T input, ReductionOp reduction_op)
+  {
+    AssertAlgorithmSupportsOverload<!IS_NONDETERMINISTIC>();
+    return BroadcastAggregate(BlockReduceT{temp_storage.reduce}.Reduce(input, reduction_op));
+  }
+
+  //! @rst
+  //! Computes a block-wide reduction of multiple items per thread in a blocked arrangement and returns the aggregate to
+  //! every thread in the block.
+  //!
+  //! - @granularity
+  //! @smemreuse
+  //! @endrst
+  //!
+  //! @tparam ItemsPerThread
+  //!   **[inferred]** The number of input items per thread.
+  //!
+  //! @tparam ReductionOp
+  //!   **[inferred]** Binary reduction operator type having member ``T operator()(const T &a, const T &b)``.
+  //!
+  //! @param[in] inputs
+  //!   Calling thread's input items.
+  //!
+  //! @param[in] reduction_op
+  //!   Binary reduction operator.
+  //!
+  //! @return
+  //!   The block-wide reduction aggregate, returned in every thread in the block.
+  template <int ItemsPerThread, typename ReductionOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T Reduce(T (&inputs)[ItemsPerThread], ReductionOp reduction_op)
+  {
+    AssertAlgorithmSupportsOverload<!IS_NONDETERMINISTIC>();
+    return BroadcastAggregate(BlockReduceT{temp_storage.reduce}.Reduce(inputs, reduction_op));
+  }
+
+  //! @rst
+  //! Computes a block-wide reduction of up to ``num_valid`` threads and returns the aggregate to every thread in the
+  //! block.
+  //!
+  //! @smemreuse
+  //! @endrst
+  //!
+  //! @tparam ReductionOp
+  //!   **[inferred]** Binary reduction operator type having member ``T operator()(const T &a, const T &b)``.
+  //!
+  //! @param[in] input
+  //!   Calling thread's input item.
+  //!
+  //! @param[in] reduction_op
+  //!   Binary reduction operator.
+  //!
+  //! @param[in] num_valid
+  //!   Number of threads containing valid elements (may be less than the number of threads in the block).
+  //!
+  //! @return
+  //!   The block-wide reduction aggregate, returned in every thread in the block.
+  template <typename ReductionOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T Reduce(T input, ReductionOp reduction_op, int num_valid)
+  {
+    AssertAlgorithmSupportsOverload<!IS_NONDETERMINISTIC>();
+    return BroadcastAggregate(BlockReduceT{temp_storage.reduce}.Reduce(input, reduction_op, num_valid));
+  }
+
+  //! @}
+  //! @name Sum reductions
+  //! @{
+
+  //! @rst
+  //! Computes a block-wide sum of one item per thread and returns the aggregate to every thread in the block.
+  //!
+  //! @smemreuse
+  //! @endrst
+  //!
+  //! @param[in] input
+  //!   Calling thread's input item.
+  //!
+  //! @return
+  //!   The block-wide sum, returned in every thread in the block.
+  _CCCL_DEVICE _CCCL_FORCEINLINE T Sum(T input)
+  {
+    return BroadcastAggregate(BlockReduceT{temp_storage.reduce}.Sum(input));
+  }
+
+  //! @rst
+  //! Computes a block-wide sum of multiple items per thread in a blocked arrangement and returns the aggregate to every
+  //! thread in the block.
+  //!
+  //! - @granularity
+  //! @smemreuse
+  //! @endrst
+  //!
+  //! @tparam ItemsPerThread
+  //!   **[inferred]** The number of input items per thread.
+  //!
+  //! @param[in] inputs
+  //!   Calling thread's input items.
+  //!
+  //! @return
+  //!   The block-wide sum, returned in every thread in the block.
+  template <int ItemsPerThread>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T Sum(T (&inputs)[ItemsPerThread])
+  {
+    return BroadcastAggregate(BlockReduceT{temp_storage.reduce}.Sum(inputs));
+  }
+
+  //! @rst
+  //! Computes a block-wide sum of up to ``num_valid`` threads and returns the aggregate to every thread in the block.
+  //!
+  //! - This overload does not support the ``BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC`` algorithm. Use a full-tile
+  //!   ``Sum`` overload with that algorithm.
+  //!
+  //! @smemreuse
+  //! @endrst
+  //!
+  //! @param[in] input
+  //!   Calling thread's input item.
+  //!
+  //! @param[in] num_valid
+  //!   Number of threads containing valid elements (may be less than the number of threads in the block).
+  //!
+  //! @return
+  //!   The sum of the valid items, returned in every thread in the block.
+  _CCCL_DEVICE _CCCL_FORCEINLINE T Sum(T input, int num_valid)
+  {
+    AssertAlgorithmSupportsOverload<!IS_NONDETERMINISTIC>();
+    return BroadcastAggregate(BlockReduceT{temp_storage.reduce}.Sum(input, num_valid));
+  }
+
+  //! @}
+};
+
+CUB_NAMESPACE_END

--- a/cub/cub/cub.cuh
+++ b/cub/cub/cub.cuh
@@ -37,6 +37,7 @@
 #include <cub/block/block_radix_rank.cuh>
 #include <cub/block/block_radix_sort.cuh>
 #include <cub/block/block_reduce.cuh>
+#include <cub/block/block_reduce_broadcast.cuh>
 #include <cub/block/block_scan.cuh>
 #include <cub/block/block_store.cuh>
 // #include <cub/block/block_shift.cuh>

--- a/cub/test/catch2_test_block_reduce_broadcast.cu
+++ b/cub/test/catch2_test_block_reduce_broadcast.cu
@@ -1,0 +1,654 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/block/block_reduce_broadcast.cuh>
+
+#include <thrust/type_traits/is_trivially_relocatable.h>
+
+#include <cuda/functional>
+#include <cuda/std/functional>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include <c2h/catch2_test_helper.h>
+#include <c2h/check_results.cuh>
+#include <c2h/operator.cuh>
+
+inline constexpr int num_items_per_thread = 4;
+
+enum class BlockReduceBroadcastMode
+{
+  Sum,
+  SumValidItems,
+  SumMultipleItems,
+  Reduce,
+  ReduceValidItems,
+  ReduceMultipleItems
+};
+
+template <BlockReduceBroadcastMode Mode>
+inline constexpr int items_per_thread_for_mode_v =
+  (Mode == BlockReduceBroadcastMode::SumMultipleItems || Mode == BlockReduceBroadcastMode::ReduceMultipleItems)
+    ? num_items_per_thread
+    : 1;
+
+template <BlockReduceBroadcastMode Mode, int BlockDimX, int BlockDimY, int BlockDimZ>
+inline constexpr int max_reduction_items_v = BlockDimX * BlockDimY * BlockDimZ * items_per_thread_for_mode_v<Mode>;
+
+template <typename ReductionOp>
+inline constexpr bool is_commutative_test_op_v =
+  ::cuda::std::is_same_v<::cuda::std::remove_cvref_t<ReductionOp>, ::cuda::std::plus<>>
+  || ::cuda::std::is_same_v<::cuda::std::remove_cvref_t<ReductionOp>, ::cuda::maximum<>>
+  || ::cuda::std::is_same_v<::cuda::std::remove_cvref_t<ReductionOp>, ::cuda::minimum<>>;
+
+struct affine_value_t
+{
+  int scale;
+  int offset;
+
+  friend bool operator==(const affine_value_t& lhs, const affine_value_t& rhs)
+  {
+    return lhs.scale == rhs.scale && lhs.offset == rhs.offset;
+  }
+};
+
+struct affine_compose_op
+{
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE affine_value_t operator()(affine_value_t lhs, affine_value_t rhs) const
+  {
+    constexpr int modulo = 32749;
+    return affine_value_t{(lhs.scale * rhs.scale) % modulo, (lhs.scale * rhs.offset + lhs.offset) % modulo};
+  }
+};
+
+template <>
+inline constexpr affine_value_t identity_v<affine_compose_op, affine_value_t> = affine_value_t{1, 0};
+
+struct non_trivial_value_t
+{
+  int value;
+
+  _CCCL_HOST_DEVICE non_trivial_value_t()
+      : value(0)
+  {}
+
+  _CCCL_HOST_DEVICE explicit non_trivial_value_t(int value)
+      : value(value)
+  {}
+
+  // Keep these copy operations user-provided so this remains non-trivially copyable.
+  _CCCL_HOST_DEVICE non_trivial_value_t(const non_trivial_value_t& other) // NOLINT(modernize-use-equals-default)
+      : value(other.value)
+  {}
+
+  _CCCL_HOST_DEVICE non_trivial_value_t&
+  operator=(const non_trivial_value_t& other) // NOLINT(modernize-use-equals-default)
+  {
+    value = other.value;
+    return *this;
+  }
+
+  friend _CCCL_HOST_DEVICE bool operator==(non_trivial_value_t lhs, non_trivial_value_t rhs)
+  {
+    return lhs.value == rhs.value;
+  }
+};
+
+static_assert(!::cuda::std::is_trivially_copyable_v<non_trivial_value_t>);
+static_assert(::cuda::std::is_trivially_destructible_v<non_trivial_value_t>);
+static_assert(!thrust::is_trivially_relocatable_v<non_trivial_value_t>);
+
+struct non_trivial_sum_op
+{
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE non_trivial_value_t
+  operator()(non_trivial_value_t lhs, non_trivial_value_t rhs) const
+  {
+    return non_trivial_value_t{lhs.value + rhs.value};
+  }
+};
+
+template <BlockReduceBroadcastMode Mode,
+          cub::BlockReduceAlgorithm Algorithm,
+          int ItemsPerThread,
+          int BlockDimX,
+          int BlockDimY,
+          int BlockDimZ,
+          typename T,
+          typename ReductionOp>
+__launch_bounds__(BlockDimX* BlockDimY* BlockDimZ) __global__
+  void block_reduce_broadcast_kernel(const T* input, T* output, ReductionOp reduction_op, int valid_items)
+{
+  constexpr int block_threads = BlockDimX * BlockDimY * BlockDimZ;
+  static_assert(block_threads > 0, "Block must contain at least one thread");
+
+  using block_reduce_t = cub::BlockReduceBroadcast<T, BlockDimX, Algorithm, BlockDimY, BlockDimZ>;
+
+  __shared__ typename block_reduce_t::TempStorage temp_storage;
+
+  const int tid           = static_cast<int>(cub::RowMajorTid(BlockDimX, BlockDimY, BlockDimZ));
+  const int thread_offset = tid * ItemsPerThread;
+  T thread_data[ItemsPerThread];
+
+  // The test buffer is intentionally sized for the full tile, including lanes masked by valid_items overloads.
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (int item = 0; item < ItemsPerThread; ++item)
+  {
+    thread_data[item] = input[thread_offset + item];
+  }
+
+  if constexpr (Mode == BlockReduceBroadcastMode::Sum)
+  {
+    output[tid] = block_reduce_t{temp_storage}.Sum(thread_data[0]);
+  }
+  else if constexpr (Mode == BlockReduceBroadcastMode::SumValidItems)
+  {
+    output[tid] = block_reduce_t{temp_storage}.Sum(thread_data[0], valid_items);
+  }
+  else if constexpr (Mode == BlockReduceBroadcastMode::SumMultipleItems)
+  {
+    output[tid] = block_reduce_t{temp_storage}.Sum(thread_data);
+  }
+  else if constexpr (Mode == BlockReduceBroadcastMode::Reduce)
+  {
+    output[tid] = block_reduce_t{temp_storage}.Reduce(thread_data[0], reduction_op);
+  }
+  else if constexpr (Mode == BlockReduceBroadcastMode::ReduceValidItems)
+  {
+    output[tid] = block_reduce_t{temp_storage}.Reduce(thread_data[0], reduction_op, valid_items);
+  }
+  else
+  {
+    output[tid] = block_reduce_t{temp_storage}.Reduce(thread_data, reduction_op);
+  }
+}
+
+template <typename T, int MaxReductionItems>
+void gen_bounded_input(c2h::seed_t seed, c2h::device_vector<T>& input)
+{
+  if constexpr (::cuda::std::is_floating_point_v<T>)
+  {
+    c2h::gen(seed, input, T(0.5), T(1.5));
+  }
+  else if constexpr (::cuda::std::is_integral_v<T> && ::cuda::std::is_signed_v<T>)
+  {
+    using bound_t      = long long;
+    const auto raw_max = static_cast<bound_t>(::cuda::std::numeric_limits<T>::max()) / MaxReductionItems;
+    const T gen_max    = static_cast<T>(raw_max > bound_t{0} ? raw_max : bound_t{1});
+    c2h::gen(seed, input, -gen_max, gen_max);
+  }
+  else if constexpr (::cuda::std::is_integral_v<T>)
+  {
+    using bound_t           = unsigned long long;
+    constexpr auto raw_max  = static_cast<bound_t>(::cuda::std::numeric_limits<T>::max()) / MaxReductionItems;
+    constexpr bool is_bound = raw_max > bound_t{0};
+    if constexpr (is_bound)
+    {
+      c2h::gen(seed, input, T(0), static_cast<T>(raw_max));
+    }
+    else
+    {
+      // Exercise the full unsigned range when no positive bounded range exists. Small unsigned Sum cases deliberately
+      // test modular arithmetic; the device result and host reference use the same wrapping semantics.
+      c2h::gen(seed, input);
+    }
+  }
+  else
+  {
+    c2h::gen(seed, input);
+  }
+}
+
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_MSVC(4244) // numeric(33): C: '=': conversion from 'int' to '_Ty', possible loss of data
+
+template <int ItemsPerThread, int BlockThreads, typename T, typename ReductionOp>
+void compute_host_reference(
+  const c2h::host_vector<T>& input, c2h::host_vector<T>& reference, ReductionOp reduction_op, int valid_items)
+{
+  static_assert(ItemsPerThread > 0, "ItemsPerThread must be greater than zero");
+
+  auto aggregate = identity_v<ReductionOp, T>;
+  for (int thread = 0; thread < BlockThreads; ++thread)
+  {
+    for (int item = 0; item < ItemsPerThread; ++item)
+    {
+      const int idx = thread * ItemsPerThread + item;
+      if (idx < valid_items)
+      {
+        aggregate = reduction_op(aggregate, input[idx]);
+      }
+    }
+  }
+
+  for (int thread = 0; thread < BlockThreads; ++thread)
+  {
+    reference[thread] = static_cast<T>(aggregate);
+  }
+}
+
+_CCCL_DIAG_POP
+
+template <int BlockThreads, int ItemsPerThread, bool IsPartial, typename F>
+void for_each_valid_items(F callback)
+{
+  if constexpr (IsPartial)
+  {
+    // Keep the partial-coverage set unique for small blocks while still exercising first, middle, near-full, and full
+    // valid ranges for larger blocks.
+    callback(::cuda::std::integral_constant<int, 1>{});
+    if constexpr (BlockThreads > 2)
+    {
+      callback(::cuda::std::integral_constant<int, BlockThreads / 2>{});
+      callback(::cuda::std::integral_constant<int, BlockThreads - 1>{});
+    }
+    if constexpr (BlockThreads > 1)
+    {
+      callback(::cuda::std::integral_constant<int, BlockThreads>{});
+    }
+  }
+  else
+  {
+    callback(::cuda::std::integral_constant<int, BlockThreads * ItemsPerThread>{});
+  }
+}
+
+template <BlockReduceBroadcastMode Mode,
+          cub::BlockReduceAlgorithm Algorithm,
+          int BlockDimX,
+          int BlockDimY,
+          int BlockDimZ,
+          typename T,
+          typename ReductionOp>
+void test_block_reduce_broadcast(ReductionOp reduction_op = ReductionOp{})
+{
+  static_assert(Algorithm != cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY
+                  || is_commutative_test_op_v<ReductionOp>,
+                "BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY test cases require a commutative reduction operator");
+
+  constexpr int items_per_thread = items_per_thread_for_mode_v<Mode>;
+  constexpr int block_threads    = BlockDimX * BlockDimY * BlockDimZ;
+  constexpr bool is_partial =
+    (Mode == BlockReduceBroadcastMode::SumValidItems || Mode == BlockReduceBroadcastMode::ReduceValidItems);
+
+  for_each_valid_items<BlockDimX * BlockDimY * BlockDimZ, items_per_thread_for_mode_v<Mode>, is_partial>(
+    [&](auto valid_items_constant) {
+      constexpr int valid_items = decltype(valid_items_constant)::value;
+
+      CAPTURE(c2h::type_name<T>(),
+              c2h::type_name<ReductionOp>(),
+              Algorithm,
+              BlockDimX,
+              BlockDimY,
+              BlockDimZ,
+              items_per_thread,
+              valid_items);
+
+      c2h::device_vector<T> d_input(block_threads * items_per_thread);
+      gen_bounded_input<T, max_reduction_items_v<Mode, BlockDimX, BlockDimY, BlockDimZ>>(C2H_SEED(10), d_input);
+
+      c2h::device_vector<T> d_output(block_threads);
+      dim3 block_dims(BlockDimX, BlockDimY, BlockDimZ);
+      block_reduce_broadcast_kernel<Mode, Algorithm, items_per_thread_for_mode_v<Mode>, BlockDimX, BlockDimY, BlockDimZ>
+        <<<1, block_dims>>>(thrust::raw_pointer_cast(d_input.data()),
+                            thrust::raw_pointer_cast(d_output.data()),
+                            reduction_op,
+                            valid_items);
+
+      REQUIRE(cudaSuccess == cudaPeekAtLastError());
+      REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+      c2h::host_vector<T> h_input  = d_input;
+      c2h::host_vector<T> h_output = d_output;
+      c2h::host_vector<T> h_reference(block_threads);
+
+      compute_host_reference<items_per_thread_for_mode_v<Mode>, BlockDimX * BlockDimY * BlockDimZ>(
+        h_input, h_reference, reduction_op, valid_items);
+      verify_results(h_reference, h_output);
+    });
+}
+
+static affine_value_t make_affine_value(int idx)
+{
+  return affine_value_t{idx % 3 + 1, (idx * 7 + 5) % 17};
+}
+
+template <BlockReduceBroadcastMode Mode,
+          cub::BlockReduceAlgorithm Algorithm,
+          int BlockDimX = 64,
+          int BlockDimY = 1,
+          int BlockDimZ = 1>
+void test_block_reduce_broadcast_non_commutative()
+{
+  static_assert(Mode == BlockReduceBroadcastMode::Reduce || Mode == BlockReduceBroadcastMode::ReduceMultipleItems,
+                "Only full-tile Reduce modes are tested with the non-commutative operator");
+
+  constexpr int block_threads    = BlockDimX * BlockDimY * BlockDimZ;
+  constexpr int items_per_thread = Mode == BlockReduceBroadcastMode::ReduceMultipleItems ? num_items_per_thread : 1;
+  constexpr int valid_items      = block_threads * items_per_thread;
+
+  c2h::host_vector<affine_value_t> h_input(block_threads * items_per_thread);
+  for (int idx = 0; idx < static_cast<int>(h_input.size()); ++idx)
+  {
+    h_input[idx] = make_affine_value(idx);
+  }
+
+  c2h::device_vector<affine_value_t> d_input = h_input;
+  c2h::device_vector<affine_value_t> d_output(block_threads);
+  dim3 block_dims(BlockDimX, BlockDimY, BlockDimZ);
+  block_reduce_broadcast_kernel<Mode, Algorithm, items_per_thread, BlockDimX, BlockDimY, BlockDimZ><<<1, block_dims>>>(
+    thrust::raw_pointer_cast(d_input.data()),
+    thrust::raw_pointer_cast(d_output.data()),
+    affine_compose_op{},
+    valid_items);
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  c2h::host_vector<affine_value_t> h_output = d_output;
+  c2h::host_vector<affine_value_t> h_reference(block_threads);
+
+  compute_host_reference<items_per_thread, block_threads>(h_input, h_reference, affine_compose_op{}, valid_items);
+  REQUIRE(h_reference == h_output);
+}
+
+template <cub::BlockReduceAlgorithm Algorithm>
+__global__ void block_reduce_broadcast_reuse_storage_kernel(int* output)
+{
+  constexpr int block_dim_x = 64;
+  using block_reduce_t      = cub::BlockReduceBroadcast<int, block_dim_x, Algorithm>;
+
+  __shared__ typename block_reduce_t::TempStorage temp_storage;
+
+  block_reduce_t block_reduce(temp_storage);
+  const auto first  = block_reduce.Sum(static_cast<int>(threadIdx.x));
+  const auto second = block_reduce.Sum(static_cast<int>(threadIdx.x + 1));
+
+  output[threadIdx.x]               = first;
+  output[threadIdx.x + block_dim_x] = second;
+}
+
+template <cub::BlockReduceAlgorithm Algorithm>
+void test_block_reduce_broadcast_reuse_storage()
+{
+  constexpr int block_dim_x = 64;
+  c2h::device_vector<int> d_output(block_dim_x * 2);
+
+  block_reduce_broadcast_reuse_storage_kernel<Algorithm><<<1, block_dim_x>>>(thrust::raw_pointer_cast(d_output.data()));
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  c2h::host_vector<int> h_reference(block_dim_x * 2);
+  for (int thread = 0; thread < block_dim_x; ++thread)
+  {
+    h_reference[thread]               = 2016;
+    h_reference[thread + block_dim_x] = 2080;
+  }
+
+  REQUIRE(h_reference == d_output);
+}
+
+template <cub::BlockReduceAlgorithm Algorithm>
+__global__ void block_reduce_broadcast_non_trivial_kernel(non_trivial_value_t* output)
+{
+  constexpr int block_dim_x = 64;
+  using block_reduce_t      = cub::BlockReduceBroadcast<non_trivial_value_t, block_dim_x, Algorithm>;
+
+  __shared__ typename block_reduce_t::TempStorage temp_storage;
+
+  const auto input    = non_trivial_value_t{static_cast<int>(threadIdx.x)};
+  const auto result   = block_reduce_t{temp_storage}.Reduce(input, non_trivial_sum_op{});
+  output[threadIdx.x] = result;
+}
+
+template <cub::BlockReduceAlgorithm Algorithm>
+void test_block_reduce_broadcast_non_trivial()
+{
+  constexpr int block_dim_x = 64;
+  c2h::device_vector<non_trivial_value_t> d_output(block_dim_x);
+
+  block_reduce_broadcast_non_trivial_kernel<Algorithm><<<1, block_dim_x>>>(thrust::raw_pointer_cast(d_output.data()));
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  c2h::host_vector<non_trivial_value_t> h_output = d_output;
+  for (int thread = 0; thread < block_dim_x; ++thread)
+  {
+    CAPTURE(thread);
+    REQUIRE(h_output[thread].value == 2016);
+  }
+}
+
+template <cub::BlockReduceAlgorithm Algorithm>
+__global__ void block_reduce_broadcast_private_storage_kernel(int* output)
+{
+  constexpr int block_dim_x = 64;
+  using block_reduce_t      = cub::BlockReduceBroadcast<int, block_dim_x, Algorithm>;
+
+  const auto result   = block_reduce_t{}.Sum(static_cast<int>(threadIdx.x));
+  output[threadIdx.x] = result;
+}
+
+template <cub::BlockReduceAlgorithm Algorithm>
+void test_block_reduce_broadcast_private_storage()
+{
+  constexpr int block_dim_x = 64;
+  c2h::device_vector<int> d_output(block_dim_x);
+
+  block_reduce_broadcast_private_storage_kernel<Algorithm>
+    <<<1, block_dim_x>>>(thrust::raw_pointer_cast(d_output.data()));
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  c2h::host_vector<int> h_reference(block_dim_x, 2016);
+  REQUIRE(h_reference == d_output);
+}
+
+using value_types =
+  c2h::type_list<::cuda::std::uint8_t, ::cuda::std::uint16_t, ::cuda::std::int32_t, ::cuda::std::int64_t, float, double>;
+using block_dim_xs  = c2h::enum_type_list<int, 64, 128>;
+using block_dim_yzs = c2h::enum_type_list<int, 1, 2>;
+using commutative_algorithms =
+  c2h::enum_type_list<cub::BlockReduceAlgorithm,
+                      cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING,
+                      cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY,
+                      cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS>;
+using ordered_algorithms =
+  c2h::enum_type_list<cub::BlockReduceAlgorithm,
+                      cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING,
+                      cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS>;
+using commutative_only_algorithms =
+  c2h::enum_type_list<cub::BlockReduceAlgorithm, cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY>;
+using reduction_ops = c2h::type_list<::cuda::maximum<>, ::cuda::minimum<>>;
+
+C2H_TEST("BlockReduceBroadcast::Sum returns the aggregate to every thread",
+         "[block][reduce]",
+         value_types,
+         block_dim_xs,
+         block_dim_yzs,
+         block_dim_yzs,
+         commutative_algorithms)
+{
+  using value_t             = typename c2h::get<0, TestType>;
+  constexpr int block_dim_x = c2h::get<1, TestType>::value;
+  constexpr int block_dim_y = c2h::get<2, TestType>::value;
+  constexpr int block_dim_z = c2h::get<3, TestType>::value;
+  constexpr auto algorithm  = c2h::get<4, TestType>::value;
+
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::Sum, algorithm, block_dim_x, block_dim_y, block_dim_z, value_t>(
+    ::cuda::std::plus<>{});
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::SumValidItems,
+                              algorithm,
+                              block_dim_x,
+                              block_dim_y,
+                              block_dim_z,
+                              value_t>(::cuda::std::plus<>{});
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::SumMultipleItems,
+                              algorithm,
+                              block_dim_x,
+                              block_dim_y,
+                              block_dim_z,
+                              value_t>(::cuda::std::plus<>{});
+}
+
+C2H_TEST("BlockReduceBroadcast::Reduce returns the aggregate to every thread",
+         "[block][reduce]",
+         value_types,
+         block_dim_xs,
+         block_dim_yzs,
+         block_dim_yzs,
+         ordered_algorithms,
+         reduction_ops)
+{
+  using value_t             = typename c2h::get<0, TestType>;
+  constexpr int block_dim_x = c2h::get<1, TestType>::value;
+  constexpr int block_dim_y = c2h::get<2, TestType>::value;
+  constexpr int block_dim_z = c2h::get<3, TestType>::value;
+  constexpr auto algorithm  = c2h::get<4, TestType>::value;
+  using op_t                = typename c2h::get<5, TestType>;
+
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::Reduce, algorithm, block_dim_x, block_dim_y, block_dim_z, value_t>(
+    op_t{});
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::ReduceValidItems,
+                              algorithm,
+                              block_dim_x,
+                              block_dim_y,
+                              block_dim_z,
+                              value_t>(op_t{});
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::ReduceMultipleItems,
+                              algorithm,
+                              block_dim_x,
+                              block_dim_y,
+                              block_dim_z,
+                              value_t>(op_t{});
+}
+
+C2H_TEST("BlockReduceBroadcast::Reduce supports commutative-only algorithms",
+         "[block][reduce]",
+         value_types,
+         commutative_only_algorithms,
+         reduction_ops)
+{
+  using value_t            = typename c2h::get<0, TestType>;
+  constexpr auto algorithm = c2h::get<1, TestType>::value;
+  using op_t               = typename c2h::get<2, TestType>;
+
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::Reduce, algorithm, 64, 1, 1, value_t>(op_t{});
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::ReduceValidItems, algorithm, 64, 1, 1, value_t>(op_t{});
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::ReduceMultipleItems, algorithm, 64, 1, 1, value_t>(op_t{});
+}
+
+C2H_TEST("BlockReduceBroadcast::Sum supports nondeterministic warp reductions", "[block][reduce]")
+{
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::Sum,
+                              cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
+                              128,
+                              1,
+                              1,
+                              int>(::cuda::std::plus<>{});
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::SumMultipleItems,
+                              cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
+                              128,
+                              1,
+                              1,
+                              int>(::cuda::std::plus<>{});
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::Sum,
+                              cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
+                              64,
+                              1,
+                              1,
+                              float>(::cuda::std::plus<>{});
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::SumMultipleItems,
+                              cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
+                              64,
+                              1,
+                              1,
+                              float>(::cuda::std::plus<>{});
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::Sum,
+                              cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
+                              256,
+                              1,
+                              1,
+                              double>(::cuda::std::plus<>{});
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::SumMultipleItems,
+                              cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
+                              256,
+                              1,
+                              1,
+                              double>(::cuda::std::plus<>{});
+}
+
+C2H_TEST("BlockReduceBroadcast supports irregular block layouts", "[block][reduce]")
+{
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::Sum, cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING, 1, 1, 1, int>(
+    ::cuda::std::plus<>{});
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::SumValidItems,
+                              cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING,
+                              7,
+                              1,
+                              1,
+                              int>(::cuda::std::plus<>{});
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::Reduce,
+                              cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS,
+                              65,
+                              1,
+                              1,
+                              int>(::cuda::maximum<>{});
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::ReduceValidItems,
+                              cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS,
+                              13,
+                              3,
+                              1,
+                              int>(::cuda::minimum<>{});
+  test_block_reduce_broadcast<BlockReduceBroadcastMode::SumMultipleItems,
+                              cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY,
+                              65,
+                              1,
+                              1,
+                              int>(::cuda::std::plus<>{});
+}
+
+C2H_TEST("BlockReduceBroadcast::Reduce preserves non-commutative reduction order", "[block][reduce]")
+{
+  test_block_reduce_broadcast_non_commutative<BlockReduceBroadcastMode::Reduce,
+                                              cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING>();
+  test_block_reduce_broadcast_non_commutative<BlockReduceBroadcastMode::ReduceMultipleItems,
+                                              cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING>();
+  test_block_reduce_broadcast_non_commutative<BlockReduceBroadcastMode::Reduce,
+                                              cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS>();
+  test_block_reduce_broadcast_non_commutative<BlockReduceBroadcastMode::ReduceMultipleItems,
+                                              cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS>();
+  test_block_reduce_broadcast_non_commutative<BlockReduceBroadcastMode::Reduce,
+                                              cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING,
+                                              32,
+                                              2,
+                                              1>();
+  test_block_reduce_broadcast_non_commutative<BlockReduceBroadcastMode::ReduceMultipleItems,
+                                              cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING,
+                                              32,
+                                              2,
+                                              1>();
+}
+
+C2H_TEST("BlockReduceBroadcast supports non-trivially-copyable value types", "[block][reduce]")
+{
+  test_block_reduce_broadcast_non_trivial<cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING>();
+  test_block_reduce_broadcast_non_trivial<cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY>();
+  test_block_reduce_broadcast_non_trivial<cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS>();
+}
+
+C2H_TEST("BlockReduceBroadcast supports reusing temporary storage", "[block][reduce]")
+{
+  test_block_reduce_broadcast_reuse_storage<cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING>();
+  test_block_reduce_broadcast_reuse_storage<cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY>();
+  test_block_reduce_broadcast_reuse_storage<cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS>();
+}
+
+C2H_TEST("BlockReduceBroadcast supports private temporary storage", "[block][reduce]")
+{
+  test_block_reduce_broadcast_private_storage<cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING>();
+  test_block_reduce_broadcast_private_storage<cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY>();
+  test_block_reduce_broadcast_private_storage<cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS>();
+}

--- a/docs/cub/api_docs/block_wide.rst
+++ b/docs/cub/api_docs/block_wide.rst
@@ -20,6 +20,7 @@ CUB block-level algorithms are specialized for execution by threads in the same 
 * :cpp:class:`cub::BlockMergeSort` sorts items partitioned across a CUDA thread block
 * :cpp:class:`cub::BlockRadixSort` sorts items partitioned across a CUDA thread block using radix sorting method
 * :cpp:struct:`cub::BlockReduce` computes reduction of items partitioned across a CUDA thread block
+* :cpp:class:`cub::BlockReduceBroadcast` computes reduction of items partitioned across a CUDA thread block and returns the aggregate to every thread
 * :cpp:class:`cub::BlockRunLengthDecode` decodes a run-length encoded sequence partitioned across a CUDA thread block
 * :cpp:struct:`cub::BlockScan` computes a prefix scan of items partitioned across a CUDA thread block
 * :cpp:struct:`cub::BlockShuffle` shifts items partitioned across a CUDA thread block


### PR DESCRIPTION
## Summary

Adds `cub::BlockReduceBroadcast`, a block collective that reduces a CTA-wide value and returns the aggregate to every thread in the block.

This removes the repeated pattern of `BlockReduce` plus caller-owned shared-memory publication, barrier, and reload when the aggregate is needed by every thread.

## Why this primitive

Norms, quantizers, and softmax-like kernels often compute one CTA-wide statistic and immediately need it in all threads. The CUB reduction is already available, but the broadcast side is still open-coded: write the owner-lane result to shared memory, synchronize, reload, and then apply the scale. That is small code, but it is repeated everywhere and is easy to get subtly wrong when logical block sizes, partial participation, or DSL lowering are involved.

Concrete OSS patterns this can replace or simplify:

- vLLM's RMSNorm/layernorm kernels use `cub::BlockReduce<float, 1024>`, then publish `s_variance` through shared memory and `__syncthreads()` before every thread consumes it: https://github.com/vllm-project/vllm/blob/2ee51063722c9e6d28f71340966942394f330c0e/csrc/libtorch_stable/layernorm_kernels.cu#L61-L68 and https://github.com/vllm-project/vllm/blob/2ee51063722c9e6d28f71340966942394f330c0e/csrc/libtorch_stable/layernorm_kernels.cu#L126-L133
- FlashInfer's CuTe `block_reduce` helper explicitly writes one value per warp to `reduction_buffer`, barriers, reloads those values, then performs the final warp reduction: https://github.com/flashinfer-ai/flashinfer/blob/97b7de6846e72a9f5cbb536ac8eff04d2e9535bb/flashinfer/norm/utils.py#L414-L433
- FlashInfer FP4 quantization uses the same pattern for per-token row amax before computing scales: https://github.com/flashinfer-ai/flashinfer/blob/97b7de6846e72a9f5cbb536ac8eff04d2e9535bb/flashinfer/quantization/kernels/nvfp4_quantize.py#L718-L748

For C++ this removes repeated shared-memory plumbing. For cuda.coop wrappers it gives DSL kernels a one-call representation of "CTA reduction whose result is live in every thread."

## Validation

- `git diff --check`
- `pre-commit run --files cub/cub/block/block_reduce_broadcast.cuh cub/test/catch2_test_block_reduce_broadcast.cu cub/benchmarks/bench/reduce/block_reduce_broadcast.cu`
- `bash ci/util/build_and_test_targets.sh --preset cub-cpp20 --build-targets "cub.headers.base cub.test.block.reduce_broadcast" --ctest-targets '^cub\.test\.block\.reduce_broadcast$'`
  - Passed: 63,384 assertions in 354 test cases.
- Benchmark smoke on NVIDIA RTX PRO 6000 Blackwell Workstation Edition:
  - `cmake --build build/cub-benchmark --target cub.bench.reduce.block_reduce_broadcast.base -j "$(nproc)" && ./build/cub-benchmark/bin/cub.bench.reduce.block_reduce_broadcast.base --devices 0 --profile --timeout 5 --min-samples 1 --min-time 0.001`
  - Passed 72/72 cases.

## Local Review

- Local roborev branch reviews with Claude, Codex, and Gemini completed with no blocking findings.
- Follow-up docstring cleanup from review was applied before validation.
