### PR TITLE
[libcu++] Implement `cuda::std::vformat_to`

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/visibility.h
+++ b/libcudacxx/include/cuda/std/__cccl/visibility.h
@@ -72,10 +72,17 @@
 #if _CCCL_COMPILER(MSVC)
 #  define _CCCL_FORCEINLINE __forceinline
 #  define _CCCL_FORCEINLINE_LAMBDA
-#else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv _CCCL_COMPILER(MSVC) vvv
+#else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
 #  define _CCCL_FORCEINLINE        __inline__ __attribute__((__always_inline__))
 #  define _CCCL_FORCEINLINE_LAMBDA __attribute__((__always_inline__))
-#endif // !_CCCL_COMPILER(MSVC)
+#endif // ^^^ !_CCCL_COMPILER(MSVC) ^^^
+
+#if _CCCL_COMPILER(MSVC)
+#  define _CCCL_NOINLINE __declspec(noinline)
+#else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv _CCCL_COMPILER(MSVC) vvv
+// We can't use __noinline__ here because of CTK defining this macro.
+#  define _CCCL_NOINLINE __attribute__((noinline))
+#endif // ^^^ !_CCCL_COMPILER(MSVC) ^^^
 
 #if _CCCL_HAS_ATTRIBUTE(__exclude_from_explicit_instantiation__)
 #  define _CCCL_EXCLUDE_FROM_EXPLICIT_INSTANTIATION __attribute__((__exclude_from_explicit_instantiation__))

--- a/libcudacxx/include/cuda/std/__format/buffer.h
+++ b/libcudacxx/include/cuda/std/__format/buffer.h
@@ -3,7 +3,7 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -20,26 +20,526 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__algorithm/copy.h>
+#include <cuda/std/__algorithm/copy_n.h>
+#include <cuda/std/__algorithm/fill_n.h>
+#include <cuda/std/__algorithm/max.h>
+#include <cuda/std/__algorithm/min.h>
+#include <cuda/std/__algorithm/transform.h>
+#include <cuda/std/__concepts/same_as.h>
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__exception/exception_macros.h>
+#include <cuda/std/__format/concepts.h>
 #include <cuda/std/__fwd/format.h>
+#include <cuda/std/__host_stdlib/stdexcept>
+#include <cuda/std/__iterator/back_insert_iterator.h>
+#include <cuda/std/__iterator/incrementable_traits.h>
+#include <cuda/std/__iterator/wrap_iter.h>
+#include <cuda/std/__memory/allocate_at_least.h>
+#include <cuda/std/__memory/allocator.h>
+#include <cuda/std/__memory/destruct_n.h>
+#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__utility/cmp.h>
+#include <cuda/std/__utility/exception_guard.h>
+#include <cuda/std/__utility/move.h>
+#include <cuda/std/string_view>
 
 #include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-// todo: implement __fmt_output_buffer
+// A helper to limit the total size of code units written.
+class __fmt_max_output_size
+{
+  size_t __max_size_;
+  // The code units that would have been written if there was no limit.
+  // format_to_n returns this value.
+  size_t __code_units_written_{0};
 
+public:
+  _CCCL_API constexpr explicit __fmt_max_output_size(size_t __max_size) noexcept
+      : __max_size_{__max_size}
+  {}
+
+  // This function adjusts the size of a (bulk) write operations. It ensures the
+  // number of code units written by a __fmt_output_buffer never exceeds
+  // __max_size_ code units.
+  [[nodiscard]] _CCCL_API constexpr size_t __write_request(size_t __code_units) noexcept
+  {
+    const auto __result =
+      (__code_units_written_ < __max_size_) ? ::cuda::std::min(__code_units, __max_size_ - __code_units_written_) : 0;
+    __code_units_written_ += __code_units;
+    return __result;
+  }
+
+  [[nodiscard]] _CCCL_API constexpr size_t __code_units_written() const noexcept
+  {
+    return __code_units_written_;
+  }
+};
+
+/// A "buffer" that handles writing to the proper iterator.
+///
+/// This helper is used together with the @ref __back_insert_iterator to offer
+/// type-erasure for the formatting functions. This reduces the number to
+/// template instantiations.
+///
+/// The design is the following:
+/// - There is an external object that connects the buffer to the output.
+/// - This buffer object:
+///   - inherits publicly from this class.
+///   - has a static or dynamic buffer.
+///   - has a static member function to make space in its buffer write
+///     operations. This can be done by increasing the size of the internal
+///     buffer or by writing the contents of the buffer to the output iterator.
+///
+///     This member function is a constructor argument, so its name is not
+///     fixed. The code uses the name __prepare_write.
+/// - The number of output code units can be limited by a __fmt_max_output_size
+///   object. This is used in format_to_n This object:
+///   - Contains the maximum number of code units to be written.
+///   - Contains the number of code units that are requested to be written.
+///     This number is returned to the user of format_to_n.
+///   - The write functions call the object's __request_write member function.
+///     This function:
+///     - Updates the number of code units that are requested to be written.
+///     - Returns the number of code units that can be written without
+///       exceeding the maximum number of code units to be written.
+///
+/// Documentation for the buffer usage members:
+/// - __ptr_
+///   The start of the buffer.
+/// - __capacity_
+///   The number of code units that can be written. This means
+///   [__ptr_, __ptr_ + __capacity_) is a valid range to write to.
+/// - __size_
+///   The number of code units written in the buffer. The next code unit will
+///   be written at __ptr_ + __size_. This __size_ may NOT contain the total
+///   number of code units written by the __fmt_output_buffer. Whether or not it
+///   does depends on the sub-class used. Typically the total number of code
+///   units written is not interesting. It is interesting for format_to_n which
+///   has its own way to track this number.
+///
+/// Documentation for the modifying buffer operations:
+/// The subclasses have a function with the following signature:
+///
+///   static void __prepare_write(
+///     __fmt_output_buffer<_CharT>& __buffer, size_t __code_units);
+///
+/// This function is called when a write function writes more code units than
+/// the buffer's available space. When an __max_output_size object is provided
+/// the number of code units is the number of code units returned from
+/// __max_output_size::__request_write function.
+///
+/// - The __buffer contains *this. Since the class containing this function
+///   inherits from __fmt_output_buffer it's safe to cast it to the subclass being
+///   used.
+/// - The __code_units is the number of code units the caller will write + 1.
+///   - This value does not take the available space of the buffer into account.
+///   - The push_back function is more efficient when writing before resizing,
+///     this means the buffer should always have room for one code unit. Hence
+///     the + 1 in the size.
+/// - When the function returns there is room for at least one additional code
+///   unit. There is no requirement there is room for __code_units code units:
+///   - The class has some "bulk" operations. For example, __copy which copies
+///     the contents of a basic_string_view to the output. If the sub-class has
+///     a fixed size buffer the size of the basic_string_view may be larger
+///     than the buffer. In that case it's impossible to honor the requested
+///     size.
+///   - When the buffer has room for at least one code unit the function may be
+///     a no-op.
+/// - When the function makes space for more code units it uses one for these
+///   functions to signal the change:
+///   - __buffer_flushed()
+///     - This function is typically used for a fixed sized buffer.
+///     - The current contents of [__ptr_, __ptr_ + __size_) have been
+///       processed.
+///     - __ptr_ remains unchanged.
+///     - __capacity_ remains unchanged.
+///     - __size_ will be set to 0.
+///   - __buffer_moved(_CharT* __ptr, size_t __capacity)
+///     - This function is typically used for a dynamic sized buffer. There the
+///       location of the buffer changes due to reallocations.
+///     - __ptr_ will be set to __ptr. (This value may be the old value of
+///       __ptr_).
+///     - __capacity_ will be set to __capacity. (This value may be the old
+///       value of __capacity_).
+///     - __size_ remains unchanged,
+///     - The range [__ptr, __ptr + __size_) contains the original data of the
+///       range [__ptr_, __ptr_ + __size_).
+///
+/// The push_back function expects a valid buffer and a capacity of at least 1.
+/// This means:
+/// - The class is constructed with a valid buffer,
+/// - __buffer_moved is called with a valid buffer is used before the first
+///   write operation,
+/// - no write function is ever called, or
+/// - the class is constructed with a __max_output_size object with __max_size 0.
+///
+/// The latter option allows formatted_size to use the output buffer without
+/// ever writing anything to the buffer.
 template <class _CharT>
 class __fmt_output_buffer
 {
-public:
-  using value_type = _CharT;
+  _CharT* __ptr_;
+  size_t __capacity_;
+  size_t __size_{0};
+  void (*__prepare_write_)(__fmt_output_buffer<_CharT>&, size_t);
+  __fmt_max_output_size* __max_output_size_;
 
-  _CCCL_HOST_DEVICE_API void push_back(_CharT __c)
+  [[nodiscard]] _CCCL_API constexpr size_t __available() const noexcept
   {
-    _CCCL_ASSERT(false, "unimplemented __fmt_output_buffer push_back method called");
-    (void) __c;
+    return __capacity_ - __size_;
+  }
+
+  _CCCL_API constexpr void __prepare_write(size_t __code_units)
+  {
+    // Always have space for one additional code unit. This is a precondition of the push_back function.
+    __code_units += 1;
+    if (__available() < __code_units)
+    {
+      __prepare_write_(*this, __code_units + 1);
+    }
+  }
+
+public:
+  using value_type _CCCL_NODEBUG_ALIAS           = _CharT;
+  using __prepare_write_type _CCCL_NODEBUG_ALIAS = void (*)(__fmt_output_buffer<_CharT>&, size_t);
+
+  _CCCL_API constexpr explicit __fmt_output_buffer(
+    _CharT* __ptr,
+    size_t __capacity,
+    __prepare_write_type __function,
+    __fmt_max_output_size* __max_output_size = nullptr) noexcept
+      : __ptr_{__ptr}
+      , __capacity_{__capacity}
+      , __prepare_write_{__function}
+      , __max_output_size_{__max_output_size}
+  {}
+
+  _CCCL_API constexpr void __buffer_flushed() noexcept
+  {
+    __size_ = 0;
+  }
+
+  _CCCL_API constexpr void __buffer_moved(_CharT* __ptr, size_t __capacity) noexcept
+  {
+    __ptr_      = __ptr;
+    __capacity_ = __capacity;
+  }
+
+  [[nodiscard]] _CCCL_API constexpr auto __make_output_iterator()
+  {
+    return __back_insert_iterator{*this};
+  }
+
+  // Used in std::back_insert_iterator.
+  _CCCL_API constexpr void push_back(_CharT __c)
+  {
+    if (__max_output_size_ && __max_output_size_->__write_request(1) == 0)
+    {
+      return;
+    }
+
+    _CCCL_ASSERT(__ptr_ != nullptr, "attempted to write outside the buffer - invalid __ptr_");
+    _CCCL_ASSERT(__size_ < __capacity_, "attempted to write outside the buffer - overflow");
+
+    __ptr_[__size_++] = __c;
+
+    // Profiling showed flushing after adding is more efficient than flushing when entering the function.
+    if (__size_ == __capacity_)
+    {
+      __prepare_write(0);
+    }
+  }
+
+  /// Copies the input __str to the buffer.
+  ///
+  /// Since some of the input is generated by std::to_chars, there needs to be a conversion when _CharT is wchar_t.
+  template <class _InCharT>
+  _CCCL_API constexpr void __copy(basic_string_view<_InCharT> __str)
+  {
+    // When the underlying iterator is a simple iterator the __capacity_ is
+    // infinite. For a string or container back_inserter it isn't. This means
+    // that adding a large string to the buffer can cause some overhead. In that
+    // case a better approach could be:
+    // - flush the buffer
+    // - container.append(__str.begin(), __str.end());
+    // The same holds true for the fill.
+    // For transform it might be slightly harder, however the use case for
+    // transform is slightly less common; it converts hexadecimal values to
+    // upper case. For integral these strings are short.
+    // TODO FMT Look at the improvements above.
+    auto __n = __str.size();
+    if (__max_output_size_)
+    {
+      __n = __max_output_size_->__write_request(__n);
+      if (__n == 0)
+      {
+        return;
+      }
+    }
+
+    const _InCharT* __first = __str.data();
+    do
+    {
+      __prepare_write(__n);
+      const auto __chunk = ::cuda::std::min(__n, __available());
+      ::cuda::std::copy_n(__first, __chunk, __ptr_ + __size_);
+      __size_ += __chunk;
+      __first += __chunk;
+      __n -= __chunk;
+    } while (__n);
+  }
+
+  /// A std::transform wrapper.
+  ///
+  /// Like @ref __copy it may need to do type conversion.
+  template <class _Iterator, class _UnaryOperation, class _InCharT = typename iterator_traits<_Iterator>::value_type>
+  _CCCL_API constexpr void __transform(_Iterator __first, _Iterator __last, _UnaryOperation __operation)
+  {
+    static_assert(contiguous_iterator<_Iterator>);
+
+    _CCCL_ASSERT(__first <= __last, "not a valid range");
+
+    auto __n = static_cast<size_t>(__last - __first);
+    if (__max_output_size_)
+    {
+      __n = __max_output_size_->__write_request(__n);
+      if (__n == 0)
+      {
+        return;
+      }
+    }
+
+    do
+    {
+      __prepare_write(__n);
+      const auto __chunk = ::cuda::std::min(__n, __available());
+      ::cuda::std::transform(__first, __first + __chunk, __ptr_ + __size_, __operation);
+      __size_ += __chunk;
+      __first += __chunk;
+      __n -= __chunk;
+    } while (__n);
+  }
+
+  /// A \c fill_n wrapper.
+  _CCCL_API constexpr void __fill(size_t __n, _CharT __value)
+  {
+    if (__max_output_size_)
+    {
+      __n = __max_output_size_->__write_request(__n);
+      if (__n == 0)
+      {
+        return;
+      }
+    }
+
+    do
+    {
+      __prepare_write(__n);
+      const auto __chunk = ::cuda::std::min(__n, __available());
+      ::cuda::std::fill_n(__ptr_ + __size_, __chunk, __value);
+      __size_ += __chunk;
+      __n -= __chunk;
+    } while (__n);
+  }
+
+  [[nodiscard]] _CCCL_API constexpr size_t __capacity() const noexcept
+  {
+    return __capacity_;
+  }
+  [[nodiscard]] _CCCL_API constexpr size_t __size() const noexcept
+  {
+    return __size_;
   }
 };
