### PR TITLE
Restructure the RLE encode tuning policy

### DIFF
--- a/cub/benchmarks/bench/run_length_encode/encode.cu
+++ b/cub/benchmarks/bench/run_length_encode/encode.cu
@@ -20,12 +20,13 @@ struct bench_encode_policy_selector
   [[nodiscard]] _CCCL_HOST_DEVICE constexpr auto operator()(cuda::compute_capability) const -> cub::RleEncodePolicy
   {
     return {
-      TUNE_THREADS,
-      TUNE_ITEMS,
-      TUNE_TRANSPOSE == 0 ? cub::BLOCK_LOAD_DIRECT : cub::BLOCK_LOAD_WARP_TRANSPOSE,
-      TUNE_LOAD == 0 ? cub::LOAD_DEFAULT : cub::LOAD_CA,
-      cub::BLOCK_SCAN_WARP_SCANS,
-      lookback_delay_policy,
+      cub::RleAlgorithm::lookback,
+      {TUNE_THREADS,
+       TUNE_ITEMS,
+       TUNE_TRANSPOSE == 0 ? cub::BLOCK_LOAD_DIRECT : cub::BLOCK_LOAD_WARP_TRANSPOSE,
+       TUNE_LOAD == 0 ? cub::LOAD_DEFAULT : cub::LOAD_CA,
+       cub::BLOCK_SCAN_WARP_SCANS,
+       lookback_delay_policy},
     };
   }
 };

--- a/cub/cub/device/device_run_length_encode.cuh
+++ b/cub/cub/device/device_run_length_encode.cuh
@@ -95,12 +95,12 @@ struct DeviceRunLengthEncode
     {
       const RleEncodePolicy policy = PolicySelector{}(cc);
       return ReduceByKeyPolicy{
-        policy.threads_per_block,
-        policy.items_per_thread,
-        policy.load_algorithm,
-        policy.load_modifier,
-        policy.scan_algorithm,
-        policy.lookback_delay};
+        policy.lookback.threads_per_block,
+        policy.lookback.items_per_thread,
+        policy.lookback.load_algorithm,
+        policy.lookback.load_modifier,
+        policy.lookback.scan_algorithm,
+        policy.lookback.lookback_delay};
     }
   };
 #endif // _CCCL_DOXYGEN_INVOKED

--- a/cub/cub/device/dispatch/tuning/tuning_rle_encode.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_rle_encode.cuh
@@ -33,8 +33,8 @@
 
 CUB_NAMESPACE_BEGIN
 
