### PR TITLE
Fxes msvc multi-inheritance cross host-device for `output_ordering`

### DIFF
--- a/libcudacxx/include/cuda/__execution/output_ordering.h
+++ b/libcudacxx/include/cuda/__execution/output_ordering.h
@@ -24,7 +24,6 @@
 #include <cuda/__execution/require.h>
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__execution/env.h>
-#include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_one_of.h>
 
 #include <cuda/std/__cccl/prologue.h>
@@ -52,10 +51,10 @@ enum class __output_ordering_t
 };
 
 template <__output_ordering_t _Guarantee>
-struct _CCCL_DECLSPEC_EMPTY_BASES __output_ordering_holder_t
-    : __requirement
-    , ::cuda::std::integral_constant<__output_ordering_t, _Guarantee>
+struct __output_ordering_holder_t : __requirement
 {
+  static constexpr __output_ordering_t value = _Guarantee;
+
   [[nodiscard]] _CCCL_NODEBUG_API constexpr auto query(const __get_output_ordering_t&) const noexcept
     -> __output_ordering_holder_t<_Guarantee>
   {


### PR DESCRIPTION
`cuda::execution::output_ordering::__output_ordering_holder_t` inherits from two empty base classes, which can give it a different layout/size between host and device on MSVC and is therefore UB to pass into a kernel. This mirrors the fix applied to `tie_break` to follow the `__determinism_holder_t` patter. We now keep a single empty base and expose the preference via a static constexpr value member instead (see https://github.com/NVIDIA/cccl/pull/9238#discussion_r3399659457).