### PR TITLE
[CUB] warpspeed kernel: make scan_resources_t copy

### DIFF
--- a/cub/cub/device/dispatch/kernels/kernel_scan_lookahead.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_lookahead.cuh
@@ -283,7 +283,7 @@ struct lookahead_scan_closure
   const scanKernelParams<InputT, OutputT, AccumT> params;
   mutable ScanOpT scan_op; // mutable, so we can support non-const operator()
   const RealInitValueT real_init_value;
-  scan_resources_t& res; // this is the only shared mutable state
+  scan_resources_t res; // this is the only shared mutable state
 
   _CCCL_DEVICE_API _CCCL_FORCEINLINE void
   load_next_tile_index(const warpspeed::Squad& squad, warpspeed::SmemPhase<uint4>& phaseNextBlockIdxW) const


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->


This improves performance of warpspeed on sm90 using atomics (https://github.com/NVIDIA/cccl/pull/9565). 

It doesn't impact performance on current implementation for SM100+ .

Further it reduces SASS on 
- cub.bench.scan.exclusive.deterministic.base
- cub.bench.scan.exclusive.sum.base
- cub.bench.scan.exclusive.sum.lookahead.base 

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->


<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
