### PR TITLE
[cudax] Implement `cudax::coop::shuffle_down` for threads within a warp

### DIFF
--- a/cudax/include/cuda/experimental/__coop/shuffle_down.cuh
+++ b/cudax/include/cuda/experimental/__coop/shuffle_down.cuh
@@ -1,0 +1,89 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_EXPERIMENTAL___COOP_SHUFFLE_DOWN_CUH
+#define _CUDA_EXPERIMENTAL___COOP_SHUFFLE_DOWN_CUH
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__ptx/instructions/get_sreg.h>
+#include <cuda/__warp/warp_shuffle.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/optional>
+
+#include <cuda/experimental/group.cuh>
+
+#include <cuda/std/__cccl/prologue.h>
+
+#if !defined(_CCCL_DOXYGEN_INVOKED)
+
+namespace cuda::experimental::coop
+{
+template <bool _Dummy = false>
+[[nodiscard]] _CCCL_DEVICE_API auto __shuffle_down_impl(...)
+{
+  static_assert(_Dummy, "cudax::coop::shuffle_down is not implemented for this group");
+}
+
+_CCCL_TEMPLATE(class _Group, class _Tp)
+_CCCL_REQUIRES(is_group<_Group> _CCCL_AND ::cuda::std::is_same_v<typename _Group::unit_type, thread_level>
+                 _CCCL_AND ::cuda::std::is_same_v<typename _Group::level_type, warp_level>)
+[[nodiscard]] _CCCL_DEVICE_API ::cuda::std::optional<_Tp>
+__shuffle_down_impl(const _Group& __group, const _Tp& __value, unsigned __offset) noexcept
+{
+  using _MappingResult         = typename _Group::__mapping_result_type;
+  const auto& __mapping_result = __group.__mapping_result();
+
+  const auto __lane_mask       = __mapping_result.lane_mask();
+  const auto __offset_is_valid = (__offset < __mapping_result.count() - __mapping_result.rank());
+
+  if constexpr (_MappingResult::is_always_contiguous())
+  {
+    const auto __real_offset = (__offset_is_valid) ? __offset : 0u;
+    const auto __result =
+      ::cuda::device::warp_shuffle_down(__value, static_cast<int>(__real_offset), __lane_mask.value());
+    return (__offset_is_valid) ? ::cuda::std::optional{__result.data} : ::cuda::std::nullopt;
+  }
+  else
+  {
+    const auto __lane = ::cuda::ptx::get_sreg_laneid();
+    const auto __src_lane =
+      (__offset_is_valid) ? ::__fns(__lane_mask.value(), __lane, static_cast<int>(__offset + 1)) : __lane;
+    const auto __result = ::cuda::device::warp_shuffle_idx(__value, static_cast<int>(__src_lane), __lane_mask.value());
+    return (__offset_is_valid) ? ::cuda::std::optional{__result.data} : ::cuda::std::nullopt;
+  }
+}
+
+//! @brief Gets the values from a unit with a greater rank by the specified offset.
+//! @param[in] __group The group.
+//! @param[in] __value This thread's value.
+//! @param[in] __offset The offset of the source rank from this unit's rank.
+//! @return The source's value or empty optional if no such rank exists.
+template <class _Group, class _Tp>
+[[nodiscard]] _CCCL_DEVICE_API ::cuda::std::optional<_Tp>
+shuffle_down(const _Group& __group, const _Tp& __value, unsigned __offset) noexcept
+{
+  return ::cuda::experimental::coop::__shuffle_down_impl(__group, __value, __offset);
+}
+} // namespace cuda::experimental::coop
+
+#endif // !_CCCL_DOXYGEN_INVOKED
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_EXPERIMENTAL___COOP_SHUFFLE_DOWN_CUH

--- a/cudax/include/cuda/experimental/coop.cuh
+++ b/cudax/include/cuda/experimental/coop.cuh
@@ -23,5 +23,6 @@
 
 #include <cuda/experimental/__coop/reduce.cuh>
 #include <cuda/experimental/__coop/shuffle.cuh>
+#include <cuda/experimental/__coop/shuffle_down.cuh>
 
 #endif // _CUDA_EXPERIMENTAL_COOP

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -207,6 +207,10 @@ cudax_add_catch2_test(test_target coop.shuffle.threads_within_warp
     coop/shuffle/threads_within_warp.cu
 )
 
