### PR TITLE
Add `cuda::ceil_ilog10`

### DIFF
--- a/docs/libcudacxx/extended_api/math.rst
+++ b/docs/libcudacxx/extended_api/math.rst
@@ -49,6 +49,11 @@ Math
      - CCCL 3.0.0
      - CUDA 13.0
 
+   * - :ref:`ceil_ilog2 <libcudacxx-extended-api-math-ilog>`
+     - Integer logarithm to the base 2, rounded up
+     - CCCL 3.1.0
+     - CUDA 13.1
+
    * - :ref:`ilog10 <libcudacxx-extended-api-math-ilog>`
      - Integer logarithm to the base 10
      - CCCL 3.0.0

--- a/docs/libcudacxx/extended_api/math.rst
+++ b/docs/libcudacxx/extended_api/math.rst
@@ -54,6 +54,11 @@ Math
      - CCCL 3.0.0
      - CUDA 13.0
 
+   * - :ref:`ceil_ilog10 <libcudacxx-extended-api-math-ilog>`
+     - Integer logarithm to the base 10, rounded up
+     - CCCL 3.5.0
+     - CUDA 13.5
+
    * - :ref:`ipow <libcudacxx-extended-api-math-ipow>`
      - Integer power
      - CCCL 3.1.0

--- a/docs/libcudacxx/extended_api/math/ilog.rst
+++ b/docs/libcudacxx/extended_api/math/ilog.rst
@@ -10,19 +10,19 @@ Defined in the ``<cuda/cmath>`` header.
    namespace cuda {
 
    template <typename T>
-   [[nodiscard]] __host__ __device__ constexpr
+   [[nodiscard]] __host__ __device__ __tile__ constexpr
    int ilog2(T value) noexcept;
 
    template <typename T>
-   [[nodiscard]] __host__ __device__ constexpr
+   [[nodiscard]] __host__ __device__ __tile__ constexpr
    int ceil_ilog2(T value) noexcept;
 
    template <typename T>
-   [[nodiscard]] __host__ __device__ constexpr
+   [[nodiscard]] __host__ __device__ __tile__ constexpr
    int ilog10(T value) noexcept;
 
    template <typename T>
-   [[nodiscard]] __host__ __device__ constexpr
+   [[nodiscard]] __host__ __device__ __tile__ constexpr
    int ceil_ilog10(T value) noexcept;
 
    } // namespace cuda

--- a/docs/libcudacxx/extended_api/math/ilog.rst
+++ b/docs/libcudacxx/extended_api/math/ilog.rst
@@ -1,7 +1,7 @@
 .. _libcudacxx-extended-api-math-ilog:
 
-``cuda::ilog2`` and ``cuda::ilog10``
-====================================
+``cuda::ilog2``, ``cuda::ceil_ilog2``, ``cuda::ilog10``, and ``cuda::ceil_ilog10``
+=================================================================================
 
 Defined in the ``<cuda/cmath>`` header.
 
@@ -21,6 +21,10 @@ Defined in the ``<cuda/cmath>`` header.
    [[nodiscard]] __host__ __device__ constexpr
    int ilog10(T value) noexcept;
 
+   template <typename T>
+   [[nodiscard]] __host__ __device__ constexpr
+   int ceil_ilog10(T value) noexcept;
+
    } // namespace cuda
 
 The functions compute the logarithm to the base 2 and 10 of an integer value.
@@ -32,11 +36,11 @@ The functions compute the logarithm to the base 2 and 10 of an integer value.
 **Return value**
 
 - ``ilog2``, ``ceil_ilog2``: The logarithm to the base 2, rounded down and up to the nearest integer respectively.
--  ``ilog10``: The logarithm to the 10, rounded down to the nearest integer.
+- ``ilog10``, ``ceil_ilog10``: The logarithm to the base 10, rounded down and up to the nearest integer respectively.
 
 **Constraints**
 
-- ``T`` is an integer types.
+- ``T`` is an integer type.
 
 **Preconditions**
 
@@ -44,11 +48,12 @@ The functions compute the logarithm to the base 2 and 10 of an integer value.
 
 **Performance considerations**
 
-The function performs the following operations in device code:
+The functions perform the following operations in device code:
 
 - ``ilog2``: ``FLO``
 - ``ceil_ilog2``: ``FLO``, ``POPC``, ``ADD``, comparison
 - ``ilog10``: ``FLO``, ``FMUL``, ``F2I``, constant memory lookup, ``SEL`` + ``IADD`` only if ``T == uint32_t`` or ``T == __uint128_t``
+- ``ceil_ilog10``: ``ilog10`` with an additional comparison, subtraction, and ``IADD``
 
 Example
 -------
@@ -65,6 +70,8 @@ Example
         assert(cuda::ceil_ilog2(32) == 5);
         assert(cuda::ilog10(100) == 2);
         assert(cuda::ilog10(2000) == 3);
