### PR TITLE
Implement prefetching

### DIFF
--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -19,13 +19,14 @@
 
 #include <cub/util_type.cuh>
 
+#include <thrust/type_traits/is_contiguous_iterator.h>
+#include <thrust/type_traits/unwrap_contiguous_iterator.h>
+
 #include <cuda/__memcpy_async/elect_one.h>
 #include <cuda/__memory/align_down.h>
 #include <cuda/__memory/align_up.h>
 #include <cuda/__memory/ptr_rebind.h>
 #include <cuda/std/__host_stdlib/ostream>
-#include <cuda/std/__iterator/concepts.h>
-#include <cuda/std/__memory/pointer_traits.h>
 
 #include <nv/target>
 
@@ -69,11 +70,12 @@ inline ::std::ostream& operator<<(::std::ostream& os, LoadPrefetch prefetch)
 }
 #endif // _CCCL_HOSTED()
 
-// Prefetch hints require a raw address, so only contiguous iterators qualify.
+// Prefetch hints require a raw address, so only contiguous iterators qualify. thrust::is_contiguous_iterator
+// covers raw pointers, std/libcu++ contiguous iterators, thrust vector iterators, and proclaimed types.
 // Note: ``cub::CacheModifiedInputIterator`` does not qualify: it routes loads through an explicit cache path
 // (e.g. ``LOAD_NC``) that a prefetch hint would defeat.
 template <typename It>
-inline constexpr bool can_prefetch_from = ::cuda::std::contiguous_iterator<It> && ::cuda::std::__can_to_address<It>;
+inline constexpr bool can_prefetch_from = THRUST_NS_QUALIFIER::is_contiguous_iterator_v<It>;
 
 //! A block-scope collective that cooperatively emits global-memory prefetch hints for a tile. The block size
 //! ``ThreadsPerBlock`` is fixed on the type; the cache level (``PrefetchLevel``) and the per-cache-line hint
@@ -101,7 +103,7 @@ struct BlockPrefetch
       _CCCL_ASSERT(items_to_prefetch >= 0, "items_to_prefetch must be non-negative");
 
       const int total_bytes = items_to_prefetch * int{sizeof(it_value_t<It>)};
