### PR TITLE
[DOC] Fix sidebar noise from Breathe overload anchors

### DIFF
--- a/docs/_static/deduplicate_toc.js
+++ b/docs/_static/deduplicate_toc.js
@@ -1,0 +1,32 @@
+// Clean up the "On this page" sidebar for C++ API pages.
+//
+// Two problems caused by Breathe's per-overload anchor generation:
+// 1. toc-h4 entries: Breathe adds a bare redundant "transform()" child anchor under each
+//    overload's section heading. Always remove them.
+// 2. Duplicate toc-h3 entries: when all overloads share the same display name
+//    (e.g. "ExclusiveSum()"), keep only the first occurrence.
+document.addEventListener('DOMContentLoaded', function() {
+  var tocNav = document.getElementById('pst-page-toc-nav');
+  if (!tocNav)
+    return;
+
+  tocNav.querySelectorAll('li.toc-h4').forEach(function(li) {
+    var label = li.textContent.trim();
+    if (label.endsWith('()')) {
+      li.remove();
+    }
+  });
+
+  var seen = new Set();
+  tocNav.querySelectorAll('li.toc-h3').forEach(function(li) {
+    var label = li.textContent.trim();
+    if (!label.endsWith(')')) {
+      return;
+    }
+    if (seen.has(label)) {
+      li.remove();
+    } else {
+      seen.add(label);
+    }
+  });
+});

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -157,6 +157,8 @@ html_static_path = ["_static"] if os.path.exists("_static") else []
 if os.path.exists("img"):
     html_static_path.append("img")
 
+html_js_files = ["deduplicate_toc.js"]
+
 html_title = "CUDA Core Compute Libraries"
 
 # -- Options for extensions --------------------------------------------------


### PR DESCRIPTION
Breathe generates per-overload anchors that pollute the sidebar in two ways:
- toc-h3: identical entries (e.g. ExclusiveSum() x20) when overloads share a name
- toc-h4: a bare redundant child anchor (e.g. transform()) nested under each overload section

I add a dedup js script that scopes both fixes to function signatures only (entries ending with \")\"), leaving legitimate toc-h4 content like enum values, state names, and property names untouched."

<img width="3088" height="491" alt="cub_toc3_dups" src="https://github.com/user-attachments/assets/8b047dc0-ceb4-4605-a9ce-9593ec6a1c70" />
<img width="2960" height="1255" alt="thrust_toc3_dups" src="https://github.com/user-attachments/assets/1921ca8a-21b5-45fa-8c41-06f4514cea74" />
<img width="2924" height="479" alt="thrust_toc4" src="https://github.com/user-attachments/assets/977c57bf-e08b-495a-932b-d4d3fb5a3d06" />
