### PR TITLE
[docs] Add a note about error handling using exceptions to the docs

### DIFF
--- a/docs/libcudacxx/runtime.rst
+++ b/docs/libcudacxx/runtime.rst
@@ -19,6 +19,20 @@ At a glance, the runtime layer includes:
 - Runtime algorithms like ``copy_bytes`` and ``fill_bytes`` for basic data movement.
 - Legacy memory resources as synchronous compatibility fallbacks for older toolkits.
 
+Error handling
+--------------
+
+CCCL Runtime APIs use C++ exceptions for error handling. Operations such as creating runtime objects, allocating memory,
+querying device properties, or synchronizing work report failures by throwing exceptions. Users can write ordinary
+control flow without checking a status value after every runtime call, and catch exceptions at the boundary where an
+operation can be retried, reported, or allowed to fail.
+
+See :ref:`Exception Handling <libcudacxx-extended-api-exceptions>` for details on ``cuda::cuda_error``, including how
+to access the stored ``cudaError_t`` status.
+
+This is part of the CCCL Runtime API model. It differs from the CUDA Runtime API, where operations generally return
+``cudaError_t`` values that callers check against ``cudaSuccess``.
+
 See :ref:`CUDA Runtime interactions <cccl-runtime-cudart-interactions>` if you are interested in CUDA Runtime interop.
 
 Example: vector add with buffers, pools, and launch

--- a/docs/libcudacxx/runtime/cudart_interactions.rst
+++ b/docs/libcudacxx/runtime/cudart_interactions.rst
@@ -40,6 +40,32 @@ Example: handle interop patterns
      assert(released == raw_stream);
    }
 
+Error handling
+--------------
+
+CCCL Runtime APIs use C++ exceptions for error handling. Failures from runtime abstractions are reported by throwing an
+exception, so normal code can be written without manually checking and propagating a status code after each operation.
+
+This differs from the traditional CUDA Runtime API, where operations generally return ``cudaError_t`` values that the
+caller must check against ``cudaSuccess`` and propagate or handle. When using CUDA Runtime calls directly, continue to
+check their return values; when using CCCL Runtime wrappers, handle failures with normal C++ exception handling.
+
+At a CUDA Runtime-style boundary, catch ``cuda::cuda_error`` and return its stored status.
+
+.. code:: cpp
+
+   #include <cuda/stream>
+
+   cudaError_t use_stream(cuda::stream_ref stream) {
+     try {
+       // stream usage
+       stream.sync();
+       return cudaSuccess;
+     } catch (const cuda::cuda_error& err) {
+       return err.status();
+     }
+   }
+
 Device selection
 ----------------
 

--- a/docs/libcudacxx/runtime/cudart_interactions.rst
+++ b/docs/libcudacxx/runtime/cudart_interactions.rst
@@ -56,7 +56,7 @@ At a CUDA Runtime-style boundary, catch ``cuda::cuda_error`` and return its stor
 
    #include <cuda/stream>
 
-   cudaError_t use_stream(cuda::stream_ref stream) {
+   cudaError_t use_stream(cuda::stream_ref stream) noexcept {
      try {
        // stream usage
        stream.sync();


### PR DESCRIPTION
On the cccl runtime blog post it was pointed out there is no information about the error handling model. This PR adds a note about error handling on the main page and cuda runtime interaction