### PR TITLE
Add cuda::ptx::prefetch::l1/l2 wrappers for prefetching in libcudacxx

### DIFF
--- a/libcudacxx/include/cuda/__ptx/instructions/generated/prefetch.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/prefetch.h
@@ -1,0 +1,42 @@
+// This file was automatically generated. Do not edit.
+
+#ifndef _CUDA_PTX_GENERATED_PREFETCH_H_
+#define _CUDA_PTX_GENERATED_PREFETCH_H_
+
+/*
+// prefetch.global.L2 [addr]; // PTX ISA 20, SM_50
+template <typename = void>
+__device__ static inline void prefetch_L2(cuda::ptx::space_global_t, const void* addr);
+*/
+#if __cccl_ptx_isa >= 200
+extern "C" _CCCL_DEVICE void __cuda_ptx_prefetch_L2_is_not_supported_before_SM_50__();
+template <typename = void>
+_CCCL_DEVICE static inline void prefetch_L2(space_global_t, const void* __addr)
+{
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  asm volatile("prefetch.global.L2 [%0];" : : "l"(__as_ptr_gmem(__addr)) : "memory");
+#  else
+  __cuda_ptx_prefetch_L2_is_not_supported_before_SM_50__();
+#  endif
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// prefetch.global.L1 [addr]; // PTX ISA 20, SM_50
+template <typename = void>
+__device__ static inline void prefetch_L1(cuda::ptx::space_global_t, const void* addr);
+*/
+#if __cccl_ptx_isa >= 200
+extern "C" _CCCL_DEVICE void __cuda_ptx_prefetch_L1_is_not_supported_before_SM_50__();
+template <typename = void>
+_CCCL_DEVICE static inline void prefetch_L1(space_global_t, const void* __addr)
+{
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  asm volatile("prefetch.global.L1 [%0];" : : "l"(__as_ptr_gmem(__addr)) : "memory");
+#  else
+  __cuda_ptx_prefetch_L1_is_not_supported_before_SM_50__();
+#  endif
+}
+#endif // __cccl_ptx_isa >= 200
+
+#endif // _CUDA_PTX_GENERATED_PREFETCH_H_

--- a/libcudacxx/include/cuda/__ptx/instructions/prefetch.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/prefetch.h
@@ -1,0 +1,41 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_PTX_PREFETCH_H_
+#define _CUDA_PTX_PREFETCH_H_
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__ptx/ptx_dot_variants.h>
+#include <cuda/__ptx/ptx_helper_functions.h>
+#include <cuda/std/cstdint>
+
+#include <nv/target> // __CUDA_MINIMUM_ARCH__ and friends
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_PTX
+
+#include <cuda/__ptx/instructions/generated/prefetch.h>
+
+_CCCL_END_NAMESPACE_CUDA_PTX
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_PTX_PREFETCH_H_

--- a/libcudacxx/include/cuda/ptx
+++ b/libcudacxx/include/cuda/ptx
@@ -94,6 +94,7 @@
 #include <cuda/__ptx/instructions/multimem_ld_reduce.h>
 #include <cuda/__ptx/instructions/multimem_red.h>
 #include <cuda/__ptx/instructions/multimem_st.h>
+#include <cuda/__ptx/instructions/prefetch.h>
 #include <cuda/__ptx/instructions/prmt.h>
 #include <cuda/__ptx/instructions/red_async.h>
 #include <cuda/__ptx/instructions/setmaxnreg.h>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/prefetch.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/prefetch.h
@@ -1,0 +1,34 @@
+// This file was automatically generated. Do not edit.
+
+// We use a special strategy to force the generation of the PTX. This is mainly
+// a fight against dead-code-elimination in the NVVM layer.
+//
+// The reason we need this strategy is because certain older versions of ptxas
+// segfault when a non-sensical sequence of PTX is generated. So instead, we try
+// to force the instantiation and compilation to PTX of all the overloads of the
+// PTX wrapping functions.
+//
+// We do this by writing a function pointer of each overload to the kernel
+// parameter `fn_ptr`.
+//
+// Because `fn_ptr` is possibly visible outside this translation unit, the
+// compiler must compile all the functions which are stored.
+
+__global__ void test_prefetch(void** fn_ptr)
+{
+#if __cccl_ptx_isa >= 200
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // prefetch.global.L2 [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<void (*)(cuda::ptx::space_global_t, const void*)>(cuda::ptx::prefetch_L2));));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // prefetch.global.L1 [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<void (*)(cuda::ptx::space_global_t, const void*)>(cuda::ptx::prefetch_L1));));
+#endif // __cccl_ptx_isa >= 200
+}

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.prefetch.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.prefetch.compile.pass.cpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: libcpp-has-no-threads
+
+// <cuda/ptx>
+
+#include <cuda/ptx>
+#include <cuda/std/utility>
+
+#include "generated/prefetch.h"
+
+int main(int, char**)
+{
+  return 0;
+}


### PR DESCRIPTION
fixes https://github.com/NVIDIA/cccl/issues/3126?issue=NVIDIA%7Ccccl%7C9616

We need this for #9496. I am sketching but am 0% sure about it since I've never written in libcu++ before. @fbusato  how do you like it?