### PR TITLE
[libcu++] Add tests for cross device APIs and APIs related to a device with a different device set current

### DIFF
--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -170,6 +170,7 @@ private:
     static_assert(::cuda::std::contiguous_iterator<_Iter>, "Non contiguous iterators are not supported");
     // TODO use batched memcpy for non-contiguous iterators, it allows to
     // specify stream ordered access
+    ::cuda::__ensure_current_context __guard(__buf_.stream());
     ::cuda::__driver::__memcpyAsync(
       __dest, ::cuda::std::to_address(__first), sizeof(_Tp) * __count, __buf_.stream().get());
   }
@@ -804,6 +805,7 @@ using __buffer_type_for_props = typename ::cuda::std::remove_reference_t<_PropsL
 template <typename _BufferTo, typename _BufferFrom>
 void __copy_cross_buffers(stream_ref __stream, _BufferTo& __to, const _BufferFrom& __from)
 {
+  ::cuda::__ensure_current_context __guard(__stream);
   __stream.wait(__from.stream());
   ::cuda::__driver::__memcpyAsync(
     __to.__unwrapped_begin(),

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/algorithm/copy.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/algorithm/copy.cu
@@ -8,6 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/devices>
+
 #include "common.cuh"
 #include "cuda/__algorithm/copy.h"
 
@@ -99,6 +101,59 @@ C2H_CCCLRT_TEST("1d Copy", "[algorithm]")
     CCCLRT_REQUIRE(vec[0] == get_expected_value(fill_byte));
     CCCLRT_REQUIRE(vec[1] == 0xbeef);
   }
+}
+
+C2H_CCCLRT_TEST("copy_bytes uses the stream device when current device differs", "[algorithm][multi_gpu]")
+{
+  if (cuda::devices.size() < 2)
+  {
+    return;
+  }
+
+#if _CCCL_CTK_AT_LEAST(13, 0)
+  cuda::device_ref current_device{0};
+  cuda::device_ref explicit_device{1};
+  if (!explicit_device.attribute(cuda::device_attributes::memory_pools_supported))
+  {
+    return;
+  }
+
+  cuda::stream stream{explicit_device};
+
+  int expected = get_expected_value(fill_byte);
+  int result{};
+
+  {
+    auto host_src = make_pinned_memory_buffer<int>(stream, 1, explicit_device);
+    auto host_dst = make_pinned_memory_buffer<int>(stream, 1, explicit_device);
+    auto src      = cuda::make_device_buffer<int>(stream, explicit_device, 1, cuda::no_init);
+    auto dst      = cuda::make_device_buffer<int>(stream, explicit_device, 1, cuda::no_init);
+
+    host_src.data()[0] = expected;
+    host_dst.data()[0] = 0;
+
+    {
+      cuda::__ensure_current_context guard(explicit_device);
+      cuda::copy_bytes(stream, host_src, src);
+    }
+
+    {
+      cuda::__ensure_current_context guard(current_device);
+      cuda::copy_bytes(stream, src, dst);
+    }
+
+    {
+      cuda::__ensure_current_context guard(explicit_device);
+      cuda::copy_bytes(stream, dst, host_dst);
+    }
+
+    stream.sync();
+    result = host_dst.data()[0];
+  }
+  stream.sync();
+
+  CCCLRT_REQUIRE(result == expected);
+#endif // _CCCL_CTK_AT_LEAST(13, 0)
 }
 
 template <typename SrcLayout = cuda::std::layout_right,

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/device_smoke.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/device_smoke.c2h.cu
@@ -9,6 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <cuda/__driver/driver_api.h>
+#include <cuda/__runtime/ensure_current_context.h>
 #include <cuda/devices>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/cstddef>
@@ -354,6 +355,28 @@ C2H_CCCLRT_TEST("global devices vector", "[device]")
     CCCLRT_REQUIRE(true); // expected
   }
 #endif // _CCCL_HAS_EXCEPTIONS()
