### PR TITLE
DeviceScan::InclusiveScan() accepts a `cuda::args::deferred`

### DIFF
--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -2336,7 +2336,7 @@ struct DeviceScan
   //! is assigned to ``*d_out``.
   //!
   //! .. versionadded:: 3.5.0
-  //!    First appears in CUDA Toolkit 13.4.
+  //!    First appears in CUDA Toolkit 13.5.
   //!
   //! - Supports non-commutative scan operators.
   //! - Results are not deterministic for pseudo-associative operators (e.g.,

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -2329,6 +2329,101 @@ struct DeviceScan
       d_in, d_out, scan_op, detail::InputValue<InitValueT>(init_value), num_items, env);
   }
 
+  //! @rst
+  //! Computes a device-wide inclusive prefix scan using the specified binary associative ``scan_op`` functor.
+  //! The result of applying the ``scan_op`` binary operator to ``init_value`` value and ``*d_in``
+  //! is assigned to ``*d_out``.
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! - Supports non-commutative scan operators.
+  //! - Results are not deterministic for pseudo-associative operators (e.g.,
+  //!   addition of floating-point types). Results for pseudo-associative
+  //!   operators may vary from run to run. Additional details can be found in
+  //!   the @lookback description.
+  //! - When ``d_in`` and ``d_out`` are equal, the scan is performed in-place. The
+  //!   range ``[d_in, d_in + num_items)`` and ``[d_out, d_out + num_items)``
+  //!   shall not overlap in any other way.
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates the inclusive prefix sum of an ``int`` device vector
+  //! with an initial value.
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_scan_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin inclusive-scan-init-env
+  //!     :end-before: example-end inclusive-scan-init-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading scan inputs @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Random-access output iterator type for writing scan outputs @iterator
+  //!
+  //! @tparam ScanOpT
+  //!   **[inferred]** Binary associative scan functor type having member `T operator()(const T &a, const T &b)`
+  //!
+  //! @tparam InitValueT
+  //!  **[inferred]** Type of the `init_value`
+  //!
+  //! @tparam InitValueIterT
+  //!  **[inferred]** Random-access iterator type used to access the initial value on device
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** An integral type representing the number of input elements
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Execution environment type providing stream, memory resource,
+  //!   or determinism requirements. Default is ``cuda::std::execution::env<>``.
+  //!
+  //! @param[in] d_in
+  //!   Random-access iterator to the input sequence of data items
+  //!
+  //! @param[out] d_out
+  //!   Random-access iterator to the output sequence of data items
+  //!
+  //! @param[in] scan_op
+  //!   Binary associative scan functor
+  //!
+  //! @param[in] init_value
+  //!   Initial value to seed the inclusive scan (`scan_op(init_value, d_in[0])`
+  //!   is assigned to `*d_out`), provided as future value
+  //!
+  //! @param[in] num_items
+  //!   Total number of input items (i.e., the length of `d_in`)
+  //!
+  //! @param[in] env
+  //!   @rst
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  //!   @endrst
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename ScanOpT,
+            typename InitValueT,
+            typename InitValueIterT,
+            typename NumItemsT,
+            typename EnvT                                                        = ::cuda::std::execution::env<>,
+            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t InclusiveScanInit(
+    InputIteratorT d_in,
+    OutputIteratorT d_out,
+    ScanOpT scan_op,
+    FutureValue<InitValueT, InitValueIterT> init_value,
+    NumItemsT num_items,
+    EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceScan::InclusiveScanInit");
+
+    return scan_impl_env<ForceInclusive::Yes>(
+      d_in, d_out, scan_op, detail::InputValue<InitValueT, InitValueIterT>(init_value), num_items, env);
+  }
+
   //! @}
 
   //! @name Scans by key

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -34,6 +34,7 @@
 #include <cuda/__stream/get_stream.h>
 #include <cuda/std/__execution/env.h>
 #include <cuda/std/__functional/invoke.h>
+#include <cuda/std/__iterator/concepts.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_null_pointer.h>
 #include <cuda/std/__type_traits/is_same.h>
@@ -2394,7 +2395,8 @@ struct DeviceScan
   //!
   //! @param[in] init_value
   //!   Initial value to seed the inclusive scan (`scan_op(init_value, d_in[0])`
-  //!   is assigned to `*d_out`), provided as deferred value
+  //!   is assigned to `*d_out`), provided as deferred value. The deferred value must model an
+  //!   iterator (i.e. the contained value should be dereferenceable to a value).
   //!
   //! @param[in] num_items
   //!   Total number of input items (i.e., the length of `d_in`)