-//! The tuning policy for DeviceRunLengthEncode::Encode
-struct RleEncodePolicy
+//! The lookback tuning policy for DeviceRunLengthEncode::Encode
+struct RleLookbackPolicy
 {
   int threads_per_block; //!< Number of threads in a CUDA block
   int items_per_thread; //!< Number of items processed per thread
@@ -44,7 +44,7 @@ struct RleEncodePolicy
   LookbackDelayPolicy lookback_delay; //!< The @ref LookbackDelayPolicy used for the lookback delay
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
-  operator==(const RleEncodePolicy& lhs, const RleEncodePolicy& rhs) noexcept
+  operator==(const RleLookbackPolicy& lhs, const RleLookbackPolicy& rhs) noexcept
   {
     return lhs.threads_per_block == rhs.threads_per_block && lhs.items_per_thread == rhs.items_per_thread
         && lhs.load_algorithm == rhs.load_algorithm && lhs.load_modifier == rhs.load_modifier
@@ -52,6 +52,61 @@ struct RleEncodePolicy
   }
 
   [[nodiscard]] _CCCL_HOST_DEVICE_API friend constexpr bool
+  operator!=(const RleLookbackPolicy& lhs, const RleLookbackPolicy& rhs) noexcept
+  {
+    return !(lhs == rhs);
+  }
+
+#if _CCCL_HOSTED()
+  friend ::std::ostream& operator<<(::std::ostream& os, const RleLookbackPolicy& p)
+  {
+    return os
+        << "RleLookbackPolicy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
+        << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm << ", .load_modifier = " << p.load_modifier
+        << ", .scan_algorithm = " << p.scan_algorithm << ", .lookback_delay = " << p.lookback_delay << " }";
+  }
+#endif // _CCCL_HOSTED()
+};
+
+//! The algorithm used by the run-length-encode policy.
+enum class RleAlgorithm
+{
+  lookback
+};
+
+#if _CCCL_HOSTED()
+namespace detail
+{
+[[nodiscard]] _CCCL_API constexpr const char* to_string(RleAlgorithm algo) noexcept
+{
+  switch (algo)
+  {
+    case RleAlgorithm::lookback:
+      return "RleAlgorithm::lookback";
+  }
+  return "<unknown RleAlgorithm>";
+}
+} // namespace detail
+
+inline ::std::ostream& operator<<(::std::ostream& os, RleAlgorithm algo)
+{
+  return os << CUB_NS_QUALIFIER::detail::to_string(algo);
+}
+#endif // _CCCL_HOSTED()
+
+//! The tuning policy for DeviceRunLengthEncode::Encode
+struct RleEncodePolicy
+{
+  RleAlgorithm algorithm = RleAlgorithm::lookback; //!< The RLE-encode algorithm to use
+  RleLookbackPolicy lookback; //!< The lookback policy
+
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator==(const RleEncodePolicy& lhs, const RleEncodePolicy& rhs) noexcept
+  {
+    return lhs.algorithm == rhs.algorithm && lhs.lookback == rhs.lookback;
+  }
+
+  [[nodiscard]] _CCCL_API friend constexpr bool
   operator!=(const RleEncodePolicy& lhs, const RleEncodePolicy& rhs) noexcept
   {
     return !(lhs == rhs);
@@ -60,10 +115,7 @@ struct RleEncodePolicy
 #if _CCCL_HOSTED()
   friend ::std::ostream& operator<<(::std::ostream& os, const RleEncodePolicy& p)
   {
-    return os
-        << "RleEncodePolicy { .threads_per_block = " << p.threads_per_block << ", .items_per_thread = "
-        << p.items_per_thread << ", .load_algorithm = " << p.load_algorithm << ", .load_modifier = " << p.load_modifier
-        << ", .scan_algorithm = " << p.scan_algorithm << ", .lookback_delay = " << p.lookback_delay << " }";
+    return os << "RleEncodePolicy { .algorithm = " << p.algorithm << ", .lookback = " << p.lookback << " }";
   }
 #endif // _CCCL_HOSTED()
 };
@@ -367,7 +419,7 @@ struct policy_selector
   bool length_is_trivially_copyable;
   bool key_is_primitive;
 
-  _CCCL_HOST_DEVICE_API constexpr auto __make_default_policy(CacheLoadModifier load_mod) const -> RleEncodePolicy
+  _CCCL_HOST_DEVICE_API constexpr auto __make_default_policy(CacheLoadModifier load_mod) const -> RleLookbackPolicy
   {
     constexpr int nominal_4B_items_per_thread = 6;
     const int combined_input_bytes            = length_size + key_size;
@@ -377,7 +429,7 @@ struct policy_selector
         ? 6
         : ::cuda::std::clamp(
             ::cuda::ceil_div(nominal_4B_items_per_thread * 8, combined_input_bytes), 1, nominal_4B_items_per_thread);
-    return RleEncodePolicy{
+    return RleLookbackPolicy{
       128,
       items_per_thread,
       BLOCK_LOAD_DIRECT,
@@ -387,14 +439,15 @@ struct policy_selector
         length_size, int{sizeof(int)}, length_is_primitive || length_is_trivially_copyable, true)};
   }
 
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> RleEncodePolicy
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto get_lookback_policy(::cuda::compute_capability cc) const
+    -> RleLookbackPolicy
   {
     // if we don't have a tuning for SM100, fall back to SM90
     if (cc >= ::cuda::compute_capability{10, 0} && length_is_primitive && length_size == 4 && key_is_primitive)
     {
       if (key_size == 1)
       {
-        return RleEncodePolicy{
+        return RleLookbackPolicy{
           256,
           14,
           BLOCK_LOAD_DIRECT,
@@ -404,7 +457,7 @@ struct policy_selector
       }
       if (key_size == 2)
       {
-        return RleEncodePolicy{
+        return RleLookbackPolicy{
           224,
           14,
           BLOCK_LOAD_DIRECT,
@@ -414,7 +467,7 @@ struct policy_selector
       }
       if (key_size == 4)
       {
-        return RleEncodePolicy{
+        return RleLookbackPolicy{
           256,
           14,
           BLOCK_LOAD_DIRECT,
@@ -424,7 +477,7 @@ struct policy_selector
       }
       if (key_size == 8)
       {
-        return RleEncodePolicy{
+        return RleLookbackPolicy{
           224,
           9,
           BLOCK_LOAD_WARP_TRANSPOSE,
@@ -440,17 +493,17 @@ struct policy_selector
       {
         if (key_is_primitive && key_size == 1)
         {
-          return RleEncodePolicy{
+          return RleLookbackPolicy{
             256, 13, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 620}};
         }
         if (key_is_primitive && key_size == 2)
         {
-          return RleEncodePolicy{
+          return RleLookbackPolicy{
             128, 22, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 775}};
         }
         if (key_is_primitive && key_size == 4)
         {
-          return RleEncodePolicy{
+          return RleLookbackPolicy{
             192,
             14,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -460,7 +513,7 @@ struct policy_selector
         }
         if (key_is_primitive && key_size == 8)
         {
-          return RleEncodePolicy{
+          return RleLookbackPolicy{
             128,
             19,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -470,7 +523,7 @@ struct policy_selector
         }
         if (key_t == type_t::int128 || key_t == type_t::uint128)
         {
-          return RleEncodePolicy{
+          return RleLookbackPolicy{
             128,
             11,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -495,17 +548,17 @@ struct policy_selector
       {
         if (key_is_primitive && key_size == 1)
         {
-          return RleEncodePolicy{
+          return RleLookbackPolicy{
             256, 14, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 640}};
         }
         if (key_is_primitive && key_size == 2)
         {
-          return RleEncodePolicy{
+          return RleLookbackPolicy{
             256, 13, BLOCK_LOAD_DIRECT, LOAD_DEFAULT, BLOCK_SCAN_WARP_SCANS, {LookbackDelayAlgorithm::no_delay, 0, 900}};
         }
         if (key_is_primitive && key_size == 4)
         {
-          return RleEncodePolicy{
+          return RleLookbackPolicy{
             256,
             13,
             BLOCK_LOAD_DIRECT,
@@ -515,7 +568,7 @@ struct policy_selector
         }
         if (key_is_primitive && key_size == 8)
         {
-          return RleEncodePolicy{
+          return RleLookbackPolicy{
             224,
             9,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -525,7 +578,7 @@ struct policy_selector
         }
         if (key_t == type_t::int128 || key_t == type_t::uint128)
         {
-          return RleEncodePolicy{
+          return RleLookbackPolicy{
             128,
             7,
             BLOCK_LOAD_WARP_TRANSPOSE,
@@ -541,6 +594,11 @@ struct policy_selector
 
     // for SM50
     return __make_default_policy(LOAD_LDG);
+  }
+
+  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr auto operator()(::cuda::compute_capability cc) const -> RleEncodePolicy
+  {
+    return RleEncodePolicy{RleAlgorithm::lookback, get_lookback_policy(cc)};
   }
 };
 

--- a/cub/test/catch2_test_device_run_length_encode_env.cu
+++ b/cub/test/catch2_test_device_run_length_encode_env.cu
@@ -35,7 +35,8 @@ struct rle_encode_tuning
 {
   _CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::RleEncodePolicy
   {
-    return {ThreadsPerBlock, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_SCAN_WARP_SCANS, {}};
+    return {cub::RleAlgorithm::lookback,
+            {ThreadsPerBlock, 1, cub::BLOCK_LOAD_DIRECT, cub::LOAD_DEFAULT, cub::BLOCK_SCAN_WARP_SCANS, {}}};
   }
 };
 
@@ -311,23 +312,26 @@ C2H_TEST("Test RleEncodePolicy properties", "[run_length_encode][device]")
 
   // aggregate init
   constexpr auto p1 = cub::RleEncodePolicy{
-    128,
-    7,
-    cub::BLOCK_LOAD_DIRECT,
-    cub::LOAD_DEFAULT,
-    cub::BLOCK_SCAN_WARP_SCANS,
-    {cub::LookbackDelayAlgorithm::fixed_delay, 832, 1165}};
+    cub::RleAlgorithm::lookback,
+    {128,
+     7,
+     cub::BLOCK_LOAD_DIRECT,
+     cub::LOAD_DEFAULT,
+     cub::BLOCK_SCAN_WARP_SCANS,
+     {cub::LookbackDelayAlgorithm::fixed_delay, 832, 1165}}};
 
 #  if _CCCL_STD_VER >= 2020
   // designated init
   constexpr auto p2 = cub::RleEncodePolicy{
-    .threads_per_block = 128,
-    .items_per_thread  = 7,
-    .load_algorithm    = cub::BLOCK_LOAD_DIRECT,
-    .load_modifier     = cub::LOAD_DEFAULT,
-    .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
-    .lookback_delay    = cub::LookbackDelayPolicy{
-         .kind = cub::LookbackDelayAlgorithm::fixed_delay, .delay = 832, .l2_write_latency = 1165}};
+    .algorithm = cub::RleAlgorithm::lookback,
+    .lookback  = cub::RleLookbackPolicy{
+       .threads_per_block = 128,
+       .items_per_thread  = 7,
+       .load_algorithm    = cub::BLOCK_LOAD_DIRECT,
+       .load_modifier     = cub::LOAD_DEFAULT,
+       .scan_algorithm    = cub::BLOCK_SCAN_WARP_SCANS,
+       .lookback_delay    = cub::LookbackDelayPolicy{
+            .kind = cub::LookbackDelayAlgorithm::fixed_delay, .delay = 832, .l2_write_latency = 1165}}};
 #  else // _CCCL_STD_VER >= 2020
   constexpr auto p2 = p1;
 #  endif // _CCCL_STD_VER >= 2020
@@ -342,11 +346,12 @@ C2H_TEST("Test RleEncodePolicy properties", "[run_length_encode][device]")
     return os.str();
   };
   REQUIRE(to_string(p1)
-          == "RleEncodePolicy { .threads_per_block = 128, .items_per_thread = 7"
+          == "RleEncodePolicy { .algorithm = RleAlgorithm::lookback"
+             ", .lookback = RleLookbackPolicy { .threads_per_block = 128, .items_per_thread = 7"
              ", .load_algorithm = BLOCK_LOAD_DIRECT, .load_modifier = LOAD_DEFAULT"
              ", .scan_algorithm = BLOCK_SCAN_WARP_SCANS"
              ", .lookback_delay = LookbackDelayPolicy { .kind = LookbackDelayAlgorithm::fixed_delay"
-             ", .delay = 832, .l2_write_latency = 1165 } }");
+             ", .delay = 832, .l2_write_latency = 1165 } } }");
 }
 #endif // _CCCL_COMPILER(GCC, >=, 8)
 


### PR DESCRIPTION
This is taken out from #9699 so that we can ship the changes to the tuning APIs first.

The changes are:

```
// before
_CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::RleEncodePolicy
{
  return {256, 14, cub::BLOCK_LOAD_DIRECT, cub::LOAD_CA, cub::BLOCK_SCAN_WARP_SCANS, {}};
}

// after
_CCCL_HOST_DEVICE_API constexpr auto operator()(cuda::compute_capability) const -> cub::RleEncodePolicy
{
  return {cub::RleAlgorithm::lookback,
          {256, 14, cub::BLOCK_LOAD_DIRECT, cub::LOAD_CA, cub::BLOCK_SCAN_WARP_SCANS, {}}};
}
```

After this is merged, #9699 needs to be rebased from here.