### PR TITLE
Fix `cuda::ptx` `shr` and `bfind` `long`, `long long` handling

### DIFF
--- a/docs/libcudacxx/ptx/instructions/generated/bfind.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/bfind.rst
@@ -6,69 +6,69 @@ bfind.u32
 .. code-block:: cuda
 
    // bfind.u32 dest, a_reg; // PTX ISA 20, SM_50
-   template <typename = void>
+   template <typename U32, enable_if_t<sizeof(U32) == 4 && is_integral_v<U32> && is_unsigned_v<U32>, bool> = true>
    __device__ static inline uint32_t bfind(
-     uint32_t a_reg);
+     U32 a_reg);
 
 bfind.shiftamt.u32
 ^^^^^^^^^^^^^^^^^^
 .. code-block:: cuda
 
    // bfind.shiftamt.u32 dest, a_reg; // PTX ISA 20, SM_50
-   template <typename = void>
+   template <typename U32, enable_if_t<sizeof(U32) == 4 && is_integral_v<U32> && is_unsigned_v<U32>, bool> = true>
    __device__ static inline uint32_t bfind_shiftamt(
-     uint32_t a_reg);
+     U32 a_reg);
 
 bfind.u64
 ^^^^^^^^^
 .. code-block:: cuda
 
    // bfind.u64 dest, a_reg; // PTX ISA 20, SM_50
-   template <typename = void>
+   template <typename U64, enable_if_t<sizeof(U64) == 8 && is_integral_v<U64> && is_unsigned_v<U64>, bool> = true>
    __device__ static inline uint32_t bfind(
-     uint64_t a_reg);
+     U64 a_reg);
 
 bfind.shiftamt.u64
 ^^^^^^^^^^^^^^^^^^
 .. code-block:: cuda
 
    // bfind.shiftamt.u64 dest, a_reg; // PTX ISA 20, SM_50
-   template <typename = void>
+   template <typename U64, enable_if_t<sizeof(U64) == 8 && is_integral_v<U64> && is_unsigned_v<U64>, bool> = true>
    __device__ static inline uint32_t bfind_shiftamt(
-     uint64_t a_reg);
+     U64 a_reg);
 
 bfind.s32
 ^^^^^^^^^
 .. code-block:: cuda
 
    // bfind.s32 dest, a_reg; // PTX ISA 20, SM_50
-   template <typename = void>
+   template <typename S32, enable_if_t<sizeof(S32) == 4 && is_integral_v<S32> && is_signed_v<S32>, bool> = true>
    __device__ static inline uint32_t bfind(
-     int32_t a_reg);
+     S32 a_reg);
 
 bfind.shiftamt.s32
 ^^^^^^^^^^^^^^^^^^
 .. code-block:: cuda
 
    // bfind.shiftamt.s32 dest, a_reg; // PTX ISA 20, SM_50
-   template <typename = void>
+   template <typename S32, enable_if_t<sizeof(S32) == 4 && is_integral_v<S32> && is_signed_v<S32>, bool> = true>
    __device__ static inline uint32_t bfind_shiftamt(
-     int32_t a_reg);
+     S32 a_reg);
 
 bfind.s64
 ^^^^^^^^^
 .. code-block:: cuda
 
    // bfind.s64 dest, a_reg; // PTX ISA 20, SM_50
-   template <typename = void>
+   template <typename S64, enable_if_t<sizeof(S64) == 8 && is_integral_v<S64> && is_signed_v<S64>, bool> = true>
    __device__ static inline uint32_t bfind(
-     int64_t a_reg);
+     S64 a_reg);
 
 bfind.shiftamt.s64
 ^^^^^^^^^^^^^^^^^^
 .. code-block:: cuda
 
    // bfind.shiftamt.s64 dest, a_reg; // PTX ISA 20, SM_50
-   template <typename = void>
+   template <typename S64, enable_if_t<sizeof(S64) == 8 && is_integral_v<S64> && is_signed_v<S64>, bool> = true>
    __device__ static inline uint32_t bfind_shiftamt(
-     int64_t a_reg);
+     S64 a_reg);

--- a/docs/libcudacxx/ptx/instructions/generated/shr.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/shr.rst
@@ -16,7 +16,7 @@ shr.b32
 .. code-block:: cuda
 
    // shr.b32 dest, a_reg, b_reg; // PTX ISA 10, SM_50
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   template <typename B32, enable_if_t<sizeof(B32) == 4 && !(is_integral_v<B32> && is_signed_v<B32>), bool> = true>
    __device__ static inline B32 shr(
      B32 a_reg,
      uint32_t b_reg);
