### PR TITLE
Slightly bump test sizes for mgmn tests

### DIFF
--- a/cudax/test/multi_gpu/algorithms/exclusive_scan/range_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/exclusive_scan/range_basic.cu
@@ -212,7 +212,7 @@ MULTI_GPU_TEST("exclusive_scan, one element per rank", value_types, operators)
   envs.reserve(comms.size());
   for (int r = 0; r < comms.front().size(); ++r)
   {
-    inputs_by_rank[static_cast<cuda::std::size_t>(r)] = {make_value<T>(r)};
+    inputs_by_rank[static_cast<cuda::std::size_t>(r)] = std::vector<T>(1, make_value<T>(r));
   }
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)
   {

--- a/cudax/test/multi_gpu/algorithms/exclusive_scan/range_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/exclusive_scan/range_basic.cu
@@ -265,8 +265,7 @@ MULTI_GPU_TEST("exclusive_scan, multiple elements per rank", value_types, operat
   constexpr auto values_per_rank = 10;
   for (int r = 0; r < comms.front().size(); ++r)
   {
-    const auto v                                      = make_value<T>(r);
-    inputs_by_rank[static_cast<cuda::std::size_t>(r)] = std::vector<T>(values_per_rank, v);
+    inputs_by_rank[static_cast<cuda::std::size_t>(r)] = std::vector<T>(values_per_rank, make_value<T>(r));
   }
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)
   {

--- a/cudax/test/multi_gpu/algorithms/exclusive_scan/range_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/exclusive_scan/range_basic.cu
@@ -249,10 +249,10 @@ MULTI_GPU_TEST("exclusive_scan, multiple elements per rank", value_types, operat
   auto comms   = this->communicators();
   auto streams = nccl_test_util::make_streams();
 
-  // Global rank `comms[i].rank()` contributes `{rank, rank, rank}`. `exclusive_scan` first
+  // Global rank `comms[i].rank()` contributes ten copies of `rank`. `exclusive_scan` first
   // computes a local prefix for each rank seeded by the prefix of all previous ranks. Each local
   // rank also gets an output buffer and an environment carrying its stream. `reference` mirrors
-  // every global rank's three contributions for the host-side scan.
+  // every global rank's ten contributions for the host-side scan.
   std::vector<cuda::device_buffer<T>> in;
   std::vector<cuda::device_buffer<T>> out;
   std::vector<decltype(::cuda::std::execution::env{::cuda::stream_ref{streams[0]}})> envs;
@@ -261,10 +261,12 @@ MULTI_GPU_TEST("exclusive_scan, multiple elements per rank", value_types, operat
   in.reserve(comms.size());
   out.reserve(comms.size());
   envs.reserve(comms.size());
+
+  constexpr auto values_per_rank = 10;
   for (int r = 0; r < comms.front().size(); ++r)
   {
     const auto v                                      = make_value<T>(r);
-    inputs_by_rank[static_cast<cuda::std::size_t>(r)] = {v, v, v};
+    inputs_by_rank[static_cast<cuda::std::size_t>(r)] = std::vector<T>(values_per_rank, v);
   }
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)
   {
@@ -299,7 +301,7 @@ MULTI_GPU_TEST("exclusive_scan, some ranks empty", value_types, operators)
   auto comms   = this->communicators();
   auto streams = nccl_test_util::make_streams();
 
-  // Even global ranks contribute two copies of `rank`; odd global ranks contribute an empty input
+  // Even global ranks contribute ten copies of `rank`; odd global ranks contribute an empty input
   // range. Rank 0 is always non-empty. `exclusive_scan` must treat an empty rank as contributing
   // nothing, exactly like `std::exclusive_scan` over the surviving elements. `reference` mirrors
   // that for the host-side scan.
@@ -311,11 +313,13 @@ MULTI_GPU_TEST("exclusive_scan, some ranks empty", value_types, operators)
   in.reserve(comms.size());
   out.reserve(comms.size());
   envs.reserve(comms.size());
+
+  constexpr auto values_per_rank = 10;
   for (int r = 0; r < comms.front().size(); ++r)
   {
     if (r % 2 == 0)
     {
-      inputs_by_rank[static_cast<cuda::std::size_t>(r)] = {make_value<T>(r), make_value<T>(r)};
+      inputs_by_rank[static_cast<cuda::std::size_t>(r)] = std::vector<T>(values_per_rank, make_value<T>(r));
     }
   }
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)

--- a/cudax/test/multi_gpu/algorithms/exclusive_scan/range_defaults.cu
+++ b/cudax/test/multi_gpu/algorithms/exclusive_scan/range_defaults.cu
@@ -46,12 +46,12 @@ MULTI_GPU_TEST("exclusive_scan, range overloads default values", )
   out.reserve(comms.size());
   envs.reserve(comms.size());
 
-  constexpr auto values_per_rank = 3;
+  constexpr auto values_per_rank = 10;
 
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)
   {
-    const auto first                                  = static_cast<T>(comms[i].rank() * values_per_rank + 1);
-    const cuda::std::array<T, values_per_rank> values = {first, first + 1, first + 2};
+    std::vector<T> values(values_per_rank);
+    std::iota(values.begin(), values.end(), static_cast<T>(comms[i].rank() * values_per_rank + 1));
 
     in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
     out.emplace_back(cuda::make_device_buffer<T>(

--- a/cudax/test/multi_gpu/algorithms/exclusive_scan/single_comm_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/exclusive_scan/single_comm_basic.cu
@@ -242,11 +242,12 @@ MULTI_GPU_TEST("exclusive_scan single-comm, multiple elements per rank", value_t
   const auto ident = get_identity<T, Op>();
   auto comms       = this->communicators();
 
+  constexpr auto values_per_rank = 10;
   std::vector<std::vector<T>> inputs_by_rank(static_cast<cuda::std::size_t>(comms.front().size()));
   for (int r = 0; r < comms.front().size(); ++r)
   {
     const auto value                                  = make_value<T>(r);
-    inputs_by_rank[static_cast<cuda::std::size_t>(r)] = {value, value, value};
+    inputs_by_rank[static_cast<cuda::std::size_t>(r)] = std::vector<T>(values_per_rank, value);
   }
 
   run_case(comms, inputs_by_rank, init, ident, Op{});
@@ -261,12 +262,13 @@ MULTI_GPU_TEST("exclusive_scan single-comm, some ranks empty", value_types, oper
   const auto ident = get_identity<T, Op>();
   auto comms       = this->communicators();
 
+  constexpr auto values_per_rank = 10;
   std::vector<std::vector<T>> inputs_by_rank(static_cast<cuda::std::size_t>(comms.front().size()));
   for (int r = 0; r < comms.front().size(); ++r)
   {
     if (r % 2 == 0)
     {
-      inputs_by_rank[static_cast<cuda::std::size_t>(r)] = {make_value<T>(r), make_value<T>(r)};
+      inputs_by_rank[static_cast<cuda::std::size_t>(r)] = std::vector<T>(values_per_rank, make_value<T>(r));
     }
   }
 

--- a/cudax/test/multi_gpu/algorithms/exclusive_scan/single_comm_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/exclusive_scan/single_comm_basic.cu
@@ -246,8 +246,7 @@ MULTI_GPU_TEST("exclusive_scan single-comm, multiple elements per rank", value_t
   std::vector<std::vector<T>> inputs_by_rank(static_cast<cuda::std::size_t>(comms.front().size()));
   for (int r = 0; r < comms.front().size(); ++r)
   {
-    const auto value                                  = make_value<T>(r);
-    inputs_by_rank[static_cast<cuda::std::size_t>(r)] = std::vector<T>(values_per_rank, value);
+    inputs_by_rank[static_cast<cuda::std::size_t>(r)] = std::vector<T>(values_per_rank, make_value<T>(r));
   }
 
   run_case(comms, inputs_by_rank, init, ident, Op{});

--- a/cudax/test/multi_gpu/algorithms/exclusive_scan/single_comm_defaults.cu
+++ b/cudax/test/multi_gpu/algorithms/exclusive_scan/single_comm_defaults.cu
@@ -46,12 +46,12 @@ MULTI_GPU_TEST("exclusive_scan single-comm, overloads default values", )
   out.reserve(comms.size());
   envs.reserve(comms.size());
 
-  constexpr auto values_per_rank = 3;
+  constexpr auto values_per_rank = 10;
 
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)
   {
-    const auto first                                  = static_cast<T>(comms[i].rank() * values_per_rank + 1);
-    const cuda::std::array<T, values_per_rank> values = {first, first + 1, first + 2};
+    std::vector<T> values(values_per_rank);
+    std::iota(values.begin(), values.end(), static_cast<T>(comms[i].rank() * values_per_rank + 1));
 
     in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
     out.emplace_back(cuda::make_device_buffer<T>(

--- a/cudax/test/multi_gpu/algorithms/inclusive_scan/range_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/inclusive_scan/range_basic.cu
@@ -227,7 +227,7 @@ MULTI_GPU_TEST("inclusive_scan, one element per rank", value_types, operators)
   envs.reserve(comms.size());
   for (int r = 0; r < comms.front().size(); ++r)
   {
-    inputs_by_rank[static_cast<cuda::std::size_t>(r)] = {make_value<T>(r)};
+    inputs_by_rank[static_cast<cuda::std::size_t>(r)] = std::vector<T>(1, make_value<T>(r));
   }
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)
   {

--- a/cudax/test/multi_gpu/algorithms/inclusive_scan/range_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/inclusive_scan/range_basic.cu
@@ -264,10 +264,10 @@ MULTI_GPU_TEST("inclusive_scan, multiple elements per rank", value_types, operat
   auto comms   = this->communicators();
   auto streams = nccl_test_util::make_streams();
 
-  // Global rank `comms[i].rank()` contributes `{rank, rank, rank}`. `inclusive_scan` first
+  // Global rank `comms[i].rank()` contributes ten copies of `rank`. `inclusive_scan` first
   // computes a local prefix for each rank seeded by the prefix of all previous ranks. Each local
   // rank also gets an output buffer and an environment carrying its stream. `reference` mirrors
-  // every global rank's three contributions for the host-side scan.
+  // every global rank's ten contributions for the host-side scan.
   std::vector<cuda::device_buffer<T>> in;
   std::vector<cuda::device_buffer<T>> out;
   std::vector<decltype(::cuda::std::execution::env{::cuda::stream_ref{streams[0]}})> envs;
@@ -276,10 +276,12 @@ MULTI_GPU_TEST("inclusive_scan, multiple elements per rank", value_types, operat
   in.reserve(comms.size());
   out.reserve(comms.size());
   envs.reserve(comms.size());
+
+  constexpr auto values_per_rank = 10;
   for (int r = 0; r < comms.front().size(); ++r)
   {
     const auto v                                      = make_value<T>(r);
-    inputs_by_rank[static_cast<cuda::std::size_t>(r)] = {v, v, v};
+    inputs_by_rank[static_cast<cuda::std::size_t>(r)] = std::vector<T>(values_per_rank, v);
   }
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)
   {
@@ -314,7 +316,7 @@ MULTI_GPU_TEST("inclusive_scan, some ranks empty", value_types, operators)
   auto comms   = this->communicators();
   auto streams = nccl_test_util::make_streams();
 
-  // Even global ranks contribute two copies of `rank`; odd global ranks contribute an empty input
+  // Even global ranks contribute ten copies of `rank`; odd global ranks contribute an empty input
   // range. Rank 0 is always non-empty. `inclusive_scan` must treat an empty rank as contributing
   // nothing, exactly like `std::inclusive_scan` over the surviving elements. `reference` mirrors
   // that for the host-side scan.
@@ -326,11 +328,13 @@ MULTI_GPU_TEST("inclusive_scan, some ranks empty", value_types, operators)
   in.reserve(comms.size());
   out.reserve(comms.size());
   envs.reserve(comms.size());
+
+  constexpr auto values_per_rank = 10;
   for (int r = 0; r < comms.front().size(); ++r)
   {
     if (r % 2 == 0)
     {
-      inputs_by_rank[static_cast<cuda::std::size_t>(r)] = {make_value<T>(r), make_value<T>(r)};
+      inputs_by_rank[static_cast<cuda::std::size_t>(r)] = std::vector<T>(values_per_rank, make_value<T>(r));
     }
   }
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)

--- a/cudax/test/multi_gpu/algorithms/inclusive_scan/range_defaults.cu
+++ b/cudax/test/multi_gpu/algorithms/inclusive_scan/range_defaults.cu
@@ -46,12 +46,12 @@ MULTI_GPU_TEST("inclusive_scan, range overloads default values", )
   out.reserve(comms.size());
   envs.reserve(comms.size());
 
-  constexpr auto values_per_rank = 3;
+  constexpr auto values_per_rank = 10;
 
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)
   {
-    const auto first                                  = static_cast<T>(comms[i].rank() * values_per_rank + 1);
-    const cuda::std::array<T, values_per_rank> values = {first, first + 1, first + 2};
+    std::vector<T> values(values_per_rank);
+    std::iota(values.begin(), values.end(), static_cast<T>(comms[i].rank() * values_per_rank + 1));
 
     in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
     out.emplace_back(cuda::make_device_buffer<T>(

--- a/cudax/test/multi_gpu/algorithms/inclusive_scan/single_comm_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/inclusive_scan/single_comm_basic.cu
@@ -257,11 +257,12 @@ MULTI_GPU_TEST("inclusive_scan single-comm, multiple elements per rank", value_t
   const auto ident = get_identity<T, Op>();
   auto comms       = this->communicators();
 
+  constexpr auto values_per_rank = 10;
   std::vector<std::vector<T>> inputs_by_rank(static_cast<cuda::std::size_t>(comms.front().size()));
   for (int r = 0; r < comms.front().size(); ++r)
   {
     const auto value                                  = make_value<T>(r);
-    inputs_by_rank[static_cast<cuda::std::size_t>(r)] = {value, value, value};
+    inputs_by_rank[static_cast<cuda::std::size_t>(r)] = std::vector<T>(values_per_rank, value);
   }
 
   run_case(comms, inputs_by_rank, init, ident, Op{});
@@ -276,12 +277,13 @@ MULTI_GPU_TEST("inclusive_scan single-comm, some ranks empty", value_types, oper
   const auto ident = get_identity<T, Op>();
   auto comms       = this->communicators();
 
+  constexpr auto values_per_rank = 10;
   std::vector<std::vector<T>> inputs_by_rank(static_cast<cuda::std::size_t>(comms.front().size()));
   for (int r = 0; r < comms.front().size(); ++r)
   {
     if (r % 2 == 0)
     {
-      inputs_by_rank[static_cast<cuda::std::size_t>(r)] = {make_value<T>(r), make_value<T>(r)};
+      inputs_by_rank[static_cast<cuda::std::size_t>(r)] = std::vector<T>(values_per_rank, make_value<T>(r));
     }
   }
 

--- a/cudax/test/multi_gpu/algorithms/inclusive_scan/single_comm_defaults.cu
+++ b/cudax/test/multi_gpu/algorithms/inclusive_scan/single_comm_defaults.cu
@@ -46,12 +46,12 @@ MULTI_GPU_TEST("inclusive_scan single-comm, overloads default values", )
   out.reserve(comms.size());
   envs.reserve(comms.size());
 
-  constexpr auto values_per_rank = 3;
+  constexpr auto values_per_rank = 10;
 
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)
   {
-    const auto first                                  = static_cast<T>(comms[i].rank() * values_per_rank + 1);
-    const cuda::std::array<T, values_per_rank> values = {first, first + 1, first + 2};
+    std::vector<T> values(values_per_rank);
+    std::iota(values.begin(), values.end(), static_cast<T>(comms[i].rank() * values_per_rank + 1));
 
     in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
     out.emplace_back(cuda::make_device_buffer<T>(

--- a/cudax/test/multi_gpu/algorithms/reduce/range_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/reduce/range_basic.cu
@@ -178,10 +178,10 @@ MULTI_GPU_TEST("reduce, multiple elements per rank", value_types, operators)
   auto comms   = this->communicators();
   auto streams = nccl_test_util::make_streams();
 
-  // Global rank `comms[i].rank()` contributes `{rank, rank, rank}`. `reduce` first does a local CUB
-  // reduction of each rank's range, then combines the partials across ranks. Each local rank also
-  // gets a one-element output buffer and an environment carrying its stream. `reference` mirrors
-  // every global rank's three contributions for the host-side fold.
+  // Global rank `comms[i].rank()` contributes ten copies of `rank`. `reduce` first does a local
+  // CUB reduction of each rank's range, then combines the partials across ranks. Each local rank
+  // also gets a one-element output buffer and an environment carrying its stream. `reference`
+  // mirrors every global rank's ten contributions for the host-side fold.
   std::vector<cuda::device_buffer<T>> in;
   std::vector<cuda::device_buffer<T>> out;
   std::vector<decltype(::cuda::std::execution::env{::cuda::stream_ref{streams[0]}})> envs;
@@ -189,10 +189,12 @@ MULTI_GPU_TEST("reduce, multiple elements per rank", value_types, operators)
   in.reserve(comms.size());
   out.reserve(comms.size());
   envs.reserve(comms.size());
+
+  constexpr auto values_per_rank = 10;
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)
   {
-    const auto v      = make_value<T>(comms[i].rank());
-    const auto values = {v, v, v};
+    const auto v = make_value<T>(comms[i].rank());
+    const std::vector<T> values(values_per_rank, v);
 
     in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
     out.emplace_back(
@@ -207,12 +209,12 @@ MULTI_GPU_TEST("reduce, multiple elements per rank", value_types, operators)
   const T expected = [&] {
     std::vector<T> reference;
 
-    reference.reserve(comms.front().size());
+    reference.reserve(comms.front().size() * values_per_rank);
     for (int r = 0; r < comms.front().size(); ++r)
     {
       const auto v = make_value<T>(r);
 
-      reference.insert(reference.end(), {v, v, v});
+      reference.insert(reference.end(), values_per_rank, v);
     }
 
     return std::accumulate(reference.begin(), reference.end(), init, Op{});
@@ -237,7 +239,7 @@ MULTI_GPU_TEST("reduce, some ranks empty", value_types, operators)
   auto comms   = this->communicators();
   auto streams = nccl_test_util::make_streams();
 
-  // Even global ranks contribute two copies of `rank`; odd global ranks contribute an empty input
+  // Even global ranks contribute ten copies of `rank`; odd global ranks contribute an empty input
   // range. Rank 0 (the reduction root) is always non-empty. `reduce` must treat an empty rank as
   // contributing nothing, exactly like `std::accumulate` over the surviving elements. `reference`
   // mirrors that for the host-side fold.
@@ -248,12 +250,14 @@ MULTI_GPU_TEST("reduce, some ranks empty", value_types, operators)
   in.reserve(comms.size());
   out.reserve(comms.size());
   envs.reserve(comms.size());
+
+  constexpr auto values_per_rank = 10;
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)
   {
     const auto rank = comms[i].rank();
     if (rank % 2 == 0)
     {
-      const auto values = {make_value<T>(rank), make_value<T>(rank)};
+      const std::vector<T> values(values_per_rank, make_value<T>(rank));
       in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
     }
     else
@@ -272,13 +276,12 @@ MULTI_GPU_TEST("reduce, some ranks empty", value_types, operators)
   const T expected = [&] {
     std::vector<T> reference;
 
-    reference.reserve(comms.front().size());
+    reference.reserve(comms.front().size() * values_per_rank);
     for (int r = 0; r < comms.front().size(); ++r)
     {
       if (r % 2 == 0)
       {
-        reference.push_back(make_value<T>(r));
-        reference.push_back(make_value<T>(r));
+        reference.insert(reference.end(), values_per_rank, make_value<T>(r));
       }
     }
 

--- a/cudax/test/multi_gpu/algorithms/reduce/range_defaults.cu
+++ b/cudax/test/multi_gpu/algorithms/reduce/range_defaults.cu
@@ -42,9 +42,11 @@ MULTI_GPU_TEST("reduce, range overloads default values", )
   in.reserve(comms.size());
   out.reserve(comms.size());
   envs.reserve(comms.size());
+
+  constexpr auto values_per_rank = 10;
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)
   {
-    const auto values = {static_cast<T>(comms[i].rank())};
+    const std::vector<T> values(values_per_rank, static_cast<T>(comms[i].rank()));
 
     in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
     out.emplace_back(
@@ -57,10 +59,10 @@ MULTI_GPU_TEST("reduce, range overloads default values", )
   const auto expected = [&] {
     std::vector<T> reference;
 
-    reference.reserve(comms.front().size());
+    reference.reserve(comms.front().size() * values_per_rank);
     for (int r = 0; r < comms.front().size(); ++r)
     {
-      reference.push_back(r);
+      reference.insert(reference.end(), values_per_rank, static_cast<T>(r));
     }
 
     const auto val = std::accumulate(reference.begin(), reference.end(), init, op);

--- a/cudax/test/multi_gpu/algorithms/reduce/single_comm_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/reduce/single_comm_basic.cu
@@ -184,10 +184,10 @@ MULTI_GPU_TEST("reduce single-comm, multiple elements per rank", value_types, op
   auto comms   = this->communicators();
   auto streams = nccl_test_util::make_streams();
 
-  // Global rank `comms[i].rank()` contributes `{rank, rank, rank}`. `reduce` first does a local CUB
-  // reduction of each rank's range, then combines the partials across ranks. Each local rank also
-  // gets a one-element output buffer and an environment carrying its stream. `reference` mirrors
-  // every global rank's three contributions for the host-side fold.
+  // Global rank `comms[i].rank()` contributes ten copies of `rank`. `reduce` first does a local
+  // CUB reduction of each rank's range, then combines the partials across ranks. Each local rank
+  // also gets a one-element output buffer and an environment carrying its stream. `reference`
+  // mirrors every global rank's ten contributions for the host-side fold.
   std::vector<cuda::device_buffer<T>> in;
   std::vector<cuda::device_buffer<T>> out;
   std::vector<decltype(::cuda::std::execution::env{::cuda::stream_ref{streams[0]}})> envs;
@@ -195,10 +195,12 @@ MULTI_GPU_TEST("reduce single-comm, multiple elements per rank", value_types, op
   in.reserve(comms.size());
   out.reserve(comms.size());
   envs.reserve(comms.size());
+
+  constexpr auto values_per_rank = 10;
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)
   {
-    const auto v      = make_value<T>(comms[i].rank());
-    const auto values = {v, v, v};
+    const auto v = make_value<T>(comms[i].rank());
+    const std::vector<T> values(values_per_rank, v);
 
     in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
     out.emplace_back(
@@ -213,12 +215,12 @@ MULTI_GPU_TEST("reduce single-comm, multiple elements per rank", value_types, op
   const T expected = [&] {
     std::vector<T> reference;
 
-    reference.reserve(comms.front().size());
+    reference.reserve(comms.front().size() * values_per_rank);
     for (int r = 0; r < comms.front().size(); ++r)
     {
       const auto v = make_value<T>(r);
 
-      reference.insert(reference.end(), {v, v, v});
+      reference.insert(reference.end(), values_per_rank, v);
     }
 
     return std::accumulate(reference.begin(), reference.end(), init, Op{});
@@ -243,7 +245,7 @@ MULTI_GPU_TEST("reduce single-comm, some ranks empty", value_types, operators)
   auto comms   = this->communicators();
   auto streams = nccl_test_util::make_streams();
 
-  // Even global ranks contribute two copies of `rank`; odd global ranks contribute an empty input
+  // Even global ranks contribute ten copies of `rank`; odd global ranks contribute an empty input
   // range. Rank 0 (the reduction root) is always non-empty. `reduce` must treat an empty rank as
   // contributing nothing, exactly like `std::accumulate` over the surviving elements. `reference`
   // mirrors that for the host-side fold.
@@ -254,12 +256,14 @@ MULTI_GPU_TEST("reduce single-comm, some ranks empty", value_types, operators)
   in.reserve(comms.size());
   out.reserve(comms.size());
   envs.reserve(comms.size());
+
+  constexpr auto values_per_rank = 10;
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)
   {
     const auto rank = comms[i].rank();
     if (rank % 2 == 0)
     {
-      const auto values = {make_value<T>(rank), make_value<T>(rank)};
+      const std::vector<T> values(values_per_rank, make_value<T>(rank));
       in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
     }
     else
@@ -278,13 +282,12 @@ MULTI_GPU_TEST("reduce single-comm, some ranks empty", value_types, operators)
   const T expected = [&] {
     std::vector<T> reference;
 
-    reference.reserve(comms.front().size());
+    reference.reserve(comms.front().size() * values_per_rank);
     for (int r = 0; r < comms.front().size(); ++r)
     {
       if (r % 2 == 0)
       {
-        reference.push_back(make_value<T>(r));
-        reference.push_back(make_value<T>(r));
+        reference.insert(reference.end(), values_per_rank, make_value<T>(r));
       }
     }
 

--- a/cudax/test/multi_gpu/algorithms/reduce/single_comm_defaults.cu
+++ b/cudax/test/multi_gpu/algorithms/reduce/single_comm_defaults.cu
@@ -44,9 +44,11 @@ MULTI_GPU_TEST("reduce single-comm, overloads default values", )
   in.reserve(comms.size());
   out.reserve(comms.size());
   envs.reserve(comms.size());
+
+  constexpr auto values_per_rank = 10;
   for (cuda::std::size_t i = 0; i < comms.size(); ++i)
   {
-    const auto values = {static_cast<T>(comms[i].rank())};
+    const std::vector<T> values(values_per_rank, static_cast<T>(comms[i].rank()));
 
     in.emplace_back(cuda::make_device_buffer<T>(streams[i], comms[i].logical_device().underlying_device(), values));
     out.emplace_back(
@@ -59,10 +61,10 @@ MULTI_GPU_TEST("reduce single-comm, overloads default values", )
   const auto expected = [&] {
     std::vector<T> reference;
 
-    reference.reserve(comms.front().size());
+    reference.reserve(comms.front().size() * values_per_rank);
     for (int r = 0; r < comms.front().size(); ++r)
     {
-      reference.push_back(r);
+      reference.insert(reference.end(), values_per_rank, static_cast<T>(r));
     }
 
     const auto val = std::accumulate(reference.begin(), reference.end(), init, op);


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

Previously we used a max of 3 elements. This could run into special case paths in CUB where it falls back to memcpy or other such single element optimizations. Bump to 10 elements to bypass this.

Note that we still are purposefully not doing massive sizes. These algorithms don't do much other than call CUB and then NCCL. If a problem with the algorithm were to manifest with 1M elements, it very likely also manifests with 10.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
