### PR TITLE
[cudax] Add `unit_` prefix to unit-related data in mapping result

### DIFF
--- a/cudax/include/cuda/experimental/__coop/reduce.cuh
+++ b/cudax/include/cuda/experimental/__coop/reduce.cuh
@@ -305,7 +305,7 @@ __reduce_impl(::cuda::std::bool_constant<_Broadcasted>, _Group __group, _Tp (&__
   auto __result          = ::cub::ThreadReduce(__thread_data, __red_fn);
 
   _CCCL_PRAGMA_UNROLL_FULL()
-  for (unsigned __stride = 1; __stride < ::cuda::next_power_of_two(__mapping_result.count()); __stride *= 2)
+  for (unsigned __stride = 1; __stride < ::cuda::next_power_of_two(__mapping_result.unit_count()); __stride *= 2)
   {
     const auto __other = ::cuda::experimental::coop::shuffle_down(__group, __result, __stride);
     if (__other.has_value())
@@ -321,7 +321,7 @@ __reduce_impl(::cuda::std::bool_constant<_Broadcasted>, _Group __group, _Tp (&__
   }
   else
   {
-    return (__mapping_result.rank() == 0) ? ::cuda::std::optional{__result} : ::cuda::std::nullopt;
+    return (__mapping_result.unit_rank() == 0) ? ::cuda::std::optional{__result} : ::cuda::std::nullopt;
   }
 }
 

--- a/cudax/include/cuda/experimental/__coop/shuffle.cuh
+++ b/cudax/include/cuda/experimental/__coop/shuffle.cuh
@@ -42,16 +42,16 @@ template <bool _Dummy = false>
 _CCCL_TEMPLATE(class _Group, class _Tp)
 _CCCL_REQUIRES(is_group<_Group> _CCCL_AND ::cuda::std::is_same_v<typename _Group::unit_type, thread_level>
                  _CCCL_AND ::cuda::std::is_same_v<typename _Group::level_type, warp_level>)
-[[nodiscard]] _CCCL_DEVICE_API _Tp __shuffle_impl(const _Group& __group, _Tp __value, unsigned __src_rank) noexcept
+[[nodiscard]] _CCCL_DEVICE_API _Tp __shuffle_impl(const _Group& __group, _Tp __value, unsigned __src_unit_rank) noexcept
 {
   using _MappingResult         = typename _Group::__mapping_result_type;
   const auto& __mapping_result = __group.__mapping_result();
 
-  _CCCL_ASSERT(__src_rank < __mapping_result.count(),
-               "invalid __src_rank - must be less than the number of units within the group");
+  _CCCL_ASSERT(__src_unit_rank < __mapping_result.unit_count(),
+               "invalid __src_unit_rank - must be less than the number of units within the group");
 
   const auto __lane_mask   = __mapping_result.lane_mask();
-  const auto __lane_offset = static_cast<int>(__src_rank) - static_cast<int>(__mapping_result.rank());
+  const auto __lane_offset = static_cast<int>(__src_unit_rank) - static_cast<int>(__mapping_result.unit_rank());
 
   unsigned __src_lane{};
   if constexpr (_MappingResult::is_always_contiguous())
@@ -61,7 +61,7 @@ _CCCL_REQUIRES(is_group<_Group> _CCCL_AND ::cuda::std::is_same_v<typename _Group
   }
   else
   {
-    __src_lane = ::__fns(__lane_mask.value(), 0, static_cast<int>(__src_rank) + 1);
+    __src_lane = ::__fns(__lane_mask.value(), 0, static_cast<int>(__src_unit_rank) + 1);
   }
   return ::cuda::device::warp_shuffle_idx(__value, static_cast<int>(__src_lane), __lane_mask.value());
 }
@@ -69,12 +69,12 @@ _CCCL_REQUIRES(is_group<_Group> _CCCL_AND ::cuda::std::is_same_v<typename _Group
 //! @brief Shuffles values among units within a group.
 //! @param[in] __group The group.
 //! @param[in] __value This thread's value to be shuffled.
-//! @param[in] __src_rank The rank of the unit whose value should be taken by this unit.
+//! @param[in] __src_unit_rank The rank of the unit whose value should be taken by this unit.
 //! @return The value passed to the function by the equivalent thread from the source rank unit.
 template <class _Group, class _Tp>
-[[nodiscard]] _CCCL_DEVICE_API _Tp shuffle(const _Group& __group, _Tp __value, unsigned __src_rank) noexcept
+[[nodiscard]] _CCCL_DEVICE_API _Tp shuffle(const _Group& __group, _Tp __value, unsigned __src_unit_rank) noexcept
 {
-  return ::cuda::experimental::coop::__shuffle_impl(__group, __value, __src_rank);
+  return ::cuda::experimental::coop::__shuffle_impl(__group, __value, __src_unit_rank);
 }
 } // namespace cuda::experimental::coop
 

--- a/cudax/include/cuda/experimental/__coop/shuffle_down.cuh
+++ b/cudax/include/cuda/experimental/__coop/shuffle_down.cuh
@@ -50,7 +50,7 @@ __shuffle_down_impl(const _Group& __group, const _Tp& __value, unsigned __offset
   const auto& __mapping_result = __group.__mapping_result();
 
   const auto __lane_mask       = __mapping_result.lane_mask();
-  const auto __offset_is_valid = (__offset < __mapping_result.count() - __mapping_result.rank());
+  const auto __offset_is_valid = (__offset < __mapping_result.unit_count() - __mapping_result.unit_rank());
 
   if constexpr (_MappingResult::is_always_contiguous())
   {
@@ -72,7 +72,7 @@ __shuffle_down_impl(const _Group& __group, const _Tp& __value, unsigned __offset
 //! @brief Gets the values from a unit with a greater rank by the specified offset.
 //! @param[in] __group The group.
 //! @param[in] __value This thread's value.
-//! @param[in] __offset The offset of the source rank from this unit's rank.
+//! @param[in] __offset The offset of the source unit rank from this unit's rank.
 //! @return The source's value or empty optional if no such rank exists.
 template <class _Group, class _Tp>
 [[nodiscard]] _CCCL_DEVICE_API ::cuda::std::optional<_Tp>

--- a/cudax/include/cuda/experimental/__coop/shuffle_up.cuh
+++ b/cudax/include/cuda/experimental/__coop/shuffle_up.cuh
@@ -51,7 +51,7 @@ __shuffle_up_impl(const _Group& __group, const _Tp& __value, unsigned __offset) 
   const auto& __mapping_result = __group.__mapping_result();
 
   const auto __lane_mask               = __mapping_result.lane_mask();
-  const auto [__src_rank, __underflow] = ::cuda::sub_overflow(__mapping_result.rank(), __offset);
+  const auto [__src_rank, __underflow] = ::cuda::sub_overflow(__mapping_result.unit_rank(), __offset);
   const auto __offset_is_valid         = !__underflow;
 
   if constexpr (_MappingResult::is_always_contiguous())
@@ -74,7 +74,7 @@ __shuffle_up_impl(const _Group& __group, const _Tp& __value, unsigned __offset) 
 //! @brief Gets the values from a unit with a lower rank by the specified offset.
 //! @param[in] __group The group.
 //! @param[in] __value This thread's value.
-//! @param[in] __offset The offset of the source rank from this unit's rank.
+//! @param[in] __offset The offset of the source unit rank from this unit's rank.
 //! @return The source's value or empty optional if no such rank exists.
 template <class _Group, class _Tp>
 [[nodiscard]] _CCCL_DEVICE_API ::cuda::std::optional<_Tp>

--- a/cudax/include/cuda/experimental/__group/concepts.cuh
+++ b/cudax/include/cuda/experimental/__group/concepts.cuh
@@ -53,9 +53,9 @@ _CCCL_CONCEPT __group_mapping_result = _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __v
   _Same_as(::cuda::std::size_t) _Tp::static_group_count(),
   _Same_as(unsigned) __v.group_count(),
   _Same_as(unsigned) __v.group_rank(),
-  _Same_as(::cuda::std::size_t) _Tp::static_count(),
-  _Same_as(unsigned) __v.count(),
-  _Same_as(unsigned) __v.rank(),
+  _Same_as(::cuda::std::size_t) _Tp::static_unit_count(),
+  _Same_as(unsigned) __v.unit_count(),
+  _Same_as(unsigned) __v.unit_rank(),
   _Same_as(::cuda::device::lane_mask) __v.lane_mask(),
   _Same_as(bool) _Tp::is_always_exhaustive(),
   _Same_as(bool) _Tp::is_always_contiguous());

--- a/cudax/include/cuda/experimental/__group/fwd.cuh
+++ b/cudax/include/cuda/experimental/__group/fwd.cuh
@@ -72,7 +72,7 @@ class group;
 template <class _Fn>
 class binary_partition;
 
-template <::cuda::std::size_t _Count = ::cuda::std::dynamic_extent, bool _IsExhaustive = true>
+template <::cuda::std::size_t _UnitCount = ::cuda::std::dynamic_extent, bool _IsExhaustive = true>
 class group_by;
 
 template <class _Data, bool _IsExahustive>
@@ -104,8 +104,8 @@ inline constexpr bool __is_this_group_v<this_grid<_Hierarchy>> = true;
 
 template <class _Tp>
 inline constexpr bool __is_group_mapping_v = false;
-template <::cuda::std::size_t _Count, bool _IsExhaustive>
-inline constexpr bool __is_group_mapping_v<group_by<_Count, _IsExhaustive>> = true;
+template <::cuda::std::size_t _UnitCount, bool _IsExhaustive>
+inline constexpr bool __is_group_mapping_v<group_by<_UnitCount, _IsExhaustive>> = true;
 template <class _Data, bool _IsExhaustive>
 inline constexpr bool __is_group_mapping_v<group_as<_Data, _IsExhaustive>> = true;
 

--- a/cudax/include/cuda/experimental/__group/group.cuh
+++ b/cudax/include/cuda/experimental/__group/group.cuh
@@ -98,14 +98,14 @@ class group
     if (__mapping_result.is_valid())
     {
       _CCCL_ASSERT(__mapping_result.group_rank() < __mapping_result.group_count(), "invalid group rank");
-      _CCCL_ASSERT(__mapping_result.rank() < __mapping_result.count(), "invalid rank");
+      _CCCL_ASSERT(__mapping_result.unit_rank() < __mapping_result.unit_count(), "invalid unit rank");
 
       if constexpr (::cuda::std::is_same_v<_Unit, thread_level>)
       {
         _CCCL_ASSERT(
           (__mapping_result.lane_mask() & ::cuda::device::lane_mask::this_lane()) != ::cuda::device::lane_mask::none(),
           "invalid lane mask - this lane must be contained in the lane mask");
-        _CCCL_ASSERT(::cuda::std::popcount(__mapping_result.lane_mask().value()) <= __mapping_result.count(),
+        _CCCL_ASSERT(::cuda::std::popcount(__mapping_result.lane_mask().value()) <= __mapping_result.unit_count(),
                      "invalid lane mask - too many lanes are set in the lane mask");
       }
       else

--- a/cudax/include/cuda/experimental/__group/mapping/group_as.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/group_as.cuh
@@ -43,16 +43,16 @@
 
 namespace cuda::experimental
 {
-template <::cuda::std::size_t... _Counts>
+template <::cuda::std::size_t... _UnitCounts>
 struct __group_as_static_tag;
 
-template <::cuda::std::size_t... _Counts, bool _IsExhaustive>
-class group_as<__group_as_static_tag<_Counts...>, _IsExhaustive>
+template <::cuda::std::size_t... _UnitCounts, bool _IsExhaustive>
+class group_as<__group_as_static_tag<_UnitCounts...>, _IsExhaustive>
 {
-  static_assert(((_Counts != 0) && ...), "all _Counts must not be zero");
-  static_assert((::cuda::std::in_range<unsigned>(_Counts) && ...), "all _Counts must be within uint32_t range");
+  static_assert(((_UnitCounts != 0) && ...), "all _UnitCounts must not be zero");
+  static_assert((::cuda::std::in_range<unsigned>(_UnitCounts) && ...), "all _UnitCounts must be within uint32_t range");
 
-  static constexpr auto __counts_sum = (0 + ... + _Counts);
+  static constexpr auto __counts_sum = (0 + ... + _UnitCounts);
 
 public:
   _CCCL_HIDE_FROM_ABI explicit group_as() = default;
@@ -60,27 +60,27 @@ public:
   _CCCL_TEMPLATE(bool _IsExhaustive2 = _IsExhaustive)
   _CCCL_REQUIRES(_IsExhaustive2)
   _CCCL_DEVICE_API explicit constexpr group_as(
-    const ::cuda::std::integer_sequence<::cuda::std::size_t, _Counts...>&) noexcept
+    const ::cuda::std::integer_sequence<::cuda::std::size_t, _UnitCounts...>&) noexcept
   {}
 
   _CCCL_TEMPLATE(bool _IsExhaustive2 = _IsExhaustive)
   _CCCL_REQUIRES((!_IsExhaustive2))
-  _CCCL_DEVICE_API explicit constexpr group_as(const ::cuda::std::integer_sequence<::cuda::std::size_t, _Counts...>&,
-                                               const non_exhaustive_t&) noexcept
+  _CCCL_DEVICE_API explicit constexpr group_as(
+    const ::cuda::std::integer_sequence<::cuda::std::size_t, _UnitCounts...>&, const non_exhaustive_t&) noexcept
   {}
 
   [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_group_count() noexcept
   {
-    return sizeof...(_Counts);
+    return sizeof...(_UnitCounts);
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_count(::cuda::std::size_t __i) noexcept
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_unit_count(::cuda::std::size_t __i) noexcept
   {
-    if (__i >= sizeof...(_Counts))
+    if (__i >= sizeof...(_UnitCounts))
     {
       _CCCL_THROW(::std::out_of_range, "__i is out of range");
     }
-    constexpr ::cuda::std::size_t __counts[]{_Counts...};
+    constexpr ::cuda::std::size_t __counts[]{_UnitCounts...};
     return __counts[__i];
   }
 
@@ -89,9 +89,9 @@ public:
     return _IsExhaustive;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API constexpr unsigned count(::cuda::std::size_t __i) const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API constexpr unsigned unit_count(::cuda::std::size_t __i) const noexcept
   {
-    return static_cast<unsigned>(static_count(__i));
+    return static_cast<unsigned>(static_unit_count(__i));
   }
 
   template <class _Unit, class _ParentGroup, class _PrevMappingResult>
@@ -99,8 +99,8 @@ public:
   map(const _Unit&, const _ParentGroup&, const _PrevMappingResult& __prev_mapping_result) const noexcept
   {
     constexpr auto __static_prev_ngroups = _PrevMappingResult::static_group_count();
-    constexpr auto __static_prev_nunits  = _PrevMappingResult::static_count();
-    constexpr auto __static_curr_ngroups = sizeof...(_Counts);
+    constexpr auto __static_prev_nunits  = _PrevMappingResult::static_unit_count();
+    constexpr auto __static_curr_ngroups = sizeof...(_UnitCounts);
     constexpr auto __static_ngroups =
       (__static_prev_ngroups != ::cuda::std::dynamic_extent)
         ? (__static_prev_ngroups * __static_curr_ngroups)
@@ -117,9 +117,9 @@ public:
       return _MappingResult::invalid();
     }
 
-    const auto __prev_nunits      = __prev_mapping_result.count();
-    const auto __prev_unit_rank   = __prev_mapping_result.rank();
-    constexpr auto __curr_ngroups = static_cast<unsigned>(sizeof...(_Counts));
+    const auto __prev_nunits      = __prev_mapping_result.unit_count();
+    const auto __prev_unit_rank   = __prev_mapping_result.unit_rank();
+    constexpr auto __curr_ngroups = static_cast<unsigned>(sizeof...(_UnitCounts));
     const auto __ngroups          = __prev_mapping_result.group_count() * __curr_ngroups;
 
     if constexpr (_IsExhaustive)
@@ -156,7 +156,7 @@ public:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (unsigned __i = 0; __i < __curr_ngroups; ++__i)
     {
-      const auto __i_count = count(__i);
+      const auto __i_count = unit_count(__i);
       if (__prev_unit_rank < __sum + __i_count)
       {
         const auto __group_rank = __prev_mapping_result.group_rank() * __curr_ngroups + __i;
@@ -216,7 +216,7 @@ public:
     return _GroupCount;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_count(::cuda::std::size_t __i) noexcept
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_unit_count(::cuda::std::size_t __i) noexcept
   {
     if (__i >= _GroupCount)
     {
@@ -230,7 +230,7 @@ public:
     return _IsExhaustive;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API constexpr unsigned count(::cuda::std::size_t __i) const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API constexpr unsigned unit_count(::cuda::std::size_t __i) const noexcept
   {
     if (__i >= _GroupCount)
     {
@@ -244,7 +244,7 @@ public:
   map(const _Unit&, const _ParentGroup&, const _PrevMappingResult& __prev_mapping_result) const noexcept
   {
     constexpr auto __static_prev_ngroups = _PrevMappingResult::static_group_count();
-    constexpr auto __static_prev_nunits  = _PrevMappingResult::static_count();
+    constexpr auto __static_prev_nunits  = _PrevMappingResult::static_unit_count();
     constexpr auto __static_curr_ngroups = _GroupCount;
     constexpr auto __static_ngroups =
       (__static_prev_ngroups != ::cuda::std::dynamic_extent)
@@ -262,8 +262,8 @@ public:
       return _MappingResult::invalid();
     }
 
-    const auto __prev_nunits      = __prev_mapping_result.count();
-    const auto __prev_unit_rank   = __prev_mapping_result.rank();
+    const auto __prev_nunits      = __prev_mapping_result.unit_count();
+    const auto __prev_unit_rank   = __prev_mapping_result.unit_rank();
     constexpr auto __curr_ngroups = static_cast<unsigned>(_GroupCount);
     const auto __ngroups          = __prev_mapping_result.group_count() * __curr_ngroups;
 
@@ -282,7 +282,7 @@ public:
     _CCCL_PRAGMA_UNROLL_FULL()
     for (unsigned __i = 0; __i < __curr_ngroups; ++__i)
     {
-      const auto __i_count = count(__i);
+      const auto __i_count = unit_count(__i);
       if (__prev_unit_rank < __sum + __i_count)
       {
         const auto __group_rank = __prev_mapping_result.group_rank() * __curr_ngroups + __i;
@@ -301,13 +301,13 @@ public:
   }
 };
 
-template <::cuda::std::size_t... _Counts>
-_CCCL_DEVICE group_as(const ::cuda::std::integer_sequence<::cuda::std::size_t, _Counts...>&)
-  -> group_as<__group_as_static_tag<_Counts...>, true>;
+template <::cuda::std::size_t... _UnitCounts>
+_CCCL_DEVICE group_as(const ::cuda::std::integer_sequence<::cuda::std::size_t, _UnitCounts...>&)
+  -> group_as<__group_as_static_tag<_UnitCounts...>, true>;
 
-template <::cuda::std::size_t... _Counts>
-_CCCL_DEVICE group_as(const ::cuda::std::integer_sequence<::cuda::std::size_t, _Counts...>&, const non_exhaustive_t&)
-  -> group_as<__group_as_static_tag<_Counts...>, false>;
+template <::cuda::std::size_t... _UnitCounts>
+_CCCL_DEVICE group_as(const ::cuda::std::integer_sequence<::cuda::std::size_t, _UnitCounts...>&,
+                      const non_exhaustive_t&) -> group_as<__group_as_static_tag<_UnitCounts...>, false>;
 
 _CCCL_TEMPLATE(class _Tp)
 _CCCL_REQUIRES(__is_spannable<_Tp> _CCCL_AND ::cuda::std::

--- a/cudax/include/cuda/experimental/__group/mapping/group_by.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/group_by.cuh
@@ -51,11 +51,11 @@ _CCCL_DEVICE constexpr non_exhaustive_t non_exhaustive;
 //   `__group_mapping_result` concept
 
 // todo(dabayer): do we want to add stride parameter?
-template <::cuda::std::size_t _Count, bool _IsExhaustive>
+template <::cuda::std::size_t _UnitCount, bool _IsExhaustive>
 class group_by
 {
-  static_assert(_Count != 0, "_Count must not be zero");
-  static_assert(::cuda::std::in_range<unsigned>(_Count), "_Count must be within uint32_t range");
+  static_assert(_UnitCount != 0, "_UnitCount must not be zero");
+  static_assert(::cuda::std::in_range<unsigned>(_UnitCount), "_UnitCount must be within uint32_t range");
 
 public:
   _CCCL_HIDE_FROM_ABI explicit group_by() = default;
@@ -64,9 +64,9 @@ public:
   _CCCL_REQUIRES((!_IsExhaustive))
   _CCCL_DEVICE_API constexpr group_by(const non_exhaustive_t&) noexcept {}
 
-  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_count() noexcept
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_unit_count() noexcept
   {
-    return _Count;
+    return _UnitCount;
   }
 
   [[nodiscard]] _CCCL_DEVICE_API static constexpr bool is_always_exhaustive() noexcept
@@ -74,9 +74,9 @@ public:
     return _IsExhaustive;
   }
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr unsigned count() const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr unsigned unit_count() const noexcept
   {
-    return static_cast<unsigned>(_Count);
+    return static_cast<unsigned>(_UnitCount);
   }
 
   template <class _Unit, class _ParentGroup, class _PrevMappingResult>
@@ -84,10 +84,10 @@ public:
   map(const _Unit&, const _ParentGroup& __parent, const _PrevMappingResult& __prev_mapping_result) const noexcept
   {
     constexpr auto __static_prev_ngroups = _PrevMappingResult::static_group_count();
-    constexpr auto __static_prev_nunits  = _PrevMappingResult::static_count();
+    constexpr auto __static_prev_nunits  = _PrevMappingResult::static_unit_count();
     constexpr auto __static_curr_ngroups =
       (__static_prev_nunits != ::cuda::std::dynamic_extent)
-        ? __static_prev_nunits / _Count
+        ? __static_prev_nunits / _UnitCount
         : ::cuda::std::dynamic_extent;
     constexpr auto __static_ngroups =
       (__static_prev_ngroups != ::cuda::std::dynamic_extent && __static_curr_ngroups != ::cuda::std::dynamic_extent)
@@ -96,7 +96,7 @@ public:
 
     using _MappingResult =
       __mapping_result<__static_ngroups,
-                       _Count,
+                       _UnitCount,
                        _PrevMappingResult::is_always_exhaustive() && _IsExhaustive,
                        _PrevMappingResult::is_always_contiguous()>;
 
@@ -105,10 +105,10 @@ public:
       return _MappingResult::invalid();
     }
 
-    const auto __prev_nunits     = __prev_mapping_result.count();
-    const auto __prev_unit_rank  = __prev_mapping_result.rank();
-    const auto __curr_ngroups    = __prev_nunits / count();
-    const auto __curr_group_rank = __prev_unit_rank / count();
+    const auto __prev_nunits     = __prev_mapping_result.unit_count();
+    const auto __prev_unit_rank  = __prev_mapping_result.unit_rank();
+    const auto __curr_ngroups    = __prev_nunits / unit_count();
+    const auto __curr_group_rank = __prev_unit_rank / unit_count();
     const auto __ngroups         = __prev_mapping_result.group_count() * __curr_ngroups;
 
     // If the mapping is exhaustive, check the preconditions, otherwise return invalid mapping for the remainder.
@@ -116,14 +116,14 @@ public:
     {
       if constexpr (__static_prev_nunits != ::cuda::std::dynamic_extent)
       {
-        static_assert(__static_prev_nunits % _Count == 0, "group_by mapping _IsExhaustive precondition violation");
+        static_assert(__static_prev_nunits % _UnitCount == 0, "group_by mapping _IsExhaustive precondition violation");
       }
       else
       {
-        _CCCL_ASSERT(__prev_nunits % count() == 0, "group_by mapping _IsExhaustive precondition violation");
+        _CCCL_ASSERT(__prev_nunits % unit_count() == 0, "group_by mapping _IsExhaustive precondition violation");
       }
     }
-    else if (__prev_nunits % count() != 0)
+    else if (__prev_nunits % unit_count() != 0)
     {
       if (__curr_group_rank >= __curr_ngroups)
       {
@@ -132,7 +132,7 @@ public:
     }
 
     const auto __group_rank = __prev_mapping_result.group_rank() * __curr_ngroups + __curr_group_rank;
-    const auto __n          = count();
+    const auto __n          = unit_count();
     const auto __rank       = __prev_unit_rank % __n;
     const auto __lane_mask =
       (::cuda::std::is_same_v<_Unit, thread_level>)
@@ -163,7 +163,7 @@ public:
     _CCCL_ASSERT(__count > 0, "__count cannot be 0");
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_count() noexcept
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_unit_count() noexcept
   {
     return ::cuda::std::dynamic_extent;
   }
@@ -173,7 +173,7 @@ public:
     return _IsExhaustive;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API constexpr unsigned count() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API constexpr unsigned unit_count() const noexcept
   {
     return __count_;
   }
@@ -193,8 +193,8 @@ public:
       return _MappingResult::invalid();
     }
 
-    const auto __prev_nunits     = __prev_mapping_result.count();
-    const auto __prev_unit_rank  = __prev_mapping_result.rank();
+    const auto __prev_nunits     = __prev_mapping_result.unit_count();
+    const auto __prev_unit_rank  = __prev_mapping_result.unit_rank();
     const auto __curr_ngroups    = __prev_nunits / __count_;
     const auto __curr_group_rank = __prev_unit_rank / __count_;
     const auto __ngroups         = __prev_mapping_result.group_count() * __curr_ngroups;

--- a/cudax/include/cuda/experimental/__group/mapping/mapping_result.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/mapping_result.cuh
@@ -41,8 +41,8 @@ struct __mapping_result
 {
   unsigned __group_count_;
   unsigned __group_rank_;
-  unsigned __count_;
-  unsigned __rank_;
+  unsigned __unit_count_;
+  unsigned __unit_rank_;
   ::cuda::device::lane_mask __lane_mask_;
 
   [[nodiscard]] _CCCL_DEVICE_API static constexpr __mapping_result invalid() noexcept
@@ -95,12 +95,12 @@ struct __mapping_result
     return __group_rank_;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_count() noexcept
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_unit_count() noexcept
   {
     return _StaticCount;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API unsigned count() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API unsigned unit_count() const noexcept
   {
     if constexpr (_StaticCount != ::cuda::std::dynamic_extent)
     {
@@ -112,17 +112,17 @@ struct __mapping_result
       {
         _CCCL_ASSERT(is_valid(), "getting group rank of thread that is not part of the group is UB");
       }
-      return __count_;
+      return __unit_count_;
     }
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API unsigned rank() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API unsigned unit_rank() const noexcept
   {
     if constexpr (!_IsExhaustive)
     {
-      _CCCL_ASSERT(is_valid(), "getting rank of thread that is not part of the group is UB");
+      _CCCL_ASSERT(is_valid(), "getting unit rank of thread that is not part of the group is UB");
     }
-    return __rank_;
+    return __unit_rank_;
   }
 
   [[nodiscard]] _CCCL_DEVICE_API ::cuda::device::lane_mask lane_mask() const noexcept
@@ -142,7 +142,7 @@ struct __mapping_result
     }
     else
     {
-      return __rank_ != __invalid_count_or_rank;
+      return __unit_rank_ != __invalid_count_or_rank;
     }
   }
 

--- a/cudax/include/cuda/experimental/__group/queries.cuh
+++ b/cudax/include/cuda/experimental/__group/queries.cuh
@@ -39,7 +39,7 @@ template <class _Unit, class _Group>
   using _GroupUnit          = typename _Group::unit_type;
   using _GroupMappingResult = typename _Group::__mapping_result_type;
 
-  constexpr auto __group_unit_count = _GroupMappingResult::static_count();
+  constexpr auto __group_unit_count = _GroupMappingResult::static_unit_count();
 
   if constexpr (::cuda::std::is_same_v<_Unit, _GroupUnit>)
   {
@@ -78,7 +78,7 @@ template <class _Tp, class _Unit, class _Group>
   // }
   // else
   {
-    const auto __group_unit_count = static_cast<_Tp>(__group.__mapping_result().count());
+    const auto __group_unit_count = static_cast<_Tp>(__group.__mapping_result().unit_count());
     if constexpr (::cuda::std::is_same_v<_Unit, _GroupUnit>)
     {
       return __group_unit_count;
@@ -96,7 +96,7 @@ template <class _Tp, class _Unit, class _Group>
 {
   using _GroupUnit = typename _Group::unit_type;
 
-  const auto __group_unit_rank = static_cast<_Tp>(__group.__mapping_result().rank());
+  const auto __group_unit_rank = static_cast<_Tp>(__group.__mapping_result().unit_rank());
   if constexpr (::cuda::std::is_same_v<_Unit, _GroupUnit>)
   {
     return __group_unit_rank;

--- a/cudax/include/cuda/experimental/__group/synchronizer/barrier_synchronizer.cuh
+++ b/cudax/include/cuda/experimental/__group/synchronizer/barrier_synchronizer.cuh
@@ -131,10 +131,10 @@ public:
       __thread_rank_in_unit = gpu_thread.rank(_Unit{}, __parent.hierarchy());
     }
 
-    if (__mapping_result.is_valid() && __mapping_result.rank() == 0 && __thread_rank_in_unit == 0)
+    if (__mapping_result.is_valid() && __mapping_result.unit_rank() == 0 && __thread_rank_in_unit == 0)
     {
       init(&__barriers_[__mapping_result.group_rank()],
-           static_cast<::cuda::std::ptrdiff_t>(__mapping_result.count() * __nthread_in_unit));
+           static_cast<::cuda::std::ptrdiff_t>(__mapping_result.unit_count() * __nthread_in_unit));
     }
 
     // todo(dabayer): How we can expose making this aligned?

--- a/cudax/include/cuda/experimental/__group/synchronizer/lane_synchronizer.cuh
+++ b/cudax/include/cuda/experimental/__group/synchronizer/lane_synchronizer.cuh
@@ -78,7 +78,7 @@ public:
     static_assert(__group_mapping_result<_MappingResult>);
     if (__mapping_result.is_valid())
     {
-      _CCCL_ASSERT(::cuda::std::popcount(__mapping_result.lane_mask().value()) == __mapping_result.count(),
+      _CCCL_ASSERT(::cuda::std::popcount(__mapping_result.lane_mask().value()) == __mapping_result.unit_count(),
                    "lane_synchronizer can only synchronize units within the same warp");
     }
     return {};

--- a/cudax/include/cuda/experimental/__group/this_group.cuh
+++ b/cudax/include/cuda/experimental/__group/this_group.cuh
@@ -97,17 +97,17 @@ struct __this_mapping_result
     return 0;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_count() noexcept
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_unit_count() noexcept
   {
     return 1;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API unsigned count() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API unsigned unit_count() const noexcept
   {
     return 1;
   }
 
-  [[nodiscard]] _CCCL_DEVICE_API unsigned rank() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API unsigned unit_rank() const noexcept
   {
     return 0;
   }

--- a/cudax/test/common/group_testing.cuh
+++ b/cudax/test/common/group_testing.cuh
@@ -63,17 +63,17 @@ struct ThreadsInWarpMappingResult
     return 0;
   }
 
-  __device__ static constexpr ::cuda::std::size_t static_count()
+  __device__ static constexpr ::cuda::std::size_t static_unit_count()
   {
     return 32;
   }
 
-  __device__ unsigned count() const
+  __device__ unsigned unit_count() const
   {
     return 32;
   }
 
-  __device__ unsigned rank() const
+  __device__ unsigned unit_rank() const
   {
     return cuda::gpu_thread.rank_as<unsigned>(cuda::warp);
   }

--- a/cudax/test/coop/shuffle/threads_within_warp.cu
+++ b/cudax/test/coop/shuffle/threads_within_warp.cu
@@ -89,7 +89,7 @@ struct CustomBinaryPartition
   template <class MappingResult>
   __device__ bool operator()(MappingResult mapping_result)
   {
-    switch (mapping_result.rank())
+    switch (mapping_result.unit_rank())
     {
       case 1:
       case 5:

--- a/cudax/test/coop/shuffle_down/threads_within_warp.cu
+++ b/cudax/test/coop/shuffle_down/threads_within_warp.cu
@@ -91,7 +91,7 @@ struct CustomBinaryPartition
   template <class MappingResult>
   __device__ bool operator()(MappingResult mapping_result)
   {
-    switch (mapping_result.rank())
+    switch (mapping_result.unit_rank())
     {
       case 1:
       case 5:

--- a/cudax/test/coop/shuffle_up/threads_within_warp.cu
+++ b/cudax/test/coop/shuffle_up/threads_within_warp.cu
@@ -90,7 +90,7 @@ struct CustomBinaryPartition
   template <class MappingResult>
   __device__ bool operator()(MappingResult mapping_result)
   {
-    switch (mapping_result.rank())
+    switch (mapping_result.unit_rank())
     {
       case 1:
       case 5:

--- a/cudax/test/group/group.cu
+++ b/cudax/test/group/group.cu
@@ -83,7 +83,7 @@ test_queries(const cudax::group<cuda::thread_level, ParentGroup, cudax::group_by
   using Group = cuda::std::remove_cvref_t<decltype(group)>;
   using Level = typename Group::level_type;
 
-  const auto count_ref = group.__mapping_result().count();
+  const auto count_ref = group.__mapping_result().unit_count();
   const auto rank_ref  = cuda::gpu_thread.rank(Level{}, group.hierarchy()) % count_ref;
 
   REQUIRE(cuda::gpu_thread.count(group) == count_ref);

--- a/cudax/test/group/mapping/binary_partition.cu
+++ b/cudax/test/group/mapping/binary_partition.cu
@@ -45,7 +45,7 @@ struct IsEvenPredFn
   template <class MappingResult>
   __device__ bool operator()(MappingResult mapping_result)
   {
-    return mapping_result.rank() % 2 == 0;
+    return mapping_result.unit_rank() % 2 == 0;
   }
 };
 
@@ -81,9 +81,9 @@ __device__ void test_binary_partition(Config config)
       REQUIRE(result.group_count() == 2);
       REQUIRE(result.group_rank() == 1);
 
-      static_assert(Result::static_count() == cuda::std::dynamic_extent);
-      REQUIRE(result.count() == cuda::gpu_thread.count(cuda::warp));
-      REQUIRE(result.rank() == cuda::gpu_thread.rank(cuda::warp));
+      static_assert(Result::static_unit_count() == cuda::std::dynamic_extent);
+      REQUIRE(result.unit_count() == cuda::gpu_thread.count(cuda::warp));
+      REQUIRE(result.unit_rank() == cuda::gpu_thread.rank(cuda::warp));
 
       REQUIRE(result.lane_mask() == cuda::device::lane_mask::all());
 
@@ -122,9 +122,9 @@ __device__ void test_binary_partition(Config config)
       REQUIRE(result.group_count() == 2);
       REQUIRE(result.group_rank() == 0);
 
-      static_assert(Result::static_count() == cuda::std::dynamic_extent);
-      REQUIRE(result.count() == cuda::gpu_thread.count(cuda::warp));
-      REQUIRE(result.rank() == cuda::gpu_thread.rank(cuda::warp));
+      static_assert(Result::static_unit_count() == cuda::std::dynamic_extent);
+      REQUIRE(result.unit_count() == cuda::gpu_thread.count(cuda::warp));
+      REQUIRE(result.unit_rank() == cuda::gpu_thread.rank(cuda::warp));
 
       REQUIRE(result.lane_mask() == cuda::device::lane_mask::all());
 
@@ -163,9 +163,9 @@ __device__ void test_binary_partition(Config config)
       REQUIRE(result.group_count() == 2);
       REQUIRE(result.group_rank() == (cuda::gpu_thread.rank(cuda::warp) % 2 == 0));
 
-      static_assert(Result::static_count() == cuda::std::dynamic_extent);
-      REQUIRE(result.count() == cuda::gpu_thread.count(cuda::warp) / 2);
-      REQUIRE(result.rank() == cuda::gpu_thread.rank(cuda::warp) / 2);
+      static_assert(Result::static_unit_count() == cuda::std::dynamic_extent);
+      REQUIRE(result.unit_count() == cuda::gpu_thread.count(cuda::warp) / 2);
+      REQUIRE(result.unit_rank() == cuda::gpu_thread.rank(cuda::warp) / 2);
 
       const auto lane_mask_ref =
         (cuda::gpu_thread.rank(cuda::warp) % 2 == 0)

--- a/cudax/test/group/mapping/composite_mapping.cu
+++ b/cudax/test/group/mapping/composite_mapping.cu
@@ -46,11 +46,11 @@ __device__ void test_composite_mapping(const Mapping1& mapping1, const Mapping2&
     static_assert(noexcept(mapping.get()));
 
     const auto& mapping1_ref = cuda::std::get<0>(mapping.get());
-    CHECK(mapping1_ref.count() == 4);
+    CHECK(mapping1_ref.unit_count() == 4);
 
     const auto& mapping2_ref = cuda::std::get<1>(mapping.get());
-    CHECK(mapping2_ref.count(0) == 1);
-    CHECK(mapping2_ref.count(1) == 3);
+    CHECK(mapping2_ref.unit_count(0) == 1);
+    CHECK(mapping2_ref.unit_count(1) == 3);
   }
 
   // Test map(...).
@@ -67,7 +67,7 @@ __device__ void test_composite_mapping(const Mapping1& mapping1, const Mapping2&
 
     const auto rank_in_warp = cuda::gpu_thread.rank_as<unsigned>(parent_group);
 
-    if constexpr (Mapping1::static_count() != cuda::std::dynamic_extent
+    if constexpr (Mapping1::static_unit_count() != cuda::std::dynamic_extent
                   && Mapping2::static_group_count() != cuda::std::dynamic_extent)
     {
       static_assert(Result::static_group_count() == 16);
@@ -79,9 +79,9 @@ __device__ void test_composite_mapping(const Mapping1& mapping1, const Mapping2&
     CHECK(result.group_count() == 16);
     CHECK(result.group_rank() == (rank_in_warp / 4 * 2 + (rank_in_warp % 4 > 0)));
 
-    static_assert(Result::static_count() == cuda::std::dynamic_extent);
-    CHECK(result.count() == ((rank_in_warp % 4 > 0) ? 3 : 1));
-    CHECK(result.rank() == ((rank_in_warp % 4 > 0) ? (rank_in_warp % 4 - 1) : 0));
+    static_assert(Result::static_unit_count() == cuda::std::dynamic_extent);
+    CHECK(result.unit_count() == ((rank_in_warp % 4 > 0) ? 3 : 1));
+    CHECK(result.unit_rank() == ((rank_in_warp % 4 > 0) ? (rank_in_warp % 4 - 1) : 0));
 
     const auto lane_mask_ref = ((rank_in_warp % 4 > 0) ? 0b1110u : 0b0001u) << ((rank_in_warp / 4) * 4);
     CHECK(result.lane_mask() == cuda::device::lane_mask{lane_mask_ref});
@@ -99,11 +99,11 @@ __device__ void test_composite_mapping(const Mapping1& mapping1, const Mapping2&
     static_assert(noexcept(mapping1 | mapping2));
 
     const auto& mapping1_ref = cuda::std::get<0>(mapping.get());
-    CHECK(mapping1_ref.count() == 4);
+    CHECK(mapping1_ref.unit_count() == 4);
 
     const auto& mapping2_ref = cuda::std::get<1>(mapping.get());
-    CHECK(mapping2_ref.count(0) == 1);
-    CHECK(mapping2_ref.count(1) == 3);
+    CHECK(mapping2_ref.unit_count(0) == 1);
+    CHECK(mapping2_ref.unit_count(1) == 3);
   }
   {
     auto mapping = cudax::composite_mapping{mapping1} | mapping2;
@@ -112,11 +112,11 @@ __device__ void test_composite_mapping(const Mapping1& mapping1, const Mapping2&
     static_assert(noexcept(cudax::composite_mapping{mapping1} | mapping2));
 
     const auto& mapping1_ref = cuda::std::get<0>(mapping.get());
-    CHECK(mapping1_ref.count() == 4);
+    CHECK(mapping1_ref.unit_count() == 4);
 
     const auto& mapping2_ref = cuda::std::get<1>(mapping.get());
-    CHECK(mapping2_ref.count(0) == 1);
-    CHECK(mapping2_ref.count(1) == 3);
+    CHECK(mapping2_ref.unit_count(0) == 1);
+    CHECK(mapping2_ref.unit_count(1) == 3);
   }
   {
     auto mapping = mapping1 | cudax::composite_mapping{mapping2};
@@ -125,11 +125,11 @@ __device__ void test_composite_mapping(const Mapping1& mapping1, const Mapping2&
     static_assert(noexcept(mapping1 | cudax::composite_mapping{mapping2}));
 
     const auto& mapping1_ref = cuda::std::get<0>(mapping.get());
-    CHECK(mapping1_ref.count() == 4);
+    CHECK(mapping1_ref.unit_count() == 4);
 
     const auto& mapping2_ref = cuda::std::get<1>(mapping.get());
-    CHECK(mapping2_ref.count(0) == 1);
-    CHECK(mapping2_ref.count(1) == 3);
+    CHECK(mapping2_ref.unit_count(0) == 1);
+    CHECK(mapping2_ref.unit_count(1) == 3);
   }
   {
     auto mapping = cudax::composite_mapping{mapping1} | cudax::composite_mapping{mapping2};
@@ -138,11 +138,11 @@ __device__ void test_composite_mapping(const Mapping1& mapping1, const Mapping2&
     static_assert(noexcept(cudax::composite_mapping{mapping1} | cudax::composite_mapping{mapping2}));
 
     const auto& mapping1_ref = cuda::std::get<0>(mapping.get());
-    CHECK(mapping1_ref.count() == 4);
+    CHECK(mapping1_ref.unit_count() == 4);
 
     const auto& mapping2_ref = cuda::std::get<1>(mapping.get());
-    CHECK(mapping2_ref.count(0) == 1);
-    CHECK(mapping2_ref.count(1) == 3);
+    CHECK(mapping2_ref.unit_count(0) == 1);
+    CHECK(mapping2_ref.unit_count(1) == 3);
   }
 }
 

--- a/cudax/test/group/mapping/group_as.cu
+++ b/cudax/test/group/mapping/group_as.cu
@@ -46,7 +46,7 @@ __device__ void test_group_as(Config config)
       Mapping mapping;
       for (cuda::std::size_t i = 0; i < ngroups; ++i)
       {
-        CHECK(mapping.count(i) == ns[i]);
+        CHECK(mapping.unit_count(i) == ns[i]);
       }
     }
 
@@ -59,7 +59,7 @@ __device__ void test_group_as(Config config)
 
       for (cuda::std::size_t i = 0; i < ngroups; ++i)
       {
-        CHECK(mapping.count(i) == ns[i]);
+        CHECK(mapping.unit_count(i) == ns[i]);
       }
     }
 
@@ -71,13 +71,13 @@ __device__ void test_group_as(Config config)
     static_assert(noexcept(Mapping::static_group_count()));
     static_assert(Mapping::static_group_count() == ngroups);
 
-    // Test static_count().
+    // Test static_unit_count().
     {
-      static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_count(cuda::std::size_t{}))>);
-      static_assert(noexcept(Mapping::static_count(cuda::std::size_t{})));
+      static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_unit_count(cuda::std::size_t{}))>);
+      static_assert(noexcept(Mapping::static_unit_count(cuda::std::size_t{})));
       for (cuda::std::size_t i = 0; i < ngroups; ++i)
       {
-        CHECK(Mapping::static_count(i) == ns[i]);
+        CHECK(Mapping::static_unit_count(i) == ns[i]);
       }
     }
 
@@ -86,16 +86,16 @@ __device__ void test_group_as(Config config)
     static_assert(noexcept(Mapping::is_always_exhaustive()));
     static_assert(Mapping::is_always_exhaustive());
 
-    // Test count().
+    // Test unit_count().
     {
       static_assert(
-        cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().count(cuda::std::size_t{}))>);
-      static_assert(noexcept(cuda::std::declval<const Mapping>().count(cuda::std::size_t{})));
+        cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().unit_count(cuda::std::size_t{}))>);
+      static_assert(noexcept(cuda::std::declval<const Mapping>().unit_count(cuda::std::size_t{})));
 
       const Mapping mapping;
       for (cuda::std::size_t i = 0; i < ngroups; ++i)
       {
-        CHECK(mapping.count(i) == ns[i]);
+        CHECK(mapping.unit_count(i) == ns[i]);
       }
     }
 
@@ -131,9 +131,9 @@ __device__ void test_group_as(Config config)
       CHECK(result.group_count() == static_cast<unsigned>(ngroups));
       CHECK(result.group_rank() == group_rank_ref);
 
-      static_assert(Result::static_count() == cuda::std::dynamic_extent);
-      CHECK(result.count() == ns[group_rank_ref]);
-      CHECK(result.rank() == rank_ref);
+      static_assert(Result::static_unit_count() == cuda::std::dynamic_extent);
+      CHECK(result.unit_count() == ns[group_rank_ref]);
+      CHECK(result.unit_rank() == rank_ref);
 
       const auto lane_mask_ref =
         (ns[group_rank_ref] < 32) ? ((1u << ns[group_rank_ref]) - 1) << group_starts[group_rank_ref] : ~0;
@@ -161,7 +161,7 @@ __device__ void test_group_as(Config config)
 
       for (cuda::std::size_t i = 0; i < ngroups; ++i)
       {
-        CHECK(mapping.count(i) == ns[i]);
+        CHECK(mapping.unit_count(i) == ns[i]);
       }
     }
 
@@ -173,13 +173,13 @@ __device__ void test_group_as(Config config)
     static_assert(noexcept(Mapping::static_group_count()));
     static_assert(Mapping::static_group_count() == ngroups);
 
-    // Test static_count().
+    // Test static_unit_count().
     {
-      static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_count(cuda::std::size_t{}))>);
-      static_assert(noexcept(Mapping::static_count(cuda::std::size_t{})));
+      static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_unit_count(cuda::std::size_t{}))>);
+      static_assert(noexcept(Mapping::static_unit_count(cuda::std::size_t{})));
       for (cuda::std::size_t i = 0; i < ngroups; ++i)
       {
-        CHECK(Mapping::static_count(i) == cuda::std::dynamic_extent);
+        CHECK(Mapping::static_unit_count(i) == cuda::std::dynamic_extent);
       }
     }
 
@@ -188,16 +188,16 @@ __device__ void test_group_as(Config config)
     static_assert(noexcept(Mapping::is_always_exhaustive()));
     static_assert(Mapping::is_always_exhaustive());
 
-    // Test count().
+    // Test unit_count().
     {
       static_assert(
-        cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().count(cuda::std::size_t{}))>);
-      static_assert(noexcept(cuda::std::declval<const Mapping>().count(cuda::std::size_t{})));
+        cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().unit_count(cuda::std::size_t{}))>);
+      static_assert(noexcept(cuda::std::declval<const Mapping>().unit_count(cuda::std::size_t{})));
 
       const Mapping mapping{ns};
       for (cuda::std::size_t i = 0; i < ngroups; ++i)
       {
-        CHECK(mapping.count(i) == ns[i]);
+        CHECK(mapping.unit_count(i) == ns[i]);
       }
     }
 
@@ -233,9 +233,9 @@ __device__ void test_group_as(Config config)
       CHECK(result.group_count() == static_cast<unsigned>(ngroups));
       CHECK(result.group_rank() == group_rank_ref);
 
-      static_assert(Result::static_count() == cuda::std::dynamic_extent);
-      CHECK(result.count() == ns[group_rank_ref]);
-      CHECK(result.rank() == rank_ref);
+      static_assert(Result::static_unit_count() == cuda::std::dynamic_extent);
+      CHECK(result.unit_count() == ns[group_rank_ref]);
+      CHECK(result.unit_rank() == rank_ref);
 
       const auto lane_mask_ref =
         (ns[group_rank_ref] < 32) ? ((1u << ns[group_rank_ref]) - 1) << group_starts[group_rank_ref] : ~0;
@@ -272,7 +272,7 @@ __device__ void test_group_as_non_exhaustive(Config config)
       Mapping mapping;
       for (cuda::std::size_t i = 0; i < ngroups; ++i)
       {
-        CHECK(mapping.count(i) == ns[i]);
+        CHECK(mapping.unit_count(i) == ns[i]);
       }
     }
 
@@ -288,7 +288,7 @@ __device__ void test_group_as_non_exhaustive(Config config)
 
       for (cuda::std::size_t i = 0; i < ngroups; ++i)
       {
-        CHECK(mapping.count(i) == ns[i]);
+        CHECK(mapping.unit_count(i) == ns[i]);
       }
     }
 
@@ -297,13 +297,13 @@ __device__ void test_group_as_non_exhaustive(Config config)
     static_assert(noexcept(Mapping::static_group_count()));
     static_assert(Mapping::static_group_count() == ngroups);
 
-    // Test static_count().
+    // Test static_unit_count().
     {
-      static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_count(cuda::std::size_t{}))>);
-      static_assert(noexcept(Mapping::static_count(cuda::std::size_t{})));
+      static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_unit_count(cuda::std::size_t{}))>);
+      static_assert(noexcept(Mapping::static_unit_count(cuda::std::size_t{})));
       for (cuda::std::size_t i = 0; i < ngroups; ++i)
       {
-        CHECK(Mapping::static_count(i) == ns[i]);
+        CHECK(Mapping::static_unit_count(i) == ns[i]);
       }
     }
 
@@ -312,16 +312,16 @@ __device__ void test_group_as_non_exhaustive(Config config)
     static_assert(noexcept(Mapping::is_always_exhaustive()));
     static_assert(!Mapping::is_always_exhaustive());
 
-    // Test count().
+    // Test unit_count().
     {
       static_assert(
-        cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().count(cuda::std::size_t{}))>);
-      static_assert(noexcept(cuda::std::declval<const Mapping>().count(cuda::std::size_t{})));
+        cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().unit_count(cuda::std::size_t{}))>);
+      static_assert(noexcept(cuda::std::declval<const Mapping>().unit_count(cuda::std::size_t{})));
 
       const Mapping mapping;
       for (cuda::std::size_t i = 0; i < ngroups; ++i)
       {
-        CHECK(mapping.count(i) == ns[i]);
+        CHECK(mapping.unit_count(i) == ns[i]);
       }
     }
 
@@ -343,7 +343,7 @@ __device__ void test_group_as_non_exhaustive(Config config)
       const auto is_valid_ref = (rank_in_warp < ns_sum);
 
       static_assert(Result::static_group_count() == ngroups);
-      static_assert(Result::static_count() == cuda::std::dynamic_extent);
+      static_assert(Result::static_unit_count() == cuda::std::dynamic_extent);
       static_assert(!Result::is_always_exhaustive());
       static_assert(Result::is_always_contiguous());
 
@@ -366,8 +366,8 @@ __device__ void test_group_as_non_exhaustive(Config config)
 
         CHECK(result.group_rank() == group_rank_ref);
 
-        CHECK(result.count() == ns[group_rank_ref]);
-        CHECK(result.rank() == rank_ref);
+        CHECK(result.unit_count() == ns[group_rank_ref]);
+        CHECK(result.unit_rank() == rank_ref);
 
         const auto lane_mask_ref =
           (ns[group_rank_ref] < 32) ? ((1u << ns[group_rank_ref]) - 1) << group_starts[group_rank_ref] : ~0;
@@ -395,7 +395,7 @@ __device__ void test_group_as_non_exhaustive(Config config)
 
       for (cuda::std::size_t i = 0; i < ngroups; ++i)
       {
-        CHECK(mapping.count(i) == ns[i]);
+        CHECK(mapping.unit_count(i) == ns[i]);
       }
     }
 
@@ -404,13 +404,13 @@ __device__ void test_group_as_non_exhaustive(Config config)
     static_assert(noexcept(Mapping::static_group_count()));
     static_assert(Mapping::static_group_count() == ngroups);
 
-    // Test static_count().
+    // Test static_unit_count().
     {
-      static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_count(cuda::std::size_t{}))>);
-      static_assert(noexcept(Mapping::static_count(cuda::std::size_t{})));
+      static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_unit_count(cuda::std::size_t{}))>);
+      static_assert(noexcept(Mapping::static_unit_count(cuda::std::size_t{})));
       for (cuda::std::size_t i = 0; i < ngroups; ++i)
       {
-        CHECK(Mapping::static_count(i) == cuda::std::dynamic_extent);
+        CHECK(Mapping::static_unit_count(i) == cuda::std::dynamic_extent);
       }
     }
 
@@ -419,16 +419,16 @@ __device__ void test_group_as_non_exhaustive(Config config)
     static_assert(noexcept(Mapping::is_always_exhaustive()));
     static_assert(!Mapping::is_always_exhaustive());
 
-    // Test count().
+    // Test unit_count().
     {
       static_assert(
-        cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().count(cuda::std::size_t{}))>);
-      static_assert(noexcept(cuda::std::declval<const Mapping>().count(cuda::std::size_t{})));
+        cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().unit_count(cuda::std::size_t{}))>);
+      static_assert(noexcept(cuda::std::declval<const Mapping>().unit_count(cuda::std::size_t{})));
 
       const Mapping mapping{ns, cudax::non_exhaustive};
       for (cuda::std::size_t i = 0; i < ngroups; ++i)
       {
-        CHECK(mapping.count(i) == ns[i]);
+        CHECK(mapping.unit_count(i) == ns[i]);
       }
     }
 
