### PR TITLE
[cuda.compute]: Relax synchronization around Clang compilation in v2, keeping it only for linking

### DIFF
--- a/c/parallel.v2/src/hostjit/compiler.cpp
+++ b/c/parallel.v2/src/hostjit/compiler.cpp
@@ -1695,32 +1695,33 @@ CUDACompiler::~CUDACompiler()
   delete impl_;
 }
 
-// clang and LLVM are embedded in-process and are not thread-safe for concurrent
-// compilation (shared global registries, cl::opt state, allocator use).
-// cuda.compute releases the GIL around native builds, so distinct ops built from
-// multiple threads -- on a GIL or free-threaded interpreter -- otherwise run
-// clang concurrently and corrupt that shared state. Serialize every native
-// compile/link through one process-wide mutex. This guards only the (cached,
-// one-time) build path; kernel launches are unaffected.
-static std::mutex g_native_compile_mutex;
+// The compile stages are thread-safe: each build runs clang codegen with its own
+// CompilerInstance and LLVMContext, so concurrent compiles do not race. The link
+// stage is not. lld::elf::link() keeps its state in a process-global
+// (CommonLinkerContext, a plain `static`, not `thread_local`), so concurrent links
+// from multiple threads clobber that shared context and corrupt LLD's bump
+// allocator. cuda.compute releases the GIL around native builds, so distinct ops
+// built from multiple threads -- on a GIL or free-threaded interpreter -- can
+// otherwise link concurrently. Serialize just the link step through one
+// process-wide mutex. This guards only the (cached, one-time) build path; kernel
+// launches are unaffected.
+static std::mutex g_link_mutex;
 
 BitcodeResult CUDACompiler::compileToDeviceBitcode(const std::string& source_code, const CompilerConfig& config)
 {
-  const std::lock_guard<std::mutex> lock(g_native_compile_mutex);
   return impl_->compileToDeviceBitcode(source_code, config);
 }
 
 CompilationResult CUDACompiler::compileToObject(
   const std::string& source_code, const std::string& output_path, const CompilerConfig& config)
 {
-  const std::lock_guard<std::mutex> lock(g_native_compile_mutex);
   return impl_->compileToObject(source_code, output_path, config);
 }
 
 LinkResult CUDACompiler::linkToSharedLibrary(
   const std::vector<std::string>& object_files, const std::string& output_path, const CompilerConfig& config)
 {
-  const std::lock_guard<std::mutex> lock(g_native_compile_mutex);
+  const std::lock_guard<std::mutex> lock(g_link_mutex);
   return impl_->linkToSharedLibrary(object_files, output_path, config);
 }
 } // namespace hostjit


### PR DESCRIPTION
https://github.com/NVIDIA/cccl/pull/9998 fixed a race condition caused by clang compilation by serializing all v2 builds. After further investigation, it turned out only the linking stage is not thread safe, so some of the locks can be removed