### PR TITLE
Add unaligned versions of cub::DeviceTransform babelstream and fill benchmarks

### DIFF
--- a/cub/benchmarks/bench/transform/babelstream.cu
+++ b/cub/benchmarks/bench/transform/babelstream.cu
@@ -83,8 +83,8 @@ catch (const std::bad_alloc&)
 NVBENCH_BENCH_TYPES(mul, NVBENCH_TYPE_AXES(element_types))
   .set_name("mul")
   .set_type_axes_names({"T{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", array_size_powers)
-  .add_string_axis("Aligned", {"yes", "no"});
+  .add_string_axis("Aligned", {"yes", "no"})
+  .add_int64_power_of_two_axis("Elements{io}", array_size_powers);
 
 template <typename T>
 static void add(nvbench::state& state, nvbench::type_list<T>)
@@ -117,8 +117,8 @@ catch (const std::bad_alloc&)
 NVBENCH_BENCH_TYPES(add, NVBENCH_TYPE_AXES(element_types))
   .set_name("add")
   .set_type_axes_names({"T{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", array_size_powers)
-  .add_string_axis("Aligned", {"yes", "no"});
+  .add_string_axis("Aligned", {"yes", "no"})
+  .add_int64_power_of_two_axis("Elements{io}", array_size_powers);
 
 template <typename T>
 static void triad(nvbench::state& state, nvbench::type_list<T>)
@@ -152,8 +152,8 @@ catch (const std::bad_alloc&)
 NVBENCH_BENCH_TYPES(triad, NVBENCH_TYPE_AXES(element_types))
   .set_name("triad")
   .set_type_axes_names({"T{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", array_size_powers)
-  .add_string_axis("Aligned", {"yes", "no"});
+  .add_string_axis("Aligned", {"yes", "no"})
+  .add_int64_power_of_two_axis("Elements{io}", array_size_powers);
 
 template <typename T>
 static void nstream(nvbench::state& state, nvbench::type_list<T>)
@@ -187,5 +187,5 @@ catch (const std::bad_alloc&)
 NVBENCH_BENCH_TYPES(nstream, NVBENCH_TYPE_AXES(element_types))
   .set_name("nstream")
   .set_type_axes_names({"T{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", array_size_powers)
-  .add_string_axis("Aligned", {"yes", "no"});
+  .add_string_axis("Aligned", {"yes", "no"})
+  .add_int64_power_of_two_axis("Elements{io}", array_size_powers);

--- a/cub/benchmarks/bench/transform/babelstream.cu
+++ b/cub/benchmarks/bench/transform/babelstream.cu
@@ -59,19 +59,21 @@ template <typename T>
 static void mul(nvbench::state& state, nvbench::type_list<T>)
 try
 {
-  const auto n = state.get_int64("Elements{io}");
+  const auto n         = state.get_int64("Elements{io}");
+  const bool unaligned = state.get_string("Aligned") == "no";
 
-  thrust::device_vector<T> b(n, startB);
-  thrust::device_vector<T> c(n, startC);
+  thrust::device_vector<T> b(n + unaligned, startB);
+  thrust::device_vector<T> c(n + unaligned, startC);
 
   state.add_element_count(n);
   state.add_global_memory_reads<T>(n);
   state.add_global_memory_writes<T>(n);
 
   const T scalar = startScalar;
-  bench_transform(state, cuda::std::tuple{c.begin()}, b.begin(), n, [=] _CCCL_DEVICE(const T& ci) {
-    return ci * scalar;
-  });
+  bench_transform(
+    state, cuda::std::tuple{c.begin() + unaligned}, b.begin() + unaligned, n, [=] _CCCL_DEVICE(const T& ci) {
+      return ci * scalar;
+    });
 }
 catch (const std::bad_alloc&)
 {
@@ -81,23 +83,29 @@ catch (const std::bad_alloc&)
 NVBENCH_BENCH_TYPES(mul, NVBENCH_TYPE_AXES(element_types))
   .set_name("mul")
   .set_type_axes_names({"T{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", array_size_powers);
+  .add_int64_power_of_two_axis("Elements{io}", array_size_powers)
+  .add_string_axis("Aligned", {"yes", "no"});
 
 template <typename T>
 static void add(nvbench::state& state, nvbench::type_list<T>)
 try
 {
-  const auto n = state.get_int64("Elements{io}");
+  const auto n         = state.get_int64("Elements{io}");
+  const bool unaligned = state.get_string("Aligned") == "no";
 
-  thrust::device_vector<T> a(n, startA);
-  thrust::device_vector<T> b(n, startB);
-  thrust::device_vector<T> c(n, startC);
+  thrust::device_vector<T> a(n + unaligned, startA);
+  thrust::device_vector<T> b(n + unaligned, startB);
+  thrust::device_vector<T> c(n + unaligned, startC);
 
   state.add_element_count(n);
   state.add_global_memory_reads<T>(2 * n);
   state.add_global_memory_writes<T>(n);
   bench_transform(
-    state, cuda::std::tuple{a.begin(), b.begin()}, c.begin(), n, [] _CCCL_DEVICE(const T& ai, const T& bi) -> T {
+    state,
+    cuda::std::tuple{a.begin() + unaligned, b.begin() + unaligned},
+    c.begin() + unaligned,
+    n,
+    [] _CCCL_DEVICE(const T& ai, const T& bi) -> T {
       return ai + bi;
     });
 }
@@ -109,24 +117,30 @@ catch (const std::bad_alloc&)
 NVBENCH_BENCH_TYPES(add, NVBENCH_TYPE_AXES(element_types))
   .set_name("add")
   .set_type_axes_names({"T{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", array_size_powers);
+  .add_int64_power_of_two_axis("Elements{io}", array_size_powers)
+  .add_string_axis("Aligned", {"yes", "no"});
 
 template <typename T>
 static void triad(nvbench::state& state, nvbench::type_list<T>)
 try
 {
-  const auto n = state.get_int64("Elements{io}");
+  const auto n         = state.get_int64("Elements{io}");
+  const bool unaligned = state.get_string("Aligned") == "no";
 
-  thrust::device_vector<T> a(n, startA);
-  thrust::device_vector<T> b(n, startB);
-  thrust::device_vector<T> c(n, startC);
+  thrust::device_vector<T> a(n + unaligned, startA);
+  thrust::device_vector<T> b(n + unaligned, startB);
+  thrust::device_vector<T> c(n + unaligned, startC);
 
   state.add_element_count(n);
   state.add_global_memory_reads<T>(2 * n);
   state.add_global_memory_writes<T>(n);
   const T scalar = startScalar;
   bench_transform(
-    state, cuda::std::tuple{b.begin(), c.begin()}, a.begin(), n, [=] _CCCL_DEVICE(const T& bi, const T& ci) {
+    state,
+    cuda::std::tuple{b.begin() + unaligned, c.begin() + unaligned},
+    a.begin() + unaligned,
+    n,
+    [=] _CCCL_DEVICE(const T& bi, const T& ci) {
       return bi + scalar * ci;
     });
 }
@@ -138,17 +152,19 @@ catch (const std::bad_alloc&)
 NVBENCH_BENCH_TYPES(triad, NVBENCH_TYPE_AXES(element_types))
   .set_name("triad")
   .set_type_axes_names({"T{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", array_size_powers);
+  .add_int64_power_of_two_axis("Elements{io}", array_size_powers)
+  .add_string_axis("Aligned", {"yes", "no"});
 
 template <typename T>
 static void nstream(nvbench::state& state, nvbench::type_list<T>)
 try
 {
-  const auto n = state.get_int64("Elements{io}");
+  const auto n         = state.get_int64("Elements{io}");
+  const bool unaligned = state.get_string("Aligned") == "no";
 
-  thrust::device_vector<T> a(n, startA);
-  thrust::device_vector<T> b(n, startB);
-  thrust::device_vector<T> c(n, startC);
+  thrust::device_vector<T> a(n + unaligned, startA);
+  thrust::device_vector<T> b(n + unaligned, startB);
+  thrust::device_vector<T> c(n + unaligned, startC);
 
   state.add_element_count(n);
   state.add_global_memory_reads<T>(3 * n);
@@ -156,8 +172,8 @@ try
   const T scalar = startScalar;
   bench_transform(
     state,
-    cuda::std::tuple{a.begin(), b.begin(), c.begin()},
-    a.begin(),
+    cuda::std::tuple{a.begin() + unaligned, b.begin() + unaligned, c.begin() + unaligned},
+    a.begin() + unaligned,
     n,
     [=] _CCCL_DEVICE(const T& ai, const T& bi, const T& ci) {
       return ai + bi + scalar * ci;
@@ -171,4 +187,5 @@ catch (const std::bad_alloc&)
 NVBENCH_BENCH_TYPES(nstream, NVBENCH_TYPE_AXES(element_types))
   .set_name("nstream")
   .set_type_axes_names({"T{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", array_size_powers);
+  .add_int64_power_of_two_axis("Elements{io}", array_size_powers)
+  .add_string_axis("Aligned", {"yes", "no"});

--- a/cub/benchmarks/bench/transform/fill.cu
+++ b/cub/benchmarks/bench/transform/fill.cu
@@ -60,5 +60,5 @@ catch (const std::bad_alloc&)
 NVBENCH_BENCH_TYPES(fill, NVBENCH_TYPE_AXES(integral_types))
   .set_name("fill")
   .set_type_axes_names({"T{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 32, 4))
-  .add_string_axis("Aligned", {"yes", "no"});
+  .add_string_axis("Aligned", {"yes", "no"})
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 32, 4));

--- a/cub/benchmarks/bench/transform/fill.cu
+++ b/cub/benchmarks/bench/transform/fill.cu
@@ -41,15 +41,16 @@ static void fill(nvbench::state& state, nvbench::type_list<T>)
 try
 {
   // A 32-bit offset type or the value 0 or 0xFF... have <1% performance impact
-  const auto value = T{42};
-  const auto n     = state.get_int64("Elements{io}");
-  thrust::device_vector<T> out(n);
+  const auto value     = T{42};
+  const auto n         = state.get_int64("Elements{io}");
+  const bool unaligned = state.get_string("Aligned") == "no";
+  thrust::device_vector<T> out(n + unaligned);
 
   state.add_element_count(n);
   state.add_global_memory_reads<T>(0);
   state.add_global_memory_writes<T>(n);
 
-  bench_transform(state, cuda::std::tuple{}, out.begin(), n, return_constant<T>{value});
+  bench_transform(state, cuda::std::tuple{}, out.begin() + unaligned, n, return_constant<T>{value});
 }
 catch (const std::bad_alloc&)
 {
@@ -59,4 +60,5 @@ catch (const std::bad_alloc&)
 NVBENCH_BENCH_TYPES(fill, NVBENCH_TYPE_AXES(integral_types))
   .set_name("fill")
   .set_type_axes_names({"T{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 32, 4));
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 32, 4))
+  .add_string_axis("Aligned", {"yes", "no"});

--- a/cub/benchmarks/bench/transform/tile/babelstream.cu
+++ b/cub/benchmarks/bench/transform/tile/babelstream.cu
@@ -109,14 +109,15 @@ template <typename T>
 static void mul(nvbench::state& state, nvbench::type_list<T>)
 try
 {
-  const auto n = state.get_int64("Elements{io}");
-  thrust::device_vector<T> b(n, startB);
-  thrust::device_vector<T> c(n, startC);
+  const auto n         = state.get_int64("Elements{io}");
+  const bool unaligned = state.get_string("Aligned") == "no";
+  thrust::device_vector<T> b(n + unaligned, startB);
+  thrust::device_vector<T> c(n + unaligned, startC);
 
   state.add_element_count(n);
   state.add_global_memory_reads<T>(n);
   state.add_global_memory_writes<T>(n);
-  bench_transform(state, cuda::std::tuple{c.begin()}, b.begin(), n, mul_op{});
+  bench_transform(state, cuda::std::tuple{c.begin() + unaligned}, b.begin() + unaligned, n, mul_op{});
 }
 catch (const std::bad_alloc&)
 {
@@ -126,21 +127,24 @@ catch (const std::bad_alloc&)
 NVBENCH_BENCH_TYPES(mul, NVBENCH_TYPE_AXES(element_types))
   .set_name("tile_mul")
   .set_type_axes_names({"T{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", array_size_powers);
+  .add_int64_power_of_two_axis("Elements{io}", array_size_powers)
+  .add_string_axis("Aligned", {"yes", "no"});
 
 template <typename T>
 static void add(nvbench::state& state, nvbench::type_list<T>)
 try
 {
-  const auto n = state.get_int64("Elements{io}");
-  thrust::device_vector<T> a(n, startA);
-  thrust::device_vector<T> b(n, startB);
-  thrust::device_vector<T> c(n, startC);
+  const auto n         = state.get_int64("Elements{io}");
+  const bool unaligned = state.get_string("Aligned") == "no";
+  thrust::device_vector<T> a(n + unaligned, startA);
+  thrust::device_vector<T> b(n + unaligned, startB);
+  thrust::device_vector<T> c(n + unaligned, startC);
 
   state.add_element_count(n);
   state.add_global_memory_reads<T>(2 * n);
   state.add_global_memory_writes<T>(n);
-  bench_transform(state, cuda::std::tuple{a.begin(), b.begin()}, c.begin(), n, add_op{});
+  bench_transform(
+    state, cuda::std::tuple{a.begin() + unaligned, b.begin() + unaligned}, c.begin() + unaligned, n, add_op{});
 }
 catch (const std::bad_alloc&)
 {
@@ -150,21 +154,24 @@ catch (const std::bad_alloc&)
 NVBENCH_BENCH_TYPES(add, NVBENCH_TYPE_AXES(element_types))
   .set_name("tile_add")
   .set_type_axes_names({"T{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", array_size_powers);
+  .add_int64_power_of_two_axis("Elements{io}", array_size_powers)
+  .add_string_axis("Aligned", {"yes", "no"});
 
 template <typename T>
 static void triad(nvbench::state& state, nvbench::type_list<T>)
 try
 {
-  const auto n = state.get_int64("Elements{io}");
-  thrust::device_vector<T> a(n, startA);
-  thrust::device_vector<T> b(n, startB);
-  thrust::device_vector<T> c(n, startC);
+  const auto n         = state.get_int64("Elements{io}");
+  const bool unaligned = state.get_string("Aligned") == "no";
+  thrust::device_vector<T> a(n + unaligned, startA);
+  thrust::device_vector<T> b(n + unaligned, startB);
+  thrust::device_vector<T> c(n + unaligned, startC);
 
   state.add_element_count(n);
   state.add_global_memory_reads<T>(2 * n);
   state.add_global_memory_writes<T>(n);
-  bench_transform(state, cuda::std::tuple{b.begin(), c.begin()}, a.begin(), n, triad_op{});
+  bench_transform(
+    state, cuda::std::tuple{b.begin() + unaligned, c.begin() + unaligned}, a.begin() + unaligned, n, triad_op{});
 }
 catch (const std::bad_alloc&)
 {
@@ -174,21 +181,28 @@ catch (const std::bad_alloc&)
 NVBENCH_BENCH_TYPES(triad, NVBENCH_TYPE_AXES(element_types))
   .set_name("tile_triad")
   .set_type_axes_names({"T{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", array_size_powers);
+  .add_int64_power_of_two_axis("Elements{io}", array_size_powers)
+  .add_string_axis("Aligned", {"yes", "no"});
 
 template <typename T>
 static void nstream(nvbench::state& state, nvbench::type_list<T>)
 try
 {
-  const auto n = state.get_int64("Elements{io}");
-  thrust::device_vector<T> a(n, startA);
-  thrust::device_vector<T> b(n, startB);
-  thrust::device_vector<T> c(n, startC);
+  const auto n         = state.get_int64("Elements{io}");
+  const bool unaligned = state.get_string("Aligned") == "no";
+  thrust::device_vector<T> a(n + unaligned, startA);
+  thrust::device_vector<T> b(n + unaligned, startB);
+  thrust::device_vector<T> c(n + unaligned, startC);
 
   state.add_element_count(n);
   state.add_global_memory_reads<T>(3 * n);
   state.add_global_memory_writes<T>(n);
-  bench_transform(state, cuda::std::tuple{a.begin(), b.begin(), c.begin()}, a.begin(), n, nstream_op{});
+  bench_transform(
+    state,
+    cuda::std::tuple{a.begin() + unaligned, b.begin() + unaligned, c.begin() + unaligned},
+    a.begin() + unaligned,
+    n,
+    nstream_op{});
 }
 catch (const std::bad_alloc&)
 {
@@ -198,4 +212,5 @@ catch (const std::bad_alloc&)
 NVBENCH_BENCH_TYPES(nstream, NVBENCH_TYPE_AXES(element_types))
   .set_name("tile_nstream")
   .set_type_axes_names({"T{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", array_size_powers);
+  .add_int64_power_of_two_axis("Elements{io}", array_size_powers)
+  .add_string_axis("Aligned", {"yes", "no"});

--- a/cub/benchmarks/bench/transform/tile/babelstream.cu
+++ b/cub/benchmarks/bench/transform/tile/babelstream.cu
@@ -127,8 +127,8 @@ catch (const std::bad_alloc&)
 NVBENCH_BENCH_TYPES(mul, NVBENCH_TYPE_AXES(element_types))
   .set_name("tile_mul")
   .set_type_axes_names({"T{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", array_size_powers)
-  .add_string_axis("Aligned", {"yes", "no"});
+  .add_string_axis("Aligned", {"yes", "no"})
+  .add_int64_power_of_two_axis("Elements{io}", array_size_powers);
 
 template <typename T>
 static void add(nvbench::state& state, nvbench::type_list<T>)
@@ -154,8 +154,8 @@ catch (const std::bad_alloc&)
 NVBENCH_BENCH_TYPES(add, NVBENCH_TYPE_AXES(element_types))
   .set_name("tile_add")
   .set_type_axes_names({"T{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", array_size_powers)
-  .add_string_axis("Aligned", {"yes", "no"});
+  .add_string_axis("Aligned", {"yes", "no"})
+  .add_int64_power_of_two_axis("Elements{io}", array_size_powers);
 
 template <typename T>
 static void triad(nvbench::state& state, nvbench::type_list<T>)
@@ -181,8 +181,8 @@ catch (const std::bad_alloc&)
 NVBENCH_BENCH_TYPES(triad, NVBENCH_TYPE_AXES(element_types))
   .set_name("tile_triad")
   .set_type_axes_names({"T{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", array_size_powers)
-  .add_string_axis("Aligned", {"yes", "no"});
+  .add_string_axis("Aligned", {"yes", "no"})
+  .add_int64_power_of_two_axis("Elements{io}", array_size_powers);
 
 template <typename T>
 static void nstream(nvbench::state& state, nvbench::type_list<T>)
@@ -212,5 +212,5 @@ catch (const std::bad_alloc&)
 NVBENCH_BENCH_TYPES(nstream, NVBENCH_TYPE_AXES(element_types))
   .set_name("tile_nstream")
   .set_type_axes_names({"T{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", array_size_powers)
-  .add_string_axis("Aligned", {"yes", "no"});
+  .add_string_axis("Aligned", {"yes", "no"})
+  .add_int64_power_of_two_axis("Elements{io}", array_size_powers);


### PR DESCRIPTION
Fixes: #9880

And for the curious, on RTX 5090:
```
## mul

### [0] NVIDIA GeForce RTX 5090

| T{ct} | Aligned |   Elements{io}    | Samples |  CPU Time  |  Noise  |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil |
|-------|---------|-------------------|---------|------------|---------|------------|--------|----------|--------------|--------|
|    I8 |     yes |      2^16 = 65536 |     84x | 123.209 us | 740.62% |   4.094 us |  0.31% |  16.007G |  32.015 GB/s |  1.79% |
|    I8 |      no |      2^16 = 65536 |    302x |  22.860 us |   8.85% |   4.093 us |  0.45% |  16.013G |  32.027 GB/s |  1.79% |
|    I8 |     yes |    2^20 = 1048576 |    356x |  22.076 us |  12.17% |   4.096 us |  0.38% | 256.011G | 512.022 GB/s | 28.57% |
|    I8 |      no |    2^20 = 1048576 |     12x |  24.750 us |   5.14% |   6.144 us |  0.00% | 170.667G | 341.333 GB/s | 19.05% |
|    I8 |     yes |   2^24 = 16777216 |    116x |  39.261 us |   8.22% |  20.796 us |  3.58% | 806.757G |   1.614 TB/s | 90.03% |
|    I8 |      no |   2^24 = 16777216 |    278x |  45.295 us |   7.35% |  26.650 us |  0.92% | 629.539G |   1.259 TB/s | 70.26% |
|    I8 |     yes |  2^28 = 268435456 |    354x | 372.219 us |   0.98% | 352.915 us |  0.32% | 760.624G |   1.521 TB/s | 84.89% |
|    I8 |      no |  2^28 = 268435456 |    306x | 375.077 us |   0.99% | 355.011 us |  0.29% | 756.133G |   1.512 TB/s | 84.38% |
|    I8 |     yes | 2^32 = 4294967296 |    412x |   5.644 ms |   0.23% |   5.623 ms |  0.16% | 763.868G |   1.528 TB/s | 85.25% |
|    I8 |      no | 2^32 = 4294967296 |    402x |   5.668 ms |   0.04% |   5.649 ms |  0.03% | 760.276G |   1.521 TB/s | 84.85% |
|   I16 |     yes |      2^16 = 65536 |     28x |  21.656 us |   5.13% |   4.113 us |  1.53% |  15.933G |  63.733 GB/s |  3.56% |
|   I16 |      no |      2^16 = 65536 |     48x |  21.662 us |  12.69% |   4.095 us |  0.16% |  16.005G |  64.021 GB/s |  3.57% |
|   I16 |     yes |    2^20 = 1048576 |    350x |  23.120 us |   7.03% |   5.828 us | 12.65% | 179.920G | 719.679 GB/s | 40.16% |
|   I16 |      no |    2^20 = 1048576 |     12x |  23.635 us |   3.65% |   6.144 us |  0.00% | 170.667G | 682.667 GB/s | 38.09% |
|   I16 |     yes |   2^24 = 16777216 |     78x |  60.992 us |   2.29% |  43.058 us |  1.53% | 389.642G |   1.559 TB/s | 86.97% |
|   I16 |      no |   2^24 = 16777216 |    328x |  64.637 us |   2.36% |  46.757 us |  1.81% | 358.820G |   1.435 TB/s | 80.09% |
|   I16 |     yes |  2^28 = 268435456 |    344x | 726.669 us |   0.27% | 708.605 us |  0.16% | 378.823G |   1.515 TB/s | 84.55% |
|   I16 |      no |  2^28 = 268435456 |    362x | 727.333 us |   0.26% | 709.093 us |  0.14% | 378.562G |   1.514 TB/s | 84.49% |
|   I16 |     yes | 2^32 = 4294967296 |    382x |  11.255 ms |   0.21% |  11.237 ms |  0.21% | 382.233G |   1.529 TB/s | 85.31% |
|   I16 |      no | 2^32 = 4294967296 |    378x |  11.327 ms |   0.20% |  11.307 ms |  0.20% | 379.842G |   1.519 TB/s | 84.78% |
|   F32 |     yes |      2^16 = 65536 |    332x |  22.255 us |  80.43% |   4.095 us |  1.45% |  16.002G | 128.018 GB/s |  7.14% |
|   F32 |      no |      2^16 = 65536 |    376x |  21.227 us |   4.81% |   4.094 us |  0.24% |  16.010G | 128.077 GB/s |  7.15% |
|   F32 |     yes |    2^20 = 1048576 |     12x |  23.839 us |   2.09% |   6.144 us |  0.00% | 170.667G |   1.365 TB/s | 76.19% |
|   F32 |      no |    2^20 = 1048576 |    304x |  23.956 us |   4.48% |   6.468 us | 11.84% | 162.120G |   1.297 TB/s | 72.37% |
|   F32 |     yes |   2^24 = 16777216 |    430x | 106.518 us |   1.32% |  88.699 us |  1.09% | 189.148G |   1.513 TB/s | 84.43% |
|   F32 |      no |   2^24 = 16777216 |    426x | 107.632 us |   1.28% |  89.827 us |  1.13% | 186.772G |   1.494 TB/s | 83.37% |
|   F32 |     yes |  2^28 = 268435456 |    400x |   1.435 ms |   0.26% |   1.415 ms |  0.10% | 189.729G |   1.518 TB/s | 84.69% |
|   F32 |      no |  2^28 = 268435456 |    304x |   1.436 ms |   0.23% |   1.416 ms |  0.08% | 189.530G |   1.516 TB/s | 84.61% |
|   F64 |     yes |      2^16 = 65536 |    534x |  21.423 us |   6.99% |   4.209 us | 11.50% |  15.569G | 249.101 GB/s | 13.90% |
|   F64 |      no |      2^16 = 65536 |     12x |  21.887 us |   4.80% |   4.096 us |  0.00% |  16.000G | 256.000 GB/s | 14.28% |
|   F64 |     yes |    2^20 = 1048576 |    306x |  29.485 us |   6.10% |  11.878 us |  6.89% |  88.280G |   1.412 TB/s | 78.82% |
|   F64 |      no |    2^20 = 1048576 |    818x |  29.566 us |   5.62% |  12.255 us |  2.09% |  85.565G |   1.369 TB/s | 76.39% |
|   F64 |     yes |   2^24 = 16777216 |    320x | 194.239 us |   0.74% | 176.324 us |  0.54% |  95.150G |   1.522 TB/s | 84.95% |
|   F64 |      no |   2^24 = 16777216 |    334x | 195.679 us |   0.88% | 177.652 us |  0.60% |  94.439G |   1.511 TB/s | 84.31% |
|   F64 |     yes |  2^28 = 268435456 |    622x |   2.842 ms |   0.27% |   2.824 ms |  0.27% |  95.060G |   1.521 TB/s | 84.87% |
|   F64 |      no |  2^28 = 268435456 |    310x |   2.849 ms |   0.08% |   2.829 ms |  0.05% |  94.871G |   1.518 TB/s | 84.70% |
|  I128 |     yes |      2^16 = 65536 |    308x |  21.188 us |   5.10% |   4.093 us |  0.24% |  16.013G | 512.416 GB/s | 28.59% |
|  I128 |      no |      2^16 = 65536 |     12x |  21.719 us |   2.81% |   4.096 us |  0.00% |  16.000G | 512.000 GB/s | 28.57% |
|  I128 |     yes |    2^20 = 1048576 |    300x |  38.936 us |   4.97% |  21.146 us |  4.55% |  49.587G |   1.587 TB/s | 88.54% |
|  I128 |      no |    2^20 = 1048576 |    512x |  38.379 us |   5.52% |  20.575 us |  2.11% |  50.964G |   1.631 TB/s | 91.00% |
|  I128 |     yes |   2^24 = 16777216 |    344x | 371.258 us |   0.53% | 353.148 us |  0.33% |  47.508G |   1.520 TB/s | 84.83% |
|  I128 |      no |   2^24 = 16777216 |    336x | 372.707 us |   1.54% | 353.125 us |  0.31% |  47.511G |   1.520 TB/s | 84.83% |
|  I128 |     yes |  2^28 = 268435456 |    464x |   5.647 ms |   0.42% |   5.627 ms |  0.40% |  47.707G |   1.527 TB/s | 85.18% |
|  I128 |      no |  2^28 = 268435456 |    518x |   5.677 ms |   0.15% |   5.657 ms |  0.14% |  47.448G |   1.518 TB/s | 84.72% |

## add

### [0] NVIDIA GeForce RTX 5090

| T{ct} | Aligned |   Elements{io}    | Samples |  CPU Time  | Noise  |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil |
|-------|---------|-------------------|---------|------------|--------|------------|--------|----------|--------------|--------|
|    I8 |     yes |      2^16 = 65536 |    280x |  21.496 us |  8.76% |   4.093 us |  0.31% |  16.010G |  48.031 GB/s |  2.68% |
|    I8 |      no |      2^16 = 65536 |     64x |  21.271 us |  5.10% |   4.094 us |  0.25% |  16.010G |  48.029 GB/s |  2.68% |
|    I8 |     yes |    2^20 = 1048576 |     12x |  21.528 us |  2.87% |   4.096 us |  0.00% | 256.000G | 768.000 GB/s | 42.85% |
|    I8 |      no |    2^20 = 1048576 |     12x |  23.588 us |  2.94% |   6.144 us |  0.00% | 170.667G | 512.000 GB/s | 28.57% |
|    I8 |     yes |   2^24 = 16777216 |    316x |  51.665 us |  2.58% |  34.016 us |  2.94% | 493.218G |   1.480 TB/s | 82.56% |
|    I8 |      no |   2^24 = 16777216 |     12x |  52.809 us |  1.56% |  34.816 us |  0.00% | 481.882G |   1.446 TB/s | 80.67% |
|    I8 |     yes |  2^28 = 268435456 |    376x | 534.641 us |  0.33% | 516.752 us |  0.25% | 519.467G |   1.558 TB/s | 86.96% |
|    I8 |      no |  2^28 = 268435456 |    352x | 532.835 us |  0.39% | 514.772 us |  0.20% | 521.464G |   1.564 TB/s | 87.29% |
|    I8 |     yes | 2^32 = 4294967296 |    408x |   8.207 ms |  0.05% |   8.188 ms |  0.04% | 524.566G |   1.574 TB/s | 87.81% |
|    I8 |      no | 2^32 = 4294967296 |    366x |   8.196 ms |  0.04% |   8.176 ms |  0.02% | 525.291G |   1.576 TB/s | 87.93% |
|   I16 |     yes |      2^16 = 65536 |     12x |  22.620 us | 14.82% |   4.096 us |  0.00% |  16.000G |  96.000 GB/s |  5.36% |
|   I16 |      no |      2^16 = 65536 |     12x |  21.122 us |  2.52% |   4.096 us |  0.00% |  16.000G |  96.000 GB/s |  5.36% |
|   I16 |     yes |    2^20 = 1048576 |    334x |  23.996 us |  5.58% |   6.677 us | 13.48% | 157.048G | 942.287 GB/s | 52.58% |
|   I16 |      no |    2^20 = 1048576 |    304x |  24.450 us |  6.36% |   7.080 us | 14.43% | 148.106G | 888.637 GB/s | 49.59% |
|   I16 |     yes |   2^24 = 16777216 |    562x |  83.436 us |  1.45% |  65.651 us |  0.77% | 255.552G |   1.533 TB/s | 85.56% |
|   I16 |      no |   2^24 = 16777216 |    304x |  85.897 us |  1.73% |  68.080 us |  1.29% | 246.433G |   1.479 TB/s | 82.51% |
|   I16 |     yes |  2^28 = 268435456 |    360x |   1.047 ms |  0.17% |   1.029 ms |  0.14% | 260.784G |   1.565 TB/s | 87.31% |
|   I16 |      no |  2^28 = 268435456 |    394x |   1.045 ms |  0.30% |   1.027 ms |  0.11% | 261.452G |   1.569 TB/s | 87.53% |
|   I16 |     yes | 2^32 = 4294967296 |    494x |  16.391 ms |  0.13% |  16.371 ms |  0.13% | 262.355G |   1.574 TB/s | 87.84% |
|   I16 |      no | 2^32 = 4294967296 |    308x |  16.374 ms |  0.16% |  16.354 ms |  0.16% | 262.621G |   1.576 TB/s | 87.92% |
|   F32 |     yes |      2^16 = 65536 |     78x |  21.308 us |  3.54% |   4.156 us |  7.88% |  15.768G | 189.214 GB/s | 10.56% |
|   F32 |      no |      2^16 = 65536 |    362x |  21.607 us |  7.02% |   4.462 us | 17.71% |  14.687G | 176.242 GB/s |  9.83% |
|   F32 |     yes |    2^20 = 1048576 |     12x |  27.775 us |  1.41% |  10.240 us |  0.00% | 102.400G |   1.229 TB/s | 68.57% |
|   F32 |      no |    2^20 = 1048576 |     12x |  27.800 us |  1.46% |  10.240 us |  0.00% | 102.400G |   1.229 TB/s | 68.57% |
|   F32 |     yes |   2^24 = 16777216 |    304x | 149.057 us |  0.83% | 131.230 us |  0.62% | 127.846G |   1.534 TB/s | 85.60% |
|   F32 |      no |   2^24 = 16777216 |    366x | 147.243 us |  1.08% | 129.380 us |  0.71% | 129.674G |   1.556 TB/s | 86.83% |
|   F32 |     yes |  2^28 = 268435456 |    390x |   2.072 ms |  0.20% |   2.054 ms |  0.08% | 130.668G |   1.568 TB/s | 87.49% |
|   F32 |      no |  2^28 = 268435456 |    306x |   2.070 ms |  0.08% |   2.052 ms |  0.07% | 130.805G |   1.570 TB/s | 87.59% |
|   F64 |     yes |      2^16 = 65536 |    310x |  22.261 us |  6.37% |   5.130 us | 19.91% |  12.775G | 306.594 GB/s | 17.11% |
|   F64 |      no |      2^16 = 65536 |     12x |  21.382 us |  4.54% |   4.096 us |  0.00% |  16.000G | 384.000 GB/s | 21.43% |
|   F64 |     yes |    2^20 = 1048576 |    300x |  33.919 us |  2.85% |  16.552 us |  3.43% |  63.350G |   1.520 TB/s | 84.84% |
|   F64 |      no |    2^20 = 1048576 |    408x |  35.789 us |  2.80% |  18.431 us |  0.07% |  56.892G |   1.365 TB/s | 76.19% |
|   F64 |     yes |   2^24 = 16777216 |    350x | 277.900 us |  0.50% | 260.241 us |  0.45% |  64.468G |   1.547 TB/s | 86.34% |
|   F64 |      no |   2^24 = 16777216 |    620x | 276.997 us |  0.83% | 259.173 us |  0.41% |  64.734G |   1.554 TB/s | 86.69% |
|   F64 |     yes |  2^28 = 268435456 |    330x |   4.120 ms |  0.17% |   4.101 ms |  0.06% |  65.452G |   1.571 TB/s | 87.65% |
|   F64 |      no |  2^28 = 268435456 |    314x |   4.118 ms |  0.07% |   4.100 ms |  0.05% |  65.470G |   1.571 TB/s | 87.68% |
|  I128 |     yes |      2^16 = 65536 |     12x |  23.625 us |  3.63% |   6.144 us |  0.00% |  10.667G | 512.000 GB/s | 28.57% |
|  I128 |      no |      2^16 = 65536 |    302x |  23.232 us |  3.56% |   6.141 us |  0.16% |  10.672G | 512.265 GB/s | 28.58% |
|  I128 |     yes |    2^20 = 1048576 |     22x |  50.312 us |  1.81% |  32.767 us |  0.02% |  32.001G |   1.536 TB/s | 85.71% |
|  I128 |      no |    2^20 = 1048576 |     12x |  50.659 us |  0.63% |  32.768 us |  0.00% |  32.000G |   1.536 TB/s | 85.71% |
|  I128 |     yes |   2^24 = 16777216 |    338x | 534.658 us |  0.26% | 516.972 us |  0.24% |  32.453G |   1.558 TB/s | 86.92% |
|  I128 |      no |   2^24 = 16777216 |    456x | 532.189 us |  0.25% | 514.402 us |  0.20% |  32.615G |   1.566 TB/s | 87.36% |
|  I128 |     yes |  2^28 = 268435456 |    378x |   8.211 ms |  0.05% |   8.192 ms |  0.04% |  32.767G |   1.573 TB/s | 87.76% |
|  I128 |      no |  2^28 = 268435456 |    370x |   8.212 ms |  0.25% |   8.194 ms |  0.24% |  32.761G |   1.573 TB/s | 87.75% |

## triad

### [0] NVIDIA GeForce RTX 5090

| T{ct} | Aligned |   Elements{io}    | Samples |  CPU Time  | Noise |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil |
|-------|---------|-------------------|---------|------------|-------|------------|--------|----------|--------------|--------|
|    I8 |     yes |      2^16 = 65536 |     12x |  23.118 us | 8.19% |   4.096 us |  0.00% |  16.000G |  48.000 GB/s |  2.68% |
|    I8 |      no |      2^16 = 65536 |    390x |  21.283 us | 5.33% |   4.093 us |  0.27% |  16.012G |  48.037 GB/s |  2.68% |
|    I8 |     yes |    2^20 = 1048576 |    326x |  23.398 us | 4.27% |   6.141 us |  0.15% | 170.751G | 512.254 GB/s | 28.58% |
|    I8 |      no |    2^20 = 1048576 |     12x |  23.334 us | 3.26% |   6.144 us |  0.00% | 170.667G | 512.000 GB/s | 28.57% |
|    I8 |     yes |   2^24 = 16777216 |    328x |  52.106 us | 2.98% |  34.456 us |  2.25% | 486.910G |   1.461 TB/s | 81.51% |
|    I8 |      no |   2^24 = 16777216 |    316x |  53.656 us | 4.03% |  35.979 us |  2.82% | 466.301G |   1.399 TB/s | 78.06% |
|    I8 |     yes |  2^28 = 268435456 |    372x | 533.879 us | 0.30% | 516.145 us |  0.19% | 520.078G |   1.560 TB/s | 87.06% |
|    I8 |      no |  2^28 = 268435456 |    332x | 532.435 us | 0.28% | 514.365 us |  0.15% | 521.877G |   1.566 TB/s | 87.36% |
|    I8 |     yes | 2^32 = 4294967296 |    372x |   8.207 ms | 0.04% |   8.189 ms |  0.04% | 524.499G |   1.573 TB/s | 87.80% |
|    I8 |      no | 2^32 = 4294967296 |    578x |   8.198 ms | 0.04% |   8.179 ms |  0.02% | 525.126G |   1.575 TB/s | 87.91% |
|   I16 |     yes |      2^16 = 65536 |     12x |  21.551 us | 4.93% |   4.096 us |  0.00% |  16.000G |  96.000 GB/s |  5.36% |
|   I16 |      no |      2^16 = 65536 |     12x |  21.739 us | 5.58% |   4.096 us |  0.00% |  16.000G |  96.000 GB/s |  5.36% |
|   I16 |     yes |    2^20 = 1048576 |     12x |  23.711 us | 2.46% |   6.144 us |  0.00% | 170.667G |   1.024 TB/s | 57.14% |
|   I16 |      no |    2^20 = 1048576 |    330x |  25.320 us | 7.78% |   7.645 us | 11.86% | 137.150G | 822.899 GB/s | 45.92% |
|   I16 |     yes |   2^24 = 16777216 |     12x |  83.614 us | 0.97% |  65.536 us |  0.00% | 256.000G |   1.536 TB/s | 85.71% |
|   I16 |      no |   2^24 = 16777216 |     12x |  85.842 us | 1.45% |  67.584 us |  0.00% | 248.242G |   1.489 TB/s | 83.11% |
|   I16 |     yes |  2^28 = 268435456 |    312x |   1.049 ms | 0.32% |   1.030 ms |  0.13% | 260.580G |   1.563 TB/s | 87.24% |
|   I16 |      no |  2^28 = 268435456 |    440x |   1.048 ms | 0.50% |   1.027 ms |  0.11% | 261.376G |   1.568 TB/s | 87.51% |
|   I16 |     yes | 2^32 = 4294967296 |    462x |  16.396 ms | 0.14% |  16.372 ms |  0.14% | 262.335G |   1.574 TB/s | 87.83% |
|   I16 |      no | 2^32 = 4294967296 |    438x |  16.376 ms | 0.14% |  16.355 ms |  0.13% | 262.613G |   1.576 TB/s | 87.92% |
|   F32 |     yes |      2^16 = 65536 |    334x |  21.545 us | 5.46% |   4.170 us |  9.28% |  15.716G | 188.594 GB/s | 10.52% |
|   F32 |      no |      2^16 = 65536 |     12x |  21.557 us | 3.68% |   4.096 us |  0.00% |  16.000G | 192.000 GB/s | 10.71% |
|   F32 |     yes |    2^20 = 1048576 |     12x |  28.467 us | 4.53% |  10.240 us |  0.00% | 102.400G |   1.229 TB/s | 68.57% |
|   F32 |      no |    2^20 = 1048576 |    312x |  28.366 us | 7.43% |  10.674 us |  7.84% |  98.240G |   1.179 TB/s | 65.78% |
|   F32 |     yes |   2^24 = 16777216 |    326x | 150.218 us | 1.16% | 132.282 us |  0.86% | 126.829G |   1.522 TB/s | 84.92% |
|   F32 |      no |   2^24 = 16777216 |    338x | 148.757 us | 0.99% | 130.719 us |  0.65% | 128.346G |   1.540 TB/s | 85.94% |
|   F32 |     yes |  2^28 = 268435456 |    334x |   2.073 ms | 0.25% |   2.055 ms |  0.08% | 130.656G |   1.568 TB/s | 87.49% |
|   F32 |      no |  2^28 = 268435456 |    336x |   2.071 ms | 0.09% |   2.053 ms |  0.07% | 130.753G |   1.569 TB/s | 87.55% |
|   F64 |     yes |      2^16 = 65536 |    354x |  22.620 us | 6.92% |   5.180 us | 19.69% |  12.651G | 303.624 GB/s | 16.94% |
|   F64 |      no |      2^16 = 65536 |    674x |  23.220 us | 4.04% |   6.137 us |  1.29% |  10.678G | 256.271 GB/s | 14.30% |
|   F64 |     yes |    2^20 = 1048576 |    302x |  35.879 us | 2.35% |  18.382 us |  1.67% |  57.044G |   1.369 TB/s | 76.39% |
|   F64 |      no |    2^20 = 1048576 |    320x |  36.056 us | 4.98% |  18.430 us |  0.06% |  56.894G |   1.365 TB/s | 76.19% |
|   F64 |     yes |   2^24 = 16777216 |    412x | 277.607 us | 0.55% | 259.820 us |  0.38% |  64.572G |   1.550 TB/s | 86.47% |
|   F64 |      no |   2^24 = 16777216 |    300x | 277.021 us | 0.48% | 259.323 us |  0.42% |  64.696G |   1.553 TB/s | 86.64% |
|   F64 |     yes |  2^28 = 268435456 |    476x |   4.120 ms | 0.41% |   4.102 ms |  0.41% |  65.437G |   1.570 TB/s | 87.63% |
|   F64 |      no |  2^28 = 268435456 |    332x |   4.118 ms | 0.06% |   4.100 ms |  0.05% |  65.468G |   1.571 TB/s | 87.67% |
|  I128 |     yes |      2^16 = 65536 |    312x |  23.509 us | 4.79% |   6.140 us |  0.16% |  10.673G | 512.299 GB/s | 28.59% |
|  I128 |      no |      2^16 = 65536 |     12x |  23.586 us | 3.82% |   6.144 us |  0.00% |  10.667G | 512.000 GB/s | 28.57% |
|  I128 |     yes |    2^20 = 1048576 |    304x |  50.372 us | 3.91% |  32.792 us |  0.71% |  31.977G |   1.535 TB/s | 85.65% |
|  I128 |      no |    2^20 = 1048576 |    368x |  51.037 us | 5.41% |  33.271 us |  2.66% |  31.516G |   1.513 TB/s | 84.41% |
|  I128 |     yes |   2^24 = 16777216 |    364x | 534.350 us | 0.29% | 516.365 us |  0.20% |  32.491G |   1.560 TB/s | 87.02% |
|  I128 |      no |   2^24 = 16777216 |    388x | 533.694 us | 0.62% | 515.832 us |  0.21% |  32.525G |   1.561 TB/s | 87.11% |
|  I128 |     yes |  2^28 = 268435456 |    378x |   8.212 ms | 0.04% |   8.193 ms |  0.04% |  32.763G |   1.573 TB/s | 87.75% |
|  I128 |      no |  2^28 = 268435456 |    338x |   8.214 ms | 0.24% |   8.196 ms |  0.24% |  32.754G |   1.572 TB/s | 87.73% |

## nstream

### [0] NVIDIA GeForce RTX 5090

| T{ct} | Aligned |   Elements{io}    | Samples |  CPU Time  | Noise  |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil |
|-------|---------|-------------------|---------|------------|--------|------------|--------|----------|--------------|--------|
|    I8 |     yes |      2^16 = 65536 |     12x |  23.845 us |  4.67% |   4.096 us |  0.00% |  16.000G |  64.000 GB/s |  3.57% |
|    I8 |      no |      2^16 = 65536 |     58x |  22.207 us |  9.54% |   4.307 us | 14.61% |  15.215G |  60.860 GB/s |  3.40% |
|    I8 |     yes |    2^20 = 1048576 |    382x |  23.742 us |  5.06% |   6.546 us | 12.43% | 160.198G | 640.791 GB/s | 35.76% |
|    I8 |      no |    2^20 = 1048576 |    346x |  23.484 us |  5.40% |   6.189 us |  4.98% | 169.425G | 677.699 GB/s | 37.82% |
|    I8 |     yes |   2^24 = 16777216 |    550x |  61.435 us |  3.14% |  43.714 us |  2.23% | 383.798G |   1.535 TB/s | 85.66% |
|    I8 |      no |   2^24 = 16777216 |    300x |  64.912 us |  3.02% |  47.196 us |  1.16% | 355.479G |   1.422 TB/s | 79.34% |
|    I8 |     yes |  2^28 = 268435456 |    396x | 693.966 us |  0.21% | 676.190 us |  0.17% | 396.982G |   1.588 TB/s | 88.61% |
|    I8 |      no |  2^28 = 268435456 |    332x | 693.775 us |  0.18% | 675.948 us |  0.12% | 397.125G |   1.588 TB/s | 88.64% |
|    I8 |     yes | 2^32 = 4294967296 |    450x |  10.770 ms |  0.23% |  10.751 ms |  0.23% | 399.479G |   1.598 TB/s | 89.16% |
|    I8 |      no | 2^32 = 4294967296 |    480x |  10.750 ms |  0.10% |  10.732 ms |  0.09% | 400.209G |   1.601 TB/s | 89.33% |
|   I16 |     yes |      2^16 = 65536 |    198x |  21.584 us |  7.91% |   4.151 us |  8.79% |  15.786G | 126.291 GB/s |  7.05% |
|   I16 |      no |      2^16 = 65536 |     12x |  21.466 us |  4.28% |   4.096 us |  0.00% |  16.000G | 128.000 GB/s |  7.14% |
|   I16 |     yes |    2^20 = 1048576 |     12x |  25.662 us |  2.03% |   8.192 us |  0.00% | 128.000G |   1.024 TB/s | 57.14% |
|   I16 |      no |    2^20 = 1048576 |    476x |  25.653 us |  6.46% |   8.191 us |  0.05% | 128.009G |   1.024 TB/s | 57.14% |
|   I16 |     yes |   2^24 = 16777216 |     12x | 106.207 us |  0.68% |  88.064 us |  0.00% | 190.512G |   1.524 TB/s | 85.04% |
|   I16 |      no |   2^24 = 16777216 |    304x | 105.088 us |  1.94% |  86.829 us |  1.16% | 193.222G |   1.546 TB/s | 86.25% |
|   I16 |     yes |  2^28 = 268435456 |    358x |   1.372 ms |  0.14% |   1.354 ms |  0.12% | 198.260G |   1.586 TB/s | 88.50% |
|   I16 |      no |  2^28 = 268435456 |    304x |   1.366 ms |  0.11% |   1.348 ms |  0.10% | 199.100G |   1.593 TB/s | 88.88% |
|   I16 |     yes | 2^32 = 4294967296 |    508x |  21.531 ms |  0.17% |  21.508 ms |  0.17% | 199.694G |   1.598 TB/s | 89.14% |
|   I16 |      no | 2^32 = 4294967296 |    570x |  21.502 ms |  0.16% |  21.483 ms |  0.16% | 199.928G |   1.599 TB/s | 89.25% |
|   F32 |     yes |      2^16 = 65536 |    446x |  21.886 us |  5.74% |   4.629 us | 19.59% |  14.157G | 226.515 GB/s | 12.64% |
|   F32 |      no |      2^16 = 65536 |    354x |  23.543 us | 14.02% |   6.102 us |  4.66% |  10.739G | 171.830 GB/s |  9.59% |
|   F32 |     yes |    2^20 = 1048576 |    924x |  30.951 us |  4.84% |  13.576 us |  7.28% |  77.236G |   1.236 TB/s | 68.96% |
|   F32 |      no |    2^20 = 1048576 |     12x |  32.010 us |  3.06% |  14.336 us |  0.00% |  73.143G |   1.170 TB/s | 65.30% |
|   F32 |     yes |   2^24 = 16777216 |    310x | 188.425 us |  0.68% | 170.531 us |  0.53% |  98.382G |   1.574 TB/s | 87.83% |
|   F32 |      no |   2^24 = 16777216 |    304x | 189.633 us |  0.53% | 171.721 us |  0.49% |  97.700G |   1.563 TB/s | 87.23% |
|   F32 |     yes |  2^28 = 268435456 |    348x |   2.715 ms |  0.20% |   2.695 ms |  0.10% |  99.587G |   1.593 TB/s | 88.91% |
|   F32 |      no |  2^28 = 268435456 |    412x |   2.710 ms |  0.26% |   2.691 ms |  0.08% |  99.739G |   1.596 TB/s | 89.05% |
|   F64 |     yes |      2^16 = 65536 |    348x |  24.533 us | 12.39% |   6.144 us |  1.04% |  10.667G | 341.338 GB/s | 19.05% |
|   F64 |      no |      2^16 = 65536 |    474x |  24.585 us | 14.59% |   6.141 us |  0.16% |  10.673G | 341.525 GB/s | 19.06% |
|   F64 |     yes |    2^20 = 1048576 |    298x |  43.189 us |  8.69% |  24.340 us |  2.68% |  43.080G |   1.379 TB/s | 76.92% |
|   F64 |      no |    2^20 = 1048576 |     12x |  43.386 us |  6.98% |  24.576 us |  0.00% |  42.667G |   1.365 TB/s | 76.19% |
|   F64 |     yes |   2^24 = 16777216 |    322x | 362.351 us |  0.97% | 342.364 us |  0.28% |  49.004G |   1.568 TB/s | 87.50% |
|   F64 |      no |   2^24 = 16777216 |    348x | 358.930 us |  0.41% | 341.161 us |  0.34% |  49.177G |   1.574 TB/s | 87.81% |
|   F64 |     yes |  2^28 = 268435456 |    326x |   5.414 ms |  0.12% |   5.394 ms |  0.11% |  49.764G |   1.592 TB/s | 88.86% |
|   F64 |      no |  2^28 = 268435456 |    412x |   5.401 ms |  0.42% |   5.382 ms |  0.42% |  49.880G |   1.596 TB/s | 89.07% |
|  I128 |     yes |      2^16 = 65536 |     80x |  23.547 us |  5.29% |   6.246 us |  7.17% |  10.493G | 671.561 GB/s | 37.47% |
|  I128 |      no |      2^16 = 65536 |     12x |  23.291 us |  2.69% |   6.144 us |  0.00% |  10.667G | 682.667 GB/s | 38.09% |
|  I128 |     yes |    2^20 = 1048576 |    348x |  63.021 us |  3.82% |  45.277 us |  1.41% |  23.159G |   1.482 TB/s | 82.71% |
|  I128 |      no |    2^20 = 1048576 |    312x |  64.603 us |  3.54% |  46.807 us |  1.62% |  22.402G |   1.434 TB/s | 80.00% |
|  I128 |     yes |   2^24 = 16777216 |    336x | 699.831 us |  0.29% | 681.780 us |  0.23% |  24.608G |   1.575 TB/s | 87.88% |
|  I128 |      no |   2^24 = 16777216 |    312x | 695.023 us |  0.33% | 676.887 us |  0.17% |  24.786G |   1.586 TB/s | 88.51% |
|  I128 |     yes |  2^28 = 268435456 |    338x |  10.792 ms |  0.09% |  10.773 ms |  0.09% |  24.918G |   1.595 TB/s | 88.99% |
|  I128 |      no |  2^28 = 268435456 |    422x |  10.778 ms |  0.22% |  10.758 ms |  0.22% |  24.953G |   1.597 TB/s | 89.11% |

```