### PR TITLE
[libcu++] Fix iterator traversal checks for `minmax_element`

### DIFF
--- a/libcudacxx/include/cuda/std/__algorithm/max_element.h
+++ b/libcudacxx/include/cuda/std/__algorithm/max_element.h
@@ -32,7 +32,7 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class _Compare, class _ForwardIterator>
 _CCCL_API constexpr _ForwardIterator __max_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp)
 {
-  static_assert(__has_input_traversal<_ForwardIterator>, "::cuda::std::max_element requires a ForwardIterator");
+  static_assert(__has_forward_traversal<_ForwardIterator>, "::cuda::std::max_element requires a ForwardIterator");
   if (__first != __last)
   {
     _ForwardIterator __i = __first;

--- a/libcudacxx/include/cuda/std/__algorithm/min_element.h
+++ b/libcudacxx/include/cuda/std/__algorithm/min_element.h
@@ -66,7 +66,7 @@ template <class _ForwardIterator, class _Compare>
 [[nodiscard]] _CCCL_API constexpr _ForwardIterator
 min_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp)
 {
-  static_assert(__has_input_traversal<_ForwardIterator>, "std::min_element requires a ForwardIterator");
+  static_assert(__has_forward_traversal<_ForwardIterator>, "std::min_element requires a ForwardIterator");
   static_assert(__is_callable<_Compare, decltype(*__first), decltype(*__first)>::value,
                 "The comparator has to be callable");
 

--- a/libcudacxx/include/cuda/std/__algorithm/minmax_element.h
+++ b/libcudacxx/include/cuda/std/__algorithm/minmax_element.h
@@ -124,7 +124,7 @@ template <class _ForwardIterator, class _Compare>
 [[nodiscard]] _CCCL_API constexpr pair<_ForwardIterator, _ForwardIterator>
 minmax_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp)
 {
-  static_assert(__has_input_traversal<_ForwardIterator>, "::cuda::std::minmax_element requires a ForwardIterator");
+  static_assert(__has_forward_traversal<_ForwardIterator>, "::cuda::std::minmax_element requires a ForwardIterator");
   static_assert(__is_callable<_Compare, decltype(*__first), decltype(*__first)>::value,
                 "The comparator has to be callable");
   auto __proj = identity();


### PR DESCRIPTION
Would make sense to check what we are requiring