### PR TITLE
[libcu++] Use cccl runtime in thrust tests pt 4

### DIFF
--- a/thrust/testing/cuda/cccl_runtime_test_helper.cuh
+++ b/thrust/testing/cuda/cccl_runtime_test_helper.cuh
@@ -5,8 +5,10 @@
 
 #include <cuda/__cccl_config>
 #include <cuda/algorithm>
+#include <cuda/buffer>
 #include <cuda/devices>
 #include <cuda/launch>
+#include <cuda/memory_resource>
 #include <cuda/std/cstddef>
 #include <cuda/std/initializer_list>
 #include <cuda/std/span>
@@ -40,6 +42,29 @@ _CCCL_DEVICE_API inline void assert_device(bool condition, const char* expressio
     printf("Device assertion failed: %s (%s:%d)\n", expression, file, line);
     __trap();
   }
+}
+
+template <typename T>
+[[nodiscard]] _CCCL_HOST_API inline auto make_host_buffer(cuda::stream_ref stream, cuda::std::size_t size)
+{
+  using resource_t = cuda::mr::synchronous_resource_adapter<cuda::mr::legacy_pinned_memory_resource>;
+  resource_t resource{cuda::mr::legacy_pinned_memory_resource{cuda::device_ref{0}}};
+  return cuda::make_buffer<T>(stream, resource, size, cuda::no_init);
+}
+
+template <typename T, typename RandomT = T>
+[[nodiscard]] _CCCL_HOST_API inline auto
+random_samples_buffer(cuda::stream_ref stream, cuda::std::size_t size, cuda::std::size_t first = 0)
+{
+  auto result = make_host_buffer<T>(stream, size);
+  stream.sync();
+
+  for (cuda::std::size_t i = 0; i < size; ++i)
+  {
+    result[i] = static_cast<T>(unittest::generate_random_sample<RandomT>{}(static_cast<unsigned int>(first + i)));
+  }
+
+  return result;
 }
 
 template <typename Buffer>

--- a/thrust/testing/cuda/cccl_runtime_test_helper.cuh
+++ b/thrust/testing/cuda/cccl_runtime_test_helper.cuh
@@ -59,9 +59,10 @@ random_samples_buffer(cuda::stream_ref stream, cuda::std::size_t size, cuda::std
   auto result = make_host_buffer<T>(stream, size);
   stream.sync();
 
+  const auto generator = unittest::generate_random_sample<RandomT>{};
   for (cuda::std::size_t i = 0; i < size; ++i)
   {
-    result[i] = static_cast<T>(unittest::generate_random_sample<RandomT>{}(static_cast<unsigned int>(first + i)));
+    result[i] = static_cast<T>(generator(static_cast<unsigned int>(first + i)));
   }
 
   return result;

--- a/thrust/testing/cuda/cccl_runtime_test_helper.cuh
+++ b/thrust/testing/cuda/cccl_runtime_test_helper.cuh
@@ -82,6 +82,19 @@ assert_equal(cuda::stream_ref stream, Buffer& buffer, cuda::std::initializer_lis
     ASSERT_EQUAL(expected.begin()[i], actual[i]);
   }
 }
+
+template <typename Buffer>
+_CCCL_HOST_API inline void assert_filled(cuda::stream_ref stream, Buffer& buffer, typename Buffer::value_type expected)
+{
+  std::vector<typename Buffer::value_type> actual(buffer.size());
+  cuda::copy_bytes(stream, buffer, actual);
+  stream.sync();
+
+  for (cuda::std::size_t i = 0; i < actual.size(); ++i)
+  {
+    ASSERT_EQUAL(expected, actual[i]);
+  }
+}
 } // namespace test_runtime
 
 #define TEST_ASSERT_DEVICE(condition) ::test_runtime::assert_device((condition), #condition, __FILE__, __LINE__)

--- a/thrust/testing/cuda/count.cu
+++ b/thrust/testing/cuda/count.cu
@@ -1,30 +1,37 @@
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>
 
