### PR TITLE
Add CUB block row reductions

### DIFF
--- a/cub/benchmarks/bench/reduce/block_row_reduce.cu
+++ b/cub/benchmarks/bench/reduce/block_row_reduce.cu
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/block/block_row_reduce.cuh>
+
+#include <cuda_runtime_api.h>
+#include <device_side_benchmark.cuh>
+#include <nvbench_helper.cuh>
+
+template <int RowsPerBlock, int WarpsPerRow>
+struct shared_broadcast_t
+{
+  template <typename T>
+  static constexpr int block_threads = cub::BlockRowReduce<T, RowsPerBlock, WarpsPerRow>::BLOCK_THREADS;
+
+  template <typename T>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T operator()(T thread_data) const
+  {
+    using row_reduce_t = cub::BlockRowReduce<T, RowsPerBlock, WarpsPerRow>;
+
+    __shared__ typename row_reduce_t::TempStorage temp_storage;
+
+    const T result = row_reduce_t{temp_storage}.Sum(thread_data);
+    if constexpr (WarpsPerRow > 1)
+    {
+      __syncthreads();
+    }
+    return result;
+  }
+};
+
+template <int RowsPerBlock, int WarpsPerRow>
+struct warp_broadcast_t
+{
+  template <typename T>
+  static constexpr int block_threads = cub::BlockRowReduceWarpBroadcast<T, RowsPerBlock, WarpsPerRow>::BLOCK_THREADS;
+
+  template <typename T>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T operator()(T thread_data) const
+  {
+    using row_reduce_t = cub::BlockRowReduceWarpBroadcast<T, RowsPerBlock, WarpsPerRow>;
+
+    __shared__ typename row_reduce_t::TempStorage temp_storage;
+
+    const T result = row_reduce_t{temp_storage}.Sum(thread_data);
+    if constexpr (WarpsPerRow > 1)
+    {
+      __syncthreads();
+    }
+    return result;
+  }
+};
+
+using row_reduce_variants = nvbench::type_list<
+  shared_broadcast_t<1, 1>,
+  warp_broadcast_t<1, 1>,
+  shared_broadcast_t<1, 4>,
+  warp_broadcast_t<1, 4>,
+  shared_broadcast_t<2, 4>,
+  warp_broadcast_t<2, 4>,
+  shared_broadcast_t<4, 4>,
+  warp_broadcast_t<4, 4>,
+  shared_broadcast_t<1, 16>,
+  warp_broadcast_t<1, 16>,
+  shared_broadcast_t<1, 32>,
+  warp_broadcast_t<1, 32>>;
+using value_types = nvbench::type_list<int, float, double>;
+
+template <typename RowReduceVariant, typename T>
+void block_row_reduce(nvbench::state& state, nvbench::type_list<RowReduceVariant, T>)
+{
+  constexpr int block_size = RowReduceVariant::template block_threads<T>;
+  // device_side_benchmark.cuh initializes data from registers and sinks through an unreachable global write, so the
+  // measured loop intentionally isolates the unrolled primitive body from ordinary global memory traffic.
+  constexpr int unroll_factor = 64; // compromise between compile time and noise
+  const auto& kernel          = benchmark_kernel<block_size, unroll_factor, RowReduceVariant, T>;
+  const int num_sms           = state.get_device().value().get_number_of_sms();
+  int max_blocks_per_sm       = 0;
+
+  NVBENCH_CUDA_CALL_NOEXCEPT(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_blocks_per_sm, kernel, block_size, 0));
+  if (max_blocks_per_sm <= 0)
+  {
+    state.skip("Skipping: benchmark kernel does not fit on the selected device.");
+    return;
+  }
+
+  const int grid_size = max_blocks_per_sm * num_sms;
+  state.add_element_count(grid_size * block_size * unroll_factor, "Thread reductions");
+  state.add_global_memory_reads<T>(0);
+  state.add_global_memory_writes<T>(0);
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
+    kernel<<<grid_size, block_size, 0, launch.get_stream()>>>(RowReduceVariant{});
+  });
+}
+
+NVBENCH_BENCH_TYPES(block_row_reduce, NVBENCH_TYPE_AXES(row_reduce_variants, value_types))
+  .set_name("block_row_reduce")
+  .set_type_axes_names({"Variant{ct}", "T{ct}"});

