### PR TITLE
[libcu++] Align sized integer type aliases with the platform

### DIFF
--- a/libcudacxx/include/cuda/std/cstdint
+++ b/libcudacxx/include/cuda/std/cstdint
@@ -28,14 +28,24 @@
 #elif _CCCL_COMPILER(NVRTC)
 #  include <cuda/std/climits>
 
-using int8_t   = signed char;
-using int16_t  = signed short;
-using int32_t  = signed int;
-using int64_t  = signed long long;
+// NVRTC aliases should be aligned with what the platform types.
+
+using int8_t  = signed char;
+using int16_t = signed short;
+using int32_t = signed int;
+#  if defined(__LP64__)
+using int64_t = signed long;
+#  else // ^^^ __LP64__ ^^^ / vvv !__LP64__ vvv
+using int64_t = signed long long;
+#  endif // ^^^ !__LP64__ ^^^
 using uint8_t  = unsigned char;
 using uint16_t = unsigned short;
 using uint32_t = unsigned int;
+#  if defined(__LP64__)
+using uint64_t = unsigned long;
+#  else // ^^^ __LP64__ ^^^ / vvv !__LP64__ vvv
 using uint64_t = unsigned long long;
+#  endif // ^^^ !__LP64__ ^^^
 
 using int_fast8_t   = int8_t;
 using int_fast16_t  = int16_t;


### PR DESCRIPTION
Currently, we just define `[u]int64_t` as an alias to `[un]signed long long` when compiling with NVRTC. That is not ideal, since it doesn't match the platform's type alias and causes mismatch between host-generated signature using `nvrtcGetTypeName` and what is present in the binary.

This PR changes the type alias definition based on the `__LP64__` definition to match the platform's definition.

I'm still unsure what we should do for the `_least` and `_fast` types, since e. g. on my machine they are defined as `[un]signed char` for `[u]int_fast8_t` and `[un]signed long` for other types. Maybe we can document that those shouldn't be used as kernel parameters since their definition can be different on host and device?