@@ -26,7 +26,7 @@ shr.b64
 .. code-block:: cuda
 
    // shr.b64 dest, a_reg, b_reg; // PTX ISA 10, SM_50
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+   template <typename B64, enable_if_t<sizeof(B64) == 8 && !(is_integral_v<B64> && is_signed_v<B64>), bool> = true>
    __device__ static inline B64 shr(
      B64 a_reg,
      uint32_t b_reg);
@@ -46,9 +46,9 @@ shr.s32
 .. code-block:: cuda
 
    // shr.s32 dest, a_reg, b_reg; // PTX ISA 10, SM_50
-   template <typename = void>
-   __device__ static inline int32_t shr(
-     int32_t a_reg,
+   template <typename S32, enable_if_t<sizeof(S32) == 4 && is_integral_v<S32> && is_signed_v<S32>, bool> = true>
+   __device__ static inline S32 shr(
+     S32 a_reg,
      uint32_t b_reg);
 
 shr.s64
@@ -56,7 +56,7 @@ shr.s64
 .. code-block:: cuda
 
    // shr.s64 dest, a_reg, b_reg; // PTX ISA 10, SM_50
-   template <typename = void>
-   __device__ static inline int64_t shr(
-     int64_t a_reg,
+   template <typename S64, enable_if_t<sizeof(S64) == 8 && is_integral_v<S64> && is_signed_v<S64>, bool> = true>
+   __device__ static inline S64 shr(
+     S64 a_reg,
      uint32_t b_reg);

--- a/libcudacxx/include/cuda/__ptx/instructions/bfind.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/bfind.h
@@ -24,6 +24,9 @@
 
 #include <cuda/__ptx/ptx_dot_variants.h>
 #include <cuda/__ptx/ptx_helper_functions.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/__type_traits/is_unsigned.h>
 #include <cuda/std/cstdint>
 
 #include <nv/target> // __CUDA_MINIMUM_ARCH__ and friends

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/bfind.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/bfind.h
@@ -5,185 +5,149 @@
 
 /*
 // bfind.u32 dest, a_reg; // PTX ISA 20, SM_50
-template <typename = void>
+template <typename U32, enable_if_t<sizeof(U32) == 4 && is_integral_v<U32> && is_unsigned_v<U32>, bool> = true>
 __device__ static inline uint32_t bfind(
-  uint32_t a_reg);
+  U32 a_reg);
 */
 #if __cccl_ptx_isa >= 200
-extern "C" _CCCL_DEVICE void __cuda_ptx_bfind_is_not_supported_before_SM_50__();
-template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind(::cuda::std::uint32_t __a_reg)
+template <
+  typename _U32,
+  ::cuda::std::enable_if_t<sizeof(_U32) == 4 && ::cuda::std::is_integral_v<_U32>&& ::cuda::std::is_unsigned_v<_U32>,
+                           bool> = true>
+_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind(_U32 __a_reg)
 {
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
   ::cuda::std::uint32_t __dest;
-  asm("bfind.u32 %0, %1;" : "=r"(__dest) : "r"(__a_reg) :);
+  asm("bfind.u32 %0, %1;" : "=r"(__dest) : "r"(*reinterpret_cast<const ::cuda::std::uint32_t*>(&__a_reg)) :);
   return __dest;
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_bfind_is_not_supported_before_SM_50__();
-  return 0;
-#  endif
 }
 #endif // __cccl_ptx_isa >= 200
 
 /*
 // bfind.shiftamt.u32 dest, a_reg; // PTX ISA 20, SM_50
-template <typename = void>
+template <typename U32, enable_if_t<sizeof(U32) == 4 && is_integral_v<U32> && is_unsigned_v<U32>, bool> = true>
 __device__ static inline uint32_t bfind_shiftamt(
-  uint32_t a_reg);
+  U32 a_reg);
 */
 #if __cccl_ptx_isa >= 200
-extern "C" _CCCL_DEVICE void __cuda_ptx_bfind_shiftamt_is_not_supported_before_SM_50__();
-template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind_shiftamt(::cuda::std::uint32_t __a_reg)
+template <
+  typename _U32,
+  ::cuda::std::enable_if_t<sizeof(_U32) == 4 && ::cuda::std::is_integral_v<_U32>&& ::cuda::std::is_unsigned_v<_U32>,
+                           bool> = true>
+_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind_shiftamt(_U32 __a_reg)
 {
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
   ::cuda::std::uint32_t __dest;
-  asm("bfind.shiftamt.u32 %0, %1;" : "=r"(__dest) : "r"(__a_reg) :);
+  asm("bfind.shiftamt.u32 %0, %1;" : "=r"(__dest) : "r"(*reinterpret_cast<const ::cuda::std::uint32_t*>(&__a_reg)) :);
   return __dest;
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_bfind_shiftamt_is_not_supported_before_SM_50__();
-  return 0;
-#  endif
 }
 #endif // __cccl_ptx_isa >= 200
 
 /*
 // bfind.u64 dest, a_reg; // PTX ISA 20, SM_50
-template <typename = void>
+template <typename U64, enable_if_t<sizeof(U64) == 8 && is_integral_v<U64> && is_unsigned_v<U64>, bool> = true>
 __device__ static inline uint32_t bfind(
-  uint64_t a_reg);
+  U64 a_reg);
 */
 #if __cccl_ptx_isa >= 200
-extern "C" _CCCL_DEVICE void __cuda_ptx_bfind_is_not_supported_before_SM_50__();
-template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind(::cuda::std::uint64_t __a_reg)
+template <
+  typename _U64,
+  ::cuda::std::enable_if_t<sizeof(_U64) == 8 && ::cuda::std::is_integral_v<_U64>&& ::cuda::std::is_unsigned_v<_U64>,
+                           bool> = true>
+_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind(_U64 __a_reg)
 {
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
   ::cuda::std::uint32_t __dest;
-  asm("bfind.u64 %0, %1;" : "=r"(__dest) : "l"(__a_reg) :);
+  asm("bfind.u64 %0, %1;" : "=r"(__dest) : "l"(*reinterpret_cast<const ::cuda::std::uint64_t*>(&__a_reg)) :);
   return __dest;
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_bfind_is_not_supported_before_SM_50__();
-  return 0;
-#  endif
 }
 #endif // __cccl_ptx_isa >= 200
 
 /*
 // bfind.shiftamt.u64 dest, a_reg; // PTX ISA 20, SM_50
-template <typename = void>
+template <typename U64, enable_if_t<sizeof(U64) == 8 && is_integral_v<U64> && is_unsigned_v<U64>, bool> = true>
 __device__ static inline uint32_t bfind_shiftamt(
-  uint64_t a_reg);
+  U64 a_reg);
 */
 #if __cccl_ptx_isa >= 200
-extern "C" _CCCL_DEVICE void __cuda_ptx_bfind_shiftamt_is_not_supported_before_SM_50__();
-template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind_shiftamt(::cuda::std::uint64_t __a_reg)
+template <
+  typename _U64,
+  ::cuda::std::enable_if_t<sizeof(_U64) == 8 && ::cuda::std::is_integral_v<_U64>&& ::cuda::std::is_unsigned_v<_U64>,
+                           bool> = true>
+_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind_shiftamt(_U64 __a_reg)
 {
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
   ::cuda::std::uint32_t __dest;
-  asm("bfind.shiftamt.u64 %0, %1;" : "=r"(__dest) : "l"(__a_reg) :);
+  asm("bfind.shiftamt.u64 %0, %1;" : "=r"(__dest) : "l"(*reinterpret_cast<const ::cuda::std::uint64_t*>(&__a_reg)) :);
   return __dest;
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_bfind_shiftamt_is_not_supported_before_SM_50__();
-  return 0;
-#  endif
 }
 #endif // __cccl_ptx_isa >= 200
 
 /*
 // bfind.s32 dest, a_reg; // PTX ISA 20, SM_50
-template <typename = void>
+template <typename S32, enable_if_t<sizeof(S32) == 4 && is_integral_v<S32> && is_signed_v<S32>, bool> = true>
 __device__ static inline uint32_t bfind(
-  int32_t a_reg);
+  S32 a_reg);
 */
 #if __cccl_ptx_isa >= 200
-extern "C" _CCCL_DEVICE void __cuda_ptx_bfind_is_not_supported_before_SM_50__();
-template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind(::cuda::std::int32_t __a_reg)
+template <typename _S32,
+          ::cuda::std::enable_if_t<sizeof(_S32) == 4 && ::cuda::std::is_integral_v<_S32>&& ::cuda::std::is_signed_v<_S32>,
+                                   bool> = true>
+_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind(_S32 __a_reg)
 {
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
   ::cuda::std::uint32_t __dest;
-  asm("bfind.s32 %0, %1;" : "=r"(__dest) : "r"(__a_reg) :);
+  asm("bfind.s32 %0, %1;" : "=r"(__dest) : "r"(*reinterpret_cast<const ::cuda::std::int32_t*>(&__a_reg)) :);
   return __dest;
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_bfind_is_not_supported_before_SM_50__();
-  return 0;
-#  endif
 }
 #endif // __cccl_ptx_isa >= 200
 
 /*
 // bfind.shiftamt.s32 dest, a_reg; // PTX ISA 20, SM_50
-template <typename = void>
+template <typename S32, enable_if_t<sizeof(S32) == 4 && is_integral_v<S32> && is_signed_v<S32>, bool> = true>
 __device__ static inline uint32_t bfind_shiftamt(
-  int32_t a_reg);
+  S32 a_reg);
 */
 #if __cccl_ptx_isa >= 200
-extern "C" _CCCL_DEVICE void __cuda_ptx_bfind_shiftamt_is_not_supported_before_SM_50__();
-template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind_shiftamt(::cuda::std::int32_t __a_reg)
+template <typename _S32,
+          ::cuda::std::enable_if_t<sizeof(_S32) == 4 && ::cuda::std::is_integral_v<_S32>&& ::cuda::std::is_signed_v<_S32>,
+                                   bool> = true>
+_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind_shiftamt(_S32 __a_reg)
 {
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
   ::cuda::std::uint32_t __dest;
-  asm("bfind.shiftamt.s32 %0, %1;" : "=r"(__dest) : "r"(__a_reg) :);
+  asm("bfind.shiftamt.s32 %0, %1;" : "=r"(__dest) : "r"(*reinterpret_cast<const ::cuda::std::int32_t*>(&__a_reg)) :);
   return __dest;
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_bfind_shiftamt_is_not_supported_before_SM_50__();
-  return 0;
-#  endif
 }
 #endif // __cccl_ptx_isa >= 200
 
 /*
 // bfind.s64 dest, a_reg; // PTX ISA 20, SM_50
-template <typename = void>
+template <typename S64, enable_if_t<sizeof(S64) == 8 && is_integral_v<S64> && is_signed_v<S64>, bool> = true>
 __device__ static inline uint32_t bfind(
-  int64_t a_reg);
+  S64 a_reg);
 */
 #if __cccl_ptx_isa >= 200
-extern "C" _CCCL_DEVICE void __cuda_ptx_bfind_is_not_supported_before_SM_50__();
-template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind(::cuda::std::int64_t __a_reg)
+template <typename _S64,
+          ::cuda::std::enable_if_t<sizeof(_S64) == 8 && ::cuda::std::is_integral_v<_S64>&& ::cuda::std::is_signed_v<_S64>,
+                                   bool> = true>
+_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind(_S64 __a_reg)
 {
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
   ::cuda::std::uint32_t __dest;
-  asm("bfind.s64 %0, %1;" : "=r"(__dest) : "l"(__a_reg) :);
+  asm("bfind.s64 %0, %1;" : "=r"(__dest) : "l"(*reinterpret_cast<const ::cuda::std::int64_t*>(&__a_reg)) :);
   return __dest;
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_bfind_is_not_supported_before_SM_50__();
-  return 0;
-#  endif
 }
 #endif // __cccl_ptx_isa >= 200
 
 /*
 // bfind.shiftamt.s64 dest, a_reg; // PTX ISA 20, SM_50
-template <typename = void>
+template <typename S64, enable_if_t<sizeof(S64) == 8 && is_integral_v<S64> && is_signed_v<S64>, bool> = true>
 __device__ static inline uint32_t bfind_shiftamt(
-  int64_t a_reg);
+  S64 a_reg);
 */
 #if __cccl_ptx_isa >= 200
-extern "C" _CCCL_DEVICE void __cuda_ptx_bfind_shiftamt_is_not_supported_before_SM_50__();
-template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind_shiftamt(::cuda::std::int64_t __a_reg)
+template <typename _S64,
+          ::cuda::std::enable_if_t<sizeof(_S64) == 8 && ::cuda::std::is_integral_v<_S64>&& ::cuda::std::is_signed_v<_S64>,
+                                   bool> = true>
+_CCCL_DEVICE static inline ::cuda::std::uint32_t bfind_shiftamt(_S64 __a_reg)
 {
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
   ::cuda::std::uint32_t __dest;
-  asm("bfind.shiftamt.s64 %0, %1;" : "=r"(__dest) : "l"(__a_reg) :);
+  asm("bfind.shiftamt.s64 %0, %1;" : "=r"(__dest) : "l"(*reinterpret_cast<const ::cuda::std::int64_t*>(&__a_reg)) :);
   return __dest;
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_bfind_shiftamt_is_not_supported_before_SM_50__();
-  return 0;
-#  endif
 }
 #endif // __cccl_ptx_isa >= 200
 

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/shr.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/shr.h
@@ -11,85 +11,63 @@ __device__ static inline B16 shr(
   uint32_t b_reg);
 */
 #if __cccl_ptx_isa >= 100
-extern "C" _CCCL_DEVICE void __cuda_ptx_shr_is_not_supported_before_SM_50__();
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
 _CCCL_DEVICE static inline _B16 shr(_B16 __a_reg, ::cuda::std::uint32_t __b_reg)
 {
-  static_assert(sizeof(_B16) == 2);
-  static_assert(sizeof(_B16) == 2);
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  static_assert(sizeof(_B16) == 2, "");
+  static_assert(sizeof(_B16) == 2, "");
   ::cuda::std::uint16_t __dest;
   asm("shr.b16 %0, %1, %2;"
       : "=h"(__dest)
       : "h"(/*as_b16*/ *reinterpret_cast<const ::cuda::std::int16_t*>(&__a_reg)), "r"(__b_reg)
       :);
   return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_shr_is_not_supported_before_SM_50__();
-  ::cuda::std::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
 }
 #endif // __cccl_ptx_isa >= 100
 
 /*
 // shr.b32 dest, a_reg, b_reg; // PTX ISA 10, SM_50
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4 && !(is_integral_v<B32> && is_signed_v<B32>), bool> = true>
 __device__ static inline B32 shr(
   B32 a_reg,
   uint32_t b_reg);
 */
 #if __cccl_ptx_isa >= 100
-extern "C" _CCCL_DEVICE void __cuda_ptx_shr_is_not_supported_before_SM_50__();
-template <typename _B32, ::cuda::std::enable_if_t<sizeof(_B32) == 4, bool> = true>
+template <
+  typename _B32,
+  ::cuda::std::enable_if_t<sizeof(_B32) == 4 && !(::cuda::std::is_integral_v<_B32> && ::cuda::std::is_signed_v<_B32>),
+                           bool> = true>
 _CCCL_DEVICE static inline _B32 shr(_B32 __a_reg, ::cuda::std::uint32_t __b_reg)
 {
-  static_assert(sizeof(_B32) == 4);
-  static_assert(sizeof(_B32) == 4);
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
   ::cuda::std::uint32_t __dest;
   asm("shr.b32 %0, %1, %2;"
       : "=r"(__dest)
-      : "r"(/*as_b32*/ *reinterpret_cast<const ::cuda::std::int32_t*>(&__a_reg)), "r"(__b_reg)
+      : "r"(*reinterpret_cast<const ::cuda::std::int32_t*>(&__a_reg)), "r"(__b_reg)
       :);
   return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_shr_is_not_supported_before_SM_50__();
-  ::cuda::std::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
 }
 #endif // __cccl_ptx_isa >= 100
 
 /*
 // shr.b64 dest, a_reg, b_reg; // PTX ISA 10, SM_50
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8 && !(is_integral_v<B64> && is_signed_v<B64>), bool> = true>
 __device__ static inline B64 shr(
   B64 a_reg,
   uint32_t b_reg);
 */
 #if __cccl_ptx_isa >= 100
-extern "C" _CCCL_DEVICE void __cuda_ptx_shr_is_not_supported_before_SM_50__();
-template <typename _B64, ::cuda::std::enable_if_t<sizeof(_B64) == 8, bool> = true>
+template <
+  typename _B64,
+  ::cuda::std::enable_if_t<sizeof(_B64) == 8 && !(::cuda::std::is_integral_v<_B64> && ::cuda::std::is_signed_v<_B64>),
+                           bool> = true>
 _CCCL_DEVICE static inline _B64 shr(_B64 __a_reg, ::cuda::std::uint32_t __b_reg)
 {
-  static_assert(sizeof(_B64) == 8);
-  static_assert(sizeof(_B64) == 8);
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
   ::cuda::std::uint64_t __dest;
   asm("shr.b64 %0, %1, %2;"
       : "=l"(__dest)
-      : "l"(/*as_b64*/ *reinterpret_cast<const ::cuda::std::int64_t*>(&__a_reg)), "r"(__b_reg)
+      : "l"(*reinterpret_cast<const ::cuda::std::int64_t*>(&__a_reg)), "r"(__b_reg)
       :);
   return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_shr_is_not_supported_before_SM_50__();
-  ::cuda::std::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
 }
 #endif // __cccl_ptx_isa >= 100
 
@@ -101,67 +79,56 @@ __device__ static inline int16_t shr(
   uint32_t b_reg);
 */
 #if __cccl_ptx_isa >= 100
-extern "C" _CCCL_DEVICE void __cuda_ptx_shr_is_not_supported_before_SM_50__();
 template <typename = void>
 _CCCL_DEVICE static inline ::cuda::std::int16_t shr(::cuda::std::int16_t __a_reg, ::cuda::std::uint32_t __b_reg)
 {
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
   ::cuda::std::int16_t __dest;
   asm("shr.s16 %0, %1, %2;" : "=h"(__dest) : "h"(__a_reg), "r"(__b_reg) :);
   return __dest;
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_shr_is_not_supported_before_SM_50__();
-  return 0;
-#  endif
 }
 #endif // __cccl_ptx_isa >= 100
 
 /*
 // shr.s32 dest, a_reg, b_reg; // PTX ISA 10, SM_50
-template <typename = void>
-__device__ static inline int32_t shr(
-  int32_t a_reg,
+template <typename S32, enable_if_t<sizeof(S32) == 4 && is_integral_v<S32> && is_signed_v<S32>, bool> = true>
+__device__ static inline S32 shr(
+  S32 a_reg,
   uint32_t b_reg);
 */
 #if __cccl_ptx_isa >= 100
-extern "C" _CCCL_DEVICE void __cuda_ptx_shr_is_not_supported_before_SM_50__();
-template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::int32_t shr(::cuda::std::int32_t __a_reg, ::cuda::std::uint32_t __b_reg)
+template <typename _S32,
+          ::cuda::std::enable_if_t<sizeof(_S32) == 4 && ::cuda::std::is_integral_v<_S32>&& ::cuda::std::is_signed_v<_S32>,
+                                   bool> = true>
+_CCCL_DEVICE static inline _S32 shr(_S32 __a_reg, ::cuda::std::uint32_t __b_reg)
 {
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
   ::cuda::std::int32_t __dest;
-  asm("shr.s32 %0, %1, %2;" : "=r"(__dest) : "r"(__a_reg), "r"(__b_reg) :);
-  return __dest;
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_shr_is_not_supported_before_SM_50__();
-  return 0;
-#  endif
+  asm("shr.s32 %0, %1, %2;"
+      : "=r"(__dest)
+      : "r"(*reinterpret_cast<const ::cuda::std::int32_t*>(&__a_reg)), "r"(__b_reg)
+      :);
+  return *reinterpret_cast<_S32*>(&__dest);
 }
 #endif // __cccl_ptx_isa >= 100
 
 /*
 // shr.s64 dest, a_reg, b_reg; // PTX ISA 10, SM_50
-template <typename = void>
-__device__ static inline int64_t shr(
-  int64_t a_reg,
+template <typename S64, enable_if_t<sizeof(S64) == 8 && is_integral_v<S64> && is_signed_v<S64>, bool> = true>
+__device__ static inline S64 shr(
+  S64 a_reg,
   uint32_t b_reg);
 */
 #if __cccl_ptx_isa >= 100
-extern "C" _CCCL_DEVICE void __cuda_ptx_shr_is_not_supported_before_SM_50__();
-template <typename = void>
-_CCCL_DEVICE static inline ::cuda::std::int64_t shr(::cuda::std::int64_t __a_reg, ::cuda::std::uint32_t __b_reg)
+template <typename _S64,
+          ::cuda::std::enable_if_t<sizeof(_S64) == 8 && ::cuda::std::is_integral_v<_S64>&& ::cuda::std::is_signed_v<_S64>,
+                                   bool> = true>
+_CCCL_DEVICE static inline _S64 shr(_S64 __a_reg, ::cuda::std::uint32_t __b_reg)
 {
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
   ::cuda::std::int64_t __dest;
-  asm("shr.s64 %0, %1, %2;" : "=l"(__dest) : "l"(__a_reg), "r"(__b_reg) :);
-  return __dest;
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_shr_is_not_supported_before_SM_50__();
-  return 0;
-#  endif
+  asm("shr.s64 %0, %1, %2;"
+      : "=l"(__dest)
+      : "l"(*reinterpret_cast<const ::cuda::std::int64_t*>(&__a_reg)), "r"(__b_reg)
+      :);
+  return *reinterpret_cast<_S64*>(&__dest);
 }
 #endif // __cccl_ptx_isa >= 100
 

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/shr.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/shr.h
@@ -14,8 +14,8 @@ __device__ static inline B16 shr(
 template <typename _B16, ::cuda::std::enable_if_t<sizeof(_B16) == 2, bool> = true>
 _CCCL_DEVICE static inline _B16 shr(_B16 __a_reg, ::cuda::std::uint32_t __b_reg)
 {
-  static_assert(sizeof(_B16) == 2, "");
-  static_assert(sizeof(_B16) == 2, "");
+  static_assert(sizeof(_B16) == 2);
+  static_assert(sizeof(_B16) == 2);
   ::cuda::std::uint16_t __dest;
   asm("shr.b16 %0, %1, %2;"
       : "=h"(__dest)

--- a/libcudacxx/include/cuda/__ptx/instructions/shr.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/shr.h
@@ -24,6 +24,8 @@
 
 #include <cuda/__ptx/ptx_dot_variants.h>
 #include <cuda/__ptx/ptx_helper_functions.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_signed.h>
 #include <cuda/std/cstdint>
 
 #include <nv/target> // __CUDA_MINIMUM_ARCH__ and friends

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/bfind.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/bfind.h
@@ -17,66 +17,84 @@
 __global__ void test_bfind(void** fn_ptr)
 {
 #if __cccl_ptx_isa >= 200
-  NV_IF_TARGET(NV_PROVIDES_SM_50,
-               (
-                   // bfind.u32 dest, a_reg;
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<cuda::std::uint32_t (*)(cuda::std::uint32_t)>(cuda::ptx::bfind));));
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_50,
+    (
+        // bfind.u32 dest, a_reg;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<cuda::std::uint32_t (*)(cuda::std::uint32_t)>(cuda::ptx::bfind));
+        *fn_ptr++ = reinterpret_cast<void*>(static_cast<cuda::std::uint32_t (*)(unsigned long)>(cuda::ptx::bfind));));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
-  NV_IF_TARGET(NV_PROVIDES_SM_50,
-               (
-                   // bfind.shiftamt.u32 dest, a_reg;
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<cuda::std::uint32_t (*)(cuda::std::uint32_t)>(cuda::ptx::bfind_shiftamt));));
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_50,
+    (
+        // bfind.shiftamt.u32 dest, a_reg;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<cuda::std::uint32_t (*)(cuda::std::uint32_t)>(cuda::ptx::bfind_shiftamt));
+        *fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<cuda::std::uint32_t (*)(unsigned long)>(cuda::ptx::bfind_shiftamt));));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
-  NV_IF_TARGET(NV_PROVIDES_SM_50,
-               (
-                   // bfind.u64 dest, a_reg;
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<cuda::std::uint32_t (*)(cuda::std::uint64_t)>(cuda::ptx::bfind));));
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_50,
+    (
+        // bfind.u64 dest, a_reg;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<cuda::std::uint32_t (*)(cuda::std::uint64_t)>(cuda::ptx::bfind));
+        *fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<cuda::std::uint32_t (*)(unsigned long long)>(cuda::ptx::bfind));));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
-  NV_IF_TARGET(NV_PROVIDES_SM_50,
-               (
-                   // bfind.shiftamt.u64 dest, a_reg;
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<cuda::std::uint32_t (*)(cuda::std::uint64_t)>(cuda::ptx::bfind_shiftamt));));
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_50,
+    (
+        // bfind.shiftamt.u64 dest, a_reg;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<cuda::std::uint32_t (*)(cuda::std::uint64_t)>(cuda::ptx::bfind_shiftamt));
+        *fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<cuda::std::uint32_t (*)(unsigned long long)>(cuda::ptx::bfind_shiftamt));));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
-  NV_IF_TARGET(NV_PROVIDES_SM_50,
-               (
-                   // bfind.s32 dest, a_reg;
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<cuda::std::uint32_t (*)(cuda::std::int32_t)>(cuda::ptx::bfind));));
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_50,
+    (
+        // bfind.s32 dest, a_reg;
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<cuda::std::uint32_t (*)(cuda::std::int32_t)>(cuda::ptx::bfind));
+        *fn_ptr++ = reinterpret_cast<void*>(static_cast<cuda::std::uint32_t (*)(long)>(cuda::ptx::bfind));));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
-  NV_IF_TARGET(NV_PROVIDES_SM_50,
-               (
-                   // bfind.shiftamt.s32 dest, a_reg;
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<cuda::std::uint32_t (*)(cuda::std::int32_t)>(cuda::ptx::bfind_shiftamt));));
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_50,
+    (
+        // bfind.shiftamt.s32 dest, a_reg;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<cuda::std::uint32_t (*)(cuda::std::int32_t)>(cuda::ptx::bfind_shiftamt));
+        *fn_ptr++ = reinterpret_cast<void*>(static_cast<cuda::std::uint32_t (*)(long)>(cuda::ptx::bfind_shiftamt));));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
-  NV_IF_TARGET(NV_PROVIDES_SM_50,
-               (
-                   // bfind.s64 dest, a_reg;
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<cuda::std::uint32_t (*)(cuda::std::int64_t)>(cuda::ptx::bfind));));
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_50,
+    (
+        // bfind.s64 dest, a_reg;
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<cuda::std::uint32_t (*)(cuda::std::int64_t)>(cuda::ptx::bfind));
+        *fn_ptr++ = reinterpret_cast<void*>(static_cast<cuda::std::uint32_t (*)(long long)>(cuda::ptx::bfind));));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
-  NV_IF_TARGET(NV_PROVIDES_SM_50,
-               (
-                   // bfind.shiftamt.s64 dest, a_reg;
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<cuda::std::uint32_t (*)(cuda::std::int64_t)>(cuda::ptx::bfind_shiftamt));));
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_50,
+    (
+        // bfind.shiftamt.s64 dest, a_reg;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<cuda::std::uint32_t (*)(cuda::std::int64_t)>(cuda::ptx::bfind_shiftamt));
+        *fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<cuda::std::uint32_t (*)(long long)>(cuda::ptx::bfind_shiftamt));));
 #endif // __cccl_ptx_isa >= 200
 }

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/shr.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/shr.h
@@ -29,7 +29,7 @@ __global__ void test_shr(void** fn_ptr)
                (
                    // shr.b32 dest, a_reg, b_reg;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<cuda::std::int32_t (*)(cuda::std::int32_t, cuda::std::uint32_t)>(cuda::ptx::shr));));
+                     static_cast<cuda::std::uint32_t (*)(cuda::std::uint32_t, cuda::std::uint32_t)>(cuda::ptx::shr));));
 #endif // __cccl_ptx_isa >= 100
 
 #if __cccl_ptx_isa >= 100
