### PR TITLE
Allow public tuning for `cub::DeviceSelect:::UniqueByKey`

### DIFF
--- a/cub/benchmarks/bench/select/unique_by_key.cu
+++ b/cub/benchmarks/bench/select/unique_by_key.cu
@@ -29,8 +29,7 @@
 
 struct bench_unique_by_key_policy_selector
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::unique_by_key::unique_by_key_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::UniqueByKeyPolicy
   {
     return {TUNE_THREADS,
             TUNE_ITEMS,

--- a/cub/cub/agent/agent_unique_by_key.cuh
+++ b/cub/cub/agent/agent_unique_by_key.cuh
@@ -31,20 +31,16 @@ CUB_NAMESPACE_BEGIN
  * Tuning policy types
  ******************************************************************************/
 
-/**
- * Parameterizable tuning policy type for AgentUniqueByKey
- *
- * @tparam DelayConstructorT
- *   Implementation detail, do not specify directly, requirements on the
- *   content of this type are subject to breaking change.
- */
+namespace detail
+{
+// TODO(bgruber): remove this when C++20 is the minimum, since then we can pass policy values as NTTP
 template <int ThreadsPerBlock,
           int ItemsPerThread                    = 1,
           cub::BlockLoadAlgorithm LoadAlgorithm = cub::BLOCK_LOAD_DIRECT,
           cub::CacheLoadModifier LoadModifier   = cub::LOAD_LDG,
           cub::BlockScanAlgorithm ScanAlgorithm = cub::BLOCK_SCAN_WARP_SCANS,
           typename DelayConstructorT            = detail::fixed_delay_constructor_t<350, 450>>
-struct AgentUniqueByKeyPolicy
+struct agent_unique_by_key_policy
 {
   static constexpr int BLOCK_THREADS                      = ThreadsPerBlock;
   static constexpr int ITEMS_PER_THREAD                   = ItemsPerThread;
@@ -57,6 +53,16 @@ struct AgentUniqueByKeyPolicy
     using delay_constructor_t = DelayConstructorT;
   };
 };
+} // namespace detail
+
+template <int ThreadsPerBlock,
+          int ItemsPerThread                    = 1,
+          cub::BlockLoadAlgorithm LoadAlgorithm = cub::BLOCK_LOAD_DIRECT,
+          cub::CacheLoadModifier LoadModifier   = cub::LOAD_LDG,
+          cub::BlockScanAlgorithm ScanAlgorithm = cub::BLOCK_SCAN_WARP_SCANS,
+          typename DelayConstructorT            = detail::fixed_delay_constructor_t<350, 450>>
+using AgentUniqueByKeyPolicy CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceSelect") = detail::
+  agent_unique_by_key_policy<ThreadsPerBlock, ItemsPerThread, LoadAlgorithm, LoadModifier, ScanAlgorithm, DelayConstructorT>;
 
 /******************************************************************************
  * Thread block abstractions

--- a/cub/cub/agent/agent_unique_by_key.cuh
+++ b/cub/cub/agent/agent_unique_by_key.cuh
@@ -55,6 +55,7 @@ struct agent_unique_by_key_policy
 };
 } // namespace detail
 
+//! Deprecated [Since 3.5]
 template <int ThreadsPerBlock,
           int ItemsPerThread                    = 1,
           cub::BlockLoadAlgorithm LoadAlgorithm = cub::BLOCK_LOAD_DIRECT,

--- a/cub/cub/detail/delay_constructor.cuh
+++ b/cub/cub/detail/delay_constructor.cuh
@@ -70,13 +70,13 @@ struct LookbackDelayPolicy
   unsigned int l2_write_latency; //!< The write latency of the L2 cache in nanoseconds
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const LookbackDelayPolicy& lhs, const LookbackDelayPolicy& rhs)
+  operator==(const LookbackDelayPolicy& lhs, const LookbackDelayPolicy& rhs) noexcept
   {
     return lhs.kind == rhs.kind && lhs.delay == rhs.delay && lhs.l2_write_latency == rhs.l2_write_latency;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const LookbackDelayPolicy& lhs, const LookbackDelayPolicy& rhs)
+  operator!=(const LookbackDelayPolicy& lhs, const LookbackDelayPolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -1770,6 +1770,24 @@ struct DeviceSelect
   //!     :start-after: example-begin select-uniquebykey-env
   //!     :end-before: example-end select-uniquebykey-env
   //!
+  //! @par Tuning
+  //! @rst
+  //! All algorithms in DeviceSelect that operate on key-value pairs and accept an environment can be tuned by passing a
+  //! custom :ref:`policy selector <cub-policy-selectors>` that returns a @ref UniqueByKeyPolicy, as shown in the
+  //! example below:
+  //!
+  //!  .. literalinclude:: ../../../cub/test/catch2_test_device_select_env_api.cu
+  //!      :language: c++
+  //!      :dedent:
+  //!      :start-after: example-begin unique-by-key-policy-selector
+  //!      :end-before: example-end unique-by-key-policy-selector
+  //!
+  //!  .. literalinclude:: ../../../cub/test/catch2_test_device_select_env_api.cu
+  //!      :language: c++
+  //!      :dedent:
+  //!      :start-after: example-begin unique-by-key-tuning
+  //!      :end-before: example-end unique-by-key-tuning
+  //!
   //! @endrst
   //!
   //! @tparam KeyInputIteratorT

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -1772,7 +1772,7 @@ struct DeviceSelect
   //!
   //! @par Tuning
   //! @rst
-  //! All algorithms in DeviceSelect that operate on key-value pairs and accept an environment can be tuned by passing a
+  //! All *ByKey algorithms in DeviceSelect that accept an environment can be tuned by passing a
   //! custom :ref:`policy selector <cub-policy-selectors>` that returns a @ref UniqueByKeyPolicy, as shown in the
   //! example below:
   //!

--- a/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
@@ -522,9 +522,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
       ValueOutputIteratorT,
       EqualityOpT,
       OffsetT>;
-    constexpr UniqueByKeyPolicy active_policy     = vsmem_adapted_agents::policy;
-    const ::cuda::std::size_t vsmem_per_block =
-    vsmem_helper_impl<typename vsmem_adapted_agents::agent_t>::vsmem_per_block;
+    constexpr UniqueByKeyPolicy active_policy = vsmem_adapted_agents::policy;
+    const ::cuda::std::size_t vsmem_per_block = vsmem_helper_impl<typename vsmem_adapted_agents::agent_t>::vsmem_per_block;
 #endif
 
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)

--- a/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
@@ -31,6 +31,7 @@
 #include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__algorithm/min.h>
 #include <cuda/std/__host_stdlib/sstream>
+#include <cuda/std/__type_traits/is_empty.h>
 
 CUB_NAMESPACE_BEGIN
 

--- a/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
@@ -122,7 +122,7 @@ template <
   typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY,
   typename KeyT                  = detail::it_value_t<KeyInputIteratorT>,
   typename ValueT                = detail::it_value_t<ValueInputIteratorT>>
-struct DispatchUniqueByKey
+struct CCCL_DEPRECATED_BECAUSE("Please use DeviceSelect::UniqueByKey") DispatchUniqueByKey
 {
   /******************************************************************************
    * Types and constants
@@ -232,7 +232,7 @@ struct DispatchUniqueByKey
    * Dispatch entrypoints
    ******************************************************************************/
   CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t
-  __invoke(detail::unique_by_key::unique_by_key_policy policy, ::cuda::std::size_t vsmem_per_block)
+  __invoke(UniqueByKeyPolicy policy, ::cuda::std::size_t vsmem_per_block)
   {
     // Number of input tiles
     const auto threads_per_block = policy.threads_per_block;
@@ -361,7 +361,7 @@ struct DispatchUniqueByKey
   {
     struct policy_getter
     {
-      _CCCL_HOST_DEVICE constexpr auto operator()() const -> detail::unique_by_key::unique_by_key_policy
+      _CCCL_HOST_DEVICE constexpr auto operator()() const -> UniqueByKeyPolicy
       {
         return detail::unique_by_key::convert_policy<ActivePolicyT>();
       }
@@ -463,6 +463,154 @@ struct DispatchUniqueByKey
 
 namespace detail::unique_by_key
 {
+template <typename PolicyGetter,
+          typename KeyInputIteratorT,
+          typename ValueInputIteratorT,
+          typename KeyOutputIteratorT,
+          typename ValueOutputIteratorT,
+          typename NumSelectedIteratorT,
+          typename EqualityOpT,
+          typename OffsetT,
+          typename KernelSource,
+          typename KernelLauncherFactory>
+CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t dispatch_policy(
+  [[maybe_unused]] PolicyGetter policy_getter,
+  void* d_temp_storage,
+  size_t& temp_storage_bytes,
+  KeyInputIteratorT d_keys_in,
+  ValueInputIteratorT d_values_in,
+  KeyOutputIteratorT d_keys_out,
+  ValueOutputIteratorT d_values_out,
+  NumSelectedIteratorT d_num_selected_out,
+  EqualityOpT equality_op,
+  OffsetT num_items,
+  cudaStream_t stream,
+  KernelSource kernel_source,
+  KernelLauncherFactory launcher_factory)
+{
+  static_assert(::cuda::std::is_empty_v<PolicyGetter>);
+
+#ifdef CUB_DEFINE_RUNTIME_POLICIES
+  const UniqueByKeyPolicy active_policy     = policy_getter();
+  const ::cuda::std::size_t vsmem_per_block = 0;
+#else
+  using vsmem_adapted_agents = unique_by_key_vsmem_helper_t<
+    PolicyGetter,
+    KeyInputIteratorT,
+    ValueInputIteratorT,
+    KeyOutputIteratorT,
+    ValueOutputIteratorT,
+    EqualityOpT,
+    OffsetT>;
+  constexpr UniqueByKeyPolicy active_policy = vsmem_adapted_agents::policy;
+  const ::cuda::std::size_t vsmem_per_block =
+    detail::vsmem_helper_impl<typename vsmem_adapted_agents::agent_t>::vsmem_per_block;
+#endif
+
+  const auto threads_per_block = active_policy.threads_per_block;
+  const auto items_per_thread  = active_policy.items_per_thread;
+  int tile_size                = threads_per_block * items_per_thread;
+  int num_tiles                = static_cast<int>(::cuda::ceil_div(num_items, tile_size));
+  const auto vsmem_size        = num_tiles * vsmem_per_block;
+
+  size_t allocation_sizes[2] = {0, vsmem_size};
+  auto tile_state            = kernel_source.TileState();
+
+  if (const auto error = CubDebug(tile_state.AllocationSize(num_tiles, allocation_sizes[0])))
+  {
+    return error;
+  }
+
+  void* allocations[2] = {nullptr, nullptr};
+  if (const auto error =
+        CubDebug(detail::alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))
+  {
+    return error;
+  }
+
+  if (d_temp_storage == nullptr)
+  {
+    return cudaSuccess;
+  }
+
+  if (const auto error = CubDebug(tile_state.Init(num_tiles, allocations[0], allocation_sizes[0])))
+  {
+    return error;
+  }
+
+  static constexpr int init_kernel_threads = 128;
+  num_tiles                                = ::cuda::std::max(1, num_tiles);
+  const int init_grid_size                 = ::cuda::ceil_div(num_tiles, init_kernel_threads);
+
+#ifdef CUB_DEBUG_LOG
+  _CubLog("Invoking init_kernel<<<%d, %d, 0, %lld>>>()\n", init_grid_size, init_kernel_threads, (long long) stream);
+#endif // CUB_DEBUG_LOG
+
+  launcher_factory(init_grid_size, init_kernel_threads, 0, stream)
+    .doit(kernel_source.CompactInitKernel(), tile_state, num_tiles, d_num_selected_out);
+
+  if (const auto error = CubDebug(cudaPeekAtLastError()))
+  {
+    return error;
+  }
+
+  if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+  {
+    return error;
+  }
+
+  if (num_items == 0)
+  {
+    return cudaSuccess;
+  }
+
+  constexpr int max_dim_x = INT_MAX;
+
+  dim3 scan_grid_size;
+  scan_grid_size.z = 1;
+  scan_grid_size.y = ::cuda::ceil_div(num_tiles, max_dim_x);
+  scan_grid_size.x = ::cuda::std::min(num_tiles, max_dim_x);
+
+#ifdef CUB_DEBUG_LOG
+  {
+    int sweep_sm_occupancy;
+    if (const auto error = CubDebug(launcher_factory.MaxSmOccupancy(
+          sweep_sm_occupancy, kernel_source.UniqueByKeySweepKernel(), threads_per_block)))
+    {
+      return error;
+    }
+    _CubLog("Invoking unique_by_key_kernel<<<{%d,%d,%d}, %d, 0, "
+            "%lld>>>(), %d items per thread, %d SM occupancy\n",
+            scan_grid_size.x,
+            scan_grid_size.y,
+            scan_grid_size.z,
+            threads_per_block,
+            (long long) stream,
+            items_per_thread,
+            sweep_sm_occupancy);
+  }
+#endif // CUB_DEBUG_LOG
+
+  if (const auto error = CubDebug(
+        launcher_factory(scan_grid_size, threads_per_block, 0, stream)
+          .doit(kernel_source.UniqueByKeySweepKernel(),
+                d_keys_in,
+                d_values_in,
+                d_keys_out,
+                d_values_out,
+                d_num_selected_out,
+                tile_state,
+                equality_op,
+                num_items,
+                num_tiles,
+                cub::detail::vsmem_t{allocations[1]})))
+  {
+    return error;
+  }
+
+  return CubDebug(detail::DebugSyncStream(stream));
+}
+
 template <typename KeyInputIteratorT,
           typename ValueInputIteratorT,
           typename KeyOutputIteratorT,
@@ -519,42 +667,9 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
                }))
 #endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
 
-  struct fake_policy
-  {
-    using MaxPolicy = void;
-  };
-
   return detail::dispatch_compute_cap(policy_selector, cc, [&](auto policy_getter) {
-#ifdef CUB_DEFINE_RUNTIME_POLICIES
-    const unique_by_key_policy active_policy  = policy_getter();
-    const ::cuda::std::size_t vsmem_per_block = 0;
-#else
-    using vsmem_adapted_agents = detail::unique_by_key::unique_by_key_vsmem_helper_t<
-      decltype(policy_getter),
-      KeyInputIteratorT,
-      ValueInputIteratorT,
-      KeyOutputIteratorT,
-      ValueOutputIteratorT,
-      EqualityOpT,
-      OffsetT>;
-    constexpr unique_by_key_policy active_policy = vsmem_adapted_agents::policy;
-    const ::cuda::std::size_t vsmem_per_block =
-      detail::vsmem_helper_impl<typename vsmem_adapted_agents::agent_t>::vsmem_per_block;
-#endif
-
-    return DispatchUniqueByKey<
-             KeyInputIteratorT,
-             ValueInputIteratorT,
-             KeyOutputIteratorT,
-             ValueOutputIteratorT,
-             NumSelectedIteratorT,
-             EqualityOpT,
-             OffsetT,
-             fake_policy,
-             KernelSource,
-             KernelLauncherFactory,
-             KeyT,
-             ValueT>{
+    return dispatch_policy(
+      policy_getter,
       d_temp_storage,
       temp_storage_bytes,
       d_keys_in,
@@ -566,8 +681,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
       num_items,
       stream,
       kernel_source,
-      launcher_factory}
-      .__invoke(active_policy, vsmem_per_block);
+      launcher_factory);
   });
 }
 } // namespace detail::unique_by_key

