### PR TITLE
Rename `FindPolicy` to `FindIfPolicy`

### DIFF
--- a/cub/cub/device/device_find.cuh
+++ b/cub/cub/device/device_find.cuh
@@ -31,7 +31,7 @@ CUB_NAMESPACE_BEGIN
 //! @rst
 //! @par Tuning
 //! The FindIf algorithms that accept an environment can be tuned by passing a custom
-//! :ref:`policy selector <cub-policy-selectors>` that returns a @ref FindPolicy, as shown in the
+//! :ref:`policy selector <cub-policy-selectors>` that returns a @ref FindIfPolicy, as shown in the
 //! example below:
 //!
 //!  .. literalinclude:: ../../../cub/test/catch2_test_device_find_env_api.cu

--- a/cub/cub/device/dispatch/dispatch_find.cuh
+++ b/cub/cub/device/dispatch/dispatch_find.cuh
@@ -55,7 +55,7 @@ template <typename PolicySelector, typename IteratorT, typename OffsetT, typenam
 __launch_bounds__(int(current_policy<PolicySelector>().threads_per_block)) _CCCL_KERNEL_ATTRIBUTES void find_kernel(
   IteratorT d_in, OffsetT num_items, OffsetT* found_pos_ptr, PredicateT predicate)
 {
-  constexpr FindPolicy policy = current_policy<PolicySelector>();
+  constexpr FindIfPolicy policy = current_policy<PolicySelector>();
   using agent_find_t =
     agent_t<policy.threads_per_block,
             policy.items_per_thread,
@@ -112,7 +112,7 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
     return error;
   }
 