@@ -450,7 +450,7 @@ __device__ void test_group_as_non_exhaustive(Config config)
       const auto is_valid_ref = (rank_in_warp < ns_sum);
 
       static_assert(Result::static_group_count() == ngroups);
-      static_assert(Result::static_count() == cuda::std::dynamic_extent);
+      static_assert(Result::static_unit_count() == cuda::std::dynamic_extent);
       static_assert(!Result::is_always_exhaustive());
       static_assert(Result::is_always_contiguous());
 
@@ -473,8 +473,8 @@ __device__ void test_group_as_non_exhaustive(Config config)
 
         CHECK(result.group_rank() == group_rank_ref);
 
-        CHECK(result.count() == ns[group_rank_ref]);
-        CHECK(result.rank() == rank_ref);
+        CHECK(result.unit_count() == ns[group_rank_ref]);
+        CHECK(result.unit_rank() == rank_ref);
 
         const auto lane_mask_ref =
           (ns[group_rank_ref] < 32) ? ((1u << ns[group_rank_ref]) - 1) << group_starts[group_rank_ref] : ~0;

--- a/cudax/test/group/mapping/group_by.cu
+++ b/cudax/test/group/mapping/group_by.cu
@@ -37,7 +37,7 @@ __device__ void test_group_by(Config config)
       static_assert(cuda::std::is_empty_v<Mapping>);
 
       cudax::group_by<N> mapping;
