### PR TITLE
[CUB] Refactor `DeviceHistogram::MultiHistogramEven` to always take an environment

### DIFF
--- a/cub/cub/device/device_histogram.cuh
+++ b/cub/cub/device/device_histogram.cuh
@@ -451,6 +451,9 @@ struct DeviceHistogram
   //!   **[inferred]** Signed integer type for sequence offsets, list lengths,
   //!   pointer differences, etc. @offset_size1
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., `cuda::std::execution::env<...>`)
+  //!
   //! @param[in] d_temp_storage
   //!   @devicestorage
   //!
@@ -485,16 +488,17 @@ struct DeviceHistogram
   //! @param[in] num_pixels
   //!   The number of multi-channel pixels (i.e., the length of `d_samples / NUM_CHANNELS`)
   //!
-  //! @param[in] stream
+  //! @param[in] env
   //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
   template <int NUM_CHANNELS,
             int NUM_ACTIVE_CHANNELS,
             typename SampleIteratorT,
             typename CounterT,
             typename LevelT,
-            typename OffsetT>
+            typename OffsetT,
+            typename EnvT = ::cuda::std::execution::env<>>
   CUB_RUNTIME_FUNCTION static cudaError_t MultiHistogramEven(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -504,7 +508,7 @@ struct DeviceHistogram
     ::cuda::std::array<LevelT, NUM_ACTIVE_CHANNELS> lower_level,
     ::cuda::std::array<LevelT, NUM_ACTIVE_CHANNELS> upper_level,
     OffsetT num_pixels,
-    cudaStream_t stream = nullptr)
+    const EnvT& env = {})
   {
     /// The sample value type of the input iterator
     using SampleT = cub::detail::it_value_t<SampleIteratorT>;
@@ -520,7 +524,7 @@ struct DeviceHistogram
       num_pixels,
       static_cast<OffsetT>(1),
       sizeof(SampleT) * NUM_CHANNELS * num_pixels,
-      stream);
+      env);
   }
 
 private:
@@ -539,7 +543,8 @@ public:
             typename SampleIteratorT,
             typename CounterT,
             typename LevelT,
-            typename OffsetT>
+            typename OffsetT,
+            typename EnvT = ::cuda::std::execution::env<>>
   CCCL_DEPRECATED_BECAUSE("Prefer the new overload taking cuda::std::arrays") CUB_RUNTIME_FUNCTION static cudaError_t
   MultiHistogramEven(
     void* d_temp_storage,
@@ -550,7 +555,7 @@ public:
     const LevelT lower_level[NUM_ACTIVE_CHANNELS],
     const LevelT upper_level[NUM_ACTIVE_CHANNELS],
     OffsetT num_pixels,
-    cudaStream_t stream = nullptr)
+    const EnvT& env = {})
   {
     /// The sample value type of the input iterator
     using SampleT = cub::detail::it_value_t<SampleIteratorT>;
@@ -563,7 +568,7 @@ public:
       to_array<NUM_ACTIVE_CHANNELS>(lower_level),
       to_array<NUM_ACTIVE_CHANNELS>(upper_level),
       num_pixels,
-      stream);
+      env);
   }
 
   //! @rst
@@ -675,6 +680,9 @@ public:
   //!   **[inferred]** Signed integer type for sequence offsets, list lengths,
   //!   pointer differences, etc. @offset_size1
   //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., `cuda::std::execution::env<...>`)
+  //!
   //! @param[in] d_temp_storage
   //!   @devicestorage
   //!
@@ -716,16 +724,17 @@ public:
   //!   The number of bytes between starts of consecutive rows in the region of
   //!   interest
   //!
-  //! @param[in] stream
+  //! @param[in] env
   //!   @rst
-  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   //!   @endrst
   template <int NUM_CHANNELS,
             int NUM_ACTIVE_CHANNELS,
             typename SampleIteratorT,
             typename CounterT,
             typename LevelT,
-            typename OffsetT>
+            typename OffsetT,
+            typename EnvT = ::cuda::std::execution::env<>>
   CUB_RUNTIME_FUNCTION static cudaError_t MultiHistogramEven(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -737,53 +746,56 @@ public:
     OffsetT num_row_pixels,
     OffsetT num_rows,
     size_t row_stride_bytes,
-    cudaStream_t stream = nullptr)
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceHistogram::MultiHistogramEven");
 
