### PR TITLE
[libcu++] Implement `cuda::std::range_format`

### DIFF
--- a/libcudacxx/include/cuda/std/__format/concepts.h
+++ b/libcudacxx/include/cuda/std/__format/concepts.h
@@ -25,11 +25,9 @@
 #include <cuda/std/__concepts/semiregular.h>
 #include <cuda/std/__fwd/format.h>
 #include <cuda/std/__fwd/inplace_vector.h>
-#include <cuda/std/__fwd/tuple.h>
 #include <cuda/std/__iterator/wrap_iter.h>
 #include <cuda/std/__type_traits/remove_const.h>
 #include <cuda/std/__type_traits/remove_reference.h>
-#include <cuda/std/__utility/pair.h>
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__format/format_kind.h
+++ b/libcudacxx/include/cuda/std/__format/format_kind.h
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD__FORMAT_FORMAT_KIND_H
+#define _CUDA_STD__FORMAT_FORMAT_KIND_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__concepts/same_as.h>
+#include <cuda/std/__fwd/format.h>
+#include <cuda/std/__ranges/concepts.h>
+#include <cuda/std/__tuple_dir/tuple_like.h>
+#include <cuda/std/__type_traits/always_false.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/remove_cvref.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+template <class _Rp>
+_CCCL_CONCEPT __has_key_type = _CCCL_REQUIRES_EXPR((_Rp))(typename(typename _Rp::key_type));
+
+template <class _Rp>
+_CCCL_CONCEPT __has_mapped_type = _CCCL_REQUIRES_EXPR((_Rp))(typename(typename _Rp::mapped_type));
+
+template <class _Rp>
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL range_format __fmt_format_kind_fail() noexcept
+{
+  // [format.range.fmtkind]/1
+  // A program that instantiates the primary template of format_kind is ill-formed.
+  static_assert(__always_false_v<_Rp>, "create a template specialization of format_kind for your type");
+  return range_format::disabled;
+}
+
+template <class _Rp, class = void>
+inline constexpr range_format format_kind = ::cuda::std::__fmt_format_kind_fail<_Rp>();
+
+template <class _Rp>
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL range_format __fmt_format_kind_default() noexcept
+{
+  if constexpr (same_as<remove_cvref_t<ranges::range_reference_t<_Rp>>, _Rp>)
+  {
+    return range_format::disabled;
+  }
+  else if constexpr (__has_key_type<_Rp>)
+  {
+    if constexpr (__has_mapped_type<_Rp> && __pair_like<remove_cvref_t<ranges::range_reference_t<_Rp>>>)
+    {
+      return range_format::map;
+    }
+    else
+    {
+      return range_format::set;
+    }
+  }
+  else
+  {
+    return range_format::sequence;
+  }
+}
+
+template <class _Rp>
+inline constexpr range_format
+  format_kind<_Rp, enable_if_t<ranges::input_range<_Rp> && same_as<_Rp, remove_cvref_t<_Rp>>>> =
+    ::cuda::std::__fmt_format_kind_default<_Rp>();
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD__FORMAT_FORMAT_KIND_H

--- a/libcudacxx/include/cuda/std/__format_
+++ b/libcudacxx/include/cuda/std/__format_
@@ -29,6 +29,7 @@
 #include <cuda/std/__format/format_context.h>
 #include <cuda/std/__format/format_error.h>
 #include <cuda/std/__format/format_integral.h>
+#include <cuda/std/__format/format_kind.h>
 #include <cuda/std/__format/format_parse_context.h>
 #include <cuda/std/__format/format_spec_parser.h>
 #include <cuda/std/__format/format_string.h>

--- a/libcudacxx/include/cuda/std/__fwd/format.h
+++ b/libcudacxx/include/cuda/std/__fwd/format.h
@@ -103,6 +103,16 @@ using wformat_string = basic_format_string<wchar_t, type_identity_t<_Args>...>;
 template <class _OutIt>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT format_to_n_result;
 
+enum class range_format
+{
+  disabled,
+  map,
+  set,
+  sequence,
+  string,
+  debug_string,
+};
+
 _CCCL_END_NAMESPACE_CUDA_STD
 
 #include <cuda/std/__cccl/epilogue.h>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.range/format.range.fmtkind/format_kind.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.range/format.range.fmtkind/format_kind.compile.pass.cpp
