### PR TITLE
Refactor enum to string functions

### DIFF
--- a/cub/cub/agent/agent_histogram.cuh
+++ b/cub/cub/agent/agent_histogram.cuh
@@ -53,9 +53,8 @@ namespace detail
       return "SMEM";
     case BLEND:
       return "BLEND";
-    default:
-      return "<unknown BlockHistogramMemoryPreference>";
   }
+  return "<unknown BlockHistogramMemoryPreference>";
 }
 } // namespace detail
 

--- a/cub/cub/agent/agent_histogram.cuh
+++ b/cub/cub/agent/agent_histogram.cuh
@@ -43,7 +43,7 @@ enum BlockHistogramMemoryPreference
 #if _CCCL_HOSTED()
 namespace detail
 {
-_CCCL_API [[nodiscard]] constexpr const char* to_string(BlockHistogramMemoryPreference mempref) noexcept
+[[nodiscard]] _CCCL_API constexpr const char* to_string(BlockHistogramMemoryPreference mempref) noexcept
 {
   switch (mempref)
   {

--- a/cub/cub/agent/agent_histogram.cuh
+++ b/cub/cub/agent/agent_histogram.cuh
@@ -43,7 +43,7 @@ enum BlockHistogramMemoryPreference
 #if _CCCL_HOSTED()
 namespace detail
 {
-[[nodiscard]] constexpr const char* to_string(BlockHistogramMemoryPreference mempref) noexcept
+_CCCL_API [[nodiscard]] constexpr const char* to_string(BlockHistogramMemoryPreference mempref) noexcept
 {
   switch (mempref)
   {

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -56,7 +56,7 @@ enum RadixSortStoreAlgorithm
 #if _CCCL_HOSTED()
 namespace detail
 {
-[[nodiscard]] constexpr const char* to_string(RadixSortStoreAlgorithm algo) noexcept
+_CCCL_API [[nodiscard]] constexpr const char* to_string(RadixSortStoreAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -64,9 +64,8 @@ namespace detail
       return "RADIX_SORT_STORE_DIRECT";
     case RADIX_SORT_STORE_ALIGNED:
       return "RADIX_SORT_STORE_ALIGNED";
-    default:
-      return "<unknown RadixSortStoreAlgorithm>";
   }
+  return "<unknown RadixSortStoreAlgorithm>";
 }
 } // namespace detail
 #endif // _CCCL_HOSTED()

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -56,7 +56,7 @@ enum RadixSortStoreAlgorithm
 #if _CCCL_HOSTED()
 namespace detail
 {
-_CCCL_API [[nodiscard]] constexpr const char* to_string(RadixSortStoreAlgorithm algo) noexcept
+[[nodiscard]] _CCCL_API constexpr const char* to_string(RadixSortStoreAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/block/block_load.cuh
+++ b/cub/cub/block/block_load.cuh
@@ -732,7 +732,7 @@ enum BlockLoadAlgorithm
 #if _CCCL_HOSTED() && !defined(_CCCL_DOXYGEN_INVOKED)
 namespace detail
 {
-_CCCL_API [[nodiscard]] constexpr const char* to_string(BlockLoadAlgorithm algo) noexcept
+[[nodiscard]] _CCCL_API constexpr const char* to_string(BlockLoadAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/block/block_load.cuh
+++ b/cub/cub/block/block_load.cuh
@@ -732,7 +732,7 @@ enum BlockLoadAlgorithm
 #if _CCCL_HOSTED() && !defined(_CCCL_DOXYGEN_INVOKED)
 namespace detail
 {
-[[nodiscard]] constexpr const char* to_string(BlockLoadAlgorithm algo) noexcept
+_CCCL_API [[nodiscard]] constexpr const char* to_string(BlockLoadAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/block/block_load.cuh
+++ b/cub/cub/block/block_load.cuh
@@ -748,9 +748,8 @@ namespace detail
       return "BLOCK_LOAD_WARP_TRANSPOSE";
     case BLOCK_LOAD_WARP_TRANSPOSE_TIMESLICED:
       return "BLOCK_LOAD_WARP_TRANSPOSE_TIMESLICED";
-    default:
-      return "<unknown BlockLoadAlgorithm>";
   }
+  return "<unknown BlockLoadAlgorithm>";
 }
 } // namespace detail
 

--- a/cub/cub/block/block_radix_rank.cuh
+++ b/cub/cub/block/block_radix_rank.cuh
@@ -90,9 +90,8 @@ namespace detail
       return "RADIX_RANK_MATCH_EARLY_COUNTS_ANY";
     case RADIX_RANK_MATCH_EARLY_COUNTS_ATOMIC_OR:
       return "RADIX_RANK_MATCH_EARLY_COUNTS_ATOMIC_OR";
-    default:
-      return "<unknown RadixRankAlgorithm>";
   }
+  return "<unknown RadixRankAlgorithm>";
 }
 } // namespace detail
 

--- a/cub/cub/block/block_radix_rank.cuh
+++ b/cub/cub/block/block_radix_rank.cuh
@@ -76,7 +76,7 @@ enum RadixRankAlgorithm
 #if _CCCL_HOSTED() && !defined(_CCCL_DOXYGEN_INVOKED)
 namespace detail
 {
-_CCCL_API [[nodiscard]] constexpr const char* to_string(RadixRankAlgorithm algo) noexcept
+[[nodiscard]] _CCCL_API constexpr const char* to_string(RadixRankAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/block/block_radix_rank.cuh
+++ b/cub/cub/block/block_radix_rank.cuh
@@ -76,7 +76,7 @@ enum RadixRankAlgorithm
 #if _CCCL_HOSTED() && !defined(_CCCL_DOXYGEN_INVOKED)
 namespace detail
 {
-[[nodiscard]] constexpr const char* to_string(RadixRankAlgorithm algo) noexcept
+_CCCL_API [[nodiscard]] constexpr const char* to_string(RadixRankAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/block/block_reduce.cuh
+++ b/cub/cub/block/block_reduce.cuh
@@ -166,9 +166,8 @@ namespace detail
       return "BLOCK_REDUCE_WARP_REDUCTIONS";
     case BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC:
       return "BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC";
-    default:
-      return "<unknown BlockReduceAlgorithm>";
   }
+  return "<unknown BlockReduceAlgorithm>";
 }
 } // namespace detail
 

--- a/cub/cub/block/block_reduce.cuh
+++ b/cub/cub/block/block_reduce.cuh
@@ -154,7 +154,7 @@ enum BlockReduceAlgorithm
 #if _CCCL_HOSTED() && !defined(_CCCL_DOXYGEN_INVOKED)
 namespace detail
 {
-_CCCL_API [[nodiscard]] constexpr const char* to_string(BlockReduceAlgorithm algo) noexcept
+[[nodiscard]] _CCCL_API constexpr const char* to_string(BlockReduceAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/block/block_reduce.cuh
+++ b/cub/cub/block/block_reduce.cuh
@@ -154,7 +154,7 @@ enum BlockReduceAlgorithm
 #if _CCCL_HOSTED() && !defined(_CCCL_DOXYGEN_INVOKED)
 namespace detail
 {
-[[nodiscard]] constexpr const char* to_string(BlockReduceAlgorithm algo) noexcept
+_CCCL_API [[nodiscard]] constexpr const char* to_string(BlockReduceAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/block/block_scan.cuh
+++ b/cub/cub/block/block_scan.cuh
@@ -115,9 +115,8 @@ namespace detail
       return "BLOCK_SCAN_RAKING_MEMOIZE";
     case BLOCK_SCAN_WARP_SCANS:
       return "BLOCK_SCAN_WARP_SCANS";
-    default:
-      return "<unknown BlockScanAlgorithm>";
   }
+  return "<unknown BlockScanAlgorithm>";
 }
 } // namespace detail
 

--- a/cub/cub/block/block_scan.cuh
+++ b/cub/cub/block/block_scan.cuh
@@ -105,7 +105,7 @@ enum BlockScanAlgorithm
 #if _CCCL_HOSTED() && !defined(_CCCL_DOXYGEN_INVOKED)
 namespace detail
 {
-_CCCL_API [[nodiscard]] constexpr const char* to_string(BlockScanAlgorithm algo) noexcept
+[[nodiscard]] _CCCL_API constexpr const char* to_string(BlockScanAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/block/block_scan.cuh
+++ b/cub/cub/block/block_scan.cuh
@@ -105,7 +105,7 @@ enum BlockScanAlgorithm
 #if _CCCL_HOSTED() && !defined(_CCCL_DOXYGEN_INVOKED)
 namespace detail
 {
-[[nodiscard]] constexpr const char* to_string(BlockScanAlgorithm algo) noexcept
+_CCCL_API [[nodiscard]] constexpr const char* to_string(BlockScanAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/block/block_store.cuh
+++ b/cub/cub/block/block_store.cuh
@@ -564,9 +564,8 @@ namespace detail
       return "BLOCK_STORE_WARP_TRANSPOSE";
     case BLOCK_STORE_WARP_TRANSPOSE_TIMESLICED:
       return "BLOCK_STORE_WARP_TRANSPOSE_TIMESLICED";
-    default:
-      return "<unknown BlockStoreAlgorithm>";
   }
+  return "<unknown BlockStoreAlgorithm>";
 }
 } // namespace detail
 

--- a/cub/cub/block/block_store.cuh
+++ b/cub/cub/block/block_store.cuh
@@ -548,7 +548,7 @@ enum BlockStoreAlgorithm
 #if _CCCL_HOSTED() && !defined(_CCCL_DOXYGEN_INVOKED)
 namespace detail
 {
-[[nodiscard]] constexpr const char* to_string(BlockStoreAlgorithm algo) noexcept
+_CCCL_API [[nodiscard]] constexpr const char* to_string(BlockStoreAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/block/block_store.cuh
+++ b/cub/cub/block/block_store.cuh
@@ -548,7 +548,7 @@ enum BlockStoreAlgorithm
 #if _CCCL_HOSTED() && !defined(_CCCL_DOXYGEN_INVOKED)
 namespace detail
 {
-_CCCL_API [[nodiscard]] constexpr const char* to_string(BlockStoreAlgorithm algo) noexcept
+[[nodiscard]] _CCCL_API constexpr const char* to_string(BlockStoreAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/device/dispatch/tuning/common.cuh
+++ b/cub/cub/device/dispatch/tuning/common.cuh
@@ -228,9 +228,8 @@ namespace detail
       return "LookbackDelayAlgorithm::exponential_backon";
     case LookbackDelayAlgorithm::__reduce_by_key:
       return "LookbackDelayAlgorithm::__reduce_by_key";
-    default:
-      return "<unknown LookbackDelayAlgorithm>";
   }
+  return "<unknown LookbackDelayAlgorithm>";
 }
 } // namespace detail
 

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -41,7 +41,7 @@ enum class RadixSortAlgorithm
 #if _CCCL_HOSTED()
 namespace detail
 {
-[[nodiscard]] constexpr const char* to_string(RadixSortAlgorithm algo) noexcept
+_CCCL_API [[nodiscard]] constexpr const char* to_string(RadixSortAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -49,9 +49,8 @@ namespace detail
       return "RadixSortAlgorithm::multi_pass";
     case RadixSortAlgorithm::onesweep:
       return "RadixSortAlgorithm::onesweep";
-    default:
-      return "<unknown RadixSortAlgorithm>";
   }
+  return "<unknown RadixSortAlgorithm>";
 }
 } // namespace detail
 #endif // _CCCL_HOSTED()

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -41,7 +41,7 @@ enum class RadixSortAlgorithm
 #if _CCCL_HOSTED()
 namespace detail
 {
-_CCCL_API [[nodiscard]] constexpr const char* to_string(RadixSortAlgorithm algo) noexcept
+[[nodiscard]] _CCCL_API constexpr const char* to_string(RadixSortAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -55,7 +55,7 @@ enum class ScanAlgorithm
 #if _CCCL_HOSTED()
 namespace detail
 {
-_CCCL_API [[nodiscard]] constexpr const char* to_string(ScanAlgorithm algo) noexcept
+[[nodiscard]] _CCCL_API constexpr const char* to_string(ScanAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -55,7 +55,7 @@ enum class ScanAlgorithm
 #if _CCCL_HOSTED()
 namespace detail
 {
-[[nodiscard]] constexpr const char* to_string(ScanAlgorithm algo) noexcept
+_CCCL_API [[nodiscard]] constexpr const char* to_string(ScanAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -63,9 +63,8 @@ namespace detail
       return "ScanAlgorithm::lookback";
     case ScanAlgorithm::lookahead:
       return "ScanAlgorithm::lookahead";
-    default:
-      return "<unknown ScanAlgorithm>";
   }
+  return "<unknown ScanAlgorithm>";
 }
 } // namespace detail
 #endif // _CCCL_HOSTED()

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -47,7 +47,7 @@ enum class TransformAlgorithm
 #if _CCCL_HOSTED()
 namespace detail
 {
-_CCCL_API [[nodiscard]] constexpr const char* to_string(TransformAlgorithm algo) noexcept
+[[nodiscard]] _CCCL_API constexpr const char* to_string(TransformAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -59,9 +59,8 @@ namespace detail
       return "TransformAlgorithm::ldgsts";
     case TransformAlgorithm::ublkcp:
       return "TransformAlgorithm::ublkcp";
-    default:
-      return "<unknown TransformAlgorithm>";
   }
+  return "<unknown TransformAlgorithm>";
 }
 } // namespace detail
 #endif // _CCCL_HOSTED()

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -47,7 +47,7 @@ enum class TransformAlgorithm
 #if _CCCL_HOSTED()
 namespace detail
 {
-[[nodiscard]] constexpr const char* to_string(TransformAlgorithm algo) noexcept
+_CCCL_API [[nodiscard]] constexpr const char* to_string(TransformAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/thread/thread_load.cuh
+++ b/cub/cub/thread/thread_load.cuh
@@ -51,7 +51,7 @@ enum CacheLoadModifier
 #if _CCCL_HOSTED()
 namespace detail
 {
-[[nodiscard]] constexpr const char* to_string(CacheLoadModifier modifier) noexcept
+_CCCL_API [[nodiscard]] constexpr const char* to_string(CacheLoadModifier modifier) noexcept
 {
   switch (modifier)
   {

--- a/cub/cub/thread/thread_load.cuh
+++ b/cub/cub/thread/thread_load.cuh
@@ -51,7 +51,7 @@ enum CacheLoadModifier
 #if _CCCL_HOSTED()
 namespace detail
 {
-_CCCL_API [[nodiscard]] constexpr const char* to_string(CacheLoadModifier modifier) noexcept
+[[nodiscard]] _CCCL_API constexpr const char* to_string(CacheLoadModifier modifier) noexcept
 {
   switch (modifier)
   {

--- a/cub/cub/thread/thread_load.cuh
+++ b/cub/cub/thread/thread_load.cuh
@@ -69,9 +69,8 @@ namespace detail
       return "LOAD_LDG";
     case LOAD_VOLATILE:
       return "LOAD_VOLATILE";
-    default:
-      return "<unknown CacheLoadModifier>";
   }
+  return "<unknown CacheLoadModifier>";
 }
 } // namespace detail
 #endif // _CCCL_HOSTED()

--- a/cub/cub/warp/warp_load.cuh
+++ b/cub/cub/warp/warp_load.cuh
@@ -112,7 +112,7 @@ enum WarpLoadAlgorithm
 #if _CCCL_HOSTED()
 namespace detail
 {
-[[nodiscard]] constexpr const char* to_string(WarpLoadAlgorithm algo) noexcept
+_CCCL_API [[nodiscard]] constexpr const char* to_string(WarpLoadAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/warp/warp_load.cuh
+++ b/cub/cub/warp/warp_load.cuh
@@ -112,7 +112,7 @@ enum WarpLoadAlgorithm
 #if _CCCL_HOSTED()
 namespace detail
 {
-_CCCL_API [[nodiscard]] constexpr const char* to_string(WarpLoadAlgorithm algo) noexcept
+[[nodiscard]] _CCCL_API constexpr const char* to_string(WarpLoadAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/warp/warp_load.cuh
+++ b/cub/cub/warp/warp_load.cuh
@@ -124,9 +124,8 @@ namespace detail
       return "WARP_LOAD_VECTORIZE";
     case WARP_LOAD_TRANSPOSE:
       return "WARP_LOAD_TRANSPOSE";
-    default:
-      return "<unknown WarpLoadAlgorithm>";
   }
+  return "<unknown WarpLoadAlgorithm>";
 }
 } // namespace detail
 #endif // _CCCL_HOSTED()

--- a/cub/cub/warp/warp_store.cuh
+++ b/cub/cub/warp/warp_store.cuh
@@ -116,7 +116,7 @@ enum WarpStoreAlgorithm
 #if _CCCL_HOSTED()
 namespace detail
 {
-_CCCL_API [[nodiscard]] constexpr const char* to_string(WarpStoreAlgorithm algo) noexcept
+[[nodiscard]] _CCCL_API constexpr const char* to_string(WarpStoreAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/warp/warp_store.cuh
+++ b/cub/cub/warp/warp_store.cuh
@@ -116,7 +116,7 @@ enum WarpStoreAlgorithm
 #if _CCCL_HOSTED()
 namespace detail
 {
-[[nodiscard]] constexpr const char* to_string(WarpStoreAlgorithm algo) noexcept
+_CCCL_API [[nodiscard]] constexpr const char* to_string(WarpStoreAlgorithm algo) noexcept
 {
   switch (algo)
   {

--- a/cub/cub/warp/warp_store.cuh
+++ b/cub/cub/warp/warp_store.cuh
@@ -128,9 +128,8 @@ namespace detail
       return "WARP_STORE_VECTORIZE";
     case WARP_STORE_TRANSPOSE:
       return "WARP_STORE_TRANSPOSE";
-    default:
-      return "<unknown WarpStoreAlgorithm>";
   }
+  return "<unknown WarpStoreAlgorithm>";
 }
 } // namespace detail
 


### PR DESCRIPTION
As suggested by @Jacobfaib on #9745, this PR:

* Move default cases in `to_string` functions out of `switch`es
* ~~Fully qualifies `std::formatter` specializations~~
* Adds the missing `_CCCL_API`