### PR TITLE
`cuda_error` fixups

### DIFF
--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -69,7 +69,7 @@ namespace __detail
 /**
  * @brief Exception thrown when a CUDA error is encountered.
  */
-class _CCCL_VISIBILITY_EXPORT cuda_error : public ::std::runtime_error
+class _CCCL_VISIBILITY_DEFAULT cuda_error : public ::std::runtime_error
 {
 public:
   _CCCL_HOST_API cuda_error(

--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -40,7 +40,7 @@ using __cuda_error_t = int;
 #if _CCCL_HOSTED()
 namespace __detail
 {
-static char* __format_cuda_error(
+[[nodiscard]] _CCCL_HOST_API inline char* __format_cuda_error(
   ::cuda::__msg_storage& __msg_buffer,
   const int __status,
   const char* __msg,
@@ -69,19 +69,20 @@ static char* __format_cuda_error(
 /**
  * @brief Exception thrown when a CUDA error is encountered.
  */
-class cuda_error : public ::std::runtime_error
+class _CCCL_VISIBILITY_DEFAULT cuda_error : public ::std::runtime_error
 {
 public:
-  cuda_error(const __cuda_error_t __status,
-             const char* __msg,
-             const char* __api                  = nullptr,
-             ::cuda::std::source_location __loc = ::cuda::std::source_location::current(),
-             __msg_storage __msg_buffer         = {}) noexcept
+  _CCCL_HOST_API cuda_error(
+    const __cuda_error_t __status,
+    const char* __msg,
+    const char* __api                  = nullptr,
+    ::cuda::std::source_location __loc = ::cuda::std::source_location::current(),
+    __msg_storage __msg_buffer         = {}) noexcept
       : ::std::runtime_error(::cuda::__detail::__format_cuda_error(__msg_buffer, __status, __msg, __api, __loc))
       , __status_(__status)
   {}
 
-  [[nodiscard]] auto status() const noexcept -> __cuda_error_t
+  [[nodiscard]] _CCCL_HOST_API constexpr auto status() const noexcept -> __cuda_error_t
   {
     return __status_;
   }

--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -69,7 +69,7 @@ namespace __detail
 /**
  * @brief Exception thrown when a CUDA error is encountered.
  */
-class _CCCL_VISIBILITY_DEFAULT cuda_error : public ::std::runtime_error
+class cuda_error : public ::std::runtime_error
 {
 public:
   _CCCL_HOST_API cuda_error(

--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -69,7 +69,7 @@ namespace __detail
 /**
  * @brief Exception thrown when a CUDA error is encountered.
  */
-class _CCCL_VISIBILITY_DEFAULT cuda_error : public ::std::runtime_error
+class _CCCL_PUBLIC_HOST_API cuda_error : public ::std::runtime_error
 {
 public:
   _CCCL_HOST_API cuda_error(

--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -69,7 +69,7 @@ namespace __detail
 /**
  * @brief Exception thrown when a CUDA error is encountered.
  */
-class _CCCL_PUBLIC_HOST_API cuda_error : public ::std::runtime_error
+class _CCCL_VISIBILITY_EXPORT cuda_error : public ::std::runtime_error
 {
 public:
   _CCCL_HOST_API cuda_error(


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

1. Make `__format_cuda_error` inline (and add the proper attributes).
2. Make `cuda_error` publically visible. As it is an exception that is expected to potentially be caught by users, it must have public visibility (read https://gcc.gnu.org/wiki/Visibility for more info) to properly function across DSOs.
3. Make the member functions of `cuda_error` have the proper attributes as well.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
