### PR TITLE
[libcudacxx] Add parallel cuda::std::minmax_element

### DIFF
--- a/docs/libcudacxx/standard_api/algorithms_library.rst
+++ b/docs/libcudacxx/standard_api/algorithms_library.rst
@@ -72,7 +72,10 @@ The following algorithms are supported:
   * ``is_partitioned``
   * ``is_sorted``
   * ``is_sorted_until``
+  * ``max_element``
   * ``merge``
+  * ``min_element``
+  * ``minmax_element``
   * ``mismatch``
   * ``none_of``
   * ``remove``

--- a/libcudacxx/benchmarks/bench/minmax_element/basic.cu
+++ b/libcudacxx/benchmarks/bench/minmax_element/basic.cu
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+
+#include <cuda/memory_pool>
+#include <cuda/std/execution>
+#include <cuda/stream>
+
+#include "nvbench_helper.cuh"
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> in = generate(elements);
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<typename thrust::device_vector<T>::iterator::difference_type>(2);
+
+  caching_allocator_t alloc{};
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               do_not_optimize(cuda::std::minmax_element(cuda_policy(alloc, launch), in.begin(), in.end()));
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));
+
+template <typename T>
+static void with_comp(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> in = generate(elements);
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<typename thrust::device_vector<T>::iterator::difference_type>(2);
+
+  caching_allocator_t alloc{};
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               do_not_optimize(cuda::std::minmax_element(cuda_policy(alloc, launch), in.begin(), in.end(), less_t{}));
+             });
+}
+
+NVBENCH_BENCH_TYPES(with_comp, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("with_comp")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));

