### PR TITLE
[libcu++] Guard cuda::args bounds against types without numeric_limits

### DIFF
--- a/libcudacxx/include/cuda/__argument/argument.h
+++ b/libcudacxx/include/cuda/__argument/argument.h
@@ -176,7 +176,7 @@ _CCCL_API constexpr _ElementType __wrapper_static_lowest() noexcept
 {
   if constexpr (::cuda::std::is_same_v<_StaticBounds, no_bounds>)
   {
-    return ::cuda::std::numeric_limits<_ElementType>::lowest();
+    return __type_lowest<_ElementType>();
   }
   else
   {
@@ -189,7 +189,7 @@ _CCCL_API constexpr _ElementType __wrapper_static_highest() noexcept
 {
   if constexpr (::cuda::std::is_same_v<_StaticBounds, no_bounds>)
   {
-    return (::cuda::std::numeric_limits<_ElementType>::max)();
+    return __type_highest<_ElementType>();
   }
   else
   {
@@ -744,7 +744,7 @@ _CCCL_API constexpr auto __constant_sequence_compute_lowest() noexcept
 
   if (__first == __last)
   {
-    return ::cuda::std::numeric_limits<_ElementType>::lowest();
+    return __type_lowest<_ElementType>();
   }
   return static_cast<_ElementType>(*::cuda::std::min_element(__first, __last));
 }
@@ -758,7 +758,7 @@ _CCCL_API constexpr auto __constant_sequence_compute_highest() noexcept
 
   if (__first == __last)
   {
-    return (::cuda::std::numeric_limits<_ElementType>::max)();
+    return __type_highest<_ElementType>();
   }
   return static_cast<_ElementType>(*::cuda::std::max_element(__first, __last));
 }
@@ -779,8 +779,8 @@ struct __traits_impl
   static constexpr bool is_constant     = false;
   static constexpr bool is_deferred     = false;
   static constexpr bool is_single_value = true;
-  static constexpr element_type lowest  = ::cuda::std::numeric_limits<element_type>::lowest();
-  static constexpr element_type highest = (::cuda::std::numeric_limits<element_type>::max)();
+  static constexpr element_type lowest  = __type_lowest<element_type>();
+  static constexpr element_type highest = __type_highest<element_type>();
 };
 
 template <auto _Value, class _Tp>
@@ -887,7 +887,7 @@ _CCCL_TEMPLATE(class _Tp)
 _CCCL_REQUIRES((!__is_wrapper_v<::cuda::std::remove_cv_t<_Tp>>) )
 [[nodiscard]] _CCCL_API constexpr auto __lowest_(_Tp) noexcept
 {
-  return ::cuda::std::numeric_limits<__element_type_of_t<_Tp>>::lowest();
+  return __type_lowest<__element_type_of_t<_Tp>>();
 }
 
 template <auto _Value, class _Tp>
@@ -940,7 +940,7 @@ _CCCL_TEMPLATE(class _Tp)
 _CCCL_REQUIRES((!__is_wrapper_v<::cuda::std::remove_cv_t<_Tp>>) )
 [[nodiscard]] _CCCL_API constexpr auto __highest_(_Tp) noexcept
 {
-  return (::cuda::std::numeric_limits<__element_type_of_t<_Tp>>::max)();
+  return __type_highest<__element_type_of_t<_Tp>>();
 }
 
 template <auto _Value, class _Tp>

--- a/libcudacxx/include/cuda/__argument/argument_bounds.h
+++ b/libcudacxx/include/cuda/__argument/argument_bounds.h
@@ -68,6 +68,38 @@ template <auto _Lower, auto _Upper>
 inline constexpr bool __is_static_bounds_v<static_bounds<_Lower, _Upper>> = true;
 
 // =====================================================================
+// __type_lowest / __type_highest
+// =====================================================================
+
+// The implicit bounds of an element type are derived from cuda::std::numeric_limits. The primary numeric_limits
+// template returns a value-initialized object from lowest()/max() and is therefore meaningless as a bound, so require
+// an explicit specialization rather than silently producing a degenerate range.
+
+//! @brief Returns the lowest value representable by the element type @c _Tp.
+//! @tparam _Tp The element type. It must have a @c cuda::std::numeric_limits specialization.
+//! @return @c cuda::std::numeric_limits<_Tp>::lowest().
+template <class _Tp>
+[[nodiscard]] _CCCL_API constexpr _Tp __type_lowest() noexcept
+{
+  static_assert(::cuda::std::numeric_limits<_Tp>::is_specialized,
+                "cuda::args bounds require a specialized cuda::std::numeric_limits for the element type. Provide "
+                "explicit bounds for element types without a numeric_limits specialization.");
+  return ::cuda::std::numeric_limits<_Tp>::lowest();
+}
+
+//! @brief Returns the highest value representable by the element type @c _Tp.
+//! @tparam _Tp The element type. It must have a @c cuda::std::numeric_limits specialization.
+//! @return @c cuda::std::numeric_limits<_Tp>::max().
+template <class _Tp>
+[[nodiscard]] _CCCL_API constexpr _Tp __type_highest() noexcept
+{
+  static_assert(::cuda::std::numeric_limits<_Tp>::is_specialized,
+                "cuda::args bounds require a specialized cuda::std::numeric_limits for the element type. Provide "
+                "explicit bounds for element types without a numeric_limits specialization.");
+  return (::cuda::std::numeric_limits<_Tp>::max)();
+}
+
+// =====================================================================
 // runtime_bounds
 // =====================================================================
 
@@ -77,8 +109,8 @@ inline constexpr bool __is_static_bounds_v<static_bounds<_Lower, _Upper>> = true
 template <class _Tp>
 class runtime_bounds
 {
-  _Tp __lower_ = ::cuda::std::numeric_limits<_Tp>::lowest();
-  _Tp __upper_ = (::cuda::std::numeric_limits<_Tp>::max)();
+  _Tp __lower_ = __type_lowest<_Tp>();
+  _Tp __upper_ = __type_highest<_Tp>();
 
 public:
   constexpr runtime_bounds() noexcept = default;

--- a/libcudacxx/test/libcudacxx/cuda/argument/argument_bounds.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/argument/argument_bounds.pass.cpp
@@ -10,6 +10,7 @@
 
 #include <cuda/argument>
 #include <cuda/std/cassert>
+#include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
 #include "test_macros.h"
@@ -56,6 +57,13 @@ TEST_FUNC constexpr bool test()
     assert(b.lower() == 10);
     assert(b.upper() == 100);
     static_assert(cuda::std::is_same_v<decltype(b.lower()), int>);
+  }
+
+  // Default runtime bounds span the element type's numeric_limits range
+  {
+    constexpr cuda::args::runtime_bounds<int> b{};
+    static_assert(b.lower() == cuda::std::numeric_limits<int>::lowest());
+    static_assert(b.upper() == (cuda::std::numeric_limits<int>::max)());
   }
 
   // --- argument_bounds factory functions ---

--- a/libcudacxx/test/libcudacxx/cuda/argument/runtime_bounds_unspecialized.fail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/argument/runtime_bounds_unspecialized.fail.cpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/argument>
+
+// A type without a cuda::std::numeric_limits specialization has no meaningful implicit bounds. Default-constructing
+// runtime_bounds for such a type must be rejected at compile time instead of silently producing a degenerate range.
+struct unspecialized_type
+{};
+
+[[maybe_unused]] cuda::args::runtime_bounds<unspecialized_type> invalid_bounds{};
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/argument/traits_unspecialized.fail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/argument/traits_unspecialized.fail.cpp
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/argument>
+
+// Reading the implicit bounds of __traits for an element type without a cuda::std::numeric_limits specialization must
+// fail to compile rather than silently yielding a value-initialized (and therefore meaningless) bound. This exercises
+// the __traits_impl primary-template path, which is the bound surface read by generic consumers.
+struct unspecialized_type
+{};
+
+[[maybe_unused]] constexpr auto invalid_lowest = cuda::args::__traits<unspecialized_type>::lowest;
+
+int main(int, char**)
+{
+  return 0;
+}


### PR DESCRIPTION
## Description

closes #9275

The `cuda::args` argument framework derives an element type's implicit bounds from
`cuda::std::numeric_limits<T>::lowest()`/`max()` whenever no explicit bounds are given.
The primary `numeric_limits` template (`is_specialized == false`) returns a
value-initialized `T()` from both, so for any type without a specialization the
"full range" silently collapses to the degenerate point `[T(), T()]` instead of
failing or warning. Default-constructed `runtime_bounds<T>`, the `__traits` primary
template, the `no_bounds` paths in `__wrapper_static_lowest/highest`, the empty
`__constant_sequence` case, and the `__lowest_/__highest_` free functions were all
affected.

Route every implicit-bound site through two helpers, `__type_lowest<T>()` and
`__type_highest<T>()`, that `static_assert(numeric_limits<T>::is_specialized)` before
returning the limit. Types without a specialization now produce a clear diagnostic at
the point the bound is requested; explicit `static_bounds`/`runtime_bounds` are
unaffected, and specialized types keep their existing behavior. The check sits behind
the helpers, so it only fires when an implicit bound is actually instantiated —
non-bound trait queries (`value_type`, `is_single_value`, used by the CUB
segmented-top-k consumers) still compile.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
