### PR TITLE
[DRAFT] Adds latency-optimized, redux-based reduce-then-scan algorithm

### DIFF
--- a/cub/cub/block/block_scan.cuh
+++ b/cub/cub/block/block_scan.cuh
@@ -19,6 +19,7 @@
 #endif // no system header
 
 #include <cub/block/specializations/block_scan_raking.cuh>
+#include <cub/block/specializations/block_scan_warp_reduce_then_scan.cuh>
 #include <cub/block/specializations/block_scan_warp_scans.cuh>
 #include <cub/util_ptx.cuh>
 #include <cub/util_type.cuh>
@@ -100,6 +101,30 @@ enum BlockScanAlgorithm
   //!
   //! @endrst
   BLOCK_SCAN_WARP_SCANS,
+
+  //! @rst
+  //! Overview
+  //! ++++++++++++++++++++++++++
+  //!
+  //! A warp-granularity "reduce-then-scan" variant of :cpp:enumerator:`cub::BLOCK_SCAN_WARP_SCANS`
+  //! (which is scan-then-propagate): each warp first *reduces* its inputs to the warp aggregate
+  //! using the single-instruction ``redux.sync`` warp reduction, the aggregates are folded into
+  //! warp prefixes, and only then do the warps scan. Applies whenever the scan operator and data
+  //! type are supported by ``redux.sync`` (integer sum/min/max and bitwise operations on types of
+  //! at most 4 bytes, sm_80+; results are identical). The block-wide barrier then releases as soon as the reductions
+  //! complete, the cross-warp aggregate fold overlaps the warp scans, and — most importantly — a
+  //! ``BlockPrefixCallbackOp`` is invoked one warp-scan earlier, its latency hidden under the
+  //! other warps' scans.
+  //!
+  //! Performance Considerations
+  //! ++++++++++++++++++++++++++
+  //!
+  //! - Latency-oriented: minimizes the time until the block aggregate / block prefix callback
+  //!   is available. Chosen for latency-critical (few resident blocks) usage; the extra warp
+  //!   reduction may slightly reduce throughput at full occupancy.
+  //! - For unsupported operators/types, and on architectures without ``redux.sync``, all
+  //!   methods fall back to the classic :cpp:enumerator:`cub::BLOCK_SCAN_WARP_SCANS` code paths.
+  BLOCK_SCAN_WARP_REDUCE_THEN_SCAN,
 };
 
 #if _CCCL_HOSTED() && !defined(_CCCL_DOXYGEN_INVOKED)
@@ -115,6 +140,8 @@ namespace detail
       return "BLOCK_SCAN_RAKING_MEMOIZE";
     case BLOCK_SCAN_WARP_SCANS:
       return "BLOCK_SCAN_WARP_SCANS";
+    case BLOCK_SCAN_WARP_REDUCE_THEN_SCAN:
+      return "BLOCK_SCAN_WARP_REDUCE_THEN_SCAN";
   }
   return "<unknown BlockScanAlgorithm>";
 }
@@ -165,6 +192,10 @@ CUB_NAMESPACE_BEGIN
 //!      register pressure for intermediate storage.
 //!   #. :cpp:enumerator:`cub::BLOCK_SCAN_WARP_SCANS`:
 //!      A quick (low latency) "tiled warpscans" prefix scan algorithm.
+//!   #. :cpp:enumerator:`cub::BLOCK_SCAN_WARP_REDUCE_THEN_SCAN`:
+//!      A warp-granularity "reduce-then-scan" variant that minimizes the latency until the block aggregate
+//!      (and any block prefix callback) is available, using hardware warp reductions where
+//!      supported.
 //!
 //! Performance Considerations
 //! +++++++++++++++++++++++++++++++++++++++++++++
@@ -242,16 +273,21 @@ private:
    * architectural warp size.
    */
   static constexpr BlockScanAlgorithm SAFE_ALGORITHM =
-    ((Algorithm == BLOCK_SCAN_WARP_SCANS) && (BLOCK_THREADS % detail::warp_threads != 0))
+    ((Algorithm == BLOCK_SCAN_WARP_SCANS || Algorithm == BLOCK_SCAN_WARP_REDUCE_THEN_SCAN)
+     && (BLOCK_THREADS % detail::warp_threads != 0))
       ? BLOCK_SCAN_RAKING
       : Algorithm;
 
-  using WarpScans = detail::BlockScanWarpScans<T, BlockDimX, BlockDimY, BlockDimZ>;
+  using WarpScans          = detail::BlockScanWarpScans<T, BlockDimX, BlockDimY, BlockDimZ>;
+  using WarpReduceThenScan = detail::BlockScanWarpReduceThenScan<T, BlockDimX, BlockDimY, BlockDimZ>;
   using Raking =
     detail::BlockScanRaking<T, BlockDimX, BlockDimY, BlockDimZ, (SAFE_ALGORITHM == BLOCK_SCAN_RAKING_MEMOIZE)>;
 
   /// Define the delegate type for the desired algorithm
