### PR TITLE
Remove nvcc arch flags from clangd

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -93,6 +93,8 @@ CompileFlags:
     # strip CUDA arch flags
     - "-gencode*"
     - "--generate-code*"
+    - "-arch*"
+    - "--gpu-architecture*"
     # strip gcc's -fcoroutines
     - -fcoroutines
     # strip CUDA flags unknown to clang


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

`clang` does not understand `-arch=native` and thinks it is `-march` instead

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
