### PR TITLE
Remove _CCCL_GRID_CONSTANT from merge sort kernel parameters

### DIFF
--- a/cub/cub/device/dispatch/kernels/kernel_merge_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_merge_sort.cuh
@@ -144,14 +144,14 @@ __launch_bounds__(
     KeyT,
     ValueT>::policy.threads_per_block)
   _CCCL_KERNEL_ATTRIBUTES void DeviceMergeSortBlockSortKernel(
-    _CCCL_GRID_CONSTANT const bool ping,
-    _CCCL_GRID_CONSTANT const KeyInputIteratorT keys_in,
-    _CCCL_GRID_CONSTANT const ValueInputIteratorT items_in,
-    _CCCL_GRID_CONSTANT const KeyIteratorT keys_out,
-    _CCCL_GRID_CONSTANT const ValueIteratorT items_out,
-    _CCCL_GRID_CONSTANT const OffsetT keys_count,
-    _CCCL_GRID_CONSTANT KeyT* const tmp_keys_out,
-    _CCCL_GRID_CONSTANT ValueT* const tmp_items_out,
+    const bool ping,
+    const KeyInputIteratorT keys_in,
+    const ValueInputIteratorT items_in,
+    const KeyIteratorT keys_out,
+    const ValueIteratorT items_out,
+    const OffsetT keys_count,
+    KeyT* const tmp_keys_out,
+    ValueT* const tmp_items_out,
     CompareOpT compare_op,
     vsmem_t vsmem)
 {
@@ -196,15 +196,15 @@ __launch_bounds__(
 
 template <typename KeyIteratorT, typename OffsetT, typename CompareOpT, typename KeyT>
 _CCCL_KERNEL_ATTRIBUTES void DeviceMergeSortPartitionKernel(
-  _CCCL_GRID_CONSTANT const bool ping,
-  _CCCL_GRID_CONSTANT const KeyIteratorT keys_ping,
-  _CCCL_GRID_CONSTANT KeyT* const keys_pong,
-  _CCCL_GRID_CONSTANT const OffsetT keys_count,
-  _CCCL_GRID_CONSTANT const OffsetT num_partitions,
-  _CCCL_GRID_CONSTANT OffsetT* const merge_partitions,
+  const bool ping,
+  const KeyIteratorT keys_ping,
+  KeyT* const keys_pong,
+  const OffsetT keys_count,
+  const OffsetT num_partitions,
+  OffsetT* const merge_partitions,
   CompareOpT compare_op,
-  _CCCL_GRID_CONSTANT const OffsetT target_merged_tiles_number,
-  _CCCL_GRID_CONSTANT const int items_per_tile)
+  const OffsetT target_merged_tiles_number,
+  const int items_per_tile)
 {
   const OffsetT partition_idx =
     static_cast<OffsetT>(blockDim.x * blockIdx.x + threadIdx.x); // NOLINT(bugprone-misplaced-widening-cast)
@@ -246,15 +246,15 @@ __launch_bounds__(
     KeyT,
     ValueT>::policy.threads_per_block)
   _CCCL_KERNEL_ATTRIBUTES void DeviceMergeSortMergeKernel(
-    _CCCL_GRID_CONSTANT const bool ping,
-    _CCCL_GRID_CONSTANT const KeyIteratorT keys_ping,
-    _CCCL_GRID_CONSTANT const ValueIteratorT items_ping,
-    _CCCL_GRID_CONSTANT const OffsetT keys_count,
-    _CCCL_GRID_CONSTANT KeyT* const keys_pong,
-    _CCCL_GRID_CONSTANT ValueT* const items_pong,
+    const bool ping,
+    const KeyIteratorT keys_ping,
+    const ValueIteratorT items_ping,
+    const OffsetT keys_count,
+    KeyT* const keys_pong,
+    ValueT* const items_pong,
     CompareOpT compare_op,
-    _CCCL_GRID_CONSTANT OffsetT* const merge_partitions,
-    _CCCL_GRID_CONSTANT const OffsetT target_merged_tiles_number,
+    OffsetT* const merge_partitions,
+    const OffsetT target_merged_tiles_number,
     vsmem_t vsmem)
 {
   using vsmem_adapted_agents = device_merge_sort_vsmem_helper_t<


### PR DESCRIPTION
This fixes observed regressions on `merge_sort_keys` and `merge_sort_pairs`

`merge_sort_keys`, B200

```
| T    | OffsetT | Elements | Entropy | 3.3.4 | 3.4.0 | 3.4.0-noGC | 3.4.0 vs 3.3.4 | 3.4.0-noGC vs 3.3.4 |
|------|---------|----------|---------|-------|-------|------------|----------------|---------------------|
| I8   | I32     |     2^24 |   1.000 | 0.71% | 0.70% |      0.71% |  -2.31% 🔴 SLOW |       -0.01% 🔵 SAME |
| I8   | I32     |     2^24 |   0.201 | 0.76% | 0.74% |      0.76% |  -2.14% 🔴 SLOW |       -0.01% 🔵 SAME |
| I8   | I32     |     2^28 |   1.000 | 0.72% | 0.69% |      0.72% |  -3.58% 🔴 SLOW |       -0.01% 🔵 SAME |
| I8   | I32     |     2^28 |   0.201 | 0.76% | 0.74% |      0.76% |  -3.54% 🔴 SLOW |       +0.01% 🔵 SAME |
| I8   | I64     |     2^24 |   1.000 | 0.70% | 0.68% |      0.70% |  -2.16% 🔴 SLOW |       -0.00% 🔵 SAME |
| I8   | I64     |     2^24 |   0.201 | 0.74% | 0.72% |      0.74% |  -2.14% 🔴 SLOW |       +0.00% 🔵 SAME |
| I8   | I64     |     2^28 |   1.000 | 0.70% | 0.68% |      0.70% |  -3.38% 🔴 SLOW |       +0.01% 🔵 SAME |
| I8   | I64     |     2^28 |   0.201 | 0.75% | 0.72% |      0.75% |  -3.84% 🔴 SLOW |       +0.01% 🔵 SAME |
| I16  | I32     |     2^24 |   1.000 | 1.36% | 1.31% |      1.36% |  -3.66% 🔴 SLOW |       -0.01% 🔵 SAME |
| I16  | I32     |     2^24 |   0.201 | 1.47% | 1.42% |      1.48% |  -3.93% 🔴 SLOW |       +0.28% 🟢 FAST |
| I16  | I32     |     2^28 |   1.000 | 1.33% | 1.25% |      1.33% |  -6.62% 🔴 SLOW |       -0.02% 🔵 SAME |
| I16  | I32     |     2^28 |   0.201 | 1.52% | 1.41% |      1.52% |  -7.65% 🔴 SLOW |       -0.02% 🔵 SAME |
| I16  | I64     |     2^24 |   1.000 | 1.33% | 1.28% |      1.33% |  -3.58% 🔴 SLOW |       +0.02% 🔵 SAME |
| I16  | I64     |     2^24 |   0.201 | 1.42% | 1.39% |      1.42% |  -2.08% 🔴 SLOW |       +0.21% 🟢 FAST |
| I16  | I64     |     2^28 |   1.000 | 1.29% | 1.22% |      1.29% |  -5.67% 🔴 SLOW |       -0.03% 🔵 SAME |
| I16  | I64     |     2^28 |   0.201 | 1.45% | 1.38% |      1.45% |  -4.64% 🔴 SLOW |       -0.03% 🔵 SAME |
| I32  | I32     |     2^24 |   1.000 | 2.58% | 2.42% |      2.58% |  -6.11% 🔴 SLOW |       -0.09% 🔵 SAME |
| I32  | I32     |     2^24 |   0.201 | 2.86% | 2.65% |      2.86% |  -7.34% 🔴 SLOW |       -0.11% 🔵 SAME |
| I32  | I32     |     2^28 |   1.000 | 2.77% | 2.63% |      2.77% |  -5.27% 🔴 SLOW |       -0.01% 🔵 SAME |
| I32  | I32     |     2^28 |   0.201 | 3.23% | 2.96% |      3.23% |  -8.45% 🔴 SLOW |       +0.03% 🔵 SAME |
| I32  | I64     |     2^24 |   1.000 | 2.56% | 2.42% |      2.56% |  -5.45% 🔴 SLOW |       +0.09% 🔵 SAME |
| I32  | I64     |     2^24 |   0.201 | 2.76% | 2.62% |      2.75% |  -4.97% 🔴 SLOW |       -0.18% 🔴 SLOW |
| I32  | I64     |     2^28 |   1.000 | 2.72% | 2.59% |      2.72% |  -4.76% 🔴 SLOW |       +0.01% 🔵 SAME |
| I32  | I64     |     2^28 |   0.201 | 3.07% | 2.91% |      3.07% |  -5.26% 🔴 SLOW |       +0.02% 🔵 SAME |
| I64  | I32     |     2^24 |   1.000 | 2.39% | 2.37% |      2.39% |  -1.06% 🔴 SLOW |       +0.04% 🔵 SAME |
| I64  | I32     |     2^24 |   0.201 | 2.27% | 2.24% |      2.27% |  -1.26% 🔴 SLOW |       -0.03% 🔵 SAME |
| I64  | I32     |     2^28 |   1.000 | 2.26% | 2.21% |      2.26% |  -2.09% 🔴 SLOW |       -0.02% 🔵 SAME |
| I64  | I32     |     2^28 |   0.201 | 2.14% | 2.10% |      2.13% |  -1.77% 🔴 SLOW |       -0.02% 🔵 SAME |
| I64  | I64     |     2^24 |   1.000 | 2.39% | 2.36% |      2.39% |  -1.47% 🔴 SLOW |       -0.04% 🔵 SAME |
| I64  | I64     |     2^24 |   0.201 | 2.26% | 2.23% |      2.26% |  -1.33% 🔴 SLOW |       -0.04% 🔵 SAME |
| I64  | I64     |     2^28 |   1.000 | 2.25% | 2.20% |      2.25% |  -1.94% 🔴 SLOW |       +0.03% 🔵 SAME |
| I64  | I64     |     2^28 |   0.201 | 2.13% | 2.09% |      2.13% |  -1.78% 🔴 SLOW |       +0.02% 🔵 SAME |
| I128 | I32     |     2^24 |   1.000 | 2.25% | 2.17% |      2.24% |  -3.35% 🔴 SLOW |       -0.08% 🔵 SAME |
| I128 | I32     |     2^24 |   0.201 | 2.31% | 2.27% |      2.31% |  -1.72% 🔴 SLOW |       -0.01% 🔵 SAME |
| I128 | I32     |     2^28 |   1.000 | 1.97% | 1.92% |      1.97% |  -2.51% 🔴 SLOW |       -0.01% 🔵 SAME |
| I128 | I32     |     2^28 |   0.201 | 2.09% | 2.05% |      2.09% |  -1.70% 🔴 SLOW |       -0.01% 🔵 SAME |
| I128 | I64     |     2^24 |   1.000 | 2.24% | 2.23% |      2.24% |  -0.27% 🔴 SLOW |       -0.06% 🔵 SAME |
| I128 | I64     |     2^24 |   0.201 | 2.30% | 2.30% |      2.30% |  -0.00% 🔵 SAME |       -0.04% 🔵 SAME |
| I128 | I64     |     2^28 |   1.000 | 1.96% | 1.95% |      1.96% |  -0.57% 🔴 SLOW |       -0.01% 🔴 SLOW |
| I128 | I64     |     2^28 |   0.201 | 2.08% | 2.07% |      2.08% |  -0.09% 🔴 SLOW |       -0.00% 🔵 SAME |
| F32  | I32     |     2^24 |   1.000 | 2.58% | 2.42% |      2.58% |  -6.08% 🔴 SLOW |       +0.11% 🔵 SAME |
| F32  | I32     |     2^24 |   0.201 | 2.85% | 2.64% |      2.85% |  -7.44% 🔴 SLOW |       -0.04% 🔵 SAME |
| F32  | I32     |     2^28 |   1.000 | 2.77% | 2.63% |      2.77% |  -5.25% 🔴 SLOW |       +0.05% 🔵 SAME |
| F32  | I32     |     2^28 |   0.201 | 3.23% | 2.96% |      3.23% |  -8.39% 🔴 SLOW |       +0.02% 🔵 SAME |
| F32  | I64     |     2^24 |   1.000 | 2.56% | 2.41% |      2.56% |  -5.70% 🔴 SLOW |       -0.03% 🔵 SAME |
| F32  | I64     |     2^24 |   0.201 | 2.75% | 2.61% |      2.75% |  -4.92% 🔴 SLOW |       -0.01% 🔵 SAME |
| F32  | I64     |     2^28 |   1.000 | 2.72% | 2.59% |      2.72% |  -4.83% 🔴 SLOW |       -0.01% 🔵 SAME |
| F32  | I64     |     2^28 |   0.201 | 3.07% | 2.91% |      3.07% |  -5.17% 🔴 SLOW |       +0.02% 🔵 SAME |
| F64  | I32     |     2^24 |   1.000 | 2.40% | 2.36% |      2.39% |  -1.63% 🔴 SLOW |       -0.48% 🔴 SLOW |
| F64  | I32     |     2^24 |   0.201 | 2.30% | 2.27% |      2.29% |  -1.19% 🔴 SLOW |       -0.03% 🔵 SAME |
| F64  | I32     |     2^28 |   1.000 | 2.27% | 2.22% |      2.27% |  -1.99% 🔴 SLOW |       +0.02% 🔵 SAME |
| F64  | I32     |     2^28 |   0.201 | 2.14% | 2.11% |      2.14% |  -1.76% 🔴 SLOW |       +0.02% 🔵 SAME |
| F64  | I64     |     2^24 |   1.000 | 2.40% | 2.36% |      2.38% |  -1.74% 🔴 SLOW |       -0.75% 🔴 SLOW |
| F64  | I64     |     2^24 |   0.201 | 2.29% | 2.26% |      2.29% |  -1.20% 🔴 SLOW |       +0.06% 🔵 SAME |
| F64  | I64     |     2^28 |   1.000 | 2.26% | 2.21% |      2.26% |  -1.96% 🔴 SLOW |       +0.01% 🔵 SAME |
| F64  | I64     |     2^28 |   0.201 | 2.14% | 2.10% |      2.14% |  -1.86% 🔴 SLOW |       -0.02% 🔵 SAME |
| C32  | I32     |     2^24 |   1.000 | 0.80% | 0.80% |      0.80% |  +0.10% 🔵 SAME |       -0.00% 🔵 SAME |
| C32  | I32     |     2^24 |   0.201 | 0.55% | 0.55% |      0.55% |  -0.32% 🔴 SLOW |       +0.03% 🔵 SAME |
| C32  | I32     |     2^28 |   1.000 | 0.68% | 0.68% |      0.68% |  +0.12% 🟢 FAST |       -0.00% 🔵 SAME |
| C32  | I32     |     2^28 |   0.201 | 0.54% | 0.54% |      0.54% |  -0.34% 🔴 SLOW |       +0.00% 🔵 SAME |
| C32  | I64     |     2^24 |   1.000 | 0.81% | 0.81% |      0.81% |  -0.42% 🔴 SLOW |       -0.03% 🔵 SAME |
| C32  | I64     |     2^24 |   0.201 | 0.55% | 0.55% |      0.55% |  +0.26% 🟢 FAST |       -0.00% 🔵 SAME |
| C32  | I64     |     2^28 |   1.000 | 0.69% | 0.69% |      0.69% |  -0.47% 🔴 SLOW |       +0.00% 🔵 SAME |
| C32  | I64     |     2^28 |   0.201 | 0.54% | 0.54% |      0.54% |  +0.19% 🟢 FAST |       -0.00% 🔵 SAME |
```

`merge_sort_pairs`, B200

```
| KeyT | ValueT | OffsetT | Elements | Entropy | 3.3.4 | 3.4.0 | 3.4.0-noGC | 3.4.0 vs 3.3.4 | 3.4.0-noGC vs 3.3.4 |
|------|--------|---------|----------|---------|-------|-------|------------|----------------|---------------------|
| I8   | I32    | I32     |     2^24 |   1.000 | 1.99% | 1.87% |      1.99% |  -5.94% 🔴 SLOW |       -0.05% 🔵 SAME |
| I8   | I32    | I32     |     2^24 |   0.201 | 2.14% | 2.00% |      2.14% |  -6.44% 🔴 SLOW |       -0.00% 🔵 SAME |
| I8   | I32    | I32     |     2^28 |   1.000 | 1.92% | 1.78% |      1.92% |  -7.43% 🔴 SLOW |       +0.03% 🟢 FAST |
| I8   | I32    | I32     |     2^28 |   0.201 | 2.05% | 1.89% |      2.05% |  -8.13% 🔴 SLOW |       +0.04% 🟢 FAST |
| I8   | I64    | I32     |     2^24 |   1.000 | 2.61% | 2.47% |      2.61% |  -5.09% 🔴 SLOW |       +0.05% 🔵 SAME |
| I8   | I64    | I32     |     2^24 |   0.201 | 2.81% | 2.62% |      2.81% |  -6.80% 🔴 SLOW |       +0.02% 🔵 SAME |
| I8   | I64    | I32     |     2^28 |   1.000 | 2.40% | 2.26% |      2.40% |  -5.86% 🔴 SLOW |       -0.01% 🔵 SAME |
| I8   | I64    | I32     |     2^28 |   0.201 | 2.60% | 2.38% |      2.60% |  -8.46% 🔴 SLOW |       +0.00% 🔵 SAME |
| I32  | I32    | I32     |     2^24 |   1.000 | 3.07% | 2.87% |      3.07% |  -6.42% 🔴 SLOW |       +0.00% 🔵 SAME |
| I32  | I32    | I32     |     2^24 |   0.201 | 3.32% | 3.08% |      3.32% |  -7.23% 🔴 SLOW |       +0.11% 🔵 SAME |
| I32  | I32    | I32     |     2^28 |   1.000 | 2.88% | 2.68% |      2.88% |  -7.05% 🔴 SLOW |       +0.00% 🔵 SAME |
| I32  | I32    | I32     |     2^28 |   0.201 | 3.24% | 2.96% |      3.24% |  -8.63% 🔴 SLOW |       +0.01% 🔵 SAME |
| I32  | I64    | I32     |     2^24 |   1.000 | 3.30% | 3.15% |      3.31% |  -4.56% 🔴 SLOW |       +0.04% 🔵 SAME |
| I32  | I64    | I32     |     2^24 |   0.201 | 3.58% | 3.36% |      3.58% |  -6.25% 🔴 SLOW |       -0.06% 🔵 SAME |
| I32  | I64    | I32     |     2^28 |   1.000 | 2.98% | 2.85% |      2.98% |  -4.27% 🔴 SLOW |       -0.01% 🔵 SAME |
| I32  | I64    | I32     |     2^28 |   0.201 | 3.32% | 3.09% |      3.32% |  -7.08% 🔴 SLOW |       -0.04% 🔴 SLOW |
| I64  | I32    | I32     |     2^24 |   1.000 | 2.87% | 2.82% |      2.88% |  -1.86% 🔴 SLOW |       +0.09% 🟢 FAST |
| I64  | I32    | I32     |     2^24 |   0.201 | 2.69% | 2.63% |      2.69% |  -2.20% 🔴 SLOW |       +0.12% 🟢 FAST |
| I64  | I32    | I32     |     2^28 |   1.000 | 2.63% | 2.58% |      2.63% |  -1.88% 🔴 SLOW |       +0.00% 🔵 SAME |
| I64  | I32    | I32     |     2^28 |   0.201 | 2.45% | 2.38% |      2.45% |  -2.75% 🔴 SLOW |       +0.02% 🔵 SAME |
| I64  | I64    | I32     |     2^24 |   1.000 | 3.11% | 3.06% |      3.11% |  -1.46% 🔴 SLOW |       +0.06% 🟢 FAST |
| I64  | I64    | I32     |     2^24 |   0.201 | 2.86% | 2.81% |      2.86% |  -1.57% 🔴 SLOW |       +0.08% 🟢 FAST |
| I64  | I64    | I32     |     2^28 |   1.000 | 2.79% | 2.74% |      2.79% |  -1.57% 🔴 SLOW |       +0.01% 🔵 SAME |
| I64  | I64    | I32     |     2^28 |   0.201 | 2.54% | 2.50% |      2.54% |  -1.83% 🔴 SLOW |       +0.01% 🟢 FAST |
| F32  | I32    | I32     |     2^24 |   1.000 | 3.06% | 2.86% |      3.06% |  -6.29% 🔴 SLOW |       +0.12% 🟢 FAST |
| F32  | I32    | I32     |     2^24 |   0.201 | 3.31% | 3.07% |      3.31% |  -7.21% 🔴 SLOW |       +0.06% 🔵 SAME |
| F32  | I32    | I32     |     2^28 |   1.000 | 2.87% | 2.67% |      2.87% |  -7.00% 🔴 SLOW |       +0.02% 🔵 SAME |
| F32  | I32    | I32     |     2^28 |   0.201 | 3.23% | 2.95% |      3.23% |  -8.59% 🔴 SLOW |       +0.01% 🔵 SAME |
| F32  | I64    | I32     |     2^24 |   1.000 | 3.30% | 3.15% |      3.30% |  -4.62% 🔴 SLOW |       -0.04% 🔵 SAME |
| F32  | I64    | I32     |     2^24 |   0.201 | 3.57% | 3.36% |      3.57% |  -6.07% 🔴 SLOW |       -0.00% 🔵 SAME |
| F32  | I64    | I32     |     2^28 |   1.000 | 2.97% | 2.85% |      2.97% |  -4.23% 🔴 SLOW |       -0.03% 🔴 SLOW |
| F32  | I64    | I32     |     2^28 |   0.201 | 3.32% | 3.08% |      3.32% |  -6.97% 🔴 SLOW |       +0.04% 🟢 FAST |
```
