### PR TITLE
[libcu++] Use == and < in cuda::args instead of <=

### DIFF
--- a/libcudacxx/include/cuda/__argument/argument.h
+++ b/libcudacxx/include/cuda/__argument/argument.h
@@ -200,22 +200,22 @@ _CCCL_API constexpr _ElementType __wrapper_static_highest() noexcept
 template <class _ElementType, class _StaticBounds>
 _CCCL_API constexpr _ElementType __effective_lowest(runtime_bounds<_ElementType> __runtime_bounds) noexcept
 {
-  auto __static_lowest = __wrapper_static_lowest<_ElementType, _StaticBounds>();
-  return __static_lowest > __runtime_bounds.lower() ? __static_lowest : __runtime_bounds.lower();
+  const auto __static_lowest = __wrapper_static_lowest<_ElementType, _StaticBounds>();
+  return __static_lowest < __runtime_bounds.lower() ? __runtime_bounds.lower() : __static_lowest;
 }
 
 template <class _ElementType, class _StaticBounds>
 _CCCL_API constexpr _ElementType __effective_highest(runtime_bounds<_ElementType> __runtime_bounds) noexcept
 {
-  auto __static_highest = __wrapper_static_highest<_ElementType, _StaticBounds>();
+  const auto __static_highest = __wrapper_static_highest<_ElementType, _StaticBounds>();
   return __static_highest < __runtime_bounds.upper() ? __static_highest : __runtime_bounds.upper();
 }
 
 template <class _ElementType, class _StaticBounds>
 _CCCL_API constexpr bool __has_bounds_intersection(runtime_bounds<_ElementType> __runtime_bounds) noexcept
 {
-  return __effective_lowest<_ElementType, _StaticBounds>(__runtime_bounds)
-      <= __effective_highest<_ElementType, _StaticBounds>(__runtime_bounds);
+  return __bounds_less_equal(__effective_lowest<_ElementType, _StaticBounds>(__runtime_bounds),
+                             __effective_highest<_ElementType, _StaticBounds>(__runtime_bounds));
 }
 
 template <class _ElementType, class _StaticBounds>
