### PR TITLE
[cudax] Change cuco test target names

### DIFF
--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -933,7 +933,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       using store_t      = decltype(load_store_type<store_vec_size * out_size>());
       auto* out_vec      = reinterpret_cast<store_t*>(out);
       const int num_vecs = valid_items / store_vec_size;
-      for (int v = threadIdx.x; v < num_vecs; v += threads_per_block)
+      for (auto v = static_cast<int>(threadIdx.x); v < num_vecs; v += threads_per_block)
       {
         char* smem       = smem_base;
         auto load_in_vec = [&](auto aligned_ptr) {

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -114,32 +114,32 @@ if (
   NOT "${CMAKE_CUDA_COMPILER_ID}" STREQUAL "NVIDIA"
   OR "${CMAKE_CUDA_COMPILER_VERSION}" VERSION_GREATER_EQUAL "12.1"
 )
-  cudax_add_catch2_test(test_target cuco
+  cudax_add_catch2_test(test_target cuco.utility.hashers
     cuco/utility/test_hashers.cu
   )
 endif()
 
-cudax_add_catch2_test(test_target cuco_fixed_capacity_map_insert_and_contains ${cudax_target}
+cudax_add_catch2_test(test_target cuco.fixed_capacity_map.insert_and_contains ${cudax_target}
     cuco/fixed_capacity_map/test_insert_and_contains.cu
 )
 
-cudax_add_catch2_test(test_target cuco_fixed_capacity_map_capacity ${cudax_target}
+cudax_add_catch2_test(test_target cuco.fixed_capacity_map.capacity ${cudax_target}
     cuco/fixed_capacity_map/test_capacity.cu
 )
 
-cudax_add_catch2_test(test_target cuco_fixed_capacity_map_shared_memory ${cudax_target}
+cudax_add_catch2_test(test_target cuco.fixed_capacity_map.shared_memory ${cudax_target}
     cuco/fixed_capacity_map/test_shared_memory.cu
 )
 
-cudax_add_catch2_test(test_target cuco_fixed_capacity_map_key_sentinel ${cudax_target}
+cudax_add_catch2_test(test_target cuco.fixed_capacity_map.key_sentinel ${cudax_target}
     cuco/fixed_capacity_map/test_key_sentinel.cu
 )
 
-cudax_add_catch2_test(test_target cuco_capacity ${cudax_target}
+cudax_add_catch2_test(test_target cuco.utility.capacity ${cudax_target}
     cuco/utility/test_capacity.cu
 )
 
-cudax_add_catch2_test(test_target cuco_hyperloglog ${cudax_target}
+cudax_add_catch2_test(test_target cuco.hyperloglog ${cudax_target}
   cuco/hyperloglog/test_hyperloglog.cu
 )
 


### PR DESCRIPTION
Using `.` in target names allows to build a target tree. After this change `ninja cudax.test.cuco` builds all cuco tests.