### PR TITLE
[CUB] Refactor `DeviceSelect::Unique` to always take an environment

### DIFF
--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -1492,7 +1492,7 @@ struct DeviceSelect
          OutputIteratorT d_out,
          NumSelectedIteratorT d_num_selected_out,
          ::cuda::std::int64_t num_items,
-         EnvT env = {})
+         const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSelect::Unique");
 
@@ -1593,7 +1593,7 @@ struct DeviceSelect
     NumSelectedIteratorT d_num_selected_out,
     ::cuda::std::int64_t num_items,
     EqualityOpT equality_op,
-    EnvT env = {})
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSelect::Unique");
 
@@ -1671,8 +1671,8 @@ struct DeviceSelect
             typename NumSelectedIteratorT,
             typename EnvT = ::cuda::std::execution::env<>,
             ::cuda::std::enable_if_t<!::cuda::std::indirect_binary_predicate<EnvT, IteratorT, IteratorT>, int> = 0>
-  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
-  Unique(IteratorT d_data, NumSelectedIteratorT d_num_selected_out, ::cuda::std::int64_t num_items, EnvT env = {})
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Unique(
+    IteratorT d_data, NumSelectedIteratorT d_num_selected_out, ::cuda::std::int64_t num_items, const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSelect::Unique");
 
@@ -1766,7 +1766,7 @@ struct DeviceSelect
          NumSelectedIteratorT d_num_selected_out,
          ::cuda::std::int64_t num_items,
          EqualityOpT equality_op,
-         EnvT env = {})
+         const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSelect::Unique");
 
@@ -2083,6 +2083,9 @@ struct DeviceSelect
   //! @tparam EqualityOpT
   //!   **[inferred]** Type of equality_op
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., `cuda::std::execution::env<...>`)
+  //!
   //! @param[in] d_temp_storage
   //!   @devicestorage
   //!
@@ -2105,14 +2108,13 @@ struct DeviceSelect
   //! @param[in] equality_op
   //!   Binary predicate to determine equality
   //!
-  //! @param[in] stream
-  //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
-  //!   @endrst
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   template <typename InputIteratorT,
             typename OutputIteratorT,
             typename NumSelectedIteratorT,
             typename EqualityOpT,
+            typename EnvT                 = ::cuda::std::execution::env<>,
             ::cuda::std::enable_if_t<::cuda::std::indirect_binary_predicate<EqualityOpT, InputIteratorT, InputIteratorT>,
                                      int> = 0>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Unique(
@@ -2123,23 +2125,27 @@ struct DeviceSelect
     NumSelectedIteratorT d_num_selected_out,
     ::cuda::std::int64_t num_items,
     EqualityOpT equality_op,
-    cudaStream_t stream = nullptr)
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSelect::Unique");
 
-    using SelectOpT = NullType; // Selection op (not used)
-
-    return detail::select::dispatch<SelectImpl::Select>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_in,
-      static_cast<NullType*>(nullptr),
-      d_out,
-      d_num_selected_out,
-      SelectOpT{},
-      equality_op,
-      num_items,
-      stream);
+    using default_policy_selector = detail::select::
+      policy_selector_from_types<InputIteratorT, NullType*, OutputIteratorT, ::cuda::std::int64_t, SelectImpl::Select>;
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      d_temp_storage, temp_storage_bytes, env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::select::dispatch<SelectImpl::Select>(
+          storage,
+          bytes,
+          d_in,
+          static_cast<NullType*>(nullptr),
+          d_out,
+          d_num_selected_out,
+          NullType{},
+          equality_op,
+          num_items,
+          stream,
+          policy_selector);
+      });
   }
 
   //! @rst
@@ -2202,6 +2208,9 @@ struct DeviceSelect
   //! @tparam NumSelectedIteratorT
   //!   **[inferred]** Output iterator type for recording the number of items selected @iterator
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., `cuda::std::execution::env<...>`)
+  //!
   //! @param[in] d_temp_storage
   //!   @devicestorage
   //!