-  using InternalBlockScan = ::cuda::std::_If<SAFE_ALGORITHM == BLOCK_SCAN_WARP_SCANS, WarpScans, Raking>;
+  using InternalBlockScan =
+    ::cuda::std::_If<SAFE_ALGORITHM == BLOCK_SCAN_WARP_SCANS,
+                     WarpScans,
+                     ::cuda::std::_If<SAFE_ALGORITHM == BLOCK_SCAN_WARP_REDUCE_THEN_SCAN, WarpReduceThenScan, Raking>>;
 
   /// Shared memory storage layout type for BlockScan
   using _TempStorage = typename InternalBlockScan::TempStorage;

--- a/cub/cub/block/specializations/block_scan_warp_reduce_then_scan.cuh
+++ b/cub/cub/block/specializations/block_scan_warp_reduce_then_scan.cuh
@@ -1,0 +1,295 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3
+
+/**
+ * @file
+ * cub::detail::BlockScanWarpReduceThenScan provides a warp-granularity "reduce-then-scan" parallel
+ * prefix scan across a CUDA thread block, optimized for the latency until the block aggregate (and therefore a block
+ * prefix callback) becomes available.
+ */
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/block/specializations/block_scan_warp_scans.cuh>
+#include <cub/detail/uninitialized_copy.cuh>
+#include <cub/warp/specializations/warp_redux.cuh>
+
+CUB_NAMESPACE_BEGIN
+namespace detail
+{
+/**
+ * @brief BlockScanWarpReduceThenScan provides a warp-granularity reduce-then-scan variant of
+ *        the warpscans-based parallel prefix scan across a CUDA thread block: each warp first
+ *        REDUCES its inputs to the warp aggregate (hardware `redux.sync` where supported),
+ *        the aggregates are folded into warp prefixes, and only then do the warps scan.
+ *
+ * In the classic warpscans algorithm the warp aggregate is the *last* output of each warp's
+ * shuffle-scan chain, so the block-wide barrier releases only after the slowest warp's full
+ * scan, the cross-warp aggregate fold runs as a serial tail, and a block prefix callback (e.g.
+ * the decoupled look-back's partial promotion) is invoked last. When the (scan_op, T) pair is
+ * supported by the `redux.sync` instruction (see `is_warp_redux_op_supported`), the warp
+ * aggregate can instead be produced in a single instruction *before* the warp scans: the
+ * barrier releases as soon as the reductions complete, the aggregate fold overlaps the shuffle
+ * chains, and the prefix callback is invoked by warp 0 while the other warps are still
+ * scanning — its (global-memory) latency hides in their shadow.
+ *
+ * Results are identical to BlockScanWarpScans: eligibility is restricted to associative,
+ * commutative integer operators for which the redux-computed aggregate is bit-exact.
+ * For unsupported operators/types, and on architectures without `redux.sync` (< sm_80), all
+ * methods compile to / fall back to the classic BlockScanWarpScans code paths.
+ *
+ * @tparam BlockDimX
+ *   The thread block length in threads along the X dimension
+ *
+ * @tparam BlockDimY
+ *   The thread block length in threads along the Y dimension
+ *
+ * @tparam BlockDimZ
+ *   The thread block length in threads along the Z dimension
+ */
+template <typename T, int BlockDimX, int BlockDimY, int BlockDimZ>
+struct BlockScanWarpReduceThenScan : BlockScanWarpScans<T, BlockDimX, BlockDimY, BlockDimZ>
+{
+  using Base = BlockScanWarpScans<T, BlockDimX, BlockDimY, BlockDimZ>;
+  using Base::BLOCK_THREADS;
+  using Base::WARP_THREADS;
+  using typename Base::TempStorage;
+  using WarpScanT = typename Base::WarpScanT;
+
+  static_assert(BlockDimX * BlockDimY * BlockDimZ % warp_threads == 0,
+                "BlockScanWarpReduceThenScan requires the block size to be a multiple of the warp size "
+                "(enforced by BlockScan's SAFE_ALGORITHM fallback)");
+
+  /// Constructor
+  _CCCL_DEVICE _CCCL_FORCEINLINE BlockScanWarpReduceThenScan(TempStorage& temp_storage)
+      : Base(temp_storage)
+  {}
+
+  //---------------------------------------------------------------------
+  // Reduce-then-scan core
+  //---------------------------------------------------------------------
+
+  /**
+   * @brief Produces this warp's aggregate via `redux.sync`, publishes it, and folds all warp
+   *        aggregates into the calling warp's prefix and the block aggregate — all BEFORE any
+   *        warp scan has run. Returns false when `redux.sync` is unavailable at run time
+   *        (pre-sm_80 code paths), in which case the caller must take the classic path.
+   *
+   * @param[out] warp_prefix  Prefix of all preceding warps' aggregates; valid for warp_id != 0
+   * @param[out] block_aggregate  Block-wide aggregate reduction of input items
+   */
+  template <typename ScanOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE bool
+  ReduceThenFoldAggregates(T input, ScanOp scan_op, T& warp_prefix, T& block_aggregate)
+  {
+    if (const auto warp_aggregate = detail::warp_redux(input, 0xffffffffu, scan_op))
+    {
+      if (this->lane_id == 0)
+      {
+        detail::uninitialized_copy_single(this->temp_storage.warp_aggregates + this->warp_id, *warp_aggregate);
+      }
+      __syncthreads(); // releases as soon as the reductions complete, not the scans
+
+      block_aggregate = this->temp_storage.warp_aggregates[0];
+      this->ApplyWarpAggregates(warp_prefix, scan_op, block_aggregate, constant_v<1>);
+      return true;
+    }
+    return false;
+  }
+
+  //---------------------------------------------------------------------
+  // Exclusive scans
+  //---------------------------------------------------------------------
+
+  /// Computes an exclusive thread block-wide prefix scan. With no initial value, the output
+  /// computed for thread0 is undefined.
+  template <typename ScanOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void ExclusiveScan(T input, T& exclusive_output, ScanOp scan_op)
+  {
+    T block_aggregate;
+    ExclusiveScan(input, exclusive_output, scan_op, block_aggregate);
+  }
+
+  /// Computes an exclusive thread block-wide prefix scan seeded with @p initial_value.
+  template <typename ScanOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void ExclusiveScan(T input, T& exclusive_output, const T& initial_value, ScanOp scan_op)
+  {
+    T block_aggregate;
+    ExclusiveScan(input, exclusive_output, initial_value, scan_op, block_aggregate);
+  }
+
+  /// Computes an exclusive thread block-wide prefix scan; also provides every thread with the
+  /// block-wide @p block_aggregate of all inputs. With no initial value, the output computed
+  /// for thread0 is undefined.
+  template <typename ScanOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void ExclusiveScan(T input, T& exclusive_output, ScanOp scan_op, T& block_aggregate)
+  {
+    if constexpr (detail::is_warp_redux_op_supported<ScanOp, T>)
+    {
+      T warp_prefix;
+      if (ReduceThenFoldAggregates(input, scan_op, warp_prefix, block_aggregate))
+      {
+        T inclusive_output;
+        WarpScanT(this->temp_storage.warp_scan[this->warp_id]).Scan(input, inclusive_output, exclusive_output, scan_op);
+        if (this->warp_id != 0)
+        {
+          exclusive_output = scan_op(warp_prefix, exclusive_output);
+          if (this->lane_id == 0)
+          {
+            exclusive_output = warp_prefix;
+          }
+        }
+        return;
+      }
+    }
+    Base::ExclusiveScan(input, exclusive_output, scan_op, block_aggregate);
+  }
+
+  /// Computes an exclusive thread block-wide prefix scan seeded with @p initial_value; also
+  /// provides every thread with the block-wide @p block_aggregate of all inputs.
+  template <typename ScanOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void
+  ExclusiveScan(T input, T& exclusive_output, const T& initial_value, ScanOp scan_op, T& block_aggregate)
+  {
+    if constexpr (detail::is_warp_redux_op_supported<ScanOp, T>)
+    {
+      T warp_prefix;
+      if (ReduceThenFoldAggregates(input, scan_op, warp_prefix, block_aggregate))
+      {
+        const T prefix = (this->warp_id == 0) ? initial_value : scan_op(initial_value, warp_prefix);
+
+        T inclusive_output;
+        WarpScanT(this->temp_storage.warp_scan[this->warp_id]).Scan(input, inclusive_output, exclusive_output, scan_op);
+        exclusive_output = scan_op(prefix, exclusive_output);
+        if (this->lane_id == 0)
+        {
+          exclusive_output = prefix;
+        }
+        return;
+      }
+    }
+    Base::ExclusiveScan(input, exclusive_output, initial_value, scan_op, block_aggregate);
+  }
+
+  /// Computes an exclusive thread block-wide prefix scan; the call-back functor is invoked by
+  /// the first warp with the block aggregate, and the value returned by lane0 seeds the scan.
+  /// This is the aggregate-first sweet spot: the callback (e.g. a decoupled look-back) runs one
+  /// warp-scan earlier and its latency overlaps all warps' shuffle scans.
+  template <typename ScanOp, typename BlockPrefixCallbackOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void
+  ExclusiveScan(T input, T& exclusive_output, ScanOp scan_op, BlockPrefixCallbackOp& block_prefix_callback_op)
+  {
+    if constexpr (detail::is_warp_redux_op_supported<ScanOp, T>)
+    {
+      T warp_prefix;
+      T block_aggregate;
+      if (ReduceThenFoldAggregates(input, scan_op, warp_prefix, block_aggregate))
+      {
+        // warp 0 runs the callback immediately; warps 1..N scan in its shadow
+        if (this->warp_id == 0)
+        {
+          T block_prefix = block_prefix_callback_op(block_aggregate);
+          if (this->lane_id == 0)
+          {
+            detail::uninitialized_copy_single(&this->temp_storage.block_prefix, block_prefix);
+          }
+        }
+
+        T inclusive_output;
+        WarpScanT(this->temp_storage.warp_scan[this->warp_id]).Scan(input, inclusive_output, exclusive_output, scan_op);
+        __syncthreads();
+
+        const T block_prefix = this->temp_storage.block_prefix;
+        const T prefix       = (this->warp_id == 0) ? block_prefix : scan_op(block_prefix, warp_prefix);
+        exclusive_output     = scan_op(prefix, exclusive_output);
+        if (this->lane_id == 0)
+        {
+          exclusive_output = prefix;
+        }
+        return;
+      }
+    }
+    Base::ExclusiveScan(input, exclusive_output, scan_op, block_prefix_callback_op);
+  }
+
+  //---------------------------------------------------------------------
+  // Inclusive scans
+  //---------------------------------------------------------------------
+
+  /// Computes an inclusive thread block-wide prefix scan.
+  template <typename ScanOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void InclusiveScan(T input, T& inclusive_output, ScanOp scan_op)
+  {
+    T block_aggregate;
+    InclusiveScan(input, inclusive_output, scan_op, block_aggregate);
+  }
+
+  /// Computes an inclusive thread block-wide prefix scan; also provides every thread with the
+  /// block-wide @p block_aggregate of all inputs.
+  template <typename ScanOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void InclusiveScan(T input, T& inclusive_output, ScanOp scan_op, T& block_aggregate)
+  {
+    if constexpr (detail::is_warp_redux_op_supported<ScanOp, T>)
+    {
+      T warp_prefix;
+      if (ReduceThenFoldAggregates(input, scan_op, warp_prefix, block_aggregate))
+      {
+        WarpScanT(this->temp_storage.warp_scan[this->warp_id]).InclusiveScan(input, inclusive_output, scan_op);
+        if (this->warp_id != 0)
+        {
+          inclusive_output = scan_op(warp_prefix, inclusive_output);
+        }
+        return;
+      }
+    }
+    Base::InclusiveScan(input, inclusive_output, scan_op, block_aggregate);
+  }
+
+  /// Computes an inclusive thread block-wide prefix scan; the call-back functor is invoked by
+  /// the first warp with the block aggregate, and the value returned by lane0 seeds the scan.
+  /// See the exclusive callback overload for the aggregate-first rationale.
+  template <typename ScanOp, typename BlockPrefixCallbackOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void
+  InclusiveScan(T input, T& exclusive_output, ScanOp scan_op, BlockPrefixCallbackOp& block_prefix_callback_op)
+  {
+    if constexpr (detail::is_warp_redux_op_supported<ScanOp, T>)
+    {
+      T warp_prefix;
+      T block_aggregate;
+      if (ReduceThenFoldAggregates(input, scan_op, warp_prefix, block_aggregate))
+      {
+        if (this->warp_id == 0)
+        {
+          T block_prefix = block_prefix_callback_op(block_aggregate);
+          if (this->lane_id == 0)
+          {
+            detail::uninitialized_copy_single(&this->temp_storage.block_prefix, block_prefix);
+          }
+        }
+
+        T warp_inclusive;
+        WarpScanT(this->temp_storage.warp_scan[this->warp_id]).InclusiveScan(input, warp_inclusive, scan_op);
+        __syncthreads();
+
+        const T block_prefix = this->temp_storage.block_prefix;
+        const T prefix       = (this->warp_id == 0) ? block_prefix : scan_op(block_prefix, warp_prefix);
+        exclusive_output     = scan_op(prefix, warp_inclusive);
+        return;
+      }
+    }
+    Base::InclusiveScan(input, exclusive_output, scan_op, block_prefix_callback_op);
+  }
+};
+} // namespace detail
+
+CUB_NAMESPACE_END

