### PR TITLE
Radix sort policy name improvements

### DIFF
--- a/cub/benchmarks/bench/radix_sort/policy_selector.h
+++ b/cub/benchmarks/bench/radix_sort/policy_selector.h
@@ -18,10 +18,10 @@ struct policy_selector
       return radix_sort_onesweep_policy{
         scaled.threads_per_block,
         scaled.items_per_thread,
-        1,
+        cub::RADIX_SORT_STORE_DIRECT,
         cub::RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
         cub::BLOCK_SCAN_RAKING_MEMOIZE,
-        cub::RADIX_SORT_STORE_DIRECT,
+        1,
         ONESWEEP_RADIX_BITS};
     }();
 
@@ -87,7 +87,7 @@ constexpr std::size_t max_onesweep_temp_storage_size()
     0,
     void,
     onesweep.rank_num_private_partitions,
-    onesweep.rank_algorith,
+    onesweep.rank_algorithm,
     onesweep.scan_algorithm,
     onesweep.store_algorithm,
     onesweep.radix_bits,

--- a/cub/benchmarks/bench/radix_sort/policy_selector.h
+++ b/cub/benchmarks/bench/radix_sort/policy_selector.h
@@ -100,7 +100,7 @@ constexpr std::size_t max_onesweep_temp_storage_size()
   using histogram_policy_t =
     AgentRadixSortHistogramPolicy<histogram.block_threads,
                                   histogram.items_per_thread,
-                                  histogram.num_parts,
+                                  histogram.num_private_partitions,
                                   void,
                                   histogram.radix_bits>;
   using hist_agent = cub::AgentRadixSortHistogram<histogram_policy_t, SortOrder, KeyT, OffsetT>;

--- a/cub/benchmarks/bench/radix_sort/policy_selector.h
+++ b/cub/benchmarks/bench/radix_sort/policy_selector.h
@@ -19,10 +19,10 @@ struct policy_selector
         scaled.threads_per_block,
         scaled.items_per_thread,
         1,
-        ONESWEEP_RADIX_BITS,
         cub::RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
         cub::BLOCK_SCAN_RAKING_MEMOIZE,
-        cub::RADIX_SORT_STORE_DIRECT};
+        cub::RADIX_SORT_STORE_DIRECT,
+        ONESWEEP_RADIX_BITS};
     }();
 
     // These kernels are launched once, no point in tuning at the moment

--- a/cub/benchmarks/bench/radix_sort/policy_selector.h
+++ b/cub/benchmarks/bench/radix_sort/policy_selector.h
@@ -58,7 +58,7 @@ struct policy_selector
     }();
 
     return radix_sort_policy{
-      /* use_onesweep */ true,
+      radix_sort::RadixSortAlgorithm::onesweep,
       histogram,
       exclusive_sum,
       onesweep,
@@ -113,7 +113,7 @@ constexpr std::size_t max_temp_storage_size()
 {
   using offset_t               = cub::detail::choose_offset_t<OffsetT>;
   constexpr auto active_policy = policy_selector<KeyT, ValueT, offset_t>{}(cuda::compute_capability{});
-  static_assert(active_policy.use_onesweep);
+  static_assert(active_policy.algorithm == radix_sort::RadixSortAlgorithm::onesweep);
   return max_onesweep_temp_storage_size<KeyT, ValueT, offset_t, SortOrder>();
 }
 

--- a/cub/benchmarks/bench/radix_sort/policy_selector.h
+++ b/cub/benchmarks/bench/radix_sort/policy_selector.h
@@ -22,13 +22,13 @@ struct policy_selector
         cub::RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
         cub::BLOCK_SCAN_RAKING_MEMOIZE,
         1,
-        ONESWEEP_RADIX_BITS};
+        TUNE_RADIX_BITS};
     }();
 
     // These kernels are launched once, no point in tuning at the moment
     const auto histogram = radix_sort_histogram_policy{
-      128, 16, cub::detail::radix_sort::__scale_num_parts(1, sizeof(KeyT)), ONESWEEP_RADIX_BITS};
-    const auto exclusive_sum = radix_sort_exclusive_sum_policy{256, ONESWEEP_RADIX_BITS};
+      128, 16, cub::detail::radix_sort::__scale_num_parts(1, sizeof(KeyT)), TUNE_RADIX_BITS};
+    const auto exclusive_sum = radix_sort_exclusive_sum_policy{256, TUNE_RADIX_BITS};
 
     const auto scan = [] {
       const auto scaled = cub::detail::scale_mem_bound(512, 23, sizeof(OffsetT));
@@ -59,7 +59,6 @@ struct policy_selector
 
     return radix_sort_policy{
       /* use_onesweep */ true,
-      /* onesweep_radix_bits */ TUNE_RADIX_BITS,
       histogram,
       exclusive_sum,
       onesweep,

--- a/cub/benchmarks/bench/radix_sort/policy_selector.h
+++ b/cub/benchmarks/bench/radix_sort/policy_selector.h
@@ -86,7 +86,7 @@ constexpr std::size_t max_onesweep_temp_storage_size()
     0,
     0,
     void,
-    onesweep.rank_num_parts,
+    onesweep.rank_num_private_partitions,
     onesweep.rank_algorith,
     onesweep.scan_algorithm,
     onesweep.store_algorithm,

--- a/cub/benchmarks/bench/radix_sort/policy_selector.h
+++ b/cub/benchmarks/bench/radix_sort/policy_selector.h
@@ -49,11 +49,11 @@ struct policy_selector
       return cub::detail::radix_sort::radix_sort_downsweep_policy{
         scaled.threads_per_block,
         scaled.items_per_thread,
-        single_tile_radix_bits,
         cub::BLOCK_LOAD_DIRECT,
         cub::LOAD_LDG,
         cub::RADIX_RANK_MEMOIZE,
         cub::BLOCK_SCAN_WARP_SCANS,
+        single_tile_radix_bits,
       };
     }();
 

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -1104,9 +1104,9 @@ public:
 
 #if _CCCL_COMPILER(GCC, <, 10)
     // gcc 7-9 fail to use `policy` in a constant expression, so we just compute it again inplace
-    if CUB_DETAIL_CONSTEXPR_ISH (PolicyGetter{}().use_onesweep)
+    if CUB_DETAIL_CONSTEXPR_ISH (PolicyGetter{}().algorithm == detail::radix_sort::RadixSortAlgorithm::onesweep)
 #else // _CCCL_COMPILER(GCC, <, 8)
-    if CUB_DETAIL_CONSTEXPR_ISH (policy.use_onesweep)
+    if CUB_DETAIL_CONSTEXPR_ISH (policy.algorithm == detail::radix_sort::RadixSortAlgorithm::onesweep)
 #endif // _CCCL_COMPILER(GCC, <, 8)
     {
       return __invoke_onesweep(policy);

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -530,7 +530,7 @@ _CCCL_KERNEL_ATTRIBUTES void __launch_bounds__(current_policy<PolicySelector>().
                                  0,
                                  void,
                                  policy.rank_num_private_partitions,
-                                 policy.rank_algorith,
+                                 policy.rank_algorithm,
                                  policy.scan_algorithm,
                                  policy.store_algorithm,
                                  policy.radix_bits,

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -466,7 +466,7 @@ __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) 
   using HistogramPolicyT =
     AgentRadixSortHistogramPolicy<policy.threads_per_block,
                                   policy.items_per_thread,
-                                  policy.num_parts,
+                                  policy.num_private_partitions,
                                   void,
                                   policy.radix_bits>;
   using AgentT = AgentRadixSortHistogram<HistogramPolicyT, Order == SortOrder::Descending, KeyT, OffsetT, DecomposerT>;

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -526,8 +526,8 @@ _CCCL_KERNEL_ATTRIBUTES void __launch_bounds__(current_policy<PolicySelector>().
 {
   static constexpr radix_sort_onesweep_policy policy = current_policy<PolicySelector>().onesweep;
   using OnesweepPolicyT                              = AgentRadixSortOnesweepPolicy<
-                                 policy.threads_per_block,
-                                 policy.items_per_thread,
+                                 0,
+                                 0,
                                  void,
                                  policy.rank_num_parts,
                                  policy.rank_algorith,

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -529,7 +529,7 @@ _CCCL_KERNEL_ATTRIBUTES void __launch_bounds__(current_policy<PolicySelector>().
                                  0,
                                  0,
                                  void,
-                                 policy.rank_num_parts,
+                                 policy.rank_num_private_partitions,
                                  policy.rank_algorith,
                                  policy.scan_algorithm,
                                  policy.store_algorithm,

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -159,19 +159,19 @@ struct radix_sort_downsweep_policy
 {
   int threads_per_block;
   int items_per_thread;
-  int radix_bits;
   BlockLoadAlgorithm load_algorithm;
   CacheLoadModifier load_modifier;
   RadixRankAlgorithm rank_algorithm;
   BlockScanAlgorithm scan_algorithm;
+  int radix_bits;
 
   _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const radix_sort_downsweep_policy& lhs, const radix_sort_downsweep_policy& rhs)
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
-        && lhs.radix_bits == rhs.radix_bits && lhs.load_algorithm == rhs.load_algorithm
-        && lhs.load_modifier == rhs.load_modifier && lhs.rank_algorithm == rhs.rank_algorithm
-        && lhs.scan_algorithm == rhs.scan_algorithm;
+        && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
+        && lhs.rank_algorithm == rhs.rank_algorithm && lhs.scan_algorithm == rhs.scan_algorithm
+        && lhs.radix_bits == rhs.radix_bits;
   }
 
   _CCCL_HOST_DEVICE_API constexpr friend bool
@@ -185,9 +185,9 @@ struct radix_sort_downsweep_policy
   {
     return os
         << "radix_sort_downsweep_policy { .threads_per_block = " << p.threads_per_block
-        << ", .items_per_thread = " << p.items_per_thread << ", .radix_bits = " << p.radix_bits
-        << ", .load_algorithm = " << p.load_algorithm << ", .load_modifier = " << p.load_modifier
-        << ", .rank_algorithm = " << p.rank_algorithm << ", .scan_algorithm = " << p.scan_algorithm << " }";
+        << ", .items_per_thread = " << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm
+        << ", .load_modifier = " << p.load_modifier << ", .rank_algorithm = " << p.rank_algorithm
+        << ", .scan_algorithm = " << p.scan_algorithm << ", .radix_bits = " << p.radix_bits << " }";
   }
 #endif // _CCCL_HOSTED()
 };
@@ -196,21 +196,21 @@ _CCCL_HOST_DEVICE_API constexpr auto make_reg_scaled_radix_sort_downsweep_policy
   int nominal_4b_threads_per_block,
   int nominal_4b_items_per_thread,
   int compute_t_size,
-  int radix_bits,
   BlockLoadAlgorithm load_algorithm,
   CacheLoadModifier load_modifier,
   RadixRankAlgorithm rank_algorithm,
-  BlockScanAlgorithm scan_algorithm) -> radix_sort_downsweep_policy
+  BlockScanAlgorithm scan_algorithm,
+  int radix_bits) -> radix_sort_downsweep_policy
 {
   const auto scaled = scale_reg_bound(nominal_4b_threads_per_block, nominal_4b_items_per_thread, compute_t_size);
   return radix_sort_downsweep_policy{
     scaled.threads_per_block,
     scaled.items_per_thread,
-    radix_bits,
     load_algorithm,
     load_modifier,
     rank_algorithm,
-    scan_algorithm};
+    scan_algorithm,
+    radix_bits};
 }
 
 struct radix_sort_upsweep_policy
