### PR TITLE
Adds `thrust::erase` and `thrust::erase_if`

### DIFF
--- a/thrust/testing/cuda/erase.cu
+++ b/thrust/testing/cuda/erase.cu
@@ -52,17 +52,17 @@ void TestEraseCudaStreams()
   Vector data{1, 2, 1, 3, 2};
 
   cudaStream_t s;
-  cudaStreamCreate(&s);
+  ASSERT_EQUAL(cudaSuccess, cudaStreamCreate(&s));
 
   size_t removed = thrust::erase(thrust::cuda::par.on(s), data, (T) 2);
 
-  cudaStreamSynchronize(s);
+  ASSERT_EQUAL(cudaSuccess, cudaStreamSynchronize(s));
 
   Vector ref{1, 1, 3};
   ASSERT_EQUAL(removed, 2ul);
   ASSERT_EQUAL(data, ref);
 
-  cudaStreamDestroy(s);
+  ASSERT_EQUAL(cudaSuccess, cudaStreamDestroy(s));
 }
 
 DECLARE_UNITTEST(TestEraseCudaStreams);
@@ -75,17 +75,17 @@ void TestEraseIfCudaStreams()
   Vector data{1, 2, 1, 3, 2};
 
   cudaStream_t s;
-  cudaStreamCreate(&s);
+  ASSERT_EQUAL(cudaSuccess, cudaStreamCreate(&s));
 
   size_t removed = thrust::erase_if(thrust::cuda::par.on(s), data, is_even<T>());
 
-  cudaStreamSynchronize(s);
+  ASSERT_EQUAL(cudaSuccess, cudaStreamSynchronize(s));
 
   Vector ref{1, 1, 3};
   ASSERT_EQUAL(removed, 2ul);
   ASSERT_EQUAL(data, ref);
 
-  cudaStreamDestroy(s);
+  ASSERT_EQUAL(cudaSuccess, cudaStreamDestroy(s));
 }
 DECLARE_UNITTEST(TestEraseIfCudaStreams);
 
@@ -96,16 +96,16 @@ void TestEraseIfCudaStreamsNonTrivialType()
   Vector data{1, 2, 1, 3, 2};
 
   cudaStream_t s;
-  cudaStreamCreate(&s);
+  ASSERT_EQUAL(cudaSuccess, cudaStreamCreate(&s));
 
   size_t removed = thrust::erase_if(thrust::cuda::par.on(s), data, is_even_tracked_int());
 
-  cudaStreamSynchronize(s);
+  ASSERT_EQUAL(cudaSuccess, cudaStreamSynchronize(s));
 
   Vector ref{1, 1, 3};
   ASSERT_EQUAL(removed, 2ul);
   ASSERT_EQUAL(data, ref);
 
-  cudaStreamDestroy(s);
+  ASSERT_EQUAL(cudaSuccess, cudaStreamDestroy(s));
 }
 DECLARE_UNITTEST(TestEraseIfCudaStreamsNonTrivialType);

--- a/thrust/testing/cuda/erase.cu
+++ b/thrust/testing/cuda/erase.cu
@@ -1,0 +1,59 @@
+#include <thrust/erase.h>
+#include <thrust/execution_policy.h>
+
+#include <unittest/unittest.h>
+
+template <typename T>
+struct is_even
+{
+  _CCCL_HOST_DEVICE bool operator()(T x)
+  {
+    return (static_cast<unsigned int>(x) & 1) == 0;
+  }
+};
+
+void TestEraseCudaStreams()
+{
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
+
+  Vector data{1, 2, 1, 3, 2};
+
+  cudaStream_t s;
+  cudaStreamCreate(&s);
+
+  size_t removed = thrust::erase(thrust::cuda::par.on(s), data, (T) 2);
+
+  cudaStreamSynchronize(s);
+
+  Vector ref{1, 1, 3};
+  ASSERT_EQUAL(removed, 2ul);
+  ASSERT_EQUAL(data, ref);
+
+  cudaStreamDestroy(s);
+}
+
+DECLARE_UNITTEST(TestEraseCudaStreams);
+
+void TestEraseIfCudaStreams()
+{
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
+
+  Vector data{1, 2, 1, 3, 2};
+
+  cudaStream_t s;
+  cudaStreamCreate(&s);
+
+  size_t removed = thrust::erase_if(thrust::cuda::par.on(s), data, is_even<T>());
+
+  cudaStreamSynchronize(s);
+
+  Vector ref{1, 1, 3};
+  ASSERT_EQUAL(removed, 2ul);
+  ASSERT_EQUAL(data, ref);
+
+  cudaStreamDestroy(s);
+}
+
+DECLARE_UNITTEST(TestEraseIfCudaStreams);

--- a/thrust/testing/cuda/erase.cu
+++ b/thrust/testing/cuda/erase.cu
@@ -3,12 +3,44 @@
 
 #include <unittest/unittest.h>
 
+struct tracked_int
+{
+  int value;
+
+  _CCCL_HOST_DEVICE tracked_int(int v = 0)
+      : value(v)
+  {}
+
+  tracked_int(const tracked_int&)            = default;
+  tracked_int& operator=(const tracked_int&) = default;
+
+  _CCCL_HOST_DEVICE ~tracked_int() {}
+
+  _CCCL_HOST_DEVICE bool operator==(const tracked_int& other) const
+  {
+    return value == other.value;
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const tracked_int& t)
+  {
+    return os << t.value;
+  }
+};
+
 template <typename T>
 struct is_even
 {
-  _CCCL_HOST_DEVICE bool operator()(T x)
+  _CCCL_HOST_DEVICE bool operator()(T x) const
   {
     return (static_cast<unsigned int>(x) & 1) == 0;
+  }
+};
+
+struct is_even_tracked_int
+{
+  _CCCL_HOST_DEVICE bool operator()(const tracked_int& x) const
+  {
+    return (x.value & 1) == 0;
   }
 };
 
@@ -55,5 +87,25 @@ void TestEraseIfCudaStreams()
 
   cudaStreamDestroy(s);
 }
-
 DECLARE_UNITTEST(TestEraseIfCudaStreams);
+
+void TestEraseIfCudaStreamsNonTrivialType()
+{
+  using Vector = thrust::device_vector<tracked_int>;
+
+  Vector data{1, 2, 1, 3, 2};
+
+  cudaStream_t s;
+  cudaStreamCreate(&s);
+
+  size_t removed = thrust::erase_if(thrust::cuda::par.on(s), data, is_even_tracked_int());
+
+  cudaStreamSynchronize(s);
+
+  Vector ref{1, 1, 3};
+  ASSERT_EQUAL(removed, 2ul);
+  ASSERT_EQUAL(data, ref);
+
+  cudaStreamDestroy(s);
+}
+DECLARE_UNITTEST(TestEraseIfCudaStreamsNonTrivialType);