-      CHECK(mapping.count() == static_cast<unsigned>(N));
+      CHECK(mapping.unit_count() == static_cast<unsigned>(N));
     }
 
     // Test the mapping is not constructible from unsigned.
@@ -49,23 +49,23 @@ __device__ void test_group_by(Config config)
     // Test the mapping is not constructible from unsigned and non_exhaustive_t.
     static_assert(!cuda::std::is_constructible_v<Mapping, unsigned, cudax::non_exhaustive_t>);
 
-    // Test static_count().
-    static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_count())>);
-    static_assert(noexcept(Mapping::static_count()));
-    static_assert(Mapping::static_count() == N);
+    // Test static_unit_count().
+    static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_unit_count())>);
+    static_assert(noexcept(Mapping::static_unit_count()));
+    static_assert(Mapping::static_unit_count() == N);
 
     // Test is_always_exhaustive().
     static_assert(cuda::std::is_same_v<bool, decltype(Mapping::is_always_exhaustive())>);
     static_assert(noexcept(Mapping::is_always_exhaustive()));
     static_assert(Mapping::is_always_exhaustive());
 
-    // Test count().
+    // Test unit_count().
     {
-      static_assert(cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().count())>);
-      static_assert(noexcept(cuda::std::declval<const Mapping>().count()));
+      static_assert(cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().unit_count())>);
+      static_assert(noexcept(cuda::std::declval<const Mapping>().unit_count()));
 
       const Mapping mapping;
