### PR TITLE
Use cuda::buffer in ccclrt algorithm tests

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/algorithm/common.cuh
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/algorithm/common.cuh
@@ -12,6 +12,8 @@
 #define TEST_LIBCUDACXX_CCCLRT_ALGORITHM_COMMON_CUH
 
 #include <cuda/algorithm>
+#include <cuda/buffer>
+#include <cuda/devices>
 #include <cuda/memory_resource>
 #include <cuda/std/mdspan>
 #include <cuda/stream>
@@ -21,6 +23,23 @@
 
 inline constexpr uint8_t fill_byte    = 1;
 inline constexpr uint32_t buffer_size = 42;
+
+using legacy_pinned_resource  = cuda::mr::synchronous_resource_adapter<cuda::mr::legacy_pinned_memory_resource>;
+using legacy_managed_resource = cuda::mr::synchronous_resource_adapter<cuda::mr::legacy_managed_memory_resource>;
+
+template <typename T>
+auto make_pinned_memory_buffer(cuda::stream_ref stream, std::size_t size, cuda::device_ref device = cuda::devices[0])
+{
+  legacy_pinned_resource resource{cuda::mr::legacy_pinned_memory_resource{device}};
+  return cuda::make_buffer<T>(stream, resource, size, cuda::no_init);
+}
+
+template <typename T>
+auto make_managed_memory_buffer(cuda::stream_ref stream, std::size_t size, cuda::device_ref device = cuda::devices[0])
+{
+  legacy_managed_resource resource{cuda::mr::legacy_managed_memory_resource{cudaMemAttachGlobal, device}};
+  return cuda::make_buffer<T>(stream, resource, size, cuda::no_init);
+}
 
 inline int get_expected_value(uint8_t pattern_byte)
 {
@@ -42,124 +61,15 @@ void check_result_and_erase(cuda::stream_ref stream, Result&& result, uint8_t pa
   }
 }
 
-enum class test_buffer_type
-{
-  pinned,
-  device,
-  managed
-};
-
-// Temporary test type until we move the buffer types to libcu++
-template <typename T>
-struct test_buffer
-{
-  test_buffer_type type;
-  T* data_ptr;
-  std::size_t buffer_size;
-
-  test_buffer(test_buffer_type type, std::size_t size)
-      : type(type)
-      , data_ptr(nullptr)
-      , buffer_size(size)
-  {
-    cuda::__ensure_current_context ctx_setter{cuda::device_ref{0}};
-    if (type == test_buffer_type::pinned)
-    {
-      _CCCL_TRY_CUDA_API(cudaMallocHost, "Failed to allocate pinned memory", &data_ptr, size * sizeof(T));
-    }
-    else if (type == test_buffer_type::device)
-    {
-      _CCCL_TRY_CUDA_API(cudaMalloc, "Failed to allocate device memory", &data_ptr, size * sizeof(T));
-    }
-    else if (type == test_buffer_type::managed)
-    {
-      _CCCL_TRY_CUDA_API(cudaMallocManaged, "Failed to allocate managed memory", &data_ptr, size * sizeof(T));
-    }
-  }
-
-  ~test_buffer()
-  {
-    if (data_ptr)
-    {
-      cuda::__ensure_current_context ctx_setter{cuda::device_ref{0}};
-      if (type == test_buffer_type::pinned)
-      {
-        _CCCL_LOG_CUDA_API(cudaFreeHost, "Failed to free pinned memory", data_ptr);
-      }
-      else if (type == test_buffer_type::device)
-      {
-        _CCCL_LOG_CUDA_API(cudaFree, "Failed to free device memory", data_ptr);
-      }
-      else if (type == test_buffer_type::managed)
-      {
-        _CCCL_LOG_CUDA_API(cudaFree, "Failed to free managed memory", data_ptr);
-      }
-    }
-  }
-
-  test_buffer(const test_buffer&) = delete;
-  test_buffer(test_buffer&& other) noexcept
-      : type(other.type)
-      , data_ptr(other.data_ptr)
-      , buffer_size(other.buffer_size)
-  {
-    other.data_ptr    = nullptr;
-    other.buffer_size = 0;
-  }
-
-  test_buffer& operator=(const test_buffer&) = delete;
-  test_buffer& operator=(test_buffer&& other) noexcept
-  {
-    ::cuda::std::exchange(type, other.type);
-    ::cuda::std::exchange(data_ptr, other.data_ptr);
-    ::cuda::std::exchange(buffer_size, other.buffer_size);
-    return *this;
-  }
-
-  T* begin() const
-  {
-    return data_ptr;
-  }
-
-  T* end() const
-  {
-    return data_ptr + buffer_size;
-  }
-
-  T* data() const
-  {
-    return data_ptr;
-  }
-
-  std::size_t size() const
-  {
-    return buffer_size;
-  }
-
-  std::size_t size_bytes() const
-  {
-    return buffer_size * sizeof(T);
-  }
-
-  operator cuda::std::span<const T>() const
-  {
-    return {data_ptr, buffer_size};
-  }
-
-  operator cuda::std::span<T>()
-  {
-    return {data_ptr, buffer_size};
-  }
-};
-
 template <typename Layout = cuda::std::layout_right, typename Extents>
