### PR TITLE
[cub] Implement macros for tuning policy definitions

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_macros.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_macros.cuh
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/config.cuh>
+
+#include <cuda/std/__concepts/same_as.h>
+#include <cuda/std/__host_stdlib/ostream>
+#include <cuda/std/__utility/exchange.h>
+
+#if __cpp_lib_format >= 201907L
+#  include <format>
+#  include <iterator>
+#  include <string>
+#endif // __cpp_lib_format >= 201907L
+
+#define CUB_TUNING_POLICY_FORMATTER_MEMBER_1(_TYPE, _NAME) \
+  ::std::format_to(                                        \
+    ::std::back_inserter(str), "{}." #_NAME " = {}", (::cuda::std::exchange(first, false)) ? "" : ", ", p._NAME);
+#define CUB_TUNING_POLICY_FORMATTER_MEMBER(_DESC) CUB_TUNING_POLICY_FORMATTER_MEMBER_1 _DESC
+
+#if __cpp_lib_format >= 201907L
+#  define CUB_DEFINE_TUNING_POLICY_FORMATTER(_NAME, ...)                             \
+    template <::cuda::std::same_as<char> CharT>                                      \
+    struct std::formatter<CUB_NS_QUALIFIER::_NAME, CharT> : formatter<string, CharT> \
+    {                                                                                \
+      template <class FmtCtx>                                                        \
+      auto format(const CUB_NS_QUALIFIER::_NAME& p, FmtCtx& ctx) const               \
+      {                                                                              \
+        string str;                                                                  \
+        str += #_NAME "{ ";                                                          \
+        bool first = true;                                                           \
+        _CCCL_PP_FOR_EACH(CUB_TUNING_POLICY_FORMATTER_MEMBER, __VA_ARGS__)           \
+        str += " }";                                                                 \
+        return formatter<string, CharT>::format(str, ctx);                           \
+      }                                                                              \
+    };
+#else // ^^^ __cpp_lib_format >= 201907L ^^^ / vvv __cpp_lib_format < 201907L vvv
+#  define CUB_DEFINE_TUNING_POLICY_FORMATTER(_NAME, ...)
+#endif // ^^^ __cpp_lib_format < 201907L ^^^
+
+#define CUB_DEFINE_TUNING_POLICY_MEMBER_1(_TYPE, _NAME) _TYPE _NAME;
+#define CUB_DEFINE_TUNING_POLICY_MEMBER(_DESC)          CUB_DEFINE_TUNING_POLICY_MEMBER_1 _DESC
+
+#define CUB_TUNING_POLICY_OPERATOR_EQ_1(_TYPE, _NAME) &&lhs._NAME == rhs._NAME
+#define CUB_TUNING_POLICY_OPERATOR_EQ(_DESC)          CUB_TUNING_POLICY_OPERATOR_EQ_1 _DESC
+
+#define CUB_TUNING_POLICY_OPERATOR_SHL_1(_TYPE, _NAME) \
+  << ((::cuda::std::exchange(first, false)) ? "" : ", ") << "." #_NAME " = " << p._NAME
+#define CUB_TUNING_POLICY_OPERATOR_SHL(_DESC) CUB_TUNING_POLICY_OPERATOR_SHL_1 _DESC
+
+// Macro for tuning policy definition. Must be used in global namespace.
+#define CUB_DEFINE_TUNING_POLICY(_NAME, ...)                                                                 \
+  CUB_NAMESPACE_BEGIN                                                                                        \
+                                                                                                             \
+  struct _NAME                                                                                               \
+  {                                                                                                          \
+    _CCCL_PP_FOR_EACH(CUB_DEFINE_TUNING_POLICY_MEMBER, __VA_ARGS__)                                          \
+                                                                                                             \
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool operator==(const _NAME& lhs, const _NAME& rhs) \
+    {                                                                                                        \
+      return true _CCCL_PP_FOR_EACH(CUB_TUNING_POLICY_OPERATOR_EQ, __VA_ARGS__);                             \
+    }                                                                                                        \
+                                                                                                             \
+    [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool operator!=(const _NAME& lhs, const _NAME& rhs) \
+    {                                                                                                        \
+      return !(lhs == rhs);                                                                                  \
+    }                                                                                                        \
+                                                                                                             \
+    friend ::std::ostream& operator<<(::std::ostream& os, const _NAME& p)                                    \
+    {                                                                                                        \
+      bool first = true;                                                                                     \
+      return os << #_NAME "{ " _CCCL_PP_FOR_EACH(CUB_TUNING_POLICY_OPERATOR_SHL, __VA_ARGS__) << " }";       \
+    }                                                                                                        \
+  };                                                                                                         \
+                                                                                                             \
+  CUB_NAMESPACE_END                                                                                          \
+                                                                                                             \
+  CUB_DEFINE_TUNING_POLICY_FORMATTER(_NAME, __VA_ARGS__)

--- a/cub/test/catch2_test_tuning_macros.cu
+++ b/cub/test/catch2_test_tuning_macros.cu
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/block/block_store.cuh>
+#include <cub/device/dispatch/tuning/tuning_macros.cuh>
+
+#include <cuda/std/type_traits>
+
+#include <format>
+#include <sstream>
+
+#include <c2h/catch2_test_helper.h>
+
+CUB_DEFINE_TUNING_POLICY(PolicyInt, (int, int_val))
+
+void test_policy_int()
+{
+  static_assert(!cuda::std::is_empty_v<cub::PolicyInt>);
+  static_assert(cuda::std::is_same_v<int, decltype(cub::PolicyInt::int_val)>);
+
+  static_assert(cuda::std::is_trivially_default_constructible_v<cub::PolicyInt>);
+  static_assert(cuda::std::is_trivially_copy_constructible_v<cub::PolicyInt>);
+
+  const cub::PolicyInt p1{10};
+  REQUIRE(p1 == p1);
+  REQUIRE(!(p1 != p1));
+
+  const cub::PolicyInt p2{3};
+  REQUIRE(!(p1 == p2));
+  REQUIRE(p1 != p2);
+
+  constexpr auto p1_formatted = "PolicyInt{ .int_val = 10 }";
+  std::ostringstream oss{};
+  oss << p1;
+  REQUIRE(oss.str() == p1_formatted);
+
+#if __cpp_lib_format >= 201907L
+  REQUIRE(std::format("{}", p1) == p1_formatted);
+#endif // __cpp_lib_format >= 201907L
+}
+
+CUB_DEFINE_TUNING_POLICY(PolicyIntEnum, (int, int_val), (BlockStoreAlgorithm, algo))
+
+void test_policy_int_enum()
+{
+  static_assert(!cuda::std::is_empty_v<cub::PolicyIntEnum>);
+  static_assert(cuda::std::is_same_v<int, decltype(cub::PolicyIntEnum::int_val)>);
+  static_assert(cuda::std::is_same_v<cub::BlockStoreAlgorithm, decltype(cub::PolicyIntEnum::algo)>);
+
+  static_assert(cuda::std::is_trivially_default_constructible_v<cub::PolicyIntEnum>);
+  static_assert(cuda::std::is_trivially_copy_constructible_v<cub::PolicyIntEnum>);
+
+  const cub::PolicyIntEnum p1{10, cub::BLOCK_STORE_DIRECT};
+  REQUIRE(p1 == p1);
+  REQUIRE(!(p1 != p1));
+
+  const cub::PolicyIntEnum p2{3, cub::BLOCK_STORE_DIRECT};
+  REQUIRE(!(p1 == p2));
+  REQUIRE(p1 != p2);
+
+  const cub::PolicyIntEnum p3{10, cub::BLOCK_STORE_STRIPED};
+  REQUIRE(!(p1 == p3));
+  REQUIRE(p1 != p3);
+
+  constexpr auto p1_formatted = "PolicyIntEnum{ .int_val = 10, .algo = BLOCK_STORE_DIRECT }";
+  std::ostringstream oss{};
+  oss << p1;
+  REQUIRE(oss.str() == p1_formatted);
+
+#if __cpp_lib_format >= 201907L
+  REQUIRE(std::format("{}", p1) == p1_formatted);
+#endif // __cpp_lib_format >= 201907L
+}
+
+C2H_TEST("Tuning macros", "")
+{
+  test_policy_int();
+  test_policy_int_enum();
+}


### PR DESCRIPTION
We write a lot of similar code for our tuning policies which is prone to bugs. I've implemented some macros to define the tuning policy `struct` + member functions + formatters for us in one line.