### PR TITLE
Reorganize cuco implementation headers under detail/

### DIFF
--- a/cudax/include/cuda/experimental/__cuco/detail/hash_functions/murmurhash3.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/hash_functions/murmurhash3.cuh
@@ -19,8 +19,8 @@
  * platform, but your performance with the non-native version will be less than optimal.
  */
 
-#ifndef _CUDAX___CUCO___HASH_FUNCTIONS_MURMURHASH3_CUH
-#define _CUDAX___CUCO___HASH_FUNCTIONS_MURMURHASH3_CUH
+#ifndef _CUDAX___CUCO_DETAIL_HASH_FUNCTIONS_MURMURHASH3_CUH
+#define _CUDAX___CUCO_DETAIL_HASH_FUNCTIONS_MURMURHASH3_CUH
 
 #include <cuda/__cccl_config>
 
@@ -40,7 +40,7 @@
 #include <cuda/std/cstdint>
 #include <cuda/std/span>
 
-#include <cuda/experimental/__cuco/__hash_functions/utils.cuh>
+#include <cuda/experimental/__cuco/detail/hash_functions/utils.cuh>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -845,4 +845,4 @@ private:
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDAX___CUCO___HASH_FUNCTIONS_MURMURHASH3_CUH
+#endif // _CUDAX___CUCO_DETAIL_HASH_FUNCTIONS_MURMURHASH3_CUH

--- a/cudax/include/cuda/experimental/__cuco/detail/hash_functions/utils.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/hash_functions/utils.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDAX___CUCO___HASH_FUNCTIONS_UTILS_CUH
-#define _CUDAX___CUCO___HASH_FUNCTIONS_UTILS_CUH
+#ifndef _CUDAX___CUCO_DETAIL_HASH_FUNCTIONS_UTILS_CUH
+#define _CUDAX___CUCO_DETAIL_HASH_FUNCTIONS_UTILS_CUH
 
 #include <cuda/__cccl_config>
 
@@ -147,4 +147,4 @@ struct _Byte_holder<_KeySize, _ChunkSize, _BlockSize, _UseTailBlock, _BlockT, tr
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDAX___CUCO___HASH_FUNCTIONS_UTILS_CUH
+#endif // _CUDAX___CUCO_DETAIL_HASH_FUNCTIONS_UTILS_CUH

--- a/cudax/include/cuda/experimental/__cuco/detail/hash_functions/xxhash.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/hash_functions/xxhash.cuh
@@ -42,8 +42,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _CUDAX___CUCO___HASH_FUNCTIONS_XXHASH_CUH
-#define _CUDAX___CUCO___HASH_FUNCTIONS_XXHASH_CUH
+#ifndef _CUDAX___CUCO_DETAIL_HASH_FUNCTIONS_XXHASH_CUH
+#define _CUDAX___CUCO_DETAIL_HASH_FUNCTIONS_XXHASH_CUH
 
 #include <cuda/__cccl_config>
 
@@ -63,7 +63,7 @@
 #include <cuda/std/cstdint>
 #include <cuda/std/span>
 
-#include <cuda/experimental/__cuco/__hash_functions/utils.cuh>
+#include <cuda/experimental/__cuco/detail/hash_functions/utils.cuh>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -423,4 +423,4 @@ private:
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDAX___CUCO___HASH_FUNCTIONS_XXHASH_CUH
+#endif // _CUDAX___CUCO_DETAIL_HASH_FUNCTIONS_XXHASH_CUH

--- a/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/default_policy.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/default_policy.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDAX___CUCO___HYPERLOGLOG_DEFAULT_POLICY_CUH
-#define _CUDAX___CUCO___HYPERLOGLOG_DEFAULT_POLICY_CUH
+#ifndef _CUDAX___CUCO_DETAIL_HYPERLOGLOG_DEFAULT_POLICY_CUH
+#define _CUDAX___CUCO_DETAIL_HYPERLOGLOG_DEFAULT_POLICY_CUH
 
 #include <cuda/__cccl_config>
 
