### PR TITLE
Fix clang-tidy errors reported on several PRs

### DIFF
--- a/c2h/include/c2h/bfloat16.cuh
+++ b/c2h/include/c2h/bfloat16.cuh
@@ -44,19 +44,19 @@ struct bfloat16_t
   /// Constructor from integer
   __host__ __device__ __forceinline__ explicit bfloat16_t(int a)
   {
-    *this = bfloat16_t(float(a));
+    *this = bfloat16_t(static_cast<float>(a));
   }
 
   /// Constructor from std::size_t
   __host__ __device__ __forceinline__ explicit bfloat16_t(std::size_t a)
   {
-    *this = bfloat16_t(float(a));
+    *this = bfloat16_t(static_cast<float>(a));
   }
 
   /// Constructor from double
   __host__ __device__ __forceinline__ explicit bfloat16_t(double a)
   {
-    *this = bfloat16_t(float(a));
+    *this = bfloat16_t(static_cast<float>(a));
   }
 
   /// Constructor from unsigned long long int
@@ -66,7 +66,7 @@ struct bfloat16_t
               && (!::cuda::std::is_same<std::size_t, unsigned long long int>::value)>::type>
   __host__ __device__ __forceinline__ explicit bfloat16_t(T a)
   {
-    *this = bfloat16_t(float(a));
+    *this = bfloat16_t(static_cast<float>(a));
   }
 
   /// Default constructor
@@ -108,7 +108,7 @@ struct bfloat16_t
   {
     float f     = 0;
     uint32_t* p = reinterpret_cast<uint32_t*>(&f);
-    *p          = uint32_t(__x) << 16;
+    *p          = static_cast<uint32_t>(__x) << 16;
     return f;
   }
 
@@ -133,50 +133,50 @@ struct bfloat16_t
   /// Assignment by sum
   __host__ __device__ __forceinline__ bfloat16_t& operator+=(const bfloat16_t& rhs)
   {
-    *this = bfloat16_t(float(*this) + float(rhs));
+    *this = bfloat16_t(static_cast<float>(*this) + static_cast<float>(rhs));
     return *this;
   }
 
   /// Multiply
   __host__ __device__ __forceinline__ bfloat16_t operator*(const bfloat16_t& other) const
   {
-    return bfloat16_t(float(*this) * float(other));
+    return bfloat16_t(static_cast<float>(*this) * static_cast<float>(other));
   }
 
   /// Add
   __host__ __device__ __forceinline__ bfloat16_t operator+(const bfloat16_t& other) const
   {
-    return bfloat16_t(float(*this) + float(other));
+    return bfloat16_t(static_cast<float>(*this) + static_cast<float>(other));
   }
 
   /// Sub
   __host__ __device__ __forceinline__ bfloat16_t operator-(const bfloat16_t& other) const
   {
-    return bfloat16_t(float(*this) - float(other));
+    return bfloat16_t(static_cast<float>(*this) - static_cast<float>(other));
   }
 
   /// Less-than
   __host__ __device__ __forceinline__ bool operator<(const bfloat16_t& other) const
   {
-    return float(*this) < float(other);
+    return static_cast<float>(*this) < static_cast<float>(other);
   }
 
   /// Less-than-equal
   __host__ __device__ __forceinline__ bool operator<=(const bfloat16_t& other) const
   {
-    return float(*this) <= float(other);
+    return static_cast<float>(*this) <= static_cast<float>(other);
   }
 
   /// Greater-than
   __host__ __device__ __forceinline__ bool operator>(const bfloat16_t& other) const
   {
-    return float(*this) > float(other);
+    return static_cast<float>(*this) > static_cast<float>(other);
   }
 
   /// Greater-than-equal
   __host__ __device__ __forceinline__ bool operator>=(const bfloat16_t& other) const
   {
-    return float(*this) >= float(other);
+    return static_cast<float>(*this) >= static_cast<float>(other);
   }
 
   /// numeric_traits<bfloat16_t>::max
@@ -201,7 +201,7 @@ struct bfloat16_t
 /// Insert formatted \p bfloat16_t into the output stream
 inline std::ostream& operator<<(std::ostream& out, const bfloat16_t& x)
 {
-  out << (float) x;
+  out << static_cast<float>(x);
   return out;
 }
 

