### PR TITLE
Fix Thrust contiguous iterator unwraps for cuda::device_buffer

### DIFF
--- a/thrust/testing/cuda/device_buffer_algorithms.cu
+++ b/thrust/testing/cuda/device_buffer_algorithms.cu
@@ -45,4 +45,3 @@ void TestDeviceBufferSortCudaStreams()
   test_runtime::assert_equal(stream, buffer, {0, 1, 2, 3, 4});
 }
 DECLARE_UNITTEST(TestDeviceBufferSortCudaStreams);
-#include <thrust/execution_policy.h>

--- a/thrust/testing/cuda/device_buffer_algorithms.cu
+++ b/thrust/testing/cuda/device_buffer_algorithms.cu
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <thrust/execution_policy.h>
+#include <thrust/random.h>
+#include <thrust/sequence.h>
+#include <thrust/shuffle.h>
+#include <thrust/sort.h>
+
+#include <cuda/buffer>
+#include <cuda/cccl_runtime_test_helper.cuh>
+#include <cuda/std/initializer_list>
+#include <cuda/stream>
+
+#include <unittest/unittest.h>
+
+void TestDeviceBufferShuffleCudaStreams()
+{
+  const auto device = test_runtime::current_test_device();
+  cuda::stream stream{device};
+
+  auto buffer       = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
+  const auto policy = thrust::cuda::par_nosync.on(stream.get());
+
+  thrust::sequence(policy, buffer.begin(), buffer.end());
+
+  thrust::default_random_engine rng{2};
+  thrust::shuffle(policy, buffer.begin(), buffer.end(), rng);
+  thrust::sort(policy, buffer.begin(), buffer.end());
+
+  test_runtime::assert_equal(stream, buffer, {0, 1, 2, 3, 4});
+}
+DECLARE_UNITTEST(TestDeviceBufferShuffleCudaStreams);
+
+void TestDeviceBufferSortCudaStreams()
+{
+  const auto device = test_runtime::current_test_device();
+  cuda::stream stream{device};
+
+  auto buffer       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{3, 1, 4, 0, 2});
+  const auto policy = thrust::cuda::par_nosync.on(stream.get());
+
+  thrust::sort(policy, buffer.begin(), buffer.end());
+
+  test_runtime::assert_equal(stream, buffer, {0, 1, 2, 3, 4});
+}
+DECLARE_UNITTEST(TestDeviceBufferSortCudaStreams);
+#include <thrust/execution_policy.h>

--- a/thrust/testing/cuda/device_buffer_algorithms.cu
+++ b/thrust/testing/cuda/device_buffer_algorithms.cu
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <thrust/execution_policy.h>
 #include <thrust/random.h>

--- a/thrust/thrust/system/cuda/detail/copy.h
+++ b/thrust/thrust/system/cuda/detail/copy.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016, NVIDIA CORPORATION. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
@@ -15,7 +15,6 @@
 
 #include <thrust/system/cuda/config.h>
 
-#include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/detail/temporary_array.h>
 #include <thrust/system/cuda/detail/cdp_dispatch.h>
 #include <thrust/system/cuda/detail/cross_system.h>
@@ -30,6 +29,7 @@
 #endif // _CCCL_CUDA_COMPILATION()
 
 #include <cuda/__fwd/iterator.h>
+#include <cuda/std/__memory/pointer_traits.h>
 #include <cuda/std/tuple>
 
 THRUST_NAMESPACE_BEGIN
