### PR TITLE
[HostJit] Properly use `__declspec` on windows 

### DIFF
--- a/c/parallel.v2/src/hostjit/codegen/cub_call.cpp
+++ b/c/parallel.v2/src/hostjit/codegen/cub_call.cpp
@@ -111,9 +111,9 @@ bool needs_env_include(const std::vector<Arg>& args)
   return false;
 }
 
-// Emits the system #includes + the CUB header + EXPORT macro defn. Hoisted
-// from source() so multi-function compiles can emit this once and wrap N
-// function bodies in N namespaces below.
+// Emits the system #includes + the CUB header. Hoisted from source() so
+// multi-function compiles can emit this once and wrap N function bodies in N
+// namespaces below.
 std::string shared_includes(const std::string& cub_include, bool needs_tuple, bool needs_env)
 {
   std::string src = R"(#include <cuda_runtime.h>
@@ -135,21 +135,13 @@ std::string shared_includes(const std::string& cub_include, bool needs_tuple, bo
     src += "#include <cuda/stream_ref>\n";
   }
   src += std::format("#include <{}>\n\n", cub_include);
-
-  src += R"(#ifdef _WIN32
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT __attribute__((visibility("default")))
-#endif
-
-)";
   return src;
 }
 } // namespace
 
 std::string CubCall::source() const
 {
-  // Single-function source = shared includes/EXPORT + this CubCall's body.
+  // Single-function source = shared includes + this CubCall's body.
   return shared_includes(include_, tuple_inputs_, needs_env_include(args_)) + body();
 }
 
@@ -493,12 +485,12 @@ std::string CubCall::body() const
   }
 
   // Assemble the per-function body: preamble + extern "C" function defn.
-  // System #includes and the EXPORT macro live in shared_includes(), emitted
-  // once at TU scope by either source() (single-fn) or compile() (multi-fn).
+  // System #includes live in shared_includes(), emitted once at TU scope by
+  // either source() (single-fn) or compile() (multi-fn).
   std::string src = preamble;
 
   // Function signature