-    /// The sample value type of the input iterator
     using SampleT = cub::detail::it_value_t<SampleIteratorT>;
     ::cuda::std::bool_constant<sizeof(SampleT) == 1> is_byte_sample;
 
-    auto policy_selector =
-      detail::histogram::policy_selector_from_types<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, true>{};
+    using default_policy_selector =
+      detail::histogram::policy_selector_from_types<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, true>;
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      d_temp_storage,
+      temp_storage_bytes,
+      env,
+      [&](auto policy_selector, void* storage, size_t& bytes, auto stream) -> cudaError_t {
+        if constexpr (sizeof(OffsetT) > sizeof(int))
+        {
+          if ((unsigned long long) (num_rows * row_stride_bytes) < (unsigned long long) INT_MAX)
+          {
+            return detail::histogram::dispatch_even<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
+              storage,
+              bytes,
+              d_samples,
+              d_histogram,
+              num_levels,
+              lower_level,
+              upper_level,
+              (int) num_row_pixels,
+              (int) num_rows,
+              (int) (row_stride_bytes / sizeof(SampleT)),
+              stream,
+              is_byte_sample,
+              policy_selector);
+          }
+        }
 
-    if constexpr (sizeof(OffsetT) > sizeof(int))
-    {
-      if ((unsigned long long) (num_rows * row_stride_bytes) < (unsigned long long) INT_MAX)
-      {
-        // Down-convert OffsetT data type
         return detail::histogram::dispatch_even<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-          d_temp_storage,
-          temp_storage_bytes,
+          storage,
+          bytes,
           d_samples,
           d_histogram,
           num_levels,
           lower_level,
           upper_level,
-          (int) num_row_pixels,
-          (int) num_rows,
-          (int) (row_stride_bytes / sizeof(SampleT)),
+          num_row_pixels,
+          num_rows,
+          (OffsetT) (row_stride_bytes / sizeof(SampleT)),
           stream,
           is_byte_sample,
           policy_selector);
-      }
-    }
-
-    return detail::histogram::dispatch_even<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_samples,
-      d_histogram,
-      num_levels,
-      lower_level,
-      upper_level,
-      num_row_pixels,
-      num_rows,
-      (OffsetT) (row_stride_bytes / sizeof(SampleT)),
-      stream,
-      is_byte_sample,
-      policy_selector);
+      });
   }
 
   //! Deprecate [Since 3.0]
@@ -792,7 +804,8 @@ public:
             typename SampleIteratorT,
             typename CounterT,
             typename LevelT,
-            typename OffsetT>
+            typename OffsetT,
+            typename EnvT = ::cuda::std::execution::env<>>
   CCCL_DEPRECATED_BECAUSE("Prefer the new overload taking cuda::std::arrays") CUB_RUNTIME_FUNCTION static cudaError_t
   MultiHistogramEven(
     void* d_temp_storage,
@@ -805,7 +818,7 @@ public:
     OffsetT num_row_pixels,
     OffsetT num_rows,
     size_t row_stride_bytes,
-    cudaStream_t stream = nullptr)
+    const EnvT& env = {})
   {
     return MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
       d_temp_storage,
@@ -818,7 +831,7 @@ public:
       num_row_pixels,
       num_rows,
       row_stride_bytes,
-      stream);
+      env);
   }
 
   //! @}
@@ -1847,7 +1860,7 @@ public:
     ::cuda::std::array<LevelT, NUM_ACTIVE_CHANNELS> lower_level,
     ::cuda::std::array<LevelT, NUM_ACTIVE_CHANNELS> upper_level,
     OffsetT num_pixels,
-    EnvT env = {})
+    const EnvT& env = {})
   {
     using SampleT = cub::detail::it_value_t<SampleIteratorT>;
     return MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
@@ -1996,7 +2009,7 @@ public:
     OffsetT num_row_pixels,
     OffsetT num_rows,
     size_t row_stride_bytes,
-    EnvT env = {})
+    const EnvT& env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceHistogram::MultiHistogramEven");
 

--- a/cub/test/catch2_test_device_histogram_env.cu
+++ b/cub/test/catch2_test_device_histogram_env.cu
@@ -11,7 +11,9 @@ struct stream_registry_factory_t;
 
 #include <thrust/device_vector.h>
 
+#include <cuda/devices>
 #include <cuda/std/array>
+#include <cuda/std/execution>
 
 #include "catch2_test_env_launch_helper.h"
 
