### PR TITLE
[clang-tidy] Suppress new warnings emitted by clang-tidy-22

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -195,6 +195,9 @@ Checks:
   - '-modernize-use-nullptr'
   - '-bugprone-std-exception-baseclass'
   - '-modernize-avoid-variadic-functions'
+  - '-modernize-type-traits'
+  - '-bugprone-random-generator-seed'
+  - '-bugprone-command-processor'
 
   # TODO: ironically enough, enable this someday
   - '-google-readability-todo'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -180,6 +180,18 @@ Checks:
   #
   # So better left disabled.
   - '-bugprone-macro-parentheses'
+
+  # TODO: Enable for clang-tidy-22
+  - '-modernize-avoid-c-style-cast'
+  - '-bugprone-signed-bitwise'
+  - '-bugprone-std-namespace-modification'
+  - '-clang-diagnostic-deprecated-attributes'
+  - '-bugprone-throwing-static-initialization'
+  - '-bugprone-unchecked-string-to-number-conversion'
+  - '-bugprone-invalid-enum-default-initialization'
+  - '-bugprone-derived-method-shadowing-base-method'
+  - '-bugprone-unsafe-to-allow-exceptions'
+
   # TODO: ironically enough, enable this someday
   - '-google-readability-todo'
   # Covered by modernize-avoid-c-style-cast, and also is buggier. It seems to fire on

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -193,6 +193,7 @@ Checks:
   - '-bugprone-unsafe-to-allow-exceptions'
   - '-bugprone-sizeof-expression'
   - '-modernize-use-nullptr'
+  - '-bugprone-std-exception-baseclass'
 
   # TODO: ironically enough, enable this someday
   - '-google-readability-todo'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -194,6 +194,7 @@ Checks:
   - '-bugprone-sizeof-expression'
   - '-modernize-use-nullptr'
   - '-bugprone-std-exception-baseclass'
+  - '-modernize-avoid-variadic-functions'
 
   # TODO: ironically enough, enable this someday
   - '-google-readability-todo'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -191,6 +191,8 @@ Checks:
   - '-bugprone-invalid-enum-default-initialization'
   - '-bugprone-derived-method-shadowing-base-method'
   - '-bugprone-unsafe-to-allow-exceptions'
+  - '-bugprone-sizeof-expression'
+  - '-modernize-use-nullptr'
 
   # TODO: ironically enough, enable this someday
   - '-google-readability-todo'

--- a/cudax/include/cuda/experimental/__group/group.cuh
+++ b/cudax/include/cuda/experimental/__group/group.cuh
@@ -252,7 +252,7 @@ public:
 
 _CCCL_TEMPLATE(class _Unit, class _ParentGroup, class _Mapping, class _Synchronizer)
 _CCCL_REQUIRES(__is_hierarchy_level_v<_Unit> _CCCL_AND is_group<_ParentGroup>)
-_CCCL_DEVICE group(const _Unit&, const _ParentGroup&, const _Mapping&, const _Synchronizer&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES group(const _Unit&, const _ParentGroup&, const _Mapping&, const _Synchronizer&)
   -> group<_Unit, _ParentGroup, _Mapping, _Synchronizer>;
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__group/mapping/composite_mapping.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/composite_mapping.cuh
@@ -77,7 +77,7 @@ public:
 };
 
 template <class... _Mappings>
-_CCCL_DEVICE composite_mapping(const _Mappings&...) -> composite_mapping<_Mappings...>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES composite_mapping(const _Mappings&...) -> composite_mapping<_Mappings...>;
 
 _CCCL_TEMPLATE(class _Lhs, class _Rhs)
 _CCCL_REQUIRES(__is_group_mapping_v<_Lhs> _CCCL_AND __is_group_mapping_v<_Rhs>)

--- a/cudax/include/cuda/experimental/__group/mapping/group_as.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/group_as.cuh
@@ -302,22 +302,24 @@ public:
 };
 
 template <::cuda::std::size_t... _UnitCounts>