-auto make_buffer_for_mdspan(Extents extents, char value = 0)
+auto make_buffer_for_mdspan(cuda::stream_ref stream, Extents extents, char value = 0)
 {
   auto mapping = typename Layout::template mapping<decltype(extents)>{extents};
 
-  test_buffer<int> buffer(test_buffer_type::pinned, mapping.required_span_size());
+  auto buffer = make_pinned_memory_buffer<int>(stream, mapping.required_span_size());
 
-  memset(buffer.data(), value, buffer.size_bytes());
+  stream.sync();
+  memset(buffer.data(), value, buffer.size() * sizeof(int));
 
   return buffer;
 }

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/algorithm/copy.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/algorithm/copy.cu
@@ -20,17 +20,18 @@ C2H_CCCLRT_TEST("1d Copy", "[algorithm]")
     std::vector<int> host_vector(buffer_size);
 
     {
-      test_buffer<int> buffer(test_buffer_type::device, buffer_size);
+      auto buffer = cuda::make_device_buffer<int>(_stream, cuda::device_ref{0}, buffer_size, cuda::no_init);
       cuda::fill_bytes(_stream, buffer, fill_byte);
 
       cuda::copy_bytes(_stream, buffer, host_vector);
       check_result_and_erase(_stream, host_vector);
 
-      cuda::copy_bytes(_stream, std::move(buffer), host_vector);
+      cuda::copy_bytes(_stream, buffer, host_vector);
       check_result_and_erase(_stream, host_vector);
     }
     {
-      test_buffer<int> not_yet_const_buffer(test_buffer_type::device, buffer_size);
+      auto not_yet_const_buffer =
+        cuda::make_device_buffer<int>(_stream, cuda::device_ref{0}, buffer_size, cuda::no_init);
       cuda::fill_bytes(_stream, not_yet_const_buffer, fill_byte);
 
       const auto& const_buffer = not_yet_const_buffer;
@@ -48,32 +49,31 @@ C2H_CCCLRT_TEST("1d Copy", "[algorithm]")
 #else
       config.src_access_order = cuda::source_access_order::any;
 #endif
-      cuda::copy_bytes(_stream, cuda::std::span(const_buffer), host_vector, config);
+      cuda::copy_bytes(_stream, const_buffer, host_vector, config);
       check_result_and_erase(_stream, host_vector);
 
-      cuda::std::span<int> span(const_buffer.data(), 0);
-      cuda::copy_bytes(_stream, span, host_vector);
+      cuda::copy_bytes(_stream, const_buffer.first(0), host_vector);
     }
   }
 
   SECTION("Host and managed resource")
   {
     {
-      test_buffer<int> host_buffer(test_buffer_type::pinned, buffer_size);
-      test_buffer<int> device_buffer(test_buffer_type::managed, buffer_size);
+      auto host_buffer   = make_pinned_memory_buffer<int>(_stream, buffer_size);
+      auto device_buffer = make_managed_memory_buffer<int>(_stream, buffer_size);
 
       cuda::fill_bytes(_stream, host_buffer, fill_byte);
 
       cuda::copy_bytes(_stream, host_buffer, device_buffer);
       check_result_and_erase(_stream, device_buffer);
 
-      cuda::copy_bytes(_stream, cuda::std::span(host_buffer), device_buffer);
+      cuda::copy_bytes(_stream, host_buffer, device_buffer);
       check_result_and_erase(_stream, device_buffer);
     }
 
     {
-      test_buffer<int> not_yet_const_host_buffer(test_buffer_type::pinned, buffer_size);
-      test_buffer<int> device_buffer(test_buffer_type::managed, buffer_size);
+      auto not_yet_const_host_buffer = make_pinned_memory_buffer<int>(_stream, buffer_size);
+      auto device_buffer             = make_managed_memory_buffer<int>(_stream, buffer_size);
       cuda::fill_bytes(_stream, not_yet_const_host_buffer, fill_byte);
 
       const auto& const_host_buffer = not_yet_const_host_buffer;
@@ -81,14 +81,14 @@ C2H_CCCLRT_TEST("1d Copy", "[algorithm]")
       cuda::copy_bytes(_stream, const_host_buffer, device_buffer);
       check_result_and_erase(_stream, device_buffer);
 
-      cuda::copy_bytes(_stream, cuda::std::span(const_host_buffer), device_buffer);
+      cuda::copy_bytes(_stream, const_host_buffer, device_buffer);
       check_result_and_erase(_stream, device_buffer);
     }
   }
 
   SECTION("Asymmetric size")
   {
-    test_buffer<int> host_buffer(test_buffer_type::pinned, 1);
+    auto host_buffer = make_pinned_memory_buffer<int>(_stream, 1);
     cuda::fill_bytes(_stream, host_buffer, fill_byte);
 
     ::std::vector<int> vec(buffer_size, 0xbeef);
@@ -108,9 +108,9 @@ template <typename SrcLayout = cuda::std::layout_right,
 void test_mdspan_copy_bytes(
   cuda::stream_ref stream, SrcExtents src_extents = SrcExtents(), DstExtents dst_extents = DstExtents())
 {
-  auto src_buffer = make_buffer_for_mdspan<SrcLayout>(src_extents, 1);
-  auto tmp_buffer = make_buffer_for_mdspan<SrcLayout>(src_extents, 0);
-  auto dst_buffer = make_buffer_for_mdspan<DstLayout>(dst_extents, 0);
+  auto src_buffer = make_buffer_for_mdspan<SrcLayout>(stream, src_extents, 1);
+  auto tmp_buffer = make_buffer_for_mdspan<SrcLayout>(stream, src_extents, 0);
+  auto dst_buffer = make_buffer_for_mdspan<DstLayout>(stream, dst_extents, 0);
 
   cuda::std::mdspan<int, SrcExtents, SrcLayout> src(src_buffer.data(), src_extents);
   cuda::std::mdspan<int, SrcExtents, SrcLayout> tmp(tmp_buffer.data(), src_extents);

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/algorithm/fill.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/algorithm/fill.cu
@@ -15,30 +15,25 @@ C2H_CCCLRT_TEST("Fill", "[algorithm]")
   cuda::stream _stream{cuda::device_ref{0}};
   SECTION("Host memory")
   {
-    test_buffer<int> buffer(test_buffer_type::pinned, buffer_size);
+    auto buffer = make_pinned_memory_buffer<int>(_stream, buffer_size);
 
     cuda::fill_bytes(_stream, buffer, fill_byte);
 
-    check_result_and_erase(_stream, cuda::std::span(buffer));
+    check_result_and_erase(_stream, buffer);
   }
 
   SECTION("Device memory")
   {
-    test_buffer<int> buffer(test_buffer_type::device, buffer_size);
+    auto buffer = cuda::make_device_buffer<int>(_stream, cuda::device_ref{0}, buffer_size, cuda::no_init);
     cuda::fill_bytes(_stream, buffer, fill_byte);
 
-    std::vector<int> host_vector(42);
-    {
-      cuda::__ensure_current_context ctx_setter{cuda::device_ref{0}};
-      CUDART(cudaMemcpyAsync(
-        host_vector.data(), buffer.data(), buffer.size() * sizeof(int), cudaMemcpyDefault, _stream.get()));
-    }
+    auto host_vector = make_pinned_memory_buffer<int>(_stream, buffer_size);
+    cuda::copy_bytes(_stream, buffer, host_vector);
 
     check_result_and_erase(_stream, host_vector);
 
-    cuda::std::span<int> span(buffer.data(), 0);
+    auto span = buffer.first(0);
     cuda::fill_bytes(_stream, span, fill_byte);
-    printf("0 sized span: %p\n", static_cast<void*>(span.data()));
   }
 }
 
@@ -47,19 +42,19 @@ C2H_CCCLRT_TEST("Mdspan Fill", "[algorithm]")
   cuda::stream stream{cuda::device_ref{0}};
   {
     cuda::std::dextents<size_t, 3> dynamic_extents{1, 2, 3};
-    auto buffer = make_buffer_for_mdspan(dynamic_extents, 0);
+    auto buffer = make_buffer_for_mdspan(stream, dynamic_extents, 0);
     cuda::std::mdspan<int, decltype(dynamic_extents)> dynamic_mdspan(buffer.data(), dynamic_extents);
 
     cuda::fill_bytes(stream, dynamic_mdspan, fill_byte);
-    check_result_and_erase(stream, cuda::std::span(buffer.data(), buffer.size()));
+    check_result_and_erase(stream, buffer);
   }
   {
     cuda::std::extents<size_t, 2, cuda::std::dynamic_extent, 4> mixed_extents{1};
-    auto buffer = make_buffer_for_mdspan(mixed_extents, 0);
+    auto buffer = make_buffer_for_mdspan(stream, mixed_extents, 0);
     cuda::std::mdspan<int, decltype(mixed_extents)> mixed_mdspan(buffer.data(), mixed_extents);
 
     cuda::fill_bytes(stream, cuda::std::move(mixed_mdspan), fill_byte);
-    check_result_and_erase(stream, cuda::std::span(buffer.data(), buffer.size()));
+    check_result_and_erase(stream, buffer);
   }
 }
 


### PR DESCRIPTION
Summary:
- Replace the temporary ccclrt algorithm test_buffer helper with cuda::buffer factory APIs.
- Update copy/fill algorithm tests to allocate with cuda::make_*_buffer(..., cuda::no_init).
- Keep mdspan test storage on pinned cuda::buffer.