+}
+
+C2H_CCCLRT_TEST("Device attributes use the explicit device when current device differs", "[device][multi_gpu]")
+{
+  if (cuda::devices.size() < 2)
+  {
+    return;
+  }
+
+  cuda::device_ref current_device{0};
+  cuda::device_ref explicit_device{1};
+
+  const auto expected_bus_id = cuda::__driver::__deviceGetAttribute(
+    static_cast<::CUdevice_attribute>(cudaDevAttrPciBusId), cuda::__driver::__deviceGet(explicit_device.get()));
+  const auto expected_device_id = cuda::__driver::__deviceGetAttribute(
+    static_cast<::CUdevice_attribute>(cudaDevAttrPciDeviceId), cuda::__driver::__deviceGet(explicit_device.get()));
+
+  {
+    cuda::__ensure_current_context guard(current_device);
+    CCCLRT_REQUIRE(explicit_device.attribute(cuda::device_attributes::pci_bus_id) == expected_bus_id);
+    CCCLRT_REQUIRE(explicit_device.attribute(cuda::device_attributes::pci_device_id) == expected_device_id);
+  }
 }
 
 C2H_CCCLRT_TEST("memory location", "[device]")

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/event/event_smoke.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/event/event_smoke.cu
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/atomic>
+#include <cuda/devices>
+#include <cuda/launch>
 #include <cuda/stream>
 
 #include <testing.cuh>
@@ -20,6 +23,35 @@ namespace test
 cuda::event_ref fn_takes_event_ref(cuda::event_ref ref)
 {
   return ref;
+}
+
+template <class Event>
+void test_event_uses_explicit_device_when_current_device_differs()
+{
+  if (cuda::devices.size() < 2)
+  {
+    return;
+  }
+
+  cuda::device_ref current_device{0};
+  cuda::device_ref explicit_device{1};
+
+  cuda::stream explicit_device_stream{explicit_device};
+  CCCLRT_REQUIRE(explicit_device_stream.device() == explicit_device);
+
+  Event ev = [&]() {
+    cuda::__ensure_current_context guard(current_device);
+    return Event(explicit_device);
+  }();
+
+  {
+    cuda::__ensure_current_context guard(current_device);
+    ev.record(explicit_device_stream);
+    ev.sync();
+    CCCLRT_REQUIRE(ev.is_done());
+  }
+
+  explicit_device_stream.sync();
 }
 } // namespace test
 } // namespace
@@ -102,6 +134,52 @@ C2H_CCCLRT_TEST("can construct an event with a device_ref", "[event]")
   ev.record(stream);
   ev.sync();
   CCCLRT_REQUIRE(ev.is_done());
+}
+
+C2H_CCCLRT_TEST("event device_ref constructors use the explicit device", "[event][multi_gpu]")
+{
+  ::test::test_event_uses_explicit_device_when_current_device_differs<cuda::event>();
+  ::test::test_event_uses_explicit_device_when_current_device_differs<cuda::timed_event>();
+}
+
+C2H_CCCLRT_TEST("can wait on an event from another device", "[event][multi_gpu]")
+{
+  if (cuda::devices.size() < 2)
+  {
+    return;
+  }
+
+  cuda::device_ref event_device{0};
+  cuda::device_ref waiter_device{1};
+
+  cuda::stream event_stream{event_device};
+  cuda::stream waiter_stream{waiter_device};
+
+  cuda::atomic<int> gate = 0;
+  bool waiter_ran        = false;
+
+  cuda::host_launch(event_stream, [&gate]() {
+    while (gate != 1)
+      ;
+  });
+  cuda::event ev(event_stream);
+
+  {
+    cuda::__ensure_current_context guard(event_device);
+    waiter_stream.wait(ev);
+    cuda::host_launch(waiter_stream, [&waiter_ran]() {
+      waiter_ran = true;
+    });
+  }
+
+  CCCLRT_REQUIRE(!waiter_stream.is_done());
+  CCCLRT_REQUIRE(!waiter_ran);
+
+  gate = 1;
+  waiter_stream.sync();
+  event_stream.sync();
+
+  CCCLRT_REQUIRE(waiter_ran);
 }
 
 C2H_CCCLRT_TEST("can wait on an event", "[event]")

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/launch/host_launch.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/launch/host_launch.cu
@@ -10,6 +10,7 @@
 #include <cuda/__launch/host_launch.h>
 #include <cuda/__stream/stream.h>
 #include <cuda/atomic>
