### PR TITLE
[cudax][STF] Auto-free graph allocations on launch

### DIFF
--- a/cudax/include/cuda/experimental/__stf/graph/graph_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/graph_ctx.cuh
@@ -610,7 +610,7 @@ private:
 
     ::std::shared_ptr<cudaGraphExec_t> res(new cudaGraphExec_t, cudaGraphExecDeleter);
 
-    cuda_try(cudaGraphInstantiateWithFlags(res.get(), g, cudaGraphInstantiateFlagAutoFreeOnLaunch));
+    cuda_try<cudaGraphInstantiateWithFlags>(res.get(), g, cudaGraphInstantiateFlagAutoFreeOnLaunch);
 
     return res;
   }

--- a/cudax/include/cuda/experimental/__stf/graph/graph_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/graph_ctx.cuh
@@ -610,7 +610,7 @@ private:
 
     ::std::shared_ptr<cudaGraphExec_t> res(new cudaGraphExec_t, cudaGraphExecDeleter);
 
-    cuda_try(cudaGraphInstantiateWithFlags(res.get(), g, 0));
+    cuda_try(cudaGraphInstantiateWithFlags(res.get(), g, cudaGraphInstantiateFlagAutoFreeOnLaunch));
 
     return res;
   }

--- a/cudax/include/cuda/experimental/__stf/internal/algorithm.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/algorithm.cuh
@@ -285,7 +285,7 @@ public:
 
       dump_algorithm(gctx_graph);
 
-      *eg = cuda_try<cudaGraphInstantiateWithFlags>(*gctx_graph, 0);
+      *eg = cuda_try<cudaGraphInstantiateWithFlags>(*gctx_graph, cudaGraphInstantiateFlagAutoFreeOnLaunch);
 
       cached_exec_graphs[stream].push_back(eg);
     }
@@ -341,7 +341,7 @@ public:
 
       dump_algorithm(gctx_graph);
 
-      *eg = cuda_try<cudaGraphInstantiateWithFlags>(*gctx_graph, 0);
+      *eg = cuda_try<cudaGraphInstantiateWithFlags>(*gctx_graph, cudaGraphInstantiateFlagAutoFreeOnLaunch);
 
       cached_exec_graphs[stream].push_back(eg);
     }

--- a/cudax/include/cuda/experimental/__stf/internal/executable_graph_cache.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/executable_graph_cache.cuh
@@ -57,7 +57,10 @@ inline ::std::shared_ptr<cudaGraphExec_t> graph_instantiate(cudaGraph_t g)
                                            cuda_safe_call(cudaGraphExecDestroy(*p));
                                          }};
 
-  *res = cuda_try<cudaGraphInstantiateWithFlags>(g, 0);
+  // Automatically free graph-owned async allocations between launches. This
+  // lets graphs containing cudaMallocAsync / cudaMemAllocNode allocations be
+  // relaunched even when the corresponding free is outside the captured graph.
+  *res = cuda_try<cudaGraphInstantiateWithFlags>(g, cudaGraphInstantiateFlagAutoFreeOnLaunch);
 
   return res;
 }


### PR DESCRIPTION
## Summary
- Instantiate cached STF CUDA graphs with `cudaGraphInstantiateFlagAutoFreeOnLaunch`.
- Apply the same flag to the remaining production STF graph instantiation paths in `graph_ctx` and `algorithm`.
- Allows graphs containing async allocation nodes to be relaunched when the corresponding free happens outside the captured graph.

## Test plan
- `pre-commit run --files cudax/include/cuda/experimental/__stf/internal/executable_graph_cache.cuh`
- `pre-commit run --files cudax/include/cuda/experimental/__stf/internal/executable_graph_cache.cuh cudax/include/cuda/experimental/__stf/internal/algorithm.cuh cudax/include/cuda/experimental/__stf/graph/graph_ctx.cuh`