@@ -863,11 +863,11 @@ _CCCL_HOST_DEVICE_API constexpr auto convert_downsweep_policy(DownsweepPolicy)
   return radix_sort_downsweep_policy{
     DownsweepPolicy::BLOCK_THREADS,
     DownsweepPolicy::ITEMS_PER_THREAD,
-    DownsweepPolicy::RADIX_BITS,
     DownsweepPolicy::LOAD_ALGORITHM,
     DownsweepPolicy::LOAD_MODIFIER,
     DownsweepPolicy::RANK_ALGORITHM,
-    DownsweepPolicy::SCAN_ALGORITHM};
+    DownsweepPolicy::SCAN_ALGORITHM,
+    DownsweepPolicy::RADIX_BITS};
 };
 
 // TODO(bgruber): remove in CCCL 4.0 when we drop the radix sort dispatcher after publishing the tuning API
@@ -1751,21 +1751,21 @@ struct policy_selector
       512,
       23,
       __dominant_size(),
-      primary_radix_bits,
       BLOCK_LOAD_TRANSPOSE,
       LOAD_DEFAULT,
       RADIX_RANK_MATCH,
-      BLOCK_SCAN_WARP_SCANS);
+      BLOCK_SCAN_WARP_SCANS,
+      primary_radix_bits);
 
     const auto alt_downsweep = make_reg_scaled_radix_sort_downsweep_policy(
       (key_size > 1) ? 256 : 128,
       47,
       __dominant_size(),
-      primary_radix_bits - 1,
       BLOCK_LOAD_TRANSPOSE,
       LOAD_DEFAULT,
       RADIX_RANK_MEMOIZE,
-      BLOCK_SCAN_WARP_SCANS);
+      BLOCK_SCAN_WARP_SCANS,
+      primary_radix_bits - 1);
 
     const auto upsweep =
       make_reg_scaled_radix_sort_upsweep_policy(256, 23, __dominant_size(), primary_radix_bits, LOAD_DEFAULT);
@@ -1777,11 +1777,11 @@ struct policy_selector
       256,
       19,
       __dominant_size(),
-      single_tile_radix_bits,
       BLOCK_LOAD_DIRECT,
       LOAD_LDG,
       RADIX_RANK_MEMOIZE,
-      BLOCK_SCAN_WARP_SCANS);
+      BLOCK_SCAN_WARP_SCANS,
+      single_tile_radix_bits);
 
     return radix_sort_policy{
       /* use_onesweep */ true,
@@ -1845,21 +1845,21 @@ struct policy_selector
         512,
         23,
         __dominant_size(),
-        primary_radix_bits,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MATCH,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        primary_radix_bits);
 
       const auto alt_downsweep = make_reg_scaled_radix_sort_downsweep_policy(
         (key_size > 1) ? 256 : 128,
         47,
         __dominant_size(),
-        primary_radix_bits - 1,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        primary_radix_bits - 1);
 
       const auto upsweep =
         make_reg_scaled_radix_sort_upsweep_policy(256, 23, __dominant_size(), primary_radix_bits, LOAD_DEFAULT);
@@ -1871,11 +1871,11 @@ struct policy_selector
         256,
         19,
         __dominant_size(),
-        single_tile_radix_bits,
         BLOCK_LOAD_DIRECT,
         LOAD_LDG,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        single_tile_radix_bits);
 
       return radix_sort_policy{
         use_onesweep,
@@ -1926,21 +1926,21 @@ struct policy_selector
         512,
         23,
         __dominant_size(),
-        primary_radix_bits,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MATCH,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        primary_radix_bits);
 
       const auto alt_downsweep = make_reg_scaled_radix_sort_downsweep_policy(
         (key_size > 1) ? 256 : 128,
         offset_64bit ? 46 : 47,
         __dominant_size(),
-        primary_radix_bits - 1,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        primary_radix_bits - 1);
 
       const auto upsweep =
         make_reg_scaled_radix_sort_upsweep_policy(256, 23, __dominant_size(), primary_radix_bits, LOAD_DEFAULT);
@@ -1952,11 +1952,11 @@ struct policy_selector
         256,
         19,
         __dominant_size(),
-        single_tile_radix_bits,
         BLOCK_LOAD_DIRECT,
         LOAD_LDG,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        single_tile_radix_bits);
 
       return radix_sort_policy{
         use_onesweep,
@@ -2006,21 +2006,21 @@ struct policy_selector
         256,
         16,
         __dominant_size(),
-        primary_radix_bits,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_RAKING_MEMOIZE);
+        BLOCK_SCAN_RAKING_MEMOIZE,
+        primary_radix_bits);
 
       const auto alt_downsweep = make_reg_scaled_radix_sort_downsweep_policy(
         256,
         16,
         __dominant_size(),
-        alt_radix_bits,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_RAKING_MEMOIZE);
+        BLOCK_SCAN_RAKING_MEMOIZE,
+        alt_radix_bits);
 
       const auto upsweep = radix_sort_upsweep_policy{
         downsweep.threads_per_block, downsweep.items_per_thread, downsweep.radix_bits, downsweep.load_modifier};
@@ -2035,11 +2035,11 @@ struct policy_selector
         256,
         19,
         __dominant_size(),
-        primary_radix_bits,
         BLOCK_LOAD_DIRECT,
         LOAD_LDG,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        primary_radix_bits);
 
       return radix_sort_policy{
         use_onesweep,
@@ -2089,21 +2089,21 @@ struct policy_selector
         384,
         31,
         __dominant_size(),
-        primary_radix_bits,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MATCH,
-        BLOCK_SCAN_RAKING_MEMOIZE);
+        BLOCK_SCAN_RAKING_MEMOIZE,
+        primary_radix_bits);
 
       const auto alt_downsweep = make_reg_scaled_radix_sort_downsweep_policy(
         256,
         35,
         __dominant_size(),
-        primary_radix_bits - 1,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_RAKING_MEMOIZE);
+        BLOCK_SCAN_RAKING_MEMOIZE,
+        primary_radix_bits - 1);
 
       const auto upsweep =
         make_reg_scaled_radix_sort_upsweep_policy(128, 16, __dominant_size(), primary_radix_bits, LOAD_LDG);
@@ -2115,11 +2115,11 @@ struct policy_selector
         256,
         19,
         __dominant_size(),
