### PR TITLE
Enforce MergePolicy tuning values

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
     autoupdate_branch: ''
     autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
     autoupdate_schedule: quarterly
-    skip: []
+    skip: [mypy] # mypy fails on pre-commit.ci due to numpy stub incompatibility with Python 3.14
     submodules: false
 
 repos:

--- a/cub/cub/agent/agent_merge.cuh
+++ b/cub/cub/agent/agent_merge.cuh
@@ -39,7 +39,8 @@ template <int ThreadsPerBlock,
           int ItemsPerThread,
           CacheLoadModifier LoadModifier,
           BlockStoreAlgorithm StoreAlgorithm,
-          bool UseBlockLoadToShared,
+          bool UseBl2ShForKeys,
+          bool UseBl2ShForItems,
           typename KeysIt1,
           typename ItemsIt1,
           typename KeysIt2,
@@ -61,17 +62,6 @@ struct agent_t
   using block_store_keys     = BlockStore<key_type, ThreadsPerBlock, ItemsPerThread, StoreAlgorithm>;
   using block_store_items    = BlockStore<item_type, ThreadsPerBlock, ItemsPerThread, StoreAlgorithm>;
 
-  template <typename ValueT, typename Iter1, typename Iter2>
-  static constexpr bool use_block_load_to_shared =
-    UseBlockLoadToShared && (sizeof(ValueT) == alignof(ValueT))
-    && THRUST_NS_QUALIFIER::is_trivially_relocatable_v<ValueT> //
-    && THRUST_NS_QUALIFIER::is_contiguous_iterator_v<Iter1> //
-    && THRUST_NS_QUALIFIER::is_contiguous_iterator_v<Iter2>
-    && ::cuda::std::is_same_v<ValueT, cub::detail::it_value_t<Iter1>>
-    && ::cuda::std::is_same_v<ValueT, cub::detail::it_value_t<Iter2>>;
-
-  static constexpr bool keys_use_bl2sh     = use_block_load_to_shared<key_type, KeysIt1, KeysIt2>;
-  static constexpr bool items_use_bl2sh    = use_block_load_to_shared<item_type, ItemsIt1, ItemsIt2>;
   static constexpr int bl2sh_minimum_align = cub::detail::LoadToSharedBufferAlignBytes<char>();
 
   template <typename ValueT>