@@ -2421,7 +2423,8 @@ struct DeviceScan
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceScan::InclusiveScanInit");
 
-    using __init_value_type = ::cuda::std::iter_value_t<InitValueIterT>;
+    static_assert(::cuda::std::indirectly_readable<InitValueIterT>, "The deferred value must model an iterator");
+    using __init_value_type = typename ::cuda::std::remove_cvref_t<decltype(init_value)>::__element_type;
 
     auto __fut = FutureValue<__init_value_type, InitValueIterT>{::cuda::args::__unwrap(init_value)};
 

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -2334,7 +2334,7 @@ struct DeviceScan
   //! The result of applying the ``scan_op`` binary operator to ``init_value`` value and ``*d_in``
   //! is assigned to ``*d_out``.
   //!
-  //! .. versionadded:: 3.4.0
+  //! .. versionadded:: 3.5.0
   //!    First appears in CUDA Toolkit 13.4.
   //!
   //! - Supports non-commutative scan operators.

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -2370,11 +2370,11 @@ struct DeviceScan
   //! @tparam ScanOpT
   //!   **[inferred]** Binary associative scan functor type having member `T operator()(const T &a, const T &b)`
   //!
-  //! @tparam InitValueT
-  //!  **[inferred]** Type of the `init_value`
-  //!
   //! @tparam InitValueIterT
   //!  **[inferred]** Random-access iterator type used to access the initial value on device
+  //!
+  //! @tparam InitValueBoundsT
+  //!  **[inferred]** Static bounds on `init_value`
   //!
   //! @tparam NumItemsT
   //!   **[inferred]** An integral type representing the number of input elements
@@ -2394,7 +2394,7 @@ struct DeviceScan
   //!
   //! @param[in] init_value
   //!   Initial value to seed the inclusive scan (`scan_op(init_value, d_in[0])`
-  //!   is assigned to `*d_out`), provided as future value
+  //!   is assigned to `*d_out`), provided as deferred value
   //!
   //! @param[in] num_items
   //!   Total number of input items (i.e., the length of `d_in`)
@@ -2407,7 +2407,7 @@ struct DeviceScan
             typename OutputIteratorT,
             typename ScanOpT,
             typename InitValueIterT,
-            typename InitValueBounds,
+            typename InitValueBoundsT,
             typename NumItemsT,
             typename EnvT                                                        = ::cuda::std::execution::env<>,
             ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
@@ -2415,7 +2415,7 @@ struct DeviceScan
     InputIteratorT d_in,
     OutputIteratorT d_out,
     ScanOpT scan_op,
-    const ::cuda::args::deferred<InitValueIterT, InitValueBounds>& init_value,
+    const ::cuda::args::deferred<InitValueIterT, InitValueBoundsT>& init_value,
     NumItemsT num_items,
     EnvT env = {})
   {

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -2355,8 +2355,8 @@ struct DeviceScan
   //! .. literalinclude:: ../../../cub/test/catch2_test_device_scan_env_api.cu
   //!     :language: c++
   //!     :dedent:
-  //!     :start-after: example-begin inclusive-scan-init-env
-  //!     :end-before: example-end inclusive-scan-init-env
+  //!     :start-after: example-begin inclusive-scan-future-init-env
+  //!     :end-before: example-end inclusive-scan-future-init-env
   //!
   //! @endrst
   //!

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -26,6 +26,7 @@
 #include <cub/device/dispatch/dispatch_scan_by_key.cuh>
 #include <cub/thread/thread_operators.cuh>
 
+#include <cuda/__argument/argument.h>
 #include <cuda/__execution/determinism.h>
 #include <cuda/__execution/require.h>
 #include <cuda/__execution/tune.h>
@@ -2405,8 +2406,8 @@ struct DeviceScan
   template <typename InputIteratorT,
             typename OutputIteratorT,
             typename ScanOpT,
-            typename InitValueT,
             typename InitValueIterT,
+            typename InitValueBounds,
             typename NumItemsT,
             typename EnvT                                                        = ::cuda::std::execution::env<>,
             ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
@@ -2414,14 +2415,18 @@ struct DeviceScan
     InputIteratorT d_in,
     OutputIteratorT d_out,
     ScanOpT scan_op,
-    FutureValue<InitValueT, InitValueIterT> init_value,
+    const ::cuda::args::deferred<InitValueIterT, InitValueBounds>& init_value,
     NumItemsT num_items,
     EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceScan::InclusiveScanInit");
 
+    using __init_value_type = ::cuda::std::iter_value_t<InitValueIterT>;
+
+    auto __fut = FutureValue<__init_value_type, InitValueIterT>{::cuda::args::__unwrap(init_value)};
+
     return scan_impl_env<ForceInclusive::Yes>(
-      d_in, d_out, scan_op, detail::InputValue<InitValueT, InitValueIterT>(init_value), num_items, env);
+      d_in, d_out, scan_op, detail::InputValue<__init_value_type, InitValueIterT>(__fut), num_items, env);
   }
 
   //! @}

