### PR TITLE
[libcu++] Guard tuple and pair against dangling references

### DIFF
--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -265,7 +265,8 @@ private:
       // clang-tidy incorrectly reports "'__t' used after it was forwarded".
       // Each expansion forwards the tuple only to select get<I>'s cvref-qualified overload for a distinct element.
       // NOLINTNEXTLINE(bugprone-use-after-move)
-      : tuple(::cuda::std::get<_Indices>(::cuda::std::forward<_TupleOfIteratorReferences>(__t))...)
+      : __base_(__tuple_variadic_constructor_tag{},
+                ::cuda::std::get<_Indices>(::cuda::std::forward<_TupleOfIteratorReferences>(__t))...)
   {}
 
 public:

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -249,7 +249,7 @@ public:
             // clang-tidy has fallen off its rocker and claims we can use the non-existent
             // __tuple_of_iterato_references_v here.
             // NOLINTBEGIN(modernize-type-traits)
-            enable_if_t<__is_tuple_of_iterator_references_v<_TupleOfIteratorReferences>, int> = 0,
+            enable_if_t<__is_tuple_of_iterator_references_v<remove_cvref_t<_TupleOfIteratorReferences>>, int> = 0,
             // NOLINTEND(modernize-type-traits)
             enable_if_t<(tuple_size<_TupleOfIteratorReferences>::value == sizeof...(_Tp)), int> = 0>
   _CCCL_API constexpr tuple(_TupleOfIteratorReferences&& __t)
@@ -258,15 +258,16 @@ public:
   // NOLINTEND(bugprone-forwarding-reference-overload)
 
 private:
+  // clang-tidy incorrectly reports "'__t' used after it was forwarded".
+  // Each expansion forwards the tuple only to select get<I>'s cvref-qualified overload for a distinct element.
+  // NOLINTBEGIN(bugprone-use-after-move)
   template <class _TupleOfIteratorReferences,
             size_t... _Indices,
-            enable_if_t<__is_tuple_of_iterator_references_v<_TupleOfIteratorReferences>, int> = 0>
+            enable_if_t<__is_tuple_of_iterator_references_v<remove_cvref_t<_TupleOfIteratorReferences>>, int> = 0>
   _CCCL_API constexpr tuple(_TupleOfIteratorReferences&& __t, __tuple_indices<_Indices...>)
-      // clang-tidy incorrectly reports "'__t' used after it was forwarded".
-      // Each expansion forwards the tuple only to select get<I>'s cvref-qualified overload for a distinct element.
-      // NOLINTNEXTLINE(bugprone-use-after-move)
       : __base_(__tuple_variadic_constructor_tag{},
                 ::cuda::std::get<_Indices>(::cuda::std::forward<_TupleOfIteratorReferences>(__t))...)
+  // NOLINTEND(bugprone-use-after-move)
   {}
 
 public:

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -186,6 +186,14 @@ public:
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
 
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  template <class... _UTypes,
+            enable_if_t<sizeof...(_Tp) != 0, int>  = 0, // Help Clang disambiguate for CTAD
+            __select_constructor _Trait            = _VariadicConstraints<_UTypes...>::value,
+            enable_if_t<__is_deleted<_Trait>, int> = 0>
+  constexpr tuple(_UTypes&&...) = delete;
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+
   template <class _Alloc,
             class... _UTypes,
             __select_constructor _Trait                          = _VariadicConstraints<_UTypes...>::value,
@@ -204,6 +212,14 @@ public:
       : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
 
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  template <class _Alloc,
+            class... _UTypes,
+            __select_constructor _Trait            = _VariadicConstraints<_UTypes...>::value,
+            enable_if_t<__is_deleted<_Trait>, int> = 0>
+  constexpr tuple(allocator_arg_t, const _Alloc&, _UTypes&&...) = delete;
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+
   template <class... _UTypes>
   using _VariadicConstraintsLessRank = integral_constant<
     __select_constructor,
@@ -217,6 +233,15 @@ public:
   _CCCL_API constexpr explicit tuple(_UTypes&&... __u)
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
+
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  template <class... _UTypes,
+            enable_if_t<(sizeof...(_UTypes) < sizeof...(_Tp)), int> = 0,
+            enable_if_t<(sizeof...(_UTypes) != 0), int>             = 0,
+            __select_constructor _Trait                             = _VariadicConstraintsLessRank<_UTypes...>::value,
+            enable_if_t<__is_deleted<_Trait>, int>                  = 0>
+  constexpr tuple(_UTypes&&...) = delete;
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   // Horrible hack to make tuple_of_iterator_references work
   // NOLINTBEGIN(bugprone-forwarding-reference-overload)
@@ -267,6 +292,13 @@ public:
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
 
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  template <class... _UTypes,
+            __select_constructor _Trait            = _TupleLikeConstraints<tuple<_UTypes...>&>::value,
+            enable_if_t<__is_deleted<_Trait>, int> = 0>
+  constexpr tuple(tuple<_UTypes...>&) = delete;
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+
   template <class... _UTypes,
             __select_constructor _Trait = _TupleLikeConstraints<const tuple<_UTypes...>&>::value,
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
@@ -281,6 +313,14 @@ public:
     _NothrowTupleLike<const tuple<_UTypes...>&>::value)
       : __base_(__tuple_like_constructor_tag{}, __t)
   {}
+
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  template <class... _UTypes,
+            __select_constructor _Trait            = _TupleLikeConstraints<const tuple<_UTypes...>&>::value,
+            enable_if_t<__is_deleted<_Trait>, int> = 0>
+  _CCCL_API constexpr tuple(const tuple<_UTypes...>&) = delete;
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+
   template <class... _UTypes,
             __select_constructor _Trait                          = _TupleLikeConstraints<tuple<_UTypes...>&&>::value,
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
@@ -294,6 +334,13 @@ public:
   _CCCL_API explicit constexpr tuple(tuple<_UTypes...>&& __t) noexcept(_NothrowTupleLike<tuple<_UTypes...>&&>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
+
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  template <class... _UTypes,
+            __select_constructor _Trait            = _TupleLikeConstraints<tuple<_UTypes...>&&>::value,
+            enable_if_t<__is_deleted<_Trait>, int> = 0>
+  constexpr tuple(tuple<_UTypes...>&&) = delete;
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class... _UTypes,
             __select_constructor _Trait = _TupleLikeConstraints<const tuple<_UTypes...>&&>::value,
@@ -310,6 +357,13 @@ public:
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::move(__t))
   {}
 
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  template <class... _UTypes,
+            __select_constructor _Trait            = _TupleLikeConstraints<const tuple<_UTypes...>&&>::value,
+            enable_if_t<__is_deleted<_Trait>, int> = 0>
+  constexpr tuple(const tuple<_UTypes...>&&) = delete;
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+
   // We cannot instantiate _TupleLikeConstraints eagerly because the leads to recursive constraints
   // We need to SFINAE the constructor away before instantiating the traits
   template <class _Tuple>
@@ -324,9 +378,7 @@ public:
   _CCCL_API constexpr tuple(_Tuple&& __t) noexcept(_NothrowTupleLike<_Tuple>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_Tuple>(__t))
   {}
-  // NOLINTEND(bugprone-forwarding-reference-overload)
 
-  // NOLINTBEGIN(bugprone-forwarding-reference-overload)
   template <class _Tuple,
             enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
             __select_constructor _Trait                                = _TupleLikeConstraints<_Tuple>::value,
@@ -334,6 +386,14 @@ public:
   _CCCL_API explicit constexpr tuple(_Tuple&& __t) noexcept(_NothrowTupleLike<_Tuple>::value)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_Tuple>(__t))
   {}
