### PR TITLE
Reduce P0 DeviceTransform benchmarks to babelstream and fill

### DIFF
--- a/benchmarks/scripts/cccl/bench/search.py
+++ b/benchmarks/scripts/cccl/bench/search.py
@@ -131,7 +131,8 @@ def filter_benchmarks(benchmarks, args):
     algnames = filter_benchmarks_by_regex(benchmarks.keys(), args.R)
     if args.P0:
         algnames = filter_benchmarks_by_regex(
-            algnames, r"^(?!.*segmented).*(scan|reduce|select|sort|transform).*"
+            algnames,
+            r"^(?!.*segmented).*(scan|reduce|select|sort|transform\.(babelstream|fill)).*",
         )
         algnames = filter_benchmarks_by_regex(algnames, r"^(?!.*P[123456789]\d*).*")
     algnames.sort()


### PR DESCRIPTION
Follow-up to #9774

Current P0 list (removed P1 manually):
```
$ ../benchmarks/scripts/search.py -R '^(?!.*segmented).*(scan|reduce|select|sort|transform\.(babelstream|fill)).*' -l
 ctk:  13.3.33
cccl:  v3.5.0.dev-438-g01871df097
### Benchmarks
  * `cub.bench.find_bound.lower_bound_sorted_values`: 1 variants: 
  * `cub.bench.find_bound.upper_bound_sorted_values`: 1 variants: 
  * `cub.bench.merge_sort.keys`: 1 variants: 
  * `cub.bench.merge_sort.pairs`: 1 variants: 
  * `cub.bench.radix_sort.keys`: 1 variants: 
  * `cub.bench.radix_sort.pairs`: 1 variants: 
  * `cub.bench.reduce.arg_extrema`: 1 variants: 
  * `cub.bench.reduce.by_key`: 1 variants: 
  * `cub.bench.reduce.custom`: 1 variants: 
  * `cub.bench.reduce.deferred_nondeterministic`: 1 variants: 
  * `cub.bench.reduce.deferred_sum`: 1 variants: 
  * `cub.bench.reduce.deterministic`: 1 variants: 
  * `cub.bench.reduce.min`: 1 variants: 
  * `cub.bench.reduce.nondeterministic`: 1 variants: 
  * `cub.bench.reduce.sum`: 1 variants: 
  * `cub.bench.reduce.warp_reduce_min`: 1 variants: 
  * `cub.bench.reduce.warp_reduce_sum`: 1 variants: 
  * `cub.bench.scan.exclusive.by_key`: 1 variants: 
  * `cub.bench.scan.exclusive.custom`: 1 variants: 
  * `cub.bench.scan.exclusive.deterministic`: 1 variants: 
  * `cub.bench.scan.exclusive.sum`: 1 variants: 
  * `cub.bench.scan.exclusive.sum.lookahead`: 1 variants: 
  * `cub.bench.select.flagged`: 1 variants: 
  * `cub.bench.select.if`: 1 variants: 
  * `cub.bench.select.unique`: 1 variants: 
  * `cub.bench.select.unique_by_key`: 1 variants: 
  * `cub.bench.transform.babelstream`: 1 variants: 
  * `cub.bench.transform.fill`: 1 variants: 
  * `cub.bench.transform_reduce.sum`: 1 variants: 
```