### PR TITLE
Add thrust vector constructor that accepts both no_init_t and allocator

### DIFF
--- a/thrust/testing/vector.cu
+++ b/thrust/testing/vector.cu
@@ -1024,6 +1024,30 @@ void TestVectorNoInitResize()
 }
 DECLARE_UNITTEST(TestVectorNoInitResize);
 
+void TestVectorDefaultInitCtorWithAlloc()
+{
+  // trivially-constructible type: just compilation test, since we cannot check that initialization was skipped
+  {
+    thrust::host_vector<int, std::allocator<int>> hv(10, thrust::default_init, std::allocator<int>{});
+    thrust::device_vector<int, thrust::device_allocator<int>> dv(10, thrust::default_init, thrust::device_allocator<int>{});
+  }
+
+  // non-trivially-constructible type: check that initialization was performed
+  {
+    thrust::host_vector<IntWithInit, std::allocator<IntWithInit>> hv(10, thrust::default_init, std::allocator<IntWithInit>{});
+    for (auto e : hv)
+    {
+      ASSERT_EQUAL(e.value, 42);
+    }
+
+    thrust::device_vector<IntWithInit, thrust::device_allocator<IntWithInit>> dv(10, thrust::default_init, thrust::device_allocator<IntWithInit>{});
+    for (auto e : dv)
+    {
+      ASSERT_EQUAL(static_cast<IntWithInit>(e).value, 42);
+    }
+  }
+}
+DECLARE_UNITTEST(TestVectorDefaultInitCtorWithAlloc);
 
 void TestVectorNoInitCtorWithAlloc()
 {

--- a/thrust/testing/vector.cu
+++ b/thrust/testing/vector.cu
@@ -1023,3 +1023,19 @@ void TestVectorNoInitResize()
   // thrust::device_vector<IntWithInit>(5).resize(10, thrust::no_init);
 }
 DECLARE_UNITTEST(TestVectorNoInitResize);
+
+
+void TestVectorNoInitCtorWithAlloc()
+{
+  // trivially-constructible type: just compilation test, since we cannot check that initialization was skipped
+  {
+
+    thrust::host_vector<int, std::allocator<int>> hv(10, thrust::no_init, std::allocator<int>{});
+    thrust::device_vector<int, thrust::device_allocator<int>> dv(10, thrust::no_init, thrust::device_allocator<int>{});
+  }
+
+  // non-trivially-constructible type: those should fail to compile
+  // thrust::host_vector<IntWithInit, std::allocator<int>> hv(10, thrust::no_init, std::allocator<int>{});
+  // thrust::device_vector<IntWithInit, thrust::device_allocator<int>> dv(10, thrust::no_init, thrust::device_allocator<int>{});
+}
+DECLARE_UNITTEST(TestVectorNoInitCtorWithAlloc);

--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -116,6 +116,13 @@ public:
    */
   explicit vector_base(size_type n, const value_type& value, const Alloc& alloc);
 
+  /*! This constructor creates a vector_base with default-initialized elements.
+   *  \param n The number of elements to create.
+   *  \param alloc The allocator to use by this vector_base.
+   */
+  template <typename T2 = T>
+  explicit vector_base(size_type n, default_init_t, const Alloc& alloc);
+
   /*! This constructor creates a vector_base without initializing elements. It mandates that the element type is
    *  trivially default-constructible.
    *  \param n The number of elements to create.

--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -116,17 +116,15 @@ public:
    */
   explicit vector_base(size_type n, const value_type& value, const Alloc& alloc);
 
-  /*! This constructor creates a vector_base with default-initialized elements.
-   *  \param n The number of elements to create.
-   *  \param alloc The allocator to use by this vector_base.
-   */
+  //! This constructor creates a vector_base with default-initialized elements.
+  //! \param n The number of elements to create.
+  //! \param alloc The allocator to use by this vector_base.
   explicit vector_base(size_type n, default_init_t, const Alloc& alloc);
 
-  /*! This constructor creates a vector_base without initializing elements. It mandates that the element type is
-   *  trivially default-constructible.
-   *  \param n The number of elements to create.
-   *  \param alloc The allocator to use by this vector_base.
-   */
+  //! This constructor creates a vector_base without initializing elements. It mandates that the element type is
+  //! trivially default-constructible.
+  //! \param n The number of elements to create.
+  //! \param alloc The allocator to use by this vector_base.
   template <typename T2 = T>
   explicit vector_base(size_type n, no_init_t, const Alloc& alloc);
 

