### PR TITLE
[libcu++] Support non-structural types in argument constants

### DIFF
--- a/libcudacxx/include/cuda/__argument/argument.h
+++ b/libcudacxx/include/cuda/__argument/argument.h
@@ -154,6 +154,8 @@ template <class _Tp, const auto& _Array, ::cuda::std::size_t... _Is>
 #endif // _CCCL_DOXYGEN_INVOKED
 
 //! @brief Builds a @c __constant_seq from a reference to a @c constexpr array, keeping the array's element type.
+//!
+//! @return A @c __constant_seq whose element type is the array's element type and whose values are its elements.
 template <const auto& _Array>
 [[nodiscard]] _CCCL_API constexpr auto __make_constant_seq() noexcept
 {
@@ -167,6 +169,8 @@ template <const auto& _Array>
 //!
 //! The source array element type must be structural; the target element type @c _Tp may be non-structural (e.g.
 //! @c __half), since each element is cast at use time rather than stored as a non-type template parameter.
+//!
+//! @return A @c __constant_seq with element type @c _Tp and the array's elements as its values.
 template <class _Tp, const auto& _Array>
 [[nodiscard]] _CCCL_API constexpr auto __make_constant_seq() noexcept
 {

--- a/libcudacxx/include/cuda/__argument/argument.h
+++ b/libcudacxx/include/cuda/__argument/argument.h
@@ -890,24 +890,19 @@ template <class _ElementType, auto _Value, class _Tp>
 struct __constant_traits_bounds<_ElementType, _Value, _Tp, false>
 {};
 
-// True iff the lower and upper bounds of a typed constant sequence can be constant-evaluated. This is the case unless
-// the element type cannot form a constexpr value (e.g. the extended floating-point types), since then the element
-// casts performed while reducing the sequence are not constant expressions.
-template <class _Void, class _ElementType, auto... _Values>
-inline constexpr bool __constant_seq_has_static_bounds_impl_v = false;
-
-template <class _ElementType, auto... _Values>
-inline constexpr bool __constant_seq_has_static_bounds_impl_v<
-  ::cuda::std::void_t<
-    ::cuda::std::bool_constant<(static_cast<void>(__constant_seq_compute_lowest<_ElementType, _Values...>()),
-                                static_cast<void>(__constant_seq_compute_highest<_ElementType, _Values...>()),
-                                true)>>,
-  _ElementType,
-  _Values...> = true;
-
+// True iff the lower and upper bounds of a typed constant sequence can be constant-evaluated. Reducing the sequence
+// casts every non-type template parameter to the element type, so this holds exactly when each of those casts is a
+// constant expression; element types that cannot form a constexpr value (e.g. the extended floating-point types) drop
+// out. An empty sequence takes its bounds from @c numeric_limits, which the @c __traits_impl primary template already
+// relies on being constexpr for any supported element type.
+//
+// The per-element casts are checked through @c __constant_has_static_bounds_v instead of by probing a call to
+// @c __constant_seq_compute_lowest: MSVC 14.29 does not propagate a non-constant expression out of a called constexpr
+// function during template-argument substitution, so such a probe wrongly reports @c true there. Keeping the cast in
+// the immediate context, as the single-value gate already does, is what that compiler evaluates correctly.
 template <class _ElementType, auto... _Values>
 inline constexpr bool __constant_seq_has_static_bounds_v =
-  __constant_seq_has_static_bounds_impl_v<void, _ElementType, _Values...>;
+  (__constant_has_static_bounds_v<_ElementType, _Values> && ...);
 
 // Static bound members for typed constant-sequence traits. As with @c __constant_traits_bounds, element types that
 // cannot form a @c static @c constexpr bound (e.g. the extended floating-point types) do not expose @c lowest /

--- a/libcudacxx/include/cuda/__argument/argument.h
+++ b/libcudacxx/include/cuda/__argument/argument.h
@@ -28,6 +28,8 @@
 #include <cuda/std/__iterator/iterator_traits.h>
 #include <cuda/std/__iterator/readable_traits.h>
 #include <cuda/std/__ranges/concepts.h>
+#include <cuda/std/__type_traits/extent.h>
+#include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_arithmetic.h>
 #include <cuda/std/__type_traits/is_array.h>
 #include <cuda/std/__type_traits/is_integer.h>
@@ -35,11 +37,14 @@
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/remove_cv.h>
 #include <cuda/std/__type_traits/remove_cvref.h>
+#include <cuda/std/__type_traits/remove_extent.h>
 #include <cuda/std/__type_traits/void_t.h>
 #include <cuda/std/__utility/cmp.h>
 #include <cuda/std/__utility/declval.h>
 #include <cuda/std/__utility/forward.h>
+#include <cuda/std/__utility/integer_sequence.h>
 #include <cuda/std/__utility/move.h>
+#include <cuda/std/array>
 #include <cuda/std/cstddef>
 #include <cuda/std/limits>
 
@@ -120,6 +125,56 @@ public:
 
   static_assert(__is_sequence_v<value_type>, "The value type of __constant_sequence must be a sequence");
 };
+
+//! @brief Wraps a compile-time constant argument sequence with an explicit element type.
+//!
+//! Unlike @c __constant_sequence, which carries the whole sequence as a single non-type template parameter, this
+//! wrapper carries each element as a separate structural non-type template parameter @c _Values together with a
+//! separate element type @c _Tp. This makes it usable with non-structural element types such as the extended
+//! floating-point types @c __half and @c __nv_bfloat16, whose values cannot be non-type template parameters.
+template <class _Tp, auto... _Values>
+class __constant_seq
+{
+public:
+  using __element_type = ::cuda::std::remove_cvref_t<_Tp>;
+  using value_type     = ::cuda::std::array<__element_type, sizeof...(_Values)>;
+
+  [[nodiscard]] _CCCL_API static constexpr value_type __get_value() noexcept
+  {
+    return value_type{static_cast<__element_type>(_Values)...};
+  }
+};
+
+#ifndef _CCCL_DOXYGEN_INVOKED
+template <class _Tp, const auto& _Array, ::cuda::std::size_t... _Is>
+[[nodiscard]] _CCCL_API constexpr auto __make_constant_seq_impl(::cuda::std::index_sequence<_Is...>) noexcept
+{
+  return __constant_seq<_Tp, _Array[_Is]...>{};
+}
+#endif // _CCCL_DOXYGEN_INVOKED
+
+//! @brief Builds a @c __constant_seq from a reference to a @c constexpr array, keeping the array's element type.
+template <const auto& _Array>
+[[nodiscard]] _CCCL_API constexpr auto __make_constant_seq() noexcept
+{
+  using _ArrayT = ::cuda::std::remove_cvref_t<decltype(_Array)>;
+  static_assert(::cuda::std::is_array_v<_ArrayT>, "__make_constant_seq requires a reference to an array");
+  return ::cuda::args::__make_constant_seq_impl<::cuda::std::remove_extent_t<_ArrayT>, _Array>(
+    ::cuda::std::make_index_sequence<::cuda::std::extent_v<_ArrayT>>{});
+}
+
+//! @brief Builds a @c __constant_seq from a reference to a @c constexpr array, casting each element to @c _Tp.
+//!
+//! The source array element type must be structural; the target element type @c _Tp may be non-structural (e.g.
+//! @c __half), since each element is cast at use time rather than stored as a non-type template parameter.
+template <class _Tp, const auto& _Array>
+[[nodiscard]] _CCCL_API constexpr auto __make_constant_seq() noexcept
+{
+  using _ArrayT = ::cuda::std::remove_cvref_t<decltype(_Array)>;
+  static_assert(::cuda::std::is_array_v<_ArrayT>, "__make_constant_seq requires a reference to an array");
+  return ::cuda::args::__make_constant_seq_impl<_Tp, _Array>(
+    ::cuda::std::make_index_sequence<::cuda::std::extent_v<_ArrayT>>{});
+}
 
 // __assert_in_range
 // =====================================================================
@@ -625,6 +680,8 @@ template <auto _Value, class _Tp>
 inline constexpr bool __is_wrapper_v<constant<_Value, _Tp>> = true;
 template <auto _Value>
 inline constexpr bool __is_wrapper_v<__constant_sequence<_Value>> = true;
+template <class _Tp, auto... _Values>
+inline constexpr bool __is_wrapper_v<__constant_seq<_Tp, _Values...>> = true;
 template <class _Arg, class _StaticBounds>
 inline constexpr bool __is_wrapper_v<__immediate_sequence<_Arg, _StaticBounds>> = true;
 template <class _Arg, class _StaticBounds>
@@ -669,6 +726,13 @@ template <auto _Value>
 __unwrap(const __constant_sequence<_Value>&) noexcept
 {
   return _Value;
+}
+
+template <class _Tp, auto... _Values>
+[[nodiscard]] _CCCL_API constexpr typename __constant_seq<_Tp, _Values...>::value_type
+__unwrap(const __constant_seq<_Tp, _Values...>&) noexcept
+{
+  return __constant_seq<_Tp, _Values...>::__get_value();
 }
 
 template <class _Arg, class _StaticBounds>
@@ -765,9 +829,99 @@ _CCCL_API constexpr auto __constant_sequence_compute_highest() noexcept
   return static_cast<_ElementType>(*::cuda::std::max_element(__first, __last));
 }
 
