### PR TITLE
[libcu++] Add initializer_list overloads for make_*_buffer helpers

### DIFF
--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -873,6 +873,7 @@ _CCCL_HOST_API void __fill_n(cuda::stream_ref __stream, _Tp* __first, ::cuda::st
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 
+// Require at least one explicit property on the source, so it doesn't look applicable for initializer list inputs
 _CCCL_TEMPLATE(class _Tp,
                class _FirstProperty,
                class... _RestProperties,

--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -877,13 +877,17 @@ _CCCL_TEMPLATE(class _Tp,
                class _FirstProperty,
                class... _RestProperties,
                class _Resource,
-               class... _SourceProperties,
+               class _FirstSourceProperty,
+               class... _RestSourceProperties,
                class _Env = ::cuda::std::execution::env<>)
 _CCCL_REQUIRES(
   ::cuda::mr::synchronous_resource_with<::cuda::std::decay_t<_Resource>, _FirstProperty, _RestProperties...> _CCCL_AND
     __buffer_compatible_env<_Env>)
 _CCCL_HOST_API buffer<_Tp, _FirstProperty, _RestProperties...> make_buffer(
-  stream_ref __stream, _Resource&& __mr, const buffer<_Tp, _SourceProperties...>& __source, const _Env& __env = {})
+  stream_ref __stream,
+  _Resource&& __mr,
+  const buffer<_Tp, _FirstSourceProperty, _RestSourceProperties...>& __source,
+  const _Env& __env = {})
 {
   buffer<_Tp, _FirstProperty, _RestProperties...> __res{
     __stream, ::cuda::std::forward<_Resource>(__mr), __source.size(), no_init, __env};
@@ -899,15 +903,29 @@ _CCCL_HOST_API buffer<_Tp, _FirstProperty, _RestProperties...> make_buffer(
 //! @param __source The source buffer to copy from.
 //! @param __env The environment providing additional configuration.
 #  ifdef _CCCL_DOXYGEN_INVOKED
-template <class _Tp, class _Resource, class... _SourceProperties, class _Env = ::cuda::std::execution::env<>>
+template <class _Tp,
+          class _Resource,
+          class _FirstSourceProperty,
+          class... _RestSourceProperties,
+          class _Env = ::cuda::std::execution::env<>>
 _CCCL_HOST_API auto make_buffer(
-  stream_ref __stream, _Resource&& __mr, const buffer<_Tp, _SourceProperties...>& __source, const _Env& __env = {});
+  stream_ref __stream,
+  _Resource&& __mr,
+  const buffer<_Tp, _FirstSourceProperty, _RestSourceProperties...>& __source,
+  const _Env& __env = {});
 #  else // ^^^ _CCCL_DOXYGEN_INVOKED ^^^ / vvv !_CCCL_DOXYGEN_INVOKED vvv
-_CCCL_TEMPLATE(class _Tp, class _Resource, class... _SourceProperties, class _Env = ::cuda::std::execution::env<>)
+_CCCL_TEMPLATE(class _Tp,
+               class _Resource,
+               class _FirstSourceProperty,
+               class... _RestSourceProperties,
+               class _Env = ::cuda::std::execution::env<>)
 _CCCL_REQUIRES(::cuda::mr::synchronous_resource<::cuda::std::decay_t<_Resource>>
                  _CCCL_AND ::cuda::mr::__has_default_queries<::cuda::std::decay_t<_Resource>>)
 _CCCL_HOST_API auto make_buffer(
-  stream_ref __stream, _Resource&& __mr, const buffer<_Tp, _SourceProperties...>& __source, const _Env& __env = {})
+  stream_ref __stream,
+  _Resource&& __mr,
+  const buffer<_Tp, _FirstSourceProperty, _RestSourceProperties...>& __source,
+  const _Env& __env = {})
 {
   using __buffer_type = __buffer_type_for_props<_Tp, typename ::cuda::std::decay_t<_Resource>::default_queries>;
   auto __res          = __buffer_type{__stream, ::cuda::std::forward<_Resource>(__mr), __source.size(), no_init, __env};

--- a/libcudacxx/include/cuda/__container/make_buffer_with_pool.h
+++ b/libcudacxx/include/cuda/__container/make_buffer_with_pool.h
@@ -34,6 +34,10 @@
 #    include <cuda/__memory_pool/managed_memory_pool.h>
 #  endif // _CCCL_CTK_AT_LEAST(13, 0)
 
+#  include <cuda/std/__execution/env.h>
+#  include <cuda/std/__utility/forward.h>
+#  include <cuda/std/initializer_list>
+
 #  include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA
@@ -50,6 +54,18 @@ _CCCL_HOST_API auto make_device_buffer(stream_ref __stream, device_ref __device,
     __stream, ::cuda::device_default_memory_pool(__device), ::cuda::std::forward<_Args>(__args)...);
 }
 
+//! @brief Creates a buffer backed by the default device memory pool from an initializer_list.
+//! @param __stream The stream used for allocation.
+//! @param __device The device whose default memory pool will be used.
+//! @param __ilist The initializer_list being copied into the buffer.
+//! @param __env The environment providing additional configuration.
+template <class _Tp, class _Env = ::cuda::std::execution::env<>>
+_CCCL_HOST_API auto make_device_buffer(
+  stream_ref __stream, device_ref __device, ::cuda::std::initializer_list<_Tp> __ilist, const _Env& __env = {})
+{
+  return ::cuda::make_buffer<_Tp>(__stream, ::cuda::device_default_memory_pool(__device), __ilist, __env);
+}
+
 #  if _CCCL_CTK_AT_LEAST(12, 9)
 
 //! @brief Creates a buffer backed by the default pinned memory pool.
@@ -61,6 +77,17 @@ _CCCL_HOST_API auto make_pinned_buffer(stream_ref __stream, _Args&&... __args)
 {
   return ::cuda::make_buffer<_Tp>(
     __stream, ::cuda::pinned_default_memory_pool(), ::cuda::std::forward<_Args>(__args)...);
+}
+
+//! @brief Creates a buffer backed by the default pinned memory pool from an initializer_list.
+//! @param __stream The stream used for allocation.
+//! @param __ilist The initializer_list being copied into the buffer.
+//! @param __env The environment providing additional configuration.
+template <class _Tp, class _Env = ::cuda::std::execution::env<>>
+_CCCL_HOST_API auto
+make_pinned_buffer(stream_ref __stream, ::cuda::std::initializer_list<_Tp> __ilist, const _Env& __env = {})
+{
+  return ::cuda::make_buffer<_Tp>(__stream, ::cuda::pinned_default_memory_pool(), __ilist, __env);
 }
 
 #  endif // _CCCL_CTK_AT_LEAST(12, 9)
@@ -76,6 +103,17 @@ _CCCL_HOST_API auto make_managed_buffer(stream_ref __stream, _Args&&... __args)
 {
   return ::cuda::make_buffer<_Tp>(
     __stream, ::cuda::managed_default_memory_pool(), ::cuda::std::forward<_Args>(__args)...);
+}
+
+//! @brief Creates a buffer backed by the default managed memory pool from an initializer_list.
+//! @param __stream The stream used for allocation.
+//! @param __ilist The initializer_list being copied into the buffer.
+//! @param __env The environment providing additional configuration.
+template <class _Tp, class _Env = ::cuda::std::execution::env<>>
+_CCCL_HOST_API auto
+make_managed_buffer(stream_ref __stream, ::cuda::std::initializer_list<_Tp> __ilist, const _Env& __env = {})
+{
+  return ::cuda::make_buffer<_Tp>(__stream, ::cuda::managed_default_memory_pool(), __ilist, __env);
 }
 
 #  endif // _CCCL_CTK_AT_LEAST(13, 0)

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/constructor.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/constructor.cu
@@ -202,6 +202,22 @@ C2H_CCCLRT_TEST("cuda::buffer constructors", "[container][buffer]", test_types)
       CCCLRT_CHECK(buf.size() == 6);
       CCCLRT_CHECK(equal_range(buf));
     }
