### PR TITLE
Tuning policy cleanup 1/2

### DIFF
--- a/cub/test/catch2_test_device_adjacent_difference_env.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_env.cu
@@ -242,7 +242,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRight can be tuned", "[adjacent_diff
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("AdjacentDifferencePolicy", "[adjacent_difference][device]")
+C2H_TEST("Test AdjacentDifferencePolicy properties", "[adjacent_difference][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::AdjacentDifferencePolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::AdjacentDifferencePolicy>);

--- a/cub/test/catch2_test_device_adjacent_difference_env.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_env.cu
@@ -14,6 +14,8 @@ struct stream_registry_factory_t;
 
 #include <cuda/__execution/tune.h>
 
+#include <sstream>
+
 #include "catch2_test_env_launch_helper.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceAdjacentDifference::SubtractLeftCopy, device_adjacent_difference_subtract_left_copy);
@@ -270,5 +272,13 @@ C2H_TEST("Test AdjacentDifferencePolicy properties", "[adjacent_difference][devi
   // comparison
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_adjacent_difference_env.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_env.cu
@@ -273,12 +273,14 @@ C2H_TEST("Test AdjacentDifferencePolicy properties", "[adjacent_difference][devi
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1)
+          == "AdjacentDifferencePolicy { .threads_per_block = 128, .items_per_thread = 7"
+             ", .load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE, .load_modifier = LOAD_LDG"
+             ", .store_algorithm = BLOCK_STORE_WARP_TRANSPOSE }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_find_bound_sorted_values_env.cu
+++ b/cub/test/catch2_test_device_find_bound_sorted_values_env.cu
@@ -11,6 +11,8 @@ struct stream_registry_factory_t;
 
 #include <thrust/device_vector.h>
 
+#include <sstream>
+
 #include "catch2_test_env_launch_helper.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceFind::LowerBoundSortedValues, device_lower_bound_sorted_values);
@@ -152,5 +154,13 @@ C2H_TEST("Test FindBoundSortedValuesPolicy properties", "[find][device][binary-s
   // comparison
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_find_bound_sorted_values_env.cu
+++ b/cub/test/catch2_test_device_find_bound_sorted_values_env.cu
@@ -155,12 +155,13 @@ C2H_TEST("Test FindBoundSortedValuesPolicy properties", "[find][device][binary-s
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1)
+          == "FindBoundSortedValuesPolicy { .threads_per_block = 256, .items_per_thread = 15"
+             ", .load_modifier = LOAD_LDG }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_find_bound_sorted_values_env.cu
+++ b/cub/test/catch2_test_device_find_bound_sorted_values_env.cu
@@ -133,7 +133,7 @@ C2H_TEST("Device UpperBoundSortedValues uses environment", "[find][device][binar
 }
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("FindBoundSortedValuesPolicy", "[find][device][binary-search]")
+C2H_TEST("Test FindBoundSortedValuesPolicy properties", "[find][device][binary-search]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::FindBoundSortedValuesPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::FindBoundSortedValuesPolicy>);

--- a/cub/test/catch2_test_device_find_env.cu
+++ b/cub/test/catch2_test_device_find_env.cu
@@ -16,6 +16,8 @@ struct stream_registry_factory_t;
 #include <cuda/iterator>
 #include <cuda/std/execution>
 
+#include <sstream>
+
 #include "catch2_test_env_launch_helper.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceFind::FindIf, device_find_if);
@@ -558,5 +560,13 @@ C2H_TEST("Test FindIfPolicy properties", "[find][device]")
   // comparison
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_find_env.cu
+++ b/cub/test/catch2_test_device_find_env.cu
@@ -539,7 +539,7 @@ C2H_TEST("Device FindIf can be tuned", "[find][device]", block_sizes)
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("FindIfPolicy", "[find][device]")
+C2H_TEST("Test FindIfPolicy properties", "[find][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::FindIfPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::FindIfPolicy>);

--- a/cub/test/catch2_test_device_find_env.cu
+++ b/cub/test/catch2_test_device_find_env.cu
@@ -561,12 +561,13 @@ C2H_TEST("Test FindIfPolicy properties", "[find][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1)
+          == "FindIfPolicy { .threads_per_block = 128, .items_per_thread = 7, .vec_size = 4"
+             ", .load_modifier = LOAD_LDG }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_for_env.cu
+++ b/cub/test/catch2_test_device_for_env.cu
@@ -232,7 +232,7 @@ C2H_TEST("DeviceFor::ForEachCopy can be tuned", "[for][device]", block_sizes)
 }
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("ForPolicy", "[for][device]")
+C2H_TEST("Test ForPolicy properties", "[for][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::ForPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ForPolicy>);

--- a/cub/test/catch2_test_device_for_env.cu
+++ b/cub/test/catch2_test_device_for_env.cu
@@ -12,6 +12,8 @@
 #include <cuda/devices>
 #include <cuda/stream>
 
+#include <sstream>
+
 #include <c2h/catch2_test_helper.h>
 
 struct square_ref_op
@@ -250,5 +252,13 @@ C2H_TEST("Test ForPolicy properties", "[for][device]")
   // comparison
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_for_env.cu
+++ b/cub/test/catch2_test_device_for_env.cu
@@ -253,12 +253,11 @@ C2H_TEST("Test ForPolicy properties", "[for][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1) == "ForPolicy { .threads_per_block = 128, .items_per_thread = 4 }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_histogram_env.cu
+++ b/cub/test/catch2_test_device_histogram_env.cu
@@ -15,6 +15,8 @@ struct stream_registry_factory_t;
 #include <cuda/std/array>
 #include <cuda/std/execution>
 
+#include <sstream>
+
 #include "catch2_test_env_launch_helper.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceHistogram::HistogramEven, histogram_even);
@@ -1761,5 +1763,13 @@ C2H_TEST("Test HistogramPolicy properties", "[histogram][device]")
   // comparison
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_histogram_env.cu
+++ b/cub/test/catch2_test_device_histogram_env.cu
@@ -1733,7 +1733,7 @@ C2H_TEST("DeviceHistogram::MultiHistogramRange can be tuned", "[histogram][devic
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("HistogramPolicy", "[histogram][device]")
+C2H_TEST("Test HistogramPolicy properties", "[histogram][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::HistogramPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::HistogramPolicy>);

--- a/cub/test/catch2_test_device_histogram_env.cu
+++ b/cub/test/catch2_test_device_histogram_env.cu
@@ -1764,12 +1764,14 @@ C2H_TEST("Test HistogramPolicy properties", "[histogram][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1)
+          == "HistogramPolicy { .threads_per_block = 128, .pixels_per_thread = 7, .vec_size = 4"
+             ", .load_algorithm = BLOCK_LOAD_DIRECT, .load_modifier = LOAD_LDG, .rle_compress = 0"
+             ", .mem_preference = SMEM, .use_work_stealing = 0, .init_kernel_pdl_trigger_max_bins = 2048 }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_memcpy_env.cu
+++ b/cub/test/catch2_test_device_memcpy_env.cu
@@ -17,6 +17,8 @@ struct stream_registry_factory_t;
 #include <cuda/iterator>
 #include <cuda/stream>
 
+#include <sstream>
+
 #include "catch2_test_env_launch_helper.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceMemcpy::Batched, device_memcpy_batched);
@@ -237,5 +239,15 @@ C2H_TEST("Test BatchedCopyPolicy properties", "[memcpy][device]")
 
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1_small).empty());
+  REQUIRE(!to_string(p1_large).empty());
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_memcpy_env.cu
+++ b/cub/test/catch2_test_device_memcpy_env.cu
@@ -240,14 +240,31 @@ C2H_TEST("Test BatchedCopyPolicy properties", "[memcpy][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1_small).empty());
-  REQUIRE(!to_string(p1_large).empty());
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(
+    to_string(p1_small)
+    == "BatchedCopySmallBufferPolicy { .threads_per_block = 128, .buffers_per_thread = 4"
+       ", .bytes_per_thread = 8, .prefer_pow2_bits = 0, .block_level_tile_size = 8192"
+       ", .warp_level_threshold = 128, .block_level_threshold = 8192"
+       ", .buffer_lookback_delay = LookbackDelayPolicy { .kind = LookbackDelayAlgorithm::fixed_delay"
+       ", .delay = 350, .l2_write_latency = 450 }"
+       ", .block_lookback_delay = LookbackDelayPolicy { .kind = LookbackDelayAlgorithm::fixed_delay"
+       ", .delay = 350, .l2_write_latency = 450 } }");
+  REQUIRE(to_string(p1_large) == "BatchedCopyLargeBufferPolicy { .threads_per_block = 256, .bytes_per_thread = 32 }");
+  REQUIRE(
+    to_string(p1)
+    == "BatchedCopyPolicy { .small_buffer = BatchedCopySmallBufferPolicy { .threads_per_block = 128"
+       ", .buffers_per_thread = 4, .bytes_per_thread = 8, .prefer_pow2_bits = 0"
+       ", .block_level_tile_size = 8192, .warp_level_threshold = 128, .block_level_threshold = 8192"
+       ", .buffer_lookback_delay = LookbackDelayPolicy { .kind = LookbackDelayAlgorithm::fixed_delay"
+       ", .delay = 350, .l2_write_latency = 450 }"
+       ", .block_lookback_delay = LookbackDelayPolicy { .kind = LookbackDelayAlgorithm::fixed_delay"
+       ", .delay = 350, .l2_write_latency = 450 } }"
+       ", .large_buffer = BatchedCopyLargeBufferPolicy { .threads_per_block = 256"
+       ", .bytes_per_thread = 32 } }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_memcpy_env.cu
+++ b/cub/test/catch2_test_device_memcpy_env.cu
@@ -181,7 +181,7 @@ C2H_TEST("DeviceMemcpy::Batched can be tuned", "[memcpy][device]", block_sizes)
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("BatchedCopyPolicy", "[memcpy][device]")
+C2H_TEST("Test BatchedCopyPolicy properties", "[memcpy][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::BatchedCopyPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::BatchedCopyPolicy>);

--- a/cub/test/catch2_test_device_memcpy_env.cu
+++ b/cub/test/catch2_test_device_memcpy_env.cu
@@ -186,44 +186,55 @@ C2H_TEST("BatchedCopyPolicy", "[memcpy][device]")
   STATIC_REQUIRE(::cuda::std::semiregular<cub::BatchedCopyPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::BatchedCopyPolicy>);
 
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::BatchedCopySmallBufferPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::BatchedCopySmallBufferPolicy>);
+
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::BatchedCopyLargeBufferPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::BatchedCopyLargeBufferPolicy>);
+
   // aggregate init
-  constexpr auto p1 = cub::BatchedCopyPolicy{
-    cub::BatchedCopySmallBufferPolicy{
-      128,
-      4,
-      8,
-      false,
-      256 * 32,
-      128,
-      8 * 1024,
-      cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 350, 450},
-      cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 350, 450}},
-    cub::BatchedCopyLargeBufferPolicy{256, 32}};
+  constexpr auto p1_small = cub::BatchedCopySmallBufferPolicy{
+    128,
+    4,
+    8,
+    false,
+    256 * 32,
+    128,
+    8 * 1024,
+    cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 350, 450},
+    cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 350, 450}};
+  constexpr auto p1_large = cub::BatchedCopyLargeBufferPolicy{256, 32};
+  constexpr auto p1       = cub::BatchedCopyPolicy{p1_small, p1_large};
 
 #  if _CCCL_STD_VER >= 2020
   // designated init
-  constexpr auto p2 = cub::BatchedCopyPolicy{
-    .small_buffer =
-      cub::BatchedCopySmallBufferPolicy{
-        .threads_per_block     = 128,
-        .buffers_per_thread    = 4,
-        .bytes_per_thread      = 8,
-        .prefer_pow2_bits      = false,
-        .block_level_tile_size = 256 * 32,
-        .warp_level_threshold  = 128,
-        .block_level_threshold = 8 * 1024,
-        .buffer_lookback_delay =
-          cub::LookbackDelayPolicy{
-            .kind = cub::LookbackDelayAlgorithm::fixed_delay, .delay = 350, .l2_write_latency = 450},
-        .block_lookback_delay =
-          cub::LookbackDelayPolicy{
-            .kind = cub::LookbackDelayAlgorithm::fixed_delay, .delay = 350, .l2_write_latency = 450}},
-    .large_buffer = cub::BatchedCopyLargeBufferPolicy{.threads_per_block = 256, .bytes_per_thread = 32}};
+  constexpr auto p2_small = cub::BatchedCopySmallBufferPolicy{
+    .threads_per_block     = 128,
+    .buffers_per_thread    = 4,
+    .bytes_per_thread      = 8,
+    .prefer_pow2_bits      = false,
+    .block_level_tile_size = 256 * 32,
+    .warp_level_threshold  = 128,
+    .block_level_threshold = 8 * 1024,
+    .buffer_lookback_delay =
+      cub::LookbackDelayPolicy{.kind = cub::LookbackDelayAlgorithm::fixed_delay, .delay = 350, .l2_write_latency = 450},
+    .block_lookback_delay = cub::LookbackDelayPolicy{
+      .kind = cub::LookbackDelayAlgorithm::fixed_delay, .delay = 350, .l2_write_latency = 450}};
+  constexpr auto p2_large = cub::BatchedCopyLargeBufferPolicy{.threads_per_block = 256, .bytes_per_thread = 32};
+  constexpr auto p2       = cub::BatchedCopyPolicy{.small_buffer = p2_small, .large_buffer = p2_large};
 #  else // _CCCL_STD_VER >= 2020
-  constexpr auto p2 = p1;
+  constexpr auto p2_small = p1_small;
+  constexpr auto p2_large = p1_large;
+  constexpr auto p2       = p1;
 #  endif // _CCCL_STD_VER >= 2020
 
   // comparison
+  STATIC_REQUIRE(p1_small == p2_small);
+  STATIC_REQUIRE_FALSE(p1_small != p2_small);
+
+  STATIC_REQUIRE(p1_large == p2_large);
+  STATIC_REQUIRE_FALSE(p1_large != p2_large);
+
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 }

--- a/cub/test/catch2_test_device_merge_env.cu
+++ b/cub/test/catch2_test_device_merge_env.cu
@@ -410,12 +410,14 @@ C2H_TEST("Test MergePolicy properties", "[merge][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1)
+          == "MergePolicy { .threads_per_block = 128, .items_per_thread = 7, .load_modifier = LOAD_LDG"
+             ", .store_algorithm = BLOCK_STORE_WARP_TRANSPOSE, .use_bulk_copy_for_keys = 1"
+             ", .use_bulk_copy_for_values = 0, .unroll = 0 }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_merge_env.cu
+++ b/cub/test/catch2_test_device_merge_env.cu
@@ -11,6 +11,8 @@ struct stream_registry_factory_t;
 
 #include <thrust/device_vector.h>
 
+#include <sstream>
+
 #include "catch2_test_env_launch_helper.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceMerge::MergeKeys, merge_keys);
@@ -407,5 +409,13 @@ C2H_TEST("Test MergePolicy properties", "[merge][device]")
   // comparison
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_merge_env.cu
+++ b/cub/test/catch2_test_device_merge_env.cu
@@ -381,7 +381,7 @@ TEST_CASE("DeviceMerge::MergePairs works with unroll disabled", "[merge][device]
 }
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("MergePolicy", "[merge][device]")
+C2H_TEST("Test MergePolicy properties", "[merge][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::MergePolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::MergePolicy>);

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -609,12 +609,14 @@ C2H_TEST("Test MergeSortPolicy properties", "[merge_sort][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1)
+          == "MergeSortPolicy { .threads_per_block = 256, .items_per_thread = 11"
+             ", .load_algorithm = BLOCK_LOAD_DIRECT, .load_modifier = LOAD_DEFAULT"
+             ", .store_algorithm = BLOCK_STORE_DIRECT, .unroll = 1 }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -16,6 +16,8 @@ struct stream_registry_factory_t;
 #include <cuda/devices>
 #include <cuda/stream>
 
+#include <sstream>
+
 #include "catch2_test_env_launch_helper.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceMergeSort::SortPairs, device_merge_sort_pairs);
@@ -606,5 +608,13 @@ C2H_TEST("Test MergeSortPolicy properties", "[merge_sort][device]")
   // comparison
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -578,7 +578,7 @@ TEST_CASE("DeviceMergeSort::SortKeys works with unroll disabled", "[merge_sort][
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("MergeSortPolicy", "[merge_sort][device]")
+C2H_TEST("Test MergeSortPolicy properties", "[merge_sort][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::MergeSortPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::MergeSortPolicy>);

--- a/cub/test/catch2_test_device_partition_env.cu
+++ b/cub/test/catch2_test_device_partition_env.cu
@@ -388,7 +388,7 @@ C2H_TEST("DevicePartition::If three-way can be tuned", "[partition][device]", bl
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("ThreeWayPartitionPolicy", "[partition][device]")
+C2H_TEST("Test ThreeWayPartitionPolicy properties", "[partition][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::ThreeWayPartitionPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ThreeWayPartitionPolicy>);
@@ -420,7 +420,7 @@ C2H_TEST("ThreeWayPartitionPolicy", "[partition][device]")
   STATIC_REQUIRE_FALSE(p1 != p2);
 }
 
-C2H_TEST("PartitionPolicy", "[partition][device]")
+C2H_TEST("Test PartitionPolicy properties", "[partition][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::PartitionPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::PartitionPolicy>);

--- a/cub/test/catch2_test_device_partition_env.cu
+++ b/cub/test/catch2_test_device_partition_env.cu
@@ -15,6 +15,8 @@ struct stream_registry_factory_t;
 #include <cuda/__execution/tune.h>
 #include <cuda/iterator>
 
+#include <sstream>
+
 #include "catch2_test_device_select_common.cuh"
 #include "catch2_test_env_launch_helper.h"
 
@@ -418,6 +420,14 @@ C2H_TEST("Test ThreeWayPartitionPolicy properties", "[partition][device]")
   // comparison
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1).empty());
 }
 
 C2H_TEST("Test PartitionPolicy properties", "[partition][device]")
@@ -450,5 +460,13 @@ C2H_TEST("Test PartitionPolicy properties", "[partition][device]")
   // comparison
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_partition_env.cu
+++ b/cub/test/catch2_test_device_partition_env.cu
@@ -419,4 +419,36 @@ C2H_TEST("ThreeWayPartitionPolicy", "[partition][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 }
+
+C2H_TEST("PartitionPolicy", "[partition][device]")
+{
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::PartitionPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::PartitionPolicy>);
+
+  // aggregate init
+  constexpr auto p1 = cub::PartitionPolicy{
+    128,
+    10,
+    cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+    cub::CacheLoadModifier::LOAD_DEFAULT,
+    cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_SCANS,
+    cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 350, 450}};
+
+#  if _CCCL_STD_VER >= 2020
+  // designated init
+  constexpr auto p2 = cub::PartitionPolicy{
+    .threads_per_block = 128,
+    .items_per_thread  = 10,
+    .load_algorithm    = cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+    .load_modifier     = cub::CacheLoadModifier::LOAD_DEFAULT,
+    .scan_algorithm    = cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_SCANS,
+    .lookback_delay    = cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 350, 450}};
+#  else // _CCCL_STD_VER >= 2020
+  constexpr auto p2 = p1;
+#  endif // _CCCL_STD_VER >= 2020
+
+  // comparison
+  STATIC_REQUIRE(p1 == p2);
+  STATIC_REQUIRE_FALSE(p1 != p2);
+}
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_partition_env.cu
+++ b/cub/test/catch2_test_device_partition_env.cu
@@ -421,13 +421,17 @@ C2H_TEST("Test ThreeWayPartitionPolicy properties", "[partition][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1)
+          == "ThreeWayPartitionPolicy { .threads_per_block = 256, .items_per_thread = 9"
+             ", .load_algorithm = BLOCK_LOAD_DIRECT, .load_modifier = LOAD_DEFAULT"
+             ", .scan_algorithm = BLOCK_SCAN_WARP_SCANS"
+             ", .lookback_delay = LookbackDelayPolicy { .kind = LookbackDelayAlgorithm::fixed_delay"
+             ", .delay = 350, .l2_write_latency = 450 } }");
 }
 
 C2H_TEST("Test PartitionPolicy properties", "[partition][device]")
@@ -461,12 +465,16 @@ C2H_TEST("Test PartitionPolicy properties", "[partition][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1)
+          == "PartitionPolicy { .threads_per_block = 128, .items_per_thread = 10"
+             ", .load_algorithm = BLOCK_LOAD_DIRECT, .load_modifier = LOAD_DEFAULT"
+             ", .scan_algorithm = BLOCK_SCAN_WARP_SCANS"
+             ", .lookback_delay = LookbackDelayPolicy { .kind = LookbackDelayAlgorithm::fixed_delay"
+             ", .delay = 350, .l2_write_latency = 450 } }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_radix_sort_env.cu
@@ -14,6 +14,8 @@ struct stream_registry_factory_t;
 #include <cuda/devices>
 #include <cuda/stream>
 
+#include <sstream>
+
 #include "catch2_test_env_launch_helper.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceRadixSort::SortPairs, device_radix_sort_pairs);
@@ -1697,5 +1699,21 @@ C2H_TEST("Test RadixSortPolicy properties", "[radix_sort][device]")
 
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1_histogram).empty());
+  REQUIRE(!to_string(p1_exclusive_sum).empty());
+  REQUIRE(!to_string(p1_onesweep).empty());
+  REQUIRE(!to_string(p1_downsweep).empty());
+  REQUIRE(!to_string(p1_alt_downsweep).empty());
+  REQUIRE(!to_string(p1_upsweep).empty());
+  REQUIRE(!to_string(p1_alt_upsweep).empty());
+  REQUIRE(!to_string(p1_single_tile).empty());
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_radix_sort_env.cu
@@ -1544,85 +1544,157 @@ C2H_TEST("RadixSortPolicy", "[radix_sort][device]")
   STATIC_REQUIRE(::cuda::std::semiregular<cub::RadixSortPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::RadixSortPolicy>);
 
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::RadixSortHistogramPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::RadixSortHistogramPolicy>);
+
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::RadixSortExclusiveSumPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::RadixSortExclusiveSumPolicy>);
+
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::RadixSortOnesweepPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::RadixSortOnesweepPolicy>);
+
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::RadixSortDownsweepPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::RadixSortDownsweepPolicy>);
+
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::RadixSortUpsweepPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::RadixSortUpsweepPolicy>);
+
   // aggregate init