+template <class _ElementType, auto... _Values>
+_CCCL_API constexpr _ElementType __constant_seq_compute_lowest() noexcept
+{
+  if constexpr (sizeof...(_Values) == 0)
+  {
+    return ::cuda::std::numeric_limits<_ElementType>::lowest();
+  }
+  else
+  {
+    _ElementType __vals[]{static_cast<_ElementType>(_Values)...};
+    return *::cuda::std::min_element(__vals, __vals + sizeof...(_Values));
+  }
+}
+
+template <class _ElementType, auto... _Values>
+_CCCL_API constexpr _ElementType __constant_seq_compute_highest() noexcept
+{
+  if constexpr (sizeof...(_Values) == 0)
+  {
+    return (::cuda::std::numeric_limits<_ElementType>::max)();
+  }
+  else
+  {
+    _ElementType __vals[]{static_cast<_ElementType>(_Values)...};
+    return *::cuda::std::max_element(__vals, __vals + sizeof...(_Values));
+  }
+}
+
 // =====================================================================
 // __traits
 // =====================================================================
+
+// True iff a value of element type @c _Tp can be formed from the structural non-type template parameter @c _Value
+// within a constant expression. Extended floating-point types such as @c __half have a non-constexpr converting
+// constructor, so the cast is not a constant expression and cannot back a @c static @c constexpr bound.
+template <class _Tp, auto _Value, class = void>
+inline constexpr bool __constant_has_static_bounds_v = false;
+
+template <class _Tp, auto _Value>
+inline constexpr bool __constant_has_static_bounds_v<
+  _Tp,
+  _Value,
+  ::cuda::std::void_t<::cuda::std::bool_constant<(static_cast<void>(static_cast<_Tp>(_Value)), true)>>> = true;
+
+// Static bound members for constant traits.
+//
+// A constant carries a single value, so its lower and upper bounds are both that value. Element types that cannot form
+// a constexpr value (e.g. the extended floating-point types) intentionally do not expose @c lowest / @c highest; the
+// compile-time bound members exist only when they can be constant-evaluated, which is what the compile-time dispatch
+// consumers rely on.
+template <class _ElementType, auto _Value, class _Tp, bool = __constant_has_static_bounds_v<_ElementType, _Value>>
+struct __constant_traits_bounds
+{
+  static constexpr _ElementType lowest  = __constant_compute_lowest<_Value, _Tp>();
+  static constexpr _ElementType highest = __constant_compute_highest<_Value, _Tp>();
+};
+
+template <class _ElementType, auto _Value, class _Tp>
+struct __constant_traits_bounds<_ElementType, _Value, _Tp, false>
+{};
+
+// True iff the lower and upper bounds of a typed constant sequence can be constant-evaluated. This is the case unless
+// the element type cannot form a constexpr value (e.g. the extended floating-point types), since then the element
+// casts performed while reducing the sequence are not constant expressions.
+template <class _Void, class _ElementType, auto... _Values>
+inline constexpr bool __constant_seq_has_static_bounds_impl_v = false;
+
+template <class _ElementType, auto... _Values>
+inline constexpr bool __constant_seq_has_static_bounds_impl_v<
+  ::cuda::std::void_t<
+    ::cuda::std::bool_constant<(static_cast<void>(__constant_seq_compute_lowest<_ElementType, _Values...>()),
+                                static_cast<void>(__constant_seq_compute_highest<_ElementType, _Values...>()),
+                                true)>>,
+  _ElementType,
+  _Values...> = true;
+
+template <class _ElementType, auto... _Values>
+inline constexpr bool __constant_seq_has_static_bounds_v =
+  __constant_seq_has_static_bounds_impl_v<void, _ElementType, _Values...>;
+
+// Static bound members for typed constant-sequence traits. As with @c __constant_traits_bounds, element types that
+// cannot form a @c static @c constexpr bound (e.g. the extended floating-point types) do not expose @c lowest /
+// @c highest.
+template <bool _HasStaticBounds, class _ElementType, auto... _Values>
+struct __constant_seq_traits_bounds
+{
+  static constexpr _ElementType lowest  = __constant_seq_compute_lowest<_ElementType, _Values...>();
+  static constexpr _ElementType highest = __constant_seq_compute_highest<_ElementType, _Values...>();
+};
+
+template <class _ElementType, auto... _Values>
+struct __constant_seq_traits_bounds<false, _ElementType, _Values...>
+{};
 
 //! @brief Traits for argument wrappers and plain argument values.
 //!
