### PR TITLE
fix `shared_memory_mdspan` documentation version

### DIFF
--- a/docs/libcudacxx/extended_api/mdspan.rst
+++ b/docs/libcudacxx/extended_api/mdspan.rst
@@ -40,8 +40,8 @@ Mdspan
 
    * - :ref:`shared_memory mdspan and accessor <libcudacxx-extended-api-mdspan-shared-memory-accessor>`
      - ``mdspan`` and accessor for CUDA shared memory
-     - CCCL 3.2.0
-     - CUDA 13.2
+     - CCCL 3.3.0
+     - CUDA 13.3
 
    * - :ref:`mdspan to dlpack <libcudacxx-extended-api-mdspan-mdspan-to-dlpack>`
      - Convert a ``mdspan`` to a ``DLTensor``

--- a/docs/libcudacxx/extended_api/mdspan/shared_memory_accessor.rst
+++ b/docs/libcudacxx/extended_api/mdspan/shared_memory_accessor.rst
@@ -5,6 +5,8 @@
 
 ``shared_memory`` ``mdspan`` and ``accessor`` allow to express multi-dimensional views of the CUDA shared memory space and provide additional safety checks and performance optimizations.
 
+Defined in the ``<cuda/mdspan>`` header.
+
 Types and Traits
 ----------------
 


### PR DESCRIPTION
## Description

`shared_memory_mdspan` documentation reports CCCL 3.2.0 instead of 3.3.0

Fixes ~# 9679~ #9729 