@@ -2221,11 +2230,14 @@ struct DeviceSelect
   //! @param[in] num_items
   //!   Total number of input items (i.e., length of `d_in`)
   //!
-  //! @param[in] stream
-  //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
-  //!   @endrst
-  template <typename InputIteratorT, typename OutputIteratorT, typename NumSelectedIteratorT>
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  template <
+    typename InputIteratorT,
+    typename OutputIteratorT,
+    typename NumSelectedIteratorT,
+    typename EnvT = ::cuda::std::execution::env<>,
+    ::cuda::std::enable_if_t<!::cuda::std::indirect_binary_predicate<EnvT, InputIteratorT, InputIteratorT>, int> = 0>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Unique(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -2233,24 +2245,27 @@ struct DeviceSelect
     OutputIteratorT d_out,
     NumSelectedIteratorT d_num_selected_out,
     ::cuda::std::int64_t num_items,
-    cudaStream_t stream = nullptr)
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSelect::Unique");
 
-    using SelectOp   = NullType; // Selection op (not used)
-    using EqualityOp = ::cuda::std::equal_to<>; // Default == operator
-
-    return detail::select::dispatch<SelectImpl::Select>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_in,
-      static_cast<NullType*>(nullptr),
-      d_out,
-      d_num_selected_out,
-      SelectOp{},
-      EqualityOp{},
-      num_items,
-      stream);
+    using default_policy_selector = detail::select::
+      policy_selector_from_types<InputIteratorT, NullType*, OutputIteratorT, ::cuda::std::int64_t, SelectImpl::Select>;
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      d_temp_storage, temp_storage_bytes, env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::select::dispatch<SelectImpl::Select>(
+          storage,
+          bytes,
+          d_in,
+          static_cast<NullType*>(nullptr),
+          d_out,
+          d_num_selected_out,
+          NullType{},
+          ::cuda::std::equal_to<>{},
+          num_items,
+          stream,
+          policy_selector);
+      });
   }
 
   //! @rst
@@ -2284,6 +2299,9 @@ struct DeviceSelect
   //! @tparam NumSelectedIteratorT
   //!   **[inferred]** Output iterator type for recording the number of items selected @iterator
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., `cuda::std::execution::env<...>`)
+  //!
   //! @param[in] d_temp_storage
   //!   @devicestorage
   //!
@@ -2299,36 +2317,43 @@ struct DeviceSelect
   //! @param[in] num_items
   //!   Total number of input items (i.e., length of `d_data`)
   //!
-  //! @param[in] stream
-  //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
-  //!   @endrst
-  template <typename IteratorT, typename NumSelectedIteratorT>
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  template <typename IteratorT,
+            typename NumSelectedIteratorT,
+            typename EnvT = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<!::cuda::std::indirect_binary_predicate<EnvT, IteratorT, IteratorT>, int> = 0>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Unique(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     IteratorT d_data,
     NumSelectedIteratorT d_num_selected_out,
     ::cuda::std::int64_t num_items,
-    cudaStream_t stream = nullptr)
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSelect::Unique");
 
-    using OffsetT    = ::cuda::std::int64_t;
-    using SelectOp   = NullType; // Selection op (not used)
-    using EqualityOp = ::cuda::std::equal_to<>; // Default == operator
-
-    return detail::select::dispatch<SelectImpl::SelectPotentiallyInPlace>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_data,
-      static_cast<NullType*>(nullptr),
-      d_data,
-      d_num_selected_out,
-      SelectOp{},
-      EqualityOp{},
-      static_cast<OffsetT>(num_items),
-      stream);
+    using default_policy_selector = detail::select::policy_selector_from_types<
+      IteratorT,
+      NullType*,
+      IteratorT,
+      ::cuda::std::int64_t,
+      SelectImpl::SelectPotentiallyInPlace>;
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      d_temp_storage, temp_storage_bytes, env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::select::dispatch<SelectImpl::SelectPotentiallyInPlace>(
+          storage,
+          bytes,
+          d_data,
+          static_cast<NullType*>(nullptr),
+          d_data,
+          d_num_selected_out,
+          NullType{},
+          ::cuda::std::equal_to<>{},
+          num_items,
+          stream,
+          policy_selector);
+      });
   }
 
   //! @rst