@@ -787,14 +941,13 @@ struct __traits_impl
 
 template <auto _Value, class _Tp>
 struct __traits_impl<constant<_Value, _Tp>>
+    : __constant_traits_bounds<typename constant<_Value, _Tp>::value_type, _Value, _Tp>
 {
   using value_type                      = typename constant<_Value, _Tp>::value_type;
   using element_type                    = value_type;
   static constexpr bool is_constant     = true;
   static constexpr bool is_deferred     = false;
   static constexpr bool is_single_value = true;
-  static constexpr element_type lowest  = __constant_compute_lowest<_Value, _Tp>();
-  static constexpr element_type highest = __constant_compute_highest<_Value, _Tp>();
 };
 
 template <class _Arg, class _StaticBounds>
@@ -824,6 +977,20 @@ struct __traits_impl<__constant_sequence<_Value>>
   static constexpr bool is_single_value = false;
   static constexpr element_type lowest  = __constant_sequence_compute_lowest<_Value>();
   static constexpr element_type highest = __constant_sequence_compute_highest<_Value>();
+};
+
+template <class _Tp, auto... _Values>
+struct __traits_impl<__constant_seq<_Tp, _Values...>>
+    : __constant_seq_traits_bounds<
+        __constant_seq_has_static_bounds_v<typename __constant_seq<_Tp, _Values...>::__element_type, _Values...>,
+        typename __constant_seq<_Tp, _Values...>::__element_type,
+        _Values...>
+{
+  using value_type                      = typename __constant_seq<_Tp, _Values...>::value_type;
+  using element_type                    = typename __constant_seq<_Tp, _Values...>::__element_type;
+  static constexpr bool is_constant     = true;
+  static constexpr bool is_deferred     = false;
+  static constexpr bool is_single_value = false;
 };
 
 template <class _Arg, class _StaticBounds>