+#include <cuda/buffer>
+#include <cuda/cccl_runtime_test_helper.cuh>
+#include <cuda/launch>
+#include <cuda/stream>
+
 #include <unittest/unittest.h>
 
 #ifdef THRUST_TEST_DEVICE_SIDE
-template <typename ExecutionPolicy, typename Iterator, typename T, typename Iterator2>
-__global__ void count_kernel(ExecutionPolicy exec, Iterator first, Iterator last, T value, Iterator2 result)
+struct count_kernel
 {
-  *result = thrust::count(exec, first, last, value);
-}
+  template <typename ExecutionPolicy, typename Input, typename T, typename Expected>
+  __device__ void operator()(ExecutionPolicy exec, Input data, T value, Expected expected) const
+  {
+    const auto result = thrust::count(exec, data.begin(), data.end(), value);
+    TEST_ASSERT_DEVICE(result == expected);
+  }
+};
 
 template <typename T, typename ExecutionPolicy>
 void TestCountDevice(ExecutionPolicy exec, const size_t n)
 {
-  thrust::host_vector<T> h_data   = unittest::random_samples<T>(n);
-  thrust::device_vector<T> d_data = h_data;
+  const auto device = test_runtime::current_test_device();
+  cuda::stream stream{device};
 
-  thrust::device_vector<size_t> d_result(1);
+  auto h_data = test_runtime::random_samples_buffer<T>(stream, n);
+  auto d_data = cuda::make_device_buffer<T>(stream, device, h_data);
 
-  size_t h_result = thrust::count(h_data.begin(), h_data.end(), T(5));
+  const auto expected = thrust::count(h_data.begin(), h_data.end(), T{5});
 
-  count_kernel<<<1, 1>>>(exec, d_data.begin(), d_data.end(), T(5), d_result.begin());
-  cudaError_t const err = cudaDeviceSynchronize();
-  ASSERT_EQUAL(cudaSuccess, err);
-
-  ASSERT_EQUAL(h_result, d_result[0]);
+  cuda::launch(stream, test_runtime::single_thread_config(), count_kernel{}, exec, d_data, T{5}, expected);
+  stream.sync();
 }
 
 template <typename T>
@@ -41,12 +48,6 @@ void TestCountDeviceDevice(const size_t n)
 }
 DECLARE_VARIABLE_UNITTEST(TestCountDeviceDevice);
 
-template <typename ExecutionPolicy, typename Iterator, typename Predicate, typename Iterator2>
-__global__ void count_if_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Predicate pred, Iterator2 result)
-{
-  *result = thrust::count_if(exec, first, last, pred);
-}
-
 template <typename T>
 struct greater_than_five
 {
@@ -56,20 +57,30 @@ struct greater_than_five
   }
 };
 
+struct count_if_kernel
+{
+  template <typename ExecutionPolicy, typename Input, typename Predicate, typename Expected>
+  __device__ void operator()(ExecutionPolicy exec, Input data, Predicate pred, Expected expected) const
+  {
+    const auto result = thrust::count_if(exec, data.begin(), data.end(), pred);
+    TEST_ASSERT_DEVICE(result == expected);
+  }
+};
+
 template <typename T, typename ExecutionPolicy>
 void TestCountIfDevice(ExecutionPolicy exec, const size_t n)
 {
-  thrust::host_vector<T> h_data   = unittest::random_samples<T>(n);
-  thrust::device_vector<T> d_data = h_data;
+  const auto device = test_runtime::current_test_device();
+  cuda::stream stream{device};
 
-  thrust::device_vector<size_t> d_result(1);
+  auto h_data = test_runtime::random_samples_buffer<T>(stream, n);
+  auto d_data = cuda::make_device_buffer<T>(stream, device, h_data);
 
-  size_t h_result = thrust::count_if(h_data.begin(), h_data.end(), greater_than_five<T>());
-  count_if_kernel<<<1, 1>>>(exec, d_data.begin(), d_data.end(), greater_than_five<T>(), d_result.begin());
-  cudaError_t const err = cudaDeviceSynchronize();
-  ASSERT_EQUAL(cudaSuccess, err);
+  const auto expected = thrust::count_if(h_data.begin(), h_data.end(), greater_than_five<T>{});
 
-  ASSERT_EQUAL(h_result, d_result[0]);
+  cuda::launch(
+    stream, test_runtime::single_thread_config(), count_if_kernel{}, exec, d_data, greater_than_five<T>{}, expected);
+  stream.sync();
 }
 
 template <typename T>
