### PR TITLE
[CUB] Refactor `DeviceSelect::UniqueByKey` to always take an environment

### DIFF
--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -1897,17 +1897,18 @@ struct DeviceSelect
   //!
   //! @param[in] env
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
-  template <typename KeyInputIteratorT,
-            typename ValueInputIteratorT,
-            typename KeyOutputIteratorT,
-            typename ValueOutputIteratorT,
-            typename NumSelectedIteratorT,
-            typename NumItemsT,
-            typename EqualityOpT,
-            typename EnvT                 = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>&& ::cuda::std::
-                                       indirect_binary_predicate<EqualityOpT, KeyInputIteratorT, KeyInputIteratorT>,
-                                     int> = 0>
+  template <
+    typename KeyInputIteratorT,
+    typename ValueInputIteratorT,
+    typename KeyOutputIteratorT,
+    typename ValueOutputIteratorT,
+    typename NumSelectedIteratorT,
+    typename NumItemsT,
+    typename EqualityOpT,
+    typename EnvT                                                        = ::cuda::std::execution::env<>,
+    ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0,
+    ::cuda::std::enable_if_t<::cuda::std::indirect_binary_predicate<EqualityOpT, KeyInputIteratorT, KeyInputIteratorT>,
+                             int>                                        = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t UniqueByKey(
     KeyInputIteratorT d_keys_in,
     ValueInputIteratorT d_values_in,
@@ -1916,7 +1917,7 @@ struct DeviceSelect
     NumSelectedIteratorT d_num_selected_out,
     NumItemsT num_items,
     EqualityOpT equality_op,
-    EnvT env = {})
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceSelect::UniqueByKey");
 
@@ -2025,10 +2026,10 @@ struct DeviceSelect
     typename ValueOutputIteratorT,
     typename NumSelectedIteratorT,
     typename NumItemsT,
-    typename EnvT                 = ::cuda::std::execution::env<>,
-    ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>
-                               && !::cuda::std::indirect_binary_predicate<EnvT, KeyInputIteratorT, KeyInputIteratorT>,
-                             int> = 0>
+    typename EnvT                                                        = ::cuda::std::execution::env<>,
+    ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0,
+    ::cuda::std::enable_if_t<!::cuda::std::indirect_binary_predicate<EnvT, KeyInputIteratorT, KeyInputIteratorT>, int> =
+      0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t UniqueByKey(
     KeyInputIteratorT d_keys_in,
     ValueInputIteratorT d_values_in,
@@ -2036,7 +2037,7 @@ struct DeviceSelect
     ValueOutputIteratorT d_values_out,
     NumSelectedIteratorT d_num_selected_out,
     NumItemsT num_items,
-    EnvT env = {})
+    const EnvT& env = {})
   {
     return UniqueByKey(
       d_keys_in, d_values_in, d_keys_out, d_values_out, d_num_selected_out, num_items, ::cuda::std::equal_to<>{}, env);
@@ -2566,6 +2567,9 @@ struct DeviceSelect
   //! @tparam EqualityOpT
   //!   **[inferred]** Type of equality_op
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., `cuda::std::execution::env<...>`)
+  //!
   //! @param[in] d_temp_storage
   //!   @devicestorage
   //!
@@ -2593,48 +2597,54 @@ struct DeviceSelect
   //! @param[in] equality_op
   //!   Binary predicate to determine equality
   //!
