### PR TITLE
Use block-scoped atomics in BlockHistogramAtomic on SM 60+

### DIFF
--- a/cub/cub/block/specializations/block_histogram_atomic.cuh
+++ b/cub/cub/block/specializations/block_histogram_atomic.cuh
@@ -53,7 +53,7 @@ struct BlockHistogramAtomic
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < ITEMS_PER_THREAD; ++i)
     {
-      atomicAdd(histogram + items[i], 1);
+      atomicAdd_block(histogram + items[i], 1);
     }
   }
 };


### PR DESCRIPTION
Resurrects #8162, whose source branch/fork was deleted so it could not be reopened. Original author: @NitishNaineni.

Closes #3357

## Summary
- Replaces \`atomicAdd\` with \`atomicAdd_block\` in \`BlockHistogramAtomic::Composite\`. Since CCCL only supports SM 75+, the block-scoped atomic is always available (no `NV_IF_TARGET` guard needed).
- This matches the pattern already used in \`agent_histogram.cuh\`.

## Codegen verification (from the original PR)
SASS confirms the scope change on SM 86 (RTX 3080):
- Before: \`RED.E.ADD.STRONG.GPU\`
- After: \`RED.E.ADD.STRONG.SM\`

Performance was identical on Ampere in the original benchmarks (1024 threads × 16 items, per-block global histograms, various bin counts and grid sizes).

## Test plan (from the original PR)
- [x] \`cub.test.block.histogram.bins_32\`
- [x] \`cub.test.block.histogram.bins_256\`
- [x] \`cub.test.block.histogram.bins_1024\`

Original PR: #8162