@@ -89,15 +100,16 @@ DECLARE_VARIABLE_UNITTEST(TestCountIfDeviceDevice);
 
 void TestCountCudaStreams()
 {
-  thrust::device_vector<int> data{1, 1, 0, 0, 1};
+  const auto device = test_runtime::current_test_device();
+  cuda::stream stream{device};
 
-  cudaStream_t s;
-  cudaStreamCreate(&s);
+  auto data   = cuda::make_device_buffer<int>(stream, device, {1, 1, 0, 0, 1});
+  auto policy = thrust::cuda::par.on(stream.get());
 
-  ASSERT_EQUAL(thrust::count(thrust::cuda::par.on(s), data.begin(), data.end(), 0), 2);
-  ASSERT_EQUAL(thrust::count(thrust::cuda::par.on(s), data.begin(), data.end(), 1), 3);
-  ASSERT_EQUAL(thrust::count(thrust::cuda::par.on(s), data.begin(), data.end(), 2), 0);
+  ASSERT_EQUAL(thrust::count(policy, data.begin(), data.end(), 0), 2);
+  ASSERT_EQUAL(thrust::count(policy, data.begin(), data.end(), 1), 3);
+  ASSERT_EQUAL(thrust::count(policy, data.begin(), data.end(), 2), 0);
 
-  cudaStreamDestroy(s);
+  stream.sync();
 }
 DECLARE_UNITTEST(TestCountCudaStreams);

--- a/thrust/testing/cuda/equal.cu
+++ b/thrust/testing/cuda/equal.cu
@@ -2,79 +2,93 @@
 #include <thrust/execution_policy.h>
 #include <thrust/functional.h>
 
+#include <cuda/buffer>
+#include <cuda/cccl_runtime_test_helper.cuh>
+#include <cuda/launch>
+#include <cuda/std/cstddef>
+#include <cuda/stream>
+
 #include <unittest/unittest.h>
 
 #ifdef THRUST_TEST_DEVICE_SIDE
-template <typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3>
-__global__ void equal_kernel(ExecutionPolicy exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator3 result)
+struct equal_kernel
 {
-  *result = thrust::equal(exec, first1, last1, first2);
-}
+  template <typename ExecutionPolicy, typename Input1, typename Input2>
+  __device__ void
+  operator()(ExecutionPolicy exec, Input1 data1, Input2 data2, cuda::std::size_t size, bool expected) const
+  {
+    const auto result = thrust::equal(exec, data1.begin(), data1.begin() + size, data2.begin());
+    TEST_ASSERT_DEVICE(result == expected);
+  }
+};
 
