### PR TITLE
[STF] Export blocked_partition_custom into cuda::experimental::stf

### DIFF
--- a/cudax/include/cuda/experimental/__stf/internal/stf_places_extended_exports.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/stf_places_extended_exports.cuh
@@ -39,6 +39,7 @@
 namespace cuda::experimental::stf
 {
 using ::cuda::experimental::places::blocked_partition;
+using ::cuda::experimental::places::blocked_partition_custom;
 using ::cuda::experimental::places::cyclic_partition;
 #if _CCCL_CTK_AT_LEAST(12, 4)
 using ::cuda::experimental::places::green_context_helper;


### PR DESCRIPTION
## Description

When the partitioner classes were moved into the `cuda::experimental::places` namespace, `stf_places_extended_exports.cuh` re-exported `blocked_partition` into `cuda::experimental::stf` but not the underlying `blocked_partition_custom` template it is an alias of (`blocked_partition = blocked_partition_custom<>`).

This broke existing STF user code that selects the partitioned dimension explicitly, e.g.:

```cpp
using policy = blocked_partition_custom<1>;
ctx.parallel_for(policy(), where, ...);
```

(found while updating the CUDASTF port of miniWeather to latest main)

This PR adds the missing `using` declaration alongside the other partitioner exports.

## Checklist

- [x] New or existing tests cover these changes: exercised via a downstream STF application (miniWeather) using `blocked_partition_custom<1>`, built and run against this branch.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)