-_CCCL_DEVICE group_as(const ::cuda::std::integer_sequence<::cuda::std::size_t, _UnitCounts...>&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES group_as(const ::cuda::std::integer_sequence<::cuda::std::size_t, _UnitCounts...>&)
   -> group_as<__group_as_static_tag<_UnitCounts...>, true>;
 
 template <::cuda::std::size_t... _UnitCounts>
-_CCCL_DEVICE group_as(const ::cuda::std::integer_sequence<::cuda::std::size_t, _UnitCounts...>&,
-                      const non_exhaustive_t&) -> group_as<__group_as_static_tag<_UnitCounts...>, false>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES
+group_as(const ::cuda::std::integer_sequence<::cuda::std::size_t, _UnitCounts...>&, const non_exhaustive_t&)
+  -> group_as<__group_as_static_tag<_UnitCounts...>, false>;
 
 _CCCL_TEMPLATE(class _Tp)
 _CCCL_REQUIRES(__is_spannable<_Tp> _CCCL_AND ::cuda::std::
                  is_same_v<unsigned, _SpanValueType<decltype(::cuda::std::span(::cuda::std::declval<_Tp&>()))>>)
-_CCCL_DEVICE group_as(_Tp& __v) -> group_as<__group_as_dynamic_tag<decltype(::cuda::std::span(__v))::extent>, true>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES group_as(_Tp& __v)
+  -> group_as<__group_as_dynamic_tag<decltype(::cuda::std::span(__v))::extent>, true>;
 
 _CCCL_TEMPLATE(class _Tp)
 _CCCL_REQUIRES(__is_spannable<_Tp> _CCCL_AND ::cuda::std::
                  is_same_v<unsigned, _SpanValueType<decltype(::cuda::std::span(::cuda::std::declval<_Tp&>()))>>)
-_CCCL_DEVICE group_as(_Tp& __v, const non_exhaustive_t&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES group_as(_Tp& __v, const non_exhaustive_t&)
   -> group_as<__group_as_dynamic_tag<decltype(::cuda::std::span(__v))::extent>, false>;
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__group/mapping/group_by.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/group_by.cuh
@@ -224,9 +224,10 @@ public:
   }
 };
 
-_CCCL_DEVICE group_by(unsigned) -> group_by<::cuda::std::dynamic_extent>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES group_by(unsigned) -> group_by<::cuda::std::dynamic_extent>;
 
-_CCCL_DEVICE group_by(unsigned, const non_exhaustive_t&) -> group_by<::cuda::std::dynamic_extent, false>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES group_by(unsigned, const non_exhaustive_t&)
+  -> group_by<::cuda::std::dynamic_extent, false>;
 } // namespace cuda::experimental
 
 #endif // !_CCCL_DOXYGEN_INVOKED

--- a/cudax/include/cuda/experimental/__group/synchronizer/barrier_synchronizer.cuh
+++ b/cudax/include/cuda/experimental/__group/synchronizer/barrier_synchronizer.cuh
@@ -144,11 +144,12 @@ public:
 };
 
 template <class _Barrier, ::cuda::std::size_t _Np>
-_CCCL_DEVICE barrier_synchronizer(::cuda::std::span<_Barrier, _Np>) -> barrier_synchronizer<_Barrier, _Np>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES barrier_synchronizer(::cuda::std::span<_Barrier, _Np>)
+  -> barrier_synchronizer<_Barrier, _Np>;
 
 _CCCL_TEMPLATE(class _Tp)
 _CCCL_REQUIRES(__is_spannable<_Tp&> _CCCL_AND(!::cuda::std::__is_cuda_std_span_v<::cuda::std::remove_cv_t<_Tp>>))
-_CCCL_DEVICE barrier_synchronizer(_Tp&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES barrier_synchronizer(_Tp&)
   -> barrier_synchronizer<_SpanElementType<decltype(::cuda::std::span(::cuda::std::declval<_Tp&>()))>,
                           decltype(::cuda::std::span(::cuda::std::declval<_Tp&>()))::extent>;
 } // namespace cuda::experimental


### PR DESCRIPTION
We've updated our clang-tidy to version 22, which emits new warnings that currently block the CI. Let's suppress these warnings for now and re-enable them once we are done with 3.4 release backports.