--- a/cub/test/catch2_test_device_scan_env_api.cu
+++ b/cub/test/catch2_test_device_scan_env_api.cu
@@ -284,7 +284,7 @@ C2H_TEST("cub::DeviceScan::InclusiveScanInit with FutureValue accepts environmen
   auto output = thrust::device_vector<int>(4);
 
   auto init_value_vec = thrust::device_vector<int>{10};
-  auto future_init    = cub::FutureValue(init_value_vec.begin());
+  auto future_init    = cuda::args::deferred(init_value_vec.begin());
 
   auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
 

--- a/cub/test/catch2_test_device_scan_env_api.cu
+++ b/cub/test/catch2_test_device_scan_env_api.cu
@@ -276,6 +276,29 @@ C2H_TEST("cub::DeviceScan::InclusiveScanInit accepts environment", "[scan][env]"
   REQUIRE(output == expected);
 }
 
+C2H_TEST("cub::DeviceScan::InclusiveScanInit with FutureValue accepts environment", "[scan][env]")
+{
+  auto op     = cuda::std::plus{};
+  auto input  = thrust::device_vector<int>{1, 2, 3, 4};
+  auto output = thrust::device_vector<int>(4);
+
+  auto init_value_vec = thrust::device_vector<int>{10};
+  auto future_init    = cub::FutureValue(init_value_vec.begin());
+
+  auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
+
+  auto error = cub::DeviceScan::InclusiveScanInit(input.begin(), output.begin(), op, future_init, input.size(), env);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceScan::InclusiveScanInit (FutureValue) failed with status: " << error << '\n';
+  }
+
+  thrust::device_vector<int> expected{11, 13, 16, 20};
+
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(output == expected);
+}
+
 C2H_TEST("cub::DeviceScan::InclusiveScanInit accepts stream environment", "[scan][env]")
 {
   // example-begin inclusive-scan-init-env-stream

--- a/cub/test/catch2_test_device_scan_env_api.cu
+++ b/cub/test/catch2_test_device_scan_env_api.cu
@@ -276,7 +276,7 @@ C2H_TEST("cub::DeviceScan::InclusiveScanInit accepts environment", "[scan][env]"
   REQUIRE(output == expected);
 }
 
-C2H_TEST("cub::DeviceScan::InclusiveScanInit with FutureValue accepts environment", "[scan][env]")
+C2H_TEST("cub::DeviceScan::InclusiveScanInit with args::deferred accepts environment", "[scan][env]")
 {
   // example-begin inclusive-scan-future-init-env
   auto op     = cuda::std::plus{};

--- a/cub/test/catch2_test_device_scan_env_api.cu
+++ b/cub/test/catch2_test_device_scan_env_api.cu
@@ -278,6 +278,7 @@ C2H_TEST("cub::DeviceScan::InclusiveScanInit accepts environment", "[scan][env]"
 
 C2H_TEST("cub::DeviceScan::InclusiveScanInit with FutureValue accepts environment", "[scan][env]")
 {
+  // example-begin inclusive-scan-future-init-env
   auto op     = cuda::std::plus{};
   auto input  = thrust::device_vector<int>{1, 2, 3, 4};
   auto output = thrust::device_vector<int>(4);
@@ -294,6 +295,7 @@ C2H_TEST("cub::DeviceScan::InclusiveScanInit with FutureValue accepts environmen
   }
 
   thrust::device_vector<int> expected{11, 13, 16, 20};
+  // example-end inclusive-scan-future-init-env
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(output == expected);


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

`DeviceScan::ExclusiveScan()` accepts a `FutureValue`, `InclusiveScanInit()` should ~as well~ accept a `cuda::arg::deferred`.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
