### PR TITLE
[CUB] Refactor `DeviceSelect::Flagged` to always take an environment

### DIFF
--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -139,6 +139,9 @@ struct DeviceSelect
   //! @tparam NumSelectedIteratorT
   //!   **[inferred]** Output iterator type for recording the number of items selected @iterator
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., `cuda::std::execution::env<...>`)
+  //!
   //! @param[in] d_temp_storage
   //!   @devicestorage
   //!
@@ -160,14 +163,13 @@ struct DeviceSelect
   //! @param[in] num_items
   //!   Total number of input items (i.e., length of `d_in`)
   //!
-  //! @param[in] stream
-  //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
-  //!   @endrst
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   template <typename InputIteratorT,
             typename FlagIterator,
             typename OutputIteratorT,
             typename NumSelectedIteratorT,
+            typename EnvT = ::cuda::std::execution::env<>,
             ::cuda::std::enable_if_t<!::cuda::std::is_integral_v<NumSelectedIteratorT>, int> = 0>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Flagged(
     void* d_temp_storage,
@@ -177,24 +179,27 @@ struct DeviceSelect
     OutputIteratorT d_out,
     NumSelectedIteratorT d_num_selected_out,
     ::cuda::std::int64_t num_items,
-    cudaStream_t stream = nullptr)
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSelect::Flagged");
 
-    using SelectOp   = NullType; // Selection op (not used)
-    using EqualityOp = NullType; // Equality operator (not used)
-
-    return detail::select::dispatch<SelectImpl::Select>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_in,
-      d_flags,
-      d_out,
-      d_num_selected_out,
-      SelectOp{},
-      EqualityOp{},
-      num_items,
-      stream);
+    using default_policy_selector = detail::select::
+      policy_selector_from_types<InputIteratorT, FlagIterator, OutputIteratorT, ::cuda::std::int64_t, SelectImpl::Select>;
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      d_temp_storage, temp_storage_bytes, env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::select::dispatch<SelectImpl::Select>(
+          storage,
+          bytes,
+          d_in,
+          d_flags,
+          d_out,
+          d_num_selected_out,
+          NullType{},
+          NullType{},
+          num_items,
+          stream,
+          policy_selector);
+      });
   }
 
   //! @rst
@@ -272,7 +277,7 @@ struct DeviceSelect
     OutputIteratorT d_out,
     NumSelectedIteratorT d_num_selected_out,
     ::cuda::std::int64_t num_items,
-    EnvT env = {})
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSelect::Flagged");
 
@@ -362,7 +367,7 @@ struct DeviceSelect
           FlagIterator d_flags,
           NumSelectedIteratorT d_num_selected_out,
           ::cuda::std::int64_t num_items,
-          EnvT env = {})
+          const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSelect::Flagged");
 
@@ -639,6 +644,9 @@ struct DeviceSelect
   //! @tparam NumSelectedIteratorT
   //!   **[inferred]** Output iterator type for recording the number of items selected @iterator
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., `cuda::std::execution::env<...>`)
+  //!
   //! @param[in] d_temp_storage
   //!   @devicestorage
   //!
@@ -657,11 +665,12 @@ struct DeviceSelect
   //! @param[in] num_items
   //!   Total number of input items (i.e., length of `d_data`)
   //!
-  //! @param[in] stream
-  //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
-  //!   @endrst
-  template <typename IteratorT, typename FlagIterator, typename NumSelectedIteratorT>
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  template <typename IteratorT,
+            typename FlagIterator,
+            typename NumSelectedIteratorT,
+            typename EnvT = ::cuda::std::execution::env<>>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Flagged(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -669,24 +678,31 @@ struct DeviceSelect
     FlagIterator d_flags,
     NumSelectedIteratorT d_num_selected_out,
     ::cuda::std::int64_t num_items,
-    cudaStream_t stream = nullptr)
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSelect::Flagged");
 
-    using SelectOp   = NullType; // Selection op (not used)
-    using EqualityOp = NullType; // Equality operator (not used)
-
-    return detail::select::dispatch<SelectImpl::SelectPotentiallyInPlace>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_data,
-      d_flags,
-      d_data,
-      d_num_selected_out,
-      SelectOp{},
-      EqualityOp{},
-      num_items,
-      stream);
+    using default_policy_selector = detail::select::policy_selector_from_types<
+      IteratorT,
+      FlagIterator,
+      IteratorT,
+      ::cuda::std::int64_t,
+      SelectImpl::SelectPotentiallyInPlace>;
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      d_temp_storage, temp_storage_bytes, env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::select::dispatch<SelectImpl::SelectPotentiallyInPlace>(
+          storage,
+          bytes,
+          d_data,
+          d_flags,
+          d_data,
+          d_num_selected_out,
+          NullType{},
+          NullType{},
+          num_items,
+          stream,
+          policy_selector);
+      });
   }
 
   //! @rst

