### PR TITLE
Remove unused scan output type local

### DIFF
--- a/c/parallel/src/scan.cu
+++ b/c/parallel/src/scan.cu
@@ -279,8 +279,6 @@ try
 
   const std::string op_src = make_kernel_user_binary_operator(accum_cpp, accum_cpp, accum_cpp, op);
 
-  const auto output_it_value_t = cccl_type_enum_to_name(output_it.value_type.type);
-
   const auto policy_sel = [&] {
     using cub::detail::scan::policy_selector;
     using cub::detail::scan::primitive_accum;


### PR DESCRIPTION
## Summary

- Remove the unused `output_it_value_t` local from the C parallel scan build path.

## Root Cause

`output_it_value_t` used to feed the generated scan policy selector type. After the scan policy selector switched to iterator type names, the local remained but no longer had any readers.

## Validation

- `git diff --check`
- `git grep -n "output_it_value_t" -- c/parallel/src/scan.cu c/parallel/src`