### PR TITLE
Allow public tuning of `cub::DeviceCopy`

### DIFF
--- a/cub/benchmarks/bench/copy/memcpy.cu
+++ b/cub/benchmarks/bench/copy/memcpy.cu
@@ -78,7 +78,7 @@ struct offset_to_size_t
 
 struct policy_selector_t
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::BatchedMemcpyPolicy
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::BatchedCopyPolicy
   {
     return {
       {

--- a/cub/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/cub/agent/agent_batch_memcpy.cuh
@@ -40,6 +40,7 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail
 {
+// TODO(bgruber): drop in CCCL 4.0
 template <uint32_t ThreadsPerBlock,
           uint32_t BuffersPerThread,
           uint32_t TlevBytesPerThread,
@@ -64,6 +65,7 @@ struct agent_batch_memcpy_policy
 };
 } // namespace detail
 
+// TODO(bgruber): drop in CCCL 4.0
 //! Deprecated [Since 3.5]
 template <uint32_t ThreadsPerBlock,
           uint32_t BuffersPerThread,

--- a/cub/cub/device/device_copy.cuh
+++ b/cub/cub/device/device_copy.cuh
@@ -30,6 +30,24 @@
 CUB_NAMESPACE_BEGIN
 
 //! @brief cub::DeviceCopy provides device-wide, parallel operations for copying data.
+//!
+//! @par Tuning
+//! @rst
+//! All algorithms in DeviceCopy that accept an environment can be tuned by passing a custom :ref:`policy selector
+//! <cub-policy-selectors>` that returns a @ref BatchedCopyPolicy, as shown in the example below:
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_copy_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin copy-batched-policy-selector
+//!      :end-before: example-end copy-batched-policy-selector
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_copy_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin copy-batched-tuning
+//!      :end-before: example-end copy-batched-tuning
+//! @endrst
 struct DeviceCopy
 {
   //! @rst

--- a/cub/cub/device/device_copy.cuh
+++ b/cub/cub/device/device_copy.cuh
@@ -33,8 +33,8 @@ CUB_NAMESPACE_BEGIN
 //!
 //! @par Tuning
 //! @rst
-//! All algorithms in DeviceCopy that accept an environment can be tuned by passing a custom :ref:`policy selector
-//! <cub-policy-selectors>` that returns a @ref BatchedCopyPolicy, as shown in the example below:
+//! The Batched algorithms in DeviceCopy that accept an environment can be tuned by passing a custom :ref:`policy
+//! selector <cub-policy-selectors>` that returns a @ref BatchedCopyPolicy, as shown in the example below:
 //!
 //!  .. literalinclude:: ../../../cub/test/catch2_test_device_copy_env_api.cu
 //!      :language: c++

--- a/cub/cub/device/device_memcpy.cuh
+++ b/cub/cub/device/device_memcpy.cuh
@@ -30,7 +30,7 @@ CUB_NAMESPACE_BEGIN
 //! @par Tuning
 //! @rst
 //! All algorithms in DeviceMemcpy that accept an environment can be tuned by passing a custom :ref:`policy selector
-//! <cub-policy-selectors>` that returns a @ref BatchedMemcpyPolicy, as shown in the example below:
+//! <cub-policy-selectors>` that returns a @ref BatchedCopyPolicy, as shown in the example below:
 //!
 //!  .. literalinclude:: ../../../cub/test/catch2_test_device_memcpy_env_api.cu
 //!      :language: c++

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -90,7 +90,7 @@ __launch_bounds__(int(current_policy<PolicySelector>().large_buffer.threads_per_
     TileT buffer_offset_tile,
     _CCCL_GRID_CONSTANT const TileOffsetT last_tile_offset)
 {
-  static constexpr BatchMemcpyLargeBufferPolicy policy = current_policy<PolicySelector>().large_buffer;
+  static constexpr BatchedCopyLargeBufferPolicy policy = current_policy<PolicySelector>().large_buffer;
   using StatusWord                                     = typename TileT::StatusWord;
   using BufferSizeT                                    = it_value_t<BufferSizeIteratorT>;
   /// Internal load/store type. For byte-wise memcpy, a single-byte type
@@ -224,7 +224,7 @@ __launch_bounds__(int(current_policy<PolicySelector>().small_buffer.threads_per_
     _CCCL_GRID_CONSTANT const BLevBufferOffsetTileState blev_buffer_scan_state,
     _CCCL_GRID_CONSTANT const BLevBlockOffsetTileState blev_block_scan_state)
 {
-  static constexpr BatchMemcpySmallBufferPolicy policy = current_policy<PolicySelector>().small_buffer;
+  static constexpr BatchedCopySmallBufferPolicy policy = current_policy<PolicySelector>().small_buffer;
   // Internal type used for storing a buffer's size
   using BufferSizeT = it_value_t<BufferSizeIteratorT>;
 
@@ -315,7 +315,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   {
     return error;
   }
-  const BatchedMemcpyPolicy active_policy = policy_selector(cc);
+  const BatchedCopyPolicy active_policy = policy_selector(cc);
 
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(NV_IS_HOST, ({

--- a/cub/cub/device/dispatch/tuning/tuning_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_batch_memcpy.cuh
@@ -22,8 +22,8 @@
 
 CUB_NAMESPACE_BEGIN
 
-//! The small buffer sub-policy for @ref BatchedMemcpyPolicy.
-struct BatchMemcpySmallBufferPolicy
+//! The small buffer sub-policy for @ref BatchedCopyPolicy.
+struct BatchedCopySmallBufferPolicy
 {
   int threads_per_block; //!< Number of threads in a CUDA block
   int buffers_per_thread; //!< Number of buffers processed per thread
@@ -39,7 +39,7 @@ struct BatchMemcpySmallBufferPolicy
   LookbackDelayPolicy block_lookback_delay; //!< The @ref LookbackDelayPolicy for the block offset scan
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const BatchMemcpySmallBufferPolicy& lhs, const BatchMemcpySmallBufferPolicy& rhs) noexcept
+  operator==(const BatchedCopySmallBufferPolicy& lhs, const BatchedCopySmallBufferPolicy& rhs) noexcept
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.buffers_per_thread == rhs.buffers_per_thread
         && lhs.bytes_per_thread == rhs.bytes_per_thread && lhs.prefer_pow2_bits == rhs.prefer_pow2_bits
@@ -51,16 +51,16 @@ struct BatchMemcpySmallBufferPolicy
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const BatchMemcpySmallBufferPolicy& lhs, const BatchMemcpySmallBufferPolicy& rhs) noexcept
+  operator!=(const BatchedCopySmallBufferPolicy& lhs, const BatchedCopySmallBufferPolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const BatchMemcpySmallBufferPolicy& policy)
+  friend ::std::ostream& operator<<(::std::ostream& os, const BatchedCopySmallBufferPolicy& policy)
   {
     return os
-        << "BatchMemcpySmallBufferPolicy { .threads_per_block = " << policy.threads_per_block
+        << "BatchedCopySmallBufferPolicy { .threads_per_block = " << policy.threads_per_block
         << ", .buffers_per_thread = " << policy.buffers_per_thread
         << ", .bytes_per_thread = " << policy.bytes_per_thread << ", .prefer_pow2_bits = " << policy.prefer_pow2_bits
         << ", .block_level_tile_size = " << policy.block_level_tile_size << ", .warp_level_threshold = "
@@ -71,55 +71,55 @@ struct BatchMemcpySmallBufferPolicy
 #endif // _CCCL_HOSTED()
 };
 
-//! The large buffer sub-policy for @ref BatchedMemcpyPolicy.
-struct BatchMemcpyLargeBufferPolicy
+//! The large buffer sub-policy for @ref BatchedCopyPolicy.
+struct BatchedCopyLargeBufferPolicy
 {
   int threads_per_block; //!< Number of threads in a CUDA block
   int bytes_per_thread; //!< Number of bytes processed per thread
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const BatchMemcpyLargeBufferPolicy& lhs, const BatchMemcpyLargeBufferPolicy& rhs) noexcept
+  operator==(const BatchedCopyLargeBufferPolicy& lhs, const BatchedCopyLargeBufferPolicy& rhs) noexcept
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.bytes_per_thread == rhs.bytes_per_thread;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const BatchMemcpyLargeBufferPolicy& lhs, const BatchMemcpyLargeBufferPolicy& rhs) noexcept
+  operator!=(const BatchedCopyLargeBufferPolicy& lhs, const BatchedCopyLargeBufferPolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const BatchMemcpyLargeBufferPolicy& policy)
+  friend ::std::ostream& operator<<(::std::ostream& os, const BatchedCopyLargeBufferPolicy& policy)
   {
-    return os << "BatchMemcpyLargeBufferPolicy { .threads_per_block = " << policy.threads_per_block
+    return os << "BatchedCopyLargeBufferPolicy { .threads_per_block = " << policy.threads_per_block
               << ", .bytes_per_thread = " << policy.bytes_per_thread << " }";
   }
 #endif // _CCCL_HOSTED()
 };
 
 //! The tuning policy for all algorithms in @ref DeviceMemcpy.
-struct BatchedMemcpyPolicy
+struct BatchedCopyPolicy
 {
-  BatchMemcpySmallBufferPolicy small_buffer; //!< Sub-policy for small buffers copied by a single thread block
-  BatchMemcpyLargeBufferPolicy large_buffer; //!< Sub-policy for large buffers requiring multi-block collaboration
+  BatchedCopySmallBufferPolicy small_buffer; //!< Sub-policy for small buffers copied by a single thread block
+  BatchedCopyLargeBufferPolicy large_buffer; //!< Sub-policy for large buffers requiring multi-block collaboration
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const BatchedMemcpyPolicy& lhs, const BatchedMemcpyPolicy& rhs) noexcept
+  operator==(const BatchedCopyPolicy& lhs, const BatchedCopyPolicy& rhs) noexcept
   {
     return lhs.small_buffer == rhs.small_buffer && lhs.large_buffer == rhs.large_buffer;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const BatchedMemcpyPolicy& lhs, const BatchedMemcpyPolicy& rhs) noexcept
+  operator!=(const BatchedCopyPolicy& lhs, const BatchedCopyPolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const BatchedMemcpyPolicy& policy)
+  friend ::std::ostream& operator<<(::std::ostream& os, const BatchedCopyPolicy& policy)
   {
-    return os << "BatchedMemcpyPolicy { .small_buffer = " << policy.small_buffer
+    return os << "BatchedCopyPolicy { .small_buffer = " << policy.small_buffer
               << ", .large_buffer = " << policy.large_buffer << " }";
   }
 #endif // _CCCL_HOSTED()
@@ -129,20 +129,20 @@ namespace detail::batch_memcpy
 {
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>
-concept batch_memcpy_policy_selector = policy_selector<T, BatchedMemcpyPolicy>;
+concept batch_memcpy_policy_selector = policy_selector<T, BatchedCopyPolicy>;
 #endif // _CCCL_HAS_CONCEPTS()
 
 struct policy_selector
 {
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
-    -> BatchedMemcpyPolicy
+    -> BatchedCopyPolicy
   {
-    const auto large = BatchMemcpyLargeBufferPolicy{
+    const auto large = BatchedCopyLargeBufferPolicy{
       256,
       32,
     };
-    return BatchedMemcpyPolicy{
-      BatchMemcpySmallBufferPolicy{
+    return BatchedCopyPolicy{
+      BatchedCopySmallBufferPolicy{
         /* .threads_per_block = */ 128,
         /* .buffers_per_thread = */ 4,
         /* .bytes_per_thread = */ 8,

--- a/cub/test/catch2_test_device_copy_env.cu
+++ b/cub/test/catch2_test_device_copy_env.cu
@@ -136,7 +136,7 @@ TEST_CASE("DeviceCopy::Batched uses custom stream", "[copy][device]")
 template <int BlockThreads>
 struct batch_copy_tuning
 {
-  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::BatchedMemcpyPolicy
+  _CCCL_API constexpr auto operator()(cuda::compute_capability) const -> cub::BatchedCopyPolicy
   {
     return {
       {BlockThreads, 4, 8, false, 256 * 32, 128, 8 * 1024, {}, {}},

--- a/cub/test/catch2_test_device_copy_env_api.cu
+++ b/cub/test/catch2_test_device_copy_env_api.cu
@@ -9,6 +9,7 @@
 #include <thrust/device_vector.h>
 #include <thrust/sequence.h>
 
+#include <cuda/__execution/tune.h>
 #include <cuda/devices>
 #include <cuda/std/mdspan>
 #include <cuda/stream>
@@ -56,6 +57,72 @@ C2H_TEST("cub::DeviceCopy::Batched accepts env with stream", "[copy][env]")
   REQUIRE(error == cudaSuccess);
   REQUIRE(d_dst == d_src);
 }
+
+#if _CCCL_STD_VER >= 2020
+
+// nvcc turns the `.member = value,` C++ syntax into GNU's `member: value,` when clang (14 - 21) is used
+_CCCL_DIAG_PUSH
+#  if _CCCL_COMPILER(CLANG)
+_CCCL_DIAG_SUPPRESS_CLANG("-Wgnu-designator")
+#  endif // _CCCL_COMPILER(CLANG)
+
+// example-begin copy-batched-policy-selector
+struct BatchedCopyPolicySelector
+{
+  __host__ __device__ constexpr auto operator()(cuda::compute_capability /*cc*/) const -> cub::BatchedCopyPolicy
+  {
+    return {.small_buffer = {.threads_per_block     = 128,
+                             .buffers_per_thread    = 4,
+                             .bytes_per_thread      = 8,
+                             .prefer_pow2_bits      = false,
+                             .block_level_tile_size = 256 * 32,
+                             .warp_level_threshold  = 128,
+                             .block_level_threshold = 8 * 1024,
+                             .buffer_lookback_delay = {},
+                             .block_lookback_delay  = {}},
+            .large_buffer = {.threads_per_block = 256, .bytes_per_thread = 32}};
+  }
+};
+// example-end copy-batched-policy-selector
+
+_CCCL_DIAG_POP
+
+C2H_TEST("cub::DeviceCopy::Batched env-based API with tuning", "[copy][env]")
+{
+  // example-begin copy-batched-tuning
+  // 3 contiguous ranges copied via Batched API with custom tuning
+  constexpr int num_ranges = 3;
+  constexpr int range_size = 4;
+  constexpr int num_items  = num_ranges * range_size;
+
+  thrust::device_vector<int> d_src(num_items);
+  thrust::device_vector<int> d_dst(num_items, thrust::no_init);
+  thrust::sequence(d_src.begin(), d_src.end(), 1);
+
+  const int* src_base = thrust::raw_pointer_cast(d_src.data());
+  int* dst_base       = thrust::raw_pointer_cast(d_dst.data());
+
+  thrust::device_vector<const int*> d_input_ptrs{src_base, src_base + range_size, src_base + 2 * range_size};
+  thrust::device_vector<int*> d_output_ptrs{dst_base, dst_base + range_size, dst_base + 2 * range_size};
+  thrust::device_vector<int> d_sizes{range_size, range_size, range_size};
+
+  const auto error = cub::DeviceCopy::Batched(
+    thrust::raw_pointer_cast(d_input_ptrs.data()),
+    thrust::raw_pointer_cast(d_output_ptrs.data()),
+    thrust::raw_pointer_cast(d_sizes.data()),
+    num_ranges,
+    cuda::execution::tune(BatchedCopyPolicySelector{}));
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceCopy::Batched failed with status: " << error << '\n';
+  }
+  // example-end copy-batched-tuning
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_dst == d_src);
+}
+
+#endif // _CCCL_STD_VER >= 2020
 
 C2H_TEST("cub::DeviceCopy::Copy mdspan accepts env with stream", "[copy][env]")
 {

--- a/cub/test/catch2_test_device_memcpy_env.cu
+++ b/cub/test/catch2_test_device_memcpy_env.cu
@@ -135,7 +135,7 @@ TEST_CASE("DeviceMemcpy::Batched uses custom stream", "[memcpy][device]")
 template <int BlockThreads>
 struct batch_memcpy_tuning
 {
-  _CCCL_API constexpr auto operator()(cuda::compute_capability /*cc*/) const -> cub::BatchedMemcpyPolicy
+  _CCCL_API constexpr auto operator()(cuda::compute_capability /*cc*/) const -> cub::BatchedCopyPolicy
   {
     return {
       {BlockThreads, 4, 8, false, 256 * 32, 128, 8 * 1024, {}, {}},
@@ -181,14 +181,14 @@ C2H_TEST("DeviceMemcpy::Batched can be tuned", "[memcpy][device]", block_sizes)
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("BatchedMemcpyPolicy", "[memcpy][device]")
+C2H_TEST("BatchedCopyPolicy", "[memcpy][device]")
 {
-  STATIC_REQUIRE(::cuda::std::semiregular<cub::BatchedMemcpyPolicy>);
-  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::BatchedMemcpyPolicy>);
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::BatchedCopyPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::BatchedCopyPolicy>);
 
   // aggregate init
-  constexpr auto p1 = cub::BatchedMemcpyPolicy{
-    cub::BatchMemcpySmallBufferPolicy{
+  constexpr auto p1 = cub::BatchedCopyPolicy{
+    cub::BatchedCopySmallBufferPolicy{
       128,
       4,
       8,
@@ -198,13 +198,13 @@ C2H_TEST("BatchedMemcpyPolicy", "[memcpy][device]")
       8 * 1024,
       cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 350, 450},
       cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 350, 450}},
-    cub::BatchMemcpyLargeBufferPolicy{256, 32}};
+    cub::BatchedCopyLargeBufferPolicy{256, 32}};
 
 #  if _CCCL_STD_VER >= 2020
   // designated init
-  constexpr auto p2 = cub::BatchedMemcpyPolicy{
+  constexpr auto p2 = cub::BatchedCopyPolicy{
     .small_buffer =
-      cub::BatchMemcpySmallBufferPolicy{
+      cub::BatchedCopySmallBufferPolicy{
         .threads_per_block     = 128,
         .buffers_per_thread    = 4,
         .bytes_per_thread      = 8,
@@ -218,7 +218,7 @@ C2H_TEST("BatchedMemcpyPolicy", "[memcpy][device]")
         .block_lookback_delay =
           cub::LookbackDelayPolicy{
             .kind = cub::LookbackDelayAlgorithm::fixed_delay, .delay = 350, .l2_write_latency = 450}},
-    .large_buffer = cub::BatchMemcpyLargeBufferPolicy{.threads_per_block = 256, .bytes_per_thread = 32}};
+    .large_buffer = cub::BatchedCopyLargeBufferPolicy{.threads_per_block = 256, .bytes_per_thread = 32}};
 #  else // _CCCL_STD_VER >= 2020
   constexpr auto p2 = p1;
 #  endif // _CCCL_STD_VER >= 2020

--- a/cub/test/catch2_test_device_memcpy_env_api.cu
+++ b/cub/test/catch2_test_device_memcpy_env_api.cu
@@ -80,7 +80,7 @@ _CCCL_DIAG_SUPPRESS_CLANG("-Wgnu-designator")
 // example-begin memcpy-batched-policy-selector
 struct BatchedMemcpyPolicySelector
 {
-  __host__ __device__ constexpr auto operator()(cuda::compute_capability /*cc*/) const -> cub::BatchedMemcpyPolicy
+  __host__ __device__ constexpr auto operator()(cuda::compute_capability /*cc*/) const -> cub::BatchedCopyPolicy
   {
     return {.small_buffer = {.threads_per_block     = 128,
                              .buffers_per_thread    = 4,


### PR DESCRIPTION
After some internal discussion on Slack, I decided to use the same tuning policy as `cub::DeviceMemcpy`. I therefore also renamed the tuning policy members.

Fixes: #8568