-      CHECK(mapping.count() == static_cast<unsigned>(N));
+      CHECK(mapping.unit_count() == static_cast<unsigned>(N));
     }
 
     // Test map(...).
@@ -86,9 +86,9 @@ __device__ void test_group_by(Config config)
       CHECK(result.group_count() == cuda::gpu_thread.count(cuda::warp) / N);
       CHECK(result.group_rank() == cuda::gpu_thread.rank(cuda::warp) / N);
 
-      static_assert(Result::static_count() == N);
-      CHECK(result.count() == N);
-      CHECK(result.rank() == cuda::gpu_thread.rank(cuda::warp) % N);
+      static_assert(Result::static_unit_count() == N);
+      CHECK(result.unit_count() == N);
+      CHECK(result.unit_rank() == cuda::gpu_thread.rank(cuda::warp) % N);
 
       const auto lane_mask_ref = ((N < 32) ? ((1u << N) - 1) : ~0u) << ((cuda::gpu_thread.rank(cuda::warp) / N) * N);
       CHECK(result.lane_mask() == cuda::device::lane_mask{lane_mask_ref});
@@ -114,7 +114,7 @@ __device__ void test_group_by(Config config)
 
       cudax::group_by mapping{N};
       static_assert(cuda::std::is_same_v<Mapping, decltype(mapping)>);