-        single_tile_radix_bits,
         BLOCK_LOAD_DIRECT,
         LOAD_LDG,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        single_tile_radix_bits);
 
       return radix_sort_policy{
         use_onesweep,
@@ -2170,21 +2170,21 @@ struct policy_selector
         256,
         25,
         __dominant_size(),
-        primary_radix_bits,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MATCH,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        primary_radix_bits);
 
       const auto alt_downsweep = make_reg_scaled_radix_sort_downsweep_policy(
         192,
         offset_64bit ? 32 : 39,
         __dominant_size(),
-        primary_radix_bits - 1,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        primary_radix_bits - 1);
 
       const auto upsweep = radix_sort_upsweep_policy{
         downsweep.threads_per_block, downsweep.items_per_thread, downsweep.radix_bits, downsweep.load_modifier};
@@ -2199,11 +2199,11 @@ struct policy_selector
         256,
         19,
         __dominant_size(),
-        single_tile_radix_bits,
         BLOCK_LOAD_DIRECT,
         LOAD_LDG,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        single_tile_radix_bits);
 
       return radix_sort_policy{
         use_onesweep,
@@ -2252,21 +2252,21 @@ struct policy_selector
       160,
       39,
       __dominant_size(),
-      primary_radix_bits,
       BLOCK_LOAD_WARP_TRANSPOSE,
       LOAD_DEFAULT,
       RADIX_RANK_BASIC,
-      BLOCK_SCAN_WARP_SCANS);
+      BLOCK_SCAN_WARP_SCANS,
+      primary_radix_bits);
 
     const auto alt_downsweep = make_reg_scaled_radix_sort_downsweep_policy(
       256,
       16,
       __dominant_size(),
-      primary_radix_bits - 1,
       BLOCK_LOAD_DIRECT,
       LOAD_LDG,
       RADIX_RANK_MEMOIZE,
-      BLOCK_SCAN_RAKING_MEMOIZE);
+      BLOCK_SCAN_RAKING_MEMOIZE,
+      primary_radix_bits - 1);
 
     const auto upsweep = radix_sort_upsweep_policy{
       downsweep.threads_per_block, downsweep.items_per_thread, downsweep.radix_bits, downsweep.load_modifier};
@@ -2281,11 +2281,11 @@ struct policy_selector
       256,
       19,
       __dominant_size(),
-      single_tile_radix_bits,
       BLOCK_LOAD_DIRECT,
       LOAD_LDG,
       RADIX_RANK_MEMOIZE,
