### PR TITLE
[libcu++] Add new memory pool attributes from CUDA 13.3

### DIFF
--- a/docs/libcudacxx/runtime/memory_pools.rst
+++ b/docs/libcudacxx/runtime/memory_pools.rst
@@ -299,6 +299,15 @@ querying and configuration:
 - ``reserved_mem_high`` - Get/set high watermark for reserved memory
 - ``used_mem_high`` - Get/set high watermark for used memory
 
+The following additional read-only creation attributes are available with CUDA 13.3:
+
+- ``allocation_type`` - Query the allocation type of the pool
+- ``export_handle_types`` - Query the export handle types available for the pool
+- ``location_id`` - Query the location id of the pool
+- ``location_type`` - Query the location type of the pool
+- ``max_pool_size`` - Query the maximum size of the pool
+- ``hw_decompress_enabled`` - Query whether hardware decompression is enabled for the pool
+
 Availability: CCCL 3.2.0 / CUDA 13.2
 
 Example:

--- a/docs/libcudacxx/runtime/memory_pools.rst
+++ b/docs/libcudacxx/runtime/memory_pools.rst
@@ -303,8 +303,9 @@ The following additional read-only creation attributes are available with CUDA 1
 
 - ``allocation_type`` - Query the allocation type of the pool
 - ``export_handle_types`` - Query the export handle types available for the pool
-- ``location_id`` - Query the location id of the pool
-- ``location_type`` - Query the location type of the pool
+- ``location`` - Query the location of the pool as a ``cuda::memory_location``
+- ``location_id`` - Query only the location id of the pool
+- ``location_type`` - Query only the location type of the pool
 - ``max_pool_size`` - Query the maximum size of the pool
 - ``hw_decompress_enabled`` - Query whether hardware decompression is enabled for the pool
 

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -443,10 +443,11 @@ _CCCL_HOST_API inline void __mempoolSetAttribute(::CUmemoryPool __pool, ::CUmemP
   ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to set attribute for a memory pool", __pool, __attr, __value);
 }
 
-_CCCL_HOST_API inline ::cuda::std::size_t __mempoolGetAttribute(::CUmemoryPool __pool, ::CUmemPool_attribute __attr)
+template <class _Tp>
+_CCCL_HOST_API inline _Tp __mempoolGetAttribute(::CUmemoryPool __pool, ::CUmemPool_attribute __attr)
 {
-  ::cuda::std::size_t __value = 0;
-  static auto __driver_fn     = _CCCLRT_GET_DRIVER_FUNCTION(cuMemPoolGetAttribute);
+  _Tp __value{};
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemPoolGetAttribute);
   ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get attribute for a memory pool", __pool, __attr, &__value);
   return __value;
 }

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -443,12 +443,17 @@ _CCCL_HOST_API inline void __mempoolSetAttribute(::CUmemoryPool __pool, ::CUmemP
   ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to set attribute for a memory pool", __pool, __attr, __value);
 }
 
+_CCCL_HOST_API inline void __mempoolGetAttributeImpl(::CUmemoryPool __pool, ::CUmemPool_attribute __attr, void* __value)
+{
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemPoolGetAttribute);
+  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get attribute for a memory pool", __pool, __attr, __value);
+}
+
 template <class _Tp>
 _CCCL_HOST_API inline _Tp __mempoolGetAttribute(::CUmemoryPool __pool, ::CUmemPool_attribute __attr)
 {
   _Tp __value{};
-  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemPoolGetAttribute);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get attribute for a memory pool", __pool, __attr, &__value);
+  ::cuda::__driver::__mempoolGetAttributeImpl(__pool, __attr, &__value);
   return __value;
 }
 

--- a/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
+++ b/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
@@ -28,6 +28,7 @@
 #  include <cuda/__memory_resource/any_resource.h>
 #  include <cuda/__memory_resource/properties.h>
 #  include <cuda/__runtime/api_wrapper.h>
+#  include <cuda/__runtime/types.h>
 #  include <cuda/__stream/internal_streams.h>
 #  include <cuda/__stream/stream.h>
 #  include <cuda/__stream/stream_ref.h>
@@ -53,7 +54,7 @@ enum class __pool_attr_settable : bool
 {
 };
 