-      CHECK(mapping.count() == static_cast<unsigned>(N));
+      CHECK(mapping.unit_count() == static_cast<unsigned>(N));
     }
 
     // Test the mapping is not constructible from non_exhaustive_t.
@@ -123,23 +123,23 @@ __device__ void test_group_by(Config config)
     // Test the mapping is not constructible from unsigned and non_exhaustive_t.
     static_assert(!cuda::std::is_constructible_v<Mapping, unsigned, cudax::non_exhaustive_t>);
 
-    // Test static_count().
-    static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_count())>);
-    static_assert(noexcept(Mapping::static_count()));
-    static_assert(Mapping::static_count() == cuda::std::dynamic_extent);
+    // Test static_unit_count().
+    static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_unit_count())>);
+    static_assert(noexcept(Mapping::static_unit_count()));
+    static_assert(Mapping::static_unit_count() == cuda::std::dynamic_extent);
 
     // Test is_always_exhaustive().
     static_assert(cuda::std::is_same_v<bool, decltype(Mapping::is_always_exhaustive())>);
     static_assert(noexcept(Mapping::is_always_exhaustive()));
     static_assert(Mapping::is_always_exhaustive());
 
-    // Test count().
+    // Test unit_count().
     {
-      static_assert(cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().count())>);
-      static_assert(noexcept(cuda::std::declval<const Mapping>().count()));
+      static_assert(cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().unit_count())>);
+      static_assert(noexcept(cuda::std::declval<const Mapping>().unit_count()));
 
       const Mapping mapping{N};