--- a/cub/cub/block/block_row_reduce.cuh
+++ b/cub/cub/block/block_row_reduce.cuh
@@ -1,0 +1,529 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//! @file
+//! @rst
+//! The ``cub::BlockRowReduce`` and ``cub::BlockRowReduceWarpBroadcast`` classes provide
+//! :ref:`collective <collective-primitives>` methods for row-shaped block reductions.
+//! @endrst
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/detail/uninitialized_copy.cuh>
+#include <cub/util_ptx.cuh>
+#include <cub/util_type.cuh>
+#include <cub/warp/warp_reduce.cuh>
+
+#include <cuda/functional>
+#include <cuda/std/functional>
+#include <cuda/std/type_traits>
+
+CUB_NAMESPACE_BEGIN
+
+//! @rst
+//! The ``BlockRowReduce`` class provides :ref:`collective <collective-primitives>` methods for reducing a thread block
+//! whose row-major linear thread ids are partitioned into fixed-size rows, where each row spans one or more full warps.
+//!
+//! Overview
+//! ++++++++
+//!
+//! - A row contains ``WarpsPerRow`` consecutive architectural warps.
+//! - A block contains ``RowsPerBlock`` independent rows.
+//! - Each row aggregate is returned to every thread in the corresponding row.
+//! - Generic ``Reduce`` supports associative reduction operators that need not be commutative. It uses
+//!   ``cub::WarpReduce`` trees within each warp and across row partials; bit-exact left-to-right ordering is not
+//!   guaranteed.
+//! - This primitive is useful for norm-style kernels where a CTA owns one or more rows and every thread needs the row
+//!   statistic.
+//!
+//! Performance Characteristics
+//! +++++++++++++++++++++++++++
+//!
+//! - Uses one warp-wide reduction per warp to form row partials.
+//! - Single-warp rows broadcast the aggregate with a warp shuffle and use no block barriers.
+//! - Multi-warp rows use one additional warp-wide reduction per row and two block barriers: one to publish per-warp
+//!   partials, and one to broadcast the row aggregate through temporary storage.
+//! - Row partials and row aggregates use temporary shared storage and warp shuffles, and require trivially copyable
+//!   ``T``.
+//!
+//! .. versionadded:: 3.5.0
+//!    First appears in CUDA Toolkit 13.5.
+//!
+//! @blockcollective{BlockRowReduce}
+//!
+//! Simple Example
+//! ++++++++++++++
+//!
+//! .. code-block:: c++
+//!
+//!    using RowReduce = cub::BlockRowReduce<float, 1, 4>;
+//!    __shared__ typename RowReduce::TempStorage temp_storage;
+//!
+//!    float row_sum = RowReduce(temp_storage).Sum(thread_data);
+//!    // row_sum is valid in every thread in the row.
+//!
+//! @endrst
+//!
+//! @tparam T
+//!   The reduction input/output element type. Must be trivially copyable because values are communicated with warp
+//!   shuffles and stored in temporary shared storage that may be reused by later collective calls.
+//!
+//! @tparam RowsPerBlock
+//!   The number of independent rows in the thread block.
+//!
+//! @tparam WarpsPerRow
+//!   The number of full warps assigned to each row.
+template <typename T, int RowsPerBlock, int WarpsPerRow>
+class BlockRowReduce
+{
+  static_assert(RowsPerBlock > 0, "RowsPerBlock must be greater than zero");
+  static_assert(WarpsPerRow > 0, "WarpsPerRow must be greater than zero");
+  static_assert(WarpsPerRow <= detail::warp_threads, "WarpsPerRow must fit in one final warp reduction");
+
+  static constexpr int warp_threads  = detail::warp_threads;
+  static constexpr int block_threads = RowsPerBlock * WarpsPerRow * warp_threads;
+  static constexpr int warps         = RowsPerBlock * WarpsPerRow;
+
+  static_assert(block_threads <= 1024, "RowsPerBlock * WarpsPerRow * warp_threads must fit in one CUDA thread block");
+
+  using WarpReduceT = WarpReduce<T, warp_threads>;
+
+  static_assert(::cuda::std::is_trivially_copyable_v<T>,
+                "BlockRowReduce requires a trivially copyable value type because it communicates values through warp "
+                "shuffles and reuses shared TempStorage");
+
+  struct _TempStorageSingleWarp
+  {
+    typename WarpReduceT::TempStorage warp_reduce[warps];
+  };
+
+  struct _TempStorageMultiWarp
+  {
+    // Keep phase fields explicit instead of overlaying partials and totals. The extra row-total slot avoids manual
+    // union lifetime management while keeping the layout simple; full-warp WarpReduce storage is NullType.
+    typename WarpReduceT::TempStorage warp_reduce[warps];
+    typename WarpReduceT::TempStorage final_reduce[RowsPerBlock];
+    Uninitialized<T> partials[RowsPerBlock][WarpsPerRow];
+    Uninitialized<T> totals[RowsPerBlock];
+  };
+
+  using _TempStorage = ::cuda::std::conditional_t<WarpsPerRow == 1, _TempStorageSingleWarp, _TempStorageMultiWarp>;
+
+  //! Shared storage reference.
+  _TempStorage& temp_storage;
+
+  //! Row-major linear thread id.
+  int linear_tid;
+
+  //! Internal storage allocator.
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE _TempStorage& PrivateStorage()
+  {
+    __shared__ _TempStorage private_storage;
+    return private_storage;
+  }
+
+public:
+  //! @smemstorage{BlockRowReduce}
+  struct TempStorage : Uninitialized<_TempStorage>
+  {};
+
+  //! Number of threads in the row-shaped block.
+  static constexpr int BLOCK_THREADS = block_threads;
+
+  //! @name Collective constructors
+  //! @{
+
+  //! @rst
+  //! Collective constructor using a private static allocation of shared memory as temporary storage.
+  //! Thread participation is based on the row-major linear thread id.
+  //! @endrst
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE BlockRowReduce()
+      : BlockRowReduce(RowMajorTid(blockDim.x, blockDim.y, blockDim.z))
+  {}
+
+  //! @rst
+  //! Collective constructor using a private static allocation of shared memory as temporary storage.
+  //! Thread participation is based on ``linear_tid``.
+  //! @endrst
+  //!
+  //! @param[in] linear_tid Calling thread's row-major linear thread id
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE BlockRowReduce(int linear_tid)
+      : temp_storage(PrivateStorage())
+      , linear_tid(linear_tid)
+  {}
+
+  //! @rst
+  //! Collective constructor using the specified memory allocation as temporary storage.
+  //! Thread participation is based on the row-major linear thread id.
+  //! @endrst
+  //!
+  //! @param[in] temp_storage Reference to memory allocation having layout type TempStorage
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE BlockRowReduce(TempStorage& temp_storage)
+      : BlockRowReduce(temp_storage, RowMajorTid(blockDim.x, blockDim.y, blockDim.z))
+  {}
+
+  //! @rst
+  //! Collective constructor using the specified memory allocation as temporary storage.
+  //! Thread participation is based on ``linear_tid``.
+  //! @endrst
+  //!
+  //! @param[in] temp_storage Reference to memory allocation having layout type TempStorage
+  //! @param[in] linear_tid Calling thread's row-major linear thread id
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE BlockRowReduce(TempStorage& temp_storage, int linear_tid)
+      : temp_storage(temp_storage.Alias())
+      , linear_tid(linear_tid)
+  {}
+
+  //! @}
+  //! @name Generic reductions
+  //! @{
+
+  //! @rst
+  //! Computes a row-wide reduction using the specified binary reduction functor and returns the row aggregate to every
+  //! thread in the row.
+  //! The reduction operator must be associative. It need not be commutative.
+  //!
+  //! - @smemreuse
+  //! @endrst
+  //!
+  //! @tparam ReductionOp
+  //!   **[inferred]** Binary reduction operator type having member ``T operator()(const T &a, const T &b)``.
+  //!
+  //! @param[in] input
+  //!   Calling thread's input item.
+  //!
+  //! @param[in] reduction_op
+  //!   Binary reduction operator.
+  //!
+  //! @return
+  //!   The row-wide reduction aggregate.
+  template <typename ReductionOp>
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE T Reduce(T input, ReductionOp reduction_op)
+  {
+    const int warp_id = linear_tid / warp_threads;
+
+    const T warp_aggregate = WarpReduceT{temp_storage.warp_reduce[warp_id]}.Reduce(input, reduction_op);
+    if constexpr (WarpsPerRow == 1)
+    {
+      // Rows are made from full architectural warps, so every lane participates in the broadcast.
+      return ShuffleIndex<warp_threads>(warp_aggregate, 0, 0xFFFFFFFFu);
+    }
+    else
+    {
+      const int lane_id     = linear_tid % warp_threads;
+      const int row_id      = warp_id / WarpsPerRow;
+      const int row_warp_id = warp_id % WarpsPerRow;
+
+      if (lane_id == 0)
+      {
+        detail::uninitialized_copy_single(&temp_storage.partials[row_id][row_warp_id].Alias(), warp_aggregate);
+      }
+      __syncthreads();
+
+      if (row_warp_id == 0)
+      {
+        // WarpReduce's valid_items overload only consumes lanes [0, WarpsPerRow). Lanes outside the row partial range
+        // still provide a valid object because T need not be default-constructible; only lane 0's aggregate is
+        // consumed.
+        T partial = input;
+        if (lane_id < WarpsPerRow)
+        {
+          partial = temp_storage.partials[row_id][lane_id].Alias();
+        }
+
+        const T row_aggregate =
+          WarpReduceT{temp_storage.final_reduce[row_id]}.Reduce(partial, reduction_op, WarpsPerRow);
+        if (lane_id == 0)
+        {
+          detail::uninitialized_copy_single(&temp_storage.totals[row_id].Alias(), row_aggregate);
+        }
+      }
+      __syncthreads();
+
+      const T result = temp_storage.totals[row_id].Alias();
+      return result;
+    }
+  }
+
+  //! @}
+  //! @name Sum reductions
+  //! @{
+
+  //! @rst
+  //! Computes a row-wide sum and returns the row aggregate to every thread in the row.
+  //!
+  //! - @smemreuse
+  //! @endrst
+  //!
+  //! @param[in] input
+  //!   Calling thread's input item.
+  //!
+  //! @return
+  //!   The row-wide sum.
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE T Sum(T input)
+  {
+    return Reduce(input, ::cuda::std::plus<>{});
+  }
+
+  //! @}
+};
+
+//! @rst
+//! The ``BlockRowReduceWarpBroadcast`` class provides :ref:`collective <collective-primitives>` methods for reducing a
+//! thread block whose row-major linear thread ids are partitioned into fixed-size rows, where each row spans one or
+//! more full warps.
+//!
+//! Overview
+//! ++++++++
+//!
+//! - A row contains ``WarpsPerRow`` consecutive architectural warps.
+//! - A block contains ``RowsPerBlock`` independent rows.
+//! - Each row aggregate is returned to every thread in the corresponding row.
+//! - The reduction operator must be commutative and associative. Use ``BlockRowReduce`` for associative operators that
+//!   do not commute.
+//! - Instead of storing one final row total and broadcasting it with block barriers, every warp in the row repeats the
+//!   final reduction over the row partials.
+//!
+//! Performance Characteristics
+//! +++++++++++++++++++++++++++
+//!
+//! - Uses one warp-wide all-reduce for a single-warp row.
+//! - For multi-warp rows, uses one warp-wide reduction per warp to form row partials.
+//! - Uses one warp-wide all-reduce in every row warp to broadcast the row aggregate.
+//! - The row-broadcast all-reduce uses ``log2(warp_threads)`` shuffle rounds, even when ``WarpsPerRow < warp_threads``.
+//! - Avoids the final shared-memory row total and one block barrier used by ``BlockRowReduce``.
+//! - Row partials use temporary shared storage and warp shuffles, and require trivially copyable ``T``.
+//!
+//! .. versionadded:: 3.5.0
+//!    First appears in CUDA Toolkit 13.5.
+//!
+//! @blockcollective{BlockRowReduceWarpBroadcast}
+//!
+//! Simple Example
+//! ++++++++++++++
+//!
+//! .. code-block:: c++
+//!
+//!    using RowReduce = cub::BlockRowReduceWarpBroadcast<float, 1, 4>;
+//!    __shared__ typename RowReduce::TempStorage temp_storage;
+//!
+//!    float row_sum = RowReduce(temp_storage).Sum(thread_data);
+//!    // row_sum is valid in every thread in the row.
+//!
+//! @endrst
+//!
+//! @tparam T
+//!   The reduction input/output element type. Must be trivially copyable because values are communicated with warp
+//!   shuffles and stored in temporary shared storage that may be reused by later collective calls.
+//!
+//! @tparam RowsPerBlock
+//!   The number of independent rows in the thread block.
+//!
+//! @tparam WarpsPerRow
+//!   The number of full warps assigned to each row.
+template <typename T, int RowsPerBlock, int WarpsPerRow>
+class BlockRowReduceWarpBroadcast
+{
+  static_assert(RowsPerBlock > 0, "RowsPerBlock must be greater than zero");
+  static_assert(WarpsPerRow > 0, "WarpsPerRow must be greater than zero");
+  static_assert(WarpsPerRow <= detail::warp_threads, "WarpsPerRow must fit in one final warp reduction");
+
+  static constexpr int warp_threads  = detail::warp_threads;
+  static constexpr int block_threads = RowsPerBlock * WarpsPerRow * warp_threads;
+  static constexpr int warps         = RowsPerBlock * WarpsPerRow;
+
+  static_assert(block_threads <= 1024, "RowsPerBlock * WarpsPerRow * warp_threads must fit in one CUDA thread block");
+
+  using WarpReduceT = WarpReduce<T, warp_threads>;
+
+  static_assert(::cuda::std::is_trivially_copyable_v<T>,
+                "BlockRowReduceWarpBroadcast requires a trivially copyable value type because it communicates values "
+                "through warp shuffles and reuses shared TempStorage");
+
+  struct _TempStorageSingleWarp
+  {};
+
+  struct _TempStorageMultiWarp
+  {
+    typename WarpReduceT::TempStorage warp_reduce[warps];
+    Uninitialized<T> partials[RowsPerBlock][WarpsPerRow];
+  };
+
+  using _TempStorage = ::cuda::std::conditional_t<WarpsPerRow == 1, _TempStorageSingleWarp, _TempStorageMultiWarp>;
+
+  //! Shared storage reference.
+  _TempStorage& temp_storage;
+
+  //! Row-major linear thread id.
+  int linear_tid;
+
+  //! Internal storage allocator.
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE _TempStorage& PrivateStorage()
+  {
+    __shared__ _TempStorage private_storage;
+    return private_storage;
+  }
+
+  template <typename ReductionOp>
+  [[nodiscard]] static _CCCL_DEVICE_API _CCCL_FORCEINLINE T WarpAllReduce(T input, ReductionOp reduction_op, int lane_id)
+  {
+    // Unlike WarpReduce, which returns the aggregate to lane 0, this full-warp butterfly produces an all-reduce for
+    // commutative operators so every lane can consume the row aggregate without a trailing broadcast. Each lane
+    // traverses the same balanced partition tree up to commuted operands at each tree node; the commutative contract
+    // makes the aggregate lane-invariant while avoiding an additional shuffle broadcast.
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int offset = warp_threads / 2; offset > 0; offset >>= 1)
+    {
+      const T peer = ShuffleIndex<warp_threads>(input, lane_id ^ offset, 0xFFFFFFFFu);
+      input        = reduction_op(input, peer);
+    }
+    return input;
+  }
+
+public:
+  //! @smemstorage{BlockRowReduceWarpBroadcast}
+  struct TempStorage : Uninitialized<_TempStorage>
+  {};
+
+  //! Number of threads in the row-shaped block.
+  static constexpr int BLOCK_THREADS = block_threads;
+
+  //! @name Collective constructors
+  //! @{
+
+  //! @rst
+  //! Collective constructor using a private static allocation of shared memory as temporary storage.
+  //! Thread participation is based on the row-major linear thread id.
+  //! @endrst
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE BlockRowReduceWarpBroadcast()
+      : BlockRowReduceWarpBroadcast(RowMajorTid(blockDim.x, blockDim.y, blockDim.z))
+  {}
+
+  //! @rst
+  //! Collective constructor using a private static allocation of shared memory as temporary storage.
+  //! Thread participation is based on ``linear_tid``.
+  //! @endrst
+  //!
+  //! @param[in] linear_tid Calling thread's row-major linear thread id
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE BlockRowReduceWarpBroadcast(int linear_tid)
+      : temp_storage(PrivateStorage())
+      , linear_tid(linear_tid)
+  {}
+
+  //! @rst
+  //! Collective constructor using the specified memory allocation as temporary storage.
+  //! Thread participation is based on the row-major linear thread id.
+  //! @endrst
+  //!
+  //! @param[in] temp_storage Reference to memory allocation having layout type TempStorage
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE BlockRowReduceWarpBroadcast(TempStorage& temp_storage)
+      : BlockRowReduceWarpBroadcast(temp_storage, RowMajorTid(blockDim.x, blockDim.y, blockDim.z))
+  {}
+
+  //! @rst
+  //! Collective constructor using the specified memory allocation as temporary storage.
+  //! Thread participation is based on ``linear_tid``.
+  //! @endrst
+  //!
+  //! @param[in] temp_storage Reference to memory allocation having layout type TempStorage
+  //! @param[in] linear_tid Calling thread's row-major linear thread id
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE BlockRowReduceWarpBroadcast(TempStorage& temp_storage, int linear_tid)
+      : temp_storage(temp_storage.Alias())
+      , linear_tid(linear_tid)
+  {}
+
+  //! @}
+  //! @name Commutative reductions
+  //! @{
+
+  //! @rst
+  //! Computes a row-wide reduction and returns the row aggregate to every thread in the row.
+  //! The reduction operator must be commutative and associative.
+  //!
+  //! - @smemreuse
+  //! @endrst
+  //!
+  //! @tparam ReductionOp
+  //!   **[inferred]** Commutative binary reduction operator type having member
+  //!   ``T operator()(const T &a, const T &b)``.
+  //!
+  //! @param[in] input
+  //!   Calling thread's input item.
+  //!
+  //! @param[in] reduction_op
+  //!   Commutative binary reduction operator.
+  //!
+  //! @param[in] identity
+  //!   Identity value for ``reduction_op``.
+  //!
+  //! @return
+  //!   The row-wide reduction aggregate.
+  template <typename ReductionOp>
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE T CommutativeReduce(T input, ReductionOp reduction_op, T identity)
+  {
+    const int lane_id = linear_tid % warp_threads;
+    if constexpr (WarpsPerRow == 1)
+    {
+      return WarpAllReduce(input, reduction_op, lane_id);
+    }
+    else
+    {
+      const int warp_id      = linear_tid / warp_threads;
+      const int row_id       = warp_id / WarpsPerRow;
+      const int row_warp_id  = warp_id % WarpsPerRow;
+      const T warp_aggregate = WarpReduceT{temp_storage.warp_reduce[warp_id]}.Reduce(input, reduction_op);
+
+      if (lane_id == 0)
+      {
+        detail::uninitialized_copy_single(&temp_storage.partials[row_id][row_warp_id].Alias(), warp_aggregate);
+      }
+      __syncthreads();
+
+      T partial = identity;
+      if (lane_id < WarpsPerRow)
+      {
+        partial = temp_storage.partials[row_id][lane_id].Alias();
+      }
+      const T result = WarpAllReduce(partial, reduction_op, lane_id);
+      return result;
+    }
+  }
+
+  //! @}
+  //! @name Sum reductions
+  //! @{
+
+  //! @rst
+  //! Computes a row-wide sum and returns the row aggregate to every thread in the row.
+  //! This overload requires ``cuda::identity_element`` to provide an additive identity for ``T``.
+  //!
+  //! - @smemreuse
+  //! @endrst
+  //!
+  //! @param[in] input
+  //!   Calling thread's input item.
+  //!
+  //! @return
+  //!   The row-wide sum.
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE T Sum(T input)
+  {
+    static_assert(::cuda::has_identity_element_v<::cuda::std::plus<>, T>,
+                  "T must have a cuda::identity_element for cuda::std::plus<>; use CommutativeReduce with an explicit "
+                  "identity otherwise");
+    return CommutativeReduce(input, ::cuda::std::plus<>{}, ::cuda::identity_element<::cuda::std::plus<>, T>());
+  }
+
+  //! @}
+};
+
+CUB_NAMESPACE_END

