### PR TITLE
use `__ballot_sync` in warpspeed lookahead 

### DIFF
--- a/cub/cub/detail/warpspeed/look_ahead.cuh
+++ b/cub/cub/detail/warpspeed/look_ahead.cuh
@@ -194,11 +194,6 @@ template <int numTileStatesPerThread, typename AccumT, typename ScanOpT>
                 "WarpReduce for a full warp must not require temporary storage");
   [[maybe_unused]] typename warp_reduce_t::TempStorage temp_storage;
 
-  using warp_reduce_or_t = WarpReduce<::cuda::std::uint32_t>;
-  warp_reduce_or_t::TempStorage temp_storage_or;
-  warp_reduce_or_t warp_reduce_or{temp_storage_or};
-  constexpr ::cuda::std::bit_or<::cuda::std::uint32_t> or_op{};
-
   while (idxTileCur < idxTileNext)
   {
     tile_state_t<AccumT> regTmpStates[numTileStatesPerThread];
@@ -206,12 +201,9 @@ template <int numTileStatesPerThread, typename AccumT, typename ScanOpT>
 
     for (int idx = 0; idx < numTileStatesPerThread; ++idx)
     {
-      // Bitmask with a 1 bit in the position of the current lane if current lane has a tile aggregate
-      const ::cuda::std::uint32_t lane_has_aggregate =
-        lanemaskEq * (regTmpStates[idx].state == scan_state::tile_aggregate);
-
       // Bitmask with 1 bits indicating which lane has a tile aggregate
-      const ::cuda::std::uint32_t warp_has_aggregate_mask = warp_reduce_or.Reduce(lane_has_aggregate, or_op);
+      const ::cuda::std::uint32_t warp_has_aggregate_mask =
+        __ballot_sync(0xffffffffu, regTmpStates[idx].state == scan_state::tile_aggregate);
 
       // Bitmask with 1 bits for all rightmost lanes having a tile aggregate
       const ::cuda::std::uint32_t warp_right_aggregates_mask = warp_has_aggregate_mask & (~warp_has_aggregate_mask - 1);

--- a/cub/cub/detail/warpspeed/look_ahead.cuh
+++ b/cub/cub/detail/warpspeed/look_ahead.cuh
@@ -183,8 +183,8 @@ template <int numTileStatesPerThread, typename AccumT, typename ScanOpT>
   const int idxTileNext,
   ScanOpT& scan_op)
 {
-  const int laneIdx                      = specialRegisters.laneIdx;
-  const ::cuda::std::uint32_t lanemaskEq = ::cuda::ptx::get_sreg_lanemask_eq();
+  const int laneIdx                                       = specialRegisters.laneIdx;
+  [[maybe_unused]] const ::cuda::std::uint32_t lanemaskEq = ::cuda::ptx::get_sreg_lanemask_eq();
 
   int idxTileCur             = idxTilePrev;
   AccumT aggrExclusiveCtaCur = aggrExclusiveCtaPrev;


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
### closes 

<!-- Provide a standalone description of changes in this PR. -->
### Final performance results on B200

<details>
<summary> bench.exclusive_scan.custom </summary>

```
['results/warpspeed_unstable_ballot_sync_base/B200/custom/custom.json', 'results/warpspeed_unstable_ballot_sync/B200/custom/custom.json']
# base

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I32      |      2^16      |  27.316 us |       3.23% |  27.275 us |       3.50% |   -0.041 us |  -0.15% |  🔵 SAME  |
|   I8    |      I32      |      2^20      |  32.721 us |       6.88% |  32.862 us |       7.68% |    0.141 us |   0.43% |  🔵 SAME  |
|   I8    |      I32      |      2^24      | 110.653 us |       3.95% | 111.138 us |       4.39% |    0.485 us |   0.44% |  🔵 SAME  |
|   I8    |      I32      |      2^28      |   1.187 ms |       0.29% |   1.187 ms |       0.28% |   -0.275 us |  -0.02% |  🔵 SAME  |
|   I8    |      I64      |      2^16      |  27.060 us |       3.72% |  26.991 us |       4.05% |   -0.069 us |  -0.25% |  🔵 SAME  |
|   I8    |      I64      |      2^20      |  35.031 us |      11.61% |  34.310 us |       9.72% |   -0.722 us |  -2.06% |  🔵 SAME  |
|   I8    |      I64      |      2^24      | 113.802 us |       6.17% | 113.474 us |       6.17% |   -0.327 us |  -0.29% |  🔵 SAME  |
|   I8    |      I64      |      2^28      |   1.189 ms |       0.29% |   1.189 ms |       0.29% |   -0.193 us |  -0.02% |  🔵 SAME  |
|   I8    |      I64      |      2^32      |  18.624 ms |       0.58% |  18.626 ms |       0.16% |    1.641 us |   0.01% |  🔵 SAME  |
|   I16   |      I32      |      2^16      |  11.258 us |       0.41% |  11.253 us |       0.39% |   -0.004 us |  -0.04% |  🔵 SAME  |
|   I16   |      I32      |      2^20      |  13.848 us |       6.55% |  13.779 us |       6.28% |   -0.069 us |  -0.50% |  🔵 SAME  |
|   I16   |      I32      |      2^24      |  44.367 us |       3.71% |  44.344 us |       3.94% |   -0.022 us |  -0.05% |  🔵 SAME  |
|   I16   |      I32      |      2^28      | 364.871 us |       0.53% | 364.374 us |       0.49% |   -0.498 us |  -0.14% |  🔵 SAME  |
|   I16   |      I64      |      2^16      |  11.255 us |       0.49% |  11.261 us |       0.53% |    0.006 us |   0.05% |  🔵 SAME  |
|   I16   |      I64      |      2^20      |  14.810 us |       6.14% |  14.839 us |       5.98% |    0.030 us |   0.20% |  🔵 SAME  |
|   I16   |      I64      |      2^24      |  46.963 us |       2.64% |  47.012 us |       2.57% |    0.049 us |   0.10% |  🔵 SAME  |
|   I16   |      I64      |      2^28      | 374.397 us |       0.50% | 374.323 us |       0.56% |   -0.074 us |  -0.02% |  🔵 SAME  |
|   I16   |      I64      |      2^32      |   5.668 ms |       0.30% |   5.664 ms |       0.34% |   -4.050 us |  -0.07% |  🔵 SAME  |
|   I32   |      I32      |      2^16      |   9.227 us |       2.37% |   9.266 us |       3.68% |    0.038 us |   0.41% |  🔵 SAME  |
|   I32   |      I32      |      2^20      |  13.647 us |       6.24% |  13.628 us |       7.01% |   -0.019 us |  -0.14% |  🔵 SAME  |
|   I32   |      I32      |      2^24      |  38.770 us |       3.36% |  37.884 us |       3.55% |   -0.886 us |  -2.28% |  🔵 SAME  |
|   I32   |      I32      |      2^28      | 335.316 us |       0.40% | 327.213 us |       0.45% |   -8.103 us |  -2.42% |  🟢 FAST  |
|   I32   |      I64      |      2^16      |   9.284 us |       4.39% |   9.318 us |       5.05% |    0.034 us |   0.37% |  🔵 SAME  |
|   I32   |      I64      |      2^20      |  13.345 us |       4.43% |  13.216 us |       5.35% |   -0.129 us |  -0.97% |  🔵 SAME  |
|   I32   |      I64      |      2^24      |  38.706 us |       4.24% |  37.823 us |       4.19% |   -0.883 us |  -2.28% |  🔵 SAME  |
|   I32   |      I64      |      2^28      | 334.999 us |       0.43% | 327.195 us |       0.43% |   -7.804 us |  -2.33% |  🟢 FAST  |
|   I32   |      I64      |      2^32      |   5.145 ms |       0.82% |   5.041 ms |       1.01% | -104.179 us |  -2.02% |  🟢 FAST  |
|   I64   |      I32      |      2^16      |  10.749 us |       8.20% |  11.017 us |       6.07% |    0.268 us |   2.50% |  🔵 SAME  |
|   I64   |      I32      |      2^20      |  15.627 us |       4.51% |  15.560 us |       4.31% |   -0.067 us |  -0.43% |  🔵 SAME  |
|   I64   |      I32      |      2^24      |  62.107 us |       1.65% |  60.344 us |       1.53% |   -1.763 us |  -2.84% |  🟢 FAST  |
|   I64   |      I32      |      2^28      | 758.598 us |       0.13% | 726.243 us |       0.14% |  -32.356 us |  -4.27% |  🟢 FAST  |
|   I64   |      I64      |      2^16      |  11.248 us |       1.38% |  11.237 us |       2.04% |   -0.011 us |  -0.10% |  🔵 SAME  |
|   I64   |      I64      |      2^20      |  15.340 us |       1.00% |  15.344 us |       1.31% |    0.004 us |   0.02% |  🔵 SAME  |
|   I64   |      I64      |      2^24      |  63.520 us |       1.88% |  61.782 us |       1.92% |   -1.737 us |  -2.74% |  🟢 FAST  |
|   I64   |      I64      |      2^28      | 759.112 us |       0.14% | 727.555 us |       0.16% |  -31.557 us |  -4.16% |  🟢 FAST  |
|   I64   |      I64      |      2^32      |  11.905 ms |       0.01% |  11.391 ms |       0.02% | -513.716 us |  -4.32% |  🟢 FAST  |
|  I128   |      I32      |      2^16      |  13.147 us |       4.08% |  13.105 us |       4.80% |   -0.042 us |  -0.32% |  🔵 SAME  |
|  I128   |      I32      |      2^20      |  23.539 us |       0.48% |  23.513 us |       1.10% |   -0.026 us |  -0.11% |  🔵 SAME  |
|  I128   |      I32      |      2^24      | 180.714 us |       0.82% | 179.590 us |       0.79% |   -1.124 us |  -0.62% |  🔵 SAME  |
|  I128   |      I32      |      2^28      |   2.689 ms |       0.09% |   2.672 ms |       0.09% |  -16.914 us |  -0.63% |  🟢 FAST  |
|  I128   |      I64      |      2^16      |  11.805 us |       7.58% |  11.771 us |       7.54% |   -0.034 us |  -0.29% |  🔵 SAME  |
|  I128   |      I64      |      2^20      |  25.522 us |       2.80% |  25.492 us |       2.73% |   -0.030 us |  -0.12% |  🔵 SAME  |
|  I128   |      I64      |      2^24      | 180.856 us |       0.79% | 179.440 us |       0.70% |   -1.416 us |  -0.78% |  🟢 FAST  |
|  I128   |      I64      |      2^28      |   2.687 ms |       0.08% |   2.668 ms |       0.08% |  -18.918 us |  -0.70% |  🟢 FAST  |
|  I128   |      I64      |      2^32      |  42.840 ms |       0.02% |  42.537 ms |       0.02% | -302.814 us |  -0.71% |  🟢 FAST  |
|   F32   |      I32      |      2^16      |  10.039 us |       9.99% |  10.174 us |       9.99% |    0.136 us |   1.35% |  🔵 SAME  |
|   F32   |      I32      |      2^20      |  14.315 us |       7.23% |  14.174 us |       7.40% |   -0.141 us |  -0.99% |  🔵 SAME  |
|   F32   |      I32      |      2^24      |  40.813 us |       3.68% |  39.986 us |       3.83% |   -0.827 us |  -2.03% |  🔵 SAME  |
|   F32   |      I32      |      2^28      | 358.177 us |       0.38% | 343.340 us |       0.43% |  -14.837 us |  -4.14% |  🟢 FAST  |
|   F32   |      I64      |      2^16      |   9.937 us |       9.85% |  10.088 us |       9.85% |    0.150 us |   1.51% |  🔵 SAME  |
|   F32   |      I64      |      2^20      |  14.433 us |       7.40% |  14.162 us |       7.37% |   -0.270 us |  -1.87% |  🔵 SAME  |
|   F32   |      I64      |      2^24      |  40.861 us |       3.43% |  40.089 us |       3.69% |   -0.772 us |  -1.89% |  🔵 SAME  |
|   F32   |      I64      |      2^28      | 358.413 us |       0.38% | 343.320 us |       0.40% |  -15.092 us |  -4.21% |  🟢 FAST  |
|   F32   |      I64      |      2^32      |   5.448 ms |       0.36% |   5.252 ms |       0.63% | -195.738 us |  -3.59% |  🟢 FAST  |
|   F64   |      I32      |      2^16      |  11.250 us |       1.00% |  11.268 us |       2.20% |    0.018 us |   0.16% |  🔵 SAME  |
|   F64   |      I32      |      2^20      |  15.608 us |       4.45% |  15.683 us |       4.93% |    0.075 us |   0.48% |  🔵 SAME  |
|   F64   |      I32      |      2^24      |  63.617 us |       1.71% |  61.822 us |       1.87% |   -1.795 us |  -2.82% |  🟢 FAST  |
|   F64   |      I32      |      2^28      | 761.071 us |       0.14% | 730.407 us |       0.17% |  -30.664 us |  -4.03% |  🟢 FAST  |
|   F64   |      I64      |      2^16      |  11.255 us |       0.94% |  11.231 us |       2.16% |   -0.024 us |  -0.22% |  🔵 SAME  |
|   F64   |      I64      |      2^20      |  15.521 us |       3.88% |  15.421 us |       3.39% |   -0.100 us |  -0.65% |  🔵 SAME  |
|   F64   |      I64      |      2^24      |  63.846 us |       1.71% |  61.769 us |       1.88% |   -2.078 us |  -3.25% |  🟢 FAST  |
|   F64   |      I64      |      2^28      | 761.599 us |       0.15% | 730.622 us |       0.15% |  -30.977 us |  -4.07% |  🟢 FAST  |
|   F64   |      I64      |      2^32      |  11.942 ms |       0.02% |  11.488 ms |       0.29% | -453.330 us |  -3.80% |  🟢 FAST  |
|   C32   |      I32      |      2^16      | 112.108 us |       2.80% | 111.996 us |       2.92% |   -0.113 us |  -0.10% |  🔵 SAME  |
|   C32   |      I32      |      2^20      | 157.312 us |       1.78% | 179.632 us |       1.34% |   22.320 us |  14.19% |  🔴 SLOW  |
|   C32   |      I32      |      2^24      |   1.251 ms |       5.28% |   1.191 ms |       5.17% |  -60.440 us |  -4.83% |  🔵 SAME  |
|   C32   |      I32      |      2^28      |  16.473 ms |       2.72% |  16.124 ms |       1.86% | -349.160 us |  -2.12% |  🟢 FAST  |
|   C32   |      I64      |      2^16      | 110.971 us |       0.88% | 111.233 us |       0.76% |    0.262 us |   0.24% |  🔵 SAME  |
|   C32   |      I64      |      2^20      | 170.307 us |       6.18% | 167.945 us |       6.02% |   -2.363 us |  -1.39% |  🔵 SAME  |
|   C32   |      I64      |      2^24      |   1.237 ms |       6.17% |   1.238 ms |       5.79% |    1.207 us |   0.10% |  🔵 SAME  |
|   C32   |      I64      |      2^28      |  16.324 ms |       2.98% |  16.296 ms |       2.66% |  -28.473 us |  -0.17% |  🔵 SAME  |
|   C32   |      I64      |      2^32      | 253.927 ms |       2.64% | 255.786 ms |       2.57% |    1.859 ms |   0.73% |  🔵 SAME  |
```
</details>

<details>
<summary> bench.exclusive_scan.sum </summary>

```
['results/warpspeed_unstable_ballot_sync_base/B200/sum/sum.json', 'results/warpspeed_unstable_ballot_sync/B200/sum/sum.json']
# base

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I32      |      2^16      |  11.253 us |       1.09% |  11.251 us |       1.75% |   -0.002 us |  -0.02% |  🔵 SAME  |
|   I8    |      I32      |      2^20      |  12.497 us |       7.78% |  13.029 us |       4.84% |    0.532 us |   4.26% |  🔵 SAME  |
|   I8    |      I32      |      2^24      |  27.888 us |       2.39% |  27.854 us |       2.24% |   -0.034 us |  -0.12% |  🔵 SAME  |
|   I8    |      I32      |      2^28      | 212.757 us |       0.56% | 212.285 us |       0.62% |   -0.473 us |  -0.22% |  🔵 SAME  |
|   I8    |      I64      |      2^16      |  11.101 us |       4.85% |  11.082 us |       5.20% |   -0.019 us |  -0.17% |  🔵 SAME  |
|   I8    |      I64      |      2^20      |  12.209 us |       8.34% |  11.625 us |       7.28% |   -0.584 us |  -4.78% |  🔵 SAME  |
|   I8    |      I64      |      2^24      |  27.881 us |       2.40% |  27.891 us |       2.41% |    0.011 us |   0.04% |  🔵 SAME  |
|   I8    |      I64      |      2^28      | 214.019 us |       0.44% | 213.565 us |       0.49% |   -0.454 us |  -0.21% |  🔵 SAME  |
|   I8    |      I64      |      2^32      |   3.225 ms |       0.31% |   3.219 ms |       0.40% |   -6.526 us |  -0.20% |  🔵 SAME  |
|   I16   |      I32      |      2^16      |  11.249 us |       1.34% |  11.242 us |       1.76% |   -0.006 us |  -0.06% |  🔵 SAME  |
|   I16   |      I32      |      2^20      |  13.318 us |       3.27% |  13.242 us |       3.25% |   -0.075 us |  -0.57% |  🔵 SAME  |
|   I16   |      I32      |      2^24      |  29.966 us |       4.31% |  29.903 us |       4.40% |   -0.064 us |  -0.21% |  🔵 SAME  |
|   I16   |      I32      |      2^28      | 212.939 us |       0.61% | 212.466 us |       0.58% |   -0.472 us |  -0.22% |  🔵 SAME  |
|   I16   |      I64      |      2^16      |  11.078 us |       5.24% |  11.143 us |       4.29% |    0.065 us |   0.59% |  🔵 SAME  |
|   I16   |      I64      |      2^20      |  13.266 us |       3.05% |  13.231 us |       3.89% |   -0.035 us |  -0.26% |  🔵 SAME  |
|   I16   |      I64      |      2^24      |  27.234 us |       3.70% |  27.433 us |       3.71% |    0.199 us |   0.73% |  🔵 SAME  |
|   I16   |      I64      |      2^28      | 213.110 us |       0.60% | 212.938 us |       0.59% |   -0.172 us |  -0.08% |  🔵 SAME  |
|   I16   |      I64      |      2^32      |   3.239 ms |       1.48% |   3.239 ms |       1.34% |   -0.378 us |  -0.01% |  🔵 SAME  |
|   I32   |      I32      |      2^16      |   9.599 us |       8.42% |   9.832 us |       9.58% |    0.233 us |   2.43% |  🔵 SAME  |
|   I32   |      I32      |      2^20      |  13.254 us |       6.46% |  13.379 us |       6.94% |    0.125 us |   0.94% |  🔵 SAME  |
|   I32   |      I32      |      2^24      |  32.277 us |       4.08% |  31.962 us |       4.41% |   -0.314 us |  -0.97% |  🔵 SAME  |
|   I32   |      I32      |      2^28      | 321.819 us |       0.54% | 322.162 us |       0.57% |    0.343 us |   0.11% |  🔵 SAME  |
|   I32   |      I64      |      2^16      |   9.344 us |       5.58% |   9.562 us |       8.10% |    0.218 us |   2.33% |  🔵 SAME  |
|   I32   |      I64      |      2^20      |  13.309 us |       5.52% |  13.171 us |       5.60% |   -0.138 us |  -1.03% |  🔵 SAME  |
|   I32   |      I64      |      2^24      |  32.193 us |       4.81% |  32.068 us |       4.87% |   -0.125 us |  -0.39% |  🔵 SAME  |
|   I32   |      I64      |      2^28      | 321.450 us |       0.55% | 322.254 us |       0.52% |    0.804 us |   0.25% |  🔵 SAME  |
|   I32   |      I64      |      2^32      |   4.982 ms |       1.00% |   4.968 ms |       0.89% |  -14.362 us |  -0.29% |  🔵 SAME  |
|   I64   |      I32      |      2^16      |  12.533 us |       7.95% |  11.862 us |       8.04% |   -0.671 us |  -5.35% |  🔵 SAME  |
|   I64   |      I32      |      2^20      |  16.109 us |       6.17% |  16.057 us |       6.13% |   -0.052 us |  -0.32% |  🔵 SAME  |
|   I64   |      I32      |      2^24      |  55.231 us |       2.34% |  54.206 us |       1.97% |   -1.025 us |  -1.86% |  🔵 SAME  |
|   I64   |      I32      |      2^28      | 630.209 us |       1.14% | 624.721 us |       0.28% |   -5.488 us |  -0.87% |  🟢 FAST  |
|   I64   |      I64      |      2^16      |  11.258 us |       0.39% |  11.253 us |       0.47% |   -0.005 us |  -0.04% |  🔵 SAME  |
|   I64   |      I64      |      2^20      |  15.338 us |       1.38% |  15.291 us |       2.32% |   -0.047 us |  -0.31% |  🔵 SAME  |
|   I64   |      I64      |      2^24      |  55.368 us |       2.36% |  54.151 us |       2.08% |   -1.217 us |  -2.20% |  🟢 FAST  |
|   I64   |      I64      |      2^28      | 622.896 us |       0.21% | 624.714 us |       0.30% |    1.818 us |   0.29% |  🔴 SLOW  |
|   I64   |      I64      |      2^32      |  10.280 ms |       0.64% |  10.242 ms |       0.68% |  -37.930 us |  -0.37% |  🔵 SAME  |
|  I128   |      I32      |      2^16      |  13.248 us |       5.01% |  13.442 us |       5.57% |    0.194 us |   1.47% |  🔵 SAME  |
|  I128   |      I32      |      2^20      |  21.487 us |       0.52% |  21.505 us |       0.69% |    0.018 us |   0.08% |  🔵 SAME  |
|  I128   |      I32      |      2^24      | 145.802 us |       0.85% | 147.033 us |       0.80% |    1.231 us |   0.84% |  🔴 SLOW  |
|  I128   |      I32      |      2^28      |   2.010 ms |       0.20% |   2.046 ms |       0.15% |   36.003 us |   1.79% |  🔴 SLOW  |
|  I128   |      I64      |      2^16      |  11.325 us |       3.45% |  11.364 us |       4.13% |    0.039 us |   0.34% |  🔵 SAME  |
|  I128   |      I64      |      2^20      |  23.306 us |       3.33% |  23.402 us |       3.41% |    0.096 us |   0.41% |  🔵 SAME  |
|  I128   |      I64      |      2^24      | 145.593 us |       0.90% | 147.147 us |       0.82% |    1.554 us |   1.07% |  🔴 SLOW  |
|  I128   |      I64      |      2^28      |   2.011 ms |       0.20% |   2.047 ms |       0.15% |   35.990 us |   1.79% |  🔴 SLOW  |
|  I128   |      I64      |      2^32      |  31.666 ms |       0.05% |  32.328 ms |       0.03% |  661.768 us |   2.09% |  🔴 SLOW  |
|   F32   |      I32      |      2^16      |  10.365 us |       9.73% |  10.209 us |       9.96% |   -0.156 us |  -1.51% |  🔵 SAME  |
|   F32   |      I32      |      2^20      |  13.694 us |       7.12% |  13.607 us |       6.89% |   -0.087 us |  -0.63% |  🔵 SAME  |
|   F32   |      I32      |      2^24      |  38.085 us |       3.73% |  37.633 us |       3.71% |   -0.452 us |  -1.19% |  🔵 SAME  |
|   F32   |      I32      |      2^28      | 320.198 us |       0.50% | 320.652 us |       0.56% |    0.453 us |   0.14% |  🔵 SAME  |
|   F32   |      I64      |      2^16      |  10.186 us |       9.92% |  10.150 us |      10.04% |   -0.036 us |  -0.36% |  🔵 SAME  |
|   F32   |      I64      |      2^20      |  13.827 us |       7.17% |  13.797 us |       6.93% |   -0.030 us |  -0.22% |  🔵 SAME  |
|   F32   |      I64      |      2^24      |  38.248 us |       3.60% |  38.033 us |       3.64% |   -0.215 us |  -0.56% |  🔵 SAME  |
|   F32   |      I64      |      2^28      | 320.024 us |       0.47% | 320.772 us |       0.51% |    0.749 us |   0.23% |  🔵 SAME  |
|   F32   |      I64      |      2^32      |   4.868 ms |       0.71% |   4.854 ms |       0.88% |  -14.082 us |  -0.29% |  🔵 SAME  |
|   F64   |      I32      |      2^16      |  11.385 us |       4.30% |  11.415 us |       4.76% |    0.030 us |   0.26% |  🔵 SAME  |
|   F64   |      I32      |      2^20      |  16.353 us |       6.27% |  15.993 us |       6.02% |   -0.360 us |  -2.20% |  🔵 SAME  |
|   F64   |      I32      |      2^24      |  57.719 us |       1.96% |  56.479 us |       1.82% |   -1.240 us |  -2.15% |  🟢 FAST  |
|   F64   |      I32      |      2^28      | 639.774 us |       0.20% | 621.950 us |       0.23% |  -17.825 us |  -2.79% |  🟢 FAST  |
|   F64   |      I64      |      2^16      |  11.262 us |       1.17% |  11.261 us |       0.66% |   -0.001 us |  -0.01% |  🔵 SAME  |
|   F64   |      I64      |      2^20      |  15.934 us |       5.84% |  15.794 us |       5.55% |   -0.140 us |  -0.88% |  🔵 SAME  |
|   F64   |      I64      |      2^24      |  57.612 us |       1.91% |  56.336 us |       1.83% |   -1.276 us |  -2.22% |  🟢 FAST  |
|   F64   |      I64      |      2^28      | 639.608 us |       0.20% | 622.001 us |       0.21% |  -17.607 us |  -2.75% |  🟢 FAST  |
|   F64   |      I64      |      2^32      |  10.053 ms |       3.63% |   9.826 ms |       0.46% | -227.572 us |  -2.26% |  🟢 FAST  |
|   C32   |      I32      |      2^16      |  11.291 us |       2.65% |  11.398 us |       4.59% |    0.107 us |   0.95% |  🔵 SAME  |
|   C32   |      I32      |      2^20      |  15.509 us |       3.68% |  15.535 us |       3.89% |    0.026 us |   0.16% |  🔵 SAME  |
|   C32   |      I32      |      2^24      |  55.587 us |       1.96% |  54.837 us |       1.90% |   -0.750 us |  -1.35% |  🔵 SAME  |
|   C32   |      I32      |      2^28      | 623.834 us |       0.17% | 622.039 us |       0.20% |   -1.795 us |  -0.29% |  🟢 FAST  |
|   C32   |      I64      |      2^16      |  11.254 us |       0.39% |  11.217 us |       2.17% |   -0.037 us |  -0.33% |  🔵 SAME  |
|   C32   |      I64      |      2^20      |  15.484 us |       3.42% |  15.595 us |       4.59% |    0.112 us |   0.72% |  🔵 SAME  |
|   C32   |      I64      |      2^24      |  55.578 us |       1.96% |  54.785 us |       1.94% |   -0.794 us |  -1.43% |  🔵 SAME  |
|   C32   |      I64      |      2^28      | 623.708 us |       0.16% | 622.077 us |       0.21% |   -1.631 us |  -0.26% |  🟢 FAST  |
|   C32   |      I64      |      2^32      |   9.769 ms |       0.15% |   9.713 ms |       0.08% |  -55.701 us |  -0.57% |  🟢 FAST  |
```
</details>


<details>
<summary> bench.exclusive_scan.look_ahead.sum </summary>

```
['results/warpspeed_unstable_ballot_sync_base/B200/lookahead/lookahead.json', 'results/warpspeed_unstable_ballot_sync/B200/lookahead/lookahead.json']
# base

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I64      |      2^16      |  11.249 us |       1.88% |  11.252 us |       1.46% |    0.003 us |   0.03% |  🔵 SAME  |
|   I8    |      I64      |      2^20      |  12.452 us |       7.85% |  13.022 us |       4.73% |    0.571 us |   4.58% |  🔵 SAME  |
|   I8    |      I64      |      2^24      |  27.819 us |       2.07% |  27.797 us |       1.93% |   -0.022 us |  -0.08% |  🔵 SAME  |
|   I8    |      I64      |      2^28      | 212.803 us |       0.56% | 212.243 us |       0.61% |   -0.559 us |  -0.26% |  🔵 SAME  |
|   I8    |      I64      |      2^32      |   3.227 ms |       0.39% |   3.220 ms |       0.36% |   -6.501 us |  -0.20% |  🔵 SAME  |
|   I16   |      I64      |      2^16      |  10.528 us |       8.63% |  10.445 us |       9.05% |   -0.084 us |  -0.80% |  🔵 SAME  |
|   I16   |      I64      |      2^20      |  13.308 us |       1.97% |  13.250 us |       3.80% |   -0.058 us |  -0.44% |  🔵 SAME  |
|   I16   |      I64      |      2^24      |  30.353 us |       4.13% |  30.447 us |       4.20% |    0.094 us |   0.31% |  🔵 SAME  |
|   I16   |      I64      |      2^28      | 209.891 us |       0.54% | 209.516 us |       0.53% |   -0.376 us |  -0.18% |  🔵 SAME  |
|   I16   |      I64      |      2^32      |   3.242 ms |       1.29% |   3.241 ms |       1.37% |   -0.846 us |  -0.03% |  🔵 SAME  |
|   I32   |      I64      |      2^16      |   9.994 us |       9.93% |  10.052 us |      10.02% |    0.058 us |   0.58% |  🔵 SAME  |
|   I32   |      I64      |      2^20      |  13.451 us |       5.42% |  13.385 us |       5.86% |   -0.066 us |  -0.49% |  🔵 SAME  |
|   I32   |      I64      |      2^24      |  34.119 us |       3.02% |  33.899 us |       3.36% |   -0.220 us |  -0.65% |  🔵 SAME  |
|   I32   |      I64      |      2^28      | 321.320 us |       0.53% | 322.140 us |       0.57% |    0.819 us |   0.26% |  🔵 SAME  |
|   I32   |      I64      |      2^32      |   4.978 ms |       1.07% |   4.973 ms |       0.95% |   -5.156 us |  -0.10% |  🔵 SAME  |
|   I64   |      I64      |      2^16      |  12.219 us |       8.31% |  12.070 us |       8.22% |   -0.149 us |  -1.22% |  🔵 SAME  |
|   I64   |      I64      |      2^20      |  16.041 us |       6.06% |  15.902 us |       5.85% |   -0.138 us |  -0.86% |  🔵 SAME  |
|   I64   |      I64      |      2^24      |  55.024 us |       2.66% |  54.650 us |       2.03% |   -0.374 us |  -0.68% |  🔵 SAME  |
|   I64   |      I64      |      2^28      | 622.738 us |       0.20% | 624.592 us |       0.30% |    1.853 us |   0.30% |  🔴 SLOW  |
|   I64   |      I64      |      2^32      |  10.277 ms |       0.62% |  10.245 ms |       0.73% |  -31.198 us |  -0.30% |  🔵 SAME  |
|  I128   |      I64      |      2^16      |  13.327 us |       5.45% |  13.507 us |       5.70% |    0.180 us |   1.35% |  🔵 SAME  |
|  I128   |      I64      |      2^20      |  21.046 us |       4.05% |  21.473 us |       1.06% |    0.427 us |   2.03% |  🔴 SLOW  |
|  I128   |      I64      |      2^24      | 145.029 us |       0.81% | 147.540 us |       0.90% |    2.512 us |   1.73% |  🔴 SLOW  |
|  I128   |      I64      |      2^28      |   2.009 ms |       0.21% |   2.046 ms |       0.14% |   36.708 us |   1.83% |  🔴 SLOW  |
|  I128   |      I64      |      2^32      |  31.668 ms |       0.04% |  32.326 ms |       0.03% |  658.709 us |   2.08% |  🔴 SLOW  |
|   F32   |      I64      |      2^16      |   9.680 us |       8.83% |   9.586 us |       8.23% |   -0.094 us |  -0.97% |  🔵 SAME  |
|   F32   |      I64      |      2^20      |  13.147 us |       4.44% |  13.017 us |       5.49% |   -0.130 us |  -0.99% |  🔵 SAME  |
|   F32   |      I64      |      2^24      |  37.274 us |       3.56% |  36.790 us |       3.74% |   -0.485 us |  -1.30% |  🔵 SAME  |
|   F32   |      I64      |      2^28      | 318.108 us |       0.40% | 318.518 us |       0.47% |    0.410 us |   0.13% |  🔵 SAME  |
|   F32   |      I64      |      2^32      |   4.865 ms |       0.77% |   4.851 ms |       0.77% |  -13.457 us |  -0.28% |  🔵 SAME  |
|   F64   |      I64      |      2^16      |  11.243 us |       0.84% |  11.246 us |       0.67% |    0.003 us |   0.03% |  🔵 SAME  |
|   F64   |      I64      |      2^20      |  15.362 us |       1.44% |  15.380 us |       1.82% |    0.018 us |   0.12% |  🔵 SAME  |
|   F64   |      I64      |      2^24      |  57.377 us |       2.16% |  55.842 us |       1.85% |   -1.535 us |  -2.68% |  🟢 FAST  |
|   F64   |      I64      |      2^28      | 639.248 us |       0.24% | 621.273 us |       0.24% |  -17.974 us |  -2.81% |  🟢 FAST  |
|   F64   |      I64      |      2^32      |  10.036 ms |       0.22% |   9.826 ms |       0.50% | -209.353 us |  -2.09% |  🟢 FAST  |
|   C32   |      I64      |      2^16      |  10.751 us |       8.32% |  10.635 us |       8.75% |   -0.116 us |  -1.08% |  🔵 SAME  |
|   C32   |      I64      |      2^20      |  14.792 us |       6.21% |  14.745 us |       6.39% |   -0.047 us |  -0.32% |  🔵 SAME  |
|   C32   |      I64      |      2^24      |  55.504 us |       2.09% |  54.429 us |       2.46% |   -1.075 us |  -1.94% |  🔵 SAME  |
|   C32   |      I64      |      2^28      | 623.506 us |       0.23% | 621.682 us |       0.27% |   -1.824 us |  -0.29% |  🟢 FAST  |
|   C32   |      I64      |      2^32      |   9.767 ms |       0.13% |   9.711 ms |       0.05% |  -55.671 us |  -0.57% |  🟢 FAST  |
```
</details>


<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