+  constexpr auto p1_histogram     = cub::RadixSortHistogramPolicy{256, 8, 1, 8};
+  constexpr auto p1_exclusive_sum = cub::RadixSortExclusiveSumPolicy{256, 8};
+  constexpr auto p1_onesweep      = cub::RadixSortOnesweepPolicy{
+    256, 21, cub::RADIX_SORT_STORE_DIRECT, cub::RADIX_RANK_MATCH_EARLY_COUNTS_ANY, cub::BLOCK_SCAN_WARP_SCANS, 1, 8};
+  constexpr auto p1_scan = cub::ScanPolicy{
+    cub::ScanAlgorithm::lookback,
+    cub::ScanLookbackPolicy{
+      512,
+      23,
+      cub::BLOCK_LOAD_WARP_TRANSPOSE,
+      cub::LOAD_DEFAULT,
+      cub::BLOCK_STORE_WARP_TRANSPOSE,
+      cub::BLOCK_SCAN_RAKING_MEMOIZE,
+      cub::LookbackDelayPolicy{}},
+    {}};
+  constexpr auto p1_downsweep = cub::RadixSortDownsweepPolicy{
+    256, 25, cub::BLOCK_LOAD_TRANSPOSE, cub::LOAD_DEFAULT, cub::RADIX_RANK_MATCH, cub::BLOCK_SCAN_WARP_SCANS, 7};
+  constexpr auto p1_alt_downsweep = cub::RadixSortDownsweepPolicy{
+    192, 39, cub::BLOCK_LOAD_TRANSPOSE, cub::LOAD_DEFAULT, cub::RADIX_RANK_MEMOIZE, cub::BLOCK_SCAN_WARP_SCANS, 6};
+  constexpr auto p1_upsweep     = cub::RadixSortUpsweepPolicy{256, 25, cub::LOAD_DEFAULT, 7};
+  constexpr auto p1_alt_upsweep = cub::RadixSortUpsweepPolicy{192, 39, cub::LOAD_DEFAULT, 6};
+  constexpr auto p1_single_tile = cub::RadixSortDownsweepPolicy{
+    256, 19, cub::BLOCK_LOAD_DIRECT, cub::LOAD_LDG, cub::RADIX_RANK_MEMOIZE, cub::BLOCK_SCAN_WARP_SCANS, 6};
   constexpr auto p1 = cub::RadixSortPolicy{
     cub::RadixSortAlgorithm::onesweep,
-    cub::RadixSortHistogramPolicy{256, 8, 1, 8},
-    cub::RadixSortExclusiveSumPolicy{256, 8},
-    cub::RadixSortOnesweepPolicy{
-      256, 21, cub::RADIX_SORT_STORE_DIRECT, cub::RADIX_RANK_MATCH_EARLY_COUNTS_ANY, cub::BLOCK_SCAN_WARP_SCANS, 1, 8},
-    cub::ScanPolicy{
-      cub::ScanAlgorithm::lookback,
-      cub::ScanLookbackPolicy{
-        512,
-        23,
-        cub::BLOCK_LOAD_WARP_TRANSPOSE,
-        cub::LOAD_DEFAULT,
-        cub::BLOCK_STORE_WARP_TRANSPOSE,
-        cub::BLOCK_SCAN_RAKING_MEMOIZE,
-        cub::LookbackDelayPolicy{}},
-      {}},
-    cub::RadixSortDownsweepPolicy{
-      256, 25, cub::BLOCK_LOAD_TRANSPOSE, cub::LOAD_DEFAULT, cub::RADIX_RANK_MATCH, cub::BLOCK_SCAN_WARP_SCANS, 7},
-    cub::RadixSortDownsweepPolicy{
-      192, 39, cub::BLOCK_LOAD_TRANSPOSE, cub::LOAD_DEFAULT, cub::RADIX_RANK_MEMOIZE, cub::BLOCK_SCAN_WARP_SCANS, 6},
-    cub::RadixSortUpsweepPolicy{256, 25, cub::LOAD_DEFAULT, 7},
-    cub::RadixSortUpsweepPolicy{192, 39, cub::LOAD_DEFAULT, 6},
-    cub::RadixSortDownsweepPolicy{
-      256, 19, cub::BLOCK_LOAD_DIRECT, cub::LOAD_LDG, cub::RADIX_RANK_MEMOIZE, cub::BLOCK_SCAN_WARP_SCANS, 6}};
+    p1_histogram,
+    p1_exclusive_sum,
+    p1_onesweep,
+    p1_scan,
+    p1_downsweep,
+    p1_alt_downsweep,
+    p1_upsweep,
+    p1_alt_upsweep,
+    p1_single_tile};
 
 #  if _CCCL_STD_VER >= 2020
   // designated init
