### PR TITLE
[cudax][cuco] Reject undersized hyperloglog_ref storage

### DIFF
--- a/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/hyperloglog_impl.cuh
+++ b/cudax/include/cuda/experimental/__cuco/detail/hyperloglog/hyperloglog_impl.cuh
@@ -107,6 +107,12 @@ public:
       , __sketch{reinterpret_cast<int*>(__sketch_span.data()), __sketch_bytes() / sizeof(__register_type)}
   // MSVC fails with __register_type*, use int* instead
   {
+    constexpr ::cuda::std::size_t __minimum_sketch_bytes = sizeof(__register_type) * (1ull << 4);
+    if (__sketch_span.size() < __minimum_sketch_bytes)
+    {
+      _CCCL_THROW(::std::invalid_argument, "Minimum required sketch size is 0.0625KB or 64B");
+    }
+
     if (!::cuda::is_aligned(__sketch_span.data(), __sketch_alignment()))
     {
       _CCCL_THROW(::std::invalid_argument, "Sketch storage has insufficient alignment");

--- a/cudax/test/cuco/hyperloglog/test_hyperloglog.cu
+++ b/cudax/test/cuco/hyperloglog/test_hyperloglog.cu
@@ -240,6 +240,19 @@ C2H_TEST("HyperLogLog precision constructor", "[hyperloglog]")
   REQUIRE(estimator.estimate(stream) == 0);
 }
 
+C2H_TEST("HyperLogLog ref validates sketch storage size", "[hyperloglog]")
+{
+  using ref_type = cudax::cuco::hyperloglog_ref<int32_t>;
+
+  alignas(ref_type::sketch_alignment()) cuda::std::byte undersized_storage[32]{};
+  REQUIRE_THROWS_WITH(ref_type{cuda::std::span<cuda::std::byte>{undersized_storage}},
+                      "Minimum required sketch size is 0.0625KB or 64B");
+
+  alignas(ref_type::sketch_alignment()) cuda::std::byte rounded_storage[96]{};
+  const ref_type ref{cuda::std::span<cuda::std::byte>{rounded_storage}};
+  REQUIRE(ref.sketch_bytes() == 64);
+}
+
 #if _CCCL_CTK_AT_LEAST(12, 9) // Pinned memory resource is only supported with CTK 12.9 and later
 C2H_TEST("Hyperloglog estimate works with pinned memory pool", "[hyperloglog]")
 {


### PR DESCRIPTION
Validate the original storage span before constructing a HyperLogLog ref, preventing spans below 64 bytes from being accepted. Add regression coverage for undersized and rounded-down spans.

Closes #10219