### PR TITLE
Allow public tuning of `cub::DeviceHistogram`

### DIFF
--- a/cub/benchmarks/bench/histogram/histogram_common.cuh
+++ b/cub/benchmarks/bench/histogram/histogram_common.cuh
@@ -38,7 +38,7 @@ constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::BLEND;
 template <typename SampleT, int NUM_CHANNELS, int NUM_ACTIVE_CHANNELS>
 struct bench_policy_selector
 {
-  _CCCL_API constexpr auto operator()(::cuda::compute_capability) const -> cub::detail::histogram::histogram_policy
+  _CCCL_API constexpr auto operator()(::cuda::compute_capability) const -> cub::HistogramPolicy
   {
     constexpr cub::BlockLoadAlgorithm load_algorithm =
       (TUNE_LOAD_ALGORITHM == cub::BLOCK_LOAD_STRIPED)

--- a/cub/cub/agent/agent_histogram.cuh
+++ b/cub/cub/agent/agent_histogram.cuh
@@ -54,31 +54,9 @@ inline ::std::ostream& operator<<(::std::ostream& os, BlockHistogramMemoryPrefer
 }
 #endif // _CCCL_HOSTED()
 
+namespace detail
+{
 //! Parameterizable tuning policy type for AgentHistogram
-//!
-//! @tparam ThreadsPerBlock
-//!   Threads per thread block
-//!
-//! @tparam PixelsPerThread
-//!   Pixels per thread (per tile of input)
-//!
-//! @tparam LoadAlgorithm
-//!   The BlockLoad algorithm to use
-//!
-//! @tparam LoadModifier
-//!   Cache load modifier for reading input elements
-//!
-//! @tparam RleCompress
-//!   Whether to perform localized RLE to compress samples before histogramming
-//!
-//! @tparam MemoryPreference
-//!   Whether to prefer privatized shared-memory bins (versus privatized global-memory bins)
-//!
-//! @tparam WorkStealing
-//!   Whether to dequeue tiles from a global work queue
-//!
-//! @tparam VecSize
-//!   Vector size for samples loading (1, 2, 4)
 template <int ThreadsPerBlock,
           int PixelsPerThread,
           BlockLoadAlgorithm LoadAlgorithm,
@@ -87,7 +65,7 @@ template <int ThreadsPerBlock,
           BlockHistogramMemoryPreference MemoryPreference,
           bool WorkStealing,
           int VecSize = 4>
-struct AgentHistogramPolicy
+struct agent_histogram_policy
 {
   /// Threads per thread block
   static constexpr int BLOCK_THREADS = ThreadsPerBlock;
@@ -113,6 +91,27 @@ struct AgentHistogramPolicy
   ///< Cache load modifier for reading input elements
   static constexpr CacheLoadModifier LOAD_MODIFIER = LoadModifier;
 };
+} // namespace detail
+
+//! Deprecated [Since 3.5]
+template <int ThreadsPerBlock,
+          int PixelsPerThread,
+          BlockLoadAlgorithm LoadAlgorithm,
+          CacheLoadModifier LoadModifier,
+          bool RleCompress,
+          BlockHistogramMemoryPreference MemoryPreference,
+          bool WorkStealing,
+          int VecSize = 4>
+using AgentHistogramPolicy
+  CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceHistogram") = detail::agent_histogram_policy<
+    ThreadsPerBlock,
+    PixelsPerThread,
+    LoadAlgorithm,
+    LoadModifier,
+    RleCompress,
+    MemoryPreference,
+    WorkStealing,
+    VecSize>;
 
 namespace detail::histogram
 {

--- a/cub/cub/device/device_histogram.cuh
+++ b/cub/cub/device/device_histogram.cuh
@@ -45,6 +45,23 @@ CUB_NAMESPACE_BEGIN
 //!
 //! @cdp_class{DeviceHistogram}
 //!
+//! @par Tuning
+//! All algorithms in DeviceHistogram that accept an environment can be tuned by passing a custom
+//! :ref:`policy selector <cub-policy-selectors>` that returns a @ref HistogramPolicy, as shown in the
+//! example below:
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_histogram_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin histogram-even-policy-selector
+//!      :end-before: example-end histogram-even-policy-selector
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_histogram_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin histogram-even-tuning
+//!      :end-before: example-end histogram-even-tuning
+//!
 //! @endrst
 struct DeviceHistogram
 {

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -198,7 +198,7 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto dispatch(
     return error;
   }
 
-  const histogram_policy active_policy = policy_selector(cc);
+  const HistogramPolicy active_policy = policy_selector(cc);
 
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(NV_IS_HOST, ({
@@ -739,10 +739,10 @@ _CCCL_HOST_DEVICE_API constexpr auto convert_pdl_trigger(long)
 
 // TODO(bgruber): drop in CCCL 4.0
 template <typename ActivePolicy>
-_CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> histogram_policy
+_CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> HistogramPolicy
 {
   using ap = typename ActivePolicy::AgentHistogramPolicyT;
-  return histogram_policy{
+  return HistogramPolicy{
     ap::BLOCK_THREADS,
     ap::PIXELS_PER_THREAD,
     ap::VEC_SIZE,
@@ -761,7 +761,7 @@ struct policy_selector_from_max_policy
 private:
   struct extract_policy_dispatch_t
   {
-    histogram_policy& policy;
+    HistogramPolicy& policy;
 
     template <typename ActivePolicyT>
     _CCCL_HOST_DEVICE_API constexpr cudaError_t Invoke()
@@ -772,11 +772,11 @@ private:
   };
 
 public:
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> histogram_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> HistogramPolicy
   {
     NV_IF_ELSE_TARGET(NV_IS_HOST,
                       ({
-                        histogram_policy policy{};
+                        HistogramPolicy policy{};
                         extract_policy_dispatch_t dispatch{policy};
                         _CCCL_VERIFY(MaxPolicy::Invoke(cc.get() * 10, dispatch) == cudaSuccess, "");
                         return policy;
@@ -1199,7 +1199,7 @@ template <
   typename KernelSource = detail::histogram::
     DeviceHistogramKernelSource<NUM_CHANNELS, NUM_ACTIVE_CHANNELS, SampleIteratorT, CounterT, LevelT, OffsetT, SampleT>,
   typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
-struct DispatchHistogram
+struct CCCL_DEPRECATED_BECAUSE("Please use DeviceHistogram") DispatchHistogram
 {
   static_assert(NUM_CHANNELS <= 4, "Histograms only support up to 4 channels");
   static_assert(NUM_ACTIVE_CHANNELS <= NUM_CHANNELS,

--- a/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
@@ -482,7 +482,7 @@ __launch_bounds__(int(current_policy<PolicySelector>().threads_per_block))
     hp.load_modifier,
     hp.rle_compress,
     hp.mem_preference,
-    hp.work_stealing,
+    hp.use_work_stealing,
     hp.vec_size>;
   using AgentHistogramT =
     AgentHistogram<AgentHistogramPolicyT,
@@ -668,7 +668,7 @@ __launch_bounds__(int(current_policy<PolicySelector>().threads_per_block))
     hp.load_modifier,
     hp.rle_compress,
     hp.mem_preference,
-    hp.work_stealing,
+    hp.use_work_stealing,
     hp.vec_size>;
   using AgentHistogramT =
     AgentHistogram<AgentHistogramPolicyT,

--- a/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
@@ -344,7 +344,7 @@ _CCCL_KERNEL_ATTRIBUTES void DeviceHistogramInitKernel(
   ::cuda::std::array<CounterT*, NumActiveChannels> d_output_histograms_wrapper,
   GridQueue<int> tile_queue)
 {
-  [[maybe_unused]] static constexpr histogram_policy policy = current_policy<PolicySelector>();
+  [[maybe_unused]] static constexpr HistogramPolicy policy = current_policy<PolicySelector>();
   _CCCL_PDL_GRID_DEPENDENCY_SYNC(); // TODO(bgruber): if we had the guarantee that there would be no pending
                                     // writes/reads to the temp storage, we could omit the sync here
 
@@ -472,18 +472,18 @@ __launch_bounds__(int(current_policy<PolicySelector>().threads_per_block))
     _CCCL_GRID_CONSTANT const int tiles_per_row,
     GridQueue<int> tile_queue)
 {
-  static constexpr histogram_policy hp = current_policy<PolicySelector>();
+  static constexpr HistogramPolicy hp = current_policy<PolicySelector>();
 
   // Thread block type for compositing input tiles
-  using AgentHistogramPolicyT =
-    AgentHistogramPolicy<hp.threads_per_block,
-                         hp.pixels_per_thread,
-                         hp.load_algorithm,
-                         hp.load_modifier,
-                         hp.rle_compress,
-                         hp.mem_preference,
-                         hp.work_stealing,
-                         hp.vec_size>;
+  using AgentHistogramPolicyT = agent_histogram_policy<
+    hp.threads_per_block,
+    hp.pixels_per_thread,
+    hp.load_algorithm,
+    hp.load_modifier,
+    hp.rle_compress,
+    hp.mem_preference,
+    hp.work_stealing,
+    hp.vec_size>;
   using AgentHistogramT =
     AgentHistogram<AgentHistogramPolicyT,
                    PrivatizedSmemBins,
@@ -632,7 +632,7 @@ __launch_bounds__(int(current_policy<PolicySelector>().threads_per_block))
     _CCCL_GRID_CONSTANT const int tiles_per_row,
     _CCCL_GRID_CONSTANT const GridQueue<int> tile_queue)
 {
-  static constexpr histogram_policy hp = current_policy<PolicySelector>();
+  static constexpr HistogramPolicy hp = current_policy<PolicySelector>();
 
   OutputDecodeOpT output_decode_op[NumActiveChannels];
   PrivatizedDecodeOpT privatized_decode_op[NumActiveChannels];
@@ -661,15 +661,15 @@ __launch_bounds__(int(current_policy<PolicySelector>().threads_per_block))
   }
 
   // Thread block type for compositing input tiles
-  using AgentHistogramPolicyT =
-    AgentHistogramPolicy<hp.threads_per_block,
-                         hp.pixels_per_thread,
-                         hp.load_algorithm,
-                         hp.load_modifier,
-                         hp.rle_compress,
-                         hp.mem_preference,
-                         hp.work_stealing,
-                         hp.vec_size>;
+  using AgentHistogramPolicyT = agent_histogram_policy<
+    hp.threads_per_block,
+    hp.pixels_per_thread,
+    hp.load_algorithm,
+    hp.load_modifier,
+    hp.rle_compress,
+    hp.mem_preference,
+    hp.work_stealing,
+    hp.vec_size>;
   using AgentHistogramT =
     AgentHistogram<AgentHistogramPolicyT,
                    PrivatizedSmemBins,

--- a/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
@@ -25,6 +25,50 @@
 
 CUB_NAMESPACE_BEGIN
 
+//! The tuning policy for all algorithms in @ref DeviceHistogram.
+struct HistogramPolicy
+{
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int pixels_per_thread; //!< Number of pixels processed per thread
+  int vec_size; //!< Vectorization size for loading samples
+  BlockLoadAlgorithm load_algorithm; //!< The @ref BlockLoadAlgorithm used for loading samples
+  CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading samples from global memory
+  bool rle_compress; //!< Whether to perform localized RLE to compress samples before histogramming
+  BlockHistogramMemoryPreference mem_preference; //!< Whether to prefer privatized shared-memory bins (versus privatized
+                                                 //!< global-memory bins)
+  bool work_stealing; //!< Whether to dequeue tiles from a global work queue
+  int init_kernel_pdl_trigger_max_bins; //!< Maximum number of bins for the init kernel to trigger the histogram kernel
+                                        //!< early using PDL
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const HistogramPolicy& lhs, const HistogramPolicy& rhs) noexcept
+  {
+    return lhs.threads_per_block == rhs.threads_per_block && lhs.pixels_per_thread == rhs.pixels_per_thread
+        && lhs.vec_size == rhs.vec_size && lhs.load_algorithm == rhs.load_algorithm
+        && lhs.load_modifier == rhs.load_modifier && lhs.rle_compress == rhs.rle_compress
+        && lhs.mem_preference == rhs.mem_preference && lhs.work_stealing == rhs.work_stealing
+        && lhs.init_kernel_pdl_trigger_max_bins == rhs.init_kernel_pdl_trigger_max_bins;
+  }
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const HistogramPolicy& lhs, const HistogramPolicy& rhs) noexcept
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const HistogramPolicy& p)
+  {
+    return os
+        << "HistogramPolicy { .threads_per_block = " << p.threads_per_block << ", .pixels_per_thread = "
+        << p.pixels_per_thread << ", .vec_size = " << p.vec_size << ", .load_algorithm = " << p.load_algorithm
+        << ", .load_modifier = " << p.load_modifier << ", .rle_compress = " << p.rle_compress
+        << ", .mem_preference = " << p.mem_preference << ", .work_stealing = " << p.work_stealing
+        << ", .init_kernel_pdl_trigger_max_bins = " << p.init_kernel_pdl_trigger_max_bins << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
 namespace detail::histogram
 {
 // TODO(bgruber): drop in CCCL 4.0
@@ -174,7 +218,7 @@ struct policy_hub
   {
     // TODO This might be worth it to separate usual histogram and the multi one
     using AgentHistogramPolicyT =
-      AgentHistogramPolicy<384, t_scale(16), BLOCK_LOAD_DIRECT, LOAD_LDG, true, SMEM, false>;
+      agent_histogram_policy<384, t_scale(16), BLOCK_LOAD_DIRECT, LOAD_LDG, true, SMEM, false>;
   };
 
   // SM90
@@ -183,13 +227,13 @@ struct policy_hub
     // Use values from tuning if a specialization exists, otherwise pick Policy500
     template <typename Tuning>
     _CCCL_HOST_DEVICE_API static auto select_agent_policy(int)
-      -> AgentHistogramPolicy<Tuning::threads,
-                              Tuning::items,
-                              Tuning::load_algorithm,
-                              Tuning::load_modifier,
-                              Tuning::rle_compress,
-                              Tuning::mem_preference,
-                              Tuning::work_stealing>;
+      -> agent_histogram_policy<Tuning::threads,
+                                Tuning::items,
+                                Tuning::load_algorithm,
+                                Tuning::load_modifier,
+                                Tuning::rle_compress,
+                                Tuning::mem_preference,
+                                Tuning::work_stealing>;
 
     template <typename Tuning>
     _CCCL_HOST_DEVICE_API static auto select_agent_policy(long) -> typename Policy500::AgentHistogramPolicyT;
@@ -205,15 +249,15 @@ struct policy_hub
   {
     // Use values from tuning if a specialization exists, otherwise pick Policy900
     template <typename Tuning>
-    _CCCL_HOST_DEVICE_API static auto select_agent_policy(int)
-      -> AgentHistogramPolicy<Tuning::threads,
-                              Tuning::items,
-                              Tuning::load_algorithm,
-                              Tuning::load_modifier,
-                              Tuning::rle_compress,
-                              Tuning::mem_preference,
-                              Tuning::work_stealing,
-                              Tuning::vec_size>;
+    _CCCL_HOST_DEVICE_API static auto select_agent_policy(int) -> agent_histogram_policy<
+      Tuning::threads,
+      Tuning::items,
+      Tuning::load_algorithm,
+      Tuning::load_modifier,
+      Tuning::rle_compress,
+      Tuning::mem_preference,
+      Tuning::work_stealing,
+      Tuning::vec_size>;
 
     template <typename Tuning>
     _CCCL_HOST_DEVICE_API static auto select_agent_policy(long) -> typename Policy900::AgentHistogramPolicyT;
@@ -229,50 +273,9 @@ struct policy_hub
   using MaxPolicy = Policy1000;
 };
 
-struct histogram_policy
-{
-  int threads_per_block;
-  int pixels_per_thread;
-  int vec_size;
-  BlockLoadAlgorithm load_algorithm;
-  CacheLoadModifier load_modifier;
-  bool rle_compress;
-  BlockHistogramMemoryPreference mem_preference;
-  bool work_stealing;
-  int init_kernel_pdl_trigger_max_bins;
-
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const histogram_policy& lhs, const histogram_policy& rhs)
-  {
-    return lhs.threads_per_block == rhs.threads_per_block && lhs.pixels_per_thread == rhs.pixels_per_thread
-        && lhs.vec_size == rhs.vec_size && lhs.load_algorithm == rhs.load_algorithm
-        && lhs.load_modifier == rhs.load_modifier && lhs.rle_compress == rhs.rle_compress
-        && lhs.mem_preference == rhs.mem_preference && lhs.work_stealing == rhs.work_stealing
-        && lhs.init_kernel_pdl_trigger_max_bins == rhs.init_kernel_pdl_trigger_max_bins;
-  }
-
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const histogram_policy& lhs, const histogram_policy& rhs)
-  {
-    return !(lhs == rhs);
-  }
-
-#if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const histogram_policy& p)
-  {
-    return os
-        << "histogram_policy { .threads_per_block = " << p.threads_per_block << ", .pixels_per_thread = "
-        << p.pixels_per_thread << ", .vec_size = " << p.vec_size << ", .load_algorithm = " << p.load_algorithm
-        << ", .load_modifier = " << p.load_modifier << ", .rle_compress = " << p.rle_compress
-        << ", .mem_preference = " << p.mem_preference << ", .work_stealing = " << p.work_stealing
-        << ", .init_kernel_pdl_trigger_max_bins = " << p.init_kernel_pdl_trigger_max_bins << " }";
-  }
-#endif // _CCCL_HOSTED()
-};
-
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>
-concept histogram_policy_selector = policy_selector<T, histogram_policy>;
+concept histogram_policy_selector = policy_selector<T, HistogramPolicy>;
 #endif // _CCCL_HAS_CONCEPTS()
 
 struct policy_selector
@@ -293,7 +296,7 @@ private:
   }
 
 public:
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> histogram_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> HistogramPolicy
   {
     if (cc >= ::cuda::compute_capability{10, 0})
     {
@@ -302,12 +305,12 @@ public:
         if (is_even)
         {
           // ipt_12.tpb_928.rle_0.ws_0.mem_1.ld_2.laid_0.vec_2 1.033332  0.940517  1.031835  1.195876
-          return histogram_policy{928, 12, 1 << 2, BLOCK_LOAD_DIRECT, LOAD_CA, false, SMEM, false, 2048};
+          return HistogramPolicy{928, 12, 1 << 2, BLOCK_LOAD_DIRECT, LOAD_CA, false, SMEM, false, 2048};
         }
         else
         {
           // ipt_12.tpb_448.rle_0.ws_0.mem_1.ld_1.laid_0.vec_2 1.078987  0.985542  1.085118  1.175637
-          return histogram_policy{448, 12, 1 << 2, BLOCK_LOAD_DIRECT, LOAD_LDG, false, SMEM, false, 2048};
+          return HistogramPolicy{448, 12, 1 << 2, BLOCK_LOAD_DIRECT, LOAD_LDG, false, SMEM, false, 2048};
         }
       }
 
@@ -321,17 +324,17 @@ public:
       {
         if (sample_size == 1)
         {
-          return histogram_policy{768, 12, 1 << 2, BLOCK_LOAD_DIRECT, LOAD_LDG, false, SMEM, false, 2048};
+          return HistogramPolicy{768, 12, 1 << 2, BLOCK_LOAD_DIRECT, LOAD_LDG, false, SMEM, false, 2048};
         }
         else if (sample_size == 2)
         {
-          return histogram_policy{960, 10, 1 << 2, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, true, SMEM, false, 2048};
+          return HistogramPolicy{960, 10, 1 << 2, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, true, SMEM, false, 2048};
         }
       }
     }
 
     // fallback from SM50
-    return histogram_policy{384, t_scale(16), 4, BLOCK_LOAD_DIRECT, LOAD_LDG, true, SMEM, false, 0};
+    return HistogramPolicy{384, t_scale(16), 4, BLOCK_LOAD_DIRECT, LOAD_LDG, true, SMEM, false, 0};
   }
 };
 
@@ -342,7 +345,7 @@ static_assert(histogram_policy_selector<policy_selector>);
 template <class SampleT, class CounterT, int NumChannels, int NumActiveChannels, bool IsEven>
 struct policy_selector_from_types
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> histogram_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> HistogramPolicy
   {
     constexpr auto policies = policy_selector{
       is_primitive_v<SampleT>,

--- a/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
@@ -31,12 +31,12 @@ struct HistogramPolicy
   int threads_per_block; //!< Number of threads in a CUDA block
   int pixels_per_thread; //!< Number of pixels processed per thread
   int vec_size; //!< Vectorization size for loading samples
-  BlockLoadAlgorithm load_algorithm; //!< The @ref BlockLoadAlgorithm used for loading samples
+  BlockLoadAlgorithm load_algorithm; //!< The @ref BlockLoadAlgorithm used for loading samples from global memory
   CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading samples from global memory
   bool rle_compress; //!< Whether to perform localized RLE to compress samples before histogramming
-  BlockHistogramMemoryPreference mem_preference; //!< Whether to prefer privatized shared-memory bins (versus privatized
-                                                 //!< global-memory bins)
-  bool work_stealing; //!< Whether to dequeue tiles from a global work queue
+  BlockHistogramMemoryPreference mem_preference; //!< Whether to prefer privatized shared-memory or global-memory bins,
+                                                 //!< or a mix of both
+  bool use_work_stealing; //!< Whether to dequeue tiles from a global work queue
   int init_kernel_pdl_trigger_max_bins; //!< Maximum number of bins for the init kernel to trigger the histogram kernel
                                         //!< early using PDL
 
@@ -46,7 +46,7 @@ struct HistogramPolicy
     return lhs.threads_per_block == rhs.threads_per_block && lhs.pixels_per_thread == rhs.pixels_per_thread
         && lhs.vec_size == rhs.vec_size && lhs.load_algorithm == rhs.load_algorithm
         && lhs.load_modifier == rhs.load_modifier && lhs.rle_compress == rhs.rle_compress
-        && lhs.mem_preference == rhs.mem_preference && lhs.work_stealing == rhs.work_stealing
+        && lhs.mem_preference == rhs.mem_preference && lhs.use_work_stealing == rhs.use_work_stealing
         && lhs.init_kernel_pdl_trigger_max_bins == rhs.init_kernel_pdl_trigger_max_bins;
   }
 
@@ -63,7 +63,7 @@ struct HistogramPolicy
         << "HistogramPolicy { .threads_per_block = " << p.threads_per_block << ", .pixels_per_thread = "
         << p.pixels_per_thread << ", .vec_size = " << p.vec_size << ", .load_algorithm = " << p.load_algorithm
         << ", .load_modifier = " << p.load_modifier << ", .rle_compress = " << p.rle_compress
-        << ", .mem_preference = " << p.mem_preference << ", .work_stealing = " << p.work_stealing
+        << ", .mem_preference = " << p.mem_preference << ", .use_work_stealing = " << p.use_work_stealing
         << ", .init_kernel_pdl_trigger_max_bins = " << p.init_kernel_pdl_trigger_max_bins << " }";
   }
 #endif // _CCCL_HOSTED()
@@ -136,8 +136,8 @@ struct sm90_tuning<SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sampl
 
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
 
-  static constexpr bool rle_compress  = false;
-  static constexpr bool work_stealing = false;
+  static constexpr bool rle_compress      = false;
+  static constexpr bool use_work_stealing = false;
 };
 
 template <class SampleT>
@@ -151,8 +151,8 @@ struct sm90_tuning<SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sampl
 
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
 
-  static constexpr bool rle_compress  = true;
-  static constexpr bool work_stealing = false;
+  static constexpr bool rle_compress      = true;
+  static constexpr bool use_work_stealing = false;
 };
 
 // TODO(bgruber): drop in CCCL 4.0
@@ -173,7 +173,7 @@ struct sm100_tuning<true, SampleT, 1, 1, counter_size::_4, primitive_sample::yes
   static constexpr int items                                     = 12;
   static constexpr int threads                                   = 928;
   static constexpr bool rle_compress                             = false;
-  static constexpr bool work_stealing                            = false;
+  static constexpr bool use_work_stealing                        = false;
   static constexpr BlockHistogramMemoryPreference mem_preference = SMEM;
   static constexpr CacheLoadModifier load_modifier               = LOAD_CA;
   static constexpr BlockLoadAlgorithm load_algorithm             = BLOCK_LOAD_DIRECT;
@@ -190,7 +190,7 @@ struct sm100_tuning<false, SampleT, 1, 1, counter_size::_4, primitive_sample::ye
   static constexpr int items                                     = 12;
   static constexpr int threads                                   = 448;
   static constexpr bool rle_compress                             = false;
-  static constexpr bool work_stealing                            = false;
+  static constexpr bool use_work_stealing                        = false;
   static constexpr BlockHistogramMemoryPreference mem_preference = SMEM;
   static constexpr CacheLoadModifier load_modifier               = LOAD_LDG;
   static constexpr BlockLoadAlgorithm load_algorithm             = BLOCK_LOAD_DIRECT;
@@ -233,7 +233,7 @@ struct policy_hub
                                 Tuning::load_modifier,
                                 Tuning::rle_compress,
                                 Tuning::mem_preference,
-                                Tuning::work_stealing>;
+                                Tuning::use_work_stealing>;
 
     template <typename Tuning>
     _CCCL_HOST_DEVICE_API static auto select_agent_policy(long) -> typename Policy500::AgentHistogramPolicyT;
@@ -256,7 +256,7 @@ struct policy_hub
       Tuning::load_modifier,
       Tuning::rle_compress,
       Tuning::mem_preference,
-      Tuning::work_stealing,
+      Tuning::use_work_stealing,
       Tuning::vec_size>;
 
     template <typename Tuning>

--- a/cub/test/catch2_test_device_histogram_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_histogram_custom_policy_hub.cu
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// TODO(bgruber): drop this test with CCCL 4.0 when we drop the histogram dispatcher
+#define CCCL_IGNORE_DEPRECATED_API
+
 #include "insert_nested_NVTX_range_guard.h"
 
 #include <cub/device/device_histogram.cuh>
@@ -13,8 +16,6 @@
 #include <c2h/catch2_test_helper.h>
 
 using namespace cub;
-
-// TODO(bgruber): drop this test with CCCL 4.0 when we drop the histogram dispatcher after publishing the tuning API
 
 template <class SampleT, class CounterT, int NumChannels, int NumActiveChannels, bool IsEven>
 struct my_policy_hub

--- a/cub/test/catch2_test_device_histogram_env.cu
+++ b/cub/test/catch2_test_device_histogram_env.cu
@@ -1287,7 +1287,7 @@ C2H_TEST("HistogramPolicy", "[histogram][device]")
     .load_modifier                    = cub::CacheLoadModifier::LOAD_LDG,
     .rle_compress                     = false,
     .mem_preference                   = cub::SMEM,
-    .work_stealing                    = false,
+    .use_work_stealing                = false,
     .init_kernel_pdl_trigger_max_bins = 2048};
 #  else // _CCCL_STD_VER >= 2020
   constexpr auto p2 = p1;

--- a/cub/test/catch2_test_device_histogram_env.cu
+++ b/cub/test/catch2_test_device_histogram_env.cu
@@ -1149,7 +1149,7 @@ TEST_CASE("DeviceHistogram::MultiHistogramRange 2D uses custom stream", "[histog
 template <int BlockThreads>
 struct histogram_tuning
 {
-  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::detail::histogram::histogram_policy
+  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::HistogramPolicy
   {
     return {BlockThreads, 1, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, false, cub::SMEM, false, 0};
   }
@@ -1266,3 +1266,35 @@ C2H_TEST("DeviceHistogram::MultiHistogramRange can be tuned", "[histogram][devic
 }
 
 #endif // TEST_LAUNCH != 1
+
+#if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
+C2H_TEST("HistogramPolicy", "[histogram][device]")
+{
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::HistogramPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::HistogramPolicy>);
+
+  // aggregate init
+  constexpr auto p1 = cub::HistogramPolicy{
+    128, 7, 4, cub::BLOCK_LOAD_DIRECT, cub::CacheLoadModifier::LOAD_LDG, false, cub::SMEM, false, 2048};
+
+#  if _CCCL_STD_VER >= 2020
+  // designated init
+  constexpr auto p2 = cub::HistogramPolicy{
+    .threads_per_block                = 128,
+    .pixels_per_thread                = 7,
+    .vec_size                         = 4,
+    .load_algorithm                   = cub::BLOCK_LOAD_DIRECT,
+    .load_modifier                    = cub::CacheLoadModifier::LOAD_LDG,
+    .rle_compress                     = false,
+    .mem_preference                   = cub::SMEM,
+    .work_stealing                    = false,
+    .init_kernel_pdl_trigger_max_bins = 2048};
+#  else // _CCCL_STD_VER >= 2020
+  constexpr auto p2 = p1;
+#  endif // _CCCL_STD_VER >= 2020
+
+  // comparison
+  STATIC_REQUIRE(p1 == p2);
+  STATIC_REQUIRE_FALSE(p1 != p2);
+}
+#endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_histogram_env_api.cu
+++ b/cub/test/catch2_test_device_histogram_env_api.cu
@@ -7,6 +7,7 @@
 
 #include <thrust/device_vector.h>
 
+#include <cuda/__execution/tune.h>
 #include <cuda/devices>
 #include <cuda/std/array>
 #include <cuda/stream>
@@ -409,3 +410,55 @@ C2H_TEST("cub::DeviceHistogram::MultiHistogramRange accepts env with stream (2D)
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
 }
+
+#if _CCCL_STD_VER >= 2020
+
+// example-begin histogram-even-policy-selector
+struct HistogramPolicySelector
+{
+  __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::HistogramPolicy
+  {
+    return {.threads_per_block                = 128,
+            .pixels_per_thread                = cc > cuda::compute_capability{9, 0} ? 16 : 7,
+            .vec_size                         = 4,
+            .load_algorithm                   = cub::BLOCK_LOAD_DIRECT,
+            .load_modifier                    = cub::LOAD_LDG,
+            .rle_compress                     = false,
+            .mem_preference                   = cub::SMEM,
+            .work_stealing                    = false,
+            .init_kernel_pdl_trigger_max_bins = 2048};
+  }
+};
+// example-end histogram-even-policy-selector
+
+C2H_TEST("cub::DeviceHistogram::HistogramEven env-based API with tuning", "[histogram][env]")
+{
+  // example-begin histogram-even-tuning
+  auto d_samples   = thrust::device_vector<int>{0, 2, 1, 0, 3, 4, 2, 1};
+  int num_samples  = static_cast<int>(d_samples.size());
+  int num_levels   = 6;
+  int lower_level  = 0;
+  int upper_level  = 5;
+  auto d_histogram = thrust::device_vector<int>(num_levels - 1, 0);
+
+  const auto error = cub::DeviceHistogram::HistogramEven(
+    thrust::raw_pointer_cast(d_samples.data()),
+    thrust::raw_pointer_cast(d_histogram.data()),
+    num_levels,
+    lower_level,
+    upper_level,
+    num_samples,
+    cuda::execution::tune(HistogramPolicySelector{}));
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceHistogram::HistogramEven failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected{2, 2, 2, 1, 1};
+  // example-end histogram-even-tuning
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_histogram == expected);
+}
+
+#endif // _CCCL_STD_VER >= 2020

--- a/cub/test/catch2_test_device_histogram_env_api.cu
+++ b/cub/test/catch2_test_device_histogram_env_api.cu
@@ -425,7 +425,7 @@ struct HistogramPolicySelector
             .load_modifier                    = cub::LOAD_LDG,
             .rle_compress                     = false,
             .mem_preference                   = cub::SMEM,
-            .work_stealing                    = false,
+            .use_work_stealing                = false,
             .init_kernel_pdl_trigger_max_bins = 2048};
   }
 };


### PR DESCRIPTION
- [x] Merge before: #9361

Fixes: #8571

  ### New public entities

  | Entity | Enumerators / data members |
  |--------|---------------------------|
  | `cub::HistogramPolicy` | `int threads_per_block`<br>`int pixels_per_thread`<br>`int vec_size`<br>`BlockLoadAlgorithm load_algorithm`<br>`CacheLoadModifier load_modifier`<br>`bool rle_compress`<br>`BlockHistogramMemoryPreference mem_preference`<br>`bool use_work_stealing`<br>`int init_kernel_pdl_trigger_max_bins` |    