### PR TITLE
Update Node 20 GitHub Actions

### DIFF
--- a/.github/actions/docs-build/action.yml
+++ b/.github/actions/docs-build/action.yml
@@ -27,7 +27,7 @@ runs:
     # Update docs as workflow artifact:
     - name: Upload artifact
       if: ${{ inputs.upload_workflow_artifact == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
       with:
         name: docs
         path: _site/

--- a/.github/actions/upload-artifacts/action.yml
+++ b/.github/actions/upload-artifacts/action.yml
@@ -52,7 +52,7 @@ runs:
 
     - name: Upload artifact 0
       if: ${{ steps.parse.outputs.enabled0 == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
       with:
         name: ${{ steps.parse.outputs.name0 }}
         path: ${{ steps.parse.outputs.path0 }}
@@ -60,7 +60,7 @@ runs:
         compression-level: ${{ steps.parse.outputs.compression_level0 }}
     - name: Upload artifact 1
       if: ${{ steps.parse.outputs.enabled1 == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
       with:
         name: ${{ steps.parse.outputs.name1 }}
         path: ${{ steps.parse.outputs.path1 }}
@@ -68,7 +68,7 @@ runs:
         compression-level: ${{ steps.parse.outputs.compression_level1 }}
     - name: Upload artifact 2
       if: ${{ steps.parse.outputs.enabled2 == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
       with:
         name: ${{ steps.parse.outputs.name2 }}
         path: ${{ steps.parse.outputs.path2 }}
@@ -76,7 +76,7 @@ runs:
         compression-level: ${{ steps.parse.outputs.compression_level2 }}
     - name: Upload artifact 3
       if: ${{ steps.parse.outputs.enabled3 == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
       with:
         name: ${{ steps.parse.outputs.name3 }}
         path: ${{ steps.parse.outputs.path3 }}
@@ -84,7 +84,7 @@ runs:
         compression-level: ${{ steps.parse.outputs.compression_level3 }}
     - name: Upload artifact 4
       if: ${{ steps.parse.outputs.enabled4 == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
       with:
         name: ${{ steps.parse.outputs.name4 }}
         path: ${{ steps.parse.outputs.path4 }}
@@ -92,7 +92,7 @@ runs:
         compression-level: ${{ steps.parse.outputs.compression_level4 }}
     - name: Upload artifact 5
       if: ${{ steps.parse.outputs.enabled5 == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
       with:
         name: ${{ steps.parse.outputs.name5 }}
         path: ${{ steps.parse.outputs.path5 }}
@@ -100,7 +100,7 @@ runs:
         compression-level: ${{ steps.parse.outputs.compression_level5 }}
     - name: Upload artifact 6
       if: ${{ steps.parse.outputs.enabled6 == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
       with:
         name: ${{ steps.parse.outputs.name6 }}
         path: ${{ steps.parse.outputs.path6 }}
@@ -108,7 +108,7 @@ runs:
         compression-level: ${{ steps.parse.outputs.compression_level6 }}
     - name: Upload artifact 7
       if: ${{ steps.parse.outputs.enabled7 == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
       with:
         name: ${{ steps.parse.outputs.name7 }}
         path: ${{ steps.parse.outputs.path7 }}
@@ -116,7 +116,7 @@ runs:
         compression-level: ${{ steps.parse.outputs.compression_level7 }}
     - name: Upload artifact 8
       if: ${{ steps.parse.outputs.enabled8 == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
       with:
         name: ${{ steps.parse.outputs.name8 }}
         path: ${{ steps.parse.outputs.path8 }}
@@ -124,7 +124,7 @@ runs:
         compression-level: ${{ steps.parse.outputs.compression_level8 }}
     - name: Upload artifact 9
       if: ${{ steps.parse.outputs.enabled9 == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
       with:
         name: ${{ steps.parse.outputs.name9 }}
         path: ${{ steps.parse.outputs.path9 }}

--- a/.github/actions/workflow-build/action.yml
+++ b/.github/actions/workflow-build/action.yml
@@ -184,7 +184,7 @@ runs:
         echo "::endgroup::"
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
       with:
         name: workflow
         path: workflow/

--- a/.github/actions/workflow-results/action.yml
+++ b/.github/actions/workflow-results/action.yml
@@ -28,14 +28,14 @@ runs:
   steps:
 
     - name: Download workflow artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
       with:
         name: workflow
         path: workflow/
 
     - name: Download job artifacts
       continue-on-error: true # This may fail if no jobs succeed. The checks below will catch this.
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
       with:
         path: jobs
         pattern: zz_jobs-*
@@ -55,7 +55,7 @@ runs:
     - name: Fetch workflow job info
       if: ${{ inputs.github_token != ''}}
       continue-on-error: true
-      uses: actions/github-script@v7
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
       with:
         github-token: ${{ inputs.github_token }}
         script: |

--- a/.github/actions/workflow-run-job-linux/action.yml
+++ b/.github/actions/workflow-run-job-linux/action.yml
@@ -68,7 +68,7 @@ runs:
 
     - name: Get AWS credentials for sccache bucket
       if: ${{ github.repository == 'NVIDIA/cccl' }}
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b  # v6
       with:
         role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-NVIDIA
         aws-region: us-east-2

--- a/.github/actions/workflow-run-job-windows/action.yml
+++ b/.github/actions/workflow-run-job-windows/action.yml
@@ -88,7 +88,7 @@ runs:
 
     - name: Get AWS credentials for sccache bucket
       if: ${{ github.repository == 'NVIDIA/cccl' }}
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b  # v6
       with:
         role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-NVIDIA
         aws-region: us-east-2

--- a/.github/workflows/backport-prs.yml
+++ b/.github/workflows/backport-prs.yml
@@ -29,6 +29,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Create backport pull requests
-        uses: korthout/backport-action@v3
+        uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8  # v4
         with:
           merge_commits: 'skip'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -125,7 +125,7 @@ jobs:
           persist-credentials: false
 
       - name: Get AWS credentials for sccache bucket
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b  # v6
         with:
           role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-NVIDIA
           aws-region: us-east-2
@@ -363,7 +363,7 @@ jobs:
 
       - name: Upload benchmark artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: ${{ steps.run-benchmark-compare.outputs.artifact_name }}
           path: bench-artifacts/*

--- a/.github/workflows/build-matx.yml
+++ b/.github/workflows/build-matx.yml
@@ -51,7 +51,7 @@ jobs:
           persist-credentials: false
       - name: Add NVCC problem matcher
         run: echo "::add-matcher::$(pwd)/.github/problem-matchers/problem-matcher.json"
-      - uses: aws-actions/configure-aws-credentials@v5
+      - uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b  # v6
         if: ${{ github.repository == 'NVIDIA/cccl' }}
         with:
           role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-NVIDIA

--- a/.github/workflows/build-pytorch.yml
+++ b/.github/workflows/build-pytorch.yml
@@ -51,7 +51,7 @@ jobs:
           persist-credentials: false
       - name: Add NVCC problem matcher
         run: echo "::add-matcher::$(pwd)/.github/problem-matchers/problem-matcher.json"
-      - uses: aws-actions/configure-aws-credentials@v5
+      - uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b  # v6
         if: ${{ github.repository == 'NVIDIA/cccl' }}
         with:
           role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-NVIDIA

--- a/.github/workflows/build-rapids.yml
+++ b/.github/workflows/build-rapids.yml
@@ -78,7 +78,7 @@ jobs:
           persist-credentials: false
       - name: Add NVCC problem matcher
         run: echo "::add-matcher::$(pwd)/.github/problem-matchers/problem-matcher.json"
-      - uses: aws-actions/configure-aws-credentials@v5
+      - uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b  # v6
         if: ${{ github.repository == 'NVIDIA/cccl' }}
         with:
           role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-NVIDIA

--- a/.github/workflows/ci-workflow-pull-request.yml
+++ b/.github/workflows/ci-workflow-pull-request.yml
@@ -276,7 +276,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           persist-credentials: false
 
@@ -343,7 +343,7 @@ jobs:
     steps:
       - name: Download wheel artifact
         id: download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
         continue-on-error: true
         with:
           name: wheel-cccl-linux-amd64-py3.14
@@ -362,7 +362,7 @@ jobs:
 
       - name: Set up Python
         if: steps.check-wheel.outputs.skip != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: '3.14'
 

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ github.repository == 'NVIDIA/cccl' && 'linux-amd64-cpu32' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           persist-credentials: false
 
@@ -114,7 +114,7 @@ jobs:
           cp -a _site/. "${root_dir}/"
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453  # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./deploy

--- a/.github/workflows/git-bisect.yml
+++ b/.github/workflows/git-bisect.yml
@@ -222,7 +222,7 @@ jobs:
 
       - name: Get AWS credentials for sccache bucket
         if: ${{ github.repository == 'NVIDIA/cccl' }}
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b  # v6
         with:
           role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-NVIDIA
           aws-region: us-east-2

--- a/.github/workflows/verify-devcontainers.yml
+++ b/.github/workflows/verify-devcontainers.yml
@@ -128,7 +128,7 @@ jobs:
       # We don't really need sccache configured, but we need the AWS credentials envvars to be set
       # in order to avoid the devcontainer hanging waiting for GitHub authentication
     - name: Get AWS credentials for sccache bucket
-      uses: aws-actions/configure-aws-credentials@v5
+      uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b  # v6
       with:
         role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-NVIDIA
         aws-region: us-east-2


### PR DESCRIPTION
Updates Node 20 GitHub Action workflows to newer versions.

This is to get rid of the warning annotations for using a deprecated Node version and hopefully allow our nightlight GHA workflow log to load again. 