### PR TITLE
Use __builtin_bitreverseg in cuda::bit_reverse

### DIFF
--- a/libcudacxx/include/cuda/__bit/bit_reverse.h
+++ b/libcudacxx/include/cuda/__bit/bit_reverse.h
@@ -42,12 +42,17 @@
 #  define _CCCL_BUILTIN_BITREVERSE64(...) __builtin_bitreverse64(__VA_ARGS__)
 #endif
 
+#if _CCCL_CHECK_BUILTIN(builtin_bitreverseg)
+#  define _CCCL_BUILTIN_BITREVERSEG(...) __builtin_bitreverseg(__VA_ARGS__)
+#endif
+
 // nvcc doesn't allow clang's bitreverse builtin
 #if _CCCL_CUDA_COMPILER(NVCC)
 #  undef _CCCL_BUILTIN_BITREVERSE8
 #  undef _CCCL_BUILTIN_BITREVERSE16
 #  undef _CCCL_BUILTIN_BITREVERSE32
 #  undef _CCCL_BUILTIN_BITREVERSE64
+#  undef _CCCL_BUILTIN_BITREVERSEG
 #endif // _CCCL_CUDA_COMPILER(NVCC)
 
 _CCCL_BEGIN_NAMESPACE_CUDA
@@ -186,7 +191,9 @@ template <typename _Tp>
     NV_IF_TARGET(NV_IS_DEVICE, (return ::cuda::__bit_reverse_device(__value);))
   }
 #endif // !_CCCL_TILE_COMPILATION()
-#if defined(_CCCL_BUILTIN_BITREVERSE32)
+#if defined(_CCCL_BUILTIN_BITREVERSEG)
+  return _CCCL_BUILTIN_BITREVERSEG(__value);
+#elif defined(_CCCL_BUILTIN_BITREVERSE32)
   return ::cuda::__bit_reverse_builtin(__value);
 #else
   return ::cuda::__bit_reverse_generic(__value);


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

https://github.com/NVIDIA/cccl/issues/7779

<!-- Provide a standalone description of changes in this PR. -->

Use `__builtin_bitreverseg`, the generic type-deducing bit-reverse builtin available in Clang 23+ (not released yet) in `cuda::bit_reverse`. Falls back to the existing per-type builtins or software implementation when unavailable.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
