### PR TITLE
Docs follow-up nits for flattened CUB/Thrust docs (#10012)

### DIFF
--- a/cub/test/test_device_batched_topk_requirements_fail.cu
+++ b/cub/test/test_device_batched_topk_requirements_fail.cu
@@ -16,7 +16,7 @@
 #include <iostream>
 
 // Verifies that cub::DeviceBatchedTopK rejects, at compile time, the determinism and tie_break requirement
-// combinations that the public contract marks as ill-formed (see docs/cub/api_docs/device_topk_requirements.rst):
+// combinations that the public contract marks as ill-formed (see docs/cub/device_topk_requirements.rst):
 //   * determinism and tie_break must be acknowledged together, both specified or both omitted to take the default
 //   * an explicit tie_break of prefer_smaller_index or prefer_larger_index pins the result set across GPUs and so
 //     requires determinism::gpu_to_gpu (it cannot be paired with not_guaranteed or run_to_run)

--- a/docs/cub/thread_level.rst
+++ b/docs/cub/thread_level.rst
@@ -3,13 +3,6 @@
 Thread-level Primitives
 ==================================================
 
-.. toctree::
-   :glob:
-   :hidden:
-   :maxdepth: 2
-
-   api/thread
-
 CUB thread-level algorithms are specialized for execution by a single thread.
 
 * :cpp:func:`cub::ThreadReduce <cub::ThreadReduce>` computes reduction of a sequence of items

--- a/docs/thrust/developer_overview.rst
+++ b/docs/thrust/developer_overview.rst
@@ -1,5 +1,5 @@
-Thrust Developer Overview
-#########################
+Developer Overview
+##################
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
Posting some follow ups as I didn't get to review in time for https://github.com/NVIDIA/cccl/pull/10012\

- Fix stale docs path in batched top-k test comment
- De-prefix Thrust developer overview title for consistency with CUB
- Drop api/thread toctree entry that only leads to an empty stub page