### PR TITLE
[libcu++] Do not instantiate types for inline variables of constructible traits

### DIFF
--- a/libcudacxx/include/cuda/std/__type_traits/is_copy_assignable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_copy_assignable.h
@@ -28,13 +28,30 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+#if defined(_CCCL_BUILTIN_IS_ASSIGNABLE) && !defined(_LIBCUDACXX_USE_IS_ASSIGNABLE_FALLBACK)
+
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_copy_assignable
-    : public is_assignable<add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<typename add_const<_Tp>::type>>
+    : public bool_constant<_CCCL_BUILTIN_IS_ASSIGNABLE(
+        add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<add_const_t<_Tp>>)>
 {};
 
 template <class _Tp>
-inline constexpr bool is_copy_assignable_v = is_copy_assignable<_Tp>::value;
+inline constexpr bool is_copy_assignable_v =
+  _CCCL_BUILTIN_IS_ASSIGNABLE(add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<add_const_t<_Tp>>);
+
+#else // ^^^ Use builtin ^^^ / vvv No builtin
+
+template <class _Tp>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT
+is_copy_assignable : public is_assignable<add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<add_const_t<_Tp>>>
+{};
+
+template <class _Tp>
+inline constexpr bool is_copy_assignable_v =
+  is_assignable<add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<add_const_t<_Tp>>>::value;
+
+#endif // No builtin
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_copy_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_copy_constructible.h
@@ -28,13 +28,28 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+#if defined(_CCCL_BUILTIN_IS_CONSTRUCTIBLE) && !defined(_LIBCUDACXX_USE_IS_CONSTRUCTIBLE_FALLBACK)
+
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_copy_constructible : public is_constructible<_Tp, add_lvalue_reference_t<typename add_const<_Tp>::type>>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_copy_constructible
+    : public bool_constant<_CCCL_BUILTIN_IS_CONSTRUCTIBLE(_Tp, add_lvalue_reference_t<add_const_t<_Tp>>)>
 {};
 
 template <class _Tp>
-inline constexpr bool is_copy_constructible_v = is_copy_constructible<_Tp>::value;
+inline constexpr bool is_copy_constructible_v =
+  _CCCL_BUILTIN_IS_CONSTRUCTIBLE(_Tp, add_lvalue_reference_t<add_const_t<_Tp>>);
+
+#else // ^^^ Use builtin ^^^ / vvv No builtin
+
+template <class _Tp>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT
+is_copy_constructible : public is_constructible<_Tp, add_lvalue_reference_t<add_const_t<_Tp>>>
+{};
+
+template <class _Tp>
+inline constexpr bool is_copy_constructible_v = is_constructible<_Tp, add_lvalue_reference_t<add_const_t<_Tp>>>::value;
+
+#endif // No builtin
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_move_assignable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_move_assignable.h
@@ -28,13 +28,29 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+#if defined(_CCCL_BUILTIN_IS_ASSIGNABLE) && !defined(_LIBCUDACXX_USE_IS_ASSIGNABLE_FALLBACK)
+
+template <class _Tp>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_move_assignable
+    : public bool_constant<_CCCL_BUILTIN_IS_ASSIGNABLE(add_lvalue_reference_t<_Tp>, add_rvalue_reference_t<_Tp>)>
+{};
+
+template <class _Tp>
+inline constexpr bool is_move_assignable_v =
+  _CCCL_BUILTIN_IS_ASSIGNABLE(add_lvalue_reference_t<_Tp>, add_rvalue_reference_t<_Tp>);
+
+#else // ^^^ Use builtin ^^^ / vvv No builtin
+
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT
 is_move_assignable : public is_assignable<add_lvalue_reference_t<_Tp>, add_rvalue_reference_t<_Tp>>
 {};
 
 template <class _Tp>
