### PR TITLE
[libcu++] Set current context for buffer driver operations

### DIFF
--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -170,6 +170,7 @@ private:
     static_assert(::cuda::std::contiguous_iterator<_Iter>, "Non contiguous iterators are not supported");
     // TODO use batched memcpy for non-contiguous iterators, it allows to
     // specify stream ordered access
+    ::cuda::__ensure_current_context __guard(__buf_.stream());
     ::cuda::__driver::__memcpyAsync(
       __dest, ::cuda::std::to_address(__first), sizeof(_Tp) * __count, __buf_.stream().get());
   }
@@ -804,6 +805,7 @@ using __buffer_type_for_props = typename ::cuda::std::remove_reference_t<_PropsL
 template <typename _BufferTo, typename _BufferFrom>
 void __copy_cross_buffers(stream_ref __stream, _BufferTo& __to, const _BufferFrom& __from)
 {
+  ::cuda::__ensure_current_context __guard(__stream);
   __stream.wait(__from.stream());
   ::cuda::__driver::__memcpyAsync(
     __to.__unwrapped_begin(),


### PR DESCRIPTION
It looks like with empty driver stack memcpy async succeeds, but if the streams and current context don't match it fails. I believe accessibility validation always uses current context, instead of checking the streams context as well. We should add context setter in cases where buffer calls memcpy, sadly.

Confirmed that memset is fine without it