### PR TITLE
[cuda.compute]: cache np.dtypes properly in stateful ops

### DIFF
--- a/python/cuda_cccl/cuda/compute/_caching.py
+++ b/python/cuda_cccl/cuda/compute/_caching.py
@@ -159,6 +159,8 @@ def _make_hashable(value):
         # (pointers). Thus, we only cache on the dtype and shape of
         # the referenced array, but not its pointer.
         return (get_dtype(value), get_shape(value))
+    elif isinstance(value, (np.number, np.bool_)):
+        return ("numpy.scalar", value.dtype.str, value.tobytes())
     elif isinstance(value, (list, tuple)):
         return tuple(_make_hashable(v) for v in value)
     elif isinstance(value, dict):

--- a/python/cuda_cccl/tests/compute/test_func_caching.py
+++ b/python/cuda_cccl/tests/compute/test_func_caching.py
@@ -61,6 +61,25 @@ def test_func_caching_with_closure():
     assert f1 != f3
 
 
+def test_func_caching_with_numpy_numeric_scalar_closure():
+    def factory(indexlength, regularsize):
+        index_dtype = np.int64
+        idx_len = index_dtype(indexlength)
+        reg_size = index_dtype(regularsize)
+
+        def func(counter):
+            return counter % idx_len + reg_size
+
+        return func
+
+    f1 = CachableFunction(factory(100_000, 16))
+    f2 = CachableFunction(factory(100_000, 16))
+    assert f1 == f2
+
+    f3 = CachableFunction(factory(100_000, 32))
+    assert f1 != f3
+
+
 def test_func_caching_with_global_variable():
     global global_x
 


### PR DESCRIPTION
## Description

closes #9468 

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
