### PR TITLE
Handle a type of size exactly 3 in cuda::buffer

### DIFF
--- a/cudax/include/cuda/experimental/__fill_bytes/fill_bytes_mdspan.cuh
+++ b/cudax/include/cuda/experimental/__fill_bytes/fill_bytes_mdspan.cuh
@@ -52,7 +52,7 @@ namespace cuda::experimental
 template <typename _ByteT>
 inline constexpr bool __can_fill_bytes_value_v =
   ::cuda::std::is_trivially_copyable_v<_ByteT> && ::cuda::std::has_unique_object_representations_v<_ByteT>
-  && (sizeof(_ByteT) == 1 || sizeof(_ByteT) == 2 || sizeof(_ByteT) == 4);
+  && ::cuda::__driver::__cu_driver_memsetable<_ByteT>;
 
 // __half, __nv_bfloat16 don't have a unique object representation
 #  if _CCCL_HAS_NVFP16()

--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -854,22 +854,20 @@ _CCCL_HOST_API void __fill_n(cuda::stream_ref __stream, _Tp* __first, ::cuda::st
     ::cuda::host_launch(
       __stream, ::cuda::std::uninitialized_fill_n<_Tp*, ::cuda::std::size_t, _Tp>, __first, __count, __value);
   }
+  else if constexpr (::cuda::__driver::__cu_driver_memsetable<_Tp>)
+  {
+    ::cuda::__driver::__memsetAsync(__first, __value, __count, __stream.get());
+  }
   else
   {
-    if constexpr (sizeof(_Tp) <= 4)
-    {
-      ::cuda::__driver::__memsetAsync(__first, __value, __count, __stream.get());
-    }
-    else
-    {
 #  if _CCCL_CUDA_COMPILATION()
-      ::cuda::__ensure_current_context __guard(__stream);
-      CUB_NS_QUALIFIER::DeviceTransform::Fill(__first, __count, __value, __stream.get());
+    ::cuda::__ensure_current_context __guard(__stream);
+    CUB_NS_QUALIFIER::DeviceTransform::Fill(__first, __count, __value, __stream.get());
 #  else // ^^^ _CCCL_CUDA_COMPILATION() ^^^ / vvv !_CCCL_CUDA_COMPILATION() vvv
-      static_assert(sizeof(_Tp) <= 4,
-                    "CUDA compiler is required to initialize an async_buffer with elements larger than 4 bytes");
+    static_assert(::cuda::__driver::__cu_driver_memsetable<_Tp>,
+                  "CUDA compiler is required to initialize an async_buffer with elements unable to be initialized "
+                  "with cuMemSet");
 #  endif // ^^^ !_CCCL_CUDA_COMPILATION() ^^^
-    }
   }
 }
 

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -399,8 +399,12 @@ _CCCL_HOST_API inline void __memcpyBatchAsync(
 #  endif // _CCCL_CTK_AT_LEAST(13, 0)
 
 template <typename _Tp>
+_CCCL_CONCEPT __cu_driver_memsetable = sizeof(_Tp) == 1 || sizeof(_Tp) == 2 || sizeof(_Tp) == 4;
+
+template <typename _Tp>
 _CCCL_HOST_API void __memsetAsync(void* __dst, _Tp __value, ::cuda::std::size_t __count, ::CUstream __stream)
 {
+  static_assert(__cu_driver_memsetable<_Tp>, "Unsupported type for memset");
   if constexpr (sizeof(_Tp) == 1)
   {
     static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemsetD8Async);
@@ -421,10 +425,6 @@ _CCCL_HOST_API void __memsetAsync(void* __dst, _Tp __value, ::cuda::std::size_t 
     auto __bits             = ::cuda::std::bit_cast<unsigned int>(__value);
     ::cuda::__driver::__call_driver_fn(
       __driver_fn, "Failed to perform a memset", reinterpret_cast<::CUdeviceptr>(__dst), __bits, __count, __stream);
-  }
-  else
-  {
-    static_assert(::cuda::std::__always_false_v<_Tp>, "Unsupported type for memset");
   }
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/conversion.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/conversion.cu
@@ -49,7 +49,7 @@ C2H_CCCLRT_TEST("cuda::buffer conversion", "[container][buffer]", test_types)
     }
 
     { // can be copy constructed from non-empty input
-      const MatchingBuffer input{stream, resource, {T(1), T(42), T(1337), T(0), T(12), T(-1)}};
+      const MatchingBuffer input{stream, resource, {T(1), T(42), T(1337), T(0), T(12), T(1)}};
       Buffer buf(input);
       CCCLRT_CHECK(!buf.empty());
       CCCLRT_CHECK(equal_range(buf));

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/conversion.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/conversion.cu
@@ -49,7 +49,7 @@ C2H_CCCLRT_TEST("cuda::buffer conversion", "[container][buffer]", test_types)
     }
 
     { // can be copy constructed from non-empty input
-      const MatchingBuffer input{stream, resource, {T(1), T(42), T(1337), T(0), T(12), T(1)}};
+      const MatchingBuffer input{stream, resource, {T(1), T(42), T(1337), T(0), T(12), T(-1)}};
       Buffer buf(input);
       CCCLRT_CHECK(!buf.empty());
       CCCLRT_CHECK(equal_range(buf));

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/helper.h
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/helper.h
@@ -237,11 +237,11 @@ struct custom_char3
 {
   constexpr custom_char3() = default;
 
-  TEST_FUNC constexpr custom_char3(int v) noexcept
+  TEST_FUNC custom_char3(int v) noexcept
   {
-    const auto u = static_cast<::cuda::std::int16_t>(v);
+    const auto u = static_cast<cuda::std::int16_t>(v);
 
-    ::cuda::std::memcpy(data, &u, sizeof(u));
+    cuda::std::memcpy(data, &u, sizeof(u));
   }
 
   TEST_FUNC constexpr friend bool operator==(const custom_char3& lhs, const custom_char3& rhs) noexcept

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/helper.h
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/helper.h
@@ -231,6 +231,42 @@ struct extract_properties<cuda::buffer<T, Properties...>>
   using matching_resource = memory_resource_wrapper<other_property, Properties...>;
 };
 
+// We cannot use the default ::char3 because it does not provide a constructor or comparison
+// operators against int
+struct custom_char3
+{
+  constexpr custom_char3() = default;
+
+  TEST_FUNC constexpr custom_char3(int v) noexcept
+  {
+    const auto u = static_cast<::cuda::std::int16_t>(v);
+
+    ::cuda::std::memcpy(data, &u, sizeof(u));
+  }
+
+  TEST_FUNC constexpr friend bool operator==(const custom_char3& lhs, const custom_char3& rhs) noexcept
+  {
+    for (cuda::std::size_t i = 0; i < cuda::std::size(lhs.data); ++i)
+    {
+      if (lhs.data[i] != rhs.data[i])
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  TEST_FUNC constexpr friend bool operator!=(const custom_char3& lhs, const custom_char3& rhs) noexcept
+  {
+    return !(lhs == rhs);
+  }
+
+  char data[3]{};
+};
+
+static_assert(sizeof(custom_char3) == 3);
+static_assert(::cuda::is_trivially_copyable_v<custom_char3>, "cuda::buffer will not accept the type");
+
 #if _CCCL_CTK_AT_LEAST(12, 9)
 using test_types =
   c2h::type_list<cuda::buffer<int, cuda::mr::host_accessible>,
@@ -238,13 +274,13 @@ using test_types =
                  cuda::buffer<short, cuda::mr::device_accessible>,
                  cuda::buffer<float, cuda::mr::device_accessible>,
                  cuda::buffer<int, cuda::mr::host_accessible, cuda::mr::device_accessible>,
-                 cuda::buffer<::char3, cuda::mr::device_accessible>>;
+                 cuda::buffer<::custom_char3, cuda::mr::device_accessible>>;
 #else // ^^^ _CCCL_CTK_AT_LEAST(12, 9) ^^^ / vvv _CCCL_CTK_BELOW(12, 9) vvv
 using test_types =
   c2h::type_list<cuda::buffer<int, cuda::mr::device_accessible>,
                  cuda::buffer<short, cuda::mr::device_accessible>,
                  cuda::buffer<float, cuda::mr::device_accessible>,
-                 cuda::buffer<::char3, cuda::mr::device_accessible>>;
+                 cuda::buffer<::custom_char3, cuda::mr::device_accessible>>;
 #endif // ^^^ _CCCL_CTK_BELOW(12, 9) ^^^
 
 #endif // CUDA_TEST_CONTAINER_VECTOR_HELPER_H

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/helper.h
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/helper.h
@@ -237,11 +237,14 @@ using test_types =
                  cuda::buffer<unsigned long long, cuda::mr::device_accessible>,
                  cuda::buffer<short, cuda::mr::device_accessible>,
                  cuda::buffer<float, cuda::mr::device_accessible>,
-                 cuda::buffer<int, cuda::mr::host_accessible, cuda::mr::device_accessible>>;
+                 cuda::buffer<int, cuda::mr::host_accessible, cuda::mr::device_accessible>,
+                 cuda::buffer<uchar3, cuda::mr::device_accessible>>;
 #else // ^^^ _CCCL_CTK_AT_LEAST(12, 9) ^^^ / vvv _CCCL_CTK_BELOW(12, 9) vvv
-using test_types = c2h::type_list<cuda::buffer<int, cuda::mr::device_accessible>,
-                                  cuda::buffer<short, cuda::mr::device_accessible>,
-                                  cuda::buffer<float, cuda::mr::device_accessible>>;
+using test_types =
+  c2h::type_list<cuda::buffer<int, cuda::mr::device_accessible>,
+                 cuda::buffer<short, cuda::mr::device_accessible>,
+                 cuda::buffer<float, cuda::mr::device_accessible>,
+                 cuda::buffer<uchar3, cuda::mr::device_accessible>>;
 #endif // ^^^ _CCCL_CTK_BELOW(12, 9) ^^^
 
 #endif // CUDA_TEST_CONTAINER_VECTOR_HELPER_H

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/helper.h
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/helper.h
@@ -238,13 +238,13 @@ using test_types =
                  cuda::buffer<short, cuda::mr::device_accessible>,
                  cuda::buffer<float, cuda::mr::device_accessible>,
                  cuda::buffer<int, cuda::mr::host_accessible, cuda::mr::device_accessible>,
-                 cuda::buffer<uchar3, cuda::mr::device_accessible>>;
+                 cuda::buffer<::char3, cuda::mr::device_accessible>>;
 #else // ^^^ _CCCL_CTK_AT_LEAST(12, 9) ^^^ / vvv _CCCL_CTK_BELOW(12, 9) vvv
 using test_types =
   c2h::type_list<cuda::buffer<int, cuda::mr::device_accessible>,
                  cuda::buffer<short, cuda::mr::device_accessible>,
                  cuda::buffer<float, cuda::mr::device_accessible>,
-                 cuda::buffer<uchar3, cuda::mr::device_accessible>>;
+                 cuda::buffer<::char3, cuda::mr::device_accessible>>;
 #endif // ^^^ _CCCL_CTK_BELOW(12, 9) ^^^
 
 #endif // CUDA_TEST_CONTAINER_VECTOR_HELPER_H


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

`sizeof(uchar3)` is exactly 3, which breaks some assumptions in `cuMemSet()` and using `cuda::buffer` to initialize with it. So provide a specific "can this type be memset" concept instead of checking sizeof(T) <= 4.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
