### PR TITLE
[STF] Exempt STF test CMake files from CMake owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,6 +23,9 @@ nvbench_helper/ @nvidia/cccl-infra-codeowners
 **/cmake/ @nvidia/cccl-cmake-codeowners
 # make an exception for the cudax test cmake file
 cudax/test/CMakeLists.txt @nvidia/cccl-cudax-codeowners
+# make an exception for STF test cmake files
+cudax/test/stf/CMakeLists.txt @nvidia/cccl-cudax-codeowners
+cudax/test/stf/static_error_checks/CMakeLists.txt @nvidia/cccl-cudax-codeowners
 
 # benchmarks
 benchmarks/ @nvidia/cccl-benchmark-codeowners


### PR DESCRIPTION
## Summary
- Route STF test CMake ownership to `@nvidia/cccl-cudax-codeowners` instead of the generic CMake owners.
- Follow the precedent from cudax/test/CMakeLists.txt, which made test-list updates not require CMake-owner review.

## Test plan
- Not run; CODEOWNERS-only change.