### PR TITLE
Pin NVTX to commit before upstream scope refactor

### DIFF
--- a/cmake/CCCLGetDependencies.cmake
+++ b/cmake/CCCLGetDependencies.cmake
@@ -103,7 +103,8 @@ macro(cccl_get_nvtx)
   CPMAddPackage(
     NAME NVTX
     GITHUB_REPOSITORY NVIDIA/NVTX
-    GIT_TAG release-v3
+    # We should track release-v3, but due to an upstream issue ('cpp-free-push-pop' merge (f46fccd4)), we pin it now:
+    GIT_TAG 38a82b957b97b0f111d4bc428b845a3588bbb639
     DOWNLOAD_ONLY ON
     SYSTEM ON
   )

--- a/cmake/CCCLGetDependencies.cmake
+++ b/cmake/CCCLGetDependencies.cmake
@@ -103,8 +103,8 @@ macro(cccl_get_nvtx)
   CPMAddPackage(
     NAME NVTX
     GITHUB_REPOSITORY NVIDIA/NVTX
-    # We should track release-v3, but due to an upstream issue ('cpp-free-push-pop' merge (f46fccd4)), we pin it now:
-    GIT_TAG 38a82b957b97b0f111d4bc428b845a3588bbb639
+    # We should track release-v3, but due to an upstream issue, we pin it now:
+    GIT_TAG 60587e3059c2e6a4d5c83f22c978715c98a5f1f8
     DOWNLOAD_ONLY ON
     SYSTEM ON
   )


### PR DESCRIPTION
## Problem

CUB test builds are failing across **all** GCC and Clang jobs (repo-wide, not tied to any specific PR) with a compile error inside the third-party NVTX header:

```
FAILED: cub/test/.../test_nvtx_in_usercode_explicit.cu.o
_deps/nvtx-src/c/include/nvtx3/nvtx3.hpp: error: no type named 'scope' in namespace 'nvtx3';
    did you mean '::nvtx3::v1::scope'?
```

## Root cause

`cmake/CCCLGetDependencies.cmake` tracked NVTX via the **moving `release-v3` branch**. On 2026-07-13, upstream `NVIDIA/NVTX@release-v3` received the `cpp-free-push-pop` merge (`f46fccd4`), which moved `nvtx3::scope` and broke compilation of `nvtx3.hpp`. Because the ref floats, fresh CI builds pull the broken NVTX and fail.

## Fix

Pin NVTX to `38a82b957` — the last `release-v3` commit **before** the breaking merge, verified to still define a working `nvtx3::scope`. This SHA should be bumped deliberately once upstream is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)