### PR TITLE
Rename `AgentTopKPolicy` to `agent_topk_policy`

### DIFF
--- a/cub/cub/agent/agent_topk.cuh
+++ b/cub/cub/agent/agent_topk.cuh
@@ -27,7 +27,7 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail::topk
 {
-//! @brief Parameterizable tuning policy type for AgentTopK
+//! @brief Parameterizable tuning policy type for agent_topk
 //!
 //! @tparam ThreadsPerBlock
 //!   Threads per thread block
@@ -49,7 +49,7 @@ template <int ThreadsPerBlock,
           int BitsPerPass,
           BlockLoadAlgorithm LoadAlgorithm,
           BlockScanAlgorithm ScanAlgorithm>
-struct AgentTopKPolicy
+struct agent_topk_policy
 {
   static constexpr int threads_per_block             = ThreadsPerBlock;
   static constexpr int items_per_thread              = ItemsPerThread;
@@ -200,7 +200,7 @@ enum class candidate_class
 //! device-wide topK
 //!
 //! @tparam AgentTopKPolicyT
-//!   Parameterized AgentTopKPolicy tuning policy type
+//!   Parameterized agent_topk_policy tuning policy type
 //!
 //! @tparam KeyInputIteratorT
 //!   **[inferred]** Random-access input iterator type for reading input keys @iterator

--- a/cub/cub/device/dispatch/dispatch_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_topk.cuh
@@ -271,11 +271,11 @@ __launch_bounds__(int(current_policy<PolicySelector>().threads_per_block))
 {
   static constexpr topk_policy policy = current_policy<PolicySelector>();
   using agent_topk_policy_t =
-    AgentTopKPolicy<policy.threads_per_block,
-                    policy.items_per_thread,
-                    policy.bits_per_pass,
-                    policy.load_algorithm,
-                    policy.scan_algorithm>;
+    agent_topk_policy<policy.threads_per_block,
+                      policy.items_per_thread,
+                      policy.bits_per_pass,
+                      policy.load_algorithm,
+                      policy.scan_algorithm>;
   using agent_topk_t =
     AgentTopK<agent_topk_policy_t,
               KeyInputIteratorT,
@@ -331,11 +331,11 @@ __launch_bounds__(int(current_policy<PolicySelector>().threads_per_block))
 {
   static constexpr topk_policy policy = current_policy<PolicySelector>();
   using agent_topk_policy_t =
-    AgentTopKPolicy<policy.threads_per_block,
-                    policy.items_per_thread,
-                    policy.bits_per_pass,
-                    policy.load_algorithm,
-                    policy.scan_algorithm>;
+    agent_topk_policy<policy.threads_per_block,
+                      policy.items_per_thread,
+                      policy.bits_per_pass,
+                      policy.load_algorithm,
+                      policy.scan_algorithm>;
   using identify_candidates_op_t = NullType;
   using agent_topk_t =
     AgentTopK<agent_topk_policy_t,
@@ -392,11 +392,11 @@ __launch_bounds__(int(current_policy<PolicySelector>().threads_per_block))
 {
   static constexpr topk_policy policy = current_policy<PolicySelector>();
   using agent_topk_policy_t =
-    AgentTopKPolicy<policy.threads_per_block,
-                    policy.items_per_thread,
-                    policy.bits_per_pass,
-                    policy.load_algorithm,
-                    policy.scan_algorithm>;
+    agent_topk_policy<policy.threads_per_block,
+                      policy.items_per_thread,
+                      policy.bits_per_pass,
+                      policy.load_algorithm,
+                      policy.scan_algorithm>;
   using extract_bin_op_t = NullType;
   using agent_topk_t =
     AgentTopK<agent_topk_policy_t,


### PR DESCRIPTION
## Summary
- Renames `AgentTopKPolicy` struct to `agent_topk_policy` in `cub/agent/agent_topk.cuh` for snake_case naming consistency
- Updates all usages in `cub/device/dispatch/dispatch_topk.cuh`

## Test plan
- [x] Built topk-related targets (`cub.test.device.topk_api`, `cub.test.device.topk_env`, `cub.test.block.topk`, `cub.test.device.batched_topk_api`, `cub.test.device.segmented_topk_keys`) successfully
- [x] Ran `cub.test.device.topk_keys.lid_0` — passed
- [x] Header compilation tests pass
- [x] pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)