### PR TITLE
[cccl.c] Fix scan policy mismatch between host and NVRTC

### DIFF
--- a/c/parallel/src/scan.cu
+++ b/c/parallel/src/scan.cu
@@ -401,6 +401,21 @@ static_assert(device_scan_policy()(detail::current_tuning_cc()) == {6}, "Host ge
     "-DCUB_DISABLE_CDP",
     "-std=c++20"};
 
+  // The scan tuning policy depends on the version of the CUDA compiler evaluating it, so this library and NVRTC can
+  // select different algorithms when their versions differ, tripping the policy-mismatch static_assert in the
+  // generated source (NVBug 6235538). Force the JIT to agree with the host: when the host selected lookback, disable
+  // the warpspeed/lookahead scan for the JIT as well. The other direction cannot diverge as long as this library is
+  // built with a CUDA compiler below 13.4: every NVRTC version able to target the architectures for which the host
+  // then selects lookahead also selects lookahead.
+  static_assert(_CCCL_CUDACC_BELOW(13, 4),
+                "Building cccl.c with CUDA >= 13.4 lets the host select the lookahead scan on sm_120, which an NVRTC "
+                "below 13.4 rejects, and this one-directional forcing cannot fix that. Revisit NVBug 6235538 "
+                "before lifting this assert.");
+  if (active_policy.algorithm == cub::ScanAlgorithm::lookback)
+  {
+    args.push_back("-DCCCL_DISABLE_WARPSPEED_SCAN");
+  }
+
   cccl::detail::extend_args_with_build_config(args, config);
 
   constexpr size_t num_lto_args   = 2;


### PR DESCRIPTION
The scan tuning policy is computed twice: once in the prebuilt cccl.c library and once by NVRTC while JIT-compiling the kernel, with a `static_assert` checking they agree. The decision depends on the CUDA compiler version (`_CCCL_CUDACC_BELOW(13, 4)` sm_120 guard, `MSVC && nvcc < 13.1`), so when the library's build CTK and the runtime NVRTC differ — e.g. a 13.1-built wheel meeting NVRTC 13.4, which enables warpspeed on sm_120 — the two sides pick different algorithms and every scan build fails with Error 999.

Fix: when the host picks lookback, pass `-DCCCL_DISABLE_WARPSPEED_SCAN` to NVRTC so the JIT makes the same choice. The other direction can't diverge as long as the library is built with CUDA < 13.4; a `static_assert` enforces that. This means cccl.c stays on lookback for sm_120 even with NVRTC 13.4 — acceptable since c.parallel v2 evaluates the policy only once and doesn't have this problem.

Verified on an sm_120 GPU with a 13.1-built library: baseline fails with the reported assert against NVRTC-as-13.4, fixed build compiles and produces correct scan results against both 13.3 and 13.4; sm_100 still selects warpspeed.
