### PR TITLE
Add an escape hatch to skip pre-compiling lit based tests

### DIFF
--- a/ci/test_libcudacxx.sh
+++ b/ci/test_libcudacxx.sh
@@ -6,15 +6,11 @@ source "./build_common.sh"
 
 print_environment_details
 
-"./build_libcudacxx.sh" "$@"
+"./build_libcudacxx.sh" "$@" "-cmake-options" "-DLIBCUDACXX_SKIP_LIT_BUILD=1"
 
-PRESET="libcudacxx"
-CMAKE_OPTIONS=("-DCMAKE_CXX_STANDARD=${CXX_STANDARD}" "-DCMAKE_CUDA_STANDARD=${CXX_STANDARD}")
+# test_preset "libcudacxx (CTest)" "libcudacxx-ctest"
 
-configure_preset libcudacxx "$PRESET" "${CMAKE_OPTIONS[@]}"
-
-test_preset "libcudacxx (CTest)" "libcudacxx-ctest"
-
+# Reset sccache stats to get lit build+test time
 sccache -z > /dev/null || :
 test_preset "libcudacxx (lit)" "libcudacxx-lit"
 sccache --show-adv-stats || :

--- a/ci/test_libcudacxx.sh
+++ b/ci/test_libcudacxx.sh
@@ -8,7 +8,7 @@ print_environment_details
 
 "./build_libcudacxx.sh" "$@" "-cmake-options" "-DLIBCUDACXX_SKIP_LIT_BUILD=1"
 
-# test_preset "libcudacxx (CTest)" "libcudacxx-ctest"
+test_preset "libcudacxx (CTest)" "libcudacxx-ctest"
 
 # Reset sccache stats to get lit build+test time
 sccache -z > /dev/null || :

--- a/libcudacxx/test/libcudacxx/CMakeLists.txt
+++ b/libcudacxx/test/libcudacxx/CMakeLists.txt
@@ -242,9 +242,7 @@ message(STATUS "libcudacxx_LIT_FLAGS: ${libcudacxx_LIT_FLAGS}")
 
 if (NOT LIBCUDACXX_TEST_WITH_NVRTC)
   if (LIBCUDACXX_SKIP_LIT_BUILD)
-    add_custom_target(
-      libcudacxx.test.lit.precompile
-    )
+    add_custom_target(libcudacxx.test.lit.precompile)
   else()
     # Build but don't run the tests. Used by CI to pre-seed sccache for the test machines.
     # Only executed if explicitly requested.

--- a/libcudacxx/test/libcudacxx/CMakeLists.txt
+++ b/libcudacxx/test/libcudacxx/CMakeLists.txt
@@ -241,34 +241,40 @@ set(
 message(STATUS "libcudacxx_LIT_FLAGS: ${libcudacxx_LIT_FLAGS}")
 
 if (NOT LIBCUDACXX_TEST_WITH_NVRTC)
-  # Build but don't run the tests. Used by CI to pre-seed sccache for the test machines.
-  # Only executed if explicitly requested.
-  add_custom_target(
-    libcudacxx.test.lit.precompile
-    # HACK: There is no way to tell CMake/ninja to always build a target serially,
-    # so we make this target depend on all other libcudacxx targets to avoid oversubscribing
-    # the build machine.
-    # FIXME: This has nasty side effects:
-    # - It's fragile and must be updated every time we add new targets to libcudacxx
-    # - It oversubs `-dev` presets that configure libcudacxx alongside other CCCL projects
-    # - It makes it impossible to just build this target alone since it brings in the world
-    # See related issue https://github.com/NVIDIA/cccl/issues/6163.
-    DEPENDS
-      libcudacxx.test.public_headers
-      libcudacxx.test.internal_headers
-      libcudacxx.test.public_headers_host_only
-      libcudacxx.test.c2h_all
-    # gersemi: off
-    COMMAND
-      "${CMAKE_COMMAND}" -E env "LIBCUDACXX_SITE_CONFIG=${lit_site_cfg_path}"
-        "${libcudacxx_LIT}"
-          -vv --no-progress-bar --time-tests
-          ${libcudacxx_LIT_FLAGS}
-          "-Dexecutor=\"NoopExecutor()\""
-          "${libcudacxx_SOURCE_DIR}/test/libcudacxx"
-    # gersemi: on
-    USES_TERMINAL
-  )
+  if (LIBCUDACXX_SKIP_LIT_BUILD)
+    add_custom_target(
+      libcudacxx.test.lit.precompile
+    )
+  else()
+    # Build but don't run the tests. Used by CI to pre-seed sccache for the test machines.
+    # Only executed if explicitly requested.
+    add_custom_target(
+      libcudacxx.test.lit.precompile
+      # HACK: There is no way to tell CMake/ninja to always build a target serially,
+      # so we make this target depend on all other libcudacxx targets to avoid oversubscribing
+      # the build machine.
+      # FIXME: This has nasty side effects:
+      # - It's fragile and must be updated every time we add new targets to libcudacxx
+      # - It oversubs `-dev` presets that configure libcudacxx alongside other CCCL projects
+      # - It makes it impossible to just build this target alone since it brings in the world
+      # See related issue https://github.com/NVIDIA/cccl/issues/6163.
+      DEPENDS
+        libcudacxx.test.public_headers
+        libcudacxx.test.internal_headers
+        libcudacxx.test.public_headers_host_only
+        libcudacxx.test.c2h_all
+      # gersemi: off
+      COMMAND
+        "${CMAKE_COMMAND}" -E env "LIBCUDACXX_SITE_CONFIG=${lit_site_cfg_path}"
+          "${libcudacxx_LIT}"
+            -vv --no-progress-bar --time-tests
+            ${libcudacxx_LIT_FLAGS}
+            "-Dexecutor=\"NoopExecutor()\""
+            "${libcudacxx_SOURCE_DIR}/test/libcudacxx"
+      # gersemi: on
+      USES_TERMINAL
+    )
+  endif()
 endif()
 
 # Restricted to avoid oversubscribing the GPU:


### PR DESCRIPTION
## Description

This is probably a bad idea, but let's see what testing says. There are probably different lower hanging fruit that we can tackle this problem with.

The logic for builds today with libcudacxx are as follows:

* `test_libcudacxx.sh` invokes `build_libcudacxx.sh`
* `build_libcudacxx.sh` will invoke `lit` with a number of threads - this could be higher than 8
* `lit` will precompile all tests - possibly using `${nproc}-1` CPU cores. (fast!)
* `test_libcudacxx.sh` will then invoke `lit` via `CTest` with `8` jobs to avoid oversubscribing GPU. (slow!)

Ideally `lit` during the 'test' phase will just hit sccache and skip building, this should serve to speed up builds. In the case of this PR we now have 8 threads of CPU doing build which can be highly serial depending on some of the tests (atomics are really bad at compile time).

I think this PR will overall make things worse, but I'm writing it up to trigger CI with it anyways.

I have a suspicion that we can get rid of the `8` parallel jobs requirement and actually just use `${nproc}-1`. That would do more for test times.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
