### PR TITLE
[thrust] Use CCCL Runtime in Thrust set operation tests

### DIFF
--- a/thrust/testing/cuda/cccl_runtime_test_helper.cuh
+++ b/thrust/testing/cuda/cccl_runtime_test_helper.cuh
@@ -1,5 +1,9 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
+#include <cuda/__cccl_config>
 #include <cuda/algorithm>
 #include <cuda/devices>
 #include <cuda/launch>
@@ -8,28 +12,28 @@
 #include <cuda/std/span>
 #include <cuda/stream>
 
+#include <cstdio>
+#include <vector>
+
 #include <cuda_runtime_api.h>
 
 #include <unittest/unittest.h>
 
-#include <cstdio>
-#include <vector>
-
-namespace test
+namespace test_runtime
 {
-inline cuda::device_ref current_test_device()
+[[nodiscard]] _CCCL_HOST_API cuda::device_ref current_test_device()
 {
   int device = 0;
   ASSERT_EQUAL(cudaSuccess, cudaGetDevice(&device));
   return cuda::device_ref{device};
 }
 
-inline auto single_thread_config()
+[[nodiscard]] _CCCL_HOST_API auto single_thread_config()
 {
   return cuda::make_config(cuda::make_hierarchy(cuda::grid_dims(1), cuda::block_dims<1>()));
 }
 
-__device__ inline void assert_device(bool condition, const char* expression, const char* file, int line)
+_CCCL_DEVICE_API void assert_device(bool condition, const char* expression, const char* file, int line) noexcept
 {
   if (!condition)
   {
@@ -39,7 +43,7 @@ __device__ inline void assert_device(bool condition, const char* expression, con
 }
 
 template <typename Buffer>
-void assert_equal(cuda::stream_ref stream, Buffer& buffer, cuda::std::initializer_list<int> expected)
+_CCCL_HOST_API void assert_equal(cuda::stream_ref stream, Buffer& buffer, cuda::std::initializer_list<int> expected)
 {
   std::vector<int> actual(buffer.size());
   cuda::copy_bytes(stream, buffer, actual);
@@ -52,6 +56,6 @@ void assert_equal(cuda::stream_ref stream, Buffer& buffer, cuda::std::initialize
     ASSERT_EQUAL(expected.begin()[i], actual[i]);
   }
 }
-} // namespace test
+} // namespace test_runtime
 
-#define TEST_ASSERT_DEVICE(condition) ::test::assert_device((condition), #condition, __FILE__, __LINE__)
+#define TEST_ASSERT_DEVICE(condition) ::test_runtime::assert_device((condition), #condition, __FILE__, __LINE__)

--- a/thrust/testing/cuda/cccl_runtime_test_helper.cuh
+++ b/thrust/testing/cuda/cccl_runtime_test_helper.cuh
@@ -21,19 +21,19 @@
 
 namespace test_runtime
 {
-[[nodiscard]] _CCCL_HOST_API cuda::device_ref current_test_device()
+[[nodiscard]] _CCCL_HOST_API inline cuda::device_ref current_test_device()
 {
   int device = 0;
   ASSERT_EQUAL(cudaSuccess, cudaGetDevice(&device));
   return cuda::device_ref{device};
 }
 
-[[nodiscard]] _CCCL_HOST_API auto single_thread_config()
+[[nodiscard]] _CCCL_HOST_API inline auto single_thread_config()
 {
   return cuda::make_config(cuda::make_hierarchy(cuda::grid_dims(1), cuda::block_dims<1>()));
 }
 
-_CCCL_DEVICE_API void assert_device(bool condition, const char* expression, const char* file, int line) noexcept
+_CCCL_DEVICE_API inline void assert_device(bool condition, const char* expression, const char* file, int line) noexcept
 {
   if (!condition)
   {
@@ -43,7 +43,8 @@ _CCCL_DEVICE_API void assert_device(bool condition, const char* expression, cons
 }
 
 template <typename Buffer>
-_CCCL_HOST_API void assert_equal(cuda::stream_ref stream, Buffer& buffer, cuda::std::initializer_list<int> expected)
+_CCCL_HOST_API inline void
+assert_equal(cuda::stream_ref stream, Buffer& buffer, cuda::std::initializer_list<int> expected)
 {
   std::vector<int> actual(buffer.size());
   cuda::copy_bytes(stream, buffer, actual);

--- a/thrust/testing/cuda/cccl_runtime_test_helper.h
+++ b/thrust/testing/cuda/cccl_runtime_test_helper.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cuda/algorithm>
+#include <cuda/devices>
+#include <cuda/launch>
+#include <cuda/std/cstddef>
+#include <cuda/std/initializer_list>
+#include <cuda/std/span>
+#include <cuda/stream>
+
+#include <cuda_runtime_api.h>
+
+#include <unittest/unittest.h>
+
+#include <cstdio>
+#include <vector>
+
+namespace test
+{
+inline cuda::device_ref current_test_device()
+{
+  int device = 0;
+  ASSERT_EQUAL(cudaSuccess, cudaGetDevice(&device));
+  return cuda::device_ref{device};
+}
+
+inline auto single_thread_config()
+{
+  return cuda::make_config(cuda::make_hierarchy(cuda::grid_dims(1), cuda::block_dims<1>()));
+}
+
+__device__ inline void assert_device(bool condition, const char* expression, const char* file, int line)
+{
+  if (!condition)
+  {
+    printf("Device assertion failed: %s (%s:%d)\n", expression, file, line);
+    __trap();
+  }
+}
+
+template <typename Buffer>
+void assert_equal(cuda::stream_ref stream, Buffer& buffer, cuda::std::initializer_list<int> expected)
+{
+  std::vector<int> actual(buffer.size());
+  cuda::copy_bytes(stream, buffer, actual);
+  stream.sync();
+
+  ASSERT_EQUAL(actual.size(), expected.size());
+
+  for (cuda::std::size_t i = 0; i < expected.size(); ++i)
+  {
+    ASSERT_EQUAL(expected.begin()[i], actual[i]);
+  }
+}
+} // namespace test
+
+#define TEST_ASSERT_DEVICE(condition) ::test::assert_device((condition), #condition, __FILE__, __LINE__)

--- a/thrust/testing/cuda/set_difference.cu
+++ b/thrust/testing/cuda/set_difference.cu
@@ -2,13 +2,12 @@
 #include <thrust/set_operations.h>
 
 #include <cuda/buffer>
+#include <cuda/cccl_runtime_test_helper.cuh>
 #include <cuda/launch>
 #include <cuda/std/initializer_list>
 #include <cuda/stream>
 
 #include <unittest/unittest.h>
-
-#include "cccl_runtime_test_helper.h"
 
 #ifdef THRUST_TEST_DEVICE_SIDE
 struct set_difference_kernel
@@ -24,17 +23,17 @@ struct set_difference_kernel
 template <typename ExecutionPolicy>
 void TestSetDifferenceDevice(ExecutionPolicy exec)
 {
-  const auto device = test::current_test_device();
+  const auto device = test_runtime::current_test_device();
   cuda::stream stream{device};
 
-  auto a          = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 5});
-  auto b          = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 6});
-  auto result     = cuda::make_device_buffer<int>(stream, device, 2, cuda::no_init);
+  auto a      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 5});
+  auto b      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 6});
+  auto result = cuda::make_device_buffer<int>(stream, device, 2, cuda::no_init);
 