+
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  template <class _Tuple,
+            enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
+            __select_constructor _Trait                                = _TupleLikeConstraints<_Tuple>::value,
+            enable_if_t<__is_deleted<_Trait>, int>                     = 0>
+  constexpr tuple(_Tuple&&) = delete;
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
   // NOLINTEND(bugprone-forwarding-reference-overload)
 
   template <class _Alloc,
@@ -354,6 +414,15 @@ public:
     _NothrowTupleLike<_Tuple>::value)
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::forward<_Tuple>(__t))
   {}
+
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  template <class _Alloc,
+            class _Tuple,
+            enable_if_t<__disambiguate_tuple_like<_Tuple>::value, int> = 0,
+            __select_constructor _Trait                                = _TupleLikeConstraints<_Tuple>::value,
+            enable_if_t<__is_deleted<_Trait>, int>                     = 0>
+  constexpr tuple(allocator_arg_t, const _Alloc&, _Tuple&&) = delete;
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   // [tuple.assign]
   _CCCL_HIDE_FROM_ABI tuple& operator=(const tuple& __t) = default;

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -56,6 +56,7 @@
 #include <cuda/std/__type_traits/reference_constructs_from_temporary.h>
 #include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/__type_traits/remove_reference.h>
+#include <cuda/std/__type_traits/sfinae_traits.h>
 #include <cuda/std/__utility/declval.h>
 
 #include <cuda/std/__cccl/prologue.h>
@@ -88,25 +89,6 @@ inline constexpr bool __tuple_like_with_size = false;
 template <class _Tuple, size_t _ExpectedSize>
 inline constexpr bool __tuple_like_with_size<_Tuple, _ExpectedSize, true> =
   _ExpectedSize == tuple_size<remove_cvref_t<_Tuple>>::value;