-template <typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename BinaryPredicate, typename Iterator3>
-__global__ void equal_kernel(
-  ExecutionPolicy exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, BinaryPredicate pred, Iterator3 result)
+struct equal_pred_kernel
 {
-  *result = thrust::equal(exec, first1, last1, first2, pred);
-}
+  template <typename ExecutionPolicy, typename Input1, typename Input2, typename BinaryPredicate>
+  __device__ void operator()(
+    ExecutionPolicy exec, Input1 data1, Input2 data2, cuda::std::size_t size, BinaryPredicate pred, bool expected) const
+  {
+    const auto result = thrust::equal(exec, data1.begin(), data1.begin() + size, data2.begin(), pred);
+    TEST_ASSERT_DEVICE(result == expected);
+  }
+};
 
 template <typename T, typename ExecutionPolicy>
 void TestEqualDevice(ExecutionPolicy exec, const size_t n)
 {
-  thrust::device_vector<T> d_data1 = unittest::random_samples<T>(n);
-  thrust::device_vector<T> d_data2 = unittest::random_samples<T>(n);
-  thrust::device_vector<bool> d_result(1, false);
+  const auto device = test_runtime::current_test_device();
+  cuda::stream stream{device};
 
-  // empty ranges
-  equal_kernel<<<1, 1>>>(exec, d_data1.begin(), d_data1.begin(), d_data1.begin(), d_result.begin());
-  {
-    cudaError_t const err = cudaDeviceSynchronize();
-    ASSERT_EQUAL(cudaSuccess, err);
-  }
-
-  ASSERT_EQUAL(d_result[0], true);
-
-  // symmetric cases
-  equal_kernel<<<1, 1>>>(exec, d_data1.begin(), d_data1.end(), d_data1.begin(), d_result.begin());
-  {
-    cudaError_t const err = cudaDeviceSynchronize();
-    ASSERT_EQUAL(cudaSuccess, err);
-  }
-
-  ASSERT_EQUAL(d_result[0], true);
+  auto h_data1 = test_runtime::random_samples_buffer<T>(stream, n);
+  auto h_data2 = test_runtime::random_samples_buffer<T>(stream, n, n);
 
   if (n > 0)
   {
-    d_data1[0] = 0;
-    d_data2[0] = 1;
+    h_data1[0] = T{0};
+    h_data2[0] = T{1};
+  }
 
+  auto d_data1 = cuda::make_device_buffer<T>(stream, device, h_data1);
+  auto d_data2 = cuda::make_device_buffer<T>(stream, device, h_data2);
+
+  // empty ranges
+  cuda::launch(stream, test_runtime::single_thread_config(), equal_kernel{}, exec, d_data1, d_data1, 0, true);
+  stream.sync();
+
+  // symmetric cases
+  cuda::launch(stream, test_runtime::single_thread_config(), equal_kernel{}, exec, d_data1, d_data1, n, true);
+  stream.sync();
+
+  if (n > 0)
+  {
     // different vectors
-    equal_kernel<<<1, 1>>>(exec, d_data1.begin(), d_data1.end(), d_data2.begin(), d_result.begin());
-    {
-      cudaError_t const err = cudaDeviceSynchronize();
-      ASSERT_EQUAL(cudaSuccess, err);
-    }
-
-    ASSERT_EQUAL(d_result[0], false);
+    cuda::launch(stream, test_runtime::single_thread_config(), equal_kernel{}, exec, d_data1, d_data2, n, false);
+    stream.sync();
 
     // different predicates
-    equal_kernel<<<1, 1>>>(
-      exec, d_data1.begin(), d_data1.begin() + 1, d_data2.begin(), ::cuda::std::less<T>(), d_result.begin());
-    {
-      cudaError_t const err = cudaDeviceSynchronize();
-      ASSERT_EQUAL(cudaSuccess, err);
-    }
+    cuda::launch(
+      stream,
+      test_runtime::single_thread_config(),
+      equal_pred_kernel{},
+      exec,
+      d_data1,
+      d_data2,
+      1,
+      ::cuda::std::less<T>{},
+      true);
+    stream.sync();
 
-    ASSERT_EQUAL(d_result[0], true);
-
-    equal_kernel<<<1, 1>>>(
-      exec, d_data1.begin(), d_data1.begin() + 1, d_data2.begin(), ::cuda::std::greater<T>(), d_result.begin());
-    {
-      cudaError_t const err = cudaDeviceSynchronize();
-      ASSERT_EQUAL(cudaSuccess, err);
-    }
-
-    ASSERT_EQUAL(d_result[0], false);
+    cuda::launch(
+      stream,
+      test_runtime::single_thread_config(),
+      equal_pred_kernel{},
+      exec,
+      d_data1,
+      d_data2,
+      1,
+      ::cuda::std::greater<T>{},
+      false);
+    stream.sync();
   }
 }
 
