### PR TITLE
CRITICAL: Add PDL guard back missed in #9247

### DIFF
--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -600,7 +600,8 @@ private:
     {
       return error;
     }
-    const bool use_pdl = cc >= ::cuda::compute_capability{9, 0};
+    constexpr OffsetT pdl_max_items = static_cast<OffsetT>(1) << 24;
+    const bool use_pdl              = num_items <= pdl_max_items && cc >= ::cuda::compute_capability{9, 0};
 
     const size_t num_counter_items = static_cast<size_t>(num_portions) * num_passes;
     const size_t num_bin_items     = static_cast<size_t>(num_passes) * RADIX_DIGITS;


### PR DESCRIPTION
In #9247 I said the following:

https://github.com/NVIDIA/cccl/pull/9247#issuecomment-4712933066

and I showed these results:

https://github.com/NVIDIA/cccl/pull/9247#issuecomment-4713003401


But I forgot to push the commit in the current PR hence the results that really reflect that ToT are:

https://github.com/NVIDIA/cccl/pull/9247#issuecomment-4695915465

We need to add the guard back and I missed that before merging. Let's merge asap so bad perf doesn't leak into production.