-      CHECK(mapping.count() == static_cast<unsigned>(N));
+      CHECK(mapping.unit_count() == static_cast<unsigned>(N));
     }
 
     // Test map(...).
@@ -160,9 +160,9 @@ __device__ void test_group_by(Config config)
       CHECK(result.group_count() == cuda::gpu_thread.count(cuda::warp) / N);
       CHECK(result.group_rank() == cuda::gpu_thread.rank(cuda::warp) / N);
 
-      static_assert(Result::static_count() == cuda::std::dynamic_extent);
-      CHECK(result.count() == N);
-      CHECK(result.rank() == cuda::gpu_thread.rank(cuda::warp) % N);
+      static_assert(Result::static_unit_count() == cuda::std::dynamic_extent);
+      CHECK(result.unit_count() == N);
+      CHECK(result.unit_rank() == cuda::gpu_thread.rank(cuda::warp) % N);
 
       const auto lane_mask_ref = ((N < 32) ? ((1u << N) - 1) : ~0u) << ((cuda::gpu_thread.rank(cuda::warp) / N) * N);
       CHECK(result.lane_mask() == cuda::device::lane_mask{lane_mask_ref});
@@ -194,29 +194,29 @@ __device__ void test_group_by_non_exhaustive(Config config)
 
       Mapping mapping{cudax::non_exhaustive};
       static_assert(cuda::std::is_same_v<decltype(mapping), Mapping>);
