### PR TITLE
[places] Add checked execution grid reshaping

### DIFF
--- a/cudax/include/cuda/experimental/__places/places.cuh
+++ b/cudax/include/cuda/experimental/__places/places.cuh
@@ -34,6 +34,7 @@
 #include <cuda/experimental/__places/exec_place_resources.cuh>
 #include <cuda/experimental/__stf/utility/core.cuh>
 
+#include <stdexcept>
 #include <typeinfo>
 
 // Used only for unit tests, not in the actual implementation
@@ -639,6 +640,31 @@ public:
   {
     return get_place(get_dims().get_index(p));
   }
+
+  /**
+   * @brief Return a grid with new dimensions and the same linear place order
+   *
+   * The product of @p dims must equal size(), and every extent must be
+   * positive. This changes only the coordinate system: for every linear index
+   * `i`, `result.get_place(i) == get_place(i)`.
+   *
+   * @param[in] dims New grid dimensions
+   * @return A grid over the same places with dimensions @p dims
+   */
+  [[nodiscard]] exec_place reshape(const dim4& dims) const;
+
+  /**
+   * @brief Collapse a contiguous inclusive range of grid axes
+   *
+   * Axes in [`first_axis`, `last_axis`] are replaced by one axis whose extent
+   * is their product. Later axes shift left and trailing extents become one.
+   * Linear place order is preserved.
+   *
+   * @param[in] first_axis First axis to collapse (inclusive)
+   * @param[in] last_axis Last axis to collapse (inclusive)
+   * @return A grid over the same places with the selected axes collapsed
+   */
+  [[nodiscard]] exec_place collapse_axes(const size_t first_axis, const size_t last_axis) const;
 
   // ===== Activation =====
 
@@ -1382,7 +1408,18 @@ public:
       : dims_(_dims)
       , places_(mv(_places))
   {
-    _CCCL_ASSERT(dims_.x > 0, "Grid dimensions must be positive");
+    if (places_.empty())
+    {
+      throw ::std::invalid_argument("make_grid: places must not be empty");
+    }
+    if (dims_.x == 0 || dims_.y == 0 || dims_.z == 0 || dims_.t == 0)
+    {
+      throw ::std::invalid_argument("make_grid: grid dimensions must be positive");
+    }
+    if (dims_.size() != places_.size())
+    {
+      throw ::std::invalid_argument("make_grid: grid dimensions must contain exactly one entry per place");
+    }
   }
 
   // ===== Grid interface =====
