### PR TITLE
[STF][trivial] Forward declare stf_ctx_handle in C-STF header place section

### DIFF
--- a/c/experimental/stf/include/cccl/c/experimental/stf/stf.h
+++ b/c/experimental/stf/include/cccl/c/experimental/stf/stf.h
@@ -121,6 +121,11 @@ typedef struct stf_exec_place_scope_opaque_t* stf_exec_place_scope_handle;
 //! stf_exec_place_resources_destroy().
 typedef struct stf_exec_place_resources_opaque_t* stf_exec_place_resources_handle;
 
+//! \brief Forward declaration of \c stf_ctx_handle (full definition appears
+//! below in the context section). Declared here so the
+//! stf_ctx_get_place_resources() accessor can refer to it.
+typedef struct stf_ctx_handle_t* stf_ctx_handle;
+
 //! \brief 4D position (coordinates) for partition mapping.
 //! Layout matches C++ pos4 for use as partition function arguments/result.
 typedef struct stf_pos4
@@ -335,8 +340,7 @@ int stf_data_place_allocation_is_stream_ordered(stf_data_place_handle h);
 //!
 //! Context stores the state of the STF library and serves as entry point for all API calls.
 //! Must be created with stf_ctx_create() or stf_ctx_create_graph() and destroyed with stf_ctx_finalize().
-
-typedef struct stf_ctx_handle_t* stf_ctx_handle;
+//! (Forward declared earlier in the place section.)
 
 //!
 //! \brief Opaque handle for logical data


### PR DESCRIPTION
## Summary
- Moves the `stf_ctx_handle` typedef forward into the place section of the C-STF public header (`c/experimental/stf/include/cccl/c/experimental/stf/stf.h`), so the `stf_ctx_get_place_resources()` accessor can refer to it without relying on a definition that otherwise appears later in the file.
- Leaves a short breadcrumb comment at the original location noting it is now forward declared earlier.

This is a purely cosmetic / readability change extracted as a tiny standalone PR; there is no behavioral change.

## Test plan
- [x] `pre-commit run --files c/experimental/stf/include/cccl/c/experimental/stf/stf.h` (clang-format, codespell, etc.) passes.
- Header-only change; nothing to run at runtime.