@@ -911,6 +1078,12 @@ template <auto _Value>
   return __constant_sequence_compute_lowest<_Value>();
 }
 
+template <class _Tp, auto... _Values>
+[[nodiscard]] _CCCL_API constexpr auto __lowest_(__constant_seq<_Tp, _Values...>) noexcept
+{
+  return __constant_seq_compute_lowest<typename __constant_seq<_Tp, _Values...>::__element_type, _Values...>();
+}
+
 template <class _Arg, class _StaticBounds>
 [[nodiscard]] _CCCL_API constexpr auto __lowest_(immediate<_Arg, _StaticBounds> __arg) noexcept
 {
@@ -969,6 +1142,12 @@ template <auto _Value>
 [[nodiscard]] _CCCL_API constexpr auto __highest_(__constant_sequence<_Value>) noexcept
 {
   return __constant_sequence_compute_highest<_Value>();
+}
+
+template <class _Tp, auto... _Values>
+[[nodiscard]] _CCCL_API constexpr auto __highest_(__constant_seq<_Tp, _Values...>) noexcept
+{
+  return __constant_seq_compute_highest<typename __constant_seq<_Tp, _Values...>::__element_type, _Values...>();
 }
 
 template <class _Arg, class _StaticBounds>

--- a/libcudacxx/test/libcudacxx/cuda/argument/constant_non_structural.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/argument/constant_non_structural.pass.cpp
@@ -1,0 +1,169 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// Non-structural types (e.g. the extended floating-point types __half and __nv_bfloat16) cannot be non-type template
+// parameters. The split spellings `constant<_Value, _Tp>` and `__constant_seq<_Tp, _Values...>` make them usable by
+// carrying a structural value plus a separate target type. See NVIDIA/cccl#9274.
+
+#include <cuda/argument>
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+#if _LIBCUDACXX_HAS_NVFP16()
+#  include <cuda_fp16.h>
+#endif // _LIBCUDACXX_HAS_NVFP16()
+#if _LIBCUDACXX_HAS_NVBF16()
+#  include <cuda_bf16.h>
+#endif // _LIBCUDACXX_HAS_NVBF16()
+
+#include "test_macros.h"
+
+enum class scaled_size : int
+{
+  tile = 256
+};
+
+// A user-defined type that is structural but not constexpr-constructible from an integer, mirroring how the extended
+// floating-point types behave. Always available, so the mechanism is exercised even without NVFP16/NVBF16 support.
+struct non_constexpr_value
+{
+  int __payload;
+
+  non_constexpr_value() = default;
+
+  // Intentionally not constexpr.
+  _CCCL_HOST_DEVICE non_constexpr_value(int __v)
+      : __payload(__v)
+  {}
+
+  _CCCL_HOST_DEVICE friend bool operator==(non_constexpr_value __lhs, non_constexpr_value __rhs)
+  {
+    return __lhs.__payload == __rhs.__payload;
+  }
+  _CCCL_HOST_DEVICE friend bool operator<(non_constexpr_value __lhs, non_constexpr_value __rhs)
+  {
+    return __lhs.__payload < __rhs.__payload;
+  }
+};
+
+template <class _Tp>
+_CCCL_HOST_DEVICE void test_single_value()
+{
+  using C      = cuda::args::constant<128, _Tp>;
+  using traits = cuda::args::__traits<C>;
+
+  static_assert(traits::is_constant);
+  static_assert(traits::is_single_value);
+  static_assert(!traits::is_deferred);
+  static_assert(cuda::std::is_same_v<typename traits::value_type, _Tp>);
+  static_assert(cuda::std::is_same_v<typename traits::element_type, _Tp>);
+
+  // The value and the free-function bounds are produced at run time (no constexpr ctor required).
+  assert(cuda::args::__unwrap(C{}) == _Tp(128));
+  assert(cuda::args::__lowest_(C{}) == _Tp(128));
+  assert(cuda::args::__highest_(C{}) == _Tp(128));
+}
+
+template <class _Tp>
+_CCCL_HOST_DEVICE void test_sequence()
+{
+  using S      = cuda::args::__constant_seq<_Tp, 4, 8, 2>;
+  using traits = cuda::args::__traits<S>;
+
+  static_assert(traits::is_constant);
+  static_assert(!traits::is_single_value);
+  static_assert(!traits::is_deferred);
+  static_assert(cuda::std::is_same_v<typename traits::value_type, cuda::std::array<_Tp, 3>>);
+  static_assert(cuda::std::is_same_v<typename traits::element_type, _Tp>);
+
+  const auto __arr = cuda::args::__unwrap(S{});
+  assert(__arr[0] == _Tp(4));
+  assert(__arr[1] == _Tp(8));
+  assert(__arr[2] == _Tp(2));
+  assert(cuda::args::__lowest_(S{}) == _Tp(2));
+  assert(cuda::args::__highest_(S{}) == _Tp(8));
+
+  // make_constant_seq: structural source array, non-structural target element type.
+  static constexpr int __src[]{5, 1, 9};
+  const auto __made = cuda::args::__make_constant_seq<_Tp, __src>();
+  static_assert(cuda::std::is_same_v<typename decltype(__made)::value_type, cuda::std::array<_Tp, 3>>);
+  const auto __made_arr = cuda::args::__unwrap(__made);
+  assert(__made_arr[0] == _Tp(5));
+  assert(__made_arr[1] == _Tp(1));
+  assert(__made_arr[2] == _Tp(9));
+  assert(cuda::args::__lowest_(__made) == _Tp(1));
+  assert(cuda::args::__highest_(__made) == _Tp(9));
+}
+
+TEST_FUNC void test()
+{
+  // Arithmetic element types: the split sequence is fully usable at compile time.
+  {
+    using S = cuda::args::__constant_seq<int, 3, 1, 2>;
+    static_assert(cuda::std::is_same_v<S::value_type, cuda::std::array<int, 3>>);
+    static_assert(cuda::args::__unwrap(S{}) == cuda::std::array<int, 3>{3, 1, 2});
+    static_assert(cuda::args::__traits<S>::lowest == 1);
+    static_assert(cuda::args::__traits<S>::highest == 3);
+    static_assert(cuda::args::__lowest_(S{}) == 1);
+    static_assert(cuda::args::__highest_(S{}) == 3);
+  }
+  {
+    using S = cuda::args::__constant_seq<float, 1, 2, 3>;
+    static_assert(cuda::args::__unwrap(S{}) == cuda::std::array<float, 3>{1.f, 2.f, 3.f});
+    static_assert(cuda::args::__traits<S>::highest == 3.f);
+  }
+
+  // make_constant_seq with arithmetic types.
+  {
+    static constexpr int __src[]{10, 30, 20};
+    constexpr auto __s = cuda::args::__make_constant_seq<__src>();
+    static_assert(cuda::args::__unwrap(__s) == cuda::std::array<int, 3>{10, 30, 20});
+    static_assert(cuda::args::__traits<decltype(__s)>::lowest == 10);
+    static_assert(cuda::args::__traits<decltype(__s)>::highest == 30);
+
+    constexpr auto __sf = cuda::args::__make_constant_seq<float, __src>();
+    static_assert(cuda::args::__unwrap(__sf) == cuda::std::array<float, 3>{10.f, 30.f, 20.f});
+  }
+
+  // Regression guard: a non-arithmetic but constexpr-constructible element type (enum) keeps its static bounds. A
+  // coarser `is_arithmetic`-based predicate would wrongly drop them.
+  {
+    using C = cuda::args::constant<scaled_size::tile>;
+    static_assert(cuda::std::is_same_v<C::value_type, scaled_size>);
+    static_assert(cuda::args::__unwrap(C{}) == scaled_size::tile);
+    static_assert(cuda::args::__traits<C>::lowest == scaled_size::tile);
+    static_assert(cuda::args::__traits<C>::highest == scaled_size::tile);
+
+    using S = cuda::args::__constant_seq<scaled_size, 1, 256, 64>;
+    static_assert(cuda::args::__traits<S>::lowest == scaled_size{1});
+    static_assert(cuda::args::__traits<S>::highest == scaled_size::tile);
+  }
+
+  // Non-structural, non-constexpr-constructible element type.
+  test_single_value<non_constexpr_value>();
+  test_sequence<non_constexpr_value>();
+
+#if _LIBCUDACXX_HAS_NVFP16()
+  test_single_value<__half>();
+  test_sequence<__half>();
+#endif // _LIBCUDACXX_HAS_NVFP16()
+
+#if _LIBCUDACXX_HAS_NVBF16()
+  test_single_value<__nv_bfloat16>();
+  test_sequence<__nv_bfloat16>();
+#endif // _LIBCUDACXX_HAS_NVBF16()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/argument/constant_non_structural.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/argument/constant_non_structural.pass.cpp
@@ -54,6 +54,11 @@ struct non_constexpr_value
   }
 };
 
