### PR TITLE
Revert "Pin NVTX to commit before upstream scope refactor" (#9820)

### DIFF
--- a/cmake/CCCLGetDependencies.cmake
+++ b/cmake/CCCLGetDependencies.cmake
@@ -103,8 +103,7 @@ macro(cccl_get_nvtx)
   CPMAddPackage(
     NAME NVTX
     GITHUB_REPOSITORY NVIDIA/NVTX
-    # We should track release-v3, but due to an upstream issue, we pin it now:
-    GIT_TAG 60587e3059c2e6a4d5c83f22c978715c98a5f1f8
+    GIT_TAG release-v3
     DOWNLOAD_ONLY ON
     SYSTEM ON
   )


### PR DESCRIPTION
## Summary

Reverts #9820, which pinned NVTX to a fixed commit (`60587e3059c2e6a4d5c83f22c978715c98a5f1f8`) as a workaround for an upstream regression.

The upstream NVTX issue has been fixed, so we can go back to tracking the moving `release-v3` branch instead of a pinned commit.

## Background

#9820 pinned NVTX because upstream `NVIDIA/NVTX@release-v3` had received a change that moved `nvtx3::scope` and broke compilation of `nvtx3.hpp`, failing CUB test builds repo-wide:

```
_deps/nvtx-src/c/include/nvtx3/nvtx3.hpp: error: no type named 'scope' in namespace 'nvtx3';
    did you mean '::nvtx3::v1::scope'?
```

Now that the fix has landed upstream, the workaround pin is no longer needed and this restores `GIT_TAG release-v3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)