+  constexpr auto p2_histogram = cub::RadixSortHistogramPolicy{
+    .threads_per_block = 256, .items_per_thread = 8, .private_partitions = 1, .radix_bits = 8};
+  constexpr auto p2_exclusive_sum = cub::RadixSortExclusiveSumPolicy{.threads_per_block = 256, .radix_bits = 8};
+  constexpr auto p2_onesweep      = cub::RadixSortOnesweepPolicy{
+         .threads_per_block       = 256,
+         .items_per_thread        = 21,
+         .store_algorithm         = cub::RADIX_SORT_STORE_DIRECT,
+         .rank_algorithm          = cub::RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
+         .scan_algorithm          = cub::BLOCK_SCAN_WARP_SCANS,
+         .rank_private_partitions = 1,
+         .radix_bits              = 8};
+  constexpr auto p2_scan = cub::ScanPolicy{
+    .algorithm = cub::ScanAlgorithm::lookback,
+    .lookback  = {.threads_per_block = 512,
+                  .items_per_thread  = 23,
+                  .load_algorithm    = cub::BLOCK_LOAD_WARP_TRANSPOSE,
+                  .load_modifier     = cub::LOAD_DEFAULT,
+                  .store_algorithm   = cub::BLOCK_STORE_WARP_TRANSPOSE,
+                  .scan_algorithm    = cub::BLOCK_SCAN_RAKING_MEMOIZE,
+                  .lookback_delay    = {}},
+    .lookahead = {}};
+  constexpr auto p2_downsweep = cub::RadixSortDownsweepPolicy{
+    .threads_per_block = 256,
+    .items_per_thread  = 25,
+    .load_algorithm    = cub::BLOCK_LOAD_TRANSPOSE,
+    .load_modifier     = cub::LOAD_DEFAULT,
+    .rank_algorithm    = cub::RADIX_RANK_MATCH,
+    .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
+    .radix_bits        = 7};
+  constexpr auto p2_alt_downsweep = cub::RadixSortDownsweepPolicy{
+    .threads_per_block = 192,
+    .items_per_thread  = 39,
+    .load_algorithm    = cub::BLOCK_LOAD_TRANSPOSE,
+    .load_modifier     = cub::LOAD_DEFAULT,
+    .rank_algorithm    = cub::RADIX_RANK_MEMOIZE,
+    .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
+    .radix_bits        = 6};
+  constexpr auto p2_upsweep = cub::RadixSortUpsweepPolicy{
+    .threads_per_block = 256, .items_per_thread = 25, .load_modifier = cub::LOAD_DEFAULT, .radix_bits = 7};
+  constexpr auto p2_alt_upsweep = cub::RadixSortUpsweepPolicy{
+    .threads_per_block = 192, .items_per_thread = 39, .load_modifier = cub::LOAD_DEFAULT, .radix_bits = 6};
+  constexpr auto p2_single_tile = cub::RadixSortDownsweepPolicy{
+    .threads_per_block = 256,
+    .items_per_thread  = 19,
+    .load_algorithm    = cub::BLOCK_LOAD_DIRECT,
+    .load_modifier     = cub::LOAD_LDG,
+    .rank_algorithm    = cub::RADIX_RANK_MEMOIZE,
+    .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
+    .radix_bits        = 6};
   constexpr auto p2 = cub::RadixSortPolicy{
     .algorithm     = cub::RadixSortAlgorithm::onesweep,
-    .histogram     = {.threads_per_block = 256, .items_per_thread = 8, .private_partitions = 1, .radix_bits = 8},
-    .exclusive_sum = {.threads_per_block = 256, .radix_bits = 8},
-    .onesweep      = {.threads_per_block       = 256,
-                      .items_per_thread        = 21,
-                      .store_algorithm         = cub::RADIX_SORT_STORE_DIRECT,
-                      .rank_algorithm          = cub::RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
-                      .scan_algorithm          = cub::BLOCK_SCAN_WARP_SCANS,
-                      .rank_private_partitions = 1,
-                      .radix_bits              = 8},
-    .scan          = {.algorithm = cub::ScanAlgorithm::lookback,
-                      .lookback  = {.threads_per_block = 512,
-                                    .items_per_thread  = 23,
-                                    .load_algorithm    = cub::BLOCK_LOAD_WARP_TRANSPOSE,
-                                    .load_modifier     = cub::LOAD_DEFAULT,
-                                    .store_algorithm   = cub::BLOCK_STORE_WARP_TRANSPOSE,
-                                    .scan_algorithm    = cub::BLOCK_SCAN_RAKING_MEMOIZE,
-                                    .lookback_delay    = {}},
-                      .lookahead = {}},
-    .downsweep     = {.threads_per_block = 256,
-                      .items_per_thread  = 25,
-                      .load_algorithm    = cub::BLOCK_LOAD_TRANSPOSE,
-                      .load_modifier     = cub::LOAD_DEFAULT,
-                      .rank_algorithm    = cub::RADIX_RANK_MATCH,
-                      .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
-                      .radix_bits        = 7},
-    .alt_downsweep = {.threads_per_block = 192,
-                      .items_per_thread  = 39,
-                      .load_algorithm    = cub::BLOCK_LOAD_TRANSPOSE,
-                      .load_modifier     = cub::LOAD_DEFAULT,
-                      .rank_algorithm    = cub::RADIX_RANK_MEMOIZE,
-                      .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
-                      .radix_bits        = 6},
-    .upsweep = {.threads_per_block = 256, .items_per_thread = 25, .load_modifier = cub::LOAD_DEFAULT, .radix_bits = 7},
-    .alt_upsweep =
-      {.threads_per_block = 192, .items_per_thread = 39, .load_modifier = cub::LOAD_DEFAULT, .radix_bits = 6},
-    .single_tile = {
-      .threads_per_block = 256,
-      .items_per_thread  = 19,
-      .load_algorithm    = cub::BLOCK_LOAD_DIRECT,
-      .load_modifier     = cub::LOAD_LDG,
-      .rank_algorithm    = cub::RADIX_RANK_MEMOIZE,
-      .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
-      .radix_bits        = 6}};
+    .histogram     = p2_histogram,
+    .exclusive_sum = p2_exclusive_sum,
+    .onesweep      = p2_onesweep,
+    .scan          = p2_scan,
+    .downsweep     = p2_downsweep,
+    .alt_downsweep = p2_alt_downsweep,
+    .upsweep       = p2_upsweep,
+    .alt_upsweep   = p2_alt_upsweep,
+    .single_tile   = p2_single_tile};
 #  else // _CCCL_STD_VER >= 2020
-  constexpr auto p2 = p1;
+  constexpr auto p2_histogram     = p1_histogram;
+  constexpr auto p2_exclusive_sum = p1_exclusive_sum;
+  constexpr auto p2_onesweep      = p1_onesweep;
+  constexpr auto p2_scan          = p1_scan;
+  constexpr auto p2_downsweep     = p1_downsweep;
+  constexpr auto p2_alt_downsweep = p1_alt_downsweep;
+  constexpr auto p2_upsweep       = p1_upsweep;
+  constexpr auto p2_alt_upsweep   = p1_alt_upsweep;
+  constexpr auto p2_single_tile   = p1_single_tile;
+  constexpr auto p2               = p1;
 #  endif // _CCCL_STD_VER >= 2020
 
   // comparison
+  STATIC_REQUIRE(p1_histogram == p2_histogram);
+  STATIC_REQUIRE_FALSE(p1_histogram != p2_histogram);
+
+  STATIC_REQUIRE(p1_exclusive_sum == p2_exclusive_sum);
+  STATIC_REQUIRE_FALSE(p1_exclusive_sum != p2_exclusive_sum);
+
+  STATIC_REQUIRE(p1_onesweep == p2_onesweep);
+  STATIC_REQUIRE_FALSE(p1_onesweep != p2_onesweep);
+
+  STATIC_REQUIRE(p1_downsweep == p2_downsweep);
+  STATIC_REQUIRE_FALSE(p1_downsweep != p2_downsweep);
+
+  STATIC_REQUIRE(p1_alt_downsweep == p2_alt_downsweep);
+  STATIC_REQUIRE_FALSE(p1_alt_downsweep != p2_alt_downsweep);
+
+  STATIC_REQUIRE(p1_upsweep == p2_upsweep);
+  STATIC_REQUIRE_FALSE(p1_upsweep != p2_upsweep);
+
+  STATIC_REQUIRE(p1_alt_upsweep == p2_alt_upsweep);
+  STATIC_REQUIRE_FALSE(p1_alt_upsweep != p2_alt_upsweep);
+
+  STATIC_REQUIRE(p1_single_tile == p2_single_tile);
+  STATIC_REQUIRE_FALSE(p1_single_tile != p2_single_tile);
+
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 }

--- a/cub/test/catch2_test_device_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_radix_sort_env.cu
@@ -1682,6 +1682,9 @@ C2H_TEST("Test RadixSortPolicy properties", "[radix_sort][device]")
   STATIC_REQUIRE(p1_onesweep == p2_onesweep);
   STATIC_REQUIRE_FALSE(p1_onesweep != p2_onesweep);
 
+  STATIC_REQUIRE(p1_scan == p2_scan);
+  STATIC_REQUIRE_FALSE(p1_scan != p2_scan);
+
   STATIC_REQUIRE(p1_downsweep == p2_downsweep);
   STATIC_REQUIRE_FALSE(p1_downsweep != p2_downsweep);
 

