### PR TITLE
Duplicate radix sort dispatch to deprecate `DispatchRadixSort`

### DIFF
--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -146,8 +146,7 @@ template <SortOrder Order,
             OffsetT,
             DecomposerT>,
           typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
-// FIXME(bgruber): enable deprecation
-struct /*CCCL_DEPRECATED_BECAUSE("Please use DeviceRadixSort"*/ DispatchRadixSort
+struct CCCL_DEPRECATED_BECAUSE("Please use DeviceRadixSort") DispatchRadixSort
 {
   //------------------------------------------------------------------------------
   // Constants
@@ -1031,7 +1030,7 @@ public:
     d_keys.selector ^= 1;
 
     // Copy values if necessary
-    if (!KEYS_ONLY)
+    if constexpr (!KEYS_ONLY)
     {
 #ifdef CUB_DEBUG_LOG
       _CubLog("Invoking async copy of %lld values on stream %lld\n", (long long) num_items, (long long) stream);
@@ -1213,11 +1212,794 @@ public:
 
 namespace detail::radix_sort
 {
-// not used, since we do not need to call Dispatch
-struct fake_policy
+template <typename UpsweepKernelT, typename ScanKernelT, typename DownsweepKernelT, typename OffsetT>
+struct pass_config
 {
-  using MaxPolicy = void;
+  UpsweepKernelT upsweep_kernel;
+  KernelConfig upsweep_config;
+  ScanKernelT scan_kernel;
+  KernelConfig scan_config;
+  DownsweepKernelT downsweep_kernel;
+  KernelConfig downsweep_config;
+  int radix_bits;
+  int radix_digits;
+  int max_downsweep_grid_size;
+  GridEvenShare<OffsetT> even_share;
+
+  template <typename KernelLauncherFactory>
+  CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t init(
+    UpsweepKernelT upsweep_kern,
+    ScanKernelT scan_kern,
+    DownsweepKernelT downsweep_kern,
+    int sm_count,
+    OffsetT num_items,
+    int pass_radix_bits,
+    RadixSortUpsweepPolicy upsweep_policy,
+    ScanPolicy scan_policy,
+    RadixSortDownsweepPolicy downsweep_policy,
+    KernelLauncherFactory launcher_factory)
+  {
+    this->upsweep_kernel   = upsweep_kern;
+    this->scan_kernel      = scan_kern;
+    this->downsweep_kernel = downsweep_kern;
+    this->radix_bits       = pass_radix_bits;
+    radix_digits           = 1 << radix_bits;
+
+    if (const auto error = CubDebug(upsweep_config.__init(upsweep_kernel, upsweep_policy, launcher_factory)))
+    {
+      return error;
+    }
+
+    if (const auto error = CubDebug(scan_config.__init(scan_kernel, scan_policy.lookback, launcher_factory)))
+    {
+      return error;
+    }
+
+    if (const auto error = CubDebug(downsweep_config.__init(downsweep_kernel, downsweep_policy, launcher_factory)))
+    {
+      return error;
+    }
+
+    max_downsweep_grid_size = (downsweep_config.sm_occupancy * sm_count) * detail::subscription_factor;
+
+    even_share.DispatchInit(
+      num_items, max_downsweep_grid_size, ::cuda::std::max(downsweep_config.tile_size, upsweep_config.tile_size));
+
+    return cudaSuccess;
+  }
 };
+
+template <typename SingleTileKernelT,
+          typename KeyT,
+          typename ValueT,
+          typename OffsetT,
+          typename DecomposerT,
+          typename KernelLauncherFactory>
+CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t invoke_single_tile(
+  SingleTileKernelT single_tile_kernel,
+  RadixSortDownsweepPolicy policy,
+  void* d_temp_storage,
+  size_t& temp_storage_bytes,
+  DoubleBuffer<KeyT>& d_keys,
+  DoubleBuffer<ValueT>& d_values,
+  OffsetT num_items,
+  int begin_bit,
+  int end_bit,
+  cudaStream_t stream,
+  DecomposerT decomposer,
+  KernelLauncherFactory launcher_factory)
+{
+  // Return if the caller is simply requesting the size of the storage allocation
+  if (d_temp_storage == nullptr)
+  {
+    temp_storage_bytes = 1;
+    return cudaSuccess;
+  }
+
+  // Log single_tile_kernel configuration
+#ifdef CUB_DEBUG_LOG
+  _CubLog("Invoking single_tile_kernel<<<%d, %d, 0, %lld>>>(), %d items per thread, %d SM occupancy, current bit "
+          "%d, bit_grain %d\n",
+          1,
+          policy.threads_per_block,
+          (long long) stream,
+          policy.items_per_thread,
+          1,
+          begin_bit,
+          policy.radix_bits);
+#endif
+
+  // Invoke upsweep_kernel with same grid size as downsweep_kernel
+  if (const auto error = CubDebug(
+        launcher_factory(1, policy.threads_per_block, 0, stream)
+          .doit(single_tile_kernel,
+                d_keys.Current(),
+                d_keys.Alternate(),
+                d_values.Current(),
+                d_values.Alternate(),
+                num_items,
+                begin_bit,
+                end_bit,
+                decomposer)))
+  {
+    return error;
+  }
+
+  // Check for failure to launch
+  if (const auto error = CubDebug(cudaPeekAtLastError()))
+  {
+    return error;
+  }
+
+  // Sync the stream if specified to flush runtime errors
+  if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+  {
+    return error;
+  }
+
+  // Update selector
+  d_keys.selector ^= 1;
+  d_values.selector ^= 1;
+
+  return cudaSuccess;
+}
+
+template <typename KeyT, typename ValueT, typename OffsetT, typename KernelSource>
+CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_copy(
+  void* d_temp_storage,
+  size_t& temp_storage_bytes,
+  DoubleBuffer<KeyT>& d_keys,
+  DoubleBuffer<ValueT>& d_values,
+  OffsetT num_items,
+  cudaStream_t stream,
+  KernelSource kernel_source)
+{
+  static constexpr bool keys_only = ::cuda::std::is_same_v<ValueT, NullType>;
+
+  // is_overwrite_okay == false here
+  // Return the number of temporary bytes if requested
+  if (d_temp_storage == nullptr)
+  {
+    temp_storage_bytes = 1;
+    return cudaSuccess;
+  }
+
+// Copy keys
+#ifdef CUB_DEBUG_LOG
+  _CubLog("Invoking async copy of %lld keys on stream %lld\n", (long long) num_items, (long long) stream);
+#endif
+  if (const auto error = CubDebug(cudaMemcpyAsync(
+        d_keys.Alternate(), d_keys.Current(), num_items * kernel_source.KeySize(), cudaMemcpyDefault, stream)))
+  {
+    return error;
+  }
+
+  if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+  {
+    return error;
+  }
+  d_keys.selector ^= 1;
+
+  // Copy values if necessary
+  if constexpr (!keys_only)
+  {
+#ifdef CUB_DEBUG_LOG
+    _CubLog("Invoking async copy of %lld values on stream %lld\n", (long long) num_items, (long long) stream);
+#endif
+    if (const auto error = CubDebug(cudaMemcpyAsync(
+          d_values.Alternate(), d_values.Current(), num_items * kernel_source.ValueSize(), cudaMemcpyDefault, stream)))
+    {
+      return error;
+    }
+
+    if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+    {
+      return error;
+    }
+  }
+  d_values.selector ^= 1;
+
+  return cudaSuccess;
+}
+
+template <typename KeyT,
+          typename ValueT,
+          typename OffsetT,
+          typename DecomposerT,
+          typename PassConfigT,
+          typename KernelLauncherFactory>
+CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_pass(
+  const KeyT* d_keys_in,
+  KeyT* d_keys_out,
+  const ValueT* d_values_in,
+  ValueT* d_values_out,
+  OffsetT* d_spine,
+  int /*spine_length*/,
+  int& current_bit,
+  PassConfigT& pass_config,
+  int end_bit,
+  OffsetT num_items,
+  DecomposerT decomposer,
+  KernelLauncherFactory launcher_factory,
+  cudaStream_t stream)
+{
+  int pass_bits = ::cuda::std::min(pass_config.radix_bits, end_bit - current_bit);
+
+// Log upsweep_kernel configuration
+#ifdef CUB_DEBUG_LOG
+  _CubLog("Invoking upsweep_kernel<<<%d, %d, 0, %lld>>>(), %d items per thread, %d SM occupancy, current bit %d, "
+          "bit_grain %d\n",
+          pass_config.even_share.grid_size,
+          pass_config.upsweep_config.threads_per_block,
+          (long long) stream,
+          pass_config.upsweep_config.items_per_thread,
+          pass_config.upsweep_config.sm_occupancy,
+          current_bit,
+          pass_bits);
+#endif
+
+  // Spine length written by the upsweep kernel in the current pass.
+  int pass_spine_length = pass_config.even_share.grid_size * pass_config.radix_digits;
+
+  // Invoke upsweep_kernel with same grid size as downsweep_kernel
+  if (const auto error = CubDebug(
+        launcher_factory(pass_config.even_share.grid_size, pass_config.upsweep_config.threads_per_block, 0, stream)
+          .doit(pass_config.upsweep_kernel,
+                d_keys_in,
+                d_spine,
+                num_items,
+                current_bit,
+                pass_bits,
+                pass_config.even_share,
+                decomposer)))
+  {
+    return error;
+  }
+
+  // Check for failure to launch
+  if (const auto error = CubDebug(cudaPeekAtLastError()))
+  {
+    return error;
+  }
+
+  // Sync the stream if specified to flush runtime errors
+  if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+  {
+    return error;
+  }
+
+// Log scan_kernel configuration
+#ifdef CUB_DEBUG_LOG
+  _CubLog("Invoking scan_kernel<<<%d, %d, 0, %lld>>>(), %d items per thread\n",
+          1,
+          pass_config.scan_config.threads_per_block,
+          (long long) stream,
+          pass_config.scan_config.items_per_thread);
+#endif
+
+  // Invoke scan_kernel
+  if (const auto error = CubDebug(launcher_factory(1, pass_config.scan_config.threads_per_block, 0, stream)
+                                    .doit(pass_config.scan_kernel, d_spine, pass_spine_length)))
+  {
+    return error;
+  }
+
+  // Check for failure to launch
+  if (const auto error = CubDebug(cudaPeekAtLastError()))
+  {
+    return error;
+  }
+
+  // Sync the stream if specified to flush runtime errors
+  if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+  {
+    return error;
+  }
+
+// Log downsweep_kernel configuration
+#ifdef CUB_DEBUG_LOG
+  _CubLog("Invoking downsweep_kernel<<<%d, %d, 0, %lld>>>(), %d items per thread, %d SM occupancy\n",
+          pass_config.even_share.grid_size,
+          pass_config.downsweep_config.threads_per_block,
+          (long long) stream,
+          pass_config.downsweep_config.items_per_thread,
+          pass_config.downsweep_config.sm_occupancy);
+#endif
+
+  // Invoke downsweep_kernel
+  if (const auto error = CubDebug(
+        launcher_factory(pass_config.even_share.grid_size, pass_config.downsweep_config.threads_per_block, 0, stream)
+          .doit(pass_config.downsweep_kernel,
+                d_keys_in,
+                d_keys_out,
+                d_values_in,
+                d_values_out,
+                d_spine,
+                num_items,
+                current_bit,
+                pass_bits,
+                pass_config.even_share,
+                decomposer)))
+  {
+    return error;
+  }
+
+  // Check for failure to launch
+  if (const auto error = CubDebug(cudaPeekAtLastError()))
+  {
+    return error;
+  }
+
+  // Sync the stream if specified to flush runtime errors
+  if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+  {
+    return error;
+  }
+
+  // Update current bit
+  current_bit += pass_bits;
+
+  return cudaSuccess;
+}
+
+template <typename UpsweepKernelT,
+          typename ScanKernelT,
+          typename DownsweepKernelT,
+          typename KeyT,
+          typename ValueT,
+          typename OffsetT,
+          typename DecomposerT,
+          typename KernelSource,
+          typename KernelLauncherFactory>
+CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t invoke_passes(
+  UpsweepKernelT upsweep_kernel,
+  UpsweepKernelT alt_upsweep_kernel,
+  ScanKernelT scan_kernel,
+  DownsweepKernelT downsweep_kernel,
+  DownsweepKernelT alt_downsweep_kernel,
+  const RadixSortPolicy& policy,
+  void* d_temp_storage,
+  size_t& temp_storage_bytes,
+  DoubleBuffer<KeyT>& d_keys,
+  DoubleBuffer<ValueT>& d_values,
+  OffsetT num_items,
+  int begin_bit,
+  int end_bit,
+  bool is_overwrite_okay,
+  cudaStream_t stream,
+  DecomposerT decomposer,
+  KernelSource kernel_source,
+  KernelLauncherFactory launcher_factory)
+{
+  static constexpr bool keys_only = ::cuda::std::is_same_v<ValueT, NullType>;
+
+  // Get device ordinal
+  int device_ordinal;
+  if (const auto error = CubDebug(cudaGetDevice(&device_ordinal)))
+  {
+    return error;
+  }
+
+  // Get SM count
+  int sm_count;
+  if (const auto error = CubDebug(cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, device_ordinal)))
+  {
+    return error;
+  }
+
+  // Init regular and alternate-digit kernel configurations
+  pass_config<UpsweepKernelT, ScanKernelT, DownsweepKernelT, OffsetT> pc, alt_pc;
+  if (const auto error = pc.init(
+        upsweep_kernel,
+        scan_kernel,
+        downsweep_kernel,
+        sm_count,
+        num_items,
+        policy.downsweep.radix_bits,
+        policy.upsweep,
+        policy.scan,
+        policy.downsweep,
+        launcher_factory))
+  {
+    return error;
+  }
+
+  if (const auto error = alt_pc.init(
+        alt_upsweep_kernel,
+        scan_kernel,
+        alt_downsweep_kernel,
+        sm_count,
+        num_items,
+        policy.alt_downsweep.radix_bits,
+        policy.alt_upsweep,
+        policy.scan,
+        policy.alt_downsweep,
+        launcher_factory))
+  {
+    return error;
+  }
+
+  // Get maximum spine length
+  int max_grid_size = ::cuda::std::max(pc.max_downsweep_grid_size, alt_pc.max_downsweep_grid_size);
+  int spine_length  = (max_grid_size * pc.radix_digits) + pc.scan_config.tile_size;
+
+  // Temporary storage allocation requirements
+  void* allocations[3]       = {};
+  size_t allocation_sizes[3] = {
+    // bytes needed for privatized block digit histograms
+    spine_length * sizeof(OffsetT),
+
+    // bytes needed for 3rd keys buffer
+    (is_overwrite_okay) ? 0 : num_items * kernel_source.KeySize(),
+
+    // bytes needed for 3rd values buffer
+    (is_overwrite_okay || (keys_only)) ? 0 : num_items * kernel_source.ValueSize(),
+  };
+
+  // Alias the temporary allocations from the single storage blob (or compute the necessary size of the blob)
+  if (const auto error =
+        CubDebug(detail::alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))
+  {
+    return error;
+  }
+
+  // Return if the caller is simply requesting the size of the storage allocation
+  if (d_temp_storage == nullptr)
+  {
+    return cudaSuccess;
+  }
+
+  // Pass planning.  Run passes of the alternate digit-size configuration until we have an even multiple of our
+  // preferred digit size
+  int num_bits           = end_bit - begin_bit;
+  int num_passes         = ::cuda::ceil_div(num_bits, pc.radix_bits);
+  bool is_num_passes_odd = num_passes & 1;
+  int max_alt_passes     = (num_passes * pc.radix_bits) - num_bits;
+  int alt_end_bit        = ::cuda::std::min(end_bit, begin_bit + (max_alt_passes * alt_pc.radix_bits));
+
+  // Alias the temporary storage allocations
+  OffsetT* d_spine = static_cast<OffsetT*>(allocations[0]);
+
+  DoubleBuffer<KeyT> d_keys_remaining_passes(
+    (is_overwrite_okay || is_num_passes_odd) ? d_keys.Alternate() : static_cast<KeyT*>(allocations[1]),
+    (is_overwrite_okay)   ? d_keys.Current()
+    : (is_num_passes_odd) ? static_cast<KeyT*>(allocations[1])
+                          : d_keys.Alternate());
+
+  DoubleBuffer<ValueT> d_values_remaining_passes(
+    (is_overwrite_okay || is_num_passes_odd) ? d_values.Alternate() : static_cast<ValueT*>(allocations[2]),
+    (is_overwrite_okay)   ? d_values.Current()
+    : (is_num_passes_odd) ? static_cast<ValueT*>(allocations[2])
+                          : d_values.Alternate());
+
+  // Run first pass, consuming from the input's current buffers
+  int current_bit = begin_bit;
+  if (const auto error = CubDebug(invoke_pass(
+        d_keys.Current(),
+        d_keys_remaining_passes.Current(),
+        d_values.Current(),
+        d_values_remaining_passes.Current(),
+        d_spine,
+        spine_length,
+        current_bit,
+        (current_bit < alt_end_bit) ? alt_pc : pc,
+        end_bit,
+        num_items,
+        decomposer,
+        launcher_factory,
+        stream)))
+  {
+    return error;
+  }
+
+  // Run remaining passes
+  while (current_bit < end_bit)
+  {
+    if (const auto error = CubDebug(invoke_pass(
+          d_keys_remaining_passes.d_buffers[d_keys_remaining_passes.selector],
+          d_keys_remaining_passes.d_buffers[d_keys_remaining_passes.selector ^ 1],
+          d_values_remaining_passes.d_buffers[d_keys_remaining_passes.selector],
+          d_values_remaining_passes.d_buffers[d_keys_remaining_passes.selector ^ 1],
+          d_spine,
+          spine_length,
+          current_bit,
+          (current_bit < alt_end_bit) ? alt_pc : pc,
+          end_bit,
+          num_items,
+          decomposer,
+          launcher_factory,
+          stream)))
+    {
+      return error;
+    }
+
+    // Invert selectors
+    d_keys_remaining_passes.selector ^= 1;
+    d_values_remaining_passes.selector ^= 1;
+  }
+
+  // Update selector
+  if (!is_overwrite_okay)
+  {
+    num_passes = 1; // Sorted data always ends up in the other vector
+  }
+
+  d_keys.selector   = (d_keys.selector + num_passes) & 1;
+  d_values.selector = (d_values.selector + num_passes) & 1;
+
+  return cudaSuccess;
+}
+
+template <typename KeyT,
+          typename ValueT,
+          typename OffsetT,
+          typename DecomposerT,
+          typename KernelSource,
+          typename KernelLauncherFactory>
+CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_onesweep(
+  RadixSortPolicy policy,
+  void* d_temp_storage,
+  size_t& temp_storage_bytes,
+  DoubleBuffer<KeyT>& d_keys,
+  DoubleBuffer<ValueT>& d_values,
+  OffsetT num_items,
+  int begin_bit,
+  int end_bit,
+  bool is_overwrite_okay,
+  cudaStream_t stream,
+  DecomposerT decomposer,
+  KernelSource kernel_source,
+  KernelLauncherFactory launcher_factory)
+{
+  static constexpr bool KEYS_ONLY = ::cuda::std::is_same_v<ValueT, NullType>;
+
+  // PortionOffsetT is used for offsets within a portion, and must be signed.
+  using PortionOffsetT = int;
+  using AtomicOffsetT  = PortionOffsetT;
+
+  // compute temporary storage size
+  const int RADIX_BITS                = policy.onesweep.radix_bits;
+  const int RADIX_DIGITS              = 1 << RADIX_BITS;
+  const int ONESWEEP_ITEMS_PER_THREAD = policy.onesweep.items_per_thread;
+  const int ONESWEEP_BLOCK_THREADS    = policy.onesweep.threads_per_block;
+  const int ONESWEEP_TILE_ITEMS       = ONESWEEP_ITEMS_PER_THREAD * ONESWEEP_BLOCK_THREADS;
+  // portions handle inputs with >=2**30 elements, due to the way lookback works
+  // for testing purposes, one portion is <= 2**28 elements
+  const PortionOffsetT PORTION_SIZE = ((1 << 28) - 1) / ONESWEEP_TILE_ITEMS * ONESWEEP_TILE_ITEMS;
+  int num_passes                    = ::cuda::ceil_div(end_bit - begin_bit, RADIX_BITS);
+  OffsetT num_portions              = static_cast<OffsetT>(::cuda::ceil_div(num_items, PORTION_SIZE));
+  PortionOffsetT max_num_blocks     = ::cuda::ceil_div(
+    static_cast<int>(::cuda::std::min(num_items, static_cast<OffsetT>(PORTION_SIZE))), ONESWEEP_TILE_ITEMS);
+
+  size_t value_size         = KEYS_ONLY ? 0 : kernel_source.ValueSize();
+  size_t allocation_sizes[] = {
+    // bins
+    num_portions * num_passes * RADIX_DIGITS * sizeof(OffsetT),
+    // lookback
+    max_num_blocks * RADIX_DIGITS * sizeof(AtomicOffsetT),
+    // extra key buffer
+    is_overwrite_okay || num_passes <= 1 ? 0 : num_items * kernel_source.KeySize(),
+    // extra value buffer
+    is_overwrite_okay || num_passes <= 1 ? 0 : num_items * value_size,
+    // counters
+    num_portions * num_passes * sizeof(AtomicOffsetT),
+  };
+  constexpr int NUM_ALLOCATIONS      = sizeof(allocation_sizes) / sizeof(allocation_sizes[0]);
+  void* allocations[NUM_ALLOCATIONS] = {};
+  if (const auto error =
+        detail::alias_temporaries<NUM_ALLOCATIONS>(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes))
+  {
+    return error;
+  }
+
+  // just return if no temporary storage is provided
+  if (d_temp_storage == nullptr)
+  {
+    return cudaSuccess;
+  }
+
+  OffsetT* d_bins           = (OffsetT*) allocations[0];
+  AtomicOffsetT* d_lookback = (AtomicOffsetT*) allocations[1];
+  KeyT* d_keys_tmp2         = (KeyT*) allocations[2];
+  ValueT* d_values_tmp2     = (ValueT*) allocations[3];
+  AtomicOffsetT* d_ctrs     = (AtomicOffsetT*) allocations[4];
+
+  ::cuda::compute_capability cc{};
+  if (const auto error = CubDebug(launcher_factory.PtxComputeCap(cc)))
+  {
+    return error;
+  }
+  constexpr OffsetT pdl_max_items = static_cast<OffsetT>(1) << 24;
+  const bool use_pdl              = num_items <= pdl_max_items && cc >= ::cuda::compute_capability{9, 0};
+
+  const size_t num_counter_items = static_cast<size_t>(num_portions) * num_passes;
+  const size_t num_bin_items     = static_cast<size_t>(num_passes) * RADIX_DIGITS;
+  int device                     = -1;
+  int num_sms                    = 0;
+
+  if (const auto error = CubDebug(cudaGetDevice(&device)))
+  {
+    return error;
+  }
+
+  if (const auto error = CubDebug(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, device)))
+  {
+    return error;
+  }
+
+  const int HISTO_BLOCK_THREADS = policy.histogram.threads_per_block;
+  int histo_blocks_per_sm       = 1;
+  auto histogram_kernel         = kernel_source.RadixSortHistogramKernel();
+
+  if (const auto error =
+        CubDebug(launcher_factory.MaxSmOccupancy(histo_blocks_per_sm, histogram_kernel, HISTO_BLOCK_THREADS, 0)))
+  {
+    return error;
+  }
+
+// log histogram_kernel configuration
+#ifdef CUB_DEBUG_LOG
+  _CubLog("Invoking histogram_kernel<<<%d, %d, 0, %lld>>>(), %d items per iteration, "
+          "%d SM occupancy, bit_grain %d\n",
+          histo_blocks_per_sm * num_sms,
+          HISTO_BLOCK_THREADS,
+          reinterpret_cast<long long>(stream),
+          policy.histogram.items_per_thread,
+          histo_blocks_per_sm,
+          policy.histogram.radix_bits);
+#endif
+
+  // exclusive sums to determine starts
+  const int SCAN_BLOCK_THREADS = policy.exclusive_sum.threads_per_block;
+
+// log exclusive_sum_kernel configuration
+#ifdef CUB_DEBUG_LOG
+  _CubLog("Invoking exclusive_sum_kernel<<<%d, %d, 0, %lld>>>(), bit_grain %d\n",
+          num_passes,
+          SCAN_BLOCK_THREADS,
+          reinterpret_cast<long long>(stream),
+          policy.exclusive_sum.radix_bits);
+#endif
+
+  // Initialization is intentionally adjacent to the histogram launch. For the PDL path, this avoids consuming the
+  // short init kernel's runtime in host-side launch setup work before the dependent histogram is submitted.
+  {
+    constexpr int init_startup_threads = 256;
+    const size_t num_init_items        = ::cuda::std::max(num_counter_items, num_bin_items);
+    const int init_startup_blocks =
+      static_cast<int>(::cuda::ceil_div(num_init_items, static_cast<size_t>(init_startup_threads)));
+
+#ifdef CUB_DEBUG_LOG
+    _CubLog("Invoking init_bins_and_counters_kernel<<<%d, %d, 0, %lld>>>()\n",
+            init_startup_blocks,
+            init_startup_threads,
+            reinterpret_cast<long long>(stream));
+#endif
+
+    if (const auto error = CubDebug(
+          launcher_factory(init_startup_blocks, init_startup_threads, 0, stream, use_pdl)
+            .doit(kernel_source.RadixSortInitBinsAndCountersKernel(), d_ctrs, num_counter_items, d_bins, num_bin_items)))
+    {
+      return error;
+    }
+  }
+
+  if (const auto error = CubDebug(
+        launcher_factory(histo_blocks_per_sm * num_sms, HISTO_BLOCK_THREADS, 0, stream, use_pdl)
+          .doit(histogram_kernel, d_bins, d_keys.Current(), num_items, begin_bit, end_bit, decomposer)))
+  {
+    return error;
+  }
+
+  if (const auto error = CubDebug(launcher_factory(num_passes, SCAN_BLOCK_THREADS, 0, stream, use_pdl)
+                                    .doit(kernel_source.RadixSortExclusiveSumKernel(), d_bins)))
+  {
+    return error;
+  }
+
+  if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+  {
+    return error;
+  }
+
+  // use the other buffer if no overwrite is allowed
+  KeyT* d_keys_tmp     = d_keys.Alternate();
+  ValueT* d_values_tmp = d_values.Alternate();
+  if (!is_overwrite_okay && num_passes % 2 == 0)
+  {
+    d_keys.d_buffers[1]   = d_keys_tmp2;
+    d_values.d_buffers[1] = d_values_tmp2;
+  }
+
+  for (int current_bit = begin_bit, pass = 0; current_bit < end_bit; current_bit += RADIX_BITS, ++pass)
+  {
+    int num_bits = ::cuda::std::min(end_bit - current_bit, RADIX_BITS);
+    for (OffsetT portion = 0; portion < num_portions; ++portion)
+    {
+      PortionOffsetT portion_num_items = static_cast<PortionOffsetT>(
+        ::cuda::std::min(num_items - portion * PORTION_SIZE, static_cast<OffsetT>(PORTION_SIZE)));
+
+      PortionOffsetT num_blocks       = ::cuda::ceil_div(portion_num_items, ONESWEEP_TILE_ITEMS);
+      const size_t num_lookback_items = static_cast<size_t>(num_blocks) * RADIX_DIGITS;
+
+      if (use_pdl)
+      {
+        constexpr int init_lookback_threads = 256;
+        const int init_lookback_blocks =
+          static_cast<int>(::cuda::ceil_div(num_lookback_items, static_cast<size_t>(init_lookback_threads)));
+
+        if (const auto error = CubDebug(
+              launcher_factory(init_lookback_blocks, init_lookback_threads, 0, stream, use_pdl)
+                .doit(
+                  kernel_source.RadixSortInitLookbackKernel(), d_lookback, num_lookback_items, d_lookback, size_t{0})))
+        {
+          return error;
+        }
+      }
+      else
+      {
+        if (const auto error =
+              CubDebug(cudaMemsetAsync(d_lookback, 0, num_lookback_items * sizeof(AtomicOffsetT), stream)))
+        {
+          return error;
+        }
+      }
+
+// log onesweep_kernel configuration
+#ifdef CUB_DEBUG_LOG
+      _CubLog("Invoking onesweep_kernel<<<%d, %d, 0, %lld>>>(), %d items per thread, "
+              "current bit %d, bit_grain %d, portion %d/%d\n",
+              num_blocks,
+              ONESWEEP_BLOCK_THREADS,
+              reinterpret_cast<long long>(stream),
+              policy.onesweep.items_per_thread,
+              current_bit,
+              num_bits,
+              static_cast<int>(portion),
+              static_cast<int>(num_portions));
+#endif
+
+      auto onesweep_kernel = kernel_source.RadixSortOnesweepKernel();
+
+      if (const auto error = CubDebug(
+            launcher_factory(num_blocks, ONESWEEP_BLOCK_THREADS, 0, stream, use_pdl)
+              .doit(onesweep_kernel,
+                    d_lookback,
+                    d_ctrs + portion * num_passes + pass,
+                    portion < num_portions - 1 ? d_bins + ((portion + 1) * num_passes + pass) * RADIX_DIGITS : nullptr,
+                    d_bins + (portion * num_passes + pass) * RADIX_DIGITS,
+                    d_keys.Alternate(),
+                    kernel_source.AdvanceKeys(d_keys.Current(), portion * PORTION_SIZE),
+                    d_values.Alternate(),
+                    kernel_source.AdvanceValues(d_values.Current(), portion * PORTION_SIZE),
+                    portion_num_items,
+                    current_bit,
+                    num_bits,
+                    decomposer)))
+      {
+        return error;
+      }
+
+      if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+      {
+        return error;
+      }
+    }
+
+    // use the temporary buffers if no overwrite is allowed
+    if (!is_overwrite_okay && pass == 0)
+    {
+      d_keys =
+        num_passes % 2 == 0 ? DoubleBuffer<KeyT>(d_keys_tmp, d_keys_tmp2) : DoubleBuffer<KeyT>(d_keys_tmp2, d_keys_tmp);
+      d_values = num_passes % 2 == 0 ? DoubleBuffer<ValueT>(d_values_tmp, d_values_tmp2)
+                                     : DoubleBuffer<ValueT>(d_values_tmp2, d_values_tmp);
+    }
+    d_keys.selector ^= 1;
+    d_values.selector ^= 1;
+  }
+
+  return cudaSuccess;
+}
 
 template <SortOrder Order,
           typename KeyT,
@@ -1260,21 +2042,95 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
 #endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
 
   return dispatch_compute_cap(policy_selector, cc, [&](auto policy_getter) {
-    return DispatchRadixSort<Order, KeyT, ValueT, OffsetT, DecomposerT, fake_policy, KernelSource, KernelLauncherFactory>{
-      d_temp_storage,
-      temp_storage_bytes,
-      d_keys,
-      d_values,
-      static_cast<OffsetT>(num_items),
-      begin_bit,
-      end_bit,
-      is_overwrite_okay,
-      stream,
-      -1 /* ptx_version, not used actually */,
-      decomposer,
-      kernel_source,
-      launcher_factory}
-      .__invoke(policy_getter);
+    CUB_DETAIL_CONSTEXPR_ISH auto policy = policy_getter();
+
+    // Return if empty problem, or if no bits to sort and double-buffering is used
+    if (num_items == 0 || (begin_bit == end_bit && is_overwrite_okay))
+    {
+      if (d_temp_storage == nullptr)
+      {
+        temp_storage_bytes = 1;
+      }
+      return cudaSuccess;
+    }
+
+    // Check if simple copy suffices (is_overwrite_okay == false at this point)
+    if (begin_bit == end_bit)
+    {
+      bool has_uva = false;
+      if (const auto error = detail::HasUVA(has_uva))
+      {
+        return error;
+      }
+      if (has_uva)
+      {
+        return invoke_copy(d_temp_storage, temp_storage_bytes, d_keys, d_values, num_items, stream, kernel_source);
+      }
+    }
+
+    // Force kernel code-generation in all compiler passes
+    if (num_items <= static_cast<OffsetT>(policy.single_tile.threads_per_block * policy.single_tile.items_per_thread))
+    {
+      // Small, single tile size
+      return invoke_single_tile(
+        kernel_source.RadixSortSingleTileKernel(),
+        policy.single_tile,
+        d_temp_storage,
+        temp_storage_bytes,
+        d_keys,
+        d_values,
+        num_items,
+        begin_bit,
+        end_bit,
+        stream,
+        decomposer,
+        launcher_factory);
+    }
+
+#if _CCCL_COMPILER(GCC, <, 10)
+    // gcc 7-9 fail to use `policy` in a constant expression, so we just compute it again inplace
+    if CUB_DETAIL_CONSTEXPR_ISH (decltype(policy_getter){}().algorithm == RadixSortAlgorithm::onesweep)
+#else // _CCCL_COMPILER(GCC, <, 10)
+    if CUB_DETAIL_CONSTEXPR_ISH (policy.algorithm == RadixSortAlgorithm::onesweep)
+#endif // _CCCL_COMPILER(GCC, <, 10)
+    {
+      return invoke_onesweep(
+        policy,
+        d_temp_storage,
+        temp_storage_bytes,
+        d_keys,
+        d_values,
+        num_items,
+        begin_bit,
+        end_bit,
+        is_overwrite_okay,
+        stream,
+        decomposer,
+        kernel_source,
+        launcher_factory);
+    }
+    else
+    {
+      return invoke_passes(
+        kernel_source.RadixSortUpsweepKernel(),
+        kernel_source.RadixSortAltUpsweepKernel(),
+        kernel_source.DeviceRadixSortScanBinsKernel(),
+        kernel_source.RadixSortDownsweepKernel(),
+        kernel_source.RadixSortAltDownsweepKernel(),
+        policy,
+        d_temp_storage,
+        temp_storage_bytes,
+        d_keys,
+        d_values,
+        num_items,
+        begin_bit,
+        end_bit,
+        is_overwrite_okay,
+        stream,
+        decomposer,
+        kernel_source,
+        launcher_factory);
+    }
   });
 }
 } // namespace detail::radix_sort

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -1269,125 +1269,104 @@ struct pass_config
   }
 };
 