-  cuda::launch(stream, test::single_thread_config(), set_difference_kernel{}, exec, a, b, result);
+  cuda::launch(stream, test_runtime::single_thread_config(), set_difference_kernel{}, exec, a, b, result);
   stream.sync();
 
-  test::assert_equal(stream, result, {2, 5});
+  test_runtime::assert_equal(stream, result, {2, 5});
 }
 
 void TestSetDifferenceDeviceSeq()
@@ -52,7 +51,7 @@ DECLARE_UNITTEST(TestSetDifferenceDeviceDevice);
 
 void TestSetDifferenceCudaStreams()
 {
-  const auto device = test::current_test_device();
+  const auto device = test_runtime::current_test_device();
   cuda::stream stream{device};
 
   auto a      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 5});
@@ -63,6 +62,6 @@ void TestSetDifferenceCudaStreams()
     thrust::set_difference(thrust::cuda::par.on(stream.get()), a.begin(), a.end(), b.begin(), b.end(), result.begin());
 
   ASSERT_EQUAL_QUIET(result.end(), end);
-  test::assert_equal(stream, result, {2, 5});
+  test_runtime::assert_equal(stream, result, {2, 5});
 }
 DECLARE_UNITTEST(TestSetDifferenceCudaStreams);

--- a/thrust/testing/cuda/set_difference.cu
+++ b/thrust/testing/cuda/set_difference.cu
@@ -1,43 +1,40 @@
 #include <thrust/execution_policy.h>
 #include <thrust/set_operations.h>
 
+#include <cuda/buffer>
+#include <cuda/launch>
+#include <cuda/std/initializer_list>
+#include <cuda/stream>
+
 #include <unittest/unittest.h>
 
+#include "cccl_runtime_test_helper.h"
+
 #ifdef THRUST_TEST_DEVICE_SIDE
-template <typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4>
-__global__ void set_difference_kernel(
-  ExecutionPolicy exec,
-  Iterator1 first1,
-  Iterator1 last1,
-  Iterator2 first2,
-  Iterator2 last2,
-  Iterator3 result1,
-  Iterator4 result2)
+struct set_difference_kernel
 {
-  *result2 = thrust::set_difference(exec, first1, last1, first2, last2, result1);
-}
+  template <typename ExecutionPolicy, typename Input1, typename Input2, typename Output>
+  __device__ void operator()(ExecutionPolicy exec, Input1 a, Input2 b, Output result) const
+  {
+    const auto end = thrust::set_difference(exec, a.begin(), a.end(), b.begin(), b.end(), result.begin());
+    TEST_ASSERT_DEVICE(end == result.end());
+  }
+};
 
 template <typename ExecutionPolicy>
 void TestSetDifferenceDevice(ExecutionPolicy exec)
 {
-  using Vector   = thrust::device_vector<int>;
-  using Iterator = typename Vector::iterator;
+  const auto device = test::current_test_device();
+  cuda::stream stream{device};
 
-  Vector a{0, 2, 4, 5}, b{0, 3, 3, 4, 6};
+  auto a          = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 5});
+  auto b          = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 6});
+  auto result     = cuda::make_device_buffer<int>(stream, device, 2, cuda::no_init);
 
-  Vector ref{2, 5};
-  Vector result(2);
+  cuda::launch(stream, test::single_thread_config(), set_difference_kernel{}, exec, a, b, result);
+  stream.sync();
 
-  thrust::device_vector<Iterator> end_vec(1);
-
-  set_difference_kernel<<<1, 1>>>(exec, a.begin(), a.end(), b.begin(), b.end(), result.begin(), end_vec.begin());
-  cudaError_t const err = cudaDeviceSynchronize();
-  ASSERT_EQUAL(cudaSuccess, err);
-
-  Iterator end = end_vec.front();
-
-  ASSERT_EQUAL_QUIET(result.end(), end);
-  ASSERT_EQUAL(ref, result);
+  test::assert_equal(stream, result, {2, 5});
 }
 
 void TestSetDifferenceDeviceSeq()
@@ -55,24 +52,17 @@ DECLARE_UNITTEST(TestSetDifferenceDeviceDevice);
 
 void TestSetDifferenceCudaStreams()
 {
-  using Vector   = thrust::device_vector<int>;
-  using Iterator = Vector::iterator;
+  const auto device = test::current_test_device();
+  cuda::stream stream{device};
 
-  Vector a{0, 2, 4, 5}, b{0, 3, 3, 4, 6};
+  auto a      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 5});
+  auto b      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 6});
+  auto result = cuda::make_device_buffer<int>(stream, device, 2, cuda::no_init);
 
-  Vector ref{2, 5};
-  Vector result(2);
-
-  cudaStream_t s;
-  cudaStreamCreate(&s);
-
-  Iterator end =
-    thrust::set_difference(thrust::cuda::par.on(s), a.begin(), a.end(), b.begin(), b.end(), result.begin());
-  cudaStreamSynchronize(s);
+  auto end =
+    thrust::set_difference(thrust::cuda::par.on(stream.get()), a.begin(), a.end(), b.begin(), b.end(), result.begin());
 
   ASSERT_EQUAL_QUIET(result.end(), end);
-  ASSERT_EQUAL(ref, result);
-
-  cudaStreamDestroy(s);
+  test::assert_equal(stream, result, {2, 5});
 }
 DECLARE_UNITTEST(TestSetDifferenceCudaStreams);

--- a/thrust/testing/cuda/set_difference_by_key.cu
+++ b/thrust/testing/cuda/set_difference_by_key.cu
@@ -3,13 +3,12 @@
 #include <thrust/sort.h>
 
 #include <cuda/buffer>
+#include <cuda/cccl_runtime_test_helper.cuh>
 #include <cuda/launch>
 #include <cuda/std/initializer_list>
 #include <cuda/stream>
 
 #include <unittest/unittest.h>
-
-#include "cccl_runtime_test_helper.h"
 
 #ifdef THRUST_TEST_DEVICE_SIDE
 struct set_difference_by_key_kernel