--- a/cub/cub/block/specializations/block_scan_warp_reduce_then_scan.cuh
+++ b/cub/cub/block/specializations/block_scan_warp_reduce_then_scan.cuh
@@ -1,12 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-// SPDX-License-Identifier: BSD-3
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-/**
- * @file
- * cub::detail::BlockScanWarpReduceThenScan provides a warp-granularity "reduce-then-scan" parallel
- * prefix scan across a CUDA thread block, optimized for the latency until the block aggregate (and therefore a block
- * prefix callback) becomes available.
- */
+//! @file
+//! cub::detail::BlockScanWarpReduceThenScan provides a warp-granularity "reduce-then-scan" parallel
+//! prefix scan across a CUDA thread block, optimized for the latency until the block aggregate (and therefore a block
+//! prefix callback) becomes available.
 
 #pragma once
 
@@ -27,36 +25,34 @@
 CUB_NAMESPACE_BEGIN
 namespace detail
 {
-/**
- * @brief BlockScanWarpReduceThenScan provides a warp-granularity reduce-then-scan variant of
- *        the warpscans-based parallel prefix scan across a CUDA thread block: each warp first
- *        REDUCES its inputs to the warp aggregate (hardware `redux.sync` where supported),
- *        the aggregates are folded into warp prefixes, and only then do the warps scan.
- *
- * In the classic warpscans algorithm the warp aggregate is the *last* output of each warp's
- * shuffle-scan chain, so the block-wide barrier releases only after the slowest warp's full
- * scan, the cross-warp aggregate fold runs as a serial tail, and a block prefix callback (e.g.
- * the decoupled look-back's partial promotion) is invoked last. When the (scan_op, T) pair is
- * supported by the `redux.sync` instruction (see `is_warp_redux_op_supported`), the warp
- * aggregate can instead be produced in a single instruction *before* the warp scans: the
- * barrier releases as soon as the reductions complete, the aggregate fold overlaps the shuffle
- * chains, and the prefix callback is invoked by warp 0 while the other warps are still
- * scanning — its (global-memory) latency hides in their shadow.
- *
- * Results are identical to BlockScanWarpScans: eligibility is restricted to associative,
- * commutative integer operators for which the redux-computed aggregate is bit-exact.
- * For unsupported operators/types, and on architectures without `redux.sync` (< sm_80), all
- * methods compile to / fall back to the classic BlockScanWarpScans code paths.
- *
- * @tparam BlockDimX
- *   The thread block length in threads along the X dimension
- *
- * @tparam BlockDimY
- *   The thread block length in threads along the Y dimension
- *
- * @tparam BlockDimZ
- *   The thread block length in threads along the Z dimension
- */
+//! @brief BlockScanWarpReduceThenScan provides a warp-granularity reduce-then-scan variant of
+//!        the warpscans-based parallel prefix scan across a CUDA thread block: each warp first
+//!        REDUCES its inputs to the warp aggregate (hardware `redux.sync` where supported),
+//!        the aggregates are folded into warp prefixes, and only then do the warps scan.
+//!
+//! In the classic warpscans algorithm the warp aggregate is the *last* output of each warp's
+//! shuffle-scan chain, so the block-wide barrier releases only after the slowest warp's full
+//! scan, the cross-warp aggregate fold runs as a serial tail, and a block prefix callback (e.g.
+//! the decoupled look-back's partial promotion) is invoked last. When the (scan_op, T) pair is
+//! supported by the `redux.sync` instruction (see `is_warp_redux_op_supported`), the warp
+//! aggregate can instead be produced in a single instruction *before* the warp scans: the
+//! barrier releases as soon as the reductions complete, the aggregate fold overlaps the shuffle
+//! chains, and the prefix callback is invoked by warp 0 while the other warps are still
+//! scanning — its (global-memory) latency hides in their shadow.
+//!
+//! Results are identical to BlockScanWarpScans: eligibility is restricted to associative,
+//! commutative integer operators for which the redux-computed aggregate is bit-exact.
+//! For unsupported operators/types, and on architectures without `redux.sync` (< sm_80), all
+//! methods compile to / fall back to the classic BlockScanWarpScans code paths.
+//!
+//! @tparam BlockDimX
+//!   The thread block length in threads along the X dimension
+//!
+//! @tparam BlockDimY
+//!   The thread block length in threads along the Y dimension
+//!
+//! @tparam BlockDimZ
+//!   The thread block length in threads along the Z dimension
 template <typename T, int BlockDimX, int BlockDimY, int BlockDimZ>
 struct BlockScanWarpReduceThenScan : BlockScanWarpScans<T, BlockDimX, BlockDimY, BlockDimZ>
 {
@@ -70,7 +66,7 @@ struct BlockScanWarpReduceThenScan : BlockScanWarpScans<T, BlockDimX, BlockDimY,
                 "BlockScanWarpReduceThenScan requires the block size to be a multiple of the warp size "
                 "(enforced by BlockScan's SAFE_ALGORITHM fallback)");
 
-  /// Constructor
+  //! Constructor
   _CCCL_DEVICE _CCCL_FORCEINLINE BlockScanWarpReduceThenScan(TempStorage& temp_storage)
       : Base(temp_storage)
   {}
@@ -79,15 +75,13 @@ struct BlockScanWarpReduceThenScan : BlockScanWarpScans<T, BlockDimX, BlockDimY,
   // Reduce-then-scan core
   //---------------------------------------------------------------------
 
-  /**
-   * @brief Produces this warp's aggregate via `redux.sync`, publishes it, and folds all warp
-   *        aggregates into the calling warp's prefix and the block aggregate — all BEFORE any
-   *        warp scan has run. Returns false when `redux.sync` is unavailable at run time
-   *        (pre-sm_80 code paths), in which case the caller must take the classic path.
-   *
-   * @param[out] warp_prefix  Prefix of all preceding warps' aggregates; valid for warp_id != 0
-   * @param[out] block_aggregate  Block-wide aggregate reduction of input items
-   */
+  //! @brief Produces this warp's aggregate via `redux.sync`, publishes it, and folds all warp
+  //!        aggregates into the calling warp's prefix and the block aggregate — all BEFORE any
+  //!        warp scan has run. Returns false when `redux.sync` is unavailable at run time
+  //!        (pre-sm_80 code paths), in which case the caller must take the classic path.
+  //!
+  //! @param[out] warp_prefix  Prefix of all preceding warps' aggregates; valid for warp_id != 0
+  //! @param[out] block_aggregate  Block-wide aggregate reduction of input items
   template <typename ScanOp>
   _CCCL_DEVICE _CCCL_FORCEINLINE bool
   ReduceThenFoldAggregates(T input, ScanOp scan_op, T& warp_prefix, T& block_aggregate)
@@ -111,8 +105,8 @@ struct BlockScanWarpReduceThenScan : BlockScanWarpScans<T, BlockDimX, BlockDimY,
   // Exclusive scans
   //---------------------------------------------------------------------
 
-  /// Computes an exclusive thread block-wide prefix scan. With no initial value, the output
-  /// computed for thread0 is undefined.
+  //! Computes an exclusive thread block-wide prefix scan. With no initial value, the output
+  //! computed for thread0 is undefined.
   template <typename ScanOp>
   _CCCL_DEVICE _CCCL_FORCEINLINE void ExclusiveScan(T input, T& exclusive_output, ScanOp scan_op)
   {
@@ -120,7 +114,7 @@ struct BlockScanWarpReduceThenScan : BlockScanWarpScans<T, BlockDimX, BlockDimY,
     ExclusiveScan(input, exclusive_output, scan_op, block_aggregate);
   }
 
-  /// Computes an exclusive thread block-wide prefix scan seeded with @p initial_value.
+  //! Computes an exclusive thread block-wide prefix scan seeded with @p initial_value.
   template <typename ScanOp>
   _CCCL_DEVICE _CCCL_FORCEINLINE void ExclusiveScan(T input, T& exclusive_output, const T& initial_value, ScanOp scan_op)
   {
@@ -128,9 +122,9 @@ struct BlockScanWarpReduceThenScan : BlockScanWarpScans<T, BlockDimX, BlockDimY,
     ExclusiveScan(input, exclusive_output, initial_value, scan_op, block_aggregate);
   }
 
-  /// Computes an exclusive thread block-wide prefix scan; also provides every thread with the
-  /// block-wide @p block_aggregate of all inputs. With no initial value, the output computed
-  /// for thread0 is undefined.
+  //! Computes an exclusive thread block-wide prefix scan; also provides every thread with the
+  //! block-wide @p block_aggregate of all inputs. With no initial value, the output computed
+  //! for thread0 is undefined.
   template <typename ScanOp>
   _CCCL_DEVICE _CCCL_FORCEINLINE void ExclusiveScan(T input, T& exclusive_output, ScanOp scan_op, T& block_aggregate)
   {
@@ -155,8 +149,8 @@ struct BlockScanWarpReduceThenScan : BlockScanWarpScans<T, BlockDimX, BlockDimY,
     Base::ExclusiveScan(input, exclusive_output, scan_op, block_aggregate);
   }
 
-  /// Computes an exclusive thread block-wide prefix scan seeded with @p initial_value; also
-  /// provides every thread with the block-wide @p block_aggregate of all inputs.
+  //! Computes an exclusive thread block-wide prefix scan seeded with @p initial_value; also
+  //! provides every thread with the block-wide @p block_aggregate of all inputs.
   template <typename ScanOp>
   _CCCL_DEVICE _CCCL_FORCEINLINE void
   ExclusiveScan(T input, T& exclusive_output, const T& initial_value, ScanOp scan_op, T& block_aggregate)
@@ -181,10 +175,10 @@ struct BlockScanWarpReduceThenScan : BlockScanWarpScans<T, BlockDimX, BlockDimY,
     Base::ExclusiveScan(input, exclusive_output, initial_value, scan_op, block_aggregate);
   }
 
