### PR TITLE
Fully classify the `cub::detail::InputValue` template to avoid implicit conversions

### DIFF
--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -1163,7 +1163,7 @@ struct DeviceScan
       d_in,
       d_out,
       scan_op,
-      detail::InputValue<InitValueT>(init_value),
+      detail::InputValue<InitValueT, InitValueIterT>(init_value),
       static_cast<OffsetT>(num_items),
       stream);
   }
@@ -1460,7 +1460,8 @@ struct DeviceScan
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceScan::ExclusiveScan");
 
-    return scan_impl_env(d_in, d_out, scan_op, detail::InputValue<InitValueT>(init_value), num_items, env);
+    return scan_impl_env(
+      d_in, d_out, scan_op, detail::InputValue<InitValueT, InitValueIterT>(init_value), num_items, env);
   }
 
   //! @}

--- a/cub/test/catch2_test_device_scan_iterators.cu
+++ b/cub/test/catch2_test_device_scan_iterators.cu
@@ -157,34 +157,39 @@ C2H_TEST("Device scan works with iterators", "[scan][device]", iterator_type_lis
 
   SECTION("exclusive scan with future-init value, non-pointer iterator")
   {
-    using op_t    = cuda::std::plus<>;
-    using accum_t = cuda::std::__accumulator_t<op_t, input_t, input_t>;
+    // cuda::buffer currently does not handle types with size of exactly 3 in the value
+    // constructor. See https://github.com/NVIDIA/cccl/pull/9776
+    if constexpr (sizeof(input_t) == 3)
+    {
+      using op_t    = cuda::std::plus<>;
+      using accum_t = cuda::std::__accumulator_t<op_t, input_t, input_t>;
 
-    // Prepare verification data
-    accum_t init_value{};
-    init_default_constant(init_value);
-    c2h::host_vector<output_t> expected_result(num_items);
-    compute_exclusive_scan_reference(in_it, in_it + num_items, expected_result.begin(), init_value, op_t{});
+      // Prepare verification data
+      accum_t init_value{};
+      init_default_constant(init_value);
+      c2h::host_vector<output_t> expected_result(num_items);
+      compute_exclusive_scan_reference(in_it, in_it + num_items, expected_result.begin(), init_value, op_t{});
 
-    // Run test
-    c2h::device_vector<output_t> out_result(num_items);
-    auto d_out_it      = thrust::raw_pointer_cast(out_result.data());
-    using init_value_t = cub::detail::it_value_t<decltype(unwrap_it(d_out_it))>;
-    // Note using device buffer here because dereferencing the iterator will return a raw
-    // device reference and cause a segfault if the detail::InputValue is convert-constructed
-    // from the future value below.
-    auto d_initial_value = cuda::make_device_buffer<init_value_t>(
-      cuda::stream_ref{cudaStream_t{}}, cuda::devices[0], /*__size=*/1, init_value);
+      // Run test
+      c2h::device_vector<output_t> out_result(num_items);
+      auto d_out_it      = thrust::raw_pointer_cast(out_result.data());
+      using init_value_t = cub::detail::it_value_t<decltype(unwrap_it(d_out_it))>;
+      // Note using device buffer here because dereferencing the iterator will return a raw
+      // device reference and cause a segfault if the detail::InputValue is convert-constructed
+      // from the future value below.
+      auto d_initial_value = cuda::make_device_buffer<init_value_t>(
+        cuda::stream_ref{cudaStream_t{}}, cuda::devices[0], /*__size=*/1, init_value);
 
-    using device_buffer_t = decltype(d_initial_value);
-    using future_t        = cub::FutureValue<typename device_buffer_t::value_type, typename device_buffer_t::iterator>;
+      using device_buffer_t = decltype(d_initial_value);
+      using future_t = cub::FutureValue<typename device_buffer_t::value_type, typename device_buffer_t::iterator>;
 
-    auto future_init_value = future_t{d_initial_value.begin()};
+      auto future_init_value = future_t{d_initial_value.begin()};
 
-    device_exclusive_scan(in_it, d_out_it, op_t{}, future_init_value, num_items);
+      device_exclusive_scan(in_it, d_out_it, op_t{}, future_init_value, num_items);
 
-    // Verify result
-    REQUIRE(expected_result == out_result);
+      // Verify result
+      REQUIRE(expected_result == out_result);
+    }
   }
 }
 

