### PR TITLE
Fix managed memory smoke test

### DIFF
--- a/test/cuda_smoke/cuda_runtime_smoke.cu
+++ b/test/cuda_smoke/cuda_runtime_smoke.cu
@@ -43,7 +43,7 @@ TEST_CASE("cudaMallocManaged round-trip works", "[cuda_smoke][managed_memory]")
 
   int managed_supported = 0;
   CUDART_REQUIRE(cudaDeviceGetAttribute(&managed_supported, cudaDevAttrManagedMemory, 0));
-  REQUIRE(managed_supported);
+  REQUIRE(managed_supported); // CCCL tests require managed memory
 
   constexpr int n = 256;
   int* p          = nullptr;

--- a/test/cuda_smoke/cuda_runtime_smoke.cu
+++ b/test/cuda_smoke/cuda_runtime_smoke.cu
@@ -43,10 +43,7 @@ TEST_CASE("cudaMallocManaged round-trip works", "[cuda_smoke][managed_memory]")
 
   int managed_supported = 0;
   CUDART_REQUIRE(cudaDeviceGetAttribute(&managed_supported, cudaDevAttrManagedMemory, 0));
-  if (!managed_supported)
-  {
-    SKIP("Device does not support managed memory (cudaDevAttrManagedMemory == 0).");
-  }
+  REQUIRE(managed_supported);
 
   constexpr int n = 256;
   int* p          = nullptr;


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
CCCL tests require managed memory. For instance, all thrust tests that are added with `DECLARE_VECTOR_UNITTEST` check if universal vector works. Current smoke implementation didn't trigger an error if system hasn't supported managed memory. 

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