-template <::cudaMemPoolAttr _Attr, typename _Type, __pool_attr_settable _Settable>
+template <::cudaMemPoolAttr _Attr, typename _Type, __pool_attr_settable _Settable, typename _StorageType>
 struct __pool_attr_impl
 {
   using type = _Type;
@@ -65,15 +66,16 @@ struct __pool_attr_impl
 
   [[nodiscard]] _CCCL_HOST_API type operator()(::cudaMemPool_t __pool) const
   {
-    size_t __value = ::cuda::__driver::__mempoolGetAttribute(__pool, static_cast<::CUmemPool_attribute>(_Attr));
+    const auto __value =
+      ::cuda::__driver::__mempoolGetAttribute<_StorageType>(__pool, static_cast<::CUmemPool_attribute>(_Attr));
     return static_cast<type>(__value);
   }
 
   _CCCL_HOST_API static void set(::cudaMemPool_t __pool, type __value)
   {
-    size_t __value_copy = __value;
     if constexpr (_Settable == __pool_attr_settable{true})
     {
+      _StorageType __value_copy = static_cast<_StorageType>(__value);
       ::cuda::__driver::__mempoolSetAttribute(__pool, static_cast<::CUmemPool_attribute>(_Attr), &__value_copy);
     }
     else
@@ -84,36 +86,77 @@ struct __pool_attr_impl
 };
 
 template <::cudaMemPoolAttr _Attr>
-struct __pool_attr : __pool_attr_impl<_Attr, size_t, __pool_attr_settable{true}>
+struct __pool_attr : __pool_attr_impl<_Attr, size_t, __pool_attr_settable{true}, ::cuuint64_t>
 {};
 
 template <>
 struct __pool_attr<::cudaMemPoolReuseFollowEventDependencies>
-    : __pool_attr_impl<::cudaMemPoolReuseFollowEventDependencies, bool, __pool_attr_settable{true}>
+    : __pool_attr_impl<::cudaMemPoolReuseFollowEventDependencies, bool, __pool_attr_settable{true}, int>
 {};
 
 template <>
 struct __pool_attr<::cudaMemPoolReuseAllowOpportunistic>
-    : __pool_attr_impl<::cudaMemPoolReuseAllowOpportunistic, bool, __pool_attr_settable{true}>
+    : __pool_attr_impl<::cudaMemPoolReuseAllowOpportunistic, bool, __pool_attr_settable{true}, int>
 {};
 
 template <>
 struct __pool_attr<::cudaMemPoolReuseAllowInternalDependencies>
-    : __pool_attr_impl<::cudaMemPoolReuseAllowInternalDependencies, bool, __pool_attr_settable{true}>
+    : __pool_attr_impl<::cudaMemPoolReuseAllowInternalDependencies, bool, __pool_attr_settable{true}, int>
 {};
 
 template <>
 struct __pool_attr<::cudaMemPoolAttrReservedMemCurrent>
-    : __pool_attr_impl<::cudaMemPoolAttrReservedMemCurrent, size_t, __pool_attr_settable{false}>
+    : __pool_attr_impl<::cudaMemPoolAttrReservedMemCurrent, size_t, __pool_attr_settable{false}, ::cuuint64_t>
 {};
 
 template <>
 struct __pool_attr<::cudaMemPoolAttrUsedMemCurrent>
-    : __pool_attr_impl<::cudaMemPoolAttrUsedMemCurrent, size_t, __pool_attr_settable{false}>
+    : __pool_attr_impl<::cudaMemPoolAttrUsedMemCurrent, size_t, __pool_attr_settable{false}, ::cuuint64_t>
 {};
 
+#  if _CCCL_CTK_AT_LEAST(13, 3)
+template <>
+struct __pool_attr<::cudaMemPoolAttrAllocationType>
+    : __pool_attr_impl<::cudaMemPoolAttrAllocationType,
+                       ::cudaMemAllocationType,
+                       __pool_attr_settable{false},
+                       ::CUmemAllocationType>
+{};
+
+template <>
+struct __pool_attr<::cudaMemPoolAttrExportHandleTypes>
+    : __pool_attr_impl<::cudaMemPoolAttrExportHandleTypes,
+                       ::cudaMemAllocationHandleType,
+                       __pool_attr_settable{false},
+                       ::CUmemAllocationHandleType>
+{};
+
+template <>
+struct __pool_attr<::cudaMemPoolAttrLocationId>
+    : __pool_attr_impl<::cudaMemPoolAttrLocationId, int, __pool_attr_settable{false}, int>
+{};
+
+template <>
+struct __pool_attr<::cudaMemPoolAttrLocationType>
+    : __pool_attr_impl<::cudaMemPoolAttrLocationType,
+                       ::cudaMemLocationType,
+                       __pool_attr_settable{false},
+                       ::CUmemLocationType>
+{};
+
+template <>
+struct __pool_attr<::cudaMemPoolAttrMaxPoolSize>
+    : __pool_attr_impl<::cudaMemPoolAttrMaxPoolSize, ::cuuint64_t, __pool_attr_settable{false}, ::cuuint64_t>
+{};
+
+template <>
+struct __pool_attr<::cudaMemPoolAttrHwDecompressEnabled>
+    : __pool_attr_impl<::cudaMemPoolAttrHwDecompressEnabled, bool, __pool_attr_settable{false}, int>
+{};
+#  endif // _CCCL_CTK_AT_LEAST(13, 3)
+
 _CCCL_HOST_API inline void
-__set_attribute_non_zero_only(::cudaMemPool_t __pool, ::CUmemPool_attribute __attr, size_t __value)
+__set_attribute_non_zero_only(::cudaMemPool_t __pool, ::CUmemPool_attribute __attr, ::cuuint64_t __value)
 {
   if (__value != 0)
   {
@@ -124,7 +167,7 @@ __set_attribute_non_zero_only(::cudaMemPool_t __pool, ::CUmemPool_attribute __at
 
 template <>
 struct __pool_attr<::cudaMemPoolAttrReservedMemHigh>
-    : __pool_attr_impl<::cudaMemPoolAttrReservedMemHigh, size_t, __pool_attr_settable{true}>
+    : __pool_attr_impl<::cudaMemPoolAttrReservedMemHigh, size_t, __pool_attr_settable{true}, ::cuuint64_t>
 {
   _CCCL_HOST_API static void set(::cudaMemPool_t __pool, type __value)
   {
@@ -134,7 +177,7 @@ struct __pool_attr<::cudaMemPoolAttrReservedMemHigh>
 
 template <>
 struct __pool_attr<::cudaMemPoolAttrUsedMemHigh>
-    : __pool_attr_impl<::cudaMemPoolAttrUsedMemHigh, size_t, __pool_attr_settable{true}>
+    : __pool_attr_impl<::cudaMemPoolAttrUsedMemHigh, size_t, __pool_attr_settable{true}, ::cuuint64_t>
 {
   _CCCL_HOST_API static void set(::cudaMemPool_t __pool, type __value)
   {
@@ -178,6 +221,51 @@ inline constexpr used_mem_current_t used_mem_current{};
 // The high water mark for the used memory in the pool.
 using used_mem_high_t = __pool_attr<::cudaMemPoolAttrUsedMemHigh>;
 inline constexpr used_mem_high_t used_mem_high{};
+
+#  if _CCCL_CTK_AT_LEAST(13, 3)
+// The allocation type of the pool.
+using allocation_type_t = __pool_attr<::cudaMemPoolAttrAllocationType>;
+inline constexpr allocation_type_t allocation_type{};
+
+// The export handle types available for the pool.
+using export_handle_types_t = __pool_attr<::cudaMemPoolAttrExportHandleTypes>;
+inline constexpr export_handle_types_t export_handle_types{};
+
+// The location id of the pool.
+using location_id_t = __pool_attr<::cudaMemPoolAttrLocationId>;
+inline constexpr location_id_t location_id{};
+
+// The location type of the pool.
+using location_type_t = __pool_attr<::cudaMemPoolAttrLocationType>;
+inline constexpr location_type_t location_type{};
+
+// The location of the pool.
+struct location_t
+{
+  using type = ::cuda::memory_location;
+
+  [[nodiscard]] _CCCL_HOST_API type operator()(::cudaMemPool_t __pool) const
+  {
+    return type{static_cast<::cudaMemLocationType>(::cuda::__driver::__mempoolGetAttribute<::CUmemLocationType>(
+                  __pool, ::CU_MEMPOOL_ATTR_LOCATION_TYPE)),
+                ::cuda::__driver::__mempoolGetAttribute<int>(__pool, ::CU_MEMPOOL_ATTR_LOCATION_ID)};
+  }
+
+  _CCCL_HOST_API static void set(::cudaMemPool_t, type)
+  {
+    _CCCL_THROW(::std::invalid_argument, "This attribute can't be set");
+  }
+};
+inline constexpr location_t location{};
+
+// The maximum size of the pool.
+using max_pool_size_t = __pool_attr<::cudaMemPoolAttrMaxPoolSize>;
+inline constexpr max_pool_size_t max_pool_size{};
+
+// Whether hardware decompression is enabled for the pool.
+using hw_decompress_enabled_t = __pool_attr<::cudaMemPoolAttrHwDecompressEnabled>;
+inline constexpr hw_decompress_enabled_t hw_decompress_enabled{};
+#  endif // _CCCL_CTK_AT_LEAST(13, 3)
 }; // namespace memory_pool_attributes
 
 [[nodiscard]] _CCCL_HOST_API inline bool __is_host_memory_pool_supported()

--- a/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
+++ b/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
@@ -146,7 +146,7 @@ struct __pool_attr<::cudaMemPoolAttrLocationType>
 
 template <>
 struct __pool_attr<::cudaMemPoolAttrMaxPoolSize>
-    : __pool_attr_impl<::cudaMemPoolAttrMaxPoolSize, ::cuuint64_t, __pool_attr_settable{false}, ::cuuint64_t>
+    : __pool_attr_impl<::cudaMemPoolAttrMaxPoolSize, size_t, __pool_attr_settable{false}, ::cuuint64_t>
 {};
 
 template <>

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/device_memory_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/device_memory_resource.cu
@@ -93,6 +93,12 @@ static inline void check_default_device_pool_attributes(const cuda::device_memor
           == get_raw_attribute<cudaMemLocationType>(pool.get(), ::cudaMemPoolAttrLocationType));
   REQUIRE(pool.attribute(cuda::memory_pool_attributes::location_type) == ::cudaMemLocationTypeDevice);
 
+  const auto location = pool.attribute(cuda::memory_pool_attributes::location);
+  REQUIRE(location.id == get_raw_attribute<int>(pool.get(), ::cudaMemPoolAttrLocationId));
+  REQUIRE(location.id == device);
+  REQUIRE(location.type == get_raw_attribute<cudaMemLocationType>(pool.get(), ::cudaMemPoolAttrLocationType));
+  REQUIRE(location.type == ::cudaMemLocationTypeDevice);
+
   REQUIRE(pool.attribute(cuda::memory_pool_attributes::max_pool_size)
           == get_raw_attribute<::cuuint64_t>(pool.get(), ::cudaMemPoolAttrMaxPoolSize));
   REQUIRE(pool.attribute(cuda::memory_pool_attributes::hw_decompress_enabled)

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/device_memory_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/device_memory_resource.cu
@@ -70,33 +70,33 @@ static bool ensure_export_handle(::cudaMemPool_t pool, const ::cudaMemAllocation
 
 #if _CCCL_CTK_AT_LEAST(13, 3)
 template <typename T>
-static T get_raw_attribute(::cudaMemPool_t pool, ::cudaMemPoolAttr attr)
+[[nodiscard]] static T get_raw_attribute(const ::cudaMemPool_t pool, const ::cudaMemPoolAttr attr)
 {
   T value{};
   _CCCL_TRY_CUDA_API(::cudaMemPoolGetAttribute, "Failed to call cudaMemPoolGetAttribute", pool, attr, &value);
   return value;
 }
 
-static void check_default_device_pool_attributes(cuda::device_memory_pool_ref pool, int device)
+static inline void check_default_device_pool_attributes(const cuda::device_memory_pool_ref pool, const int device)
 {
-  CHECK(pool.attribute(cuda::memory_pool_attributes::allocation_type)
-        == get_raw_attribute<cudaMemAllocationType>(pool.get(), ::cudaMemPoolAttrAllocationType));
-  CHECK(pool.attribute(cuda::memory_pool_attributes::allocation_type) == ::cudaMemAllocationTypePinned);
+  REQUIRE(pool.attribute(cuda::memory_pool_attributes::allocation_type)
+          == get_raw_attribute<cudaMemAllocationType>(pool.get(), ::cudaMemPoolAttrAllocationType));
+  REQUIRE(pool.attribute(cuda::memory_pool_attributes::allocation_type) == ::cudaMemAllocationTypePinned);
 
-  CHECK(pool.attribute(cuda::memory_pool_attributes::export_handle_types)
-        == get_raw_attribute<cudaMemAllocationHandleType>(pool.get(), ::cudaMemPoolAttrExportHandleTypes));
-  CHECK(pool.attribute(cuda::memory_pool_attributes::location_id)
-        == get_raw_attribute<int>(pool.get(), ::cudaMemPoolAttrLocationId));
-  CHECK(pool.attribute(cuda::memory_pool_attributes::location_id) == device);
+  REQUIRE(pool.attribute(cuda::memory_pool_attributes::export_handle_types)
+          == get_raw_attribute<cudaMemAllocationHandleType>(pool.get(), ::cudaMemPoolAttrExportHandleTypes));
+  REQUIRE(pool.attribute(cuda::memory_pool_attributes::location_id)
+          == get_raw_attribute<int>(pool.get(), ::cudaMemPoolAttrLocationId));
+  REQUIRE(pool.attribute(cuda::memory_pool_attributes::location_id) == device);
 
-  CHECK(pool.attribute(cuda::memory_pool_attributes::location_type)
-        == get_raw_attribute<cudaMemLocationType>(pool.get(), ::cudaMemPoolAttrLocationType));
-  CHECK(pool.attribute(cuda::memory_pool_attributes::location_type) == ::cudaMemLocationTypeDevice);
+  REQUIRE(pool.attribute(cuda::memory_pool_attributes::location_type)
+          == get_raw_attribute<cudaMemLocationType>(pool.get(), ::cudaMemPoolAttrLocationType));
+  REQUIRE(pool.attribute(cuda::memory_pool_attributes::location_type) == ::cudaMemLocationTypeDevice);
 
-  CHECK(pool.attribute(cuda::memory_pool_attributes::max_pool_size)
-        == get_raw_attribute<::cuuint64_t>(pool.get(), ::cudaMemPoolAttrMaxPoolSize));
-  CHECK(pool.attribute(cuda::memory_pool_attributes::hw_decompress_enabled)
-        == (get_raw_attribute<int>(pool.get(), ::cudaMemPoolAttrHwDecompressEnabled) != 0));
+  REQUIRE(pool.attribute(cuda::memory_pool_attributes::max_pool_size)
+          == get_raw_attribute<::cuuint64_t>(pool.get(), ::cudaMemPoolAttrMaxPoolSize));
+  REQUIRE(pool.attribute(cuda::memory_pool_attributes::hw_decompress_enabled)
+          == (get_raw_attribute<int>(pool.get(), ::cudaMemPoolAttrHwDecompressEnabled) != 0));
 }
 #endif // _CCCL_CTK_AT_LEAST(13, 3)
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/device_memory_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/device_memory_resource.cu
@@ -68,6 +68,38 @@ static bool ensure_export_handle(::cudaMemPool_t pool, const ::cudaMemAllocation
   return allocation_handle == ::cudaMemHandleTypeNone ? status == ::cudaErrorInvalidValue : status == ::cudaSuccess;
 }
 
+#if _CCCL_CTK_AT_LEAST(13, 3)
+template <typename T>
+static T get_raw_attribute(::cudaMemPool_t pool, ::cudaMemPoolAttr attr)
+{
+  T value{};
+  _CCCL_TRY_CUDA_API(::cudaMemPoolGetAttribute, "Failed to call cudaMemPoolGetAttribute", pool, attr, &value);
+  return value;
+}
+
+static void check_default_device_pool_attributes(cuda::device_memory_pool_ref pool, int device)
+{
+  CHECK(pool.attribute(cuda::memory_pool_attributes::allocation_type)
+        == get_raw_attribute<cudaMemAllocationType>(pool.get(), ::cudaMemPoolAttrAllocationType));
+  CHECK(pool.attribute(cuda::memory_pool_attributes::allocation_type) == ::cudaMemAllocationTypePinned);
+
+  CHECK(pool.attribute(cuda::memory_pool_attributes::export_handle_types)
+        == get_raw_attribute<cudaMemAllocationHandleType>(pool.get(), ::cudaMemPoolAttrExportHandleTypes));
+  CHECK(pool.attribute(cuda::memory_pool_attributes::location_id)
+        == get_raw_attribute<int>(pool.get(), ::cudaMemPoolAttrLocationId));
+  CHECK(pool.attribute(cuda::memory_pool_attributes::location_id) == device);
+
+  CHECK(pool.attribute(cuda::memory_pool_attributes::location_type)
+        == get_raw_attribute<cudaMemLocationType>(pool.get(), ::cudaMemPoolAttrLocationType));
+  CHECK(pool.attribute(cuda::memory_pool_attributes::location_type) == ::cudaMemLocationTypeDevice);
+
+  CHECK(pool.attribute(cuda::memory_pool_attributes::max_pool_size)
+        == get_raw_attribute<::cuuint64_t>(pool.get(), ::cudaMemPoolAttrMaxPoolSize));
+  CHECK(pool.attribute(cuda::memory_pool_attributes::hw_decompress_enabled)
+        == (get_raw_attribute<int>(pool.get(), ::cudaMemPoolAttrHwDecompressEnabled) != 0));
+}
+#endif // _CCCL_CTK_AT_LEAST(13, 3)
+
 C2H_CCCLRT_TEST("device_memory_pool construction", "[memory_resource]")
 {
   test::skip_if_unsupported_memory_pool<cuda::device_memory_pool_ref>();
@@ -113,6 +145,14 @@ C2H_CCCLRT_TEST("device_memory_pool construction", "[memory_resource]")
       ptr,
       ::cudaStream_t{nullptr});
   }
+
+#if _CCCL_CTK_AT_LEAST(13, 3)
+  SECTION("Default pool attributes")
+  {
+    test_resource default_pool = cuda::device_default_memory_pool(cuda::device_ref{current_device});
+    check_default_device_pool_attributes(default_pool, current_device);
+  }
+#endif // _CCCL_CTK_AT_LEAST(13, 3)
 
   SECTION("Construct from mempool handle")
   {

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/memory_pools.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/memory_pools.cu
@@ -60,8 +60,8 @@ static_assert(!cuda::std::is_default_constructible<cuda::device_memory_pool>::va
 
 #if _CCCL_CTK_AT_LEAST(13, 3)
 static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::allocation_type_t::type, cudaMemAllocationType>);
-static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::export_handle_types_t::type,
-                                   cudaMemAllocationHandleType>);
+static_assert(
+  cuda::std::is_same_v<cuda::memory_pool_attributes::export_handle_types_t::type, cudaMemAllocationHandleType>);
 static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::location_id_t::type, int>);
 static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::location_type_t::type, cudaMemLocationType>);
 static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::max_pool_size_t::type, ::cuuint64_t>);

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/memory_pools.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/memory_pools.cu
@@ -58,6 +58,16 @@ static_assert(cuda::std::is_default_constructible<cuda::pinned_memory_pool>::val
 #endif // _CCCL_CTK_AT_LEAST(13, 0)
 static_assert(!cuda::std::is_default_constructible<cuda::device_memory_pool>::value);
 
+#if _CCCL_CTK_AT_LEAST(13, 3)
+static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::allocation_type_t::type, cudaMemAllocationType>);
+static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::export_handle_types_t::type,
+                                   cudaMemAllocationHandleType>);
+static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::location_id_t::type, int>);
+static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::location_type_t::type, cudaMemLocationType>);
+static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::max_pool_size_t::type, ::cuuint64_t>);
+static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::hw_decompress_enabled_t::type, bool>);
+#endif // _CCCL_CTK_AT_LEAST(13, 3)
+
 template <typename PoolType>
 PoolType construct_pool(cuda::memory_pool_properties props = {})
 {
@@ -114,6 +124,70 @@ static bool ensure_export_handle(::cudaMemPool_t pool, const ::cudaMemAllocation
   return allocation_handle == ::cudaMemHandleTypeNone ? status == ::cudaErrorInvalidValue : status == ::cudaSuccess;
 }
 
+#if _CCCL_CTK_AT_LEAST(13, 3)
+template <typename PoolType>
+static void check_creation_attributes(PoolType& pool, cuda::memory_pool_properties props, int current_device)
+{
+  auto expected_allocation_type = ::cudaMemAllocationTypePinned;
+  auto expected_location_type   = ::cudaMemLocationTypeDevice;
+  auto expected_location_id     = current_device;
+
+#  if _CCCL_CTK_AT_LEAST(12, 9)
+  if constexpr (cuda::std::is_same_v<PoolType, cuda::pinned_memory_pool>)
+  {
+    expected_location_type = ::cudaMemLocationTypeHostNuma;
+    expected_location_id   = 0;
+  }
+#  endif // _CCCL_CTK_AT_LEAST(12, 9)
+#  if _CCCL_CTK_AT_LEAST(13, 0)
+  if constexpr (cuda::std::is_same_v<PoolType, cuda::managed_memory_pool>)
+  {
+    expected_allocation_type = ::cudaMemAllocationTypeManaged;
+    expected_location_type   = ::cudaMemLocationTypeNone;
+    expected_location_id     = 0;
+  }
+#  endif // _CCCL_CTK_AT_LEAST(13, 0)
+
+  CHECK(pool.attribute(cuda::memory_pool_attributes::allocation_type) == expected_allocation_type);
+  CHECK(pool.attribute(cuda::memory_pool_attributes::export_handle_types) == props.allocation_handle_type);
+  CHECK(pool.attribute(cuda::memory_pool_attributes::location_id) == expected_location_id);
+  CHECK(pool.attribute(cuda::memory_pool_attributes::location_type) == expected_location_type);
+  CHECK(pool.attribute(cuda::memory_pool_attributes::max_pool_size) >= props.max_pool_size);
+  CHECK(!pool.attribute(cuda::memory_pool_attributes::hw_decompress_enabled));
+}
+
+#  if _CCCL_HAS_EXCEPTIONS()
+template <typename PoolType>
+static void check_creation_attributes_are_read_only(PoolType& pool)
+{
+  CHECK_THROWS_AS(
+    pool.set_attribute(
+      cuda::memory_pool_attributes::allocation_type, pool.attribute(cuda::memory_pool_attributes::allocation_type)),
+    std::invalid_argument);
+  CHECK_THROWS_AS(
+    pool.set_attribute(cuda::memory_pool_attributes::export_handle_types,
+                       pool.attribute(cuda::memory_pool_attributes::export_handle_types)),
+    std::invalid_argument);
+  CHECK_THROWS_AS(
+    pool.set_attribute(cuda::memory_pool_attributes::location_id,
+                       pool.attribute(cuda::memory_pool_attributes::location_id)),
+    std::invalid_argument);
+  CHECK_THROWS_AS(
+    pool.set_attribute(
+      cuda::memory_pool_attributes::location_type, pool.attribute(cuda::memory_pool_attributes::location_type)),
+    std::invalid_argument);
+  CHECK_THROWS_AS(
+    pool.set_attribute(
+      cuda::memory_pool_attributes::max_pool_size, pool.attribute(cuda::memory_pool_attributes::max_pool_size)),
+    std::invalid_argument);
+  CHECK_THROWS_AS(
+    pool.set_attribute(cuda::memory_pool_attributes::hw_decompress_enabled,
+                       pool.attribute(cuda::memory_pool_attributes::hw_decompress_enabled)),
+    std::invalid_argument);
+}
+#  endif // _CCCL_HAS_EXCEPTIONS()
+#endif // _CCCL_CTK_AT_LEAST(13, 3)
+
 C2H_CCCLRT_TEST_LIST("device_memory_pool construction", "[memory_resource]", TEST_TYPES)
 {
   using memory_pool = TestType;
@@ -152,6 +226,11 @@ C2H_CCCLRT_TEST_LIST("device_memory_pool construction", "[memory_resource]", TES
 
     // Ensure that we disable export
     CHECK(ensure_export_handle(get, ::cudaMemHandleTypeNone));
+
+#if _CCCL_CTK_AT_LEAST(13, 3)
+    cuda::memory_pool_properties expected_props{};
+    check_creation_attributes(from_device, expected_props, current_device);
+#endif // _CCCL_CTK_AT_LEAST(13, 3)
   }
 
   SECTION("Construct with empty properties")
@@ -170,6 +249,10 @@ C2H_CCCLRT_TEST_LIST("device_memory_pool construction", "[memory_resource]", TES
 
     // Ensure that we disable export
     CHECK(ensure_export_handle(get, ::cudaMemHandleTypeNone));
+
+#if _CCCL_CTK_AT_LEAST(13, 3)
+    check_creation_attributes(from_defaulted_properties, props, current_device);
+#endif // _CCCL_CTK_AT_LEAST(13, 3)
   }
 
   SECTION("Construct with initial pool size")
@@ -188,6 +271,10 @@ C2H_CCCLRT_TEST_LIST("device_memory_pool construction", "[memory_resource]", TES
 
     // Ensure that we disable export
     CHECK(ensure_export_handle(get, ::cudaMemHandleTypeNone));
+
+#if _CCCL_CTK_AT_LEAST(13, 3)
+    check_creation_attributes(with_threshold, props, current_device);
+#endif // _CCCL_CTK_AT_LEAST(13, 3)
   }
 
   SECTION("Take ownership of native handle")
@@ -276,6 +363,10 @@ C2H_CCCLRT_TEST_LIST("base_memory_pool construction", "[memory_resource]", TEST_
 
       // Ensure that we disable export
       CHECK(ensure_export_handle(get, ::cudaMemHandleTypeNone));
+
+#  if _CCCL_CTK_AT_LEAST(13, 3)
+      check_creation_attributes(with_max_pool_size, props, current_device);
+#  endif // _CCCL_CTK_AT_LEAST(13, 3)
 
       void* ptr{nullptr};
 
@@ -510,6 +601,12 @@ C2H_CCCLRT_TEST_LIST("device_memory_pool accessors", "[memory_resource]", TEST_T
       // cudaMemPoolAttrUsedMemCurrent cannot be set
     }
 
+#if _CCCL_CTK_AT_LEAST(13, 3) && _CCCL_HAS_EXCEPTIONS()
+    { // CUDA 13.3 creation attributes
+      check_creation_attributes_are_read_only(pool);
+    }
+#endif // _CCCL_CTK_AT_LEAST(13, 3) && _CCCL_HAS_EXCEPTIONS()
+
     // Free the last allocation
     resource.deallocate(stream, ptr, 2048 * sizeof(int));
     stream.sync();
@@ -653,6 +750,10 @@ C2H_CCCLRT_TEST("device_memory_pool with allocation handle", "[memory_resource]"
 
   // Ensure that we disable export
   CHECK(ensure_export_handle(get, static_cast<cudaMemAllocationHandleType>(props.allocation_handle_type)));
+
+#  if _CCCL_CTK_AT_LEAST(13, 3)
+  check_creation_attributes(with_allocation_handle, props, 0);
+#  endif // _CCCL_CTK_AT_LEAST(13, 3)
 }
 
 #  if _CCCL_CTK_AT_LEAST(12, 9)
@@ -679,6 +780,10 @@ C2H_CCCLRT_TEST("pinned_memory_pool with allocation handle", "[memory_resource]"
 
   // Ensure that we disable export
   CHECK(ensure_export_handle(get, static_cast<cudaMemAllocationHandleType>(props.allocation_handle_type)));
+
+#    if _CCCL_CTK_AT_LEAST(13, 3)
+  check_creation_attributes(with_allocation_handle, props, 0);
+#    endif // _CCCL_CTK_AT_LEAST(13, 3)
 }
 #  endif // _CCCL_CTK_AT_LEAST(12, 9)
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/memory_pools.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/memory_pools.cu
@@ -64,6 +64,7 @@ static_assert(
   cuda::std::is_same_v<cuda::memory_pool_attributes::export_handle_types_t::type, cudaMemAllocationHandleType>);
 static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::location_id_t::type, int>);
 static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::location_type_t::type, cudaMemLocationType>);
+static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::location_t::type, cuda::memory_location>);
 static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::max_pool_size_t::type, ::cuuint64_t>);
 static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::hw_decompress_enabled_t::type, bool>);
 #endif // _CCCL_CTK_AT_LEAST(13, 3)