@@ -1003,6 +1005,140 @@ TEST_CASE("DeviceHistogram::MultiHistogramEven 2D uses custom stream", "[histogr
 
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
+
+#if TEST_LAUNCH == 0
+TEST_CASE("DeviceHistogram::MultiHistogramEven works with user provided memory and environment", "[histogram][device]")
+{
+  [[maybe_unused]] constexpr int NUM_CHANNELS        = 4;
+  [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
+
+  auto d_samples =
+    c2h::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128, 0, 0, 0, 0, 1, 1, 3, 200, 2, 3, 0, 100, 0, 0, 0, 0};
+
+  int num_row_pixels      = 2;
+  int num_rows            = 2;
+  size_t row_stride_bytes = 3 * NUM_CHANNELS * sizeof(unsigned char);
+
+  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels            = {5, 5, 5};
+  cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
+  cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
+
+  auto d_histogram_r = c2h::device_vector<int>(4, 0);
+  auto d_histogram_g = c2h::device_vector<int>(4, 0);
+  auto d_histogram_b = c2h::device_vector<int>(4, 0);
+
+  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+    thrust::raw_pointer_cast(d_histogram_r.data()),
+    thrust::raw_pointer_cast(d_histogram_g.data()),
+    thrust::raw_pointer_cast(d_histogram_b.data())};
+
+  c2h::device_vector<int> expected_r{1, 1, 1, 1};
+  c2h::device_vector<int> expected_g{0, 1, 1, 1};
+  c2h::device_vector<int> expected_b{1, 1, 1, 1};
+
+  size_t expected_bytes_allocated{};
+  auto error = cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
+    nullptr,
+    expected_bytes_allocated,
+    thrust::raw_pointer_cast(d_samples.data()),
+    d_histogram,
+    num_levels,
+    lower_level,
+    upper_level,
+    num_row_pixels,
+    num_rows,
+    row_stride_bytes);
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  auto d_temp        = c2h::device_vector<uint8_t>(expected_bytes_allocated, thrust::no_init);
+  void* temp_storage = thrust::raw_pointer_cast(d_temp.data());
+
+  auto test_multi_histogram_even = [&](const auto& env) {
+    size_t num_bytes = 0;
+    error            = cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
+      nullptr,
+      num_bytes,
+      thrust::raw_pointer_cast(d_samples.data()),
+      d_histogram,
+      num_levels,
+      lower_level,
+      upper_level,
+      num_row_pixels,
+      num_rows,
+      row_stride_bytes,
+      env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+    REQUIRE(expected_bytes_allocated == num_bytes);
+
+    error = cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
+      temp_storage,
+      num_bytes,
+      thrust::raw_pointer_cast(d_samples.data()),
+      d_histogram,
+      num_levels,
+      lower_level,
+      upper_level,
+      num_row_pixels,
+      num_rows,
+      row_stride_bytes,
+      env);
+    REQUIRE(error == cudaSuccess);
+    REQUIRE(cudaSuccess == cudaPeekAtLastError());
+    REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+    // Verify result
+    REQUIRE(d_histogram_r == expected_r);
+    REQUIRE(d_histogram_g == expected_g);
+    REQUIRE(d_histogram_b == expected_b);
+  };
+
+  int current_device;
+  error = cudaGetDevice(&current_device);
+  REQUIRE(error == cudaSuccess);
+
+  SECTION("DeviceHistogram::HistogramEven works with cudaStream_t")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_multi_histogram_even(stream.get());
+  }
+
+  SECTION("DeviceHistogram::HistogramEven works with cuda::stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    test_multi_histogram_even(stream);
+  }
+
+  SECTION("DeviceHistogram::HistogramEven works with cuda::stream_ref")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    cuda::stream_ref stream_ref{stream};
+    test_multi_histogram_even(stream_ref);
+  }
+
+  SECTION("DeviceHistogram::HistogramEven works with cuda::std::execution::env")
+  {
+    cuda::std::execution::env env{};
+    test_multi_histogram_even(env);
+  }
+
+  SECTION("DeviceHistogram::HistogramEven works with cuda::execution::gpu")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_multi_histogram_even(policy);
+  }
+
+  SECTION("DeviceHistogram::HistogramEven works with cuda::execution::gpu with stream")
+  {
+    cuda::stream stream{cuda::devices[current_device]};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_multi_histogram_even(policy);
+  }
+}
+#endif // TEST_LAUNCH == 0
 
 C2H_TEST("DeviceHistogram::MultiHistogramRange 2D uses environment", "[histogram][device]")
 {


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.