-template <typename SingleTileKernelT,
-          typename KeyT,
+template <typename KeyT,
           typename ValueT,
           typename OffsetT,
           typename DecomposerT,
+          typename KernelSource,
           typename KernelLauncherFactory>
-CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t invoke_single_tile(
-  SingleTileKernelT single_tile_kernel,
-  RadixSortDownsweepPolicy policy,
-  void* d_temp_storage,
-  size_t& temp_storage_bytes,
-  DoubleBuffer<KeyT>& d_keys,
-  DoubleBuffer<ValueT>& d_values,
-  OffsetT num_items,
-  int begin_bit,
-  int end_bit,
-  cudaStream_t stream,
-  DecomposerT decomposer,
-  KernelLauncherFactory launcher_factory)
-{
-  // Return if the caller is simply requesting the size of the storage allocation
-  if (d_temp_storage == nullptr)
-  {
-    temp_storage_bytes = 1;
-    return cudaSuccess;
-  }
-
-  // Log single_tile_kernel configuration
-#ifdef CUB_DEBUG_LOG
-  _CubLog("Invoking single_tile_kernel<<<%d, %d, 0, %lld>>>(), %d items per thread, %d SM occupancy, current bit "
-          "%d, bit_grain %d\n",
-          1,
-          policy.threads_per_block,
-          (long long) stream,
-          policy.items_per_thread,
-          1,
-          begin_bit,
-          policy.radix_bits);
-#endif
-
-  // Invoke upsweep_kernel with same grid size as downsweep_kernel
-  if (const auto error = CubDebug(
-        launcher_factory(1, policy.threads_per_block, 0, stream)
-          .doit(single_tile_kernel,
-                d_keys.Current(),
-                d_keys.Alternate(),
-                d_values.Current(),
-                d_values.Alternate(),
-                num_items,
-                begin_bit,
-                end_bit,
-                decomposer)))
-  {
-    return error;
-  }
-
-  // Check for failure to launch
-  if (const auto error = CubDebug(cudaPeekAtLastError()))
-  {
-    return error;
-  }
-
-  // Sync the stream if specified to flush runtime errors
-  if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
-  {
-    return error;
-  }
-
-  // Update selector
-  d_keys.selector ^= 1;
-  d_values.selector ^= 1;
-
-  return cudaSuccess;
-}
-
-template <typename KeyT, typename ValueT, typename OffsetT, typename KernelSource>
-CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_copy(
-  void* d_temp_storage,
-  size_t& temp_storage_bytes,
-  DoubleBuffer<KeyT>& d_keys,
-  DoubleBuffer<ValueT>& d_values,
-  OffsetT num_items,
-  cudaStream_t stream,
-  KernelSource kernel_source)
+struct dispatch_impl
 {
   static constexpr bool keys_only = ::cuda::std::is_same_v<ValueT, NullType>;
 
-  // is_overwrite_okay == false here
-  // Return the number of temporary bytes if requested
-  if (d_temp_storage == nullptr)
+  void* d_temp_storage;
+  size_t& temp_storage_bytes;
+  DoubleBuffer<KeyT>& d_keys; // current buffer holds unsorted input keys, updated before returning to caller
+  DoubleBuffer<ValueT>& d_values; // current buffer holds unsorted input keys, updated before returning to caller
+  OffsetT num_items;
+  int begin_bit; // the beginning least-significant bit index for key comparison
+  int end_bit; // the one-past-the-end least-significant bit index for key comparison
+  bool can_overwrite_source_buffer;
+  cudaStream_t stream;
+  DecomposerT decomposer;
+  KernelSource kernel_source;
+  KernelLauncherFactory launcher_factory;
+
+  template <typename SingleTileKernelT>
+  CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t
+  invoke_single_tile(SingleTileKernelT single_tile_kernel, RadixSortDownsweepPolicy policy)
   {
-    temp_storage_bytes = 1;
+    // Return if the caller is simply requesting the size of the storage allocation
+    if (d_temp_storage == nullptr)
+    {
+      temp_storage_bytes = 1;
+      return cudaSuccess;
+    }
+
+    // Log single_tile_kernel configuration
+#ifdef CUB_DEBUG_LOG
+    _CubLog("Invoking single_tile_kernel<<<%d, %d, 0, %lld>>>(), %d items per thread, %d SM occupancy, current bit "
+            "%d, bit_grain %d\n",
+            1,
+            policy.threads_per_block,
+            (long long) stream,
+            policy.items_per_thread,
+            1,
+            begin_bit,
+            policy.radix_bits);
+#endif
+
+    // Invoke upsweep_kernel with same grid size as downsweep_kernel
+    if (const auto error = CubDebug(
+          launcher_factory(1, policy.threads_per_block, 0, stream)
+            .doit(single_tile_kernel,
+                  d_keys.Current(),
+                  d_keys.Alternate(),
+                  d_values.Current(),
+                  d_values.Alternate(),
+                  num_items,
+                  begin_bit,
+                  end_bit,
+                  decomposer)))
+    {
+      return error;
+    }
+
+    // Check for failure to launch
+    if (const auto error = CubDebug(cudaPeekAtLastError()))
+    {
+      return error;
+    }
+
+    // Sync the stream if specified to flush runtime errors
+    if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+    {
+      return error;
+    }
+
+    // Update selector
+    d_keys.selector ^= 1;
+    d_values.selector ^= 1;
+
     return cudaSuccess;
   }
 
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_copy()
+  {
+    // can_overwrite_source_buffer == false here
+    // Return the number of temporary bytes if requested
+    if (d_temp_storage == nullptr)
+    {
+      temp_storage_bytes = 1;
+      return cudaSuccess;
+    }
+
 // Copy keys
 #ifdef CUB_DEBUG_LOG
-  _CubLog("Invoking async copy of %lld keys on stream %lld\n", (long long) num_items, (long long) stream);
-#endif
-  if (const auto error = CubDebug(cudaMemcpyAsync(
-        d_keys.Alternate(), d_keys.Current(), num_items * kernel_source.KeySize(), cudaMemcpyDefault, stream)))
-  {
-    return error;
-  }
-
-  if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
-  {
-    return error;
-  }
-  d_keys.selector ^= 1;
-
-  // Copy values if necessary
-  if constexpr (!keys_only)
-  {
-#ifdef CUB_DEBUG_LOG
-    _CubLog("Invoking async copy of %lld values on stream %lld\n", (long long) num_items, (long long) stream);
+    _CubLog("Invoking async copy of %lld keys on stream %lld\n", (long long) num_items, (long long) stream);
 #endif
     if (const auto error = CubDebug(cudaMemcpyAsync(
-          d_values.Alternate(), d_values.Current(), num_items * kernel_source.ValueSize(), cudaMemcpyDefault, stream)))
+          d_keys.Alternate(), d_keys.Current(), num_items * kernel_source.KeySize(), cudaMemcpyDefault, stream)))
     {
       return error;
     }
