### PR TITLE
[CUB] Provide pointer traits to cache modified iterators

### DIFF
--- a/cub/cub/iterator/cache_modified_input_iterator.cuh
+++ b/cub/cub/iterator/cache_modified_input_iterator.cuh
@@ -27,6 +27,7 @@
 
 #include <cuda/std/__host_stdlib/ostream>
 #include <cuda/std/__iterator/iterator_traits.h>
+#include <cuda/std/__memory/pointer_traits.h>
 #include <cuda/std/__type_traits/remove_cv.h>
 #include <cuda/std/__utility/declval.h>
 
@@ -213,6 +214,12 @@ public:
     return os;
   }
 #endif // _CCCL_HOSTED()
+
+  /// Structure dereference
+  _CCCL_HOST_DEVICE_API ValueType* __unwrap() const noexcept
+  {
+    return ptr;
+  }
 };
 
 namespace detail
@@ -243,3 +250,24 @@ using try_make_cache_modified_iterator_t =
 } // namespace detail
 
 CUB_NAMESPACE_END
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+template <CUB_NS_QUALIFIER::CacheLoadModifier MODIFIER, typename ValueType, typename OffsetT>
+struct pointer_traits<CUB_NS_QUALIFIER::CacheModifiedInputIterator<MODIFIER, ValueType, OffsetT>,
+                      enable_if_t<MODIFIER != LOAD_CV && MODIFIER != LOAD_VOLATILE>>
+{
+  using pointer         = CUB_NS_QUALIFIER::CacheModifiedInputIterator<MODIFIER, ValueType, OffsetT>;
+  using element_type    = ValueType;
+  using difference_type = OffsetT;
+
+  //! @brief Retrieve the address of the element pointed at by a CacheModifiedInputIterator
+  //! @param iter A CacheModifiedInputIterator
+  //! @return A pointer to the element pointed to by the CacheModifiedInputIterator
+  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr ValueType* to_address(const pointer iter) noexcept
+  {
+    return iter.__unwrap();
+  }
+};
+
+_CCCL_END_NAMESPACE_CUDA_STD

--- a/cub/test/catch2_test_iterator.cu
+++ b/cub/test/catch2_test_iterator.cu
@@ -91,32 +91,46 @@ void test_iterator(InputIteratorT d_in, const c2h::host_vector<T>& h_reference)
 
 static_assert(cuda::std::is_void_v<cub::detail::it_value_t<cub::CacheModifiedOutputIterator<cub::STORE_DEFAULT, int>>>);
 
-// using cache_modifiers =
-//   c2h::enum_type_list<cub::CacheLoadModifier,
-//                       cub::LOAD_DEFAULT,
-//                       cub::LOAD_CA,
-//                       cub::LOAD_CG,
-//                       cub::LOAD_CS,
-//                       cub::LOAD_CV,
-//                       cub::LOAD_LDG,
-//                       cub::LOAD_VOLATILE>;
-//
-// C2H_TEST("Test cache modified iterator", "[iterator]", types, cache_modifiers)
-// {
-//   using T                       = c2h::get<0, TestType>;
-//   constexpr auto cache_modifier = c2h::get<1, TestType>::value;
-//   constexpr int TEST_VALUES     = 11000;
-//
-//   c2h::device_vector<T> d_data(TEST_VALUES);
-//   c2h::gen(C2H_SEED(1), d_data);
-//   c2h::host_vector<T> h_data(d_data);
-//
-//   const auto h_reference = c2h::host_vector<T>{
-//     h_data[0], h_data[100], h_data[1000], h_data[10000], h_data[1], h_data[21], h_data[11], h_data[0]};
-//   test_iterator(
-//     cub::CacheModifiedInputIterator<cache_modifier, T>(const_cast<const
-//     T*>(thrust::raw_pointer_cast(d_data.data()))), h_reference);
-// }
+using cache_modifiers =
+  c2h::enum_type_list<cub::CacheLoadModifier,
+                      cub::LOAD_DEFAULT,
+                      cub::LOAD_CA,
+                      cub::LOAD_CG,
+                      cub::LOAD_CS,
+                      cub::LOAD_CV,
+                      cub::LOAD_LDG,
+                      cub::LOAD_VOLATILE>;
+
+C2H_TEST("Test cache modified iterator", "[iterator]", types, cache_modifiers)
+{
+  using T                       = c2h::get<0, TestType>;
+  constexpr auto cache_modifier = c2h::get<1, TestType>::value;
+  constexpr int TEST_VALUES     = 11000;
+
+  c2h::device_vector<T> d_data(TEST_VALUES);
+  c2h::gen(C2H_SEED(1), d_data);
+  c2h::host_vector<T> h_data(d_data);
+
+  const auto h_reference = c2h::host_vector<T>{
+    h_data[0], h_data[100], h_data[1000], h_data[10000], h_data[1], h_data[21], h_data[11], h_data[0]};
+  test_iterator(
+    cub::CacheModifiedInputIterator<cache_modifier, T>(const_cast<const T*>(thrust::raw_pointer_cast(d_data.data()))),
+    h_reference);
+
+  if constexpr (cache_modifier != cub::LOAD_CV && cache_modifier != cub::LOAD_VOLATILE)
+  { // Test that pointer traits work as intended
+    T* raw_pointer = thrust::raw_pointer_cast(d_data.data());
+    cub::CacheModifiedInputIterator<cache_modifier, T> iter{raw_pointer};
+    CHECK(raw_pointer == cuda::std::to_address(iter));
+  }
+
+  if constexpr (cache_modifier != cub::LOAD_CV && cache_modifier != cub::LOAD_VOLATILE)
+  { // Test that pointer traits work as intended with const pointer
+    const T* raw_pointer = const_cast<const T*>(thrust::raw_pointer_cast(d_data.data()));
+    cub::CacheModifiedInputIterator<cache_modifier, T> iter{raw_pointer};
+    CHECK(raw_pointer == cuda::std::to_address(iter));
+  }
+}
 
 template <typename T>
 struct transform_op_t


### PR DESCRIPTION
This provides `pointer_traits` to the cache modified iterators

Its a bit dangerous, because it essentially drops the cache modifiers on the floor, but at the same time if we want to use a raw pointer anyway we might as well do the thing.

We could also just enable it for the default cases and leave .eg. volatile loads out
