### PR TITLE
Improves segmented top-k test compilation times 

### DIFF
--- a/cub/test/catch2_test_device_segmented_topk_keys.cu
+++ b/cub/test/catch2_test_device_segmented_topk_keys.cu
@@ -356,7 +356,7 @@ C2H_TEST("DeviceBatchedTopK::{Min,Max}Keys work with fixed-size segments and per
   // Copy input for verification
   c2h::device_vector<key_t> expected_keys(keys_in_buffer);
 
-  // Run the top-k algorithm with a per-segment k passed as an immediate sequence
+  // Run the top-k algorithm with a per-segment k passed as an deferred sequence
   batched_topk_keys<direction>(
     d_keys_in,
     d_keys_out,
@@ -455,7 +455,7 @@ C2H_TEST("DeviceBatchedTopK::{Min,Max}Keys work with variable-size segments and 
   // Copy input for verification
   c2h::device_vector<key_t> expected_keys(keys_in_buffer);
 
-  // Run the top-k algorithm with a per-segment k passed as an immediate sequence
+  // Run the top-k algorithm with a per-segment k passed as an deferred sequence
   batched_topk_keys<direction>(
     d_keys_in,
     d_keys_out,

--- a/cub/test/catch2_test_device_segmented_topk_keys.cu
+++ b/cub/test/catch2_test_device_segmented_topk_keys.cu
@@ -356,7 +356,7 @@ C2H_TEST("DeviceBatchedTopK::{Min,Max}Keys work with fixed-size segments and per
   // Copy input for verification
   c2h::device_vector<key_t> expected_keys(keys_in_buffer);
 
-  // Run the top-k algorithm with a per-segment k passed as an deferred sequence
+  // Run the top-k algorithm with a per-segment k passed as a deferred sequence
   batched_topk_keys<direction>(
     d_keys_in,
     d_keys_out,
@@ -455,7 +455,7 @@ C2H_TEST("DeviceBatchedTopK::{Min,Max}Keys work with variable-size segments and 
   // Copy input for verification
   c2h::device_vector<key_t> expected_keys(keys_in_buffer);
 
-  // Run the top-k algorithm with a per-segment k passed as an deferred sequence
+  // Run the top-k algorithm with a per-segment k passed as a deferred sequence
   batched_topk_keys<direction>(
     d_keys_in,
     d_keys_out,

--- a/cub/test/catch2_test_device_segmented_topk_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_topk_pairs.cu
@@ -498,7 +498,7 @@ C2H_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with fixed-size segments and pe
   // Copy input for verification
   c2h::device_vector<key_t> expected_keys(keys_in_buffer);
 
-  // Run the top-k algorithm with a per-segment k passed as an immediate sequence
+  // Run the top-k algorithm with a per-segment k passed as an deferred sequence
   batched_topk_pairs<direction>(
     d_keys_in,
     d_keys_out,
@@ -618,7 +618,7 @@ C2H_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with variable-size segments and
   // Copy input for verification
   c2h::device_vector<key_t> expected_keys(keys_in_buffer);
 
-  // Run the top-k algorithm with a per-segment k passed as an immediate sequence
+  // Run the top-k algorithm with a per-segment k passed as an deferred sequence
   batched_topk_pairs<direction>(
     d_keys_in,
     d_keys_out,

--- a/cub/test/catch2_test_device_segmented_topk_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_topk_pairs.cu
@@ -498,7 +498,7 @@ C2H_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with fixed-size segments and pe
   // Copy input for verification
   c2h::device_vector<key_t> expected_keys(keys_in_buffer);
 
-  // Run the top-k algorithm with a per-segment k passed as an deferred sequence
+  // Run the top-k algorithm with a per-segment k passed as a deferred sequence
   batched_topk_pairs<direction>(
     d_keys_in,
     d_keys_out,
@@ -618,7 +618,7 @@ C2H_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with variable-size segments and
   // Copy input for verification
   c2h::device_vector<key_t> expected_keys(keys_in_buffer);
 
-  // Run the top-k algorithm with a per-segment k passed as an deferred sequence
+  // Run the top-k algorithm with a per-segment k passed as a deferred sequence
   batched_topk_pairs<direction>(
     d_keys_in,
     d_keys_out,

--- a/cub/test/catch2_test_device_topk_common.cuh
+++ b/cub/test/catch2_test_device_topk_common.cuh
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <cub/device/device_copy.cuh>
-#include <cub/device/device_segmented_sort.cuh>
+#include <cub/device/device_segmented_radix_sort.cuh>
 #include <cub/device/dispatch/dispatch_common.cuh> // topk::select::{min, max}
 
 #include <thrust/remove.h>
@@ -354,8 +354,8 @@ void segmented_sort_keys(
   OffsetItT d_segment_offsets_end_it,
   cub::detail::topk::select direction)
 {
-  // TODO: switch this reference sort to cub::DeviceSegmentedRadixSort in a follow-up PR: it compiles ~30% faster
-  // than cub::DeviceSegmentedSort at negligible runtime cost.
+  // Use cub::DeviceSegmentedRadixSort rather than cub::DeviceSegmentedSort for this reference sort: it compiles
+  // ~30% faster at negligible runtime cost (the reference only needs per-segment ordering of arithmetic keys).
   cuda::std::int64_t num_items = d_keys_in.size();
 
   // Prepare alternate buffer for double buffering
@@ -367,7 +367,7 @@ void segmented_sort_keys(
   size_t temp_storage_bytes = 0;
   if (direction == cub::detail::topk::select::min)
   {
-    cub::DeviceSegmentedSort::SortKeys(
+    cub::DeviceSegmentedRadixSort::SortKeys(
       nullptr,
       temp_storage_bytes,
       d_keys,
@@ -380,7 +380,7 @@ void segmented_sort_keys(
     c2h::device_vector<cuda::std::uint8_t> d_temp_storage(temp_storage_bytes, thrust::no_init);
 
     // Run segmented sort
-    cub::DeviceSegmentedSort::SortKeys(
+    cub::DeviceSegmentedRadixSort::SortKeys(
       thrust::raw_pointer_cast(d_temp_storage.data()),
       temp_storage_bytes,
       d_keys,
@@ -391,7 +391,7 @@ void segmented_sort_keys(
   }
   else
   {
-    cub::DeviceSegmentedSort::SortKeysDescending(
+    cub::DeviceSegmentedRadixSort::SortKeysDescending(
       nullptr,
       temp_storage_bytes,
       d_keys,
@@ -404,7 +404,7 @@ void segmented_sort_keys(
     c2h::device_vector<cuda::std::uint8_t> d_temp_storage(temp_storage_bytes, thrust::no_init);
 
     // Run segmented sort
-    cub::DeviceSegmentedSort::SortKeysDescending(
+    cub::DeviceSegmentedRadixSort::SortKeysDescending(
       thrust::raw_pointer_cast(d_temp_storage.data()),
       temp_storage_bytes,
       d_keys,


### PR DESCRIPTION
## Description

The sort we use for verification contributes a majority of the compilation times. A host-only sort for verification would cut the compilation time in half but runtime would exploude to 1 min and above. `DeviceSegmentedRadixSort` is a reasonable alternative, cutting  Improves top-k test compilation times

## Before / after 

| Test | Metric | Before (`DeviceSegmentedSort`) | After (`DeviceSegmentedRadixSort`) | Δ |
|---|---|---|---|---|
| **keys** | compile | 1:48.7 (108.7 s) | 1:21.8 (81.8 s) | −26.9 s (−25%) |
| | runtime | 3.46 / 3.41 s | 3.54 s | +0.1 s  |
| **pairs** | compile | 2:29.7 (149.7 s) | 1:46.0 (106.0 s) | −43.6 s (−29%) |
| | runtime | 1.88 / 1.84 s | 1.95 s | +0.07 s  |
