### PR TITLE
[STF] Fix data race on stackable_logical_data across host threads

### DIFF
--- a/cudax/include/cuda/experimental/__stf/stackable/stackable_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/stackable/stackable_ctx.cuh
@@ -148,24 +148,22 @@ public:
     return data().data_root_offset;
   }
 
-  const auto& get_ld(int offset) const
+  // Returns a *copy* of the logical_data handle (not a reference into
+  // data_nodes). The data_nodes vector can be reallocated by a concurrent
+  // push_at()/grow_data_nodes() running on another host thread that shares
+  // this logical data, so a reference into the vector would dangle as soon as
+  // the shared lock below is released. The handle itself is a cheap shared_ptr
+  // wrapper and stays valid regardless of vector growth.
+  logical_data<T> get_ld(int offset) const
   {
+    auto lock = data().acquire_shared_lock();
     _CCCL_ASSERT(offset >= 0 && data().was_imported(offset), "Failed to find imported data");
     return data().get_data_node(offset).ld;
   }
 
-  auto& get_ld(int offset)
-  {
-    _CCCL_ASSERT(offset >= 0 && mut_data().was_imported(offset), "Failed to find imported data");
-    return mut_data().get_data_node(offset).ld;
-  }
-
   int get_unique_id() const
   {
-    const int root = get_data_root_offset();
-    _CCCL_ASSERT(root >= 0, "");
-    _CCCL_ASSERT(data().data_nodes[static_cast<size_t>(root)].has_value(), "");
-    return data().get_data_node(root).ld.get_unique_id();
+    return get_ld(get_data_root_offset()).get_unique_id();
   }
 
   void push(int ctx_offset, access_mode m, data_place where = data_place::invalid()) const
@@ -756,7 +754,7 @@ public:
   // Callers must ensure validate_access has already been called for this offset.
   task_dep<T, reduce_op, initialize> resolve(int context_offset) const
   {
-    auto& context_ld = d.get_ld(context_offset);
+    auto context_ld = d.get_ld(context_offset);
     return task_dep<T, reduce_op, initialize>(context_ld, mode, dplace);
   }
 

--- a/cudax/include/cuda/experimental/__stf/stackable/stackable_ctx_impl.cuh
+++ b/cudax/include/cuda/experimental/__stf/stackable/stackable_ctx_impl.cuh
@@ -173,7 +173,7 @@ public:
         };
 
         info.resolve_op = [logical_data](int offset, access_mode mode) mutable -> task_dep_untyped {
-          auto& ld = logical_data.get_ld(offset);
+          auto ld = logical_data.get_ld(offset);
           return task_dep_untyped(ld, mode);
         };
 

--- a/cudax/include/cuda/experimental/__stf/stackable/stackable_ctx_impl.cuh
+++ b/cudax/include/cuda/experimental/__stf/stackable/stackable_ctx_impl.cuh
@@ -1827,7 +1827,11 @@ public:
       abort();
     }
 
-    return get_ctx(offset).wait(ldata.get_ld(offset));
+    // get_ld() returns a logical_data handle by value (a copy), so bind it to a
+    // named local: context::wait() takes a non-const lvalue reference and cannot
+    // bind to the temporary directly.
+    auto ld = ldata.get_ld(offset);
+    return get_ctx(offset).wait(ld);
   }
 
   auto get_dot()


### PR DESCRIPTION
## Summary
- When a `stackable_logical_data` is shared by several host threads (e.g. a read-only input consumed by concurrent worker threads), its shared `state::data_nodes` vector could be **reallocated** by `push_at()` / `grow_data_nodes()` on one thread (under the state's exclusive lock) while another thread read it through `get_unique_id()` / `get_ld()` / `shape()` **with no lock**. This is a data race on the vector, seen intermittently as `get_unique_id: data_nodes[root].has_value()` assertion aborts.
- The read accessors now take the state's shared lock, and `get_ld()` returns a **copy** of the `logical_data` handle rather than a reference into `data_nodes` (a returned reference would dangle as soon as the lock is released and another thread reallocates the vector). `task_dep` copies the handle at construction, so callers only needed to bind by value.

## Test plan
- Reproduced the original failure (`cudax.test.stf.local_stf.stackable_threads`) and confirmed the race with **ThreadSanitizer** (host instrumentation): writer `vector::resize` in `grow_data_nodes` racing reader `operator[]` in `get_unique_id`.
- After the fix: ThreadSanitizer reports **0** `data_nodes` read/resize races (down from the racing pair), and the test passes **60/60** runs on an RTX 3080 Ti (sm_86) with `CCCL_ENABLE_ASSERTIONS`.
- [ ] Full cudax CI