### PR TITLE
[libcu++][cuda::ptx] Add prefetch PTX wrappers

### DIFF
--- a/libcudacxx/include/cuda/__ptx/instructions/generated/prefetch.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/prefetch.h
@@ -1,0 +1,90 @@
+// This file was automatically generated. Do not edit.
+
+#ifndef _CUDA_PTX_GENERATED_PREFETCH_H_
+#define _CUDA_PTX_GENERATED_PREFETCH_H_
+
+/*
+// prefetch.global.L1 [addr]; // PTX ISA 20, SM_50
+template <typename = void>
+__device__ static inline void prefetch_L1(
+  const void* addr);
+*/
+#if __cccl_ptx_isa >= 200
+template <typename = void>
+_CCCL_DEVICE static inline void prefetch_L1(const void* __addr)
+{
+  asm volatile("prefetch.global.L1 [%0];" : : "l"(__as_ptr_gmem(__addr)) : "memory");
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// prefetch.global.L2 [addr]; // PTX ISA 20, SM_50
+template <typename = void>
+__device__ static inline void prefetch_L2(
+  const void* addr);
+*/
+#if __cccl_ptx_isa >= 200
+template <typename = void>
+_CCCL_DEVICE static inline void prefetch_L2(const void* __addr)
+{
+  asm volatile("prefetch.global.L2 [%0];" : : "l"(__as_ptr_gmem(__addr)) : "memory");
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// prefetch.global.L1::32B.valid_addr [addr]; // PTX ISA 94, SM_90
+template <typename = void>
+__device__ static inline void prefetch_L1_32B(
+  const void* addr);
+*/
+#if __cccl_ptx_isa >= 940
+template <typename = void>
+_CCCL_DEVICE static inline void prefetch_L1_32B(const void* __addr)
+{
+  asm volatile("prefetch.global.L1::32B.valid_addr [%0];" : : "l"(__as_ptr_gmem(__addr)) : "memory");
+}
+#endif // __cccl_ptx_isa >= 940
+
+/*
+// prefetch.global.L2::evict_last [addr]; // PTX ISA 74, SM_80
+template <typename = void>
+__device__ static inline void prefetch_L2_evict_last(
+  const void* addr);
+*/
+#if __cccl_ptx_isa >= 740
+template <typename = void>
+_CCCL_DEVICE static inline void prefetch_L2_evict_last(const void* __addr)
+{
+  asm volatile("prefetch.global.L2::evict_last [%0];" : : "l"(__as_ptr_gmem(__addr)) : "memory");
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// prefetch.global.L2::evict_normal [addr]; // PTX ISA 74, SM_80
+template <typename = void>
+__device__ static inline void prefetch_L2_evict_normal(
+  const void* addr);
+*/
+#if __cccl_ptx_isa >= 740
+template <typename = void>
+_CCCL_DEVICE static inline void prefetch_L2_evict_normal(const void* __addr)
+{
+  asm volatile("prefetch.global.L2::evict_normal [%0];" : : "l"(__as_ptr_gmem(__addr)) : "memory");
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// prefetch.tensormap [addr]; // PTX ISA 80, SM_90
+template <typename = void>
+__device__ static inline void prefetch_tensormap(
+  const void* addr);
+*/
+#if __cccl_ptx_isa >= 800
+template <typename = void>
+_CCCL_DEVICE static inline void prefetch_tensormap(const void* __addr)
+{
+  asm volatile("prefetch.tensormap [%0];" : : "l"(__addr) : "memory");
+}
+#endif // __cccl_ptx_isa >= 800
+
+#endif // _CUDA_PTX_GENERATED_PREFETCH_H_

--- a/libcudacxx/include/cuda/__ptx/instructions/prefetch.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/prefetch.h
@@ -1,0 +1,40 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_PTX_PREFETCH_H_
+#define _CUDA_PTX_PREFETCH_H_
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__ptx/ptx_helper_functions.h>
+#include <cuda/std/cstdint>
+
+#include <nv/target> // __CUDA_MINIMUM_ARCH__ and friends
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_PTX
+
+#include <cuda/__ptx/instructions/generated/prefetch.h>
+
+_CCCL_END_NAMESPACE_CUDA_PTX
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_PTX_PREFETCH_H_

--- a/libcudacxx/include/cuda/ptx
+++ b/libcudacxx/include/cuda/ptx
@@ -94,6 +94,7 @@
 #include <cuda/__ptx/instructions/multimem_ld_reduce.h>
 #include <cuda/__ptx/instructions/multimem_red.h>
 #include <cuda/__ptx/instructions/multimem_st.h>
+#include <cuda/__ptx/instructions/prefetch.h>
 #include <cuda/__ptx/instructions/prmt.h>
 #include <cuda/__ptx/instructions/red_async.h>
 #include <cuda/__ptx/instructions/setmaxnreg.h>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/prefetch.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/prefetch.h
@@ -1,0 +1,64 @@
+// This file was automatically generated. Do not edit.
+
+// We use a special strategy to force the generation of the PTX. This is mainly
+// a fight against dead-code-elimination in the NVVM layer.
+//
+// The reason we need this strategy is because certain older versions of ptxas
+// segfault when a non-sensical sequence of PTX is generated. So instead, we try
+// to force the instantiation and compilation to PTX of all the overloads of the
+// PTX wrapping functions.
+//
+// We do this by writing a function pointer of each overload to the kernel
+// parameter `fn_ptr`.
+//
+// Because `fn_ptr` is possibly visible outside this translation unit, the
+// compiler must compile all the functions which are stored.
+
+__global__ void test_prefetch(void** fn_ptr)
+{
+#if __cccl_ptx_isa >= 200
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // prefetch.global.L1 [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(const void*)>(cuda::ptx::prefetch_L1));));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // prefetch.global.L2 [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(const void*)>(cuda::ptx::prefetch_L2));));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 940
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_90,
+    (
+        // prefetch.global.L1::32B.valid_addr [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(const void*)>(cuda::ptx::prefetch_L1_32B));));
+#endif // __cccl_ptx_isa >= 940
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // prefetch.global.L2::evict_last [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(const void*)>(cuda::ptx::prefetch_L2_evict_last));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // prefetch.global.L2::evict_normal [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(const void*)>(cuda::ptx::prefetch_L2_evict_normal));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_90,
+    (
+        // prefetch.tensormap [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(const void*)>(cuda::ptx::prefetch_tensormap));));
+#endif // __cccl_ptx_isa >= 800
+}

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.prefetch.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.prefetch.compile.pass.cpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: libcpp-has-no-threads
+
+// <cuda/ptx>
+
+#include <cuda/ptx>
+#include <cuda/std/utility>
+
+#include "generated/prefetch.h"
+
+int main(int, char**)
+{
+  return 0;
+}


### PR DESCRIPTION
Second try to fix https://github.com/NVIDIA/cccl/issues/9616

I took Fede's advice and tried to use the internal libcucxx_ptx tool and then added a test. Given that both Bernhard and Fede are out I'll ask @ahendriksen to pinpoint any wrongdoings he might notice.