-  //! @param[in] stream
-  //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
-  //!   @endrst
-  template <typename KeyInputIteratorT,
-            typename ValueInputIteratorT,
-            typename KeyOutputIteratorT,
-            typename ValueOutputIteratorT,
-            typename NumSelectedIteratorT,
-            typename NumItemsT,
-            typename EqualityOpT>
-  CUB_RUNTIME_FUNCTION __forceinline__ static //
-    ::cuda::std::enable_if_t< //
-      !::cuda::std::is_convertible_v<EqualityOpT, cudaStream_t>, //
-      cudaError_t>
-    UniqueByKey(
-      void* d_temp_storage,
-      size_t& temp_storage_bytes,
-      KeyInputIteratorT d_keys_in,
-      ValueInputIteratorT d_values_in,
-      KeyOutputIteratorT d_keys_out,
-      ValueOutputIteratorT d_values_out,
-      NumSelectedIteratorT d_num_selected_out,
-      NumItemsT num_items,
-      EqualityOpT equality_op,
-      cudaStream_t stream = nullptr)
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  template <
+    typename KeyInputIteratorT,
+    typename ValueInputIteratorT,
+    typename KeyOutputIteratorT,
+    typename ValueOutputIteratorT,
+    typename NumSelectedIteratorT,
+    typename NumItemsT,
+    typename EqualityOpT,
+    typename EnvT                                                        = ::cuda::std::execution::env<>,
+    ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0,
+    ::cuda::std::enable_if_t<::cuda::std::indirect_binary_predicate<EqualityOpT, KeyInputIteratorT, KeyInputIteratorT>,
+                             int>                                        = 0>
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t UniqueByKey(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    KeyInputIteratorT d_keys_in,
+    ValueInputIteratorT d_values_in,
+    KeyOutputIteratorT d_keys_out,
+    ValueOutputIteratorT d_values_out,
+    NumSelectedIteratorT d_num_selected_out,
+    NumItemsT num_items,
+    EqualityOpT equality_op,
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSelect::UniqueByKey");
 
     using offset_t = detail::choose_offset_t<NumItemsT>;
 
-    return detail::unique_by_key::dispatch(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_keys_in,
-      d_values_in,
-      d_keys_out,
-      d_values_out,
-      d_num_selected_out,
-      equality_op,
-      static_cast<offset_t>(num_items),
-      stream);
+    using default_policy_selector =
+      detail::unique_by_key::policy_selector_from_types<detail::it_value_t<KeyInputIteratorT>,
+                                                        detail::it_value_t<ValueInputIteratorT>>;
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      d_temp_storage, temp_storage_bytes, env, [&](auto policy_selector, void* storage, size_t& bytes, auto stream) {
+        return detail::unique_by_key::dispatch(
+          storage,
+          bytes,
+          d_keys_in,
+          d_values_in,
+          d_keys_out,
+          d_values_out,
+          d_num_selected_out,
+          equality_op,
+          static_cast<offset_t>(num_items),
+          stream,
+          policy_selector);
+      });
   }
 
   //! @rst
@@ -2720,6 +2730,9 @@ struct DeviceSelect
   //! @tparam NumItemsT
   //!   **[inferred]** Type of num_items
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., `cuda::std::execution::env<...>`)
+  //!
   //! @param[in] d_temp_storage
   //!   @devicestorage
   //!
@@ -2744,17 +2757,20 @@ struct DeviceSelect
   //! @param[in] num_items
   //!   Total number of input items (i.e., length of `d_keys_in` or `d_values_in`)
   //!
-  //! @param[in] stream
-  //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
-  //!   @endrst
-  template <typename KeyInputIteratorT,
-            typename ValueInputIteratorT,
-            typename KeyOutputIteratorT,
-            typename ValueOutputIteratorT,
-            typename NumSelectedIteratorT,
-            typename NumItemsT>
-  CUB_RUNTIME_FUNCTION __forceinline__ static cudaError_t UniqueByKey(
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  template <
+    typename KeyInputIteratorT,
+    typename ValueInputIteratorT,
+    typename KeyOutputIteratorT,
+    typename ValueOutputIteratorT,
+    typename NumSelectedIteratorT,
+    typename NumItemsT,
+    typename EnvT                                                        = ::cuda::std::execution::env<>,
+    ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0,
+    ::cuda::std::enable_if_t<!::cuda::std::indirect_binary_predicate<EnvT, KeyInputIteratorT, KeyInputIteratorT>, int> =
+      0>
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t UniqueByKey(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeyInputIteratorT d_keys_in,
@@ -2763,7 +2779,7 @@ struct DeviceSelect
     ValueOutputIteratorT d_values_out,
     NumSelectedIteratorT d_num_selected_out,
     NumItemsT num_items,
-    cudaStream_t stream = nullptr)
+    const EnvT& env = {})
   {
     return UniqueByKey(
       d_temp_storage,
@@ -2775,7 +2791,7 @@ struct DeviceSelect
       d_num_selected_out,
       num_items,
       ::cuda::std::equal_to<>{},
-      stream);
+      env);
   }
 };
 

