### PR TITLE
[libcu++] Implement `cuda::std::formatted_size`

### DIFF
--- a/libcudacxx/include/cuda/std/__format/format_arg_store.h
+++ b/libcudacxx/include/cuda/std/__format/format_arg_store.h
@@ -27,6 +27,7 @@
 #include <cuda/std/__format/format_arg.h>
 #include <cuda/std/__string/char_traits.h>
 #include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/extent.h>
 #include <cuda/std/__type_traits/is_integer.h>
 #include <cuda/std/__type_traits/is_signed.h>
@@ -44,12 +45,12 @@ inline constexpr bool __is_bounded_array_of = false;
 template <class _Elem, size_t _Len>
 inline constexpr bool __is_bounded_array_of<_Elem[_Len], _Elem> = true;
 
-template <class _Context, class _Tp>
-[[nodiscard]] _CCCL_HOST_DEVICE_API _CCCL_CONSTEVAL __fmt_arg_t __fmt_determine_arg_t()
+template <class _Context, class _Tp, class _Dummy>
+[[nodiscard]] _CCCL_HOST_DEVICE_API _CCCL_CONSTEVAL __fmt_arg_t __fmt_determine_arg_t_impl(_Dummy) noexcept
 {
   using _CtxCharT = typename _Context::char_type;
 
-  __fmt_arg_t __ret = __fmt_arg_t::__none;
+  __fmt_arg_t __ret = __fmt_arg_t::__handle;
 
   if constexpr (is_same_v<_Tp, bool>)
   {
@@ -113,20 +114,27 @@ template <class _Context, class _Tp>
   {
     __ret = __fmt_arg_t::__ptr;
   }
-
-  if constexpr (__formattable_with<_Tp, _Context>)
-  {
-    __ret = (__ret == __fmt_arg_t::__none) ? __fmt_arg_t::__handle : __ret;
-  }
-
   return __ret;
+}
+
+template <class _Context, class _Tp>
+[[nodiscard]] _CCCL_HOST_DEVICE_API _CCCL_CONSTEVAL enable_if_t<!__formattable_with<_Tp, _Context>, __fmt_arg_t>
+__fmt_determine_arg_t_impl(int) noexcept
+{
+  return __fmt_arg_t::__none;
+}
+
+template <class _Context, class _Tp>
+[[nodiscard]] _CCCL_HOST_DEVICE_API _CCCL_CONSTEVAL __fmt_arg_t __fmt_determine_arg_t() noexcept
+{
+  return ::cuda::std::__fmt_determine_arg_t_impl<_Context, _Tp>(0);
 }
 
 template <class _Context, class _Tp>
 [[nodiscard]] _CCCL_HOST_DEVICE_API basic_format_arg<_Context> __fmt_make_format_arg(_Tp& __value) noexcept
 {
   using _Dp                   = remove_const_t<_Tp>;
-  constexpr __fmt_arg_t __arg = __fmt_determine_arg_t<_Context, _Dp>();
+  constexpr __fmt_arg_t __arg = ::cuda::std::__fmt_determine_arg_t<_Context, _Dp>();
 
   static_assert(__arg != __fmt_arg_t::__none, "the supplied type is not formattable");
   static_assert(__formattable_with<_Tp, _Context>);

--- a/libcudacxx/include/cuda/std/__format/formatted_size.h
+++ b/libcudacxx/include/cuda/std/__format/formatted_size.h
@@ -1,0 +1,99 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___FORMAT_FORMATTED_SIZE_H
+#define _CUDA_STD___FORMAT_FORMATTED_SIZE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__format/buffer.h>
+#include <cuda/std/__format/format_args.h>
+#include <cuda/std/__format/format_context.h>
+#include <cuda/std/__format/format_parse_context.h>
+#include <cuda/std/__format/format_string.h>
+#include <cuda/std/__utility/move.h>
+#include <cuda/std/string_view>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+// A buffer that counts the number of insertions.
+//
+// Since formatted_size only needs to know the size, the output itself is
+// discarded.
+template <class _CharT>
+class __fmt_formatted_size_buffer : __fmt_output_buffer<_CharT>
+{
+  __fmt_max_output_size __max_output_size_{0};
+
+  _CCCL_API static constexpr void __prepare_write(__fmt_output_buffer<_CharT>&, size_t)
+  {
+    // Note this function does not satisfy the requirement of giving a 1 code unit buffer.
+    _CCCL_ASSERT(false, "Since __max_output_size_.__max_size_ == 0 there should never be call to this function.");
+  }
+
+public:
+  using _Base _CCCL_NODEBUG_ALIAS = __fmt_output_buffer<_CharT>;
+
+  _CCCL_API constexpr __fmt_formatted_size_buffer() noexcept
+      : _Base{nullptr, 0, __prepare_write, &__max_output_size_}
+  {}
+
+  [[nodiscard]] _CCCL_API constexpr auto __make_output_iterator()
+  {
+    return _Base::__make_output_iterator();
+  }
+
+  // This function does not need to be r-value qualified, however this is
+  // consistent with similar objects.
+  [[nodiscard]] _CCCL_API constexpr size_t __result() &&
+  {
+    return __max_output_size_.__code_units_written();
+  }
+};
+
+template <class _CharT, class _FmtArgs>
+[[nodiscard]] _CCCL_API size_t __formatted_size_impl(basic_string_view<_CharT> __fmt, _FmtArgs __args)
+{
+  __fmt_formatted_size_buffer<_CharT> __buffer;
+  (void) ::cuda::std::__fmt_vformat_to(
+    basic_format_parse_context{__fmt, __args.__size()},
+    ::cuda::std::__fmt_make_format_context(__buffer.__make_output_iterator(), __args));
+  return ::cuda::std::move(__buffer).__result();
+}
+
+template <class... _Args>
+[[nodiscard]] _CCCL_API size_t formatted_size(format_string<_Args...> __fmt, _Args&&... __args)
+{
+  return ::cuda::std::__formatted_size_impl(__fmt.get(), basic_format_args{::cuda::std::make_format_args(__args...)});
+}
+
+#if _CCCL_HAS_WCHAR_T()
+template <class... _Args>
+[[nodiscard]] _CCCL_API size_t formatted_size(wformat_string<_Args...> __fmt, _Args&&... __args)
+{
+  return ::cuda::std::__formatted_size_impl(__fmt.get(), basic_format_args{::cuda::std::make_wformat_args(__args...)});
+}
+#endif // _CCCL_HAS_WCHAR_T()
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD___FORMAT_FORMATTED_SIZE_H

--- a/libcudacxx/include/cuda/std/__format/validation.h
+++ b/libcudacxx/include/cuda/std/__format/validation.h
@@ -86,8 +86,6 @@ class __fmt_validation_format_context
 
 public:
   using char_type = _CharT;
-  template <class _Tp>
-  using formatter_type = formatter<_Tp, _CharT>;
 
   //! @brief Dummy iterator. During the compile-time validation nothing needs to be written. Therefore all operations of
   //!        this iterator are a NOP.

--- a/libcudacxx/include/cuda/std/__format_
+++ b/libcudacxx/include/cuda/std/__format_
@@ -32,6 +32,7 @@
 #include <cuda/std/__format/format_parse_context.h>
 #include <cuda/std/__format/format_spec_parser.h>
 #include <cuda/std/__format/format_string.h>
+#include <cuda/std/__format/formatted_size.h>
 #include <cuda/std/__format/formatter.h>
 #include <cuda/std/__format/formatters/bool.h>
 #include <cuda/std/__format/formatters/char.h>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/checkers/formatted_size.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/checkers/formatted_size.h
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__format_>
+#include <cuda/std/string_view>
+#include <cuda/std/utility>
+
+#include "format_functions_common.h"
+#include "test_macros.h"
+
+template <class CharT, class... Args>
+TEST_FUNC _CCCL_NOINLINE bool
+check(cuda::std::basic_string_view<CharT> expected, test_format_string<CharT, Args...> fmt, Args&&... args)
+{
+  const auto size = cuda::std::formatted_size(fmt, cuda::std::forward<Args>(args)...);
+  return size == expected.size();
+}
+
+template <class CharT, class... Args>
+TEST_FUNC bool check_exception(cuda::std::string_view, cuda::std::basic_string_view<CharT>, Args&&...)
+{
+  // After P2216 most exceptions thrown by std::formatted_size become ill-formed.
+  // Therefore this tests does nothing.
+  // A basic ill-formed test is done in formatted_size.verify.cpp
+  // The exceptions are tested by other functions that don't use the basic-format-string as fmt argument.
+
+  return true;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/formatted_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/formatted_size.pass.cpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
+// <cuda/std/format>
+
+// template<class... Args>
+//   size_t formatted_size(format-string<Args...> fmt, const Args&... args);
+// template<class... Args>
+//   size_t formatted_size(wformat-string<Args...> fmt, const Args&... args);
+
+#include <cuda/std/__format_>
+#include <cuda/std/cstddef>
+#include <cuda/std/type_traits>
+
+static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::std::formatted_size(""))>);
+static_assert(!noexcept(cuda::std::formatted_size("")));
+#if _CCCL_HAS_WCHAR_T()
+static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::std::formatted_size(L""))>);
+static_assert(!noexcept(cuda::std::formatted_size(L"")));
+#endif // _CCCL_HAS_WCHAR_T()
+
+#include "checkers/formatted_size.h"
+#include "tests/smoke.h"

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/bool.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/bool.h
@@ -14,11 +14,8 @@
 #include "test_macros.h"
 
 // Provided by the selected checker.
