### PR TITLE
[cudax] Fix cudax benchmarks prefix

### DIFF
--- a/cudax/benchmarks/CMakeLists.txt
+++ b/cudax/benchmarks/CMakeLists.txt
@@ -44,7 +44,7 @@ function(add_bench_dir bench_dir)
 
   foreach (bench_src IN LISTS bench_srcs)
     get_filename_component(bench_name "${bench_src}" NAME_WLE)
-    string(PREPEND bench_name "${config_prefix}.${bench_prefix}.")
+    string(PREPEND bench_name "cudax.${bench_prefix}.")
     register_cccl_benchmark("${bench_name}" "")
 
     string(APPEND bench_name ".base")


### PR DESCRIPTION
We removed `config_prefix` some time ago, now it just expands to nothing and creates `.bench.meow` targets instead of `cudax.bench.meow` targets