### PR TITLE
Histogram tuning policy cleanup

### DIFF
--- a/cub/benchmarks/bench/histogram/histogram_common.cuh
+++ b/cub/benchmarks/bench/histogram/histogram_common.cuh
@@ -47,12 +47,12 @@ struct bench_policy_selector
 
     return {TUNE_THREADS,
             TUNE_ITEMS,
+            TUNE_VEC_SIZE,
             load_algorithm,
             TUNE_LOAD_MODIFIER,
             TUNE_RLE_COMPRESS,
             MEM_PREFERENCE,
             TUNE_WORK_STEALING,
-            TUNE_VEC_SIZE,
             2048}; // TODO(bgruber): make tunable
   }
 };

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -745,12 +745,12 @@ _CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> histogram_policy
   return histogram_policy{
     ap::BLOCK_THREADS,
     ap::PIXELS_PER_THREAD,
+    ap::VEC_SIZE,
     ap::LOAD_ALGORITHM,
     ap::LOAD_MODIFIER,
     ap::IS_RLE_COMPRESS,
     ap::MEM_PREFERENCE,
     ap::IS_WORK_STEALING,
-    ap::VEC_SIZE,
     convert_pdl_trigger<ActivePolicy>(0)};
 }
 

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -725,9 +725,9 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t __dispatch_even_device
 // TODO(bgruber): drop in CCCL 4.0
 template <typename ActivePolicy>
 _CCCL_HOST_DEVICE_API constexpr auto convert_pdl_trigger(int)
-  -> decltype(ActivePolicy::pdl_trigger_next_launch_in_init_kernel_max_bin_count)
+  -> decltype(ActivePolicy::init_kernel_pdl_trigger_max_bins)
 {
-  return ActivePolicy::pdl_trigger_next_launch_in_init_kernel_max_bin_count;
+  return ActivePolicy::init_kernel_pdl_trigger_max_bins;
 }
 
 // TODO(bgruber): drop in CCCL 4.0

