### PR TITLE
[cudax] Implement `cudax::coop::any_of` algorithm for <= warp groups

### DIFF
--- a/cudax/include/cuda/experimental/__coop/any_of.cuh
+++ b/cudax/include/cuda/experimental/__coop/any_of.cuh
@@ -1,0 +1,137 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_EXPERIMENTAL___COOP_ANY_OF_CUH
+#define _CUDA_EXPERIMENTAL___COOP_ANY_OF_CUH
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__functional/operations.h>
+#include <cuda/std/__numeric/reduce.h>
+#include <cuda/std/__type_traits/integral_constant.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/optional>
+
+#include <cuda/experimental/__utility/broadcasted.cuh>
+#include <cuda/experimental/group.cuh>
+
+#include <cuda/std/__cccl/prologue.h>
+
+#if !defined(_CCCL_DOXYGEN_INVOKED)
+
+// todo: Can we make any_of be implemented as reduce(group, data, cuda::std::logical_or{})?
+
+namespace cuda::experimental::coop
+{
+template <bool _Dummy = false>
+_CCCL_DEVICE_API auto __any_of_impl(...)
+{
+  static_assert(_Dummy, "cudax::coop::any_of is not supported for the group");
+}
+
+template <bool _Broadcasted, class _Hierarchy>
+[[nodiscard]] _CCCL_DEVICE_API auto
+__any_of_impl(::cuda::std::bool_constant<_Broadcasted>, const this_thread<_Hierarchy>&, bool __thread_data)
+{
+  if constexpr (_Broadcasted)
+  {
+    return __thread_data;
+  }
+  else
+  {
+    return ::cuda::std::optional{__thread_data};
+  }
+}
+
+_CCCL_TEMPLATE(bool _Broadcasted, class _Group)
+_CCCL_REQUIRES(is_group<_Group> _CCCL_AND ::cuda::std::is_same_v<typename _Group::level_type, warp_level>)
+[[nodiscard]] _CCCL_DEVICE_API auto
+__any_of_impl(::cuda::std::bool_constant<_Broadcasted>, const _Group& __group, bool __thread_data) noexcept
+{
+  const auto& __mapping_result = __group.__mapping_result();
+  const auto __result          = static_cast<bool>(::__any_sync(__mapping_result.lane_mask().value(), __thread_data));
+  if constexpr (_Broadcasted)
+  {
+    return __result;
+  }
+  else
+  {
+    return (gpu_thread.is_root_rank(__group)) ? ::cuda::std::optional{__result} : ::cuda::std::nullopt;
+  }
+}
+
+_CCCL_TEMPLATE(class _Group, class _Tp)
+_CCCL_REQUIRES(::cuda::std::is_same_v<_Tp, bool>)
+[[nodiscard]] _CCCL_DEVICE_API ::cuda::std::optional<bool> any_of(const _Group& __group, _Tp __thread_data)
+{
+  _CCCL_ASSERT(gpu_thread.is_part_of(__group), "Only threads that are part of the group can call cudax::coop::any_of");
+  return ::cuda::experimental::coop::__any_of_impl(::cuda::std::false_type{}, __group, __thread_data);
+}
+
+_CCCL_TEMPLATE(class _Group, class _Tp)
+_CCCL_REQUIRES(::cuda::std::is_same_v<_Tp, bool>)
+[[nodiscard]] _CCCL_DEVICE_API bool any_of(broadcasted_t, const _Group& __group, _Tp __thread_data)
+{
+  _CCCL_ASSERT(gpu_thread.is_part_of(__group), "Only threads that are part of the group can call cudax::coop::any_of");
+  return ::cuda::experimental::coop::__any_of_impl(::cuda::std::true_type{}, __group, __thread_data);
+}
+
+_CCCL_TEMPLATE(class _Group, class _Tp, ::cuda::std::size_t _Np)
+_CCCL_REQUIRES(::cuda::std::is_same_v<_Tp, bool>)
+[[nodiscard]] _CCCL_DEVICE_API ::cuda::std::optional<bool> any_of(const _Group& __group, _Tp (&__thread_data)[_Np])
+{
+  _CCCL_ASSERT(gpu_thread.is_part_of(__group), "Only threads that are part of the group can call cudax::coop::any_of");
+  return ::cuda::experimental::coop::any_of(
+    __group, ::cuda::std::reduce(__thread_data, __thread_data + _Np, false, ::cuda::std::logical_or<bool>{}));
+}
+
+_CCCL_TEMPLATE(class _Group, class _Tp, ::cuda::std::size_t _Np)
+_CCCL_REQUIRES(::cuda::std::is_same_v<_Tp, bool>)
+[[nodiscard]] _CCCL_DEVICE_API bool any_of(broadcasted_t, const _Group& __group, _Tp (&__thread_data)[_Np])
+{
+  _CCCL_ASSERT(gpu_thread.is_part_of(__group), "Only threads that are part of the group can call cudax::coop::any_of");
+  return ::cuda::experimental::coop::any_of(
+    broadcasted,
+    __group,
+    ::cuda::std::reduce(__thread_data, __thread_data + _Np, false, ::cuda::std::logical_or<bool>{}));
+}
+
+_CCCL_TEMPLATE(class _Group, class _Tp)
+_CCCL_REQUIRES((!::cuda::std::is_same_v<_Tp, bool>) )
+auto any_of(const _Group& __group, _Tp __thread_data) = delete;
+
+_CCCL_TEMPLATE(class _Group, class _Tp)
+_CCCL_REQUIRES((!::cuda::std::is_same_v<_Tp, bool>) )
+auto any_of(broadcasted_t, const _Group& __group, _Tp __thread_data) = delete;
+
+_CCCL_TEMPLATE(class _Group, class _Tp, ::cuda::std::size_t _Np)
+_CCCL_REQUIRES((!::cuda::std::is_same_v<_Tp, bool>) )
+auto any_of(const _Group& __group, _Tp (&__thread_data)[_Np]) = delete;
+
+_CCCL_TEMPLATE(class _Group, class _Tp, ::cuda::std::size_t _Np)
+_CCCL_REQUIRES((!::cuda::std::is_same_v<_Tp, bool>) )
+auto any_of(broadcasted_t, const _Group& __group, _Tp (&__thread_data)[_Np]) = delete;
+} // namespace cuda::experimental::coop
+
+#endif // !_CCCL_DOXYGEN_INVOKED
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_EXPERIMENTAL___COOP_ANY_OF_CUH