@@ -1396,586 +1375,16 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_copy(
     {
       return error;
     }
-  }
-  d_values.selector ^= 1;
+    d_keys.selector ^= 1;
 
-  return cudaSuccess;
-}
-
-template <typename KeyT,
-          typename ValueT,
-          typename OffsetT,
-          typename DecomposerT,
-          typename PassConfigT,
-          typename KernelLauncherFactory>
-CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_pass(
-  const KeyT* d_keys_in,
-  KeyT* d_keys_out,
-  const ValueT* d_values_in,
-  ValueT* d_values_out,
-  OffsetT* d_spine,
-  int /*spine_length*/,
-  int& current_bit,
-  PassConfigT& pass_config,
-  int end_bit,
-  OffsetT num_items,
-  DecomposerT decomposer,
-  KernelLauncherFactory launcher_factory,
-  cudaStream_t stream)
-{
-  int pass_bits = ::cuda::std::min(pass_config.radix_bits, end_bit - current_bit);
-
-// Log upsweep_kernel configuration
-#ifdef CUB_DEBUG_LOG
-  _CubLog("Invoking upsweep_kernel<<<%d, %d, 0, %lld>>>(), %d items per thread, %d SM occupancy, current bit %d, "
-          "bit_grain %d\n",
-          pass_config.even_share.grid_size,
-          pass_config.upsweep_config.threads_per_block,
-          (long long) stream,
-          pass_config.upsweep_config.items_per_thread,
-          pass_config.upsweep_config.sm_occupancy,
-          current_bit,
-          pass_bits);
-#endif
-
-  // Spine length written by the upsweep kernel in the current pass.
-  int pass_spine_length = pass_config.even_share.grid_size * pass_config.radix_digits;
-
-  // Invoke upsweep_kernel with same grid size as downsweep_kernel
-  if (const auto error = CubDebug(
-        launcher_factory(pass_config.even_share.grid_size, pass_config.upsweep_config.threads_per_block, 0, stream)
-          .doit(pass_config.upsweep_kernel,
-                d_keys_in,
-                d_spine,
-                num_items,
-                current_bit,
-                pass_bits,
-                pass_config.even_share,
-                decomposer)))
-  {
-    return error;
-  }
-
-  // Check for failure to launch
-  if (const auto error = CubDebug(cudaPeekAtLastError()))
-  {
-    return error;
-  }
-
-  // Sync the stream if specified to flush runtime errors
-  if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
-  {
-    return error;
-  }
-
-// Log scan_kernel configuration
-#ifdef CUB_DEBUG_LOG
-  _CubLog("Invoking scan_kernel<<<%d, %d, 0, %lld>>>(), %d items per thread\n",
-          1,
-          pass_config.scan_config.threads_per_block,
-          (long long) stream,
-          pass_config.scan_config.items_per_thread);
-#endif
-
-  // Invoke scan_kernel
-  if (const auto error = CubDebug(launcher_factory(1, pass_config.scan_config.threads_per_block, 0, stream)
-                                    .doit(pass_config.scan_kernel, d_spine, pass_spine_length)))
-  {
-    return error;
-  }
-
-  // Check for failure to launch
-  if (const auto error = CubDebug(cudaPeekAtLastError()))
-  {
-    return error;
-  }
-
-  // Sync the stream if specified to flush runtime errors
-  if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
-  {
-    return error;
-  }
-
-// Log downsweep_kernel configuration
-#ifdef CUB_DEBUG_LOG
-  _CubLog("Invoking downsweep_kernel<<<%d, %d, 0, %lld>>>(), %d items per thread, %d SM occupancy\n",
-          pass_config.even_share.grid_size,
-          pass_config.downsweep_config.threads_per_block,
-          (long long) stream,
-          pass_config.downsweep_config.items_per_thread,
-          pass_config.downsweep_config.sm_occupancy);
-#endif
-
-  // Invoke downsweep_kernel
-  if (const auto error = CubDebug(
-        launcher_factory(pass_config.even_share.grid_size, pass_config.downsweep_config.threads_per_block, 0, stream)
-          .doit(pass_config.downsweep_kernel,
-                d_keys_in,
-                d_keys_out,
-                d_values_in,
-                d_values_out,
-                d_spine,
-                num_items,
-                current_bit,
-                pass_bits,
-                pass_config.even_share,
-                decomposer)))
-  {
-    return error;
-  }
-
-  // Check for failure to launch
-  if (const auto error = CubDebug(cudaPeekAtLastError()))
-  {
-    return error;
-  }
-
-  // Sync the stream if specified to flush runtime errors
-  if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
-  {
-    return error;
-  }
-
-  // Update current bit
-  current_bit += pass_bits;
-
-  return cudaSuccess;
-}
-
-template <typename UpsweepKernelT,
-          typename ScanKernelT,
-          typename DownsweepKernelT,
-          typename KeyT,
-          typename ValueT,
-          typename OffsetT,
-          typename DecomposerT,
-          typename KernelSource,
-          typename KernelLauncherFactory>
-CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t invoke_passes(
-  UpsweepKernelT upsweep_kernel,
-  UpsweepKernelT alt_upsweep_kernel,
-  ScanKernelT scan_kernel,
-  DownsweepKernelT downsweep_kernel,
-  DownsweepKernelT alt_downsweep_kernel,
-  const RadixSortPolicy& policy,
-  void* d_temp_storage,
-  size_t& temp_storage_bytes,
-  DoubleBuffer<KeyT>& d_keys,
-  DoubleBuffer<ValueT>& d_values,
-  OffsetT num_items,
-  int begin_bit,
-  int end_bit,
-  bool is_overwrite_okay,
-  cudaStream_t stream,
-  DecomposerT decomposer,
-  KernelSource kernel_source,
-  KernelLauncherFactory launcher_factory)
-{
-  static constexpr bool keys_only = ::cuda::std::is_same_v<ValueT, NullType>;
-
-  // Get device ordinal
-  int device_ordinal;
-  if (const auto error = CubDebug(cudaGetDevice(&device_ordinal)))
-  {
-    return error;
-  }
-
-  // Get SM count
-  int sm_count;
-  if (const auto error = CubDebug(cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, device_ordinal)))
-  {
-    return error;
-  }
-
-  // Init regular and alternate-digit kernel configurations
-  pass_config<UpsweepKernelT, ScanKernelT, DownsweepKernelT, OffsetT> pc, alt_pc;
-  if (const auto error = pc.init(
-        upsweep_kernel,
-        scan_kernel,
-        downsweep_kernel,
-        sm_count,
-        num_items,
-        policy.downsweep.radix_bits,
-        policy.upsweep,
-        policy.scan,
-        policy.downsweep,
-        launcher_factory))
-  {
-    return error;
-  }
-
-  if (const auto error = alt_pc.init(
-        alt_upsweep_kernel,
-        scan_kernel,
-        alt_downsweep_kernel,
-        sm_count,
-        num_items,
-        policy.alt_downsweep.radix_bits,
-        policy.alt_upsweep,
-        policy.scan,
-        policy.alt_downsweep,
-        launcher_factory))
-  {
-    return error;
-  }
-
-  // Get maximum spine length
-  int max_grid_size = ::cuda::std::max(pc.max_downsweep_grid_size, alt_pc.max_downsweep_grid_size);
-  int spine_length  = (max_grid_size * pc.radix_digits) + pc.scan_config.tile_size;
-
-  // Temporary storage allocation requirements
-  void* allocations[3]       = {};
-  size_t allocation_sizes[3] = {
-    // bytes needed for privatized block digit histograms
-    spine_length * sizeof(OffsetT),
-
-    // bytes needed for 3rd keys buffer
-    (is_overwrite_okay) ? 0 : num_items * kernel_source.KeySize(),
-
-    // bytes needed for 3rd values buffer
-    (is_overwrite_okay || (keys_only)) ? 0 : num_items * kernel_source.ValueSize(),
-  };
-
-  // Alias the temporary allocations from the single storage blob (or compute the necessary size of the blob)
-  if (const auto error =
-        CubDebug(detail::alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))
-  {
-    return error;
-  }
-
-  // Return if the caller is simply requesting the size of the storage allocation
-  if (d_temp_storage == nullptr)
-  {
-    return cudaSuccess;
-  }
-
-  // Pass planning.  Run passes of the alternate digit-size configuration until we have an even multiple of our
-  // preferred digit size
-  int num_bits           = end_bit - begin_bit;
-  int num_passes         = ::cuda::ceil_div(num_bits, pc.radix_bits);
-  bool is_num_passes_odd = num_passes & 1;
-  int max_alt_passes     = (num_passes * pc.radix_bits) - num_bits;
-  int alt_end_bit        = ::cuda::std::min(end_bit, begin_bit + (max_alt_passes * alt_pc.radix_bits));
-
-  // Alias the temporary storage allocations
-  OffsetT* d_spine = static_cast<OffsetT*>(allocations[0]);
-
-  DoubleBuffer<KeyT> d_keys_remaining_passes(
-    (is_overwrite_okay || is_num_passes_odd) ? d_keys.Alternate() : static_cast<KeyT*>(allocations[1]),
-    (is_overwrite_okay)   ? d_keys.Current()
-    : (is_num_passes_odd) ? static_cast<KeyT*>(allocations[1])
-                          : d_keys.Alternate());
-
-  DoubleBuffer<ValueT> d_values_remaining_passes(
-    (is_overwrite_okay || is_num_passes_odd) ? d_values.Alternate() : static_cast<ValueT*>(allocations[2]),
-    (is_overwrite_okay)   ? d_values.Current()
-    : (is_num_passes_odd) ? static_cast<ValueT*>(allocations[2])
-                          : d_values.Alternate());
-
-  // Run first pass, consuming from the input's current buffers
-  int current_bit = begin_bit;
-  if (const auto error = CubDebug(invoke_pass(
-        d_keys.Current(),
-        d_keys_remaining_passes.Current(),
-        d_values.Current(),
-        d_values_remaining_passes.Current(),
-        d_spine,
-        spine_length,
-        current_bit,
-        (current_bit < alt_end_bit) ? alt_pc : pc,
-        end_bit,
-        num_items,
-        decomposer,
-        launcher_factory,
-        stream)))
-  {
-    return error;
-  }
-
-  // Run remaining passes
-  while (current_bit < end_bit)
-  {
-    if (const auto error = CubDebug(invoke_pass(
-          d_keys_remaining_passes.d_buffers[d_keys_remaining_passes.selector],
-          d_keys_remaining_passes.d_buffers[d_keys_remaining_passes.selector ^ 1],
-          d_values_remaining_passes.d_buffers[d_keys_remaining_passes.selector],
-          d_values_remaining_passes.d_buffers[d_keys_remaining_passes.selector ^ 1],
-          d_spine,
-          spine_length,
-          current_bit,
-          (current_bit < alt_end_bit) ? alt_pc : pc,
-          end_bit,
-          num_items,
-          decomposer,
-          launcher_factory,
-          stream)))
+    // Copy values if necessary
+    if constexpr (!keys_only)
     {
-      return error;
-    }
-
-    // Invert selectors
-    d_keys_remaining_passes.selector ^= 1;
-    d_values_remaining_passes.selector ^= 1;
-  }
-
-  // Update selector
-  if (!is_overwrite_okay)
-  {
-    num_passes = 1; // Sorted data always ends up in the other vector
-  }
-
-  d_keys.selector   = (d_keys.selector + num_passes) & 1;
-  d_values.selector = (d_values.selector + num_passes) & 1;
-
-  return cudaSuccess;
-}
-
-template <typename KeyT,
-          typename ValueT,
-          typename OffsetT,
-          typename DecomposerT,
-          typename KernelSource,
-          typename KernelLauncherFactory>
-CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_onesweep(
-  RadixSortPolicy policy,
-  void* d_temp_storage,
-  size_t& temp_storage_bytes,
-  DoubleBuffer<KeyT>& d_keys,
-  DoubleBuffer<ValueT>& d_values,
-  OffsetT num_items,
-  int begin_bit,
-  int end_bit,
-  bool is_overwrite_okay,
-  cudaStream_t stream,
-  DecomposerT decomposer,
-  KernelSource kernel_source,
-  KernelLauncherFactory launcher_factory)
-{
-  static constexpr bool KEYS_ONLY = ::cuda::std::is_same_v<ValueT, NullType>;
-
-  // PortionOffsetT is used for offsets within a portion, and must be signed.
-  using PortionOffsetT = int;
-  using AtomicOffsetT  = PortionOffsetT;
-
-  // compute temporary storage size
-  const int RADIX_BITS                = policy.onesweep.radix_bits;
-  const int RADIX_DIGITS              = 1 << RADIX_BITS;
-  const int ONESWEEP_ITEMS_PER_THREAD = policy.onesweep.items_per_thread;
-  const int ONESWEEP_BLOCK_THREADS    = policy.onesweep.threads_per_block;
-  const int ONESWEEP_TILE_ITEMS       = ONESWEEP_ITEMS_PER_THREAD * ONESWEEP_BLOCK_THREADS;
-  // portions handle inputs with >=2**30 elements, due to the way lookback works
-  // for testing purposes, one portion is <= 2**28 elements
-  const PortionOffsetT PORTION_SIZE = ((1 << 28) - 1) / ONESWEEP_TILE_ITEMS * ONESWEEP_TILE_ITEMS;
-  int num_passes                    = ::cuda::ceil_div(end_bit - begin_bit, RADIX_BITS);
-  OffsetT num_portions              = static_cast<OffsetT>(::cuda::ceil_div(num_items, PORTION_SIZE));
-  PortionOffsetT max_num_blocks     = ::cuda::ceil_div(
-    static_cast<int>(::cuda::std::min(num_items, static_cast<OffsetT>(PORTION_SIZE))), ONESWEEP_TILE_ITEMS);
-
-  size_t value_size         = KEYS_ONLY ? 0 : kernel_source.ValueSize();
-  size_t allocation_sizes[] = {
-    // bins
-    num_portions * num_passes * RADIX_DIGITS * sizeof(OffsetT),
-    // lookback
-    max_num_blocks * RADIX_DIGITS * sizeof(AtomicOffsetT),
-    // extra key buffer
-    is_overwrite_okay || num_passes <= 1 ? 0 : num_items * kernel_source.KeySize(),
-    // extra value buffer
-    is_overwrite_okay || num_passes <= 1 ? 0 : num_items * value_size,
-    // counters
-    num_portions * num_passes * sizeof(AtomicOffsetT),
-  };
-  constexpr int NUM_ALLOCATIONS      = sizeof(allocation_sizes) / sizeof(allocation_sizes[0]);
-  void* allocations[NUM_ALLOCATIONS] = {};
-  if (const auto error =
-        detail::alias_temporaries<NUM_ALLOCATIONS>(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes))
-  {
-    return error;
-  }
-
-  // just return if no temporary storage is provided
-  if (d_temp_storage == nullptr)
-  {
-    return cudaSuccess;
-  }
-
-  OffsetT* d_bins           = (OffsetT*) allocations[0];
-  AtomicOffsetT* d_lookback = (AtomicOffsetT*) allocations[1];
-  KeyT* d_keys_tmp2         = (KeyT*) allocations[2];
-  ValueT* d_values_tmp2     = (ValueT*) allocations[3];
-  AtomicOffsetT* d_ctrs     = (AtomicOffsetT*) allocations[4];
-
-  ::cuda::compute_capability cc{};
-  if (const auto error = CubDebug(launcher_factory.PtxComputeCap(cc)))
-  {
-    return error;
-  }
-  constexpr OffsetT pdl_max_items = static_cast<OffsetT>(1) << 24;
-  const bool use_pdl              = num_items <= pdl_max_items && cc >= ::cuda::compute_capability{9, 0};
-
-  const size_t num_counter_items = static_cast<size_t>(num_portions) * num_passes;
-  const size_t num_bin_items     = static_cast<size_t>(num_passes) * RADIX_DIGITS;
-  int device                     = -1;
-  int num_sms                    = 0;
-
-  if (const auto error = CubDebug(cudaGetDevice(&device)))
-  {
-    return error;
-  }
-
-  if (const auto error = CubDebug(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, device)))
-  {
-    return error;
-  }
-
-  const int HISTO_BLOCK_THREADS = policy.histogram.threads_per_block;
-  int histo_blocks_per_sm       = 1;
-  auto histogram_kernel         = kernel_source.RadixSortHistogramKernel();
-
-  if (const auto error =
-        CubDebug(launcher_factory.MaxSmOccupancy(histo_blocks_per_sm, histogram_kernel, HISTO_BLOCK_THREADS, 0)))
-  {
-    return error;
-  }
-
-// log histogram_kernel configuration
 #ifdef CUB_DEBUG_LOG
