### PR TITLE
Fix install script verbose option parsing

### DIFF
--- a/ci/install_cccl.sh
+++ b/ci/install_cccl.sh
@@ -2,9 +2,6 @@
 
 set -eo pipefail
 
-target_dir=$(realpath "$1")
-mkdir -p "$target_dir"
-
 # Move script to the root directory of the project
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 
@@ -17,7 +14,7 @@ function usage {
     echo "Installs CCCL to the provided directory"
 
     echo "Options:"
-    echo "  -v/-verbose: Enable shell echo for debugging"
+    echo "  -v/--verbose/-verbose: Enable shell echo for debugging"
     echo
     echo "Examples:"
     echo "  $ $0 ~/my/prefix"
@@ -28,10 +25,18 @@ while [[ "$#" -gt 0 ]]; do
     case "$1" in
         --verbose) VERBOSE=true; ;;
         -v) VERBOSE=true; ;;
+        -verbose) VERBOSE=true; ;;
         *) break ;;
     esac
     shift
 done
+
+if [[ "$#" -ne 1 ]]; then
+    usage
+fi
+
+target_dir=$(realpath "$1")
+mkdir -p "$target_dir"
 
 if [[ -n "$VERBOSE" ]]; then
     set -x


### PR DESCRIPTION
## Summary

- Parse `ci/install_cccl.sh` options before resolving the install target.
- Require exactly one positional install directory after options are consumed.
- Accept and document `-verbose` alongside `-v` and `--verbose`.

## Root Cause

`target_dir=$(realpath "$1")` ran before option parsing, so option-first usage such as `ci/install_cccl.sh --verbose /tmp/cccl-install` passed `--verbose` to `realpath` instead of treating it as a script option.

## Validation

- `bash -n ci/install_cccl.sh`
- `git diff --check`
- Fake `cmake` shim probes for `--verbose`, `-v`, `-verbose`, missing directory, and extra directory arguments.