@@ -48,19 +47,19 @@ struct set_difference_by_key_kernel
 template <typename ExecutionPolicy>
 void TestSetDifferenceByKeyDevice(ExecutionPolicy exec)
 {
-  const auto device = test::current_test_device();
+  const auto device = test_runtime::current_test_device();
   cuda::stream stream{device};
 
-  auto a_key       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 5});
-  auto b_key       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 6});
-  auto a_val       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 0, 0, 0});
-  auto b_val       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{1, 1, 1, 1, 1});
-  auto result_key  = cuda::make_device_buffer<int>(stream, device, 2, cuda::no_init);
-  auto result_val  = cuda::make_device_buffer<int>(stream, device, 2, cuda::no_init);
+  auto a_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 5});
+  auto b_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 6});
+  auto a_val      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 0, 0, 0});
+  auto b_val      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{1, 1, 1, 1, 1});
+  auto result_key = cuda::make_device_buffer<int>(stream, device, 2, cuda::no_init);
+  auto result_val = cuda::make_device_buffer<int>(stream, device, 2, cuda::no_init);
 
   cuda::launch(
     stream,
-    test::single_thread_config(),
+    test_runtime::single_thread_config(),
     set_difference_by_key_kernel{},
     exec,
     a_key,
@@ -71,8 +70,8 @@ void TestSetDifferenceByKeyDevice(ExecutionPolicy exec)
     result_val);
   stream.sync();
 
-  test::assert_equal(stream, result_key, {2, 5});
-  test::assert_equal(stream, result_val, {0, 0});
+  test_runtime::assert_equal(stream, result_key, {2, 5});
+  test_runtime::assert_equal(stream, result_val, {0, 0});
 }
 
 void TestSetDifferenceByKeyDeviceSeq()
@@ -90,7 +89,7 @@ DECLARE_UNITTEST(TestSetDifferenceByKeyDeviceDevice);
 
 void TestSetDifferenceByKeyCudaStreams()
 {
-  const auto device = test::current_test_device();
+  const auto device = test_runtime::current_test_device();
   cuda::stream stream{device};
 
   auto a_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 5});
@@ -113,7 +112,7 @@ void TestSetDifferenceByKeyCudaStreams()
 
   ASSERT_EQUAL_QUIET(result_key.end(), end.first);
   ASSERT_EQUAL_QUIET(result_val.end(), end.second);
-  test::assert_equal(stream, result_key, {2, 5});
-  test::assert_equal(stream, result_val, {0, 0});
+  test_runtime::assert_equal(stream, result_key, {2, 5});
+  test_runtime::assert_equal(stream, result_val, {0, 0});
 }
 DECLARE_UNITTEST(TestSetDifferenceByKeyCudaStreams);

--- a/thrust/testing/cuda/set_difference_by_key.cu
+++ b/thrust/testing/cuda/set_difference_by_key.cu
@@ -2,69 +2,77 @@
 #include <thrust/set_operations.h>
 #include <thrust/sort.h>
 
+#include <cuda/buffer>
+#include <cuda/launch>
+#include <cuda/std/initializer_list>
+#include <cuda/stream>
+
 #include <unittest/unittest.h>
 
+#include "cccl_runtime_test_helper.h"
+
 #ifdef THRUST_TEST_DEVICE_SIDE
-template <typename ExecutionPolicy,
-          typename Iterator1,
-          typename Iterator2,
-          typename Iterator3,
-          typename Iterator4,
-          typename Iterator5,
-          typename Iterator6,
-          typename Iterator7>
-__global__ void set_difference_by_key_kernel(
-  ExecutionPolicy exec,
-  Iterator1 keys_first1,
-  Iterator1 keys_last1,
-  Iterator2 keys_first2,
-  Iterator2 keys_last2,
-  Iterator3 values_first1,
-  Iterator4 values_first2,
-  Iterator5 keys_result,
-  Iterator6 values_result,
-  Iterator7 result)
+struct set_difference_by_key_kernel
 {
-  *result = thrust::set_difference_by_key(
-    exec, keys_first1, keys_last1, keys_first2, keys_last2, values_first1, values_first2, keys_result, values_result);
-}
+  template <typename ExecutionPolicy,
+            typename Keys1,
+            typename Keys2,
+            typename Values1,
+            typename Values2,
+            typename KeysOutput,
+            typename ValuesOutput>
+  __device__ void operator()(
+    ExecutionPolicy exec,
+    Keys1 keys1,
+    Keys2 keys2,
+    Values1 values1,
+    Values2 values2,
+    KeysOutput keys_result,
+    ValuesOutput values_result) const
+  {
+    auto end = thrust::set_difference_by_key(
+      exec,
+      keys1.begin(),
+      keys1.end(),
+      keys2.begin(),
+      keys2.end(),
+      values1.begin(),
+      values2.begin(),
+      keys_result.begin(),
+      values_result.begin());
+    TEST_ASSERT_DEVICE(end.first == keys_result.end());
+    TEST_ASSERT_DEVICE(end.second == values_result.end());
+  }
+};
 
 template <typename ExecutionPolicy>
 void TestSetDifferenceByKeyDevice(ExecutionPolicy exec)
 {
-  using Vector   = thrust::device_vector<int>;
-  using Iterator = typename Vector::iterator;
+  const auto device = test::current_test_device();
+  cuda::stream stream{device};
 
-  Vector a_key{0, 2, 4, 5}, b_key{0, 3, 3, 4, 6};
-  Vector a_val(4, 0), b_val(5, 1);
+  auto a_key       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 5});
+  auto b_key       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 6});
+  auto a_val       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 0, 0, 0});
+  auto b_val       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{1, 1, 1, 1, 1});
+  auto result_key  = cuda::make_device_buffer<int>(stream, device, 2, cuda::no_init);
+  auto result_val  = cuda::make_device_buffer<int>(stream, device, 2, cuda::no_init);
 
-  Vector ref_key{2, 5}, ref_val{0, 0};
-  Vector result_key(2), result_val(2);
-
-  using iter_pair = cuda::std::pair<Iterator, Iterator>;
-
-  thrust::device_vector<iter_pair> end_vec(1);
-
-  set_difference_by_key_kernel<<<1, 1>>>(
+  cuda::launch(
+    stream,
+    test::single_thread_config(),
+    set_difference_by_key_kernel{},
     exec,
-    a_key.begin(),
-    a_key.end(),
-    b_key.begin(),
-    b_key.end(),
-    a_val.begin(),
-    b_val.begin(),
-    result_key.begin(),
-    result_val.begin(),
-    end_vec.begin());
-  cudaError_t const err = cudaDeviceSynchronize();
-  ASSERT_EQUAL(cudaSuccess, err);
+    a_key,
+    b_key,
+    a_val,
+    b_val,
+    result_key,
+    result_val);
+  stream.sync();
 
-  iter_pair end = end_vec.front();
-
-  ASSERT_EQUAL_QUIET(result_key.end(), end.first);
-  ASSERT_EQUAL_QUIET(result_val.end(), end.second);
-  ASSERT_EQUAL(ref_key, result_key);
-  ASSERT_EQUAL(ref_val, result_val);
+  test::assert_equal(stream, result_key, {2, 5});
+  test::assert_equal(stream, result_val, {0, 0});
 }
 
 void TestSetDifferenceByKeyDeviceSeq()
