### PR TITLE
Support init values for `DeviceReduce` using `FutureValue`

### DIFF
--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -513,6 +513,271 @@ public:
   }
 
   //! @rst
+  //! Computes a device-wide reduction using the specified binary ``reduction_op`` functor and a device-resident initial
+  //! value (future value).
+  //!
+  //! .. versionadded:: 2.2.0
+  //!    First appears in CUDA Toolkit 12.3.
+  //!
+  //! - Does not support binary reduction operators that are non-commutative.
+  //! - Provides "run-to-run" determinism for pseudo-associative reduction
+  //!   (e.g., addition of floating point types) on the same GPU device.
+  //!   However, results for pseudo-associative reduction may be inconsistent
+  //!   from one device to a another device of a different compute-capability
+  //!   because CUB can employ different tile-sizing for different architectures.
+  //! - The range ``[d_in, d_in + num_items)`` shall not overlap ``d_out``.
+  //! - @devicestorage
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates a user-defined product-reduction of a device vector of ``int`` data elements
+  //! with a device-resident initial value.
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>
+  //!    // or equivalently <cub/device/device_reduce.cuh>
+  //!
+  //!    // CustomProduct functor
+  //!    struct CustomProduct
+  //!    {
+  //!        template <typename T>
+  //!        __device__ __forceinline__
+  //!        T operator()(const T &a, const T &b) const {
+  //!            return a * b;
+  //!        }
+  //!    };
+  //!
+  //!    // Declare, allocate, and initialize device-accessible pointers
+  //!    int              num_items;      // e.g., 7
+  //!    int              *d_in;          // e.g., [8, 6, 7, 5, 3, 0, 9]
+  //!    int              *d_out;         // e.g., [-]
+  //!    int              *d_init_iter;   // e.g., 1
+  //!    CustomProduct    prod_op;
+  //!
+  //!    auto future_init_value = cub::FutureValue<int>(d_init_iter);
+  //!
+  //!    ...
+  //!
+  //!    // Determine temporary device storage requirements
+  //!    void     *d_temp_storage = nullptr;
+  //!    size_t   temp_storage_bytes = 0;
+  //!    cub::DeviceReduce::Reduce(
+  //!      d_temp_storage, temp_storage_bytes,
+  //!      d_in, d_out, num_items, prod_op, future_init_value);
+  //!
+  //!    // Allocate temporary storage
+  //!    cudaMalloc(&d_temp_storage, temp_storage_bytes);
+  //!
+  //!    // Run reduction
+  //!    cub::DeviceReduce::Reduce(
+  //!      d_temp_storage, temp_storage_bytes,
+  //!      d_in, d_out, num_items, prod_op, future_init_value);
+  //!
+  //!    // d_out <-- [15120]
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input items @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Output iterator type for recording the reduced aggregate @iterator
+  //!
+  //! @tparam ReductionOpT
+  //!   **[inferred]** Binary reduction functor type having member `T operator()(const T &a, const T &b)`
+  //!
+  //! @tparam T
+  //!   **[inferred]** Data element type that is convertible to the `value` type of `InputIteratorT`
+  //!
+  //! @tparam IterT
+  //!   **[inferred]** Iterator type for the future value
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
+  //! @param[in] d_temp_storage
+  //!   Device-accessible allocation of temporary storage. When `nullptr`, the
+  //!   required allocation size is written to `temp_storage_bytes` and no work is done.
+  //!
+  //! @param[in,out] temp_storage_bytes
+  //!   Reference to size in bytes of `d_temp_storage` allocation
+  //!
+  //! @param[in] d_in
+  //!   Pointer to the input sequence of data items
+  //!
+  //! @param[out] d_out
+  //!   Pointer to the output aggregate
+  //!
+  //! @param[in] num_items
+  //!   Total number of input items (i.e., length of ``d_in``)
+  //!
+  //! @param[in] reduction_op
+  //!   Binary reduction functor
+  //!
+  //! @param[in] init
+  //!   Initial value of the reduction (provided as a future value)
+  //!
+  //! @param[in] stream
+  //!   @rst
+  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   @endrst
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename ReductionOpT,
+            typename T,
+            typename IterT = T*,
+            typename NumItemsT>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t Reduce(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    InputIteratorT d_in,
+    OutputIteratorT d_out,
+    NumItemsT num_items,
+    ReductionOpT reduction_op,
+    FutureValue<T, IterT> init,
+    cudaStream_t stream = nullptr)
+  {
+    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceReduce::Reduce");
+
+    // Unsigned integer type for global offsets
+    using OffsetT = detail::choose_offset_t<NumItemsT>;
+
+    return detail::reduce::dispatch(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_in,
+      d_out,
+      static_cast<OffsetT>(num_items),
+      reduction_op,
+      detail::InputValue<T>(init),
+      stream);
+  }
+
+  //! @rst
+  //! Computes a device-wide reduction using the specified binary ``reduction_op`` functor and a device-resident initial
+  //! value (future value).
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! - Does not support binary reduction operators that are non-commutative.
+  //! - By default, provides "run-to-run" determinism for pseudo-associative reduction
+  //!   (e.g., addition of floating point types) on the same GPU device.
+  //!   However, results for pseudo-associative reduction may be inconsistent
+  //!   from one device to a another device of a different compute-capability
+  //!   because CUB can employ different tile-sizing for different architectures.
+  //!   To request "gpu-to-gpu" determinism, pass ``cuda::execution::require(cuda::execution::determinism::gpu_to_gpu)``
+  //!   as the `env` parameter.
+  //!   To request "not-guaranteed" determinism, pass
+  //!   ``cuda::execution::require(cuda::execution::determinism::not_guaranteed)`` as the `env` parameter.
+  //! - The range ``[d_in, d_in + num_items)`` shall not overlap ``d_out``.
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates a user-defined product-reduction of a device vector of ``int`` data elements
+  //! with a device-resident initial value and a stream environment.
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>
+  //!    // or equivalently <cub/device/device_reduce.cuh>
+  //!
+  //!    // CustomProduct functor
+  //!    struct CustomProduct
+  //!    {
+  //!        template <typename T>
+  //!        __device__ __forceinline__
+  //!        T operator()(const T &a, const T &b) const {
+  //!            return a * b;
+  //!        }
+  //!    };
+  //!
+  //!    // Declare, allocate, and initialize device-accessible pointers
+  //!    int              num_items;      // e.g., 7
+  //!    int              *d_in;          // e.g., [8, 6, 7, 5, 3, 0, 9]
+  //!    int              *d_out;         // e.g., [-]
+  //!    int              *d_init_iter;   // e.g., 1
+  //!    CustomProduct    prod_op;
+  //!
+  //!    auto future_init_value = cub::FutureValue<int>(d_init_iter);
+  //!
+  //!    ...
+  //!
+  //!    // Run reduction with a custom stream
+  //!    cub::DeviceReduce::Reduce(
+  //!      d_in, d_out, num_items, prod_op, future_init_value, stream);
+  //!
+  //!    // d_out <-- [15120]
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input items @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Output iterator type for recording the reduced aggregate @iterator
+  //!
+  //! @tparam ReductionOpT
+  //!   **[inferred]** Binary reduction functor type having member `T operator()(const T &a, const T &b)`
+  //!
+  //! @tparam T
+  //!   **[inferred]** Data element type that is convertible to the `value` type of `InputIteratorT`
+  //!
+  //! @tparam IterT
+  //!   **[inferred]** Iterator type for the future value
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Execution environment type. Default is ``cuda::std::execution::env<>``.
+  //!
+  //! @param[in] d_in
+  //!   Pointer to the input sequence of data items
+  //!
+  //! @param[out] d_out
+  //!   Pointer to the output aggregate
+  //!
+  //! @param[in] num_items
+  //!   Total number of input items (i.e., length of ``d_in``)
+  //!
+  //! @param[in] reduction_op
+  //!   Binary reduction functor
+  //!
+  //! @param[in] init
+  //!   Initial value of the reduction (provided as a future value)
+  //!
+  //! @param[in] env
+  //!   @rst
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  //!   @endrst
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename ReductionOpT,
+            typename T,
+            typename IterT = T*,
+            typename NumItemsT,
+            typename EnvT = ::cuda::std::execution::env<>>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t Reduce(
+    InputIteratorT d_in,
+    OutputIteratorT d_out,
+    NumItemsT num_items,
+    ReductionOpT reduction_op,
+    FutureValue<T, IterT> init,
+    EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::Reduce");
+
+    using accum_t = ::cuda::std::__accumulator_t<ReductionOpT, detail::it_value_t<InputIteratorT>, T>;
+
+    return __transform_reduce<accum_t>(
+      d_in, d_out, num_items, reduction_op, ::cuda::std::identity{}, detail::InputValue<T>(init), env);
+  }
+
+  //! @rst
   //! Computes a device-wide sum using the addition (``+``) operator.
   //!
   //! .. versionadded:: 2.2.0