--- a/cub/test/catch2_test_device_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_radix_sort_env.cu
@@ -1539,7 +1539,7 @@ TEST_CASE("DeviceRadixSort::SortPairsDescending DB decomposer+bits can be tuned"
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("RadixSortPolicy", "[radix_sort][device]")
+C2H_TEST("Test RadixSortPolicy properties", "[radix_sort][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::RadixSortPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::RadixSortPolicy>);

--- a/cub/test/catch2_test_device_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_radix_sort_env.cu
@@ -1612,14 +1612,16 @@ C2H_TEST("Test RadixSortPolicy properties", "[radix_sort][device]")
          .radix_bits              = 8};
   constexpr auto p2_scan = cub::ScanPolicy{
     .algorithm = cub::ScanAlgorithm::lookback,
-    .lookback  = {.threads_per_block = 512,
-                  .items_per_thread  = 23,
-                  .load_algorithm    = cub::BLOCK_LOAD_WARP_TRANSPOSE,
-                  .load_modifier     = cub::LOAD_DEFAULT,
-                  .store_algorithm   = cub::BLOCK_STORE_WARP_TRANSPOSE,
-                  .scan_algorithm    = cub::BLOCK_SCAN_RAKING_MEMOIZE,
-                  .lookback_delay    = {}},
-    .lookahead = {}};
+    .lookback =
+      cub::ScanLookbackPolicy{
+        .threads_per_block = 512,
+        .items_per_thread  = 23,
+        .load_algorithm    = cub::BLOCK_LOAD_WARP_TRANSPOSE,
+        .load_modifier     = cub::LOAD_DEFAULT,
+        .store_algorithm   = cub::BLOCK_STORE_WARP_TRANSPOSE,
+        .scan_algorithm    = cub::BLOCK_SCAN_RAKING_MEMOIZE,
+        .lookback_delay    = cub::LookbackDelayPolicy{}},
+    .lookahead = cub::ScanLookaheadPolicy{}};
   constexpr auto p2_downsweep = cub::RadixSortDownsweepPolicy{
     .threads_per_block = 256,
     .items_per_thread  = 25,

--- a/cub/test/catch2_test_device_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_radix_sort_env.cu
@@ -1703,20 +1703,69 @@ C2H_TEST("Test RadixSortPolicy properties", "[radix_sort][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1_histogram).empty());
-  REQUIRE(!to_string(p1_exclusive_sum).empty());
-  REQUIRE(!to_string(p1_onesweep).empty());
-  REQUIRE(!to_string(p1_downsweep).empty());
-  REQUIRE(!to_string(p1_alt_downsweep).empty());
-  REQUIRE(!to_string(p1_upsweep).empty());
-  REQUIRE(!to_string(p1_alt_upsweep).empty());
-  REQUIRE(!to_string(p1_single_tile).empty());
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1_histogram)
+          == "RadixSortHistogramPolicy { .threads_per_block = 256, .items_per_thread = 8"
+             ", .private_partitions = 1, .radix_bits = 8 }");
+  REQUIRE(to_string(p1_exclusive_sum) == "RadixSortExclusiveSumPolicy { .threads_per_block = 256, .radix_bits = 8 }");
+  REQUIRE(to_string(p1_onesweep)
+          == "RadixSortOnesweepPolicy { .threads_per_block = 256, .items_per_thread = 21"
+             ", .store_algorithm = RADIX_SORT_STORE_DIRECT"
+             ", .rank_algorithm = RADIX_RANK_MATCH_EARLY_COUNTS_ANY"
+             ", .scan_algorithm = BLOCK_SCAN_WARP_SCANS, .rank_private_partitions = 1, .radix_bits = 8 }");
+  REQUIRE(to_string(p1_downsweep)
+          == "RadixSortDownsweepPolicy { .threads_per_block = 256, .items_per_thread = 25"
+             ", .load_algorithm = BLOCK_LOAD_TRANSPOSE, .load_modifier = LOAD_DEFAULT"
+             ", .rank_algorithm = RADIX_RANK_MATCH, .scan_algorithm = BLOCK_SCAN_WARP_SCANS"
+             ", .radix_bits = 7 }");
+  REQUIRE(to_string(p1_alt_downsweep)
+          == "RadixSortDownsweepPolicy { .threads_per_block = 192, .items_per_thread = 39"
+             ", .load_algorithm = BLOCK_LOAD_TRANSPOSE, .load_modifier = LOAD_DEFAULT"
+             ", .rank_algorithm = RADIX_RANK_MEMOIZE, .scan_algorithm = BLOCK_SCAN_WARP_SCANS"
+             ", .radix_bits = 6 }");
+  REQUIRE(to_string(p1_upsweep)
+          == "RadixSortUpsweepPolicy { .threads_per_block = 256, .items_per_thread = 25"
+             ", .load_modifier = LOAD_DEFAULT, .radix_bits = 7 }");
+  REQUIRE(to_string(p1_alt_upsweep)
+          == "RadixSortUpsweepPolicy { .threads_per_block = 192, .items_per_thread = 39"
+             ", .load_modifier = LOAD_DEFAULT, .radix_bits = 6 }");
+  REQUIRE(to_string(p1_single_tile)
+          == "RadixSortDownsweepPolicy { .threads_per_block = 256, .items_per_thread = 19"
+             ", .load_algorithm = BLOCK_LOAD_DIRECT, .load_modifier = LOAD_LDG"
+             ", .rank_algorithm = RADIX_RANK_MEMOIZE, .scan_algorithm = BLOCK_SCAN_WARP_SCANS"
+             ", .radix_bits = 6 }");
+  REQUIRE(
+    to_string(p1)
+    == "RadixSortPolicy { .algorithm = RadixSortAlgorithm::onesweep"
+       ", .histogram = RadixSortHistogramPolicy { .threads_per_block = 256, .items_per_thread = 8, .private_partitions "
+       "= 1, .radix_bits = 8 }"
+       ", .exclusive_sum = RadixSortExclusiveSumPolicy { .threads_per_block = 256, .radix_bits = 8 }"
+       ", .onesweep = RadixSortOnesweepPolicy { .threads_per_block = 256, .items_per_thread = 21, .store_algorithm = "
+       "RADIX_SORT_STORE_DIRECT, .rank_algorithm = RADIX_RANK_MATCH_EARLY_COUNTS_ANY, .scan_algorithm = "
+       "BLOCK_SCAN_WARP_SCANS, .rank_private_partitions = 1, .radix_bits = 8 }"
+       ", .scan = ScanPolicy { .algorithm = ScanAlgorithm::lookback"
+       ", .lookback = ScanLookbackPolicy { .threads_per_block = 512, .items_per_thread = 23, .load_algorithm = "
+       "BLOCK_LOAD_WARP_TRANSPOSE, .load_modifier = LOAD_DEFAULT, .store_algorithm = BLOCK_STORE_WARP_TRANSPOSE, "
+       ".scan_algorithm = BLOCK_SCAN_RAKING_MEMOIZE, .lookback_delay = LookbackDelayPolicy { .kind = "
+       "LookbackDelayAlgorithm::no_delay, .delay = 0, .l2_write_latency = 0 } }"
+       ", .lookahead = ScanLookaheadPolicy { .reduce_and_scan_warps = 0, .items_per_thread = 0, "
+       ".lookahead_items_per_thread = 0, .lookahead_stages = 2, .block_idx_stages = -1 } }"
+       ", .downsweep = RadixSortDownsweepPolicy { .threads_per_block = 256, .items_per_thread = 25, .load_algorithm = "
+       "BLOCK_LOAD_TRANSPOSE, .load_modifier = LOAD_DEFAULT, .rank_algorithm = RADIX_RANK_MATCH, .scan_algorithm = "
+       "BLOCK_SCAN_WARP_SCANS, .radix_bits = 7 }"
+       ", .alt_downsweep = RadixSortDownsweepPolicy { .threads_per_block = 192, .items_per_thread = 39, "
+       ".load_algorithm = BLOCK_LOAD_TRANSPOSE, .load_modifier = LOAD_DEFAULT, .rank_algorithm = RADIX_RANK_MEMOIZE, "
+       ".scan_algorithm = BLOCK_SCAN_WARP_SCANS, .radix_bits = 6 }"
+       ", .upsweep = RadixSortUpsweepPolicy { .threads_per_block = 256, .items_per_thread = 25, .load_modifier = "
+       "LOAD_DEFAULT, .radix_bits = 7 }"
+       ", .alt_upsweep = RadixSortUpsweepPolicy { .threads_per_block = 192, .items_per_thread = 39, .load_modifier = "
+       "LOAD_DEFAULT, .radix_bits = 6 }"
+       ", .single_tile = RadixSortDownsweepPolicy { .threads_per_block = 256, .items_per_thread = 19, .load_algorithm "
+       "= BLOCK_LOAD_DIRECT, .load_modifier = LOAD_LDG, .rank_algorithm = RADIX_RANK_MEMOIZE, .scan_algorithm = "
+       "BLOCK_SCAN_WARP_SCANS, .radix_bits = 6 } }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -31,6 +31,8 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMax, device_arg_max);
 #include <cuda/__execution/determinism.h>
 #include <cuda/__execution/require.h>
 
+#include <sstream>
+
 #include <c2h/catch2_test_helper.h>
 
 namespace stdexec = cuda::std::execution;
@@ -1130,6 +1132,16 @@ C2H_TEST("Test ReducePolicy properties", "[reduce][device]")
 
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1_multi).empty());
+  REQUIRE(!to_string(p1_single).empty());
+  REQUIRE(!to_string(p1).empty());
 }
 
 C2H_TEST("Test ReduceByKeyPolicy properties", "[reduce][device]")
@@ -1163,5 +1175,13 @@ C2H_TEST("Test ReduceByKeyPolicy properties", "[reduce][device]")
   // comparison
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -1085,60 +1085,49 @@ C2H_TEST("cub::DeviceReduce::Reduce allows no_init in env overloads", "[reduce][
 }
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test ReducePassPolicy properties", "[reduce][device]")
-{
-  STATIC_REQUIRE(::cuda::std::semiregular<cub::ReducePassPolicy>);
-  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ReducePassPolicy>);
-
-  // aggregate init
-  constexpr auto p1 = cub::ReducePassPolicy{
-    256, 16, 4, cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS, cub::CacheLoadModifier::LOAD_LDG};
-
-#  if _CCCL_STD_VER >= 2020
-  // designated init
-  constexpr auto p2 = cub::ReducePassPolicy{
-    .threads_per_block = 256,
-    .items_per_thread  = 16,
-    .vec_size          = 4,
-    .reduce_algorithm  = cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS,
-    .load_modifier     = cub::CacheLoadModifier::LOAD_LDG};
-#  else // _CCCL_STD_VER >= 2020
-  constexpr auto p2 = p1;
-#  endif // _CCCL_STD_VER >= 2020
-
-  // comparison
-  STATIC_REQUIRE(p1 == p2);
-  STATIC_REQUIRE_FALSE(p1 != p2);
-}
-
 C2H_TEST("Test ReducePolicy properties", "[reduce][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::ReducePolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ReducePolicy>);
 
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::ReducePassPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ReducePassPolicy>);
+
   // aggregate init
-  constexpr auto pass = cub::ReducePassPolicy{
+  constexpr auto p1_multi = cub::ReducePassPolicy{
     256, 16, 4, cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS, cub::CacheLoadModifier::LOAD_LDG};
-  constexpr auto p1 = cub::ReducePolicy{pass, pass};
+  constexpr auto p1_single = cub::ReducePassPolicy{
+    128, 8, 2, cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, cub::CacheLoadModifier::LOAD_DEFAULT};
+  constexpr auto p1 = cub::ReducePolicy{p1_multi, p1_single};
 
 #  if _CCCL_STD_VER >= 2020
   // designated init
-  constexpr auto p2 = cub::ReducePolicy{
-    .multi_tile  = {.threads_per_block = 256,
-                    .items_per_thread  = 16,
-                    .vec_size          = 4,
-                    .reduce_algorithm  = cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS,
-                    .load_modifier     = cub::CacheLoadModifier::LOAD_LDG},
-    .single_tile = {.threads_per_block = 256,
-                    .items_per_thread  = 16,
-                    .vec_size          = 4,
-                    .reduce_algorithm  = cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS,
-                    .load_modifier     = cub::CacheLoadModifier::LOAD_LDG}};
+  constexpr auto p2_multi = cub::ReducePassPolicy{
+    .threads_per_block = 256,
+    .items_per_thread  = 16,
+    .vec_size          = 4,
+    .reduce_algorithm  = cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS,
+    .load_modifier     = cub::CacheLoadModifier::LOAD_LDG};
+  constexpr auto p2_single = cub::ReducePassPolicy{
+    .threads_per_block = 128,
+    .items_per_thread  = 8,
+    .vec_size          = 2,
+    .reduce_algorithm  = cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY,
+    .load_modifier     = cub::CacheLoadModifier::LOAD_DEFAULT};
+  constexpr auto p2 = cub::ReducePolicy{.multi_tile = p2_multi, .single_tile = p2_single};
 #  else // _CCCL_STD_VER >= 2020
-  constexpr auto p2 = p1;
+  constexpr auto p2_multi  = p1_multi;
+  constexpr auto p2_single = p1_single;
+  constexpr auto p2        = p1;
 #  endif // _CCCL_STD_VER >= 2020
 
   // comparison
+  STATIC_REQUIRE(p1_multi == p2_multi);
+  STATIC_REQUIRE_FALSE(p1_multi != p2_multi);
+
+  STATIC_REQUIRE(p1_single == p2_single);
+  STATIC_REQUIRE_FALSE(p1_single != p2_single);
+
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 }

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -1123,7 +1123,17 @@ C2H_TEST("ReducePolicy", "[reduce][device]")
 
 #  if _CCCL_STD_VER >= 2020
   // designated init
-  constexpr auto p2 = cub::ReducePolicy{.multi_tile = pass, .single_tile = pass};
+  constexpr auto p2 = cub::ReducePolicy{
+    .multi_tile  = {.threads_per_block = 256,
+                    .items_per_thread  = 16,
+                    .vec_size          = 4,
+                    .reduce_algorithm  = cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS,
+                    .load_modifier     = cub::CacheLoadModifier::LOAD_LDG},
+    .single_tile = {.threads_per_block = 256,
+                    .items_per_thread  = 16,
+                    .vec_size          = 4,
+                    .reduce_algorithm  = cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS,
+                    .load_modifier     = cub::CacheLoadModifier::LOAD_LDG}};
 #  else // _CCCL_STD_VER >= 2020
   constexpr auto p2 = p1;
 #  endif // _CCCL_STD_VER >= 2020

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -1085,7 +1085,7 @@ C2H_TEST("cub::DeviceReduce::Reduce allows no_init in env overloads", "[reduce][
 }
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("ReducePassPolicy", "[reduce][device]")
+C2H_TEST("Test ReducePassPolicy properties", "[reduce][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::ReducePassPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ReducePassPolicy>);
@@ -1111,7 +1111,7 @@ C2H_TEST("ReducePassPolicy", "[reduce][device]")
   STATIC_REQUIRE_FALSE(p1 != p2);
 }
 
-C2H_TEST("ReducePolicy", "[reduce][device]")
+C2H_TEST("Test ReducePolicy properties", "[reduce][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::ReducePolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ReducePolicy>);
@@ -1143,7 +1143,7 @@ C2H_TEST("ReducePolicy", "[reduce][device]")
   STATIC_REQUIRE_FALSE(p1 != p2);
 }
 