--- a/cudax/include/cuda/experimental/coop.cuh
+++ b/cudax/include/cuda/experimental/coop.cuh
@@ -21,6 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/experimental/__coop/any_of.cuh>
 #include <cuda/experimental/__coop/reduce.cuh>
 #include <cuda/experimental/__coop/shuffle.cuh>
 #include <cuda/experimental/__coop/shuffle_down.cuh>

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -186,6 +186,16 @@ cudax_add_catch2_test(test_target group.invoke_one
     group/invoke_one.cu
 )
 
+cudax_add_catch2_test(test_target coop.any_of.this_thread
+    coop/any_of/this_thread.cu
+)
+cudax_add_catch2_test(test_target coop.any_of.this_warp
+    coop/any_of/this_warp.cu
+)
+cudax_add_catch2_test(test_target coop.any_of.threads_within_warp
+    coop/any_of/threads_within_warp.cu
+)
+
 cudax_add_catch2_test(test_target coop.reduce.this_thread
     coop/reduce/this_thread.cu
 )

--- a/cudax/test/coop/any_of/this_thread.cu
+++ b/cudax/test/coop/any_of/this_thread.cu
@@ -1,0 +1,139 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/devices>
+#include <cuda/hierarchy>
+#include <cuda/launch>
+#include <cuda/stream>
+
+#include <cuda/experimental/coop.cuh>
+#include <cuda/experimental/group.cuh>
+
+#include "testing.cuh"
+
+template <class Group>
+__device__ void test_group(const Group& group)
+{
+  // Single value tests.
+  {
+    // Test all threads with false.
+    {
+      const auto result = cudax::coop::any_of(group, false);
+      REQUIRE(result.has_value());
+      if (result.has_value())
+      {
+        REQUIRE(!result.value());
+      }
+    }
+
+    // Test all threads with true.
+    {
+      const auto result = cudax::coop::any_of(group, true);
+      REQUIRE(result.has_value());
+      if (result.has_value())
+      {
+        REQUIRE(result.value());
+      }
+    }
+  }
+
+  {
+    // Test all threads with false (broadcasted).
+    {
+      const bool result = cudax::coop::any_of(cudax::broadcasted, group, false);
+      REQUIRE(!result);
+    }
+
+    // Test all threads with true (broadcasted).
+    {
+      const bool result = cudax::coop::any_of(cudax::broadcasted, group, true);
+      REQUIRE(result);
+    }
+  }
+
+  // Array tests.
+  {
+    // Test all threads with false.
+    {
+      bool in[]{false, false, false};
+      const auto result = cudax::coop::any_of(group, in);
+      REQUIRE(result.has_value());
+      if (result.has_value())
+      {
+        REQUIRE(!result.value());
+      }
+    }
+
+    // Test all threads with true.
+    {
+      bool in[]{true, true, true, true};
+      const auto result = cudax::coop::any_of(group, in);
+      REQUIRE(result.has_value());
+      if (result.has_value())
+      {
+        REQUIRE(result.value());
+      }
+    }
+
+    // Test all threads except 1 with false.
+    {
+      bool in[]{false, false, true};
+      const auto result = cudax::coop::any_of(group, in);
+      REQUIRE(result.has_value());
+      if (result.has_value())
+      {
+        REQUIRE(result.value());
+      }
+    }
+
+    // Test all threads with false (broadcasted).
+    {
+      bool in[]{false, false, false};
+      const bool result = cudax::coop::any_of(cudax::broadcasted, group, in);
+      REQUIRE(!result);
+    }
+
+    // Test all threads with true (broadcasted).
+    {
+      bool in[]{true, true, true, true};
+      const bool result = cudax::coop::any_of(cudax::broadcasted, group, in);
+      REQUIRE(result);
+    }
+
+    // Test all threads except 1 with false (broadcasted).
+    {
+      bool in[]{false, false, true};
+      const bool result = cudax::coop::any_of(cudax::broadcasted, group, in);
+      REQUIRE(result);
+    }
+  }
+}
+
+struct TestKernel
+{
+  template <class Config>
+  __device__ void operator()(const Config& config)
+  {
+    test_group(cudax::this_thread{});
+    test_group(cudax::this_thread{config});
+  }
+};
+
+C2H_TEST("any_of/this_thread", "[any_of][this_thread]")
+{
+  const auto device = cuda::devices[0];
+
+  const cuda::stream stream{device};
+
+  const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims<32>());
+  cuda::launch(stream, config, TestKernel{});
+
+  stream.sync();
+}