--- a/cub/test/catch2_test_device_select_flagged.cu
+++ b/cub/test/catch2_test_device_select_flagged.cu
@@ -9,7 +9,9 @@
 #include <thrust/partition.h>
 #include <thrust/reverse.h>
 
+#include <cuda/devices>
 #include <cuda/iterator>
+#include <cuda/std/execution>
 
 #include <algorithm>
 
@@ -191,6 +193,103 @@ C2H_TEST("DeviceSelect::Flagged is stable",
   out.resize(num_selected_out[0]);
   REQUIRE(num_selected == num_selected_out[0]);
   REQUIRE(reference == out);
+}
+
+C2H_TEST("DeviceSelect::Flagged works with user provided memory and environment", "[device][select_flagged]", all_types)
+{
+  using type = typename c2h::get<0, TestType>;
+
+  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
+  c2h::device_vector<type> in(num_items);
+  c2h::device_vector<type> out(num_items);
+  c2h::gen(C2H_SEED(2), in);
+
+  c2h::device_vector<int> flags(num_items);
+  c2h::gen(C2H_SEED(1), flags, 0, 1);
+  const int num_selected = static_cast<int>(thrust::count(c2h::device_policy, flags.begin(), flags.end(), 1));
+  const c2h::host_vector<type> reference = get_reference(in, flags);
+
+  // Needs to be device accessible
+  c2h::device_vector<int> num_selected_out(1, 0);
+  int* d_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
+
+  size_t expected_allocation_size = 0;
+  auto error                      = cub::DeviceSelect::Flagged(
+    static_cast<void*>(nullptr),
+    expected_allocation_size,
+    in.data(),
+    flags.begin(),
+    out.data(),
+    d_num_selected_out,
+    num_items);
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  auto d_temp        = c2h::device_vector<uint8_t>(expected_allocation_size, thrust::no_init);
+  void* temp_storage = thrust::raw_pointer_cast(d_temp.data());
+
+  auto test_flagged = [&](const auto& env) {
+    size_t num_bytes = 0;
+    error            = cub::DeviceSelect::Flagged(
+      static_cast<void*>(nullptr), num_bytes, in.data(), flags.begin(), out.data(), d_num_selected_out, num_items, env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+    REQUIRE(expected_allocation_size == num_bytes);
+
+    error = cub::DeviceSelect::Flagged(
+      temp_storage, num_bytes, in.data(), flags.begin(), out.data(), d_num_selected_out, num_items, env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    out.resize(num_selected_out[0]);
+    REQUIRE(num_selected == num_selected_out[0]);
+    REQUIRE(reference == out);
+  };
+
+  int current_device;
+  error = cudaGetDevice(&current_device);
+  REQUIRE(error == cudaSuccess);
+
+  SECTION("DeviceSelect::Flagged works with cudaStream_t")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_flagged(stream.get());
+  }
+
+  SECTION("DeviceSelect::Flagged works with cuda::stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_flagged(stream);
+  }
+
+  SECTION("DeviceSelect::Flagged works with cuda::stream_ref")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    cuda::stream_ref stream_ref{stream};
+    test_flagged(stream_ref);
+  }
+
+  SECTION("DeviceSelect::Flagged works with cuda::std::execution::env")
+  {
+    cuda::std::execution::env env{};
+    test_flagged(env);
+  }
+
+  SECTION("DeviceSelect::Flagged works with cuda::execution::gpu")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_flagged(policy);
+  }
+
+  SECTION("DeviceSelect::Flagged works with cuda::execution::gpu with stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_flagged(policy);
+  }
 }
 
 C2H_TEST("DeviceSelect::Flagged works with iterators", "[device][select_flagged]", all_types)

--- a/libcudacxx/include/cuda/std/__pstl/cuda/shift_left.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/shift_left.h
@@ -99,7 +99,7 @@ struct __pstl_dispatch<__pstl_algorithm::__shift_left, __execution_backend::__cu
       __flag_iter,
       static_cast<_OffsetType*>(nullptr),
       __count,
-      __stream.get());
+      __policy);
 
     {
       __temporary_storage<_OffsetType> __storage{__policy, __num_bytes, 1};
@@ -112,9 +112,9 @@ struct __pstl_dispatch<__pstl_algorithm::__shift_left, __execution_backend::__cu
         __num_bytes,
         ::cuda::std::move(__first),
         ::cuda::std::move(__flag_iter),
-        __storage.template __get_ptr<0>(),
+        __storage.template __get_raw_ptr<0>(),
         __count,
-        __stream.get());
+        __policy);
     }
 
     __stream.sync();


### PR DESCRIPTION
We want to be able to pass tunings to the APIs that take user provided memory.

Also use the new overload for PSTL shift_left

- [x] Merge after #9318