--- a/cub/test/catch2_test_device_scan_iterators.cu
+++ b/cub/test/catch2_test_device_scan_iterators.cu
@@ -5,6 +5,8 @@
 
 #include <cub/device/device_scan.cuh>
 
+#include <cuda/buffer>
+#include <cuda/devices>
 #include <cuda/iterator>
 #include <cuda/std/limits>
 
@@ -147,6 +149,38 @@ C2H_TEST("Device scan works with iterators", "[scan][device]", iterator_type_lis
     c2h::device_vector<init_value_t> d_initial_value(1);
     d_initial_value[0]     = static_cast<init_value_t>(init_value);
     auto future_init_value = cub::FutureValue<init_value_t>(thrust::raw_pointer_cast(d_initial_value.data()));
+    device_exclusive_scan(in_it, d_out_it, op_t{}, future_init_value, num_items);
+
+    // Verify result
+    REQUIRE(expected_result == out_result);
+  }
+
+  SECTION("exclusive scan with future-init value, non-pointer iterator")
+  {
+    using op_t    = cuda::std::plus<>;
+    using accum_t = cuda::std::__accumulator_t<op_t, input_t, input_t>;
+
+    // Prepare verification data
+    accum_t init_value{};
+    init_default_constant(init_value);
+    c2h::host_vector<output_t> expected_result(num_items);
+    compute_exclusive_scan_reference(in_it, in_it + num_items, expected_result.begin(), init_value, op_t{});
+
+    // Run test
+    c2h::device_vector<output_t> out_result(num_items);
+    auto d_out_it      = thrust::raw_pointer_cast(out_result.data());
+    using init_value_t = cub::detail::it_value_t<decltype(unwrap_it(d_out_it))>;
+    // Note using device buffer here because dereferencing the iterator will return a raw
+    // device reference and cause a segfault if the detail::InputValue is convert-constructed
+    // from the future value below.
+    auto d_initial_value = cuda::make_device_buffer<init_value_t>(
+      cuda::stream_ref{cudaStream_t{}}, cuda::devices[0], /*__size=*/1, init_value);
+
+    using device_buffer_t = decltype(d_initial_value);
+    using future_t        = cub::FutureValue<typename device_buffer_t::value_type, typename device_buffer_t::iterator>;
+
+    auto future_init_value = future_t{d_initial_value.begin()};
+
     device_exclusive_scan(in_it, d_out_it, op_t{}, future_init_value, num_items);
 
     // Verify result

--- a/cub/test/catch2_test_device_scan_iterators.cu
+++ b/cub/test/catch2_test_device_scan_iterators.cu
@@ -159,7 +159,7 @@ C2H_TEST("Device scan works with iterators", "[scan][device]", iterator_type_lis
   {
     // cuda::buffer currently does not handle types with size of exactly 3 in the value
     // constructor. See https://github.com/NVIDIA/cccl/pull/9776
-    if constexpr (sizeof(input_t) == 3)
+    if constexpr (sizeof(input_t) != 3)
     {
       using op_t    = cuda::std::plus<>;
       using accum_t = cuda::std::__accumulator_t<op_t, input_t, input_t>;

--- a/cub/test/catch2_test_device_scan_iterators.cu
+++ b/cub/test/catch2_test_device_scan_iterators.cu
@@ -178,7 +178,7 @@ C2H_TEST("Device scan works with iterators", "[scan][device]", iterator_type_lis
       // device reference and cause a segfault if the detail::InputValue is convert-constructed
       // from the future value below.
       auto d_initial_value = cuda::make_device_buffer<init_value_t>(
-        cuda::stream_ref{cudaStream_t{}}, cuda::devices[0], /*__size=*/1, init_value);
+        cuda::stream_ref{cudaStream_t{}}, cuda::devices[0], /*__size=*/1, static_cast<init_value_t>(init_value));
 
       using device_buffer_t = decltype(d_initial_value);
       using future_t = cub::FutureValue<typename device_buffer_t::value_type, typename device_buffer_t::iterator>;


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

If `FutureValue<T, Iter>` is passed to `InputValue<T, /* Iter = T* */>`, when `Iter != T *` then the goes through `FutureValue::operator T()`. `operator T()` in turn dereferences the held iterator, usually leading to segfaults because it's device memory.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