+        assert(cuda::ceil_ilog10(100) == 2);
+        assert(cuda::ceil_ilog10(2000) == 4);
     }
 
     int main() {

--- a/libcudacxx/include/cuda/__cmath/ilog.h
+++ b/libcudacxx/include/cuda/__cmath/ilog.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -23,7 +23,6 @@
 
 #include <cuda/std/__bit/has_single_bit.h>
 #include <cuda/std/__bit/integral.h>
-#include <cuda/std/__cmath/rounding_functions.h>
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__limits/numeric_limits.h>
 #include <cuda/std/__type_traits/is_integer.h>
@@ -38,7 +37,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 
 _CCCL_TEMPLATE(typename _Tp)
 _CCCL_REQUIRES(::cuda::std::__cccl_is_cv_integer_v<_Tp>)
-_CCCL_API constexpr int ilog2(_Tp __t) noexcept
+_CCCL_API constexpr int ilog2(const _Tp __t) noexcept
 {
   using _Up = ::cuda::std::make_unsigned_t<_Tp>;
   _CCCL_ASSERT(__t > 0, "ilog2() argument must be strictly positive");
@@ -49,13 +48,13 @@ _CCCL_API constexpr int ilog2(_Tp __t) noexcept
 
 _CCCL_TEMPLATE(typename _Tp)
 _CCCL_REQUIRES(::cuda::std::__cccl_is_cv_integer_v<_Tp>)
-_CCCL_API constexpr int ceil_ilog2(_Tp __t) noexcept
+_CCCL_API constexpr int ceil_ilog2(const _Tp __t) noexcept
 {
   using _Up = ::cuda::std::make_unsigned_t<_Tp>;
   return ::cuda::ilog2(__t) + !::cuda::std::has_single_bit(static_cast<_Up>(__t));
 }
 
-[[nodiscard]] _CCCL_API constexpr ::cuda::std::array<uint32_t, 10> __power_of_10_32bit() noexcept
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL ::cuda::std::array<::cuda::std::uint32_t, 10> __power_of_10_32bit() noexcept
 {
   return {10,
           100,
@@ -66,10 +65,10 @@ _CCCL_API constexpr int ceil_ilog2(_Tp __t) noexcept
           10'000'000,
           100'000'000,
           1'000'000'000,
-          ::cuda::std::numeric_limits<uint32_t>::max()};
+          ::cuda::std::numeric_limits<::cuda::std::uint32_t>::max()};
 }
 
-[[nodiscard]] _CCCL_API constexpr ::cuda::std::array<uint64_t, 20> __power_of_10_64bit() noexcept
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL ::cuda::std::array<::cuda::std::uint64_t, 20> __power_of_10_64bit() noexcept
 {
   return {
     10,
@@ -91,12 +90,12 @@ _CCCL_API constexpr int ceil_ilog2(_Tp __t) noexcept
     100'000'000'000'000'000,
     1'000'000'000'000'000'000,
     10'000'000'000'000'000'000ull,
-    ::cuda::std::numeric_limits<uint64_t>::max()};
+    ::cuda::std::numeric_limits<::cuda::std::uint64_t>::max()};
 }
 
 #if _CCCL_HAS_INT128()
 
