### PR TITLE
Introduce public `CCCL_HOST_ARCH`

### DIFF
--- a/docs/cccl/development/macro.rst
+++ b/docs/cccl/development/macro.rst
@@ -92,11 +92,11 @@ Architecture Macros
 
 The following macros are used to check the target architecture. They comply with the compiler supported by the CUDA toolkit. Compilers outside the CUDA toolkit may define such macros in a different way.
 
-+-------------------------+---------------------------------------------------+
-| ``_CCCL_ARCH(ARM64)``   |  ARM 64-bit, including MSVC emulation             |
-+-------------------------+---------------------------------------------------+
-| ``_CCCL_ARCH(X86_64)``  |  X86 64-bit. False on ARM 64-bit MSVC emulation   |
-+-------------------------+---------------------------------------------------+
++------------------------------+---------------------------------------------------+
+| ``_CCCL_HOST_ARCH(ARM64)``   |  ARM 64-bit, including MSVC emulation             |
++------------------------------+---------------------------------------------------+
+| ``_CCCL_HOST_ARCH(X86_64)``  |  X86 64-bit. False on ARM 64-bit MSVC emulation   |
++------------------------------+---------------------------------------------------+
 
 ----
 

--- a/docs/libcudacxx/Doxyfile
+++ b/docs/libcudacxx/Doxyfile
@@ -20,6 +20,7 @@ INPUT                  = ../../libcudacxx/include/cuda/__algorithm \
                          ../../libcudacxx/include/cuda/__memory_resource \
                          ../../libcudacxx/include/cuda/__stream \
                          ../../libcudacxx/include/nv \
+                         ../../libcudacxx/include/cuda/std/__cccl/architecture.h \
                          ../../libcudacxx/include/cuda/std/__cccl/os.h
 
 RECURSIVE              = YES

--- a/docs/libcudacxx/extended_api/macros.rst
+++ b/docs/libcudacxx/extended_api/macros.rst
@@ -20,6 +20,14 @@ included, and do not require including a specific header file.
    * - .. toctree::
           :maxdepth: 1
 
+          ../api/macro_cccl_arch
+     - Detecting the current host architecture.
+     - CCCL 3.5.0
+     - CUDA 13.5
+
+   * - .. toctree::
+          :maxdepth: 1
+
           ../api/macro_cccl_os
      - Detecting the current operating system.
      - CCCL 3.4.0

--- a/docs/libcudacxx/extended_api/macros.rst
+++ b/docs/libcudacxx/extended_api/macros.rst
@@ -20,7 +20,7 @@ included, and do not require including a specific header file.
    * - .. toctree::
           :maxdepth: 1
 
-          ../api/macro_cccl_arch
+          ../api/macro_cccl_host_arch
      - Detecting the current host architecture.
      - CCCL 3.5.0
      - CUDA 13.5

--- a/libcudacxx/include/cuda/__numeric/add_overflow.h
+++ b/libcudacxx/include/cuda/__numeric/add_overflow.h
@@ -39,9 +39,9 @@
 
 #include <nv/target>
 
-#if _CCCL_COMPILER(MSVC) && _CCCL_ARCH(X86_64)
+#if _CCCL_COMPILER(MSVC) && _CCCL_HOST_ARCH(X86_64)
 #  include <intrin.h>
-#endif // _CCCL_COMPILER(MSVC) && _CCCL_ARCH(X86_64)
+#endif // _CCCL_COMPILER(MSVC) && _CCCL_HOST_ARCH(X86_64)
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -162,7 +162,7 @@ template <class _Tp>
 template <class _Tp>
 [[nodiscard]] _CCCL_HOST_API overflow_result<_Tp> __add_overflow_host(_Tp __lhs, _Tp __rhs) noexcept
 {
-#  if _CCCL_COMPILER(MSVC) && _CCCL_ARCH(X86_64)
+#  if _CCCL_COMPILER(MSVC) && _CCCL_HOST_ARCH(X86_64)
   if constexpr (sizeof(_Tp) <= 8)
   {
 #    if _CCCL_COMPILER(MSVC, >=, 19, 37)
@@ -216,7 +216,7 @@ template <class _Tp>
       }
   }
   else
-#  endif // ^^^ _CCCL_COMPILER(MSVC) || _CCCL_ARCH(X86_64) ^^^
+#  endif // ^^^ _CCCL_COMPILER(MSVC) || _CCCL_HOST_ARCH(X86_64) ^^^
   {
     return ::cuda::__add_overflow_generic_impl(__lhs, __rhs);
   }

--- a/libcudacxx/include/cuda/__numeric/mul_overflow.h
+++ b/libcudacxx/include/cuda/__numeric/mul_overflow.h
@@ -55,9 +55,9 @@
 #endif // _CCCL_COMPILER(NVHPC, <, 26, 1)
 
 // On ARM64, using the builtin with 128-bit ints result in `undefined reference to __muloti4` with nvc++ and clang < 20.
-#if _CCCL_ARCH(ARM64) && (_CCCL_COMPILER(NVHPC) || _CCCL_COMPILER(CLANG, <, 20))
+#if _CCCL_HOST_ARCH(ARM64) && (_CCCL_COMPILER(NVHPC) || _CCCL_COMPILER(CLANG, <, 20))
 #  undef _CCCL_BUILTIN_MUL_OVERFLOW
