### PR TITLE
[CUB] Refactor `DeviceAdjacentDifference::SubtractRight` to always take an environment

### DIFF
--- a/cub/cub/device/device_adjacent_difference.cuh
+++ b/cub/cub/device/device_adjacent_difference.cuh
@@ -24,7 +24,6 @@
 #include <cuda/std/__execution/env.h>
 #include <cuda/std/__iterator/concepts.h>
 #include <cuda/std/__type_traits/enable_if.h>
-#include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
@@ -437,6 +436,9 @@ struct DeviceAdjacentDifference
   //! @tparam NumItemsT
   //!   **[inferred]** Type of num_items
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Execution environment type. Default is ``cuda::std::execution::env<>``.
+  //!
   //! @param[in] d_temp_storage
   //!   @devicestorage
   //!
@@ -455,14 +457,15 @@ struct DeviceAdjacentDifference
   //! @param[in] difference_op
   //!   The binary function used to compute differences.
   //!
-  //! @param[in] stream
+  //! @param[in] env
   //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
   template <typename InputIteratorT,
             typename OutputIteratorT,
             typename DifferenceOpT = ::cuda::std::minus<>,
-            typename NumItemsT     = uint32_t>
+            typename NumItemsT     = uint32_t,
+            typename EnvT          = ::cuda::std::execution::env<>>
   static CUB_RUNTIME_FUNCTION cudaError_t SubtractRightCopy(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -470,12 +473,21 @@ struct DeviceAdjacentDifference
     OutputIteratorT d_output,
     NumItemsT num_items,
     DifferenceOpT difference_op = {},
-    cudaStream_t stream         = nullptr)
+    const EnvT& env             = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceAdjacentDifference::SubtractRightCopy");
-    using OffsetT = detail::choose_offset_t<NumItemsT>;
-    return detail::adjacent_difference::dispatch<MayAlias::No, ReadOption::Right>(
-      d_temp_storage, temp_storage_bytes, d_input, d_output, static_cast<OffsetT>(num_items), difference_op, stream);
+
+    using OffsetT                 = detail::choose_offset_t<NumItemsT>;
+    using default_policy_selector = detail::adjacent_difference::policy_selector_from_types<InputIteratorT, false>;
+
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      d_temp_storage,
+      temp_storage_bytes,
+      env,
+      [&](auto policy_selector, void* storage, size_t& bytes, cudaStream_t stream) {
+        return detail::adjacent_difference::dispatch<MayAlias::No, ReadOption::Right>(
+          storage, bytes, d_input, d_output, static_cast<OffsetT>(num_items), difference_op, stream, policy_selector);
+      });
   }
 
   //! @rst
@@ -536,6 +548,9 @@ struct DeviceAdjacentDifference
   //! @tparam NumItemsT
   //!   **[inferred]** Type of num_items
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Execution environment type. Default is ``cuda::std::execution::env<>``.
+  //!
   //! @param[in] d_temp_storage
   //!   @devicestorage
   //!
@@ -551,23 +566,36 @@ struct DeviceAdjacentDifference
   //! @param[in] difference_op
   //!   The binary function used to compute differences
   //!
-  //! @param[in] stream
+  //! @param[in] env
   //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
-  template <typename RandomAccessIteratorT, typename DifferenceOpT = ::cuda::std::minus<>, typename NumItemsT = uint32_t>
+  template <typename RandomAccessIteratorT,
+            typename DifferenceOpT = ::cuda::std::minus<>,
+            typename NumItemsT     = uint32_t,
+            typename EnvT          = ::cuda::std::execution::env<>>
   static CUB_RUNTIME_FUNCTION cudaError_t SubtractRight(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     RandomAccessIteratorT d_input,
     NumItemsT num_items,
     DifferenceOpT difference_op = {},
-    cudaStream_t stream         = nullptr)
+    const EnvT& env             = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceAdjacentDifference::SubtractRight");
+
     using OffsetT = detail::choose_offset_t<NumItemsT>;
-    return detail::adjacent_difference::dispatch<MayAlias::Yes, ReadOption::Right>(
-      d_temp_storage, temp_storage_bytes, d_input, d_input, static_cast<OffsetT>(num_items), difference_op, stream);
+    using default_policy_selector =
+      detail::adjacent_difference::policy_selector_from_types<RandomAccessIteratorT, true>;
+
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      d_temp_storage,
+      temp_storage_bytes,
+      env,
+      [&](auto policy_selector, void* storage, size_t& bytes, cudaStream_t stream) {
+        return detail::adjacent_difference::dispatch<MayAlias::Yes, ReadOption::Right>(
+          storage, bytes, d_input, d_input, static_cast<OffsetT>(num_items), difference_op, stream, policy_selector);
+      });
   }
 
   //! @rst
