### PR TITLE
support for p0 explicit benchmarks

### DIFF
--- a/benchmarks/scripts/cccl/bench/search.py
+++ b/benchmarks/scripts/cccl/bench/search.py
@@ -128,26 +128,27 @@ def filter_benchmarks(benchmarks, args):
     if args.run_shard >= args.num_shards:
         raise ValueError("run-shard must be less than num-shards")
 
-    p0_regex_benchmarks = (
-        r"^(?!.*segmented).*(?:select|sort|transform\.(?:babelstream|fill)).*$"
-    )
-
-    p0_explicit_benchmarks = [
-        "cub.bench.reduce.sum",
-        "cub.bench.reduce.custom",
+    p0_benchmarks = [
+        "cub.bench.merge_sort.keys",
+        "cub.bench.merge_sort.pairs",
+        "cub.bench.radix_sort.keys",
+        "cub.bench.radix_sort.pairs",
         "cub.bench.reduce.by_key",
-        "cub.bench.scan.exclusive.sum",
+        "cub.bench.reduce.custom",
+        "cub.bench.reduce.sum",
         "cub.bench.scan.exclusive.deterministic",
+        "cub.bench.scan.exclusive.sum",
+        "cub.bench.select.flagged",
+        "cub.bench.select.if",
+        "cub.bench.select.unique",
+        "cub.bench.select.unique_by_key",
+        "cub.bench.transform.babelstream",
+        "cub.bench.transform.fill",
     ]
 
     algnames = filter_benchmarks_by_regex(benchmarks.keys(), args.R)
     if args.P0:
-        regex_matched = filter_benchmarks_by_regex(algnames, p0_regex_benchmarks)
-        regex_matched = filter_benchmarks_by_regex(
-            regex_matched, r"^(?!.*P[123456789]\d*).*"
-        )
-        explicit = [name for name in p0_explicit_benchmarks if name in algnames]
-        algnames = list(set(regex_matched) | set(explicit))
+        algnames = [name for name in p0_benchmarks if name in algnames]
     algnames.sort()
 
     if args.num_shards > 1:

--- a/benchmarks/scripts/cccl/bench/search.py
+++ b/benchmarks/scripts/cccl/bench/search.py
@@ -128,13 +128,26 @@ def filter_benchmarks(benchmarks, args):
     if args.run_shard >= args.num_shards:
         raise ValueError("run-shard must be less than num-shards")
 
+    p0_regex_benchmarks = (
+        r"^(?!.*segmented).*(?:select|sort|transform\.(?:babelstream|fill)).*$"
+    )
+
+    p0_explicit_benchmarks = [
+        "cub.bench.reduce.sum",
+        "cub.bench.reduce.custom",
+        "cub.bench.reduce.by_key",
+        "cub.bench.scan.exclusive.sum",
+        "cub.bench.scan.exclusive.deterministic",
+    ]
+
     algnames = filter_benchmarks_by_regex(benchmarks.keys(), args.R)
     if args.P0:
-        algnames = filter_benchmarks_by_regex(
-            algnames,
-            r"^(?!.*segmented).*(scan|reduce|select|sort|transform\.(babelstream|fill)).*",
+        regex_matched = filter_benchmarks_by_regex(algnames, p0_regex_benchmarks)
+        regex_matched = filter_benchmarks_by_regex(
+            regex_matched, r"^(?!.*P[123456789]\d*).*"
         )
-        algnames = filter_benchmarks_by_regex(algnames, r"^(?!.*P[123456789]\d*).*")
+        explicit = [name for name in p0_explicit_benchmarks if name in algnames]
+        algnames = list(set(regex_matched) | set(explicit))
     algnames.sort()
 
     if args.num_shards > 1:


### PR DESCRIPTION
## Description

Add a specific known benchmark to `p0_explicit_benchmarks`, which simplifies and shortens regex output. 
Previously, p0 benchmarks had all the variants of the reduce and scan algorithms, but we only want to have few of them, which will reduce the final list of benchmarks. 

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