-[[nodiscard]] _CCCL_API constexpr ::cuda::std::array<__uint128_t, 39> __power_of_10_128bit() noexcept
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL ::cuda::std::array<__uint128_t, 39> __power_of_10_128bit() noexcept
 {
   return {
     10,
@@ -143,11 +142,13 @@ _CCCL_API constexpr int ceil_ilog2(_Tp __t) noexcept
 
 _CCCL_TEMPLATE(typename _Tp)
 _CCCL_REQUIRES(::cuda::std::__cccl_is_cv_integer_v<_Tp>)
-_CCCL_API constexpr int ilog10(_Tp __t) noexcept
+_CCCL_API constexpr int ilog10(const _Tp __t) noexcept
 {
-  _CCCL_ASSERT(__t > 0, "ilog10() argument must be strictly positive");
+  using ::cuda::std::uint32_t;
+  using ::cuda::std::uint64_t;
+  _CCCL_ASSERT(__t > 0, "cuda::ilog10() argument must be strictly positive");
   constexpr auto __reciprocal_log2_10 = 0.301029995663f; // 1 / log2(10)
-  auto __log2                         = ::cuda::ilog2(__t) * __reciprocal_log2_10;
+  const auto __log2                   = ::cuda::ilog2(__t) * __reciprocal_log2_10;
   auto __log10_approx                 = static_cast<int>(__log2);
   if constexpr (sizeof(_Tp) <= sizeof(uint32_t))
   {
@@ -185,6 +186,14 @@ _CCCL_API constexpr int ilog10(_Tp __t) noexcept
 #endif // _CCCL_HAS_INT128()
   _CCCL_ASSUME(__log10_approx <= ::cuda::std::numeric_limits<_Tp>::digits / 3); // 2^X < 10^(x/3) -> 8^X < 10^x
   return __log10_approx;
+}
+
+_CCCL_TEMPLATE(typename _Tp)
+_CCCL_REQUIRES(::cuda::std::__cccl_is_cv_integer_v<_Tp>)
+_CCCL_API constexpr int ceil_ilog10(const _Tp __t) noexcept
+{
+  _CCCL_ASSERT(__t > 0, "cuda::ceil_ilog10() argument must be strictly positive");
+  return __t == 1 ? 0 : ::cuda::ilog10(static_cast<_Tp>(__t - 1)) + 1;
 }
 
 _CCCL_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/__cmath/ilog.h
+++ b/libcudacxx/include/cuda/__cmath/ilog.h
@@ -37,7 +37,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 
 _CCCL_TEMPLATE(typename _Tp)
 _CCCL_REQUIRES(::cuda::std::__cccl_is_cv_integer_v<_Tp>)
-_CCCL_API constexpr int ilog2(const _Tp __t) noexcept
+[[nodiscard]] _CCCL_API constexpr int ilog2(const _Tp __t) noexcept
 {
   using _Up = ::cuda::std::make_unsigned_t<_Tp>;
   _CCCL_ASSERT(__t > 0, "ilog2() argument must be strictly positive");
@@ -48,7 +48,7 @@ _CCCL_API constexpr int ilog2(const _Tp __t) noexcept
 
 _CCCL_TEMPLATE(typename _Tp)
 _CCCL_REQUIRES(::cuda::std::__cccl_is_cv_integer_v<_Tp>)
-_CCCL_API constexpr int ceil_ilog2(const _Tp __t) noexcept
+[[nodiscard]] _CCCL_API constexpr int ceil_ilog2(const _Tp __t) noexcept
 {
   using _Up = ::cuda::std::make_unsigned_t<_Tp>;
   return ::cuda::ilog2(__t) + !::cuda::std::has_single_bit(static_cast<_Up>(__t));
@@ -142,7 +142,7 @@ _CCCL_API constexpr int ceil_ilog2(const _Tp __t) noexcept
 
 _CCCL_TEMPLATE(typename _Tp)
 _CCCL_REQUIRES(::cuda::std::__cccl_is_cv_integer_v<_Tp>)
-_CCCL_API constexpr int ilog10(const _Tp __t) noexcept
+[[nodiscard]] _CCCL_API constexpr int ilog10(const _Tp __t) noexcept
 {
   using ::cuda::std::uint32_t;
   using ::cuda::std::uint64_t;
@@ -190,7 +190,7 @@ _CCCL_API constexpr int ilog10(const _Tp __t) noexcept
 
 _CCCL_TEMPLATE(typename _Tp)
 _CCCL_REQUIRES(::cuda::std::__cccl_is_cv_integer_v<_Tp>)
-_CCCL_API constexpr int ceil_ilog10(const _Tp __t) noexcept
+[[nodiscard]] _CCCL_API constexpr int ceil_ilog10(const _Tp __t) noexcept
 {
   _CCCL_ASSERT(__t > 0, "cuda::ceil_ilog10() argument must be strictly positive");
   return __t == 1 ? 0 : ::cuda::ilog10(static_cast<_Tp>(__t - 1)) + 1;

--- a/libcudacxx/test/libcudacxx/cuda/cmath/ilog.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/cmath/ilog.pass.cpp
@@ -77,11 +77,38 @@ TEST_FUNC constexpr void test_log10()
 }
 
 template <class T>
+TEST_FUNC constexpr void test_ceil_log10()
+{
+  int i = 0;
+  for (T value = 1; value <= cuda::std::numeric_limits<T>::max() / 10; value *= 10)
+  {
+    assert(cuda::ceil_ilog10(value) == i);
+    assert(cuda::ceil_ilog10(static_cast<T>(value + 1)) == i + 1);
+    if (i >= 1)
+    {
+      assert(cuda::ceil_ilog10(static_cast<T>(value - 1)) == i);
+      assert(cuda::ceil_ilog10(value + value / 2) == i + 1);
+      assert(cuda::ceil_ilog10(value - value / 2) == i);
+      assert(cuda::ceil_ilog10(value - value / 2 - 1) == i);
+    }
+    i++;
+  }
+#if !TEST_COMPILER(MSVC)
+  if (!cuda::std::__cccl_default_is_constant_evaluated())
+  {
+    constexpr auto max_v = cuda::std::numeric_limits<T>::max();
+    assert(cuda::ceil_ilog10(max_v) == static_cast<int>(cuda::std::ceil(cuda::std::log10(max_v))));
+  }
+#endif // !TEST_COMPILER(MSVC)
+}
+
+template <class T>
 TEST_FUNC constexpr void test()
 {
   test_log2<T>();
   test_ceil_log2<T>();
   test_log10<T>();
+  test_ceil_log10<T>();
 }
 
 TEST_FUNC constexpr bool test()


### PR DESCRIPTION
## Description

The `ceil_ilog10` can be used to covert integers to chars (e.g. `to_chars`).
In addition, we already have `ilog2`, `ceil_ilog2`, and `ilog10`, so would make sense to add `ceil_log10` for completeness.

It tried a couple of optimizations but the simplest version should be also the most efficient.