--- a/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
@@ -463,154 +463,6 @@ struct CCCL_DEPRECATED_BECAUSE("Please use DeviceSelect::UniqueByKey") DispatchU
 
 namespace detail::unique_by_key
 {
-template <typename PolicyGetter,
-          typename KeyInputIteratorT,
-          typename ValueInputIteratorT,
-          typename KeyOutputIteratorT,
-          typename ValueOutputIteratorT,
-          typename NumSelectedIteratorT,
-          typename EqualityOpT,
-          typename OffsetT,
-          typename KernelSource,
-          typename KernelLauncherFactory>
-CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t dispatch_policy(
-  [[maybe_unused]] PolicyGetter policy_getter,
-  void* d_temp_storage,
-  size_t& temp_storage_bytes,
-  KeyInputIteratorT d_keys_in,
-  ValueInputIteratorT d_values_in,
-  KeyOutputIteratorT d_keys_out,
-  ValueOutputIteratorT d_values_out,
-  NumSelectedIteratorT d_num_selected_out,
-  EqualityOpT equality_op,
-  OffsetT num_items,
-  cudaStream_t stream,
-  KernelSource kernel_source,
-  KernelLauncherFactory launcher_factory)
-{
-  static_assert(::cuda::std::is_empty_v<PolicyGetter>);
-
-#ifdef CUB_DEFINE_RUNTIME_POLICIES
-  const UniqueByKeyPolicy active_policy     = policy_getter();
-  const ::cuda::std::size_t vsmem_per_block = 0;
-#else
-  using vsmem_adapted_agents = unique_by_key_vsmem_helper_t<
-    PolicyGetter,
-    KeyInputIteratorT,
-    ValueInputIteratorT,
-    KeyOutputIteratorT,
-    ValueOutputIteratorT,
-    EqualityOpT,
-    OffsetT>;
-  constexpr UniqueByKeyPolicy active_policy = vsmem_adapted_agents::policy;
-  const ::cuda::std::size_t vsmem_per_block =
-    detail::vsmem_helper_impl<typename vsmem_adapted_agents::agent_t>::vsmem_per_block;
-#endif
-
-  const auto threads_per_block = active_policy.threads_per_block;
-  const auto items_per_thread  = active_policy.items_per_thread;
-  int tile_size                = threads_per_block * items_per_thread;
-  int num_tiles                = static_cast<int>(::cuda::ceil_div(num_items, tile_size));
-  const auto vsmem_size        = num_tiles * vsmem_per_block;
-
-  size_t allocation_sizes[2] = {0, vsmem_size};
-  auto tile_state            = kernel_source.TileState();
-
-  if (const auto error = CubDebug(tile_state.AllocationSize(num_tiles, allocation_sizes[0])))
-  {
-    return error;
-  }
-
-  void* allocations[2] = {nullptr, nullptr};
-  if (const auto error =
-        CubDebug(detail::alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))
-  {
-    return error;
-  }
-
-  if (d_temp_storage == nullptr)
-  {
-    return cudaSuccess;
-  }
-
-  if (const auto error = CubDebug(tile_state.Init(num_tiles, allocations[0], allocation_sizes[0])))
-  {
-    return error;
-  }
-
-  static constexpr int init_kernel_threads = 128;
-  num_tiles                                = ::cuda::std::max(1, num_tiles);
-  const int init_grid_size                 = ::cuda::ceil_div(num_tiles, init_kernel_threads);
-
-#ifdef CUB_DEBUG_LOG
-  _CubLog("Invoking init_kernel<<<%d, %d, 0, %lld>>>()\n", init_grid_size, init_kernel_threads, (long long) stream);
-#endif // CUB_DEBUG_LOG
-
-  launcher_factory(init_grid_size, init_kernel_threads, 0, stream)
-    .doit(kernel_source.CompactInitKernel(), tile_state, num_tiles, d_num_selected_out);
-
-  if (const auto error = CubDebug(cudaPeekAtLastError()))
-  {
-    return error;
-  }
-
-  if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
-  {
-    return error;
-  }
-
-  if (num_items == 0)
-  {
-    return cudaSuccess;
-  }
-
-  constexpr int max_dim_x = INT_MAX;
-
-  dim3 scan_grid_size;
-  scan_grid_size.z = 1;
-  scan_grid_size.y = ::cuda::ceil_div(num_tiles, max_dim_x);
-  scan_grid_size.x = ::cuda::std::min(num_tiles, max_dim_x);
-
-#ifdef CUB_DEBUG_LOG
-  {
-    int sweep_sm_occupancy;
-    if (const auto error = CubDebug(launcher_factory.MaxSmOccupancy(
-          sweep_sm_occupancy, kernel_source.UniqueByKeySweepKernel(), threads_per_block)))
-    {
-      return error;
-    }
-    _CubLog("Invoking unique_by_key_kernel<<<{%d,%d,%d}, %d, 0, "
-            "%lld>>>(), %d items per thread, %d SM occupancy\n",
-            scan_grid_size.x,
-            scan_grid_size.y,
-            scan_grid_size.z,
-            threads_per_block,
-            (long long) stream,
-            items_per_thread,
-            sweep_sm_occupancy);
-  }
-#endif // CUB_DEBUG_LOG
-
-  if (const auto error = CubDebug(
-        launcher_factory(scan_grid_size, threads_per_block, 0, stream)
-          .doit(kernel_source.UniqueByKeySweepKernel(),
-                d_keys_in,
-                d_values_in,
-                d_keys_out,
-                d_values_out,
-                d_num_selected_out,
-                tile_state,
-                equality_op,
-                num_items,
-                num_tiles,
-                cub::detail::vsmem_t{allocations[1]})))
-  {
-    return error;
-  }
-
-  return CubDebug(detail::DebugSyncStream(stream));
-}
-
 template <typename KeyInputIteratorT,
           typename ValueInputIteratorT,
           typename KeyOutputIteratorT,
@@ -656,32 +508,152 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
     return error;
   }
 
