### PR TITLE
[cuda.compute]: stop wrapping binary search comparator in python callable

### DIFF
--- a/python/cuda_cccl/cuda/compute/algorithms/_binary_search.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_binary_search.py
@@ -16,19 +16,6 @@ from ..op import OpAdapter, OpKind, make_op_adapter
 from ..typing import DeviceArrayLike, IteratorT, Operator
 
 
-def _normalize_comp(comp: Operator | None) -> OpAdapter:
-    # Use a lambda for the default comparator rather than OpKind.LESS
-    # because well-known ops don't carry type information needed by
-    # the binary search JIT compilation.
-    if comp is None or comp is OpKind.LESS:
-
-        def _default_less(a, b):
-            return a < b
-
-        return make_op_adapter(_default_less)
-    return make_op_adapter(comp)
-
-
 class _BinarySearch:
     __slots__ = [
         "build_result",
@@ -96,9 +83,7 @@ class _BinarySearch:
         set_cccl_iterator_state(self.d_out_cccl, d_out)
 
         # Update op state for stateful ops
-        comp_adapter = (
-            _normalize_comp(comp) if comp is not None else _normalize_comp(None)
-        )
+        comp_adapter = make_op_adapter(OpKind.LESS if comp is None else comp)
         self.op_cccl.state = comp_adapter.get_state()
 
         stream_handle = protocols.validate_and_get_stream(stream)
@@ -154,7 +139,7 @@ def make_lower_bound(
     See Also:
         :func:`lower_bound`
     """
-    comp_adapter = _normalize_comp(comp)
+    comp_adapter = make_op_adapter(OpKind.LESS if comp is None else comp)
     return _make_binary_search(
         d_data,
         d_values,
@@ -193,7 +178,7 @@ def make_upper_bound(
     See Also:
         :func:`upper_bound`
     """
-    comp_adapter = _normalize_comp(comp)
+    comp_adapter = make_op_adapter(OpKind.LESS if comp is None else comp)
     return _make_binary_search(
         d_data,
         d_values,

--- a/python/cuda_cccl/tests/compute/test_binary_search.py
+++ b/python/cuda_cccl/tests/compute/test_binary_search.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import cuda.compute
+from cuda.compute import OpKind
 
 DTYPE_LIST = [
     np.int32,
@@ -37,6 +38,65 @@ def disable_sass_check(monkeypatch):
         "_check_sass",
         False,
     )
+
+
+@pytest.mark.parametrize(
+    "search, side",
+    [
+        (cuda.compute.lower_bound, "left"),
+        (cuda.compute.upper_bound, "right"),
+    ],
+)
+def test_binary_search_explicit_opkind_less(search, side):
+    h_data = np.array([1, 3, 3, 7, 9], dtype=np.int32)
+    h_values = np.array([0, 3, 4, 10], dtype=np.int32)
+
+    d_data = cp.asarray(h_data)
+    d_values = cp.asarray(h_values)
+    d_out = cp.empty(len(h_values), dtype=np.uintp)
+
+    search(
+        d_data=d_data,
+        num_items=len(d_data),
+        d_values=d_values,
+        num_values=len(d_values),
+        d_out=d_out,
+        comp=OpKind.LESS,
+    )
+
+    expected = np.searchsorted(h_data, h_values, side=side).astype(np.uintp)
+    np.testing.assert_array_equal(d_out.get(), expected)
+
+
+@pytest.mark.parametrize(
+    "search, side",
+    [
+        (cuda.compute.lower_bound, "left"),
+        (cuda.compute.upper_bound, "right"),
+    ],
+)
+def test_binary_search_custom_comparator(search, side):
+    h_data = np.array([9, 7, 3, 3, 1], dtype=np.int32)
+    h_values = np.array([10, 4, 3, 0], dtype=np.int32)
+
+    def greater(lhs, rhs):
+        return lhs > rhs
+
+    d_data = cp.asarray(h_data)
+    d_values = cp.asarray(h_values)
+    d_out = cp.empty(len(h_values), dtype=np.uintp)
+
+    search(
+        d_data=d_data,
+        num_items=len(d_data),
+        d_values=d_values,
+        num_values=len(d_values),
+        d_out=d_out,
+        comp=greater,
+    )
+
+    expected = np.searchsorted(-h_data, -h_values, side=side).astype(np.uintp)
+    np.testing.assert_array_equal(d_out.get(), expected)
 
 
 @pytest.mark.parametrize("dtype", DTYPE_LIST)


### PR DESCRIPTION
## Description

Previously we wrapped `OpKind.LESS` in a comparator. I tested it locally and found that this is no longer necessary. Also added tests for full coverage of possible comparators.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
