### PR TITLE
Override GPU name

### DIFF
--- a/benchmarks/scripts/cccl/bench/bench.py
+++ b/benchmarks/scripts/cccl/bench/bench.py
@@ -274,6 +274,16 @@ def device_json(algname):
     return JsonCache().get_device(algname)
 
 
+CCCL_BENCH_GPU_ENV = "CCCL_BENCH_GPU"
+
+
+def get_gpu_name_override():
+    override = os.environ.get(CCCL_BENCH_GPU_ENV)
+    if override is not None and override.strip():
+        return override.strip()
+    return None
+
+
 def get_device_name(device):
     gpu_name = device["name"]
     bus_width = device["global_memory_bus_width"]
@@ -281,6 +291,13 @@ def get_device_name(device):
     ecc = "eccon" if device["ecc_state"] else "eccoff"
     name = "{} ({}, {}, {})".format(gpu_name, bus_width, sms, ecc)
     return name.replace("NVIDIA ", "")
+
+
+def get_gpu_name(algname):
+    override = get_gpu_name_override()
+    if override is not None:
+        return override
+    return get_device_name(device_json(algname))
 
 
 def is_ct_axis(name):
@@ -374,7 +391,7 @@ class BenchCache:
         config = Config()
         ctk = config.ctk
         cccl = config.cccl
-        gpu = get_device_name(device_json(bench.algname))
+        gpu = get_gpu_name(bench.algname)
         conn = Storage().connection()
 
         self.create_table_if_not_exists(conn, bench)
@@ -424,7 +441,7 @@ class BenchCache:
         config = Config()
         ctk = config.ctk
         cccl = config.cccl
-        gpu = get_device_name(device_json(bench.algname))
+        gpu = get_gpu_name(bench.algname)
         conn = Storage().connection()
 
         self.create_table_if_not_exists(conn, bench)


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl_private/issues/715

<!-- Provide a standalone description of changes in this PR. -->

Sometimes, we have to customize GPU name in performance database. This PR adds an env variable that overrides it:

```bash
CCCL_BENCH_GPU="New name" ../benchmarks/scripts/run.py
``` 

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
