### PR TITLE
Allow public tuning of `cub::DeviceFind::*BoundSortedValues`

### DIFF
--- a/cub/cub/device/device_find.cuh
+++ b/cub/cub/device/device_find.cuh
@@ -46,6 +46,22 @@ CUB_NAMESPACE_BEGIN
 //!      :start-after: example-begin find-if-tuning
 //!      :end-before: example-end find-if-tuning
 //!
+//! The ``LowerBoundSortedValues`` and ``UpperBoundSortedValues`` algorithms that accept an environment can be tuned by
+//! passing a custom :ref:`policy selector <cub-policy-selectors>` that returns a
+//! @ref FindBoundSortedValuesPolicy, as shown in the example below:
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_find_bound_sorted_values_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin lower-bound-sorted-values-policy-selector
+//!      :end-before: example-end lower-bound-sorted-values-policy-selector
+//!
+//!  .. literalinclude:: ../../../cub/test/catch2_test_device_find_bound_sorted_values_env_api.cu
+//!      :language: c++
+//!      :dedent:
+//!      :start-after: example-begin lower-bound-sorted-values-tuning
+//!      :end-before: example-end lower-bound-sorted-values-tuning
+//!
 //! @endrst
 struct DeviceFind
 {

--- a/cub/cub/device/dispatch/dispatch_find_bound_sorted_values.cuh
+++ b/cub/cub/device/dispatch/dispatch_find_bound_sorted_values.cuh
@@ -49,8 +49,8 @@ _CCCL_KERNEL_ATTRIBUTES void device_partition_find_bound_sorted_values_kernel(
   _CCCL_GRID_CONSTANT Offset* const range_beg_offsets,
   PartitionCompOp partition_comp)
 {
-  constexpr find_bound_sorted_values_policy policy = current_policy<PolicySelector>();
-  constexpr int tile_size                          = policy.threads_per_block * policy.items_per_thread;
+  constexpr FindBoundSortedValuesPolicy policy = current_policy<PolicySelector>();
+  constexpr int tile_size                      = policy.threads_per_block * policy.items_per_thread;
 
   const Offset diagonal_idx = static_cast<Offset>(blockDim.x) * blockIdx.x + threadIdx.x;
   if (diagonal_idx < num_diagonals)
@@ -78,7 +78,7 @@ __launch_bounds__(int(current_policy<PolicySelector>().threads_per_block))
     _CCCL_GRID_CONSTANT Offset* const range_beg_offsets,
     CompareOp comp)
 {
-  constexpr find_bound_sorted_values_policy policy = current_policy<PolicySelector>();
+  constexpr FindBoundSortedValuesPolicy policy = current_policy<PolicySelector>();
   using AgentT =
     agent_t<policy.threads_per_block,
             policy.items_per_thread,

--- a/cub/cub/device/dispatch/tuning/tuning_find_bound_sorted_values.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_find_bound_sorted_values.cuh
@@ -26,39 +26,40 @@
 
 CUB_NAMESPACE_BEGIN
 
-namespace detail::find_bound_sorted_values
+//! The tuning policy for the LowerBoundSortedValues and UpperBoundSortedValues algorithms in @ref DeviceFind.
+struct FindBoundSortedValuesPolicy
 {
-struct find_bound_sorted_values_policy
-{
-  int threads_per_block;
-  int items_per_thread;
-  CacheLoadModifier load_modifier;
+  int threads_per_block; //!< Number of threads in a CUDA block
+  int items_per_thread; //!< Number of items processed per thread
+  CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const find_bound_sorted_values_policy& lhs, const find_bound_sorted_values_policy& rhs)
+  operator==(const FindBoundSortedValuesPolicy& lhs, const FindBoundSortedValuesPolicy& rhs) noexcept
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
         && lhs.load_modifier == rhs.load_modifier;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const find_bound_sorted_values_policy& lhs, const find_bound_sorted_values_policy& rhs)
+  operator!=(const FindBoundSortedValuesPolicy& lhs, const FindBoundSortedValuesPolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const find_bound_sorted_values_policy& p)
+  friend ::std::ostream& operator<<(::std::ostream& os, const FindBoundSortedValuesPolicy& p)
   {
-    return os << "find_bound_sorted_values_policy { .threads_per_block = " << p.threads_per_block
+    return os << "FindBoundSortedValuesPolicy { .threads_per_block = " << p.threads_per_block
               << ", .items_per_thread = " << p.items_per_thread << ", .load_modifier = " << p.load_modifier << " }";
   }
 #endif // _CCCL_HOSTED()
 };
 
+namespace detail::find_bound_sorted_values
+{
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>
-concept find_bound_sorted_values_policy_selector = policy_selector<T, find_bound_sorted_values_policy>;
+concept find_bound_sorted_values_policy_selector = policy_selector<T, FindBoundSortedValuesPolicy>;
 #endif // _CCCL_HAS_CONCEPTS()
 
 struct policy_selector
@@ -67,23 +68,23 @@ struct policy_selector
   int values_type_size;
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
-    -> find_bound_sorted_values_policy
+    -> FindBoundSortedValuesPolicy
   {
     const int combined_size = range_type_size + values_type_size;
     const int ipt           = cub::detail::nominal_4B_items_to_items(15, combined_size);
 
     if (cc >= ::cuda::compute_capability{8, 0})
     {
-      return find_bound_sorted_values_policy{512, ipt, LOAD_DEFAULT};
+      return FindBoundSortedValuesPolicy{512, ipt, LOAD_DEFAULT};
     }
 
     if (cc >= ::cuda::compute_capability{6, 0})
     {
-      return find_bound_sorted_values_policy{256, ipt, LOAD_DEFAULT};
+      return FindBoundSortedValuesPolicy{256, ipt, LOAD_DEFAULT};
     }
 
     // default
-    return find_bound_sorted_values_policy{256, ipt, LOAD_LDG};
+    return FindBoundSortedValuesPolicy{256, ipt, LOAD_LDG};
   }
 };
 
@@ -95,7 +96,7 @@ template <typename RangeT, typename ValuesT>
 struct policy_selector_from_types
 {
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
-    -> find_bound_sorted_values_policy
+    -> FindBoundSortedValuesPolicy
   {
     return policy_selector{int{sizeof(RangeT)}, int{sizeof(ValuesT)}}(cc);
   }

--- a/cub/test/catch2_test_device_find_bound_sorted_values_env.cu
+++ b/cub/test/catch2_test_device_find_bound_sorted_values_env.cu
@@ -131,3 +131,26 @@ C2H_TEST("Device UpperBoundSortedValues uses environment", "[find][device][binar
   c2h::device_vector<int> expected = {1, 2, 3, 4};
   REQUIRE(d_output == expected);
 }
+
+#if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
+C2H_TEST("FindBoundSortedValuesPolicy", "[find][device][binary-search]")
+{
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::FindBoundSortedValuesPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::FindBoundSortedValuesPolicy>);
+
+  // aggregate init
+  constexpr auto p1 = cub::FindBoundSortedValuesPolicy{256, 15, cub::CacheLoadModifier::LOAD_LDG};
+
+#  if _CCCL_STD_VER >= 2020
+  // designated init
+  constexpr auto p2 = cub::FindBoundSortedValuesPolicy{
+    .threads_per_block = 256, .items_per_thread = 15, .load_modifier = cub::CacheLoadModifier::LOAD_LDG};
+#  else // _CCCL_STD_VER >= 2020
+  constexpr auto p2 = p1;
+#  endif // _CCCL_STD_VER >= 2020
+
+  // comparison
+  STATIC_REQUIRE(p1 == p2);
+  STATIC_REQUIRE_FALSE(p1 != p2);
+}
+#endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_find_bound_sorted_values_env_api.cu
+++ b/cub/test/catch2_test_device_find_bound_sorted_values_env_api.cu
@@ -7,6 +7,7 @@
 
 #include <thrust/device_vector.h>
 
+#include <cuda/__execution/tune.h>
 #include <cuda/devices>
 #include <cuda/stream>
 
@@ -75,3 +76,46 @@ C2H_TEST("cub::DeviceFind::UpperBoundSortedValues accepts env with stream", "[fi
   REQUIRE(error == cudaSuccess);
   REQUIRE(d_output == expected);
 }
+
+#if _CCCL_STD_VER >= 2020
+
+// example-begin lower-bound-sorted-values-policy-selector
+struct FindBoundSortedValuesPolicySelector
+{
+  __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::FindBoundSortedValuesPolicy
+  {
+    return {.threads_per_block = cc >= cuda::compute_capability{8, 0} ? 512 : 256,
+            .items_per_thread  = 7,
+            .load_modifier     = cub::LOAD_DEFAULT};
+  }
+};
+// example-end lower-bound-sorted-values-policy-selector
+
+C2H_TEST("cub::DeviceFind::LowerBoundSortedValues env-based API with tuning", "[find][env][binary-search]")
+{
+  // example-begin lower-bound-sorted-values-tuning
+  thrust::device_vector<int> d_range  = {0, 2, 4, 6, 8};
+  thrust::device_vector<int> d_values = {0, 3, 4, 7};
+  thrust::device_vector<int> d_output(4, thrust::no_init);
+
+  auto error = cub::DeviceFind::LowerBoundSortedValues(
+    d_range.begin(),
+    d_range.size(),
+    d_values.begin(),
+    d_values.size(),
+    d_output.begin(),
+    cuda::std::less{},
+    cuda::execution::tune(FindBoundSortedValuesPolicySelector{}));
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceFind::LowerBoundSortedValues failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected = {0, 2, 2, 4};
+  // example-end lower-bound-sorted-values-tuning
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(d_output == expected);
+}
+
+#endif // _CCCL_STD_VER >= 2020


### PR DESCRIPTION
Fixes: #9687