### PR TITLE
[FEA] Unify square_t functors across benchmarks and tests

### DIFF
--- a/cub/benchmarks/bench/transform_reduce/sum.cu
+++ b/cub/benchmarks/bench/transform_reduce/sum.cu
@@ -3,6 +3,8 @@
 
 #include <cub/device/device_reduce.cuh>
 
+#include <thrust/functional.h>
+
 #include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_ITEMS_PER_THREAD ipt 7:24:1
@@ -25,21 +27,12 @@ struct policy_selector
 };
 #endif // !TUNE_BASE
 
-template <class T>
-struct square_t
-{
-  __host__ __device__ T operator()(const T& x) const
-  {
-    return x * x;
-  }
-};
-
 template <typename T, typename OffsetT>
 void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 {
   using init_value_t   = T;
   using reduction_op_t = ::cuda::std::plus<>;
-  using transform_op_t = square_t<T>;
+  using transform_op_t = thrust::square<T>;
 
   // Retrieve axis parameters
   const auto elements = state.get_int64("Elements{io}");

--- a/cub/test/catch2_test_device_transform_reduce.cu
+++ b/cub/test/catch2_test_device_transform_reduce.cu
@@ -5,6 +5,8 @@
 
 #include <cub/device/device_reduce.cuh>
 
+#include <thrust/functional.h>
+
 #include <cstdint>
 
 #include "catch2_test_device_reduce.cuh"
@@ -19,22 +21,13 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::TransformReduce, device_transform_redu
 
 using types = c2h::type_list<std::uint32_t, std::uint64_t>;
 
-template <class T>
-struct square_t
-{
-  __host__ __device__ T operator()(const T& x) const
-  {
-    return x * x;
-  }
-};
-
 C2H_TEST("Device transform reduce works with pointers", "[reduce][device]", types)
 {
   using item_t         = c2h::get<0, TestType>;
   using init_value_t   = item_t;
   using offset_t       = std::int32_t;
   using reduction_op_t = cuda::std::plus<>;
-  using transform_op_t = square_t<item_t>;
+  using transform_op_t = thrust::square<item_t>;
 
   constexpr int max_items = 5000000;
   constexpr int min_items = 1;
@@ -81,7 +74,7 @@ C2H_TEST("Device transform reduce works with iterators", "[reduce][device]", typ
   using init_value_t   = item_t;
   using offset_t       = std::int32_t;
   using reduction_op_t = cuda::std::plus<>;
-  using transform_op_t = square_t<item_t>;
+  using transform_op_t = thrust::square<item_t>;
 
   constexpr int max_items = 5000000;
   constexpr int min_items = 1;

--- a/libcudacxx/benchmarks/bench/for_each/basic.cu
+++ b/libcudacxx/benchmarks/bench/for_each/basic.cu
@@ -16,15 +16,6 @@
 
 #include "nvbench_helper.cuh"
 
-template <class T>
-struct square_t
-{
-  __device__ void operator()(T& x) const
-  {
-    x = x * x;
-  }
-};
-
 template <typename T>
 static void basic(nvbench::state& state, nvbench::type_list<T>)
 {
@@ -36,7 +27,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  square_t<T> op{};
+  square_inplace_t<T> op{};
 
   caching_allocator_t alloc{};
 

--- a/libcudacxx/benchmarks/bench/for_each_n/basic.cu
+++ b/libcudacxx/benchmarks/bench/for_each_n/basic.cu
@@ -16,15 +16,6 @@
 
 #include "nvbench_helper.cuh"
 
-template <class T>
-struct square_t
-{
-  __device__ void operator()(T& x) const
-  {
-    x = x * x;
-  }
-};
-
 template <typename T>
 static void basic(nvbench::state& state, nvbench::type_list<T>)
 {
@@ -36,7 +27,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  square_t<T> op{};
+  square_inplace_t<T> op{};
 
   caching_allocator_t alloc{};
 

--- a/nvbench_helper/nvbench_helper/nvbench_helper.cuh
+++ b/nvbench_helper/nvbench_helper/nvbench_helper.cuh
@@ -118,6 +118,15 @@ using all_types =
 #endif
 
 template <class T>
+struct square_inplace_t
+{
+  __device__ void operator()(T& x) const noexcept
+  {
+    x = x * x;
+  }
+};
+
+template <class T>
 class value_wrapper_t
 {
   T m_val{};

--- a/thrust/benchmarks/bench/for_each/basic.cu
+++ b/thrust/benchmarks/bench/for_each/basic.cu
@@ -7,15 +7,6 @@
 
 #include "nvbench_helper.cuh"
 
-template <class T>
-struct square_t
-{
-  __device__ void operator()(T& x) const
-  {
-    x = x * x;
-  }
-};
-
 template <typename T>
 static void basic(nvbench::state& state, nvbench::type_list<T>)
 {
@@ -27,7 +18,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  square_t<T> op{};
+  square_inplace_t<T> op{};
   caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch) {

--- a/thrust/benchmarks/bench/for_each_n/basic.cu
+++ b/thrust/benchmarks/bench/for_each_n/basic.cu
@@ -9,15 +9,6 @@
 
 #include "nvbench_helper.cuh"
 
-template <class T>
-struct square_t
-{
-  __device__ void operator()(T& x) const
-  {
-    x = x * x;
-  }
-};
-
 template <typename T>
 static void basic(nvbench::state& state, nvbench::type_list<T>)
 {
@@ -29,7 +20,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  square_t<T> op{};
+  square_inplace_t<T> op{};
 
   caching_allocator_t alloc{};
 

--- a/thrust/benchmarks/bench/transform_reduce/sum.cu
+++ b/thrust/benchmarks/bench/transform_reduce/sum.cu
@@ -3,18 +3,10 @@
 
 #include <thrust/device_vector.h>
 #include <thrust/execution_policy.h>
+#include <thrust/functional.h>
 #include <thrust/transform_reduce.h>
 
 #include "nvbench_helper.cuh"
-
-template <class T>
-struct square_t
-{
-  __host__ __device__ T operator()(const T& x) const
-  {
-    return x * x;
-  }
-};
 
 template <typename T>
 static void basic(nvbench::state& state, nvbench::type_list<T>)
@@ -31,7 +23,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
              [&](nvbench::launch& launch) {
                do_not_optimize(thrust::transform_reduce(
-                 policy(alloc, launch), in.begin(), in.end(), square_t<T>{}, T{}, ::cuda::std::plus<T>{}));
+                 policy(alloc, launch), in.begin(), in.end(), thrust::square<T>{}, T{}, ::cuda::std::plus<T>{}));
              });
 }
 


### PR DESCRIPTION
## Description

closes #9619 

Replaces locally-defined `square_t` structs with `thrust::square<T>`
where semantically equivalent (value-returning `T operator()(const T& x)`),
and consolidates the in-place variant into a shared `square_inplace_t`
in `nvbench_helper.cuh`.

**Value-returning `square_t` to `thrust::square<T>`:**
- `cub/benchmarks/bench/transform_reduce/sum.cu`
- `thrust/benchmarks/bench/transform_reduce/sum.cu`
- `cub/test/catch2_test_device_transform_reduce.cu`

**In-place `square_t<T>` to `square_inplace_t<T>` (added to `nvbench_helper.cuh`):**
- `thrust/benchmarks/bench/for_each/basic.cu`
- `thrust/benchmarks/bench/for_each_n/basic.cu`
- `libcudacxx/benchmarks/bench/for_each/basic.cu`
- `libcudacxx/benchmarks/bench/for_each_n/basic.cu`

**Intentionally not changed:**
- `catch2_test_device_for_api.cu` / `for_env_api.cu`:  `square_t` is inside `// example-begin` documentation tags
- `catch2_test_device_reduce_deterministic.cu`:  takes `int` input, different signature from `thrust::square<T>`
- `catch2_test_device_reduce_nondeterministic.cu`: already wraps `thrust::square<T>{}` internally

---

## Checklist
- [x] "New or existing tests cover these changes"
- [x] "The documentation is up to date"