+  return detail::dispatch_compute_cap(policy_selector, cc, [&]([[maybe_unused]] auto policy_getter) {
+#ifdef CUB_DEFINE_RUNTIME_POLICIES
+    // vsmem is not supported in CCCL.C, so just use the policy directly
+    const UniqueByKeyPolicy active_policy     = policy_getter();
+    const ::cuda::std::size_t vsmem_per_block = 0;
+#else
+  using vsmem_adapted_agents = unique_by_key_vsmem_helper_t<
+    decltype(policy_getter),
+    KeyInputIteratorT,
+    ValueInputIteratorT,
+    KeyOutputIteratorT,
+    ValueOutputIteratorT,
+    EqualityOpT,
+    OffsetT>;
+  const ::cuda::std::size_t vsmem_per_block =
+    vsmem_helper_impl<typename vsmem_adapted_agents::agent_t>::vsmem_per_block;
+    constexpr UniqueByKeyPolicy active_policy     = vsmem_adapted_agents::policy;
+#endif
+
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
-  NV_IF_TARGET(NV_IS_HOST, ({
-                 ::std::stringstream ss;
-                 ss << policy_selector(cc);
-                 _CubLog("Dispatching DeviceSelect::UniqueByKey to compute capability %d.%d with tuning: %s\n",
-                         cc.major_cap(),
-                         cc.minor_cap(),
-                         ss.str().c_str());
-               }))
+    NV_IF_TARGET(NV_IS_HOST, ({
+                   ::std::stringstream ss;
+                   ss << active_policy;
+                   _CubLog("Dispatching DeviceSelect::UniqueByKey to compute capability %d.%d with tuning: %s\n",
+                           cc.major_cap(),
+                           cc.minor_cap(),
+                           ss.str().c_str());
+                 }))
 #endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
 
-  return detail::dispatch_compute_cap(policy_selector, cc, [&](auto policy_getter) {
-    return dispatch_policy(
-      policy_getter,
-      d_temp_storage,
-      temp_storage_bytes,
-      d_keys_in,
-      d_values_in,
-      d_keys_out,
-      d_values_out,
-      d_num_selected_out,
-      equality_op,
-      num_items,
-      stream,
-      kernel_source,
-      launcher_factory);
+    const auto threads_per_block = active_policy.threads_per_block;
+    const auto items_per_thread  = active_policy.items_per_thread;
+    int tile_size                = threads_per_block * items_per_thread;
+    int num_tiles                = static_cast<int>(::cuda::ceil_div(num_items, tile_size));
+    const auto vsmem_size        = num_tiles * vsmem_per_block;
+
+    // Specify temporary storage allocation requirements
+    size_t allocation_sizes[2] = {0, vsmem_size};
+    auto tile_state            = kernel_source.TileState();
+
+    // Bytes needed for tile status descriptors
+    if (const auto error = CubDebug(tile_state.AllocationSize(num_tiles, allocation_sizes[0])))
+    {
+      return error;
+    }
+
+    // Compute allocation pointers into the single storage blob (or compute the necessary size of the blob)
+    void* allocations[2] = {nullptr, nullptr};
+    if (const auto error =
+          CubDebug(detail::alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))
+    {
+      return error;
+    }
+
+    if (d_temp_storage == nullptr)
+    {
+      // Return if the caller is simply requesting the size of the storage allocation
+      return cudaSuccess;
+    }
+
+    if (const auto error = CubDebug(tile_state.Init(num_tiles, allocations[0], allocation_sizes[0])))
+    {
+      return error;
+    }
+
+    // Log init_kernel configuration
+    static constexpr int init_kernel_threads = 128;
+    num_tiles                                = ::cuda::std::max(1, num_tiles);
+    const int init_grid_size                 = ::cuda::ceil_div(num_tiles, init_kernel_threads);
+
+#ifdef CUB_DEBUG_LOG
+    _CubLog("Invoking init_kernel<<<%d, %d, 0, %lld>>>()\n", init_grid_size, init_kernel_threads, (long long) stream);
+#endif // CUB_DEBUG_LOG
+
+    // Invoke init_kernel to initialize tile descriptors
+    if (const auto error = CubDebug(
+          launcher_factory(init_grid_size, init_kernel_threads, 0, stream)
+            .doit(kernel_source.CompactInitKernel(), tile_state, num_tiles, d_num_selected_out)))
+    {
+      return error;
+    }
+
+    if (const auto error = CubDebug(cudaPeekAtLastError()))
+    {
+      return error;
+    }
+
+    if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+    {
+      return error;
+    }
+
+    // Return if empty problem
+    if (num_items == 0)
+    {
+      return cudaSuccess;
+    }
+
+    constexpr int max_dim_x = INT_MAX; // Since sm30
+
+    // Get grid size for scanning tiles
+    dim3 scan_grid_size;
+    scan_grid_size.z = 1;
+    scan_grid_size.y = ::cuda::ceil_div(num_tiles, max_dim_x);
+    scan_grid_size.x = ::cuda::std::min(num_tiles, max_dim_x);
+
+#ifdef CUB_DEBUG_LOG
+    {
+      // Get SM occupancy for unique_by_key_kernel
+      int sweep_sm_occupancy;
+      if (const auto error = CubDebug(launcher_factory.MaxSmOccupancy(
+            sweep_sm_occupancy, kernel_source.UniqueByKeySweepKernel(), threads_per_block)))
+      {
+        return error;
+      }
+      _CubLog("Invoking unique_by_key_kernel<<<{%d,%d,%d}, %d, 0, "
+              "%lld>>>(), %d items per thread, %d SM occupancy\n",
+              scan_grid_size.x,
+              scan_grid_size.y,
+              scan_grid_size.z,
+              threads_per_block,
+              (long long) stream,
+              items_per_thread,
+              sweep_sm_occupancy);
+    }
+#endif // CUB_DEBUG_LOG
+
+    // Invoke select_if_kernel
+    if (const auto error = CubDebug(
+          launcher_factory(scan_grid_size, threads_per_block, 0, stream)
+            .doit(kernel_source.UniqueByKeySweepKernel(),
+                  d_keys_in,
+                  d_values_in,
+                  d_keys_out,
+                  d_values_out,
+                  d_num_selected_out,
+                  tile_state,
+                  equality_op,
+                  num_items,
+                  num_tiles,
+                  cub::detail::vsmem_t{allocations[1]})))
+    {
+      return error;
+    }
+
+    return CubDebug(detail::DebugSyncStream(stream));
   });
 }
 } // namespace detail::unique_by_key

