### PR TITLE
[CUB] Refactor `DeviceReduce::Arg{Min, Max}` to always take an environment

### DIFF
--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -914,7 +914,11 @@ public:
   }
 
 private:
-  template <typename InputIteratorT, typename ExtremumOutIteratorT, typename IndexOutIteratorT, typename CompareOpT>
+  template <typename InputIteratorT,
+            typename ExtremumOutIteratorT,
+            typename IndexOutIteratorT,
+            typename CompareOpT,
+            typename EnvT = ::cuda::std::execution::env<>>
   CUB_RUNTIME_FUNCTION static cudaError_t __arg_min(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -923,20 +927,45 @@ private:
     IndexOutIteratorT d_index_out,
     ::cuda::std::int64_t num_items,
     CompareOpT compare_op,
-    cudaStream_t stream)
+    const EnvT& env)
   {
-    using PerPartitionOffsetT = int; // used by the kernel to index within one partition
-    using GlobalOffsetT       = ::cuda::std::int64_t; // in the range [d_in, d_in + num_items)
+    static_assert(!::cuda::std::execution::__queryable_with<EnvT, ::cuda::execution::determinism::__get_determinism_t>,
+                  "Determinism should be used inside requires to have an effect.");
+    using requirements_t = ::cuda::std::execution::
+      __query_result_or_t<EnvT, ::cuda::execution::__get_requirements_t, ::cuda::std::execution::env<>>;
+    using requested_determinism_t =
+      ::cuda::std::execution::__query_result_or_t<requirements_t, //
+                                                  ::cuda::execution::determinism::__get_determinism_t,
+                                                  ::cuda::execution::determinism::run_to_run_t>;
 
-    return detail::reduce::dispatch_streaming_arg_reduce<PerPartitionOffsetT>(
+    // Static assert to reject gpu_to_gpu determinism since it's not properly implemented
+    static_assert(!::cuda::std::is_same_v<requested_determinism_t, ::cuda::execution::determinism::gpu_to_gpu_t>,
+                  "gpu_to_gpu determinism is not supported");
+
+    using PerPartitionOffsetT     = int; // used by the kernel to index within one partition
+    using GlobalOffsetT           = ::cuda::std::int64_t; // in the range [d_in, d_in + num_items)
+    using input_value_t           = detail::it_value_t<InputIteratorT>;
+    using output_extremum_t       = detail::non_void_value_t<ExtremumOutIteratorT, input_value_t>;
+    using reduce_op_t             = detail::arg_reduce_op<CompareOpT>;
+    using default_policy_selector = detail::reduce::
+      policy_selector_from_types<KeyValuePair<PerPartitionOffsetT, output_extremum_t>, PerPartitionOffsetT, reduce_op_t>;
+
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
       d_temp_storage,
       temp_storage_bytes,
-      d_in,
-      d_min_out,
-      d_index_out,
-      static_cast<GlobalOffsetT>(num_items),
-      detail::arg_reduce_op{compare_op},
-      stream);
+      env,
+      [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+        return detail::reduce::dispatch_streaming_arg_reduce<PerPartitionOffsetT>(
+          d_temp_storage,
+          temp_storage_bytes,
+          d_in,
+          d_min_out,
+          d_index_out,
+          static_cast<GlobalOffsetT>(num_items),
+          reduce_op_t{compare_op},
+          stream,
+          policy_selector);
+      });
   }
 
 public:
@@ -1016,6 +1045,9 @@ public:
   //! @tparam IndexOutIteratorT
   //!   **[inferred]** Output iterator type for recording index of the returned value
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Execution environment type. Default is ``cuda::std::execution::env<>``.
+  //!
   //! @param[in] d_temp_storage
   //!   @devicestorage
   //!
@@ -1037,13 +1069,17 @@ public:
   //! @param[in] num_items
   //!   Total number of input items (i.e., length of ``d_in``)
   //!
-  //! @param[in] stream
+  //! @param[in] env
   //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
   // TODO(bgruber): this constraint is not accurate, since the implementation will compare the value types of
   // ExtremumOutIteratorT, which is wrong IMO
