### PR TITLE
[CUB] Refactor `cub::DeviceSelect::If` to always take an environment

### DIFF
--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -463,14 +463,15 @@ struct DeviceSelect
             typename OutputIteratorT,
             typename NumSelectedIteratorT,
             typename SelectOp,
-            typename EnvT = ::cuda::std::execution::env<>>
+            typename EnvT = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<::cuda::std::indirect_unary_predicate<SelectOp, InputIteratorT>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
   If(InputIteratorT d_in,
      OutputIteratorT d_out,
      NumSelectedIteratorT d_num_selected_out,
      ::cuda::std::int64_t num_items,
      SelectOp select_op,
-     EnvT env = {})
+     const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSelect::If");
 
@@ -552,13 +553,14 @@ struct DeviceSelect
   template <typename IteratorT,
             typename NumSelectedIteratorT,
             typename SelectOp,
-            typename EnvT = ::cuda::std::execution::env<>>
+            typename EnvT = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<::cuda::std::indirect_unary_predicate<SelectOp, IteratorT>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
   If(IteratorT d_data,
      NumSelectedIteratorT d_num_selected_out,
      ::cuda::std::int64_t num_items,
      SelectOp select_op,
-     EnvT env = {})
+     const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSelect::If");
 
@@ -782,6 +784,9 @@ struct DeviceSelect
   //! @tparam SelectOp
   //!   **[inferred]** Selection operator type having member `bool operator()(const T &a)`
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., `cuda::std::execution::env<...>`)
+  //!
   //! @param[in] d_temp_storage
   //!   @devicestorage
   //!
@@ -804,11 +809,14 @@ struct DeviceSelect
   //! @param[in] select_op
   //!   Unary selection operator
   //!
-  //! @param[in] stream
-  //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
-  //!   @endrst
-  template <typename InputIteratorT, typename OutputIteratorT, typename NumSelectedIteratorT, typename SelectOp>
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename NumSelectedIteratorT,
+            typename SelectOp,
+            typename EnvT = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<::cuda::std::indirect_unary_predicate<SelectOp, InputIteratorT>, int> = 0>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
   If(void* d_temp_storage,
      size_t& temp_storage_bytes,
@@ -817,23 +825,27 @@ struct DeviceSelect
      NumSelectedIteratorT d_num_selected_out,
      ::cuda::std::int64_t num_items,
      SelectOp select_op,
-     cudaStream_t stream = nullptr)
+     const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSelect::If");
 
-    using EqualityOp = NullType; // Equality operator (not used)
-
-    return detail::select::dispatch<SelectImpl::Select, InputIteratorT>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_in,
-      static_cast<NullType*>(nullptr),
-      d_out,
-      d_num_selected_out,
-      select_op,
-      EqualityOp{},
-      num_items,
-      stream);
+    using default_policy_selector = detail::select::
+      policy_selector_from_types<InputIteratorT, NullType*, OutputIteratorT, ::cuda::std::int64_t, SelectImpl::Select>;
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      d_temp_storage, temp_storage_bytes, env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::select::dispatch<SelectImpl::Select>(
+          storage,
+          bytes,
+          d_in,
+          static_cast<NullType*>(nullptr),
+          d_out,
+          d_num_selected_out,
+          select_op,
+          NullType{},
+          num_items,
+          stream,
+          policy_selector);
+      });
   }
 
   //! @rst
@@ -907,6 +919,9 @@ struct DeviceSelect
   //! @tparam SelectOp
   //!   **[inferred]** Selection operator type having member `bool operator()(const T &a)`
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., `cuda::std::execution::env<...>`)
+  //!
   //! @param[in] d_temp_storage
   //!   @devicestorage
   //!
@@ -925,11 +940,13 @@ struct DeviceSelect
   //! @param[in] select_op
   //!   Unary selection operator
   //!
-  //! @param[in] stream
-  //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
-  //!   @endrst
-  template <typename IteratorT, typename NumSelectedIteratorT, typename SelectOp>
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  template <typename IteratorT,
+            typename NumSelectedIteratorT,
+            typename SelectOp,
+            typename EnvT = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<::cuda::std::indirect_unary_predicate<SelectOp, IteratorT>, int> = 0>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
   If(void* d_temp_storage,
      size_t& temp_storage_bytes,
@@ -937,23 +954,31 @@ struct DeviceSelect
      NumSelectedIteratorT d_num_selected_out,
      ::cuda::std::int64_t num_items,
      SelectOp select_op,
-     cudaStream_t stream = nullptr)
+     const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSelect::If");
 