--- a/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
@@ -514,17 +514,17 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE auto dispatch(
     const UniqueByKeyPolicy active_policy     = policy_getter();
     const ::cuda::std::size_t vsmem_per_block = 0;
 #else
-  using vsmem_adapted_agents = unique_by_key_vsmem_helper_t<
-    decltype(policy_getter),
-    KeyInputIteratorT,
-    ValueInputIteratorT,
-    KeyOutputIteratorT,
-    ValueOutputIteratorT,
-    EqualityOpT,
-    OffsetT>;
-  const ::cuda::std::size_t vsmem_per_block =
-    vsmem_helper_impl<typename vsmem_adapted_agents::agent_t>::vsmem_per_block;
+    using vsmem_adapted_agents = unique_by_key_vsmem_helper_t<
+      decltype(policy_getter),
+      KeyInputIteratorT,
+      ValueInputIteratorT,
+      KeyOutputIteratorT,
+      ValueOutputIteratorT,
+      EqualityOpT,
+      OffsetT>;
     constexpr UniqueByKeyPolicy active_policy     = vsmem_adapted_agents::policy;
+    const ::cuda::std::size_t vsmem_per_block =
+    vsmem_helper_impl<typename vsmem_adapted_agents::agent_t>::vsmem_per_block;
 #endif
 
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)

