### PR TITLE
[libcu++] Optimize `to_chars` integral width calculation

### DIFF
--- a/libcudacxx/include/cuda/std/__charconv/to_chars.h
+++ b/libcudacxx/include/cuda/std/__charconv/to_chars.h
@@ -20,7 +20,11 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/__cmath/ceil_div.h>
+#include <cuda/__cmath/ilog.h>
+#include <cuda/__cmath/pow2.h>
 #include <cuda/__cmath/uabs.h>
+#include <cuda/std/__bit/countl.h>
 #include <cuda/std/__charconv/chars_format.h>
 #include <cuda/std/__charconv/to_chars_result.h>
 #include <cuda/std/__concepts/concept_macros.h>
@@ -32,6 +36,7 @@
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/is_signed.h>
 #include <cuda/std/__type_traits/make_unsigned.h>
+#include <cuda/std/__type_traits/num_bits.h>
 #include <cuda/std/cstdint>
 
 #include <cuda/std/__cccl/prologue.h>
@@ -87,6 +92,27 @@ template <class _Tp>
   return __r;
 }
 
+template <int _Base, class _Tp>
+[[nodiscard]] _CCCL_API constexpr int __to_chars_int_width(_Tp __v) noexcept
+{
+  if constexpr (::cuda::is_power_of_two(_Base))
+  {
+    // For bases that are powers of 2, we can count leading zeros to compute the width more efficiently.
+    constexpr auto __base_ilog2 = ::cuda::ilog2(_Base);
+
+    // If value == 0 still need one digit, so we always set the least significant bit.
+    return ::cuda::ceil_div(__num_bits_v<_Tp> - ::cuda::std::countl_zero(static_cast<_Tp>(__v | 1)), __base_ilog2);
+  }
+  else if constexpr (_Base == 10)
+  {
+    return (__v > 1) ? ::cuda::ceil_ilog10(__v) : 1;
+  }
+  else
+  {
+    return ::cuda::std::__to_chars_int_width(__v, _Base);
+  }
+}
+
 template <class _Tp>
 _CCCL_API constexpr void __to_chars_int_generic(char* __last, _Tp __value, int __base) noexcept
 {
@@ -117,7 +143,32 @@ to_chars(char* __first, char* __last, _Tp __value, int __base = 10) noexcept
   else
   {
     const ptrdiff_t __cap = __last - __first;
-    const int __n         = ::cuda::std::__to_chars_int_width(__value, __base);
+
+    int __n{};
+    switch (__base)
+    {
+      case 2:
+        __n = ::cuda::std::__to_chars_int_width<2>(__value);
+        break;
+      case 4:
+        __n = ::cuda::std::__to_chars_int_width<4>(__value);
+        break;
+      case 8:
+        __n = ::cuda::std::__to_chars_int_width<8>(__value);
+        break;
+      case 10:
+        __n = ::cuda::std::__to_chars_int_width<10>(__value);
+        break;
+      case 16:
+        __n = ::cuda::std::__to_chars_int_width<16>(__value);
+        break;
+      case 32:
+        __n = ::cuda::std::__to_chars_int_width<32>(__value);
+        break;
+      default:
+        __n = ::cuda::std::__to_chars_int_width(__value, __base);
+        break;
+    }
 
     if (__n > __cap)
     {


### PR DESCRIPTION
This PR optimizes `to_chars` integral width calculation for bases that are a power of `2`.