### PR TITLE
[cudax][cuco] Use the detail config header and proper visibility macros in cuco headers

### DIFF
--- a/cudax/include/cuda/experimental/__cuco/detail/hash_functions/murmurhash3.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/hash_functions/murmurhash3.cuh
@@ -22,7 +22,7 @@
 #ifndef _CUDAX___CUCO_DETAIL_HASH_FUNCTIONS_MURMURHASH3_CUH
 #define _CUDAX___CUCO_DETAIL_HASH_FUNCTIONS_MURMURHASH3_CUH
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
@@ -229,14 +229,14 @@ private:
   static constexpr ::cuda::std::uint32_t __chunk_size = 16;
 
 public:
-  _CCCL_HOST_DEVICE constexpr _MurmurHash3_x86_128(::cuda::std::uint32_t __seed = 0)
+  _CCCL_HOST_DEVICE_API constexpr _MurmurHash3_x86_128(::cuda::std::uint32_t __seed = 0)
       : __seed_{__seed}
   {}
 
   //! @brief Returns a hash value for its argument, as a value of type `__uint128_t`.
   //! @param __key The input argument to hash
   //! @return The resulting hash value
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr __uint128_t operator()(const _Key& __key) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __uint128_t operator()(const _Key& __key) const noexcept
   {
     using _Holder = _Byte_holder<sizeof(_Key), __chunk_size, __block_size, false, ::cuda::std::uint32_t>;
     return __compute_hash(::cuda::std::bit_cast<_Holder>(__key));
@@ -247,7 +247,7 @@ public:
   //! @param __keys span of keys to hash
   //! @return The resulting hash value
   template <size_t _Extent>
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr __uint128_t
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __uint128_t
   operator()(::cuda::std::span<_Key, _Extent> __keys) const noexcept
   {
     return __compute_hash_span(__keys);
@@ -255,7 +255,7 @@ public:
 
 private:
   template <class _Holder>
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr __uint128_t __compute_hash(_Holder __holder) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __uint128_t __compute_hash(_Holder __holder) const noexcept
   {
     ::cuda::std::array<::cuda::std::uint32_t, 4> __h{__seed_, __seed_, __seed_, __seed_};
     const auto __size = ::cuda::std::uint32_t{sizeof(_Holder)};
@@ -410,7 +410,7 @@ private:
     return ::cuda::std::bit_cast<__uint128_t>(__h);
   }
 
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr __uint128_t
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __uint128_t
   __compute_hash_span(::cuda::std::span<const _Key> __keys) const noexcept
   {
     const auto __bytes = ::cuda::std::as_bytes(__keys).data();
@@ -586,14 +586,14 @@ private:
   static constexpr ::cuda::std::uint32_t __chunk_size = 16;
 
 public:
-  _CCCL_HOST_DEVICE constexpr _MurmurHash3_x64_128(::cuda::std::uint64_t __seed = 0)
+  _CCCL_HOST_DEVICE_API constexpr _MurmurHash3_x64_128(::cuda::std::uint64_t __seed = 0)
       : __seed_{__seed}
   {}
 
   //! @brief Returns a hash value for its argument, as a value of type `__uint128_t`.
   //! @param __key The input argument to hash
   //! @return The resulting hash value
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr __uint128_t operator()(const _Key& __key) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __uint128_t operator()(const _Key& __key) const noexcept
   {
     using _Holder = _Byte_holder<sizeof(_Key), __chunk_size, __block_size, false, ::cuda::std::uint64_t>;
     return __compute_hash(::cuda::std::bit_cast<_Holder>(__key));
@@ -604,7 +604,7 @@ public:
   //! @param __keys span of keys to hash
   //! @return The resulting hash value
   template <size_t _Extent>
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr __uint128_t
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __uint128_t
   operator()(::cuda::std::span<_Key, _Extent> __keys) const noexcept
   {
     return __compute_hash_span(__keys);
@@ -612,7 +612,7 @@ public:
 
 private:
   template <class _Holder>
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr __uint128_t __compute_hash(_Holder __holder) const noexcept
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __uint128_t __compute_hash(_Holder __holder) const noexcept
   {
     ::cuda::std::array<::cuda::std::uint64_t, 2> __h{__seed_, __seed_};
     const auto __size = ::cuda::std::uint64_t{sizeof(_Holder)};
@@ -722,7 +722,7 @@ private:
     return ::cuda::std::bit_cast<__uint128_t>(__h);
   }
 
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr __uint128_t
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __uint128_t
   __compute_hash_span(::cuda::std::span<const _Key> __keys) const noexcept
   {
     const auto __bytes = ::cuda::std::as_bytes(__keys).data();

--- a/cudax/include/cuda/experimental/__cuco/detail/hash_functions/utils.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/hash_functions/utils.cuh
@@ -11,7 +11,7 @@
 #ifndef _CUDAX___CUCO_DETAIL_HASH_FUNCTIONS_UTILS_CUH
 #define _CUDAX___CUCO_DETAIL_HASH_FUNCTIONS_UTILS_CUH
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/cudax/include/cuda/experimental/__cuco/detail/hash_functions/xxhash.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/hash_functions/xxhash.cuh
@@ -45,7 +45,7 @@
 #ifndef _CUDAX___CUCO_DETAIL_HASH_FUNCTIONS_XXHASH_CUH
 #define _CUDAX___CUCO_DETAIL_HASH_FUNCTIONS_XXHASH_CUH
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/default_policy.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/default_policy.cuh
@@ -11,7 +11,7 @@
 #ifndef _CUDAX___CUCO_DETAIL_HYPERLOGLOG_DEFAULT_POLICY_CUH
 #define _CUDAX___CUCO_DETAIL_HYPERLOGLOG_DEFAULT_POLICY_CUH
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/finalizer.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/finalizer.cuh
@@ -11,7 +11,7 @@
 #ifndef _CUDAX___CUCO_DETAIL_HYPERLOGLOG_FINALIZER_CUH
 #define _CUDAX___CUCO_DETAIL_HYPERLOGLOG_FINALIZER_CUH
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/hyperloglog_impl.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/hyperloglog_impl.cuh
@@ -11,7 +11,7 @@
 #ifndef _CUDAX___CUCO_DETAIL_HYPERLOGLOG_IMPL_CUH
 #define _CUDAX___CUCO_DETAIL_HYPERLOGLOG_IMPL_CUH
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
@@ -126,7 +126,7 @@ public:
   //!
   //! @param __group CUDA Cooperative group this operation is executed in
   template <class _CG>
-  _CCCL_DEVICE constexpr void __clear(_CG __group) noexcept
+  _CCCL_DEVICE_API constexpr void __clear(_CG __group) noexcept
   {
     for (int __i = __group.thread_rank(); __i < __sketch.size(); __i += __group.size())
     {
@@ -140,7 +140,7 @@ public:
   //! `__clear_async`.
   //!
   //! @param __stream CUDA stream this operation is executed in
-  _CCCL_HOST constexpr void __clear(::cuda::stream_ref __stream)
+  _CCCL_HOST_API constexpr void __clear(::cuda::stream_ref __stream)
   {
     __clear_async(__stream);
     __stream.sync();
@@ -149,7 +149,7 @@ public:
   //! @brief Asynchronously resets the estimator, i.e., clears the current count estimate.
   //!
   //! @param __stream CUDA stream this operation is executed in
-  _CCCL_HOST constexpr void __clear_async(::cuda::stream_ref __stream)
+  _CCCL_HOST_API constexpr void __clear_async(::cuda::stream_ref __stream)
   {
     constexpr auto __block_size = 1024;
     ::cuda::experimental::cuco::__hyperloglog_ns::__clear<<<1, __block_size, 0, __stream.get()>>>(*this);
@@ -160,7 +160,7 @@ public:
   //! @note Hash, register index, and rho are determined by the active policy.
   //!
   //! @param __item The item to be counted
-  _CCCL_DEVICE constexpr void __add(const _Tp& __item) noexcept
+  _CCCL_DEVICE_API constexpr void __add(const _Tp& __item) noexcept
   {
     const auto __h = __policy.hash(__item);
     this->__update_max(__policy.register_index(__h, __precision), __policy.register_value(__h, __precision));
@@ -176,7 +176,7 @@ public:
   //! @param __last End of the sequence of items
   //! @param __stream CUDA stream this operation is executed in
   template <class _InputIt>
-  _CCCL_HOST constexpr void __add_async(_InputIt __first, _InputIt __last, ::cuda::stream_ref __stream)
+  _CCCL_HOST_API constexpr void __add_async(_InputIt __first, _InputIt __last, ::cuda::stream_ref __stream)
   {
     const auto __num_items = ::cuda::std::distance(__first, __last);
     if (__num_items == 0)
@@ -315,7 +315,7 @@ public:
   //! @param __last End of the sequence of items
   //! @param __stream CUDA stream this operation is executed in
   template <class _InputIt>
-  _CCCL_HOST constexpr void __add(_InputIt __first, _InputIt __last, ::cuda::stream_ref __stream)
+  _CCCL_HOST_API constexpr void __add(_InputIt __first, _InputIt __last, ::cuda::stream_ref __stream)
   {
     __add_async(__first, __last, __stream);
     __stream.sync();
@@ -331,7 +331,7 @@ public:
   //! @param __group CUDA Cooperative group this operation is executed in
   //! @param __other Other estimator reference to be merged into `*this`
   template <class _CG, ::cuda::thread_scope _OtherScope>
-  _CCCL_DEVICE constexpr void __merge(_CG __group, __hyperloglog_impl<_Tp, _OtherScope, _Policy>& __other)
+  _CCCL_DEVICE_API constexpr void __merge(_CG __group, __hyperloglog_impl<_Tp, _OtherScope, _Policy>& __other)
   {
     if (__other.__precision != __precision)
     {
@@ -354,7 +354,7 @@ public:
   //! @param __other Other estimator reference to be merged into `*this`
   //! @param __stream CUDA stream this operation is executed in
   template <::cuda::thread_scope _OtherScope>
-  _CCCL_HOST constexpr void
+  _CCCL_HOST_API constexpr void
   __merge_async(const __hyperloglog_impl<_Tp, _OtherScope, _Policy>& __other, ::cuda::stream_ref __stream)
   {
     if (__other.__precision != __precision)
@@ -378,7 +378,7 @@ public:
   //! @param __other Other estimator reference to be merged into `*this`
   //! @param __stream CUDA stream this operation is executed in
   template <::cuda::thread_scope _OtherScope>
-  _CCCL_HOST constexpr void
+  _CCCL_HOST_API constexpr void
   __merge(const __hyperloglog_impl<_Tp, _OtherScope, _Policy>& __other, ::cuda::stream_ref __stream)
   {
     __merge_async(__other, __stream);
@@ -390,7 +390,7 @@ public:
   //! @param __group CUDA thread block group this operation is executed in
   //!
   //! @return Approximate distinct items count
-  [[nodiscard]] _CCCL_DEVICE ::cuda::std::size_t
+  [[nodiscard]] _CCCL_DEVICE_API ::cuda::std::size_t
   __estimate(const ::cooperative_groups::thread_block& __group) const noexcept
   {
     __shared__ ::cuda::atomic<__fp_type, ::cuda::std::thread_scope_block> __block_sum;
@@ -444,7 +444,7 @@ public:
   //!
   //! @return Approximate distinct items count
   template <typename _HostMemoryResource>
-  [[nodiscard]] _CCCL_HOST ::cuda::std::size_t
+  [[nodiscard]] _CCCL_HOST_API ::cuda::std::size_t
   __estimate(_HostMemoryResource __host_mr, ::cuda::stream_ref __stream) const
   {
     const auto __num_regs = __sketch.size();
@@ -565,7 +565,7 @@ private:
   //!
   //! @param __i Register index
   //! @param __value New value
-  _CCCL_DEVICE constexpr void __update_max(int __i, __register_type __value) noexcept
+  _CCCL_DEVICE_API constexpr void __update_max(int __i, __register_type __value) noexcept
   {
     ::cuda::atomic_ref<__register_type, _Scope> __register_ref(__sketch[__i]);
     __register_ref.fetch_max(__value, ::cuda::memory_order_relaxed);
@@ -580,7 +580,7 @@ private:
   //!
   //! @returns True iff kernel configuration is successful
   template <typename _Kernel>
-  [[nodiscard]] _CCCL_HOST constexpr bool __try_reserve_shmem(_Kernel __kernel, int __shmem_bytes) const
+  [[nodiscard]] _CCCL_HOST_API constexpr bool __try_reserve_shmem(_Kernel __kernel, int __shmem_bytes) const
   {
     int __device = -1;
     _CCCL_TRY_CUDA_API(::cudaGetDevice, "cudaGetDevice failed", &__device);

--- a/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/kernels.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/kernels.cuh
@@ -11,7 +11,7 @@
 #ifndef _CUDAX___CUCO_DETAIL_HYPERLOGLOG_KERNELS_CUH
 #define _CUDAX___CUCO_DETAIL_HYPERLOGLOG_KERNELS_CUH
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
@@ -38,7 +38,7 @@ namespace cuda::experimental::cuco::__hyperloglog_ns
 //! @brief Returns the global thread ID in a 1D grid
 //!
 //! @return The global thread ID
-[[nodiscard]] _CCCL_DEVICE inline ::cuda::std::int64_t __global_thread_id() noexcept
+[[nodiscard]] _CCCL_DEVICE_API inline ::cuda::std::int64_t __global_thread_id() noexcept
 {
   return static_cast<::cuda::std::int64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
 }
@@ -46,7 +46,7 @@ namespace cuda::experimental::cuco::__hyperloglog_ns
 //! @brief Returns the grid stride of a 1D grid
 //!
 //! @return The grid stride
-[[nodiscard]] _CCCL_DEVICE inline ::cuda::std::int64_t __grid_stride() noexcept
+[[nodiscard]] _CCCL_DEVICE_API inline ::cuda::std::int64_t __grid_stride() noexcept
 {
   return static_cast<::cuda::std::int64_t>(gridDim.x) * blockDim.x;
 }

--- a/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/tuning.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/tuning.cuh
@@ -11,7 +11,7 @@
 #ifndef _CUDAX___CUCO_DETAIL_HYPERLOGLOG_TUNING_CUH
 #define _CUDAX___CUCO_DETAIL_HYPERLOGLOG_TUNING_CUH
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/cudax/include/cuda/experimental/__cuco/detail/utility/strong_type.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/utility/strong_type.cuh
@@ -11,7 +11,7 @@
 #ifndef _CUDAX___CUCO_DETAIL_UTILITY_STRONG_TYPE_CUH
 #define _CUDAX___CUCO_DETAIL_UTILITY_STRONG_TYPE_CUH
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/cudax/include/cuda/experimental/__cuco/hash_functions.cuh
+++ b/cudax/include/cuda/experimental/__cuco/hash_functions.cuh
@@ -11,7 +11,7 @@
 #ifndef _CUDAX___CUCO_HASH_FUNCTIONS_CUH
 #define _CUDAX___CUCO_HASH_FUNCTIONS_CUH
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/cudax/include/cuda/experimental/__cuco/hll_policies.cuh
+++ b/cudax/include/cuda/experimental/__cuco/hll_policies.cuh
@@ -11,7 +11,7 @@
 #ifndef _CUDAX___CUCO_HLL_POLICIES_CUH
 #define _CUDAX___CUCO_HLL_POLICIES_CUH
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/cudax/include/cuda/experimental/__cuco/hyperloglog.cuh
+++ b/cudax/include/cuda/experimental/__cuco/hyperloglog.cuh
@@ -11,7 +11,7 @@
 #ifndef _CUDAX___CUCO_HYPERLOGLOG_CUH
 #define _CUDAX___CUCO_HYPERLOGLOG_CUH
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/cudax/include/cuda/experimental/__cuco/hyperloglog_ref.cuh
+++ b/cudax/include/cuda/experimental/__cuco/hyperloglog_ref.cuh
@@ -11,7 +11,7 @@
 #ifndef _CUDAX___CUCO_HYPERLOGLOG_REF_CUH
 #define _CUDAX___CUCO_HYPERLOGLOG_REF_CUH
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
@@ -109,7 +109,7 @@ public:
   //!
   //! @param __group CUDA Cooperative group this operation is executed in
   template <class _CG>
-  _CCCL_DEVICE constexpr ::cuda::std::enable_if_t<!::cuda::std::is_convertible_v<_CG, ::cuda::stream_ref>>
+  _CCCL_DEVICE_API constexpr ::cuda::std::enable_if_t<!::cuda::std::is_convertible_v<_CG, ::cuda::stream_ref>>
   clear(_CG __group) noexcept
   {
     // The enable_if above is to work around an incompatibility between host and device
@@ -147,7 +147,8 @@ public:
   //! @brief Asynchronously resets the estimator, i.e., clears the current count estimate.
   //!
   //! @param __stream CUDA stream this operation is executed in
-  _CCCL_HOST constexpr void clear_async(::cuda::stream_ref __stream = ::cuda::stream_ref{cudaStream_t{nullptr}}) noexcept
+  _CCCL_HOST_API constexpr void
+  clear_async(::cuda::stream_ref __stream = ::cuda::stream_ref{cudaStream_t{nullptr}}) noexcept
   {
     __impl.__clear_async(__stream);
   }
@@ -158,7 +159,7 @@ public:
   //! `clear_async`.
   //!
   //! @param __stream CUDA stream this operation is executed in
-  _CCCL_HOST constexpr void clear(::cuda::stream_ref __stream = ::cuda::stream_ref{cudaStream_t{nullptr}})
+  _CCCL_HOST_API constexpr void clear(::cuda::stream_ref __stream = ::cuda::stream_ref{cudaStream_t{nullptr}})
   {
     __impl.__clear(__stream);
   }
@@ -166,7 +167,7 @@ public:
   //! @brief Adds an item to the estimator.
   //!
   //! @param __item The item to be counted
-  _CCCL_DEVICE constexpr void add(const _Tp& __item) noexcept
+  _CCCL_DEVICE_API constexpr void add(const _Tp& __item) noexcept
   {
     __impl.__add(__item);
   }
@@ -181,7 +182,7 @@ public:
   //! @param __last End of the sequence of items
   //! @param __stream CUDA stream this operation is executed in
   template <class _InputIt>
-  _CCCL_HOST constexpr void
+  _CCCL_HOST_API constexpr void
   add_async(_InputIt __first, _InputIt __last, ::cuda::stream_ref __stream = ::cuda::stream_ref{cudaStream_t{nullptr}})
   {
     __impl.__add_async(__first, __last, __stream);
@@ -200,7 +201,7 @@ public:
   //! @param __last End of the sequence of items
   //! @param __stream CUDA stream this operation is executed in
   template <class _InputIt>
-  _CCCL_HOST constexpr void
+  _CCCL_HOST_API constexpr void
   add(_InputIt __first, _InputIt __last, ::cuda::stream_ref __stream = ::cuda::stream_ref{cudaStream_t{nullptr}})
   {
     __impl.__add(__first, __last, __stream);
@@ -216,7 +217,7 @@ public:
   //! @param __group CUDA Cooperative group this operation is executed in
   //! @param __other Other estimator reference to be merged into `*this`
   template <class _CG, ::cuda::thread_scope _OtherScope>
-  _CCCL_DEVICE constexpr void merge(_CG __group, const hyperloglog_ref<_Tp, _OtherScope, _Policy>& __other)
+  _CCCL_DEVICE_API constexpr void merge(_CG __group, const hyperloglog_ref<_Tp, _OtherScope, _Policy>& __other)
   {
     __impl.__merge(__group, __other.__impl);
   }
@@ -232,8 +233,8 @@ public:
   //! @param __other Other estimator reference to be merged into `*this`
   //! @param __stream CUDA stream this operation is executed in
   template <::cuda::thread_scope _OtherScope>
-  _CCCL_HOST constexpr void merge_async(const hyperloglog_ref<_Tp, _OtherScope, _Policy>& __other,
-                                        ::cuda::stream_ref __stream = ::cuda::stream_ref{cudaStream_t{nullptr}})
+  _CCCL_HOST_API constexpr void merge_async(const hyperloglog_ref<_Tp, _OtherScope, _Policy>& __other,
+                                            ::cuda::stream_ref __stream = ::cuda::stream_ref{cudaStream_t{nullptr}})
   {
     __impl.__merge_async(__other.__impl, __stream);
   }
@@ -250,8 +251,8 @@ public:
   //! @param __other Other estimator reference to be merged into `*this`
   //! @param __stream CUDA stream this operation is executed in
   template <::cuda::thread_scope _OtherScope>
-  _CCCL_HOST constexpr void merge(const hyperloglog_ref<_Tp, _OtherScope, _Policy>& __other,
-                                  ::cuda::stream_ref __stream = ::cuda::stream_ref{cudaStream_t{nullptr}})
+  _CCCL_HOST_API constexpr void merge(const hyperloglog_ref<_Tp, _OtherScope, _Policy>& __other,
+                                      ::cuda::stream_ref __stream = ::cuda::stream_ref{cudaStream_t{nullptr}})
   {
     __impl.__merge(__other.__impl, __stream);
   }
@@ -261,7 +262,7 @@ public:
   //! @param __group CUDA thread block group this operation is executed in
   //!
   //! @return Approximate distinct items count
-  [[nodiscard]] _CCCL_DEVICE ::cuda::std::size_t
+  [[nodiscard]] _CCCL_DEVICE_API ::cuda::std::size_t
   estimate(const ::cooperative_groups::thread_block& __group) const noexcept
   {
     return __impl.__estimate(__group);
@@ -279,7 +280,7 @@ public:
   //!
   //! @return Approximate distinct items count
   template <typename _HostMemoryResource = ::cuda::mr::legacy_pinned_memory_resource>
-  [[nodiscard]] _CCCL_HOST constexpr ::cuda::std::size_t estimate(
+  [[nodiscard]] _CCCL_HOST_API constexpr ::cuda::std::size_t estimate(
     _HostMemoryResource __host_mr = {}, ::cuda::stream_ref __stream = ::cuda::stream_ref{cudaStream_t{nullptr}}) const
   {
     return __impl.__estimate(__host_mr, __stream);


### PR DESCRIPTION
## Description

This PR cleans up two include/macro conventions across the existing `cuco` headers in cudax so they match the rest of the library:

1. **Config header.** Replace `#include <cuda/__cccl_config>` with `#include <cuda/std/detail/__config>`, which is the detail config header used everywhere else in cudax.

2. **Visibility macros.** Convert plain execution-space macros (`_CCCL_HOST_DEVICE`/`_CCCL_HOST`/`_CCCL_DEVICE`) on function definitions to the `_CCCL_*_API` family so every symbol gets consistent hidden visibility.


This is a pure refactor with no functional or ABI-visible behavior change.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