--- a/cub/cub/device/dispatch/kernels/kernel_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_unique_by_key.cuh
@@ -37,39 +37,39 @@ namespace detail::unique_by_key
 template <typename PolicyGetter>
 struct host_policy_provider
 {
-  static constexpr unique_by_key_policy selected_policy = PolicyGetter{}();
+  static constexpr UniqueByKeyPolicy selected_policy = PolicyGetter{}();
 
   struct fallback_pol_getter
   {
     _CCCL_HOST_DEVICE_API _CCCL_FORCEINLINE constexpr auto operator()() const
     {
-      unique_by_key_policy policy = PolicyGetter{}();
-      policy.threads_per_block    = 64;
-      policy.items_per_thread     = 1;
+      UniqueByKeyPolicy policy = PolicyGetter{}();
+      policy.threads_per_block = 64;
+      policy.items_per_thread  = 1;
       return policy;
     }
   };
 
-  static constexpr unique_by_key_policy fallback_policy = fallback_pol_getter{}();
+  static constexpr UniqueByKeyPolicy fallback_policy = fallback_pol_getter{}();
 };
 
 template <typename PolicyGetter>
 struct device_policy_provider
 {
-  static constexpr unique_by_key_policy selected_policy = PolicyGetter{}();
+  static constexpr UniqueByKeyPolicy selected_policy = PolicyGetter{}();
 
   struct fallback_pol_getter
   {
     _CCCL_DEVICE_API _CCCL_FORCEINLINE constexpr auto operator()() const
     {
-      unique_by_key_policy policy = PolicyGetter{}();
-      policy.threads_per_block    = 64;
-      policy.items_per_thread     = 1;
+      UniqueByKeyPolicy policy = PolicyGetter{}();
+      policy.threads_per_block = 64;
+      policy.items_per_thread  = 1;
       return policy;
     }
   };
 
-  static constexpr unique_by_key_policy fallback_policy = fallback_pol_getter{}();
+  static constexpr UniqueByKeyPolicy fallback_policy = fallback_pol_getter{}();
 };
 
 template <typename PolicyProvider,
@@ -81,29 +81,29 @@ template <typename PolicyProvider,
           typename OffsetT>
 class unique_by_key_vsmem_helper_impl
 {
-  static constexpr unique_by_key_policy selected_policy = PolicyProvider::selected_policy;
+  static constexpr UniqueByKeyPolicy selected_policy = PolicyProvider::selected_policy;
 
-  using selected_policy_t = AgentUniqueByKeyPolicy<
+  using selected_policy_t = agent_unique_by_key_policy<
     selected_policy.threads_per_block,
     selected_policy.items_per_thread,
     selected_policy.load_algorithm,
     selected_policy.load_modifier,
     selected_policy.scan_algorithm,
-    delay_constructor_t<selected_policy.delay_constructor.kind,
-                        selected_policy.delay_constructor.delay,
-                        selected_policy.delay_constructor.l2_write_latency>>;
+    delay_constructor_t<selected_policy.lookback_delay.kind,
+                        selected_policy.lookback_delay.delay,
+                        selected_policy.lookback_delay.l2_write_latency>>;
 
-  static constexpr unique_by_key_policy fallback_policy = PolicyProvider::fallback_policy;
+  static constexpr UniqueByKeyPolicy fallback_policy = PolicyProvider::fallback_policy;
 
-  using fallback_policy_t = AgentUniqueByKeyPolicy<
+  using fallback_policy_t = agent_unique_by_key_policy<
     fallback_policy.threads_per_block,
     fallback_policy.items_per_thread,
     fallback_policy.load_algorithm,
     fallback_policy.load_modifier,
     fallback_policy.scan_algorithm,
-    delay_constructor_t<fallback_policy.delay_constructor.kind,
-                        fallback_policy.delay_constructor.delay,
-                        fallback_policy.delay_constructor.l2_write_latency>>;
+    delay_constructor_t<fallback_policy.lookback_delay.kind,
+                        fallback_policy.lookback_delay.delay,
+                        fallback_policy.lookback_delay.l2_write_latency>>;
 
   using default_agent_t =
     AgentUniqueByKey<selected_policy_t,
@@ -128,7 +128,7 @@ class unique_by_key_vsmem_helper_impl
     (max_default_size > max_smem_per_block) && (max_fallback_size <= max_smem_per_block);
 
 public:
-  static constexpr unique_by_key_policy policy    = uses_fallback_policy ? fallback_policy : selected_policy;
+  static constexpr UniqueByKeyPolicy policy       = uses_fallback_policy ? fallback_policy : selected_policy;
   static constexpr bool selected_policy_fits_smem = max_default_size <= max_smem_per_block;
 
   using selected_agent_t = default_agent_t;

--- a/cub/cub/device/dispatch/tuning/tuning_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_unique_by_key.cuh
@@ -29,42 +29,43 @@
 
 CUB_NAMESPACE_BEGIN
 
-namespace detail::unique_by_key
+//! The tuning policy for all algorithms in @ref DeviceSelect that operate UniqueByKey.
+struct UniqueByKeyPolicy
 {
-struct unique_by_key_policy
-{
-  int threads_per_block;
-  int items_per_thread;
-  BlockLoadAlgorithm load_algorithm;
-  CacheLoadModifier load_modifier;
-  BlockScanAlgorithm scan_algorithm;
-  LookbackDelayPolicy delay_constructor;
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int items_per_thread; //!< Number of items processed per thread
+  BlockLoadAlgorithm load_algorithm; //!< The @ref BlockLoadAlgorithm used for loading items from global memory
+  CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
+  BlockScanAlgorithm scan_algorithm; //!< The @ref BlockScanAlgorithm used for scanning
+  LookbackDelayPolicy lookback_delay; //!< The policy configuring the delay used in decoupled lookback
 
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const unique_by_key_policy& lhs, const unique_by_key_policy& rhs)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const UniqueByKeyPolicy& lhs, const UniqueByKeyPolicy& rhs) noexcept
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
         && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
-        && lhs.scan_algorithm == rhs.scan_algorithm && lhs.delay_constructor == rhs.delay_constructor;
+        && lhs.scan_algorithm == rhs.scan_algorithm && lhs.lookback_delay == rhs.lookback_delay;
   }
 
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const unique_by_key_policy& lhs, const unique_by_key_policy& rhs)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const UniqueByKeyPolicy& lhs, const UniqueByKeyPolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const unique_by_key_policy& p)
+  friend ::std::ostream& operator<<(::std::ostream& os, const UniqueByKeyPolicy& p)
   {
     return os
-        << "unique_by_key_policy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
+        << "UniqueByKeyPolicy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
         << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm << ", .load_modifier = " << p.load_modifier
-        << ", .scan_algorithm = " << p.scan_algorithm << ", .delay_constructor = " << p.delay_constructor << " }";
+        << ", .scan_algorithm = " << p.scan_algorithm << ", .lookback_delay = " << p.lookback_delay << " }";
   }
 #endif // _CCCL_HOSTED()
 };
 