--- a/libcudacxx/include/cuda/std/__pstl/cuda/minmax_element.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/minmax_element.h
@@ -1,0 +1,215 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_CUDA_MINMAX_ELEMENT_H
+#define _CUDA_STD___PSTL_CUDA_MINMAX_ELEMENT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_HAS_BACKEND_CUDA()
+
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
+_CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
+
+#  include <cub/device/device_reduce.cuh>
+
+_CCCL_DIAG_POP
+
+#  include <cuda/__execution/policy.h>
+#  include <cuda/__functional/call_or.h>
+#  include <cuda/__iterator/discard_iterator.h>
+#  include <cuda/__runtime/api_wrapper.h>
+#  include <cuda/__stream/get_stream.h>
+#  include <cuda/__stream/stream_ref.h>
+#  include <cuda/std/__algorithm/minmax_element.h>
+#  include <cuda/std/__exception/cuda_error.h>
+#  include <cuda/std/__exception/exception_macros.h>
+#  include <cuda/std/__execution/env.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__iterator/reverse_iterator.h>
+#  include <cuda/std/__memory/addressof.h>
+#  include <cuda/std/__pstl/cuda/ensure_current_context.h>
+#  include <cuda/std/__pstl/cuda/temporary_storage.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__utility/move.h>
+#  include <cuda/std/__utility/pair.h>
+#  include <cuda/std/tuple>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+template <>
+struct __pstl_dispatch<__pstl_algorithm::__minmax_element, __execution_backend::__cuda>
+{
+  template <class _Policy, class _InputIterator, class _BinaryPred>
+  [[nodiscard]] _CCCL_HOST_API static ::cuda::std::pair<_InputIterator, _InputIterator> __par_impl(
+    [[maybe_unused]] const _Policy& __policy, _InputIterator __first, _InputIterator __last, _BinaryPred __pred)
+  {
+    const auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
+    const auto __ctx    = ::cuda::std::execution::__pstl_ensure_current_ctx_for(__policy);
+
+    const auto __count = static_cast<int64_t>(::cuda::std::distance(__first, __last));
+
+    // cuda::std::minmax_element returns the *first* minimum and the *last* maximum.
+    // cub::DeviceReduce::ArgMin/ArgMax both keep the smaller offset on ties (i.e. the
+    // first extremum encountered). ArgMin over the forward range therefore yields the
+    // first minimum directly, while the last maximum is obtained by running ArgMax over
+    // the reversed range: the first maximum in reverse order is the last maximum in
+    // forward order. The reversed index __max_rev is mapped back via __count - 1 - __max_rev.
+    auto __rfirst = ::cuda::std::make_reverse_iterator(__last);
+
+    // Determine the device storage requirements for both reductions. The two reductions run
+    // sequentially on the same stream, so they share a single scratch buffer and a single
+    // allocation that also holds both result slots.
+    size_t __min_bytes = 0;
+    _CCCL_TRY_CUDA_API(
+      CUB_NS_QUALIFIER::DeviceReduce::ArgMin,
+      "__pstl_cuda_minmax_element: determination of device storage for cub::DeviceReduce::ArgMin failed",
+      static_cast<void*>(nullptr),
+      __min_bytes,
+      __first,
+      ::cuda::discard_iterator{},
+      static_cast<size_t*>(nullptr),
+      __count,
+      __pred,
+      __policy);
+
+    size_t __max_bytes = 0;
+    _CCCL_TRY_CUDA_API(
+      CUB_NS_QUALIFIER::DeviceReduce::ArgMax,
+      "__pstl_cuda_minmax_element: determination of device storage for cub::DeviceReduce::ArgMax failed",
+      static_cast<void*>(nullptr),
+      __max_bytes,
+      __rfirst,
+      ::cuda::discard_iterator{},
+      static_cast<size_t*>(nullptr),
+      __count,
+      __pred,
+      __policy);
+
+    size_t __min_idx = 0ull;
+    size_t __max_rev = 0ull;
+    {
+      __temporary_storage<size_t, size_t> __storage{
+        __policy, (__min_bytes < __max_bytes ? __max_bytes : __min_bytes), 1, 1};
+
+      // First minimum: ArgMin over [__first, __last)
+      _CCCL_TRY_CUDA_API(
+        CUB_NS_QUALIFIER::DeviceReduce::ArgMin,
+        "__pstl_cuda_minmax_element: kernel launch of cub::DeviceReduce::ArgMin failed",
+        __storage.__get_temp_storage(),
+        __min_bytes,
+        __first,
+        ::cuda::discard_iterator{},
+        __storage.template __get_raw_ptr<0>(),
+        __count,
+        __pred,
+        __policy);
+
+      // Last maximum: ArgMax over reverse([__first, __last))
+      _CCCL_TRY_CUDA_API(
+        CUB_NS_QUALIFIER::DeviceReduce::ArgMax,
+        "__pstl_cuda_minmax_element: kernel launch of cub::DeviceReduce::ArgMax failed",
+        __storage.__get_temp_storage(),
+        __max_bytes,
+        __rfirst,
+        ::cuda::discard_iterator{},
+        __storage.template __get_raw_ptr<1>(),
+        __count,
+        ::cuda::std::move(__pred),
+        __policy);
+
+      _CCCL_TRY_CUDA_API(
+        ::cudaMemcpyAsync,
+        "__pstl_cuda_minmax_element: copy of min result from device to host failed",
+        ::cuda::std::addressof(__min_idx),
+        __storage.template __get_raw_ptr<0>(),
+        sizeof(size_t),
+        ::cudaMemcpyDefault,
+        __stream.get());
+
+      _CCCL_TRY_CUDA_API(
+        ::cudaMemcpyAsync,
+        "__pstl_cuda_minmax_element: copy of max result from device to host failed",
+        ::cuda::std::addressof(__max_rev),
+        __storage.template __get_raw_ptr<1>(),
+        sizeof(size_t),
+        ::cudaMemcpyDefault,
+        __stream.get());
+    }
+
+    __stream.sync();
+
+    using __diff_t = iter_difference_t<_InputIterator>;
+    return ::cuda::std::pair<_InputIterator, _InputIterator>{
+      __first + static_cast<__diff_t>(__min_idx),
+      __first + static_cast<__diff_t>(__count - 1 - static_cast<int64_t>(__max_rev))};
+  }
+
+  template <class _Policy, class _InputIterator, class _BinaryPred>
+  [[nodiscard]] _CCCL_HOST_API ::cuda::std::pair<_InputIterator, _InputIterator> operator()(
+    [[maybe_unused]] const _Policy& __policy, _InputIterator __first, _InputIterator __last, _BinaryPred __pred) const
+  {
+    if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>)
+    {
+      _CCCL_TRY
+      {
+        return __par_impl(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
+      }
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
+      {
+        if (__err.status() == cudaErrorMemoryAllocation)
+        {
+          _CCCL_THROW(::std::bad_alloc);
+        }
+        else
+        {
+          _CCCL_RETHROW;
+        }
+      }
+      _CCCL_CATCH_FALLTHROUGH
+    }
+    else
+    {
+      static_assert(__always_false_v<_Policy>,
+                    "__pstl_dispatch: CUDA backend of cuda::std::minmax_element requires at least random access "
+                    "iterators");
+      return ::cuda::std::minmax_element(
+        ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
+    }
+  }
+};
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD_EXECUTION
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CCCL_HAS_BACKEND_CUDA()
+
+#endif // _CUDA_STD___PSTL_CUDA_MINMAX_ELEMENT_H

--- a/libcudacxx/include/cuda/std/__pstl/cuda/minmax_element.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/minmax_element.h
@@ -1,0 +1,174 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_CUDA_MINMAX_ELEMENT_H
+#define _CUDA_STD___PSTL_CUDA_MINMAX_ELEMENT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_HAS_BACKEND_CUDA()
+
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
+_CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
+
+#  include <cub/device/device_reduce.cuh>
+
+_CCCL_DIAG_POP
+
+#  include <cuda/__execution/policy.h>
+#  include <cuda/__functional/call_or.h>
+#  include <cuda/__iterator/discard_iterator.h>
+#  include <cuda/__runtime/api_wrapper.h>
+#  include <cuda/__stream/get_stream.h>
+#  include <cuda/__stream/stream_ref.h>
+#  include <cuda/std/__algorithm/minmax_element.h>
+#  include <cuda/std/__exception/cuda_error.h>
+#  include <cuda/std/__exception/exception_macros.h>
+#  include <cuda/std/__execution/env.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__memory/addressof.h>
+#  include <cuda/std/__pstl/cuda/ensure_current_context.h>
+#  include <cuda/std/__pstl/cuda/temporary_storage.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__utility/move.h>
+#  include <cuda/std/__utility/pair.h>
+#  include <cuda/std/cstdint>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+template <>
+struct __pstl_dispatch<__pstl_algorithm::__minmax_element, __execution_backend::__cuda>
+{
+  template <class _Policy, class _InputIterator, class _BinaryPred>
+  [[nodiscard]] _CCCL_HOST_API static ::cuda::std::pair<_InputIterator, _InputIterator> __par_impl(
+    [[maybe_unused]] const _Policy& __policy, _InputIterator __first, _InputIterator __last, _BinaryPred __pred)
+  {
+    const auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
+    const auto __ctx    = ::cuda::std::execution::__pstl_ensure_current_ctx_for(__policy);
+
+    // cub::DeviceReduce::ArgMinLastMax reports the first minimum and the last maximum in a single traversal, which is
+    // exactly what cuda::std::minmax_element requires. Both offsets are written as int64_t.
+    int64_t __ret[2]{};
+    const auto __count = static_cast<int64_t>(::cuda::std::distance(__first, __last));
+
+    // Determine temporary device storage requirements for minmax_element
+    size_t __num_bytes = 0;
+    _CCCL_TRY_CUDA_API(
+      CUB_NS_QUALIFIER::DeviceReduce::ArgMinLastMax,
+      "__pstl_cuda_minmax_element: determination of device storage for cub::DeviceReduce::ArgMinLastMax failed",
+      static_cast<void*>(nullptr),
+      __num_bytes,
+      __first,
+      ::cuda::discard_iterator{},
+      static_cast<int64_t*>(nullptr),
+      ::cuda::discard_iterator{},
+      static_cast<int64_t*>(nullptr),
+      __count,
+      __pred,
+      __policy);
+
+    {
+      // Both offsets share one allocation, so they also travel back to the host in a single copy
+      __temporary_storage<int64_t> __storage{__policy, __num_bytes, 2};
+
+      // Run the reduction
+      _CCCL_TRY_CUDA_API(
+        CUB_NS_QUALIFIER::DeviceReduce::ArgMinLastMax,
+        "__pstl_cuda_minmax_element: kernel launch of cub::DeviceReduce::ArgMinLastMax failed",
+        __storage.__get_temp_storage(),
+        __num_bytes,
+        __first,
+        ::cuda::discard_iterator{},
+        __storage.template __get_raw_ptr<0>(),
+        ::cuda::discard_iterator{},
+        __storage.template __get_raw_ptr<0>() + 1,
+        __count,
+        ::cuda::std::move(__pred),
+        __policy);
+
+      // Copy the result back from storage
+      _CCCL_TRY_CUDA_API(
+        ::cudaMemcpyAsync,
+        "__pstl_cuda_minmax_element: copy of result from device to host failed",
+        ::cuda::std::addressof(__ret[0]),
+        __storage.template __get_raw_ptr<0>(),
+        sizeof(__ret),
+        ::cudaMemcpyDefault,
+        __stream.get());
+    }
+
+    __stream.sync();
+
+    using __diff_t = iter_difference_t<_InputIterator>;
+    return ::cuda::std::pair<_InputIterator, _InputIterator>{
+      __first + static_cast<__diff_t>(__ret[0]), __first + static_cast<__diff_t>(__ret[1])};
+  }
+
+  template <class _Policy, class _InputIterator, class _BinaryPred>
+  [[nodiscard]] _CCCL_HOST_API ::cuda::std::pair<_InputIterator, _InputIterator> _CCCL_STATIC_CALL_OPERATOR(
+    [[maybe_unused]] const _Policy& __policy, _InputIterator __first, _InputIterator __last, _BinaryPred __pred)
+  {
+    if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>)
+    {
+      _CCCL_TRY
+      {
+        return __par_impl(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
+      }
+      _CCCL_CATCH (const ::cuda::cuda_error& __err)
+      {
+        if (__err.status() == cudaErrorMemoryAllocation)
+        {
+          _CCCL_THROW(::std::bad_alloc);
+        }
+        else
+        {
+          _CCCL_RETHROW;
+        }
+      }
+      _CCCL_CATCH_FALLTHROUGH
+    }
+    else
+    {
+      static_assert(__always_false_v<_Policy>,
+                    "__pstl_dispatch: CUDA backend of cuda::std::minmax_element requires at least random access "
+                    "iterators");
+      return ::cuda::std::minmax_element(
+        ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
+    }
+  }
+};
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD_EXECUTION
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CCCL_HAS_BACKEND_CUDA()
+
+#endif // _CUDA_STD___PSTL_CUDA_MINMAX_ELEMENT_H

--- a/libcudacxx/include/cuda/std/__pstl/cuda/minmax_element.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/minmax_element.h
@@ -35,7 +35,7 @@ _CCCL_DIAG_POP
 
 #  include <cuda/__execution/policy.h>
 #  include <cuda/__functional/call_or.h>
-#  include <cuda/__iterator/discard_iterator.h>
+#  include <cuda/__iterator/counting_iterator.h>
 #  include <cuda/__runtime/api_wrapper.h>
 #  include <cuda/__stream/get_stream.h>
 #  include <cuda/__stream/stream_ref.h>
@@ -46,7 +46,6 @@ _CCCL_DIAG_POP
 #  include <cuda/std/__execution/policy.h>
 #  include <cuda/std/__iterator/distance.h>
 #  include <cuda/std/__iterator/iterator_traits.h>
-#  include <cuda/std/__iterator/reverse_iterator.h>
 #  include <cuda/std/__memory/addressof.h>
 #  include <cuda/std/__pstl/cuda/ensure_current_context.h>
 #  include <cuda/std/__pstl/cuda/temporary_storage.h>
@@ -54,11 +53,74 @@ _CCCL_DIAG_POP
 #  include <cuda/std/__type_traits/always_false.h>
 #  include <cuda/std/__utility/move.h>
 #  include <cuda/std/__utility/pair.h>
-#  include <cuda/std/tuple>
+#  include <cuda/std/cstdint>
 
 #  include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
+
+//! @brief Accumulator of the reduction, carrying the current first minimum and last maximum with their offsets
+template <class _Tp>
+struct __minmax_element_result
+{
+  _Tp __min_value_;
+  _Tp __max_value_;
+  int64_t __min_index_;
+  int64_t __max_index_;
+};
+
+//! @brief Loads the element at the given offset and enters it into the reduction as both minimum and maximum
+template <class _Iter>
+struct __minmax_element_transform_fn
+{
+  _Iter __first_;
+
+  [[nodiscard]] _CCCL_API __minmax_element_result<iter_value_t<_Iter>> operator()(int64_t __index) const
+  {
+    const iter_value_t<_Iter> __value = __first_[static_cast<iter_difference_t<_Iter>>(__index)];
+    return __minmax_element_result<iter_value_t<_Iter>>{__value, __value, __index, __index};
+  }
+};
+
+//! @brief Combines two accumulators in a single pass: on equivalent values the minimum keeps the smaller offset and
+//!        the maximum keeps the larger offset, matching the first-minimum / last-maximum requirement of
+//!        cuda::std::minmax_element
+template <class _Tp, class _BinaryPred>
+struct __minmax_element_reduce_fn
+{
+  _BinaryPred __pred_;
+
+  [[nodiscard]] _CCCL_API constexpr __minmax_element_result<_Tp>
+  operator()(const __minmax_element_result<_Tp>& __lhs, const __minmax_element_result<_Tp>& __rhs) const
+  {
+    // The initial value of the reduction is flagged with offset -1 and loses against every element
+    if (__lhs.__min_index_ < 0)
+    {
+      return __rhs;
+    }
+    if (__rhs.__min_index_ < 0)
+    {
+      return __lhs;
+    }
+
+    __minmax_element_result<_Tp> __result = __lhs;
+    // first minimum: a strictly smaller value wins, equivalent values keep the smaller offset
+    if (__pred_(__rhs.__min_value_, __lhs.__min_value_)
+        || (!__pred_(__lhs.__min_value_, __rhs.__min_value_) && __rhs.__min_index_ < __lhs.__min_index_))
+    {
+      __result.__min_value_ = __rhs.__min_value_;
+      __result.__min_index_ = __rhs.__min_index_;
+    }
+    // last maximum: a strictly greater value wins, equivalent values keep the larger offset
+    if (__pred_(__lhs.__max_value_, __rhs.__max_value_)
+        || (!__pred_(__rhs.__max_value_, __lhs.__max_value_) && __rhs.__max_index_ > __lhs.__max_index_))
+    {
+      __result.__max_value_ = __rhs.__max_value_;
+      __result.__max_index_ = __rhs.__max_index_;
+    }
+    return __result;
+  }
+};
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
@@ -72,92 +134,58 @@ struct __pstl_dispatch<__pstl_algorithm::__minmax_element, __execution_backend::
     const auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
     const auto __ctx    = ::cuda::std::execution::__pstl_ensure_current_ctx_for(__policy);
 
+    using _ValueT  = iter_value_t<_InputIterator>;
+    using _ResultT = __minmax_element_result<_ValueT>;
+
     const auto __count = static_cast<int64_t>(::cuda::std::distance(__first, __last));
 
-    // cuda::std::minmax_element returns the *first* minimum and the *last* maximum.
-    // cub::DeviceReduce::ArgMin/ArgMax both keep the smaller offset on ties (i.e. the
-    // first extremum encountered). ArgMin over the forward range therefore yields the
-    // first minimum directly, while the last maximum is obtained by running ArgMax over
-    // the reversed range: the first maximum in reverse order is the last maximum in
-    // forward order. The reversed index __max_rev is mapped back via __count - 1 - __max_rev.
-    auto __rfirst = ::cuda::std::make_reverse_iterator(__last);
+    // cuda::std::minmax_element returns the *first* minimum and the *last* maximum. Both are found
+    // in a single traversal of the range: every element enters the reduction as an accumulator
+    // {value, value, index, index} and the reduction operator resolves ties via the offsets. The
+    // initial value is flagged with offset -1 so that it loses against every element of the range.
+    __minmax_element_transform_fn<_InputIterator> __transform_op{__first};
+    __minmax_element_reduce_fn<_ValueT, _BinaryPred> __reduce_op{::cuda::std::move(__pred)};
+    _ResultT __init{_ValueT{}, _ValueT{}, -1, -1};
 
-    // Determine the device storage requirements for both reductions. The two reductions run
-    // sequentially on the same stream, so they share a single scratch buffer and a single
-    // allocation that also holds both result slots.
-    size_t __min_bytes = 0;
+    // Determine temporary device storage requirements for the reduction
+    size_t __num_bytes = 0;
     _CCCL_TRY_CUDA_API(
-      CUB_NS_QUALIFIER::DeviceReduce::ArgMin,
-      "__pstl_cuda_minmax_element: determination of device storage for cub::DeviceReduce::ArgMin failed",
+      CUB_NS_QUALIFIER::DeviceReduce::TransformReduce,
+      "__pstl_cuda_minmax_element: determination of device storage for cub::DeviceReduce::TransformReduce failed",
       static_cast<void*>(nullptr),
-      __min_bytes,
-      __first,
-      ::cuda::discard_iterator{},
-      static_cast<size_t*>(nullptr),
+      __num_bytes,
+      ::cuda::counting_iterator<int64_t>{0},
+      static_cast<_ResultT*>(nullptr),
       __count,
-      __pred,
-      __policy);
+      __reduce_op,
+      __transform_op,
+      __init);
 
-    size_t __max_bytes = 0;
-    _CCCL_TRY_CUDA_API(
-      CUB_NS_QUALIFIER::DeviceReduce::ArgMax,
-      "__pstl_cuda_minmax_element: determination of device storage for cub::DeviceReduce::ArgMax failed",
-      static_cast<void*>(nullptr),
-      __max_bytes,
-      __rfirst,
-      ::cuda::discard_iterator{},
-      static_cast<size_t*>(nullptr),
-      __count,
-      __pred,
-      __policy);
-
-    size_t __min_idx = 0ull;
-    size_t __max_rev = 0ull;
+    _ResultT __result;
     {
-      __temporary_storage<size_t, size_t> __storage{
-        __policy, (__min_bytes < __max_bytes ? __max_bytes : __min_bytes), 1, 1};
+      __temporary_storage<_ResultT> __storage{__policy, __num_bytes, 1};
 
-      // First minimum: ArgMin over [__first, __last)
+      // Run the reduction
       _CCCL_TRY_CUDA_API(
-        CUB_NS_QUALIFIER::DeviceReduce::ArgMin,
-        "__pstl_cuda_minmax_element: kernel launch of cub::DeviceReduce::ArgMin failed",
+        CUB_NS_QUALIFIER::DeviceReduce::TransformReduce,
+        "__pstl_cuda_minmax_element: kernel launch of cub::DeviceReduce::TransformReduce failed",
         __storage.__get_temp_storage(),
-        __min_bytes,
-        __first,
-        ::cuda::discard_iterator{},
-        __storage.template __get_raw_ptr<0>(),
+        __num_bytes,
+        ::cuda::counting_iterator<int64_t>{0},
+        __storage.template __get_ptr<0, _ResultT>(),
         __count,
-        __pred,
-        __policy);
-
-      // Last maximum: ArgMax over reverse([__first, __last))
-      _CCCL_TRY_CUDA_API(
-        CUB_NS_QUALIFIER::DeviceReduce::ArgMax,
-        "__pstl_cuda_minmax_element: kernel launch of cub::DeviceReduce::ArgMax failed",
-        __storage.__get_temp_storage(),
-        __max_bytes,
-        __rfirst,
-        ::cuda::discard_iterator{},
-        __storage.template __get_raw_ptr<1>(),
-        __count,
-        ::cuda::std::move(__pred),
-        __policy);
-
-      _CCCL_TRY_CUDA_API(
-        ::cudaMemcpyAsync,
-        "__pstl_cuda_minmax_element: copy of min result from device to host failed",
-        ::cuda::std::addressof(__min_idx),
-        __storage.template __get_raw_ptr<0>(),
-        sizeof(size_t),
-        ::cudaMemcpyDefault,
+        ::cuda::std::move(__reduce_op),
+        ::cuda::std::move(__transform_op),
+        ::cuda::std::move(__init),
         __stream.get());
 
+      // Copy the result back from storage
       _CCCL_TRY_CUDA_API(
         ::cudaMemcpyAsync,
-        "__pstl_cuda_minmax_element: copy of max result from device to host failed",
-        ::cuda::std::addressof(__max_rev),
-        __storage.template __get_raw_ptr<1>(),
-        sizeof(size_t),
+        "__pstl_cuda_minmax_element: copy of result from device to host failed",
+        ::cuda::std::addressof(__result),
+        __storage.template __get_raw_ptr<0>(),
+        sizeof(_ResultT),
         ::cudaMemcpyDefault,
         __stream.get());
     }
@@ -166,8 +194,7 @@ struct __pstl_dispatch<__pstl_algorithm::__minmax_element, __execution_backend::
 
     using __diff_t = iter_difference_t<_InputIterator>;
     return ::cuda::std::pair<_InputIterator, _InputIterator>{
-      __first + static_cast<__diff_t>(__min_idx),
-      __first + static_cast<__diff_t>(__count - 1 - static_cast<int64_t>(__max_rev))};
+      __first + static_cast<__diff_t>(__result.__min_index_), __first + static_cast<__diff_t>(__result.__max_index_)};
   }
 
   template <class _Policy, class _InputIterator, class _BinaryPred>

