### PR TITLE
Optimize `cuda::std::rotl/rotr`

### DIFF
--- a/libcudacxx/include/cuda/std/__bit/rotate.h
+++ b/libcudacxx/include/cuda/std/__bit/rotate.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -21,12 +21,10 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__cmath/neg.h>
 #include <cuda/std/__concepts/concept_macros.h>
-#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__limits/numeric_limits.h>
 #include <cuda/std/__type_traits/is_unsigned_integer.h>
 #include <cuda/std/cstdint>
-#include <cuda/std/limits>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -76,8 +74,9 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-template <typename _Tp>
-[[nodiscard]] _CCCL_API constexpr _Tp __cccl_rotr_impl(_Tp __v, int __cnt) noexcept
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES(__cccl_is_unsigned_integer_v<_Tp>)
+[[nodiscard]] _CCCL_API constexpr _Tp rotr(const _Tp __v, const int __cnt) noexcept
 {
 #if !_CCCL_TILE_COMPILATION() // nvbug6084444: error: "call to non-tile function not supported!"
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
@@ -113,12 +112,13 @@ template <typename _Tp>
   }
 #endif // _CCCL_BUILTIN_ROTATERIGHT64
   constexpr auto __digits = numeric_limits<_Tp>::digits;
-  auto __cnt_mod          = static_cast<uint32_t>(__cnt) % __digits; // __cnt is always >= 0
+  const auto __cnt_mod    = static_cast<uint32_t>(__cnt) % __digits; // __cnt is always >= 0
   return __cnt_mod == 0 ? __v : (__v >> __cnt_mod) | (__v << (__digits - __cnt_mod));
 }
 
-template <typename _Tp>
-[[nodiscard]] _CCCL_API constexpr _Tp __cccl_rotl_impl(_Tp __v, int __cnt) noexcept
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES(__cccl_is_unsigned_integer_v<_Tp>)
+[[nodiscard]] _CCCL_API constexpr _Tp rotl(const _Tp __v, const int __cnt) noexcept
 {
 #if !_CCCL_TILE_COMPILATION() // nvbug6084444: error: "call to non-tile function not supported!"
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
@@ -154,32 +154,8 @@ template <typename _Tp>
   }
 #endif // _CCCL_BUILTIN_ROTATELEFT64
   constexpr auto __digits = numeric_limits<_Tp>::digits;
-  auto __cnt_mod          = static_cast<uint32_t>(__cnt) % __digits; // __cnt is always >= 0
+  const auto __cnt_mod    = static_cast<uint32_t>(__cnt) % __digits; // __cnt is always >= 0
   return __cnt_mod == 0 ? __v : (__v << __cnt_mod) | (__v >> (__digits - __cnt_mod));