+namespace detail::unique_by_key
+{
 enum class primitive_key
 {
   no,
@@ -790,12 +791,12 @@ struct policy_hub
   {
     static constexpr int items_per_thread = Nominal4BItemsToItems<KeyT>(Nominal4bItemsPerThread);
     using UniqueByKeyPolicyT =
-      AgentUniqueByKeyPolicy<Threads,
-                             items_per_thread,
-                             BLOCK_LOAD_WARP_TRANSPOSE,
-                             LOAD_LDG,
-                             BLOCK_SCAN_WARP_SCANS,
-                             detail::default_delay_constructor_t<int>>;
+      agent_unique_by_key_policy<Threads,
+                                 items_per_thread,
+                                 BLOCK_LOAD_WARP_TRANSPOSE,
+                                 LOAD_LDG,
+                                 BLOCK_SCAN_WARP_SCANS,
+                                 detail::default_delay_constructor_t<int>>;
   };
 
   // nvbug5935129: GCC-11.2 cannot directly use DefaultPolicy inside Policy500
@@ -809,12 +810,12 @@ struct policy_hub
   // Use values from tuning if a specialization exists, otherwise pick the default
   template <typename Tuning>
   static _CCCL_HOST_DEVICE auto select_agent_policy(int)
-    -> AgentUniqueByKeyPolicy<Tuning::threads,
-                              Tuning::items,
-                              Tuning::load_algorithm,
-                              Tuning::load_modifier,
-                              BLOCK_SCAN_WARP_SCANS,
-                              typename Tuning::delay_constructor>;
+    -> agent_unique_by_key_policy<Tuning::threads,
+                                  Tuning::items,
+                                  Tuning::load_algorithm,
+                                  Tuning::load_modifier,
+                                  BLOCK_SCAN_WARP_SCANS,
+                                  typename Tuning::delay_constructor>;
   template <typename Tuning>
   static _CCCL_HOST_DEVICE auto select_agent_policy(long) -> typename DefaultPolicy<11, 64>::UniqueByKeyPolicyT;
 
@@ -849,12 +850,12 @@ struct policy_hub
     // Use values from tuning if a specialization exists, otherwise pick Policy900
     template <typename Tuning>
     static _CCCL_HOST_DEVICE auto select_agent_policy100(int)
-      -> AgentUniqueByKeyPolicy<Tuning::threads,
-                                Tuning::items,
-                                Tuning::load_algorithm,
-                                Tuning::load_modifier,
-                                BLOCK_SCAN_WARP_SCANS,
-                                typename Tuning::delay_constructor>;
+      -> agent_unique_by_key_policy<Tuning::threads,
+                                    Tuning::items,
+                                    Tuning::load_algorithm,
+                                    Tuning::load_modifier,
+                                    BLOCK_SCAN_WARP_SCANS,
+                                    typename Tuning::delay_constructor>;
     template <typename Tuning>
     static _CCCL_HOST_DEVICE auto select_agent_policy100(long) -> typename Policy900::UniqueByKeyPolicyT;
 
@@ -877,7 +878,7 @@ private:
     return cub::detail::nominal_4B_items_to_items(11, key_size);
   }
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto get_default_policy() const -> unique_by_key_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto get_default_policy() const -> UniqueByKeyPolicy
   {
     return {64,
             default_items_per_thread(),
@@ -888,7 +889,7 @@ private:
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto get_sm100_tuning() const
-    -> ::cuda::std::optional<unique_by_key_policy>
+    -> ::cuda::std::optional<UniqueByKeyPolicy>
   {
     if (!primitive_key)
     {
@@ -904,7 +905,7 @@ private:
           {
             case 1:
               // ipt_12.tpb_512.trp_0.ld_0.ns_948.dcid_5.l2w_955 1.121279  1.000000  1.114566  1.43765
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 512,
                 12,
                 BLOCK_LOAD_DIRECT,
@@ -913,7 +914,7 @@ private:
                 LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 948, 955}};
             case 2:
               // ipt_14.tpb_512.trp_0.ld_0.ns_1228.dcid_7.l2w_320 1.151229  1.007229  1.151131  1.443520
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 512,
                 14,
                 BLOCK_LOAD_DIRECT,
@@ -922,7 +923,7 @@ private:
                 LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 1228, 320}};
             case 4:
               // ipt_14.tpb_512.trp_0.ld_0.ns_2016.dcid_7.l2w_620 1.165300  1.095238  1.164478  1.266667
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 512,
                 14,
                 BLOCK_LOAD_DIRECT,
@@ -931,7 +932,7 @@ private:
                 LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 2016, 620}};
             case 8:
               // ipt_10.tpb_384.trp_0.ld_0.ns_1728.dcid_5.l2w_980 1.118716  0.997167  1.116537  1.400000
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 384,
                 10,
                 BLOCK_LOAD_DIRECT,
@@ -946,7 +947,7 @@ private:
           {
             case 1:
               // ipt_14.tpb_512.trp_0.ld_0.ns_508.dcid_7.l2w_1020 1.171886  0.906530  1.157128  1.457933
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 512,
                 14,
                 BLOCK_LOAD_DIRECT,
@@ -955,7 +956,7 @@ private:
                 LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 508, 1020}};
             case 2:
               // ipt_12.tpb_384.trp_0.ld_0.ns_928.dcid_7.l2w_605 1.166564  0.997579  1.154805  1.406709
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 384,
                 12,
                 BLOCK_LOAD_DIRECT,
@@ -964,7 +965,7 @@ private:
                 LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 928, 605}};
             case 4:
               // ipt_11.tpb_384.trp_0.ld_1.ns_1620.dcid_7.l2w_810 1.144483  1.011085  1.152798  1.393750
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 384,
                 11,
                 BLOCK_LOAD_DIRECT,
@@ -973,7 +974,7 @@ private:
                 LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 1620, 810}};
             case 8:
               // ipt_10.tpb_384.trp_0.ld_0.ns_1984.dcid_5.l2w_935 1.605554  1.177083  1.564488  1.946224
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 384,
                 10,
                 BLOCK_LOAD_DIRECT,
@@ -988,7 +989,7 @@ private:
           {
             case 1:
               // ipt_14.tpb_512.trp_0.ld_0.ns_1136.dcid_7.l2w_605 1.148057  0.848558  1.133064  1.451074
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 512,
                 14,
                 BLOCK_LOAD_DIRECT,
@@ -997,7 +998,7 @@ private:
                 LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 1136, 605}};
             case 2:
               // ipt_11.tpb_384.trp_0.ld_0.ns_656.dcid_7.l2w_825 1.216312  1.090485  1.211800  1.535714
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 384,
                 11,
                 BLOCK_LOAD_DIRECT,
@@ -1006,7 +1007,7 @@ private:
                 LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon, 656, 825}};
             case 8:
               // ipt_10.tpb_384.trp_0.ld_0.ns_1012.dcid_5.l2w_800 1.164713  1.014819  1.174307  1.526042
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 384,
                 10,
                 BLOCK_LOAD_DIRECT,