@@ -1476,7 +1513,18 @@ private:
 //! Returns the single element if size == 1 (no grid wrapper needed)
 inline exec_place make_grid(::std::vector<exec_place> places, const dim4& dims)
 {
-  _CCCL_ASSERT(!places.empty(), "invalid places");
+  if (places.empty())
+  {
+    throw ::std::invalid_argument("make_grid: places must not be empty");
+  }
+  if (dims.x == 0 || dims.y == 0 || dims.z == 0 || dims.t == 0)
+  {
+    throw ::std::invalid_argument("make_grid: grid dimensions must be positive");
+  }
+  if (dims.size() != places.size())
+  {
+    throw ::std::invalid_argument("make_grid: grid dimensions must contain exactly one entry per place");
+  }
   if (places.size() == 1)
   {
     return mv(places[0]);
@@ -1491,6 +1539,49 @@ inline exec_place make_grid(::std::vector<exec_place> places)
   _CCCL_ASSERT(!places.empty(), "invalid places");
   const size_t n = places.size();
   return make_grid(mv(places), dim4(n, 1, 1, 1));
+}
+
+inline exec_place exec_place::reshape(const dim4& dims) const
+{
+  ::std::vector<exec_place> places;
+  places.reserve(size());
+  for (size_t i = 0; i < size(); i++)
+  {
+    places.push_back(get_place(i));
+  }
+  return ::cuda::experimental::places::make_grid(::cuda::experimental::stf::mv(places), dims);
+}
+
+inline exec_place exec_place::collapse_axes(const size_t first_axis, const size_t last_axis) const
+{
+  if (first_axis > last_axis || last_axis > 3)
+  {
+    throw ::std::invalid_argument("exec_place::collapse_axes: expected 0 <= first_axis <= last_axis < 4");
+  }
+
+  const dim4 old_dims         = get_dims();
+  const size_t old_extents[4] = {old_dims.x, old_dims.y, old_dims.z, old_dims.t};
+  size_t new_extents[4]       = {1, 1, 1, 1};
+
+  size_t output_axis = 0;
+  for (size_t axis = 0; axis < first_axis; axis++)
+  {
+    new_extents[output_axis++] = old_extents[axis];
+  }
+
+  size_t collapsed_extent = 1;
+  for (size_t axis = first_axis; axis <= last_axis; axis++)
+  {
+    collapsed_extent *= old_extents[axis];
+  }
+  new_extents[output_axis++] = collapsed_extent;
+
+  for (size_t axis = last_axis + 1; axis < 4; axis++)
+  {
+    new_extents[output_axis++] = old_extents[axis];
+  }
+
+  return reshape(dim4(new_extents[0], new_extents[1], new_extents[2], new_extents[3]));
 }
 
 // === data_place::affine_exec_place implementation ===
@@ -1859,6 +1950,100 @@ UNITTEST("grid exec place equality")
   EXPECT(exec_place::all_devices() == exec_place::all_devices());
 
   EXPECT(all != repeated_dev0);
+};
+
+UNITTEST("exec place grid reshape preserves linear place order")
+{
+  ::std::vector<exec_place> places;
+  for (size_t i = 0; i < 24; i++)
+  {
+    places.push_back(exec_place::repeat(exec_place::host(), i + 2));
+  }
+
+  const auto grid      = make_grid(places, dim4(2, 3, 4));
+  const auto reshaped  = grid.reshape(dim4(6, 4));
+  const auto flattened = grid.reshape(dim4(24));
+
+  EXPECT(reshaped.get_dims() == dim4(6, 4));
+  EXPECT(flattened.get_dims() == dim4(24));
+  for (size_t i = 0; i < grid.size(); i++)
+  {
+    EXPECT(reshaped.get_place(i) == grid.get_place(i));
+    EXPECT(flattened.get_place(i) == grid.get_place(i));
+  }
+};
+
+UNITTEST("exec place grid collapse axes preserves linear place order")
+{
+  ::std::vector<exec_place> places;
+  for (size_t i = 0; i < 24; i++)
+  {
+    places.push_back(exec_place::repeat(exec_place::host(), i + 2));
+  }
+
+  const auto grid         = make_grid(places, dim4(2, 3, 4));
+  const auto collapse_xy  = grid.collapse_axes(0, 1);
+  const auto collapse_yz  = grid.collapse_axes(1, 2);
+  const auto collapse_all = grid.collapse_axes(0, 3);
+
+  EXPECT(collapse_xy.get_dims() == dim4(6, 4));
+  EXPECT(collapse_yz.get_dims() == dim4(2, 12));
+  EXPECT(collapse_all.get_dims() == dim4(24));
+  for (size_t i = 0; i < grid.size(); i++)
+  {
+    EXPECT(collapse_xy.get_place(i) == grid.get_place(i));
+    EXPECT(collapse_yz.get_place(i) == grid.get_place(i));
+    EXPECT(collapse_all.get_place(i) == grid.get_place(i));
+  }
+};
+
+UNITTEST("exec place grid reshape rejects invalid dimensions")
+{
+  const auto grid = exec_place::repeat(exec_place::host(), 6);
+
+  bool thrown = false;
+  try
+  {
+    (void) grid.reshape(dim4(2, 2));
+  }
+  catch (const ::std::invalid_argument&)
+  {
+    thrown = true;
+  }
+  EXPECT(thrown);
+
+  thrown = false;
+  try
+  {
+    (void) grid.reshape(dim4(6, 0));
+  }
+  catch (const ::std::invalid_argument&)
+  {
+    thrown = true;
+  }
+  EXPECT(thrown);
+
+  thrown = false;
+  try
+  {
+    (void) grid.collapse_axes(2, 1);
+  }
+  catch (const ::std::invalid_argument&)
+  {
+    thrown = true;
+  }
+  EXPECT(thrown);
+
+  thrown = false;
+  try
+  {
+    (void) grid.collapse_axes(0, 4);
+  }
+  catch (const ::std::invalid_argument&)
+  {
+    thrown = true;
+  }
+  EXPECT(thrown);
 };
 
 UNITTEST("pos4 dim4 handle large values beyond 32bit")