+    {
+      const auto buf = cuda::make_buffer<T>(stream, resource, {T(1), T(42), T(1337), T(0), T(12), T(-1)});
+      CCCLRT_CHECK(check_offseted_pointer(buf.data()));
+      CCCLRT_CHECK(buf.size() == 6);
+      CCCLRT_CHECK(equal_range(buf));
+    }
+    {
+      const ::cuda::std::size_t alignment = ::cuda::mr::default_cuda_malloc_alignment / 2;
+      const auto env                      = ::cuda::std::execution::prop{::cuda::allocation_alignment, alignment};
+      const auto buf = cuda::make_buffer<T>(stream, resource, {T(1), T(42), T(1337), T(0), T(12), T(-1)}, env);
+      CCCLRT_CHECK(check_offseted_pointer_with_alignment(buf.data(), alignment));
+      CCCLRT_CHECK(buf.alignment() == alignment);
+      CCCLRT_CHECK(cuda::allocation_alignment(buf) == alignment);
+      CCCLRT_CHECK(buf.size() == 6);
+      CCCLRT_CHECK(equal_range(buf));
+    }
   }
 
   SECTION("copy construction")
@@ -560,6 +576,24 @@ C2H_CCCLRT_TEST("cuda::make_device_buffer", "[container][buffer]")
     CCCLRT_CHECK(equal_range(buf));
   }
 