@@ -95,26 +109,25 @@ DECLARE_VARIABLE_UNITTEST(TestEqualDeviceDevice);
 
 void TestEqualCudaStreams()
 {
-  thrust::device_vector<int> v1 = {5, 2, 0, 0, 0};
-  thrust::device_vector<int> v2 = {5, 2, 0, 6, 1};
+  const auto device = test_runtime::current_test_device();
+  cuda::stream stream{device};
 
-  cudaStream_t s;
-  cudaStreamCreate(&s);
+  auto v1     = cuda::make_device_buffer<int>(stream, device, {5, 2, 0, 0, 0});
+  auto v2     = cuda::make_device_buffer<int>(stream, device, {5, 2, 0, 6, 1});
+  auto policy = thrust::cuda::par.on(stream.get());
 
-  ASSERT_EQUAL(thrust::equal(thrust::cuda::par.on(s), v1.begin(), v1.end(), v1.begin()), true);
-  ASSERT_EQUAL(thrust::equal(thrust::cuda::par.on(s), v1.begin(), v1.end(), v2.begin()), false);
-  ASSERT_EQUAL(thrust::equal(thrust::cuda::par.on(s), v2.begin(), v2.end(), v2.begin()), true);
+  ASSERT_EQUAL(thrust::equal(policy, v1.begin(), v1.end(), v1.begin()), true);
+  ASSERT_EQUAL(thrust::equal(policy, v1.begin(), v1.end(), v2.begin()), false);
+  ASSERT_EQUAL(thrust::equal(policy, v2.begin(), v2.end(), v2.begin()), true);
 
-  ASSERT_EQUAL(thrust::equal(thrust::cuda::par.on(s), v1.begin(), v1.begin() + 0, v1.begin()), true);
-  ASSERT_EQUAL(thrust::equal(thrust::cuda::par.on(s), v1.begin(), v1.begin() + 1, v1.begin()), true);
-  ASSERT_EQUAL(thrust::equal(thrust::cuda::par.on(s), v1.begin(), v1.begin() + 3, v2.begin()), true);
-  ASSERT_EQUAL(thrust::equal(thrust::cuda::par.on(s), v1.begin(), v1.begin() + 4, v2.begin()), false);
+  ASSERT_EQUAL(thrust::equal(policy, v1.begin(), v1.begin() + 0, v1.begin()), true);
+  ASSERT_EQUAL(thrust::equal(policy, v1.begin(), v1.begin() + 1, v1.begin()), true);
+  ASSERT_EQUAL(thrust::equal(policy, v1.begin(), v1.begin() + 3, v2.begin()), true);
+  ASSERT_EQUAL(thrust::equal(policy, v1.begin(), v1.begin() + 4, v2.begin()), false);
 
-  ASSERT_EQUAL(thrust::equal(thrust::cuda::par.on(s), v1.begin(), v1.end(), v2.begin(), ::cuda::std::less_equal<int>()),
-               true);
-  ASSERT_EQUAL(thrust::equal(thrust::cuda::par.on(s), v1.begin(), v1.end(), v2.begin(), ::cuda::std::greater<int>()),
-               false);
+  ASSERT_EQUAL(thrust::equal(policy, v1.begin(), v1.end(), v2.begin(), ::cuda::std::less_equal<int>{}), true);
+  ASSERT_EQUAL(thrust::equal(policy, v1.begin(), v1.end(), v2.begin(), ::cuda::std::greater<int>{}), false);
 
-  cudaStreamDestroy(s);
+  stream.sync();
 }
 DECLARE_UNITTEST(TestEqualCudaStreams);

--- a/thrust/testing/cuda/generate.cu
+++ b/thrust/testing/cuda/generate.cu
@@ -1,6 +1,11 @@
 #include <thrust/execution_policy.h>
 #include <thrust/generate.h>
 
+#include <cuda/buffer>
+#include <cuda/cccl_runtime_test_helper.cuh>
+#include <cuda/launch>
+#include <cuda/stream>
+
 #include <unittest/unittest.h>
 
 template <typename T>
@@ -13,37 +18,37 @@ struct return_value
       : val(v)
   {}
 