-      CHECK(mapping.count() == static_cast<unsigned>(N));
+      CHECK(mapping.unit_count() == static_cast<unsigned>(N));
     }
 
     // Test the mapping is not constructible from unsigned and non_exhaustive_t.
     static_assert(!cuda::std::is_constructible_v<Mapping, unsigned, cudax::non_exhaustive_t>);
 
-    // Test static_count().
-    static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_count())>);
-    static_assert(noexcept(Mapping::static_count()));
-    static_assert(Mapping::static_count() == N);
+    // Test static_unit_count().
+    static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_unit_count())>);
+    static_assert(noexcept(Mapping::static_unit_count()));
+    static_assert(Mapping::static_unit_count() == N);
 
     // Test is_always_exhaustive().
     static_assert(cuda::std::is_same_v<bool, decltype(Mapping::is_always_exhaustive())>);
     static_assert(noexcept(Mapping::is_always_exhaustive()));
     static_assert(!Mapping::is_always_exhaustive());
 
-    // Test count().
+    // Test unit_count().
     {
-      static_assert(cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().count())>);
-      static_assert(noexcept(cuda::std::declval<const Mapping>().count()));
+      static_assert(cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().unit_count())>);
+      static_assert(noexcept(cuda::std::declval<const Mapping>().unit_count()));
 
       const Mapping mapping{cudax::non_exhaustive};