+#include <cuda/devices>
 #include <cuda/memory>
 
 #include <cooperative_groups.h>
@@ -279,4 +280,28 @@ C2H_CCCLRT_TEST("Host launch", "")
     cuda::host_launch(stream, MoveOnlyCallable::make(), MoveOnlyArg::make());
     stream.sync();
   }
+}
+
+C2H_CCCLRT_TEST("Host launch uses the stream device when current device differs", "[launch][multi_gpu]")
+{
+  if (cuda::devices.size() < 2)
+  {
+    return;
+  }
+
+  cuda::device_ref current_device{0};
+  cuda::device_ref explicit_device{1};
+
+  cuda::stream stream{explicit_device};
+  int value = 0;
+
+  {
+    cuda::__ensure_current_context guard(current_device);
+    cuda::host_launch(stream, [&value]() {
+      value = 42;
+    });
+  }
+
+  stream.sync();
+  CCCLRT_REQUIRE(value == 42);
 }

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/launch/launch_smoke.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/launch/launch_smoke.cu
@@ -366,6 +366,43 @@ C2H_CCCLRT_TEST("Launch functor with __restrict__ pointer arg", "[launch]")
   CCCLRT_CHECK(*val == 42);
 }
 
+C2H_CCCLRT_TEST("Launch uses the stream device when current device differs", "[launch][multi_gpu]")
+{
+  if (cuda::devices.size() < 2)
+  {
+    return;
+  }
+
+  cuda::device_ref current_device{0};
+  cuda::device_ref explicit_device{1};
+
+  cuda::stream stream{explicit_device};
+
+  int* device_value{};
+  {
+    cuda::__ensure_current_context guard(explicit_device);
+    CUDART(cudaMalloc(reinterpret_cast<void**>(&device_value), sizeof(int)));
+    CUDART(cudaMemsetAsync(device_value, 0, sizeof(int), stream.get()));
+  }
+
+  {
+    cuda::__ensure_current_context guard(current_device);
+    auto config = cuda::make_config(cuda::grid_dims(1), cuda::block_dims<1>());
+    cuda::launch(stream, config, test::assign_42{}, device_value);
+  }
+
+  stream.sync();
+
+  int value{};
+  {
+    cuda::__ensure_current_context guard(explicit_device);
+    CUDART(cudaMemcpy(&value, device_value, sizeof(int), cudaMemcpyDeviceToHost));
+    CUDART(cudaFree(device_value));
+  }
+
+  CCCLRT_CHECK(value == 42);
+}
+
 __managed__ cuda::std::size_t launched_nthreads;
 __managed__ cuda::std::size_t launched_nblocks;
 __managed__ cuda::std::size_t launched_nclusters;

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/stream_smoke.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/stream_smoke.cu
@@ -125,6 +125,57 @@ C2H_CCCLRT_TEST("Stream get device", "[stream]")
   CCCLRT_REQUIRE(stream_ref_cudart.device() == *std::prev(cuda::devices.end()));
 }
 
+C2H_CCCLRT_TEST("Stream construction uses the explicit device", "[stream][multi_gpu]")
+{
+  if (cuda::devices.size() < 2)
+  {
+    return;
+  }
+
+  cuda::device_ref current_device{0};
+  cuda::device_ref explicit_device{1};
+
+  auto stream = [&]() {
+    cuda::__ensure_current_context guard(current_device);
+    return cuda::stream{explicit_device};
+  }();
+
+  CCCLRT_REQUIRE(stream.device() == explicit_device);
+}
+
+C2H_CCCLRT_TEST("Stream dependency uses the explicit stream device", "[stream][multi_gpu]")
+{
+  if (cuda::devices.size() < 2)
+  {
+    return;
+  }
+
+  cuda::device_ref current_device{0};
+  cuda::device_ref explicit_device{1};
+
+  cuda::stream waiter{explicit_device};
+  cuda::stream waitee{explicit_device};
+
+  ::test::pinned<int> value(0);
+  ::cuda::atomic_ref atomic_value(*value);
+
+  ::test::launch_kernel_single_thread(waitee, ::test::spin_until_80{}, value.get());
+  ::test::launch_kernel_single_thread(waitee, ::test::assign_42{}, value.get());
+
+  {
+    cuda::__ensure_current_context guard(current_device);
+    waiter.wait(waitee);
+  }
+
+  ::test::launch_kernel_single_thread(waiter, ::test::verify_42{}, value.get());
+  CCCLRT_REQUIRE(atomic_value.load() != 42);
+  CCCLRT_REQUIRE(!waiter.is_done());
+
+  atomic_value.store(80);
+  waiter.sync();
+  waitee.sync();
+}
+
 C2H_CCCLRT_TEST("Stream ID", "[stream]")
 {
   STATIC_REQUIRE(cuda::std::is_same_v<unsigned long long, cuda::std::underlying_type_t<cuda::stream_id>>);

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/constructor.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/constructor.cu
@@ -597,6 +597,35 @@ C2H_CCCLRT_TEST("cuda::make_device_buffer", "[container][buffer]")
   stream.sync();
 }
 