@@ -82,20 +90,18 @@ DECLARE_UNITTEST(TestSetDifferenceByKeyDeviceDevice);
 
 void TestSetDifferenceByKeyCudaStreams()
 {
-  using Vector   = thrust::device_vector<int>;
-  using Iterator = Vector::iterator;
+  const auto device = test::current_test_device();
+  cuda::stream stream{device};
 
-  Vector a_key{0, 2, 4, 5}, b_key{0, 3, 3, 4, 6};
-  Vector a_val(4, 0), b_val(5, 1);
+  auto a_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 5});
+  auto b_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 6});
+  auto a_val      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 0, 0, 0});
+  auto b_val      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{1, 1, 1, 1, 1});
+  auto result_key = cuda::make_device_buffer<int>(stream, device, 2, cuda::no_init);
+  auto result_val = cuda::make_device_buffer<int>(stream, device, 2, cuda::no_init);
 
-  Vector ref_key{2, 5}, ref_val{0, 0};
-  Vector result_key(2), result_val(2);
-
-  cudaStream_t s;
-  cudaStreamCreate(&s);
-
-  cuda::std::pair<Iterator, Iterator> end = thrust::set_difference_by_key(
-    thrust::cuda::par.on(s),
+  auto end = thrust::set_difference_by_key(
+    thrust::cuda::par.on(stream.get()),
     a_key.begin(),
     a_key.end(),
     b_key.begin(),
@@ -104,13 +110,10 @@ void TestSetDifferenceByKeyCudaStreams()
     b_val.begin(),
     result_key.begin(),
     result_val.begin());
-  cudaStreamSynchronize(s);
 
   ASSERT_EQUAL_QUIET(result_key.end(), end.first);
   ASSERT_EQUAL_QUIET(result_val.end(), end.second);
-  ASSERT_EQUAL(ref_key, result_key);
-  ASSERT_EQUAL(ref_val, result_val);
-
-  cudaStreamDestroy(s);
+  test::assert_equal(stream, result_key, {2, 5});
+  test::assert_equal(stream, result_val, {0, 0});
 }
 DECLARE_UNITTEST(TestSetDifferenceByKeyCudaStreams);

--- a/thrust/testing/cuda/set_symmetric_difference.cu
+++ b/thrust/testing/cuda/set_symmetric_difference.cu
@@ -2,13 +2,12 @@
 #include <thrust/set_operations.h>
 
 #include <cuda/buffer>
+#include <cuda/cccl_runtime_test_helper.cuh>
 #include <cuda/launch>
 #include <cuda/std/initializer_list>
 #include <cuda/stream>
 
 #include <unittest/unittest.h>
-
-#include "cccl_runtime_test_helper.h"
 
 #ifdef THRUST_TEST_DEVICE_SIDE
 struct set_symmetric_difference_kernel
@@ -24,17 +23,17 @@ struct set_symmetric_difference_kernel
 template <typename ExecutionPolicy>
 void TestSetSymmetricDifferenceDevice(ExecutionPolicy exec)
 {
-  const auto device = test::current_test_device();
+  const auto device = test_runtime::current_test_device();
   cuda::stream stream{device};
 
-  auto a          = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 6});
-  auto b          = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 7});
-  auto result     = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
+  auto a      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 6});
+  auto b      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 7});
+  auto result = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
 
-  cuda::launch(stream, test::single_thread_config(), set_symmetric_difference_kernel{}, exec, a, b, result);
+  cuda::launch(stream, test_runtime::single_thread_config(), set_symmetric_difference_kernel{}, exec, a, b, result);
   stream.sync();
 
-  test::assert_equal(stream, result, {2, 3, 3, 6, 7});
+  test_runtime::assert_equal(stream, result, {2, 3, 3, 6, 7});
 }
 
 void TestSetSymmetricDifferenceDeviceSeq()
@@ -52,7 +51,7 @@ DECLARE_UNITTEST(TestSetSymmetricDifferenceDeviceDevice);
 
 void TestSetSymmetricDifferenceCudaStreams()
 {
-  const auto device = test::current_test_device();
+  const auto device = test_runtime::current_test_device();
   cuda::stream stream{device};
 
   auto a      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 6});
@@ -63,6 +62,6 @@ void TestSetSymmetricDifferenceCudaStreams()
     thrust::cuda::par.on(stream.get()), a.begin(), a.end(), b.begin(), b.end(), result.begin());
 
   ASSERT_EQUAL_QUIET(result.end(), end);
-  test::assert_equal(stream, result, {2, 3, 3, 6, 7});
+  test_runtime::assert_equal(stream, result, {2, 3, 3, 6, 7});
 }
 DECLARE_UNITTEST(TestSetSymmetricDifferenceCudaStreams);

--- a/thrust/testing/cuda/set_symmetric_difference.cu
+++ b/thrust/testing/cuda/set_symmetric_difference.cu
@@ -1,43 +1,40 @@
 #include <thrust/execution_policy.h>
 #include <thrust/set_operations.h>
 
+#include <cuda/buffer>
+#include <cuda/launch>
+#include <cuda/std/initializer_list>
+#include <cuda/stream>
+
 #include <unittest/unittest.h>
 
+#include "cccl_runtime_test_helper.h"
+
 #ifdef THRUST_TEST_DEVICE_SIDE
-template <typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4>
-__global__ void set_symmetric_difference_kernel(
-  ExecutionPolicy exec,
-  Iterator1 first1,
-  Iterator1 last1,
-  Iterator2 first2,
-  Iterator2 last2,
-  Iterator3 result1,
-  Iterator4 result2)
+struct set_symmetric_difference_kernel
 {
-  *result2 = thrust::set_symmetric_difference(exec, first1, last1, first2, last2, result1);
-}
+  template <typename ExecutionPolicy, typename Input1, typename Input2, typename Output>
+  __device__ void operator()(ExecutionPolicy exec, Input1 a, Input2 b, Output result) const
+  {
+    const auto end = thrust::set_symmetric_difference(exec, a.begin(), a.end(), b.begin(), b.end(), result.begin());
+    TEST_ASSERT_DEVICE(end == result.end());
+  }
+};
 
 template <typename ExecutionPolicy>
 void TestSetSymmetricDifferenceDevice(ExecutionPolicy exec)
 {
-  using Vector   = thrust::device_vector<int>;
-  using Iterator = typename Vector::iterator;
+  const auto device = test::current_test_device();
+  cuda::stream stream{device};
 
-  Vector a{0, 2, 4, 6}, b{0, 3, 3, 4, 7};
+  auto a          = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 6});
+  auto b          = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 7});
+  auto result     = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
 
-  Vector ref{2, 3, 3, 6, 7};
-  Vector result(5);
-  thrust::device_vector<Iterator> end_vec(1);
+  cuda::launch(stream, test::single_thread_config(), set_symmetric_difference_kernel{}, exec, a, b, result);
+  stream.sync();
 
-  set_symmetric_difference_kernel<<<1, 1>>>(
-    exec, a.begin(), a.end(), b.begin(), b.end(), result.begin(), end_vec.begin());
-  cudaError_t const err = cudaDeviceSynchronize();
-  ASSERT_EQUAL(cudaSuccess, err);
-
-  Iterator end = end_vec[0];
-
-  ASSERT_EQUAL_QUIET(result.end(), end);
-  ASSERT_EQUAL(ref, result);
+  test::assert_equal(stream, result, {2, 3, 3, 6, 7});
 }
 
 void TestSetSymmetricDifferenceDeviceSeq()