-  _CCCL_TEMPLATE(typename InputIteratorT, typename ExtremumOutIteratorT, typename IndexOutIteratorT, typename CompareOpT)
+  _CCCL_TEMPLATE(typename InputIteratorT,
+                 typename ExtremumOutIteratorT,
+                 typename IndexOutIteratorT,
+                 typename CompareOpT,
+                 typename EnvT = ::cuda::std::execution::env<>)
   _CCCL_REQUIRES((::cuda::std::indirectly_comparable<InputIteratorT, InputIteratorT, CompareOpT>) )
   CUB_RUNTIME_FUNCTION static cudaError_t ArgMin(
     void* d_temp_storage,
@@ -1053,10 +1089,10 @@ public:
     IndexOutIteratorT d_index_out,
     ::cuda::std::int64_t num_items,
     CompareOpT compare_op,
-    cudaStream_t stream = nullptr)
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceReduce::ArgMin");
-    return __arg_min(d_temp_storage, temp_storage_bytes, d_in, d_min_out, d_index_out, num_items, compare_op, stream);
+    return __arg_min(d_temp_storage, temp_storage_bytes, d_in, d_min_out, d_index_out, num_items, compare_op, env);
   }
 
   //! @rst
@@ -1066,7 +1102,11 @@ public:
   //!
   //! @overload
   //! @note Uses ``cuda::std::less`` as comparison operator
-  template <typename InputIteratorT, typename ExtremumOutIteratorT, typename IndexOutIteratorT>
+  _CCCL_TEMPLATE(typename InputIteratorT,
+                 typename ExtremumOutIteratorT,
+                 typename IndexOutIteratorT,
+                 typename EnvT = ::cuda::std::execution::env<>)
+  _CCCL_REQUIRES((!::cuda::std::indirectly_comparable<InputIteratorT, InputIteratorT, EnvT>) )
   CUB_RUNTIME_FUNCTION static cudaError_t ArgMin(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -1074,10 +1114,9 @@ public:
     ExtremumOutIteratorT d_min_out,
     IndexOutIteratorT d_index_out,
     ::cuda::std::int64_t num_items,
-    cudaStream_t stream = nullptr)
+    const EnvT& env = {})
   {
-    return ArgMin(
-      d_temp_storage, temp_storage_bytes, d_in, d_min_out, d_index_out, num_items, ::cuda::std::less{}, stream);
+    return ArgMin(d_temp_storage, temp_storage_bytes, d_in, d_min_out, d_index_out, num_items, ::cuda::std::less{}, env);
   }
 
 private:
@@ -1092,7 +1131,7 @@ private:
     IndexOutIteratorT d_index_out,
     ::cuda::std::int64_t num_items,
     CompareOpT compare_op,
-    EnvT env = {})
+    const EnvT& env = {})
   {
     static_assert(!::cuda::std::execution::__queryable_with<EnvT, ::cuda::execution::determinism::__get_determinism_t>,
                   "Determinism should be used inside requires to have an effect.");
@@ -1208,7 +1247,7 @@ public:
     IndexOutIteratorT d_index_out,
     ::cuda::std::int64_t num_items,
     CompareOpT compare_op,
-    EnvT env = {})
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMin");
     return __arg_min_env(d_in, d_min_out, d_index_out, num_items, compare_op, env);
@@ -1228,7 +1267,7 @@ public:
     ExtremumOutIteratorT d_min_out,
     IndexOutIteratorT d_index_out,
     ::cuda::std::int64_t num_items,
-    EnvT env = {})
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMin");
     return __arg_min_env(d_in, d_min_out, d_index_out, num_items, ::cuda::std::less{}, env);
@@ -1619,6 +1658,9 @@ public:
   //! @tparam IndexOutIteratorT
   //!   **[inferred]** Output iterator type for recording index of the returned value
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Execution environment type. Default is ``cuda::std::execution::env<>``.
+  //!
   //! @param[in] d_temp_storage
   //!   @devicestorage
   //!
@@ -1640,13 +1682,17 @@ public:
   //! @param[in] num_items
   //!   Total number of input items (i.e., length of ``d_in``)
   //!
-  //! @param[in] stream
+  //! @param[in] env
   //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
   // TODO(bgruber): this constraint is not accurate, since the implementation will compare the value types of
   // ExtremumOutIteratorT, which is wrong IMO