-#endif // _CCCL_ARCH(ARM64) && (_CCCL_COMPILER(NVHPC) || _CCCL_COMPILER(CLANG, <, 20))
+#endif // _CCCL_HOST_ARCH(ARM64) && (_CCCL_COMPILER(NVHPC) || _CCCL_COMPILER(CLANG, <, 20))
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
@@ -105,7 +105,7 @@ template <class _Tp>
 {
   if constexpr (::cuda::std::is_signed_v<_Tp>)
   {
-#  if _CCCL_COMPILER(MSVC, >=, 19, 37) && _CCCL_ARCH(X86_64)
+#  if _CCCL_COMPILER(MSVC, >=, 19, 37) && _CCCL_HOST_ARCH(X86_64)
     if constexpr (sizeof(_Tp) == sizeof(::cuda::std::int8_t))
     {
       ::cuda::std::int16_t __result;
@@ -131,14 +131,14 @@ template <class _Tp>
       return {__result, __overflow};
     }
     else
-#  endif // _CCCL_COMPILER(MSVC, >=, 19, 37) && _CCCL_ARCH(X86_64)
+#  endif // _CCCL_COMPILER(MSVC, >=, 19, 37) && _CCCL_HOST_ARCH(X86_64)
     {
       return ::cuda::__mul_overflow_generic<_Tp>(__lhs, __rhs);
     }
   }
   else // ^^^ signed types ^^^ / vvv unsigned types vvv
   {
-#  if _CCCL_COMPILER(MSVC, >=, 19, 37) && _CCCL_ARCH(X86_64)
+#  if _CCCL_COMPILER(MSVC, >=, 19, 37) && _CCCL_HOST_ARCH(X86_64)
     if constexpr (sizeof(_Tp) == sizeof(::cuda::std::uint8_t))
     {
       ::cuda::std::uint16_t __result;
@@ -167,7 +167,7 @@ template <class _Tp>
       return {__lo, __overflow};
     }
     else
-#  endif // _CCCL_COMPILER(MSVC, >=, 19, 37) && _CCCL_ARCH(X86_64)
+#  endif // _CCCL_COMPILER(MSVC, >=, 19, 37) && _CCCL_HOST_ARCH(X86_64)
     {
       return ::cuda::__mul_overflow_generic<_Tp>(__lhs, __rhs);
     }

--- a/libcudacxx/include/cuda/__numeric/sub_overflow.h
+++ b/libcudacxx/include/cuda/__numeric/sub_overflow.h
@@ -37,9 +37,9 @@
 
 #include <nv/target>
 
-#if _CCCL_COMPILER(MSVC) && _CCCL_ARCH(X86_64)
+#if _CCCL_COMPILER(MSVC) && _CCCL_HOST_ARCH(X86_64)
 #  include <intrin.h>
-#endif // _CCCL_COMPILER(MSVC) && _CCCL_ARCH(X86_64)
+#endif // _CCCL_COMPILER(MSVC) && _CCCL_HOST_ARCH(X86_64)
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -179,7 +179,7 @@ template <class _Tp>
 template <class _Tp>
 [[nodiscard]] _CCCL_HOST_API overflow_result<_Tp> __sub_overflow_host(_Tp __lhs, _Tp __rhs) noexcept
 {
-#  if _CCCL_COMPILER(MSVC) && _CCCL_ARCH(X86_64)
+#  if _CCCL_COMPILER(MSVC) && _CCCL_HOST_ARCH(X86_64)
   if constexpr (sizeof(_Tp) <= 8)
   {
 #    if _CCCL_COMPILER(MSVC, >=, 19, 37)
@@ -233,7 +233,7 @@ template <class _Tp>
       }
   }
   else
-#  endif // ^^^ _CCCL_COMPILER(MSVC) || _CCCL_ARCH(X86_64) ^^^
+#  endif // ^^^ _CCCL_COMPILER(MSVC) || _CCCL_HOST_ARCH(X86_64) ^^^
   {
     return ::cuda::__sub_overflow_generic_impl(__lhs, __rhs);
   }

--- a/libcudacxx/include/cuda/std/__atomic/platform/msvc_to_builtins.h
+++ b/libcudacxx/include/cuda/std/__atomic/platform/msvc_to_builtins.h
@@ -40,10 +40,10 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #  define _LIBCUDACXX_COMPILER_BARRIER() _ReadWriteBarrier()
 
-#  if _CCCL_ARCH(ARM64)
+#  if _CCCL_HOST_ARCH(ARM64)
 #    define _LIBCUDACXX_MEMORY_BARRIER()             __dmb(0xB) // inner shared data memory barrier
 #    define _LIBCUDACXX_COMPILER_OR_MEMORY_BARRIER() _LIBCUDACXX_MEMORY_BARRIER()
-#  elif _CCCL_ARCH(X86_64)
+#  elif _CCCL_HOST_ARCH(X86_64)
 #    define _LIBCUDACXX_MEMORY_BARRIER()             __faststorefence()
 // x86/x64 hardware only emits memory barriers inside _Interlocked intrinsics
 #    define _LIBCUDACXX_COMPILER_OR_MEMORY_BARRIER() _LIBCUDACXX_COMPILER_BARRIER()

--- a/libcudacxx/include/cuda/std/__bit/popcount.h
+++ b/libcudacxx/include/cuda/std/__bit/popcount.h
@@ -86,7 +86,7 @@ template <typename _Tp>
 template <typename _Tp>
 [[nodiscard]] _CCCL_HOST_API int __cccl_popcount_impl_host(_Tp __v) noexcept
 {
-#    if _CCCL_COMPILER(MSVC) && _CCCL_ARCH(X86_64)
+#    if _CCCL_COMPILER(MSVC) && _CCCL_HOST_ARCH(X86_64)
   if constexpr (sizeof(_Tp) == sizeof(uint32_t))
   {
     return static_cast<int>(::__popcnt(__v));
@@ -96,7 +96,7 @@ template <typename _Tp>
     return static_cast<int>(::__popcnt64(__v));
   }
   // _CountOneBits exists after MSVC 1931
-#    elif _CCCL_COMPILER(MSVC, >, 19, 30) && _CCCL_ARCH(ARM64)
+#    elif _CCCL_COMPILER(MSVC, >, 19, 30) && _CCCL_HOST_ARCH(ARM64)
   if constexpr (sizeof(_Tp) == sizeof(uint32_t))
   {
     return static_cast<int>(::_CountOneBits(__v));

--- a/libcudacxx/include/cuda/std/__cccl/architecture.h
+++ b/libcudacxx/include/cuda/std/__cccl/architecture.h
@@ -16,10 +16,10 @@
 
 // The header provides the following macros to determine the host architecture:
 //
-// _CCCL_ARCH(ARM64)     ARM64
-// _CCCL_ARCH(X86_64)    X86 64 bit
-// CCCL_ARCH(ARM64)      ARM64
-// CCCL_ARCH(X86_64)     X86 64 bit
+// _CCCL_ARCH(ARM64)      ARM64
+// _CCCL_ARCH(X86_64)     X86 64 bit
+// CCCL_HOST_ARCH(ARM64)  ARM64
+// CCCL_HOST_ARCH(X86_64) X86 64 bit
 
 // Determine the host architecture
 
@@ -41,7 +41,7 @@
 
 #define _CCCL_ARCH(...) _CCCL_ARCH_##__VA_ARGS__##_()
 
-//! @def CCCL_ARCH(ARCH) /* implementation defined */
+//! @def CCCL_HOST_ARCH(ARCH) /* implementation defined */
 //!
 //! @brief Detect the current host architecture.
 //!
@@ -67,21 +67,21 @@
 //! #define MY_OTHER_MACRO 1
 //!
 //! // Expansion value can be used in ordinary macro conditionals
-//! #if CCCL_ARCH(X86_64) && MY_OTHER_MACRO
+//! #if CCCL_HOST_ARCH(X86_64) && MY_OTHER_MACRO
 //!   // ...
 //! #endif
 //!
 //! // Can be negated as usual
-//! #if !CCCL_ARCH(ARM64)
+//! #if !CCCL_HOST_ARCH(ARM64)
 //!   // ...
 //! #endif
 //! @endcode
 //!
 //! @return true if the specified host architecture is being compiled for, false otherwise.
 #ifdef _CCCL_DOXYGEN_INVOKED
-#  define CCCL_ARCH(ARCH) /* implementation defined */
+#  define CCCL_HOST_ARCH(ARCH) /* implementation defined */
 #else
-#  define CCCL_ARCH(__arch__) _CCCL_ARCH_##__arch__##_()
+#  define CCCL_HOST_ARCH(__arch__) _CCCL_ARCH_##__arch__##_()
 #endif
 
 // Note: the public API is single-arg to constrain the API and allow for future expansion. The

--- a/libcudacxx/include/cuda/std/__cccl/architecture.h
+++ b/libcudacxx/include/cuda/std/__cccl/architecture.h
@@ -16,30 +16,30 @@
 
 // The header provides the following macros to determine the host architecture:
 //
-// _CCCL_ARCH(ARM64)      ARM64
-// _CCCL_ARCH(X86_64)     X86 64 bit
-// CCCL_HOST_ARCH(ARM64)  ARM64
-// CCCL_HOST_ARCH(X86_64) X86 64 bit
+// _CCCL_HOST_ARCH(ARM64)  ARM64
+// _CCCL_HOST_ARCH(X86_64) X86 64 bit
+// CCCL_HOST_ARCH(ARM64)   ARM64
+// CCCL_HOST_ARCH(X86_64)  X86 64 bit
 
 // Determine the host architecture
 
 // Arm 64-bit
 #if (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC) /*emulation*/)
-#  define _CCCL_ARCH_ARM64_() 1
+#  define _CCCL_HOST_ARCH_ARM64_() 1
 #else
-#  define _CCCL_ARCH_ARM64_() 0
+#  define _CCCL_HOST_ARCH_ARM64_() 0
 #endif
 
 // X86 64-bit
 
 // _M_X64 is defined even if we are compiling in Arm64 emulation mode
 #if (defined(_M_X64) && !defined(_M_ARM64EC)) || defined(__amd64__) || defined(__x86_64__)
-#  define _CCCL_ARCH_X86_64_() 1
+#  define _CCCL_HOST_ARCH_X86_64_() 1
 #else
-#  define _CCCL_ARCH_X86_64_() 0
+#  define _CCCL_HOST_ARCH_X86_64_() 0
 #endif
 
-#define _CCCL_ARCH(...) _CCCL_ARCH_##__VA_ARGS__##_()
+#define _CCCL_HOST_ARCH(...) _CCCL_HOST_ARCH_##__VA_ARGS__##_()
 
 //! @def CCCL_HOST_ARCH(ARCH) /* implementation defined */
 //!
@@ -81,7 +81,7 @@
 #ifdef _CCCL_DOXYGEN_INVOKED
 #  define CCCL_HOST_ARCH(ARCH) /* implementation defined */
 #else
-#  define CCCL_HOST_ARCH(__arch__) _CCCL_ARCH_##__arch__##_()
+#  define CCCL_HOST_ARCH(__arch__) _CCCL_HOST_ARCH_##__arch__##_()
 #endif
 
 // Note: the public API is single-arg to constrain the API and allow for future expansion. The
@@ -94,7 +94,8 @@
 #define _CCCL_ENDIAN_BIG()    0xFACE
 #define _CCCL_ENDIAN_PDP()    0xBEEF
 
-#if _CCCL_COMPILER(NVRTC) || (_CCCL_COMPILER(MSVC) && (_CCCL_ARCH(X86_64) || _CCCL_ARCH(ARM64))) || __LITTLE_ENDIAN__
+#if _CCCL_COMPILER(NVRTC) || (_CCCL_COMPILER(MSVC) && (_CCCL_HOST_ARCH(X86_64) || _CCCL_HOST_ARCH(ARM64))) \
+  || __LITTLE_ENDIAN__
 #  define _CCCL_ENDIAN_NATIVE() _CCCL_ENDIAN_LITTLE()
 #elif __BIG_ENDIAN__
 #  define _CCCL_ENDIAN_NATIVE() _CCCL_ENDIAN_BIG()

--- a/libcudacxx/include/cuda/std/__cccl/architecture.h
+++ b/libcudacxx/include/cuda/std/__cccl/architecture.h
@@ -18,8 +18,10 @@
 //
 // _CCCL_ARCH(ARM64)     ARM64
 // _CCCL_ARCH(X86_64)    X86 64 bit
+// CCCL_ARCH(ARM64)      ARM64
+// CCCL_ARCH(X86_64)     X86 64 bit
 
-// Determine the host compiler and its version
+// Determine the host architecture
 
 // Arm 64-bit
 #if (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC) /*emulation*/)
@@ -38,6 +40,53 @@
 #endif
 
 #define _CCCL_ARCH(...) _CCCL_ARCH_##__VA_ARGS__##_()
+
+//! @def CCCL_ARCH(ARCH) /* implementation defined */
+//!
+//! @brief Detect the current host architecture.
+//!
+//! @param ARCH The name of the host architecture to test.
+//!
+//! @note This macro is made available when including any libcu++ header. Users that wish to
+//! include the smallest possible header for this macro should include `<cuda/std/version>`.
+//!
+//! For supported host architectures, the macro expands to an implementation-defined true value
+//! if the current host architecture matches, or false otherwise. These values may be used in
+//! boolean expressions (preprocessor or otherwise), but no other guarantees are made.
+//!
+//! Available values for `ARCH` include:
+//!
+//! - ``ARM64``: ARM 64-bit, including MSVC ARM64EC emulation.
+//! - ``X86_64``: X86 64-bit. This is false when compiling in MSVC ARM64EC emulation mode.
+//!
+//! Passing any other value will result in an undefined expansion, which may or may not be
+//! diagnosed by the compiler.
+//!
+//! @par Example
+//! @code
+//! #define MY_OTHER_MACRO 1
+//!
+//! // Expansion value can be used in ordinary macro conditionals
+//! #if CCCL_ARCH(X86_64) && MY_OTHER_MACRO
+//!   // ...
+//! #endif
+//!
+//! // Can be negated as usual
+//! #if !CCCL_ARCH(ARM64)
+//!   // ...
+//! #endif
+//! @endcode
+//!
+//! @return true if the specified host architecture is being compiled for, false otherwise.
+#ifdef _CCCL_DOXYGEN_INVOKED
+#  define CCCL_ARCH(ARCH) /* implementation defined */
+#else
+#  define CCCL_ARCH(__arch__) _CCCL_ARCH_##__arch__##_()
+#endif
+
+// Note: the public API is single-arg to constrain the API and allow for future expansion. The
+// implementation is duplicated to guard against the architecture targets being accidentally
+// defined by the user.
 
 // Determine the endianness
 

--- a/libcudacxx/include/cuda/std/__cccl/extended_data_types.h
+++ b/libcudacxx/include/cuda/std/__cccl/extended_data_types.h
@@ -116,7 +116,7 @@ struct __nv_fp4x4_e2m1;
  * __float128
  **********************************************************************************************************************/
 
-#if !defined(CCCL_DISABLE_FLOAT128_SUPPORT) && _CCCL_HAS_INT128() && _CCCL_OS(LINUX) && !_CCCL_ARCH(ARM64) \
+#if !defined(CCCL_DISABLE_FLOAT128_SUPPORT) && _CCCL_HAS_INT128() && _CCCL_OS(LINUX) && !_CCCL_HOST_ARCH(ARM64) \
   && !_CCCL_TILE_COMPILATION()
 // Detect host compiler support
 #  if (defined(__CUDACC_RTC_FLOAT128__) || defined(__SIZEOF_FLOAT128__) || defined(__FLOAT128__))
@@ -131,7 +131,7 @@ struct __nv_fp4x4_e2m1;
 #      define _CCCL_HAS_FLOAT128() 1
 #    endif // ^^^ !_CCCL_DEVICE_COMPILATION() ^^^
 #  endif // Host compiler support
-#endif // !defined(CCCL_DISABLE_FLOAT128_SUPPORT) && _CCCL_HAS_INT128() && _CCCL_OS(LINUX) && !_CCCL_ARCH(ARM64)
+#endif // !defined(CCCL_DISABLE_FLOAT128_SUPPORT) && _CCCL_HAS_INT128() && _CCCL_OS(LINUX) && !_CCCL_HOST_ARCH(ARM64)
 
 // gcc does not allow to use q/Q floating point literals when __STRICT_ANSI__ is defined. They may be allowed by
 // -fext-numeric-literals, but there is no way to detect it in the preprocessor. The user is required to define

--- a/libcudacxx/include/cuda/std/__functional/hash.h
+++ b/libcudacxx/include/cuda/std/__functional/hash.h
@@ -574,7 +574,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<long double> : public __scalar_hash<lo
     {
       return 0;
     }
-#  if _CCCL_ARCH(X86_64) && _CCCL_OS(LINUX)
+#  if _CCCL_HOST_ARCH(X86_64) && _CCCL_OS(LINUX)
     // Zero out padding bits
     union
     {

--- a/libcudacxx/include/cuda/std/__limits/numeric_limits.h
+++ b/libcudacxx/include/cuda/std/__limits/numeric_limits.h
@@ -228,7 +228,7 @@ public:
   static constexpr bool is_bounded = true;
   static constexpr bool is_modulo  = !is_signed;
 
-#if (_CCCL_ARCH(X86_64) && _CCCL_OS(LINUX)) || defined(__pnacl__) || defined(__wasm__)
+#if (_CCCL_HOST_ARCH(X86_64) && _CCCL_OS(LINUX)) || defined(__pnacl__) || defined(__wasm__)
   static constexpr bool traps = true;
 #else
   static constexpr bool traps = false;

--- a/libcudacxx/include/cuda/std/__numeric/saturating_add.h
+++ b/libcudacxx/include/cuda/std/__numeric/saturating_add.h
@@ -60,7 +60,7 @@ template <class _Tp>
 #  else // ^^^ _CCCL_BUILTIN_ELEMENTWISE_ADD_SAT ^^^ / vvv !_CCCL_BUILTIN_ELEMENTWISE_ADD_SAT vvv
   if constexpr (is_signed_v<_Tp>)
   {
-#    if _CCCL_COMPILER(MSVC, >=, 19, 41) && _CCCL_ARCH(X86_64)
+#    if _CCCL_COMPILER(MSVC, >=, 19, 41) && _CCCL_HOST_ARCH(X86_64)
     if constexpr (sizeof(_Tp) == sizeof(int8_t))
     {
       return ::_sat_add_i8(__x, __y);
@@ -78,14 +78,14 @@ template <class _Tp>
       return ::_sat_add_i64(__x, __y);
     }
     else
-#    endif // _CCCL_COMPILER(MSVC, >=, 19, 41) && _CCCL_ARCH(X86_64)
+#    endif // _CCCL_COMPILER(MSVC, >=, 19, 41) && _CCCL_HOST_ARCH(X86_64)
     {
       return ::cuda::saturating_add_overflow(__x, __y).value;
     }
   }
   else
   {
-#    if _CCCL_COMPILER(MSVC, >=, 19, 41) && _CCCL_ARCH(X86_64)
+#    if _CCCL_COMPILER(MSVC, >=, 19, 41) && _CCCL_HOST_ARCH(X86_64)
     if constexpr (sizeof(_Tp) == sizeof(uint8_t))
     {
       return ::_sat_add_u8(__x, __y);
@@ -103,7 +103,7 @@ template <class _Tp>
       return ::_sat_add_u64(__x, __y);
     }
     else
-#    endif // _CCCL_COMPILER(MSVC, >=, 19, 41) && _CCCL_ARCH(X86_64)
+#    endif // _CCCL_COMPILER(MSVC, >=, 19, 41) && _CCCL_HOST_ARCH(X86_64)
     {
       return ::cuda::saturating_add_overflow(__x, __y).value;
     }

--- a/libcudacxx/include/cuda/std/__numeric/saturating_sub.h
+++ b/libcudacxx/include/cuda/std/__numeric/saturating_sub.h
@@ -60,7 +60,7 @@ template <class _Tp>
 #  else // ^^^ _CCCL_BUILTIN_ELEMENTWISE_SUB_SAT ^^^ / vvv !_CCCL_BUILTIN_ELEMENTWISE_SUB_SAT vvv
   if constexpr (is_signed_v<_Tp>)
   {
-#    if _CCCL_COMPILER(MSVC, >=, 19, 41) && _CCCL_ARCH(X86_64)
+#    if _CCCL_COMPILER(MSVC, >=, 19, 41) && _CCCL_HOST_ARCH(X86_64)
     if constexpr (sizeof(_Tp) == sizeof(int8_t))
     {
       return ::_sat_sub_i8(__x, __y);
@@ -78,14 +78,14 @@ template <class _Tp>
       return ::_sat_sub_i64(__x, __y);
     }
     else
-#    endif // _CCCL_COMPILER(MSVC, >=, 19, 41) && _CCCL_ARCH(X86_64)
+#    endif // _CCCL_COMPILER(MSVC, >=, 19, 41) && _CCCL_HOST_ARCH(X86_64)
     {
       return ::cuda::saturating_sub_overflow(__x, __y).value;
     }
   }
   else
   {
-#    if _CCCL_COMPILER(MSVC, >=, 19, 41) && _CCCL_ARCH(X86_64)
+#    if _CCCL_COMPILER(MSVC, >=, 19, 41) && _CCCL_HOST_ARCH(X86_64)
     if constexpr (sizeof(_Tp) == sizeof(uint8_t))
     {
       return ::_sat_sub_u8(__x, __y);
@@ -103,7 +103,7 @@ template <class _Tp>
       return ::_sat_sub_u64(__x, __y);
     }
     else
-#    endif // _CCCL_COMPILER(MSVC, >=, 19, 41) && _CCCL_ARCH(X86_64)
+#    endif // _CCCL_COMPILER(MSVC, >=, 19, 41) && _CCCL_HOST_ARCH(X86_64)
     {
       return ::cuda::saturating_sub_overflow(__x, __y).value;
     }

--- a/libcudacxx/include/cuda/std/__thread/threading_support.h
+++ b/libcudacxx/include/cuda/std/__thread/threading_support.h
@@ -43,13 +43,13 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #define _LIBCUDACXX_POLLING_COUNT 16
 
-#if _CCCL_ARCH(ARM64) && _CCCL_OS(LINUX)
+#if _CCCL_HOST_ARCH(ARM64) && _CCCL_OS(LINUX)
 #  define __LIBCUDACXX_ASM_THREAD_YIELD (asm volatile("yield" :: :);)
-#elif _CCCL_ARCH(X86_64) && _CCCL_OS(LINUX)
+#elif _CCCL_HOST_ARCH(X86_64) && _CCCL_OS(LINUX)
 #  define __LIBCUDACXX_ASM_THREAD_YIELD (asm volatile("pause" :: :);)
-#else // ^^^  _CCCL_ARCH(X86_64) ^^^ / vvv ! _CCCL_ARCH(X86_64) vvv
+#else // ^^^  _CCCL_HOST_ARCH(X86_64) ^^^ / vvv ! _CCCL_HOST_ARCH(X86_64) vvv
 #  define __LIBCUDACXX_ASM_THREAD_YIELD (;)
-#endif // ! _CCCL_ARCH(X86_64)
+#endif // ! _CCCL_HOST_ARCH(X86_64)
 
 _CCCL_HOST_DEVICE_API inline void __cccl_thread_yield_processor()
 {

--- a/libcudacxx/include/cuda/std/__thread/threading_support_win32.h
+++ b/libcudacxx/include/cuda/std/__thread/threading_support_win32.h
@@ -35,7 +35,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 using __cccl_mutex_t = void*;
 #  define _LIBCUDACXX_MUTEX_INITIALIZER 0
 
-#  if _CCCL_ARCH(ARM64) || _CCCL_ARCH(X86_64)
+#  if _CCCL_HOST_ARCH(ARM64) || _CCCL_HOST_ARCH(X86_64)
 using __cccl_recursive_mutex_t = void* [5];
 #  else
 #    error Unsupported architecture

--- a/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/iterator_traits.compile.pass.cpp
@@ -30,9 +30,9 @@ TEST_FUNC void test()
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, void>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
-#if !_CCCL_ARCH(ARM64) // There are some compiler issues on arm compilers
+#if !_CCCL_HOST_ARCH(ARM64) // There are some compiler issues on arm compilers
     static_assert(cuda::std::output_iterator<Iter, int>);
-#endif // !_CCCL_ARCH(ARM64)
+#endif // !_CCCL_HOST_ARCH(ARM64)
     static_assert(cuda::std::__has_random_access_traversal<Iter>);
   }
 
@@ -42,9 +42,9 @@ TEST_FUNC void test()
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, void>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, signed char>);
-#if !_CCCL_ARCH(ARM64) // There are some compiler issues on arm compilers
+#if !_CCCL_HOST_ARCH(ARM64) // There are some compiler issues on arm compilers
     static_assert(cuda::std::output_iterator<Iter, int>);
-#endif // !_CCCL_ARCH(ARM64)
+#endif // !_CCCL_HOST_ARCH(ARM64)
     static_assert(cuda::std::__has_random_access_traversal<Iter>);
   }
 }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/member_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/member_typedefs.compile.pass.cpp
@@ -26,9 +26,9 @@ TEST_FUNC void test()
     static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::value_type, void>);
     static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::ptrdiff_t>);
-#if !_CCCL_ARCH(ARM64) // There are some compiler issues on arm compilers
+#if !_CCCL_HOST_ARCH(ARM64) // There are some compiler issues on arm compilers
     static_assert(cuda::std::output_iterator<Iter, int>);
-#endif // !_CCCL_ARCH(ARM64)
+#endif // !_CCCL_HOST_ARCH(ARM64)
     static_assert(cuda::std::is_trivially_copyable_v<Iter>);
   }
 
@@ -38,9 +38,9 @@ TEST_FUNC void test()
     static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::value_type, void>);
     static_assert(cuda::std::same_as<Iter::difference_type, signed char>);
