### PR TITLE
[cudax] Implement `cudax::coop::shuffle` for threads within a warp

### DIFF
--- a/cudax/include/cuda/experimental/__coop/shuffle.cuh
+++ b/cudax/include/cuda/experimental/__coop/shuffle.cuh
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_EXPERIMENTAL___COOP_SHUFFLE_CUH
+#define _CUDA_EXPERIMENTAL___COOP_SHUFFLE_CUH
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__ptx/instructions/get_sreg.h>
+#include <cuda/__warp/warp_shuffle.h>
+#include <cuda/std/__type_traits/is_same.h>
+
+#include <cuda/experimental/group.cuh>
+
+#include <cuda/std/__cccl/prologue.h>
+
+#if !defined(_CCCL_DOXYGEN_INVOKED)
+
+namespace cuda::experimental::coop
+{
+template <bool _Dummy = false>
+[[nodiscard]] _CCCL_DEVICE_API auto __shuffle_impl(...)
+{
+  static_assert(_Dummy, "cudax::coop::shuffle is not implemented for this group");
+}
+
+_CCCL_TEMPLATE(class _Group, class _Tp)
+_CCCL_REQUIRES(is_group<_Group> _CCCL_AND ::cuda::std::is_same_v<typename _Group::unit_type, thread_level>
+                 _CCCL_AND ::cuda::std::is_same_v<typename _Group::level_type, warp_level>)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __shuffle_impl(const _Group& __group, _Tp __value, unsigned __src_rank) noexcept
+{
+  using _MappingResult         = typename _Group::__mapping_result_type;
+  const auto& __mapping_result = __group.__mapping_result();
+
+  _CCCL_ASSERT(__src_rank < __mapping_result.count(),
+               "invalid __src_rank - must be less than the number of units within the group");
+
+  const auto __lane_mask   = __mapping_result.lane_mask();
+  const auto __lane_offset = static_cast<int>(__src_rank) - static_cast<int>(__mapping_result.rank());
+
+  unsigned __src_lane{};
+  if constexpr (_MappingResult::is_always_contiguous())
+  {
+    const auto __lane = ::cuda::ptx::get_sreg_laneid();
+    __src_lane        = static_cast<unsigned>(__lane + __lane_offset);
+  }
+  else
+  {
+    __src_lane = ::__fns(__lane_mask.value(), 0, static_cast<int>(__src_rank) + 1);
+  }
+  return ::cuda::device::warp_shuffle_idx(__value, static_cast<int>(__src_lane), __lane_mask.value());
+}
+
+//! @brief Shuffles values among units within a group.
+//! @param[in] __group The group.
+//! @param[in] __value This thread's value to be shuffled.
+//! @param[in] __src_rank The rank of the unit whose value should be taken by this unit.
+//! @return The value passed to the function by the equivalent thread from the source rank unit.
+template <class _Group, class _Tp>
+[[nodiscard]] _CCCL_DEVICE_API _Tp shuffle(const _Group& __group, _Tp __value, unsigned __src_rank) noexcept
+{
+  return ::cuda::experimental::coop::__shuffle_impl(__group, __value, __src_rank);
+}
+} // namespace cuda::experimental::coop
+
+#endif // !_CCCL_DOXYGEN_INVOKED
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_EXPERIMENTAL___COOP_SHUFFLE_CUH

