### PR TITLE
Fix undefined `TUNE_LOAD_ALGORITHM` in `scan` benchmark `.variant` builds

### DIFF
--- a/cub/benchmarks/bench/scan/policy_selector.h
+++ b/cub/benchmarks/bench/scan/policy_selector.h
@@ -10,6 +10,20 @@
 #if !TUNE_BASE
 #  if !USES_LOOKAHEAD()
 #    include <look_back_helper.cuh>
+
+#    if TUNE_TRANSPOSE == 0
+#      define TUNE_LOAD_ALGORITHM  cub::BLOCK_LOAD_DIRECT
+#      define TUNE_STORE_ALGORITHM cub::BLOCK_STORE_DIRECT
+#    else // TUNE_TRANSPOSE == 1
+#      define TUNE_LOAD_ALGORITHM  cub::BLOCK_LOAD_WARP_TRANSPOSE
+#      define TUNE_STORE_ALGORITHM cub::BLOCK_STORE_WARP_TRANSPOSE
+#    endif // TUNE_TRANSPOSE
+
+#    if TUNE_LOAD == 0
+#      define TUNE_LOAD_MODIFIER cub::LOAD_DEFAULT
+#    else // TUNE_LOAD == 1
+#      define TUNE_LOAD_MODIFIER cub::LOAD_CA
+#    endif // TUNE_LOAD
 #  endif // !USES_LOOKAHEAD()
 
 template <typename AccumT>


### PR DESCRIPTION
`cub/benchmarks/bench/scan/policy_selector.h` consumes `TUNE_LOAD_ALGORITHM/TUNE_LOAD_MODIFIER/TUNE_STORE_ALGORITHM`, but `sum.cu`'s `%RANGE%` axes only define `TUNE_TRANSPOSE/TUNE_LOAD`. The translation block every other lookback bench carries (`partition`, `select`, `by_key`) is missing from the scan chain. 

That results for every `scan.exclusive.sum` variant build to fail with "identifier TUNE_LOAD_ALGORITHM is undefined". The scan tuning is broken upstream on every architecture. This is invisible in CI because `.variant` targets are never built there which is something that has led to other problems in the past.

I ran a dummy tuning to verify that the fix works since no tests exist.

```bash
(cccl) root ➜ /src/fixtest/cccl (scan_tuning_bug) $  CIQ_GPU=0 CIQ_POOL=32 CIQ_GENERATIONS=1 python3 /src/compileiq_search.py \
    -R '^cub\.bench\.scan\.exclusive\.sum$' -a 'T{ct}=I32' -a 'OffsetT{ct}=I32' \
    -DCMAKE_CUDA_ARCHITECTURES=native
cmake ../.. -DCUB_ENABLE_BENCHMARKS=YES -DCUB_ENABLE_TUNING=YES -DCCCL_ENABLE_THRUST=OFF -DCCCL_ENABLE_LIBCUDACXX=OFF -DCCCL_ENABLE_CUB=ON -DCCCL_ENABLE_TESTING=OFF -DCUB_ENABLE_DIALECT_CPP11=OFF -DCUB_ENABLE_DIALECT_CPP14=OFF -DCUB_ENABLE_DIALECT_CPP17=ON -DCUB_ENABLE_DIALECT_CPP20=OFF -DTHRUST_IGNORE_DEPRECATED_CPP_DIALECT=ON -DCUB_ENABLE_RDC_TESTS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES=native
 ctk:  13.4.46
cccl:  monorepo-5367-g0bfeaa0611
Driver-side probe evaluation: {'ipt': 7, 'tpb': 128, 'ns': 0, 'dcid': 0, 'l2w': 0, 'trp': 0, 'ld': 0}
cub.bench.scan.exclusive.sum.ipt_7.tpb_128.ns_0.dcid_0.l2w_0.trp_0.ld_0 0.4714180865641916
Probe score: 0.4714180865641916
```

ping @bernhardmgruber 