--- a/libcudacxx/include/cuda/std/__pstl/cuda/minmax_element.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/minmax_element.h
@@ -54,44 +54,45 @@ _CCCL_DIAG_POP
 #  include <cuda/std/__utility/move.h>
 #  include <cuda/std/__utility/pair.h>
 #  include <cuda/std/cstdint>
+#  include <cuda/std/limits>
 
 #  include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 //! @brief Accumulator of the reduction, carrying the current first minimum and last maximum with their offsets
-template <class _Tp>
+template <class _Tp, class _Index>
 struct __minmax_element_result
 {
   _Tp __min_value_;
   _Tp __max_value_;
-  int64_t __min_index_;
-  int64_t __max_index_;
+  _Index __min_index_;
+  _Index __max_index_;
 };
 
 //! @brief Loads the element at the given offset and enters it into the reduction as both minimum and maximum
-template <class _Iter>
+template <class _Iter, class _Index>
 struct __minmax_element_transform_fn
 {
   _Iter __first_;
 
-  [[nodiscard]] _CCCL_API __minmax_element_result<iter_value_t<_Iter>> operator()(int64_t __index) const
+  [[nodiscard]] _CCCL_API __minmax_element_result<iter_value_t<_Iter>, _Index> operator()(_Index __index) const
   {
     const iter_value_t<_Iter> __value = __first_[static_cast<iter_difference_t<_Iter>>(__index)];
-    return __minmax_element_result<iter_value_t<_Iter>>{__value, __value, __index, __index};
+    return __minmax_element_result<iter_value_t<_Iter>, _Index>{__value, __value, __index, __index};
   }
 };
 
 //! @brief Combines two accumulators in a single pass: on equivalent values the minimum keeps the smaller offset and
 //!        the maximum keeps the larger offset, matching the first-minimum / last-maximum requirement of
 //!        cuda::std::minmax_element
