### PR TITLE
Allow public tuning of `cub::DeviceMemcpy`

### DIFF
--- a/cub/benchmarks/bench/copy/memcpy.cu
+++ b/cub/benchmarks/bench/copy/memcpy.cu
@@ -78,8 +78,7 @@ struct offset_to_size_t
 
 struct policy_selector_t
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::batch_memcpy::batch_memcpy_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::BatchedMemcpyPolicy
   {
     return {
       {

--- a/cub/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/cub/agent/agent_batch_memcpy.cuh
@@ -445,9 +445,8 @@ private:
   BackingUnitT data[NUM_TOTAL_UNITS] = {};
 };
 
-/**
- * Parameterizable tuning policy type for AgentBatchMemcpy
- */
+namespace detail
+{
 template <uint32_t ThreadsPerBlock,
           uint32_t BuffersPerThread,
           uint32_t TlevBytesPerThread,
@@ -457,7 +456,7 @@ template <uint32_t ThreadsPerBlock,
           uint32_t BlockLevelThreshold,
           class BuffDelayConstructor,
           class BlockDelayConstructor>
-struct AgentBatchMemcpyPolicy
+struct agent_batch_memcpy_policy
 {
   /// Threads per thread block
   static constexpr uint32_t BLOCK_THREADS = ThreadsPerBlock;
@@ -479,6 +478,29 @@ struct AgentBatchMemcpyPolicy
   using buff_delay_constructor  = BuffDelayConstructor;
   using block_delay_constructor = BlockDelayConstructor;
 };
+} // namespace detail
+
+//! Deprecated [Since 3.5]
+template <uint32_t ThreadsPerBlock,
+          uint32_t BuffersPerThread,
+          uint32_t TlevBytesPerThread,
+          bool PreferPow2Bits,
+          uint32_t BlockLevelTileSize,
+          uint32_t WarpLevelThreshold,
+          uint32_t BlockLevelThreshold,
+          class BuffDelayConstructor,
+          class BlockDelayConstructor>
+using AgentBatchMemcpyPolicy
+  CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceMemcpy") = detail::agent_batch_memcpy_policy<
+    ThreadsPerBlock,
+    BuffersPerThread,
+    TlevBytesPerThread,
+    PreferPow2Bits,
+    BlockLevelTileSize,
+    WarpLevelThreshold,
+    BlockLevelThreshold,
+    BuffDelayConstructor,
+    BlockDelayConstructor>;
 
 template <typename AgentMemcpySmallBuffersPolicyT,
           typename InputBufferIt,

--- a/cub/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/cub/agent/agent_batch_memcpy.cuh
@@ -38,6 +38,54 @@
 
 CUB_NAMESPACE_BEGIN
 
+namespace detail
+{
+template <uint32_t ThreadsPerBlock,
+          uint32_t BuffersPerThread,
+          uint32_t TlevBytesPerThread,
+          bool PreferPow2Bits,
+          uint32_t BlockLevelTileSize,
+          uint32_t WarpLevelThreshold,
+          uint32_t BlockLevelThreshold,
+          class BuffDelayConstructor,
+          class BlockDelayConstructor>
+struct agent_batch_memcpy_policy
+{
+  static constexpr uint32_t BLOCK_THREADS         = ThreadsPerBlock;
+  static constexpr uint32_t BUFFERS_PER_THREAD    = BuffersPerThread;
+  static constexpr uint32_t TLEV_BYTES_PER_THREAD = TlevBytesPerThread;
+  static constexpr uint32_t PREFER_POW2_BITS      = PreferPow2Bits;
+  static constexpr uint32_t BLOCK_LEVEL_TILE_SIZE = BlockLevelTileSize;
+  static constexpr uint32_t WARP_LEVEL_THRESHOLD  = WarpLevelThreshold;
+  static constexpr uint32_t BLOCK_LEVEL_THRESHOLD = BlockLevelThreshold;
+
+  using buff_delay_constructor  = BuffDelayConstructor;
+  using block_delay_constructor = BlockDelayConstructor;
+};
+} // namespace detail
+
+//! Deprecated [Since 3.5]
+template <uint32_t ThreadsPerBlock,
+          uint32_t BuffersPerThread,
+          uint32_t TlevBytesPerThread,
+          bool PreferPow2Bits,
+          uint32_t BlockLevelTileSize,
+          uint32_t WarpLevelThreshold,
+          uint32_t BlockLevelThreshold,
+          class BuffDelayConstructor,
+          class BlockDelayConstructor>
+using AgentBatchMemcpyPolicy
+  CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceMemcpy") = detail::agent_batch_memcpy_policy<
+    ThreadsPerBlock,
+    BuffersPerThread,
+    TlevBytesPerThread,
+    PreferPow2Bits,
+    BlockLevelTileSize,
+    WarpLevelThreshold,
+    BlockLevelThreshold,
+    BuffDelayConstructor,
+    BlockDelayConstructor>;
+
 namespace detail::batch_memcpy
 {
 template <bool PTR_IS_FOUR_BYTE_ALIGNED>
@@ -444,63 +492,6 @@ public:
 private:
   BackingUnitT data[NUM_TOTAL_UNITS] = {};
 };
-
-namespace detail
-{
-template <uint32_t ThreadsPerBlock,
-          uint32_t BuffersPerThread,
-          uint32_t TlevBytesPerThread,
-          bool PreferPow2Bits,
-          uint32_t BlockLevelTileSize,
-          uint32_t WarpLevelThreshold,
-          uint32_t BlockLevelThreshold,
-          class BuffDelayConstructor,
-          class BlockDelayConstructor>
-struct agent_batch_memcpy_policy
-{
-  /// Threads per thread block
-  static constexpr uint32_t BLOCK_THREADS = ThreadsPerBlock;
-  /// Items per thread (per tile of input)
-  static constexpr uint32_t BUFFERS_PER_THREAD = BuffersPerThread;
-  /// The number of bytes that each thread will work on with each iteration of reading in bytes
-  /// from one or more
-  // source-buffers and writing them out to the respective destination-buffers.
-  static constexpr uint32_t TLEV_BYTES_PER_THREAD = TlevBytesPerThread;
-  /// Whether the bit_packed_counter should prefer allocating a power-of-2 number of bits per
-  /// counter
-  static constexpr uint32_t PREFER_POW2_BITS = PreferPow2Bits;
-  /// BLEV tile size granularity
-  static constexpr uint32_t BLOCK_LEVEL_TILE_SIZE = BlockLevelTileSize;
-
-  static constexpr uint32_t WARP_LEVEL_THRESHOLD  = WarpLevelThreshold;
-  static constexpr uint32_t BLOCK_LEVEL_THRESHOLD = BlockLevelThreshold;
-
-  using buff_delay_constructor  = BuffDelayConstructor;
-  using block_delay_constructor = BlockDelayConstructor;
-};
-} // namespace detail
-
-//! Deprecated [Since 3.5]
-template <uint32_t ThreadsPerBlock,
-          uint32_t BuffersPerThread,
-          uint32_t TlevBytesPerThread,
-          bool PreferPow2Bits,
-          uint32_t BlockLevelTileSize,
-          uint32_t WarpLevelThreshold,
-          uint32_t BlockLevelThreshold,
-          class BuffDelayConstructor,
-          class BlockDelayConstructor>
-using AgentBatchMemcpyPolicy
-  CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceMemcpy") = detail::agent_batch_memcpy_policy<
-    ThreadsPerBlock,
-    BuffersPerThread,
-    TlevBytesPerThread,
-    PreferPow2Bits,
-    BlockLevelTileSize,
-    WarpLevelThreshold,
-    BlockLevelThreshold,
-    BuffDelayConstructor,
-    BlockDelayConstructor>;
 
 template <typename AgentMemcpySmallBuffersPolicyT,
           typename InputBufferIt,

--- a/cub/cub/device/device_memcpy.cuh
+++ b/cub/cub/device/device_memcpy.cuh
@@ -26,6 +26,24 @@
 CUB_NAMESPACE_BEGIN
 
 //! @brief cub::DeviceMemcpy provides device-wide, parallel operations for copying data.
+//!
+//! @par Tuning
+//! @rst
+//! All algorithms in DeviceMemcpy that accept an environment can be tuned by passing a custom :ref:`policy selector
+//! <cub-policy-selectors>` that returns a @ref BatchedMemcpyPolicy, as shown in the example below:
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_memcpy_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin memcpy-batched-policy-selector
+//!      :end-before: example-end memcpy-batched-policy-selector
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_memcpy_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin memcpy-batched-tuning
+//!      :end-before: example-end memcpy-batched-tuning
+//! @endrst
 struct DeviceMemcpy
 {
   //! @rst

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -237,9 +237,9 @@ __launch_bounds__(int(current_policy<PolicySelector>().small_buffer.threads_per_
     policy.block_level_tile_size,
     policy.warp_level_threshold,
     policy.block_level_threshold,
-    delay_constructor_t<policy.buff_lookback_delay.kind,
-                        policy.buff_lookback_delay.delay,
-                        policy.buff_lookback_delay.l2_write_latency>,
+    delay_constructor_t<policy.buffer_lookback_delay.kind,
+                        policy.buffer_lookback_delay.delay,
+                        policy.buffer_lookback_delay.l2_write_latency>,
     delay_constructor_t<policy.block_lookback_delay.kind,
                         policy.block_lookback_delay.delay,
                         policy.block_lookback_delay.l2_write_latency>>;

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -90,9 +90,9 @@ __launch_bounds__(int(current_policy<PolicySelector>().large_buffer.threads_per_
     TileT buffer_offset_tile,
     _CCCL_GRID_CONSTANT const TileOffsetT last_tile_offset)
 {
-  static constexpr large_buffer_policy policy = current_policy<PolicySelector>().large_buffer;
-  using StatusWord                            = typename TileT::StatusWord;
-  using BufferSizeT                           = it_value_t<BufferSizeIteratorT>;
+  static constexpr BatchMemcpyLargeBufferPolicy policy = current_policy<PolicySelector>().large_buffer;
+  using StatusWord                                     = typename TileT::StatusWord;
+  using BufferSizeT                                    = it_value_t<BufferSizeIteratorT>;
   /// Internal load/store type. For byte-wise memcpy, a single-byte type
   using AliasT = typename ::cuda::std::conditional_t<MemcpyOpt == CopyAlg::Memcpy,
                                                      ::cuda::std::type_identity<char>,
@@ -224,12 +224,12 @@ __launch_bounds__(int(current_policy<PolicySelector>().small_buffer.threads_per_
     _CCCL_GRID_CONSTANT const BLevBufferOffsetTileState blev_buffer_scan_state,
     _CCCL_GRID_CONSTANT const BLevBlockOffsetTileState blev_block_scan_state)
 {
-  static constexpr small_buffer_policy policy = current_policy<PolicySelector>().small_buffer;
+  static constexpr BatchMemcpySmallBufferPolicy policy = current_policy<PolicySelector>().small_buffer;
   // Internal type used for storing a buffer's size
   using BufferSizeT = it_value_t<BufferSizeIteratorT>;
 
   // TODO(bgruber): refactor this in C++20, when we can pass policy as NTTP
-  using AgentBatchMemcpyPolicyT = AgentBatchMemcpyPolicy<
+  using AgentBatchMemcpyPolicyT = agent_batch_memcpy_policy<
     policy.threads_per_block,
     policy.buffers_per_thread,
     policy.tlev_bytes_per_thread,
@@ -237,12 +237,12 @@ __launch_bounds__(int(current_policy<PolicySelector>().small_buffer.threads_per_
     policy.block_level_tile_size,
     policy.warp_level_threshold,
     policy.block_level_threshold,
-    delay_constructor_t<policy.buff_delay_constructor.kind,
-                        policy.buff_delay_constructor.delay,
-                        policy.buff_delay_constructor.l2_write_latency>,
-    delay_constructor_t<policy.block_delay_constructor.kind,
-                        policy.block_delay_constructor.delay,
-                        policy.block_delay_constructor.l2_write_latency>>;
+    delay_constructor_t<policy.buff_lookback_delay.kind,
+                        policy.buff_lookback_delay.delay,
+                        policy.buff_lookback_delay.l2_write_latency>,
+    delay_constructor_t<policy.block_lookback_delay.kind,
+                        policy.block_lookback_delay.delay,
+                        policy.block_lookback_delay.l2_write_latency>>;
 
   // Block-level specialization
   using AgentBatchMemcpyT = AgentBatchMemcpy<
@@ -315,7 +315,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   {
     return error;
   }
-  const batch_memcpy_policy active_policy = policy_selector(cc);
+  const BatchedMemcpyPolicy active_policy = policy_selector(cc);
 
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(NV_IS_HOST, ({

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -232,7 +232,7 @@ __launch_bounds__(int(current_policy<PolicySelector>().small_buffer.threads_per_
   using AgentBatchMemcpyPolicyT = agent_batch_memcpy_policy<
     policy.threads_per_block,
     policy.buffers_per_thread,
-    policy.tlev_bytes_per_thread,
+    policy.bytes_per_thread,
     policy.prefer_pow2_bits,
     policy.block_level_tile_size,
     policy.warp_level_threshold,

--- a/cub/cub/device/dispatch/tuning/tuning_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_batch_memcpy.cuh
@@ -27,9 +27,9 @@ struct BatchMemcpySmallBufferPolicy
 {
   int threads_per_block; //!< Number of threads in a CUDA block
   int buffers_per_thread; //!< Number of buffers processed per thread
-  int tlev_bytes_per_thread; //!< The number of bytes that each thread will work on with each iteration of reading in
-                             //!< bytes from one or more source-buffers and writing them out to the respective
-                             //!< destination-buffers.
+  int bytes_per_thread; //!< The number of bytes that each thread will work on with each iteration of reading in
+                        //!< bytes from one or more source-buffers and writing them out to the respective
+                        //!< destination-buffers.
   bool prefer_pow2_bits; //!< Whether the bit_packed_counter should prefer allocating a power-of-2 number of bits per
                          //!< counter
   int block_level_tile_size; //!< Tile size granularity for block-level buffers
@@ -42,7 +42,7 @@ struct BatchMemcpySmallBufferPolicy
   operator==(const BatchMemcpySmallBufferPolicy& lhs, const BatchMemcpySmallBufferPolicy& rhs) noexcept
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.buffers_per_thread == rhs.buffers_per_thread
-        && lhs.tlev_bytes_per_thread == rhs.tlev_bytes_per_thread && lhs.prefer_pow2_bits == rhs.prefer_pow2_bits
+        && lhs.bytes_per_thread == rhs.bytes_per_thread && lhs.prefer_pow2_bits == rhs.prefer_pow2_bits
         && lhs.block_level_tile_size == rhs.block_level_tile_size
         && lhs.warp_level_threshold == rhs.warp_level_threshold
         && lhs.block_level_threshold == rhs.block_level_threshold
@@ -61,8 +61,8 @@ struct BatchMemcpySmallBufferPolicy
   {
     return os
         << "BatchMemcpySmallBufferPolicy { .threads_per_block = " << policy.threads_per_block
-        << ", .buffers_per_thread = " << policy.buffers_per_thread << ", .tlev_bytes_per_thread = "
-        << policy.tlev_bytes_per_thread << ", .prefer_pow2_bits = " << policy.prefer_pow2_bits
+        << ", .buffers_per_thread = " << policy.buffers_per_thread
+        << ", .bytes_per_thread = " << policy.bytes_per_thread << ", .prefer_pow2_bits = " << policy.prefer_pow2_bits
         << ", .block_level_tile_size = " << policy.block_level_tile_size << ", .warp_level_threshold = "
         << policy.warp_level_threshold << ", .block_level_threshold = " << policy.block_level_threshold
         << ", .buffer_lookback_delay = " << policy.buffer_lookback_delay
@@ -145,7 +145,7 @@ struct policy_selector
       BatchMemcpySmallBufferPolicy{
         /* .threads_per_block = */ 128,
         /* .buffers_per_thread = */ 4,
-        /* .tlev_bytes_per_thread = */ 8,
+        /* .bytes_per_thread = */ 8,
         /* .prefer_pow2_bits = */ cc < ::cuda::compute_capability{7, 0},
         /* .block_level_tile_size = */ large.threads_per_block * large.bytes_per_thread,
         /* .warp_level_threshold = */ 128,

--- a/cub/cub/device/dispatch/tuning/tuning_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_batch_memcpy.cuh
@@ -35,7 +35,7 @@ struct BatchMemcpySmallBufferPolicy
   int block_level_tile_size; //!< Tile size granularity for block-level buffers
   int warp_level_threshold; //!< Buffer size threshold above which warp-level collaboration is used
   int block_level_threshold; //!< Buffer size threshold above which block-level collaboration is used
-  LookbackDelayPolicy buff_lookback_delay; //!< The @ref LookbackDelayPolicy for the buffer offset scan
+  LookbackDelayPolicy buffer_lookback_delay; //!< The @ref LookbackDelayPolicy for the buffer offset scan
   LookbackDelayPolicy block_lookback_delay; //!< The @ref LookbackDelayPolicy for the block offset scan
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
@@ -45,7 +45,8 @@ struct BatchMemcpySmallBufferPolicy
         && lhs.tlev_bytes_per_thread == rhs.tlev_bytes_per_thread && lhs.prefer_pow2_bits == rhs.prefer_pow2_bits
         && lhs.block_level_tile_size == rhs.block_level_tile_size
         && lhs.warp_level_threshold == rhs.warp_level_threshold
-        && lhs.block_level_threshold == rhs.block_level_threshold && lhs.buff_lookback_delay == rhs.buff_lookback_delay
+        && lhs.block_level_threshold == rhs.block_level_threshold
+        && lhs.buffer_lookback_delay == rhs.buffer_lookback_delay
         && lhs.block_lookback_delay == rhs.block_lookback_delay;
   }
 
@@ -64,7 +65,7 @@ struct BatchMemcpySmallBufferPolicy
         << policy.tlev_bytes_per_thread << ", .prefer_pow2_bits = " << policy.prefer_pow2_bits
         << ", .block_level_tile_size = " << policy.block_level_tile_size << ", .warp_level_threshold = "
         << policy.warp_level_threshold << ", .block_level_threshold = " << policy.block_level_threshold
-        << ", .buff_lookback_delay = " << policy.buff_lookback_delay
+        << ", .buffer_lookback_delay = " << policy.buffer_lookback_delay
         << ", .block_lookback_delay = " << policy.block_lookback_delay << " }";
   }
 #endif // _CCCL_HOSTED()
@@ -150,7 +151,7 @@ struct policy_selector
         /* .warp_level_threshold = */ 128,
         /* .block_level_threshold = */ 8 * 1024,
         // BufferOffsetT and BlockOffsetT are primitive/trivially copyable
-        /* .buff_lookback_delay = */ default_delay_constructor_policy(true),
+        /* .buffer_lookback_delay = */ default_delay_constructor_policy(true),
         /* .block_lookback_delay = */ default_delay_constructor_policy(true)},
       large,
     };

--- a/cub/cub/device/dispatch/tuning/tuning_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_batch_memcpy.cuh
@@ -22,120 +22,126 @@
 
 CUB_NAMESPACE_BEGIN
 
-namespace detail::batch_memcpy
+//! The small buffer sub-policy for @ref BatchedMemcpyPolicy.
+struct BatchMemcpySmallBufferPolicy
 {
-struct small_buffer_policy
-{
-  int threads_per_block;
-  int buffers_per_thread;
-  int tlev_bytes_per_thread;
-  bool prefer_pow2_bits;
-  int block_level_tile_size;
-  int warp_level_threshold;
-  int block_level_threshold;
-  LookbackDelayPolicy buff_delay_constructor;
-  LookbackDelayPolicy block_delay_constructor;
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int buffers_per_thread; //!< Number of buffers processed per thread
+  int tlev_bytes_per_thread; //!< The number of bytes that each thread will work on with each iteration of reading in
+                             //!< bytes from one or more source-buffers and writing them out to the respective
+                             //!< destination-buffers.
+  bool prefer_pow2_bits; //!< Whether the bit_packed_counter should prefer allocating a power-of-2 number of bits per
+                         //!< counter
+  int block_level_tile_size; //!< Tile size granularity for block-level buffers
+  int warp_level_threshold; //!< Buffer size threshold above which warp-level collaboration is used
+  int block_level_threshold; //!< Buffer size threshold above which block-level collaboration is used
+  LookbackDelayPolicy buff_lookback_delay; //!< The @ref LookbackDelayPolicy for the buffer offset scan
+  LookbackDelayPolicy block_lookback_delay; //!< The @ref LookbackDelayPolicy for the block offset scan
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const small_buffer_policy& lhs, const small_buffer_policy& rhs)
+  operator==(const BatchMemcpySmallBufferPolicy& lhs, const BatchMemcpySmallBufferPolicy& rhs) noexcept
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.buffers_per_thread == rhs.buffers_per_thread
         && lhs.tlev_bytes_per_thread == rhs.tlev_bytes_per_thread && lhs.prefer_pow2_bits == rhs.prefer_pow2_bits
         && lhs.block_level_tile_size == rhs.block_level_tile_size
         && lhs.warp_level_threshold == rhs.warp_level_threshold
-        && lhs.block_level_threshold == rhs.block_level_threshold
-        && lhs.buff_delay_constructor == rhs.buff_delay_constructor
-        && lhs.block_delay_constructor == rhs.block_delay_constructor;
+        && lhs.block_level_threshold == rhs.block_level_threshold && lhs.buff_lookback_delay == rhs.buff_lookback_delay
+        && lhs.block_lookback_delay == rhs.block_lookback_delay;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const small_buffer_policy& lhs, const small_buffer_policy& rhs)
+  operator!=(const BatchMemcpySmallBufferPolicy& lhs, const BatchMemcpySmallBufferPolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const small_buffer_policy& policy)
+  friend ::std::ostream& operator<<(::std::ostream& os, const BatchMemcpySmallBufferPolicy& policy)
   {
     return os
-        << "small_buffer_policy { .threads_per_block = " << policy.threads_per_block << ", .buffers_per_thread = "
-        << policy.buffers_per_thread << ", .tlev_bytes_per_thread = " << policy.tlev_bytes_per_thread
-        << ", .prefer_pow2_bits = " << policy.prefer_pow2_bits << ", .block_level_tile_size = "
-        << policy.block_level_tile_size << ", .warp_level_threshold = " << policy.warp_level_threshold
-        << ", .block_level_threshold = " << policy.block_level_threshold << ", .buff_delay_constructor = "
-        << policy.buff_delay_constructor << ", .block_delay_constructor = " << policy.block_delay_constructor << " }";
+        << "BatchMemcpySmallBufferPolicy { .threads_per_block = " << policy.threads_per_block
+        << ", .buffers_per_thread = " << policy.buffers_per_thread << ", .tlev_bytes_per_thread = "
+        << policy.tlev_bytes_per_thread << ", .prefer_pow2_bits = " << policy.prefer_pow2_bits
+        << ", .block_level_tile_size = " << policy.block_level_tile_size << ", .warp_level_threshold = "
+        << policy.warp_level_threshold << ", .block_level_threshold = " << policy.block_level_threshold
+        << ", .buff_lookback_delay = " << policy.buff_lookback_delay
+        << ", .block_lookback_delay = " << policy.block_lookback_delay << " }";
   }
 #endif // _CCCL_HOSTED()
 };
 
-struct large_buffer_policy
+//! The large buffer sub-policy for @ref BatchedMemcpyPolicy.
+struct BatchMemcpyLargeBufferPolicy
 {
-  int threads_per_block;
-  int bytes_per_thread;
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int bytes_per_thread; //!< Number of bytes processed per thread
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const large_buffer_policy& lhs, const large_buffer_policy& rhs)
+  operator==(const BatchMemcpyLargeBufferPolicy& lhs, const BatchMemcpyLargeBufferPolicy& rhs) noexcept
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.bytes_per_thread == rhs.bytes_per_thread;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const large_buffer_policy& lhs, const large_buffer_policy& rhs)
+  operator!=(const BatchMemcpyLargeBufferPolicy& lhs, const BatchMemcpyLargeBufferPolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const large_buffer_policy& policy)
+  friend ::std::ostream& operator<<(::std::ostream& os, const BatchMemcpyLargeBufferPolicy& policy)
   {
-    return os << "large_buffer_policy { .threads_per_block = " << policy.threads_per_block
+    return os << "BatchMemcpyLargeBufferPolicy { .threads_per_block = " << policy.threads_per_block
               << ", .bytes_per_thread = " << policy.bytes_per_thread << " }";
   }
 #endif // _CCCL_HOSTED()
 };
 
-struct batch_memcpy_policy
+//! The tuning policy for all algorithms in @ref DeviceMemcpy.
+struct BatchedMemcpyPolicy
 {
-  small_buffer_policy small_buffer;
-  large_buffer_policy large_buffer;
+  BatchMemcpySmallBufferPolicy small_buffer; //!< Sub-policy for small buffers copied by a single thread block
+  BatchMemcpyLargeBufferPolicy large_buffer; //!< Sub-policy for large buffers requiring multi-block collaboration
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const batch_memcpy_policy& lhs, const batch_memcpy_policy& rhs)
+  operator==(const BatchedMemcpyPolicy& lhs, const BatchedMemcpyPolicy& rhs) noexcept
   {
     return lhs.small_buffer == rhs.small_buffer && lhs.large_buffer == rhs.large_buffer;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const batch_memcpy_policy& lhs, const batch_memcpy_policy& rhs)
+  operator!=(const BatchedMemcpyPolicy& lhs, const BatchedMemcpyPolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const batch_memcpy_policy& policy)
+  friend ::std::ostream& operator<<(::std::ostream& os, const BatchedMemcpyPolicy& policy)
   {
-    return os << "batch_memcpy_policy { .small_buffer = " << policy.small_buffer
+    return os << "BatchedMemcpyPolicy { .small_buffer = " << policy.small_buffer
               << ", .large_buffer = " << policy.large_buffer << " }";
   }
 #endif // _CCCL_HOSTED()
 };
 
+namespace detail::batch_memcpy
+{
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>
-concept batch_memcpy_policy_selector = policy_selector<T, batch_memcpy_policy>;
+concept batch_memcpy_policy_selector = policy_selector<T, BatchedMemcpyPolicy>;
 #endif // _CCCL_HAS_CONCEPTS()
 
 struct policy_selector
 {
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
-    -> batch_memcpy_policy
+    -> BatchedMemcpyPolicy
   {
-    const auto large = large_buffer_policy{
+    const auto large = BatchMemcpyLargeBufferPolicy{
       256,
       32,
     };
-    return batch_memcpy_policy{
-      small_buffer_policy{
+    return BatchedMemcpyPolicy{
+      BatchMemcpySmallBufferPolicy{
         /* .threads_per_block = */ 128,
         /* .buffers_per_thread = */ 4,
         /* .tlev_bytes_per_thread = */ 8,
@@ -144,8 +150,8 @@ struct policy_selector
         /* .warp_level_threshold = */ 128,
         /* .block_level_threshold = */ 8 * 1024,
         // BufferOffsetT and BlockOffsetT are primitive/trivially copyable
-        /* .buff_delay_constructor = */ default_delay_constructor_policy(true),
-        /* .block_delay_constructor = */ default_delay_constructor_policy(true)},
+        /* .buff_lookback_delay = */ default_delay_constructor_policy(true),
+        /* .block_lookback_delay = */ default_delay_constructor_policy(true)},
       large,
     };
   }

--- a/cub/test/catch2_test_device_copy_env.cu
+++ b/cub/test/catch2_test_device_copy_env.cu
@@ -136,7 +136,7 @@ TEST_CASE("DeviceCopy::Batched uses custom stream", "[copy][device]")
 template <int BlockThreads>
 struct batch_copy_tuning
 {
-  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::detail::batch_memcpy::batch_memcpy_policy
+  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::BatchedMemcpyPolicy
   {
     return {
       {BlockThreads, 4, 8, false, 256 * 32, 128, 8 * 1024, {}, {}},

--- a/cub/test/catch2_test_device_memcpy_env.cu
+++ b/cub/test/catch2_test_device_memcpy_env.cu
@@ -135,8 +135,7 @@ TEST_CASE("DeviceMemcpy::Batched uses custom stream", "[memcpy][device]")
 template <int BlockThreads>
 struct batch_memcpy_tuning
 {
-  _CCCL_API constexpr auto operator()(cuda::compute_capability /*cc*/) const
-    -> cub::detail::batch_memcpy::batch_memcpy_policy
+  _CCCL_API constexpr auto operator()(cuda::compute_capability /*cc*/) const -> cub::BatchedMemcpyPolicy
   {
     return {
       {BlockThreads, 4, 8, false, 256 * 32, 128, 8 * 1024, {}, {}},
@@ -180,3 +179,52 @@ C2H_TEST("DeviceMemcpy::Batched can be tuned", "[memcpy][device]", block_sizes)
 }
 
 #endif // TEST_LAUNCH != 1
+
+#if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
+C2H_TEST("BatchedMemcpyPolicy", "[memcpy][device]")
+{
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::BatchedMemcpyPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::BatchedMemcpyPolicy>);
+
+  // aggregate init
+  constexpr auto p1 = cub::BatchedMemcpyPolicy{
+    cub::BatchMemcpySmallBufferPolicy{
+      128,
+      4,
+      8,
+      false,
+      256 * 32,
+      128,
+      8 * 1024,
+      cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 350, 450},
+      cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 350, 450}},
+    cub::BatchMemcpyLargeBufferPolicy{256, 32}};
+
+#  if _CCCL_STD_VER >= 2020
+  // designated init
+  constexpr auto p2 = cub::BatchedMemcpyPolicy{
+    .small_buffer =
+      cub::BatchMemcpySmallBufferPolicy{
+        .threads_per_block     = 128,
+        .buffers_per_thread    = 4,
+        .tlev_bytes_per_thread = 8,
+        .prefer_pow2_bits      = false,
+        .block_level_tile_size = 256 * 32,
+        .warp_level_threshold  = 128,
+        .block_level_threshold = 8 * 1024,
+        .buff_lookback_delay =
+          cub::LookbackDelayPolicy{
+            .kind = cub::LookbackDelayAlgorithm::fixed_delay, .delay = 350, .l2_write_latency = 450},
+        .block_lookback_delay =
+          cub::LookbackDelayPolicy{
+            .kind = cub::LookbackDelayAlgorithm::fixed_delay, .delay = 350, .l2_write_latency = 450}},
+    .large_buffer = cub::BatchMemcpyLargeBufferPolicy{.threads_per_block = 256, .bytes_per_thread = 32}};
+#  else // _CCCL_STD_VER >= 2020
+  constexpr auto p2 = p1;
+#  endif // _CCCL_STD_VER >= 2020
+
+  // comparison
+  STATIC_REQUIRE(p1 == p2);
+  STATIC_REQUIRE_FALSE(p1 != p2);
+}
+#endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_memcpy_env.cu
+++ b/cub/test/catch2_test_device_memcpy_env.cu
@@ -212,7 +212,7 @@ C2H_TEST("BatchedMemcpyPolicy", "[memcpy][device]")
         .block_level_tile_size = 256 * 32,
         .warp_level_threshold  = 128,
         .block_level_threshold = 8 * 1024,
-        .buff_lookback_delay =
+        .buffer_lookback_delay =
           cub::LookbackDelayPolicy{
             .kind = cub::LookbackDelayAlgorithm::fixed_delay, .delay = 350, .l2_write_latency = 450},
         .block_lookback_delay =

--- a/cub/test/catch2_test_device_memcpy_env.cu
+++ b/cub/test/catch2_test_device_memcpy_env.cu
@@ -207,7 +207,7 @@ C2H_TEST("BatchedMemcpyPolicy", "[memcpy][device]")
       cub::BatchMemcpySmallBufferPolicy{
         .threads_per_block     = 128,
         .buffers_per_thread    = 4,
-        .tlev_bytes_per_thread = 8,
+        .bytes_per_thread      = 8,
         .prefer_pow2_bits      = false,
         .block_level_tile_size = 256 * 32,
         .warp_level_threshold  = 128,

--- a/cub/test/catch2_test_device_memcpy_env_api.cu
+++ b/cub/test/catch2_test_device_memcpy_env_api.cu
@@ -8,6 +8,7 @@
 #include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/device_vector.h>
 
+#include <cuda/__execution/tune.h>
 #include <cuda/devices>
 #include <cuda/stream>
 
@@ -67,3 +68,79 @@ C2H_TEST("cub::DeviceMemcpy::Batched accepts env with stream", "[memcpy][env]")
   REQUIRE(d_dst_a == expected_a);
   REQUIRE(d_dst_b == expected_b);
 }
+
+#if _CCCL_STD_VER >= 2020
+
+// nvcc turns the `.member = value,` C++ syntax into GNU's `member: value,` when clang (14 - 21) is used
+_CCCL_DIAG_PUSH
+#  if _CCCL_COMPILER(CLANG)
+_CCCL_DIAG_SUPPRESS_CLANG("-Wgnu-designator")
+#  endif // _CCCL_COMPILER(CLANG)
+
+// example-begin memcpy-batched-policy-selector
+struct BatchedMemcpyPolicySelector
+{
+  __host__ __device__ constexpr auto operator()(cuda::compute_capability /*cc*/) const -> cub::BatchedMemcpyPolicy
+  {
+    return {.small_buffer = {.threads_per_block     = 128,
+                             .buffers_per_thread    = 4,
+                             .tlev_bytes_per_thread = 8,
+                             .prefer_pow2_bits      = false,
+                             .block_level_tile_size = 256 * 32,
+                             .warp_level_threshold  = 128,
+                             .block_level_threshold = 8 * 1024,
+                             .buff_lookback_delay   = {},
+                             .block_lookback_delay  = {}},
+            .large_buffer = {.threads_per_block = 256, .bytes_per_thread = 32}};
+  }
+};
+// example-end memcpy-batched-policy-selector
+
+_CCCL_DIAG_POP
+
+C2H_TEST("cub::DeviceMemcpy::Batched env-based API with tuning", "[memcpy][env]")
+{
+  // example-begin memcpy-batched-tuning
+  // Source data: 3 buffers laid out contiguously
+  // Buffer 0: [10, 20]     Buffer 1: [30, 40, 50]     Buffer 2: [60]
+  auto d_src = thrust::device_vector<int>{10, 20, 30, 40, 50, 60};
+
+  // Two separate destination buffers
+  auto d_dst_a = thrust::device_vector<int>(5, 0);
+  auto d_dst_b = thrust::device_vector<int>(1, 0);
+
+  auto d_src_ptrs = thrust::device_vector<const int*>{
+    thrust::raw_pointer_cast(d_src.data()) + 0,
+    thrust::raw_pointer_cast(d_src.data()) + 2,
+    thrust::raw_pointer_cast(d_src.data()) + 5};
+
+  // Buffers 0,1 go to d_dst_a, buffer 2 goes to d_dst_b
+  auto d_dst_ptrs = thrust::device_vector<int*>{
+    thrust::raw_pointer_cast(d_dst_a.data()) + 0,
+    thrust::raw_pointer_cast(d_dst_a.data()) + 2,
+    thrust::raw_pointer_cast(d_dst_b.data()) + 0};
+
+  auto d_sizes = thrust::device_vector<int>{
+    2 * static_cast<int>(sizeof(int)), 3 * static_cast<int>(sizeof(int)), 1 * static_cast<int>(sizeof(int))};
+
+  const auto error = cub::DeviceMemcpy::Batched(
+    thrust::raw_pointer_cast(d_src_ptrs.data()),
+    thrust::raw_pointer_cast(d_dst_ptrs.data()),
+    thrust::raw_pointer_cast(d_sizes.data()),
+    3,
+    cuda::execution::tune(BatchedMemcpyPolicySelector{}));
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceMemcpy::Batched failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected_a{10, 20, 30, 40, 50};
+  thrust::device_vector<int> expected_b{60};
+  // example-end memcpy-batched-tuning
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_dst_a == expected_a);
+  REQUIRE(d_dst_b == expected_b);
+}
+
+#endif // _CCCL_STD_VER >= 2020

--- a/cub/test/catch2_test_device_memcpy_env_api.cu
+++ b/cub/test/catch2_test_device_memcpy_env_api.cu
@@ -89,7 +89,7 @@ struct BatchedMemcpyPolicySelector
                              .block_level_tile_size = 256 * 32,
                              .warp_level_threshold  = 128,
                              .block_level_threshold = 8 * 1024,
-                             .buff_lookback_delay   = {},
+                             .buffer_lookback_delay = {},
                              .block_lookback_delay  = {}},
             .large_buffer = {.threads_per_block = 256, .bytes_per_thread = 32}};
   }

--- a/cub/test/catch2_test_device_memcpy_env_api.cu
+++ b/cub/test/catch2_test_device_memcpy_env_api.cu
@@ -84,7 +84,7 @@ struct BatchedMemcpyPolicySelector
   {
     return {.small_buffer = {.threads_per_block     = 128,
                              .buffers_per_thread    = 4,
-                             .tlev_bytes_per_thread = 8,
+                             .bytes_per_thread      = 8,
                              .prefer_pow2_bits      = false,
                              .block_level_tile_size = 256 * 32,
                              .warp_level_threshold  = 128,


### PR DESCRIPTION
Fixes: #8572

### New public entities                                                                                                                                                                                            
                                                                                                                                                                                                                     
  | Entity | Enumerators / Data members |                                                                                                                                                                            
  |--------|---------------------------|                                                                                                                                                                             
  | `cub::BatchMemcpySmallBufferPolicy` | `int threads_per_block`<br>`int buffers_per_thread`<br>`int bytes_per_thread`<br>`bool prefer_pow2_bits`<br>`int block_level_tile_size`<br>`int warp_level_threshold`<br>`int block_level_threshold`<br>`LookbackDelayPolicy buffer_lookback_delay`<br>`LookbackDelayPolicy block_lookback_delay` |                                                                  
  | `cub::BatchMemcpyLargeBufferPolicy` | `int threads_per_block`<br>`int bytes_per_thread` |
  | `cub::BatchMemcpyPolicy` | `BatchMemcpySmallBufferPolicy small_buffer`<br>`BatchMemcpyLargeBufferPolicy large_buffer` |   