+
+/// Extract the container type of a \ref back_insert_iterator.
+template <class _It, class = void>
+struct __fmt_back_insert_iterator_container
+{
+  using type _CCCL_NODEBUG_ALIAS = void;
+};
+
+template <class _Container>
+struct __fmt_back_insert_iterator_container<__back_insert_iterator<_Container>, enable_if_t<__fmt_insertable<_Container>>>
+{
+  using type _CCCL_NODEBUG_ALIAS = _Container;
+};
+
+// A dynamically growing buffer.
+template <class _CharT>
+class __fmt_allocating_buffer : public __fmt_output_buffer<_CharT>
+{
+  using _Alloc _CCCL_NODEBUG_ALIAS = allocator<_CharT>;
+
+  // Since allocating is expensive the class has a small internal buffer. When
+  // its capacity is exceeded a dynamic buffer will be allocated.
+  static constexpr size_t __buffer_size = 256;
+  _CharT __small_buffer_[__buffer_size];
+
+  _CharT* __ptr_{__small_buffer_};
+
+  _CCCL_API constexpr void __grow_buffer(size_t __capacity)
+  {
+    if (__capacity < __buffer_size)
+    {
+      return;
+    }
+
+    _CCCL_ASSERT(__capacity > this->__capacity(), "the buffer must grow");
+
+    // _CharT is an implicit lifetime type so can be used without explicit
+    // construction or destruction.
+    _Alloc __alloc;
+    auto __result = ::cuda::std::__allocate_at_least(__alloc, __capacity);
+    ::cuda::std::copy_n(__ptr_, this->__size(), __result.ptr);
+    if (__ptr_ != __small_buffer_)
+    {
+      __alloc.deallocate(__ptr_, this->__capacity());
+    }
+
+    __ptr_ = __result.ptr;
+    this->__buffer_moved(__ptr_, __result.count);
+  }
+
+  _CCCL_API constexpr void __prepare_write(size_t __size_hint)
+  {
+    __grow_buffer(::cuda::std::max<size_t>(this->__capacity() + __size_hint, this->__capacity() * 1.6));
+  }
+
+  _CCCL_API static constexpr void __prepare_write(__fmt_output_buffer<_CharT>& __buffer, size_t __size_hint)
+  {
+    static_cast<__fmt_allocating_buffer<_CharT>&>(__buffer).__prepare_write(__size_hint);
+  }
+
+public:
+  _CCCL_API constexpr explicit __fmt_allocating_buffer(__fmt_max_output_size* __max_output_size = nullptr) noexcept
+      : __fmt_output_buffer<_CharT>{__small_buffer_, __buffer_size, __prepare_write, __max_output_size}
+  {}
+
+  __fmt_allocating_buffer(const __fmt_allocating_buffer&)            = delete;
+  __fmt_allocating_buffer(__fmt_allocating_buffer&&)                 = delete;
+  __fmt_allocating_buffer& operator=(const __fmt_allocating_buffer&) = delete;
+  __fmt_allocating_buffer& operator=(__fmt_allocating_buffer&&)      = delete;
+
+  _CCCL_API _CCCL_CONSTEXPR_CXX20 ~__fmt_allocating_buffer()
+  {
+    if (__ptr_ != __small_buffer_)
+    {
+      _Alloc{}.deallocate(__ptr_, this->__capacity());
+    }
+  }
+
+  [[nodiscard]] _CCCL_API constexpr basic_string_view<_CharT> __view() const noexcept
+  {
+    return {__ptr_, this->__size()};
+  }
+};
+
+// A buffer that directly writes to the underlying buffer.
+template <class _OutIt, class _CharT>
+class __fmt_direct_iterator_buffer : public __fmt_output_buffer<_CharT>
+{
+  // The function format_to expects a buffer large enough for the output. The
+  // function format_to_n has its own helper class that restricts the number of
+  // write options. So this function class can pretend to have an infinite
+  // buffer.
+  static constexpr auto __buffer_size = static_cast<size_t>(-1);
+
+  _OutIt __out_it_;
+
+  _CCCL_API static constexpr void
+  __prepare_write([[maybe_unused]] __fmt_output_buffer<_CharT>& __buffer, [[maybe_unused]] size_t __size_hint)
+  {
+    _CCCL_THROW(::std::length_error, "cuda::std::__fmt_direct_iterator_buffer");
+  }
+
+public:
+  _CCCL_API constexpr explicit __fmt_direct_iterator_buffer(
+    _OutIt __out_it, __fmt_max_output_size* __max_output_size = nullptr) noexcept
+      : __fmt_output_buffer<_CharT>{::cuda::std::__unwrap_iter(__out_it),
+                                    __buffer_size,
+                                    __prepare_write,
+                                    __max_output_size}
+      , __out_it_{__out_it}
+  {}
+
+  [[nodiscard]] _CCCL_API constexpr _OutIt __out_it() &&
+  {
+    return __out_it_ + this->__size();
+  }
+};
+
+// A buffer that writes its output to the end of a container.
+template <class _OutIt, class _CharT>
+class __fmt_container_inserter_buffer : public __fmt_output_buffer<_CharT>
+{
+  typename __fmt_back_insert_iterator_container<_OutIt>::type* __container_;
+
+  // This class uses a fixed size buffer and appends the elements in
+  // __buffer_size chunks. An alternative would be to use an allocating buffer
+  // and append the output in a single write operation. Benchmarking showed no
+  // performance difference.
+  static constexpr size_t __buffer_size = 256;
+  _CharT __small_buffer_[__buffer_size];
+
+  _CCCL_API constexpr void __prepare_write()
+  {
+    __container_->insert(__container_->end(), __small_buffer_, __small_buffer_ + this->__size());
+    this->__buffer_flushed();
+  }
+
+  _CCCL_API static constexpr void
+  __prepare_write(__fmt_output_buffer<_CharT>& __buffer, [[maybe_unused]] size_t __size_hint)
+  {
+    static_cast<__fmt_container_inserter_buffer<_OutIt, _CharT>&>(__buffer).__prepare_write();
+  }
+
+public:
+  _CCCL_API constexpr explicit __fmt_container_inserter_buffer(
+    _OutIt __out_it, __fmt_max_output_size* __max_output_size = nullptr) noexcept
+      : __fmt_output_buffer<_CharT>{__small_buffer_, __buffer_size, __prepare_write, __max_output_size}
+      , __container_{__out_it.__get_container()}
+  {}
+
+  [[nodiscard]] _CCCL_API constexpr auto __out_it() &&
+  {
+    __container_->insert(__container_->end(), __small_buffer_, __small_buffer_ + this->__size());
+    return __back_insert_iterator{*__container_};
+  }
+};
+
+// A buffer that writes to an iterator.
+//
+// Unlike the __container_inserter_buffer this class' performance does benefit
+// from allocating and then inserting.
+template <class _OutIt, class _CharT>
+class __fmt_iterator_buffer : public __fmt_allocating_buffer<_CharT>
+{
+  _OutIt __out_it_;
+
+public:
+  _CCCL_API constexpr explicit __fmt_iterator_buffer(_OutIt __out_it, __fmt_max_output_size* __max_output_size = nullptr)
+      : __fmt_allocating_buffer<_CharT>{__max_output_size}
+      , __out_it_{::cuda::std::move(__out_it)}
+  {}
+
+  [[nodiscard]] _CCCL_API constexpr auto __out_it() &&
+  {
+    return ::cuda::std::copy(this->__view().begin(), this->__view().end(), ::cuda::std::move(__out_it_));
+  }
+};
+
+// Selects the type of the buffer used for the output iterator.
+template <class _OutIt, class _CharT, class _Container = typename __fmt_back_insert_iterator_container<_OutIt>::type>
+using __fmt_buffer_select_t _CCCL_NODEBUG_ALIAS =
+  conditional_t<!same_as<_Container, void>,
+                __fmt_container_inserter_buffer<_OutIt, _CharT>,
+                conditional_t<__fmt_enable_direct_output<_OutIt, _CharT>,
+                              __fmt_direct_iterator_buffer<_OutIt, _CharT>,
+                              __fmt_iterator_buffer<_OutIt, _CharT>>>;
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__format/concepts.h
+++ b/libcudacxx/include/cuda/std/__format/concepts.h
@@ -24,7 +24,9 @@
 #include <cuda/std/__concepts/same_as.h>
 #include <cuda/std/__concepts/semiregular.h>
 #include <cuda/std/__fwd/format.h>
+#include <cuda/std/__fwd/inplace_vector.h>
 #include <cuda/std/__fwd/tuple.h>
+#include <cuda/std/__iterator/wrap_iter.h>
 #include <cuda/std/__type_traits/remove_const.h>
 #include <cuda/std/__type_traits/remove_reference.h>
 #include <cuda/std/__utility/pair.h>
@@ -61,6 +63,38 @@ _CCCL_CONCEPT __formattable_with_helper = _CCCL_REQUIRES_EXPR(
 
 template <class _Tp, class _Context, class _Formatter = typename _Context::template formatter_type<remove_const_t<_Tp>>>
 _CCCL_CONCEPT __formattable_with = semiregular<_Formatter> && __formattable_with_helper<_Tp, _Context, _Formatter>;
+
+template <class _OutIt, class _CharT>
+_CCCL_CONCEPT __fmt_enable_direct_output =
+  __fmt_char_type<_CharT> && (same_as<_OutIt, _CharT*> || same_as<_OutIt, __wrap_iter<_CharT*>>);
+
+/// Opt-in to enable \ref __fmt_insertable for a \a _Container.
+template <class _Container>
+inline constexpr bool __fmt_enable_insertable_v = false;
+
+template <class _Tp, size_t _Np>
+inline constexpr bool __fmt_enable_insertable_v<inplace_vector<_Tp, _Np>> = true;
+
+// todo(dabayer): Enable insertable for host stdlib containers.
+
+template <class _Container>
+_CCCL_CONCEPT __fmt_insertable_helper = _CCCL_REQUIRES_EXPR(
+  (_Container),
+  _Container& __c,
+  add_pointer_t<typename _Container::value_type> __first,
+  add_pointer_t<typename _Container::value_type> __last)(__c.insert(__c.end(), __first, __last));
+
+/// Concept to see whether a \a _Container is insertable.
+///
+/// The concept is used to validate whether multiple calls to a
+/// \ref back_insert_iterator can be replace by a call to \c _Container::insert.
+///
+/// \note a \a _Container needs to opt-in to the concept by specializing
+/// \ref __enable_insertable.
+template <class _Container>
+_CCCL_CONCEPT __fmt_insertable =
+  __fmt_enable_insertable_v<_Container> && __fmt_char_type<typename _Container::value_type>
+  && __fmt_insertable_helper<_Container>;
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__format/format_integral.h
+++ b/libcudacxx/include/cuda/std/__format/format_integral.h
@@ -3,7 +3,7 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -152,7 +152,7 @@ template <class _Tp, class _CharT, class _FmtCtx>
     __out_it                  = ::cuda::std::__fmt_copy(__array, __first, ::cuda::std::move(__out_it));
     __specs.__alignment_      = ::cuda::std::to_underlying(__fmt_spec_alignment::__right);
     __specs.__fill_.__data[0] = _CharT{'0'};
-    __specs.__width_ -= ::cuda::std::min(static_cast<uint32_t>(__last - __first), __specs.__width_);
+    __specs.__width_ -= ::cuda::std::min(static_cast<uint32_t>(__first - __array), __specs.__width_);
   }
 
   if (__specs.__std_.__type_ != __fmt_spec_type::__hexadecimal_upper_case)
@@ -168,42 +168,43 @@ __fmt_format_int(_Tp __value, _FmtCtx& __ctx, __fmt_parsed_spec<_CharT> __specs)
 {
   static_assert(__cccl_is_integer_v<_Tp>);
 
+  using _Up             = make_unsigned_t<_Tp>;
   const auto __uvalue   = ::cuda::uabs(__value);
   const auto __negative = is_signed_v<_Tp> && __value < 0;
 
   switch (__specs.__std_.__type_)
   {
     case __fmt_spec_type::__binary_lower_case: {
-      char __array[__fmt_int_buffer_size_v<_Tp, 2>];
+      char __array[__fmt_int_buffer_size_v<_Up, 2>];
       return ::cuda::std::__fmt_format_int_impl(
-        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Tp, 2>, "0b", 2);
+        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Up, 2>, "0b", 2);
     }
     case __fmt_spec_type::__binary_upper_case: {
-      char __array[__fmt_int_buffer_size_v<_Tp, 2>];
+      char __array[__fmt_int_buffer_size_v<_Up, 2>];
       return ::cuda::std::__fmt_format_int_impl(
-        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Tp, 2>, "0B", 2);
+        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Up, 2>, "0B", 2);
     }
     case __fmt_spec_type::__octal: {
       // Octal is special; if __uvalue == 0 there's no prefix.
-      char __array[__fmt_int_buffer_size_v<_Tp, 8>];
+      char __array[__fmt_int_buffer_size_v<_Up, 8>];
       return ::cuda::std::__fmt_format_int_impl(
-        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Tp, 8>, __uvalue != 0 ? "0" : nullptr, 8);
+        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Up, 8>, __uvalue != 0 ? "0" : nullptr, 8);
     }
     case __fmt_spec_type::__default:
     case __fmt_spec_type::__decimal: {
-      char __array[__fmt_int_buffer_size_v<_Tp, 10>];
+      char __array[__fmt_int_buffer_size_v<_Up, 10>];
       return ::cuda::std::__fmt_format_int_impl(
-        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Tp, 10>, nullptr, 10);
+        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Up, 10>, nullptr, 10);
     }
     case __fmt_spec_type::__hexadecimal_lower_case: {
-      char __array[__fmt_int_buffer_size_v<_Tp, 16>];
+      char __array[__fmt_int_buffer_size_v<_Up, 16>];
       return ::cuda::std::__fmt_format_int_impl(
-        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Tp, 16>, "0x", 16);
+        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Up, 16>, "0x", 16);
     }
     case __fmt_spec_type::__hexadecimal_upper_case: {
-      char __array[__fmt_int_buffer_size_v<_Tp, 16>];
+      char __array[__fmt_int_buffer_size_v<_Up, 16>];
       return ::cuda::std::__fmt_format_int_impl(
-        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Tp, 16>, "0X", 16);
+        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Up, 16>, "0X", 16);
     }
     default:
       _CCCL_UNREACHABLE();