@@ -153,6 +154,9 @@ check_creation_attributes(const PoolType& pool, const cuda::memory_pool_properti
   REQUIRE(pool.attribute(cuda::memory_pool_attributes::export_handle_types) == props.allocation_handle_type);
   REQUIRE(pool.attribute(cuda::memory_pool_attributes::location_id) == expected_location_id);
   REQUIRE(pool.attribute(cuda::memory_pool_attributes::location_type) == expected_location_type);
+  const auto location = pool.attribute(cuda::memory_pool_attributes::location);
+  REQUIRE(location.id == expected_location_id);
+  REQUIRE(location.type == expected_location_type);
   REQUIRE(pool.attribute(cuda::memory_pool_attributes::max_pool_size) >= props.max_pool_size);
   REQUIRE(!pool.attribute(cuda::memory_pool_attributes::hw_decompress_enabled));
 }
@@ -184,6 +188,7 @@ static void check_creation_attributes_are_read_only(PoolType& pool)
   check_creation_attribute_is_read_only(pool, cuda::memory_pool_attributes::export_handle_types);
   check_creation_attribute_is_read_only(pool, cuda::memory_pool_attributes::location_id);
   check_creation_attribute_is_read_only(pool, cuda::memory_pool_attributes::location_type);
+  check_creation_attribute_is_read_only(pool, cuda::memory_pool_attributes::location);
   check_creation_attribute_is_read_only(pool, cuda::memory_pool_attributes::max_pool_size);
   check_creation_attribute_is_read_only(pool, cuda::memory_pool_attributes::hw_decompress_enabled);
 }

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/memory_pools.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/memory_pools.cu
@@ -126,7 +126,8 @@ static bool ensure_export_handle(::cudaMemPool_t pool, const ::cudaMemAllocation
 
 #if _CCCL_CTK_AT_LEAST(13, 3)
 template <typename PoolType>
-static void check_creation_attributes(PoolType& pool, cuda::memory_pool_properties props, int current_device)
+static void
+check_creation_attributes(const PoolType& pool, const cuda::memory_pool_properties props, const int current_device)
 {
   auto expected_allocation_type = ::cudaMemAllocationTypePinned;
   auto expected_location_type   = ::cudaMemLocationTypeDevice;
@@ -148,42 +149,43 @@ static void check_creation_attributes(PoolType& pool, cuda::memory_pool_properti
   }
 #  endif // _CCCL_CTK_AT_LEAST(13, 0)
 
-  CHECK(pool.attribute(cuda::memory_pool_attributes::allocation_type) == expected_allocation_type);
-  CHECK(pool.attribute(cuda::memory_pool_attributes::export_handle_types) == props.allocation_handle_type);
-  CHECK(pool.attribute(cuda::memory_pool_attributes::location_id) == expected_location_id);
-  CHECK(pool.attribute(cuda::memory_pool_attributes::location_type) == expected_location_type);
-  CHECK(pool.attribute(cuda::memory_pool_attributes::max_pool_size) >= props.max_pool_size);
-  CHECK(!pool.attribute(cuda::memory_pool_attributes::hw_decompress_enabled));
+  REQUIRE(pool.attribute(cuda::memory_pool_attributes::allocation_type) == expected_allocation_type);
+  REQUIRE(pool.attribute(cuda::memory_pool_attributes::export_handle_types) == props.allocation_handle_type);
+  REQUIRE(pool.attribute(cuda::memory_pool_attributes::location_id) == expected_location_id);
+  REQUIRE(pool.attribute(cuda::memory_pool_attributes::location_type) == expected_location_type);
+  REQUIRE(pool.attribute(cuda::memory_pool_attributes::max_pool_size) >= props.max_pool_size);
+  REQUIRE(!pool.attribute(cuda::memory_pool_attributes::hw_decompress_enabled));
 }
 
 #  if _CCCL_HAS_EXCEPTIONS()
+template <typename PoolType, typename Attr>
+static void check_creation_attribute_is_read_only(PoolType& pool, const Attr attr)
+{
+  const auto value = pool.attribute(attr);
+  try
+  {
+    pool.set_attribute(attr, value);
+    CHECK(false);
+  }
+  catch (const ::std::invalid_argument& err)
+  {
+    CHECK(strcmp(err.what(), "This attribute can't be set") == 0);
+  }
+  catch (...)
+  {
+    CHECK(false);
+  }
+}
+
 template <typename PoolType>
 static void check_creation_attributes_are_read_only(PoolType& pool)
 {
-  CHECK_THROWS_AS(
-    pool.set_attribute(
-      cuda::memory_pool_attributes::allocation_type, pool.attribute(cuda::memory_pool_attributes::allocation_type)),
-    std::invalid_argument);
-  CHECK_THROWS_AS(
-    pool.set_attribute(cuda::memory_pool_attributes::export_handle_types,
-                       pool.attribute(cuda::memory_pool_attributes::export_handle_types)),
-    std::invalid_argument);
-  CHECK_THROWS_AS(
-    pool.set_attribute(cuda::memory_pool_attributes::location_id,
-                       pool.attribute(cuda::memory_pool_attributes::location_id)),
-    std::invalid_argument);
-  CHECK_THROWS_AS(
-    pool.set_attribute(
-      cuda::memory_pool_attributes::location_type, pool.attribute(cuda::memory_pool_attributes::location_type)),
-    std::invalid_argument);
-  CHECK_THROWS_AS(
-    pool.set_attribute(
-      cuda::memory_pool_attributes::max_pool_size, pool.attribute(cuda::memory_pool_attributes::max_pool_size)),
-    std::invalid_argument);
-  CHECK_THROWS_AS(
-    pool.set_attribute(cuda::memory_pool_attributes::hw_decompress_enabled,
-                       pool.attribute(cuda::memory_pool_attributes::hw_decompress_enabled)),
-    std::invalid_argument);
+  check_creation_attribute_is_read_only(pool, cuda::memory_pool_attributes::allocation_type);
+  check_creation_attribute_is_read_only(pool, cuda::memory_pool_attributes::export_handle_types);
+  check_creation_attribute_is_read_only(pool, cuda::memory_pool_attributes::location_id);
+  check_creation_attribute_is_read_only(pool, cuda::memory_pool_attributes::location_type);
+  check_creation_attribute_is_read_only(pool, cuda::memory_pool_attributes::max_pool_size);
+  check_creation_attribute_is_read_only(pool, cuda::memory_pool_attributes::hw_decompress_enabled);
 }
 #  endif // _CCCL_HAS_EXCEPTIONS()
 #endif // _CCCL_CTK_AT_LEAST(13, 3)
@@ -602,9 +604,7 @@ C2H_CCCLRT_TEST_LIST("device_memory_pool accessors", "[memory_resource]", TEST_T
     }
 
 #if _CCCL_CTK_AT_LEAST(13, 3) && _CCCL_HAS_EXCEPTIONS()
-    { // CUDA 13.3 creation attributes
-      check_creation_attributes_are_read_only(pool);
-    }
+    check_creation_attributes_are_read_only(pool);
 #endif // _CCCL_CTK_AT_LEAST(13, 3) && _CCCL_HAS_EXCEPTIONS()
 
     // Free the last allocation

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/memory_pools.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/memory_pools.cu
@@ -65,7 +65,7 @@ static_assert(
 static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::location_id_t::type, int>);
 static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::location_type_t::type, cudaMemLocationType>);
 static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::location_t::type, cuda::memory_location>);
