### PR TITLE
[libcu++] Optimize integral formatters

### DIFF
--- a/libcudacxx/include/cuda/std/__format/format_integral.h
+++ b/libcudacxx/include/cuda/std/__format/format_integral.h
@@ -54,8 +54,7 @@ __fmt_format_char(_Tp __value, _OutIt __out_it, __fmt_parsed_spec<_CharT> __spec
     }
   }
   const auto __c = static_cast<_CharT>(__value);
-  return ::cuda::std::__fmt_write(
-    ::cuda::std::addressof(__c), ::cuda::std::addressof(__c) + 1, ::cuda::std::move(__out_it), __specs);
+  return ::cuda::std::__fmt_write(&__c, &__c + 1, ::cuda::std::move(__out_it), __specs);
 }
 
 //! Helper to determine the buffer size to output an unsigned integer in Base @em x.
@@ -110,18 +109,14 @@ __fmt_insert_sign(char* __buf, bool __negative, __fmt_spec_sign __sign)
   return __buf;
 }
 
-template <class _Tp, class _CharT, class _FmtCtx>
-[[nodiscard]] _CCCL_HOST_DEVICE_API typename _FmtCtx::iterator __fmt_format_int_impl(
-  _Tp __value,
-  _FmtCtx& __ctx,
-  __fmt_parsed_spec<_CharT> __specs,
-  bool __negative,
-  char* __array,
-  int __size,
-  const char* __prefix,
-  int __base)
+template <int _Base, class _Tp, class _CharT, class _OutIt>
+[[nodiscard]] _CCCL_HOST_DEVICE_API _OutIt __fmt_format_int_impl(
+  _Tp __value, _OutIt __out_it, __fmt_parsed_spec<_CharT> __specs, bool __negative, const char* __prefix)
 {
-  char* __first = ::cuda::std::__fmt_insert_sign(__array, __negative, __fmt_spec_sign{__specs.__std_.__sign_});
+  constexpr auto __buffer_size = __fmt_int_buffer_size_v<_Tp, _Base>;
+  char __buffer[__buffer_size];
+
+  char* __first = ::cuda::std::__fmt_insert_sign(__buffer, __negative, __fmt_spec_sign{__specs.__std_.__sign_});
   if (__specs.__std_.__alternate_form_ && __prefix != nullptr)
   {
     while (*__prefix)
@@ -132,15 +127,14 @@ template <class _Tp, class _CharT, class _FmtCtx>
 
   char* __last{};
   {
-    const auto __r = ::cuda::std::to_chars(__first, __array + __size, __value, __base);
+    const auto __r = ::cuda::std::to_chars(__first, __buffer + __buffer_size, __value, _Base);
     _CCCL_ASSERT(__r.ec == errc(0), "Internal buffer too small");
     __last = __r.ptr;
   }
 
-  auto __out_it = __ctx.out();
   if (__fmt_spec_alignment{__specs.__alignment_} != __fmt_spec_alignment::__zero_padding)
   {
-    __first = __array;
+    __first = __buffer;
   }
   else
   {
@@ -149,71 +143,59 @@ template <class _Tp, class _CharT, class _FmtCtx>
     // The zero padding is done like:
     // - Write [sign][prefix]
     // - Write data right aligned with '0' as fill character.
-    __out_it                  = ::cuda::std::__fmt_copy(__array, __first, ::cuda::std::move(__out_it));
+    __out_it                  = ::cuda::std::__fmt_copy(__buffer, __first, ::cuda::std::move(__out_it));
     __specs.__alignment_      = ::cuda::std::to_underlying(__fmt_spec_alignment::__right);
     __specs.__fill_.__data[0] = _CharT{'0'};
-    __specs.__width_ -= ::cuda::std::min(static_cast<uint32_t>(__first - __array), __specs.__width_);
+    __specs.__width_ -= ::cuda::std::min(static_cast<uint32_t>(__first - __buffer), __specs.__width_);
   }
 
   if (__specs.__std_.__type_ != __fmt_spec_type::__hexadecimal_upper_case)
   {
-    return ::cuda::std::__fmt_write(__first, __last, __ctx.out(), __specs);
+    return ::cuda::std::__fmt_write(__first, __last, ::cuda::std::move(__out_it), __specs);
   }
-  return ::cuda::std::__fmt_write_transformed(__first, __last, __ctx.out(), __specs, ::cuda::std::__fmt_hex_to_upper);
+  return ::cuda::std::__fmt_write_transformed(
+    __first, __last, ::cuda::std::move(__out_it), __specs, ::cuda::std::__fmt_hex_to_upper);
 }
 
-template <class _Tp, class _CharT, class _FmtCtx>
-[[nodiscard]] _CCCL_HOST_DEVICE_API typename _FmtCtx::iterator
-__fmt_format_int(_Tp __value, _FmtCtx& __ctx, __fmt_parsed_spec<_CharT> __specs)
+template <class _Tp, class _CharT, class _OutIt>
+[[nodiscard]] _CCCL_HOST_DEVICE_API _OutIt __fmt_format_int(
+  _Tp __value, _OutIt __out_it, __fmt_parsed_spec<_CharT> __specs, [[maybe_unused]] bool __negative = false)
 {
   static_assert(__cccl_is_integer_v<_Tp>);
 
-  using _Up             = make_unsigned_t<_Tp>;
-  const auto __uvalue   = ::cuda::uabs(__value);
-  const auto __negative = is_signed_v<_Tp> && __value < 0;
-
-  switch (__specs.__std_.__type_)
+  if constexpr (is_signed_v<_Tp>)
   {
-    case __fmt_spec_type::__binary_lower_case: {
-      char __array[__fmt_int_buffer_size_v<_Up, 2>];
-      return ::cuda::std::__fmt_format_int_impl(
-        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Up, 2>, "0b", 2);
+    return ::cuda::std::__fmt_format_int(::cuda::uabs(__value), ::cuda::std::move(__out_it), __specs, __value < 0);
+  }
+  else
+  {
+    switch (__specs.__std_.__type_)
+    {
+      case __fmt_spec_type::__binary_lower_case:
+        return ::cuda::std::__fmt_format_int_impl<2>(__value, ::cuda::std::move(__out_it), __specs, __negative, "0b");
+      case __fmt_spec_type::__binary_upper_case:
+        return ::cuda::std::__fmt_format_int_impl<2>(__value, ::cuda::std::move(__out_it), __specs, __negative, "0B");
+      case __fmt_spec_type::__octal:
+        // Octal is special; if __value == 0 there's no prefix.
+        return ::cuda::std::__fmt_format_int_impl<8>(
+          __value, ::cuda::std::move(__out_it), __specs, __negative, __value != 0 ? "0" : nullptr);
+      case __fmt_spec_type::__default:
+      case __fmt_spec_type::__decimal:
+        return ::cuda::std::__fmt_format_int_impl<10>(
+          __value, ::cuda::std::move(__out_it), __specs, __negative, nullptr);
+      case __fmt_spec_type::__hexadecimal_lower_case:
+        return ::cuda::std::__fmt_format_int_impl<16>(__value, ::cuda::std::move(__out_it), __specs, __negative, "0x");
+      case __fmt_spec_type::__hexadecimal_upper_case:
+        return ::cuda::std::__fmt_format_int_impl<16>(__value, ::cuda::std::move(__out_it), __specs, __negative, "0X");
+      default:
+        _CCCL_UNREACHABLE();
     }
-    case __fmt_spec_type::__binary_upper_case: {
-      char __array[__fmt_int_buffer_size_v<_Up, 2>];
-      return ::cuda::std::__fmt_format_int_impl(
-        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Up, 2>, "0B", 2);
-    }
-    case __fmt_spec_type::__octal: {
-      // Octal is special; if __uvalue == 0 there's no prefix.
-      char __array[__fmt_int_buffer_size_v<_Up, 8>];
-      return ::cuda::std::__fmt_format_int_impl(
-        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Up, 8>, __uvalue != 0 ? "0" : nullptr, 8);
-    }
-    case __fmt_spec_type::__default:
-    case __fmt_spec_type::__decimal: {
-      char __array[__fmt_int_buffer_size_v<_Up, 10>];
-      return ::cuda::std::__fmt_format_int_impl(
-        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Up, 10>, nullptr, 10);
-    }
-    case __fmt_spec_type::__hexadecimal_lower_case: {
-      char __array[__fmt_int_buffer_size_v<_Up, 16>];
-      return ::cuda::std::__fmt_format_int_impl(
-        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Up, 16>, "0x", 16);
-    }
-    case __fmt_spec_type::__hexadecimal_upper_case: {
-      char __array[__fmt_int_buffer_size_v<_Up, 16>];
-      return ::cuda::std::__fmt_format_int_impl(
-        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Up, 16>, "0X", 16);
-    }
-    default:
-      _CCCL_UNREACHABLE();
   }
 }
 
-template <class _CharT, class _FmtContext>
-[[nodiscard]] _CCCL_HOST_DEVICE_API typename _FmtContext::iterator
-__fmt_format_bool(bool __value, _FmtContext& __ctx, __fmt_parsed_spec<_CharT> __specs)
+template <class _CharT, class _OutIt>
+[[nodiscard]] _CCCL_HOST_DEVICE_API _OutIt
+__fmt_format_bool(bool __value, _OutIt __out_it, __fmt_parsed_spec<_CharT> __specs)
 {
   basic_string_view<_CharT> __str{};
   if constexpr (is_same_v<_CharT, char>)
@@ -230,7 +212,7 @@ __fmt_format_bool(bool __value, _FmtContext& __ctx, __fmt_parsed_spec<_CharT> __
   {
     static_assert(__always_false_v<_CharT>, "Unsupported character type for boolean formatting");
   }
-  return ::cuda::std::__fmt_write(__str, __ctx.out(), __specs, static_cast<ptrdiff_t>(__str.size()));
+  return ::cuda::std::__fmt_write(__str, ::cuda::std::move(__out_it), __specs, static_cast<ptrdiff_t>(__str.size()));
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__format/formatters/bool.h
+++ b/libcudacxx/include/cuda/std/__format/formatters/bool.h
@@ -64,7 +64,7 @@ struct __fmt_formatter_bool
     {
       case __fmt_spec_type::__default:
       case __fmt_spec_type::__string:
-        return ::cuda::std::__fmt_format_bool(__value, __ctx, __parser_.__get_parsed_std_spec(__ctx));
+        return ::cuda::std::__fmt_format_bool(__value, __ctx.out(), __parser_.__get_parsed_std_spec(__ctx));
       case __fmt_spec_type::__binary_lower_case:
       case __fmt_spec_type::__binary_upper_case:
       case __fmt_spec_type::__octal:
@@ -74,7 +74,7 @@ struct __fmt_formatter_bool
         // Promotes bool to an integral type. This reduces the number of
         // instantiations of __format_integer reducing code size.
         return ::cuda::std::__fmt_format_int(
-          static_cast<unsigned>(__value), __ctx, __parser_.__get_parsed_std_spec(__ctx));
+          static_cast<unsigned>(__value), __ctx.out(), __parser_.__get_parsed_std_spec(__ctx));
       default:
         _CCCL_UNREACHABLE();
     }

--- a/libcudacxx/include/cuda/std/__format/formatters/char.h
+++ b/libcudacxx/include/cuda/std/__format/formatters/char.h
@@ -74,11 +74,11 @@ struct __fmt_formatter_char
 
     if constexpr (sizeof(_CharT) <= sizeof(unsigned))
     {
-      return ::cuda::std::__fmt_format_int(static_cast<unsigned>(static_cast<_Up>(__value)), __ctx, __specs);
+      return ::cuda::std::__fmt_format_int(static_cast<unsigned>(static_cast<_Up>(__value)), __ctx.out(), __specs);
     }
     else
     {
-      return ::cuda::std::__fmt_format_int(static_cast<_Up>(__value), __ctx, __specs);
+      return ::cuda::std::__fmt_format_int(static_cast<_Up>(__value), __ctx.out(), __specs);
     }
   }
 

--- a/libcudacxx/include/cuda/std/__format/formatters/int.h
+++ b/libcudacxx/include/cuda/std/__format/formatters/int.h
@@ -76,7 +76,7 @@ struct __fmt_formatter_int
       __make_nbit_int_t<::cuda::std::max(sizeof(_Tp) * CHAR_BIT, sizeof(int32_t) * CHAR_BIT), is_signed_v<_Tp>>;
 
     // Reduce the number of instantiation of the integer formatter
-    return ::cuda::std::__fmt_format_int(static_cast<_Type>(__value), __ctx, __specs);
+    return ::cuda::std::__fmt_format_int(static_cast<_Type>(__value), __ctx.out(), __specs);
   }
 
   __fmt_spec_parser<_CharT> __parser_; //!< The parser for format specifications.

--- a/libcudacxx/include/cuda/std/__format/formatters/ptr.h
+++ b/libcudacxx/include/cuda/std/__format/formatters/ptr.h
@@ -68,7 +68,7 @@ struct __fmt_formatter_ptr
         ? __fmt_spec_type::__hexadecimal_upper_case
         : __fmt_spec_type::__hexadecimal_lower_case;
 
-    return ::cuda::std::__fmt_format_int(reinterpret_cast<uintptr_t>(__value), __ctx, __specs);
+    return ::cuda::std::__fmt_format_int(reinterpret_cast<uintptr_t>(__value), __ctx.out(), __specs);
   }
 
   __fmt_spec_parser<_CharT> __parser_; //!< The parser for format specifications.

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/ctad.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/ctad.compile.pass.cpp
@@ -16,11 +16,13 @@
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
 
