### PR TITLE
[INFRA] Link contributor docs from CI results

### DIFF
--- a/.github/actions/workflow-results/action.yml
+++ b/.github/actions/workflow-results/action.yml
@@ -159,6 +159,8 @@ runs:
           echo "### $(cat execution/heading.txt)"
           echo ""
           echo "See results [here]($(cat workflow/summary_url.txt))."
+          echo ""
+          echo "New to CCCL? See the [contributing guide](https://github.com/NVIDIA/cccl/blob/main/CONTRIBUTING.md) and [CI overview](https://github.com/NVIDIA/cccl/blob/main/docs/infrastructure/ci/references/ci_overview.rst)."
         ) | tee pr_comment.md
         echo "::endgroup::"
 


### PR DESCRIPTION
## Description

Closes #1827

The sticky PR CI results comment currently links only to the workflow summary, leaving first-time and irregular contributors without a direct path to CCCL's contribution and CI guidance.

Add links to the contributing guide and the current CI overview source while keeping the notification brief.

## Validation

- `pre-commit run --files .github/actions/workflow-results/action.yml`
- Rendered the generated Markdown comment locally.
- Verified both documentation links return HTTP 200.

AI assistance: OpenAI Codex helped investigate, implement, and validate this change.

## Checklist

- [x] New or existing tests cover these changes. (Comment-only change; validated with pre-commit and a local render.)
- [x] The documentation is up to date with these changes.