+cudax_add_catch2_test(test_target coop.shuffle_down.threads_within_warp
+    coop/shuffle_down/threads_within_warp.cu
+)
+
 if (cudax_ENABLE_CUFILE)
   cudax_add_catch2_test(test_target cufile.driver_attributes
       cufile/driver_attributes.cu

--- a/cudax/test/coop/shuffle_down/threads_within_warp.cu
+++ b/cudax/test/coop/shuffle_down/threads_within_warp.cu
@@ -1,0 +1,143 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/devices>
+#include <cuda/hierarchy>
+#include <cuda/launch>
+#include <cuda/stream>
+#include <cuda/type_traits>
+
+#include <cuda/experimental/coop.cuh>
+#include <cuda/experimental/group.cuh>
+
+#include "testing.cuh"
+
+template <class T>
+__device__ T make_instance_for(unsigned rank)
+{
+  if constexpr (cuda::is_vector_type_v<T>)
+  {
+    using U = cuda::scalar_type_t<T>;
+    return T{static_cast<U>(rank), static_cast<U>(rank), static_cast<U>(rank)};
+  }
+  else
+  {
+    return static_cast<T>(rank);
+  }
+}
+
+template <class T, class Group>
+__device__ void test_group(const Group& group)
+{
+  // Exit all threads that are not part of the group.
+  if (!cuda::gpu_thread.is_part_of(group))
+  {
+    return;
+  }
+
+  const auto my_rank  = cuda::gpu_thread.rank_as<unsigned>(group);
+  const auto my_value = make_instance_for<T>(my_rank);
+
+  // Test identity.
+  REQUIRE(cudax::coop::shuffle_down(group, my_value, 0) == my_value);
+
+  // Test getting value from the next rank.
+  {
+    const auto offset     = 1;
+    const auto other_rank = cuda::gpu_thread.rank(group) + offset;
+    const auto ref        = (other_rank < cuda::gpu_thread.count(group))
+                            ? cuda::std::optional{make_instance_for<T>(other_rank)}
+                            : cuda::std::nullopt;
+    REQUIRE(cudax::coop::shuffle_down(group, my_value, offset) == ref);
+  }
+
+  // Test getting value from the this + 2 rank.
+  {
+    const auto offset     = 2;
+    const auto other_rank = cuda::gpu_thread.rank(group) + offset;
+    const auto ref        = (other_rank < cuda::gpu_thread.count(group))
+                            ? cuda::std::optional{make_instance_for<T>(other_rank)}
+                            : cuda::std::nullopt;
+    REQUIRE(cudax::coop::shuffle_down(group, my_value, offset) == ref);
+  }
+
+  // Test getting value from the last rank.
+  {
+    const auto other_rank = cuda::gpu_thread.count(group) - 1;
+    const auto offset     = other_rank - cuda::gpu_thread.rank(group);
+    REQUIRE(cudax::coop::shuffle_down(group, my_value, offset) == make_instance_for<T>(other_rank));
+  }
+
+  // Test getting value from the last rank + 1.
+  {
+    const auto other_rank = cuda::gpu_thread.count(group);
+    const auto offset     = other_rank - cuda::gpu_thread.rank(group);
+    REQUIRE(cudax::coop::shuffle_down(group, my_value, offset) == cuda::std::nullopt);
+  }
+
+  // Test getting value from out of range offset.
+  REQUIRE(cudax::coop::shuffle_down(group, my_value, ~0u) == cuda::std::nullopt);
+}
+
+struct CustomBinaryPartition
+{
+  template <class MappingResult>
+  __device__ bool operator()(MappingResult mapping_result)
+  {
+    switch (mapping_result.rank())
+    {
+      case 1:
+      case 5:
+      case 14:
+      case 15:
+      case 31:
+        return true;
+      default:
+        return false;
+    }
+  }
+};
+
+template <class T, class Config>
+__device__ void test_type(const Config& config)
+{
+  const cudax::this_warp warp{config};
+  test_group<T>(cudax::group{cuda::gpu_thread, warp, cudax::identity_mapping{}, cudax::lane_synchronizer{}});
+  test_group<T>(cudax::group{cuda::gpu_thread, warp, cudax::group_by<4>{}, cudax::lane_synchronizer{}});
+  test_group<T>(cudax::group{cuda::gpu_thread, warp, cudax::group_by{1}, cudax::lane_synchronizer{}});
+  test_group<T>(
+    cudax::group{cuda::gpu_thread, warp, cudax::group_by{3, cudax::non_exhaustive}, cudax::lane_synchronizer{}});
+  test_group<T>(
+    cudax::group{cuda::gpu_thread, warp, cudax::binary_partition{CustomBinaryPartition{}}, cudax::lane_synchronizer{}});
+}
+
+struct TestKernel
+{
+  template <class Config>
+  __device__ void operator()(const Config& config)
+  {
+    test_type<signed char>(config);
+    test_type<unsigned>(config);
+    test_type<unsigned long long>(config);
+    test_type<longlong3>(config);
+  }
+};
+
+C2H_TEST("shuffle/threads_within_warp", "[shuffle][threads_within_warp]")
+{
+  const auto device = cuda::devices[0];
+
+  const cuda::stream stream{device};
+
+  const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims<32>());
+  cuda::launch(stream, config, TestKernel{});
+
+  stream.sync();
+}


### PR DESCRIPTION
Fixes #9376.