--- a/cub/test/catch2_test_device_select_unique_by_key_env.cu
+++ b/cub/test/catch2_test_device_select_unique_by_key_env.cu
@@ -1,0 +1,336 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "insert_nested_NVTX_range_guard.h"
+
+#include <cub/device/device_select.cuh>
+
+#include <thrust/detail/raw_pointer_cast.h>
+
+#include <cuda/devices>
+#include <cuda/iterator>
+#include <cuda/std/execution>
+
+#include <algorithm>
+
+#include <c2h/catch2_test_helper.h>
+
+template <class T>
+inline T to_bound(const unsigned long long bound)
+{
+  return static_cast<T>(bound);
+}
+
+template <>
+inline ulonglong2 to_bound(const unsigned long long bound)
+{
+  return {bound, bound};
+}
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+_CCCL_SUPPRESS_DEPRECATED_NVRTC_DIAG
+template <>
+inline ulonglong4 to_bound(const unsigned long long bound)
+{
+  return {bound, bound, bound, bound};
+}
+_CCCL_SUPPRESS_DEPRECATED_POP
+
+#if _CCCL_CTK_AT_LEAST(13, 0)
+template <>
+inline ulonglong4_16a to_bound(const unsigned long long bound)
+{
+  return {bound, bound, bound, bound};
+}
+#endif // _CCCL_CTK_AT_LEAST(13, 0)
+
+template <>
+inline long2 to_bound(const unsigned long long bound)
+{
+  return {static_cast<long>(bound), static_cast<long>(bound)};
+}
+
+template <>
+inline c2h::custom_type_t<c2h::equal_comparable_t> to_bound(const unsigned long long bound)
+{
+  c2h::custom_type_t<c2h::equal_comparable_t> val;
+  val.key = bound;
+  val.val = bound;
+  return val;
+}
+template <typename EqualityOpT>
+struct project_first
+{
+  EqualityOpT equality_op;
+  template <typename Tuple>
+  __host__ __device__ bool operator()(const Tuple& lhs, const Tuple& rhs) const
+  {
+    return equality_op(cuda::std::get<0>(lhs), cuda::std::get<0>(rhs));
+  }
+};
+
+template <typename T>
+struct custom_equality_op
+{
+  T div_val;
+  __host__ __device__ __forceinline__ bool operator()(const T& lhs, const T& rhs) const
+  {
+    return (lhs / div_val) == (rhs / div_val);
+  }
+};
+
+C2H_TEST("DeviceSelect::UniqueByKey works with user provided memory and environment", "[device][select_unique_by_key]")
+{
+  using type     = int;
+  using val_type = c2h::custom_type_t<c2h::equal_comparable_t>;
+
+  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
+  c2h::device_vector<type> keys_in(num_items, thrust::default_init);
+  c2h::device_vector<val_type> vals_in(num_items, thrust::default_init);
+  c2h::device_vector<type> keys_out(num_items, thrust::default_init);
+  c2h::device_vector<val_type> vals_out(num_items, thrust::default_init);
+  c2h::gen(C2H_SEED(2), keys_in, to_bound<type>(0), to_bound<type>(42));
+  c2h::gen(C2H_SEED(1), vals_in);
+
+  // Needs to be device accessible
+  c2h::device_vector<int> num_selected_out(1, 0);
+  int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
+
+  size_t expected_allocation_size = 0;
+  auto error                      = cub::DeviceSelect::UniqueByKey(
+    static_cast<void*>(nullptr),
+    expected_allocation_size,
+    keys_in.begin(),
+    vals_in.begin(),
+    keys_out.begin(),
+    vals_out.begin(),
+    d_first_num_selected_out,
+    num_items);
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  auto d_temp        = c2h::device_vector<uint8_t>(expected_allocation_size, thrust::no_init);
+  void* temp_storage = thrust::raw_pointer_cast(d_temp.data());
+
+  auto test_unique_by_key = [&](const auto& env) {
+    size_t num_bytes = 0;
+    error            = cub::DeviceSelect::UniqueByKey(
+      static_cast<void*>(nullptr),
+      num_bytes,
+      keys_in.begin(),
+      vals_in.begin(),
+      keys_out.begin(),
+      vals_out.begin(),
+      d_first_num_selected_out,
+      num_items,
+      env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+    REQUIRE(expected_allocation_size == num_bytes);
+
+    error = cub::DeviceSelect::UniqueByKey(
+      temp_storage,
+      num_bytes,
+      keys_in.begin(),
+      vals_in.begin(),
+      keys_out.begin(),
+      vals_out.begin(),
+      d_first_num_selected_out,
+      num_items,
+      env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    // Ensure that we create the same output as std
+    c2h::host_vector<type> reference_keys     = keys_in;
+    c2h::host_vector<val_type> reference_vals = vals_in;
+    const auto zip_begin                      = cuda::make_zip_iterator(reference_keys.begin(), reference_vals.begin());
+    const auto zip_end                        = cuda::make_zip_iterator(reference_keys.end(), reference_vals.end());
+    const auto boundary =
+      std::unique(zip_begin, zip_end, project_first<cuda::std::equal_to<>>{cuda::std::equal_to<>{}});
+
+    keys_out.resize(num_selected_out[0]);
+    vals_out.resize(num_selected_out[0]);
+    reference_keys.resize(num_selected_out[0]);
+    reference_vals.resize(num_selected_out[0]);
+    REQUIRE(static_cast<int>(boundary - zip_begin) == num_selected_out[0]);
+    REQUIRE(reference_keys == keys_out);
+    REQUIRE(reference_vals == vals_out);
+  };
+
+  int current_device;
+  error = cudaGetDevice(&current_device);
+  REQUIRE(error == cudaSuccess);
+
+  SECTION("DeviceSelect::UniqueByKey works with cudaStream_t")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_unique_by_key(stream.get());
+  }
+
+  SECTION("DeviceSelect::UniqueByKey works with cuda::stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_unique_by_key(stream);
+  }
+
+  SECTION("DeviceSelect::UniqueByKey works with cuda::stream_ref")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    cuda::stream_ref stream_ref{stream};
+    test_unique_by_key(stream_ref);
+  }
+
+  SECTION("DeviceSelect::UniqueByKey works with cuda::std::execution::env")
+  {
+    cuda::std::execution::env env{};
+    test_unique_by_key(env);
+  }
+
+  SECTION("DeviceSelect::UniqueByKey works with cuda::execution::gpu")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_unique_by_key(policy);
+  }
+
+  SECTION("DeviceSelect::UniqueByKey works with cuda::execution::gpu with stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_unique_by_key(policy);
+  }
+}
+
+C2H_TEST("DeviceSelect::UniqueByKey works with user provided operator, memory and environment",
+         "[device][select_unique_by_key]")
+{
+  using type        = int;
+  using custom_op_t = custom_equality_op<type>;
+  using val_type    = c2h::custom_type_t<c2h::equal_comparable_t>;
+
+  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
+  c2h::device_vector<type> keys_in(num_items, thrust::default_init);
+  c2h::device_vector<val_type> vals_in(num_items, thrust::default_init);
+  c2h::device_vector<type> keys_out(num_items, thrust::default_init);
+  c2h::device_vector<val_type> vals_out(num_items, thrust::default_init);
+  c2h::gen(C2H_SEED(2), keys_in, to_bound<type>(0), to_bound<type>(42));
+  c2h::gen(C2H_SEED(1), vals_in);
+
+  // Needs to be device accessible
+  c2h::device_vector<int> num_selected_out(1, 0);
+  int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
+
+  custom_op_t op{static_cast<type>(8)};
+
+  size_t expected_allocation_size = 0;
+  auto error                      = cub::DeviceSelect::UniqueByKey(
+    static_cast<void*>(nullptr),
+    expected_allocation_size,
+    keys_in.begin(),
+    vals_in.begin(),
+    keys_out.begin(),
+    vals_out.begin(),
+    d_first_num_selected_out,
+    num_items,
+    op);
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  auto d_temp        = c2h::device_vector<uint8_t>(expected_allocation_size, thrust::no_init);
+  void* temp_storage = thrust::raw_pointer_cast(d_temp.data());
+
+  auto test_unique_by_key = [&](const auto& env) {
+    size_t num_bytes = 0;
+    error            = cub::DeviceSelect::UniqueByKey(
+      static_cast<void*>(nullptr),
+      num_bytes,
+      keys_in.begin(),
+      vals_in.begin(),
+      keys_out.begin(),
+      vals_out.begin(),
+      d_first_num_selected_out,
+      num_items,
+      op,
+      env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+    REQUIRE(expected_allocation_size == num_bytes);
+
+    error = cub::DeviceSelect::UniqueByKey(
+      temp_storage,
+      num_bytes,
+      keys_in.begin(),
+      vals_in.begin(),
+      keys_out.begin(),
+      vals_out.begin(),
+      d_first_num_selected_out,
+      num_items,
+      op,
+      env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    // Ensure that we create the same output as std
+    c2h::host_vector<type> reference_keys     = keys_in;
+    c2h::host_vector<val_type> reference_vals = vals_in;
+    const auto zip_begin                      = cuda::make_zip_iterator(reference_keys.begin(), reference_vals.begin());
+    const auto zip_end                        = cuda::make_zip_iterator(reference_keys.end(), reference_vals.end());
+    const auto boundary                       = std::unique(zip_begin, zip_end, project_first<custom_op_t>{op});
+
+    keys_out.resize(num_selected_out[0]);
+    vals_out.resize(num_selected_out[0]);
+    reference_keys.resize(num_selected_out[0]);
+    reference_vals.resize(num_selected_out[0]);
+    REQUIRE(static_cast<int>(boundary - zip_begin) == num_selected_out[0]);
+    REQUIRE(reference_keys == keys_out);
+    REQUIRE(reference_vals == vals_out);
+  };
+
+  int current_device;
+  error = cudaGetDevice(&current_device);
+  REQUIRE(error == cudaSuccess);
+
+  SECTION("DeviceSelect::UniqueByKey works with cudaStream_t")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_unique_by_key(stream.get());
+  }
+
+  SECTION("DeviceSelect::UniqueByKey works with cuda::stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_unique_by_key(stream);
+  }
+
+  SECTION("DeviceSelect::UniqueByKey works with cuda::stream_ref")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    cuda::stream_ref stream_ref{stream};
+    test_unique_by_key(stream_ref);
+  }
+
+  SECTION("DeviceSelect::UniqueByKey works with cuda::std::execution::env")
+  {
+    cuda::std::execution::env env{};
+    test_unique_by_key(env);
+  }
+
+  SECTION("DeviceSelect::UniqueByKey works with cuda::execution::gpu")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_unique_by_key(policy);
+  }
+
+  SECTION("DeviceSelect::UniqueByKey works with cuda::execution::gpu with stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_unique_by_key(policy);
+  }
+}