@@ -55,24 +52,17 @@ DECLARE_UNITTEST(TestSetSymmetricDifferenceDeviceDevice);
 
 void TestSetSymmetricDifferenceCudaStreams()
 {
-  using Vector   = thrust::device_vector<int>;
-  using Iterator = Vector::iterator;
+  const auto device = test::current_test_device();
+  cuda::stream stream{device};
 
-  Vector a{0, 2, 4, 6}, b{0, 3, 3, 4, 7};
+  auto a      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 6});
+  auto b      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 7});
+  auto result = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
 
-  Vector ref{2, 3, 3, 6, 7};
-  Vector result(5);
-
-  cudaStream_t s;
-  cudaStreamCreate(&s);
-
-  Iterator end =
-    thrust::set_symmetric_difference(thrust::cuda::par.on(s), a.begin(), a.end(), b.begin(), b.end(), result.begin());
-  cudaStreamSynchronize(s);
+  auto end = thrust::set_symmetric_difference(
+    thrust::cuda::par.on(stream.get()), a.begin(), a.end(), b.begin(), b.end(), result.begin());
 
   ASSERT_EQUAL_QUIET(result.end(), end);
-  ASSERT_EQUAL(ref, result);
-
-  cudaStreamDestroy(s);
+  test::assert_equal(stream, result, {2, 3, 3, 6, 7});
 }
 DECLARE_UNITTEST(TestSetSymmetricDifferenceCudaStreams);

--- a/thrust/testing/cuda/set_symmetric_difference_by_key.cu
+++ b/thrust/testing/cuda/set_symmetric_difference_by_key.cu
@@ -2,13 +2,12 @@
 #include <thrust/set_operations.h>
 
 #include <cuda/buffer>
+#include <cuda/cccl_runtime_test_helper.cuh>
 #include <cuda/launch>
 #include <cuda/std/initializer_list>
 #include <cuda/stream>
 
 #include <unittest/unittest.h>
-
-#include "cccl_runtime_test_helper.h"
 
 #ifdef THRUST_TEST_DEVICE_SIDE
 struct set_symmetric_difference_by_key_kernel
@@ -47,19 +46,19 @@ struct set_symmetric_difference_by_key_kernel
 template <typename ExecutionPolicy>
 void TestSetSymmetricDifferenceByKeyDevice(ExecutionPolicy exec)
 {
-  const auto device = test::current_test_device();
+  const auto device = test_runtime::current_test_device();
   cuda::stream stream{device};
 
-  auto a_key       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 6});
-  auto b_key       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 7});
-  auto a_val       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 0, 0, 0});
-  auto b_val       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{1, 1, 1, 1, 1});
-  auto result_key  = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
-  auto result_val  = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
+  auto a_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 6});
+  auto b_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 7});
+  auto a_val      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 0, 0, 0});
+  auto b_val      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{1, 1, 1, 1, 1});
+  auto result_key = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
+  auto result_val = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
 
   cuda::launch(
     stream,
-    test::single_thread_config(),
+    test_runtime::single_thread_config(),
     set_symmetric_difference_by_key_kernel{},
     exec,
     a_key,
@@ -70,8 +69,8 @@ void TestSetSymmetricDifferenceByKeyDevice(ExecutionPolicy exec)
     result_val);
   stream.sync();
 
-  test::assert_equal(stream, result_key, {2, 3, 3, 6, 7});
-  test::assert_equal(stream, result_val, {0, 1, 1, 0, 1});
+  test_runtime::assert_equal(stream, result_key, {2, 3, 3, 6, 7});
+  test_runtime::assert_equal(stream, result_val, {0, 1, 1, 0, 1});
 }
 
 void TestSetSymmetricDifferenceByKeyDeviceSeq()
@@ -89,7 +88,7 @@ DECLARE_UNITTEST(TestSetSymmetricDifferenceByKeyDeviceDevice);
 
 void TestSetSymmetricDifferenceByKeyCudaStreams()
 {
-  const auto device = test::current_test_device();
+  const auto device = test_runtime::current_test_device();
   cuda::stream stream{device};
 
   auto a_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 6});
@@ -112,7 +111,7 @@ void TestSetSymmetricDifferenceByKeyCudaStreams()
 
   ASSERT_EQUAL_QUIET(result_key.end(), end.first);
   ASSERT_EQUAL_QUIET(result_val.end(), end.second);
-  test::assert_equal(stream, result_key, {2, 3, 3, 6, 7});
-  test::assert_equal(stream, result_val, {0, 1, 1, 0, 1});
+  test_runtime::assert_equal(stream, result_key, {2, 3, 3, 6, 7});
+  test_runtime::assert_equal(stream, result_val, {0, 1, 1, 0, 1});
 }
 DECLARE_UNITTEST(TestSetSymmetricDifferenceByKeyCudaStreams);

--- a/thrust/testing/cuda/set_symmetric_difference_by_key.cu
+++ b/thrust/testing/cuda/set_symmetric_difference_by_key.cu
@@ -1,68 +1,77 @@
 #include <thrust/execution_policy.h>
 #include <thrust/set_operations.h>
 
+#include <cuda/buffer>
+#include <cuda/launch>
+#include <cuda/std/initializer_list>
+#include <cuda/stream>
+
 #include <unittest/unittest.h>
 
+#include "cccl_runtime_test_helper.h"
+
 #ifdef THRUST_TEST_DEVICE_SIDE
-template <typename ExecutionPolicy,
-          typename Iterator1,
-          typename Iterator2,
-          typename Iterator3,
-          typename Iterator4,
-          typename Iterator5,
-          typename Iterator6,
-          typename Iterator7>
-__global__ void set_symmetric_difference_by_key_kernel(
-  ExecutionPolicy exec,
-  Iterator1 keys_first1,
-  Iterator1 keys_last1,
-  Iterator2 keys_first2,
-  Iterator2 keys_last2,
-  Iterator3 values_first1,
-  Iterator4 values_first2,
-  Iterator5 keys_result,
-  Iterator6 values_result,
-  Iterator7 result)
+struct set_symmetric_difference_by_key_kernel
 {
-  *result = thrust::set_symmetric_difference_by_key(
-    exec, keys_first1, keys_last1, keys_first2, keys_last2, values_first1, values_first2, keys_result, values_result);
-}
+  template <typename ExecutionPolicy,
+            typename Keys1,
+            typename Keys2,
+            typename Values1,
+            typename Values2,
+            typename KeysOutput,
+            typename ValuesOutput>
+  __device__ void operator()(
+    ExecutionPolicy exec,
+    Keys1 keys1,
+    Keys2 keys2,
+    Values1 values1,
+    Values2 values2,
+    KeysOutput keys_result,
+    ValuesOutput values_result) const
+  {
+    auto end = thrust::set_symmetric_difference_by_key(
+      exec,
+      keys1.begin(),
+      keys1.end(),
+      keys2.begin(),
+      keys2.end(),
+      values1.begin(),
+      values2.begin(),
+      keys_result.begin(),
+      values_result.begin());
+    TEST_ASSERT_DEVICE(end.first == keys_result.end());
+    TEST_ASSERT_DEVICE(end.second == values_result.end());
+  }
+};
 
 template <typename ExecutionPolicy>
 void TestSetSymmetricDifferenceByKeyDevice(ExecutionPolicy exec)
 {
-  using Vector   = thrust::device_vector<int>;
-  using Iterator = typename Vector::iterator;
+  const auto device = test::current_test_device();
+  cuda::stream stream{device};
 
-  Vector a_key{0, 2, 4, 6}, b_key{0, 3, 3, 4, 7};
-  Vector a_val(4, 0), b_val(5, 1);
+  auto a_key       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 6});
+  auto b_key       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 7});
+  auto a_val       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 0, 0, 0});
+  auto b_val       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{1, 1, 1, 1, 1});
+  auto result_key  = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
+  auto result_val  = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
 