-  /// Computes an exclusive thread block-wide prefix scan; the call-back functor is invoked by
-  /// the first warp with the block aggregate, and the value returned by lane0 seeds the scan.
-  /// This is the aggregate-first sweet spot: the callback (e.g. a decoupled look-back) runs one
-  /// warp-scan earlier and its latency overlaps all warps' shuffle scans.
+  //! Computes an exclusive thread block-wide prefix scan; the call-back functor is invoked by
+  //! the first warp with the block aggregate, and the value returned by lane0 seeds the scan.
+  //! This is the aggregate-first sweet spot: the callback (e.g. a decoupled look-back) runs one
+  //! warp-scan earlier and its latency overlaps all warps' shuffle scans.
   template <typename ScanOp, typename BlockPrefixCallbackOp>
   _CCCL_DEVICE _CCCL_FORCEINLINE void
   ExclusiveScan(T input, T& exclusive_output, ScanOp scan_op, BlockPrefixCallbackOp& block_prefix_callback_op)
@@ -226,7 +220,7 @@ struct BlockScanWarpReduceThenScan : BlockScanWarpScans<T, BlockDimX, BlockDimY,
   // Inclusive scans
   //---------------------------------------------------------------------
 
-  /// Computes an inclusive thread block-wide prefix scan.
+  //! Computes an inclusive thread block-wide prefix scan.
   template <typename ScanOp>
   _CCCL_DEVICE _CCCL_FORCEINLINE void InclusiveScan(T input, T& inclusive_output, ScanOp scan_op)
   {
@@ -234,8 +228,8 @@ struct BlockScanWarpReduceThenScan : BlockScanWarpScans<T, BlockDimX, BlockDimY,
     InclusiveScan(input, inclusive_output, scan_op, block_aggregate);
   }
 