-static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::max_pool_size_t::type, ::cuuint64_t>);
+static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::max_pool_size_t::type, size_t>);
 static_assert(cuda::std::is_same_v<cuda::memory_pool_attributes::hw_decompress_enabled_t::type, bool>);
 #endif // _CCCL_CTK_AT_LEAST(13, 3)
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/shared_memory_pools.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/shared_memory_pools.cu
@@ -76,6 +76,9 @@ void check_shared_pool_creation_attributes(const PoolType& pool, const cuda::mem
   REQUIRE(pool.attribute(cuda::memory_pool_attributes::export_handle_types) == props.allocation_handle_type);
   REQUIRE(pool.attribute(cuda::memory_pool_attributes::location_id) == expected_location_id);
   REQUIRE(pool.attribute(cuda::memory_pool_attributes::location_type) == expected_location_type);
+  const auto location = pool.attribute(cuda::memory_pool_attributes::location);
+  REQUIRE(location.id == expected_location_id);
+  REQUIRE(location.type == expected_location_type);
   REQUIRE(pool.attribute(cuda::memory_pool_attributes::max_pool_size) >= props.max_pool_size);
   REQUIRE(!pool.attribute(cuda::memory_pool_attributes::hw_decompress_enabled));
 }

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/shared_memory_pools.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/shared_memory_pools.cu
@@ -50,7 +50,7 @@ PoolType construct_shared_pool(cuda::memory_pool_properties props = {})
 
 #if _CCCL_CTK_AT_LEAST(13, 3)
 template <typename PoolType>
