### PR TITLE
Allow public tuning of the `cub::DeviceReduce::ReduceByKey` and `cub::DeviceRunLengthEncode::Encode`

### DIFF
--- a/cub/benchmarks/bench/reduce/by_key.cu
+++ b/cub/benchmarks/bench/reduce/by_key.cu
@@ -17,8 +17,7 @@
 #if !TUNE_BASE
 struct bench_reduce_by_key_policy_selector
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::reduce_by_key::reduce_by_key_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::ReduceByKeyPolicy
   {
     return {
       TUNE_THREADS,

--- a/cub/benchmarks/bench/run_length_encode/encode.cu
+++ b/cub/benchmarks/bench/run_length_encode/encode.cu
@@ -17,8 +17,7 @@
 #if !TUNE_BASE
 struct bench_encode_policy_selector
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::reduce_by_key::reduce_by_key_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::ReduceByKeyPolicy
   {
     return {
       TUNE_THREADS,

--- a/cub/benchmarks/bench/run_length_encode/encode.cu
+++ b/cub/benchmarks/bench/run_length_encode/encode.cu
@@ -17,7 +17,7 @@
 #if !TUNE_BASE
 struct bench_encode_policy_selector
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::ReduceByKeyPolicy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::RLEEncodePolicy
   {
     return {
       TUNE_THREADS,

--- a/cub/benchmarks/bench/run_length_encode/encode.cu
+++ b/cub/benchmarks/bench/run_length_encode/encode.cu
@@ -17,7 +17,7 @@
 #if !TUNE_BASE
 struct bench_encode_policy_selector
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::RLEEncodePolicy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::RleEncodePolicy
   {
     return {
       TUNE_THREADS,

--- a/cub/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/cub/agent/agent_reduce_by_key.cuh
@@ -36,49 +36,20 @@ CUB_NAMESPACE_BEGIN
  * Tuning policy types
  ******************************************************************************/
 
-/**
- * @brief Parameterizable tuning policy type for AgentReduceByKey
- *
- * @tparam ThreadsPerBlock
- *   Threads per thread block
- *
- * @tparam ItemsPerThread
- *   Items per thread (per tile of input)
- *
- * @tparam LoadAlgorithm
- *   The BlockLoad algorithm to use
- *
- * @tparam LoadModifier
- *   Cache load modifier for reading input elements
- *
- * @tparam ScanAlgorithm
- *   The BlockScan algorithm to use
- *
- * @tparam DelayConstructorT
- *   Implementation detail, do not specify directly, requirements on the
- *   content of this type are subject to breaking change.
- */
+namespace detail
+{
 template <int ThreadsPerBlock,
           int ItemsPerThread,
           BlockLoadAlgorithm LoadAlgorithm,
           CacheLoadModifier LoadModifier,
           BlockScanAlgorithm ScanAlgorithm,
           typename DelayConstructorT = detail::fixed_delay_constructor_t<350, 450>>
-struct AgentReduceByKeyPolicy
+struct agent_reduce_by_key_policy
 {
-  ///< Threads per thread block
-  static constexpr int BLOCK_THREADS = ThreadsPerBlock;
-
-  ///< Items per thread (per tile of input)
-  static constexpr int ITEMS_PER_THREAD = ItemsPerThread;
-
-  ///< The BlockLoad algorithm to use
+  static constexpr int BLOCK_THREADS                 = ThreadsPerBlock;
+  static constexpr int ITEMS_PER_THREAD              = ItemsPerThread;
   static constexpr BlockLoadAlgorithm LOAD_ALGORITHM = LoadAlgorithm;
-
-  ///< Cache load modifier for reading input elements
-  static constexpr CacheLoadModifier LOAD_MODIFIER = LoadModifier;
-
-  ///< The BlockScan algorithm to use
+  static constexpr CacheLoadModifier LOAD_MODIFIER   = LoadModifier;
   static constexpr BlockScanAlgorithm SCAN_ALGORITHM = ScanAlgorithm;
 
   struct detail
@@ -86,6 +57,16 @@ struct AgentReduceByKeyPolicy
     using delay_constructor_t = DelayConstructorT;
   };
 };
+} // namespace detail
+
+template <int ThreadsPerBlock,
+          int ItemsPerThread,
+          BlockLoadAlgorithm LoadAlgorithm,
+          CacheLoadModifier LoadModifier,
+          BlockScanAlgorithm ScanAlgorithm,
+          typename DelayConstructorT = detail::fixed_delay_constructor_t<350, 450>>
+using AgentReduceByKeyPolicy CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceReduce::ReduceByKey") = detail::
+  agent_reduce_by_key_policy<ThreadsPerBlock, ItemsPerThread, LoadAlgorithm, LoadModifier, ScanAlgorithm, DelayConstructorT>;
 
 /******************************************************************************
  * Thread block abstractions

--- a/cub/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/cub/agent/agent_reduce_by_key.cuh
@@ -59,6 +59,7 @@ struct agent_reduce_by_key_policy
 };
 } // namespace detail
 
+//! Deprecated [Since 3.5]
 template <int ThreadsPerBlock,
           int ItemsPerThread,
           BlockLoadAlgorithm LoadAlgorithm,

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -2156,6 +2156,25 @@ public:
   //!     :start-after: example-begin reduce-by-key-env
   //!     :end-before: example-end reduce-by-key-env
   //!
+  //! Tuning
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! ``DeviceReduce::ReduceByKey`` can be tuned by passing a custom
+  //! :ref:`policy selector <cub-policy-selectors>` that returns a @ref ReduceByKeyPolicy, as shown in the
+  //! example below:
+  //!
+  //!  .. literalinclude:: ../../../cub/test/catch2_test_device_reduce_by_key_env_api.cu
+  //!      :language: c++
+  //!      :dedent:
+  //!      :start-after: example-begin reduce-by-key-policy-selector
+  //!      :end-before: example-end reduce-by-key-policy-selector
+  //!
+  //!  .. literalinclude:: ../../../cub/test/catch2_test_device_reduce_by_key_env_api.cu
+  //!      :language: c++
+  //!      :dedent:
+  //!      :start-after: example-begin reduce-by-key-tuning
+  //!      :end-before: example-end reduce-by-key-tuning
+  //!
   //! @endrst
   //!
   //! @tparam KeysInputIteratorT

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -85,6 +85,25 @@ inline constexpr bool is_non_deterministic_v =
 //!
 //! @linear_performance{reduction, reduce-by-key, and run-length encode}
 //!
+//! Tuning
+//! +++++++++++++++++++++++++++++++++++++++++++++
+//!
+//! ``DeviceReduce::ReduceByKey`` can be tuned by passing a custom
+//! :ref:`policy selector <cub-policy-selectors>` that returns a @ref ReduceByKeyPolicy, as shown in the
+//! example below:
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_reduce_by_key_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin reduce-by-key-policy-selector
+//!      :end-before: example-end reduce-by-key-policy-selector
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_reduce_by_key_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin reduce-by-key-tuning
+//!      :end-before: example-end reduce-by-key-tuning
+//!
 //! @endrst
 struct DeviceReduce
 {
@@ -2155,25 +2174,6 @@ public:
   //!     :dedent:
   //!     :start-after: example-begin reduce-by-key-env
   //!     :end-before: example-end reduce-by-key-env
-  //!
-  //! Tuning
-  //! +++++++++++++++++++++++++++++++++++++++++++++
-  //!
-  //! ``DeviceReduce::ReduceByKey`` can be tuned by passing a custom
-  //! :ref:`policy selector <cub-policy-selectors>` that returns a @ref ReduceByKeyPolicy, as shown in the
-  //! example below:
-  //!
-  //!  .. literalinclude:: ../../../cub/test/catch2_test_device_reduce_by_key_env_api.cu
-  //!      :language: c++
-  //!      :dedent:
-  //!      :start-after: example-begin reduce-by-key-policy-selector
-  //!      :end-before: example-end reduce-by-key-policy-selector
-  //!
-  //!  .. literalinclude:: ../../../cub/test/catch2_test_device_reduce_by_key_env_api.cu
-  //!      :language: c++
-  //!      :dedent:
-  //!      :start-after: example-begin reduce-by-key-tuning
-  //!      :end-before: example-end reduce-by-key-tuning
   //!
   //! @endrst
   //!

--- a/cub/cub/device/device_run_length_encode.cuh
+++ b/cub/cub/device/device_run_length_encode.cuh
@@ -71,7 +71,7 @@ struct DeviceRunLengthEncode
     [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
       -> ReduceByKeyPolicy
     {
-      const RLEEncodePolicy policy = PolicySelector{}(cc);
+      const RleEncodePolicy policy = PolicySelector{}(cc);
       return ReduceByKeyPolicy{
         policy.threads_per_block,
         policy.items_per_thread,

--- a/cub/cub/device/device_run_length_encode.cuh
+++ b/cub/cub/device/device_run_length_encode.cuh
@@ -64,7 +64,7 @@ struct DeviceRunLengthEncode
   // to adapt the policy selector to convert the tuning policy
   template <typename PolicySelector>
 #  if _CCCL_HAS_CONCEPTS()
-    requires detail::rle::rle_encode_policy_selector<PolicySelector>
+    requires detail::rle::encode::rle_encode_policy_selector<PolicySelector>
 #  endif // _CCCL_HAS_CONCEPTS()
   struct __policy_selector_adapter
   {

--- a/cub/cub/device/device_run_length_encode.cuh
+++ b/cub/cub/device/device_run_length_encode.cuh
@@ -327,7 +327,7 @@ struct DeviceRunLengthEncode
     using default_policy_selector = detail::rle::encode::policy_selector_from_types<accum_t, key_t>;
 
     return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+      env, [&]([[maybe_unused]] auto policy_selector, void* storage, size_t& bytes, auto stream) {
         return detail::reduce_by_key::dispatch_streaming(
           storage,
           bytes,
@@ -340,7 +340,7 @@ struct DeviceRunLengthEncode
           reduction_op{},
           static_cast<offset_t>(num_items),
           stream,
-          policy_selector);
+          __policy_selector_adapter<decltype(policy_selector)>{});
       });
   }
 

--- a/cub/cub/device/device_run_length_encode.cuh
+++ b/cub/cub/device/device_run_length_encode.cuh
@@ -59,6 +59,30 @@ CUB_NAMESPACE_BEGIN
 //! @endrst
 struct DeviceRunLengthEncode
 {
+#ifndef _CCCL_DOXYGEN_INVOKED // Do not document
+  // DeviceRunLengthEncode::Encode dispatches to ReduceByKey, but we want to have a dedicated tuning policy, so we need
+  // to adapt the policy selector to convert the tuning policy
+  template <typename PolicySelector>
+#  if _CCCL_HAS_CONCEPTS()
+    requires detail::rle::rle_encode_policy_selector<PolicySelector>
+#  endif // _CCCL_HAS_CONCEPTS()
+  struct __policy_selector_adapter
+  {
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
+      -> ReduceByKeyPolicy
+    {
+      const RLEEncodePolicy policy = PolicySelector{}(cc);
+      return ReduceByKeyPolicy{
+        policy.threads_per_block,
+        policy.items_per_thread,
+        policy.load_algorithm,
+        policy.load_modifier,
+        policy.scan_algorithm,
+        policy.lookback_delay};
+    }
+  };
+#endif // _CCCL_DOXYGEN_INVOKED
+
   //! @rst
   //! Computes a run-length encoding of the sequence ``d_in``.
   //!
@@ -203,7 +227,7 @@ struct DeviceRunLengthEncode
       reduction_op{},
       static_cast<offset_t>(num_items),
       stream,
-      policy_selector_t{});
+      __policy_selector_adapter<policy_selector_t>{});
   }
 
   //! @rst

--- a/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
@@ -203,16 +203,14 @@ __launch_bounds__(int(current_policy<PolicySelector>().threads_per_block))
     _CCCL_GRID_CONSTANT const StreamingContextT streaming_context,
     vsmem_t vsmem)
 {
-  static constexpr reduce_by_key_policy policy = current_policy<PolicySelector>();
-  using AgentReduceByKeyPolicyT                = AgentReduceByKeyPolicy<
-                   policy.threads_per_block,
-                   policy.items_per_thread,
-                   policy.load_algorithm,
-                   policy.load_modifier,
-                   policy.scan_algorithm,
-                   delay_constructor_t<policy.delay_constructor.kind,
-                                       policy.delay_constructor.delay,
-                                       policy.delay_constructor.l2_write_latency>>;
+  static constexpr ReduceByKeyPolicy policy = current_policy<PolicySelector>();
+  using AgentReduceByKeyPolicyT             = agent_reduce_by_key_policy<
+                policy.threads_per_block,
+                policy.items_per_thread,
+                policy.load_algorithm,
+                policy.load_modifier,
+                policy.scan_algorithm,
+                delay_constructor_t<policy.lookback_delay.kind, policy.lookback_delay.delay, policy.lookback_delay.l2_write_latency>>;
 
   using vsmem_helper_t = vsmem_helper_default_fallback_policy_t<
     AgentReduceByKeyPolicyT,
@@ -292,7 +290,6 @@ __launch_bounds__(int(current_policy<PolicySelector>().threads_per_block))
  *   Implementation detail, do not specify directly, requirements on the
  *   content of this type are subject to breaking change.
  */
-// TODO(bgruber): deprecate when we make the tuning API public and remove in CCCL 4.0
 template <typename KeysInputIteratorT,
           typename UniqueOutputIteratorT,
           typename ValuesInputIteratorT,
@@ -308,7 +305,7 @@ template <typename KeysInputIteratorT,
             ReductionOpT,
             AccumT,
             cub::detail::non_void_value_t<UniqueOutputIteratorT, cub::detail::it_value_t<KeysInputIteratorT>>>>
-struct DispatchReduceByKey
+struct CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceReduce::ReduceByKey") DispatchReduceByKey
 {
   //-------------------------------------------------------------------------
   // Types and constants
@@ -650,16 +647,14 @@ template <typename PolicyGetter, typename... Args>
 _CCCL_HOST_DEVICE_API auto determine_threads_items_vsmem(PolicyGetter policy_getter)
 {
   // TODO(bgruber): refactor this in the future
-  constexpr reduce_by_key_policy policy = policy_getter();
-  using Policy                          = AgentReduceByKeyPolicy<
-                             policy.threads_per_block,
-                             policy.items_per_thread,
-                             policy.load_algorithm,
-                             policy.load_modifier,
-                             policy.scan_algorithm,
-                             delay_constructor_t<policy.delay_constructor.kind,
-                                                 policy.delay_constructor.delay,
-                                                 policy.delay_constructor.l2_write_latency>>;
+  constexpr ReduceByKeyPolicy policy = policy_getter();
+  using Policy                       = agent_reduce_by_key_policy<
+                          policy.threads_per_block,
+                          policy.items_per_thread,
+                          policy.load_algorithm,
+                          policy.load_modifier,
+                          policy.scan_algorithm,
+                          delay_constructor_t<policy.lookback_delay.kind, policy.lookback_delay.delay, policy.lookback_delay.l2_write_latency>>;
   using vsmem_helper_t = vsmem_helper_default_fallback_policy_t<Policy, AgentReduceByKey, Args...>;
   return ::cuda::std::tuple{vsmem_helper_t::agent_policy_t::BLOCK_THREADS,
                             vsmem_helper_t::agent_policy_t::ITEMS_PER_THREAD,

--- a/cub/cub/device/dispatch/dispatch_streaming_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_streaming_reduce_by_key.cuh
@@ -68,7 +68,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming(
     return error;
   }
 
-  const reduce_by_key_policy policy = policy_selector(cc);
+  const ReduceByKeyPolicy policy = policy_selector(cc);
 
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(NV_IS_HOST, ({

--- a/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
@@ -31,6 +31,41 @@
 
 CUB_NAMESPACE_BEGIN
 
+//! The tuning policy for `DeviceReduce::ReduceByKey`
+struct ReduceByKeyPolicy
+{
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int items_per_thread; //!< Number of items processed per thread
+  BlockLoadAlgorithm load_algorithm; //!< The @ref BlockLoadAlgorithm used for loading items from global memory
+  CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
+  BlockScanAlgorithm scan_algorithm; //!< The @ref BlockScanAlgorithm used for the prefix scan
+  LookbackDelayPolicy lookback_delay; //!< The @ref LookbackDelayPolicy used for the lookback delay
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const ReduceByKeyPolicy& lhs, const ReduceByKeyPolicy& rhs) noexcept
+  {
+    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
+        && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
+        && lhs.scan_algorithm == rhs.scan_algorithm && lhs.lookback_delay == rhs.lookback_delay;
+  }
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const ReduceByKeyPolicy& lhs, const ReduceByKeyPolicy& rhs) noexcept
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const ReduceByKeyPolicy& p)
+  {
+    return os
+        << "ReduceByKeyPolicy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
+        << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm << ", .load_modifier = " << p.load_modifier
+        << ", .scan_algorithm = " << p.scan_algorithm << ", .lookback_delay = " << p.lookback_delay << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
 namespace detail::reduce_by_key
 {
 // TODO(bgruber): remove in CCCL 4.0 when we drop the reduce-by-key dispatchers
@@ -872,12 +907,12 @@ struct policy_hub
             ::cuda::ceil_div(nominal_4B_items_per_thread * 8, combined_input_bytes), 1, nominal_4B_items_per_thread);
 
     using ReduceByKeyPolicyT =
-      AgentReduceByKeyPolicy<128,
-                             items_per_thread,
-                             BLOCK_LOAD_DIRECT,
-                             LoadModifier,
-                             BLOCK_SCAN_WARP_SCANS,
-                             default_reduce_by_key_delay_constructor_t<AccumT, int>>;
+      agent_reduce_by_key_policy<128,
+                                 items_per_thread,
+                                 BLOCK_LOAD_DIRECT,
+                                 LoadModifier,
+                                 BLOCK_SCAN_WARP_SCANS,
+                                 default_reduce_by_key_delay_constructor_t<AccumT, int>>;
   };
 
   // nvbug5935129: GCC-11.2 cannot directly use DefaultPolicy inside Policy500
@@ -891,12 +926,12 @@ struct policy_hub
   // Use values from tuning if a specialization exists, otherwise pick DefaultPolicy
   template <typename Tuning>
   static auto select_agent_policy(int)
-    -> AgentReduceByKeyPolicy<Tuning::threads,
-                              Tuning::items,
-                              Tuning::load_algorithm,
-                              LOAD_DEFAULT,
-                              BLOCK_SCAN_WARP_SCANS,
-                              typename Tuning::delay_constructor>;
+    -> agent_reduce_by_key_policy<Tuning::threads,
+                                  Tuning::items,
+                                  Tuning::load_algorithm,
+                                  LOAD_DEFAULT,
+                                  BLOCK_SCAN_WARP_SCANS,
+                                  typename Tuning::delay_constructor>;
 
   template <typename Tuning>
   static auto select_agent_policy(long) -> typename DefaultPolicy<LOAD_DEFAULT>::ReduceByKeyPolicyT;
@@ -926,12 +961,12 @@ struct policy_hub
     // Use values from tuning if a specialization exists, otherwise fall back to SM90
     template <typename Tuning>
     static auto select_agent_policy(int)
-      -> AgentReduceByKeyPolicy<Tuning::threads,
-                                Tuning::items,
-                                Tuning::load_algorithm,
-                                Tuning::load_modifier,
-                                BLOCK_SCAN_WARP_SCANS,
-                                typename Tuning::delay_constructor>;
+      -> agent_reduce_by_key_policy<Tuning::threads,
+                                    Tuning::items,
+                                    Tuning::load_algorithm,
+                                    Tuning::load_modifier,
+                                    BLOCK_SCAN_WARP_SCANS,
+                                    typename Tuning::delay_constructor>;
 
     template <typename Tuning>
     static auto select_agent_policy(long) -> typename Policy900::ReduceByKeyPolicyT;
@@ -942,43 +977,9 @@ struct policy_hub
   using MaxPolicy = Policy1000;
 };
 
-struct reduce_by_key_policy
-{
-  int threads_per_block;
-  int items_per_thread;
-  BlockLoadAlgorithm load_algorithm;
-  CacheLoadModifier load_modifier;
-  BlockScanAlgorithm scan_algorithm;
-  LookbackDelayPolicy delay_constructor;
-
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const reduce_by_key_policy& lhs, const reduce_by_key_policy& rhs)
-  {
-    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
-        && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
-        && lhs.scan_algorithm == rhs.scan_algorithm && lhs.delay_constructor == rhs.delay_constructor;
-  }
-
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const reduce_by_key_policy& lhs, const reduce_by_key_policy& rhs)
-  {
-    return !(lhs == rhs);
-  }
-
-#if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const reduce_by_key_policy& p)
-  {
-    return os
-        << "reduce_by_key_policy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
-        << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm << ", .load_modifier = " << p.load_modifier
-        << ", .scan_algorithm = " << p.scan_algorithm << ", .delay_constructor = " << p.delay_constructor << " }";
-  }
-#endif // _CCCL_HOSTED()
-};
-
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>
-concept reduce_by_key_policy_selector = detail::policy_selector<T, reduce_by_key_policy>;
+concept reduce_by_key_policy_selector = detail::policy_selector<T, ReduceByKeyPolicy>;
 #endif // _CCCL_HAS_CONCEPTS()
 
 struct policy_selector
@@ -995,7 +996,7 @@ struct policy_selector
   bool accum_is_primitive;
   bool op_is_primitive;
 
-  _CCCL_HOST_DEVICE_API constexpr auto __make_default_policy(CacheLoadModifier load_mod) const -> reduce_by_key_policy
+  _CCCL_HOST_DEVICE_API constexpr auto __make_default_policy(CacheLoadModifier load_mod) const -> ReduceByKeyPolicy
   {
     constexpr int nominal_4B_items_per_thread = 6;
     const int combined_input_bytes            = key_size + accum_size;
@@ -1005,7 +1006,7 @@ struct policy_selector
         ? 6
         : ::cuda::std::clamp(
             ::cuda::ceil_div(nominal_4B_items_per_thread * 8, combined_input_bytes), 1, nominal_4B_items_per_thread);
-    return reduce_by_key_policy{
+    return ReduceByKeyPolicy{
       128,
       items_per_thread,
       BLOCK_LOAD_DIRECT,
@@ -1016,7 +1017,7 @@ struct policy_selector
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
-    -> reduce_by_key_policy
+    -> ReduceByKeyPolicy
   {
     // bail out if we don't know the operation. TODO(bgruber): drop this check when we make the tuning API public
     if (!op_is_primitive)
@@ -1634,11 +1635,10 @@ static_assert(reduce_by_key_policy_selector<policy_selector>);
 template <typename PolicyHub>
 struct policy_selector_from_hub
 {
-  [[nodiscard]] _CCCL_DEVICE_API constexpr auto operator()(::cuda::compute_capability /*cc*/) const
-    -> reduce_by_key_policy
+  [[nodiscard]] _CCCL_DEVICE_API constexpr auto operator()(::cuda::compute_capability /*cc*/) const -> ReduceByKeyPolicy
   {
     using ReduceByKeyPolicyT = typename PolicyHub::MaxPolicy::ReduceByKeyPolicyT;
-    return reduce_by_key_policy{
+    return ReduceByKeyPolicy{
       ReduceByKeyPolicyT::BLOCK_THREADS,
       ReduceByKeyPolicyT::ITEMS_PER_THREAD,
       ReduceByKeyPolicyT::LOAD_ALGORITHM,
@@ -1653,7 +1653,7 @@ template <class ReductionOpT, class AccumT, class KeyT>
 struct policy_selector_from_types
 {
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
-    -> reduce_by_key_policy
+    -> ReduceByKeyPolicy
   {
     return policy_selector{
       int{sizeof(KeyT)},

--- a/cub/cub/device/dispatch/tuning/tuning_rle_encode.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_rle_encode.cuh
@@ -33,6 +33,9 @@
 
 CUB_NAMESPACE_BEGIN
 
+//! The tuning policy for DeviceRunLengthEncode::Encode
+using RLEEncodePolicy = ReduceByKeyPolicy;
+
 namespace detail::rle::encode
 {
 // TODO(bgruber): remove in CCCL 4.0 when we drop the CUB dispatchers
@@ -311,12 +314,9 @@ struct policy_hub
   using MaxPolicy = Policy1000;
 };
 
-// DeviceRunLengthEncode::Encode delegates to reduce by key
-using rle_encode_policy = ReduceByKeyPolicy;
-
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>
-concept rle_encode_policy_selector = reduce_by_key::reduce_by_key_policy_selector<T>;
+concept RLEEncodePolicy_selector = reduce_by_key::reduce_by_key_policy_selector<T>;
 #endif // _CCCL_HAS_CONCEPTS()
 
 // TODO(bgruber): remove in CCCL 4.0 when we drop the RLE dispatchers
@@ -335,7 +335,7 @@ struct policy_selector
   bool length_is_trivially_copyable;
   bool key_is_primitive;
 
-  _CCCL_HOST_DEVICE_API constexpr auto __make_default_policy(CacheLoadModifier load_mod) const -> rle_encode_policy
+  _CCCL_HOST_DEVICE_API constexpr auto __make_default_policy(CacheLoadModifier load_mod) const -> RLEEncodePolicy
   {
     constexpr int nominal_4B_items_per_thread = 6;
     const int combined_input_bytes            = length_size + key_size;
@@ -345,7 +345,7 @@ struct policy_selector
         ? 6
         : ::cuda::std::clamp(
             ::cuda::ceil_div(nominal_4B_items_per_thread * 8, combined_input_bytes), 1, nominal_4B_items_per_thread);
-    return rle_encode_policy{
+    return RLEEncodePolicy{
       128,
       items_per_thread,
       BLOCK_LOAD_DIRECT,
@@ -355,15 +355,14 @@ struct policy_selector
         length_size, int{sizeof(int)}, length_is_primitive || length_is_trivially_copyable, true)};
   }
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
-    -> rle_encode_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> RLEEncodePolicy
   {
     // if we don't have a tuning for SM100, fall back to SM90
     if (cc >= ::cuda::compute_capability{10, 0} && length_is_primitive && length_size == 4 && key_is_primitive)
     {
       if (key_size == 1)
       {
-        return rle_encode_policy{
+        return RLEEncodePolicy{
           256,
           14,
           BLOCK_LOAD_DIRECT,
@@ -373,7 +372,7 @@ struct policy_selector
       }
       if (key_size == 2)
       {
-        return rle_encode_policy{
+        return RLEEncodePolicy{
           224,
           14,
           BLOCK_LOAD_DIRECT,
@@ -383,7 +382,7 @@ struct policy_selector
       }
       if (key_size == 4)
       {
-        return rle_encode_policy{
+        return RLEEncodePolicy{
           256,
           14,
           BLOCK_LOAD_DIRECT,
@@ -393,7 +392,7 @@ struct policy_selector
       }
       if (key_size == 8)
       {
-        return rle_encode_policy{
+        return RLEEncodePolicy{
           224,
           9,
           BLOCK_LOAD_WARP_TRANSPOSE,
@@ -409,17 +408,17 @@ struct policy_selector
       {
         if (key_is_primitive && key_size == 1)
         {
-          return rle_encode_policy{
+          return RLEEncodePolicy{
             256, 13, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 620}};
         }
         if (key_is_primitive && key_size == 2)
         {
-          return rle_encode_policy{
+          return RLEEncodePolicy{
             128, 22, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 775}};
         }
         if (key_is_primitive && key_size == 4)
         {
-          return rle_encode_policy{
+          return RLEEncodePolicy{
             192,
             14,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -429,7 +428,7 @@ struct policy_selector
         }
         if (key_is_primitive && key_size == 8)
         {
-          return rle_encode_policy{
+          return RLEEncodePolicy{
             128,
             19,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -439,7 +438,7 @@ struct policy_selector
         }
         if (key_t == type_t::int128 || key_t == type_t::uint128)
         {
-          return rle_encode_policy{
+          return RLEEncodePolicy{
             128,
             11,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -464,17 +463,17 @@ struct policy_selector
       {
         if (key_is_primitive && key_size == 1)
         {
-          return rle_encode_policy{
+          return RLEEncodePolicy{
             256, 14, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 640}};
         }
         if (key_is_primitive && key_size == 2)
         {
-          return rle_encode_policy{
+          return RLEEncodePolicy{
             256, 13, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 900}};
         }
         if (key_is_primitive && key_size == 4)
         {
-          return rle_encode_policy{
+          return RLEEncodePolicy{
             256,
             13,
             BLOCK_LOAD_DIRECT,
@@ -484,7 +483,7 @@ struct policy_selector
         }
         if (key_is_primitive && key_size == 8)
         {
-          return rle_encode_policy{
+          return RLEEncodePolicy{
             224,
             9,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -494,7 +493,7 @@ struct policy_selector
         }
         if (key_t == type_t::int128 || key_t == type_t::uint128)
         {
-          return rle_encode_policy{
+          return RLEEncodePolicy{
             128,
             7,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -514,14 +513,13 @@ struct policy_selector
 };
 
 #if _CCCL_HAS_CONCEPTS()
-static_assert(rle_encode_policy_selector<policy_selector>);
+static_assert(RLEEncodePolicy_selector<policy_selector>);
 #endif // _CCCL_HAS_CONCEPTS()
 
 template <class LengthT, class KeyT>
 struct policy_selector_from_types
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
-    -> rle_encode_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> RLEEncodePolicy
   {
     constexpr policy_selector selector{
       int{sizeof(LengthT)},

--- a/cub/cub/device/dispatch/tuning/tuning_rle_encode.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_rle_encode.cuh
@@ -245,12 +245,12 @@ struct policy_hub
         : ::cuda::std::clamp(
             ::cuda::ceil_div(nominal_4B_items_per_thread * 8, combined_input_bytes), 1, nominal_4B_items_per_thread);
     using ReduceByKeyPolicyT =
-      AgentReduceByKeyPolicy<128,
-                             items,
-                             BLOCK_LOAD_DIRECT,
-                             LoadModifier,
-                             BLOCK_SCAN_WARP_SCANS,
-                             default_reduce_by_key_delay_constructor_t<LengthT, int>>;
+      agent_reduce_by_key_policy<128,
+                                 items,
+                                 BLOCK_LOAD_DIRECT,
+                                 LoadModifier,
+                                 BLOCK_SCAN_WARP_SCANS,
+                                 default_reduce_by_key_delay_constructor_t<LengthT, int>>;
   };
 
   // nvbug5935129: GCC-11.2 cannot directly use DefaultPolicy inside Policy500
@@ -264,12 +264,12 @@ struct policy_hub
   // Use values from tuning if a specialization exists, otherwise pick the default
   template <typename Tuning>
   static auto select_agent_policy(int)
-    -> AgentReduceByKeyPolicy<Tuning::threads,
-                              Tuning::items,
-                              Tuning::load_algorithm,
-                              LOAD_DEFAULT,
-                              BLOCK_SCAN_WARP_SCANS,
-                              typename Tuning::delay_constructor>;
+    -> agent_reduce_by_key_policy<Tuning::threads,
+                                  Tuning::items,
+                                  Tuning::load_algorithm,
+                                  LOAD_DEFAULT,
+                                  BLOCK_SCAN_WARP_SCANS,
+                                  typename Tuning::delay_constructor>;
   template <typename Tuning>
   static auto select_agent_policy(long) -> typename DefaultPolicy<LOAD_DEFAULT>::ReduceByKeyPolicyT;
 
@@ -296,12 +296,12 @@ struct policy_hub
     // Use values from tuning if a specialization exists, otherwise pick Policy900
     template <typename Tuning>
     static auto select_agent_policy100(int)
-      -> AgentReduceByKeyPolicy<Tuning::threads,
-                                Tuning::items,
-                                Tuning::load_algorithm,
-                                Tuning::load_modifier,
-                                BLOCK_SCAN_WARP_SCANS,
-                                typename Tuning::delay_constructor>;
+      -> agent_reduce_by_key_policy<Tuning::threads,
+                                    Tuning::items,
+                                    Tuning::load_algorithm,
+                                    Tuning::load_modifier,
+                                    BLOCK_SCAN_WARP_SCANS,
+                                    typename Tuning::delay_constructor>;
     template <typename Tuning>
     static auto select_agent_policy100(long) -> typename Policy900::ReduceByKeyPolicyT;
 
@@ -312,7 +312,7 @@ struct policy_hub
 };
 
 // DeviceRunLengthEncode::Encode delegates to reduce by key
-using rle_encode_policy = reduce_by_key::reduce_by_key_policy;
+using rle_encode_policy = ReduceByKeyPolicy;
 
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>

--- a/cub/cub/device/dispatch/tuning/tuning_rle_encode.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_rle_encode.cuh
@@ -34,7 +34,7 @@
 CUB_NAMESPACE_BEGIN
 
 //! The tuning policy for DeviceRunLengthEncode::Encode
-struct RLEEncodePolicy
+struct RleEncodePolicy
 {
   int threads_per_block; //!< Number of threads in a CUDA block
   int items_per_thread; //!< Number of items processed per thread
@@ -44,7 +44,7 @@ struct RLEEncodePolicy
   LookbackDelayPolicy lookback_delay; //!< The @ref LookbackDelayPolicy used for the lookback delay
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const RLEEncodePolicy& lhs, const RLEEncodePolicy& rhs) noexcept
+  operator==(const RleEncodePolicy& lhs, const RleEncodePolicy& rhs) noexcept
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
         && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
@@ -52,16 +52,16 @@ struct RLEEncodePolicy
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const RLEEncodePolicy& lhs, const RLEEncodePolicy& rhs) noexcept
+  operator!=(const RleEncodePolicy& lhs, const RleEncodePolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const RLEEncodePolicy& p)
+  friend ::std::ostream& operator<<(::std::ostream& os, const RleEncodePolicy& p)
   {
     return os
-        << "RLEEncodePolicy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
+        << "RleEncodePolicy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
         << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm << ", .load_modifier = " << p.load_modifier
         << ", .scan_algorithm = " << p.scan_algorithm << ", .lookback_delay = " << p.lookback_delay << " }";
   }
@@ -348,7 +348,7 @@ struct policy_hub
 
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>
-concept rle_encode_policy_selector = detail::policy_selector<T, RLEEncodePolicy>;
+concept rle_encode_policy_selector = detail::policy_selector<T, RleEncodePolicy>;
 #endif // _CCCL_HAS_CONCEPTS()
 
 // TODO(bgruber): remove in CCCL 4.0 when we drop the RLE dispatchers
@@ -367,7 +367,7 @@ struct policy_selector
   bool length_is_trivially_copyable;
   bool key_is_primitive;
 
-  _CCCL_HOST_DEVICE_API constexpr auto __make_default_policy(CacheLoadModifier load_mod) const -> RLEEncodePolicy
+  _CCCL_HOST_DEVICE_API constexpr auto __make_default_policy(CacheLoadModifier load_mod) const -> RleEncodePolicy
   {
     constexpr int nominal_4B_items_per_thread = 6;
     const int combined_input_bytes            = length_size + key_size;
@@ -377,7 +377,7 @@ struct policy_selector
         ? 6
         : ::cuda::std::clamp(
             ::cuda::ceil_div(nominal_4B_items_per_thread * 8, combined_input_bytes), 1, nominal_4B_items_per_thread);
-    return RLEEncodePolicy{
+    return RleEncodePolicy{
       128,
       items_per_thread,
       BLOCK_LOAD_DIRECT,
@@ -387,14 +387,14 @@ struct policy_selector
         length_size, int{sizeof(int)}, length_is_primitive || length_is_trivially_copyable, true)};
   }
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> RLEEncodePolicy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> RleEncodePolicy
   {
     // if we don't have a tuning for SM100, fall back to SM90
     if (cc >= ::cuda::compute_capability{10, 0} && length_is_primitive && length_size == 4 && key_is_primitive)
     {
       if (key_size == 1)
       {
-        return RLEEncodePolicy{
+        return RleEncodePolicy{
           256,
           14,
           BLOCK_LOAD_DIRECT,
@@ -404,7 +404,7 @@ struct policy_selector
       }
       if (key_size == 2)
       {
-        return RLEEncodePolicy{
+        return RleEncodePolicy{
           224,
           14,
           BLOCK_LOAD_DIRECT,
@@ -414,7 +414,7 @@ struct policy_selector
       }
       if (key_size == 4)
       {
-        return RLEEncodePolicy{
+        return RleEncodePolicy{
           256,
           14,
           BLOCK_LOAD_DIRECT,
@@ -424,7 +424,7 @@ struct policy_selector
       }
       if (key_size == 8)
       {
-        return RLEEncodePolicy{
+        return RleEncodePolicy{
           224,
           9,
           BLOCK_LOAD_WARP_TRANSPOSE,
@@ -440,17 +440,17 @@ struct policy_selector
       {
         if (key_is_primitive && key_size == 1)
         {
-          return RLEEncodePolicy{
+          return RleEncodePolicy{
             256, 13, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 620}};
         }
         if (key_is_primitive && key_size == 2)
         {
-          return RLEEncodePolicy{
+          return RleEncodePolicy{
             128, 22, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 775}};
         }
         if (key_is_primitive && key_size == 4)
         {
-          return RLEEncodePolicy{
+          return RleEncodePolicy{
             192,
             14,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -460,7 +460,7 @@ struct policy_selector
         }
         if (key_is_primitive && key_size == 8)
         {
-          return RLEEncodePolicy{
+          return RleEncodePolicy{
             128,
             19,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -470,7 +470,7 @@ struct policy_selector
         }
         if (key_t == type_t::int128 || key_t == type_t::uint128)
         {
-          return RLEEncodePolicy{
+          return RleEncodePolicy{
             128,
             11,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -495,17 +495,17 @@ struct policy_selector
       {
         if (key_is_primitive && key_size == 1)
         {
-          return RLEEncodePolicy{
+          return RleEncodePolicy{
             256, 14, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 640}};
         }
         if (key_is_primitive && key_size == 2)
         {
-          return RLEEncodePolicy{
+          return RleEncodePolicy{
             256, 13, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 900}};
         }
         if (key_is_primitive && key_size == 4)
         {
-          return RLEEncodePolicy{
+          return RleEncodePolicy{
             256,
             13,
             BLOCK_LOAD_DIRECT,
@@ -515,7 +515,7 @@ struct policy_selector
         }
         if (key_is_primitive && key_size == 8)
         {
-          return RLEEncodePolicy{
+          return RleEncodePolicy{
             224,
             9,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -525,7 +525,7 @@ struct policy_selector
         }
         if (key_t == type_t::int128 || key_t == type_t::uint128)
         {
-          return RLEEncodePolicy{
+          return RleEncodePolicy{
             128,
             7,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -551,7 +551,7 @@ static_assert(rle_encode_policy_selector<policy_selector>);
 template <class LengthT, class KeyT>
 struct policy_selector_from_types
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> RLEEncodePolicy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> RleEncodePolicy
   {
     constexpr policy_selector selector{
       int{sizeof(LengthT)},

--- a/cub/cub/device/dispatch/tuning/tuning_rle_encode.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_rle_encode.cuh
@@ -348,7 +348,7 @@ struct policy_hub
 
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>
-concept rle_encode_policy_selector = reduce_by_key::reduce_by_key_policy_selector<T>;
+concept rle_encode_policy_selector = detail::policy_selector<T, RLEEncodePolicy>;
 #endif // _CCCL_HAS_CONCEPTS()
 
 // TODO(bgruber): remove in CCCL 4.0 when we drop the RLE dispatchers

--- a/cub/cub/device/dispatch/tuning/tuning_rle_encode.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_rle_encode.cuh
@@ -34,7 +34,39 @@
 CUB_NAMESPACE_BEGIN
 
 //! The tuning policy for DeviceRunLengthEncode::Encode
-using RLEEncodePolicy = ReduceByKeyPolicy;
+struct RLEEncodePolicy
+{
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int items_per_thread; //!< Number of items processed per thread
+  BlockLoadAlgorithm load_algorithm; //!< The @ref BlockLoadAlgorithm used for loading items from global memory
+  CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
+  BlockScanAlgorithm scan_algorithm; //!< The @ref BlockScanAlgorithm used for the prefix scan
+  LookbackDelayPolicy lookback_delay; //!< The @ref LookbackDelayPolicy used for the lookback delay
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const RLEEncodePolicy& lhs, const RLEEncodePolicy& rhs) noexcept
+  {
+    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
+        && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
+        && lhs.scan_algorithm == rhs.scan_algorithm && lhs.lookback_delay == rhs.lookback_delay;
+  }
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const RLEEncodePolicy& lhs, const RLEEncodePolicy& rhs) noexcept
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const RLEEncodePolicy& p)
+  {
+    return os
+        << "RLEEncodePolicy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
+        << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm << ", .load_modifier = " << p.load_modifier
+        << ", .scan_algorithm = " << p.scan_algorithm << ", .lookback_delay = " << p.lookback_delay << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
 
 namespace detail::rle::encode
 {
@@ -316,7 +348,7 @@ struct policy_hub
 
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>
-concept RLEEncodePolicy_selector = reduce_by_key::reduce_by_key_policy_selector<T>;
+concept rle_encode_policy_selector = reduce_by_key::reduce_by_key_policy_selector<T>;
 #endif // _CCCL_HAS_CONCEPTS()
 
 // TODO(bgruber): remove in CCCL 4.0 when we drop the RLE dispatchers
@@ -513,7 +545,7 @@ struct policy_selector
 };
 
 #if _CCCL_HAS_CONCEPTS()
-static_assert(RLEEncodePolicy_selector<policy_selector>);
+static_assert(rle_encode_policy_selector<policy_selector>);
 #endif // _CCCL_HAS_CONCEPTS()
 
 template <class LengthT, class KeyT>

--- a/cub/test/catch2_test_device_reduce_by_key_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_reduce_by_key_custom_policy_hub.cu
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// TODO(bgruber): drop this test with CCCL 4.0 when we drop the reduce-by-key dispatcher
+
+#define CCCL_IGNORE_DEPRECATED_API
+
 #include "insert_nested_NVTX_range_guard.h"
 
 #include <cub/device/dispatch/dispatch_reduce_by_key.cuh>
@@ -10,8 +14,6 @@
 #include <c2h/catch2_test_helper.h>
 
 using namespace cub;
-
-// TODO(bgruber): drop this test with CCCL 4.0 when we drop the reduce-by-key dispatcher after publishing the tuning API
 
 template <class ReductionOpT, class AccumT, class KeyT>
 struct my_policy_hub

--- a/cub/test/catch2_test_device_reduce_by_key_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_by_key_env_api.cu
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "insert_nested_NVTX_range_guard.h"
+
+#include <cub/device/device_reduce.cuh>
+
+#include <thrust/device_vector.h>
+
+#include <cuda/__execution/tune.h>
+#include <cuda/devices>
+#include <cuda/stream>
+
+#include <c2h/catch2_test_helper.h>
+
+#if _CCCL_STD_VER >= 2020
+
+// example-begin reduce-by-key-policy-selector
+struct ReduceByKeyPolicySelector
+{
+  __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::ReduceByKeyPolicy
+  {
+    return {.threads_per_block = 128,
+            .items_per_thread  = cc > cuda::compute_capability{9, 0} ? 7 : 6,
+            .load_algorithm    = cub::BLOCK_LOAD_DIRECT,
+            .load_modifier     = cub::LOAD_DEFAULT,
+            .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
+            .lookback_delay    = cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 832, 1165}};
+  }
+};
+// example-end reduce-by-key-policy-selector
+
+C2H_TEST("cub::DeviceReduce::ReduceByKey env-based API with tuning", "[reduce][env]")
+{
+  // example-begin reduce-by-key-tuning
+  auto d_keys_in        = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
+  auto d_values_in      = thrust::device_vector<int>{0, 7, 1, 6, 2, 5, 3, 4};
+  auto d_unique_out     = thrust::device_vector<int>(8, thrust::no_init);
+  auto d_aggregates_out = thrust::device_vector<int>(8, thrust::no_init);
+  auto d_num_runs_out   = thrust::device_vector<int>(1, thrust::no_init);
+
+  const auto error = cub::DeviceReduce::ReduceByKey(
+    d_keys_in.begin(),
+    d_unique_out.begin(),
+    d_values_in.begin(),
+    d_aggregates_out.begin(),
+    d_num_runs_out.begin(),
+    cuda::minimum<int>{},
+    static_cast<int>(d_keys_in.size()),
+    cuda::execution::tune(ReduceByKeyPolicySelector{}));
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceReduce::ReduceByKey failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
+  thrust::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
+  // example-end reduce-by-key-tuning
+
+  REQUIRE(error == cudaSuccess);
+  CHECK(d_num_runs_out[0] == 5);
+  d_unique_out.resize(5);
+  d_aggregates_out.resize(5);
+  CHECK(d_unique_out == expected_keys);
+  CHECK(d_aggregates_out == expected_aggregates);
+}
+
+#endif // _CCCL_STD_VER >= 2020

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -1094,7 +1094,7 @@ C2H_TEST("ReduceByKeyPolicy", "[reduce][device]")
     cub::BLOCK_LOAD_DIRECT,
     cub::LOAD_DEFAULT,
     cub::BLOCK_SCAN_WARP_SCANS,
-    {cub::LookbackDelayAlgorithm::fixed_delay, 1165}};
+    {cub::LookbackDelayAlgorithm::fixed_delay, 832, 1165}};
 
 #  if _CCCL_STD_VER >= 2020
   // designated init

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -339,8 +339,7 @@ C2H_TEST("Device ArgMax can be tuned", "[reduce][device]", block_sizes)
 template <int BlockThreads>
 struct reduce_by_key_tuning
 {
-  _CCCL_API constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::reduce_by_key::reduce_by_key_policy
+  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::ReduceByKeyPolicy
   {
     return {BlockThreads, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_SCAN_WARP_SCANS, {}};
   }
@@ -1081,3 +1080,38 @@ C2H_TEST("Device ArgMax with compare_op uses environment", "[reduce][device]")
   REQUIRE(max_output[0] == 4.0f);
   REQUIRE(index_output[0] == 2);
 }
+
+#if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
+C2H_TEST("ReduceByKeyPolicy", "[reduce][device]")
+{
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::ReduceByKeyPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ReduceByKeyPolicy>);
+
+  // aggregate init
+  constexpr auto p1 = cub::ReduceByKeyPolicy{
+    128,
+    7,
+    cub::BLOCK_LOAD_DIRECT,
+    cub::LOAD_DEFAULT,
+    cub::BLOCK_SCAN_WARP_SCANS,
+    {cub::LookbackDelayAlgorithm::fixed_delay, 1165}};
+
+#  if _CCCL_STD_VER >= 2020
+  // designated init
+  constexpr auto p2 = cub::ReduceByKeyPolicy{
+    .threads_per_block = 128,
+    .items_per_thread  = 7,
+    .load_algorithm    = cub::BLOCK_LOAD_DIRECT,
+    .load_modifier     = cub::LOAD_DEFAULT,
+    .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
+    .lookback_delay    = cub::LookbackDelayPolicy{
+         .kind = cub::LookbackDelayAlgorithm::fixed_delay, .delay = 832, .l2_write_latency = 1165}};
+#  else // _CCCL_STD_VER >= 2020
+  constexpr auto p2 = p1;
+#  endif // _CCCL_STD_VER >= 2020
+
+  // comparison
+  STATIC_REQUIRE(p1 == p2);
+  STATIC_REQUIRE_FALSE(p1 != p2);
+}
+#endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_run_length_encode_env.cu
+++ b/cub/test/catch2_test_device_run_length_encode_env.cu
@@ -31,8 +31,7 @@ namespace stdexec = cuda::std::execution;
 template <int ThreadsPerBlock>
 struct rle_encode_tuning
 {
-  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::reduce_by_key::reduce_by_key_policy
+  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::ReduceByKeyPolicy
   {
     return {ThreadsPerBlock, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_SCAN_WARP_SCANS, {}};
   }

--- a/cub/test/catch2_test_device_run_length_encode_env.cu
+++ b/cub/test/catch2_test_device_run_length_encode_env.cu
@@ -303,7 +303,7 @@ C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns can be tuned", "[run_length_enco
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("RleEncodePolicy", "[reduce][device]")
+C2H_TEST("RleEncodePolicy", "[run_length_encode][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::RleEncodePolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::RleEncodePolicy>);

--- a/cub/test/catch2_test_device_run_length_encode_env.cu
+++ b/cub/test/catch2_test_device_run_length_encode_env.cu
@@ -301,3 +301,38 @@ C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns can be tuned", "[run_length_enco
 }
 
 #endif // TEST_LAUNCH != 1
+
+#if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
+C2H_TEST("RLEEncodePolicy", "[reduce][device]")
+{
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::RLEEncodePolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::RLEEncodePolicy>);
+
+  // aggregate init
+  constexpr auto p1 = cub::RLEEncodePolicy{
+    128,
+    7,
+    cub::BLOCK_LOAD_DIRECT,
+    cub::LOAD_DEFAULT,
+    cub::BLOCK_SCAN_WARP_SCANS,
+    {cub::LookbackDelayAlgorithm::fixed_delay, 832, 1165}};
+
+#  if _CCCL_STD_VER >= 2020
+  // designated init
+  constexpr auto p2 = cub::RLEEncodePolicy{
+    .threads_per_block = 128,
+    .items_per_thread  = 7,
+    .load_algorithm    = cub::BLOCK_LOAD_DIRECT,
+    .load_modifier     = cub::LOAD_DEFAULT,
+    .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
+    .lookback_delay    = cub::LookbackDelayPolicy{
+         .kind = cub::LookbackDelayAlgorithm::fixed_delay, .delay = 832, .l2_write_latency = 1165}};
+#  else // _CCCL_STD_VER >= 2020
+  constexpr auto p2 = p1;
+#  endif // _CCCL_STD_VER >= 2020
+
+  // comparison
+  STATIC_REQUIRE(p1 == p2);
+  STATIC_REQUIRE_FALSE(p1 != p2);
+}
+#endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_run_length_encode_env.cu
+++ b/cub/test/catch2_test_device_run_length_encode_env.cu
@@ -303,13 +303,13 @@ C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns can be tuned", "[run_length_enco
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("RLEEncodePolicy", "[reduce][device]")
+C2H_TEST("RleEncodePolicy", "[reduce][device]")
 {
-  STATIC_REQUIRE(::cuda::std::semiregular<cub::RLEEncodePolicy>);
-  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::RLEEncodePolicy>);
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::RleEncodePolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::RleEncodePolicy>);
 
   // aggregate init
-  constexpr auto p1 = cub::RLEEncodePolicy{
+  constexpr auto p1 = cub::RleEncodePolicy{
     128,
     7,
     cub::BLOCK_LOAD_DIRECT,
@@ -319,7 +319,7 @@ C2H_TEST("RLEEncodePolicy", "[reduce][device]")
 
 #  if _CCCL_STD_VER >= 2020
   // designated init
-  constexpr auto p2 = cub::RLEEncodePolicy{
+  constexpr auto p2 = cub::RleEncodePolicy{
     .threads_per_block = 128,
     .items_per_thread  = 7,
     .load_algorithm    = cub::BLOCK_LOAD_DIRECT,

--- a/cub/test/catch2_test_device_run_length_encode_env.cu
+++ b/cub/test/catch2_test_device_run_length_encode_env.cu
@@ -31,7 +31,7 @@ namespace stdexec = cuda::std::execution;
 template <int ThreadsPerBlock>
 struct rle_encode_tuning
 {
-  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::ReduceByKeyPolicy
+  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::RleEncodePolicy
   {
     return {ThreadsPerBlock, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_SCAN_WARP_SCANS, {}};
   }


### PR DESCRIPTION
Fixes: #9326

### New public entities                                                                                                                                                                                            
                                                                                                                                                                                                                     
  | Entity | Enumerators / Data members |                                                                                                                                                                            
  |--------|---------------------------|                                                                                                                                                                             
  | `cub::ReduceByKeyPolicy` | `int threads_per_block`<br>`int items_per_thread`<br>`BlockLoadAlgorithm load_algorithm`<br>`CacheLoadModifier load_modifier`<br>`BlockScanAlgorithm scan_algorithm`<br>`LookbackDelayPolicy lookback_delay` |
  | `cub::RleEncodePolicy` | `int threads_per_block`<br>`int items_per_thread`<br>`BlockLoadAlgorithm load_algorithm`<br>`CacheLoadModifier load_modifier`<br>`BlockScanAlgorithm scan_algorithm`<br>`LookbackDelayPolicy lookback_delay` |