--- a/cudax/test/coop/any_of/this_warp.cu
+++ b/cudax/test/coop/any_of/this_warp.cu
@@ -1,0 +1,156 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/devices>
+#include <cuda/hierarchy>
+#include <cuda/launch>
+#include <cuda/stream>
+
+#include <cuda/experimental/coop.cuh>
+#include <cuda/experimental/group.cuh>
+
+#include "testing.cuh"
+
+template <class Group>
+__device__ void test_group(const Group& group)
+{
+  const auto my_rank = cuda::gpu_thread.rank_as<unsigned>(group);
+
+  // Single value tests.
+  {
+    // Test all threads with false.
+    {
+      const auto result = cudax::coop::any_of(group, false);
+      REQUIRE(result.has_value() == (my_rank == 0));
+      if (result.has_value())
+      {
+        REQUIRE(!result.value());
+      }
+    }
+
+    // Test all threads with true.
+    {
+      const auto result = cudax::coop::any_of(group, true);
+      REQUIRE(result.has_value() == (my_rank == 0));
+      if (result.has_value())
+      {
+        REQUIRE(result.value());
+      }
+    }
+
+    // Test all threads except 1 with false.
+    {
+      const auto result = cudax::coop::any_of(group, (my_rank == cuda::gpu_thread.count_as<unsigned>(group) - 1));
+      REQUIRE(result.has_value() == (my_rank == 0));
+      if (result.has_value())
+      {
+        REQUIRE(result.value());
+      }
+    }
+
+    // Test all threads with false (broadcasted).
+    {
+      const bool result = cudax::coop::any_of(cudax::broadcasted, group, false);
+      REQUIRE(!result);
+    }
+
+    // Test all threads with true (broadcasted).
+    {
+      const bool result = cudax::coop::any_of(cudax::broadcasted, group, true);
+      REQUIRE(result);
+    }
+
+    // Test all threads except 1 with false (broadcasted).
+    {
+      const bool result =
+        cudax::coop::any_of(cudax::broadcasted, group, (my_rank == cuda::gpu_thread.count_as<unsigned>(group) - 1));
+      REQUIRE(result);
+    }
+  }
+
+  // Array tests.
+  {
+    // Test all threads with false.
+    {
+      bool in[]{false, false, false};
+      const auto result = cudax::coop::any_of(group, in);
+      REQUIRE(result.has_value() == (my_rank == 0));
+      if (result.has_value())
+      {
+        REQUIRE(!result.value());
+      }
+    }
+
+    // Test all threads with true.
+    {
+      bool in[]{true, true, true, true};
+      const auto result = cudax::coop::any_of(group, in);
+      REQUIRE(result.has_value() == (my_rank == 0));
+      if (result.has_value())
+      {
+        REQUIRE(result.value());
+      }
+    }
+
+    // Test all threads except 1 with false.
+    {
+      bool in[]{false, false, my_rank == cuda::gpu_thread.count_as<unsigned>(group) - 1};
+      const auto result = cudax::coop::any_of(group, in);
+      REQUIRE(result.has_value() == (my_rank == 0));
+      if (result.has_value())
+      {
+        REQUIRE(result.value());
+      }
+    }
+
+    // Test all threads with false (broadcasted).
+    {
+      bool in[]{false, false, false};
+      const bool result = cudax::coop::any_of(cudax::broadcasted, group, in);
+      REQUIRE(!result);
+    }
+
+    // Test all threads with true (broadcasted).
+    {
+      bool in[]{true, true, true, true};
+      const bool result = cudax::coop::any_of(cudax::broadcasted, group, in);
+      REQUIRE(result);
+    }
+
+    // Test all threads except 1 with false (broadcasted).
+    {
+      bool in[]{false, false, my_rank == cuda::gpu_thread.count_as<unsigned>(group) - 1};
+      const bool result = cudax::coop::any_of(cudax::broadcasted, group, in);
+      REQUIRE(result);
+    }
+  }
+}
+
+struct TestKernel
+{
+  template <class Config>
+  __device__ void operator()(const Config& config)
+  {
+    test_group(cudax::this_warp{});
+    test_group(cudax::this_warp{config});
+  }
+};
+
+C2H_TEST("any_of/this_warp", "[any_of][this_warp]")
+{
+  const auto device = cuda::devices[0];
+
+  const cuda::stream stream{device};
+
+  const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims<32>());
+  cuda::launch(stream, config, TestKernel{});
+
+  stream.sync();
+}

