### PR TITLE
Update `__cccl_ptx_isa` for clang-cuda 22

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/ptx_isa.h
+++ b/libcudacxx/include/cuda/std/__cccl/ptx_isa.h
@@ -53,7 +53,7 @@
 #elif _CCCL_CUDACC_AT_LEAST(13, 0) && !_CCCL_CUDA_COMPILER(CLANG)
 #  define __cccl_ptx_isa 900ULL
 // PTX ISA 8.8 is available from CUDA 12.9, driver r575
-#elif _CCCL_CUDACC_AT_LEAST(12, 9) && !_CCCL_CUDA_COMPILER(CLANG)
+#elif _CCCL_CUDACC_AT_LEAST(12, 9) && !_CCCL_CUDA_COMPILER(CLANG, <, 22)
 #  define __cccl_ptx_isa 880ULL
 // PTX ISA 8.7 is available from CUDA 12.8, driver r570
 #elif _CCCL_CUDACC_AT_LEAST(12, 8) && !_CCCL_CUDA_COMPILER(CLANG, <, 20)


### PR DESCRIPTION
According to https://github.com/llvm/llvm-project/blob/release/22.x/clang/lib/Driver/ToolChains/Cuda.cpp, CTK 12.9 is partially supported by clang-cuda 22.