--- a/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
@@ -351,7 +351,7 @@ _CCCL_KERNEL_ATTRIBUTES void DeviceHistogramInitKernel(
   // we trigger the sweep kernel only if we have a small number of remaining writes in this kernel
   NV_IF_TARGET(NV_PROVIDES_SM_90, ({
                  if (::cuda::std::reduce(num_output_bins_wrapper.begin(), num_output_bins_wrapper.end())
-                     <= policy.pdl_trigger_next_launch_in_init_kernel_max_bin_count)
+                     <= policy.init_kernel_pdl_trigger_max_bins)
                  {
                    _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
                  }

--- a/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
@@ -233,21 +233,21 @@ struct histogram_policy
 {
   int threads_per_block;
   int pixels_per_thread;
+  int vec_size;
   BlockLoadAlgorithm load_algorithm;
   CacheLoadModifier load_modifier;
   bool rle_compress;
   BlockHistogramMemoryPreference mem_preference;
   bool work_stealing;
-  int vec_size;
   int pdl_trigger_next_launch_in_init_kernel_max_bin_count;
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const histogram_policy& lhs, const histogram_policy& rhs)
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.pixels_per_thread == rhs.pixels_per_thread
-        && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
-        && lhs.rle_compress == rhs.rle_compress && lhs.mem_preference == rhs.mem_preference
-        && lhs.work_stealing == rhs.work_stealing && lhs.vec_size == rhs.vec_size
+        && lhs.vec_size == rhs.vec_size && lhs.load_algorithm == rhs.load_algorithm
+        && lhs.load_modifier == rhs.load_modifier && lhs.rle_compress == rhs.rle_compress
+        && lhs.mem_preference == rhs.mem_preference && lhs.work_stealing == rhs.work_stealing
         && lhs.pdl_trigger_next_launch_in_init_kernel_max_bin_count
              == rhs.pdl_trigger_next_launch_in_init_kernel_max_bin_count;
   }
@@ -263,10 +263,10 @@ struct histogram_policy
   {
     return os
         << "histogram_policy { .threads_per_block = " << p.threads_per_block
-        << ", .pixels_per_thread = " << p.pixels_per_thread << ", .load_algorithm = " << p.load_algorithm
-        << ", .load_modifier = " << p.load_modifier << ", .rle_compress = " << p.rle_compress
-        << ", .mem_preference = " << p.mem_preference << ", .work_stealing = " << p.work_stealing
-        << ", .vec_size = " << p.vec_size << ", .pdl_trigger_next_launch_in_init_kernel_max_bin_count = "
+        << ", .pixels_per_thread = " << p.pixels_per_thread << ", .vec_size = " << p.vec_size
+        << ", .load_algorithm = " << p.load_algorithm << ", .load_modifier = " << p.load_modifier
+        << ", .rle_compress = " << p.rle_compress << ", .mem_preference = " << p.mem_preference
+        << ", .work_stealing = " << p.work_stealing << ", .pdl_trigger_next_launch_in_init_kernel_max_bin_count = "
         << p.pdl_trigger_next_launch_in_init_kernel_max_bin_count << " }";
   }
 #endif // _CCCL_HOSTED()
@@ -304,12 +304,12 @@ public:
         if (is_even)
         {
           // ipt_12.tpb_928.rle_0.ws_0.mem_1.ld_2.laid_0.vec_2 1.033332  0.940517  1.031835  1.195876
-          return histogram_policy{928, 12, BLOCK_LOAD_DIRECT, LOAD_CA, false, SMEM, false, 1 << 2, 2048};
+          return histogram_policy{928, 12, 1 << 2, BLOCK_LOAD_DIRECT, LOAD_CA, false, SMEM, false, 2048};
         }
         else
         {
           // ipt_12.tpb_448.rle_0.ws_0.mem_1.ld_1.laid_0.vec_2 1.078987  0.985542  1.085118  1.175637
-          return histogram_policy{448, 12, BLOCK_LOAD_DIRECT, LOAD_LDG, false, SMEM, false, 1 << 2, 2048};
+          return histogram_policy{448, 12, 1 << 2, BLOCK_LOAD_DIRECT, LOAD_LDG, false, SMEM, false, 2048};
         }
       }
 
@@ -323,17 +323,17 @@ public:
       {
         if (sample_size == 1)
         {
-          return histogram_policy{768, 12, BLOCK_LOAD_DIRECT, LOAD_LDG, false, SMEM, false, 1 << 2, 2048};
+          return histogram_policy{768, 12, 1 << 2, BLOCK_LOAD_DIRECT, LOAD_LDG, false, SMEM, false, 2048};
         }
         else if (sample_size == 2)
         {
-          return histogram_policy{960, 10, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, true, SMEM, false, 1 << 2, 2048};
+          return histogram_policy{960, 10, 1 << 2, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, true, SMEM, false, 2048};
         }
       }
     }
 
     // fallback from SM50
-    return histogram_policy{384, t_scale(16), BLOCK_LOAD_DIRECT, LOAD_LDG, true, SMEM, false, 4, 0};
+    return histogram_policy{384, t_scale(16), 4, BLOCK_LOAD_DIRECT, LOAD_LDG, true, SMEM, false, 0};
   }
 };
 

--- a/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
@@ -198,7 +198,7 @@ struct policy_hub
       decltype(select_agent_policy<
                sm90_tuning<SampleT, NumChannels, NumActiveChannels, histogram::classify_counter_size<CounterT>()>>(0));
 
-    static constexpr int pdl_trigger_next_launch_in_init_kernel_max_bin_count = 2048;
+    static constexpr int init_kernel_pdl_trigger_max_bins = 2048;
   };
 
   struct Policy1000 : ChainedPolicy<1000, Policy1000, Policy900>
@@ -223,7 +223,7 @@ struct policy_hub
                sm100_tuning<IsEven, SampleT, NumChannels, NumActiveChannels, histogram::classify_counter_size<CounterT>()>>(
         0));
 
-    static constexpr int pdl_trigger_next_launch_in_init_kernel_max_bin_count = 2048;
+    static constexpr int init_kernel_pdl_trigger_max_bins = 2048;
   };
 
   using MaxPolicy = Policy1000;