@@ -815,18 +843,20 @@ struct DeviceAdjacentDifference
   //!   @rst
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
-  template <typename InputIteratorT,
-            typename OutputIteratorT,
-            typename DifferenceOpT                                               = ::cuda::std::minus<>,
-            typename NumItemsT                                                   = uint32_t,
-            typename EnvT                                                        = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
+  template <
+    typename InputIteratorT,
+    typename OutputIteratorT,
+    typename DifferenceOpT        = ::cuda::std::minus<>,
+    typename NumItemsT            = uint32_t,
+    typename EnvT                 = ::cuda::std::execution::env<>,
+    ::cuda::std::enable_if_t<::cuda::std::__indirectly_binary_invocable<DifferenceOpT, InputIteratorT, InputIteratorT>,
+                             int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t SubtractRightCopy(
     InputIteratorT d_input,
     OutputIteratorT d_output,
     NumItemsT num_items,
     DifferenceOpT difference_op = {},
-    EnvT env                    = {})
+    const EnvT& env             = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceAdjacentDifference::SubtractRightCopy");
 
@@ -834,16 +864,9 @@ struct DeviceAdjacentDifference
     using default_policy_selector = detail::adjacent_difference::policy_selector_from_types<InputIteratorT, false>;
 
     return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+      env, [&](auto policy_selector, void* storage, size_t& bytes, cudaStream_t stream) {
         return detail::adjacent_difference::dispatch<MayAlias::No, ReadOption::Right>(
-          d_temp_storage,
-          temp_storage_bytes,
-          d_input,
-          d_output,
-          static_cast<OffsetT>(num_items),
-          difference_op,
-          stream,
-          policy_selector);
+          storage, bytes, d_input, d_output, static_cast<OffsetT>(num_items), difference_op, stream, policy_selector);
       });
   }
 
@@ -910,9 +933,11 @@ struct DeviceAdjacentDifference
             typename DifferenceOpT = ::cuda::std::minus<>,
             typename NumItemsT     = uint32_t,
             typename EnvT          = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT> && !::cuda::std::is_integral_v<EnvT>, int> = 0>
-  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t
-  SubtractRight(RandomAccessIteratorT d_input, NumItemsT num_items, DifferenceOpT difference_op = {}, EnvT env = {})
+            ::cuda::std::enable_if_t<
+              ::cuda::std::__indirectly_binary_invocable<DifferenceOpT, RandomAccessIteratorT, RandomAccessIteratorT>,
+              int> = 0>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t SubtractRight(
+    RandomAccessIteratorT d_input, NumItemsT num_items, DifferenceOpT difference_op = {}, const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceAdjacentDifference::SubtractRight");
 
@@ -921,16 +946,9 @@ struct DeviceAdjacentDifference
       detail::adjacent_difference::policy_selector_from_types<RandomAccessIteratorT, true>;
 
     return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+      env, [&](auto policy_selector, void* storage, size_t& bytes, cudaStream_t stream) {
         return detail::adjacent_difference::dispatch<MayAlias::Yes, ReadOption::Right>(
-          d_temp_storage,
-          temp_storage_bytes,
-          d_input,
-          d_input,
-          static_cast<OffsetT>(num_items),
-          difference_op,
-          stream,
-          policy_selector);
+          storage, bytes, d_input, d_input, static_cast<OffsetT>(num_items), difference_op, stream, policy_selector);
       });
   }
 };

--- a/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
@@ -5,7 +5,9 @@
 
 #include <cub/device/device_adjacent_difference.cuh>
 
+#include <cuda/devices>
 #include <cuda/iterator>
+#include <cuda/std/execution>
 
 #include <algorithm>
 #include <numeric>
@@ -91,6 +93,97 @@ struct ref_diff
 };
 _CCCL_SUPPRESS_DEPRECATED_POP
 