@@ -86,8 +76,8 @@ struct agent_t
 
   struct temp_storages_without_bl2sh
   {
-    using keys_smem  = ::cuda::std::conditional_t<keys_use_bl2sh, buffer_t<key_type>, key_type[items_per_tile + 1]>;
-    using items_smem = ::cuda::std::conditional_t<items_use_bl2sh, buffer_t<item_type>, item_type[items_per_tile + 1]>;
+    using keys_smem  = ::cuda::std::conditional_t<UseBl2ShForKeys, buffer_t<key_type>, key_type[items_per_tile + 1]>;
+    using items_smem = ::cuda::std::conditional_t<UseBl2ShForItems, buffer_t<item_type>, item_type[items_per_tile + 1]>;
     union
     {
       typename block_store_keys::TempStorage store_keys;
@@ -103,8 +93,8 @@ struct agent_t
     typename block_load_to_shared::TempStorage load2sh;
   };
 
-  using temp_storages =
-    ::cuda::std::conditional_t<keys_use_bl2sh || items_use_bl2sh, temp_storages_with_bl2sh, temp_storages_without_bl2sh>;
+  using temp_storages = ::cuda::std::
+    conditional_t<UseBl2ShForKeys || UseBl2ShForItems, temp_storages_with_bl2sh, temp_storages_without_bl2sh>;
 
   using TempStorage = Uninitialized<temp_storages>;
 
@@ -154,7 +144,7 @@ struct agent_t
     }
 
     [[maybe_unused]] auto load2sh = [&] {
-      if constexpr (keys_use_bl2sh || items_use_bl2sh)
+      if constexpr (UseBl2ShForKeys || UseBl2ShForItems)
       {
         return block_load_to_shared{storage.load2sh};
       }
@@ -168,7 +158,7 @@ struct agent_t
     key_type* keys1_shared;
     key_type* keys2_shared;
     int keys2_offset;
-    if constexpr (keys_use_bl2sh)
+    if constexpr (UseBl2ShForKeys)
     {
       ::cuda::std::span keys1_src{THRUST_NS_QUALIFIER::unwrap_contiguous_iterator(keys1_in + keys1_beg),
                                   static_cast<::cuda::std::size_t>(keys1_count_tile)};
@@ -265,7 +255,7 @@ struct agent_t
 
       item_type items_loc[ItemsPerThread];
       item_type* items1_shared;
-      if constexpr (items_use_bl2sh)
+      if constexpr (UseBl2ShForItems)
       {
         ::cuda::std::span items1_src{THRUST_NS_QUALIFIER::unwrap_contiguous_iterator(items1_in + keys1_beg),
                                      static_cast<::cuda::std::size_t>(keys1_count_tile)};
@@ -294,7 +284,7 @@ struct agent_t
             items_loc, items1_in_cm + keys1_beg, items2_in_cm + keys2_beg, keys1_count_tile, keys2_count_tile);
           __syncthreads(); // block_store_keys above uses SMEM, so make sure all threads are done before we write to it
           items1_shared = &storage.items_shared[0];
-          if constexpr (keys_use_bl2sh)
+          if constexpr (UseBl2ShForKeys)
           {
             const int items2_offset = keys1_count_tile;
             translate_indices(items2_offset);

--- a/cub/cub/detail/cc_dispatch.cuh
+++ b/cub/cub/detail/cc_dispatch.cuh
@@ -44,7 +44,7 @@ struct device_policy_getter : PolicySelector
 };
 
 #if !defined(CUB_DEFINE_RUNTIME_POLICIES) && !_CCCL_COMPILER(NVRTC)
-#  if _CCCL_STD_VER < 2020
+#  if _CCCL_STD_VER < 2020 && !_CCCL_COMPILER(GCC, <, 8)
 template <typename CudaCcSeq, typename PolicySelector, size_t... Is>
 struct lowest_cc_resolver;
 
@@ -57,21 +57,12 @@ struct lowest_cc_resolver<::cuda::std::integer_sequence<int, CudaCcs...>, Policy
   using policy_t = decltype(PolicySelector{}(::cuda::compute_capability{}));
 
   static constexpr ::cuda::compute_capability all_ccs[sizeof...(Is)]{::cuda::compute_capability{CudaCcs}...};
-
-  // GCC 7 has issues reusing the constexpr array of tuning policies in find_lowest below (it loses the constexpr-ness)
-#    if _CCCL_COMPILER(GCC, >=, 8)
   static constexpr policy_t all_policies[sizeof...(Is)]{PolicySelector{}(all_ccs[Is])...};
-#    endif // _CCCL_COMPILER(GCC, <, 8)
 
   _CCCL_HOST_DEVICE_API static constexpr auto find_lowest(size_t i) -> ::cuda::compute_capability
   {
-#    if _CCCL_COMPILER(GCC, >=, 8)
     const auto& policy = all_policies[i];
     while (i > 0 && policy == all_policies[i - 1])
-#    else // _CCCL_COMPILER(GCC, >=, 8)
-    const auto& policy = PolicySelector{}(all_ccs[i]);
-    while (i > 0 && policy == PolicySelector{}(all_ccs[i - 1]))
-#    endif // _CCCL_COMPILER(GCC, >=, 8)
     {
       --i;
     }
@@ -80,7 +71,7 @@ struct lowest_cc_resolver<::cuda::std::integer_sequence<int, CudaCcs...>, Policy
 
   static constexpr ::cuda::compute_capability lowest_cc_with_same_policy[sizeof...(Is)]{find_lowest(Is)...};
 };
-#  endif // if _CCCL_STD_VER < 2020
+#  endif // if _CCCL_STD_VER < 2020 && !_CCCL_COMPILER(GCC, <, 8)
 
 // GCC below 12 ICEs in some cases when creating an integral_constant holding a policy
 #  if _CCCL_STD_VER >= 2020 && _CCCL_COMPILER(GCC, <, 12)
@@ -113,7 +104,14 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_to_cc_list(
   // in the same integral_constant type passed to f
   using policy_t = decltype(policy_selector(::cuda::compute_capability{}));
   (..., (device_cc == all_ccs[Is] ? (e = f(policy_constant<policy_t, policy_selector(all_ccs[Is])>{})) : cudaSuccess));
-#  else // if _CCCL_STD_VER >= 2020
+#  else // _CCCL_STD_VER >= 2020
+#    if _CCCL_COMPILER(GCC, <, 8)
+  // GCC 7 ICEs on constexpr evaluation of policy comparisons, so we skip the lowest-CC-with-same-policy optimization
+  // and instantiate f for each CC directly. This may increase compile time and binary size.
+  (...,
+   (device_cc == all_ccs[Is] ? (e = f(policy_getter<PolicySelector, all_ccs[Is].get()>{policy_selector}))
+                             : cudaSuccess));
+#    else // _CCCL_COMPILER(GCC, <, 8)
   // In C++17, we have to collapse architectures with the same policies ourselves, so we instantiate call_for_cc once
   // per policy on the lowest CC which produces the same policy
   using resolver_t =
@@ -122,8 +120,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_to_cc_list(
    (device_cc == all_ccs[Is]
       ? (e = f(policy_getter<PolicySelector, resolver_t::lowest_cc_with_same_policy[Is].get()>{policy_selector}))
       : cudaSuccess));
-
-#  endif // if _CCCL_STD_VER >= 2020
+#    endif // _CCCL_COMPILER(GCC, <, 8)
+#  endif // _CCCL_STD_VER >= 2020
   return e;
 }
 

--- a/cub/cub/device/device_merge.cuh
+++ b/cub/cub/device/device_merge.cuh
@@ -194,7 +194,7 @@ struct DeviceMerge
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceMerge::MergeKeys");
 
     using default_policy_selector =
-      detail::merge::policy_selector_from_types<detail::it_value_t<KeyIteratorIn1>, NullType, int64_t>;
+      detail::merge::policy_selector_from_types<KeyIteratorIn1, NullType*, KeyIteratorIn2, NullType*, int64_t>;
     return detail::dispatch_with_env_and_tuning<default_policy_selector>(
       env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return detail::merge::dispatch(
@@ -419,7 +419,7 @@ struct DeviceMerge
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceMerge::MergePairs");
     using default_policy_selector = detail::merge::
-      policy_selector_from_types<detail::it_value_t<KeyIteratorIn1>, detail::it_value_t<ValueIteratorIn1>, int64_t>;
+      policy_selector_from_types<KeyIteratorIn1, ValueIteratorIn1, KeyIteratorIn2, ValueIteratorIn2, int64_t>;
     return detail::dispatch_with_env_and_tuning<default_policy_selector>(
       env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return detail::merge::dispatch(

--- a/cub/cub/device/dispatch/dispatch_merge.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge.cuh
@@ -43,14 +43,16 @@ class choose_merge_agent
             active_policy.items_per_thread,
             active_policy.load_modifier,
             active_policy.store_algorithm,
-            active_policy.use_block_load_to_shared,
+            active_policy.use_bulk_copy_for_keys,
+            active_policy.use_bulk_copy_for_values,
             Args...>;
   using default_noload2sh_agent_t =
     agent_t<active_policy.threads_per_block,
             active_policy.items_per_thread,
             active_policy.load_modifier,
             active_policy.store_algorithm,
-            /* UseBlockLoadToShared */ false,
+            /* UseBl2ShForKeys */ false,
+            /* UseBl2ShForItems */ false,
             Args...>;
 
   using fallback_agent_t =
@@ -58,7 +60,8 @@ class choose_merge_agent
             fallback_ITEMS_PER_THREAD,
             active_policy.load_modifier,
             active_policy.store_algorithm,
-            /* UseBlockLoadToShared */ false,
+            /* UseBl2ShForKeys */ false,
+            /* UseBl2ShForItems */ false,
             Args...>;
 
   static constexpr bool use_default_load2sh =
@@ -189,7 +192,7 @@ template <typename KeyIt1,
           typename ValueIt3,
           typename Offset,
           typename CompareOp,
-          typename PolicySelector        = policy_selector_from_types<it_value_t<KeyIt1>, it_value_t<ValueIt1>, Offset>,
+          typename PolicySelector        = policy_selector_from_types<KeyIt1, ValueIt1, KeyIt2, ValueIt2, Offset>,
           typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
 #if _CCCL_HAS_CONCEPTS()
   requires merge_policy_selector<PolicySelector>

--- a/cub/cub/device/dispatch/tuning/tuning_merge.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_merge.cuh
@@ -17,6 +17,10 @@
 #include <cub/device/dispatch/tuning/common.cuh>
 #include <cub/thread/thread_load.cuh>
 #include <cub/util_math.cuh>
+#include <cub/util_type.cuh>
+
+#include <thrust/type_traits/is_contiguous_iterator.h>
+#include <thrust/type_traits/is_trivially_relocatable.h>
 
 #include <cuda/__device/compute_capability.h>
 #include <cuda/std/__algorithm/clamp.h>

--- a/cub/cub/device/dispatch/tuning/tuning_merge.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_merge.cuh
@@ -100,20 +100,36 @@ struct policy_selector
 
     if (cc >= ::cuda::compute_capability{9, 0})
     {
-      const bool use_bl2sh_keys = can_bulk_keys && key_size != 8;
-      const bool use_bl2sh_pairs =
-        can_bulk_values && !(key_size == 8 && value_size == 8)
+      const bool should_bl2sh_keys = key_size != 8;
+      const bool should_bl2sh_pairs =
+        !(key_size == 8 && value_size == 8)
         && (key_size != 16 || (key_size == 16 && value_size == 1 && offset_size == 4)
             || (key_size == 16 && value_size == 8));
-      return merge_policy{512, ipt_800_plus, LOAD_DEFAULT, BLOCK_STORE_WARP_TRANSPOSE, use_bl2sh_keys, use_bl2sh_pairs};
+      // TODO(bgruber): consider not using a combined should_bl2sh flag. Kept to avoid SASS diffs
+      const bool should_bl2sh = value_size == 0 ? should_bl2sh_keys : should_bl2sh_pairs;
+      return merge_policy{
+        512,
+        ipt_800_plus,
+        LOAD_DEFAULT,
+        BLOCK_STORE_WARP_TRANSPOSE,
+        can_bulk_keys && should_bl2sh,
+        can_bulk_values && should_bl2sh};
     }
 
     if (cc >= ::cuda::compute_capability{8, 0})
     {
-      const bool use_bl2sh_keys = can_bulk_keys && key_size < 4;
-      const bool use_bl2sh_pairs =
-        can_bulk_values && (key_size == 1 || (key_size == 2 && value_size < 4) || (key_size == 4 && value_size == 1));
-      return merge_policy{512, ipt_800_plus, LOAD_DEFAULT, BLOCK_STORE_WARP_TRANSPOSE, use_bl2sh_keys, use_bl2sh_pairs};
+      const bool should_bl2sh_keys = key_size < 4;
+      const bool should_bl2sh_pairs =
+        key_size == 1 || (key_size == 2 && value_size < 4) || (key_size == 4 && value_size == 1);
+      // TODO(bgruber): consider not using a combined should_bl2sh flag. Kept to avoid SASS diffs
+      const bool should_bl2sh = value_size == 0 ? should_bl2sh_keys : should_bl2sh_pairs;
+      return merge_policy{
+        512,
+        ipt_800_plus,
+        LOAD_DEFAULT,
+        BLOCK_STORE_WARP_TRANSPOSE,
+        can_bulk_keys && should_bl2sh,
+        can_bulk_values && should_bl2sh};
     }
 
     if (cc >= ::cuda::compute_capability{6, 0})

--- a/cub/cub/device/dispatch/tuning/tuning_merge.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_merge.cuh
@@ -112,7 +112,7 @@ struct policy_selector
     {
       const bool use_bl2sh_keys = can_bulk_keys && key_size < 4;
       const bool use_bl2sh_pairs =
-        can_bulk_values && key_size == 1 || (key_size == 2 && value_size < 4) || (key_size == 4 && value_size == 1);
+        can_bulk_values && (key_size == 1 || (key_size == 2 && value_size < 4) || (key_size == 4 && value_size == 1));
       return merge_policy{512, ipt_800_plus, LOAD_DEFAULT, BLOCK_STORE_WARP_TRANSPOSE, use_bl2sh_keys, use_bl2sh_pairs};
     }
 

--- a/cub/cub/device/dispatch/tuning/tuning_merge.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_merge.cuh
@@ -33,13 +33,15 @@ struct merge_policy
   int items_per_thread;
   CacheLoadModifier load_modifier;
   BlockStoreAlgorithm store_algorithm;
-  bool use_block_load_to_shared;
+  bool use_bulk_copy_for_keys;
+  bool use_bulk_copy_for_values;
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const merge_policy& lhs, const merge_policy& rhs)
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
         && lhs.load_modifier == rhs.load_modifier && lhs.store_algorithm == rhs.store_algorithm
-        && lhs.use_block_load_to_shared == rhs.use_block_load_to_shared;
+        && lhs.use_bulk_copy_for_keys == rhs.use_bulk_copy_for_keys
+        && lhs.use_bulk_copy_for_values == rhs.use_bulk_copy_for_values;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool operator!=(const merge_policy& lhs, const merge_policy& rhs)
@@ -53,8 +55,8 @@ struct merge_policy
     return os
         << "merge_policy { .threads_per_block = " << p.threads_per_block
         << ", .items_per_thread = " << p.items_per_thread << ", .load_modifier = " << p.load_modifier
-        << ", .store_algorithm = " << p.store_algorithm
-        << ", .use_block_load_to_shared = " << p.use_block_load_to_shared << " }";
+        << ", .store_algorithm = " << p.store_algorithm << ", .use_bulk_copy_for_keys = " << p.use_bulk_copy_for_keys
+        << ", .use_bulk_copy_for_values = " << p.use_bulk_copy_for_values << " }";
   }
 #endif // _CCCL_HOSTED()
 };
@@ -67,48 +69,58 @@ concept merge_policy_selector = policy_selector<T, merge_policy>;
 struct policy_selector
 {
   int key_size;
+  int key_align;
+  int key_is_trivially_relocatable;
+  bool key_iterators_are_contiguous;
+  bool key_iterator_value_types_are_the_same;
   int value_size; // if 0, then this is a keys-only policy
+  int value_align;
+  int value_is_trivially_relocatable;
+  bool value_iterators_are_contiguous;
+  bool value_iterator_value_types_are_the_same;
   int offset_size;
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> merge_policy
   {
     const int tune_type_size = key_size + value_size;
     const int ipt_800_plus   = nominal_4B_items_to_items(15, tune_type_size);
+    const bool can_bulk_keys = (key_size == key_align) && key_is_trivially_relocatable && key_iterators_are_contiguous
+                            && key_iterator_value_types_are_the_same;
+    const bool can_bulk_values = (value_size == value_align) && value_is_trivially_relocatable
+                              && value_iterators_are_contiguous && value_iterator_value_types_are_the_same;
 
     if (cc >= ::cuda::compute_capability{10, 0})
     {
-      return merge_policy{512, ipt_800_plus, LOAD_DEFAULT, BLOCK_STORE_WARP_TRANSPOSE, true};
+      return merge_policy{512, ipt_800_plus, LOAD_DEFAULT, BLOCK_STORE_WARP_TRANSPOSE, can_bulk_keys, can_bulk_values};
     }
 
     if (cc >= ::cuda::compute_capability{9, 0})
     {
-      const bool use_bl2sh_keys = key_size != 8;
+      const bool use_bl2sh_keys = can_bulk_keys && key_size != 8;
       const bool use_bl2sh_pairs =
-        !(key_size == 8 && value_size == 8)
+        can_bulk_values && !(key_size == 8 && value_size == 8)
         && (key_size != 16 || (key_size == 16 && value_size == 1 && offset_size == 4)
             || (key_size == 16 && value_size == 8));
-      return merge_policy{
-        512, ipt_800_plus, LOAD_DEFAULT, BLOCK_STORE_WARP_TRANSPOSE, value_size == 0 ? use_bl2sh_keys : use_bl2sh_pairs};
+      return merge_policy{512, ipt_800_plus, LOAD_DEFAULT, BLOCK_STORE_WARP_TRANSPOSE, use_bl2sh_keys, use_bl2sh_pairs};
     }
 
     if (cc >= ::cuda::compute_capability{8, 0})
     {
-      const bool use_bl2sh_keys = key_size < 4;
+      const bool use_bl2sh_keys = can_bulk_keys && key_size < 4;
       const bool use_bl2sh_pairs =
-        key_size == 1 || (key_size == 2 && value_size < 4) || (key_size == 4 && value_size == 1);
-      return merge_policy{
-        512, ipt_800_plus, LOAD_DEFAULT, BLOCK_STORE_WARP_TRANSPOSE, value_size == 0 ? use_bl2sh_keys : use_bl2sh_pairs};
+        can_bulk_values && key_size == 1 || (key_size == 2 && value_size < 4) || (key_size == 4 && value_size == 1);
+      return merge_policy{512, ipt_800_plus, LOAD_DEFAULT, BLOCK_STORE_WARP_TRANSPOSE, use_bl2sh_keys, use_bl2sh_pairs};
     }
 
     if (cc >= ::cuda::compute_capability{6, 0})
     {
       const int ipt_600 = nominal_4B_items_to_items(15, tune_type_size);
-      return merge_policy{512, ipt_600, LOAD_DEFAULT, BLOCK_STORE_WARP_TRANSPOSE, false};
+      return merge_policy{512, ipt_600, LOAD_DEFAULT, BLOCK_STORE_WARP_TRANSPOSE, false, false};
     }
 
     // default is SM52
     const int ipt_520 = nominal_4B_items_to_items(13, tune_type_size);
-    return merge_policy{512, ipt_520, LOAD_LDG, BLOCK_STORE_WARP_TRANSPOSE, false};
+    return merge_policy{512, ipt_520, LOAD_LDG, BLOCK_STORE_WARP_TRANSPOSE, false, false};
   }
 };
 
@@ -116,13 +128,27 @@ struct policy_selector
 static_assert(merge_policy_selector<policy_selector>);
 #endif // _CCCL_HAS_CONCEPTS()
 
-template <typename KeyT, typename ValueT, typename OffsetT>
+template <typename KeysIt1, typename ItemsIt1, typename KeysIt2, typename ItemsIt2, typename OffsetT>
 struct policy_selector_from_types
 {
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> merge_policy
   {
+    using key_t  = it_value_t<KeysIt1>;
+    using item_t = it_value_t<ItemsIt1>;
+
     return policy_selector{
-      int{sizeof(KeyT)}, ::cuda::std::is_same_v<ValueT, NullType> ? 0 : int{sizeof(ValueT)}, int{sizeof(OffsetT)}}(cc);
+      int{sizeof(key_t)},
+      int{alignof(key_t)},
+      THRUST_NS_QUALIFIER::is_trivially_relocatable_v<key_t>,
+      THRUST_NS_QUALIFIER::is_contiguous_iterator_v<KeysIt1> && THRUST_NS_QUALIFIER::is_contiguous_iterator_v<KeysIt2>,
+      ::cuda::std::is_same_v<key_t, it_value_t<KeysIt2>>,
+      ::cuda::std::is_same_v<item_t, NullType> ? 0 : int{sizeof(item_t)},
+      int{alignof(item_t)},
+      THRUST_NS_QUALIFIER::is_trivially_relocatable_v<item_t>,
+      THRUST_NS_QUALIFIER::is_contiguous_iterator_v<ItemsIt1>
+        && THRUST_NS_QUALIFIER::is_contiguous_iterator_v<ItemsIt2>,
+      ::cuda::std::is_same_v<item_t, it_value_t<ItemsIt2>>,
+      int{sizeof(OffsetT)}}(cc);
   }
 };
 } // namespace detail::merge

--- a/cub/test/catch2_test_device_merge.cu
+++ b/cub/test/catch2_test_device_merge.cu
@@ -110,7 +110,8 @@ C2H_TEST("DeviceMerge::MergeKeys almost tile-sized input sizes", "[merge][device
   cuda::compute_capability cc{};
   REQUIRE(cub::detail::ptx_compute_cap(cc) == cudaSuccess);
   const offset_t items_per_tile =
-    cub::detail::merge::policy_selector_from_types<key_t, cub::NullType, offset_t>{}(cc).items_per_thread;
+    cub::detail::merge::policy_selector_from_types<key_t*, cub::NullType*, key_t*, cub::NullType*, offset_t>{}(cc)
+      .items_per_thread;
 
   test_keys<key_t>(items_per_tile - 1, 1);
   test_keys<key_t>(items_per_tile, 1);

--- a/cub/test/catch2_test_device_merge_env.cu
+++ b/cub/test/catch2_test_device_merge_env.cu
@@ -31,7 +31,7 @@ struct merge_tuning
 {
   _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::detail::merge::merge_policy
   {
-    return {ThreadsPerBlock, 1, cub::LOAD_DEFAULT, cub::BLOCK_STORE_WARP_TRANSPOSE, false};
+    return {ThreadsPerBlock, 1, cub::LOAD_DEFAULT, cub::BLOCK_STORE_WARP_TRANSPOSE, false, false};
   }
 };
 

--- a/cub/test/catch2_test_device_merge_no_unroll.cu
+++ b/cub/test/catch2_test_device_merge_no_unroll.cu
@@ -66,7 +66,7 @@ struct fixed_policy_selector
 {
   _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const -> cub::detail::merge::merge_policy
   {
-    return {128, 7, cub::LOAD_DEFAULT, cub::BLOCK_STORE_WARP_TRANSPOSE, false};
+    return {128, 7, cub::LOAD_DEFAULT, cub::BLOCK_STORE_WARP_TRANSPOSE, false, false};
   }
 };
 


### PR DESCRIPTION
Instead of letting the kernel downgrade the chosen values. This improves tuning and user experience.

Longer explanation: https://github.com/NVIDIA/cccl/issues/8573#issuecomment-4695776933


- [x] No SASS changes for `cub.bench.merge.pairs.base` on SM`75;80;90;100`