### PR TITLE
[bench] Enable metatargets for benchmark targets

### DIFF
--- a/cub/benchmarks/CMakeLists.txt
+++ b/cub/benchmarks/CMakeLists.txt
@@ -84,7 +84,7 @@ function(add_bench target_name bench_name bench_src)
   set(bench_target ${bench_name})
   set(${target_name} ${bench_target} PARENT_SCOPE)
 
-  cccl_add_executable(${bench_target} NO_METATARGETS SOURCES "${bench_src}")
+  cccl_add_executable(${bench_target} SOURCES "${bench_src}")
   target_link_libraries(
     ${bench_target}
     PRIVATE #

--- a/cudax/benchmarks/CMakeLists.txt
+++ b/cudax/benchmarks/CMakeLists.txt
@@ -27,7 +27,7 @@ function(add_bench target_name bench_name bench_src)
   set(bench_target ${bench_name})
   set(${target_name} ${bench_target} PARENT_SCOPE)
 
-  cccl_add_executable(${bench_target} NO_METATARGETS SOURCES "${bench_src}")
+  cccl_add_executable(${bench_target} SOURCES "${bench_src}")
   target_link_libraries(
     ${bench_target}
     PRIVATE #

--- a/libcudacxx/benchmarks/CMakeLists.txt
+++ b/libcudacxx/benchmarks/CMakeLists.txt
@@ -54,7 +54,7 @@ function(add_bench target_name bench_name bench_src)
   set(bench_target ${bench_name})
   set(${target_name} ${bench_target} PARENT_SCOPE)
 
-  cccl_add_executable(${bench_target} NO_METATARGETS SOURCES "${bench_src}")
+  cccl_add_executable(${bench_target} SOURCES "${bench_src}")
   target_link_libraries(
     ${bench_target}
     PRIVATE libcudacxx::libcudacxx cccl.nvbench_helper nvbench::main

--- a/thrust/benchmarks/CMakeLists.txt
+++ b/thrust/benchmarks/CMakeLists.txt
@@ -27,7 +27,7 @@ function(add_bench target_name bench_name bench_src)
   set(bench_target ${bench_name})
   set(${target_name} ${bench_target} PARENT_SCOPE)
 
-  cccl_add_executable(${bench_target} NO_METATARGETS SOURCES "${bench_src}")
+  cccl_add_executable(${bench_target} SOURCES "${bench_src}")
   target_link_libraries(
     ${bench_target}
     PRIVATE #


### PR DESCRIPTION
I'd like to build `cudax.bench.cuco` target to build all cuco benchmarks