### PR TITLE
[Tile] Mark alignment helpers as `_CCCL_HOST_DEVICE_API`

### DIFF
--- a/libcudacxx/include/cuda/__memory/align_down.h
+++ b/libcudacxx/include/cuda/__memory/align_down.h
@@ -42,7 +42,7 @@
 _CCCL_BEGIN_NAMESPACE_CUDA
 
 template <typename _Tp>
-[[nodiscard]] _CCCL_API _Tp* align_down(_Tp* __ptr, ::cuda::std::size_t __alignment) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API _Tp* align_down(_Tp* __ptr, ::cuda::std::size_t __alignment) noexcept
 {
   using ::cuda::std::uintptr_t;
   _CCCL_ASSERT(::cuda::__is_valid_alignment<_Tp>(__alignment), "invalid alignment");

--- a/libcudacxx/include/cuda/__memory/align_up.h
+++ b/libcudacxx/include/cuda/__memory/align_up.h
@@ -43,7 +43,7 @@
 _CCCL_BEGIN_NAMESPACE_CUDA
 
 template <typename _Tp>
-[[nodiscard]] _CCCL_API inline _Tp* align_up(_Tp* __ptr, ::cuda::std::size_t __alignment) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API inline _Tp* align_up(_Tp* __ptr, ::cuda::std::size_t __alignment) noexcept
 {
   using ::cuda::std::uintptr_t;
   _CCCL_ASSERT(::cuda::__is_valid_alignment<_Tp>(__alignment), "invalid alignment");

--- a/libcudacxx/include/cuda/__memory/ptr_rebind.h
+++ b/libcudacxx/include/cuda/__memory/ptr_rebind.h
@@ -31,7 +31,7 @@
 _CCCL_BEGIN_NAMESPACE_CUDA
 
 template <typename _Up, typename _Tp>
-[[nodiscard]] _CCCL_API _Up* ptr_rebind(_Tp* __ptr) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API _Up* ptr_rebind(_Tp* __ptr) noexcept
 {
   if constexpr (::cuda::std::is_same_v<_Up, _Tp>) // also handle _Tp == _Up == void
   {
@@ -51,19 +51,19 @@ template <typename _Up, typename _Tp>
 }
 
 template <typename _Up, typename _Tp>
-[[nodiscard]] _CCCL_API const _Up* ptr_rebind(const _Tp* __ptr) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API const _Up* ptr_rebind(const _Tp* __ptr) noexcept
 {
   return ::cuda::ptr_rebind<const _Up>(const_cast<_Tp*>(__ptr));
 }
 
 template <typename _Up, typename _Tp>
-[[nodiscard]] _CCCL_API volatile _Up* ptr_rebind(volatile _Tp* __ptr) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API volatile _Up* ptr_rebind(volatile _Tp* __ptr) noexcept
 {
   return ::cuda::ptr_rebind<volatile _Up>(const_cast<_Tp*>(__ptr));
 }
 
 template <typename _Up, typename _Tp>
-[[nodiscard]] _CCCL_API const volatile _Up* ptr_rebind(const volatile _Tp* __ptr) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API const volatile _Up* ptr_rebind(const volatile _Tp* __ptr) noexcept
 {
   return ::cuda::ptr_rebind<const volatile _Up>(const_cast<_Tp*>(__ptr));
 }

--- a/libcudacxx/include/cuda/std/__mdspan/aligned_accessor.h
+++ b/libcudacxx/include/cuda/std/__mdspan/aligned_accessor.h
@@ -77,12 +77,13 @@ public:
     return {};
   }
 
-  _CCCL_API constexpr reference access(data_handle_type __p, size_t __i) const noexcept
+  _CCCL_HOST_DEVICE_API constexpr reference access(data_handle_type __p, size_t __i) const noexcept
   {
     return ::cuda::std::assume_aligned<byte_alignment>(__p)[__i];
   }
 
-  _CCCL_API constexpr typename offset_policy::data_handle_type offset(data_handle_type __p, size_t __i) const noexcept
+  _CCCL_HOST_DEVICE_API constexpr typename offset_policy::data_handle_type
+  offset(data_handle_type __p, size_t __i) const noexcept
   {
     return ::cuda::std::assume_aligned<byte_alignment>(__p) + __i;
   }

--- a/libcudacxx/include/cuda/std/__memory/align.h
+++ b/libcudacxx/include/cuda/std/__memory/align.h
@@ -35,7 +35,7 @@ _CCCL_DIAG_SUPPRESS_MSVC(4146) // unary minus operator applied to unsigned type,
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-_CCCL_API inline void* align(size_t __alignment, size_t __size, void*& __ptr, size_t& __space)
+_CCCL_HOST_DEVICE_API inline void* align(size_t __alignment, size_t __size, void*& __ptr, size_t& __space)
 {
   _CCCL_ASSERT(::cuda::__is_valid_alignment(__alignment), "cuda::std::align: invalid alignment");
   if (__space < __size)

--- a/libcudacxx/include/cuda/std/__memory/assume_aligned.h
+++ b/libcudacxx/include/cuda/std/__memory/assume_aligned.h
@@ -32,7 +32,7 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <size_t _Align, class _Tp>
-[[nodiscard]] _CCCL_API constexpr _Tp* assume_aligned(_Tp* __ptr) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _Tp* assume_aligned(_Tp* __ptr) noexcept
 {
   static_assert(::cuda::__is_valid_alignment<_Tp>(_Align), "invalid _Align value for _Tp");
 #if !defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)

--- a/libcudacxx/include/cuda/std/__memory/runtime_assume_aligned.h
+++ b/libcudacxx/include/cuda/std/__memory/runtime_assume_aligned.h
@@ -29,7 +29,8 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <typename _Tp>
-[[nodiscard]] _CCCL_API _Tp* __runtime_assume_aligned(_Tp* __ptr, ::cuda::std::size_t __alignment) noexcept
+[[nodiscard]] _CCCL_HOST_DEVICE_API _Tp*
+__runtime_assume_aligned(_Tp* __ptr, [[maybe_unused]] ::cuda::std::size_t __alignment) noexcept
 {
 #if defined(_CCCL_BUILTIN_ASSUME_ALIGNED)
   using _Up = remove_volatile_t<_Tp>;

--- a/libcudacxx/test/libcudacxx/cuda/functional/proclaim_return_type.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/proclaim_return_type.pass.cpp
@@ -20,7 +20,7 @@ TEST_FUNC void test_lambda_return_type()
 {
 // Ensure type can be queried from cuda::std::invoke_result_t
 #  if _CCCL_TILE_COMPILATION()
-  auto d_lm = [] _CCCL_TILE() -> ReturnT {
+  auto d_lm = [] TEST_TILE_FUNC() -> ReturnT {
     return ReturnT{};
   };
 #  else // ^^^ _CCCL_TILE_COMPILATION() ^^^ / vvv !_CCCL_TILE_COMPILATION() vvv
@@ -96,11 +96,11 @@ struct h_callable
 
 struct d_callable
 {
-  TEST_DEVICE_FUNC int operator()() const&
+  TEST_TILE_DEVICE_FUNC int operator()() const&
   {
     return 42;
   }
-  TEST_DEVICE_FUNC int operator()() const&&
+  TEST_TILE_DEVICE_FUNC int operator()() const&&
   {
     return 42;
   }

--- a/libcudacxx/test/libcudacxx/cuda/memory/align_down.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/align_down.pass.cpp
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
+// nvbug6327166: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
 
 #include <cuda/memory>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/memory/align_up.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/align_up.pass.cpp
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
+// nvbug6327166: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
 
 #include <cuda/memory>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/memory/ptr_rebind.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/ptr_rebind.pass.cpp
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
+// nvbug6327166: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
 
 #include <cuda/memory>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/cuda/utilities/expected/device_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/expected/device_only_types.pass.cpp
@@ -17,7 +17,7 @@
 #include "host_device_types.h"
 #include "test_macros.h"
 
-#if _CCCL_DEVICE_COMPILATION()
+#if _CCCL_TILE_COMPILATION() || _CCCL_DEVICE_COMPILATION()
 TEST_DEVICE_FUNC void test()
 {
   using expected = cuda::std::expected<device_only_type, device_only_type>;
@@ -193,7 +193,7 @@ TEST_DEVICE_FUNC void test()
     assert(rhs.error() == 1337);
   }
 }
-#endif // _CCCL_DEVICE_COMPILATION()
+#endif // _CCCL_TILE_COMPILATION() || _CCCL_DEVICE_COMPILATION()
 
 #if _CCCL_TILE_COMPILATION() //  cannot run main because its __tile_global__
 __global__ void test_kernel()

--- a/libcudacxx/test/libcudacxx/cuda/utilities/expected/expected.void/device_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/expected/expected.void/device_only_types.pass.cpp
@@ -16,7 +16,7 @@
 #include "host_device_types.h"
 #include "test_macros.h"
 
-#if _CCCL_DEVICE_COMPILATION()
+#if _CCCL_TILE_COMPILATION() || _CCCL_DEVICE_COMPILATION()
 TEST_DEVICE_FUNC void test()
 {
   using expected = cuda::std::expected<void, device_only_type>;
@@ -157,7 +157,7 @@ TEST_DEVICE_FUNC void test()
     assert(rhs.error() == 1337);
   }
 }
-#endif // _CCCL_DEVICE_COMPILATION()
+#endif // _CCCL_TILE_COMPILATION() || _CCCL_DEVICE_COMPILATION()
 
 #if _CCCL_TILE_COMPILATION() //  cannot run main because its __tile_global__
 __global__ void test_kernel()

--- a/libcudacxx/test/libcudacxx/cuda/utilities/optional/device_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/optional/device_only_types.pass.cpp
@@ -17,7 +17,7 @@
 #include "host_device_types.h"
 #include "test_macros.h"
 
-#if _CCCL_DEVICE_COMPILATION()
+#if _CCCL_TILE_COMPILATION() || _CCCL_DEVICE_COMPILATION()
 template <class T>
 TEST_DEVICE_FUNC void test()
 {
@@ -139,7 +139,7 @@ TEST_DEVICE_FUNC void test()
   test<device_only_type>();
   test<device_only_type&>();
 }
-#endif // _CCCL_DEVICE_COMPILATION()
+#endif // _CCCL_TILE_COMPILATION() || _CCCL_DEVICE_COMPILATION()
 
 #if _CCCL_TILE_COMPILATION() //  cannot run main because its __tile_global__
 __global__ void test_kernel()

--- a/libcudacxx/test/libcudacxx/cuda/utilities/tuple/device_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/tuple/device_only_types.pass.cpp
@@ -13,7 +13,7 @@
 #include "host_device_types.h"
 #include "test_macros.h"
 
-#if _CCCL_DEVICE_COMPILATION()
+#if _CCCL_TILE_COMPILATION() || _CCCL_DEVICE_COMPILATION()
 TEST_DEVICE_FUNC void test()
 {
   using tuple = cuda::std::tuple<device_only_type>;
@@ -74,7 +74,7 @@ TEST_DEVICE_FUNC void test()
     assert(cuda::std::get<0>(rhs) == 1337);
   }
 }
-#endif // _CCCL_DEVICE_COMPILATION()
+#endif // _CCCL_TILE_COMPILATION() || _CCCL_DEVICE_COMPILATION()
 
 #if _CCCL_TILE_COMPILATION() //  cannot run main because its __tile_global__
 __global__ void test_kernel()

--- a/libcudacxx/test/libcudacxx/cuda/utilities/unexpected/device_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/unexpected/device_only_types.pass.cpp
@@ -13,7 +13,7 @@
 #include "host_device_types.h"
 #include "test_macros.h"
 
-#if _CCCL_DEVICE_COMPILATION()
+#if _CCCL_TILE_COMPILATION() || _CCCL_DEVICE_COMPILATION()
 TEST_DEVICE_FUNC void test()
 {
   using unexpected = cuda::std::unexpected<device_only_type>;
@@ -75,7 +75,7 @@ TEST_DEVICE_FUNC void test()
     assert(rhs.error() == 1337);
   }
 }
-#endif // _CCCL_DEVICE_COMPILATION()
+#endif // _CCCL_TILE_COMPILATION() || _CCCL_DEVICE_COMPILATION()
 
 #if _CCCL_TILE_COMPILATION() //  cannot run main because its __tile_global__
 __global__ void test_kernel()

--- a/libcudacxx/test/libcudacxx/cuda/utilities/utility/pair/device_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/utility/pair/device_only_types.pass.cpp
@@ -13,7 +13,7 @@
 #include "host_device_types.h"
 #include "test_macros.h"
 
-#if _CCCL_DEVICE_COMPILATION()
+#if _CCCL_TILE_COMPILATION() || _CCCL_DEVICE_COMPILATION()
 TEST_DEVICE_FUNC void test()
 {
   using pair = cuda::std::pair<device_only_type, device_only_type>;
@@ -84,7 +84,7 @@ TEST_DEVICE_FUNC void test()
     assert(rhs.second == 42);
   }
 }
-#endif // _CCCL_DEVICE_COMPILATION()
+#endif // _CCCL_TILE_COMPILATION() || _CCCL_DEVICE_COMPILATION()
 
 #if _CCCL_TILE_COMPILATION() //  cannot run main because its __tile_global__
 __global__ void test_kernel()

--- a/libcudacxx/test/libcudacxx/cuda/utilities/variant/device_only_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/variant/device_only_types.pass.cpp
@@ -13,7 +13,7 @@
 #include "host_device_types.h"
 #include "test_macros.h"
 
-#if _CCCL_DEVICE_COMPILATION()
+#if _CCCL_TILE_COMPILATION() || _CCCL_DEVICE_COMPILATION()
 TEST_DEVICE_FUNC void test()
 {
   using variant = cuda::std::variant<device_only_type>;
@@ -113,7 +113,7 @@ TEST_DEVICE_FUNC void test()
     assert(cuda::std::get<0>(rhs) == 1337);
   }
 }
-#endif // _CCCL_DEVICE_COMPILATION()
+#endif // _CCCL_TILE_COMPILATION() || _CCCL_DEVICE_COMPILATION()
 
 #if _CCCL_TILE_COMPILATION() //  cannot run main because its __tile_global__
 __global__ void test_kernel()

--- a/libcudacxx/test/libcudacxx/libcxx/macros/extended_data_types.fp8.fail.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/macros/extended_data_types.fp8.fail.cpp
@@ -16,7 +16,7 @@
 
 int main(int, char**)
 {
-#if !_CCCL_HAS_NVFP8()
+#if !_CCCL_HAS_NVFP8() && !_CCCL_TILE_COMPILATION()
   auto x1 = __nv_fp8_e4m3(1.0f);
   unused(x1);
 #else

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/device_fp128_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/device_fp128_functions.pass.cpp
@@ -10,6 +10,7 @@
 
 // ADDITIONAL_COMPILE_OPTIONS_HOST: -fext-numeric-literals
 // ADDITIONAL_COMPILE_DEFINITIONS: CCCL_GCC_HAS_EXTENDED_NUMERIC_LITERALS
+// UNSUPPORTED: enable-tile
 
 #include <cuda/std/__floating_point/cuda_fp_types.h>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_backward.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_backward.pass.cpp
@@ -174,9 +174,9 @@ TEST_CONSTEXPR_CXX20 TEST_FUNC bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !_CCCL_TILE_COMPILATION()
   NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !_CCCL_TILE_COMPILATION()
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_n.pass.cpp
@@ -99,9 +99,9 @@ TEST_CONSTEXPR_CXX20 TEST_FUNC bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !_CCCL_TILE_COMPILATION()
   NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !_CCCL_TILE_COMPILATION()
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_rand.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/copy_rand.pass.cpp
@@ -30,9 +30,9 @@ TEST_CONSTEXPR_CXX20 TEST_FUNC bool test()
 #if !TEST_COMPILER(NVRTC)
   NV_IF_TARGET(NV_IS_HOST, (test<const int*, host_only_iterator<int*>>();))
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_CUDA_COMPILATION()
+#if TEST_CUDA_COMPILATION() && !_CCCL_TILE_COMPILATION()
   NV_IF_TARGET(NV_IS_DEVICE, (test<const int*, device_only_iterator<int*>>();))
-#endif // TEST_CUDA_COMPILATION()
+#endif // TEST_CUDA_COMPILATION() && !_CCCL_TILE_COMPILATION()
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/16b_integral_ref.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/16b_integral_ref.pass.cpp
@@ -10,6 +10,9 @@
 // UNSUPPORTED: windows
 // UNSUPPORTED: aarch64-unknown-linux-gnu
 
+// XFAIL: enable-tile
+// error: asm statement is unsupported in tile code
+
 // <cuda/std/atomic>
 
 // template <>

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan.aligned_accessor/aligned_accessor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan.aligned_accessor/aligned_accessor.pass.cpp
@@ -6,6 +6,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: enable-tile
+// nvbug6327166: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+
 #include <cuda/std/cassert>
 #include <cuda/std/mdspan>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.fmt.string/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.fmt.string/ctor.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // template<class charT, class... Args>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.fmt.string/get.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.fmt.string/get.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// error: bit field read/write is unsupported in tile code
+
 // <cuda/std/format>
 
 // template<class charT, class... Args>

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/ptr.align/align.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/ptr.align/align.pass.cpp
@@ -8,7 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: enable-tile
-// error: asm statement is unsupported in tile code
+// nvbug6327166: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
 
 // #include <memory>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/ptr.align/assume_aligned.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/ptr.align/assume_aligned.pass.cpp
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: enable-tile
+// nvbug6327166: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+
 // #include <memory>
 
 // template<size_t N, class T>

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/ptr.align/assume_aligned.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/ptr.align/assume_aligned.runfail.cpp
@@ -6,7 +6,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-#include "cuda/std/__memory/assume_aligned.h"
+
+// UNSUPPORTED: enable-tile
+// nvbug6327166: error: Internal Compiler Error (tile codegen): "call to unknown tile builtin function!"
+
+#include <cuda/std/memory>
 
 #include <test_macros.h>
 


### PR DESCRIPTION
Currently tile does not support `__builtin_assume_aligned`

Previously we would just disable the whole codepath but with added support for `__builtin_is_constant_evaluated` it became active again.