### PR TITLE
[STF] Make exec_place/data_place singletons thread-safe

### DIFF
--- a/cudax/include/cuda/experimental/__places/places.cuh
+++ b/cudax/include/cuda/experimental/__places/places.cuh
@@ -91,7 +91,15 @@ class data_place
   static ::std::shared_ptr<data_place_interface> make_static_instance()
   {
     static T instance;
-    return ::std::shared_ptr<data_place_interface>(&instance, [](data_place_interface*) {});
+    // Build the aliasing shared_ptr exactly once and hand out copies. Besides
+    // avoiding a redundant control block per call, this keeps the factory
+    // thread-safe if T ever derives from enable_shared_from_this: constructing
+    // a shared_ptr from a raw pointer writes the object's weak-this member, so
+    // doing it on every call would race across host threads. The guarded
+    // function-local static performs that write once; later calls only copy
+    // the handle (atomic refcount bump).
+    static ::std::shared_ptr<data_place_interface> handle{&instance, [](data_place_interface*) {}};
+    return handle;
   }
 
 public:
@@ -542,7 +550,15 @@ public:
   static ::std::shared_ptr<impl> make_static_instance()
   {
     static T instance;
-    return ::std::shared_ptr<impl>(&instance, [](impl*) {});
+    // Build the aliasing shared_ptr exactly once and hand out copies.
+    // exec_place::impl derives from enable_shared_from_this, so constructing a
+    // shared_ptr from the raw &instance writes the object's weak-this member.
+    // Doing that on every call races when multiple host threads request the
+    // same singleton (e.g. concurrent parallel_for -> exec_place::current_device()).
+    // The guarded function-local static performs that write once; later calls
+    // only copy the handle (atomic refcount bump).
+    static ::std::shared_ptr<impl> handle{&instance, [](impl*) {}};
+    return handle;
   }
 
   exec_place() = default;

--- a/cudax/include/cuda/experimental/__places/places.cuh
+++ b/cudax/include/cuda/experimental/__places/places.cuh
@@ -1080,8 +1080,12 @@ public:
   ::std::shared_ptr<exec_place::impl> get_place(size_t idx) override
   {
     _CCCL_ASSERT(idx == 0, "Index out of bounds for host exec_place");
-    // Static instance - use no-op deleter instead of shared_from_this()
-    return ::std::shared_ptr<impl>(this, [](impl*) {});
+    // This singleton is owned by the permanent shared_ptr created once in
+    // make_static_instance(), so shared_from_this() is valid here. Unlike
+    // re-wrapping ``this`` in a fresh shared_ptr, it does not mutate the
+    // enable_shared_from_this weak-this member; it only bumps the atomic
+    // reference count, which is safe to call concurrently from host threads.
+    return shared_from_this();
   }
 
   // Activation - no-op for host
@@ -1152,8 +1156,12 @@ public:
   ::std::shared_ptr<exec_place::impl> get_place(size_t idx) override
   {
     _CCCL_ASSERT(idx == 0, "Index out of bounds for device_auto exec_place");
-    // Static instance - use no-op deleter instead of shared_from_this()
-    return ::std::shared_ptr<impl>(this, [](impl*) {});
+    // This singleton is owned by the permanent shared_ptr created once in
+    // make_static_instance(), so shared_from_this() is valid here. Unlike
+    // re-wrapping ``this`` in a fresh shared_ptr, it does not mutate the
+    // enable_shared_from_this weak-this member; it only bumps the atomic
+    // reference count, which is safe to call concurrently from host threads.
+    return shared_from_this();
   }
 
   ::std::string to_string() const override


### PR DESCRIPTION
## Summary
- `make_static_instance()` built a fresh aliasing `shared_ptr` from a raw pointer to a function-local static on **every call**. Because `exec_place::impl` derives from `std::enable_shared_from_this`, constructing a `shared_ptr` from the raw pointer writes the object's weak-this member (a check-then-set on `use_count`). Concurrent host threads doing `parallel_for -> exec_place::current_device()` therefore raced on that shared static.
- Build the aliasing `shared_ptr` **exactly once** via a guarded function-local static and hand out copies (atomic refcount bumps). This removes the race, avoids manufacturing a redundant control block per call, and keeps the factory correct should `data_place_interface` ever adopt `enable_shared_from_this`.

## Test plan
- Confirmed the race with **ThreadSanitizer**: `__weak_ptr::_M_assign` vs `_M_get_use_count` on `exec_place::make_static_instance<exec_place_device_auto_impl>()::instance`.
- After the fix (combined with the `stackable_logical_data` locking fix): ThreadSanitizer reports **0** `exec_place`-static / shared_ptr data races in `cudax.test.stf.local_stf.stackable_threads` (down from 100+).
- [ ] Full cudax CI

Note: this is independent of and complementary to the `stackable_logical_data` data-race fix; a separate `lock-order-inversion` category in the graph backend remains and is left for a follow-up.