+C2H_CCCLRT_TEST("cuda::make_device_buffer uses the explicit device", "[container][buffer][multi_gpu]")
+{
+  if (cuda::devices.size() < 2)
+  {
+    return;
+  }
+
+  cuda::device_ref current_device{0};
+  cuda::device_ref explicit_device{1};
+  cuda::stream explicit_device_stream{explicit_device};
+  cuda::std::array<int, 6> input{1, 42, 1337, 0, 12, -1};
+
+  {
+    cuda::__ensure_current_context guard{current_device};
+    auto buf = cuda::make_device_buffer<int>(explicit_device_stream, explicit_device, input);
+
+    CCCLRT_CHECK(buf.size() == input.size());
+    check_allocation_device(buf, explicit_device);
+    CCCLRT_CHECK(equal_range(buf));
+
+    auto filled = cuda::make_device_buffer<int>(explicit_device_stream, explicit_device, 5, 42);
+    CCCLRT_CHECK(filled.size() == 5);
+    check_allocation_device(filled, explicit_device);
+    CCCLRT_CHECK(equal_size_value(filled, 5, 42));
+  }
+
+  explicit_device_stream.sync();
+}
+
 // ── make_pinned_buffer ──────────────────────────────────────────────────────
 
 #if _CCCL_CTK_AT_LEAST(12, 9)

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/copy.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/copy.cu
@@ -10,6 +10,7 @@
 
 #include <cuda/__memory_resource/shared_resource.h>
 #include <cuda/buffer>
+#include <cuda/devices>
 #include <cuda/memory_resource>
 #include <cuda/std/algorithm>
 #include <cuda/std/array>
@@ -229,6 +230,35 @@ C2H_CCCLRT_TEST("make_buffer variants", "[container][buffer]")
   static_assert(!::cuda::mr::synchronous_resource_with<typename decltype(buf8)::__resource_t, other_property>);
   static_assert(
     !::cuda::mr::synchronous_resource_with<typename decltype(buf8)::__resource_t, cuda::mr::host_accessible>);
+}
+
+C2H_CCCLRT_TEST("cuda::buffer make_buffer uses the explicit device", "[container][buffer][multi_gpu]")
+{
+  if (cuda::devices.size() < 2)
+  {
+    return;
+  }
+
+  cuda::device_ref current_device{0};
+  cuda::device_ref explicit_device{1};
+  cuda::stream explicit_device_stream{explicit_device};
+  cuda::std::array<int, 6> input{1, 42, 1337, 0, 12, -1};
+
+  {
+    cuda::__ensure_current_context guard{current_device};
+    auto resource = cuda::device_default_memory_pool(explicit_device);
+    cuda::device_buffer<int> source{explicit_device_stream, resource, input};
+    auto copy = cuda::make_buffer(explicit_device_stream, resource, source);
+
+    CCCLRT_CHECK(source.size() == input.size());
+    CCCLRT_CHECK(copy.size() == source.size());
+    check_allocation_device(source, explicit_device);
+    check_allocation_device(copy, explicit_device);
+    CCCLRT_CHECK(equal_range(source));
+    CCCLRT_CHECK(equal_range(copy));
+  }
+
+  explicit_device_stream.sync();
 }
 
 C2H_CCCLRT_TEST("make_buffer with legacy resource", "[container][buffer]")

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/helper.h
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/helper.h
@@ -21,6 +21,7 @@
 #include <cuda/std/iterator>
 #include <cuda/std/type_traits>
 
