### PR TITLE
[libcu++] Avoid compilation issue with tuple_of_iterator_references

### DIFF
--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -244,6 +244,7 @@ public:
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   // Horrible hack to make tuple_of_iterator_references work
+  // NOLINTBEGIN(bugprone-forwarding-reference-overload)
   template <class _TupleOfIteratorReferences,
             // clang-tidy has fallen off its rocker and claims we can use the non-existent
             // __tuple_of_iterato_references_v here.
@@ -254,6 +255,7 @@ public:
   _CCCL_API constexpr tuple(_TupleOfIteratorReferences&& __t)
       : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_TupleOfIteratorReferences>(__t))
   {}
+  // NOLINTEND(bugprone-forwarding-reference-overload)
 
   template <class _UTuple>
   using _TupleLikeConstraints = integral_constant<

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -244,7 +244,7 @@ public:
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   // Horrible hack to make tuple_of_iterator_references work
-  // NOLINTBEGIN(bugprone-forwarding-reference-overload)
+  // We intentionally rely on the conversion operator of the tuple_of_iterator_references
   template <class _TupleOfIteratorReferences,
             // clang-tidy has fallen off its rocker and claims we can use the non-existent
             // __tuple_of_iterato_references_v here.
@@ -253,24 +253,10 @@ public:
             // NOLINTEND(modernize-type-traits)
             enable_if_t<(tuple_size<_TupleOfIteratorReferences>::value == sizeof...(_Tp)), int> = 0>
   _CCCL_API constexpr tuple(_TupleOfIteratorReferences&& __t)
-      : tuple(::cuda::std::forward<_TupleOfIteratorReferences>(__t), __make_tuple_indices_t<sizeof...(_Tp)>{})
-  {}
-  // NOLINTEND(bugprone-forwarding-reference-overload)
-
-private:
-  // clang-tidy incorrectly reports "'__t' used after it was forwarded".
-  // Each expansion forwards the tuple only to select get<I>'s cvref-qualified overload for a distinct element.
-  // NOLINTBEGIN(bugprone-use-after-move)
-  template <class _TupleOfIteratorReferences,
-            size_t... _Indices,
-            enable_if_t<__is_tuple_of_iterator_references_v<remove_cvref_t<_TupleOfIteratorReferences>>, int> = 0>
-  _CCCL_API constexpr tuple(_TupleOfIteratorReferences&& __t, __tuple_indices<_Indices...>)
-      : __base_(__tuple_variadic_constructor_tag{},
-                ::cuda::std::get<_Indices>(::cuda::std::forward<_TupleOfIteratorReferences>(__t))...)
-  // NOLINTEND(bugprone-use-after-move)
+      : __base_(__tuple_like_constructor_tag{},
+                static_cast<tuple>(::cuda::std::forward<_TupleOfIteratorReferences>(__t)))
   {}
 
-public:
   template <class _UTuple>
   using _TupleLikeConstraints = integral_constant<
     __select_constructor,

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -244,7 +244,6 @@ public:
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY
 
   // Horrible hack to make tuple_of_iterator_references work
-  // We intentionally rely on the conversion operator of the tuple_of_iterator_references
   template <class _TupleOfIteratorReferences,
             // clang-tidy has fallen off its rocker and claims we can use the non-existent
             // __tuple_of_iterato_references_v here.
@@ -253,8 +252,7 @@ public:
             // NOLINTEND(modernize-type-traits)
             enable_if_t<(tuple_size<_TupleOfIteratorReferences>::value == sizeof...(_Tp)), int> = 0>
   _CCCL_API constexpr tuple(_TupleOfIteratorReferences&& __t)