-  _CCCL_HOST_DEVICE T operator()()
+  _CCCL_HOST_DEVICE T operator()() const
   {
     return val;
   }
 };
 
 #ifdef THRUST_TEST_DEVICE_SIDE
-template <typename ExecutionPolicy, typename Iterator, typename Function>
-__global__ void generate_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Function f)
+struct generate_kernel
 {
-  thrust::generate(exec, first, last, f);
-}
+  template <typename ExecutionPolicy, typename Result, typename Function>
+  __device__ void operator()(ExecutionPolicy exec, Result result, Function f) const
+  {
+    thrust::generate(exec, result.begin(), result.end(), f);
+  }
+};
 
 template <typename T, typename ExecutionPolicy>
 void TestGenerateDevice(ExecutionPolicy exec, const size_t n)
 {
-  thrust::host_vector<T> h_result(n);
-  thrust::device_vector<T> d_result(n);
+  const auto device = test_runtime::current_test_device();
+  cuda::stream stream{device};
 
-  T value = 13;
-  return_value<T> f(value);
+  auto result = cuda::make_device_buffer<T>(stream, device, n, cuda::no_init);
 
-  thrust::generate(h_result.begin(), h_result.end(), f);
+  const T value{13};
+  const auto f = return_value<T>{value};
 
-  generate_kernel<<<1, 1>>>(exec, d_result.begin(), d_result.end(), f);
-  {
-    cudaError_t const err = cudaDeviceSynchronize();
-    ASSERT_EQUAL(cudaSuccess, err);
-  }
+  cuda::launch(stream, test_runtime::single_thread_config(), generate_kernel{}, exec, result, f);
+  stream.sync();
 
-  ASSERT_EQUAL(h_result, d_result);
+  test_runtime::assert_filled(stream, result, value);
 }
 
 template <typename T>
@@ -63,53 +68,46 @@ DECLARE_VARIABLE_UNITTEST(TestGenerateDeviceDevice);
 
 void TestGenerateCudaStreams()
 {
-  thrust::device_vector<int> result(5);
+  const auto device = test_runtime::current_test_device();
+  cuda::stream stream{device};
 
-  int value = 13;
+  auto result = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
 
-  return_value<int> f(value);
+  const int value = 13;
+  const auto f    = return_value<int>{value};
 
-  cudaStream_t s;
-  cudaStreamCreate(&s);
+  thrust::generate(thrust::cuda::par.on(stream.get()), result.begin(), result.end(), f);
+  stream.sync();
 
-  thrust::generate(thrust::cuda::par.on(s), result.begin(), result.end(), f);
-  cudaStreamSynchronize(s);
-
-  ASSERT_EQUAL(result[0], value);
-  ASSERT_EQUAL(result[1], value);
-  ASSERT_EQUAL(result[2], value);
-  ASSERT_EQUAL(result[3], value);
-  ASSERT_EQUAL(result[4], value);
-
-  cudaStreamDestroy(s);
+  test_runtime::assert_equal(stream, result, {13, 13, 13, 13, 13});
 }
 DECLARE_UNITTEST(TestGenerateCudaStreams);
 
 #ifdef THRUST_TEST_DEVICE_SIDE