@@ -1,0 +1,134 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// libstdc++ < 10 uses some of the names we treat as nasty macros. Let's omit the "nasty_macros.h" inclusion for this
+// test.
+// ADDITIONAL_COMPILE_DEFINITIONS: SUPPORT_NASTY_MACROS_H
+
+// <cuda/std/format>
+
+// template<ranges::input_range R>
+//     requires same_as<R, remove_cvref_t<R>>
+//  constexpr range_format format_kind<R> = see below;
+
+#include "test_macros.h"
+
+#if _CCCL_HAS_HOST_STD_LIB()
+#  include <array>
+#  include <deque>
+#  if __has_include(<filesystem>)
+#    include <filesystem>
+#  endif // __has_include(<filesystem>)
+#  include <forward_list>
+#  include <list>
+#  include <map>
+#  include <set>
+#  include <unordered_map>
+#  include <unordered_set>
+#  include <valarray>
+#  include <vector>
+#endif // _CCCL_HAS_HOST_STD_LIB()
+
+#include <cuda/std/__format_>
+#include <cuda/std/array>
+#include <cuda/std/cstddef>
+#include <cuda/std/inplace_vector>
+#include <cuda/std/iterator>
+#include <cuda/std/ranges>
+#include <cuda/std/span>
+
+// [format.range.fmtkind]
+// If same_as<remove_cvref_t<ranges::range_reference_t<R>>, R> is true,
+// format_kind<R> is range_format::disabled.
+// [Note 1: This prevents constraint recursion for ranges whose reference type
+// is the same range type. For example, cuda::std::filesystem::path is a range of
+// cuda::std::filesystem::path. - end note]
+struct recursive_range
+{
+  struct iterator
+  {
+    using iterator_concept = cuda::std::input_iterator_tag;
+    using value_type       = recursive_range;
+    using difference_type  = cuda::std::ptrdiff_t;
+    using reference        = recursive_range;
+
+    TEST_FUNC reference operator*() const;
+
+    TEST_FUNC iterator& operator++();
+    TEST_FUNC iterator operator++(int);
+
+    TEST_FUNC friend bool operator==(const iterator&, const iterator&);
+    TEST_FUNC friend bool operator!=(const iterator&, const iterator&);
+  };
+
+  TEST_FUNC iterator begin();
+  TEST_FUNC iterator end();
+};
+
+static_assert(cuda::std::ranges::input_range<recursive_range>, "format_kind requires an input range");
+static_assert(cuda::std::format_kind<recursive_range> == cuda::std::range_format::disabled);
+
+static_assert(cuda::std::format_kind<cuda::std::array<int, 1>> == cuda::std::range_format::sequence);
+static_assert(cuda::std::format_kind<cuda::std::span<int>> == cuda::std::range_format::sequence);
+static_assert(cuda::std::format_kind<cuda::std::inplace_vector<int, 1>> == cuda::std::range_format::sequence);
+
+#if _CCCL_HAS_HOST_STD_LIB()
+#  if __has_include(<filesystem>)
+static_assert(cuda::std::format_kind<std::filesystem::path> == cuda::std::range_format::disabled);
+#  endif // __has_include(<filesystem>)
+
+static_assert(cuda::std::format_kind<std::map<int, int>> == cuda::std::range_format::map);
+static_assert(cuda::std::format_kind<std::multimap<int, int>> == cuda::std::range_format::map);
+static_assert(cuda::std::format_kind<std::unordered_map<int, int>> == cuda::std::range_format::map);
+static_assert(cuda::std::format_kind<std::unordered_multimap<int, int>> == cuda::std::range_format::map);
+
+static_assert(cuda::std::format_kind<std::set<int>> == cuda::std::range_format::set);
+static_assert(cuda::std::format_kind<std::multiset<int>> == cuda::std::range_format::set);
+static_assert(cuda::std::format_kind<std::unordered_set<int>> == cuda::std::range_format::set);
+static_assert(cuda::std::format_kind<std::unordered_multiset<int>> == cuda::std::range_format::set);
+
+static_assert(cuda::std::format_kind<std::array<int, 1>> == cuda::std::range_format::sequence);
+static_assert(cuda::std::format_kind<std::vector<int>> == cuda::std::range_format::sequence);
+static_assert(cuda::std::format_kind<std::deque<int>> == cuda::std::range_format::sequence);
+static_assert(cuda::std::format_kind<std::forward_list<int>> == cuda::std::range_format::sequence);
+static_assert(cuda::std::format_kind<std::list<int>> == cuda::std::range_format::sequence);
+
+static_assert(cuda::std::format_kind<std::valarray<int>> == cuda::std::range_format::sequence);
+#endif // _CCCL_HAS_HOST_STD_LIB()
+
+// [format.range.fmtkind]/3
+//   Remarks: Pursuant to [namespace.std], users may specialize format_kind for
+//   cv-unqualified program-defined types that model ranges::input_range. Such
+//   specializations shall be usable in constant expressions ([expr.const]) and
+//   have type const range_format.
+// Note only test the specializing, not all constraints.
+struct no_specialization : cuda::std::ranges::view_base
+{
+  using key_type = void;
+  TEST_FUNC int* begin() const;
+  TEST_FUNC int* end() const;
+};
+static_assert(cuda::std::format_kind<no_specialization> == cuda::std::range_format::set);
+
+// The struct's "contents" are the same as no_specialization.
+struct specialized : cuda::std::ranges::view_base
+{
+  using key_type = void;
+  TEST_FUNC int* begin() const;
+  TEST_FUNC int* end() const;
+};
+
+template <>
+constexpr cuda::std::range_format cuda::std::format_kind<specialized> = cuda::std::range_format::sequence;
+static_assert(cuda::std::format_kind<specialized> == cuda::std::range_format::sequence);
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.range/format.range.fmtkind/range_format.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.range/format.range.fmtkind/range_format.compile.pass.cpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// enum class range_format {
+//   disabled,
+//   map,
+//   set,
+//   sequence,
+//   string,
+//   debug_string
+// };
+
+#include <cuda/std/__format_>
+
+// test that the enumeration values exist
+static_assert(cuda::std::range_format::disabled == cuda::std::range_format::disabled);
+static_assert(cuda::std::range_format::map == cuda::std::range_format::map);
+static_assert(cuda::std::range_format::set == cuda::std::range_format::set);
+static_assert(cuda::std::range_format::sequence == cuda::std::range_format::sequence);
+static_assert(cuda::std::range_format::string == cuda::std::range_format::string);
+static_assert(cuda::std::range_format::debug_string == cuda::std::range_format::debug_string);
+
+int main(int, char**)
+{
+  return 0;
+}


### PR DESCRIPTION
Implements:
- [`format_kind`](https://cppreference.com/cpp/utility/format/format_kind)
- [`range_format`](https://cppreference.com/cpp/utility/format/range_format)