### PR TITLE
CCCL works with old DLPack versions

### DIFF
--- a/libcudacxx/include/cuda/__internal/dlpack.h
+++ b/libcudacxx/include/cuda/__internal/dlpack.h
@@ -34,8 +34,10 @@
 #  define _CCCL_DLPACK_BELOW(_MAJOR, _MINOR) (!_CCCL_DLPACK_AT_LEAST(_MAJOR, _MINOR))
 
 #  if DLPACK_MAJOR_VERSION != 1
-#    error "Unsupported DLPack version, only version 1 is currently supported"
-#  endif // DLPACK_MAJOR_VERSION != 1
+#    define _CCCL_HAS_DLPACK_VERSION_1() 0
+#  else
+#    define _CCCL_HAS_DLPACK_VERSION_1() 1
+#  endif
 
 #endif // _CCCL_HAS_DLPACK()
 

--- a/libcudacxx/include/cuda/__mdspan/dlpack_to_mdspan.h
+++ b/libcudacxx/include/cuda/__mdspan/dlpack_to_mdspan.h
@@ -23,23 +23,25 @@
 #if _CCCL_HAS_DLPACK()
 
 #  include <cuda/__internal/dlpack.h>
-#  include <cuda/__mdspan/host_device_mdspan.h>
-#  include <cuda/__mdspan/layout_stride_relaxed.h>
-#  include <cuda/__mdspan/mdspan_to_dlpack.h>
-#  include <cuda/__mdspan/traits.h>
-#  include <cuda/__memory/is_aligned.h>
-#  include <cuda/__numeric/mul_overflow.h>
-#  include <cuda/mdspan>
-#  include <cuda/std/__cstddef/types.h>
-#  include <cuda/std/__exception/exception_macros.h>
-#  include <cuda/std/__host_stdlib/stdexcept>
-#  include <cuda/std/__utility/cmp.h>
-#  include <cuda/std/array>
-#  include <cuda/std/cstdint>
 
-#  include <dlpack/dlpack.h>
+#  if _CCCL_HAS_DLPACK_VERSION_1()
+#    include <cuda/__mdspan/host_device_mdspan.h>
+#    include <cuda/__mdspan/layout_stride_relaxed.h>
+#    include <cuda/__mdspan/mdspan_to_dlpack.h>
+#    include <cuda/__mdspan/traits.h>
+#    include <cuda/__memory/is_aligned.h>
+#    include <cuda/__numeric/mul_overflow.h>
+#    include <cuda/mdspan>
+#    include <cuda/std/__cstddef/types.h>
+#    include <cuda/std/__exception/exception_macros.h>
+#    include <cuda/std/__host_stdlib/stdexcept>
+#    include <cuda/std/__utility/cmp.h>
+#    include <cuda/std/array>
+#    include <cuda/std/cstdint>
+
+#    include <dlpack/dlpack.h>
 //
