### PR TITLE
Move cccl_get_catch2() into testing block

### DIFF
--- a/nvbench_helper/CMakeLists.txt
+++ b/nvbench_helper/CMakeLists.txt
@@ -4,7 +4,6 @@ project(nvbench_helper LANGUAGES CXX CUDA)
 
 include(CMakeDependentOption)
 
-cccl_get_catch2()
 cccl_get_cub()
 cccl_get_cudatoolkit()
 cccl_get_libcudacxx()
@@ -48,6 +47,7 @@ cmake_dependent_option(
 mark_as_advanced(nvbench_helper_ENABLE_TESTING)
 
 if (nvbench_helper_ENABLE_TESTING)
+  cccl_get_catch2()
   cccl_get_boost()
 
   thrust_create_target(cccl.nvbench_helper.test.Thrust.cpp.cuda DEVICE CUDA)


### PR DESCRIPTION
## Description

Mentioned in #7298 

Move cccl_get_catch2() into the testing block so that Catch2 is only fetched when testing is enabled.

### Impact
This reduces CMake configuration time significantly on my system:

*  Before: ~85s
*  After: ~58s
*  Improvement: ~30% faster

Profiling was done using:
```sh
cmake .. --preset=cub-tune \
  --profiling-format=google-trace \
  --profiling-output=cmake_profile.json \
  -DCMAKE_CUDA_HOST_COMPILER=/usr/bin/c++
```

### Observations

* Without testing enabled, Catch2 is no longer fetched.
* With testing enabled (`-DCCCL_ENABLE_NVBENCH_HELPER=ON`), Catch2 is still fetched as expected.
* The remaining configuration time when testing is enabled is mostly dominated by fetching Boost.

Profiling before the change:

<img width="1792" height="590" alt="image" src="https://github.com/user-attachments/assets/03f02461-67e8-49ab-8284-7a6b43a340f1" />

Profiling after the change:

<img width="1777" height="597" alt="image" src="https://github.com/user-attachments/assets/e327d696-804c-4305-b1ce-891795965256" />

Profiling with tests (red circle is Catch2). Note that the above cmake call with the mentioned preset only works when the fix from #9364 is applied.

<img width="1754" height="624" alt="image" src="https://github.com/user-attachments/assets/e8cb910c-5a1f-4417-ad28-0f1812f1a396" />
<img width="598" height="274" alt="image" src="https://github.com/user-attachments/assets/7642e874-2a24-4ce9-8343-422badbe3f5f" />

## Checklist
- [x] I am familiar with the [Contributing Guidelines]().
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
