### PR TITLE
Add environment docs landing page with essential info

### DIFF
--- a/cub/test/catch2_test_device_merge_env_api.cu
+++ b/cub/test/catch2_test_device_merge_env_api.cu
@@ -118,6 +118,7 @@ C2H_TEST("cub::DeviceMerge::MergeKeys accepts a custom policy selector", "[merge
     result.begin(),
     cuda::std::less{},
     cuda::execution::tune(MergePolicySelector{}));
+
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceMerge::MergeKeys failed with status: " << error << '\n';

--- a/docs/cub/determinism.rst
+++ b/docs/cub/determinism.rst
@@ -26,7 +26,8 @@ The general rules for requesting a guarantee are described in the
 :ref:`CCCL determinism overview <cccl-determinism>`.
 
 Each CUB algorithm has its own default guarantee, applied when none is requested, and its own type and
-operator constraints for each guarantee, summarized below.
+operator constraints for each guarantee, summarized below. Requesting a guarantee that an algorithm
+does not support is rejected at compile time.
 
 Support matrix
 --------------

--- a/docs/cub/device_wide.rst
+++ b/docs/cub/device_wide.rst
@@ -15,7 +15,7 @@ Almost all of CUB's device-wide APIs come in two flavors:
 * the traditional two-phase style that requires calling the API twice and managing temporary storage explicitly,
 * and the newer single-phase style where temporary storage is obtained from a memory resource in the execution environment.
 
-Some APIs that do not require any temporary storage may have a traditional single-phase overload in addition to an newer environment one.
+Some APIs that do not require any temporary storage may also have a traditional single-phase form in addition to the newer environment-based one.
 
 .. _device-temp-storage:
 
@@ -54,7 +54,7 @@ Example pattern:
 Environment API (single phase)
 ++++++++++++++++++++++++++++++
 
-Environment-based overloads are available for all CUB device-wide algorithms.
+The environment-based API is available for all CUB device-wide algorithms.
 They remove the split of query/execute phase and manually obtaining the temporary storage.
 Instead, the temporary storage is automatically requested from a memory resource queried from the execution environment argument.
 The environment supports further properties like passing a stream or an execution requirement in addition to a memory resource.
@@ -80,6 +80,9 @@ Example pattern:
    :dedent:
    :start-after: example-begin env-overload-run
    :end-before: example-end env-overload-run
+
+Further information on CUB execution environments can be found in
+:ref:`Execution Environments <cub-environment>`.
 
 
 API overview