@@ -239,7 +239,7 @@ struct histogram_policy
   bool rle_compress;
   BlockHistogramMemoryPreference mem_preference;
   bool work_stealing;
-  int pdl_trigger_next_launch_in_init_kernel_max_bin_count;
+  int init_kernel_pdl_trigger_max_bins;
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const histogram_policy& lhs, const histogram_policy& rhs)
@@ -248,8 +248,7 @@ struct histogram_policy
         && lhs.vec_size == rhs.vec_size && lhs.load_algorithm == rhs.load_algorithm
         && lhs.load_modifier == rhs.load_modifier && lhs.rle_compress == rhs.rle_compress
         && lhs.mem_preference == rhs.mem_preference && lhs.work_stealing == rhs.work_stealing
-        && lhs.pdl_trigger_next_launch_in_init_kernel_max_bin_count
-             == rhs.pdl_trigger_next_launch_in_init_kernel_max_bin_count;
+        && lhs.init_kernel_pdl_trigger_max_bins == rhs.init_kernel_pdl_trigger_max_bins;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
@@ -262,12 +261,11 @@ struct histogram_policy
   friend ::std::ostream& operator<<(::std::ostream& os, const histogram_policy& p)
   {
     return os
-        << "histogram_policy { .threads_per_block = " << p.threads_per_block
-        << ", .pixels_per_thread = " << p.pixels_per_thread << ", .vec_size = " << p.vec_size
-        << ", .load_algorithm = " << p.load_algorithm << ", .load_modifier = " << p.load_modifier
-        << ", .rle_compress = " << p.rle_compress << ", .mem_preference = " << p.mem_preference
-        << ", .work_stealing = " << p.work_stealing << ", .pdl_trigger_next_launch_in_init_kernel_max_bin_count = "
-        << p.pdl_trigger_next_launch_in_init_kernel_max_bin_count << " }";
+        << "histogram_policy { .threads_per_block = " << p.threads_per_block << ", .pixels_per_thread = "
+        << p.pixels_per_thread << ", .vec_size = " << p.vec_size << ", .load_algorithm = " << p.load_algorithm
+        << ", .load_modifier = " << p.load_modifier << ", .rle_compress = " << p.rle_compress
+        << ", .mem_preference = " << p.mem_preference << ", .work_stealing = " << p.work_stealing
+        << ", .init_kernel_pdl_trigger_max_bins = " << p.init_kernel_pdl_trigger_max_bins << " }";
   }
 #endif // _CCCL_HOSTED()
 };

--- a/cub/test/catch2_test_device_histogram_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_histogram_custom_policy_hub.cu
@@ -23,7 +23,7 @@ struct my_policy_hub
   struct MaxPolicy : ChainedPolicy<500, MaxPolicy, MaxPolicy>
   {
     using AgentHistogramPolicyT = AgentHistogramPolicy<384, 16, BLOCK_LOAD_DIRECT, LOAD_LDG, true, SMEM, false>;
-    static constexpr int pdl_trigger_next_launch_in_init_kernel_max_bin_count = 2048;
+    static constexpr int init_kernel_pdl_trigger_max_bins = 2048;
   };
 };
 

--- a/cub/test/catch2_test_device_histogram_env.cu
+++ b/cub/test/catch2_test_device_histogram_env.cu
@@ -1151,7 +1151,7 @@ struct histogram_tuning
 {
   _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::detail::histogram::histogram_policy
   {
-    return {BlockThreads, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, false, cub::SMEM, false, 1, 0};
+    return {BlockThreads, 1, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, false, cub::SMEM, false, 0};
   }
 };
 


### PR DESCRIPTION
This basically brings the histogram tuning policy more in-line with other policies and simplifies it a bit. Concretely:

- Move the `vec_size` to the right position before the `load_algorithm`
- Rename the overly long `pdl_trigger_next_launch_in_init_kernel_max_bin_count` to `init_kernel_pdl_trigger_max_bins`. Better suggestion are welcome!