--- a/libcudacxx/include/cuda/std/__format/format_parse_context.h
+++ b/libcudacxx/include/cuda/std/__format/format_parse_context.h
@@ -71,7 +71,7 @@ public:
   {
     if (__indexing_ == _Indexing::__manual)
     {
-      ::cuda::std::__throw_format_error("using automatic argument numbering in manual argument numbering mode");
+      ::cuda::std::__throw_format_error("Using automatic argument numbering in manual argument numbering mode");
     }
     if (__indexing_ == _Indexing::__unknown)
     {
@@ -88,7 +88,7 @@ public:
   {
     if (__indexing_ == _Indexing::__automatic)
     {
-      ::cuda::std::__throw_format_error("using manual argument numbering in automatic argument numbering mode");
+      ::cuda::std::__throw_format_error("Using manual argument numbering in automatic argument numbering mode");
     }
     if (__indexing_ == _Indexing::__unknown)
     {

--- a/libcudacxx/include/cuda/std/__format/format_string.h
+++ b/libcudacxx/include/cuda/std/__format/format_string.h
@@ -48,12 +48,12 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT basic_format_string
       constexpr _FmtArgHandle __handles[] = {
         ::cuda::std::__fmt_make_validation_format_arg_handle<_FmtContext, remove_cvref_t<_Args>>()...};
 
-      ::cuda::std::__fmt_vformat_to(basic_format_parse_context<_CharT>{__str_, sizeof...(_Args)},
-                                    _FmtContext{__types, __handles, sizeof...(_Args)});
+      (void) ::cuda::std::__fmt_vformat_to(basic_format_parse_context<_CharT>{__str_, sizeof...(_Args)},
+                                           _FmtContext{__types, __handles, sizeof...(_Args)});
     }
     else
     {
-      ::cuda::std::__fmt_vformat_to(
+      (void) ::cuda::std::__fmt_vformat_to(
         basic_format_parse_context<_CharT>{__str_, sizeof...(_Args)}, _FmtContext{nullptr, nullptr, sizeof...(_Args)});
     }
   }

--- a/libcudacxx/include/cuda/std/__format/formatters/fp.h
+++ b/libcudacxx/include/cuda/std/__format/formatters/fp.h
@@ -73,11 +73,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<float, char> : __fmt_formatter_fp
 template <>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<double, char> : __fmt_formatter_fp<char>
 {};
-#if _CCCL_HAS_LONG_DOUBLE()
 template <>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<long double, char> : __fmt_formatter_fp<char>
 {};
-#endif // _CCCL_HAS_LONG_DOUBLE()
 
 #if _CCCL_HAS_WCHAR_T()
 template <>
@@ -86,11 +84,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<float, wchar_t> : __fmt_formatter
 template <>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<double, wchar_t> : __fmt_formatter_fp<wchar_t>
 {};
-#  if _CCCL_HAS_LONG_DOUBLE()
 template <>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<long double, wchar_t> : __fmt_formatter_fp<wchar_t>
 {};
-#  endif // _CCCL_HAS_LONG_DOUBLE()
 #endif // _CCCL_HAS_WCHAR_T()
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__format/output_utils.h
+++ b/libcudacxx/include/cuda/std/__format/output_utils.h
@@ -23,7 +23,9 @@
 #include <cuda/std/__algorithm/copy.h>
 #include <cuda/std/__algorithm/fill_n.h>
 #include <cuda/std/__algorithm/transform.h>
+#include <cuda/std/__concepts/same_as.h>
 #include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__format/buffer.h>
 #include <cuda/std/__format/format_spec_parser.h>
 #include <cuda/std/__iterator/iterator_traits.h>
 #include <cuda/std/__utility/move.h>
@@ -100,12 +102,20 @@ _CCCL_END_NV_DIAG_SUPPRESS()
 
 //! Copy wrapper.
 //!
-//! This uses a "mass output function" of __format::__output_buffer when possible.
+//! This uses a "mass output function" of __fmt_output_buffer when possible.
 template <class _CharT, class _OutCharT = _CharT, class _OutIt>
 [[nodiscard]] _CCCL_HOST_DEVICE_API _OutIt __fmt_copy(basic_string_view<_CharT> __str, _OutIt __out_it)
 {
-  // todo: handle __fmt_output_buffer and __fmt_retarget_buffer when they are implemented
-  return ::cuda::std::copy(__str.begin(), __str.end(), ::cuda::std::move(__out_it));
+  // todo: handle __fmt_retarget_buffer once implemented
+  if constexpr (same_as<decltype(__out_it), __back_insert_iterator<__fmt_output_buffer<_OutCharT>>>)
+  {
+    __out_it.__get_container()->__copy(__str);
+    return __out_it;
+  }
+  else
+  {
+    return ::cuda::std::copy(__str.begin(), __str.end(), ::cuda::std::move(__out_it));
+  }
 }
 
 template <class _It, class _CharT = iter_value_t<_It>, class _OutCharT = _CharT, class _OutIt>
@@ -122,23 +132,39 @@ template <class _It, class _CharT = iter_value_t<_It>, class _OutCharT = _CharT,
 
 //! Transform wrapper.
 //!
-//! This uses a "mass output function" of __format::__output_buffer when possible.
+//! This uses a "mass output function" of __fmt_output_buffer when possible.
 template <class _It, class _CharT = iter_value_t<_It>, class _OutCharT = _CharT, class _OutIt, class _UnaryOp>
 [[nodiscard]] _CCCL_HOST_DEVICE_API _OutIt
 __fmt_transform(_It __first, _It __last, _OutIt __out_it, _UnaryOp __operation)
 {
-  // todo: handle __fmt_output_buffer and __fmt_retarget_buffer when they are implemented
-  return ::cuda::std::transform(__first, __last, ::cuda::std::move(__out_it), __operation);
+  // todo: handle __fmt_retarget_buffer once implemented
+  if constexpr (same_as<decltype(__out_it), __back_insert_iterator<__fmt_output_buffer<_OutCharT>>>)
+  {
+    __out_it.__get_container()->__transform(__first, __last, ::cuda::std::move(__operation));
+    return __out_it;
+  }
+  else
+  {
+    return ::cuda::std::transform(__first, __last, ::cuda::std::move(__out_it), __operation);
+  }
 }
 
 //! Fill wrapper.
 //!
-//! This uses a "mass output function" of __format::__output_buffer when possible.
+//! This uses a "mass output function" of __fmt_output_buffer when possible.
 template <class _CharT, class _OutIt>
 [[nodiscard]] _CCCL_HOST_DEVICE_API _OutIt __fmt_fill(_OutIt __out_it, size_t __n, _CharT __value)
 {
-  // todo: handle __fmt_output_buffer and __fmt_retarget_buffer when they are implemented
-  return ::cuda::std::fill_n(::cuda::std::move(__out_it), __n, __value);
+  // todo: handle __fmt_retarget_buffer once implemented
+  if constexpr (same_as<decltype(__out_it), __back_insert_iterator<__fmt_output_buffer<_CharT>>>)
+  {
+    __out_it.__get_container()->__fill(__n, __value);
+    return __out_it;
+  }
+  else
+  {
+    return ::cuda::std::fill_n(::cuda::std::move(__out_it), __n, __value);
+  }
 }
 
 template <class _CharT, class _OutIt>

--- a/libcudacxx/include/cuda/std/__format/vformat.h
+++ b/libcudacxx/include/cuda/std/__format/vformat.h
@@ -20,12 +20,21 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__format/buffer.h>
 #include <cuda/std/__format/format_arg.h>
+#include <cuda/std/__format/format_args.h>
+#include <cuda/std/__format/format_context.h>
 #include <cuda/std/__format/format_error.h>
+#include <cuda/std/__format/format_parse_context.h>
 #include <cuda/std/__format/formatter.h>
 #include <cuda/std/__format/parse_arg_id.h>
 #include <cuda/std/__format/validation.h>
+#include <cuda/std/__iterator/concepts.h>
 #include <cuda/std/__iterator/iterator_traits.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__utility/move.h>
+#include <cuda/std/string_view>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -39,7 +48,7 @@ struct __fmt_replacement_field_visitor
   bool __parse_;
 
   template <class _Tp>
-  _CCCL_API constexpr void operator()(_Tp __arg)
+  _CCCL_API constexpr void operator()([[maybe_unused]] _Tp __arg)
   {
     if constexpr (is_same_v<_Tp, monostate>)
     {
@@ -119,7 +128,7 @@ __fmt_handle_replacement_field(_It __begin, _It __end, _ParseCtx& __parse_ctx, _
 }
 
 template <class _ParseCtx, class _Ctx>
-_CCCL_API constexpr typename _Ctx::iterator __fmt_vformat_to(_ParseCtx&& __parse_ctx, _Ctx&& __ctx)
+[[nodiscard]] _CCCL_API constexpr typename _Ctx::iterator __fmt_vformat_to(_ParseCtx&& __parse_ctx, _Ctx&& __ctx)
 {
   using _CharT = typename _ParseCtx::char_type;
   static_assert(is_same_v<typename _Ctx::char_type, _CharT>);
@@ -165,6 +174,43 @@ _CCCL_API constexpr typename _Ctx::iterator __fmt_vformat_to(_ParseCtx&& __parse
   }
   return __out_it;
 }
+
+// We mark this function as noinline because ptxas takes a lot of time and resources to inline and optimize the
+// formatting function. We expect the function to be mostly used for debugging anyway.
+template <class _OutIt, class _CharT, class _FormatOutIt>
+[[nodiscard]] _CCCL_API _CCCL_NOINLINE _OutIt __vformat_to_impl(
+  _OutIt __out_it, basic_string_view<_CharT> __fmt, basic_format_args<basic_format_context<_FormatOutIt, _CharT>> __args)
+{
+  if constexpr (is_same_v<_OutIt, _FormatOutIt>)
+  {
+    return ::cuda::std::__fmt_vformat_to(basic_format_parse_context{__fmt, __args.__size()},
+                                         ::cuda::std::__fmt_make_format_context(::cuda::std::move(__out_it), __args));
+  }
+  else
+  {
+    __fmt_buffer_select_t<_OutIt, _CharT> __buffer{::cuda::std::move(__out_it)};
+    (void) ::cuda::std::__fmt_vformat_to(
+      basic_format_parse_context{__fmt, __args.__size()},
+      ::cuda::std::__fmt_make_format_context(__buffer.__make_output_iterator(), __args));
+    return ::cuda::std::move(__buffer).__out_it();
+  }
+}
+
+_CCCL_TEMPLATE(class _OutIt)
+_CCCL_REQUIRES(output_iterator<_OutIt, const char&>)
+/*discard*/ _CCCL_API _OutIt vformat_to(_OutIt __out_it, string_view __fmt, format_args __args)
+{
+  return ::cuda::std::__vformat_to_impl(::cuda::std::move(__out_it), __fmt, __args);
+}
+
+#if _CCCL_HAS_WCHAR_T()
+_CCCL_TEMPLATE(class _OutIt)
+_CCCL_REQUIRES(output_iterator<_OutIt, const wchar_t&>)
+/*discard*/ _CCCL_API _OutIt vformat_to(_OutIt __out_it, wstring_view __fmt, wformat_args __args)
+{
+  return ::cuda::std::__vformat_to_impl(::cuda::std::move(__out_it), __fmt, __args);
+}
+#endif // _CCCL_HAS_WCHAR_T()
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__fwd/inplace_vector.h
+++ b/libcudacxx/include/cuda/std/__fwd/inplace_vector.h
@@ -1,0 +1,36 @@
+//===---------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___FWD_INPLACE_VECTOR_H
+#define _CUDA_STD___FWD_INPLACE_VECTOR_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cstddef/types.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+template <class _Tp, size_t _Np>
+class _CCCL_TYPE_VISIBILITY_DEFAULT inplace_vector;
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD___FWD_INPLACE_VECTOR_H

--- a/libcudacxx/include/cuda/std/__iterator/back_insert_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/back_insert_iterator.h
@@ -33,6 +33,9 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+// todo(dabayer): This is a version of __back_insert_iterator that satisfies output_iterator even in C++17. We should
+// find a way to make the ordinary back_insert_iterator satisfy output_iterator in C++17 and remove this internal
+// version.
 template <class _Container>
 class _CCCL_TYPE_VISIBILITY_DEFAULT __back_insert_iterator
 {

--- a/libcudacxx/include/cuda/std/inplace_vector
+++ b/libcudacxx/include/cuda/std/inplace_vector
@@ -32,6 +32,7 @@
 #include <cuda/std/__algorithm/swap_ranges.h>
 #include <cuda/std/__exception/exception_macros.h>
 #include <cuda/std/__exception/terminate.h>
+#include <cuda/std/__fwd/inplace_vector.h>
 #include <cuda/std/__host_stdlib/new>
 #include <cuda/std/__host_stdlib/stdexcept>
 #include <cuda/std/__iterator/advance.h>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/checkers/vformat_to.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/checkers/vformat_to.h
@@ -1,0 +1,80 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__format_>
+#include <cuda/std/algorithm>
+#include <cuda/std/inplace_vector>
+#include <cuda/std/iterator>
+#include <cuda/std/string_view>
+
+#include "format_functions_common.h"
+#include "test_macros.h"
+
+// Marking checkers with _CCCL_NOINLINE greatly improves ptxas compile times.
+
+template <class CharT, class... Args>
+TEST_FUNC _CCCL_NOINLINE bool
+check(cuda::std::basic_string_view<CharT> expected, cuda::std::basic_string_view<CharT> fmt, Args&&... args)
+{
+  assert(expected.size() < 4096 && "Update the size of the buffer.");
+  {
+    cuda::std::inplace_vector<CharT, 4096> out;
+    cuda::std::vformat_to(
+      cuda::std::__back_insert_iterator{out}, fmt, cuda::std::make_format_args<context_t<CharT>>(args...));
+    if (!cuda::std::equal(out.begin(), out.end(), expected.begin(), expected.end()))
+    {
+      return false;
+    }
+  }
+  {
+    CharT out[4096];
+    CharT* it = cuda::std::vformat_to(out, fmt, cuda::std::make_format_args<context_t<CharT>>(args...));
+    if (cuda::std::distance(out, it) != int(expected.size()))
+    {
+      return false;
+    }
+    if (cuda::std::basic_string_view<CharT>{out, it} != expected)
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <class CharT, class... Args>
+TEST_FUNC _CCCL_NOINLINE bool check_exception(
+  [[maybe_unused]] cuda::std::string_view what,
+  [[maybe_unused]] cuda::std::basic_string_view<CharT> fmt,
+  [[maybe_unused]] Args&&... args)
+{
+#if _CCCL_HAS_EXCEPTIONS()
+  NV_IF_TARGET(NV_IS_HOST, ({
+                 try
+                 {
+                   cuda::std::inplace_vector<char, 4096> out;
+                   cuda::std::vformat_to(cuda::std::__back_insert_iterator{out},
+                                         fmt,
+                                         cuda::std::make_format_args<context_t<CharT>>(args...));
+                   return false;
+                 }
+                 catch (const cuda::std::format_error& e)
+                 {
+                   if (e.what() != what)
+                   {
+                     return false;
+                   }
+                 }
+                 catch (...)
+                 {
+                   return false;
+                 }
+               }))
+#endif // _CCCL_HAS_EXCEPTIONS()
+  return true;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/bool.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/bool.h
@@ -1,0 +1,184 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/cassert>
+#include <cuda/std/string_view>
+
+#include "format_functions_common.h"
+#include "test_macros.h"
+
+// Provided by the selected checker.
+template <class CharT, class... Args>
+TEST_FUNC bool
+check(cuda::std::basic_string_view<CharT> expected, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+template <class CharT, class... Args>
+TEST_FUNC bool check_exception(cuda::std::string_view what, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+
+template <class CharT>
+TEST_FUNC void test_bool()
+{
+  // *** align-fill & width ***
+  assert(check(SV("answer is 'true   '"), SV("answer is '{:7}'"), true));
+  assert(check(SV("answer is '   true'"), SV("answer is '{:>7}'"), true));
+  assert(check(SV("answer is 'true   '"), SV("answer is '{:<7}'"), true));
+  assert(check(SV("answer is ' true  '"), SV("answer is '{:^7}'"), true));
+
+  assert(check(SV("answer is 'false   '"), SV("answer is '{:8s}'"), false));
+  assert(check(SV("answer is '   false'"), SV("answer is '{:>8s}'"), false));
+  assert(check(SV("answer is 'false   '"), SV("answer is '{:<8s}'"), false));
+  assert(check(SV("answer is ' false  '"), SV("answer is '{:^8s}'"), false));
+
+  // The fill character ':' is allowed here (P0645) but not in ranges (P2286).
+  assert(check(SV("answer is ':::true'"), SV("answer is '{::>7}'"), true));
+  assert(check(SV("answer is 'true:::'"), SV("answer is '{::<7}'"), true));
+  assert(check(SV("answer is ':true::'"), SV("answer is '{::^7}'"), true));
+
+  assert(check(SV("answer is '---false'"), SV("answer is '{:->8s}'"), false));
+  assert(check(SV("answer is 'false---'"), SV("answer is '{:-<8s}'"), false));
+  assert(check(SV("answer is '-false--'"), SV("answer is '{:-^8s}'"), false));
+
+  // *** Sign ***
+  assert(check_exception("The format specifier for a bool does not allow the sign option", SV("{:-}"), true));
+  assert(check_exception("The format specifier for a bool does not allow the sign option", SV("{:+}"), true));
+  assert(check_exception("The format specifier for a bool does not allow the sign option", SV("{: }"), true));
+
+  assert(check_exception("The format specifier for a bool does not allow the sign option", SV("{:-s}"), true));
+  assert(check_exception("The format specifier for a bool does not allow the sign option", SV("{:+s}"), true));
+  assert(check_exception("The format specifier for a bool does not allow the sign option", SV("{: s}"), true));
+
+  // *** alternate form ***
+  assert(check_exception("The format specifier for a bool does not allow the alternate form option", SV("{:#}"), true));
+  assert(
+    check_exception("The format specifier for a bool does not allow the alternate form option", SV("{:#s}"), true));
+
+  // *** zero-padding ***
+  assert(check_exception("The format specifier for a bool does not allow the zero-padding option", SV("{:0}"), true));
+  assert(check_exception("The format specifier for a bool does not allow the zero-padding option", SV("{:0s}"), true));
+
+  // *** precision ***
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.}"), true));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.0}"), true));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.42}"), true));
+
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.s}"), true));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.0s}"), true));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.42s}"), true));
+
+  // todo(dabayer): Test invalid types.
+  // *** type ***
+  // for (const auto& fmt : invalid_types<CharT>("bBdosxX"))
+  // {
+  //   assert(check_exception("The type option contains an invalid value for a bool formatting argument", fmt, true));
+  // }
+}
+
+template <class CharT>
+TEST_FUNC void test_bool_as_integer()
+{
+  // *** align-fill & width ***
+  assert(check(SV("answer is '1'"), SV("answer is '{:<1d}'"), true));
+  assert(check(SV("answer is '1 '"), SV("answer is '{:<2d}'"), true));
+  assert(check(SV("answer is '0 '"), SV("answer is '{:<2d}'"), false));
+
+  assert(check(SV("answer is '     1'"), SV("answer is '{:6d}'"), true));
+  assert(check(SV("answer is '     1'"), SV("answer is '{:>6d}'"), true));
+  assert(check(SV("answer is '1     '"), SV("answer is '{:<6d}'"), true));
+  assert(check(SV("answer is '  1   '"), SV("answer is '{:^6d}'"), true));
+
+  // The fill character ':' is allowed here (P0645) but not in ranges (P2286).
+  assert(check(SV("answer is ':::::0'"), SV("answer is '{::>6d}'"), false));
+  assert(check(SV("answer is '0:::::'"), SV("answer is '{::<6d}'"), false));
+  assert(check(SV("answer is '::0:::'"), SV("answer is '{::^6d}'"), false));
+
+  // Test whether zero padding is ignored
+  assert(check(SV("answer is '     1'"), SV("answer is '{:>06d}'"), true));
+  assert(check(SV("answer is '1     '"), SV("answer is '{:<06d}'"), true));
+  assert(check(SV("answer is '  1   '"), SV("answer is '{:^06d}'"), true));
+
+  // *** Sign ***
+  assert(check(SV("answer is 1"), SV("answer is {:d}"), true));
+  assert(check(SV("answer is 0"), SV("answer is {:-d}"), false));
+  assert(check(SV("answer is +1"), SV("answer is {:+d}"), true));
+  assert(check(SV("answer is  0"), SV("answer is {: d}"), false));
+
+  // *** alternate form ***
+  assert(check(SV("answer is +1"), SV("answer is {:+#d}"), true));
+  assert(check(SV("answer is +1"), SV("answer is {:+b}"), true));
+  assert(check(SV("answer is +0b1"), SV("answer is {:+#b}"), true));
+  assert(check(SV("answer is +0B1"), SV("answer is {:+#B}"), true));
+  assert(check(SV("answer is +1"), SV("answer is {:+o}"), true));
+  assert(check(SV("answer is +01"), SV("answer is {:+#o}"), true));
+  assert(check(SV("answer is +1"), SV("answer is {:+x}"), true));
+  assert(check(SV("answer is +0x1"), SV("answer is {:+#x}"), true));
+  assert(check(SV("answer is +1"), SV("answer is {:+X}"), true));
+  assert(check(SV("answer is +0X1"), SV("answer is {:+#X}"), true));
+
+  assert(check(SV("answer is 0"), SV("answer is {:#d}"), false));
+  assert(check(SV("answer is 0"), SV("answer is {:b}"), false));
+  assert(check(SV("answer is 0b0"), SV("answer is {:#b}"), false));
+  assert(check(SV("answer is 0B0"), SV("answer is {:#B}"), false));
+  assert(check(SV("answer is 0"), SV("answer is {:o}"), false));
+  assert(check(SV("answer is 0"), SV("answer is {:#o}"), false));
+  assert(check(SV("answer is 0"), SV("answer is {:x}"), false));
+  assert(check(SV("answer is 0x0"), SV("answer is {:#x}"), false));
+  assert(check(SV("answer is 0"), SV("answer is {:X}"), false));
+  assert(check(SV("answer is 0X0"), SV("answer is {:#X}"), false));
+
+  // todo(dabayer): Make tests that are commented out work.
+  // *** zero-padding & width ***
+  assert(check(SV("answer is +00000000001"), SV("answer is {:+#012d}"), true));
+  assert(check(SV("answer is +00000000001"), SV("answer is {:+012b}"), true));
+  assert(check(SV("answer is +0b000000001"), SV("answer is {:+#012b}"), true));
+  assert(check(SV("answer is +0B000000001"), SV("answer is {:+#012B}"), true));
+  assert(check(SV("answer is +00000000001"), SV("answer is {:+012o}"), true));
+  assert(check(SV("answer is +00000000001"), SV("answer is {:+#012o}"), true));
+  assert(check(SV("answer is +00000000001"), SV("answer is {:+012x}"), true));
+  assert(check(SV("answer is +0x000000001"), SV("answer is {:+#012x}"), true));
+  assert(check(SV("answer is +00000000001"), SV("answer is {:+012X}"), true));
+  assert(check(SV("answer is +0X000000001"), SV("answer is {:+#012X}"), true));
+
+  assert(check(SV("answer is 000000000000"), SV("answer is {:#012d}"), false));
+  assert(check(SV("answer is 000000000000"), SV("answer is {:012b}"), false));
+  assert(check(SV("answer is 0b0000000000"), SV("answer is {:#012b}"), false));
+  assert(check(SV("answer is 0B0000000000"), SV("answer is {:#012B}"), false));
+  assert(check(SV("answer is 000000000000"), SV("answer is {:012o}"), false));
+  assert(check(SV("answer is 000000000000"), SV("answer is {:#012o}"), false));
+  assert(check(SV("answer is 000000000000"), SV("answer is {:012x}"), false));
+  assert(check(SV("answer is 0x0000000000"), SV("answer is {:#012x}"), false));
+  assert(check(SV("answer is 000000000000"), SV("answer is {:012X}"), false));
+  assert(check(SV("answer is 0X0000000000"), SV("answer is {:#012X}"), false));
+
+  // *** precision ***
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.}"), true));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.0}"), true));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.42}"), true));
+
+  // todo(dabayer): Test invalid types.
+  // *** type ***
+  // for (const auto& fmt : invalid_types<CharT>("bBcdosxX"))
+  // {
+  //   assert(check_exception("The type option contains an invalid value for a bool formatting argument", fmt, true));
+  // }
+}
+
+TEST_FUNC void test()
+{
+  test_bool<char>();
+  test_bool_as_integer<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_bool<wchar_t>();
+  test_bool_as_integer<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/buffer.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/buffer.h
@@ -1,0 +1,507 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// todo(dabayer): Fix failing tests.
+
+#include <cuda/std/cassert>
+#include <cuda/std/string_view>
+
+#include "format_functions_common.h"
+#include "test_macros.h"
+
+// Provided by the selected checker.
+template <class CharT, class... Args>
+TEST_FUNC bool
+check(cuda::std::basic_string_view<CharT> expected, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+template <class CharT, class... Args>
+TEST_FUNC bool check_exception(cuda::std::string_view what, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+
+template <class CharT>
+TEST_FUNC void test_buffer_copy()
+{
+  // *** copy ***
+  assert(check(SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+               SV("{}"),
+               SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")));
+
+  assert(check(SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+               SV("{}"),
+               SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")));
+
+  assert(check(
+    SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+    SV("{}"),
+    SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")));
+
+  assert(check(
+    SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+    SV("{}"),
+    SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")));
+
+  assert(check(
+    SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+    SV("{}"),
+    SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")));
+
+  // *** copy + push_back ***
+
+  assert(check(SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                  "X"),
+               SV("{}X"),
+               SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")));
+
+  assert(check(SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                  "X"),
+               SV("{}X"),
+               SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")));
+
+  //   assert(check(
+  //     SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "X"),
+  //     SV("{}X"),
+  //     SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")));
+
+  //   assert(check(
+  //     SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "X"),
+  //     SV("{}X"),
+  //     SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")));
+
+  //   assert(check(
+  //     SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "X"),
+  //     SV("{}X"),
+  //     SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")));
+
+  // ***  push_back + copy ***
+
+  assert(check(SV("X"
+                  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+               SV("X{}"),
+               SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")));
+
+  assert(check(SV("X"
+                  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+               SV("X{}"),
+               SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")));
+
+  assert(check(
+    SV("X"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+    SV("X{}"),
+    SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")));
+
+  //   assert(check(
+  //     SV("X"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+  //     SV("X{}"),
+  //     SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")));
+
+  //   assert(check(
+  //     SV("X"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+  //     SV("X{}"),
+  //     SV("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  //        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")));
+}
+
+template <class CharT>
+TEST_FUNC void test_buffer_fill()
+{
+  // *** fill ***
+  assert(check(SV("||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"), SV("{:|<64}"), SV("")));
+
+  assert(check(SV("||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"),
+               SV("{:|<128}"),
+               SV("")));
+
+  assert(check(SV("||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"),
+               SV("{:|<256}"),
+               SV("")));
+
+  assert(check(
+    SV("||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"),
+    SV("{:|<512}"),
+    SV("")));
+
+  assert(check(
+    SV("||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"),
+    SV("{:|<1024}"),
+    SV("")));
+
+  // *** fill + push_back ***
+
+  assert(check(SV("||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+                  "X"),
+               SV("{:|<64}X"),
+               SV("")));
+
+  assert(check(SV("||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+                  "X"),
+               SV("{:|<128}X"),
+               SV("")));
+
+  //   assert(check(
+  //     SV("||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "X"),
+  //     SV("{:|<256}X"),
+  //     SV("")));
+
+  //   assert(check(
+  //     SV("||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "X"),
+  //     SV("{:|<512}X"),
+  //     SV("")));
+
+  //   assert(check(
+  //     SV("||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "X"),
+  //     SV("{:|<1024}X"),
+  //     SV("")));
+
+  // *** push_back + fill ***
+
+  assert(check(SV("X"
+                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"),
+               SV("X{:|<64}"),
+               SV("")));
+
+  assert(check(SV("X"
+                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"),
+               SV("X{:|<128}"),
+               SV("")));
+
+  //   assert(check(
+  //     SV("X"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"),
+  //     SV("X{:|<256}"),
+  //     SV("")));
+
+  //   assert(check(
+  //     SV("X"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"),
+  //     SV("X{:|<512}"),
+  //     SV("")));
+
+  //   assert(check(
+  //     SV("X"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+  //        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"),
+  //     SV("X{:|<1024}"),
+  //     SV("")));
+}
+
+/// Tests special buffer functions with a "large" input.
+///
+/// This is a test specific for libc++, however the code should behave the same
+/// on all implementations.
+/// In \c __fmt_output_buffer there are some special functions to optimize
+/// outputting multiple characters, \c __copy, \c __transform, \c __fill. This
+/// test validates whether the functions behave properly when the output size
+/// doesn't fit in its internal buffer.
+template <class CharT>
+TEST_FUNC void test_buffer_optimizations()
+{
+  // Used to validate our test sets are the proper size.
+  // To test the chunked operations it needs to be larger than the internal
+  // buffer. Picked a nice looking number.
+  constexpr int minimum = 3 * 256;
+
+  // Copy
+  const auto str = SV(
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog."
+    "The quick brown fox jumps over the lazy dog.");
+  assert(str.size() > minimum);
+  assert(check(cuda::std::basic_string_view<CharT>{str}, SV("{}"), str));
+
+  // todo(dabayer): Make this work.
+  // Fill
+  // cuda::std::inplace_vector<CharT, minimum> fill(minimum, CharT('*'));
+  // check(cuda::std::basic_string_view<CharT>{str + fill}, SV("{:*<{}}"), str, str.size() + minimum);
+  // check(cuda::std::basic_string_view<CharT>{fill + str + fill}, SV("{:*^{}}"), str, minimum + str.size() + minimum);
+  // check(cuda::std::basic_string_view<CharT>{fill + str}, SV("{:*>{}}"), str, minimum + str.size());
+}
+
+TEST_FUNC void test()
+{
+  test_buffer_copy<char>();
+  test_buffer_fill<char>();
+  test_buffer_optimizations<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_buffer_copy<wchar_t>();
+  test_buffer_fill<wchar_t>();
+  test_buffer_optimizations<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/char.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/char.h
@@ -1,0 +1,190 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/cassert>
+#include <cuda/std/string_view>
+
+#include "format_functions_common.h"
+#include "test_macros.h"
+
+// Provided by the selected checker.
+template <class CharT, class... Args>
+TEST_FUNC bool
+check(cuda::std::basic_string_view<CharT> expected, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+template <class CharT, class... Args>
+TEST_FUNC bool check_exception(cuda::std::string_view what, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+
+template <class CharT>
+TEST_FUNC void test_char()
+{
+  // ***** Char type *****
+  // *** align-fill & width ***
+  assert(check(SV("answer is '*     '"), SV("answer is '{:6}'"), CharT('*')));
+  assert(check(SV("answer is '     *'"), SV("answer is '{:>6}'"), CharT('*')));
+  assert(check(SV("answer is '*     '"), SV("answer is '{:<6}'"), CharT('*')));
+  assert(check(SV("answer is '  *   '"), SV("answer is '{:^6}'"), CharT('*')));
+
+  assert(check(SV("answer is '*     '"), SV("answer is '{:6c}'"), CharT('*')));
+  assert(check(SV("answer is '     *'"), SV("answer is '{:>6c}'"), CharT('*')));
+  assert(check(SV("answer is '*     '"), SV("answer is '{:<6c}'"), CharT('*')));
+  assert(check(SV("answer is '  *   '"), SV("answer is '{:^6c}'"), CharT('*')));
+
+  // The fill character ':' is allowed here (P0645) but not in ranges (P2286).
+  assert(check(SV("answer is ':::::*'"), SV("answer is '{::>6}'"), CharT('*')));
+  assert(check(SV("answer is '*:::::'"), SV("answer is '{::<6}'"), CharT('*')));
+  assert(check(SV("answer is '::*:::'"), SV("answer is '{::^6}'"), CharT('*')));
+
+  assert(check(SV("answer is '-----*'"), SV("answer is '{:->6c}'"), CharT('*')));
+  assert(check(SV("answer is '*-----'"), SV("answer is '{:-<6c}'"), CharT('*')));
+  assert(check(SV("answer is '--*---'"), SV("answer is '{:-^6c}'"), CharT('*')));
+
+  // *** Sign ***
+  assert(
+    check_exception("The format specifier for a character does not allow the sign option", SV("{:-}"), CharT('*')));
+  assert(
+    check_exception("The format specifier for a character does not allow the sign option", SV("{:+}"), CharT('*')));
+  assert(
+    check_exception("The format specifier for a character does not allow the sign option", SV("{: }"), CharT('*')));
+
+  assert(
+    check_exception("The format specifier for a character does not allow the sign option", SV("{:-c}"), CharT('*')));
+  assert(
+    check_exception("The format specifier for a character does not allow the sign option", SV("{:+c}"), CharT('*')));
+  assert(
+    check_exception("The format specifier for a character does not allow the sign option", SV("{: c}"), CharT('*')));
+
+  // *** alternate form ***
+  assert(check_exception(
+    "The format specifier for a character does not allow the alternate form option", SV("{:#}"), CharT('*')));
+  assert(check_exception(
+    "The format specifier for a character does not allow the alternate form option", SV("{:#c}"), CharT('*')));
+
+  // *** zero-padding ***
+  assert(check_exception(
+    "The format specifier for a character does not allow the zero-padding option", SV("{:0}"), CharT('*')));
+  assert(check_exception(
+    "The format specifier for a character does not allow the zero-padding option", SV("{:0c}"), CharT('*')));
+
+  // *** precision ***
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.}"), CharT('*')));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.0}"), CharT('*')));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.42}"), CharT('*')));
+
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.c}"), CharT('*')));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.0c}"), CharT('*')));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.42c}"), CharT('*')));
+
+  // todo(dabayer): Test invalid types.
+  // *** type ***
+  // #if TEST_STD_VER > 20
+  //   const char* valid_types = "bBcdoxX?";
+  // #else
+  //   const char* valid_types = "bBcdoxX";
+  // #endif
+  // for (const auto& fmt : invalid_types<CharT>(valid_types))
+  // {
+  //   check_exception("The type option contains an invalid value for a character formatting argument", fmt,
+  //   CharT('*'));
+  // }
+}
+
+template <class CharT>
+TEST_FUNC void test_char_as_int()
+{
+  // *** align-fill & width ***
+  assert(check(SV("answer is '42'"), SV("answer is '{:<1d}'"), CharT('*')));
+
+  assert(check(SV("answer is '42'"), SV("answer is '{:<2d}'"), CharT('*')));
+  assert(check(SV("answer is '42 '"), SV("answer is '{:<3d}'"), CharT('*')));
+
+  assert(check(SV("answer is '     42'"), SV("answer is '{:7d}'"), CharT('*')));
+  assert(check(SV("answer is '     42'"), SV("answer is '{:>7d}'"), CharT('*')));
+  assert(check(SV("answer is '42     '"), SV("answer is '{:<7d}'"), CharT('*')));
+  assert(check(SV("answer is '  42   '"), SV("answer is '{:^7d}'"), CharT('*')));
+
+  // The fill character ':' is allowed here (P0645) but not in ranges (P2286).
+  assert(check(SV("answer is ':::::42'"), SV("answer is '{::>7d}'"), CharT('*')));
+  assert(check(SV("answer is '42:::::'"), SV("answer is '{::<7d}'"), CharT('*')));
+  assert(check(SV("answer is '::42:::'"), SV("answer is '{::^7d}'"), CharT('*')));
+
+  // Test whether zero padding is ignored
+  assert(check(SV("answer is '     42'"), SV("answer is '{:>07d}'"), CharT('*')));
+  assert(check(SV("answer is '42     '"), SV("answer is '{:<07d}'"), CharT('*')));
+  assert(check(SV("answer is '  42   '"), SV("answer is '{:^07d}'"), CharT('*')));
+
+  // *** Sign ***
+  assert(check(SV("answer is 42"), SV("answer is {:d}"), CharT('*')));
+  assert(check(SV("answer is 42"), SV("answer is {:-d}"), CharT('*')));
+  assert(check(SV("answer is +42"), SV("answer is {:+d}"), CharT('*')));
+  assert(check(SV("answer is  42"), SV("answer is {: d}"), CharT('*')));
+
+  // *** alternate form ***
+  assert(check(SV("answer is +42"), SV("answer is {:+#d}"), CharT('*')));
+  assert(check(SV("answer is +101010"), SV("answer is {:+b}"), CharT('*')));
+  assert(check(SV("answer is +0b101010"), SV("answer is {:+#b}"), CharT('*')));
+  assert(check(SV("answer is +0B101010"), SV("answer is {:+#B}"), CharT('*')));
+  assert(check(SV("answer is +52"), SV("answer is {:+o}"), CharT('*')));
+  assert(check(SV("answer is +052"), SV("answer is {:+#o}"), CharT('*')));
+  assert(check(SV("answer is +2a"), SV("answer is {:+x}"), CharT('*')));
+  assert(check(SV("answer is +0x2a"), SV("answer is {:+#x}"), CharT('*')));
+  assert(check(SV("answer is +2A"), SV("answer is {:+X}"), CharT('*')));
+  assert(check(SV("answer is +0X2A"), SV("answer is {:+#X}"), CharT('*')));
+
+  // *** zero-padding & width ***
+  assert(check(SV("answer is +00000000042"), SV("answer is {:+#012d}"), CharT('*')));
+  assert(check(SV("answer is +00000101010"), SV("answer is {:+012b}"), CharT('*')));
+  assert(check(SV("answer is +0b000101010"), SV("answer is {:+#012b}"), CharT('*')));
+  assert(check(SV("answer is +0B000101010"), SV("answer is {:+#012B}"), CharT('*')));
+  assert(check(SV("answer is +00000000052"), SV("answer is {:+012o}"), CharT('*')));
+  assert(check(SV("answer is +00000000052"), SV("answer is {:+#012o}"), CharT('*')));
+  assert(check(SV("answer is +0000000002a"), SV("answer is {:+012x}"), CharT('*')));
+  assert(check(SV("answer is +0x00000002a"), SV("answer is {:+#012x}"), CharT('*')));
+  assert(check(SV("answer is +0000000002A"), SV("answer is {:+012X}"), CharT('*')));
+
+  assert(check(SV("answer is +0X00000002A"), SV("answer is {:+#012X}"), CharT('*')));
+
+  // *** precision ***
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.d}"), CharT('*')));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.0d}"), CharT('*')));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.42d}"), CharT('*')));
+
+  // todo(dabayer): Test invalid types.
+  // *** type ***
+  // #if TEST_STD_VER > 20
+  //   const char* valid_types = "bBcdoxX?";
+  // #else
+  //   const char* valid_types = "bBcdoxX";
+  // #endif
+  // for (const auto& fmt : invalid_types<CharT>(valid_types))
+  // {
+  //   check_exception("The type option contains an invalid value for a character formatting argument", fmt,
+  //   CharT('*'));
+  // }
+}
+
+TEST_FUNC void test()
+{
+  test_char<char>();
+  test_char_as_int<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_char<wchar_t>();
+  test_char_as_int<wchar_t>();
+
+  {
+    using CharT = wchar_t;
+    assert(check(SV("hello 09azA"), SV("hello {}{}{}{}{}"), '0', '9', 'a', 'z', 'A'));
+  }
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/handle.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/handle.h
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/cassert>
+#include <cuda/std/string_view>
+
+#include "format_functions_common.h"
+#include "test_macros.h"
+
+// Provided by the selected checker.
+template <class CharT, class... Args>
+TEST_FUNC bool
+check(cuda::std::basic_string_view<CharT> expected, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+template <class CharT, class... Args>
+TEST_FUNC bool check_exception(cuda::std::string_view what, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+
+template <class CharT>
+TEST_FUNC void test_handle()
+{
+  // *** Valid permutations ***
+  assert(check(SV("answer is '0xaaaa'"), SV("answer is '{}'"), status::foo));
+  assert(check(SV("answer is '0xaaaa'"), SV("answer is '{:x}'"), status::foo));
+  assert(check(SV("answer is '0XAAAA'"), SV("answer is '{:X}'"), status::foo));
+  assert(check(SV("answer is 'foo'"), SV("answer is '{:s}'"), status::foo));
+
+  assert(check(SV("answer is '0x5555'"), SV("answer is '{}'"), status::bar));
+  assert(check(SV("answer is '0x5555'"), SV("answer is '{:x}'"), status::bar));
+  assert(check(SV("answer is '0X5555'"), SV("answer is '{:X}'"), status::bar));
+  assert(check(SV("answer is 'bar'"), SV("answer is '{:s}'"), status::bar));
+
+  assert(check(SV("answer is '0xaa55'"), SV("answer is '{}'"), status::foobar));
+  assert(check(SV("answer is '0xaa55'"), SV("answer is '{:x}'"), status::foobar));
+  assert(check(SV("answer is '0XAA55'"), SV("answer is '{:X}'"), status::foobar));
+  assert(check(SV("answer is 'foobar'"), SV("answer is '{:s}'"), status::foobar));
+
+  // P2418 Changed the argument from a const reference to a forwarding reference.
+  // This mainly affects handle classes, however since we use an abstraction
+  // layer here it's "tricky" to verify whether this test would do the "right"
+  // thing. So these tests are done separately.
+
+  // todo(dabayer): Test invalid types.
+  // *** type ***
+  // for (const auto& fmt : invalid_types<CharT>("xXs"))
+  // {
+  //   check_exception("The type option contains an invalid value for a status formatting argument", fmt, status::foo);
+  // }
+}
+
+TEST_FUNC void test()
+{
+  test_handle<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_handle<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/pointer.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/pointer.h
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/cassert>
+#include <cuda/std/cstddef>
+#include <cuda/std/string_view>
+
+#include "format_functions_common.h"
+#include "test_macros.h"
+
+// Provided by the selected checker.
+template <class CharT, class... Args>
+TEST_FUNC bool
+check(cuda::std::basic_string_view<CharT> expected, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+template <class CharT, class... Args>
+TEST_FUNC bool check_exception(cuda::std::string_view what, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+
+template <class CharT, class T>
+TEST_FUNC void test_pointer()
+{
+  // *** align-fill & width ***
+  assert(check(SV("answer is '   0x0'"), SV("answer is '{:6}'"), T(nullptr)));
+  assert(check(SV("answer is '   0x0'"), SV("answer is '{:>6}'"), T(nullptr)));
+  assert(check(SV("answer is '0x0   '"), SV("answer is '{:<6}'"), T(nullptr)));
+  assert(check(SV("answer is ' 0x0  '"), SV("answer is '{:^6}'"), T(nullptr)));
+
+  // The fill character ':' is allowed here (P0645) but not in ranges (P2286).
+  assert(check(SV("answer is ':::0x0'"), SV("answer is '{::>6}'"), T(nullptr)));
+  assert(check(SV("answer is '0x0:::'"), SV("answer is '{::<6}'"), T(nullptr)));
+  assert(check(SV("answer is ':0x0::'"), SV("answer is '{::^6}'"), T(nullptr)));
+
+  // Test whether zero padding is ignored
+  assert(check(SV("answer is ':::0x0'"), SV("answer is '{::>06}'"), T(nullptr)));
+  assert(check(SV("answer is '0x0:::'"), SV("answer is '{::<06}'"), T(nullptr)));
+  assert(check(SV("answer is ':0x0::'"), SV("answer is '{::^06}'"), T(nullptr)));
+
+  // *** Sign ***
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:-}"), T(nullptr)));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:+}"), T(nullptr)));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{: }"), T(nullptr)));
+
+  // *** alternate form ***
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:#}"), T(nullptr)));
+
+  // *** zero-padding ***
+  assert(check(SV("answer is '0x0000'"), SV("answer is '{:06}'"), T(nullptr)));
+  assert(check(SV("answer is '0x0000'"), SV("answer is '{:06p}'"), T(nullptr)));
+  assert(check(SV("answer is '0X0000'"), SV("answer is '{:06P}'"), T(nullptr)));
+
+  // *** precision ***
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.}"), nullptr));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.0}"), nullptr));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.42}"), nullptr));
+
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.{}}"), nullptr));
+  assert(
+    check_exception("The format specifier should consume the input or end with a '}'", SV("{:.{}}"), nullptr, true));
+  assert(
+    check_exception("The format specifier should consume the input or end with a '}'", SV("{:.{}}"), nullptr, 1.0));
+
+  // todo(dabayer): Test invalid types.
+  // *** type ***
+  // for (const auto& fmt : invalid_types<CharT>("pP"))
+  // {
+  //   check_exception("The type option contains an invalid value for a pointer formatting argument", fmt, T(nullptr));
+  // }
+}
+
+template <class CharT>
+TEST_FUNC void test()
+{
+  test_pointer<CharT, cuda::std::nullptr_t>();
+  test_pointer<CharT, void*>();
+  test_pointer<CharT, const void*>();
+}
+
+TEST_FUNC void test()
+{
+  test<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/signed_integer.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/signed_integer.h
@@ -1,0 +1,331 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/cassert>
+#include <cuda/std/concepts>
+#include <cuda/std/limits>
+#include <cuda/std/string_view>
+
+#include "format_functions_common.h"
+#include "test_macros.h"
+
+// Provided by the selected checker.
+template <class CharT, class... Args>
+TEST_FUNC bool
+check(cuda::std::basic_string_view<CharT> expected, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+template <class CharT, class... Args>
+TEST_FUNC bool check_exception(cuda::std::string_view what, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+
+template <class CharT, class I>
+TEST_FUNC _CCCL_NOINLINE void test_integer_as_integer()
+{
+  // *** align-fill & width ***
+  assert(check(SV("answer is '42'"), SV("answer is '{:<1}'"), I(42)));
+  assert(check(SV("answer is '42'"), SV("answer is '{:<2}'"), I(42)));
+  assert(check(SV("answer is '42 '"), SV("answer is '{:<3}'"), I(42)));
+
+  assert(check(SV("answer is '     42'"), SV("answer is '{:7}'"), I(42)));
+  assert(check(SV("answer is '     42'"), SV("answer is '{:>7}'"), I(42)));
+  assert(check(SV("answer is '42     '"), SV("answer is '{:<7}'"), I(42)));
+  assert(check(SV("answer is '  42   '"), SV("answer is '{:^7}'"), I(42)));
+
+  // The fill character ':' is allowed here (P0645) but not in ranges (P2286).
+  assert(check(SV("answer is ':::::42'"), SV("answer is '{::>7}'"), I(42)));
+  assert(check(SV("answer is '42:::::'"), SV("answer is '{::<7}'"), I(42)));
+  assert(check(SV("answer is '::42:::'"), SV("answer is '{::^7}'"), I(42)));
+
+  // Test whether zero padding is ignored
+  assert(check(SV("answer is '     42'"), SV("answer is '{:>07}'"), I(42)));
+  assert(check(SV("answer is '42     '"), SV("answer is '{:<07}'"), I(42)));
+  assert(check(SV("answer is '  42   '"), SV("answer is '{:^07}'"), I(42)));
+
+  // *** Sign ***
+  assert(check(SV("answer is -42"), SV("answer is {}"), I(-42)));
+  assert(check(SV("answer is 0"), SV("answer is {}"), I(0)));
+  assert(check(SV("answer is 42"), SV("answer is {}"), I(42)));
+
+  assert(check(SV("answer is -42"), SV("answer is {:-}"), I(-42)));
+  assert(check(SV("answer is 0"), SV("answer is {:-}"), I(0)));
+  assert(check(SV("answer is 42"), SV("answer is {:-}"), I(42)));
+
+  assert(check(SV("answer is -42"), SV("answer is {:+}"), I(-42)));
+  assert(check(SV("answer is +0"), SV("answer is {:+}"), I(0)));
+  assert(check(SV("answer is +42"), SV("answer is {:+}"), I(42)));
+
+  assert(check(SV("answer is -42"), SV("answer is {: }"), I(-42)));
+  assert(check(SV("answer is  0"), SV("answer is {: }"), I(0)));
+  assert(check(SV("answer is  42"), SV("answer is {: }"), I(42)));
+
+  // *** alternate form ***
+  assert(check(SV("answer is -42"), SV("answer is {:#}"), I(-42)));
+  assert(check(SV("answer is -42"), SV("answer is {:#d}"), I(-42)));
+  assert(check(SV("answer is -101010"), SV("answer is {:b}"), I(-42)));
+  assert(check(SV("answer is -0b101010"), SV("answer is {:#b}"), I(-42)));
+  assert(check(SV("answer is -0B101010"), SV("answer is {:#B}"), I(-42)));
+  assert(check(SV("answer is -52"), SV("answer is {:o}"), I(-42)));
+  assert(check(SV("answer is -052"), SV("answer is {:#o}"), I(-42)));
+  assert(check(SV("answer is -2a"), SV("answer is {:x}"), I(-42)));
+  assert(check(SV("answer is -0x2a"), SV("answer is {:#x}"), I(-42)));
+  assert(check(SV("answer is -2A"), SV("answer is {:X}"), I(-42)));
+  assert(check(SV("answer is -0X2A"), SV("answer is {:#X}"), I(-42)));
+
+  assert(check(SV("answer is 0"), SV("answer is {:#}"), I(0)));
+  assert(check(SV("answer is 0"), SV("answer is {:#d}"), I(0)));
+  assert(check(SV("answer is 0"), SV("answer is {:b}"), I(0)));
+  assert(check(SV("answer is 0b0"), SV("answer is {:#b}"), I(0)));
+  assert(check(SV("answer is 0B0"), SV("answer is {:#B}"), I(0)));
+  assert(check(SV("answer is 0"), SV("answer is {:o}"), I(0)));
+  assert(check(SV("answer is 0"), SV("answer is {:#o}"), I(0)));
+  assert(check(SV("answer is 0"), SV("answer is {:x}"), I(0)));
+  assert(check(SV("answer is 0x0"), SV("answer is {:#x}"), I(0)));
+  assert(check(SV("answer is 0"), SV("answer is {:X}"), I(0)));
+  assert(check(SV("answer is 0X0"), SV("answer is {:#X}"), I(0)));
+
+  assert(check(SV("answer is +42"), SV("answer is {:+#}"), I(42)));
+  assert(check(SV("answer is +42"), SV("answer is {:+#d}"), I(42)));
+  assert(check(SV("answer is +101010"), SV("answer is {:+b}"), I(42)));
+  assert(check(SV("answer is +0b101010"), SV("answer is {:+#b}"), I(42)));
+  assert(check(SV("answer is +0B101010"), SV("answer is {:+#B}"), I(42)));
+  assert(check(SV("answer is +52"), SV("answer is {:+o}"), I(42)));
+  assert(check(SV("answer is +052"), SV("answer is {:+#o}"), I(42)));
+  assert(check(SV("answer is +2a"), SV("answer is {:+x}"), I(42)));
+  assert(check(SV("answer is +0x2a"), SV("answer is {:+#x}"), I(42)));
+  assert(check(SV("answer is +2A"), SV("answer is {:+X}"), I(42)));
+  assert(check(SV("answer is +0X2A"), SV("answer is {:+#X}"), I(42)));
+
+  // *** zero-padding & width ***
+  assert(check(SV("answer is -00000000042"), SV("answer is {:#012}"), I(-42)));
+  assert(check(SV("answer is -00000000042"), SV("answer is {:#012d}"), I(-42)));
+  assert(check(SV("answer is -00000101010"), SV("answer is {:012b}"), I(-42)));
+  assert(check(SV("answer is -0b000101010"), SV("answer is {:#012b}"), I(-42)));
+  assert(check(SV("answer is -0B000101010"), SV("answer is {:#012B}"), I(-42)));
+  assert(check(SV("answer is -00000000052"), SV("answer is {:012o}"), I(-42)));
+  assert(check(SV("answer is -00000000052"), SV("answer is {:#012o}"), I(-42)));
+  assert(check(SV("answer is -0000000002a"), SV("answer is {:012x}"), I(-42)));
+  assert(check(SV("answer is -0x00000002a"), SV("answer is {:#012x}"), I(-42)));
+  assert(check(SV("answer is -0000000002A"), SV("answer is {:012X}"), I(-42)));
+  assert(check(SV("answer is -0X00000002A"), SV("answer is {:#012X}"), I(-42)));
+
+  assert(check(SV("answer is 000000000000"), SV("answer is {:#012}"), I(0)));
+  assert(check(SV("answer is 000000000000"), SV("answer is {:#012d}"), I(0)));
+  assert(check(SV("answer is 000000000000"), SV("answer is {:012b}"), I(0)));
+  assert(check(SV("answer is 0b0000000000"), SV("answer is {:#012b}"), I(0)));
+  assert(check(SV("answer is 0B0000000000"), SV("answer is {:#012B}"), I(0)));
+  assert(check(SV("answer is 000000000000"), SV("answer is {:012o}"), I(0)));
+  assert(check(SV("answer is 000000000000"), SV("answer is {:#012o}"), I(0)));
+  assert(check(SV("answer is 000000000000"), SV("answer is {:012x}"), I(0)));
+  assert(check(SV("answer is 0x0000000000"), SV("answer is {:#012x}"), I(0)));
+  assert(check(SV("answer is 000000000000"), SV("answer is {:012X}"), I(0)));
+  assert(check(SV("answer is 0X0000000000"), SV("answer is {:#012X}"), I(0)));
+
+  assert(check(SV("answer is +00000000042"), SV("answer is {:+#012}"), I(42)));
+  assert(check(SV("answer is +00000000042"), SV("answer is {:+#012d}"), I(42)));
+  assert(check(SV("answer is +00000101010"), SV("answer is {:+012b}"), I(42)));
+  assert(check(SV("answer is +0b000101010"), SV("answer is {:+#012b}"), I(42)));
+  assert(check(SV("answer is +0B000101010"), SV("answer is {:+#012B}"), I(42)));
+  assert(check(SV("answer is +00000000052"), SV("answer is {:+012o}"), I(42)));
+  assert(check(SV("answer is +00000000052"), SV("answer is {:+#012o}"), I(42)));
+  assert(check(SV("answer is +0000000002a"), SV("answer is {:+012x}"), I(42)));
+  assert(check(SV("answer is +0x00000002a"), SV("answer is {:+#012x}"), I(42)));
+  assert(check(SV("answer is +0000000002A"), SV("answer is {:+012X}"), I(42)));
+  assert(check(SV("answer is +0X00000002A"), SV("answer is {:+#012X}"), I(42)));
+
+  // *** precision ***
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.}"), I(0)));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.0}"), I(0)));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.42}"), I(0)));
+
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.{}}"), I(0)));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.{}}"), I(0), true));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.{}}"), I(0), 1.0));
+
+  // todo(dabayer): Test invalid types.
+  // *** type ***
+  // for (const auto& fmt : invalid_types<CharT>("bBcdoxX"))
+  // {
+  //   check_exception("The type option contains an invalid value for an integer formatting argument", fmt, I(0));
+  // }
+}
+
+template <class CharT, class I>
+TEST_FUNC _CCCL_NOINLINE void test_integer_as_char()
+{
+  // *** align-fill & width ***
+  assert(check(SV("answer is '*     '"), SV("answer is '{:6c}'"), I(42)));
+  assert(check(SV("answer is '     *'"), SV("answer is '{:>6c}'"), I(42)));
+  assert(check(SV("answer is '*     '"), SV("answer is '{:<6c}'"), I(42)));
+  assert(check(SV("answer is '  *   '"), SV("answer is '{:^6c}'"), I(42)));
+
+  // The fill character ':' is allowed here (P0645) but not in ranges (P2286).
+  assert(check(SV("answer is ':::::*'"), SV("answer is '{::>6c}'"), I(42)));
+  assert(check(SV("answer is '*:::::'"), SV("answer is '{::<6c}'"), I(42)));
+  assert(check(SV("answer is '::*:::'"), SV("answer is '{::^6c}'"), I(42)));
+
+  // *** Sign ***
+  assert(check(SV("answer is *"), SV("answer is {:c}"), I(42)));
+  assert(check_exception(
+    "The format specifier for an integer does not allow the sign option", SV("answer is {:-c}"), I(42)));
+  assert(check_exception(
+    "The format specifier for an integer does not allow the sign option", SV("answer is {:+c}"), I(42)));
+  assert(check_exception(
+    "The format specifier for an integer does not allow the sign option", SV("answer is {: c}"), I(42)));
+
+  // *** alternate form ***
+  assert(check_exception(
+    "The format specifier for an integer does not allow the alternate form option", SV("answer is {:#c}"), I(42)));
+
+  // *** zero-padding & width ***
+  assert(check_exception(
+    "The format specifier for an integer does not allow the zero-padding option", SV("answer is {:01c}"), I(42)));
+
+  // *** precision ***
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.c}"), I(0)));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.0c}"), I(0)));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.42c}"), I(0)));
+
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.{}c}"), I(0)));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.{}c}"), I(0), true));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.{}c}"), I(0), 1.0));
+
+  // todo(dabayer): Test invalid types.
+  // *** type ***
+  // for (const auto& fmt : invalid_types<CharT>("bBcdoxX"))
+  // {
+  //   check_exception("The type option contains an invalid value for an integer formatting argument", fmt, I(42));
+  // }
+
+  // *** Validate range ***
+  // The code has some duplications to keep the if statement readable.
+  if constexpr (cuda::std::signed_integral<CharT>)
+  {
+    if constexpr (sizeof(I) > sizeof(CharT))
+    {
+      assert(check_exception(
+        "Integral value outside the range of the char type", SV("{:c}"), cuda::std::numeric_limits<I>::min()));
+      assert(check_exception(
+        "Integral value outside the range of the char type", SV("{:c}"), cuda::std::numeric_limits<I>::max()));
+    }
+  }
+  else if constexpr (sizeof(I) > sizeof(CharT))
+  {
+    assert(check_exception(
+      "Integral value outside the range of the char type", SV("{:c}"), cuda::std::numeric_limits<I>::max()));
+  }
+}
+
+template <class CharT, class T>
+TEST_FUNC void test_integer()
+{
+  test_integer_as_integer<CharT, T>();
+  test_integer_as_char<CharT, T>();
+}
+
+template <class CharT>
+TEST_FUNC _CCCL_NOINLINE void test_min_max()
+{
+  // *** check the minima and maxima ***
+  assert(check(SV("-0b10000000"), SV("{:#b}"), cuda::std::numeric_limits<cuda::std::int8_t>::min()));
+  assert(check(SV("-0200"), SV("{:#o}"), cuda::std::numeric_limits<cuda::std::int8_t>::min()));
+  assert(check(SV("-128"), SV("{:#}"), cuda::std::numeric_limits<cuda::std::int8_t>::min()));
+  assert(check(SV("-0x80"), SV("{:#x}"), cuda::std::numeric_limits<cuda::std::int8_t>::min()));
+
+  assert(check(SV("-0b1000000000000000"), SV("{:#b}"), cuda::std::numeric_limits<cuda::std::int16_t>::min()));
+  assert(check(SV("-0100000"), SV("{:#o}"), cuda::std::numeric_limits<cuda::std::int16_t>::min()));
+  assert(check(SV("-32768"), SV("{:#}"), cuda::std::numeric_limits<cuda::std::int16_t>::min()));
+  assert(check(SV("-0x8000"), SV("{:#x}"), cuda::std::numeric_limits<cuda::std::int16_t>::min()));
+
+  assert(check(
+    SV("-0b10000000000000000000000000000000"), SV("{:#b}"), cuda::std::numeric_limits<cuda::std::int32_t>::min()));
+  assert(check(SV("-020000000000"), SV("{:#o}"), cuda::std::numeric_limits<cuda::std::int32_t>::min()));
+  assert(check(SV("-2147483648"), SV("{:#}"), cuda::std::numeric_limits<cuda::std::int32_t>::min()));
+  assert(check(SV("-0x80000000"), SV("{:#x}"), cuda::std::numeric_limits<cuda::std::int32_t>::min()));
+
+  assert(check(SV("-0b1000000000000000000000000000000000000000000000000000000000000000"),
+               SV("{:#b}"),
+               cuda::std::numeric_limits<cuda::std::int64_t>::min()));
+  assert(check(SV("-01000000000000000000000"), SV("{:#o}"), cuda::std::numeric_limits<cuda::std::int64_t>::min()));
+  assert(check(SV("-9223372036854775808"), SV("{:#}"), cuda::std::numeric_limits<cuda::std::int64_t>::min()));
+  assert(check(SV("-0x8000000000000000"), SV("{:#x}"), cuda::std::numeric_limits<cuda::std::int64_t>::min()));
+
+#if _CCCL_HAS_INT128()
+  assert(check(SV("-0b1000000000000000000000000000000000000000000000000000000000000000"
+                  "0000000000000000000000000000000000000000000000000000000000000000"),
+               SV("{:#b}"),
+               cuda::std::numeric_limits<__int128_t>::min()));
+  assert(check(
+    SV("-02000000000000000000000000000000000000000000"), SV("{:#o}"), cuda::std::numeric_limits<__int128_t>::min()));
+  assert(
+    check(SV("-170141183460469231731687303715884105728"), SV("{:#}"), cuda::std::numeric_limits<__int128_t>::min()));
+  assert(check(SV("-0x80000000000000000000000000000000"), SV("{:#x}"), cuda::std::numeric_limits<__int128_t>::min()));
+#endif // _CCCL_HAS_INT128()
+
+  assert(check(SV("0b1111111"), SV("{:#b}"), cuda::std::numeric_limits<cuda::std::int8_t>::max()));
+  assert(check(SV("0177"), SV("{:#o}"), cuda::std::numeric_limits<cuda::std::int8_t>::max()));
+  assert(check(SV("127"), SV("{:#}"), cuda::std::numeric_limits<cuda::std::int8_t>::max()));
+  assert(check(SV("0x7f"), SV("{:#x}"), cuda::std::numeric_limits<cuda::std::int8_t>::max()));
+
+  assert(check(SV("0b111111111111111"), SV("{:#b}"), cuda::std::numeric_limits<cuda::std::int16_t>::max()));
+  assert(check(SV("077777"), SV("{:#o}"), cuda::std::numeric_limits<cuda::std::int16_t>::max()));
+  assert(check(SV("32767"), SV("{:#}"), cuda::std::numeric_limits<cuda::std::int16_t>::max()));
+  assert(check(SV("0x7fff"), SV("{:#x}"), cuda::std::numeric_limits<cuda::std::int16_t>::max()));
+
+  assert(
+    check(SV("0b1111111111111111111111111111111"), SV("{:#b}"), cuda::std::numeric_limits<cuda::std::int32_t>::max()));
+  assert(check(SV("017777777777"), SV("{:#o}"), cuda::std::numeric_limits<cuda::std::int32_t>::max()));
+  assert(check(SV("2147483647"), SV("{:#}"), cuda::std::numeric_limits<cuda::std::int32_t>::max()));
+  assert(check(SV("0x7fffffff"), SV("{:#x}"), cuda::std::numeric_limits<cuda::std::int32_t>::max()));
+
+  assert(check(SV("0b111111111111111111111111111111111111111111111111111111111111111"),
+               SV("{:#b}"),
+               cuda::std::numeric_limits<cuda::std::int64_t>::max()));
+  assert(check(SV("0777777777777777777777"), SV("{:#o}"), cuda::std::numeric_limits<cuda::std::int64_t>::max()));
+  assert(check(SV("9223372036854775807"), SV("{:#}"), cuda::std::numeric_limits<cuda::std::int64_t>::max()));
+  assert(check(SV("0x7fffffffffffffff"), SV("{:#x}"), cuda::std::numeric_limits<cuda::std::int64_t>::max()));
+
+#if _CCCL_HAS_INT128()
+  assert(check(SV("0b111111111111111111111111111111111111111111111111111111111111111"
+                  "1111111111111111111111111111111111111111111111111111111111111111"),
+               SV("{:#b}"),
+               cuda::std::numeric_limits<__int128_t>::max()));
+  assert(check(
+    SV("01777777777777777777777777777777777777777777"), SV("{:#o}"), cuda::std::numeric_limits<__int128_t>::max()));
+  assert(
+    check(SV("170141183460469231731687303715884105727"), SV("{:#}"), cuda::std::numeric_limits<__int128_t>::max()));
+  assert(check(SV("0x7fffffffffffffffffffffffffffffff"), SV("{:#x}"), cuda::std::numeric_limits<__int128_t>::max()));
+#endif // _CCCL_HAS_INT128()
+}
+
+template <class CharT>
+TEST_FUNC _CCCL_NOINLINE void test()
+{
+  test_integer<CharT, signed char>();
+  test_integer<CharT, signed short>();
+  test_integer<CharT, signed int>();
+  test_integer<CharT, signed long>();
+  test_integer<CharT, signed long long>();
+#if _CCCL_HAS_INT128()
+  test_integer<CharT, __int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  test_min_max<CharT>();
+}
+
+TEST_FUNC void test()
+{
+  test<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/smoke.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/smoke.h
@@ -1,0 +1,199 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/cassert>
+#include <cuda/std/string_view>
+
+#include "format_functions_common.h"
+#include "test_macros.h"
+
+// Provided by the selected checker.
+template <class CharT, class... Args>
+TEST_FUNC bool
+check(cuda::std::basic_string_view<CharT> expected, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+template <class CharT, class... Args>
+TEST_FUNC bool check_exception(cuda::std::string_view what, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+
+template <class CharT>
+TEST_FUNC void smoke_test()
+{
+  // *** Test escaping  ***
+  assert(check(SV("{"), SV("{{")));
+  assert(check(SV("}"), SV("}}")));
+  assert(check(SV("{:^}"), SV("{{:^}}")));
+  assert(check(SV("{: ^}"), SV("{{:{}^}}"), CharT(' ')));
+  assert(check(SV("{:{}^}"), SV("{{:{{}}^}}")));
+  assert(check(SV("{:{ }^}"), SV("{{:{{{}}}^}}"), CharT(' ')));
+
+  // *** Test argument ID ***
+  assert(check(SV("hello false true"), SV("hello {0:} {1:}"), false, true));
+  assert(check(SV("hello true false"), SV("hello {1:} {0:}"), false, true));
+
+  // *** Test many arguments ***
+
+  // [format.args]/1
+  // An instance of basic_format_args provides access to formatting arguments.
+  // Implementations should optimize the representation of basic_format_args
+  // for a small number of formatting arguments.
+  //
+  // These's no guidances what "a small number of formatting arguments" is.
+  // - fmtlib uses a 15 elements
+  // - libc++ uses 12 elements
+  // - MSVC STL uses a different approach regardless of the number of arguments
+  // - libstdc++ has no implementation yet
+  // fmtlib and libc++ use a similar approach, this approach can support 16
+  // elements (based on design choices both support less elements). This test
+  // makes sure "the large number of formatting arguments" code path is tested.
+  assert(check(
+    SV("1234567890\t1234567890"),
+    SV("{}{}{}{}{}{}{}{}{}{}\t{}{}{}{}{}{}{}{}{}{}"),
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    0));
+
+  // *** Test invalid format strings ***
+  assert(check_exception("The format string terminates at a '{'", SV("{")));
+  assert(check_exception("The argument index value is too large for the number of arguments supplied", SV("{:")));
+  assert(check_exception("The replacement field misses a terminating '}'", SV("{:"), 42));
+
+  assert(check_exception("The argument index should end with a ':' or a '}'", SV("{0")));
+  assert(check_exception("The argument index value is too large for the number of arguments supplied", SV("{0:")));
+  assert(check_exception("The replacement field misses a terminating '}'", SV("{0:"), 42));
+
+  assert(check_exception("The format string contains an invalid escape sequence", SV("}")));
+  assert(check_exception("The format string contains an invalid escape sequence", SV("{:}-}"), 42));
+
+  assert(check_exception("The format string contains an invalid escape sequence", SV("} ")));
+  assert(check_exception("The argument index starts with an invalid character", SV("{-"), 42));
+  assert(check_exception("The argument index value is too large for the number of arguments supplied", SV("hello {}")));
+  assert(
+    check_exception("The argument index value is too large for the number of arguments supplied", SV("hello {0}")));
+  assert(
+    check_exception("The argument index value is too large for the number of arguments supplied", SV("hello {1}"), 42));
+
+  // *** Test char format argument ***
+  // The `char` to `wchar_t` formatting is tested separately.
+  assert(check(
+    SV("hello 09azAZ!"),
+    SV("hello {}{}{}{}{}{}{}"),
+    CharT('0'),
+    CharT('9'),
+    CharT('a'),
+    CharT('z'),
+    CharT('A'),
+    CharT('Z'),
+    CharT('!')));
+
+  // *** Test string format argument ***
+  {
+    CharT buffer[] = {CharT('0'), CharT('9'), CharT('a'), CharT('z'), CharT('A'), CharT('Z'), CharT('!'), 0};
+    CharT* data    = buffer;
+    assert(check(SV("hello 09azAZ!"), SV("hello {}"), data));
+  }
+  {
+    CharT buffer[]    = {CharT('0'), CharT('9'), CharT('a'), CharT('z'), CharT('A'), CharT('Z'), CharT('!'), 0};
+    const CharT* data = buffer;
+    assert(check(SV("hello 09azAZ!"), SV("hello {}"), data));
+  }
+  {
+    // https://llvm.org/PR115935
+    // Contents after the embedded null character are discarded.
+    CharT buffer[] = {CharT('a'), CharT('b'), CharT('c'), 0, CharT('d'), CharT('e'), CharT('f'), 0};
+    assert(check(SV("hello abc"), SV("hello {}"), buffer));
+    // Even when the last element of the array is not null character.
+    CharT buffer2[] = {CharT('a'), CharT('b'), CharT('c'), 0, CharT('d'), CharT('e'), CharT('f')};
+    assert(check(SV("hello abc"), SV("hello {}"), buffer2));
+  }
+  {
+    // todo(dabayer): Host stdlib interop.
+    // std::basic_string<CharT> data = TEST_STRLIT(CharT, "world");
+    // assert(check(SV("hello world"), SV("hello {}"), data));
+  }
+  {
+    // todo(dabayer): Host stdlib interop.
+    // std::basic_string_view<CharT> data = TEST_STRLIT(CharT, "world");
+    // assert(check(SV("hello world"), SV("hello {}"), data));
+  }
+  {
+    cuda::std::basic_string_view<CharT> data = TEST_STRLIT(CharT, "world");
+    assert(check(SV("hello world"), SV("hello {}"), data));
+  }
+
+  // *** Test Boolean format argument ***
+  assert(check(SV("hello false true"), SV("hello {} {}"), false, true));
+
+  // *** Test signed integral format argument ***
+  assert(check(SV("hello 42"), SV("hello {}"), static_cast<signed char>(42)));
+  assert(check(SV("hello 42"), SV("hello {}"), static_cast<short>(42)));
+  assert(check(SV("hello 42"), SV("hello {}"), static_cast<int>(42)));
+  assert(check(SV("hello 42"), SV("hello {}"), static_cast<long>(42)));
+  assert(check(SV("hello 42"), SV("hello {}"), static_cast<long long>(42)));
+#if _CCCL_HAS_INT128()
+  assert(check(SV("hello 42"), SV("hello {}"), static_cast<__int128_t>(42)));
+#endif // _CCCL_HAS_INT128()
+
+  // ** Test unsigned integral format argument ***
+  assert(check(SV("hello 42"), SV("hello {}"), static_cast<unsigned char>(42)));
+  assert(check(SV("hello 42"), SV("hello {}"), static_cast<unsigned short>(42)));
+  assert(check(SV("hello 42"), SV("hello {}"), static_cast<unsigned>(42)));
+  assert(check(SV("hello 42"), SV("hello {}"), static_cast<unsigned long>(42)));
+  assert(check(SV("hello 42"), SV("hello {}"), static_cast<unsigned long long>(42)));
+#if _CCCL_HAS_INT128()
+  assert(check(SV("hello 42"), SV("hello {}"), static_cast<__uint128_t>(42)));
+#endif // _CCCL_HAS_INT128()
+
+  // todo(dabayer): Make formatters for fp types work.
+  // *** Test floating point format argument ***
+  //   assert(check(SV("hello 42"), SV("hello {}"), static_cast<float>(42)));
+  //   assert(check(SV("hello 42"), SV("hello {}"), static_cast<double>(42)));
+  // #if _CCCL_HAS_LONG_DOUBLE()
+  //   assert(check(SV("hello 42"), SV("hello {}"), static_cast<long double>(42)));
+  // #endif // _CCCL_HAS_LONG_DOUBLE()
+
+  // *** Test pointer formatter argument ***
+  assert(check(SV("hello 0x0"), SV("hello {}"), nullptr));
+  assert(check(SV("hello 0x42"), SV("hello {}"), reinterpret_cast<void*>(0x42)));
+  assert(check(SV("hello 0x42"), SV("hello {}"), reinterpret_cast<const void*>(0x42)));
+
+  // *** Test handle formatter argument ***
+  assert(check(SV("answer is '0xaaaa'"), SV("answer is '{}'"), status::foo));
+  assert(check(SV("answer is '0x5555'"), SV("answer is '{:x}'"), status::bar));
+  assert(check(SV("answer is 'foobar'"), SV("answer is '{:s}'"), status::foobar));
+}
+
+TEST_FUNC void test()
+{
+  smoke_test<char>();
+#if _CCCL_HAS_WCHAR_T()
+  smoke_test<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/string.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/string.h
@@ -1,0 +1,187 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/concepts>
+#include <cuda/std/string_view>
+
+#include "format_functions_common.h"
+#include "test_macros.h"
+
+// Provided by the selected checker.
+template <class CharT, class... Args>
+TEST_FUNC bool
+check(cuda::std::basic_string_view<CharT> expected, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+template <class CharT, class... Args>
+TEST_FUNC bool check_exception(cuda::std::string_view what, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+
+// Using a const ref for world and universe so a string literal will be a character array.
+// When passed as character array W and U have different types.
+template <class CharT, class W, class U>
+TEST_FUNC void test_string(const W& world, const U& universe)
+{
+  // *** Valid input tests ***
+  // Unused argument is ignored. TODO FMT what does the Standard mandate?
+  assert(check(SV("hello world"), SV("hello {}"), world, universe));
+  assert(check(SV("hello world and universe"), SV("hello {} and {}"), world, universe));
+  assert(check(SV("hello world"), SV("hello {0}"), world, universe));
+  assert(check(SV("hello universe"), SV("hello {1}"), world, universe));
+  assert(check(SV("hello universe and world"), SV("hello {1} and {0}"), world, universe));
+
+  assert(check(SV("hello world"), SV("hello {:_>}"), world));
+  assert(check(SV("hello world   "), SV("hello {:8}"), world));
+  assert(check(SV("hello    world"), SV("hello {:>8}"), world));
+  assert(check(SV("hello ___world"), SV("hello {:_>8}"), world));
+  assert(check(SV("hello _world__"), SV("hello {:_^8}"), world));
+  assert(check(SV("hello world___"), SV("hello {:_<8}"), world));
+
+  // The fill character ':' is allowed here (P0645) but not in ranges (P2286).
+  assert(check(SV("hello :::world"), SV("hello {::>8}"), world));
+  assert(check(SV("hello <<<world"), SV("hello {:<>8}"), world));
+  assert(check(SV("hello ^^^world"), SV("hello {:^>8}"), world));
+
+  assert(check(SV("hello $world"), SV("hello {:$>{}}"), world, 6));
+  assert(check(SV("hello $world"), SV("hello {0:$>{1}}"), world, 6));
+  assert(check(SV("hello $world"), SV("hello {1:$>{0}}"), 6, world));
+
+  assert(check(SV("hello world"), SV("hello {:.5}"), world));
+  assert(check(SV("hello unive"), SV("hello {:.5}"), universe));
+
+  assert(check(SV("hello univer"), SV("hello {:.{}}"), universe, 6));
+  assert(check(SV("hello univer"), SV("hello {0:.{1}}"), universe, 6));
+  assert(check(SV("hello univer"), SV("hello {1:.{0}}"), 6, universe));
+
+  assert(check(SV("hello %world%"), SV("hello {:%^7.7}"), world));
+  assert(check(SV("hello univers"), SV("hello {:%^7.7}"), universe));
+  assert(check(SV("hello %world%"), SV("hello {:%^{}.{}}"), world, 7, 7));
+  assert(check(SV("hello %world%"), SV("hello {0:%^{1}.{2}}"), world, 7, 7));
+  assert(check(SV("hello %world%"), SV("hello {0:%^{2}.{1}}"), world, 7, 7));
+  assert(check(SV("hello %world%"), SV("hello {1:%^{0}.{2}}"), 7, world, 7));
+
+  assert(check(SV("hello world"), SV("hello {:_>s}"), world));
+  assert(check(SV("hello $world"), SV("hello {:$>{}s}"), world, 6));
+  assert(check(SV("hello world"), SV("hello {:.5s}"), world));
+  assert(check(SV("hello univer"), SV("hello {:.{}s}"), universe, 6));
+  assert(check(SV("hello %world%"), SV("hello {:%^7.7s}"), world));
+
+  assert(check(SV("hello #####uni"), SV("hello {:#>8.3s}"), universe));
+  assert(check(SV("hello ##uni###"), SV("hello {:#^8.3s}"), universe));
+  assert(check(SV("hello uni#####"), SV("hello {:#<8.3s}"), universe));
+
+  // *** sign ***
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("hello {:-}"), world));
+
+  // *** alternate form ***
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("hello {:#}"), world));
+
+  // *** zero-padding ***
+  assert(check_exception("The width option should not have a leading zero", SV("hello {:0}"), world));
+
+  // *** width ***
+  // Width 0 allowed, but not useful for string arguments.
+  assert(check(SV("hello world"), SV("hello {:{}}"), world, 0));
+
+  // This limit isn't specified in the Standard.
+  static_assert(cuda::std::__fmt_number_max == 2'147'483'647, "Update the assert and the test.");
+  assert(check_exception("The numeric value of the format specifier is too large", SV("{:2147483648}"), world));
+  assert(check_exception("The numeric value of the format specifier is too large", SV("{:5000000000}"), world));
+  assert(check_exception("The numeric value of the format specifier is too large", SV("{:10000000000}"), world));
+
+  assert(check_exception("An argument index may not have a negative value", SV("hello {:{}}"), world, -1));
+  assert(check_exception(
+    "The value of the argument index exceeds its maximum value", SV("hello {:{}}"), world, unsigned(-1)));
+  assert(check_exception(
+    "The argument index value is too large for the number of arguments supplied", SV("hello {:{}}"), world));
+  assert(check_exception(
+    "Replacement argument isn't a standard signed or unsigned integer type", SV("hello {:{}}"), world, universe));
+  assert(check_exception(
+    "Using manual argument numbering in automatic argument numbering mode", SV("hello {:{0}}"), world, 1));
+  assert(check_exception(
+    "Using automatic argument numbering in manual argument numbering mode", SV("hello {0:{}}"), world, 1));
+  assert(check_exception("The argument index is invalid", SV("hello {0:{01}}"), world, 1));
+
+  // This limit isn't specified in the Standard.
+  static_assert(cuda::std::__fmt_number_max == 2'147'483'647, "Update the assert and the test.");
+  assert(check_exception("The numeric value of the format specifier is too large", SV("{:.2147483648}"), world));
+  assert(check_exception("The numeric value of the format specifier is too large", SV("{:.5000000000}"), world));
+  assert(check_exception("The numeric value of the format specifier is too large", SV("{:.10000000000}"), world));
+
+  // Precision 0 allowed, but not useful for string arguments.
+  assert(check(SV("hello "), SV("hello {:.{}}"), world, 0));
+  // Precision may have leading zeros. Secondly tests the value is still base 10.
+  assert(check(SV("hello 0123456789"), SV("hello {:.000010}"), SV("0123456789abcdef")));
+  assert(check_exception("An argument index may not have a negative value", SV("hello {:.{}}"), world, -1));
+  assert(check_exception("The value of the argument index exceeds its maximum value", SV("hello {:.{}}"), world, ~0u));
+  assert(check_exception(
+    "The argument index value is too large for the number of arguments supplied", SV("hello {:.{}}"), world));
+  assert(check_exception(
+    "Replacement argument isn't a standard signed or unsigned integer type", SV("hello {:.{}}"), world, universe));
+  assert(check_exception(
+    "Using manual argument numbering in automatic argument numbering mode", SV("hello {:.{0}}"), world, 1));
+  assert(check_exception(
+    "Using automatic argument numbering in manual argument numbering mode", SV("hello {0:.{}}"), world, 1));
+  assert(check_exception("The argument index is invalid", SV("hello {0:.{01}}"), world, 1));
+
+  // todo(dabayer): Test invalid types.
+  // *** type ***
+  // #if TEST_STD_VER > 20
+  //   const char* valid_types = "s?";
+  // #else
+  //   const char* valid_types = "s";
+  // #endif
+  // for (const auto& fmt : invalid_types<CharT>(valid_types))
+  // {
+  //   assert(check_exception("The type option contains an invalid value for a string formatting argument", fmt,
+  //   world));
+  // }
+}
+
+template <class CharT>
+TEST_FUNC void test_string()
+{
+  const auto& world    = TEST_STRLIT(CharT, "world");
+  const auto& universe = TEST_STRLIT(CharT, "universe");
+
+  // Test a string literal in a way it won't decay to a pointer.
+  if constexpr (cuda::std::same_as<CharT, char>)
+  {
+    test_string<CharT>("world", "universe");
+  }
+#if _CCCL_HAS_WCHAR_T()
+  else
+  {
+    test_string<CharT>(L"world", L"universe");
+  }
+#endif // _CCCL_HAS_WCHAR_T()
+
+  test_string<CharT>(world, universe);
+  test_string<CharT>(const_cast<CharT*>(world), const_cast<CharT*>(universe));
+  test_string<CharT>(cuda::std::basic_string_view<CharT>{world}, cuda::std::basic_string_view<CharT>{universe});
+
+  // todo(dabayer): Host stdlib interop.
+  // test_string<CharT>(std::basic_string<CharT>{world}, std::basic_string<CharT>{universe});
+  // test_string<CharT>(
+  //   std::basic_string_view<CharT>{world}, std::basic_string_view<CharT>{universe});
+}
+
+TEST_FUNC void test()
+{
+  test_string<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_string<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  NV_IF_TARGET(NV_IS_HOST, test();)
+  // test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/unsigned_integer.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/unsigned_integer.h
@@ -1,0 +1,266 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/cassert>
+#include <cuda/std/concepts>
+#include <cuda/std/limits>
+#include <cuda/std/string_view>
+
+#include "format_functions_common.h"
+#include "test_macros.h"
+
+// Provided by the selected checker.
+template <class CharT, class... Args>
+TEST_FUNC bool
+check(cuda::std::basic_string_view<CharT> expected, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+template <class CharT, class... Args>
+TEST_FUNC bool check_exception(cuda::std::string_view what, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+
+template <class CharT, class I>
+TEST_FUNC _CCCL_NOINLINE void test_integer_as_integer()
+{
+  // *** align-fill & width ***
+  assert(check(SV("answer is '42'"), SV("answer is '{:<1}'"), I(42)));
+  assert(check(SV("answer is '42'"), SV("answer is '{:<2}'"), I(42)));
+  assert(check(SV("answer is '42 '"), SV("answer is '{:<3}'"), I(42)));
+
+  assert(check(SV("answer is '     42'"), SV("answer is '{:7}'"), I(42)));
+  assert(check(SV("answer is '     42'"), SV("answer is '{:>7}'"), I(42)));
+  assert(check(SV("answer is '42     '"), SV("answer is '{:<7}'"), I(42)));
+  assert(check(SV("answer is '  42   '"), SV("answer is '{:^7}'"), I(42)));
+
+  // The fill character ':' is allowed here (P0645) but not in ranges (P2286).
+  assert(check(SV("answer is ':::::42'"), SV("answer is '{::>7}'"), I(42)));
+  assert(check(SV("answer is '42:::::'"), SV("answer is '{::<7}'"), I(42)));
+  assert(check(SV("answer is '::42:::'"), SV("answer is '{::^7}'"), I(42)));
+
+  // Test whether zero padding is ignored
+  assert(check(SV("answer is '     42'"), SV("answer is '{:>07}'"), I(42)));
+  assert(check(SV("answer is '42     '"), SV("answer is '{:<07}'"), I(42)));
+  assert(check(SV("answer is '  42   '"), SV("answer is '{:^07}'"), I(42)));
+
+  // *** Sign ***
+  assert(check(SV("answer is 0"), SV("answer is {}"), I(0)));
+  assert(check(SV("answer is 42"), SV("answer is {}"), I(42)));
+
+  assert(check(SV("answer is 0"), SV("answer is {:-}"), I(0)));
+  assert(check(SV("answer is 42"), SV("answer is {:-}"), I(42)));
+
+  assert(check(SV("answer is +0"), SV("answer is {:+}"), I(0)));
+  assert(check(SV("answer is +42"), SV("answer is {:+}"), I(42)));
+
+  assert(check(SV("answer is  0"), SV("answer is {: }"), I(0)));
+  assert(check(SV("answer is  42"), SV("answer is {: }"), I(42)));
+
+  // *** alternate form ***
+  assert(check(SV("answer is 0"), SV("answer is {:#}"), I(0)));
+  assert(check(SV("answer is 0"), SV("answer is {:#d}"), I(0)));
+  assert(check(SV("answer is 0"), SV("answer is {:b}"), I(0)));
+  assert(check(SV("answer is 0b0"), SV("answer is {:#b}"), I(0)));
+  assert(check(SV("answer is 0B0"), SV("answer is {:#B}"), I(0)));
+  assert(check(SV("answer is 0"), SV("answer is {:o}"), I(0)));
+  assert(check(SV("answer is 0"), SV("answer is {:#o}"), I(0)));
+  assert(check(SV("answer is 0"), SV("answer is {:x}"), I(0)));
+  assert(check(SV("answer is 0x0"), SV("answer is {:#x}"), I(0)));
+  assert(check(SV("answer is 0"), SV("answer is {:X}"), I(0)));
+  assert(check(SV("answer is 0X0"), SV("answer is {:#X}"), I(0)));
+
+  assert(check(SV("answer is +42"), SV("answer is {:+#}"), I(42)));
+  assert(check(SV("answer is +42"), SV("answer is {:+#d}"), I(42)));
+  assert(check(SV("answer is +101010"), SV("answer is {:+b}"), I(42)));
+  assert(check(SV("answer is +0b101010"), SV("answer is {:+#b}"), I(42)));
+  assert(check(SV("answer is +0B101010"), SV("answer is {:+#B}"), I(42)));
+  assert(check(SV("answer is +52"), SV("answer is {:+o}"), I(42)));
+  assert(check(SV("answer is +052"), SV("answer is {:+#o}"), I(42)));
+  assert(check(SV("answer is +2a"), SV("answer is {:+x}"), I(42)));
+  assert(check(SV("answer is +0x2a"), SV("answer is {:+#x}"), I(42)));
+  assert(check(SV("answer is +2A"), SV("answer is {:+X}"), I(42)));
+  assert(check(SV("answer is +0X2A"), SV("answer is {:+#X}"), I(42)));
+
+  // *** zero-padding & width ***
+  assert(check(SV("answer is 000000000000"), SV("answer is {:#012}"), I(0)));
+  assert(check(SV("answer is 000000000000"), SV("answer is {:#012d}"), I(0)));
+  assert(check(SV("answer is 000000000000"), SV("answer is {:012b}"), I(0)));
+  assert(check(SV("answer is 0b0000000000"), SV("answer is {:#012b}"), I(0)));
+  assert(check(SV("answer is 0B0000000000"), SV("answer is {:#012B}"), I(0)));
+  assert(check(SV("answer is 000000000000"), SV("answer is {:012o}"), I(0)));
+  assert(check(SV("answer is 000000000000"), SV("answer is {:#012o}"), I(0)));
+  assert(check(SV("answer is 000000000000"), SV("answer is {:012x}"), I(0)));
+  assert(check(SV("answer is 0x0000000000"), SV("answer is {:#012x}"), I(0)));
+  assert(check(SV("answer is 000000000000"), SV("answer is {:012X}"), I(0)));
+  assert(check(SV("answer is 0X0000000000"), SV("answer is {:#012X}"), I(0)));
+
+  assert(check(SV("answer is +00000000042"), SV("answer is {:+#012}"), I(42)));
+  assert(check(SV("answer is +00000000042"), SV("answer is {:+#012d}"), I(42)));
+  assert(check(SV("answer is +00000101010"), SV("answer is {:+012b}"), I(42)));
+  assert(check(SV("answer is +0b000101010"), SV("answer is {:+#012b}"), I(42)));
+  assert(check(SV("answer is +0B000101010"), SV("answer is {:+#012B}"), I(42)));
+  assert(check(SV("answer is +00000000052"), SV("answer is {:+012o}"), I(42)));
+  assert(check(SV("answer is +00000000052"), SV("answer is {:+#012o}"), I(42)));
+  assert(check(SV("answer is +0000000002a"), SV("answer is {:+012x}"), I(42)));
+  assert(check(SV("answer is +0x00000002a"), SV("answer is {:+#012x}"), I(42)));
+  assert(check(SV("answer is +0000000002A"), SV("answer is {:+012X}"), I(42)));
+  assert(check(SV("answer is +0X00000002A"), SV("answer is {:+#012X}"), I(42)));
+
+  // *** precision ***
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.}"), I(0)));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.0}"), I(0)));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.42}"), I(0)));
+
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.{}}"), I(0)));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.{}}"), I(0), true));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.{}}"), I(0), 1.0));
+
+  // todo(dabayer): Test invalid types.
+  // *** type ***
+  // for (const auto& fmt : invalid_types<CharT>("bBcdoxX"))
+  // {
+  //   check_exception("The type option contains an invalid value for an integer formatting argument", fmt, I(0));
+  // }
+}
+
+template <class CharT, class I>
+TEST_FUNC _CCCL_NOINLINE void test_integer_as_char()
+{
+  // *** align-fill & width ***
+  assert(check(SV("answer is '*     '"), SV("answer is '{:6c}'"), I(42)));
+  assert(check(SV("answer is '     *'"), SV("answer is '{:>6c}'"), I(42)));
+  assert(check(SV("answer is '*     '"), SV("answer is '{:<6c}'"), I(42)));
+  assert(check(SV("answer is '  *   '"), SV("answer is '{:^6c}'"), I(42)));
+
+  // The fill character ':' is allowed here (P0645) but not in ranges (P2286).
+  assert(check(SV("answer is ':::::*'"), SV("answer is '{::>6c}'"), I(42)));
+  assert(check(SV("answer is '*:::::'"), SV("answer is '{::<6c}'"), I(42)));
+  assert(check(SV("answer is '::*:::'"), SV("answer is '{::^6c}'"), I(42)));
+
+  // *** Sign ***
+  assert(check(SV("answer is *"), SV("answer is {:c}"), I(42)));
+  assert(check_exception(
+    "The format specifier for an integer does not allow the sign option", SV("answer is {:-c}"), I(42)));
+  assert(check_exception(
+    "The format specifier for an integer does not allow the sign option", SV("answer is {:+c}"), I(42)));
+  assert(check_exception(
+    "The format specifier for an integer does not allow the sign option", SV("answer is {: c}"), I(42)));
+
+  // *** alternate form ***
+  assert(check_exception(
+    "The format specifier for an integer does not allow the alternate form option", SV("answer is {:#c}"), I(42)));
+
+  // *** zero-padding & width ***
+  assert(check_exception(
+    "The format specifier for an integer does not allow the zero-padding option", SV("answer is {:01c}"), I(42)));
+
+  // *** precision ***
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.c}"), I(0)));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.0c}"), I(0)));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.42c}"), I(0)));
+
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.{}c}"), I(0)));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.{}c}"), I(0), true));
+  assert(check_exception("The format specifier should consume the input or end with a '}'", SV("{:.{}c}"), I(0), 1.0));
+
+  // todo(dabayer): Test invalid types.
+  // *** type ***
+  // for (const auto& fmt : invalid_types<CharT>("bBcdoxX"))
+  // {
+  //   check_exception("The type option contains an invalid value for an integer formatting argument", fmt, I(42));
+  // }
+
+  // *** Validate range ***
+  // The code has some duplications to keep the if statement readable.
+  if constexpr (cuda::std::signed_integral<CharT>)
+  {
+    if constexpr (sizeof(I) >= sizeof(CharT))
+    {
+      assert(check_exception(
+        "Integral value outside the range of the char type", SV("{:c}"), cuda::std::numeric_limits<I>::max()));
+    }
+  }
+  else if constexpr (sizeof(I) > sizeof(CharT))
+  {
+    assert(check_exception(
+      "Integral value outside the range of the char type", SV("{:c}"), cuda::std::numeric_limits<I>::max()));
+  }
+}
+
+template <class CharT, class T>
+TEST_FUNC void test_integer()
+{
+  test_integer_as_integer<CharT, T>();
+  test_integer_as_char<CharT, T>();
+}
+
+template <class CharT>
+TEST_FUNC _CCCL_NOINLINE void test_max()
+{
+  // *** test the maxima ***
+  assert(check(SV("0b11111111"), SV("{:#b}"), cuda::std::numeric_limits<cuda::std::uint8_t>::max()));
+  assert(check(SV("0377"), SV("{:#o}"), cuda::std::numeric_limits<cuda::std::uint8_t>::max()));
+  assert(check(SV("255"), SV("{:#}"), cuda::std::numeric_limits<cuda::std::uint8_t>::max()));
+  assert(check(SV("0xff"), SV("{:#x}"), cuda::std::numeric_limits<cuda::std::uint8_t>::max()));
+
+  assert(check(SV("0b1111111111111111"), SV("{:#b}"), cuda::std::numeric_limits<cuda::std::uint16_t>::max()));
+  assert(check(SV("0177777"), SV("{:#o}"), cuda::std::numeric_limits<cuda::std::uint16_t>::max()));
+  assert(check(SV("65535"), SV("{:#}"), cuda::std::numeric_limits<cuda::std::uint16_t>::max()));
+  assert(check(SV("0xffff"), SV("{:#x}"), cuda::std::numeric_limits<cuda::std::uint16_t>::max()));
+
+  assert(check(
+    SV("0b11111111111111111111111111111111"), SV("{:#b}"), cuda::std::numeric_limits<cuda::std::uint32_t>::max()));
+  assert(check(SV("037777777777"), SV("{:#o}"), cuda::std::numeric_limits<cuda::std::uint32_t>::max()));
+  assert(check(SV("4294967295"), SV("{:#}"), cuda::std::numeric_limits<cuda::std::uint32_t>::max()));
+  assert(check(SV("0xffffffff"), SV("{:#x}"), cuda::std::numeric_limits<cuda::std::uint32_t>::max()));
+
+  assert(check(SV("0b1111111111111111111111111111111111111111111111111111111111111111"),
+               SV("{:#b}"),
+               cuda::std::numeric_limits<cuda::std::uint64_t>::max()));
+  assert(check(SV("01777777777777777777777"), SV("{:#o}"), cuda::std::numeric_limits<cuda::std::uint64_t>::max()));
+  assert(check(SV("18446744073709551615"), SV("{:#}"), cuda::std::numeric_limits<cuda::std::uint64_t>::max()));
+  assert(check(SV("0xffffffffffffffff"), SV("{:#x}"), cuda::std::numeric_limits<cuda::std::uint64_t>::max()));
+
+#if _CCCL_HAS_INT128()
+  assert(check(SV("0b1111111111111111111111111111111111111111111111111111111111111111"
+                  "1111111111111111111111111111111111111111111111111111111111111111"),
+               SV("{:#b}"),
+               cuda::std::numeric_limits<__uint128_t>::max()));
+  assert(check(
+    SV("03777777777777777777777777777777777777777777"), SV("{:#o}"), cuda::std::numeric_limits<__uint128_t>::max()));
+  assert(
+    check(SV("340282366920938463463374607431768211455"), SV("{:#}"), cuda::std::numeric_limits<__uint128_t>::max()));
+  assert(check(SV("0xffffffffffffffffffffffffffffffff"), SV("{:#x}"), cuda::std::numeric_limits<__uint128_t>::max()));
+#endif // _CCCL_HAS_INT128()
+}
+
+template <class CharT>
+TEST_FUNC _CCCL_NOINLINE void test()
+{
+  test_integer<CharT, unsigned char>();
+  test_integer<CharT, unsigned short>();
+  test_integer<CharT, unsigned int>();
+  test_integer<CharT, unsigned long>();
+  test_integer<CharT, unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test_integer<CharT, __uint128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  test_max<CharT>();
+}
+
+TEST_FUNC void test()
+{
+  test<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/vformat_to.bool.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/vformat_to.bool.pass.cpp
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
+// <cuda/std/format>
+
+// template<class Out>
+//   Out vformat_to(Out out, string_view fmt, format_args args);
+// template<class Out>
+//    Out vformat_to(Out out, wstring_view fmt, wformat_args_t args);
+
+#include "checkers/vformat_to.h"
+
+#include "tests/bool.h"

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/vformat_to.buffer.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/vformat_to.buffer.pass.cpp
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
+// <cuda/std/format>
+
+// template<class Out>
+//   Out vformat_to(Out out, string_view fmt, format_args args);
+// template<class Out>
+//    Out vformat_to(Out out, wstring_view fmt, wformat_args_t args);
+
+#include "checkers/vformat_to.h"
+
+#include "tests/buffer.h"

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/vformat_to.char.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/vformat_to.char.pass.cpp
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
+// <cuda/std/format>
+
+// template<class Out>
+//   Out vformat_to(Out out, string_view fmt, format_args args);
+// template<class Out>
+//    Out vformat_to(Out out, wstring_view fmt, wformat_args_t args);
+
+#include "checkers/vformat_to.h"
+
+#include "tests/char.h"

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/vformat_to.handle.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/vformat_to.handle.pass.cpp
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
+// <cuda/std/format>
+
+// template<class Out>
+//   Out vformat_to(Out out, string_view fmt, format_args args);
+// template<class Out>
+//    Out vformat_to(Out out, wstring_view fmt, wformat_args_t args);
+
+#include "checkers/vformat_to.h"
+
+#include "tests/handle.h"

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/vformat_to.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/vformat_to.pass.cpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
+// <cuda/std/format>
+
+// template<class Out>
+//   Out vformat_to(Out out, string_view fmt, format_args args);
+// template<class Out>
+//    Out vformat_to(Out out, wstring_view fmt, wformat_args_t args);
+
+#include <cuda/std/__format_>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+static_assert(cuda::std::is_same_v<char*,
+                                   decltype(cuda::std::vformat_to(cuda::std::declval<char*>(),
+                                                                  cuda::std::declval<cuda::std::string_view>(),
+                                                                  cuda::std::declval<cuda::std::format_args>()))>);
+static_assert(!noexcept(cuda::std::vformat_to(cuda::std::declval<char*>(),
+                                              cuda::std::declval<cuda::std::string_view>(),
+                                              cuda::std::declval<cuda::std::format_args>())));
+#if _CCCL_HAS_WCHAR_T()
+static_assert(cuda::std::is_same_v<wchar_t*,
+                                   decltype(cuda::std::vformat_to(cuda::std::declval<wchar_t*>(),
+                                                                  cuda::std::declval<cuda::std::wstring_view>(),
+                                                                  cuda::std::declval<cuda::std::wformat_args>()))>);
+static_assert(!noexcept(cuda::std::vformat_to(cuda::std::declval<wchar_t*>(),
+                                              cuda::std::declval<cuda::std::wstring_view>(),
+                                              cuda::std::declval<cuda::std::wformat_args>())));
+#endif // _CCCL_HAS_WCHAR_T()
+
+#include "checkers/vformat_to.h"
+#include "tests/smoke.h"

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/vformat_to.pointer.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/vformat_to.pointer.pass.cpp
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
+// <cuda/std/format>
+
+// template<class Out>
+//   Out vformat_to(Out out, string_view fmt, format_args args);
+// template<class Out>
+//    Out vformat_to(Out out, wstring_view fmt, wformat_args_t args);
+
+#include "checkers/vformat_to.h"
+
+#include "tests/pointer.h"

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/vformat_to.signed_integer.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/vformat_to.signed_integer.pass.cpp
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
+// <cuda/std/format>
+
+// template<class Out>
+//   Out vformat_to(Out out, string_view fmt, format_args args);
+// template<class Out>
+//    Out vformat_to(Out out, wstring_view fmt, wformat_args_t args);
+
+#include "checkers/vformat_to.h"
+
+#include "tests/signed_integer.h"

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/vformat_to.string.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/vformat_to.string.pass.cpp
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
+// <cuda/std/format>
+
+// template<class Out>
+//   Out vformat_to(Out out, string_view fmt, format_args args);
+// template<class Out>
+//    Out vformat_to(Out out, wstring_view fmt, wformat_args_t args);
+
+#include "checkers/vformat_to.h"
+
+#include "tests/string.h"

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/vformat_to.unsigned_integer.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/vformat_to.unsigned_integer.pass.cpp
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
+// <cuda/std/format>
+
+// template<class Out>
+//   Out vformat_to(Out out, string_view fmt, format_args args);
+// template<class Out>
+//    Out vformat_to(Out out, wstring_view fmt, wformat_args_t args);
+
+#include "checkers/vformat_to.h"
+
+#include "tests/unsigned_integer.h"

