### PR TITLE
[libcu++] Reformulate tuple constraints to reduce memory consumption

### DIFF
--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -55,6 +55,8 @@ private:
 
   _BaseT __base_;
 
+  using __constraints = __tuple_constraints<_Tp...>;
+
 public:
   template <size_t _Ip>
   _CCCL_API constexpr tuple_element_t<_Ip, tuple>& __get_impl() & noexcept
@@ -85,12 +87,13 @@ public:
   }
 
   // Going through an inline variable forces instantiation of the default constructors of all _Tp fr old GCC
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_Tp...>{}),
+  template <__select_constructor _Trait                          = __constraints::__select_default_constructible(),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr tuple() noexcept((is_nothrow_default_constructible_v<_Tp> && ...))
   {}
 
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_Tp...>{}),
+  template <enable_if_t<sizeof...(_Tp) != 0, int>                = 0, // Help Clang disambiguate for CTAD
+            __select_constructor _Trait                          = __constraints::__select_default_constructible(),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API explicit constexpr tuple() noexcept((is_nothrow_default_constructible_v<_Tp> && ...))
   {}
@@ -99,7 +102,7 @@ public:
   _CCCL_HIDE_FROM_ABI tuple(tuple&&)      = default;
 
   template <class _Alloc,
-            __select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_Tp...>{}),
+            __select_constructor _Trait                          = __constraints::__select_default_constructible(),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t,
                             _Alloc const& __a) noexcept((is_nothrow_default_constructible_v<_Tp> && ...))
@@ -107,20 +110,21 @@ public:
   {}
 
   template <class _Alloc,
-            __select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_Tp...>{}),
+            enable_if_t<sizeof...(_Tp) != 0, int>                = 0, // Help Clang disambiguate for CTAD
+            __select_constructor _Trait                          = __constraints::__select_default_constructible(),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API explicit constexpr tuple(allocator_arg_t,
                                      _Alloc const& __a) noexcept((is_nothrow_default_constructible_v<_Tp> && ...))
       : __base_(allocator_arg_t(), __a)
   {}
 
-  template <__select_constructor _Trait = __tuple_select_variadic_copy_constructible_v<__tuple_types<_Tp...>>,
+  template <__select_constructor _Trait = __constraints::__select_variadic_copy_constructible(),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr tuple(const _Tp&... __t) noexcept(__tuple_all_nothrow_copy_constructible_v<_Tp...>)
       : __base_(__tuple_variadic_constructor_tag{}, __t...)
   {}
 
-  template <__select_constructor _Trait = __tuple_select_variadic_copy_constructible_v<__tuple_types<_Tp...>>,
+  template <__select_constructor _Trait = __constraints::__select_variadic_copy_constructible(),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API constexpr explicit tuple(const _Tp&... __t) noexcept(__tuple_all_nothrow_copy_constructible_v<_Tp...>)
       : __base_(__tuple_variadic_constructor_tag{}, __t...)
@@ -128,7 +132,7 @@ public:
 
   template <class _Alloc,
             enable_if_t<sizeof...(_Tp) != 0, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Trait           = __tuple_select_variadic_copy_constructible_v<__tuple_types<_Tp...>>,
+            __select_constructor _Trait           = __constraints::__select_variadic_copy_constructible(),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t, const _Alloc& __a, const _Tp&... __t) noexcept(
     __tuple_all_nothrow_copy_constructible_v<_Tp...>)
@@ -137,7 +141,7 @@ public:
 
   template <class _Alloc,
             enable_if_t<sizeof...(_Tp) != 0, int> = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Trait           = __tuple_select_variadic_copy_constructible_v<__tuple_types<_Tp...>>,
+            __select_constructor _Trait           = __constraints::__select_variadic_copy_constructible(),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API explicit constexpr tuple(allocator_arg_t, const _Alloc& __a, const _Tp&... __t) noexcept(
     __tuple_all_nothrow_copy_constructible_v<_Tp...>)
@@ -145,7 +149,7 @@ public:
   {}
 
   template <class _Alloc,
-            __select_constructor _Trait = __tuple_select_variadic_copy_constructible_v<__tuple_types<_Tp...>>,
+            __select_constructor _Trait               = __constraints::__select_variadic_copy_constructible(),
             enable_if_t<__can_construct<_Trait>, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t, const _Alloc& __a, const tuple& __t) noexcept(
     __tuple_all_nothrow_copy_constructible_v<_Tp...>)
@@ -153,93 +157,90 @@ public:
   {}
 
   template <class _Alloc,
-            __select_constructor _Trait = __tuple_select_variadic_move_constructible_v<__tuple_types<_Tp...>>,
+            __select_constructor _Trait               = __constraints::__select_variadic_move_constructible(),
             enable_if_t<__can_construct<_Trait>, int> = 0>
   _CCCL_API constexpr tuple(allocator_arg_t, const _Alloc& __a, tuple&& __t) noexcept(
     __tuple_all_nothrow_move_constructible_v<_Tp...>)
       : __base_(__tuple_like_constructor_tag{}, allocator_arg_t(), __a, ::cuda::std::move(__t))
   {}
 
-  // Old MSVC chokes about a static constexpr variable needing an initializer. Work around by using a type
+  // We need to SFINAE the constructor away to ensure we avoid CTAD ambigouities
   template <class... _UTypes>
-  using _VariadicConstraints =
-    integral_constant<__select_constructor,
-                      __tuple_select_variadic_constructible_v<__tuple_types<_Tp...>, __tuple_types<_UTypes...>>>;
-
-  template <class... _UTypes>
-  using _NothrowVariadic =
-    bool_constant<__tuple_all_nothrow_constructible_v<__tuple_types<_Tp...>, __tuple_types<_UTypes...>>>;
+  using __disambiguate_variadic = bool_constant<__constraints::__disambiguate_variadic(__tuple_types<_UTypes...>{})>;
 
   template <class... _UTypes,
-            enable_if_t<sizeof...(_Tp) != 0, int>                = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Trait                          = _VariadicConstraints<_UTypes...>::value,
+            enable_if_t<__disambiguate_variadic<_UTypes...>::value, int> = 0,
+            __select_constructor _Trait = __constraints::__select_variadic_constructible(__tuple_types<_UTypes...>{}),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
-  _CCCL_API constexpr tuple(_UTypes&&... __u) noexcept(_NothrowVariadic<_UTypes...>::value)
+  _CCCL_API constexpr tuple(_UTypes&&... __u) noexcept(
+    __tuple_all_nothrow_constructible_v<__tuple_types<_Tp...>, __tuple_types<_UTypes...>>)
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
 
   template <class... _UTypes,
-            enable_if_t<sizeof...(_Tp) != 0, int>                = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Trait                          = _VariadicConstraints<_UTypes...>::value,
+            enable_if_t<__disambiguate_variadic<_UTypes...>::value, int> = 0,
+            __select_constructor _Trait = __constraints::__select_variadic_constructible(__tuple_types<_UTypes...>{}),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
-  _CCCL_API constexpr explicit tuple(_UTypes&&... __u) noexcept(_NothrowVariadic<_UTypes...>::value)
+  _CCCL_API constexpr explicit tuple(_UTypes&&... __u) noexcept(
+    __tuple_all_nothrow_constructible_v<__tuple_types<_Tp...>, __tuple_types<_UTypes...>>)
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class... _UTypes,
-            enable_if_t<sizeof...(_Tp) != 0, int>  = 0, // Help Clang disambiguate for CTAD
-            __select_constructor _Trait            = _VariadicConstraints<_UTypes...>::value,
+            enable_if_t<__disambiguate_variadic<_UTypes...>::value, int> = 0,
+            __select_constructor _Trait = __constraints::__select_variadic_constructible(__tuple_types<_UTypes...>{}),
             enable_if_t<__is_deleted<_Trait>, int> = 0>
   constexpr tuple(_UTypes&&...) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   template <class _Alloc,
             class... _UTypes,
-            __select_constructor _Trait                          = _VariadicConstraints<_UTypes...>::value,
+            enable_if_t<__disambiguate_variadic<_UTypes...>::value, int> = 0,
+            __select_constructor _Trait = __constraints::__select_variadic_constructible(__tuple_types<_UTypes...>{}),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API inline tuple(allocator_arg_t, const _Alloc& __a, _UTypes&&... __u) noexcept(
-    _NothrowVariadic<_UTypes...>::value)
+    __tuple_all_nothrow_constructible_v<__tuple_types<_Tp...>, __tuple_types<_UTypes...>>)
       : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
 
   template <class _Alloc,
             class... _UTypes,
-            __select_constructor _Trait                          = _VariadicConstraints<_UTypes...>::value,
+            enable_if_t<__disambiguate_variadic<_UTypes...>::value, int> = 0,
+            __select_constructor _Trait = __constraints::__select_variadic_constructible(__tuple_types<_UTypes...>{}),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API inline explicit tuple(allocator_arg_t, const _Alloc& __a, _UTypes&&... __u) noexcept(
-    _NothrowVariadic<_UTypes...>::value)
+    __tuple_all_nothrow_constructible_v<__tuple_types<_Tp...>, __tuple_types<_UTypes...>>)
       : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
   template <class _Alloc,
             class... _UTypes,
-            __select_constructor _Trait            = _VariadicConstraints<_UTypes...>::value,
+            enable_if_t<__disambiguate_variadic<_UTypes...>::value, int> = 0,
+            __select_constructor _Trait = __constraints::__select_variadic_constructible(__tuple_types<_UTypes...>{}),
             enable_if_t<__is_deleted<_Trait>, int> = 0>
   constexpr tuple(allocator_arg_t, const _Alloc&, _UTypes&&...) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