-template <class _Tp, class _BinaryPred>
+template <class _Tp, class _Index, class _BinaryPred>
 struct __minmax_element_reduce_fn
 {
   _BinaryPred __pred_;
 
-  [[nodiscard]] _CCCL_API constexpr __minmax_element_result<_Tp>
-  operator()(const __minmax_element_result<_Tp>& __lhs, const __minmax_element_result<_Tp>& __rhs) const
+  [[nodiscard]] _CCCL_API constexpr __minmax_element_result<_Tp, _Index>
+  operator()(const __minmax_element_result<_Tp, _Index>& __lhs, const __minmax_element_result<_Tp, _Index>& __rhs) const
   {
     // The initial value of the reduction is flagged with offset -1 and loses against every element
     if (__lhs.__min_index_ < 0)
@@ -103,7 +104,7 @@ struct __minmax_element_reduce_fn
       return __lhs;
     }
 
-    __minmax_element_result<_Tp> __result = __lhs;
+    __minmax_element_result<_Tp, _Index> __result = __lhs;
     // first minimum: a strictly smaller value wins, equivalent values keep the smaller offset
     if (__pred_(__rhs.__min_value_, __lhs.__min_value_)
         || (!__pred_(__lhs.__min_value_, __rhs.__min_value_) && __rhs.__min_index_ < __lhs.__min_index_))
@@ -127,25 +128,22 @@ _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 template <>
 struct __pstl_dispatch<__pstl_algorithm::__minmax_element, __execution_backend::__cuda>
 {
-  template <class _Policy, class _InputIterator, class _BinaryPred>
-  [[nodiscard]] _CCCL_HOST_API static ::cuda::std::pair<_InputIterator, _InputIterator> __par_impl(
-    [[maybe_unused]] const _Policy& __policy, _InputIterator __first, _InputIterator __last, _BinaryPred __pred)
+  template <class _IndexT, class _Policy, class _InputIterator, class _BinaryPred>
+  [[nodiscard]] _CCCL_HOST_API static ::cuda::std::pair<_InputIterator, _InputIterator>
+  __reduce_impl(const _Policy& __policy, _InputIterator __first, const _IndexT __count, _BinaryPred __pred)
   {
     const auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}}, __policy);