-inline constexpr bool is_move_assignable_v = is_move_assignable<_Tp>::value;
+inline constexpr bool is_move_assignable_v =
+  is_assignable<add_lvalue_reference_t<_Tp>, add_rvalue_reference_t<_Tp>>::value;
+
+#endif // No builtin
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_move_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_move_constructible.h
@@ -28,12 +28,26 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+#if defined(_CCCL_BUILTIN_IS_CONSTRUCTIBLE) && !defined(_LIBCUDACXX_USE_IS_CONSTRUCTIBLE_FALLBACK)
+
+template <class _Tp>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT
+is_move_constructible : public bool_constant<_CCCL_BUILTIN_IS_CONSTRUCTIBLE(_Tp, add_rvalue_reference_t<_Tp>)>
+{};
+
+template <class _Tp>
+inline constexpr bool is_move_constructible_v = _CCCL_BUILTIN_IS_CONSTRUCTIBLE(_Tp, add_rvalue_reference_t<_Tp>);
+
+#else // ^^^ Use builtin ^^^ / vvv No builtin
+
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_move_constructible : public is_constructible<_Tp, add_rvalue_reference_t<_Tp>>
 {};
 
 template <class _Tp>
-inline constexpr bool is_move_constructible_v = is_move_constructible<_Tp>::value;
+inline constexpr bool is_move_constructible_v = is_constructible<_Tp, add_rvalue_reference_t<_Tp>>::value;
+
+#endif // No builtin
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_copy_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_copy_constructible.h
@@ -28,6 +28,19 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+#if defined(_CCCL_BUILTIN_IS_NOTHROW_CONSTRUCTIBLE) && !defined(_LIBCUDACXX_USE_IS_NOTHROW_CONSTRUCTIBLE_FALLBACK)
+
+template <class _Tp>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_copy_constructible
+    : public bool_constant<_CCCL_BUILTIN_IS_NOTHROW_CONSTRUCTIBLE(_Tp, add_lvalue_reference_t<add_const_t<_Tp>>)>
+{};
+
+template <class _Tp>
+inline constexpr bool is_nothrow_copy_constructible_v =
+  _CCCL_BUILTIN_IS_NOTHROW_CONSTRUCTIBLE(_Tp, add_lvalue_reference_t<add_const_t<_Tp>>);
+
+#else // ^^^ Use builtin ^^^ / vvv No builtin
+
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_copy_constructible
     : public is_nothrow_constructible<_Tp, add_lvalue_reference_t<typename add_const<_Tp>::type>>
@@ -35,6 +48,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_copy_constructible
 
 template <class _Tp>
 inline constexpr bool is_nothrow_copy_constructible_v = is_nothrow_copy_constructible<_Tp>::value;
+
+#endif // No builtin
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_move_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_move_constructible.h
@@ -27,6 +27,19 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+#if defined(_CCCL_BUILTIN_IS_NOTHROW_CONSTRUCTIBLE) && !defined(_LIBCUDACXX_USE_IS_NOTHROW_CONSTRUCTIBLE_FALLBACK)
+
+template <class _Tp>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_move_constructible
+    : public bool_constant<_CCCL_BUILTIN_IS_NOTHROW_CONSTRUCTIBLE(_Tp, add_rvalue_reference_t<_Tp>)>
+{};
+
+template <class _Tp>
+inline constexpr bool is_nothrow_move_constructible_v =
+  _CCCL_BUILTIN_IS_NOTHROW_CONSTRUCTIBLE(_Tp, add_rvalue_reference_t<_Tp>);
+
+#else // ^^^ Use builtin ^^^ / vvv No builtin
+
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT
 is_nothrow_move_constructible : public is_nothrow_constructible<_Tp, add_rvalue_reference_t<_Tp>>
@@ -34,6 +47,8 @@ is_nothrow_move_constructible : public is_nothrow_constructible<_Tp, add_rvalue_
 
 template <class _Tp>
 inline constexpr bool is_nothrow_move_constructible_v = is_nothrow_move_constructible<_Tp>::value;
+
+#endif // No builtin
 
 _CCCL_END_NAMESPACE_CUDA_STD
 


### PR DESCRIPTION
We never updated the definition of those fundamental type traits from the original libc++ source.

That means that what should be an essentially free compiler builtin was instantiating *multiple* types every single time