--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -120,7 +120,6 @@ public:
    *  \param n The number of elements to create.
    *  \param alloc The allocator to use by this vector_base.
    */
-  template <typename T2 = T>
   explicit vector_base(size_type n, default_init_t, const Alloc& alloc);
 
   /*! This constructor creates a vector_base without initializing elements. It mandates that the element type is

--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -116,6 +116,14 @@ public:
    */
   explicit vector_base(size_type n, const value_type& value, const Alloc& alloc);
 
+  /*! This constructor creates a vector_base without initializing elements. It mandates that the element type is
+   *  trivially default-constructible.
+   *  \param n The number of elements to create.
+   *  \param alloc The allocator to use by this vector_base.
+   */
+  template <typename T2 = T>
+  explicit vector_base(size_type n, no_init_t, const Alloc& alloc);
+
   /*! Copy constructor copies from an exemplar vector_base.
    *  \param v The vector_base to copy.
    */

--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -123,7 +123,6 @@ vector_base<T, Alloc>::vector_base(size_type n, const value_type& value, const A
 } // end vector_base::vector_base()
 
 template <typename T, typename Alloc>
-template <typename T2>
 vector_base<T, Alloc>::vector_base(size_type n, default_init_t, const Alloc& alloc)
     : m_storage(alloc)
     , m_size(0)

--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -123,6 +123,21 @@ vector_base<T, Alloc>::vector_base(size_type n, const value_type& value, const A
 } // end vector_base::vector_base()
 
 template <typename T, typename Alloc>
+template <typename T2>
+vector_base<T, Alloc>::vector_base(size_type n, no_init_t, const Alloc& alloc)
+    : m_storage(alloc)
+    , m_size(0)
+{
+  static_assert(::cuda::std::is_trivially_constructible_v<T2>,
+                "The vector's element type must be trivially constructible to skip initialization.");
+  if (n > 0)
+  {
+    m_storage.allocate(n);
+    m_size = n;
+  }
+} // end vector_base::vector_base()
+
+template <typename T, typename Alloc>
 vector_base<T, Alloc>::vector_base(const vector_base& v)
     : m_storage(copy_allocator_t(), v.m_storage)
     , m_size(0)