-  _CCCL_TEMPLATE(typename InputIteratorT, typename ExtremumOutIteratorT, typename IndexOutIteratorT, typename CompareOpT)
+  _CCCL_TEMPLATE(typename InputIteratorT,
+                 typename ExtremumOutIteratorT,
+                 typename IndexOutIteratorT,
+                 typename CompareOpT,
+                 typename EnvT = ::cuda::std::execution::env<>)
   _CCCL_REQUIRES((::cuda::std::indirectly_comparable<InputIteratorT, InputIteratorT, CompareOpT>) )
   CUB_RUNTIME_FUNCTION static cudaError_t ArgMax(
     void* d_temp_storage,
@@ -1656,11 +1702,11 @@ public:
     IndexOutIteratorT d_index_out,
     ::cuda::std::int64_t num_items,
     CompareOpT compare_op,
-    cudaStream_t stream = nullptr)
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceReduce::ArgMax");
     return __arg_min(
-      d_temp_storage, temp_storage_bytes, d_in, d_max_out, d_index_out, num_items, detail::swap_args{compare_op}, stream);
+      d_temp_storage, temp_storage_bytes, d_in, d_max_out, d_index_out, num_items, detail::swap_args{compare_op}, env);
   }
 
   //! @rst
@@ -1669,7 +1715,11 @@ public:
   //! @overload
   //! @note Uses ``cuda::std::less`` as comparison operator
   //! @endrst
-  template <typename InputIteratorT, typename ExtremumOutIteratorT, typename IndexOutIteratorT>
+  _CCCL_TEMPLATE(typename InputIteratorT,
+                 typename ExtremumOutIteratorT,
+                 typename IndexOutIteratorT,
+                 typename EnvT = ::cuda::std::execution::env<>)
+  _CCCL_REQUIRES((!::cuda::std::indirectly_comparable<InputIteratorT, InputIteratorT, EnvT>) )
   CUB_RUNTIME_FUNCTION static cudaError_t ArgMax(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -1677,11 +1727,11 @@ public:
     ExtremumOutIteratorT d_max_out,
     IndexOutIteratorT d_index_out,
     ::cuda::std::int64_t num_items,
-    cudaStream_t stream = nullptr)
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceReduce::ArgMax");
     return __arg_min(
-      d_temp_storage, temp_storage_bytes, d_in, d_max_out, d_index_out, num_items, ::cuda::std::greater{}, stream);
+      d_temp_storage, temp_storage_bytes, d_in, d_max_out, d_index_out, num_items, ::cuda::std::greater{}, env);
   }
 
   //! @rst
@@ -1894,7 +1944,7 @@ public:
     IndexOutIteratorT d_index_out,
     ::cuda::std::int64_t num_items,
     CompareOpT compare_op,
-    EnvT env = {})
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMax");
     return __arg_min_env(d_in, d_max_out, d_index_out, num_items, detail::swap_args{compare_op}, env);
@@ -1914,7 +1964,7 @@ public:
          ExtremumOutIteratorT d_max_out,
          IndexOutIteratorT d_index_out,
          ::cuda::std::int64_t num_items,
-         EnvT env = {})
+         const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMax");
     return __arg_min_env(d_in, d_max_out, d_index_out, num_items, ::cuda::std::greater{}, env);

--- a/cub/test/catch2_test_device_reduce.cu
+++ b/cub/test/catch2_test_device_reduce.cu
@@ -7,8 +7,10 @@
 #include <thrust/sequence.h>
 
 #include <cuda/__cmath/uabs.h>
+#include <cuda/devices>
 #include <cuda/std/__algorithm/max_element.h>
 #include <cuda/std/__algorithm/min_element.h>
+#include <cuda/std/execution>
 
 #include <cstdint>
 
@@ -228,6 +230,94 @@ C2H_TEST("Device reduce works with all device interfaces", "[reduce][device]", f
     REQUIRE((expected_result - host_items.cbegin()) == gpu_result.first);
   }
 
