### PR TITLE
Fix test helper producing inverted interval

### DIFF
--- a/cub/test/thread_reduce/catch2_test_thread_reduce_helper.cuh
+++ b/cub/test/thread_reduce/catch2_test_thread_reduce_helper.cuh
@@ -20,6 +20,38 @@
 
 namespace detail
 {
+// Convert a bound computed in a wider or floating-point domain down to `To`, avoiding the pitfalls of a plain
+// static_cast:
+//   * integer -> narrower integer: static_cast wraps around when the value is outside `To`'s range (e.g.
+//     static_cast<int16_t>(INT_MAX) == -1), which can invert the resulting interval (min > max). Saturating clamps to
+//     `To`'s range instead, preserving the intersection.
+//   * floating-point -> integer: static_cast is UB when the (truncated) value is outside `To`'s range (e.g.
+//     static_cast<int64_t>(exp2(log2(INT64_MAX))), where log2/exp2 round-trip up to 2^63). Clamp to `To`'s range first.
+template <typename To, typename From>
+constexpr To clamp_to(From value)
+{
+  if constexpr (cuda::std::__cccl_is_integer_v<To> && cuda::std::__cccl_is_integer_v<From>)
+  {
+    return cuda::std::saturating_cast<To>(value);
+  }
+  else if constexpr (cuda::std::__cccl_is_integer_v<To> && cuda::std::is_floating_point_v<From>)
+  {
+    if (value <= static_cast<From>(cuda::std::numeric_limits<To>::lowest()))
+    {
+      return cuda::std::numeric_limits<To>::lowest();
+    }
+    if (value >= static_cast<From>(cuda::std::numeric_limits<To>::max()))
+    {
+      return cuda::std::numeric_limits<To>::max();
+    }
+    return static_cast<To>(value);
+  }
+  else
+  {
+    return static_cast<To>(value);
+  }
+}
+
 template <typename T, typename Operator, cuda::std::ptrdiff_t MaxReductionLength, typename = void>
 struct dist_interval
 {
@@ -62,46 +94,20 @@ struct dist_interval<
   // signed_integer: Avoid possibility of over-/underflow causing UB
   // floating_point: Avoid possibility of over-/underflow causing inf destroying pseudo-associativity
   // Use floating point arithmetic to avoid unnecessarily small interval.
+  // clamp_to guards the floating -> T conversion: the log2/exp2 round-trip can round up above T's range (e.g. for
+  // int64_t at MaxReductionLength == 1, exp2(log2(INT64_MAX)) == 2^63), and static_cast of that is float-cast-overflow
+  // UB.
   static constexpr T min()
   {
     const double log2_abs_min = cuda::std::log2(cuda::std::fabs(cuda::std::numeric_limits<T>::lowest()));
-    return static_cast<T>(-cuda::std::exp2(log2_abs_min / MaxReductionLength));
+    return clamp_to<T>(-cuda::std::exp2(log2_abs_min / MaxReductionLength));
   }
   static constexpr T max()
   {
     const double log2_max = cuda::std::log2(cuda::std::numeric_limits<T>::max());
-    return static_cast<T>(cuda::std::exp2(log2_max / MaxReductionLength));
+    return clamp_to<T>(cuda::std::exp2(log2_max / MaxReductionLength));
   }
 };
-
-// Narrow a bound computed in a wider Accum/Output domain down to the Input domain. A plain static_cast would wrap
-// around when the value is outside Input's range (e.g. static_cast<int16_t>(INT_MAX) == -1), which can invert the
-// resulting interval (min > max). Saturating instead clamps to Input's range, preserving the intersection.
-template <typename To, typename From>
-constexpr To clamp_to(From value)
-{
-  if constexpr (cuda::std::__cccl_is_integer_v<To> && cuda::std::__cccl_is_integer_v<From>)
-  {
-    return cuda::std::saturating_cast<To>(value);
-  }
-  else if constexpr (cuda::std::__cccl_is_integer_v<To> && cuda::std::is_floating_point_v<From>)
-  {
-    // Floating -> integer narrowing: a plain static_cast is UB when the value is outside To's range, so clamp first.
-    if (value <= static_cast<From>(cuda::std::numeric_limits<To>::lowest()))
-    {
-      return cuda::std::numeric_limits<To>::lowest();
-    }
-    if (value >= static_cast<From>(cuda::std::numeric_limits<To>::max()))
-    {
-      return cuda::std::numeric_limits<To>::max();
-    }
-    return static_cast<To>(value);
-  }
-  else
-  {
-    return static_cast<To>(value);
-  }
-}
 } // namespace detail
 
 template <typename Input,