@@ -233,9 +233,9 @@ _CCCL_API constexpr void __validate_static_element_bounds([[maybe_unused]] const
 {
   if constexpr (!::cuda::std::is_same_v<_StaticBounds, no_bounds>)
   {
-    _CCCL_ASSERT((__val >= __wrapper_static_lowest<_ElementType, _StaticBounds>()),
+    _CCCL_ASSERT((__bounds_greater_equal(__val, __wrapper_static_lowest<_ElementType, _StaticBounds>())),
                  "immediate argument value is below static lowest bound");
-    _CCCL_ASSERT((__val <= __wrapper_static_highest<_ElementType, _StaticBounds>()),
+    _CCCL_ASSERT((__bounds_less_equal(__val, __wrapper_static_highest<_ElementType, _StaticBounds>())),
                  "immediate argument value is above static highest bound");
   }
 }
@@ -244,8 +244,10 @@ template <class _ElementType>
 _CCCL_API constexpr void __validate_runtime_element_bounds(
   [[maybe_unused]] const _ElementType& __val, [[maybe_unused]] runtime_bounds<_ElementType> __runtime_bounds) noexcept
 {
-  _CCCL_ASSERT((__val >= __runtime_bounds.lower()), "immediate argument value is below runtime lower bound");
-  _CCCL_ASSERT((__val <= __runtime_bounds.upper()), "immediate argument value is above runtime upper bound");
+  _CCCL_ASSERT((__bounds_greater_equal(__val, __runtime_bounds.lower())),
+               "immediate argument value is below runtime lower bound");
+  _CCCL_ASSERT((__bounds_less_equal(__val, __runtime_bounds.upper())),
+               "immediate argument value is above runtime upper bound");
 }
 
 // =====================================================================

--- a/libcudacxx/include/cuda/__argument/argument_bounds.h
+++ b/libcudacxx/include/cuda/__argument/argument_bounds.h
@@ -30,6 +30,18 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_ARGUMENT
 
+template <class _Lhs, class _Rhs>
+[[nodiscard]] _CCCL_API constexpr bool __bounds_less_equal(const _Lhs& __lhs, const _Rhs& __rhs) noexcept
+{
+  return (__lhs < __rhs) || (__lhs == __rhs);
+}
+
+template <class _Lhs, class _Rhs>
+[[nodiscard]] _CCCL_API constexpr bool __bounds_greater_equal(const _Lhs& __lhs, const _Rhs& __rhs) noexcept
+{
+  return (__rhs < __lhs) || (__lhs == __rhs);
+}
+
 //! @brief Sentinel type indicating no bounds are present.
 struct no_bounds
 {};
@@ -50,7 +62,7 @@ class static_bounds
 public:
   static_assert(::cuda::std::is_same_v<decltype(_Lower), decltype(_Upper)>,
                 "Static bounds endpoints must have the same type");
-  static_assert(_Lower <= _Upper, "Lower bound must be <= upper bound");
+  static_assert(__bounds_less_equal(_Lower, _Upper), "Lower bound must be <= upper bound");
 
   [[nodiscard]] _CCCL_API static constexpr decltype(_Lower) lower() noexcept
   {
@@ -119,7 +131,7 @@ public:
       : __lower_(__lower)
       , __upper_(__upper)
   {
-    _CCCL_ASSERT(__lower <= __upper, "Runtime lower bound must be <= runtime upper bound");
+    _CCCL_ASSERT(__bounds_less_equal(__lower, __upper), "Runtime lower bound must be <= runtime upper bound");
   }
 
   [[nodiscard]] _CCCL_API constexpr _Tp lower() const noexcept

--- a/libcudacxx/test/libcudacxx/cuda/argument/argument_bounds.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/argument/argument_bounds.pass.cpp
@@ -11,9 +11,45 @@
 #include <cuda/argument>
 #include <cuda/std/cassert>
 #include <cuda/std/limits>
+#include <cuda/std/span>
 #include <cuda/std/type_traits>
 
 #include "test_macros.h"
+
+struct minimal_comparable_value
+{
+  int value;
+};
+
+TEST_FUNC constexpr bool operator<(minimal_comparable_value lhs, minimal_comparable_value rhs)
+{
+  return lhs.value < rhs.value;
+}
+
+TEST_FUNC constexpr bool operator==(minimal_comparable_value lhs, minimal_comparable_value rhs)
+{
+  return lhs.value == rhs.value;
+}
+
+namespace cuda::std
+{
+template <>
+class numeric_limits<minimal_comparable_value>
+{
+public:
+  static constexpr bool is_specialized = true;
+
+  TEST_FUNC static constexpr minimal_comparable_value lowest() noexcept
+  {
+    return {0};
+  }
+
+  TEST_FUNC static constexpr minimal_comparable_value max() noexcept
+  {
+    return {100};
+  }
+};
+} // namespace cuda::std
 
 TEST_FUNC constexpr bool test()
 {
@@ -88,6 +124,13 @@ TEST_FUNC constexpr bool test()
     static_assert(cuda::args::__is_bounds_v<decltype(b)>);
   }
 
+  // Runtime bounds only require operator< and operator==.
+  {
+    constexpr auto b = cuda::args::bounds(minimal_comparable_value{10}, minimal_comparable_value{20});
+    static_assert(b.lower() == minimal_comparable_value{10});
+    static_assert(b.upper() == minimal_comparable_value{20});
+  }
+
   // Static and runtime bounds intersection
   {
     static_assert(cuda::args::__has_bounds_intersection<int, cuda::args::static_bounds<1, 100>>(
@@ -95,6 +138,40 @@ TEST_FUNC constexpr bool test()
     static_assert(!cuda::args::__has_bounds_intersection<int, cuda::args::static_bounds<100, 200>>(
       cuda::args::runtime_bounds<int>{0, 50}));
   }
+
+  // Runtime bounds validation with no static bounds only requires operator< and operator==.
+  {
+    minimal_comparable_value values[] = {{10}, {20}};
+    [[maybe_unused]] auto arg         = cuda::args::deferred_sequence{
+      cuda::std::span<minimal_comparable_value>{values, 2},
+      cuda::args::bounds(minimal_comparable_value{5}, minimal_comparable_value{50})};
+  }
+
+  // Unsigned no-bounds arguments must not instantiate a pointless `value < 0` comparison.
+  {
+    unsigned int value        = 0;
+    [[maybe_unused]] auto arg = cuda::args::deferred{&value};
+  }
+
+#if TEST_HAS_CLASS_NTTP
+  // Static/runtime bounds intersection only requires operator< and operator==.
+  {
+    using static_bounds_t = cuda::args::static_bounds<minimal_comparable_value{10}, minimal_comparable_value{50}>;
+
+    constexpr auto runtime_bounds = cuda::args::bounds(minimal_comparable_value{20}, minimal_comparable_value{40});
+    static_assert(cuda::args::__has_bounds_intersection<minimal_comparable_value, static_bounds_t>(runtime_bounds));
+    static_assert(!cuda::args::__has_bounds_intersection<minimal_comparable_value, static_bounds_t>(
+      cuda::args::bounds(minimal_comparable_value{60}, minimal_comparable_value{70})));
+
+    cuda::args::__validate_static_element_bounds<minimal_comparable_value, static_bounds_t>(
+      minimal_comparable_value{30});
+    cuda::args::__validate_runtime_element_bounds(minimal_comparable_value{30}, runtime_bounds);
+
+    minimal_comparable_value values[] = {{20}, {30}};
+    [[maybe_unused]] auto arg         = cuda::args::__immediate_sequence{
+      cuda::std::span<minimal_comparable_value>{values, 2}, static_bounds_t{}, runtime_bounds};
+  }
+#endif // TEST_HAS_CLASS_NTTP
 
   // Non-bounds type
   {


### PR DESCRIPTION
@Jacobfaib reported `cuda::args` have issues working with types without `operator<=`. This PR switches the internals to use `==` and `<` instead