-  /// Computes an inclusive thread block-wide prefix scan; also provides every thread with the
-  /// block-wide @p block_aggregate of all inputs.
+  //! Computes an inclusive thread block-wide prefix scan; also provides every thread with the
+  //! block-wide @p block_aggregate of all inputs.
   template <typename ScanOp>
   _CCCL_DEVICE _CCCL_FORCEINLINE void InclusiveScan(T input, T& inclusive_output, ScanOp scan_op, T& block_aggregate)
   {
@@ -255,9 +249,9 @@ struct BlockScanWarpReduceThenScan : BlockScanWarpScans<T, BlockDimX, BlockDimY,
     Base::InclusiveScan(input, inclusive_output, scan_op, block_aggregate);
   }
 
-  /// Computes an inclusive thread block-wide prefix scan; the call-back functor is invoked by
-  /// the first warp with the block aggregate, and the value returned by lane0 seeds the scan.
-  /// See the exclusive callback overload for the aggregate-first rationale.
+  //! Computes an inclusive thread block-wide prefix scan; the call-back functor is invoked by
+  //! the first warp with the block aggregate, and the value returned by lane0 seeds the scan.
+  //! See the exclusive callback overload for the aggregate-first rationale.
   template <typename ScanOp, typename BlockPrefixCallbackOp>
   _CCCL_DEVICE _CCCL_FORCEINLINE void
   InclusiveScan(T input, T& exclusive_output, ScanOp scan_op, BlockPrefixCallbackOp& block_prefix_callback_op)