@@ -2371,6 +2396,9 @@ struct DeviceSelect
   //! @tparam EqualityOpT
   //!   **[inferred]** Type of equality_op
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., `cuda::std::execution::env<...>`)
+  //!
   //! @param[in] d_temp_storage
   //!   @devicestorage
   //!
@@ -2389,13 +2417,12 @@ struct DeviceSelect
   //! @param[in] equality_op
   //!   Binary predicate to determine equality
   //!
-  //! @param[in] stream
-  //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
-  //!   @endrst
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   template <typename IteratorT,
             typename NumSelectedIteratorT,
             typename EqualityOpT,
+            typename EnvT = ::cuda::std::execution::env<>,
             ::cuda::std::enable_if_t<::cuda::std::indirect_binary_predicate<EqualityOpT, IteratorT, IteratorT>, int> = 0>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Unique(
     void* d_temp_storage,
@@ -2404,24 +2431,31 @@ struct DeviceSelect
     NumSelectedIteratorT d_num_selected_out,
     ::cuda::std::int64_t num_items,
     EqualityOpT equality_op,
-    cudaStream_t stream = nullptr)
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSelect::Unique");
 
-    using OffsetT   = ::cuda::std::int64_t;
-    using SelectOpT = NullType; // Selection op (not used)
-
-    return detail::select::dispatch<SelectImpl::SelectPotentiallyInPlace>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_data,
-      static_cast<NullType*>(nullptr),
-      d_data,
-      d_num_selected_out,
-      SelectOpT{},
-      equality_op,
-      static_cast<OffsetT>(num_items),
-      stream);
+    using default_policy_selector = detail::select::policy_selector_from_types<
+      IteratorT,
+      NullType*,
+      IteratorT,
+      ::cuda::std::int64_t,
+      SelectImpl::SelectPotentiallyInPlace>;
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      d_temp_storage, temp_storage_bytes, env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::select::dispatch<SelectImpl::SelectPotentiallyInPlace>(
+          storage,
+          bytes,
+          d_data,
+          static_cast<NullType*>(nullptr),
+          d_data,
+          d_num_selected_out,
+          NullType{},
+          equality_op,
+          num_items,
+          stream,
+          policy_selector);
+      });
   }
 
   //! @rst

--- a/cub/test/catch2_test_device_select_unique.cu
+++ b/cub/test/catch2_test_device_select_unique.cu
@@ -6,7 +6,9 @@
 #include <cub/device/device_select.cuh>
 
 #include <cuda/cmath>
+#include <cuda/devices>
 #include <cuda/iterator>
+#include <cuda/std/execution>
 #include <cuda/stream>
 
 #include <algorithm>
@@ -189,6 +191,118 @@ C2H_TEST("DeviceSelect::Unique does not change input", "[device][select_unique]"
   // test overload with predicate
   select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items, fake_equal_to{});
   REQUIRE(reference == in);
