### PR TITLE
Refactor `DeviceFind`

### DIFF
--- a/cub/cub/detail/env_dispatch.cuh
+++ b/cub/cub/detail/env_dispatch.cuh
@@ -102,8 +102,7 @@ dispatch_with_env_and_tuning(const EnvT& env, AlgorithmCallable&& algorithm_call
 //! @param[in,out] temp_storage_bytes Reference to size in bytes of `d_temp_storage` allocation
 //! @param algorithm_callable Callable that invokes the algorithm implementation with determinism specified
 template <typename EnvT, typename AlgorithmCallable>
-CUB_RUNTIME_FUNCTION static cudaError_t dispatch_with_env(
-  void* d_temp_storage, size_t& temp_storage_bytes, const EnvT& env, AlgorithmCallable&& algorithm_callable)
+CUB_RUNTIME_FUNCTION static cudaError_t unpack_env(const EnvT& env, AlgorithmCallable&& algorithm_callable)
 {
   // Query stream from environment
   auto stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, env);
@@ -111,25 +110,7 @@ CUB_RUNTIME_FUNCTION static cudaError_t dispatch_with_env(
   // Query tuning from environment
   const auto tuning = ::cuda::__call_or(::cuda::execution::__get_tuning, ::cuda::std::execution::env<>{}, env);
 
-  return algorithm_callable(tuning, d_temp_storage, temp_storage_bytes, stream.get());
-}
-//! @endcond
-
-template <typename DefaultPolicySelector, typename EnvT, typename AlgorithmCallable>
-CUB_RUNTIME_FUNCTION static cudaError_t dispatch_with_env_and_tuning(
-  void* d_temp_storage, size_t& temp_storage_bytes, const EnvT& env, AlgorithmCallable&& algorithm_callable)
-{
-  return detail::dispatch_with_env(
-    d_temp_storage,
-    temp_storage_bytes,
-    env,
-    [&algorithm_callable](
-      [[maybe_unused]] auto tuning_env, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
-      using policy_t = decltype(DefaultPolicySelector{}(::cuda::compute_capability{}));
-      using policy_selector =
-        ::cuda::std::execution::__query_result_or_t<decltype(tuning_env), policy_t, DefaultPolicySelector>;
-      return algorithm_callable(policy_selector{}, d_temp_storage, temp_storage_bytes, stream);
-    });
+  return algorithm_callable(tuning, stream.get());
 }
 //! @endcond
 } // namespace detail

--- a/cub/cub/device/device_find.cuh
+++ b/cub/cub/device/device_find.cuh
@@ -149,17 +149,10 @@ struct DeviceFind
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceFind::FindIf");
 
     using OffsetT = detail::choose_offset_t<NumItemsT>;
-
-    using default_policy_selector = detail::find::policy_selector_from_types<detail::it_value_t<InputIteratorT>>;
-
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      d_temp_storage,
-      temp_storage_bytes,
-      env,
-      [&](auto policy_selector, void* storage, size_t& bytes, cudaStream_t stream) {
-        return detail::find::dispatch(
-          storage, bytes, d_in, d_out, static_cast<OffsetT>(num_items), scan_op, stream, policy_selector);
-      });
+    return detail::unpack_env(env, [&]([[maybe_unused]] auto tuning_env, cudaStream_t stream) {
+      return detail::find::dispatch(
+        d_temp_storage, temp_storage_bytes, d_in, d_out, static_cast<OffsetT>(num_items), scan_op, stream, tuning_env);
+    });
   }
 
   //! @rst
@@ -268,26 +261,22 @@ struct DeviceFind
     using RangeOffsetT  = detail::choose_offset_t<RangeNumItemsT>;
     using ValuesOffsetT = detail::choose_offset_t<ValuesNumItemsT>;
 
-    return detail::dispatch_with_env(
-      d_temp_storage,
-      temp_storage_bytes,
-      env,
-      [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-        if (storage == nullptr)
-        {
-          bytes = 1;
-          return cudaSuccess;
-        }
+    return detail::unpack_env(env, [&]([[maybe_unused]] auto tuning, auto stream) {
+      if (d_temp_storage == nullptr)
+      {
+        temp_storage_bytes = 1;
+        return cudaSuccess;
+      }
 
-        return DeviceTransform::__transform_internal(
-          ::cuda::std::make_tuple(d_values),
-          d_output,
-          static_cast<ValuesOffsetT>(values_num_items),
-          ::cuda::always_true{},
-          detail::find::make_binary_search_transform_op<detail::find::lower_bound>(
-            d_range, static_cast<RangeOffsetT>(range_num_items), comp),
-          ::cuda::stream_ref{stream});
-      });
+      return DeviceTransform::__transform_internal(
+        ::cuda::std::make_tuple(d_values),
+        d_output,
+        static_cast<ValuesOffsetT>(values_num_items),
+        ::cuda::always_true{},
+        detail::find::make_binary_search_transform_op<detail::find::lower_bound>(
+          d_range, static_cast<RangeOffsetT>(range_num_items), comp),
+        ::cuda::stream_ref{stream});
+    });
   }
 
   //! @rst