@@ -1021,7 +1022,7 @@ private:
           {
             case 2:
               // ipt_10.tpb_384.trp_0.ld_0.ns_864.dcid_5.l2w_1130 1.124095  0.985748  1.120262  1.391304
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 384,
                 10,
                 BLOCK_LOAD_DIRECT,
@@ -1030,7 +1031,7 @@ private:
                 LookbackDelayPolicy{LookbackDelayAlgorithm::exponential_backon_jitter_window, 864, 1130}};
             case 4:
               // ipt_10.tpb_384.trp_0.ld_0.ns_772.dcid_5.l2w_665 1.152243  1.019816  1.166636  1.517526
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 384,
                 10,
                 BLOCK_LOAD_DIRECT,
@@ -1048,8 +1049,7 @@ private:
     return {};
   }
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto get_sm90_tuning() const
-    -> ::cuda::std::optional<unique_by_key_policy>
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto get_sm90_tuning() const -> ::cuda::std::optional<UniqueByKeyPolicy>
   {
     if (!primitive_key)
     {
@@ -1064,7 +1064,7 @@ private:
           switch (value_size)
           {
             case 1:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 256,
                 12,
                 BLOCK_LOAD_DIRECT,
@@ -1072,7 +1072,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 550}};
             case 2:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 448,
                 14,
                 BLOCK_LOAD_DIRECT,
@@ -1080,7 +1080,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 725}};
             case 4:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 256,
                 12,
                 BLOCK_LOAD_DIRECT,
@@ -1088,7 +1088,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1130}};
             case 8:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 512,
                 10,
                 BLOCK_LOAD_DIRECT,
@@ -1102,7 +1102,7 @@ private:
           switch (value_size)
           {
             case 1:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 256,
                 12,
                 BLOCK_LOAD_DIRECT,
@@ -1110,7 +1110,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 640}};
             case 2:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 288,
                 14,
                 BLOCK_LOAD_DIRECT,
@@ -1118,7 +1118,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 404, 710}};
             case 4:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 512,
                 12,
                 BLOCK_LOAD_DIRECT,
@@ -1126,7 +1126,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 525}};
             case 8:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 256,
                 23,
                 BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1140,7 +1140,7 @@ private:
           switch (value_size)
           {
             case 1:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 448,
                 12,
                 BLOCK_LOAD_DIRECT,
@@ -1148,7 +1148,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 348, 580}};
             case 2:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 384,
                 9,
                 BLOCK_LOAD_DIRECT,
@@ -1156,7 +1156,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1060}};
             case 4:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 512,
                 14,
                 BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1164,7 +1164,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1045}};
             case 8:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 512,
                 11,
                 BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1178,7 +1178,7 @@ private:
           switch (value_size)
           {
             case 1:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 384,
                 9,
                 BLOCK_LOAD_DIRECT,
@@ -1186,7 +1186,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1060}};
             case 2:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 384,
                 9,
                 BLOCK_LOAD_DIRECT,
@@ -1194,7 +1194,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 964, 1125}};
             case 4:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 640,
                 7,
                 BLOCK_LOAD_DIRECT,
@@ -1202,7 +1202,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1070}};
             case 8:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 448,
                 11,
                 BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1222,7 +1222,7 @@ private:
       switch (key_size)
       {
         case 1:
-          return unique_by_key_policy{
+          return UniqueByKeyPolicy{
             288,
             7,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1230,7 +1230,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 344, 1165}};
         case 2:
-          return unique_by_key_policy{
+          return UniqueByKeyPolicy{
             224,
             9,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1238,7 +1238,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 424, 1055}};
         case 4:
-          return unique_by_key_policy{
+          return UniqueByKeyPolicy{
             384,
             7,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1246,7 +1246,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1025}};
         case 8:
-          return unique_by_key_policy{
+          return UniqueByKeyPolicy{
             256,
             9,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1261,8 +1261,7 @@ private:
     return {};
   }
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto get_sm80_tuning() const
-    -> ::cuda::std::optional<unique_by_key_policy>
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto get_sm80_tuning() const -> ::cuda::std::optional<UniqueByKeyPolicy>
   {
     if (!primitive_key)
     {
@@ -1277,7 +1276,7 @@ private:
           switch (value_size)
           {
             case 1:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 256,
                 12,
                 BLOCK_LOAD_DIRECT,
@@ -1285,7 +1284,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 835}};
             case 2:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 256,
                 12,
                 BLOCK_LOAD_DIRECT,
@@ -1293,7 +1292,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 765}};
             case 4:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 256,
                 12,
                 BLOCK_LOAD_DIRECT,
@@ -1301,7 +1300,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1155}};
             case 8:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 224,
                 10,
                 BLOCK_LOAD_DIRECT,
@@ -1315,7 +1314,7 @@ private:
           switch (value_size)
           {
             case 1:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 320,
                 20,
                 BLOCK_LOAD_DIRECT,
@@ -1323,7 +1322,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1020}};
             case 2:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 192,
                 22,
                 BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1331,7 +1330,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 328, 1080}};
             case 4:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 256,
                 14,
                 BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1339,7 +1338,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 535}};
             case 8:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 256,
                 10,
                 BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1353,7 +1352,7 @@ private:
           switch (value_size)
           {
             case 1:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 256,
                 12,
                 BLOCK_LOAD_DIRECT,
@@ -1361,7 +1360,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1120}};
             case 2:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 256,
                 14,
                 BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1369,7 +1368,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1185}};
             case 4:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 256,
                 11,
                 BLOCK_LOAD_DIRECT,
@@ -1377,7 +1376,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::no_delay, 0, 1115}};
             case 8:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 256,
                 7,
                 BLOCK_LOAD_DIRECT,
@@ -1391,7 +1390,7 @@ private:
           switch (value_size)
           {
             case 1:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 256,
                 7,
                 BLOCK_LOAD_DIRECT,
@@ -1399,7 +1398,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 24, 555}};
             case 2:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 256,
                 7,
                 BLOCK_LOAD_DIRECT,
@@ -1407,7 +1406,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 324, 1105}};
             case 4:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 256,
                 7,
                 BLOCK_LOAD_DIRECT,
@@ -1415,7 +1414,7 @@ private:
                 BLOCK_SCAN_WARP_SCANS,
                 LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 740, 1105}};
             case 8:
