### PR TITLE
[CUB] Fully support warp `redux` 

### DIFF
--- a/cub/cub/detail/warpspeed/look_ahead.cuh
+++ b/cub/cub/detail/warpspeed/look_ahead.cuh
@@ -16,7 +16,7 @@
 #include <cub/detail/strong_store.cuh>
 #include <cub/detail/warpspeed/special_registers.cuh>
 #include <cub/thread/thread_store.cuh>
-#include <cub/warp/specializations/warp_reduce_shfl.cuh>
+#include <cub/warp/specializations/warp_redux.cuh>
 #include <cub/warp/warp_reduce.cuh>
 
 #include <cuda/__cmath/pow2.h>
@@ -25,6 +25,7 @@
 #include <cuda/__ptx/instructions/get_sreg.h>
 #include <cuda/__type_traits/is_trivially_copyable.h>
 #include <cuda/std/__bit/popcount.h>
+#include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/underlying_type.h>
 
 #if !_CCCL_HAS_NV_ATOMIC_BUILTINS()
@@ -228,13 +229,11 @@ template <int numTileStatesPerThread, typename AccumT, typename ScanOpT>
       NV_IF_ELSE_TARGET(
         NV_PROVIDES_SM_80,
         ({ // NOTE: Inlined from warp_reduce_shfl
-          if constexpr (::cuda::std::is_integral_v<AccumT> && sizeof(AccumT) <= sizeof(unsigned)
-                        && (is_cuda_std_plus_v<ScanOpT, AccumT> || is_cuda_minimum_maximum_v<ScanOpT, AccumT>
-                            || is_cuda_std_bitwise_v<ScanOpT, AccumT>) )
+          if constexpr (is_warp_redux_op_supported_sm80<ScanOpT, AccumT>)
           {
             const bool use_value = lanemaskEq & warp_right_aggregates_mask;
             const AccumT value   = use_value ? regTmpStates[idx].value : cuda::identity_element<ScanOpT, AccumT>();
-            local_aggr           = reduce_op_sync(value, ~0, scan_op);
+            local_aggr           = cub::detail::warp_redux_sm80(value, ~0, scan_op);
           }
           else
           {

--- a/cub/cub/thread/thread_operators.cuh
+++ b/cub/cub/thread/thread_operators.cuh
@@ -554,15 +554,6 @@ inline constexpr bool is_simd_enabled_cuda_operator =
   is_cuda_std_plus_mul_v<Op, T> || //
   is_cuda_std_bitwise_v<Op, T>;
 
-// TODO: enable FP32 min/max (SM100a/SM100f)
-template <typename Op, typename T, typename UnqualifiedOp = ::cuda::std::remove_cvref_t<Op>>
-inline constexpr bool is_redux_enabled_cuda_operator =
-  ::cuda::std::is_integral_v<T> && //
-  sizeof(T) <= sizeof(unsigned) && //
-  (is_cuda_minimum_maximum_v<UnqualifiedOp, T> || //
-   is_cuda_std_plus_v<UnqualifiedOp, T> || //
-   is_cuda_std_bitwise_v<UnqualifiedOp, T>);
-
 template <typename Op, typename T = void>
 inline constexpr bool is_cuda_binary_operator =
   is_cuda_minimum_maximum_v<Op, T> || //

--- a/cub/cub/warp/specializations/warp_reduce_batched_wspro.cuh
+++ b/cub/cub/warp/specializations/warp_reduce_batched_wspro.cuh
@@ -20,9 +20,7 @@
 #include <cub/util_arch.cuh>
 #include <cub/util_ptx.cuh>
 #include <cub/util_type.cuh>
-// Next two for REDUX helpers
-#include <cub/thread/thread_operators.cuh>
-#include <cub/warp/specializations/warp_reduce_shfl.cuh>
+#include <cub/warp/specializations/warp_redux.cuh>
 
 #include <cuda/__cmath/ceil_div.h>
 #include <cuda/__cmath/pow2.h>
@@ -88,12 +86,12 @@ struct warp_reduce_batched_wspro
     // REDUX. For subwarps both throughput and latency are worse with REDUX independent of the number of batches. This
     // might be a codegen issue.
     constexpr bool redux_performs_better = is_arch_warp && Batches <= 8;
-    if constexpr (is_redux_enabled_cuda_operator<ReductionOp, T> && redux_performs_better)
+    if constexpr (is_warp_redux_op_supported<ReductionOp, T> && redux_performs_better)
     {
-      NV_IF_TARGET(NV_PROVIDES_SM_80, ({
-                     ReduceRedux<ToBlocked>(inputs, outputs, reduction_op);
-                     return;
-                   }))
+      if (ReduceRedux<ToBlocked>(inputs, outputs, reduction_op))
+      {
+        return;
+      }
     }
 
     // Needed in case of outputs aliasing inputs
@@ -112,7 +110,8 @@ struct warp_reduce_batched_wspro
   }
 
   template <bool ToBlocked, typename InputT, typename OutputT, typename ReductionOp>
-  _CCCL_DEVICE_API _CCCL_FORCEINLINE void ReduceRedux(const InputT& inputs, OutputT& outputs, ReductionOp reduction_op)
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE bool
+  ReduceRedux(const InputT& inputs, OutputT& outputs, ReductionOp reduction_op)
   {
     // Needed to avoid compiler error on "/ 0" and improve compile time.
     if constexpr (Batches != 0)
@@ -125,12 +124,16 @@ struct warp_reduce_batched_wspro
       _CCCL_PRAGMA_UNROLL_FULL()
       for (int i = 0; i < Batches; ++i)
       {
-        auto result         = cub::detail::reduce_op_sync(inputs[i], reduce_mask, reduction_op);
+        const auto result = cub::detail::warp_redux(inputs[i], reduce_mask, reduction_op);
+        if (!result)
+        {
+          return false;
+        }
         const auto out_lane = ToBlocked ? i / max_out_per_thread : i % LogicalWarpThreads;
         const auto out_idx  = ToBlocked ? i % max_out_per_thread : i / LogicalWarpThreads;
         if (logical_lane_id == out_lane)
         {
-          intermediate_outputs[out_idx] = result;
+          intermediate_outputs[out_idx] = *result;
         }
       }
 
@@ -140,6 +143,7 @@ struct warp_reduce_batched_wspro
         outputs[i] = intermediate_outputs[i];
       }
     }
+    return true;
   }
 
   template <bool ToBlocked, int BaseIdxStriped, int PrevStride = LogicalWarpThreads, typename InputT, typename ReductionOp>

--- a/cub/cub/warp/specializations/warp_reduce_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_reduce_shfl.cuh
@@ -23,6 +23,7 @@
 #include <cub/thread/thread_operators.cuh>
 #include <cub/util_ptx.cuh>
 #include <cub/util_type.cuh>
+#include <cub/warp/specializations/warp_redux.cuh>
 
 #include <cuda/__cmath/pow2.h>
 #include <cuda/__functional/maximum.h>
@@ -30,9 +31,6 @@
 #include <cuda/__ptx/instructions/get_sreg.h>
 #include <cuda/std/__bit/countr.h>
 #include <cuda/std/__functional/operations.h>
-#include <cuda/std/__type_traits/conditional.h>
-#include <cuda/std/__type_traits/is_integral.h>
-#include <cuda/std/__type_traits/is_unsigned.h>
 #include <cuda/std/cstdint>
 
 #include <nv/target>
@@ -41,43 +39,6 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail
 {
-template <typename T, typename ReductionOp>
-_CCCL_DEVICE _CCCL_FORCEINLINE T reduce_op_sync(T input, const uint32_t mask, ReductionOp)
-{
-  static_assert(::cuda::std::is_integral_v<T>, "T must be an integral type");
-  static_assert(sizeof(T) <= sizeof(unsigned), "T must be less than or equal to unsigned");
-  using promoted_t = ::cuda::std::conditional_t<::cuda::std::is_unsigned_v<T>, unsigned, int>;
-  if constexpr (is_cuda_maximum_v<ReductionOp, T>)
-  {
-    return static_cast<T>(__reduce_max_sync(mask, static_cast<promoted_t>(input)));
-  }
-  else if constexpr (is_cuda_minimum_v<ReductionOp, T>)
-  {
-    return static_cast<T>(__reduce_min_sync(mask, static_cast<promoted_t>(input)));
-  }
-  else if constexpr (is_cuda_std_plus_v<ReductionOp, T>)
-  {
-    return static_cast<T>(__reduce_add_sync(mask, static_cast<promoted_t>(input)));
-  }
-  else if constexpr (is_cuda_std_bit_and_v<ReductionOp, T>)
-  {
-    return static_cast<T>(__reduce_and_sync(mask, static_cast<promoted_t>(input)));
-  }
-  else if constexpr (is_cuda_std_bit_or_v<ReductionOp, T>)
-  {
-    return static_cast<T>(__reduce_or_sync(mask, static_cast<promoted_t>(input)));
-  }
-  else if constexpr (is_cuda_std_bit_xor_v<ReductionOp, T>)
-  {
-    return static_cast<T>(__reduce_xor_sync(mask, static_cast<promoted_t>(input)));
-  }
-  else
-  {
-    _CCCL_UNREACHABLE();
-    return T{};
-  }
-}
-
 /**
  * @brief WarpReduceShfl provides SHFL-based variants of parallel reduction of items partitioned
  *        across a CUDA thread warp.
@@ -500,11 +461,12 @@ struct WarpReduceShfl
   _CCCL_DEVICE _CCCL_FORCEINLINE T Reduce(T input, int valid_items, ReductionOp reduction_op)
   {
     // Dispatch to more efficient intrinsics when applicable
-    if constexpr (ALL_LANES_VALID && ::cuda::std::is_integral_v<T> && sizeof(T) <= sizeof(unsigned)
-                  && (is_cuda_minimum_maximum_v<ReductionOp, T> || is_cuda_std_plus_v<ReductionOp, T>
-                      || is_cuda_std_bitwise_v<ReductionOp, T>) )
+    if constexpr (ALL_LANES_VALID && is_warp_redux_op_supported<ReductionOp, T>)
     {
-      NV_IF_TARGET(NV_PROVIDES_SM_80, (return reduce_op_sync(input, member_mask, reduction_op);))
+      if (const auto output = cub::detail::warp_redux(input, member_mask, reduction_op))
+      {
+        return *output;
+      }
     }
     T output = input;
     // Template-iterate reduction steps

--- a/cub/cub/warp/specializations/warp_redux.cuh
+++ b/cub/cub/warp/specializations/warp_redux.cuh
@@ -95,21 +95,21 @@ warp_redux_sm80(const T input, const ::cuda::std::uint32_t mask, ReductionOp)
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-// SM100f Redux
+// SM100af Redux
 
 #if __cccl_ptx_isa >= 860
 
-#  define _CUB_REDUX_FLOAT_OP(_CCCL_PTX_OP)                                                   \
-    [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE float redux_sm100f_##_CCCL_PTX_OP##_ptx( \
-      const float value, ::cuda::std::uint32_t mask)                                          \
-    {                                                                                         \
-      float result;                                                                           \
-      asm volatile("{"                                                                        \
-                   "redux.sync." #_CCCL_PTX_OP ".f32 %0, %1, %2;"                             \
-                   "}"                                                                        \
-                   : "=f"(result)                                                             \
-                   : "f"(value), "r"(mask));                                                  \
-      return result;                                                                          \
+#  define _CUB_REDUX_FLOAT_OP(_CCCL_PTX_OP)                                                    \
+    [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE float redux_sm100af_##_CCCL_PTX_OP##_ptx( \
+      const float value, ::cuda::std::uint32_t mask)                                           \
+    {                                                                                          \
+      float result;                                                                            \
+      asm volatile("{"                                                                         \
+                   "redux.sync." #_CCCL_PTX_OP ".f32 %0, %1, %2;"                              \
+                   "}"                                                                         \
+                   : "=f"(result)                                                              \
+                   : "f"(value), "r"(mask));                                                   \
+      return result;                                                                           \
     }
 
 _CUB_REDUX_FLOAT_OP(min)
@@ -131,11 +131,11 @@ warp_redux_sm100af(const T input, const ::cuda::std::uint32_t mask, ReductionOp)
   float result;
   if constexpr (is_cuda_minimum_v<ReductionOp, T>)
   {
-    result = cub::detail::redux_sm100f_min_ptx(value, mask);
+    result = cub::detail::redux_sm100af_min_ptx(value, mask);
   }
   else
   {
-    result = cub::detail::redux_sm100f_max_ptx(value, mask);
+    result = cub::detail::redux_sm100af_max_ptx(value, mask);
   }
   return ::cuda::std::__fp_cast<T>(result);
 }
@@ -158,9 +158,9 @@ warp_redux(const T input, const ::cuda::std::uint32_t mask, ReductionOp reductio
   {
     // Before PTX ISA 8.8, float reductions are only supported on sm100a.
 #if __cccl_ptx_isa >= 880
-    NV_IF_TARGET(NV_HAS_FEATURE_SM_100f, (return cub::detail::warp_redux_sm100f(input, mask, reduction_op);))
+    NV_IF_TARGET(NV_HAS_FEATURE_SM_100f, (return cub::detail::warp_redux_sm100af(input, mask, reduction_op);))
 #else // ^^^ __cccl_ptx_isa >= 880 ^^^ / vvv __cccl_ptx_isa < 880 vvv
-    NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (return cub::detail::warp_redux_sm100f(input, mask, reduction_op);))
+    NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (return cub::detail::warp_redux_sm100af(input, mask, reduction_op);))
 #endif // ^^^ __cccl_ptx_isa < 880 ^^^
   }
   return ::cuda::std::nullopt;

--- a/cub/cub/warp/specializations/warp_redux.cuh
+++ b/cub/cub/warp/specializations/warp_redux.cuh
@@ -21,7 +21,7 @@
 #include <cub/detail/type_traits.cuh>
 #include <cub/thread/thread_operators.cuh>
 
-#include <cuda/std/__floating_point/cast.h>
+#include <cuda/std/__floating_point/cast.h> // IWYU pragma: keep
 #include <cuda/std/__optional/optional.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/is_integral.h>
@@ -44,15 +44,7 @@ inline constexpr bool is_warp_redux_op_supported_sm80 =
 
 template <typename Op, typename T, typename ReduceOp = ::cuda::std::remove_cvref_t<Op>>
 inline constexpr bool is_warp_redux_op_supported_sm100af =
-  __cccl_ptx_isa >= 860
-  && (::cuda::std::is_same_v<T, float>
-#if _CCCL_HAS_NVFP16()
-      || is_half_v<T>
-#endif // _CCCL_HAS_NVFP16()
-#if _CCCL_HAS_NVBF16()
-      || is_bfloat16_v<T>
-#endif // _CCCL_HAS_NVBF16()
-      )
+  __cccl_ptx_isa >= 860 && (::cuda::std::is_same_v<T, float> || is_half_v<T> || is_bfloat16_v<T>)
   && is_cuda_minimum_maximum_v<ReduceOp, T>;
 
 template <typename Op, typename T>
@@ -122,15 +114,15 @@ warp_redux_sm80(const T input, const ::cuda::std::uint32_t mask, ReductionOp)
 
 _CUB_REDUX_FLOAT_OP(min)
 _CUB_REDUX_FLOAT_OP(max)
-// TODO: min_abs, max_abs are also available but we need to introduce the corresposing operators
+// TODO(fbusato): min_abs, max_abs are also available but we need to introduce the corresposing operators
 // _CUB_REDUX_FLOAT_OP(min_abs)
 // _CUB_REDUX_FLOAT_OP(max_abs)
 
 #  undef _CUB_REDUX_FLOAT_OP
 
 template <typename T, typename ReductionOp>
-[[nodiscard]] _CCCL_DEVICE_API
-_CCCL_FORCEINLINE T warp_redux_sm100af(const T input, const ::cuda::std::uint32_t mask, ReductionOp)
+[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE T
+warp_redux_sm100af(const T input, const ::cuda::std::uint32_t mask, ReductionOp)
 {
   static_assert(is_warp_redux_op_supported_sm100af<ReductionOp, T>, "Reduction operator not supported");
   _CCCL_ASSERT(mask != 0, "Mask must not be 0");
@@ -162,16 +154,15 @@ warp_redux(const T input, const ::cuda::std::uint32_t mask, ReductionOp reductio
   {
     NV_IF_TARGET(NV_PROVIDES_SM_80, (return cub::detail::warp_redux_sm80(input, mask, reduction_op);))
   }
-  else if constexpr (is_warp_redux_op_supported_sm100f<ReductionOp, T>)
+  else if constexpr (is_warp_redux_op_supported_sm100af<ReductionOp, T>)
   {
     // Before PTX ISA 8.8, float reductions are only supported on sm100a.
-#  if __cccl_ptx_isa >= 880
+#if __cccl_ptx_isa >= 880
     NV_IF_TARGET(NV_HAS_FEATURE_SM_100f, (return cub::detail::warp_redux_sm100f(input, mask, reduction_op);))
-#  else // ^^^ __cccl_ptx_isa >= 880 ^^^ / vvv __cccl_ptx_isa < 880 vvv
+#else // ^^^ __cccl_ptx_isa >= 880 ^^^ / vvv __cccl_ptx_isa < 880 vvv
     NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (return cub::detail::warp_redux_sm100f(input, mask, reduction_op);))
-#  endif // ^^^ __cccl_ptx_isa < 880 ^^^
+#endif // ^^^ __cccl_ptx_isa < 880 ^^^
   }
-#endif // __cccl_ptx_isa >= 860
   return ::cuda::std::nullopt;
 }
 } // namespace detail

--- a/cub/cub/warp/specializations/warp_redux.cuh
+++ b/cub/cub/warp/specializations/warp_redux.cuh
@@ -49,7 +49,7 @@ inline constexpr bool is_warp_redux_op_supported_sm100af =
 
 template <typename Op, typename T>
 inline constexpr bool is_warp_redux_op_supported =
-  is_warp_redux_op_supported_sm80<Op, T> || is_warp_redux_op_supported_sm100f<Op, T>;
+  is_warp_redux_op_supported_sm80<Op, T> || is_warp_redux_op_supported_sm100af<Op, T>;
 
 //----------------------------------------------------------------------------------------------------------------------
 // SM80 Redux
@@ -124,7 +124,7 @@ template <typename T, typename ReductionOp>
 [[nodiscard]] _CCCL_DEVICE_API
 _CCCL_FORCEINLINE T warp_redux_sm100af(const T input, const ::cuda::std::uint32_t mask, ReductionOp)
 {
-  static_assert(is_warp_redux_op_supported_sm100f<ReductionOp, T>, "Reduction operator not supported");
+  static_assert(is_warp_redux_op_supported_sm100af<ReductionOp, T>, "Reduction operator not supported");
   _CCCL_ASSERT(mask != 0, "Mask must not be 0");
 
   const float value = ::cuda::std::__fp_cast<float>(input);

--- a/cub/cub/warp/specializations/warp_redux.cuh
+++ b/cub/cub/warp/specializations/warp_redux.cuh
@@ -121,8 +121,8 @@ _CUB_REDUX_FLOAT_OP(max)
 #  undef _CUB_REDUX_FLOAT_OP
 
 template <typename T, typename ReductionOp>
-[[nodiscard]] _CCCL_DEVICE_API
-_CCCL_FORCEINLINE T warp_redux_sm100af(const T input, const ::cuda::std::uint32_t mask, ReductionOp)
+[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE T
+warp_redux_sm100af(const T input, const ::cuda::std::uint32_t mask, ReductionOp)
 {
   static_assert(is_warp_redux_op_supported_sm100af<ReductionOp, T>, "Reduction operator not supported");
   _CCCL_ASSERT(mask != 0, "Mask must not be 0");

--- a/cub/cub/warp/specializations/warp_redux.cuh
+++ b/cub/cub/warp/specializations/warp_redux.cuh
@@ -43,7 +43,7 @@ inline constexpr bool is_warp_redux_op_supported_sm80 =
   && (is_cuda_minimum_maximum_v<ReduceOp, T> || is_cuda_std_plus_v<ReduceOp, T> || is_cuda_std_bitwise_v<ReduceOp, T>);
 
 template <typename Op, typename T, typename ReduceOp = ::cuda::std::remove_cvref_t<Op>>
-inline constexpr bool is_warp_redux_op_supported_sm100af =
+inline constexpr bool is_warp_redux_op_supported_sm100f =
   __cccl_ptx_isa >= 860
   && (::cuda::std::is_same_v<T, float>
 #if _CCCL_HAS_NVFP16()
@@ -57,7 +57,7 @@ inline constexpr bool is_warp_redux_op_supported_sm100af =
 
 template <typename Op, typename T>
 inline constexpr bool is_warp_redux_op_supported =
-  is_warp_redux_op_supported_sm80<Op, T> || is_warp_redux_op_supported_sm100af<Op, T>;
+  is_warp_redux_op_supported_sm80<Op, T> || is_warp_redux_op_supported_sm100f<Op, T>;
 
 //----------------------------------------------------------------------------------------------------------------------
 // SM80 Redux
@@ -103,12 +103,12 @@ warp_redux_sm80(const T input, const ::cuda::std::uint32_t mask, ReductionOp)
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-// SM100af Redux
+// SM100f Redux
 
 #if __cccl_ptx_isa >= 860
 
 #  define _CUB_REDUX_FLOAT_OP(_CCCL_PTX_OP)                                                    \
-    [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE float redux_sm100af_##_CCCL_PTX_OP##_ptx( \
+    [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE float redux_sm100f_##_CCCL_PTX_OP##_ptx( \
       const float value, ::cuda::std::uint32_t mask)                                           \
     {                                                                                          \
       float result;                                                                            \
@@ -130,20 +130,20 @@ _CUB_REDUX_FLOAT_OP(max)
 
 template <typename T, typename ReductionOp>
 [[nodiscard]] _CCCL_DEVICE_API
-_CCCL_FORCEINLINE T warp_redux_sm100af(const T input, const ::cuda::std::uint32_t mask, ReductionOp)
+_CCCL_FORCEINLINE T warp_redux_sm100f(const T input, const ::cuda::std::uint32_t mask, ReductionOp)
 {
-  static_assert(is_warp_redux_op_supported_sm100af<ReductionOp, T>, "Reduction operator not supported");
+  static_assert(is_warp_redux_op_supported_sm100f<ReductionOp, T>, "Reduction operator not supported");
   _CCCL_ASSERT(mask != 0, "Mask must not be 0");
 
   const float value = ::cuda::std::__fp_cast<float>(input);
   float result;
   if constexpr (is_cuda_minimum_v<ReductionOp, T>)
   {
-    result = cub::detail::redux_sm100af_min_ptx(value, mask);
+    result = cub::detail::redux_sm100f_min_ptx(value, mask);
   }
   else
   {
-    result = cub::detail::redux_sm100af_max_ptx(value, mask);
+    result = cub::detail::redux_sm100f_max_ptx(value, mask);
   }
   return ::cuda::std::__fp_cast<T>(result);
 }

--- a/cub/cub/warp/specializations/warp_redux.cuh
+++ b/cub/cub/warp/specializations/warp_redux.cuh
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3
+
+/**
+ * @file
+ * Helpers for warp-level REDUX reductions.
+ */
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/detail/type_traits.cuh>
+#include <cub/thread/thread_operators.cuh>
+
+#include <cuda/std/__floating_point/cast.h>
+#include <cuda/std/__optional/optional.h>
+#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/__type_traits/remove_cvref.h>
+#include <cuda/std/cstdint>
+
+CUB_NAMESPACE_BEGIN
+
+namespace detail
+{
+//----------------------------------------------------------------------------------------------------------------------
+// Redux Traits
+
+template <typename Op, typename T, typename ReduceOp = ::cuda::std::remove_cvref_t<Op>>
+inline constexpr bool is_warp_redux_op_supported_sm80 =
+  ::cuda::std::is_integral_v<T> && sizeof(T) <= sizeof(unsigned)
+  && (is_cuda_minimum_maximum_v<ReduceOp, T> || is_cuda_std_plus_v<ReduceOp, T> || is_cuda_std_bitwise_v<ReduceOp, T>);
+
+template <typename Op, typename T, typename ReduceOp = ::cuda::std::remove_cvref_t<Op>>
+inline constexpr bool is_warp_redux_op_supported_sm100af =
+  __cccl_ptx_isa >= 860
+  && (::cuda::std::is_same_v<T, float>
+#if _CCCL_HAS_NVFP16()
+      || is_half_v<T>
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
+      || is_bfloat16_v<T>
+#endif // _CCCL_HAS_NVBF16()
+      )
+  && is_cuda_minimum_maximum_v<ReduceOp, T>;
+
+template <typename Op, typename T>
+inline constexpr bool is_warp_redux_op_supported =
+  is_warp_redux_op_supported_sm80<Op, T> || is_warp_redux_op_supported_sm100af<Op, T>;
+
+//----------------------------------------------------------------------------------------------------------------------
+// SM80 Redux
+
+template <typename T, typename ReductionOp>
+[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE T
+warp_redux_sm80(const T input, const ::cuda::std::uint32_t mask, ReductionOp)
+{
+  static_assert(is_warp_redux_op_supported_sm80<ReductionOp, T>, "Reduction operator not supported");
+  _CCCL_ASSERT(mask != 0, "Mask must not be 0");
+
+  using promotion_t = ::cuda::std::conditional_t<::cuda::std::is_signed_v<T>, int, unsigned>;
+  const auto value  = static_cast<promotion_t>(input);
+  if constexpr (is_cuda_maximum_v<ReductionOp, T>)
+  {
+    return static_cast<T>(::__reduce_max_sync(mask, value));
+  }
+  else if constexpr (is_cuda_minimum_v<ReductionOp, T>)
+  {
+    return static_cast<T>(::__reduce_min_sync(mask, value));
+  }
+  else if constexpr (is_cuda_std_plus_v<ReductionOp, T>)
+  {
+    return static_cast<T>(::__reduce_add_sync(mask, value));
+  }
+  else if constexpr (is_cuda_std_bit_and_v<ReductionOp, T>)
+  {
+    return static_cast<T>(::__reduce_and_sync(mask, value));
+  }
+  else if constexpr (is_cuda_std_bit_or_v<ReductionOp, T>)
+  {
+    return static_cast<T>(::__reduce_or_sync(mask, value));
+  }
+  else if constexpr (is_cuda_std_bit_xor_v<ReductionOp, T>)
+  {
+    return static_cast<T>(::__reduce_xor_sync(mask, value));
+  }
+  else
+  {
+    _CCCL_UNREACHABLE();
+    return T{};
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// SM100af Redux
+
+#if __cccl_ptx_isa >= 860
+
+#  define _CUB_REDUX_FLOAT_OP(_CCCL_PTX_OP)                                                    \
+    [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE float redux_sm100af_##_CCCL_PTX_OP##_ptx( \
+      const float value, ::cuda::std::uint32_t mask)                                           \
+    {                                                                                          \
+      float result;                                                                            \
+      asm volatile("{"                                                                         \
+                   "redux.sync." #_CCCL_PTX_OP ".f32 %0, %1, %2;"                              \
+                   "}"                                                                         \
+                   : "=f"(result)                                                              \
+                   : "f"(value), "r"(mask));                                                   \
+      return result;                                                                           \
+    }
+
+_CUB_REDUX_FLOAT_OP(min)
+_CUB_REDUX_FLOAT_OP(max)
+// TODO: min_abs, max_abs are also available but we need to introduce the corresposing operators
+// _CUB_REDUX_FLOAT_OP(min_abs)
+// _CUB_REDUX_FLOAT_OP(max_abs)
+
+#  undef _CUB_REDUX_FLOAT_OP
+
+template <typename T, typename ReductionOp>
+[[nodiscard]] _CCCL_DEVICE_API
+_CCCL_FORCEINLINE T warp_redux_sm100af(const T input, const ::cuda::std::uint32_t mask, ReductionOp)
+{
+  static_assert(is_warp_redux_op_supported_sm100af<ReductionOp, T>, "Reduction operator not supported");
+  _CCCL_ASSERT(mask != 0, "Mask must not be 0");
+
+  const float value = ::cuda::std::__fp_cast<float>(input);
+  float result;
+  if constexpr (is_cuda_minimum_v<ReductionOp, T>)
+  {
+    result = cub::detail::redux_sm100af_min_ptx(value, mask);
+  }
+  else
+  {
+    result = cub::detail::redux_sm100af_max_ptx(value, mask);
+  }
+  return ::cuda::std::__fp_cast<T>(result);
+}
+
+#endif // __cccl_ptx_isa >= 860
+
+//----------------------------------------------------------------------------------------------------------------------
+// Redux Dispatch
+
+template <typename T, typename ReductionOp>
+[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE constexpr ::cuda::std::optional<T>
+warp_redux(const T input, const ::cuda::std::uint32_t mask, ReductionOp reduction_op)
+{
+  static_assert(is_warp_redux_op_supported<ReductionOp, T>, "Reduction operator not supported");
+  if constexpr (is_warp_redux_op_supported_sm80<ReductionOp, T>)
+  {
+    NV_IF_TARGET(NV_PROVIDES_SM_80, (return cub::detail::warp_redux_sm80(input, mask, reduction_op);))
+  }
+#if __cccl_ptx_isa >= 860
+  else if constexpr (is_warp_redux_op_supported_sm100af<ReductionOp, T>)
+  {
+    NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (return cub::detail::warp_redux_sm100af(input, mask, reduction_op);))
+#  if __cccl_ptx_isa >= 880
+    NV_IF_TARGET(NV_HAS_FEATURE_SM_100f, (return cub::detail::warp_redux_sm100af(input, mask, reduction_op);))
+#  endif // __cccl_ptx_isa >= 880
+  }
+#endif // __cccl_ptx_isa >= 860
+  return ::cuda::std::nullopt;
+}
+} // namespace detail
+
+CUB_NAMESPACE_END

--- a/cub/cub/warp/specializations/warp_redux.cuh
+++ b/cub/cub/warp/specializations/warp_redux.cuh
@@ -107,17 +107,17 @@ warp_redux_sm80(const T input, const ::cuda::std::uint32_t mask, ReductionOp)
 
 #if __cccl_ptx_isa >= 860
 
-#  define _CUB_REDUX_FLOAT_OP(_CCCL_PTX_OP)                                                    \
+#  define _CUB_REDUX_FLOAT_OP(_CCCL_PTX_OP)                                                   \
     [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE float redux_sm100f_##_CCCL_PTX_OP##_ptx( \
-      const float value, ::cuda::std::uint32_t mask)                                           \
-    {                                                                                          \
-      float result;                                                                            \
-      asm volatile("{"                                                                         \
-                   "redux.sync." #_CCCL_PTX_OP ".f32 %0, %1, %2;"                              \
-                   "}"                                                                         \
-                   : "=f"(result)                                                              \
-                   : "f"(value), "r"(mask));                                                   \
-      return result;                                                                           \
+      const float value, ::cuda::std::uint32_t mask)                                          \
+    {                                                                                         \
+      float result;                                                                           \
+      asm volatile("{"                                                                        \
+                   "redux.sync." #_CCCL_PTX_OP ".f32 %0, %1, %2;"                             \
+                   "}"                                                                        \
+                   : "=f"(result)                                                             \
+                   : "f"(value), "r"(mask));                                                  \
+      return result;                                                                          \
     }
 
 _CUB_REDUX_FLOAT_OP(min)
@@ -129,8 +129,8 @@ _CUB_REDUX_FLOAT_OP(max)
 #  undef _CUB_REDUX_FLOAT_OP
 
 template <typename T, typename ReductionOp>
-[[nodiscard]] _CCCL_DEVICE_API
-_CCCL_FORCEINLINE T warp_redux_sm100f(const T input, const ::cuda::std::uint32_t mask, ReductionOp)
+[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE T
+warp_redux_sm100f(const T input, const ::cuda::std::uint32_t mask, ReductionOp)
 {
   static_assert(is_warp_redux_op_supported_sm100f<ReductionOp, T>, "Reduction operator not supported");
   _CCCL_ASSERT(mask != 0, "Mask must not be 0");
@@ -165,11 +165,11 @@ warp_redux(const T input, const ::cuda::std::uint32_t mask, ReductionOp reductio
   else if constexpr (is_warp_redux_op_supported_sm100f<ReductionOp, T>)
   {
     // Before PTX ISA 8.8, float reductions are only supported on sm100a.
-#  if __cccl_ptx_isa >= 880
+#if __cccl_ptx_isa >= 880
     NV_IF_TARGET(NV_HAS_FEATURE_SM_100f, (return cub::detail::warp_redux_sm100f(input, mask, reduction_op);))
-#  else // ^^^ __cccl_ptx_isa >= 880 ^^^ / vvv __cccl_ptx_isa < 880 vvv
+#else // ^^^ __cccl_ptx_isa >= 880 ^^^ / vvv __cccl_ptx_isa < 880 vvv
     NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (return cub::detail::warp_redux_sm100f(input, mask, reduction_op);))
-#  endif // ^^^ __cccl_ptx_isa < 880 ^^^
+#endif // ^^^ __cccl_ptx_isa < 880 ^^^
   }
 #endif // __cccl_ptx_isa >= 860
   return ::cuda::std::nullopt;

--- a/cub/cub/warp/specializations/warp_redux.cuh
+++ b/cub/cub/warp/specializations/warp_redux.cuh
@@ -162,13 +162,14 @@ warp_redux(const T input, const ::cuda::std::uint32_t mask, ReductionOp reductio
   {
     NV_IF_TARGET(NV_PROVIDES_SM_80, (return cub::detail::warp_redux_sm80(input, mask, reduction_op);))
   }
-#if __cccl_ptx_isa >= 860
-  else if constexpr (is_warp_redux_op_supported_sm100af<ReductionOp, T>)
+  else if constexpr (is_warp_redux_op_supported_sm100f<ReductionOp, T>)
   {
-    NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (return cub::detail::warp_redux_sm100af(input, mask, reduction_op);))
+    // Before PTX ISA 8.8, float reductions are only supported on sm100a.
 #  if __cccl_ptx_isa >= 880
-    NV_IF_TARGET(NV_HAS_FEATURE_SM_100f, (return cub::detail::warp_redux_sm100af(input, mask, reduction_op);))
-#  endif // __cccl_ptx_isa >= 880
+    NV_IF_TARGET(NV_HAS_FEATURE_SM_100f, (return cub::detail::warp_redux_sm100f(input, mask, reduction_op);))
+#  else // ^^^ __cccl_ptx_isa >= 880 ^^^ / vvv __cccl_ptx_isa < 880 vvv
+    NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (return cub::detail::warp_redux_sm100f(input, mask, reduction_op);))
+#  endif // ^^^ __cccl_ptx_isa < 880 ^^^
   }
 #endif // __cccl_ptx_isa >= 860
   return ::cuda::std::nullopt;

--- a/cub/cub/warp/specializations/warp_redux.cuh
+++ b/cub/cub/warp/specializations/warp_redux.cuh
@@ -65,27 +65,27 @@ warp_redux_sm80(const T input, const ::cuda::std::uint32_t mask, ReductionOp)
   const auto value  = static_cast<promotion_t>(input);
   if constexpr (is_cuda_maximum_v<ReductionOp, T>)
   {
-    return static_cast<T>(::__reduce_max_sync(mask, value));
+    return static_cast<T>(__reduce_max_sync(mask, value));
   }
   else if constexpr (is_cuda_minimum_v<ReductionOp, T>)
   {
-    return static_cast<T>(::__reduce_min_sync(mask, value));
+    return static_cast<T>(__reduce_min_sync(mask, value));
   }
   else if constexpr (is_cuda_std_plus_v<ReductionOp, T>)
   {
-    return static_cast<T>(::__reduce_add_sync(mask, value));
+    return static_cast<T>(__reduce_add_sync(mask, value));
   }
   else if constexpr (is_cuda_std_bit_and_v<ReductionOp, T>)
   {
-    return static_cast<T>(::__reduce_and_sync(mask, value));
+    return static_cast<T>(__reduce_and_sync(mask, value));
   }
   else if constexpr (is_cuda_std_bit_or_v<ReductionOp, T>)
   {
-    return static_cast<T>(::__reduce_or_sync(mask, value));
+    return static_cast<T>(__reduce_or_sync(mask, value));
   }
   else if constexpr (is_cuda_std_bit_xor_v<ReductionOp, T>)
   {
-    return static_cast<T>(::__reduce_xor_sync(mask, value));
+    return static_cast<T>(__reduce_xor_sync(mask, value));
   }
   else
   {

--- a/cub/test/warp/catch2_test_warp_reduce.cu
+++ b/cub/test/warp/catch2_test_warp_reduce.cu
@@ -174,7 +174,21 @@ using full_type_list =
 
 using builtin_type_list = c2h::type_list<uint8_t, uint16_t, int32_t, int64_t>;
 
+// clang-format off
+using floating_point_redux_type_list = c2h::type_list<
+float
+#if TEST_HALF_T()
+, __half
+#endif // TEST_HALF_T()
+#if TEST_BF_T()
+, __nv_bfloat16
+#endif // TEST_BF_T()
+>;
+// clang-format on
+
 using predefined_op_list = c2h::type_list<cuda::std::plus<>, cuda::maximum<>, cuda::minimum<>>;
+
+using predefined_min_max_op_list = c2h::type_list<cuda::maximum<>, cuda::minimum<>>;
 
 using logical_warp_threads = c2h::enum_type_list<unsigned, 32, 16, 9, 7, 1>;
 
@@ -259,6 +273,35 @@ C2H_TEST("WarpReduce::Sum/Max/Min, builtin types",
   c2h::host_vector<T> h_out(output_size);
   compute_host_reference<predefined_op>(h_in, h_out, logical_warps, logical_warp_threads);
   verify_results(h_out, d_out);
+}
+
+C2H_TEST("WarpReduce::Max/Min, floating-point redux types",
+         "[reduce][warp][predefined_op][redux]",
+         floating_point_redux_type_list,
+         predefined_min_max_op_list,
+         logical_warp_threads)
+{
+  using T                                       = c2h::get<0, TestType>;
+  using predefined_op                           = c2h::get<1, TestType>;
+  constexpr auto logical_warp_threads           = c2h::get<2, TestType>::value;
+  auto [input_size, output_size, logical_warps] = get_test_config(logical_warp_threads);
+  CAPTURE(c2h::type_name<T>(), c2h::type_name<predefined_op>(), logical_warp_threads);
+  c2h::device_vector<T> d_in(input_size);
+  c2h::device_vector<T> d_out(output_size);
+  c2h::gen(C2H_SEED(10), d_in);
+  warp_reduce_launch<logical_warp_threads>(d_in, d_out, warp_reduce_t<predefined_op, T>{});
+
+  c2h::host_vector<T> h_in = d_in;
+  c2h::host_vector<T> h_out(output_size);
+  compute_host_reference<predefined_op>(h_in, h_out, logical_warps, logical_warp_threads);
+  if constexpr (cuda::std::is_same_v<T, float>)
+  {
+    verify_results_exact(h_out, d_out);
+  }
+  else
+  {
+    verify_results(h_out, d_out);
+  }
 }
 
 C2H_TEST("WarpReduce::CustomSum", "[reduce][warp][generic][full]", full_type_list, logical_warp_threads)


### PR DESCRIPTION
## Description

I recently saw at least two PRs related to the warp reduction with specific dispatch for `redux`. Considering that the current dispatch logic is quite messy and there are additional optimizations, I create this PR: 

- Moved warp `redux` code to a dedicated header.
- Added `sm100a/f` `redux.sync.min/max.f32` for `float`
- `__half` and `__nv_bfloat16` min/max are also handled by promoted them to `float`.
- The new `warp_redux` function returns `cuda::std::optional` to greatly simplify the calling dispatch.
- Provided specific traits to understand when  `redux` is valid.

~Todo~:

- sass comparison/benchmarks