-#if !_CCCL_ARCH(ARM64) // There are some compiler issues on arm compilers
+#if !_CCCL_HOST_ARCH(ARM64) // There are some compiler issues on arm compilers
     static_assert(cuda::std::output_iterator<Iter, int>);
-#endif // !_CCCL_ARCH(ARM64)
+#endif // !_CCCL_HOST_ARCH(ARM64)
     static_assert(cuda::std::is_trivially_copyable_v<Iter>);
   }
 }

--- a/libcudacxx/test/libcudacxx/libcxx/macros/architecture.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/macros/architecture.compile.pass.cpp
@@ -35,37 +35,37 @@
 #  endif // CCCL_HOST_ARCH(X86_64)
 #endif // !X86_64
 
-#if CCCL_HOST_ARCH(ARM64) != _CCCL_ARCH(ARM64)
-#  error "CCCL_HOST_ARCH(ARM64) does not match _CCCL_ARCH(ARM64)"
-#endif // CCCL_HOST_ARCH(ARM64) != _CCCL_ARCH(ARM64)
+#if CCCL_HOST_ARCH(ARM64) != _CCCL_HOST_ARCH(ARM64)
+#  error "CCCL_HOST_ARCH(ARM64) does not match _CCCL_HOST_ARCH(ARM64)"
+#endif // CCCL_HOST_ARCH(ARM64) != _CCCL_HOST_ARCH(ARM64)
 
