### PR TITLE
[libcu++] Indirect `indirect_binary invocable`

### DIFF
--- a/libcudacxx/include/cuda/std/__iterator/concepts.h
+++ b/libcudacxx/include/cuda/std/__iterator/concepts.h
@@ -79,12 +79,12 @@ using iter_common_reference_t = common_reference_t<iter_reference_t<_Tp>, iter_v
 // [iterator.concept.writable]
 template <class _Out, class _Tp>
 concept indirectly_writable = requires(_Out&& __o, _Tp&& __t) {
-  *__o                                             = static_cast<_Tp&&>(__t); // not required to be equality-preserving
-  *static_cast<_Out&&>(__o)                        = static_cast<_Tp&&>(__t); // not required to be equality-preserving
-  const_cast<const iter_reference_t<_Out>&&>(*__o) = static_cast<_Tp&&>(__t); // not required to be
-                                                                              // equality-preserving
-  const_cast<const iter_reference_t<_Out>&&>(*static_cast<_Out&&>(__o)) =
-    static_cast<_Tp&&>(__t); // not required to be equality-preserving
+  *__o                       = static_cast<_Tp &&>(__t); // not required to be equality-preserving
+  *static_cast<_Out &&>(__o) = static_cast<_Tp &&>(__t); // not required to be equality-preserving
+  const_cast<const iter_reference_t<_Out> &&>(*__o) = static_cast<_Tp &&>(__t); // not required to be
+                                                                                // equality-preserving
+  const_cast<const iter_reference_t<_Out> &&>(*static_cast<_Out &&>(__o)) =
+    static_cast<_Tp &&>(__t); // not required to be equality-preserving
 };
 
 // [iterator.concept.winc]
@@ -142,7 +142,7 @@ concept input_iterator = input_or_output_iterator<_Ip> && indirectly_readable<_I
 template <class _Ip, class _Tp>
 concept output_iterator =
   input_or_output_iterator<_Ip> && indirectly_writable<_Ip, _Tp> && requires(_Ip __it, _Tp&& __t) {
-    *__it++ = static_cast<_Tp&&>(__t); // not required to be equality-preserving
+    *__it++ = static_cast<_Tp &&>(__t); // not required to be equality-preserving
   };
 
 // [iterator.concept.forward]

--- a/libcudacxx/include/cuda/std/__iterator/concepts.h
+++ b/libcudacxx/include/cuda/std/__iterator/concepts.h
@@ -79,12 +79,12 @@ using iter_common_reference_t = common_reference_t<iter_reference_t<_Tp>, iter_v
 // [iterator.concept.writable]
 template <class _Out, class _Tp>
 concept indirectly_writable = requires(_Out&& __o, _Tp&& __t) {
-  *__o                       = static_cast<_Tp &&>(__t); // not required to be equality-preserving
-  *static_cast<_Out &&>(__o) = static_cast<_Tp &&>(__t); // not required to be equality-preserving
-  const_cast<const iter_reference_t<_Out> &&>(*__o) = static_cast<_Tp &&>(__t); // not required to be
-                                                                                // equality-preserving
-  const_cast<const iter_reference_t<_Out> &&>(*static_cast<_Out &&>(__o)) =
-    static_cast<_Tp &&>(__t); // not required to be equality-preserving
+  *__o                                             = static_cast<_Tp&&>(__t); // not required to be equality-preserving
+  *static_cast<_Out&&>(__o)                        = static_cast<_Tp&&>(__t); // not required to be equality-preserving
+  const_cast<const iter_reference_t<_Out>&&>(*__o) = static_cast<_Tp&&>(__t); // not required to be
+                                                                              // equality-preserving
+  const_cast<const iter_reference_t<_Out>&&>(*static_cast<_Out&&>(__o)) =
+    static_cast<_Tp&&>(__t); // not required to be equality-preserving
 };
 
 // [iterator.concept.winc]
@@ -142,7 +142,7 @@ concept input_iterator = input_or_output_iterator<_Ip> && indirectly_readable<_I
 template <class _Ip, class _Tp>
 concept output_iterator =
   input_or_output_iterator<_Ip> && indirectly_writable<_Ip, _Tp> && requires(_Ip __it, _Tp&& __t) {
-    *__it++ = static_cast<_Tp &&>(__t); // not required to be equality-preserving
+    *__it++ = static_cast<_Tp&&>(__t); // not required to be equality-preserving
   };
 
 // [iterator.concept.forward]