-              return unique_by_key_policy{
+              return UniqueByKeyPolicy{
                 192,
                 7,
                 BLOCK_LOAD_DIRECT,
@@ -1435,7 +1434,7 @@ private:
       switch (key_size)
       {
         case 1:
-          return unique_by_key_policy{
+          return UniqueByKeyPolicy{
             128,
             15,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1443,7 +1442,7 @@ private:
             BLOCK_SCAN_WARP_SCANS,
             LookbackDelayPolicy{LookbackDelayAlgorithm::fixed_delay, 248, 1200}};
         case 8:
-          return unique_by_key_policy{
+          return UniqueByKeyPolicy{
             128,
             7,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -1460,7 +1459,7 @@ private:
 
 public:
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
-    -> unique_by_key_policy
+    -> UniqueByKeyPolicy
   {
     if (cc >= ::cuda::compute_capability{10, 0})
     {
@@ -1500,7 +1499,7 @@ template <typename KeyT, typename ValueT>
 struct policy_selector_from_types
 {
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
-    -> unique_by_key_policy
+    -> UniqueByKeyPolicy
   {
     return policy_selector{
       static_cast<int>(sizeof(KeyT)),
@@ -1511,7 +1510,7 @@ struct policy_selector_from_types
 };
 
 template <typename ActivePolicyT>
-_CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> unique_by_key_policy
+_CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> UniqueByKeyPolicy
 {
   using policy_t = typename ActivePolicyT::UniqueByKeyPolicyT;
   return {policy_t::BLOCK_THREADS,
@@ -1525,7 +1524,7 @@ _CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> unique_by_key_policy
 template <typename PolicyHub>
 struct policy_selector_from_hub
 {
-  [[nodiscard]] _CCCL_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const -> unique_by_key_policy
+  [[nodiscard]] _CCCL_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const -> UniqueByKeyPolicy
   {
     return convert_policy<typename PolicyHub::MaxPolicy>();
   }
@@ -1533,7 +1532,7 @@ struct policy_selector_from_hub
 
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>
-concept unique_by_key_policy_selector = cub::detail::policy_selector<T, unique_by_key_policy>;
+concept unique_by_key_policy_selector = cub::detail::policy_selector<T, UniqueByKeyPolicy>;
 #endif
 } // namespace detail::unique_by_key
 

--- a/cub/test/catch2_test_device_select_env.cu
+++ b/cub/test/catch2_test_device_select_env.cu
@@ -1111,8 +1111,7 @@ struct select_tuning
 template <unsigned int BlockThreads>
 struct unique_by_key_tuning
 {
-  _CCCL_API constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::unique_by_key::unique_by_key_policy
+  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::UniqueByKeyPolicy
   {
     return {static_cast<int>(BlockThreads),
             10,
@@ -1273,6 +1272,40 @@ C2H_TEST("DeviceSelect::UniqueByKey can be tuned", "[select][device]", block_siz
   REQUIRE(d_num_selected[0] == 4);
   REQUIRE(d_block_size[0] == target_block_size);
 }
+
+#  if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
+C2H_TEST("UniqueByKeyPolicy new API is equivalent to existing API", "[select_unique_by_key][device]")
+{
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::UniqueByKeyPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::UniqueByKeyPolicy>);
+
+  // aggregate init
+  constexpr auto p1 = cub::UniqueByKeyPolicy{
+    256,
+    11,
+    cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+    cub::CacheLoadModifier::LOAD_DEFAULT,
+    cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_SCANS,
+    cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 350, 450}};
+
+#    if _CCCL_STD_VER >= 2020
+  // designated init
+  constexpr auto p2 = cub::UniqueByKeyPolicy{
+    .threads_per_block = 256,
+    .items_per_thread  = 11,
+    .load_algorithm    = cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+    .load_modifier     = cub::CacheLoadModifier::LOAD_DEFAULT,
+    .scan_algorithm    = cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_SCANS,
+    .lookback_delay    = cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 350, 450}};
+#    else // _CCCL_STD_VER >= 2020
+  constexpr auto p2 = p1;
+#    endif // _CCCL_STD_VER >= 2020
+
+  // comparison
+  STATIC_REQUIRE(p1 == p2);
+  STATIC_REQUIRE_FALSE(p1 != p2);
+}
+#  endif // _CCCL_COMPILER(GCC, >=, 8)
 
 #endif // TEST_LAUNCH != 1
 

--- a/cub/test/catch2_test_device_select_env_api.cu
+++ b/cub/test/catch2_test_device_select_env_api.cu
@@ -487,14 +487,16 @@ C2H_TEST("cub::DeviceSelect::UniqueByKey accepts a custom policy selector", "[se
     std::cerr << "cub::DeviceSelect::UniqueByKey failed with status: " << error << '\n';
   }
 
-  const int n = num_selected_out[0];
-  keys_out.resize(n);
-  values_out.resize(n);
+  thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
+  thrust::device_vector<int> expected_values{0, 1, 3, 4, 7};
   // example-end unique-by-key-tuning
 
   REQUIRE(error == cudaSuccess);
-  REQUIRE(keys_out == thrust::device_vector<int>{0, 2, 9, 5, 8});
-  REQUIRE(values_out == thrust::device_vector<int>{0, 1, 3, 4, 7});
+  const int n = num_selected_out[0];
+  keys_out.resize(n);
+  values_out.resize(n);
+  CHECK(keys_out == expected_keys);
+  CHECK(values_out == expected_values);
 }
 
 #endif // _CCCL_STD_VER >= 2020

--- a/cub/test/catch2_test_device_select_env_api.cu
+++ b/cub/test/catch2_test_device_select_env_api.cu
@@ -450,4 +450,51 @@ C2H_TEST("cub::DeviceSelect::If env-based API with tuning", "[select][env]")
   REQUIRE(d_num_selected[0] == expected_num_selected);
 }
 
+// example-begin unique-by-key-policy-selector
+struct UniqueByKeyPolicySelector
+{
+  __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::UniqueByKeyPolicy
+  {
+    return {.threads_per_block = 256,
+            .items_per_thread  = cc > cuda::compute_capability{9, 0} ? 12 : 10,
+            .load_algorithm    = cub::BLOCK_LOAD_DIRECT,
+            .load_modifier     = cub::LOAD_DEFAULT,
+            .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
+            .lookback_delay    = cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 350, 450}};
+  }
+};
+// example-end unique-by-key-policy-selector
+
+C2H_TEST("cub::DeviceSelect::UniqueByKey accepts a custom policy selector", "[select_unique_by_key][env]")
+{
+  // example-begin unique-by-key-tuning
+  auto keys_in          = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
+  auto values_in        = thrust::device_vector<int>{0, 1, 2, 3, 4, 5, 6, 7};
+  auto keys_out         = thrust::device_vector<int>(8, thrust::no_init);
+  auto values_out       = thrust::device_vector<int>(8, thrust::no_init);
+  auto num_selected_out = thrust::device_vector<int>(1, thrust::no_init);
+
+  const auto error = cub::DeviceSelect::UniqueByKey(
+    keys_in.begin(),
+    values_in.begin(),
+    keys_out.begin(),
+    values_out.begin(),
+    num_selected_out.begin(),
+    keys_in.size(),
+    cuda::execution::tune(UniqueByKeyPolicySelector{}));
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceSelect::UniqueByKey failed with status: " << error << '\n';
+  }
+
+  const int n = num_selected_out[0];
+  keys_out.resize(n);
+  values_out.resize(n);
+  // example-end unique-by-key-tuning
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(keys_out == thrust::device_vector<int>{0, 2, 9, 5, 8});
+  REQUIRE(values_out == thrust::device_vector<int>{0, 1, 3, 4, 7});
+}
+
 #endif // _CCCL_STD_VER >= 2020

--- a/cub/test/catch2_test_device_select_unique_by_key_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_select_unique_by_key_custom_policy_hub.cu
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// TODO(bgruber): drop this test with CCCL 4.0 when we drop the unique by key dispatcher
+
+#define CCCL_IGNORE_DEPRECATED_API
+
 #include "insert_nested_NVTX_range_guard.h"
 
 #include <cub/device/dispatch/dispatch_unique_by_key.cuh>
@@ -12,9 +16,6 @@
 #include <c2h/catch2_test_helper.h>
 
 using namespace cub;
-
-// TODO(bgruber): drop this test with CCCL 4.0 when we drop the unique by key dispatcher after publishing the
-// tuning API
 
 template <class KeyT, class ValueT>
 struct my_policy_hub


### PR DESCRIPTION
fixes #9242 

adds `dispatch_policy()` free function along the way and deprecates `DispatchUniqueByKey()` along the way
