### PR TITLE
Remove __syncthreads() duplicate from agent_radix_histogram

### DIFF
--- a/cub/cub/agent/agent_radix_sort_histogram.cuh
+++ b/cub/cub/agent/agent_radix_sort_histogram.cuh
@@ -242,7 +242,6 @@ struct AgentRadixSortHistogram
     {
       // Reset the counters.
       Init();
-      __syncthreads();
 
       // Process the tiles.
       OffsetT portion_offset = portion * MAX_PORTION_SIZE;


### PR DESCRIPTION
`Init()` already has a `__syncthreads()` at the end. No need to put another one right after its calling line.


https://github.com/NVIDIA/cccl/blob/8c0e6cb1b6412d7bd0070f9ac3f55fa80231961a/cub/cub/agent/agent_radix_sort_histogram.cuh#L152-L169

kinda touches #9247 but its small. Also it's very critical for perf and functionality that's why I open separately