-    using EqualityOp = NullType; // Equality operator (not used)
-
-    return detail::select::dispatch<SelectImpl::SelectPotentiallyInPlace>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_data,
-      static_cast<NullType*>(nullptr),
-      d_data,
-      d_num_selected_out,
-      select_op,
-      EqualityOp{},
-      num_items,
-      stream);
+    using default_policy_selector = detail::select::policy_selector_from_types<
+      IteratorT,
+      NullType*,
+      IteratorT,
+      ::cuda::std::int64_t,
+      SelectImpl::SelectPotentiallyInPlace>;
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      d_temp_storage, temp_storage_bytes, env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::select::dispatch<SelectImpl::SelectPotentiallyInPlace>(
+          storage,
+          bytes,
+          d_data,
+          static_cast<NullType*>(nullptr),
+          d_data,
+          d_num_selected_out,
+          select_op,
+          NullType{},
+          num_items,
+          stream,
+          policy_selector);
+      });
   }
 
   //! @rst

--- a/cub/test/catch2_test_device_select_if.cu
+++ b/cub/test/catch2_test_device_select_if.cu
@@ -13,8 +13,10 @@
 #include <thrust/partition.h>
 #include <thrust/reverse.h>
 
+#include <cuda/devices>
 #include <cuda/functional>
 #include <cuda/iterator>
+#include <cuda/std/execution>
 #include <cuda/std/limits>
 
 #include <algorithm>
@@ -166,6 +168,189 @@ C2H_TEST("DeviceSelect::If is stable", "[device][select_if]")
   reference.resize(num_selected_out[0]);
   REQUIRE(reference == out);
 }