-      BLOCK_SCAN_WARP_SCANS);
+      BLOCK_SCAN_WARP_SCANS,
+      single_tile_radix_bits);
 
     return radix_sort_policy{
       use_onesweep,

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -258,7 +258,6 @@ _CCCL_HOST_DEVICE_API constexpr auto make_reg_scaled_radix_sort_upsweep_policy(
 struct radix_sort_policy
 {
   bool use_onesweep;
-  int onesweep_radix_bits;
   radix_sort_histogram_policy histogram;
   radix_sort_exclusive_sum_policy exclusive_sum;
   radix_sort_onesweep_policy onesweep;
@@ -271,10 +270,10 @@ struct radix_sort_policy
 
   _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const radix_sort_policy& lhs, const radix_sort_policy& rhs)
   {
-    return lhs.use_onesweep == rhs.use_onesweep && lhs.onesweep_radix_bits == rhs.onesweep_radix_bits
-        && lhs.histogram == rhs.histogram && lhs.exclusive_sum == rhs.exclusive_sum && lhs.onesweep == rhs.onesweep
-        && lhs.scan == rhs.scan && lhs.downsweep == rhs.downsweep && lhs.alt_downsweep == rhs.alt_downsweep
-        && lhs.upsweep == rhs.upsweep && lhs.alt_upsweep == rhs.alt_upsweep && lhs.single_tile == rhs.single_tile;
+    return lhs.use_onesweep == rhs.use_onesweep && lhs.histogram == rhs.histogram
+        && lhs.exclusive_sum == rhs.exclusive_sum && lhs.onesweep == rhs.onesweep && lhs.scan == rhs.scan
+        && lhs.downsweep == rhs.downsweep && lhs.alt_downsweep == rhs.alt_downsweep && lhs.upsweep == rhs.upsweep
+        && lhs.alt_upsweep == rhs.alt_upsweep && lhs.single_tile == rhs.single_tile;
   }
 
   _CCCL_HOST_DEVICE_API constexpr friend bool operator!=(const radix_sort_policy& lhs, const radix_sort_policy& rhs)
@@ -286,8 +285,7 @@ struct radix_sort_policy
   friend ::std::ostream& operator<<(::std::ostream& os, const radix_sort_policy& p)
   {
     return os
-        << "radix_sort_policy { .use_onesweep = " << p.use_onesweep
-        << ", .onesweep_radix_bits = " << p.onesweep_radix_bits << ", .histogram = " << p.histogram
+        << "radix_sort_policy { .use_onesweep = " << p.use_onesweep << ", .histogram = " << p.histogram
         << ", .exclusive_sum = " << p.exclusive_sum << ", .onesweep = " << p.onesweep << ", .scan = " << p.scan
         << ", .downsweep = " << p.downsweep << ", .alt_downsweep = " << p.alt_downsweep << ", .upsweep = " << p.upsweep
         << ", .alt_upsweep = " << p.alt_upsweep << ", .single_tile = " << p.single_tile << " }";
@@ -922,7 +920,6 @@ _CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> radix_sort_policy
 
   return radix_sort_policy{
     active_policy::ONESWEEP,
-    active_policy::ONESWEEP_RADIX_BITS,
     histogram,
     exclusive_sum,
     onesweep,
@@ -1786,7 +1783,6 @@ struct policy_selector
 
     return radix_sort_policy{
       /* use_onesweep */ true,
-      onesweep_radix_bits,
       histogram,
       exclusive_sum,
       onesweep,
@@ -1880,7 +1876,6 @@ struct policy_selector
 
       return radix_sort_policy{
         use_onesweep,
-        onesweep_radix_bits,
         histogram,
         exclusive_sum,
         onesweep,
@@ -1961,7 +1956,6 @@ struct policy_selector
 
       return radix_sort_policy{
         use_onesweep,
-        onesweep_radix_bits,
         histogram,
         exclusive_sum,
         onesweep,
@@ -2044,7 +2038,6 @@ struct policy_selector
 
       return radix_sort_policy{
         use_onesweep,
-        onesweep_radix_bits,
         histogram,
         exclusive_sum,
         onesweep,
@@ -2124,7 +2117,6 @@ struct policy_selector
 
       return radix_sort_policy{
         use_onesweep,
-        onesweep_radix_bits,
         histogram,
         exclusive_sum,
         onesweep,
@@ -2208,7 +2200,6 @@ struct policy_selector
 
       return radix_sort_policy{
         use_onesweep,
-        onesweep_radix_bits,
         histogram,
         exclusive_sum,
         onesweep,
@@ -2290,7 +2281,6 @@ struct policy_selector
 
     return radix_sort_policy{
       use_onesweep,
-      onesweep_radix_bits,
       histogram,
       exclusive_sum,
       onesweep,

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -36,14 +36,17 @@ struct radix_sort_histogram_policy
 {
   int threads_per_block;
   int items_per_thread;
-  int num_parts;
+
+  //! The number of private histograms partitions in shared memory each histogram is split during counting to reduce the
+  //! contention of atomic operations
+  int num_private_partitions;
   int radix_bits;
 
   _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const radix_sort_histogram_policy& lhs, const radix_sort_histogram_policy& rhs)
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
-        && lhs.num_parts == rhs.num_parts && lhs.radix_bits == rhs.radix_bits;
+        && lhs.num_private_partitions == rhs.num_private_partitions && lhs.radix_bits == rhs.radix_bits;
   }
 
   _CCCL_HOST_DEVICE_API constexpr friend bool
@@ -56,8 +59,9 @@ struct radix_sort_histogram_policy
   friend ::std::ostream& operator<<(::std::ostream& os, const radix_sort_histogram_policy& p)
   {
     return os
-        << "radix_sort_histogram_policy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
-        << p.items_per_thread << ", .num_parts = " << p.num_parts << ", .radix_bits = " << p.radix_bits << " }";
+        << "radix_sort_histogram_policy { .threads_per_block = " << p.threads_per_block
+        << ", .items_per_thread = " << p.items_per_thread << ", .num_private_partitions = " << p.num_private_partitions
+        << ", .radix_bits = " << p.radix_bits << " }";
   }
 #endif // _CCCL_HOSTED()
 };

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -96,7 +96,12 @@ struct radix_sort_onesweep_policy
 {
   int threads_per_block;
   int items_per_thread;
-  int rank_num_parts;
+
+  //! The number of private histograms partitions in shared memory each histogram is split during the ranking phase to
+  //! reduce the contention of atomic operations. Ignored if @p rank_algorith is not one of
+  //! RADIX_RANK_MATCH_EARLY_COUNTS_*
+  int rank_num_private_partitions;
+
   int radix_bits;
   RadixRankAlgorithm rank_algorith;
   BlockScanAlgorithm scan_algorithm;
@@ -106,7 +111,7 @@ struct radix_sort_onesweep_policy
   operator==(const radix_sort_onesweep_policy& lhs, const radix_sort_onesweep_policy& rhs)
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
-        && lhs.rank_num_parts == rhs.rank_num_parts && lhs.radix_bits == rhs.radix_bits
+        && lhs.rank_num_private_partitions == rhs.rank_num_private_partitions && lhs.radix_bits == rhs.radix_bits
         && lhs.rank_algorith == rhs.rank_algorith && lhs.scan_algorithm == rhs.scan_algorithm
         && lhs.store_algorithm == rhs.store_algorithm;
   }
@@ -121,8 +126,8 @@ struct radix_sort_onesweep_policy
   friend ::std::ostream& operator<<(::std::ostream& os, const radix_sort_onesweep_policy& p)
   {
     return os
-        << "radix_sort_onesweep_policy { .threads_per_block = " << p.threads_per_block
-        << ", .items_per_thread = " << p.items_per_thread << ", .rank_num_parts = " << p.rank_num_parts
+        << "radix_sort_onesweep_policy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
+        << p.items_per_thread << ", .rank_num_private_partitions = " << p.rank_num_private_partitions
         << ", .radix_bits = " << p.radix_bits << ", .rank_algorith = " << p.rank_algorith
         << ", .scan_algorithm = " << p.scan_algorithm << ", .store_algorithm = " << p.store_algorithm << " }";
   }
@@ -133,7 +138,7 @@ _CCCL_HOST_DEVICE_API constexpr auto make_reg_scaled_radix_sort_onesweep_policy(
   int nominal_4b_threads_per_block,
   int nominal_4b_items_per_thread,
   int compute_t_size,
-  int rank_num_parts,
+  int rank_num_private_partitions,
   int radix_bits,
   RadixRankAlgorithm rank_algorith,
   BlockScanAlgorithm scan_algorithm,
@@ -143,7 +148,7 @@ _CCCL_HOST_DEVICE_API constexpr auto make_reg_scaled_radix_sort_onesweep_policy(
   return radix_sort_onesweep_policy{
     scaled.threads_per_block,
     scaled.items_per_thread,
-    rank_num_parts,
+    rank_num_private_partitions,
     radix_bits,
     rank_algorith,
     scan_algorithm,

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -96,24 +96,24 @@ struct radix_sort_onesweep_policy
 {
   int threads_per_block;
   int items_per_thread;
+  RadixSortStoreAlgorithm store_algorithm;
+  RadixRankAlgorithm rank_algorithm;
+  BlockScanAlgorithm scan_algorithm;
 
   //! The number of private histograms partitions in shared memory each histogram is split during the ranking phase to
-  //! reduce the contention of atomic operations. Ignored if @p rank_algorith is not one of
+  //! reduce the contention of atomic operations. Ignored if @p rank_algorithm is not one of
   //! RADIX_RANK_MATCH_EARLY_COUNTS_*
   int rank_num_private_partitions;
 
-  RadixRankAlgorithm rank_algorith;
-  BlockScanAlgorithm scan_algorithm;
-  RadixSortStoreAlgorithm store_algorithm;
   int radix_bits;
 
   _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const radix_sort_onesweep_policy& lhs, const radix_sort_onesweep_policy& rhs)
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
-        && lhs.rank_num_private_partitions == rhs.rank_num_private_partitions && lhs.rank_algorith == rhs.rank_algorith
-        && lhs.scan_algorithm == rhs.scan_algorithm && lhs.store_algorithm == rhs.store_algorithm
-        && lhs.radix_bits == rhs.radix_bits;
+        && lhs.store_algorithm == rhs.store_algorithm && lhs.rank_algorithm == rhs.rank_algorithm
+        && lhs.scan_algorithm == rhs.scan_algorithm
+        && lhs.rank_num_private_partitions == rhs.rank_num_private_partitions && lhs.radix_bits == rhs.radix_bits;
   }
 
   _CCCL_HOST_DEVICE_API constexpr friend bool
@@ -126,10 +126,11 @@ struct radix_sort_onesweep_policy
   friend ::std::ostream& operator<<(::std::ostream& os, const radix_sort_onesweep_policy& p)
   {
     return os
-        << "radix_sort_onesweep_policy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
-        << p.items_per_thread << ", .rank_num_private_partitions = " << p.rank_num_private_partitions
-        << ", .rank_algorith = " << p.rank_algorith << ", .scan_algorithm = " << p.scan_algorithm
-        << ", .store_algorithm = " << p.store_algorithm << ", .radix_bits = " << p.radix_bits << " }";
+        << "radix_sort_onesweep_policy { .threads_per_block = " << p.threads_per_block
+        << ", .items_per_thread = " << p.items_per_thread << ", .store_algorithm = " << p.store_algorithm
+        << ", .rank_algorithm = " << p.rank_algorithm << ", .scan_algorithm = " << p.scan_algorithm
+        << ", .rank_num_private_partitions = " << p.rank_num_private_partitions << ", .radix_bits = " << p.radix_bits
+        << " }";
   }
 #endif // _CCCL_HOSTED()
 };
@@ -138,20 +139,20 @@ _CCCL_HOST_DEVICE_API constexpr auto make_reg_scaled_radix_sort_onesweep_policy(
   int nominal_4b_threads_per_block,
   int nominal_4b_items_per_thread,
   int compute_t_size,
-  int rank_num_private_partitions,
-  RadixRankAlgorithm rank_algorith,
-  BlockScanAlgorithm scan_algorithm,
   RadixSortStoreAlgorithm store_algorithm,
+  RadixRankAlgorithm rank_algorithm,
+  BlockScanAlgorithm scan_algorithm,
+  int rank_num_private_partitions,
   int radix_bits) -> radix_sort_onesweep_policy
 {
   const auto scaled = scale_reg_bound(nominal_4b_threads_per_block, nominal_4b_items_per_thread, compute_t_size);
   return radix_sort_onesweep_policy{
     scaled.threads_per_block,
     scaled.items_per_thread,
-    rank_num_private_partitions,
-    rank_algorith,
-    scan_algorithm,
     store_algorithm,
+    rank_algorithm,
+    scan_algorithm,
+    rank_num_private_partitions,
     radix_bits};
 }
 
@@ -887,10 +888,10 @@ _CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> radix_sort_policy
   const auto onesweep = radix_sort_onesweep_policy{
     one_pol::BLOCK_THREADS,
     one_pol::ITEMS_PER_THREAD,
-    one_pol::RANK_NUM_PARTS,
+    one_pol::STORE_ALGORITHM,
     one_pol::RANK_ALGORITHM,
     one_pol::SCAN_ALGORITHM,
-    one_pol::STORE_ALGORITHM,
+    one_pol::RANK_NUM_PARTS,
     one_pol::RADIX_BITS};
 
   using scan_pol  = typename active_policy::ScanPolicy;
@@ -1702,20 +1703,20 @@ struct policy_selector
       __keys_only() ? 20 - offset_64bit - key_is_float
                     : (value_size < 8 ? (offset_64bit ? 17 : 23) : (offset_64bit ? 29 : 30)),
       __dominant_size(),
-      1,
+      RADIX_SORT_STORE_DIRECT,
       RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
       BLOCK_SCAN_RAKING_MEMOIZE,
-      RADIX_SORT_STORE_DIRECT,
+      1,
       onesweep_radix_bits);
 
     const auto onesweep_policy_key64 = make_reg_scaled_radix_sort_onesweep_policy(
       384,
       value_size < 8 ? 30 : 24,
       __dominant_size(),
-      1,
+      RADIX_SORT_STORE_DIRECT,
       RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
       BLOCK_SCAN_RAKING_MEMOIZE,
-      RADIX_SORT_STORE_DIRECT,
+      1,
       onesweep_radix_bits);
 
     const auto onesweep_large_key_policy = key_size == 4 ? onesweep_policy_key32 : onesweep_policy_key64;
@@ -1724,10 +1725,10 @@ struct policy_selector
       tuning.threads,
       tuning.items,
       __dominant_size(),
-      1,
+      RADIX_SORT_STORE_DIRECT,
       RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
       BLOCK_SCAN_RAKING_MEMOIZE,
-      RADIX_SORT_STORE_DIRECT,
+      1,
       8);
 
     const auto onesweep = key_size < 4 ? onesweep_small_key_policy : onesweep_large_key_policy;
@@ -1826,10 +1827,10 @@ struct policy_selector
         384,
         offset_64bit && key_size == 4 && !__keys_only() ? 17 : 21,
         __dominant_size(),
-        1,
+        RADIX_SORT_STORE_DIRECT,
         RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
         BLOCK_SCAN_RAKING_MEMOIZE,
-        RADIX_SORT_STORE_DIRECT,
+        1,
         onesweep_radix_bits);
 
       const auto scan = make_mem_scaled_lookback_scan_policy(
@@ -1907,10 +1908,10 @@ struct policy_selector
         256,
         key_size == 4 && value_size == 4 ? 46 : 23,
         __dominant_size(),
-        4,
+        RADIX_SORT_STORE_DIRECT,
         RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
         BLOCK_SCAN_WARP_SCANS,
-        RADIX_SORT_STORE_DIRECT,
+        4,
         onesweep_radix_bits);
 
       const auto scan = make_mem_scaled_lookback_scan_policy(
@@ -1987,10 +1988,10 @@ struct policy_selector
         256,
         30,
         __dominant_size(),
-        2,
+        RADIX_SORT_STORE_DIRECT,
         RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
         BLOCK_SCAN_WARP_SCANS,
-        RADIX_SORT_STORE_DIRECT,
+        2,
         onesweep_radix_bits);
 
       const auto scan = make_mem_scaled_lookback_scan_policy(
@@ -2070,10 +2071,10 @@ struct policy_selector
         256,
         30,
         __dominant_size(),
-        2,
+        RADIX_SORT_STORE_DIRECT,
         RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
         BLOCK_SCAN_WARP_SCANS,
-        RADIX_SORT_STORE_DIRECT,
+        2,
         onesweep_radix_bits);
 
       const auto scan = make_mem_scaled_lookback_scan_policy(
@@ -2151,10 +2152,10 @@ struct policy_selector
         256,
         offset_64bit ? 29 : 30,
         __dominant_size(),
-        2,
+        RADIX_SORT_STORE_DIRECT,
         RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
         BLOCK_SCAN_WARP_SCANS,
-        RADIX_SORT_STORE_DIRECT,
+        2,
         onesweep_radix_bits);
 
       const auto scan = make_mem_scaled_lookback_scan_policy(
@@ -2233,10 +2234,10 @@ struct policy_selector
       256,
       21,
       __dominant_size(),
-      1,
+      RADIX_SORT_STORE_DIRECT,
       RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
       BLOCK_SCAN_WARP_SCANS,
-      RADIX_SORT_STORE_DIRECT,
+      1,
       onesweep_radix_bits);
 
     const auto scan = make_mem_scaled_lookback_scan_policy(

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -217,14 +217,14 @@ struct radix_sort_upsweep_policy
 {
   int threads_per_block;
   int items_per_thread;
-  int radix_bits;
   CacheLoadModifier load_modifier;
+  int radix_bits;
 
   _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const radix_sort_upsweep_policy& lhs, const radix_sort_upsweep_policy& rhs)
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
-        && lhs.radix_bits == rhs.radix_bits && lhs.load_modifier == rhs.load_modifier;
+        && lhs.load_modifier == rhs.load_modifier && lhs.radix_bits == rhs.radix_bits;
   }
 
   _CCCL_HOST_DEVICE_API constexpr friend bool
@@ -238,7 +238,7 @@ struct radix_sort_upsweep_policy
   {
     return os
         << "radix_sort_upsweep_policy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
-        << p.items_per_thread << ", .radix_bits = " << p.radix_bits << ", .load_modifier = " << p.load_modifier << " }";
+        << p.items_per_thread << ", .load_modifier = " << p.load_modifier << ", .radix_bits = " << p.radix_bits << " }";
   }
 #endif // _CCCL_HOSTED()
 };
@@ -247,11 +247,11 @@ _CCCL_HOST_DEVICE_API constexpr auto make_reg_scaled_radix_sort_upsweep_policy(
   int nominal_4b_threads_per_block,
   int nominal_4b_items_per_thread,
   int compute_t_size,
-  int radix_bits,
-  CacheLoadModifier load_modifier) -> radix_sort_upsweep_policy
+  CacheLoadModifier load_modifier,
+  int radix_bits) -> radix_sort_upsweep_policy
 {
   const auto scaled = scale_reg_bound(nominal_4b_threads_per_block, nominal_4b_items_per_thread, compute_t_size);
-  return radix_sort_upsweep_policy{scaled.threads_per_block, scaled.items_per_thread, radix_bits, load_modifier};
+  return radix_sort_upsweep_policy{scaled.threads_per_block, scaled.items_per_thread, load_modifier, radix_bits};
 }
 
 struct radix_sort_policy
@@ -911,11 +911,11 @@ _CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> radix_sort_policy
 
   using up_pol       = typename active_policy::UpsweepPolicy;
   const auto upsweep = radix_sort_upsweep_policy{
-    up_pol::BLOCK_THREADS, up_pol::ITEMS_PER_THREAD, up_pol::RADIX_BITS, up_pol::LOAD_MODIFIER};
+    up_pol::BLOCK_THREADS, up_pol::ITEMS_PER_THREAD, up_pol::LOAD_MODIFIER, up_pol::RADIX_BITS};
 
   using alt_up_pol       = typename active_policy::AltUpsweepPolicy;
   const auto alt_upsweep = radix_sort_upsweep_policy{
-    alt_up_pol::BLOCK_THREADS, alt_up_pol::ITEMS_PER_THREAD, alt_up_pol::RADIX_BITS, alt_up_pol::LOAD_MODIFIER};
+    alt_up_pol::BLOCK_THREADS, alt_up_pol::ITEMS_PER_THREAD, alt_up_pol::LOAD_MODIFIER, alt_up_pol::RADIX_BITS};
 
   const auto single_tile = radix_sort::convert_downsweep_policy(typename active_policy::SingleTilePolicy{});
 
@@ -1768,10 +1768,10 @@ struct policy_selector
       primary_radix_bits - 1);
 
     const auto upsweep =
-      make_reg_scaled_radix_sort_upsweep_policy(256, 23, __dominant_size(), primary_radix_bits, LOAD_DEFAULT);
+      make_reg_scaled_radix_sort_upsweep_policy(256, 23, __dominant_size(), LOAD_DEFAULT, primary_radix_bits);
 
     const auto alt_upsweep =
-      make_reg_scaled_radix_sort_upsweep_policy(256, 47, __dominant_size(), primary_radix_bits - 1, LOAD_DEFAULT);
+      make_reg_scaled_radix_sort_upsweep_policy(256, 47, __dominant_size(), LOAD_DEFAULT, primary_radix_bits - 1);
 
     const auto single_tile = make_reg_scaled_radix_sort_downsweep_policy(
       256,
@@ -1862,10 +1862,10 @@ struct policy_selector
         primary_radix_bits - 1);
 
       const auto upsweep =
-        make_reg_scaled_radix_sort_upsweep_policy(256, 23, __dominant_size(), primary_radix_bits, LOAD_DEFAULT);
+        make_reg_scaled_radix_sort_upsweep_policy(256, 23, __dominant_size(), LOAD_DEFAULT, primary_radix_bits);
 
       const auto alt_upsweep =
-        make_reg_scaled_radix_sort_upsweep_policy(256, 47, __dominant_size(), primary_radix_bits - 1, LOAD_DEFAULT);
+        make_reg_scaled_radix_sort_upsweep_policy(256, 47, __dominant_size(), LOAD_DEFAULT, primary_radix_bits - 1);
 
       const auto single_tile = make_reg_scaled_radix_sort_downsweep_policy(
         256,
@@ -1943,10 +1943,10 @@ struct policy_selector
         primary_radix_bits - 1);
 
       const auto upsweep =
-        make_reg_scaled_radix_sort_upsweep_policy(256, 23, __dominant_size(), primary_radix_bits, LOAD_DEFAULT);
+        make_reg_scaled_radix_sort_upsweep_policy(256, 23, __dominant_size(), LOAD_DEFAULT, primary_radix_bits);
 
       const auto alt_upsweep = make_reg_scaled_radix_sort_upsweep_policy(
-        256, offset_64bit ? 46 : 47, __dominant_size(), primary_radix_bits - 1, LOAD_DEFAULT);
+        256, offset_64bit ? 46 : 47, __dominant_size(), LOAD_DEFAULT, primary_radix_bits - 1);
 
       const auto single_tile = make_reg_scaled_radix_sort_downsweep_policy(
         256,
@@ -2023,13 +2023,13 @@ struct policy_selector
         alt_radix_bits);
 
       const auto upsweep = radix_sort_upsweep_policy{
-        downsweep.threads_per_block, downsweep.items_per_thread, downsweep.radix_bits, downsweep.load_modifier};
+        downsweep.threads_per_block, downsweep.items_per_thread, downsweep.load_modifier, downsweep.radix_bits};
 
       const auto alt_upsweep = radix_sort_upsweep_policy{
         alt_downsweep.threads_per_block,
         alt_downsweep.items_per_thread,
-        alt_downsweep.radix_bits,
-        alt_downsweep.load_modifier};
+        alt_downsweep.load_modifier,
+        alt_downsweep.radix_bits};
 
       const auto single_tile = make_reg_scaled_radix_sort_downsweep_policy(
         256,
@@ -2106,10 +2106,10 @@ struct policy_selector
         primary_radix_bits - 1);
 
       const auto upsweep =