@@ -397,26 +386,22 @@ struct DeviceFind
     using RangeOffsetT  = detail::choose_offset_t<RangeNumItemsT>;
     using ValuesOffsetT = detail::choose_offset_t<ValuesNumItemsT>;
 
-    return detail::dispatch_with_env(
-      d_temp_storage,
-      temp_storage_bytes,
-      env,
-      [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-        if (storage == nullptr)
-        {
-          bytes = 1;
-          return cudaSuccess;
-        }
+    return detail::unpack_env(env, [&]([[maybe_unused]] auto tuning, auto stream) {
+      if (d_temp_storage == nullptr)
+      {
+        temp_storage_bytes = 1;
+        return cudaSuccess;
+      }
 
-        return DeviceTransform::__transform_internal(
-          ::cuda::std::make_tuple(d_values),
-          d_output,
-          static_cast<ValuesOffsetT>(values_num_items),
-          ::cuda::always_true{},
-          detail::find::make_binary_search_transform_op<detail::find::upper_bound>(
-            d_range, static_cast<RangeOffsetT>(range_num_items), comp),
-          ::cuda::stream_ref{stream});
-      });
+      return DeviceTransform::__transform_internal(
+        ::cuda::std::make_tuple(d_values),
+        d_output,
+        static_cast<ValuesOffsetT>(values_num_items),
+        ::cuda::always_true{},
+        detail::find::make_binary_search_transform_op<detail::find::upper_bound>(
+          d_range, static_cast<RangeOffsetT>(range_num_items), comp),
+        ::cuda::stream_ref{stream});
+    });
   }
   //! @rst
   //! Finds the first element in the input sequence that satisfies the given predicate.
@@ -496,13 +481,10 @@ struct DeviceFind
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceFind::FindIf");
 
     using OffsetT = detail::choose_offset_t<NumItemsT>;
-
-    using default_policy_selector = detail::find::policy_selector_from_types<detail::it_value_t<InputIteratorT>>;
-
-    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
-      env, [&](auto policy_selector, void* storage, size_t& bytes, cudaStream_t stream) {
+    return detail::dispatch_with_env(
+      env, [&]([[maybe_unused]] auto tuning_env, void* storage, size_t& bytes, cudaStream_t stream) {
         return detail::find::dispatch(
-          storage, bytes, d_in, d_out, static_cast<OffsetT>(num_items), scan_op, stream, policy_selector);
+          storage, bytes, d_in, d_out, static_cast<OffsetT>(num_items), scan_op, stream, tuning_env);
       });
   }
 

--- a/cub/cub/device/dispatch/dispatch_find.cuh
+++ b/cub/cub/device/dispatch/dispatch_find.cuh
@@ -83,10 +83,7 @@ template <typename InputIteratorT,
           typename OutputIteratorT,
           typename OffsetT,
           typename PredicateT,
-          typename PolicySelector = policy_selector_from_types<it_value_t<InputIteratorT>>>
-#if _CCCL_HAS_CONCEPTS()
-  requires find_policy_selector<PolicySelector>
-#endif // _CCCL_HAS_CONCEPTS()
+          typename TuningEnvT = ::cuda::std::execution::env<>>
 CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   void* d_temp_storage,
   size_t& temp_storage_bytes,
@@ -95,8 +92,15 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   OffsetT num_items,
   PredicateT predicate,
   cudaStream_t stream,
-  PolicySelector policy_selector = {})
+  TuningEnvT = {})
 {
+  using default_policy_selector_t = policy_selector_from_types<it_value_t<InputIteratorT>>;
+  using policy_selector_t =
+    ::cuda::std::execution::__query_result_or_t<TuningEnvT, FindPolicy, default_policy_selector_t>;
+#if _CCCL_HAS_CONCEPTS()
+  static_assert(find_policy_selector<PolicySelector>);
+#endif // _CCCL_HAS_CONCEPTS()
+
   using output_t = it_value_t<OutputIteratorT>;
 
   // if the output iterator can be turned into a pointer, the value type is integral, and has the same size as OffsetT
@@ -112,7 +116,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
     return error;
   }
 
-  const FindIfPolicy active_policy = policy_selector(cc);
+  const FindIfPolicy active_policy = policy_selector_t{}(cc);
 
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(NV_IS_HOST, ({
@@ -141,7 +145,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   }
 
   using unwrapped_input_iterator_t = THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator_t<InputIteratorT>;
-  auto kernel_ptr                  = find_kernel<PolicySelector, unwrapped_input_iterator_t, OffsetT, PredicateT>;
+  auto kernel_ptr                  = find_kernel<policy_selector_t, unwrapped_input_iterator_t, OffsetT, PredicateT>;
 
   int find_if_sm_occupancy;
   if (const auto error =


### PR DESCRIPTION
This is a follow-up to #9318, suggesting a few improvements.

* Move policy selector handling into dispatch function
* Rename and simplify the simply dispatch_with_env overload to unpack_env
* Remove the simple overload of dispatch_with_env_and_tuning, since it's no longer needed