--- a/cub/cub/cub.cuh
+++ b/cub/cub/cub.cuh
@@ -37,6 +37,7 @@
 #include <cub/block/block_radix_rank.cuh>
 #include <cub/block/block_radix_sort.cuh>
 #include <cub/block/block_reduce.cuh>
+#include <cub/block/block_row_reduce.cuh>
 #include <cub/block/block_scan.cuh>
 #include <cub/block/block_store.cuh>
 // #include <cub/block/block_shift.cuh>

--- a/cub/test/catch2_test_block_row_reduce.cu
+++ b/cub/test/catch2_test_block_row_reduce.cu
@@ -1,0 +1,613 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/block/block_row_reduce.cuh>
+
+#include <cuda/functional>
+#include <cuda/std/functional>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include <c2h/catch2_test_helper.h>
+#include <c2h/check_results.cuh>
+#include <c2h/operator.cuh>
+
+inline constexpr int warp_size = cub::detail::warp_threads;
+
+enum class BlockRowReduceVariant
+{
+  SharedBroadcast,
+  WarpBroadcast
+};
+
+enum class BlockRowReduceMode
+{
+  Sum,
+  Reduce
+};
+
+template <int RowsPerBlock, int WarpsPerRow>
+struct row_reduce_layout
+{
+  static constexpr int rows_per_block = RowsPerBlock;
+  static constexpr int warps_per_row  = WarpsPerRow;
+};
+
+struct affine_value_t
+{
+  int scale;
+  int offset;
+
+  friend _CCCL_HOST_DEVICE bool operator==(const affine_value_t& lhs, const affine_value_t& rhs)
+  {
+    return lhs.scale == rhs.scale && lhs.offset == rhs.offset;
+  }
+};
+
+struct affine_compose_op
+{
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE affine_value_t operator()(affine_value_t lhs, affine_value_t rhs) const
+  {
+    constexpr int modulo = 32749;
+    return affine_value_t{(lhs.scale * rhs.scale) % modulo, (lhs.scale * rhs.offset + lhs.offset) % modulo};
+  }
+};
+
+template <>
+inline constexpr affine_value_t identity_v<affine_compose_op, affine_value_t> = affine_value_t{1, 0};
+
+struct modular_multiply_op
+{
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE static int normalize(int value)
+  {
+    constexpr int modulo = 251;
+    const int result     = value % modulo;
+    return result < 0 ? result + modulo : result;
+  }
+
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE int operator()(int lhs, int rhs) const
+  {
+    constexpr int modulo = 251;
+    return (normalize(lhs) * normalize(rhs)) % modulo;
+  }
+};
+
+template <>
+inline constexpr int identity_v<modular_multiply_op, int> = 1;
+
+template <BlockRowReduceVariant Variant,
+          BlockRowReduceMode Mode,
+          int RowsPerBlock,
+          int WarpsPerRow,
+          typename T,
+          typename ReductionOp>
+__launch_bounds__(RowsPerBlock* WarpsPerRow* warp_size) __global__
+  void block_row_reduce_kernel(const T* input, T* output, ReductionOp reduction_op, T identity)
+{
+  constexpr int block_threads = RowsPerBlock * WarpsPerRow * warp_size;
+  static_assert(block_threads <= 1024, "BlockRowReduce test block must fit in a CUDA CTA");
+
+  const int tid = static_cast<int>(threadIdx.x);
+
+  if constexpr (Variant == BlockRowReduceVariant::SharedBroadcast)
+  {
+    using row_reduce_t = cub::BlockRowReduce<T, RowsPerBlock, WarpsPerRow>;
+    __shared__ typename row_reduce_t::TempStorage temp_storage;
+
+    if constexpr (Mode == BlockRowReduceMode::Sum)
+    {
+      output[tid] = row_reduce_t{temp_storage}.Sum(input[tid]);
+    }
+    else
+    {
+      output[tid] = row_reduce_t{temp_storage}.Reduce(input[tid], reduction_op);
+    }
+  }
+  else
+  {
+    using row_reduce_t = cub::BlockRowReduceWarpBroadcast<T, RowsPerBlock, WarpsPerRow>;
+    __shared__ typename row_reduce_t::TempStorage temp_storage;
+
+    if constexpr (Mode == BlockRowReduceMode::Sum)
+    {
+      output[tid] = row_reduce_t{temp_storage}.Sum(input[tid]);
+    }
+    else
+    {
+      output[tid] = row_reduce_t{temp_storage}.CommutativeReduce(input[tid], reduction_op, identity);
+    }
+  }
+}
+
+template <typename T, int MaxReductionItems>
+void gen_bounded_input(c2h::seed_t seed, c2h::device_vector<T>& input)
+{
+  if constexpr (::cuda::std::is_floating_point_v<T>)
+  {
+    c2h::gen(seed, input, T(0.5), T(1.5));
+  }
+  else if constexpr (::cuda::std::is_integral_v<T> && ::cuda::std::is_signed_v<T>)
+  {
+    const T gen_max = ::cuda::std::numeric_limits<T>::max() / static_cast<T>(MaxReductionItems);
+    c2h::gen(seed, input, -gen_max, gen_max);
+  }
+  else if constexpr (::cuda::std::is_integral_v<T>)
+  {
+    const T gen_max = ::cuda::std::numeric_limits<T>::max() / static_cast<T>(MaxReductionItems);
+    c2h::gen(seed, input, T(0), gen_max);
+  }
+  else
+  {
+    static_assert(::cuda::std::is_integral_v<T> || ::cuda::std::is_floating_point_v<T>,
+                  "gen_bounded_input only supports integral and floating-point types");
+  }
+}
+
+template <int RowsPerBlock, int WarpsPerRow, typename T, typename ReductionOp>
+void compute_host_reference(const c2h::host_vector<T>& input, c2h::host_vector<T>& reference, ReductionOp reduction_op)
+{
+  static_assert(RowsPerBlock * WarpsPerRow * warp_size <= 1024, "BlockRowReduce test block must fit in a CUDA CTA");
+
+  constexpr int row_threads = WarpsPerRow * warp_size;
+
+  for (int row = 0; row < RowsPerBlock; ++row)
+  {
+    T aggregate = identity_v<ReductionOp, T>;
+    for (int item = 0; item < row_threads; ++item)
+    {
+      aggregate = static_cast<T>(reduction_op(aggregate, input[row * row_threads + item]));
+    }
+
+    for (int item = 0; item < row_threads; ++item)
+    {
+      reference[row * row_threads + item] = aggregate;
+    }
+  }
+}
+
+template <BlockRowReduceVariant Variant,
+          BlockRowReduceMode Mode,
+          int RowsPerBlock,
+          int WarpsPerRow,
+          typename T,
+          typename ReductionOp>
+void test_block_row_reduce(ReductionOp reduction_op = ReductionOp{})
+{
+  constexpr int row_threads   = WarpsPerRow * warp_size;
+  constexpr int block_threads = RowsPerBlock * row_threads;
+
+  CAPTURE(c2h::type_name<T>(), c2h::type_name<ReductionOp>(), RowsPerBlock, WarpsPerRow, block_threads);
+
+  c2h::device_vector<T> d_input(block_threads);
+  gen_bounded_input<T, row_threads>(C2H_SEED(10), d_input);
+
+  c2h::device_vector<T> d_output(block_threads);
+  block_row_reduce_kernel<Variant, Mode, RowsPerBlock, WarpsPerRow><<<1, block_threads>>>(
+    thrust::raw_pointer_cast(d_input.data()),
+    thrust::raw_pointer_cast(d_output.data()),
+    reduction_op,
+    identity_v<ReductionOp, T>);
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  c2h::host_vector<T> h_input(d_input);
+  c2h::host_vector<T> h_output(d_output);
+  c2h::host_vector<T> h_reference(block_threads);
+
+  compute_host_reference<RowsPerBlock, WarpsPerRow>(h_input, h_reference, reduction_op);
+  verify_results(h_reference, h_output);
+
+  for (int row = 0; row < RowsPerBlock; ++row)
+  {
+    const int row_begin = row * row_threads;
+    for (int item = 1; item < row_threads; ++item)
+    {
+      REQUIRE(h_output[row_begin + item] == h_output[row_begin]);
+    }
+  }
+}
+
+static affine_value_t make_affine_value(int idx)
+{
+  return affine_value_t{idx % 3 + 1, (idx * 7 + 5) % 17};
+}
+
+template <int RowsPerBlock, int WarpsPerRow>
+void test_block_row_reduce_non_commutative()
+{
+  constexpr int row_threads   = WarpsPerRow * warp_size;
+  constexpr int block_threads = RowsPerBlock * row_threads;
+
+  c2h::host_vector<affine_value_t> h_input(block_threads);
+  for (int idx = 0; idx < static_cast<int>(h_input.size()); ++idx)
+  {
+    h_input[idx] = make_affine_value(idx);
+  }
+
+  c2h::device_vector<affine_value_t> d_input = h_input;
+  c2h::device_vector<affine_value_t> d_output(block_threads);
+  block_row_reduce_kernel<BlockRowReduceVariant::SharedBroadcast, BlockRowReduceMode::Reduce, RowsPerBlock, WarpsPerRow>
+    <<<1, block_threads>>>(
+      thrust::raw_pointer_cast(d_input.data()),
+      thrust::raw_pointer_cast(d_output.data()),
+      affine_compose_op{},
+      identity_v<affine_compose_op, affine_value_t>);
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  c2h::host_vector<affine_value_t> h_output(d_output);
+  c2h::host_vector<affine_value_t> h_reference(block_threads);
+
+  compute_host_reference<RowsPerBlock, WarpsPerRow>(h_input, h_reference, affine_compose_op{});
+  REQUIRE(h_reference == h_output);
+}
+
+template <BlockRowReduceVariant Variant, int RowsPerBlock, int WarpsPerRow>
+__launch_bounds__(RowsPerBlock* WarpsPerRow* warp_size) __global__
+  void block_row_reduce_private_storage_kernel(int* output)
+{
+  constexpr int block_threads = RowsPerBlock * WarpsPerRow * warp_size;
+  static_assert(block_threads <= 1024, "BlockRowReduce test block must fit in a CUDA CTA");
+
+  const int tid = static_cast<int>(threadIdx.x);
+
+  if constexpr (Variant == BlockRowReduceVariant::SharedBroadcast)
+  {
+    output[tid] = cub::BlockRowReduce<int, RowsPerBlock, WarpsPerRow>{}.Sum(tid);
+  }
+  else
+  {
+    output[tid] = cub::BlockRowReduceWarpBroadcast<int, RowsPerBlock, WarpsPerRow>{}.Sum(tid);
+  }
+}
+
+template <BlockRowReduceVariant Variant, int RowsPerBlock, int WarpsPerRow>
+void test_block_row_reduce_private_storage()
+{
+  constexpr int row_threads   = WarpsPerRow * warp_size;
+  constexpr int block_threads = RowsPerBlock * row_threads;
+  c2h::device_vector<int> d_output(block_threads);
+
+  block_row_reduce_private_storage_kernel<Variant, RowsPerBlock, WarpsPerRow>
+    <<<1, block_threads>>>(thrust::raw_pointer_cast(d_output.data()));
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  c2h::host_vector<int> h_reference(block_threads);
+  for (int row = 0; row < RowsPerBlock; ++row)
+  {
+    const int row_begin = row * row_threads;
+    const int row_sum   = (row_begin + row_begin + row_threads - 1) * row_threads / 2;
+    for (int item = 0; item < row_threads; ++item)
+    {
+      h_reference[row_begin + item] = row_sum;
+    }
+  }
+
+  c2h::host_vector<int> h_output = d_output;
+  REQUIRE(h_reference == h_output);
+}
+
+template <BlockRowReduceVariant Variant, int RowsPerBlock, int WarpsPerRow>
+__launch_bounds__(RowsPerBlock* WarpsPerRow* warp_size) __global__
+  void block_row_reduce_multidimensional_kernel(int* output)
+{
+  constexpr int block_threads = RowsPerBlock * WarpsPerRow * warp_size;
+  static_assert(block_threads <= 1024, "BlockRowReduce test block must fit in a CUDA CTA");
+
+  const int tid = cub::RowMajorTid(blockDim.x, blockDim.y, blockDim.z);
+
+  if constexpr (Variant == BlockRowReduceVariant::SharedBroadcast)
+  {
+    using row_reduce_t = cub::BlockRowReduce<int, RowsPerBlock, WarpsPerRow>;
+    __shared__ typename row_reduce_t::TempStorage temp_storage;
+    output[tid] = row_reduce_t{temp_storage}.Sum(tid);
+  }
+  else
+  {
+    using row_reduce_t = cub::BlockRowReduceWarpBroadcast<int, RowsPerBlock, WarpsPerRow>;
+    __shared__ typename row_reduce_t::TempStorage temp_storage;
+    output[tid] = row_reduce_t{temp_storage}.Sum(tid);
+  }
+}
+
+template <BlockRowReduceVariant Variant, int RowsPerBlock, int WarpsPerRow>
+void test_block_row_reduce_multidimensional()
+{
+  constexpr int row_threads   = WarpsPerRow * warp_size;
+  constexpr int block_threads = RowsPerBlock * row_threads;
+  static_assert(block_threads % 16 == 0, "BlockRowReduce multidimensional test assumes a 16-wide block dimension");
+  c2h::device_vector<int> d_output(block_threads);
+
+  block_row_reduce_multidimensional_kernel<Variant, RowsPerBlock, WarpsPerRow>
+    <<<1, dim3(16, block_threads / 16)>>>(thrust::raw_pointer_cast(d_output.data()));
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  c2h::host_vector<int> h_reference(block_threads);
+  for (int row = 0; row < RowsPerBlock; ++row)
+  {
+    const int row_begin = row * row_threads;
+    const int row_sum   = (row_begin + row_begin + row_threads - 1) * row_threads / 2;
+    for (int item = 0; item < row_threads; ++item)
+    {
+      h_reference[row_begin + item] = row_sum;
+    }
+  }
+
+  c2h::host_vector<int> h_output = d_output;
+  REQUIRE(h_reference == h_output);
+}
+
+template <BlockRowReduceVariant Variant, int RowsPerBlock, int WarpsPerRow>
+__launch_bounds__(RowsPerBlock* WarpsPerRow* warp_size) __global__
+  void block_row_reduce_reuse_temp_storage_kernel(int* output)
+{
+  constexpr int block_threads = RowsPerBlock * WarpsPerRow * warp_size;
+  static_assert(block_threads <= 1024, "BlockRowReduce test block must fit in a CUDA CTA");
+
+  const int tid = static_cast<int>(threadIdx.x);
+
+  if constexpr (Variant == BlockRowReduceVariant::SharedBroadcast)
+  {
+    using row_reduce_t = cub::BlockRowReduce<int, RowsPerBlock, WarpsPerRow>;
+    __shared__ typename row_reduce_t::TempStorage temp_storage;
+    row_reduce_t row_reduce{temp_storage};
+
+    output[tid] = row_reduce.Sum(tid);
+    // Reusing a collective's temporary storage across calls requires a block barrier between calls.
+    __syncthreads();
+    output[block_threads + tid] = row_reduce.Sum(tid + block_threads);
+  }
+  else
+  {
+    using row_reduce_t = cub::BlockRowReduceWarpBroadcast<int, RowsPerBlock, WarpsPerRow>;
+    __shared__ typename row_reduce_t::TempStorage temp_storage;
+    row_reduce_t row_reduce{temp_storage};
+
+    output[tid] = row_reduce.Sum(tid);
+    // Reusing a collective's temporary storage across calls requires a block barrier between calls.
+    __syncthreads();
+    output[block_threads + tid] = row_reduce.Sum(tid + block_threads);
+  }
+}
+
+template <int RowsPerBlock, int WarpsPerRow>
+__launch_bounds__(RowsPerBlock* WarpsPerRow* warp_size) __global__
+  void block_row_reduce_warp_broadcast_float_consistency_kernel(float* output)
+{
+  constexpr int block_threads = RowsPerBlock * WarpsPerRow * warp_size;
+  static_assert(block_threads <= 1024, "BlockRowReduce test block must fit in a CUDA CTA");
+
+  using row_reduce_t = cub::BlockRowReduceWarpBroadcast<float, RowsPerBlock, WarpsPerRow>;
+  __shared__ typename row_reduce_t::TempStorage temp_storage;
+
+  const int tid     = static_cast<int>(threadIdx.x);
+  const int lane_id = tid % warp_size;
+  const int warp_id = tid / warp_size;
+  const float input = lane_id % 4 == 0 ? 1.0e20f : (lane_id % 4 == 2 ? -1.0e20f : 1.0f);
+  output[tid]       = row_reduce_t{temp_storage}.Sum(input + static_cast<float>(warp_id % WarpsPerRow));
+}
+
+template <int RowsPerBlock, int WarpsPerRow>
+void test_block_row_reduce_warp_broadcast_float_consistency()
+{
+  constexpr int row_threads   = WarpsPerRow * warp_size;
+  constexpr int block_threads = RowsPerBlock * row_threads;
+
+  c2h::device_vector<float> d_output(block_threads);
+  block_row_reduce_warp_broadcast_float_consistency_kernel<RowsPerBlock, WarpsPerRow>
+    <<<1, block_threads>>>(thrust::raw_pointer_cast(d_output.data()));
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  c2h::host_vector<float> h_output = d_output;
+  for (int row = 0; row < RowsPerBlock; ++row)
+  {
+    const int row_begin = row * row_threads;
+    for (int item = 1; item < row_threads; ++item)
+    {
+      REQUIRE(h_output[row_begin + item] == h_output[row_begin]);
+    }
+  }
+}
+
+template <BlockRowReduceVariant Variant, int RowsPerBlock, int WarpsPerRow>
+void test_block_row_reduce_reuse_temp_storage()
+{
+  constexpr int row_threads   = WarpsPerRow * warp_size;
+  constexpr int block_threads = RowsPerBlock * row_threads;
+  c2h::device_vector<int> d_output(2 * block_threads);
+
+  block_row_reduce_reuse_temp_storage_kernel<Variant, RowsPerBlock, WarpsPerRow>
+    <<<1, block_threads>>>(thrust::raw_pointer_cast(d_output.data()));
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  c2h::host_vector<int> h_reference(2 * block_threads);
+  for (int pass = 0; pass < 2; ++pass)
+  {
+    const int input_offset  = pass * block_threads;
+    const int output_offset = pass * block_threads;
+    for (int row = 0; row < RowsPerBlock; ++row)
+    {
+      const int row_begin = row * row_threads;
+      int row_sum         = 0;
+      for (int item = 0; item < row_threads; ++item)
+      {
+        row_sum += input_offset + row_begin + item;
+      }
+      for (int item = 0; item < row_threads; ++item)
+      {
+        h_reference[output_offset + row_begin + item] = row_sum;
+      }
+    }
+  }
+
+  c2h::host_vector<int> h_output = d_output;
+  REQUIRE(h_reference == h_output);
+}
+
+using value_types = c2h::type_list<::cuda::std::uint16_t, ::cuda::std::int32_t, ::cuda::std::int64_t, float>;
+using row_layouts = c2h::type_list<
+  row_reduce_layout<1, 1>,
+  row_reduce_layout<1, 2>,
+  row_reduce_layout<1, 4>,
+  row_reduce_layout<1, 8>,
+  row_reduce_layout<1, 16>,
+  row_reduce_layout<2, 1>,
+  row_reduce_layout<2, 2>,
+  row_reduce_layout<2, 4>,
+  row_reduce_layout<2, 8>,
+  row_reduce_layout<2, 16>,
+  row_reduce_layout<4, 1>,
+  row_reduce_layout<4, 2>,
+  row_reduce_layout<4, 4>,
+  row_reduce_layout<4, 8>>;
+using reduction_ops = c2h::type_list<::cuda::std::plus<>, ::cuda::maximum<>, ::cuda::minimum<>>;
+
+C2H_TEST("BlockRowReduce returns one aggregate per row", "[block][reduce][row]", value_types, row_layouts)
+{
+  using value_t              = typename c2h::get<0, TestType>;
+  using layout_t             = typename c2h::get<1, TestType>;
+  constexpr int num_rows     = layout_t::rows_per_block;
+  constexpr int warps_in_row = layout_t::warps_per_row;
+
+  test_block_row_reduce<BlockRowReduceVariant::SharedBroadcast, BlockRowReduceMode::Sum, num_rows, warps_in_row, value_t>(
+    ::cuda::std::plus<>{});
+}
+
+C2H_TEST(
+  "BlockRowReduce supports custom row reductions", "[block][reduce][row]", value_types, row_layouts, reduction_ops)
+{
+  using value_t              = typename c2h::get<0, TestType>;
+  using layout_t             = typename c2h::get<1, TestType>;
+  constexpr int num_rows     = layout_t::rows_per_block;
+  constexpr int warps_in_row = layout_t::warps_per_row;
+  using op_t                 = typename c2h::get<2, TestType>;
+
+  test_block_row_reduce<BlockRowReduceVariant::SharedBroadcast,
+                        BlockRowReduceMode::Reduce,
+                        num_rows,
+                        warps_in_row,
+                        value_t,
+                        op_t>();
+}
+
+C2H_TEST(
+  "BlockRowReduceWarpBroadcast::Sum returns one aggregate per row", "[block][reduce][row]", value_types, row_layouts)
+{
+  using value_t              = typename c2h::get<0, TestType>;
+  using layout_t             = typename c2h::get<1, TestType>;
+  constexpr int num_rows     = layout_t::rows_per_block;
+  constexpr int warps_in_row = layout_t::warps_per_row;
+
+  test_block_row_reduce<BlockRowReduceVariant::WarpBroadcast, BlockRowReduceMode::Sum, num_rows, warps_in_row, value_t>(
+    ::cuda::std::plus<>{});
+}
+
+C2H_TEST("BlockRowReduceWarpBroadcast supports custom row reductions",
+         "[block][reduce][row]",
+         value_types,
+         row_layouts,
+         reduction_ops)
+{
+  using value_t              = typename c2h::get<0, TestType>;
+  using layout_t             = typename c2h::get<1, TestType>;
+  constexpr int num_rows     = layout_t::rows_per_block;
+  constexpr int warps_in_row = layout_t::warps_per_row;
+  using op_t                 = typename c2h::get<2, TestType>;
+
+  test_block_row_reduce<BlockRowReduceVariant::WarpBroadcast,
+                        BlockRowReduceMode::Reduce,
+                        num_rows,
+                        warps_in_row,
+                        value_t,
+                        op_t>();
+}
+
+C2H_TEST("BlockRowReduce variants support custom identities", "[block][reduce][row]")
+{
+  test_block_row_reduce<BlockRowReduceVariant::SharedBroadcast,
+                        BlockRowReduceMode::Reduce,
+                        1,
+                        4,
+                        int,
+                        modular_multiply_op>();
+  test_block_row_reduce<BlockRowReduceVariant::SharedBroadcast,
+                        BlockRowReduceMode::Reduce,
+                        3,
+                        3,
+                        int,
+                        modular_multiply_op>();
+  test_block_row_reduce<BlockRowReduceVariant::WarpBroadcast, BlockRowReduceMode::Reduce, 1, 4, int, modular_multiply_op>();
+  test_block_row_reduce<BlockRowReduceVariant::WarpBroadcast, BlockRowReduceMode::Reduce, 3, 3, int, modular_multiply_op>();
+}
+
+C2H_TEST("BlockRowReduce supports associative non-commutative row reductions", "[block][reduce][row]")
+{
+  test_block_row_reduce_non_commutative<1, 1>();
+  test_block_row_reduce_non_commutative<1, 4>();
+  test_block_row_reduce_non_commutative<1, 8>();
+  test_block_row_reduce_non_commutative<2, 2>();
+  test_block_row_reduce_non_commutative<2, 8>();
+}
+
+C2H_TEST("BlockRowReduce supports private temporary storage", "[block][reduce][row]")
+{
+  test_block_row_reduce_private_storage<BlockRowReduceVariant::SharedBroadcast, 1, 1>();
+  test_block_row_reduce_private_storage<BlockRowReduceVariant::SharedBroadcast, 2, 2>();
+  test_block_row_reduce_private_storage<BlockRowReduceVariant::WarpBroadcast, 1, 1>();
+  test_block_row_reduce_private_storage<BlockRowReduceVariant::WarpBroadcast, 2, 2>();
+}
+
+C2H_TEST("BlockRowReduce supports multidimensional thread blocks", "[block][reduce][row]")
+{
+  test_block_row_reduce_multidimensional<BlockRowReduceVariant::SharedBroadcast, 2, 2>();
+  test_block_row_reduce_multidimensional<BlockRowReduceVariant::WarpBroadcast, 2, 2>();
+}
+
+C2H_TEST("BlockRowReduce supports temporary storage reuse", "[block][reduce][row]")
+{
+  test_block_row_reduce_reuse_temp_storage<BlockRowReduceVariant::SharedBroadcast, 1, 4>();
+  test_block_row_reduce_reuse_temp_storage<BlockRowReduceVariant::SharedBroadcast, 2, 8>();
+  test_block_row_reduce_reuse_temp_storage<BlockRowReduceVariant::WarpBroadcast, 1, 4>();
+  test_block_row_reduce_reuse_temp_storage<BlockRowReduceVariant::WarpBroadcast, 2, 8>();
+}
+
+C2H_TEST("BlockRowReduceWarpBroadcast returns lane-invariant floating-point sums", "[block][reduce][row]")
+{
+  test_block_row_reduce_warp_broadcast_float_consistency<1, 1>();
+  test_block_row_reduce_warp_broadcast_float_consistency<1, 4>();
+  test_block_row_reduce_warp_broadcast_float_consistency<2, 3>();
+}
+
+C2H_TEST("BlockRowReduce supports maximum block width", "[block][reduce][row]")
+{
+  test_block_row_reduce<BlockRowReduceVariant::SharedBroadcast, BlockRowReduceMode::Sum, 1, 32, ::cuda::std::int32_t>(
+    ::cuda::std::plus<>{});
+  test_block_row_reduce<BlockRowReduceVariant::SharedBroadcast, BlockRowReduceMode::Sum, 32, 1, ::cuda::std::int32_t>(
+    ::cuda::std::plus<>{});
+  test_block_row_reduce<BlockRowReduceVariant::WarpBroadcast, BlockRowReduceMode::Sum, 1, 32, ::cuda::std::int32_t>(
+    ::cuda::std::plus<>{});
+  test_block_row_reduce<BlockRowReduceVariant::WarpBroadcast, BlockRowReduceMode::Sum, 32, 1, ::cuda::std::int32_t>(
+    ::cuda::std::plus<>{});
+}
+
+C2H_TEST("BlockRowReduce supports non-power-of-two row layouts", "[block][reduce][row]")
+{
+  test_block_row_reduce<BlockRowReduceVariant::SharedBroadcast, BlockRowReduceMode::Sum, 3, 3, ::cuda::std::int32_t>(
+    ::cuda::std::plus<>{});
+  test_block_row_reduce<BlockRowReduceVariant::SharedBroadcast, BlockRowReduceMode::Sum, 5, 3, ::cuda::std::int32_t>(
+    ::cuda::std::plus<>{});
+  test_block_row_reduce<BlockRowReduceVariant::WarpBroadcast, BlockRowReduceMode::Sum, 3, 3, ::cuda::std::int32_t>(
+    ::cuda::std::plus<>{});
+  test_block_row_reduce<BlockRowReduceVariant::WarpBroadcast, BlockRowReduceMode::Sum, 5, 3, ::cuda::std::int32_t>(
+    ::cuda::std::plus<>{});
+}