-  Vector ref_key{2, 3, 3, 6, 7}, ref_val{0, 1, 1, 0, 1};
-  Vector result_key(5), result_val(5);
-
-  using iter_pair = cuda::std::pair<Iterator, Iterator>;
-  thrust::device_vector<iter_pair> end_vec(1);
-
-  set_symmetric_difference_by_key_kernel<<<1, 1>>>(
+  cuda::launch(
+    stream,
+    test::single_thread_config(),
+    set_symmetric_difference_by_key_kernel{},
     exec,
-    a_key.begin(),
-    a_key.end(),
-    b_key.begin(),
-    b_key.end(),
-    a_val.begin(),
-    b_val.begin(),
-    result_key.begin(),
-    result_val.begin(),
-    end_vec.begin());
-  cudaError_t const err = cudaDeviceSynchronize();
-  ASSERT_EQUAL(cudaSuccess, err);
+    a_key,
+    b_key,
+    a_val,
+    b_val,
+    result_key,
+    result_val);
+  stream.sync();
 
-  iter_pair end = end_vec[0];
-
-  ASSERT_EQUAL_QUIET(result_key.end(), end.first);
-  ASSERT_EQUAL_QUIET(result_val.end(), end.second);
-  ASSERT_EQUAL(ref_key, result_key);
-  ASSERT_EQUAL(ref_val, result_val);
+  test::assert_equal(stream, result_key, {2, 3, 3, 6, 7});
+  test::assert_equal(stream, result_val, {0, 1, 1, 0, 1});
 }
 
 void TestSetSymmetricDifferenceByKeyDeviceSeq()
@@ -80,20 +89,18 @@ DECLARE_UNITTEST(TestSetSymmetricDifferenceByKeyDeviceDevice);
 
 void TestSetSymmetricDifferenceByKeyCudaStreams()
 {
-  using Vector   = thrust::device_vector<int>;
-  using Iterator = Vector::iterator;
+  const auto device = test::current_test_device();
+  cuda::stream stream{device};
 
-  Vector a_key{0, 2, 4, 6}, b_key{0, 3, 3, 4, 7};
-  Vector a_val(4, 0), b_val(5, 1);
+  auto a_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 6});
+  auto b_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 7});
+  auto a_val      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 0, 0, 0});
+  auto b_val      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{1, 1, 1, 1, 1});
+  auto result_key = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
+  auto result_val = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
 
-  Vector ref_key{2, 3, 3, 6, 7}, ref_val{0, 1, 1, 0, 1};
-  Vector result_key(5), result_val(5);
-
-  cudaStream_t s;
-  cudaStreamCreate(&s);
-
-  cuda::std::pair<Iterator, Iterator> end = thrust::set_symmetric_difference_by_key(
-    thrust::cuda::par.on(s),
+  auto end = thrust::set_symmetric_difference_by_key(
+    thrust::cuda::par.on(stream.get()),
     a_key.begin(),
     a_key.end(),
     b_key.begin(),
@@ -102,13 +109,10 @@ void TestSetSymmetricDifferenceByKeyCudaStreams()
     b_val.begin(),
     result_key.begin(),
     result_val.begin());
-  cudaStreamSynchronize(s);
 
   ASSERT_EQUAL_QUIET(result_key.end(), end.first);
   ASSERT_EQUAL_QUIET(result_val.end(), end.second);
-  ASSERT_EQUAL(ref_key, result_key);
-  ASSERT_EQUAL(ref_val, result_val);
-
-  cudaStreamDestroy(s);
+  test::assert_equal(stream, result_key, {2, 3, 3, 6, 7});
+  test::assert_equal(stream, result_val, {0, 1, 1, 0, 1});
 }
 DECLARE_UNITTEST(TestSetSymmetricDifferenceByKeyCudaStreams);

--- a/thrust/testing/cuda/set_union.cu
+++ b/thrust/testing/cuda/set_union.cu
@@ -1,42 +1,40 @@
 #include <thrust/execution_policy.h>
 #include <thrust/set_operations.h>
 
+#include <cuda/buffer>
+#include <cuda/launch>
+#include <cuda/std/initializer_list>
+#include <cuda/stream>
+
 #include <unittest/unittest.h>
 
+#include "cccl_runtime_test_helper.h"
+
 #ifdef THRUST_TEST_DEVICE_SIDE
-template <typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4>
-__global__ void set_union_kernel(
-  ExecutionPolicy exec,
-  Iterator1 first1,
-  Iterator1 last1,
-  Iterator2 first2,
-  Iterator2 last2,
-  Iterator3 result1,
-  Iterator4 result2)
+struct set_union_kernel
 {
-  *result2 = thrust::set_union(exec, first1, last1, first2, last2, result1);
-}
+  template <typename ExecutionPolicy, typename Input1, typename Input2, typename Output>
+  __device__ void operator()(ExecutionPolicy exec, Input1 a, Input2 b, Output result) const
+  {
+    const auto end = thrust::set_union(exec, a.begin(), a.end(), b.begin(), b.end(), result.begin());
+    TEST_ASSERT_DEVICE(end == result.end());
+  }
+};
 
 template <typename ExecutionPolicy>
 void TestSetUnionDevice(ExecutionPolicy exec)
 {
-  using Vector   = thrust::device_vector<int>;
-  using Iterator = typename Vector::iterator;
+  const auto device = test::current_test_device();
+  cuda::stream stream{device};
 
-  Vector a{0, 2, 4}, b{0, 3, 3, 4};
+  auto a          = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4});
+  auto b          = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4});
+  auto result     = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
 
-  Vector ref{0, 2, 3, 3, 4};
-  Vector result(5);
-  thrust::device_vector<Iterator> end_vec(1);
+  cuda::launch(stream, test::single_thread_config(), set_union_kernel{}, exec, a, b, result);
+  stream.sync();
 