+#if TEST_LAUNCH == 0
+C2H_TEST("DeviceAdjacentDifference::SubtractRight works with user provided memory and environment",
+         "[device][adjacent_difference]",
+         types)
+{
+  using type = typename c2h::get<0, TestType>;
+
+  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
+  c2h::device_vector<type> in(num_items, thrust::default_init);
+  c2h::device_vector<type> out(num_items, thrust::default_init);
+  c2h::gen(C2H_SEED(2), in);
+
+  c2h::host_vector<type> h_in = in;
+  c2h::host_vector<type> reference(num_items, thrust::default_init);
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), ref_diff<type>{});
+  std::rotate(reference.begin(), reference.begin() + 1, reference.end());
+  reference.back() = h_in.back();
+
+  size_t expected_allocation_size = 0;
+  auto error                      = cub::DeviceAdjacentDifference::SubtractRight(
+    static_cast<void*>(nullptr), expected_allocation_size, in.begin(), num_items, cuda::std::minus<>{});
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  auto d_temp        = c2h::device_vector<uint8_t>(expected_allocation_size, thrust::no_init);
+  void* temp_storage = thrust::raw_pointer_cast(d_temp.data());
+
+  auto test_subtract_right = [&](const auto& env) {
+    size_t num_bytes = 0;
+    error            = cub::DeviceAdjacentDifference::SubtractRight(
+      static_cast<void*>(nullptr), num_bytes, in.begin(), num_items, cuda::std::minus<>{}, env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+    REQUIRE(expected_allocation_size == num_bytes);
+
+    error = cub::DeviceAdjacentDifference::SubtractRight(
+      temp_storage, num_bytes, in.begin(), num_items, cuda::std::minus<>{}, env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    // Verify result
+    REQUIRE(reference == in);
+  };
+
+  int current_device;
+  error = cudaGetDevice(&current_device);
+  REQUIRE(error == cudaSuccess);
+
+  SECTION("DeviceAdjacentDifference::SubtractRight works with cudaStream_t")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_subtract_right(stream.get());
+  }
+
+  SECTION("DeviceAdjacentDifference::SubtractRight works with cuda::stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_subtract_right(stream);
+  }
+
+  SECTION("DeviceAdjacentDifference::SubtractRight works with cuda::stream_ref")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    cuda::stream_ref stream_ref{stream};
+    test_subtract_right(stream_ref);
+  }
+
+  SECTION("DeviceAdjacentDifference::SubtractRight works with cuda::std::execution::env")
+  {
+    cuda::std::execution::env env{};
+    test_subtract_right(env);
+  }
+
+  SECTION("DeviceAdjacentDifference::SubtractRight works with cuda::execution::gpu")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_subtract_right(policy);
+  }
+
+  SECTION("DeviceAdjacentDifference::SubtractRight works with cuda::execution::gpu with stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_subtract_right(policy);
+  }
+}
+#endif // TEST_LAUNCH == 0
+
 C2H_TEST("DeviceAdjacentDifference::SubtractRight works with iterators", "[device][adjacent_difference]", types)
 {
   using type = typename c2h::get<0, TestType>;
@@ -110,6 +203,97 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRight works with iterators", "[devic
 
   REQUIRE(reference == in);
 }
+
+#if TEST_LAUNCH == 0
+C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy works with user provided memory and environment",
+         "[device][adjacent_difference]",
+         types)
+{
+  using type = typename c2h::get<0, TestType>;
+
+  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
+  c2h::device_vector<type> in(num_items);
+  c2h::device_vector<type> out(num_items);
+  c2h::gen(C2H_SEED(2), in);
+
+  c2h::host_vector<type> h_in = in;
+  c2h::host_vector<type> reference(num_items);
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), ref_diff<type>{});
+  std::rotate(reference.begin(), reference.begin() + 1, reference.end());
+  reference.back() = h_in.back();
+
+  size_t expected_allocation_size = 0;
+  auto error                      = cub::DeviceAdjacentDifference::SubtractRightCopy(
+    static_cast<void*>(nullptr), expected_allocation_size, in.begin(), out.begin(), num_items, cuda::std::minus<>{});
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  auto d_temp        = c2h::device_vector<uint8_t>(expected_allocation_size, thrust::no_init);
+  void* temp_storage = thrust::raw_pointer_cast(d_temp.data());
+
+  auto test_subtract_right_copy = [&](const auto& env) {
+    size_t num_bytes = 0;
+    error            = cub::DeviceAdjacentDifference::SubtractRightCopy(
+      static_cast<void*>(nullptr), num_bytes, in.begin(), out.begin(), num_items, cuda::std::minus<>{}, env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+    REQUIRE(expected_allocation_size == num_bytes);
+
+    error = cub::DeviceAdjacentDifference::SubtractRightCopy(
+      temp_storage, num_bytes, in.begin(), out.begin(), num_items, cuda::std::minus<>{}, env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    // Verify result
+    REQUIRE(reference == out);
+  };
+
+  int current_device;
+  error = cudaGetDevice(&current_device);
+  REQUIRE(error == cudaSuccess);
+
+  SECTION("DeviceAdjacentDifference::SubtractRightCopy works with cudaStream_t")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_subtract_right_copy(stream.get());
+  }
+
+  SECTION("DeviceAdjacentDifference::SubtractRightCopy works with cuda::stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_subtract_right_copy(stream);
+  }
+
+  SECTION("DeviceAdjacentDifference::SubtractRightCopy works with cuda::stream_ref")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    cuda::stream_ref stream_ref{stream};
+    test_subtract_right_copy(stream_ref);
+  }
+
+  SECTION("DeviceAdjacentDifference::SubtractRightCopy works with cuda::std::execution::env")
+  {
+    cuda::std::execution::env env{};
+    test_subtract_right_copy(env);
+  }
+
+  SECTION("DeviceAdjacentDifference::SubtractRightCopy works with cuda::execution::gpu")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_subtract_right_copy(policy);
+  }
+
+  SECTION("DeviceAdjacentDifference::SubtractRightCopy works with cuda::execution::gpu with stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_subtract_right_copy(policy);
+  }
+}
+#endif // TEST_LAUNCH == 0
 
 C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy works with iterators", "[device][adjacent_difference]", types)
 {


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.