--- a/docs/cub/api_docs/block_wide.rst
+++ b/docs/cub/api_docs/block_wide.rst
@@ -20,6 +20,8 @@ CUB block-level algorithms are specialized for execution by threads in the same 
 * :cpp:class:`cub::BlockMergeSort` sorts items partitioned across a CUDA thread block
 * :cpp:class:`cub::BlockRadixSort` sorts items partitioned across a CUDA thread block using radix sorting method
 * :cpp:struct:`cub::BlockReduce` computes reduction of items partitioned across a CUDA thread block
+* :cpp:class:`cub::BlockRowReduce` computes independent row-shaped reductions within a CUDA thread block
+* :cpp:class:`cub::BlockRowReduceWarpBroadcast` computes row-shaped commutative reductions and returns each row aggregate through warp broadcasts
 * :cpp:class:`cub::BlockRunLengthDecode` decodes a run-length encoded sequence partitioned across a CUDA thread block
 * :cpp:struct:`cub::BlockScan` computes a prefix scan of items partitioned across a CUDA thread block
 * :cpp:struct:`cub::BlockShuffle` shifts items partitioned across a CUDA thread block


### PR DESCRIPTION
## Summary

Adds row-shaped CUB block reductions for CTA layouts where each block owns one or more rows:

- `cub::BlockRowReduce<T, RowsPerBlock, WarpsPerRow>`: associative row reductions where each row spans one or more full warps and every row thread receives its row aggregate.
- `cub::BlockRowReduceWarpBroadcast<T, RowsPerBlock, WarpsPerRow>`: commutative row reductions that avoid the final shared-memory row-total publication/barrier by reusing warp broadcasts.

