### PR TITLE
Use if in _CCCL_TRY_CUDA_API

### DIFF
--- a/libcudacxx/include/cuda/__runtime/api_wrapper.h
+++ b/libcudacxx/include/cuda/__runtime/api_wrapper.h
@@ -23,20 +23,16 @@
 
 #include <cuda/std/__exception/cuda_error.h>
 #include <cuda/std/__exception/exception_macros.h>
-#include <cuda/std/__exception/terminate.h>
 
-#define _CCCL_TRY_CUDA_API(_NAME, _MSG, ...)                     \
-  do                                                             \
-  {                                                              \
-    const ::cudaError_t __status = _NAME(__VA_ARGS__);           \
-    switch (__status)                                            \
-    {                                                            \
-      case ::cudaSuccess:                                        \
-        break;                                                   \
-      default:                                                   \
-        ::cudaGetLastError(); /* clear CUDA error state */       \
-        _CCCL_THROW(::cuda::cuda_error, __status, _MSG, #_NAME); \
-    }                                                            \
+#define _CCCL_TRY_CUDA_API(_NAME, _MSG, ...)                   \
+  do                                                           \
+  {                                                            \
+    const ::cudaError_t __status = _NAME(__VA_ARGS__);         \
+    if (__status != ::cudaSuccess)                             \
+    {                                                          \
+      ::cudaGetLastError(); /* clear CUDA error state */       \
+      _CCCL_THROW(::cuda::cuda_error, __status, _MSG, #_NAME); \
+    }                                                          \
   } while (0)
 
 #define _CCCL_ASSERT_CUDA_API(_NAME, _MSG, ...)                         \


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

Use a simple `if` in `_CCCL_TRY_CUDA_API` instead of the `switch` abomination.

Also get rid of unused include, `terminate()` is called by the throw macros but they already include the header for us.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