-  set_union_kernel<<<1, 1>>>(exec, a.begin(), a.end(), b.begin(), b.end(), result.begin(), end_vec.begin());
-  cudaError_t const err = cudaDeviceSynchronize();
-  ASSERT_EQUAL(cudaSuccess, err);
-
-  Iterator end = end_vec[0];
-
-  ASSERT_EQUAL_QUIET(result.end(), end);
-  ASSERT_EQUAL(ref, result);
+  test::assert_equal(stream, result, {0, 2, 3, 3, 4});
 }
 
 void TestSetUnionDeviceSeq()
@@ -54,23 +52,17 @@ DECLARE_UNITTEST(TestSetUnionDeviceDevice);
 
 void TestSetUnionCudaStreams()
 {
-  using Vector   = thrust::device_vector<int>;
-  using Iterator = Vector::iterator;
+  const auto device = test::current_test_device();
+  cuda::stream stream{device};
 
-  Vector a{0, 2, 4}, b{0, 3, 3, 4};
+  auto a      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4});
+  auto b      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4});
+  auto result = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
 
-  Vector ref{0, 2, 3, 3, 4};
-  Vector result(5);
-
-  cudaStream_t s;
-  cudaStreamCreate(&s);
-
-  Iterator end = thrust::set_union(thrust::cuda::par.on(s), a.begin(), a.end(), b.begin(), b.end(), result.begin());
-  cudaStreamSynchronize(s);
+  auto end =
+    thrust::set_union(thrust::cuda::par.on(stream.get()), a.begin(), a.end(), b.begin(), b.end(), result.begin());
 
   ASSERT_EQUAL_QUIET(result.end(), end);
-  ASSERT_EQUAL(ref, result);
-
-  cudaStreamDestroy(s);
+  test::assert_equal(stream, result, {0, 2, 3, 3, 4});
 }
 DECLARE_UNITTEST(TestSetUnionCudaStreams);

--- a/thrust/testing/cuda/set_union.cu
+++ b/thrust/testing/cuda/set_union.cu
@@ -2,13 +2,12 @@
 #include <thrust/set_operations.h>
 
 #include <cuda/buffer>
+#include <cuda/cccl_runtime_test_helper.cuh>
 #include <cuda/launch>
 #include <cuda/std/initializer_list>
 #include <cuda/stream>
 
 #include <unittest/unittest.h>
-
-#include "cccl_runtime_test_helper.h"
 
 #ifdef THRUST_TEST_DEVICE_SIDE
 struct set_union_kernel
@@ -24,17 +23,17 @@ struct set_union_kernel
 template <typename ExecutionPolicy>
 void TestSetUnionDevice(ExecutionPolicy exec)
 {
-  const auto device = test::current_test_device();
+  const auto device = test_runtime::current_test_device();
   cuda::stream stream{device};
 
-  auto a          = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4});
-  auto b          = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4});
-  auto result     = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
+  auto a      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4});
+  auto b      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4});
+  auto result = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
 
-  cuda::launch(stream, test::single_thread_config(), set_union_kernel{}, exec, a, b, result);
+  cuda::launch(stream, test_runtime::single_thread_config(), set_union_kernel{}, exec, a, b, result);
   stream.sync();
 
-  test::assert_equal(stream, result, {0, 2, 3, 3, 4});
+  test_runtime::assert_equal(stream, result, {0, 2, 3, 3, 4});
 }
 
 void TestSetUnionDeviceSeq()
@@ -52,7 +51,7 @@ DECLARE_UNITTEST(TestSetUnionDeviceDevice);
 
 void TestSetUnionCudaStreams()
 {
-  const auto device = test::current_test_device();
+  const auto device = test_runtime::current_test_device();
   cuda::stream stream{device};
 
   auto a      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4});
@@ -63,6 +62,6 @@ void TestSetUnionCudaStreams()
     thrust::set_union(thrust::cuda::par.on(stream.get()), a.begin(), a.end(), b.begin(), b.end(), result.begin());
 
   ASSERT_EQUAL_QUIET(result.end(), end);
-  test::assert_equal(stream, result, {0, 2, 3, 3, 4});
+  test_runtime::assert_equal(stream, result, {0, 2, 3, 3, 4});
 }
 DECLARE_UNITTEST(TestSetUnionCudaStreams);

--- a/thrust/testing/cuda/set_union_by_key.cu
+++ b/thrust/testing/cuda/set_union_by_key.cu
@@ -1,67 +1,77 @@
 #include <thrust/execution_policy.h>
 #include <thrust/set_operations.h>
 
+#include <cuda/buffer>
+#include <cuda/launch>
+#include <cuda/std/initializer_list>
+#include <cuda/stream>
+
 #include <unittest/unittest.h>
 
+#include "cccl_runtime_test_helper.h"
+
 #ifdef THRUST_TEST_DEVICE_SIDE
-template <typename ExecutionPolicy,
-          typename Iterator1,
-          typename Iterator2,
-          typename Iterator3,
-          typename Iterator4,
-          typename Iterator5,
-          typename Iterator6,
-          typename Iterator7>
-__global__ void set_union_by_key_kernel(
-  ExecutionPolicy exec,
-  Iterator1 keys_first1,
-  Iterator1 keys_last1,
-  Iterator2 keys_first2,
-  Iterator2 keys_last2,
-  Iterator3 values_first1,
-  Iterator4 values_first2,
-  Iterator5 keys_result,
-  Iterator6 values_result,
-  Iterator7 result)
+struct set_union_by_key_kernel
 {
-  *result = thrust::set_union_by_key(
-    exec, keys_first1, keys_last1, keys_first2, keys_last2, values_first1, values_first2, keys_result, values_result);
-}
+  template <typename ExecutionPolicy,
+            typename Keys1,
+            typename Keys2,
+            typename Values1,
+            typename Values2,
+            typename KeysOutput,
+            typename ValuesOutput>
+  __device__ void operator()(
+    ExecutionPolicy exec,
+    Keys1 keys1,
+    Keys2 keys2,
+    Values1 values1,
+    Values2 values2,
+    KeysOutput keys_result,
+    ValuesOutput values_result) const
+  {
+    auto end = thrust::set_union_by_key(
+      exec,
+      keys1.begin(),
+      keys1.end(),
+      keys2.begin(),
+      keys2.end(),
+      values1.begin(),
+      values2.begin(),
+      keys_result.begin(),
+      values_result.begin());
+    TEST_ASSERT_DEVICE(end.first == keys_result.end());
+    TEST_ASSERT_DEVICE(end.second == values_result.end());
+  }
+};
 
 template <typename ExecutionPolicy>
 void TestSetUnionByKeyDevice(ExecutionPolicy exec)
 {
-  using Vector   = thrust::device_vector<int>;
-  using Iterator = typename Vector::iterator;
+  const auto device = test::current_test_device();
+  cuda::stream stream{device};
 
-  Vector a_key{0, 2, 4}, b_key{0, 3, 3, 4};
-  Vector a_val(3, 0), b_val(4, 1);
+  auto a_key       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4});
+  auto b_key       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4});
+  auto a_val       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 0, 0});
+  auto b_val       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{1, 1, 1, 1});
+  auto result_key  = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
+  auto result_val  = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
 