--- a/cudax/test/coop/any_of/threads_within_warp.cu
+++ b/cudax/test/coop/any_of/threads_within_warp.cu
@@ -1,0 +1,187 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/devices>
+#include <cuda/hierarchy>
+#include <cuda/launch>
+#include <cuda/stream>
+
+#include <cuda/experimental/coop.cuh>
+#include <cuda/experimental/group.cuh>
+
+#include "testing.cuh"
+
+template <class Group>
+__device__ void test_group(const Group& group)
+{
+  // Exit all threads that are not part of the group.
+  if (!cuda::gpu_thread.is_part_of(group))
+  {
+    return;
+  }
+
+  const auto my_rank = cuda::gpu_thread.rank_as<unsigned>(group);
+
+  // Single value tests.
+  {
+    // Test all threads with false.
+    {
+      const auto result = cudax::coop::any_of(group, false);
+      REQUIRE(result.has_value() == (my_rank == 0));
+      if (result.has_value())
+      {
+        REQUIRE(!result.value());
+      }
+    }
+
+    // Test all threads with true.
+    {
+      const auto result = cudax::coop::any_of(group, true);
+      REQUIRE(result.has_value() == (my_rank == 0));
+      if (result.has_value())
+      {
+        REQUIRE(result.value());
+      }
+    }
+
+    // Test all threads except 1 with false.
+    {
+      const auto result = cudax::coop::any_of(group, (my_rank == cuda::gpu_thread.count_as<unsigned>(group) - 1));
+      REQUIRE(result.has_value() == (my_rank == 0));
+      if (result.has_value())
+      {
+        REQUIRE(result.value());
+      }
+    }
+
+    // Test all threads with false (broadcasted).
+    {
+      const bool result = cudax::coop::any_of(cudax::broadcasted, group, false);
+      REQUIRE(!result);
+    }
+
+    // Test all threads with true (broadcasted).
+    {
+      const bool result = cudax::coop::any_of(cudax::broadcasted, group, true);
+      REQUIRE(result);
+    }
+
+    // Test all threads except 1 with false (broadcasted).
+    {
+      const bool result =
+        cudax::coop::any_of(cudax::broadcasted, group, (my_rank == cuda::gpu_thread.count_as<unsigned>(group) - 1));
+      REQUIRE(result);
+    }
+  }
+
+  // Array tests.
+  {
+    // Test all threads with false.
+    {
+      bool in[]{false, false, false};
+      const auto result = cudax::coop::any_of(group, in);
+      REQUIRE(result.has_value() == (my_rank == 0));
+      if (result.has_value())
+      {
+        REQUIRE(!result.value());
+      }
+    }
+
+    // Test all threads with true.
+    {
+      bool in[]{true, true, true, true};
+      const auto result = cudax::coop::any_of(group, in);
+      REQUIRE(result.has_value() == (my_rank == 0));
+      if (result.has_value())
+      {
+        REQUIRE(result.value());
+      }
+    }
+
+    // Test all threads except 1 with false.
+    {
+      bool in[]{false, false, my_rank == cuda::gpu_thread.count_as<unsigned>(group) - 1};
+      const auto result = cudax::coop::any_of(group, in);
+      REQUIRE(result.has_value() == (my_rank == 0));
+      if (result.has_value())
+      {
+        REQUIRE(result.value());
+      }
+    }
+
+    // Test all threads with false (broadcasted).
+    {
+      bool in[]{false, false, false};
+      const bool result = cudax::coop::any_of(cudax::broadcasted, group, in);
+      REQUIRE(!result);
+    }
+
+    // Test all threads with true (broadcasted).
+    {
+      bool in[]{true, true, true, true};
+      const bool result = cudax::coop::any_of(cudax::broadcasted, group, in);
+      REQUIRE(result);
+    }
+
+    // Test all threads except 1 with false (broadcasted).
+    {
+      bool in[]{false, false, my_rank == cuda::gpu_thread.count_as<unsigned>(group) - 1};
+      const bool result = cudax::coop::any_of(cudax::broadcasted, group, in);
+      REQUIRE(result);
+    }
+  }
+}
+
+struct CustomBinaryPartition
+{
+  template <class MappingResult>
+  __device__ bool operator()(MappingResult mapping_result)
+  {
+    switch (mapping_result.unit_rank())
+    {
+      case 1:
+      case 5:
+      case 14:
+      case 15:
+      case 31:
+        return true;
+      default:
+        return false;
+    }
+  }
+};
+
+struct TestKernel
+{
+  template <class Config>
+  __device__ void operator()(const Config& config)
+  {
+    const cudax::this_warp warp{config};
+    test_group(cudax::group{cuda::gpu_thread, warp, cudax::identity_mapping{}, cudax::lane_synchronizer{}});
+    test_group(cudax::group{cuda::gpu_thread, warp, cudax::group_by<4>{}, cudax::lane_synchronizer{}});
+    test_group(cudax::group{cuda::gpu_thread, warp, cudax::group_by{1}, cudax::lane_synchronizer{}});
+    test_group(
+      cudax::group{cuda::gpu_thread, warp, cudax::group_by{3, cudax::non_exhaustive}, cudax::lane_synchronizer{}});
+    test_group(cudax::group{
+      cuda::gpu_thread, warp, cudax::binary_partition{CustomBinaryPartition{}}, cudax::lane_synchronizer{}});
+  }
+};
+
+C2H_TEST("any_of/threads_within_warp", "[any_of][threads_within_warp]")
+{
+  const auto device = cuda::devices[0];
+
+  const cuda::stream stream{device};
+
+  const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims<32>());
+  cuda::launch(stream, config, TestKernel{});
+
+  stream.sync();
+}


### PR DESCRIPTION
Fixes #9669, #9670 and #9672.