@@ -28,7 +28,7 @@
 #include <cuda/std/__utility/declval.h>
 #include <cuda/std/cstdint>
 
-#include <cuda/experimental/__cuco/__hyperloglog/finalizer.cuh>
+#include <cuda/experimental/__cuco/detail/hyperloglog/finalizer.cuh>
 #include <cuda/experimental/__cuco/hash_functions.cuh>
 
 #include <cuda/std/__cccl/prologue.h>
@@ -124,4 +124,4 @@ struct default_hll_policy
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDAX___CUCO___HYPERLOGLOG_DEFAULT_POLICY_CUH
+#endif // _CUDAX___CUCO_DETAIL_HYPERLOGLOG_DEFAULT_POLICY_CUH

--- a/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/finalizer.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/finalizer.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDAX___CUCO___HYPERLOGLOG_FINALIZER_CUH
-#define _CUDAX___CUCO___HYPERLOGLOG_FINALIZER_CUH
+#ifndef _CUDAX___CUCO_DETAIL_HYPERLOGLOG_FINALIZER_CUH
+#define _CUDAX___CUCO_DETAIL_HYPERLOGLOG_FINALIZER_CUH
 
 #include <cuda/__cccl_config>
 
@@ -30,7 +30,7 @@
 #include <cuda/std/__numeric/midpoint.h>
 #include <cuda/std/cstdint>
 
-#include <cuda/experimental/__cuco/__hyperloglog/tuning.cuh>
+#include <cuda/experimental/__cuco/detail/hyperloglog/tuning.cuh>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -188,4 +188,4 @@ private:
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDAX___CUCO___HYPERLOGLOG_FINALIZER_CUH
+#endif // _CUDAX___CUCO_DETAIL_HYPERLOGLOG_FINALIZER_CUH

--- a/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/hyperloglog_impl.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/hyperloglog_impl.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDAX___CUCO___HYPERLOGLOG_IMPL_CUH
-#define _CUDAX___CUCO___HYPERLOGLOG_IMPL_CUH
+#ifndef _CUDAX___CUCO_DETAIL_HYPERLOGLOG_IMPL_CUH
+#define _CUDAX___CUCO_DETAIL_HYPERLOGLOG_IMPL_CUH
 
 #include <cuda/__cccl_config>
 
@@ -38,9 +38,9 @@
 #include <cuda/std/__memory/pointer_traits.h>
 #include <cuda/std/span>
 
-#include <cuda/experimental/__cuco/__hyperloglog/finalizer.cuh>
-#include <cuda/experimental/__cuco/__hyperloglog/kernels.cuh>
-#include <cuda/experimental/__cuco/__utility/strong_type.cuh>
+#include <cuda/experimental/__cuco/detail/hyperloglog/finalizer.cuh>
+#include <cuda/experimental/__cuco/detail/hyperloglog/kernels.cuh>
+#include <cuda/experimental/__cuco/detail/utility/strong_type.cuh>
 #include <cuda/experimental/__cuco/hash_functions.cuh>
 #include <cuda/experimental/memory_resource.cuh>
 
@@ -612,4 +612,4 @@ private:
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDAX___CUCO___HYPERLOGLOG_IMPL_CUH
+#endif // _CUDAX___CUCO_DETAIL_HYPERLOGLOG_IMPL_CUH

--- a/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/kernels.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/kernels.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDAX___CUCO___HYPERLOGLOG_KERNELS_CUH
-#define _CUDAX___CUCO___HYPERLOGLOG_KERNELS_CUH
+#ifndef _CUDAX___CUCO_DETAIL_HYPERLOGLOG_KERNELS_CUH
+#define _CUDAX___CUCO_DETAIL_HYPERLOGLOG_KERNELS_CUH
 
 #include <cuda/__cccl_config>
 
@@ -175,4 +175,4 @@ _CCCL_DIAG_POP
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDAX___CUCO___HYPERLOGLOG_KERNELS_CUH
+#endif // _CUDAX___CUCO_DETAIL_HYPERLOGLOG_KERNELS_CUH