-#if CCCL_HOST_ARCH(X86_64) != _CCCL_ARCH(X86_64)
-#  error "CCCL_HOST_ARCH(X86_64) does not match _CCCL_ARCH(X86_64)"
-#endif // CCCL_HOST_ARCH(X86_64) != _CCCL_ARCH(X86_64)
+#if CCCL_HOST_ARCH(X86_64) != _CCCL_HOST_ARCH(X86_64)
+#  error "CCCL_HOST_ARCH(X86_64) does not match _CCCL_HOST_ARCH(X86_64)"
+#endif // CCCL_HOST_ARCH(X86_64) != _CCCL_HOST_ARCH(X86_64)
 
 #undef ARM64
 #undef X86_64
 
 #if !_CCCL_COMPILER(NVRTC)
-#  if _CCCL_ARCH(X86_64)
+#  if _CCCL_HOST_ARCH(X86_64)
 #    if _CCCL_COMPILER(MSVC)
 #      include <intrin.h>
 #    elif _CCCL_COMPILER(GCC) || _CCCL_COMPILER(CLANG)
 #      include <cpuid.h>
 #    endif // _CCCL_COMPILER(GCC) || _CCCL_COMPILER(CLANG)
-#  endif // _CCCL_ARCH(X86_64)
+#  endif // _CCCL_HOST_ARCH(X86_64)
 
 #  if !_CCCL_COMPILER(NVHPC) // nvbug5395777