-  _CubLog("Invoking histogram_kernel<<<%d, %d, 0, %lld>>>(), %d items per iteration, "
-          "%d SM occupancy, bit_grain %d\n",
-          histo_blocks_per_sm * num_sms,
-          HISTO_BLOCK_THREADS,
-          reinterpret_cast<long long>(stream),
-          policy.histogram.items_per_thread,
-          histo_blocks_per_sm,
-          policy.histogram.radix_bits);
+      _CubLog("Invoking async copy of %lld values on stream %lld\n", (long long) num_items, (long long) stream);
 #endif
-
-  // exclusive sums to determine starts
-  const int SCAN_BLOCK_THREADS = policy.exclusive_sum.threads_per_block;
-
-// log exclusive_sum_kernel configuration
-#ifdef CUB_DEBUG_LOG
-  _CubLog("Invoking exclusive_sum_kernel<<<%d, %d, 0, %lld>>>(), bit_grain %d\n",
-          num_passes,
-          SCAN_BLOCK_THREADS,
-          reinterpret_cast<long long>(stream),
-          policy.exclusive_sum.radix_bits);
-#endif
-
-  // Initialization is intentionally adjacent to the histogram launch. For the PDL path, this avoids consuming the
-  // short init kernel's runtime in host-side launch setup work before the dependent histogram is submitted.
-  {
-    constexpr int init_startup_threads = 256;
-    const size_t num_init_items        = ::cuda::std::max(num_counter_items, num_bin_items);
-    const int init_startup_blocks =
-      static_cast<int>(::cuda::ceil_div(num_init_items, static_cast<size_t>(init_startup_threads)));
-
-#ifdef CUB_DEBUG_LOG
-    _CubLog("Invoking init_bins_and_counters_kernel<<<%d, %d, 0, %lld>>>()\n",
-            init_startup_blocks,
-            init_startup_threads,
-            reinterpret_cast<long long>(stream));
-#endif
-
-    if (const auto error = CubDebug(
-          launcher_factory(init_startup_blocks, init_startup_threads, 0, stream, use_pdl)
-            .doit(kernel_source.RadixSortInitBinsAndCountersKernel(), d_ctrs, num_counter_items, d_bins, num_bin_items)))
-    {
-      return error;
-    }
-  }
-
-  if (const auto error = CubDebug(
-        launcher_factory(histo_blocks_per_sm * num_sms, HISTO_BLOCK_THREADS, 0, stream, use_pdl)
-          .doit(histogram_kernel, d_bins, d_keys.Current(), num_items, begin_bit, end_bit, decomposer)))
-  {
-    return error;
-  }
-
-  if (const auto error = CubDebug(launcher_factory(num_passes, SCAN_BLOCK_THREADS, 0, stream, use_pdl)
-                                    .doit(kernel_source.RadixSortExclusiveSumKernel(), d_bins)))
-  {
-    return error;
-  }
-
-  if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
-  {
-    return error;
-  }
-
-  // use the other buffer if no overwrite is allowed
-  KeyT* d_keys_tmp     = d_keys.Alternate();
-  ValueT* d_values_tmp = d_values.Alternate();
-  if (!is_overwrite_okay && num_passes % 2 == 0)
-  {
-    d_keys.d_buffers[1]   = d_keys_tmp2;
-    d_values.d_buffers[1] = d_values_tmp2;
-  }
-
-  for (int current_bit = begin_bit, pass = 0; current_bit < end_bit; current_bit += RADIX_BITS, ++pass)
-  {
-    int num_bits = ::cuda::std::min(end_bit - current_bit, RADIX_BITS);
-    for (OffsetT portion = 0; portion < num_portions; ++portion)
-    {
-      PortionOffsetT portion_num_items = static_cast<PortionOffsetT>(
-        ::cuda::std::min(num_items - portion * PORTION_SIZE, static_cast<OffsetT>(PORTION_SIZE)));
-
-      PortionOffsetT num_blocks       = ::cuda::ceil_div(portion_num_items, ONESWEEP_TILE_ITEMS);
-      const size_t num_lookback_items = static_cast<size_t>(num_blocks) * RADIX_DIGITS;
-
-      if (use_pdl)
-      {
-        constexpr int init_lookback_threads = 256;
-        const int init_lookback_blocks =
-          static_cast<int>(::cuda::ceil_div(num_lookback_items, static_cast<size_t>(init_lookback_threads)));
-
-        if (const auto error = CubDebug(
-              launcher_factory(init_lookback_blocks, init_lookback_threads, 0, stream, use_pdl)
-                .doit(
-                  kernel_source.RadixSortInitLookbackKernel(), d_lookback, num_lookback_items, d_lookback, size_t{0})))
-        {
-          return error;
-        }
-      }
-      else
-      {
-        if (const auto error =
-              CubDebug(cudaMemsetAsync(d_lookback, 0, num_lookback_items * sizeof(AtomicOffsetT), stream)))
-        {
-          return error;
-        }
-      }
-
-// log onesweep_kernel configuration
-#ifdef CUB_DEBUG_LOG
-      _CubLog("Invoking onesweep_kernel<<<%d, %d, 0, %lld>>>(), %d items per thread, "
-              "current bit %d, bit_grain %d, portion %d/%d\n",
-              num_blocks,
-              ONESWEEP_BLOCK_THREADS,
-              reinterpret_cast<long long>(stream),
-              policy.onesweep.items_per_thread,
-              current_bit,
-              num_bits,
-              static_cast<int>(portion),
-              static_cast<int>(num_portions));
-#endif
-
-      auto onesweep_kernel = kernel_source.RadixSortOnesweepKernel();
-
-      if (const auto error = CubDebug(
-            launcher_factory(num_blocks, ONESWEEP_BLOCK_THREADS, 0, stream, use_pdl)
-              .doit(onesweep_kernel,
-                    d_lookback,
-                    d_ctrs + portion * num_passes + pass,
-                    portion < num_portions - 1 ? d_bins + ((portion + 1) * num_passes + pass) * RADIX_DIGITS : nullptr,
-                    d_bins + (portion * num_passes + pass) * RADIX_DIGITS,
-                    d_keys.Alternate(),
-                    kernel_source.AdvanceKeys(d_keys.Current(), portion * PORTION_SIZE),
-                    d_values.Alternate(),
-                    kernel_source.AdvanceValues(d_values.Current(), portion * PORTION_SIZE),
-                    portion_num_items,
-                    current_bit,
-                    num_bits,
-                    decomposer)))
+      if (const auto error = CubDebug(cudaMemcpyAsync(
+            d_values.Alternate(), d_values.Current(), num_items * kernel_source.ValueSize(), cudaMemcpyDefault, stream)))
       {
         return error;
       }
@@ -1985,21 +1394,606 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_onesweep(
         return error;
       }
     }
-
-    // use the temporary buffers if no overwrite is allowed
-    if (!is_overwrite_okay && pass == 0)
-    {
-      d_keys =
-        num_passes % 2 == 0 ? DoubleBuffer<KeyT>(d_keys_tmp, d_keys_tmp2) : DoubleBuffer<KeyT>(d_keys_tmp2, d_keys_tmp);
-      d_values = num_passes % 2 == 0 ? DoubleBuffer<ValueT>(d_values_tmp, d_values_tmp2)
-                                     : DoubleBuffer<ValueT>(d_values_tmp2, d_values_tmp);
-    }
-    d_keys.selector ^= 1;
     d_values.selector ^= 1;
+
+    return cudaSuccess;
   }
 