--- a/docs/cub/environment.rst
+++ b/docs/cub/environment.rst
@@ -1,0 +1,273 @@
+.. _cub-environment:
+
+Execution Environments
+======================
+
+Most CUB device-wide algorithms accept an optional *execution environment* as their last
+argument. The environment is a single object that bundles everything CUB needs to know
+about *how* to run the algorithm: which stream to use, where to get temporary memory, what
+reproducibility guarantees to apply, which tuning policy to select etc.
+
+This page explains what the CUB environment APIs are, and how to use them. The main
+properties an environment carries, each optional and freely composable with the others,
+are:
+
+1. :ref:`Streams <cub-env-building>` — select the stream the algorithm runs on.
+2. :ref:`Determinism requirements <cub-env-determinism>` — request a reproducibility
+   guarantee for the algorithm's results.
+3. :ref:`Custom tuning policy <cub-env-tuning>` — override CUB's built-in kernel tuning
+   for the current device.
+4. :ref:`Memory resources <cub-env-memory-resource>` — control where temporary storage
+   is allocated from.
+
+This list is not exhaustive: a few algorithms accept additional, algorithm-specific
+requirements — e.g. tie-breaking and output-ordering controls for
+:ref:`cub::DeviceTopK <cub-topk-requirements>` — and the set of properties an environment
+can carry keeps growing.
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Why environments?
+-----------------
+
+The classic two-phase CUB API requires three steps: query temporary-storage size, allocate,
+then execute. That is fine for one-off calls, but it becomes repetitive once you need to
+attach a custom stream or a memory pool.
+
+The environment-based single-phase API collapses all of that into one call. The algorithm
+queries the environment for a stream, allocates temporary storage from the memory resource
+found there, enforces the requested determinism guarantee, and then executes:
+
+.. code-block:: c++
+
+   cub::DeviceReduce::Sum(d_input, d_output, num_items, env);
+
+.. note::
+
+   A byproduct of the environment overloads is that the environment argument is entirely
+   optional: since it is defaulted, an algorithm can be invoked with no temporary-storage
+   arguments and no environment at all, and every property falls back to its default
+   (see :ref:`Fallback behavior <cub-environment-fallback>`):
+
+   .. code-block:: c++
+
+      cub::DeviceReduce::Sum(d_input, d_output, num_items);
+
+The rest of this page shows how to build the ``env`` object.
+
+
+.. _cub-env-building:
+
+Building an environment
+-----------------------
+
+Some types are already valid environments on their own and can be passed directly to an
+algorithm. The most common case is a stream: ``cuda::stream_ref`` (or a raw
+``cudaStream_t``) passed as the last argument is treated as an environment containing
+just that stream.
+
+.. literalinclude:: ../../cub/test/catch2_test_device_reduce_env_api.cu
+   :language: c++
+   :dedent:
+   :start-after: example-begin reduce-env-stream
+   :end-before: example-end reduce-env-stream
+
+When you need more than one property, combine them with ``cuda::std::execution::env``.
+Properties are listed in any order; CUB queries each one independently. The example below
+composes a stream, a memory pool for temporary storage, and a determinism requirement
+(the required declarations are provided by ``<cuda/execution>``, ``<cuda/stream>``,
+``<cuda/memory_pool>``, and ``<cuda/devices>``):
+
+.. literalinclude:: ../../cub/examples/device/example_device_reduce_env.cu
+   :language: c++
+   :dedent:
+   :start-after: example-begin env-overload-setup
+   :end-before: example-end env-overload-setup
+
+.. literalinclude:: ../../cub/examples/device/example_device_reduce_env.cu
+   :language: c++
+   :dedent:
+   :start-after: example-begin env-overload-run
+   :end-before: example-end env-overload-run
+
+The same ``env`` object can be passed to multiple algorithm calls without rebuilding it each
+time, see :ref:`cub-environment-reuse`.
+
+
+Environment features
+--------------------
+
+Each of the controls outlined at the top of this page is detailed below.
+
+.. _cub-env-determinism:
+
+Determinism requirements
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``cuda::execution::require`` to request a reproducibility guarantee:
+
+.. literalinclude:: ../../cub/test/catch2_test_device_reduce_env_api.cu
+   :language: c++
+   :dedent:
+   :start-after: example-begin reduce-env-determinism
+   :end-before: example-end reduce-env-determinism
+
+Three levels are available, in increasing strictness: ``not_guaranteed``, ``run_to_run``,
+and ``gpu_to_gpu``. The meaning of each guarantee is described in the
+:ref:`CCCL determinism overview <cccl-determinism>`; which algorithms support which levels,
+and each algorithm's default, are listed in the :ref:`CUB determinism support matrix
+<cub-determinism>`. Requesting a level an algorithm does not support is rejected at
+compile time.
+
+
+.. _cub-env-tuning:
+
+Custom tuning policy
+~~~~~~~~~~~~~~~~~~~~
+
+Pass a custom policy selector through the environment to override CUB's built-in tuning.
+A policy selector is a stateless callable mapping a ``cuda::compute_capability`` to the
+algorithm's public policy struct:
+
+.. literalinclude:: ../../cub/test/catch2_test_device_merge_env_api.cu
+   :language: c++
+   :dedent:
+   :start-after: example-begin merge-keys-policy-selector
+   :end-before: example-end merge-keys-policy-selector
+
+The selector is wrapped with ``cuda::execution::tune`` and passed as (part of) the
+environment:
+
+.. literalinclude:: ../../cub/test/catch2_test_device_merge_env_api.cu
+   :language: c++
+   :dedent:
+   :start-after: example-begin merge-keys-tuning
+   :end-before: example-end merge-keys-tuning
+
+The policy selector must be stateless (``std::is_empty_v<T> == true``). CUB passes only its
+*type* to device kernels, so any captured state would be silently lost.
+
+.. seealso:: :ref:`cub-policy-selectors` - full guide on defining and composing policy
+   selectors.
+
+.. _cub-env-memory-resource:
+
+Memory resources
+~~~~~~~~~~~~~~~~
+
+The memory resource controls where an algorithm's temporary storage is allocated from.
+Memory resource types are valid environments on their own, so they can be passed directly
+or composed with other properties:
+
+.. code-block:: c++
+
+   auto pool = cuda::device_default_memory_pool(cuda::devices[0]);
+
+   // Pass directly...
+   cub::DeviceReduce::Sum(d_input, d_output, num_items, pool);
+
+   // ...or compose with other properties
+   auto env = cuda::std::execution::env{cuda::stream_ref{stream}, pool};
+   cub::DeviceReduce::Sum(d_input, d_output, num_items, env);
+
+Temporary storage is allocated from the memory resource on the algorithm's stream before
+execution and released on the same stream afterwards. When no memory resource is present
+in the environment, CUB falls back to a stream-ordered ``cudaMallocAsync`` allocator
+(see :ref:`Fallback behavior <cub-environment-fallback>`).
+
+
+.. _cub-environment-reuse:
+
+Reusing an environment across multiple calls
+---------------------------------------------
+
+An ``env`` object is copyable and movable. Build it once and pass it to as many algorithm
+calls as you like:
+
+.. code-block:: c++
+
+   auto stream = cuda::stream{cuda::devices[0]};
+   auto pool   = cuda::device_default_memory_pool(cuda::devices[0]);
+   auto env    = cuda::std::execution::env{cuda::stream_ref{stream}, pool};
+
+   cub::DeviceScan::ExclusiveSum(d_a, d_out_a, n, env);
+   cub::DeviceReduce::Sum(d_b, d_out_b, n, env);
+   cub::DeviceSelect::If(d_c, d_out_c, d_num_selected, n, my_predicate, env);
+
+   stream.sync();
+
+All three calls share the same stream and memory pool. Temporary storage is allocated and
+released from the pool independently for each call.
+
+.. note::
+
+   When a tuning policy is embedded in the environment, the *same* policy applies to every
+   call that uses that environment. If two algorithms in the same pipeline need different
+   tunings, build separate environments or use separate ``cuda::execution::tune`` properties.
+
+
+.. _cub-environment-fallback:
+
+Fallback behavior
+-----------------
+
+The environment argument is optional on every algorithm that supports it. CUB applies the
+following defaults when a property is absent from the environment (or when no environment
+is passed at all):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Property
+     - Default when absent
+   * - Stream
+     - The CUDA null stream (``cudaStreamDefault``), which synchronizes with all other streams
+       on the current device.
+   * - Memory resource
+     - A stream-ordered allocator based on ``cudaMallocAsync``. Temporary storage is
+       allocated on the stream the algorithm runs on.
+   * - Determinism
+     - Algorithm-specific, typically ``run_to_run``. See :ref:`cub-determinism`.
+   * - Tuning policy
+     - CUB's built-in architecture-tuned default for the current device.
+
+Missing properties never cause an error. The algorithm simply falls back to its default for
+that property.
+
+
+Environment building blocks
+---------------------------
+
+These are the utilities a user needs to construct environments:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Utility
+     - Purpose
+   * - ``cuda::std::execution::env{props...}``
+     - Compose multiple properties into one environment object.
+   * - ``cuda::execution::require(property)``
+     - Wrap a requirement (e.g. a determinism level) so that an algorithm enforces rather
+       than hints it.
+   * - ``cuda::execution::tune(selector)``
+     - Embed a custom policy selector into an environment.
+
+..
+   TODO(gonidelis): link to the developer-facing environments page (queries, CPOs, prop,
+   building custom environment types) once it lands via
+   https://github.com/NVIDIA/cccl/pull/10013
+
+
+See also
+--------
+
+- :ref:`cub-determinism` - per-algorithm determinism support matrix
+- :ref:`cub-policy-selectors` - defining and registering custom tuning policies
+- :ref:`device-module` - overview of the device-wide API and the two-phase alternative
+- :ref:`cccl-determinism` - CCCL-level determinism concepts

--- a/docs/cub/environment.rst
+++ b/docs/cub/environment.rst
@@ -11,7 +11,7 @@ Part of what it carries is familiar: the CUDA stream, which CUB algorithms have 
 accepted, now simply travels inside the environment. The rest are controls that had no
 place in the classic API and are enabled by environments:
 :ref:`determinism requirements <cub-env-determinism>`,
-:ref:`custom tuning policies <cub-env-tuning>`, and
+:ref:`custom tuning policy selectors <cub-env-tuning>`, and
 :ref:`memory resources <cub-env-memory-resource>`. All properties are optional and freely
 composable with each other.
 
@@ -26,8 +26,11 @@ Why environments?
 -----------------
 
 The classic two-phase CUB API requires three steps: query temporary-storage size, allocate,
-then execute. That is fine for one-off calls, but it becomes repetitive once you need to
-attach a custom stream or a memory pool.
+then execute. That is fine for situations where precise control over the temporary storage 
+allocation is required, or when the temporary storage size needs to be queried independently
+of allocating it. For example, when the temporary storage is combined with other storage, e.g.
+for an output, into a single allocation. But in many cases this is not needed and the two-step
+API is just repetitive boilerplate.
 
 The environment-based single-phase API collapses all of that into one call. The algorithm
 queries the environment for the properties it needs — for example, the stream to run on,
@@ -41,7 +44,7 @@ pass to many different algorithms:
 
 .. note::
 
-   A byproduct of the environment overloads is that the environment argument is entirely
+   The environment argument is entirely
    optional: since it is defaulted, an algorithm can be invoked with no temporary-storage
    arguments and no environment at all, and every property falls back to its default
    (see :ref:`Fallback behavior <cub-environment-fallback>`):
@@ -69,7 +72,7 @@ just that stream.
    :end-before: example-end reduce-env-stream
 
 When you need more than one property, combine them with ``cuda::std::execution::env``.
-Properties are listed in any order; CUB queries each one independently. The example below
+Properties can be listed in any order. The example below
 composes a stream, a memory pool for temporary storage, and a determinism requirement
 (the required declarations are provided by ``<cuda/execution>``, ``<cuda/stream>``,
 ``<cuda/memory_pool>``, and ``<cuda/devices>``):
@@ -103,7 +106,7 @@ keeps growing.
 Determinism requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use ``cuda::execution::require`` to request a reproducibility guarantee:
+Use ``cuda::execution::require`` to request a guarantee, like a reproducible/deterministic execution:
 
 .. literalinclude:: ../../cub/test/catch2_test_device_reduce_env_api.cu
    :language: c++
@@ -121,14 +124,14 @@ compile time.
 
 .. _cub-env-tuning:
 
-Custom tuning policy
-~~~~~~~~~~~~~~~~~~~~
+Custom Tuning Policy Selectors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Pass a custom policy selector through the environment to override CUB's built-in tuning.
 A policy selector answers the question "which tuning parameters should this algorithm use
 on this GPU?": it is a function object that CUB calls with the GPU's compute capability,
 and that returns the tuning parameters — threads per block, items per thread, and so on —
-packed in the algorithm's policy struct (here ``cub::MergePolicy``):
+packaged as the algorithm's policy (here ``cub::MergePolicy``):
 
 .. literalinclude:: ../../cub/test/catch2_test_device_merge_env_api.cu
    :language: c++
@@ -145,13 +148,8 @@ environment:
    :start-after: example-begin merge-keys-tuning
    :end-before: example-end merge-keys-tuning
 
-.. warning::
-
-   The policy selector must be stateless (``std::is_empty_v<T> == true``). CUB passes only
-   its *type* to device kernels, so any captured state would be silently lost.
-
 .. seealso:: :ref:`cub-policy-selectors` - full guide on defining and composing policy
-   selectors.
+   selectors, including the requirements a policy selector must satisfy.
 
 .. _cub-env-memory-resource:
 
@@ -170,12 +168,12 @@ or composed with other properties:
    cub::DeviceReduce::Sum(d_input, d_output, num_items, pool);
 
    // ...or compose with other properties
-   auto env = cuda::std::execution::env{cuda::stream_ref{stream}, pool};
+   auto env = cuda::std::execution::env{stream, pool};
    cub::DeviceReduce::Sum(d_input, d_output, num_items, env);
 
 Temporary storage is allocated from the memory resource on the algorithm's stream before
 execution and released on the same stream afterwards. When no memory resource is present
-in the environment, CUB falls back to a stream-ordered ``cudaMallocAsync`` allocator
+in the environment, CUB falls back to a stream-ordered ``cudaMallocAsync``/``cudaFree``  allocator
 (see :ref:`Fallback behavior <cub-environment-fallback>`).
 
 .. TODO: Add Guarantees sub-section after #9278 is merged.
@@ -185,14 +183,14 @@ in the environment, CUB falls back to a stream-ordered ``cudaMallocAsync`` alloc
 Reusing an environment across multiple calls
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-An ``env`` object is copyable and movable. Build it once and pass it to as many algorithm
+An ``env`` object can be built once and passed to as many algorithm
 calls as you like:
 
 .. code-block:: c++
 
    auto stream = cuda::stream{cuda::devices[0]};
    auto pool   = cuda::device_default_memory_pool(cuda::devices[0]);
-   auto env    = cuda::std::execution::env{cuda::stream_ref{stream}, pool};
+   auto env    = cuda::std::execution::env{std::move(stream), pool};
 
    cub::DeviceScan::ExclusiveSum(d_a, d_out_a, n, env);
    cub::DeviceReduce::Sum(d_b, d_out_b, n, env);
@@ -205,9 +203,11 @@ released from the pool independently for each call.
 
 .. note::
 
-   When a tuning policy is embedded in the environment, the *same* policy applies to every
-   call that uses that environment. If two algorithms in the same pipeline need different
-   tunings, build separate environments or use separate ``cuda::execution::tune`` properties.
+   When a tuning policy selector is embedded in the environment, it applies to *every*
+   algorithm that can be tuned by this selector. For example, a policy selector returning
+   a ``cub::ReducePolicy`` will be used by all calls to ``cub::DeviceReduce::*`` that use
+   the same environment. If two algorithms using the same environment need different
+   tunings, build separate environments.
 
 
 Reference
@@ -235,9 +235,10 @@ is passed at all):
      - A stream-ordered allocator based on ``cudaMallocAsync``. Temporary storage is
        allocated on the stream the algorithm runs on.
    * - Determinism
-     - Algorithm-specific, typically ``run_to_run``. See :ref:`cub-determinism`.
-   * - Tuning policy
-     - CUB's built-in architecture-tuned default for the current device.
+     - Algorithm-specific. See :ref:`cub-determinism`.
+   * - Policy selector
+     - CUB's built-in selector, returning architecture-tuned defaults for the current
+       device.
 
 Missing properties never cause an error. The algorithm simply falls back to its default for
 that property.
@@ -272,6 +273,6 @@ See also
 --------
 
 - :ref:`cub-determinism` - per-algorithm determinism support matrix
-- :ref:`cub-policy-selectors` - defining and registering custom tuning policies
+- :ref:`cub-policy-selectors` - defining and composing custom policy selectors
 - :ref:`device-module` - overview of the device-wide API and the two-phase alternative
 - :ref:`cccl-determinism` - CCCL-level determinism concepts

--- a/docs/cub/environment.rst
+++ b/docs/cub/environment.rst
@@ -26,7 +26,7 @@ Why environments?
 -----------------
 
 The classic two-phase CUB API requires three steps: query temporary-storage size, allocate,
-then execute. That is fine for situations where precise control over the temporary storage 
+then execute. That is fine for situations where precise control over the temporary storage
 allocation is required, or when the temporary storage size needs to be queried independently
 of allocating it. For example, when the temporary storage is combined with other storage, e.g.
 for an output, into a single allocation. But in many cases this is not needed and the two-step
@@ -47,7 +47,7 @@ pass to many different algorithms:
    The environment argument is entirely
    optional: since it is defaulted, an algorithm can be invoked with no temporary-storage
    arguments and no environment at all, and every property falls back to its default
-   (see :ref:`Fallback behavior <cub-environment-fallback>`):
+   (see :ref:`Default behavior <cub-environment-fallback>`):
 
    .. code-block:: c++
 
@@ -103,7 +103,7 @@ keeps growing.
 
 .. _cub-env-determinism:
 
-Determinism requirements
+Determinism Requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use ``cuda::execution::require`` to request a guarantee, like a reproducible/deterministic execution:
@@ -114,9 +114,8 @@ Use ``cuda::execution::require`` to request a guarantee, like a reproducible/det
    :start-after: example-begin reduce-env-determinism
    :end-before: example-end reduce-env-determinism
 
-Three levels are available, in increasing strictness: ``not_guaranteed``, ``run_to_run``,
-and ``gpu_to_gpu``. The meaning of each guarantee is described in the
-:ref:`CCCL determinism overview <cccl-determinism>`; which algorithms support which levels,
+Multiple determinism levels are available. The meaning of each is described in the
+:ref:`CCCL determinism overview <cccl-determinism>`. Which algorithms support which levels,
 and each algorithm's default, are listed in the :ref:`CUB determinism support matrix
 <cub-determinism>`. Requesting a level an algorithm does not support is rejected at
 compile time.
@@ -153,7 +152,7 @@ environment:
 
 .. _cub-env-memory-resource:
 
-Memory resources
+Memory Resources
 ~~~~~~~~~~~~~~~~
 
 The memory resource controls where an algorithm's temporary storage is allocated from.
@@ -174,7 +173,7 @@ or composed with other properties:
 Temporary storage is allocated from the memory resource on the algorithm's stream before
 execution and released on the same stream afterwards. When no memory resource is present
 in the environment, CUB falls back to a stream-ordered ``cudaMallocAsync``/``cudaFree``  allocator
-(see :ref:`Fallback behavior <cub-environment-fallback>`).
+(see :ref:`Default behavior <cub-environment-fallback>`).
 
 .. TODO: Add Guarantees sub-section after #9278 is merged.
 
@@ -190,7 +189,7 @@ calls as you like:
 
    auto stream = cuda::stream{cuda::devices[0]};
    auto pool   = cuda::device_default_memory_pool(cuda::devices[0]);
-   auto env    = cuda::std::execution::env{std::move(stream), pool};
+   auto env    = cuda::std::execution::env{cuda::stream_ref{stream}, pool};
 
    cub::DeviceScan::ExclusiveSum(d_a, d_out_a, n, env);
    cub::DeviceReduce::Sum(d_b, d_out_b, n, env);
@@ -210,13 +209,10 @@ released from the pool independently for each call.
    tunings, build separate environments.
 
 
-Reference
----------
-
 .. _cub-environment-fallback:
 
-Fallback behavior
-~~~~~~~~~~~~~~~~~
+Default behavior
+----------------
 
 The environment argument is optional on every algorithm that supports it. CUB applies the
 following defaults when a property is absent from the environment (or when no environment
@@ -229,8 +225,7 @@ is passed at all):
    * - Property
      - Default when absent
    * - Stream
-     - The CUDA null stream (``cudaStreamDefault``), which synchronizes with all other streams
-       on the current device.
+     - The default CUDA stream (``cudaStream_t{}``).
    * - Memory resource
      - A stream-ordered allocator based on ``cudaMallocAsync``. Temporary storage is
        allocated on the stream the algorithm runs on.
@@ -242,26 +237,6 @@ is passed at all):
 
 Missing properties never cause an error. The algorithm simply falls back to its default for
 that property.
-
-
-Environment building blocks
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-These are the utilities a user needs to construct environments:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 40 60
-
-   * - Utility
-     - Purpose
-   * - ``cuda::std::execution::env{props...}``
-     - Compose multiple properties into one environment object.
-   * - ``cuda::execution::require(property)``
-     - Wrap a requirement (e.g. a determinism level) so that an algorithm enforces rather
-       than hints it.
-   * - ``cuda::execution::tune(selector)``
-     - Embed a custom policy selector into an environment.
 
 ..
    TODO(gonidelis): link to the developer-facing environments page (queries, CPOs, prop,

--- a/docs/cub/environment.rst
+++ b/docs/cub/environment.rst
@@ -5,25 +5,17 @@ Execution Environments
 
 Most CUB device-wide algorithms accept an optional *execution environment* as their last
 argument. The environment is a single object that bundles everything CUB needs to know
-about *how* to run the algorithm: which stream to use, where to get temporary memory, what
-reproducibility guarantees to apply, which tuning policy to select etc.
+about *how* to run the algorithm.
 
-This page explains what the CUB environment APIs are, and how to use them. The main
-properties an environment carries, each optional and freely composable with the others,
-are:
+Part of what it carries is familiar: the CUDA stream, which CUB algorithms have always
+accepted, now simply travels inside the environment. The rest are controls that had no
+place in the classic API and are enabled by environments:
+:ref:`determinism requirements <cub-env-determinism>`,
+:ref:`custom tuning policies <cub-env-tuning>`, and
+:ref:`memory resources <cub-env-memory-resource>`. All properties are optional and freely
+composable with each other.
 
-1. :ref:`Streams <cub-env-building>` — select the stream the algorithm runs on.
-2. :ref:`Determinism requirements <cub-env-determinism>` — request a reproducibility
-   guarantee for the algorithm's results.
-3. :ref:`Custom tuning policy <cub-env-tuning>` — override CUB's built-in kernel tuning
-   for the current device.
-4. :ref:`Memory resources <cub-env-memory-resource>` — control where temporary storage
-   is allocated from.
-
-This list is not exhaustive: a few algorithms accept additional, algorithm-specific
-requirements — e.g. tie-breaking and output-ordering controls for
-:ref:`cub::DeviceTopK <cub-topk-requirements>` — and the set of properties an environment
-can carry keeps growing.
+This page explains what the CUB environment APIs are, and how to use them.
 
 .. contents::
    :local:
@@ -38,8 +30,10 @@ then execute. That is fine for one-off calls, but it becomes repetitive once you
 attach a custom stream or a memory pool.
 
 The environment-based single-phase API collapses all of that into one call. The algorithm
-queries the environment for a stream, allocates temporary storage from the memory resource
-found there, enforces the requested determinism guarantee, and then executes:
+queries the environment for the properties it needs — for example, the stream to run on,
+or a memory resource to allocate temporary storage from — and then executes. Properties
+an algorithm does not use are simply ignored, which is what makes one environment safe to
+pass to many different algorithms:
 
 .. code-block:: c++
 
@@ -56,14 +50,13 @@ found there, enforces the requested determinism guarantee, and then executes:
 
       cub::DeviceReduce::Sum(d_input, d_output, num_items);
 
-The rest of this page shows how to build the ``env`` object.
-
 
 .. _cub-env-building:
 
 Building an environment
 -----------------------
 
+.. list explicitly what types are valid environments
 Some types are already valid environments on their own and can be passed directly to an
 algorithm. The most common case is a stream: ``cuda::stream_ref`` (or a raw
 ``cudaStream_t``) passed as the last argument is treated as an environment containing
@@ -97,10 +90,13 @@ The same ``env`` object can be passed to multiple algorithm calls without rebuil
 time, see :ref:`cub-environment-reuse`.
 
 
-Environment features
---------------------
+How to use environments
+-----------------------
 
-Each of the controls outlined at the top of this page is detailed below.
+The controls below are what environments enable beyond the classic API. A few algorithms
+additionally accept algorithm-specific controls — e.g. tie-breaking and output-ordering
+for :ref:`cub::DeviceTopK <cub-topk-requirements>`. The set of supported properties
+keeps growing.
 
 .. _cub-env-determinism:
 
@@ -129,8 +125,10 @@ Custom tuning policy
 ~~~~~~~~~~~~~~~~~~~~
 
 Pass a custom policy selector through the environment to override CUB's built-in tuning.
-A policy selector is a stateless callable mapping a ``cuda::compute_capability`` to the
-algorithm's public policy struct:
+A policy selector answers the question "which tuning parameters should this algorithm use
+on this GPU?": it is a function object that CUB calls with the GPU's compute capability,
+and that returns the tuning parameters — threads per block, items per thread, and so on —
+packed in the algorithm's policy struct (here ``cub::MergePolicy``):
 
 .. literalinclude:: ../../cub/test/catch2_test_device_merge_env_api.cu
    :language: c++
@@ -147,8 +145,10 @@ environment:
    :start-after: example-begin merge-keys-tuning
    :end-before: example-end merge-keys-tuning
 
-The policy selector must be stateless (``std::is_empty_v<T> == true``). CUB passes only its
-*type* to device kernels, so any captured state would be silently lost.
+.. warning::
+
+   The policy selector must be stateless (``std::is_empty_v<T> == true``). CUB passes only
+   its *type* to device kernels, so any captured state would be silently lost.
 
 .. seealso:: :ref:`cub-policy-selectors` - full guide on defining and composing policy
    selectors.
@@ -178,11 +178,12 @@ execution and released on the same stream afterwards. When no memory resource is
 in the environment, CUB falls back to a stream-ordered ``cudaMallocAsync`` allocator
 (see :ref:`Fallback behavior <cub-environment-fallback>`).
 
+.. TODO: Add Guarantees sub-section after #9278 is merged.
 
 .. _cub-environment-reuse:
 
 Reusing an environment across multiple calls
----------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 An ``env`` object is copyable and movable. Build it once and pass it to as many algorithm
 calls as you like:
@@ -209,10 +210,13 @@ released from the pool independently for each call.
    tunings, build separate environments or use separate ``cuda::execution::tune`` properties.
 
 
+Reference
+---------
+
 .. _cub-environment-fallback:
 
 Fallback behavior
------------------
+~~~~~~~~~~~~~~~~~
 
 The environment argument is optional on every algorithm that supports it. CUB applies the
 following defaults when a property is absent from the environment (or when no environment
@@ -240,7 +244,7 @@ that property.
 
 
 Environment building blocks
----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 These are the utilities a user needs to construct environments:
 

--- a/docs/cub/index.rst
+++ b/docs/cub/index.rst
@@ -12,6 +12,7 @@ CUB
    warp_wide
    block_wide
    device_wide
+   environment
    determinism
    benchmarking
    tuning

--- a/docs/cub/tuning.rst
+++ b/docs/cub/tuning.rst
@@ -68,10 +68,14 @@ taking a ``cuda::compute_capability`` and returning the algorithm's policy struc
       }
     };
 
-The policy selector must be stateless (:code:`std::is_empty_v<T>` must be :code:`true`)
-since only its type will be passed to a kernel.
-Policy selectors are also freely constructed and copied where needed,
-so they must also be default constructible and copyable (:code:`std::semiregular<T>` must be :code:`true`).
+.. warning::
+
+   The policy selector must be stateless (:code:`std::is_empty_v<T>` must be :code:`true`)
+   since only its type will be passed to a kernel — any captured state would be silently
+   lost. Policy selectors are also freely constructed and copied where needed, so they
+   must also be default constructible and copyable (:code:`std::semiregular<T>` must be
+   :code:`true`).
+
 It can be a class template, but then only a full specialization can be passed to CUB,
 e.g., :code:`my_reduce_tuning<float>`.
 The implementation can use branches and helper functions arbitrarily,


### PR DESCRIPTION
fixes https://github.com/NVIDIA/cccl/issues/7712

Adds docs landing page for Environments as discussed in https://github.com/NVIDIA/cccl/pull/10013#issuecomment-5032631542

It doesn't go into deep details (e.g CPOs, last sub-section offers fertile ground for that). It provides an overview with

a) a strong definition and 
b) minimal usable examples on environment features extracted from our real compilable tests

Pics that showcase the generated HTML page:

<img width="1144" height="712" alt="image" src="https://github.com/user-attachments/assets/ffcabfc0-a6c3-4ad9-8d4f-2e37f1a6b36c" />
<img width="1125" height="902" alt="image" src="https://github.com/user-attachments/assets/c5b973bc-fdbb-444b-9fdc-413958d7eed3" />
<img width="1041" height="915" alt="image" src="https://github.com/user-attachments/assets/9bbffdca-6482-47a3-8d5a-6e14dc4933c1" />
<img width="867" height="887" alt="image" src="https://github.com/user-attachments/assets/916fbb62-ac45-43b5-bff1-7d0663346774" />
<img width="905" height="836" alt="image" src="https://github.com/user-attachments/assets/944a8158-e37f-41e0-bf1f-52bf98bb79b3" />
<img width="848" height="906" alt="image" src="https://github.com/user-attachments/assets/cb5a4b2c-72ea-495e-a036-9b8280cf569d" />
