### PR TITLE
[CUB] Refactor `DeviceSelect::FlaggedIf` to always take an environment

### DIFF
--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -1027,6 +1027,9 @@ struct DeviceSelect
   //! @tparam SelectOp
   //!   **[inferred]** Selection operator type having member `bool operator()(const T &a)`
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., `cuda::std::execution::env<...>`)
+  //!
   //! @param[in] d_temp_storage
   //!   @devicestorage
   //!
@@ -1052,15 +1055,14 @@ struct DeviceSelect
   //! @param[in] select_op
   //!   Unary selection operator
   //!
-  //! @param[in] stream
-  //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
-  //!   @endrst
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   template <typename InputIteratorT,
             typename FlagIterator,
             typename OutputIteratorT,
             typename NumSelectedIteratorT,
-            typename SelectOp>
+            typename SelectOp,
+            typename EnvT = ::cuda::std::execution::env<>>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t FlaggedIf(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -1070,23 +1072,27 @@ struct DeviceSelect
     NumSelectedIteratorT d_num_selected_out,
     ::cuda::std::int64_t num_items,
     SelectOp select_op,
-    cudaStream_t stream = nullptr)
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSelect::FlaggedIf");
 
-    using EqualityOp = NullType; // Equality operator (not used)
-
-    return detail::select::dispatch<SelectImpl::Select>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_in,
-      d_flags,
-      d_out,
-      d_num_selected_out,
-      select_op,
-      EqualityOp{},
-      num_items,
-      stream);
+    using default_policy_selector = detail::select::
+      policy_selector_from_types<InputIteratorT, FlagIterator, OutputIteratorT, ::cuda::std::int64_t, SelectImpl::Select>;
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      d_temp_storage, temp_storage_bytes, env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::select::dispatch<SelectImpl::Select>(
+          storage,
+          bytes,
+          d_in,
+          d_flags,
+          d_out,
+          d_num_selected_out,
+          select_op,
+          NullType{},
+          num_items,
+          stream,
+          policy_selector);
+      });
   }
 
   //! @rst
@@ -1135,6 +1141,9 @@ struct DeviceSelect
   //! @tparam SelectOp
   //!   **[inferred]** Selection operator type having member `bool operator()(const T &a)`
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., `cuda::std::execution::env<...>`)
+  //!
   //! @param[in] d_temp_storage
   //!   @devicestorage
   //!
@@ -1156,11 +1165,13 @@ struct DeviceSelect
   //! @param[in] select_op
   //!   Unary selection operator
   //!
-  //! @param[in] stream
-  //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
-  //!   @endrst
-  template <typename IteratorT, typename FlagIterator, typename NumSelectedIteratorT, typename SelectOp>
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  template <typename IteratorT,
+            typename FlagIterator,
+            typename NumSelectedIteratorT,
+            typename SelectOp,
+            typename EnvT = ::cuda::std::execution::env<>>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t FlaggedIf(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -1169,23 +1180,31 @@ struct DeviceSelect
     NumSelectedIteratorT d_num_selected_out,
     ::cuda::std::int64_t num_items,
     SelectOp select_op,
-    cudaStream_t stream = nullptr)
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSelect::FlaggedIf");
 
-    using EqualityOp = NullType; // Equality operator (not used)
-
-    return detail::select::dispatch<SelectImpl::SelectPotentiallyInPlace>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_data,
-      d_flags,
-      d_data,
-      d_num_selected_out,
-      select_op,
-      EqualityOp{},
-      num_items,
-      stream);
+    using default_policy_selector = detail::select::policy_selector_from_types<
+      IteratorT,
+      FlagIterator,
+      IteratorT,
+      ::cuda::std::int64_t,
+      SelectImpl::SelectPotentiallyInPlace>;
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      d_temp_storage, temp_storage_bytes, env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::select::dispatch<SelectImpl::SelectPotentiallyInPlace>(
+          storage,
+          bytes,
+          d_data,
+          d_flags,
+          d_data,
+          d_num_selected_out,
+          select_op,
+          NullType{},
+          num_items,
+          stream,
+          policy_selector);
+      });
   }
 
   //! @rst
@@ -1275,7 +1294,7 @@ struct DeviceSelect
     NumSelectedIteratorT d_num_selected_out,
     ::cuda::std::int64_t num_items,
     SelectOp select_op,
-    EnvT env = {})
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSelect::FlaggedIf");
 