-        make_reg_scaled_radix_sort_upsweep_policy(128, 16, __dominant_size(), primary_radix_bits, LOAD_LDG);
+        make_reg_scaled_radix_sort_upsweep_policy(128, 16, __dominant_size(), LOAD_LDG, primary_radix_bits);
 
       const auto alt_upsweep =
-        make_reg_scaled_radix_sort_upsweep_policy(128, 16, __dominant_size(), primary_radix_bits - 1, LOAD_LDG);
+        make_reg_scaled_radix_sort_upsweep_policy(128, 16, __dominant_size(), LOAD_LDG, primary_radix_bits - 1);
 
       const auto single_tile = make_reg_scaled_radix_sort_downsweep_policy(
         256,
@@ -2187,13 +2187,13 @@ struct policy_selector
         primary_radix_bits - 1);
 
       const auto upsweep = radix_sort_upsweep_policy{
-        downsweep.threads_per_block, downsweep.items_per_thread, downsweep.radix_bits, downsweep.load_modifier};
+        downsweep.threads_per_block, downsweep.items_per_thread, downsweep.load_modifier, downsweep.radix_bits};
 
       const auto alt_upsweep = radix_sort_upsweep_policy{
         alt_downsweep.threads_per_block,
         alt_downsweep.items_per_thread,
-        alt_downsweep.radix_bits,
-        alt_downsweep.load_modifier};
+        alt_downsweep.load_modifier,
+        alt_downsweep.radix_bits};
 
       const auto single_tile = make_reg_scaled_radix_sort_downsweep_policy(
         256,
@@ -2269,13 +2269,13 @@ struct policy_selector
       primary_radix_bits - 1);
 
     const auto upsweep = radix_sort_upsweep_policy{
-      downsweep.threads_per_block, downsweep.items_per_thread, downsweep.radix_bits, downsweep.load_modifier};
+      downsweep.threads_per_block, downsweep.items_per_thread, downsweep.load_modifier, downsweep.radix_bits};
 
     const auto alt_upsweep = radix_sort_upsweep_policy{
       alt_downsweep.threads_per_block,
       alt_downsweep.items_per_thread,
-      alt_downsweep.radix_bits,
-      alt_downsweep.load_modifier};
+      alt_downsweep.load_modifier,
+      alt_downsweep.radix_bits};
 
     const auto single_tile = make_reg_scaled_radix_sort_downsweep_policy(
       256,

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -255,9 +255,30 @@ _CCCL_HOST_DEVICE_API constexpr auto make_reg_scaled_radix_sort_upsweep_policy(
   return radix_sort_upsweep_policy{scaled.threads_per_block, scaled.items_per_thread, load_modifier, radix_bits};
 }
 
+enum class RadixSortAlgorithm
+{
+  multi_pass,
+  onesweep
+};
+
+#if _CCCL_HOSTED()
+inline ::std::ostream& operator<<(::std::ostream& os, RadixSortAlgorithm algorithm)
+{
+  switch (algorithm)
+  {
+    case RadixSortAlgorithm::multi_pass:
+      return os << "RadixSortAlgorithm::multi_pass";
+    case RadixSortAlgorithm::onesweep:
+      return os << "RadixSortAlgorithm::onesweep";
+    default:
+      return os << "RadixSortAlgorithm::unknown(" << static_cast<int>(algorithm) << ")";
+  }
+}
+#endif // _CCCL_HOSTED()
+
 struct radix_sort_policy
 {
-  bool use_onesweep;
+  RadixSortAlgorithm algorithm;
   radix_sort_histogram_policy histogram;
   radix_sort_exclusive_sum_policy exclusive_sum;
   radix_sort_onesweep_policy onesweep;
@@ -270,10 +291,10 @@ struct radix_sort_policy
 
   _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const radix_sort_policy& lhs, const radix_sort_policy& rhs)
   {
-    return lhs.use_onesweep == rhs.use_onesweep && lhs.histogram == rhs.histogram
-        && lhs.exclusive_sum == rhs.exclusive_sum && lhs.onesweep == rhs.onesweep && lhs.scan == rhs.scan
-        && lhs.downsweep == rhs.downsweep && lhs.alt_downsweep == rhs.alt_downsweep && lhs.upsweep == rhs.upsweep
-        && lhs.alt_upsweep == rhs.alt_upsweep && lhs.single_tile == rhs.single_tile;
+    return lhs.algorithm == rhs.algorithm && lhs.histogram == rhs.histogram && lhs.exclusive_sum == rhs.exclusive_sum
+        && lhs.onesweep == rhs.onesweep && lhs.scan == rhs.scan && lhs.downsweep == rhs.downsweep
+        && lhs.alt_downsweep == rhs.alt_downsweep && lhs.upsweep == rhs.upsweep && lhs.alt_upsweep == rhs.alt_upsweep
+        && lhs.single_tile == rhs.single_tile;
   }
 
   _CCCL_HOST_DEVICE_API constexpr friend bool operator!=(const radix_sort_policy& lhs, const radix_sort_policy& rhs)
@@ -285,7 +306,7 @@ struct radix_sort_policy
   friend ::std::ostream& operator<<(::std::ostream& os, const radix_sort_policy& p)
   {
     return os
-        << "radix_sort_policy { .use_onesweep = " << p.use_onesweep << ", .histogram = " << p.histogram
+        << "radix_sort_policy { .algorithm = " << p.algorithm << ", .histogram = " << p.histogram
         << ", .exclusive_sum = " << p.exclusive_sum << ", .onesweep = " << p.onesweep << ", .scan = " << p.scan
         << ", .downsweep = " << p.downsweep << ", .alt_downsweep = " << p.alt_downsweep << ", .upsweep = " << p.upsweep
         << ", .alt_upsweep = " << p.alt_upsweep << ", .single_tile = " << p.single_tile << " }";
@@ -919,7 +940,7 @@ _CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> radix_sort_policy
   const auto single_tile = radix_sort::convert_downsweep_policy(typename active_policy::SingleTilePolicy{});
 
   return radix_sort_policy{
-    active_policy::ONESWEEP,
+    active_policy::ONESWEEP ? RadixSortAlgorithm::onesweep : RadixSortAlgorithm::multi_pass,
     histogram,
     exclusive_sum,
     onesweep,
@@ -1782,7 +1803,7 @@ struct policy_selector
       single_tile_radix_bits);
 
     return radix_sort_policy{
-      /* use_onesweep */ true,
+      RadixSortAlgorithm::onesweep,
       histogram,
       exclusive_sum,
       onesweep,
@@ -1811,9 +1832,10 @@ struct policy_selector
     {
       const int primary_radix_bits     = (key_size > 1) ? 7 : 5;
       const int single_tile_radix_bits = (key_size > 1) ? 6 : 5;
-      const bool use_onesweep          = key_size >= int{sizeof(uint32_t)};
-      const int onesweep_radix_bits    = 8;
-      const bool offset_64bit          = offset_size == 8;
+      const auto use_onesweep =
+        key_size >= int{sizeof(uint32_t)} ? RadixSortAlgorithm::onesweep : RadixSortAlgorithm::multi_pass;
+      const int onesweep_radix_bits = 8;
+      const bool offset_64bit       = offset_size == 8;
 
       const auto histogram = radix_sort_histogram_policy{128, 16, __scale_num_parts(1, key_size), onesweep_radix_bits};
 
@@ -1891,7 +1913,9 @@ struct policy_selector
     {
       const int primary_radix_bits     = (key_size > 1) ? 7 : 5; // 7.62B 32b keys/s (GV100)
       const int single_tile_radix_bits = (key_size > 1) ? 6 : 5;
-      const bool use_onesweep = key_size >= int{sizeof(uint32_t)}; // 15.8B 32b keys/s (V100-SXM2, 64M random keys)
+      // 15.8B 32b keys/s (V100-SXM2, 64M random keys)
+      const auto use_onesweep =
+        key_size >= int{sizeof(uint32_t)} ? RadixSortAlgorithm::onesweep : RadixSortAlgorithm::multi_pass;
       const int onesweep_radix_bits = 8;
       const bool offset_64bit       = offset_size == 8;
 
@@ -1969,9 +1993,10 @@ struct policy_selector
 
     if (cc >= ::cuda::compute_capability{6, 2})
     {
-      const int primary_radix_bits  = 5;
-      const int alt_radix_bits      = primary_radix_bits - 1;
-      const bool use_onesweep       = key_size >= int{sizeof(uint32_t)};
+      const int primary_radix_bits = 5;
+      const int alt_radix_bits     = primary_radix_bits - 1;
+      const auto use_onesweep =
+        key_size >= int{sizeof(uint32_t)} ? RadixSortAlgorithm::onesweep : RadixSortAlgorithm::multi_pass;
       const int onesweep_radix_bits = 8;
 
       const auto histogram = radix_sort_histogram_policy{256, 8, __scale_num_parts(8, key_size), onesweep_radix_bits};
@@ -2053,8 +2078,10 @@ struct policy_selector
     {
       const int primary_radix_bits     = (key_size > 1) ? 7 : 5; // 3.4B 32b keys/s, 1.83B 32b pairs/s (1080)
       const int single_tile_radix_bits = (key_size > 1) ? 6 : 5;
-      const bool use_onesweep          = key_size >= int{sizeof(uint32_t)}; // 10.0B 32b keys/s (GP100, 64M random keys)
-      const int onesweep_radix_bits    = 8;
+      // 10.0B 32b keys/s (GP100, 64M random keys)
+      const auto use_onesweep =
+        key_size >= int{sizeof(uint32_t)} ? RadixSortAlgorithm::onesweep : RadixSortAlgorithm::multi_pass;
+      const int onesweep_radix_bits = 8;
 
       const auto histogram = radix_sort_histogram_policy{256, 8, __scale_num_parts(8, key_size), onesweep_radix_bits};
 
@@ -2132,9 +2159,11 @@ struct policy_selector
     {
       const int primary_radix_bits     = (key_size > 1) ? 7 : 5; // 6.9B 32b keys/s (Quadro P100)
       const int single_tile_radix_bits = (key_size > 1) ? 6 : 5;
-      const bool use_onesweep          = key_size >= int{sizeof(uint32_t)}; // 10.0B 32b keys/s (GP100, 64M random keys)
-      const int onesweep_radix_bits    = 8;
-      const bool offset_64bit          = (offset_size == 8);
+      // 10.0B 32b keys/s (GP100, 64M random keys)
+      const auto use_onesweep =
+        key_size >= int{sizeof(uint32_t)} ? RadixSortAlgorithm::onesweep : RadixSortAlgorithm::multi_pass;
+      const int onesweep_radix_bits = 8;
+      const bool offset_64bit       = (offset_size == 8);
 
       const auto histogram = radix_sort_histogram_policy{256, 8, __scale_num_parts(8, key_size), onesweep_radix_bits};
 
@@ -2214,7 +2243,7 @@ struct policy_selector
     // SM50
     const int primary_radix_bits     = (key_size > 1) ? 7 : 5; // 3.5B 32b keys/s, 1.92B 32b pairs/s (TitanX)
     const int single_tile_radix_bits = (key_size > 1) ? 6 : 5;
-    const bool use_onesweep          = false;
+    const auto use_onesweep          = RadixSortAlgorithm::multi_pass;
     const int onesweep_radix_bits    = 8;
 
     const auto histogram = radix_sort_histogram_policy{256, 8, __scale_num_parts(1, key_size), onesweep_radix_bits};

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -102,18 +102,18 @@ struct radix_sort_onesweep_policy
   //! RADIX_RANK_MATCH_EARLY_COUNTS_*
   int rank_num_private_partitions;
 
-  int radix_bits;
   RadixRankAlgorithm rank_algorith;
   BlockScanAlgorithm scan_algorithm;
   RadixSortStoreAlgorithm store_algorithm;
+  int radix_bits;
 
   _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const radix_sort_onesweep_policy& lhs, const radix_sort_onesweep_policy& rhs)
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
-        && lhs.rank_num_private_partitions == rhs.rank_num_private_partitions && lhs.radix_bits == rhs.radix_bits
-        && lhs.rank_algorith == rhs.rank_algorith && lhs.scan_algorithm == rhs.scan_algorithm
-        && lhs.store_algorithm == rhs.store_algorithm;
+        && lhs.rank_num_private_partitions == rhs.rank_num_private_partitions && lhs.rank_algorith == rhs.rank_algorith
+        && lhs.scan_algorithm == rhs.scan_algorithm && lhs.store_algorithm == rhs.store_algorithm
+        && lhs.radix_bits == rhs.radix_bits;
   }
 
   _CCCL_HOST_DEVICE_API constexpr friend bool
@@ -128,8 +128,8 @@ struct radix_sort_onesweep_policy
     return os
         << "radix_sort_onesweep_policy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
         << p.items_per_thread << ", .rank_num_private_partitions = " << p.rank_num_private_partitions
-        << ", .radix_bits = " << p.radix_bits << ", .rank_algorith = " << p.rank_algorith
-        << ", .scan_algorithm = " << p.scan_algorithm << ", .store_algorithm = " << p.store_algorithm << " }";
+        << ", .rank_algorith = " << p.rank_algorith << ", .scan_algorithm = " << p.scan_algorithm
+        << ", .store_algorithm = " << p.store_algorithm << ", .radix_bits = " << p.radix_bits << " }";
   }
 #endif // _CCCL_HOSTED()
 };
@@ -139,20 +139,20 @@ _CCCL_HOST_DEVICE_API constexpr auto make_reg_scaled_radix_sort_onesweep_policy(
   int nominal_4b_items_per_thread,
   int compute_t_size,
   int rank_num_private_partitions,
-  int radix_bits,
   RadixRankAlgorithm rank_algorith,
   BlockScanAlgorithm scan_algorithm,
-  RadixSortStoreAlgorithm store_algorithm) -> radix_sort_onesweep_policy
+  RadixSortStoreAlgorithm store_algorithm,
+  int radix_bits) -> radix_sort_onesweep_policy
 {
   const auto scaled = scale_reg_bound(nominal_4b_threads_per_block, nominal_4b_items_per_thread, compute_t_size);
   return radix_sort_onesweep_policy{
     scaled.threads_per_block,
     scaled.items_per_thread,
     rank_num_private_partitions,
-    radix_bits,
     rank_algorith,
     scan_algorithm,
-    store_algorithm};
+    store_algorithm,
+    radix_bits};
 }
 
 struct radix_sort_downsweep_policy
@@ -888,10 +888,10 @@ _CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> radix_sort_policy
     one_pol::BLOCK_THREADS,
     one_pol::ITEMS_PER_THREAD,
     one_pol::RANK_NUM_PARTS,
-    one_pol::RADIX_BITS,
     one_pol::RANK_ALGORITHM,
     one_pol::SCAN_ALGORITHM,
-    one_pol::STORE_ALGORITHM};
+    one_pol::STORE_ALGORITHM,
+    one_pol::RADIX_BITS};
 
   using scan_pol  = typename active_policy::ScanPolicy;
   const auto scan = ScanPolicy{
@@ -1703,20 +1703,20 @@ struct policy_selector
                     : (value_size < 8 ? (offset_64bit ? 17 : 23) : (offset_64bit ? 29 : 30)),
       __dominant_size(),
       1,
-      onesweep_radix_bits,
       RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
       BLOCK_SCAN_RAKING_MEMOIZE,
-      RADIX_SORT_STORE_DIRECT);
+      RADIX_SORT_STORE_DIRECT,
+      onesweep_radix_bits);
 
     const auto onesweep_policy_key64 = make_reg_scaled_radix_sort_onesweep_policy(
       384,
       value_size < 8 ? 30 : 24,
       __dominant_size(),
       1,
-      onesweep_radix_bits,
       RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
       BLOCK_SCAN_RAKING_MEMOIZE,
-      RADIX_SORT_STORE_DIRECT);
+      RADIX_SORT_STORE_DIRECT,
+      onesweep_radix_bits);
 
     const auto onesweep_large_key_policy = key_size == 4 ? onesweep_policy_key32 : onesweep_policy_key64;
 
