### PR TITLE
Enable `__float128` in `cuda::std::copysign` and `cuda::std::signbit`

### DIFF
--- a/libcudacxx/include/cuda/std/__cmath/copysign.h
+++ b/libcudacxx/include/cuda/std/__cmath/copysign.h
@@ -25,9 +25,21 @@
 #include <cuda/std/__floating_point/fp.h>
 #include <cuda/std/__type_traits/is_extended_arithmetic.h>
 #include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/limits>
 
 #include <cuda/std/__cccl/prologue.h>
+
+#if _CCCL_HAS_FLOAT128()
+#  if _CCCL_CHECK_BUILTIN(builtin_copysignf128) || _CCCL_COMPILER(GCC)
+#    define _CCCL_BUILTIN_COPYSIGNF128(...) __builtin_copysignf128(__VA_ARGS__)
+#  endif // _CCCL_CHECK_BUILTIN(builtin_copysignf128) || _CCCL_COMPILER(GCC)
+#endif // _CCCL_HAS_FLOAT128()
+
+// nvcc doesn't implement __builtin_copysignf128 on device
+#if _CCCL_CUDA_COMPILER(NVCC) && _CCCL_DEVICE_COMPILATION()
+#  undef _CCCL_BUILTIN_COPYSIGNF128
+#endif // _CCCL_CUDA_COMPILER(NVCC) && _CCCL_DEVICE_COMPILATION()
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
@@ -62,6 +74,25 @@ _CCCL_REQUIRES(__is_extended_arithmetic_v<_Tp>)
     }
     else
     {
+#if _CCCL_HAS_FLOAT128()
+      if constexpr (is_same_v<_Tp, __float128>)
+      {
+#  if defined(_CCCL_BUILTIN_COPYSIGNF128)
+        // nvcc doesn't support _CCCL_BUILTIN_COPYSIGNF128 in constexpr context
+#    if _CCCL_CUDA_COMPILER(NVCC)
+        _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+#    endif // _CCCL_CUDA_COMPILER(NVCC)
+        {
+          return static_cast<__float128>(_CCCL_BUILTIN_COPYSIGNF128(__x, __y));
+        }
+#  else // ^^^ _CCCL_BUILTIN_COPYSIGNF128 ^^^ / vvv !_CCCL_BUILTIN_COPYSIGNF128 vvv
+        _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+        {
+          NV_IF_TARGET(NV_IS_DEVICE, (return ::__nv_fp128_copysign(__x, __y);))
+        }
+#  endif // ^^^ !_CCCL_BUILTIN_COPYSIGNF128 ^^^
+      }
+#endif // _CCCL_HAS_FLOAT128()
       const auto __val = (::cuda::std::__fp_get_storage(__x) & __fp_exp_mant_mask_of_v<_Tp>)
                        | (::cuda::std::__fp_get_storage(__y) & __fp_sign_mask_of_v<_Tp>);
       return ::cuda::std::__fp_from_storage<_Tp>(static_cast<__fp_storage_of_t<_Tp>>(__val));

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_manip/copysign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_manip/copysign.pass.cpp
@@ -165,6 +165,9 @@ TEST_FUNC constexpr bool test(float val)
 #if _CCCL_HAS_NVFP4_E2M1()
   test_type<__nv_fp4_e2m1>(val);
 #endif // _CCCL_HAS_NVFP4_E2M1
+#if _CCCL_HAS_FLOAT128()
+  test_type<__float128>(val);
+#endif // _CCCL_HAS_FLOAT128()
 
   test_type<signed char>(val);
   test_type<unsigned char>(val);

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/signbit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/signbit.pass.cpp
@@ -132,6 +132,9 @@ TEST_FUNC constexpr bool test(float val)
 #if _CCCL_HAS_NVFP4_E2M1()
   test_type<__nv_fp4_e2m1>(val);
 #endif // _CCCL_HAS_NVFP4_E2M1
+#if _CCCL_HAS_FLOAT128()
+  test_type<__float128>(val);
+#endif // _CCCL_HAS_FLOAT128()
 
   test_type<signed char>(val);
   test_type<unsigned char>(val);


### PR DESCRIPTION
Adds `__float128` support to `cuda::std::copysign` and test coverage for both `copysign` and `signbit`. Doing these two together since the `signbit` test generates its negative values through `copysign`.

`copysign` follows the same pattern as `fabs` in #9895: route to `__builtin_copysignf128` when available, to `__nv_fp128_copysign` in device code otherwise, and keep the existing storage mask path as the constexpr fallback. `signbit` needed no implementation change, the generic sign mask path already handles binary128.

No `__float128` capable host here (macOS arm64), so locally I could only compile and run both tests with float128 disabled to check for regressions. CI is the gate for the new paths.

Fixes #9961, fixes #9967