-C2H_TEST("ReduceByKeyPolicy", "[reduce][device]")
+C2H_TEST("Test ReduceByKeyPolicy properties", "[reduce][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::ReduceByKeyPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ReduceByKeyPolicy>);

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -1133,15 +1133,24 @@ C2H_TEST("Test ReducePolicy properties", "[reduce][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1_multi).empty());
-  REQUIRE(!to_string(p1_single).empty());
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1_multi)
+          == "ReducePassPolicy { .threads_per_block = 256, .items_per_thread = 16, .vec_size = 4"
+             ", .reduce_algorithm = BLOCK_REDUCE_WARP_REDUCTIONS, .load_modifier = LOAD_LDG }");
+  REQUIRE(to_string(p1_single)
+          == "ReducePassPolicy { .threads_per_block = 128, .items_per_thread = 8, .vec_size = 2"
+             ", .reduce_algorithm = BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, .load_modifier = LOAD_DEFAULT }");
+  REQUIRE(to_string(p1)
+          == "ReducePolicy { .multi_tile = ReducePassPolicy { .threads_per_block = 256"
+             ", .items_per_thread = 16, .vec_size = 4"
+             ", .reduce_algorithm = BLOCK_REDUCE_WARP_REDUCTIONS, .load_modifier = LOAD_LDG }"
+             ", .single_tile = ReducePassPolicy { .threads_per_block = 128"
+             ", .items_per_thread = 8, .vec_size = 2"
+             ", .reduce_algorithm = BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY, .load_modifier = LOAD_DEFAULT } }");
 }
 
 C2H_TEST("Test ReduceByKeyPolicy properties", "[reduce][device]")
@@ -1176,12 +1185,16 @@ C2H_TEST("Test ReduceByKeyPolicy properties", "[reduce][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1)
+          == "ReduceByKeyPolicy { .threads_per_block = 128, .items_per_thread = 7"
+             ", .load_algorithm = BLOCK_LOAD_DIRECT, .load_modifier = LOAD_DEFAULT"
+             ", .scan_algorithm = BLOCK_SCAN_WARP_SCANS"
+             ", .lookback_delay = LookbackDelayPolicy { .kind = LookbackDelayAlgorithm::fixed_delay"
+             ", .delay = 832, .l2_write_latency = 1165 } }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_run_length_encode_env.cu
+++ b/cub/test/catch2_test_device_run_length_encode_env.cu
@@ -375,7 +375,8 @@ C2H_TEST("Test RleNonTrivialRunsPolicy properties", "[run_length_encode][device]
     .load_modifier           = cub::CacheLoadModifier::LOAD_LDG,
     .store_with_time_slicing = false,
     .scan_algorithm          = cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_SCANS,
-    .lookback_delay = {.kind = cub::LookbackDelayAlgorithm::fixed_delay, .delay = 350, .l2_write_latency = 450}};
+    .lookback_delay          = cub::LookbackDelayPolicy{
+               .kind = cub::LookbackDelayAlgorithm::fixed_delay, .delay = 350, .l2_write_latency = 450}};
 #  else // _CCCL_STD_VER >= 2020
   constexpr auto p2 = p1;
 #  endif // _CCCL_STD_VER >= 2020

--- a/cub/test/catch2_test_device_run_length_encode_env.cu
+++ b/cub/test/catch2_test_device_run_length_encode_env.cu
@@ -17,6 +17,8 @@ struct stream_registry_factory_t;
 #include <cuda/iterator>
 #include <cuda/stream>
 
+#include <sstream>
+
 #include "catch2_test_env_launch_helper.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceRunLengthEncode::Encode, run_length_encode_env);
@@ -333,6 +335,14 @@ C2H_TEST("Test RleEncodePolicy properties", "[run_length_encode][device]")
   // comparison
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)
 