-  src += std::format("extern \"C\" EXPORT int {}(\n", fn_name_);
+  src += std::format("extern \"C\" _CCCL_VISIBILITY_EXPORT int {}(\n", fn_name_);
   for (size_t i = 0; i < params.size(); ++i)
   {
     src += "    " + params[i];
@@ -745,7 +737,7 @@ MultiCubCallResult CubCall::compile(
 
   // entry_point_name is used to mark a single function as preserved during
   // internalization. Use the first CubCall's name as the primary entry; the
-  // others will still be exported via extern "C" EXPORT so dlsym finds them.
+  // others will still be exported via extern "C" _CCCL_VISIBILITY_EXPORT so dlsym finds them.
   auto jit_config = make_jit_config(cc_major, cc_minor, config, ctk_path, cccl_include_path, calls.begin()->fn_name_);
 
   // Shared BitcodeCollector across all CubCalls — identical user-op or
@@ -762,10 +754,11 @@ MultiCubCallResult CubCall::compile(
     cb.collect_bitcode(bitcode, op_idx, in_idx, out_idx);
   }
 
-  // Build the merged source: shared includes + EXPORT macro at TU scope,
-  // then one `namespace fn_<i> { ... body() }` per CubCall. The extern "C"
-  // EXPORT symbols defined inside each namespace export under the global
-  // C-linkage name (no mangling), so dlsym(handle, cb.fn_name_) finds them.
+  // Build the merged source: shared includes at TU scope, then one
+  // `namespace fn_<i> { ... body() }` per CubCall.
+  // The extern "C" _CCCL_VISIBILITY_EXPORT symbols defined inside each
+  // namespace export under the global C-linkage name (no mangling),
+  // so dlsym(handle, cb.fn_name_) finds them.
   std::string cuda_source = shared_includes(shared_include, any_tuple, any_env);
   int i                   = 0;
   for (const auto& cb : calls)

--- a/c/parallel.v2/src/hostjit/include/hostjit/codegen/cub_call.hpp
+++ b/c/parallel.v2/src/hostjit/include/hostjit/codegen/cub_call.hpp
@@ -280,8 +280,8 @@ private:
   bool tuple_inputs_ = false;
 
   // Internal: just the per-function body (preamble + function defn), no
-  // shared #includes and no EXPORT macro. Used by the multi-compile path to
-  // wrap N bodies in N namespaces under a single shared include block.
+  // shared #includes. Used by the multi-compile path to wrap N bodies in
+  // N namespaces under a single shared include block.
   std::string body() const;
 
   // Internal: walk args_ and register any user-op / iterator bitcode with

--- a/libcudacxx/include/cuda/std/__cccl/visibility.h
+++ b/libcudacxx/include/cuda/std/__cccl/visibility.h
@@ -30,6 +30,7 @@
 #include <cuda/std/__cccl/attributes.h>
 #include <cuda/std/__cccl/cuda_capabilities.h>
 #include <cuda/std/__cccl/execution_space.h>
+#include <cuda/std/__cccl/os.h>
 
 // For unknown reasons, nvc++ need to selectively disable this warning
 // We do not want to use our usual macro because that would have push / pop semantics
@@ -38,27 +39,29 @@
 #endif // _CCCL_COMPILER(NVHPC)
 
 // Enable us to hide kernels
-#if _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
+#if _CCCL_OS(WINDOWS) || _CCCL_COMPILER(NVRTC)
 #  define _CCCL_VISIBILITY_HIDDEN
 #else // ^^^ _CCCL_COMPILER(NVRTC) ^^^ / vvv _CCCL_COMPILER(NVRTC) vvv
 #  define _CCCL_VISIBILITY_HIDDEN __attribute__((__visibility__("hidden")))
 #endif // !_CCCL_COMPILER(NVRTC)
 
-#if _CCCL_COMPILER(MSVC)
-#  define _CCCL_VISIBILITY_DEFAULT __declspec(dllimport)
-#elif _CCCL_COMPILER(NVRTC) // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv _CCCL_COMPILER(NVRTC) vvv
+#if _CCCL_COMPILER(NVRTC)
 #  define _CCCL_VISIBILITY_DEFAULT
+#elif _CCCL_OS(WINDOWS)
+#  define _CCCL_VISIBILITY_DEFAULT __declspec(dllimport)
 #else // ^^^ _CCCL_COMPILER(NVRTC) ^^^ / vvv !_CCCL_COMPILER(NVRTC) vvv
 #  define _CCCL_VISIBILITY_DEFAULT __attribute__((__visibility__("default")))
 #endif // !_CCCL_COMPILER(NVRTC)
 
-#if _CCCL_COMPILER(MSVC)
+#if _CCCL_COMPILER(NVRTC)
+#  define _CCCL_VISIBILITY_EXPORT
+#elif _CCCL_OS(WINDOWS)
 #  define _CCCL_VISIBILITY_EXPORT __declspec(dllexport)
 #else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
 #  define _CCCL_VISIBILITY_EXPORT _CCCL_VISIBILITY_DEFAULT
 #endif // !_CCCL_COMPILER(MSVC)
 
-#if _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
+#if _CCCL_OS(WINDOWS) || _CCCL_COMPILER(NVRTC)
 #  define _CCCL_TYPE_VISIBILITY_DEFAULT
 #  define _CCCL_TYPE_VISIBILITY_HIDDEN
 #elif _CCCL_HAS_ATTRIBUTE(__type_visibility__)
@@ -77,7 +80,9 @@
 #  define _CCCL_FORCEINLINE_LAMBDA __attribute__((__always_inline__))
 #endif // ^^^ !_CCCL_COMPILER(MSVC) ^^^
 
-#if _CCCL_COMPILER(MSVC)
+#if _CCCL_COMPILER(NVRTC)
+#  define _CCCL_NOINLINE __attribute__((noinline))
+#elif _CCCL_OS(WINDOWS)
 #  define _CCCL_NOINLINE __declspec(noinline)
 #else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv _CCCL_COMPILER(MSVC) vvv
 // We can't use __noinline__ here because of CTK defining this macro.
@@ -154,15 +159,15 @@
 // of a member of a class that is declared `__attribute__((visibility("default")))`, GCC
 // complains bitterly. So we avoid declaring those functions `hidden`. Instead of the
 // typical `_CCCL_API` macro, we use `_CCCL_PUBLIC_API` for those functions.
-#if _CCCL_COMPILER(MSVC)
+#if _CCCL_OS(WINDOWS)
 #  define _CCCL_PUBLIC_API        _CCCL_HOST_DEVICE
 #  define _CCCL_PUBLIC_HOST_API   _CCCL_HOST
 #  define _CCCL_PUBLIC_DEVICE_API _CCCL_DEVICE
-#else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
+#else // ^^^ _CCCL_OS(WINDOWS) ^^^ / vvv !_CCCL_OS(WINDOWS) vvv
 #  define _CCCL_PUBLIC_API        _CCCL_HOST_DEVICE _CCCL_VISIBILITY_DEFAULT
 #  define _CCCL_PUBLIC_HOST_API   _CCCL_HOST _CCCL_VISIBILITY_DEFAULT
 #  define _CCCL_PUBLIC_DEVICE_API _CCCL_DEVICE _CCCL_VISIBILITY_DEFAULT
-#endif // !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_OS(WINDOWS)
 
 #ifdef _CCCL_DOXYGEN_INVOKED // Only for documentation
 //! If defined, usage of CUDA Dynamic Parallelism is disabled and APIs launching kernels can only be called from the


### PR DESCRIPTION
Currently we only check for the visual studio compiler. 

However, this does not work properly when e.g building with clang-cl on windows.

We need to use the declspec  attributes whenever we link on windows, so fix that