These are intended for norm-style and row-major CTA kernels that otherwise hand-write warp grouping, shared scratch layout, row publication, and synchronization plumbing.

## Why these primitives

A common GPU-kernel shape is "one CTA owns several rows" or "one row spans several warps." The reduction is conceptually row-local, but implementations have to manually derive row id, warp-in-row id, shared-memory coordinates, leader warp behavior, and row-total publication. That code is more about topology than math. A CUB row-reduction primitive makes the row topology explicit and gives cuda.coop DSLs a stable primitive to lower to.

Concrete OSS patterns this can replace or simplify:

- FlashInfer RMSNorm's CuTe kernel is parameterized by `rows_per_block`, `threads_per_row`, and `warps_per_row`, allocates a `(rows_per_block, warps_per_row)` reduction buffer, then calls a multi-row row reduction for the sum of squares: https://github.com/flashinfer-ai/flashinfer/blob/97b7de6846e72a9f5cbb536ac8eff04d2e9535bb/flashinfer/norm/kernels/rmsnorm.py#L257-L285 and https://github.com/flashinfer-ai/flashinfer/blob/97b7de6846e72a9f5cbb536ac8eff04d2e9535bb/flashinfer/norm/kernels/rmsnorm.py#L382-L386
- FlashInfer's FP4 common utilities implement row-local reductions by computing `row_idx` and `col_idx`, storing per-warp row partials to shared memory, synchronizing, and reducing the row total: https://github.com/flashinfer-ai/flashinfer/blob/97b7de6846e72a9f5cbb536ac8eff04d2e9535bb/flashinfer/cute_dsl/fp4_common.py#L1154-L1174 and https://github.com/flashinfer-ai/flashinfer/blob/97b7de6846e72a9f5cbb536ac8eff04d2e9535bb/flashinfer/cute_dsl/fp4_common.py#L1230-L1257
- vLLM's MiniMax RMS float4 path processes four token rows at once with `block_reduce_sum[4][...]`, per-row warp partial writes, barriers, leader-warp row reductions, and per-row scale publication: https://github.com/vllm-project/vllm/blob/2ee51063722c9e6d28f71340966942394f330c0e/csrc/libtorch_stable/minimax_reduce_rms_kernel.cu#L420-L552