--- a/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/tuning.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/tuning.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDAX___CUCO___HYPERLOGLOG___TUNING_CUH
-#define _CUDAX___CUCO___HYPERLOGLOG___TUNING_CUH
+#ifndef _CUDAX___CUCO_DETAIL_HYPERLOGLOG_TUNING_CUH
+#define _CUDAX___CUCO_DETAIL_HYPERLOGLOG_TUNING_CUH
 
 #include <cuda/__cccl_config>
 
@@ -163,4 +163,4 @@ _CUDAX_CUCO_HLL_TUNING_ARR_DECL __bias_data_p18[] = {189083.0, 185696.913, 18234
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDAX___CUCO___HYPERLOGLOG_TUNING_CUH
+#endif // _CUDAX___CUCO_DETAIL_HYPERLOGLOG_TUNING_CUH

--- a/cudax/include/cuda/experimental/__cuco/detail/utility/strong_type.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/utility/strong_type.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDAX___CUCO___UTILITY_STRONG_TYPE_CUH
-#define _CUDAX___CUCO___UTILITY_STRONG_TYPE_CUH
+#ifndef _CUDAX___CUCO_DETAIL_UTILITY_STRONG_TYPE_CUH
+#define _CUDAX___CUCO_DETAIL_UTILITY_STRONG_TYPE_CUH
 
 #include <cuda/__cccl_config>
 
@@ -63,4 +63,4 @@ struct __strong_type
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDAX___CUCO___UTILITY_STRONG_TYPE_CUH
+#endif // _CUDAX___CUCO_DETAIL_UTILITY_STRONG_TYPE_CUH

--- a/cudax/include/cuda/experimental/__cuco/hash_functions.cuh
+++ b/cudax/include/cuda/experimental/__cuco/hash_functions.cuh
@@ -21,8 +21,8 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/experimental/__cuco/__hash_functions/murmurhash3.cuh>
-#include <cuda/experimental/__cuco/__hash_functions/xxhash.cuh>
+#include <cuda/experimental/__cuco/detail/hash_functions/murmurhash3.cuh>
+#include <cuda/experimental/__cuco/detail/hash_functions/xxhash.cuh>
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/cudax/include/cuda/experimental/__cuco/hll_policies.cuh
+++ b/cudax/include/cuda/experimental/__cuco/hll_policies.cuh
@@ -21,6 +21,6 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/experimental/__cuco/__hyperloglog/default_policy.cuh>
+#include <cuda/experimental/__cuco/detail/hyperloglog/default_policy.cuh>
 
 #endif // _CUDAX___CUCO_HLL_POLICIES_CUH

--- a/cudax/include/cuda/experimental/__cuco/hyperloglog_ref.cuh
+++ b/cudax/include/cuda/experimental/__cuco/hyperloglog_ref.cuh
@@ -27,7 +27,7 @@
 #include <cuda/std/span>
 #include <cuda/stream>
 
-#include <cuda/experimental/__cuco/__hyperloglog/hyperloglog_impl.cuh>
+#include <cuda/experimental/__cuco/detail/hyperloglog/hyperloglog_impl.cuh>
 #include <cuda/experimental/__cuco/hll_policies.cuh>
 
 #include <cooperative_groups.h>
@@ -136,7 +136,7 @@ public:
     // `clear(::cuda::stream_ref)` on this class is only __host__, it will take lower priority
     // that `clear(_CG)`, and we get:
     //
-    // cudax/include/cuda/experimental/__cuco/__hyperloglog/hyperloglog_impl.cuh:131:28: error: no member named
+    // cudax/include/cuda/experimental/__cuco/detail/hyperloglog/hyperloglog_impl.cuh:131:28: error: no member named
     // 'thread_rank' in 'cuda::stream_ref' [clang-diagnostic-error]
     //
     // 131 | for (int __i = __group.thread_rank(); __i < __sketch.size(); __i += __group.size())


### PR DESCRIPTION
## Description

Followup of https://github.com/NVIDIA/cccl/pull/7705#discussion_r3398079079

This PR reorganizes the existing `cuco` implementation headers in `cudax` to a consistent directory convention. There are no actual code changes, only folder renaming.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