-      : __base_(__tuple_like_constructor_tag{},
-                static_cast<tuple>(::cuda::std::forward<_TupleOfIteratorReferences>(__t)))
+      : __base_(__tuple_like_constructor_tag{}, ::cuda::std::forward<_TupleOfIteratorReferences>(__t))
   {}
 
   template <class _UTuple>

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_constraints.h
@@ -224,7 +224,10 @@ template <class _Type, class _UType>
 __tuple_select_variadic_constructible(__tuple_types<_Type>, __tuple_types<_UType>) noexcept
 {
   // NOLINTBEGIN(bugprone-branch-clone)
-  if constexpr (__is_tuple_of_iterator_references_v<remove_cvref_t<_UType>>)
+  // Reject unpacking a tuple_of_iterator_references through the 1-arg variadic constructor so the
+  // dedicated constructor is used instead. Do allow it if the original type is a tuple_of_iterator_references though
+  if constexpr (__is_tuple_of_iterator_references_v<remove_cvref_t<_UType>>
+                && !__is_tuple_of_iterator_references_v<remove_cvref_t<_Type>>)
   {
     return __select_constructor::__invalid;
   }

--- a/thrust/testing/zip_iterator.cu
+++ b/thrust/testing/zip_iterator.cu
@@ -552,3 +552,27 @@ void TestZipIteratorNestedCopy()
   }
 }
 DECLARE_UNITTEST(TestZipIteratorNestedCopy);
+
+// See https://github.com/NVIDIA/cccl/issues/9773
+void TestZipIteratorComparison()
+{
+  using T = int;
+
+  thrust::device_vector<T> a{5, 4, 3, 2, 1, 0};
+  thrust::device_vector<T> b{1, 2, 3, 4, 5, 6};
+
+  {
+    static_assert(
+      cuda::std::is_convertible_v<thrust::detail::tuple_of_iterator_references<int&, int&>, cuda::std::tuple<int, int>>);
+    auto iter = thrust::make_zip_iterator(a.data(), b.data());
+    auto pos  = thrust::find(iter, iter + 6, cuda::std::tuple{4, 2});
+    ASSERT_EQUAL_QUIET(pos, iter + 1);
+  }
+
+  {
+    auto iter = thrust::make_zip_iterator(a.begin(), b.begin());
+    auto pos  = thrust::find(iter, iter + 6, cuda::std::tuple{4, 2});
+    ASSERT_EQUAL_QUIET(pos, iter + 1);
+  }
+}
+DECLARE_UNITTEST(TestZipIteratorComparison);

--- a/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
+++ b/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
@@ -212,8 +212,9 @@ struct tuple_element<Id, THRUST_NS_QUALIFIER::detail::tuple_of_iterator_referenc
     : tuple_element<Id, tuple<Ts...>>
 {};
 
-// tuple_of_iterator_references<_TTypes...> implicitly converts to tuple<_UTypes...> if is_compatible_tuple_v holds
-// So make sure that basic_common_reference in that case is the same as that of tuple<_UTypes...> with qualifiers
+// tuple_of_iterator_references<_TTypes...> implicitly converts to tuple<_UTypes...> if is_compatible_tuple_v holds.
+// Compute the common reference from the actual element types (not by substituting _UTypes/_TTypes on both sides),
+// so proxy reference elements (e.g. __transform_input_output_proxy) participate correctly.
 template <class... _TTypes, class... _UTypes, template <class> class _TQual, template <class> class _UQual>
 struct basic_common_reference<
   THRUST_NS_QUALIFIER::detail::tuple_of_iterator_references<_TTypes...>,
@@ -221,7 +222,7 @@ struct basic_common_reference<
   _TQual,
   _UQual,
   enable_if_t<THRUST_NS_QUALIFIER::detail::is_compatible_tuple_v<tuple<_TTypes...>, tuple<_UTypes...>>>>
-    : basic_common_reference<tuple<_UTypes...>, tuple<_UTypes...>, _TQual, _UQual>
+    : basic_common_reference<tuple<_TTypes...>, tuple<_UTypes...>, _TQual, _UQual>
 {};
 
 template <class... _TTypes, class... _UTypes, template <class> class _TQual, template <class> class _UQual>
@@ -231,7 +232,7 @@ struct basic_common_reference<
   _TQual,
   _UQual,
   enable_if_t<THRUST_NS_QUALIFIER::detail::is_compatible_tuple_v<tuple<_TTypes...>, tuple<_UTypes...>>>>
-    : basic_common_reference<tuple<_TTypes...>, tuple<_TTypes...>, _TQual, _UQual>
+    : basic_common_reference<tuple<_TTypes...>, tuple<_UTypes...>, _TQual, _UQual>
 {};
 
 _CCCL_END_NAMESPACE_CUDA_STD


### PR DESCRIPTION

Looks like some construction paths go through the variadic constructor.

Its a bit unclear why this does not work given there is a separate constructor just for that but :shrug:

Fixes #9773