@@ -369,5 +379,13 @@ C2H_TEST("Test RleNonTrivialRunsPolicy properties", "[run_length_encode][device]
   // comparison
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_run_length_encode_env.cu
+++ b/cub/test/catch2_test_device_run_length_encode_env.cu
@@ -302,7 +302,7 @@ C2H_TEST("DeviceRunLengthEncode::NonTrivialRuns can be tuned", "[run_length_enco
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("RleEncodePolicy", "[run_length_encode][device]")
+C2H_TEST("Test RleEncodePolicy properties", "[run_length_encode][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::RleEncodePolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::RleEncodePolicy>);
@@ -337,7 +337,7 @@ C2H_TEST("RleEncodePolicy", "[run_length_encode][device]")
 #endif // _CCCL_COMPILER(GCC, >=, 8)
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("RleNonTrivialRunsPolicy", "[run_length_encode][device]")
+C2H_TEST("Test RleNonTrivialRunsPolicy properties", "[run_length_encode][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::RleNonTrivialRunsPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::RleNonTrivialRunsPolicy>);

--- a/cub/test/catch2_test_device_run_length_encode_env.cu
+++ b/cub/test/catch2_test_device_run_length_encode_env.cu
@@ -336,13 +336,17 @@ C2H_TEST("Test RleEncodePolicy properties", "[run_length_encode][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1)
+          == "RleEncodePolicy { .threads_per_block = 128, .items_per_thread = 7"
+             ", .load_algorithm = BLOCK_LOAD_DIRECT, .load_modifier = LOAD_DEFAULT"
+             ", .scan_algorithm = BLOCK_SCAN_WARP_SCANS"
+             ", .lookback_delay = LookbackDelayPolicy { .kind = LookbackDelayAlgorithm::fixed_delay"
+             ", .delay = 832, .l2_write_latency = 1165 } }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)
 
@@ -380,12 +384,16 @@ C2H_TEST("Test RleNonTrivialRunsPolicy properties", "[run_length_encode][device]
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1)
+          == "RleNonTrivialRunsPolicy { .threads_per_block = 128, .items_per_thread = 7"
+             ", .load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE, .load_modifier = LOAD_LDG"
+             ", .store_with_time_slicing = 0, .scan_algorithm = BLOCK_SCAN_WARP_SCANS"
+             ", .lookback_delay = LookbackDelayPolicy { .kind = LookbackDelayAlgorithm::fixed_delay"
+             ", .delay = 350, .l2_write_latency = 450 } }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_scan_by_key_env.cu
+++ b/cub/test/catch2_test_device_scan_by_key_env.cu
@@ -384,12 +384,16 @@ C2H_TEST("Test ScanByKeyPolicy properties", "[scan][by_key][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1)
+          == "ScanByKeyPolicy { .threads_per_block = 256, .items_per_thread = 11"
+             ", .load_algorithm = BLOCK_LOAD_DIRECT, .load_modifier = LOAD_DEFAULT"
+             ", .store_algorithm = BLOCK_STORE_DIRECT, .scan_algorithm = BLOCK_SCAN_RAKING"
+             ", .lookback_delay = LookbackDelayPolicy { .kind = LookbackDelayAlgorithm::fixed_delay"
+             ", .delay = 832, .l2_write_latency = 1165 } }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_scan_by_key_env.cu
+++ b/cub/test/catch2_test_device_scan_by_key_env.cu
@@ -16,6 +16,8 @@ struct stream_registry_factory_t;
 #include <cuda/__execution/tune.h>
 #include <cuda/__iterator/constant_iterator.h>
 
+#include <sstream>
+
 #include "catch2_test_env_launch_helper.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceScan::ExclusiveSumByKey, device_scan_exclusive_sum_by_key);
@@ -381,5 +383,13 @@ C2H_TEST("Test ScanByKeyPolicy properties", "[scan][by_key][device]")
   // comparison
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_scan_by_key_env.cu
+++ b/cub/test/catch2_test_device_scan_by_key_env.cu
@@ -349,7 +349,7 @@ C2H_TEST("Device scan inclusive-scan-by-key uses environment", "[scan][by_key][d
 }
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("ScanByKeyPolicy", "[scan][by_key][device]")
+C2H_TEST("Test ScanByKeyPolicy properties", "[scan][by_key][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::ScanByKeyPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ScanByKeyPolicy>);

--- a/cub/test/catch2_test_device_scan_env.cu
+++ b/cub/test/catch2_test_device_scan_env.cu
@@ -18,6 +18,8 @@ struct stream_registry_factory_t;
 #include <cuda/__device/compute_capability.h>
 #include <cuda/iterator>
 
+#include <sstream>
+
 #include "catch2_test_device_scan.cuh"
 #include "catch2_test_env_launch_helper.h"
 
@@ -650,5 +652,15 @@ C2H_TEST("Test ScanPolicy properties", "[scan][device]")
 
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1_lb).empty());
+  REQUIRE(!to_string(p1_la).empty());
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_scan_env.cu
+++ b/cub/test/catch2_test_device_scan_env.cu
@@ -594,7 +594,7 @@ C2H_TEST("Device scan inclusive-scan in-place uses environment", "[scan][device]
 }
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("ScanPolicy", "[scan][device]")
+C2H_TEST("Test ScanPolicy properties", "[scan][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::ScanPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ScanPolicy>);

--- a/cub/test/catch2_test_device_scan_env.cu
+++ b/cub/test/catch2_test_device_scan_env.cu
@@ -653,14 +653,29 @@ C2H_TEST("Test ScanPolicy properties", "[scan][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1_lb).empty());
-  REQUIRE(!to_string(p1_la).empty());
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1_lb)
+          == "ScanLookbackPolicy { .threads_per_block = 256, .items_per_thread = 11"
+             ", .load_algorithm = BLOCK_LOAD_DIRECT, .load_modifier = LOAD_DEFAULT"
+             ", .store_algorithm = BLOCK_STORE_DIRECT, .scan_algorithm = BLOCK_SCAN_RAKING"
+             ", .lookback_delay = LookbackDelayPolicy { .kind = LookbackDelayAlgorithm::fixed_delay"
+             ", .delay = 832, .l2_write_latency = 1165 } }");
+  REQUIRE(to_string(p1_la)
+          == "ScanLookaheadPolicy { .reduce_and_scan_warps = 3, .items_per_thread = 8"
+             ", .lookahead_items_per_thread = 4, .lookahead_stages = 2, .block_idx_stages = -1 }");
+  REQUIRE(
+    to_string(p1)
+    == "ScanPolicy { .algorithm = ScanAlgorithm::lookback"
+       ", .lookback = ScanLookbackPolicy { .threads_per_block = 256, .items_per_thread = 11"
+       ", .load_algorithm = BLOCK_LOAD_DIRECT, .load_modifier = LOAD_DEFAULT"
+       ", .store_algorithm = BLOCK_STORE_DIRECT, .scan_algorithm = BLOCK_SCAN_RAKING"
+       ", .lookback_delay = LookbackDelayPolicy { .kind = LookbackDelayAlgorithm::fixed_delay"
+       ", .delay = 832, .l2_write_latency = 1165 } }"
+       ", .lookahead = ScanLookaheadPolicy { .reduce_and_scan_warps = 3, .items_per_thread = 8"
+       ", .lookahead_items_per_thread = 4, .lookahead_stages = 2, .block_idx_stages = -1 } }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_scan_env.cu
+++ b/cub/test/catch2_test_device_scan_env.cu
@@ -606,37 +606,48 @@ C2H_TEST("ScanPolicy", "[scan][device]")
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::ScanLookaheadPolicy>);
 
   // aggregate init
-  constexpr auto p1 = cub::ScanPolicy{
-    cub::ScanAlgorithm::lookback,
-    cub::ScanLookbackPolicy{
-      256,
-      11,
-      cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
-      cub::CacheLoadModifier::LOAD_DEFAULT,
-      cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
-      cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING,
-      cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 832, 1165}},
-    cub::ScanLookaheadPolicy{}};
+  constexpr auto p1_lb = cub::ScanLookbackPolicy{
+    256,
+    11,
+    cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+    cub::CacheLoadModifier::LOAD_DEFAULT,
+    cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+    cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING,
+    cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 832, 1165}};
+  constexpr auto p1_la = cub::ScanLookaheadPolicy{3, 8, 4, 2, -1};
+  constexpr auto p1    = cub::ScanPolicy{cub::ScanAlgorithm::lookback, p1_lb, p1_la};
 
 #  if _CCCL_STD_VER >= 2020
   // designated init
-  constexpr auto p2 = cub::ScanPolicy{
-    .algorithm = cub::ScanAlgorithm::lookback,
-    .lookback =
-      cub::ScanLookbackPolicy{
-        .threads_per_block = 256,
-        .items_per_thread  = 11,
-        .load_algorithm    = cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
-        .load_modifier     = cub::CacheLoadModifier::LOAD_DEFAULT,
-        .store_algorithm   = cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
-        .scan_algorithm    = cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING,
-        .lookback_delay    = cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 832, 1165}},
-    .lookahead = cub::ScanLookaheadPolicy{}};
+  constexpr auto p2_lb = cub::ScanLookbackPolicy{
+    .threads_per_block = 256,
+    .items_per_thread  = 11,
+    .load_algorithm    = cub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+    .load_modifier     = cub::CacheLoadModifier::LOAD_DEFAULT,
+    .store_algorithm   = cub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+    .scan_algorithm    = cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING,
+    .lookback_delay    = cub::LookbackDelayPolicy{cub::LookbackDelayAlgorithm::fixed_delay, 832, 1165}};
+  constexpr auto p2_la = cub::ScanLookaheadPolicy{
+    .reduce_and_scan_warps      = 3,
+    .items_per_thread           = 8,
+    .lookahead_items_per_thread = 4,
+    .lookahead_stages           = 2,
+    .block_idx_stages           = -1};
+
+  constexpr auto p2 = cub::ScanPolicy{.algorithm = cub::ScanAlgorithm::lookback, .lookback = p2_lb, .lookahead = p2_la};
 #  else // _CCCL_STD_VER >= 2020
-  constexpr auto p2 = p1;
+  constexpr auto p2_lb = p1_lb;
+  constexpr auto p2_la = p1_la;
+  constexpr auto p2    = p1;
 #  endif // _CCCL_STD_VER >= 2020
 
   // comparison
+  STATIC_REQUIRE(p1_lb == p2_lb);
+  STATIC_REQUIRE_FALSE(p1_lb != p2_lb);
+
+  STATIC_REQUIRE(p1_la == p2_la);
+  STATIC_REQUIRE_FALSE(p1_la != p2_la);
+
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 }

--- a/cub/test/catch2_test_device_segmented_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_env.cu
@@ -1105,12 +1105,21 @@ C2H_TEST("Test SegmentedRadixSortPolicy properties", "[segmented_radix_sort][dev
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(
+    to_string(p1)
+    == "SegmentedRadixSortPolicy { .regular_pass = RadixSortDownsweepPolicy {"
+       " .threads_per_block = 192, .items_per_thread = 15"
+       ", .load_algorithm = BLOCK_LOAD_TRANSPOSE, .load_modifier = LOAD_DEFAULT"
+       ", .rank_algorithm = RADIX_RANK_MEMOIZE, .scan_algorithm = BLOCK_SCAN_WARP_SCANS"
+       ", .radix_bits = 6 }"
+       ", .alternate_pass = RadixSortDownsweepPolicy { .threads_per_block = 384"
+       ", .items_per_thread = 11, .load_algorithm = BLOCK_LOAD_TRANSPOSE"
+       ", .load_modifier = LOAD_DEFAULT, .rank_algorithm = RADIX_RANK_MEMOIZE"
+       ", .scan_algorithm = BLOCK_SCAN_WARP_SCANS, .radix_bits = 5 } }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_segmented_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_env.cu
@@ -1063,6 +1063,8 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer can be tuned
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
 C2H_TEST("Test SegmentedRadixSortPolicy properties", "[segmented_radix_sort][device]")
 {
+  // no need to test RadixSortDownsweepPolicy, already covered by the radix sort tests
+
   STATIC_REQUIRE(::cuda::std::semiregular<cub::SegmentedRadixSortPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::SegmentedRadixSortPolicy>);
 

--- a/cub/test/catch2_test_device_segmented_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_env.cu
@@ -11,6 +11,8 @@ struct stream_registry_factory_t;
 
 #include <thrust/device_vector.h>
 
+#include <sstream>
+
 #include "catch2_test_env_launch_helper.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedRadixSort::SortPairs, sort_pairs);
@@ -1102,5 +1104,13 @@ C2H_TEST("Test SegmentedRadixSortPolicy properties", "[segmented_radix_sort][dev
   // comparison
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_segmented_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_env.cu
@@ -1061,7 +1061,7 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer can be tuned
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("SegmentedRadixSortPolicy", "[segmented_radix_sort][device]")
+C2H_TEST("Test SegmentedRadixSortPolicy properties", "[segmented_radix_sort][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::SegmentedRadixSortPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::SegmentedRadixSortPolicy>);

--- a/cub/test/catch2_test_device_segmented_reduce_env.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_env.cu
@@ -694,15 +694,28 @@ C2H_TEST("Test SegmentedReducePolicy properties", "[segmented_reduce][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1_large).empty());
-  REQUIRE(!to_string(p1_medium).empty());
-  REQUIRE(!to_string(p1_small).empty());
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1_large)
+          == "ReducePassPolicy { .threads_per_block = 256, .items_per_thread = 16, .vec_size = 4"
+             ", .reduce_algorithm = BLOCK_REDUCE_WARP_REDUCTIONS, .load_modifier = LOAD_LDG }");
+  REQUIRE(to_string(p1_medium)
+          == "SegmentedReduceWarpReducePolicy { .threads_per_block = 256, .threads_per_warp = 32"
+             ", .items_per_thread = 16, .vec_size = 4, .load_modifier = LOAD_LDG }");
+  REQUIRE(to_string(p1_small)
+          == "SegmentedReduceWarpReducePolicy { .threads_per_block = 256, .threads_per_warp = 1"
+             ", .items_per_thread = 16, .vec_size = 4, .load_modifier = LOAD_LDG }");
+  REQUIRE(
+    to_string(p1)
+    == "SegmentedReducePolicy { .large_reduce = ReducePassPolicy { .threads_per_block = 256"
+       ", .items_per_thread = 16, .vec_size = 4"
+       ", .reduce_algorithm = BLOCK_REDUCE_WARP_REDUCTIONS, .load_modifier = LOAD_LDG }"
+       ", .medium_reduce = SegmentedReduceWarpReducePolicy { .threads_per_block = 256"
+       ", .threads_per_warp = 32, .items_per_thread = 16, .vec_size = 4, .load_modifier = LOAD_LDG }"
+       ", .small_reduce = SegmentedReduceWarpReducePolicy { .threads_per_block = 256"
+       ", .threads_per_warp = 1, .items_per_thread = 16, .vec_size = 4, .load_modifier = LOAD_LDG } }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_segmented_reduce_env.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_env.cu
@@ -636,53 +636,59 @@ C2H_TEST("Fixed-size DeviceSegmentedReduce::ArgMax can be tuned", "[segmented_re
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("Test SegmentedReduceWarpReducePolicy properties", "[segmented_reduce][device]")
-{
-  STATIC_REQUIRE(::cuda::std::semiregular<cub::SegmentedReduceWarpReducePolicy>);
-  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::SegmentedReduceWarpReducePolicy>);
-
-  // aggregate init
-  constexpr auto p1 = cub::SegmentedReduceWarpReducePolicy{256, 32, 16, 4, cub::CacheLoadModifier::LOAD_LDG};
-
-#  if _CCCL_STD_VER >= 2020
-  // designated init
-  constexpr auto p2 = cub::SegmentedReduceWarpReducePolicy{
-    .threads_per_block = 256,
-    .threads_per_warp  = 32,
-    .items_per_thread  = 16,
-    .vec_size          = 4,
-    .load_modifier     = cub::CacheLoadModifier::LOAD_LDG};
-#  else // _CCCL_STD_VER >= 2020
-  constexpr auto p2 = p1;
-#  endif // _CCCL_STD_VER >= 2020
-
-  // comparison
-  STATIC_REQUIRE(p1 == p2);
-  STATIC_REQUIRE_FALSE(p1 != p2);
-}
-
 C2H_TEST("Test SegmentedReducePolicy properties", "[segmented_reduce][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::SegmentedReducePolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::SegmentedReducePolicy>);
 
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::SegmentedReduceWarpReducePolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::SegmentedReduceWarpReducePolicy>);
+
   // aggregate init
-  constexpr auto p1 = cub::SegmentedReducePolicy{
-    cub::ReducePassPolicy{256, 16, 4, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_LDG},
-    cub::SegmentedReduceWarpReducePolicy{256, 32, 16, 4, cub::LOAD_LDG},
-    cub::SegmentedReduceWarpReducePolicy{256, 1, 16, 4, cub::LOAD_LDG}};
+  constexpr auto p1_large  = cub::ReducePassPolicy{256, 16, 4, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_LDG};
+  constexpr auto p1_medium = cub::SegmentedReduceWarpReducePolicy{256, 32, 16, 4, cub::LOAD_LDG};
+  constexpr auto p1_small  = cub::SegmentedReduceWarpReducePolicy{256, 1, 16, 4, cub::LOAD_LDG};
+  constexpr auto p1        = cub::SegmentedReducePolicy{p1_large, p1_medium, p1_small};
 
 #  if _CCCL_STD_VER >= 2020
   // designated init
-  constexpr auto p2 = cub::SegmentedReducePolicy{
-    .large_reduce  = cub::ReducePassPolicy{256, 16, 4, cub::BLOCK_REDUCE_WARP_REDUCTIONS, cub::LOAD_LDG},
-    .medium_reduce = cub::SegmentedReduceWarpReducePolicy{256, 32, 16, 4, cub::LOAD_LDG},
-    .small_reduce  = cub::SegmentedReduceWarpReducePolicy{256, 1, 16, 4, cub::LOAD_LDG}};
+  constexpr auto p2_large = cub::ReducePassPolicy{
+    .threads_per_block = 256,
+    .items_per_thread  = 16,
+    .vec_size          = 4,
+    .reduce_algorithm  = cub::BLOCK_REDUCE_WARP_REDUCTIONS,
+    .load_modifier     = cub::LOAD_LDG};
+  constexpr auto p2_medium = cub::SegmentedReduceWarpReducePolicy{
+    .threads_per_block = 256,
+    .threads_per_warp  = 32,
+    .items_per_thread  = 16,
+    .vec_size          = 4,
+    .load_modifier     = cub::LOAD_LDG};
+  constexpr auto p2_small = cub::SegmentedReduceWarpReducePolicy{
+    .threads_per_block = 256,
+    .threads_per_warp  = 1,
+    .items_per_thread  = 16,
+    .vec_size          = 4,
+    .load_modifier     = cub::LOAD_LDG};
+  constexpr auto p2 =
+    cub::SegmentedReducePolicy{.large_reduce = p2_large, .medium_reduce = p2_medium, .small_reduce = p2_small};
 #  else // _CCCL_STD_VER >= 2020
-  constexpr auto p2 = p1;
+  constexpr auto p2_large  = p1_large;
+  constexpr auto p2_medium = p1_medium;
+  constexpr auto p2_small  = p1_small;
+  constexpr auto p2        = p1;
 #  endif // _CCCL_STD_VER >= 2020
 
   // comparison
+  STATIC_REQUIRE(p1_large == p2_large);
+  STATIC_REQUIRE_FALSE(p1_large != p2_large);
+
+  STATIC_REQUIRE(p1_medium == p2_medium);
+  STATIC_REQUIRE_FALSE(p1_medium != p2_medium);
+
+  STATIC_REQUIRE(p1_small == p2_small);
+  STATIC_REQUIRE_FALSE(p1_small != p2_small);
+
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 }

--- a/cub/test/catch2_test_device_segmented_reduce_env.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_env.cu
@@ -636,7 +636,7 @@ C2H_TEST("Fixed-size DeviceSegmentedReduce::ArgMax can be tuned", "[segmented_re
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("SegmentedReduceWarpReducePolicy", "[segmented_reduce][device]")
+C2H_TEST("Test SegmentedReduceWarpReducePolicy properties", "[segmented_reduce][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::SegmentedReduceWarpReducePolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::SegmentedReduceWarpReducePolicy>);
@@ -661,7 +661,7 @@ C2H_TEST("SegmentedReduceWarpReducePolicy", "[segmented_reduce][device]")
   STATIC_REQUIRE_FALSE(p1 != p2);
 }
 
-C2H_TEST("SegmentedReducePolicy", "[segmented_reduce][device]")
+C2H_TEST("Test SegmentedReducePolicy properties", "[segmented_reduce][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::SegmentedReducePolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::SegmentedReducePolicy>);

--- a/cub/test/catch2_test_device_segmented_reduce_env.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_env.cu
@@ -12,6 +12,8 @@ struct stream_registry_factory_t;
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 
+#include <sstream>
+
 #include "catch2_test_env_launch_helper.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedReduce::Reduce, device_segmented_reduce);
@@ -691,5 +693,16 @@ C2H_TEST("Test SegmentedReducePolicy properties", "[segmented_reduce][device]")
 
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1_large).empty());
+  REQUIRE(!to_string(p1_medium).empty());
+  REQUIRE(!to_string(p1_small).empty());
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_segmented_scan_env.cu
+++ b/cub/test/catch2_test_device_segmented_scan_env.cu
@@ -12,6 +12,8 @@ struct stream_registry_factory_t;
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 
+#include <sstream>
+
 #include "catch2_test_env_launch_helper.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedScan::ExclusiveSegmentedSum, device_segmented_exclusive_sum);
@@ -703,5 +705,14 @@ C2H_TEST("Test SegmentedScanPolicy properties", "[segmented_scan][device]")
 
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(block1).empty());
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_segmented_scan_env.cu
+++ b/cub/test/catch2_test_device_segmented_scan_env.cu
@@ -663,7 +663,7 @@ C2H_TEST("Device segmented inclusive scan init can be tuned", "[segmented_scan][
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("SegmentedScanPolicy", "[segmented_scan][device]")
+C2H_TEST("Test SegmentedScanPolicy properties", "[segmented_scan][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::SegmentedScanPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::SegmentedScanPolicy>);

--- a/cub/test/catch2_test_device_segmented_scan_env.cu
+++ b/cub/test/catch2_test_device_segmented_scan_env.cu
@@ -706,13 +706,20 @@ C2H_TEST("Test SegmentedScanPolicy properties", "[segmented_scan][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(block1).empty());
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(block1)
+          == "SegmentedScanBlockPolicy { .threads_per_block = 128, .items_per_thread = 9"
+             ", .load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE, .load_modifier = LOAD_DEFAULT"
+             ", .store_algorithm = BLOCK_STORE_WARP_TRANSPOSE, .scan_algorithm = BLOCK_SCAN_WARP_SCANS"
+             ", .max_segments_per_block = 512 }");
+  REQUIRE(to_string(p1)
+          == "SegmentedScanPolicy { .block = SegmentedScanBlockPolicy { .threads_per_block = 128"
+             ", .items_per_thread = 9, .load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE"
+             ", .load_modifier = LOAD_DEFAULT, .store_algorithm = BLOCK_STORE_WARP_TRANSPOSE"
+             ", .scan_algorithm = BLOCK_SCAN_WARP_SCANS, .max_segments_per_block = 512 } }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_segmented_scan_env.cu
+++ b/cub/test/catch2_test_device_segmented_scan_env.cu
@@ -693,10 +693,14 @@ C2H_TEST("SegmentedScanPolicy", "[segmented_scan][device]")
     .max_segments      = 512};
   constexpr auto p2 = cub::SegmentedScanPolicy{.block = block2};
 #  else // _CCCL_STD_VER >= 2020
-  constexpr auto p2 = p1;
+  constexpr auto block2 = block1;
+  constexpr auto p2     = p1;
 #  endif // _CCCL_STD_VER >= 2020
 
   // comparison
+  STATIC_REQUIRE(block1 == block2);
+  STATIC_REQUIRE_FALSE(block1 != block2);
+
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 }

--- a/cub/test/catch2_test_device_segmented_sort_keys_env.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys_env.cu
@@ -610,49 +610,57 @@ C2H_TEST("SegmentedSortPolicy structs", "[segmented_sort][device]")
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::SegmentedSortSubWarpMergeSortPolicy>);
 
   // aggregate init
-  constexpr auto p1 = cub::SegmentedSortPolicy{
-    cub::SegmentedSortRadixSortPolicy{
-      256, 16, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::RADIX_RANK_MEMOIZE, cub::BLOCK_SCAN_RAKING_MEMOIZE, 6},
-    cub::SegmentedSortSubWarpMergeSortPolicy{
-      256, 32, 7, cub::WARP_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::WARP_STORE_DIRECT},
-    cub::SegmentedSortSubWarpMergeSortPolicy{
-      256, 4, 7, cub::WARP_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::WARP_STORE_DIRECT},
-    300};
+  constexpr auto p1_large = cub::SegmentedSortRadixSortPolicy{
+    256, 16, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::RADIX_RANK_MEMOIZE, cub::BLOCK_SCAN_RAKING_MEMOIZE, 6};
+  constexpr auto p1_small = cub::SegmentedSortSubWarpMergeSortPolicy{
+    256, 32, 7, cub::WARP_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::WARP_STORE_DIRECT};
+  constexpr auto p1_medium = cub::SegmentedSortSubWarpMergeSortPolicy{
+    256, 4, 7, cub::WARP_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::WARP_STORE_DIRECT};
+  constexpr auto p1 = cub::SegmentedSortPolicy{p1_large, p1_small, p1_medium, 300};
 
 #  if _CCCL_STD_VER >= 2020
   // designated init
+  constexpr auto p2_large = cub::SegmentedSortRadixSortPolicy{
+    .threads_per_block = 256,
+    .items_per_thread  = 16,
+    .load_algorithm    = cub::BLOCK_LOAD_DIRECT,
+    .load_modifier     = cub::LOAD_DEFAULT,
+    .rank_algorithm    = cub::RADIX_RANK_MEMOIZE,
+    .scan_algorithm    = cub::BLOCK_SCAN_RAKING_MEMOIZE,
+    .radix_bits        = 6};
+  constexpr auto p2_medium = cub::SegmentedSortSubWarpMergeSortPolicy{
+    .threads_per_block = 256,
+    .threads_per_warp  = 32,
+    .items_per_thread  = 7,
+    .load_algorithm    = cub::WARP_LOAD_DIRECT,
+    .load_modifier     = cub::LOAD_DEFAULT,
+    .store_algorithm   = cub::WARP_STORE_DIRECT};
+  constexpr auto p2_small = cub::SegmentedSortSubWarpMergeSortPolicy{
+    .threads_per_block = 256,
+    .threads_per_warp  = 4,
+    .items_per_thread  = 7,
+    .load_algorithm    = cub::WARP_LOAD_DIRECT,
+    .load_modifier     = cub::LOAD_DEFAULT,
+    .store_algorithm   = cub::WARP_STORE_DIRECT};
   constexpr auto p2 = cub::SegmentedSortPolicy{
-    .large_segment =
-      cub::SegmentedSortRadixSortPolicy{
-        .threads_per_block = 256,
-        .items_per_thread  = 16,
-        .load_algorithm    = cub::BLOCK_LOAD_DIRECT,
-        .load_modifier     = cub::LOAD_DEFAULT,
-        .rank_algorithm    = cub::RADIX_RANK_MEMOIZE,
-        .scan_algorithm    = cub::BLOCK_SCAN_RAKING_MEMOIZE,
-        .radix_bits        = 6},
-    .medium_segment =
-      cub::SegmentedSortSubWarpMergeSortPolicy{
-        .threads_per_block = 256,
-        .threads_per_warp  = 32,
-        .items_per_thread  = 7,
-        .load_algorithm    = cub::WARP_LOAD_DIRECT,
-        .load_modifier     = cub::LOAD_DEFAULT,
-        .store_algorithm   = cub::WARP_STORE_DIRECT},
-    .small_segment =
-      cub::SegmentedSortSubWarpMergeSortPolicy{
-        .threads_per_block = 256,
-        .threads_per_warp  = 4,
-        .items_per_thread  = 7,
-        .load_algorithm    = cub::WARP_LOAD_DIRECT,
-        .load_modifier     = cub::LOAD_DEFAULT,
-        .store_algorithm   = cub::WARP_STORE_DIRECT},
-    .partitioning_threshold = 300};
+    .large_segment = p2_large, .medium_segment = p2_medium, .small_segment = p2_small, .partitioning_threshold = 300};
 #  else
-  constexpr auto p2 = p1;
+  constexpr auto p2_large  = p1_large;
+  constexpr auto p2_small  = p1_small;
+  constexpr auto p2_medium = p1_medium;
+  constexpr auto p2        = p1;
 #  endif // _CCCL_STD_VER >= 2020
 
   // comparison
+  STATIC_REQUIRE(p1_large == p2_large);
+  STATIC_REQUIRE_FALSE(p1_large != p2_large);
+
+  STATIC_REQUIRE(p1_small == p2_small);
+  STATIC_REQUIRE_FALSE(p1_small != p2_small);
+
+  STATIC_REQUIRE(p1_medium == p2_medium);
+  STATIC_REQUIRE_FALSE(p1_medium != p2_medium);
+
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 }

--- a/cub/test/catch2_test_device_segmented_sort_keys_env.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys_env.cu
@@ -13,6 +13,8 @@ struct stream_registry_factory_t;
 
 #include <cuda/__execution/tune.h>
 
+#include <sstream>
+
 #include "catch2_test_env_launch_helper.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedSort::SortKeys, sort_keys);
@@ -663,5 +665,16 @@ C2H_TEST("Test SegmentedSortPolicy properties", "[segmented_sort][device]")
 
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1_large).empty());
+  REQUIRE(!to_string(p1_small).empty());
+  REQUIRE(!to_string(p1_medium).empty());
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_segmented_sort_keys_env.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys_env.cu
@@ -691,11 +691,11 @@ C2H_TEST("Test SegmentedSortPolicy properties", "[segmented_sort][device]")
        ", .load_algorithm = BLOCK_LOAD_DIRECT, .load_modifier = LOAD_DEFAULT"
        ", .rank_algorithm = RADIX_RANK_MEMOIZE, .scan_algorithm = BLOCK_SCAN_RAKING_MEMOIZE"
        ", .radix_bits = 6 }"