-template <class CharT, class... Args>
-TEST_FUNC bool
-check(cuda::std::basic_string_view<CharT> expected, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
-template <class CharT, class... Args>
-TEST_FUNC bool check_exception(cuda::std::string_view what, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+TEST_FUNC bool check(...);
+TEST_FUNC bool check_exception(...);
 
 template <class CharT>
 TEST_FUNC void test_bool()

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/buffer.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/buffer.h
@@ -16,11 +16,8 @@
 #include "test_macros.h"
 
 // Provided by the selected checker.
-template <class CharT, class... Args>
-TEST_FUNC bool
-check(cuda::std::basic_string_view<CharT> expected, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
-template <class CharT, class... Args>
-TEST_FUNC bool check_exception(cuda::std::string_view what, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+TEST_FUNC bool check(...);
+TEST_FUNC bool check_exception(...);
 
 template <class CharT>
 TEST_FUNC void test_buffer_copy()

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/char.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/char.h
@@ -14,11 +14,8 @@
 #include "test_macros.h"
 
 // Provided by the selected checker.
-template <class CharT, class... Args>
-TEST_FUNC bool
-check(cuda::std::basic_string_view<CharT> expected, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
-template <class CharT, class... Args>
-TEST_FUNC bool check_exception(cuda::std::string_view what, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+TEST_FUNC bool check(...);
+TEST_FUNC bool check_exception(...);
 
 template <class CharT>
 TEST_FUNC void test_char()

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/handle.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/handle.h
@@ -14,11 +14,8 @@
 #include "test_macros.h"
 
 // Provided by the selected checker.
-template <class CharT, class... Args>
-TEST_FUNC bool
-check(cuda::std::basic_string_view<CharT> expected, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
-template <class CharT, class... Args>
-TEST_FUNC bool check_exception(cuda::std::string_view what, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+TEST_FUNC bool check(...);
+TEST_FUNC bool check_exception(...);
 
 template <class CharT>
 TEST_FUNC void test_handle()

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/pointer.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/pointer.h
@@ -15,11 +15,8 @@
 #include "test_macros.h"
 
 // Provided by the selected checker.
-template <class CharT, class... Args>
-TEST_FUNC bool
-check(cuda::std::basic_string_view<CharT> expected, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
-template <class CharT, class... Args>
-TEST_FUNC bool check_exception(cuda::std::string_view what, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+TEST_FUNC bool check(...);
+TEST_FUNC bool check_exception(...);
 
 template <class CharT, class T>
 TEST_FUNC void test_pointer()

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/signed_integer.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/signed_integer.h
@@ -16,11 +16,8 @@
 #include "test_macros.h"
 
 // Provided by the selected checker.
-template <class CharT, class... Args>
-TEST_FUNC bool
-check(cuda::std::basic_string_view<CharT> expected, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
-template <class CharT, class... Args>
-TEST_FUNC bool check_exception(cuda::std::string_view what, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+TEST_FUNC bool check(...);
+TEST_FUNC bool check_exception(...);
 
 template <class CharT, class I>
 TEST_FUNC _CCCL_NOINLINE void test_integer_as_integer()

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/smoke.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/smoke.h
@@ -14,11 +14,8 @@
 #include "test_macros.h"
 
 // Provided by the selected checker.
-template <class CharT, class... Args>
-TEST_FUNC bool
-check(cuda::std::basic_string_view<CharT> expected, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
-template <class CharT, class... Args>
-TEST_FUNC bool check_exception(cuda::std::string_view what, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+TEST_FUNC bool check(...);
+TEST_FUNC bool check_exception(...);
 
 template <class CharT>
 TEST_FUNC void smoke_test()

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/string.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/string.h
@@ -16,11 +16,8 @@
 #include "test_macros.h"
 
 // Provided by the selected checker.
-template <class CharT, class... Args>
-TEST_FUNC bool
-check(cuda::std::basic_string_view<CharT> expected, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
-template <class CharT, class... Args>
-TEST_FUNC bool check_exception(cuda::std::string_view what, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+TEST_FUNC bool check(...);
+TEST_FUNC bool check_exception(...);
 
 // Using a const ref for world and universe so a string literal will be a character array.
 // When passed as character array W and U have different types.

--- a/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/unsigned_integer.h
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.functions/tests/unsigned_integer.h
@@ -16,11 +16,8 @@
 #include "test_macros.h"
 
 // Provided by the selected checker.
-template <class CharT, class... Args>
-TEST_FUNC bool
-check(cuda::std::basic_string_view<CharT> expected, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
-template <class CharT, class... Args>
-TEST_FUNC bool check_exception(cuda::std::string_view what, cuda::std::basic_string_view<CharT> fmt, Args&&... args);
+TEST_FUNC bool check(...);
+TEST_FUNC bool check_exception(...);
 
 template <class CharT, class I>
 TEST_FUNC _CCCL_NOINLINE void test_integer_as_integer()

--- a/libcudacxx/test/support/format_functions_common.h
+++ b/libcudacxx/test/support/format_functions_common.h
@@ -22,6 +22,7 @@
 #include <cuda/std/cstring>
 #include <cuda/std/ranges>
 #include <cuda/std/string_view>
+#include <cuda/std/type_traits>
 
 #include "literal.h"
 
@@ -262,5 +263,16 @@ TEST_FUNC constexpr cuda::std::string_view get_format_types()
 // cuda::std::vector<cuda::std::basic_string<CharT>> fmt_invalid_nested_types(cuda::std::string_view valid) {
 //   return detail::fmt_invalid_types<CharT, 2>(valid);
 // }
+
+#if _CCCL_HAS_WCHAR_T()
+template <class CharT, class... Args>
+using test_format_string =
+  cuda::std::conditional_t<cuda::std::is_same_v<CharT, char>,
+                           cuda::std::format_string<Args...>,
+                           cuda::std::wformat_string<Args...>>;
+#else
+template <class CharT, class... Args>
+using test_format_string = cuda::std::format_string<Args...>;
+#endif
 
 #endif // TEST_SUPPORT_FORMAT_FUNCTIONS_COMMON_H


### PR DESCRIPTION
This PR implements `cuda::std::formatted_size` as described in https://en.cppreference.com/cpp/utility/format/formatted_size