--- a/cub/test/catch2_test_block_scan.cu
+++ b/cub/test/catch2_test_block_scan.cu
@@ -370,7 +370,8 @@ using algorithms =
   c2h::enum_type_list<cub::BlockScanAlgorithm,
                       cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING,
                       cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_SCANS,
-                      cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING_MEMOIZE>;
+                      cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING_MEMOIZE,
+                      cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_REDUCE_THEN_SCAN>;
 using algorithm = c2h::enum_type_list<cub::BlockScanAlgorithm, c2h::get<ALGO_TYPE, algorithms>::value>;
 
 #if TEST_MODE == 0


### PR DESCRIPTION

### Open questions:

- Naming and fallback behavior: We use a fallback if redux is not supported (i.e.,`detail::is_warp_redux_op_supported`). I am semi-happy with the current choice of `BLOCK_SCAN_WARP_REDUCE_THEN_SCAN`, as it sounds that we'd always reduce-then-scan. I wonder if (a) we should change the name to something like `BLOCK_SCAN_WARP_REDUX_THEN_SCAN` or if we should even consider changing the fallback behaviour to _always_ perform a reduce-then-scan. 

### Eligibility and fallback

This PR adds a new, opt-in `BlockScanAlgorithm`. It is a warp-granularity "reduce-then-scan" variant of `BLOCK_SCAN_WARP_SCANS` that minimizes the time until the block aggregate (and with it, a `BlockPrefixCallbackOp`) becomes available.