-      const auto src_ptr    = ::cuda::ptr_rebind<char>(::cuda::std::to_address(tile_base));
+      const auto src_ptr    = ::cuda::ptr_rebind<char>(THRUST_NS_QUALIFIER::unwrap_contiguous_iterator(tile_base));
 
       if constexpr (PrefetchLevel == LoadPrefetch::bulk_l2)
       {

--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -99,6 +99,11 @@ struct BlockPrefetch
       const int total_bytes     = items_to_prefetch * static_cast<int>(sizeof(it_value_t<It>));
       const auto* const src_ptr = reinterpret_cast<const char*>(::cuda::std::to_address(tile_base));
 
+      // Suppress "variable declared but not referenced" MSVC error
+      (void) linear_tid;
+      (void) total_bytes;
+      (void) src_ptr;
+
       if constexpr (PrefetchLevel == LoadPrefetch::bulk_l2)
       {
         // One elected thread issues a single TMA bulk prefetch for the whole tile.

--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -22,7 +22,7 @@
 #include <cuda/__cmath/round_up.h>
 #include <cuda/__memcpy_async/elect_one.h>
 #include <cuda/__memory/align_down.h>
-#include <cuda/__ptx/ptx_helper_functions.h>
+#include <cuda/__memory/ptr_rebind.h>
 #include <cuda/std/__host_stdlib/ostream>
 #include <cuda/std/__iterator/concepts.h>
 #include <cuda/std/__memory/pointer_traits.h>
@@ -96,8 +96,8 @@ struct BlockPrefetch
   {
     if constexpr (PrefetchLevel != LoadPrefetch::none && can_prefetch_from<It>)
     {
-      const int total_bytes     = items_to_prefetch * static_cast<int>(sizeof(it_value_t<It>));
-      const auto* const src_ptr = reinterpret_cast<const char*>(::cuda::std::to_address(tile_base));
+      const int total_bytes = items_to_prefetch * static_cast<int>(sizeof(it_value_t<It>));
+      const auto src_ptr    = ::cuda::ptr_rebind<char>(::cuda::std::to_address(tile_base));
       if (total_bytes <= 0)
       {
         return;
@@ -114,13 +114,12 @@ struct BlockPrefetch
             if (::cuda::device::__block_elect_one())
             {
               // srcMem must be 16-byte aligned per PTX ISA; align base down and extend size to compensate
-              const auto* const aligned_base = ::cuda::align_down(src_ptr, 16);
-              const unsigned int prefix      = static_cast<unsigned int>(src_ptr - aligned_base);
-              const unsigned int aligned_size =
-                ::cuda::round_up(static_cast<unsigned int>(total_bytes) + prefix, 16u);
+              const auto* aligned_base = ::cuda::align_down(src_ptr, 16);
+              const auto prefix        = static_cast<unsigned>(src_ptr - aligned_base);
+              const auto aligned_size  = ::cuda::round_up(static_cast<unsigned>(total_bytes) + prefix, 16u);
               asm volatile("cp.async.bulk.prefetch.L2.global [%0], %1;"
                            :
-                           : "l"(::cuda::ptx::__as_ptr_gmem(aligned_base)), "r"(aligned_size)
+                           : "l"(::__cvta_generic_to_global(aligned_base)), "r"(aligned_size)
                            : "memory");
             }
           }),
@@ -146,11 +145,11 @@ private:
       // TODO: replace with cuda::ptx::prefetch_L1/L2 once exposed in libcudacxx
       if constexpr (Level == LoadPrefetch::l1)
       {
-        asm volatile("prefetch.global.L1 [%0];" : : "l"(::cuda::ptx::__as_ptr_gmem(src_ptr + offset)) : "memory");
+        asm volatile("prefetch.global.L1 [%0];" : : "l"(::__cvta_generic_to_global(src_ptr + offset)) : "memory");
       }
       else
       {
-        asm volatile("prefetch.global.L2 [%0];" : : "l"(::cuda::ptx::__as_ptr_gmem(src_ptr + offset)) : "memory");
+        asm volatile("prefetch.global.L2 [%0];" : : "l"(::__cvta_generic_to_global(src_ptr + offset)) : "memory");
       }
     }
   }

--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -84,15 +84,20 @@ inline constexpr bool can_prefetch_from = ::cuda::std::contiguous_iterator<It> &
 template <int ThreadsPerBlock, LoadPrefetch PrefetchLevel = LoadPrefetch::l2, int PrefetchStride = 128>
 struct BlockPrefetch
 {
-  //! Cooperatively emit prefetch hints covering the tile ``[block_src_it, block_src_it + items_to_prefetch)``
+  //! Cooperatively emit prefetch hints covering the tile ``[tile_base, tile_base + items_to_prefetch)``.
+  //!
+  //! @param tile_base Iterator to the first item of the calling block's tile.
+  //! @param items_to_prefetch Total number of items in the tile, across all threads of the block — NOT a
+  //!   per-thread count. Same semantics as ``BlockLoad::Load``'s ``valid_items``: pass e.g.
+  //!   ``min(num_remaining, TILE_ITEMS)`` for a partial tile.
   template <typename It>
-  static _CCCL_DEVICE _CCCL_FORCEINLINE void Prefetch(It block_src_it, int items_to_prefetch)
+  static _CCCL_DEVICE _CCCL_FORCEINLINE void Prefetch(It tile_base, int items_to_prefetch)
   {
     if constexpr (PrefetchLevel != LoadPrefetch::none && can_prefetch_from<It>)
     {
       const int linear_tid           = static_cast<int>(threadIdx.x);
       const unsigned int total_bytes = static_cast<unsigned int>(items_to_prefetch) * unsigned{sizeof(it_value_t<It>)};
-      const auto* const src_ptr      = reinterpret_cast<const char*>(::cuda::std::to_address(block_src_it));
+      const auto* const src_ptr      = reinterpret_cast<const char*>(::cuda::std::to_address(tile_base));
 
       if constexpr (PrefetchLevel == LoadPrefetch::bulk_l2)
       {

--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -43,8 +43,9 @@ enum class LoadPrefetch : int
   //! Emit an L1 prefetch hint (``prefetch.global.L1``) to all affected cache lines. Falls back to L2 on
   //! architectures that do not support real L1 prefetch.
   l1,
-  //! Emit a TMA bulk prefetch into L2 (``cp.async.bulk.prefetch``) for the whole tile.
-  //! Requires SM_90 or later (Hopper/Blackwell). Falls back to a no-op on older architectures.
+  //! Emit a TMA bulk prefetch into L2 (``cp.async.bulk.prefetch``) for the whole tile on SM_90 or later
+  //! (Hopper/Blackwell). On older architectures falls back to the same strided per-cache-line L2 prefetch
+  //! as ``l2``, so the tile still reaches L2 — via a different mechanism with different (unmeasured) cost.
   bulk_l2,
 };
 
@@ -95,50 +96,61 @@ struct BlockPrefetch
   {
     if constexpr (PrefetchLevel != LoadPrefetch::none && can_prefetch_from<It>)
     {
-      const int linear_tid      = static_cast<int>(threadIdx.x);
       const int total_bytes     = items_to_prefetch * static_cast<int>(sizeof(it_value_t<It>));
       const auto* const src_ptr = reinterpret_cast<const char*>(::cuda::std::to_address(tile_base));
-
-      // Suppress "variable declared but not referenced" MSVC error
-      (void) linear_tid;
-      (void) total_bytes;
-      (void) src_ptr;
+      if (total_bytes <= 0)
+      {
+        return;
+      }
 
       if constexpr (PrefetchLevel == LoadPrefetch::bulk_l2)
       {
         // One elected thread issues a single TMA bulk prefetch for the whole tile.
         // cp.async.bulk.prefetch is fire-and-forget: no commit_group/wait_group needed.
-        // Requires SM_90+; a no-op on older architectures.
-        NV_IF_TARGET(NV_PROVIDES_SM_90, ({
-                       if (total_bytes > 0 && ::cuda::device::__block_elect_one())
-                       {
-                         // srcMem must be 16-byte aligned per PTX ISA; align base down and extend size to compensate
-                         const auto* const aligned_base = ::cuda::align_down(src_ptr, 16);
-                         const unsigned int prefix      = static_cast<unsigned int>(src_ptr - aligned_base);
-                         const unsigned int aligned_size =
-                           ::cuda::round_up(static_cast<unsigned int>(total_bytes) + prefix, 16u);
-                         asm volatile("cp.async.bulk.prefetch.L2.global [%0], %1;"
-                                      :
-                                      : "l"(::cuda::ptx::__as_ptr_gmem(aligned_base)), "r"(aligned_size)
-                                      : "memory");
-                       }
-                     }))
+        // Requires SM_90+; on older architectures fall back to the strided L2 prefetch.
+        NV_IF_ELSE_TARGET(
+          NV_PROVIDES_SM_90,
+          ({
+            if (::cuda::device::__block_elect_one())
+            {
+              // srcMem must be 16-byte aligned per PTX ISA; align base down and extend size to compensate
+              const auto* const aligned_base = ::cuda::align_down(src_ptr, 16);
+              const unsigned int prefix      = static_cast<unsigned int>(src_ptr - aligned_base);
+              const unsigned int aligned_size =
+                ::cuda::round_up(static_cast<unsigned int>(total_bytes) + prefix, 16u);
+              asm volatile("cp.async.bulk.prefetch.L2.global [%0], %1;"
+                           :
+                           : "l"(::cuda::ptx::__as_ptr_gmem(aligned_base)), "r"(aligned_size)
+                           : "memory");
+            }
+          }),
+          ({ __strided_prefetch<LoadPrefetch::l2>(src_ptr, total_bytes); }))
       }
       else
       {
-        _CCCL_PRAGMA_NOUNROLL()
-        for (int offset = linear_tid * PrefetchStride; offset < total_bytes; offset += ThreadsPerBlock * PrefetchStride)
-        {
-          // TODO: replace with cuda::ptx::prefetch_L1/L2 once exposed in libcudacxx
-          if constexpr (PrefetchLevel == LoadPrefetch::l1)
-          {
-            asm volatile("prefetch.global.L1 [%0];" : : "l"(::cuda::ptx::__as_ptr_gmem(src_ptr + offset)) : "memory");
-          }
-          else
-          {
-            asm volatile("prefetch.global.L2 [%0];" : : "l"(::cuda::ptx::__as_ptr_gmem(src_ptr + offset)) : "memory");
-          }
-        }
+        __strided_prefetch<PrefetchLevel>(src_ptr, total_bytes);
+      }
+    }
+  }
+
+private:
+  //! The block's threads cooperatively walk ``[src_ptr, src_ptr + total_bytes)`` in ``PrefetchStride``-byte
+  //! steps, each issuing one prefetch hint per cache line targeting ``Level`` (``l1`` or ``l2``).
+  template <LoadPrefetch Level>
+  static _CCCL_DEVICE _CCCL_FORCEINLINE void __strided_prefetch(const char* src_ptr, int total_bytes)
+  {
+    _CCCL_PRAGMA_NOUNROLL()
+    for (int offset = static_cast<int>(threadIdx.x) * PrefetchStride; offset < total_bytes;
+         offset += ThreadsPerBlock * PrefetchStride)
+    {
+      // TODO: replace with cuda::ptx::prefetch_L1/L2 once exposed in libcudacxx
+      if constexpr (Level == LoadPrefetch::l1)
+      {
+        asm volatile("prefetch.global.L1 [%0];" : : "l"(::cuda::ptx::__as_ptr_gmem(src_ptr + offset)) : "memory");
+      }
+      else
+      {
+        asm volatile("prefetch.global.L2 [%0];" : : "l"(::cuda::ptx::__as_ptr_gmem(src_ptr + offset)) : "memory");
       }
     }
   }

--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -94,7 +94,7 @@ struct BlockPrefetch
   //! @param items_to_prefetch Total number of items in the tile, across all threads of the block — NOT a
   //!   per-thread count. Must be non-negative.
   template <typename It>
-  static _CCCL_DEVICE _CCCL_FORCEINLINE void Prefetch(It tile_base, int items_to_prefetch)
+  static _CCCL_DEVICE_API _CCCL_FORCEINLINE void Prefetch(It tile_base, int items_to_prefetch)
   {
     if constexpr (PrefetchLevel != LoadPrefetch::none && can_prefetch_from<It>)
     {
@@ -138,7 +138,7 @@ private:
   //! The block's threads cooperatively walk ``[src_ptr, src_ptr + total_bytes)`` in ``PrefetchStride``-byte
   //! steps, each issuing one prefetch hint per cache line targeting ``Level`` (``l1`` or ``l2``).
   template <LoadPrefetch Level>
-  static _CCCL_DEVICE _CCCL_FORCEINLINE void __strided_prefetch(const char* src_ptr, int total_bytes)
+  static _CCCL_DEVICE_API _CCCL_FORCEINLINE void __strided_prefetch(const char* src_ptr, int total_bytes)
   {
     const int start    = static_cast<int>(threadIdx.x) * PrefetchStride;
     constexpr int step = ThreadsPerBlock * PrefetchStride;

--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -72,6 +72,7 @@ inline ::std::ostream& operator<<(::std::ostream& os, LoadPrefetch prefetch)
 
 // Prefetch hints require a raw address, so only contiguous iterators qualify. thrust::is_contiguous_iterator
 // covers raw pointers, std/libcu++ contiguous iterators, thrust vector iterators, and proclaimed types.
+// TODO(#9893): replace with the unified CCCL iterator-to-pointer mechanism once it exists.
 // Note: ``cub::CacheModifiedInputIterator`` does not qualify: it routes loads through an explicit cache path
 // (e.g. ``LOAD_NC``) that a prefetch hint would defeat.
 template <typename It>

--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -109,22 +109,22 @@ struct BlockPrefetch
         // One elected thread issues a single TMA bulk prefetch for the whole tile.
         // cp.async.bulk.prefetch is fire-and-forget: no commit_group/wait_group needed.
         // Requires SM_90+; on older architectures fall back to the strided L2 prefetch.
-        NV_IF_ELSE_TARGET(
-          NV_PROVIDES_SM_90,
-          ({
-            if (::cuda::device::__block_elect_one())
-            {
-              // srcMem must be 16-byte aligned per PTX ISA; align the range outward on both ends to compensate
-              const auto* aligned_base = ::cuda::align_down(src_ptr, 16);
-              const auto* aligned_end  = ::cuda::align_up(src_ptr + total_bytes, 16);
-              const auto aligned_size  = static_cast<unsigned>(aligned_end - aligned_base);
-              asm volatile("cp.async.bulk.prefetch.L2.global [%0], %1;"
-                           :
-                           : "l"(::__cvta_generic_to_global(aligned_base)), "r"(aligned_size)
-                           : "memory");
-            }
-          }),
-          ({ __strided_prefetch<LoadPrefetch::l2>(src_ptr, total_bytes); }))
+        NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,
+                          ({
+                            if (::cuda::device::__block_elect_one())
+                            {
+                              // srcMem must be 16-byte aligned per PTX ISA; align the range outward on both ends to
+                              // compensate
+                              const auto* aligned_base = ::cuda::align_down(src_ptr, 16);
+                              const auto* aligned_end  = ::cuda::align_up(src_ptr + total_bytes, 16);
+                              const auto aligned_size  = static_cast<unsigned>(aligned_end - aligned_base);
+                              asm volatile("cp.async.bulk.prefetch.L2.global [%0], %1;"
+                                           :
+                                           : "l"(::__cvta_generic_to_global(aligned_base)), "r"(aligned_size)
+                                           : "memory");
+                            }
+                          }),
+                          ({ __strided_prefetch<LoadPrefetch::l2>(src_ptr, total_bytes); }))
       }
       else
       {
@@ -139,18 +139,20 @@ private:
   template <LoadPrefetch Level>
   static _CCCL_DEVICE _CCCL_FORCEINLINE void __strided_prefetch(const char* src_ptr, int total_bytes)
   {
+    const int start    = static_cast<int>(threadIdx.x) * PrefetchStride;
+    constexpr int step = ThreadsPerBlock * PrefetchStride;
     _CCCL_PRAGMA_NOUNROLL()
-    for (int offset = static_cast<int>(threadIdx.x) * PrefetchStride; offset < total_bytes;
-         offset += ThreadsPerBlock * PrefetchStride)
+    for (int offset = start; offset < total_bytes; offset += step)
     {
+      const auto gmem_ptr = ::__cvta_generic_to_global(src_ptr + offset);
       // TODO: replace with cuda::ptx::prefetch_L1/L2 once exposed in libcudacxx
       if constexpr (Level == LoadPrefetch::l1)
       {
-        asm volatile("prefetch.global.L1 [%0];" : : "l"(::__cvta_generic_to_global(src_ptr + offset)) : "memory");
+        asm volatile("prefetch.global.L1 [%0];" : : "l"(gmem_ptr) : "memory");
       }
       else
       {
-        asm volatile("prefetch.global.L2 [%0];" : : "l"(::__cvta_generic_to_global(src_ptr + offset)) : "memory");
+        asm volatile("prefetch.global.L2 [%0];" : : "l"(gmem_ptr) : "memory");
       }
     }
   }

--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -97,6 +97,9 @@ struct BlockPrefetch
   {
     if constexpr (PrefetchLevel != LoadPrefetch::none && can_prefetch_from<It>)
     {
+      // The tile is strided by the linear thread id, which this implementation derives from threadIdx.x alone
+      _CCCL_ASSERT(blockDim.y == 1 && blockDim.z == 1, "BlockPrefetch requires a one-dimensional thread block");
+
       const int total_bytes = items_to_prefetch * static_cast<int>(sizeof(it_value_t<It>));
       const auto src_ptr    = ::cuda::ptr_rebind<char>(::cuda::std::to_address(tile_base));
       if (total_bytes <= 0)

--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 //! @file
-//! Cooperative global-memory prefetch hints for tiles of data, placed explicitly by algorithm agents (or kernel
-//! authors) at points in the kernel schedule where the hint has lead time before the corresponding loads.
+//! Cooperative global-memory prefetch hints for tiles of data, placed explicitly in device code
+//! at points where the hint has lead time before the corresponding loads.
 
 #pragma once
 
@@ -90,8 +90,7 @@ struct BlockPrefetch
   //!
   //! @param tile_base Iterator to the first item of the calling block's tile.
   //! @param items_to_prefetch Total number of items in the tile, across all threads of the block — NOT a
-  //!   per-thread count. Same semantics as ``BlockLoad::Load``'s ``block_items_end``: pass e.g.
-  //!   ``min(num_remaining, TILE_ITEMS)`` for a partial tile. Must be non-negative.
+  //!   per-thread count. Must be non-negative.
   template <typename It>
   static _CCCL_DEVICE _CCCL_FORCEINLINE void Prefetch(It tile_base, int items_to_prefetch)
   {

--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -95,9 +95,9 @@ struct BlockPrefetch
   {
     if constexpr (PrefetchLevel != LoadPrefetch::none && can_prefetch_from<It>)
     {
-      const int linear_tid           = static_cast<int>(threadIdx.x);
-      const unsigned int total_bytes = static_cast<unsigned int>(items_to_prefetch) * unsigned{sizeof(it_value_t<It>)};
-      const auto* const src_ptr      = reinterpret_cast<const char*>(::cuda::std::to_address(tile_base));
+      const int linear_tid      = static_cast<int>(threadIdx.x);
+      const int total_bytes     = items_to_prefetch * static_cast<int>(sizeof(it_value_t<It>));
+      const auto* const src_ptr = reinterpret_cast<const char*>(::cuda::std::to_address(tile_base));
 
       if constexpr (PrefetchLevel == LoadPrefetch::bulk_l2)
       {
@@ -105,27 +105,24 @@ struct BlockPrefetch
         // cp.async.bulk.prefetch is fire-and-forget: no commit_group/wait_group needed.
         // Requires SM_90+; a no-op on older architectures.
         NV_IF_TARGET(NV_PROVIDES_SM_90, ({
-                       if (::cuda::device::__block_elect_one())
+                       if (total_bytes > 0 && ::cuda::device::__block_elect_one())
                        {
                          // srcMem must be 16-byte aligned per PTX ISA; align base down and extend size to compensate
-                         const auto* const aligned_base  = ::cuda::align_down(src_ptr, 16);
-                         const unsigned int prefix       = static_cast<unsigned int>(src_ptr - aligned_base);
-                         const unsigned int aligned_size = ::cuda::round_up(total_bytes + prefix, 16u);
-                         if (aligned_size > 0)
-                         {
-                           asm volatile("cp.async.bulk.prefetch.L2.global [%0], %1;"
-                                        :
-                                        : "l"(::cuda::ptx::__as_ptr_gmem(aligned_base)), "r"(aligned_size)
-                                        : "memory");
-                         }
+                         const auto* const aligned_base = ::cuda::align_down(src_ptr, 16);
+                         const unsigned int prefix      = static_cast<unsigned int>(src_ptr - aligned_base);
+                         const unsigned int aligned_size =
+                           ::cuda::round_up(static_cast<unsigned int>(total_bytes) + prefix, 16u);
+                         asm volatile("cp.async.bulk.prefetch.L2.global [%0], %1;"
+                                      :
+                                      : "l"(::cuda::ptx::__as_ptr_gmem(aligned_base)), "r"(aligned_size)
+                                      : "memory");
                        }
                      }))
       }
       else
       {
         _CCCL_PRAGMA_NOUNROLL()
-        for (unsigned int offset = static_cast<unsigned int>(linear_tid) * PrefetchStride; offset < total_bytes;
-             offset += static_cast<unsigned int>(ThreadsPerBlock) * PrefetchStride)
+        for (int offset = linear_tid * PrefetchStride; offset < total_bytes; offset += ThreadsPerBlock * PrefetchStride)
         {
           // TODO: replace with cuda::ptx::prefetch_L1/L2 once exposed in libcudacxx
           if constexpr (PrefetchLevel == LoadPrefetch::l1)

--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -91,7 +91,7 @@ struct BlockPrefetch
   //! @param tile_base Iterator to the first item of the calling block's tile.
   //! @param items_to_prefetch Total number of items in the tile, across all threads of the block — NOT a
   //!   per-thread count. Same semantics as ``BlockLoad::Load``'s ``block_items_end``: pass e.g.
-  //!   ``min(num_remaining, TILE_ITEMS)`` for a partial tile.
+  //!   ``min(num_remaining, TILE_ITEMS)`` for a partial tile. Must be non-negative.
   template <typename It>
   static _CCCL_DEVICE _CCCL_FORCEINLINE void Prefetch(It tile_base, int items_to_prefetch)
   {
@@ -99,13 +99,10 @@ struct BlockPrefetch
     {
       // The tile is strided by the linear thread id, which this implementation derives from threadIdx.x alone
       _CCCL_ASSERT(blockDim.y == 1 && blockDim.z == 1, "BlockPrefetch requires a one-dimensional thread block");
+      _CCCL_ASSERT(items_to_prefetch >= 0, "items_to_prefetch must be non-negative");
 
-      const int total_bytes = items_to_prefetch * static_cast<int>(sizeof(it_value_t<It>));
+      const int total_bytes = items_to_prefetch * int{sizeof(it_value_t<It>)};
       const auto src_ptr    = ::cuda::ptr_rebind<char>(::cuda::std::to_address(tile_base));
-      if (total_bytes <= 0)
-      {
-        return;
-      }
 
       if constexpr (PrefetchLevel == LoadPrefetch::bulk_l2)
       {

--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -40,8 +40,9 @@ enum class LoadPrefetch : int
   none,
   //! Emit an L2 prefetch hint (``prefetch.global.L2``) to all affected cache lines.
   l2,
-  //! Emit an L1 prefetch hint (``prefetch.global.L1``) to all affected cache lines. Falls back to L2 on
-  //! architectures that do not support real L1 prefetch.
+  //! Emit an L1 prefetch hint (``prefetch.global.L1``) to all affected cache lines. The emitted instruction is
+  //! always ``prefetch.global.L1``; on architectures without real L1 prefetch the hardware itself services the
+  //! hint as an L2 prefetch (e.g. on Blackwell).
   l1,
   //! Emit a TMA bulk prefetch into L2 (``cp.async.bulk.prefetch``) for the whole tile on SM_90 or later
   //! (Hopper/Blackwell). On older architectures falls back to the same strided per-cache-line L2 prefetch
@@ -89,7 +90,7 @@ struct BlockPrefetch
   //!
   //! @param tile_base Iterator to the first item of the calling block's tile.
   //! @param items_to_prefetch Total number of items in the tile, across all threads of the block — NOT a
-  //!   per-thread count. Same semantics as ``BlockLoad::Load``'s ``valid_items``: pass e.g.
+  //!   per-thread count. Same semantics as ``BlockLoad::Load``'s ``block_items_end``: pass e.g.
   //!   ``min(num_remaining, TILE_ITEMS)`` for a partial tile.
   template <typename It>
   static _CCCL_DEVICE _CCCL_FORCEINLINE void Prefetch(It tile_base, int items_to_prefetch)

--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3
+
+//! @file
+//! Cooperative global-memory prefetch hints for tiles of data, placed explicitly by algorithm agents (or kernel
+//! authors) at points in the kernel schedule where the hint has lead time before the corresponding loads.
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/util_type.cuh>
+
+#include <cuda/__cmath/round_up.h>
+#include <cuda/__memcpy_async/elect_one.h>
+#include <cuda/__memory/align_down.h>
+#include <cuda/__ptx/ptx_helper_functions.h>
+#include <cuda/std/__host_stdlib/ostream>
+#include <cuda/std/__iterator/concepts.h>
+#include <cuda/std/__memory/pointer_traits.h>
+
+#include <nv/target>
+
+CUB_NAMESPACE_BEGIN
+
+namespace detail
+{
+//! Enumerates the cache levels a tile prefetch hint can target.
+enum class LoadPrefetch : int
+{
+  //! No prefetch hint emitted.
+  none,
+  //! Emit an L2 prefetch hint (``prefetch.global.L2``) to all affected cache lines.
+  l2,
+  //! Emit an L1 prefetch hint (``prefetch.global.L1``) to all affected cache lines. Falls back to L2 on
+  //! architectures that do not support real L1 prefetch.
+  l1,
+  //! Emit a TMA bulk prefetch into L2 (``cp.async.bulk.prefetch``) for the whole tile.
+  //! Requires SM_90 or later (Hopper/Blackwell). Falls back to a no-op on older architectures.
+  bulk_l2,
+};
+
+#if _CCCL_HOSTED() && !defined(_CCCL_DOXYGEN_INVOKED)
+inline ::std::ostream& operator<<(::std::ostream& os, LoadPrefetch prefetch)
+{
+  switch (prefetch)
+  {
+    case LoadPrefetch::none:
+      return os << "detail::LoadPrefetch::none";
+    case LoadPrefetch::l2:
+      return os << "detail::LoadPrefetch::l2";
+    case LoadPrefetch::l1:
+      return os << "detail::LoadPrefetch::l1";
+    case LoadPrefetch::bulk_l2:
+      return os << "detail::LoadPrefetch::bulk_l2";
+    default:
+      return os << "<unknown detail::LoadPrefetch: " << static_cast<int>(prefetch) << ">";
+  }
+}
+#endif // _CCCL_HOSTED() && !_CCCL_DOXYGEN_INVOKED
+
+// Prefetch hints require a raw address, so only contiguous iterators qualify.
+// Note: ``cub::CacheModifiedInputIterator`` does not qualify: it routes loads through an explicit cache path
+// (e.g. ``LOAD_NC``) that a prefetch hint would defeat.
+template <typename RandomAccessIterator>
+inline constexpr bool can_prefetch_from =
+  ::cuda::std::contiguous_iterator<RandomAccessIterator> && ::cuda::std::__can_to_address<RandomAccessIterator>;
+
+//! A block-scope collective that cooperatively emits global-memory prefetch hints for a tile. The element type
+//! ``T`` and block size ``ThreadsPerBlock`` are fixed on the type; the cache level (``Prefetch``) and the
+//! per-cache-line hint spacing (``PrefetchStride``, bytes) are template configuration. Placement in the kernel
+//! schedule is the caller's — fire it where there is lead time before the corresponding loads.
+//!
+//! @tparam T             Element type of the tile being prefetched (drives the byte-size math).
+//! @tparam ThreadsPerBlock Number of threads in the block cooperating on the hints.
+//! @tparam Prefetch      Which cache level to target (see ``LoadPrefetch``); ``none`` makes ``Prefetch()`` a no-op.
+//! @tparam PrefetchStride Byte stride between successive hints; one hint per cache line (default 128 B).
+template <typename T, int ThreadsPerBlock, LoadPrefetch Prefetch = LoadPrefetch::l2, int PrefetchStride = 128>
+struct BlockPrefetch
+{
+  //! Cooperatively emit prefetch hints covering the tile ``[block_src_it, block_src_it + items_to_prefetch)``
+  template <typename RandomAccessIterator>
+  static _CCCL_DEVICE _CCCL_FORCEINLINE void Prefetch(RandomAccessIterator block_src_it, int items_to_prefetch)
+  {
+    if constexpr (Prefetch != LoadPrefetch::none && can_prefetch_from<RandomAccessIterator>)
+    {
+      static_assert(sizeof(cub::detail::it_value_t<RandomAccessIterator>) == sizeof(T),
+                    "BlockPrefetch element type T must match the iterator's value type size");
+      const int linear_tid           = static_cast<int>(threadIdx.x);
+      const unsigned int total_bytes = static_cast<unsigned int>(items_to_prefetch) * unsigned{sizeof(T)};
+      const auto* const src_ptr      = reinterpret_cast<const char*>(::cuda::std::to_address(block_src_it));
+
+      if constexpr (Prefetch == LoadPrefetch::bulk_l2)
+      {
+        // One elected thread issues a single TMA bulk prefetch for the whole tile.
+        // cp.async.bulk.prefetch is fire-and-forget: no commit_group/wait_group needed.
+        // Requires SM_90+; a no-op on older architectures.
+        NV_IF_TARGET(NV_PROVIDES_SM_90, (if (::cuda::device::__block_elect_one()) {
+                       // srcMem must be 16-byte aligned per PTX ISA; align base down and extend size to compensate
+                       const auto* const aligned_base  = ::cuda::align_down(src_ptr, 16);
+                       const unsigned int prefix       = static_cast<unsigned int>(src_ptr - aligned_base);
+                       const unsigned int aligned_size = ::cuda::round_up(total_bytes + prefix, 16u);
+                       if (aligned_size > 0)
+                       {
+                         asm volatile("cp.async.bulk.prefetch.L2.global [%0], %1;"
+                                      :
+                                      : "l"(::cuda::ptx::__as_ptr_gmem(aligned_base)), "r"(aligned_size)
+                                      : "memory");
+                       }
+                     }))
+      }
+      else
+      {
+        _CCCL_PRAGMA_NOUNROLL()
+        for (unsigned int offset = static_cast<unsigned int>(linear_tid) * PrefetchStride; offset < total_bytes;
+             offset += static_cast<unsigned int>(ThreadsPerBlock) * PrefetchStride)
+        {
+          // TODO: replace with cuda::ptx::prefetch_L1/L2 once exposed in libcudacxx
+          if constexpr (Prefetch == LoadPrefetch::l1)
+          {
+            asm volatile("prefetch.global.L1 [%0];" : : "l"(::cuda::ptx::__as_ptr_gmem(src_ptr + offset)) : "memory");
+          }
+          else
+          {
+            asm volatile("prefetch.global.L2 [%0];" : : "l"(::cuda::ptx::__as_ptr_gmem(src_ptr + offset)) : "memory");
+          }
+        }
+      }
+    }
+  }
+};
+} // namespace detail
+
+CUB_NAMESPACE_END

--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -151,6 +151,8 @@ private:
     {
       const auto gmem_ptr = ::__cvta_generic_to_global(src_ptr + offset);
       // TODO: replace with cuda::ptx::prefetch_L1/L2 once exposed in libcudacxx
+      // clang-tidy ignores the differing asm strings: https://github.com/llvm/llvm-project/issues/198616
+      // NOLINTBEGIN(bugprone-branch-clone)
       if constexpr (Level == LoadPrefetch::l1)
       {
         asm volatile("prefetch.global.L1 [%0];" : : "l"(gmem_ptr) : "memory");
@@ -159,6 +161,7 @@ private:
       {
         asm volatile("prefetch.global.L2 [%0];" : : "l"(gmem_ptr) : "memory");
       }
+      // NOLINTEND(bugprone-branch-clone)
     }
   }
 };

--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -48,7 +48,7 @@ enum class LoadPrefetch : int
   bulk_l2,
 };
 
-#if _CCCL_HOSTED() && !defined(_CCCL_DOXYGEN_INVOKED)
+#if _CCCL_HOSTED()
 inline ::std::ostream& operator<<(::std::ostream& os, LoadPrefetch prefetch)
 {
   switch (prefetch)
@@ -65,7 +65,7 @@ inline ::std::ostream& operator<<(::std::ostream& os, LoadPrefetch prefetch)
       return os << "<unknown detail::LoadPrefetch: " << static_cast<int>(prefetch) << ">";
   }
 }
-#endif // _CCCL_HOSTED() && !_CCCL_DOXYGEN_INVOKED
+#endif // _CCCL_HOSTED()
 
 // Prefetch hints require a raw address, so only contiguous iterators qualify.
 // Note: ``cub::CacheModifiedInputIterator`` does not qualify: it routes loads through an explicit cache path
@@ -104,17 +104,20 @@ struct BlockPrefetch
         // One elected thread issues a single TMA bulk prefetch for the whole tile.
         // cp.async.bulk.prefetch is fire-and-forget: no commit_group/wait_group needed.
         // Requires SM_90+; a no-op on older architectures.
-        NV_IF_TARGET(NV_PROVIDES_SM_90, (if (::cuda::device::__block_elect_one()) {
-                       // srcMem must be 16-byte aligned per PTX ISA; align base down and extend size to compensate
-                       const auto* const aligned_base  = ::cuda::align_down(src_ptr, 16);
-                       const unsigned int prefix       = static_cast<unsigned int>(src_ptr - aligned_base);
-                       const unsigned int aligned_size = ::cuda::round_up(total_bytes + prefix, 16u);
-                       if (aligned_size > 0)
+        NV_IF_TARGET(NV_PROVIDES_SM_90, ({
+                       if (::cuda::device::__block_elect_one())
                        {
-                         asm volatile("cp.async.bulk.prefetch.L2.global [%0], %1;"
-                                      :
-                                      : "l"(::cuda::ptx::__as_ptr_gmem(aligned_base)), "r"(aligned_size)
-                                      : "memory");
+                         // srcMem must be 16-byte aligned per PTX ISA; align base down and extend size to compensate
+                         const auto* const aligned_base  = ::cuda::align_down(src_ptr, 16);
+                         const unsigned int prefix       = static_cast<unsigned int>(src_ptr - aligned_base);
+                         const unsigned int aligned_size = ::cuda::round_up(total_bytes + prefix, 16u);
+                         if (aligned_size > 0)
+                         {
+                           asm volatile("cp.async.bulk.prefetch.L2.global [%0], %1;"
+                                        :
+                                        : "l"(::cuda::ptx::__as_ptr_gmem(aligned_base)), "r"(aligned_size)
+                                        : "memory");
+                         }
                        }
                      }))
       }

--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -19,9 +19,9 @@
 
 #include <cub/util_type.cuh>
 
-#include <cuda/__cmath/round_up.h>
 #include <cuda/__memcpy_async/elect_one.h>
 #include <cuda/__memory/align_down.h>
+#include <cuda/__memory/align_up.h>
 #include <cuda/__memory/ptr_rebind.h>
 #include <cuda/std/__host_stdlib/ostream>
 #include <cuda/std/__iterator/concepts.h>
@@ -117,10 +117,10 @@ struct BlockPrefetch
           ({
             if (::cuda::device::__block_elect_one())
             {
-              // srcMem must be 16-byte aligned per PTX ISA; align base down and extend size to compensate
+              // srcMem must be 16-byte aligned per PTX ISA; align the range outward on both ends to compensate
               const auto* aligned_base = ::cuda::align_down(src_ptr, 16);
-              const auto prefix        = static_cast<unsigned>(src_ptr - aligned_base);
-              const auto aligned_size  = ::cuda::round_up(static_cast<unsigned>(total_bytes) + prefix, 16u);
+              const auto* aligned_end  = ::cuda::align_up(src_ptr + total_bytes, 16);
+              const auto aligned_size  = static_cast<unsigned>(aligned_end - aligned_base);
               asm volatile("cp.async.bulk.prefetch.L2.global [%0], %1;"
                            :
                            : "l"(::__cvta_generic_to_global(aligned_base)), "r"(aligned_size)

--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 //! @file
 //! Cooperative global-memory prefetch hints for tiles of data, placed explicitly by algorithm agents (or kernel
@@ -70,32 +70,28 @@ inline ::std::ostream& operator<<(::std::ostream& os, LoadPrefetch prefetch)
 // Prefetch hints require a raw address, so only contiguous iterators qualify.
 // Note: ``cub::CacheModifiedInputIterator`` does not qualify: it routes loads through an explicit cache path
 // (e.g. ``LOAD_NC``) that a prefetch hint would defeat.
-template <typename RandomAccessIterator>
-inline constexpr bool can_prefetch_from =
-  ::cuda::std::contiguous_iterator<RandomAccessIterator> && ::cuda::std::__can_to_address<RandomAccessIterator>;
+template <typename It>
+inline constexpr bool can_prefetch_from = ::cuda::std::contiguous_iterator<It> && ::cuda::std::__can_to_address<It>;
 
-//! A block-scope collective that cooperatively emits global-memory prefetch hints for a tile. The element type
-//! ``T`` and block size ``ThreadsPerBlock`` are fixed on the type; the cache level (``PrefetchLevel``) and the
-//! per-cache-line hint spacing (``PrefetchStride``, bytes) are template configuration. Placement in the kernel
-//! schedule is the caller's — fire it where there is lead time before the corresponding loads.
+//! A block-scope collective that cooperatively emits global-memory prefetch hints for a tile. The block size
+//! ``ThreadsPerBlock`` is fixed on the type; the cache level (``PrefetchLevel``) and the per-cache-line hint
+//! spacing (``PrefetchStride``, bytes) are template configuration. Placement in the kernel schedule is the
+//! caller's — fire it where there is lead time before the corresponding loads.
 //!
-//! @tparam T             Element type of the tile being prefetched (drives the byte-size math).
 //! @tparam ThreadsPerBlock Number of threads in the block cooperating on the hints.
 //! @tparam PrefetchLevel  Which cache level to target (see ``LoadPrefetch``); ``none`` makes ``Prefetch()`` a no-op.
 //! @tparam PrefetchStride Byte stride between successive hints; one hint per cache line (default 128 B).
-template <typename T, int ThreadsPerBlock, LoadPrefetch PrefetchLevel = LoadPrefetch::l2, int PrefetchStride = 128>
+template <int ThreadsPerBlock, LoadPrefetch PrefetchLevel = LoadPrefetch::l2, int PrefetchStride = 128>
 struct BlockPrefetch
 {
   //! Cooperatively emit prefetch hints covering the tile ``[block_src_it, block_src_it + items_to_prefetch)``
-  template <typename RandomAccessIterator>
-  static _CCCL_DEVICE _CCCL_FORCEINLINE void Prefetch(RandomAccessIterator block_src_it, int items_to_prefetch)
+  template <typename It>
+  static _CCCL_DEVICE _CCCL_FORCEINLINE void Prefetch(It block_src_it, int items_to_prefetch)
   {
-    if constexpr (PrefetchLevel != LoadPrefetch::none && can_prefetch_from<RandomAccessIterator>)
+    if constexpr (PrefetchLevel != LoadPrefetch::none && can_prefetch_from<It>)
     {
-      static_assert(sizeof(cub::detail::it_value_t<RandomAccessIterator>) == sizeof(T),
-                    "BlockPrefetch element type T must match the iterator's value type size");
       const int linear_tid           = static_cast<int>(threadIdx.x);
-      const unsigned int total_bytes = static_cast<unsigned int>(items_to_prefetch) * unsigned{sizeof(T)};
+      const unsigned int total_bytes = static_cast<unsigned int>(items_to_prefetch) * unsigned{sizeof(it_value_t<It>)};
       const auto* const src_ptr      = reinterpret_cast<const char*>(::cuda::std::to_address(block_src_it));
 
       if constexpr (PrefetchLevel == LoadPrefetch::bulk_l2)

--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: BSD-3
+// SPDX-License-Identifier: BSD-3-Clause
 
 //! @file
 //! Cooperative global-memory prefetch hints for tiles of data, placed explicitly by algorithm agents (or kernel
@@ -75,22 +75,22 @@ inline constexpr bool can_prefetch_from =
   ::cuda::std::contiguous_iterator<RandomAccessIterator> && ::cuda::std::__can_to_address<RandomAccessIterator>;
 
 //! A block-scope collective that cooperatively emits global-memory prefetch hints for a tile. The element type
-//! ``T`` and block size ``ThreadsPerBlock`` are fixed on the type; the cache level (``Prefetch``) and the
+//! ``T`` and block size ``ThreadsPerBlock`` are fixed on the type; the cache level (``PrefetchLevel``) and the
 //! per-cache-line hint spacing (``PrefetchStride``, bytes) are template configuration. Placement in the kernel
 //! schedule is the caller's — fire it where there is lead time before the corresponding loads.
 //!
 //! @tparam T             Element type of the tile being prefetched (drives the byte-size math).
 //! @tparam ThreadsPerBlock Number of threads in the block cooperating on the hints.
-//! @tparam Prefetch      Which cache level to target (see ``LoadPrefetch``); ``none`` makes ``Prefetch()`` a no-op.
+//! @tparam PrefetchLevel  Which cache level to target (see ``LoadPrefetch``); ``none`` makes ``Prefetch()`` a no-op.
 //! @tparam PrefetchStride Byte stride between successive hints; one hint per cache line (default 128 B).
-template <typename T, int ThreadsPerBlock, LoadPrefetch Prefetch = LoadPrefetch::l2, int PrefetchStride = 128>
+template <typename T, int ThreadsPerBlock, LoadPrefetch PrefetchLevel = LoadPrefetch::l2, int PrefetchStride = 128>
 struct BlockPrefetch
 {
   //! Cooperatively emit prefetch hints covering the tile ``[block_src_it, block_src_it + items_to_prefetch)``
   template <typename RandomAccessIterator>
   static _CCCL_DEVICE _CCCL_FORCEINLINE void Prefetch(RandomAccessIterator block_src_it, int items_to_prefetch)
   {
-    if constexpr (Prefetch != LoadPrefetch::none && can_prefetch_from<RandomAccessIterator>)
+    if constexpr (PrefetchLevel != LoadPrefetch::none && can_prefetch_from<RandomAccessIterator>)
     {
       static_assert(sizeof(cub::detail::it_value_t<RandomAccessIterator>) == sizeof(T),
                     "BlockPrefetch element type T must match the iterator's value type size");
@@ -98,7 +98,7 @@ struct BlockPrefetch
       const unsigned int total_bytes = static_cast<unsigned int>(items_to_prefetch) * unsigned{sizeof(T)};
       const auto* const src_ptr      = reinterpret_cast<const char*>(::cuda::std::to_address(block_src_it));
 
-      if constexpr (Prefetch == LoadPrefetch::bulk_l2)
+      if constexpr (PrefetchLevel == LoadPrefetch::bulk_l2)
       {
         // One elected thread issues a single TMA bulk prefetch for the whole tile.
         // cp.async.bulk.prefetch is fire-and-forget: no commit_group/wait_group needed.
@@ -124,7 +124,7 @@ struct BlockPrefetch
              offset += static_cast<unsigned int>(ThreadsPerBlock) * PrefetchStride)
         {
           // TODO: replace with cuda::ptx::prefetch_L1/L2 once exposed in libcudacxx
-          if constexpr (Prefetch == LoadPrefetch::l1)
+          if constexpr (PrefetchLevel == LoadPrefetch::l1)
           {
             asm volatile("prefetch.global.L1 [%0];" : : "l"(::cuda::ptx::__as_ptr_gmem(src_ptr + offset)) : "memory");
           }

--- a/cub/cub/detail/prefetch.cuh
+++ b/cub/cub/detail/prefetch.cuh
@@ -89,6 +89,9 @@ inline constexpr bool can_prefetch_from = THRUST_NS_QUALIFIER::is_contiguous_ite
 template <int ThreadsPerBlock, LoadPrefetch PrefetchLevel = LoadPrefetch::l2, int PrefetchStride = 128>
 struct BlockPrefetch
 {
+  static_assert(ThreadsPerBlock > 0, "ThreadsPerBlock must be positive");
+  static_assert(PrefetchStride > 0, "PrefetchStride must be positive");
+
   //! Cooperatively emit prefetch hints covering the tile ``[tile_base, tile_base + items_to_prefetch)``.
   //!
   //! @param tile_base Iterator to the first item of the calling block's tile.

--- a/cub/test/catch2_test_block_prefetch.cu
+++ b/cub/test/catch2_test_block_prefetch.cu
@@ -4,13 +4,21 @@
 #include <cub/detail/prefetch.cuh>
 #include <cub/iterator/cache_modified_input_iterator.cuh>
 
+#include <thrust/universal_vector.h>
+
+#include <cuda/buffer>
+#include <cuda/memory_resource>
+#include <cuda/std/memory>
+#include <cuda/stream>
+
 #include <c2h/catch2_test_helper.h>
 
 // BlockPrefetch emits global-memory prefetch *hints*: they carry no functional result and cannot be observed from
-// the device program. A runtime test can therefore only assert that (1) issuing the hints never faults for any
-// level / element type / tile shape, (2) the hints never disturb the data they cover, and (3) `none` and
-// non-contiguous iterators (e.g. CacheModifiedInputIterator) compile and run as a genuine no-op. Whether the
-// intended SASS is actually emitted is verified out-of-band (cuobjdump), not here.
+// the device program. A runtime test can therefore only assert that issuing the hints compiles and never faults for
+// any level / element type / tile shape / iterator category, and that `none` and iterators rejected by
+// `can_prefetch_from` (e.g. CacheModifiedInputIterator) compile as a genuine no-op. Each kernel copies its tile
+// through so the launch has an observable, checkable result. Whether the intended SASS is actually emitted is
+// verified out-of-band (cuobjdump), not here.
 
 // Compile-time coverage of the trait that gates every hint.
 static_assert(cub::detail::can_prefetch_from<int*>, "raw pointers are contiguous and must be prefetchable");
@@ -18,8 +26,7 @@ static_assert(cub::detail::can_prefetch_from<const double*>, "const raw pointers
 static_assert(!cub::detail::can_prefetch_from<cub::CacheModifiedInputIterator<cub::CacheLoadModifier::LOAD_CS, int>>,
               "CacheModifiedInputIterator routes through an explicit cache path and must be rejected");
 
-// Prefetch the tile, then faithfully copy it through, so the launch is observable and any corruption of the
-// prefetched region is caught by the host-side comparison.
+// Prefetch the tile, then copy it through so the launch has an observable result.
 template <typename T, int ThreadsInBlock, cub::detail::LoadPrefetch Level, int Stride, typename InputIteratorT>
 __global__ void block_prefetch_kernel(InputIteratorT input, T* output, int num_items)
 {
@@ -35,14 +42,13 @@ template <typename T, int ThreadsInBlock, cub::detail::LoadPrefetch Level, int S
 void test_block_prefetch(const c2h::device_vector<T>& d_input, InputIteratorT input)
 {
   const int num_items = static_cast<int>(d_input.size());
-  c2h::device_vector<T> d_output(num_items, T{});
+  c2h::device_vector<T> d_output(num_items, thrust::no_init);
 
   block_prefetch_kernel<T, ThreadsInBlock, Level, Stride>
     <<<1, ThreadsInBlock>>>(input, thrust::raw_pointer_cast(d_output.data()), num_items);
   REQUIRE(cudaSuccess == cudaPeekAtLastError());
   REQUIRE(cudaSuccess == cudaDeviceSynchronize());
 
-  // A prefetch hint must never alter the data it covers.
   REQUIRE(d_input == d_output);
 }
 
@@ -64,7 +70,7 @@ struct params_t
   static constexpr cub::detail::LoadPrefetch level = c2h::get<2, TestType>::value;
 };
 
-C2H_TEST("BlockPrefetch issues hints without disturbing the tile",
+C2H_TEST("BlockPrefetch runs for every level and tile shape",
          "[prefetch][block]",
          types,
          threads_in_block,
@@ -78,7 +84,7 @@ C2H_TEST("BlockPrefetch issues hints without disturbing the tile",
   const int num_items     = GENERATE_COPY(0, 1, 7, params::threads_in_block + 3, take(5, random(1, max_items)));
   CAPTURE(num_items);
 
-  c2h::device_vector<type> d_input(num_items);
+  c2h::device_vector<type> d_input(num_items, thrust::no_init);
   c2h::gen(C2H_SEED(2), d_input);
 
   test_block_prefetch<type, params::threads_in_block, params::level>(d_input, thrust::raw_pointer_cast(d_input.data()));
@@ -93,12 +99,61 @@ C2H_TEST("BlockPrefetch is a no-op for CacheModifiedInputIterator", "[prefetch][
   const int num_items = GENERATE_COPY(7, 200, take(3, random(1, 1024)));
   CAPTURE(num_items);
 
-  c2h::device_vector<type> d_input(num_items);
+  c2h::device_vector<type> d_input(num_items, thrust::no_init);
   c2h::gen(C2H_SEED(2), d_input);
 
   // can_prefetch_from<CMI> is false, so Prefetch must compile out to nothing; the copy still reads through the CMI.
   cub::CacheModifiedInputIterator<cub::CacheLoadModifier::LOAD_CS, type> in(thrust::raw_pointer_cast(d_input.data()));
   test_block_prefetch<type, threads_in_block, level>(d_input, in);
+}
+
+C2H_TEST("BlockPrefetch is safe with thrust vector iterators", "[prefetch][block]")
+{
+  using type                     = int;
+  constexpr int threads_in_block = 128;
+
+  const int num_items = GENERATE_COPY(7, 200, take(3, random(1, 1024)));
+  CAPTURE(num_items);
+
+  c2h::device_vector<type> d_input(num_items, thrust::no_init);
+  c2h::gen(C2H_SEED(2), d_input);
+
+  // Wrapped thrust iterators do not model cuda::std::contiguous_iterator, so the trait rejects them and
+  // Prefetch must compile to a safe no-op while the copy-through still works. If thrust iterators ever gain
+  // contiguous conformance these asserts flip and this test should start expecting real prefetches.
+  STATIC_REQUIRE(!cub::detail::can_prefetch_from<decltype(d_input.cbegin())>);
+  test_block_prefetch<type, threads_in_block, cub::detail::LoadPrefetch::l2>(d_input, d_input.cbegin());
+
+  thrust::universal_vector<type> universal_input(d_input.begin(), d_input.end());
+  STATIC_REQUIRE(!cub::detail::can_prefetch_from<decltype(universal_input.cbegin())>);
+  test_block_prefetch<type, threads_in_block, cub::detail::LoadPrefetch::l2>(d_input, universal_input.cbegin());
+}
+
+C2H_TEST("BlockPrefetch works with cuda::buffer iterators", "[prefetch][block]", load_prefetch_levels)
+{
+  using type                                = int;
+  constexpr int threads_in_block            = 128;
+  constexpr cub::detail::LoadPrefetch level = c2h::get<0, TestType>::value;
+
+  const int num_items = GENERATE_COPY(7, 200, take(3, random(1, 1024)));
+  CAPTURE(num_items);
+
+  c2h::device_vector<type> d_input(num_items, thrust::no_init);
+  c2h::gen(C2H_SEED(2), d_input);
+
+  // Managed memory is host- and device-accessible, so the buffer can be filled from the host and read in the kernel.
+  cuda::mr::legacy_managed_memory_resource mr;
+  auto buf = cuda::make_buffer<type>(
+    cuda::stream_ref{cudaStream_t{}}, mr, static_cast<cuda::std::size_t>(num_items), cuda::no_init);
+  REQUIRE(cudaSuccess
+          == cudaMemcpy(cuda::std::to_address(buf.begin()),
+                        thrust::raw_pointer_cast(d_input.data()),
+                        num_items * sizeof(type),
+                        cudaMemcpyDefault));
+
+  // cuda::buffer's heterogeneous_iterator is a contiguous iterator, so the trait accepts it and hints are emitted.
+  STATIC_REQUIRE(cub::detail::can_prefetch_from<decltype(buf.begin())>);
+  test_block_prefetch<type, threads_in_block, level>(d_input, buf.begin());
 }
 
 C2H_TEST("BlockPrefetch handles unaligned tile bases", "[prefetch][block]", c2h::type_list<std::uint8_t, std::int32_t>)
@@ -111,7 +166,7 @@ C2H_TEST("BlockPrefetch handles unaligned tile bases", "[prefetch][block]", c2h:
   const int num_items = GENERATE(1, 33, 512);
   CAPTURE(offset, num_items);
 
-  c2h::device_vector<type> d_storage(num_items + offset);
+  c2h::device_vector<type> d_storage(num_items + offset, thrust::no_init);
   c2h::gen(C2H_SEED(1), d_storage);
 
   // Prefetch/copy the sub-range that starts at an unaligned offset into the allocation.
@@ -126,13 +181,13 @@ C2H_TEST("BlockPrefetch honors a non-default stride", "[prefetch][block]")
   using type                     = int;
   constexpr int threads_in_block = 64;
 
-  const int num_items = GENERATE_COPY(values({1, 100, 777}));
+  const int num_items = GENERATE(1, 100, 777);
   CAPTURE(num_items);
 
-  c2h::device_vector<type> d_input(num_items);
+  c2h::device_vector<type> d_input(num_items, thrust::no_init);
   c2h::gen(C2H_SEED(1), d_input);
 
-  // A coarser 256 B stride issues fewer hints; the data must still be left intact.
+  // A coarser 256 B stride issues fewer hints; the copy-through must still be correct.
   test_block_prefetch<type, threads_in_block, cub::detail::LoadPrefetch::l2, 256>(
     d_input, thrust::raw_pointer_cast(d_input.data()));
 }

--- a/cub/test/catch2_test_block_prefetch.cu
+++ b/cub/test/catch2_test_block_prefetch.cu
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <cub/detail/prefetch.cuh>
 #include <cub/iterator/cache_modified_input_iterator.cuh>
@@ -23,7 +23,7 @@ static_assert(!cub::detail::can_prefetch_from<cub::CacheModifiedInputIterator<cu
 template <typename T, int ThreadsInBlock, cub::detail::LoadPrefetch Level, int Stride, typename InputIteratorT>
 __global__ void block_prefetch_kernel(InputIteratorT input, T* output, int num_items)
 {
-  cub::detail::BlockPrefetch<T, ThreadsInBlock, Level, Stride>::Prefetch(input, num_items);
+  cub::detail::BlockPrefetch<ThreadsInBlock, Level, Stride>::Prefetch(input, num_items);
 
   for (int i = static_cast<int>(threadIdx.x); i < num_items; i += ThreadsInBlock)
   {

--- a/cub/test/catch2_test_block_prefetch.cu
+++ b/cub/test/catch2_test_block_prefetch.cu
@@ -57,7 +57,7 @@ void test_block_prefetch(const c2h::device_vector<T>& d_input, InputIteratorT in
   REQUIRE(d_input == d_output);
 }
 
-using types            = c2h::type_list<std::uint8_t, std::int32_t, std::int64_t>;
+using types            = c2h::type_list<uint8_t, int32_t, int64_t>;
 using threads_in_block = c2h::enum_type_list<int, 32, 128>;
 using load_prefetch_levels =
   c2h::enum_type_list<cub::detail::LoadPrefetch,
@@ -147,8 +147,8 @@ C2H_TEST("BlockPrefetch works with cuda::buffer iterators", "[prefetch][block]",
 
   // Managed memory is host- and device-accessible, so the buffer can be filled from the host and read in the kernel.
   cuda::mr::legacy_managed_memory_resource mr;
-  auto buf = cuda::make_buffer<type>(
-    cuda::stream_ref{cudaStream_t{}}, mr, static_cast<cuda::std::size_t>(num_items), cuda::no_init);
+  auto buf =
+    cuda::make_buffer<type>(cuda::stream_ref{cudaStream_t{}}, mr, static_cast<size_t>(num_items), cuda::no_init);
   REQUIRE(cudaSuccess
           == cudaMemcpy(cuda::std::to_address(buf.begin()),
                         thrust::raw_pointer_cast(d_input.data()),
@@ -160,7 +160,7 @@ C2H_TEST("BlockPrefetch works with cuda::buffer iterators", "[prefetch][block]",
   test_block_prefetch<type, threads_in_block, level>(d_input, buf.begin());
 }
 
-C2H_TEST("BlockPrefetch handles unaligned tile bases", "[prefetch][block]", c2h::type_list<std::uint8_t, std::int32_t>)
+C2H_TEST("BlockPrefetch handles unaligned tile bases", "[prefetch][block]", c2h::type_list<uint8_t, int32_t>)
 {
   using type                     = c2h::get<0, TestType>;
   constexpr int threads_in_block = 128;

--- a/cub/test/catch2_test_block_prefetch.cu
+++ b/cub/test/catch2_test_block_prefetch.cu
@@ -84,9 +84,9 @@ C2H_TEST("BlockPrefetch runs for every level and tile shape",
   using params = params_t<TestType>;
   using type   = typename params::type;
 
-  // Cover the empty tile, single item, sub-block and ragged tiles, and tiles spanning many cache lines.
-  constexpr int max_items = 8 * params::threads_in_block;
-  const int num_items     = GENERATE_COPY(0, 1, 7, params::threads_in_block + 3, take(5, random(1, max_items)));
+  // Each shape exercises a distinct address-math path: 0 = empty tile (size-0 TMA range), 1 = sub-cache-line,
+  // 7 = sub-warp, threads + 3 = ragged tile, 8 * threads = multiple strided-loop iterations per thread.
+  const int num_items = GENERATE_COPY(0, 1, 7, params::threads_in_block + 3, 8 * params::threads_in_block);
   CAPTURE(num_items);
 
   c2h::device_vector<type> d_input(num_items, thrust::no_init);
@@ -101,7 +101,8 @@ C2H_TEST("BlockPrefetch is a no-op for CacheModifiedInputIterator", "[prefetch][
   constexpr int threads_in_block            = 128;
   constexpr cub::detail::LoadPrefetch level = c2h::get<0, TestType>::value;
 
-  const int num_items = GENERATE_COPY(7, 200, take(3, random(1, 1024)));
+  // The no-op path has no size-dependent behavior; one size suffices.
+  const int num_items = 200;
   CAPTURE(num_items, threads_in_block, level);
 
   c2h::device_vector<type> d_input(num_items, thrust::no_init);
@@ -118,7 +119,8 @@ C2H_TEST("BlockPrefetch works with thrust vector iterators", "[prefetch][block]"
   constexpr int threads_in_block            = 128;
   constexpr cub::detail::LoadPrefetch level = c2h::get<0, TestType>::value;
 
-  const int num_items = GENERATE_COPY(7, 200, take(3, random(1, 1024)));
+  // A sub-line tile and a multi-line tile cover both strided-loop shapes through wrapped iterators.
+  const int num_items = GENERATE(7, 200);
   CAPTURE(num_items, threads_in_block, level);
 
   c2h::device_vector<type> d_input(num_items, thrust::no_init);
@@ -139,7 +141,8 @@ C2H_TEST("BlockPrefetch works with cuda::buffer iterators", "[prefetch][block]",
   constexpr int threads_in_block            = 128;
   constexpr cub::detail::LoadPrefetch level = c2h::get<0, TestType>::value;
 
-  const int num_items = GENERATE_COPY(7, 200, take(3, random(1, 1024)));
+  // A sub-line tile and a multi-line tile cover both strided-loop shapes through the buffer iterator.
+  const int num_items = GENERATE(7, 200);
   CAPTURE(num_items, threads_in_block, level);
 
   c2h::device_vector<type> d_input(num_items, thrust::no_init);
@@ -165,8 +168,9 @@ C2H_TEST("BlockPrefetch handles unaligned tile bases", "[prefetch][block]", c2h:
   using type                     = c2h::get<0, TestType>;
   constexpr int threads_in_block = 128;
 
-  // bulk_l2 aligns the base down to 16 B and extends the size to compensate; walk the base across a 16 B window.
-  const int offset    = GENERATE(0, 1, 2, 3, 4, 5, 7, 8, 15);
+  // bulk_l2 aligns the base down to 16 B and extends the size to compensate. The offsets cover the
+  // equivalence classes of the 16 B window: aligned, minimal, mid, and maximal misalignment.
+  const int offset    = GENERATE(0, 1, 8, 15);
   const int num_items = GENERATE(1, 33, 512);
   CAPTURE(offset, num_items, threads_in_block);
 

--- a/cub/test/catch2_test_block_prefetch.cu
+++ b/cub/test/catch2_test_block_prefetch.cu
@@ -22,14 +22,16 @@
 // verified out-of-band (cuobjdump), not here.
 
 // Compile-time coverage of the trait that gates every hint.
-static_assert(cub::detail::can_prefetch_from<int*>, "raw pointers are contiguous and must be prefetchable");
-static_assert(cub::detail::can_prefetch_from<const double*>, "const raw pointers must be prefetchable");
-static_assert(cub::detail::can_prefetch_from<thrust::device_vector<int>::iterator>,
-              "thrust vector iterators are contiguous and must be prefetchable");
-static_assert(cub::detail::can_prefetch_from<thrust::universal_vector<int>::iterator>,
-              "thrust universal_vector iterators are contiguous and must be prefetchable");
-static_assert(!cub::detail::can_prefetch_from<cub::CacheModifiedInputIterator<cub::CacheLoadModifier::LOAD_CS, int>>,
-              "CacheModifiedInputIterator routes through an explicit cache path and must be rejected");
+C2H_TEST("can_prefetch_from accepts contiguous iterators and rejects explicit cache paths", "[prefetch][block]")
+{
+  STATIC_REQUIRE(cub::detail::can_prefetch_from<int*>);
+  STATIC_REQUIRE(cub::detail::can_prefetch_from<const double*>);
+  STATIC_REQUIRE(cub::detail::can_prefetch_from<thrust::device_vector<int>::iterator>);
+  STATIC_REQUIRE(cub::detail::can_prefetch_from<thrust::universal_vector<int>::iterator>);
+  // CacheModifiedInputIterator routes loads through an explicit cache path that a prefetch hint would defeat.
+  STATIC_REQUIRE_FALSE(
+    cub::detail::can_prefetch_from<cub::CacheModifiedInputIterator<cub::CacheLoadModifier::LOAD_CS, int>>);
+}
 
 // Prefetch the tile, then copy it through so the launch has an observable result.
 template <typename T, int ThreadsInBlock, cub::detail::LoadPrefetch Level, int Stride, typename InputIteratorT>
@@ -178,10 +180,10 @@ C2H_TEST("BlockPrefetch handles unaligned tile bases", "[prefetch][block]", c2h:
   c2h::gen(C2H_SEED(1), d_storage);
 
   // Prefetch/copy the sub-range that starts at an unaligned offset into the allocation.
-  auto* base = thrust::raw_pointer_cast(d_storage.data()) + offset;
+  auto* start = thrust::raw_pointer_cast(d_storage.data()) + offset;
   c2h::device_vector<type> d_input(d_storage.begin() + offset, d_storage.end());
 
-  test_block_prefetch<type, threads_in_block, cub::detail::LoadPrefetch::bulk_l2>(d_input, base);
+  test_block_prefetch<type, threads_in_block, cub::detail::LoadPrefetch::bulk_l2>(d_input, start);
 }
 
 C2H_TEST("BlockPrefetch honors a non-default stride", "[prefetch][block]")

--- a/cub/test/catch2_test_block_prefetch.cu
+++ b/cub/test/catch2_test_block_prefetch.cu
@@ -4,6 +4,7 @@
 #include <cub/detail/prefetch.cuh>
 #include <cub/iterator/cache_modified_input_iterator.cuh>
 
+#include <thrust/device_vector.h>
 #include <thrust/universal_vector.h>
 
 #include <cuda/buffer>
@@ -23,6 +24,10 @@
 // Compile-time coverage of the trait that gates every hint.
 static_assert(cub::detail::can_prefetch_from<int*>, "raw pointers are contiguous and must be prefetchable");
 static_assert(cub::detail::can_prefetch_from<const double*>, "const raw pointers must be prefetchable");
+static_assert(cub::detail::can_prefetch_from<thrust::device_vector<int>::iterator>,
+              "thrust vector iterators are contiguous and must be prefetchable");
+static_assert(cub::detail::can_prefetch_from<thrust::universal_vector<int>::iterator>,
+              "thrust universal_vector iterators are contiguous and must be prefetchable");
 static_assert(!cub::detail::can_prefetch_from<cub::CacheModifiedInputIterator<cub::CacheLoadModifier::LOAD_CS, int>>,
               "CacheModifiedInputIterator routes through an explicit cache path and must be rejected");
 
@@ -107,26 +112,25 @@ C2H_TEST("BlockPrefetch is a no-op for CacheModifiedInputIterator", "[prefetch][
   test_block_prefetch<type, threads_in_block, level>(d_input, in);
 }
 
-C2H_TEST("BlockPrefetch is safe with thrust vector iterators", "[prefetch][block]")
+C2H_TEST("BlockPrefetch works with thrust vector iterators", "[prefetch][block]", load_prefetch_levels)
 {
-  using type                     = int;
-  constexpr int threads_in_block = 128;
+  using type                                = int;
+  constexpr int threads_in_block            = 128;
+  constexpr cub::detail::LoadPrefetch level = c2h::get<0, TestType>::value;
 
   const int num_items = GENERATE_COPY(7, 200, take(3, random(1, 1024)));
-  CAPTURE(num_items, threads_in_block);
+  CAPTURE(num_items, threads_in_block, level);
 
   c2h::device_vector<type> d_input(num_items, thrust::no_init);
   c2h::gen(C2H_SEED(2), d_input);
 
-  // Wrapped thrust iterators do not model cuda::std::contiguous_iterator, so the trait rejects them and
-  // Prefetch must compile to a safe no-op while the copy-through still works. If thrust iterators ever gain
-  // contiguous conformance these asserts flip and this test should start expecting real prefetches.
-  STATIC_REQUIRE(!cub::detail::can_prefetch_from<decltype(d_input.cbegin())>);
-  test_block_prefetch<type, threads_in_block, cub::detail::LoadPrefetch::l2>(d_input, d_input.cbegin());
+  // thrust vector iterators are contiguous (thrust::is_contiguous_iterator), so hints flow through them.
+  STATIC_REQUIRE(cub::detail::can_prefetch_from<decltype(d_input.cbegin())>);
+  test_block_prefetch<type, threads_in_block, level>(d_input, d_input.cbegin());
 
   thrust::universal_vector<type> universal_input(d_input.begin(), d_input.end());
-  STATIC_REQUIRE(!cub::detail::can_prefetch_from<decltype(universal_input.cbegin())>);
-  test_block_prefetch<type, threads_in_block, cub::detail::LoadPrefetch::l2>(d_input, universal_input.cbegin());
+  STATIC_REQUIRE(cub::detail::can_prefetch_from<decltype(universal_input.cbegin())>);
+  test_block_prefetch<type, threads_in_block, level>(d_input, universal_input.cbegin());
 }
 
 C2H_TEST("BlockPrefetch works with cuda::buffer iterators", "[prefetch][block]", load_prefetch_levels)

--- a/cub/test/catch2_test_block_prefetch.cu
+++ b/cub/test/catch2_test_block_prefetch.cu
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <cub/detail/prefetch.cuh>
+#include <cub/iterator/cache_modified_input_iterator.cuh>
+
+#include <c2h/catch2_test_helper.h>
+
+// BlockPrefetch emits global-memory prefetch *hints*: they carry no functional result and cannot be observed from
+// the device program. A runtime test can therefore only assert that (1) issuing the hints never faults for any
+// level / element type / tile shape, (2) the hints never disturb the data they cover, and (3) `none` and
+// non-contiguous iterators (e.g. CacheModifiedInputIterator) compile and run as a genuine no-op. Whether the
+// intended SASS is actually emitted is verified out-of-band (cuobjdump), not here.
+
+// Compile-time coverage of the trait that gates every hint.
+static_assert(cub::detail::can_prefetch_from<int*>, "raw pointers are contiguous and must be prefetchable");
+static_assert(cub::detail::can_prefetch_from<const double*>, "const raw pointers must be prefetchable");
+static_assert(!cub::detail::can_prefetch_from<cub::CacheModifiedInputIterator<cub::CacheLoadModifier::LOAD_CS, int>>,
+              "CacheModifiedInputIterator routes through an explicit cache path and must be rejected");
+
+// Prefetch the tile, then faithfully copy it through, so the launch is observable and any corruption of the
+// prefetched region is caught by the host-side comparison.
+template <typename T, int ThreadsInBlock, cub::detail::LoadPrefetch Level, int Stride, typename InputIteratorT>
+__global__ void block_prefetch_kernel(InputIteratorT input, T* output, int num_items)
+{
+  cub::detail::BlockPrefetch<T, ThreadsInBlock, Level, Stride>::Prefetch(input, num_items);
+
+  for (int i = static_cast<int>(threadIdx.x); i < num_items; i += ThreadsInBlock)
+  {
+    output[i] = input[i];
+  }
+}
+
+template <typename T, int ThreadsInBlock, cub::detail::LoadPrefetch Level, int Stride = 128, typename InputIteratorT>
+void test_block_prefetch(const c2h::device_vector<T>& d_input, InputIteratorT input)
+{
+  const int num_items = static_cast<int>(d_input.size());
+  c2h::device_vector<T> d_output(num_items, T{});
+
+  block_prefetch_kernel<T, ThreadsInBlock, Level, Stride>
+    <<<1, ThreadsInBlock>>>(input, thrust::raw_pointer_cast(d_output.data()), num_items);
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+
+  // A prefetch hint must never alter the data it covers.
+  REQUIRE(d_input == d_output);
+}
+
+using types            = c2h::type_list<std::uint8_t, std::int32_t, std::int64_t>;
+using threads_in_block = c2h::enum_type_list<int, 32, 128>;
+using load_prefetch_levels =
+  c2h::enum_type_list<cub::detail::LoadPrefetch,
+                      cub::detail::LoadPrefetch::none,
+                      cub::detail::LoadPrefetch::l2,
+                      cub::detail::LoadPrefetch::l1,
+                      cub::detail::LoadPrefetch::bulk_l2>;
+
+template <class TestType>
+struct params_t
+{
+  using type = typename c2h::get<0, TestType>;
+
+  static constexpr int threads_in_block            = c2h::get<1, TestType>::value;
+  static constexpr cub::detail::LoadPrefetch level = c2h::get<2, TestType>::value;
+};
+
+C2H_TEST("BlockPrefetch issues hints without disturbing the tile",
+         "[prefetch][block]",
+         types,
+         threads_in_block,
+         load_prefetch_levels)
+{
+  using params = params_t<TestType>;
+  using type   = typename params::type;
+
+  // Cover the empty tile, single item, sub-block and ragged tiles, and tiles spanning many cache lines.
+  constexpr int max_items = 8 * params::threads_in_block;
+  const int num_items     = GENERATE_COPY(0, 1, 7, params::threads_in_block + 3, take(5, random(1, max_items)));
+  CAPTURE(num_items);
+
+  c2h::device_vector<type> d_input(num_items);
+  c2h::gen(C2H_SEED(2), d_input);
+
+  test_block_prefetch<type, params::threads_in_block, params::level>(d_input, thrust::raw_pointer_cast(d_input.data()));
+}
+
+C2H_TEST("BlockPrefetch is a no-op for CacheModifiedInputIterator", "[prefetch][block]", load_prefetch_levels)
+{
+  using type                                = int;
+  constexpr int threads_in_block            = 128;
+  constexpr cub::detail::LoadPrefetch level = c2h::get<0, TestType>::value;
+
+  const int num_items = GENERATE_COPY(7, 200, take(3, random(1, 1024)));
+  CAPTURE(num_items);
+
+  c2h::device_vector<type> d_input(num_items);
+  c2h::gen(C2H_SEED(2), d_input);
+
+  // can_prefetch_from<CMI> is false, so Prefetch must compile out to nothing; the copy still reads through the CMI.
+  cub::CacheModifiedInputIterator<cub::CacheLoadModifier::LOAD_CS, type> in(thrust::raw_pointer_cast(d_input.data()));
+  test_block_prefetch<type, threads_in_block, level>(d_input, in);
+}
+
+C2H_TEST("BlockPrefetch handles unaligned tile bases", "[prefetch][block]", c2h::type_list<std::uint8_t, std::int32_t>)
+{
+  using type                     = c2h::get<0, TestType>;
+  constexpr int threads_in_block = 128;
+
+  // bulk_l2 aligns the base down to 16 B and extends the size to compensate; walk the base across a 16 B window.
+  const int offset    = GENERATE(0, 1, 2, 3, 4, 5, 7, 8, 15);
+  const int num_items = GENERATE(1, 33, 512);
+  CAPTURE(offset, num_items);
+
+  c2h::device_vector<type> d_storage(num_items + offset);
+  c2h::gen(C2H_SEED(1), d_storage);
+
+  // Prefetch/copy the sub-range that starts at an unaligned offset into the allocation.
+  auto* base = thrust::raw_pointer_cast(d_storage.data()) + offset;
+  c2h::device_vector<type> d_input(d_storage.begin() + offset, d_storage.end());
+
+  test_block_prefetch<type, threads_in_block, cub::detail::LoadPrefetch::bulk_l2>(d_input, base);
+}
+
+C2H_TEST("BlockPrefetch honors a non-default stride", "[prefetch][block]")
+{
+  using type                     = int;
+  constexpr int threads_in_block = 64;
+
+  const int num_items = GENERATE_COPY(values({1, 100, 777}));
+  CAPTURE(num_items);
+
+  c2h::device_vector<type> d_input(num_items);
+  c2h::gen(C2H_SEED(1), d_input);
+
+  // A coarser 256 B stride issues fewer hints; the data must still be left intact.
+  test_block_prefetch<type, threads_in_block, cub::detail::LoadPrefetch::l2, 256>(
+    d_input, thrust::raw_pointer_cast(d_input.data()));
+}

--- a/cub/test/catch2_test_block_prefetch.cu
+++ b/cub/test/catch2_test_block_prefetch.cu
@@ -97,7 +97,7 @@ C2H_TEST("BlockPrefetch is a no-op for CacheModifiedInputIterator", "[prefetch][
   constexpr cub::detail::LoadPrefetch level = c2h::get<0, TestType>::value;
 
   const int num_items = GENERATE_COPY(7, 200, take(3, random(1, 1024)));
-  CAPTURE(num_items);
+  CAPTURE(num_items, threads_in_block, level);
 
   c2h::device_vector<type> d_input(num_items, thrust::no_init);
   c2h::gen(C2H_SEED(2), d_input);
@@ -113,7 +113,7 @@ C2H_TEST("BlockPrefetch is safe with thrust vector iterators", "[prefetch][block
   constexpr int threads_in_block = 128;
 
   const int num_items = GENERATE_COPY(7, 200, take(3, random(1, 1024)));
-  CAPTURE(num_items);
+  CAPTURE(num_items, threads_in_block);
 
   c2h::device_vector<type> d_input(num_items, thrust::no_init);
   c2h::gen(C2H_SEED(2), d_input);
@@ -136,7 +136,7 @@ C2H_TEST("BlockPrefetch works with cuda::buffer iterators", "[prefetch][block]",
   constexpr cub::detail::LoadPrefetch level = c2h::get<0, TestType>::value;
 
   const int num_items = GENERATE_COPY(7, 200, take(3, random(1, 1024)));
-  CAPTURE(num_items);
+  CAPTURE(num_items, threads_in_block, level);
 
   c2h::device_vector<type> d_input(num_items, thrust::no_init);
   c2h::gen(C2H_SEED(2), d_input);
@@ -164,7 +164,7 @@ C2H_TEST("BlockPrefetch handles unaligned tile bases", "[prefetch][block]", c2h:
   // bulk_l2 aligns the base down to 16 B and extends the size to compensate; walk the base across a 16 B window.
   const int offset    = GENERATE(0, 1, 2, 3, 4, 5, 7, 8, 15);
   const int num_items = GENERATE(1, 33, 512);
-  CAPTURE(offset, num_items);
+  CAPTURE(offset, num_items, threads_in_block);
 
   c2h::device_vector<type> d_storage(num_items + offset, thrust::no_init);
   c2h::gen(C2H_SEED(1), d_storage);
@@ -182,7 +182,7 @@ C2H_TEST("BlockPrefetch honors a non-default stride", "[prefetch][block]")
   constexpr int threads_in_block = 64;
 
   const int num_items = GENERATE(1, 100, 777);
-  CAPTURE(num_items);
+  CAPTURE(num_items, threads_in_block);
 
   c2h::device_vector<type> d_input(num_items, thrust::no_init);
   c2h::gen(C2H_SEED(1), d_input);


### PR DESCRIPTION
fixes #9588 with a new design.

Adds `cub::detail::BlockPrefetch`, a standalone block-scope facility for cooperatively emitting global-memory tile-prefetch hints.

Design-only PR: it lands the facility and nothing else, no algorithm is wired to it yet (net diff is a single new header).

#### What this adds

- `cub::detail::LoadPrefetch` - enum of prefetch targets: `none`, `l2` (`prefetch.global.L2`), l1 (`prefetch.global.L1`, falls back to L2 where real L1 prefetch is unavailable), and `bulk_l2` (TMA `cp.async.bulk.prefetch` into L2; requires SM90+, no-op on older arch).
- `cub::detail::BlockPrefetch<T, ThreadsPerBlock, Prefetch, PrefetchStride>`- a collective with a single static `Prefetch(it, items_to_prefetch)`. The block's threads cooperatively stride the tile, one hint per cache line (or one TMA bulk prefetch for `bulk_l2`). _A no-op for none and for iterators that can't yield a raw address_ (e.g. `CacheModifiedInputIterator`), so call sites need no enablement check.

_Everything is under detail, no public-API or stability commitment._