### PR TITLE
Fix unused comparison operators now that cuda::arguments only uses `operator<`

### DIFF
--- a/cudax/test/multi_gpu/algorithms/inclusive_scan/range_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/inclusive_scan/range_basic.cu
@@ -40,24 +40,9 @@ struct custom_plus
   }
 };
 
-template <class CustomType>
-class less_equal_comparable_t
-{
-public:
-  friend _CCCL_HOST_DEVICE bool operator<=(const CustomType& lhs, const CustomType& rhs)
-  {
-    return lhs.key <= rhs.key;
-  }
-};
-
-using custom_value =
-  c2h::custom_type_t<c2h::accumulateable_t,
-                     c2h::less_comparable_t,
-                     c2h::equal_comparable_t,
-                     c2h::greater_comparable_t,
-                     less_equal_comparable_t>;
-using value_types = c2h::type_list<cuda::std::int32_t, float, custom_value>;
-using operators   = c2h::type_list<::cuda::std::plus<>, ::cuda::maximum<>, custom_plus>;
+using custom_value = c2h::custom_type_t<c2h::accumulateable_t, c2h::less_comparable_t, c2h::equal_comparable_t>;
+using value_types  = c2h::type_list<cuda::std::int32_t, float, custom_value>;
+using operators    = c2h::type_list<::cuda::std::plus<>, ::cuda::maximum<>, custom_plus>;
 
 static_assert(cudax::nccl_transportable<custom_value>);
 

--- a/cudax/test/multi_gpu/algorithms/inclusive_scan/single_comm_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/inclusive_scan/single_comm_basic.cu
@@ -40,24 +40,9 @@ struct custom_plus
   }
 };
 
-template <class CustomType>
-class less_equal_comparable_t
-{
-public:
-  friend _CCCL_HOST_DEVICE bool operator<=(const CustomType& lhs, const CustomType& rhs)
-  {
-    return lhs.key <= rhs.key;
-  }
-};
-
-using custom_value =
-  c2h::custom_type_t<c2h::accumulateable_t,
-                     c2h::less_comparable_t,
-                     c2h::equal_comparable_t,
-                     c2h::greater_comparable_t,
-                     less_equal_comparable_t>;
-using value_types = c2h::type_list<cuda::std::int32_t, float, custom_value>;
-using operators   = c2h::type_list<::cuda::std::plus<>, ::cuda::maximum<>, custom_plus>;
+using custom_value = c2h::custom_type_t<c2h::accumulateable_t, c2h::less_comparable_t, c2h::equal_comparable_t>;
+using value_types  = c2h::type_list<cuda::std::int32_t, float, custom_value>;
+using operators    = c2h::type_list<::cuda::std::plus<>, ::cuda::maximum<>, custom_plus>;
 
 static_assert(cudax::nccl_transportable<custom_value>);
 


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