--- a/cudax/include/cuda/experimental/__group/mapping/binary_partition.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/binary_partition.cuh
@@ -45,7 +45,7 @@ class binary_partition
 {
   static_assert(::cuda::std::is_move_constructible_v<_Fn>, "_Fn must be move constructible");
 
-  _Fn __fn_;
+  mutable _Fn __fn_;
 
 public:
   _CCCL_DEVICE_API explicit binary_partition(_Fn __fn) noexcept(::cuda::std::is_nothrow_move_constructible_v<_Fn>)
@@ -54,8 +54,8 @@ public:
 
   template <class _Unit, class _ParentGroup, class _PrevMappingResult>
   [[nodiscard]] _CCCL_DEVICE_API auto
-  map(const _Unit&, const _ParentGroup& __parent, const _PrevMappingResult& __prev_mapping_result) noexcept(
-    ::cuda::std::is_nothrow_invocable_v<_Fn, const _PrevMappingResult&>)
+  map(const _Unit&, const _ParentGroup& __parent, const _PrevMappingResult& __prev_mapping_result) const
+    noexcept(::cuda::std::is_nothrow_invocable_v<_Fn, const _PrevMappingResult&>)
   {
     static_assert(::cuda::std::is_same_v<_Unit, thread_level>, "binary_partition can only group threads");
     static_assert(::cuda::std::is_same_v<typename _ParentGroup::level_type, warp_level>,

--- a/cudax/include/cuda/experimental/coop.cuh
+++ b/cudax/include/cuda/experimental/coop.cuh
@@ -22,5 +22,6 @@
 #endif // no system header
 
 #include <cuda/experimental/__coop/reduce.cuh>
+#include <cuda/experimental/__coop/shuffle.cuh>
 
 #endif // _CUDA_EXPERIMENTAL_COOP

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -203,6 +203,10 @@ cudax_add_catch2_test(test_target coop.reduce.warps_within_block
     coop/reduce/warps_within_block.cu
 )
 
+cudax_add_catch2_test(test_target coop.shuffle.threads_within_warp
+    coop/shuffle/threads_within_warp.cu
+)
+
 if (cudax_ENABLE_CUFILE)
   cudax_add_catch2_test(test_target cufile.driver_attributes
       cufile/driver_attributes.cu

--- a/cudax/test/coop/shuffle/threads_within_warp.cu
+++ b/cudax/test/coop/shuffle/threads_within_warp.cu
@@ -1,0 +1,141 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/devices>
+#include <cuda/hierarchy>
+#include <cuda/launch>
+#include <cuda/stream>
+#include <cuda/type_traits>
+
+#include <cuda/experimental/coop.cuh>
+#include <cuda/experimental/group.cuh>
+
+#include "testing.cuh"
+
+template <class T>
+__device__ T make_instance_for(unsigned rank)
+{
+  if constexpr (cuda::is_vector_type_v<T>)
+  {
+    using U = cuda::scalar_type_t<T>;
+    return T{static_cast<U>(rank), static_cast<U>(rank), static_cast<U>(rank)};
+  }
+  else
+  {
+    return static_cast<T>(rank);
+  }
+}
+
+template <class T, class Group>
+__device__ void test_group(const Group& group)
+{
+  // Exit all threads that are not part of the group.
+  if (!cuda::gpu_thread.is_part_of(group))
+  {
+    return;
+  }
+
+  const auto my_rank  = cuda::gpu_thread.rank_as<unsigned>(group);
+  const auto my_value = make_instance_for<T>(my_rank);
+
+  // Test identity.
+  REQUIRE(cudax::coop::shuffle(group, my_value, my_rank) == my_value);
+
+  // Test broadcast from root rank.
+  REQUIRE(cudax::coop::shuffle(group, my_value, 0) == make_instance_for<T>(0));
+
+  // Test broadcast from last rank.
+  {
+    const auto other_rank = cuda::gpu_thread.count_as<unsigned>(group) - 1;
+    REQUIRE(cudax::coop::shuffle(group, my_value, other_rank) == make_instance_for<T>(other_rank));
+  }
+
+  // Test my_rank + 1.
+  {
+    const auto other_rank = (my_rank + 1) % cuda::gpu_thread.count_as<unsigned>(group);
+    REQUIRE(cudax::coop::shuffle(group, my_value, other_rank) == make_instance_for<T>(other_rank));
+  }
+
+  // Test my_rank + 6.
+  {
+    const auto other_rank = (my_rank + 6) % cuda::gpu_thread.count_as<unsigned>(group);
+    REQUIRE(cudax::coop::shuffle(group, my_value, other_rank) == make_instance_for<T>(other_rank));
+  }
+
+  // Test my_rank +- 1 based on whether my_rank is even or not.
+  {
+    const auto other_rank =
+      ((my_rank % 2 == 0) ? my_rank + 1 : my_rank - 1) % cuda::gpu_thread.count_as<unsigned>(group);
+    REQUIRE(cudax::coop::shuffle(group, my_value, other_rank) == make_instance_for<T>(other_rank));
+  }
+
+  // Test my_rank +- 3 based on whether my_rank is even or not.
+  {
+    const auto other_rank =
+      ((my_rank % 2 == 0) ? my_rank + 3 : my_rank - 3) % cuda::gpu_thread.count_as<unsigned>(group);
+    REQUIRE(cudax::coop::shuffle(group, my_value, other_rank) == make_instance_for<T>(other_rank));
+  }
+}
+
+struct CustomBinaryPartition
+{
+  template <class MappingResult>
+  __device__ bool operator()(MappingResult mapping_result)
+  {
+    switch (mapping_result.rank())
+    {
+      case 1:
+      case 5:
+      case 14:
+      case 15:
+      case 31:
+        return true;
+      default:
+        return false;
+    }
+  }
+};
+
+template <class T, class Config>
+__device__ void test_type(const Config& config)
+{
+  const cudax::this_warp warp{config};
+  test_group<T>(cudax::group{cuda::gpu_thread, warp, cudax::identity_mapping{}, cudax::lane_synchronizer{}});
+  test_group<T>(cudax::group{cuda::gpu_thread, warp, cudax::group_by<4>{}, cudax::lane_synchronizer{}});
+  test_group<T>(cudax::group{cuda::gpu_thread, warp, cudax::group_by{1}, cudax::lane_synchronizer{}});
+  test_group<T>(
+    cudax::group{cuda::gpu_thread, warp, cudax::group_by{3, cudax::non_exhaustive}, cudax::lane_synchronizer{}});
+  test_group<T>(
+    cudax::group{cuda::gpu_thread, warp, cudax::binary_partition{CustomBinaryPartition{}}, cudax::lane_synchronizer{}});
+}
+
+struct TestKernel
+{
+  template <class Config>
+  __device__ void operator()(const Config& config)
+  {
+    test_type<signed char>(config);
+    test_type<unsigned>(config);
+    test_type<unsigned long long>(config);
+    test_type<longlong3>(config);
+  }
+};
+
+C2H_TEST("shuffle/threads_within_warp", "[shuffle][threads_within_warp]")
+{
+  const auto device = cuda::devices[0];
+
+  const cuda::stream stream{device};
+
+  const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims<32>());
+  cuda::launch(stream, config, TestKernel{});
+
+  stream.sync();
+}

--- a/cudax/test/group/mapping/binary_partition.cu
+++ b/cudax/test/group/mapping/binary_partition.cu
@@ -68,11 +68,12 @@ __device__ void test_binary_partition(Config config)
       const cudax::this_warp parent_group{config};
       const ThreadsInWarpMappingResult prev_mapping_result;
 
-      static_assert(cudax::__group_mapping_result<decltype(cuda::std::declval<Mapping>().map(
+      static_assert(cudax::__group_mapping_result<decltype(cuda::std::declval<const Mapping>().map(
                       cuda::gpu_thread, parent_group, prev_mapping_result))>);
-      static_assert(!noexcept(cuda::std::declval<Mapping>().map(cuda::gpu_thread, parent_group, prev_mapping_result)));
+      static_assert(
+        !noexcept(cuda::std::declval<const Mapping>().map(cuda::gpu_thread, parent_group, prev_mapping_result)));
 
-      Mapping mapping{Pred{}};
+      const Mapping mapping{Pred{}};
       auto result  = mapping.map(cuda::gpu_thread, parent_group, prev_mapping_result);
       using Result = decltype(result);
 
@@ -108,11 +109,12 @@ __device__ void test_binary_partition(Config config)
       const cudax::this_warp parent_group{config};
       const ThreadsInWarpMappingResult prev_mapping_result;
 
-      static_assert(cudax::__group_mapping_result<decltype(cuda::std::declval<Mapping>().map(
+      static_assert(cudax::__group_mapping_result<decltype(cuda::std::declval<const Mapping>().map(
                       cuda::gpu_thread, parent_group, prev_mapping_result))>);
-      static_assert(noexcept(cuda::std::declval<Mapping>().map(cuda::gpu_thread, parent_group, prev_mapping_result)));
+      static_assert(
+        noexcept(cuda::std::declval<const Mapping>().map(cuda::gpu_thread, parent_group, prev_mapping_result)));
 
-      Mapping mapping{Pred{}};
+      const Mapping mapping{Pred{}};
       auto result  = mapping.map(cuda::gpu_thread, parent_group, prev_mapping_result);
       using Result = decltype(result);
 
@@ -148,11 +150,12 @@ __device__ void test_binary_partition(Config config)
       const cudax::this_warp parent_group{config};
       const ThreadsInWarpMappingResult prev_mapping_result;
 
-      static_assert(cudax::__group_mapping_result<decltype(cuda::std::declval<Mapping>().map(
+      static_assert(cudax::__group_mapping_result<decltype(cuda::std::declval<const Mapping>().map(
                       cuda::gpu_thread, parent_group, prev_mapping_result))>);
-      static_assert(!noexcept(cuda::std::declval<Mapping>().map(cuda::gpu_thread, parent_group, prev_mapping_result)));
+      static_assert(
+        !noexcept(cuda::std::declval<const Mapping>().map(cuda::gpu_thread, parent_group, prev_mapping_result)));
 
-      Mapping mapping{Pred{}};
+      const Mapping mapping{Pred{}};
       auto result  = mapping.map(cuda::gpu_thread, parent_group, prev_mapping_result);
       using Result = decltype(result);
 


### PR DESCRIPTION
Fixes #9374.