### PR TITLE
Silence buffer environment compat checks

### DIFF
--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -62,10 +62,15 @@
 //! @brief The \c buffer class provides a container of contiguous memory
 _CCCL_BEGIN_NAMESPACE_CUDA
 
+// TODO:
+//
+// Find a way to enable checks again without bricking for environments that clearly (which we
+// can somehow detect) dont intend to have alignment.
 template <class _Env>
 inline constexpr bool __buffer_compatible_env =
   ::cuda::std::is_same_v<::cuda::std::decay_t<_Env>, ::cuda::std::execution::env<>>
-  || ::cuda::std::execution::__queryable_with<const _Env&, allocation_alignment_t>;
+  || ::cuda::std::execution::__queryable_with<const _Env&, allocation_alignment_t>
+  || true; // NOLINT(readability-simplify-boolean-expr)
 
 _CCCL_BEGIN_NAMESPACE_ABI_VER4_BUMP
 //! @rst

--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -51,6 +51,7 @@
 #  include <cuda/std/__ranges/size.h>
 #  include <cuda/std/__ranges/unwrap_end.h>
 #  include <cuda/std/__type_traits/decay.h>
+#  include <cuda/std/__type_traits/remove_cvref.h>
 #  include <cuda/std/__utility/forward.h>
 #  include <cuda/std/__utility/move.h>
 #  include <cuda/std/cstdint>
@@ -62,15 +63,20 @@
 //! @brief The \c buffer class provides a container of contiguous memory
 _CCCL_BEGIN_NAMESPACE_CUDA
 
+template <class _Tp>
+inline constexpr bool __is_any_env = false;
+
+template <class... _Tp>
+inline constexpr bool __is_any_env<::cuda::std::execution::env<_Tp...>> = true;
+
 // TODO:
 //
 // Find a way to enable checks again without bricking for environments that clearly (which we
 // can somehow detect) dont intend to have alignment.
 template <class _Env>
 inline constexpr bool __buffer_compatible_env =
-  ::cuda::std::is_same_v<::cuda::std::decay_t<_Env>, ::cuda::std::execution::env<>>
-  || ::cuda::std::execution::__queryable_with<const _Env&, allocation_alignment_t>
-  || true; // NOLINT(readability-simplify-boolean-expr)
+  __is_any_env<::cuda::std::remove_cvref_t<_Env>>
+  || ::cuda::std::execution::__queryable_with<const _Env&, allocation_alignment_t>;
 
 _CCCL_BEGIN_NAMESPACE_ABI_VER4_BUMP
 //! @rst


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

As environments become more common in our public APIs, it is convenient to simply pass the user env to _all_ subsequent calls inside a function. This way the user can saddle up their environment with all the necessary tuning knobs and these just automagically get routed to where they are used.

`buffer`, however, unfortunately checks that the incoming env satisfies it (or is empty). But this doesn't work so well when passing the envs around haphazardly as described above. The caller could screen the incoming user env:
```c++
if constexpr (__buffer_compatible_env<_Env>) {
  buffer{...., env}
} else {
  buffer{...};
}
```
but this quickly gets cumbersome and tedious.

We will need to find a way to revive some level of checking though that may catch typos in the properties or other such unintended user mistakes.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
