### PR TITLE
Allow public tuning of `cub::DeviceMerge`

### DIFF
--- a/cub/benchmarks/bench/merge/merge_common.cuh
+++ b/cub/benchmarks/bench/merge/merge_common.cuh
@@ -30,10 +30,9 @@
 template <typename KeyT>
 struct bench_policy_selector
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const
-    -> cub::detail::merge::merge_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::MergePolicy
   {
-    return cub::detail::merge::merge_policy{
+    return cub::MergePolicy{
       (1 << TUNE_THREADS_PER_BLOCK_POW2),
       cub::Nominal4BItemsToItems<KeyT>(TUNE_ITEMS_PER_THREAD),
       TUNE_LOAD_MODIFIER,

--- a/cub/cub/device/device_merge.cuh
+++ b/cub/cub/device/device_merge.cuh
@@ -22,11 +22,30 @@
 
 CUB_NAMESPACE_BEGIN
 
+//! @rst
 //! DeviceMerge provides device-wide, parallel operations for merging two sorted sequences of values (called keys) or
 //! key-value pairs in device-accessible memory. The sorting order is determined by a comparison functor (default:
-//! less-than), which has to establish a [strict weak ordering].
+//! less-than), which has to establish a `strict weak ordering
+//! <https://en.cppreference.com/w/cpp/concepts/strict_weak_order>`_.
 //!
-//! [strict weak ordering]: https://en.cppreference.com/w/cpp/concepts/strict_weak_order
+//! @par Tuning
+//! All algorithms in DeviceMerge that accept an environment can be tuned by passing a custom
+//! :ref:`policy selector <cub-policy-selectors>` that returns a @ref MergePolicy, as shown in the
+//! example below:
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_merge_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin merge-keys-policy-selector
+//!      :end-before: example-end merge-keys-policy-selector
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_merge_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin merge-keys-tuning
+//!      :end-before: example-end merge-keys-tuning
+//!
+//! @endrst
 struct DeviceMerge
 {
   //! @rst

--- a/cub/cub/device/dispatch/dispatch_merge.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge.cuh
@@ -32,11 +32,11 @@ namespace detail::merge
 inline constexpr int fallback_BLOCK_THREADS    = 64;
 inline constexpr int fallback_ITEMS_PER_THREAD = 1;
 
-// TODO(bgruber): we should choose the merge_policy rather than the agent, but before C++20 this is more verbose
+// TODO(bgruber): we should choose the MergePolicy rather than the agent, but before C++20 this is more verbose
 template <typename PolicyGetter, class... Args>
 class choose_merge_agent
 {
-  static constexpr merge_policy active_policy = PolicyGetter{}();
+  static constexpr MergePolicy active_policy = PolicyGetter{}();
 
   using default_load2sh_agent_t =
     agent_t<active_policy.threads_per_block,

--- a/cub/cub/device/dispatch/tuning/tuning_merge.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_merge.cuh
@@ -29,18 +29,18 @@
 
 CUB_NAMESPACE_BEGIN
 
-namespace detail::merge
+//! The tuning policy for all algorithms in @ref DeviceMerge.
+struct MergePolicy
 {
-struct merge_policy
-{
-  int threads_per_block;
-  int items_per_thread;
-  CacheLoadModifier load_modifier;
-  BlockStoreAlgorithm store_algorithm;
-  bool use_bulk_copy_for_keys;
-  bool use_bulk_copy_for_values;
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int items_per_thread; //!< Number of items processed per thread
+  CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
+  BlockStoreAlgorithm store_algorithm; //!< The @ref BlockStoreAlgorithm used for storing items to global memory
+  bool use_bulk_copy_for_keys; //!< Whether to use bulk copy (cp.async.bulk) for loading keys into shared memory
+  bool use_bulk_copy_for_values; //!< Whether to use bulk copy (cp.async.bulk) for loading values into shared memory
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const merge_policy& lhs, const merge_policy& rhs)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator==(const MergePolicy& lhs, const MergePolicy& rhs) noexcept
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
         && lhs.load_modifier == rhs.load_modifier && lhs.store_algorithm == rhs.store_algorithm
@@ -48,16 +48,17 @@ struct merge_policy
         && lhs.use_bulk_copy_for_values == rhs.use_bulk_copy_for_values;
   }
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool operator!=(const merge_policy& lhs, const merge_policy& rhs)
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
+  operator!=(const MergePolicy& lhs, const MergePolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const merge_policy& p)
+  friend ::std::ostream& operator<<(::std::ostream& os, const MergePolicy& p)
   {
     return os
-        << "merge_policy { .threads_per_block = " << p.threads_per_block
+        << "MergePolicy { .threads_per_block = " << p.threads_per_block
         << ", .items_per_thread = " << p.items_per_thread << ", .load_modifier = " << p.load_modifier
         << ", .store_algorithm = " << p.store_algorithm << ", .use_bulk_copy_for_keys = " << p.use_bulk_copy_for_keys
         << ", .use_bulk_copy_for_values = " << p.use_bulk_copy_for_values << " }";
@@ -65,9 +66,11 @@ struct merge_policy
 #endif // _CCCL_HOSTED()
 };
 
+namespace detail::merge
+{
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>
-concept merge_policy_selector = policy_selector<T, merge_policy>;
+concept merge_policy_selector = policy_selector<T, MergePolicy>;
 #endif // _CCCL_HAS_CONCEPTS()
 
 struct policy_selector
@@ -84,7 +87,7 @@ struct policy_selector
   bool value_iterator_value_types_are_the_same;
   int offset_size;
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> merge_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> MergePolicy
   {
     const int tune_type_size = key_size + value_size;
     const int ipt_800_plus   = nominal_4B_items_to_items(15, tune_type_size);
@@ -95,7 +98,7 @@ struct policy_selector
 
     if (cc >= ::cuda::compute_capability{10, 0})
     {
-      return merge_policy{512, ipt_800_plus, LOAD_DEFAULT, BLOCK_STORE_WARP_TRANSPOSE, can_bulk_keys, can_bulk_values};
+      return MergePolicy{512, ipt_800_plus, LOAD_DEFAULT, BLOCK_STORE_WARP_TRANSPOSE, can_bulk_keys, can_bulk_values};
     }
 
     if (cc >= ::cuda::compute_capability{9, 0})
@@ -107,7 +110,7 @@ struct policy_selector
             || (key_size == 16 && value_size == 8));
       // TODO(bgruber): consider not using a combined should_bl2sh flag. Kept to avoid SASS diffs
       const bool should_bl2sh = value_size == 0 ? should_bl2sh_keys : should_bl2sh_pairs;
-      return merge_policy{
+      return MergePolicy{
         512,
         ipt_800_plus,
         LOAD_DEFAULT,
@@ -123,7 +126,7 @@ struct policy_selector
         key_size == 1 || (key_size == 2 && value_size < 4) || (key_size == 4 && value_size == 1);
       // TODO(bgruber): consider not using a combined should_bl2sh flag. Kept to avoid SASS diffs
       const bool should_bl2sh = value_size == 0 ? should_bl2sh_keys : should_bl2sh_pairs;
-      return merge_policy{
+      return MergePolicy{
         512,
         ipt_800_plus,
         LOAD_DEFAULT,
@@ -135,12 +138,12 @@ struct policy_selector
     if (cc >= ::cuda::compute_capability{6, 0})
     {
       const int ipt_600 = nominal_4B_items_to_items(15, tune_type_size);
-      return merge_policy{512, ipt_600, LOAD_DEFAULT, BLOCK_STORE_WARP_TRANSPOSE, false, false};
+      return MergePolicy{512, ipt_600, LOAD_DEFAULT, BLOCK_STORE_WARP_TRANSPOSE, false, false};
     }
 
     // default is SM52
     const int ipt_520 = nominal_4B_items_to_items(13, tune_type_size);
-    return merge_policy{512, ipt_520, LOAD_LDG, BLOCK_STORE_WARP_TRANSPOSE, false, false};
+    return MergePolicy{512, ipt_520, LOAD_LDG, BLOCK_STORE_WARP_TRANSPOSE, false, false};
   }
 };
 
@@ -151,7 +154,7 @@ static_assert(merge_policy_selector<policy_selector>);
 template <typename KeysIt1, typename ItemsIt1, typename KeysIt2, typename ItemsIt2, typename OffsetT>
 struct policy_selector_from_types
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> merge_policy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> MergePolicy
   {
     using key_t  = it_value_t<KeysIt1>;
     using item_t = it_value_t<ItemsIt1>;

--- a/cub/test/catch2_test_device_merge_env.cu
+++ b/cub/test/catch2_test_device_merge_env.cu
@@ -29,7 +29,7 @@ using block_size_extracting_less_t = block_size_extracting_op<cuda::std::less<>>
 template <int ThreadsPerBlock>
 struct merge_tuning
 {
-  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::detail::merge::merge_policy
+  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::MergePolicy
   {
     return {ThreadsPerBlock, 1, cub::LOAD_DEFAULT, cub::BLOCK_STORE_WARP_TRANSPOSE, false, false};
   }
@@ -318,3 +318,32 @@ TEST_CASE("DeviceMerge::MergePairs uses custom stream", "[merge][device]")
 
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
+
+#if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
+C2H_TEST("MergePolicy", "[merge][device]")
+{
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::MergePolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::MergePolicy>);
+
+  // aggregate init
+  constexpr auto p1 = cub::MergePolicy{
+    128, 7, cub::CacheLoadModifier::LOAD_LDG, cub::BlockStoreAlgorithm::BLOCK_STORE_WARP_TRANSPOSE, true, false};
+
+#  if _CCCL_STD_VER >= 2020
+  // designated init
+  constexpr auto p2 = cub::MergePolicy{
+    .threads_per_block        = 128,
+    .items_per_thread         = 7,
+    .load_modifier            = cub::CacheLoadModifier::LOAD_LDG,
+    .store_algorithm          = cub::BlockStoreAlgorithm::BLOCK_STORE_WARP_TRANSPOSE,
+    .use_bulk_copy_for_keys   = true,
+    .use_bulk_copy_for_values = false};
+#  else // _CCCL_STD_VER >= 2020
+  constexpr auto p2 = p1;
+#  endif // _CCCL_STD_VER >= 2020
+
+  // comparison
+  STATIC_REQUIRE(p1 == p2);
+  STATIC_REQUIRE_FALSE(p1 != p2);
+}
+#endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_merge_env_api.cu
+++ b/cub/test/catch2_test_device_merge_env_api.cu
@@ -7,6 +7,7 @@
 
 #include <thrust/device_vector.h>
 
+#include <cuda/__execution/tune.h>
 #include <cuda/devices>
 #include <cuda/stream>
 
@@ -84,3 +85,49 @@ C2H_TEST("cub::DeviceMerge::MergePairs accepts env with stream", "[merge][env]")
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }
+
+#if _CCCL_STD_VER >= 2020
+
+// example-begin merge-keys-policy-selector
+struct MergePolicySelector
+{
+  __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::MergePolicy
+  {
+    return {.threads_per_block        = 512,
+            .items_per_thread         = cc > cuda::compute_capability{9, 0} ? 15 : 11,
+            .load_modifier            = cub::LOAD_DEFAULT,
+            .store_algorithm          = cub::BLOCK_STORE_WARP_TRANSPOSE,
+            .use_bulk_copy_for_keys   = true,
+            .use_bulk_copy_for_values = false};
+  }
+};
+// example-end merge-keys-policy-selector
+
+C2H_TEST("cub::DeviceMerge::MergeKeys env-based API with tuning", "[merge][env]")
+{
+  // example-begin merge-keys-tuning
+  auto keys1  = thrust::device_vector<int>{0, 2, 5};
+  auto keys2  = thrust::device_vector<int>{0, 3, 3, 4};
+  auto result = thrust::device_vector<int>(7, thrust::no_init);
+
+  const auto error = cub::DeviceMerge::MergeKeys(
+    keys1.begin(),
+    static_cast<int>(keys1.size()),
+    keys2.begin(),
+    static_cast<int>(keys2.size()),
+    result.begin(),
+    cuda::std::less{},
+    cuda::execution::tune(MergePolicySelector{}));
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceMerge::MergeKeys failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
+  // example-end merge-keys-tuning
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(result == expected);
+}
+
+#endif // _CCCL_STD_VER >= 2020

--- a/cub/test/catch2_test_device_merge_no_unroll.cu
+++ b/cub/test/catch2_test_device_merge_no_unroll.cu
@@ -64,7 +64,7 @@ using large_type_vsmem = c2h::custom_type_t<c2h::equal_comparable_t, c2h::less_c
 
 struct fixed_policy_selector
 {
-  _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const -> cub::detail::merge::merge_policy
+  _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const -> cub::MergePolicy
   {
     return {128, 7, cub::LOAD_DEFAULT, cub::BLOCK_STORE_WARP_TRANSPOSE, false, false};
   }


### PR DESCRIPTION
- [x] Merge before: #9439 

Fixes: #8573