-    const auto __ctx    = ::cuda::std::execution::__pstl_ensure_current_ctx_for(__policy);
 
     using _ValueT  = iter_value_t<_InputIterator>;
-    using _ResultT = __minmax_element_result<_ValueT>;
-
-    const auto __count = static_cast<int64_t>(::cuda::std::distance(__first, __last));
+    using _ResultT = __minmax_element_result<_ValueT, _IndexT>;
 
     // cuda::std::minmax_element returns the *first* minimum and the *last* maximum. Both are found
     // in a single traversal of the range: every element enters the reduction as an accumulator
     // {value, value, index, index} and the reduction operator resolves ties via the offsets. The
     // initial value is flagged with offset -1 so that it loses against every element of the range.
-    __minmax_element_transform_fn<_InputIterator> __transform_op{__first};
-    __minmax_element_reduce_fn<_ValueT, _BinaryPred> __reduce_op{::cuda::std::move(__pred)};
-    _ResultT __init{_ValueT{}, _ValueT{}, -1, -1};
+    __minmax_element_transform_fn<_InputIterator, _IndexT> __transform_op{__first};
+    __minmax_element_reduce_fn<_ValueT, _IndexT, _BinaryPred> __reduce_op{::cuda::std::move(__pred)};
+    _ResultT __init{_ValueT{}, _ValueT{}, _IndexT{-1}, _IndexT{-1}};
 
     // Determine temporary device storage requirements for the reduction
     size_t __num_bytes = 0;