@@ -1375,7 +1394,7 @@ struct DeviceSelect
     NumSelectedIteratorT d_num_selected_out,
     ::cuda::std::int64_t num_items,
     SelectOp select_op,
-    EnvT env = {})
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSelect::FlaggedIf");
 

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -9,7 +9,9 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/logical.h>
 
-#include <cuda/functional>
+#include <cuda/devices>
+#include <cuda/iterator>
+#include <cuda/std/execution>
 
 #include <algorithm>
 
@@ -199,6 +201,118 @@ C2H_TEST("DeviceSelect::FlaggedIf does not change input and is stable",
 
   out.resize(num_selected_out[0]);
   REQUIRE(reference_out == out);
+}
+
+C2H_TEST("DeviceSelect::FlaggedIf works with user provided memory and environment",
+         "[device][select_if]",
+         all_types,
+         flag_types)
+{
+  using input_type = typename c2h::get<0, TestType>;
+  using flag_type  = typename c2h::get<1, TestType>;
+
+  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
+  c2h::device_vector<input_type> in(num_items);
+  c2h::device_vector<input_type> out(num_items);
+  c2h::gen(C2H_SEED(2), in);
+
+  is_even_t<flag_type> is_even{};
+
+  c2h::device_vector<flag_type> flags(num_items);
+  c2h::gen(C2H_SEED(1), flags);
+  const c2h::host_vector<input_type> reference = get_reference(in, flags, is_even);
+  const int num_selected                       = static_cast<int>(reference.size());
+
+  // Needs to be device accessible
+  c2h::device_vector<int> num_selected_out(1, 0);
+  int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
+
+  size_t expected_allocation_size = 0;
+  auto error                      = cub::DeviceSelect::FlaggedIf(
+    static_cast<void*>(nullptr),
+    expected_allocation_size,
+    in.begin(),
+    flags.begin(),
+    out.begin(),
+    d_first_num_selected_out,
+    num_items,
+    is_even);
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  auto d_temp        = c2h::device_vector<uint8_t>(expected_allocation_size, thrust::no_init);
+  void* temp_storage = thrust::raw_pointer_cast(d_temp.data());
+
+  auto test_flagged_if = [&, num_selected](const auto& env) { // Avoid GCC-7 ICE when taking num_selected by reference
+    size_t num_bytes = 0;
+    error            = cub::DeviceSelect::FlaggedIf(
+      static_cast<void*>(nullptr),
+      num_bytes,
+      in.begin(),
+      flags.begin(),
+      out.begin(),
+      d_first_num_selected_out,
+      num_items,
+      is_even,
+      env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+    REQUIRE(expected_allocation_size == num_bytes);
+
+    error = cub::DeviceSelect::FlaggedIf(
+      temp_storage, num_bytes, in.begin(), flags.begin(), out.begin(), d_first_num_selected_out, num_items, is_even, env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    out.resize(num_selected_out[0]);
+    REQUIRE(num_selected == num_selected_out[0]);
+    REQUIRE(reference == out);
+  };
+
+  int current_device;
+  error = cudaGetDevice(&current_device);
+  REQUIRE(error == cudaSuccess);
+
+  SECTION("DeviceSelect::FlaggedIf works with cudaStream_t")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_flagged_if(stream.get());
+  }
+
+  SECTION("DeviceSelect::FlaggedIf works with cuda::stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_flagged_if(stream);
+  }
+
+  SECTION("DeviceSelect::FlaggedIf works with cuda::stream_ref")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    cuda::stream_ref stream_ref{stream};
+    test_flagged_if(stream_ref);
+  }
+
+  SECTION("DeviceSelect::FlaggedIf works with cuda::std::execution::env")
+  {
+    cuda::std::execution::env env{};
+    test_flagged_if(env);
+  }
+
+  SECTION("DeviceSelect::FlaggedIf works with cuda::execution::gpu")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_flagged_if(policy);
+  }
+
+  SECTION("DeviceSelect::FlaggedIf works with cuda::execution::gpu with stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_flagged_if(policy);
+  }
 }
 
 C2H_TEST("DeviceSelect::FlaggedIf works with iterators", "[device][select_if]", all_types, flag_types)


### PR DESCRIPTION
We want to be able to pass tunings to the APIs that take user provided memory

Make sure we can pass any environment or stream type to them

- [ ] Merge after #9318