### PR TITLE
Fix `cudafe++` < 13.1 with older gcc

### DIFF
--- a/c2h/include/c2h/custom_type.h
+++ b/c2h/include/c2h/custom_type.h
@@ -159,27 +159,33 @@ class cuda::std::numeric_limits<c2h::custom_type_t<Policies...>>
 public:
   static constexpr bool is_specialized = true;
 
+  // template <class SizeT = size_t> is a workaround for cudafe++ < 13.1 + gcc < 13 replacing `numeric_limits<size_t>`
+  // with `numeric_limits<conditional<is_void_v<void>, __common_type2_imp<uint64_t, uint64_t>::type, void>::type>`
+
+  template <class SizeT = std::size_t>
   static __host__ __device__ c2h::custom_type_t<Policies...> max()
   {
     c2h::custom_type_t<Policies...> val;
-    val.key = numeric_limits<std::size_t>::max();
-    val.val = numeric_limits<std::size_t>::max();
+    val.key = numeric_limits<SizeT>::max();
+    val.val = numeric_limits<SizeT>::max();
     return val;
   }
 
+  template <class SizeT = std::size_t>
   static __host__ __device__ c2h::custom_type_t<Policies...> min()
   {
     c2h::custom_type_t<Policies...> val;
-    val.key = numeric_limits<std::size_t>::min();
-    val.val = numeric_limits<std::size_t>::min();
+    val.key = numeric_limits<SizeT>::min();
+    val.val = numeric_limits<SizeT>::min();
     return val;
   }
 
+  template <class SizeT = std::size_t>
   static __host__ __device__ c2h::custom_type_t<Policies...> lowest()
   {
     c2h::custom_type_t<Policies...> val;
-    val.key = numeric_limits<std::size_t>::lowest();
-    val.val = numeric_limits<std::size_t>::lowest();
+    val.key = numeric_limits<SizeT>::lowest();
+    val.val = numeric_limits<SizeT>::lowest();
     return val;
   }
 };

--- a/libcudacxx/include/cuda/std/string_view
+++ b/libcudacxx/include/cuda/std/string_view
@@ -288,9 +288,12 @@ public:
     return __size_;
   }
 
+  // Workaround for cudafe++ < 13.1 + gcc < 13 replacing `numeric_limits<size_t>` with
+  // `numeric_limits<conditional<is_void_v<void>, __common_type2_imp<uint64_t, uint64_t>::type, void>::type>`
+  template <class _SizeType = size_type>
   [[nodiscard]] _CCCL_API constexpr size_type max_size() const noexcept
   {
-    return numeric_limits<size_type>::max() / sizeof(value_type);
+    return numeric_limits<_SizeType>::max() / sizeof(value_type);
   }
 
   [[nodiscard]] _CCCL_API constexpr bool empty() const noexcept

--- a/thrust/thrust/detail/allocator/tagged_allocator.h
+++ b/thrust/thrust/detail/allocator/tagged_allocator.h
@@ -81,9 +81,12 @@ public:
     return &x;
   }
 
+  // Workaround for cudafe++ < 13.1 + gcc < 13 replacing `numeric_limits<size_t>` with
+  // `numeric_limits<conditional<is_void_v<void>, __common_type2_imp<uint64_t, uint64_t>::type, void>::type>`
+  template <class SizeType = size_type>
   size_type max_size() const
   {
-    return (::cuda::std::numeric_limits<size_type>::max)() / sizeof(T);
+    return (::cuda::std::numeric_limits<SizeType>::max)() / sizeof(T);
   }
 
   _CCCL_HOST_DEVICE friend bool operator==(const tagged_allocator&, const tagged_allocator&)

--- a/thrust/thrust/mr/allocator.h
+++ b/thrust/thrust/mr/allocator.h
@@ -90,9 +90,12 @@ public:
    *  \return the maximum value of \p std::size_t, divided by the size of \p T.
    */
   _CCCL_EXEC_CHECK_DISABLE
+  template <class SizeType = size_type>
   _CCCL_HOST_DEVICE size_type max_size() const
   {
-    return (::cuda::std::numeric_limits<size_type>::max)() / sizeof(T);
+    // Workaround for cudafe++ < 13.1 + gcc < 13 replacing `numeric_limits<size_t>` with
+    // `numeric_limits<conditional<is_void_v<void>, __common_type2_imp<uint64_t, uint64_t>::type, void>::type>`
+    return (::cuda::std::numeric_limits<SizeType>::max)() / sizeof(T);
   }
 
   /*! Constructor.


### PR DESCRIPTION
There seems to be a bug in `nvcc` < 13.1 when used with `gcc` < 13 which makes `cudafe++` generate a source file that has `numeric_limits<[std::]size_t>` replaced by `numeric_limits<conditional<is_void_v<void>, __common_type2_imp<uint64_t, uint64_t>::type, void>::type>` and fails to compile.

This appeared in the past in #7740 and now reappeared in #7705. I found an ugly workaround for it.