--- a/cudax/include/cuda/experimental/__places/places.cuh
+++ b/cudax/include/cuda/experimental/__places/places.cuh
@@ -651,7 +651,7 @@ public:
    * @param[in] dims New grid dimensions
    * @return A grid over the same places with dimensions @p dims
    */
-  [[nodiscard]] exec_place reshape(const dim4& dims) const;
+  [[nodiscard]] _CCCL_HOST_API exec_place reshape(const dim4& dims) const;
 
   /**
    * @brief Collapse a contiguous inclusive range of grid axes
@@ -664,7 +664,7 @@ public:
    * @param[in] last_axis Last axis to collapse (inclusive)
    * @return A grid over the same places with the selected axes collapsed
    */
-  [[nodiscard]] exec_place collapse_axes(const size_t first_axis, const size_t last_axis) const;
+  [[nodiscard]] _CCCL_HOST_API exec_place collapse_axes(const size_t first_axis, const size_t last_axis) const;
 
   // ===== Activation =====
 
@@ -1541,7 +1541,7 @@ inline exec_place make_grid(::std::vector<exec_place> places)
   return make_grid(mv(places), dim4(n, 1, 1, 1));
 }
 
-inline exec_place exec_place::reshape(const dim4& dims) const
+_CCCL_HOST_API inline exec_place exec_place::reshape(const dim4& dims) const
 {
   ::std::vector<exec_place> places;
   places.reserve(size());
@@ -1552,7 +1552,7 @@ inline exec_place exec_place::reshape(const dim4& dims) const
   return ::cuda::experimental::places::make_grid(::cuda::experimental::stf::mv(places), dims);
 }
 
-inline exec_place exec_place::collapse_axes(const size_t first_axis, const size_t last_axis) const
+_CCCL_HOST_API inline exec_place exec_place::collapse_axes(const size_t first_axis, const size_t last_axis) const
 {
   if (first_axis > last_axis || last_axis > 3)
   {

--- a/docs/cudax/places.rst
+++ b/docs/cudax/places.rst
@@ -431,6 +431,39 @@ It is possible to query the *shape* of the grid using ``get_dims()``,
 which returns a ``dim4`` object. Individual places can be accessed by
 multi-dimensional position using ``get_place(pos4)``.
 
+Reshaping and collapsing grid axes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An existing grid can be viewed with different dimensions using
+``reshape()``. The new dimensions must contain exactly the same number of
+places:
+
+.. code:: c++
+
+   exec_place cube = make_grid(my_places, dim4(2, 3, 4));
+   exec_place flat = cube.reshape(dim4(24));
+
+Reshaping changes only the grid coordinate system. It preserves dimension-0-
+fastest linear order, so ``flat.get_place(i) == cube.get_place(i)`` for every
+linear index ``i``. It does not reorder, replicate, or remove places.
+
+``collapse_axes(first, last)`` is a convenience operation that combines a
+contiguous inclusive range of axes. The collapsed extent is the product of
+the selected extents; later axes shift left and trailing extents become one:
+
+.. code:: c++
+
+   exec_place grid = make_grid(my_places, dim4(2, 3, 4));
+
+   exec_place grid_6x4 = grid.collapse_axes(0, 1); // dim4(6, 4)
+   exec_place grid_2x12 = grid.collapse_axes(1, 2); // dim4(2, 12)
+   exec_place grid_24 = grid.collapse_axes(0, 3); // dim4(24)
+
+These operations are useful when a partition should consume several axes of
+a processor grid as one logical axis. They are coordinate transformations,
+not :ref:`places-partitioning`: the latter decomposes a place into constituent
+resources.
+
 .. _places-partitioning:
 
 Partitioning grids


### PR DESCRIPTION
## Summary
- add `exec_place::reshape()` to change grid coordinates while preserving linear place order
- add `collapse_axes()` for merging contiguous processor-grid axes
- reject shaped grids whose dimensions are zero or do not match the place count
- document the coordinate transformation semantics and pin them with co-located unit tests

## Test plan
- [x] `pre-commit run --files cudax/include/cuda/experimental/__places/places.cuh docs/cudax/places.rst`
- [x] `cmake --build build/preset-latest --target cudax.test.places.unittest_headers.__places.places -j 4`
- [x] `ctest --test-dir build/preset-latest --output-on-failure -R '^cudax\.test\.places\.unittest_headers\.__places\.places$'`