-      CHECK(mapping.count() == static_cast<unsigned>(N));
+      CHECK(mapping.unit_count() == static_cast<unsigned>(N));
     }
 
     // Test map(...).
@@ -234,7 +234,7 @@ __device__ void test_group_by_non_exhaustive(Config config)
       using Result = decltype(result);
 
       static_assert(Result::static_group_count() == 32 / N);
-      static_assert(Result::static_count() == N);
+      static_assert(Result::static_unit_count() == N);
       static_assert(!Result::is_always_exhaustive());
       static_assert(Result::is_always_contiguous());
 
@@ -246,8 +246,8 @@ __device__ void test_group_by_non_exhaustive(Config config)
         CHECK(result.group_count() == cuda::gpu_thread.count(cuda::warp) / N);
         CHECK(result.group_rank() == cuda::gpu_thread.rank(cuda::warp) / N);
 
-        CHECK(result.count() == N);
-        CHECK(result.rank() == cuda::gpu_thread.rank(cuda::warp) % N);
+        CHECK(result.unit_count() == N);
+        CHECK(result.unit_rank() == cuda::gpu_thread.rank(cuda::warp) % N);
 
         const auto lane_mask_ref = ((N < 32) ? ((1u << N) - 1) : ~0u) << ((cuda::gpu_thread.rank(cuda::warp) / N) * N);
         CHECK(result.lane_mask() == cuda::device::lane_mask{lane_mask_ref});
@@ -269,7 +269,7 @@ __device__ void test_group_by_non_exhaustive(Config config)
 
       Mapping mapping{N};
       static_assert(cuda::std::is_same_v<Mapping, decltype(mapping)>);
-      CHECK(mapping.count() == static_cast<unsigned>(N));
+      CHECK(mapping.unit_count() == static_cast<unsigned>(N));
     }
 
     // Test the mapping is not constructible from non_exhaustive_t.
@@ -281,21 +281,21 @@ __device__ void test_group_by_non_exhaustive(Config config)
 
       cudax::group_by mapping{static_cast<unsigned>(N), cudax::non_exhaustive};
       static_assert(cuda::std::is_same_v<decltype(mapping), Mapping>);
-      CHECK(mapping.count() == static_cast<unsigned>(N));
+      CHECK(mapping.unit_count() == static_cast<unsigned>(N));
     }
 
-    // Test static_count().
-    static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_count())>);
-    static_assert(noexcept(Mapping::static_count()));
-    static_assert(Mapping::static_count() == cuda::std::dynamic_extent);
+    // Test static_unit_count().
+    static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(Mapping::static_unit_count())>);
+    static_assert(noexcept(Mapping::static_unit_count()));
+    static_assert(Mapping::static_unit_count() == cuda::std::dynamic_extent);
 
-    // Test count().
+    // Test unit_count().
     {
-      static_assert(cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().count())>);
-      static_assert(noexcept(cuda::std::declval<const Mapping>().count()));
+      static_assert(cuda::std::is_same_v<unsigned, decltype(cuda::std::declval<const Mapping>().unit_count())>);
+      static_assert(noexcept(cuda::std::declval<const Mapping>().unit_count()));
 
       const Mapping mapping{N, cudax::non_exhaustive};
-      CHECK(mapping.count() == static_cast<unsigned>(N));
+      CHECK(mapping.unit_count() == static_cast<unsigned>(N));
     }
 
     // Test map(...).
@@ -313,7 +313,7 @@ __device__ void test_group_by_non_exhaustive(Config config)
       using Result = decltype(result);
 
       static_assert(Result::static_group_count() == cuda::std::dynamic_extent);
-      static_assert(Result::static_count() == cuda::std::dynamic_extent);
+      static_assert(Result::static_unit_count() == cuda::std::dynamic_extent);
       static_assert(!Result::is_always_exhaustive());
       static_assert(Result::is_always_contiguous());
 
@@ -325,8 +325,8 @@ __device__ void test_group_by_non_exhaustive(Config config)
         CHECK(result.group_count() == cuda::gpu_thread.count(cuda::warp) / N);
         CHECK(result.group_rank() == cuda::gpu_thread.rank(cuda::warp) / N);
 
-        CHECK(result.count() == N);
-        CHECK(result.rank() == cuda::gpu_thread.rank(cuda::warp) % N);
+        CHECK(result.unit_count() == N);
+        CHECK(result.unit_rank() == cuda::gpu_thread.rank(cuda::warp) % N);
 
         const auto lane_mask_ref = ((N < 32) ? ((1u << N) - 1) : ~0u) << ((cuda::gpu_thread.rank(cuda::warp) / N) * N);
         CHECK(result.lane_mask() == cuda::device::lane_mask{lane_mask_ref});

--- a/cudax/test/group/mapping/identity_mapping.cu
+++ b/cudax/test/group/mapping/identity_mapping.cu
@@ -56,9 +56,9 @@ __device__ void test_identity_mapping(Config config)
     CHECK(result.group_count() == prev_mapping_result.group_count());
     CHECK(result.group_rank() == prev_mapping_result.group_rank());
 
-    static_assert(Result::static_count() == ThreadsInWarpMappingResult::static_count());
-    CHECK(result.count() == prev_mapping_result.count());
-    CHECK(result.rank() == prev_mapping_result.rank());
+    static_assert(Result::static_unit_count() == ThreadsInWarpMappingResult::static_unit_count());
+    CHECK(result.unit_count() == prev_mapping_result.unit_count());
+    CHECK(result.unit_rank() == prev_mapping_result.unit_rank());
 
     CHECK(result.lane_mask() == prev_mapping_result.lane_mask());
 


### PR DESCRIPTION
On Friday, me and @pciolkosz, we talked about the groups APIs and we realized that the current naming for unit-related data/queries in mapping result are confusing. We think prefixing them with `unit_` makes things more clear.