-#    if _CCCL_ARCH(ARM64) && defined(__ARM_ACLE)
+#    if _CCCL_HOST_ARCH(ARM64) && defined(__ARM_ACLE)
 #      include <arm_acle.h>
-#    endif // _CCCL_ARCH(ARM64) && defined(__ARM_ACLE)
+#    endif // _CCCL_HOST_ARCH(ARM64) && defined(__ARM_ACLE)
 #  endif // !_CCCL_COMPILER(NVHPC)
 #endif // _CCCL_HOSTED()
 
 int main(int, char**)
 {
-  static_assert(CCCL_HOST_ARCH(ARM64) == _CCCL_ARCH(ARM64));
-  static_assert(CCCL_HOST_ARCH(X86_64) == _CCCL_ARCH(X86_64));
+  static_assert(CCCL_HOST_ARCH(ARM64) == _CCCL_HOST_ARCH(ARM64));
+  static_assert(CCCL_HOST_ARCH(X86_64) == _CCCL_HOST_ARCH(X86_64));
   static_assert(sizeof(void*) == 8);
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/libcxx/macros/architecture.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/macros/architecture.compile.pass.cpp
@@ -7,8 +7,44 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cuda/std/__cccl/architecture.h>
-#include <cuda/std/__cccl/compiler.h>
+#include <cuda/std/version>
+
+// Define these macros to true values. This tests that CCCL_ARCH(FOO) is resilient against
+// macro-expansion in case the user defines FOO, because if CCCL_ARCH() expands the macro, then
+// the below assertions should fire.
+#define ARM64  1
+#define X86_64 1
+
+#if (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC))
+#  if !CCCL_ARCH(ARM64)
+#    error "ARM64 NOT detected when it SHOULD be"
+#  endif // !CCCL_ARCH(ARM64)
+#else // ^^^ ARM64 ^^^ / vvv !ARM64 vvv
+#  if CCCL_ARCH(ARM64)
+#    error "ARM64 detected when it SHOULDN'T be"
+#  endif // CCCL_ARCH(ARM64)
+#endif // !ARM64
+
+#if (defined(_M_X64) && !defined(_M_ARM64EC)) || defined(__amd64__) || defined(__x86_64__)
+#  if !CCCL_ARCH(X86_64)
+#    error "X86_64 NOT detected when it SHOULD be"
+#  endif // !CCCL_ARCH(X86_64)
+#else // ^^^ X86_64 ^^^ / vvv !X86_64 vvv
+#  if CCCL_ARCH(X86_64)
+#    error "X86_64 detected when it SHOULDN'T be"
+#  endif // CCCL_ARCH(X86_64)
+#endif // !X86_64
+
+#if CCCL_ARCH(ARM64) != _CCCL_ARCH(ARM64)
+#  error "CCCL_ARCH(ARM64) does not match _CCCL_ARCH(ARM64)"
+#endif // CCCL_ARCH(ARM64) != _CCCL_ARCH(ARM64)
+
+#if CCCL_ARCH(X86_64) != _CCCL_ARCH(X86_64)
+#  error "CCCL_ARCH(X86_64) does not match _CCCL_ARCH(X86_64)"
+#endif // CCCL_ARCH(X86_64) != _CCCL_ARCH(X86_64)
+
+#undef ARM64
+#undef X86_64
 
 #if !_CCCL_COMPILER(NVRTC)
 #  if _CCCL_ARCH(X86_64)
@@ -28,6 +64,8 @@
 
 int main(int, char**)
 {
+  static_assert(CCCL_ARCH(ARM64) == _CCCL_ARCH(ARM64));
+  static_assert(CCCL_ARCH(X86_64) == _CCCL_ARCH(X86_64));
   static_assert(sizeof(void*) == 8);
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/libcxx/macros/architecture.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/macros/architecture.compile.pass.cpp
@@ -9,39 +9,39 @@
 
 #include <cuda/std/version>
 
-// Define these macros to true values. This tests that CCCL_ARCH(FOO) is resilient against
-// macro-expansion in case the user defines FOO, because if CCCL_ARCH() expands the macro, then
+// Define these macros to true values. This tests that CCCL_HOST_ARCH(FOO) is resilient against
+// macro-expansion in case the user defines FOO, because if CCCL_HOST_ARCH() expands the macro, then
 // the below assertions should fire.
 #define ARM64  1
 #define X86_64 1
 
 #if (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC))
-#  if !CCCL_ARCH(ARM64)
+#  if !CCCL_HOST_ARCH(ARM64)
 #    error "ARM64 NOT detected when it SHOULD be"
-#  endif // !CCCL_ARCH(ARM64)
+#  endif // !CCCL_HOST_ARCH(ARM64)
 #else // ^^^ ARM64 ^^^ / vvv !ARM64 vvv
-#  if CCCL_ARCH(ARM64)
+#  if CCCL_HOST_ARCH(ARM64)
 #    error "ARM64 detected when it SHOULDN'T be"
-#  endif // CCCL_ARCH(ARM64)
+#  endif // CCCL_HOST_ARCH(ARM64)
 #endif // !ARM64
 
 #if (defined(_M_X64) && !defined(_M_ARM64EC)) || defined(__amd64__) || defined(__x86_64__)
-#  if !CCCL_ARCH(X86_64)
+#  if !CCCL_HOST_ARCH(X86_64)
 #    error "X86_64 NOT detected when it SHOULD be"
-#  endif // !CCCL_ARCH(X86_64)
+#  endif // !CCCL_HOST_ARCH(X86_64)
 #else // ^^^ X86_64 ^^^ / vvv !X86_64 vvv
-#  if CCCL_ARCH(X86_64)
+#  if CCCL_HOST_ARCH(X86_64)
 #    error "X86_64 detected when it SHOULDN'T be"
-#  endif // CCCL_ARCH(X86_64)
+#  endif // CCCL_HOST_ARCH(X86_64)
 #endif // !X86_64
 
-#if CCCL_ARCH(ARM64) != _CCCL_ARCH(ARM64)
-#  error "CCCL_ARCH(ARM64) does not match _CCCL_ARCH(ARM64)"
-#endif // CCCL_ARCH(ARM64) != _CCCL_ARCH(ARM64)
+#if CCCL_HOST_ARCH(ARM64) != _CCCL_ARCH(ARM64)
+#  error "CCCL_HOST_ARCH(ARM64) does not match _CCCL_ARCH(ARM64)"
+#endif // CCCL_HOST_ARCH(ARM64) != _CCCL_ARCH(ARM64)
 
-#if CCCL_ARCH(X86_64) != _CCCL_ARCH(X86_64)
-#  error "CCCL_ARCH(X86_64) does not match _CCCL_ARCH(X86_64)"
-#endif // CCCL_ARCH(X86_64) != _CCCL_ARCH(X86_64)
+#if CCCL_HOST_ARCH(X86_64) != _CCCL_ARCH(X86_64)
+#  error "CCCL_HOST_ARCH(X86_64) does not match _CCCL_ARCH(X86_64)"
+#endif // CCCL_HOST_ARCH(X86_64) != _CCCL_ARCH(X86_64)
 
 #undef ARM64
 #undef X86_64
@@ -64,8 +64,8 @@
 
 int main(int, char**)
 {
-  static_assert(CCCL_ARCH(ARM64) == _CCCL_ARCH(ARM64));
-  static_assert(CCCL_ARCH(X86_64) == _CCCL_ARCH(X86_64));
+  static_assert(CCCL_HOST_ARCH(ARM64) == _CCCL_ARCH(ARM64));
+  static_assert(CCCL_HOST_ARCH(X86_64) == _CCCL_ARCH(X86_64));
   static_assert(sizeof(void*) == 8);
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp
@@ -17,7 +17,7 @@
 
 #include "test_macros.h"
 
-#if _CCCL_ARCH(X86_64) && _CCCL_OS(LINUX)
+#if _CCCL_HOST_ARCH(X86_64) && _CCCL_OS(LINUX)
 static const bool integral_types_trap = true;
 #else
 static const bool integral_types_trap = false;


### PR DESCRIPTION
## Description

In a very similar way of `CCCL_OS`, the PR introduces the public version of `_CCCL_ARCH` to identify the host cpu architecture in a reliable way, including ARM64 emulation on Windows.

Partially address https://github.com/NVIDIA/cccl/issues/8247