+
+#if TEST_LAUNCH == 0
+C2H_TEST("DeviceSelect::If works with user provided memory and environment", "[device][select_if]", all_types)
+{
+  using type = typename c2h::get<0, TestType>;
+
+  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
+  c2h::device_vector<type> in(num_items, thrust::default_init);
+  c2h::device_vector<type> out(num_items); // value-initialized to ensure we do not overwrite beyond the boundary
+  c2h::gen(C2H_SEED(2), in);
+
+  // just pick one of the input elements as boundary
+  less_than_t<type> le{in[num_items / 2]};
+
+  // Needs to be device accessible
+  c2h::device_vector<int> num_selected_out(1, 0);
+  int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
+
+  size_t expected_allocation_size = 0;
+  auto error                      = cub::DeviceSelect::If(
+    static_cast<void*>(nullptr),
+    expected_allocation_size,
+    in.begin(),
+    out.begin(),
+    d_first_num_selected_out,
+    num_items,
+    le);
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  auto d_temp        = c2h::device_vector<uint8_t>(expected_allocation_size, thrust::no_init);
+  void* temp_storage = thrust::raw_pointer_cast(d_temp.data());
+
+  auto test_select_if = [&](const auto& env) {
+    size_t num_bytes = 0;
+    error            = cub::DeviceSelect::If(
+      static_cast<void*>(nullptr), num_bytes, in.begin(), out.begin(), d_first_num_selected_out, num_items, le, env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+    REQUIRE(expected_allocation_size == num_bytes);
+
+    error = cub::DeviceSelect::If(
+      temp_storage, num_bytes, in.begin(), out.begin(), d_first_num_selected_out, num_items, le, env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    const auto boundary = out.begin() + num_selected_out[0];
+    REQUIRE(thrust::all_of(c2h::device_policy, out.begin(), boundary, le));
+    REQUIRE(thrust::all_of(c2h::device_policy, boundary, out.end(), cuda::equal_to_value{type{}}));
+  };
+
+  int current_device;
+  error = cudaGetDevice(&current_device);
+  REQUIRE(error == cudaSuccess);
+
+  SECTION("DeviceSelect::If works with cudaStream_t")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_select_if(stream.get());
+  }
+
+  SECTION("DeviceSelect::If works with cuda::stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_select_if(stream);
+  }
+
+  SECTION("DeviceSelect::If works with cuda::stream_ref")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    cuda::stream_ref stream_ref{stream};
+    test_select_if(stream_ref);
+  }
+
+  SECTION("DeviceSelect::If works with cuda::std::execution::env")
+  {
+    cuda::std::execution::env env{};
+    test_select_if(env);
+  }
+
+  SECTION("DeviceSelect::If works with cuda::execution::gpu")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_select_if(policy);
+  }
+
+  SECTION("DeviceSelect::If works with cuda::execution::gpu with stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_select_if(policy);
+  }
+}
+
+C2H_TEST("DeviceSelect::If works in place with user provided memory and environment", "[device][select_if]", all_types)
+{
+  using type = typename c2h::get<0, TestType>;
+
+  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
+  c2h::device_vector<type> in(num_items, thrust::default_init);
+  c2h::gen(C2H_SEED(2), in);
+
+  // just pick one of the input elements as boundary
+  less_than_t<type> le{in[num_items / 2]};
+
+  // Needs to be device accessible
+  c2h::device_vector<int> num_selected_out(1, 0);
+  int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
+
+  size_t expected_allocation_size = 0;
+  auto error                      = cub::DeviceSelect::If(
+    static_cast<void*>(nullptr), expected_allocation_size, in.begin(), d_first_num_selected_out, num_items, le);
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  auto d_temp        = c2h::device_vector<uint8_t>(expected_allocation_size, thrust::no_init);
+  void* temp_storage = thrust::raw_pointer_cast(d_temp.data());
+
+  auto test_select_if = [&](const auto& env) {
+    size_t num_bytes = 0;
+    error            = cub::DeviceSelect::If(
+      static_cast<void*>(nullptr), num_bytes, in.begin(), d_first_num_selected_out, num_items, le, env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+    REQUIRE(expected_allocation_size == num_bytes);
+
+    error = cub::DeviceSelect::If(temp_storage, num_bytes, in.begin(), d_first_num_selected_out, num_items, le, env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    const auto boundary = in.begin() + num_selected_out[0];
+    REQUIRE(thrust::all_of(c2h::device_policy, in.begin(), boundary, le));
+  };
+
+  int current_device;
+  error = cudaGetDevice(&current_device);
+  REQUIRE(error == cudaSuccess);
+
+  SECTION("DeviceSelect::If works with cudaStream_t")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_select_if(stream.get());
+  }
+
+  SECTION("DeviceSelect::If works with cuda::stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_select_if(stream);
+  }
+
+  SECTION("DeviceSelect::If works with cuda::stream_ref")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    cuda::stream_ref stream_ref{stream};
+    test_select_if(stream_ref);
+  }
+
+  SECTION("DeviceSelect::If works with cuda::std::execution::env")
+  {
+    cuda::std::execution::env env{};
+    test_select_if(env);
+  }
+
+  SECTION("DeviceSelect::If works with cuda::execution::gpu")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_select_if(policy);
+  }
+
+  SECTION("DeviceSelect::If works with cuda::execution::gpu with stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_select_if(policy);
+  }
+}
+#endif // TEST_LAUNCH == 0
 
 C2H_TEST("DeviceSelect::If works with iterators", "[device][select_if]", all_types)
 {

--- a/libcudacxx/include/cuda/std/__pstl/cuda/copy_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/copy_if.h
@@ -77,19 +77,18 @@ struct __pstl_dispatch<__pstl_algorithm::__copy_if, __execution_backend::__cuda>
     _OffsetType __ret;
 
     // Determine temporary device storage requirements
-    void* __temp_storage = nullptr;
-    size_t __num_bytes   = 0;
+    size_t __num_bytes = 0;
     _CCCL_TRY_CUDA_API(
       CUB_NS_QUALIFIER::DeviceSelect::If,
       "__pstl_cuda_select_if: determination of device storage for cub::DeviceSelect::If failed",
-      __temp_storage,
+      static_cast<void*>(nullptr),
       __num_bytes,
       __first,
       __result,
       static_cast<_OffsetType*>(nullptr),
       __count,
       __pred,
-      __stream.get());
+      __policy);
 
     {
       __temporary_storage<_OffsetType> __storage{__policy, __num_bytes, 1};
@@ -102,17 +101,17 @@ struct __pstl_dispatch<__pstl_algorithm::__copy_if, __execution_backend::__cuda>
         __num_bytes,
         ::cuda::std::move(__first),
         __result,
-        __storage.template __get_ptr<0>(),
+        __storage.template __get_raw_ptr<0>(),
         __count,
         ::cuda::std::move(__pred),
-        __stream.get());
+        __policy);
 
       // Copy the result back from storage
       _CCCL_TRY_CUDA_API(
         ::cudaMemcpyAsync,
         "__pstl_cuda_select_if: copy of result from device to host failed",
         ::cuda::std::addressof(__ret),
-        __storage.template __get_ptr<0>(),
+        __storage.template __get_raw_ptr<0>(),
         sizeof(_OffsetType),
         ::cudaMemcpyDefault,
         __stream.get());