@@ -154,8 +154,8 @@ OutputIt _CCCL_HOST cross_system_copy_n(cross_system<System1, System2> systems, 
   if constexpr (is_indirectly_trivially_relocate_to_v<InputIt, OutputIt>)
   {
     using InputTy = thrust::detail::it_value_t<InputIt>;
-    auto* dst     = reinterpret_cast<InputTy*>(thrust::raw_pointer_cast(&*result));
-    auto* src     = reinterpret_cast<InputTy const*>(thrust::raw_pointer_cast(&*begin));
+    auto* dst     = reinterpret_cast<InputTy*>(::cuda::std::to_address(result));
+    auto* src     = reinterpret_cast<InputTy const*>(::cuda::std::to_address(begin));
     trivial_cross_system_copy_n(derived_cast(systems.sys1), derived_cast(systems.sys2), dst, src, n);
     return result + n;
   }
@@ -181,8 +181,8 @@ device_to_device(execution_policy<Derived>& policy, InputIt first, InputIt last,
     {
       const cudaError status = trivial_copy_device_to_device(
         policy,
-        reinterpret_cast<InputTy*>(thrust::raw_pointer_cast(&*result)),
-        reinterpret_cast<InputTy const*>(thrust::raw_pointer_cast(&*first)),
+        reinterpret_cast<InputTy*>(::cuda::std::to_address(result)),
+        reinterpret_cast<InputTy const*>(::cuda::std::to_address(first)),
         n);
       throw_on_error(status, "__copy:: D->D: failed");
     }

--- a/thrust/thrust/system/cuda/detail/sort.h
+++ b/thrust/thrust/system/cuda/detail/sort.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016, NVIDIA CORPORATION. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
@@ -35,6 +35,7 @@
 #  include <cuda/__cmath/round_up.h>
 #  include <cuda/std/__functional/operations.h>
 #  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__memory/pointer_traits.h>
 #  include <cuda/std/__type_traits/enable_if.h>
 #  include <cuda/std/__type_traits/integral_constant.h>
 #  include <cuda/std/__type_traits/is_arithmetic.h>
@@ -308,8 +309,8 @@ THRUST_RUNTIME_FUNCTION void smart_sort(
 
     __radix_sort::radix_sort<SORT_ITEMS>(
       policy,
-      thrust::raw_pointer_cast(&*keys.begin()),
-      thrust::raw_pointer_cast(&*values.begin()),
+      ::cuda::std::to_address(keys.begin()),
+      ::cuda::std::to_address(values.begin()),
       keys_last - keys_first,
       compare_op);
 
@@ -322,8 +323,8 @@ THRUST_RUNTIME_FUNCTION void smart_sort(
   {
     __radix_sort::radix_sort<SORT_ITEMS>(
       policy,
-      thrust::raw_pointer_cast(&*keys.begin()),
-      thrust::raw_pointer_cast(&*keys.begin()),
+      ::cuda::std::to_address(keys.begin()),
+      ::cuda::std::to_address(keys.begin()),
       keys_last - keys_first,
       compare_op);
   }

--- a/thrust/thrust/type_traits/unwrap_contiguous_iterator.h
+++ b/thrust/thrust/type_traits/unwrap_contiguous_iterator.h
@@ -1,13 +1,13 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2021, NVIDIA Corporation. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2026, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
 #include <thrust/detail/config.h>
 
-#include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/type_traits/is_contiguous_iterator.h>
 
+#include <cuda/std/__memory/pointer_traits.h>
 #include <cuda/std/__utility/declval.h>
 
 THRUST_NAMESPACE_BEGIN
@@ -19,7 +19,7 @@ _CCCL_HOST_DEVICE auto unwrap_contiguous_iterator(ContiguousIterator it)
 {
   static_assert(thrust::is_contiguous_iterator_v<ContiguousIterator>,
                 "unwrap_contiguous_iterator called with non-contiguous iterator.");
-  return thrust::raw_pointer_cast(&*it);
+  return ::cuda::std::to_address(it);
 }
 
 //! Converts a contiguous iterator type to its underlying raw pointer type.


### PR DESCRIPTION
Closes #9755

## Summary

This fixes ClangCUDA compilation failures when Thrust CUDA algorithm paths unwrap contiguous iterators from `cuda::device_buffer`.

The issue was caused by recovering raw pointers via `&*it`, which dereferences `cuda::heterogeneous_iterator<T, cuda::mr::device_accessible>` from host-side code. `cuda::heterogeneous_iterator` already provides `cuda::std::pointer_traits` support, so this PR switches those unwrap paths to `::cuda::std::to_address(...)`.

## Changes

- Uses `::cuda::std::to_address(...)` in Thrust contiguous iterator unwraps.
- Updates CUDA copy fast paths and radix-sort dispatch paths that used `thrust::raw_pointer_cast(&*it)`.
- Adds a CUDA regression test covering `cuda::device_buffer` with `thrust::shuffle` and `thrust::sort`.
