### PR TITLE
[Backport to 3.4] Use plus tunings for lookahead scan more widely (#9813)

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -937,7 +937,7 @@ struct policy_selector
     if (cc >= ::cuda::compute_capability{10, 0})
     {
       // tunings from cub/benchmarks/bench/scan/exclusive/sum.warpspeed.cu
-      if (operation_t == op_kind_t::plus && accum_is_primitive_or_trivially_copy_constructible)
+      if (accum_is_primitive_or_trivially_copy_constructible)
       {
         switch (input_value_size)
         {


### PR DESCRIPTION
Fixes: #9811

(cherry picked from commit 22e4e6802bdc84f088ce6649043b875cd5a54180)