### PR TITLE
Small refactorings for batched memcpy

### DIFF
--- a/cub/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/cub/agent/agent_batch_memcpy.cuh
@@ -96,7 +96,7 @@ LoadVectorAndFunnelShiftR(uint32_t const* aligned_ptr, uint32_t bit_shift, uint4
 {
   data_out = {aligned_ptr[0], aligned_ptr[1], aligned_ptr[2], aligned_ptr[3]};
 
-  if (!PTR_IS_FOUR_BYTE_ALIGNED)
+  if constexpr (!PTR_IS_FOUR_BYTE_ALIGNED)
   {
     uint32_t tail = aligned_ptr[4];
     data_out.x    = __funnelshift_r(data_out.x, data_out.y, bit_shift);
@@ -112,7 +112,7 @@ LoadVectorAndFunnelShiftR(uint32_t const* aligned_ptr, uint32_t bit_shift, uint2
 {
   data_out = {aligned_ptr[0], aligned_ptr[1]};
 
-  if (!PTR_IS_FOUR_BYTE_ALIGNED)
+  if constexpr (!PTR_IS_FOUR_BYTE_ALIGNED)
   {
     uint32_t tail = aligned_ptr[2];
     data_out.x    = __funnelshift_r(data_out.x, data_out.y, bit_shift);
@@ -126,7 +126,7 @@ LoadVectorAndFunnelShiftR(uint32_t const* aligned_ptr, uint32_t bit_shift, uint3
 {
   data_out = aligned_ptr[0];
 
-  if (!PTR_IS_FOUR_BYTE_ALIGNED)
+  if constexpr (!PTR_IS_FOUR_BYTE_ALIGNED)
   {
     uint32_t tail = aligned_ptr[1];
     data_out      = __funnelshift_r(data_out, tail, bit_shift);
@@ -204,14 +204,14 @@ GetAlignedPtrs(const void* in_begin, void* out_begin, ByteOffsetT num_bytes)
   constexpr auto in_datatype_size = uint32_t{sizeof(uint32_t)};
 
   // char-aliased ptrs to simplify pointer arithmetic
-  char* out_ptr      = reinterpret_cast<char*>(out_begin);
-  const char* in_ptr = reinterpret_cast<const char*>(in_begin);
+  char* out_ptr      = static_cast<char*>(out_begin);
+  const char* in_ptr = static_cast<const char*>(in_begin);
 
   // Number of bytes between the first VectorT-aligned address at or before out_begin and out_begin
   const uint32_t alignment_offset = reinterpret_cast<uintptr_t>(out_ptr) % out_datatype_size;
 
   // The first VectorT-aligned address before (or at) out_begin
-  char* out_chars_aligned = reinterpret_cast<char*>(out_ptr - alignment_offset);
+  char* out_chars_aligned = out_ptr - alignment_offset;
 
   // The number of extra bytes preceding `in_ptr` that are loaded but dropped
   uint32_t in_extra_bytes = reinterpret_cast<uintptr_t>(in_ptr) % in_datatype_size;
@@ -272,8 +272,8 @@ template <int LOGICAL_WARP_SIZE, typename VectorT, typename ByteOffsetT>
 _CCCL_DEVICE _CCCL_FORCEINLINE void
 vectorized_copy(int32_t thread_rank, void* dest, ByteOffsetT num_bytes, const void* src)
 {
-  char* out_ptr      = reinterpret_cast<char*>(dest);
-  const char* in_ptr = reinterpret_cast<const char*>(src);
+  char* out_ptr      = static_cast<char*>(dest);
+  const char* in_ptr = static_cast<const char*>(src);
 
   // Gets the byte range that can safely be copied using vectorized stores of type VectorT
   auto aligned_range = GetAlignedPtrs<VectorT>(src, dest, num_bytes);
@@ -313,7 +313,7 @@ vectorized_copy(int32_t thread_rank, void* dest, ByteOffsetT num_bytes, const vo
     // Copy bytes in range `[aligned_range.out_end, dest + num_bytes)`.
     out_ptr = reinterpret_cast<char*>(aligned_range.out_end) + thread_rank;
     in_ptr  = aligned_range.in_end + thread_rank;
-    while (out_ptr < reinterpret_cast<char*>(dest) + num_bytes)
+    while (out_ptr < static_cast<char*>(dest) + num_bytes)
     {
       *out_ptr = *in_ptr;
       out_ptr += LOGICAL_WARP_SIZE;
@@ -322,61 +322,53 @@ vectorized_copy(int32_t thread_rank, void* dest, ByteOffsetT num_bytes, const vo
   }
 }
 
-template <bool IsMemcpy,
-          uint32_t LOGICAL_WARP_SIZE,
-          typename InputBufferT,
-          typename OutputBufferT,
-          typename OffsetT,
-          ::cuda::std::enable_if_t<IsMemcpy, int> = 0>
-_CCCL_DEVICE _CCCL_FORCEINLINE void
-copy_items(InputBufferT input_buffer, OutputBufferT output_buffer, OffsetT num_bytes, OffsetT offset = 0)
-{
-  vectorized_copy<LOGICAL_WARP_SIZE, uint4>(
-    threadIdx.x % LOGICAL_WARP_SIZE,
-    &reinterpret_cast<char*>(output_buffer)[offset],
-    num_bytes,
-    &reinterpret_cast<const char*>(input_buffer)[offset]);
-}
-
-template <bool IsMemcpy,
-          uint32_t LOGICAL_WARP_SIZE,
-          typename InputBufferT,
-          typename OutputBufferT,
-          typename OffsetT,
-          ::cuda::std::enable_if_t<!IsMemcpy, int> = 0>
+template <bool IsMemcpy, uint32_t LOGICAL_WARP_SIZE, typename InputBufferT, typename OutputBufferT, typename OffsetT>
 _CCCL_DEVICE _CCCL_FORCEINLINE void
 copy_items(InputBufferT input_buffer, OutputBufferT output_buffer, OffsetT num_items, OffsetT offset = 0)
 {
-  output_buffer += offset;
-  input_buffer += offset;
-  for (OffsetT i = threadIdx.x % LOGICAL_WARP_SIZE; i < num_items; i += LOGICAL_WARP_SIZE)
+  if constexpr (IsMemcpy)
   {
-    *(output_buffer + i) = *(input_buffer + i);
+    vectorized_copy<LOGICAL_WARP_SIZE, uint4>(
+      threadIdx.x % LOGICAL_WARP_SIZE,
+      &reinterpret_cast<char*>(output_buffer)[offset],
+      num_items,
+      &reinterpret_cast<const char*>(input_buffer)[offset]);
+  }
+  else
+  {
+    output_buffer += offset;
+    input_buffer += offset;
+    for (OffsetT i = threadIdx.x % LOGICAL_WARP_SIZE; i < num_items; i += LOGICAL_WARP_SIZE)
+    {
+      *(output_buffer + i) = *(input_buffer + i);
+    }
   }
 }
 
-template <bool IsMemcpy, typename AliasT, typename InputIt, typename OffsetT, ::cuda::std::enable_if_t<IsMemcpy, int> = 0>
+template <bool IsMemcpy, typename AliasT, typename InputIt, typename OffsetT>
 _CCCL_DEVICE _CCCL_FORCEINLINE AliasT read_item(InputIt buffer_src, OffsetT offset)
 {
-  return *(reinterpret_cast<const AliasT*>(buffer_src) + offset);
+  if constexpr (IsMemcpy)
+  {
+    return *(reinterpret_cast<const AliasT*>(buffer_src) + offset);
+  }
+  else
+  {
+    return *(buffer_src + offset);
+  }
 }
 
-template <bool IsMemcpy, typename AliasT, typename InputIt, typename OffsetT, ::cuda::std::enable_if_t<!IsMemcpy, int> = 0>
-_CCCL_DEVICE _CCCL_FORCEINLINE AliasT read_item(InputIt buffer_src, OffsetT offset)
-{
-  return *(buffer_src + offset);
-}
-
-template <bool IsMemcpy, typename AliasT, typename OutputIt, typename OffsetT, ::cuda::std::enable_if_t<IsMemcpy, int> = 0>
+template <bool IsMemcpy, typename AliasT, typename OutputIt, typename OffsetT>
 _CCCL_DEVICE _CCCL_FORCEINLINE void write_item(OutputIt buffer_dst, OffsetT offset, AliasT value)
 {
-  *(reinterpret_cast<AliasT*>(buffer_dst) + offset) = value;
-}
-
-template <bool IsMemcpy, typename AliasT, typename OutputIt, typename OffsetT, ::cuda::std::enable_if_t<!IsMemcpy, int> = 0>
-_CCCL_DEVICE _CCCL_FORCEINLINE void write_item(OutputIt buffer_dst, OffsetT offset, AliasT value)
-{
-  *(buffer_dst + offset) = value;
+  if constexpr (IsMemcpy)
+  {
+    *(reinterpret_cast<AliasT*>(buffer_dst) + offset) = value;
+  }
+  else
+  {
+    *(buffer_dst + offset) = value;
+  }
 }
 
 enum class prefer_power_of_two_bits_option

--- a/cub/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/cub/agent/agent_batch_memcpy.cuh
@@ -32,7 +32,6 @@
 #include <cuda/__cmath/round_up.h>
 #include <cuda/std/__functional/operations.h>
 #include <cuda/std/__type_traits/conditional.h>
-#include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/type_identity.h>
 #include <cuda/std/cstdint>
 

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -91,7 +91,6 @@ __launch_bounds__(int(current_policy<PolicySelector>().large_buffer.threads_per_
     _CCCL_GRID_CONSTANT const TileOffsetT last_tile_offset)
 {
   static constexpr BatchedCopyLargeBufferPolicy policy = current_policy<PolicySelector>().large_buffer;
-  using StatusWord                                     = typename TileT::StatusWord;
   using BufferSizeT                                    = it_value_t<BufferSizeIteratorT>;
   /// Internal load/store type. For byte-wise memcpy, a single-byte type
   using AliasT = typename ::cuda::std::conditional_t<MemcpyOpt == CopyAlg::Memcpy,
@@ -225,8 +224,6 @@ __launch_bounds__(int(current_policy<PolicySelector>().small_buffer.threads_per_
     _CCCL_GRID_CONSTANT const BLevBlockOffsetTileState blev_block_scan_state)
 {
   static constexpr BatchedCopySmallBufferPolicy policy = current_policy<PolicySelector>().small_buffer;
-  // Internal type used for storing a buffer's size
-  using BufferSizeT = it_value_t<BufferSizeIteratorT>;
 
   // TODO(bgruber): refactor this in C++20, when we can pass policy as NTTP
   using AgentBatchMemcpyPolicyT = agent_batch_memcpy_policy<


### PR DESCRIPTION
- [x] No SASS changes for `cub.bench.copy.memcpy.base` on SM120
- [x] Merge before: #9658