--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -650,7 +650,8 @@ inline std::size_t get_override_seed_count()
   // Setting this environment variable forces a fixed number of seeds to be generated, regardless of the requested
   // count. Set to 1 to reduce redundant, expensive testing when using sanitizers, etc.
   static std::optional<std::string> override_str = c2h::detail::get_env("C2H_SEED_COUNT_OVERRIDE");
-  static const int override_seeds                = override_str ? std::atoi(override_str->c_str()) : 0;
+  static const int override_seeds =
+    override_str ? static_cast<int>(std::strtol(override_str->c_str(), nullptr, 10)) : 0;
   return override_seeds;
 }
 

--- a/c2h/include/c2h/checked_allocator.cuh
+++ b/c2h/include/c2h/checked_allocator.cuh
@@ -54,14 +54,15 @@ struct memory_info
 inline std::size_t get_device_memory_limit()
 {
   static std::optional<std::string> override_str = get_env("C2H_DEVICE_MEMORY_LIMIT");
-  static std::size_t result = override_str ? static_cast<std::size_t>(std::atoll(override_str->c_str())) : 0;
+  static std::size_t result =
+    override_str ? static_cast<std::size_t>(std::strtoll(override_str->c_str(), nullptr, 10)) : 0;
   return result;
 }
 
 inline bool get_debug_checked_allocs()
 {
   static std::optional<std::string> debug_checked_allocs = get_env("C2H_DEBUG_CHECKED_ALLOC_FAILURES");
-  static bool result = debug_checked_allocs && (std::atoi(debug_checked_allocs->c_str()) != 0);
+  static bool result = debug_checked_allocs && (std::strtol(debug_checked_allocs->c_str(), nullptr, 10) != 0);
   return result;
 }
 

