### PR TITLE
Fix `BlockTopK` +/-0.0 handling

### DIFF
--- a/cub/cub/block/specializations/block_topk_air.cuh
+++ b/cub/cub/block/specializations/block_topk_air.cuh
@@ -75,7 +75,6 @@ private:
   using traits                 = detail::radix::traits_t<KeyT>;
   using bit_ordered_type       = typename traits::bit_ordered_type;
   using bit_ordered_conversion = typename traits::bit_ordered_conversion_policy;
-  using bit_ordered_inversion  = typename traits::bit_ordered_inversion_policy;
 
   using fundamental_digit_extractor_t = BFEDigitExtractor<KeyT>;
 
@@ -133,7 +132,7 @@ private:
   }
 
   // Compute histogram over keys
-  template <bool IsFullTile, typename DigitExtractorT, typename FilterOpT>
+  template <detail::topk::select SelectDirection, bool IsFullTile, typename DigitExtractorT, typename FilterOpT>
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void compute_histograms(
     const bit_ordered_type (&unsigned_keys)[items_per_thread],
     int valid_items,
@@ -147,8 +146,9 @@ private:
       const bit_ordered_type key = unsigned_keys[i];
       if ((IsFullTile || item_index < valid_items) && filter_op(key))
       {
-        const auto digit = digit_extractor.Digit(key);
-        atomicAdd(&storage.stage.passes.histogram[digit], histo_counter_t{1});
+        const auto digit  = static_cast<int>(digit_extractor.Digit(key));
+        const auto bucket = (SelectDirection == detail::topk::select::min) ? digit : (num_buckets - 1 - digit);
+        atomicAdd(&storage.stage.passes.histogram[bucket], histo_counter_t{1});
       }
     }
   }
@@ -255,7 +255,7 @@ private:
       auto filter_op = compare_key_prefix_op<bit_ordered_type>{prefix_mask, kth_key_prefix};
       auto digit_extractor =
         traits::template digit_extractor<fundamental_digit_extractor_t>(pass_begin_bit, pass_bits, decomposer);
-      compute_histograms<IsFullTile>(unsigned_keys, valid_items, digit_extractor, filter_op);
+      compute_histograms<SelectDirection, IsFullTile>(unsigned_keys, valid_items, digit_extractor, filter_op);
       __syncthreads();
 
       // Compute prefix sum over buckets
@@ -273,7 +273,11 @@ private:
 
       // Update the kth_key_prefix and prefix_mask for the next pass
       // Basically, we will have valid_items candidates with the prefix kth_key_prefix
-      kth_key_prefix |= bit_ordered_type(storage.stage.passes.pass_state.bucket) << pass_begin_bit;
+      const auto kth_key_digit =
+        (SelectDirection == detail::topk::select::min)
+          ? storage.stage.passes.pass_state.bucket
+          : (num_buckets - 1 - storage.stage.passes.pass_state.bucket);
+      kth_key_prefix |= bit_ordered_type(kth_key_digit) << pass_begin_bit;
       prefix_mask |= pass_mask;
 
       // Short-circuit if all candidates are amongst the top-k
@@ -346,10 +350,6 @@ private:
           flip_back_bits[i / 32] |= (1u << (i % 32));
           unsigned_keys[i] = twiddled_zero;
         }
-        if constexpr (SelectDirection == detail::topk::select::max)
-        {
-          unsigned_keys[i] = bit_ordered_inversion::inverse(decomposer, unsigned_keys[i]);
-        }
       }
     }
     else
@@ -358,10 +358,6 @@ private:
       for (int i = 0; i < items_per_thread; ++i)
       {
         unsigned_keys[i] = bit_ordered_conversion::to_bit_ordered(decomposer, unsigned_keys[i]);
-        if constexpr (SelectDirection == detail::topk::select::max)
-        {
-          unsigned_keys[i] = bit_ordered_inversion::inverse(decomposer, unsigned_keys[i]);
-        }
       }
     }
 