+  SECTION("initializer_list")
+  {
+    auto buf = cuda::make_device_buffer<int>(stream, dev, {1, 42, 1337, 0, 12, -1});
+    CCCLRT_CHECK(buf.size() == 6);
+    CCCLRT_CHECK(equal_range(buf));
+  }
+
+  SECTION("initializer_list with env")
+  {
+    const auto alignment = cuda::mr::default_cuda_malloc_alignment / 2;
+    const auto env       = cuda::std::execution::prop{cuda::allocation_alignment, alignment};
+    auto buf             = cuda::make_device_buffer<int>(stream, dev, {1, 42, 1337, 0, 12, -1}, env);
+    CCCLRT_CHECK(buf.size() == 6);
+    CCCLRT_CHECK(buf.alignment() == alignment);
+    CCCLRT_CHECK(cuda::allocation_alignment(buf) == alignment);
+    CCCLRT_CHECK(equal_range(buf));
+  }
+
   stream.sync();
 }
 
@@ -611,6 +645,24 @@ C2H_CCCLRT_TEST("cuda::make_pinned_buffer", "[container][buffer]")
     cuda::std::array<int, 6> input{1, 42, 1337, 0, 12, -1};
     auto buf = cuda::make_pinned_buffer<int>(stream, input);
     CCCLRT_CHECK(buf.size() == 6);
+    CCCLRT_CHECK(equal_range(buf));
+  }
+
+  SECTION("initializer_list")
+  {
+    auto buf = cuda::make_pinned_buffer<int>(stream, {1, 42, 1337, 0, 12, -1});
+    CCCLRT_CHECK(buf.size() == 6);
+    CCCLRT_CHECK(equal_range(buf));
+  }
+
+  SECTION("initializer_list with env")
+  {
+    const auto alignment = cuda::mr::default_cuda_malloc_alignment / 2;
+    const auto env       = cuda::std::execution::prop{cuda::allocation_alignment, alignment};
+    auto buf             = cuda::make_pinned_buffer<int>(stream, {1, 42, 1337, 0, 12, -1}, env);
+    CCCLRT_CHECK(buf.size() == 6);
+    CCCLRT_CHECK(buf.alignment() == alignment);
+    CCCLRT_CHECK(cuda::allocation_alignment(buf) == alignment);
     CCCLRT_CHECK(equal_range(buf));
   }
 
@@ -666,6 +718,24 @@ C2H_CCCLRT_TEST("cuda::make_managed_buffer", "[container][buffer]")
     cuda::std::array<int, 6> input{1, 42, 1337, 0, 12, -1};
     auto buf = cuda::make_managed_buffer<int>(stream, input);
     CCCLRT_CHECK(buf.size() == 6);
+    CCCLRT_CHECK(equal_range(buf));
+  }
+
+  SECTION("initializer_list")
+  {
+    auto buf = cuda::make_managed_buffer<int>(stream, {1, 42, 1337, 0, 12, -1});
+    CCCLRT_CHECK(buf.size() == 6);
+    CCCLRT_CHECK(equal_range(buf));
+  }
+
+  SECTION("initializer_list with env")
+  {
+    const auto alignment = cuda::mr::default_cuda_malloc_alignment / 2;
+    const auto env       = cuda::std::execution::prop{cuda::allocation_alignment, alignment};
+    auto buf             = cuda::make_managed_buffer<int>(stream, {1, 42, 1337, 0, 12, -1}, env);
+    CCCLRT_CHECK(buf.size() == 6);
+    CCCLRT_CHECK(buf.alignment() == alignment);
+    CCCLRT_CHECK(cuda::allocation_alignment(buf) == alignment);
     CCCLRT_CHECK(equal_range(buf));
   }
 


### PR DESCRIPTION
It's not the most useful overload, but sometimes you need device or managed memory to hold just a few elements and it's nice to initialize inline. `make_buffer` already has initializer list overloads, but `make_device/pinned/managed_buffer` does not, so passing `{...}` can't be deduced to one.

This PR also include a fix for a conflict between the copy overload of `make_buffer` and the initializer list one, where `{ ... }` could be interpreted as initializing a buffer with no properties. Restricting the copy to require at least one property (as buffer currently requires anyway) fixes that.