--- a/c2h/include/c2h/device_policy.h
+++ b/c2h/include/c2h/device_policy.h
@@ -10,8 +10,12 @@
 namespace c2h
 {
 #if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+// These policies are constructed from a checked allocator whose (non-noexcept) construction clang-tidy conservatively
+// treats as potentially throwing during static initialization.
+// NOLINTBEGIN(bugprone-throwing-static-initialization)
 static const auto device_policy        = THRUST_NS_QUALIFIER::cuda::par(checked_cuda_allocator<char>{});
 static const auto nosync_device_policy = THRUST_NS_QUALIFIER::cuda::par_nosync(checked_cuda_allocator<char>{});
+// NOLINTEND(bugprone-throwing-static-initialization)
 #else // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
 static const auto device_policy        = THRUST_NS_QUALIFIER::device;
 static const auto nosync_device_policy = THRUST_NS_QUALIFIER::device;

--- a/c2h/include/c2h/half.cuh
+++ b/c2h/include/c2h/half.cuh
@@ -47,19 +47,19 @@ struct half_t
   /// Constructor from integer
   __host__ __device__ __forceinline__ explicit half_t(int a)
   {
-    *this = half_t(float(a));
+    *this = half_t(static_cast<float>(a));
   }
 
   /// Constructor from std::size_t
   __host__ __device__ __forceinline__ explicit half_t(std::size_t a)
   {
-    *this = half_t(float(a));
+    *this = half_t(static_cast<float>(a));
   }
 
   /// Constructor from double
   __host__ __device__ __forceinline__ explicit half_t(double a)
   {
-    *this = half_t(float(a));
+    *this = half_t(static_cast<float>(a));
   }
 
   /// Constructor from unsigned long long int
@@ -69,7 +69,7 @@ struct half_t
               && (!::cuda::std::is_same<std::size_t, unsigned long long int>::value)>::type>
   __host__ __device__ __forceinline__ explicit half_t(T a)
   {
-    *this = half_t(float(a));
+    *this = half_t(static_cast<float>(a));
   }
 
   /// Default constructor
@@ -97,7 +97,7 @@ struct half_t
     }
     else if ((ia & 0x7f800000) >= 0x33000000)
     {
-      int32_t shift = (int32_t) ((ia >> 23) & 0xff) - 127;
+      int32_t shift = static_cast<int32_t>((ia >> 23) & 0xff) - 127;
       if (shift > 15)
       {
         ir |= 0x7c00; /* infinity */
@@ -211,20 +211,20 @@ struct half_t
   /// Assignment by sum
   __host__ __device__ __forceinline__ half_t& operator+=(const half_t& rhs)
   {
-    *this = half_t(float(*this) + float(rhs));
+    *this = half_t(static_cast<float>(*this) + static_cast<float>(rhs));
     return *this;
   }
 
   /// Multiply
   __host__ __device__ __forceinline__ half_t operator*(const half_t& other) const
   {
-    return half_t(float(*this) * float(other));
+    return half_t(static_cast<float>(*this) * static_cast<float>(other));
   }
 
   /// Divide
   __host__ __device__ __forceinline__ half_t& operator/=(const half_t& other)
   {
-    return *this = half_t(float(*this) / float(other));
+    return *this = half_t(static_cast<float>(*this) / static_cast<float>(other));
   }
 
   friend __host__ __device__ __forceinline__ half_t operator/(half_t self, const half_t& other)
@@ -235,37 +235,37 @@ struct half_t
   /// Add
   __host__ __device__ __forceinline__ half_t operator+(const half_t& other) const
   {
-    return half_t(float(*this) + float(other));
+    return half_t(static_cast<float>(*this) + static_cast<float>(other));
   }
 
   /// Sub
   __host__ __device__ __forceinline__ half_t operator-(const half_t& other) const
   {
-    return half_t(float(*this) - float(other));
+    return half_t(static_cast<float>(*this) - static_cast<float>(other));
   }
 
   /// Less-than
   __host__ __device__ __forceinline__ bool operator<(const half_t& other) const
   {
-    return float(*this) < float(other);
+    return static_cast<float>(*this) < static_cast<float>(other);
   }
 
   /// Less-than-equal
   __host__ __device__ __forceinline__ bool operator<=(const half_t& other) const
   {
-    return float(*this) <= float(other);
+    return static_cast<float>(*this) <= static_cast<float>(other);
   }
 
   /// Greater-than
   __host__ __device__ __forceinline__ bool operator>(const half_t& other) const
   {
-    return float(*this) > float(other);
+    return static_cast<float>(*this) > static_cast<float>(other);
   }
 
   /// Greater-than-equal
   __host__ __device__ __forceinline__ bool operator>=(const half_t& other) const
   {
-    return float(*this) >= float(other);
+    return static_cast<float>(*this) >= static_cast<float>(other);
   }
 
   /// numeric_traits<half_t>::max
@@ -290,7 +290,7 @@ struct half_t
 /// Insert formatted \p half_t into the output stream
 inline std::ostream& operator<<(std::ostream& out, const half_t& x)
 {
-  out << (float) x;
+  out << static_cast<float>(x);
   return out;
 }
 

--- a/c2h/include/c2h/operator.cuh
+++ b/c2h/include/c2h/operator.cuh
@@ -25,6 +25,10 @@ inline const T identity_v<cuda::std::plus<>, T> = T{}; // e.g. short2, float2, c
  * half_t specializations
  **********************************************************************************************************************/
 
+// The fp16/bf16 identity tables below are initialized from non-constexpr, non-noexcept constructors (and CUDA's
+// numeric_limits for __half/__nv_bfloat16), i.e. dynamic static initialization that clang-tidy conservatively flags as
+// potentially throwing.
+// NOLINTBEGIN(bugprone-throwing-static-initialization)
 template <>
 inline const half_t identity_v<cuda::std::plus<>, half_t> = half_t{0.0f};
 
@@ -91,6 +95,7 @@ inline const __half2 identity_v<cuda::minimum<>, __half2> =
 template <>
 inline const __nv_bfloat162 identity_v<cuda::minimum<>, __nv_bfloat162> =
   __nv_bfloat162{cuda::std::numeric_limits<__nv_bfloat16>::max(), cuda::std::numeric_limits<__nv_bfloat16>::max()};
+// NOLINTEND(bugprone-throwing-static-initialization)
 
 template <template <typename> class... Policies>
 inline const c2h::custom_type_t<Policies...> identity_v<cuda::maximum<>, c2h::custom_type_t<Policies...>> =


### PR DESCRIPTION
This may have been caused by the clang-tidy 22 upgrade in the devcontainers.