-  template <class... _UTypes>
-  using _VariadicConstraintsLessRank = integral_constant<
-    __select_constructor,
-    __tuple_select_variadic_constructible_less_rank_v<__tuple_types<_Tp...>, __tuple_types<_UTypes...>>>;
-
-  template <class... _UTypes,
-            enable_if_t<(sizeof...(_UTypes) < sizeof...(_Tp)), int> = 0,
-            enable_if_t<(sizeof...(_UTypes) != 0), int>             = 0,
-            __select_constructor _Trait                             = _VariadicConstraintsLessRank<_UTypes...>::value,
-            enable_if_t<__can_construct_explicitly<_Trait>, int>    = 0>
+  // Needs to be disambiguated from the full rank constructor, so the sizeof check is at a different position
+  template <
+    class... _UTypes,
+    enable_if_t<sizeof...(_UTypes) < sizeof...(_Tp), int>        = 0,
+    enable_if_t<__disambiguate_variadic<_UTypes...>::value, int> = 0,
+    __select_constructor _Trait = __constraints::__select_variadic_constructible_less_rank(__tuple_types<_UTypes...>{}),
+    enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API constexpr explicit tuple(_UTypes&&... __u)
       : __base_(__tuple_variadic_constructor_tag{}, ::cuda::std::forward<_UTypes>(__u)...)
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-  template <class... _UTypes,
-            enable_if_t<(sizeof...(_UTypes) < sizeof...(_Tp)), int> = 0,
-            enable_if_t<(sizeof...(_UTypes) != 0), int>             = 0,
-            __select_constructor _Trait                             = _VariadicConstraintsLessRank<_UTypes...>::value,
-            enable_if_t<__is_deleted<_Trait>, int>                  = 0>
+  template <
+    class... _UTypes,
+    enable_if_t<sizeof...(_UTypes) < sizeof...(_Tp), int>        = 0,
+    enable_if_t<__disambiguate_variadic<_UTypes...>::value, int> = 0,
+    __select_constructor _Trait = __constraints::__select_variadic_constructible_less_rank(__tuple_types<_UTypes...>{}),
+    enable_if_t<__is_deleted<_Trait>, int> = 0>
   constexpr tuple(_UTypes&&...) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
@@ -274,11 +275,11 @@ public:
   template <class _UTuple>
   using _TupleLikeConstraints = integral_constant<
     __select_constructor,
-    __tuple_select_tuple_like_constructible_v<_UTuple, __tuple_types<_Tp...>, __make_tuple_indices_t<sizeof...(_Tp)>>>;
+    __constraints::template __select_tuple_like_constructible<_UTuple>(__make_tuple_indices_t<sizeof...(_Tp)>{})>;
 
   template <class _UTuple>
-  using _NothrowTupleLike = bool_constant<
-    __tuple_nothrow_tuple_like_constructible_v<_UTuple, __tuple_types<_Tp...>, __make_tuple_indices_t<sizeof...(_Tp)>>>;
+  using _NothrowTupleLike = bool_constant<__constraints::template __tuple_nothrow_tuple_like_constructible<_UTuple>(
+    __make_tuple_indices_t<sizeof...(_Tp)>{})>;
 
   template <class... _UTypes,
             __select_constructor _Trait                          = _TupleLikeConstraints<tuple<_UTypes...>&>::value,
@@ -431,7 +432,7 @@ public:
   _CCCL_HIDE_FROM_ABI tuple& operator=(tuple&& __t)      = default;
 
   // [tuple.assign]-5
-  template <__select_assignment _Trait             = __tuple_select_const_copy_assignable_v<__tuple_types<_Tp...>>,
+  template <__select_assignment _Trait             = __constraints::__select_const_copy_assignable(),
             enable_if_t<__can_assign<_Trait>, int> = 0>
   _CCCL_API constexpr const tuple& operator=(const tuple& __t) const noexcept(__can_nothrow_assign<_Trait>)
   {
@@ -440,7 +441,7 @@ public:
   }
 
   // [tuple.assign]-12
