### PR TITLE
[TRIVIAL] Pin numba below 0.66 for Python CUDA extras

### DIFF
--- a/python/cuda_cccl/pyproject.toml
+++ b/python/cuda_cccl/pyproject.toml
@@ -59,22 +59,26 @@ minimal-sysctk13 = [
 ]
 cu12 = [
   "cuda-cccl[minimal-cu12]",
-  "numba>=0.60.0",
+  # numba-cuda currently expects numba.cuda.types.NPDatetime, removed in numba 0.66.
+  "numba>=0.60.0,<0.66",
   "numba-cuda[cu12]>=0.23.0,!=0.27.*,!=0.28.*,!=0.29.*,!=0.30.0",
 ]
 cu13 = [
   "cuda-cccl[minimal-cu13]",
-  "numba>=0.60.0",
+  # numba-cuda currently expects numba.cuda.types.NPDatetime, removed in numba 0.66.
+  "numba>=0.60.0,<0.66",
   "numba-cuda[cu13]>=0.23.0,!=0.27.*,!=0.28.*,!=0.29.*,!=0.30.0"
 ]
 sysctk12 = [
   "cuda-cccl[minimal-sysctk12]",
-  "numba>=0.60.0",
+  # numba-cuda currently expects numba.cuda.types.NPDatetime, removed in numba 0.66.
+  "numba>=0.60.0,<0.66",
   "numba-cuda[cu12]>=0.23.0,!=0.27.*,!=0.28.*,!=0.29.*,!=0.30.0"
 ]
 sysctk13 = [
   "cuda-cccl[minimal-sysctk13]",
-  "numba>=0.60.0",
+  # numba-cuda currently expects numba.cuda.types.NPDatetime, removed in numba 0.66.
+  "numba>=0.60.0,<0.66",
   "numba-cuda[cu13]>=0.23.0,!=0.27.*,!=0.28.*,!=0.29.*,!=0.30.0",
 ]
 test-cu12 = [


### PR DESCRIPTION
## Summary
- Pin `numba` to `<0.66` in the Python CUDA extras that install `numba-cuda`.
- Add a short comment explaining the temporary compatibility issue with `numba.cuda.types.NPDatetime`.

## Test plan
- `pre-commit run --files python/cuda_cccl/pyproject.toml`