-void check_shared_pool_creation_attributes(PoolType& pool, cuda::memory_pool_properties props)
+void check_shared_pool_creation_attributes(const PoolType& pool, const cuda::memory_pool_properties props)
 {
   auto expected_allocation_type = ::cudaMemAllocationTypePinned;
   auto expected_location_type   = ::cudaMemLocationTypeDevice;
@@ -72,12 +72,12 @@ void check_shared_pool_creation_attributes(PoolType& pool, cuda::memory_pool_pro
   }
 #  endif // _CCCL_CTK_AT_LEAST(13, 0)
 
-  CHECK(pool.attribute(cuda::memory_pool_attributes::allocation_type) == expected_allocation_type);
-  CHECK(pool.attribute(cuda::memory_pool_attributes::export_handle_types) == props.allocation_handle_type);
-  CHECK(pool.attribute(cuda::memory_pool_attributes::location_id) == expected_location_id);
-  CHECK(pool.attribute(cuda::memory_pool_attributes::location_type) == expected_location_type);
-  CHECK(pool.attribute(cuda::memory_pool_attributes::max_pool_size) >= props.max_pool_size);
-  CHECK(!pool.attribute(cuda::memory_pool_attributes::hw_decompress_enabled));
+  REQUIRE(pool.attribute(cuda::memory_pool_attributes::allocation_type) == expected_allocation_type);
+  REQUIRE(pool.attribute(cuda::memory_pool_attributes::export_handle_types) == props.allocation_handle_type);
+  REQUIRE(pool.attribute(cuda::memory_pool_attributes::location_id) == expected_location_id);
+  REQUIRE(pool.attribute(cuda::memory_pool_attributes::location_type) == expected_location_type);
+  REQUIRE(pool.attribute(cuda::memory_pool_attributes::max_pool_size) >= props.max_pool_size);
+  REQUIRE(!pool.attribute(cuda::memory_pool_attributes::hw_decompress_enabled));
 }
 #endif // _CCCL_CTK_AT_LEAST(13, 3)
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/shared_memory_pools.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/shared_memory_pools.cu
@@ -48,6 +48,39 @@ PoolType construct_shared_pool(cuda::memory_pool_properties props = {})
 #endif // _CCCL_CTK_AT_LEAST(13, 0)
 }
 
