### PR TITLE
[libcu++] Adds `stable_sorted` output_ordering

### DIFF
--- a/libcudacxx/include/cuda/__execution/output_ordering.h
+++ b/libcudacxx/include/cuda/__execution/output_ordering.h
@@ -31,6 +31,15 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_EXECUTION
 
+//! @brief Requirement describing the order in which an algorithm writes its results to the output (e.g. the top-k
+//! elements of cub::DeviceBatchedTopK).
+//!
+//! The available options are:
+//! - cuda::execution::output_ordering::unsorted: the results may be written in any order.
+//! - cuda::execution::output_ordering::sorted: the results are written sorted by key. Among elements that compare
+//!   equal, their relative order is unspecified.
+//! - cuda::execution::output_ordering::stable_sorted: the results are written sorted by key and, among elements that
+//!   compare equal, their relative order matches the order of their source indices (smaller source index first).
 namespace output_ordering
 {
 struct __get_output_ordering_t;
@@ -38,6 +47,7 @@ struct __get_output_ordering_t;
 enum class __output_ordering_t
 {
   __sorted,
+  __stable_sorted,
   __unsorted
 };
 
@@ -53,10 +63,12 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __output_ordering_holder_t
   }
 };
 
-using sorted_t   = __output_ordering_holder_t<__output_ordering_t::__sorted>;
-using unsorted_t = __output_ordering_holder_t<__output_ordering_t::__unsorted>;
+using sorted_t        = __output_ordering_holder_t<__output_ordering_t::__sorted>;
+using stable_sorted_t = __output_ordering_holder_t<__output_ordering_t::__stable_sorted>;
+using unsorted_t      = __output_ordering_holder_t<__output_ordering_t::__unsorted>;
 
 _CCCL_GLOBAL_CONSTANT sorted_t sorted{};
+_CCCL_GLOBAL_CONSTANT stable_sorted_t stable_sorted{};
 _CCCL_GLOBAL_CONSTANT unsorted_t unsorted{};
 
 struct __get_output_ordering_t

--- a/libcudacxx/include/cuda/__execution/output_ordering.h
+++ b/libcudacxx/include/cuda/__execution/output_ordering.h
@@ -47,8 +47,8 @@ struct __get_output_ordering_t;
 enum class __output_ordering_t
 {
   __sorted,
-  __stable_sorted,
-  __unsorted
+  __unsorted,
+  __stable_sorted
 };
 
 template <__output_ordering_t _Guarantee>

--- a/libcudacxx/include/cuda/__execution/output_ordering.h
+++ b/libcudacxx/include/cuda/__execution/output_ordering.h
@@ -35,10 +35,10 @@ _CCCL_BEGIN_NAMESPACE_CUDA_EXECUTION
 //! elements of cub::DeviceBatchedTopK).
 //!
 //! The available options are:
-//! - cuda::execution::output_ordering::unsorted: the results may be written in any order.
-//! - cuda::execution::output_ordering::sorted: the results are written sorted by key. Among elements that compare
+//! - output_ordering::unsorted: the results may be written in any order.
+//! - output_ordering::sorted: the results are written sorted by key. Among elements that compare
 //!   equal, their relative order is unspecified.
-//! - cuda::execution::output_ordering::stable_sorted: the results are written sorted by key and, among elements that
+//! - output_ordering::stable_sorted: the results are written sorted by key and, among elements that
 //!   compare equal, their relative order matches the order of their source indices (smaller source index first).
 namespace output_ordering
 {

--- a/libcudacxx/test/libcudacxx/cuda/execution/output_ordering.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/execution/output_ordering.pass.cpp
@@ -16,11 +16,15 @@ TEST_FUNC void test()
 {
   namespace exec = cuda::execution;
   static_assert(cuda::std::is_base_of_v<exec::__requirement, exec::output_ordering::sorted_t>);
+  static_assert(cuda::std::is_base_of_v<exec::__requirement, exec::output_ordering::stable_sorted_t>);
   static_assert(cuda::std::is_base_of_v<exec::__requirement, exec::output_ordering::unsorted_t>);
 
   static_assert(
     cuda::std::is_same_v<decltype(exec::output_ordering::__get_output_ordering(exec::output_ordering::sorted)),
                          exec::output_ordering::sorted_t>);
+  static_assert(
+    cuda::std::is_same_v<decltype(exec::output_ordering::__get_output_ordering(exec::output_ordering::stable_sorted)),
+                         exec::output_ordering::stable_sorted_t>);
   static_assert(
     cuda::std::is_same_v<decltype(exec::output_ordering::__get_output_ordering(exec::output_ordering::unsorted)),
                          exec::output_ordering::unsorted_t>);

--- a/libcudacxx/test/libcudacxx/cuda/execution/require.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/execution/require.pass.cpp
@@ -37,6 +37,11 @@ TEST_FUNC void test()
       decltype(cuda::execution::output_ordering::__get_output_ordering(
         cuda::execution::__get_requirements(cuda::execution::require(cuda::execution::output_ordering::unsorted)))),
       cuda::execution::output_ordering::unsorted_t>);
+
+  static_assert(cuda::std::is_same_v<
+                decltype(cuda::execution::output_ordering::__get_output_ordering(cuda::execution::__get_requirements(
+                  cuda::execution::require(cuda::execution::output_ordering::stable_sorted)))),
+                cuda::execution::output_ordering::stable_sorted_t>);
 }
 
 int main(int, char**)


### PR DESCRIPTION
## Description

More details on the motivation can be found in this issue: 
- https://github.com/NVIDIA/cccl/issues/9354