It also fits the existing naming scheme: `BLOCK_SCAN_RAKING` is reduce-then-scan done by sequential raking in a single warp, this variant is reduce-then-scan done by hardware warp reductions with all warps active, and `BLOCK_SCAN_WARP_SCANS` is scan-then-propagate.

### Where the latency goes today

Every thread's result needs two independent ingredients: its warp-local prefix (a scan over its warp's 32 inputs) and its warp base (the sum of the preceding warps' aggregates). `BLOCK_SCAN_WARP_SCANS` computes them one after the other, because each warp's aggregate only exists as a by-product of its scan (the last lane's inclusive value):

```text
LDS(~33) -> 5-shuffle scan (~150) -> aggregate now known -> store -> BARRIER -> fold aggregates (~63) -> result
            \_______________________________________________________/
            the aggregate exchange is welded to the END of the scan chain
```

This has two structural costs. The barrier releases late, since a warp only arrives once its full shuffle chain is done. And the cross-warp fold turns into a serial tail: its loads can't be hoisted above the barrier, and by the time it runs, every warp has already finished its scan, so there is nothing left to overlap it with.

### What this variant changes

`redux.sync` produces a warp's aggregate in about 22 cycles without any scan, which decouples the two ingredients:

```text
LDS(~33) -> redux(~22) -> store -> BARRIER (releases ~120 cycles earlier)
                                    |-> 5-shuffle scan (~150)     unchanged, each warp's own work
                                    |-> fold aggregates (~63)     independent LDS/adds, issued in the
                                                                  shuffle chain's stall slots
                                 -> result  (join: incl + base)
```

The scan itself is not any faster. The point is that nothing queues up behind it anymore. The fold's loads and adds don't depend on the shuffles, so the SASS scheduler interleaves them into the shuffle chain's stall cycles (about 14 issue slots hidden in about 120 stall cycles). Wall time after the barrier becomes max(scan, fold) instead of scan + barrier wait + fold. In the prefix-callback overloads, warp 0 additionally invokes the callback right after the fold and before its own scan, so the callback's latency (typically global memory) also hides under the other warps' scans.

### Eligibility and fallback

Results are identical to `BLOCK_SCAN_WARP_SCANS`. Eligibility (`detail::is_warp_redux_op_supported`) is limited to associative, commutative integer operators (sum/min/max/bitwise, types up to 4 bytes), where the redux-computed aggregate is bit-exact. Unsupported operators/types and pre-sm_80 targets fall back to the classic code paths at compile/dispatch time. Blocks that aren't a multiple of the warp size fall back to raking via `SAFE_ALGORITHM`, same as `BLOCK_SCAN_WARP_SCANS`. `TempStorage` is unchanged: it reuses the `BlockScanWarpScans` layout, including the existing `warp_aggregates` array. The variant only changes who writes that array, and when.

### Results and scope

Measured on B200 (sm_100), callback-style `int` exclusive sum, 256 threads, single resident block: 397 -> 320 cycles/call, a 19.5% reduction. The motivating use case is latency-critical block-scope primitives where the scan sits on a pass-serial critical path with no other resident work to hide stalls. Concretely: the radix pass of block-level top-k selection, where this stage is about 40% of the optimized call and the change saves 64 to 82 cycles per pass.

Scope note: I also tried routing a decoupled look-back algorithm (`DeviceSelect`) through this variant and found no measurable end-to-end change on B200. Presumably, the windowed look-back absorbs the earlier aggregate publication. This will require further investigation. The main target for now, is `BlockTopK`.

## Checklist

- [x] New specialization `detail::BlockScanWarpReduceThenScan` (full method surface, compile-time and runtime fallback)
- [x] Enum value, docs, `to_string`, and `InternalBlockScan` dispatch in `block_scan.cuh`
- [x] Added to the catch2 `BlockScan` test algorithm matrix
- [x] Validated on sm_100: exclusive/inclusive, single/multi-item, with/without aggregate, multi-tile prefix callback; eligible and fallback paths against host references