@@ -154,7 +152,7 @@ struct __pstl_dispatch<__pstl_algorithm::__minmax_element, __execution_backend::
       "__pstl_cuda_minmax_element: determination of device storage for cub::DeviceReduce::TransformReduce failed",
       static_cast<void*>(nullptr),
       __num_bytes,
-      ::cuda::counting_iterator<int64_t>{0},
+      ::cuda::counting_iterator<_IndexT>{0},
       static_cast<_ResultT*>(nullptr),
       __count,
       __reduce_op,
@@ -171,7 +169,7 @@ struct __pstl_dispatch<__pstl_algorithm::__minmax_element, __execution_backend::
         "__pstl_cuda_minmax_element: kernel launch of cub::DeviceReduce::TransformReduce failed",
         __storage.__get_temp_storage(),
         __num_bytes,
-        ::cuda::counting_iterator<int64_t>{0},
+        ::cuda::counting_iterator<_IndexT>{0},
         __storage.template __get_ptr<0, _ResultT>(),
         __count,
         ::cuda::std::move(__reduce_op),
@@ -195,6 +193,23 @@ struct __pstl_dispatch<__pstl_algorithm::__minmax_element, __execution_backend::
     using __diff_t = iter_difference_t<_InputIterator>;
     return ::cuda::std::pair<_InputIterator, _InputIterator>{
       __first + static_cast<__diff_t>(__result.__min_index_), __first + static_cast<__diff_t>(__result.__max_index_)};
+  }
+
+  template <class _Policy, class _InputIterator, class _BinaryPred>
+  [[nodiscard]] _CCCL_HOST_API static ::cuda::std::pair<_InputIterator, _InputIterator>
+  __par_impl(const _Policy& __policy, _InputIterator __first, _InputIterator __last, _BinaryPred __pred)
+  {
+    const auto __ctx = ::cuda::std::execution::__pstl_ensure_current_ctx_for(__policy);
+
+    const auto __count = static_cast<int64_t>(::cuda::std::distance(__first, __last));
+
+    // Prefer 32 bit offsets: they shrink the accumulator and let cub select the 32 bit offset kernels
+    if (__count <= static_cast<int64_t>(::cuda::std::numeric_limits<int32_t>::max()))
+    {
+      return __reduce_impl(
+        __policy, ::cuda::std::move(__first), static_cast<int32_t>(__count), ::cuda::std::move(__pred));
+    }
+    return __reduce_impl(__policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__pred));
   }
 
   template <class _Policy, class _InputIterator, class _BinaryPred>

--- a/libcudacxx/include/cuda/std/__pstl/dispatch.h
+++ b/libcudacxx/include/cuda/std/__pstl/dispatch.h
@@ -43,6 +43,7 @@ enum class __pstl_algorithm
   __max_element,
   __merge,
   __min_element,
+  __minmax_element,
   __partition,
   __partition_copy,
   __reduce,