@@ -1725,10 +1725,10 @@ struct policy_selector
       tuning.items,
       __dominant_size(),
       1,
-      8,
       RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
       BLOCK_SCAN_RAKING_MEMOIZE,
-      RADIX_SORT_STORE_DIRECT);
+      RADIX_SORT_STORE_DIRECT,
+      8);
 
     const auto onesweep = key_size < 4 ? onesweep_small_key_policy : onesweep_large_key_policy;
 
@@ -1827,10 +1827,10 @@ struct policy_selector
         offset_64bit && key_size == 4 && !__keys_only() ? 17 : 21,
         __dominant_size(),
         1,
-        onesweep_radix_bits,
         RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
         BLOCK_SCAN_RAKING_MEMOIZE,
-        RADIX_SORT_STORE_DIRECT);
+        RADIX_SORT_STORE_DIRECT,
+        onesweep_radix_bits);
 
       const auto scan = make_mem_scaled_lookback_scan_policy(
         512,
@@ -1908,10 +1908,10 @@ struct policy_selector
         key_size == 4 && value_size == 4 ? 46 : 23,
         __dominant_size(),
         4,
-        onesweep_radix_bits,
         RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
         BLOCK_SCAN_WARP_SCANS,
-        RADIX_SORT_STORE_DIRECT);
+        RADIX_SORT_STORE_DIRECT,
+        onesweep_radix_bits);
 
       const auto scan = make_mem_scaled_lookback_scan_policy(
         512,
@@ -1988,10 +1988,10 @@ struct policy_selector
         30,
         __dominant_size(),
         2,
-        onesweep_radix_bits,
         RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
         BLOCK_SCAN_WARP_SCANS,
-        RADIX_SORT_STORE_DIRECT);
+        RADIX_SORT_STORE_DIRECT,
+        onesweep_radix_bits);
 
       const auto scan = make_mem_scaled_lookback_scan_policy(
         512,
@@ -2071,10 +2071,10 @@ struct policy_selector
         30,
         __dominant_size(),
         2,
-        onesweep_radix_bits,
         RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
         BLOCK_SCAN_WARP_SCANS,
-        RADIX_SORT_STORE_DIRECT);
+        RADIX_SORT_STORE_DIRECT,
+        onesweep_radix_bits);
 
       const auto scan = make_mem_scaled_lookback_scan_policy(
         512,
@@ -2152,10 +2152,10 @@ struct policy_selector
         offset_64bit ? 29 : 30,
         __dominant_size(),
         2,
-        onesweep_radix_bits,
         RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
         BLOCK_SCAN_WARP_SCANS,
-        RADIX_SORT_STORE_DIRECT);
+        RADIX_SORT_STORE_DIRECT,
+        onesweep_radix_bits);
 
       const auto scan = make_mem_scaled_lookback_scan_policy(
         512,
@@ -2234,10 +2234,10 @@ struct policy_selector
       21,
       __dominant_size(),
       1,
-      onesweep_radix_bits,
       RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
       BLOCK_SCAN_WARP_SCANS,
-      RADIX_SORT_STORE_DIRECT);
+      RADIX_SORT_STORE_DIRECT,
+      onesweep_radix_bits);
 
     const auto scan = make_mem_scaled_lookback_scan_policy(
       512,

--- a/cub/cub/device/dispatch/tuning/tuning_segmented_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_segmented_radix_sort.cuh
@@ -77,21 +77,21 @@ struct policy_selector
         192,
         39,
         __dominant_size(),
-        segmented_radix_bits,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        segmented_radix_bits);
 
       const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
         384,
         11,
         __dominant_size(),
