### PR TITLE
Support `__float128` for `isfinite()` and `isinf()`

### DIFF
--- a/libcudacxx/include/cuda/std/__cmath/isfinite.h
+++ b/libcudacxx/include/cuda/std/__cmath/isfinite.h
@@ -27,6 +27,8 @@
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__floating_point/fp.h>
 #include <cuda/std/__host_stdlib/math.h>
+#include <cuda/std/__type_traits/is_extended_floating_point.h>
+#include <cuda/std/__type_traits/is_floating_point.h>
 #include <cuda/std/__type_traits/is_integral.h>
 
 #include <cuda/std/__cccl/prologue.h>
@@ -44,13 +46,17 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr bool __isfinite_impl(_Tp __x) noexcept
 {
-  static_assert(is_floating_point_v<_Tp>, "Only standard floating-point types are supported");
-#if !_CCCL_TILE_COMPILATION() // nvbug6077402: error: "call to non-tile function not supported!"
-  _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+  static_assert(is_floating_point_v<_Tp> || __is_extended_floating_point_v<_Tp>,
+                "Only floating-point types are supported");
+  if constexpr (is_floating_point_v<_Tp>)
   {
-    return ::isfinite(__x);
-  }
+#if !_CCCL_TILE_COMPILATION() // nvbug6077402: error: "call to non-tile function not supported!"
+    _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+    {
+      return ::isfinite(__x);
+    }
 #endif // !_CCCL_TILE_COMPILATION()
+  }
   return !::cuda::std::isnan(__x) && !::cuda::std::isinf(__x);
 }
 
@@ -158,6 +164,13 @@ template <class _Tp>
   return true;
 }
 #endif // _CCCL_HAS_NVFP4_E2M1()
+
+#if _CCCL_HAS_FLOAT128()
+[[nodiscard]] _CCCL_API constexpr bool isfinite(__float128 __x) noexcept
+{
+  return ::cuda::std::__isfinite_impl(__x);
+}
+#endif // _CCCL_HAS_FLOAT128()
 
 _CCCL_TEMPLATE(class _Tp)
 _CCCL_REQUIRES(is_integral_v<_Tp>)

--- a/libcudacxx/include/cuda/std/__cmath/isinf.h
+++ b/libcudacxx/include/cuda/std/__cmath/isinf.h
@@ -206,7 +206,7 @@ template <class _Tp>
 {
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
-    NV_IF_TARGET(NV_PROVIDES_SM_100, (return return ::__nv_fp128_fabs(__x) == ::cuda::std::__fp_inf<__float128>();))
+    NV_IF_TARGET(NV_PROVIDES_SM_100, (return ::__nv_fp128_fabs(__x) == ::cuda::std::__fp_inf<__float128>();))
   }
   return ::cuda::std::__isinf_impl(__x);
 }

--- a/libcudacxx/include/cuda/std/__cmath/isinf.h
+++ b/libcudacxx/include/cuda/std/__cmath/isinf.h
@@ -25,6 +25,7 @@
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__floating_point/fp.h>
 #include <cuda/std/__host_stdlib/math.h>
+#include <cuda/std/__type_traits/is_extended_floating_point.h>
 #include <cuda/std/__type_traits/is_floating_point.h>
 #include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/limits>
@@ -44,13 +45,17 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr bool __isinf_impl(_Tp __x) noexcept
 {
-  static_assert(is_floating_point_v<_Tp>, "Only standard floating-point types are supported");
-#if !_CCCL_TILE_COMPILATION() // nvbug6077402: error: "call to non-tile function not supported!"
-  _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+  static_assert(is_floating_point_v<_Tp> || __is_extended_floating_point_v<_Tp>,
+                "Only floating-point types are supported");
+  if constexpr (is_floating_point_v<_Tp>)
   {
-    return ::isinf(__x);
-  }
+#if !_CCCL_TILE_COMPILATION() // nvbug6077402: error: "call to non-tile function not supported!"
+    _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+    {
+      return ::isinf(__x);
+    }
 #endif // !_CCCL_TILE_COMPILATION()
+  }
   if (::cuda::std::isnan(__x))
   {
     return false;
@@ -195,6 +200,17 @@ template <class _Tp>
   return false;
 }
 #endif // _CCCL_HAS_NVFP4_E2M1()
+
+#if _CCCL_HAS_FLOAT128()
+[[nodiscard]] _CCCL_API constexpr bool isinf(__float128 __x) noexcept
+{
+  _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+  {
+    NV_IF_TARGET(NV_PROVIDES_SM_100, (return !::__nv_fp128_isnan(__x) && ::__nv_fp128_isnan(__x - __x);))
+  }
+  return ::cuda::std::__isinf_impl(__x);
+}
+#endif // _CCCL_HAS_FLOAT128()
 
 _CCCL_TEMPLATE(class _Tp)
 _CCCL_REQUIRES(is_integral_v<_Tp>)

--- a/libcudacxx/include/cuda/std/__cmath/isinf.h
+++ b/libcudacxx/include/cuda/std/__cmath/isinf.h
@@ -206,7 +206,7 @@ template <class _Tp>
 {
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
-    NV_IF_TARGET(NV_PROVIDES_SM_100, (return !::__nv_fp128_isnan(__x) && ::__nv_fp128_isnan(__x - __x);))
+    NV_IF_TARGET(NV_PROVIDES_SM_100, (return return ::__nv_fp128_fabs(__x) == ::cuda::std::__fp_inf<__float128>();))
   }
   return ::cuda::std::__isinf_impl(__x);
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/isfinite.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/isfinite.pass.cpp
@@ -45,6 +45,12 @@ TEST_FUNC constexpr void test_isfinite(const T pos, bool expected)
     {
       neg = -pos;
     }
+#if _CCCL_HAS_FLOAT128()
+    else if constexpr (cuda::std::is_same_v<T, __float128>)
+    {
+      neg = -pos;
+    }
+#endif // _CCCL_HAS_FLOAT128()
     else // nvfp types
     {
       neg = cuda::std::copysign(pos, cuda::std::numeric_limits<T>::lowest());
@@ -97,6 +103,9 @@ TEST_FUNC constexpr bool test()
 #if _CCCL_HAS_LONG_DOUBLE()
   test_type<long double>();
 #endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_FLOAT128()
+  test_type<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
 #if _CCCL_HAS_NVFP16()
   test_type<__half>();
 #endif // _CCCL_HAS_NVFP16()

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/isinf.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/isinf.pass.cpp
@@ -45,6 +45,12 @@ TEST_FUNC constexpr void test_isinf(const T pos, bool expected)
     {
       neg = -pos;
     }
+#if _CCCL_HAS_FLOAT128()
+    else if constexpr (cuda::std::is_same_v<T, __float128>)
+    {
+      neg = -pos;
+    }
+#endif // _CCCL_HAS_FLOAT128()
     else // nvfp types
     {
       neg = cuda::std::copysign(pos, cuda::std::numeric_limits<T>::lowest());
@@ -97,6 +103,9 @@ TEST_FUNC constexpr bool test()
 #if _CCCL_HAS_LONG_DOUBLE()
   test_type<long double>();
 #endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_FLOAT128()
+  test_type<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
 #if _CCCL_HAS_NVFP16()
   test_type<__half>();
 #endif // _CCCL_HAS_NVFP16()


### PR DESCRIPTION
## Description

Small PR to support `__float128` for `isfinite()` and `isinf()` with runtime (intrinsics) and compile-time evaluation.
This is aligned with `isnan` that already supports `__float128`