-using namespace cuda::std;
-
-static_assert(is_same_v<format_args, decltype(basic_format_args{make_format_args(declval<int&>())})>);
+static_assert(
+  cuda::std::is_same_v<cuda::std::format_args,
+                       decltype(cuda::std::basic_format_args{cuda::std::make_format_args(cuda::std::declval<int&>())})>);
 #if _CCCL_HAS_WCHAR_T()
-static_assert(is_same_v<wformat_args, decltype(basic_format_args{make_wformat_args(declval<int&>())})>);
+static_assert(cuda::std::is_same_v<
+              cuda::std::wformat_args,
+              decltype(cuda::std::basic_format_args{cuda::std::make_wformat_args(cuda::std::declval<int&>())})>);
 #endif // _CCCL_HAS_WCHAR_T()
 
 int main(int, char**)


### PR DESCRIPTION
I've found out that our formatting infrastructure emits humongous amount of SASS code even when doing `format_to(buffer, "")`. One of the causes was the instantiating the formatter for `int` added more than 20k SASS instructions :D

This PR improves the situation a bit by splitting paths for signed and unsigned integers.

A simple example:
```cpp
#include <cuda/std/__format_>
#include <cstdio>

__global__ void kernel()
{
  char buffer[128]{};
  cuda::std::format_to(buffer, "{}", 1);
  printf("%s\n", buffer);
}

int main()
{
  kernel<<<1, 1>>>();
  cudaDeviceSynchronize();
}
```
Before: 8.237s, ~102,9k lines of `cuobjdump` output (sm120)
After: 5.930s, ~69,5k lines of `cuobjdump` output (sm120)

Still terrible, but a huge improvement.