-template <typename ExecutionPolicy, typename Iterator, typename Size, typename Function>
-__global__ void generate_n_kernel(ExecutionPolicy exec, Iterator first, Size n, Function f)
+struct generate_n_kernel
 {
-  thrust::generate_n(exec, first, n, f);
-}
+  template <typename ExecutionPolicy, typename Result, typename Function>
+  __device__ void operator()(ExecutionPolicy exec, Result result, Function f) const
+  {
+    thrust::generate_n(exec, result.begin(), result.size(), f);
+  }
+};
 
 template <typename T, typename ExecutionPolicy>
 void TestGenerateNDevice(ExecutionPolicy exec, const size_t n)
 {
-  thrust::host_vector<T> h_result(n);
-  thrust::device_vector<T> d_result(n);
+  const auto device = test_runtime::current_test_device();
+  cuda::stream stream{device};
 
-  T value = 13;
-  return_value<T> f(value);
+  auto result = cuda::make_device_buffer<T>(stream, device, n, cuda::no_init);
 
-  thrust::generate_n(h_result.begin(), h_result.size(), f);
+  const T value{13};
+  const auto f = return_value<T>{value};
 
-  generate_n_kernel<<<1, 1>>>(exec, d_result.begin(), d_result.size(), f);
-  {
-    cudaError_t const err = cudaDeviceSynchronize();
-    ASSERT_EQUAL(cudaSuccess, err);
-  }
+  cuda::launch(stream, test_runtime::single_thread_config(), generate_n_kernel{}, exec, result, f);
+  stream.sync();
 
-  ASSERT_EQUAL(h_result, d_result);
+  test_runtime::assert_filled(stream, result, value);
 }
 
 template <typename T>
@@ -129,24 +127,17 @@ DECLARE_VARIABLE_UNITTEST(TestGenerateNDeviceDevice);
 
 void TestGenerateNCudaStreams()
 {
-  thrust::device_vector<int> result(5);
+  const auto device = test_runtime::current_test_device();
+  cuda::stream stream{device};
 
-  int value = 13;
+  auto result = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
 
-  return_value<int> f(value);
+  const int value = 13;
+  const auto f    = return_value<int>{value};
 
-  cudaStream_t s;
-  cudaStreamCreate(&s);
+  thrust::generate_n(thrust::cuda::par.on(stream.get()), result.begin(), result.size(), f);
+  stream.sync();
 
-  thrust::generate_n(thrust::cuda::par.on(s), result.begin(), result.size(), f);
-  cudaStreamSynchronize(s);
-
-  ASSERT_EQUAL(result[0], value);
-  ASSERT_EQUAL(result[1], value);
-  ASSERT_EQUAL(result[2], value);
-  ASSERT_EQUAL(result[3], value);
-  ASSERT_EQUAL(result[4], value);
-
-  cudaStreamDestroy(s);
+  test_runtime::assert_equal(stream, result, {13, 13, 13, 13, 13});
 }
 DECLARE_UNITTEST(TestGenerateNCudaStreams);

--- a/thrust/testing/cuda/tabulate.cu
+++ b/thrust/testing/cuda/tabulate.cu
@@ -2,50 +2,52 @@
 #include <thrust/functional.h>
 #include <thrust/tabulate.h>
 
+#include <cuda/buffer>
+#include <cuda/cccl_runtime_test_helper.cuh>
+#include <cuda/launch>
+#include <cuda/std/functional>
+#include <cuda/stream>
+
 #include <unittest/unittest.h>
 
 #ifdef THRUST_TEST_DEVICE_SIDE
