### PR TITLE
Minor QOL improvements to devcontainer launching script

### DIFF
--- a/.devcontainer/launch.sh
+++ b/.devcontainer/launch.sh
@@ -148,6 +148,12 @@ launch_docker() {
     local -;
     set -euo pipefail
 
+    if ! docker --version > /dev/null 2>&1 ; then
+      echo "Docker launch requires a working installation of docker."
+      echo "Ensure that 'docker' is reachable on PATH."
+      exit 127
+    fi
+
     ###
     # Read relevant values from devcontainer.json
     ###
@@ -291,6 +297,13 @@ launch_docker() {
 launch_vscode() {
     local -;
     set -euo pipefail;
+
+    if ! code --version > /dev/null 2>&1 ; then
+      echo "VSCode launch requires a working installation of vscode."
+      echo "Ensure that 'code' is reachable on PATH."
+      exit 127
+    fi
+
     # Since Visual Studio Code allows only one instance per `devcontainer.json`,
     # this code prepares a unique temporary directory structure for each launch of a devcontainer.
     # By doing so, it ensures that multiple instances of the same environment can be run

--- a/.devcontainer/launch.sh
+++ b/.devcontainer/launch.sh
@@ -82,6 +82,13 @@ parse_options() {
 
     local -a DOCKER_RUN_ARGS=();
 
+    if command -v code > /dev/null 2>&1 ; then
+      docker_mode=false
+    else
+      # no vscode, default to docker
+      docker_mode=true
+    fi
+
     while true; do
         case "$1" in
             -c|--cuda)
@@ -328,6 +335,16 @@ main() {
     if [[ -z ${cuda_version:-} ]] && [[ -z ${host_compiler:-} ]]; then
         path=".devcontainer"
     else
+        if [[ -z ${cuda_version:-} ]]; then
+          echo "Must also provide a CUDA version when specifying the host compiler" >&2
+          exit 2
+        fi
+
+        if [[ -z ${host_compiler:-} ]]; then
+          echo "Must also provide a host compiler when specifying the cuda version" >&2
+          exit 2
+        fi
+
         if ${cuda_ext:-false}; then
           cuda_suffix="ext"
         fi


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

The script shouldn't just crash if you pass `--cuda 12.34` but no host compiler. Likewise if you pass `--host gcc12` it should handle this gracefully as well.

It can also be smarter when detecting whether to default to vscode or docker.

Furthermore, it can provide a better error message if either docker or vscode aren't working/aren't present

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