--- a/thrust/testing/erase.cu
+++ b/thrust/testing/erase.cu
@@ -10,8 +10,10 @@ struct TestVectorRangeEraseSingleElement
   {
     Vector v{5};
 
-    auto prev_size = v.size();
-    auto new_size  = v.size() - 1ul;
+    typename Vector::size_type erased{1};
+
+    auto prev_size{v.size()};
+    auto new_size{v.size() - erased};
 
     auto del = thrust::erase(v, 5);
 
@@ -32,8 +34,10 @@ struct TestVectorRangeEraseMultipleElements
   {
     Vector v{1, 2, 3, 5, 5, 4, 5};
 
-    auto prev_size = v.size();
-    auto new_size  = v.size() - 3ul;
+    typename Vector::size_type erased{3};
+
+    auto prev_size{v.size()};
+    auto new_size{v.size() - erased};
 
     auto del = thrust::erase(v, 5);
 
@@ -55,8 +59,10 @@ struct TestVectorRangeEraseFirstElement
   {
     Vector v{0, 1, 2, 3};
 
-    auto prev_size = v.size();
-    auto new_size  = v.size() - 1ul;
+    typename Vector::size_type erased{1};
+
+    auto prev_size{v.size()};
+    auto new_size{prev_size - erased};
 
     auto del = thrust::erase(v, 0);
 
@@ -78,8 +84,8 @@ struct TestVectorRangeEraseEmptyVector
   {
     Vector v{};
 
-    auto prev_size = v.size();
-    auto new_size  = prev_size;
+    auto prev_size{v.size()};
+    auto new_size{prev_size};
 
     auto del = thrust::erase(v, 0);
 
@@ -101,8 +107,8 @@ struct TestVectorRangeEraseElementMissing
   {
     Vector v{1, 2, 3, 4};
 
-    auto prev_size = v.size();
-    auto new_size  = prev_size;
+    auto prev_size{v.size()};
+    auto new_size{prev_size};
 
     auto del = thrust::erase(v, 0);
 
@@ -124,8 +130,10 @@ struct TestVectorRangeEraseAllElements
   {
     Vector v{5, 5, 5, 5};
 
-    auto prev_size = v.size();
-    auto new_size  = 0ul;
+    typename Vector::size_type erased{4};
+
+    auto prev_size{v.size()};
+    auto new_size{prev_size - erased};
 
     auto del = thrust::erase(v, 5);
 
@@ -147,8 +155,10 @@ struct TestVectorRangeEraseLastElement
   {
     Vector v{1, 2, 3, 5};
 
-    auto prev_size = v.size();
-    auto new_size  = prev_size - 1ul;
+    typename Vector::size_type erased{1};
+
+    auto prev_size{v.size()};
+    auto new_size{prev_size - erased};
 
     auto del = thrust::erase(v, 5);
 
@@ -170,8 +180,10 @@ struct TestVectorRangeEraseConsecutiveElementsAtStart
   {
     Vector v{5, 5, 5, 1, 2, 3};
 
-    auto prev_size = v.size();
-    auto new_size  = prev_size - 3ul;
+    typename Vector::size_type erased{3};
+
+    auto prev_size{v.size()};
+    auto new_size{prev_size - erased};
 
     auto del = thrust::erase(v, 5);
 
@@ -196,8 +208,10 @@ struct TestVectorRangeEraseConsecutiveElementsAtEnd
   {
     Vector v{1, 2, 3, 5, 5, 5};
 
-    auto prev_size = v.size();
-    auto new_size  = prev_size - 3ul;
+    typename Vector::size_type erased{3};
+
+    auto prev_size{v.size()};
+    auto new_size{prev_size - erased};
 
     auto del = thrust::erase(v, 5);
 
@@ -222,8 +236,10 @@ struct TestVectorRangeEraseConsecutiveElementsAtMid
   {
     Vector v{1, 2, 5, 5, 5, 3, 4};
 
-    auto prev_size = v.size();
-    auto new_size  = prev_size - 3ul;
+    typename Vector::size_type erased{3};
+
+    auto prev_size{v.size()};
+    auto new_size{prev_size - erased};
 
     auto del = thrust::erase(v, 5);
 
@@ -248,8 +264,10 @@ struct TestVectorRangeEraseAlternatingElements
   {
     Vector v{5, 1, 5, 2, 5, 3, 5, 4};
 
-    auto prev_size = v.size();
-    auto new_size  = prev_size - 4ul;
+    typename Vector::size_type erased{4};
+
+    auto prev_size{v.size()};
+    auto new_size{prev_size - erased};
 
     auto del = thrust::erase(v, 5);
 
@@ -274,8 +292,8 @@ struct TestVectorRangeEraseNoneFromSingleElementVector
   {
     Vector v{1};
 
-    auto prev_size = v.size();
-    auto new_size  = prev_size;
+    auto prev_size{v.size()};
+    auto new_size{prev_size};
 
     auto del = thrust::erase(v, 5);
 
@@ -298,10 +316,11 @@ struct TestVectorRangeEraseBigVector
 {
   void operator()(size_t)
   {
-    Vector v(10000, 5);
+    const typename Vector::size_type n{10000};
+    Vector v(n, 5);
 
-    auto prev_size = v.size();
-    auto new_size  = 0ul;
+    auto prev_size{v.size()};
+    auto new_size{prev_size - n};
 
     auto del = thrust::erase(v, 5);
 

--- a/thrust/testing/erase.cu
+++ b/thrust/testing/erase.cu
@@ -4,22 +4,23 @@
 #include <unittest/unittest.h>
 
 template <class Vector>
+void verify_erase(Vector input, typename Vector::value_type value, Vector expected)
+{
+  const auto old_size = input.size();
+
+  const auto erased = thrust::erase(input, value);
+
+  ASSERT_EQUAL(erased, old_size - expected.size());
+  ASSERT_EQUAL(input.size(), expected.size());
+  ASSERT_EQUAL(input, expected);
+}
+
+template <class Vector>
 struct TestVectorRangeEraseSingleElement
 {
   void operator()(size_t)
   {
-    Vector v{5};
-
-    typename Vector::size_type erased{1};
-
-    auto prev_size{v.size()};
-    auto new_size{v.size() - erased};
-
-    auto del = thrust::erase(v, 5);
-
-    ASSERT_EQUAL(v, Vector{});
-    ASSERT_EQUAL(v.size(), new_size);
-    ASSERT_EQUAL(del, prev_size - new_size);
+    verify_erase(Vector{5}, typename Vector::value_type{5}, Vector{});
   }
 };
 VectorUnitTest<TestVectorRangeEraseSingleElement, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -32,19 +33,7 @@ struct TestVectorRangeEraseMultipleElements
 {
   void operator()(size_t)
   {
-    Vector v{1, 2, 3, 5, 5, 4, 5};
-
-    typename Vector::size_type erased{3};
-
-    auto prev_size{v.size()};
-    auto new_size{v.size() - erased};
-
-    auto del = thrust::erase(v, 5);
-
-    Vector v_comp{1, 2, 3, 4};
-    ASSERT_EQUAL(v, v_comp);
-    ASSERT_EQUAL(v.size(), new_size);
-    ASSERT_EQUAL(del, prev_size - new_size);
+    verify_erase(Vector{1, 2, 3, 5, 5, 4, 5}, typename Vector::value_type{5}, Vector{1, 2, 3, 4});
   }
 };
 VectorUnitTest<TestVectorRangeEraseMultipleElements, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -57,19 +46,7 @@ struct TestVectorRangeEraseFirstElement
 {
   void operator()(size_t)
   {
-    Vector v{0, 1, 2, 3};
-
-    typename Vector::size_type erased{1};
-
-    auto prev_size{v.size()};
-    auto new_size{prev_size - erased};
-
-    auto del = thrust::erase(v, 0);
-
-    Vector v_comp{1, 2, 3};
-    ASSERT_EQUAL(v, v_comp);
-    ASSERT_EQUAL(v.size(), new_size);
-    ASSERT_EQUAL(del, prev_size - new_size);
+    verify_erase(Vector{0, 1, 2, 3}, typename Vector::value_type{0}, Vector{1, 2, 3});
   }
 };
 VectorUnitTest<TestVectorRangeEraseFirstElement, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -82,17 +59,7 @@ struct TestVectorRangeEraseEmptyVector
 {
   void operator()(size_t)
   {
-    Vector v{};
-
-    auto prev_size{v.size()};
-    auto new_size{prev_size};
-
-    auto del = thrust::erase(v, 0);
-
-    Vector v_comp{};
-    ASSERT_EQUAL(v, v_comp);
-    ASSERT_EQUAL(v.size(), new_size);
-    ASSERT_EQUAL(del, prev_size - new_size);
+    verify_erase(Vector{}, typename Vector::value_type{0}, Vector{});
   }
 };
 VectorUnitTest<TestVectorRangeEraseEmptyVector, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -105,17 +72,7 @@ struct TestVectorRangeEraseElementMissing
 {
   void operator()(size_t)
   {
-    Vector v{1, 2, 3, 4};
-
-    auto prev_size{v.size()};
-    auto new_size{prev_size};
-
-    auto del = thrust::erase(v, 0);
-
-    Vector v_comp{1, 2, 3, 4};
-    ASSERT_EQUAL(v, v_comp);
-    ASSERT_EQUAL(v.size(), new_size);
-    ASSERT_EQUAL(del, prev_size - new_size);
+    verify_erase(Vector{1, 2, 3, 4}, typename Vector::value_type{0}, Vector{1, 2, 3, 4});
   }
 };
 VectorUnitTest<TestVectorRangeEraseElementMissing, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -128,19 +85,7 @@ struct TestVectorRangeEraseAllElements
 {
   void operator()(size_t)
   {
-    Vector v{5, 5, 5, 5};
-
-    typename Vector::size_type erased{4};
-
-    auto prev_size{v.size()};
-    auto new_size{prev_size - erased};
-
-    auto del = thrust::erase(v, 5);
-
-    Vector v_comp{};
-    ASSERT_EQUAL(v, v_comp);
-    ASSERT_EQUAL(v.size(), new_size);
-    ASSERT_EQUAL(del, prev_size - new_size);
+    verify_erase(Vector{5, 5, 5, 5}, typename Vector::value_type{5}, Vector{});
   }
 };
 VectorUnitTest<TestVectorRangeEraseAllElements, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -153,19 +98,7 @@ struct TestVectorRangeEraseLastElement
 {
   void operator()(size_t)
   {
-    Vector v{1, 2, 3, 5};
-
-    typename Vector::size_type erased{1};
-
-    auto prev_size{v.size()};
-    auto new_size{prev_size - erased};
-
-    auto del = thrust::erase(v, 5);
-
-    Vector v_comp{1, 2, 3};
-    ASSERT_EQUAL(v, v_comp);
-    ASSERT_EQUAL(v.size(), new_size);
-    ASSERT_EQUAL(del, prev_size - new_size);
+    verify_erase(Vector{1, 2, 3, 5}, typename Vector::value_type{5}, Vector{1, 2, 3});
   }
 };
 VectorUnitTest<TestVectorRangeEraseLastElement, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -178,19 +111,7 @@ struct TestVectorRangeEraseConsecutiveElementsAtStart
 {
   void operator()(size_t)
   {
-    Vector v{5, 5, 5, 1, 2, 3};
-
-    typename Vector::size_type erased{3};
-
-    auto prev_size{v.size()};
-    auto new_size{prev_size - erased};
-
-    auto del = thrust::erase(v, 5);
-
-    Vector v_comp{1, 2, 3};
-    ASSERT_EQUAL(v, v_comp);
-    ASSERT_EQUAL(v.size(), new_size);
-    ASSERT_EQUAL(del, prev_size - new_size);
+    verify_erase(Vector{5, 5, 5, 1, 2, 3}, typename Vector::value_type{5}, Vector{1, 2, 3});
   }
 };
 VectorUnitTest<TestVectorRangeEraseConsecutiveElementsAtStart,
@@ -206,19 +127,7 @@ struct TestVectorRangeEraseConsecutiveElementsAtEnd
 {
   void operator()(size_t)
   {
-    Vector v{1, 2, 3, 5, 5, 5};
-
-    typename Vector::size_type erased{3};
-
-    auto prev_size{v.size()};
-    auto new_size{prev_size - erased};
-
-    auto del = thrust::erase(v, 5);
-
-    Vector v_comp{1, 2, 3};
-    ASSERT_EQUAL(v, v_comp);
-    ASSERT_EQUAL(v.size(), new_size);
-    ASSERT_EQUAL(del, prev_size - new_size);
+    verify_erase(Vector{1, 2, 3, 5, 5, 5}, typename Vector::value_type{5}, Vector{1, 2, 3});
   }
 };
 VectorUnitTest<TestVectorRangeEraseConsecutiveElementsAtEnd,
@@ -234,19 +143,7 @@ struct TestVectorRangeEraseConsecutiveElementsAtMid
 {
   void operator()(size_t)
   {
-    Vector v{1, 2, 5, 5, 5, 3, 4};
-
-    typename Vector::size_type erased{3};
-
-    auto prev_size{v.size()};
-    auto new_size{prev_size - erased};
-
-    auto del = thrust::erase(v, 5);
-
-    Vector v_comp{1, 2, 3, 4};
-    ASSERT_EQUAL(v, v_comp);
-    ASSERT_EQUAL(v.size(), new_size);
-    ASSERT_EQUAL(del, prev_size - new_size);
+    verify_erase(Vector{1, 2, 5, 5, 5, 3, 4}, typename Vector::value_type{5}, Vector{1, 2, 3, 4});
   }
 };
 VectorUnitTest<TestVectorRangeEraseConsecutiveElementsAtMid,
@@ -262,19 +159,7 @@ struct TestVectorRangeEraseAlternatingElements
 {
   void operator()(size_t)
   {
-    Vector v{5, 1, 5, 2, 5, 3, 5, 4};
-
-    typename Vector::size_type erased{4};
-
-    auto prev_size{v.size()};
-    auto new_size{prev_size - erased};
-
-    auto del = thrust::erase(v, 5);
-
-    Vector v_comp{1, 2, 3, 4};
-    ASSERT_EQUAL(v, v_comp);
-    ASSERT_EQUAL(v.size(), new_size);
-    ASSERT_EQUAL(del, prev_size - new_size);
+    verify_erase(Vector{5, 1, 5, 2, 5, 3, 5, 4}, typename Vector::value_type{5}, Vector{1, 2, 3, 4});
   }
 };
 VectorUnitTest<TestVectorRangeEraseAlternatingElements,
@@ -290,17 +175,7 @@ struct TestVectorRangeEraseNoneFromSingleElementVector
 {
   void operator()(size_t)
   {
-    Vector v{1};
-
-    auto prev_size{v.size()};
-    auto new_size{prev_size};
-
-    auto del = thrust::erase(v, 5);
-
-    Vector v_comp{1};
-    ASSERT_EQUAL(v, v_comp);
-    ASSERT_EQUAL(v.size(), new_size);
-    ASSERT_EQUAL(del, prev_size - new_size);
+    verify_erase(Vector{1}, typename Vector::value_type{5}, Vector{1});
   }
 };
 VectorUnitTest<TestVectorRangeEraseNoneFromSingleElementVector,
@@ -317,17 +192,8 @@ struct TestVectorRangeEraseBigVector
   void operator()(size_t)
   {
     const typename Vector::size_type n{10000};
-    Vector v(n, 5);
 
-    auto prev_size{v.size()};
-    auto new_size{prev_size - n};
-
-    auto del = thrust::erase(v, 5);
-
-    Vector v_comp{};
-    ASSERT_EQUAL(v, v_comp);
-    ASSERT_EQUAL(v.size(), new_size);
-    ASSERT_EQUAL(del, prev_size - new_size);
+    verify_erase(Vector(n, typename Vector::value_type{5}), typename Vector::value_type{5}, Vector{});
   }
 };
 VectorUnitTest<TestVectorRangeEraseBigVector, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>

--- a/thrust/testing/erase.cu
+++ b/thrust/testing/erase.cu
@@ -1,0 +1,317 @@
+#include <thrust/device_malloc_allocator.h>
+#include <thrust/erase.h>
+
+#include <unittest/unittest.h>
+
+template <class Vector>
+struct TestVectorRangeEraseSingleElement
+{
+  void operator()(size_t)
+  {
+    Vector v{5};
+
+    auto prev_size = v.size();
+    auto new_size  = v.size() - 1ul;
+
+    auto del = thrust::erase(v, 5);
+
+    ASSERT_EQUAL(v, Vector{});
+    ASSERT_EQUAL(v.size(), new_size);
+    ASSERT_EQUAL(del, prev_size - new_size);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseSingleElement, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
+  TestVectorRangeEraseSingleElementDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseSingleElement, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseSingleElementHostInstance;
+
+template <class Vector>
+struct TestVectorRangeEraseMultipleElements
+{
+  void operator()(size_t)
+  {
+    Vector v{1, 2, 3, 5, 5, 4, 5};
+
+    auto prev_size = v.size();
+    auto new_size  = v.size() - 3ul;
+
+    auto del = thrust::erase(v, 5);
+
+    Vector v_comp{1, 2, 3, 4};
+    ASSERT_EQUAL(v, v_comp);
+    ASSERT_EQUAL(v.size(), new_size);
+    ASSERT_EQUAL(del, prev_size - new_size);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseMultipleElements, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
+  TestVectorRangeEraseMultipleElementsDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseMultipleElements, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseMultipleElementsHostInstance;
+
+template <class Vector>
+struct TestVectorRangeEraseFirstElement
+{
+  void operator()(size_t)
+  {
+    Vector v{0, 1, 2, 3};
+
+    auto prev_size = v.size();
+    auto new_size  = v.size() - 1ul;
+
+    auto del = thrust::erase(v, 0);
+
+    Vector v_comp{1, 2, 3};
+    ASSERT_EQUAL(v, v_comp);
+    ASSERT_EQUAL(v.size(), new_size);
+    ASSERT_EQUAL(del, prev_size - new_size);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseFirstElement, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
+  TestVectorRangeEraseFirstElementDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseFirstElement, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseFirstElementHostInstance;
+
+template <class Vector>
+struct TestVectorRangeEraseEmptyVector
+{
+  void operator()(size_t)
+  {
+    Vector v{};
+
+    auto prev_size = v.size();
+    auto new_size  = prev_size;
+
+    auto del = thrust::erase(v, 0);
+
+    Vector v_comp{};
+    ASSERT_EQUAL(v, v_comp);
+    ASSERT_EQUAL(v.size(), new_size);
+    ASSERT_EQUAL(del, prev_size - new_size);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseEmptyVector, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
+  TestVectorRangeEraseEmptyVectorDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseEmptyVector, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseEmptyVectorHostInstance;
+
+template <class Vector>
+struct TestVectorRangeEraseElementMissing
+{
+  void operator()(size_t)
+  {
+    Vector v{1, 2, 3, 4};
+
+    auto prev_size = v.size();
+    auto new_size  = prev_size;
+
+    auto del = thrust::erase(v, 0);
+
+    Vector v_comp{1, 2, 3, 4};
+    ASSERT_EQUAL(v, v_comp);
+    ASSERT_EQUAL(v.size(), new_size);
+    ASSERT_EQUAL(del, prev_size - new_size);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseElementMissing, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
+  TestVectorRangeEraseElementMissingDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseElementMissing, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseElementMissingHostInstance;
+
+template <class Vector>
+struct TestVectorRangeEraseAllElements
+{
+  void operator()(size_t)
+  {
+    Vector v{5, 5, 5, 5};
+
+    auto prev_size = v.size();
+    auto new_size  = 0ul;
+
+    auto del = thrust::erase(v, 5);
+
+    Vector v_comp{};
+    ASSERT_EQUAL(v, v_comp);
+    ASSERT_EQUAL(v.size(), new_size);
+    ASSERT_EQUAL(del, prev_size - new_size);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseAllElements, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
+  TestVectorRangeEraseAllElementsDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseAllElements, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseAllElementsHostInstance;
+
+template <class Vector>
+struct TestVectorRangeEraseLastElement
+{
+  void operator()(size_t)
+  {
+    Vector v{1, 2, 3, 5};
+
+    auto prev_size = v.size();
+    auto new_size  = prev_size - 1ul;
+
+    auto del = thrust::erase(v, 5);
+
+    Vector v_comp{1, 2, 3};
+    ASSERT_EQUAL(v, v_comp);
+    ASSERT_EQUAL(v.size(), new_size);
+    ASSERT_EQUAL(del, prev_size - new_size);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseLastElement, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
+  TestVectorRangeEraseLastElementDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseLastElement, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseLastElementHostInstance;
+
+template <class Vector>
+struct TestVectorRangeEraseConsecutiveElementsAtStart
+{
+  void operator()(size_t)
+  {
+    Vector v{5, 5, 5, 1, 2, 3};
+
+    auto prev_size = v.size();
+    auto new_size  = prev_size - 3ul;
+
+    auto del = thrust::erase(v, 5);
+
+    Vector v_comp{1, 2, 3};
+    ASSERT_EQUAL(v, v_comp);
+    ASSERT_EQUAL(v.size(), new_size);
+    ASSERT_EQUAL(del, prev_size - new_size);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseConsecutiveElementsAtStart,
+               NumericTypes,
+               thrust::device_vector,
+               thrust::device_malloc_allocator>
+  TestVectorRangeEraseConsecutiveElementsAtStartDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseConsecutiveElementsAtStart, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseConsecutiveElementsAtStartHostInstance;
+
+template <class Vector>
+struct TestVectorRangeEraseConsecutiveElementsAtEnd
+{
+  void operator()(size_t)
+  {
+    Vector v{1, 2, 3, 5, 5, 5};
+
+    auto prev_size = v.size();
+    auto new_size  = prev_size - 3ul;
+
+    auto del = thrust::erase(v, 5);
+
+    Vector v_comp{1, 2, 3};
+    ASSERT_EQUAL(v, v_comp);
+    ASSERT_EQUAL(v.size(), new_size);
+    ASSERT_EQUAL(del, prev_size - new_size);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseConsecutiveElementsAtEnd,
+               NumericTypes,
+               thrust::device_vector,
+               thrust::device_malloc_allocator>
+  TestVectorRangeEraseConsecutiveElementsAtEndDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseConsecutiveElementsAtEnd, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseConsecutiveElementsAtEndHostInstance;
+
+template <class Vector>
+struct TestVectorRangeEraseConsecutiveElementsAtMid
+{
+  void operator()(size_t)
+  {
+    Vector v{1, 2, 5, 5, 5, 3, 4};
+
+    auto prev_size = v.size();
+    auto new_size  = prev_size - 3ul;
+
+    auto del = thrust::erase(v, 5);
+
+    Vector v_comp{1, 2, 3, 4};
+    ASSERT_EQUAL(v, v_comp);
+    ASSERT_EQUAL(v.size(), new_size);
+    ASSERT_EQUAL(del, prev_size - new_size);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseConsecutiveElementsAtMid,
+               NumericTypes,
+               thrust::device_vector,
+               thrust::device_malloc_allocator>
+  TestVectorRangeEraseConsecutiveElementsAtMidDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseConsecutiveElementsAtMid, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseConsecutiveElementsAtMidHostInstance;
+
+template <class Vector>
+struct TestVectorRangeEraseAlternatingElements
+{
+  void operator()(size_t)
+  {
+    Vector v{5, 1, 5, 2, 5, 3, 5, 4};
+
+    auto prev_size = v.size();
+    auto new_size  = prev_size - 4ul;
+
+    auto del = thrust::erase(v, 5);
+
+    Vector v_comp{1, 2, 3, 4};
+    ASSERT_EQUAL(v, v_comp);
+    ASSERT_EQUAL(v.size(), new_size);
+    ASSERT_EQUAL(del, prev_size - new_size);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseAlternatingElements,
+               NumericTypes,
+               thrust::device_vector,
+               thrust::device_malloc_allocator>
+  TestVectorRangeEraseAlternatingElementsDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseAlternatingElements, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseAlternatingElementsHostInstance;
+
+template <class Vector>
+struct TestVectorRangeEraseNoneFromSingleElementVector
+{
+  void operator()(size_t)
+  {
+    Vector v{1};
+
+    auto prev_size = v.size();
+    auto new_size  = prev_size;
+
+    auto del = thrust::erase(v, 5);
+
+    Vector v_comp{1};
+    ASSERT_EQUAL(v, v_comp);
+    ASSERT_EQUAL(v.size(), new_size);
+    ASSERT_EQUAL(del, prev_size - new_size);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseNoneFromSingleElementVector,
+               NumericTypes,
+               thrust::device_vector,
+               thrust::device_malloc_allocator>
+  TestVectorRangeEraseNoneFromSingleElementVectorDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseNoneFromSingleElementVector, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseNoneFromSingleElementVectorHostInstance;
+
+template <class Vector>
+struct TestVectorRangeEraseBigVector
+{
+  void operator()(size_t)
+  {
+    Vector v(10000, 5);
+
+    auto prev_size = v.size();
+    auto new_size  = 0ul;
+
+    auto del = thrust::erase(v, 5);
+
+    Vector v_comp{};
+    ASSERT_EQUAL(v, v_comp);
+    ASSERT_EQUAL(v.size(), new_size);
+    ASSERT_EQUAL(del, prev_size - new_size);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseBigVector, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
+  TestVectorRangeEraseBigVectorDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseBigVector, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseBigVectorHostInstance;

--- a/thrust/testing/erase.cu
+++ b/thrust/testing/erase.cu
@@ -217,3 +217,15 @@ VectorUnitTest<TestVectorRangeEraseBigVector, NumericTypes, thrust::device_vecto
   TestVectorRangeEraseBigVectorDeviceInstance;
 VectorUnitTest<TestVectorRangeEraseBigVector, NumericTypes, thrust::host_vector, std::allocator>
   TestVectorRangeEraseBigVectorHostInstance;
+
+void TestEraseHeterogeneousType()
+{
+  thrust::device_vector<double> data{1.0, 2.0, 1.0, 3.0, 2.0};
+
+  auto erased = thrust::erase(data, 2);
+
+  thrust::device_vector<double> ref{1.0, 1.0, 3.0};
+  ASSERT_EQUAL(erased, 2ul);
+  ASSERT_EQUAL(data, ref);
+}
+DECLARE_UNITTEST(TestEraseHeterogeneousType);

--- a/thrust/testing/erase.cu
+++ b/thrust/testing/erase.cu
@@ -4,6 +4,17 @@
 #include <unittest/unittest.h>
 
 template <class Vector>
+Vector make_vector(std::initializer_list<int> values)
+{
+  Vector v;
+  for (int x : values)
+  {
+    v.push_back(static_cast<typename Vector::value_type>(x));
+  }
+  return v;
+}
+
+template <class Vector>
 void verify_erase(Vector input, typename Vector::value_type value, Vector expected)
 {
   const auto old_size = input.size();
@@ -15,12 +26,18 @@ void verify_erase(Vector input, typename Vector::value_type value, Vector expect
   ASSERT_EQUAL(input, expected);
 }
 
+template <class Vector, class Predicate>
+void verify_erase(std::initializer_list<int> input, Predicate pred, std::initializer_list<int> expected)
+{
+  verify_erase<Vector>(make_vector<Vector>(input), pred, make_vector<Vector>(expected));
+}
+
 template <class Vector>
 struct TestVectorRangeEraseSingleElement
 {
   void operator()(size_t)
   {
-    verify_erase(Vector{5}, typename Vector::value_type{5}, Vector{});
+    verify_erase<Vector>(Vector{5}, typename Vector::value_type{5}, Vector{});
   }
 };
 VectorUnitTest<TestVectorRangeEraseSingleElement, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -33,7 +50,7 @@ struct TestVectorRangeEraseMultipleElements
 {
   void operator()(size_t)
   {
-    verify_erase(Vector{1, 2, 3, 5, 5, 4, 5}, typename Vector::value_type{5}, Vector{1, 2, 3, 4});
+    verify_erase<Vector>({1, 2, 3, 5, 5, 4, 5}, typename Vector::value_type{5}, {1, 2, 3, 4});
   }
 };
 VectorUnitTest<TestVectorRangeEraseMultipleElements, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -46,7 +63,7 @@ struct TestVectorRangeEraseFirstElement
 {
   void operator()(size_t)
   {
-    verify_erase(Vector{0, 1, 2, 3}, typename Vector::value_type{0}, Vector{1, 2, 3});
+    verify_erase<Vector>({0, 1, 2, 3}, typename Vector::value_type{0}, {1, 2, 3});
   }
 };
 VectorUnitTest<TestVectorRangeEraseFirstElement, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -59,7 +76,7 @@ struct TestVectorRangeEraseEmptyVector
 {
   void operator()(size_t)
   {
-    verify_erase(Vector{}, typename Vector::value_type{0}, Vector{});
+    verify_erase<Vector>({}, typename Vector::value_type{0}, {});
   }
 };
 VectorUnitTest<TestVectorRangeEraseEmptyVector, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -72,7 +89,7 @@ struct TestVectorRangeEraseElementMissing
 {
   void operator()(size_t)
   {
-    verify_erase(Vector{1, 2, 3, 4}, typename Vector::value_type{0}, Vector{1, 2, 3, 4});
+    verify_erase<Vector>({1, 2, 3, 4}, typename Vector::value_type{0}, {1, 2, 3, 4});
   }
 };
 VectorUnitTest<TestVectorRangeEraseElementMissing, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -85,7 +102,7 @@ struct TestVectorRangeEraseAllElements
 {
   void operator()(size_t)
   {
-    verify_erase(Vector{5, 5, 5, 5}, typename Vector::value_type{5}, Vector{});
+    verify_erase<Vector>({5, 5, 5, 5}, typename Vector::value_type{5}, {});
   }
 };
 VectorUnitTest<TestVectorRangeEraseAllElements, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -98,7 +115,7 @@ struct TestVectorRangeEraseLastElement
 {
   void operator()(size_t)
   {
-    verify_erase(Vector{1, 2, 3, 5}, typename Vector::value_type{5}, Vector{1, 2, 3});
+    verify_erase<Vector>({1, 2, 3, 5}, typename Vector::value_type{5}, {1, 2, 3});
   }
 };
 VectorUnitTest<TestVectorRangeEraseLastElement, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -111,7 +128,7 @@ struct TestVectorRangeEraseConsecutiveElementsAtStart
 {
   void operator()(size_t)
   {
-    verify_erase(Vector{5, 5, 5, 1, 2, 3}, typename Vector::value_type{5}, Vector{1, 2, 3});
+    verify_erase<Vector>({5, 5, 5, 1, 2, 3}, typename Vector::value_type{5}, {1, 2, 3});
   }
 };
 VectorUnitTest<TestVectorRangeEraseConsecutiveElementsAtStart,
@@ -127,7 +144,7 @@ struct TestVectorRangeEraseConsecutiveElementsAtEnd
 {
   void operator()(size_t)
   {
-    verify_erase(Vector{1, 2, 3, 5, 5, 5}, typename Vector::value_type{5}, Vector{1, 2, 3});
+    verify_erase<Vector>({1, 2, 3, 5, 5, 5}, typename Vector::value_type{5}, {1, 2, 3});
   }
 };
 VectorUnitTest<TestVectorRangeEraseConsecutiveElementsAtEnd,
@@ -143,7 +160,7 @@ struct TestVectorRangeEraseConsecutiveElementsAtMid
 {
   void operator()(size_t)
   {
-    verify_erase(Vector{1, 2, 5, 5, 5, 3, 4}, typename Vector::value_type{5}, Vector{1, 2, 3, 4});
+    verify_erase<Vector>({1, 2, 5, 5, 5, 3, 4}, typename Vector::value_type{5}, {1, 2, 3, 4});
   }
 };
 VectorUnitTest<TestVectorRangeEraseConsecutiveElementsAtMid,
@@ -159,7 +176,7 @@ struct TestVectorRangeEraseAlternatingElements
 {
   void operator()(size_t)
   {
-    verify_erase(Vector{5, 1, 5, 2, 5, 3, 5, 4}, typename Vector::value_type{5}, Vector{1, 2, 3, 4});
+    verify_erase<Vector>({5, 1, 5, 2, 5, 3, 5, 4}, typename Vector::value_type{5}, {1, 2, 3, 4});
   }
 };
 VectorUnitTest<TestVectorRangeEraseAlternatingElements,
@@ -175,7 +192,7 @@ struct TestVectorRangeEraseNoneFromSingleElementVector
 {
   void operator()(size_t)
   {
-    verify_erase(Vector{1}, typename Vector::value_type{5}, Vector{1});
+    verify_erase<Vector>(Vector{1}, typename Vector::value_type{5}, Vector{1});
   }
 };
 VectorUnitTest<TestVectorRangeEraseNoneFromSingleElementVector,
@@ -193,7 +210,7 @@ struct TestVectorRangeEraseBigVector
   {
     const typename Vector::size_type n{10000};
 
-    verify_erase(Vector(n, typename Vector::value_type{5}), typename Vector::value_type{5}, Vector{});
+    verify_erase<Vector>(Vector(n, typename Vector::value_type{5}), typename Vector::value_type{5}, Vector{});
   }
 };
 VectorUnitTest<TestVectorRangeEraseBigVector, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>

--- a/thrust/testing/erase.cu
+++ b/thrust/testing/erase.cu
@@ -26,10 +26,11 @@ void verify_erase(Vector input, typename Vector::value_type value, Vector expect
   ASSERT_EQUAL(input, expected);
 }
 
-template <class Vector, class Predicate>
-void verify_erase(std::initializer_list<int> input, Predicate pred, std::initializer_list<int> expected)
+template <class Vector, class T>
+void verify_erase(
+  std::initializer_list<int> input, typename Vector::value_type value, std::initializer_list<int> expected)
 {
-  verify_erase<Vector>(make_vector<Vector>(input), pred, make_vector<Vector>(expected));
+  verify_erase<Vector>(make_vector<Vector>(input), value, make_vector<Vector>(expected));
 }
 
 template <class Vector>

--- a/thrust/testing/erase.cu
+++ b/thrust/testing/erase.cu
@@ -26,7 +26,7 @@ void verify_erase(Vector input, typename Vector::value_type value, Vector expect
   ASSERT_EQUAL(input, expected);
 }
 
-template <class Vector, class T>
+template <class Vector>
 void verify_erase(
   std::initializer_list<int> input, typename Vector::value_type value, std::initializer_list<int> expected)
 {

--- a/thrust/testing/erase_if.cu
+++ b/thrust/testing/erase_if.cu
@@ -19,8 +19,10 @@ struct TestVectorRangeEraseIfSingleElement
   {
     Vector v{5};
 
-    auto prev_size = v.size();
-    auto new_size  = 0ul;
+    typename Vector::size_type erased{1};
+
+    auto prev_size{v.size()};
+    auto new_size{prev_size - erased};
 
     auto del = thrust::erase_if(v, IsFive{});
 
@@ -41,8 +43,10 @@ struct TestVectorRangeEraseIfMultipleElements
   {
     Vector v{1, 2, 3, 5, 5, 4, 5};
 
-    auto prev_size = v.size();
-    auto new_size  = prev_size - 3ul;
+    typename Vector::size_type erased{3};
+
+    auto prev_size{v.size()};
+    auto new_size{prev_size - erased};
 
     auto del = thrust::erase_if(v, IsFive{});
 
@@ -65,10 +69,12 @@ struct TestVectorRangeEraseIfEmptyVector
   {
     Vector v{};
 
+    typename Vector::size_type new_size{0};
+
     auto del = thrust::erase_if(v, IsFive{});
 
     ASSERT_EQUAL(v, Vector{});
-    ASSERT_EQUAL(del, 0ul);
+    ASSERT_EQUAL(del, new_size);
   }
 };
 VectorUnitTest<TestVectorRangeEraseIfEmptyVector, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -83,7 +89,10 @@ struct TestVectorRangeEraseIfNoMatch
   {
     Vector v{1, 2, 3, 4};
 
-    auto prev_size = v.size();
+    typename Vector::size_type erased{0};
+
+    auto prev_size{v.size()};
+    auto new_size{prev_size - erased};
 
     auto del = thrust::erase_if(v, IsFive{});
 
@@ -91,7 +100,7 @@ struct TestVectorRangeEraseIfNoMatch
 
     ASSERT_EQUAL(v, expected);
     ASSERT_EQUAL(v.size(), prev_size);
-    ASSERT_EQUAL(del, 0ul);
+    ASSERT_EQUAL(del, new_size);
   }
 };
 VectorUnitTest<TestVectorRangeEraseIfNoMatch, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -106,12 +115,15 @@ struct TestVectorRangeEraseIfAllMatch
   {
     Vector v{5, 5, 5, 5};
 
-    auto prev_size = v.size();
+    typename Vector::size_type erased{0};
+
+    auto prev_size{v.size()};
+    auto new_size{prev_size - erased};
 
     auto del = thrust::erase_if(v, IsFive{});
 
     ASSERT_EQUAL(v, Vector{});
-    ASSERT_EQUAL(v.size(), 0ul);
+    ASSERT_EQUAL(v.size(), new_size);
     ASSERT_EQUAL(del, prev_size);
   }
 };
@@ -127,15 +139,18 @@ struct TestVectorRangeEraseIfAlternatingMatches
   {
     Vector v{5, 1, 5, 2, 5, 3, 5, 4};
 
-    auto prev_size = v.size();
+    typename Vector::size_type erased{4};
+
+    auto prev_size{v.size()};
+    auto new_size{prev_size - erased};
 
     auto del = thrust::erase_if(v, IsFive{});
 
     Vector expected{1, 2, 3, 4};
 
     ASSERT_EQUAL(v, expected);
-    ASSERT_EQUAL(v.size(), 4ul);
-    ASSERT_EQUAL(del, prev_size - 4ul);
+    ASSERT_EQUAL(v.size(), new_size);
+    ASSERT_EQUAL(del, prev_size);
   }
 };
 VectorUnitTest<TestVectorRangeEraseIfAlternatingMatches,
@@ -151,12 +166,16 @@ struct TestVectorRangeEraseIfBigVector
 {
   void operator()(size_t)
   {
-    Vector v(10000, 5);
+    const typename Vector::size_type n{10000};
+    Vector v(n, 5);
+
+    auto prev_size{v.size()};
+    auto new_size{prev_size - n};
 
     auto del = thrust::erase_if(v, IsFive{});
 
     ASSERT_EQUAL(v, Vector{});
-    ASSERT_EQUAL(del, 10000ul);
+    ASSERT_EQUAL(del, new_size);
   }
 };
 VectorUnitTest<TestVectorRangeEraseIfBigVector, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>

--- a/thrust/testing/erase_if.cu
+++ b/thrust/testing/erase_if.cu
@@ -1,0 +1,165 @@
+#include <thrust/device_malloc_allocator.h>
+#include <thrust/erase.h>
+
+#include <unittest/unittest.h>
+
+struct IsFive
+{
+  template <class T>
+  bool operator()(const T& x) const
+  {
+    return x == 5;
+  }
+};
+
+template <class Vector>
+struct TestVectorRangeEraseIfSingleElement
+{
+  void operator()(size_t)
+  {
+    Vector v{5};
+
+    auto prev_size = v.size();
+    auto new_size  = 0ul;
+
+    auto del = thrust::erase_if(v, IsFive{});
+
+    ASSERT_EQUAL(v, Vector{});
+    ASSERT_EQUAL(v.size(), new_size);
+    ASSERT_EQUAL(del, prev_size - new_size);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseIfSingleElement, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
+  TestVectorRangeEraseIfSingleElementDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseIfSingleElement, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseIfSingleElementHostInstance;
+
+template <class Vector>
+struct TestVectorRangeEraseIfMultipleElements
+{
+  void operator()(size_t)
+  {
+    Vector v{1, 2, 3, 5, 5, 4, 5};
+
+    auto prev_size = v.size();
+    auto new_size  = prev_size - 3ul;
+
+    auto del = thrust::erase_if(v, IsFive{});
+
+    Vector expected{1, 2, 3, 4};
+
+    ASSERT_EQUAL(v, expected);
+    ASSERT_EQUAL(v.size(), new_size);
+    ASSERT_EQUAL(del, prev_size - new_size);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseIfMultipleElements, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
+  TestVectorRangeEraseIfMultipleElementsDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseIfMultipleElements, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseIfMultipleElementsHostInstance;
+
+template <class Vector>
+struct TestVectorRangeEraseIfEmptyVector
+{
+  void operator()(size_t)
+  {
+    Vector v{};
+
+    auto del = thrust::erase_if(v, IsFive{});
+
+    ASSERT_EQUAL(v, Vector{});
+    ASSERT_EQUAL(del, 0ul);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseIfEmptyVector, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
+  TestVectorRangeEraseIfEmptyVectorDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseIfEmptyVector, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseIfEmptyVectorHostInstance;
+
+template <class Vector>
+struct TestVectorRangeEraseIfNoMatch
+{
+  void operator()(size_t)
+  {
+    Vector v{1, 2, 3, 4};
+
+    auto prev_size = v.size();
+
+    auto del = thrust::erase_if(v, IsFive{});
+
+    Vector expected{1, 2, 3, 4};
+
+    ASSERT_EQUAL(v, expected);
+    ASSERT_EQUAL(v.size(), prev_size);
+    ASSERT_EQUAL(del, 0ul);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseIfNoMatch, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
+  TestVectorRangeEraseIfNoMatchDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseIfNoMatch, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseIfNoMatchHostInstance;
+
+template <class Vector>
+struct TestVectorRangeEraseIfAllMatch
+{
+  void operator()(size_t)
+  {
+    Vector v{5, 5, 5, 5};
+
+    auto prev_size = v.size();
+
+    auto del = thrust::erase_if(v, IsFive{});
+
+    ASSERT_EQUAL(v, Vector{});
+    ASSERT_EQUAL(v.size(), 0ul);
+    ASSERT_EQUAL(del, prev_size);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseIfAllMatch, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
+  TestVectorRangeEraseIfAllMatchDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseIfAllMatch, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseIfAllMatchHostInstance;
+
+template <class Vector>
+struct TestVectorRangeEraseIfAlternatingMatches
+{
+  void operator()(size_t)
+  {
+    Vector v{5, 1, 5, 2, 5, 3, 5, 4};
+
+    auto prev_size = v.size();
+
+    auto del = thrust::erase_if(v, IsFive{});
+
+    Vector expected{1, 2, 3, 4};
+
+    ASSERT_EQUAL(v, expected);
+    ASSERT_EQUAL(v.size(), 4ul);
+    ASSERT_EQUAL(del, prev_size - 4ul);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseIfAlternatingMatches,
+               NumericTypes,
+               thrust::device_vector,
+               thrust::device_malloc_allocator>
+  TestVectorRangeEraseIfAlternatingMatchesDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseIfAlternatingMatches, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseIfAlternatingMatchesHostInstance;
+
+template <class Vector>
+struct TestVectorRangeEraseIfBigVector
+{
+  void operator()(size_t)
+  {
+    Vector v(10000, 5);
+
+    auto del = thrust::erase_if(v, IsFive{});
+
+    ASSERT_EQUAL(v, Vector{});
+    ASSERT_EQUAL(del, 10000ul);
+  }
+};
+VectorUnitTest<TestVectorRangeEraseIfBigVector, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
+  TestVectorRangeEraseIfBigVectorDeviceInstance;
+VectorUnitTest<TestVectorRangeEraseIfBigVector, NumericTypes, thrust::host_vector, std::allocator>
+  TestVectorRangeEraseIfBigVectorHostInstance;

--- a/thrust/testing/erase_if.cu
+++ b/thrust/testing/erase_if.cu
@@ -6,29 +6,30 @@
 struct IsFive
 {
   template <class T>
-  bool operator()(const T& x) const
+  _CCCL_HOST_DEVICE bool operator()(const T& x) const
   {
     return x == 5;
   }
 };
+
+template <class Vector, class Predicate>
+void check_erase_if(Vector input, Predicate pred, Vector expected)
+{
+  const auto old_size = input.size();
+
+  const auto erased = thrust::erase_if(input, pred);
+
+  ASSERT_EQUAL(input, expected);
+  ASSERT_EQUAL(erased, old_size - expected.size());
+  ASSERT_EQUAL(input.size(), expected.size());
+}
 
 template <class Vector>
 struct TestVectorRangeEraseIfSingleElement
 {
   void operator()(size_t)
   {
-    Vector v{5};
-
-    typename Vector::size_type erased{1};
-
-    auto prev_size{v.size()};
-    auto new_size{prev_size - erased};
-
-    auto del = thrust::erase_if(v, IsFive{});
-
-    ASSERT_EQUAL(v, Vector{});
-    ASSERT_EQUAL(v.size(), new_size);
-    ASSERT_EQUAL(del, prev_size - new_size);
+    check_erase_if(Vector{5}, IsFive{}, Vector{});
   }
 };
 VectorUnitTest<TestVectorRangeEraseIfSingleElement, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -41,20 +42,7 @@ struct TestVectorRangeEraseIfMultipleElements
 {
   void operator()(size_t)
   {
-    Vector v{1, 2, 3, 5, 5, 4, 5};
-
-    typename Vector::size_type erased{3};
-
-    auto prev_size{v.size()};
-    auto new_size{prev_size - erased};
-
-    auto del = thrust::erase_if(v, IsFive{});
-
-    Vector expected{1, 2, 3, 4};
-
-    ASSERT_EQUAL(v, expected);
-    ASSERT_EQUAL(v.size(), new_size);
-    ASSERT_EQUAL(del, prev_size - new_size);
+    check_erase_if(Vector{1, 2, 3, 5, 5, 4, 5}, IsFive{}, Vector{1, 2, 3, 4});
   }
 };
 VectorUnitTest<TestVectorRangeEraseIfMultipleElements, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -67,14 +55,7 @@ struct TestVectorRangeEraseIfEmptyVector
 {
   void operator()(size_t)
   {
-    Vector v{};
-
-    typename Vector::size_type new_size{0};
-
-    auto del = thrust::erase_if(v, IsFive{});
-
-    ASSERT_EQUAL(v, Vector{});
-    ASSERT_EQUAL(del, new_size);
+    check_erase_if(Vector{}, IsFive{}, Vector{});
   }
 };
 VectorUnitTest<TestVectorRangeEraseIfEmptyVector, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -87,20 +68,7 @@ struct TestVectorRangeEraseIfNoMatch
 {
   void operator()(size_t)
   {
-    Vector v{1, 2, 3, 4};
-
-    typename Vector::size_type erased{0};
-
-    auto prev_size{v.size()};
-    auto new_size{prev_size - erased};
-
-    auto del = thrust::erase_if(v, IsFive{});
-
-    Vector expected{1, 2, 3, 4};
-
-    ASSERT_EQUAL(v, expected);
-    ASSERT_EQUAL(v.size(), prev_size);
-    ASSERT_EQUAL(del, new_size);
+    check_erase_if(Vector{1, 2, 3, 4}, IsFive{}, Vector{1, 2, 3, 4});
   }
 };
 VectorUnitTest<TestVectorRangeEraseIfNoMatch, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -113,18 +81,7 @@ struct TestVectorRangeEraseIfAllMatch
 {
   void operator()(size_t)
   {
-    Vector v{5, 5, 5, 5};
-
-    typename Vector::size_type erased{0};
-
-    auto prev_size{v.size()};
-    auto new_size{prev_size - erased};
-
-    auto del = thrust::erase_if(v, IsFive{});
-
-    ASSERT_EQUAL(v, Vector{});
-    ASSERT_EQUAL(v.size(), new_size);
-    ASSERT_EQUAL(del, prev_size);
+    check_erase_if(Vector{5, 5, 5, 5}, IsFive{}, Vector{});
   }
 };
 VectorUnitTest<TestVectorRangeEraseIfAllMatch, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -137,20 +94,7 @@ struct TestVectorRangeEraseIfAlternatingMatches
 {
   void operator()(size_t)
   {
-    Vector v{5, 1, 5, 2, 5, 3, 5, 4};
-
-    typename Vector::size_type erased{4};
-
-    auto prev_size{v.size()};
-    auto new_size{prev_size - erased};
-
-    auto del = thrust::erase_if(v, IsFive{});
-
-    Vector expected{1, 2, 3, 4};
-
-    ASSERT_EQUAL(v, expected);
-    ASSERT_EQUAL(v.size(), new_size);
-    ASSERT_EQUAL(del, prev_size);
+    check_erase_if(Vector{5, 1, 5, 2, 5, 3, 5, 4}, IsFive{}, Vector{1, 2, 3, 4});
   }
 };
 VectorUnitTest<TestVectorRangeEraseIfAlternatingMatches,
@@ -167,15 +111,8 @@ struct TestVectorRangeEraseIfBigVector
   void operator()(size_t)
   {
     const typename Vector::size_type n{10000};
-    Vector v(n, 5);
 
-    auto prev_size{v.size()};
-    auto new_size{prev_size - n};
-
-    auto del = thrust::erase_if(v, IsFive{});
-
-    ASSERT_EQUAL(v, Vector{});
-    ASSERT_EQUAL(del, new_size);
+    check_erase_if(Vector(n, typename Vector::value_type{5}), IsFive{}, Vector{});
   }
 };
 VectorUnitTest<TestVectorRangeEraseIfBigVector, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>

--- a/thrust/testing/erase_if.cu
+++ b/thrust/testing/erase_if.cu
@@ -1,5 +1,10 @@
 #include <thrust/device_malloc_allocator.h>
+#include <thrust/device_vector.h>
 #include <thrust/erase.h>
+#include <thrust/host_vector.h>
+
+#include <initializer_list>
+#include <memory>
 
 #include <unittest/unittest.h>
 

--- a/thrust/testing/erase_if.cu
+++ b/thrust/testing/erase_if.cu
@@ -12,8 +12,19 @@ struct IsFive
   }
 };
 
+template <class Vector>
+Vector make_vector(std::initializer_list<int> values)
+{
+  Vector v;
+  for (int x : values)
+  {
+    v.push_back(static_cast<typename Vector::value_type>(x));
+  }
+  return v;
+}
+
 template <class Vector, class Predicate>
-void check_erase_if(Vector input, Predicate pred, Vector expected)
+void verify_erase_if(Vector input, Predicate pred, const Vector& expected)
 {
   const auto old_size = input.size();
 
@@ -24,12 +35,18 @@ void check_erase_if(Vector input, Predicate pred, Vector expected)
   ASSERT_EQUAL(input.size(), expected.size());
 }
 
+template <class Vector, class Predicate>
+void verify_erase_if(std::initializer_list<int> input, Predicate pred, std::initializer_list<int> expected)
+{
+  verify_erase_if<Vector>(make_vector<Vector>(input), pred, make_vector<Vector>(expected));
+}
+
 template <class Vector>
 struct TestVectorRangeEraseIfSingleElement
 {
   void operator()(size_t)
   {
-    check_erase_if(Vector{5}, IsFive{}, Vector{});
+    verify_erase_if<Vector>({5}, IsFive{}, {});
   }
 };
 VectorUnitTest<TestVectorRangeEraseIfSingleElement, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -42,7 +59,7 @@ struct TestVectorRangeEraseIfMultipleElements
 {
   void operator()(size_t)
   {
-    check_erase_if(Vector{1, 2, 3, 5, 5, 4, 5}, IsFive{}, Vector{1, 2, 3, 4});
+    verify_erase_if<Vector>({1, 2, 3, 5, 5, 4, 5}, IsFive{}, {1, 2, 3, 4});
   }
 };
 VectorUnitTest<TestVectorRangeEraseIfMultipleElements, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -55,7 +72,7 @@ struct TestVectorRangeEraseIfEmptyVector
 {
   void operator()(size_t)
   {
-    check_erase_if(Vector{}, IsFive{}, Vector{});
+    verify_erase_if<Vector>({}, IsFive{}, {});
   }
 };
 VectorUnitTest<TestVectorRangeEraseIfEmptyVector, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -68,7 +85,7 @@ struct TestVectorRangeEraseIfNoMatch
 {
   void operator()(size_t)
   {
-    check_erase_if(Vector{1, 2, 3, 4}, IsFive{}, Vector{1, 2, 3, 4});
+    verify_erase_if<Vector>({1, 2, 3, 4}, IsFive{}, {1, 2, 3, 4});
   }
 };
 VectorUnitTest<TestVectorRangeEraseIfNoMatch, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -81,7 +98,7 @@ struct TestVectorRangeEraseIfAllMatch
 {
   void operator()(size_t)
   {
-    check_erase_if(Vector{5, 5, 5, 5}, IsFive{}, Vector{});
+    verify_erase_if<Vector>({5, 5, 5, 5}, IsFive{}, {});
   }
 };
 VectorUnitTest<TestVectorRangeEraseIfAllMatch, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>
@@ -94,7 +111,7 @@ struct TestVectorRangeEraseIfAlternatingMatches
 {
   void operator()(size_t)
   {
-    check_erase_if(Vector{5, 1, 5, 2, 5, 3, 5, 4}, IsFive{}, Vector{1, 2, 3, 4});
+    verify_erase_if<Vector>({5, 1, 5, 2, 5, 3, 5, 4}, IsFive{}, {1, 2, 3, 4});
   }
 };
 VectorUnitTest<TestVectorRangeEraseIfAlternatingMatches,
@@ -112,7 +129,7 @@ struct TestVectorRangeEraseIfBigVector
   {
     const typename Vector::size_type n{10000};
 
-    check_erase_if(Vector(n, typename Vector::value_type{5}), IsFive{}, Vector{});
+    verify_erase_if<Vector>(Vector(n, typename Vector::value_type{5}), IsFive{}, Vector{});
   }
 };
 VectorUnitTest<TestVectorRangeEraseIfBigVector, NumericTypes, thrust::device_vector, thrust::device_malloc_allocator>

--- a/thrust/thrust/detail/erase.inl
+++ b/thrust/thrust/detail/erase.inl
@@ -14,6 +14,8 @@
 #endif // no system header
 #include <thrust/erase.h>
 
+#include <cuda/std/__iterator/distance.h>
+
 THRUST_NAMESPACE_BEGIN
 
 template <class Vector, class U, ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int>>

--- a/thrust/thrust/detail/erase.inl
+++ b/thrust/thrust/detail/erase.inl
@@ -17,7 +17,7 @@
 THRUST_NAMESPACE_BEGIN
 
 template <class Vector, class U, ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int>>
-typename Vector::size_type erase(Vector& c, const U& value)
+_CCCL_HOST typename Vector::size_type erase(Vector& c, const U& value)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::erase");
   using value_type = typename Vector::value_type;
@@ -31,9 +31,8 @@ typename Vector::size_type erase(Vector& c, const U& value)
   return removed;
 }
 
-_CCCL_EXEC_CHECK_DISABLE
 template <typename DerivedPolicy, class Vector, class U, ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int>>
-_CCCL_HOST_DEVICE typename Vector::size_type
+_CCCL_HOST typename Vector::size_type
 erase(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& c, const U& value)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::erase");
@@ -42,14 +41,13 @@ erase(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& 
   auto first = thrust::remove(exec, c.begin(), c.end(), static_cast<value_type>(value));
 
   auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
-
   c.erase(first, c.end());
 
   return removed;
 }
 
 template <class Vector, class Predicate, ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int>>
-typename Vector::size_type erase_if(Vector& c, Predicate pred)
+_CCCL_HOST typename Vector::size_type erase_if(Vector& c, Predicate pred)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::erase_if");
 
@@ -62,9 +60,8 @@ typename Vector::size_type erase_if(Vector& c, Predicate pred)
   return removed;
 }
 
-_CCCL_EXEC_CHECK_DISABLE
 template <typename DerivedPolicy, class Vector, class Predicate, ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int>>
-_CCCL_HOST_DEVICE typename Vector::size_type
+_CCCL_HOST typename Vector::size_type
 erase_if(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& c, Predicate pred)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::erase_if");

--- a/thrust/thrust/detail/erase.inl
+++ b/thrust/thrust/detail/erase.inl
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/detail/erase.inl
+++ b/thrust/thrust/detail/erase.inl
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <thrust/detail/config.h>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+#include <thrust/erase.h>
+
+THRUST_NAMESPACE_BEGIN
+
+template <class Vector, class U, ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int>>
+typename Vector::size_type erase(Vector& c, const U& value)
+{
+  _CCCL_NVTX_RANGE_SCOPE("thrust::erase");
+  using value_type = typename Vector::value_type;
+
+  auto first = thrust::remove(c.begin(), c.end(), static_cast<value_type>(value));
+
+  auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
+
+  c.erase(first, c.end());
+
+  return removed;
+}
+
+_CCCL_EXEC_CHECK_DISABLE
+template <typename DerivedPolicy, class Vector, class U, ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int>>
+_CCCL_HOST_DEVICE typename Vector::size_type
+erase(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& c, const U& value)
+{
+  _CCCL_NVTX_RANGE_SCOPE("thrust::erase");
+  using value_type = typename Vector::value_type;
+
+  auto first = thrust::remove(exec, c.begin(), c.end(), static_cast<value_type>(value));
+
+  auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
+
+  c.erase(first, c.end());
+
+  return removed;
+}
+
+template <class Vector, class Predicate, ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int>>
+typename Vector::size_type erase_if(Vector& c, Predicate pred)
+{
+  _CCCL_NVTX_RANGE_SCOPE("thrust::erase_if");
+
+  auto first = thrust::remove_if(c.begin(), c.end(), pred);
+
+  auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
+
+  c.erase(first, c.end());
+
+  return removed;
+}
+
+_CCCL_EXEC_CHECK_DISABLE
+template <typename DerivedPolicy, class Vector, class Predicate, ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int>>
+_CCCL_HOST_DEVICE typename Vector::size_type
+erase_if(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& c, Predicate pred)
+{
+  _CCCL_NVTX_RANGE_SCOPE("thrust::erase_if");
+
+  auto first = thrust::remove_if(exec, c.begin(), c.end(), pred);
+
+  auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
+
+  c.erase(first, c.end());
+
+  return removed;
+}
+
+THRUST_NAMESPACE_END

--- a/thrust/thrust/detail/erase.inl
+++ b/thrust/thrust/detail/erase.inl
@@ -23,9 +23,9 @@ _CCCL_HOST typename Vector::size_type erase(Vector& c, const U& value)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::erase");
 
-  auto first = thrust::remove(c.begin(), c.end(), value);
+  const auto first = thrust::remove(c.begin(), c.end(), value);
 
-  auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
+  const auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
 
   c.erase(first, c.end());
 
@@ -38,9 +38,9 @@ erase(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& 
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::erase");
 
-  auto first = thrust::remove(exec, c.begin(), c.end(), value);
+  const auto first = thrust::remove(exec, c.begin(), c.end(), value);
 
-  auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
+  const auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
 
   c.erase(first, c.end());
 
@@ -52,9 +52,9 @@ _CCCL_HOST typename Vector::size_type erase_if(Vector& c, Predicate pred)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::erase_if");
 
-  auto first = thrust::remove_if(c.begin(), c.end(), pred);
+  const auto first = thrust::remove_if(c.begin(), c.end(), pred);
 
-  auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
+  const auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
 
   c.erase(first, c.end());
 
@@ -67,9 +67,9 @@ erase_if(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vecto
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::erase_if");
 
-  auto first = thrust::remove_if(exec, c.begin(), c.end(), pred);
+  const auto first = thrust::remove_if(exec, c.begin(), c.end(), pred);
 
-  auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
+  const auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
 
   c.erase(first, c.end());
 

--- a/thrust/thrust/detail/erase.inl
+++ b/thrust/thrust/detail/erase.inl
@@ -20,9 +20,8 @@ template <class Vector, class U, ::cuda::std::enable_if_t<is_thrust_vector_v<Vec
 _CCCL_HOST typename Vector::size_type erase(Vector& c, const U& value)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::erase");
-  using value_type = typename Vector::value_type;
 
-  auto first = thrust::remove(c.begin(), c.end(), static_cast<value_type>(value));
+  auto first = thrust::remove(c.begin(), c.end(), value);
 
   auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
 
@@ -36,11 +35,11 @@ _CCCL_HOST typename Vector::size_type
 erase(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& c, const U& value)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::erase");
-  using value_type = typename Vector::value_type;
 
-  auto first = thrust::remove(exec, c.begin(), c.end(), static_cast<value_type>(value));
+  auto first = thrust::remove(exec, c.begin(), c.end(), value);
 
   auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
+
   c.erase(first, c.end());
 
   return removed;

--- a/thrust/thrust/erase.h
+++ b/thrust/thrust/erase.h
@@ -89,7 +89,7 @@ _CCCL_HOST typename Vector::size_type erase(Vector& c, const U& value);
  *
  *  \tparam DerivedPolicy The name of the derived execution policy.
  *  \tparam Vector must be a Thrust vector type.
- *  tparam U must be a type comparable (operator '==') to \c Vector's \c value_type.
+ *  \tparam U must be a type comparable (operator '==') to \c Vector's \c value_type.
  *
  *  The following code snippet demonstrates how to use \p erase
  *  to remove all instances of a value from a vector using the \p thrust::device parallelization policy:

--- a/thrust/thrust/erase.h
+++ b/thrust/thrust/erase.h
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*! \file thrust/erase.h
+ *  \brief TODO
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+#include <thrust/detail/execution_policy.h>
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+#include <thrust/remove.h>
+
+#include <type_traits>
+
+THRUST_NAMESPACE_BEGIN
+
+/*! \addtogroup algorithms
+ */
+
+/*! \addtogroup copying
+ *  \ingroup algorithms
+ *  \{
+ */
+
+// TODO: FIx documentation
+/*! \p copy copies elements from the range [\p first, \p last) to the range
+ *  [\p result, \p result + (\p last - \p first)). That is, it performs
+ *  the assignments *\p result = *\p first, *(\p result + \c 1) = *(\p first + \c 1),
+ *  and so on. Generally, for every integer \c n from \c 0 to \p last - \p first, \p copy
+ *  performs the assignment *(\p result + \c n) = *(\p first + \c n). Unlike
+ *  \c std::copy, \p copy offers no guarantee on order of operation.  As a result,
+ *  calling \p copy with overlapping source and destination ranges has undefined
+ *  behavior.
+ *
+ *  The return value is \p result + (\p last - \p first).
+ *
+ *  The algorithm's execution is parallelized as determined by \p exec.
+ *
+ *  \param exec The execution policy to use for parallelization.
+ *  \param first The beginning of the sequence to copy.
+ *  \param last The end of the sequence to copy.
+ *  \param result The destination sequence.
+ *  \return The end of the destination sequence.
+ *  \see https://en.cppreference.com/w/cpp/algorithm/copy
+ *
+ *  \tparam DerivedPolicy The name of the derived execution policy.
+ *  \tparam InputIterator must be a model of <a href="https://en.cppreference.com/w/cpp/iterator/input_iterator">Input
+ * Iterator</a> and \c InputIterator's \c value_type must be convertible to \c OutputIterator's \c value_type. \tparam
+ * OutputIterator must be a model of <a href="https://en.cppreference.com/w/cpp/iterator/output_iterator">Output
+ * Iterator</a>.
+ *
+ *  \pre \p result may be equal to \p first, but \p result shall not be in the range <tt>[first, last)</tt> otherwise.
+ *
+ *  The following code snippet demonstrates how to use \p copy
+ *  to copy from one range to another using the \p thrust::device parallelization policy:
+ *
+ *  \code
+ *  #include <thrust/copy.h>
+ *  #include <thrust/device_vector.h>
+ *  #include <thrust/execution_policy.h>
+ *  ...
+ *
+ *  thrust::device_vector<int> vec0(100);
+ *  thrust::device_vector<int> vec1(100);
+ *  ...
+ *
+ *  thrust::copy(thrust::device, vec0.begin(), vec0.end(), vec1.begin());
+ *
+ *  // vec1 is now a copy of vec0
+ *  \endcode
+ *
+ *  \verbatim embed:rst:leading-asterisk
+ *     .. versionadded:: 2.2.0
+ *  \endverbatim
+ */
+
+template <class V>
+struct is_thrust_vector : std::false_type
+{};
+
+template <class T, class Alloc>
+struct is_thrust_vector<thrust::host_vector<T, Alloc>> : std::true_type
+{};
+
+template <class T, class Alloc>
+struct is_thrust_vector<thrust::device_vector<T, Alloc>> : std::true_type
+{};
+
+// Add exec policy function alternative
+
+template <class Vector,
+          class U                                                        = typename Vector::value_type,
+          ::cuda::std::enable_if_t<is_thrust_vector<Vector>::value, int> = 0>
+typename Vector::size_type erase(Vector& c, const U& value)
+{
+  using value_type = typename Vector::value_type;
+
+  auto first = thrust::remove(c.begin(), c.end(), static_cast<value_type>(value));
+
+  auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
+
+  c.erase(first, c.end());
+
+  return removed;
+}
+
+THRUST_NAMESPACE_END

--- a/thrust/thrust/erase.h
+++ b/thrust/thrust/erase.h
@@ -36,7 +36,7 @@ THRUST_NAMESPACE_BEGIN
  *
  *  The return value is the number of elements that were erased.
  *
- *  Note: unlike \p remove, erase performs container resizing and is host-only.
+ *  Note: unlike \p remove, \p erase performs container resizing and is host-only.
  *
  *  \param c The vector from which to erase elements.
  *  \param value The value to erase from the vector.
@@ -77,10 +77,10 @@ _CCCL_HOST typename Vector::size_type erase(Vector& c, const U& value);
  *
  *  The return value is the number of elements that were erased.
  *
- *  Note: unlike remove, erase performs container resizing and is host-only.
+ *  Note: unlike \p remove, \p erase performs container resizing and is host-only.
  *
  *  The supplied execution policy \p exec is applied to the stream compaction phase
- *  (the underlying call to remove/remove_if). After compaction, the vector
+ *  (the underlying call to \p remove). After compaction, the vector
  *  is resized through Vector::erase on the host to remove the trailing
  *  elements.
  *
@@ -127,7 +127,7 @@ erase(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& 
  *
  *  The return value is the number of elements that were erased.
  *
- *  Note: unlike \p remove_if, erase_if performs container resizing and is host-only.
+ *  Note: unlike \p remove_if, \p erase_if performs container resizing and is host-only.
  *
  *  \param c The vector from which to erase elements.
  *  \param pred The predicate used to determine which elements to erase.
@@ -174,10 +174,10 @@ _CCCL_HOST typename Vector::size_type erase_if(Vector& c, Predicate pred);
  *
  *  The return value is the number of elements that were erased.
  *
- *  Note: unlike remove_if, erase_if performs container resizing and is host-only.
+ *  Note: unlike \p remove_if, \p erase_if performs container resizing and is host-only.
  *
  *  The supplied execution policy \p exec is applied to the stream compaction phase
- *  (the underlying call to remove/remove_if). After compaction, the vector
+ *  (the underlying call to \p remove_if). After compaction, the vector
  *  is resized through Vector::erase on the host to remove the trailing
  *  elements.
  *

--- a/thrust/thrust/erase.h
+++ b/thrust/thrust/erase.h
@@ -44,7 +44,7 @@ THRUST_NAMESPACE_BEGIN
  *  \see https://en.cppreference.com/cpp/container/vector/erase2
  *
  *  \tparam Vector must be a Thrust vector type.
- *  \tparam U must be a type convertible to \c Vector's \c value_type.
+ *  \tparam U must be a type comparable (operator '==') to \c Vector's \c value_type.
  *
  *  The following code snippet demonstrates how to use \p erase
  *  to remove all instances of a value from a vector:
@@ -89,7 +89,7 @@ _CCCL_HOST typename Vector::size_type erase(Vector& c, const U& value);
  *
  *  \tparam DerivedPolicy The name of the derived execution policy.
  *  \tparam Vector must be a Thrust vector type.
- *  \tparam U must be a type convertible to \c Vector's \c value_type.
+ *  tparam U must be a type comparable (operator '==') to \c Vector's \c value_type.
  *
  *  The following code snippet demonstrates how to use \p erase
  *  to remove all instances of a value from a vector using the \p thrust::device parallelization policy:

--- a/thrust/thrust/erase.h
+++ b/thrust/thrust/erase.h
@@ -118,4 +118,32 @@ erase(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& 
   return removed;
 }
 
+template <class Vector, class Predicate, ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
+typename Vector::size_type erase_if(Vector& c, Predicate pred)
+{
+  auto first = thrust::remove_if(c.begin(), c.end(), pred);
+
+  auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
+
+  c.erase(first, c.end());
+
+  return removed;
+}
+
+template <typename DerivedPolicy,
+          class Vector,
+          class Predicate,
+          ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
+typename Vector::size_type
+erase_if(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& c, Predicate pred)
+{
+  auto first = thrust::remove_if(exec, c.begin(), c.end(), pred);
+
+  auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
+
+  c.erase(first, c.end());
+
+  return removed;
+}
+
 THRUST_NAMESPACE_END

--- a/thrust/thrust/erase.h
+++ b/thrust/thrust/erase.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*! \file thrust/erase.h
- *  \brief TODO
+ *  \brief Functions to erase and erase_if elements from Thrust vectors
  */
 
 #pragma once
@@ -32,58 +32,42 @@ THRUST_NAMESPACE_BEGIN
  *  \{
  */
 
-// TODO: FIx documentation
-/*! \p copy copies elements from the range [\p first, \p last) to the range
- *  [\p result, \p result + (\p last - \p first)). That is, it performs
- *  the assignments *\p result = *\p first, *(\p result + \c 1) = *(\p first + \c 1),
- *  and so on. Generally, for every integer \c n from \c 0 to \p last - \p first, \p copy
- *  performs the assignment *(\p result + \c n) = *(\p first + \c n). Unlike
- *  \c std::copy, \p copy offers no guarantee on order of operation.  As a result,
- *  calling \p copy with overlapping source and destination ranges has undefined
- *  behavior.
+/*! \p erase removes all elements equal to \p value from the vector \p c.
+ *  It performs the operation of erasing matching elements and shifting the remaining
+ *  elements towards the beginning of the vector. The size of the vector is reduced
+ *  by the number of erased elements.
  *
- *  The return value is \p result + (\p last - \p first).
+ *  The return value is the number of elements that were erased.
  *
- *  The algorithm's execution is parallelized as determined by \p exec.
+ *  \param c The vector from which to erase elements.
+ *  \param value The value to erase from the vector.
+ *  \return The number of elements erased.
+ *  \see https://en.cppreference.com/cpp/container/vector/erase2
  *
- *  \param exec The execution policy to use for parallelization.
- *  \param first The beginning of the sequence to copy.
- *  \param last The end of the sequence to copy.
- *  \param result The destination sequence.
- *  \return The end of the destination sequence.
- *  \see https://en.cppreference.com/w/cpp/algorithm/copy
+ *  \tparam Vector must be a Thrust vector type.
+ *  \tparam U must be a type convertible to \c Vector's \c value_type.
  *
- *  \tparam DerivedPolicy The name of the derived execution policy.
- *  \tparam InputIterator must be a model of <a href="https://en.cppreference.com/w/cpp/iterator/input_iterator">Input
- * Iterator</a> and \c InputIterator's \c value_type must be convertible to \c OutputIterator's \c value_type. \tparam
- * OutputIterator must be a model of <a href="https://en.cppreference.com/w/cpp/iterator/output_iterator">Output
- * Iterator</a>.
- *
- *  \pre \p result may be equal to \p first, but \p result shall not be in the range <tt>[first, last)</tt> otherwise.
- *
- *  The following code snippet demonstrates how to use \p copy
- *  to copy from one range to another using the \p thrust::device parallelization policy:
+ *  The following code snippet demonstrates how to use \p erase
+ *  to remove all instances of a value from a vector:
  *
  *  \code
- *  #include <thrust/copy.h>
+ *  #include <thrust/erase.h>
  *  #include <thrust/device_vector.h>
- *  #include <thrust/execution_policy.h>
  *  ...
  *
- *  thrust::device_vector<int> vec0(100);
- *  thrust::device_vector<int> vec1(100);
+ *  thrust::device_vector<int> vec{1, 2, 3, 2, 4};
  *  ...
  *
- *  thrust::copy(thrust::device, vec0.begin(), vec0.end(), vec1.begin());
+ *  auto erased = thrust::erase(vec, 2);
  *
- *  // vec1 is now a copy of vec0
+ *  // vec is now {1, 3, 4}
+ *  // erased is 2
  *  \endcode
  *
  *  \verbatim embed:rst:leading-asterisk
- *     .. versionadded:: 2.2.0
+ *     .. versionadded:: ?.?.?
  *  \endverbatim
  */
-
 template <class Vector,
           class U                                                   = typename Vector::value_type,
           ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
@@ -100,6 +84,47 @@ typename Vector::size_type erase(Vector& c, const U& value)
   return removed;
 }
 
+/*! \p erase removes all elements equal to \p value from the vector \p c.
+ *  It performs the operation of erasing matching elements and shifting the remaining
+ *  elements towards the beginning of the vector. The size of the vector is reduced
+ *  by the number of erased elements.
+ *
+ *  The return value is the number of elements that were erased.
+ *
+ *  The algorithm's execution is parallelized as determined by \p exec.
+ *
+ *  \param exec The execution policy to use for parallelization.
+ *  \param c The vector from which to erase elements.
+ *  \param value The value to erase from the vector.
+ *  \return The number of elements erased.
+ *  \see https://en.cppreference.com/cpp/container/vector/erase2
+ *
+ *  \tparam DerivedPolicy The name of the derived execution policy.
+ *  \tparam Vector must be a Thrust vector type.
+ *  \tparam U must be a type convertible to \c Vector's \c value_type.
+ *
+ *  The following code snippet demonstrates how to use \p erase
+ *  to remove all instances of a value from a vector using the \p thrust::device parallelization policy:
+ *
+ *  \code
+ *  #include <thrust/erase.h>
+ *  #include <thrust/device_vector.h>
+ *  #include <thrust/execution_policy.h>
+ *  ...
+ *
+ *  thrust::device_vector<int> vec{1, 2, 3, 2, 4};
+ *  ...
+ *
+ *  auto erased = thrust::erase(thrust::device, vec, 2);
+ *
+ *  // vec is now {1, 3, 4}
+ *  // erased is 2
+ *  \endcode
+ *
+ *  \verbatim embed:rst:leading-asterisk
+ *     .. versionadded:: ?.?.?
+ *  \endverbatim
+ */
 template <typename DerivedPolicy,
           class Vector,
           class U                                                   = typename Vector::value_type,
@@ -118,6 +143,48 @@ erase(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& 
   return removed;
 }
 
+/*! \p erase_if removes all elements from the vector \p c that satisfy the predicate \p pred.
+ *  It performs the operation of erasing matching elements and shifting the remaining
+ *  elements towards the beginning of the vector. The size of the vector is reduced
+ *  by the number of erased elements.
+ *
+ *  The return value is the number of elements that were erased.
+ *
+ *  \param c The vector from which to erase elements.
+ *  \param pred The predicate used to determine which elements to erase.
+ *  \return The number of elements erased.
+ *  \see https://en.cppreference.com/cpp/container/vector/erase2
+ *
+ *  \tparam Vector must be a Thrust vector type.
+ *  \tparam Predicate must be a unary functor that returns \c true for elements to erase.
+ *
+ *  The following code snippet demonstrates how to use \p erase_if
+ *  to remove all elements satisfying a predicate from a vector:
+ *
+ *  \code
+ *  #include <thrust/erase.h>
+ *  #include <thrust/device_vector.h>
+ *  ...
+ *
+ *  struct is_negative
+ *  {
+ *    __host__ __device__
+ *    bool operator()(int x) { return x < 0; }
+ *  };
+ *
+ *  thrust::device_vector<int> vec{1, -2, 3, -4, 5};
+ *  ...
+ *
+ *  auto erased = thrust::erase_if(vec, is_negative());
+ *
+ *  // vec is now {1, 3, 5}
+ *  // erased is 2
+ *  \endcode
+ *
+ *  \verbatim embed:rst:leading-asterisk
+ *     .. versionadded:: ?.?.?
+ *  \endverbatim
+ */
 template <class Vector, class Predicate, ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
 typename Vector::size_type erase_if(Vector& c, Predicate pred)
 {
@@ -130,6 +197,53 @@ typename Vector::size_type erase_if(Vector& c, Predicate pred)
   return removed;
 }
 
+/*! \p erase_if removes all elements from the vector \p c that satisfy the predicate \p pred.
+ *  It performs the operation of erasing matching elements and shifting the remaining
+ *  elements towards the beginning of the vector. The size of the vector is reduced
+ *  by the number of erased elements.
+ *
+ *  The return value is the number of elements that were erased.
+ *
+ *  The algorithm's execution is parallelized as determined by \p exec.
+ *
+ *  \param exec The execution policy to use for parallelization.
+ *  \param c The vector from which to erase elements.
+ *  \param pred The predicate used to determine which elements to erase.
+ *  \return The number of elements erased.
+ *  \see https://en.cppreference.com/cpp/container/vector/erase2
+ *
+ *  \tparam DerivedPolicy The name of the derived execution policy.
+ *  \tparam Vector must be a Thrust vector type.
+ *  \tparam Predicate must be a unary functor that returns \c true for elements to erase.
+ *
+ *  The following code snippet demonstrates how to use \p erase_if
+ *  to remove all elements satisfying a predicate from a vector using the \p thrust::device parallelization policy:
+ *
+ *  \code
+ *  #include <thrust/erase.h>
+ *  #include <thrust/device_vector.h>
+ *  #include <thrust/execution_policy.h>
+ *  ...
+ *
+ *  struct is_negative
+ *  {
+ *    __host__ __device__
+ *    bool operator()(int x) { return x < 0; }
+ *  };
+ *
+ *  thrust::device_vector<int> vec{1, -2, 3, -4, 5};
+ *  ...
+ *
+ *  auto erased = thrust::erase_if(thrust::device, vec, is_negative());
+ *
+ *  // vec is now {1, 3, 5}
+ *  // erased is 2
+ *  \endcode
+ *
+ *  \verbatim embed:rst:leading-asterisk
+ *     .. versionadded:: ?.?.?
+ *  \endverbatim
+ */
 template <typename DerivedPolicy,
           class Vector,
           class Predicate,

--- a/thrust/thrust/erase.h
+++ b/thrust/thrust/erase.h
@@ -39,6 +39,8 @@ THRUST_NAMESPACE_BEGIN
  *
  *  The return value is the number of elements that were erased.
  *
+ *  Note: unlike \p remove, erase performs container resizing and is host-only.
+ *
  *  \param c The vector from which to erase elements.
  *  \param value The value to erase from the vector.
  *  \return The number of elements erased.
@@ -71,7 +73,7 @@ THRUST_NAMESPACE_BEGIN
 template <class Vector,
           class U                                                   = typename Vector::value_type,
           ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
-typename Vector::size_type erase(Vector& c, const U& value);
+_CCCL_HOST typename Vector::size_type erase(Vector& c, const U& value);
 
 /*! \p erase removes all elements equal to \p value from the vector \p c.
  *  It performs the operation of erasing matching elements and shifting the remaining
@@ -79,6 +81,8 @@ typename Vector::size_type erase(Vector& c, const U& value);
  *  by the number of erased elements.
  *
  *  The return value is the number of elements that were erased.
+ *
+ *  Note: unlike \p remove, erase performs container resizing and is host-only.
  *
  *  The algorithm's execution is parallelized as determined by \p exec.
  *
@@ -118,7 +122,7 @@ template <typename DerivedPolicy,
           class Vector,
           class U                                                   = typename Vector::value_type,
           ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
-typename Vector::size_type
+_CCCL_HOST typename Vector::size_type
 erase(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& c, const U& value);
 
 /*! \p erase_if removes all elements from the vector \p c that satisfy the predicate \p pred.
@@ -127,6 +131,8 @@ erase(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& 
  *  by the number of erased elements.
  *
  *  The return value is the number of elements that were erased.
+ *
+ *  Note: unlike \p remove_if, erase_if performs container resizing and is host-only.
  *
  *  \param c The vector from which to erase elements.
  *  \param pred The predicate used to determine which elements to erase.
@@ -164,7 +170,7 @@ erase(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& 
  *  \endverbatim
  */
 template <class Vector, class Predicate, ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
-typename Vector::size_type erase_if(Vector& c, Predicate pred);
+_CCCL_HOST typename Vector::size_type erase_if(Vector& c, Predicate pred);
 
 /*! \p erase_if removes all elements from the vector \p c that satisfy the predicate \p pred.
  *  It performs the operation of erasing matching elements and shifting the remaining
@@ -172,6 +178,8 @@ typename Vector::size_type erase_if(Vector& c, Predicate pred);
  *  by the number of erased elements.
  *
  *  The return value is the number of elements that were erased.
+ *
+ *  Note: unlike \p remove_if, erase_if performs container resizing and is host-only.
  *
  *  The algorithm's execution is parallelized as determined by \p exec.
  *
@@ -217,7 +225,7 @@ template <typename DerivedPolicy,
           class Vector,
           class Predicate,
           ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
-typename Vector::size_type
+_CCCL_HOST typename Vector::size_type
 erase_if(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& c, Predicate pred);
 
 THRUST_NAMESPACE_END

--- a/thrust/thrust/erase.h
+++ b/thrust/thrust/erase.h
@@ -27,7 +27,6 @@ THRUST_NAMESPACE_BEGIN
 /*! \addtogroup stream_compaction Stream Compaction
  *  \ingroup reordering
  *  \{
- *
  */
 
 /*! \p erase removes all elements equal to \p value from the vector \p c.

--- a/thrust/thrust/erase.h
+++ b/thrust/thrust/erase.h
@@ -27,6 +27,7 @@ THRUST_NAMESPACE_BEGIN
 /*! \addtogroup stream_compaction Stream Compaction
  *  \ingroup reordering
  *  \{
+ *
  */
 
 /*! \p erase removes all elements equal to \p value from the vector \p c.
@@ -77,9 +78,12 @@ _CCCL_HOST typename Vector::size_type erase(Vector& c, const U& value);
  *
  *  The return value is the number of elements that were erased.
  *
- *  Note: unlike \p remove, erase performs container resizing and is host-only.
+ *  Note: unlike remove, erase performs container resizing and is host-only.
  *
- *  The algorithm's execution is parallelized as determined by \p exec.
+ *  The supplied execution policy \p exec is applied to the stream compaction phase
+ *  (the underlying call to remove/remove_if). After compaction, the vector
+ *  is resized through Vector::erase on the host to remove the trailing
+ *  elements.
  *
  *  \param exec The execution policy to use for parallelization.
  *  \param c The vector from which to erase elements.
@@ -171,9 +175,12 @@ _CCCL_HOST typename Vector::size_type erase_if(Vector& c, Predicate pred);
  *
  *  The return value is the number of elements that were erased.
  *
- *  Note: unlike \p remove_if, erase_if performs container resizing and is host-only.
+ *  Note: unlike remove_if, erase_if performs container resizing and is host-only.
  *
- *  The algorithm's execution is parallelized as determined by \p exec.
+ *  The supplied execution policy \p exec is applied to the stream compaction phase
+ *  (the underlying call to remove/remove_if). After compaction, the vector
+ *  is resized through Vector::erase on the host to remove the trailing
+ *  elements.
  *
  *  \param exec The execution policy to use for parallelization.
  *  \param c The vector from which to erase elements.

--- a/thrust/thrust/erase.h
+++ b/thrust/thrust/erase.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 /*! \file thrust/erase.h

--- a/thrust/thrust/erase.h
+++ b/thrust/thrust/erase.h
@@ -70,7 +70,7 @@ THRUST_NAMESPACE_BEGIN
  *  \endverbatim
  */
 template <class Vector, class U, ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
-_CCCL_HOST typename Vector::size_type erase(Vector& c, const U& value);
+_CCCL_HOST_API typename Vector::size_type erase(Vector& c, const U& value);
 
 /*! \p erase removes all elements equal to \p value from the vector \p c.
  *  It performs the operation of erasing matching elements and shifting the remaining
@@ -119,7 +119,7 @@ _CCCL_HOST typename Vector::size_type erase(Vector& c, const U& value);
  *  \endverbatim
  */
 template <typename DerivedPolicy, class Vector, class U, ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
-_CCCL_HOST typename Vector::size_type
+_CCCL_HOST_API typename Vector::size_type
 erase(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& c, const U& value);
 
 /*! \p erase_if removes all elements from the vector \p c that satisfy the predicate \p pred.
@@ -167,7 +167,7 @@ erase(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& 
  *  \endverbatim
  */
 template <class Vector, class Predicate, ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
-_CCCL_HOST typename Vector::size_type erase_if(Vector& c, Predicate pred);
+_CCCL_HOST_API typename Vector::size_type erase_if(Vector& c, Predicate pred);
 
 /*! \p erase_if removes all elements from the vector \p c that satisfy the predicate \p pred.
  *  It performs the operation of erasing matching elements and shifting the remaining
@@ -225,7 +225,7 @@ template <typename DerivedPolicy,
           class Vector,
           class Predicate,
           ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
-_CCCL_HOST typename Vector::size_type
+_CCCL_HOST_API typename Vector::size_type
 erase_if(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& c, Predicate pred);
 
 THRUST_NAMESPACE_END

--- a/thrust/thrust/erase.h
+++ b/thrust/thrust/erase.h
@@ -22,6 +22,8 @@
 #include <thrust/remove.h>
 #include <thrust/type_traits/is_thrust_vector.h>
 
+#include <cuda/std/__type_traits/enable_if.h>
+
 THRUST_NAMESPACE_BEGIN
 
 /*! \addtogroup stream_compaction Stream Compaction

--- a/thrust/thrust/erase.h
+++ b/thrust/thrust/erase.h
@@ -71,18 +71,7 @@ THRUST_NAMESPACE_BEGIN
 template <class Vector,
           class U                                                   = typename Vector::value_type,
           ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
-typename Vector::size_type erase(Vector& c, const U& value)
-{
-  using value_type = typename Vector::value_type;
-
-  auto first = thrust::remove(c.begin(), c.end(), static_cast<value_type>(value));
-
-  auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
-
-  c.erase(first, c.end());
-
-  return removed;
-}
+typename Vector::size_type erase(Vector& c, const U& value);
 
 /*! \p erase removes all elements equal to \p value from the vector \p c.
  *  It performs the operation of erasing matching elements and shifting the remaining
@@ -130,18 +119,7 @@ template <typename DerivedPolicy,
           class U                                                   = typename Vector::value_type,
           ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
 typename Vector::size_type
-erase(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& c, const U& value)
-{
-  using value_type = typename Vector::value_type;
-
-  auto first = thrust::remove(exec, c.begin(), c.end(), static_cast<value_type>(value));
-
-  auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
-
-  c.erase(first, c.end());
-
-  return removed;
-}
+erase(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& c, const U& value);
 
 /*! \p erase_if removes all elements from the vector \p c that satisfy the predicate \p pred.
  *  It performs the operation of erasing matching elements and shifting the remaining
@@ -186,16 +164,7 @@ erase(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& 
  *  \endverbatim
  */
 template <class Vector, class Predicate, ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
-typename Vector::size_type erase_if(Vector& c, Predicate pred)
-{
-  auto first = thrust::remove_if(c.begin(), c.end(), pred);
-
-  auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
-
-  c.erase(first, c.end());
-
-  return removed;
-}
+typename Vector::size_type erase_if(Vector& c, Predicate pred);
 
 /*! \p erase_if removes all elements from the vector \p c that satisfy the predicate \p pred.
  *  It performs the operation of erasing matching elements and shifting the remaining
@@ -249,15 +218,8 @@ template <typename DerivedPolicy,
           class Predicate,
           ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
 typename Vector::size_type
-erase_if(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& c, Predicate pred)
-{
-  auto first = thrust::remove_if(exec, c.begin(), c.end(), pred);
-
-  auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
-
-  c.erase(first, c.end());
-
-  return removed;
-}
+erase_if(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& c, Predicate pred);
 
 THRUST_NAMESPACE_END
+
+#include <thrust/detail/erase.inl>

--- a/thrust/thrust/erase.h
+++ b/thrust/thrust/erase.h
@@ -70,9 +70,7 @@ THRUST_NAMESPACE_BEGIN
  *     .. versionadded:: ?.?.?
  *  \endverbatim
  */
-template <class Vector,
-          class U                                                   = typename Vector::value_type,
-          ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
+template <class Vector, class U, ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
 _CCCL_HOST typename Vector::size_type erase(Vector& c, const U& value);
 
 /*! \p erase removes all elements equal to \p value from the vector \p c.
@@ -118,10 +116,7 @@ _CCCL_HOST typename Vector::size_type erase(Vector& c, const U& value);
  *     .. versionadded:: ?.?.?
  *  \endverbatim
  */
-template <typename DerivedPolicy,
-          class Vector,
-          class U                                                   = typename Vector::value_type,
-          ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
+template <typename DerivedPolicy, class Vector, class U, ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
 _CCCL_HOST typename Vector::size_type
 erase(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& c, const U& value);
 

--- a/thrust/thrust/erase.h
+++ b/thrust/thrust/erase.h
@@ -85,23 +85,20 @@ THRUST_NAMESPACE_BEGIN
  *  \endverbatim
  */
 
-template <class V>
-struct is_thrust_vector : std::false_type
-{};
+template <typename T>
+inline constexpr bool is_thrust_vector_v = false;
 
-template <class T, class Alloc>
-struct is_thrust_vector<thrust::host_vector<T, Alloc>> : std::true_type
-{};
+template <typename T, typename Alloc>
+inline constexpr bool is_thrust_vector_v<thrust::host_vector<T, Alloc>> = true;
 
-template <class T, class Alloc>
-struct is_thrust_vector<thrust::device_vector<T, Alloc>> : std::true_type
-{};
+template <typename T, typename Alloc>
+inline constexpr bool is_thrust_vector_v<thrust::device_vector<T, Alloc>> = true;
 
-// Add exec policy function alternative
+// TODO: Add exec policy function alternative
 
 template <class Vector,
-          class U                                                        = typename Vector::value_type,
-          ::cuda::std::enable_if_t<is_thrust_vector<Vector>::value, int> = 0>
+          class U                                                   = typename Vector::value_type,
+          ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
 typename Vector::size_type erase(Vector& c, const U& value)
 {
   using value_type = typename Vector::value_type;

--- a/thrust/thrust/erase.h
+++ b/thrust/thrust/erase.h
@@ -24,11 +24,8 @@
 
 THRUST_NAMESPACE_BEGIN
 
-/*! \addtogroup algorithms
- */
-
-/*! \addtogroup copying
- *  \ingroup algorithms
+/*! \addtogroup stream_compaction Stream Compaction
+ *  \ingroup reordering
  *  \{
  */
 

--- a/thrust/thrust/erase.h
+++ b/thrust/thrust/erase.h
@@ -112,4 +112,22 @@ typename Vector::size_type erase(Vector& c, const U& value)
   return removed;
 }
 
+template <typename DerivedPolicy,
+          class Vector,
+          class U                                                   = typename Vector::value_type,
+          ::cuda::std::enable_if_t<is_thrust_vector_v<Vector>, int> = 0>
+typename Vector::size_type
+erase(const thrust::detail::execution_policy_base<DerivedPolicy>& exec, Vector& c, const U& value)
+{
+  using value_type = typename Vector::value_type;
+
+  auto first = thrust::remove(exec, c.begin(), c.end(), static_cast<value_type>(value));
+
+  auto removed = static_cast<typename Vector::size_type>(::cuda::std::distance(first, c.end()));
+
+  c.erase(first, c.end());
+
+  return removed;
+}
+
 THRUST_NAMESPACE_END

--- a/thrust/thrust/erase.h
+++ b/thrust/thrust/erase.h
@@ -20,8 +20,7 @@
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 #include <thrust/remove.h>
-
-#include <type_traits>
+#include <thrust/type_traits/is_thrust_vector.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -84,17 +83,6 @@ THRUST_NAMESPACE_BEGIN
  *     .. versionadded:: 2.2.0
  *  \endverbatim
  */
-
-template <typename T>
-inline constexpr bool is_thrust_vector_v = false;
-
-template <typename T, typename Alloc>
-inline constexpr bool is_thrust_vector_v<thrust::host_vector<T, Alloc>> = true;
-
-template <typename T, typename Alloc>
-inline constexpr bool is_thrust_vector_v<thrust::device_vector<T, Alloc>> = true;
-
-// TODO: Add exec policy function alternative
 
 template <class Vector,
           class U                                                   = typename Vector::value_type,

--- a/thrust/thrust/type_traits/is_thrust_vector.h
+++ b/thrust/thrust/type_traits/is_thrust_vector.h
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2008-2021, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/*! \file TODO
- *  \brief A type trait that determines if a type is an \a ExecutionPolicy.
+/*! \file thrust/type_traits/is_thrust_vector.h
+ *  \brief A type trait that determines if a type is a Thrust vector.
  */
 
 #pragma once
@@ -32,14 +32,8 @@ THRUST_NAMESPACE_BEGIN
  *  \{
  */
 
-// TODO
-/*! \brief <a href="https://en.cppreference.com/w/cpp/named_req/UnaryTypeTrait"><i>UnaryTypeTrait</i></a>
- *  that returns \c true_type if \c T is an \a ExecutionPolicy and \c false_type
- *  otherwise.
- */
-
-/*! \brief <tt>constexpr bool</tt> that is \c true if \c T is an
- *  \a ExecutionPolicy and \c false otherwise.
+/*! \brief <tt>constexpr bool</tt> that is \c true if \c T is a
+ *  Thrust vector and \c false otherwise.
  */
 template <typename T>
 inline constexpr bool is_thrust_vector_v = false;

--- a/thrust/thrust/type_traits/is_thrust_vector.h
+++ b/thrust/thrust/type_traits/is_thrust_vector.h
@@ -17,6 +17,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <thrust/detail/type_traits.h>
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 
@@ -34,13 +35,19 @@ THRUST_NAMESPACE_BEGIN
  *  Thrust vector and \c false otherwise.
  */
 template <typename T>
-inline constexpr bool is_thrust_vector_v = false;
+struct is_thrust_vector : thrust::detail::false_type
+{};
 
 template <typename T, typename Alloc>
-inline constexpr bool is_thrust_vector_v<thrust::host_vector<T, Alloc>> = true;
+struct is_thrust_vector<thrust::host_vector<T, Alloc>> : thrust::detail::true_type
+{};
 
 template <typename T, typename Alloc>
-inline constexpr bool is_thrust_vector_v<thrust::device_vector<T, Alloc>> = true;
+struct is_thrust_vector<thrust::device_vector<T, Alloc>> : thrust::detail::true_type
+{};
+
+template <typename T>
+inline constexpr bool is_thrust_vector_v = is_thrust_vector<::cuda::std::remove_cvref_t<T>>::value;
 
 /*! \} // type traits
  */

--- a/thrust/thrust/type_traits/is_thrust_vector.h
+++ b/thrust/thrust/type_traits/is_thrust_vector.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2021, NVIDIA Corporation. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 /*! \file thrust/type_traits/is_thrust_vector.h

--- a/thrust/thrust/type_traits/is_thrust_vector.h
+++ b/thrust/thrust/type_traits/is_thrust_vector.h
@@ -17,8 +17,6 @@
 #  pragma system_header
 #endif // no system header
 
-#include <thrust/detail/execution_policy.h>
-#include <thrust/detail/type_traits.h>
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 

--- a/thrust/thrust/type_traits/is_thrust_vector.h
+++ b/thrust/thrust/type_traits/is_thrust_vector.h
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (c) 2008-2021, NVIDIA Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*! \file TODO
+ *  \brief A type trait that determines if a type is an \a ExecutionPolicy.
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <thrust/detail/execution_policy.h>
+#include <thrust/detail/type_traits.h>
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+THRUST_NAMESPACE_BEGIN
+
+/*! \addtogroup utility
+ *  \{
+ */
+
+/*! \addtogroup type_traits Type Traits
+ *  \{
+ */
+
+// TODO
+/*! \brief <a href="https://en.cppreference.com/w/cpp/named_req/UnaryTypeTrait"><i>UnaryTypeTrait</i></a>
+ *  that returns \c true_type if \c T is an \a ExecutionPolicy and \c false_type
+ *  otherwise.
+ */
+
+/*! \brief <tt>constexpr bool</tt> that is \c true if \c T is an
+ *  \a ExecutionPolicy and \c false otherwise.
+ */
+template <typename T>
+inline constexpr bool is_thrust_vector_v = false;
+
+template <typename T, typename Alloc>
+inline constexpr bool is_thrust_vector_v<thrust::host_vector<T, Alloc>> = true;
+
+template <typename T, typename Alloc>
+inline constexpr bool is_thrust_vector_v<thrust::device_vector<T, Alloc>> = true;
+
+/*! \} // type traits
+ */
+
+/*! \} // utility
+ */
+
+THRUST_NAMESPACE_END


### PR DESCRIPTION
## Description

closes #727

Adds `thrust::erase` and `thrust::erase_if` for `thrust::host_vector` and `thrust::device_vector`, following the C++20 container erasure idiom (`std::erase`/`std::erase_if`) and eliminating the need for the manual erase-remove idiom.

Both functions are implemented as host-only APIs, since resizing a vector requires host-side allocator and destructor calls that cannot be expressed as device code:

- `erase(c, value)` removes all elements equal to `value` from vector `c` and returns the number of elements removed.
- `erase_if(c, pred)` removes all elements from vector `c` for which the predicate `pred` returns `true`, and returns the number of elements removed.

Both are also available as overloads accepting an execution policy, e.g. `thrust::erase(thrust::cuda::par.on(stream), c, value)`. The supplied execution policy is applied to the underlying stream compaction step (`thrust::remove`/`thrust::remove_if`); the subsequent container resize is performed host-side via `Vector::erase`.

A new type trait `is_thrust_vector_v<T>` was introduced to constrain these overloads to `thrust::host_vector` and `thrust::device_vector`.

Note: unlike `remove`/`remove_if`, `erase`/`erase_if` compare/test elements against the container's `value_type` directly (no implicit cast of the comparison value), matching `std::erase`'s semantics. `U` (the type of the value passed to `erase`) only needs to be comparable to `Vector::value_type` via `operator==`, not implicitly convertible to it.

### Testing
- Correctness tests for `erase`/`erase_if` covering empty vectors, single/multiple/all/no matches, consecutive and alternating matches, first/last element, and large vectors (10000 elements), for both `host_vector` and `device_vector` across `NumericTypes`.
- CUDA stream tests verifying `erase`/`erase_if` work correctly with a custom `cudaStream_t` via `thrust::cuda::par.on(s)`, including a non-trivially-destructible element type.
- A dedicated test covering the heterogeneous-type comparison path (`U != value_type`).

### Notes

* I didn't add an example but I can submit it later if desired
* I didn't add benchmark tests since the implementation relies on the `thrust::remove`/`thrust::remove_if` implementation which is already benchmarked
* In the documentation of the functions I added a placeholder for the version `versionadded:: ?.?.?`
* I'm not sure if I added the functions to the correct doxygen group, please verify that
* I set the copyright in the files to 2026, not sure if this is correct.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cccl/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