--- a/thrust/testing/unique_by_key.cu
+++ b/thrust/testing/unique_by_key.cu
@@ -467,8 +467,8 @@ namespace
 {
 struct CompareFirst
 {
-  template <typename T, typename U>
-  _CCCL_HOST_DEVICE bool operator()(::cuda::std::pair<T, U> const& lhs, ::cuda::std::pair<T, U> const& rhs) const
+  template <typename T>
+  _CCCL_HOST_DEVICE bool operator()(T const& lhs, T const& rhs) const
   {
     return lhs.first == rhs.first;
   }

--- a/thrust/testing/unique_by_key.cu
+++ b/thrust/testing/unique_by_key.cu
@@ -467,8 +467,8 @@ namespace
 {
 struct CompareFirst
 {
-  template <typename T>
-  _CCCL_HOST_DEVICE bool operator()(T const& lhs, T const& rhs) const
+  template <typename T, typename U>
+  _CCCL_HOST_DEVICE bool operator()(::cuda::std::pair<T, U> const& lhs, ::cuda::std::pair<T, U> const& rhs) const
   {
     return lhs.first == rhs.first;
   }

--- a/thrust/thrust/system/cuda/detail/unique_by_key.h
+++ b/thrust/thrust/system/cuda/detail/unique_by_key.h
@@ -22,6 +22,7 @@
 #  include <cub/util_temporary_storage.cuh>
 
 #  include <thrust/detail/alignment.h>
+#  include <thrust/detail/function.h>
 #  include <thrust/detail/temporary_array.h>
 #  include <thrust/functional.h>
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
@@ -81,6 +82,8 @@ THRUST_RUNTIME_FUNCTION cudaError_t unique_by_key_impl(
   std::size_t allocation_sizes[2] = {0, sizeof(OffsetT)};
   void* allocations[2]            = {nullptr, nullptr};
 
+  thrust::detail::wrapped_function<BinaryPred, bool> wrapped_pred{binary_pred};
+
   // Query temp storage
   cudaError_t status = cub::DeviceSelect::UniqueByKey(
     nullptr,
@@ -91,7 +94,7 @@ THRUST_RUNTIME_FUNCTION cudaError_t unique_by_key_impl(
     values_result,
     static_cast<OffsetT*>(nullptr),
     num_items,
-    binary_pred,
+    wrapped_pred,
     stream);
   cuda_cub::throw_on_error(status, "unique_by_key: failed on 1st step");
 
@@ -118,7 +121,7 @@ THRUST_RUNTIME_FUNCTION cudaError_t unique_by_key_impl(
     values_result,
     d_num_selected_out,
     num_items,
-    binary_pred,
+    wrapped_pred,
     stream);
   cuda_cub::throw_on_error(status, "unique_by_key: failed on 2nd step");
 


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.