--- a/libcudacxx/test/support/format_functions_common.h
+++ b/libcudacxx/test/support/format_functions_common.h
@@ -1,0 +1,266 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TEST_SUPPORT_FORMAT_FUNCTIONS_COMMON_H
+#define TEST_SUPPORT_FORMAT_FUNCTIONS_COMMON_H
+
+// Contains the common part of the formatter tests for different papers.
+
+#include <cuda/std/__format_>
+#include <cuda/std/algorithm>
+#include <cuda/std/cassert>
+#include <cuda/std/charconv>
+#include <cuda/std/cstddef>
+#include <cuda/std/cstdint>
+#include <cuda/std/cstdlib>
+#include <cuda/std/cstring>
+#include <cuda/std/ranges>
+#include <cuda/std/string_view>
+
+#include "literal.h"
+
+#define SV(S)                         \
+  cuda::std::basic_string_view<CharT> \
+  {                                   \
+    TEST_STRLIT(CharT, S)             \
+  }
+#define CSTR(S) TEST_STRLIT(CharT, S)
+
+template <class T>
+struct context
+{};
+
+template <>
+struct context<char>
+{
+  using type = cuda::std::format_context;
+};
+
+#if _CCCL_HAS_WCHAR_T()
+template <>
+struct context<wchar_t>
+{
+  using type = cuda::std::wformat_context;
+};
+#endif // _CCCL_HAS_WCHAR_T()
+
+template <class T>
+using context_t = typename context<T>::type;
+
+// A user-defined type used to test the handle formatter.
+enum class status : cuda::std::uint16_t
+{
+  foo    = 0xAAAA,
+  bar    = 0x5555,
+  foobar = 0xAA55
+};
+
+// The formatter for a user-defined type used to test the handle formatter.
+template <class CharT>
+struct cuda::std::formatter<status, CharT>
+{
+  // During the 2023 Issaquah meeting LEWG made it clear a formatter is
+  // required to call its parse function. LWG3892 Adds the wording for that
+  // requirement. Therefore this formatter is initialized in an invalid state.
+  // A call to parse sets it in a valid state and a call to format validates
+  // the state.
+  int type = -1;
+
+  TEST_FUNC constexpr auto parse(basic_format_parse_context<CharT>& parse_ctx) -> decltype(parse_ctx.begin())
+  {
+    auto it = parse_ctx.begin();
+    type    = 0;
+    if (it == parse_ctx.end())
+    {
+      return it;
+    }
+
+    switch (*it)
+    {
+      case CharT('x'):
+        break;
+      case CharT('X'):
+        type = 1;
+        break;
+      case CharT('s'):
+        type = 2;
+        break;
+      case CharT('}'):
+        return it;
+      default:
+        assert(false);
+    }
+
+    ++it;
+    if (it != parse_ctx.end() && *it != CharT('}'))
+    {
+      assert(false);
+    }
+
+    return it;
+  }
+
+  template <class Out>
+  TEST_FUNC auto format(status s, basic_format_context<Out, CharT>& ctx) const -> decltype(ctx.out())
+  {
+    const char* names[] = {"foo", "bar", "foobar"};
+    char buffer[7];
+    const char* result_begin = names[0];
+    const char* result_end   = names[0];
+    switch (type)
+    {
+      case -1:
+        assert(false);
+
+      case 0:
+        result_begin = buffer;
+        buffer[0]    = '0';
+        buffer[1]    = 'x';
+        result_end =
+          cuda::std::to_chars(&buffer[2], cuda::std::end(buffer), static_cast<cuda::std::uint16_t>(s), 16).ptr;
+        buffer[6] = '\0';
+        break;
+
+      case 1:
+        result_begin = buffer;
+        buffer[0]    = '0';
+        buffer[1]    = 'X';
+        result_end =
+          cuda::std::to_chars(&buffer[2], cuda::std::end(buffer), static_cast<cuda::std::uint16_t>(s), 16).ptr;
+        cuda::std::transform(static_cast<const char*>(&buffer[2]), result_end, &buffer[2], [](char c) {
+          if (c >= 'a' && c <= 'z')
+          {
+            return static_cast<char>(c - ('a' - 'A'));
+          }
+          return c;
+        });
+        buffer[6] = '\0';
+        break;
+
+      case 2:
+        switch (s)
+        {
+          case status::foo:
+            result_begin = names[0];
+            break;
+          case status::bar:
+            result_begin = names[1];
+            break;
+          case status::foobar:
+            result_begin = names[2];
+            break;
+        }
+        result_end = result_begin + cuda::std::strlen(result_begin);
+        break;
+    }
+
+    return cuda::std::copy(result_begin, result_end, ctx.out());
+  }
+};
+
+struct parse_call_validator
+{
+  struct parse_function_not_called
+  {};
+
+  TEST_FUNC friend constexpr auto operator==(const parse_call_validator& lhs, const parse_call_validator& rhs)
+  {
+    return &lhs == &rhs;
+  }
+};
+
+// The formatter for a user-defined type used to test the handle formatter.
+//
+// Like cuda::std::formatter<status, CharT> this formatter validates that parse is
+// called. This formatter is intended to be used when the formatter's parse is
+// called directly and not with format. In that case the format-spec does not
+// require a terminating }. The tests must be written in a fashion where this
+// formatter is always called with an empty format-spec. This requirement
+// allows testing of certain code paths that are never reached by using a
+// well-formed format-string in the format functions.
+template <class CharT>
+struct cuda::std::formatter<parse_call_validator, CharT>
+{
+  bool parse_called{false};
+
+  TEST_FUNC constexpr auto parse(basic_format_parse_context<CharT>& parse_ctx) -> decltype(parse_ctx.begin())
+  {
+    assert(parse_ctx.begin() == parse_ctx.end());
+    parse_called = true;
+    return parse_ctx.begin();
+  }
+
+  template <class Ctx>
+  TEST_FUNC auto format(parse_call_validator, Ctx& ctx) const -> decltype(ctx.out())
+  {
+    if (!parse_called)
+    {
+      assert(false);
+    }
+    return ctx.out();
+  }
+};
+
+// Creates format string for the invalid types.
+//
+// valid contains a list of types that are valid.
+// - The type ?s is the only type requiring 2 characters, use S for that type.
+// - Whether n is a type or not depends on the context, is is always used.
+//
+// The return value is a collection of basic_strings, instead of
+// basic_string_views since the values are temporaries.
+namespace detail
+{
+template <class CharT, cuda::std::size_t N>
+TEST_FUNC auto get_colons()
+{
+  return cuda::std::inplace_vector<CharT, N>(N, CharT(':'));
+}
+
+TEST_FUNC constexpr cuda::std::string_view get_format_types()
+{
+  return "aAbBcdeEfFgGopPsxX"
+#if TEST_STD_VER > 20
+         "?"
+#endif
+    ;
+}
+
+// template <class CharT, /*format_types types,*/ size_t N>
+// cuda::std::vector<cuda::std::basic_string<CharT>> fmt_invalid_types(cuda::std::string_view valid) {
+//   // cuda::std::ranges::to is not available in C++20.
+//   cuda::std::vector<cuda::std::basic_string<CharT>> result;
+//   cuda::std::ranges::copy(
+//       get_format_types() | cuda::std::views::filter([&](char type) { return valid.find(type) ==
+//       cuda::std::string_view::npos; }) |
+//           cuda::std::views::transform([&](char type) { return cuda::std::format(SV("{{{}{}}}"), get_colons<CharT,
+//           N>(), type); }),
+//       cuda::std::back_inserter(result));
+//   return result;
+// }
+} // namespace detail
+
+// Creates format string for the invalid types.
+//
+// valid contains a list of types that are valid.
+//
+// The return value is a collection of basic_strings, instead of
+// basic_string_views since the values are temporaries.
+// template <class CharT>
+// cuda::std::vector<cuda::std::basic_string<CharT>> fmt_invalid_types(cuda::std::string_view valid) {
+//   return detail::fmt_invalid_types<CharT, 1>(valid);
+// }
+
+// Like fmt_invalid_types but when the format spec is for an underlying formatter.
+// template <class CharT>
+// cuda::std::vector<cuda::std::basic_string<CharT>> fmt_invalid_nested_types(cuda::std::string_view valid) {
+//   return detail::fmt_invalid_types<CharT, 2>(valid);
+// }
+
+#endif // TEST_SUPPORT_FORMAT_FUNCTIONS_COMMON_H


### PR DESCRIPTION
This PR implements `cuda::std::vformat_to` function on top of which all other formatting functions are implemented. Most of the tests pass, however there are some that fail and will require some investigation.

I've omitted floating point types tests, because we don't implement their formatters, we need to implement `cuda::std::to_chars` for floating point types first.

Compiling the formatting function on device takes a lot of time and resources. I've got some tests compiling for half an hour and using 120 GB of memory. That's why I decided to mark the main formatting function as noinline.