-        segmented_radix_bits - 1,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        segmented_radix_bits - 1);
 
       return segmented_radix_sort_policy{segmented, alt_segmented};
     }
@@ -104,21 +104,21 @@ struct policy_selector
         192,
         39,
         __dominant_size(),
-        segmented_radix_bits,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        segmented_radix_bits);
 
       const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
         384,
         11,
         __dominant_size(),
-        segmented_radix_bits - 1,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        segmented_radix_bits - 1);
 
       return segmented_radix_sort_policy{segmented, alt_segmented};
     }
@@ -131,21 +131,21 @@ struct policy_selector
         192,
         39,
         __dominant_size(),
-        segmented_radix_bits,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        segmented_radix_bits);
 
       const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
         384,
         11,
         __dominant_size(),
-        segmented_radix_bits - 1,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        segmented_radix_bits - 1);
 
       return segmented_radix_sort_policy{segmented, alt_segmented};
     }
@@ -158,21 +158,21 @@ struct policy_selector
         192,
         39,
         __dominant_size(),
-        segmented_radix_bits,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        segmented_radix_bits);
 
       const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
         384,
         11,
         __dominant_size(),
-        segmented_radix_bits - 1,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        segmented_radix_bits - 1);
 
       return segmented_radix_sort_policy{segmented, alt_segmented};
     }