-  return cudaSuccess;
-}
+  template <typename PassConfigT>
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_pass(
+    const KeyT* d_keys_in,
+    KeyT* d_keys_out,
+    const ValueT* d_values_in,
+    ValueT* d_values_out,
+    OffsetT* d_spine,
+    int /*spine_length*/,
+    int& current_bit,
+    PassConfigT& pass_config)
+  {
+    int pass_bits = ::cuda::std::min(pass_config.radix_bits, end_bit - current_bit);
+
+// Log upsweep_kernel configuration
+#ifdef CUB_DEBUG_LOG
+    _CubLog("Invoking upsweep_kernel<<<%d, %d, 0, %lld>>>(), %d items per thread, %d SM occupancy, current bit %d, "
+            "bit_grain %d\n",
+            pass_config.even_share.grid_size,
+            pass_config.upsweep_config.threads_per_block,
+            (long long) stream,
+            pass_config.upsweep_config.items_per_thread,
+            pass_config.upsweep_config.sm_occupancy,
+            current_bit,
+            pass_bits);
+#endif
+
+    // Spine length written by the upsweep kernel in the current pass.
+    int pass_spine_length = pass_config.even_share.grid_size * pass_config.radix_digits;
+
+    // Invoke upsweep_kernel with same grid size as downsweep_kernel
+    if (const auto error = CubDebug(
+          launcher_factory(pass_config.even_share.grid_size, pass_config.upsweep_config.threads_per_block, 0, stream)
+            .doit(pass_config.upsweep_kernel,
+                  d_keys_in,
+                  d_spine,
+                  num_items,
+                  current_bit,
+                  pass_bits,
+                  pass_config.even_share,
+                  decomposer)))
+    {
+      return error;
+    }
+
+    // Check for failure to launch
+    if (const auto error = CubDebug(cudaPeekAtLastError()))
+    {
+      return error;
+    }
+
+    // Sync the stream if specified to flush runtime errors
+    if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+    {
+      return error;
+    }
+
+// Log scan_kernel configuration
+#ifdef CUB_DEBUG_LOG
+    _CubLog("Invoking scan_kernel<<<%d, %d, 0, %lld>>>(), %d items per thread\n",
+            1,
+            pass_config.scan_config.threads_per_block,
+            (long long) stream,
+            pass_config.scan_config.items_per_thread);
+#endif
+
+    // Invoke scan_kernel
+    if (const auto error = CubDebug(launcher_factory(1, pass_config.scan_config.threads_per_block, 0, stream)
+                                      .doit(pass_config.scan_kernel, d_spine, pass_spine_length)))
+    {
+      return error;
+    }
+
+    // Check for failure to launch
+    if (const auto error = CubDebug(cudaPeekAtLastError()))
+    {
+      return error;
+    }
+
+    // Sync the stream if specified to flush runtime errors
+    if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+    {
+      return error;
+    }
+
+// Log downsweep_kernel configuration
+#ifdef CUB_DEBUG_LOG
+    _CubLog("Invoking downsweep_kernel<<<%d, %d, 0, %lld>>>(), %d items per thread, %d SM occupancy\n",
+            pass_config.even_share.grid_size,
+            pass_config.downsweep_config.threads_per_block,
+            (long long) stream,
+            pass_config.downsweep_config.items_per_thread,
+            pass_config.downsweep_config.sm_occupancy);
+#endif
+
+    // Invoke downsweep_kernel
+    if (const auto error = CubDebug(
+          launcher_factory(pass_config.even_share.grid_size, pass_config.downsweep_config.threads_per_block, 0, stream)
+            .doit(pass_config.downsweep_kernel,
+                  d_keys_in,
+                  d_keys_out,
+                  d_values_in,
+                  d_values_out,
+                  d_spine,
+                  num_items,
+                  current_bit,
+                  pass_bits,
+                  pass_config.even_share,
+                  decomposer)))
+    {
+      return error;
+    }
+
+    // Check for failure to launch
+    if (const auto error = CubDebug(cudaPeekAtLastError()))
+    {
+      return error;
+    }
+
+    // Sync the stream if specified to flush runtime errors
+    if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+    {
+      return error;
+    }
+
+    // Update current bit
+    current_bit += pass_bits;
+
+    return cudaSuccess;
+  }
+
+  template <typename UpsweepKernelT, typename ScanKernelT, typename DownsweepKernelT>
+  CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t invoke_passes(
+    UpsweepKernelT upsweep_kernel,
+    UpsweepKernelT alt_upsweep_kernel,
+    ScanKernelT scan_kernel,
+    DownsweepKernelT downsweep_kernel,
+    DownsweepKernelT alt_downsweep_kernel,
+    const RadixSortPolicy& policy)
+  {
+    // Get device ordinal
+    int device_ordinal;
+    if (const auto error = CubDebug(cudaGetDevice(&device_ordinal)))
+    {
+      return error;
+    }
+
+    // Get SM count
+    int sm_count;
+    if (const auto error = CubDebug(cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, device_ordinal)))
+    {
+      return error;
+    }
+
+    // Init regular and alternate-digit kernel configurations
+    pass_config<UpsweepKernelT, ScanKernelT, DownsweepKernelT, OffsetT> pc, alt_pc;
+    if (const auto error = pc.init(
+          upsweep_kernel,
+          scan_kernel,
+          downsweep_kernel,
+          sm_count,
+          num_items,
+          policy.downsweep.radix_bits,
+          policy.upsweep,
+          policy.scan,
+          policy.downsweep,
+          launcher_factory))
+    {
+      return error;
+    }
+
+    if (const auto error = alt_pc.init(
+          alt_upsweep_kernel,
+          scan_kernel,
+          alt_downsweep_kernel,
+          sm_count,
+          num_items,
+          policy.alt_downsweep.radix_bits,
+          policy.alt_upsweep,
+          policy.scan,
+          policy.alt_downsweep,
+          launcher_factory))
+    {
+      return error;
+    }
+
+    // Get maximum spine length
+    int max_grid_size = ::cuda::std::max(pc.max_downsweep_grid_size, alt_pc.max_downsweep_grid_size);
+    int spine_length  = (max_grid_size * pc.radix_digits) + pc.scan_config.tile_size;
+
+    // Temporary storage allocation requirements
+    void* allocations[3]       = {};
+    size_t allocation_sizes[3] = {
+      // bytes needed for privatized block digit histograms
+      spine_length * sizeof(OffsetT),
+
+      // bytes needed for 3rd keys buffer
+      (can_overwrite_source_buffer) ? 0 : num_items * kernel_source.KeySize(),
+
+      // bytes needed for 3rd values buffer
+      (can_overwrite_source_buffer || (keys_only)) ? 0 : num_items * kernel_source.ValueSize(),
+    };
+
+    // Alias the temporary allocations from the single storage blob (or compute the necessary size of the blob)
+    if (const auto error =
+          CubDebug(detail::alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))
+    {
+      return error;
+    }
+
+    // Return if the caller is simply requesting the size of the storage allocation
+    if (d_temp_storage == nullptr)
+    {
+      return cudaSuccess;
+    }
+
+    // Pass planning.  Run passes of the alternate digit-size configuration until we have an even multiple of our
+    // preferred digit size
+    int num_bits           = end_bit - begin_bit;
+    int num_passes         = ::cuda::ceil_div(num_bits, pc.radix_bits);
+    bool is_num_passes_odd = num_passes & 1;
+    int max_alt_passes     = (num_passes * pc.radix_bits) - num_bits;
+    int alt_end_bit        = ::cuda::std::min(end_bit, begin_bit + (max_alt_passes * alt_pc.radix_bits));
+
+    // Alias the temporary storage allocations
+    OffsetT* d_spine = static_cast<OffsetT*>(allocations[0]);
+
+    DoubleBuffer<KeyT> d_keys_remaining_passes(
+      (can_overwrite_source_buffer || is_num_passes_odd) ? d_keys.Alternate() : static_cast<KeyT*>(allocations[1]),
+      (can_overwrite_source_buffer) ? d_keys.Current()
+      : (is_num_passes_odd)         ? static_cast<KeyT*>(allocations[1])
+                                    : d_keys.Alternate());
+
+    DoubleBuffer<ValueT> d_values_remaining_passes(
+      (can_overwrite_source_buffer || is_num_passes_odd) ? d_values.Alternate() : static_cast<ValueT*>(allocations[2]),
+      (can_overwrite_source_buffer) ? d_values.Current()
+      : (is_num_passes_odd)         ? static_cast<ValueT*>(allocations[2])
+                                    : d_values.Alternate());
+
+    // Run first pass, consuming from the input's current buffers
+    int current_bit = begin_bit;
+    if (const auto error = CubDebug(invoke_pass(
+          d_keys.Current(),
+          d_keys_remaining_passes.Current(),
+          d_values.Current(),
+          d_values_remaining_passes.Current(),
+          d_spine,
+          spine_length,
+          current_bit,
+          (current_bit < alt_end_bit) ? alt_pc : pc)))
+    {
+      return error;
+    }
+
+    // Run remaining passes
+    while (current_bit < end_bit)
+    {
+      if (const auto error = CubDebug(invoke_pass(
+            d_keys_remaining_passes.d_buffers[d_keys_remaining_passes.selector],
+            d_keys_remaining_passes.d_buffers[d_keys_remaining_passes.selector ^ 1],
+            d_values_remaining_passes.d_buffers[d_keys_remaining_passes.selector],
+            d_values_remaining_passes.d_buffers[d_keys_remaining_passes.selector ^ 1],
+            d_spine,
+            spine_length,
+            current_bit,
+            (current_bit < alt_end_bit) ? alt_pc : pc)))
+      {
+        return error;
+      }
+
+      // Invert selectors
+      d_keys_remaining_passes.selector ^= 1;
+      d_values_remaining_passes.selector ^= 1;
+    }
+
+    // Update selector
+    if (!can_overwrite_source_buffer)
+    {
+      num_passes = 1; // Sorted data always ends up in the other vector
+    }
+
+    d_keys.selector   = (d_keys.selector + num_passes) & 1;
+    d_values.selector = (d_values.selector + num_passes) & 1;
+
+    return cudaSuccess;
+  }
+
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_onesweep(RadixSortPolicy policy)
+  {
+    // PortionOffsetT is used for offsets within a portion, and must be signed.
+    using PortionOffsetT = int;
+    using AtomicOffsetT  = PortionOffsetT;
+
+    // compute temporary storage size
+    const int radix_bits                = policy.onesweep.radix_bits;
+    const int radix_digits              = 1 << radix_bits;
+    const int onesweep_items_per_thread = policy.onesweep.items_per_thread;
+    const int onesweep_block_threads    = policy.onesweep.threads_per_block;
+    const int onesweep_tile_items       = onesweep_items_per_thread * onesweep_block_threads;
+    // portions handle inputs with >=2**30 elements, due to the way lookback works
+    // for testing purposes, one portion is <= 2**28 elements
+    const PortionOffsetT portion_size = ((1 << 28) - 1) / onesweep_tile_items * onesweep_tile_items;
+    int num_passes                    = ::cuda::ceil_div(end_bit - begin_bit, radix_bits);
+    OffsetT num_portions              = static_cast<OffsetT>(::cuda::ceil_div(num_items, portion_size));
+    PortionOffsetT max_num_blocks     = ::cuda::ceil_div(
+      static_cast<int>(::cuda::std::min(num_items, static_cast<OffsetT>(portion_size))), onesweep_tile_items);
+
+    size_t value_size         = keys_only ? 0 : kernel_source.ValueSize();
+    size_t allocation_sizes[] = {
+      // bins
+      num_portions * num_passes * radix_digits * sizeof(OffsetT),
+      // lookback
+      max_num_blocks * radix_digits * sizeof(AtomicOffsetT),
+      // extra key buffer
+      can_overwrite_source_buffer || num_passes <= 1 ? 0 : num_items * kernel_source.KeySize(),
+      // extra value buffer
+      can_overwrite_source_buffer || num_passes <= 1 ? 0 : num_items * value_size,
+      // counters
+      num_portions * num_passes * sizeof(AtomicOffsetT),
+    };
+    constexpr int num_allocations      = sizeof(allocation_sizes) / sizeof(allocation_sizes[0]);
+    void* allocations[num_allocations] = {};
+    if (const auto error =
+          detail::alias_temporaries<num_allocations>(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes))
+    {
+      return error;
+    }
+
+    // just return if no temporary storage is provided
+    if (d_temp_storage == nullptr)
+    {
+      return cudaSuccess;
+    }
+
+    OffsetT* d_bins           = (OffsetT*) allocations[0];
+    AtomicOffsetT* d_lookback = (AtomicOffsetT*) allocations[1];
+    KeyT* d_keys_tmp2         = (KeyT*) allocations[2];
+    ValueT* d_values_tmp2     = (ValueT*) allocations[3];
+    AtomicOffsetT* d_ctrs     = (AtomicOffsetT*) allocations[4];
+
+    ::cuda::compute_capability cc{};
+    if (const auto error = CubDebug(launcher_factory.PtxComputeCap(cc)))
+    {
+      return error;
+    }
+    constexpr OffsetT pdl_max_items = static_cast<OffsetT>(1) << 24;
+    const bool use_pdl              = num_items <= pdl_max_items && cc >= ::cuda::compute_capability{9, 0};
+
+    const size_t num_counter_items = static_cast<size_t>(num_portions) * num_passes;
+    const size_t num_bin_items     = static_cast<size_t>(num_passes) * radix_digits;
+    int device                     = -1;
+    int num_sms                    = 0;
+
+    if (const auto error = CubDebug(cudaGetDevice(&device)))
+    {
+      return error;
+    }
+
+    if (const auto error = CubDebug(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, device)))
+    {
+      return error;
+    }
+
+    const int histo_block_threads = policy.histogram.threads_per_block;
+    int histo_blocks_per_sm       = 1;
+    auto histogram_kernel         = kernel_source.RadixSortHistogramKernel();
+
+    if (const auto error =
+          CubDebug(launcher_factory.MaxSmOccupancy(histo_blocks_per_sm, histogram_kernel, histo_block_threads, 0)))
+    {
+      return error;
+    }
+
+// log histogram_kernel configuration
+#ifdef CUB_DEBUG_LOG
+    _CubLog("Invoking histogram_kernel<<<%d, %d, 0, %lld>>>(), %d items per iteration, "
+            "%d SM occupancy, bit_grain %d\n",
+            histo_blocks_per_sm * num_sms,
+            histo_block_threads,
+            reinterpret_cast<long long>(stream),
+            policy.histogram.items_per_thread,
+            histo_blocks_per_sm,
+            policy.histogram.radix_bits);
+#endif
+
+    // exclusive sums to determine starts
+    const int scan_block_threads = policy.exclusive_sum.threads_per_block;
+
+// log exclusive_sum_kernel configuration
+#ifdef CUB_DEBUG_LOG
+    _CubLog("Invoking exclusive_sum_kernel<<<%d, %d, 0, %lld>>>(), bit_grain %d\n",
+            num_passes,
+            scan_block_threads,
+            reinterpret_cast<long long>(stream),
+            policy.exclusive_sum.radix_bits);
+#endif
+
+    // Initialization is intentionally adjacent to the histogram launch. For the PDL path, this avoids consuming the
+    // short init kernel's runtime in host-side launch setup work before the dependent histogram is submitted.
+    {
+      constexpr int init_startup_threads = 256;
+      const size_t num_init_items        = ::cuda::std::max(num_counter_items, num_bin_items);
+      const int init_startup_blocks =
+        static_cast<int>(::cuda::ceil_div(num_init_items, static_cast<size_t>(init_startup_threads)));
+
+#ifdef CUB_DEBUG_LOG
+      _CubLog("Invoking init_bins_and_counters_kernel<<<%d, %d, 0, %lld>>>()\n",
+              init_startup_blocks,
+              init_startup_threads,
+              reinterpret_cast<long long>(stream));
+#endif
+
+      if (const auto error = CubDebug(
+            launcher_factory(init_startup_blocks, init_startup_threads, 0, stream, use_pdl)
+              .doit(
+                kernel_source.RadixSortInitBinsAndCountersKernel(), d_ctrs, num_counter_items, d_bins, num_bin_items)))
+      {
+        return error;
+      }
+    }
+
+    if (const auto error = CubDebug(
+          launcher_factory(histo_blocks_per_sm * num_sms, histo_block_threads, 0, stream, use_pdl)
+            .doit(histogram_kernel, d_bins, d_keys.Current(), num_items, begin_bit, end_bit, decomposer)))
+    {
+      return error;
+    }
+
+    if (const auto error = CubDebug(launcher_factory(num_passes, scan_block_threads, 0, stream, use_pdl)
+                                      .doit(kernel_source.RadixSortExclusiveSumKernel(), d_bins)))
+    {
+      return error;
+    }
+
+    if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+    {
+      return error;
+    }
+
+    // use the other buffer if no overwrite is allowed
+    KeyT* d_keys_tmp     = d_keys.Alternate();
+    ValueT* d_values_tmp = d_values.Alternate();
+    if (!can_overwrite_source_buffer && num_passes % 2 == 0)
+    {
+      d_keys.d_buffers[1]   = d_keys_tmp2;
+      d_values.d_buffers[1] = d_values_tmp2;
+    }
+
+    for (int current_bit = begin_bit, pass = 0; current_bit < end_bit; current_bit += radix_bits, ++pass)
+    {
+      int num_bits = ::cuda::std::min(end_bit - current_bit, radix_bits);
+      for (OffsetT portion = 0; portion < num_portions; ++portion)
+      {
+        PortionOffsetT portion_num_items = static_cast<PortionOffsetT>(
+          ::cuda::std::min(num_items - portion * portion_size, static_cast<OffsetT>(portion_size)));
+
+        PortionOffsetT num_blocks       = ::cuda::ceil_div(portion_num_items, onesweep_tile_items);
+        const size_t num_lookback_items = static_cast<size_t>(num_blocks) * radix_digits;
+
+        if (use_pdl)
+        {
+          constexpr int init_lookback_threads = 256;
+          const int init_lookback_blocks =
+            static_cast<int>(::cuda::ceil_div(num_lookback_items, static_cast<size_t>(init_lookback_threads)));
+
+          if (const auto error = CubDebug(
+                launcher_factory(init_lookback_blocks, init_lookback_threads, 0, stream, use_pdl)
+                  .doit(
+                    kernel_source.RadixSortInitLookbackKernel(), d_lookback, num_lookback_items, d_lookback, size_t{0})))
+          {
+            return error;
+          }
+        }
+        else
+        {
+          if (const auto error =
+                CubDebug(cudaMemsetAsync(d_lookback, 0, num_lookback_items * sizeof(AtomicOffsetT), stream)))
+          {
+            return error;
+          }
+        }
+
+// log onesweep_kernel configuration
+#ifdef CUB_DEBUG_LOG
+        _CubLog("Invoking onesweep_kernel<<<%d, %d, 0, %lld>>>(), %d items per thread, "
+                "current bit %d, bit_grain %d, portion %d/%d\n",
+                num_blocks,
+                onesweep_block_threads,
+                reinterpret_cast<long long>(stream),
+                policy.onesweep.items_per_thread,
+                current_bit,
+                num_bits,
+                static_cast<int>(portion),
+                static_cast<int>(num_portions));
+#endif
+
+        auto onesweep_kernel = kernel_source.RadixSortOnesweepKernel();
+
+        if (const auto error = CubDebug(
+              launcher_factory(num_blocks, onesweep_block_threads, 0, stream, use_pdl)
+                .doit(
+                  onesweep_kernel,
+                  d_lookback,
+                  d_ctrs + portion * num_passes + pass,
+                  portion < num_portions - 1 ? d_bins + ((portion + 1) * num_passes + pass) * radix_digits : nullptr,
+                  d_bins + (portion * num_passes + pass) * radix_digits,
+                  d_keys.Alternate(),
+                  kernel_source.AdvanceKeys(d_keys.Current(), portion * portion_size),
+                  d_values.Alternate(),
+                  kernel_source.AdvanceValues(d_values.Current(), portion * portion_size),
+                  portion_num_items,
+                  current_bit,
+                  num_bits,
+                  decomposer)))
+        {
+          return error;
+        }
+
+        if (const auto error = CubDebug(detail::DebugSyncStream(stream)))
+        {
+          return error;
+        }
+      }
+
+      // use the temporary buffers if no overwrite is allowed
+      if (!can_overwrite_source_buffer && pass == 0)
+      {
+        d_keys   = num_passes % 2 == 0 ? DoubleBuffer<KeyT>(d_keys_tmp, d_keys_tmp2)
+                                       : DoubleBuffer<KeyT>(d_keys_tmp2, d_keys_tmp);
+        d_values = num_passes % 2 == 0 ? DoubleBuffer<ValueT>(d_values_tmp, d_values_tmp2)
+                                       : DoubleBuffer<ValueT>(d_values_tmp2, d_values_tmp);
+      }
+      d_keys.selector ^= 1;
+      d_values.selector ^= 1;
+    }
+
+    return cudaSuccess;
+  }
+
+  template <typename PolicyGetter>
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke(PolicyGetter policy_getter)
+  {
+    CUB_DETAIL_CONSTEXPR_ISH auto policy = policy_getter();
+
+    // Return if empty problem, or if no bits to sort and double-buffering is used
+    if (num_items == 0 || (begin_bit == end_bit && can_overwrite_source_buffer))
+    {
+      if (d_temp_storage == nullptr)
+      {
+        temp_storage_bytes = 1;
+      }
+      return cudaSuccess;
+    }
+
+    // Check if simple copy suffices (can_overwrite_source_buffer == false at this point)
+    if (begin_bit == end_bit)
+    {
+      bool has_uva = false;
+      if (const auto error = detail::HasUVA(has_uva))
+      {
+        return error;
+      }
+      if (has_uva)
+      {
+        return invoke_copy();
+      }
+    }
+
+    // Force kernel code-generation in all compiler passes
+    if (num_items <= static_cast<OffsetT>(policy.single_tile.threads_per_block * policy.single_tile.items_per_thread))
+    {
+      // Small, single tile size
+      return invoke_single_tile(kernel_source.RadixSortSingleTileKernel(), policy.single_tile);
+    }
+
+#if _CCCL_COMPILER(GCC, <, 10)
+    // gcc 7-9 fail to use `policy` in a constant expression, so we just compute it again inplace
+    if CUB_DETAIL_CONSTEXPR_ISH (PolicyGetter{}().algorithm == RadixSortAlgorithm::onesweep)
+#else // _CCCL_COMPILER(GCC, <, 10)
+    if CUB_DETAIL_CONSTEXPR_ISH (policy.algorithm == RadixSortAlgorithm::onesweep)
+#endif // _CCCL_COMPILER(GCC, <, 10)
+    {
+      return invoke_onesweep(policy);
+    }
+    else
+    {
+      return invoke_passes(
+        kernel_source.RadixSortUpsweepKernel(),
+        kernel_source.RadixSortAltUpsweepKernel(),
+        kernel_source.DeviceRadixSortScanBinsKernel(),
+        kernel_source.RadixSortDownsweepKernel(),
+        kernel_source.RadixSortAltDownsweepKernel(),
+        policy);
+    }
+  }
+};
 
 template <SortOrder Order,
           typename KeyT,
