### PR TITLE
Rename `warp_threads` in tuning policies

### DIFF
--- a/cub/cub/device/dispatch/kernels/kernel_segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_segmented_reduce.cuh
@@ -141,7 +141,7 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(current_policy<PolicySelector>().large
   static constexpr warp_reduce_policy med_pol = full_policy.medium_reduce;
   using medium_agent_policy_t =
     AgentWarpReducePolicy<med_pol.threads_per_block,
-                          med_pol.warp_threads,
+                          med_pol.threads_per_warp,
                           med_pol.items_per_thread,
                           void,
                           med_pol.vec_size,
@@ -153,7 +153,7 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(current_policy<PolicySelector>().large
   static constexpr warp_reduce_policy small_pol = full_policy.small_reduce;
   using small_agent_policy_t =
     AgentWarpReducePolicy<small_pol.threads_per_block,
-                          small_pol.warp_threads,
+                          small_pol.threads_per_warp,
                           small_pol.items_per_thread,
                           void,
                           small_pol.vec_size,
@@ -165,9 +165,9 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(current_policy<PolicySelector>().large
   constexpr int medium_items_per_tile = med_pol.items_per_tile();
 
   constexpr int segments_per_small_block  = small_pol.segments_per_block();
-  constexpr int small_threads_per_warp    = small_pol.warp_threads;
+  constexpr int small_threads_per_warp    = small_pol.threads_per_warp;
   constexpr int segments_per_medium_block = med_pol.segments_per_block();
-  constexpr int medium_threads_per_warp   = med_pol.warp_threads;
+  constexpr int medium_threads_per_warp   = med_pol.threads_per_warp;
 
   // Shared memory storage
   __shared__ union
@@ -347,7 +347,7 @@ __launch_bounds__(current_policy<PolicySelector>().large_reduce.threads_per_bloc
   static constexpr warp_reduce_policy med_pol = full_policy.medium_reduce;
   using medium_agent_policy_t =
     AgentWarpReducePolicy<med_pol.threads_per_block,
-                          med_pol.warp_threads,
+                          med_pol.threads_per_warp,
                           med_pol.items_per_thread,
                           void,
                           med_pol.vec_size,
@@ -358,7 +358,7 @@ __launch_bounds__(current_policy<PolicySelector>().large_reduce.threads_per_bloc
   static constexpr warp_reduce_policy small_pol = full_policy.small_reduce;
   using small_agent_policy_t =
     AgentWarpReducePolicy<small_pol.threads_per_block,
-                          small_pol.warp_threads,
+                          small_pol.threads_per_warp,
                           small_pol.items_per_thread,
                           void,
                           small_pol.vec_size,
@@ -369,9 +369,9 @@ __launch_bounds__(current_policy<PolicySelector>().large_reduce.threads_per_bloc
   constexpr int medium_items_per_tile = med_pol.items_per_tile();
 
   constexpr int segments_per_small_block  = small_pol.segments_per_block();
-  constexpr int small_threads_per_warp    = small_pol.warp_threads;
+  constexpr int small_threads_per_warp    = small_pol.threads_per_warp;
   constexpr int segments_per_medium_block = med_pol.segments_per_block();
-  constexpr int medium_threads_per_warp   = med_pol.warp_threads;
+  constexpr int medium_threads_per_warp   = med_pol.threads_per_warp;
 
   // Shared memory storage
   __shared__ union

--- a/cub/cub/device/dispatch/kernels/kernel_segmented_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_segmented_sort.cuh
@@ -156,7 +156,7 @@ __launch_bounds__(current_policy<PolicySelector>().large_segment.threads_per_blo
   static constexpr auto medium_policy = active_policy.medium_segment;
   using MediumPolicyT =
     AgentSubWarpMergeSortPolicy<medium_policy.threads_per_block,
-                                medium_policy.warp_threads,
+                                medium_policy.threads_per_warp,
                                 medium_policy.items_per_thread,
                                 medium_policy.load_algorithm,
                                 medium_policy.load_modifier,
@@ -350,7 +350,7 @@ __launch_bounds__(current_policy<PolicySelector>().small_segment.threads_per_blo
   static constexpr auto small_policy                   = active_policy.small_segment;
   using SmallPolicyT =
     AgentSubWarpMergeSortPolicy<small_policy.threads_per_block,
-                                small_policy.warp_threads,
+                                small_policy.threads_per_warp,
                                 small_policy.items_per_thread,
                                 small_policy.load_algorithm,
                                 small_policy.load_modifier,
@@ -358,7 +358,7 @@ __launch_bounds__(current_policy<PolicySelector>().small_segment.threads_per_blo
   static constexpr auto medium_policy = active_policy.medium_segment;
   using MediumPolicyT =
     AgentSubWarpMergeSortPolicy<medium_policy.threads_per_block,
-                                medium_policy.warp_threads,
+                                medium_policy.threads_per_warp,
                                 medium_policy.items_per_thread,
                                 medium_policy.load_algorithm,
                                 medium_policy.load_modifier,

--- a/cub/cub/device/dispatch/tuning/tuning_segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_segmented_reduce.cuh
@@ -24,25 +24,25 @@ namespace detail::segmented_reduce
 struct warp_reduce_policy
 {
   int threads_per_block;
-  int warp_threads;
+  int threads_per_warp;
   int items_per_thread;
   int vec_size;
   CacheLoadModifier load_modifier;
 
   _CCCL_HOST_DEVICE_API constexpr int items_per_tile() const
   {
-    return warp_threads * items_per_thread;
+    return threads_per_warp * items_per_thread;
   }
 
   _CCCL_HOST_DEVICE_API constexpr int segments_per_block() const
   {
-    return threads_per_block / warp_threads;
+    return threads_per_block / threads_per_warp;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const warp_reduce_policy& lhs, const warp_reduce_policy& rhs)
   {
-    return lhs.threads_per_block == rhs.threads_per_block && lhs.warp_threads == rhs.warp_threads
+    return lhs.threads_per_block == rhs.threads_per_block && lhs.threads_per_warp == rhs.threads_per_warp
         && lhs.items_per_thread == rhs.items_per_thread && lhs.vec_size == rhs.vec_size
         && lhs.load_modifier == rhs.load_modifier;
   }
@@ -57,7 +57,7 @@ struct warp_reduce_policy
   friend ::std::ostream& operator<<(::std::ostream& os, const warp_reduce_policy& p)
   {
     return os << "warp_reduce_policy { .threads_per_block = " << p.threads_per_block
-              << ", .warp_threads = " << p.warp_threads << ", .items_per_thread = " << p.items_per_thread
+              << ", .threads_per_warp = " << p.threads_per_warp << ", .items_per_thread = " << p.items_per_thread
               << ", .vec_size = " << p.vec_size << ", .load_modifier = " << p.load_modifier << " }";
   }
 #endif // _CCCL_HOSTED()

--- a/cub/cub/device/dispatch/tuning/tuning_segmented_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_segmented_sort.cuh
@@ -68,7 +68,7 @@ struct segmented_radix_sort_policy
 struct sub_warp_merge_sort_policy
 {
   int threads_per_block;
-  int warp_threads;
+  int threads_per_warp;
   int items_per_thread;
   WarpLoadAlgorithm load_algorithm;
   CacheLoadModifier load_modifier;
@@ -76,18 +76,18 @@ struct sub_warp_merge_sort_policy
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr int segments_per_block() const
   {
-    return threads_per_block / warp_threads;
+    return threads_per_block / threads_per_warp;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr int items_per_tile() const
   {
-    return warp_threads * items_per_thread;
+    return threads_per_warp * items_per_thread;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const sub_warp_merge_sort_policy& lhs, const sub_warp_merge_sort_policy& rhs)
   {
-    return lhs.threads_per_block == rhs.threads_per_block && lhs.warp_threads == rhs.warp_threads
+    return lhs.threads_per_block == rhs.threads_per_block && lhs.threads_per_warp == rhs.threads_per_warp
         && lhs.items_per_thread == rhs.items_per_thread && lhs.load_algorithm == rhs.load_algorithm
         && lhs.load_modifier == rhs.load_modifier && lhs.store_algorithm == rhs.store_algorithm;
   }
@@ -103,7 +103,7 @@ struct sub_warp_merge_sort_policy
   {
     return os
         << "sub_warp_merge_sort_policy { .threads_per_block = " << p.threads_per_block
-        << ", .warp_threads = " << p.warp_threads << ", .items_per_thread = " << p.items_per_thread
+        << ", .threads_per_warp = " << p.threads_per_warp << ", .items_per_thread = " << p.items_per_thread
         << ", .load_algorithm = " << p.load_algorithm << ", .load_modifier = " << p.load_modifier
         << ", .store_algorithm = " << p.store_algorithm << " }";
   }


### PR DESCRIPTION
Prefer `threads_per_warp` for consistency with other tuning policy members.