--- a/libcudacxx/include/cuda/std/__pstl/cuda/remove_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/remove_if.h
@@ -71,18 +71,17 @@ struct __pstl_dispatch<__pstl_algorithm::__remove_if, __execution_backend::__cud
     _OffsetType __ret;
 
     // Determine temporary device storage requirements
-    void* __temp_storage = nullptr;
-    size_t __num_bytes   = 0;
+    size_t __num_bytes = 0;
     _CCCL_TRY_CUDA_API(
       CUB_NS_QUALIFIER::DeviceSelect::If,
       "__pstl_cuda_select_if: determination of device storage for cub::DeviceSelect::If failed",
-      __temp_storage,
+      static_cast<void*>(nullptr),
       __num_bytes,
       __first,
       static_cast<_OffsetType*>(nullptr),
       __count,
       __pred,
-      __stream.get());
+      __policy);
 
     {
       __temporary_storage<_OffsetType> __storage{__policy, __num_bytes, 1};
@@ -94,17 +93,17 @@ struct __pstl_dispatch<__pstl_algorithm::__remove_if, __execution_backend::__cud
         __storage.__get_temp_storage(),
         __num_bytes,
         ::cuda::std::move(__first),
-        __storage.template __get_ptr<0>(),
+        __storage.template __get_raw_ptr<0>(),
         __count,
         ::cuda::std::move(__pred),
-        __stream.get());
+        __policy);
 
       // Copy the result back from storage
       _CCCL_TRY_CUDA_API(
         ::cudaMemcpyAsync,
         "__pstl_cuda_select_if: copy of result from device to host failed",
         ::cuda::std::addressof(__ret),
-        __storage.template __get_ptr<0>(),
+        __storage.template __get_raw_ptr<0>(),
         sizeof(_OffsetType),
         ::cudaMemcpyDefault,
         __stream.get());

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove.cu
@@ -65,6 +65,7 @@ void test_remove(const Policy& policy, c2h::device_vector<T>& input)
     CHECK(cuda::std::distance(random_access_iterator{raw_pointer}, res) == size - 1);
   }
 
+#if !TEST_COMPILER(GCC, <, 8) // GCC7 complains bitterly about signed unsignned comparisons
   if constexpr (::cuda::std::__is_cpp17_equality_comparable_v<T, int>)
   {
     thrust::sequence(input.begin(), input.end(), static_cast<T>(0));
@@ -84,6 +85,7 @@ void test_remove(const Policy& policy, c2h::device_vector<T>& input)
       CHECK(cuda::std::distance(random_access_iterator{raw_pointer}, res) == size - 1);
     }
   }
+#endif // ! TEST_COMPILER(GCC , <, 8)
 }
 
 C2H_TEST("cuda::std::remove", "[parallel algorithm]", all_types)

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove_copy.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove_copy.cu
@@ -82,6 +82,7 @@ void test_remove_copy(const Policy& policy,
     CHECK(cuda::std::distance(output.begin(), res) == size - 1);
   }
 
+#if !TEST_COMPILER(GCC, <, 8) // GCC7 complains bitterly about signed unsignned comparisons
   if constexpr (::cuda::std::__is_cpp17_equality_comparable_v<T, int>)
   {
     cuda::std::fill(policy, output.begin(), output.end(), 0);
@@ -101,6 +102,7 @@ void test_remove_copy(const Policy& policy,
       CHECK(cuda::std::distance(output.begin(), res) == size - 1);
     }
   }
+#endif // !TEST_COMPILER(GCC, <, 8)
 
   cuda::std::fill(policy, output.begin(), output.end(), 0);
   { // contiguous iterator, converting input sequence


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.