@@ -2017,7 +2011,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   OffsetT num_items,
   int begin_bit,
   int end_bit,
-  bool is_overwrite_okay,
+  bool can_overwrite_source_buffer,
   cudaStream_t stream,
   DecomposerT decomposer                 = {},
   PolicySelector policy_selector         = {},
@@ -2041,96 +2035,22 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
                }))
 #endif // _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
 
+  dispatch_impl<KeyT, ValueT, OffsetT, DecomposerT, KernelSource, KernelLauncherFactory> impl{
+    d_temp_storage,
+    temp_storage_bytes,
+    d_keys,
+    d_values,
+    num_items,
+    begin_bit,
+    end_bit,
+    can_overwrite_source_buffer,
+    stream,
+    decomposer,
+    kernel_source,
+    launcher_factory};
+
   return dispatch_compute_cap(policy_selector, cc, [&](auto policy_getter) {
-    CUB_DETAIL_CONSTEXPR_ISH auto policy = policy_getter();
-
-    // Return if empty problem, or if no bits to sort and double-buffering is used
-    if (num_items == 0 || (begin_bit == end_bit && is_overwrite_okay))
-    {
-      if (d_temp_storage == nullptr)
-      {
-        temp_storage_bytes = 1;
-      }
-      return cudaSuccess;
-    }
-
-    // Check if simple copy suffices (is_overwrite_okay == false at this point)
-    if (begin_bit == end_bit)
-    {
-      bool has_uva = false;
-      if (const auto error = detail::HasUVA(has_uva))
-      {
-        return error;
-      }
-      if (has_uva)
-      {
-        return invoke_copy(d_temp_storage, temp_storage_bytes, d_keys, d_values, num_items, stream, kernel_source);
-      }
-    }
-
-    // Force kernel code-generation in all compiler passes
-    if (num_items <= static_cast<OffsetT>(policy.single_tile.threads_per_block * policy.single_tile.items_per_thread))
-    {
-      // Small, single tile size
-      return invoke_single_tile(
-        kernel_source.RadixSortSingleTileKernel(),
-        policy.single_tile,
-        d_temp_storage,
-        temp_storage_bytes,
-        d_keys,
-        d_values,
-        num_items,
-        begin_bit,
-        end_bit,
-        stream,
-        decomposer,
-        launcher_factory);
-    }
-
-#if _CCCL_COMPILER(GCC, <, 10)
-    // gcc 7-9 fail to use `policy` in a constant expression, so we just compute it again inplace
-    if CUB_DETAIL_CONSTEXPR_ISH (decltype(policy_getter){}().algorithm == RadixSortAlgorithm::onesweep)
-#else // _CCCL_COMPILER(GCC, <, 10)
-    if CUB_DETAIL_CONSTEXPR_ISH (policy.algorithm == RadixSortAlgorithm::onesweep)
-#endif // _CCCL_COMPILER(GCC, <, 10)
-    {
-      return invoke_onesweep(
-        policy,
-        d_temp_storage,
-        temp_storage_bytes,
-        d_keys,
-        d_values,
-        num_items,
-        begin_bit,
-        end_bit,
-        is_overwrite_okay,
-        stream,
-        decomposer,
-        kernel_source,
-        launcher_factory);
-    }
-    else
-    {
-      return invoke_passes(
-        kernel_source.RadixSortUpsweepKernel(),
-        kernel_source.RadixSortAltUpsweepKernel(),
-        kernel_source.DeviceRadixSortScanBinsKernel(),
-        kernel_source.RadixSortDownsweepKernel(),
-        kernel_source.RadixSortAltDownsweepKernel(),
-        policy,
-        d_temp_storage,
-        temp_storage_bytes,
-        d_keys,
-        d_values,
-        num_items,
-        begin_bit,
-        end_bit,
-        is_overwrite_okay,
-        stream,
-        decomposer,
-        kernel_source,
-        launcher_factory);
-    }
+    return impl.invoke(policy_getter);
   });
 }
 } // namespace detail::radix_sort


### PR DESCRIPTION
- [x] No SASS changes for `cub.bench.radix_sort.pairs.base` on SM`75;80;90;100`