### PR TITLE
[CUB][Bug] Fix DeviceHistogram out-of-bounds write

### DIFF
--- a/cub/cub/agent/agent_histogram.cuh
+++ b/cub/cub/agent/agent_histogram.cuh
@@ -605,13 +605,13 @@ struct AgentHistogram
                                                : // prefer gmem privatized histograms
                       blockIdx.x & 1) // prefer blended privatized histograms
   {
-    const int blockId = (blockIdx.y * gridDim.x) + blockIdx.x;
+    const auto block_id = static_cast<int64_t>(blockIdx.y) * gridDim.x + blockIdx.x;
 
     // TODO(bgruber): d_privatized_histograms seems only used when !prefer_smem, can we skip it if prefer_smem?
     // Initialize the locations of this block's privatized histograms
     for (int ch = 0; ch < NumActiveChannels; ++ch)
     {
-      this->d_privatized_histograms[ch] = d_privatized_histograms[ch] + (blockId * num_privatized_bins[ch]);
+      this->d_privatized_histograms[ch] = d_privatized_histograms[ch] + (block_id * num_privatized_bins[ch]);
     }
   }
 

--- a/cub/cub/agent/agent_histogram.cuh
+++ b/cub/cub/agent/agent_histogram.cuh
@@ -27,6 +27,7 @@
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_pointer.h>
+#include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
 
@@ -605,7 +606,7 @@ struct AgentHistogram
                                                : // prefer gmem privatized histograms
                       blockIdx.x & 1) // prefer blended privatized histograms
   {
-    const auto block_id = static_cast<int64_t>(blockIdx.y) * gridDim.x + blockIdx.x;
+    const auto block_id = static_cast<::cuda::std::int64_t>(blockIdx.y) * gridDim.x + blockIdx.x;
 
     // TODO(bgruber): d_privatized_histograms seems only used when !prefer_smem, can we skip it if prefer_smem?
     // Initialize the locations of this block's privatized histograms

--- a/cub/cub/agent/agent_histogram.cuh
+++ b/cub/cub/agent/agent_histogram.cuh
@@ -606,13 +606,14 @@ struct AgentHistogram
                                                : // prefer gmem privatized histograms
                       blockIdx.x & 1) // prefer blended privatized histograms
   {
-    const auto block_id = static_cast<::cuda::std::int64_t>(blockIdx.y) * gridDim.x + blockIdx.x;
+    const int blockId = (blockIdx.y * gridDim.x) + blockIdx.x;
 
     // TODO(bgruber): d_privatized_histograms seems only used when !prefer_smem, can we skip it if prefer_smem?
     // Initialize the locations of this block's privatized histograms
     for (int ch = 0; ch < NumActiveChannels; ++ch)
     {
-      this->d_privatized_histograms[ch] = d_privatized_histograms[ch] + (block_id * num_privatized_bins[ch]);
+      const auto offset                 = static_cast<::cuda::std::int64_t>(blockId) * num_privatized_bins[ch];
+      this->d_privatized_histograms[ch] = d_privatized_histograms[ch] + offset;
     }
   }
 

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -19,8 +19,10 @@
 #include <cuda/type_traits>
 
 #include <algorithm>
+#include <exception>
 #include <limits>
 #include <new>
+#include <string>
 #include <tuple>
 
 #include "catch2_test_launch_helper.h"
@@ -687,6 +689,10 @@ try
 catch (const std::bad_alloc&)
 {
   SUCCEED("allocation failure is not a test failure");
+}
+catch (const std::exception& e)
+{
+  FAIL("Unexpected exception: " + std::string(e.what()));
 }
 
 // Our bin computation for HistogramEven is guaranteed only for when (max_level - min_level) * num_bins does not

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -9,6 +9,8 @@
 
 #include <cub/device/device_histogram.cuh>
 
+#include <thrust/gather.h>
+
 #include <cuda/iterator>
 #include <cuda/std/algorithm>
 #include <cuda/std/array>
@@ -18,6 +20,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <new>
 #include <tuple>
 
 #include "catch2_test_launch_helper.h"
@@ -651,8 +654,41 @@ C2H_TEST("DeviceHistogram::HistogramRange levels/samples aliasing", "[histogram_
   }
 }
 
-// We cannot use launch wrappers for this test, since it checks error codes explicitly.
+// Limit this large-memory reproducer to the host launch path.
 #if TEST_LAUNCH == 0
+C2H_TEST("DeviceHistogram::MultiHistogramEven large privatized offsets", "[histogram_even][device]")
+try
+{
+  using sample_t  = int64_t;
+  using counter_t = int;
+
+  constexpr int num_bins    = 14234160;
+  constexpr int num_samples = 822702;
+  constexpr int num_levels  = num_bins + 1;
+
+  auto sample_iterator = cuda::counting_iterator<sample_t>{0};
+  array<counter_t*, 1> d_histogram_array{};
+  array<int, 1> num_levels_array  = {num_levels};
+  array<int, 1> lower_level_array = {0};
+  array<int, 1> upper_level_array = {num_bins};
+
+  c2h::device_vector<counter_t> d_histogram(num_bins);
+  d_histogram_array[0] = thrust::raw_pointer_cast(d_histogram.data());
+
+  multi_histogram_even<1, 1>(
+    sample_iterator, d_histogram_array, num_levels_array, lower_level_array, upper_level_array, num_samples);
+
+  c2h::device_vector<int> d_bin_indices{num_samples - 1, num_samples};
+  c2h::device_vector<counter_t> d_selected_bins(2);
+  thrust::gather(
+    c2h::device_policy, d_bin_indices.begin(), d_bin_indices.end(), d_histogram.begin(), d_selected_bins.begin());
+  CHECK(d_selected_bins == c2h::host_vector<counter_t>{1, 0});
+}
+catch (const std::bad_alloc&)
+{
+  SUCCEED("allocation failure is not a test failure");
+}
+
 // Our bin computation for HistogramEven is guaranteed only for when (max_level - min_level) * num_bins does not
 // overflow using uint64_t arithmetic. In case of overflow, we expect cudaErrorInvalidValue to be returned.
 C2H_TEST_LIST("DeviceHistogram::HistogramEven bin computation does not overflow",


### PR DESCRIPTION
## Description

Fixes https://github.com/NVIDIA/cccl/issues/9559

`AgentHistogram` uses 32-bit integer to represent block indices (2D) which can overflow for large inputs. The PR also adds the test case that triggered the failure.