-template <typename ExecutionPolicy, typename Iterator, typename Function>
-__global__ void tabulate_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Function f)
+struct tabulate_kernel
 {
-  thrust::tabulate(exec, first, last, f);
-}
+  template <typename ExecutionPolicy, typename Result, typename Function>
+  __device__ void operator()(ExecutionPolicy exec, Result result, Function f) const
+  {
+    thrust::tabulate(exec, result.begin(), result.end(), f);
+  }
+};
 
 template <typename ExecutionPolicy>
 void TestTabulateDevice(ExecutionPolicy exec)
 {
-  using Vector = thrust::device_vector<int>;
-  using namespace thrust::placeholders;
-  using T = typename Vector::value_type;
+  const auto device = test_runtime::current_test_device();
+  cuda::stream stream{device};
 
-  Vector v(5);
+  auto v = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
 
-  tabulate_kernel<<<1, 1>>>(exec, v.begin(), v.end(), ::cuda::std::identity{});
-  {
-    cudaError_t const err = cudaDeviceSynchronize();
-    ASSERT_EQUAL(cudaSuccess, err);
-  }
+  cuda::launch(stream, test_runtime::single_thread_config(), tabulate_kernel{}, exec, v, ::cuda::std::identity{});
+  stream.sync();
 
-  Vector ref{0, 1, 2, 3, 4};
-  ASSERT_EQUAL(v, ref);
+  test_runtime::assert_equal(stream, v, {0, 1, 2, 3, 4});
 
-  tabulate_kernel<<<1, 1>>>(exec, v.begin(), v.end(), -_1);
-  {
-    cudaError_t const err = cudaDeviceSynchronize();
-    ASSERT_EQUAL(cudaSuccess, err);
-  }
+  cuda::launch(stream, test_runtime::single_thread_config(), tabulate_kernel{}, exec, v, -thrust::placeholders::_1);
+  stream.sync();
 
-  ref = {0, -1, -2, -3, -4};
-  ASSERT_EQUAL(v, ref);
+  test_runtime::assert_equal(stream, v, {0, -1, -2, -3, -4});
 
-  tabulate_kernel<<<1, 1>>>(exec, v.begin(), v.end(), _1 * _1 * _1);
-  {
-    cudaError_t const err = cudaDeviceSynchronize();
-    ASSERT_EQUAL(cudaSuccess, err);
-  }
+  cuda::launch(
+    stream,
+    test_runtime::single_thread_config(),
+    tabulate_kernel{},
+    exec,
+    v,
+    thrust::placeholders::_1 * thrust::placeholders::_1 * thrust::placeholders::_1);
+  stream.sync();
 
-  ref = {0, 1, 8, 27, 64};
-  ASSERT_EQUAL(v, ref);
+  test_runtime::assert_equal(stream, v, {0, 1, 8, 27, 64});
 }
 
 void TestTabulateDeviceSeq()
@@ -63,33 +65,27 @@ DECLARE_UNITTEST(TestTabulateDeviceDevice);
 
 void TestTabulateCudaStreams()
 {
-  using namespace thrust::placeholders;
-  using Vector = thrust::device_vector<int>;
-  using T      = Vector::value_type;
+  const auto device = test_runtime::current_test_device();
+  cuda::stream stream{device};
 
-  Vector v(5);
+  auto v = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
 
-  cudaStream_t s;
-  cudaStreamCreate(&s);
+  thrust::tabulate(thrust::cuda::par.on(stream.get()), v.begin(), v.end(), ::cuda::std::identity{});
+  stream.sync();
 
-  thrust::tabulate(thrust::cuda::par.on(s), v.begin(), v.end(), ::cuda::std::identity{});
-  cudaStreamSynchronize(s);
+  test_runtime::assert_equal(stream, v, {0, 1, 2, 3, 4});
 
-  Vector ref{0, 1, 2, 3, 4};
-  ASSERT_EQUAL(v, ref);
+  thrust::tabulate(thrust::cuda::par.on(stream.get()), v.begin(), v.end(), -thrust::placeholders::_1);
+  stream.sync();
 
-  thrust::tabulate(thrust::cuda::par.on(s), v.begin(), v.end(), -_1);
-  cudaStreamSynchronize(s);
+  test_runtime::assert_equal(stream, v, {0, -1, -2, -3, -4});
 
-  ref = {0, -1, -2, -3, -4};
-  ASSERT_EQUAL(v, ref);
+  thrust::tabulate(thrust::cuda::par.on(stream.get()),
+                   v.begin(),
+                   v.end(),
+                   thrust::placeholders::_1 * thrust::placeholders::_1 * thrust::placeholders::_1);
+  stream.sync();
 
-  thrust::tabulate(thrust::cuda::par.on(s), v.begin(), v.end(), _1 * _1 * _1);
-  cudaStreamSynchronize(s);
-
-  ref = {0, 1, 8, 27, 64};
-  ASSERT_EQUAL(v, ref);
-
-  cudaStreamSynchronize(s);
+  test_runtime::assert_equal(stream, v, {0, 1, 8, 27, 64});
 }
 DECLARE_UNITTEST(TestTabulateCudaStreams);


### PR DESCRIPTION
Another change to use cccl-runtime in Thrust testing #2800 