@@ -2028,6 +2293,153 @@ public:
 
   //! @rst
   //! Computes a device-wide reduction using the specified binary ``reduction_op`` functor,
+  //! a unary ``transform_op`` functor, and a device-resident initial value (future value).
+  //!
+  //! .. versionadded:: 2.2.0
+  //!    First appears in CUDA Toolkit 12.3.
+  //!
+  //! - Does not support binary reduction operators that are non-commutative.
+  //! - Provides "run-to-run" determinism for pseudo-associative reduction
+  //!   (e.g., addition of floating point types) on the same GPU device.
+  //!   However, results for pseudo-associative reduction may be inconsistent
+  //!   from one device to a another device of a different compute-capability
+  //!   because CUB can employ different tile-sizing for different architectures.
+  //! - The range ``[d_in, d_in + num_items)`` shall not overlap ``d_out``.
+  //! - @devicestorage
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates a user-defined min-reduction of a
+  //! device vector of `int` data elements.
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>
+  //!    // or equivalently <cub/device/device_reduce.cuh>
+  //!
+  //!    thrust::device_vector<int> in = { 1, 2, 3, 4 };
+  //!    thrust::device_vector<int> out(1);
+  //!
+  //!    size_t temp_storage_bytes = 0;
+  //!    uint8_t *d_temp_storage = nullptr;
+  //!
+  //!    thrust::device_vector<int> init{42};
+  //!    auto future_init_value = cub::FutureValue<int>(init);
+  //!
+  //!    cub::DeviceReduce::TransformReduce(
+  //!      d_temp_storage,
+  //!      temp_storage_bytes,
+  //!      in.begin(),
+  //!      out.begin(),
+  //!      in.size(),
+  //!      cuda::std::plus<>{},
+  //!      square_t{},
+  //!      future_init_value);
+  //!
+  //!    thrust::device_vector<uint8_t> temp_storage(temp_storage_bytes);
+  //!    d_temp_storage = temp_storage.data().get();
+  //!
+  //!    cub::DeviceReduce::TransformReduce(
+  //!      d_temp_storage,
+  //!      temp_storage_bytes,
+  //!      in.begin(),
+  //!      out.begin(),
+  //!      in.size(),
+  //!      cuda::std::plus<>{},
+  //!      square_t{},
+  //!      future_init_value);
+  //!
+  //!    // out[0] <-- 72
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input items @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Output iterator type for recording the reduced aggregate @iterator
+  //!
+  //! @tparam ReductionOpT
+  //!   **[inferred]** Binary reduction functor type having member `T operator()(const T &a, const T &b)`
+  //!
+  //! @tparam TransformOpT
+  //!   **[inferred]** Unary reduction functor type having member `auto operator()(const T &a)`
+  //!
+  //! @tparam T
+  //!   **[inferred]** Data element type that is convertible to the `value` type of `InputIteratorT`
+  //!
+  //! @tparam IterT
+  //!   **[inferred]** Iterator type for the future value
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
+  //! @param[in] d_temp_storage
+  //!   Device-accessible allocation of temporary storage. When `nullptr`, the
+  //!   required allocation size is written to `temp_storage_bytes` and no work is done.
+  //!
+  //! @param[in,out] temp_storage_bytes
+  //!   Reference to size in bytes of `d_temp_storage` allocation
+  //!
+  //! @param[in] d_in
+  //!   Pointer to the input sequence of data items
+  //!
+  //! @param[out] d_out
+  //!   Pointer to the output aggregate
+  //!
+  //! @param[in] num_items
+  //!   Total number of input items (i.e., length of ``d_in``)
+  //!
+  //! @param[in] reduction_op
+  //!   Binary reduction functor
+  //!
+  //! @param[in] transform_op
+  //!   Unary transform functor
+  //!
+  //! @param[in] init
+  //!   Initial value of the reduction (provided as a future value)
+  //!
+  //! @param[in] stream
+  //!   @rst
+  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   @endrst
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename ReductionOpT,
+            typename TransformOpT,
+            typename T,
+            typename IterT = T*,
+            typename NumItemsT>
+  CUB_RUNTIME_FUNCTION static cudaError_t TransformReduce(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    InputIteratorT d_in,
+    OutputIteratorT d_out,
+    NumItemsT num_items,
+    ReductionOpT reduction_op,
+    TransformOpT transform_op,
+    FutureValue<T, IterT> init,
+    cudaStream_t stream = nullptr)
+  {
+    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceReduce::TransformReduce");
+
+    using OffsetT = detail::choose_offset_t<NumItemsT>;
+
+    return detail::reduce::dispatch(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_in,
+      d_out,
+      static_cast<OffsetT>(num_items),
+      reduction_op,
+      detail::InputValue<T>(init),
+      stream,
+      transform_op);
+  }
+
+  //! @rst
+  //! Computes a device-wide reduction using the specified binary ``reduction_op`` functor,
   //! a unary ``transform_op`` functor, and initial value ``init``.
   //!
   //! .. versionadded:: 3.4.0