--- a/libcudacxx/include/cuda/std/__pstl/minmax_element.h
+++ b/libcudacxx/include/cuda/std/__pstl/minmax_element.h
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_MINMAX_ELEMENT_H
+#define _CUDA_STD___PSTL_MINMAX_ELEMENT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_HOSTED()
+
+#  include <cuda/__nvtx/nvtx.h>
+#  include <cuda/std/__algorithm/minmax_element.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__iterator/concepts.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__utility/move.h>
+#  include <cuda/std/__utility/pair.h>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/minmax_element.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_TEMPLATE(class _Policy, class _Iter, class _BinaryPredicate = less<>)
+_CCCL_REQUIRES(__has_forward_traversal<_Iter> _CCCL_AND is_execution_policy_v<_Policy>)
+[[nodiscard]] _CCCL_HOST_API pair<_Iter, _Iter>
+minmax_element([[maybe_unused]] const _Policy& __policy, _Iter __first, _Iter __last, _BinaryPredicate __pred = {})
+{
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__minmax_element, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cuda::std::minmax_element");
+
+    if (__first == __last)
+    {
+      return pair<_Iter, _Iter>{__first, __first};
+    }
+
+    return __dispatch(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
+  }
+  else
+  {
+    static_assert(__always_false_v<_Policy>,
+                  "Parallel cuda::std::minmax_element requires at least one selected backend");
+    return ::cuda::std::minmax_element(::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
+  }
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CCCL_HOSTED()
+
+#endif // _CUDA_STD___PSTL_MINMAX_ELEMENT_H

--- a/libcudacxx/include/cuda/std/execution
+++ b/libcudacxx/include/cuda/std/execution
@@ -57,6 +57,7 @@
 #  include <cuda/std/__pstl/max_element.h>
 #  include <cuda/std/__pstl/merge.h>
 #  include <cuda/std/__pstl/min_element.h>
+#  include <cuda/std/__pstl/minmax_element.h>
 #  include <cuda/std/__pstl/mismatch.h>
 #  include <cuda/std/__pstl/none_of.h>
 #  include <cuda/std/__pstl/partition.h>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/pstl_minmax_element.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/pstl_minmax_element.cu
@@ -1,0 +1,122 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template<class ExecutionPolicy, class ForwardIterator>
+//   pair<ForwardIterator, ForwardIterator>
+//   minmax_element(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last);
+
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/sequence.h>
+
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/algorithm>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "test_pstl.h"
+
+inline constexpr int size = 1000;
+
+template <class Policy, class T>
+void test_minmax_element(const Policy& policy, c2h::device_vector<T>& input)
+{
+  { // empty range should not access anything and return {first, first}
+    auto res = cuda::std::minmax_element(policy, static_cast<T*>(nullptr), static_cast<T*>(nullptr));
+    static_assert(cuda::std::is_same_v<decltype(res), cuda::std::pair<T*, T*>>);
+    CHECK(res.first == nullptr);
+    CHECK(res.second == nullptr);
+  }
+
+  const T* raw_pointer = thrust::raw_pointer_cast(input.data());
+
+  // Verify the parallel result against the serial cuda::std::minmax_element reference on the
+  // same data. This is robust to ties (e.g. low-precision floating point types where several
+  // adjacent values round to the same representation): the standard returns the *first* minimum
+  // and the *last* maximum, and the parallel overload must match that positionally for any data.
+  auto check_matches_serial = [&] {
+    c2h::host_vector<T> host = input;
+    const T* hp              = thrust::raw_pointer_cast(host.data());
+    const auto expected      = cuda::std::minmax_element(hp, hp + size);
+    const auto expected_min  = expected.first - hp;
+    const auto expected_max  = expected.second - hp;
+
+    { // contiguous iterator
+      auto res = cuda::std::minmax_element(policy, input.begin(), input.end());
+      CHECK((res.first - input.begin()) == expected_min);
+      CHECK((res.second - input.begin()) == expected_max);
+    }
+
+    { // random access iterator
+      auto res = cuda::std::minmax_element(
+        policy, random_access_iterator{raw_pointer}, random_access_iterator{raw_pointer + size});
+      CHECK((res.first - random_access_iterator{raw_pointer}) == expected_min);
+      CHECK((res.second - random_access_iterator{raw_pointer}) == expected_max);
+    }
+  };
+
+  thrust::sequence(input.begin(), input.end(), 1); // strictly ascending: min first, max last
+  check_matches_serial();
+
+  thrust::sequence(input.begin(), input.end(), size, -1); // strictly descending: min last, max first
+  check_matches_serial();
+
+  cuda::std::fill(policy, input.begin(), input.end(), T{42}); // all equal: first min, *last* max
+  check_matches_serial();
+
+  { // single element -> {first, first}
+    c2h::device_vector<T> one(1, T{7});
+    auto res = cuda::std::minmax_element(policy, one.begin(), one.end());
+    CHECK(res.first == one.begin());
+    CHECK(res.second == one.begin());
+  }
+}
+
+C2H_TEST("cuda::std::minmax_element(Iter, Iter)", "[parallel algorithm]", all_types)
+{
+  using T = typename c2h::get<0, TestType>;
+  c2h::device_vector<T> input(size, thrust::no_init);
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_minmax_element(policy, input);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_minmax_element(policy, input);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource);
+    test_minmax_element(policy, input);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy =
+      cuda::execution::gpu.with(cuda::get_stream, stream).with(cuda::mr::get_memory_resource, device_resource);
+    test_minmax_element(policy, input);
+  }
+}

--- a/thrust/benchmarks/bench/extrema/basic.cu
+++ b/thrust/benchmarks/bench/extrema/basic.cu
@@ -52,3 +52,16 @@ NVBENCH_BENCH_TYPES(max_element, NVBENCH_TYPE_AXES(fundamental_types))
   .set_name("max_element")
   .set_type_axes_names({"T{ct}"})
   .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));