-
-//! @brief Determines whether a constructor is valid and whether it is implicit or explicit
-enum class __select_constructor
-{
-  __invalid, //!< The constructor is not valid
-  __implicit, //!< The constructor is valid and implicit
-  __explicit, //!< The constructor is valid and explicit
-  __deleted, //!< The constructor is marked as deleted
-};
-
-template <__select_constructor _Trait>
-inline constexpr bool __can_construct_implicitly = _Trait == __select_constructor::__implicit;
-template <__select_constructor _Trait>
-inline constexpr bool __can_construct_explicitly = _Trait == __select_constructor::__explicit;
-template <__select_constructor _Trait>
-inline constexpr bool __can_construct =
-  (_Trait == __select_constructor::__implicit) || (_Trait == __select_constructor::__explicit);
-template <__select_constructor _Trait>
-inline constexpr bool __is_deleted = _Trait == __select_constructor::__deleted;
 
 template <class... _Types>
 [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
@@ -491,26 +473,13 @@ _CCCL_API _CCCL_CONSTEVAL auto __tuple_is_comparable(__tuple_types<_Types...>, _
 template <class>
 [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __tuple_is_comparable(...) noexcept -> _InvalidTupleComparison;
 
-//! @brief Determines whether an assignment is valid and also whether it does not throw
-enum class __select_assignment
-{
-  __none, //!< No assignment possible
-  __is_nothrow, //!< Assignment possible, is nothrow
-  __may_throw, //!< Assignment possible, may throw
-};
-
-template <__select_assignment _Trait>
-inline constexpr bool __can_assign = _Trait != __select_assignment::__none;
-template <__select_assignment _Trait>
-inline constexpr bool __can_nothrow_assign = _Trait == __select_assignment::__is_nothrow;
-
 template <class... _Types>
 [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_assignment
 __tuple_select_const_copy_assignable(__tuple_types<_Types...>) noexcept
 {
   if constexpr (!(is_copy_assignable_v<const _Types> && ...))
   { // [tuple.assign]-5: is_copy_assignable_v<const Types> is true for all i.
-    return __select_assignment::__none;
+    return __select_assignment::__invalid;
   }
   else if constexpr ((is_nothrow_copy_assignable_v<const _Types> && ...))
   {
@@ -532,7 +501,7 @@ __tuple_select_const_move_assignable(__tuple_types<_Types...>) noexcept
 {
   if constexpr (!(is_assignable_v<const _Types&, _Types> && ...))
   { // [tuple.assign]-12: is_assignable_v<const Types&, Types> is true for all i.
-    return __select_assignment::__none;
+    return __select_assignment::__invalid;
   }
   else if constexpr ((is_nothrow_assignable_v<const _Types&, _Types> && ...))
   {
@@ -554,11 +523,11 @@ __tuple_select_converting_assignable(__tuple_types<_Types...>, __tuple_types<_UT
 {
   if constexpr (sizeof...(_Types) != sizeof...(_UTypes))
   { // [tuple.assign]-15.1: sizeof...(Types) equals sizeof...(UTypes) and
-    return __select_assignment::__none;
+    return __select_assignment::__invalid;
   }
   else if constexpr (is_same_v<tuple<_Types...>, tuple<_UTypes...>>)
   { // Disambiguate the non-converting assignments
-    return __select_assignment::__none;
+    return __select_assignment::__invalid;
   }
   else if constexpr (_IsConst)
   {
@@ -571,7 +540,7 @@ __tuple_select_converting_assignable(__tuple_types<_Types...>, __tuple_types<_UT
     }
     else
     {
-      return __select_assignment::__none;
+      return __select_assignment::__invalid;
     }
   }
   else if constexpr ((is_assignable_v<_Types&, _UTypes> && ...))
@@ -583,7 +552,7 @@ __tuple_select_converting_assignable(__tuple_types<_Types...>, __tuple_types<_UT
   }
   else
   {
-    return __select_assignment::__none;
+    return __select_assignment::__invalid;
   }
 }
 
@@ -599,15 +568,15 @@ __tuple_select_tuple_like_assignable(__tuple_types<_Types...>, __tuple_indices<_
   using ::cuda::std::get;
   if constexpr (is_same_v<remove_cvref_t<_UTuple>, tuple<_Types...>>)
   { // [tuple.assign]-39.1: different-from<UTuple, tuple>
-    return __select_assignment::__none;
+    return __select_assignment::__invalid;
   }
   else if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UTuple>>)
   { // [tuple.assign]-39.2: remove_cvref_t<UTuple> is not a specialization of ranges​::​subrange,
-    return __select_assignment::__none;
+    return __select_assignment::__invalid;
   }
   else if constexpr (!__tuple_like_with_size<_UTuple, sizeof...(_Types)>)
   { // [tuple.assign]-39.3: sizeof...(Types) equals tuple_size_v<remove_cvref_t<UTuple>>, and
-    return __select_assignment::__none;
+    return __select_assignment::__invalid;
   }
   else if constexpr (_IsConst)
   {
@@ -620,7 +589,7 @@ __tuple_select_tuple_like_assignable(__tuple_types<_Types...>, __tuple_indices<_
     }
     else
     {
-      return __select_assignment::__none;
+      return __select_assignment::__invalid;
     }
   }
   else if constexpr ((is_assignable_v<_Types&, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...))
@@ -631,7 +600,7 @@ __tuple_select_tuple_like_assignable(__tuple_types<_Types...>, __tuple_indices<_
   }
   else
   {
-    return __select_assignment::__none;
+    return __select_assignment::__invalid;
   }
 }
 

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -221,7 +221,11 @@ template <class _Type, class _UType>
 [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
 __tuple_select_variadic_constructible(__tuple_types<_Type>, __tuple_types<_UType>) noexcept
 {
-  if constexpr (is_same_v<remove_cvref_t<_UType>, tuple<_Type>>)
+  if constexpr (__is_tuple_of_iterator_references_v<remove_cvref_t<_UType>>)
+  {
+    return __select_constructor::__invalid;
+  }
+  else if constexpr (is_same_v<remove_cvref_t<_UType>, tuple<_Type>>)
   { // [tuple.cnstr]-12.1: negation<is_same<remove_cvref_t<U0>, tuple>> if sizeof...(Types) is 1
     return __select_constructor::__invalid;
   }

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -53,6 +53,7 @@
 #include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/lazy.h>
+#include <cuda/std/__type_traits/reference_constructs_from_temporary.h>
 #include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/__type_traits/remove_reference.h>
 #include <cuda/std/__utility/declval.h>
@@ -91,9 +92,10 @@ inline constexpr bool __tuple_like_with_size<_Tuple, _ExpectedSize, true> =
 //! @brief Determines whether a constructor is valid and whether it is implicit or explicit
 enum class __select_constructor
 {
-  __none, //!< The constructor is not valid
+  __invalid, //!< The constructor is not valid
   __implicit, //!< The constructor is valid and implicit
   __explicit, //!< The constructor is valid and explicit
+  __deleted, //!< The constructor is marked as deleted
 };
 
 template <__select_constructor _Trait>
@@ -101,7 +103,10 @@ inline constexpr bool __can_construct_implicitly = _Trait == __select_constructo
 template <__select_constructor _Trait>
 inline constexpr bool __can_construct_explicitly = _Trait == __select_constructor::__explicit;
 template <__select_constructor _Trait>
-inline constexpr bool __can_construct = _Trait != __select_constructor::__none;
+inline constexpr bool __can_construct =
+  (_Trait == __select_constructor::__implicit) || (_Trait == __select_constructor::__explicit);
+template <__select_constructor _Trait>
+inline constexpr bool __is_deleted = _Trait == __select_constructor::__deleted;
 
 template <class... _Types>
 [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
@@ -109,7 +114,7 @@ __tuple_select_default_constructible(__tuple_types<_Types...>) noexcept
 {
   if constexpr (!(is_default_constructible_v<_Types> && ...))
   {
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr ((__is_implicitly_default_constructible<_Types>::value && ...))
   {
@@ -127,7 +132,7 @@ __tuple_select_variadic_copy_constructible(__tuple_types<_Types...>) noexcept
 {
   if constexpr (!(is_copy_constructible_v<_Types> && ...))
   {
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr ((is_convertible_v<const _Types&, _Types> && ...))
   {
@@ -149,7 +154,7 @@ __tuple_select_variadic_move_constructible(__tuple_types<_Types...>) noexcept
 {
   if constexpr (!(is_move_constructible_v<_Types> && ...))
   {
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr ((is_convertible_v<_Types&&, _Types> && ...))
   {
@@ -171,42 +176,62 @@ __tuple_select_variadic_constructible(__tuple_types<_Types...>, __tuple_types<_U
 {
   if constexpr (sizeof...(_Types) != sizeof...(_UTypes))
   { // [tuple.cnstr]-13.1: sizeof...(Types) equals sizeof...(UTypes),
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr (sizeof...(_Types) == 0)
   { // [tuple.cnstr]-13.2: sizeof...(Types) >= 1,
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr (sizeof...(_Types) == 2 || sizeof...(_Types) == 3)
   { // [tuple.cnstr]-12.2: otherwise, if sizeof...(Types) is 2 or 3
-    //    !is_same_v<remove_cvref_t<U0>, allocator_arg_t> || is_same_v<remove_cvref_t<T0>, allocator_arg_t>>
     using _U0 = __type_index_c<0, _UTypes...>;
     using _T0 = __type_index_c<0, _Types...>;
     if constexpr (!is_same_v<remove_cvref_t<_U0>, allocator_arg_t> || is_same_v<remove_cvref_t<_T0>, allocator_arg_t>)
-    { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
-      if constexpr ((is_constructible_v<_Types, _UTypes> && ...))
-      {
-        constexpr bool __can_construct_implicitly = (is_convertible_v<_UTypes, _Types> && ...);
-        return __can_construct_implicitly ? __select_constructor::__implicit : __select_constructor::__explicit;
+    { // [tuple.cnstr]-13.3: !is_same_v<remove_cvref_t<U0>, allocator_arg_t> || is_same_v<remove_cvref_t<T0>,
+      // allocator_arg_t>>
+      if constexpr (!(is_constructible_v<_Types, _UTypes> && ...))
+      { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
+        return __select_constructor::__invalid;
+      }
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+      else if constexpr ((reference_constructs_from_temporary_v<_Types, _UTypes&&> || ...))
+      { // [tuple.cnstr]-15: This constructor is defined as deleted if
+        // (reference_constructs_from_temporary_v<Types, UTypes&&> || ...) is true
+        return __select_constructor::__deleted;
+      }
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+      else if constexpr (!(is_convertible_v<_UTypes, _Types> && ...))
+      { // [tuple.cnstr]-15: !conjunction_v<is_convertible<UTypes, Types>...>
+        return __select_constructor::__explicit;
       }
       else
       {
-        return __select_constructor::__none;
+        return __select_constructor::__implicit;
       }
     }
     else
     {
-      return __select_constructor::__none;
+      return __select_constructor::__invalid;
     }
   }
-  else if constexpr ((is_constructible_v<_Types, _UTypes> && ...))
+  else if constexpr (!(is_constructible_v<_Types, _UTypes> && ...))
   { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
-    constexpr bool __can_construct_implicitly = (is_convertible_v<_UTypes, _Types> && ...);
-    return __can_construct_implicitly ? __select_constructor::__implicit : __select_constructor::__explicit;
+    return __select_constructor::__invalid;
+  }
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  else if constexpr ((reference_constructs_from_temporary_v<_Types, _UTypes&&> || ...))
+  { // [tuple.cnstr]-15: This constructor is defined as deleted if
+    // (reference_constructs_from_temporary_v<Types, UTypes&&> || ...) is true
+    return __select_constructor::__deleted;
+  }
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+  else if constexpr (!(is_convertible_v<_UTypes, _Types> && ...))
+  { // [tuple.cnstr]-15: !conjunction_v<is_convertible<UTypes, Types>...>
+    return __select_constructor::__explicit;
   }
   else
   {
-    return __select_constructor::__none;
+    return __select_constructor::__implicit;
   }
 }
 
@@ -216,15 +241,26 @@ __tuple_select_variadic_constructible(__tuple_types<_Type>, __tuple_types<_UType
 {
   if constexpr (is_same_v<remove_cvref_t<_UType>, tuple<_Type>>)
   { // [tuple.cnstr]-12.1: negation<is_same<remove_cvref_t<U0>, tuple>> if sizeof...(Types) is 1
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr (!is_constructible_v<_Type, _UType>)
   { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
+  }
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  else if constexpr (reference_constructs_from_temporary_v<_Type, _UType&&>)
+  { // [tuple.cnstr]-15: This constructor is defined as deleted if
+    // (reference_constructs_from_temporary_v<Types, UTypes&&> || ...) is true
+    return __select_constructor::__deleted;
+  }
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+  else if constexpr (!is_convertible_v<_UType, _Type>)
+  { // [tuple.cnstr]-15: !conjunction_v<is_convertible<UTypes, Types>...>
+    return __select_constructor::__explicit;
   }
   else
-  { // [tuple.cnstr]-15: !conjunction_v<is_convertible<UTypes, Types>...>
-    return is_convertible_v<_UType, _Type> ? __select_constructor::__implicit : __select_constructor::__explicit;
+  {
+    return __select_constructor::__implicit;
   }
 }
 
@@ -238,31 +274,36 @@ __tuple_select_variadic_constructible_less_rank(__tuple_types<_Types...>, __tupl
 {
   if constexpr (!(sizeof...(_UTypes) < sizeof...(_Types)))
   {
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr (sizeof...(_UTypes) == 0)
   {
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else
   {
     using __arg_list       = __make_tuple_types_t<__tuple_types<_Types...>, sizeof...(_UTypes)>;
     using __defaulted_list = __make_tuple_types_t<__tuple_types<_Types...>, sizeof...(_Types), sizeof...(_UTypes)>;
-    if constexpr (::cuda::std::__tuple_select_variadic_constructible(__arg_list{}, __tuple_types<_UTypes...>{})
-                  == __select_constructor::__none)
+    [[maybe_unused]] constexpr __select_constructor __variadic_trait =
+      ::cuda::std::__tuple_select_variadic_constructible(__arg_list{}, __tuple_types<_UTypes...>{});
+    [[maybe_unused]] constexpr __select_constructor __defaulted_trait =
+      ::cuda::std::__tuple_select_default_constructible(__defaulted_list{});
+    if constexpr (__variadic_trait == __select_constructor::__invalid
+                  || __variadic_trait == __select_constructor::__deleted)
     {
-      return __select_constructor::__none;
+      return __select_constructor::__invalid;
     }
-    else if constexpr (::cuda::std::__tuple_select_default_constructible(__defaulted_list{})
-                       == __select_constructor::__none)
+    else if constexpr (__defaulted_trait == __select_constructor::__invalid
+                       || __defaulted_trait == __select_constructor::__deleted)
     {
-      return __select_constructor::__none;
+      return __select_constructor::__invalid;
     }
     else
     {
       return __select_constructor::__explicit;
     }
   }
+  _CCCL_UNREACHABLE();
 }
 
 template <class _TupleTypes, class _TupleUTypes>
@@ -277,35 +318,49 @@ __tuple_select_tuple_like_constructible(__tuple_types<_Types...>, __tuple_indice
   using ::cuda::std::get;
   if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UTuple>>)
   { // [tuple#cnstr]-29.2: remove_cvref_t<UTuple> is not a specialization of ranges​::​subrange,
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr (is_same_v<_UTuple, const tuple<_Types...>&> || is_same_v<_UTuple, tuple<_Types...>&&>)
   { // Prefers the copy/move constructor
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr (sizeof...(_Types) == 0)
   { // Avoids issues with the size 1 constructor below
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr (!__tuple_like_with_size<_UTuple, sizeof...(_Types)>)
   { // [tuple#cnstr]-21.1: sizeof...(Types) equals sizeof...(UTypes), and
     // [tuple#cnstr]-25.1: sizeof...(Types) is 2,
     // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr (!(is_constructible_v<_Types, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...))
   { // [tuple.cnstr]-21.2: is_constructible<Types, decltype(get<I>(std​::​forward<UTuple>(u)))>... is true
     // [tuple.cnstr]-25.2: is_constructible<Types, decltype(get<I>(std​::​forward<UTuple>(u)))>... is true
     // [tuple.cnstr]-29.4: is_constructible<Types, decltype(get<I>(std​::​forward<UTuple>(u)))>... is true
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
-  else
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  else if constexpr ((reference_constructs_from_temporary_v<_Types,
+                                                            decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))>
+                      || ...))
+  { // [tuple.cnstr]-23: This constructor is defined as deleted if
+    // [tuple.cnstr]-27: This constructor is defined as deleted if
+    // [tuple.cnstr]-31: This constructor is defined as deleted if
+    // (reference_constructs_from_temporary_v<Types, decltype(get<I>(FWD(u)))> || ...) is true
+    return __select_constructor::__deleted;
+  }
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+  else if constexpr (!(is_convertible_v<decltype(get<_Indices>(::cuda::std::declval<_UTuple>())), _Types> && ...))
   { // [tuple.cnstr]-15: The expression inside explicit is equivalent to:
     // [tuple.cnstr]-23: The expression inside explicit is equivalent to:
+    // [tuple.cnstr]-31: The expression inside explicit is equivalent to:
     // !(is_convertible_v<decltype(get<I>(FWD(u))), Types> && ...)
-    return (is_convertible_v<decltype(get<_Indices>(::cuda::std::declval<_UTuple>())), _Types> && ...)
-           ? __select_constructor::__implicit
-           : __select_constructor::__explicit;
+    return __select_constructor::__explicit;
+  }
+  else
+  {
+    return __select_constructor::__implicit;
   }
 }
 
@@ -317,46 +372,55 @@ __tuple_select_tuple_like_constructible(__tuple_types<_Type>, __tuple_indices<_I
   using ::cuda::std::get;
   if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UTuple>>)
   { // [tuple#cnstr]-29.2: remove_cvref_t<UTuple> is not a specialization of ranges​::​subrange,
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr (is_same_v<_UTuple, const tuple<_Type>&> || is_same_v<_UTuple, tuple<_Type>&&>)
   { // Prefers the copy/move constructor
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr (!__tuple_like_with_size<_UTuple, 1>)
   { // [tuple#cnstr]-21.1: sizeof...(Types) equals sizeof...(UTypes), and
     // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr (__is_cuda_std_tuple<remove_cvref_t<_UTuple>>
                      && is_same_v<_Type, tuple_element_t<_Index, remove_cvref_t<_UTuple>>>)
   { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1
     // [tuple#cnstr]-21.3: is_same_v<T, U> is false
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr (is_constructible_v<_Type, _UTuple>)
   { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1, or is_constructible_v<T, _UTuple> are false
     // [tuple#cnstr]-29.5: either sizeof...(Types) is not 1, or is_constructible_v<T, _UTuple> are false
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr (is_convertible_v<_UTuple, _Type>)
   { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1, or is_convertible_v<_UTuple, T> are false
     // [tuple#cnstr]-29.5: either sizeof...(Types) is not 1, or is_convertible_v<_UTuple, T> are false
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr (!is_constructible_v<_Type, decltype(get<_Index>(::cuda::std::declval<_UTuple>()))>)
   { // [tuple.cnstr]-21.2: is_constructible<Types, decltype(get<I>(std​::​forward<UTuple>(u)))>... is true
-    // [tuple.cnstr]-25.2: is_constructible<Types, decltype(get<I>(std​::​forward<UTuple>(u)))>... is true
     // [tuple.cnstr]-29.4: is_constructible<Types, decltype(get<I>(std​::​forward<UTuple>(u)))>... is true
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
-  else
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  else if constexpr (reference_constructs_from_temporary_v<_Type, decltype(get<_Index>(::cuda::std::declval<_UTuple>()))>)
+  { // [tuple.cnstr]-23: This constructor is defined as deleted if
+    // [tuple.cnstr]-31: This constructor is defined as deleted if
+    // (reference_constructs_from_temporary_v<Types, decltype(get<I>(FWD(u)))> || ...) is true
+    return __select_constructor::__deleted;
+  }
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+  else if constexpr (!is_convertible_v<decltype(get<_Index>(::cuda::std::declval<_UTuple>())), _Type>)
   { // [tuple.cnstr]-15: The expression inside explicit is equivalent to:
     // [tuple.cnstr]-23: The expression inside explicit is equivalent to:
     // !(is_convertible_v<decltype(get<I>(FWD(u))), Types> && ...)
-    return is_convertible_v<decltype(get<_Index>(::cuda::std::declval<_UTuple>())), _Type>
-           ? __select_constructor::__implicit
-           : __select_constructor::__explicit;
+    return __select_constructor::__explicit;
+  }
+  else
+  {
+    return __select_constructor::__implicit;
   }
 }
 

--- a/libcudacxx/include/cuda/std/__type_traits/sfinae_traits.h
+++ b/libcudacxx/include/cuda/std/__type_traits/sfinae_traits.h
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___TYPE_TRAITS_SFINAE_TRAITS_H
+#define _CUDA_STD___TYPE_TRAITS_SFINAE_TRAITS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+//! @brief Determines whether a constructor is valid and whether it is implicit or explicit
+enum class __select_constructor
+{
+  __invalid, //!< The constructor is not valid
+  __implicit, //!< The constructor is valid and implicit
+  __explicit, //!< The constructor is valid and explicit
+  __deleted, //!< The constructor is marked as deleted
+};
+
+template <__select_constructor _Trait>
+inline constexpr bool __can_construct_implicitly = _Trait == __select_constructor::__implicit;
+template <__select_constructor _Trait>
+inline constexpr bool __can_construct_explicitly = _Trait == __select_constructor::__explicit;
+template <__select_constructor _Trait>
+inline constexpr bool __can_construct =
+  (_Trait == __select_constructor::__implicit) || (_Trait == __select_constructor::__explicit);
+template <__select_constructor _Trait>
+inline constexpr bool __is_deleted = _Trait == __select_constructor::__deleted;
+
+//! @brief Determines whether an assignment is valid and also whether it does not throw
+enum class __select_assignment
+{
+  __invalid, //!< The assignment is invalid
+  __is_nothrow, //!< The assignment is valid and noexcept
+  __may_throw, //!< The assignment is valid but may throw
+};
+
+template <__select_assignment _Trait>
+inline constexpr bool __can_assign = _Trait != __select_assignment::__invalid;
+template <__select_assignment _Trait>
+inline constexpr bool __can_nothrow_assign = _Trait == __select_assignment::__is_nothrow;
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD___TYPE_TRAITS_SFINAE_TRAITS_H

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -77,19 +77,19 @@ template <class _UPair, class _T1, class _T2>
   using ::cuda::std::get;
   if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UPair>>)
   { // [pairs#pair]-15.1: remove_cvref_t<UTuple> is not a specialization of ranges​::​subrange,
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr (!__pair_like<_UPair>)
   {
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr (!is_constructible_v<_T1, decltype(get<0>(::cuda::std::declval<_UPair>()))>)
   { // [pairs#pair]-15.2: is_constructible<T1, decltype(get<0>(std​::​forward<UTuple>(u)))>... is true
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr (!is_constructible_v<_T2, decltype(get<1>(::cuda::std::declval<_UPair>()))>)
   { // [pairs#pair]-15.3: is_constructible<T2, decltype(get<1>(std​::​forward<UTuple>(u)))>... is true
-    return __select_constructor::__none;
+    return __select_constructor::__invalid;
   }
   else if constexpr (is_convertible_v<decltype(get<0>(::cuda::std::declval<_UPair>())), _T1>
                      && is_convertible_v<decltype(get<1>(::cuda::std::declval<_UPair>())), _T2>)

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -60,6 +60,7 @@
 #include <cuda/std/__type_traits/is_swappable.h>
 #include <cuda/std/__type_traits/make_const_lvalue_ref.h>
 #include <cuda/std/__type_traits/reference_constructs_from_temporary.h>
+#include <cuda/std/__type_traits/sfinae_traits.h>
 #include <cuda/std/__utility/forward.h>
 #include <cuda/std/__utility/move.h>
 #include <cuda/std/__utility/piecewise_construct.h>
@@ -125,27 +126,27 @@ template <bool _IsConst, class _UPair, class _T1, class _T2>
   if constexpr (is_same_v<remove_cvref_t<_UPair>, pair<_T1, _T2>>)
   { // [pairs.pair]-42.1: different-from<UPair, pair>
     // [pairs.pair]-45.1: different-from<UPair, pair>
-    return __select_assignment::__none;
+    return __select_assignment::__invalid;
   }
   else if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UPair>>)
   { // [pairs.pair]-42.2: remove_cvref_t<UTuple> is not a specialization of ranges​::​subrange,
     // [pairs.pair]-45.2: remove_cvref_t<UTuple> is not a specialization of ranges​::​subrange,
-    return __select_assignment::__none;
+    return __select_assignment::__invalid;
   }
   else if constexpr (!__pair_like<_UPair>)
   { // [pairs.pair]-42: pair-like P
     // [pairs.pair]-45: pair-like P
-    return __select_assignment::__none;
+    return __select_assignment::__invalid;
   }
   else if constexpr (_IsConst)
   {
     if constexpr (!is_assignable_v<const _T1&, decltype(get<0>(::cuda::std::declval<_UPair>()))>)
     { // [pairs.pair]-45.3: is_assignable_v<const T1&, decltype(get<0>(std​::​forward<P>(p)))> is true
-      return __select_assignment::__none;
+      return __select_assignment::__invalid;
     }
     else if constexpr (!is_assignable_v<const _T2&, decltype(get<1>(::cuda::std::declval<_UPair>()))>)
     { // [pairs.pair]-45.4: is_assignable_v<const T2&, decltype(get<1>(std​::​forward<P>(p)))> is true
-      return __select_assignment::__none;
+      return __select_assignment::__invalid;
     }
     else if constexpr (is_nothrow_assignable_v<const _T1&, decltype(get<0>(::cuda::std::declval<_UPair>()))>
                        && is_nothrow_assignable_v<const _T2&, decltype(get<1>(::cuda::std::declval<_UPair>()))>)
@@ -159,11 +160,11 @@ template <bool _IsConst, class _UPair, class _T1, class _T2>
   }
   else if constexpr (!is_assignable_v<_T1&, decltype(get<0>(::cuda::std::declval<_UPair>()))>)
   { // [pairs.pair]-42.3: is_assignable_v<const T1&, decltype(get<0>(std​::​forward<P>(p)))> is true
-    return __select_assignment::__none;
+    return __select_assignment::__invalid;
   }
   else if constexpr (!is_assignable_v<_T2&, decltype(get<1>(::cuda::std::declval<_UPair>()))>)
   { // [pairs.pair]-42.4: is_assignable_v<const T2&, decltype(get<1>(std​::​forward<P>(p)))> is true
-    return __select_assignment::__none;
+    return __select_assignment::__invalid;
   }
   else if constexpr (is_nothrow_assignable_v<_T1&, decltype(get<0>(::cuda::std::declval<_UPair>()))>
                      && is_nothrow_assignable_v<_T2&, decltype(get<1>(::cuda::std::declval<_UPair>()))>)

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -59,6 +59,7 @@
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/is_swappable.h>
 #include <cuda/std/__type_traits/make_const_lvalue_ref.h>
+#include <cuda/std/__type_traits/reference_constructs_from_temporary.h>
 #include <cuda/std/__utility/forward.h>
 #include <cuda/std/__utility/move.h>
 #include <cuda/std/__utility/piecewise_construct.h>
@@ -91,6 +92,15 @@ template <class _UPair, class _T1, class _T2>
   { // [pairs#pair]-15.3: is_constructible<T2, decltype(get<1>(std​::​forward<UTuple>(u)))>... is true
     return __select_constructor::__invalid;
   }
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  else if constexpr (reference_constructs_from_temporary_v<_T1, decltype(get<0>(::cuda::std::declval<_UPair>()))>
+                     || reference_constructs_from_temporary_v<_T2, decltype(get<1>(::cuda::std::declval<_UPair>()))>)
+  { // [pairs#pair]-17: This constructor is defined as deleted if
+    // reference_constructs_from_temporary_v<T1, decltype(get<0>(FWD(u)))> or
+    // reference_constructs_from_temporary_v<T2, decltype(get<1>(FWD(u)))> is true
+    return __select_constructor::__deleted;
+  }
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
   else if constexpr (is_convertible_v<decltype(get<0>(::cuda::std::declval<_UPair>())), _T1>
                      && is_convertible_v<decltype(get<1>(::cuda::std::declval<_UPair>())), _T2>)
   { // [pairs#pair]-17 !is_convertible_v<decltype(get<0>(FWD(u))), T1> &&
@@ -341,6 +351,15 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
       : __base(::cuda::std::forward<_U1>(__u1), ::cuda::std::forward<_U2>(__u2))
   {}
 
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  template <class _U1 = _T1,
+            class _U2 = _T2,
+            __select_constructor _Trait =
+              __tuple_select_variadic_constructible_v<__tuple_types<_T1, _T2>, __tuple_types<_U1, _U2>>,
+            enable_if_t<__is_deleted<_Trait>, int> = 0>
+  constexpr pair(_U1&&, _U2&&) = delete;
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+
   // converting constructors
   template <class _U1,
             class _U2,
@@ -360,6 +379,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
       : __base(__p.first, __p.second)
   {}
 
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  template <class _U1,
+            class _U2,
+            __select_constructor _Trait            = __pair_select_pair_like_constructible_v<pair<_U1, _U2>&, _T1, _T2>,
+            enable_if_t<__is_deleted<_Trait>, int> = 0>
+  constexpr pair(pair<_U1, _U2>&) = delete;
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+
   template <class _U1,
             class _U2,
             __select_constructor _Trait = __pair_select_pair_like_constructible_v<const pair<_U1, _U2>&, _T1, _T2>,
@@ -377,6 +404,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
     is_nothrow_constructible_v<_T1, const _U1&> && is_nothrow_constructible_v<_T2, const _U2&>)
       : __base(__p.first, __p.second)
   {}
+
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  template <class _U1,
+            class _U2,
+            __select_constructor _Trait = __pair_select_pair_like_constructible_v<const pair<_U1, _U2>&, _T1, _T2>,
+            enable_if_t<__is_deleted<_Trait>, int> = 0>
+  constexpr pair(const pair<_U1, _U2>&) = delete;
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _U1,
             class _U2,
@@ -396,6 +431,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
       : __base(::cuda::std::move(__p.first), ::cuda::std::move(__p.second))
   {}
 
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  template <class _U1,
+            class _U2,
+            __select_constructor _Trait = __pair_select_pair_like_constructible_v<pair<_U1, _U2>&&, _T1, _T2>,
+            enable_if_t<__is_deleted<_Trait>, int> = 0>
+  constexpr pair(pair<_U1, _U2>&&) = delete;
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+
   template <class _U1,
             class _U2,
             __select_constructor _Trait = __pair_select_pair_like_constructible_v<const pair<_U1, _U2>&&, _T1, _T2>,
@@ -413,6 +456,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
     is_nothrow_constructible_v<_T1, const _U1> && is_nothrow_constructible_v<_T2, const _U2>)
       : __base(::cuda::std::move(__p.first), ::cuda::std::move(__p.second))
   {}
+
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  template <class _U1,
+            class _U2,
+            __select_constructor _Trait = __pair_select_pair_like_constructible_v<const pair<_U1, _U2>&&, _T1, _T2>,
+            enable_if_t<__is_deleted<_Trait>, int> = 0>
+  constexpr pair(const pair<_U1, _U2>&&) = delete;
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   // NOLINTBEGIN(bugprone-forwarding-reference-overload)
   _CCCL_EXEC_CHECK_DISABLE
@@ -432,9 +483,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
           // NOLINTEND(bugprone-use-after-move)
         )
   {}
-  // NOLINTEND(bugprone-forwarding-reference-overload)
 
-  // NOLINTBEGIN(bugprone-forwarding-reference-overload)
   _CCCL_EXEC_CHECK_DISABLE
   template <class _UPair,
             enable_if_t<!is_same_v<remove_cvref_t<_UPair>, pair>, int> = 0,
@@ -446,6 +495,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
       : __base(::cuda::std::__adl_get<0>(::cuda::std::forward<_UPair>(__p)),
                ::cuda::std::__adl_get<1>(::cuda::std::forward<_UPair>(__p)))
   {}
+
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  template <class _UPair,
+            enable_if_t<!is_same_v<remove_cvref_t<_UPair>, pair>, int> = 0,
+            __select_constructor _Trait            = __pair_select_pair_like_constructible_v<_UPair, _T1, _T2>,
+            enable_if_t<__is_deleted<_Trait>, int> = 0>
+  _CCCL_API constexpr pair(_UPair&&) = delete;
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
   // NOLINTEND(bugprone-forwarding-reference-overload)
 
   template <class... _Args1, class... _Args2>

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/reference_constructs_from_temporary.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/reference_constructs_from_temporary.pass.cpp
@@ -14,7 +14,7 @@
 
 #include "test_macros.h"
 
-#ifdef _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
 
 struct SimpleClass
 {

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/from_temporaries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/from_temporaries.pass.cpp
@@ -1,0 +1,174 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/utility>
+
+// template <class T1, class T2> struct pair
+
+// template <pair-like Pair> EXPLICIT constexpr pair(Pair&& p);
+
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/complex>
+#include <cuda/std/tuple>
+#include <cuda/std/utility>
+
+#if _CCCL_HAS_HOST_STD_LIB()
+#  include <tuple>
+#  include <utility>
+#endif // _CCCL_HAS_HOST_STD_LIB()
+
+#include "copy_move_types.h"
+#include "test_macros.h"
+
+template <bool Expected, class Tuple, class... Args>
+TEST_FUNC void assert_constref_constructible_single()
+{
+  static_assert(cuda::std::is_constructible_v<Tuple, Args&...> == Expected);
+  static_assert(cuda::std::is_constructible_v<Tuple, Args...> == Expected);
+  static_assert(cuda::std::is_constructible_v<Tuple, const Args&...> == Expected);
+  static_assert(cuda::std::is_constructible_v<Tuple, const Args...> == Expected);
+  if constexpr (sizeof...(Args) == 2)
+  {
+    static_assert(cuda::std::is_constructible_v<Tuple, cuda::std::pair<Args...>&> == Expected);
+    static_assert(cuda::std::is_constructible_v<Tuple, const cuda::std::pair<Args...>&> == Expected);
+    static_assert(cuda::std::is_constructible_v<Tuple, cuda::std::pair<Args...>> == Expected);
+    static_assert(cuda::std::is_constructible_v<Tuple, const cuda::std::pair<Args...>> == Expected);
+
+#if _CCCL_HAS_HOST_STD_LIB()
+    static_assert(cuda::std::is_constructible_v<Tuple, std::pair<Args...>&> == Expected);
+    static_assert(cuda::std::is_constructible_v<Tuple, const std::pair<Args...>&> == Expected);
+    static_assert(cuda::std::is_constructible_v<Tuple, std::pair<Args...>> == Expected);
+    static_assert(cuda::std::is_constructible_v<Tuple, const std::pair<Args...>> == Expected);
+#endif // _CCCL_HAS_HOST_STD_LIB()
+  }
+
+  static_assert(cuda::std::is_constructible_v<Tuple, cuda::std::tuple<Args...>&> == Expected);
+  static_assert(cuda::std::is_constructible_v<Tuple, const cuda::std::tuple<Args...>&> == Expected);
+  static_assert(cuda::std::is_constructible_v<Tuple, cuda::std::tuple<Args...>> == Expected);
+  static_assert(cuda::std::is_constructible_v<Tuple, const cuda::std::tuple<Args...>> == Expected);
+
+#if _CCCL_HAS_HOST_STD_LIB()
+  static_assert(cuda::std::is_constructible_v<Tuple, std::tuple<Args...>&> == Expected);
+  static_assert(cuda::std::is_constructible_v<Tuple, const std::tuple<Args...>&> == Expected);
+  static_assert(cuda::std::is_constructible_v<Tuple, std::tuple<Args...>> == Expected);
+  static_assert(cuda::std::is_constructible_v<Tuple, const std::tuple<Args...>> == Expected);
+#endif // _CCCL_HAS_HOST_STD_LIB()
+}
+
+template <bool Expected, class Tuple, class... Args>
+TEST_FUNC void assert_mutref_constructible_single()
+{
+  static_assert(cuda::std::is_constructible_v<Tuple, Args...> == Expected);
+  if constexpr (sizeof...(Args) == 2)
+  {
+    static_assert(cuda::std::is_constructible_v<Tuple, cuda::std::pair<Args...>> == Expected);
+  }
+  static_assert(cuda::std::is_constructible_v<Tuple, cuda::std::tuple<Args...>> == Expected);
+
+#if _CCCL_HAS_HOST_STD_LIB()
+  if constexpr (sizeof...(Args) == 2)
+  {
+    static_assert(cuda::std::is_constructible_v<Tuple, std::pair<Args...>> == Expected);
+  }
+  static_assert(cuda::std::is_constructible_v<Tuple, std::tuple<Args...>> == Expected);
+#endif // _CCCL_HAS_HOST_STD_LIB()
+}
+
+TEST_FUNC void assert_normal_constructible()
+{
+  assert_constref_constructible_single<true, cuda::std::tuple<const int&>, int>();
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  assert_constref_constructible_single<false, cuda::std::tuple<const int&>, long>();
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+
+  assert_constref_constructible_single<true, cuda::std::tuple<const int&, const int&>, int, int>();
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  assert_constref_constructible_single<false, cuda::std::tuple<const int&, const int&>, long, int>();
+  assert_constref_constructible_single<false, cuda::std::tuple<const int&, const int&>, long, long>();
+  assert_constref_constructible_single<false, cuda::std::tuple<const int&, const int&>, int, long>();
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+
+  assert_mutref_constructible_single<true, cuda::std::tuple<int&&>, int>();
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  assert_mutref_constructible_single<false, cuda::std::tuple<int&&>, long>();
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+
+  assert_mutref_constructible_single<true, cuda::std::tuple<int&&, int&&>, int, int>();
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  assert_mutref_constructible_single<false, cuda::std::tuple<int&&, int&&>, long, int>();
+  assert_mutref_constructible_single<false, cuda::std::tuple<int&&, int&&>, long, long>();
+  assert_mutref_constructible_single<false, cuda::std::tuple<int&&, int&&>, int, long>();
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+}
+
+struct LvalueTempConverter
+{
+  TEST_FUNC operator int() &;
+  TEST_FUNC operator int&&() &&;
+  TEST_FUNC operator const int&() &&;
+};
+
+template <class Tuple, class... Args>
+TEST_FUNC void assert_lvalue_temp_converter_single()
+{
+  static_assert(cuda::std::is_constructible_v<Tuple, Args..., LvalueTempConverter>);
+  if constexpr (sizeof...(Args) == 1)
+  {
+    static_assert(cuda::std::is_constructible_v<Tuple, cuda::std::pair<Args..., LvalueTempConverter>>);
+  }
+  static_assert(cuda::std::is_constructible_v<Tuple, cuda::std::tuple<Args..., LvalueTempConverter>>);
+
+#if _CCCL_HAS_HOST_STD_LIB()
+  if constexpr (sizeof...(Args) == 1)
+  {
+    static_assert(cuda::std::is_constructible_v<Tuple, std::pair<Args..., LvalueTempConverter>>);
+  }
+  static_assert(cuda::std::is_constructible_v<Tuple, std::tuple<Args..., LvalueTempConverter>>);
+#endif // _CCCL_HAS_HOST_STD_LIB()
+
+// GCC 13 fails to properly consider the LvalueTempConverter
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY) && !TEST_COMPILER(GCC, <, 14)
+  static_assert(!cuda::std::is_constructible_v<Tuple, Args&..., LvalueTempConverter&>);
+  static_assert(!cuda::std::is_constructible_v<Tuple, cuda::std::tuple<Args&..., LvalueTempConverter&>>);
+  if constexpr (sizeof...(Args) == 1)
+  {
+    static_assert(!cuda::std::is_constructible_v<Tuple, cuda::std::pair<Args&..., LvalueTempConverter&>>);
+  }
+
+#  if _CCCL_HAS_HOST_STD_LIB()
+  static_assert(!cuda::std::is_constructible_v<Tuple, std::tuple<Args&..., LvalueTempConverter&>>);
+  if constexpr (sizeof...(Args) == 1)
+  {
+    static_assert(!cuda::std::is_constructible_v<Tuple, std::pair<Args&..., LvalueTempConverter&>>);
+  }
+#  endif // _CCCL_HAS_HOST_STD_LIB()
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY && !TEST_COMPILER(GCC, <, 14)
+}
+
+TEST_FUNC void assert_lvalue_temp_converter()
+{
+  assert_lvalue_temp_converter_single<cuda::std::tuple<const int&>>();
+  assert_lvalue_temp_converter_single<cuda::std::tuple<int&&>>();
+
+  assert_lvalue_temp_converter_single<cuda::std::tuple<const int&, const int&>, const int&>();
+}
+
+TEST_FUNC void test()
+{
+  assert_normal_constructible();
+  assert_lvalue_temp_converter();
+}
+
+int main(int, char**)
+{
+  test();
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/pairs/pairs.pair/convert_non_const_copy.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/pairs/pairs.pair/convert_non_const_copy.cpp
@@ -150,12 +150,6 @@ TEST_FUNC constexpr bool test()
 
     test_pair_non_const<ConvertingType&, int, false>();
     test_pair_non_const<ExplicitTypes::ConvertingType&, int, false>();
-    // Unfortunately the below conversions are allowed and create dangling
-    // references.
-    test_pair_non_const<ConvertingType&&, int>();
-    test_pair_non_const<ConvertingType const&, int>();
-    test_pair_non_const<ConvertingType const&&, int>();
-    // But these are not because the converting constructor is explicit.
     test_pair_non_const<ExplicitTypes::ConvertingType&&, int, false>();
     test_pair_non_const<ExplicitTypes::ConvertingType const&, int, false>();
     test_pair_non_const<ExplicitTypes::ConvertingType const&&, int, false>();

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/pairs/pairs.pair/convert_non_const_copy.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/pairs/pairs.pair/convert_non_const_copy.cpp
@@ -152,9 +152,9 @@ TEST_FUNC constexpr bool test()
     test_pair_non_const<ExplicitTypes::ConvertingType&, int, false>();
     // Unfortunately the below conversions are allowed and create dangling
     // references.
-    // test_pair_non_const<ConvertingType&&, int>();
-    // test_pair_non_const<ConvertingType const&, int>();
-    // test_pair_non_const<ConvertingType const&&, int>();
+    test_pair_non_const<ConvertingType&&, int>();
+    test_pair_non_const<ConvertingType const&, int>();
+    test_pair_non_const<ConvertingType const&&, int>();
     // But these are not because the converting constructor is explicit.
     test_pair_non_const<ExplicitTypes::ConvertingType&&, int, false>();
     test_pair_non_const<ExplicitTypes::ConvertingType const&, int, false>();

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/pairs/pairs.pair/from_temporaries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/pairs/pairs.pair/from_temporaries.pass.cpp
@@ -1,0 +1,137 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/utility>
+
+// template <class T1, class T2> struct pair
+
+// template <pair-like Pair> EXPLICIT constexpr pair(Pair&& p);
+
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/complex>
+#include <cuda/std/tuple>
+#include <cuda/std/utility>
+
+#if _CCCL_HAS_HOST_STD_LIB()
+#  include <tuple>
+#  include <utility>
+#endif // _CCCL_HAS_HOST_STD_LIB()
+
+#include "copy_move_types.h"
+#include "test_macros.h"
+
+template <bool Expected, class Pair, class... Args>
+TEST_FUNC void assert_constref_constructible_single()
+{
+  static_assert(cuda::std::is_constructible_v<Pair, Args&...> == Expected);
+  static_assert(cuda::std::is_constructible_v<Pair, Args...> == Expected);
+  static_assert(cuda::std::is_constructible_v<Pair, const Args&...> == Expected);
+  static_assert(cuda::std::is_constructible_v<Pair, const Args...> == Expected);
+
+  static_assert(cuda::std::is_constructible_v<Pair, cuda::std::pair<Args...>&> == Expected);
+  static_assert(cuda::std::is_constructible_v<Pair, const cuda::std::pair<Args...>&> == Expected);
+  static_assert(cuda::std::is_constructible_v<Pair, cuda::std::pair<Args...>> == Expected);
+  static_assert(cuda::std::is_constructible_v<Pair, const cuda::std::pair<Args...>> == Expected);
+
+#if _CCCL_HAS_HOST_STD_LIB()
+  static_assert(cuda::std::is_constructible_v<Pair, std::pair<Args...>&> == Expected);
+  static_assert(cuda::std::is_constructible_v<Pair, const std::pair<Args...>&> == Expected);
+  static_assert(cuda::std::is_constructible_v<Pair, std::pair<Args...>> == Expected);
+  static_assert(cuda::std::is_constructible_v<Pair, const std::pair<Args...>> == Expected);
+#endif // _CCCL_HAS_HOST_STD_LIB()
+
+  static_assert(cuda::std::is_constructible_v<Pair, cuda::std::tuple<Args...>&> == Expected);
+  static_assert(cuda::std::is_constructible_v<Pair, const cuda::std::tuple<Args...>&> == Expected);
+  static_assert(cuda::std::is_constructible_v<Pair, cuda::std::tuple<Args...>> == Expected);
+  static_assert(cuda::std::is_constructible_v<Pair, const cuda::std::tuple<Args...>> == Expected);
+
+#if _CCCL_HAS_HOST_STD_LIB()
+  static_assert(cuda::std::is_constructible_v<Pair, std::tuple<Args...>&> == Expected);
+  static_assert(cuda::std::is_constructible_v<Pair, const std::tuple<Args...>&> == Expected);
+  static_assert(cuda::std::is_constructible_v<Pair, std::tuple<Args...>> == Expected);
+  static_assert(cuda::std::is_constructible_v<Pair, const std::tuple<Args...>> == Expected);
+#endif // _CCCL_HAS_HOST_STD_LIB()
+}
+
+template <bool Expected, class Pair, class... Args>
+TEST_FUNC void assert_mutref_constructible_single()
+{
+  static_assert(cuda::std::is_constructible_v<Pair, Args...> == Expected);
+  static_assert(cuda::std::is_constructible_v<Pair, cuda::std::pair<Args...>> == Expected);
+  static_assert(cuda::std::is_constructible_v<Pair, cuda::std::tuple<Args...>> == Expected);
+
+#if _CCCL_HAS_HOST_STD_LIB()
+  static_assert(cuda::std::is_constructible_v<Pair, std::pair<Args...>> == Expected);
+  static_assert(cuda::std::is_constructible_v<Pair, std::tuple<Args...>> == Expected);
+#endif // _CCCL_HAS_HOST_STD_LIB()
+}
+
+TEST_FUNC void assert_normal_constructible()
+{
+  assert_constref_constructible_single<true, cuda::std::pair<const int&, const int&>, int, int>();
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  assert_constref_constructible_single<false, cuda::std::pair<const int&, const int&>, long, int>();
+  assert_constref_constructible_single<false, cuda::std::pair<const int&, const int&>, int, long>();
+  assert_constref_constructible_single<false, cuda::std::pair<const int&, const int&>, long, long>();
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+
+  assert_mutref_constructible_single<true, cuda::std::pair<int&&, int&&>, int, int>();
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+  assert_mutref_constructible_single<false, cuda::std::pair<int&&, int&&>, long, int>();
+  assert_mutref_constructible_single<false, cuda::std::pair<int&&, int&&>, int, long>();
+  assert_mutref_constructible_single<false, cuda::std::pair<int&&, int&&>, long, long>();
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+}
+
+struct LvalueTempConverter
+{
+  TEST_FUNC operator int() &;
+  TEST_FUNC operator int&&() &&;
+  TEST_FUNC operator const int&() &&;
+};
+
+template <class Pair, class... Args>
+TEST_FUNC void assert_lvalue_temp_converter_single()
+{
+  static_assert(cuda::std::is_constructible_v<Pair, Args..., LvalueTempConverter>);
+  static_assert(cuda::std::is_constructible_v<Pair, cuda::std::tuple<Args..., LvalueTempConverter>>);
+#if _CCCL_HAS_HOST_STD_LIB()
+  static_assert(cuda::std::is_constructible_v<Pair, std::tuple<Args..., LvalueTempConverter>>);
+#endif // _CCCL_HAS_HOST_STD_LIB()
+
+// GCC 13 fails to properly consider the LvalueTempConverter
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY) && !TEST_COMPILER(GCC, <, 14)
+  static_assert(!cuda::std::is_constructible_v<Pair, Args&..., LvalueTempConverter&>);
+  static_assert(!cuda::std::is_constructible_v<Pair, cuda::std::tuple<Args&..., LvalueTempConverter&>>);
+
+#  if _CCCL_HAS_HOST_STD_LIB()
+  static_assert(!cuda::std::is_constructible_v<Pair, std::tuple<Args&..., LvalueTempConverter&>>);
+#  endif // _CCCL_HAS_HOST_STD_LIB()
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY && !TEST_COMPILER(GCC, <, 14)
+}
+
+TEST_FUNC void assert_lvalue_temp_converter()
+{
+  assert_lvalue_temp_converter_single<cuda::std::pair<const int&, const int&>, const int&>();
+  assert_lvalue_temp_converter_single<cuda::std::pair<int&&, int&&>, int&&>();
+}
+
+TEST_FUNC void test()
+{
+  assert_normal_constructible();
+  assert_lvalue_temp_converter();
+}
+
+int main(int, char**)
+{
+  test();
+
+  return 0;
+}


### PR DESCRIPTION
With the new __tuple-like__ constructors we also get deleted constructors if the user tries to store a reference to a temporary

This is an important source of bugs, so we should adopt this too 