-}
-
-_CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(::cuda::std::__cccl_is_unsigned_integer_v<_Tp>)
-[[nodiscard]] _CCCL_API constexpr _Tp rotl(_Tp __v, int __cnt) noexcept
-{
-  if (__cnt < 0)
-  {
-    __cnt = static_cast<int>(static_cast<unsigned>(::cuda::neg(__cnt)) % numeric_limits<_Tp>::digits);
-    return ::cuda::std::__cccl_rotr_impl(__v, __cnt);
-  }
-  return ::cuda::std::__cccl_rotl_impl(__v, __cnt);
-}
-
-_CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(::cuda::std::__cccl_is_unsigned_integer_v<_Tp>)
-[[nodiscard]] _CCCL_API constexpr _Tp rotr(_Tp __v, int __cnt) noexcept
-{
-  if (__cnt < 0)
-  {
-    __cnt = static_cast<int>(static_cast<unsigned>(::cuda::neg(__cnt)) % numeric_limits<_Tp>::digits);
-    return ::cuda::std::__cccl_rotl_impl(__v, __cnt);
-  }
-  return ::cuda::std::__cccl_rotr_impl(__v, __cnt);
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.rot/rotl.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.rot/rotl.pass.cpp
@@ -1,7 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of libcu++, the C++ Standard Library for your entire system,
-// under the Apache License v2.0 with LLVM Exceptions.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.rot/rotl.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.rot/rotl.pass.cpp
@@ -1,9 +1,10 @@
 //===----------------------------------------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is dual licensed under the MIT and the University of Illinois Open
-// Source Licenses. See LICENSE.TXT for details.
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -16,101 +17,69 @@
 #include <cuda/std/bit>
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>
+#include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
 #include "test_macros.h"
 
-class A
-{};
-enum E1 : unsigned char
-{
-  rEd
-};
-enum class E2 : unsigned char
-{
-  red
-};
-
 template <typename T>
-TEST_FUNC constexpr bool constexpr_test()
+TEST_FUNC constexpr T expected_rotl(T value, int count)
 {
-  using nl = cuda::std::numeric_limits<T>;
-  return cuda::std::rotl(T(1), 0) == T(1) && cuda::std::rotl(T(1), 1) == T(2) && cuda::std::rotl(T(1), 2) == T(4)
-      && cuda::std::rotl(T(1), 3) == T(8) && cuda::std::rotl(T(1), 4) == T(16) && cuda::std::rotl(T(1), 5) == T(32)
-      && cuda::std::rotl(T(1), 6) == T(64) && cuda::std::rotl(T(1), 7) == T(128)
-      && cuda::std::rotl(nl::max(), 0) == nl::max() && cuda::std::rotl(nl::max(), 1) == nl::max()
-      && cuda::std::rotl(nl::max(), 2) == nl::max() && cuda::std::rotl(nl::max(), 3) == nl::max()
-      && cuda::std::rotl(nl::max(), 4) == nl::max() && cuda::std::rotl(nl::max(), 5) == nl::max()
-      && cuda::std::rotl(nl::max(), 6) == nl::max() && cuda::std::rotl(nl::max(), 7) == nl::max();
+  constexpr int digits = cuda::std::numeric_limits<T>::digits;
+  int count_mod        = count % digits;
+  if (count_mod < 0)
+  {
+    count_mod += digits;
+  }
+  return count_mod == 0 ? value : static_cast<T>((value << count_mod) | (value >> (digits - count_mod)));
 }
 
 template <typename T>
-TEST_FUNC void runtime_test()
+TEST_FUNC constexpr void test()
 {
   static_assert(cuda::std::is_same_v<T, decltype(cuda::std::rotl(T(0), 0))>);
   static_assert(noexcept(cuda::std::rotl(T(0), 0)));
-  const T val = cuda::std::numeric_limits<T>::max() - 1;
 
-  assert(cuda::std::rotl(val, 0) == val);
-  assert(cuda::std::rotl(val, 1) == static_cast<T>((val << 1) + 1));
-  assert(cuda::std::rotl(val, 2) == static_cast<T>((val << 2) + 3));
-  assert(cuda::std::rotl(val, 3) == static_cast<T>((val << 3) + 7));
-  assert(cuda::std::rotl(val, 4) == static_cast<T>((val << 4) + 15));
-  assert(cuda::std::rotl(val, 5) == static_cast<T>((val << 5) + 31));
-  assert(cuda::std::rotl(val, 6) == static_cast<T>((val << 6) + 63));
-  assert(cuda::std::rotl(val, 7) == static_cast<T>((val << 7) + 127));
+  T values[] = {
+    T(0),
+    T(1),
+    T(0xB3),
+    cuda::std::numeric_limits<T>::max(),
+    T{cuda::std::numeric_limits<T>::max() - 1},
+  };
+  for (const auto& value : values)
+  {
+    for (int count = -34; count <= 34; ++count)
+    {
+      assert(cuda::std::rotl(value, count) == expected_rotl(value, count));
+    }
+  }
+}
+
+TEST_FUNC constexpr bool test()
+{
+  test<unsigned char>();
+  test<unsigned short>();
+  test<unsigned>();
+  test<unsigned long>();
+  test<unsigned long long>();
+  test<uint8_t>();
+  test<uint16_t>();
+  test<uint32_t>();
+  test<uint64_t>();
+  test<size_t>();
+  test<uintmax_t>();
+  test<uintptr_t>();
+#if _CCCL_HAS_INT128()
+  test<__uint128_t>();
+#endif // _CCCL_HAS_INT128()
+  return true;
 }
 
 int main(int, char**)
 {
-  static_assert(constexpr_test<unsigned char>());
-  static_assert(constexpr_test<unsigned short>());
-  static_assert(constexpr_test<unsigned>());
-  static_assert(constexpr_test<unsigned long>());
-  static_assert(constexpr_test<unsigned long long>());
-
-  static_assert(constexpr_test<uint8_t>());
-  static_assert(constexpr_test<uint16_t>());
-  static_assert(constexpr_test<uint32_t>());
-  static_assert(constexpr_test<uint64_t>());
-  static_assert(constexpr_test<size_t>());
-  static_assert(constexpr_test<uintmax_t>());
-  static_assert(constexpr_test<uintptr_t>());
-
-#if _CCCL_HAS_INT128()
-  static_assert(constexpr_test<__uint128_t>());
-#endif // _CCCL_HAS_INT128()
-
-  runtime_test<unsigned char>();
-  runtime_test<unsigned short>();
-  runtime_test<unsigned>();
-  runtime_test<unsigned long>();
-  runtime_test<unsigned long long>();
-
-  runtime_test<uint8_t>();
-  runtime_test<uint16_t>();
-  runtime_test<uint32_t>();
-  runtime_test<uint64_t>();
-  runtime_test<size_t>();
-  runtime_test<uintmax_t>();
-  runtime_test<uintptr_t>();
-
-#if _CCCL_HAS_INT128()
-  runtime_test<__uint128_t>();
-
-  {
-    __uint128_t val = 168; // 0xA8 (aka 10101000)
-
-    assert(cuda::std::rotl(val, 128) == 168);
-    val <<= 32;
-    assert(cuda::std::rotl(val, 96) == 168);
-    val <<= 2;
-    assert(cuda::std::rotl(val, 95) == 336);
-    val <<= 3;
-    assert(cuda::std::rotl(val, 90) == 84);
-    assert(cuda::std::rotl(val, 218) == 84);
-  }
-#endif // _CCCL_HAS_INT128()
+  static_assert(test());
+  assert(test());
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.rot/rotl.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.rot/rotl.pass.cpp
@@ -31,7 +31,17 @@ TEST_FUNC constexpr T expected_rotl(T value, int count)
   {
     count_mod += digits;
   }
-  return count_mod == 0 ? value : static_cast<T>((value << count_mod) | (value >> (digits - count_mod)));
+
+  T result = 0;
+  for (int dst = 0; dst < digits; ++dst)
+  {
+    int src = (dst - count_mod + digits) % digits;
+    if ((value & (T{1} << src)) != T{0})
+    {
+      result = result | (T{1} << dst);
+    }
+  }
+  return result;
 }
 
 template <typename T>
@@ -41,9 +51,9 @@ TEST_FUNC constexpr void test()
   static_assert(noexcept(cuda::std::rotl(T(0), 0)));
 
   T values[] = {
-    T(0),
-    T(1),
-    T(0xB3),
+    T{0},
+    T{1},
+    T{0xB3},
     cuda::std::numeric_limits<T>::max(),
     T{cuda::std::numeric_limits<T>::max() - 1},
   };
@@ -51,7 +61,10 @@ TEST_FUNC constexpr void test()
   {
     for (int count = -34; count <= 34; ++count)
     {
-      assert(cuda::std::rotl(value, count) == expected_rotl(value, count));
+      auto rotated = cuda::std::rotl(value, count);
+      assert(rotated == expected_rotl(value, count));
+      assert(rotated == cuda::std::rotr(value, -count));
+      assert(cuda::std::rotr(rotated, count) == value);
     }
   }
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.rot/rotr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.rot/rotr.pass.cpp
@@ -1,7 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of libcu++, the C++ Standard Library for your entire system,
-// under the Apache License v2.0 with LLVM Exceptions.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.rot/rotr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.rot/rotr.pass.cpp
@@ -31,7 +31,17 @@ TEST_FUNC constexpr T expected_rotr(T value, int count)
   {
     count_mod += digits;
   }
-  return count_mod == 0 ? value : static_cast<T>((value >> count_mod) | (value << (digits - count_mod)));
+
+  T result = 0;
+  for (int dst = 0; dst < digits; ++dst)
+  {
+    int src = (dst + count_mod) % digits;
+    if ((value & (T{1} << src)) != T{0})
+    {
+      result = result | (T{1} << dst);
+    }
+  }
+  return result;
 }
 
 template <typename T>