-  template <__select_assignment _Trait             = __tuple_select_const_move_assignable_v<__tuple_types<_Tp...>>,
+  template <__select_assignment _Trait             = __constraints::__select_const_move_assignable(),
             enable_if_t<__can_assign<_Trait>, int> = 0>
   _CCCL_API constexpr const tuple& operator=(tuple&& __t) const noexcept(__can_nothrow_assign<_Trait>)
   {
@@ -451,9 +452,8 @@ public:
 
   // [tuple.assign]-15
   template <class... _UTypes,
-            __select_assignment _Trait             = __tuple_select_converting_assignable_v</*__is_const=*/false,
-                                                                                __tuple_types<_Tp...>,
-                                                                                __tuple_types<const _UTypes&...>>,
+            __select_assignment _Trait = __constraints::template __select_converting_assignable<
+              /*__is_const=*/false>(__tuple_types<const _UTypes&...>{}),
             enable_if_t<__can_assign<_Trait>, int> = 0>
   _CCCL_API constexpr tuple& operator=(const tuple<_UTypes...>& __t) noexcept(__can_nothrow_assign<_Trait>)
   {
@@ -463,9 +463,8 @@ public:
 
   // [tuple.assign]-18
   template <class... _UTypes,
-            __select_assignment _Trait             = __tuple_select_converting_assignable_v</*__is_const=*/true,
-                                                                                __tuple_types<_Tp...>,
-                                                                                __tuple_types<const _UTypes&...>>,
+            __select_assignment _Trait = __constraints::template __select_converting_assignable<
+              /*__is_const=*/true>(__tuple_types<const _UTypes&...>{}),
             enable_if_t<__can_assign<_Trait>, int> = 0>
   _CCCL_API constexpr const tuple& operator=(const tuple<_UTypes...>& __t) const noexcept(__can_nothrow_assign<_Trait>)
   {
@@ -474,11 +473,10 @@ public:
   }
 
   // [tuple.assign]-21
-  template <
-    class... _UTypes,
-    __select_assignment _Trait =
-      __tuple_select_converting_assignable_v</*__is_const=*/false, __tuple_types<_Tp...>, __tuple_types<_UTypes...>>,
-    enable_if_t<__can_assign<_Trait>, int> = 0>
+  template <class... _UTypes,
+            __select_assignment _Trait = __constraints::template __select_converting_assignable<
+              /*__is_const=*/false>(__tuple_types<_UTypes...>{}),
+            enable_if_t<__can_assign<_Trait>, int> = 0>
   _CCCL_API constexpr tuple& operator=(tuple<_UTypes...>&& __t) noexcept(__can_nothrow_assign<_Trait>)
   {
     ::cuda::std::__memberwise_forward_assign(
@@ -487,11 +485,10 @@ public:
   }
 
   // [tuple.assign]-24
-  template <
-    class... _UTypes,
-    __select_assignment _Trait =
-      __tuple_select_converting_assignable_v</*__is_const=*/true, __tuple_types<_Tp...>, __tuple_types<_UTypes...>>,
-    enable_if_t<__can_assign<_Trait>, int> = 0>
+  template <class... _UTypes,
+            __select_assignment _Trait = __constraints::template __select_converting_assignable<
+              /*__is_const=*/true>(__tuple_types<_UTypes...>{}),
+            enable_if_t<__can_assign<_Trait>, int> = 0>
   _CCCL_API constexpr const tuple& operator=(tuple<_UTypes...>&& __t) const noexcept(__can_nothrow_assign<_Trait>)
   {
     ::cuda::std::__memberwise_forward_assign(
@@ -500,13 +497,12 @@ public:
   }
 
   // [tuple.assign]-39
-  template <class _UTuple,
-            enable_if_t<!__is_cuda_std_tuple<remove_cvref_t<_UTuple>>, int> = 0,
-            __select_assignment _Trait             = __tuple_select_tuple_like_assignable_v</*__is_const=*/false,
-                                                                                _UTuple,
-                                                                                __tuple_types<_Tp...>,
-                                                                                __make_tuple_indices_t<sizeof...(_Tp)>>,
-            enable_if_t<__can_assign<_Trait>, int> = 0>
+  template <
+    class _UTuple,
+    enable_if_t<!__is_cuda_std_tuple<remove_cvref_t<_UTuple>>, int> = 0,
+    __select_assignment _Trait = __constraints::template __select_tuple_like_assignable</*__is_const=*/false, _UTuple>(
+      __make_tuple_indices_t<sizeof...(_Tp)>{}),
+    enable_if_t<__can_assign<_Trait>, int> = 0>
   _CCCL_API constexpr tuple& operator=(_UTuple&& __t) noexcept(__can_nothrow_assign<_Trait>)
   {
     ::cuda::std::__memberwise_tuple_assign(
@@ -515,13 +511,12 @@ public:
   }
 
   // [tuple.assign]-42
-  template <class _UTuple,
-            enable_if_t<!__is_cuda_std_tuple<remove_cvref_t<_UTuple>>, int> = 0,
-            __select_assignment _Trait             = __tuple_select_tuple_like_assignable_v</*__is_const=*/true,
-                                                                                _UTuple,
-                                                                                __tuple_types<_Tp...>,
-                                                                                __make_tuple_indices_t<sizeof...(_Tp)>>,
-            enable_if_t<__can_assign<_Trait>, int> = 0>
+  template <
+    class _UTuple,
+    enable_if_t<!__is_cuda_std_tuple<remove_cvref_t<_UTuple>>, int> = 0,
+    __select_assignment _Trait = __constraints::template __select_tuple_like_assignable</*__is_const=*/true, _UTuple>(
+      __make_tuple_indices_t<sizeof...(_Tp)>{}),
+    enable_if_t<__can_assign<_Trait>, int> = 0>
   _CCCL_API constexpr const tuple& operator=(_UTuple&& __t) const noexcept(__can_nothrow_assign<_Trait>)
   {
     ::cuda::std::__memberwise_tuple_assign(
@@ -539,44 +534,39 @@ public:
     __t.swap(__u);
   }
 
-  template <class... _UTypes>
-  using _ComparisonConstraints =
-    decltype(::cuda::std::__tuple_is_comparable(__tuple_types<_Tp...>{}, __tuple_types<_UTypes...>{}));
-
   _CCCL_EXEC_CHECK_DISABLE
-  template <class... _UTypes, size_t... _Indices, class _Constraints = _ComparisonConstraints<_UTypes...>>
+  template <class... _UTypes, size_t... _Indices>
   [[nodiscard]] _CCCL_API constexpr bool __equal(const tuple<_UTypes...>& __other, __tuple_indices<_Indices...>) const
-    noexcept(_Constraints::__nothrow_equality_comparable)
+    noexcept(__constraints::template __tuple_all_nothrow_equality_comparable_v<_UTypes...>)
   {
     using ::cuda::std::get;
     return ((get<_Indices>(*this) == get<_Indices>(__other)) && ...);
   }
 
   // Not a friend function because MSVC has issues with nested namespaces and thrust::tuple
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = _ComparisonConstraints<_UTypes...>)
-  _CCCL_REQUIRES(_Constraints::__equality_comparable)
+  _CCCL_TEMPLATE(class... _UTypes)
+  _CCCL_REQUIRES((sizeof...(_Tp) == sizeof...(_UTypes))
+                   _CCCL_AND __constraints::template __tuple_all_equality_comparable_v<_UTypes...>)
   [[nodiscard]] _CCCL_API constexpr bool operator==(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::__nothrow_equality_comparable)
+    noexcept(__constraints::template __tuple_all_nothrow_equality_comparable_v<_UTypes...>)
   {
     return __equal(__rhs, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }
 
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = _ComparisonConstraints<_UTypes...>)
-  _CCCL_REQUIRES(_Constraints::__equality_comparable)
+  _CCCL_TEMPLATE(class... _UTypes)
+  _CCCL_REQUIRES((sizeof...(_Tp) == sizeof...(_UTypes))
+                   _CCCL_AND __constraints::template __tuple_all_equality_comparable_v<_UTypes...>)
   [[nodiscard]] _CCCL_API constexpr bool operator!=(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::__nothrow_equality_comparable)
+    noexcept(__constraints::template __tuple_all_nothrow_equality_comparable_v<_UTypes...>)
   {
     return !__equal(__rhs, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <class... _UTypes,
-            size_t _CurrentIndex,
-            size_t... _Indices,
-            class _Constraints = _ComparisonConstraints<_UTypes...>>
+  template <class... _UTypes, size_t _CurrentIndex, size_t... _Indices>
   [[nodiscard]] _CCCL_API constexpr bool
   __tuple_less_than(const tuple<_UTypes...>& __other, __tuple_indices<_CurrentIndex, _Indices...>) const
-    noexcept(_Constraints::__nothrow_less_than_comparable)
+    noexcept(__constraints::template __tuple_all_nothrow_less_than_comparable_v<_UTypes...>)
   {
     using ::cuda::std::get;
     if constexpr (sizeof...(_Indices) == 0)
@@ -597,34 +587,38 @@ public:
     }
   }
 
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = _ComparisonConstraints<_UTypes...>)
-  _CCCL_REQUIRES(_Constraints::__less_than_comparable)
+  _CCCL_TEMPLATE(class... _UTypes)
+  _CCCL_REQUIRES((sizeof...(_Tp) == sizeof...(_UTypes))
+                   _CCCL_AND __constraints::template __tuple_all_less_than_comparable_v<_UTypes...>)
   [[nodiscard]] _CCCL_API constexpr bool operator<(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::__nothrow_less_than_comparable)
+    noexcept(__constraints::template __tuple_all_nothrow_less_than_comparable_v<_UTypes...>)
   {
     return __tuple_less_than(__rhs, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }
 
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = _ComparisonConstraints<_UTypes...>)
-  _CCCL_REQUIRES(_Constraints::__less_than_comparable)
+  _CCCL_TEMPLATE(class... _UTypes)
+  _CCCL_REQUIRES((sizeof...(_Tp) == sizeof...(_UTypes))
+                   _CCCL_AND __constraints::template __tuple_all_less_than_comparable_v<_UTypes...>)
   [[nodiscard]] _CCCL_API constexpr bool operator>(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::__nothrow_less_than_comparable)
+    noexcept(__constraints::template __tuple_all_nothrow_less_than_comparable_v<_UTypes...>)
   {
     return __rhs.__tuple_less_than(*this, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }
 
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = _ComparisonConstraints<_UTypes...>)
-  _CCCL_REQUIRES(_Constraints::__less_than_comparable)
+  _CCCL_TEMPLATE(class... _UTypes)
+  _CCCL_REQUIRES((sizeof...(_Tp) == sizeof...(_UTypes))
+                   _CCCL_AND __constraints::template __tuple_all_less_than_comparable_v<_UTypes...>)
   [[nodiscard]] _CCCL_API constexpr bool operator>=(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::__nothrow_less_than_comparable)
+    noexcept(__constraints::template __tuple_all_nothrow_less_than_comparable_v<_UTypes...>)
   {
     return !__tuple_less_than(__rhs, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }
 
-  _CCCL_TEMPLATE(class... _UTypes, class _Constraints = _ComparisonConstraints<_UTypes...>)
-  _CCCL_REQUIRES(_Constraints::__less_than_comparable)
+  _CCCL_TEMPLATE(class... _UTypes)
+  _CCCL_REQUIRES((sizeof...(_Tp) == sizeof...(_UTypes))
+                   _CCCL_AND __constraints::template __tuple_all_less_than_comparable_v<_UTypes...>)
   [[nodiscard]] _CCCL_API constexpr bool operator<=(const tuple<_UTypes...>& __rhs) const
-    noexcept(_Constraints::__nothrow_less_than_comparable)
+    noexcept(__constraints::template __tuple_all_nothrow_less_than_comparable_v<_UTypes...>)
   {
     return !__rhs.__tuple_less_than(*this, __make_tuple_indices_t<sizeof...(_Tp)>{});
   }

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -91,547 +91,515 @@ inline constexpr bool __tuple_like_with_size<_Tuple, _ExpectedSize, true> =
   _ExpectedSize == tuple_size<remove_cvref_t<_Tuple>>::value;
 
 template <class... _Types>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
-__tuple_select_default_constructible(__tuple_types<_Types...>) noexcept
+struct __tuple_constraints
 {
-  if constexpr (!(is_default_constructible_v<_Types> && ...))
+  template <int = 0>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL __select_constructor __select_default_constructible() noexcept
   {
-    return __select_constructor::__invalid;
+    if constexpr (!(is_default_constructible_v<_Types> && ...))
+    {
+      return __select_constructor::__invalid;
+    }
+    else if constexpr ((__is_implicitly_default_constructible<_Types>::value && ...))
+    {
+      return __select_constructor::__implicit;
+    }
+    else
+    {
+      return __select_constructor::__explicit;
+    }
   }
-  else if constexpr ((__is_implicitly_default_constructible<_Types>::value && ...))
-  {
-    return __select_constructor::__implicit;
-  }
-  else
-  {
-    return __select_constructor::__explicit;
-  }
-}
 
-template <class... _Types>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
-__tuple_select_variadic_copy_constructible(__tuple_types<_Types...>) noexcept
-{
-  if constexpr (!(is_copy_constructible_v<_Types> && ...))
+  template <int = 0>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL __select_constructor __select_variadic_copy_constructible() noexcept
   {
-    return __select_constructor::__invalid;
+    if constexpr (!(is_copy_constructible_v<_Types> && ...))
+    {
+      return __select_constructor::__invalid;
+    }
+    else if constexpr ((is_convertible_v<const _Types&, _Types> && ...))
+    {
+      return __select_constructor::__implicit;
+    }
+    else
+    {
+      return __select_constructor::__explicit;
+    }
   }
-  else if constexpr ((is_convertible_v<const _Types&, _Types> && ...))
-  {
-    return __select_constructor::__implicit;
-  }
-  else
-  {
-    return __select_constructor::__explicit;
-  }
-}
 
-template <class _TupleTypes>
-inline constexpr __select_constructor __tuple_select_variadic_copy_constructible_v =
-  ::cuda::std::__tuple_select_variadic_copy_constructible(_TupleTypes{});
-
-template <class... _Types>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
-__tuple_select_variadic_move_constructible(__tuple_types<_Types...>) noexcept
-{
-  if constexpr (!(is_move_constructible_v<_Types> && ...))
+  template <int = 0>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL __select_constructor __select_variadic_move_constructible() noexcept
   {
-    return __select_constructor::__invalid;
+    if constexpr (!(is_move_constructible_v<_Types> && ...))
+    {
+      return __select_constructor::__invalid;
+    }
+    else if constexpr ((is_convertible_v<_Types&&, _Types> && ...))
+    {
+      return __select_constructor::__implicit;
+    }
+    else
+    {
+      return __select_constructor::__explicit;
+    }
   }
-  else if constexpr ((is_convertible_v<_Types&&, _Types> && ...))
-  {
-    return __select_constructor::__implicit;
-  }
-  else
-  {
-    return __select_constructor::__explicit;
-  }
-}
 
-template <class _TupleTypes>
-inline constexpr __select_constructor __tuple_select_variadic_move_constructible_v =
-  ::cuda::std::__tuple_select_variadic_move_constructible(_TupleTypes{});
+  template <class... _UTypes>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL bool __disambiguate_variadic(__tuple_types<_UTypes...>) noexcept
+  {
+    if constexpr (sizeof...(_Types) == 0 || sizeof...(_UTypes) == 0)
+    {
+      return false;
+    }
+    else if constexpr (sizeof...(_UTypes) == 1)
+    { // [tuple.cnstr]-12.1: negation<is_same<remove_cvref_t<U0>, tuple>> if sizeof...(Types) is 1
+      return !(is_same_v<remove_cvref_t<_UTypes>, tuple<_Types...>> || ...);
+    }
+    else if constexpr (sizeof...(_UTypes) == 2 && sizeof...(_Types) != 0)
+    { // [tuple.cnstr]-12.2: !is_same_v<remove_cvref_t<U0>, allocator_arg_t>
+      //                   || is_same_v<remove_cvref_t<T0>, allocator_arg_t>>
+      using _U0 = __type_index_c<0, _UTypes...>;
+      using _T0 = __type_index_c<0, _Types...>;
+      return !is_same_v<remove_cvref_t<_U0>, allocator_arg_t> || is_same_v<remove_cvref_t<_T0>, allocator_arg_t>;
+    }
+    else
+    {
+      return true;
+    }
+  }
 
-template <class... _Types, class... _UTypes>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
-__tuple_select_variadic_constructible(__tuple_types<_Types...>, __tuple_types<_UTypes...>) noexcept
-{
-  // NOLINTBEGIN(bugprone-branch-clone)
-  if constexpr (sizeof...(_Types) != sizeof...(_UTypes))
-  { // [tuple.cnstr]-13.1: sizeof...(Types) equals sizeof...(UTypes),
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (sizeof...(_Types) == 0)
-  { // [tuple.cnstr]-13.2: sizeof...(Types) >= 1,
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (sizeof...(_Types) == 2 || sizeof...(_Types) == 3)
-  { // [tuple.cnstr]-12.2: otherwise, if sizeof...(Types) is 2 or 3
-    using _U0 = __type_index_c<0, _UTypes...>;
-    using _T0 = __type_index_c<0, _Types...>;
-    if constexpr (!is_same_v<remove_cvref_t<_U0>, allocator_arg_t> || is_same_v<remove_cvref_t<_T0>, allocator_arg_t>)
-    { // [tuple.cnstr]-13.3: !is_same_v<remove_cvref_t<U0>, allocator_arg_t> || is_same_v<remove_cvref_t<T0>,
-      // allocator_arg_t>>
-      if constexpr (!(is_constructible_v<_Types, _UTypes> && ...))
-      { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
-        return __select_constructor::__invalid;
-      }
+  template <class... _UTypes>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL __select_constructor
+  __select_variadic_constructible(__tuple_types<_UTypes...>) noexcept
+  {
+    // NOLINTBEGIN(bugprone-branch-clone)
+    if constexpr (sizeof...(_Types) != sizeof...(_UTypes))
+    { // [tuple.cnstr]-13.1: sizeof...(Types) equals sizeof...(UTypes),
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (sizeof...(_Types) == 0)
+    { // [tuple.cnstr]-13.2: sizeof...(Types) >= 1,
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (sizeof...(_Types) == 2 || sizeof...(_Types) == 3)
+    { // [tuple.cnstr]-12.2: otherwise, if sizeof...(Types) is 2 or 3
+      using _U0 = __type_index_c<0, _UTypes...>;
+      using _T0 = __type_index_c<0, _Types...>;
+      if constexpr (!is_same_v<remove_cvref_t<_U0>, allocator_arg_t> || is_same_v<remove_cvref_t<_T0>, allocator_arg_t>)
+      { // [tuple.cnstr]-13.3: !is_same_v<remove_cvref_t<U0>, allocator_arg_t> || is_same_v<remove_cvref_t<T0>,
+        // allocator_arg_t>>
+        if constexpr (!(is_constructible_v<_Types, _UTypes> && ...))
+        { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
+          return __select_constructor::__invalid;
+        }
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-      else if constexpr ((reference_constructs_from_temporary_v<_Types, _UTypes&&> || ...))
-      { // [tuple.cnstr]-15: This constructor is defined as deleted if
-        // (reference_constructs_from_temporary_v<Types, UTypes&&> || ...) is true
-        return __select_constructor::__deleted;
-      }
+        else if constexpr ((reference_constructs_from_temporary_v<_Types, _UTypes&&> || ...))
+        { // [tuple.cnstr]-15: This constructor is defined as deleted if
+          // (reference_constructs_from_temporary_v<Types, UTypes&&> || ...) is true
+          return __select_constructor::__deleted;
+        }
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
-      else if constexpr (!(is_convertible_v<_UTypes, _Types> && ...))
-      { // [tuple.cnstr]-15: !conjunction_v<is_convertible<UTypes, Types>...>
-        return __select_constructor::__explicit;
+        else if constexpr (!(is_convertible_v<_UTypes, _Types> && ...))
+        { // [tuple.cnstr]-15: !conjunction_v<is_convertible<UTypes, Types>...>
+          return __select_constructor::__explicit;
+        }
+        else
+        {
+          return __select_constructor::__implicit;
+        }
       }
       else
       {
-        return __select_constructor::__implicit;
+        return __select_constructor::__invalid;
       }
     }
-    else
-    {
+    else if constexpr (!(is_constructible_v<_Types, _UTypes> && ...))
+    { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
       return __select_constructor::__invalid;
     }
-  }
-  else if constexpr (!(is_constructible_v<_Types, _UTypes> && ...))
-  { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
-    return __select_constructor::__invalid;
-  }
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-  else if constexpr ((reference_constructs_from_temporary_v<_Types, _UTypes&&> || ...))
-  { // [tuple.cnstr]-15: This constructor is defined as deleted if
-    // (reference_constructs_from_temporary_v<Types, UTypes&&> || ...) is true
-    return __select_constructor::__deleted;
-  }
+    else if constexpr ((reference_constructs_from_temporary_v<_Types, _UTypes&&> || ...))
+    { // [tuple.cnstr]-15: This constructor is defined as deleted if
+      // (reference_constructs_from_temporary_v<Types, UTypes&&> || ...) is true
+      return __select_constructor::__deleted;
+    }
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
-  else if constexpr (!(is_convertible_v<_UTypes, _Types> && ...))
-  { // [tuple.cnstr]-15: !conjunction_v<is_convertible<UTypes, Types>...>
-    return __select_constructor::__explicit;
-  }
-  else
-  {
-    return __select_constructor::__implicit;
-  }
-  // NOLINTEND(bugprone-branch-clone)
-}
-
-template <class _Type, class _UType>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
-__tuple_select_variadic_constructible(__tuple_types<_Type>, __tuple_types<_UType>) noexcept
-{
-  // NOLINTBEGIN(bugprone-branch-clone)
-  if constexpr (__is_tuple_of_iterator_references_v<remove_cvref_t<_UType>>)
-  {
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (is_same_v<remove_cvref_t<_UType>, tuple<_Type>>)
-  { // [tuple.cnstr]-12.1: negation<is_same<remove_cvref_t<U0>, tuple>> if sizeof...(Types) is 1
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (!is_constructible_v<_Type, _UType>)
-  { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
-    return __select_constructor::__invalid;
-  }
-#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-  else if constexpr (reference_constructs_from_temporary_v<_Type, _UType&&>)
-  { // [tuple.cnstr]-15: This constructor is defined as deleted if
-    // (reference_constructs_from_temporary_v<Types, UTypes&&> || ...) is true
-    return __select_constructor::__deleted;
-  }
-#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
-  else if constexpr (!is_convertible_v<_UType, _Type>)
-  { // [tuple.cnstr]-15: !conjunction_v<is_convertible<UTypes, Types>...>
-    return __select_constructor::__explicit;
-  }
-  else
-  {
-    return __select_constructor::__implicit;
-  }
-  // NOLINTEND(bugprone-branch-clone)
-}
-
-template <class _TupleTypes, class _TupleUTypes>
-inline constexpr __select_constructor __tuple_select_variadic_constructible_v =
-  ::cuda::std::__tuple_select_variadic_constructible(_TupleTypes{}, _TupleUTypes{});
-
-template <class... _Types, class... _UTypes>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
-__tuple_select_variadic_constructible_less_rank(__tuple_types<_Types...>, __tuple_types<_UTypes...>) noexcept
-{
-  // NOLINTBEGIN(bugprone-branch-clone)
-  if constexpr (!(sizeof...(_UTypes) < sizeof...(_Types)))
-  {
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (sizeof...(_UTypes) == 0)
-  {
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (sizeof...(_UTypes) == 1 && (is_same_v<remove_cvref_t<_UTypes>, tuple<_Types...>> && ...))
-  { // Avoid this shadowing the copy / move constructors
-    return __select_constructor::__invalid;
-  }
-  else
-  { // MSVC has issues with constexpr variables here, so no `__can_construct<_Trait>` or constexpr variable
-    using __arg_list = __make_tuple_types_t<__tuple_types<_Types...>, sizeof...(_UTypes)>;
-    if constexpr (::cuda::std::__tuple_select_variadic_constructible(__arg_list{}, __tuple_types<_UTypes...>{})
-                    == __select_constructor::__invalid
-                  || ::cuda::std::__tuple_select_variadic_constructible(__arg_list{}, __tuple_types<_UTypes...>{})
-                       == __select_constructor::__deleted)
-    {
-      return __select_constructor::__invalid;
+    else if constexpr (!(is_convertible_v<_UTypes, _Types> && ...))
+    { // [tuple.cnstr]-15: !conjunction_v<is_convertible<UTypes, Types>...>
+      return __select_constructor::__explicit;
     }
     else
     {
-      using __defaulted_list = __make_tuple_types_t<__tuple_types<_Types...>, sizeof...(_Types), sizeof...(_UTypes)>;
-      if constexpr (::cuda::std::__tuple_select_default_constructible(__defaulted_list{})
+      return __select_constructor::__implicit;
+    }
+    // NOLINTEND(bugprone-branch-clone)
+  }
+
+  template <class _UType>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL __select_constructor
+  __select_variadic_constructible(__tuple_types<_UType>) noexcept
+  {
+    // NOLINTBEGIN(bugprone-branch-clone)
+    if constexpr (sizeof...(_Types) != 1)
+    {
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (__is_tuple_of_iterator_references_v<remove_cvref_t<_UType>>)
+    {
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (is_same_v<remove_cvref_t<_UType>, tuple<_Types...>>)
+    { // [tuple.cnstr]-12.1: negation<is_same<remove_cvref_t<U0>, tuple>> if sizeof...(Types) is 1
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (!(is_constructible_v<_Types, _UType> && ...))
+    { // [tuple.cnstr]-13.3: is_constructible<Types, UTypes>... is true
+      return __select_constructor::__invalid;
+    }
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
+    else if constexpr ((reference_constructs_from_temporary_v<_Types, _UType&&> || ...))
+    { // [tuple.cnstr]-15: This constructor is defined as deleted if
+      // (reference_constructs_from_temporary_v<Types, UTypes&&> || ...) is true
+      return __select_constructor::__deleted;
+    }
+#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
+    else if constexpr (!(is_convertible_v<_UType, _Types> && ...))
+    { // [tuple.cnstr]-15: !conjunction_v<is_convertible<UTypes, Types>...>
+      return __select_constructor::__explicit;
+    }
+    else
+    {
+      return __select_constructor::__implicit;
+    }
+    // NOLINTEND(bugprone-branch-clone)
+  }
+
+  template <class... _UTypes>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL __tuple_constraints<_UTypes...>
+  __get_tuple_constraints(__tuple_types<_UTypes...>) noexcept
+  {
+    return {};
+  }
+
+  template <class... _UTypes>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL __select_constructor
+  __select_variadic_constructible_less_rank(__tuple_types<_UTypes...>) noexcept
+  {
+    // NOLINTBEGIN(bugprone-branch-clone)
+    if constexpr (!(sizeof...(_UTypes) < sizeof...(_Types)))
+    {
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (sizeof...(_UTypes) == 0)
+    {
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (sizeof...(_UTypes) == 1 && (is_same_v<remove_cvref_t<_UTypes>, tuple<_Types...>> && ...))
+    { // Avoid this shadowing the copy / move constructors
+      return __select_constructor::__invalid;
+    }
+    else
+    { // MSVC has issues with constexpr variables here, so no `__can_construct<_Trait>` or constexpr variable
+      using __arg_list        = __make_tuple_types_t<__tuple_types<_Types...>, sizeof...(_UTypes)>;
+      using __arg_constraints = decltype(__get_tuple_constraints(__arg_list{}));
+      if constexpr (__arg_constraints::__select_variadic_constructible(__tuple_types<_UTypes...>{})
                       == __select_constructor::__invalid
-                    || ::cuda::std::__tuple_select_default_constructible(__defaulted_list{})
+                    || __arg_constraints::__select_variadic_constructible(__tuple_types<_UTypes...>{})
                          == __select_constructor::__deleted)
       {
         return __select_constructor::__invalid;
       }
       else
       {
-        return __select_constructor::__explicit;
+        using __defaulted_list = __make_tuple_types_t<__tuple_types<_Types...>, sizeof...(_Types), sizeof...(_UTypes)>;
+        using __defautled_constraints = decltype(__get_tuple_constraints(__defaulted_list{}));
+        if constexpr (__defautled_constraints::__select_default_constructible() == __select_constructor::__invalid
+                      || __defautled_constraints::__select_default_constructible() == __select_constructor::__deleted)
+        {
+          return __select_constructor::__invalid;
+        }
+        else
+        {
+          return __select_constructor::__explicit;
+        }
       }
     }
+    _CCCL_UNREACHABLE();
+    // NOLINTEND(bugprone-branch-clone)
   }
-  _CCCL_UNREACHABLE();
-  // NOLINTEND(bugprone-branch-clone)
-}
 
-template <class _TupleTypes, class _TupleUTypes>
-inline constexpr __select_constructor __tuple_select_variadic_constructible_less_rank_v =
-  ::cuda::std::__tuple_select_variadic_constructible_less_rank(_TupleTypes{}, _TupleUTypes{});
-
-_CCCL_EXEC_CHECK_DISABLE
-template <class _UTuple, class... _Types, size_t... _Indices>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
-__tuple_select_tuple_like_constructible(__tuple_types<_Types...>, __tuple_indices<_Indices...>) noexcept
-{
-  using ::cuda::std::get;
-  // NOLINTBEGIN(bugprone-branch-clone)
-  if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UTuple>>)
-  { // [tuple#cnstr]-29.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (is_same_v<_UTuple, const tuple<_Types...>&> || is_same_v<_UTuple, tuple<_Types...>&&>)
-  { // Prefers the copy/move constructor
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (sizeof...(_Types) == 0)
-  { // Avoids issues with the size 1 constructor below
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (!__tuple_like_with_size<_UTuple, sizeof...(_Types)>)
-  { // [tuple#cnstr]-21.1: sizeof...(Types) equals sizeof...(UTypes), and
-    // [tuple#cnstr]-25.1: sizeof...(Types) is 2,
-    // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (!(is_constructible_v<_Types, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...))
-  { // [tuple.cnstr]-21.2: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
-    // [tuple.cnstr]-25.2: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
-    // [tuple.cnstr]-29.4: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
-    return __select_constructor::__invalid;
-  }
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _UTuple, size_t... _Indices>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL __select_constructor
+  __select_tuple_like_constructible(__tuple_indices<_Indices...>) noexcept
+  {
+    // NOLINTBEGIN(bugprone-branch-clone)
+    using ::cuda::std::get;
+    if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UTuple>>)
+    { // [tuple#cnstr]-29.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (is_same_v<_UTuple, const tuple<_Types...>&> || is_same_v<_UTuple, tuple<_Types...>&&>)
+    { // Prefers the copy/move constructor
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (sizeof...(_Types) == 0)
+    { // Avoids issues with the size 1 constructor below
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (!__tuple_like_with_size<_UTuple, sizeof...(_Types)>)
+    { // [tuple#cnstr]-21.1: sizeof...(Types) equals sizeof...(UTypes), and
+      // [tuple#cnstr]-25.1: sizeof...(Types) is 2,
+      // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (!(is_constructible_v<_Types, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...))
+    { // [tuple.cnstr]-21.2: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
+      // [tuple.cnstr]-25.2: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
+      // [tuple.cnstr]-29.4: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
+      return __select_constructor::__invalid;
+    }
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-  else if constexpr ((reference_constructs_from_temporary_v<_Types,
-                                                            decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))>
-                      || ...))
-  { // [tuple.cnstr]-23: This constructor is defined as deleted if
-    // [tuple.cnstr]-27: This constructor is defined as deleted if
-    // [tuple.cnstr]-31: This constructor is defined as deleted if
-    // (reference_constructs_from_temporary_v<Types, decltype(get<I>(FWD(u)))> || ...) is true
-    return __select_constructor::__deleted;
-  }
+    else if constexpr ((reference_constructs_from_temporary_v<_Types,
+                                                              decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))>
+                        || ...))
+    { // [tuple.cnstr]-23: This constructor is defined as deleted if
+      // [tuple.cnstr]-27: This constructor is defined as deleted if
+      // [tuple.cnstr]-31: This constructor is defined as deleted if
+      // (reference_constructs_from_temporary_v<Types, decltype(get<I>(FWD(u)))> || ...) is true
+      return __select_constructor::__deleted;
+    }
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
-  else if constexpr (!(is_convertible_v<decltype(get<_Indices>(::cuda::std::declval<_UTuple>())), _Types> && ...))
-  { // [tuple.cnstr]-15: The expression inside explicit is equivalent to:
-    // [tuple.cnstr]-23: The expression inside explicit is equivalent to:
-    // [tuple.cnstr]-31: The expression inside explicit is equivalent to:
-    // !(is_convertible_v<decltype(get<I>(FWD(u))), Types> && ...)
-    return __select_constructor::__explicit;
+    else if constexpr (!(is_convertible_v<decltype(get<_Indices>(::cuda::std::declval<_UTuple>())), _Types> && ...))
+    { // [tuple.cnstr]-15: The expression inside explicit is equivalent to:
+      // [tuple.cnstr]-23: The expression inside explicit is equivalent to:
+      // [tuple.cnstr]-31: The expression inside explicit is equivalent to:
+      // !(is_convertible_v<decltype(get<I>(FWD(u))), Types> && ...)
+      return __select_constructor::__explicit;
+    }
+    else
+    {
+      return __select_constructor::__implicit;
+    }
+    // NOLINTEND(bugprone-branch-clone)
   }
-  else
-  {
-    return __select_constructor::__implicit;
-  }
-  // NOLINTEND(bugprone-branch-clone)
-}
 
-_CCCL_EXEC_CHECK_DISABLE
-template <class _UTuple, class _Type, size_t _Index>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_constructor
-__tuple_select_tuple_like_constructible(__tuple_types<_Type>, __tuple_indices<_Index>) noexcept
-{
-  using ::cuda::std::get;
-  // NOLINTBEGIN(bugprone-branch-clone)
-  if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UTuple>>)
-  { // [tuple#cnstr]-29.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (is_same_v<_UTuple, const tuple<_Type>&> || is_same_v<_UTuple, tuple<_Type>&&>)
-  { // Prefers the copy/move constructor
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (!__tuple_like_with_size<_UTuple, 1>)
-  { // [tuple#cnstr]-21.1: sizeof...(Types) equals sizeof...(UTypes), and
-    // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (__is_cuda_std_tuple<remove_cvref_t<_UTuple>>
-                     && is_same_v<_Type, tuple_element_t<_Index, remove_cvref_t<_UTuple>>>)
-  { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1
-    // [tuple#cnstr]-21.3: is_same_v<T, U> is false
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (is_constructible_v<_Type, _UTuple>)
-  { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1, or is_constructible_v<T, _UTuple> are false
-    // [tuple#cnstr]-29.5: either sizeof...(Types) is not 1, or is_constructible_v<T, _UTuple> are false
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (is_convertible_v<_UTuple, _Type>)
-  { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1, or is_convertible_v<_UTuple, T> are false
-    // [tuple#cnstr]-29.5: either sizeof...(Types) is not 1, or is_convertible_v<_UTuple, T> are false
-    return __select_constructor::__invalid;
-  }
-  else if constexpr (!is_constructible_v<_Type, decltype(get<_Index>(::cuda::std::declval<_UTuple>()))>)
-  { // [tuple.cnstr]-21.2: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
-    // [tuple.cnstr]-29.4: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
-    return __select_constructor::__invalid;
-  }
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _UTuple, size_t _Index>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL __select_constructor
+  __select_tuple_like_constructible(__tuple_indices<_Index>) noexcept
+  {
+    // NOLINTBEGIN(bugprone-branch-clone)
+    using ::cuda::std::get;
+    if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UTuple>>)
+    { // [tuple#cnstr]-29.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (is_same_v<_UTuple, const tuple<_Types...>&> || is_same_v<_UTuple, tuple<_Types...>&&>)
+    { // Prefers the copy/move constructor
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (!__tuple_like_with_size<_UTuple, 1>)
+    { // [tuple#cnstr]-21.1: sizeof...(Types) equals sizeof...(UTypes), and
+      // [tuple#cnstr]-29.3: sizeof...(Types) equals sizeof...(UTypes), and
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (__is_cuda_std_tuple<remove_cvref_t<_UTuple>>
+                       && (is_same_v<_Types, tuple_element_t<_Index, remove_cvref_t<_UTuple>>> && ...))
+    { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1
+      // [tuple#cnstr]-21.3: is_same_v<T, U> is false
+      return __select_constructor::__invalid;
+    }
+    else if constexpr ((is_constructible_v<_Types, _UTuple> && ...))
+    { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1, or is_constructible_v<T, _UTuple> are false
+      // [tuple#cnstr]-29.5: either sizeof...(Types) is not 1, or is_constructible_v<T, _UTuple> are false
+      return __select_constructor::__invalid;
+    }
+    else if constexpr ((is_convertible_v<_UTuple, _Types> && ...))
+    { // [tuple#cnstr]-21.3: either sizeof...(Types) is not 1, or is_convertible_v<_UTuple, T> are false
+      // [tuple#cnstr]-29.5: either sizeof...(Types) is not 1, or is_convertible_v<_UTuple, T> are false
+      return __select_constructor::__invalid;
+    }
+    else if constexpr (!(is_constructible_v<_Types, decltype(get<_Index>(::cuda::std::declval<_UTuple>()))> && ...))
+    { // [tuple.cnstr]-21.2: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
+      // [tuple.cnstr]-29.4: is_constructible<Types, decltype(get<I>(std::forward<UTuple>(u)))>... is true
+      return __select_constructor::__invalid;
+    }
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-  else if constexpr (reference_constructs_from_temporary_v<_Type, decltype(get<_Index>(::cuda::std::declval<_UTuple>()))>)
-  { // [tuple.cnstr]-23: This constructor is defined as deleted if
-    // [tuple.cnstr]-31: This constructor is defined as deleted if
-    // (reference_constructs_from_temporary_v<Types, decltype(get<I>(FWD(u)))> || ...) is true
-    return __select_constructor::__deleted;
-  }
+    else if constexpr ((reference_constructs_from_temporary_v<_Types,
+                                                              decltype(get<_Index>(::cuda::std::declval<_UTuple>()))>
+                        || ...))
+    { // [tuple.cnstr]-23: This constructor is defined as deleted if
+      // [tuple.cnstr]-31: This constructor is defined as deleted if
+      // (reference_constructs_from_temporary_v<Types, decltype(get<I>(FWD(u)))> || ...) is true
+      return __select_constructor::__deleted;
+    }
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
-  else if constexpr (!is_convertible_v<decltype(get<_Index>(::cuda::std::declval<_UTuple>())), _Type>)
-  { // [tuple.cnstr]-15: The expression inside explicit is equivalent to:
-    // [tuple.cnstr]-23: The expression inside explicit is equivalent to:
-    // !(is_convertible_v<decltype(get<I>(FWD(u))), Types> && ...)
-    return __select_constructor::__explicit;
+    else if constexpr (!(is_convertible_v<decltype(get<_Index>(::cuda::std::declval<_UTuple>())), _Types> && ...))
+    { // [tuple.cnstr]-15: The expression inside explicit is equivalent to:
+      // [tuple.cnstr]-23: The expression inside explicit is equivalent to:
+      // !(is_convertible_v<decltype(get<I>(FWD(u))), Types> && ...)
+      return __select_constructor::__explicit;
+    }
+    else
+    {
+      return __select_constructor::__implicit;
+    }
+    // NOLINTEND(bugprone-branch-clone)
   }
-  else
-  {
-    return __select_constructor::__implicit;
-  }
-  // NOLINTEND(bugprone-branch-clone)
-}
 
-template <class _UTuple, class _TupleTypes, class _TupleIndices>
-inline constexpr __select_constructor __tuple_select_tuple_like_constructible_v =
-  ::cuda::std::__tuple_select_tuple_like_constructible<_UTuple>(_TupleTypes{}, _TupleIndices{});
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _UTuple, size_t... _Indices>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL bool
+  __tuple_nothrow_tuple_like_constructible(__tuple_indices<_Indices...>) noexcept
+  {
+    using ::cuda::std::get;
+    return (is_nothrow_constructible_v<_Types, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...);
+  }
 
-_CCCL_EXEC_CHECK_DISABLE
-template <class _UTuple, class _Type, class... _Types, size_t _Index, size_t... _Indices>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL bool
-__tuple_nothrow_tuple_like_constructible(__tuple_types<_Type, _Types...>, __tuple_indices<_Index, _Indices...>) noexcept
-{
-  using ::cuda::std::get;
-  if constexpr (!is_nothrow_constructible_v<_Type, decltype(get<_Index>(::cuda::std::declval<_UTuple>()))>)
-  {
-    return false;
-  }
-  else if constexpr (sizeof...(_Types) != 0)
-  {
-    return ::cuda::std::__tuple_nothrow_tuple_like_constructible<_UTuple>(
-      __tuple_types<_Types...>{}, __tuple_indices<_Indices...>{});
-  }
-  else
+  template <class _UTuple>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL bool
+  __tuple_nothrow_tuple_like_constructible(__tuple_indices<>) noexcept
   {
     return true;
   }
-}
 
-template <class _UTuple>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL bool
-__tuple_nothrow_tuple_like_constructible(__tuple_types<>, __tuple_indices<>) noexcept
-{
-  return true;
-}
+  template <int = 0>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL __select_assignment __select_const_copy_assignable() noexcept
+  {
+    if constexpr (!(is_copy_assignable_v<const _Types> && ...))
+    { // [tuple.assign]-5: is_copy_assignable_v<const Types> is true for all i.
+      return __select_assignment::__invalid;
+    }
+    else if constexpr ((is_nothrow_copy_assignable_v<const _Types> && ...))
+    {
+      return __select_assignment::__is_nothrow;
+    }
+    else
+    {
+      return __select_assignment::__may_throw;
+    }
+  }
 
-template <class _UTuple, class _TupleTypes, class _TupleIndices>
-inline constexpr bool __tuple_nothrow_tuple_like_constructible_v =
-  ::cuda::std::__tuple_nothrow_tuple_like_constructible<_UTuple>(_TupleTypes{}, _TupleIndices{});
+  template <int = 0>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL __select_assignment __select_const_move_assignable() noexcept
+  {
+    if constexpr (!(is_assignable_v<const _Types&, _Types> && ...))
+    { // [tuple.assign]-12: is_assignable_v<const Types&, Types> is true for all i.
+      return __select_assignment::__invalid;
+    }
+    else if constexpr ((is_nothrow_assignable_v<const _Types&, _Types> && ...))
+    {
+      return __select_assignment::__is_nothrow;
+    }
+    else
+    {
+      return __select_assignment::__may_throw;
+    }
+  }
 
-struct _InvalidTupleComparison
-{
-  static constexpr bool __equality_comparable         = false;
-  static constexpr bool __nothrow_equality_comparable = false;
+  template <bool _IsConst, class... _UTypes>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL __select_assignment
+  __select_converting_assignable(__tuple_types<_UTypes...>) noexcept
+  {
+    // NOLINTBEGIN(bugprone-branch-clone)
+    if constexpr (sizeof...(_Types) != sizeof...(_UTypes))
+    { // [tuple.assign]-15.1: sizeof...(Types) equals sizeof...(UTypes) and
+      return __select_assignment::__invalid;
+    }
+    else if constexpr (is_same_v<tuple<_Types...>, tuple<_UTypes...>>)
+    { // Disambiguate the non-converting assignments
+      return __select_assignment::__invalid;
+    }
+    else if constexpr (_IsConst)
+    {
+      if constexpr ((is_assignable_v<const _Types&, _UTypes> && ...))
+      { // [tuple.assign]-18.2: is_assignable_v<const Types&, const UTypes&> is true for all i.
+        // [tuple.assign]-24.2: is_assignable_v<const Types&, UTypes> is true for all i.
+        return (is_nothrow_assignable_v<const _Types&, _UTypes> && ...)
+               ? __select_assignment::__is_nothrow
+               : __select_assignment::__may_throw;
+      }
+      else
+      {
+        return __select_assignment::__invalid;
+      }
+    }
+    else if constexpr ((is_assignable_v<_Types&, _UTypes> && ...))
+    { // [tuple.assign]-15.2: is_assignable_v<Types&, const UTypes&> is true for all i.
+      // [tuple.assign]-21.2: is_assignable_v<Types&, UTypes> is true for all i.
+      return (is_nothrow_assignable_v<_Types&, _UTypes> && ...)
+             ? __select_assignment::__is_nothrow
+             : __select_assignment::__may_throw;
+    }
+    else
+    {
+      return __select_assignment::__invalid;
+    }
+    // NOLINTEND(bugprone-branch-clone)
+  }
 
-  static constexpr bool __less_than_comparable         = false;
-  static constexpr bool __nothrow_less_than_comparable = false;
-};
+  _CCCL_EXEC_CHECK_DISABLE
+  template <bool _IsConst, class _UTuple, size_t... _Indices>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL __select_assignment
+  __select_tuple_like_assignable(__tuple_indices<_Indices...>) noexcept
+  {
+    // NOLINTBEGIN(bugprone-branch-clone)
+    using ::cuda::std::get;
+    if constexpr (is_same_v<remove_cvref_t<_UTuple>, tuple<_Types...>>)
+    { // [tuple.assign]-39.1: different-from<UTuple, tuple>
+      return __select_assignment::__invalid;
+    }
+    else if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UTuple>>)
+    { // [tuple.assign]-39.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
+      return __select_assignment::__invalid;
+    }
+    else if constexpr (!__tuple_like_with_size<_UTuple, sizeof...(_Types)>)
+    { // [tuple.assign]-39.3: sizeof...(Types) equals tuple_size_v<remove_cvref_t<UTuple>>, and
+      return __select_assignment::__invalid;
+    }
+    else if constexpr (_IsConst)
+    {
+      if constexpr ((is_assignable_v<const _Types&, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...))
+      { // [tuple.assign]-42.4: is_assignable_v<const T_i&, decltype(get<i>(std::forward<UTuple>(u)))> is true for
+        // all i
+        return (is_nothrow_assignable_v<const _Types&, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...)
+               ? __select_assignment::__is_nothrow
+               : __select_assignment::__may_throw;
+      }
+      else
+      {
+        return __select_assignment::__invalid;
+      }
+    }
+    else if constexpr ((is_assignable_v<_Types&, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...))
+    { // [tuple.assign]-39.4: is_assignable_v<T_i&, decltype(get<i>(std::forward<UTuple>(u)))> is true for all i
+      return (is_nothrow_assignable_v<_Types&, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...)
+             ? __select_assignment::__is_nothrow
+             : __select_assignment::__may_throw;
+    }
+    else
+    {
+      return __select_assignment::__invalid;
+    }
+    // NOLINTEND(bugprone-branch-clone)
+  }
 
-template <class, class>
-struct _TupleComparableTraits;
+  template <class... _UTypes>
+  static constexpr bool __tuple_all_equality_comparable_v = (__is_cpp17_equality_comparable_v<_Types, _UTypes> && ...);
 
-template <class... _Types, class... _UTypes>
-struct _TupleComparableTraits<__tuple_types<_Types...>, __tuple_types<_UTypes...>>
-{
-  static constexpr bool __equality_comparable = (__is_cpp17_equality_comparable_v<_Types, _UTypes> && ...);
-  static constexpr bool __nothrow_equality_comparable =
+  template <class... _UTypes>
+  static constexpr bool __tuple_all_nothrow_equality_comparable_v =
     (__is_cpp17_nothrow_equality_comparable_v<_Types, _UTypes> && ...);
 
-  static constexpr bool __less_than_comparable = (__is_cpp17_less_than_comparable_v<_Types, _UTypes> && ...);
-  static constexpr bool __nothrow_less_than_comparable =
+  template <class... _UTypes>
+  static constexpr bool __tuple_all_less_than_comparable_v =
+    (__is_cpp17_less_than_comparable_v<_Types, _UTypes> && ...);
+
+  template <class... _UTypes>
+  static constexpr bool __tuple_all_nothrow_less_than_comparable_v =
     (__is_cpp17_nothrow_less_than_comparable_v<_Types, _UTypes> && ...);
 };
-
-template <class... _Types, class... _UTypes, enable_if_t<(sizeof...(_Types) == sizeof...(_UTypes)), int> = 0>
-[[nodiscard]]
-_CCCL_API _CCCL_CONSTEVAL auto __tuple_is_comparable(__tuple_types<_Types...>, __tuple_types<_UTypes...>) noexcept
-  -> _TupleComparableTraits<__tuple_types<_Types...>, __tuple_types<_UTypes...>>;
-template <class>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __tuple_is_comparable(...) noexcept -> _InvalidTupleComparison;
-
-template <class... _Types>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_assignment
-__tuple_select_const_copy_assignable(__tuple_types<_Types...>) noexcept
-{
-  if constexpr (!(is_copy_assignable_v<const _Types> && ...))
-  { // [tuple.assign]-5: is_copy_assignable_v<const Types> is true for all i.
-    return __select_assignment::__invalid;
-  }
-  else if constexpr ((is_nothrow_copy_assignable_v<const _Types> && ...))
-  {
-    return __select_assignment::__is_nothrow;
-  }
-  else
-  {
-    return __select_assignment::__may_throw;
-  }
-}
-
-template <class _TupleTypes>
-inline constexpr __select_assignment __tuple_select_const_copy_assignable_v =
-  ::cuda::std::__tuple_select_const_copy_assignable(_TupleTypes{});
-
-template <class... _Types>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_assignment
-__tuple_select_const_move_assignable(__tuple_types<_Types...>) noexcept
-{
-  if constexpr (!(is_assignable_v<const _Types&, _Types> && ...))
-  { // [tuple.assign]-12: is_assignable_v<const Types&, Types> is true for all i.
-    return __select_assignment::__invalid;
-  }
-  else if constexpr ((is_nothrow_assignable_v<const _Types&, _Types> && ...))
-  {
-    return __select_assignment::__is_nothrow;
-  }
-  else
-  {
-    return __select_assignment::__may_throw;
-  }
-}
-
-template <class _TupleTypes>
-inline constexpr __select_assignment __tuple_select_const_move_assignable_v =
-  ::cuda::std::__tuple_select_const_move_assignable(_TupleTypes{});
-
-template <bool _IsConst, class... _Types, class... _UTypes>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_assignment
-__tuple_select_converting_assignable(__tuple_types<_Types...>, __tuple_types<_UTypes...>) noexcept
-{
-  // NOLINTBEGIN(bugprone-branch-clone)
-  if constexpr (sizeof...(_Types) != sizeof...(_UTypes))
-  { // [tuple.assign]-15.1: sizeof...(Types) equals sizeof...(UTypes) and
-    return __select_assignment::__invalid;
-  }
-  else if constexpr (is_same_v<tuple<_Types...>, tuple<_UTypes...>>)
-  { // Disambiguate the non-converting assignments
-    return __select_assignment::__invalid;
-  }
-  else if constexpr (_IsConst)
-  {
-    if constexpr ((is_assignable_v<const _Types&, _UTypes> && ...))
-    { // [tuple.assign]-18.2: is_assignable_v<const Types&, const UTypes&> is true for all i.
-      // [tuple.assign]-24.2: is_assignable_v<const Types&, UTypes> is true for all i.
-      return (is_nothrow_assignable_v<const _Types&, _UTypes> && ...)
-             ? __select_assignment::__is_nothrow
-             : __select_assignment::__may_throw;
-    }
-    else
-    {
-      return __select_assignment::__invalid;
-    }
-  }
-  else if constexpr ((is_assignable_v<_Types&, _UTypes> && ...))
-  { // [tuple.assign]-15.2: is_assignable_v<Types&, const UTypes&> is true for all i.
-    // [tuple.assign]-21.2: is_assignable_v<Types&, UTypes> is true for all i.
-    return (is_nothrow_assignable_v<_Types&, _UTypes> && ...)
-           ? __select_assignment::__is_nothrow
-           : __select_assignment::__may_throw;
-  }
-  else
-  {
-    return __select_assignment::__invalid;
-  }
-  // NOLINTEND(bugprone-branch-clone)
-}
-
-template <bool _IsConst, class _TupleTypes, class _TupleUTypes>
-inline constexpr __select_assignment __tuple_select_converting_assignable_v =
-  ::cuda::std::__tuple_select_converting_assignable<_IsConst>(_TupleTypes{}, _TupleUTypes{});
-
-_CCCL_EXEC_CHECK_DISABLE
-template <bool _IsConst, class _UTuple, class... _Types, size_t... _Indices>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __select_assignment
-__tuple_select_tuple_like_assignable(__tuple_types<_Types...>, __tuple_indices<_Indices...>) noexcept
-{
-  using ::cuda::std::get;
-  // NOLINTBEGIN(bugprone-branch-clone)
-  if constexpr (is_same_v<remove_cvref_t<_UTuple>, tuple<_Types...>>)
-  { // [tuple.assign]-39.1: different-from<UTuple, tuple>
-    return __select_assignment::__invalid;
-  }
-  else if constexpr (__is_cuda_std_ranges_subrange_v<remove_cvref_t<_UTuple>>)
-  { // [tuple.assign]-39.2: remove_cvref_t<UTuple> is not a specialization of ranges::subrange,
-    return __select_assignment::__invalid;
-  }
-  else if constexpr (!__tuple_like_with_size<_UTuple, sizeof...(_Types)>)
-  { // [tuple.assign]-39.3: sizeof...(Types) equals tuple_size_v<remove_cvref_t<UTuple>>, and
-    return __select_assignment::__invalid;
-  }
-  else if constexpr (_IsConst)
-  {
-    if constexpr ((is_assignable_v<const _Types&, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...))
-    { // [tuple.assign]-42.4: is_assignable_v<const T_i&, decltype(get<i>(std::forward<UTuple>(u)))> is true for
-      // all i
-      return (is_nothrow_assignable_v<const _Types&, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...)
-             ? __select_assignment::__is_nothrow
-             : __select_assignment::__may_throw;
-    }
-    else
-    {
-      return __select_assignment::__invalid;
-    }
-  }
-  else if constexpr ((is_assignable_v<_Types&, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...))
-  { // [tuple.assign]-39.4: is_assignable_v<T_i&, decltype(get<i>(std::forward<UTuple>(u)))> is true for all i
-    return (is_nothrow_assignable_v<_Types&, decltype(get<_Indices>(::cuda::std::declval<_UTuple>()))> && ...)
-           ? __select_assignment::__is_nothrow
-           : __select_assignment::__may_throw;
-  }
-  else
-  {
-    return __select_assignment::__invalid;
-  }
-  // NOLINTEND(bugprone-branch-clone)
-}
-
-template <bool _IsConst, class _UTuple, class _TupleTypes, class _TupleIndices>
-inline constexpr __select_assignment __tuple_select_tuple_like_assignable_v =
-  ::cuda::std::__tuple_select_tuple_like_assignable<_IsConst, _UTuple>(_TupleTypes{}, _TupleIndices{});
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -192,8 +192,10 @@ struct __pair_base
   _T1 first;
   _T2 second;
 
+  using __constraints = __tuple_constraints<_T1, _T2>;
+
   _CCCL_EXEC_CHECK_DISABLE
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_T1, _T2>{}),
+  template <__select_constructor _Trait                          = __constraints::__select_default_constructible(),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr __pair_base() noexcept(is_nothrow_default_constructible_v<_T1>
                                              && is_nothrow_default_constructible_v<_T2>)
@@ -202,7 +204,7 @@ struct __pair_base
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_T1, _T2>{}),
+  template <__select_constructor _Trait                          = __constraints::__select_default_constructible(),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API explicit constexpr __pair_base() noexcept(
     is_nothrow_default_constructible_v<_T1> && is_nothrow_default_constructible_v<_T2>)
@@ -234,8 +236,10 @@ struct __pair_base<_T1, _T2, true>
   _T1 first;
   _T2 second;
 
+  using __constraints = __tuple_constraints<_T1, _T2>;
+
   _CCCL_EXEC_CHECK_DISABLE
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_T1, _T2>{}),
+  template <__select_constructor _Trait                          = __constraints::__select_default_constructible(),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr __pair_base() noexcept(is_nothrow_default_constructible_v<_T1>
                                              && is_nothrow_default_constructible_v<_T2>)
@@ -244,7 +248,7 @@ struct __pair_base<_T1, _T2, true>
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_T1, _T2>{}),
+  template <__select_constructor _Trait                          = __constraints::__select_default_constructible(),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API explicit constexpr __pair_base() noexcept(
     is_nothrow_default_constructible_v<_T1> && is_nothrow_default_constructible_v<_T2>)
@@ -300,18 +304,19 @@ protected:
 template <class _T1, class _T2>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 {
-  using __base = __pair_base<_T1, _T2>;
+  using __base        = __pair_base<_T1, _T2>;
+  using __constraints = __tuple_constraints<_T1, _T2>;
 
   using first_type  = _T1;
   using second_type = _T2;
 
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_T1, _T2>{}),
+  template <__select_constructor _Trait                          = __constraints::__select_default_constructible(),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr pair() noexcept(is_nothrow_default_constructible_v<_T1> && is_nothrow_default_constructible_v<_T2>)
       : __base()
   {}
 
-  template <__select_constructor _Trait = ::cuda::std::__tuple_select_default_constructible(__tuple_types<_T1, _T2>{}),
+  template <__select_constructor _Trait                          = __constraints::__select_default_constructible(),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API explicit constexpr pair() noexcept(is_nothrow_default_constructible_v<_T1>
                                                && is_nothrow_default_constructible_v<_T2>)
@@ -323,33 +328,31 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   _CCCL_HIDE_FROM_ABI pair(pair&&)      = default;
 
   // element wise constructors
-  template <__select_constructor _Trait = __tuple_select_variadic_copy_constructible_v<__tuple_types<_T1, _T2>>,
+  template <__select_constructor _Trait = __constraints::__select_variadic_copy_constructible(),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr pair(const _T1& __t1, const _T2& __t2) noexcept(
     is_nothrow_copy_constructible_v<_T1> && is_nothrow_copy_constructible_v<_T2>)
       : __base(__t1, __t2)
   {}
-  template <__select_constructor _Trait = __tuple_select_variadic_copy_constructible_v<__tuple_types<_T1, _T2>>,
+  template <__select_constructor _Trait = __constraints::__select_variadic_copy_constructible(),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API explicit constexpr pair(const _T1& __t1, const _T2& __t2) noexcept(
     is_nothrow_copy_constructible_v<_T1> && is_nothrow_copy_constructible_v<_T2>)
       : __base(__t1, __t2)
   {}
 
-  template <class _U1 = _T1,
-            class _U2 = _T2,
-            __select_constructor _Trait =
-              __tuple_select_variadic_constructible_v<__tuple_types<_T1, _T2>, __tuple_types<_U1, _U2>>,
+  template <class _U1                   = _T1,
+            class _U2                   = _T2,
+            __select_constructor _Trait = __constraints::__select_variadic_constructible(__tuple_types<_U1, _U2>{}),
             enable_if_t<__can_construct_implicitly<_Trait>, int> = 0>
   _CCCL_API constexpr pair(_U1&& __u1, _U2&& __u2) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(::cuda::std::forward<_U1>(__u1), ::cuda::std::forward<_U2>(__u2))
   {}
 
-  template <class _U1 = _T1,
-            class _U2 = _T2,
-            __select_constructor _Trait =
-              __tuple_select_variadic_constructible_v<__tuple_types<_T1, _T2>, __tuple_types<_U1, _U2>>,
+  template <class _U1                   = _T1,
+            class _U2                   = _T2,
+            __select_constructor _Trait = __constraints::__select_variadic_constructible(__tuple_types<_U1, _U2>{}),
             enable_if_t<__can_construct_explicitly<_Trait>, int> = 0>
   _CCCL_API explicit constexpr pair(_U1&& __u1, _U2&& __u2) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
@@ -357,10 +360,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   {}
 
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY)
-  template <class _U1 = _T1,
-            class _U2 = _T2,
-            __select_constructor _Trait =
-              __tuple_select_variadic_constructible_v<__tuple_types<_T1, _T2>, __tuple_types<_U1, _U2>>,
+  template <class _U1                   = _T1,
+            class _U2                   = _T2,
+            __select_constructor _Trait = __constraints::__select_variadic_constructible(__tuple_types<_U1, _U2>{}),
             enable_if_t<__is_deleted<_Trait>, int> = 0>
   constexpr pair(_U1&&, _U2&&) = delete;
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY


### PR DESCRIPTION
We are experiencing memory consumption issues recently. One of the major changes was a rewrite of tuple constraints to support the new tuple like constructors.

This refactors the machinery to be closer to what we had previously in hopes it reduces the memory consumption