@@ -283,6 +283,42 @@ concept indirectly_copyable_storable =
 
 // Note: indirectly_swappable is located in iter_swap.h to prevent a dependency cycle
 // (both iter_swap and indirectly_swappable require indirectly_readable).
+
+// Extension of indirectly_unary_invocable to binary operators
+template <class _Fp, class _It1, class _It2>
+concept __indirectly_binary_invocable =
+  indirectly_readable<_It1> && indirectly_readable<_It2> && copy_constructible<_Fp>
+  && invocable<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>
+  && invocable<_Fp&, iter_value_t<_It1>&, iter_reference_t<_It2>>
+  && invocable<_Fp&, iter_reference_t<_It1>, iter_value_t<_It2>&>
+  && invocable<_Fp&, iter_reference_t<_It1>, iter_reference_t<_It2>>
+  && invocable<_Fp&, iter_common_reference_t<_It1>, iter_common_reference_t<_It2>>
+  && common_reference_with<invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>,
+                           invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_reference_t<_It2>>>
+  && common_reference_with<invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>,
+                           invoke_result_t<_Fp&, iter_reference_t<_It1>, iter_value_t<_It2>&>>
+  && common_reference_with<invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>,
+                           invoke_result_t<_Fp&, iter_reference_t<_It1>, iter_reference_t<_It2>>>
+  && common_reference_with<invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>,
+                           invoke_result_t<_Fp&, iter_common_reference_t<_It1>, iter_common_reference_t<_It2>>>;
+
+// Extension of indirectly_regular_unary_invocable to binary operators
+template <class _Fp, class _It1, class _It2>
+concept __indirectly_regular_binary_invocable =
+  indirectly_readable<_It1> && indirectly_readable<_It2> && copy_constructible<_Fp>
+  && regular_invocable<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>
+  && regular_invocable<_Fp&, iter_value_t<_It1>&, iter_reference_t<_It2>>
+  && regular_invocable<_Fp&, iter_reference_t<_It1>, iter_value_t<_It2>&>
+  && regular_invocable<_Fp&, iter_reference_t<_It1>, iter_reference_t<_It2>>
+  && regular_invocable<_Fp&, iter_common_reference_t<_It1>, iter_common_reference_t<_It2>>
+  && common_reference_with<invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>,
+                           invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_reference_t<_It2>>>
+  && common_reference_with<invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>,
+                           invoke_result_t<_Fp&, iter_reference_t<_It1>, iter_value_t<_It2>&>>
+  && common_reference_with<invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>,
+                           invoke_result_t<_Fp&, iter_reference_t<_It1>, iter_reference_t<_It2>>>
+  && common_reference_with<invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>,
+                           invoke_result_t<_Fp&, iter_common_reference_t<_It1>, iter_common_reference_t<_It2>>>;
 
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 
@@ -623,6 +659,44 @@ _CCCL_CONCEPT_FRAGMENT(
 
 template <class _In, class _Out>
 _CCCL_CONCEPT indirectly_copyable_storable = _CCCL_FRAGMENT(__indirectly_copyable_storable_, _In, _Out);
+
+template <class _Fp, class _It1, class _It2>
+_CCCL_CONCEPT __indirectly_binary_invocable = _CCCL_REQUIRES_EXPR((_Fp, _It1, _It2))(
+  requires(indirectly_readable<_It1>),
+  requires(indirectly_readable<_It2>),
+  requires(copy_constructible<_Fp>),
+  requires(invocable<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>),
+  requires(invocable<_Fp&, iter_value_t<_It1>&, iter_reference_t<_It2>>),
+  requires(invocable<_Fp&, iter_reference_t<_It1>, iter_value_t<_It2>&>),
+  requires(invocable<_Fp&, iter_reference_t<_It1>, iter_reference_t<_It2>>),
+  requires(invocable<_Fp&, iter_common_reference_t<_It1>, iter_common_reference_t<_It2>>),
+  requires(common_reference_with<invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>,
+                                 invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_reference_t<_It2>>>),
+  requires(common_reference_with<invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>,
+                                 invoke_result_t<_Fp&, iter_reference_t<_It1>, iter_value_t<_It2>&>>),
+  requires(common_reference_with<invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>,
+                                 invoke_result_t<_Fp&, iter_reference_t<_It1>, iter_reference_t<_It2>>>),
+  requires(common_reference_with<invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>,
+                                 invoke_result_t<_Fp&, iter_common_reference_t<_It1>, iter_common_reference_t<_It2>>>));
+
+template <class _Fp, class _It1, class _It2>
+_CCCL_CONCEPT __indirectly_regular_binary_invocable = _CCCL_REQUIRES_EXPR((_Fp, _It1, _It2))(
+  requires(indirectly_readable<_It1>),
+  requires(indirectly_readable<_It2>),
+  requires(copy_constructible<_Fp>),
+  requires(regular_invocable<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>),
+  requires(regular_invocable<_Fp&, iter_value_t<_It1>&, iter_reference_t<_It2>>),
+  requires(regular_invocable<_Fp&, iter_reference_t<_It1>, iter_value_t<_It2>&>),
+  requires(regular_invocable<_Fp&, iter_reference_t<_It1>, iter_reference_t<_It2>>),
+  requires(regular_invocable<_Fp&, iter_common_reference_t<_It1>, iter_common_reference_t<_It2>>),
+  requires(common_reference_with<invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>,
+                                 invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_reference_t<_It2>>>),
+  requires(common_reference_with<invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>,
+                                 invoke_result_t<_Fp&, iter_reference_t<_It1>, iter_value_t<_It2>&>>),
+  requires(common_reference_with<invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>,
+                                 invoke_result_t<_Fp&, iter_reference_t<_It1>, iter_reference_t<_It2>>>),
+  requires(common_reference_with<invoke_result_t<_Fp&, iter_value_t<_It1>&, iter_value_t<_It2>&>,
+                                 invoke_result_t<_Fp&, iter_common_reference_t<_It1>, iter_common_reference_t<_It2>>>));
 
 template <class _Ip, class = void>
 inline constexpr bool __has_iter_category = false;

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirectly_binary_invocable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirectly_binary_invocable.compile.pass.cpp
@@ -1,0 +1,181 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template<class F, class I1, class I2>
+// concept __indirectly_binary_invocable;
+
+#include <cuda/std/concepts>
+#include <cuda/std/iterator>
+
+#include "indirectly_readable.h"
+#include "test_macros.h"
+
+using It1 = IndirectlyReadable<struct Token>;
+using It2 = IndirectlyReadable2<struct Token>;
+using R1  = T1<struct ReturnToken>;
+using R2  = T2<struct ReturnToken>;
+
+template <class I1, class I2>
+struct GoodInvocable
+{
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<I1>&, cuda::std::iter_value_t<I2>&) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<I1>&, cuda::std::iter_reference_t<I2>) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_reference_t<I1>, cuda::std::iter_value_t<I2>&) const;
+  TEST_FUNC R2 operator()(cuda::std::iter_reference_t<I1>, cuda::std::iter_reference_t<I2>) const;
+  TEST_FUNC R2 operator()(cuda::std::iter_common_reference_t<I1>, cuda::std::iter_common_reference_t<I2>) const;
+};
+
+// Should work when all constraints are satisfied
+static_assert(cuda::std::__indirectly_binary_invocable<GoodInvocable<It1, It2>, It1, It2>);
+
+// Should fail when the iterator is not indirectly_readable
+#if TEST_STD_VER > 2017
+struct NotIndirectlyReadable
+{};
+static_assert(
+  !cuda::std::__indirectly_binary_invocable<GoodInvocable<NotIndirectlyReadable, It2>, NotIndirectlyReadable, It2>);
+#endif
+
+// Should fail when the invocable is not copy constructible
+struct BadInvocable1
+{
+  BadInvocable1(BadInvocable1 const&) = delete;
+  template <class T1, class T2>
+  TEST_FUNC R1 operator()(T1 const&, T2 const&) const;
+};
+static_assert(!cuda::std::__indirectly_binary_invocable<BadInvocable1, It1, It2>);
+
+// Should fail when the invocable can't be called with (cuda::std::iter_value_t<I1>&, cuda::std::iter_value_t<I2>&)
+struct BadInvocable2
+{
+  template <class T1, class T2>
+  TEST_FUNC R1 operator()(T1 const&, T2 const&) const;
+  R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_value_t<It2>&) const = delete;
+};
+static_assert(!cuda::std::__indirectly_binary_invocable<BadInvocable2, It1, It2>);
+
+// Should fail when the invocable can't be called with (cuda::std::iter_value_t<I1>&, cuda::std::iter_reference_t<I2>)
+struct BadInvocable3
+{
+  template <class T1, class T2>
+  TEST_FUNC R1 operator()(T1 const&, T2 const&) const;
+  R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_reference_t<It2>) const = delete;
+};
+static_assert(!cuda::std::__indirectly_binary_invocable<BadInvocable3, It1, It2>);
+
+// Should fail when the invocable can't be called with (cuda::std::iter_reference_t<I1>, cuda::std::iter_value_t<I2>&)
+struct BadInvocable4
+{
+  template <class T1, class T2>
+  TEST_FUNC R1 operator()(T1 const&, T2 const&) const;
+  R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_value_t<It2>&) const = delete;
+};
+static_assert(!cuda::std::__indirectly_binary_invocable<BadInvocable4, It1, It2>);
+
+// Should fail when the invocable can't be called with (cuda::std::iter_reference_t<I1>,
+// cuda::std::iter_reference_t<I2>)
+struct BadInvocable5
+{
+  template <class T1, class T2>
+  TEST_FUNC R1 operator()(T1 const&, T2 const&) const;
+  R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_reference_t<It2>) const = delete;
+};
+static_assert(!cuda::std::__indirectly_binary_invocable<BadInvocable5, It1, It2>);
+
+// Should fail when the invocable can't be called with (iter_common_reference_t)
+struct BadInvocable6
+{
+  template <class T1, class T2>
+  TEST_FUNC R1 operator()(T1 const&, T2 const&) const;
+  R1 operator()(cuda::std::iter_common_reference_t<It1>, cuda::std::iter_common_reference_t<It2>) const = delete;
+};
+static_assert(!cuda::std::__indirectly_binary_invocable<BadInvocable6, It1, It2>);
+
+// Should fail when the invocable doesn't have a common reference between its return types
+struct BadInvocable7
+{
+  struct Unrelated
+  {};
+  TEST_FUNC Unrelated operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_common_reference_t<It1>, cuda::std::iter_common_reference_t<It2>) const;
+};
+static_assert(!cuda::std::__indirectly_binary_invocable<BadInvocable7, It1, It2>);
+
+// Should fail when the invocable doesn't have a common reference between its return types
+struct BadInvocable8
+{
+  struct Unrelated
+  {};
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC Unrelated operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_common_reference_t<It1>, cuda::std::iter_common_reference_t<It2>) const;
+};
+static_assert(!cuda::std::__indirectly_binary_invocable<BadInvocable8, It1, It2>);
+
+// Should fail when the invocable doesn't have a common reference between its return types
+struct BadInvocable9
+{
+  struct Unrelated
+  {};
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC Unrelated operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_common_reference_t<It1>, cuda::std::iter_common_reference_t<It2>) const;
+};
+static_assert(!cuda::std::__indirectly_binary_invocable<BadInvocable9, It1, It2>);
+
+// Should fail when the invocable doesn't have a common reference between its return types
+struct BadInvocable10
+{
+  struct Unrelated
+  {};
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC Unrelated operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_common_reference_t<It1>, cuda::std::iter_common_reference_t<It2>) const;
+};
+static_assert(!cuda::std::__indirectly_binary_invocable<BadInvocable10, It1, It2>);
+
+// Should fail when the invocable doesn't have a common reference between its return types
+struct BadInvocable11
+{
+  struct Unrelated
+  {};
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC Unrelated operator()(cuda::std::iter_common_reference_t<It1>, cuda::std::iter_common_reference_t<It2>) const;
+};
+static_assert(!cuda::std::__indirectly_binary_invocable<BadInvocable11, It1, It2>);
+
+// Various tests with callables
+struct S
+{};
+static_assert(cuda::std::__indirectly_binary_invocable<int (*)(int, double), int*, double*>);
+static_assert(cuda::std::__indirectly_binary_invocable<int (&)(int, double), int*, double*>);
+static_assert(cuda::std::__indirectly_binary_invocable<void (*)(int, double), int*, double*>);
+
+static_assert(!cuda::std::__indirectly_binary_invocable<int(int, double), int*, double*>); // not move constructible
+static_assert(!cuda::std::__indirectly_binary_invocable<int (*)(int*, int*, int*), int*, int*>);
+static_assert(!cuda::std::__indirectly_binary_invocable<int (&)(int*, int*, int*), int*, int*>);
+static_assert(!cuda::std::__indirectly_binary_invocable<int (*)(int*), int*, int*>);
+static_assert(!cuda::std::__indirectly_binary_invocable<int (&)(int*), int*, int*>);
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirectly_regular_binary_invocable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirectly_regular_binary_invocable.compile.pass.cpp
@@ -1,0 +1,183 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template<class F, class I1, class I2>
+// concept __indirectly_regular_binary_invocable;
+
+#include <cuda/std/concepts>
+#include <cuda/std/iterator>
+
+#include "indirectly_readable.h"
+#include "test_macros.h"
+
+using It1 = IndirectlyReadable<struct Token>;
+using It2 = IndirectlyReadable2<struct Token>;
+using R1  = T1<struct ReturnToken>;
+using R2  = T2<struct ReturnToken>;
+
+template <class I1, class I2>
+struct GoodInvocable
+{
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<I1>&, cuda::std::iter_value_t<I2>&) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<I1>&, cuda::std::iter_reference_t<I2>) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_reference_t<I1>, cuda::std::iter_value_t<I2>&) const;
+  TEST_FUNC R2 operator()(cuda::std::iter_reference_t<I1>, cuda::std::iter_reference_t<I2>) const;
+  TEST_FUNC R2 operator()(cuda::std::iter_common_reference_t<I1>, cuda::std::iter_common_reference_t<I2>) const;
+};
+
+// Should work when all constraints are satisfied
+static_assert(cuda::std::__indirectly_regular_binary_invocable<GoodInvocable<It1, It2>, It1, It2>);
+
+// Should fail when the iterator is not indirectly_readable
+#if TEST_STD_VER > 2017
+struct NotIndirectlyReadable
+{};
+static_assert(
+  !cuda::std::
+    __indirectly_regular_binary_invocable<GoodInvocable<NotIndirectlyReadable, It2>, NotIndirectlyReadable, It2>);
+#endif
+
+// Should fail when the invocable is not copy constructible
+struct BadInvocable1
+{
+  BadInvocable1(BadInvocable1 const&) = delete;
+  template <class T1, class T2>
+  TEST_FUNC R1 operator()(T1 const&, T2 const&) const;
+};
+static_assert(!cuda::std::__indirectly_regular_binary_invocable<BadInvocable1, It1, It2>);
+
+// Should fail when the invocable can't be called with (cuda::std::iter_value_t<I1>&, cuda::std::iter_value_t<I2>&)
+struct BadInvocable2
+{
+  template <class T1, class T2>
+  TEST_FUNC R1 operator()(T1 const&, T2 const&) const;
+  R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_value_t<It2>&) const = delete;
+};
+static_assert(!cuda::std::__indirectly_regular_binary_invocable<BadInvocable2, It1, It2>);
+
+// Should fail when the invocable can't be called with (cuda::std::iter_value_t<I1>&, cuda::std::iter_reference_t<I2>)
+struct BadInvocable3
+{
+  template <class T1, class T2>
+  TEST_FUNC R1 operator()(T1 const&, T2 const&) const;
+  R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_reference_t<It2>) const = delete;
+};
+static_assert(!cuda::std::__indirectly_regular_binary_invocable<BadInvocable3, It1, It2>);
+
+// Should fail when the invocable can't be called with (cuda::std::iter_reference_t<I1>, cuda::std::iter_value_t<I2>&)
+struct BadInvocable4
+{
+  template <class T1, class T2>
+  TEST_FUNC R1 operator()(T1 const&, T2 const&) const;
+  R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_value_t<It2>&) const = delete;
+};
+static_assert(!cuda::std::__indirectly_regular_binary_invocable<BadInvocable4, It1, It2>);
+
+// Should fail when the invocable can't be called with (cuda::std::iter_reference_t<I1>,
+// cuda::std::iter_reference_t<I2>)
+struct BadInvocable5
+{
+  template <class T1, class T2>
+  TEST_FUNC R1 operator()(T1 const&, T2 const&) const;
+  R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_reference_t<It2>) const = delete;
+};
+static_assert(!cuda::std::__indirectly_regular_binary_invocable<BadInvocable5, It1, It2>);
+
+// Should fail when the invocable can't be called with (iter_common_reference_t)
+struct BadInvocable6
+{
+  template <class T1, class T2>
+  TEST_FUNC R1 operator()(T1 const&, T2 const&) const;
+  R1 operator()(cuda::std::iter_common_reference_t<It1>, cuda::std::iter_common_reference_t<It2>) const = delete;
+};
+static_assert(!cuda::std::__indirectly_regular_binary_invocable<BadInvocable6, It1, It2>);
+
+// Should fail when the invocable doesn't have a common reference between its return types
+struct BadInvocable7
+{
+  struct Unrelated
+  {};
+  TEST_FUNC Unrelated operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_common_reference_t<It1>, cuda::std::iter_common_reference_t<It2>) const;
+};
+static_assert(!cuda::std::__indirectly_regular_binary_invocable<BadInvocable7, It1, It2>);
+
+// Should fail when the invocable doesn't have a common reference between its return types
+struct BadInvocable8
+{
+  struct Unrelated
+  {};
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC Unrelated operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_common_reference_t<It1>, cuda::std::iter_common_reference_t<It2>) const;
+};
+static_assert(!cuda::std::__indirectly_regular_binary_invocable<BadInvocable8, It1, It2>);
+
+// Should fail when the invocable doesn't have a common reference between its return types
+struct BadInvocable9
+{
+  struct Unrelated
+  {};
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC Unrelated operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_common_reference_t<It1>, cuda::std::iter_common_reference_t<It2>) const;
+};
+static_assert(!cuda::std::__indirectly_regular_binary_invocable<BadInvocable9, It1, It2>);
+
+// Should fail when the invocable doesn't have a common reference between its return types
+struct BadInvocable10
+{
+  struct Unrelated
+  {};
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC Unrelated operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_common_reference_t<It1>, cuda::std::iter_common_reference_t<It2>) const;
+};
+static_assert(!cuda::std::__indirectly_regular_binary_invocable<BadInvocable10, It1, It2>);
+
+// Should fail when the invocable doesn't have a common reference between its return types
+struct BadInvocable11
+{
+  struct Unrelated
+  {};
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_value_t<It2>&) const;
+  TEST_FUNC R1 operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_reference_t<It2>) const;
+  TEST_FUNC Unrelated operator()(cuda::std::iter_common_reference_t<It1>, cuda::std::iter_common_reference_t<It2>) const;
+};
+static_assert(!cuda::std::__indirectly_regular_binary_invocable<BadInvocable11, It1, It2>);
+
+// Various tests with callables
+struct S
+{};
+static_assert(cuda::std::__indirectly_regular_binary_invocable<int (*)(int, double), int*, double*>);
+static_assert(cuda::std::__indirectly_regular_binary_invocable<int (&)(int, double), int*, double*>);
+static_assert(cuda::std::__indirectly_regular_binary_invocable<void (*)(int, double), int*, double*>);
+
+static_assert(!cuda::std::__indirectly_regular_binary_invocable<int(int, double), int*, double*>); // not move
+                                                                                                   // constructible
+static_assert(!cuda::std::__indirectly_regular_binary_invocable<int (*)(int*, int*, int*), int*, int*>);
+static_assert(!cuda::std::__indirectly_regular_binary_invocable<int (&)(int*, int*, int*), int*, int*>);
+static_assert(!cuda::std::__indirectly_regular_binary_invocable<int (*)(int*), int*, int*>);
+static_assert(!cuda::std::__indirectly_regular_binary_invocable<int (&)(int*), int*, int*>);
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/support/indirectly_readable.h
+++ b/libcudacxx/test/support/indirectly_readable.h
@@ -46,4 +46,11 @@ struct IndirectlyReadable
   TEST_FUNC T2<Token>& operator*() const;
 };
 
+template <class Token>
+struct IndirectlyReadable2
+{
+  using value_type = T1<Token>;
+  TEST_FUNC T2<Token>& operator*() const;
+};
+
 #endif // LIBCXX_TEST_SUPPORT_INDIRECTLY_READABLE_H


### PR DESCRIPTION
The standard currently does only know `indirectly_unary_invocable`. However, there are a lot of algorithms like `adjacent_difference` where we want to make sure that we can invoke a functor by dereferencing two iterators.

Add this as an extension