@@ -41,9 +51,9 @@ TEST_FUNC constexpr void test()
   static_assert(noexcept(cuda::std::rotr(T(0), 0)));
 
   T values[] = {
-    T(0),
-    T(1),
-    T(0xB3),
+    T{0},
+    T{1},
+    T{0xB3},
     cuda::std::numeric_limits<T>::max(),
     T{cuda::std::numeric_limits<T>::max() - 1},
   };
@@ -51,7 +61,10 @@ TEST_FUNC constexpr void test()
   {
     for (int count = -34; count <= 34; ++count)
     {
-      assert(cuda::std::rotr(value, count) == expected_rotr(value, count));
+      auto rotated = cuda::std::rotr(value, count);
+      assert(rotated == expected_rotr(value, count));
+      assert(rotated == cuda::std::rotl(value, -count));
+      assert(cuda::std::rotl(rotated, count) == value);
     }
   }
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.rot/rotr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bitops.rot/rotr.pass.cpp
@@ -1,9 +1,10 @@
 //===----------------------------------------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is dual licensed under the MIT and the University of Illinois Open
-// Source Licenses. See LICENSE.TXT for details.
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -16,105 +17,69 @@
 #include <cuda/std/bit>
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>
+#include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
 #include "test_macros.h"
 
 template <typename T>
