### PR TITLE
Use __builtin_bswapg in cuda::std::byteswap when available

### DIFF
--- a/libcudacxx/include/cuda/std/__bit/byteswap.h
+++ b/libcudacxx/include/cuda/std/__bit/byteswap.h
@@ -50,12 +50,17 @@
 #  define _CCCL_BUILTIN_BSWAP128(...) __builtin_bswap128(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_bswap128)
 
+#if _CCCL_CHECK_BUILTIN(builtin_bswapg)
+#  define _CCCL_BUILTIN_BSWAPG(...) __builtin_bswapg(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_bswapg)
+
 // nvcc doesn't support these builtins in device code
 #if _CCCL_CUDA_COMPILER(NVCC) && _CCCL_DEVICE_COMPILATION()
 #  undef _CCCL_BUILTIN_BSWAP16
 #  undef _CCCL_BUILTIN_BSWAP32
 #  undef _CCCL_BUILTIN_BSWAP64
 #  undef _CCCL_BUILTIN_BSWAP128
+#  undef _CCCL_BUILTIN_BSWAPG
 #endif // _CCCL_CUDA_COMPILER(NVCC) && _CCCL_DEVICE_COMPILATION()
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
@@ -202,7 +207,11 @@ _CCCL_REQUIRES(is_integral_v<_Integer>)
 {
   if constexpr (sizeof(_Integer) > 1)
   {
+#if defined(_CCCL_BUILTIN_BSWAPG)
+    return static_cast<_Integer>(_CCCL_BUILTIN_BSWAPG(__val));
+#else // ^^^ _CCCL_BUILTIN_BSWAPG ^^^ / vvv !_CCCL_BUILTIN_BSWAPG vvv
     return static_cast<_Integer>(::cuda::std::__byteswap_impl(::cuda::std::__to_unsigned_like(__val)));
+#endif // !_CCCL_BUILTIN_BSWAPG
   }
   else
   {


### PR DESCRIPTION
Fixes #7778.