+#if _CCCL_CTK_AT_LEAST(13, 3)
+template <typename PoolType>
+void check_shared_pool_creation_attributes(PoolType& pool, cuda::memory_pool_properties props)
+{
+  auto expected_allocation_type = ::cudaMemAllocationTypePinned;
+  auto expected_location_type   = ::cudaMemLocationTypeDevice;
+  auto expected_location_id     = 0;
+
+#  if _CCCL_CTK_AT_LEAST(12, 9)
+  if constexpr (cuda::std::is_same_v<PoolType, cuda::shared_pinned_memory_pool>)
+  {
+    expected_location_type = ::cudaMemLocationTypeHostNuma;
+    expected_location_id   = 0;
+  }
+#  endif // _CCCL_CTK_AT_LEAST(12, 9)
+#  if _CCCL_CTK_AT_LEAST(13, 0)
+  if constexpr (cuda::std::is_same_v<PoolType, cuda::shared_managed_memory_pool>)
+  {
+    expected_allocation_type = ::cudaMemAllocationTypeManaged;
+    expected_location_type   = ::cudaMemLocationTypeNone;
+    expected_location_id     = 0;
+  }
+#  endif // _CCCL_CTK_AT_LEAST(13, 0)
+
+  CHECK(pool.attribute(cuda::memory_pool_attributes::allocation_type) == expected_allocation_type);
+  CHECK(pool.attribute(cuda::memory_pool_attributes::export_handle_types) == props.allocation_handle_type);
+  CHECK(pool.attribute(cuda::memory_pool_attributes::location_id) == expected_location_id);
+  CHECK(pool.attribute(cuda::memory_pool_attributes::location_type) == expected_location_type);
+  CHECK(pool.attribute(cuda::memory_pool_attributes::max_pool_size) >= props.max_pool_size);
+  CHECK(!pool.attribute(cuda::memory_pool_attributes::hw_decompress_enabled));
+}
+#endif // _CCCL_CTK_AT_LEAST(13, 3)
+
 // --- static assertions ---
 
 template <typename PoolType>
@@ -224,6 +257,11 @@ C2H_CCCLRT_TEST_LIST("shared_memory_pool operations", "[memory_resource]", SHARE
   {
     size_t threshold = pool.attribute(cuda::memory_pool_attributes::release_threshold);
     CHECK(threshold == cuda::std::numeric_limits<size_t>::max());
+
+#if _CCCL_CTK_AT_LEAST(13, 3)
+    cuda::memory_pool_properties expected_props{};
+    check_shared_pool_creation_attributes(pool, expected_props);
+#endif // _CCCL_CTK_AT_LEAST(13, 3)
   }
 
   SECTION("set_attribute")


### PR DESCRIPTION
CUDA 13.3 added a bunch of read-only memory pool attributes. This PR adds support for it for the CCCL memory pool types.

Also includes a fix to make the attribute getter correctly use the type specified in the documentation