`BlockRowReduce` covers the general row-reduction shape. `BlockRowReduceWarpBroadcast` targets the commutative version where each row thread needs the aggregate and we can avoid some of the final shared-memory publication pattern.

## Validation

- `git diff --check`
- `pre-commit run --files cub/cub/block/block_row_reduce.cuh cub/test/catch2_test_block_row_reduce.cu cub/benchmarks/bench/reduce/block_row_reduce.cu docs/cub/api_docs/block_wide.rst cub/cub/cub.cuh`
- `bash ci/util/build_and_test_targets.sh --preset cub-cpp20 --build-targets "cub.headers.base cub.test.block.row_reduce" --ctest-targets '^cub\.test\.block\.row_reduce$'`
  - Passed: 1,634,385 assertions in 455 test cases.
- Benchmark smoke on NVIDIA RTX PRO 6000 Blackwell Workstation Edition:
  - `cmake --build build/cub-benchmark --target cub.bench.reduce.block_row_reduce.base -j "$(nproc)" && ./build/cub-benchmark/bin/cub.bench.reduce.block_row_reduce.base --devices 0 --profile --timeout 5 --min-samples 1 --min-time 0.001`
  - Passed 36/36 cases.

## Local Review

- Local roborev branch reviews completed with Codex, Gemini, and Claude.
- Codex and Gemini reported no issues.
- Claude reported only non-blocking advisory lows after cleanup; the actionable comment-only mask and benchmark-contract notes were addressed before this draft PR.