+}
+
+C2H_TEST("DeviceSelect::Unique works with user provided memory and environments", "[device][select_unique]", types)
+{
+  using type = typename c2h::get<0, TestType>;
+
+  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
+  c2h::device_vector<type> in(num_items);
+  c2h::device_vector<type> out(num_items);
+  c2h::gen(C2H_SEED(2), in, to_bound<type>(0), to_bound<type>(42));
+
+  // Needs to be device accessible
+  c2h::device_vector<int> num_selected_out(1, 0);
+  int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
+
+  // Ensure that we create the same output as std
+  c2h::host_vector<type> reference = in;
+  const auto boundary              = std::unique(reference.begin(), reference.end());
+  const auto num_selected_std      = cuda::std::distance(reference.begin(), boundary);
+
+  size_t expected_allocation_size = 0;
+  auto error                      = cub::DeviceSelect::Unique(
+    static_cast<void*>(nullptr), expected_allocation_size, in.begin(), out.begin(), d_first_num_selected_out, num_items);
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  auto d_temp        = c2h::device_vector<uint8_t>(expected_allocation_size, thrust::no_init);
+  void* temp_storage = thrust::raw_pointer_cast(d_temp.data());
+
+  auto test_unique = [&](const auto& env) {
+    { // test overload without predicate
+      size_t num_bytes = 0;
+      error            = cub::DeviceSelect::Unique(
+        static_cast<void*>(nullptr), num_bytes, in.begin(), out.begin(), d_first_num_selected_out, num_items, env);
+      REQUIRE(error == cudaSuccess);
+      REQUIRE(cudaSuccess == cudaPeekAtLastError());
+      REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+      REQUIRE(expected_allocation_size == num_bytes);
+
+      error = cub::DeviceSelect::Unique(
+        temp_storage, num_bytes, in.begin(), out.begin(), d_first_num_selected_out, num_items, env);
+      REQUIRE(error == cudaSuccess);
+      REQUIRE(cudaSuccess == cudaPeekAtLastError());
+      REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+      out.resize(num_selected_out[0]);
+      reference.resize(num_selected_out[0]);
+      REQUIRE(reference == out);
+    }
+
+    { // test overload without predicate
+      size_t num_bytes = 0;
+      error            = cub::DeviceSelect::Unique(
+        static_cast<void*>(nullptr),
+        num_bytes,
+        in.begin(),
+        out.begin(),
+        d_first_num_selected_out,
+        num_items,
+        fake_equal_to{},
+        env);
+      REQUIRE(error == cudaSuccess);
+      REQUIRE(cudaSuccess == cudaPeekAtLastError());
+      REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+      REQUIRE(expected_allocation_size == num_bytes);
+
+      error = cub::DeviceSelect::Unique(
+        temp_storage, num_bytes, in.begin(), out.begin(), d_first_num_selected_out, num_items, fake_equal_to{}, env);
+      REQUIRE(error == cudaSuccess);
+      REQUIRE(cudaSuccess == cudaPeekAtLastError());
+      REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+      REQUIRE(reference == out);
+    }
+  };
+
+  SECTION("DeviceSelect::Unique works with cudaStream_t")
+  {
+    cuda::stream stream{cuda::devices[0]};
+    test_unique(stream.get());
+  }
+
+  SECTION("DeviceSelect::Unique works with cuda::stream")
+  {
+    cuda::stream stream{cuda::devices[0]};
+    test_unique(stream);
+  }
+
+  SECTION("DeviceSelect::Unique works with cuda::stream_ref")
+  {
+    cuda::stream stream{cuda::devices[0]};
+    cuda::stream_ref stream_ref{stream};
+    test_unique(stream_ref);
+  }
+
+  SECTION("DeviceSelect::Unique works with cuda::std::execution::env")
+  {
+    cuda::std::execution::env env{};
+    test_unique(env);
+  }
+
+  SECTION("DeviceSelect::Unique works with cuda::execution::gpu")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_unique(policy);
+  }
+
+  SECTION("DeviceSelect::Unique works with cuda::execution::gpu with stream")
+  {
+    cuda::stream stream{cuda::devices[0]};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_unique(policy);
+  }
 }
 
 C2H_TEST("DeviceSelect::Unique works with iterators", "[device][select_unique]", all_types)

--- a/cub/test/catch2_test_device_select_unique.cu
+++ b/cub/test/catch2_test_device_select_unique.cu
@@ -236,12 +236,14 @@ C2H_TEST("DeviceSelect::Unique works with user provided memory and environments"
       REQUIRE(error == cudaSuccess);
       REQUIRE(cudaSuccess == cudaPeekAtLastError());
       REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+      REQUIRE(num_selected_std == num_selected_out[0]);
       out.resize(num_selected_out[0]);
       reference.resize(num_selected_out[0]);
       REQUIRE(reference == out);
     }
 