+
+template <typename T>
+static void minmax_element(nvbench::state& state, nvbench::type_list<T> list)
+{
+  bench_extremum(state, list, [](auto&&... args) {
+    return thrust::minmax_element(args...);
+  });
+}
+
+NVBENCH_BENCH_TYPES(minmax_element, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("minmax_element")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));

--- a/thrust/benchmarks/bench/extrema/basic.cu
+++ b/thrust/benchmarks/bench/extrema/basic.cu
@@ -8,7 +8,7 @@
 #include "nvbench_helper.cuh"
 
 template <typename T, typename Func>
-static void bench_extremum(nvbench::state& state, nvbench::type_list<T>, Func func)
+static void bench_extremum(nvbench::state& state, nvbench::type_list<T>, Func func, std::size_t num_outputs = 1)
 {
   const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
 
@@ -18,7 +18,7 @@ static void bench_extremum(nvbench::state& state, nvbench::type_list<T>, Func fu
 
   state.add_element_count(elements);
   state.add_global_memory_reads<T>(elements);
-  state.add_global_memory_writes<offset_t>(1);
+  state.add_global_memory_writes<offset_t>(num_outputs);
 
   caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
@@ -50,5 +50,23 @@ static void max_element(nvbench::state& state, nvbench::type_list<T> list)
 
 NVBENCH_BENCH_TYPES(max_element, NVBENCH_TYPE_AXES(fundamental_types))
   .set_name("max_element")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));
+
+template <typename T>
+static void minmax_element(nvbench::state& state, nvbench::type_list<T> list)
+{
+  // minmax_element writes two iterators
+  bench_extremum(
+    state,
+    list,
+    [](auto&&... args) {
+      return thrust::minmax_element(args...);
+    },
+    2);
+}
+
+NVBENCH_BENCH_TYPES(minmax_element, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("minmax_element")
   .set_type_axes_names({"T{ct}"})
   .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));

--- a/thrust/benchmarks/bench/extrema/basic.cu
+++ b/thrust/benchmarks/bench/extrema/basic.cu
@@ -8,7 +8,7 @@
 #include "nvbench_helper.cuh"
 
 template <typename T, typename Func>
-static void bench_extremum(nvbench::state& state, nvbench::type_list<T>, Func func)
+static void bench_extremum(nvbench::state& state, nvbench::type_list<T>, Func func, std::size_t num_outputs = 1)
 {
   const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
 
@@ -18,7 +18,7 @@ static void bench_extremum(nvbench::state& state, nvbench::type_list<T>, Func fu
 
   state.add_element_count(elements);
   state.add_global_memory_reads<T>(elements);
-  state.add_global_memory_writes<offset_t>(1);
+  state.add_global_memory_writes<offset_t>(num_outputs);
 
   caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
@@ -56,9 +56,14 @@ NVBENCH_BENCH_TYPES(max_element, NVBENCH_TYPE_AXES(fundamental_types))
 template <typename T>
 static void minmax_element(nvbench::state& state, nvbench::type_list<T> list)
 {
-  bench_extremum(state, list, [](auto&&... args) {
-    return thrust::minmax_element(args...);
-  });
+  // minmax_element writes two iterators
+  bench_extremum(
+    state,
+    list,
+    [](auto&&... args) {
+      return thrust::minmax_element(args...);
+    },
+    2);
 }
 
 NVBENCH_BENCH_TYPES(minmax_element, NVBENCH_TYPE_AXES(fundamental_types))


### PR DESCRIPTION
## Description

Adds the `ExecutionPolicy` overload of `cuda::std::minmax_element` together with a CUDA backend, completing the `min_element` / `max_element` / `minmax_element` parallel algorithm family (the serial overload already existed).

**Implementation.** A single traversal of the range following the `thrust::extrema` approach: one `cub::DeviceReduce::TransformReduce` over a counting iterator, where each element enters the reduction as a `{value, value, index, index}` accumulator and a fused operator combines the min and max halves. Unlike thrust's operator, the max half prefers the larger index on ties, so a single pass directly yields the *first* minimum and *last* maximum required by the standard. The initial value is flagged with offset `-1` and loses against every element, avoiding the need for an identity value of `T` (requires `T` to be default-constructible, same as `ArgMin`'s empty-input path). For counts `<= INT_MAX` the accumulator carries 32 bit offsets, shrinking it by 8 bytes and selecting cub's 32 bit offset kernels. One allocation (scratch buffer plus result slot), one kernel launch, one synchronization.

**Benchmarks.** Adds `bench/minmax_element/basic.cu` mirroring the existing `min_element` benchmark, and the missing `minmax_element` entry in the thrust extrema benchmark for a same-harness comparison. On RTX 5070 at 2^28 elements: 1.39x/1.18x faster than `thrust::minmax_element` for 1/2 byte types, parity for 4/8 byte integer and F32 types, 0.76x for F64 (bound by `cub::DeviceReduce` default tuning versus thrust's own `ReduceAgent`; see PR discussion for details).

**Tests.** `pstl_minmax_element.cu` compares the parallel result positionally against the serial `cuda::std::minmax_element` reference computed on identical data. This stays correct under ties — e.g. `__nv_bfloat16`, where adjacent large values round to the same representation, so the *last* maximum is not at a fixed position — across `all_types`, all four policy configurations (default stream / provided stream / provided memory_resource / both), plus empty and single-element ranges.

Verified locally: **512 assertions / 8 test cases pass on RTX 5070 (sm_120, CUDA 13.3)**, plus a 2^31+ elements spot check exercising the 64 bit offset path; `clang-format` clean.

Related: #5160, #5592.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
