### PR TITLE
Allow public tuning of `cub::DeviceRadixSort`

### DIFF
--- a/cub/benchmarks/bench/radix_sort/policy_selector.h
+++ b/cub/benchmarks/bench/radix_sort/policy_selector.h
@@ -87,14 +87,14 @@ constexpr std::size_t max_onesweep_temp_storage_size()
     onesweep.scan_algorithm,
     onesweep.store_algorithm,
     onesweep.radix_bits,
-    cub::NoScaling<onesweep.block_threads, onesweep.items_per_thread>>;
+    cub::NoScaling<onesweep.threads_per_block, onesweep.items_per_thread>>;
 
   using agent_radix_sort_onesweep_t =
     cub::AgentRadixSortOnesweep<onesweep_policy_t, SortOrder, KeyT, ValueT, OffsetT, portion_offset>;
 
   constexpr auto histogram = active_policy.histogram;
   using histogram_policy_t = cub::detail::agent_radix_sort_histogram_policy<
-    histogram.block_threads,
+    histogram.threads_per_block,
     histogram.items_per_thread,
     histogram.num_private_partitions,
     void,

--- a/cub/benchmarks/bench/radix_sort/policy_selector.h
+++ b/cub/benchmarks/bench/radix_sort/policy_selector.h
@@ -9,13 +9,12 @@ struct policy_selector
 {
   using DominantT = cuda::std::conditional_t<(sizeof(ValueT) > sizeof(KeyT)), ValueT, KeyT>;
 
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> ::cub::detail::radix_sort::radix_sort_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> ::cub::RadixSortPolicy
   {
     const auto onesweep = [] {
       const auto scaled =
         cub::detail::scale_reg_bound(TUNE_THREADS_PER_BLOCK, TUNE_ITEMS_PER_THREAD, sizeof(DominantT));
-      return radix_sort_onesweep_policy{
+      return cub::RadixSortOnesweepPolicy{
         scaled.threads_per_block,
         scaled.items_per_thread,
         cub::RADIX_SORT_STORE_DIRECT,
@@ -26,9 +25,9 @@ struct policy_selector
     }();
 
     // These kernels are launched once, no point in tuning at the moment
-    const auto histogram = radix_sort_histogram_policy{
+    const auto histogram = cub::RadixSortHistogramPolicy{
       128, 16, cub::detail::radix_sort::__scale_num_parts(1, sizeof(KeyT)), TUNE_RADIX_BITS};
-    const auto exclusive_sum = radix_sort_exclusive_sum_policy{256, TUNE_RADIX_BITS};
+    const auto exclusive_sum = cub::RadixSortExclusiveSumPolicy{256, TUNE_RADIX_BITS};
 
     const auto scan = [] {
       const auto scaled = cub::detail::scale_mem_bound(512, 23, sizeof(OffsetT));
@@ -46,7 +45,7 @@ struct policy_selector
     // No point in tuning single-tile policy
     const auto single_tile = [] {
       const auto scaled = cub::detail::scale_reg_bound(256, 19, sizeof(DominantT));
-      return cub::detail::radix_sort::radix_sort_downsweep_policy{
+      return cub::RadixSortDownsweepPolicy{
         scaled.threads_per_block,
         scaled.items_per_thread,
         cub::BLOCK_LOAD_DIRECT,
@@ -57,8 +56,8 @@ struct policy_selector
       };
     }();
 
-    return radix_sort_policy{
-      radix_sort::RadixSortAlgorithm::onesweep,
+    return cub::RadixSortPolicy{
+      cub::RadixSortAlgorithm::onesweep,
       histogram,
       exclusive_sum,
       onesweep,
@@ -67,9 +66,7 @@ struct policy_selector
       /* alt_downsweep */ {},
       /* upsweep */ {},
       /* alt_upsweep */ {},
-      single_tile,
-      /* segmented not used */ {},
-      /* alt_segmented not used */ {}};
+      single_tile};
   }
 };
 
@@ -81,7 +78,7 @@ constexpr std::size_t max_onesweep_temp_storage_size()
   constexpr auto active_policy = policy_selector<KeyT, ValueT, OffsetT>{}(cuda::compute_capability{});
 
   constexpr auto onesweep = active_policy.onesweep;
-  using onesweep_policy_t = AgentRadixSortOnesweepPolicy<
+  using onesweep_policy_t = cub::detail::agent_radix_sort_onesweep_policy<
     0,
     0,
     void,
@@ -90,18 +87,18 @@ constexpr std::size_t max_onesweep_temp_storage_size()
     onesweep.scan_algorithm,
     onesweep.store_algorithm,
     onesweep.radix_bits,
-    NoScaling<onesweep.block_threads, onesweep.items_per_thread>>;
+    cub::NoScaling<onesweep.block_threads, onesweep.items_per_thread>>;
 
   using agent_radix_sort_onesweep_t =
     cub::AgentRadixSortOnesweep<onesweep_policy_t, SortOrder, KeyT, ValueT, OffsetT, portion_offset>;
 
   constexpr auto histogram = active_policy.histogram;
-  using histogram_policy_t =
-    AgentRadixSortHistogramPolicy<histogram.block_threads,
-                                  histogram.items_per_thread,
-                                  histogram.num_private_partitions,
-                                  void,
-                                  histogram.radix_bits>;
+  using histogram_policy_t = cub::detail::agent_radix_sort_histogram_policy<
+    histogram.block_threads,
+    histogram.items_per_thread,
+    histogram.num_private_partitions,
+    void,
+    histogram.radix_bits>;
   using hist_agent = cub::AgentRadixSortHistogram<histogram_policy_t, SortOrder, KeyT, OffsetT>;
 
   return cuda::std::max(sizeof(typename agent_radix_sort_onesweep_t::TempStorage),
@@ -113,7 +110,7 @@ constexpr std::size_t max_temp_storage_size()
 {
   using offset_t               = cub::detail::choose_offset_t<OffsetT>;
   constexpr auto active_policy = policy_selector<KeyT, ValueT, offset_t>{}(cuda::compute_capability{});
-  static_assert(active_policy.algorithm == radix_sort::RadixSortAlgorithm::onesweep);
+  static_assert(active_policy.algorithm == cub::RadixSortAlgorithm::onesweep);
   return max_onesweep_temp_storage_size<KeyT, ValueT, offset_t, SortOrder>();
 }
 

--- a/cub/cub/agent/agent_radix_sort_downsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_downsweep.cuh
@@ -34,11 +34,8 @@
 #include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
-
-/******************************************************************************
- * Tuning policy types
- ******************************************************************************/
-
+namespace detail
+{
 /**
  * @brief Parameterizable tuning policy type for AgentRadixSortDownsweep
  *
@@ -75,7 +72,7 @@ template <int NominalThreadsPerBlock4B,
           BlockScanAlgorithm ScanAlgorithm,
           int RadixBits,
           typename ScalingType = detail::RegBoundScaling<NominalThreadsPerBlock4B, NominalItemsPerThread4B, ComputeT>>
-struct AgentRadixSortDownsweepPolicy : ScalingType
+struct agent_radix_sort_downsweep_policy : ScalingType
 {
   /// The number of radix bits, i.e., log2(bins)
   static constexpr int RADIX_BITS = RadixBits;
@@ -92,6 +89,32 @@ struct AgentRadixSortDownsweepPolicy : ScalingType
   /// The BlockScan algorithm to use
   static constexpr BlockScanAlgorithm SCAN_ALGORITHM = ScanAlgorithm;
 };
+} // namespace detail
+
+/******************************************************************************
+ * Tuning policy types
+ ******************************************************************************/
+
+template <int NominalThreadsPerBlock4B,
+          int NominalItemsPerThread4B,
+          typename ComputeT,
+          BlockLoadAlgorithm LoadAlgorithm,
+          CacheLoadModifier LoadModifier,
+          RadixRankAlgorithm RankAlgorithm,
+          BlockScanAlgorithm ScanAlgorithm,
+          int RadixBits,
+          typename ScalingType = detail::RegBoundScaling<NominalThreadsPerBlock4B, NominalItemsPerThread4B, ComputeT>>
+using AgentRadixSortDownsweepPolicy
+  CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceRadixSort") = detail::agent_radix_sort_downsweep_policy<
+    NominalThreadsPerBlock4B,
+    NominalItemsPerThread4B,
+    ComputeT,
+    LoadAlgorithm,
+    LoadModifier,
+    RankAlgorithm,
+    ScanAlgorithm,
+    RadixBits,
+    ScalingType>;
 
 /******************************************************************************
  * Thread block abstractions

--- a/cub/cub/agent/agent_radix_sort_histogram.cuh
+++ b/cub/cub/agent/agent_radix_sort_histogram.cuh
@@ -35,9 +35,11 @@
 
 CUB_NAMESPACE_BEGIN
 
+namespace detail
+{
 //! @param ComputeT If void, use NOMINAL_4B_NUM_PARTS directly for NUM_PARTS. Otherwise, perform scaling.
 template <int ThreadsPerBlock, int ItemsPerThread, int NOMINAL_4B_NUM_PARTS, typename ComputeT, int RadixBits>
-struct AgentRadixSortHistogramPolicy
+struct agent_radix_sort_histogram_policy
 {
   static constexpr int BLOCK_THREADS    = ThreadsPerBlock;
   static constexpr int ITEMS_PER_THREAD = ItemsPerThread;
@@ -67,11 +69,20 @@ struct AgentRadixSortHistogramPolicy
 };
 
 template <int ThreadsPerBlock, int RadixBits>
-struct AgentRadixSortExclusiveSumPolicy
+struct agent_radix_sort_exclusive_sum_policy
 {
   static constexpr int BLOCK_THREADS = ThreadsPerBlock;
   static constexpr int RADIX_BITS    = RadixBits;
 };
+} // namespace detail
+
+template <int ThreadsPerBlock, int ItemsPerThread, int NOMINAL_4B_NUM_PARTS, typename ComputeT, int RadixBits>
+using AgentRadixSortHistogramPolicy CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceRadixSort") =
+  detail::agent_radix_sort_histogram_policy<ThreadsPerBlock, ItemsPerThread, NOMINAL_4B_NUM_PARTS, ComputeT, RadixBits>;
+
+template <int ThreadsPerBlock, int RadixBits>
+using AgentRadixSortExclusiveSumPolicy CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceRadixSort") =
+  detail::agent_radix_sort_exclusive_sum_policy<ThreadsPerBlock, RadixBits>;
 
 namespace detail::radix_sort
 {

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -66,6 +66,8 @@ inline ::std::ostream& operator<<(::std::ostream& os, RadixSortStoreAlgorithm al
 }
 #endif // _CCCL_HOSTED() && !_CCCL_DOXYGEN_INVOKED
 
+namespace detail
+{
 template <int NominalThreadsPerBlock4B,
           int NominalItemsPerThread4B,
           typename ComputeT,
@@ -79,7 +81,7 @@ template <int NominalThreadsPerBlock4B,
           RadixSortStoreAlgorithm StoreAlgorithm,
           int RadixBits,
           typename ScalingType = detail::RegBoundScaling<NominalThreadsPerBlock4B, NominalItemsPerThread4B, ComputeT>>
-struct AgentRadixSortOnesweepPolicy : ScalingType
+struct agent_radix_sort_onesweep_policy : ScalingType
 {
   static constexpr int RANK_NUM_PARTS                      = RankNumParts;
   static constexpr int RADIX_BITS                          = RadixBits;
@@ -87,6 +89,28 @@ struct AgentRadixSortOnesweepPolicy : ScalingType
   static constexpr BlockScanAlgorithm SCAN_ALGORITHM       = ScanAlgorithm;
   static constexpr RadixSortStoreAlgorithm STORE_ALGORITHM = StoreAlgorithm;
 };
+} // namespace detail
+
+template <int NominalThreadsPerBlock4B,
+          int NominalItemsPerThread4B,
+          typename ComputeT,
+          int RankNumParts,
+          RadixRankAlgorithm RankAlgorithm,
+          BlockScanAlgorithm ScanAlgorithm,
+          RadixSortStoreAlgorithm StoreAlgorithm,
+          int RadixBits,
+          typename ScalingType = detail::RegBoundScaling<NominalThreadsPerBlock4B, NominalItemsPerThread4B, ComputeT>>
+using AgentRadixSortOnesweepPolicy
+  CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceRadixSort") = detail::agent_radix_sort_onesweep_policy<
+    NominalThreadsPerBlock4B,
+    NominalItemsPerThread4B,
+    ComputeT,
+    RankNumParts,
+    RankAlgorithm,
+    ScanAlgorithm,
+    StoreAlgorithm,
+    RadixBits,
+    ScalingType>;
 
 namespace detail::radix_sort
 {

--- a/cub/cub/agent/agent_radix_sort_upsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_upsweep.cuh
@@ -40,6 +40,8 @@ CUB_NAMESPACE_BEGIN
  * Tuning policy types
  ******************************************************************************/
 
+namespace detail
+{
 /**
  * @brief Parameterizable tuning policy type for AgentRadixSortUpsweep
  *
@@ -64,7 +66,7 @@ template <int NominalThreadsPerBlock4B,
           CacheLoadModifier LoadModifier,
           int RadixBits,
           typename ScalingType = detail::RegBoundScaling<NominalThreadsPerBlock4B, NominalItemsPerThread4B, ComputeT>>
-struct AgentRadixSortUpsweepPolicy : ScalingType
+struct agent_radix_sort_upsweep_policy : ScalingType
 {
   /// The number of radix bits, i.e., log2(bins)
   static constexpr int RADIX_BITS = RadixBits;
@@ -72,6 +74,22 @@ struct AgentRadixSortUpsweepPolicy : ScalingType
   /// Cache load modifier for reading keys
   static constexpr CacheLoadModifier LOAD_MODIFIER = LoadModifier;
 };
+} // namespace detail
+
+template <int NominalThreadsPerBlock4B,
+          int NominalItemsPerThread4B,
+          typename ComputeT,
+          CacheLoadModifier LoadModifier,
+          int RadixBits,
+          typename ScalingType = detail::RegBoundScaling<NominalThreadsPerBlock4B, NominalItemsPerThread4B, ComputeT>>
+using AgentRadixSortUpsweepPolicy
+  CCCL_DEPRECATED_BECAUSE("Use the tuning API for DeviceRadixSort") = detail::agent_radix_sort_upsweep_policy<
+    NominalThreadsPerBlock4B,
+    NominalItemsPerThread4B,
+    ComputeT,
+    LoadModifier,
+    RadixBits,
+    ScalingType>;
 
 /******************************************************************************
  * Thread block abstractions

--- a/cub/cub/device/device_radix_sort.cuh
+++ b/cub/cub/device/device_radix_sort.cuh
@@ -145,6 +145,23 @@ inline constexpr bool __can_use_radix_sort =
 //!
 //! @linear_performance{radix sort}
 //!
+//! @par Tuning
+//! All algorithms in DeviceRadixSort that accept an environment can be tuned by passing a custom
+//! :ref:`policy selector <cub-policy-selectors>` that returns a @ref RadixSortPolicy, as shown in the
+//! example below:
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_radix_sort_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin radix-sort-keys-policy-selector
+//!      :end-before: example-end radix-sort-keys-policy-selector
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_radix_sort_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin radix-sort-keys-tuning
+//!      :end-before: example-end radix-sort-keys-tuning
+//!
 //! @endrst
 struct DeviceRadixSort
 {
@@ -172,8 +189,8 @@ private:
     TuningEnvT             = {})
   {
     using default_policy_selector_t = detail::radix_sort::policy_selector_from_types<KeyT, ValueT, OffsetT>;
-    using policy_selector_t         = ::cuda::std::execution::
-      __query_result_or_t<TuningEnvT, detail::radix_sort::radix_sort_policy, default_policy_selector_t>;
+    using policy_selector_t =
+      ::cuda::std::execution::__query_result_or_t<TuningEnvT, RadixSortPolicy, default_policy_selector_t>;
     return detail::radix_sort::dispatch<Order>(
       d_temp_storage,
       temp_storage_bytes,

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -132,7 +132,6 @@ struct DeviceRadixSortKernelSource
  *   Implementation detail, do not specify directly, requirements on the
  *   content of this type are subject to breaking change.
  */
-// TODO(bgruber): deprecate when we make the tuning API public and remove in CCCL 4.0
 template <SortOrder Order,
           typename KeyT,
           typename ValueT,
@@ -147,7 +146,8 @@ template <SortOrder Order,
             OffsetT,
             DecomposerT>,
           typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
-struct DispatchRadixSort
+// FIXME(bgruber): enable deprecation
+struct /*CCCL_DEPRECATED_BECAUSE("Please use DeviceRadixSort"*/ DispatchRadixSort
 {
   //------------------------------------------------------------------------------
   // Constants
@@ -261,7 +261,7 @@ struct DispatchRadixSort
 private:
   template <typename SingleTileKernelT>
   CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t
-  __invoke_single_tile(SingleTileKernelT single_tile_kernel, detail::radix_sort::radix_sort_downsweep_policy policy)
+  __invoke_single_tile(SingleTileKernelT single_tile_kernel, RadixSortDownsweepPolicy policy)
   {
     // Return if the caller is simply requesting the size of the storage allocation
     if (d_temp_storage == nullptr)
@@ -499,9 +499,9 @@ public:
       int sm_count,
       OffsetT num_items,
       int pass_radix_bits,
-      detail::radix_sort::radix_sort_upsweep_policy upsweep_policy,
+      RadixSortUpsweepPolicy upsweep_policy,
       ScanPolicy scan_policy,
-      detail::radix_sort::radix_sort_downsweep_policy downsweep_policy,
+      RadixSortDownsweepPolicy downsweep_policy,
       KernelLauncherFactory launcher_factory)
     {
       this->upsweep_kernel   = upsweep_kern;
@@ -542,7 +542,7 @@ public:
   }
 
 private:
-  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t __invoke_onesweep(detail::radix_sort::radix_sort_policy policy)
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t __invoke_onesweep(RadixSortPolicy policy)
   {
     // PortionOffsetT is used for offsets within a portion, and must be signed.
     using PortionOffsetT = int;
@@ -853,7 +853,7 @@ private:
     ScanKernelT scan_kernel,
     DownsweepKernelT downsweep_kernel,
     DownsweepKernelT alt_downsweep_kernel,
-    const detail::radix_sort::radix_sort_policy& policy)
+    const RadixSortPolicy& policy)
   {
     // Get device ordinal
     int device_ordinal;
@@ -1105,9 +1105,9 @@ public:
 
 #if _CCCL_COMPILER(GCC, <, 10)
     // gcc 7-9 fail to use `policy` in a constant expression, so we just compute it again inplace
-    if CUB_DETAIL_CONSTEXPR_ISH (PolicyGetter{}().algorithm == detail::radix_sort::RadixSortAlgorithm::onesweep)
+    if CUB_DETAIL_CONSTEXPR_ISH (PolicyGetter{}().algorithm == RadixSortAlgorithm::onesweep)
 #else // _CCCL_COMPILER(GCC, <, 8)
-    if CUB_DETAIL_CONSTEXPR_ISH (policy.algorithm == detail::radix_sort::RadixSortAlgorithm::onesweep)
+    if CUB_DETAIL_CONSTEXPR_ISH (policy.algorithm == RadixSortAlgorithm::onesweep)
 #endif // _CCCL_COMPILER(GCC, <, 8)
     {
       return __invoke_onesweep(policy);

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -91,17 +91,16 @@ __launch_bounds__(int(ALT_DIGIT_BITS ? current_policy<PolicySelector>().alt_upsw
     GridEvenShare<OffsetT> even_share,
     _CCCL_GRID_CONSTANT const DecomposerT decomposer = {})
 {
-  static constexpr radix_sort_policy policy = current_policy<PolicySelector>();
-  static constexpr radix_sort_upsweep_policy active_upsweep_policy =
-    ALT_DIGIT_BITS ? policy.alt_upsweep : policy.upsweep;
-  static constexpr radix_sort_downsweep_policy active_downsweep_policy =
+  static constexpr RadixSortPolicy policy                       = current_policy<PolicySelector>();
+  static constexpr RadixSortUpsweepPolicy active_upsweep_policy = ALT_DIGIT_BITS ? policy.alt_upsweep : policy.upsweep;
+  static constexpr RadixSortDownsweepPolicy active_downsweep_policy =
     ALT_DIGIT_BITS ? policy.alt_downsweep : policy.downsweep;
 
   static constexpr int TILE_ITEMS =
     ::cuda::std::max(active_upsweep_policy.threads_per_block * active_upsweep_policy.items_per_thread,
                      active_downsweep_policy.threads_per_block * active_downsweep_policy.items_per_thread);
 
-  using ActiveUpsweepPolicyT = AgentRadixSortUpsweepPolicy<
+  using ActiveUpsweepPolicyT = detail::agent_radix_sort_upsweep_policy<
     active_upsweep_policy.threads_per_block,
     active_upsweep_policy.items_per_thread,
     void,
@@ -255,18 +254,17 @@ __launch_bounds__(int(ALT_DIGIT_BITS ? current_policy<PolicySelector>().alt_down
     GridEvenShare<OffsetT> even_share,
     _CCCL_GRID_CONSTANT const DecomposerT decomposer = {})
 {
-  static constexpr radix_sort_policy policy = current_policy<PolicySelector>();
+  static constexpr RadixSortPolicy policy = current_policy<PolicySelector>();
 
-  static constexpr radix_sort_upsweep_policy active_upsweep_policy =
-    ALT_DIGIT_BITS ? policy.alt_upsweep : policy.upsweep;
-  static constexpr radix_sort_downsweep_policy active_downsweep_policy =
+  static constexpr RadixSortUpsweepPolicy active_upsweep_policy = ALT_DIGIT_BITS ? policy.alt_upsweep : policy.upsweep;
+  static constexpr RadixSortDownsweepPolicy active_downsweep_policy =
     ALT_DIGIT_BITS ? policy.alt_downsweep : policy.downsweep;
 
   static constexpr int TILE_ITEMS =
     ::cuda::std::max(active_upsweep_policy.threads_per_block * active_upsweep_policy.items_per_thread,
                      active_downsweep_policy.threads_per_block * active_downsweep_policy.items_per_thread);
 
-  using ActiveDownsweepPolicyT = AgentRadixSortDownsweepPolicy<
+  using ActiveDownsweepPolicyT = detail::agent_radix_sort_downsweep_policy<
     active_downsweep_policy.threads_per_block,
     active_downsweep_policy.items_per_thread,
     void,
@@ -348,10 +346,10 @@ __launch_bounds__(current_policy<PolicySelector>().single_tile.threads_per_block
     _CCCL_GRID_CONSTANT const DecomposerT decomposer = {})
 {
   // Constants
-  static constexpr radix_sort_policy policy = current_policy<PolicySelector>();
-  static constexpr int BLOCK_THREADS        = policy.single_tile.threads_per_block;
-  static constexpr int ITEMS_PER_THREAD     = policy.single_tile.items_per_thread;
-  static constexpr bool KEYS_ONLY           = ::cuda::std::is_same_v<ValueT, NullType>;
+  static constexpr RadixSortPolicy policy = current_policy<PolicySelector>();
+  static constexpr int BLOCK_THREADS      = policy.single_tile.threads_per_block;
+  static constexpr int ITEMS_PER_THREAD   = policy.single_tile.items_per_thread;
+  static constexpr bool KEYS_ONLY         = ::cuda::std::is_same_v<ValueT, NullType>;
 
   // BlockRadixSort type
   using BlockRadixSortT =
@@ -461,14 +459,14 @@ __launch_bounds__(current_policy<PolicySelector>().histogram.threads_per_block) 
   _CCCL_GRID_CONSTANT const int end_bit,
   _CCCL_GRID_CONSTANT const DecomposerT decomposer = {})
 {
-  static constexpr radix_sort_histogram_policy policy = current_policy<PolicySelector>().histogram;
+  static constexpr RadixSortHistogramPolicy policy = current_policy<PolicySelector>().histogram;
 
-  using HistogramPolicyT =
-    AgentRadixSortHistogramPolicy<policy.threads_per_block,
-                                  policy.items_per_thread,
-                                  policy.num_private_partitions,
-                                  void,
-                                  policy.radix_bits>;
+  using HistogramPolicyT = detail::agent_radix_sort_histogram_policy<
+    policy.threads_per_block,
+    policy.items_per_thread,
+    policy.num_private_partitions,
+    void,
+    policy.radix_bits>;
   using AgentT = AgentRadixSortHistogram<HistogramPolicyT, Order == SortOrder::Descending, KeyT, OffsetT, DecomposerT>;
   __shared__ typename AgentT::TempStorage temp_storage;
   AgentT agent(temp_storage, d_bins_out, d_keys_in, num_items, start_bit, end_bit, decomposer);
@@ -524,17 +522,17 @@ _CCCL_KERNEL_ATTRIBUTES void __launch_bounds__(current_policy<PolicySelector>().
     _CCCL_GRID_CONSTANT const int num_bits,
     _CCCL_GRID_CONSTANT const DecomposerT decomposer = {})
 {
-  static constexpr radix_sort_onesweep_policy policy = current_policy<PolicySelector>().onesweep;
-  using OnesweepPolicyT                              = AgentRadixSortOnesweepPolicy<
-                                 0,
-                                 0,
-                                 void,
-                                 policy.rank_num_private_partitions,
-                                 policy.rank_algorithm,
-                                 policy.scan_algorithm,
-                                 policy.store_algorithm,
-                                 policy.radix_bits,
-                                 NoScaling<policy.threads_per_block, policy.items_per_thread>>;
+  static constexpr RadixSortOnesweepPolicy policy = current_policy<PolicySelector>().onesweep;
+  using OnesweepPolicyT                           = detail::agent_radix_sort_onesweep_policy<
+                              0,
+                              0,
+                              void,
+                              policy.rank_num_private_partitions,
+                              policy.rank_algorithm,
+                              policy.scan_algorithm,
+                              policy.store_algorithm,
+                              policy.radix_bits,
+                              NoScaling<policy.threads_per_block, policy.items_per_thread>>;
 
   using AgentT =
     AgentRadixSortOnesweep<OnesweepPolicyT,
@@ -569,12 +567,12 @@ _CCCL_KERNEL_ATTRIBUTES void __launch_bounds__(current_policy<PolicySelector>().
 template <typename PolicySelector, typename OffsetT>
 _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortExclusiveSumKernel(_CCCL_GRID_CONSTANT OffsetT* const d_bins)
 {
-  static constexpr radix_sort_exclusive_sum_policy policy = current_policy<PolicySelector>().exclusive_sum;
-  constexpr int RADIX_BITS                                = policy.radix_bits;
-  constexpr int RADIX_DIGITS                              = 1 << RADIX_BITS;
-  constexpr int BLOCK_THREADS                             = policy.threads_per_block;
-  constexpr int BINS_PER_THREAD                           = (RADIX_DIGITS + BLOCK_THREADS - 1) / BLOCK_THREADS;
-  using BlockScan                                         = cub::BlockScan<OffsetT, BLOCK_THREADS>;
+  static constexpr RadixSortExclusiveSumPolicy policy = current_policy<PolicySelector>().exclusive_sum;
+  constexpr int RADIX_BITS                            = policy.radix_bits;
+  constexpr int RADIX_DIGITS                          = 1 << RADIX_BITS;
+  constexpr int BLOCK_THREADS                         = policy.threads_per_block;
+  constexpr int BINS_PER_THREAD                       = (RADIX_DIGITS + BLOCK_THREADS - 1) / BLOCK_THREADS;
+  using BlockScan                                     = cub::BlockScan<OffsetT, BLOCK_THREADS>;
   __shared__ typename BlockScan::TempStorage temp_storage;
 
   // Make sure the histograms are done

--- a/cub/cub/device/dispatch/kernels/kernel_segmented_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_segmented_radix_sort.cuh
@@ -125,26 +125,26 @@ __launch_bounds__(segmented_radix_sort_kernel_launch_bounds<PolicySelector, AltD
   // Constants
   //
 
-  static constexpr segmented_radix_sort_policy policy        = current_policy<PolicySelector>();
-  static constexpr radix_sort_downsweep_policy active_policy = AltDigitBits ? policy.alt_segmented : policy.segmented;
+  static constexpr segmented_radix_sort_policy policy     = current_policy<PolicySelector>();
+  static constexpr RadixSortDownsweepPolicy active_policy = AltDigitBits ? policy.alt_segmented : policy.segmented;
 
   static constexpr int threads_per_block = active_policy.threads_per_block;
   static constexpr int radix_bits        = active_policy.radix_bits;
   static constexpr int radix_digits      = 1 << radix_bits;
 
-  using ActiveUpsweepPolicyT =
-    AgentRadixSortUpsweepPolicy<active_policy.threads_per_block,
-                                active_policy.items_per_thread,
-                                void,
-                                active_policy.load_modifier,
-                                active_policy.radix_bits,
-                                NoScaling<active_policy.threads_per_block, active_policy.items_per_thread>>;
+  using ActiveUpsweepPolicyT = detail::agent_radix_sort_upsweep_policy<
+    active_policy.threads_per_block,
+    active_policy.items_per_thread,
+    void,
+    active_policy.load_modifier,
+    active_policy.radix_bits,
+    NoScaling<active_policy.threads_per_block, active_policy.items_per_thread>>;
 
   using BlockUpsweepT = radix_sort::AgentRadixSortUpsweep<ActiveUpsweepPolicyT, KeyT, SegmentSizeT, DecomposerT>;
 
   using DigitScanT = BlockScan<SegmentSizeT, threads_per_block>;
 
-  using ActiveDownsweepPolicyT = AgentRadixSortDownsweepPolicy<
+  using ActiveDownsweepPolicyT = detail::agent_radix_sort_downsweep_policy<
     active_policy.threads_per_block,
     active_policy.items_per_thread,
     void,

--- a/cub/cub/device/dispatch/kernels/kernel_segmented_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_segmented_sort.cuh
@@ -143,7 +143,7 @@ __launch_bounds__(current_policy<PolicySelector>().large_segment.threads_per_blo
 {
   static constexpr segmented_sort_policy active_policy = current_policy<PolicySelector>();
   static constexpr auto large_policy                   = active_policy.large_segment;
-  using LargeSegmentPolicyT                            = AgentRadixSortDownsweepPolicy<
+  using LargeSegmentPolicyT                            = detail::agent_radix_sort_downsweep_policy<
                                0,
                                0,
                                void,
@@ -478,7 +478,7 @@ __launch_bounds__(current_policy<PolicySelector>().large_segment.threads_per_blo
     const _CCCL_GRID_CONSTANT EndOffsetIteratorT d_end_offsets)
 {
   static constexpr segmented_radix_sort_policy large_policy = current_policy<PolicySelector>().large_segment;
-  using LargeSegmentPolicyT                                 = AgentRadixSortDownsweepPolicy<
+  using LargeSegmentPolicyT                                 = detail::agent_radix_sort_downsweep_policy<
                                     0,
                                     0,
                                     void,

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -28,237 +28,12 @@
 #include <cuda/std/optional>
 
 CUB_NAMESPACE_BEGIN
-namespace detail::radix_sort
-{
-using detail::scan::make_mem_scaled_lookback_scan_policy;
 
-struct radix_sort_histogram_policy
-{
-  int threads_per_block;
-  int items_per_thread;
-
-  //! The number of private histograms partitions in shared memory each histogram is split during counting to reduce the
-  //! contention of atomic operations
-  int num_private_partitions;
-  int radix_bits;
-
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const radix_sort_histogram_policy& lhs, const radix_sort_histogram_policy& rhs)
-  {
-    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
-        && lhs.num_private_partitions == rhs.num_private_partitions && lhs.radix_bits == rhs.radix_bits;
-  }
-
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const radix_sort_histogram_policy& lhs, const radix_sort_histogram_policy& rhs)
-  {
-    return !(lhs == rhs);
-  }
-
-#if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const radix_sort_histogram_policy& p)
-  {
-    return os
-        << "radix_sort_histogram_policy { .threads_per_block = " << p.threads_per_block
-        << ", .items_per_thread = " << p.items_per_thread << ", .num_private_partitions = " << p.num_private_partitions
-        << ", .radix_bits = " << p.radix_bits << " }";
-  }
-#endif // _CCCL_HOSTED()
-};
-
-struct radix_sort_exclusive_sum_policy
-{
-  int threads_per_block;
-  int radix_bits;
-
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const radix_sort_exclusive_sum_policy& lhs, const radix_sort_exclusive_sum_policy& rhs)
-  {
-    return lhs.threads_per_block == rhs.threads_per_block && lhs.radix_bits == rhs.radix_bits;
-  }
-
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const radix_sort_exclusive_sum_policy& lhs, const radix_sort_exclusive_sum_policy& rhs)
-  {
-    return !(lhs == rhs);
-  }
-
-#if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const radix_sort_exclusive_sum_policy& p)
-  {
-    return os << "radix_sort_exclusive_sum_policy { .threads_per_block = " << p.threads_per_block
-              << ", .radix_bits = " << p.radix_bits << " }";
-  }
-#endif // _CCCL_HOSTED()
-};
-
-struct radix_sort_onesweep_policy
-{
-  int threads_per_block;
-  int items_per_thread;
-  RadixSortStoreAlgorithm store_algorithm;
-  RadixRankAlgorithm rank_algorithm;
-  BlockScanAlgorithm scan_algorithm;
-
-  //! The number of private histograms partitions in shared memory each histogram is split during the ranking phase to
-  //! reduce the contention of atomic operations. Ignored if @p rank_algorithm is not one of
-  //! RADIX_RANK_MATCH_EARLY_COUNTS_*
-  int rank_num_private_partitions;
-
-  int radix_bits;
-
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const radix_sort_onesweep_policy& lhs, const radix_sort_onesweep_policy& rhs)
-  {
-    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
-        && lhs.store_algorithm == rhs.store_algorithm && lhs.rank_algorithm == rhs.rank_algorithm
-        && lhs.scan_algorithm == rhs.scan_algorithm
-        && lhs.rank_num_private_partitions == rhs.rank_num_private_partitions && lhs.radix_bits == rhs.radix_bits;
-  }
-
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const radix_sort_onesweep_policy& lhs, const radix_sort_onesweep_policy& rhs)
-  {
-    return !(lhs == rhs);
-  }
-
-#if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const radix_sort_onesweep_policy& p)
-  {
-    return os
-        << "radix_sort_onesweep_policy { .threads_per_block = " << p.threads_per_block
-        << ", .items_per_thread = " << p.items_per_thread << ", .store_algorithm = " << p.store_algorithm
-        << ", .rank_algorithm = " << p.rank_algorithm << ", .scan_algorithm = " << p.scan_algorithm
-        << ", .rank_num_private_partitions = " << p.rank_num_private_partitions << ", .radix_bits = " << p.radix_bits
-        << " }";
-  }
-#endif // _CCCL_HOSTED()
-};
-
-_CCCL_HOST_DEVICE_API constexpr auto make_reg_scaled_radix_sort_onesweep_policy(
-  int nominal_4b_threads_per_block,
-  int nominal_4b_items_per_thread,
-  int compute_t_size,
-  RadixSortStoreAlgorithm store_algorithm,
-  RadixRankAlgorithm rank_algorithm,
-  BlockScanAlgorithm scan_algorithm,
-  int rank_num_private_partitions,
-  int radix_bits) -> radix_sort_onesweep_policy
-{
-  const auto scaled = scale_reg_bound(nominal_4b_threads_per_block, nominal_4b_items_per_thread, compute_t_size);
-  return radix_sort_onesweep_policy{
-    scaled.threads_per_block,
-    scaled.items_per_thread,
-    store_algorithm,
-    rank_algorithm,
-    scan_algorithm,
-    rank_num_private_partitions,
-    radix_bits};
-}
-
-struct radix_sort_downsweep_policy
-{
-  int threads_per_block;
-  int items_per_thread;
-  BlockLoadAlgorithm load_algorithm;
-  CacheLoadModifier load_modifier;
-  RadixRankAlgorithm rank_algorithm;
-  BlockScanAlgorithm scan_algorithm;
-  int radix_bits;
-
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const radix_sort_downsweep_policy& lhs, const radix_sort_downsweep_policy& rhs)
-  {
-    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
-        && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
-        && lhs.rank_algorithm == rhs.rank_algorithm && lhs.scan_algorithm == rhs.scan_algorithm
-        && lhs.radix_bits == rhs.radix_bits;
-  }
-
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const radix_sort_downsweep_policy& lhs, const radix_sort_downsweep_policy& rhs)
-  {
-    return !(lhs == rhs);
-  }
-
-#if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const radix_sort_downsweep_policy& p)
-  {
-    return os
-        << "radix_sort_downsweep_policy { .threads_per_block = " << p.threads_per_block
-        << ", .items_per_thread = " << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm
-        << ", .load_modifier = " << p.load_modifier << ", .rank_algorithm = " << p.rank_algorithm
-        << ", .scan_algorithm = " << p.scan_algorithm << ", .radix_bits = " << p.radix_bits << " }";
-  }
-#endif // _CCCL_HOSTED()
-};
-
-_CCCL_HOST_DEVICE_API constexpr auto make_reg_scaled_radix_sort_downsweep_policy(
-  int nominal_4b_threads_per_block,
-  int nominal_4b_items_per_thread,
-  int compute_t_size,
-  BlockLoadAlgorithm load_algorithm,
-  CacheLoadModifier load_modifier,
-  RadixRankAlgorithm rank_algorithm,
-  BlockScanAlgorithm scan_algorithm,
-  int radix_bits) -> radix_sort_downsweep_policy
-{
-  const auto scaled = scale_reg_bound(nominal_4b_threads_per_block, nominal_4b_items_per_thread, compute_t_size);
-  return radix_sort_downsweep_policy{
-    scaled.threads_per_block,
-    scaled.items_per_thread,
-    load_algorithm,
-    load_modifier,
-    rank_algorithm,
-    scan_algorithm,
-    radix_bits};
-}
-
-struct radix_sort_upsweep_policy
-{
-  int threads_per_block;
-  int items_per_thread;
-  CacheLoadModifier load_modifier;
-  int radix_bits;
-
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const radix_sort_upsweep_policy& lhs, const radix_sort_upsweep_policy& rhs)
-  {
-    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
-        && lhs.load_modifier == rhs.load_modifier && lhs.radix_bits == rhs.radix_bits;
-  }
-
-  _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const radix_sort_upsweep_policy& lhs, const radix_sort_upsweep_policy& rhs)
-  {
-    return !(lhs == rhs);
-  }
-
-#if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const radix_sort_upsweep_policy& p)
-  {
-    return os
-        << "radix_sort_upsweep_policy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
-        << p.items_per_thread << ", .load_modifier = " << p.load_modifier << ", .radix_bits = " << p.radix_bits << " }";
-  }
-#endif // _CCCL_HOSTED()
-};
-
-_CCCL_HOST_DEVICE_API constexpr auto make_reg_scaled_radix_sort_upsweep_policy(
-  int nominal_4b_threads_per_block,
-  int nominal_4b_items_per_thread,
-  int compute_t_size,
-  CacheLoadModifier load_modifier,
-  int radix_bits) -> radix_sort_upsweep_policy
-{
-  const auto scaled = scale_reg_bound(nominal_4b_threads_per_block, nominal_4b_items_per_thread, compute_t_size);
-  return radix_sort_upsweep_policy{scaled.threads_per_block, scaled.items_per_thread, load_modifier, radix_bits};
-}
-
+//! The algorithm to use for radix sorting.
 enum class RadixSortAlgorithm
 {
-  multi_pass,
-  onesweep
+  multi_pass, //!< Multi-pass radix sort (upsweep + scan + downsweep per digit)
+  onesweep //!< Single-pass radix sort using decoupled look-back
 };
 
 #if _CCCL_HOSTED()
@@ -276,20 +51,197 @@ inline ::std::ostream& operator<<(::std::ostream& os, RadixSortAlgorithm algorit
 }
 #endif // _CCCL_HOSTED()
 
-struct radix_sort_policy
+//! The tuning policy for the histogram pass of @ref DeviceRadixSort (used by the onesweep algorithm).
+struct RadixSortHistogramPolicy
 {
-  RadixSortAlgorithm algorithm;
-  radix_sort_histogram_policy histogram;
-  radix_sort_exclusive_sum_policy exclusive_sum;
-  radix_sort_onesweep_policy onesweep;
-  ScanPolicy scan;
-  radix_sort_downsweep_policy downsweep;
-  radix_sort_downsweep_policy alt_downsweep;
-  radix_sort_upsweep_policy upsweep;
-  radix_sort_upsweep_policy alt_upsweep;
-  radix_sort_downsweep_policy single_tile;
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int items_per_thread; //!< Number of items processed per thread
 
-  _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const radix_sort_policy& lhs, const radix_sort_policy& rhs)
+  //! The number of private histogram partitions in shared memory each histogram is split during counting to reduce the
+  //! contention of atomic operations
+  int num_private_partitions;
+  int radix_bits; //!< Number of bits per radix digit
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const RadixSortHistogramPolicy& lhs, const RadixSortHistogramPolicy& rhs) noexcept
+  {
+    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
+        && lhs.num_private_partitions == rhs.num_private_partitions && lhs.radix_bits == rhs.radix_bits;
+  }
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const RadixSortHistogramPolicy& lhs, const RadixSortHistogramPolicy& rhs) noexcept
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const RadixSortHistogramPolicy& p)
+  {
+    return os
+        << "RadixSortHistogramPolicy { .threads_per_block = " << p.threads_per_block
+        << ", .items_per_thread = " << p.items_per_thread << ", .num_private_partitions = " << p.num_private_partitions
+        << ", .radix_bits = " << p.radix_bits << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
+//! The tuning policy for the exclusive sum pass of @ref DeviceRadixSort (used by the onesweep algorithm).
+struct RadixSortExclusiveSumPolicy
+{
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int radix_bits; //!< Number of bits per radix digit
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const RadixSortExclusiveSumPolicy& lhs, const RadixSortExclusiveSumPolicy& rhs) noexcept
+  {
+    return lhs.threads_per_block == rhs.threads_per_block && lhs.radix_bits == rhs.radix_bits;
+  }
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const RadixSortExclusiveSumPolicy& lhs, const RadixSortExclusiveSumPolicy& rhs) noexcept
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const RadixSortExclusiveSumPolicy& p)
+  {
+    return os << "RadixSortExclusiveSumPolicy { .threads_per_block = " << p.threads_per_block
+              << ", .radix_bits = " << p.radix_bits << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
+//! The tuning policy for the onesweep pass of @ref DeviceRadixSort.
+struct RadixSortOnesweepPolicy
+{
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int items_per_thread; //!< Number of items processed per thread
+  RadixSortStoreAlgorithm store_algorithm; //!< The @ref RadixSortStoreAlgorithm used for writing results
+  RadixRankAlgorithm rank_algorithm; //!< The @ref RadixRankAlgorithm used for ranking keys
+  BlockScanAlgorithm scan_algorithm; //!< The @ref BlockScanAlgorithm used for scanning within a thread block
+
+  //! The number of private histogram partitions in shared memory each histogram is split during the ranking phase to
+  //! reduce the contention of atomic operations. Ignored if @p rank_algorithm is not one of
+  //! RADIX_RANK_MATCH_EARLY_COUNTS_*
+  int rank_num_private_partitions;
+
+  int radix_bits; //!< Number of bits per radix digit
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const RadixSortOnesweepPolicy& lhs, const RadixSortOnesweepPolicy& rhs) noexcept
+  {
+    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
+        && lhs.store_algorithm == rhs.store_algorithm && lhs.rank_algorithm == rhs.rank_algorithm
+        && lhs.scan_algorithm == rhs.scan_algorithm
+        && lhs.rank_num_private_partitions == rhs.rank_num_private_partitions && lhs.radix_bits == rhs.radix_bits;
+  }
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const RadixSortOnesweepPolicy& lhs, const RadixSortOnesweepPolicy& rhs) noexcept
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const RadixSortOnesweepPolicy& p)
+  {
+    return os
+        << "RadixSortOnesweepPolicy { .threads_per_block = " << p.threads_per_block
+        << ", .items_per_thread = " << p.items_per_thread << ", .store_algorithm = " << p.store_algorithm
+        << ", .rank_algorithm = " << p.rank_algorithm << ", .scan_algorithm = " << p.scan_algorithm
+        << ", .rank_num_private_partitions = " << p.rank_num_private_partitions << ", .radix_bits = " << p.radix_bits
+        << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
+//! The tuning policy for the downsweep pass (and single-tile path) of @ref DeviceRadixSort.
+struct RadixSortDownsweepPolicy
+{
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int items_per_thread; //!< Number of items processed per thread
+  BlockLoadAlgorithm load_algorithm; //!< The @ref BlockLoadAlgorithm used for loading items from global memory
+  CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
+  RadixRankAlgorithm rank_algorithm; //!< The @ref RadixRankAlgorithm used for ranking keys
+  BlockScanAlgorithm scan_algorithm; //!< The @ref BlockScanAlgorithm used for scanning within a thread block
+  int radix_bits; //!< Number of bits per radix digit
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const RadixSortDownsweepPolicy& lhs, const RadixSortDownsweepPolicy& rhs) noexcept
+  {
+    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
+        && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
+        && lhs.rank_algorithm == rhs.rank_algorithm && lhs.scan_algorithm == rhs.scan_algorithm
+        && lhs.radix_bits == rhs.radix_bits;
+  }
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const RadixSortDownsweepPolicy& lhs, const RadixSortDownsweepPolicy& rhs) noexcept
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const RadixSortDownsweepPolicy& p)
+  {
+    return os
+        << "RadixSortDownsweepPolicy { .threads_per_block = " << p.threads_per_block
+        << ", .items_per_thread = " << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm
+        << ", .load_modifier = " << p.load_modifier << ", .rank_algorithm = " << p.rank_algorithm
+        << ", .scan_algorithm = " << p.scan_algorithm << ", .radix_bits = " << p.radix_bits << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
+//! The tuning policy for the upsweep pass of @ref DeviceRadixSort (used by the multi-pass algorithm).
+struct RadixSortUpsweepPolicy
+{
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int items_per_thread; //!< Number of items processed per thread
+  CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
+  int radix_bits; //!< Number of bits per radix digit
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const RadixSortUpsweepPolicy& lhs, const RadixSortUpsweepPolicy& rhs) noexcept
+  {
+    return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
+        && lhs.load_modifier == rhs.load_modifier && lhs.radix_bits == rhs.radix_bits;
+  }
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const RadixSortUpsweepPolicy& lhs, const RadixSortUpsweepPolicy& rhs) noexcept
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const RadixSortUpsweepPolicy& p)
+  {
+    return os
+        << "RadixSortUpsweepPolicy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
+        << p.items_per_thread << ", .load_modifier = " << p.load_modifier << ", .radix_bits = " << p.radix_bits << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
+//! The tuning policy for all algorithms in @ref DeviceRadixSort.
+struct RadixSortPolicy
+{
+  RadixSortAlgorithm algorithm; //!< The radix sort algorithm to use
+  RadixSortHistogramPolicy histogram; //!< Histogram pass policy (onesweep only)
+  RadixSortExclusiveSumPolicy exclusive_sum; //!< Exclusive sum pass policy (onesweep only)
+  RadixSortOnesweepPolicy onesweep; //!< Onesweep pass policy
+  ScanPolicy scan; //!< Scan policy (multi-pass only)
+  RadixSortDownsweepPolicy downsweep; //!< Downsweep pass policy (multi-pass only)
+  RadixSortDownsweepPolicy alt_downsweep; //!< Alternate downsweep pass policy with fewer radix bits
+  RadixSortUpsweepPolicy upsweep; //!< Upsweep pass policy (multi-pass only)
+  RadixSortUpsweepPolicy alt_upsweep; //!< Alternate upsweep pass policy with fewer radix bits
+  RadixSortDownsweepPolicy single_tile; //!< Single-tile sort policy for small inputs
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const RadixSortPolicy& lhs, const RadixSortPolicy& rhs) noexcept
   {
     return lhs.algorithm == rhs.algorithm && lhs.histogram == rhs.histogram && lhs.exclusive_sum == rhs.exclusive_sum
         && lhs.onesweep == rhs.onesweep && lhs.scan == rhs.scan && lhs.downsweep == rhs.downsweep
@@ -297,22 +249,80 @@ struct radix_sort_policy
         && lhs.single_tile == rhs.single_tile;
   }
 
-  _CCCL_HOST_DEVICE_API constexpr friend bool operator!=(const radix_sort_policy& lhs, const radix_sort_policy& rhs)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const RadixSortPolicy& lhs, const RadixSortPolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const radix_sort_policy& p)
+  friend ::std::ostream& operator<<(::std::ostream& os, const RadixSortPolicy& p)
   {
     return os
-        << "radix_sort_policy { .algorithm = " << p.algorithm << ", .histogram = " << p.histogram
+        << "RadixSortPolicy { .algorithm = " << p.algorithm << ", .histogram = " << p.histogram
         << ", .exclusive_sum = " << p.exclusive_sum << ", .onesweep = " << p.onesweep << ", .scan = " << p.scan
         << ", .downsweep = " << p.downsweep << ", .alt_downsweep = " << p.alt_downsweep << ", .upsweep = " << p.upsweep
         << ", .alt_upsweep = " << p.alt_upsweep << ", .single_tile = " << p.single_tile << " }";
   }
 #endif // _CCCL_HOSTED()
 };
+
+namespace detail::radix_sort
+{
+using detail::scan::make_mem_scaled_lookback_scan_policy;
+
+_CCCL_HOST_DEVICE_API constexpr auto make_reg_scaled_radix_sort_onesweep_policy(
+  int nominal_4b_threads_per_block,
+  int nominal_4b_items_per_thread,
+  int compute_t_size,
+  RadixSortStoreAlgorithm store_algorithm,
+  RadixRankAlgorithm rank_algorithm,
+  BlockScanAlgorithm scan_algorithm,
+  int rank_num_private_partitions,
+  int radix_bits) -> RadixSortOnesweepPolicy
+{
+  const auto scaled = scale_reg_bound(nominal_4b_threads_per_block, nominal_4b_items_per_thread, compute_t_size);
+  return RadixSortOnesweepPolicy{
+    scaled.threads_per_block,
+    scaled.items_per_thread,
+    store_algorithm,
+    rank_algorithm,
+    scan_algorithm,
+    rank_num_private_partitions,
+    radix_bits};
+}
+
+_CCCL_HOST_DEVICE_API constexpr auto make_reg_scaled_radix_sort_downsweep_policy(
+  int nominal_4b_threads_per_block,
+  int nominal_4b_items_per_thread,
+  int compute_t_size,
+  BlockLoadAlgorithm load_algorithm,
+  CacheLoadModifier load_modifier,
+  RadixRankAlgorithm rank_algorithm,
+  BlockScanAlgorithm scan_algorithm,
+  int radix_bits) -> RadixSortDownsweepPolicy
+{
+  const auto scaled = scale_reg_bound(nominal_4b_threads_per_block, nominal_4b_items_per_thread, compute_t_size);
+  return RadixSortDownsweepPolicy{
+    scaled.threads_per_block,
+    scaled.items_per_thread,
+    load_algorithm,
+    load_modifier,
+    rank_algorithm,
+    scan_algorithm,
+    radix_bits};
+}
+
+_CCCL_HOST_DEVICE_API constexpr auto make_reg_scaled_radix_sort_upsweep_policy(
+  int nominal_4b_threads_per_block,
+  int nominal_4b_items_per_thread,
+  int compute_t_size,
+  CacheLoadModifier load_modifier,
+  int radix_bits) -> RadixSortUpsweepPolicy
+{
+  const auto scaled = scale_reg_bound(nominal_4b_threads_per_block, nominal_4b_items_per_thread, compute_t_size);
+  return RadixSortUpsweepPolicy{scaled.threads_per_block, scaled.items_per_thread, load_modifier, radix_bits};
+}
 
 // TODO(bgruber): remove for CCCL 4.0 when we drop the public radix sort dispatcher
 // sm90 default
@@ -880,7 +890,7 @@ _CCCL_HOST_DEVICE RadixSortPolicyWrapper<PolicyT> MakeRadixSortPolicyWrapper(Pol
 template <typename DownsweepPolicy>
 _CCCL_HOST_DEVICE_API constexpr auto convert_downsweep_policy(DownsweepPolicy)
 {
-  return radix_sort_downsweep_policy{
+  return RadixSortDownsweepPolicy{
     DownsweepPolicy::BLOCK_THREADS,
     DownsweepPolicy::ITEMS_PER_THREAD,
     DownsweepPolicy::LOAD_ALGORITHM,
@@ -892,19 +902,19 @@ _CCCL_HOST_DEVICE_API constexpr auto convert_downsweep_policy(DownsweepPolicy)
 
 // TODO(bgruber): remove in CCCL 4.0 when we drop the radix sort dispatcher after publishing the tuning API
 template <typename LegacyActivePolicy>
-_CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> radix_sort_policy
+_CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> RadixSortPolicy
 {
   using active_policy = LegacyActivePolicy;
 
   using hist_pol       = typename active_policy::HistogramPolicy;
-  const auto histogram = radix_sort_histogram_policy{
+  const auto histogram = RadixSortHistogramPolicy{
     hist_pol::BLOCK_THREADS, hist_pol::ITEMS_PER_THREAD, hist_pol::NUM_PARTS, hist_pol::RADIX_BITS};
 
   using exc_sum_pol        = typename active_policy::ExclusiveSumPolicy;
-  const auto exclusive_sum = radix_sort_exclusive_sum_policy{exc_sum_pol::BLOCK_THREADS, exc_sum_pol::RADIX_BITS};
+  const auto exclusive_sum = RadixSortExclusiveSumPolicy{exc_sum_pol::BLOCK_THREADS, exc_sum_pol::RADIX_BITS};
 
   using one_pol       = typename active_policy::OnesweepPolicy;
-  const auto onesweep = radix_sort_onesweep_policy{
+  const auto onesweep = RadixSortOnesweepPolicy{
     one_pol::BLOCK_THREADS,
     one_pol::ITEMS_PER_THREAD,
     one_pol::STORE_ALGORITHM,
@@ -929,17 +939,17 @@ _CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> radix_sort_policy
   const auto downsweep     = radix_sort::convert_downsweep_policy(typename active_policy::DownsweepPolicy{});
   const auto alt_downsweep = radix_sort::convert_downsweep_policy(typename active_policy::AltDownsweepPolicy{});
 
-  using up_pol       = typename active_policy::UpsweepPolicy;
-  const auto upsweep = radix_sort_upsweep_policy{
-    up_pol::BLOCK_THREADS, up_pol::ITEMS_PER_THREAD, up_pol::LOAD_MODIFIER, up_pol::RADIX_BITS};
+  using up_pol = typename active_policy::UpsweepPolicy;
+  const auto upsweep =
+    RadixSortUpsweepPolicy{up_pol::BLOCK_THREADS, up_pol::ITEMS_PER_THREAD, up_pol::LOAD_MODIFIER, up_pol::RADIX_BITS};
 
   using alt_up_pol       = typename active_policy::AltUpsweepPolicy;
-  const auto alt_upsweep = radix_sort_upsweep_policy{
+  const auto alt_upsweep = RadixSortUpsweepPolicy{
     alt_up_pol::BLOCK_THREADS, alt_up_pol::ITEMS_PER_THREAD, alt_up_pol::LOAD_MODIFIER, alt_up_pol::RADIX_BITS};
 
   const auto single_tile = radix_sort::convert_downsweep_policy(typename active_policy::SingleTilePolicy{});
 
-  return radix_sort_policy{
+  return RadixSortPolicy{
     active_policy::ONESWEEP ? RadixSortAlgorithm::onesweep : RadixSortAlgorithm::multi_pass,
     histogram,
     exclusive_sum,
@@ -955,7 +965,7 @@ _CCCL_HOST_DEVICE_API constexpr auto convert_policy() -> radix_sort_policy
 // TODO(bgruber): remove in CCCL 4.0 when we drop the radix sort dispatcher after publishing the tuning API
 template <typename LegacyActivePolicy>
 _CCCL_HOST_DEVICE_API _CCCL_FORCEINLINE constexpr auto convert_policy(RadixSortPolicyWrapper<LegacyActivePolicy> policy)
-  -> radix_sort_policy
+  -> RadixSortPolicy
 {
   return convert_policy<LegacyActivePolicy>();
 }
@@ -964,7 +974,7 @@ _CCCL_HOST_DEVICE_API _CCCL_FORCEINLINE constexpr auto convert_policy(RadixSortP
 template <typename PolicyHub>
 struct policy_selector_from_hub
 {
-  _CCCL_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const -> radix_sort_policy
+  _CCCL_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const -> RadixSortPolicy
   {
     return convert_policy<typename PolicyHub::MaxPolicy::ActivePolicy>();
   }
@@ -1010,13 +1020,13 @@ struct policy_hub
     static constexpr int ONESWEEP_RADIX_BITS    = 8;
 
     // Histogram policy
-    using HistogramPolicy = AgentRadixSortHistogramPolicy<256, 8, 1, KeyT, ONESWEEP_RADIX_BITS>;
+    using HistogramPolicy = detail::agent_radix_sort_histogram_policy<256, 8, 1, KeyT, ONESWEEP_RADIX_BITS>;
 
     // Exclusive sum policy
-    using ExclusiveSumPolicy = AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS>;
+    using ExclusiveSumPolicy = detail::agent_radix_sort_exclusive_sum_policy<256, ONESWEEP_RADIX_BITS>;
 
     // Onesweep policy
-    using OnesweepPolicy = AgentRadixSortOnesweepPolicy<
+    using OnesweepPolicy = detail::agent_radix_sort_onesweep_policy<
       256,
       21,
       DominantT,
@@ -1037,7 +1047,7 @@ struct policy_hub
                         BLOCK_SCAN_RAKING_MEMOIZE>;
 
     // Downsweep policies
-    using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
+    using DownsweepPolicy = detail::agent_radix_sort_downsweep_policy<
       160,
       39,
       DominantT,
@@ -1046,7 +1056,7 @@ struct policy_hub
       RADIX_RANK_BASIC,
       BLOCK_SCAN_WARP_SCANS,
       PRIMARY_RADIX_BITS>;
-    using AltDownsweepPolicy = AgentRadixSortDownsweepPolicy<
+    using AltDownsweepPolicy = detail::agent_radix_sort_downsweep_policy<
       256,
       16,
       DominantT,
@@ -1061,7 +1071,7 @@ struct policy_hub
     using AltUpsweepPolicy = AltDownsweepPolicy;
 
     // Single-tile policy
-    using SingleTilePolicy = AgentRadixSortDownsweepPolicy<
+    using SingleTilePolicy = detail::agent_radix_sort_downsweep_policy<
       256,
       19,
       DominantT,
@@ -1072,7 +1082,7 @@ struct policy_hub
       SINGLE_TILE_RADIX_BITS>;
 
     // Segmented policies
-    using SegmentedPolicy = AgentRadixSortDownsweepPolicy<
+    using SegmentedPolicy = detail::agent_radix_sort_downsweep_policy<
       192,
       31,
       DominantT,
@@ -1081,7 +1091,7 @@ struct policy_hub
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
       SEGMENTED_RADIX_BITS>;
-    using AltSegmentedPolicy = AgentRadixSortDownsweepPolicy<
+    using AltSegmentedPolicy = detail::agent_radix_sort_downsweep_policy<
       256,
       11,
       DominantT,
@@ -1103,13 +1113,13 @@ struct policy_hub
     static constexpr bool OFFSET_64BIT       = sizeof(OffsetT) == 8;
 
     // Histogram policy
-    using HistogramPolicy = AgentRadixSortHistogramPolicy<256, 8, 8, KeyT, ONESWEEP_RADIX_BITS>;
+    using HistogramPolicy = detail::agent_radix_sort_histogram_policy<256, 8, 8, KeyT, ONESWEEP_RADIX_BITS>;
 
     // Exclusive sum policy
-    using ExclusiveSumPolicy = AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS>;
+    using ExclusiveSumPolicy = detail::agent_radix_sort_exclusive_sum_policy<256, ONESWEEP_RADIX_BITS>;
 
     // Onesweep policy
-    using OnesweepPolicy = AgentRadixSortOnesweepPolicy<
+    using OnesweepPolicy = detail::agent_radix_sort_onesweep_policy<
       256,
       OFFSET_64BIT ? 29 : 30,
       DominantT,
@@ -1130,7 +1140,7 @@ struct policy_hub
                         BLOCK_SCAN_RAKING_MEMOIZE>;
 
     // Downsweep policies
-    using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
+    using DownsweepPolicy = detail::agent_radix_sort_downsweep_policy<
       256,
       25,
       DominantT,
@@ -1139,7 +1149,7 @@ struct policy_hub
       RADIX_RANK_MATCH,
       BLOCK_SCAN_WARP_SCANS,
       PRIMARY_RADIX_BITS>;
-    using AltDownsweepPolicy = AgentRadixSortDownsweepPolicy<
+    using AltDownsweepPolicy = detail::agent_radix_sort_downsweep_policy<
       192,
       OFFSET_64BIT ? 32 : 39,
       DominantT,
@@ -1154,7 +1164,7 @@ struct policy_hub
     using AltUpsweepPolicy = AltDownsweepPolicy;
 
     // Single-tile policy
-    using SingleTilePolicy = AgentRadixSortDownsweepPolicy<
+    using SingleTilePolicy = detail::agent_radix_sort_downsweep_policy<
       256,
       19,
       DominantT,
@@ -1165,7 +1175,7 @@ struct policy_hub
       SINGLE_TILE_RADIX_BITS>;
 
     // Segmented policies
-    using SegmentedPolicy = AgentRadixSortDownsweepPolicy<
+    using SegmentedPolicy = detail::agent_radix_sort_downsweep_policy<
       192,
       39,
       DominantT,
@@ -1174,7 +1184,7 @@ struct policy_hub
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
       SEGMENTED_RADIX_BITS>;
-    using AltSegmentedPolicy = AgentRadixSortDownsweepPolicy<
+    using AltSegmentedPolicy = detail::agent_radix_sort_downsweep_policy<
       384,
       11,
       DominantT,
@@ -1195,13 +1205,13 @@ struct policy_hub
     static constexpr int ONESWEEP_RADIX_BITS    = 8;
 
     // Histogram policy
-    using HistogramPolicy = AgentRadixSortHistogramPolicy<256, 8, 8, KeyT, ONESWEEP_RADIX_BITS>;
+    using HistogramPolicy = detail::agent_radix_sort_histogram_policy<256, 8, 8, KeyT, ONESWEEP_RADIX_BITS>;
 
     // Exclusive sum policy
-    using ExclusiveSumPolicy = AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS>;
+    using ExclusiveSumPolicy = detail::agent_radix_sort_exclusive_sum_policy<256, ONESWEEP_RADIX_BITS>;
 
     // Onesweep policy
-    using OnesweepPolicy = AgentRadixSortOnesweepPolicy<
+    using OnesweepPolicy = detail::agent_radix_sort_onesweep_policy<
       256,
       30,
       DominantT,
@@ -1222,7 +1232,7 @@ struct policy_hub
                         BLOCK_SCAN_RAKING_MEMOIZE>;
 
     // Downsweep policies
-    using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
+    using DownsweepPolicy = detail::agent_radix_sort_downsweep_policy<
       384,
       31,
       DominantT,
@@ -1231,7 +1241,7 @@ struct policy_hub
       RADIX_RANK_MATCH,
       BLOCK_SCAN_RAKING_MEMOIZE,
       PRIMARY_RADIX_BITS>;
-    using AltDownsweepPolicy = AgentRadixSortDownsweepPolicy<
+    using AltDownsweepPolicy = detail::agent_radix_sort_downsweep_policy<
       256,
       35,
       DominantT,
@@ -1242,11 +1252,12 @@ struct policy_hub
       PRIMARY_RADIX_BITS - 1>;
 
     // Upsweep policies
-    using UpsweepPolicy    = AgentRadixSortUpsweepPolicy<128, 16, DominantT, LOAD_LDG, PRIMARY_RADIX_BITS>;
-    using AltUpsweepPolicy = AgentRadixSortUpsweepPolicy<128, 16, DominantT, LOAD_LDG, PRIMARY_RADIX_BITS - 1>;
+    using UpsweepPolicy = detail::agent_radix_sort_upsweep_policy<128, 16, DominantT, LOAD_LDG, PRIMARY_RADIX_BITS>;
+    using AltUpsweepPolicy =
+      detail::agent_radix_sort_upsweep_policy<128, 16, DominantT, LOAD_LDG, PRIMARY_RADIX_BITS - 1>;
 
     // Single-tile policy
-    using SingleTilePolicy = AgentRadixSortDownsweepPolicy<
+    using SingleTilePolicy = detail::agent_radix_sort_downsweep_policy<
       256,
       19,
       DominantT,
@@ -1257,7 +1268,7 @@ struct policy_hub
       SINGLE_TILE_RADIX_BITS>;
 
     // Segmented policies
-    using SegmentedPolicy = AgentRadixSortDownsweepPolicy<
+    using SegmentedPolicy = detail::agent_radix_sort_downsweep_policy<
       192,
       39,
       DominantT,
@@ -1266,7 +1277,7 @@ struct policy_hub
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
       SEGMENTED_RADIX_BITS>;
-    using AltSegmentedPolicy = AgentRadixSortDownsweepPolicy<
+    using AltSegmentedPolicy = detail::agent_radix_sort_downsweep_policy<
       384,
       11,
       DominantT,
@@ -1286,13 +1297,13 @@ struct policy_hub
     static constexpr int ONESWEEP_RADIX_BITS = 8;
 
     // Histogram policy
-    using HistogramPolicy = AgentRadixSortHistogramPolicy<256, 8, 8, KeyT, ONESWEEP_RADIX_BITS>;
+    using HistogramPolicy = detail::agent_radix_sort_histogram_policy<256, 8, 8, KeyT, ONESWEEP_RADIX_BITS>;
 
     // Exclusive sum policy
-    using ExclusiveSumPolicy = AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS>;
+    using ExclusiveSumPolicy = detail::agent_radix_sort_exclusive_sum_policy<256, ONESWEEP_RADIX_BITS>;
 
     // Onesweep policy
-    using OnesweepPolicy = AgentRadixSortOnesweepPolicy<
+    using OnesweepPolicy = detail::agent_radix_sort_onesweep_policy<
       256,
       30,
       DominantT,
@@ -1313,7 +1324,7 @@ struct policy_hub
                         BLOCK_SCAN_RAKING_MEMOIZE>;
 
     // Downsweep policies
-    using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
+    using DownsweepPolicy = detail::agent_radix_sort_downsweep_policy<
       256,
       16,
       DominantT,
@@ -1322,7 +1333,7 @@ struct policy_hub
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_RAKING_MEMOIZE,
       PRIMARY_RADIX_BITS>;
-    using AltDownsweepPolicy = AgentRadixSortDownsweepPolicy<
+    using AltDownsweepPolicy = detail::agent_radix_sort_downsweep_policy<
       256,
       16,
       DominantT,
@@ -1337,7 +1348,7 @@ struct policy_hub
     using AltUpsweepPolicy = AltDownsweepPolicy;
 
     // Single-tile policy
-    using SingleTilePolicy = AgentRadixSortDownsweepPolicy<
+    using SingleTilePolicy = detail::agent_radix_sort_downsweep_policy<
       256,
       19,
       DominantT,
@@ -1363,13 +1374,13 @@ struct policy_hub
     static constexpr bool OFFSET_64BIT       = sizeof(OffsetT) == 8;
 
     // Histogram policy
-    using HistogramPolicy = AgentRadixSortHistogramPolicy<256, 8, 8, KeyT, ONESWEEP_RADIX_BITS>;
+    using HistogramPolicy = detail::agent_radix_sort_histogram_policy<256, 8, 8, KeyT, ONESWEEP_RADIX_BITS>;
 
     // Exclusive sum policy
-    using ExclusiveSumPolicy = AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS>;
+    using ExclusiveSumPolicy = detail::agent_radix_sort_exclusive_sum_policy<256, ONESWEEP_RADIX_BITS>;
 
     // Onesweep policy
-    using OnesweepPolicy = AgentRadixSortOnesweepPolicy<
+    using OnesweepPolicy = detail::agent_radix_sort_onesweep_policy<
       256,
       sizeof(KeyT) == 4 && sizeof(ValueT) == 4 ? 46 : 23,
       DominantT,
@@ -1390,7 +1401,7 @@ struct policy_hub
                         BLOCK_SCAN_RAKING_MEMOIZE>;
 
     // Downsweep policies
-    using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
+    using DownsweepPolicy = detail::agent_radix_sort_downsweep_policy<
       512,
       23,
       DominantT,
@@ -1399,7 +1410,7 @@ struct policy_hub
       RADIX_RANK_MATCH,
       BLOCK_SCAN_WARP_SCANS,
       PRIMARY_RADIX_BITS>;
-    using AltDownsweepPolicy = AgentRadixSortDownsweepPolicy<
+    using AltDownsweepPolicy = detail::agent_radix_sort_downsweep_policy<
       (sizeof(KeyT) > 1) ? 256 : 128,
       OFFSET_64BIT ? 46 : 47,
       DominantT,
@@ -1410,12 +1421,12 @@ struct policy_hub
       PRIMARY_RADIX_BITS - 1>;
 
     // Upsweep policies
-    using UpsweepPolicy = AgentRadixSortUpsweepPolicy<256, 23, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS>;
-    using AltUpsweepPolicy =
-      AgentRadixSortUpsweepPolicy<256, OFFSET_64BIT ? 46 : 47, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS - 1>;
+    using UpsweepPolicy = detail::agent_radix_sort_upsweep_policy<256, 23, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS>;
+    using AltUpsweepPolicy = detail::
+      agent_radix_sort_upsweep_policy<256, OFFSET_64BIT ? 46 : 47, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS - 1>;
 
     // Single-tile policy
-    using SingleTilePolicy = AgentRadixSortDownsweepPolicy<
+    using SingleTilePolicy = detail::agent_radix_sort_downsweep_policy<
       256,
       19,
       DominantT,
@@ -1426,7 +1437,7 @@ struct policy_hub
       SINGLE_TILE_RADIX_BITS>;
 
     // Segmented policies
-    using SegmentedPolicy = AgentRadixSortDownsweepPolicy<
+    using SegmentedPolicy = detail::agent_radix_sort_downsweep_policy<
       192,
       39,
       DominantT,
@@ -1435,7 +1446,7 @@ struct policy_hub
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
       SEGMENTED_RADIX_BITS>;
-    using AltSegmentedPolicy = AgentRadixSortDownsweepPolicy<
+    using AltSegmentedPolicy = detail::agent_radix_sort_downsweep_policy<
       384,
       11,
       DominantT,
@@ -1457,13 +1468,13 @@ struct policy_hub
     static constexpr bool OFFSET_64BIT          = sizeof(OffsetT) == 8;
 
     // Histogram policy
-    using HistogramPolicy = AgentRadixSortHistogramPolicy<128, 16, 1, KeyT, ONESWEEP_RADIX_BITS>;
+    using HistogramPolicy = detail::agent_radix_sort_histogram_policy<128, 16, 1, KeyT, ONESWEEP_RADIX_BITS>;
 
     // Exclusive sum policy
-    using ExclusiveSumPolicy = AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS>;
+    using ExclusiveSumPolicy = detail::agent_radix_sort_exclusive_sum_policy<256, ONESWEEP_RADIX_BITS>;
 
     // Onesweep policy
-    using OnesweepPolicy = AgentRadixSortOnesweepPolicy<
+    using OnesweepPolicy = detail::agent_radix_sort_onesweep_policy<
       384,
       OFFSET_64BIT && sizeof(KeyT) == 4 && !KEYS_ONLY ? 17 : 21,
       DominantT,
@@ -1484,7 +1495,7 @@ struct policy_hub
                         BLOCK_SCAN_RAKING_MEMOIZE>;
 
     // Downsweep policies
-    using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
+    using DownsweepPolicy = detail::agent_radix_sort_downsweep_policy<
       512,
       23,
       DominantT,
@@ -1493,7 +1504,7 @@ struct policy_hub
       RADIX_RANK_MATCH,
       BLOCK_SCAN_WARP_SCANS,
       PRIMARY_RADIX_BITS>;
-    using AltDownsweepPolicy = AgentRadixSortDownsweepPolicy<
+    using AltDownsweepPolicy = detail::agent_radix_sort_downsweep_policy<
       (sizeof(KeyT) > 1) ? 256 : 128,
       47,
       DominantT,
@@ -1504,11 +1515,12 @@ struct policy_hub
       PRIMARY_RADIX_BITS - 1>;
 
     // Upsweep policies
-    using UpsweepPolicy    = AgentRadixSortUpsweepPolicy<256, 23, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS>;
-    using AltUpsweepPolicy = AgentRadixSortUpsweepPolicy<256, 47, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS - 1>;
+    using UpsweepPolicy = detail::agent_radix_sort_upsweep_policy<256, 23, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS>;
+    using AltUpsweepPolicy =
+      detail::agent_radix_sort_upsweep_policy<256, 47, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS - 1>;
 
     // Single-tile policy
-    using SingleTilePolicy = AgentRadixSortDownsweepPolicy<
+    using SingleTilePolicy = detail::agent_radix_sort_downsweep_policy<
       256,
       19,
       DominantT,
@@ -1519,7 +1531,7 @@ struct policy_hub
       SINGLE_TILE_RADIX_BITS>;
 
     // Segmented policies
-    using SegmentedPolicy = AgentRadixSortDownsweepPolicy<
+    using SegmentedPolicy = detail::agent_radix_sort_downsweep_policy<
       192,
       39,
       DominantT,
@@ -1528,7 +1540,7 @@ struct policy_hub
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
       SEGMENTED_RADIX_BITS>;
-    using AltSegmentedPolicy = AgentRadixSortDownsweepPolicy<
+    using AltSegmentedPolicy = detail::agent_radix_sort_downsweep_policy<
       384,
       11,
       DominantT,
@@ -1545,8 +1557,8 @@ struct policy_hub
     static constexpr bool ONESWEEP           = true;
     static constexpr int ONESWEEP_RADIX_BITS = 8;
 
-    using HistogramPolicy    = AgentRadixSortHistogramPolicy<128, 16, 1, KeyT, ONESWEEP_RADIX_BITS>;
-    using ExclusiveSumPolicy = AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS>;
+    using HistogramPolicy    = detail::agent_radix_sort_histogram_policy<128, 16, 1, KeyT, ONESWEEP_RADIX_BITS>;
+    using ExclusiveSumPolicy = detail::agent_radix_sort_exclusive_sum_policy<256, ONESWEEP_RADIX_BITS>;
 
   private:
     static constexpr int PRIMARY_RADIX_BITS     = (sizeof(KeyT) > 1) ? 7 : 5;
@@ -1555,7 +1567,7 @@ struct policy_hub
     static constexpr int OFFSET_64BIT           = sizeof(OffsetT) == 8 ? 1 : 0;
     static constexpr int FLOAT_KEYS             = ::cuda::std::is_same_v<KeyT, float> ? 1 : 0;
 
-    using OnesweepPolicyKey32 = AgentRadixSortOnesweepPolicy<
+    using OnesweepPolicyKey32 = detail::agent_radix_sort_onesweep_policy<
       384,
       KEYS_ONLY ? 20 - OFFSET_64BIT - FLOAT_KEYS
                 : (sizeof(ValueT) < 8 ? (OFFSET_64BIT ? 17 : 23) : (OFFSET_64BIT ? 29 : 30)),
@@ -1566,7 +1578,7 @@ struct policy_hub
       RADIX_SORT_STORE_DIRECT,
       ONESWEEP_RADIX_BITS>;
 
-    using OnesweepPolicyKey64 = AgentRadixSortOnesweepPolicy<
+    using OnesweepPolicyKey64 = detail::agent_radix_sort_onesweep_policy<
       384,
       sizeof(ValueT) < 8 ? 30 : 24,
       DominantT,
@@ -1578,7 +1590,7 @@ struct policy_hub
 
     using OnesweepLargeKeyPolicy = ::cuda::std::_If<sizeof(KeyT) == 4, OnesweepPolicyKey32, OnesweepPolicyKey64>;
 
-    using OnesweepSmallKeyPolicy = AgentRadixSortOnesweepPolicy<
+    using OnesweepSmallKeyPolicy = detail::agent_radix_sort_onesweep_policy<
       OnesweepSmallKeyPolicySizes::threads,
       OnesweepSmallKeyPolicySizes::items,
       DominantT,
@@ -1605,7 +1617,7 @@ struct policy_hub
                         BLOCK_STORE_WARP_TRANSPOSE,
                         BLOCK_SCAN_RAKING_MEMOIZE>;
 
-    using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
+    using DownsweepPolicy = detail::agent_radix_sort_downsweep_policy<
       512,
       23,
       DominantT,
@@ -1615,7 +1627,7 @@ struct policy_hub
       BLOCK_SCAN_WARP_SCANS,
       PRIMARY_RADIX_BITS>;
 
-    using AltDownsweepPolicy = AgentRadixSortDownsweepPolicy<
+    using AltDownsweepPolicy = detail::agent_radix_sort_downsweep_policy<
       (sizeof(KeyT) > 1) ? 256 : 128,
       47,
       DominantT,
@@ -1625,10 +1637,11 @@ struct policy_hub
       BLOCK_SCAN_WARP_SCANS,
       PRIMARY_RADIX_BITS - 1>;
 
-    using UpsweepPolicy    = AgentRadixSortUpsweepPolicy<256, 23, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS>;
-    using AltUpsweepPolicy = AgentRadixSortUpsweepPolicy<256, 47, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS - 1>;
+    using UpsweepPolicy = detail::agent_radix_sort_upsweep_policy<256, 23, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS>;
+    using AltUpsweepPolicy =
+      detail::agent_radix_sort_upsweep_policy<256, 47, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS - 1>;
 
-    using SingleTilePolicy = AgentRadixSortDownsweepPolicy<
+    using SingleTilePolicy = detail::agent_radix_sort_downsweep_policy<
       256,
       19,
       DominantT,
@@ -1638,7 +1651,7 @@ struct policy_hub
       BLOCK_SCAN_WARP_SCANS,
       SINGLE_TILE_RADIX_BITS>;
 
-    using SegmentedPolicy = AgentRadixSortDownsweepPolicy<
+    using SegmentedPolicy = detail::agent_radix_sort_downsweep_policy<
       192,
       39,
       DominantT,
@@ -1648,7 +1661,7 @@ struct policy_hub
       BLOCK_SCAN_WARP_SCANS,
       SEGMENTED_RADIX_BITS>;
 
-    using AltSegmentedPolicy = AgentRadixSortDownsweepPolicy<
+    using AltSegmentedPolicy = detail::agent_radix_sort_downsweep_policy<
       384,
       11,
       DominantT,
@@ -1680,7 +1693,7 @@ struct policy_hub
 
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>
-concept radix_sort_policy_selector = detail::policy_selector<T, radix_sort_policy>;
+concept radix_sort_policy_selector = detail::policy_selector<T, RadixSortPolicy>;
 #endif // _CCCL_HAS_CONCEPTS()
 
 struct policy_selector
@@ -1703,15 +1716,15 @@ struct policy_selector
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto
-  make_onesweep_small_key_policy(const small_key_tuning_values& tuning) const -> radix_sort_policy
+  make_onesweep_small_key_policy(const small_key_tuning_values& tuning) const -> RadixSortPolicy
   {
     const int primary_radix_bits     = (key_size > 1) ? 7 : 5;
     const int single_tile_radix_bits = (key_size > 1) ? 6 : 5;
     const int onesweep_radix_bits    = 8;
 
-    const auto histogram = radix_sort_histogram_policy{128, 16, __scale_num_parts(1, key_size), onesweep_radix_bits};
+    const auto histogram = RadixSortHistogramPolicy{128, 16, __scale_num_parts(1, key_size), onesweep_radix_bits};
 
-    const auto exclusive_sum = radix_sort_exclusive_sum_policy{256, onesweep_radix_bits};
+    const auto exclusive_sum = RadixSortExclusiveSumPolicy{256, onesweep_radix_bits};
 
     const bool offset_64bit = offset_size == 8;
     const bool key_is_float = key_type == type_t::float32;
@@ -1802,7 +1815,7 @@ struct policy_selector
       BLOCK_SCAN_WARP_SCANS,
       single_tile_radix_bits);
 
-    return radix_sort_policy{
+    return RadixSortPolicy{
       RadixSortAlgorithm::onesweep,
       histogram,
       exclusive_sum,
@@ -1815,8 +1828,7 @@ struct policy_selector
       single_tile};
   }
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
-    -> radix_sort_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> RadixSortPolicy
   {
     if (cc >= ::cuda::compute_capability{10, 0})
     {
@@ -1837,9 +1849,9 @@ struct policy_selector
       const int onesweep_radix_bits = 8;
       const bool offset_64bit       = offset_size == 8;
 
-      const auto histogram = radix_sort_histogram_policy{128, 16, __scale_num_parts(1, key_size), onesweep_radix_bits};
+      const auto histogram = RadixSortHistogramPolicy{128, 16, __scale_num_parts(1, key_size), onesweep_radix_bits};
 
-      const auto exclusive_sum = radix_sort_exclusive_sum_policy{256, onesweep_radix_bits};
+      const auto exclusive_sum = RadixSortExclusiveSumPolicy{256, onesweep_radix_bits};
 
       const auto onesweep = make_reg_scaled_radix_sort_onesweep_policy(
         384,
@@ -1896,7 +1908,7 @@ struct policy_selector
         BLOCK_SCAN_WARP_SCANS,
         single_tile_radix_bits);
 
-      return radix_sort_policy{
+      return RadixSortPolicy{
         use_onesweep,
         histogram,
         exclusive_sum,
@@ -1919,9 +1931,9 @@ struct policy_selector
       const int onesweep_radix_bits = 8;
       const bool offset_64bit       = offset_size == 8;
 
-      const auto histogram = radix_sort_histogram_policy{256, 8, __scale_num_parts(8, key_size), onesweep_radix_bits};
+      const auto histogram = RadixSortHistogramPolicy{256, 8, __scale_num_parts(8, key_size), onesweep_radix_bits};
 
-      const auto exclusive_sum = radix_sort_exclusive_sum_policy{256, onesweep_radix_bits};
+      const auto exclusive_sum = RadixSortExclusiveSumPolicy{256, onesweep_radix_bits};
 
       const auto onesweep = make_reg_scaled_radix_sort_onesweep_policy(
         256,
@@ -1978,7 +1990,7 @@ struct policy_selector
         BLOCK_SCAN_WARP_SCANS,
         single_tile_radix_bits);
 
-      return radix_sort_policy{
+      return RadixSortPolicy{
         use_onesweep,
         histogram,
         exclusive_sum,
@@ -1999,9 +2011,9 @@ struct policy_selector
         key_size >= int{sizeof(uint32_t)} ? RadixSortAlgorithm::onesweep : RadixSortAlgorithm::multi_pass;
       const int onesweep_radix_bits = 8;
 
-      const auto histogram = radix_sort_histogram_policy{256, 8, __scale_num_parts(8, key_size), onesweep_radix_bits};
+      const auto histogram = RadixSortHistogramPolicy{256, 8, __scale_num_parts(8, key_size), onesweep_radix_bits};
 
-      const auto exclusive_sum = radix_sort_exclusive_sum_policy{256, onesweep_radix_bits};
+      const auto exclusive_sum = RadixSortExclusiveSumPolicy{256, onesweep_radix_bits};
 
       const auto onesweep = make_reg_scaled_radix_sort_onesweep_policy(
         256,
@@ -2042,10 +2054,10 @@ struct policy_selector
         BLOCK_SCAN_RAKING_MEMOIZE,
         alt_radix_bits);
 
-      const auto upsweep = radix_sort_upsweep_policy{
+      const auto upsweep = RadixSortUpsweepPolicy{
         downsweep.threads_per_block, downsweep.items_per_thread, downsweep.load_modifier, downsweep.radix_bits};
 
-      const auto alt_upsweep = radix_sort_upsweep_policy{
+      const auto alt_upsweep = RadixSortUpsweepPolicy{
         alt_downsweep.threads_per_block,
         alt_downsweep.items_per_thread,
         alt_downsweep.load_modifier,
@@ -2061,7 +2073,7 @@ struct policy_selector
         BLOCK_SCAN_WARP_SCANS,
         primary_radix_bits);
 
-      return radix_sort_policy{
+      return RadixSortPolicy{
         use_onesweep,
         histogram,
         exclusive_sum,
@@ -2083,9 +2095,9 @@ struct policy_selector
         key_size >= int{sizeof(uint32_t)} ? RadixSortAlgorithm::onesweep : RadixSortAlgorithm::multi_pass;
       const int onesweep_radix_bits = 8;
 
-      const auto histogram = radix_sort_histogram_policy{256, 8, __scale_num_parts(8, key_size), onesweep_radix_bits};
+      const auto histogram = RadixSortHistogramPolicy{256, 8, __scale_num_parts(8, key_size), onesweep_radix_bits};
 
-      const auto exclusive_sum = radix_sort_exclusive_sum_policy{256, onesweep_radix_bits};
+      const auto exclusive_sum = RadixSortExclusiveSumPolicy{256, onesweep_radix_bits};
 
       const auto onesweep = make_reg_scaled_radix_sort_onesweep_policy(
         256,
@@ -2142,7 +2154,7 @@ struct policy_selector
         BLOCK_SCAN_WARP_SCANS,
         single_tile_radix_bits);
 
-      return radix_sort_policy{
+      return RadixSortPolicy{
         use_onesweep,
         histogram,
         exclusive_sum,
@@ -2165,9 +2177,9 @@ struct policy_selector
       const int onesweep_radix_bits = 8;
       const bool offset_64bit       = (offset_size == 8);
 
-      const auto histogram = radix_sort_histogram_policy{256, 8, __scale_num_parts(8, key_size), onesweep_radix_bits};
+      const auto histogram = RadixSortHistogramPolicy{256, 8, __scale_num_parts(8, key_size), onesweep_radix_bits};
 
-      const auto exclusive_sum = radix_sort_exclusive_sum_policy{256, onesweep_radix_bits};
+      const auto exclusive_sum = RadixSortExclusiveSumPolicy{256, onesweep_radix_bits};
 
       const auto onesweep = make_reg_scaled_radix_sort_onesweep_policy(
         256,
@@ -2208,10 +2220,10 @@ struct policy_selector
         BLOCK_SCAN_WARP_SCANS,
         primary_radix_bits - 1);
 
-      const auto upsweep = radix_sort_upsweep_policy{
+      const auto upsweep = RadixSortUpsweepPolicy{
         downsweep.threads_per_block, downsweep.items_per_thread, downsweep.load_modifier, downsweep.radix_bits};
 
-      const auto alt_upsweep = radix_sort_upsweep_policy{
+      const auto alt_upsweep = RadixSortUpsweepPolicy{
         alt_downsweep.threads_per_block,
         alt_downsweep.items_per_thread,
         alt_downsweep.load_modifier,
@@ -2227,7 +2239,7 @@ struct policy_selector
         BLOCK_SCAN_WARP_SCANS,
         single_tile_radix_bits);
 
-      return radix_sort_policy{
+      return RadixSortPolicy{
         use_onesweep,
         histogram,
         exclusive_sum,
@@ -2246,9 +2258,9 @@ struct policy_selector
     const auto use_onesweep          = RadixSortAlgorithm::multi_pass;
     const int onesweep_radix_bits    = 8;
 
-    const auto histogram = radix_sort_histogram_policy{256, 8, __scale_num_parts(1, key_size), onesweep_radix_bits};
+    const auto histogram = RadixSortHistogramPolicy{256, 8, __scale_num_parts(1, key_size), onesweep_radix_bits};
 
-    const auto exclusive_sum = radix_sort_exclusive_sum_policy{256, onesweep_radix_bits};
+    const auto exclusive_sum = RadixSortExclusiveSumPolicy{256, onesweep_radix_bits};
 
     const auto onesweep = make_reg_scaled_radix_sort_onesweep_policy(
       256,
@@ -2289,10 +2301,10 @@ struct policy_selector
       BLOCK_SCAN_RAKING_MEMOIZE,
       primary_radix_bits - 1);
 
-    const auto upsweep = radix_sort_upsweep_policy{
+    const auto upsweep = RadixSortUpsweepPolicy{
       downsweep.threads_per_block, downsweep.items_per_thread, downsweep.load_modifier, downsweep.radix_bits};
 
-    const auto alt_upsweep = radix_sort_upsweep_policy{
+    const auto alt_upsweep = RadixSortUpsweepPolicy{
       alt_downsweep.threads_per_block,
       alt_downsweep.items_per_thread,
       alt_downsweep.load_modifier,
@@ -2308,7 +2320,7 @@ struct policy_selector
       BLOCK_SCAN_WARP_SCANS,
       single_tile_radix_bits);
 
-    return radix_sort_policy{
+    return RadixSortPolicy{
       use_onesweep,
       histogram,
       exclusive_sum,
@@ -2329,7 +2341,7 @@ static_assert(radix_sort_policy_selector<policy_selector>);
 template <typename KeyT, typename ValueT, typename OffsetT>
 struct policy_selector_from_types
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability cc) const -> radix_sort_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability cc) const -> RadixSortPolicy
   {
     constexpr auto policies = policy_selector{
       int{sizeof(KeyT)},

--- a/cub/cub/device/dispatch/tuning/tuning_segmented_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_segmented_radix_sort.cuh
@@ -22,12 +22,11 @@ CUB_NAMESPACE_BEGIN
 namespace detail::segmented_radix_sort
 {
 using radix_sort::make_reg_scaled_radix_sort_downsweep_policy;
-using radix_sort::radix_sort_downsweep_policy;
 
 struct segmented_radix_sort_policy
 {
-  radix_sort_downsweep_policy segmented;
-  radix_sort_downsweep_policy alt_segmented;
+  RadixSortDownsweepPolicy segmented;
+  RadixSortDownsweepPolicy alt_segmented;
 
   _CCCL_HOST_DEVICE_API constexpr friend bool
   operator==(const segmented_radix_sort_policy& lhs, const segmented_radix_sort_policy& rhs)

--- a/cub/cub/device/dispatch/tuning/tuning_segmented_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_segmented_sort.cuh
@@ -403,7 +403,7 @@ struct policy_hub
     static constexpr int RADIX_BITS             = sizeof(KeyT) > 1 ? 6 : 4;
     static constexpr int PARTITIONING_THRESHOLD = 300;
 
-    using LargeSegmentPolicy = AgentRadixSortDownsweepPolicy<
+    using LargeSegmentPolicy = detail::agent_radix_sort_downsweep_policy<
       BLOCK_THREADS,
       16,
       DominantT,
@@ -436,7 +436,7 @@ struct policy_hub
     static constexpr int RADIX_BITS             = sizeof(KeyT) > 1 ? 6 : 4;
     static constexpr int PARTITIONING_THRESHOLD = 500;
 
-    using LargeSegmentPolicy = AgentRadixSortDownsweepPolicy<
+    using LargeSegmentPolicy = detail::agent_radix_sort_downsweep_policy<
       BLOCK_THREADS,
       19,
       DominantT,
@@ -469,7 +469,7 @@ struct policy_hub
     static constexpr int RADIX_BITS             = sizeof(KeyT) > 1 ? 6 : 4;
     static constexpr int PARTITIONING_THRESHOLD = 500;
 
-    using LargeSegmentPolicy = AgentRadixSortDownsweepPolicy<
+    using LargeSegmentPolicy = detail::agent_radix_sort_downsweep_policy<
       BLOCK_THREADS,
       19,
       DominantT,
@@ -502,7 +502,7 @@ struct policy_hub
     static constexpr int RADIX_BITS             = sizeof(KeyT) > 1 ? 5 : 4;
     static constexpr int PARTITIONING_THRESHOLD = 500;
 
-    using LargeSegmentPolicy = AgentRadixSortDownsweepPolicy<
+    using LargeSegmentPolicy = detail::agent_radix_sort_downsweep_policy<
       BLOCK_THREADS,
       16,
       DominantT,
@@ -535,7 +535,7 @@ struct policy_hub
     static constexpr int RADIX_BITS             = sizeof(KeyT) > 1 ? 6 : 4;
     static constexpr int PARTITIONING_THRESHOLD = 500;
 
-    using LargeSegmentPolicy = AgentRadixSortDownsweepPolicy<
+    using LargeSegmentPolicy = detail::agent_radix_sort_downsweep_policy<
       BLOCK_THREADS,
       19,
       DominantT,
@@ -566,7 +566,7 @@ struct policy_hub
   {
     static constexpr int BLOCK_THREADS          = 256;
     static constexpr int PARTITIONING_THRESHOLD = 500;
-    using LargeSegmentPolicy                    = AgentRadixSortDownsweepPolicy<
+    using LargeSegmentPolicy                    = detail::agent_radix_sort_downsweep_policy<
                          BLOCK_THREADS,
                          23,
                          DominantT,
@@ -597,7 +597,7 @@ struct policy_hub
   {
     static constexpr int BLOCK_THREADS          = 256;
     static constexpr int PARTITIONING_THRESHOLD = 500;
-    using LargeSegmentPolicy                    = AgentRadixSortDownsweepPolicy<
+    using LargeSegmentPolicy                    = detail::agent_radix_sort_downsweep_policy<
                          BLOCK_THREADS,
                          23,
                          DominantT,

--- a/cub/test/catch2_test_device_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_radix_sort_env.cu
@@ -1116,11 +1116,11 @@ TEST_CASE("Device radix sort pairs descending DB decomposer+bits uses custom str
 template <typename KeyT, typename ValueT, int BlockThreads>
 struct tiny_onesweep_policy_selector
 {
-  _CCCL_API constexpr auto operator()(cuda::compute_capability cc) const -> cub::detail::radix_sort::radix_sort_policy
+  _CCCL_API constexpr auto operator()(cuda::compute_capability cc) const -> cub::RadixSortPolicy
   {
     using default_selector_t                = cub::detail::radix_sort::policy_selector_from_types<KeyT, ValueT, int>;
     auto policy                             = default_selector_t{}(cc);
-    policy.algorithm                        = cub::detail::radix_sort::RadixSortAlgorithm::onesweep;
+    policy.algorithm                        = cub::RadixSortAlgorithm::onesweep;
     policy.onesweep.threads_per_block       = BlockThreads;
     policy.onesweep.items_per_thread        = 1;
     policy.single_tile.threads_per_block    = BlockThreads;
@@ -1537,3 +1537,93 @@ TEST_CASE("DeviceRadixSort::SortPairsDescending DB decomposer+bits can be tuned"
 }
 
 #endif // TEST_LAUNCH != 1
+
+#if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
+C2H_TEST("RadixSortPolicy", "[radix_sort][device]")
+{
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::RadixSortPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::RadixSortPolicy>);
+
+  // aggregate init
+  constexpr auto p1 = cub::RadixSortPolicy{
+    cub::RadixSortAlgorithm::onesweep,
+    cub::RadixSortHistogramPolicy{256, 8, 1, 8},
+    cub::RadixSortExclusiveSumPolicy{256, 8},
+    cub::RadixSortOnesweepPolicy{
+      256, 21, cub::RADIX_SORT_STORE_DIRECT, cub::RADIX_RANK_MATCH_EARLY_COUNTS_ANY, cub::BLOCK_SCAN_WARP_SCANS, 1, 8},
+    cub::ScanPolicy{
+      cub::ScanAlgorithm::lookback,
+      cub::ScanLookbackPolicy{
+        512,
+        23,
+        cub::BLOCK_LOAD_WARP_TRANSPOSE,
+        cub::LOAD_DEFAULT,
+        cub::BLOCK_STORE_WARP_TRANSPOSE,
+        cub::BLOCK_SCAN_RAKING_MEMOIZE,
+        cub::LookbackDelayPolicy{}},
+      {}},
+    cub::RadixSortDownsweepPolicy{
+      256, 25, cub::BLOCK_LOAD_TRANSPOSE, cub::LOAD_DEFAULT, cub::RADIX_RANK_MATCH, cub::BLOCK_SCAN_WARP_SCANS, 7},
+    cub::RadixSortDownsweepPolicy{
+      192, 39, cub::BLOCK_LOAD_TRANSPOSE, cub::LOAD_DEFAULT, cub::RADIX_RANK_MEMOIZE, cub::BLOCK_SCAN_WARP_SCANS, 6},
+    cub::RadixSortUpsweepPolicy{256, 25, cub::LOAD_DEFAULT, 7},
+    cub::RadixSortUpsweepPolicy{192, 39, cub::LOAD_DEFAULT, 6},
+    cub::RadixSortDownsweepPolicy{
+      256, 19, cub::BLOCK_LOAD_DIRECT, cub::LOAD_LDG, cub::RADIX_RANK_MEMOIZE, cub::BLOCK_SCAN_WARP_SCANS, 6}};
+
+#  if _CCCL_STD_VER >= 2020
+  // designated init
+  constexpr auto p2 = cub::RadixSortPolicy{
+    .algorithm     = cub::RadixSortAlgorithm::onesweep,
+    .histogram     = {.threads_per_block = 256, .items_per_thread = 8, .num_private_partitions = 1, .radix_bits = 8},
+    .exclusive_sum = {.threads_per_block = 256, .radix_bits = 8},
+    .onesweep      = {.threads_per_block           = 256,
+                      .items_per_thread            = 21,
+                      .store_algorithm             = cub::RADIX_SORT_STORE_DIRECT,
+                      .rank_algorithm              = cub::RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
+                      .scan_algorithm              = cub::BLOCK_SCAN_WARP_SCANS,
+                      .rank_num_private_partitions = 1,
+                      .radix_bits                  = 8},
+    .scan          = {.algorithm = cub::ScanAlgorithm::lookback,
+                      .lookback  = {.threads_per_block = 512,
+                                    .items_per_thread  = 23,
+                                    .load_algorithm    = cub::BLOCK_LOAD_WARP_TRANSPOSE,
+                                    .load_modifier     = cub::LOAD_DEFAULT,
+                                    .store_algorithm   = cub::BLOCK_STORE_WARP_TRANSPOSE,
+                                    .scan_algorithm    = cub::BLOCK_SCAN_RAKING_MEMOIZE,
+                                    .lookback_delay    = {}},
+                      .lookahead = {}},
+    .downsweep     = {.threads_per_block = 256,
+                      .items_per_thread  = 25,
+                      .load_algorithm    = cub::BLOCK_LOAD_TRANSPOSE,
+                      .load_modifier     = cub::LOAD_DEFAULT,
+                      .rank_algorithm    = cub::RADIX_RANK_MATCH,
+                      .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
+                      .radix_bits        = 7},
+    .alt_downsweep = {.threads_per_block = 192,
+                      .items_per_thread  = 39,
+                      .load_algorithm    = cub::BLOCK_LOAD_TRANSPOSE,
+                      .load_modifier     = cub::LOAD_DEFAULT,
+                      .rank_algorithm    = cub::RADIX_RANK_MEMOIZE,
+                      .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
+                      .radix_bits        = 6},
+    .upsweep = {.threads_per_block = 256, .items_per_thread = 25, .load_modifier = cub::LOAD_DEFAULT, .radix_bits = 7},
+    .alt_upsweep =
+      {.threads_per_block = 192, .items_per_thread = 39, .load_modifier = cub::LOAD_DEFAULT, .radix_bits = 6},
+    .single_tile = {
+      .threads_per_block = 256,
+      .items_per_thread  = 19,
+      .load_algorithm    = cub::BLOCK_LOAD_DIRECT,
+      .load_modifier     = cub::LOAD_LDG,
+      .rank_algorithm    = cub::RADIX_RANK_MEMOIZE,
+      .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
+      .radix_bits        = 6}};
+#  else // _CCCL_STD_VER >= 2020
+  constexpr auto p2 = p1;
+#  endif // _CCCL_STD_VER >= 2020
+
+  // comparison
+  STATIC_REQUIRE(p1 == p2);
+  STATIC_REQUIRE_FALSE(p1 != p2);
+}
+#endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_radix_sort_env_api.cu
+++ b/cub/test/catch2_test_device_radix_sort_env_api.cu
@@ -9,6 +9,7 @@
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 
+#include <cuda/__execution/tune.h>
 #include <cuda/devices>
 #include <cuda/stream>
 
@@ -658,3 +659,88 @@ C2H_TEST("cub::DeviceRadixSort::SortPairsDescending DB decomposer+bits env-based
   REQUIRE(keys == expected_keys);
   REQUIRE(values == expected_values);
 }
+
+#if _CCCL_STD_VER >= 2020
+
+// example-begin radix-sort-keys-policy-selector
+struct RadixSortKeysPolicySelector
+{
+  __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::RadixSortPolicy
+  {
+    const int onesweep_threads = cc >= cuda::compute_capability{8, 0} ? 256 : 128;
+    return {
+      .algorithm     = cub::RadixSortAlgorithm::onesweep,
+      .histogram     = {.threads_per_block = 256, .items_per_thread = 8, .num_private_partitions = 1, .radix_bits = 8},
+      .exclusive_sum = {.threads_per_block = 256, .radix_bits = 8},
+      .onesweep      = {.threads_per_block           = onesweep_threads,
+                        .items_per_thread            = 21,
+                        .store_algorithm             = cub::RADIX_SORT_STORE_DIRECT,
+                        .rank_algorithm              = cub::RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
+                        .scan_algorithm              = cub::BLOCK_SCAN_WARP_SCANS,
+                        .rank_num_private_partitions = 2,
+                        .radix_bits                  = 8},
+      .scan          = {.algorithm = cub::ScanAlgorithm::lookback,
+                        .lookback  = {.threads_per_block = 512,
+                                      .items_per_thread  = 23,
+                                      .load_algorithm    = cub::BLOCK_LOAD_WARP_TRANSPOSE,
+                                      .load_modifier     = cub::LOAD_DEFAULT,
+                                      .store_algorithm   = cub::BLOCK_STORE_WARP_TRANSPOSE,
+                                      .scan_algorithm    = cub::BLOCK_SCAN_RAKING_MEMOIZE,
+                                      .lookback_delay    = {}},
+                        .lookahead = {}},
+      .downsweep     = {.threads_per_block = 256,
+                        .items_per_thread  = 25,
+                        .load_algorithm    = cub::BLOCK_LOAD_TRANSPOSE,
+                        .load_modifier     = cub::LOAD_DEFAULT,
+                        .rank_algorithm    = cub::RADIX_RANK_MATCH,
+                        .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
+                        .radix_bits        = 7},
+      .alt_downsweep = {.threads_per_block = 192,
+                        .items_per_thread  = 39,
+                        .load_algorithm    = cub::BLOCK_LOAD_TRANSPOSE,
+                        .load_modifier     = cub::LOAD_DEFAULT,
+                        .rank_algorithm    = cub::RADIX_RANK_MEMOIZE,
+                        .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
+                        .radix_bits        = 6},
+      .upsweep = {.threads_per_block = 256, .items_per_thread = 25, .load_modifier = cub::LOAD_DEFAULT, .radix_bits = 7},
+      .alt_upsweep =
+        {.threads_per_block = 192, .items_per_thread = 39, .load_modifier = cub::LOAD_DEFAULT, .radix_bits = 6},
+      .single_tile = {
+        .threads_per_block = 256,
+        .items_per_thread  = 19,
+        .load_algorithm    = cub::BLOCK_LOAD_DIRECT,
+        .load_modifier     = cub::LOAD_LDG,
+        .rank_algorithm    = cub::RADIX_RANK_MEMOIZE,
+        .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
+        .radix_bits        = 6}};
+  }
+};
+// example-end radix-sort-keys-policy-selector
+
+C2H_TEST("cub::DeviceRadixSort::SortKeys env-based API with tuning", "[radix_sort][env]")
+{
+  // example-begin radix-sort-keys-tuning
+  auto keys_in  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
+  auto keys_out = thrust::device_vector<int>(7, thrust::no_init);
+
+  auto error = cub::DeviceRadixSort::SortKeys(
+    keys_in.data().get(),
+    keys_out.data().get(),
+    static_cast<int>(keys_in.size()),
+    0,
+    sizeof(int) * 8,
+    cuda::execution::tune(RadixSortKeysPolicySelector{}));
+
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceRadixSort::SortKeys failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  // example-end radix-sort-keys-tuning
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(keys_out == expected_keys);
+}
+
+#endif // _CCCL_STD_VER >= 2020

--- a/cub/test/catch2_test_device_segmented_sort_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_segmented_sort_custom_policy_hub.cu
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// TODO(bgruber): drop this test with CCCL 4.0 when we drop the segmented sort dispatcher
+
+// disable deprecation warnings for radix sort agent policies
+#define CCCL_IGNORE_DEPRECATED_API
+
 #include "insert_nested_NVTX_range_guard.h"
 
 #include <cub/device/dispatch/dispatch_segmented_sort.cuh>
@@ -12,9 +17,6 @@
 #include <c2h/catch2_test_helper.h>
 
 using namespace cub;
-
-// TODO(bgruber): drop this test with CCCL 4.0 when we drop the segmented sort dispatcher after publishing the tuning
-// API
 
 template <typename KeyT>
 struct my_policy_hub


### PR DESCRIPTION
- [x] Create follow-up PR for duplicating the logic of `DispatchRadixSort` into a new `dispatch` function: #9530


Fixes: #8576 