-       ", .small_segment = SegmentedSortSubWarpMergeSortPolicy { .threads_per_block = 256"
-       ", .threads_per_warp = 4, .items_per_thread = 7, .load_algorithm = WARP_LOAD_DIRECT"
-       ", .load_modifier = LOAD_DEFAULT, .store_algorithm = WARP_STORE_DIRECT }"
        ", .medium_segment = SegmentedSortSubWarpMergeSortPolicy { .threads_per_block = 256"
        ", .threads_per_warp = 32, .items_per_thread = 7, .load_algorithm = WARP_LOAD_DIRECT"
+       ", .load_modifier = LOAD_DEFAULT, .store_algorithm = WARP_STORE_DIRECT }"
+       ", .small_segment = SegmentedSortSubWarpMergeSortPolicy { .threads_per_block = 256"
+       ", .threads_per_warp = 4, .items_per_thread = 7, .load_algorithm = WARP_LOAD_DIRECT"
        ", .load_modifier = LOAD_DEFAULT, .store_algorithm = WARP_STORE_DIRECT }"
        ", .partitioning_threshold = 300 }");
 }

--- a/cub/test/catch2_test_device_segmented_sort_keys_env.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys_env.cu
@@ -666,15 +666,37 @@ C2H_TEST("Test SegmentedSortPolicy properties", "[segmented_sort][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1_large).empty());
-  REQUIRE(!to_string(p1_small).empty());
-  REQUIRE(!to_string(p1_medium).empty());
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1_large)
+          == "SegmentedSortRadixSortPolicy { .threads_per_block = 256, .items_per_thread = 16"
+             ", .load_algorithm = BLOCK_LOAD_DIRECT, .load_modifier = LOAD_DEFAULT"
+             ", .rank_algorithm = RADIX_RANK_MEMOIZE, .scan_algorithm = BLOCK_SCAN_RAKING_MEMOIZE"
+             ", .radix_bits = 6 }");
+  REQUIRE(to_string(p1_small)
+          == "SegmentedSortSubWarpMergeSortPolicy { .threads_per_block = 256, .threads_per_warp = 4"
+             ", .items_per_thread = 7, .load_algorithm = WARP_LOAD_DIRECT"
+             ", .load_modifier = LOAD_DEFAULT, .store_algorithm = WARP_STORE_DIRECT }");
+  REQUIRE(to_string(p1_medium)
+          == "SegmentedSortSubWarpMergeSortPolicy { .threads_per_block = 256, .threads_per_warp = 32"
+             ", .items_per_thread = 7, .load_algorithm = WARP_LOAD_DIRECT"
+             ", .load_modifier = LOAD_DEFAULT, .store_algorithm = WARP_STORE_DIRECT }");
+  REQUIRE(
+    to_string(p1)
+    == "SegmentedSortPolicy { .large_segment = SegmentedSortRadixSortPolicy {"
+       " .threads_per_block = 256, .items_per_thread = 16"
+       ", .load_algorithm = BLOCK_LOAD_DIRECT, .load_modifier = LOAD_DEFAULT"
+       ", .rank_algorithm = RADIX_RANK_MEMOIZE, .scan_algorithm = BLOCK_SCAN_RAKING_MEMOIZE"
+       ", .radix_bits = 6 }"
+       ", .small_segment = SegmentedSortSubWarpMergeSortPolicy { .threads_per_block = 256"
+       ", .threads_per_warp = 4, .items_per_thread = 7, .load_algorithm = WARP_LOAD_DIRECT"
+       ", .load_modifier = LOAD_DEFAULT, .store_algorithm = WARP_STORE_DIRECT }"
+       ", .medium_segment = SegmentedSortSubWarpMergeSortPolicy { .threads_per_block = 256"
+       ", .threads_per_warp = 32, .items_per_thread = 7, .load_algorithm = WARP_LOAD_DIRECT"
+       ", .load_modifier = LOAD_DEFAULT, .store_algorithm = WARP_STORE_DIRECT }"
+       ", .partitioning_threshold = 300 }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_segmented_sort_keys_env.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys_env.cu
@@ -614,9 +614,9 @@ C2H_TEST("Test SegmentedSortPolicy properties", "[segmented_sort][device]")
   // aggregate init
   constexpr auto p1_large = cub::SegmentedSortRadixSortPolicy{
     256, 16, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::RADIX_RANK_MEMOIZE, cub::BLOCK_SCAN_RAKING_MEMOIZE, 6};
-  constexpr auto p1_small = cub::SegmentedSortSubWarpMergeSortPolicy{
-    256, 32, 7, cub::WARP_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::WARP_STORE_DIRECT};
   constexpr auto p1_medium = cub::SegmentedSortSubWarpMergeSortPolicy{
+    256, 32, 7, cub::WARP_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::WARP_STORE_DIRECT};
+  constexpr auto p1_small = cub::SegmentedSortSubWarpMergeSortPolicy{
     256, 4, 7, cub::WARP_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::WARP_STORE_DIRECT};
   constexpr auto p1 = cub::SegmentedSortPolicy{p1_large, p1_small, p1_medium, 300};
 

--- a/cub/test/catch2_test_device_segmented_sort_keys_env.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys_env.cu
@@ -600,7 +600,7 @@ C2H_TEST("DeviceSegmentedSort::StableSortKeysDescending can be tuned", "[segment
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("SegmentedSortPolicy structs", "[segmented_sort][device]")
+C2H_TEST("Test SegmentedSortPolicy properties", "[segmented_sort][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::SegmentedSortPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::SegmentedSortPolicy>);

--- a/cub/test/catch2_test_device_segmented_sort_keys_env.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys_env.cu
@@ -618,7 +618,7 @@ C2H_TEST("Test SegmentedSortPolicy properties", "[segmented_sort][device]")
     256, 32, 7, cub::WARP_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::WARP_STORE_DIRECT};
   constexpr auto p1_small = cub::SegmentedSortSubWarpMergeSortPolicy{
     256, 4, 7, cub::WARP_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::WARP_STORE_DIRECT};
-  constexpr auto p1 = cub::SegmentedSortPolicy{p1_large, p1_small, p1_medium, 300};
+  constexpr auto p1 = cub::SegmentedSortPolicy{p1_large, p1_medium, p1_small, 300};
 
 #  if _CCCL_STD_VER >= 2020
   // designated init

--- a/cub/test/catch2_test_device_select_env.cu
+++ b/cub/test/catch2_test_device_select_env.cu
@@ -1307,13 +1307,17 @@ C2H_TEST("Test UniqueByKeyPolicy properties", "[select_unique_by_key][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1)
+          == "UniqueByKeyPolicy { .threads_per_block = 256, .items_per_thread = 11"
+             ", .load_algorithm = BLOCK_LOAD_DIRECT, .load_modifier = LOAD_DEFAULT"
+             ", .scan_algorithm = BLOCK_SCAN_WARP_SCANS"
+             ", .lookback_delay = LookbackDelayPolicy { .kind = LookbackDelayAlgorithm::fixed_delay"
+             ", .delay = 350, .l2_write_latency = 450 } }");
 }
 #  endif // _CCCL_COMPILER(GCC, >=, 8)
 
@@ -1351,12 +1355,16 @@ C2H_TEST("Test SelectPolicy properties", "[select][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1)
+          == "SelectPolicy { .threads_per_block = 128, .items_per_thread = 10"
+             ", .load_algorithm = BLOCK_LOAD_DIRECT, .load_modifier = LOAD_DEFAULT"
+             ", .scan_algorithm = BLOCK_SCAN_WARP_SCANS"
+             ", .lookback_delay = LookbackDelayPolicy { .kind = LookbackDelayAlgorithm::fixed_delay"
+             ", .delay = 350, .l2_write_latency = 450 } }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_select_env.cu
+++ b/cub/test/catch2_test_device_select_env.cu
@@ -1274,7 +1274,7 @@ C2H_TEST("DeviceSelect::UniqueByKey can be tuned", "[select][device]", block_siz
 }
 
 #  if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("UniqueByKeyPolicy new API is equivalent to existing API", "[select_unique_by_key][device]")
+C2H_TEST("Test UniqueByKeyPolicy properties", "[select_unique_by_key][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::UniqueByKeyPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::UniqueByKeyPolicy>);
@@ -1310,7 +1310,7 @@ C2H_TEST("UniqueByKeyPolicy new API is equivalent to existing API", "[select_uni
 #endif // TEST_LAUNCH != 1
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("SelectPolicy", "[select][device]")
+C2H_TEST("Test SelectPolicy properties", "[select][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::SelectPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::SelectPolicy>);

--- a/cub/test/catch2_test_device_select_env.cu
+++ b/cub/test/catch2_test_device_select_env.cu
@@ -17,6 +17,8 @@ struct stream_registry_factory_t;
 #include <cuda/__iterator/constant_iterator.h>
 #include <cuda/iterator>
 
+#include <sstream>
+
 #include "catch2_test_device_select_common.cuh"
 #include "catch2_test_env_launch_helper.h"
 
@@ -1304,6 +1306,14 @@ C2H_TEST("Test UniqueByKeyPolicy properties", "[select_unique_by_key][device]")
   // comparison
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1).empty());
 }
 #  endif // _CCCL_COMPILER(GCC, >=, 8)
 
@@ -1340,5 +1350,13 @@ C2H_TEST("Test SelectPolicy properties", "[select][device]")
   // comparison
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_transform_env.cu
+++ b/cub/test/catch2_test_device_transform_env.cu
@@ -9,6 +9,8 @@
 #include <cuda/iterator>
 #include <cuda/stream>
 
+#include <sstream>
+
 #include <c2h/catch2_test_helper.h>
 
 using namespace thrust::placeholders;
@@ -352,5 +354,16 @@ C2H_TEST("Test TransformPolicy properties", "[transform][device]")
 
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
+
+  // just verify operator<< produces a non-empty string; we don't care about the content
+  auto to_string = [](const auto& p) {
+    std::ostringstream os;
+    os << p;
+    return os.str();
+  };
+  REQUIRE(!to_string(p1_prefetch).empty());
+  REQUIRE(!to_string(p1_vectorized).empty());
+  REQUIRE(!to_string(p1_async_copy).empty());
+  REQUIRE(!to_string(p1).empty());
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_transform_env.cu
+++ b/cub/test/catch2_test_device_transform_env.cu
@@ -293,7 +293,7 @@ C2H_TEST("DeviceTransform::Transform can be tuned with custom stream", "[reduce]
 }
 
 #if _CCCL_COMPILER(GCC, >=, 8) // gcc 7 cannot preserve constexpr-ness from p1 to p2
-C2H_TEST("TransformPolicy", "[transform][device]")
+C2H_TEST("Test TransformPolicy properties", "[transform][device]")
 {
   STATIC_REQUIRE(::cuda::std::semiregular<cub::TransformPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::TransformPolicy>);

--- a/cub/test/catch2_test_device_transform_env.cu
+++ b/cub/test/catch2_test_device_transform_env.cu
@@ -355,15 +355,30 @@ C2H_TEST("Test TransformPolicy properties", "[transform][device]")
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 
-  // just verify operator<< produces a non-empty string; we don't care about the content
   auto to_string = [](const auto& p) {
     std::ostringstream os;
     os << p;
     return os.str();
   };
-  REQUIRE(!to_string(p1_prefetch).empty());
-  REQUIRE(!to_string(p1_vectorized).empty());
-  REQUIRE(!to_string(p1_async_copy).empty());
-  REQUIRE(!to_string(p1).empty());
+  REQUIRE(to_string(p1_prefetch)
+          == "TransformPrefetchPolicy { .threads_per_block = 256, .items_per_thread_no_input = 2"
+             ", .min_items_per_thread = 1, .max_items_per_thread = 32"
+             ", .prefetch_byte_stride = 128, .unroll_factor = 0 }");
+  REQUIRE(to_string(p1_vectorized)
+          == "TransformVectorizedPolicy { .threads_per_block = 256, .items_per_thread = 8, .vec_size = 4 }");
+  REQUIRE(to_string(p1_async_copy)
+          == "TransformAsyncCopyPolicy { .threads_per_block = 256, .min_items_per_thread = 1"
+             ", .max_items_per_thread = 32, .unroll_factor = 1 }");
+  REQUIRE(
+    to_string(p1)
+    == "TransformPolicy { .min_bytes_in_flight = 65536"
+       ", .algorithm = TransformAlgorithm::prefetch"
+       ", .prefetch = TransformPrefetchPolicy { .threads_per_block = 256"
+       ", .items_per_thread_no_input = 2, .min_items_per_thread = 1, .max_items_per_thread = 32"
+       ", .prefetch_byte_stride = 128, .unroll_factor = 0 }"
+       ", .vectorized = TransformVectorizedPolicy { .threads_per_block = 256"
+       ", .items_per_thread = 8, .vec_size = 4 }"
+       ", .async_copy = TransformAsyncCopyPolicy { .threads_per_block = 256"
+       ", .min_items_per_thread = 1, .max_items_per_thread = 32, .unroll_factor = 1 } }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_transform_env.cu
+++ b/cub/test/catch2_test_device_transform_env.cu
@@ -368,7 +368,7 @@ C2H_TEST("Test TransformPolicy properties", "[transform][device]")
           == "TransformVectorizedPolicy { .threads_per_block = 256, .items_per_thread = 8, .vec_size = 4 }");
   REQUIRE(to_string(p1_async_copy)
           == "TransformAsyncCopyPolicy { .threads_per_block = 256, .min_items_per_thread = 1"
-             ", .max_items_per_thread = 32, .unroll_factor = 1 }");
+             ", .max_items_per_thread = 32, .unroll_factor = 1, .store_vec_size = 0 }");
   REQUIRE(
     to_string(p1)
     == "TransformPolicy { .min_bytes_in_flight = 65536"
@@ -379,6 +379,6 @@ C2H_TEST("Test TransformPolicy properties", "[transform][device]")
        ", .vectorized = TransformVectorizedPolicy { .threads_per_block = 256"
        ", .items_per_thread = 8, .vec_size = 4 }"
        ", .async_copy = TransformAsyncCopyPolicy { .threads_per_block = 256"
-       ", .min_items_per_thread = 1, .max_items_per_thread = 32, .unroll_factor = 1 } }");
+       ", .min_items_per_thread = 1, .max_items_per_thread = 32, .unroll_factor = 1, .store_vec_size = 0 } }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)

--- a/cub/test/catch2_test_device_transform_env.cu
+++ b/cub/test/catch2_test_device_transform_env.cu
@@ -298,35 +298,58 @@ C2H_TEST("TransformPolicy", "[transform][device]")
   STATIC_REQUIRE(::cuda::std::semiregular<cub::TransformPolicy>);
   STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::TransformPolicy>);
 
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::TransformPrefetchPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::TransformPrefetchPolicy>);
+
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::TransformVectorizedPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::TransformVectorizedPolicy>);
+
+  STATIC_REQUIRE(::cuda::std::semiregular<cub::TransformAsyncCopyPolicy>);
+  STATIC_REQUIRE(::cuda::std::is_aggregate_v<cub::TransformAsyncCopyPolicy>);
+
   // aggregate init