@@ -148,8 +154,9 @@ struct dist_interval
 
 // Regression guard: these (Input, Op, num_items, Output) combinations used to compute inverted intervals (min > max)
 // because a wider Accum/Output bound was narrowed to Input with a wrapping static_cast (e.g.
-// static_cast<int16_t>(INT_MAX) == -1). An inverted interval makes Catch2's random(min, max) hang. These cover the
-// integer-narrowing cases; they avoid log2/exp2 so they are always constant-evaluable across host compilers.
+// static_cast<int16_t>(INT_MAX) == -1). An inverted interval violates the precondition of Catch2's random(min, max).
+// These cover the integer-narrowing cases; they avoid log2/exp2 so they are always constant-evaluable across host
+// compilers.
 template <typename Input, typename Op, cuda::std::ptrdiff_t MaxReductionLength, typename Output>
 using test_dist_interval = dist_interval<Input, Op, MaxReductionLength, cuda::std::__accumulator_t<Op, Input>, Output>;
 

--- a/cub/test/thread_reduce/catch2_test_thread_reduce_helper.cuh
+++ b/cub/test/thread_reduce/catch2_test_thread_reduce_helper.cuh
@@ -8,6 +8,7 @@
 #include <cuda/std/cmath>
 #include <cuda/std/functional>
 #include <cuda/std/limits>
+#include <cuda/std/numeric>
 #include <cuda/std/type_traits>
 
 #include <ostream>
@@ -71,6 +72,35 @@ struct dist_interval<
     return static_cast<T>(cuda::std::exp2(log2_max / MaxReductionLength));
   }
 };
+
+// Narrow a bound computed in a wider Accum/Output domain down to the Input domain. A plain static_cast would wrap
+// around when the value is outside Input's range (e.g. static_cast<int16_t>(INT_MAX) == -1), which can invert the
+// resulting interval (min > max). Saturating instead clamps to Input's range, preserving the intersection.
+template <typename To, typename From>
+constexpr To clamp_to(From value)
+{
+  if constexpr (cuda::std::__cccl_is_integer_v<To> && cuda::std::__cccl_is_integer_v<From>)
+  {
+    return cuda::std::saturating_cast<To>(value);
+  }
+  else if constexpr (cuda::std::__cccl_is_integer_v<To> && cuda::std::is_floating_point_v<From>)
+  {
+    // Floating -> integer narrowing: a plain static_cast is UB when the value is outside To's range, so clamp first.
+    if (value <= static_cast<From>(cuda::std::numeric_limits<To>::lowest()))
+    {
+      return cuda::std::numeric_limits<To>::lowest();
+    }
+    if (value >= static_cast<From>(cuda::std::numeric_limits<To>::max()))
+    {
+      return cuda::std::numeric_limits<To>::max();
+    }
+    return static_cast<To>(value);
+  }
+  else
+  {
+    return static_cast<To>(value);
+  }
+}
 } // namespace detail
 
 template <typename Input,
@@ -88,12 +118,13 @@ struct dist_interval
     auto res = cuda::std::numeric_limits<Input>::lowest();
     if constexpr (cuda::std::__cccl_is_signed_integer_v<Output>)
     {
-      res =
-        cuda::std::max(res, static_cast<Input>(detail::dist_interval<Output, Operator, MaxRedductionLength>::min()));
+      res = cuda::std::max(
+        res, detail::clamp_to<Input>(detail::dist_interval<Output, Operator, MaxRedductionLength>::min()));
     }
     if constexpr (cuda::std::__cccl_is_signed_integer_v<Accum> || cuda::std::is_floating_point_v<Accum>)
     {
-      res = cuda::std::max(res, static_cast<Input>(detail::dist_interval<Accum, Operator, MaxRedductionLength>::min()));
+      res = cuda::std::max(res,
+                           detail::clamp_to<Input>(detail::dist_interval<Accum, Operator, MaxRedductionLength>::min()));
     }
     return res;
   }
