### PR TITLE
[cub] Fix `bugprone-branch-clone` error

### DIFF
--- a/cub/cub/agent/agent_merge.cuh
+++ b/cub/cub/agent/agent_merge.cuh
@@ -135,7 +135,7 @@ struct agent_t
     // number of keys per tile
     const int keys1_count_tile = static_cast<int>(keys1_end - keys1_beg);
     const int keys2_count_tile = static_cast<int>(keys2_end - keys2_beg);
-    if constexpr (IsFullTile)
+    if constexpr (IsFullTile) // NOLINT(bugprone-branch-clone)
     {
       _CCCL_ASSERT(keys1_count_tile + keys2_count_tile == items_per_tile, "");
     }


### PR DESCRIPTION
`clang-tidy` warns about those branches being identical, even tough they are not. I think this is because we run `clang-tidy` without assertions enabled, thus `_CCCL_ASSERT` expanding to `(void)0` in both branches