-  constexpr auto p1 = cub::TransformPolicy{
-    64 * 1024,
-    cub::TransformAlgorithm::prefetch,
-    cub::TransformPrefetchPolicy{256, 2, 1, 32, 128, 0},
-    cub::TransformVectorizedPolicy{256, 8, 4},
-    cub::TransformAsyncCopyPolicy{256, 1, 32, 1}};
+  constexpr auto p1_prefetch   = cub::TransformPrefetchPolicy{256, 2, 1, 32, 128, 0};
+  constexpr auto p1_vectorized = cub::TransformVectorizedPolicy{256, 8, 4};
+  constexpr auto p1_async_copy = cub::TransformAsyncCopyPolicy{256, 1, 32, 1};
+  constexpr auto p1 =
+    cub::TransformPolicy{64 * 1024, cub::TransformAlgorithm::prefetch, p1_prefetch, p1_vectorized, p1_async_copy};
 
 #  if _CCCL_STD_VER >= 2020
   // designated init
+  constexpr auto p2_prefetch = cub::TransformPrefetchPolicy{
+    .threads_per_block         = 256,
+    .items_per_thread_no_input = 2,
+    .min_items_per_thread      = 1,
+    .max_items_per_thread      = 32,
+    .prefetch_byte_stride      = 128,
+    .unroll_factor             = 0};
+  constexpr auto p2_vectorized =
+    cub::TransformVectorizedPolicy{.threads_per_block = 256, .items_per_thread = 8, .vec_size = 4};
+  constexpr auto p2_async_copy = cub::TransformAsyncCopyPolicy{
+    .threads_per_block = 256, .min_items_per_thread = 1, .max_items_per_thread = 32, .unroll_factor = 1};
   constexpr auto p2 = cub::TransformPolicy{
     .min_bytes_in_flight = 64 * 1024,
     .algorithm           = cub::TransformAlgorithm::prefetch,
-    .prefetch =
-      cub::TransformPrefetchPolicy{
-        .threads_per_block         = 256,
-        .items_per_thread_no_input = 2,
-        .min_items_per_thread      = 1,
-        .max_items_per_thread      = 32,
-        .prefetch_byte_stride      = 128,
-        .unroll_factor             = 0},
-    .vectorized = cub::TransformVectorizedPolicy{.threads_per_block = 256, .items_per_thread = 8, .vec_size = 4},
-    .async_copy = cub::TransformAsyncCopyPolicy{
-      .threads_per_block = 256, .min_items_per_thread = 1, .max_items_per_thread = 32, .unroll_factor = 1}};
+    .prefetch            = p2_prefetch,
+    .vectorized          = p2_vectorized,
+    .async_copy          = p2_async_copy};
 #  else // _CCCL_STD_VER >= 2020
-  constexpr auto p2 = p1;
+  constexpr auto p2_prefetch   = p1_prefetch;
+  constexpr auto p2_vectorized = p1_vectorized;
+  constexpr auto p2_async_copy = p1_async_copy;
+  constexpr auto p2            = p1;
 #  endif // _CCCL_STD_VER >= 2020
 
   // comparison
+  STATIC_REQUIRE(p1_prefetch == p2_prefetch);
+  STATIC_REQUIRE_FALSE(p1_prefetch != p2_prefetch);
+
+  STATIC_REQUIRE(p1_vectorized == p2_vectorized);
+  STATIC_REQUIRE_FALSE(p1_vectorized != p2_vectorized);
+
+  STATIC_REQUIRE(p1_async_copy == p2_async_copy);
+  STATIC_REQUIRE_FALSE(p1_async_copy != p2_async_copy);
+
   STATIC_REQUIRE(p1 == p2);
   STATIC_REQUIRE_FALSE(p1 != p2);
 }


### PR DESCRIPTION
* Proper designated init for `ReducePolicy`
* Extend all tests with the missing sub policy tests
* Rename policy tests
* Test `operator<<`

Fixes part of: #9378