+#include <cuda_runtime_api.h>
 #include <test_resources.h>
 
 #include "test_macros.h"
@@ -69,7 +70,7 @@ bool equal_range(const Buffer& buf)
     {
       return false;
     }
-    cuda::__ensure_current_context guard{cuda::device_ref{0}};
+    cuda::__ensure_current_context guard{buf.stream()};
     check_equal_kernel<<<1, 1, 0, buf.stream().get()>>>(buf.begin());
     CCCLRT_CHECK(cudaGetLastError() == cudaSuccess);
     buf.stream().sync();
@@ -155,7 +156,7 @@ bool equal_size_value(const Buffer& buf, const size_t size, const typename Buffe
     {
       return false;
     }
-    cuda::__ensure_current_context guard{cuda::device_ref{0}};
+    cuda::__ensure_current_context guard{buf.stream()};
     check_equal_value_kernel<<<1, 1, 0, buf.stream().get()>>>(buf.begin(), size, value);
     CCCLRT_CHECK(cudaGetLastError() == cudaSuccess);
     buf.stream().sync();
@@ -174,10 +175,18 @@ bool equal_range(const Range1& range1, const Range2& range2)
   }
   else
   {
-    cuda::__ensure_current_context guard{cuda::device_ref{0}};
+    cuda::__ensure_current_context guard{range1.stream()};
     return range1.size() == range2.size()
         && thrust::equal(thrust::cuda::par.on(range1.stream().get()), range1.begin(), range1.end(), range2.begin());
   }
+}
+
+template <class Buffer>
+void check_allocation_device(const Buffer& buf, cuda::device_ref device)
+{
+  ::cudaPointerAttributes attributes{};
+  CCCLRT_REQUIRE(::cudaPointerGetAttributes(&attributes, buf.data()) == ::cudaSuccess);
+  CCCLRT_CHECK(attributes.device == device.get());
 }
 
 // helper class as we need to pass the properties in a tuple to the catch tests

--- a/libcudacxx/test/libcudacxx/cuda/memory/get_device_address.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/get_device_address.pass.cpp
@@ -11,6 +11,7 @@
 // UNSUPPORTED: enable-tile
 // error: asm statement is unsupported in tile code
 
+#include <cuda/__runtime/ensure_current_context.h>
 #include <cuda/devices>
 #include <cuda/memory>
 #include <cuda/std/cassert>
@@ -58,6 +59,32 @@ void test_host(T& object)
     assert(attributes.devicePointer == device_address);
   }
 }
+
+void test_explicit_device_with_different_current_device()
+{
+  if (cuda::devices.size() < 2)
+  {
+    return;
+  }
+
+  cuda::device_ref current_device{0};
+  cuda::device_ref explicit_device{1};
+
+  int* device_address = nullptr;
+  {
+    cuda::__ensure_current_context guard(current_device);
+    device_address = cuda::get_device_address(scalar_object, explicit_device);
+  }
+
+  {
+    cuda::__ensure_current_context guard(explicit_device);
+    cudaPointerAttributes attributes;
+    cudaError_t status = cudaPointerGetAttributes(&attributes, device_address);
+    assert(status == cudaSuccess);
+    assert(attributes.device == explicit_device.get());
+    assert(attributes.devicePointer == device_address);
+  }
+}
 #endif // !TEST_COMPILER(NVRTC)
 
 template <class T>
@@ -73,6 +100,9 @@ int main(int argc, char** argv)
   test(const_scalar_object);
   test(array_object);
   test(const_array_object);
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test_explicit_device_with_different_current_device();))
+#endif // !TEST_COMPILER(NVRTC)
 
   return 0;
 }


### PR DESCRIPTION
We test our APIs with empty driver context stack, but it seems sometimes that differs from it being set to a non-matching device. This PR adds a bunch of tests to APIs that take a device or a stream to confirm that if a different device is set current they continue to work.

It also adds tests for using events/streams across devices.