### PR TITLE
[libcu++] Fix device memory pool test

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/device_memory_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/device_memory_resource.cu
@@ -455,11 +455,11 @@ C2H_CCCLRT_TEST("Async memory resource access", "")
         cuda::device_memory_pool_ref another_default_pool_resource =
           cuda::device_default_memory_pool(cuda::device_ref{0});
 
-        pool.enable_access_from(peers_ext.front());
+        default_pool_resource.enable_access_from(peers_ext);
 
-        CCCLRT_CHECK(default_pool_resource.is_accessible_from(peers_ext.front()));
+        CCCLRT_REQUIRE(default_pool_resource.is_accessible_from(peers_ext.front()));
         allocate_and_check_access(default_pool_resource);
-        CCCLRT_CHECK(another_default_pool_resource.is_accessible_from(peers_ext.front()));
+        CCCLRT_REQUIRE(another_default_pool_resource.is_accessible_from(peers_ext.front()));
         allocate_and_check_access(another_default_pool_resource);
       }
     }


### PR DESCRIPTION
Peer access is enabled on the wrong pool, later checks use the default pool, while it was enabled on a custom pool