### PR TITLE
Improve NV_IF_ELSE_TARGET formatting in segmented reduce dispatch

### DIFF
--- a/cub/cub/device/dispatch/dispatch_segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_segmented_reduce.cuh
@@ -98,13 +98,15 @@ public:
   [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const
     -> SegmentedReducePolicy
   {
-    NV_IF_ELSE_TARGET(
-      NV_IS_HOST,
-      (const int ptx_version = cc.get() * 10; SegmentedReducePolicy policy{};
-       extract_policy_dispatch_t dispatch{policy};
-       PolicyHub::MaxPolicy::Invoke(ptx_version, dispatch);
-       return policy;),
-      (return convert_policy<typename PolicyHub::MaxPolicy::ActivePolicy>();));
+    NV_IF_ELSE_TARGET(NV_IS_HOST,
+                      ({
+                        const int ptx_version = cc.get() * 10;
+                        SegmentedReducePolicy policy{};
+                        extract_policy_dispatch_t dispatch{policy};
+                        PolicyHub::MaxPolicy::Invoke(ptx_version, dispatch);
+                        return policy;
+                      }),
+                      (return convert_policy<typename PolicyHub::MaxPolicy::ActivePolicy>();));
   }
 };
 } // namespace detail::segmented_reduce


### PR DESCRIPTION
## Summary
- Use compound statement expression `({ ... })` for the host branch of `NV_IF_ELSE_TARGET` in the segmented reduce policy selector, as suggested by @davebayer in https://github.com/NVIDIA/cccl/pull/9686#discussion_r3527103869

## Test plan
- [ ] No functional change, formatting only

🤖 Generated with [Claude Code](https://claude.com/claude-code)