-  Vector ref_key{0, 2, 3, 3, 4}, ref_val{0, 0, 1, 1, 0};
-  Vector result_key(5), result_val(5);
-
-  thrust::device_vector<cuda::std::pair<Iterator, Iterator>> end_vec(1);
-
-  set_union_by_key_kernel<<<1, 1>>>(
+  cuda::launch(
+    stream,
+    test::single_thread_config(),
+    set_union_by_key_kernel{},
     exec,
-    a_key.begin(),
-    a_key.end(),
-    b_key.begin(),
-    b_key.end(),
-    a_val.begin(),
-    b_val.begin(),
-    result_key.begin(),
-    result_val.begin(),
-    end_vec.begin());
-  cudaError_t const err = cudaDeviceSynchronize();
-  ASSERT_EQUAL(cudaSuccess, err);
+    a_key,
+    b_key,
+    a_val,
+    b_val,
+    result_key,
+    result_val);
+  stream.sync();
 
-  cuda::std::pair<Iterator, Iterator> end = end_vec[0];
-
-  ASSERT_EQUAL_QUIET(result_key.end(), end.first);
-  ASSERT_EQUAL_QUIET(result_val.end(), end.second);
-  ASSERT_EQUAL(ref_key, result_key);
-  ASSERT_EQUAL(ref_val, result_val);
+  test::assert_equal(stream, result_key, {0, 2, 3, 3, 4});
+  test::assert_equal(stream, result_val, {0, 0, 1, 1, 0});
 }
 
 void TestSetUnionByKeyDeviceSeq()
@@ -79,20 +89,18 @@ DECLARE_UNITTEST(TestSetUnionByKeyDeviceDevice);
 
 void TestSetUnionByKeyCudaStreams()
 {
-  using Vector   = thrust::device_vector<int>;
-  using Iterator = Vector::iterator;
+  const auto device = test::current_test_device();
+  cuda::stream stream{device};
 
-  Vector a_key{0, 2, 4}, b_key{0, 3, 3, 4};
-  Vector a_val(3, 0), b_val(4, 1);
+  auto a_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4});
+  auto b_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4});
+  auto a_val      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 0, 0});
+  auto b_val      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{1, 1, 1, 1});
+  auto result_key = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
+  auto result_val = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
 
-  Vector ref_key{0, 2, 3, 3, 4}, ref_val{0, 0, 1, 1, 0};
-  Vector result_key(5), result_val(5);
-
-  cudaStream_t s;
-  cudaStreamCreate(&s);
-
-  cuda::std::pair<Iterator, Iterator> end = thrust::set_union_by_key(
-    thrust::cuda::par.on(s),
+  auto end = thrust::set_union_by_key(
+    thrust::cuda::par.on(stream.get()),
     a_key.begin(),
     a_key.end(),
     b_key.begin(),
@@ -101,13 +109,10 @@ void TestSetUnionByKeyCudaStreams()
     b_val.begin(),
     result_key.begin(),
     result_val.begin());
-  cudaStreamSynchronize(s);
 
   ASSERT_EQUAL_QUIET(result_key.end(), end.first);
   ASSERT_EQUAL_QUIET(result_val.end(), end.second);
-  ASSERT_EQUAL(ref_key, result_key);
-  ASSERT_EQUAL(ref_val, result_val);
-
-  cudaStreamDestroy(s);
+  test::assert_equal(stream, result_key, {0, 2, 3, 3, 4});
+  test::assert_equal(stream, result_val, {0, 0, 1, 1, 0});
 }
 DECLARE_UNITTEST(TestSetUnionByKeyCudaStreams);

--- a/thrust/testing/cuda/set_union_by_key.cu
+++ b/thrust/testing/cuda/set_union_by_key.cu
@@ -2,13 +2,12 @@
 #include <thrust/set_operations.h>
 
 #include <cuda/buffer>
+#include <cuda/cccl_runtime_test_helper.cuh>
 #include <cuda/launch>
 #include <cuda/std/initializer_list>
 #include <cuda/stream>
 
 #include <unittest/unittest.h>
-
-#include "cccl_runtime_test_helper.h"
 
 #ifdef THRUST_TEST_DEVICE_SIDE
 struct set_union_by_key_kernel
@@ -47,19 +46,19 @@ struct set_union_by_key_kernel
 template <typename ExecutionPolicy>
 void TestSetUnionByKeyDevice(ExecutionPolicy exec)
 {
-  const auto device = test::current_test_device();
+  const auto device = test_runtime::current_test_device();
   cuda::stream stream{device};
 
-  auto a_key       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4});
-  auto b_key       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4});
-  auto a_val       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 0, 0});
-  auto b_val       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{1, 1, 1, 1});
-  auto result_key  = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
-  auto result_val  = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
+  auto a_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4});
+  auto b_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4});
+  auto a_val      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 0, 0});
+  auto b_val      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{1, 1, 1, 1});
+  auto result_key = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
+  auto result_val = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
 
   cuda::launch(
     stream,
-    test::single_thread_config(),
+    test_runtime::single_thread_config(),
     set_union_by_key_kernel{},
     exec,
     a_key,
@@ -70,8 +69,8 @@ void TestSetUnionByKeyDevice(ExecutionPolicy exec)
     result_val);
   stream.sync();
 
-  test::assert_equal(stream, result_key, {0, 2, 3, 3, 4});
-  test::assert_equal(stream, result_val, {0, 0, 1, 1, 0});
+  test_runtime::assert_equal(stream, result_key, {0, 2, 3, 3, 4});
+  test_runtime::assert_equal(stream, result_val, {0, 0, 1, 1, 0});
 }
 
 void TestSetUnionByKeyDeviceSeq()
@@ -89,7 +88,7 @@ DECLARE_UNITTEST(TestSetUnionByKeyDeviceDevice);
 
 void TestSetUnionByKeyCudaStreams()
 {
-  const auto device = test::current_test_device();
+  const auto device = test_runtime::current_test_device();
   cuda::stream stream{device};
 
   auto a_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4});
@@ -112,7 +111,7 @@ void TestSetUnionByKeyCudaStreams()
 
   ASSERT_EQUAL_QUIET(result_key.end(), end.first);
   ASSERT_EQUAL_QUIET(result_val.end(), end.second);
-  test::assert_equal(stream, result_key, {0, 2, 3, 3, 4});
-  test::assert_equal(stream, result_val, {0, 0, 1, 1, 0});
+  test_runtime::assert_equal(stream, result_key, {0, 2, 3, 3, 4});
+  test_runtime::assert_equal(stream, result_val, {0, 0, 1, 1, 0});
 }
 DECLARE_UNITTEST(TestSetUnionByKeyCudaStreams);


### PR DESCRIPTION
Part of https://github.com/NVIDIA/cccl/issues/2800

This PR is first on a series to use cccl runtime APIs in other CCCL tests as a form of dog fooding. The first PR is an arbitrary set of thrust tests to mostly gather feedback before I do more changes.

The test framework uses current device setting, which I believe is also needed for thrust. I don't think we can rework the tests to use an explicit device, even if that would make more sense with cccl runtime APIs.