-    { // test overload without predicate
+    { // test overload with predicate
       size_t num_bytes = 0;
       error            = cub::DeviceSelect::Unique(
         static_cast<void*>(nullptr),
@@ -262,25 +264,33 @@ C2H_TEST("DeviceSelect::Unique works with user provided memory and environments"
       REQUIRE(error == cudaSuccess);
       REQUIRE(cudaSuccess == cudaPeekAtLastError());
       REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+      REQUIRE(num_selected_std == num_selected_out[0]);
+      out.resize(num_selected_out[0]);
+      reference.resize(num_selected_out[0]);
       REQUIRE(reference == out);
     }
   };
 
+  int current_device;
+  error = cudaGetDevice(&current_device);
+  REQUIRE(error == cudaSuccess);
+
   SECTION("DeviceSelect::Unique works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[0]};
+    cuda::stream stream{cuda::devices[current_device]};
     test_unique(stream.get());
   }
 
   SECTION("DeviceSelect::Unique works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[0]};
+    cuda::stream stream{cuda::devices[current_device]};
     test_unique(stream);
   }
 
   SECTION("DeviceSelect::Unique works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[0]};
+    cuda::stream stream{cuda::devices[current_device]};
     cuda::stream_ref stream_ref{stream};
     test_unique(stream_ref);
   }
@@ -299,7 +309,7 @@ C2H_TEST("DeviceSelect::Unique works with user provided memory and environments"
 
   SECTION("DeviceSelect::Unique works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[0]};
+    cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_unique(policy);
   }

--- a/libcudacxx/include/cuda/std/__pstl/cuda/unique_copy.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/unique_copy.h
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_STD___PSTL_CUDA_UNIQUE_H
-#define _CUDA_STD___PSTL_CUDA_UNIQUE_H
+#ifndef _CUDA_STD___PSTL_CUDA_UNIQUE_COPY_H
+#define _CUDA_STD___PSTL_CUDA_UNIQUE_COPY_H
 
 #include <cuda/std/detail/__config>
 
@@ -62,11 +62,15 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
 template <>
-struct __pstl_dispatch<__pstl_algorithm::__unique, __execution_backend::__cuda>
+struct __pstl_dispatch<__pstl_algorithm::__unique_copy, __execution_backend::__cuda>
 {
-  template <class _Policy, class _InputIterator, class _BinaryPredicate>
-  [[nodiscard]] _CCCL_HOST_API static _InputIterator
-  __par_impl(const _Policy& __policy, _InputIterator __first, _InputIterator __last, _BinaryPredicate __pred)
+  template <class _Policy, class _InputIterator, class _OutputIterator, class _BinaryPredicate>
+  [[nodiscard]] _CCCL_HOST_API static _OutputIterator __par_impl(
+    const _Policy& __policy,
+    _InputIterator __first,
+    _InputIterator __last,
+    _OutputIterator __result,
+    _BinaryPredicate __pred)
   {
     const auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
     const auto __ctx    = ::cuda::std::execution::__pstl_ensure_current_ctx_for(__policy);
@@ -82,6 +86,7 @@ struct __pstl_dispatch<__pstl_algorithm::__unique, __execution_backend::__cuda>
       static_cast<void*>(nullptr),
       __num_bytes,
       __first,
+      __result,
       static_cast<_OffsetType*>(nullptr),
       __count,
       __pred,
@@ -95,7 +100,8 @@ struct __pstl_dispatch<__pstl_algorithm::__unique, __execution_backend::__cuda>
         "__pstl_cuda_unique: kernel launch of cub::DeviceSelect::Unique failed",
         __storage.__get_temp_storage(),
         __num_bytes,
-        __first,
+        ::cuda::std::move(__first),
+        __result,
         __storage.template __get_raw_ptr<0>(),
         __count,
         ::cuda::std::move(__pred),
@@ -112,22 +118,29 @@ struct __pstl_dispatch<__pstl_algorithm::__unique, __execution_backend::__cuda>
     }
 
     __stream.sync();
-    return __first + __num_selected;
+    return __result + static_cast<iter_difference_t<_OutputIterator>>(__num_selected);
   }
 
-  _CCCL_TEMPLATE(class _Policy, class _InputIterator, class _BinaryPredicate)
-  _CCCL_REQUIRES(__has_forward_traversal<_InputIterator>)
-  [[nodiscard]] _CCCL_HOST_API _InputIterator operator()(
+  _CCCL_TEMPLATE(class _Policy, class _InputIterator, class _OutputIterator, class _BinaryPredicate)
+  _CCCL_REQUIRES(__has_forward_traversal<_OutputIterator>)
+  [[nodiscard]] _CCCL_HOST_API _OutputIterator operator()(
     [[maybe_unused]] const _Policy& __policy,
     _InputIterator __first,
     _InputIterator __last,
+    _OutputIterator __result,
     _BinaryPredicate __pred) const
   {
-    if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>)
+    if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>
+                  && ::cuda::std::__has_random_access_traversal<_OutputIterator>)
     {
       _CCCL_TRY
       {
-        return __par_impl(__policy, __first, ::cuda::std::move(__last), ::cuda::std::move(__pred));
+        return __par_impl(
+          __policy,
+          ::cuda::std::move(__first),
+          ::cuda::std::move(__last),
+          ::cuda::std::move(__result),
+          ::cuda::std::move(__pred));
       }
       _CCCL_CATCH (const ::cuda::cuda_error& __err)
       {
@@ -145,8 +158,10 @@ struct __pstl_dispatch<__pstl_algorithm::__unique, __execution_backend::__cuda>
     else
     {
       static_assert(__always_false_v<_Policy>,
-                    "__pstl_dispatch: CUDA backend of cuda::std::unique requires at least random access iterators");
-      return ::cuda::std::unique(::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
+                    "__pstl_dispatch: CUDA backend of cuda::std::unique_copy requires at least random access "
+                    "iterators");
+      return ::cuda::std::unique_copy(
+        ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__result), ::cuda::std::move(__pred));
     }
   }
 };
@@ -159,4 +174,4 @@ _CCCL_END_NAMESPACE_CUDA_STD_EXECUTION
 
 #endif // _CCCL_HAS_BACKEND_CUDA()
 
-#endif // _CUDA_STD___PSTL_CUDA_UNIQUE_H
+#endif // _CUDA_STD___PSTL_CUDA_UNIQUE_COPY_H

--- a/libcudacxx/include/cuda/std/__pstl/dispatch.h
+++ b/libcudacxx/include/cuda/std/__pstl/dispatch.h
@@ -56,6 +56,7 @@ enum class __pstl_algorithm
   __transform,
   __transform_reduce,
   __unique,
+  __unique_copy,
 };
 
 //! @brief tag type to indicate that we cannot dispatch to a parallel algorithm and should run the algorithm serially

--- a/libcudacxx/include/cuda/std/__pstl/unique_copy.h
+++ b/libcudacxx/include/cuda/std/__pstl/unique_copy.h
@@ -41,7 +41,7 @@
 #  include <cuda/std/tuple>
 
 #  if _CCCL_HAS_BACKEND_CUDA()
-#    include <cuda/std/__pstl/cuda/unique.h>
+#    include <cuda/std/__pstl/cuda/unique_copy.h>
 #  endif // _CCCL_HAS_BACKEND_CUDA()
 
 #  include <cuda/std/__cccl/prologue.h>
@@ -68,7 +68,7 @@ _CCCL_HOST_API _OutputIterator unique_copy(
                 "indirect_binary_predicate<BinaryPredicate, InputIterator, InputIterator>");
 
   [[maybe_unused]] auto __dispatch =
-    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__unique, _Policy>();
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__unique_copy, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::unique_copy");


### PR DESCRIPTION
This refactors `cub::DeviceSelect::Unique` to always take an environment instead of just a stream.

With that we can take advantage of tunings even for those overloads.

We also refactor the PSTL algorithms that use this API to always pass the policy so a user can tune them

- [ ] Merge before: #9318 