### PR TITLE
Don't use the thrust size dispatchers anymore in multi-GPU

### DIFF
--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/common.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/common.h
@@ -22,14 +22,12 @@
 #  pragma system_header
 #endif // no system header
 
-#include <thrust/system/cuda/detail/dispatch.h>
-#include <thrust/system/cuda/detail/util.h>
-
 #include <cuda/__container/buffer.h>
 #include <cuda/__device/device_ref.h>
 #include <cuda/__functional/lazy_call_or.h>
 #include <cuda/__memory_pool/device_memory_pool.h>
 #include <cuda/__memory_resource/get_memory_resource.h>
+#include <cuda/__runtime/api_wrapper.h>
 #include <cuda/__runtime/ensure_current_context.h>
 #include <cuda/__stream/stream_ref.h>
 #include <cuda/__utility/no_init.h>
@@ -49,24 +47,11 @@
 
 namespace cuda::experimental::__detail
 {
-#define __CUDAX_MULTI_GPU_DISPATCH(__logical_device, __count, __call, __arguments)                       \
-  do                                                                                                     \
-  {                                                                                                      \
-    const auto __cur_context = ::cuda::__ensure_current_context{(__logical_device).context()};           \
-    auto __status            = ::cudaError_t{};                                                          \
-                                                                                                         \
-    THRUST_INDEX_TYPE_DISPATCH(__status, __call, __count, __arguments);                                  \
-    THRUST_NS_QUALIFIER::cuda_cub::throw_on_error(__status, /*msg=*/"performing " #__call #__arguments); \
-  } while (0)
-
-#define __CUDAX_MULTI_GPU_DOUBLE_DISPATCH(__logical_device, __count1, __count2, __call, __arguments)     \
-  do                                                                                                     \
-  {                                                                                                      \
-    const auto __cur_context = ::cuda::__ensure_current_context{(__logical_device).context()};           \
-    auto __status            = ::cudaError_t{};                                                          \
-                                                                                                         \
-    THRUST_DOUBLE_INDEX_TYPE_DISPATCH(__status, __call, __count1, __count2, __arguments);                \
-    THRUST_NS_QUALIFIER::cuda_cub::throw_on_error(__status, /*msg=*/"performing " #__call #__arguments); \
+#define __CUDAX_MULTI_GPU_DISPATCH(__logical_device, __call, ...)                              \
+  do                                                                                           \
+  {                                                                                            \
+    const auto __cur_context = ::cuda::__ensure_current_context{(__logical_device).context()}; \
+    _CCCL_TRY_CUDA_API(__call, "performing" #__call "(" #__VA_ARGS__ ")", __VA_ARGS__);        \
   } while (0)
 
 template <class _Env>

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/reduce/reduce.h
@@ -88,7 +88,6 @@ template <class _Buffer, class _Comm, class _Env, class _InputRange, class _Tp, 
 
   static_assert(::cuda::std::ranges::sized_range<_InputRange>);
 
-  const auto __num_items = ::cuda::std::ranges::size(__inputs);
   // Allocate enough storage so that we can use the buffer directly in an in-place comm all
   // gather/all reduce call. Those calls require that the receive buffer is of size nranks *
   // sendcount.
@@ -100,17 +99,16 @@ template <class _Buffer, class _Comm, class _Env, class _InputRange, class _Tp, 
 
   __CUDAX_MULTI_GPU_DISPATCH(
     __logical_device,
-    __num_items,
     CUB_NS_QUALIFIER::DeviceReduce::Reduce,
-    (::cuda::std::ranges::begin(__inputs),
-     // Similarly to above, prepare for the comm calls later. In order for those to be
-     // in-place, the sendbuff = recvbuff + rank, so we need to place our partial result
-     // there
-     __buff.begin() + __rank,
-     __num_items_fixed,
-     ::cuda::std::move(__op),
-     __rank == __ROOT_RANK ? __init : __ident,
-     __env));
+    ::cuda::std::ranges::begin(__inputs),
+    // Similarly to above, prepare for the comm calls later. In order for those to be
+    // in-place, the sendbuff = recvbuff + rank, so we need to place our partial result
+    // there
+    __buff.begin() + __rank,
+    ::cuda::std::ranges::size(__inputs),
+    ::cuda::std::move(__op),
+    __rank == __ROOT_RANK ? __init : __ident,
+    __env);
 
   return __buff;
 }
@@ -155,13 +153,15 @@ _CCCL_HOST_API void __two_stage_gather_reduction(
   for (auto&& [__comm, __env, __buffer, __out] :
        ::cuda::std::ranges::views::zip(__comms, __envs, *__partials, __outputs))
   {
-    const auto __num_items = __buffer.size();
-
     __CUDAX_MULTI_GPU_DISPATCH(
       __comm.logical_device(),
-      __num_items,
       CUB_NS_QUALIFIER::DeviceReduce::Reduce,
-      (__buffer.begin(), __out, __num_items_fixed, __op, CUB_NS_QUALIFIER::detail::reduce::no_init, __env));
+      __buffer.begin(),
+      __out,
+      __buffer.size(),
+      __op,
+      CUB_NS_QUALIFIER::detail::reduce::no_init,
+      __env);
   }
 }
 } // namespace __detail::__reduce

--- a/cudax/include/cuda/experimental/__multi_gpu/algorithm/scan/scan.h
+++ b/cudax/include/cuda/experimental/__multi_gpu/algorithm/scan/scan.h
@@ -166,7 +166,6 @@ _CCCL_HOST_API void __scan(
       __part.stream(), __part.memory_resource(), /*__size=*/1, __env);
 
     {
-      const auto __num_items = __comm.rank();
       // Root rank has no preceding partials and therefore starts directly with init. Other ranks
       // include root rank partial, which already contains init, so their prefix reduction starts
       // with ident.
@@ -180,12 +179,14 @@ _CCCL_HOST_API void __scan(
       // multiple times, we need to cache the result.
       __CUDAX_MULTI_GPU_DISPATCH(
         __comm.logical_device(),
-        __num_items,
         CUB_NS_QUALIFIER::DeviceReduce::Reduce,
-        (__part.begin(), __prefix.begin(), __num_items_fixed, __op, __prefix_init, __env));
+        __part.begin(),
+        __prefix.begin(),
+        __comm.rank(),
+        __op,
+        __prefix_init,
+        __env);
     }
-
-    const auto __num_items = ::cuda::std::ranges::size(__inputs);
 
     if constexpr (_Kind == __kind::__exclusive)
     {
@@ -196,27 +197,25 @@ _CCCL_HOST_API void __scan(
 
       __CUDAX_MULTI_GPU_DISPATCH(
         __comm.logical_device(),
-        __num_items,
         CUB_NS_QUALIFIER::DeviceScan::ExclusiveScan,
-        (::cuda::std::ranges::begin(__inputs),
-         __out,
-         __op,
-         /*__init=*/__future_type{__prefix.begin()},
-         __num_items_fixed,
-         __env));
+        ::cuda::std::ranges::begin(__inputs),
+        __out,
+        __op,
+        /*__init=*/__future_type{__prefix.begin()},
+        ::cuda::std::ranges::size(__inputs),
+        __env);
     }
     else
     {
       __CUDAX_MULTI_GPU_DISPATCH(
         __comm.logical_device(),
-        __num_items,
         CUB_NS_QUALIFIER::DeviceScan::InclusiveScanInit,
-        (::cuda::std::ranges::begin(__inputs),
-         __out,
-         __op,
-         /*__init=*/::cuda::args::deferred{__prefix.begin()},
-         __num_items_fixed,
-         __env));
+        ::cuda::std::ranges::begin(__inputs),
+        __out,
+        __op,
+        /*__init=*/::cuda::args::deferred{__prefix.begin()},
+        ::cuda::std::ranges::size(__inputs),
+        __env);
     }
   }
 }


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

Using the thrust size dispatching just bloated compile time and object size for not much gain. Communication is expected to largely outweigh any potential speedup we might get from using slightly smaller size types in CUB calls.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