@@ -37,7 +37,7 @@ __global__ void test_shr(void** fn_ptr)
                (
                    // shr.b64 dest, a_reg, b_reg;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<cuda::std::int64_t (*)(cuda::std::int64_t, cuda::std::uint32_t)>(cuda::ptx::shr));));
+                     static_cast<cuda::std::uint64_t (*)(cuda::std::uint64_t, cuda::std::uint32_t)>(cuda::ptx::shr));));
 #endif // __cccl_ptx_isa >= 100
 
 #if __cccl_ptx_isa >= 100
@@ -49,18 +49,23 @@ __global__ void test_shr(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 100
 
 #if __cccl_ptx_isa >= 100
-  NV_IF_TARGET(NV_PROVIDES_SM_50,
-               (
-                   // shr.s32 dest, a_reg, b_reg;
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<cuda::std::int32_t (*)(cuda::std::int32_t, cuda::std::uint32_t)>(cuda::ptx::shr));));
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_50,
+    (
+        // shr.s32 dest, a_reg, b_reg;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<cuda::std::int32_t (*)(cuda::std::int32_t, cuda::std::uint32_t)>(cuda::ptx::shr));
+        *fn_ptr++ = reinterpret_cast<void*>(static_cast<long (*)(long, cuda::std::uint32_t)>(cuda::ptx::shr));));
 #endif // __cccl_ptx_isa >= 100
 
 #if __cccl_ptx_isa >= 100
-  NV_IF_TARGET(NV_PROVIDES_SM_50,
-               (
-                   // shr.s64 dest, a_reg, b_reg;
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<cuda::std::int64_t (*)(cuda::std::int64_t, cuda::std::uint32_t)>(cuda::ptx::shr));));
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_50,
+    (
+        // shr.s64 dest, a_reg, b_reg;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<cuda::std::int64_t (*)(cuda::std::int64_t, cuda::std::uint32_t)>(cuda::ptx::shr));
+        *fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<long long (*)(long long, cuda::std::uint32_t)>(cuda::ptx::shr));));
 #endif // __cccl_ptx_isa >= 100
 }


### PR DESCRIPTION
## Description

Fix `cuda::ptx` `shr` and `bfind` `long`, `long long` (+ unsigned) handling across Linux and Windows

Fixes https://github.com/NVIDIA/cccl/issues/9992