-  const FindPolicy active_policy = policy_selector(cc);
+  const FindIfPolicy active_policy = policy_selector(cc);
 
 #if _CCCL_HOSTED() && defined(CUB_DEBUG_LOG)
   NV_IF_TARGET(NV_IS_HOST, ({

--- a/cub/cub/device/dispatch/tuning/tuning_find.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_find.cuh
@@ -22,7 +22,7 @@
 
 CUB_NAMESPACE_BEGIN
 
-//! The tuning policy for all algorithms in @ref DeviceFind.
+//! The tuning policy for the @c FindIf algorithms in @ref DeviceFind.
 struct FindIfPolicy
 {
   int threads_per_block; //!< Number of threads in a CUDA block

--- a/cub/cub/device/dispatch/tuning/tuning_find.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_find.cuh
@@ -23,7 +23,7 @@
 CUB_NAMESPACE_BEGIN
 
 //! The tuning policy for all algorithms in @ref DeviceFind.
-struct FindPolicy
+struct FindIfPolicy
 {
   int threads_per_block; //!< Number of threads in a CUDA block
   int items_per_thread; //!< Number of items processed per thread
@@ -31,24 +31,24 @@ struct FindPolicy
   CacheLoadModifier load_modifier; //!< The @ref CacheLoadModifier used for loading items from global memory
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator==(const FindPolicy& lhs, const FindPolicy& rhs) noexcept
+  operator==(const FindIfPolicy& lhs, const FindIfPolicy& rhs) noexcept
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
         && lhs.vec_size == rhs.vec_size && lhs.load_modifier == rhs.load_modifier;
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr friend bool
-  operator!=(const FindPolicy& lhs, const FindPolicy& rhs) noexcept
+  operator!=(const FindIfPolicy& lhs, const FindIfPolicy& rhs) noexcept
   {
     return !(lhs == rhs);
   }
 
 #if _CCCL_HOSTED()
-  friend ::std::ostream& operator<<(::std::ostream& os, const FindPolicy& p)
+  friend ::std::ostream& operator<<(::std::ostream& os, const FindIfPolicy& p)
   {
     return os
-        << "FindPolicy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = " << p.items_per_thread
-        << ", .vec_size = " << p.vec_size << ", .load_modifier = " << p.load_modifier << " }";
+        << "FindIfPolicy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
+        << p.items_per_thread << ", .vec_size = " << p.vec_size << ", .load_modifier = " << p.load_modifier << " }";
   }
 #endif // _CCCL_HOSTED()
 };
@@ -57,18 +57,18 @@ namespace detail::find
 {
 #if _CCCL_HAS_CONCEPTS()
 template <typename T>
-concept find_policy_selector = policy_selector<T, FindPolicy>;
+concept find_policy_selector = policy_selector<T, FindIfPolicy>;
 #endif // _CCCL_HAS_CONCEPTS()
 
 struct policy_selector
 {
   int input_type_size;
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const -> FindPolicy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability) const -> FindIfPolicy
   {
-    // FindPolicy (GTX670: 154.0 @ 48M 4B items) - single policy for all ccs
+    // FindIfPolicy (GTX670: 154.0 @ 48M 4B items) - single policy for all ccs
     const auto scaled = scale_mem_bound(128, 16, input_type_size);
-    return FindPolicy{scaled.threads_per_block, scaled.items_per_thread, 4, LOAD_LDG};
+    return FindIfPolicy{scaled.threads_per_block, scaled.items_per_thread, 4, LOAD_LDG};
   }
 };
 
@@ -80,7 +80,7 @@ static_assert(find_policy_selector<policy_selector>);
 template <typename InputType>
 struct policy_selector_from_types
 {
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> FindPolicy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> FindIfPolicy
   {
     return policy_selector{int{sizeof(InputType)}}(cc);
   }

--- a/cub/test/catch2_test_device_find_env.cu
+++ b/cub/test/catch2_test_device_find_env.cu
@@ -41,7 +41,7 @@ struct is_greater_than_t
 template <int ThreadsPerBlock>
 struct find_tuning
 {
-  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::FindPolicy
+  _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::FindIfPolicy
   {
     return {ThreadsPerBlock, 4, 4, cub::LOAD_LDG};
   }
@@ -539,17 +539,17 @@ C2H_TEST("Device FindIf can be tuned", "[find][device]", block_sizes)
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("FindPolicy", "[find][device]")
+C2H_TEST("FindIfPolicy", "[find][device]")
 {
-  STATIC_REQUIRE(::cuda::std::semiregular<cub::FindPolicy>);
-  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::FindPolicy>);
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::FindIfPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::FindIfPolicy>);
 
   // aggregate init
-  constexpr auto p1 = cub::FindPolicy{128, 7, 4, cub::CacheLoadModifier::LOAD_LDG};
+  constexpr auto p1 = cub::FindIfPolicy{128, 7, 4, cub::CacheLoadModifier::LOAD_LDG};
 
 #  if _CCCL_STD_VER >= 2020
   // designated init
-  constexpr auto p2 = cub::FindPolicy{
+  constexpr auto p2 = cub::FindIfPolicy{
     .threads_per_block = 128, .items_per_thread = 7, .vec_size = 4, .load_modifier = cub::CacheLoadModifier::LOAD_LDG};
 #  else // _CCCL_STD_VER >= 2020
   constexpr auto p2 = p1;

--- a/cub/test/catch2_test_device_find_env_api.cu
+++ b/cub/test/catch2_test_device_find_env_api.cu
@@ -118,7 +118,7 @@ C2H_TEST("cub::DeviceFind::UpperBound accepts env with stream", "[find][env]")
 // example-begin find-if-policy-selector
 struct FindPolicySelector
 {
-  __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::FindPolicy
+  __host__ __device__ constexpr auto operator()(cuda::compute_capability cc) const -> cub::FindIfPolicy
   {
     return {.threads_per_block = 128,
             .items_per_thread  = cc > cuda::compute_capability{9, 0} ? 16 : 7,


### PR DESCRIPTION
To put more emphasize on the policy applying only to the `FindIf` algorithm in `DeviceFind`.