-TEST_FUNC constexpr bool constexpr_test()
+TEST_FUNC constexpr T expected_rotr(T value, int count)
 {
-  using nl = cuda::std::numeric_limits<T>;
-
-  return cuda::std::rotr(T(128), 0) == T(128) && cuda::std::rotr(T(128), 1) == T(64)
-      && cuda::std::rotr(T(128), 2) == T(32) && cuda::std::rotr(T(128), 3) == T(16)
-      && cuda::std::rotr(T(128), 4) == T(8) && cuda::std::rotr(T(128), 5) == T(4) && cuda::std::rotr(T(128), 6) == T(2)
-      && cuda::std::rotr(T(128), 7) == T(1) && cuda::std::rotr(nl::max(), 0) == nl::max()
-      && cuda::std::rotr(nl::max(), 1) == nl::max() && cuda::std::rotr(nl::max(), 2) == nl::max()
-      && cuda::std::rotr(nl::max(), 3) == nl::max() && cuda::std::rotr(nl::max(), 4) == nl::max()
-      && cuda::std::rotr(nl::max(), 5) == nl::max() && cuda::std::rotr(nl::max(), 6) == nl::max()
-      && cuda::std::rotr(nl::max(), 7) == nl::max();
+  constexpr int digits = cuda::std::numeric_limits<T>::digits;
+  int count_mod        = count % digits;
+  if (count_mod < 0)
+  {
+    count_mod += digits;
+  }
+  return count_mod == 0 ? value : static_cast<T>((value >> count_mod) | (value << (digits - count_mod)));
 }
 
 template <typename T>
