### PR TITLE
Fix duplicate add_subdirectory(nvbench_helper) call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ if (CCCL_ENABLE_EXAMPLES)
 endif()
 
 if (CCCL_ENABLE_NVBENCH_HELPER)
-  add_subdirectory(nvbench_helper)
+  cccl_get_nvbench_helper()
 endif()
 
 # Must stay at the end of this file.


### PR DESCRIPTION
## Description

closes #9363 

Replace the `add_subdirectory(nvbench_helper)` call at the end of the main `CMakeLists.txt` with `cccl_get_nvbench_helper()`.  
The macro ensures the subdirectory is only added once, preventing a duplicate `add_subdirectory(nvbench_helper)` call.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cccl/blob/main/CONTRIBUTING.md)
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