--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -124,6 +124,24 @@ vector_base<T, Alloc>::vector_base(size_type n, const value_type& value, const A
 
 template <typename T, typename Alloc>
 template <typename T2>
+vector_base<T, Alloc>::vector_base(size_type n, default_init_t, const Alloc& alloc)
+    : m_storage(alloc)
+    , m_size(0)
+{
+  if (n > 0)
+  {
+    m_storage.allocate(n);
+    m_size = n;
+
+    if constexpr (!::cuda::std::is_trivially_constructible_v<T>)
+    {
+      m_storage.value_initialize_n(begin(), size());
+    }
+  }
+} // end vector_base::vector_base()
+
+template <typename T, typename Alloc>
+template <typename T2>
 vector_base<T, Alloc>::vector_base(size_type n, no_init_t, const Alloc& alloc)
     : m_storage(alloc)
     , m_size(0)

--- a/thrust/thrust/device_vector.h
+++ b/thrust/thrust/device_vector.h
@@ -129,20 +129,18 @@ public:
       : Parent(n, value, alloc)
   {}
 
-  /*! This constructor creates a \p device_vector with the given size, performing only default-initialization instead of
-   *  value-initialization.
-   *  \param n The number of elements to initially create.
-   *  \param alloc The allocator to use by this device_vector.
-   */
+  //! This constructor creates a \p device_vector with the given size, performing only default-initialization instead of
+  //! value-initialization.
+  //! \param n The number of elements to initially create.
+  //! \param alloc The allocator to use by this device_vector.
   device_vector(size_type n, default_init_t, const Alloc& alloc)
       : Parent(n, default_init_t{}, alloc)
   {}
 
-  /*! This constructor creates a \p device_vector with the given size, without initializing elements. It mandates that
-   *  the element type is trivially default-constructible.
-   *  \param n The number of elements to initially create.
-   *  \param alloc The allocator to use by this device_vector.
-   */
+  //! This constructor creates a \p device_vector with the given size, without initializing elements. It mandates that
+  //! the element type is trivially default-constructible.
+  //! \param n The number of elements to initially create.
+  //! \param alloc The allocator to use by this device_vector.
   device_vector(size_type n, no_init_t, const Alloc& alloc)
       : Parent(n, no_init_t{}, alloc)
   {}

--- a/thrust/thrust/device_vector.h
+++ b/thrust/thrust/device_vector.h
@@ -129,6 +129,15 @@ public:
       : Parent(n, value, alloc)
   {}
 
+  /*! This constructor creates a \p device_vector with the given size, performing only default-initialization instead of
+   *  value-initialization.
+   *  \param n The number of elements to initially create.
+   *  \param alloc The allocator to use by this device_vector.
+   */
+  device_vector(size_type n, default_init_t, const Alloc& alloc)
+      : Parent(n, default_init_t{}, alloc)
+  {}
+
   /*! This constructor creates a \p device_vector with the given size, without initializing elements. It mandates that
    *  the element type is trivially default-constructible.
    *  \param n The number of elements to initially create.

--- a/thrust/thrust/device_vector.h
+++ b/thrust/thrust/device_vector.h
@@ -129,6 +129,15 @@ public:
       : Parent(n, value, alloc)
   {}
 
+  /*! This constructor creates a \p device_vector with the given size, without initializing elements. It mandates that
+   *  the element type is trivially default-constructible.
+   *  \param n The number of elements to initially create.
+   *  \param alloc The allocator to use by this device_vector.
+   */
+  device_vector(size_type n, no_init_t, const Alloc& alloc)
+      : Parent(n, no_init_t{}, alloc)
+  {}
+
   /*! Copy constructor copies from an exemplar \p device_vector.
    *  \param v The \p device_vector to copy.
    */

--- a/thrust/thrust/host_vector.h
+++ b/thrust/thrust/host_vector.h
@@ -160,20 +160,18 @@ public:
       : Parent(n, value, alloc)
   {}
 
-  /*! This constructor creates a \p host_vector with the given size, performing only default-initialization instead of
-   *  value-initialization.
-   *  \param n The number of elements to initially create.
-   *  \param alloc The allocator to use by this host_vector.
-   */
+  //! This constructor creates a \p host_vector with the given size, performing only default-initialization instead of
+  //! value-initialization.
+  //! \param n The number of elements to initially create.
+  //! \param alloc The allocator to use by this host_vector.
   _CCCL_HOST host_vector(size_type n, default_init_t, const Alloc& alloc)
       : Parent(n, default_init_t{}, alloc)
   {}
 
-  /*! This constructor creates a \p host_vector with the given size, without initializing elements. It mandates that
-   *  the element type is trivially default-constructible.
-   *  \param n The number of elements to initially create.
-   *  \param alloc The allocator to use by this host_vector.
-   */
+  //! This constructor creates a \p host_vector with the given size, without initializing elements. It mandates that
+  //! the element type is trivially default-constructible.
+  //! \param n The number of elements to initially create.
+  //! \param alloc The allocator to use by this host_vector.
   _CCCL_HOST host_vector(size_type n, no_init_t, const Alloc& alloc)
       : Parent(n, no_init_t{}, alloc)
   {}

--- a/thrust/thrust/host_vector.h
+++ b/thrust/thrust/host_vector.h
@@ -160,6 +160,15 @@ public:
       : Parent(n, value, alloc)
   {}
 
+  /*! This constructor creates a \p host_vector with the given size, without initializing elements. It mandates that
+   *  the element type is trivially default-constructible.
+   *  \param n The number of elements to initially create.
+   *  \param alloc The allocator to use by this host_vector.
+   */
+  _CCCL_HOST host_vector(size_type n, no_init_t, const Alloc& alloc)
+      : Parent(n, no_init_t{}, alloc)
+  {}
+
   /*! Copy constructor copies from an exemplar \p host_vector.
    *  \param v The \p host_vector to copy.
    *

--- a/thrust/thrust/host_vector.h
+++ b/thrust/thrust/host_vector.h
@@ -160,6 +160,15 @@ public:
       : Parent(n, value, alloc)
   {}
 
+  /*! This constructor creates a \p host_vector with the given size, performing only default-initialization instead of
+   *  value-initialization.
+   *  \param n The number of elements to initially create.
+   *  \param alloc The allocator to use by this host_vector.
+   */
+  _CCCL_HOST host_vector(size_type n, default_init_t, const Alloc& alloc)
+      : Parent(n, default_init_t{}, alloc)
+  {}
+
   /*! This constructor creates a \p host_vector with the given size, without initializing elements. It mandates that
    *  the element type is trivially default-constructible.
    *  \param n The number of elements to initially create.


### PR DESCRIPTION
Convenience change that enables writing
```
thrust::device_vector<int, Alloc> vec(10, thrust::no_init, alloc);
```
instead of
```
thrust::device_vector<int, Alloc> vec(alloc);
vec.resize(10, thrust::no_init);
```