@@ -102,16 +133,35 @@ struct dist_interval
     auto res = cuda::std::numeric_limits<Input>::max();
     if constexpr (cuda::std::__cccl_is_signed_integer_v<Output>)
     {
-      res =
-        cuda::std::min(res, static_cast<Input>(detail::dist_interval<Output, Operator, MaxRedductionLength>::max()));
+      res = cuda::std::min(
+        res, detail::clamp_to<Input>(detail::dist_interval<Output, Operator, MaxRedductionLength>::max()));
     }
     if constexpr (cuda::std::__cccl_is_signed_integer_v<Accum> || cuda::std::is_floating_point_v<Accum>)
     {
-      res = cuda::std::min(res, static_cast<Input>(detail::dist_interval<Accum, Operator, MaxRedductionLength>::max()));
+      res = cuda::std::min(res,
+                           detail::clamp_to<Input>(detail::dist_interval<Accum, Operator, MaxRedductionLength>::max()));
     }
     return res;
   }
 };
+
+// Regression guard: these (Input, Op, num_items, Output) combinations used to compute inverted intervals (min > max)
+// because a wider Accum/Output bound was narrowed to Input with a wrapping static_cast (e.g.
+// static_cast<int16_t>(INT_MAX) == -1). An inverted interval makes Catch2's random(min, max) hang. These cover the
+// integer-narrowing cases; they avoid log2/exp2 so they are always constant-evaluable across host compilers.
+template <typename Input, typename Op, cuda::std::ptrdiff_t MaxReductionLength, typename Output>
+using test_dist_interval = dist_interval<Input, Op, MaxReductionLength, cuda::std::__accumulator_t<Op, Input>, Output>;
+
+// Primary reported case (int16_t input, wider int accumulator): assert the exact overflow-safe bounds, not just
+// ordering, so a semantic regression (not only an inversion) is caught too.
+static_assert(test_dist_interval<cuda::std::int16_t, cuda::std::plus<>, 16, cuda::std::int16_t>::min() == -2048);
+static_assert(test_dist_interval<cuda::std::int16_t, cuda::std::plus<>, 16, cuda::std::int16_t>::max() == 2047);
+// Further combinations that previously inverted (bit_and reaches the primary full-range specialization; the signed
+// int8_t/int32_t pair is exercised by catch2_test_thread_scan_inclusive_partial.cu).
+static_assert(test_dist_interval<cuda::std::int16_t, cuda::std::bit_and<>, 16, cuda::std::int16_t>::min()
+              <= test_dist_interval<cuda::std::int16_t, cuda::std::bit_and<>, 16, cuda::std::int16_t>::max());
+static_assert(test_dist_interval<cuda::std::int8_t, cuda::std::plus<>, 3, cuda::std::int32_t>::min()
+              <= test_dist_interval<cuda::std::int8_t, cuda::std::plus<>, 3, cuda::std::int32_t>::max());
 
 /***********************************************************************************************************************
  * For testing for invalid values being passed to the binary operator

--- a/cub/test/thread_reduce/catch2_test_thread_reduce_helper.cuh
+++ b/cub/test/thread_reduce/catch2_test_thread_reduce_helper.cuh
@@ -6,6 +6,7 @@
 #include <cuda/cmath>
 #include <cuda/functional>
 #include <cuda/std/cmath>
+#include <cuda/std/cstdint>
 #include <cuda/std/functional>
 #include <cuda/std/limits>
 #include <cuda/std/numeric>


### PR DESCRIPTION
## Description

A test helper that was supposed to produce safe RNG distribution intervals for scans/reductions was producing intervals with min > max in some edge cases due to casting to unsigned without saturation. There was also UB due to casting big FP values to integers. This PR fixes those behaviors and makes sure it stays fixed with some `static_assert`s.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
<!-- closes  Link issue here -->
Fixes NVBug 6400113

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