-#  include <cuda/std/__cccl/prologue.h>
+#    include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
@@ -89,9 +91,9 @@ _CCCL_HOST_API void __validate_dlpack_strides(const ::DLTensor& __tensor, [[mayb
   const auto __strides_ptr = __tensor.strides;
   if (__strides_ptr == nullptr)
   {
-#  if _CCCL_DLPACK_AT_LEAST(1, 2)
+#    if _CCCL_DLPACK_AT_LEAST(1, 2)
     _CCCL_THROW(::std::invalid_argument, "strides=nullptr is not supported for DLPack v1.2 and later");
-#  else
+#    else
     // strides == nullptr means row-major (C-contiguous) layout
     if (__is_layout_left && __rank > 1)
     {
@@ -101,7 +103,7 @@ _CCCL_HOST_API void __validate_dlpack_strides(const ::DLTensor& __tensor, [[mayb
     {
       return;
     }
-#  endif // _CCCL_DLPACK_AT_LEAST(1, 2)
+#    endif // _CCCL_DLPACK_AT_LEAST(1, 2)
   }
   for (::cuda::std::size_t __pos = 0; __pos < __rank; ++__pos)
   {
@@ -300,7 +302,8 @@ to_managed_mdspan(const ::DLTensor& __tensor)
 
 _CCCL_END_NAMESPACE_CUDA
 
-#  include <cuda/std/__cccl/epilogue.h>
+#    include <cuda/std/__cccl/epilogue.h>
 
+#  endif // _CCCL_HAS_DLPACK_VERSION_1()
 #endif // __CCCL_HAS_DLPACK()
 #endif // _CUDA___MDSPAN_DLPACK_TO_MDSPAN_H

--- a/libcudacxx/include/cuda/__mdspan/mdspan_to_dlpack.h
+++ b/libcudacxx/include/cuda/__mdspan/mdspan_to_dlpack.h
@@ -22,28 +22,30 @@
 
 #if _CCCL_HAS_DLPACK()
 
-#  include <cuda/__driver/driver_api.h>
 #  include <cuda/__internal/dlpack.h>
-#  include <cuda/__mdspan/host_device_mdspan.h>
-#  include <cuda/__type_traits/is_floating_point.h>
-#  include <cuda/__type_traits/is_vector_type.h>
-#  include <cuda/std/__cstddef/types.h>
-#  include <cuda/std/__exception/cuda_error.h>
-#  include <cuda/std/__exception/exception_macros.h>
-#  include <cuda/std/__fwd/complex.h>
-#  include <cuda/std/__host_stdlib/stdexcept>
-#  include <cuda/std/__limits/numeric_limits.h>
-#  include <cuda/std/__type_traits/always_false.h>
-#  include <cuda/std/__type_traits/is_pointer.h>
-#  include <cuda/std/__type_traits/is_same.h>
-#  include <cuda/std/__type_traits/num_bits.h>
-#  include <cuda/std/__type_traits/remove_cv.h>
-#  include <cuda/std/__utility/cmp.h>
-#  include <cuda/std/array>
-#  include <cuda/std/cstdint>
-#  include <cuda/std/mdspan>
 
-#  include <cuda/std/__cccl/prologue.h>
+#  if _CCCL_HAS_DLPACK_VERSION_1()
+#    include <cuda/__driver/driver_api.h>
+#    include <cuda/__mdspan/host_device_mdspan.h>
+#    include <cuda/__type_traits/is_floating_point.h>
+#    include <cuda/__type_traits/is_vector_type.h>
+#    include <cuda/std/__cstddef/types.h>
+#    include <cuda/std/__exception/cuda_error.h>
+#    include <cuda/std/__exception/exception_macros.h>
+#    include <cuda/std/__fwd/complex.h>
+#    include <cuda/std/__host_stdlib/stdexcept>
+#    include <cuda/std/__limits/numeric_limits.h>
+#    include <cuda/std/__type_traits/always_false.h>
+#    include <cuda/std/__type_traits/is_pointer.h>
+#    include <cuda/std/__type_traits/is_same.h>
+#    include <cuda/std/__type_traits/num_bits.h>
+#    include <cuda/std/__type_traits/remove_cv.h>
+#    include <cuda/std/__utility/cmp.h>
+#    include <cuda/std/array>
+#    include <cuda/std/cstdint>
+#    include <cuda/std/mdspan>
+
+#    include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
@@ -63,50 +65,50 @@ template <typename _ElementType>
   }
   //--------------------------------------------------------------------------------------------------------------------
   // bfloat16 (must come before general floating-point)
-#  if _CCCL_HAS_NVBF16()
+#    if _CCCL_HAS_NVBF16()
   else if constexpr (::cuda::std::is_same_v<_ElementType, ::__nv_bfloat16>)
   {
     return ::DLDataType{::kDLBfloat, 16, 1};
   }
-#  endif // _CCCL_HAS_NVBF16()
+#    endif // _CCCL_HAS_NVBF16()
   //--------------------------------------------------------------------------------------------------------------------
   // Low-precision Floating-point types (must come before general floating-point)
-#  if _CCCL_HAS_NVFP8_E4M3()
+#    if _CCCL_HAS_NVFP8_E4M3()
   else if constexpr (::cuda::std::is_same_v<_ElementType, ::__nv_fp8_e4m3>)
   {
     return ::DLDataType{::kDLFloat8_e4m3fn, 8, 1};
   }
-#  endif // _CCCL_HAS_NVFP8_E4M3()
-#  if _CCCL_HAS_NVFP8_E5M2()
+#    endif // _CCCL_HAS_NVFP8_E4M3()
+#    if _CCCL_HAS_NVFP8_E5M2()
   else if constexpr (::cuda::std::is_same_v<_ElementType, ::__nv_fp8_e5m2>)
   {
     return ::DLDataType{::kDLFloat8_e5m2, 8, 1};
   }
-#  endif // _CCCL_HAS_NVFP8_E5M2()
-#  if _CCCL_HAS_NVFP8_E8M0()
+#    endif // _CCCL_HAS_NVFP8_E5M2()
+#    if _CCCL_HAS_NVFP8_E8M0()
   else if constexpr (::cuda::std::is_same_v<_ElementType, ::__nv_fp8_e8m0>)
   {
     return ::DLDataType{::kDLFloat8_e8m0fnu, 8, 1};
   }
-#  endif // _CCCL_HAS_NVFP8_E8M0()
-#  if _CCCL_HAS_NVFP6_E2M3()
+#    endif // _CCCL_HAS_NVFP8_E8M0()
+#    if _CCCL_HAS_NVFP6_E2M3()
   else if constexpr (::cuda::std::is_same_v<_ElementType, ::__nv_fp6_e2m3>)
   {
     return ::DLDataType{::kDLFloat6_e2m3fn, 6, 1};
   }
-#  endif // _CCCL_HAS_NVFP6_E2M3()
-#  if _CCCL_HAS_NVFP6_E3M2()
+#    endif // _CCCL_HAS_NVFP6_E2M3()
+#    if _CCCL_HAS_NVFP6_E3M2()
   else if constexpr (::cuda::std::is_same_v<_ElementType, ::__nv_fp6_e3m2>)
   {
     return ::DLDataType{::kDLFloat6_e3m2fn, 6, 1};
   }
-#  endif // _CCCL_HAS_NVFP6_E3M2()
-#  if _CCCL_HAS_NVFP4_E2M1()
+#    endif // _CCCL_HAS_NVFP6_E3M2()
+#    if _CCCL_HAS_NVFP4_E2M1()
   else if constexpr (::cuda::std::is_same_v<_ElementType, ::__nv_fp4_e2m1>)
   {
     return ::DLDataType{::kDLFloat4_e2m1fn, 4, 1};
   }
-#  endif // _CCCL_HAS_NVFP4_E2M1()
+#    endif // _CCCL_HAS_NVFP4_E2M1()
   //--------------------------------------------------------------------------------------------------------------------
   // Floating-point types (after specific types)
   else if constexpr (::cuda::is_floating_point_v<_ElementType>)
@@ -124,7 +126,7 @@ template <typename _ElementType>
   }
   //--------------------------------------------------------------------------------------------------------------------
   // CUDA built-in vector types
-#  if _CCCL_HAS_CTK()
+#    if _CCCL_HAS_CTK()
   else if constexpr (::cuda::is_vector_type_v<_ElementType> || ::cuda::is_extended_fp_vector_type_v<_ElementType>)
   {
     constexpr ::cuda::std::uint16_t __lanes = ::cuda::std::tuple_size_v<_ElementType>;
@@ -141,7 +143,7 @@ template <typename _ElementType>
       return ::DLDataType{};
     }
   }
-#  endif // _CCCL_HAS_CTK()
+#    endif // _CCCL_HAS_CTK()
   //--------------------------------------------------------------------------------------------------------------------
   // Unsupported types
   else
@@ -242,7 +244,8 @@ to_dlpack_tensor(const ::cuda::managed_mdspan<_ElementType, _Extents, _Layout, _
 
 _CCCL_END_NAMESPACE_CUDA
 
-#  include <cuda/std/__cccl/epilogue.h>
+#    include <cuda/std/__cccl/epilogue.h>
 
+#  endif // _CCCL_HAS_DLPACK_VERSION_1()
 #endif // _CCCL_HAS_DLPACK()
 #endif // _CUDA___MDSPAN_MDSPAN_TO_DLPACK_H

--- a/libcudacxx/include/cuda/__tma/make_tma_descriptor.h
+++ b/libcudacxx/include/cuda/__tma/make_tma_descriptor.h
@@ -22,23 +22,25 @@
 
 #if _CCCL_HAS_CTK() && _CCCL_HAS_DLPACK()
 
-#  include <cuda/__driver/driver_api.h>
 #  include <cuda/__internal/dlpack.h>
-#  include <cuda/__memory/is_aligned.h>
-#  include <cuda/__memory/is_pointer_accessible.h>
-#  include <cuda/devices> // sub headers cause circular dependency
-#  include <cuda/std/__algorithm/min.h>
-#  include <cuda/std/__cstddef/types.h>
-#  include <cuda/std/__exception/exception_macros.h>
-#  include <cuda/std/__host_stdlib/stdexcept>
-#  include <cuda/std/__utility/unreachable.h>
-#  include <cuda/std/array>
-#  include <cuda/std/cstdint>
-#  include <cuda/std/span>
 
-#  include <driver_types.h>
+#  if _CCCL_HAS_DLPACK_VERSION_1()
+#    include <cuda/__driver/driver_api.h>
+#    include <cuda/__memory/is_aligned.h>
+#    include <cuda/__memory/is_pointer_accessible.h>
+#    include <cuda/devices> // sub headers cause circular dependency
+#    include <cuda/std/__algorithm/min.h>
+#    include <cuda/std/__cstddef/types.h>
+#    include <cuda/std/__exception/exception_macros.h>
+#    include <cuda/std/__host_stdlib/stdexcept>
+#    include <cuda/std/__utility/unreachable.h>
+#    include <cuda/std/array>
+#    include <cuda/std/cstdint>
+#    include <cuda/std/span>
 
-#  include <cuda/std/__cccl/prologue.h>
+#    include <driver_types.h>
+
+#    include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
@@ -73,11 +75,11 @@ enum class tma_swizzle
   bytes32  = ::CU_TENSOR_MAP_SWIZZLE_32B,
   bytes64  = ::CU_TENSOR_MAP_SWIZZLE_64B,
   bytes128 = ::CU_TENSOR_MAP_SWIZZLE_128B,
-#  if _CCCL_CTK_AT_LEAST(12, 8)
+#    if _CCCL_CTK_AT_LEAST(12, 8)
   bytes128_atom_32B         = ::CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B,
   bytes128_atom_32B_flip_8B = ::CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B_FLIP_8B,
   bytes128_atom_64B         = ::CU_TENSOR_MAP_SWIZZLE_128B_ATOM_64B,
-#  endif // _CCCL_CTK_AT_LEAST(12, 8)
+#    endif // _CCCL_CTK_AT_LEAST(12, 8)
 };
 
 /***********************************************************************************************************************
@@ -143,14 +145,14 @@ __to_cutensor_map(tma_interleave_layout __interleave_layout) noexcept
       return ::CU_TENSOR_MAP_SWIZZLE_64B;
     case tma_swizzle::bytes128:
       return ::CU_TENSOR_MAP_SWIZZLE_128B;
-#  if _CCCL_CTK_AT_LEAST(12, 8)
+#    if _CCCL_CTK_AT_LEAST(12, 8)
     case tma_swizzle::bytes128_atom_32B:
       return ::CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B;
     case tma_swizzle::bytes128_atom_32B_flip_8B:
       return ::CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B_FLIP_8B;
     case tma_swizzle::bytes128_atom_64B:
       return ::CU_TENSOR_MAP_SWIZZLE_128B_ATOM_64B;
-#  endif // _CCCL_CTK_AT_LEAST(12, 8)
+#    endif // _CCCL_CTK_AT_LEAST(12, 8)
     default:
       ::cuda::std::unreachable();
   }
@@ -174,13 +176,13 @@ _CCCL_HOST_API inline void __check_device(const ::DLTensor& __tensor, tma_swizzl
   }
   if (__compute_capability == 9)
   {
-#  if _CCCL_CTK_AT_LEAST(12, 8)
+#    if _CCCL_CTK_AT_LEAST(12, 8)
     if (__swizzle == tma_swizzle::bytes128_atom_32B || __swizzle == tma_swizzle::bytes128_atom_32B_flip_8B
         || __swizzle == tma_swizzle::bytes128_atom_64B)
     {
       _CCCL_THROW(::std::invalid_argument, "tma_swizzle::bytes128_atom* are not supported with compute capability 9");
     }
-#  endif // _CCCL_CTK_AT_LEAST(12, 8)
+#    endif // _CCCL_CTK_AT_LEAST(12, 8)
     if (__tensor.dtype.code == ::kDLUInt && __tensor.dtype.bits == 4 && __tensor.dtype.lanes == 16)
     {
       _CCCL_THROW(::std::invalid_argument, "U4x16 is not supported with compute capability 9");
@@ -220,11 +222,11 @@ __get_tensor_map_data_type(const ::DLTensor& __tensor, tma_oob_fill __oobfill)
           {
             _CCCL_THROW(::std::invalid_argument, "uint4 data type must be 16 lanes");
           }
-#  if _CCCL_CTK_AT_LEAST(12, 8)
+#    if _CCCL_CTK_AT_LEAST(12, 8)
           return ::CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B;
-#  else
+#    else
           _CCCL_THROW(::std::invalid_argument, "U4x16 is not supported for compute capability 9");
-#  endif // _CCCL_CTK_AT_LEAST(12, 8)
+#    endif // _CCCL_CTK_AT_LEAST(12, 8)
         }
         case 8:
           if (__tensor.dtype.lanes != 1)
@@ -301,11 +303,11 @@ __get_tensor_map_data_type(const ::DLTensor& __tensor, tma_oob_fill __oobfill)
       {
         _CCCL_THROW(::std::invalid_argument, "Float4_e2m1fn data type must be 4 bits");
       }
-#  if _CCCL_CTK_AT_LEAST(12, 8)
+#    if _CCCL_CTK_AT_LEAST(12, 8)
       return ::CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B;
-#  else
+#    else
       _CCCL_THROW(::std::invalid_argument, "U4x16 (Float4_e2m1fn) is not supported for compute capability 9");
-#  endif // _CCCL_CTK_AT_LEAST(12, 8)
+#    endif // _CCCL_CTK_AT_LEAST(12, 8)
     default:
       _CCCL_THROW(::std::invalid_argument, "Unsupported data type");
   }
@@ -370,7 +372,7 @@ __get_tensor_sizes(const ::DLTensor& __tensor, int __rank, ::CUtensorMapDataType
   {
     _CCCL_THROW(::std::invalid_argument, "__tensor.shape is null");
   }
-#  if _CCCL_CTK_AT_LEAST(12, 8)
+#    if _CCCL_CTK_AT_LEAST(12, 8)
   if (__data_type == ::CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B)
   {
     if (__tensor_sizes[__rank - 1] % 2 != 0)
@@ -379,7 +381,7 @@ __get_tensor_sizes(const ::DLTensor& __tensor, int __rank, ::CUtensorMapDataType
                   "The innermost tensor dimension size must be a multiple of 2 for U4x16 or Float4_e2m1fn");
     }
   }
-#  endif // _CCCL_CTK_AT_LEAST(12, 8)
+#    endif // _CCCL_CTK_AT_LEAST(12, 8)
   for (int __i = 0; __i < __rank; ++__i)
   {
     constexpr auto __max_allowed_size = int64_t{1} << 32; // 2^32
@@ -411,9 +413,9 @@ __get_tensor_sizes(const ::DLTensor& __tensor, int __rank, ::CUtensorMapDataType
   [[maybe_unused]] int64_t __cumulative_size = 1;
   if (__input_strides == nullptr)
   {
-#  if _CCCL_DLPACK_AT_LEAST(1, 2)
+#    if _CCCL_DLPACK_AT_LEAST(1, 2)
     _CCCL_THROW(::std::invalid_argument, "__tensor.strides=nullptr is not supported for DLPack v1.2 and later");
-#  else // ^^^ _CCCL_DLPACK_AT_LEAST(1, 2) ^^^ / vvv _CCCL_DLPACK_BELOW(1, 2) vvv
+#    else // ^^^ _CCCL_DLPACK_AT_LEAST(1, 2) ^^^ / vvv _CCCL_DLPACK_BELOW(1, 2) vvv
     for (int __i = 0; __i < __rank - 1; ++__i)
     {
       // TODO(fbusato): check mul overflow
@@ -430,7 +432,7 @@ __get_tensor_sizes(const ::DLTensor& __tensor, int __rank, ::CUtensorMapDataType
       __output_strides[__i] = __stride_bytes;
     }
     return __output_strides;
-#  endif // ^^^ _CCCL_DLPACK_BELOW(1, 2) ^^^
+#    endif // ^^^ _CCCL_DLPACK_BELOW(1, 2) ^^^
   }
   // TMA ignores the innermost stride (always 1).
   for (int __i = __rank - 2; __i >= 0; --__i)
@@ -523,7 +525,7 @@ _CCCL_HOST_API inline __tma_box_sizes_array_t __get_box_sizes(
                     "be less than or equal to 128");
       }
     }
-#  if _CCCL_CTK_AT_LEAST(12, 8)
+#    if _CCCL_CTK_AT_LEAST(12, 8)
     if (__swizzle == tma_swizzle::bytes128_atom_32B || __swizzle == tma_swizzle::bytes128_atom_32B_flip_8B
         || __swizzle == tma_swizzle::bytes128_atom_64B)
     {
@@ -534,7 +536,7 @@ _CCCL_HOST_API inline __tma_box_sizes_array_t __get_box_sizes(
                     "bytes to be less than or equal to 128");
       }
     }
-#  endif // _CCCL_CTK_AT_LEAST(12, 8)
+#    endif // _CCCL_CTK_AT_LEAST(12, 8)
   }
   const auto __max_shmem =
     ::cuda::__driver::__deviceGetAttribute(::CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, __device_id);
@@ -649,8 +651,9 @@ _CCCL_HOST_API inline void __check_swizzle(tma_interleave_layout __interleave_la
 
 _CCCL_END_NAMESPACE_CUDA
 
-#  include <cuda/std/__cccl/epilogue.h>
+#    include <cuda/std/__cccl/epilogue.h>
 
+#  endif // _CCCL_HAS_DLPACK_VERSION_1()
 #endif // _CCCL_HAS_CTK() && _CCCL_HAS_DLPACK()
 
 #endif // _CUDA___TMA_MAKE_TMA_DESCRIPTOR_H


### PR DESCRIPTION
## Description

If libcu++ is used on systems with very old DLPack versions, it fails to compile. This requires the user to add `CCCL_DISABLE_DLPACK` definition.
To avoid this workaround, the PR disables the compilation of the three headers that requires DLPack when the version is < 1. The behavior is also aligned with the current documentation (no changes)