-TEST_FUNC void runtime_test()
+TEST_FUNC constexpr void test()
 {
   static_assert(cuda::std::is_same_v<T, decltype(cuda::std::rotr(T(0), 0))>);
   static_assert(noexcept(cuda::std::rotr(T(0), 0)));
-  const T max = cuda::std::numeric_limits<T>::max();
-  const T val = cuda::std::numeric_limits<T>::max() - 1;
 
-  const T uppers[] = {
-    max, // not used
-    max - max, // 000 .. 0
-    max - (max >> 1), // 800 .. 0
-    max - (max >> 2), // C00 .. 0
-    max - (max >> 3), // E00 .. 0
-    max - (max >> 4), // F00 .. 0
-    max - (max >> 5), // F80 .. 0
-    max - (max >> 6), // FC0 .. 0
-    max - (max >> 7), // FE0 .. 0
+  T values[] = {
+    T(0),
+    T(1),
+    T(0xB3),
+    cuda::std::numeric_limits<T>::max(),
+    T{cuda::std::numeric_limits<T>::max() - 1},
   };
+  for (const auto& value : values)
+  {
+    for (int count = -34; count <= 34; ++count)
+    {
+      assert(cuda::std::rotr(value, count) == expected_rotr(value, count));
+    }
+  }
+}
 
-  assert(cuda::std::rotr(val, 0) == val);
-  assert(cuda::std::rotr(val, 1) == T((val >> 1) + uppers[1]));
-  assert(cuda::std::rotr(val, 2) == T((val >> 2) + uppers[2]));
-  assert(cuda::std::rotr(val, 3) == T((val >> 3) + uppers[3]));
-  assert(cuda::std::rotr(val, 4) == T((val >> 4) + uppers[4]));
-  assert(cuda::std::rotr(val, 5) == T((val >> 5) + uppers[5]));
-  assert(cuda::std::rotr(val, 6) == T((val >> 6) + uppers[6]));
-  assert(cuda::std::rotr(val, 7) == T((val >> 7) + uppers[7]));
+TEST_FUNC constexpr bool test()
+{
+  test<unsigned char>();
+  test<unsigned short>();
+  test<unsigned>();
+  test<unsigned long>();
+  test<unsigned long long>();
+  test<uint8_t>();
+  test<uint16_t>();
+  test<uint32_t>();
+  test<uint64_t>();
+  test<size_t>();
+  test<uintmax_t>();
+  test<uintptr_t>();
+#if _CCCL_HAS_INT128()
+  test<__uint128_t>();
+#endif // _CCCL_HAS_INT128()
+  return true;
 }
 
 int main(int, char**)
 {
-  static_assert(constexpr_test<unsigned char>());
-  static_assert(constexpr_test<unsigned short>());
-  static_assert(constexpr_test<unsigned>());
-  static_assert(constexpr_test<unsigned long>());
-  static_assert(constexpr_test<unsigned long long>());
-
-  static_assert(constexpr_test<uint8_t>());
-  static_assert(constexpr_test<uint16_t>());
-  static_assert(constexpr_test<uint32_t>());
-  static_assert(constexpr_test<uint64_t>());
-  static_assert(constexpr_test<size_t>());
-  static_assert(constexpr_test<uintmax_t>());
-  static_assert(constexpr_test<uintptr_t>());
-
-#if _CCCL_HAS_INT128()
-  static_assert(constexpr_test<__uint128_t>());
-#endif // _CCCL_HAS_INT128()
-
-  runtime_test<unsigned char>();
-  runtime_test<unsigned>();
-  runtime_test<unsigned short>();
-  runtime_test<unsigned long>();
-  runtime_test<unsigned long long>();
-
-  runtime_test<uint8_t>();
-  runtime_test<uint16_t>();
-  runtime_test<uint32_t>();
-  runtime_test<uint64_t>();
-  runtime_test<size_t>();
-  runtime_test<uintmax_t>();
-  runtime_test<uintptr_t>();
-
-#if _CCCL_HAS_INT128()
-  runtime_test<__uint128_t>();
-
-  {
-    __uint128_t val = 168; // 0xA8 (aka 10101000)
-
-    assert(cuda::std::rotr(val, 128) == 168);
-    val <<= 32;
-    assert(cuda::std::rotr(val, 32) == 168);
-    val <<= 2;
-    assert(cuda::std::rotr(val, 33) == 336);
-    val <<= 3;
-    assert(cuda::std::rotr(val, 38) == 84);
-    assert(cuda::std::rotr(val, 166) == 84);
-  }
-#endif // _CCCL_HAS_INT128()
+  static_assert(test());
+  assert(test());
 
   return 0;
 }


### PR DESCRIPTION
## Description

Following the discussion in the CUDA developer forum https://forums.developer.nvidia.com/t/suboptimal-cuda-rotl-and-cuda-rotr-in-cuda-13-3-and-earlier-versions/372453.
The C++ standard requires `cuda::std::rotl(x, -3)` to be mapped to `cuda::std::rotr(x, 3)` (note opposite direction). Noting that `-3 % N` is equivalent to `N - 3`, `cuda::std::rotr(x, 3)` is equivalent to  `cuda::std::rotl(x, N - 3)`. This observation allows to entirely removing the dispatch.