@@ -2129,6 +2541,98 @@ public:
     using accum_t = ::cuda::std::
       __accumulator_t<ReductionOpT, ::cuda::std::invoke_result_t<TransformOpT, detail::it_value_t<InputIteratorT>>, T>;
     return __transform_reduce<accum_t>(d_in, d_out, num_items, reduction_op, transform_op, init, env);
+  }
+
+  //! @rst
+  //! Computes a device-wide reduction using the specified binary ``reduction_op`` functor,
+  //! a unary ``transform_op`` functor, and a device-resident initial value (future value).
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! - Does not support binary reduction operators that are non-commutative.
+  //! - By default, provides "run-to-run" determinism for pseudo-associative reduction
+  //!   (e.g., addition of floating point types) on the same GPU device.
+  //!   However, results for pseudo-associative reduction may be inconsistent
+  //!   from one device to a another device of a different compute-capability
+  //!   because CUB can employ different tile-sizing for different architectures.
+  //!   To request "gpu-to-gpu" determinism, pass ``cuda::execution::require(cuda::execution::determinism::gpu_to_gpu)``
+  //!   as the `env` parameter.
+  //!   To request "not-guaranteed" determinism, pass
+  //!   ``cuda::execution::require(cuda::execution::determinism::not_guaranteed)`` as the `env` parameter.
+  //! - The range ``[d_in, d_in + num_items)`` shall not overlap ``d_out``.
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input items @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Output iterator type for recording the reduced aggregate @iterator
+  //!
+  //! @tparam ReductionOpT
+  //!   **[inferred]** Binary reduction functor type having member `T operator()(const T &a, const T &b)`
+  //!
+  //! @tparam TransformOpT
+  //!   **[inferred]** Unary reduction functor type having member `auto operator()(const T &a)`
+  //!
+  //! @tparam T
+  //!   **[inferred]** Data element type that is convertible to the `value` type of `InputIteratorT`
+  //!
+  //! @tparam IterT
+  //!   **[inferred]** Iterator type for the future value
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Execution environment type. Default is ``cuda::std::execution::env<>``.
+  //!   Supports customization of stream via ``cuda::get_stream``.
+  //!
+  //! @param[in] d_in
+  //!   Pointer to the input sequence of data items
+  //!
+  //! @param[out] d_out
+  //!   Pointer to the output aggregate
+  //!
+  //! @param[in] num_items
+  //!   Total number of input items (i.e., length of ``d_in``)
+  //!
+  //! @param[in] reduction_op
+  //!   Binary reduction functor
+  //!
+  //! @param[in] transform_op
+  //!   Unary transform functor
+  //!
+  //! @param[in] init
+  //!   Initial value of the reduction (provided as a future value)
+  //!
+  //! @param[in] env
+  //!   @rst
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}`.
+  //!   @endrst
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename ReductionOpT,
+            typename TransformOpT,
+            typename T,
+            typename IterT = T*,
+            typename NumItemsT,
+            typename EnvT = ::cuda::std::execution::env<>>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t TransformReduce(
+    InputIteratorT d_in,
+    OutputIteratorT d_out,
+    NumItemsT num_items,
+    ReductionOpT reduction_op,
+    TransformOpT transform_op,
+    FutureValue<T, IterT> init,
+    EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::TransformReduce");
+    using accum_t = ::cuda::std::
+      __accumulator_t<ReductionOpT, ::cuda::std::invoke_result_t<TransformOpT, detail::it_value_t<InputIteratorT>>, T>;
+    return __transform_reduce<accum_t>(
+      d_in, d_out, num_items, reduction_op, transform_op, detail::InputValue<T>(init), env);
   }
 
   //! @rst

--- a/cub/test/catch2_test_device_reduce.cu
+++ b/cub/test/catch2_test_device_reduce.cu
@@ -153,6 +153,36 @@ C2H_TEST("Device reduce works with all device interfaces", "[reduce][device]", f
     // Verify result
     REQUIRE(expected_result == out_result[0]);
   }
+
+  SECTION("reduce with FutureValue")
+  {
+    // example-begin device-reduce-future-value
+    using op_t = cuda::std::plus<>;
+
+    // Binary reduction operator
+    auto reduction_op = unwrap_op(reference_extended_fp(d_in_it), op_t{});
+
+    // Prepare verification data
+    using accum_t = cuda::std::__accumulator_t<op_t, item_t, output_t>;
+    accum_t init_value{};
+    init_default_constant(init_value);
+    output_t expected_result =
+      static_cast<output_t>(compute_single_problem_reference(in_items, reduction_op, init_value));
+
+    // Run test
+    c2h::device_vector<output_t> out_result(num_segments);
+    auto d_out_it = thrust::raw_pointer_cast(out_result.data());
+    using init_t  = cub::detail::it_value_t<decltype(unwrap_it(d_out_it))>;
+    // Create device-resident initial value
+    c2h::device_vector<init_t> d_initial_value(1);
+    d_initial_value[0]     = static_cast<init_t>(*unwrap_it(&init_value));
+    auto future_init_value = cub::FutureValue<init_t>(thrust::raw_pointer_cast(d_initial_value.data()));
+    device_reduce(unwrap_it(d_in_it), unwrap_it(d_out_it), num_items, reduction_op, future_init_value);
+
+    // example-end device-reduce-future-value
+    // Verify result
+    REQUIRE(expected_result == out_result[0]);
+  }
 #endif // TEST_TYPES != 4
 
 // Skip DeviceReduce::Sum tests for extended floating-point types because of unbounded epsilon due

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -117,6 +117,37 @@ TEST_CASE("Device reduce works with default environment", "[reduce][device]")
   REQUIRE(d_block_size[0] == target_block_size);
 }
 
+TEST_CASE("Device reduce with FutureValue works with default environment", "[reduce][device]")
+{
+  using num_items_t = int;
+  using value_t     = int;
+  using offset_t    = cub::detail::choose_offset_t<num_items_t>;
+
+  int current_device{};
+  REQUIRE(cudaSuccess == cudaGetDevice(&current_device));
+
+  cuda::compute_capability cc{};
+  REQUIRE(cudaSuccess == cub::detail::ptx_compute_cap(cc, current_device));
+
+  unsigned int target_block_size =
+    cub::detail::reduce::policy_selector_from_types<value_t, offset_t, block_size_check_plus_t>{}(cc)
+      .single_tile.threads_per_block;
+
+  num_items_t num_items = 1;
+  c2h::device_vector<unsigned int> d_block_size(1);
+  block_size_check_plus_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
+  auto d_in  = cuda::constant_iterator(value_t{1});
+  auto d_out = thrust::device_vector<value_t>(1);
+
+  auto init_value_vec = c2h::device_vector<value_t>{0};
+  auto future_init    = cub::FutureValue<value_t>(thrust::raw_pointer_cast(init_value_vec.data()));
+
+  REQUIRE(cudaSuccess == cub::DeviceReduce::Reduce(d_in, d_out.begin(), num_items, block_size_check, future_init));
+
+  REQUIRE(d_out[0] == num_items);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
 TEST_CASE("Device Sum works with default environment", "[reduce][device]")
 {
   using num_items_t     = int;
@@ -520,6 +551,139 @@ C2H_TEST("Device reduce uses environment", "[reduce][device]", requirements)
   REQUIRE(d_out[0] == num_items);
 }
 
+C2H_TEST("Device reduce with FutureValue uses environment", "[reduce][device]", requirements)
+{
+  using determinism_t = c2h::get<0, TestType>;
+  using accumulator_t = float;
+  using op_t          = cuda::std::plus<>;
+  using num_items_t   = int;
+  using offset_t      = cub::detail::choose_offset_t<num_items_t>;
+  using transform_t   = cuda::std::identity;
+  using init_t        = accumulator_t;
+
+  num_items_t num_items = GENERATE(1 << 4, 1 << 24);
+  auto d_in             = cuda::constant_iterator(1.0f);
+  auto d_out            = thrust::device_vector<accumulator_t>(1);
+
+  auto init_value_vec = c2h::device_vector<init_t>{0};
+  auto future_init    = cub::FutureValue<init_t>(thrust::raw_pointer_cast(init_value_vec.data()));
+
+  size_t expected_bytes_allocated{};
+
+  // To check if a given algorithm implementation is used, we check if associated kernels are invoked.
+  auto kernels = [&]() {
+    if constexpr (std::is_same_v<determinism_t, cuda::execution::determinism::run_to_run_t>)
+    {
+      REQUIRE(cudaSuccess
+              == cub::DeviceReduce::Reduce(
+                nullptr, expected_bytes_allocated, d_in, d_out.begin(), num_items, op_t{}, future_init));
+
+      using policy_t = cub::detail::reduce::policy_selector_from_types<accumulator_t, offset_t, op_t>;
+      return cuda::std::array<void*, 3>{
+        reinterpret_cast<void*>(
+          cub::detail::reduce::DeviceReduceSingleTileKernel<
+            policy_t,
+            decltype(d_in),
+            decltype(d_out.begin()),
+            offset_t,
+            op_t,
+            init_t,
+            accumulator_t,
+            transform_t>),
+        reinterpret_cast<void*>(
+          cub::detail::reduce::DeviceReduceKernel<policy_t, decltype(d_in), offset_t, op_t, accumulator_t, transform_t>),
+        reinterpret_cast<void*>(
+          cub::detail::reduce::DeviceReduceSingleTileKernel<
+            policy_t,
+            accumulator_t*,
+            decltype(d_out.begin()),
+            int, // always used with int offset
+            op_t,
+            init_t,
+            accumulator_t>)};
+    }
+    else if constexpr (cub::detail::is_non_deterministic_v<determinism_t>)
+    {
+      using policy_t = cub::detail::reduce_nondeterministic::policy_selector_from_types<accumulator_t, offset_t, op_t>;
+      auto* raw_ptr  = thrust::raw_pointer_cast(d_out.data());
+
+      REQUIRE(
+        cudaSuccess
+        == cub::detail::reduce_nondeterministic::dispatch(
+          nullptr,
+          expected_bytes_allocated,
+          d_in,
+          raw_ptr,
+          num_items,
+          op_t{},
+          cub::detail::InputValue<init_t>(future_init),
+          /* stream */ nullptr,
+          transform_t{}));
+
+      return cuda::std::array<void*, 1>{reinterpret_cast<void*>(
+        cub::detail::reduce::NondeterministicDeviceReduceAtomicKernel<
+          policy_t,
+          decltype(d_in),
+          decltype(raw_ptr),
+          offset_t,
+          op_t,
+          init_t,
+          accumulator_t,
+          transform_t>)};
+    }
+    else
+    {
+      using policy_t              = cub::detail::rfa::policy_selector_from_types<accumulator_t>;
+      using deterministic_add_t   = cub::detail::rfa::deterministic_sum_t<accumulator_t>;
+      using reduction_op_t        = deterministic_add_t;
+      using deterministic_accum_t = deterministic_add_t::DeterministicAcc;
+      using output_it_t           = decltype(d_out.begin());
+
+      REQUIRE(
+        cudaSuccess
+        == cub::detail::rfa::
+          dispatch<decltype(d_in), decltype(d_out.begin()), offset_t, init_t, transform_t, accumulator_t>(
+            nullptr,
+            expected_bytes_allocated,
+            d_in,
+            d_out.begin(),
+            num_items,
+            cub::detail::InputValue<init_t>(future_init)));
+
+      auto k1 = cub::detail::reduce::DeterministicDeviceReduceSingleTileKernel<
+        policy_t,
+        decltype(d_in),
+        output_it_t,
+        reduction_op_t,
+        init_t,
+        deterministic_accum_t,
+        transform_t>;
+      auto k2 = cub::detail::reduce::
+        DeterministicDeviceReduceKernel<policy_t, decltype(d_in), reduction_op_t, deterministic_accum_t, transform_t>;
+      auto k3 = cub::detail::reduce::DeterministicDeviceReduceSingleTileKernel<
+        policy_t,
+        deterministic_accum_t*,
+        output_it_t,
+        reduction_op_t,
+        init_t,
+        deterministic_accum_t,
+        transform_t>;
+      return cuda::std::array<void*, 3>{
+        reinterpret_cast<void*>(k1), reinterpret_cast<void*>(k2), reinterpret_cast<void*>(k3)};
+    }
+  }();
+
+  // Equivalent to `cuexec::require(cuexec::determinism::run_to_run)` and
+  //               `cuexec::require(cuexec::determinism::not_guaranteed)`
+  auto env = stdexec::env{cuda::execution::require(determinism_t{}), // determinism
+                          allowed_kernels(kernels), // allowed kernels for the given determinism
+                          expected_allocation_size(expected_bytes_allocated)}; // temp storage size
+
+  device_reduce(d_in, d_out.begin(), num_items, op_t{}, future_init, env);
+
+  REQUIRE(d_out[0] == num_items);
+}
+
 C2H_TEST("Device sum uses environment", "[reduce][device]", requirements)
 {
   using determinism_t = c2h::get<0, TestType>;
@@ -790,6 +954,24 @@ TEST_CASE("Device TransformReduce works with default environment", "[reduce][dev
   REQUIRE(d_out[0] == -10);
 }
 
+TEST_CASE("Device TransformReduce with FutureValue works with default environment", "[reduce][device]")
+{
+  auto d_in  = c2h::device_vector<int>{1, 2, 3, 4};
+  auto d_out = thrust::device_vector<int>(1);
+
+  auto negate = cuda::std::negate<int>{};
+
+  // future init value
+  auto init_value_vec = c2h::device_vector<int>{0};
+  auto future_init    = cub::FutureValue<int>(thrust::raw_pointer_cast(init_value_vec.data()));
+
+  REQUIRE(cudaSuccess
+          == cub::DeviceReduce::TransformReduce(
+            d_in.begin(), d_out.begin(), static_cast<int>(d_in.size()), cuda::std::plus<int>{}, negate, future_init));
+
+  REQUIRE(d_out[0] == -10);
+}
+
 TEST_CASE("Device ReduceByKey works with default environment", "[reduce][device]")
 {
   auto d_keys_in        = c2h::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
@@ -896,6 +1078,38 @@ C2H_TEST("Device TransformReduce uses environment", "[reduce][device]")
 
   device_transform_reduce(
     d_in.begin(), d_out.begin(), static_cast<int>(d_in.size()), cuda::std::plus<int>{}, negate, 0, env);
+
+  REQUIRE(d_out[0] == -10);
+}
+
+C2H_TEST("Device TransformReduce with FutureValue uses environment", "[reduce][device]")
+{
+  auto d_in  = c2h::device_vector<int>{1, 2, 3, 4};
+  auto d_out = thrust::device_vector<int>(1);
+
+  auto negate = cuda::std::negate<int>{};
+
+  // future init value
+  auto init_value_vec = c2h::device_vector<int>{0};
+  auto future_init    = cub::FutureValue<int>(thrust::raw_pointer_cast(init_value_vec.data()));
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceReduce::TransformReduce(
+      nullptr,
+      expected_bytes_allocated,
+      d_in.begin(),
+      d_out.begin(),
+      static_cast<int>(d_in.size()),
+      cuda::std::plus<int>{},
+      negate,
+      future_init));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_transform_reduce(
+    d_in.begin(), d_out.begin(), static_cast<int>(d_in.size()), cuda::std::plus<int>{}, negate, future_init, env);
 
   REQUIRE(d_out[0] == -10);
 }

--- a/cub/test/catch2_test_device_reduce_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_env_api.cu
@@ -88,6 +88,56 @@ C2H_TEST("cub::DeviceReduce::Reduce accepts stream", "[reduce][env]")
   REQUIRE(output == expected);
 }
 
+C2H_TEST("cub::DeviceReduce::Reduce with FutureValue accepts environment")
+{
+  // example-begin reduce-future-env
+  auto op             = cuda::std::plus{};
+  auto input          = thrust::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
+  auto output         = thrust::device_vector<float>(1);
+  auto init_value_vec = thrust::device_vector<float>{0.0f};
+  auto future_init    = cub::FutureValue<float>(thrust::raw_pointer_cast(init_value_vec.data()));
+
+  auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
+
+  auto error = cub::DeviceReduce::Reduce(input.begin(), output.begin(), input.size(), op, future_init, env);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceReduce::Reduce failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<float> expected{6.0f};
+  // example-end reduce-future-env
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(output == expected);
+}
+
+C2H_TEST("cub::DeviceReduce::Reduce with FutureValue accepts stream")
+{
+  // example-begin reduce-future-stream
+  auto op             = cuda::std::plus{};
+  auto input          = thrust::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
+  auto output         = thrust::device_vector<float>(1);
+  auto init_value_vec = thrust::device_vector<float>{0.0f};
+  auto future_init    = cub::FutureValue<float>(thrust::raw_pointer_cast(init_value_vec.data()));
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceReduce::Reduce(input.begin(), output.begin(), input.size(), op, future_init, stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceReduce::Reduce failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<float> expected{6.0f};
+  // example-end reduce-future-stream
+  stream.sync();
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(output == expected);
+}
+
 C2H_TEST("cub::DeviceReduce::Sum accepts run_to_run determinism requirements", "[reduce][env]")
 {
   // TODO(srinivas): replace with gpu_to_gpu once offset size restriction is relaxed
@@ -483,6 +533,32 @@ C2H_TEST("cub::DeviceReduce::TransformReduce accepts not_guaranteed determinism 
   REQUIRE(output == expected);
 }
 
+C2H_TEST("cub::DeviceReduce::TransformReduce with FutureValue accepts environments", "[reduce][env]")
+{
+  // example-begin transform-reduce-future-env-determinism
+  auto op             = cuda::std::plus{};
+  auto transform      = cuda::std::negate{};
+  auto input          = thrust::device_vector<float>{1.0f, 2.0f, 3.0f, 4.0f};
+  auto output         = thrust::device_vector<float>(1);
+  auto init_value_vec = c2h::device_vector<float>{0.0f};
+  auto future_init    = cub::FutureValue<float>(thrust::raw_pointer_cast(init_value_vec.data()));
+
+  auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
+
+  auto error =
+    cub::DeviceReduce::TransformReduce(input.begin(), output.begin(), input.size(), op, transform, future_init, env);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceReduce::TransformReduce failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<float> expected{-10.0f};
+  // example-end transform-reduce-future-env-determinism
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(output == expected);
+}
+
 C2H_TEST("cub::DeviceReduce::TransformReduce accepts stream", "[reduce][env]")
 {
   // example-begin transform-reduce-env-stream
@@ -504,6 +580,34 @@ C2H_TEST("cub::DeviceReduce::TransformReduce accepts stream", "[reduce][env]")
 
   thrust::device_vector<float> expected{-10.0f};
   // example-end transform-reduce-env-stream
+  stream.sync();
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(output == expected);
+}
+
+C2H_TEST("cub::DeviceReduce::TransformReduce with FutureValue accepts stream", "[reduce][env]")
+{
+  // example-begin transform-reduce-future-env-stream
+  auto op             = cuda::std::plus{};
+  auto transform      = cuda::std::negate{};
+  auto input          = thrust::device_vector<float>{1.0f, 2.0f, 3.0f, 4.0f};
+  auto output         = thrust::device_vector<float>(1);
+  auto init_value_vec = c2h::device_vector<float>{0.0f};
+  auto future_init    = cub::FutureValue<float>(thrust::raw_pointer_cast(init_value_vec.data()));
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceReduce::TransformReduce(
+    input.begin(), output.begin(), input.size(), op, transform, future_init, stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceReduce::TransformReduce failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<float> expected{-10.0f};
+  // example-end transform-reduce-future-env-stream
   stream.sync();
 
   REQUIRE(error == cudaSuccess);

--- a/cub/test/catch2_test_device_reduce_iterators.cu
+++ b/cub/test/catch2_test_device_reduce_iterators.cu
@@ -58,36 +58,80 @@ C2H_TEST("Device reduce works with fancy input iterators", "[reduce][device]", i
   constexpr int min_items    = 1;
   constexpr int num_segments = 1;
 
-  // Generate the input sizes to test for
-  const int num_items = GENERATE_COPY(
-    take(3, random(min_items, max_items)),
-    values({
-      min_items,
-      max_items,
-    }));
+  SECTION("reduce")
+  {
+    // Generate the input sizes to test for
+    const int num_items = GENERATE_COPY(
+      take(3, random(min_items, max_items)),
+      values({
+        min_items,
+        max_items,
+      }));
 
-  // Prepare input data
-  item_t default_constant{};
-  init_default_constant(default_constant);
-  auto in_it = cuda::constant_iterator(default_constant);
+    // Prepare input data
+    item_t default_constant{};
+    init_default_constant(default_constant);
+    auto in_it = cuda::constant_iterator(default_constant);
 
-  using op_t         = cuda::std::plus<>;
-  using init_value_t = output_t;
+    using op_t   = cuda::std::plus<>;
+    using init_t = output_t;
 
-  // Binary reduction operator
-  auto reduction_op = op_t{};
+    // Binary reduction operator
+    auto reduction_op = op_t{};
 
-  // Prepare verification data
-  using accum_t            = cuda::std::__accumulator_t<op_t, item_t, init_value_t>;
-  output_t expected_result = compute_single_problem_reference(in_it, in_it + num_items, reduction_op, accum_t{});
+    // Prepare verification data
+    using accum_t            = cuda::std::__accumulator_t<op_t, item_t, init_t>;
+    output_t expected_result = compute_single_problem_reference(in_it, in_it + num_items, reduction_op, accum_t{});
 
-  // Run test
-  c2h::device_vector<output_t> out_result(num_segments);
-  auto d_out_it = thrust::raw_pointer_cast(out_result.data());
-  device_reduce(in_it, d_out_it, num_items, reduction_op, init_value_t{});
+    // Run test
+    c2h::device_vector<output_t> out_result(num_segments);
+    auto d_out_it = thrust::raw_pointer_cast(out_result.data());
+    device_reduce(in_it, d_out_it, num_items, reduction_op, init_t{});
 
-  // Verify result
-  REQUIRE(expected_result == out_result[0]);
+    // Verify result
+    REQUIRE(expected_result == out_result[0]);
+  }
+
+  SECTION("reduce with FutureValue")
+  {
+    // Generate the input sizes to test for
+    const int num_items = GENERATE_COPY(
+      take(3, random(min_items, max_items)),
+      values({
+        min_items,
+        max_items,
+      }));
+
+    // Prepare input data
+    item_t default_constant{};
+    init_default_constant(default_constant);
+    auto in_it = cuda::constant_iterator(default_constant);
+
+    using op_t   = cuda::std::plus<>;
+    using init_t = output_t;
+
+    // Binary reduction operator
+    auto reduction_op = op_t{};
+
+    // Prepare verification data
+    using accum_t            = cuda::std::__accumulator_t<op_t, item_t, init_t>;
+    output_t expected_result = compute_single_problem_reference(in_it, in_it + num_items, reduction_op, accum_t{});
+
+    accum_t init_value{};
+    init_default_constant(init_value);
+
+    // Device-resident init value (FutureValue)
+    auto init_value_vec = c2h::device_vector<init_t>{static_cast<init_t>(*unwrap_it(&init_value)};
+    auto future_init    = cub::FutureValue<init_t>(thrust::raw_pointer_cast(init_value_vec.data()));
+
+    // Run test
+    c2h::device_vector<output_t> out_result(num_segments);
+    auto d_out_it = thrust::raw_pointer_cast(out_result.data());
+    device_reduce(in_it, d_out_it, num_items, reduction_op, future_init);
+
+    // Verify result
+    REQUIRE(expected_result == out_result[0]);
+  }
 }
 
 C2H_TEST("Device reduce compiles with discard output iterator", "[reduce][device]", iterator_type_list)

--- a/cub/test/catch2_test_device_reduce_large_offsets.cu
+++ b/cub/test/catch2_test_device_reduce_large_offsets.cu
@@ -108,6 +108,34 @@ C2H_TEST("Device reduce works with all device interfaces", "[reduce][device]", o
     REQUIRE(expected_result == out_result[0]);
   }
 
+  SECTION("reduce with FutureValue")
+  {
+    using op_t = custom_sum_op;
+
+    // Segment size (generate a series of: 0, 1, 2, ..., <segment_size-1>,  0, 1, 2, ..., <segment_size-1>, 0, 1, ...)
+    const auto segment_size = 1000;
+
+    // Initial value of reduction (FutureValue)
+    auto init_value_vec = c2h::device_vector<index_t>{42};
+    auto future_init    = cub::FutureValue<index_t>(thrust::raw_pointer_cast(init_value_vec.data()));
+
+    // Binary reduction operator
+    const auto reduction_op = op_t{};
+
+    // Prepare verification data
+    const index_t expected_result = index_t{42} + get_segmented_guassian_sum(num_items, segment_size);
+
+    // Run test
+    c2h::device_vector<index_t> out_result(1);
+    const auto d_out_it = thrust::raw_pointer_cast(out_result.data());
+    const auto d_in_it  = cuda::transform_iterator(index_it, mod_op<index_t>{segment_size});
+
+    device_reduce(d_in_it, d_out_it, num_items, reduction_op, future_init);
+
+    // Verify result
+    REQUIRE(expected_result == out_result[0]);
+  }
+
   SECTION("sum")
   {
     // Segment size (generate a series of: 0, 1, 2, ..., <segment_size-1>,  0, 1, 2, ..., <segment_size-1>, 0, 1, ...)

--- a/cub/test/catch2_test_device_transform_reduce.cu
+++ b/cub/test/catch2_test_device_transform_reduce.cu
@@ -75,6 +75,62 @@ C2H_TEST("Device transform reduce works with pointers", "[reduce][device]", type
   }
 }
 
+C2H_TEST("Device transform reduce with FutureValue works with pointers", "[reduce][device]", types)
+{
+  using item_t         = c2h::get<0, TestType>;
+  using init_t         = item_t;
+  using offset_t       = std::int32_t;
+  using reduction_op_t = cuda::std::plus<>;
+  using transform_op_t = square_t<item_t>;
+
+  constexpr int max_items = 5000000;
+  constexpr int min_items = 1;
+
+  const int num_items = GENERATE_COPY(take(3, random(min_items, max_items)));
+
+  // future init value
+  auto init_value_vec = c2h::device_vector<item_t>{42};
+  auto future_init    = cub::FutureValue<item_t>(thrust::raw_pointer_cast(init_value_vec.data()));
+
+  c2h::device_vector<item_t> out(1);
+  c2h::device_vector<item_t> in(num_items + 1);
+  c2h::gen(C2H_SEED(2), in);
+
+  item_t* d_in  = thrust::raw_pointer_cast(in.data());
+  item_t* d_out = thrust::raw_pointer_cast(out.data());
+
+  const c2h::host_vector<item_t> h_in = in;
+  c2h::host_vector<item_t> h_transformed_in(h_in.size() - 1);
+
+  SECTION("when aligned")
+  {
+    // example-begin device-transform-reduce-future-value-aligned
+    device_transform_reduce(d_in, d_out, num_items, reduction_op_t{}, transform_op_t{}, future_init);
+
+    std::transform(h_in.begin(), h_in.end() - 1, h_transformed_in.begin(), transform_op_t{});
+    const item_t expected =
+      std::accumulate(h_transformed_in.begin(), h_transformed_in.end(), item_t{42});
+
+    INFO("num_items: " << num_items);
+    REQUIRE(expected == out[0]);
+    // example-end device-transform-reduce-future-value-aligned
+  }
+
+  SECTION("when unaligned")
+  {
+    // example-begin device-transform-reduce-future-value-unaligned
+    device_transform_reduce(d_in + 1, d_out, num_items, reduction_op_t{}, transform_op_t{}, future_init);
+
+    std::transform(h_in.begin() + 1, h_in.end(), h_transformed_in.begin(), transform_op_t{});
+    const item_t expected =
+      std::accumulate(h_transformed_in.begin(), h_transformed_in.end(), item_t{42});
+
+    INFO("num_items: " << num_items);
+    REQUIRE(expected == out[0]);
+    // example-end device-transform-reduce-future-value-unaligned
+  }
+}
+
 C2H_TEST("Device transform reduce works with iterators", "[reduce][device]", types)
 {
   using item_t         = c2h::get<0, TestType>;

--- a/cub/test/catch2_test_device_transform_reduce.cu
+++ b/cub/test/catch2_test_device_transform_reduce.cu
@@ -108,8 +108,7 @@ C2H_TEST("Device transform reduce with FutureValue works with pointers", "[reduc
     device_transform_reduce(d_in, d_out, num_items, reduction_op_t{}, transform_op_t{}, future_init);
 
     std::transform(h_in.begin(), h_in.end() - 1, h_transformed_in.begin(), transform_op_t{});
-    const item_t expected =
-      std::accumulate(h_transformed_in.begin(), h_transformed_in.end(), item_t{42});
+    const item_t expected = std::accumulate(h_transformed_in.begin(), h_transformed_in.end(), item_t{42});
 
     INFO("num_items: " << num_items);
     REQUIRE(expected == out[0]);
@@ -122,8 +121,7 @@ C2H_TEST("Device transform reduce with FutureValue works with pointers", "[reduc
     device_transform_reduce(d_in + 1, d_out, num_items, reduction_op_t{}, transform_op_t{}, future_init);
 
     std::transform(h_in.begin() + 1, h_in.end(), h_transformed_in.begin(), transform_op_t{});
-    const item_t expected =
-      std::accumulate(h_transformed_in.begin(), h_transformed_in.end(), item_t{42});
+    const item_t expected = std::accumulate(h_transformed_in.begin(), h_transformed_in.end(), item_t{42});
 
     INFO("num_items: " << num_items);
     REQUIRE(expected == out[0]);


### PR DESCRIPTION
## Description
Closes #9133
- Add overloads for `DeviceReduce::Reduce` and `DeviceReduce::TransformReduce` that accept `cub::FutureValue<T>` for device-resident initial values in `cub/cub/device/device_reduce.cuh`
- Add tests for the `cub::FutureValue<T>` supported overloads in:
    - `cub\test\catch2_test_device_reduce.cu`
    - `cub\test\catch2_test_device_transform_reduce.cu`
    - `cub\test\catch2_test_device_reduce_env.cu`
    - `cub\test\catch2_test_device_reduce_large_offsets.cu`
    - `cub\test\catch2_test_device_reduce_iterators.cu`
    - `cub\test\catch2_test_device_reduce_env_api.cu`

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.