@@ -420,18 +416,16 @@ private:
     {
       const bit_ordered_type key_prefix = unsigned_keys[i] & prefix_mask;
 
-      const bool is_valid     = (IsFullTile || linear_tid * items_per_thread + i < valid_items);
-      const bool is_selected  = key_prefix < kth_prefix;
+      const bool is_valid = (IsFullTile || linear_tid * items_per_thread + i < valid_items);
+      using comparison_t  = ::cuda::std::
+        conditional_t<SelectDirection == detail::topk::select::min, ::cuda::std::less<>, ::cuda::std::greater<>>;
+      const bool is_selected  = comparison_t{}(key_prefix, kth_prefix);
       const bool is_candidate = key_prefix == kth_prefix;
 
       // We differentiate between candidates and selected only if not all candidates make it into the top-k items.
       int item_class = (!select_all_candidates) && is_candidate ? 1 : 0;
 
       // Untwiddle the key before storing in shared memory
-      if constexpr (SelectDirection == detail::topk::select::max)
-      {
-        unsigned_keys[i] = bit_ordered_inversion::inverse(decomposer, unsigned_keys[i]);
-      }
       unsigned_keys[i] = bit_ordered_conversion::from_bit_ordered(decomposer, unsigned_keys[i]);
 
       if (is_valid && (is_selected || is_candidate))

--- a/cub/test/catch2_test_block_topk.cu
+++ b/cub/test/catch2_test_block_topk.cu
@@ -28,6 +28,7 @@ __global__ void topk_kernel(cuda::std::span<const KeyT> g_in, cuda::std::span<Ke
   __shared__ typename topk_t::TempStorage smem;
 
   KeyT keys[ItemsPerThread];
+  // Sentinel values are adversarial by design to surface bugs in partial tile handling.
   constexpr KeyT oob_sentinel =
     SelectMax ? cuda::std::numeric_limits<KeyT>::max() : cuda::std::numeric_limits<KeyT>::lowest();
   if constexpr (BlockedInput)

--- a/cub/test/catch2_test_block_topk.cu
+++ b/cub/test/catch2_test_block_topk.cu
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Block-level tests for `block_topk` / `block_topk_air`: deterministic
+// boundary fixtures (incl. `+/-0.0` ties) and both selection directions.
+
+#include <cub/block/block_load.cuh>
+#include <cub/block/block_topk.cuh>
+
+#include <thrust/count.h>
+#include <thrust/shuffle.h>
+
+#include <cuda/std/span>
+
+#include <algorithm>
+#include <cmath>
+
+#include "catch2_test_block_topk_common.cuh"
+#include <c2h/catch2_test_helper.h>
+
+namespace
+{
+template <typename KeyT, int BlockDim, int ItemsPerThread, bool IsFullTile, bool BlockedInput, bool SelectMax>
+__global__ void topk_kernel(cuda::std::span<const KeyT> g_in, cuda::std::span<KeyT> g_top, int k, int num_valid)
+{
+  using topk_t = cub::detail::block_topk<KeyT, BlockDim, ItemsPerThread>;
+
+  __shared__ typename topk_t::TempStorage smem;
+
+  KeyT keys[ItemsPerThread];
+  constexpr KeyT oob_sentinel =
+    SelectMax ? cuda::std::numeric_limits<KeyT>::max() : cuda::std::numeric_limits<KeyT>::lowest();
+  if constexpr (BlockedInput)
+  {
+    cub::LoadDirectBlocked(static_cast<int>(threadIdx.x), g_in.data(), keys, num_valid, oob_sentinel);
+  }
+  else
+  {
+    cub::LoadDirectStriped<BlockDim>(static_cast<int>(threadIdx.x), g_in.data(), keys, num_valid, oob_sentinel);
+  }
+
+  if constexpr (SelectMax)
+  {
+    topk_t(smem).template max_keys<IsFullTile>(keys, k, num_valid);
+  }
+  else
+  {
+    topk_t(smem).template min_keys<IsFullTile>(keys, k, num_valid);
+  }
+
+  for (int i = 0; i < ItemsPerThread; ++i)
+  {
+    const int idx = static_cast<int>(threadIdx.x) * ItemsPerThread + i;
+    if (idx < k)
+    {
+      g_top[idx] = keys[i];
+    }
+  }
+}
+
+template <typename KeyT, int BlockDim, int ItemsPerThread, bool IsFullTile, bool BlockedInput, bool SelectMax>
+void check_topk(const c2h::host_vector<KeyT>& h_in, cuda::std::span<const KeyT> h_ref, int k)
+{
+  constexpr int tile  = BlockDim * ItemsPerThread;
+  const int num_valid = static_cast<int>(h_in.size());
+  REQUIRE(0 < k);
+  REQUIRE(num_valid <= tile);
+  REQUIRE((!IsFullTile || num_valid == tile));
+
+  const int top_size = cuda::std::min(k, num_valid);
+  REQUIRE(static_cast<int>(h_ref.size()) == top_size);
+
+  c2h::device_vector<KeyT> d_in(h_in);
+  c2h::device_vector<KeyT> d_top(k, KeyT{});
+
+  topk_kernel<KeyT, BlockDim, ItemsPerThread, IsFullTile, BlockedInput, SelectMax>
+    <<<1, BlockDim>>>(to_span(d_in), to_span(d_top), k, num_valid);
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  c2h::host_vector<KeyT> h_top(d_top);
+  h_top.resize(top_size);
+  std::sort(h_top.begin(), h_top.end(), comparator_t<SelectMax>{});
+  c2h::host_vector<KeyT> h_ref_vec(h_ref.begin(), h_ref.end());
+  CAPTURE(bit_repr(h_top), bit_repr(h_ref_vec));
+  REQUIRE(h_top == h_ref_vec);
+}
+} // namespace
+
+using select_direction_max = c2h::type_list<cuda::std::false_type, cuda::std::true_type>;
+using fp_key_types         = c2h::type_list<float, double>;
+
+template <int BlockDim, int ItemsPerThread>
+struct block_shape
+{
+  static constexpr int threads_per_block = BlockDim;
+  static constexpr int items_per_thread  = ItemsPerThread;
+};
+
+using block_shapes_full_tile =
+  c2h::type_list<block_shape<64, 8>, block_shape<256, 2>, block_shape<32, 16>, block_shape<128, 4>>;
+
+C2H_TEST("block_topk preserves keys across FP edge cases", "[block][topk]", fp_key_types, select_direction_max)
+{
+  using key_t                            = c2h::get<0, TestType>;
+  static constexpr bool select_max       = c2h::get<1, TestType>::value;
+  static constexpr int threads_per_block = 128;
+  static constexpr int items_per_thread  = 4;
+  static constexpr int tile_size         = threads_per_block * items_per_thread;
+
+  rng_t rng(static_cast<cuda::std::uint32_t>(C2H_SEED(1).get()));
+  c2h::host_vector<key_t> h_in = distinct_keys<key_t>(tile_size, rng);
+  h_in[0]                      = static_cast<key_t>(-0.0);
+  h_in[1]                      = static_cast<key_t>(+0.0);
+  h_in[2]                      = cuda::std::numeric_limits<key_t>::infinity();
+  h_in[3]                      = -cuda::std::numeric_limits<key_t>::infinity();
+  thrust::shuffle(h_in.begin(), h_in.end(), rng);
+
+  CAPTURE(c2h::type_name<key_t>(), select_max);
+
+  const int num_valid = tile_size / 2 + 7;
+  c2h::host_vector<key_t> h_in_partial(h_in.begin(), h_in.begin() + num_valid);
+
+  SECTION("full tile, blocked input")
+  {
+    static constexpr bool is_full_tile  = true;
+    static constexpr bool blocked_input = true;
+    const int k                         = GENERATE_COPY(values<int>({1, tile_size / 4, tile_size - 1}));
+    CAPTURE(k);
+    const auto h_ref = sorted_top_k<select_max>(h_in, k);
+    check_topk<key_t, threads_per_block, items_per_thread, is_full_tile, blocked_input, select_max>(
+      h_in, to_span(h_ref), k);
+  }
+
+  SECTION("partial tile, blocked input")
+  {
+    static constexpr bool is_full_tile  = false;
+    static constexpr bool blocked_input = true;
+    const int k                         = GENERATE_COPY(values<int>({1, num_valid / 4, num_valid - 1}));
+    CAPTURE(num_valid, k);
+    const auto h_ref = sorted_top_k<select_max>(h_in_partial, k);
+    check_topk<key_t, threads_per_block, items_per_thread, is_full_tile, blocked_input, select_max>(
+      h_in_partial, to_span(h_ref), k);
+  }
+}
+
+C2H_TEST("block_topk::select_* selects the right top-k on a full tile",
+         "[block][topk]",
+         fp_key_types,
+         block_shapes_full_tile,
+         select_direction_max)
+{
+  using key_t                            = c2h::get<0, TestType>;
+  using shape_t                          = c2h::get<1, TestType>;
+  static constexpr bool select_max       = c2h::get<2, TestType>::value;
+  static constexpr int threads_per_block = shape_t::threads_per_block;
+  static constexpr int items_per_thread  = shape_t::items_per_thread;
+  static constexpr int tile_size         = threads_per_block * items_per_thread;
+
+  rng_t rng(static_cast<cuda::std::uint32_t>(C2H_SEED(2).get()));
+  const int k = GENERATE_COPY(values<int>({1, tile_size / 4, tile_size / 2, tile_size - 1}));
+
+  static constexpr bool is_full_tile  = true;
+  static constexpr bool blocked_input = true;
+
+  const int overhang = GENERATE_COPY(overhang_generator(tile_size - k <= 1, {0, 1, tile_size - k}));
+
+  auto run_check = [&](rng_t& local_rng, key_t boundary_key) {
+    CAPTURE(c2h::type_name<key_t>(), select_max, k, overhang, boundary_key);
+    c2h::host_vector<key_t> h_in =
+      gen_keys_from_boundary_key<select_max>(tile_size, k, overhang, boundary_key, local_rng);
+    const auto h_ref = sorted_top_k<select_max>(h_in, k);
+    check_topk<key_t, threads_per_block, items_per_thread, is_full_tile, blocked_input, select_max>(
+      h_in, to_span(h_ref), k);
+  };
+
+  SECTION("fixed boundary_key")
+  {
+    const key_t boundary_key = GENERATE_COPY(boundary_key_generator<key_t>());
+    run_check(rng, boundary_key);
+  }
+
+  SECTION("random boundary_key")
+  {
+    const key_t boundary_key = random_boundary_key<key_t>(rng);
+    run_check(rng, boundary_key);
+  }
+}
+
+C2H_TEST("block_topk::{Min,Max}Keys preserve -0.0 in output", "[block][topk][float]", select_direction_max)
+{
+  static constexpr bool select_max       = c2h::get<0, TestType>::value;
+  static constexpr int threads_per_block = 128;
+  static constexpr int items_per_thread  = 1;
+  static constexpr int tile_size         = 8;
+
+  const c2h::host_vector<float> h_in =
+    select_max ? c2h::host_vector<float>{-2.0f, -0.0f, -3.0f, 0.0f, -1.0f, -4.0f, -5.0f, -6.0f}
+               : c2h::host_vector<float>{3.0f, -0.0f, 1.0f, 2.0f, 0.0f, -1.0f, 4.0f, 5.0f};
+  const int k = select_max ? 3 : 5;
+
+  const auto h_ref = sorted_top_k<select_max>(h_in, k);
+  check_topk<float, threads_per_block, items_per_thread, false, true, select_max>(h_in, to_span(h_ref), k);
+
+  c2h::device_vector<float> d_in(h_in);
+  c2h::device_vector<float> d_top(k);
+  topk_kernel<float, threads_per_block, items_per_thread, false, true, select_max>
+    <<<1, threads_per_block>>>(to_span(d_in), to_span(d_top), k, tile_size);
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  c2h::host_vector<float> h_top(d_top);
+  const int num_minus_zero = static_cast<int>(thrust::count_if(h_top.begin(), h_top.end(), [](float x) {
+    return x == 0.0f && std::signbit(x);
+  }));
+  REQUIRE(num_minus_zero >= 1);
+}

--- a/cub/test/catch2_test_block_topk.cu
+++ b/cub/test/catch2_test_block_topk.cu
@@ -81,7 +81,9 @@ void check_topk(const c2h::host_vector<KeyT>& h_in, cuda::std::span<const KeyT> 
 
   c2h::host_vector<KeyT> h_top(d_top);
   h_top.resize(top_size);
-  std::sort(h_top.begin(), h_top.end(), comparator_t<SelectMax>{});
+  std::sort(h_top.begin(),
+            h_top.end(),
+            direction_to_comparator_t<SelectMax ? cub::detail::topk::select::max : cub::detail::topk::select::min>{});
   c2h::host_vector<KeyT> h_ref_vec(h_ref.begin(), h_ref.end());
   CAPTURE(bit_repr(h_top), bit_repr(h_ref_vec));
   REQUIRE(h_top == h_ref_vec);

--- a/cub/test/catch2_test_block_topk_common.cuh
+++ b/cub/test/catch2_test_block_topk_common.cuh
@@ -1,0 +1,360 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Shared helpers for block-level top-k API tests: deterministic and
+// random key generation (incl. fine control over the top-k boundary),
+// host-side top-k references, and small CUDA-test glue.
+
+#pragma once
+
+#include <thrust/random.h>
+#include <thrust/shuffle.h>
+
+#include <cuda/std/__algorithm/max.h>
+#include <cuda/std/__algorithm/min.h>
+#include <cuda/std/__bit/bit_cast.h>
+#include <cuda/std/__cmath/isfinite.h>
+#include <cuda/std/__cmath/rounding_functions.h>
+#include <cuda/std/__functional/operations.h>
+#include <cuda/std/__memory/pointer_traits.h>
+#include <cuda/std/__type_traits/remove_pointer.h>
+#include <cuda/std/cstddef>
+#include <cuda/std/cstdint>
+#include <cuda/std/limits>
+#include <cuda/std/optional>
+#include <cuda/std/span>
+#include <cuda/type_traits>
+
+#include <algorithm>
+#include <initializer_list>
+
+#include <c2h/catch2_test_helper.h>
+
+// --- RNG and data generation ---
+
+// Shared RNG type; each test constructs one and threads it through every
+// helper that consumes randomness.
+using rng_t = thrust::default_random_engine;
+
+// `n` distinct, shuffled values of `T` centered at `0` (or `max() / 2` for unsigned).
+template <typename T>
+c2h::host_vector<T> distinct_keys(cuda::std::size_t n, rng_t& rng)
+{
+  constexpr T mean = cuda::std::is_signed_v<T> ? T{0} : (cuda::std::numeric_limits<T>::max() / T{2});
+  const T start    = static_cast<T>(mean - static_cast<T>(n / 2));
+  c2h::host_vector<T> v(n);
+  for (cuda::std::size_t i = 0; i < n; ++i)
+  {
+    v[i] = static_cast<T>(start + static_cast<T>(i));
+  }
+  thrust::shuffle(v.begin(), v.end(), rng);
+  return v;
+}
+
+// `n` keys from a centered distribution: standard normal for FP, uniform
+// over a width-`n` window for integers (centered at `0` for signed,
+// `max() / 2` for unsigned). The narrow window gives `~n/2` expected
+// collision pairs by birthday paradox, exercising the tie-break path
+// without engineering ties.
+template <typename KeyT>
+c2h::host_vector<KeyT> random_keys_centered(int n, rng_t& rng)
+{
+  c2h::host_vector<KeyT> v(n);
+  auto fill_keys = [&](auto& dist) {
+    for (auto& x : v)
+    {
+      x = dist(rng);
+    }
+  };
+  if constexpr (cuda::is_floating_point_v<KeyT>)
+  {
+    constexpr KeyT mean   = KeyT{0};
+    constexpr KeyT stddev = KeyT{1};
+    thrust::random::normal_distribution<KeyT> dist(mean, stddev);
+    fill_keys(dist);
+  }
+  else
+  {
+    constexpr KeyT mean = cuda::std::is_signed_v<KeyT> ? KeyT{0} : (cuda::std::numeric_limits<KeyT>::max() / KeyT{2});
+    const KeyT half     = static_cast<KeyT>(n / 2);
+    thrust::random::uniform_int_distribution<KeyT> dist(static_cast<KeyT>(mean - half), static_cast<KeyT>(mean + half));
+    fill_keys(dist);
+  }
+  return v;
+}
+
+// Random `boundary_key` valid for `gen_keys_from_boundary_key<KeyT>`
+// (strictly inside the representable range; FP halves the span to satisfy
+// `uniform_real_distribution`'s `b - a <= max()` precondition).
+template <typename KeyT>
+KeyT random_boundary_key(rng_t& rng)
+{
+  if constexpr (cuda::std::is_integral_v<KeyT>)
+  {
+    constexpr KeyT type_lo = cuda::std::numeric_limits<KeyT>::lowest();
+    constexpr KeyT type_hi = cuda::std::numeric_limits<KeyT>::max();
+    thrust::random::uniform_int_distribution<KeyT> dist(
+      static_cast<KeyT>(type_lo + KeyT{1}), static_cast<KeyT>(type_hi - KeyT{1}));
+    return dist(rng);
+  }
+  else
+  {
+    // FP: half-span to satisfy `uniform_real_distribution`'s `b - a <= max()` precondition.
+    constexpr KeyT type_hi = cuda::std::numeric_limits<KeyT>::max() / KeyT{2};
+    constexpr KeyT type_lo = -type_hi;
+    thrust::random::uniform_real_distribution<KeyT> dist(
+      cuda::std::nextafter(type_lo, KeyT{0}), cuda::std::nextafter(type_hi, KeyT{0}));
+    return dist(rng);
+  }
+}
+
+// Generates `n` keys with knobs for top-k boundary behavior: the boundary
+// value (`boundary_key`), the number of boundary ties (`num_tied >=
+// overhang + 1`), and built-in coverage of near-boundary values
+// (`boundary_succ` / `boundary_pred`) and FP specials (`+/-inf`, and a
+// `+0.0` / `-0.0` mix when `boundary_key == 0.0`). Remaining slots are
+// random above-/below-k fillers.
+//
+// `overhang > 0` forces ranking to pick a `num_tied - overhang` subset of
+// boundary copies; `overhang == 0` only fixes the *order* of selected
+// items. Requires `effective_k + overhang <= num_items` (with
+// `effective_k = min(k, num_items)`). `boundary_key` must be strictly
+// inside the integer range, or finite for FP (`lowest()` / `max()`
+// collapse the corresponding above-/below-k slots to `+/-inf`).
+template <bool SelectMax, typename KeyT>
+c2h::host_vector<KeyT> gen_keys_from_boundary_key(int num_items, int k, int overhang, KeyT boundary_key, rng_t& rng)
+{
+  REQUIRE(0 < k);
+  REQUIRE(0 <= overhang);
+  const int effective_k = cuda::std::min(k, num_items);
+  REQUIRE(effective_k + overhang <= num_items);
+
+  // overhang only specifies the lower bound of the number of tied keys.
+  thrust::random::uniform_int_distribution<int> num_tied_dist(overhang + 1, effective_k + overhang);
+  const int num_tied        = num_tied_dist(rng);
+  const int num_after_sieve = effective_k + overhang;
+  const int num_winners     = num_after_sieve - num_tied;
+  const int num_losers      = num_items - num_after_sieve;
+
+  // Map selection direction onto the two sides of `boundary_key` once;
+  // rest is direction-agnostic.
+  const int num_above_k = SelectMax ? num_winners : num_losers;
+  const int num_below_k = SelectMax ? num_losers : num_winners;
+  REQUIRE(num_above_k + num_tied + num_below_k == num_items);
+
+  c2h::host_vector<KeyT> keys(num_items);
+
+  // Slot 0 of each non-empty side is pinned to `boundary_succ` /
+  // `boundary_pred` so the sieve discriminates adjacent bit patterns.
+  auto fill_keys = [&](auto above_gen, auto below_gen, auto boundary_key_gen) {
+    int idx = 0;
+    for (int i = 0; i < num_above_k; ++i, ++idx)
+    {
+      keys[idx] = above_gen(i);
+    }
+    for (int i = 0; i < num_below_k; ++i, ++idx)
+    {
+      keys[idx] = below_gen(i);
+    }
+    for (int i = 0; i < num_tied; ++i, ++idx)
+    {
+      keys[idx] = boundary_key_gen(i);
+    }
+  };
+
+  if constexpr (cuda::std::is_integral_v<KeyT>)
+  {
+    constexpr KeyT type_lo = cuda::std::numeric_limits<KeyT>::lowest();
+    constexpr KeyT type_hi = cuda::std::numeric_limits<KeyT>::max();
+
+    // Strict inequality so `boundary_key +/- 1` stay representable.
+    REQUIRE(type_lo < boundary_key);
+    REQUIRE(boundary_key < type_hi);
+    const KeyT boundary_succ = static_cast<KeyT>(boundary_key + KeyT{1});
+    const KeyT boundary_pred = static_cast<KeyT>(boundary_key - KeyT{1});
+
+    thrust::random::uniform_int_distribution<KeyT> above_dist(boundary_succ, type_hi);
+    thrust::random::uniform_int_distribution<KeyT> below_dist(type_lo, boundary_pred);
+
+    // First slot of each side is pinned to `boundary_succ` / `boundary_pred` so the sieve discriminates adjacent bit
+    // patterns.
+    fill_keys(
+      [&](int i) {
+        return (i == 0) ? boundary_succ : above_dist(rng);
+      },
+      [&](int i) {
+        return (i == 0) ? boundary_pred : below_dist(rng);
+      },
+      [&](int) {
+        return boundary_key;
+      });
+  }
+  else
+  {
+    constexpr KeyT inf      = cuda::std::numeric_limits<KeyT>::infinity();
+    constexpr KeyT type_max = cuda::std::numeric_limits<KeyT>::max();
+    constexpr KeyT type_min = -type_max;
+
+    REQUIRE(cuda::std::isfinite(boundary_key));
+
+    // `boundary_key == max()` / `lowest()` saturates `nextafter` to
+    // `+/-inf` (slot 0 then carries `+/-inf` for free); the non-edge side
+    // uses the optional, clamped to `max()` to satisfy
+    // `uniform_real_distribution`'s `b - a <= max()` precondition.
+    const KeyT boundary_succ = cuda::std::nextafter(boundary_key, +inf);
+    const KeyT boundary_pred = cuda::std::nextafter(boundary_key, -inf);
+
+    // Make sure the distributions are valid.
+    cuda::std::optional<thrust::random::uniform_real_distribution<KeyT>> above_dist;
+    cuda::std::optional<thrust::random::uniform_real_distribution<KeyT>> below_dist;
+    if (boundary_key != type_max)
+    {
+      above_dist.emplace(boundary_succ, cuda::std::min(boundary_succ + type_max, type_max));
+    }
+    if (boundary_key != type_min)
+    {
+      below_dist.emplace(cuda::std::max(boundary_pred - type_max, type_min), boundary_pred);
+    }
+
+    fill_keys(
+      [&](int i) -> KeyT {
+        if (i == 0)
+        {
+          return boundary_succ;
+        }
+        else if (i == 1)
+        {
+          return inf;
+        }
+        else
+        {
+          return above_dist ? (*above_dist)(rng) : inf;
+        }
+      },
+      [&](int i) -> KeyT {
+        if (i == 0)
+        {
+          return boundary_pred;
+        }
+        else if (i == 1)
+        {
+          return -inf;
+        }
+        else
+        {
+          return below_dist ? (*below_dist)(rng) : -inf;
+        }
+      },
+      // For `boundary_key == +/-0.0`, alternate signs to mix `+0.0` and
+      // `-0.0` ties; otherwise every tied slot is identical.
+      [&](int i) -> KeyT {
+        if ((i % 2 == 0) || (boundary_key != KeyT{0.0}))
+        {
+          return boundary_key;
+        }
+        return -boundary_key;
+      });
+  }
+
+  thrust::shuffle(keys.begin(), keys.end(), rng);
+  return keys;
+}
+
+// Catch2 generator over type-specific deterministic `boundary_key` values:
+// FP gets `0.0`, the smallest positive/negative values, the subnormal/
+// normal boundary on each side, and `max()` / `lowest()`. Signed integers
+// get just `0`; unsigned integers get `max() / 2` (the top-bit transition).
+template <typename KeyT>
+auto boundary_key_generator()
+{
+  using namespace Catch::Generators;
+  if constexpr (cuda::is_floating_point_v<KeyT>)
+  {
+    constexpr KeyT inf     = cuda::std::numeric_limits<KeyT>::infinity();
+    constexpr KeyT pos_min = cuda::std::numeric_limits<KeyT>::min();
+    return values<KeyT>({
+      KeyT{0}, // -0.0 is automatically generated by the FP branch of gen_keys_from_boundary_key
+      cuda::std::nextafter(KeyT{0}, +inf), // smallest finite positive value (possibly subnormal)
+      cuda::std::nextafter(KeyT{0}, -inf), // largest finite negative value (possibly subnormal)
+      // Subnormal/normal boundary on each side -- the bit-cast unsigned representation jumps when the exponent flips
+      // from all-zeros to a leading 1.
+      cuda::std::nextafter(pos_min, KeyT{0}), // largest positive subnormal
+      pos_min, // smallest positive normal
+      -pos_min, // largest negative normal (closest to 0)
+      cuda::std::nextafter(-pos_min, KeyT{0}), // largest-magnitude negative subnormal
+      cuda::std::numeric_limits<KeyT>::max(), // largest finite -- collapses above-k slots to +inf
+      cuda::std::numeric_limits<KeyT>::lowest(), // smallest finite (== -max()) -- collapses below-k slots to -inf
+    });
+  }
+  else
+  {
+    constexpr KeyT fixed = cuda::std::is_signed_v<KeyT> ? KeyT{0} : (cuda::std::numeric_limits<KeyT>::max() / KeyT{2});
+    return values<KeyT>({fixed});
+  }
+}
+
+// Catch2 generator over `options`, narrowed to the leading entry when
+// `narrow` (callers must list the always-applicable value first).
+inline auto overhang_generator(bool narrow, std::initializer_list<int> options)
+{
+  using namespace Catch::Generators;
+  return narrow ? take(1, values<int>(options)) : values<int>(options);
+}
+
+// --- Host top-k reference ---
+
+// Winner-first ordering: largest for SelectMax, smallest for SelectMin.
+template <bool SelectMax>
+using comparator_t = cuda::std::conditional_t<SelectMax, cuda::std::greater<>, cuda::std::less<>>;
+
+// Up to `min(k, in.size())` items so callers can pass a `k` exceeding the input length.
+template <bool SelectMax, typename T>
+c2h::host_vector<T> sorted_top_k(const c2h::host_vector<T>& in, int k)
+{
+  c2h::host_vector<T> ref = in;
+  const auto out_size     = cuda::std::min(static_cast<cuda::std::size_t>(k), ref.size());
+  std::partial_sort(ref.begin(), ref.begin() + out_size, ref.end(), comparator_t<SelectMax>{});
+  ref.resize(out_size);
+  return ref;
+}
+
+// --- Kernel-launch glue ---
+
+// Wraps a thrust-compatible contiguous container as a dynamic-extent
+// `cuda::std::span` (static-extent spans are built manually at call sites).
+template <typename Container>
+auto to_span(Container&& v)
+{
+  using element_t = cuda::std::remove_pointer_t<decltype(cuda::std::to_address(v.data()))>;
+  return cuda::std::span<element_t>{cuda::std::to_address(v.data()), v.size()};
+}
+
+// --- Post-processing / comparison ---
+
+// For FP `T`, returns each element's same-sized unsigned-int bit pattern
+// (no-op for non-FP `T`). Used in CAPTURE so mismatch diagnostics stay
+// readable when values would otherwise print as `0.0` (e.g. `+/-0.0`). Note
+// that `host_vector` equality treats `-0.0` and `+0.0` as equal; the
+// dedicated `-0.0` regression test's `signbit` count is the guard for that.
+template <typename T>
+auto bit_repr(const c2h::host_vector<T>& v)
+{
+  if constexpr (cuda::is_floating_point_v<T>)
+  {
+    using U = cuda::std::conditional_t<
+      sizeof(T) == sizeof(cuda::std::uint64_t),
+      cuda::std::uint64_t,
+      cuda::std::conditional_t<sizeof(T) == sizeof(cuda::std::uint32_t), cuda::std::uint32_t, cuda::std::uint16_t>>;
+    static_assert(sizeof(U) == sizeof(T), "bit_repr: no matching unsigned-int width for T");
+    c2h::host_vector<U> out(v.size());
+    for (cuda::std::size_t i = 0; i < v.size(); ++i)
+    {
+      out[i] = cuda::std::bit_cast<U>(v[i]);
+    }
+    return out;
+  }
+  else
+  {
+    return v;
+  }
+}

--- a/cub/test/catch2_test_block_topk_common.cuh
+++ b/cub/test/catch2_test_block_topk_common.cuh
@@ -15,7 +15,6 @@
 #include <cuda/std/__bit/bit_cast.h>
 #include <cuda/std/__cmath/isfinite.h>
 #include <cuda/std/__cmath/rounding_functions.h>
-#include <cuda/std/__functional/operations.h>
 #include <cuda/std/__memory/pointer_traits.h>
 #include <cuda/std/__type_traits/remove_pointer.h>
 #include <cuda/std/cstddef>
@@ -28,6 +27,7 @@
 #include <algorithm>
 #include <initializer_list>
 
+#include "catch2_test_device_topk_common.cuh"
 #include <c2h/catch2_test_helper.h>
 
 // --- RNG and data generation ---
@@ -48,38 +48,6 @@ c2h::host_vector<T> distinct_keys(cuda::std::size_t n, rng_t& rng)
     v[i] = static_cast<T>(start + static_cast<T>(i));
   }
   thrust::shuffle(v.begin(), v.end(), rng);
-  return v;
-}
-
-// `n` keys from a centered distribution: standard normal for FP, uniform
-// over a width-`n` window for integers (centered at `0` for signed,
-// `max() / 2` for unsigned). The narrow window gives `~n/2` expected
-// collision pairs by birthday paradox, exercising the tie-break path
-// without engineering ties.
-template <typename KeyT>
-c2h::host_vector<KeyT> random_keys_centered(int n, rng_t& rng)
-{
-  c2h::host_vector<KeyT> v(n);
-  auto fill_keys = [&](auto& dist) {
-    for (auto& x : v)
-    {
-      x = dist(rng);
-    }
-  };
-  if constexpr (cuda::is_floating_point_v<KeyT>)
-  {
-    constexpr KeyT mean   = KeyT{0};
-    constexpr KeyT stddev = KeyT{1};
-    thrust::random::normal_distribution<KeyT> dist(mean, stddev);
-    fill_keys(dist);
-  }
-  else
-  {
-    constexpr KeyT mean = cuda::std::is_signed_v<KeyT> ? KeyT{0} : (cuda::std::numeric_limits<KeyT>::max() / KeyT{2});
-    const KeyT half     = static_cast<KeyT>(n / 2);
-    thrust::random::uniform_int_distribution<KeyT> dist(static_cast<KeyT>(mean - half), static_cast<KeyT>(mean + half));
-    fill_keys(dist);
-  }
   return v;
 }
 
@@ -303,17 +271,14 @@ inline auto overhang_generator(bool narrow, std::initializer_list<int> options)
 
 // --- Host top-k reference ---
 
-// Winner-first ordering: largest for SelectMax, smallest for SelectMin.
-template <bool SelectMax>
-using comparator_t = cuda::std::conditional_t<SelectMax, cuda::std::greater<>, cuda::std::less<>>;
-
 // Up to `min(k, in.size())` items so callers can pass a `k` exceeding the input length.
 template <bool SelectMax, typename T>
 c2h::host_vector<T> sorted_top_k(const c2h::host_vector<T>& in, int k)
 {
-  c2h::host_vector<T> ref = in;
-  const auto out_size     = cuda::std::min(static_cast<cuda::std::size_t>(k), ref.size());
-  std::partial_sort(ref.begin(), ref.begin() + out_size, ref.end(), comparator_t<SelectMax>{});
+  constexpr auto direction = SelectMax ? cub::detail::topk::select::max : cub::detail::topk::select::min;
+  c2h::host_vector<T> ref  = in;
+  const auto out_size      = cuda::std::min(static_cast<cuda::std::size_t>(k), ref.size());
+  std::partial_sort(ref.begin(), ref.begin() + out_size, ref.end(), direction_to_comparator_t<direction>{});
   ref.resize(out_size);
   return ref;
 }

--- a/cub/test/catch2_test_device_segmented_topk_keys.cu
+++ b/cub/test/catch2_test_device_segmented_topk_keys.cu
@@ -477,15 +477,22 @@ C2H_TEST("DeviceBatchedTopK::{Min,Max}Keys work with variable-size segments and 
 }
 
 // Regression test: top-k must preserve -0.0f in the output (not normalize to +0.0f).
-C2H_TEST("DeviceBatchedTopK::MinKeys preserves -0.0f in output", "[keys][segmented][topk][device][float]")
+C2H_TEST("DeviceBatchedTopK::{Min,Max}Keys preserve -0.0f in output",
+         "[keys][segmented][topk][device][float]",
+         select_direction_list)
 {
   constexpr cuda::std::int64_t segment_size                      = 8;
-  constexpr cuda::std::int64_t k                                 = 5;
   constexpr cuda::std::int64_t num_segments                      = 1;
   [[maybe_unused]] constexpr cuda::std::int64_t max_segment_size = 64; // msvc warns, only used in nttp
 
-  // Input: one segment containing -0.0f and +0.0f; top-5 min should include both zeros.
-  c2h::device_vector<float> d_keys_in{3.0f, -0.0f, 1.0f, 2.0f, 0.0f, -1.0f, 4.0f, 5.0f};
+  constexpr auto direction = c2h::get<0, TestType>::value;
+
+  c2h::device_vector<float> d_keys_in =
+    (direction == cub::detail::topk::select::min)
+      ? c2h::device_vector<float>{3.0f, -0.0f, 1.0f, 2.0f, 0.0f, -1.0f, 4.0f, 5.0f}
+      : c2h::device_vector<float>{-2.0f, -0.0f, -3.0f, 0.0f, -1.0f, -4.0f, -5.0f, -6.0f};
+  const cuda::std::int64_t k = (direction == cub::detail::topk::select::min) ? 5 : 3;
+
   c2h::device_vector<float> d_keys_out(k, thrust::no_init);
 
   auto d_keys_in_it =
@@ -493,7 +500,7 @@ C2H_TEST("DeviceBatchedTopK::MinKeys preserves -0.0f in output", "[keys][segment
   auto d_keys_out_it =
     cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(d_keys_out.data())), k);
 
-  batched_topk_keys<cub::detail::topk::select::min>(
+  batched_topk_keys<direction>(
     d_keys_in_it,
     d_keys_out_it,
     cuda::args::immediate{segment_size, cuda::args::bounds<cuda::std::int64_t{1}, max_segment_size>()},


### PR DESCRIPTION
## Description

### Cause

The bug is caused by combining `detail::radix::traits_t<KeyT>::bit_ordered_inversion_policy::inverse()` and `BFEDigitExtractor<KeyT>{}.Digit(key)` as well as comparing non-digit-extracted keys with a mask built from extracted digits.

In `BlockTopK` we handle -0.0 manually and get rid of the corresponding bit-pattern which keeps the bug from appearing in the `min` case. But in the `max` case we invert the keys after that transformation which means that instead of both 0.0 and -0.0 being mapped to the 0.0 bit-pattern, they both get mapped to the -0.0 bit pattern.

The digit-extractor has built-in negative-zero handling for FP (it extracts the 0.0 bit pattern even from -0.0). But this handling conflicts with our use of the extracted digit to build up a prefix mask b/c we compare the mask directly with the key which still has the -0.0 bit-pattern. So keys that were registered in the histogram-pass as 0.0-bit-pattern wont be filtered correctly later.

This issue can be reproduced by having input data with tied keys being 0.0 or -0.0 and using the `max` select-direction. This causes the candidate bin to count all the 0.0/-0.0 keys but none of them participating in the next histogram pass since they do not compare equal with the prefix mask.

### Fix

The actual fix is just 14 lines of code. All the rest is testing infrastructure I brought over from #9066 to make sure the bug is fixed and remains fixed. I found and fixed the bug there originally but the PR was de-prioritized to focus on #9077. So to still get this fix in, I extracted it into its own PR.

While one could also fix the issue by first inverting and then doing the -0.0 to 0.0 mapping, I decided to get rid of the bit pattern inversion completely. Instead, we reverse the histogram index for the `max`-direction (and undo the reversal when transforming the bin index into the prefix mask). This is also what other radix-ranking facilities seem to be doing (even though they don't have the same issue of building up a mask and comparing it to the keys). It feels less bug-prone, easier to understand/review and seemed to have a neutral to positive effect in benchmarks (in the context of my bigger PR #9066, I did not re-benchmark this PR).

In a follow-up PR we should look into getting a digit-extractor w/o the -0.0 handling to avoid the unnecessary conditional (dead code) introduced by it due to our manual handling of -0.0.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
<!-- closes  Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