+// Source arrays for `__make_constant_seq`. They live at namespace scope on purpose: until C++20 a reference non-type
+// template parameter requires an entity with linkage, and a block-scope object never has one.
+constexpr int __seq_src[]{5, 1, 9};
+constexpr int __make_src[]{10, 30, 20};
+
 template <class _Tp>
 _CCCL_HOST_DEVICE void test_single_value()
 {
@@ -92,8 +97,7 @@ _CCCL_HOST_DEVICE void test_sequence()
   assert(cuda::args::__highest_(S{}) == _Tp(8));
 
   // make_constant_seq: structural source array, non-structural target element type.
-  static constexpr int __src[]{5, 1, 9};
-  const auto __made = cuda::args::__make_constant_seq<_Tp, __src>();
+  const auto __made = cuda::args::__make_constant_seq<_Tp, __seq_src>();
   static_assert(cuda::std::is_same_v<typename decltype(__made)::value_type, cuda::std::array<_Tp, 3>>);
   const auto __made_arr = cuda::args::__unwrap(__made);
   assert(__made_arr[0] == _Tp(5));
@@ -123,13 +127,12 @@ TEST_FUNC void test()
 
   // make_constant_seq with arithmetic types.
   {
-    static constexpr int __src[]{10, 30, 20};
-    constexpr auto __s = cuda::args::__make_constant_seq<__src>();
+    constexpr auto __s = cuda::args::__make_constant_seq<__make_src>();
     static_assert(cuda::args::__unwrap(__s) == cuda::std::array<int, 3>{10, 30, 20});
     static_assert(cuda::args::__traits<decltype(__s)>::lowest == 10);
     static_assert(cuda::args::__traits<decltype(__s)>::highest == 30);
 
-    constexpr auto __sf = cuda::args::__make_constant_seq<float, __src>();
+    constexpr auto __sf = cuda::args::__make_constant_seq<float, __make_src>();
     static_assert(cuda::args::__unwrap(__sf) == cuda::std::array<float, 3>{10.f, 30.f, 20.f});
   }
 

--- a/libcudacxx/test/libcudacxx/cuda/argument/constant_non_structural.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/argument/constant_non_structural.pass.cpp
@@ -40,15 +40,15 @@ struct non_constexpr_value
   non_constexpr_value() = default;
 
   // Intentionally not constexpr.
-  _CCCL_HOST_DEVICE non_constexpr_value(int __v)
+  TEST_FUNC non_constexpr_value(int __v)
       : __payload(__v)
   {}
 
-  _CCCL_HOST_DEVICE friend bool operator==(non_constexpr_value __lhs, non_constexpr_value __rhs)
+  TEST_FUNC friend bool operator==(non_constexpr_value __lhs, non_constexpr_value __rhs)
   {
     return __lhs.__payload == __rhs.__payload;
   }
-  _CCCL_HOST_DEVICE friend bool operator<(non_constexpr_value __lhs, non_constexpr_value __rhs)
+  TEST_FUNC friend bool operator<(non_constexpr_value __lhs, non_constexpr_value __rhs)
   {
     return __lhs.__payload < __rhs.__payload;
   }
@@ -59,8 +59,22 @@ struct non_constexpr_value
 constexpr int __seq_src[]{5, 1, 9};
 constexpr int __make_src[]{10, 30, 20};
 
+// Detect whether a traits specialization exposes the static bound members. They must exist only when the bound can be
+// constant-evaluated, so an element type without a constexpr converting constructor has to omit them entirely rather
+// than expose a bound computed some other way.
+template <class Traits, class = void>
+inline constexpr bool has_static_lowest = false;
+template <class Traits>
+inline constexpr bool has_static_lowest<Traits, cuda::std::void_t<decltype(Traits::lowest)>> = true;
+
+template <class Traits, class = void>
+inline constexpr bool has_static_highest = false;
+template <class Traits>
+inline constexpr bool has_static_highest<Traits, cuda::std::void_t<decltype(Traits::highest)>> = true;
+
+// Both helpers below are instantiated only with element types that have no constexpr converting constructor.
 template <class _Tp>
-_CCCL_HOST_DEVICE void test_single_value()
+TEST_FUNC void test_single_value()
 {
   using C      = cuda::args::constant<128, _Tp>;
   using traits = cuda::args::__traits<C>;
@@ -71,6 +85,10 @@ _CCCL_HOST_DEVICE void test_single_value()
   static_assert(cuda::std::is_same_v<typename traits::value_type, _Tp>);
   static_assert(cuda::std::is_same_v<typename traits::element_type, _Tp>);
 
+  // The static bound members must be absent: `_Tp{128}` is not a constant expression.
+  static_assert(!has_static_lowest<traits>);
+  static_assert(!has_static_highest<traits>);
+
   // The value and the free-function bounds are produced at run time (no constexpr ctor required).
   assert(cuda::args::__unwrap(C{}) == _Tp(128));
   assert(cuda::args::__lowest_(C{}) == _Tp(128));
@@ -78,7 +96,7 @@ _CCCL_HOST_DEVICE void test_single_value()
 }
 
 template <class _Tp>
-_CCCL_HOST_DEVICE void test_sequence()
+TEST_FUNC void test_sequence()
 {
   using S      = cuda::args::__constant_seq<_Tp, 4, 8, 2>;
   using traits = cuda::args::__traits<S>;
@@ -88,6 +106,15 @@ _CCCL_HOST_DEVICE void test_sequence()
   static_assert(!traits::is_deferred);
   static_assert(cuda::std::is_same_v<typename traits::value_type, cuda::std::array<_Tp, 3>>);
   static_assert(cuda::std::is_same_v<typename traits::element_type, _Tp>);
+
+  // The static bound members must be absent: reducing the sequence casts each element to `_Tp`, which is not a
+  // constant expression here.
+  static_assert(!has_static_lowest<traits>);
+  static_assert(!has_static_highest<traits>);
+
+  // `__make_constant_seq` produces the same shape, so its traits must drop the bounds too.
+  static_assert(!has_static_lowest<cuda::args::__traits<decltype(cuda::args::__make_constant_seq<_Tp, __seq_src>())>>);
+  static_assert(!has_static_highest<cuda::args::__traits<decltype(cuda::args::__make_constant_seq<_Tp, __seq_src>())>>);
 
   const auto __arr = cuda::args::__unwrap(S{});
   assert(__arr[0] == _Tp(4));
@@ -116,6 +143,10 @@ TEST_FUNC void test()
     static_assert(cuda::args::__unwrap(S{}) == cuda::std::array<int, 3>{3, 1, 2});
     static_assert(cuda::args::__traits<S>::lowest == 1);
     static_assert(cuda::args::__traits<S>::highest == 3);
+    // Counterpart to the absence checks in the helpers above: the detector must see the members when they do exist,
+    // otherwise those checks would hold vacuously.
+    static_assert(has_static_lowest<cuda::args::__traits<S>>);
+    static_assert(has_static_highest<cuda::args::__traits<S>>);
     static_assert(cuda::args::__lowest_(S{}) == 1);
     static_assert(cuda::args::__highest_(S{}) == 3);
   }


### PR DESCRIPTION
## Description

Closes #9274. Related to #9273.

Non-structural types such as `__half` and `__nv_bfloat16` can't be non-type template parameters, so they couldn't be used in `cuda::args::constant`.

`constant<_Value, _Tp>` already lets the stored type differ from the NTTP, but it still didn't work for these types: `__traits` exposes `lowest`/`highest` as `static constexpr element_type`, and the extended floating-point types have no constexpr constructor to form such a bound. So `constant<128, __half>` compiles in isolation but breaks the moment it goes through the traits/bounds path the framework uses.

### Changes

- Gate the `constant` `lowest`/`highest` trait members on whether the value is actually constant-evaluable, instead of requiring it unconditionally. Types that can't form a constexpr bound (the extended FP types) just don't expose them; arithmetic, enum and literal types are unaffected.
- Add `__constant_seq<_Tp, _Values...>` and `__make_constant_seq` for the sequence case. Each element is carried as a structural NTTP and cast to the (possibly non-structural) element type on use, so e.g. a `__half` sequence works too.

Both spellings work in C++17 — the value comes from an integral NTTP, not the float type itself:

```cpp
cuda::args::constant<128, __half> c;              // value is __half{128}
cuda::args::__constant_seq<__half, 4, 8, 2> s;    // sequence of __half
```

### Testing

New `constant_non_structural.pass.cpp` covers single values, sequences and `__make_constant_seq` for `__half`/`__nv_bfloat16` (guarded), plus a non-constexpr user type so the mechanism is exercised on host-only builds. Includes an enum case as a regression guard for the bounds gate. Built and run locally in C++17 and C++20.

### Open question

`__constant_seq` sits right next to the existing `__constant_sequence` and the names are easy to confuse. Happy to rename if you'd prefer something clearer.