+  SECTION("argmax with user provided memory and environment")
+  {
+    // Prepare verification data
+    c2h::host_vector<item_t> host_items(in_items);
+    auto expected_result = std::max_element(host_items.cbegin(), host_items.cend());
+
+    // Run test
+    using result_t = cuda::std::pair<cuda::std::int32_t, unwrap_value_t<output_t>>;
+    c2h::device_vector<result_t> out_result(num_segments);
+    auto d_result_ptr   = thrust::raw_pointer_cast(out_result.data());
+    auto d_index_out    = &d_result_ptr->first;
+    auto d_extremum_out = &d_result_ptr->second;
+
+    size_t expected_allocation_size = 0;
+    auto error                      = cub::DeviceReduce::ArgMax(
+      static_cast<void*>(nullptr), expected_allocation_size, unwrap_it(d_in_it), d_extremum_out, d_index_out, num_items);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    auto d_temp        = c2h::device_vector<uint8_t>(expected_allocation_size, thrust::no_init);
+    void* temp_storage = thrust::raw_pointer_cast(d_temp.data());
+
+    auto test_argmax = [&](const auto& env) {
+      size_t num_bytes = 0;
+      error            = cub::DeviceReduce::ArgMax(
+        static_cast<void*>(nullptr), num_bytes, unwrap_it(d_in_it), d_extremum_out, d_index_out, num_items, env);
+      REQUIRE(error == cudaSuccess);
+      REQUIRE(cudaSuccess == cudaPeekAtLastError());
+      REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+      REQUIRE(expected_allocation_size == num_bytes);
+
+      error = cub::DeviceReduce::ArgMax(
+        temp_storage, num_bytes, unwrap_it(d_in_it), d_extremum_out, d_index_out, num_items, env);
+      REQUIRE(error == cudaSuccess);
+      REQUIRE(cudaSuccess == cudaPeekAtLastError());
+      REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+      // Verify result
+      result_t gpu_result   = out_result[0];
+      output_t gpu_extremum = static_cast<output_t>(gpu_result.second); // Explicitly rewrap the gpu value
+      REQUIRE(expected_result[0] == gpu_extremum);
+      REQUIRE((expected_result - host_items.cbegin()) == gpu_result.first);
+    };
+
+    int current_device;
+    error = cudaGetDevice(&current_device);
+    REQUIRE(error == cudaSuccess);
+
+    SECTION("DeviceReduce::ArgMax works with cudaStream_t")
+    {
+      cuda::stream stream{cuda::devices[current_device]};
+      test_argmax(stream.get());
+    }
+
+    SECTION("DeviceReduce::ArgMax works with cuda::stream")
+    {
+      cuda::stream stream{cuda::devices[current_device]};
+      test_argmax(stream);
+    }
+
+    SECTION("DeviceReduce::ArgMax works with cuda::stream_ref")
+    {
+      cuda::stream stream{cuda::devices[current_device]};
+      cuda::stream_ref stream_ref{stream};
+      test_argmax(stream_ref);
+    }
+
+    SECTION("DeviceReduce::ArgMax works with cuda::std::execution::env")
+    {
+      cuda::std::execution::env env{};
+      test_argmax(env);
+    }
+
+    SECTION("DeviceReduce::ArgMax works with cuda::execution::gpu")
+    {
+      const auto policy = cuda::execution::gpu;
+      test_argmax(policy);
+    }
+
+    SECTION("DeviceReduce::ArgMax works with cuda::execution::gpu with stream")
+    {
+      cuda::stream stream{cuda::devices[current_device]};
+      const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+      test_argmax(policy);
+    }
+  }
+
   SECTION("argmin")
   {
     // Prepare verification data
@@ -247,6 +337,94 @@ C2H_TEST("Device reduce works with all device interfaces", "[reduce][device]", f
     output_t gpu_extremum = static_cast<output_t>(gpu_result.second); // Explicitly rewrap the gpu value
     REQUIRE(expected_result[0] == gpu_extremum);
     REQUIRE((expected_result - host_items.cbegin()) == gpu_result.first);
+  }
+
+  SECTION("argmin with user provided memory and environment")
+  {
+    // Prepare verification data
+    c2h::host_vector<item_t> host_items(in_items);
+    auto expected_result = std::min_element(host_items.cbegin(), host_items.cend());
+
+    // Run test
+    using result_t = cuda::std::pair<cuda::std::int32_t, unwrap_value_t<output_t>>;
+    c2h::device_vector<result_t> out_result(num_segments);
+    auto d_result_ptr   = thrust::raw_pointer_cast(out_result.data());
+    auto d_index_out    = &d_result_ptr->first;
+    auto d_extremum_out = &d_result_ptr->second;
+
+    size_t expected_allocation_size = 0;
+    auto error                      = cub::DeviceReduce::ArgMin(
+      static_cast<void*>(nullptr), expected_allocation_size, unwrap_it(d_in_it), d_extremum_out, d_index_out, num_items);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    auto d_temp        = c2h::device_vector<uint8_t>(expected_allocation_size, thrust::no_init);
+    void* temp_storage = thrust::raw_pointer_cast(d_temp.data());
+
+    auto test_argmin = [&](const auto& env) {
+      size_t num_bytes = 0;
+      error            = cub::DeviceReduce::ArgMin(
+        static_cast<void*>(nullptr), num_bytes, unwrap_it(d_in_it), d_extremum_out, d_index_out, num_items, env);
+      REQUIRE(error == cudaSuccess);
+      REQUIRE(cudaSuccess == cudaPeekAtLastError());
+      REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+      REQUIRE(expected_allocation_size == num_bytes);
+
+      error = cub::DeviceReduce::ArgMin(
+        temp_storage, num_bytes, unwrap_it(d_in_it), d_extremum_out, d_index_out, num_items, env);
+      REQUIRE(error == cudaSuccess);
+      REQUIRE(cudaSuccess == cudaPeekAtLastError());
+      REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+      // Verify result
+      result_t gpu_result   = out_result[0];
+      output_t gpu_extremum = static_cast<output_t>(gpu_result.second); // Explicitly rewrap the gpu value
+      REQUIRE(expected_result[0] == gpu_extremum);
+      REQUIRE((expected_result - host_items.cbegin()) == gpu_result.first);
+    };
+
+    int current_device;
+    error = cudaGetDevice(&current_device);
+    REQUIRE(error == cudaSuccess);
+
+    SECTION("DeviceReduce::ArgMin works with cudaStream_t")
+    {
+      cuda::stream stream{cuda::devices[current_device]};
+      test_argmin(stream.get());
+    }
+
+    SECTION("DeviceReduce::ArgMin works with cuda::stream")
+    {
+      cuda::stream stream{cuda::devices[current_device]};
+      test_argmin(stream);
+    }
+
+    SECTION("DeviceReduce::ArgMin works with cuda::stream_ref")
+    {
+      cuda::stream stream{cuda::devices[current_device]};
+      cuda::stream_ref stream_ref{stream};
+      test_argmin(stream_ref);
+    }
+
+    SECTION("DeviceReduce::ArgMin works with cuda::std::execution::env")
+    {
+      cuda::std::execution::env env{};
+      test_argmin(env);
+    }
+
+    SECTION("DeviceReduce::ArgMin works with cuda::execution::gpu")
+    {
+      const auto policy = cuda::execution::gpu;
+      test_argmin(policy);
+    }
+
+    SECTION("DeviceReduce::ArgMin works with cuda::execution::gpu with stream")
+    {
+      cuda::stream stream{cuda::devices[current_device]};
+      const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+      test_argmin(policy);
+    }
   }
 
   SECTION("argmax deprecated interface")

--- a/libcudacxx/include/cuda/std/__pstl/cuda/max_element.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/max_element.h
@@ -85,7 +85,7 @@ struct __pstl_dispatch<__pstl_algorithm::__max_element, __execution_backend::__c
       static_cast<size_t*>(nullptr),
       __count,
       __pred,
-      __stream.get());
+      __policy);
 
     {
       __temporary_storage<size_t> __storage{__policy, __num_bytes, 1};
@@ -101,7 +101,7 @@ struct __pstl_dispatch<__pstl_algorithm::__max_element, __execution_backend::__c
         __storage.template __get_raw_ptr<0>(),
         __count,
         ::cuda::std::move(__pred),
-        __stream.get());
+        __policy);
 
       // Copy the result back from storage
       _CCCL_TRY_CUDA_API(

--- a/libcudacxx/include/cuda/std/__pstl/cuda/min_element.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/min_element.h
@@ -85,7 +85,7 @@ struct __pstl_dispatch<__pstl_algorithm::__min_element, __execution_backend::__c
       static_cast<size_t*>(nullptr),
       __count,
       __pred,
-      __stream.get());
+      __policy);
 
     {
       __temporary_storage<size_t> __storage{__policy, __num_bytes, 1};
@@ -101,7 +101,7 @@ struct __pstl_dispatch<__pstl_algorithm::__min_element, __execution_backend::__c
         __storage.template __get_raw_ptr<0>(),
         __count,
         ::cuda::std::move(__pred),
-        __stream.get());
+        __policy);
 
       // Copy the result back from storage
       _CCCL_TRY_CUDA_API(


### PR DESCRIPTION
We want to be able to pass tunings even to the APIs that currently only take a stream.

Refactor so that we can pass an arbitrary environment to those APIs that take user provided memory

Also port the PSTL algorithms to use the new API

 - [x] Merge after #9318