@@ -187,21 +187,21 @@ struct policy_selector
         256,
         16,
         __dominant_size(),
-        primary_radix_bits,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_RAKING_MEMOIZE);
+        BLOCK_SCAN_RAKING_MEMOIZE,
+        primary_radix_bits);
 
       const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
         256,
         16,
         __dominant_size(),
-        alt_radix_bits,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_RAKING_MEMOIZE);
+        BLOCK_SCAN_RAKING_MEMOIZE,
+        alt_radix_bits);
 
       return segmented_radix_sort_policy{segmented, alt_segmented};
     }
@@ -214,21 +214,21 @@ struct policy_selector
         192,
         39,
         __dominant_size(),
-        segmented_radix_bits,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        segmented_radix_bits);
 
       const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
         384,
         11,
         __dominant_size(),
-        segmented_radix_bits - 1,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        segmented_radix_bits - 1);
 
       return segmented_radix_sort_policy{segmented, alt_segmented};
     }
@@ -241,21 +241,21 @@ struct policy_selector
         192,
         39,
         __dominant_size(),
-        segmented_radix_bits,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        segmented_radix_bits);
 
       const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
         384,
         11,
         __dominant_size(),
-        segmented_radix_bits - 1,
         BLOCK_LOAD_TRANSPOSE,
         LOAD_DEFAULT,
         RADIX_RANK_MEMOIZE,
-        BLOCK_SCAN_WARP_SCANS);
+        BLOCK_SCAN_WARP_SCANS,
+        segmented_radix_bits - 1);
 
       return segmented_radix_sort_policy{segmented, alt_segmented};
     }
@@ -267,21 +267,21 @@ struct policy_selector
       192,
       31,
       __dominant_size(),
-      segmented_radix_bits,
       BLOCK_LOAD_WARP_TRANSPOSE,
       LOAD_DEFAULT,
       RADIX_RANK_MEMOIZE,
-      BLOCK_SCAN_WARP_SCANS);
+      BLOCK_SCAN_WARP_SCANS,
+      segmented_radix_bits);
 
     const auto alt_segmented = make_reg_scaled_radix_sort_downsweep_policy(
       256,
       11,
       __dominant_size(),
-      segmented_radix_bits - 1,
       BLOCK_LOAD_WARP_TRANSPOSE,
       LOAD_DEFAULT,
       RADIX_RANK_MEMOIZE,
-      BLOCK_SCAN_WARP_SCANS);
+      BLOCK_SCAN_WARP_SCANS,
+      segmented_radix_bits - 1);
 
     return segmented_radix_sort_policy{segmented, alt_segmented};
   }

--- a/cub/test/catch2_test_device_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_radix_sort_env.cu
@@ -1118,18 +1118,18 @@ struct tiny_onesweep_policy_selector
 {
   _CCCL_API constexpr auto operator()(cuda::compute_capability cc) const -> cub::detail::radix_sort::radix_sort_policy
   {
-    using default_selector_t               = cub::detail::radix_sort::policy_selector_from_types<KeyT, ValueT, int>;
-    auto policy                            = default_selector_t{}(cc);
-    policy.use_onesweep                    = true;
-    policy.onesweep.threads_per_block      = BlockThreads;
-    policy.onesweep.items_per_thread       = 1;
-    policy.single_tile.threads_per_block   = BlockThreads;
-    policy.single_tile.items_per_thread    = 1;
-    policy.downsweep.threads_per_block     = BlockThreads;
-    policy.downsweep.items_per_thread      = 1;
-    policy.alt_downsweep.threads_per_block = BlockThreads;
-    policy.alt_downsweep.items_per_thread  = 1;
-    policy.histogram.num_parts             = 1;
+    using default_selector_t                = cub::detail::radix_sort::policy_selector_from_types<KeyT, ValueT, int>;
+    auto policy                             = default_selector_t{}(cc);
+    policy.use_onesweep                     = true;
+    policy.onesweep.threads_per_block       = BlockThreads;
+    policy.onesweep.items_per_thread        = 1;
+    policy.single_tile.threads_per_block    = BlockThreads;
+    policy.single_tile.items_per_thread     = 1;
+    policy.downsweep.threads_per_block      = BlockThreads;
+    policy.downsweep.items_per_thread       = 1;
+    policy.alt_downsweep.threads_per_block  = BlockThreads;
+    policy.alt_downsweep.items_per_thread   = 1;
+    policy.histogram.num_private_partitions = 1;
     return policy;
   }
 };

--- a/cub/test/catch2_test_device_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_radix_sort_env.cu
@@ -1120,7 +1120,7 @@ struct tiny_onesweep_policy_selector
   {
     using default_selector_t                = cub::detail::radix_sort::policy_selector_from_types<KeyT, ValueT, int>;
     auto policy                             = default_selector_t{}(cc);
-    policy.use_onesweep                     = true;
+    policy.algorithm                        = cub::detail::radix_sort::RadixSortAlgorithm::onesweep;
     policy.onesweep.threads_per_block       = BlockThreads;
     policy.onesweep.items_per_thread        = 1;
     policy.single_tile.threads_per_block    = BlockThreads;


### PR DESCRIPTION
Here are a few improvements to the radix sort tuning policies:

* Rename `num_parts` in radix histogram policy to `num_private_partitions`
* Rename `rank_num_parts` in radix onesweep policy to `ranknum_private_partitions`
* Put `radix_bits` last in all affected policies
* Reorder members in `radix_sort_onesweep_policy` for consistency with other tuning policies
* Drop `onesweep_radix_bits` from `radix_sort_policy`. It seems this was added by accident and it's unused.
* Turn `bool use_onesweep` into an algorithm enumeration

- [x] No SASS changes for `cub.bench.radix_sort.pairs.base` for SM`80;90;100`