### PR TITLE
Fix dead 64-bit rotate builtin macros and popcount tile undef in <bit>

### DIFF
--- a/libcudacxx/include/cuda/std/__bit/popcount.h
+++ b/libcudacxx/include/cuda/std/__bit/popcount.h
@@ -51,7 +51,7 @@
 #if _CCCL_TILE_COMPILATION() // nvbug6081171: error: "call to non-tile function not supported!"
 #  undef _CCCL_BUILTIN_POPCOUNT
 #  undef _CCCL_BUILTIN_POPCOUNTLL
-#  undef _CCCL_BUILTIN_POPCOUNTLL
+#  undef _CCCL_BUILTIN_POPCOUNTG
 #endif // _CCCL_TILE_COMPILATION()
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__bit/rotate.h
+++ b/libcudacxx/include/cuda/std/__bit/rotate.h
@@ -41,7 +41,7 @@
 #endif
 
 #if _CCCL_CHECK_BUILTIN(builtin_rotateleft64)
-#  define _CCCL_BUILTIN_ROTATELEFT44(...) __builtin_rotateleft64(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ROTATELEFT64(...) __builtin_rotateleft64(__VA_ARGS__)
 #endif
 
 #if _CCCL_CHECK_BUILTIN(builtin_rotateright8)
@@ -57,7 +57,7 @@
 #endif
 
 #if _CCCL_CHECK_BUILTIN(builtin_rotateright64)
-#  define _CCCL_BUILTIN_ROTATERIGHT44(...) __builtin_rotateright64(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ROTATERIGHT64(...) __builtin_rotateright64(__VA_ARGS__)
 #endif
 
 // nvcc doesn't allow clang's rotater left/right builtins


### PR DESCRIPTION
Went through the `<bit>` headers for #1018. The two hacks the issue links (the `__libcpp_ctz` software fallback and the endian sentinel enum) are already gone since the headers were rewritten and split, and the g-builtins (`clzg`/`ctzg`/`popcountg`/`bswapg`) are already wired. Two small gating bugs are what remained:

- `rotate.h` defines the 64-bit builtin macros as `_CCCL_BUILTIN_ROTATELEFT44`/`_CCCL_BUILTIN_ROTATERIGHT44`, but the call sites and the nvcc undef block check the 64 names, so the 64-bit builtin path was never taken. Renamed to 64, matching the 8/16/32 pattern.
- `popcount.h` undefs `_CCCL_BUILTIN_POPCOUNTLL` twice in the tile block; the second was clearly meant to be `_CCCL_BUILTIN_POPCOUNTG`, like the `CLZG` undef in `countl.h`. As written, `popcount` still takes the `popcountg` path under tile compilation, which is what the block (nvbug6081171) is there to prevent.

Verified on a clang host: a TU that #errors when the 64-bit rotate macros are missing fails before this change and compiles after, `rotl`/`rotr<uint64_t>` match the generic fallback over a few million value/count combinations plus the boundary counts, and `rotr` lowers to a single `ror` at -O2. The tile popcount change I could only verify by inspection against `countl.h`, since I have no tile toolchain locally.